### PR TITLE
fix: reduce keywords to crates.io limit of 5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/PawanSikawat/faucet-stream"
 documentation = "https://docs.rs/faucet-stream"
 readme = "README.md"
-keywords = ["rest", "api", "pagination", "http", "streaming", "meltano", "singer", "stream", "data"]
+keywords = ["rest", "api", "meltano", "http", "streaming"]
 categories = ["web-programming::http-client"]
 exclude = [".trunk/"]
 


### PR DESCRIPTION
## Summary
- Trimmed `keywords` in `Cargo.toml` from 9 to 5 entries — crates.io enforces a hard limit of 5 keywords per crate, causing the publish workflow to fail with a 400 error

## Test plan
- [ ] Merge and re-run the publish workflow — verify it publishes successfully without the 400 Bad Request error

🤖 Generated with [Claude Code](https://claude.com/claude-code)