### PR TITLE
feat(sources): wire parent context into all 13 source connectors

### DIFF
--- a/crates/source/csv/src/stream.rs
+++ b/crates/source/csv/src/stream.rs
@@ -25,9 +25,13 @@ impl CsvSource {
 impl faucet_core::Source for CsvSource {
     async fn fetch_with_context(
         &self,
-        _context: &std::collections::HashMap<String, serde_json::Value>,
+        context: &std::collections::HashMap<String, serde_json::Value>,
     ) -> Result<Vec<Value>, FaucetError> {
-        let config = self.config.clone();
+        let mut config = self.config.clone();
+
+        if !context.is_empty() {
+            config.path = faucet_core::util::substitute_context(&config.path, context);
+        }
 
         // CSV reading is synchronous I/O — run on a blocking thread to avoid
         // starving the async runtime.

--- a/crates/source/elasticsearch/src/stream.rs
+++ b/crates/source/elasticsearch/src/stream.rs
@@ -73,22 +73,33 @@ impl ElasticsearchSource {
 impl faucet_core::Source for ElasticsearchSource {
     async fn fetch_with_context(
         &self,
-        _context: &std::collections::HashMap<String, serde_json::Value>,
+        context: &std::collections::HashMap<String, serde_json::Value>,
     ) -> Result<Vec<Value>, FaucetError> {
+        // Resolve index and query with context substitution.
+        let index = if context.is_empty() {
+            self.config.index.clone()
+        } else {
+            faucet_core::util::substitute_context(&self.config.index, context)
+        };
+        let query = if context.is_empty() {
+            self.config.query.clone()
+        } else {
+            let s = serde_json::to_string(&self.config.query)
+                .map_err(|e| FaucetError::Config(format!("failed to serialize query: {e}")))?;
+            let s = faucet_core::util::substitute_context(&s, context);
+            serde_json::from_str(&s).map_err(|e| {
+                FaucetError::Config(format!("failed to parse substituted query: {e}"))
+            })?
+        };
+
         let mut all_records = Vec::new();
 
         // Initial search request with scroll.
         let url = format!(
             "{}/{}/_search?scroll={}&size={}",
-            self.config.base_url,
-            self.config.index,
-            self.config.scroll_timeout,
-            self.config.scroll_size
+            self.config.base_url, index, self.config.scroll_timeout, self.config.scroll_size
         );
-        let req = self
-            .client
-            .post(&url)
-            .json(&json!({"query": self.config.query}));
+        let req = self.client.post(&url).json(&json!({"query": query}));
         let req = self.apply_auth(req);
 
         let resp = req.send().await?;

--- a/crates/source/grpc/src/stream.rs
+++ b/crates/source/grpc/src/stream.rs
@@ -35,52 +35,64 @@ impl GrpcStream {
 
     /// Fetch all records by calling the configured gRPC method.
     pub async fn fetch_all(&self) -> Result<Vec<Value>, FaucetError> {
-        let full_method = format!("/{}/{}", self.config.service_name, self.config.method_name);
+        self.fetch_resolved(
+            &self.config.endpoint,
+            &self.config.service_name,
+            &self.config.method_name,
+            &self.config.request,
+        )
+        .await
+    }
+
+    /// Internal fetch with resolved (context-substituted) parameters.
+    async fn fetch_resolved(
+        &self,
+        endpoint: &str,
+        service_name: &str,
+        method_name: &str,
+        request: &Value,
+    ) -> Result<Vec<Value>, FaucetError> {
+        let full_method = format!("/{service_name}/{method_name}");
 
         // Look up the method descriptor.
-        let service = self
-            .pool
-            .get_service_by_name(&self.config.service_name)
-            .ok_or_else(|| {
-                FaucetError::Config(format!(
-                    "service '{}' not found in descriptor set",
-                    self.config.service_name
-                ))
-            })?;
+        let service = self.pool.get_service_by_name(service_name).ok_or_else(|| {
+            FaucetError::Config(format!(
+                "service '{service_name}' not found in descriptor set",
+            ))
+        })?;
 
         let method = service
             .methods()
-            .find(|m| m.name() == self.config.method_name)
+            .find(|m| m.name() == method_name)
             .ok_or_else(|| {
                 FaucetError::Config(format!(
-                    "method '{}' not found in service '{}'",
-                    self.config.method_name, self.config.service_name
+                    "method '{method_name}' not found in service '{service_name}'",
                 ))
             })?;
 
         // Build the request message from JSON.
         let input_desc = method.input();
-        let request_msg = DynamicMessage::deserialize(input_desc, &self.config.request)
+        let request_msg = DynamicMessage::deserialize(input_desc, request)
             .map_err(|e| FaucetError::Config(format!("failed to build request message: {e}")))?;
 
         // Connect to the gRPC endpoint.
         let use_tls = self
             .config
             .tls
-            .unwrap_or_else(|| self.config.endpoint.starts_with("https"));
+            .unwrap_or_else(|| endpoint.starts_with("https"));
 
-        let endpoint = Channel::from_shared(self.config.endpoint.clone())
+        let channel_endpoint = Channel::from_shared(endpoint.to_string())
             .map_err(|e| FaucetError::Url(format!("invalid gRPC endpoint: {e}")))?;
 
         let channel: Channel = if use_tls {
-            endpoint
+            channel_endpoint
                 .tls_config(tonic::transport::ClientTlsConfig::new())
                 .map_err(|e| FaucetError::Config(format!("TLS config failed: {e}")))?
                 .connect()
                 .await
                 .map_err(|e| FaucetError::Config(format!("gRPC connect failed: {e}")))?
         } else {
-            endpoint
+            channel_endpoint
                 .connect()
                 .await
                 .map_err(|e| FaucetError::Config(format!("gRPC connect failed: {e}")))?
@@ -151,9 +163,28 @@ impl GrpcStream {
 impl faucet_core::Source for GrpcStream {
     async fn fetch_with_context(
         &self,
-        _context: &std::collections::HashMap<String, serde_json::Value>,
+        context: &std::collections::HashMap<String, serde_json::Value>,
     ) -> Result<Vec<Value>, FaucetError> {
-        GrpcStream::fetch_all(self).await
+        if context.is_empty() {
+            return GrpcStream::fetch_all(self).await;
+        }
+
+        let endpoint = faucet_core::util::substitute_context(&self.config.endpoint, context);
+        let service_name =
+            faucet_core::util::substitute_context(&self.config.service_name, context);
+        let method_name = faucet_core::util::substitute_context(&self.config.method_name, context);
+
+        let request = {
+            let s = serde_json::to_string(&self.config.request)
+                .map_err(|e| FaucetError::Config(format!("failed to serialize request: {e}")))?;
+            let s = faucet_core::util::substitute_context(&s, context);
+            serde_json::from_str(&s).map_err(|e| {
+                FaucetError::Config(format!("failed to parse substituted request: {e}"))
+            })?
+        };
+
+        self.fetch_resolved(&endpoint, &service_name, &method_name, &request)
+            .await
     }
 
     fn config_schema(&self) -> serde_json::Value {

--- a/crates/source/mongodb/src/stream.rs
+++ b/crates/source/mongodb/src/stream.rs
@@ -93,14 +93,91 @@ impl MongoSource {
 impl faucet_core::Source for MongoSource {
     async fn fetch_with_context(
         &self,
-        _context: &std::collections::HashMap<String, serde_json::Value>,
+        context: &std::collections::HashMap<String, serde_json::Value>,
     ) -> Result<Vec<Value>, FaucetError> {
-        MongoSource::fetch_all(self).await
+        if context.is_empty() {
+            return MongoSource::fetch_all(self).await;
+        }
+
+        // Substitute context placeholders into filter, projection, and sort.
+        let filter = substitute_optional_value(&self.config.filter, context, "filter")?;
+        let projection = substitute_optional_value(&self.config.projection, context, "projection")?;
+        let sort = substitute_optional_value(&self.config.sort, context, "sort")?;
+
+        let db = self.client.database(&self.config.database);
+        let collection = db.collection::<Document>(&self.config.collection);
+
+        let filter_doc = filter.as_ref().map(json_value_to_document).transpose()?;
+
+        let mut find_options = FindOptions::default();
+        if let Some(ref proj) = projection {
+            find_options.projection = Some(json_value_to_document(proj)?);
+        }
+        if let Some(ref s) = sort {
+            find_options.sort = Some(json_value_to_document(s)?);
+        }
+        if let Some(limit) = self.config.limit {
+            find_options.limit = Some(limit);
+        }
+        if let Some(batch_size) = self.config.batch_size {
+            find_options.batch_size = Some(batch_size);
+        }
+
+        let mut cursor = collection
+            .find(filter_doc.unwrap_or_default())
+            .with_options(find_options)
+            .await
+            .map_err(|e| FaucetError::Config(format!("MongoDB find failed: {e}")))?;
+
+        let mut records = Vec::new();
+        while cursor
+            .advance()
+            .await
+            .map_err(|e| FaucetError::Config(format!("MongoDB cursor advance failed: {e}")))?
+        {
+            let doc = cursor
+                .deserialize_current()
+                .map_err(|e| FaucetError::Config(format!("MongoDB deserialization failed: {e}")))?;
+            records.push(bson_document_to_json_value(&doc)?);
+        }
+
+        tracing::info!(
+            records = records.len(),
+            database = %self.config.database,
+            collection = %self.config.collection,
+            "MongoDB fetch complete (with context)"
+        );
+
+        Ok(records)
     }
 
     fn config_schema(&self) -> serde_json::Value {
         serde_json::to_value(faucet_core::schema_for!(MongoSourceConfig))
             .expect("schema serialization")
+    }
+}
+
+/// Substitute context placeholders in an optional JSON value.
+///
+/// Serialises the value to a string, runs `substitute_context`, then
+/// deserialises back. Returns `None` when the input is `None`.
+fn substitute_optional_value(
+    value: &Option<Value>,
+    context: &std::collections::HashMap<String, Value>,
+    field_name: &str,
+) -> Result<Option<Value>, FaucetError> {
+    match value {
+        Some(v) => {
+            let s = serde_json::to_string(v).map_err(|e| {
+                FaucetError::Config(format!("failed to serialize {field_name}: {e}"))
+            })?;
+            let s = faucet_core::util::substitute_context(&s, context);
+            let resolved = serde_json::from_str(&s).map_err(|e| {
+                FaucetError::Config(format!("failed to parse substituted {field_name}: {e}"))
+            })?;
+            Ok(Some(resolved))
+        }
+        None => Ok(None),
     }
 }
 

--- a/crates/source/redis/src/stream.rs
+++ b/crates/source/redis/src/stream.rs
@@ -177,9 +177,51 @@ impl RedisSource {
 impl faucet_core::Source for RedisSource {
     async fn fetch_with_context(
         &self,
-        _context: &std::collections::HashMap<String, serde_json::Value>,
+        context: &std::collections::HashMap<String, serde_json::Value>,
     ) -> Result<Vec<Value>, FaucetError> {
-        RedisSource::fetch_all(self).await
+        if context.is_empty() {
+            return RedisSource::fetch_all(self).await;
+        }
+
+        let client = redis::Client::open(self.config.url.as_str())
+            .map_err(|e| FaucetError::Config(format!("invalid Redis URL: {e}")))?;
+
+        let mut conn = client
+            .get_multiplexed_async_connection()
+            .await
+            .map_err(|e| FaucetError::Config(format!("Redis connection failed: {e}")))?;
+
+        // Substitute context into the key/pattern of each source type variant.
+        let mut records = match &self.config.source_type {
+            RedisSourceType::List { key } => {
+                let resolved_key = faucet_core::util::substitute_context(key, context);
+                self.fetch_list(&mut conn, &resolved_key).await?
+            }
+            RedisSourceType::Stream {
+                key,
+                group,
+                consumer,
+                count,
+            } => {
+                let resolved_key = faucet_core::util::substitute_context(key, context);
+                self.fetch_stream(&mut conn, &resolved_key, group, consumer, count)
+                    .await?
+            }
+            RedisSourceType::Keys { pattern } => {
+                let resolved_pattern = faucet_core::util::substitute_context(pattern, context);
+                self.fetch_keys(&mut conn, &resolved_pattern).await?
+            }
+        };
+
+        if let Some(max) = self.config.max_records {
+            records.truncate(max);
+        }
+
+        tracing::info!(
+            records = records.len(),
+            "Redis fetch complete (with context)"
+        );
+        Ok(records)
     }
 
     fn config_schema(&self) -> serde_json::Value {

--- a/crates/source/webhook/src/stream.rs
+++ b/crates/source/webhook/src/stream.rs
@@ -109,9 +109,63 @@ async fn webhook_handler(
 impl faucet_core::Source for WebhookSource {
     async fn fetch_with_context(
         &self,
-        _context: &std::collections::HashMap<String, serde_json::Value>,
+        context: &std::collections::HashMap<String, serde_json::Value>,
     ) -> Result<Vec<Value>, FaucetError> {
-        WebhookSource::fetch_all(self).await
+        if context.is_empty() {
+            return WebhookSource::fetch_all(self).await;
+        }
+
+        // Substitute context into the webhook path.
+        let resolved_path = faucet_core::util::substitute_context(&self.config.path, context);
+
+        let state = Arc::new(AppState {
+            records: Mutex::new(Vec::new()),
+            max_payloads: self.config.max_payloads,
+            done: Notify::new(),
+        });
+
+        let app = Router::new()
+            .route(&resolved_path, post(webhook_handler))
+            .with_state(Arc::clone(&state));
+
+        let listener = tokio::net::TcpListener::bind(&self.config.listen_addr)
+            .await
+            .map_err(|e| {
+                FaucetError::Config(format!(
+                    "failed to bind to {}: {e}",
+                    self.config.listen_addr
+                ))
+            })?;
+
+        tracing::info!(
+            addr = %self.config.listen_addr,
+            path = %resolved_path,
+            "webhook server listening (with context)"
+        );
+
+        let timeout = tokio::time::sleep(std::time::Duration::from_secs(self.config.timeout_secs));
+        let done_notified = state.done.notified();
+
+        tokio::select! {
+            result = axum::serve(listener, app).into_future() => {
+                if let Err(e) = result {
+                    return Err(FaucetError::Config(format!("webhook server error: {e}")));
+                }
+            }
+            () = timeout => {
+                tracing::info!("webhook timeout reached");
+            }
+            () = done_notified => {
+                tracing::info!("max payloads reached");
+            }
+        }
+
+        let records = state.records.lock().await.clone();
+        tracing::info!(
+            records = records.len(),
+            "webhook fetch complete (with context)"
+        );
+        Ok(records)
     }
 
     fn config_schema(&self) -> serde_json::Value {

--- a/crates/source/xml/src/stream.rs
+++ b/crates/source/xml/src/stream.rs
@@ -26,6 +26,14 @@ impl XmlStream {
 
     /// Fetch all records across all pages.
     pub async fn fetch_all(&self) -> Result<Vec<Value>, FaucetError> {
+        self.fetch_all_with_context(&HashMap::new()).await
+    }
+
+    /// Fetch all records, substituting parent context into path, query_params, and body.
+    async fn fetch_all_with_context(
+        &self,
+        context: &HashMap<String, serde_json::Value>,
+    ) -> Result<Vec<Value>, FaucetError> {
         let mut all_records = Vec::new();
         let mut pages_fetched = 0usize;
         let mut offset = 0usize;
@@ -48,7 +56,7 @@ impl XmlStream {
             let mut params = self.config.query_params.clone();
             self.apply_pagination_params(&mut params, page_number, offset);
 
-            let xml_text = self.execute_request(&params).await?;
+            let xml_text = self.execute_request(&params, context).await?;
             let json = convert::xml_to_json(&xml_text)?;
 
             let records = match &self.config.records_element_path {
@@ -133,18 +141,31 @@ impl XmlStream {
     async fn execute_request(
         &self,
         params: &HashMap<String, String>,
+        context: &HashMap<String, serde_json::Value>,
     ) -> Result<String, FaucetError> {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url,
-            self.config.path.trim_start_matches('/')
-        );
+        let path = if context.is_empty() {
+            self.config.path.clone()
+        } else {
+            faucet_core::util::substitute_context(&self.config.path, context)
+        };
+
+        let url = format!("{}/{}", self.config.base_url, path.trim_start_matches('/'));
+
+        // Substitute context into query parameter values.
+        let resolved_params: HashMap<String, String> = if context.is_empty() {
+            params.clone()
+        } else {
+            params
+                .iter()
+                .map(|(k, v)| (k.clone(), faucet_core::util::substitute_context(v, context)))
+                .collect()
+        };
 
         let mut req = self
             .client
             .request(self.config.method.clone(), &url)
             .headers(self.config.headers.clone())
-            .query(params);
+            .query(&resolved_params);
 
         // Apply auth.
         match &self.config.auth {
@@ -160,11 +181,16 @@ impl XmlStream {
             }
         }
 
-        // Set body for POST requests (SOAP).
+        // Set body for POST requests (SOAP), with context substitution.
         if let Some(body) = &self.config.body {
+            let resolved_body = if context.is_empty() {
+                body.clone()
+            } else {
+                faucet_core::util::substitute_context(body, context)
+            };
             req = req
                 .header("Content-Type", "text/xml; charset=utf-8")
-                .body(body.clone());
+                .body(resolved_body);
         }
 
         let resp = req.send().await.map_err(FaucetError::Http)?;
@@ -177,9 +203,9 @@ impl XmlStream {
 impl faucet_core::Source for XmlStream {
     async fn fetch_with_context(
         &self,
-        _context: &std::collections::HashMap<String, serde_json::Value>,
+        context: &std::collections::HashMap<String, serde_json::Value>,
     ) -> Result<Vec<Value>, FaucetError> {
-        XmlStream::fetch_all(self).await
+        self.fetch_all_with_context(context).await
     }
 
     fn config_schema(&self) -> serde_json::Value {


### PR DESCRIPTION
## Summary

- Wire parent context substitution into the remaining 7 source connectors (MongoDB, Redis, CSV, Elasticsearch, gRPC, XML, Webhook)
- All 13 source connectors now actively use the `context` parameter from `fetch_with_context()`, completing the parent-child DAG feature

## Context per source

| Source | Substituted fields |
|--------|-------------------|
| MongoDB | `filter`, `projection`, `sort` |
| Redis | `key`/`pattern` in List/Stream/Keys variants |
| CSV | file `path` |
| Elasticsearch | `index`, `query` |
| gRPC | `endpoint`, `service_name`, `method_name`, `request` |
| XML | `path`, `query_params`, `body` |
| Webhook | listen `path` |

## Test plan

- [x] All 58 workspace test suites pass (0 failures)
- [x] Clippy clean, fmt clean
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)