### PR TITLE
Ignore docs/superpowers/ AI workflow artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ Thumbs.db
 # AI Instructions
 CLAUDE.md
 .claude/
+docs/superpowers/
 
 # Cargo
 Cargo.lock


### PR DESCRIPTION
## Summary

Pair this with the existing `CLAUDE.md` / `.claude/` ignores. `docs/superpowers/{plans,specs}` is where the superpowers skill writes per-feature plan and design files — they're useful local context for the agent run that produced them, but they duplicate the shipped code, CLAUDE.md, and commit history for any other reader, and would otherwise clutter the repo top level as features accumulate.

## Test plan

- [x] `git status` no longer shows `docs/superpowers/` as untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)