### PR TITLE
feat: stdout/stderr sink + pluggable replication state stores (#25, #35)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,9 +93,14 @@ jobs:
           - sink-csv
           - sink-elasticsearch
           - sink-http
+          - sink-stdout
+          # State-store backends
+          - state-redis
+          - state-postgres
           # Aggregates
           - source
           - sink
+          - state
           - full
     steps:
       - uses: actions/checkout@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ This is a library workspace — there is no binary, no database, no migrations, 
 
 ## Workspace Structure
 
-The project is a Cargo workspace with 27 crates:
+The project is a Cargo workspace with 30 crates:
 
 | Crate | Path | Description |
 |-------|------|-------------|
@@ -43,7 +43,10 @@ The project is a Cargo workspace with 27 crates:
 | `faucet-sink-csv` | `crates/sink/csv/` | CSV file sink — write JSON records as CSV rows |
 | `faucet-sink-elasticsearch` | `crates/sink/elasticsearch/` | Elasticsearch sink — bulk index API |
 | `faucet-sink-http` | `crates/sink/http/` | HTTP POST sink — send records to HTTP endpoint |
-| `faucet-stream` | `faucet-stream/` | Umbrella crate — feature-gated re-exports of all connectors |
+| `faucet-sink-stdout` | `crates/sink/stdout/` | Stdout/stderr sink — JSON Lines, pretty JSON, or TSV |
+| `faucet-state-redis` | `crates/state/redis/` | Redis-backed `StateStore` for replication bookmarks |
+| `faucet-state-postgres` | `crates/state/postgres/` | PostgreSQL-backed `StateStore` for replication bookmarks |
+| `faucet-stream` | `faucet-stream/` | Umbrella crate — feature-gated re-exports of all connectors and state backends |
 
 ### Crate Dependency Graph
 
@@ -75,8 +78,36 @@ faucet-core  <──  faucet-source-rest
              <──  faucet-sink-csv
              <──  faucet-sink-elasticsearch
              <──  faucet-sink-http
+             <──  faucet-sink-stdout
+             <──  faucet-state-redis
+             <──  faucet-state-postgres
              <──  faucet-stream (umbrella, all optional)
 ```
+
+## Capturing Feature Ideas as GitHub Issues
+
+**Whenever a new feature, enhancement, or bug surfaces in conversation — whether the user asks for it directly, you propose it, or it emerges as a side observation while working on something else — file it as a GitHub issue immediately, before continuing the current task.** This is how future sessions inherit the full context without needing to re-derive it from chat history.
+
+Rules:
+
+- **File the issue right away.** Don't wait until the end of the session, and don't batch multiple ideas into one issue unless they are genuinely the same change. One issue per discrete piece of work.
+- **Be exhaustively descriptive.** Each issue must stand alone — a fresh Claude session opening it cold should have everything needed to scope and implement the work. Include:
+  - **Summary** — one-paragraph statement of the problem and the proposed change.
+  - **Motivation** — why this matters (performance, correctness, ergonomics, third-party connector friendliness, etc.). Tie it back to the [Primary Goal](#primary-goal) or [Third-Party Connector Friendliness](#third-party-connector-friendliness) sections where relevant.
+  - **Proposed design** — concrete API shape, config field names, trait method signatures, file paths to touch. Show example usage in Rust where useful.
+  - **Affected crates / files** — explicit list of crates and modules that need changes, mirroring the [Architecture](#architecture) layout in this file.
+  - **Edge cases & failure modes** — what could go wrong, what error variants apply, what tests are needed.
+  - **Acceptance criteria** — bullet list of what "done" looks like (tests pass, docs updated, README updated, CI matrix updated if a new feature flag is added, etc.).
+  - **Out of scope** — anything explicitly deferred so the scope doesn't drift.
+  - **References** — links to related issues, PRs, upstream docs, or specific lines in this CLAUDE.md.
+- **Apply two labels to every issue:**
+  - **Type:** exactly one of `feature` (brand-new capability — a new connector, a new transform), `enhancement` (improvement to existing capability — new auth method on REST, new pagination style), or `bug` (incorrect behavior in existing code).
+  - **Tier:** exactly one of `tier-1` (critical — correctness bug, broken API, blocks a core use case, regression), `tier-2` (important — significant improvement, frequently-requested connector, perf win on a hot path), or `tier-3` (nice-to-have — niche connector, minor ergonomic polish, speculative idea).
+- **If a required label doesn't exist, create it first** with `gh label create <name> --description "<desc>" --color <hex>` before filing the issue. The repo uses GitHub's default `bug` and `enhancement` labels; `feature`, `tier-1`, `tier-2`, and `tier-3` may need to be created on first use.
+- **Confirm the GitHub remote auth flow** before running `gh` commands — see the [GitHub Auth Switching](#github-auth-switching) section at the bottom of this file.
+- **Don't file duplicates.** Search existing open issues (`gh issue list --search "<keywords>" --state open`) before creating a new one. If a related issue exists, comment on it instead.
+- **Mention the issue number in any follow-up PR** so the work links back automatically.
+- **Cross-link to the roadmap epic.** The repo maintains a single tracking epic — currently **[#38 Roadmap: faucet-stream connector & runtime coverage](https://github.com/PawanSikawat/faucet-stream/issues/38)** (labelled `epic`) — that organizes every feature/enhancement by tier and by area. When you file a new issue in scope of that roadmap, add a row to the relevant table in the epic (either by editing the epic body or by leaving a comment that links the new issue) so the epic stays a complete index. If the open `epic`-labelled issue has changed, follow the most recent one — find it with `gh issue list --label epic --state open`.
 
 ## Keeping This File Up to Date
 
@@ -164,12 +195,13 @@ cargo publish --dry-run -p faucet-stream
 
 ### faucet-core (`crates/core/`)
 
-- **`src/lib.rs`** — crate root; re-exports `FaucetError`, `Source`, `Sink`, `Pipeline`, `PipelineResult`, `run_stream`, `RecordTransform`, `ReplicationMethod`, `SourceDAG`, `DagResult`, `DagNodeResult`, `DagNodeError`, `DagNode`. Also re-exports third-party crates for connector authors: `async_trait`, `serde_json` (+ `Value`, `json!`), `schemars` (+ `JsonSchema`, `schema_for!`)
-- **`src/error.rs`** — `FaucetError` enum: `Http`, `HttpStatus`, `Json`, `JsonPath`, `Auth`, `RateLimited`, `Url`, `Transform`, `Config`, `Source`, `Sink`, `Custom(Box<dyn Error>)`
+- **`src/lib.rs`** — crate root; re-exports `FaucetError`, `Source`, `Sink`, `Pipeline`, `PipelineResult`, `run_stream`, `RecordTransform`, `ReplicationMethod`, `SourceDAG`, `DagResult`, `DagNodeResult`, `DagNodeError`, `DagNode`, `StateStore`, `MemoryStateStore`, `FileStateStore`. Also re-exports third-party crates for connector authors: `async_trait`, `serde_json` (+ `Value`, `json!`), `schemars` (+ `JsonSchema`, `schema_for!`)
+- **`src/error.rs`** — `FaucetError` enum: `Http`, `HttpStatus`, `Json`, `JsonPath`, `Auth`, `RateLimited`, `Url`, `Transform`, `Config`, `Source`, `Sink`, `State`, `Custom(Box<dyn Error>)`
 - **`src/config.rs`** — Config loading utilities: `load_json()` (from JSON file), `load_env()` (from env vars with prefix), `load_env_file()` (load `.env` then env vars). Also `duration_secs` and `duration_secs_option` serde helper modules for `Duration` fields
 - **`src/util.rs`** — Shared utilities: `quote_ident()` (SQL injection prevention), `extract_records()` (JSONPath extraction), `check_http_response()` (HTTP status error handling), `substitute_context()` (placeholder substitution for URLs/paths — NOT safe for SQL or JSON), `substitute_context_bind_params()` (SQL-safe substitution using bind parameter markers), `substitute_context_json()` (JSON-safe substitution with proper escaping), `extract_context()` (JSONPath-based context extraction from parent records)
-- **`src/traits.rs`** — `Source` and `Sink` async traits. `Source` uses `fetch_with_context()` as primary method (receives parent context); `fetch_all()` is a convenience wrapper. Both include `config_schema(&self) -> Value` method that returns a JSON Schema describing the connector's configuration (auto-generated via `schemars`)
-- **`src/pipeline.rs`** — `Pipeline` struct (batch source→sink), `run_stream()` (streaming source→sink), `PipelineResult`
+- **`src/traits.rs`** — `Source` and `Sink` async traits. `Source` uses `fetch_with_context()` as primary method (receives parent context); `fetch_all()` is a convenience wrapper. Both include `config_schema(&self) -> Value`. `Source` also exposes `state_key(&self) -> Option<String>` and `apply_start_bookmark(&self, bookmark)` for opting into resumable runs via a `StateStore` (both default no-ops, backwards-compatible).
+- **`src/pipeline.rs`** — `Pipeline` struct (batch source→sink), `run_stream()` (streaming source→sink), `PipelineResult`. `Pipeline::with_state_store(Arc<dyn StateStore>)` wires in durable bookmarks — read before fetch, persisted only after sink confirms the batch.
+- **`src/state.rs`** — `StateStore` async trait (`get` / `put` / `delete` over `serde_json::Value`), plus two built-in implementations: `MemoryStateStore` (in-process, for tests) and `FileStateStore` (one JSON file per key, written via atomic rename). Keys are validated by `validate_state_key`. Heavier backends (Redis, Postgres) live in their own crates to keep `faucet-core` dependency-light.
 - **`src/transform.rs`** — `RecordTransform` enum + `CompiledTransform`: flatten, rename keys (regex), snake_case, custom closures; feature-gated built-ins
 - **`src/replication.rs`** — `ReplicationMethod` enum, `filter_incremental()`, `max_replication_value()` for bookmark-based incremental replication
 - **`src/schema.rs`** — `infer_schema()`: JSON Schema inference from record samples with type merging and nullable detection
@@ -316,6 +348,19 @@ cargo publish --dry-run -p faucet-stream
 - **`src/sink.rs`** — `HttpSink`: POST records individually or as array; implements `faucet_core::Sink`
 - **`src/serde_helpers.rs`** — `http_method` module: serialize/deserialize `reqwest::Method` as string
 
+### faucet-sink-stdout (`crates/sink/stdout/`)
+
+- **`src/config.rs`** — `StdoutSinkConfig`, `StdStream` (Stdout, Stderr), `StdoutFormat` (JsonLines, PrettyJson, Tsv)
+- **`src/sink.rs`** — `StdoutSink`: writes encoded records to the chosen standard stream behind a `Mutex<Box<dyn AsyncWrite + Unpin + Send>>`. Treats `BrokenPipe` as clean termination. Honors `max_records` and `flush_per_record`. `StdoutSink::with_writer(...)` accepts a custom writer for tests and redirected output.
+
+### faucet-state-redis (`crates/state/redis/`)
+
+- **`src/store.rs`** — `RedisStateStore`: Redis-backed `StateStore`. Uses `redis::aio::MultiplexedConnection`, namespaces keys as `{namespace}:{key}`, exposes `connect(url, namespace)`, `from_connection(conn, namespace)`, and `ensure_table` is not needed (Redis is schemaless). Helper functions `build_redis_key`, `validate_namespace` are unit-tested.
+
+### faucet-state-postgres (`crates/state/postgres/`)
+
+- **`src/store.rs`** — `PostgresStateStore`: PostgreSQL-backed `StateStore`. Single table `faucet_state(key TEXT PRIMARY KEY, value JSONB, updated_at TIMESTAMPTZ)`. `connect`, `connect_with(url, max_connections, table)`, `from_pool(pool, table)`, and `ensure_table()` for schema bootstrap. Upsert via `ON CONFLICT (key) DO UPDATE`. SQL builders (`create_table_sql`, `select_sql`, `upsert_sql`, `delete_sql`) are free functions for unit testing.
+
 ### faucet-stream (umbrella, `faucet-stream/`)
 
 - **`src/lib.rs`** — feature-gated re-exports of all connectors; `pub use faucet_core::*` always available; backwards-compatible flat re-exports for existing users
@@ -349,9 +394,13 @@ cargo publish --dry-run -p faucet-stream
 | `sink-csv` | no | CSV file sink |
 | `sink-elasticsearch` | no | Elasticsearch bulk index sink |
 | `sink-http` | no | HTTP POST sink |
+| `sink-stdout` | no | Stdout/stderr sink (JSON Lines, pretty JSON, TSV) |
+| `state-redis` | no | Redis-backed `StateStore` backend |
+| `state-postgres` | no | PostgreSQL-backed `StateStore` backend |
 | `source` | no | All source connectors |
 | `sink` | no | All sink connectors |
-| `full` | no | Every connector |
+| `state` | no | All state-store backends (file lives in `faucet-core`) |
+| `full` | no | Every connector and state backend |
 | `transform-flatten` | yes (via source-rest) | Flatten nested objects |
 | `transform-rename-keys` | yes (via source-rest) | Regex key renaming |
 | `transform-snake-case` | yes (via source-rest) | Snake_case normalisation |
@@ -384,6 +433,7 @@ When the user points out something fundamental about how code in this library sh
 - `src/transform.rs` — record transform compilation and application only. No HTTP logic. Built-in transforms are feature-gated.
 - `src/replication.rs` — incremental replication filtering and bookmark computation only. No HTTP logic.
 - `src/schema.rs` — JSON Schema inference from `Vec<Value>` only. No HTTP logic.
+- `src/state.rs` — `StateStore` trait + in-memory and file-backed implementations only. No external service code (Redis / Postgres backends live in their own crates).
 
 #### faucet-source-rest
 - `src/auth/` — auth strategies only. No HTTP logic here.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,9 @@ members = [
     "crates/sink/csv",
     "crates/sink/elasticsearch",
     "crates/sink/http",
+    "crates/sink/stdout",
+    "crates/state/redis",
+    "crates/state/postgres",
     "faucet-stream",
 ]
 
@@ -68,6 +71,9 @@ faucet-sink-redis = { path = "crates/sink/redis", version = "0.2.0" }
 faucet-sink-csv = { path = "crates/sink/csv", version = "0.2.0" }
 faucet-sink-elasticsearch = { path = "crates/sink/elasticsearch", version = "0.2.0" }
 faucet-sink-http = { path = "crates/sink/http", version = "0.2.0" }
+faucet-sink-stdout = { path = "crates/sink/stdout", version = "0.2.0" }
+faucet-state-redis = { path = "crates/state/redis", version = "0.2.0" }
+faucet-state-postgres = { path = "crates/state/postgres", version = "0.2.0" }
 
 # Shared external deps
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -45,7 +45,11 @@ faucet-stream is a Cargo workspace with 27 crates — 13 sources, 12 sinks, a sh
 | [`faucet-sink-csv`](crates/sink/csv) | CSV — write JSON records as CSV rows |
 | [`faucet-sink-elasticsearch`](crates/sink/elasticsearch) | Elasticsearch — bulk index API |
 | [`faucet-sink-http`](crates/sink/http) | HTTP — POST records to any endpoint |
-| [`faucet-stream`](faucet-stream) | Umbrella crate — feature-gated re-exports of all connectors |
+| [`faucet-sink-stdout`](crates/sink/stdout) | Stdout/stderr — JSON Lines, pretty JSON, or TSV |
+| **State stores** | |
+| [`faucet-state-redis`](crates/state/redis) | Redis-backed `StateStore` for persistent bookmarks |
+| [`faucet-state-postgres`](crates/state/postgres) | PostgreSQL-backed `StateStore` for persistent bookmarks |
+| [`faucet-stream`](faucet-stream) | Umbrella crate — feature-gated re-exports of all connectors and state backends |
 
 Install only what you need:
 
@@ -715,9 +719,13 @@ All pagination styles include loop detection — if the same cursor or link is r
 | `sink-csv` | no | CSV file sink |
 | `sink-elasticsearch` | no | Elasticsearch bulk index sink |
 | `sink-http` | no | HTTP POST sink |
+| `sink-stdout` | no | Stdout/stderr sink (JSON Lines, pretty JSON, TSV) |
+| `state-redis` | no | Redis-backed `StateStore` backend |
+| `state-postgres` | no | PostgreSQL-backed `StateStore` backend |
 | `source` | no | All source connectors |
 | `sink` | no | All sink connectors |
-| `full` | no | Every connector |
+| `state` | no | All state-store backends (file backend lives in `faucet-core` directly) |
+| `full` | no | Every connector and state backend |
 | `transform-flatten` | yes | Flatten nested objects (forwarded to source-rest) |
 | `transform-rename-keys` | yes | Regex key renaming (forwarded to source-rest) |
 | `transform-snake-case` | yes | Snake_case normalisation (forwarded to source-rest) |

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -25,7 +25,7 @@ jsonpath-rust.workspace = true
 regex = { workspace = true, optional = true }
 futures-core.workspace = true
 futures.workspace = true
-tokio = { workspace = true, features = ["sync"] }
+tokio = { workspace = true, features = ["sync", "fs", "io-util"] }
 dotenvy = "0.15"
 envy = "0.4"
 schemars.workspace = true
@@ -34,3 +34,4 @@ schemars.workspace = true
 serde_json.workspace = true
 tokio = { workspace = true, features = ["macros", "rt"] }
 futures.workspace = true
+tempfile = "3"

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -56,6 +56,11 @@ pub enum FaucetError {
     #[error("Sink error: {0}")]
     Sink(String),
 
+    /// A state-store operation failed (read/write/delete of a replication
+    /// bookmark, checkpoint, or other persisted pipeline state).
+    #[error("State error: {0}")]
+    State(String),
+
     /// A custom error from a third-party connector.
     ///
     /// Use this to wrap your own error types without losing the error chain:

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -17,6 +17,7 @@ pub mod error;
 pub mod pipeline;
 pub mod replication;
 pub mod schema;
+pub mod state;
 pub mod traits;
 pub mod transform;
 pub mod util;
@@ -25,6 +26,7 @@ pub use dag::{DagNode, DagNodeError, DagNodeResult, DagResult, SourceDAG};
 pub use error::FaucetError;
 pub use pipeline::{Pipeline, PipelineResult, run_stream};
 pub use replication::ReplicationMethod;
+pub use state::{FileStateStore, MemoryStateStore, StateStore};
 pub use traits::{Sink, Source};
 pub use transform::RecordTransform;
 

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -40,10 +40,12 @@
 //! ```
 
 use crate::error::FaucetError;
+use crate::state::{StateStore, validate_state_key};
 use crate::traits::{Sink, Source};
 use futures_core::Stream;
 use serde_json::Value;
 use std::pin::Pin;
+use std::sync::Arc;
 
 /// Result of a pipeline run.
 #[derive(Debug, Clone)]
@@ -67,22 +69,56 @@ pub struct PipelineResult {
 pub struct Pipeline<'a, So: Source + ?Sized, Si: Sink + ?Sized> {
     source: &'a So,
     sink: &'a Si,
+    state_store: Option<Arc<dyn StateStore>>,
 }
 
 impl<'a, So: Source + ?Sized, Si: Sink + ?Sized> Pipeline<'a, So, Si> {
     /// Create a new pipeline from a source and a sink.
     pub fn new(source: &'a So, sink: &'a Si) -> Self {
-        Self { source, sink }
+        Self {
+            source,
+            sink,
+            state_store: None,
+        }
+    }
+
+    /// Attach a [`StateStore`] for persistent incremental-replication bookmarks.
+    ///
+    /// When configured, `run()` will:
+    /// 1. Read any previously stored bookmark at the source's
+    ///    [`state_key`](Source::state_key) and call
+    ///    [`apply_start_bookmark`](Source::apply_start_bookmark) on the source
+    ///    so it can resume from that point.
+    /// 2. Run the fetch + write as usual.
+    /// 3. Persist the new bookmark **only after** the sink confirms the
+    ///    batch was written and flushed.
+    ///
+    /// Sources that do not return a [`state_key`](Source::state_key) are
+    /// unaffected — the store is consulted only when the source opts in.
+    pub fn with_state_store(mut self, store: Arc<dyn StateStore>) -> Self {
+        self.state_store = Some(store);
+        self
     }
 
     /// Run the pipeline in batch mode.
     ///
-    /// 1. Calls [`Source::fetch_all_incremental`] to get all records and an
+    /// 1. Loads the stored bookmark and pushes it to the source (if a state
+    ///    store is configured and the source returns a `state_key`).
+    /// 2. Calls [`Source::fetch_all_incremental`] to get all records and an
     ///    optional bookmark.
-    /// 2. Writes the records to the sink via [`Sink::write_batch`].
-    /// 3. Calls [`Sink::flush`] to ensure all data is committed.
-    /// 4. Returns a [`PipelineResult`] with the total count and bookmark.
+    /// 3. Writes the records to the sink via [`Sink::write_batch`].
+    /// 4. Calls [`Sink::flush`] to ensure all data is committed.
+    /// 5. Persists the new bookmark to the state store.
+    /// 6. Returns a [`PipelineResult`] with the total count and bookmark.
     pub async fn run(&self) -> Result<PipelineResult, FaucetError> {
+        let state_key = self.source.state_key();
+        if let (Some(store), Some(key)) = (self.state_store.as_ref(), state_key.as_ref()) {
+            validate_state_key(key)?;
+            if let Some(prior) = store.get(key).await? {
+                self.source.apply_start_bookmark(prior).await?;
+            }
+        }
+
         let (records, bookmark) = self
             .source
             .fetch_with_context_incremental(&std::collections::HashMap::new())
@@ -96,9 +132,18 @@ impl<'a, So: Source + ?Sized, Si: Sink + ?Sized> Pipeline<'a, So, Si> {
 
         self.sink.flush().await?;
 
+        if let (Some(store), Some(key), Some(value)) = (
+            self.state_store.as_ref(),
+            state_key.as_ref(),
+            bookmark.as_ref(),
+        ) {
+            store.put(key, value).await?;
+        }
+
         tracing::info!(
             records_written,
             has_bookmark = bookmark.is_some(),
+            persisted = self.state_store.is_some() && state_key.is_some() && bookmark.is_some(),
             "pipeline batch run complete"
         );
 
@@ -383,5 +428,192 @@ mod tests {
 
         let result = run_stream(stream, sink.as_ref()).await.unwrap();
         assert_eq!(result.records_written, 1);
+    }
+
+    // ── State-store integration tests ───────────────────────────────────────
+
+    use crate::state::{FileStateStore, MemoryStateStore, StateStore};
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    /// Source that opts into state persistence. It records the bookmark it
+    /// received via `apply_start_bookmark` so tests can verify the pipeline
+    /// pushed the stored value back into it on resume.
+    struct StatefulSource {
+        key: String,
+        records: Vec<Value>,
+        new_bookmark: Value,
+        seen_bookmark: std::sync::Mutex<Option<Value>>,
+    }
+
+    impl StatefulSource {
+        fn new(key: &str, records: Vec<Value>, new_bookmark: Value) -> Self {
+            Self {
+                key: key.into(),
+                records,
+                new_bookmark,
+                seen_bookmark: std::sync::Mutex::new(None),
+            }
+        }
+        fn observed_start(&self) -> Option<Value> {
+            self.seen_bookmark.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl Source for StatefulSource {
+        async fn fetch_with_context(
+            &self,
+            _ctx: &std::collections::HashMap<String, Value>,
+        ) -> Result<Vec<Value>, FaucetError> {
+            Ok(self.records.clone())
+        }
+        async fn fetch_with_context_incremental(
+            &self,
+            _ctx: &std::collections::HashMap<String, Value>,
+        ) -> Result<(Vec<Value>, Option<Value>), FaucetError> {
+            Ok((self.records.clone(), Some(self.new_bookmark.clone())))
+        }
+        fn state_key(&self) -> Option<String> {
+            Some(self.key.clone())
+        }
+        async fn apply_start_bookmark(&self, bookmark: Value) -> Result<(), FaucetError> {
+            *self.seen_bookmark.lock().unwrap() = Some(bookmark);
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn pipeline_with_state_store_persists_bookmark_after_sink() {
+        let store: Arc<dyn StateStore> = Arc::new(MemoryStateStore::new());
+        let source = StatefulSource::new(
+            "github_issues",
+            vec![json!({"id": 1, "ts": "2026-05-01"})],
+            json!("2026-05-01"),
+        );
+        let sink = MockSink::new();
+        let result = Pipeline::new(&source, &sink)
+            .with_state_store(Arc::clone(&store))
+            .run()
+            .await
+            .unwrap();
+
+        assert_eq!(result.records_written, 1);
+        assert_eq!(result.bookmark, Some(json!("2026-05-01")));
+        // Stored value matches what the source returned.
+        let stored = store.get("github_issues").await.unwrap();
+        assert_eq!(stored, Some(json!("2026-05-01")));
+    }
+
+    #[tokio::test]
+    async fn pipeline_with_state_store_resumes_from_stored_bookmark() {
+        let store: Arc<dyn StateStore> = Arc::new(MemoryStateStore::new());
+        store
+            .put("github_issues", &json!("2026-04-30"))
+            .await
+            .unwrap();
+
+        let source =
+            StatefulSource::new("github_issues", vec![json!({"id": 2})], json!("2026-05-01"));
+        let sink = MockSink::new();
+        Pipeline::new(&source, &sink)
+            .with_state_store(Arc::clone(&store))
+            .run()
+            .await
+            .unwrap();
+
+        // The pipeline pushed the previously-stored bookmark back into the source.
+        assert_eq!(source.observed_start(), Some(json!("2026-04-30")));
+        // And then overwrote it with the new value from this run.
+        assert_eq!(
+            store.get("github_issues").await.unwrap(),
+            Some(json!("2026-05-01"))
+        );
+    }
+
+    #[tokio::test]
+    async fn pipeline_with_state_store_does_not_persist_when_sink_fails() {
+        let store: Arc<dyn StateStore> = Arc::new(MemoryStateStore::new());
+        let source = StatefulSource::new("k", vec![json!({"id": 1})], json!("2026-05-01"));
+        let sink = FailingSink;
+
+        let result = Pipeline::new(&source, &sink)
+            .with_state_store(Arc::clone(&store))
+            .run()
+            .await;
+        assert!(result.is_err());
+        assert!(store.get("k").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn pipeline_with_state_store_no_state_key_means_no_persist() {
+        let store: Arc<dyn StateStore> = Arc::new(MemoryStateStore::new());
+        let source = IncrementalSource {
+            records: vec![json!({"id": 1})],
+            bookmark: json!("ignored"),
+        };
+        let sink = MockSink::new();
+        Pipeline::new(&source, &sink)
+            .with_state_store(Arc::clone(&store))
+            .run()
+            .await
+            .unwrap();
+        // IncrementalSource doesn't override state_key, so nothing was persisted.
+        // Cross-check that no keys exist by trying a likely one.
+        assert!(store.get("anything").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn pipeline_with_state_store_skips_persist_when_bookmark_is_none() {
+        let store: Arc<dyn StateStore> = Arc::new(MemoryStateStore::new());
+        struct NoBookmarkSource;
+        #[async_trait]
+        impl Source for NoBookmarkSource {
+            async fn fetch_with_context(
+                &self,
+                _ctx: &std::collections::HashMap<String, Value>,
+            ) -> Result<Vec<Value>, FaucetError> {
+                Ok(vec![json!({"id": 1})])
+            }
+            fn state_key(&self) -> Option<String> {
+                Some("k".into())
+            }
+        }
+        let source = NoBookmarkSource;
+        let sink = MockSink::new();
+        Pipeline::new(&source, &sink)
+            .with_state_store(Arc::clone(&store))
+            .run()
+            .await
+            .unwrap();
+        assert!(store.get("k").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn pipeline_with_file_state_store_round_trips_across_runs() {
+        let dir = TempDir::new().unwrap();
+        let store: Arc<dyn StateStore> = Arc::new(FileStateStore::new(dir.path()));
+
+        // Run 1: nothing stored yet, persist new bookmark.
+        let s1 = StatefulSource::new("k", vec![json!({"i": 1})], json!("v1"));
+        let sink1 = MockSink::new();
+        Pipeline::new(&s1, &sink1)
+            .with_state_store(Arc::clone(&store))
+            .run()
+            .await
+            .unwrap();
+        assert_eq!(s1.observed_start(), None);
+        assert_eq!(store.get("k").await.unwrap(), Some(json!("v1")));
+
+        // Run 2: resume from v1, persist v2.
+        let s2 = StatefulSource::new("k", vec![json!({"i": 2})], json!("v2"));
+        let sink2 = MockSink::new();
+        Pipeline::new(&s2, &sink2)
+            .with_state_store(Arc::clone(&store))
+            .run()
+            .await
+            .unwrap();
+        assert_eq!(s2.observed_start(), Some(json!("v1")));
+        assert_eq!(store.get("k").await.unwrap(), Some(json!("v2")));
     }
 }

--- a/crates/core/src/state.rs
+++ b/crates/core/src/state.rs
@@ -1,0 +1,417 @@
+//! Pluggable state store for incremental replication bookmarks.
+//!
+//! Sources that support incremental replication need to remember where they
+//! left off across runs. This module defines the [`StateStore`] trait that
+//! the pipeline orchestrator uses to read and persist that progress, plus two
+//! ready-to-use implementations:
+//!
+//! - [`MemoryStateStore`] — in-process map. Useful for tests and for runs
+//!   that intentionally start fresh each time.
+//! - [`FileStateStore`] — one JSON file per key, written via atomic rename
+//!   so a crash mid-update never leaves the bookmark torn.
+//!
+//! Heavier backends (Redis, PostgreSQL) live in their own crates so
+//! `faucet-core` stays dependency-light. They implement the same trait.
+
+use crate::error::FaucetError;
+use async_trait::async_trait;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use tokio::sync::Mutex;
+
+/// Persistent key/value store for replication bookmarks and pipeline checkpoints.
+///
+/// Implementations must be safe to call from multiple tasks at once. The
+/// trait is intentionally minimal — three operations cover every bookmark
+/// flow the pipeline orchestrator needs.
+#[async_trait]
+pub trait StateStore: Send + Sync {
+    /// Return the value stored under `key`, or `None` if no entry exists.
+    async fn get(&self, key: &str) -> Result<Option<Value>, FaucetError>;
+
+    /// Store `value` under `key`, replacing any previous entry.
+    ///
+    /// Implementations should make the update durable before returning so a
+    /// crash immediately after `put` does not lose the bookmark.
+    async fn put(&self, key: &str, value: &Value) -> Result<(), FaucetError>;
+
+    /// Remove the entry for `key`. A missing key is not an error.
+    async fn delete(&self, key: &str) -> Result<(), FaucetError>;
+}
+
+/// Reject keys that could escape the storage namespace or break filename
+/// rules on common filesystems. Allowed: ASCII letters, digits, `_`, `-`,
+/// `:`, `.`. Empty keys are rejected.
+pub fn validate_state_key(key: &str) -> Result<(), FaucetError> {
+    if key.is_empty() {
+        return Err(FaucetError::State("state key must not be empty".into()));
+    }
+    if key.len() > 256 {
+        return Err(FaucetError::State(format!(
+            "state key '{key}' exceeds 256 characters"
+        )));
+    }
+    for (i, c) in key.char_indices() {
+        let ok = c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | ':' | '.');
+        if !ok {
+            return Err(FaucetError::State(format!(
+                "state key '{key}' contains illegal character {c:?} at byte {i}"
+            )));
+        }
+    }
+    if key == "." || key == ".." || key.starts_with('.') {
+        return Err(FaucetError::State(format!(
+            "state key '{key}' must not begin with a dot"
+        )));
+    }
+    Ok(())
+}
+
+// ── MemoryStateStore ────────────────────────────────────────────────────────
+
+/// In-memory `StateStore` for tests and ephemeral pipelines.
+#[derive(Default)]
+pub struct MemoryStateStore {
+    inner: Mutex<HashMap<String, Value>>,
+}
+
+impl MemoryStateStore {
+    /// Create an empty in-memory store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait]
+impl StateStore for MemoryStateStore {
+    async fn get(&self, key: &str) -> Result<Option<Value>, FaucetError> {
+        validate_state_key(key)?;
+        Ok(self.inner.lock().await.get(key).cloned())
+    }
+
+    async fn put(&self, key: &str, value: &Value) -> Result<(), FaucetError> {
+        validate_state_key(key)?;
+        self.inner
+            .lock()
+            .await
+            .insert(key.to_owned(), value.clone());
+        Ok(())
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), FaucetError> {
+        validate_state_key(key)?;
+        self.inner.lock().await.remove(key);
+        Ok(())
+    }
+}
+
+// ── FileStateStore ──────────────────────────────────────────────────────────
+
+/// File-backed `StateStore`. Each key maps to a JSON file at
+/// `{root}/{key}.json`, written via atomic rename.
+///
+/// The store creates its root directory on first use. All writes are
+/// serialized through a per-store mutex so two concurrent `put`s for the
+/// same key cannot race on the temp filename. Different processes pointing
+/// at the same directory rely on the filesystem's atomic rename guarantee.
+pub struct FileStateStore {
+    root: PathBuf,
+    write_lock: Mutex<()>,
+}
+
+impl FileStateStore {
+    /// Open or create a file-backed state store rooted at `root`.
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self {
+            root: root.into(),
+            write_lock: Mutex::new(()),
+        }
+    }
+
+    fn entry_path(&self, key: &str) -> PathBuf {
+        self.root.join(format!("{key}.json"))
+    }
+
+    fn temp_path(&self, key: &str) -> PathBuf {
+        self.root.join(format!("{key}.json.tmp"))
+    }
+
+    async fn ensure_root(&self) -> Result<(), FaucetError> {
+        tokio::fs::create_dir_all(&self.root).await.map_err(|e| {
+            FaucetError::State(format!(
+                "failed to create state dir {}: {e}",
+                self.root.display()
+            ))
+        })
+    }
+
+    /// Returns the root directory this store writes into.
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+}
+
+#[async_trait]
+impl StateStore for FileStateStore {
+    async fn get(&self, key: &str) -> Result<Option<Value>, FaucetError> {
+        validate_state_key(key)?;
+        let path = self.entry_path(key);
+        match tokio::fs::read(&path).await {
+            Ok(bytes) => {
+                let value: Value = serde_json::from_slice(&bytes).map_err(|e| {
+                    FaucetError::State(format!(
+                        "failed to parse state file {}: {e}",
+                        path.display()
+                    ))
+                })?;
+                Ok(Some(value))
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(FaucetError::State(format!(
+                "failed to read state file {}: {e}",
+                path.display()
+            ))),
+        }
+    }
+
+    async fn put(&self, key: &str, value: &Value) -> Result<(), FaucetError> {
+        validate_state_key(key)?;
+        let _guard = self.write_lock.lock().await;
+        self.ensure_root().await?;
+        let bytes = serde_json::to_vec(value).map_err(|e| {
+            FaucetError::State(format!("failed to serialize state for key '{key}': {e}"))
+        })?;
+        let final_path = self.entry_path(key);
+        let tmp_path = self.temp_path(key);
+        tokio::fs::write(&tmp_path, &bytes).await.map_err(|e| {
+            FaucetError::State(format!(
+                "failed to write temp state file {}: {e}",
+                tmp_path.display()
+            ))
+        })?;
+        tokio::fs::rename(&tmp_path, &final_path)
+            .await
+            .map_err(|e| {
+                FaucetError::State(format!(
+                    "failed to commit state file {}: {e}",
+                    final_path.display()
+                ))
+            })?;
+        tracing::debug!(
+            key,
+            path = %final_path.display(),
+            "state file written"
+        );
+        Ok(())
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), FaucetError> {
+        validate_state_key(key)?;
+        let path = self.entry_path(key);
+        match tokio::fs::remove_file(&path).await {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(FaucetError::State(format!(
+                "failed to delete state file {}: {e}",
+                path.display()
+            ))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    // ── key validation ─────────────────────────────────────────────────────
+
+    #[test]
+    fn rejects_empty_key() {
+        let err = validate_state_key("").unwrap_err();
+        assert!(matches!(err, FaucetError::State(_)));
+    }
+
+    #[test]
+    fn rejects_path_traversal_segments() {
+        for k in ["../etc/passwd", "a/b", "a\\b", "..", "."] {
+            assert!(validate_state_key(k).is_err(), "expected reject for {k:?}");
+        }
+    }
+
+    #[test]
+    fn rejects_leading_dot() {
+        assert!(validate_state_key(".hidden").is_err());
+    }
+
+    #[test]
+    fn rejects_over_long_key() {
+        let k = "a".repeat(257);
+        assert!(validate_state_key(&k).is_err());
+    }
+
+    #[test]
+    fn accepts_typical_keys() {
+        for k in [
+            "github_issues",
+            "pipeline:rest:issues",
+            "with.dot",
+            "with-dash_and_underscore",
+            "lower-Case_99",
+        ] {
+            validate_state_key(k).unwrap_or_else(|e| panic!("expected ok for {k:?}: {e}"));
+        }
+    }
+
+    // ── MemoryStateStore ────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn memory_get_returns_none_for_missing_key() {
+        let s = MemoryStateStore::new();
+        assert!(s.get("nope").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn memory_put_then_get_round_trips() {
+        let s = MemoryStateStore::new();
+        s.put("k", &json!({"cursor": "abc", "n": 7})).await.unwrap();
+        let got = s.get("k").await.unwrap().unwrap();
+        assert_eq!(got["cursor"], "abc");
+        assert_eq!(got["n"], 7);
+    }
+
+    #[tokio::test]
+    async fn memory_put_overwrites_previous_value() {
+        let s = MemoryStateStore::new();
+        s.put("k", &json!(1)).await.unwrap();
+        s.put("k", &json!(2)).await.unwrap();
+        assert_eq!(s.get("k").await.unwrap().unwrap(), json!(2));
+    }
+
+    #[tokio::test]
+    async fn memory_delete_makes_get_return_none() {
+        let s = MemoryStateStore::new();
+        s.put("k", &json!("v")).await.unwrap();
+        s.delete("k").await.unwrap();
+        assert!(s.get("k").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn memory_delete_missing_key_is_ok() {
+        let s = MemoryStateStore::new();
+        s.delete("absent").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn memory_rejects_invalid_keys() {
+        let s = MemoryStateStore::new();
+        assert!(s.get("a/b").await.is_err());
+        assert!(s.put("a/b", &json!(1)).await.is_err());
+        assert!(s.delete("a/b").await.is_err());
+    }
+
+    // ── FileStateStore ──────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn file_get_returns_none_for_missing_key() {
+        let dir = TempDir::new().unwrap();
+        let s = FileStateStore::new(dir.path());
+        assert!(s.get("nope").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn file_put_creates_root_directory_lazily() {
+        let dir = TempDir::new().unwrap();
+        let root = dir.path().join("nested/state");
+        let s = FileStateStore::new(&root);
+        s.put("k", &json!("v")).await.unwrap();
+        assert!(root.is_dir(), "root dir should be created on first put");
+    }
+
+    #[tokio::test]
+    async fn file_put_then_get_round_trips() {
+        let dir = TempDir::new().unwrap();
+        let s = FileStateStore::new(dir.path());
+        let value = json!({"cursor": "abc", "n": 42, "nested": {"flag": true}});
+        s.put("github_issues", &value).await.unwrap();
+        let got = s.get("github_issues").await.unwrap().unwrap();
+        assert_eq!(got, value);
+    }
+
+    #[tokio::test]
+    async fn file_put_overwrites_previous_value_atomically() {
+        let dir = TempDir::new().unwrap();
+        let s = FileStateStore::new(dir.path());
+        s.put("k", &json!({"v": 1})).await.unwrap();
+        s.put("k", &json!({"v": 2})).await.unwrap();
+        assert_eq!(s.get("k").await.unwrap().unwrap(), json!({"v": 2}));
+        // The temp path must not be left behind.
+        let leftover = dir.path().join("k.json.tmp");
+        assert!(!leftover.exists());
+    }
+
+    #[tokio::test]
+    async fn file_delete_removes_file() {
+        let dir = TempDir::new().unwrap();
+        let s = FileStateStore::new(dir.path());
+        s.put("k", &json!("v")).await.unwrap();
+        s.delete("k").await.unwrap();
+        assert!(s.get("k").await.unwrap().is_none());
+        assert!(!dir.path().join("k.json").exists());
+    }
+
+    #[tokio::test]
+    async fn file_delete_missing_key_is_ok() {
+        let dir = TempDir::new().unwrap();
+        let s = FileStateStore::new(dir.path());
+        s.delete("absent").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn file_get_returns_error_for_corrupt_json() {
+        let dir = TempDir::new().unwrap();
+        let s = FileStateStore::new(dir.path());
+        tokio::fs::create_dir_all(dir.path()).await.unwrap();
+        tokio::fs::write(dir.path().join("bad.json"), b"not json")
+            .await
+            .unwrap();
+        let err = s.get("bad").await.unwrap_err();
+        match err {
+            FaucetError::State(msg) => assert!(msg.contains("bad.json")),
+            other => panic!("expected State error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn file_concurrent_puts_do_not_corrupt_or_leak_temp() {
+        let dir = TempDir::new().unwrap();
+        let s = Arc::new(FileStateStore::new(dir.path()));
+        let mut handles = vec![];
+        for i in 0..50 {
+            let s = Arc::clone(&s);
+            handles.push(tokio::spawn(async move {
+                s.put("k", &json!({"i": i})).await.unwrap();
+            }));
+        }
+        for h in handles {
+            h.await.unwrap();
+        }
+        // The final value must be one of the 50 we wrote.
+        let got = s.get("k").await.unwrap().unwrap();
+        let i = got["i"].as_i64().unwrap();
+        assert!((0..50).contains(&i));
+        // And no temp file should remain.
+        assert!(!dir.path().join("k.json.tmp").exists());
+    }
+
+    #[tokio::test]
+    async fn file_store_works_through_trait_object() {
+        let dir = TempDir::new().unwrap();
+        let s: Box<dyn StateStore> = Box::new(FileStateStore::new(dir.path()));
+        s.put("k", &json!(1)).await.unwrap();
+        assert_eq!(s.get("k").await.unwrap().unwrap(), json!(1));
+    }
+}

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -48,6 +48,33 @@ pub trait Source: Send + Sync {
     fn config_schema(&self) -> Value {
         serde_json::json!({"type": "object", "properties": {}})
     }
+
+    /// Stable key under which this source's incremental-replication bookmark
+    /// should be persisted in a [`StateStore`](crate::state::StateStore).
+    ///
+    /// Returning `Some(key)` opts this source into resumable runs: when the
+    /// pipeline is configured with a state store via
+    /// [`Pipeline::with_state_store`](crate::Pipeline::with_state_store), it
+    /// reads the bookmark at `key` before fetching and writes the new
+    /// bookmark back only after the sink confirms the batch was written.
+    ///
+    /// The default returns `None`, meaning the source is not persisted.
+    /// Keys must satisfy [`validate_state_key`](crate::state::validate_state_key).
+    fn state_key(&self) -> Option<String> {
+        None
+    }
+
+    /// Apply a bookmark loaded from a [`StateStore`](crate::state::StateStore)
+    /// as this run's starting point.
+    ///
+    /// The default implementation ignores the value, which keeps existing
+    /// sources backwards-compatible. Sources that support incremental
+    /// replication override this — typically by storing the value behind
+    /// interior mutability and consulting it inside
+    /// `fetch_with_context_incremental`.
+    async fn apply_start_bookmark(&self, _bookmark: Value) -> Result<(), FaucetError> {
+        Ok(())
+    }
 }
 
 /// A sink writes records to an external system.

--- a/crates/sink/stdout/Cargo.toml
+++ b/crates/sink/stdout/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "faucet-sink-stdout"
+version = "0.2.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Stdout/stderr sink connector for the faucet-stream ecosystem"
+
+[dependencies]
+faucet-core.workspace = true
+schemars.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+async-trait.workspace = true
+tracing.workspace = true
+tokio = { workspace = true, features = ["io-util", "io-std", "sync"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt", "io-util", "sync"] }
+serde_json.workspace = true

--- a/crates/sink/stdout/README.md
+++ b/crates/sink/stdout/README.md
@@ -1,0 +1,64 @@
+# faucet-sink-stdout
+
+Stdout/stderr sink for the [faucet-stream](https://crates.io/crates/faucet-stream) ecosystem. Writes each record to a standard stream in one of three formats — useful for debugging pipelines, building demos, and powering the `faucet preview` CLI workflow.
+
+## Install
+
+```toml
+[dependencies]
+faucet-core = "0.2"
+faucet-sink-stdout = "0.2"
+```
+
+Or via the umbrella crate with the `sink-stdout` feature:
+
+```toml
+[dependencies]
+faucet-stream = { version = "0.2", features = ["sink-stdout"] }
+```
+
+## Usage
+
+```rust,no_run
+use faucet_core::Sink;
+use faucet_sink_stdout::{StdoutFormat, StdStream, StdoutSink, StdoutSinkConfig};
+use serde_json::json;
+
+# async fn run() -> Result<(), faucet_core::FaucetError> {
+let sink = StdoutSink::new(
+    StdoutSinkConfig::new()
+        .destination(StdStream::Stdout)
+        .format(StdoutFormat::JsonLines),
+);
+
+sink.write_batch(&[json!({"id": 1, "name": "Alice"})]).await?;
+sink.flush().await?;
+# Ok(())
+# }
+```
+
+## Configuration
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `destination` | `stdout` \| `stderr` | `stdout` | Which standard stream to write to. |
+| `format` | `json_lines` \| `pretty_json` \| `tsv` | `json_lines` | Output format. |
+| `flush_per_record` | `bool` | `false` | Flush after every record (lower latency, slightly lower throughput). |
+| `max_records` | `usize?` | `None` | Stop after `n` records. Useful for `faucet preview --limit=N`. |
+
+### Formats
+
+- **`json_lines`** — one compact JSON object per line. The de facto debug format.
+- **`pretty_json`** — indented JSON, each record separated by a newline. Easier on the eyes.
+- **`tsv`** — tab-separated values. Each record's keys are sorted alphabetically; scalar values are emitted raw (with control characters replaced by spaces in strings), and nested objects/arrays are emitted as compact JSON. Requires every record to be a JSON object.
+
+## Behavior notes
+
+- The underlying writer is opened eagerly in `new()`.
+- A `BrokenPipe` from the consumer (e.g. piping into `head`) is treated as a clean termination — subsequent `write_batch` calls return `Ok(0)` rather than erroring.
+- `flush()` flushes the underlying writer; the default `Sink` impl does not flush on `Drop`, so call it explicitly if you need durability of buffered output.
+- `StdoutSink::with_writer(config, writer)` accepts any `Box<dyn AsyncWrite + Unpin + Send>`. Useful in tests and when redirecting into log files or in-memory buffers.
+
+## License
+
+Licensed under either of MIT or Apache-2.0 at your option.

--- a/crates/sink/stdout/src/config.rs
+++ b/crates/sink/stdout/src/config.rs
@@ -1,0 +1,124 @@
+//! Stdout/stderr sink configuration.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Which standard stream to write records to.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum StdStream {
+    /// Standard output (default). Honors shell redirection.
+    #[default]
+    Stdout,
+    /// Standard error. Useful when stdout is reserved for piping pipeline output.
+    Stderr,
+}
+
+/// How each record should be serialized before writing.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum StdoutFormat {
+    /// One compact JSON object per line (default — matches JSONL format).
+    #[default]
+    JsonLines,
+    /// Indented JSON, separated by newlines. Easier to read but not a single-line format.
+    PrettyJson,
+    /// Tab-separated values, with each record's keys sorted alphabetically.
+    /// Scalars are emitted as-is; nested objects/arrays are emitted as compact JSON.
+    Tsv,
+}
+
+/// Configuration for the stdout/stderr sink.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+pub struct StdoutSinkConfig {
+    /// Which standard stream to write to.
+    #[serde(default)]
+    pub destination: StdStream,
+    /// Output format.
+    #[serde(default)]
+    pub format: StdoutFormat,
+    /// Flush the underlying writer after every record instead of at batch boundaries.
+    /// Tradeoff: lower latency for live preview, slightly lower throughput.
+    #[serde(default)]
+    pub flush_per_record: bool,
+    /// Stop writing after this many records have been emitted. Subsequent
+    /// `write_batch` calls become no-ops. `None` means unlimited.
+    #[serde(default)]
+    pub max_records: Option<usize>,
+}
+
+impl StdoutSinkConfig {
+    /// Create a new config with all defaults (stdout, JSON Lines, no limit).
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Send records to the given standard stream.
+    pub fn destination(mut self, destination: StdStream) -> Self {
+        self.destination = destination;
+        self
+    }
+
+    /// Choose the output format.
+    pub fn format(mut self, format: StdoutFormat) -> Self {
+        self.format = format;
+        self
+    }
+
+    /// Flush after every record.
+    pub fn flush_per_record(mut self, flush_per_record: bool) -> Self {
+        self.flush_per_record = flush_per_record;
+        self
+    }
+
+    /// Stop after writing `n` records total.
+    pub fn max_records(mut self, max_records: usize) -> Self {
+        self.max_records = Some(max_records);
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults() {
+        let c = StdoutSinkConfig::new();
+        assert_eq!(c.destination, StdStream::Stdout);
+        assert_eq!(c.format, StdoutFormat::JsonLines);
+        assert!(!c.flush_per_record);
+        assert!(c.max_records.is_none());
+    }
+
+    #[test]
+    fn builder_chains() {
+        let c = StdoutSinkConfig::new()
+            .destination(StdStream::Stderr)
+            .format(StdoutFormat::PrettyJson)
+            .flush_per_record(true)
+            .max_records(10);
+        assert_eq!(c.destination, StdStream::Stderr);
+        assert_eq!(c.format, StdoutFormat::PrettyJson);
+        assert!(c.flush_per_record);
+        assert_eq!(c.max_records, Some(10));
+    }
+
+    #[test]
+    fn serde_round_trip() {
+        let c = StdoutSinkConfig::new()
+            .destination(StdStream::Stderr)
+            .format(StdoutFormat::Tsv);
+        let json = serde_json::to_string(&c).unwrap();
+        let back: StdoutSinkConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.destination, StdStream::Stderr);
+        assert_eq!(back.format, StdoutFormat::Tsv);
+    }
+
+    #[test]
+    fn deserialize_from_minimal_json() {
+        let c: StdoutSinkConfig = serde_json::from_str("{}").unwrap();
+        assert_eq!(c.destination, StdStream::Stdout);
+        assert_eq!(c.format, StdoutFormat::JsonLines);
+    }
+}

--- a/crates/sink/stdout/src/lib.rs
+++ b/crates/sink/stdout/src/lib.rs
@@ -1,0 +1,16 @@
+//! # faucet-sink-stdout
+//!
+//! Stdout/stderr sink connector for the faucet-stream ecosystem.
+//!
+//! Writes each `serde_json::Value` record to the chosen standard stream in
+//! one of three formats: JSON Lines (default), pretty-printed JSON, or
+//! tab-separated values. Useful for debugging, examples, the upcoming
+//! `faucet preview` CLI workflow, and ad-hoc inspection.
+
+pub mod config;
+pub mod sink;
+
+pub use faucet_core::{FaucetError, Sink};
+
+pub use config::{StdStream, StdoutFormat, StdoutSinkConfig};
+pub use sink::StdoutSink;

--- a/crates/sink/stdout/src/sink.rs
+++ b/crates/sink/stdout/src/sink.rs
@@ -1,0 +1,372 @@
+//! Stdout/stderr sink implementation.
+
+use crate::config::{StdStream, StdoutFormat, StdoutSinkConfig};
+use async_trait::async_trait;
+use faucet_core::FaucetError;
+use serde_json::Value;
+use std::io;
+use tokio::io::{AsyncWrite, AsyncWriteExt};
+use tokio::sync::Mutex;
+
+/// State guarded by a single mutex so the running record count, the writer,
+/// and the "consumer closed the pipe" flag can't race against each other.
+struct State {
+    writer: Box<dyn AsyncWrite + Unpin + Send>,
+    written: usize,
+    closed: bool,
+}
+
+/// A sink that writes records to standard output or standard error.
+pub struct StdoutSink {
+    config: StdoutSinkConfig,
+    state: Mutex<State>,
+}
+
+impl StdoutSink {
+    /// Create a new stdout/stderr sink. Opens the underlying stream eagerly.
+    pub fn new(config: StdoutSinkConfig) -> Self {
+        let writer: Box<dyn AsyncWrite + Unpin + Send> = match config.destination {
+            StdStream::Stdout => Box::new(tokio::io::stdout()),
+            StdStream::Stderr => Box::new(tokio::io::stderr()),
+        };
+        Self::with_writer(config, writer)
+    }
+
+    /// Construct with a caller-provided async writer. Used by tests to capture
+    /// output, and by integrators who want to redirect into something other
+    /// than the real stdio handles (e.g. a log file, an in-memory buffer).
+    pub fn with_writer(
+        config: StdoutSinkConfig,
+        writer: Box<dyn AsyncWrite + Unpin + Send>,
+    ) -> Self {
+        Self {
+            config,
+            state: Mutex::new(State {
+                writer,
+                written: 0,
+                closed: false,
+            }),
+        }
+    }
+
+    fn encode(&self, record: &Value) -> Result<Vec<u8>, FaucetError> {
+        match self.config.format {
+            StdoutFormat::JsonLines => {
+                let mut bytes = serde_json::to_vec(record)
+                    .map_err(|e| FaucetError::Sink(format!("JSON serialization failed: {e}")))?;
+                bytes.push(b'\n');
+                Ok(bytes)
+            }
+            StdoutFormat::PrettyJson => {
+                let mut bytes = serde_json::to_vec_pretty(record)
+                    .map_err(|e| FaucetError::Sink(format!("JSON serialization failed: {e}")))?;
+                bytes.push(b'\n');
+                Ok(bytes)
+            }
+            StdoutFormat::Tsv => encode_tsv(record),
+        }
+    }
+}
+
+fn encode_tsv(record: &Value) -> Result<Vec<u8>, FaucetError> {
+    let obj = record.as_object().ok_or_else(|| {
+        FaucetError::Sink("Tsv format requires each record to be a JSON object".into())
+    })?;
+    let mut keys: Vec<&String> = obj.keys().collect();
+    keys.sort();
+    let mut line = String::new();
+    for (i, key) in keys.iter().enumerate() {
+        if i > 0 {
+            line.push('\t');
+        }
+        let value = &obj[*key];
+        line.push_str(&tsv_cell(value)?);
+    }
+    line.push('\n');
+    Ok(line.into_bytes())
+}
+
+fn tsv_cell(value: &Value) -> Result<String, FaucetError> {
+    Ok(match value {
+        // Render strings without JSON quoting, but neutralise control chars
+        // that would corrupt the TSV layout.
+        Value::String(s) => s.replace(['\t', '\n', '\r'], " "),
+        Value::Null => String::new(),
+        Value::Bool(_) | Value::Number(_) => value.to_string(),
+        Value::Array(_) | Value::Object(_) => serde_json::to_string(value)
+            .map_err(|e| FaucetError::Sink(format!("JSON serialization failed: {e}")))?,
+    })
+}
+
+#[async_trait]
+impl faucet_core::Sink for StdoutSink {
+    fn config_schema(&self) -> Value {
+        serde_json::to_value(faucet_core::schema_for!(StdoutSinkConfig))
+            .expect("schema serialization")
+    }
+
+    async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
+        if records.is_empty() {
+            return Ok(0);
+        }
+
+        let mut state = self.state.lock().await;
+        if state.closed {
+            return Ok(0);
+        }
+
+        let remaining = match self.config.max_records {
+            Some(max) => max.saturating_sub(state.written),
+            None => usize::MAX,
+        };
+        if remaining == 0 {
+            return Ok(0);
+        }
+
+        let take = records.len().min(remaining);
+        let mut written_this_call = 0usize;
+        for record in records.iter().take(take) {
+            let bytes = self.encode(record)?;
+            match state.writer.write_all(&bytes).await {
+                Ok(()) => {}
+                Err(e) if e.kind() == io::ErrorKind::BrokenPipe => {
+                    state.closed = true;
+                    tracing::debug!("stdout consumer closed pipe; stopping writes");
+                    return Ok(written_this_call);
+                }
+                Err(e) => return Err(FaucetError::Sink(format!("write failed: {e}"))),
+            }
+            if self.config.flush_per_record {
+                state
+                    .writer
+                    .flush()
+                    .await
+                    .map_err(|e| FaucetError::Sink(format!("flush failed: {e}")))?;
+            }
+            state.written += 1;
+            written_this_call += 1;
+        }
+        Ok(written_this_call)
+    }
+
+    async fn flush(&self) -> Result<(), FaucetError> {
+        let mut state = self.state.lock().await;
+        state
+            .writer
+            .flush()
+            .await
+            .map_err(|e| FaucetError::Sink(format!("flush failed: {e}")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use faucet_core::Sink;
+    use serde_json::json;
+    use std::pin::Pin;
+    use std::sync::Arc;
+    use std::sync::Mutex as StdMutex;
+    use std::task::{Context, Poll};
+    use tokio::io::AsyncWrite;
+
+    /// In-memory async writer that records bytes for assertions and can
+    /// optionally simulate a broken-pipe error after a fixed number of writes.
+    #[derive(Clone, Default)]
+    struct CaptureWriter {
+        inner: Arc<StdMutex<CaptureInner>>,
+    }
+
+    #[derive(Default)]
+    struct CaptureInner {
+        bytes: Vec<u8>,
+        flushes: usize,
+        fail_after: Option<usize>,
+        writes: usize,
+    }
+
+    impl CaptureWriter {
+        fn fail_after(n: usize) -> Self {
+            let me = Self::default();
+            me.inner.lock().unwrap().fail_after = Some(n);
+            me
+        }
+        fn captured(&self) -> Vec<u8> {
+            self.inner.lock().unwrap().bytes.clone()
+        }
+        fn flushes(&self) -> usize {
+            self.inner.lock().unwrap().flushes
+        }
+        fn as_str(&self) -> String {
+            String::from_utf8(self.captured()).unwrap()
+        }
+    }
+
+    impl AsyncWrite for CaptureWriter {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            let mut inner = self.inner.lock().unwrap();
+            inner.writes += 1;
+            if let Some(fail_after) = inner.fail_after
+                && inner.writes > fail_after
+            {
+                return Poll::Ready(Err(io::Error::from(io::ErrorKind::BrokenPipe)));
+            }
+            inner.bytes.extend_from_slice(buf);
+            Poll::Ready(Ok(buf.len()))
+        }
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            self.inner.lock().unwrap().flushes += 1;
+            Poll::Ready(Ok(()))
+        }
+        fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    fn sink_with(config: StdoutSinkConfig) -> (StdoutSink, CaptureWriter) {
+        let writer = CaptureWriter::default();
+        let sink = StdoutSink::with_writer(config, Box::new(writer.clone()));
+        (sink, writer)
+    }
+
+    #[tokio::test]
+    async fn json_lines_emits_one_record_per_line() {
+        let (sink, capture) = sink_with(StdoutSinkConfig::new());
+        let records = vec![json!({"id": 1}), json!({"id": 2})];
+        let n = sink.write_batch(&records).await.unwrap();
+        assert_eq!(n, 2);
+        let out = capture.as_str();
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(lines.len(), 2);
+        assert_eq!(
+            serde_json::from_str::<Value>(lines[0]).unwrap(),
+            json!({"id": 1})
+        );
+        assert_eq!(
+            serde_json::from_str::<Value>(lines[1]).unwrap(),
+            json!({"id": 2})
+        );
+    }
+
+    #[tokio::test]
+    async fn pretty_json_indents_and_separates_records() {
+        let (sink, capture) = sink_with(StdoutSinkConfig::new().format(StdoutFormat::PrettyJson));
+        sink.write_batch(&[json!({"id": 1, "nested": {"k": "v"}})])
+            .await
+            .unwrap();
+        let out = capture.as_str();
+        assert!(out.contains("  \"id\": 1"));
+        assert!(out.contains("  \"nested\": {"));
+        assert!(out.ends_with('\n'));
+    }
+
+    #[tokio::test]
+    async fn tsv_emits_keys_sorted_with_tab_separators() {
+        let (sink, capture) = sink_with(StdoutSinkConfig::new().format(StdoutFormat::Tsv));
+        sink.write_batch(&[json!({"name": "alice", "id": 7, "tags": ["a","b"], "active": true})])
+            .await
+            .unwrap();
+        let out = capture.as_str();
+        let line = out.lines().next().unwrap();
+        let cells: Vec<&str> = line.split('\t').collect();
+        // sorted: active, id, name, tags
+        assert_eq!(cells, vec!["true", "7", "alice", r#"["a","b"]"#]);
+    }
+
+    #[tokio::test]
+    async fn tsv_replaces_tabs_and_newlines_in_string_values() {
+        let (sink, capture) = sink_with(StdoutSinkConfig::new().format(StdoutFormat::Tsv));
+        sink.write_batch(&[json!({"a": "tab\there\nand-newline"})])
+            .await
+            .unwrap();
+        let out = capture.as_str();
+        let line = out.lines().next().unwrap();
+        assert_eq!(line, "tab here and-newline");
+    }
+
+    #[tokio::test]
+    async fn tsv_rejects_non_object_records() {
+        let (sink, _capture) = sink_with(StdoutSinkConfig::new().format(StdoutFormat::Tsv));
+        let result = sink.write_batch(&[json!([1, 2, 3])]).await;
+        assert!(matches!(result, Err(FaucetError::Sink(_))));
+    }
+
+    #[tokio::test]
+    async fn empty_batch_returns_zero() {
+        let (sink, _capture) = sink_with(StdoutSinkConfig::new());
+        let n = sink.write_batch(&[]).await.unwrap();
+        assert_eq!(n, 0);
+    }
+
+    #[tokio::test]
+    async fn max_records_caps_output() {
+        let (sink, capture) = sink_with(StdoutSinkConfig::new().max_records(2));
+        let n = sink
+            .write_batch(&[json!({"id": 1}), json!({"id": 2}), json!({"id": 3})])
+            .await
+            .unwrap();
+        assert_eq!(n, 2);
+        assert_eq!(capture.as_str().lines().count(), 2);
+        // Subsequent calls become no-ops.
+        let n2 = sink.write_batch(&[json!({"id": 4})]).await.unwrap();
+        assert_eq!(n2, 0);
+        assert_eq!(capture.as_str().lines().count(), 2);
+    }
+
+    #[tokio::test]
+    async fn flush_per_record_flushes_after_each() {
+        let (sink, capture) = sink_with(StdoutSinkConfig::new().flush_per_record(true));
+        sink.write_batch(&[json!({"id": 1}), json!({"id": 2})])
+            .await
+            .unwrap();
+        assert_eq!(capture.flushes(), 2);
+    }
+
+    #[tokio::test]
+    async fn batch_boundary_flush_only_on_explicit_flush() {
+        let (sink, capture) = sink_with(StdoutSinkConfig::new());
+        sink.write_batch(&[json!({"id": 1})]).await.unwrap();
+        assert_eq!(capture.flushes(), 0);
+        sink.flush().await.unwrap();
+        assert_eq!(capture.flushes(), 1);
+    }
+
+    #[tokio::test]
+    async fn broken_pipe_is_treated_as_clean_termination() {
+        // Writer accepts 1 write then errors with BrokenPipe.
+        let capture = CaptureWriter::fail_after(1);
+        let sink = StdoutSink::with_writer(StdoutSinkConfig::new(), Box::new(capture.clone()));
+        let n = sink
+            .write_batch(&[json!({"id": 1}), json!({"id": 2}), json!({"id": 3})])
+            .await
+            .unwrap();
+        assert_eq!(n, 1);
+        // Further writes are no-ops because the sink is now marked closed.
+        let n2 = sink.write_batch(&[json!({"id": 4})]).await.unwrap();
+        assert_eq!(n2, 0);
+    }
+
+    #[tokio::test]
+    async fn as_trait_object() {
+        let capture = CaptureWriter::default();
+        let sink: Box<dyn Sink> = Box::new(StdoutSink::with_writer(
+            StdoutSinkConfig::new(),
+            Box::new(capture.clone()),
+        ));
+        let n = sink.write_batch(&[json!({"id": 1})]).await.unwrap();
+        assert_eq!(n, 1);
+        assert!(capture.as_str().contains("\"id\":1"));
+    }
+
+    #[tokio::test]
+    async fn config_schema_is_well_formed_object() {
+        let sink = StdoutSink::new(StdoutSinkConfig::new());
+        let schema = sink.config_schema();
+        assert_eq!(schema["type"], "object");
+        assert!(schema["properties"].is_object());
+    }
+}

--- a/crates/source/rest/Cargo.toml
+++ b/crates/source/rest/Cargo.toml
@@ -35,3 +35,5 @@ wiremock = "0.6"
 tracing-subscriber = "0.3"
 futures.workspace = true
 serde = { version = "1", features = ["derive"] }
+tempfile = "3"
+async-trait.workspace = true

--- a/crates/source/rest/src/config.rs
+++ b/crates/source/rest/src/config.rs
@@ -58,6 +58,13 @@ pub struct RestStreamConfig {
     /// Bookmark value: records where `record[replication_key] <= start_replication_value`
     /// are filtered out when `replication_method` is `Incremental`.
     pub start_replication_value: Option<Value>,
+    /// Opt-in identifier used by [`Pipeline::with_state_store`](faucet_core::Pipeline::with_state_store)
+    /// to persist this stream's bookmark across runs. When set, the pipeline
+    /// will load any previously-stored bookmark before fetching and write the
+    /// new bookmark only after the sink confirms the batch.
+    ///
+    /// Keys must satisfy [`faucet_core::state::validate_state_key`].
+    pub state_key: Option<String>,
 
     // ── Singer / Meltano metadata ─────────────────────────────────────────────
     /// Human-readable stream name (used in logging and Singer SCHEMA messages).
@@ -108,6 +115,7 @@ impl Default for RestStreamConfig {
             replication_method: ReplicationMethod::FullTable,
             replication_key: None,
             start_replication_value: None,
+            state_key: None,
             name: None,
             primary_keys: Vec::new(),
             schema: None,
@@ -220,6 +228,15 @@ impl RestStreamConfig {
     /// when using `ReplicationMethod::Incremental`.
     pub fn start_replication_value(mut self, v: Value) -> Self {
         self.start_replication_value = Some(v);
+        self
+    }
+
+    /// Opt the stream into resumable runs by giving it a stable state key.
+    /// When this is set and the [`Pipeline`](faucet_core::Pipeline) is
+    /// configured with a state store, the previously persisted bookmark is
+    /// applied to the stream before fetching.
+    pub fn state_key(mut self, key: &str) -> Self {
+        self.state_key = Some(key.into());
         self
     }
 

--- a/crates/source/rest/src/stream.rs
+++ b/crates/source/rest/src/stream.rs
@@ -19,7 +19,9 @@ use serde::Deserialize;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::pin::Pin;
+use std::sync::Arc;
 use std::time::Duration;
+use tokio::sync::Mutex as AsyncMutex;
 
 /// A configured REST API stream that handles pagination, auth, and extraction.
 pub struct RestStream {
@@ -31,6 +33,10 @@ pub struct RestStream {
     token_cache: TokenCache,
     /// Shared token endpoint cache (only used when `config.auth` is `Auth::TokenEndpoint`).
     token_endpoint_cache: TokenEndpointCache,
+    /// Bookmark applied at runtime via
+    /// [`Source::apply_start_bookmark`](faucet_core::Source::apply_start_bookmark).
+    /// Takes precedence over `config.start_replication_value` when set.
+    runtime_start: Arc<AsyncMutex<Option<Value>>>,
 }
 
 impl RestStream {
@@ -71,6 +77,7 @@ impl RestStream {
             compiled_transforms,
             token_cache: TokenCache::new(),
             token_endpoint_cache: TokenEndpointCache::new(),
+            runtime_start: Arc::new(AsyncMutex::new(None)),
         })
     }
 
@@ -210,6 +217,17 @@ impl RestStream {
         let owned_context: Option<HashMap<String, Value>> = context.cloned();
 
         Box::pin(async_stream::try_stream! {
+            // Resolve the effective start-bookmark once at the top of the stream.
+            // A runtime override (applied via `Source::apply_start_bookmark` —
+            // typically by the pipeline reading from a `StateStore`) takes
+            // precedence over the static config value.
+            let effective_start: Option<Value> = {
+                let guard = self.runtime_start.lock().await;
+                guard
+                    .clone()
+                    .or_else(|| self.config.start_replication_value.clone())
+            };
+
             let mut state = PaginationState::default();
             let mut pages_fetched = 0usize;
 
@@ -246,10 +264,9 @@ impl RestStream {
 
                 let records =
                     if self.config.replication_method == ReplicationMethod::Incremental {
-                        if let (Some(key), Some(start)) = (
-                            &self.config.replication_key,
-                            &self.config.start_replication_value,
-                        ) {
+                        if let (Some(key), Some(start)) =
+                            (&self.config.replication_key, effective_start.as_ref())
+                        {
                             filter_incremental(raw_records, key, start)
                         } else {
                             raw_records
@@ -543,6 +560,15 @@ impl faucet_core::Source for RestStream {
     fn config_schema(&self) -> serde_json::Value {
         serde_json::to_value(faucet_core::schema_for!(RestStreamConfig))
             .expect("schema serialization")
+    }
+
+    fn state_key(&self) -> Option<String> {
+        self.config.state_key.clone()
+    }
+
+    async fn apply_start_bookmark(&self, bookmark: Value) -> Result<(), FaucetError> {
+        *self.runtime_start.lock().await = Some(bookmark);
+        Ok(())
     }
 }
 

--- a/crates/source/rest/tests/state_resume_test.rs
+++ b/crates/source/rest/tests/state_resume_test.rs
@@ -1,0 +1,210 @@
+//! End-to-end resumable-replication test for `RestStream`.
+//!
+//! Proves the full state-store loop: a first run fetches all records and
+//! persists the maximum bookmark; a second run with the same `state_key`
+//! pulls the bookmark out of the store, calls `apply_start_bookmark` on the
+//! REST source, and the source filters out everything at or below it —
+//! emitting only the newer records and advancing the bookmark.
+
+use async_trait::async_trait;
+use faucet_core::state::{FileStateStore, StateStore};
+use faucet_core::{FaucetError, Pipeline, ReplicationMethod, Sink, Source, Value};
+use faucet_source_rest::{PaginationStyle, RestStream, RestStreamConfig};
+use serde_json::json;
+use std::sync::{Arc, Mutex};
+use tempfile::TempDir;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// In-memory sink that records every batch it sees so the test can inspect
+/// exactly which records made it past the source's incremental filter.
+#[derive(Default)]
+struct RecordingSink {
+    received: Mutex<Vec<Value>>,
+}
+
+impl RecordingSink {
+    fn new() -> Self {
+        Self::default()
+    }
+    fn snapshot(&self) -> Vec<Value> {
+        self.received.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl Sink for RecordingSink {
+    async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
+        self.received
+            .lock()
+            .unwrap()
+            .extend(records.iter().cloned());
+        Ok(records.len())
+    }
+}
+
+fn rest_config(server_uri: &str) -> RestStreamConfig {
+    RestStreamConfig::new(server_uri, "/api/events")
+        .records_path("$.items[*]")
+        .pagination(PaginationStyle::None)
+        .replication_method(ReplicationMethod::Incremental)
+        .replication_key("updated_at")
+        .state_key("rest_events_stream")
+}
+
+#[tokio::test]
+async fn rest_source_resumes_from_file_state_store_across_runs() {
+    let server = MockServer::start().await;
+
+    // ── Run 1: server returns three records, none filtered. ─────────────────
+    let initial_payload = json!({
+        "items": [
+            {"id": 1, "updated_at": "2026-01-01"},
+            {"id": 2, "updated_at": "2026-02-01"},
+            {"id": 3, "updated_at": "2026-03-01"},
+        ]
+    });
+    let initial_mock = Mock::given(method("GET"))
+        .and(path("/api/events"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(initial_payload))
+        .expect(1)
+        .mount_as_scoped(&server)
+        .await;
+
+    let state_dir = TempDir::new().unwrap();
+    let store: Arc<dyn StateStore> = Arc::new(FileStateStore::new(state_dir.path()));
+
+    let source1 = RestStream::new(rest_config(&server.uri())).unwrap();
+    let sink1 = RecordingSink::new();
+    let result1 = Pipeline::new(&source1, &sink1)
+        .with_state_store(Arc::clone(&store))
+        .run()
+        .await
+        .unwrap();
+    drop(initial_mock);
+
+    assert_eq!(result1.records_written, 3, "first run sees all records");
+    assert_eq!(result1.bookmark, Some(json!("2026-03-01")));
+    assert_eq!(
+        store.get("rest_events_stream").await.unwrap(),
+        Some(json!("2026-03-01")),
+        "bookmark persisted to the file state store"
+    );
+    let r1 = sink1.snapshot();
+    assert_eq!(r1.len(), 3);
+    assert_eq!(r1[0]["id"], 1);
+    assert_eq!(r1[2]["id"], 3);
+
+    // ── Run 2: server returns all four records (the original three plus a
+    // newer one). The stored bookmark should filter the original three back
+    // out so only the new record reaches the sink, and the bookmark advances.
+    let resumed_payload = json!({
+        "items": [
+            {"id": 1, "updated_at": "2026-01-01"},
+            {"id": 2, "updated_at": "2026-02-01"},
+            {"id": 3, "updated_at": "2026-03-01"},
+            {"id": 4, "updated_at": "2026-04-01"},
+        ]
+    });
+    Mock::given(method("GET"))
+        .and(path("/api/events"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(resumed_payload))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let source2 = RestStream::new(rest_config(&server.uri())).unwrap();
+    let sink2 = RecordingSink::new();
+    let result2 = Pipeline::new(&source2, &sink2)
+        .with_state_store(Arc::clone(&store))
+        .run()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        result2.records_written, 1,
+        "only the new record passes the incremental filter"
+    );
+    assert_eq!(result2.bookmark, Some(json!("2026-04-01")));
+    assert_eq!(
+        store.get("rest_events_stream").await.unwrap(),
+        Some(json!("2026-04-01")),
+        "bookmark advances to the new max"
+    );
+    let r2 = sink2.snapshot();
+    assert_eq!(r2.len(), 1);
+    assert_eq!(r2[0]["id"], 4);
+    assert_eq!(r2[0]["updated_at"], "2026-04-01");
+}
+
+#[tokio::test]
+async fn rest_source_with_state_store_but_no_stored_bookmark_emits_all_records() {
+    // First-run-ever scenario: state store exists but has no entry yet. The
+    // source must behave exactly like a non-incremental run and persist the
+    // bookmark for next time.
+    let server = MockServer::start().await;
+    let payload = json!({
+        "items": [
+            {"id": 10, "updated_at": "2026-05-01"},
+            {"id": 11, "updated_at": "2026-06-01"},
+        ]
+    });
+    Mock::given(method("GET"))
+        .and(path("/api/events"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(payload))
+        .mount(&server)
+        .await;
+
+    let state_dir = TempDir::new().unwrap();
+    let store: Arc<dyn StateStore> = Arc::new(FileStateStore::new(state_dir.path()));
+    assert!(store.get("rest_events_stream").await.unwrap().is_none());
+
+    let source = RestStream::new(rest_config(&server.uri())).unwrap();
+    let sink = RecordingSink::new();
+    let result = Pipeline::new(&source, &sink)
+        .with_state_store(Arc::clone(&store))
+        .run()
+        .await
+        .unwrap();
+
+    assert_eq!(result.records_written, 2);
+    assert_eq!(
+        store.get("rest_events_stream").await.unwrap(),
+        Some(json!("2026-06-01"))
+    );
+}
+
+#[tokio::test]
+async fn rest_source_apply_start_bookmark_overrides_config_value() {
+    // Direct unit test of the override semantics: if both the static config
+    // value and a runtime bookmark are present, the runtime value wins.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/events"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "items": [
+                {"id": 1, "updated_at": "2026-01-01"},
+                {"id": 2, "updated_at": "2026-02-01"},
+                {"id": 3, "updated_at": "2026-03-01"},
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let config = rest_config(&server.uri()).start_replication_value(json!("2026-01-01"));
+    let source = RestStream::new(config).unwrap();
+
+    // With only the static config value, two records (Feb + Mar) pass.
+    let (records, _) = source.fetch_all_incremental().await.unwrap();
+    assert_eq!(records.len(), 2);
+
+    // After applying a stricter runtime bookmark, only March passes.
+    source
+        .apply_start_bookmark(json!("2026-02-01"))
+        .await
+        .unwrap();
+    let (records, bookmark) = source.fetch_all_incremental().await.unwrap();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0]["id"], 3);
+    assert_eq!(bookmark, Some(json!("2026-03-01")));
+}

--- a/crates/state/postgres/Cargo.toml
+++ b/crates/state/postgres/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "faucet-state-postgres"
+version = "0.2.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "PostgreSQL-backed StateStore for faucet-stream incremental replication"
+
+[dependencies]
+faucet-core.workspace = true
+async-trait.workspace = true
+serde_json.workspace = true
+tracing.workspace = true
+sqlx.workspace = true
+tokio = { workspace = true, features = ["sync"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/state/postgres/README.md
+++ b/crates/state/postgres/README.md
@@ -1,0 +1,67 @@
+# faucet-state-postgres
+
+PostgreSQL-backed [`StateStore`](https://docs.rs/faucet-core/latest/faucet_core/state/trait.StateStore.html) for the [faucet-stream](https://crates.io/crates/faucet-stream) ecosystem. Persists incremental-replication bookmarks across pipeline runs in a single JSONB-backed table, so sources can resume exactly where they left off after a crash, restart, or scheduled invocation.
+
+## Install
+
+```toml
+[dependencies]
+faucet-core = "0.2"
+faucet-state-postgres = "0.2"
+```
+
+## Usage
+
+```rust,no_run
+use std::sync::Arc;
+use faucet_core::{Pipeline, state::StateStore};
+use faucet_state_postgres::PostgresStateStore;
+
+# async fn run(source: impl faucet_core::Source, sink: impl faucet_core::Sink) -> Result<(), faucet_core::FaucetError> {
+let store = PostgresStateStore::connect("postgres://user:pass@localhost/faucet").await?;
+store.ensure_table().await?;
+let store: Arc<dyn StateStore> = Arc::new(store);
+
+Pipeline::new(&source, &sink)
+    .with_state_store(store)
+    .run()
+    .await?;
+# Ok(())
+# }
+```
+
+## Storage layout
+
+```sql
+CREATE TABLE faucet_state (
+    key        TEXT        PRIMARY KEY,
+    value      JSONB       NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+
+`ensure_table()` runs the `CREATE TABLE IF NOT EXISTS` for you. If you manage schema separately, skip it.
+
+## Operations
+
+- `get(key)` — `SELECT value FROM <table> WHERE key = $1`. Returns `None` when no row exists.
+- `put(key, value)` — `INSERT ... ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = NOW()`.
+- `delete(key)` — `DELETE FROM <table> WHERE key = $1`. A missing row is not an error.
+
+The pool is configured via `connect_with(url, max_connections, table)`; the default `connect(url)` uses 5 connections and the `faucet_state` table.
+
+## Configuration
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `max_connections` | `5` | Size of the `sqlx::PgPool`. State writes are cheap; the default is intentionally small. |
+| `table` | `faucet_state` | Override the table name. Validated as a Postgres identifier (letters/digits/underscore, ≤ 63 chars). |
+
+## Validation
+
+- State keys are validated by [`faucet_core::state::validate_state_key`] — ASCII alphanumerics plus `_ - : .`, max 256 characters.
+- Table identifiers are validated against the Postgres rules to keep error messages clear and avoid SQL injection through misconfiguration. Identifiers are also double-quoted via `faucet_core::util::quote_ident`.
+
+## License
+
+Licensed under either of MIT or Apache-2.0 at your option.

--- a/crates/state/postgres/src/lib.rs
+++ b/crates/state/postgres/src/lib.rs
@@ -1,0 +1,10 @@
+//! # faucet-state-postgres
+//!
+//! PostgreSQL-backed [`StateStore`](faucet_core::state::StateStore) for
+//! faucet-stream incremental replication bookmarks. Stores each entry in a
+//! single `faucet_state(key TEXT PRIMARY KEY, value JSONB, updated_at TIMESTAMPTZ)`
+//! table.
+
+pub mod store;
+
+pub use store::PostgresStateStore;

--- a/crates/state/postgres/src/store.rs
+++ b/crates/state/postgres/src/store.rs
@@ -1,0 +1,280 @@
+//! PostgreSQL-backed [`StateStore`].
+
+use async_trait::async_trait;
+use faucet_core::state::{StateStore, validate_state_key};
+use faucet_core::util::quote_ident;
+use faucet_core::{FaucetError, Value};
+use sqlx::postgres::PgPoolOptions;
+use sqlx::{PgPool, Row};
+
+/// Default name for the state-store table. Override via
+/// [`PostgresStateStore::with_table`].
+pub const DEFAULT_TABLE: &str = "faucet_state";
+
+/// A `StateStore` that persists each entry as a row in a single Postgres
+/// table.
+///
+/// The table layout is:
+///
+/// ```sql
+/// CREATE TABLE faucet_state (
+///     key        TEXT        PRIMARY KEY,
+///     value      JSONB       NOT NULL,
+///     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+/// );
+/// ```
+///
+/// Calling [`PostgresStateStore::ensure_table`] creates the table if it does
+/// not exist; integrators that manage schema separately can skip this call.
+pub struct PostgresStateStore {
+    pool: PgPool,
+    table: String,
+}
+
+impl PostgresStateStore {
+    /// Connect to a PostgreSQL server with the default `faucet_state` table.
+    pub async fn connect(connection_url: &str) -> Result<Self, FaucetError> {
+        Self::connect_with(connection_url, 5, DEFAULT_TABLE).await
+    }
+
+    /// Connect with explicit pool size and table name.
+    pub async fn connect_with(
+        connection_url: &str,
+        max_connections: u32,
+        table: &str,
+    ) -> Result<Self, FaucetError> {
+        validate_table_name(table)?;
+        let pool = PgPoolOptions::new()
+            .max_connections(max_connections)
+            .connect(connection_url)
+            .await
+            .map_err(|e| {
+                FaucetError::State(format!("PostgreSQL state-store connection failed: {e}"))
+            })?;
+        Ok(Self {
+            pool,
+            table: table.to_owned(),
+        })
+    }
+
+    /// Construct from an existing pool. Useful when integrators already
+    /// manage a shared `PgPool`.
+    pub fn from_pool(pool: PgPool, table: impl Into<String>) -> Result<Self, FaucetError> {
+        let table = table.into();
+        validate_table_name(&table)?;
+        Ok(Self { pool, table })
+    }
+
+    /// Returns the table name in use.
+    pub fn table(&self) -> &str {
+        &self.table
+    }
+
+    /// Create the state-store table if it does not already exist.
+    pub async fn ensure_table(&self) -> Result<(), FaucetError> {
+        let sql = create_table_sql(&self.table);
+        sqlx::query(&sql).execute(&self.pool).await.map_err(|e| {
+            FaucetError::State(format!("failed to ensure state table {}: {e}", self.table))
+        })?;
+        Ok(())
+    }
+}
+
+/// SQL identifiers in faucet-stream must already be safe for `quote_ident`;
+/// additionally restrict the table name to printable ASCII to keep error
+/// messages readable.
+pub(crate) fn validate_table_name(table: &str) -> Result<(), FaucetError> {
+    if table.is_empty() {
+        return Err(FaucetError::Config(
+            "state-store table name must not be empty".into(),
+        ));
+    }
+    if table.len() > 63 {
+        return Err(FaucetError::Config(format!(
+            "state-store table name '{table}' exceeds Postgres' 63-character identifier limit"
+        )));
+    }
+    for (i, c) in table.char_indices() {
+        let ok = c.is_ascii_alphanumeric() || c == '_';
+        if !ok {
+            return Err(FaucetError::Config(format!(
+                "state-store table name '{table}' contains illegal character {c:?} at byte {i}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn create_table_sql(table: &str) -> String {
+    format!(
+        "CREATE TABLE IF NOT EXISTS {table_ident} (\
+            key TEXT PRIMARY KEY,\
+            value JSONB NOT NULL,\
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()\
+        )",
+        table_ident = quote_ident(table)
+    )
+}
+
+pub(crate) fn select_sql(table: &str) -> String {
+    format!("SELECT value FROM {} WHERE key = $1", quote_ident(table))
+}
+
+pub(crate) fn upsert_sql(table: &str) -> String {
+    format!(
+        "INSERT INTO {tbl} (key, value, updated_at) VALUES ($1, $2, NOW()) \
+         ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = NOW()",
+        tbl = quote_ident(table)
+    )
+}
+
+pub(crate) fn delete_sql(table: &str) -> String {
+    format!("DELETE FROM {} WHERE key = $1", quote_ident(table))
+}
+
+#[async_trait]
+impl StateStore for PostgresStateStore {
+    async fn get(&self, key: &str) -> Result<Option<Value>, FaucetError> {
+        validate_state_key(key)?;
+        let row = sqlx::query(&select_sql(&self.table))
+            .bind(key)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| {
+                FaucetError::State(format!("Postgres SELECT for key '{key}' failed: {e}"))
+            })?;
+        match row {
+            None => Ok(None),
+            Some(r) => {
+                let value: Value = r.try_get(0).map_err(|e| {
+                    FaucetError::State(format!(
+                        "failed to decode JSONB column for key '{key}': {e}"
+                    ))
+                })?;
+                Ok(Some(value))
+            }
+        }
+    }
+
+    async fn put(&self, key: &str, value: &Value) -> Result<(), FaucetError> {
+        validate_state_key(key)?;
+        sqlx::query(&upsert_sql(&self.table))
+            .bind(key)
+            .bind(value)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| {
+                FaucetError::State(format!("Postgres UPSERT for key '{key}' failed: {e}"))
+            })?;
+        tracing::debug!(key, table = %self.table, "state written to Postgres");
+        Ok(())
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), FaucetError> {
+        validate_state_key(key)?;
+        sqlx::query(&delete_sql(&self.table))
+            .bind(key)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| {
+                FaucetError::State(format!("Postgres DELETE for key '{key}' failed: {e}"))
+            })?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_table_name_accepts_typical_values() {
+        for t in [
+            "faucet_state",
+            "FaucetState",
+            "state_v2",
+            "f1",
+            "abcdefghijklmnopqrstuvwxyz_0123456789_FOO",
+        ] {
+            validate_table_name(t).unwrap_or_else(|e| panic!("expected ok for {t:?}: {e}"));
+        }
+    }
+
+    #[test]
+    fn validate_table_name_rejects_empty() {
+        let err = validate_table_name("").unwrap_err();
+        assert!(matches!(err, FaucetError::Config(_)));
+    }
+
+    #[test]
+    fn validate_table_name_rejects_illegal_chars() {
+        for t in [
+            "table-name",
+            "schema.table",
+            "drop table users;--",
+            "spaces in name",
+        ] {
+            let err = validate_table_name(t).expect_err(&format!("expected error for {t:?}"));
+            assert!(matches!(err, FaucetError::Config(_)));
+        }
+    }
+
+    #[test]
+    fn validate_table_name_rejects_over_long() {
+        let t = "a".repeat(64);
+        assert!(validate_table_name(&t).is_err());
+    }
+
+    #[test]
+    fn create_table_sql_quotes_identifier() {
+        let sql = create_table_sql("faucet_state");
+        assert!(sql.contains("\"faucet_state\""));
+        assert!(sql.contains("CREATE TABLE IF NOT EXISTS"));
+        assert!(sql.contains("PRIMARY KEY"));
+        assert!(sql.contains("JSONB"));
+    }
+
+    #[test]
+    fn create_table_sql_escapes_embedded_quote() {
+        // quote_ident escapes embedded quotes by doubling — verify the
+        // identifier remains a single quoted token.
+        let sql = create_table_sql("ab\"c");
+        // The opening quote, doubled inner quote, closing quote — should
+        // appear in the output regardless of whether the table-name
+        // validator would normally allow it.
+        assert!(sql.contains("\"ab\"\"c\""));
+    }
+
+    #[test]
+    fn select_sql_uses_parameter_marker() {
+        let sql = select_sql("faucet_state");
+        assert_eq!(sql, "SELECT value FROM \"faucet_state\" WHERE key = $1");
+    }
+
+    #[test]
+    fn upsert_sql_uses_on_conflict_do_update() {
+        let sql = upsert_sql("faucet_state");
+        assert!(sql.contains("INSERT INTO \"faucet_state\""));
+        assert!(sql.contains("ON CONFLICT (key) DO UPDATE"));
+        assert!(sql.contains("value = EXCLUDED.value"));
+        assert!(sql.contains("updated_at = NOW()"));
+    }
+
+    #[test]
+    fn delete_sql_uses_parameter_marker() {
+        let sql = delete_sql("faucet_state");
+        assert_eq!(sql, "DELETE FROM \"faucet_state\" WHERE key = $1");
+    }
+
+    #[tokio::test]
+    async fn connect_rejects_invalid_table_name() {
+        let result =
+            PostgresStateStore::connect_with("postgres://localhost/does_not_matter", 5, "bad-name")
+                .await;
+        match result {
+            Err(FaucetError::Config(_)) => {}
+            Err(other) => panic!("expected Config error, got {other:?}"),
+            Ok(_) => panic!("expected error, got Ok"),
+        }
+    }
+}

--- a/crates/state/redis/Cargo.toml
+++ b/crates/state/redis/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "faucet-state-redis"
+version = "0.2.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Redis-backed StateStore for faucet-stream incremental replication"
+
+[dependencies]
+faucet-core.workspace = true
+async-trait.workspace = true
+serde_json.workspace = true
+tracing.workspace = true
+redis.workspace = true
+tokio = { workspace = true, features = ["sync"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/state/redis/README.md
+++ b/crates/state/redis/README.md
@@ -1,0 +1,57 @@
+# faucet-state-redis
+
+Redis-backed [`StateStore`](https://docs.rs/faucet-core/latest/faucet_core/state/trait.StateStore.html) for the [faucet-stream](https://crates.io/crates/faucet-stream) ecosystem. Persists incremental-replication bookmarks across pipeline runs so a source can resume exactly where it left off after a crash, restart, or scheduled invocation.
+
+## Install
+
+```toml
+[dependencies]
+faucet-core = "0.2"
+faucet-state-redis = "0.2"
+```
+
+## Usage
+
+```rust,no_run
+use std::sync::Arc;
+use faucet_core::{Pipeline, state::StateStore};
+use faucet_state_redis::RedisStateStore;
+
+# async fn run(source: impl faucet_core::Source, sink: impl faucet_core::Sink) -> Result<(), faucet_core::FaucetError> {
+let store: Arc<dyn StateStore> = Arc::new(
+    RedisStateStore::connect("redis://127.0.0.1:6379", "faucet").await?,
+);
+
+Pipeline::new(&source, &sink)
+    .with_state_store(store)
+    .run()
+    .await?;
+# Ok(())
+# }
+```
+
+## Storage layout
+
+Each entry is a single Redis string:
+
+| Redis key | Value |
+|-----------|-------|
+| `{namespace}:{state_key}` | UTF-8 JSON serialization of the bookmark value. |
+
+The namespace is configured once in `connect()` and prefixed onto every key. Use it to keep multiple pipelines isolated within a shared Redis instance (e.g. `prod:`, `staging:`, `team-a:`).
+
+## Operations
+
+- `get(key)` — `GET {namespace}:{key}` → parse JSON, return `None` if the key is missing.
+- `put(key, value)` — `SET {namespace}:{key} <serialized>`.
+- `delete(key)` — `DEL {namespace}:{key}` (a missing key is not an error).
+
+Connections use `redis::aio::MultiplexedConnection`, which is cheaply cloneable and safe to share across tasks.
+
+## Key validation
+
+State keys are validated by [`faucet_core::state::validate_state_key`] — ASCII alphanumerics plus `_ - : .`, max 256 characters, no leading dot. Namespaces additionally disallow `:` (since the namespace itself becomes a key prefix).
+
+## License
+
+Licensed under either of MIT or Apache-2.0 at your option.

--- a/crates/state/redis/src/lib.rs
+++ b/crates/state/redis/src/lib.rs
@@ -1,0 +1,9 @@
+//! # faucet-state-redis
+//!
+//! Redis-backed [`StateStore`](faucet_core::state::StateStore) for faucet-stream
+//! incremental replication bookmarks. Stores each entry as a single Redis
+//! string under `{namespace}:{key}` containing a serialized JSON value.
+
+pub mod store;
+
+pub use store::RedisStateStore;

--- a/crates/state/redis/src/store.rs
+++ b/crates/state/redis/src/store.rs
@@ -1,0 +1,178 @@
+//! Redis-backed [`StateStore`].
+
+use async_trait::async_trait;
+use faucet_core::state::{StateStore, validate_state_key};
+use faucet_core::{FaucetError, Value};
+use redis::AsyncCommands;
+
+/// A `StateStore` that persists each entry as a single Redis string under
+/// `{namespace}:{key}`.
+///
+/// The connection is opened in [`RedisStateStore::connect`] and reused across
+/// all calls — `redis::aio::MultiplexedConnection` is cheaply cloneable.
+pub struct RedisStateStore {
+    namespace: String,
+    conn: redis::aio::MultiplexedConnection,
+}
+
+impl RedisStateStore {
+    /// Connect to a Redis server and namespace all keys under `namespace:`.
+    ///
+    /// `url` follows the standard Redis URL form (`redis://[:pass@]host:port/db`).
+    pub async fn connect(
+        url: impl AsRef<str>,
+        namespace: impl Into<String>,
+    ) -> Result<Self, FaucetError> {
+        let namespace = namespace.into();
+        validate_namespace(&namespace)?;
+        let client = redis::Client::open(url.as_ref())
+            .map_err(|e| FaucetError::Config(format!("invalid Redis URL: {e}")))?;
+        let conn = client
+            .get_multiplexed_async_connection()
+            .await
+            .map_err(|e| FaucetError::State(format!("Redis connection failed: {e}")))?;
+        Ok(Self { namespace, conn })
+    }
+
+    /// Construct from an existing async connection. Useful for tests and for
+    /// integrators who want to share a connection across multiple stores.
+    pub fn from_connection(
+        conn: redis::aio::MultiplexedConnection,
+        namespace: impl Into<String>,
+    ) -> Result<Self, FaucetError> {
+        let namespace = namespace.into();
+        validate_namespace(&namespace)?;
+        Ok(Self { namespace, conn })
+    }
+
+    /// Returns the fully-qualified Redis key for a given state key.
+    pub fn redis_key(&self, key: &str) -> String {
+        build_redis_key(&self.namespace, key)
+    }
+}
+
+/// Format the namespaced Redis key. Exposed as a free function so it can be
+/// unit-tested without constructing a `RedisStateStore` (which needs a real
+/// Redis connection).
+pub(crate) fn build_redis_key(namespace: &str, key: &str) -> String {
+    format!("{namespace}:{key}")
+}
+
+pub(crate) fn validate_namespace(namespace: &str) -> Result<(), FaucetError> {
+    if namespace.is_empty() {
+        return Err(FaucetError::Config(
+            "Redis state namespace must not be empty".into(),
+        ));
+    }
+    for (i, c) in namespace.char_indices() {
+        let ok = c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.');
+        if !ok {
+            return Err(FaucetError::Config(format!(
+                "Redis state namespace contains illegal character {c:?} at byte {i}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+#[async_trait]
+impl StateStore for RedisStateStore {
+    async fn get(&self, key: &str) -> Result<Option<Value>, FaucetError> {
+        validate_state_key(key)?;
+        let mut conn = self.conn.clone();
+        let raw: Option<String> = conn
+            .get(self.redis_key(key))
+            .await
+            .map_err(|e| FaucetError::State(format!("Redis GET for key '{key}' failed: {e}")))?;
+        match raw {
+            None => Ok(None),
+            Some(s) => {
+                let value: Value = serde_json::from_str(&s).map_err(|e| {
+                    FaucetError::State(format!(
+                        "stored value for key '{key}' is not valid JSON: {e}"
+                    ))
+                })?;
+                Ok(Some(value))
+            }
+        }
+    }
+
+    async fn put(&self, key: &str, value: &Value) -> Result<(), FaucetError> {
+        validate_state_key(key)?;
+        let serialized = serde_json::to_string(value).map_err(|e| {
+            FaucetError::State(format!("failed to serialize state for key '{key}': {e}"))
+        })?;
+        let mut conn = self.conn.clone();
+        let _: () = conn
+            .set(self.redis_key(key), serialized)
+            .await
+            .map_err(|e| FaucetError::State(format!("Redis SET for key '{key}' failed: {e}")))?;
+        tracing::debug!(key, namespace = %self.namespace, "state written to Redis");
+        Ok(())
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), FaucetError> {
+        validate_state_key(key)?;
+        let mut conn = self.conn.clone();
+        let _: i64 = conn
+            .del(self.redis_key(key))
+            .await
+            .map_err(|e| FaucetError::State(format!("Redis DEL for key '{key}' failed: {e}")))?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_redis_key_namespaces_consistently() {
+        assert_eq!(
+            build_redis_key("faucet", "github_issues"),
+            "faucet:github_issues"
+        );
+        assert_eq!(build_redis_key("a", "b"), "a:b");
+    }
+
+    #[test]
+    fn validate_namespace_accepts_typical_values() {
+        for ns in ["faucet", "team-1.prod", "a_b", "ABC.123"] {
+            validate_namespace(ns).unwrap_or_else(|e| panic!("expected ok for {ns:?}: {e}"));
+        }
+    }
+
+    #[test]
+    fn validate_namespace_rejects_empty() {
+        let err = validate_namespace("").unwrap_err();
+        assert!(matches!(err, FaucetError::Config(_)));
+    }
+
+    #[test]
+    fn validate_namespace_rejects_illegal_chars() {
+        for ns in ["a:b", "a/b", "a b", "hello world"] {
+            let err = validate_namespace(ns).expect_err(&format!("expected error for {ns:?}"));
+            assert!(matches!(err, FaucetError::Config(_)));
+        }
+    }
+
+    #[tokio::test]
+    async fn connect_rejects_invalid_url() {
+        let result = RedisStateStore::connect("not a url", "faucet").await;
+        match result {
+            Err(FaucetError::Config(msg)) => assert!(msg.contains("invalid Redis URL")),
+            Err(other) => panic!("expected Config error, got {other:?}"),
+            Ok(_) => panic!("expected error, got Ok"),
+        }
+    }
+
+    #[tokio::test]
+    async fn connect_rejects_invalid_namespace() {
+        let result = RedisStateStore::connect("redis://127.0.0.1:6379", "bad:namespace").await;
+        match result {
+            Err(FaucetError::Config(_)) => {}
+            Err(other) => panic!("expected Config error, got {other:?}"),
+            Ok(_) => panic!("expected error, got Ok"),
+        }
+    }
+}

--- a/faucet-stream/Cargo.toml
+++ b/faucet-stream/Cargo.toml
@@ -44,9 +44,15 @@ sink = [
     "sink-csv",
     "sink-elasticsearch",
     "sink-http",
+    "sink-stdout",
 ]
-## Every connector.
-full = ["source", "sink"]
+## All state-store backends (file backend is exposed via `faucet-core` directly).
+state = [
+    "state-redis",
+    "state-postgres",
+]
+## Every connector and state backend.
+full = ["source", "sink", "state"]
 
 ## Individual source connectors.
 source-rest = ["dep:faucet-source-rest"]
@@ -77,6 +83,11 @@ sink-redis = ["dep:faucet-sink-redis"]
 sink-csv = ["dep:faucet-sink-csv"]
 sink-elasticsearch = ["dep:faucet-sink-elasticsearch"]
 sink-http = ["dep:faucet-sink-http"]
+sink-stdout = ["dep:faucet-sink-stdout"]
+
+## Individual state-store backends.
+state-redis = ["dep:faucet-state-redis"]
+state-postgres = ["dep:faucet-state-postgres"]
 
 ## Transform features (forwarded to source-rest when enabled).
 transform-flatten = ["faucet-source-rest?/transform-flatten"]
@@ -112,6 +123,10 @@ faucet-sink-redis = { workspace = true, optional = true }
 faucet-sink-csv = { workspace = true, optional = true }
 faucet-sink-elasticsearch = { workspace = true, optional = true }
 faucet-sink-http = { workspace = true, optional = true }
+faucet-sink-stdout = { workspace = true, optional = true }
+
+faucet-state-redis = { workspace = true, optional = true }
+faucet-state-postgres = { workspace = true, optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/faucet-stream/src/lib.rs
+++ b/faucet-stream/src/lib.rs
@@ -244,4 +244,23 @@ pub mod sink {
     pub mod http {
         pub use faucet_sink_http::*;
     }
+
+    #[cfg(feature = "sink-stdout")]
+    pub mod stdout {
+        pub use faucet_sink_stdout::*;
+    }
+}
+
+// ── State-store backends ─────────────────────────────────────────────────────
+
+pub mod state {
+    #[cfg(feature = "state-redis")]
+    pub mod redis {
+        pub use faucet_state_redis::*;
+    }
+
+    #[cfg(feature = "state-postgres")]
+    pub mod postgres {
+        pub use faucet_state_postgres::*;
+    }
 }


### PR DESCRIPTION
## Summary

Closes #25.
Closes #35.

Lands two of the tier-1 building blocks for the upcoming config-driven CLI ([#37](https://github.com/PawanSikawat/faucet-stream/issues/37)) and for production deployments that need resumable runs:

- **[#35](https://github.com/PawanSikawat/faucet-stream/issues/35) stdout/stderr sink** — `faucet-sink-stdout` with JSON Lines, pretty JSON, and TSV formats.
- **[#25](https://github.com/PawanSikawat/faucet-stream/issues/25) pluggable state store** — `StateStore` trait in `faucet-core` plus three implementations (`FileStateStore`, `RedisStateStore`, `PostgresStateStore`). `Pipeline::with_state_store` reads the bookmark before fetch and persists the new one only after the sink confirms the batch.

Tracking epic: [#38](https://github.com/PawanSikawat/faucet-stream/issues/38).

## New crates

| Crate | Purpose |
|-------|---------|
| `faucet-sink-stdout` | Writes records to stdout/stderr in JSON Lines, pretty JSON, or TSV. Honors `flush_per_record`, `max_records`, and treats `BrokenPipe` as clean termination so pipes into `head` don't error. |
| `faucet-state-redis` | Redis-backed `StateStore`. Stores `{namespace}:{key}` as a JSON string via `MultiplexedConnection`. |
| `faucet-state-postgres` | Postgres-backed `StateStore`. Single `faucet_state(key TEXT PK, value JSONB, updated_at TIMESTAMPTZ)` table; upsert via `ON CONFLICT (key) DO UPDATE`. |

Redis and Postgres backends live in their own crates so `faucet-core` stays dependency-light (CLAUDE.md "no heavy deps in `faucet-core`" rule). The file backend ships inside `faucet-core` because it only needs `tokio::fs`.

## `faucet-core` changes

- New `state` module: `StateStore` trait + `MemoryStateStore` + `FileStateStore` (atomic-rename writes, lazy root-dir creation, path-traversal-safe key validation).
- `FaucetError::State(String)` variant for state-store errors.
- `Source::state_key(&self) -> Option<String>` and `Source::apply_start_bookmark(&self, Value)` — both default no-ops so existing connectors are unaffected.
- `Pipeline::with_state_store(Arc<dyn StateStore>)` — reads stored bookmark, pushes it to the source via `apply_start_bookmark`, writes the new bookmark **only after** sink confirms the write.

## Tests

`cargo test --workspace --all-features` → **491 passed, 0 failed**.

Highlights:
- 16 stdout-sink unit tests (formats, max_records, flush, broken-pipe termination, trait-object usage, schema introspection).
- 23 state-module tests in `faucet-core` (key validation, `MemoryStateStore`, `FileStateStore` atomicity + concurrent puts, corrupt-file handling).
- 6 end-to-end pipeline ↔ state-store tests (resume from stored bookmark, persist only after sink, sink-failure does not commit, no-state-key passthrough, `None` bookmark skips persist, two-run round-trip with `FileStateStore`).
- 6 unit tests in `faucet-state-redis` (key namespacing, namespace validation, URL/namespace error paths).
- 10 unit tests in `faucet-state-postgres` (table-name validation, SQL string construction including identifier quoting, error paths).

## CI matrix

`feature-check` extended with `sink-stdout`, `state-redis`, `state-postgres`, and the new `state` aggregate.

## Out of scope (follow-ups)

- REST source integration with the state store (the acceptance criterion's "REST source resumable integration test"). The pipeline-side wiring is complete and proven end-to-end with a `StatefulSource` test fixture; updating `RestStream` to override `apply_start_bookmark` is mechanical and will land in a smaller follow-up PR against [#25](https://github.com/PawanSikawat/faucet-stream/issues/25).
- Live integration tests against real Redis/Postgres servers — matches the repo's current pattern (Redis/Postgres source+sink ship unit tests only).

## Test plan

- [ ] `cargo fmt --all --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --all-features`
- [ ] `cargo check -p faucet-stream --no-default-features --features sink-stdout`
- [ ] `cargo check -p faucet-stream --no-default-features --features state-redis`
- [ ] `cargo check -p faucet-stream --no-default-features --features state-postgres`
- [ ] `cargo check -p faucet-stream --no-default-features --features full`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
