### PR TITLE
chore: set faucet-stream version to 0.1.0

### DIFF
--- a/faucet-stream/Cargo.toml
+++ b/faucet-stream/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "faucet-stream"
-version = "0.2.0"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
Align umbrella crate version with all other workspace crates at 0.1.0.