### PR TITLE
feat(cli): add 'faucet' config-driven pipeline runner binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,8 @@ jobs:
           - sink
           - state
           - full
+          # CLI build matrix — verify the binary builds with every default-on
+          # feature plus a slim "only the bare minimum" combo.
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -116,3 +118,30 @@ jobs:
           key: ${{ runner.os }}-feat-${{ matrix.feature }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-feat-${{ matrix.feature }}-
       - run: cargo check -p faucet-stream --no-default-features --features ${{ matrix.feature }}
+
+  cli-build:
+    name: CLI build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Defaults pull in every connector; the slim profile covers the
+        # smallest interesting combination so accidental cross-feature deps
+        # surface immediately.
+        features:
+          - "full"
+          - "source-rest,sink-jsonl,sink-stdout,transforms"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.94.0"
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cli-${{ matrix.features }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cli-
+      - run: cargo build -p faucet-cli --no-default-features --features "${{ matrix.features }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,6 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cli-${{ matrix.features }}-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cli-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('cli/**/*.rs', 'cli/Cargo.toml') }}
           restore-keys: ${{ runner.os }}-cli-
       - run: cargo build -p faucet-cli --no-default-features --features "${{ matrix.features }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,18 +2,19 @@
 
 ## Library Purpose
 
-`faucet-stream` is a modular, config-driven data pipeline toolkit for Rust with pluggable **source** and **sink** connectors.
+`faucet-stream` is a modular, config-driven data pipeline toolkit for Rust with pluggable **source** and **sink** connectors, plus a `faucet` CLI binary that runs pipelines declaratively from YAML/JSON — no Rust code required.
 
 - **Sources** fetch data from external systems (e.g. REST APIs).
 - **Sinks** write data to external systems (e.g. BigQuery).
+- **`faucet` CLI** (`cli/`) wires source → transforms → sink together based on a config file.
 
-Design goal: callers configure a source or sink once, call `fetch_all()` or `write_batch()`, and get/write all records — no manual pagination loop, no auth boilerplate.
+Design goal: callers configure a source or sink once, call `fetch_all()` or `write_batch()`, and get/write all records — no manual pagination loop, no auth boilerplate. Rust users embed the library directly; everyone else runs the `faucet` binary.
 
-This is a library workspace — there is no binary, no database, no migrations, no server.
+This workspace produces both library crates (`faucet-core` + every connector and state backend) and the `faucet` CLI binary. There is no database, no migrations, and no server.
 
 ## Workspace Structure
 
-The project is a Cargo workspace with 30 crates:
+The project is a Cargo workspace with 31 crates (30 libraries + the `faucet-cli` binary):
 
 | Crate | Path | Description |
 |-------|------|-------------|
@@ -47,6 +48,7 @@ The project is a Cargo workspace with 30 crates:
 | `faucet-state-redis` | `crates/state/redis/` | Redis-backed `StateStore` for replication bookmarks |
 | `faucet-state-postgres` | `crates/state/postgres/` | PostgreSQL-backed `StateStore` for replication bookmarks |
 | `faucet-stream` | `faucet-stream/` | Umbrella crate — feature-gated re-exports of all connectors and state backends |
+| `faucet-cli` | `cli/` | `faucet` binary — YAML/JSON config-driven pipeline runner (`run`, `validate`, `schema`, `list`, `preview`, `init`) |
 
 ### Crate Dependency Graph
 
@@ -82,6 +84,7 @@ faucet-core  <──  faucet-source-rest
              <──  faucet-state-redis
              <──  faucet-state-postgres
              <──  faucet-stream (umbrella, all optional)
+             <──  faucet-cli (binary — depends on every connector + state crate via optional features)
 ```
 
 ## Capturing Feature Ideas as GitHub Issues
@@ -189,6 +192,18 @@ cargo publish --dry-run -p faucet-core
 cargo publish --dry-run -p faucet-source-rest
 cargo publish --dry-run -p faucet-sink-bigquery
 cargo publish --dry-run -p faucet-stream
+cargo publish --dry-run -p faucet-cli
+
+# Build / install the CLI binary
+cargo build -p faucet-cli                     # debug build → target/debug/faucet
+cargo install --path cli                      # release install → ~/.cargo/bin/faucet
+cargo install --path cli --no-default-features --features "source-rest,sink-jsonl,sink-stdout,transforms"  # slim build
+
+# Drive the CLI on a config file
+./target/debug/faucet list
+./target/debug/faucet schema source rest
+./target/debug/faucet validate cli/examples/csv_to_jsonl.yaml
+./target/debug/faucet run cli/examples/csv_to_jsonl.yaml
 ```
 
 ## Architecture
@@ -364,6 +379,23 @@ cargo publish --dry-run -p faucet-stream
 ### faucet-stream (umbrella, `faucet-stream/`)
 
 - **`src/lib.rs`** — feature-gated re-exports of all connectors; `pub use faucet_core::*` always available; backwards-compatible flat re-exports for existing users
+
+### faucet-cli (binary, `cli/`)
+
+- **`src/main.rs`** — `tokio::main` entry point; installs `tracing-subscriber` against `--log-level` / `FAUCET_LOG`, then dispatches to `commands::*::run`. Reports `CliError` to stderr and exits 1 on failure.
+- **`src/lib.rs`** — library half of the crate; re-exports `cli`, `commands`, `config`, `error`, `interpolate`, `registry`, `state`, `transforms` so tests (and downstream tooling) can drive the same code paths the binary does.
+- **`src/cli.rs`** — `clap` argument types: `Cli`, `Command::{Run, Validate, Schema, List, Preview, Init}`, and per-subcommand arg structs (`RunArgs`, `ValidateArgs`, `SchemaArgs`, `PreviewArgs`, `InitArgs`).
+- **`src/config.rs`** — `PipelineConfig` (top-level YAML/JSON schema) with `ConnectorSpec { kind, config }`, `TransformSpec`, `StateStoreSpec`. `from_path()` reads + interpolates + dispatches to the YAML or JSON parser based on the file extension. Rejects `version != 1`.
+- **`src/interpolate.rs`** — substitutes `${env:VAR}`, `${file:PATH}`, `${secret:VAR}` (today an alias for `env`) in raw config text before parsing. `$${` is the escape for a literal `${`. Unclosed directives are left untouched.
+- **`src/registry.rs`** — feature-gated `build_source` / `build_sink` async dispatchers, plus `source_schema` / `sink_schema` (via `schemars::schema_for!`) and `source_descriptions` / `sink_descriptions` for `faucet list`.
+- **`src/state.rs`** — `build_state_store(&StateStoreSpec)` returns `Arc<dyn StateStore>`. Built-in `memory` and `file` backends are always available; `redis` / `postgres` are feature-gated.
+- **`src/transforms.rs`** — `compile_transforms(&[TransformSpec])` turns YAML transform blocks into `RecordTransform` values. Only the built-in `flatten`, `rename_keys`, `snake_case` transforms are exposed via config; custom-closure transforms remain Rust-only.
+- **`src/commands/run.rs`** — orchestrates a single `Pipeline` run, wrapping the source with `TransformingSource` when transforms are configured, and the sink with `LimitedSink` for `--limit` or `CountingSink` for `--dry-run`. Wires in a state store from `cfg.state` or `--state-path`.
+- **`src/commands/validate.rs`** — parses the config and verifies the source/sink kinds, transform names, and state-store kind are compiled into the binary. Prints a one-line summary on success.
+- **`src/commands/schema.rs`** — prints `source_schema()` / `sink_schema()` for the requested connector.
+- **`src/commands/list.rs`** — two-column listing of every compiled-in source, sink, transform, and state-store backend.
+- **`src/commands/preview.rs`** — runs only the source side, applies transforms, then writes the first `--limit` records to stdout via `faucet-sink-stdout`. Gated by the `sink-stdout` feature.
+- **`src/commands/init.rs`** — scaffolds a starter `pipeline.yaml` (REST → JSONL with a file state store). Refuses to overwrite unless `--force`.
 
 ## Feature Flags (umbrella crate)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ members = [
     "crates/state/redis",
     "crates/state/postgres",
     "faucet-stream",
+    "cli",
 ]
 
 [workspace.package]
@@ -74,6 +75,7 @@ faucet-sink-http = { path = "crates/sink/http", version = "0.2.0" }
 faucet-sink-stdout = { path = "crates/sink/stdout", version = "0.2.0" }
 faucet-state-redis = { path = "crates/state/redis", version = "0.2.0" }
 faucet-state-postgres = { path = "crates/state/postgres", version = "0.2.0" }
+faucet-cli = { path = "cli", version = "0.2.0" }
 
 # Shared external deps
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -6,14 +6,53 @@
 [![License](https://img.shields.io/crates/l/faucet-stream.svg)](LICENSE-MIT)
 
 A modular, config-driven data pipeline toolkit for Rust with pluggable
-**source** and **sink** connectors.
+**source** and **sink** connectors — plus the `faucet` CLI binary that runs
+pipelines declaratively from a YAML/JSON file. No Rust code required.
 
 Inspired by [Meltano's RESTStream](https://sdk.meltano.com/en/latest/classes/singer_sdk.RESTStream.html)
-— but for Rust, and as a reusable library.
+— but for Rust, both as a reusable library and as a standalone CLI.
+
+## Run a pipeline from a YAML file (no Rust required)
+
+```bash
+cargo install faucet-cli
+faucet init my_pipeline      # scaffold pipeline.yaml
+faucet validate pipeline.yaml
+faucet run pipeline.yaml
+```
+
+```yaml
+# pipeline.yaml
+version: 1
+source:
+  type: rest
+  config:
+    base_url: https://api.github.com
+    path: /repos/PawanSikawat/faucet-stream/issues
+    method: GET
+    auth: { type: ApiKey, header: Authorization, value: "Bearer ${env:GITHUB_TOKEN}" }
+    query_params: { state: open }
+    pagination: { type: LinkHeader }
+    max_retries: 3
+    retry_backoff: 1
+    tolerated_http_errors: []
+    replication_method: { type: FullTable }
+    primary_keys: ["id"]
+    partitions: []
+    schema_sample_size: 100
+transforms:
+  - type: snake_case
+sink:
+  type: jsonl
+  config:
+    path: ./out/issues.jsonl
+```
+
+See [`cli/README.md`](cli/README.md) and [`cli/examples/`](cli/examples/) for the full CLI reference and ready-to-run pipeline YAMLs.
 
 ## Architecture
 
-faucet-stream is a Cargo workspace with 27 crates — 13 sources, 12 sinks, a shared core, and an umbrella crate:
+faucet-stream is a Cargo workspace with 31 crates — 13 sources, 13 sinks, 2 state-store backends, the shared core, the umbrella crate, and the CLI binary:
 
 | Crate | Description |
 |-------|-------------|
@@ -50,6 +89,8 @@ faucet-stream is a Cargo workspace with 27 crates — 13 sources, 12 sinks, a sh
 | [`faucet-state-redis`](crates/state/redis) | Redis-backed `StateStore` for persistent bookmarks |
 | [`faucet-state-postgres`](crates/state/postgres) | PostgreSQL-backed `StateStore` for persistent bookmarks |
 | [`faucet-stream`](faucet-stream) | Umbrella crate — feature-gated re-exports of all connectors and state backends |
+| **CLI** | |
+| [`faucet-cli`](cli) | `faucet` binary — YAML/JSON config-driven pipeline runner (`run`, `validate`, `schema`, `list`, `preview`, `init`) |
 
 Install only what you need:
 
@@ -884,7 +925,18 @@ crates/
     csv/                      — CSV file writer
     elasticsearch/            — Elasticsearch bulk index
     http/                     — HTTP POST
+    stdout/                   — Stdout / stderr (JSON Lines, pretty JSON, TSV)
+  state/
+    redis/                    — Redis-backed StateStore
+    postgres/                 — PostgreSQL-backed StateStore
 faucet-stream/                — umbrella crate with feature-gated re-exports
+cli/                          — faucet-cli: `faucet` binary, YAML/JSON pipeline runner
+  src/
+    main.rs, lib.rs, cli.rs, config.rs, interpolate.rs,
+    registry.rs, state.rs, transforms.rs, error.rs,
+    commands/{run, validate, schema, list, preview, init}.rs
+  examples/                   — ready-to-run pipeline YAMLs
+  tests/                      — assert_cmd + wiremock integration tests
 ```
 
 ## License

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,0 +1,137 @@
+[package]
+name = "faucet-cli"
+version = "0.2.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Config-driven CLI runner for faucet-stream pipelines (YAML / JSON, Meltano-style)"
+readme = "README.md"
+keywords = ["pipeline", "etl", "cli", "meltano", "faucet"]
+categories = ["command-line-utilities"]
+
+[[bin]]
+name = "faucet"
+path = "src/main.rs"
+
+[features]
+# Default: every first-party source, sink, and state backend so `cargo install`
+# yields a binary that can run any of the published example YAMLs out of the box.
+default = ["full"]
+
+full = ["source", "sink", "state", "transforms"]
+
+source = [
+    "source-rest",
+    "source-graphql",
+    "source-xml",
+    "source-grpc",
+    "source-postgres",
+    "source-mysql",
+    "source-sqlite",
+    "source-s3",
+    "source-mongodb",
+    "source-redis",
+    "source-webhook",
+    "source-csv",
+    "source-elasticsearch",
+]
+sink = [
+    "sink-bigquery",
+    "sink-postgres",
+    "sink-jsonl",
+    "sink-snowflake",
+    "sink-mysql",
+    "sink-sqlite",
+    "sink-s3",
+    "sink-mongodb",
+    "sink-redis",
+    "sink-csv",
+    "sink-elasticsearch",
+    "sink-http",
+    "sink-stdout",
+]
+state = ["state-redis", "state-postgres"]
+
+source-rest = ["dep:faucet-source-rest"]
+source-graphql = ["dep:faucet-source-graphql"]
+source-xml = ["dep:faucet-source-xml"]
+source-grpc = ["dep:faucet-source-grpc"]
+source-postgres = ["dep:faucet-source-postgres"]
+source-mysql = ["dep:faucet-source-mysql"]
+source-sqlite = ["dep:faucet-source-sqlite"]
+source-s3 = ["dep:faucet-source-s3"]
+source-mongodb = ["dep:faucet-source-mongodb"]
+source-redis = ["dep:faucet-source-redis"]
+source-webhook = ["dep:faucet-source-webhook"]
+source-csv = ["dep:faucet-source-csv"]
+source-elasticsearch = ["dep:faucet-source-elasticsearch"]
+
+sink-bigquery = ["dep:faucet-sink-bigquery"]
+sink-postgres = ["dep:faucet-sink-postgres"]
+sink-jsonl = ["dep:faucet-sink-jsonl"]
+sink-snowflake = ["dep:faucet-sink-snowflake"]
+sink-mysql = ["dep:faucet-sink-mysql"]
+sink-sqlite = ["dep:faucet-sink-sqlite"]
+sink-s3 = ["dep:faucet-sink-s3"]
+sink-mongodb = ["dep:faucet-sink-mongodb"]
+sink-redis = ["dep:faucet-sink-redis"]
+sink-csv = ["dep:faucet-sink-csv"]
+sink-elasticsearch = ["dep:faucet-sink-elasticsearch"]
+sink-http = ["dep:faucet-sink-http"]
+sink-stdout = ["dep:faucet-sink-stdout"]
+
+state-redis = ["dep:faucet-state-redis"]
+state-postgres = ["dep:faucet-state-postgres"]
+
+transforms = [
+    "faucet-core/transforms",
+    "faucet-source-rest?/transforms",
+]
+
+[dependencies]
+faucet-core.workspace = true
+faucet-source-rest = { workspace = true, optional = true }
+faucet-source-graphql = { workspace = true, optional = true }
+faucet-source-xml = { workspace = true, optional = true }
+faucet-source-grpc = { workspace = true, optional = true }
+faucet-source-postgres = { workspace = true, optional = true }
+faucet-source-mysql = { workspace = true, optional = true }
+faucet-source-sqlite = { workspace = true, optional = true }
+faucet-source-s3 = { workspace = true, optional = true }
+faucet-source-mongodb = { workspace = true, optional = true }
+faucet-source-redis = { workspace = true, optional = true }
+faucet-source-webhook = { workspace = true, optional = true }
+faucet-source-csv = { workspace = true, optional = true }
+faucet-source-elasticsearch = { workspace = true, optional = true }
+faucet-sink-bigquery = { workspace = true, optional = true }
+faucet-sink-postgres = { workspace = true, optional = true }
+faucet-sink-jsonl = { workspace = true, optional = true }
+faucet-sink-snowflake = { workspace = true, optional = true }
+faucet-sink-mysql = { workspace = true, optional = true }
+faucet-sink-sqlite = { workspace = true, optional = true }
+faucet-sink-s3 = { workspace = true, optional = true }
+faucet-sink-mongodb = { workspace = true, optional = true }
+faucet-sink-redis = { workspace = true, optional = true }
+faucet-sink-csv = { workspace = true, optional = true }
+faucet-sink-elasticsearch = { workspace = true, optional = true }
+faucet-sink-http = { workspace = true, optional = true }
+faucet-sink-stdout = { workspace = true, optional = true }
+faucet-state-redis = { workspace = true, optional = true }
+faucet-state-postgres = { workspace = true, optional = true }
+
+clap = { version = "4", features = ["derive", "env"] }
+serde.workspace = true
+serde_json.workspace = true
+serde_yaml = "0.9"
+thiserror.workspace = true
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "signal", "fs"] }
+tracing.workspace = true
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+async-trait.workspace = true
+
+[dev-dependencies]
+tempfile = "3"
+assert_cmd = "2"
+predicates = "3"
+wiremock = "0.6"

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,123 @@
+# faucet-cli
+
+`faucet` — config-driven runner for [`faucet-stream`](https://crates.io/crates/faucet-stream) pipelines.
+
+Write a YAML or JSON file describing a source, optional transforms, a sink, and (optionally) a state store. Run it with the `faucet` binary. No Rust code required.
+
+## Install
+
+```bash
+cargo install faucet-cli
+```
+
+To build a slim binary with only the connectors you need:
+
+```bash
+cargo install faucet-cli --no-default-features \
+    --features source-rest,sink-jsonl,sink-stdout,transforms
+```
+
+## Commands
+
+| Command | What it does |
+|---------|--------------|
+| `faucet run <config>` | Execute the pipeline end-to-end. Supports `--dry-run`, `--limit N`, `--state-path PATH`. |
+| `faucet validate <config>` | Parse + validate without running. Exits non-zero on error. |
+| `faucet schema source|sink <name>` | Print the JSON Schema for a specific connector's config. |
+| `faucet list` | List every compiled-in source, sink, transform, and state-store backend. |
+| `faucet preview <config> --limit N` | Run only the source side and emit the first N records to stdout as JSONL. |
+| `faucet init <name>` | Scaffold a starter `pipeline.yaml`. |
+
+Pass `--log-level debug` (or set `FAUCET_LOG=debug`) for verbose tracing. Logs are written to stderr; pipeline records and command output go to stdout.
+
+## Config shape
+
+```yaml
+version: 1
+name: github_to_jsonl
+source:
+  type: rest
+  config:
+    base_url: https://api.github.com
+    path: /repos/PawanSikawat/faucet-stream/issues
+    method: GET
+    auth:
+      type: ApiKey
+      header: Authorization
+      value: Bearer ${env:GITHUB_TOKEN}
+    query_params: {state: open}
+    pagination:
+      type: LinkHeader
+    max_retries: 3
+    retry_backoff: 1
+    tolerated_http_errors: []
+    replication_method: { type: FullTable }
+    primary_keys: ["id"]
+    partitions: []
+    schema_sample_size: 100
+transforms:
+  - type: snake_case
+sink:
+  type: jsonl
+  config:
+    path: ./out/issues.jsonl
+state:
+  type: file
+  config:
+    path: ./.faucet-state
+```
+
+### Env / file interpolation
+
+Anywhere in the config, `${env:VAR}` is replaced with the value of the environment variable, and `${file:./path}` with the (trimmed) contents of the file. Interpolation runs before YAML / JSON parsing, so resolved values can become any structured type. `${secret:VAR}` is an alias for `${env:VAR}` today; future releases will plug in a real secrets backend behind that prefix.
+
+### State stores
+
+```yaml
+state:
+  type: file              # or: memory, redis, postgres
+  config:
+    path: ./.faucet-state
+```
+
+The Redis and PostgreSQL backends ship behind the `state-redis` and `state-postgres` features.
+
+### Transforms
+
+```yaml
+transforms:
+  - type: snake_case
+  - type: rename_keys
+    config: { pattern: "^_sdc_", replacement: "" }
+  - type: flatten
+    config: { separator: "__" }
+```
+
+## Examples
+
+[`examples/`](examples/) ships YAML pipelines for every `faucet-stream/examples/*.rs` use case — the same source → sink combinations the library docs cover, expressed as config.
+
+CLI-only smoke tests:
+
+- [`csv_to_jsonl.yaml`](examples/csv_to_jsonl.yaml) — read a CSV, write JSONL (zero external deps)
+- [`rest_to_stdout_preview.yaml`](examples/rest_to_stdout_preview.yaml) — pipe REST records into `jq`
+
+Mirrors of the Rust examples (one `.yaml` per `.rs`):
+
+- REST: [`rest_to_jsonl`](examples/rest_to_jsonl.yaml), [`rest_to_bigquery`](examples/rest_to_bigquery.yaml), [`rest_to_postgres`](examples/rest_to_postgres.yaml), [`rest_to_s3`](examples/rest_to_s3.yaml), [`rest_streaming`](examples/rest_streaming.yaml)
+- GraphQL: [`graphql_to_bigquery`](examples/graphql_to_bigquery.yaml), [`graphql_to_postgres`](examples/graphql_to_postgres.yaml)
+- XML/SOAP: [`xml_to_s3`](examples/xml_to_s3.yaml), [`xml_to_mongodb`](examples/xml_to_mongodb.yaml)
+- gRPC: [`grpc_to_elasticsearch`](examples/grpc_to_elasticsearch.yaml), [`grpc_to_http`](examples/grpc_to_http.yaml)
+- Databases: [`postgres_to_bigquery`](examples/postgres_to_bigquery.yaml), [`postgres_to_elasticsearch`](examples/postgres_to_elasticsearch.yaml), [`postgres_to_s3`](examples/postgres_to_s3.yaml), [`postgres_to_snowflake`](examples/postgres_to_snowflake.yaml), [`mysql_to_bigquery`](examples/mysql_to_bigquery.yaml), [`mysql_to_postgres`](examples/mysql_to_postgres.yaml), [`mysql_to_snowflake`](examples/mysql_to_snowflake.yaml), [`sqlite_to_jsonl`](examples/sqlite_to_jsonl.yaml), [`sqlite_to_csv`](examples/sqlite_to_csv.yaml)
+- Document stores: [`mongodb_to_postgres`](examples/mongodb_to_postgres.yaml), [`mongodb_to_elasticsearch`](examples/mongodb_to_elasticsearch.yaml), [`mongodb_to_redis`](examples/mongodb_to_redis.yaml)
+- Search / cache: [`elasticsearch_to_redis`](examples/elasticsearch_to_redis.yaml), [`elasticsearch_to_s3`](examples/elasticsearch_to_s3.yaml), [`redis_to_mysql`](examples/redis_to_mysql.yaml), [`redis_to_sqlite`](examples/redis_to_sqlite.yaml)
+- Object storage: [`s3_to_bigquery`](examples/s3_to_bigquery.yaml), [`s3_to_mongodb`](examples/s3_to_mongodb.yaml), [`s3_to_postgres`](examples/s3_to_postgres.yaml), [`s3_to_snowflake`](examples/s3_to_snowflake.yaml)
+- CSV in: [`csv_to_bigquery`](examples/csv_to_bigquery.yaml), [`csv_to_mysql`](examples/csv_to_mysql.yaml), [`csv_to_sqlite`](examples/csv_to_sqlite.yaml)
+- Webhook receiver: [`webhook_to_csv`](examples/webhook_to_csv.yaml), [`webhook_to_http`](examples/webhook_to_http.yaml), [`webhook_to_postgres`](examples/webhook_to_postgres.yaml)
+- DAG parent leg: [`dag_users_posts`](examples/dag_users_posts.yaml) — parent only (multi-node DAGs require the library API today)
+
+A handful of YAMLs note specific limitations in their header comment — chiefly that `Auth::Bearer(String)` and similar newtype-in-tagged-enum variants can't currently round-trip through serde. The [tracking issue](https://github.com/PawanSikawat/faucet-stream/issues) will replace those with struct variants so the YAML versions become 1:1 with the Rust ones.
+
+## License
+
+MIT OR Apache-2.0

--- a/cli/examples/csv_to_bigquery.yaml
+++ b/cli/examples/csv_to_bigquery.yaml
@@ -1,0 +1,23 @@
+# YAML equivalent of `faucet-stream/examples/csv_to_bigquery.rs`.
+# CSV → BigQuery with service-account key path + non-default batch size.
+version: 1
+name: csv_to_bigquery
+
+source:
+  type: csv
+  config:
+    path: transactions.csv
+    has_headers: true
+    delimiter: 44   # b','
+    quote: 34       # b'"'
+
+sink:
+  type: bigquery
+  config:
+    project_id: my-gcp-project
+    dataset_id: warehouse
+    table_id: transactions
+    credentials:
+      type: ServiceAccountKeyPath
+      value: service-account.json
+    batch_size: 1000

--- a/cli/examples/csv_to_jsonl.yaml
+++ b/cli/examples/csv_to_jsonl.yaml
@@ -1,0 +1,17 @@
+# Pipe a local CSV file through to JSONL. Useful as the simplest possible
+# smoke test for a fresh `faucet` install:
+#
+#   faucet validate cli/examples/csv_to_jsonl.yaml
+#   faucet run      cli/examples/csv_to_jsonl.yaml
+version: 1
+name: csv_to_jsonl
+
+source:
+  type: csv
+  config:
+    path: ./data/input.csv
+
+sink:
+  type: jsonl
+  config:
+    path: ./out/records.jsonl

--- a/cli/examples/csv_to_mysql.yaml
+++ b/cli/examples/csv_to_mysql.yaml
@@ -1,0 +1,22 @@
+# YAML equivalent of `faucet-stream/examples/csv_to_mysql.rs`.
+# CSV → MySQL with AutoMap column mapping.
+version: 1
+name: csv_to_mysql
+
+source:
+  type: csv
+  config:
+    path: customers.csv
+    has_headers: true
+    delimiter: 44   # b','
+    quote: 34       # b'"'
+
+sink:
+  type: mysql
+  config:
+    connection_url: mysql://user:pass@localhost/crm
+    table_name: customers_imported
+    column_mapping:
+      type: auto_map
+    batch_size: 1000
+    max_connections: 10

--- a/cli/examples/csv_to_sqlite.yaml
+++ b/cli/examples/csv_to_sqlite.yaml
@@ -1,0 +1,23 @@
+# YAML equivalent of `faucet-stream/examples/csv_to_sqlite.rs`.
+# TSV-like CSV (tab delimiter, no headers) → SQLite with JSON column mapping.
+version: 1
+name: csv_to_sqlite
+
+source:
+  type: csv
+  config:
+    path: inventory.tsv
+    has_headers: false
+    delimiter: 9    # b'\t'
+    quote: 39       # b'\''
+
+sink:
+  type: sqlite
+  config:
+    database_url: sqlite:./inventory.db
+    table_name: inventory
+    column_mapping:
+      type: json
+      column: row
+    batch_size: 500
+    max_connections: 4

--- a/cli/examples/dag_users_posts.yaml
+++ b/cli/examples/dag_users_posts.yaml
@@ -1,0 +1,48 @@
+# YAML equivalent of `faucet-stream/examples/dag_users_posts.rs`.
+#
+# Limitation: the `faucet` CLI today only runs a single source → sink
+# pipeline. The Rust example uses `SourceDAG` to fan out per-user post
+# fetches with `context_mapping` + `inject_context`. Until the CLI gains
+# a `dag:` section (tracking issue pending), wire DAGs via the library
+# API. The YAML below captures the parent (users) leg only.
+version: 1
+name: dag_users_posts__parent_only
+
+source:
+  type: rest
+  config:
+    base_url: https://api.example.com
+    path: /v1/users
+    method: GET
+    name: users
+    auth:
+      type: ApiKey
+      header: Authorization
+      value: Bearer ${env:API_TOKEN}
+    headers: {}
+    query_params:
+      active: "true"
+    records_path: $.data[*]
+    pagination:
+      type: PageNumber
+      param_name: page
+      start_page: 1
+      page_size: 100
+      page_size_param: per_page
+    max_pages: 20
+    timeout: 30
+    max_retries: 3
+    retry_backoff: 1
+    tolerated_http_errors: []
+    replication_method:
+      type: FullTable
+    primary_keys: [id]
+    partitions: []
+    schema_sample_size: 100
+
+sink:
+  type: jsonl
+  config:
+    path: users.jsonl
+    append: false
+    pretty: false

--- a/cli/examples/elasticsearch_to_redis.yaml
+++ b/cli/examples/elasticsearch_to_redis.yaml
@@ -1,0 +1,30 @@
+# YAML equivalent of `faucet-stream/examples/elasticsearch_to_redis.rs`.
+# Elasticsearch (Basic auth, scroll API) → Redis key-value cache.
+version: 1
+name: elasticsearch_to_redis
+
+source:
+  type: elasticsearch
+  config:
+    base_url: https://es.example.com:9200
+    index: products
+    query:
+      term:
+        available: true
+    scroll_timeout: 1m
+    scroll_size: 1000
+    auth:
+      type: Basic
+      value:
+        username: ${env:ES_USER}
+        password: ${env:ES_PASS}
+    max_pages: 500
+
+sink:
+  type: redis
+  config:
+    url: redis://localhost:6379
+    sink_type:
+      type: KeyValue
+      key_field: id
+    batch_size: 2000

--- a/cli/examples/elasticsearch_to_s3.yaml
+++ b/cli/examples/elasticsearch_to_s3.yaml
@@ -1,0 +1,28 @@
+# YAML equivalent of `faucet-stream/examples/elasticsearch_to_s3.rs`.
+# Elasticsearch (API-key auth) → S3 with sharded parallel uploads.
+version: 1
+name: elasticsearch_to_s3
+
+source:
+  type: elasticsearch
+  config:
+    base_url: https://es.example.com:9200
+    index: logs-2026-05
+    query:
+      match:
+        level: error
+    scroll_timeout: 2m
+    scroll_size: 2000
+    auth:
+      type: ApiKey
+      value: ${env:ES_API_KEY}
+
+sink:
+  type: s3
+  config:
+    bucket: my-es-backups
+    prefix: logs/2026-05/
+    region: us-east-1
+    file_extension: .jsonl
+    max_records_per_file: 50000
+    concurrency: 16

--- a/cli/examples/graphql_to_bigquery.yaml
+++ b/cli/examples/graphql_to_bigquery.yaml
@@ -1,0 +1,42 @@
+# YAML equivalent of `faucet-stream/examples/graphql_to_bigquery.rs`.
+# GraphQL (Relay cursor pagination) → BigQuery with ApplicationDefault credentials.
+#
+# Limitation: the GraphQL source's `headers` and `auth: Custom(HeaderMap)`
+# variants are `#[serde(skip)]`, so the Rust example's per-request header
+# auth is not yet expressible in YAML. Pending follow-up issue.
+version: 1
+name: graphql_to_bigquery
+
+source:
+  type: graphql
+  config:
+    endpoint: https://api.example.com/graphql
+    query: |
+      query Orders($after: String, $first: Int!) {
+        orders(first: $first, after: $after) {
+          edges { node { id total status createdAt } }
+          pageInfo { endCursor hasNextPage }
+        }
+      }
+    variables:
+      first: 200
+    auth:
+      type: None
+    records_path: $.data.orders.edges[*].node
+    pagination:
+      has_next_page_path: $.data.orders.pageInfo.hasNextPage
+      cursor_path: $.data.orders.pageInfo.endCursor
+      cursor_variable: after
+      page_size: 200
+      page_size_variable: first
+    max_pages: 500
+
+sink:
+  type: bigquery
+  config:
+    project_id: my-gcp-project
+    dataset_id: raw
+    table_id: orders
+    credentials:
+      type: ApplicationDefault
+    batch_size: 1000

--- a/cli/examples/graphql_to_postgres.yaml
+++ b/cli/examples/graphql_to_postgres.yaml
@@ -1,0 +1,42 @@
+# YAML equivalent of `faucet-stream/examples/graphql_to_postgres.rs`.
+# GraphQL (Relay cursor pagination) → PostgreSQL with AutoMap column mapping.
+#
+# Limitation: GraphqlAuth::Bearer(String) is a newtype-in-tagged-enum and
+# can't round-trip through serde — see the follow-up issue. Until that's
+# fixed, the YAML version omits auth; add it on the wire-level proxy if
+# your endpoint requires a token.
+version: 1
+name: graphql_to_postgres
+
+source:
+  type: graphql
+  config:
+    endpoint: https://api.example.com/graphql
+    query: |
+      query Users($after: String, $first: Int!) {
+        users(first: $first, after: $after) {
+          edges { node { id name email createdAt } }
+          pageInfo { endCursor hasNextPage }
+        }
+      }
+    variables:
+      first: 100
+    auth:
+      type: None
+    records_path: $.data.users.edges[*].node
+    pagination:
+      has_next_page_path: $.data.users.pageInfo.hasNextPage
+      cursor_path: $.data.users.pageInfo.endCursor
+      cursor_variable: after
+      page_size: 100
+      page_size_variable: first
+
+sink:
+  type: postgres
+  config:
+    connection_url: postgres://user:pass@localhost/app
+    table_name: users_imported
+    column_mapping:
+      type: auto_map
+    batch_size: 1000
+    max_connections: 8

--- a/cli/examples/grpc_to_elasticsearch.yaml
+++ b/cli/examples/grpc_to_elasticsearch.yaml
@@ -1,0 +1,37 @@
+# YAML equivalent of `faucet-stream/examples/grpc_to_elasticsearch.rs`.
+# gRPC (TLS) → Elasticsearch with Basic auth and id_field.
+#
+# Limitation: GrpcAuth::Metadata and GrpcAuth::Bearer are newtype variants of
+# an internally-tagged enum and cannot round-trip through serde today (see the
+# tracking issue). Run the .rs example for metadata-based auth until the
+# config type is split into struct variants.
+version: 1
+name: grpc_to_elasticsearch
+
+source:
+  type: grpc
+  config:
+    endpoint: https://grpc.example.com:443
+    service_name: events.EventService
+    method_name: ListEvents
+    descriptor_set_path: proto/events.bin
+    request:
+      since: "2026-01-01T00:00:00Z"
+      page_size: 1000
+    auth:
+      type: None
+    tls: true
+    records_path: $.events[*]
+
+sink:
+  type: elasticsearch
+  config:
+    base_url: https://es.example.com:9200
+    index: events
+    auth:
+      type: Basic
+      value:
+        username: ${env:ES_USER}
+        password: ${env:ES_PASS}
+    batch_size: 1000
+    id_field: event_id

--- a/cli/examples/grpc_to_http.yaml
+++ b/cli/examples/grpc_to_http.yaml
@@ -1,0 +1,37 @@
+# YAML equivalent of `faucet-stream/examples/grpc_to_http.rs`.
+# gRPC (TLS) → HTTP POST with Basic auth and array batching.
+#
+# Limitation: GrpcAuth::Bearer and HttpSinkAuth::Bearer are newtype variants
+# of internally-tagged enums and can't round-trip through serde today. The
+# YAML below uses Basic auth on the sink and no source auth as a closest
+# expressible equivalent — see the tracking issue.
+version: 1
+name: grpc_to_http
+
+source:
+  type: grpc
+  config:
+    endpoint: https://grpc.example.com:443
+    service_name: metrics.MetricsService
+    method_name: ListMetrics
+    descriptor_set_path: proto/metrics.bin
+    request:
+      window: 1h
+    auth:
+      type: None
+    tls: true
+    records_path: $.metrics[*]
+
+sink:
+  type: http
+  config:
+    url: https://ingest.example.com/v1/events?tenant=acme
+    method: POST
+    auth:
+      type: Basic
+      username: ${env:INGEST_USER}
+      password: ${env:INGEST_PASS}
+    batch_mode:
+      type: Array
+    max_retries: 3
+    concurrency: 8

--- a/cli/examples/mongodb_to_elasticsearch.yaml
+++ b/cli/examples/mongodb_to_elasticsearch.yaml
@@ -1,0 +1,35 @@
+# YAML equivalent of `faucet-stream/examples/mongodb_to_elasticsearch.rs`.
+# MongoDB (filter + projection + sort + limit) → Elasticsearch with id_field.
+version: 1
+name: mongodb_to_elasticsearch
+
+source:
+  type: mongodb
+  config:
+    connection_uri: mongodb://localhost:27017
+    database: shop
+    collection: products
+    filter:
+      available: true
+    projection:
+      _id: 1
+      name: 1
+      description: 1
+      tags: 1
+    sort:
+      updated_at: -1
+    limit: 100000
+    batch_size: 1000
+
+sink:
+  type: elasticsearch
+  config:
+    base_url: https://es.example.com:9200
+    index: products
+    auth:
+      type: Basic
+      value:
+        username: ${env:ES_USER}
+        password: ${env:ES_PASS}
+    batch_size: 1000
+    id_field: _id

--- a/cli/examples/mongodb_to_postgres.yaml
+++ b/cli/examples/mongodb_to_postgres.yaml
@@ -1,0 +1,33 @@
+# YAML equivalent of `faucet-stream/examples/mongodb_to_postgres.rs`.
+# MongoDB (filter, projection, sort, limit) → PostgreSQL JSONB sink.
+version: 1
+name: mongodb_to_postgres
+
+source:
+  type: mongodb
+  config:
+    connection_uri: mongodb://localhost:27017
+    database: shop
+    collection: orders
+    filter:
+      status: completed
+    projection:
+      _id: 1
+      customer_id: 1
+      total: 1
+      items: 1
+    sort:
+      created_at: 1
+    limit: 500000
+    batch_size: 1000
+
+sink:
+  type: postgres
+  config:
+    connection_url: postgres://user:pass@localhost/warehouse
+    table_name: orders_mirror
+    column_mapping:
+      type: jsonb
+      column: payload
+    batch_size: 1000
+    max_connections: 10

--- a/cli/examples/mongodb_to_redis.yaml
+++ b/cli/examples/mongodb_to_redis.yaml
@@ -1,0 +1,26 @@
+# YAML equivalent of `faucet-stream/examples/mongodb_to_redis.rs`.
+# MongoDB filter + sort + cursor batch → Redis stream sink.
+version: 1
+name: mongodb_to_redis
+
+source:
+  type: mongodb
+  config:
+    connection_uri: mongodb://localhost:27017
+    database: events
+    collection: raw
+    filter:
+      processed: false
+    sort:
+      created_at: 1
+    limit: 50000
+    batch_size: 500
+
+sink:
+  type: redis
+  config:
+    url: redis://localhost:6379
+    sink_type:
+      type: Stream
+      key: events:raw
+    batch_size: 1000

--- a/cli/examples/mysql_to_bigquery.yaml
+++ b/cli/examples/mysql_to_bigquery.yaml
@@ -1,0 +1,21 @@
+# YAML equivalent of `faucet-stream/examples/mysql_to_bigquery.rs`.
+version: 1
+name: mysql_to_bigquery
+
+source:
+  type: mysql
+  config:
+    connection_url: mysql://user:pass@localhost/sales
+    query: SELECT order_id, customer_id, total, ordered_at FROM orders
+    max_connections: 16
+
+sink:
+  type: bigquery
+  config:
+    project_id: my-gcp-project
+    dataset_id: warehouse
+    table_id: orders
+    credentials:
+      type: ServiceAccountKeyPath
+      value: service-account.json
+    batch_size: 1000

--- a/cli/examples/mysql_to_postgres.yaml
+++ b/cli/examples/mysql_to_postgres.yaml
@@ -1,0 +1,20 @@
+# YAML equivalent of `faucet-stream/examples/mysql_to_postgres.rs`.
+version: 1
+name: mysql_to_postgres
+
+source:
+  type: mysql
+  config:
+    connection_url: mysql://user:pass@localhost/legacy
+    query: SELECT id, name, address, created_at FROM customers ORDER BY id
+    max_connections: 16
+
+sink:
+  type: postgres
+  config:
+    connection_url: postgres://user:pass@localhost/modern
+    table_name: customers_imported
+    column_mapping:
+      type: auto_map
+    batch_size: 1000
+    max_connections: 10

--- a/cli/examples/mysql_to_snowflake.yaml
+++ b/cli/examples/mysql_to_snowflake.yaml
@@ -1,0 +1,23 @@
+# YAML equivalent of `faucet-stream/examples/mysql_to_snowflake.rs`.
+version: 1
+name: mysql_to_snowflake
+
+source:
+  type: mysql
+  config:
+    connection_url: mysql://user:pass@localhost/sales
+    query: SELECT order_id, customer_id, total, ordered_at FROM orders
+    max_connections: 16
+
+sink:
+  type: snowflake
+  config:
+    account: xy12345.us-east-1
+    warehouse: LOAD_WH
+    database: ANALYTICS
+    schema: STAGING
+    table: ORDERS
+    auth:
+      type: OAuth
+      token: ${env:SNOWFLAKE_OAUTH_TOKEN}
+    batch_size: 1000

--- a/cli/examples/postgres_to_bigquery.yaml
+++ b/cli/examples/postgres_to_bigquery.yaml
@@ -1,0 +1,24 @@
+# YAML equivalent of `faucet-stream/examples/postgres_to_bigquery.rs`.
+version: 1
+name: postgres_to_bigquery
+
+source:
+  type: postgres
+  config:
+    connection_url: postgres://user:pass@localhost/app
+    query: SELECT id, created_at, payload FROM orders WHERE created_at > $1 AND status = $2
+    params:
+      - "2026-01-01T00:00:00Z"
+      - completed
+    max_connections: 16
+
+sink:
+  type: bigquery
+  config:
+    project_id: my-gcp-project
+    dataset_id: warehouse
+    table_id: orders
+    credentials:
+      type: ServiceAccountKey
+      value: ${env:GCP_KEY_JSON}
+    batch_size: 1000

--- a/cli/examples/postgres_to_elasticsearch.yaml
+++ b/cli/examples/postgres_to_elasticsearch.yaml
@@ -1,0 +1,23 @@
+# YAML equivalent of `faucet-stream/examples/postgres_to_elasticsearch.rs`.
+version: 1
+name: postgres_to_elasticsearch
+
+source:
+  type: postgres
+  config:
+    connection_url: postgres://user:pass@localhost/app
+    query: SELECT id, title, body, tags FROM articles WHERE published = $1
+    params:
+      - true
+    max_connections: 8
+
+sink:
+  type: elasticsearch
+  config:
+    base_url: https://es.example.com:9200
+    index: articles
+    auth:
+      type: ApiKey
+      value: ${env:ES_API_KEY}
+    batch_size: 500
+    id_field: id

--- a/cli/examples/postgres_to_s3.yaml
+++ b/cli/examples/postgres_to_s3.yaml
@@ -1,0 +1,23 @@
+# YAML equivalent of `faucet-stream/examples/postgres_to_s3.rs`.
+version: 1
+name: postgres_to_s3
+
+source:
+  type: postgres
+  config:
+    connection_url: postgres://user:pass@localhost/app
+    query: SELECT * FROM events WHERE created_at < $1
+    params:
+      - "2026-01-01T00:00:00Z"
+    max_connections: 12
+
+sink:
+  type: s3
+  config:
+    bucket: my-archive-bucket
+    prefix: events/2025/
+    region: us-east-1
+    endpoint_url: https://s3.us-east-1.amazonaws.com
+    file_extension: .jsonl
+    max_records_per_file: 50000
+    concurrency: 16

--- a/cli/examples/postgres_to_snowflake.yaml
+++ b/cli/examples/postgres_to_snowflake.yaml
@@ -1,0 +1,28 @@
+# YAML equivalent of `faucet-stream/examples/postgres_to_snowflake.rs`.
+# The Rust example reads the private key from disk; in YAML use the file:
+# interpolation directive ($${file:PATH}) to inline the PEM body directly.
+version: 1
+name: postgres_to_snowflake
+
+source:
+  type: postgres
+  config:
+    connection_url: postgres://user:pass@localhost/app
+    query: SELECT id, email, created_at FROM users WHERE tenant_id = $1
+    params:
+      - acme
+    max_connections: 8
+
+sink:
+  type: snowflake
+  config:
+    account: xy12345.us-east-1
+    warehouse: INGEST_WH
+    database: ANALYTICS
+    schema: RAW
+    table: USERS
+    auth:
+      type: KeyPair
+      user: INGEST_USER
+      private_key_pem: ${file:./snowflake_key.pem}
+    batch_size: 500

--- a/cli/examples/redis_to_mysql.yaml
+++ b/cli/examples/redis_to_mysql.yaml
@@ -1,0 +1,27 @@
+# YAML equivalent of `faucet-stream/examples/redis_to_mysql.rs`.
+# Redis stream (consumer group) → MySQL JSON column.
+version: 1
+name: redis_to_mysql
+
+source:
+  type: redis
+  config:
+    url: redis://localhost:6379
+    source_type:
+      type: Stream
+      key: events:raw
+      group: archiver
+      consumer: worker-1
+      count: 1000
+    max_records: 100000
+
+sink:
+  type: mysql
+  config:
+    connection_url: mysql://user:pass@localhost/archive
+    table_name: events_raw
+    column_mapping:
+      type: json
+      column: payload
+    batch_size: 1000
+    max_connections: 10

--- a/cli/examples/redis_to_sqlite.yaml
+++ b/cli/examples/redis_to_sqlite.yaml
@@ -1,0 +1,23 @@
+# YAML equivalent of `faucet-stream/examples/redis_to_sqlite.rs`.
+# Redis list → SQLite with AutoMap column mapping.
+version: 1
+name: redis_to_sqlite
+
+source:
+  type: redis
+  config:
+    url: redis://localhost:6379
+    source_type:
+      type: List
+      key: jobs:pending
+    max_records: 10000
+
+sink:
+  type: sqlite
+  config:
+    database_url: sqlite:./cache.db
+    table_name: jobs
+    column_mapping:
+      type: auto_map
+    batch_size: 500
+    max_connections: 4

--- a/cli/examples/rest_streaming.yaml
+++ b/cli/examples/rest_streaming.yaml
@@ -1,0 +1,43 @@
+# YAML equivalent of `faucet-stream/examples/rest_streaming.rs`.
+#
+# Note: the Rust example uses `run_stream` to write pages as they arrive,
+# keeping memory bounded across multi-million-record feeds. The `faucet`
+# CLI today only runs the batch `Pipeline::run` path — for very large
+# feeds, either fall back to the Rust API or wait for the streaming-mode
+# follow-up issue.
+version: 1
+name: rest_streaming
+
+source:
+  type: rest
+  config:
+    base_url: https://api.example.com
+    path: /v1/comments
+    method: GET
+    name: comments
+    auth:
+      type: ApiKey
+      header: X-API-Key
+      value: ${env:API_KEY}
+    query_params: {}
+    pagination:
+      type: LinkHeader
+    records_path: $.items[*]
+    max_pages: 4294967295
+    request_delay: 0
+    timeout: 60
+    max_retries: 5
+    retry_backoff: 2
+    tolerated_http_errors: [429]
+    replication_method:
+      type: FullTable
+    primary_keys: []
+    partitions: []
+    schema_sample_size: 100
+
+sink:
+  type: jsonl
+  config:
+    path: comments.jsonl
+    append: false
+    pretty: false

--- a/cli/examples/rest_to_bigquery.yaml
+++ b/cli/examples/rest_to_bigquery.yaml
@@ -1,0 +1,47 @@
+# YAML equivalent of `faucet-stream/examples/rest_to_bigquery.rs`.
+# REST (Basic auth, page-number pagination) → BigQuery service account.
+version: 1
+name: rest_to_bigquery
+
+source:
+  type: rest
+  config:
+    base_url: https://api.example.com
+    path: /v1/events
+    method: GET
+    name: events
+    auth:
+      type: Basic
+      username: ${env:API_USER}
+      password: ${env:API_PASS}
+    query_params:
+      type: purchase
+    records_path: $.events[*]
+    pagination:
+      type: PageNumber
+      param_name: page
+      start_page: 1
+      page_size: 500
+      page_size_param: per_page
+    max_pages: 200
+    request_delay: 0
+    timeout: 45
+    max_retries: 5
+    retry_backoff: 2
+    tolerated_http_errors: [404]
+    replication_method:
+      type: FullTable
+    primary_keys: [event_id]
+    partitions: []
+    schema_sample_size: 100
+
+sink:
+  type: bigquery
+  config:
+    project_id: my-gcp-project
+    dataset_id: analytics
+    table_id: events
+    credentials:
+      type: ServiceAccountKeyPath
+      value: service-account.json
+    batch_size: 1000

--- a/cli/examples/rest_to_jsonl.yaml
+++ b/cli/examples/rest_to_jsonl.yaml
@@ -1,0 +1,40 @@
+# GitHub-style REST API → JSONL on disk.
+#
+# Required env vars:
+#   GITHUB_TOKEN — personal access token with `repo` scope
+#
+#   faucet run cli/examples/rest_to_jsonl.yaml
+version: 1
+name: github_issues_to_jsonl
+
+source:
+  type: rest
+  config:
+    base_url: https://api.github.com
+    path: /repos/PawanSikawat/faucet-stream/issues
+    method: GET
+    auth:
+      type: ApiKey
+      header: Authorization
+      value: Bearer ${env:GITHUB_TOKEN}
+    query_params:
+      state: open
+      per_page: "100"
+    pagination:
+      type: LinkHeader
+    max_retries: 3
+    retry_backoff: 1
+    tolerated_http_errors: []
+    replication_method:
+      type: FullTable
+    primary_keys: ["id"]
+    partitions: []
+    schema_sample_size: 100
+
+transforms:
+  - type: snake_case
+
+sink:
+  type: jsonl
+  config:
+    path: ./out/issues.jsonl

--- a/cli/examples/rest_to_postgres.yaml
+++ b/cli/examples/rest_to_postgres.yaml
@@ -1,0 +1,54 @@
+# REST API → PostgreSQL with incremental replication + a persisted state
+# bookmark, so re-runs only fetch new rows.
+#
+# Required env vars:
+#   PG_URL          — connection URL, e.g. postgres://user:pass@localhost/app
+#   STRIPE_TOKEN    — bearer token for the source API
+version: 1
+name: stripe_charges_to_postgres
+
+source:
+  type: rest
+  config:
+    base_url: https://api.stripe.com/v1
+    path: /charges
+    method: GET
+    auth:
+      type: ApiKey
+      header: Authorization
+      value: Bearer ${env:STRIPE_TOKEN}
+    query_params:
+      limit: "100"
+    pagination:
+      type: Cursor
+      next_token_path: $.next_page
+      param_name: starting_after
+    max_retries: 5
+    retry_backoff: 2
+    tolerated_http_errors: []
+    replication_method:
+      type: Incremental
+    replication_key: created
+    primary_keys: ["id"]
+    partitions: []
+    schema_sample_size: 200
+    state_key: stripe:charges
+
+transforms:
+  - type: snake_case
+
+sink:
+  type: postgres
+  config:
+    connection_url: ${env:PG_URL}
+    table_name: stripe_charges
+    column_mapping:
+      type: jsonb
+      column: data
+    batch_size: 500
+    max_connections: 5
+
+state:
+  type: file
+  config:
+    path: ./.faucet-state

--- a/cli/examples/rest_to_s3.yaml
+++ b/cli/examples/rest_to_s3.yaml
@@ -1,0 +1,45 @@
+# YAML equivalent of `faucet-stream/examples/rest_to_s3.rs`.
+# REST (ApiKey + offset pagination) → S3 sharded JSONL.
+version: 1
+name: rest_to_s3
+
+source:
+  type: rest
+  config:
+    base_url: https://api.example.com
+    path: /v1/events
+    method: GET
+    name: events
+    auth:
+      type: ApiKey
+      header: X-Auth-Token
+      value: ${env:AUTH_TOKEN}
+    query_params:
+      source: web
+    records_path: $.events[*]
+    pagination:
+      type: Offset
+      offset_param: offset
+      limit_param: limit
+      limit: 500
+      total_path: $.meta.total
+    request_delay: 0
+    timeout: 30
+    max_retries: 3
+    retry_backoff: 1
+    tolerated_http_errors: []
+    replication_method:
+      type: FullTable
+    primary_keys: []
+    partitions: []
+    schema_sample_size: 0
+
+sink:
+  type: s3
+  config:
+    bucket: my-data-lake
+    prefix: events/raw/
+    region: us-east-1
+    file_extension: .jsonl
+    max_records_per_file: 10000
+    concurrency: 8

--- a/cli/examples/rest_to_stdout_preview.yaml
+++ b/cli/examples/rest_to_stdout_preview.yaml
@@ -1,0 +1,33 @@
+# A read-only REST → stdout flow you can pipe into `jq` or another shell tool:
+#
+#   faucet run cli/examples/rest_to_stdout_preview.yaml | jq '.id'
+version: 1
+name: rest_preview
+
+source:
+  type: rest
+  config:
+    base_url: https://jsonplaceholder.typicode.com
+    path: /posts
+    method: GET
+    auth:
+      type: None
+    query_params: {}
+    pagination:
+      type: None
+    max_retries: 3
+    retry_backoff: 1
+    tolerated_http_errors: []
+    replication_method:
+      type: FullTable
+    primary_keys: ["id"]
+    partitions: []
+    schema_sample_size: 0
+
+sink:
+  type: stdout
+  config:
+    destination: stdout
+    format: json_lines
+    flush_per_record: true
+    max_records: 10

--- a/cli/examples/s3_to_bigquery.yaml
+++ b/cli/examples/s3_to_bigquery.yaml
@@ -1,0 +1,26 @@
+# Backfill JSONL files in S3 into a BigQuery table.
+#
+# Required env vars:
+#   AWS_*                            — standard AWS credential chain
+#   GOOGLE_APPLICATION_CREDENTIALS   — path to a BigQuery service-account JSON
+version: 1
+name: s3_jsonl_to_bigquery
+
+source:
+  type: s3
+  config:
+    bucket: my-data-lake
+    prefix: events/2026/
+    file_format:
+      type: json_lines
+    region: us-east-1
+
+sink:
+  type: bigquery
+  config:
+    project_id: my-gcp-project
+    dataset_id: analytics
+    table_id: events
+    credentials:
+      type: service_account_json
+      path: ${env:GOOGLE_APPLICATION_CREDENTIALS}

--- a/cli/examples/s3_to_mongodb.yaml
+++ b/cli/examples/s3_to_mongodb.yaml
@@ -1,0 +1,22 @@
+# YAML equivalent of `faucet-stream/examples/s3_to_mongodb.rs`.
+# S3 (JSON array files) → MongoDB.
+version: 1
+name: s3_to_mongodb
+
+source:
+  type: s3
+  config:
+    bucket: my-data-lake
+    prefix: snapshots/users/
+    region: us-west-2
+    file_format: json_array
+    max_objects: 500
+    concurrency: 8
+
+sink:
+  type: mongodb
+  config:
+    connection_uri: mongodb://localhost:27017
+    database: warehouse
+    collection: users
+    batch_size: 2000

--- a/cli/examples/s3_to_postgres.yaml
+++ b/cli/examples/s3_to_postgres.yaml
@@ -1,0 +1,26 @@
+# YAML equivalent of `faucet-stream/examples/s3_to_postgres.rs`.
+# S3 (JSON Lines + endpoint override) → PostgreSQL JSONB.
+version: 1
+name: s3_to_postgres
+
+source:
+  type: s3
+  config:
+    bucket: my-data-lake
+    prefix: events/2026/
+    region: us-east-1
+    endpoint_url: https://s3.us-east-1.amazonaws.com
+    file_format: json_lines
+    max_objects: 1000
+    concurrency: 16
+
+sink:
+  type: postgres
+  config:
+    connection_url: postgres://user:pass@localhost/warehouse
+    table_name: events_raw
+    column_mapping:
+      type: jsonb
+      column: payload
+    batch_size: 1000
+    max_connections: 10

--- a/cli/examples/s3_to_snowflake.yaml
+++ b/cli/examples/s3_to_snowflake.yaml
@@ -1,0 +1,27 @@
+# YAML equivalent of `faucet-stream/examples/s3_to_snowflake.rs`.
+# S3 (JSON Lines) → Snowflake (key-pair auth).
+version: 1
+name: s3_to_snowflake
+
+source:
+  type: s3
+  config:
+    bucket: my-data-lake
+    prefix: raw/events/
+    region: us-east-1
+    file_format: json_lines
+    concurrency: 16
+
+sink:
+  type: snowflake
+  config:
+    account: xy12345.us-east-1
+    warehouse: LOAD_WH
+    database: ANALYTICS
+    schema: RAW
+    table: EVENTS
+    auth:
+      type: KeyPair
+      user: LOADER
+      private_key_pem: ${file:./snowflake_key.pem}
+    batch_size: 1000

--- a/cli/examples/sqlite_to_csv.yaml
+++ b/cli/examples/sqlite_to_csv.yaml
@@ -1,0 +1,18 @@
+# Read a SQLite table into CSV. Demonstrates source/sink combinations that
+# don't require network access — handy in CI and locked-down environments.
+version: 1
+name: sqlite_to_csv
+
+source:
+  type: sqlite
+  config:
+    database_url: sqlite://./data/app.db
+    query: SELECT id, email, created_at FROM users ORDER BY id
+
+sink:
+  type: csv
+  config:
+    path: ./out/users.csv
+    delimiter: 44       # ','
+    write_headers: true
+    append: false

--- a/cli/examples/sqlite_to_jsonl.yaml
+++ b/cli/examples/sqlite_to_jsonl.yaml
@@ -1,0 +1,17 @@
+# YAML equivalent of `faucet-stream/examples/sqlite_to_jsonl.rs`.
+version: 1
+name: sqlite_to_jsonl
+
+source:
+  type: sqlite
+  config:
+    database_url: sqlite:./app.db
+    query: SELECT * FROM events ORDER BY ts
+    max_connections: 4
+
+sink:
+  type: jsonl
+  config:
+    path: events.jsonl
+    append: true
+    pretty: false

--- a/cli/examples/webhook_to_csv.yaml
+++ b/cli/examples/webhook_to_csv.yaml
@@ -1,0 +1,20 @@
+# YAML equivalent of `faucet-stream/examples/webhook_to_csv.rs`.
+# HTTP receiver → CSV file with semicolon delimiter.
+version: 1
+name: webhook_to_csv
+
+source:
+  type: webhook
+  config:
+    listen_addr: 127.0.0.1:9090
+    path: /inbox
+    max_payloads: 5000
+    timeout_secs: 120
+
+sink:
+  type: csv
+  config:
+    path: webhooks.csv
+    delimiter: 59     # b';'
+    write_headers: true
+    append: true

--- a/cli/examples/webhook_to_http.yaml
+++ b/cli/examples/webhook_to_http.yaml
@@ -1,0 +1,30 @@
+# YAML equivalent of `faucet-stream/examples/webhook_to_http.rs`.
+# HTTP receiver → HTTP forwarder.
+#
+# Limitation: HttpSinkAuth::Bearer is a newtype-in-tagged-enum variant and
+# cannot round-trip through serde today; this YAML falls back to Basic
+# auth. See the tracking issue for the wider connector serde fix-up.
+version: 1
+name: webhook_to_http
+
+source:
+  type: webhook
+  config:
+    listen_addr: 0.0.0.0:8080
+    path: /webhook
+    max_payloads: 10000
+    timeout_secs: 60
+
+sink:
+  type: http
+  config:
+    url: https://downstream.example.com/ingest
+    method: POST
+    auth:
+      type: Basic
+      username: ${env:INGEST_USER}
+      password: ${env:INGEST_PASS}
+    batch_mode:
+      type: Individual
+    max_retries: 3
+    concurrency: 16

--- a/cli/examples/webhook_to_postgres.yaml
+++ b/cli/examples/webhook_to_postgres.yaml
@@ -1,0 +1,23 @@
+# YAML equivalent of `faucet-stream/examples/webhook_to_postgres.rs`.
+# HTTP receiver → PostgreSQL JSONB.
+version: 1
+name: webhook_to_postgres
+
+source:
+  type: webhook
+  config:
+    listen_addr: 0.0.0.0:8080
+    path: /inbox
+    max_payloads: 50000
+    timeout_secs: 300
+
+sink:
+  type: postgres
+  config:
+    connection_url: postgres://user:pass@localhost/inbox
+    table_name: webhook_events
+    column_mapping:
+      type: jsonb
+      column: body
+    batch_size: 500
+    max_connections: 8

--- a/cli/examples/xml_to_mongodb.yaml
+++ b/cli/examples/xml_to_mongodb.yaml
@@ -1,0 +1,33 @@
+# YAML equivalent of `faucet-stream/examples/xml_to_mongodb.rs`.
+#
+# Limitation: XmlAuth::Bearer(String) is a newtype-in-tagged-enum variant
+# and can't round-trip through serde today. The Rust example uses Bearer
+# auth; this YAML falls back to None — adjust the upstream API or use the
+# library directly until the connector serde fix-up lands.
+version: 1
+name: xml_to_mongodb
+
+source:
+  type: xml
+  config:
+    base_url: https://feeds.example.com
+    path: /catalog
+    method: GET
+    auth:
+      type: None
+    query_params:
+      format: xml
+    records_element_path: catalog.products.product
+    pagination:
+      type: Offset
+      offset_param: offset
+      limit_param: limit
+      limit: 250
+
+sink:
+  type: mongodb
+  config:
+    connection_uri: mongodb://localhost:27017
+    database: warehouse
+    collection: catalog_items
+    batch_size: 1000

--- a/cli/examples/xml_to_s3.yaml
+++ b/cli/examples/xml_to_s3.yaml
@@ -1,0 +1,47 @@
+# YAML equivalent of `faucet-stream/examples/xml_to_s3.rs`.
+# SOAP-style POST XML → S3 (sharded JSONL with parallel uploads).
+#
+# Limitation: XmlStreamConfig::headers is `#[serde(skip)]`, so the custom
+# Content-Type and SOAPAction headers from the Rust example can't be set
+# from YAML today. Use the Rust API when SOAP headers are required.
+version: 1
+name: xml_to_s3
+
+source:
+  type: xml
+  config:
+    base_url: https://soap.example.com
+    path: /InventoryService
+    method: POST
+    auth:
+      type: Basic
+      username: ${env:SOAP_USER}
+      password: ${env:SOAP_PASS}
+    body: |
+      <?xml version="1.0"?>
+      <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+        <soap:Body>
+          <GetInventory><Region>us-east</Region></GetInventory>
+        </soap:Body>
+      </soap:Envelope>
+    query_params:
+      region: us-east
+    records_element_path: soap:Envelope.soap:Body.GetInventoryResponse.Items.Item
+    pagination:
+      type: PageNumber
+      param_name: page
+      start_page: 1
+      page_size: 500
+      page_size_param: size
+    max_pages: 50
+
+sink:
+  type: s3
+  config:
+    bucket: my-data-lake
+    prefix: xml/inventory/
+    region: us-east-1
+    endpoint_url: https://s3.us-east-1.amazonaws.com
+    file_extension: .jsonl
+    max_records_per_file: 5000
+    concurrency: 8

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1,0 +1,89 @@
+//! Argument parser shared by `main.rs` and the integration tests.
+
+use clap::{Parser, Subcommand};
+use std::path::PathBuf;
+
+/// `faucet` — config-driven runner for faucet-stream pipelines.
+#[derive(Debug, Parser)]
+#[command(name = "faucet", version, about, long_about = None)]
+pub struct Cli {
+    /// Override the global log level (also honors `FAUCET_LOG`).
+    #[arg(long, global = true, env = "FAUCET_LOG", default_value = "info")]
+    pub log_level: String,
+
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+/// Top-level subcommands.
+#[derive(Debug, Subcommand)]
+pub enum Command {
+    /// Execute a pipeline config end-to-end.
+    Run(RunArgs),
+    /// Parse + validate a pipeline config without running it.
+    Validate(ValidateArgs),
+    /// Print the JSON Schema for a specific connector.
+    Schema(SchemaArgs),
+    /// List every compiled-in source and sink with a one-line description.
+    List,
+    /// Run only the source side and print records to stdout (uses the stdout sink).
+    Preview(PreviewArgs),
+    /// Scaffold a starter `pipeline.yaml` to disk.
+    Init(InitArgs),
+}
+
+/// `faucet run` arguments.
+#[derive(Debug, Parser)]
+pub struct RunArgs {
+    /// Path to a `.yaml`, `.yml`, or `.json` pipeline config.
+    pub config: PathBuf,
+    /// Stop after fetching from the source — write nothing to the sink.
+    #[arg(long)]
+    pub dry_run: bool,
+    /// Stop after writing this many records to the sink. Default: unlimited.
+    #[arg(long)]
+    pub limit: Option<usize>,
+    /// Override the state-store directory (file backend only).
+    #[arg(long)]
+    pub state_path: Option<PathBuf>,
+}
+
+/// `faucet validate` arguments.
+#[derive(Debug, Parser)]
+pub struct ValidateArgs {
+    /// Path to a `.yaml`, `.yml`, or `.json` pipeline config.
+    pub config: PathBuf,
+}
+
+/// `faucet schema` arguments.
+#[derive(Debug, Parser)]
+pub struct SchemaArgs {
+    /// `source` or `sink`.
+    #[arg(value_parser = ["source", "sink"])]
+    pub kind: String,
+    /// Connector name (e.g. `rest`, `jsonl`, `bigquery`).
+    pub name: String,
+}
+
+/// `faucet preview` arguments.
+#[derive(Debug, Parser)]
+pub struct PreviewArgs {
+    /// Path to a `.yaml`, `.yml`, or `.json` pipeline config.
+    pub config: PathBuf,
+    /// Stop after this many records. Default: 10.
+    #[arg(long, default_value_t = 10)]
+    pub limit: usize,
+}
+
+/// `faucet init` arguments.
+#[derive(Debug, Parser)]
+pub struct InitArgs {
+    /// Name of the pipeline (used in the generated file's `name:` field).
+    pub name: String,
+    /// Output file path. Defaults to `pipeline.yaml`.
+    #[arg(long, default_value = "pipeline.yaml")]
+    pub output: PathBuf,
+    /// Overwrite the output file if it already exists.
+    #[arg(long)]
+    pub force: bool,
+}

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -1,0 +1,67 @@
+//! `faucet init` — scaffold a starter `pipeline.yaml`.
+
+use crate::cli::InitArgs;
+use crate::error::{CliError, CliResult};
+
+const TEMPLATE: &str = r#"version: 1
+name: {NAME}
+
+# Pull JSON records from a REST API. Replace base_url/path with your own
+# endpoint, and configure auth + pagination as needed. See:
+#   faucet schema source rest
+source:
+  type: rest
+  config:
+    base_url: https://api.example.com
+    path: /things
+    method: GET
+    # Auth — see `faucet schema source rest` for every supported variant.
+    # ApiKey sends the value in a request header; swap to {type: Basic,
+    # username, password} for HTTP basic, or {type: None} for no auth.
+    auth:
+      type: ApiKey
+      header: Authorization
+      value: Bearer ${env:API_TOKEN}
+    query_params: {}
+    pagination:
+      type: None
+    max_retries: 3
+    retry_backoff: 1
+    tolerated_http_errors: []
+    replication_method:
+      type: FullTable
+    primary_keys: []
+    partitions: []
+    schema_sample_size: 100
+
+# Optional transforms applied to every record, in declaration order.
+transforms:
+  - type: snake_case
+
+# Where the records go. Replace with bigquery/postgres/s3/etc as needed:
+#   faucet list
+sink:
+  type: jsonl
+  config:
+    path: ./out.jsonl
+
+# Optional. Tracks incremental-replication bookmarks across runs so the
+# pipeline resumes from where it left off.
+state:
+  type: file
+  config:
+    path: ./.faucet-state
+"#;
+
+/// Execute the `init` subcommand.
+pub async fn run(args: InitArgs) -> CliResult<()> {
+    if args.output.exists() && !args.force {
+        return Err(CliError::ScaffoldExists {
+            path: args.output.clone(),
+        });
+    }
+    let body = TEMPLATE.replace("{NAME}", &args.name);
+    std::fs::write(&args.output, body)?;
+    println!("wrote {}", args.output.display());
+    Ok(())
+}

--- a/cli/src/commands/list.rs
+++ b/cli/src/commands/list.rs
@@ -1,0 +1,31 @@
+//! `faucet list` — show every compiled-in source, sink, transform, and
+//! state-store backend so users can discover what their binary supports.
+
+use crate::error::CliResult;
+use crate::registry::{sink_descriptions, source_descriptions};
+use crate::state::available_state_kinds;
+use crate::transforms::available_transforms;
+
+/// Execute the `list` subcommand.
+pub async fn run() -> CliResult<()> {
+    println!("Sources:");
+    print_two_column(&source_descriptions());
+    println!();
+    println!("Sinks:");
+    print_two_column(&sink_descriptions());
+    println!();
+    println!("Transforms: {}", available_transforms().join(", "));
+    println!("State stores: {}", available_state_kinds().join(", "));
+    Ok(())
+}
+
+fn print_two_column(entries: &[(&'static str, &'static str)]) {
+    if entries.is_empty() {
+        println!("  (none — rebuild faucet-cli with the relevant features enabled)");
+        return;
+    }
+    let width = entries.iter().map(|(n, _)| n.len()).max().unwrap_or(0);
+    for (name, desc) in entries {
+        println!("  {name:<width$}  {desc}", width = width);
+    }
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,0 +1,21 @@
+//! Subcommand implementations. Each module owns its `run(...)` entry point
+//! and stays free of clap so the integration tests can drive it directly.
+
+pub mod init;
+pub mod list;
+pub mod preview;
+pub mod run;
+pub mod schema;
+pub mod validate;
+
+use crate::error::CliError;
+
+/// Render any [`CliError`] to a single line on stderr.
+pub fn report(err: &CliError) {
+    eprintln!("error: {err}");
+    let mut src = std::error::Error::source(err);
+    while let Some(s) = src {
+        eprintln!("  caused by: {s}");
+        src = std::error::Error::source(s);
+    }
+}

--- a/cli/src/commands/preview.rs
+++ b/cli/src/commands/preview.rs
@@ -1,0 +1,60 @@
+//! `faucet preview` — run only the source side and emit the first N records
+//! to stdout as JSON Lines.
+//!
+//! Requires the `sink-stdout` feature to be enabled.
+
+use crate::cli::PreviewArgs;
+use crate::config::PipelineConfig;
+use crate::error::CliResult;
+use crate::registry::build_source;
+use crate::transforms::compile_transforms;
+use faucet_core::transform::{apply_all, compile as compile_transform};
+
+#[cfg(feature = "sink-stdout")]
+use faucet_core::{Pipeline, Sink};
+
+/// Execute the `preview` subcommand.
+#[cfg(feature = "sink-stdout")]
+pub async fn run(args: PreviewArgs) -> CliResult<()> {
+    use faucet_sink_stdout::{StdoutFormat, StdoutSink, StdoutSinkConfig};
+    let cfg = PipelineConfig::from_path(&args.config)?;
+    let source = build_source(&cfg.source.kind, cfg.source.config.clone()).await?;
+
+    let transforms = compile_transforms(&cfg.transforms)?;
+    let records = source.fetch_all().await?;
+    let records: Vec<_> = if transforms.is_empty() {
+        records
+    } else {
+        let compiled = transforms
+            .iter()
+            .map(compile_transform)
+            .collect::<Result<Vec<_>, _>>()?;
+        records
+            .into_iter()
+            .map(|r| apply_all(r, &compiled))
+            .collect()
+    };
+
+    let limited: Vec<_> = records.into_iter().take(args.limit).collect();
+    let sink = StdoutSink::new(
+        StdoutSinkConfig::new()
+            .format(StdoutFormat::JsonLines)
+            .flush_per_record(true),
+    );
+    sink.write_batch(&limited).await?;
+    sink.flush().await?;
+
+    // Suppress unused-import warning on the path that builds Pipeline.
+    let _ = std::marker::PhantomData::<Pipeline<'_, dyn faucet_core::Source, dyn Sink>>;
+    Ok(())
+}
+
+#[cfg(not(feature = "sink-stdout"))]
+pub async fn run(_args: PreviewArgs) -> CliResult<()> {
+    Err(crate::error::CliError::UnknownConnector {
+        kind: "sink",
+        name: "stdout".into(),
+        available: "(preview requires faucet-cli to be built with the 'sink-stdout' feature)"
+            .into(),
+    })
+}

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -1,0 +1,232 @@
+//! `faucet run` — load a pipeline config, build the connectors, and execute.
+
+use crate::cli::RunArgs;
+use crate::config::PipelineConfig;
+use crate::error::CliResult;
+use crate::registry::{build_sink, build_source};
+use crate::state::build_state_store;
+use crate::transforms::compile_transforms;
+use async_trait::async_trait;
+use faucet_core::transform::{CompiledTransform, apply_all, compile as compile_transform};
+use faucet_core::{FaucetError, Pipeline, Sink, Source, StateStore};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Adapter that applies a list of compiled transforms to every record before
+/// the sink sees them.
+struct TransformingSource {
+    inner: Box<dyn Source>,
+    transforms: Vec<CompiledTransform>,
+}
+
+#[async_trait]
+impl Source for TransformingSource {
+    async fn fetch_with_context(
+        &self,
+        ctx: &HashMap<String, Value>,
+    ) -> Result<Vec<Value>, FaucetError> {
+        let records = self.inner.fetch_with_context(ctx).await?;
+        Ok(records
+            .into_iter()
+            .map(|r| apply_all(r, &self.transforms))
+            .collect())
+    }
+
+    async fn fetch_with_context_incremental(
+        &self,
+        ctx: &HashMap<String, Value>,
+    ) -> Result<(Vec<Value>, Option<Value>), FaucetError> {
+        let (records, bookmark) = self.inner.fetch_with_context_incremental(ctx).await?;
+        let transformed = records
+            .into_iter()
+            .map(|r| apply_all(r, &self.transforms))
+            .collect();
+        Ok((transformed, bookmark))
+    }
+
+    fn state_key(&self) -> Option<String> {
+        self.inner.state_key()
+    }
+
+    async fn apply_start_bookmark(&self, bookmark: Value) -> Result<(), FaucetError> {
+        self.inner.apply_start_bookmark(bookmark).await
+    }
+}
+
+/// Sink wrapper that drops any records past a soft cap. Used by `--limit`.
+struct LimitedSink {
+    inner: Box<dyn Sink>,
+    remaining: AtomicUsize,
+}
+
+#[async_trait]
+impl Sink for LimitedSink {
+    async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
+        let remaining = self.remaining.load(Ordering::Relaxed);
+        if remaining == 0 {
+            return Ok(0);
+        }
+        let take = remaining.min(records.len());
+        let slice = &records[..take];
+        let written = self.inner.write_batch(slice).await?;
+        // Subtract however many actually landed, never going below zero.
+        self.remaining
+            .fetch_sub(written.min(remaining), Ordering::Relaxed);
+        Ok(written)
+    }
+
+    async fn flush(&self) -> Result<(), FaucetError> {
+        self.inner.flush().await
+    }
+}
+
+/// Sink that swallows every batch — used by `--dry-run` to exercise the source
+/// without touching the configured sink.
+struct CountingSink {
+    seen: AtomicUsize,
+}
+
+#[async_trait]
+impl Sink for CountingSink {
+    async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
+        self.seen.fetch_add(records.len(), Ordering::Relaxed);
+        Ok(records.len())
+    }
+}
+
+/// Execute the `run` subcommand.
+pub async fn run(args: RunArgs) -> CliResult<()> {
+    let cfg = PipelineConfig::from_path(&args.config)?;
+    let pipeline_name = cfg.name.clone().unwrap_or_else(|| {
+        args.config
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("pipeline")
+            .to_owned()
+    });
+
+    let source = build_source(&cfg.source.kind, cfg.source.config.clone()).await?;
+    let transforms = compile_transforms(&cfg.transforms)?;
+    let source: Box<dyn Source> = if transforms.is_empty() {
+        source
+    } else {
+        let compiled = transforms
+            .iter()
+            .map(compile_transform)
+            .collect::<Result<Vec<_>, _>>()?;
+        Box::new(TransformingSource {
+            inner: source,
+            transforms: compiled,
+        })
+    };
+
+    let sink: Box<dyn Sink> = if args.dry_run {
+        tracing::info!("dry-run mode — sink writes are suppressed");
+        Box::new(CountingSink {
+            seen: AtomicUsize::new(0),
+        })
+    } else {
+        build_sink(&cfg.sink.kind, cfg.sink.config.clone()).await?
+    };
+
+    let sink: Box<dyn Sink> = match args.limit {
+        Some(n) => Box::new(LimitedSink {
+            inner: sink,
+            remaining: AtomicUsize::new(n),
+        }),
+        None => sink,
+    };
+
+    let state = match (&cfg.state, &args.state_path) {
+        (Some(spec), None) => Some(build_state_store(spec).await?),
+        (None, Some(path)) => {
+            // Default to file backend at the override path when the YAML has no
+            // state: block but the user passed `--state-path` anyway.
+            Some(state_from_override(path).await?)
+        }
+        (Some(spec), Some(path)) => {
+            // Honour explicit override on top of the configured backend.
+            if spec.kind == "file" {
+                Some(state_from_override(path).await?)
+            } else {
+                tracing::warn!(
+                    state = %spec.kind,
+                    "--state-path is only meaningful for the 'file' backend; ignoring override"
+                );
+                Some(build_state_store(spec).await?)
+            }
+        }
+        (None, None) => None,
+    };
+
+    let pipeline = Pipeline::new(source.as_ref(), sink.as_ref());
+    let pipeline = match state {
+        Some(store) => pipeline.with_state_store(Arc::clone(&store)),
+        None => pipeline,
+    };
+
+    let result = pipeline.run().await?;
+
+    tracing::info!(
+        pipeline = %pipeline_name,
+        records_written = result.records_written,
+        has_bookmark = result.bookmark.is_some(),
+        "pipeline completed"
+    );
+    println!(
+        "{}: wrote {} record{}",
+        pipeline_name,
+        result.records_written,
+        if result.records_written == 1 { "" } else { "s" }
+    );
+    Ok(())
+}
+
+async fn state_from_override(path: &std::path::Path) -> CliResult<Arc<dyn StateStore>> {
+    Ok(Arc::new(faucet_core::FileStateStore::new(path)) as Arc<dyn StateStore>)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn limited_sink_caps_writes() {
+        struct CountingInner(std::sync::Mutex<Vec<Value>>);
+        #[async_trait]
+        impl Sink for CountingInner {
+            async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
+                self.0.lock().unwrap().extend(records.iter().cloned());
+                Ok(records.len())
+            }
+        }
+        let inner: Box<dyn Sink> = Box::new(CountingInner(std::sync::Mutex::new(Vec::new())));
+        let sink = LimitedSink {
+            inner,
+            remaining: AtomicUsize::new(2),
+        };
+        let r1 = sink
+            .write_batch(&[json!({"a": 1}), json!({"a": 2}), json!({"a": 3})])
+            .await
+            .unwrap();
+        assert_eq!(r1, 2);
+        let r2 = sink.write_batch(&[json!({"a": 4})]).await.unwrap();
+        assert_eq!(r2, 0);
+    }
+
+    #[tokio::test]
+    async fn counting_sink_swallows_all_records() {
+        let sink = CountingSink {
+            seen: AtomicUsize::new(0),
+        };
+        let n = sink
+            .write_batch(&[json!({}), json!({}), json!({})])
+            .await
+            .unwrap();
+        assert_eq!(n, 3);
+        assert_eq!(sink.seen.load(Ordering::Relaxed), 3);
+    }
+}

--- a/cli/src/commands/schema.rs
+++ b/cli/src/commands/schema.rs
@@ -1,0 +1,23 @@
+//! `faucet schema` — print the JSON Schema for a connector's config.
+
+use crate::cli::SchemaArgs;
+use crate::error::CliResult;
+use crate::registry::{sink_schema, source_schema};
+
+/// Execute the `schema` subcommand.
+pub async fn run(args: SchemaArgs) -> CliResult<()> {
+    let schema = match args.kind.as_str() {
+        "source" => source_schema(&args.name)?,
+        "sink" => sink_schema(&args.name)?,
+        // clap restricts this via value_parser, but keep the safety net.
+        other => {
+            return Err(crate::error::CliError::ParseConfig {
+                path: std::path::PathBuf::from(other),
+                message: format!("kind must be 'source' or 'sink', got {other}"),
+            });
+        }
+    };
+    let body = serde_json::to_string_pretty(&schema).unwrap_or_else(|_| schema.to_string());
+    println!("{body}");
+    Ok(())
+}

--- a/cli/src/commands/validate.rs
+++ b/cli/src/commands/validate.rs
@@ -1,0 +1,46 @@
+//! `faucet validate` — parse + validate a pipeline config without running.
+
+use crate::cli::ValidateArgs;
+use crate::config::PipelineConfig;
+use crate::error::CliResult;
+use crate::registry::{sink_schema, source_schema};
+use crate::state::available_state_kinds;
+use crate::transforms::available_transforms;
+
+/// Execute the `validate` subcommand.
+pub async fn run(args: ValidateArgs) -> CliResult<()> {
+    let cfg = PipelineConfig::from_path(&args.config)?;
+    // Verifying the schema lookup also catches unknown connector kinds.
+    source_schema(&cfg.source.kind)?;
+    sink_schema(&cfg.sink.kind)?;
+
+    for t in &cfg.transforms {
+        if !available_transforms().contains(&t.kind.as_str()) {
+            return Err(crate::error::CliError::UnknownTransform {
+                name: t.kind.clone(),
+                available: available_transforms().join(", "),
+            });
+        }
+    }
+    if let Some(state) = &cfg.state
+        && !available_state_kinds().contains(&state.kind.as_str())
+    {
+        return Err(crate::error::CliError::UnknownStateStore {
+            name: state.kind.clone(),
+            available: available_state_kinds().join(", "),
+        });
+    }
+
+    println!(
+        "ok: '{}' source={} sink={} transforms={} state={}",
+        cfg.name.as_deref().unwrap_or("(unnamed)"),
+        cfg.source.kind,
+        cfg.sink.kind,
+        cfg.transforms.len(),
+        cfg.state
+            .as_ref()
+            .map(|s| s.kind.as_str())
+            .unwrap_or("(none)"),
+    );
+    Ok(())
+}

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1,0 +1,252 @@
+//! Parsed `pipeline.yaml` / `pipeline.json` schema.
+//!
+//! The wire format is intentionally loose: every connector keeps its own
+//! config schema, and the CLI threads a `serde_json::Value` through to the
+//! connector's `serde::Deserialize` impl. That keeps this struct stable as
+//! new fields are added to individual connectors without needing CLI work.
+
+use crate::error::{CliError, CliResult};
+use crate::interpolate::interpolate;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+
+/// Top-level pipeline definition.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PipelineConfig {
+    /// Config-format version. Currently always `1`.
+    #[serde(default = "default_version")]
+    pub version: u32,
+
+    /// Optional human-readable name (used in logs and error messages).
+    #[serde(default)]
+    pub name: Option<String>,
+
+    /// The source connector — fetches records.
+    pub source: ConnectorSpec,
+
+    /// Record transforms applied between source and sink, in declaration order.
+    #[serde(default)]
+    pub transforms: Vec<TransformSpec>,
+
+    /// The sink connector — writes records.
+    pub sink: ConnectorSpec,
+
+    /// Optional state store for incremental-replication bookmarks.
+    #[serde(default)]
+    pub state: Option<StateStoreSpec>,
+}
+
+fn default_version() -> u32 {
+    1
+}
+
+/// A `{ type, config }` block, the universal shape for both sources and sinks.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConnectorSpec {
+    /// Connector type — matches the suffix of the underlying crate
+    /// (e.g. `rest` for `faucet-source-rest`).
+    #[serde(rename = "type")]
+    pub kind: String,
+
+    /// Connector-specific config object. Passed through verbatim to the
+    /// connector's `serde::Deserialize` impl.
+    #[serde(default = "empty_object")]
+    pub config: Value,
+}
+
+fn empty_object() -> Value {
+    Value::Object(Default::default())
+}
+
+/// A single transform declaration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransformSpec {
+    /// Built-in transform identifier: `flatten`, `rename_keys`, `snake_case`.
+    #[serde(rename = "type")]
+    pub kind: String,
+
+    /// Transform-specific config object (e.g. `{ separator: "__" }` for flatten).
+    #[serde(default = "empty_object")]
+    pub config: Value,
+}
+
+/// State-store backend selector.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StateStoreSpec {
+    /// Store type: `file`, `memory`, `redis`, or `postgres`.
+    #[serde(rename = "type")]
+    pub kind: String,
+
+    /// Store-specific config.
+    #[serde(default = "empty_object")]
+    pub config: Value,
+}
+
+impl PipelineConfig {
+    /// Load a pipeline config from disk. The file extension determines the
+    /// parser: `.yaml` / `.yml` → YAML, `.json` → JSON. Other extensions are
+    /// rejected.
+    pub fn from_path(path: impl AsRef<Path>) -> CliResult<Self> {
+        let path = path.as_ref();
+        let raw = std::fs::read_to_string(path).map_err(|source| CliError::ReadConfig {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        let interpolated = interpolate(&raw)?;
+        Self::from_text(&interpolated, path)
+    }
+
+    /// Parse an interpolated config string. `path` is only used for error
+    /// messages and to pick the parser based on extension.
+    pub fn from_text(text: &str, path: &Path) -> CliResult<Self> {
+        let ext = path
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(str::to_ascii_lowercase);
+        let cfg: PipelineConfig = match ext.as_deref() {
+            Some("yaml" | "yml") => {
+                serde_yaml::from_str(text).map_err(|e| CliError::ParseConfig {
+                    path: path.to_path_buf(),
+                    message: e.to_string(),
+                })?
+            }
+            Some("json") => serde_json::from_str(text).map_err(|e| CliError::ParseConfig {
+                path: path.to_path_buf(),
+                message: e.to_string(),
+            })?,
+            _ => {
+                return Err(CliError::UnknownExtension {
+                    path: path.to_path_buf(),
+                });
+            }
+        };
+        if cfg.version != 1 {
+            return Err(CliError::ParseConfig {
+                path: path.to_path_buf(),
+                message: format!(
+                    "unsupported pipeline version {}, only version 1 is recognised",
+                    cfg.version
+                ),
+            });
+        }
+        Ok(cfg)
+    }
+}
+
+/// Convenience: parse a config from text using a synthetic path so the right
+/// parser is selected. Used by tests and the `validate --stdin` flow.
+pub fn parse_with_extension(text: &str, ext: &str) -> CliResult<PipelineConfig> {
+    let synthetic = PathBuf::from(format!("pipeline.{ext}"));
+    PipelineConfig::from_text(text, &synthetic)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parses_minimal_yaml() {
+        let yaml = r#"
+version: 1
+source:
+  type: rest
+  config:
+    base_url: https://api.example.com
+sink:
+  type: jsonl
+  config:
+    path: ./out.jsonl
+"#;
+        let cfg = parse_with_extension(yaml, "yaml").unwrap();
+        assert_eq!(cfg.source.kind, "rest");
+        assert_eq!(cfg.sink.kind, "jsonl");
+        assert_eq!(cfg.transforms.len(), 0);
+        assert!(cfg.state.is_none());
+    }
+
+    #[test]
+    fn parses_minimal_json() {
+        let raw = r#"{
+            "version": 1,
+            "source": {"type": "rest", "config": {}},
+            "sink": {"type": "jsonl", "config": {"path": "./out.jsonl"}}
+        }"#;
+        let cfg = parse_with_extension(raw, "json").unwrap();
+        assert_eq!(cfg.source.kind, "rest");
+    }
+
+    #[test]
+    fn rejects_unknown_extension() {
+        let text = "version: 1\n";
+        let err = PipelineConfig::from_text(text, Path::new("pipeline.toml")).unwrap_err();
+        assert!(matches!(err, CliError::UnknownExtension { .. }));
+    }
+
+    #[test]
+    fn rejects_future_version() {
+        let yaml = r#"
+version: 99
+source: { type: rest, config: {} }
+sink: { type: jsonl, config: { path: "./x" } }
+"#;
+        let err = parse_with_extension(yaml, "yaml").unwrap_err();
+        match err {
+            CliError::ParseConfig { message, .. } => assert!(message.contains("version 99")),
+            other => panic!("expected ParseConfig, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn transforms_and_state_round_trip() {
+        let yaml = r#"
+version: 1
+source:
+  type: rest
+  config: {}
+transforms:
+  - type: snake_case
+  - type: flatten
+    config: { separator: "__" }
+sink:
+  type: jsonl
+  config: { path: "./out.jsonl" }
+state:
+  type: file
+  config: { path: "./.faucet-state" }
+"#;
+        let cfg = parse_with_extension(yaml, "yaml").unwrap();
+        assert_eq!(cfg.transforms.len(), 2);
+        assert_eq!(cfg.transforms[0].kind, "snake_case");
+        assert_eq!(cfg.transforms[1].kind, "flatten");
+        assert_eq!(cfg.transforms[1].config, json!({"separator": "__"}));
+        let state = cfg.state.unwrap();
+        assert_eq!(state.kind, "file");
+    }
+
+    #[test]
+    fn from_path_interpolates_env_var() {
+        unsafe { std::env::set_var("FAUCET_CFG_URL", "https://x.example") };
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pipeline.yaml");
+        std::fs::write(
+            &path,
+            r#"
+version: 1
+source:
+  type: rest
+  config:
+    base_url: ${env:FAUCET_CFG_URL}
+sink:
+  type: jsonl
+  config:
+    path: ./out.jsonl
+"#,
+        )
+        .unwrap();
+        let cfg = PipelineConfig::from_path(&path).unwrap();
+        assert_eq!(cfg.source.config["base_url"], "https://x.example");
+        unsafe { std::env::remove_var("FAUCET_CFG_URL") };
+    }
+}

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -1,0 +1,88 @@
+//! CLI-level error type. Wraps every failure mode the binary surfaces so
+//! `main()` can render a single, user-readable line per failure.
+
+use std::path::PathBuf;
+use thiserror::Error;
+
+/// Convenience alias used by every CLI module.
+pub type CliResult<T> = Result<T, CliError>;
+
+/// Top-level error variants for the `faucet` binary.
+#[derive(Debug, Error)]
+pub enum CliError {
+    /// Failed to read a config file from disk.
+    #[error("failed to read config file '{path}': {source}")]
+    ReadConfig {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// The config file extension is neither `.yaml`/`.yml` nor `.json`.
+    #[error(
+        "unsupported config extension for '{path}' — use .yaml, .yml, or .json (mixed JSON/YAML in a single file is not allowed)"
+    )]
+    UnknownExtension { path: PathBuf },
+
+    /// Failed to parse the raw config text after interpolation.
+    #[error("failed to parse config '{path}': {message}")]
+    ParseConfig { path: PathBuf, message: String },
+
+    /// An `${env:VAR}` reference could not be resolved.
+    #[error("missing environment variable '{var}' referenced in config at '{location}'")]
+    MissingEnvVar { var: String, location: String },
+
+    /// A `${file:PATH}` reference could not be read.
+    #[error("failed to read interpolated file '{}' referenced in config: {source}", path.display())]
+    ReadInterpolatedFile {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// An interpolation directive used an unknown prefix.
+    #[error(
+        "unsupported interpolation prefix '{prefix}' in '{full}' — expected env, file, or secret"
+    )]
+    UnknownInterpolationPrefix { prefix: String, full: String },
+
+    /// The named connector is unknown (or its feature flag is disabled in this build).
+    #[error("unknown {kind} '{name}'. Available: {available}")]
+    UnknownConnector {
+        kind: &'static str,
+        name: String,
+        available: String,
+    },
+
+    /// The state-store type referenced in the config is unknown or not compiled in.
+    #[error("unknown state store '{name}'. Available: {available}")]
+    UnknownStateStore { name: String, available: String },
+
+    /// A transform type referenced in the config is not recognised.
+    #[error("unknown transform '{name}'. Available: {available}")]
+    UnknownTransform { name: String, available: String },
+
+    /// The transform config block could not be deserialized into the expected shape.
+    #[error("invalid transform '{name}': {message}")]
+    InvalidTransform { name: String, message: String },
+
+    /// A connector config object failed to deserialize.
+    #[error("invalid config for {kind} '{name}': {message}")]
+    InvalidConnectorConfig {
+        kind: &'static str,
+        name: String,
+        message: String,
+    },
+
+    /// A scaffold target already exists.
+    #[error("refusing to overwrite existing file '{path}' — pass --force to overwrite")]
+    ScaffoldExists { path: PathBuf },
+
+    /// Pass-through for failures bubbling up from `faucet-core` or a connector.
+    #[error(transparent)]
+    Faucet(#[from] faucet_core::FaucetError),
+
+    /// Pass-through I/O error.
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+}

--- a/cli/src/interpolate.rs
+++ b/cli/src/interpolate.rs
@@ -1,0 +1,165 @@
+//! `${env:VAR}` / `${file:PATH}` interpolation.
+//!
+//! Runs over the raw config text *before* JSON/YAML parsing so the resolved
+//! values can be substituted into any string value — including ones that
+//! become structured types after parsing (numbers, durations, paths).
+//!
+//! Supported directives:
+//!
+//! | Form               | Resolves to |
+//! |--------------------|-------------|
+//! | `${env:VAR}`       | the value of environment variable `VAR` |
+//! | `${file:PATH}`     | the contents of the file at `PATH` (trimmed of trailing whitespace) |
+//! | `${secret:VAR}`    | reserved — currently aliased to `${env:VAR}`. A future secrets backend will own this prefix. |
+//!
+//! Escapes: a literal `${` can be written as `$${` and is decoded by the
+//! interpolator. Anything that doesn't match `${prefix:body}` is left as-is.
+
+use crate::error::{CliError, CliResult};
+use std::path::PathBuf;
+
+/// Resolve every `${prefix:body}` token in `input`. Returns the substituted
+/// string or the first error encountered.
+pub fn interpolate(input: &str) -> CliResult<String> {
+    let mut out = String::with_capacity(input.len());
+    let bytes = input.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        // Escape: $${ → ${
+        if bytes[i] == b'$' && i + 2 < bytes.len() && bytes[i + 1] == b'$' && bytes[i + 2] == b'{' {
+            out.push('$');
+            i += 2;
+            continue;
+        }
+        if bytes[i] == b'$' && i + 1 < bytes.len() && bytes[i + 1] == b'{' {
+            // Locate matching `}` — interpolations cannot nest.
+            let start = i + 2;
+            let Some(rel_end) = input[start..].find('}') else {
+                // No closing brace → emit literally and stop scanning for
+                // directives so we don't quietly swallow content.
+                out.push_str(&input[i..]);
+                break;
+            };
+            let end = start + rel_end;
+            let directive = &input[start..end];
+            let resolved = resolve_directive(directive)?;
+            out.push_str(&resolved);
+            i = end + 1;
+            continue;
+        }
+        out.push(input[i..].chars().next().unwrap());
+        i += input[i..].chars().next().unwrap().len_utf8();
+    }
+    Ok(out)
+}
+
+fn resolve_directive(directive: &str) -> CliResult<String> {
+    let (prefix, body) =
+        directive
+            .split_once(':')
+            .ok_or_else(|| CliError::UnknownInterpolationPrefix {
+                prefix: directive.to_owned(),
+                full: format!("${{{directive}}}"),
+            })?;
+    match prefix {
+        "env" | "secret" => std::env::var(body).map_err(|_| CliError::MissingEnvVar {
+            var: body.to_owned(),
+            location: format!("${{{directive}}}"),
+        }),
+        "file" => {
+            let path = PathBuf::from(body);
+            let bytes = std::fs::read(&path).map_err(|source| CliError::ReadInterpolatedFile {
+                path: path.clone(),
+                source,
+            })?;
+            let text = String::from_utf8_lossy(&bytes);
+            Ok(text.trim_end().to_owned())
+        }
+        other => Err(CliError::UnknownInterpolationPrefix {
+            prefix: other.to_owned(),
+            full: format!("${{{directive}}}"),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn passes_through_text_with_no_directives() {
+        let out = interpolate("just a string").unwrap();
+        assert_eq!(out, "just a string");
+    }
+
+    #[test]
+    fn substitutes_env_var() {
+        // SAFETY: tests run sequentially within this module via tokio's default
+        // single-thread runtime when used with #[tokio::test], and these
+        // synchronous tests don't share env state across cases.
+        unsafe { std::env::set_var("FAUCET_TEST_VAR", "hello") };
+        let out = interpolate("token=${env:FAUCET_TEST_VAR}").unwrap();
+        assert_eq!(out, "token=hello");
+        unsafe { std::env::remove_var("FAUCET_TEST_VAR") };
+    }
+
+    #[test]
+    fn missing_env_var_is_an_error() {
+        unsafe { std::env::remove_var("FAUCET_TEST_MISSING") };
+        let err = interpolate("token=${env:FAUCET_TEST_MISSING}").unwrap_err();
+        match err {
+            CliError::MissingEnvVar { var, .. } => assert_eq!(var, "FAUCET_TEST_MISSING"),
+            other => panic!("expected MissingEnvVar, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn secret_prefix_is_env_alias_for_now() {
+        unsafe { std::env::set_var("FAUCET_SECRET_VAR", "shh") };
+        let out = interpolate("${secret:FAUCET_SECRET_VAR}").unwrap();
+        assert_eq!(out, "shh");
+        unsafe { std::env::remove_var("FAUCET_SECRET_VAR") };
+    }
+
+    #[test]
+    fn reads_file_directive_and_trims_trailing_newline() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("token.txt");
+        std::fs::write(&path, "abcdef\n").unwrap();
+        let raw = format!("token=${{file:{}}}", path.display());
+        let out = interpolate(&raw).unwrap();
+        assert_eq!(out, "token=abcdef");
+    }
+
+    #[test]
+    fn unknown_prefix_is_reported() {
+        let err = interpolate("${weird:thing}").unwrap_err();
+        match err {
+            CliError::UnknownInterpolationPrefix { prefix, .. } => assert_eq!(prefix, "weird"),
+            other => panic!("expected UnknownInterpolationPrefix, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn dollar_dollar_brace_is_escaped() {
+        // `$${env:VAR}` should pass through as `${env:VAR}` without resolving.
+        let out = interpolate("path=$${env:VAR}").unwrap();
+        assert_eq!(out, "path=${env:VAR}");
+    }
+
+    #[test]
+    fn unclosed_directive_is_left_literal() {
+        let out = interpolate("hello ${env:NOPE").unwrap();
+        assert_eq!(out, "hello ${env:NOPE");
+    }
+
+    #[test]
+    fn multiple_directives_resolve_in_order() {
+        unsafe { std::env::set_var("FAUCET_A", "one") };
+        unsafe { std::env::set_var("FAUCET_B", "two") };
+        let out = interpolate("${env:FAUCET_A}-${env:FAUCET_B}").unwrap();
+        assert_eq!(out, "one-two");
+        unsafe { std::env::remove_var("FAUCET_A") };
+        unsafe { std::env::remove_var("FAUCET_B") };
+    }
+}

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,0 +1,21 @@
+//! # faucet-cli
+//!
+//! A config-driven runner for [`faucet-stream`](https://docs.rs/faucet-stream)
+//! pipelines.  Define a source, optional transforms, a sink, and (optionally)
+//! a state store in a YAML or JSON file, then run it with the `faucet` binary —
+//! no Rust code required.
+//!
+//! The library half of this crate exposes the same building blocks the binary
+//! uses (config parsing, env interpolation, the connector registry) so that
+//! integrations and tests can reuse them.
+
+pub mod cli;
+pub mod commands;
+pub mod config;
+pub mod error;
+pub mod interpolate;
+pub mod registry;
+pub mod state;
+pub mod transforms;
+
+pub use error::{CliError, CliResult};

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,0 +1,34 @@
+//! `faucet` — binary entry point.
+
+use clap::Parser;
+use faucet_cli::cli::{Cli, Command};
+use faucet_cli::commands;
+use tracing_subscriber::EnvFilter;
+
+#[tokio::main]
+async fn main() {
+    let cli = Cli::parse();
+    install_tracing(&cli.log_level);
+
+    let result = match cli.command {
+        Command::Run(args) => commands::run::run(args).await,
+        Command::Validate(args) => commands::validate::run(args).await,
+        Command::Schema(args) => commands::schema::run(args).await,
+        Command::List => commands::list::run().await,
+        Command::Preview(args) => commands::preview::run(args).await,
+        Command::Init(args) => commands::init::run(args).await,
+    };
+
+    if let Err(err) = result {
+        commands::report(&err);
+        std::process::exit(1);
+    }
+}
+
+fn install_tracing(level: &str) {
+    let filter = EnvFilter::try_new(level).unwrap_or_else(|_| EnvFilter::new("info"));
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_writer(std::io::stderr)
+        .try_init();
+}

--- a/cli/src/registry.rs
+++ b/cli/src/registry.rs
@@ -1,0 +1,413 @@
+//! Feature-gated dispatch from a string `type` to a concrete connector.
+//!
+//! Every arm in this file is guarded by the matching `source-*` / `sink-*`
+//! Cargo feature so users can build a slim binary with just the connectors
+//! they need. The string keys here are the public contract of the CLI's
+//! `type:` field in YAML/JSON pipeline configs.
+
+use crate::error::{CliError, CliResult};
+use faucet_core::{Sink, Source};
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+
+/// Build a [`Source`] trait object from a `(kind, config)` pair.
+pub async fn build_source(kind: &str, config: Value) -> CliResult<Box<dyn Source>> {
+    match kind {
+        #[cfg(feature = "source-rest")]
+        "rest" => {
+            let cfg = decode::<faucet_source_rest::RestStreamConfig>("source", "rest", config)?;
+            Ok(Box::new(faucet_source_rest::RestStream::new(cfg)?))
+        }
+        #[cfg(feature = "source-graphql")]
+        "graphql" => {
+            let cfg =
+                decode::<faucet_source_graphql::GraphqlStreamConfig>("source", "graphql", config)?;
+            Ok(Box::new(faucet_source_graphql::GraphqlStream::new(cfg)))
+        }
+        #[cfg(feature = "source-xml")]
+        "xml" => {
+            let cfg = decode::<faucet_source_xml::XmlStreamConfig>("source", "xml", config)?;
+            Ok(Box::new(faucet_source_xml::XmlStream::new(cfg)))
+        }
+        #[cfg(feature = "source-grpc")]
+        "grpc" => {
+            let cfg = decode::<faucet_source_grpc::GrpcStreamConfig>("source", "grpc", config)?;
+            Ok(Box::new(faucet_source_grpc::GrpcStream::new(cfg)?))
+        }
+        #[cfg(feature = "source-postgres")]
+        "postgres" => {
+            let cfg = decode::<faucet_source_postgres::PostgresSourceConfig>(
+                "source", "postgres", config,
+            )?;
+            Ok(Box::new(
+                faucet_source_postgres::PostgresSource::new(cfg).await?,
+            ))
+        }
+        #[cfg(feature = "source-mysql")]
+        "mysql" => {
+            let cfg = decode::<faucet_source_mysql::MysqlSourceConfig>("source", "mysql", config)?;
+            Ok(Box::new(faucet_source_mysql::MysqlSource::new(cfg).await?))
+        }
+        #[cfg(feature = "source-sqlite")]
+        "sqlite" => {
+            let cfg =
+                decode::<faucet_source_sqlite::SqliteSourceConfig>("source", "sqlite", config)?;
+            Ok(Box::new(
+                faucet_source_sqlite::SqliteSource::new(cfg).await?,
+            ))
+        }
+        #[cfg(feature = "source-s3")]
+        "s3" => {
+            let cfg = decode::<faucet_source_s3::S3SourceConfig>("source", "s3", config)?;
+            Ok(Box::new(faucet_source_s3::S3Source::new(cfg).await?))
+        }
+        #[cfg(feature = "source-mongodb")]
+        "mongodb" => {
+            let cfg =
+                decode::<faucet_source_mongodb::MongoSourceConfig>("source", "mongodb", config)?;
+            Ok(Box::new(
+                faucet_source_mongodb::MongoSource::new(cfg).await?,
+            ))
+        }
+        #[cfg(feature = "source-redis")]
+        "redis" => {
+            let cfg = decode::<faucet_source_redis::RedisSourceConfig>("source", "redis", config)?;
+            Ok(Box::new(faucet_source_redis::RedisSource::new(cfg)))
+        }
+        #[cfg(feature = "source-webhook")]
+        "webhook" => {
+            let cfg =
+                decode::<faucet_source_webhook::WebhookSourceConfig>("source", "webhook", config)?;
+            Ok(Box::new(faucet_source_webhook::WebhookSource::new(cfg)))
+        }
+        #[cfg(feature = "source-csv")]
+        "csv" => {
+            let cfg = decode::<faucet_source_csv::CsvSourceConfig>("source", "csv", config)?;
+            Ok(Box::new(faucet_source_csv::CsvSource::new(cfg)))
+        }
+        #[cfg(feature = "source-elasticsearch")]
+        "elasticsearch" => {
+            let cfg = decode::<faucet_source_elasticsearch::ElasticsearchSourceConfig>(
+                "source",
+                "elasticsearch",
+                config,
+            )?;
+            Ok(Box::new(
+                faucet_source_elasticsearch::ElasticsearchSource::new(cfg),
+            ))
+        }
+        other => Err(unknown(other, "source", source_kinds())),
+    }
+}
+
+/// Build a [`Sink`] trait object from a `(kind, config)` pair.
+pub async fn build_sink(kind: &str, config: Value) -> CliResult<Box<dyn Sink>> {
+    match kind {
+        #[cfg(feature = "sink-bigquery")]
+        "bigquery" => {
+            let cfg =
+                decode::<faucet_sink_bigquery::BigQuerySinkConfig>("sink", "bigquery", config)?;
+            Ok(Box::new(
+                faucet_sink_bigquery::BigQuerySink::new(cfg).await?,
+            ))
+        }
+        #[cfg(feature = "sink-postgres")]
+        "postgres" => {
+            let cfg =
+                decode::<faucet_sink_postgres::PostgresSinkConfig>("sink", "postgres", config)?;
+            Ok(Box::new(
+                faucet_sink_postgres::PostgresSink::new(cfg).await?,
+            ))
+        }
+        #[cfg(feature = "sink-jsonl")]
+        "jsonl" => {
+            let cfg = decode::<faucet_sink_jsonl::JsonlSinkConfig>("sink", "jsonl", config)?;
+            Ok(Box::new(faucet_sink_jsonl::JsonlSink::new(cfg)))
+        }
+        #[cfg(feature = "sink-snowflake")]
+        "snowflake" => {
+            let cfg =
+                decode::<faucet_sink_snowflake::SnowflakeSinkConfig>("sink", "snowflake", config)?;
+            Ok(Box::new(faucet_sink_snowflake::SnowflakeSink::new(cfg)))
+        }
+        #[cfg(feature = "sink-mysql")]
+        "mysql" => {
+            let cfg = decode::<faucet_sink_mysql::MysqlSinkConfig>("sink", "mysql", config)?;
+            Ok(Box::new(faucet_sink_mysql::MysqlSink::new(cfg).await?))
+        }
+        #[cfg(feature = "sink-sqlite")]
+        "sqlite" => {
+            let cfg = decode::<faucet_sink_sqlite::SqliteSinkConfig>("sink", "sqlite", config)?;
+            Ok(Box::new(faucet_sink_sqlite::SqliteSink::new(cfg).await?))
+        }
+        #[cfg(feature = "sink-s3")]
+        "s3" => {
+            let cfg = decode::<faucet_sink_s3::S3SinkConfig>("sink", "s3", config)?;
+            Ok(Box::new(faucet_sink_s3::S3Sink::new(cfg).await?))
+        }
+        #[cfg(feature = "sink-mongodb")]
+        "mongodb" => {
+            let cfg = decode::<faucet_sink_mongodb::MongoSinkConfig>("sink", "mongodb", config)?;
+            Ok(Box::new(faucet_sink_mongodb::MongoSink::new(cfg).await?))
+        }
+        #[cfg(feature = "sink-redis")]
+        "redis" => {
+            let cfg = decode::<faucet_sink_redis::RedisSinkConfig>("sink", "redis", config)?;
+            Ok(Box::new(faucet_sink_redis::RedisSink::new(cfg).await?))
+        }
+        #[cfg(feature = "sink-csv")]
+        "csv" => {
+            let cfg = decode::<faucet_sink_csv::CsvSinkConfig>("sink", "csv", config)?;
+            Ok(Box::new(faucet_sink_csv::CsvSink::new(cfg)))
+        }
+        #[cfg(feature = "sink-elasticsearch")]
+        "elasticsearch" => {
+            let cfg = decode::<faucet_sink_elasticsearch::ElasticsearchSinkConfig>(
+                "sink",
+                "elasticsearch",
+                config,
+            )?;
+            Ok(Box::new(faucet_sink_elasticsearch::ElasticsearchSink::new(
+                cfg,
+            )))
+        }
+        #[cfg(feature = "sink-http")]
+        "http" => {
+            let cfg = decode::<faucet_sink_http::HttpSinkConfig>("sink", "http", config)?;
+            Ok(Box::new(faucet_sink_http::HttpSink::new(cfg)))
+        }
+        #[cfg(feature = "sink-stdout")]
+        "stdout" => {
+            let cfg = decode::<faucet_sink_stdout::StdoutSinkConfig>("sink", "stdout", config)?;
+            Ok(Box::new(faucet_sink_stdout::StdoutSink::new(cfg)))
+        }
+        other => Err(unknown(other, "sink", sink_kinds())),
+    }
+}
+
+/// Return the JSON Schema for the named source's config struct.
+pub fn source_schema(kind: &str) -> CliResult<Value> {
+    match kind {
+        #[cfg(feature = "source-rest")]
+        "rest" => Ok(schema::<faucet_source_rest::RestStreamConfig>()),
+        #[cfg(feature = "source-graphql")]
+        "graphql" => Ok(schema::<faucet_source_graphql::GraphqlStreamConfig>()),
+        #[cfg(feature = "source-xml")]
+        "xml" => Ok(schema::<faucet_source_xml::XmlStreamConfig>()),
+        #[cfg(feature = "source-grpc")]
+        "grpc" => Ok(schema::<faucet_source_grpc::GrpcStreamConfig>()),
+        #[cfg(feature = "source-postgres")]
+        "postgres" => Ok(schema::<faucet_source_postgres::PostgresSourceConfig>()),
+        #[cfg(feature = "source-mysql")]
+        "mysql" => Ok(schema::<faucet_source_mysql::MysqlSourceConfig>()),
+        #[cfg(feature = "source-sqlite")]
+        "sqlite" => Ok(schema::<faucet_source_sqlite::SqliteSourceConfig>()),
+        #[cfg(feature = "source-s3")]
+        "s3" => Ok(schema::<faucet_source_s3::S3SourceConfig>()),
+        #[cfg(feature = "source-mongodb")]
+        "mongodb" => Ok(schema::<faucet_source_mongodb::MongoSourceConfig>()),
+        #[cfg(feature = "source-redis")]
+        "redis" => Ok(schema::<faucet_source_redis::RedisSourceConfig>()),
+        #[cfg(feature = "source-webhook")]
+        "webhook" => Ok(schema::<faucet_source_webhook::WebhookSourceConfig>()),
+        #[cfg(feature = "source-csv")]
+        "csv" => Ok(schema::<faucet_source_csv::CsvSourceConfig>()),
+        #[cfg(feature = "source-elasticsearch")]
+        "elasticsearch" => Ok(schema::<
+            faucet_source_elasticsearch::ElasticsearchSourceConfig,
+        >()),
+        other => Err(unknown(other, "source", source_kinds())),
+    }
+}
+
+/// Return the JSON Schema for the named sink's config struct.
+pub fn sink_schema(kind: &str) -> CliResult<Value> {
+    match kind {
+        #[cfg(feature = "sink-bigquery")]
+        "bigquery" => Ok(schema::<faucet_sink_bigquery::BigQuerySinkConfig>()),
+        #[cfg(feature = "sink-postgres")]
+        "postgres" => Ok(schema::<faucet_sink_postgres::PostgresSinkConfig>()),
+        #[cfg(feature = "sink-jsonl")]
+        "jsonl" => Ok(schema::<faucet_sink_jsonl::JsonlSinkConfig>()),
+        #[cfg(feature = "sink-snowflake")]
+        "snowflake" => Ok(schema::<faucet_sink_snowflake::SnowflakeSinkConfig>()),
+        #[cfg(feature = "sink-mysql")]
+        "mysql" => Ok(schema::<faucet_sink_mysql::MysqlSinkConfig>()),
+        #[cfg(feature = "sink-sqlite")]
+        "sqlite" => Ok(schema::<faucet_sink_sqlite::SqliteSinkConfig>()),
+        #[cfg(feature = "sink-s3")]
+        "s3" => Ok(schema::<faucet_sink_s3::S3SinkConfig>()),
+        #[cfg(feature = "sink-mongodb")]
+        "mongodb" => Ok(schema::<faucet_sink_mongodb::MongoSinkConfig>()),
+        #[cfg(feature = "sink-redis")]
+        "redis" => Ok(schema::<faucet_sink_redis::RedisSinkConfig>()),
+        #[cfg(feature = "sink-csv")]
+        "csv" => Ok(schema::<faucet_sink_csv::CsvSinkConfig>()),
+        #[cfg(feature = "sink-elasticsearch")]
+        "elasticsearch" => Ok(schema::<faucet_sink_elasticsearch::ElasticsearchSinkConfig>()),
+        #[cfg(feature = "sink-http")]
+        "http" => Ok(schema::<faucet_sink_http::HttpSinkConfig>()),
+        #[cfg(feature = "sink-stdout")]
+        "stdout" => Ok(schema::<faucet_sink_stdout::StdoutSinkConfig>()),
+        other => Err(unknown(other, "sink", sink_kinds())),
+    }
+}
+
+/// One-line summary of every compiled-in source connector. Used by `faucet list`.
+#[allow(clippy::vec_init_then_push)]
+pub fn source_descriptions() -> Vec<(&'static str, &'static str)> {
+    let mut v: Vec<(&'static str, &'static str)> = Vec::new();
+    #[cfg(feature = "source-rest")]
+    v.push(("rest", "REST API source with pagination, auth, transforms"));
+    #[cfg(feature = "source-graphql")]
+    v.push(("graphql", "GraphQL API source with cursor pagination"));
+    #[cfg(feature = "source-xml")]
+    v.push(("xml", "XML / SOAP API source with XML→JSON conversion"));
+    #[cfg(feature = "source-grpc")]
+    v.push(("grpc", "gRPC source with dynamic protobuf"));
+    #[cfg(feature = "source-postgres")]
+    v.push(("postgres", "PostgreSQL query source"));
+    #[cfg(feature = "source-mysql")]
+    v.push(("mysql", "MySQL query source"));
+    #[cfg(feature = "source-sqlite")]
+    v.push(("sqlite", "SQLite query source"));
+    #[cfg(feature = "source-s3")]
+    v.push(("s3", "AWS S3 object source"));
+    #[cfg(feature = "source-mongodb")]
+    v.push(("mongodb", "MongoDB query source"));
+    #[cfg(feature = "source-redis")]
+    v.push(("redis", "Redis (streams, lists, keys) source"));
+    #[cfg(feature = "source-webhook")]
+    v.push(("webhook", "Webhook HTTP receiver source"));
+    #[cfg(feature = "source-csv")]
+    v.push(("csv", "CSV file source"));
+    #[cfg(feature = "source-elasticsearch")]
+    v.push(("elasticsearch", "Elasticsearch search / scroll source"));
+    v
+}
+
+/// One-line summary of every compiled-in sink connector. Used by `faucet list`.
+#[allow(clippy::vec_init_then_push)]
+pub fn sink_descriptions() -> Vec<(&'static str, &'static str)> {
+    let mut v: Vec<(&'static str, &'static str)> = Vec::new();
+    #[cfg(feature = "sink-bigquery")]
+    v.push(("bigquery", "Google BigQuery streaming-insert sink"));
+    #[cfg(feature = "sink-postgres")]
+    v.push(("postgres", "PostgreSQL sink (JSONB or auto-mapped columns)"));
+    #[cfg(feature = "sink-jsonl")]
+    v.push(("jsonl", "JSON Lines file sink"));
+    #[cfg(feature = "sink-snowflake")]
+    v.push(("snowflake", "Snowflake SQL REST API sink"));
+    #[cfg(feature = "sink-mysql")]
+    v.push(("mysql", "MySQL sink"));
+    #[cfg(feature = "sink-sqlite")]
+    v.push(("sqlite", "SQLite sink"));
+    #[cfg(feature = "sink-s3")]
+    v.push(("s3", "AWS S3 object sink"));
+    #[cfg(feature = "sink-mongodb")]
+    v.push(("mongodb", "MongoDB insert sink"));
+    #[cfg(feature = "sink-redis")]
+    v.push(("redis", "Redis (streams, lists, key-value) sink"));
+    #[cfg(feature = "sink-csv")]
+    v.push(("csv", "CSV file sink"));
+    #[cfg(feature = "sink-elasticsearch")]
+    v.push(("elasticsearch", "Elasticsearch bulk index sink"));
+    #[cfg(feature = "sink-http")]
+    v.push(("http", "HTTP POST sink (individual or array batch)"));
+    #[cfg(feature = "sink-stdout")]
+    v.push(("stdout", "Stdout / stderr sink (JSON Lines, pretty, TSV)"));
+    v
+}
+
+/// Names of every compiled-in source connector.
+pub fn source_kinds() -> Vec<&'static str> {
+    source_descriptions().into_iter().map(|(k, _)| k).collect()
+}
+
+/// Names of every compiled-in sink connector.
+pub fn sink_kinds() -> Vec<&'static str> {
+    sink_descriptions().into_iter().map(|(k, _)| k).collect()
+}
+
+fn decode<T: DeserializeOwned>(kind: &'static str, name: &str, config: Value) -> CliResult<T> {
+    serde_json::from_value(config).map_err(|e| CliError::InvalidConnectorConfig {
+        kind,
+        name: name.to_owned(),
+        message: e.to_string(),
+    })
+}
+
+fn schema<T: faucet_core::JsonSchema>() -> Value {
+    serde_json::to_value(faucet_core::schema_for!(T))
+        .unwrap_or_else(|_| serde_json::json!({"type": "object"}))
+}
+
+fn unknown(name: &str, kind: &'static str, available: Vec<&'static str>) -> CliError {
+    CliError::UnknownConnector {
+        kind,
+        name: name.to_owned(),
+        available: if available.is_empty() {
+            "(none — rebuild faucet-cli with the relevant feature enabled)".to_owned()
+        } else {
+            available.join(", ")
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(feature = "source-rest")]
+    #[test]
+    fn rest_source_appears_in_listings() {
+        assert!(source_kinds().contains(&"rest"));
+    }
+
+    #[cfg(feature = "sink-jsonl")]
+    #[test]
+    fn jsonl_sink_appears_in_listings() {
+        assert!(sink_kinds().contains(&"jsonl"));
+    }
+
+    #[tokio::test]
+    async fn unknown_source_kind_errors() {
+        let err = build_source("nope", serde_json::json!({}))
+            .await
+            .err()
+            .expect("should fail");
+        match err {
+            CliError::UnknownConnector { kind, name, .. } => {
+                assert_eq!(kind, "source");
+                assert_eq!(name, "nope");
+            }
+            other => panic!("expected UnknownConnector, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn unknown_sink_kind_errors() {
+        let err = build_sink("nope", serde_json::json!({}))
+            .await
+            .err()
+            .expect("should fail");
+        assert!(matches!(
+            err,
+            CliError::UnknownConnector { kind: "sink", .. }
+        ));
+    }
+
+    #[cfg(feature = "source-rest")]
+    #[test]
+    fn rest_schema_is_object() {
+        let s = source_schema("rest").unwrap();
+        assert!(s.is_object());
+    }
+
+    #[cfg(feature = "sink-jsonl")]
+    #[test]
+    fn jsonl_schema_is_object() {
+        let s = sink_schema("jsonl").unwrap();
+        assert!(s.is_object());
+    }
+}

--- a/cli/src/state.rs
+++ b/cli/src/state.rs
@@ -1,0 +1,135 @@
+//! Build a `StateStore` from a `(kind, config)` pair, with feature-gated
+//! backends for Redis and PostgreSQL.
+
+use crate::config::StateStoreSpec;
+use crate::error::{CliError, CliResult};
+use faucet_core::{FileStateStore, MemoryStateStore, StateStore};
+use serde::Deserialize;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+/// Config block for the built-in file backend.
+#[derive(Debug, Deserialize)]
+struct FileStateConfig {
+    path: PathBuf,
+}
+
+#[cfg(feature = "state-redis")]
+#[derive(Debug, Deserialize)]
+struct RedisStateConfig {
+    url: String,
+    #[serde(default = "default_redis_namespace")]
+    namespace: String,
+}
+
+#[cfg(feature = "state-redis")]
+fn default_redis_namespace() -> String {
+    "faucet".to_owned()
+}
+
+#[cfg(feature = "state-postgres")]
+#[derive(Debug, Deserialize)]
+struct PostgresStateConfig {
+    url: String,
+    #[serde(default = "default_pg_table")]
+    table: String,
+    #[serde(default)]
+    ensure_table: bool,
+}
+
+#[cfg(feature = "state-postgres")]
+fn default_pg_table() -> String {
+    "faucet_state".to_owned()
+}
+
+/// Construct a state store from the parsed `state:` block.
+pub async fn build_state_store(spec: &StateStoreSpec) -> CliResult<Arc<dyn StateStore>> {
+    match spec.kind.as_str() {
+        "memory" => Ok(Arc::new(MemoryStateStore::new())),
+        "file" => {
+            let cfg = decode::<FileStateConfig>("file", spec.config.clone())?;
+            Ok(Arc::new(FileStateStore::new(cfg.path)))
+        }
+        #[cfg(feature = "state-redis")]
+        "redis" => {
+            let cfg = decode::<RedisStateConfig>("redis", spec.config.clone())?;
+            Ok(Arc::new(
+                faucet_state_redis::RedisStateStore::connect(&cfg.url, &cfg.namespace).await?,
+            ))
+        }
+        #[cfg(feature = "state-postgres")]
+        "postgres" => {
+            let cfg = decode::<PostgresStateConfig>("postgres", spec.config.clone())?;
+            let store =
+                faucet_state_postgres::PostgresStateStore::connect_with(&cfg.url, 5, &cfg.table)
+                    .await?;
+            if cfg.ensure_table {
+                store.ensure_table().await?;
+            }
+            Ok(Arc::new(store))
+        }
+        other => Err(CliError::UnknownStateStore {
+            name: other.to_owned(),
+            available: available_state_kinds().join(", "),
+        }),
+    }
+}
+
+/// Names of every state-store backend compiled into this build.
+pub fn available_state_kinds() -> Vec<&'static str> {
+    let mut v = vec!["memory", "file"];
+    #[cfg(feature = "state-redis")]
+    v.push("redis");
+    #[cfg(feature = "state-postgres")]
+    v.push("postgres");
+    v
+}
+
+fn decode<T: serde::de::DeserializeOwned>(name: &str, config: serde_json::Value) -> CliResult<T> {
+    serde_json::from_value(config).map_err(|e| CliError::InvalidConnectorConfig {
+        kind: "state",
+        name: name.to_owned(),
+        message: e.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn builds_memory_store() {
+        let spec = StateStoreSpec {
+            kind: "memory".into(),
+            config: json!({}),
+        };
+        let store = build_state_store(&spec).await.unwrap();
+        store.put("k", &json!(1)).await.unwrap();
+        assert_eq!(store.get("k").await.unwrap(), Some(json!(1)));
+    }
+
+    #[tokio::test]
+    async fn builds_file_store() {
+        let dir = tempfile::tempdir().unwrap();
+        let spec = StateStoreSpec {
+            kind: "file".into(),
+            config: json!({"path": dir.path().to_str().unwrap()}),
+        };
+        let store = build_state_store(&spec).await.unwrap();
+        store.put("k", &json!("v")).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn unknown_kind_errors() {
+        let spec = StateStoreSpec {
+            kind: "nope".into(),
+            config: json!({}),
+        };
+        let err = build_state_store(&spec).await.err().expect("should fail");
+        match err {
+            CliError::UnknownStateStore { name, .. } => assert_eq!(name, "nope"),
+            other => panic!("expected UnknownStateStore, got {other:?}"),
+        }
+    }
+}

--- a/cli/src/transforms.rs
+++ b/cli/src/transforms.rs
@@ -1,0 +1,140 @@
+//! Compile YAML/JSON transform declarations into `RecordTransform` values.
+//!
+//! Only the built-in transforms (flatten, rename_keys, snake_case) are
+//! exposed via config — custom closure transforms require Rust code and are
+//! reserved for the library API.
+
+use crate::config::TransformSpec;
+use crate::error::{CliError, CliResult};
+use faucet_core::RecordTransform;
+use serde::Deserialize;
+use serde_json::Value;
+
+/// Inline-config schema for the `flatten` transform.
+#[derive(Debug, Deserialize)]
+struct FlattenConfig {
+    #[serde(default = "default_separator")]
+    separator: String,
+}
+
+fn default_separator() -> String {
+    "__".to_owned()
+}
+
+/// Inline-config schema for the `rename_keys` transform.
+#[derive(Debug, Deserialize)]
+struct RenameKeysConfig {
+    pattern: String,
+    replacement: String,
+}
+
+/// Compile a list of [`TransformSpec`]s into [`RecordTransform`]s in the
+/// declared order. Unknown or malformed entries surface as a `CliError`.
+pub fn compile_transforms(specs: &[TransformSpec]) -> CliResult<Vec<RecordTransform>> {
+    let mut out = Vec::with_capacity(specs.len());
+    for s in specs {
+        out.push(compile_one(s)?);
+    }
+    Ok(out)
+}
+
+fn compile_one(spec: &TransformSpec) -> CliResult<RecordTransform> {
+    match spec.kind.as_str() {
+        #[cfg(feature = "transforms")]
+        "flatten" => {
+            let cfg = decode::<FlattenConfig>(&spec.kind, spec.config.clone())?;
+            Ok(RecordTransform::Flatten {
+                separator: cfg.separator,
+            })
+        }
+        #[cfg(feature = "transforms")]
+        "rename_keys" => {
+            let cfg = decode::<RenameKeysConfig>(&spec.kind, spec.config.clone())?;
+            Ok(RecordTransform::RenameKeys {
+                pattern: cfg.pattern,
+                replacement: cfg.replacement,
+            })
+        }
+        #[cfg(feature = "transforms")]
+        "snake_case" => Ok(RecordTransform::KeysToSnakeCase),
+        other => Err(CliError::UnknownTransform {
+            name: other.to_owned(),
+            available: available_transforms().join(", "),
+        }),
+    }
+}
+
+/// Names of every transform compiled into this build.
+pub fn available_transforms() -> Vec<&'static str> {
+    #[cfg(feature = "transforms")]
+    {
+        vec!["flatten", "rename_keys", "snake_case"]
+    }
+    #[cfg(not(feature = "transforms"))]
+    {
+        Vec::new()
+    }
+}
+
+fn decode<T: serde::de::DeserializeOwned>(name: &str, config: Value) -> CliResult<T> {
+    serde_json::from_value(config).map_err(|e| CliError::InvalidTransform {
+        name: name.to_owned(),
+        message: e.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn empty_list_compiles_to_empty() {
+        let out = compile_transforms(&[]).unwrap();
+        assert!(out.is_empty());
+    }
+
+    #[cfg(feature = "transforms")]
+    #[test]
+    fn compiles_snake_case_and_flatten() {
+        let specs = vec![
+            TransformSpec {
+                kind: "snake_case".into(),
+                config: json!({}),
+            },
+            TransformSpec {
+                kind: "flatten".into(),
+                config: json!({"separator": "."}),
+            },
+        ];
+        let out = compile_transforms(&specs).unwrap();
+        assert_eq!(out.len(), 2);
+    }
+
+    #[cfg(feature = "transforms")]
+    #[test]
+    fn rename_keys_requires_pattern_and_replacement() {
+        let specs = vec![TransformSpec {
+            kind: "rename_keys".into(),
+            config: json!({"pattern": "^_"}),
+        }];
+        let err = compile_transforms(&specs).unwrap_err();
+        match err {
+            CliError::InvalidTransform { name, .. } => assert_eq!(name, "rename_keys"),
+            other => panic!("expected InvalidTransform, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unknown_transform_errors() {
+        let specs = vec![TransformSpec {
+            kind: "make_uppercase".into(),
+            config: json!({}),
+        }];
+        let err = compile_transforms(&specs).unwrap_err();
+        match err {
+            CliError::UnknownTransform { name, .. } => assert_eq!(name, "make_uppercase"),
+            other => panic!("expected UnknownTransform, got {other:?}"),
+        }
+    }
+}

--- a/cli/tests/cli_end_to_end.rs
+++ b/cli/tests/cli_end_to_end.rs
@@ -1,0 +1,330 @@
+//! Integration tests for the `faucet` binary. Each test drives the binary
+//! built by cargo via `assert_cmd`, mirroring how users invoke it.
+
+use assert_cmd::Command;
+use predicates::str::contains;
+use std::fs;
+use std::path::Path;
+use tempfile::TempDir;
+
+/// Helper: a config that reads two records from a CSV file and writes them
+/// as JSONL. Uses absolute paths so the test isn't sensitive to cwd.
+fn csv_to_jsonl_yaml(csv: &Path, out: &Path) -> String {
+    format!(
+        r#"version: 1
+name: csv_to_jsonl_smoke
+source:
+  type: csv
+  config:
+    path: {csv}
+sink:
+  type: jsonl
+  config:
+    path: {out}
+"#,
+        csv = csv.display(),
+        out = out.display(),
+    )
+}
+
+#[test]
+fn list_lists_compiled_in_connectors() {
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(contains("Sources:"))
+        .stdout(contains("Sinks:"))
+        .stdout(contains("rest "))
+        .stdout(contains("jsonl "));
+}
+
+#[test]
+fn schema_prints_jsonl_sink_schema() {
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["schema", "sink", "jsonl"])
+        .assert()
+        .success()
+        .stdout(contains("\"path\""));
+}
+
+#[test]
+fn schema_rejects_unknown_kind() {
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["schema", "source", "nope"])
+        .assert()
+        .failure()
+        .stderr(contains("unknown source 'nope'"));
+}
+
+#[test]
+fn init_scaffolds_pipeline_yaml() {
+    let dir = TempDir::new().unwrap();
+    let out = dir.path().join("pipeline.yaml");
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["init", "my_pipeline", "--output"])
+        .arg(&out)
+        .assert()
+        .success()
+        .stdout(contains("wrote"));
+    let body = fs::read_to_string(&out).unwrap();
+    assert!(body.contains("name: my_pipeline"));
+    assert!(body.contains("type: rest"));
+}
+
+#[test]
+fn init_refuses_to_overwrite_existing_file() {
+    let dir = TempDir::new().unwrap();
+    let out = dir.path().join("pipeline.yaml");
+    fs::write(&out, "version: 1\n").unwrap();
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["init", "again", "--output"])
+        .arg(&out)
+        .assert()
+        .failure()
+        .stderr(contains("refusing to overwrite"));
+}
+
+#[test]
+fn validate_accepts_csv_to_jsonl_yaml() {
+    let dir = TempDir::new().unwrap();
+    let csv = dir.path().join("in.csv");
+    let out = dir.path().join("out.jsonl");
+    fs::write(&csv, "name,score\nalice,1\nbob,2\n").unwrap();
+
+    let yaml = csv_to_jsonl_yaml(&csv, &out);
+    let cfg = dir.path().join("pipeline.yaml");
+    fs::write(&cfg, yaml).unwrap();
+
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["validate"])
+        .arg(&cfg)
+        .assert()
+        .success()
+        .stdout(contains("source=csv"))
+        .stdout(contains("sink=jsonl"));
+}
+
+#[test]
+fn run_executes_csv_to_jsonl_pipeline() {
+    let dir = TempDir::new().unwrap();
+    let csv = dir.path().join("in.csv");
+    let out = dir.path().join("out.jsonl");
+    fs::write(&csv, "name,score\nalice,1\nbob,2\n").unwrap();
+
+    let yaml = csv_to_jsonl_yaml(&csv, &out);
+    let cfg = dir.path().join("pipeline.yaml");
+    fs::write(&cfg, yaml).unwrap();
+
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["run"])
+        .arg(&cfg)
+        .assert()
+        .success()
+        .stdout(contains("wrote 2 records"));
+
+    let lines: Vec<_> = fs::read_to_string(&out)
+        .unwrap()
+        .lines()
+        .map(str::to_owned)
+        .collect();
+    assert_eq!(lines.len(), 2);
+    assert!(lines[0].contains("\"alice\""));
+}
+
+#[test]
+fn run_with_dry_run_does_not_touch_the_sink_path() {
+    let dir = TempDir::new().unwrap();
+    let csv = dir.path().join("in.csv");
+    let out = dir.path().join("out.jsonl");
+    fs::write(&csv, "name\nalice\nbob\n").unwrap();
+
+    let yaml = csv_to_jsonl_yaml(&csv, &out);
+    let cfg = dir.path().join("pipeline.yaml");
+    fs::write(&cfg, yaml).unwrap();
+
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["run", "--dry-run"])
+        .arg(&cfg)
+        .assert()
+        .success();
+
+    assert!(
+        !out.exists(),
+        "dry-run must not write to the configured sink path"
+    );
+}
+
+#[test]
+fn run_with_limit_caps_records_written() {
+    let dir = TempDir::new().unwrap();
+    let csv = dir.path().join("in.csv");
+    let out = dir.path().join("out.jsonl");
+    fs::write(&csv, "name\nalice\nbob\ncarol\n").unwrap();
+
+    let yaml = csv_to_jsonl_yaml(&csv, &out);
+    let cfg = dir.path().join("pipeline.yaml");
+    fs::write(&cfg, yaml).unwrap();
+
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["run", "--limit", "2"])
+        .arg(&cfg)
+        .assert()
+        .success();
+
+    let body = fs::read_to_string(&out).unwrap();
+    assert_eq!(body.lines().count(), 2);
+}
+
+#[test]
+fn run_with_state_path_persists_a_bookmark_dir() {
+    // CSV source doesn't return bookmarks; this just exercises the wiring so
+    // the override doesn't crash when present alongside a non-stateful source.
+    let dir = TempDir::new().unwrap();
+    let csv = dir.path().join("in.csv");
+    let out = dir.path().join("out.jsonl");
+    fs::write(&csv, "name\nalice\n").unwrap();
+    let yaml = csv_to_jsonl_yaml(&csv, &out);
+    let cfg = dir.path().join("pipeline.yaml");
+    fs::write(&cfg, yaml).unwrap();
+    let state_dir = dir.path().join("state");
+
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["run", "--state-path"])
+        .arg(&state_dir)
+        .arg(&cfg)
+        .assert()
+        .success();
+}
+
+#[test]
+fn env_interpolation_resolves_inside_config_values() {
+    let dir = TempDir::new().unwrap();
+    let csv = dir.path().join("in.csv");
+    let out = dir.path().join("out.jsonl");
+    fs::write(&csv, "name\nalice\n").unwrap();
+
+    let cfg_text = format!(
+        r#"version: 1
+source:
+  type: csv
+  config:
+    path: ${{env:FAUCET_TEST_CSV_PATH}}
+sink:
+  type: jsonl
+  config:
+    path: {out}
+"#,
+        out = out.display()
+    );
+    let cfg = dir.path().join("pipeline.yaml");
+    fs::write(&cfg, cfg_text).unwrap();
+
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .env("FAUCET_TEST_CSV_PATH", &csv)
+        .args(["run"])
+        .arg(&cfg)
+        .assert()
+        .success();
+}
+
+#[test]
+fn shipped_example_yamls_pass_validate() {
+    // Validate every example under cli/examples/. The YAMLs reference
+    // environment variables that the env-interpolator needs present, so
+    // stuff placeholders in for every var any example mentions. `validate`
+    // is offline — placeholders are safe.
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let env_placeholders: &[(&str, &str)] = &[
+        ("API_KEY", "x"),
+        ("API_TOKEN", "x"),
+        ("API_USER", "x"),
+        ("API_PASS", "x"),
+        ("AUTH_TOKEN", "x"),
+        ("ES_USER", "x"),
+        ("ES_PASS", "x"),
+        ("ES_API_KEY", "x"),
+        ("GCP_KEY_JSON", "{}"),
+        ("GITHUB_TOKEN", "x"),
+        ("GRPC_API_KEY", "x"),
+        ("GRPC_TOKEN", "x"),
+        ("INGEST_TOKEN", "x"),
+        ("INGEST_USER", "x"),
+        ("INGEST_PASS", "x"),
+        ("PG_URL", "postgres://u:p@localhost/db"),
+        ("SNOWFLAKE_OAUTH_TOKEN", "x"),
+        ("SOAP_USER", "x"),
+        ("SOAP_PASS", "x"),
+        ("STRIPE_TOKEN", "x"),
+        ("FEED_TOKEN", "x"),
+        (
+            "GOOGLE_APPLICATION_CREDENTIALS",
+            "/tmp/service-account.json",
+        ),
+    ];
+    let examples_dir = std::path::Path::new(manifest_dir).join("examples");
+    // Some examples interpolate `${file:./snowflake_key.pem}`. We run faucet
+    // with cwd set to a temp dir that holds a placeholder PEM so the file
+    // directive can resolve.
+    let workdir = TempDir::new().unwrap();
+    fs::write(workdir.path().join("snowflake_key.pem"), "dummy-key").unwrap();
+
+    let mut count = 0;
+    for entry in fs::read_dir(&examples_dir).unwrap() {
+        let path = entry.unwrap().path();
+        if path.extension().and_then(|e| e.to_str()) != Some("yaml") {
+            continue;
+        }
+        count += 1;
+        let mut cmd = Command::cargo_bin("faucet").unwrap();
+        for (k, v) in env_placeholders {
+            cmd.env(k, v);
+        }
+        cmd.current_dir(workdir.path())
+            .args(["validate"])
+            .arg(&path)
+            .assert()
+            .success();
+    }
+    assert!(count >= 30, "expected many YAML examples, got {count}");
+}
+
+#[test]
+fn missing_env_var_in_config_is_reported() {
+    let dir = TempDir::new().unwrap();
+    let cfg = dir.path().join("pipeline.yaml");
+    fs::write(
+        &cfg,
+        r#"version: 1
+source:
+  type: csv
+  config:
+    path: ${env:FAUCET_DEFINITELY_UNSET}
+sink:
+  type: jsonl
+  config:
+    path: /tmp/no.jsonl
+"#,
+    )
+    .unwrap();
+
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .env_remove("FAUCET_DEFINITELY_UNSET")
+        .args(["validate"])
+        .arg(&cfg)
+        .assert()
+        .failure()
+        .stderr(contains("missing environment variable"));
+}

--- a/cli/tests/rest_pipeline.rs
+++ b/cli/tests/rest_pipeline.rs
@@ -1,0 +1,77 @@
+//! End-to-end REST → JSONL test using wiremock. Verifies that the YAML
+//! source config — including the tagged Auth and pagination enums — round-trips
+//! through serde into a working RestStream.
+
+#![cfg(feature = "source-rest")]
+#![cfg(feature = "sink-jsonl")]
+
+use assert_cmd::Command;
+use predicates::str::contains;
+use std::fs;
+use tempfile::TempDir;
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rest_to_jsonl_round_trip() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/things"))
+        .and(header("x-api-key", "secret-xyz"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+            {"id": 1, "name": "thing one"},
+            {"id": 2, "name": "thing two"},
+        ])))
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().unwrap();
+    let out = dir.path().join("out.jsonl");
+    let cfg = dir.path().join("pipeline.yaml");
+    let yaml = format!(
+        r#"version: 1
+name: rest_smoke
+source:
+  type: rest
+  config:
+    base_url: {base}
+    path: /things
+    method: GET
+    auth:
+      type: ApiKey
+      header: X-Api-Key
+      value: ${{env:FAUCET_TEST_API_KEY}}
+    query_params: {{}}
+    pagination:
+      type: None
+    max_retries: 0
+    retry_backoff: 0
+    tolerated_http_errors: []
+    replication_method:
+      type: FullTable
+    primary_keys: []
+    partitions: []
+    schema_sample_size: 0
+sink:
+  type: jsonl
+  config:
+    path: {out}
+"#,
+        base = server.uri(),
+        out = out.display(),
+    );
+    fs::write(&cfg, yaml).unwrap();
+
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .env("FAUCET_TEST_API_KEY", "secret-xyz")
+        .args(["run"])
+        .arg(&cfg)
+        .assert()
+        .success()
+        .stdout(contains("wrote 2 records"));
+
+    let body = fs::read_to_string(&out).unwrap();
+    assert_eq!(body.lines().count(), 2);
+    assert!(body.contains("\"thing one\""));
+}


### PR DESCRIPTION
## Summary
- New `faucet-cli` crate at `cli/` ships a single `faucet` binary that runs a source → transforms → sink pipeline from a YAML or JSON config — no Rust code required
- Six subcommands: `run`, `validate`, `schema`, `list`, `preview`, `init`; supports `--dry-run`, `--limit`, `--state-path`, `--log-level`
- Feature-gated dispatch covers every existing source, sink, and state-store crate, plus the built-in `flatten` / `rename_keys` / `snake_case` transforms
- `${env:VAR}`, `${file:PATH}`, and `${secret:VAR}` interpolation (with `$${` escape) runs before YAML/JSON parsing so resolved values can become any structured type
- 40 example YAMLs under `cli/examples/` — one for every `faucet-stream/examples/*.rs` plus two CLI-only smoke tests; every YAML is exercised by an integration test
- CI gains a `cli-build` matrix verifying both `full` and a slim feature set compile cleanly
- Surfaced a connector-level limitation while writing the YAML examples: filed [#40](https://github.com/PawanSikawat/faucet-stream/issues/40) to convert newtype auth variants (`Auth::Bearer(String)`, etc.) to struct variants so they round-trip through serde

## Test plan
- [x] `cargo test --workspace --all-features` — 70 groups, 538 tests, 0 failures
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] Manually verified `faucet list`, `faucet schema sink jsonl`, `faucet validate cli/examples/csv_to_jsonl.yaml`, `faucet run cli/examples/csv_to_jsonl.yaml`
- [x] Integration test `shipped_example_yamls_pass_validate` walks every YAML in `cli/examples/` and asserts `faucet validate` succeeds with placeholder env vars

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)