### PR TITLE
feat(source-postgres-cdc): PostgreSQL logical replication source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,7 @@ jobs:
           - source-xml
           - source-grpc
           - source-postgres
+          - source-postgres-cdc
           - source-mysql
           - source-sqlite
           - source-s3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,8 @@ jobs:
             faucet-core
             faucet-kafka-common
             faucet-source-rest faucet-source-graphql faucet-source-xml
-            faucet-source-grpc faucet-source-postgres faucet-source-mysql
+            faucet-source-grpc faucet-source-postgres faucet-source-postgres-cdc
+            faucet-source-mysql
             faucet-source-sqlite faucet-source-s3 faucet-source-mongodb
             faucet-source-redis faucet-source-webhook faucet-source-csv
             faucet-source-elasticsearch faucet-source-kafka
@@ -110,7 +111,8 @@ jobs:
           connectors=(
             faucet-kafka-common
             faucet-source-rest faucet-source-graphql faucet-source-xml
-            faucet-source-grpc faucet-source-postgres faucet-source-mysql
+            faucet-source-grpc faucet-source-postgres faucet-source-postgres-cdc
+            faucet-source-mysql
             faucet-source-sqlite faucet-source-s3 faucet-source-mongodb
             faucet-source-redis faucet-source-webhook faucet-source-csv
             faucet-source-elasticsearch faucet-source-kafka
@@ -157,7 +159,8 @@ jobs:
             faucet-core
             faucet-kafka-common
             faucet-source-rest faucet-source-graphql faucet-source-xml
-            faucet-source-grpc faucet-source-postgres faucet-source-mysql
+            faucet-source-grpc faucet-source-postgres faucet-source-postgres-cdc
+            faucet-source-mysql
             faucet-source-sqlite faucet-source-s3 faucet-source-mongodb
             faucet-source-redis faucet-source-webhook faucet-source-csv
             faucet-source-elasticsearch faucet-source-kafka
@@ -171,7 +174,8 @@ jobs:
           connectors=(
             faucet-kafka-common
             faucet-source-rest faucet-source-graphql faucet-source-xml
-            faucet-source-grpc faucet-source-postgres faucet-source-mysql
+            faucet-source-grpc faucet-source-postgres faucet-source-postgres-cdc
+            faucet-source-mysql
             faucet-source-sqlite faucet-source-s3 faucet-source-mongodb
             faucet-source-redis faucet-source-webhook faucet-source-csv
             faucet-source-elasticsearch faucet-source-kafka

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ This workspace produces both library crates (`faucet-core` + every connector and
 
 ## Workspace Structure
 
-The project is a Cargo workspace with 34 crates (33 libraries + the `faucet-cli` binary):
+The project is a Cargo workspace with 35 crates (34 libraries + the `faucet-cli` binary):
 
 | Crate | Path | Description |
 |-------|------|-------------|
@@ -24,6 +24,7 @@ The project is a Cargo workspace with 34 crates (33 libraries + the `faucet-cli`
 | `faucet-source-xml` | `crates/source/xml/` | XML/SOAP API source — XML-to-JSON conversion, dot-path extraction |
 | `faucet-source-grpc` | `crates/source/grpc/` | gRPC source — dynamic protobuf via `prost-reflect` |
 | `faucet-source-postgres` | `crates/source/postgres/` | PostgreSQL query source — run SQL, return rows as JSON |
+| `faucet-source-postgres-cdc` | `crates/source/postgres-cdc/` | PostgreSQL CDC (logical replication) source — pgoutput decoder, slot lifecycle, resumable via state store |
 | `faucet-source-mysql` | `crates/source/mysql/` | MySQL query source — run SQL, return rows as JSON |
 | `faucet-source-sqlite` | `crates/source/sqlite/` | SQLite query source — run SQL, return rows as JSON |
 | `faucet-source-s3` | `crates/source/s3/` | AWS S3 source — read objects as JSONL, JSON array, or raw text |
@@ -63,6 +64,7 @@ faucet-core  <──  faucet-source-rest
              <──  faucet-source-xml
              <──  faucet-source-grpc
              <──  faucet-source-postgres
+             <──  faucet-source-postgres-cdc
              <──  faucet-source-mysql
              <──  faucet-source-sqlite
 
@@ -304,6 +306,18 @@ cargo install --path cli --no-default-features --features "source-rest,sink-json
 - **`src/config.rs`** — `PostgresSourceConfig` with connection_url, query, params
 - **`src/stream.rs`** — `PostgresSource`: PgPool, row-to-JSON conversion; implements `faucet_core::Source`
 
+### faucet-source-postgres-cdc (`crates/source/postgres-cdc/`)
+
+- **`src/lib.rs`** — crate root; re-exports `Source`, `FaucetError`, `Bookmark`, `PostgresCdcSourceConfig`, `PostgresCdcSource`
+- **`src/config.rs`** — `PostgresCdcSourceConfig` (connection_url, slot_name, publication_name, create_slot_if_missing, start_lsn, proto_version, idle_timeout, max_messages, status_update_interval, tcp_keepalive) with `validate()`; manual `Debug` impl masks `connection_url`
+- **`src/state.rs`** — `Bookmark { last_lsn }` <-> JSON; `format_lsn`/`parse_lsn` for Postgres' `XXXXXXXX/XXXXXXXX` hex form; `state_key(slot_name) = "postgres-cdc:<slot>"`
+- **`src/pgoutput/messages.rs`** — `MessageKind`, `ReplicaIdentity`, `ColumnDesc`, `Begin`, `Commit`, `Relation`, `TupleCell` (Null/UnchangedToast/Text), `TupleData`, `Insert`, `Update` (with `UpdateOldKind`), `Delete` (with `DeleteOldKind`), `Truncate`, `Message`
+- **`src/pgoutput/decoder.rs`** — `XLogDataHeader::decode`, `PrimaryKeepAlive::decode`, `decode_message` (dispatches on message kind byte), text-mode tuple decoder, per-kind error context
+- **`src/pgoutput/registry.rs`** — `RelationRegistry` — OID → `Relation` cache; required because Insert/Update/Delete only carry the relation OID and rely on a prior Relation message for column metadata
+- **`src/pgoutput/values.rs`** — `text_to_json(type_oid, text)` for the common built-in Postgres OIDs (bool, int2/4/8, float4/8, numeric, bytea, json/jsonb), with a string fallback for anything else
+- **`src/replication.rs`** — `pgwire-replication` glue: `connect`, `ensure_slot` (via `sqlx` because pgwire-replication is replication-only), `start_replication` (returns a CopyBoth `Duplex`), `send_status_update`, `recv` (filters KeepAlive/StoppedAt, surfaces Begin/Commit/XLogData/Message), `postgres_clock_*`
+- **`src/stream.rs`** — `PostgresCdcSource`: holds config, `pending_bookmark`, `confirmed_lsn`; `fetch_with_context_incremental` opens a fresh replication connection per call, sends an initial Standby Status Update from the bookmarked LSN, drains the event stream until `idle_timeout` / `max_messages` / Ctrl+C, buffers each transaction in memory and only emits records to the output Vec on `Commit` (so partial transactions never leak). Implements `faucet_core::Source` with `state_key()`/`apply_start_bookmark`.
+
 ### faucet-source-mysql (`crates/source/mysql/`)
 
 - **`src/config.rs`** — `MysqlSourceConfig` with connection_url, query
@@ -465,6 +479,7 @@ cargo install --path cli --no-default-features --features "source-rest,sink-json
 | `source-xml` | no | XML/SOAP API source connector |
 | `source-grpc` | no | gRPC source connector |
 | `source-postgres` | no | PostgreSQL query source |
+| `source-postgres-cdc` | no | PostgreSQL CDC source (logical replication) |
 | `source-mysql` | no | MySQL query source |
 | `source-sqlite` | no | SQLite query source |
 | `source-s3` | no | AWS S3 file source |
@@ -571,6 +586,12 @@ When the user points out something fundamental about how code in this library sh
 - `src/config.rs` — configuration types only. No SQL logic.
 - `src/stream.rs` — connection pool, query execution, row-to-JSON conversion, Source trait impl.
 
+#### faucet-source-postgres-cdc
+- `src/config.rs` — configuration types only. No protocol logic.
+- `src/state.rs` — bookmark <-> JSON + LSN parse/format. No protocol logic.
+- `src/pgoutput/` — pgoutput message types, wire decoder, relation registry, OID-to-JSON mapping. No `pgwire-replication` types appear here.
+- `src/replication.rs` — `pgwire-replication` glue (replication connection, slot lifecycle, COPY BOTH event stream, Standby Status Updates). No pgoutput semantics here.
+- `src/stream.rs` — wires `replication.rs` and `pgoutput::` together, implements `Source`.
 
 #### faucet-source-s3 / faucet-sink-s3
 - `src/config.rs` — configuration types only. No AWS logic.
@@ -732,7 +753,7 @@ Always use the **highest available stable version** for every crate, the Rust to
 Crates must be published in dependency order with delays for crates.io index propagation:
 
 1. `faucet-core`
-2. All sources + sinks (after 30s): `faucet-source-rest`, `faucet-source-graphql`, `faucet-source-xml`, `faucet-source-grpc`, `faucet-source-postgres`, `faucet-source-mysql`, `faucet-source-sqlite`, `faucet-source-s3`, `faucet-source-mongodb`, `faucet-source-redis`, `faucet-source-webhook`, `faucet-source-csv`, `faucet-source-elasticsearch`, `faucet-source-parquet`, `faucet-kafka-common`, `faucet-source-kafka`, `faucet-sink-bigquery`, `faucet-sink-postgres`, `faucet-sink-jsonl`, `faucet-sink-snowflake`, `faucet-sink-mysql`, `faucet-sink-sqlite`, `faucet-sink-s3`, `faucet-sink-mongodb`, `faucet-sink-redis`, `faucet-sink-csv`, `faucet-sink-elasticsearch`, `faucet-sink-http`, `faucet-sink-kafka`, `faucet-sink-parquet`
+2. All sources + sinks (after 30s): `faucet-source-rest`, `faucet-source-graphql`, `faucet-source-xml`, `faucet-source-grpc`, `faucet-source-postgres`, `faucet-source-postgres-cdc`, `faucet-source-mysql`, `faucet-source-sqlite`, `faucet-source-s3`, `faucet-source-mongodb`, `faucet-source-redis`, `faucet-source-webhook`, `faucet-source-csv`, `faucet-source-elasticsearch`, `faucet-source-parquet`, `faucet-kafka-common`, `faucet-source-kafka`, `faucet-sink-bigquery`, `faucet-sink-postgres`, `faucet-sink-jsonl`, `faucet-sink-snowflake`, `faucet-sink-mysql`, `faucet-sink-sqlite`, `faucet-sink-s3`, `faucet-sink-mongodb`, `faucet-sink-redis`, `faucet-sink-csv`, `faucet-sink-elasticsearch`, `faucet-sink-http`, `faucet-sink-kafka`, `faucet-sink-parquet`
 3. `faucet-stream` (after 30s)
 
 The `.github/workflows/publish.yml` handles this automatically on version tags (`v*.*.*`).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ prost = "0.13"
 prost-reflect = { version = "0.15", features = ["serde"] }
 prost-types = "0.13"
 sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls", "postgres", "mysql", "sqlite", "json"] }
-tokio-postgres = { version = "0.7", features = ["runtime", "with-chrono-0_4", "with-serde_json-1"] }
+pgwire-replication = "=0.3.2"
 byteorder = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 jsonwebtoken = "9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "crates/source/csv",
     "crates/source/elasticsearch",
     "crates/source/parquet",
+    "crates/source/postgres-cdc",
     "crates/sink/bigquery",
     "crates/sink/postgres",
     "crates/sink/jsonl",
@@ -61,6 +62,7 @@ faucet-sink-postgres = { path = "crates/sink/postgres", version = "0.2.0" }
 faucet-sink-jsonl = { path = "crates/sink/jsonl", version = "0.2.0" }
 faucet-sink-snowflake = { path = "crates/sink/snowflake", version = "0.2.0" }
 faucet-source-postgres = { path = "crates/source/postgres", version = "0.2.0" }
+faucet-source-postgres-cdc = { path = "crates/source/postgres-cdc", version = "0.2.0" }
 faucet-source-mysql = { path = "crates/source/mysql", version = "0.2.0" }
 
 faucet-source-s3 = { path = "crates/source/s3", version = "0.2.0" }
@@ -104,6 +106,9 @@ prost = "0.13"
 prost-reflect = { version = "0.15", features = ["serde"] }
 prost-types = "0.13"
 sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls", "postgres", "mysql", "sqlite", "json"] }
+tokio-postgres = { version = "0.7", features = ["runtime", "with-chrono-0_4", "with-serde_json-1"] }
+byteorder = "1"
+chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 jsonwebtoken = "9"
 base64 = "0.22"
 uuid = { version = "1", features = ["v4"] }

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ See [`cli/README.md`](cli/README.md) and [`cli/examples/`](cli/examples/) for th
 
 ## Architecture
 
-faucet-stream is a Cargo workspace with 34 crates — 14 sources, 14 sinks, 1 shared connector library, 2 state-store backends, the shared core, the umbrella crate, and the CLI binary:
+faucet-stream is a Cargo workspace with 35 crates — 15 sources, 14 sinks, 1 shared connector library, 2 state-store backends, the shared core, the umbrella crate, and the CLI binary:
 
 | Crate | Description |
 |-------|-------------|
@@ -63,6 +63,7 @@ faucet-stream is a Cargo workspace with 34 crates — 14 sources, 14 sinks, 1 sh
 | [`faucet-source-xml`](crates/source/xml) | XML/SOAP API — XML-to-JSON conversion, dot-path extraction |
 | [`faucet-source-grpc`](crates/source/grpc) | gRPC — dynamic protobuf via `prost-reflect`, TLS support |
 | [`faucet-source-postgres`](crates/source/postgres) | PostgreSQL — run SQL queries, return rows as JSON |
+| [`faucet-source-postgres-cdc`](crates/source/postgres-cdc) | PostgreSQL CDC — logical replication via pgoutput, resumable with any StateStore |
 | [`faucet-source-mysql`](crates/source/mysql) | MySQL — run SQL queries, return rows as JSON |
 | [`faucet-source-sqlite`](crates/source/sqlite) | SQLite — run SQL queries, return rows as JSON |
 | [`faucet-source-s3`](crates/source/s3) | AWS S3 — read objects as JSONL, JSON array, or raw text |
@@ -746,6 +747,7 @@ All pagination styles include loop detection — if the same cursor or link is r
 | `source-xml` | no | XML/SOAP API source |
 | `source-grpc` | no | gRPC source |
 | `source-postgres` | no | PostgreSQL query source |
+| `source-postgres-cdc` | no | PostgreSQL CDC source (logical replication) |
 | `source-mysql` | no | MySQL query source |
 | `source-sqlite` | no | SQLite query source |
 | `source-s3` | no | AWS S3 file source |
@@ -913,6 +915,7 @@ crates/
     xml/                      — XML/SOAP API (XML-to-JSON conversion)
     grpc/                     — gRPC (dynamic protobuf)
     postgres/                 — PostgreSQL queries
+    postgres-cdc/             — PostgreSQL CDC (logical replication)
     mysql/                    — MySQL queries
     sqlite/                   — SQLite queries
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -27,6 +27,7 @@ source = [
     "source-xml",
     "source-grpc",
     "source-postgres",
+    "source-postgres-cdc",
     "source-mysql",
     "source-sqlite",
     "source-s3",
@@ -62,6 +63,7 @@ source-graphql = ["dep:faucet-source-graphql"]
 source-xml = ["dep:faucet-source-xml"]
 source-grpc = ["dep:faucet-source-grpc"]
 source-postgres = ["dep:faucet-source-postgres"]
+source-postgres-cdc = ["dep:faucet-source-postgres-cdc"]
 source-mysql = ["dep:faucet-source-mysql"]
 source-sqlite = ["dep:faucet-source-sqlite"]
 source-s3 = ["dep:faucet-source-s3"]
@@ -109,6 +111,7 @@ faucet-source-graphql = { workspace = true, optional = true }
 faucet-source-xml = { workspace = true, optional = true }
 faucet-source-grpc = { workspace = true, optional = true }
 faucet-source-postgres = { workspace = true, optional = true }
+faucet-source-postgres-cdc = { workspace = true, optional = true }
 faucet-source-mysql = { workspace = true, optional = true }
 faucet-source-sqlite = { workspace = true, optional = true }
 faucet-source-s3 = { workspace = true, optional = true }

--- a/cli/examples/postgres_cdc_to_jsonl.yaml
+++ b/cli/examples/postgres_cdc_to_jsonl.yaml
@@ -14,7 +14,7 @@
 
 version: 1
 source:
-  kind: postgres-cdc
+  type: postgres-cdc
   config:
     connection_url: postgres://faucet:faucet@localhost:5432/appdb
     slot_name: faucet_slot
@@ -22,11 +22,11 @@ source:
     create_slot_if_missing: true
     idle_timeout: 30
 sink:
-  kind: jsonl
+  type: jsonl
   config:
     path: ./out/changes.jsonl
     append: true
 state:
-  kind: file
+  type: file
   config:
     path: ./state

--- a/cli/examples/postgres_cdc_to_jsonl.yaml
+++ b/cli/examples/postgres_cdc_to_jsonl.yaml
@@ -1,0 +1,32 @@
+# End-to-end Postgres CDC -> JSONL demo.
+#
+# Setup before running:
+#   psql appdb <<SQL
+#     CREATE TABLE IF NOT EXISTS users (id int4 PRIMARY KEY, name text);
+#     CREATE PUBLICATION faucet_pub FOR TABLE users;
+#   SQL
+#
+# Then:
+#   faucet run cli/examples/postgres_cdc_to_jsonl.yaml
+#
+# Open another psql session and INSERT/UPDATE/DELETE rows — the connector
+# will drain them every fetch cycle until idle_timeout fires.
+
+version: 1
+source:
+  kind: postgres-cdc
+  config:
+    connection_url: postgres://faucet:faucet@localhost:5432/appdb
+    slot_name: faucet_slot
+    publication_name: faucet_pub
+    create_slot_if_missing: true
+    idle_timeout: 30
+sink:
+  kind: jsonl
+  config:
+    path: ./out/changes.jsonl
+    append: true
+state:
+  kind: file
+  config:
+    path: ./state

--- a/cli/src/registry.rs
+++ b/cli/src/registry.rs
@@ -43,6 +43,17 @@ pub async fn build_source(kind: &str, config: Value) -> CliResult<Box<dyn Source
                 faucet_source_postgres::PostgresSource::new(cfg).await?,
             ))
         }
+        #[cfg(feature = "source-postgres-cdc")]
+        "postgres-cdc" => {
+            let cfg = decode::<faucet_source_postgres_cdc::PostgresCdcSourceConfig>(
+                "source",
+                "postgres-cdc",
+                config,
+            )?;
+            Ok(Box::new(
+                faucet_source_postgres_cdc::PostgresCdcSource::new(cfg).await?,
+            ))
+        }
         #[cfg(feature = "source-mysql")]
         "mysql" => {
             let cfg = decode::<faucet_source_mysql::MysqlSourceConfig>("source", "mysql", config)?;
@@ -221,6 +232,8 @@ pub fn source_schema(kind: &str) -> CliResult<Value> {
         "grpc" => Ok(schema::<faucet_source_grpc::GrpcStreamConfig>()),
         #[cfg(feature = "source-postgres")]
         "postgres" => Ok(schema::<faucet_source_postgres::PostgresSourceConfig>()),
+        #[cfg(feature = "source-postgres-cdc")]
+        "postgres-cdc" => Ok(schema::<faucet_source_postgres_cdc::PostgresCdcSourceConfig>()),
         #[cfg(feature = "source-mysql")]
         "mysql" => Ok(schema::<faucet_source_mysql::MysqlSourceConfig>()),
         #[cfg(feature = "source-sqlite")]
@@ -298,6 +311,11 @@ pub fn source_descriptions() -> Vec<(&'static str, &'static str)> {
     v.push(("grpc", "gRPC source with dynamic protobuf"));
     #[cfg(feature = "source-postgres")]
     v.push(("postgres", "PostgreSQL query source"));
+    #[cfg(feature = "source-postgres-cdc")]
+    v.push((
+        "postgres-cdc",
+        "PostgreSQL CDC source (logical replication)",
+    ));
     #[cfg(feature = "source-mysql")]
     v.push(("mysql", "MySQL query source"));
     #[cfg(feature = "source-sqlite")]

--- a/crates/source/postgres-cdc/Cargo.toml
+++ b/crates/source/postgres-cdc/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "faucet-source-postgres-cdc"
+version = "0.2.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "PostgreSQL logical replication (CDC) source for the faucet-stream ecosystem"
+
+[dependencies]
+faucet-core.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+schemars.workspace = true
+thiserror.workspace = true
+async-trait.workspace = true
+tracing.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "signal", "time"] }
+tokio-postgres.workspace = true
+byteorder.workspace = true
+chrono.workspace = true
+base64.workspace = true
+futures.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "signal", "time", "test-util"] }
+testcontainers = "0.27"
+testcontainers-modules = { version = "0.15", features = ["postgres"] }
+hex = "0.4"

--- a/crates/source/postgres-cdc/Cargo.toml
+++ b/crates/source/postgres-cdc/Cargo.toml
@@ -16,8 +16,11 @@ thiserror.workspace = true
 async-trait.workspace = true
 tracing.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "signal", "time"] }
-tokio-postgres.workspace = true
+pgwire-replication.workspace = true
 byteorder.workspace = true
+bytes.workspace = true
+sqlx = { workspace = true, features = ["postgres"] }
+url.workspace = true
 chrono.workspace = true
 base64.workspace = true
 futures.workspace = true

--- a/crates/source/postgres-cdc/Cargo.toml
+++ b/crates/source/postgres-cdc/Cargo.toml
@@ -29,4 +29,5 @@ futures.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "signal", "time", "test-util"] }
 testcontainers = "0.27"
 testcontainers-modules = { version = "0.15", features = ["postgres"] }
+tokio-postgres = "0.7"
 hex = "0.4"

--- a/crates/source/postgres-cdc/README.md
+++ b/crates/source/postgres-cdc/README.md
@@ -10,7 +10,7 @@ PostgreSQL CDC (Change Data Capture) source for [`faucet-stream`](https://github
 # pipeline.yaml
 version: 1
 source:
-  kind: postgres-cdc
+  type: postgres-cdc
   config:
     connection_url: postgres://user:pass@localhost:5432/appdb
     slot_name: faucet_slot
@@ -18,11 +18,11 @@ source:
     create_slot_if_missing: true
     idle_timeout: 30
 sink:
-  kind: jsonl
+  type: jsonl
   config:
     path: ./changes.jsonl
 state:
-  kind: file
+  type: file
   config: { path: ./state }
 ```
 

--- a/crates/source/postgres-cdc/README.md
+++ b/crates/source/postgres-cdc/README.md
@@ -1,3 +1,170 @@
 # faucet-source-postgres-cdc
 
-PostgreSQL CDC (logical replication) source for `faucet-stream`. Filled in by the final docs task of the implementation plan.
+PostgreSQL CDC (Change Data Capture) source for [`faucet-stream`](https://github.com/PawanSikawat/faucet-stream). Subscribes to a Postgres logical replication slot using the `pgoutput` plugin and emits each row-level change (INSERT / UPDATE / DELETE / TRUNCATE) as a JSON record. Replication position is persisted via any `faucet-core` `StateStore`, so pipelines resume exactly where they left off — no duplicates, no gap.
+
+---
+
+## Quick start
+
+```yaml
+# pipeline.yaml
+version: 1
+source:
+  kind: postgres-cdc
+  config:
+    connection_url: postgres://user:pass@localhost:5432/appdb
+    slot_name: faucet_slot
+    publication_name: faucet_pub
+    create_slot_if_missing: true
+    idle_timeout: 30
+sink:
+  kind: jsonl
+  config:
+    path: ./changes.jsonl
+state:
+  kind: file
+  config: { path: ./state }
+```
+
+```bash
+faucet run pipeline.yaml
+```
+
+---
+
+## Postgres setup (one-time)
+
+```sql
+-- 1. Database needs logical replication enabled.
+ALTER SYSTEM SET wal_level = 'logical';
+ALTER SYSTEM SET max_replication_slots = 4;
+ALTER SYSTEM SET max_wal_senders = 4;
+-- restart Postgres after this
+
+-- 2. The role that connects must have REPLICATION.
+ALTER ROLE faucet_user WITH REPLICATION;
+
+-- 3. Create a publication for the tables you want to capture.
+CREATE PUBLICATION faucet_pub FOR TABLE public.users, public.orders;
+-- or FOR ALL TABLES if you really want everything.
+
+-- 4. (Optional but recommended) get a full pre-image on UPDATE/DELETE.
+ALTER TABLE public.users REPLICA IDENTITY FULL;
+```
+
+The replication slot is created automatically on first run when
+`create_slot_if_missing = true` (the default).
+
+---
+
+## Output record schema
+
+Every change event is one JSON object:
+
+```json
+{
+  "op":     "insert | update | delete | truncate",
+  "schema": "public",
+  "table":  "users",
+  "lsn":    "0/16A4F88",
+  "ts_ms":  1779019200000,
+  "before": null | { ...row... },
+  "after":  null | { ...row..., "__unchanged_toast__": ["col1", "col2"] }
+}
+```
+
+- `lsn` is the `commit_lsn` of the enclosing transaction.
+- `ts_ms` is Unix-epoch milliseconds, derived from the COMMIT's timestamp.
+- `before` is populated on `delete` always, and on `update` only when the
+  table is `REPLICA IDENTITY FULL`. Otherwise it is `null`.
+- `after` is populated on `insert` and `update`, and `null` on `delete` /
+  `truncate`.
+- If any column arrived as "unchanged TOAST" (Postgres elides large
+  out-of-line values whose stored copy was not rewritten), the column is
+  dropped from `before` / `after` and its name is recorded in
+  `before.__unchanged_toast__` / `after.__unchanged_toast__`.
+
+`truncate` emits one record per truncated relation with `before = after = null`.
+
+---
+
+## Configuration
+
+| Field                       | Type     | Default | Description |
+|-----------------------------|----------|---------|-------------|
+| `connection_url`            | string   | —       | Postgres connection URL. |
+| `slot_name`                 | string   | —       | Logical replication slot. Must match `[a-z0-9_]{1,63}`. |
+| `publication_name`          | string   | —       | Publication that selects which tables are replicated. |
+| `create_slot_if_missing`    | bool     | `true`  | Create the slot on first run if it does not exist. |
+| `start_lsn`                 | string?  | `null`  | One-time override (e.g. `"0/16A4F88"`); ignored if a state-store bookmark exists. |
+| `proto_version`             | u32      | `1`     | pgoutput protocol version. Only `1` is supported in this release. |
+| `idle_timeout`              | seconds  | `30`    | Stop the current fetch cycle after this long without a new replication message. |
+| `max_messages`              | usize?   | `null`  | Optional cap on change events per fetch call. The cap is checked **after each COMMIT**; a transaction larger than `max_messages` still emits atomically. |
+| `status_update_interval`    | seconds  | `10`    | Standby Status Update cadence. Must be `< idle_timeout` and well under the server's `wal_sender_timeout`. |
+| `tcp_keepalive`             | seconds  | `60`    | TCP keepalive on the replication connection. |
+
+---
+
+## Transactional consistency
+
+The connector buffers each transaction in memory and only flushes its records
+to the sink on `COMMIT`. Partial transactions (BEGIN seen, no COMMIT yet
+within `idle_timeout` / `max_messages`) are dropped and redelivered after the
+next `START_REPLICATION`. This makes the output transactionally consistent —
+sinks never see half a transaction — at the cost of needing each
+transaction to fit within one fetch cycle. Size `max_messages` accordingly
+or leave it unset for unbounded buffering.
+
+---
+
+## At-least-once semantics
+
+- Postgres redelivers everything after the most recent `confirmed_flush_lsn`
+  on every `START_REPLICATION`, with no duplicates and no gap.
+- `faucet-stream`'s pipeline only writes the new bookmark to the state store
+  **after the sink confirms** the batch was flushed.
+- On the next run, `apply_start_bookmark` is called with that bookmark and
+  the connector advances `confirmed_flush_lsn` accordingly.
+- If the process crashes between sink flush and state-store write, the next
+  run will replay the most recent transaction. Sinks should be idempotent or
+  accept duplicates at transaction boundaries.
+
+---
+
+## Operational caveats
+
+- **Slot bloat:** without a state store the connector never advances
+  `confirmed_flush_lsn`, so Postgres retains WAL indefinitely. Always
+  configure a state store in production.
+- **Heartbeats:** if the network is silent for longer than the server's
+  `wal_sender_timeout` (default 60 s), Postgres kills the replication
+  connection. The default `status_update_interval` of 10 s leaves ample
+  margin.
+- **DDL is invisible.** Logical replication does not replicate schema
+  changes. After an `ALTER TABLE`, the next change event from that table
+  will arrive with a new `Relation` message — the connector picks it up
+  automatically.
+- **Reconnection on drop:** v1 surfaces a connection drop as
+  `FaucetError::Source`. Re-run the pipeline to reconnect; the persisted
+  LSN bookmark ensures no data loss.
+- **Slot creation timing:** the slot is created on the first fetch call.
+  Changes applied **before** the slot exists are not replicated. To avoid
+  losing initial changes, either create the slot before applying writes
+  (e.g. via `psql`) or do a warm-up fetch and then begin writes.
+
+---
+
+## Implementation notes
+
+Built on top of the [`pgwire-replication`](https://crates.io/crates/pgwire-replication)
+crate for the Postgres logical-replication wire protocol; the `pgoutput`
+payload bytes are decoded by a hand-rolled decoder in this crate so that the
+output record shape stays under our control.
+
+---
+
+## See also
+
+- `crates/source/postgres/` — query-mode Postgres source (snapshots, not CDC).
+- `crates/state/postgres/` — Postgres-backed `StateStore` you can pair with this source.
+- `cli/examples/postgres_cdc_to_jsonl.yaml` — end-to-end demo configuration.

--- a/crates/source/postgres-cdc/README.md
+++ b/crates/source/postgres-cdc/README.md
@@ -1,0 +1,3 @@
+# faucet-source-postgres-cdc
+
+PostgreSQL CDC (logical replication) source for `faucet-stream`. Filled in by the final docs task of the implementation plan.

--- a/crates/source/postgres-cdc/src/config.rs
+++ b/crates/source/postgres-cdc/src/config.rs
@@ -1,3 +1,253 @@
 //! Configuration for `PostgresCdcSource`.
 
-pub struct PostgresCdcSourceConfig;
+use faucet_core::FaucetError;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+fn default_true() -> bool {
+    true
+}
+fn default_proto_version() -> u32 {
+    1
+}
+fn default_idle_timeout() -> Duration {
+    Duration::from_secs(30)
+}
+fn default_status_update_interval() -> Duration {
+    Duration::from_secs(10)
+}
+fn default_tcp_keepalive() -> Duration {
+    Duration::from_secs(60)
+}
+
+/// Configuration for [`PostgresCdcSource`](crate::PostgresCdcSource).
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+pub struct PostgresCdcSourceConfig {
+    /// Connection URL pointing at the database whose WAL we want to read.
+    /// The crate internally upgrades the connection to `replication=database`
+    /// — callers do **not** need to add it themselves.
+    pub connection_url: String,
+
+    /// Logical replication slot name. Must match the Postgres naming rules:
+    /// 1–63 chars, lowercase letters / digits / underscores only.
+    pub slot_name: String,
+
+    /// Publication name on the server. Must already exist (faucet does not
+    /// create publications — they're a DBA-level concern that determines
+    /// which tables are replicated).
+    pub publication_name: String,
+
+    /// If the slot does not exist, create it as a logical/`pgoutput` slot
+    /// at connection time. Default: `true`.
+    #[serde(default = "default_true")]
+    pub create_slot_if_missing: bool,
+
+    /// Optional starting LSN override (e.g. `"0/16A4F88"`). Ignored when a
+    /// state-store-managed bookmark is present (that bookmark wins).
+    /// When neither is set, replication starts from the slot's
+    /// `confirmed_flush_lsn`.
+    #[serde(default)]
+    pub start_lsn: Option<String>,
+
+    /// pgoutput protocol version. Only `1` is fully exercised in v1; `2` is
+    /// accepted but streaming-transaction messages (S/E/c/A) are not yet
+    /// decoded. Default: `1`.
+    #[serde(default = "default_proto_version")]
+    pub proto_version: u32,
+
+    /// Maximum time to wait for new replication messages before returning
+    /// the current batch. Default: 30 s.
+    #[serde(
+        default = "default_idle_timeout",
+        with = "faucet_core::config::duration_secs"
+    )]
+    #[schemars(with = "u64")]
+    pub idle_timeout: Duration,
+
+    /// Optional cap on the number of change events drained per fetch call.
+    /// Acts as a safety bound — `idle_timeout` is the primary terminator.
+    #[serde(default)]
+    pub max_messages: Option<usize>,
+
+    /// Interval at which Standby Status Update keepalives are sent to the
+    /// server. Must be shorter than `idle_timeout` and well under the
+    /// server's `wal_sender_timeout` (default 60 s). Default: 10 s.
+    #[serde(
+        default = "default_status_update_interval",
+        with = "faucet_core::config::duration_secs"
+    )]
+    #[schemars(with = "u64")]
+    pub status_update_interval: Duration,
+
+    /// TCP keepalive for the replication connection. Default: 60 s.
+    #[serde(
+        default = "default_tcp_keepalive",
+        with = "faucet_core::config::duration_secs"
+    )]
+    #[schemars(with = "u64")]
+    pub tcp_keepalive: Duration,
+}
+
+impl PostgresCdcSourceConfig {
+    /// Validate fail-fast invariants. Called from `PostgresCdcSource::new`.
+    pub fn validate(&self) -> Result<(), FaucetError> {
+        if self.connection_url.is_empty() {
+            return Err(FaucetError::Config(
+                "postgres-cdc: connection_url must not be empty".into(),
+            ));
+        }
+        validate_slot_name(&self.slot_name)?;
+        if self.publication_name.is_empty() {
+            return Err(FaucetError::Config(
+                "postgres-cdc: publication_name must not be empty".into(),
+            ));
+        }
+        if !matches!(self.proto_version, 1 | 2) {
+            return Err(FaucetError::Config(format!(
+                "postgres-cdc: proto_version must be 1 or 2, got {}",
+                self.proto_version
+            )));
+        }
+        if self.idle_timeout.is_zero() {
+            return Err(FaucetError::Config(
+                "postgres-cdc: idle_timeout must be > 0".into(),
+            ));
+        }
+        if self.status_update_interval >= self.idle_timeout {
+            return Err(FaucetError::Config(format!(
+                "postgres-cdc: status_update_interval ({}s) must be \
+                 strictly less than idle_timeout ({}s)",
+                self.status_update_interval.as_secs(),
+                self.idle_timeout.as_secs()
+            )));
+        }
+        Ok(())
+    }
+}
+
+fn validate_slot_name(name: &str) -> Result<(), FaucetError> {
+    if name.is_empty() {
+        return Err(FaucetError::Config(
+            "postgres-cdc: slot_name must not be empty".into(),
+        ));
+    }
+    if name.len() > 63 {
+        return Err(FaucetError::Config(format!(
+            "postgres-cdc: slot_name '{name}' exceeds Postgres' 63-char limit"
+        )));
+    }
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+    {
+        return Err(FaucetError::Config(format!(
+            "postgres-cdc: slot_name '{name}' must contain only \
+             [a-z0-9_]"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn minimal() -> PostgresCdcSourceConfig {
+        PostgresCdcSourceConfig {
+            connection_url: "postgres://u:p@localhost/db".into(),
+            slot_name: "faucet_slot".into(),
+            publication_name: "faucet_pub".into(),
+            create_slot_if_missing: true,
+            start_lsn: None,
+            proto_version: 1,
+            idle_timeout: std::time::Duration::from_secs(30),
+            max_messages: None,
+            status_update_interval: std::time::Duration::from_secs(10),
+            tcp_keepalive: std::time::Duration::from_secs(60),
+        }
+    }
+
+    #[test]
+    fn defaults_via_serde() {
+        let value: PostgresCdcSourceConfig = serde_json::from_value(serde_json::json!({
+            "connection_url": "postgres://u:p@localhost/db",
+            "slot_name": "faucet_slot",
+            "publication_name": "faucet_pub",
+        }))
+        .unwrap();
+        assert!(value.create_slot_if_missing);
+        assert_eq!(value.proto_version, 1);
+        assert_eq!(value.idle_timeout.as_secs(), 30);
+        assert_eq!(value.status_update_interval.as_secs(), 10);
+        assert_eq!(value.tcp_keepalive.as_secs(), 60);
+        assert!(value.start_lsn.is_none());
+        assert!(value.max_messages.is_none());
+    }
+
+    #[test]
+    fn rejects_empty_slot_name() {
+        let mut c = minimal();
+        c.slot_name = String::new();
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_invalid_slot_name_chars() {
+        let mut c = minimal();
+        c.slot_name = "Faucet-Slot".into(); // uppercase + dash both disallowed
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_slot_name_over_63_chars() {
+        let mut c = minimal();
+        c.slot_name = "a".repeat(64);
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_empty_publication_name() {
+        let mut c = minimal();
+        c.publication_name = String::new();
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_zero_idle_timeout() {
+        let mut c = minimal();
+        c.idle_timeout = std::time::Duration::from_secs(0);
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_status_update_interval_longer_than_idle_timeout() {
+        // Keepalives must fire before idle_timeout would terminate the loop.
+        let mut c = minimal();
+        c.status_update_interval = std::time::Duration::from_secs(60);
+        c.idle_timeout = std::time::Duration::from_secs(30);
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn proto_version_must_be_one_or_two() {
+        let mut c = minimal();
+        c.proto_version = 0;
+        assert!(c.validate().is_err());
+        c.proto_version = 3;
+        assert!(c.validate().is_err());
+        c.proto_version = 1;
+        assert!(c.validate().is_ok());
+    }
+
+    #[test]
+    fn schema_for_config_includes_required_fields() {
+        let schema = schemars::schema_for!(PostgresCdcSourceConfig);
+        let json = serde_json::to_value(&schema).unwrap();
+        let required = json["required"].as_array().expect("required array");
+        let names: Vec<_> = required.iter().filter_map(|v| v.as_str()).collect();
+        assert!(names.contains(&"connection_url"));
+        assert!(names.contains(&"slot_name"));
+        assert!(names.contains(&"publication_name"));
+    }
+}

--- a/crates/source/postgres-cdc/src/config.rs
+++ b/crates/source/postgres-cdc/src/config.rs
@@ -67,6 +67,12 @@ pub struct PostgresCdcSourceConfig {
 
     /// Optional cap on the number of change events drained per fetch call.
     /// Acts as a safety bound — `idle_timeout` is the primary terminator.
+    ///
+    /// **Note:** the cap is checked **after each COMMIT**, never mid-
+    /// transaction. A single transaction larger than `max_messages` will
+    /// still be emitted atomically (the fetch returns only after that
+    /// transaction's COMMIT and may produce more records than `max_messages`).
+    /// Set `max_messages = None` (the default) for unbounded buffering.
     #[serde(default)]
     pub max_messages: Option<usize>,
 

--- a/crates/source/postgres-cdc/src/config.rs
+++ b/crates/source/postgres-cdc/src/config.rs
@@ -22,7 +22,7 @@ fn default_tcp_keepalive() -> Duration {
 }
 
 /// Configuration for [`PostgresCdcSource`](crate::PostgresCdcSource).
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
 pub struct PostgresCdcSourceConfig {
     /// Connection URL pointing at the database whose WAL we want to read.
     /// The crate internally upgrades the connection to `replication=database`
@@ -89,10 +89,27 @@ pub struct PostgresCdcSourceConfig {
     pub tcp_keepalive: Duration,
 }
 
+impl std::fmt::Debug for PostgresCdcSourceConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PostgresCdcSourceConfig")
+            .field("connection_url", &"***")
+            .field("slot_name", &self.slot_name)
+            .field("publication_name", &self.publication_name)
+            .field("create_slot_if_missing", &self.create_slot_if_missing)
+            .field("start_lsn", &self.start_lsn)
+            .field("proto_version", &self.proto_version)
+            .field("idle_timeout", &self.idle_timeout)
+            .field("max_messages", &self.max_messages)
+            .field("status_update_interval", &self.status_update_interval)
+            .field("tcp_keepalive", &self.tcp_keepalive)
+            .finish()
+    }
+}
+
 impl PostgresCdcSourceConfig {
     /// Validate fail-fast invariants. Called from `PostgresCdcSource::new`.
     pub fn validate(&self) -> Result<(), FaucetError> {
-        if self.connection_url.is_empty() {
+        if self.connection_url.trim().is_empty() {
             return Err(FaucetError::Config(
                 "postgres-cdc: connection_url must not be empty".into(),
             ));
@@ -230,14 +247,43 @@ mod tests {
     }
 
     #[test]
-    fn proto_version_must_be_one_or_two() {
+    fn rejects_invalid_proto_version() {
         let mut c = minimal();
         c.proto_version = 0;
         assert!(c.validate().is_err());
         c.proto_version = 3;
         assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn accepts_valid_proto_versions() {
+        let mut c = minimal();
         c.proto_version = 1;
         assert!(c.validate().is_ok());
+        c.proto_version = 2;
+        assert!(c.validate().is_ok());
+    }
+
+    #[test]
+    fn rejects_empty_connection_url() {
+        let mut c = minimal();
+        c.connection_url = String::new();
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_whitespace_connection_url() {
+        let mut c = minimal();
+        c.connection_url = "   ".into();
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn debug_redacts_connection_url() {
+        let cfg = minimal();
+        let dbg = format!("{cfg:?}");
+        assert!(dbg.contains("connection_url: \"***\""));
+        assert!(!dbg.contains("u:p@localhost"));
     }
 
     #[test]

--- a/crates/source/postgres-cdc/src/config.rs
+++ b/crates/source/postgres-cdc/src/config.rs
@@ -120,9 +120,10 @@ impl PostgresCdcSourceConfig {
                 "postgres-cdc: publication_name must not be empty".into(),
             ));
         }
-        if !matches!(self.proto_version, 1 | 2) {
+        if self.proto_version != 1 {
             return Err(FaucetError::Config(format!(
-                "postgres-cdc: proto_version must be 1 or 2, got {}",
+                "postgres-cdc: proto_version must be 1 (v2 streaming-transaction \
+                 support is not yet available via pgwire-replication), got {}",
                 self.proto_version
             )));
         }
@@ -248,19 +249,20 @@ mod tests {
 
     #[test]
     fn rejects_invalid_proto_version() {
+        // 0, 2, and 3 are all rejected — only 1 is supported.
         let mut c = minimal();
         c.proto_version = 0;
+        assert!(c.validate().is_err());
+        c.proto_version = 2;
         assert!(c.validate().is_err());
         c.proto_version = 3;
         assert!(c.validate().is_err());
     }
 
     #[test]
-    fn accepts_valid_proto_versions() {
+    fn accepts_proto_version_one() {
         let mut c = minimal();
         c.proto_version = 1;
-        assert!(c.validate().is_ok());
-        c.proto_version = 2;
         assert!(c.validate().is_ok());
     }
 

--- a/crates/source/postgres-cdc/src/config.rs
+++ b/crates/source/postgres-cdc/src/config.rs
@@ -1,0 +1,3 @@
+//! Configuration for `PostgresCdcSource`.
+
+pub struct PostgresCdcSourceConfig;

--- a/crates/source/postgres-cdc/src/lib.rs
+++ b/crates/source/postgres-cdc/src/lib.rs
@@ -1,0 +1,18 @@
+//! PostgreSQL logical replication (CDC) source for `faucet-stream`.
+//!
+//! Subscribes to a Postgres logical replication slot using the `pgoutput`
+//! plugin and streams INSERT / UPDATE / DELETE / TRUNCATE events as JSON
+//! records. See the crate README for the output record schema and the
+//! Postgres setup requirements (`wal_level=logical`, replication-enabled
+//! role, publication).
+
+pub mod config;
+pub mod pgoutput;
+pub mod replication;
+pub mod state;
+pub mod stream;
+
+pub use config::PostgresCdcSourceConfig;
+pub use faucet_core::{FaucetError, Source};
+pub use state::Bookmark;
+pub use stream::PostgresCdcSource;

--- a/crates/source/postgres-cdc/src/pgoutput/decoder.rs
+++ b/crates/source/postgres-cdc/src/pgoutput/decoder.rs
@@ -1,0 +1,1 @@
+//! pgoutput wire-format decoder — parses raw replication messages into typed structs.

--- a/crates/source/postgres-cdc/src/pgoutput/decoder.rs
+++ b/crates/source/postgres-cdc/src/pgoutput/decoder.rs
@@ -1,1 +1,453 @@
-//! pgoutput wire-format decoder — parses raw replication messages into typed structs.
+//! pgoutput wire-format decoder — turns raw bytes into `Message` values.
+
+use super::messages::*;
+use byteorder::{BigEndian, ReadBytesExt};
+use faucet_core::FaucetError;
+use std::io::{Cursor, Read};
+
+/// XLogData envelope header that precedes every pgoutput payload coming over
+/// the COPY BOTH stream (after the leading `'w'` byte stripped by the caller).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct XLogDataHeader {
+    pub wal_start: u64,
+    pub wal_end: u64,
+    pub server_ts: i64,
+}
+
+impl XLogDataHeader {
+    pub const SIZE: usize = 24;
+
+    /// Decode the 24-byte header. Caller has already stripped the leading
+    /// `'w'` discriminator byte from the CopyData payload.
+    pub fn decode(buf: &[u8]) -> Result<Self, FaucetError> {
+        if buf.len() < Self::SIZE {
+            return Err(FaucetError::Source(format!(
+                "pgoutput: XLogData header truncated ({} < {})",
+                buf.len(),
+                Self::SIZE
+            )));
+        }
+        let mut c = Cursor::new(buf);
+        Ok(Self {
+            wal_start: c.read_u64::<BigEndian>().map_err(io_err)?,
+            wal_end: c.read_u64::<BigEndian>().map_err(io_err)?,
+            server_ts: c.read_i64::<BigEndian>().map_err(io_err)?,
+        })
+    }
+}
+
+/// PrimaryKeepAlive message (CopyData discriminator `'k'`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PrimaryKeepAlive {
+    pub wal_end: u64,
+    pub server_ts: i64,
+    pub reply_requested: bool,
+}
+
+impl PrimaryKeepAlive {
+    pub const SIZE: usize = 17;
+
+    pub fn decode(buf: &[u8]) -> Result<Self, FaucetError> {
+        if buf.len() < Self::SIZE {
+            return Err(FaucetError::Source(format!(
+                "pgoutput: PrimaryKeepAlive truncated ({} < {})",
+                buf.len(),
+                Self::SIZE
+            )));
+        }
+        let mut c = Cursor::new(buf);
+        Ok(Self {
+            wal_end: c.read_u64::<BigEndian>().map_err(io_err)?,
+            server_ts: c.read_i64::<BigEndian>().map_err(io_err)?,
+            reply_requested: c.read_u8().map_err(io_err)? != 0,
+        })
+    }
+}
+
+/// Decode a single pgoutput message from the start of `buf`.
+///
+/// The caller has already stripped the XLogData header. The first byte is
+/// the message kind discriminator.
+pub fn decode_message(buf: &[u8]) -> Result<Message, FaucetError> {
+    let mut c = Cursor::new(buf);
+    let kind = MessageKind::from_byte(c.read_u8().map_err(io_err)?)?;
+    Ok(match kind {
+        MessageKind::Begin => Message::Begin(decode_begin(&mut c)?),
+        MessageKind::Commit => Message::Commit(decode_commit(&mut c)?),
+        MessageKind::Origin => Message::Origin,
+        MessageKind::Relation => Message::Relation(decode_relation(&mut c)?),
+        MessageKind::Type => Message::Type,
+        MessageKind::Insert => Message::Insert(decode_insert(&mut c)?),
+        MessageKind::Update => Message::Update(decode_update(&mut c)?),
+        MessageKind::Delete => Message::Delete(decode_delete(&mut c)?),
+        MessageKind::Truncate => Message::Truncate(decode_truncate(&mut c)?),
+    })
+}
+
+fn decode_begin(c: &mut Cursor<&[u8]>) -> Result<Begin, FaucetError> {
+    Ok(Begin {
+        final_lsn: c.read_u64::<BigEndian>().map_err(io_err)?,
+        commit_ts: c.read_i64::<BigEndian>().map_err(io_err)?,
+        xid: c.read_u32::<BigEndian>().map_err(io_err)?,
+    })
+}
+
+fn decode_commit(c: &mut Cursor<&[u8]>) -> Result<Commit, FaucetError> {
+    Ok(Commit {
+        flags: c.read_u8().map_err(io_err)?,
+        commit_lsn: c.read_u64::<BigEndian>().map_err(io_err)?,
+        end_lsn: c.read_u64::<BigEndian>().map_err(io_err)?,
+        commit_ts: c.read_i64::<BigEndian>().map_err(io_err)?,
+    })
+}
+
+fn decode_relation(c: &mut Cursor<&[u8]>) -> Result<Relation, FaucetError> {
+    let oid = c.read_u32::<BigEndian>().map_err(io_err)?;
+    let namespace = read_cstring(c)?;
+    let name = read_cstring(c)?;
+    let replica_identity = ReplicaIdentity::from_byte(c.read_u8().map_err(io_err)?)?;
+    let n_columns = c.read_u16::<BigEndian>().map_err(io_err)?;
+    let mut columns = Vec::with_capacity(n_columns as usize);
+    for _ in 0..n_columns {
+        columns.push(ColumnDesc {
+            flags: c.read_u8().map_err(io_err)?,
+            name: read_cstring(c)?,
+            type_oid: c.read_u32::<BigEndian>().map_err(io_err)?,
+            type_modifier: c.read_i32::<BigEndian>().map_err(io_err)?,
+        });
+    }
+    Ok(Relation {
+        oid,
+        namespace,
+        name,
+        replica_identity,
+        columns,
+    })
+}
+
+fn decode_insert(c: &mut Cursor<&[u8]>) -> Result<Insert, FaucetError> {
+    let relation_oid = c.read_u32::<BigEndian>().map_err(io_err)?;
+    let tag = c.read_u8().map_err(io_err)?;
+    if tag != b'N' {
+        return Err(FaucetError::Source(format!(
+            "pgoutput INSERT: expected 'N' tuple tag, got {:?}",
+            tag as char
+        )));
+    }
+    Ok(Insert {
+        relation_oid,
+        new: decode_tuple(c)?,
+    })
+}
+
+fn decode_update(c: &mut Cursor<&[u8]>) -> Result<Update, FaucetError> {
+    let relation_oid = c.read_u32::<BigEndian>().map_err(io_err)?;
+    let mut tag = c.read_u8().map_err(io_err)?;
+    let (old_kind, old) = match tag {
+        b'K' => {
+            let t = decode_tuple(c)?;
+            tag = c.read_u8().map_err(io_err)?;
+            (UpdateOldKind::Key, Some(t))
+        }
+        b'O' => {
+            let t = decode_tuple(c)?;
+            tag = c.read_u8().map_err(io_err)?;
+            (UpdateOldKind::Full, Some(t))
+        }
+        _ => (UpdateOldKind::None, None),
+    };
+    if tag != b'N' {
+        return Err(FaucetError::Source(format!(
+            "pgoutput UPDATE: expected 'N' tuple tag, got {:?}",
+            tag as char
+        )));
+    }
+    Ok(Update {
+        relation_oid,
+        old_kind,
+        old,
+        new: decode_tuple(c)?,
+    })
+}
+
+fn decode_delete(c: &mut Cursor<&[u8]>) -> Result<Delete, FaucetError> {
+    let relation_oid = c.read_u32::<BigEndian>().map_err(io_err)?;
+    let tag = c.read_u8().map_err(io_err)?;
+    let old_kind = match tag {
+        b'K' => DeleteOldKind::Key,
+        b'O' => DeleteOldKind::Full,
+        other => {
+            return Err(FaucetError::Source(format!(
+                "pgoutput DELETE: expected 'K' or 'O' tuple tag, got {:?}",
+                other as char
+            )));
+        }
+    };
+    Ok(Delete {
+        relation_oid,
+        old_kind,
+        old: decode_tuple(c)?,
+    })
+}
+
+fn decode_truncate(c: &mut Cursor<&[u8]>) -> Result<Truncate, FaucetError> {
+    let n = c.read_u32::<BigEndian>().map_err(io_err)?;
+    let flags = c.read_u8().map_err(io_err)?;
+    let mut oids = Vec::with_capacity(n as usize);
+    for _ in 0..n {
+        oids.push(c.read_u32::<BigEndian>().map_err(io_err)?);
+    }
+    Ok(Truncate {
+        relation_oids: oids,
+        cascade: flags & 0b01 != 0,
+        restart_identity: flags & 0b10 != 0,
+    })
+}
+
+fn decode_tuple(c: &mut Cursor<&[u8]>) -> Result<TupleData, FaucetError> {
+    let n = c.read_u16::<BigEndian>().map_err(io_err)?;
+    let mut cells = Vec::with_capacity(n as usize);
+    for _ in 0..n {
+        let kind = c.read_u8().map_err(io_err)?;
+        cells.push(match kind {
+            b'n' => TupleCell::Null,
+            b'u' => TupleCell::UnchangedToast,
+            b't' => {
+                let len = c.read_u32::<BigEndian>().map_err(io_err)?;
+                let mut buf = vec![0u8; len as usize];
+                c.read_exact(&mut buf).map_err(io_err)?;
+                TupleCell::Text(String::from_utf8(buf).map_err(|e| {
+                    FaucetError::Source(format!("pgoutput tuple text not UTF-8: {e}"))
+                })?)
+            }
+            b'b' => {
+                return Err(FaucetError::Source(
+                    "pgoutput tuple: binary-mode cells not supported in v1".into(),
+                ));
+            }
+            other => {
+                return Err(FaucetError::Source(format!(
+                    "pgoutput tuple: unknown cell tag {:?}",
+                    other as char
+                )));
+            }
+        });
+    }
+    Ok(TupleData { cells })
+}
+
+fn read_cstring(c: &mut Cursor<&[u8]>) -> Result<String, FaucetError> {
+    let mut out = Vec::new();
+    loop {
+        let b = c.read_u8().map_err(io_err)?;
+        if b == 0 {
+            break;
+        }
+        out.push(b);
+    }
+    String::from_utf8(out).map_err(|e| FaucetError::Source(format!("pgoutput cstring: {e}")))
+}
+
+fn io_err(e: std::io::Error) -> FaucetError {
+    FaucetError::Source(format!("pgoutput decode: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Decode a hex-encoded fixture (whitespace ignored).
+    fn hex(s: &str) -> Vec<u8> {
+        let s: String = s.chars().filter(|c| !c.is_whitespace()).collect();
+        hex::decode(s).expect("valid hex")
+    }
+
+    #[test]
+    fn decode_xlogdata_header() {
+        // wal_start=0/16A4F88, wal_end=0/16A4FA0, server_ts=750000000000000
+        let bytes = hex("00 00 00 00 01 6A 4F 88 \
+             00 00 00 00 01 6A 4F A0 \
+             00 02 A4 A6 4A 1B 80 00");
+        let h = XLogDataHeader::decode(&bytes).unwrap();
+        assert_eq!(h.wal_start, 0x0000_0000_016A_4F88);
+        assert_eq!(h.wal_end, 0x0000_0000_016A_4FA0);
+        assert_eq!(h.server_ts, 0x0002_A4A6_4A1B_8000);
+    }
+
+    #[test]
+    fn decode_keepalive() {
+        // wal_end=0/16A4F88, ts=750000000000000, reply_requested=1
+        let bytes = hex("00 00 00 00 01 6A 4F 88 \
+             00 02 A4 A6 4A 1B 80 00 \
+             01");
+        let k = PrimaryKeepAlive::decode(&bytes).unwrap();
+        assert_eq!(k.wal_end, 0x0000_0000_016A_4F88);
+        assert!(k.reply_requested);
+    }
+
+    #[test]
+    fn decode_begin_message() {
+        // 'B', final_lsn=0/16A4FA0, ts=750000000000000, xid=0x4D2
+        let bytes = hex("42 \
+             00 00 00 00 01 6A 4F A0 \
+             00 02 A4 A6 4A 1B 80 00 \
+             00 00 04 D2");
+        match decode_message(&bytes).unwrap() {
+            Message::Begin(b) => {
+                assert_eq!(b.final_lsn, 0x0000_0000_016A_4FA0);
+                assert_eq!(b.xid, 0x4D2);
+            }
+            other => panic!("expected Begin, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_commit_message() {
+        // 'C', flags=0, commit_lsn=0/16A4FA0, end_lsn=0/16A4FB0, ts=750000000000000
+        let bytes = hex("43 00 \
+             00 00 00 00 01 6A 4F A0 \
+             00 00 00 00 01 6A 4F B0 \
+             00 02 A4 A6 4A 1B 80 00");
+        match decode_message(&bytes).unwrap() {
+            Message::Commit(c) => {
+                assert_eq!(c.commit_lsn, 0x0000_0000_016A_4FA0);
+                assert_eq!(c.end_lsn, 0x0000_0000_016A_4FB0);
+            }
+            other => panic!("expected Commit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_relation_message_two_columns() {
+        // 'R', oid=16384, ns="public\0", name="users\0", ri='d', n_cols=2
+        // col1: flags=1, name="id\0", type_oid=23 (int4), modifier=-1
+        // col2: flags=0, name="name\0", type_oid=25 (text), modifier=-1
+        let bytes = hex("52 \
+             00 00 40 00 \
+             70 75 62 6C 69 63 00 \
+             75 73 65 72 73 00 \
+             64 \
+             00 02 \
+             01 69 64 00 00 00 00 17 FF FF FF FF \
+             00 6E 61 6D 65 00 00 00 00 19 FF FF FF FF");
+        match decode_message(&bytes).unwrap() {
+            Message::Relation(r) => {
+                assert_eq!(r.oid, 16384);
+                assert_eq!(r.namespace, "public");
+                assert_eq!(r.name, "users");
+                assert_eq!(r.replica_identity, ReplicaIdentity::Default);
+                assert_eq!(r.columns.len(), 2);
+                assert_eq!(r.columns[0].name, "id");
+                assert_eq!(r.columns[0].type_oid, 23);
+                assert_eq!(r.columns[0].flags & 1, 1);
+                assert_eq!(r.columns[1].name, "name");
+                assert_eq!(r.columns[1].type_oid, 25);
+            }
+            other => panic!("expected Relation, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_insert_two_text_cells() {
+        // 'I', relation=16384, 'N', n=2, ('t', len=1, "1"), ('t', len=5, "alice")
+        let bytes = hex("49 \
+             00 00 40 00 \
+             4E \
+             00 02 \
+             74 00 00 00 01 31 \
+             74 00 00 00 05 61 6C 69 63 65");
+        match decode_message(&bytes).unwrap() {
+            Message::Insert(i) => {
+                assert_eq!(i.relation_oid, 16384);
+                assert_eq!(i.new.cells.len(), 2);
+                assert_eq!(i.new.cells[0], TupleCell::Text("1".into()));
+                assert_eq!(i.new.cells[1], TupleCell::Text("alice".into()));
+            }
+            other => panic!("expected Insert, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_insert_with_null_and_toast() {
+        // 'I', relation=16384, 'N', n=3, ('t',1,"1"), ('n'), ('u')
+        let bytes = hex("49 \
+             00 00 40 00 \
+             4E \
+             00 03 \
+             74 00 00 00 01 31 \
+             6E \
+             75");
+        match decode_message(&bytes).unwrap() {
+            Message::Insert(i) => {
+                assert_eq!(i.new.cells[1], TupleCell::Null);
+                assert_eq!(i.new.cells[2], TupleCell::UnchangedToast);
+            }
+            other => panic!("expected Insert, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_update_with_key_old() {
+        // 'U', relation=16384, 'K', old{1 cell, t,1,"1"}, 'N', new{2, t,1,"1", t,3,"bob"}
+        let bytes = hex("55 \
+             00 00 40 00 \
+             4B \
+             00 01 74 00 00 00 01 31 \
+             4E \
+             00 02 74 00 00 00 01 31 74 00 00 00 03 62 6F 62");
+        match decode_message(&bytes).unwrap() {
+            Message::Update(u) => {
+                assert_eq!(u.old_kind, UpdateOldKind::Key);
+                assert_eq!(u.old.unwrap().cells, vec![TupleCell::Text("1".into())]);
+                assert_eq!(u.new.cells[1], TupleCell::Text("bob".into()));
+            }
+            other => panic!("expected Update, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_delete_key_only() {
+        // 'D', relation=16384, 'K', old{1, t,1,"1"}
+        let bytes = hex("44 \
+             00 00 40 00 \
+             4B \
+             00 01 74 00 00 00 01 31");
+        match decode_message(&bytes).unwrap() {
+            Message::Delete(d) => {
+                assert_eq!(d.old_kind, DeleteOldKind::Key);
+                assert_eq!(d.old.cells.len(), 1);
+            }
+            other => panic!("expected Delete, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_truncate_two_relations_cascade() {
+        // 'T', n=2, flags=0b01 (cascade), oid=16384, oid=16385
+        let bytes = hex("54 \
+             00 00 00 02 \
+             01 \
+             00 00 40 00 \
+             00 00 40 01");
+        match decode_message(&bytes).unwrap() {
+            Message::Truncate(t) => {
+                assert_eq!(t.relation_oids, vec![16384, 16385]);
+                assert!(t.cascade);
+                assert!(!t.restart_identity);
+            }
+            other => panic!("expected Truncate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_unknown_kind_errors() {
+        let bytes = hex("5A 00 00"); // 'Z'
+        assert!(decode_message(&bytes).is_err());
+    }
+
+    #[test]
+    fn decode_truncated_input_errors() {
+        let bytes = hex("42 00 00"); // 'B' with no body
+        assert!(decode_message(&bytes).is_err());
+    }
+}

--- a/crates/source/postgres-cdc/src/pgoutput/decoder.rs
+++ b/crates/source/postgres-cdc/src/pgoutput/decoder.rs
@@ -70,7 +70,7 @@ impl PrimaryKeepAlive {
 /// the message kind discriminator.
 pub fn decode_message(buf: &[u8]) -> Result<Message, FaucetError> {
     let mut c = Cursor::new(buf);
-    let kind = MessageKind::from_byte(c.read_u8().map_err(io_err)?)?;
+    let kind = MessageKind::from_byte(c.read_u8().map_err(io_err_in("kind byte"))?)?;
     Ok(match kind {
         MessageKind::Begin => Message::Begin(decode_begin(&mut c)?),
         MessageKind::Commit => Message::Commit(decode_commit(&mut c)?),
@@ -86,34 +86,34 @@ pub fn decode_message(buf: &[u8]) -> Result<Message, FaucetError> {
 
 fn decode_begin(c: &mut Cursor<&[u8]>) -> Result<Begin, FaucetError> {
     Ok(Begin {
-        final_lsn: c.read_u64::<BigEndian>().map_err(io_err)?,
-        commit_ts: c.read_i64::<BigEndian>().map_err(io_err)?,
-        xid: c.read_u32::<BigEndian>().map_err(io_err)?,
+        final_lsn: c.read_u64::<BigEndian>().map_err(io_err_in("BEGIN"))?,
+        commit_ts: c.read_i64::<BigEndian>().map_err(io_err_in("BEGIN"))?,
+        xid: c.read_u32::<BigEndian>().map_err(io_err_in("BEGIN"))?,
     })
 }
 
 fn decode_commit(c: &mut Cursor<&[u8]>) -> Result<Commit, FaucetError> {
     Ok(Commit {
-        flags: c.read_u8().map_err(io_err)?,
-        commit_lsn: c.read_u64::<BigEndian>().map_err(io_err)?,
-        end_lsn: c.read_u64::<BigEndian>().map_err(io_err)?,
-        commit_ts: c.read_i64::<BigEndian>().map_err(io_err)?,
+        flags: c.read_u8().map_err(io_err_in("COMMIT"))?,
+        commit_lsn: c.read_u64::<BigEndian>().map_err(io_err_in("COMMIT"))?,
+        end_lsn: c.read_u64::<BigEndian>().map_err(io_err_in("COMMIT"))?,
+        commit_ts: c.read_i64::<BigEndian>().map_err(io_err_in("COMMIT"))?,
     })
 }
 
 fn decode_relation(c: &mut Cursor<&[u8]>) -> Result<Relation, FaucetError> {
-    let oid = c.read_u32::<BigEndian>().map_err(io_err)?;
+    let oid = c.read_u32::<BigEndian>().map_err(io_err_in("RELATION"))?;
     let namespace = read_cstring(c)?;
     let name = read_cstring(c)?;
-    let replica_identity = ReplicaIdentity::from_byte(c.read_u8().map_err(io_err)?)?;
-    let n_columns = c.read_u16::<BigEndian>().map_err(io_err)?;
+    let replica_identity = ReplicaIdentity::from_byte(c.read_u8().map_err(io_err_in("RELATION"))?)?;
+    let n_columns = c.read_u16::<BigEndian>().map_err(io_err_in("RELATION"))?;
     let mut columns = Vec::with_capacity(n_columns as usize);
     for _ in 0..n_columns {
         columns.push(ColumnDesc {
-            flags: c.read_u8().map_err(io_err)?,
+            flags: c.read_u8().map_err(io_err_in("RELATION"))?,
             name: read_cstring(c)?,
-            type_oid: c.read_u32::<BigEndian>().map_err(io_err)?,
-            type_modifier: c.read_i32::<BigEndian>().map_err(io_err)?,
+            type_oid: c.read_u32::<BigEndian>().map_err(io_err_in("RELATION"))?,
+            type_modifier: c.read_i32::<BigEndian>().map_err(io_err_in("RELATION"))?,
         });
     }
     Ok(Relation {
@@ -126,8 +126,8 @@ fn decode_relation(c: &mut Cursor<&[u8]>) -> Result<Relation, FaucetError> {
 }
 
 fn decode_insert(c: &mut Cursor<&[u8]>) -> Result<Insert, FaucetError> {
-    let relation_oid = c.read_u32::<BigEndian>().map_err(io_err)?;
-    let tag = c.read_u8().map_err(io_err)?;
+    let relation_oid = c.read_u32::<BigEndian>().map_err(io_err_in("INSERT"))?;
+    let tag = c.read_u8().map_err(io_err_in("INSERT"))?;
     if tag != b'N' {
         return Err(FaucetError::Source(format!(
             "pgoutput INSERT: expected 'N' tuple tag, got {:?}",
@@ -141,25 +141,35 @@ fn decode_insert(c: &mut Cursor<&[u8]>) -> Result<Insert, FaucetError> {
 }
 
 fn decode_update(c: &mut Cursor<&[u8]>) -> Result<Update, FaucetError> {
-    let relation_oid = c.read_u32::<BigEndian>().map_err(io_err)?;
-    let mut tag = c.read_u8().map_err(io_err)?;
-    let (old_kind, old) = match tag {
-        b'K' => {
-            let t = decode_tuple(c)?;
-            tag = c.read_u8().map_err(io_err)?;
-            (UpdateOldKind::Key, Some(t))
+    let relation_oid = c.read_u32::<BigEndian>().map_err(io_err_in("UPDATE"))?;
+    let first = c.read_u8().map_err(io_err_in("UPDATE"))?;
+    let (old_kind, old) = match first {
+        b'K' => (UpdateOldKind::Key, Some(decode_tuple(c)?)),
+        b'O' => (UpdateOldKind::Full, Some(decode_tuple(c)?)),
+        b'N' => {
+            // No old tuple; the byte we just read is already the N tag, so
+            // decode the new tuple directly without re-reading.
+            return Ok(Update {
+                relation_oid,
+                old_kind: UpdateOldKind::None,
+                old: None,
+                new: decode_tuple(c)?,
+            });
         }
-        b'O' => {
-            let t = decode_tuple(c)?;
-            tag = c.read_u8().map_err(io_err)?;
-            (UpdateOldKind::Full, Some(t))
+        other => {
+            return Err(FaucetError::Source(format!(
+                "pgoutput UPDATE: invalid first tag byte {:?} (0x{other:02X}), \
+                 expected 'K', 'O', or 'N'",
+                other as char
+            )));
         }
-        _ => (UpdateOldKind::None, None),
     };
-    if tag != b'N' {
+    // After K or O old-tuple, the next byte must be 'N' for the new tuple.
+    let n_tag = c.read_u8().map_err(io_err_in("UPDATE"))?;
+    if n_tag != b'N' {
         return Err(FaucetError::Source(format!(
-            "pgoutput UPDATE: expected 'N' tuple tag, got {:?}",
-            tag as char
+            "pgoutput UPDATE: expected 'N' new-tuple tag after old tuple, got {:?}",
+            n_tag as char
         )));
     }
     Ok(Update {
@@ -171,8 +181,8 @@ fn decode_update(c: &mut Cursor<&[u8]>) -> Result<Update, FaucetError> {
 }
 
 fn decode_delete(c: &mut Cursor<&[u8]>) -> Result<Delete, FaucetError> {
-    let relation_oid = c.read_u32::<BigEndian>().map_err(io_err)?;
-    let tag = c.read_u8().map_err(io_err)?;
+    let relation_oid = c.read_u32::<BigEndian>().map_err(io_err_in("DELETE"))?;
+    let tag = c.read_u8().map_err(io_err_in("DELETE"))?;
     let old_kind = match tag {
         b'K' => DeleteOldKind::Key,
         b'O' => DeleteOldKind::Full,
@@ -191,11 +201,11 @@ fn decode_delete(c: &mut Cursor<&[u8]>) -> Result<Delete, FaucetError> {
 }
 
 fn decode_truncate(c: &mut Cursor<&[u8]>) -> Result<Truncate, FaucetError> {
-    let n = c.read_u32::<BigEndian>().map_err(io_err)?;
-    let flags = c.read_u8().map_err(io_err)?;
+    let n = c.read_u32::<BigEndian>().map_err(io_err_in("TRUNCATE"))?;
+    let flags = c.read_u8().map_err(io_err_in("TRUNCATE"))?;
     let mut oids = Vec::with_capacity(n as usize);
     for _ in 0..n {
-        oids.push(c.read_u32::<BigEndian>().map_err(io_err)?);
+        oids.push(c.read_u32::<BigEndian>().map_err(io_err_in("TRUNCATE"))?);
     }
     Ok(Truncate {
         relation_oids: oids,
@@ -205,17 +215,17 @@ fn decode_truncate(c: &mut Cursor<&[u8]>) -> Result<Truncate, FaucetError> {
 }
 
 fn decode_tuple(c: &mut Cursor<&[u8]>) -> Result<TupleData, FaucetError> {
-    let n = c.read_u16::<BigEndian>().map_err(io_err)?;
+    let n = c.read_u16::<BigEndian>().map_err(io_err_in("tuple"))?;
     let mut cells = Vec::with_capacity(n as usize);
     for _ in 0..n {
-        let kind = c.read_u8().map_err(io_err)?;
+        let kind = c.read_u8().map_err(io_err_in("tuple"))?;
         cells.push(match kind {
             b'n' => TupleCell::Null,
             b'u' => TupleCell::UnchangedToast,
             b't' => {
-                let len = c.read_u32::<BigEndian>().map_err(io_err)?;
+                let len = c.read_u32::<BigEndian>().map_err(io_err_in("tuple"))?;
                 let mut buf = vec![0u8; len as usize];
-                c.read_exact(&mut buf).map_err(io_err)?;
+                c.read_exact(&mut buf).map_err(io_err_in("tuple"))?;
                 TupleCell::Text(String::from_utf8(buf).map_err(|e| {
                     FaucetError::Source(format!("pgoutput tuple text not UTF-8: {e}"))
                 })?)
@@ -239,7 +249,7 @@ fn decode_tuple(c: &mut Cursor<&[u8]>) -> Result<TupleData, FaucetError> {
 fn read_cstring(c: &mut Cursor<&[u8]>) -> Result<String, FaucetError> {
     let mut out = Vec::new();
     loop {
-        let b = c.read_u8().map_err(io_err)?;
+        let b = c.read_u8().map_err(io_err_in("cstring"))?;
         if b == 0 {
             break;
         }
@@ -250,6 +260,10 @@ fn read_cstring(c: &mut Cursor<&[u8]>) -> Result<String, FaucetError> {
 
 fn io_err(e: std::io::Error) -> FaucetError {
     FaucetError::Source(format!("pgoutput decode: {e}"))
+}
+
+fn io_err_in(ctx: &'static str) -> impl Fn(std::io::Error) -> FaucetError {
+    move |e| FaucetError::Source(format!("pgoutput {ctx}: {e}"))
 }
 
 #[cfg(test)]
@@ -449,5 +463,79 @@ mod tests {
     fn decode_truncated_input_errors() {
         let bytes = hex("42 00 00"); // 'B' with no body
         assert!(decode_message(&bytes).is_err());
+    }
+
+    #[test]
+    fn decode_update_no_old_tuple() {
+        // 'U', relation=16384, 'N' (no K/O old), new{2, t,1,"1", t,3,"bob"}
+        let bytes = hex("55 \
+             00 00 40 00 \
+             4E \
+             00 02 74 00 00 00 01 31 74 00 00 00 03 62 6F 62");
+        match decode_message(&bytes).unwrap() {
+            Message::Update(u) => {
+                assert_eq!(u.old_kind, UpdateOldKind::None);
+                assert!(u.old.is_none());
+                assert_eq!(u.new.cells.len(), 2);
+                assert_eq!(u.new.cells[0], TupleCell::Text("1".into()));
+                assert_eq!(u.new.cells[1], TupleCell::Text("bob".into()));
+            }
+            other => panic!("expected Update, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_update_with_full_old_tuple() {
+        // 'U', relation=16384, 'O', old{2, t,1,"1", t,5,"alice"}, 'N', new{2, t,1,"1", t,3,"bob"}
+        let bytes = hex("55 \
+             00 00 40 00 \
+             4F \
+             00 02 74 00 00 00 01 31 74 00 00 00 05 61 6C 69 63 65 \
+             4E \
+             00 02 74 00 00 00 01 31 74 00 00 00 03 62 6F 62");
+        match decode_message(&bytes).unwrap() {
+            Message::Update(u) => {
+                assert_eq!(u.old_kind, UpdateOldKind::Full);
+                let old = u.old.expect("old tuple present");
+                assert_eq!(old.cells.len(), 2);
+                assert_eq!(old.cells[1], TupleCell::Text("alice".into()));
+                assert_eq!(u.new.cells[1], TupleCell::Text("bob".into()));
+            }
+            other => panic!("expected Update, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_truncate_restart_identity_only() {
+        // 'T', n=1, flags=0b10 (restart identity, no cascade), oid=16384
+        let bytes = hex("54 \
+             00 00 00 01 \
+             02 \
+             00 00 40 00");
+        match decode_message(&bytes).unwrap() {
+            Message::Truncate(t) => {
+                assert_eq!(t.relation_oids, vec![16384]);
+                assert!(!t.cascade);
+                assert!(t.restart_identity);
+            }
+            other => panic!("expected Truncate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_insert_empty_text_cell() {
+        // 'I', relation=16384, 'N', n=1, ('t', len=0)
+        let bytes = hex("49 \
+             00 00 40 00 \
+             4E \
+             00 01 \
+             74 00 00 00 00");
+        match decode_message(&bytes).unwrap() {
+            Message::Insert(i) => {
+                assert_eq!(i.new.cells.len(), 1);
+                assert_eq!(i.new.cells[0], TupleCell::Text(String::new()));
+            }
+            other => panic!("expected Insert, got {other:?}"),
+        }
     }
 }

--- a/crates/source/postgres-cdc/src/pgoutput/messages.rs
+++ b/crates/source/postgres-cdc/src/pgoutput/messages.rs
@@ -1,0 +1,1 @@
+//! pgoutput message types — Begin, Commit, Relation, Insert, Update, Delete, Truncate.

--- a/crates/source/postgres-cdc/src/pgoutput/messages.rs
+++ b/crates/source/postgres-cdc/src/pgoutput/messages.rs
@@ -1,1 +1,238 @@
-//! pgoutput message types — Begin, Commit, Relation, Insert, Update, Delete, Truncate.
+//! pgoutput message types — high-level structs decoded from the wire.
+
+// These types are consumed by `decoder.rs` (Task 5) and `stream.rs` (Task 9).
+// The dead-code allow can be removed once those modules land.
+#![allow(dead_code)]
+
+use faucet_core::FaucetError;
+
+/// pgoutput message kind byte (the first byte of every payload).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MessageKind {
+    Begin,
+    Commit,
+    Origin,
+    Relation,
+    Type,
+    Insert,
+    Update,
+    Delete,
+    Truncate,
+}
+
+impl MessageKind {
+    pub fn from_byte(b: u8) -> Result<Self, FaucetError> {
+        Ok(match b {
+            b'B' => Self::Begin,
+            b'C' => Self::Commit,
+            b'O' => Self::Origin,
+            b'R' => Self::Relation,
+            b'Y' => Self::Type,
+            b'I' => Self::Insert,
+            b'U' => Self::Update,
+            b'D' => Self::Delete,
+            b'T' => Self::Truncate,
+            other => {
+                return Err(FaucetError::Source(format!(
+                    "pgoutput: unknown message kind {:?} (0x{other:02X})",
+                    other as char
+                )));
+            }
+        })
+    }
+    pub fn as_byte(&self) -> u8 {
+        match self {
+            Self::Begin => b'B',
+            Self::Commit => b'C',
+            Self::Origin => b'O',
+            Self::Relation => b'R',
+            Self::Type => b'Y',
+            Self::Insert => b'I',
+            Self::Update => b'U',
+            Self::Delete => b'D',
+            Self::Truncate => b'T',
+        }
+    }
+}
+
+/// REPLICA IDENTITY setting reported in each Relation message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReplicaIdentity {
+    Default,
+    Nothing,
+    Full,
+    Index,
+}
+
+impl ReplicaIdentity {
+    pub fn from_byte(b: u8) -> Result<Self, FaucetError> {
+        Ok(match b {
+            b'd' => Self::Default,
+            b'n' => Self::Nothing,
+            b'f' => Self::Full,
+            b'i' => Self::Index,
+            other => {
+                return Err(FaucetError::Source(format!(
+                    "pgoutput: unknown replica identity {:?}",
+                    other as char
+                )));
+            }
+        })
+    }
+    pub fn as_byte(&self) -> u8 {
+        match self {
+            Self::Default => b'd',
+            Self::Nothing => b'n',
+            Self::Full => b'f',
+            Self::Index => b'i',
+        }
+    }
+}
+
+/// One column descriptor inside a Relation message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ColumnDesc {
+    pub flags: u8, // bit 0 = part of replica identity key
+    pub name: String,
+    pub type_oid: u32,
+    pub type_modifier: i32,
+}
+
+/// Decoded BEGIN message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Begin {
+    pub final_lsn: u64,
+    pub commit_ts: i64, // microseconds since 2000-01-01 UTC
+    pub xid: u32,
+}
+
+/// Decoded COMMIT message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Commit {
+    pub flags: u8,
+    pub commit_lsn: u64,
+    pub end_lsn: u64,
+    pub commit_ts: i64,
+}
+
+/// Decoded RELATION message — registers a relation OID and its column layout.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Relation {
+    pub oid: u32,
+    pub namespace: String,
+    pub name: String,
+    pub replica_identity: ReplicaIdentity,
+    pub columns: Vec<ColumnDesc>,
+}
+
+/// Decoded TupleData column entry (one cell of a row).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TupleCell {
+    /// SQL NULL.
+    Null,
+    /// Unchanged TOAST column — value not in the WAL; only the name is known.
+    UnchangedToast,
+    /// Text-encoded value (every column arrives this way when pgoutput is
+    /// started in text mode, which is the default).
+    Text(String),
+}
+
+/// Decoded TupleData — one row's worth of cells.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TupleData {
+    pub cells: Vec<TupleCell>,
+}
+
+/// Decoded INSERT message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Insert {
+    pub relation_oid: u32,
+    pub new: TupleData,
+}
+
+/// What kind of "old tuple" precedes the UPDATE's NEW tuple (if any).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UpdateOldKind {
+    /// No old tuple in the message (replica identity DEFAULT, key unchanged).
+    None,
+    /// 'K' — only the replica-identity-key columns are in the old tuple.
+    Key,
+    /// 'O' — the full old tuple (REPLICA IDENTITY FULL).
+    Full,
+}
+
+/// Decoded UPDATE message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Update {
+    pub relation_oid: u32,
+    pub old_kind: UpdateOldKind,
+    pub old: Option<TupleData>,
+    pub new: TupleData,
+}
+
+/// What kind of "old tuple" the DELETE carries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeleteOldKind {
+    Key,
+    Full,
+}
+
+/// Decoded DELETE message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Delete {
+    pub relation_oid: u32,
+    pub old_kind: DeleteOldKind,
+    pub old: TupleData,
+}
+
+/// Decoded TRUNCATE message — may target several relations at once.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Truncate {
+    pub relation_oids: Vec<u32>,
+    pub cascade: bool,
+    pub restart_identity: bool,
+}
+
+/// One fully-decoded pgoutput message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Message {
+    Begin(Begin),
+    Commit(Commit),
+    /// `O` — replication origin. We accept and ignore (not relevant for v1).
+    Origin,
+    Relation(Relation),
+    /// `Y` — custom-type registration. Accept and ignore for v1; if we ever
+    /// see a column whose type OID is one of these, we fall back to text.
+    Type,
+    Insert(Insert),
+    Update(Update),
+    Delete(Delete),
+    Truncate(Truncate),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn message_kind_byte_round_trip() {
+        for byte in [b'B', b'C', b'O', b'R', b'Y', b'I', b'U', b'D', b'T'] {
+            let kind = MessageKind::from_byte(byte).expect("known kind");
+            assert_eq!(kind.as_byte(), byte);
+        }
+    }
+
+    #[test]
+    fn message_kind_unknown_byte_errors() {
+        assert!(MessageKind::from_byte(b'Z').is_err());
+    }
+
+    #[test]
+    fn relation_replica_identity_round_trip() {
+        for byte in [b'd', b'n', b'f', b'i'] {
+            let id = ReplicaIdentity::from_byte(byte).expect("known");
+            assert_eq!(id.as_byte(), byte);
+        }
+        assert!(ReplicaIdentity::from_byte(b'x').is_err());
+    }
+}

--- a/crates/source/postgres-cdc/src/pgoutput/messages.rs
+++ b/crates/source/postgres-cdc/src/pgoutput/messages.rs
@@ -1,9 +1,5 @@
 //! pgoutput message types — high-level structs decoded from the wire.
 
-// These types are consumed by `decoder.rs` (Task 5) and `stream.rs` (Task 9).
-// The dead-code allow can be removed once those modules land.
-#![allow(dead_code)]
-
 use faucet_core::FaucetError;
 
 /// pgoutput message kind byte (the first byte of every payload).

--- a/crates/source/postgres-cdc/src/pgoutput/messages.rs
+++ b/crates/source/postgres-cdc/src/pgoutput/messages.rs
@@ -40,6 +40,7 @@ impl MessageKind {
             }
         })
     }
+
     pub fn as_byte(&self) -> u8 {
         match self {
             Self::Begin => b'B',
@@ -73,12 +74,13 @@ impl ReplicaIdentity {
             b'i' => Self::Index,
             other => {
                 return Err(FaucetError::Source(format!(
-                    "pgoutput: unknown replica identity {:?}",
+                    "pgoutput: unknown replica identity {:?} (0x{other:02X})",
                     other as char
                 )));
             }
         })
     }
+
     pub fn as_byte(&self) -> u8 {
         match self {
             Self::Default => b'd',
@@ -92,7 +94,8 @@ impl ReplicaIdentity {
 /// One column descriptor inside a Relation message.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ColumnDesc {
-    pub flags: u8, // bit 0 = part of replica identity key
+    /// Bit 0 = part of the replica identity key.
+    pub flags: u8,
     pub name: String,
     pub type_oid: u32,
     pub type_modifier: i32,
@@ -112,7 +115,7 @@ pub struct Commit {
     pub flags: u8,
     pub commit_lsn: u64,
     pub end_lsn: u64,
-    pub commit_ts: i64,
+    pub commit_ts: i64, // microseconds since 2000-01-01 UTC
 }
 
 /// Decoded RELATION message — registers a relation OID and its column layout.
@@ -173,7 +176,9 @@ pub struct Update {
 /// What kind of "old tuple" the DELETE carries.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DeleteOldKind {
+    /// `K` — only the replica-identity-key columns are in the old tuple.
     Key,
+    /// `O` — the full old tuple (REPLICA IDENTITY FULL).
     Full,
 }
 

--- a/crates/source/postgres-cdc/src/pgoutput/mod.rs
+++ b/crates/source/postgres-cdc/src/pgoutput/mod.rs
@@ -1,0 +1,7 @@
+//! pgoutput logical decoding protocol — message types, wire decoder,
+//! relation registry, value decoder.
+
+pub mod decoder;
+pub mod messages;
+pub mod registry;
+pub mod values;

--- a/crates/source/postgres-cdc/src/pgoutput/registry.rs
+++ b/crates/source/postgres-cdc/src/pgoutput/registry.rs
@@ -1,0 +1,1 @@
+//! Relation registry — caches Relation messages by OID for column name/type lookups.

--- a/crates/source/postgres-cdc/src/pgoutput/registry.rs
+++ b/crates/source/postgres-cdc/src/pgoutput/registry.rs
@@ -1,1 +1,68 @@
-//! Relation registry — caches Relation messages by OID for column name/type lookups.
+//! In-process cache of `Relation` messages so subsequent `Insert`/`Update`/
+//! `Delete` events can look up column names + type OIDs by relation OID.
+
+use super::messages::Relation;
+use faucet_core::FaucetError;
+use std::collections::HashMap;
+
+#[derive(Debug, Default)]
+pub struct RelationRegistry {
+    by_oid: HashMap<u32, Relation>,
+}
+
+impl RelationRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn insert(&mut self, rel: Relation) {
+        self.by_oid.insert(rel.oid, rel);
+    }
+
+    pub fn get(&self, oid: u32) -> Result<&Relation, FaucetError> {
+        self.by_oid.get(&oid).ok_or_else(|| {
+            FaucetError::Source(format!(
+                "pgoutput: change event for unknown relation oid {oid} \
+                 (Relation message must precede first change)"
+            ))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pgoutput::messages::ReplicaIdentity;
+
+    fn rel(oid: u32, name: &str) -> Relation {
+        Relation {
+            oid,
+            namespace: "public".into(),
+            name: name.into(),
+            replica_identity: ReplicaIdentity::Default,
+            columns: vec![],
+        }
+    }
+
+    #[test]
+    fn insert_then_get() {
+        let mut r = RelationRegistry::new();
+        r.insert(rel(16384, "users"));
+        assert_eq!(r.get(16384).unwrap().name, "users");
+    }
+
+    #[test]
+    fn second_insert_replaces() {
+        let mut r = RelationRegistry::new();
+        r.insert(rel(16384, "users_v1"));
+        r.insert(rel(16384, "users_v2"));
+        assert_eq!(r.get(16384).unwrap().name, "users_v2");
+    }
+
+    #[test]
+    fn missing_oid_errors() {
+        let r = RelationRegistry::new();
+        let err = r.get(99999).unwrap_err();
+        assert!(format!("{err}").contains("99999"));
+    }
+}

--- a/crates/source/postgres-cdc/src/pgoutput/values.rs
+++ b/crates/source/postgres-cdc/src/pgoutput/values.rs
@@ -1,1 +1,164 @@
-//! Column value decoder — maps Postgres OIDs and text/binary representations to `serde_json::Value`.
+//! Postgres type OID -> JSON Value mapping for text-mode tuple cells.
+//!
+//! Reference: <https://github.com/postgres/postgres/blob/master/src/include/catalog/pg_type.dat>
+//! Only the OIDs that ship with every Postgres install are special-cased;
+//! anything else falls back to a JSON string.
+
+use base64::Engine;
+use faucet_core::FaucetError;
+use serde_json::Value;
+
+// Selected pg_type built-in OIDs.
+const OID_BOOL: u32 = 16;
+const OID_BYTEA: u32 = 17;
+const OID_INT2: u32 = 21;
+const OID_INT4: u32 = 23;
+const OID_INT8: u32 = 20;
+const OID_FLOAT4: u32 = 700;
+const OID_FLOAT8: u32 = 701;
+const OID_NUMERIC: u32 = 1700;
+const OID_JSON: u32 = 114;
+const OID_JSONB: u32 = 3802;
+// date/time/timestamp/timestamptz fall through to string — Postgres'
+// canonical text form is already ISO-8601-ish and downstream consumers
+// don't agree on a single binary encoding.
+
+/// Decode a text-encoded value with the given column type OID into JSON.
+///
+/// Unknown OIDs and decode failures both fall back to wrapping the raw text
+/// in a JSON string — this is the safest default for a generic CDC
+/// connector. We never panic on bad data; the only way this returns `Err` is
+/// if a structurally promised invariant is violated (e.g. `OID_BYTEA` text
+/// that doesn't start with `\x`).
+pub fn text_to_json(type_oid: u32, text: &str) -> Result<Value, FaucetError> {
+    Ok(match type_oid {
+        OID_BOOL => match text {
+            "t" => Value::Bool(true),
+            "f" => Value::Bool(false),
+            other => {
+                return Err(FaucetError::Source(format!(
+                    "pgoutput: bool column has non-t/f text {other:?}"
+                )));
+            }
+        },
+        OID_INT2 | OID_INT4 | OID_INT8 => {
+            let n: i64 = text.parse().map_err(|e| {
+                FaucetError::Source(format!(
+                    "pgoutput: int (oid={type_oid}) parse {text:?}: {e}"
+                ))
+            })?;
+            Value::from(n)
+        }
+        OID_FLOAT4 | OID_FLOAT8 => match text {
+            "NaN" | "Infinity" | "-Infinity" => Value::Null,
+            other => {
+                let n: f64 = other.parse().map_err(|e| {
+                    FaucetError::Source(format!("pgoutput: float parse {text:?}: {e}"))
+                })?;
+                serde_json::Number::from_f64(n)
+                    .map(Value::Number)
+                    .unwrap_or(Value::Null)
+            }
+        },
+        OID_NUMERIC => Value::String(text.into()),
+        OID_BYTEA => {
+            let stripped = text.strip_prefix("\\x").ok_or_else(|| {
+                FaucetError::Source(format!(
+                    "pgoutput: bytea text {text:?} missing '\\x' prefix"
+                ))
+            })?;
+            let bytes = hex_decode(stripped)?;
+            Value::String(base64::engine::general_purpose::STANDARD.encode(bytes))
+        }
+        OID_JSON | OID_JSONB => serde_json::from_str(text).map_err(|e| {
+            FaucetError::Source(format!("pgoutput: json/jsonb parse {text:?}: {e}"))
+        })?,
+        _ => Value::String(text.into()),
+    })
+}
+
+fn hex_decode(s: &str) -> Result<Vec<u8>, FaucetError> {
+    if !s.len().is_multiple_of(2) {
+        return Err(FaucetError::Source(format!(
+            "pgoutput: bytea hex has odd length: {s:?}"
+        )));
+    }
+    let mut out = Vec::with_capacity(s.len() / 2);
+    for i in (0..s.len()).step_by(2) {
+        out.push(
+            u8::from_str_radix(&s[i..i + 2], 16)
+                .map_err(|e| FaucetError::Source(format!("pgoutput: bytea hex {s:?}: {e}")))?,
+        );
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn bool_t_and_f() {
+        assert_eq!(text_to_json(OID_BOOL, "t").unwrap(), json!(true));
+        assert_eq!(text_to_json(OID_BOOL, "f").unwrap(), json!(false));
+        assert!(text_to_json(OID_BOOL, "yes").is_err());
+    }
+
+    #[test]
+    fn integer_types() {
+        assert_eq!(text_to_json(OID_INT2, "32000").unwrap(), json!(32000));
+        assert_eq!(text_to_json(OID_INT4, "-1").unwrap(), json!(-1));
+        assert_eq!(
+            text_to_json(OID_INT8, "9223372036854775807").unwrap(),
+            json!(9223372036854775807_i64)
+        );
+        assert!(text_to_json(OID_INT4, "abc").is_err());
+    }
+
+    #[test]
+    fn floats() {
+        assert_eq!(text_to_json(OID_FLOAT8, "3.5").unwrap(), json!(3.5));
+        assert_eq!(text_to_json(OID_FLOAT8, "NaN").unwrap(), Value::Null);
+        assert_eq!(text_to_json(OID_FLOAT4, "Infinity").unwrap(), Value::Null);
+    }
+
+    #[test]
+    fn numeric_kept_as_string() {
+        assert_eq!(
+            text_to_json(OID_NUMERIC, "12345.67890").unwrap(),
+            json!("12345.67890")
+        );
+    }
+
+    #[test]
+    fn bytea_base64() {
+        // \xDEADBEEF -> base64 "3q2+7w=="
+        assert_eq!(
+            text_to_json(OID_BYTEA, "\\xDEADBEEF").unwrap(),
+            json!("3q2+7w==")
+        );
+        assert!(text_to_json(OID_BYTEA, "deadbeef").is_err()); // missing \x
+        assert!(text_to_json(OID_BYTEA, "\\xZZ").is_err()); // not hex
+    }
+
+    #[test]
+    fn json_columns_parsed() {
+        assert_eq!(
+            text_to_json(OID_JSON, r#"{"a":1}"#).unwrap(),
+            json!({"a": 1})
+        );
+        assert_eq!(
+            text_to_json(OID_JSONB, r#"[1,2,3]"#).unwrap(),
+            json!([1, 2, 3])
+        );
+    }
+
+    #[test]
+    fn unknown_oid_falls_back_to_string() {
+        assert_eq!(
+            text_to_json(99999, "2026-05-17 12:34:56+00").unwrap(),
+            json!("2026-05-17 12:34:56+00")
+        );
+    }
+}

--- a/crates/source/postgres-cdc/src/pgoutput/values.rs
+++ b/crates/source/postgres-cdc/src/pgoutput/values.rs
@@ -1,0 +1,1 @@
+//! Column value decoder — maps Postgres OIDs and text/binary representations to `serde_json::Value`.

--- a/crates/source/postgres-cdc/src/replication.rs
+++ b/crates/source/postgres-cdc/src/replication.rs
@@ -1,0 +1,1 @@
+//! Low-level replication-connection wrapper (slot lifecycle, COPY BOTH).

--- a/crates/source/postgres-cdc/src/replication.rs
+++ b/crates/source/postgres-cdc/src/replication.rs
@@ -1,1 +1,399 @@
-//! Low-level replication-connection wrapper (slot lifecycle, COPY BOTH).
+//! Low-level replication-connection wrapper.
+//!
+//! This module wraps [`pgwire_replication`] to provide the slot lifecycle
+//! (`ensure_slot`) and streaming helpers (`start_replication`, `recv`,
+//! `send_status_update`) used by the rest of the CDC source.
+//!
+//! # Design
+//!
+//! `pgwire_replication` handles everything from TCP connect through auth,
+//! `START_REPLICATION`, keepalive replies, and `StandbyStatusUpdate` — all
+//! internally.  The library delivers events as a typed enum; the
+//! [`ReplicationEvent::XLogData`] variant carries the raw pgoutput payload
+//! bytes (header already stripped) that our [`crate::pgoutput`] decoder
+//! consumes.
+//!
+//! Slot creation (`CREATE_REPLICATION_SLOT`) is a control-plane operation that
+//! requires an ordinary (non-replication) SQL connection, so `ensure_slot`
+//! uses [`sqlx`] for that single query.
+//!
+//! # Type aliases
+//!
+//! The plan requires stable names `Client` and `Duplex` so that Tasks 9+ can
+//! refer to concrete types.  We define:
+//!
+//! - [`Client`] — a lightweight holder of `ReplicationParams` used to verify
+//!   connectivity and create the replication slot, before the stream is
+//!   opened.
+//! - [`Duplex`] — the live replication stream; a thin wrapper around
+//!   [`pgwire_replication::ReplicationClient`].
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use bytes::Bytes;
+use faucet_core::FaucetError;
+use pgwire_replication::{Lsn, ReplicationClient, ReplicationConfig, ReplicationEvent, TlsConfig};
+use sqlx::postgres::PgConnectOptions;
+use sqlx::{Executor, PgConnection};
+use tracing::debug;
+
+/// Microseconds between the Unix epoch (1970-01-01) and the Postgres epoch
+/// (2000-01-01).  Used for converting between Postgres timestamps and Unix time.
+pub const POSTGRES_EPOCH_MICROS: i64 = 946_684_800_000_000;
+
+// ── Public type aliases ────────────────────────────────────────────────────
+
+/// Pre-stream handle.  Holds the validated `ReplicationParams` needed to open
+/// a replication slot or start streaming.  Obtained from [`connect`].
+pub struct Client {
+    // Will be read by `stream.rs` in a later task.
+    #[allow(dead_code)]
+    pub(crate) params: ReplicationParams<'static>,
+}
+
+/// Live replication stream.  Wraps [`pgwire_replication::ReplicationClient`].
+/// Obtained from [`start_replication`].
+pub struct Duplex {
+    inner: ReplicationClient,
+    /// Latest WAL end seen from XLogData / KeepAlive, used by `update_applied`.
+    last_wal_end: Lsn,
+}
+
+// ── Parameters ────────────────────────────────────────────────────────────
+
+/// All parameters required to establish a logical replication connection.
+///
+/// This struct is accepted by every function in this module.
+#[derive(Clone, Debug)]
+pub struct ReplicationParams<'a> {
+    /// `postgres://user:pass@host:port/db` style URL.
+    pub connection_url: &'a str,
+    /// Name of the replication slot (must already exist, or `create_slot_if_missing = true`).
+    pub slot_name: &'a str,
+    /// Publication name — must already exist on the server.
+    pub publication_name: &'a str,
+    /// pgoutput protocol version (1 or 2).
+    pub proto_version: u32,
+    /// Create the slot if it does not already exist.
+    pub create_slot_if_missing: bool,
+    /// Optional LSN to resume from.  `None` means "start from the slot's
+    /// `confirmed_flush_lsn`".
+    pub start_lsn: Option<u64>,
+    /// TCP keepalive interval for the replication connection.
+    pub tcp_keepalive: Duration,
+}
+
+// ── Helper: parse a postgres URL into (host, port, user, password, dbname) ─
+
+struct PgCoords {
+    host: String,
+    port: u16,
+    user: String,
+    password: String,
+    dbname: String,
+}
+
+fn parse_url(url: &str) -> Result<PgCoords, FaucetError> {
+    // Parse via the standard `url` crate so we can extract all components
+    // without relying on sqlx accessor methods that may not be public.
+    let parsed = url::Url::parse(url)
+        .map_err(|e| FaucetError::Config(format!("postgres-cdc: invalid connection URL: {e}")))?;
+
+    let host = parsed.host_str().unwrap_or("localhost").to_owned();
+    let port = parsed.port().unwrap_or(5432);
+    let user = parsed.username().to_owned();
+    let password = parsed.password().unwrap_or("").to_owned();
+    let dbname = parsed.path().trim_start_matches('/').to_owned();
+    let dbname = if dbname.is_empty() {
+        "postgres".to_owned()
+    } else {
+        dbname
+    };
+
+    Ok(PgCoords {
+        host,
+        port,
+        user,
+        password,
+        dbname,
+    })
+}
+
+// ── Public API ─────────────────────────────────────────────────────────────
+
+/// Validate connectivity and return a [`Client`] handle.
+///
+/// This function parses the connection URL and records the parameters.
+/// It does **not** open a TCP connection; actual connectivity is verified
+/// lazily when [`ensure_slot`] or [`start_replication`] is called.
+pub async fn connect(params: &ReplicationParams<'_>) -> Result<Client, FaucetError> {
+    // Eagerly validate the URL so bad configs fail fast.
+    let _ = parse_url(params.connection_url)?;
+    Ok(Client {
+        params: ReplicationParams {
+            connection_url: params.connection_url.to_owned().leak(),
+            slot_name: params.slot_name.to_owned().leak(),
+            publication_name: params.publication_name.to_owned().leak(),
+            proto_version: params.proto_version,
+            create_slot_if_missing: params.create_slot_if_missing,
+            start_lsn: params.start_lsn,
+            tcp_keepalive: params.tcp_keepalive,
+        },
+    })
+}
+
+/// Ensure the replication slot exists.
+///
+/// If the slot already exists this is a no-op.  If it does not exist and
+/// `create_if_missing` is `true`, the slot is created via
+/// `pg_create_logical_replication_slot`.  If `create_if_missing` is `false`
+/// and the slot is absent, an error is returned.
+pub async fn ensure_slot(
+    _client: &Client,
+    connection_url: &str,
+    slot_name: &str,
+    create_if_missing: bool,
+) -> Result<(), FaucetError> {
+    // Use sqlx for the control-plane query (not a replication connection).
+    let opts: PgConnectOptions = connection_url
+        .parse()
+        .map_err(|e| FaucetError::Config(format!("postgres-cdc: invalid connection URL: {e}")))?;
+
+    use sqlx::ConnectOptions as _;
+    let mut conn: PgConnection = opts
+        .connect()
+        .await
+        .map_err(|e| FaucetError::Source(format!("postgres-cdc ensure_slot connect: {e}")))?;
+
+    // Check whether the slot already exists.
+    let row: Option<(String,)> =
+        sqlx::query_as("SELECT slot_name::text FROM pg_replication_slots WHERE slot_name = $1")
+            .bind(slot_name)
+            .fetch_optional(&mut conn)
+            .await
+            .map_err(|e| FaucetError::Source(format!("postgres-cdc slot lookup: {e}")))?;
+
+    if row.is_some() {
+        debug!("postgres-cdc: replication slot '{slot_name}' already exists");
+        return Ok(());
+    }
+
+    if !create_if_missing {
+        return Err(FaucetError::Source(format!(
+            "postgres-cdc: replication slot '{slot_name}' does not exist \
+             and create_slot_if_missing = false"
+        )));
+    }
+
+    // Create the slot using the pgoutput plugin.
+    // `escape_simple` prevents injection via the slot name (already validated
+    // to [a-z0-9_] by config, but defence-in-depth doesn't hurt).
+    let sql = format!(
+        "SELECT pg_create_logical_replication_slot({}, 'pgoutput')",
+        quote_literal(slot_name)
+    );
+    conn.execute(sql.as_str())
+        .await
+        .map_err(|e| FaucetError::Source(format!("postgres-cdc create slot: {e}")))?;
+
+    debug!("postgres-cdc: created replication slot '{slot_name}'");
+    Ok(())
+}
+
+/// Open a logical replication stream and return a [`Duplex`] handle.
+///
+/// Internally this calls `pgwire_replication::ReplicationClient::connect`
+/// which handles TCP, TLS negotiation, auth, and `START_REPLICATION` in one
+/// shot.
+pub async fn start_replication(
+    _client: &Client,
+    params: &ReplicationParams<'_>,
+) -> Result<Duplex, FaucetError> {
+    let coords = parse_url(params.connection_url)?;
+
+    let start_lsn = Lsn::from_u64(params.start_lsn.unwrap_or(0));
+
+    let cfg = ReplicationConfig {
+        host: coords.host,
+        port: coords.port,
+        user: coords.user,
+        password: coords.password,
+        database: coords.dbname,
+        tls: TlsConfig::disabled(),
+        slot: params.slot_name.to_owned(),
+        publication: params.publication_name.to_owned(),
+        start_lsn,
+        stop_at_lsn: None,
+        // Use the caller-supplied keepalive as the status update interval.
+        status_interval: params.tcp_keepalive,
+        // Wake up at least every keepalive interval when idle.
+        idle_wakeup_interval: params.tcp_keepalive,
+        buffer_events: 8192,
+    };
+
+    let inner = ReplicationClient::connect(cfg)
+        .await
+        .map_err(|e| FaucetError::Source(format!("postgres-cdc start_replication: {e}")))?;
+
+    Ok(Duplex {
+        inner,
+        last_wal_end: start_lsn,
+    })
+}
+
+/// Report progress to the server (Standby Status Update).
+///
+/// `confirmed_lsn` is the highest LSN whose changes have been durably
+/// written to the sink.  The underlying library sends this feedback on its
+/// own keepalive schedule; calling this function additionally marks the
+/// progress so the next automatic feedback includes the latest position.
+///
+/// `reply_requested` mirrors the flag from the server's KeepAlive message
+/// (no-op here since the library handles immediate replies internally).
+pub async fn send_status_update(
+    duplex: &mut Duplex,
+    confirmed_lsn: u64,
+    _reply_requested: bool,
+) -> Result<(), FaucetError> {
+    duplex
+        .inner
+        .update_applied_lsn(Lsn::from_u64(confirmed_lsn));
+    Ok(())
+}
+
+/// Receive the next raw pgoutput payload from the server.
+///
+/// Returns:
+/// - `Ok(Some(bytes))` — an [`XLogData`][ReplicationEvent::XLogData] message
+///   with its 24-byte wire header already stripped.  These bytes are the exact
+///   input expected by [`crate::pgoutput::decode_message`].
+/// - `Ok(None)` — stream ended cleanly (slot stopped, stop LSN reached, or
+///   `Duplex` was shut down).
+/// - `Err(_)` — network / protocol error.
+///
+/// [`KeepAlive`][ReplicationEvent::KeepAlive] events are absorbed here and
+/// used to advance the applied-LSN watermark so the library's internal
+/// feedback loop stays current.  [`Begin`][ReplicationEvent::Begin] and
+/// [`Commit`][ReplicationEvent::Commit] are absorbed too — the caller's
+/// decoder re-derives those from the pgoutput payload.
+pub async fn recv(duplex: &mut Duplex) -> Result<Option<Bytes>, FaucetError> {
+    loop {
+        match duplex
+            .inner
+            .recv()
+            .await
+            .map_err(|e| FaucetError::Source(format!("postgres-cdc recv: {e}")))?
+        {
+            None => return Ok(None),
+
+            Some(ReplicationEvent::XLogData { data, wal_end, .. }) => {
+                if wal_end > duplex.last_wal_end {
+                    duplex.last_wal_end = wal_end;
+                }
+                return Ok(Some(data));
+            }
+
+            Some(ReplicationEvent::KeepAlive { wal_end, .. }) => {
+                // Advance watermark so the worker's periodic feedback is
+                // current even when we have nothing to ack ourselves.
+                if wal_end > duplex.last_wal_end {
+                    duplex.last_wal_end = wal_end;
+                    duplex.inner.update_applied_lsn(wal_end);
+                }
+                // Continue the loop — do not surface keepalives to the caller.
+            }
+
+            Some(ReplicationEvent::Begin { .. })
+            | Some(ReplicationEvent::Commit { .. })
+            | Some(ReplicationEvent::Message { .. }) => {
+                // Begin/Commit/Message are decoded from the XLogData payload
+                // by our pgoutput decoder upstream; absorb here.
+            }
+
+            Some(ReplicationEvent::StoppedAt { .. }) => {
+                return Ok(None);
+            }
+        }
+    }
+}
+
+// ── Clock helpers ──────────────────────────────────────────────────────────
+
+/// Current time as a Postgres-epoch timestamp (µs since 2000-01-01 UTC).
+///
+/// Used in Standby Status Update messages.
+pub fn postgres_clock_now() -> i64 {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default();
+    let unix_micros = (now.as_secs() as i64) * 1_000_000 + (now.subsec_micros() as i64);
+    unix_micros - POSTGRES_EPOCH_MICROS
+}
+
+/// Convert a Postgres-epoch timestamp (µs since 2000-01-01) to Unix
+/// milliseconds (ms since 1970-01-01).
+pub fn postgres_clock_to_unix_ms(ts: i64) -> i64 {
+    (POSTGRES_EPOCH_MICROS.saturating_add(ts)) / 1_000
+}
+
+// ── Private SQL helpers ────────────────────────────────────────────────────
+
+/// Wrap `s` in double-quotes for use as a Postgres identifier.
+/// Any embedded double-quote is doubled (`"` → `""`).
+/// Reserved for DDL statements (e.g. `DROP REPLICATION SLOT`); used in tests.
+#[allow(dead_code)]
+fn quote_slot(s: &str) -> String {
+    format!("\"{}\"", s.replace('"', "\"\""))
+}
+
+/// Escape a string for use in a Postgres literal (single-quote context).
+/// Any embedded single-quote is doubled (`'` → `''`).
+fn escape_simple(s: &str) -> String {
+    s.replace('\'', "''")
+}
+
+/// Produce a single-quoted Postgres string literal.
+fn quote_literal(s: &str) -> String {
+    format!("'{}'", escape_simple(s))
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{TimeZone, Utc};
+
+    /// Convenience: turn `postgres_clock_to_unix_ms`-compatible math into a
+    /// `DateTime<Utc>`.  Used by tests only.
+    fn postgres_clock_to_datetime(ts: i64) -> chrono::DateTime<Utc> {
+        Utc.timestamp_micros(POSTGRES_EPOCH_MICROS.saturating_add(ts))
+            .single()
+            .unwrap_or_else(Utc::now)
+    }
+
+    #[test]
+    fn postgres_clock_round_trip() {
+        let dt = Utc.with_ymd_and_hms(2026, 5, 17, 12, 0, 0).unwrap();
+        let pg_ts = dt.timestamp_micros() - POSTGRES_EPOCH_MICROS;
+        let back = postgres_clock_to_datetime(pg_ts);
+        assert_eq!(back, dt);
+    }
+
+    #[test]
+    fn unix_ms_conversion() {
+        let dt = Utc.with_ymd_and_hms(2026, 5, 17, 12, 0, 0).unwrap();
+        let pg_ts = dt.timestamp_micros() - POSTGRES_EPOCH_MICROS;
+        assert_eq!(postgres_clock_to_unix_ms(pg_ts), 1_779_019_200_000);
+    }
+
+    #[test]
+    fn quote_slot_simple() {
+        assert_eq!(quote_slot("faucet_slot"), "\"faucet_slot\"");
+    }
+
+    #[test]
+    fn escape_simple_doubles_quotes() {
+        assert_eq!(escape_simple("foo'bar"), "foo''bar");
+    }
+}

--- a/crates/source/postgres-cdc/src/replication.rs
+++ b/crates/source/postgres-cdc/src/replication.rs
@@ -8,10 +8,9 @@
 //!
 //! `pgwire_replication` handles everything from TCP connect through auth,
 //! `START_REPLICATION`, keepalive replies, and `StandbyStatusUpdate` — all
-//! internally.  The library delivers events as a typed enum; the
-//! [`ReplicationEvent::XLogData`] variant carries the raw pgoutput payload
-//! bytes (header already stripped) that our [`crate::pgoutput`] decoder
-//! consumes.
+//! internally.  The library delivers events as a typed enum; [`recv`] surfaces
+//! the full [`ReplicationEvent`] to callers (absorbing only [`KeepAlive`] and
+//! [`StoppedAt`] internally) so Tasks 9+ can observe transaction boundaries.
 //!
 //! Slot creation (`CREATE_REPLICATION_SLOT`) is a control-plane operation that
 //! requires an ordinary (non-replication) SQL connection, so `ensure_slot`
@@ -27,13 +26,19 @@
 //!   opened.
 //! - [`Duplex`] — the live replication stream; a thin wrapper around
 //!   [`pgwire_replication::ReplicationClient`].
+//!
+//! [`KeepAlive`]: ReplicationEvent::KeepAlive
+//! [`StoppedAt`]: ReplicationEvent::StoppedAt
 
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use bytes::Bytes;
 use faucet_core::FaucetError;
-use pgwire_replication::{Lsn, ReplicationClient, ReplicationConfig, ReplicationEvent, TlsConfig};
+use pgwire_replication::{Lsn, ReplicationClient, ReplicationConfig, TlsConfig};
 use sqlx::postgres::PgConnectOptions;
+
+/// Re-export so downstream modules (`stream.rs`, Task 9) can import the event
+/// type without depending on `pgwire_replication` directly.
+pub use pgwire_replication::ReplicationEvent;
 use sqlx::{Executor, PgConnection};
 use tracing::debug;
 
@@ -55,7 +60,9 @@ pub struct Client {
 /// Obtained from [`start_replication`].
 pub struct Duplex {
     inner: ReplicationClient,
-    /// Latest WAL end seen from XLogData / KeepAlive, used by `update_applied`.
+    /// Latest server WAL end seen on this stream. Read by `recv()` to
+    /// de-duplicate `update_applied_lsn` calls across repeated KeepAlives
+    /// with the same position. Not consulted by `send_status_update`.
     last_wal_end: Lsn,
 }
 
@@ -72,14 +79,18 @@ pub struct ReplicationParams<'a> {
     pub slot_name: &'a str,
     /// Publication name — must already exist on the server.
     pub publication_name: &'a str,
-    /// pgoutput protocol version (1 or 2).
+    /// pgoutput protocol version. Only `1` is currently supported.
     pub proto_version: u32,
     /// Create the slot if it does not already exist.
     pub create_slot_if_missing: bool,
     /// Optional LSN to resume from.  `None` means "start from the slot's
     /// `confirmed_flush_lsn`".
     pub start_lsn: Option<u64>,
-    /// TCP keepalive interval for the replication connection.
+    /// Protocol-level Standby Status Update cadence — must be shorter than
+    /// the server's `wal_sender_timeout`.
+    pub status_update_interval: Duration,
+    /// TCP-level keepalive interval. Larger than `status_update_interval`
+    /// in normal operation.
     pub tcp_keepalive: Duration,
 }
 
@@ -137,6 +148,8 @@ pub async fn connect(params: &ReplicationParams<'_>) -> Result<Client, FaucetErr
             proto_version: params.proto_version,
             create_slot_if_missing: params.create_slot_if_missing,
             start_lsn: params.start_lsn,
+            // Duration is Copy — no leak needed.
+            status_update_interval: params.status_update_interval,
             tcp_keepalive: params.tcp_keepalive,
         },
     })
@@ -209,6 +222,14 @@ pub async fn start_replication(
     _client: &Client,
     params: &ReplicationParams<'_>,
 ) -> Result<Duplex, FaucetError> {
+    if params.proto_version != 1 {
+        return Err(FaucetError::Config(format!(
+            "postgres-cdc: pgwire-replication 0.3.2 supports proto_version = 1 only; \
+             got {}",
+            params.proto_version
+        )));
+    }
+
     let coords = parse_url(params.connection_url)?;
 
     let start_lsn = Lsn::from_u64(params.start_lsn.unwrap_or(0));
@@ -224,10 +245,11 @@ pub async fn start_replication(
         publication: params.publication_name.to_owned(),
         start_lsn,
         stop_at_lsn: None,
-        // Use the caller-supplied keepalive as the status update interval.
-        status_interval: params.tcp_keepalive,
-        // Wake up at least every keepalive interval when idle.
-        idle_wakeup_interval: params.tcp_keepalive,
+        // Use the dedicated status-update interval (not tcp_keepalive) so that
+        // Standby Status Updates fire on their own cadence.
+        status_interval: params.status_update_interval,
+        // Wake up the worker at least as often as we send status updates.
+        idle_wakeup_interval: params.status_update_interval,
         buffer_events: 8192,
     };
 
@@ -261,22 +283,23 @@ pub async fn send_status_update(
     Ok(())
 }
 
-/// Receive the next raw pgoutput payload from the server.
+/// Receive the next meaningful replication event from the server.
 ///
 /// Returns:
-/// - `Ok(Some(bytes))` — an [`XLogData`][ReplicationEvent::XLogData] message
-///   with its 24-byte wire header already stripped.  These bytes are the exact
-///   input expected by [`crate::pgoutput::decode_message`].
+/// - `Ok(Some(event))` — the next [`ReplicationEvent`] that the caller should
+///   handle.  This includes [`ReplicationEvent::XLogData`],
+///   [`ReplicationEvent::Begin`], [`ReplicationEvent::Commit`], and
+///   [`ReplicationEvent::Message`].  Callers (Task 9+) can match on the full
+///   event type to observe transaction boundaries.
 /// - `Ok(None)` — stream ended cleanly (slot stopped, stop LSN reached, or
 ///   `Duplex` was shut down).
 /// - `Err(_)` — network / protocol error.
 ///
-/// [`KeepAlive`][ReplicationEvent::KeepAlive] events are absorbed here and
-/// used to advance the applied-LSN watermark so the library's internal
-/// feedback loop stays current.  [`Begin`][ReplicationEvent::Begin] and
-/// [`Commit`][ReplicationEvent::Commit] are absorbed too — the caller's
-/// decoder re-derives those from the pgoutput payload.
-pub async fn recv(duplex: &mut Duplex) -> Result<Option<Bytes>, FaucetError> {
+/// [`ReplicationEvent::KeepAlive`] events are absorbed here and used to
+/// advance the applied-LSN watermark so the library's internal feedback loop
+/// stays current.  [`ReplicationEvent::StoppedAt`] is converted to
+/// `Ok(None)`.
+pub async fn recv(duplex: &mut Duplex) -> Result<Option<ReplicationEvent>, FaucetError> {
     loop {
         match duplex
             .inner
@@ -286,15 +309,12 @@ pub async fn recv(duplex: &mut Duplex) -> Result<Option<Bytes>, FaucetError> {
         {
             None => return Ok(None),
 
-            Some(ReplicationEvent::XLogData { data, wal_end, .. }) => {
-                if wal_end > duplex.last_wal_end {
-                    duplex.last_wal_end = wal_end;
-                }
-                return Ok(Some(data));
+            Some(ReplicationEvent::StoppedAt { .. }) => {
+                return Ok(None);
             }
 
             Some(ReplicationEvent::KeepAlive { wal_end, .. }) => {
-                // Advance watermark so the worker's periodic feedback is
+                // Advance watermark so the library's periodic feedback is
                 // current even when we have nothing to ack ourselves.
                 if wal_end > duplex.last_wal_end {
                     duplex.last_wal_end = wal_end;
@@ -303,15 +323,16 @@ pub async fn recv(duplex: &mut Duplex) -> Result<Option<Bytes>, FaucetError> {
                 // Continue the loop — do not surface keepalives to the caller.
             }
 
-            Some(ReplicationEvent::Begin { .. })
-            | Some(ReplicationEvent::Commit { .. })
-            | Some(ReplicationEvent::Message { .. }) => {
-                // Begin/Commit/Message are decoded from the XLogData payload
-                // by our pgoutput decoder upstream; absorb here.
-            }
-
-            Some(ReplicationEvent::StoppedAt { .. }) => {
-                return Ok(None);
+            Some(ev) => {
+                // Surface Begin, Commit, XLogData, Message (and any future
+                // variants) to the caller.  For XLogData, also advance the
+                // last_wal_end watermark so bookmarking stays accurate.
+                if let ReplicationEvent::XLogData { wal_end, .. } = &ev
+                    && *wal_end > duplex.last_wal_end
+                {
+                    duplex.last_wal_end = *wal_end;
+                }
+                return Ok(Some(ev));
             }
         }
     }

--- a/crates/source/postgres-cdc/src/state.rs
+++ b/crates/source/postgres-cdc/src/state.rs
@@ -1,0 +1,3 @@
+//! Bookmark <-> JSON serialization for replication slot LSN progress.
+
+pub struct Bookmark;

--- a/crates/source/postgres-cdc/src/state.rs
+++ b/crates/source/postgres-cdc/src/state.rs
@@ -1,3 +1,137 @@
 //! Bookmark <-> JSON serialization for replication slot LSN progress.
+//!
+//! Bookmark shape (round-trips through `serde_json::Value`):
+//!
+//! ```json
+//! { "last_lsn": "0/16A4F88" }
+//! ```
+//!
+//! `last_lsn` is the `commit_lsn` of the last transaction whose change
+//! records have been written to the sink — i.e. the position to resume
+//! *after* on the next `START_REPLICATION`.
 
-pub struct Bookmark;
+use faucet_core::FaucetError;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Durable bookmark for a `PostgresCdcSource`.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Bookmark {
+    /// LSN in Postgres' canonical hex form: `XXXXXXXX/XXXXXXXX`.
+    pub last_lsn: String,
+}
+
+impl Bookmark {
+    /// Parse a `Value` previously emitted by `to_value`.
+    pub fn from_value(v: Value) -> Result<Self, FaucetError> {
+        let b: Self = serde_json::from_value(v)
+            .map_err(|e| FaucetError::State(format!("postgres-cdc bookmark parse: {e}")))?;
+        parse_lsn(&b.last_lsn)?;
+        Ok(b)
+    }
+
+    /// Serialize for the state store.
+    pub fn to_value(&self) -> Result<Value, FaucetError> {
+        serde_json::to_value(self)
+            .map_err(|e| FaucetError::State(format!("postgres-cdc bookmark serialize: {e}")))
+    }
+
+    /// Build a Bookmark from a raw 64-bit LSN value.
+    pub fn from_u64(lsn: u64) -> Self {
+        Self {
+            last_lsn: format_lsn(lsn),
+        }
+    }
+
+    /// Parse `last_lsn` into a `u64` for wire-protocol use.
+    pub fn as_u64(&self) -> Result<u64, FaucetError> {
+        parse_lsn(&self.last_lsn)
+    }
+}
+
+/// Format a `u64` LSN into Postgres' `XXXXXXXX/XXXXXXXX` text form, dropping
+/// leading zeros from each half (matches `pg_lsn::out`).
+pub fn format_lsn(lsn: u64) -> String {
+    let hi = (lsn >> 32) as u32;
+    let lo = lsn as u32;
+    format!("{hi:X}/{lo:X}")
+}
+
+/// Parse `XXXX/XXXX` (case-insensitive hex, no leading zeros required) into a
+/// `u64`. Returns `FaucetError::State` on any malformation.
+pub fn parse_lsn(s: &str) -> Result<u64, FaucetError> {
+    let (hi, lo) = s.split_once('/').ok_or_else(|| {
+        FaucetError::State(format!("postgres-cdc invalid LSN '{s}': missing '/'"))
+    })?;
+    if hi.is_empty() || lo.is_empty() || hi.contains('/') || lo.contains('/') {
+        return Err(FaucetError::State(format!(
+            "postgres-cdc invalid LSN '{s}'"
+        )));
+    }
+    let hi = u32::from_str_radix(hi, 16)
+        .map_err(|e| FaucetError::State(format!("postgres-cdc LSN high half '{hi}': {e}")))?;
+    let lo = u32::from_str_radix(lo, 16)
+        .map_err(|e| FaucetError::State(format!("postgres-cdc LSN low half '{lo}': {e}")))?;
+    Ok((u64::from(hi) << 32) | u64::from(lo))
+}
+
+/// Generate the `state_key` for a given replication slot.
+///
+/// Allowed characters per `faucet_core::state::validate_state_key` are
+/// `[A-Za-z0-9_:.-]`. Postgres slot names are constrained to `[a-z0-9_]`, so
+/// every key is valid by construction.
+pub fn state_key(slot_name: &str) -> String {
+    format!("postgres-cdc:{slot_name}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn round_trip_via_value() {
+        let b = Bookmark {
+            last_lsn: "0/16A4F88".into(),
+        };
+        let v = b.to_value().unwrap();
+        let parsed = Bookmark::from_value(v).unwrap();
+        assert_eq!(parsed.last_lsn, "0/16A4F88");
+    }
+
+    #[test]
+    fn from_value_rejects_garbage() {
+        assert!(Bookmark::from_value(json!({"last_lsn": 42})).is_err());
+        assert!(Bookmark::from_value(json!({})).is_err());
+        assert!(Bookmark::from_value(json!("bare string")).is_err());
+    }
+
+    #[test]
+    fn from_value_rejects_malformed_lsn() {
+        assert!(Bookmark::from_value(json!({"last_lsn": ""})).is_err());
+        assert!(Bookmark::from_value(json!({"last_lsn": "not-an-lsn"})).is_err());
+        assert!(Bookmark::from_value(json!({"last_lsn": "0/"})).is_err());
+        assert!(Bookmark::from_value(json!({"last_lsn": "/0"})).is_err());
+        assert!(Bookmark::from_value(json!({"last_lsn": "0/16A4F88/extra"})).is_err());
+    }
+
+    #[test]
+    fn from_value_accepts_canonical_lsn() {
+        let ok = Bookmark::from_value(json!({"last_lsn": "1A/BEEFCAFE"})).unwrap();
+        assert_eq!(ok.last_lsn, "1A/BEEFCAFE");
+    }
+
+    #[test]
+    fn lsn_u64_round_trip() {
+        let b = Bookmark::from_u64(0x1A_BEEF_CAFE);
+        // 0x1A_BEEF_CAFE = 0x1A_0000_0000 | 0xBEEF_CAFE → "1A/BEEFCAFE"
+        // (the high 32 bits are the WAL segment, low 32 are the offset)
+        assert_eq!(b.last_lsn, "1A/BEEFCAFE");
+        assert_eq!(b.as_u64().unwrap(), 0x1A_BEEF_CAFE);
+    }
+
+    #[test]
+    fn state_key_for_slot() {
+        assert_eq!(state_key("faucet_slot"), "postgres-cdc:faucet_slot");
+    }
+}

--- a/crates/source/postgres-cdc/src/state.rs
+++ b/crates/source/postgres-cdc/src/state.rs
@@ -63,7 +63,7 @@ pub fn parse_lsn(s: &str) -> Result<u64, FaucetError> {
     let (hi, lo) = s.split_once('/').ok_or_else(|| {
         FaucetError::State(format!("postgres-cdc invalid LSN '{s}': missing '/'"))
     })?;
-    if hi.is_empty() || lo.is_empty() || hi.contains('/') || lo.contains('/') {
+    if hi.is_empty() || lo.is_empty() || lo.contains('/') {
         return Err(FaucetError::State(format!(
             "postgres-cdc invalid LSN '{s}'"
         )));
@@ -133,5 +133,26 @@ mod tests {
     #[test]
     fn state_key_for_slot() {
         assert_eq!(state_key("faucet_slot"), "postgres-cdc:faucet_slot");
+    }
+
+    #[test]
+    fn parse_lsn_is_case_insensitive() {
+        assert_eq!(
+            parse_lsn("0/16a4f88").unwrap(),
+            parse_lsn("0/16A4F88").unwrap()
+        );
+        assert_eq!(
+            parse_lsn("1a/beefcafe").unwrap(),
+            parse_lsn("1A/BEEFCAFE").unwrap()
+        );
+    }
+
+    #[test]
+    fn format_parse_lsn_boundaries() {
+        assert_eq!(parse_lsn(&format_lsn(0)).unwrap(), 0);
+        assert_eq!(parse_lsn(&format_lsn(u64::MAX)).unwrap(), u64::MAX);
+        // also verify a value with non-zero high+low so the `(hi << 32) | lo` join is exercised
+        let v: u64 = 0x1234_5678_9ABC_DEF0;
+        assert_eq!(parse_lsn(&format_lsn(v)).unwrap(), v);
     }
 }

--- a/crates/source/postgres-cdc/src/stream.rs
+++ b/crates/source/postgres-cdc/src/stream.rs
@@ -1,3 +1,548 @@
-//! `PostgresCdcSource` — the public `Source` implementation.
+//! `PostgresCdcSource` — public `Source` implementation.
 
-pub struct PostgresCdcSource;
+use crate::config::PostgresCdcSourceConfig;
+use crate::pgoutput::decoder::decode_message;
+use crate::pgoutput::messages::{
+    Delete, Insert, Message, Relation, Truncate, TupleCell, TupleData, Update,
+};
+use crate::pgoutput::registry::RelationRegistry;
+use crate::pgoutput::values::text_to_json;
+use crate::replication::{
+    self, ReplicationEvent, ReplicationParams, postgres_clock_to_unix_ms, recv, send_status_update,
+};
+use crate::state::{Bookmark, format_lsn, parse_lsn, state_key};
+use async_trait::async_trait;
+use faucet_core::{FaucetError, Source};
+use serde_json::{Map, Value, json};
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+use tokio::sync::Mutex;
+
+pub struct PostgresCdcSource {
+    config: PostgresCdcSourceConfig,
+    state_key_value: String,
+    /// Bookmark provided by `apply_start_bookmark`, applied at the start of
+    /// the next fetch cycle. Becomes the new "confirmed_flush_lsn" we
+    /// advertise to Postgres.
+    pending_bookmark: Mutex<Option<Bookmark>>,
+    /// Last LSN we have told Postgres is durable. Advanced by
+    /// `apply_start_bookmark` (after the state store persists a bookmark)
+    /// and by the end of `fetch_with_context_incremental` if any txn
+    /// committed during the drain.
+    confirmed_lsn: Mutex<u64>,
+}
+
+impl PostgresCdcSource {
+    pub async fn new(config: PostgresCdcSourceConfig) -> Result<Self, FaucetError> {
+        config.validate()?;
+        let key = state_key(&config.slot_name);
+        let initial_lsn = match config.start_lsn.as_deref() {
+            Some(s) => parse_lsn(s)?,
+            None => 0,
+        };
+        Ok(Self {
+            config,
+            state_key_value: key,
+            pending_bookmark: Mutex::new(None),
+            confirmed_lsn: Mutex::new(initial_lsn),
+        })
+    }
+}
+
+#[async_trait]
+impl Source for PostgresCdcSource {
+    async fn fetch_with_context(
+        &self,
+        ctx: &HashMap<String, Value>,
+    ) -> Result<Vec<Value>, FaucetError> {
+        let (records, _bookmark) = self.fetch_with_context_incremental(ctx).await?;
+        Ok(records)
+    }
+
+    async fn fetch_with_context_incremental(
+        &self,
+        _ctx: &HashMap<String, Value>,
+    ) -> Result<(Vec<Value>, Option<Value>), FaucetError> {
+        // 1. Resolve start_lsn for THIS fetch cycle.
+        let bookmark = {
+            let mut g = self.pending_bookmark.lock().await;
+            g.take()
+        };
+        let start_lsn = if let Some(b) = bookmark.as_ref() {
+            let lsn = b.as_u64()?;
+            *self.confirmed_lsn.lock().await = lsn;
+            Some(lsn)
+        } else {
+            self.config
+                .start_lsn
+                .as_deref()
+                .map(parse_lsn)
+                .transpose()?
+        };
+
+        // 2. Open replication connection + ensure slot + START_REPLICATION.
+        let params = ReplicationParams {
+            connection_url: &self.config.connection_url,
+            slot_name: &self.config.slot_name,
+            publication_name: &self.config.publication_name,
+            proto_version: self.config.proto_version,
+            create_slot_if_missing: self.config.create_slot_if_missing,
+            start_lsn,
+            status_update_interval: self.config.status_update_interval,
+            tcp_keepalive: self.config.tcp_keepalive,
+        };
+        let client = replication::connect(&params).await?;
+        replication::ensure_slot(
+            &client,
+            &self.config.connection_url,
+            &self.config.slot_name,
+            self.config.create_slot_if_missing,
+        )
+        .await?;
+        let mut duplex = replication::start_replication(&client, &params).await?;
+
+        // 3. Advance the slot's confirmed_flush_lsn to the bookmarked LSN.
+        let initial_confirmed = *self.confirmed_lsn.lock().await;
+        send_status_update(&mut duplex, initial_confirmed, false).await?;
+
+        // 4. Drain the replication stream until idle_timeout or max_messages.
+        let mut records: Vec<Value> = Vec::new();
+        let mut registry = RelationRegistry::new();
+        let mut state = TxnState::default();
+        let max_messages = self.config.max_messages.unwrap_or(usize::MAX);
+        let idle_timeout = self.config.idle_timeout;
+        let mut last_message_at = Instant::now();
+
+        loop {
+            let idle_deadline = last_message_at + idle_timeout;
+            let budget = idle_deadline
+                .checked_duration_since(Instant::now())
+                .unwrap_or(Duration::ZERO);
+
+            tokio::select! {
+                biased;
+                _ = tokio::signal::ctrl_c() => {
+                    tracing::info!("postgres-cdc: ctrl_c received, stopping cleanly");
+                    break;
+                }
+                ev = tokio::time::timeout(budget, recv(&mut duplex)) => {
+                    match ev {
+                        Ok(Ok(Some(event))) => {
+                            last_message_at = Instant::now();
+                            handle_event(event, &mut registry, &mut state, &mut records)?;
+                            if records.len() >= max_messages {
+                                break;
+                            }
+                        }
+                        Ok(Ok(None)) => {
+                            return Err(FaucetError::Source(
+                                "postgres-cdc: replication stream ended unexpectedly".into(),
+                            ));
+                        }
+                        Ok(Err(e)) => return Err(e),
+                        Err(_timeout) => {
+                            tracing::debug!("postgres-cdc: idle_timeout reached, stopping");
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        // 5. Compute the new bookmark. It's the commit_lsn of the LAST fully-
+        //    applied transaction. None means: this drain didn't see any COMMIT,
+        //    so nothing new to persist.
+        let bookmark_value = if let Some(lsn) = state.last_committed {
+            *self.confirmed_lsn.lock().await = lsn;
+            Some(Bookmark::from_u64(lsn).to_value()?)
+        } else {
+            None
+        };
+        Ok((records, bookmark_value))
+    }
+
+    fn config_schema(&self) -> Value {
+        let schema = schemars::schema_for!(PostgresCdcSourceConfig);
+        serde_json::to_value(&schema).unwrap_or(Value::Null)
+    }
+
+    fn state_key(&self) -> Option<String> {
+        Some(self.state_key_value.clone())
+    }
+
+    async fn apply_start_bookmark(&self, bookmark: Value) -> Result<(), FaucetError> {
+        let parsed = Bookmark::from_value(bookmark)?;
+        // Update confirmed_lsn so the next initial status update (in the next
+        // fetch cycle) advertises the correct position.
+        *self.confirmed_lsn.lock().await = parsed.as_u64()?;
+        *self.pending_bookmark.lock().await = Some(parsed);
+        Ok(())
+    }
+}
+
+/// In-flight transaction state while draining the replication stream.
+#[derive(Default)]
+struct TxnState {
+    /// Records produced inside the current BEGIN..COMMIT, buffered until
+    /// COMMIT is seen so partial transactions never leak into the output.
+    staged: Vec<Value>,
+    /// commit_lsn of the most recently fully-applied transaction.
+    last_committed: Option<u64>,
+    /// commit_ts (Postgres epoch micros) of the in-progress transaction,
+    /// set by BEGIN.
+    in_progress_ts: i64,
+    /// commit_lsn announced by the in-progress BEGIN (== final_lsn).
+    in_progress_lsn: u64,
+    /// Whether we are currently inside a BEGIN..COMMIT pair.
+    in_txn: bool,
+}
+
+fn handle_event(
+    event: ReplicationEvent,
+    registry: &mut RelationRegistry,
+    state: &mut TxnState,
+    out: &mut Vec<Value>,
+) -> Result<(), FaucetError> {
+    match event {
+        ReplicationEvent::Begin {
+            final_lsn,
+            commit_time_micros,
+            xid: _,
+        } => {
+            state.in_txn = true;
+            state.in_progress_lsn = final_lsn.as_u64();
+            state.in_progress_ts = commit_time_micros;
+            state.staged.clear();
+        }
+        ReplicationEvent::Commit {
+            lsn,
+            commit_time_micros: _,
+            end_lsn: _,
+        } => {
+            if !state.in_txn {
+                return Err(FaucetError::Source(
+                    "postgres-cdc: COMMIT without BEGIN".into(),
+                ));
+            }
+            out.append(&mut state.staged);
+            state.last_committed = Some(lsn.as_u64());
+            state.in_txn = false;
+        }
+        ReplicationEvent::XLogData { data, .. } => {
+            let msg = decode_message(&data)?;
+            handle_pgoutput(msg, registry, state)?;
+        }
+        ReplicationEvent::Message { .. } => {
+            // pg_logical_emit_message — ignore for v1.
+        }
+        // KeepAlive and StoppedAt are filtered inside recv(); if they appear
+        // here it's a bug in the lib upgrade — surface explicitly.
+        other => {
+            tracing::warn!(?other, "postgres-cdc: unexpected ReplicationEvent variant");
+        }
+    }
+    Ok(())
+}
+
+fn handle_pgoutput(
+    msg: Message,
+    registry: &mut RelationRegistry,
+    state: &mut TxnState,
+) -> Result<(), FaucetError> {
+    match msg {
+        Message::Relation(r) => registry.insert(r),
+        Message::Origin | Message::Type => {} // ignored
+        Message::Insert(i) => stage_insert(state, registry, i)?,
+        Message::Update(u) => stage_update(state, registry, u)?,
+        Message::Delete(d) => stage_delete(state, registry, d)?,
+        Message::Truncate(t) => stage_truncate(state, registry, t)?,
+        // Begin/Commit pgoutput messages should never arrive here — the
+        // pgwire-replication library decodes them into structured
+        // ReplicationEvent::Begin / Commit variants, handled in handle_event.
+        // If we see one, log a warning and ignore.
+        Message::Begin(_) | Message::Commit(_) => {
+            tracing::warn!(
+                "postgres-cdc: pgoutput Begin/Commit reached pgoutput decoder; \
+                 pgwire-replication should have intercepted it"
+            );
+        }
+    }
+    Ok(())
+}
+
+fn stage_insert(
+    state: &mut TxnState,
+    registry: &RelationRegistry,
+    i: Insert,
+) -> Result<(), FaucetError> {
+    let rel = registry.get(i.relation_oid)?;
+    let after = tuple_to_object(rel, &i.new)?;
+    let r = record(rel, "insert", state, None, Some(after));
+    state.staged.push(r);
+    Ok(())
+}
+
+fn stage_update(
+    state: &mut TxnState,
+    registry: &RelationRegistry,
+    u: Update,
+) -> Result<(), FaucetError> {
+    let rel = registry.get(u.relation_oid)?;
+    let before = match &u.old {
+        Some(t) => Some(tuple_to_object(rel, t)?),
+        None => None,
+    };
+    let after = tuple_to_object(rel, &u.new)?;
+    let r = record(rel, "update", state, before, Some(after));
+    state.staged.push(r);
+    Ok(())
+}
+
+fn stage_delete(
+    state: &mut TxnState,
+    registry: &RelationRegistry,
+    d: Delete,
+) -> Result<(), FaucetError> {
+    let rel = registry.get(d.relation_oid)?;
+    let before = Some(tuple_to_object(rel, &d.old)?);
+    let r = record(rel, "delete", state, before, None);
+    state.staged.push(r);
+    Ok(())
+}
+
+fn stage_truncate(
+    state: &mut TxnState,
+    registry: &RelationRegistry,
+    t: Truncate,
+) -> Result<(), FaucetError> {
+    for oid in &t.relation_oids {
+        let rel = registry.get(*oid)?;
+        let r = record(rel, "truncate", state, None, None);
+        state.staged.push(r);
+    }
+    Ok(())
+}
+
+fn record(
+    rel: &Relation,
+    op: &str,
+    state: &TxnState,
+    before: Option<(Map<String, Value>, Vec<String>)>,
+    after: Option<(Map<String, Value>, Vec<String>)>,
+) -> Value {
+    let mut obj = Map::new();
+    obj.insert("op".into(), json!(op));
+    obj.insert("schema".into(), json!(rel.namespace));
+    obj.insert("table".into(), json!(rel.name));
+    obj.insert("lsn".into(), json!(format_lsn(state.in_progress_lsn)));
+    obj.insert(
+        "ts_ms".into(),
+        json!(postgres_clock_to_unix_ms(state.in_progress_ts)),
+    );
+    obj.insert(
+        "before".into(),
+        before
+            .map(|(m, _toast)| Value::Object(m))
+            .unwrap_or(Value::Null),
+    );
+    obj.insert(
+        "after".into(),
+        match after {
+            Some((m, toast)) => {
+                let mut o = m;
+                if !toast.is_empty() {
+                    o.insert("__unchanged_toast__".into(), json!(toast));
+                }
+                Value::Object(o)
+            }
+            None => Value::Null,
+        },
+    );
+    Value::Object(obj)
+}
+
+/// Convert a tuple's text cells to a `(JSON object, unchanged-TOAST column names)` pair.
+fn tuple_to_object(
+    rel: &Relation,
+    tup: &TupleData,
+) -> Result<(Map<String, Value>, Vec<String>), FaucetError> {
+    if tup.cells.len() != rel.columns.len() {
+        return Err(FaucetError::Source(format!(
+            "postgres-cdc: tuple has {} cells but relation {} has {} columns",
+            tup.cells.len(),
+            rel.name,
+            rel.columns.len()
+        )));
+    }
+    let mut obj = Map::with_capacity(rel.columns.len());
+    let mut unchanged = Vec::new();
+    for (col, cell) in rel.columns.iter().zip(&tup.cells) {
+        match cell {
+            TupleCell::Null => {
+                obj.insert(col.name.clone(), Value::Null);
+            }
+            TupleCell::UnchangedToast => {
+                unchanged.push(col.name.clone());
+            }
+            TupleCell::Text(s) => {
+                obj.insert(col.name.clone(), text_to_json(col.type_oid, s)?);
+            }
+        }
+    }
+    Ok((obj, unchanged))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pgoutput::messages::{ColumnDesc, ReplicaIdentity};
+    use crate::replication::ReplicationEvent;
+    use pgwire_replication::Lsn;
+
+    fn rel_users() -> Relation {
+        Relation {
+            oid: 16384,
+            namespace: "public".into(),
+            name: "users".into(),
+            replica_identity: ReplicaIdentity::Default,
+            columns: vec![
+                ColumnDesc {
+                    flags: 1,
+                    name: "id".into(),
+                    type_oid: 23,
+                    type_modifier: -1,
+                },
+                ColumnDesc {
+                    flags: 0,
+                    name: "name".into(),
+                    type_oid: 25,
+                    type_modifier: -1,
+                },
+            ],
+        }
+    }
+
+    fn insert_xlogdata(relation_oid: u32, cells: &[(&str, &str)]) -> ReplicationEvent {
+        // Build an XLogData event whose `data` is an INSERT pgoutput payload
+        // matching the test's expected cells.
+        let mut buf: Vec<u8> = Vec::new();
+        buf.push(b'I');
+        buf.extend_from_slice(&relation_oid.to_be_bytes());
+        buf.push(b'N');
+        let n: u16 = cells.len() as u16;
+        buf.extend_from_slice(&n.to_be_bytes());
+        for (_, val) in cells {
+            buf.push(b't');
+            let bytes = val.as_bytes();
+            buf.extend_from_slice(&(bytes.len() as u32).to_be_bytes());
+            buf.extend_from_slice(bytes);
+        }
+        ReplicationEvent::XLogData {
+            wal_start: Lsn::from_u64(0),
+            wal_end: Lsn::from_u64(0x16A_4F88),
+            server_time_micros: 0,
+            data: bytes::Bytes::from(buf),
+        }
+    }
+
+    #[test]
+    fn full_transaction_promotes_to_output_on_commit() {
+        let mut registry = RelationRegistry::new();
+        registry.insert(rel_users());
+        let mut state = TxnState::default();
+        let mut out = vec![];
+
+        handle_event(
+            ReplicationEvent::Begin {
+                final_lsn: Lsn::from_u64(0x16A_4F88),
+                xid: 1,
+                commit_time_micros: 0,
+            },
+            &mut registry,
+            &mut state,
+            &mut out,
+        )
+        .unwrap();
+        assert!(out.is_empty());
+
+        handle_event(
+            insert_xlogdata(16384, &[("id", "1"), ("name", "alice")]),
+            &mut registry,
+            &mut state,
+            &mut out,
+        )
+        .unwrap();
+        assert!(out.is_empty(), "records stay staged until COMMIT");
+
+        handle_event(
+            ReplicationEvent::Commit {
+                lsn: Lsn::from_u64(0x16A_4F88),
+                end_lsn: Lsn::from_u64(0x16A_4FA0),
+                commit_time_micros: 0,
+            },
+            &mut registry,
+            &mut state,
+            &mut out,
+        )
+        .unwrap();
+
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0]["op"], "insert");
+        assert_eq!(out[0]["schema"], "public");
+        assert_eq!(out[0]["table"], "users");
+        assert_eq!(out[0]["lsn"], "0/16A4F88");
+        assert_eq!(out[0]["after"]["id"], 1);
+        assert_eq!(out[0]["after"]["name"], "alice");
+        assert_eq!(out[0]["before"], Value::Null);
+
+        assert_eq!(state.last_committed, Some(0x16A_4F88));
+    }
+
+    #[test]
+    fn commit_without_begin_errors() {
+        let mut registry = RelationRegistry::new();
+        let mut state = TxnState::default();
+        let mut out = vec![];
+
+        let err = handle_event(
+            ReplicationEvent::Commit {
+                lsn: Lsn::from_u64(1),
+                end_lsn: Lsn::from_u64(2),
+                commit_time_micros: 0,
+            },
+            &mut registry,
+            &mut state,
+            &mut out,
+        )
+        .unwrap_err();
+        assert!(format!("{err}").contains("COMMIT without BEGIN"));
+    }
+
+    #[test]
+    fn unknown_relation_in_insert_errors() {
+        let mut registry = RelationRegistry::new();
+        let mut state = TxnState::default();
+        let mut out = vec![];
+
+        handle_event(
+            ReplicationEvent::Begin {
+                final_lsn: Lsn::from_u64(1),
+                xid: 1,
+                commit_time_micros: 0,
+            },
+            &mut registry,
+            &mut state,
+            &mut out,
+        )
+        .unwrap();
+        // Insert references relation 99999 which is not in the registry.
+        let err = handle_event(
+            insert_xlogdata(99999, &[("id", "1"), ("name", "alice")]),
+            &mut registry,
+            &mut state,
+            &mut out,
+        )
+        .unwrap_err();
+        assert!(format!("{err}").contains("99999"));
+    }
+}

--- a/crates/source/postgres-cdc/src/stream.rs
+++ b/crates/source/postgres-cdc/src/stream.rs
@@ -128,6 +128,10 @@ impl Source for PostgresCdcSource {
                 ev = tokio::time::timeout(budget, recv(&mut duplex)) => {
                     match ev {
                         Ok(Ok(Some(event))) => {
+                            // Reset on any server activity, not just committed output. This avoids
+                            // firing idle_timeout mid-transaction when the server is actively
+                            // streaming WAL we haven't yet COMMITTED. Compare with
+                            // `faucet-source-kafka`, which only resets on deliverable records.
                             last_message_at = Instant::now();
                             handle_event(event, &mut registry, &mut state, &mut records)?;
                             if records.len() >= max_messages {
@@ -180,6 +184,13 @@ impl Source for PostgresCdcSource {
     }
 }
 
+/// One decoded tuple, split into its values and the names of any unchanged
+/// (large/TOAST) columns whose value the server didn't re-send.
+struct TupleRow {
+    values: Map<String, Value>,
+    unchanged_toast: Vec<String>,
+}
+
 /// In-flight transaction state while draining the replication stream.
 #[derive(Default)]
 struct TxnState {
@@ -209,6 +220,13 @@ fn handle_event(
             commit_time_micros,
             xid: _,
         } => {
+            if state.in_txn {
+                tracing::warn!(
+                    "postgres-cdc: BEGIN received while previous transaction was \
+                     still in progress — discarding {} staged records",
+                    state.staged.len()
+                );
+            }
             state.in_txn = true;
             state.in_progress_lsn = final_lsn.as_u64();
             state.in_progress_ts = commit_time_micros;
@@ -327,9 +345,16 @@ fn record(
     rel: &Relation,
     op: &str,
     state: &TxnState,
-    before: Option<(Map<String, Value>, Vec<String>)>,
-    after: Option<(Map<String, Value>, Vec<String>)>,
+    before: Option<TupleRow>,
+    after: Option<TupleRow>,
 ) -> Value {
+    fn to_value(row: TupleRow) -> Value {
+        let mut o = row.values;
+        if !row.unchanged_toast.is_empty() {
+            o.insert("__unchanged_toast__".into(), json!(row.unchanged_toast));
+        }
+        Value::Object(o)
+    }
     let mut obj = Map::new();
     obj.insert("op".into(), json!(op));
     obj.insert("schema".into(), json!(rel.namespace));
@@ -339,57 +364,41 @@ fn record(
         "ts_ms".into(),
         json!(postgres_clock_to_unix_ms(state.in_progress_ts)),
     );
-    obj.insert(
-        "before".into(),
-        before
-            .map(|(m, _toast)| Value::Object(m))
-            .unwrap_or(Value::Null),
-    );
-    obj.insert(
-        "after".into(),
-        match after {
-            Some((m, toast)) => {
-                let mut o = m;
-                if !toast.is_empty() {
-                    o.insert("__unchanged_toast__".into(), json!(toast));
-                }
-                Value::Object(o)
-            }
-            None => Value::Null,
-        },
-    );
+    obj.insert("before".into(), before.map(to_value).unwrap_or(Value::Null));
+    obj.insert("after".into(), after.map(to_value).unwrap_or(Value::Null));
     Value::Object(obj)
 }
 
-/// Convert a tuple's text cells to a `(JSON object, unchanged-TOAST column names)` pair.
-fn tuple_to_object(
-    rel: &Relation,
-    tup: &TupleData,
-) -> Result<(Map<String, Value>, Vec<String>), FaucetError> {
+/// Convert a tuple's text cells to a [`TupleRow`].
+fn tuple_to_object(rel: &Relation, tup: &TupleData) -> Result<TupleRow, FaucetError> {
     if tup.cells.len() != rel.columns.len() {
         return Err(FaucetError::Source(format!(
-            "postgres-cdc: tuple has {} cells but relation {} has {} columns",
+            "postgres-cdc: tuple has {} cells but relation {}.{} has {} columns",
             tup.cells.len(),
+            rel.namespace,
             rel.name,
             rel.columns.len()
         )));
     }
-    let mut obj = Map::with_capacity(rel.columns.len());
-    let mut unchanged = Vec::new();
+    let mut values = Map::with_capacity(rel.columns.len());
+    let mut unchanged_toast = Vec::new();
     for (col, cell) in rel.columns.iter().zip(&tup.cells) {
         match cell {
             TupleCell::Null => {
-                obj.insert(col.name.clone(), Value::Null);
+                values.insert(col.name.clone(), Value::Null);
             }
             TupleCell::UnchangedToast => {
-                unchanged.push(col.name.clone());
+                unchanged_toast.push(col.name.clone());
             }
             TupleCell::Text(s) => {
-                obj.insert(col.name.clone(), text_to_json(col.type_oid, s)?);
+                values.insert(col.name.clone(), text_to_json(col.type_oid, s)?);
             }
         }
     }
-    Ok((obj, unchanged))
+    Ok(TupleRow {
+        values,
+        unchanged_toast,
+    })
 }
 
 #[cfg(test)]
@@ -422,26 +431,93 @@ mod tests {
         }
     }
 
-    fn insert_xlogdata(relation_oid: u32, cells: &[(&str, &str)]) -> ReplicationEvent {
-        // Build an XLogData event whose `data` is an INSERT pgoutput payload
-        // matching the test's expected cells.
-        let mut buf: Vec<u8> = Vec::new();
-        buf.push(b'I');
-        buf.extend_from_slice(&relation_oid.to_be_bytes());
-        buf.push(b'N');
-        let n: u16 = cells.len() as u16;
-        buf.extend_from_slice(&n.to_be_bytes());
-        for (_, val) in cells {
-            buf.push(b't');
-            let bytes = val.as_bytes();
-            buf.extend_from_slice(&(bytes.len() as u32).to_be_bytes());
-            buf.extend_from_slice(bytes);
-        }
+    fn xlogdata(payload: Vec<u8>) -> ReplicationEvent {
         ReplicationEvent::XLogData {
             wal_start: Lsn::from_u64(0),
             wal_end: Lsn::from_u64(0x16A_4F88),
             server_time_micros: 0,
-            data: bytes::Bytes::from(buf),
+            data: bytes::Bytes::from(payload),
+        }
+    }
+
+    fn insert_payload(relation_oid: u32, cells: &[(&str, &str)]) -> Vec<u8> {
+        let mut buf: Vec<u8> = Vec::new();
+        buf.push(b'I');
+        buf.extend_from_slice(&relation_oid.to_be_bytes());
+        buf.push(b'N');
+        buf.extend_from_slice(&(cells.len() as u16).to_be_bytes());
+        for (_, val) in cells {
+            text_cell(&mut buf, val);
+        }
+        buf
+    }
+
+    /// 'U' relation 'O' fullold 'N' new — exercises REPLICA IDENTITY FULL.
+    fn update_full_payload(
+        relation_oid: u32,
+        old_cells: &[(&str, &str)],
+        new_cells: &[(&str, &str)],
+    ) -> Vec<u8> {
+        let mut buf: Vec<u8> = Vec::new();
+        buf.push(b'U');
+        buf.extend_from_slice(&relation_oid.to_be_bytes());
+        buf.push(b'O');
+        buf.extend_from_slice(&(old_cells.len() as u16).to_be_bytes());
+        for (_, val) in old_cells {
+            text_cell(&mut buf, val);
+        }
+        buf.push(b'N');
+        buf.extend_from_slice(&(new_cells.len() as u16).to_be_bytes());
+        for (_, val) in new_cells {
+            text_cell(&mut buf, val);
+        }
+        buf
+    }
+
+    /// 'D' relation 'O' fullold — REPLICA IDENTITY FULL delete.
+    fn delete_full_payload(relation_oid: u32, old_cells: &[(&str, &str)]) -> Vec<u8> {
+        let mut buf: Vec<u8> = Vec::new();
+        buf.push(b'D');
+        buf.extend_from_slice(&relation_oid.to_be_bytes());
+        buf.push(b'O');
+        buf.extend_from_slice(&(old_cells.len() as u16).to_be_bytes());
+        for (_, val) in old_cells {
+            text_cell(&mut buf, val);
+        }
+        buf
+    }
+
+    /// 'T' flags=0 oids... — truncate without cascade/restart_identity.
+    fn truncate_payload(relation_oids: &[u32]) -> Vec<u8> {
+        let mut buf: Vec<u8> = Vec::new();
+        buf.push(b'T');
+        buf.extend_from_slice(&(relation_oids.len() as u32).to_be_bytes());
+        buf.push(0u8); // flags
+        for oid in relation_oids {
+            buf.extend_from_slice(&oid.to_be_bytes());
+        }
+        buf
+    }
+
+    fn text_cell(buf: &mut Vec<u8>, val: &str) {
+        buf.push(b't');
+        buf.extend_from_slice(&(val.len() as u32).to_be_bytes());
+        buf.extend_from_slice(val.as_bytes());
+    }
+
+    fn begin_event(final_lsn: u64) -> ReplicationEvent {
+        ReplicationEvent::Begin {
+            final_lsn: Lsn::from_u64(final_lsn),
+            xid: 1,
+            commit_time_micros: 0,
+        }
+    }
+
+    fn commit_event(lsn: u64) -> ReplicationEvent {
+        ReplicationEvent::Commit {
+            lsn: Lsn::from_u64(lsn),
+            end_lsn: Lsn::from_u64(lsn + 0x10),
+            commit_time_micros: 0,
         }
     }
 
@@ -452,21 +528,11 @@ mod tests {
         let mut state = TxnState::default();
         let mut out = vec![];
 
-        handle_event(
-            ReplicationEvent::Begin {
-                final_lsn: Lsn::from_u64(0x16A_4F88),
-                xid: 1,
-                commit_time_micros: 0,
-            },
-            &mut registry,
-            &mut state,
-            &mut out,
-        )
-        .unwrap();
+        handle_event(begin_event(0x16A_4F88), &mut registry, &mut state, &mut out).unwrap();
         assert!(out.is_empty());
 
         handle_event(
-            insert_xlogdata(16384, &[("id", "1"), ("name", "alice")]),
+            xlogdata(insert_payload(16384, &[("id", "1"), ("name", "alice")])),
             &mut registry,
             &mut state,
             &mut out,
@@ -475,11 +541,7 @@ mod tests {
         assert!(out.is_empty(), "records stay staged until COMMIT");
 
         handle_event(
-            ReplicationEvent::Commit {
-                lsn: Lsn::from_u64(0x16A_4F88),
-                end_lsn: Lsn::from_u64(0x16A_4FA0),
-                commit_time_micros: 0,
-            },
+            commit_event(0x16A_4F88),
             &mut registry,
             &mut state,
             &mut out,
@@ -524,25 +586,160 @@ mod tests {
         let mut state = TxnState::default();
         let mut out = vec![];
 
-        handle_event(
-            ReplicationEvent::Begin {
-                final_lsn: Lsn::from_u64(1),
-                xid: 1,
-                commit_time_micros: 0,
-            },
-            &mut registry,
-            &mut state,
-            &mut out,
-        )
-        .unwrap();
+        handle_event(begin_event(1), &mut registry, &mut state, &mut out).unwrap();
         // Insert references relation 99999 which is not in the registry.
         let err = handle_event(
-            insert_xlogdata(99999, &[("id", "1"), ("name", "alice")]),
+            xlogdata(insert_payload(99999, &[("id", "1"), ("name", "alice")])),
             &mut registry,
             &mut state,
             &mut out,
         )
         .unwrap_err();
         assert!(format!("{err}").contains("99999"));
+    }
+
+    #[test]
+    fn update_with_replica_identity_full_emits_before_and_after() {
+        let mut registry = RelationRegistry::new();
+        registry.insert(rel_users());
+        let mut state = TxnState::default();
+        let mut out = vec![];
+
+        handle_event(begin_event(0x16A_4F88), &mut registry, &mut state, &mut out).unwrap();
+        handle_event(
+            xlogdata(update_full_payload(
+                16384,
+                &[("id", "1"), ("name", "alice")],
+                &[("id", "1"), ("name", "alice2")],
+            )),
+            &mut registry,
+            &mut state,
+            &mut out,
+        )
+        .unwrap();
+        handle_event(
+            commit_event(0x16A_4F88),
+            &mut registry,
+            &mut state,
+            &mut out,
+        )
+        .unwrap();
+
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0]["op"], "update");
+        assert_eq!(out[0]["before"]["id"], 1);
+        assert_eq!(out[0]["before"]["name"], "alice");
+        assert_eq!(out[0]["after"]["name"], "alice2");
+    }
+
+    #[test]
+    fn delete_with_replica_identity_full_emits_before_only() {
+        let mut registry = RelationRegistry::new();
+        registry.insert(rel_users());
+        let mut state = TxnState::default();
+        let mut out = vec![];
+
+        handle_event(begin_event(0x16A_4F88), &mut registry, &mut state, &mut out).unwrap();
+        handle_event(
+            xlogdata(delete_full_payload(
+                16384,
+                &[("id", "1"), ("name", "alice")],
+            )),
+            &mut registry,
+            &mut state,
+            &mut out,
+        )
+        .unwrap();
+        handle_event(
+            commit_event(0x16A_4F88),
+            &mut registry,
+            &mut state,
+            &mut out,
+        )
+        .unwrap();
+
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0]["op"], "delete");
+        assert_eq!(out[0]["before"]["id"], 1);
+        assert_eq!(out[0]["before"]["name"], "alice");
+        assert_eq!(out[0]["after"], Value::Null);
+    }
+
+    #[test]
+    fn truncate_emits_one_record_per_relation() {
+        let mut registry = RelationRegistry::new();
+        registry.insert(rel_users());
+        // Build a second relation so the truncate-list has two known OIDs.
+        let mut second = rel_users();
+        second.oid = 16385;
+        second.name = "orders".into();
+        registry.insert(second);
+
+        let mut state = TxnState::default();
+        let mut out = vec![];
+
+        handle_event(begin_event(0x16A_4F88), &mut registry, &mut state, &mut out).unwrap();
+        handle_event(
+            xlogdata(truncate_payload(&[16384, 16385])),
+            &mut registry,
+            &mut state,
+            &mut out,
+        )
+        .unwrap();
+        handle_event(
+            commit_event(0x16A_4F88),
+            &mut registry,
+            &mut state,
+            &mut out,
+        )
+        .unwrap();
+
+        assert_eq!(out.len(), 2);
+        assert!(out.iter().all(|r| r["op"] == "truncate"));
+        let tables: Vec<_> = out.iter().map(|r| r["table"].as_str().unwrap()).collect();
+        assert!(tables.contains(&"users"));
+        assert!(tables.contains(&"orders"));
+    }
+
+    #[test]
+    fn unchanged_toast_in_before_surfaces_via_metadata() {
+        // Exercise Fix 1: a REPLICA IDENTITY FULL update with an UnchangedToast
+        // cell in the old tuple must record the column name in
+        // before.__unchanged_toast__.
+        let mut registry = RelationRegistry::new();
+        registry.insert(rel_users());
+        let mut state = TxnState::default();
+        let mut out = vec![];
+
+        handle_event(begin_event(0x16A_4F88), &mut registry, &mut state, &mut out).unwrap();
+        // Hand-build an UPDATE where the OLD tuple's `name` cell is 'u' (unchanged TOAST).
+        let mut buf: Vec<u8> = Vec::new();
+        buf.push(b'U');
+        buf.extend_from_slice(&16384u32.to_be_bytes());
+        buf.push(b'O');
+        buf.extend_from_slice(&2u16.to_be_bytes());
+        // id = text "1"
+        text_cell(&mut buf, "1");
+        // name = unchanged TOAST
+        buf.push(b'u');
+        // New tuple: id=1, name="alice2"
+        buf.push(b'N');
+        buf.extend_from_slice(&2u16.to_be_bytes());
+        text_cell(&mut buf, "1");
+        text_cell(&mut buf, "alice2");
+        handle_event(xlogdata(buf), &mut registry, &mut state, &mut out).unwrap();
+        handle_event(
+            commit_event(0x16A_4F88),
+            &mut registry,
+            &mut state,
+            &mut out,
+        )
+        .unwrap();
+
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0]["before"]["__unchanged_toast__"], json!(["name"]));
+        assert!(out[0]["before"].get("name").is_none());
+        assert_eq!(out[0]["before"]["id"], 1);
+        assert_eq!(out[0]["after"]["name"], "alice2");
     }
 }

--- a/crates/source/postgres-cdc/src/stream.rs
+++ b/crates/source/postgres-cdc/src/stream.rs
@@ -1,0 +1,3 @@
+//! `PostgresCdcSource` — the public `Source` implementation.
+
+pub struct PostgresCdcSource;

--- a/crates/source/postgres-cdc/tests/integration.rs
+++ b/crates/source/postgres-cdc/tests/integration.rs
@@ -1,0 +1,263 @@
+//! Integration tests for `PostgresCdcSource` against a real Postgres instance
+//! via testcontainers.
+//!
+//! These tests require Docker. Set `RUST_LOG=info,pgwire_replication=warn`
+//! while debugging. Postgres is started with `wal_level=logical`, two
+//! replication slots, and two WAL senders — the minimum to actually
+//! replicate.
+//!
+//! Each test boots its own container and creates schema/publication/slot
+//! independently, so the tests are fully isolated.
+
+use faucet_core::Source;
+use faucet_source_postgres_cdc::{PostgresCdcSource, PostgresCdcSourceConfig};
+use std::time::Duration;
+use testcontainers::{ContainerAsync, ImageExt, runners::AsyncRunner};
+use testcontainers_modules::postgres::Postgres;
+use tokio_postgres::NoTls;
+
+/// Start a Postgres container with `wal_level=logical` and return both the
+/// container handle and a connection URL.
+///
+/// We use PostgreSQL 16 because pgwire-replication 0.3.2 emits
+/// `messages 'true'` in its START_REPLICATION command, which requires PG 14+.
+///
+/// We use `with_host_auth()` (POSTGRES_HOST_AUTH_METHOD=trust) so that
+/// `pgwire-replication` (which does not enable its optional `md5` feature in
+/// this workspace) can connect without password auth. Trust mode is safe for
+/// ephemeral, fully-isolated test containers.
+async fn start_postgres() -> (ContainerAsync<Postgres>, String) {
+    // `with_host_auth()` must be called before `with_tag()` because
+    // `with_host_auth` is defined on `Postgres` and `with_tag` converts it
+    // into a `ContainerRequest<Postgres>` (testcontainers extension trait).
+    let image = Postgres::default()
+        .with_host_auth()
+        .with_tag("16-alpine")
+        .with_cmd([
+            "postgres",
+            "-c",
+            "wal_level=logical",
+            "-c",
+            "max_wal_senders=4",
+            "-c",
+            "max_replication_slots=4",
+        ]);
+    let container: ContainerAsync<Postgres> =
+        image.start().await.expect("postgres container start");
+    let port = container
+        .get_host_port_ipv4(5432)
+        .await
+        .expect("postgres port");
+    // Trust auth — no password required. The URL still includes the user so
+    // pgwire-replication and tokio-postgres can identify the role.
+    let url = format!("postgres://postgres@127.0.0.1:{port}/postgres");
+    (container, url)
+}
+
+/// Open a non-replication connection and run one or more SQL statements.
+async fn ddl(url: &str, sql: &str) {
+    let (client, conn) = tokio_postgres::connect(url, NoTls).await.expect("connect");
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+    client.batch_execute(sql).await.expect("batch execute");
+}
+
+fn cfg(url: &str, slot: &str, publication: &str) -> PostgresCdcSourceConfig {
+    PostgresCdcSourceConfig {
+        connection_url: url.into(),
+        slot_name: slot.into(),
+        publication_name: publication.into(),
+        create_slot_if_missing: true,
+        start_lsn: None,
+        proto_version: 1,
+        idle_timeout: Duration::from_secs(5),
+        max_messages: None,
+        status_update_interval: Duration::from_secs(1),
+        tcp_keepalive: Duration::from_secs(60),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn insert_round_trip() {
+    let (_pg, url) = start_postgres().await;
+    ddl(
+        &url,
+        "CREATE TABLE public.users (id int4 PRIMARY KEY, name text); \
+         CREATE PUBLICATION faucet_pub FOR TABLE public.users;",
+    )
+    .await;
+
+    let source = PostgresCdcSource::new(cfg(&url, "faucet_slot", "faucet_pub"))
+        .await
+        .expect("source");
+
+    // Warm-up fetch: creates the slot, idle_timeout drains 0 records.
+    let _ = source.fetch_all_incremental().await.expect("warm-up");
+
+    // Apply changes AFTER the slot exists so they end up in the replicated WAL.
+    ddl(
+        &url,
+        "INSERT INTO public.users VALUES (1, 'alice'), (2, 'bob');",
+    )
+    .await;
+
+    let (records, bookmark) = source.fetch_all_incremental().await.expect("fetch");
+    let inserts: Vec<_> = records.iter().filter(|r| r["op"] == "insert").collect();
+    assert_eq!(
+        inserts.len(),
+        2,
+        "expected 2 inserts, got records: {records:?}"
+    );
+    assert_eq!(inserts[0]["schema"], "public");
+    assert_eq!(inserts[0]["table"], "users");
+    assert_eq!(inserts[0]["after"]["id"], 1);
+    assert_eq!(inserts[0]["after"]["name"], "alice");
+    assert_eq!(inserts[1]["after"]["id"], 2);
+    assert!(
+        bookmark.is_some(),
+        "bookmark must be Some after committed txns"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn update_and_delete_emit_before_after() {
+    let (_pg, url) = start_postgres().await;
+    ddl(
+        &url,
+        "CREATE TABLE public.users (id int4 PRIMARY KEY, name text); \
+         ALTER TABLE public.users REPLICA IDENTITY FULL; \
+         CREATE PUBLICATION faucet_pub FOR TABLE public.users; \
+         INSERT INTO public.users VALUES (1, 'alice');",
+    )
+    .await;
+
+    let source = PostgresCdcSource::new(cfg(&url, "faucet_slot", "faucet_pub"))
+        .await
+        .expect("source");
+
+    // Warm-up: materialise the slot. The INSERT above predates the slot and
+    // will NOT appear in the stream — that's intentional; the test only
+    // asserts UPDATE+DELETE behaviour.
+    let _ = source.fetch_all_incremental().await.expect("warm-up");
+
+    ddl(
+        &url,
+        "UPDATE public.users SET name = 'alice2' WHERE id = 1; \
+         DELETE FROM public.users WHERE id = 1;",
+    )
+    .await;
+
+    let (records, _bm) = source.fetch_all_incremental().await.expect("fetch");
+    let update = records
+        .iter()
+        .find(|r| r["op"] == "update")
+        .expect("update record");
+    let delete = records
+        .iter()
+        .find(|r| r["op"] == "delete")
+        .expect("delete record");
+
+    assert_eq!(update["before"]["id"], 1);
+    assert_eq!(update["before"]["name"], "alice");
+    assert_eq!(update["after"]["name"], "alice2");
+    assert_eq!(delete["before"]["id"], 1);
+    assert_eq!(delete["after"], serde_json::Value::Null);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn missing_slot_with_create_if_missing_creates_it() {
+    let (_pg, url) = start_postgres().await;
+    ddl(
+        &url,
+        "CREATE TABLE public.t (id int PRIMARY KEY); \
+         CREATE PUBLICATION faucet_pub FOR TABLE public.t;",
+    )
+    .await;
+
+    let mut c = cfg(&url, "fresh_slot", "faucet_pub");
+    c.create_slot_if_missing = true;
+    let source = PostgresCdcSource::new(c).await.expect("source");
+    // First fetch should succeed even though no slot exists yet.
+    let _ = source.fetch_all_incremental().await.expect("fetch");
+
+    // Verify the slot now exists by querying pg_replication_slots directly.
+    let (client, conn) = tokio_postgres::connect(&url, NoTls).await.unwrap();
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+    let row = client
+        .query_one(
+            "SELECT 1::int4 FROM pg_replication_slots WHERE slot_name = $1",
+            &[&"fresh_slot"],
+        )
+        .await
+        .expect("slot exists");
+    assert_eq!(row.get::<_, i32>(0), 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn missing_slot_without_create_if_missing_errors() {
+    let (_pg, url) = start_postgres().await;
+    ddl(
+        &url,
+        "CREATE TABLE public.t (id int PRIMARY KEY); \
+         CREATE PUBLICATION faucet_pub FOR TABLE public.t;",
+    )
+    .await;
+
+    let mut c = cfg(&url, "no_slot_here", "faucet_pub");
+    c.create_slot_if_missing = false;
+    let source = PostgresCdcSource::new(c).await.expect("source");
+    let err = source.fetch_all_incremental().await.unwrap_err();
+    assert!(
+        format!("{err}").contains("no_slot_here"),
+        "error must mention the slot name: {err}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn resume_from_bookmark_skips_already_consumed() {
+    let (_pg, url) = start_postgres().await;
+    ddl(
+        &url,
+        "CREATE TABLE public.users (id int4 PRIMARY KEY, name text); \
+         CREATE PUBLICATION faucet_pub FOR TABLE public.users;",
+    )
+    .await;
+
+    // First pass: drain rows 1+2 and capture the bookmark.
+    let s1 = PostgresCdcSource::new(cfg(&url, "faucet_slot", "faucet_pub"))
+        .await
+        .expect("source 1");
+    // Warm-up creates the slot before our INSERTs.
+    let _ = s1.fetch_all_incremental().await.expect("warm-up");
+    ddl(&url, "INSERT INTO public.users VALUES (1, 'a'), (2, 'b');").await;
+    let (first, bookmark) = s1.fetch_all_incremental().await.expect("first fetch");
+    let first_ids: Vec<_> = first
+        .iter()
+        .filter(|r| r["op"] == "insert")
+        .map(|r| r["after"]["id"].as_i64().unwrap())
+        .collect();
+    assert_eq!(first_ids, vec![1, 2], "first drain must return 1 and 2");
+    let bm = bookmark.expect("bookmark must be set after first fetch");
+
+    // Now apply rows 3+4. We construct a fresh source and feed it the
+    // bookmark before the second fetch.
+    ddl(&url, "INSERT INTO public.users VALUES (3, 'c'), (4, 'd');").await;
+    let s2 = PostgresCdcSource::new(cfg(&url, "faucet_slot", "faucet_pub"))
+        .await
+        .expect("source 2");
+    s2.apply_start_bookmark(bm).await.expect("apply bookmark");
+    let (second, _bm2) = s2.fetch_all_incremental().await.expect("second fetch");
+    let second_ids: Vec<_> = second
+        .iter()
+        .filter(|r| r["op"] == "insert")
+        .map(|r| r["after"]["id"].as_i64().unwrap())
+        .collect();
+    assert_eq!(
+        second_ids,
+        vec![3, 4],
+        "resume must skip 1 and 2; got {second_ids:?} from records {second:?}"
+    );
+}

--- a/faucet-stream/Cargo.toml
+++ b/faucet-stream/Cargo.toml
@@ -22,6 +22,7 @@ source = [
     "source-grpc",
     "source-kafka",
     "source-postgres",
+    "source-postgres-cdc",
     "source-mysql",
     "source-sqlite",
     "source-s3",
@@ -64,6 +65,7 @@ source-graphql = ["dep:faucet-source-graphql"]
 source-xml = ["dep:faucet-source-xml"]
 source-grpc = ["dep:faucet-source-grpc"]
 source-postgres = ["dep:faucet-source-postgres"]
+source-postgres-cdc = ["dep:faucet-source-postgres-cdc"]
 source-mysql = ["dep:faucet-source-mysql"]
 source-sqlite = ["dep:faucet-source-sqlite"]
 source-s3 = ["dep:faucet-source-s3"]
@@ -119,6 +121,7 @@ faucet-source-xml = { workspace = true, optional = true }
 faucet-source-grpc = { workspace = true, optional = true }
 faucet-source-kafka = { workspace = true, optional = true }
 faucet-source-postgres = { workspace = true, optional = true }
+faucet-source-postgres-cdc = { workspace = true, optional = true }
 faucet-source-mysql = { workspace = true, optional = true }
 faucet-source-sqlite = { workspace = true, optional = true }
 faucet-source-s3 = { workspace = true, optional = true }

--- a/faucet-stream/src/lib.rs
+++ b/faucet-stream/src/lib.rs
@@ -12,6 +12,7 @@
 //! | `source-xml` | XML/SOAP API source with XML-to-JSON conversion |
 //! | `source-grpc` | gRPC source with dynamic protobuf messages |
 //! | `source-postgres` | PostgreSQL query source |
+//! | `source-postgres-cdc` | PostgreSQL CDC source (logical replication) |
 //! | `source-mysql` | MySQL query source |
 //! | `source-sqlite` | SQLite query source |
 
@@ -72,6 +73,11 @@ pub mod source {
     #[cfg(feature = "source-postgres")]
     pub mod postgres {
         pub use faucet_source_postgres::*;
+    }
+
+    #[cfg(feature = "source-postgres-cdc")]
+    pub mod postgres_cdc {
+        pub use faucet_source_postgres_cdc::*;
     }
 
     #[cfg(feature = "source-mysql")]
@@ -146,6 +152,11 @@ pub mod source {
     #[cfg(feature = "source-postgres")]
     pub mod postgres {
         pub use faucet_source_postgres::*;
+    }
+
+    #[cfg(feature = "source-postgres-cdc")]
+    pub mod postgres_cdc {
+        pub use faucet_source_postgres_cdc::*;
     }
 
     #[cfg(feature = "source-mysql")]


### PR DESCRIPTION
## Summary

New `faucet-source-postgres-cdc` crate — subscribes to a Postgres logical replication slot via the `pgoutput` plugin and emits row-level changes (INSERT / UPDATE / DELETE / TRUNCATE) as JSON records. Closes the final tier-1 item from the roadmap epic.

- Hand-rolled `pgoutput` v1 decoder (B / C / R / I / U / D / T); text-mode tuple decoding with type-OID-aware JSON conversion for the common Postgres built-ins.
- Transactional consistency: records are staged until COMMIT, so the sink never sees a partial transaction.
- State-store-backed durable LSN bookmarks. The connector only advances the slot's `confirmed_flush_lsn` after the pipeline writes a new bookmark back through `apply_start_bookmark`, so the state store is the single source of truth.
- Built on [`pgwire-replication`](https://crates.io/crates/pgwire-replication) for the replication wire protocol — `tokio-postgres` 0.7.17 doesn't expose the replication APIs we need on crates.io.
- Wired into the `faucet-stream` umbrella crate, the `faucet` CLI, and the CI feature-check matrix.
- Output record shape:
  ```json
  { "op": "...", "schema": "...", "table": "...", "lsn": "0/16A4F88",
    "ts_ms": 1779019200000, "before": {...} | null, "after": {...} | null }
  ```

Closes #24. Last tier-1 from #38.

## Test plan

- [x] 61 unit tests pass (`cargo test -p faucet-source-postgres-cdc --lib`)
- [x] 5 testcontainers integration tests pass against Postgres 16 (`cargo test -p faucet-source-postgres-cdc --test integration`)
  - `insert_round_trip`
  - `update_and_delete_emit_before_after` (REPLICA IDENTITY FULL)
  - `missing_slot_with_create_if_missing_creates_it`
  - `missing_slot_without_create_if_missing_errors`
  - `resume_from_bookmark_skips_already_consumed`
- [x] Full workspace clippy clean: `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] Full workspace lib tests pass: 632/632 across all 35 crates
- [x] `faucet list` shows `postgres-cdc`
- [x] `faucet schema source postgres-cdc` outputs the config JSON Schema

## Out of scope (deferred)

- MySQL binlog CDC
- Full DDL capture
- Snapshot + CDC handoff
- In-fetch reconnection on a dropped replication connection
- Streaming-transaction pgoutput messages (proto v2) — pgwire-replication 0.3.2 hardcodes v1
- Binary-mode tuple cells