### PR TITLE
fix(source-kafka): seek to bookmark in rebalance, eliminate restart duplicate

### DIFF
--- a/crates/source/kafka/README.md
+++ b/crates/source/kafka/README.md
@@ -162,11 +162,7 @@ Topics are sorted alphabetically before joining, so the key is stable regardless
 kafka:my-group:alpha.beta
 ```
 
-**Important — at-least-once delivery on restart:**
-
-Because `seek` is called after the first poll (a librdkafka constraint — partition assignment is not final until the first message is received), exactly one message per assigned partition may be delivered twice across a restart boundary. This is at-least-once delivery. Sinks should be idempotent or otherwise accept duplicate records.
-
-A future enhancement will install a custom `ConsumerContext` with a `pre_rebalance` callback to eliminate the restart duplicate — tracked in the follow-up issue filed alongside this README.
+**Delivery semantics:** Offsets are persisted via faucet-stream's state store only after the sink confirms a batch, and on restart the consumer seeds the partition assignment with the bookmarked offset *before* any message is fetched. End-to-end this is at-least-once if the sink can fail mid-batch; pair with idempotent sinks if you need stricter guarantees.
 
 ---
 

--- a/crates/source/kafka/src/context.rs
+++ b/crates/source/kafka/src/context.rs
@@ -1,0 +1,229 @@
+//! Custom rdkafka `ConsumerContext` that seeks to bookmarked offsets during
+//! partition assignment — before any message is polled — so a restart with
+//! a bookmark applied produces no duplicate records.
+//!
+//! The poll-then-seek path (the old `maybe_apply_seek`) emits one duplicate
+//! per assigned partition because partition assignment is not final until
+//! the first message arrives. By overriding `rebalance` and modifying the
+//! `TopicPartitionList` offsets before calling `rd_kafka_assign`, the
+//! bookmarked starting positions are applied atomically with the partition
+//! assignment — no messages from before the bookmark are ever fetched.
+
+use crate::state::Bookmark;
+use faucet_core::FaucetError;
+use rdkafka::Offset;
+use rdkafka::TopicPartitionList;
+use rdkafka::client::ClientContext;
+use rdkafka::consumer::base_consumer::BaseConsumer;
+use rdkafka::consumer::{Consumer, ConsumerContext, Rebalance, RebalanceProtocol};
+use rdkafka::error::KafkaError;
+use rdkafka::types::RDKafkaRespErr;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+/// Shared state between [`KafkaSource`](crate::stream::KafkaSource) and the
+/// rdkafka consumer background thread. Cloning a `BookmarkContext` clones the
+/// inner `Arc`s, not the underlying data — both clones see the same bookmark
+/// and the same error slot.
+#[derive(Clone, Default)]
+pub struct BookmarkContext {
+    /// Bookmark to apply on the next `Rebalance::Assign`. Taken (not peeked)
+    /// when the assign fires, so subsequent rebalances do not re-seek.
+    pub pending_bookmark: Arc<Mutex<Option<Bookmark>>>,
+    /// First error raised inside the rebalance callback (assign failures).
+    /// The poll loop drains this between iterations and surfaces it to the
+    /// caller.
+    pub callback_error: Arc<Mutex<Option<FaucetError>>>,
+}
+
+impl BookmarkContext {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record the first error from a callback. Subsequent errors are
+    /// dropped so the original cause survives, matching the pattern used
+    /// elsewhere in faucet-stream for background-thread error capture.
+    fn record_error(&self, err: FaucetError) {
+        let Ok(mut guard) = self.callback_error.lock() else {
+            // Mutex poisoned and we are already in an error path — nothing
+            // useful to do but swallow.
+            return;
+        };
+        if guard.is_none() {
+            *guard = Some(err);
+        }
+    }
+}
+
+impl ClientContext for BookmarkContext {}
+
+impl ConsumerContext for BookmarkContext {
+    /// Override `rebalance` to inject bookmark offsets into the
+    /// `TopicPartitionList` *before* `rd_kafka_assign` is called.
+    ///
+    /// The default `ConsumerContext::rebalance` fires `pre_rebalance`, then
+    /// calls `rd_kafka_assign`, then fires `post_rebalance`. Offsets set on
+    /// the TPL before `rd_kafka_assign` become the initial fetch positions for
+    /// those partitions — no seek call is needed and there is no race with
+    /// the fetch state machine.
+    fn rebalance(
+        &self,
+        base_consumer: &BaseConsumer<Self>,
+        err: RDKafkaRespErr,
+        tpl: &mut TopicPartitionList,
+    ) {
+        match err {
+            RDKafkaRespErr::RD_KAFKA_RESP_ERR__ASSIGN_PARTITIONS => {
+                let rebalance = Rebalance::Assign(tpl);
+                self.pre_rebalance(base_consumer, &rebalance);
+                drop(rebalance);
+
+                // `take()` consumes the bookmark on the first Assign so that
+                // subsequent cooperative rebalances do not re-apply stale
+                // offsets.
+                let bookmark = match self.pending_bookmark.lock() {
+                    Ok(mut guard) => guard.take(),
+                    Err(poisoned) => {
+                        self.record_error(FaucetError::State(format!(
+                            "kafka pending_bookmark mutex poisoned: {poisoned}"
+                        )));
+                        None
+                    }
+                };
+
+                if let Some(bookmark) = bookmark {
+                    // Build a (topic, partition) -> offset lookup.
+                    let lookup: HashMap<(&str, i32), i64> = bookmark
+                        .partition_offsets
+                        .iter()
+                        .map(|p| ((p.topic.as_str(), p.partition), p.offset))
+                        .collect();
+
+                    // Collect (topic, partition, offset) triples first to avoid
+                    // holding an immutable borrow on `tpl` while mutating it.
+                    let seeks: Vec<(String, i32, i64)> = tpl
+                        .elements()
+                        .into_iter()
+                        .filter_map(|elem| {
+                            let topic = elem.topic().to_owned();
+                            let partition = elem.partition();
+                            lookup
+                                .get(&(topic.as_str(), partition))
+                                .copied()
+                                .map(|offset| (topic, partition, offset))
+                        })
+                        .collect();
+
+                    // Apply bookmarked offsets to each matched partition.
+                    // Partitions absent from the bookmark are left at their
+                    // default offset (earliest/latest per `auto.offset.reset`).
+                    for (topic, partition, offset) in seeks {
+                        if let Err(e) =
+                            tpl.set_partition_offset(&topic, partition, Offset::Offset(offset))
+                        {
+                            self.record_error(FaucetError::State(format!(
+                                "kafka set_partition_offset topic={topic} \
+                                 partition={partition} offset={offset}: {e}"
+                            )));
+                        }
+                    }
+                }
+
+                // Call assign with the (possibly modified) TPL. Setting offsets
+                // in the TPL before assign makes them the initial fetch positions
+                // — no seek call is needed after the fact.
+                match base_consumer.rebalance_protocol() {
+                    RebalanceProtocol::Cooperative => {
+                        if let Err(e) = base_consumer.incremental_assign(tpl) {
+                            self.record_error(FaucetError::State(format!(
+                                "kafka incremental_assign failed: {e}"
+                            )));
+                        }
+                    }
+                    _ => {
+                        if let Err(e) = base_consumer.assign(tpl) {
+                            self.record_error(FaucetError::State(format!(
+                                "kafka assign failed: {e}"
+                            )));
+                        }
+                    }
+                }
+
+                let rebalance = Rebalance::Assign(tpl);
+                self.post_rebalance(base_consumer, &rebalance);
+            }
+
+            RDKafkaRespErr::RD_KAFKA_RESP_ERR__REVOKE_PARTITIONS => {
+                let rebalance = Rebalance::Revoke(tpl);
+                self.pre_rebalance(base_consumer, &rebalance);
+                drop(rebalance);
+
+                match base_consumer.rebalance_protocol() {
+                    RebalanceProtocol::Cooperative => {
+                        if let Err(e) = base_consumer.incremental_unassign(tpl) {
+                            self.record_error(FaucetError::State(format!(
+                                "kafka incremental_unassign failed: {e}"
+                            )));
+                        }
+                    }
+                    _ => {
+                        if let Err(e) = base_consumer.unassign() {
+                            self.record_error(FaucetError::State(format!(
+                                "kafka unassign failed: {e}"
+                            )));
+                        }
+                    }
+                }
+
+                let rebalance = Rebalance::Revoke(tpl);
+                self.post_rebalance(base_consumer, &rebalance);
+            }
+
+            _ => {
+                let error_code = rdkafka::error::RDKafkaErrorCode::from(err);
+                let rebalance = Rebalance::Error(KafkaError::Rebalance(error_code));
+                self.pre_rebalance(base_consumer, &rebalance);
+                // Error rebalance events: no assignment/unassignment needed.
+                self.post_rebalance(base_consumer, &rebalance);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{Bookmark, PartitionOffset};
+
+    #[test]
+    fn shared_state_round_trips_through_clone() {
+        let ctx = BookmarkContext::new();
+        let clone = ctx.clone();
+        let bookmark = Bookmark {
+            partition_offsets: vec![PartitionOffset {
+                topic: "t".into(),
+                partition: 0,
+                offset: 42,
+            }],
+        };
+        *clone.pending_bookmark.lock().unwrap() = Some(bookmark.clone());
+        let read_back = ctx.pending_bookmark.lock().unwrap().clone();
+        assert_eq!(
+            read_back.unwrap().partition_offsets,
+            bookmark.partition_offsets
+        );
+    }
+
+    #[test]
+    fn record_error_keeps_first_only() {
+        let ctx = BookmarkContext::new();
+        ctx.record_error(FaucetError::State("first".into()));
+        ctx.record_error(FaucetError::State("second".into()));
+        let captured = ctx.callback_error.lock().unwrap().take().unwrap();
+        match captured {
+            FaucetError::State(msg) => assert_eq!(msg, "first"),
+            other => panic!("expected State, got {other:?}"),
+        }
+    }
+}

--- a/crates/source/kafka/src/context.rs
+++ b/crates/source/kafka/src/context.rs
@@ -26,18 +26,18 @@ use std::sync::{Arc, Mutex};
 /// inner `Arc`s, not the underlying data — both clones see the same bookmark
 /// and the same error slot.
 #[derive(Clone, Default)]
-pub struct BookmarkContext {
+pub(crate) struct BookmarkContext {
     /// Bookmark to apply on the next `Rebalance::Assign`. Taken (not peeked)
     /// when the assign fires, so subsequent rebalances do not re-seek.
-    pub pending_bookmark: Arc<Mutex<Option<Bookmark>>>,
+    pub(crate) pending_bookmark: Arc<Mutex<Option<Bookmark>>>,
     /// First error raised inside the rebalance callback (assign failures).
     /// The poll loop drains this between iterations and surfaces it to the
     /// caller.
-    pub callback_error: Arc<Mutex<Option<FaucetError>>>,
+    pub(crate) callback_error: Arc<Mutex<Option<FaucetError>>>,
 }
 
 impl BookmarkContext {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self::default()
     }
 
@@ -93,7 +93,6 @@ impl ConsumerContext for BookmarkContext {
                 };
 
                 if let Some(bookmark) = bookmark {
-                    // Build a (topic, partition) -> offset lookup.
                     let lookup: HashMap<(&str, i32), i64> = bookmark
                         .partition_offsets
                         .iter()
@@ -115,7 +114,6 @@ impl ConsumerContext for BookmarkContext {
                         })
                         .collect();
 
-                    // Apply bookmarked offsets to each matched partition.
                     // Partitions absent from the bookmark are left at their
                     // default offset (earliest/latest per `auto.offset.reset`).
                     for (topic, partition, offset) in seeks {
@@ -130,9 +128,6 @@ impl ConsumerContext for BookmarkContext {
                     }
                 }
 
-                // Call assign with the (possibly modified) TPL. Setting offsets
-                // in the TPL before assign makes them the initial fetch positions
-                // — no seek call is needed after the fact.
                 match base_consumer.rebalance_protocol() {
                     RebalanceProtocol::Cooperative => {
                         if let Err(e) = base_consumer.incremental_assign(tpl) {
@@ -184,7 +179,6 @@ impl ConsumerContext for BookmarkContext {
                 let error_code = rdkafka::error::RDKafkaErrorCode::from(err);
                 let rebalance = Rebalance::Error(KafkaError::Rebalance(error_code));
                 self.pre_rebalance(base_consumer, &rebalance);
-                // Error rebalance events: no assignment/unassignment needed.
                 self.post_rebalance(base_consumer, &rebalance);
             }
         }

--- a/crates/source/kafka/src/lib.rs
+++ b/crates/source/kafka/src/lib.rs
@@ -6,6 +6,7 @@
 //! offset/timestamp/headers fields.
 
 pub mod config;
+pub mod context;
 pub mod decode;
 pub mod state;
 pub mod stream;

--- a/crates/source/kafka/src/lib.rs
+++ b/crates/source/kafka/src/lib.rs
@@ -6,7 +6,7 @@
 //! offset/timestamp/headers fields.
 
 pub mod config;
-pub mod context;
+pub(crate) mod context;
 pub mod decode;
 pub mod state;
 pub mod stream;

--- a/crates/source/kafka/src/stream.rs
+++ b/crates/source/kafka/src/stream.rs
@@ -1,6 +1,7 @@
 //! `KafkaSource` — the Kafka consumer implementation.
 
 use crate::config::KafkaSourceConfig;
+use crate::context::BookmarkContext;
 use crate::decode;
 use crate::state::{Bookmark, state_key};
 use async_trait::async_trait;
@@ -16,7 +17,6 @@ use serde_json::{Map, Value, json};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tokio::sync::Mutex;
 
 #[cfg(feature = "schema-registry")]
 use faucet_kafka_common::KafkaValueFormat;
@@ -25,8 +25,8 @@ use faucet_kafka_common::schema_registry::client::SchemaRegistryClient;
 
 pub struct KafkaSource {
     config: KafkaSourceConfig,
-    consumer: Arc<StreamConsumer>,
-    pending_bookmark: Mutex<Option<Bookmark>>,
+    consumer: Arc<StreamConsumer<BookmarkContext>>,
+    context: BookmarkContext,
     state_key_value: String,
     #[cfg(feature = "schema-registry")]
     sr_client: Option<SchemaRegistryClient>,
@@ -53,8 +53,9 @@ impl KafkaSource {
             client_config.set(k, v);
         }
 
-        let consumer: StreamConsumer = client_config
-            .create()
+        let context = BookmarkContext::new();
+        let consumer: StreamConsumer<BookmarkContext> = client_config
+            .create_with_context(context.clone())
             .map_err(|e| FaucetError::Source(format!("kafka consumer init: {e}")))?;
 
         let topic_refs: Vec<&str> = config.topics.iter().map(String::as_str).collect();
@@ -70,39 +71,11 @@ impl KafkaSource {
         Ok(Self {
             config,
             consumer: Arc::new(consumer),
-            pending_bookmark: Mutex::new(None),
+            context,
             state_key_value,
             #[cfg(feature = "schema-registry")]
             sr_client,
         })
-    }
-
-    /// Once the consumer has received its partition assignment, apply any
-    /// pending bookmark by seeking each partition to the stored offset.
-    async fn maybe_apply_seek(&self) -> Result<(), FaucetError> {
-        let bookmark = {
-            let mut guard = self.pending_bookmark.lock().await;
-            guard.take()
-        };
-        let Some(bookmark) = bookmark else {
-            return Ok(());
-        };
-        for entry in &bookmark.partition_offsets {
-            self.consumer
-                .seek(
-                    &entry.topic,
-                    entry.partition,
-                    rdkafka::Offset::Offset(entry.offset),
-                    Some(Duration::from_secs(5)),
-                )
-                .map_err(|e| {
-                    FaucetError::State(format!(
-                        "kafka seek topic={} partition={} offset={}: {e}",
-                        entry.topic, entry.partition, entry.offset
-                    ))
-                })?;
-        }
-        Ok(())
     }
 
     async fn message_to_value(
@@ -199,11 +172,22 @@ impl Source for KafkaSource {
         let mut records: Vec<Value> = Vec::new();
         let mut pending_offsets: HashMap<(String, i32), i64> = HashMap::new();
         let mut last_message_at = Instant::now();
-        let mut seek_applied = false;
         let max_messages = self.config.max_messages.unwrap_or(usize::MAX);
         let idle_timeout = self.config.idle_timeout;
 
         loop {
+            // Surface any error raised by the rebalance callback (e.g. a
+            // failed seek). Done before the next poll so we don't process
+            // additional messages after a bookmark application failure.
+            {
+                let mut guard = self.context.callback_error.lock().map_err(|e| {
+                    FaucetError::State(format!("kafka callback_error mutex poisoned: {e}"))
+                })?;
+                if let Some(e) = guard.take() {
+                    return Err(e);
+                }
+            }
+
             let idle_deadline = idle_timeout.map(|t| last_message_at + t);
             let poll_budget = match idle_deadline {
                 Some(deadline) => deadline
@@ -221,10 +205,6 @@ impl Source for KafkaSource {
                 recv = tokio::time::timeout(poll_budget, self.consumer.recv()) => {
                     match recv {
                         Ok(Ok(msg)) => {
-                            if !seek_applied {
-                                self.maybe_apply_seek().await?;
-                                seek_applied = true;
-                            }
                             match self.message_to_value(&msg).await {
                                 Ok(record) => {
                                     pending_offsets.insert(
@@ -280,7 +260,9 @@ impl Source for KafkaSource {
 
     async fn apply_start_bookmark(&self, bookmark: Value) -> Result<(), FaucetError> {
         let parsed = Bookmark::from_value(bookmark)?;
-        let mut guard = self.pending_bookmark.lock().await;
+        let mut guard = self.context.pending_bookmark.lock().map_err(|e| {
+            FaucetError::State(format!("kafka pending_bookmark mutex poisoned: {e}"))
+        })?;
         *guard = Some(parsed);
         Ok(())
     }

--- a/crates/source/kafka/tests/integration.rs
+++ b/crates/source/kafka/tests/integration.rs
@@ -106,20 +106,20 @@ async fn round_trip_basic() {
 }
 
 /// Verifies that `apply_start_bookmark` causes the consumer to seek past
-/// previously-consumed offsets. Because the seek fires in response to the
-/// first received message (after partition assignment), the message that
-/// triggered the seek is still included in the output; subsequent messages
-/// come from the seeked position onward.
+/// previously-consumed offsets *before any message is delivered*, so the
+/// restart boundary does not emit duplicates.
 ///
 /// With 4 messages (id 1-4) and s1 draining the first 2 (ids 1 & 2):
 ///   bookmark = partition 0 → offset 2
-/// s2 starts fresh (group g-resume-2, earliest):
-///   - receives id=1 (offset 0) → triggers seek to offset 2 → seek_applied
-///   - receives id=3 (offset 2) and id=4 (offset 3)
+/// s2 starts fresh (group g-resume-2, earliest) with the bookmark applied:
+///   - rebalance callback fires on partition assignment → seeks to offset 2
+///   - first message delivered is id=3 (offset 2)
+///   - then id=4 (offset 3)
 ///   - idle_timeout fires → stops
-/// So second = [id=1, id=3, id=4] (3 records), with second[1] == id=3.
+/// So second = [id=3, id=4] (2 records). Crucially, id=1 (the message that
+/// used to trigger the post-poll seek) is no longer in the output.
 #[tokio::test(flavor = "multi_thread")]
-async fn resume_with_bookmark_seek_to_position() {
+async fn resume_with_bookmark_no_restart_duplicate() {
     let (_container, brokers) = start_kafka().await;
     let topic = "resume";
     produce(
@@ -144,19 +144,21 @@ async fn resume_with_bookmark_seek_to_position() {
     assert_eq!(first[1]["value"]["id"], 2);
     let bookmark = bookmark.expect("bookmark should be Some after consuming messages");
 
-    // Second run: new group, apply bookmark → seek to offset 2 after assignment.
-    // The message that triggers the seek (id=1, offset=0) is still emitted first;
-    // then id=3 and id=4 come from the seeked position.
+    // Second run: new group, apply bookmark → pre_rebalance seeks to offset 2
+    // *before* any poll. id=1 and id=2 are skipped entirely.
     let s2 = KafkaSource::new(source_config(&brokers, topic, "g-resume-2", 10))
         .await
         .unwrap();
     s2.apply_start_bookmark(bookmark).await.unwrap();
     let (second, _) = s2.fetch_all_incremental().await.unwrap();
 
-    // 3 records: the pre-seek trigger (id=1) + the 2 post-seek messages (id=3, id=4).
-    assert_eq!(second.len(), 3);
-    assert_eq!(second[1]["value"]["id"], 3);
-    assert_eq!(second[2]["value"]["id"], 4);
+    assert_eq!(
+        second.len(),
+        2,
+        "expected exactly 2 records with no restart duplicate, got {second:#?}"
+    );
+    assert_eq!(second[0]["value"]["id"], 3);
+    assert_eq!(second[1]["value"]["id"], 4);
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Summary

- Replaces the post-first-poll `maybe_apply_seek` workaround in `faucet-source-kafka` with a custom `ConsumerContext` (`BookmarkContext`) that seeds partition assignments with bookmarked offsets before `rd_kafka_assign` runs — so on restart the consumer never fetches the message that previously triggered the seek.
- Eliminates the one-message-per-partition restart duplicate that callers previously had to absorb (or de-dup on the sink side).
- Drops the at-least-once-on-restart caveat from the Kafka source README.

Closes #45.

## Implementation notes

The plan originally proposed `pre_rebalance`, but librdkafka's `seek` requires the partition to be in the active-fetch state — which it is not during `pre_rebalance` or `post_rebalance`. The working pattern is to override the wrapping `ConsumerContext::rebalance` method and set `Offset::Offset(n)` on each matched `TopicPartitionList` element *before* calling `base_consumer.assign(tpl)`, so the initial fetch position is established atomically with the assignment.

The `BookmarkContext` keeps shared state (`pending_bookmark`, `callback_error`) behind `Arc<Mutex<...>>`. The poll loop drains `callback_error` between iterations to surface seek failures synchronously. The bookmark is `take()`n on the first `Assign`, so subsequent (cooperative) rebalances do not re-seek.

## Test plan

- [ ] `cargo test -p faucet-source-kafka --all-features` — including the rewritten `resume_with_bookmark_no_restart_duplicate` test, which now asserts exactly 2 records on resume (id=3, id=4), not 3.
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean.
- [ ] `cargo test --workspace --all-features` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)