### PR TITLE
Add automatic crate version update from tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,8 +19,34 @@ jobs:
   publish:
     name: Publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set version from tag
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/}"
+          TAG_VERSION="${TAG_VERSION#v}"
+          sed -i "s/^version = \".*\"/version = \"$TAG_VERSION\"/" Cargo.toml
+          echo "TAG_VERSION=$TAG_VERSION" >> "$GITHUB_ENV"
+          echo "Version set to $TAG_VERSION"
+
+      - name: Commit version bump to main
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if ! git diff --quiet Cargo.toml; then
+            git add Cargo.toml
+            git commit -m "chore: bump version to $TAG_VERSION"
+            git push origin HEAD:main
+          else
+            echo "Cargo.toml version already matched tag — no commit needed"
+          fi
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master


### PR DESCRIPTION
## Summary
- Publish workflow now automatically sets `Cargo.toml` version from the pushed tag before publishing, and commits the bump back to `main`
- CI workflow no longer triggers on direct pushes to `main` (only runs on PRs)

## Test plan
- [ ] Push a new version tag (e.g. `v0.1.3`) and verify the publish workflow sets the correct version in `Cargo.toml`, commits it to `main`, and publishes to crates.io successfully
- [ ] Verify CI does not trigger on a direct push to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)