### PR TITLE
refactor(auth)!: struct variants for newtype auth enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,9 @@ use faucet_stream::{RestStream, RestStreamConfig, Auth, PaginationStyle};
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let stream = RestStream::new(
         RestStreamConfig::new("https://api.example.com", "/v1/users")
-            .auth(Auth::Bearer("my-token".into()))
+            .auth(Auth::Bearer {
+                token: "my-token".into(),
+            })
             .records_path("$.data[*]")
             .pagination(PaginationStyle::Cursor {
                 next_token_path: "$.meta.next_cursor".into(),
@@ -459,7 +461,7 @@ let token = fetch_oauth2_token(
 ).await?;
 
 let config = RestStreamConfig::new("https://api.example.com", "/data")
-    .auth(Auth::Bearer(token));
+    .auth(Auth::Bearer { token });
 ```
 
 ### Token endpoint (fetch credentials from an API)

--- a/cli/README.md
+++ b/cli/README.md
@@ -116,7 +116,7 @@ Mirrors of the Rust examples (one `.yaml` per `.rs`):
 - Webhook receiver: [`webhook_to_csv`](examples/webhook_to_csv.yaml), [`webhook_to_http`](examples/webhook_to_http.yaml), [`webhook_to_postgres`](examples/webhook_to_postgres.yaml)
 - DAG parent leg: [`dag_users_posts`](examples/dag_users_posts.yaml) — parent only (multi-node DAGs require the library API today)
 
-A handful of YAMLs note specific limitations in their header comment — chiefly that `Auth::Bearer(String)` and similar newtype-in-tagged-enum variants can't currently round-trip through serde. The [tracking issue](https://github.com/PawanSikawat/faucet-stream/issues) will replace those with struct variants so the YAML versions become 1:1 with the Rust ones.
+Every auth shape — Bearer, Basic, API key, OAuth2, custom headers, gRPC metadata — round-trips through YAML/JSON, so the YAML examples are 1:1 with the Rust ones.
 
 ## License
 

--- a/cli/examples/dag_users_posts.yaml
+++ b/cli/examples/dag_users_posts.yaml
@@ -16,9 +16,8 @@ source:
     method: GET
     name: users
     auth:
-      type: ApiKey
-      header: Authorization
-      value: Bearer ${env:API_TOKEN}
+      type: Bearer
+      token: ${env:API_TOKEN}
     headers: {}
     query_params:
       active: "true"

--- a/cli/examples/elasticsearch_to_redis.yaml
+++ b/cli/examples/elasticsearch_to_redis.yaml
@@ -15,9 +15,8 @@ source:
     scroll_size: 1000
     auth:
       type: Basic
-      value:
-        username: ${env:ES_USER}
-        password: ${env:ES_PASS}
+      username: ${env:ES_USER}
+      password: ${env:ES_PASS}
     max_pages: 500
 
 sink:

--- a/cli/examples/elasticsearch_to_s3.yaml
+++ b/cli/examples/elasticsearch_to_s3.yaml
@@ -15,7 +15,7 @@ source:
     scroll_size: 2000
     auth:
       type: ApiKey
-      value: ${env:ES_API_KEY}
+      key: ${env:ES_API_KEY}
 
 sink:
   type: s3

--- a/cli/examples/graphql_to_bigquery.yaml
+++ b/cli/examples/graphql_to_bigquery.yaml
@@ -1,9 +1,6 @@
 # YAML equivalent of `faucet-stream/examples/graphql_to_bigquery.rs`.
-# GraphQL (Relay cursor pagination) → BigQuery with ApplicationDefault credentials.
-#
-# Limitation: the GraphQL source's `headers` and `auth: Custom(HeaderMap)`
-# variants are `#[serde(skip)]`, so the Rust example's per-request header
-# auth is not yet expressible in YAML. Pending follow-up issue.
+# GraphQL (Relay cursor pagination, custom-header auth) → BigQuery with
+# ApplicationDefault credentials.
 version: 1
 name: graphql_to_bigquery
 
@@ -21,7 +18,10 @@ source:
     variables:
       first: 200
     auth:
-      type: None
+      type: Custom
+      headers:
+        X-Api-Key: ${env:API_KEY}
+        X-Tenant: acme
     records_path: $.data.orders.edges[*].node
     pagination:
       has_next_page_path: $.data.orders.pageInfo.hasNextPage

--- a/cli/examples/graphql_to_postgres.yaml
+++ b/cli/examples/graphql_to_postgres.yaml
@@ -1,10 +1,6 @@
 # YAML equivalent of `faucet-stream/examples/graphql_to_postgres.rs`.
-# GraphQL (Relay cursor pagination) → PostgreSQL with AutoMap column mapping.
-#
-# Limitation: GraphqlAuth::Bearer(String) is a newtype-in-tagged-enum and
-# can't round-trip through serde — see the follow-up issue. Until that's
-# fixed, the YAML version omits auth; add it on the wire-level proxy if
-# your endpoint requires a token.
+# GraphQL (Relay cursor pagination, Bearer auth) → PostgreSQL with
+# AutoMap column mapping.
 version: 1
 name: graphql_to_postgres
 
@@ -22,7 +18,8 @@ source:
     variables:
       first: 100
     auth:
-      type: None
+      type: Bearer
+      token: ${env:API_TOKEN}
     records_path: $.data.users.edges[*].node
     pagination:
       has_next_page_path: $.data.users.pageInfo.hasNextPage

--- a/cli/examples/grpc_to_elasticsearch.yaml
+++ b/cli/examples/grpc_to_elasticsearch.yaml
@@ -1,10 +1,5 @@
 # YAML equivalent of `faucet-stream/examples/grpc_to_elasticsearch.rs`.
-# gRPC (TLS) → Elasticsearch with Basic auth and id_field.
-#
-# Limitation: GrpcAuth::Metadata and GrpcAuth::Bearer are newtype variants of
-# an internally-tagged enum and cannot round-trip through serde today (see the
-# tracking issue). Run the .rs example for metadata-based auth until the
-# config type is split into struct variants.
+# gRPC (TLS, custom metadata) → Elasticsearch with Basic auth and id_field.
 version: 1
 name: grpc_to_elasticsearch
 
@@ -19,7 +14,12 @@ source:
       since: "2026-01-01T00:00:00Z"
       page_size: 1000
     auth:
-      type: None
+      type: Metadata
+      entries:
+        - key: x-api-key
+          value: ${env:GRPC_API_KEY}
+        - key: x-tenant
+          value: acme
     tls: true
     records_path: $.events[*]
 
@@ -30,8 +30,7 @@ sink:
     index: events
     auth:
       type: Basic
-      value:
-        username: ${env:ES_USER}
-        password: ${env:ES_PASS}
+      username: ${env:ES_USER}
+      password: ${env:ES_PASS}
     batch_size: 1000
     id_field: event_id

--- a/cli/examples/grpc_to_http.yaml
+++ b/cli/examples/grpc_to_http.yaml
@@ -1,10 +1,5 @@
 # YAML equivalent of `faucet-stream/examples/grpc_to_http.rs`.
-# gRPC (TLS) → HTTP POST with Basic auth and array batching.
-#
-# Limitation: GrpcAuth::Bearer and HttpSinkAuth::Bearer are newtype variants
-# of internally-tagged enums and can't round-trip through serde today. The
-# YAML below uses Basic auth on the sink and no source auth as a closest
-# expressible equivalent — see the tracking issue.
+# gRPC (TLS, Bearer metadata) → HTTP POST with Bearer auth and array batching.
 version: 1
 name: grpc_to_http
 
@@ -18,7 +13,8 @@ source:
     request:
       window: 1h
     auth:
-      type: None
+      type: Bearer
+      token: ${env:GRPC_TOKEN}
     tls: true
     records_path: $.metrics[*]
 
@@ -28,9 +24,8 @@ sink:
     url: https://ingest.example.com/v1/events?tenant=acme
     method: POST
     auth:
-      type: Basic
-      username: ${env:INGEST_USER}
-      password: ${env:INGEST_PASS}
+      type: Bearer
+      token: ${env:INGEST_TOKEN}
     batch_mode:
       type: Array
     max_retries: 3

--- a/cli/examples/mongodb_to_elasticsearch.yaml
+++ b/cli/examples/mongodb_to_elasticsearch.yaml
@@ -28,8 +28,7 @@ sink:
     index: products
     auth:
       type: Basic
-      value:
-        username: ${env:ES_USER}
-        password: ${env:ES_PASS}
+      username: ${env:ES_USER}
+      password: ${env:ES_PASS}
     batch_size: 1000
     id_field: _id

--- a/cli/examples/postgres_to_elasticsearch.yaml
+++ b/cli/examples/postgres_to_elasticsearch.yaml
@@ -18,6 +18,6 @@ sink:
     index: articles
     auth:
       type: ApiKey
-      value: ${env:ES_API_KEY}
+      key: ${env:ES_API_KEY}
     batch_size: 500
     id_field: id

--- a/cli/examples/rest_to_jsonl.yaml
+++ b/cli/examples/rest_to_jsonl.yaml
@@ -14,9 +14,8 @@ source:
     path: /repos/PawanSikawat/faucet-stream/issues
     method: GET
     auth:
-      type: ApiKey
-      header: Authorization
-      value: Bearer ${env:GITHUB_TOKEN}
+      type: Bearer
+      token: ${env:GITHUB_TOKEN}
     query_params:
       state: open
       per_page: "100"

--- a/cli/examples/rest_to_postgres.yaml
+++ b/cli/examples/rest_to_postgres.yaml
@@ -14,9 +14,8 @@ source:
     path: /charges
     method: GET
     auth:
-      type: ApiKey
-      header: Authorization
-      value: Bearer ${env:STRIPE_TOKEN}
+      type: Bearer
+      token: ${env:STRIPE_TOKEN}
     query_params:
       limit: "100"
     pagination:

--- a/cli/examples/webhook_to_http.yaml
+++ b/cli/examples/webhook_to_http.yaml
@@ -1,9 +1,5 @@
 # YAML equivalent of `faucet-stream/examples/webhook_to_http.rs`.
-# HTTP receiver → HTTP forwarder.
-#
-# Limitation: HttpSinkAuth::Bearer is a newtype-in-tagged-enum variant and
-# cannot round-trip through serde today; this YAML falls back to Basic
-# auth. See the tracking issue for the wider connector serde fix-up.
+# HTTP receiver → HTTP forwarder with Bearer auth.
 version: 1
 name: webhook_to_http
 
@@ -21,9 +17,8 @@ sink:
     url: https://downstream.example.com/ingest
     method: POST
     auth:
-      type: Basic
-      username: ${env:INGEST_USER}
-      password: ${env:INGEST_PASS}
+      type: Bearer
+      token: ${env:INGEST_TOKEN}
     batch_mode:
       type: Individual
     max_retries: 3

--- a/cli/examples/xml_to_mongodb.yaml
+++ b/cli/examples/xml_to_mongodb.yaml
@@ -1,9 +1,5 @@
 # YAML equivalent of `faucet-stream/examples/xml_to_mongodb.rs`.
-#
-# Limitation: XmlAuth::Bearer(String) is a newtype-in-tagged-enum variant
-# and can't round-trip through serde today. The Rust example uses Bearer
-# auth; this YAML falls back to None — adjust the upstream API or use the
-# library directly until the connector serde fix-up lands.
+# XML feed (Bearer auth, offset pagination) → MongoDB.
 version: 1
 name: xml_to_mongodb
 
@@ -14,7 +10,8 @@ source:
     path: /catalog
     method: GET
     auth:
-      type: None
+      type: Bearer
+      token: ${env:FEED_TOKEN}
     query_params:
       format: xml
     records_element_path: catalog.products.product

--- a/crates/sink/elasticsearch/README.md
+++ b/crates/sink/elasticsearch/README.md
@@ -65,9 +65,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 | Variant | Fields | Description |
 |---------|--------|-------------|
 | `None` | -- | No authentication |
-| `Basic` | `username: String`, `password: String` | HTTP Basic authentication |
-| `Bearer` | `String` | Bearer token in the Authorization header |
-| `ApiKey` | `String` | API key sent as `ApiKey <key>` in the Authorization header |
+| `Basic { username, password }` | `String`, `String` | HTTP Basic authentication |
+| `Bearer { token }` | `String` | Bearer token in the Authorization header |
+| `ApiKey { key }` | `String` | API key sent as `ApiKey <key>` in the Authorization header |
 
 The `Debug` implementation masks passwords, tokens, and API keys with `***` to prevent credential leakage in logs.
 
@@ -114,10 +114,8 @@ let config: ElasticsearchSinkConfig = load_env_file(".env", "ES_SINK")?;
   "index": "events",
   "auth": {
     "type": "Basic",
-    "value": {
-      "username": "elastic",
-      "password": "changeme"
-    }
+    "username": "elastic",
+    "password": "changeme"
   },
   "batch_size": 500,
   "id_field": "event_id"
@@ -145,7 +143,7 @@ let config: ElasticsearchSinkConfig = load_env_file(".env", "ES_SINK")?;
   "index": "metrics",
   "auth": {
     "type": "ApiKey",
-    "value": "VnVhQ2ZHY0JDZGJrU..."
+    "key": "VnVhQ2ZHY0JDZGJrU..."
   },
   "batch_size": 500
 }
@@ -156,7 +154,7 @@ let config: ElasticsearchSinkConfig = load_env_file(".env", "ES_SINK")?;
 ```env
 ES_SINK_BASE_URL=http://localhost:9200
 ES_SINK_INDEX=events
-ES_SINK_AUTH='{"type":"Basic","value":{"username":"elastic","password":"changeme"}}'
+ES_SINK_AUTH='{"type":"Basic","username":"elastic","password":"changeme"}'
 ES_SINK_BATCH_SIZE=500
 ES_SINK_ID_FIELD=event_id
 ```
@@ -232,9 +230,9 @@ let config = ElasticsearchSinkConfig::new(
     "https://my-deployment.es.us-east-1.aws.found.io:9243",
     "application-events",
 )
-.auth(ElasticsearchSinkAuth::ApiKey(
-    std::env::var("ES_API_KEY")?
-))
+.auth(ElasticsearchSinkAuth::ApiKey {
+    key: std::env::var("ES_API_KEY")?,
+})
 .batch_size(2000);
 
 let sink = ElasticsearchSink::new(config);

--- a/crates/sink/elasticsearch/src/config.rs
+++ b/crates/sink/elasticsearch/src/config.rs
@@ -5,16 +5,16 @@ use serde::{Deserialize, Serialize};
 
 /// Authentication method for the Elasticsearch sink.
 #[derive(Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(tag = "type", content = "value")]
+#[serde(tag = "type")]
 pub enum ElasticsearchSinkAuth {
     /// No authentication.
     None,
     /// HTTP Basic authentication.
     Basic { username: String, password: String },
     /// Bearer token authentication.
-    Bearer(String),
+    Bearer { token: String },
     /// API key authentication (sent as `ApiKey` in the `Authorization` header).
-    ApiKey(String),
+    ApiKey { key: String },
 }
 
 impl std::fmt::Debug for ElasticsearchSinkAuth {
@@ -26,8 +26,8 @@ impl std::fmt::Debug for ElasticsearchSinkAuth {
                 .field("username", username)
                 .field("password", &"***")
                 .finish(),
-            Self::Bearer(_) => write!(f, "Bearer(***)"),
-            Self::ApiKey(_) => write!(f, "ApiKey(***)"),
+            Self::Bearer { .. } => write!(f, "Bearer(***)"),
+            Self::ApiKey { .. } => write!(f, "ApiKey(***)"),
         }
     }
 }
@@ -97,7 +97,9 @@ mod tests {
         let config = ElasticsearchSinkConfig::new("http://es:9200/", "idx")
             .batch_size(100)
             .id_field("doc_id")
-            .auth(ElasticsearchSinkAuth::Bearer("tok".into()));
+            .auth(ElasticsearchSinkAuth::Bearer {
+                token: "tok".into(),
+            });
         assert_eq!(config.base_url, "http://es:9200");
         assert_eq!(config.batch_size, 100);
         assert_eq!(config.id_field.as_deref(), Some("doc_id"));
@@ -117,12 +119,16 @@ mod tests {
         assert!(debug.contains("***"));
         assert!(!debug.contains("secret"));
 
-        let bearer = ElasticsearchSinkAuth::Bearer("my-token".into());
+        let bearer = ElasticsearchSinkAuth::Bearer {
+            token: "my-token".into(),
+        };
         let debug = format!("{bearer:?}");
         assert!(debug.contains("***"));
         assert!(!debug.contains("my-token"));
 
-        let api_key = ElasticsearchSinkAuth::ApiKey("my-key".into());
+        let api_key = ElasticsearchSinkAuth::ApiKey {
+            key: "my-key".into(),
+        };
         let debug = format!("{api_key:?}");
         assert!(debug.contains("***"));
         assert!(!debug.contains("my-key"));

--- a/crates/sink/elasticsearch/src/sink.rs
+++ b/crates/sink/elasticsearch/src/sink.rs
@@ -29,8 +29,8 @@ impl ElasticsearchSink {
             ElasticsearchSinkAuth::Basic { username, password } => {
                 req.basic_auth(username, Some(password))
             }
-            ElasticsearchSinkAuth::Bearer(token) => req.bearer_auth(token),
-            ElasticsearchSinkAuth::ApiKey(key) => {
+            ElasticsearchSinkAuth::Bearer { token } => req.bearer_auth(token),
+            ElasticsearchSinkAuth::ApiKey { key } => {
                 req.header("Authorization", format!("ApiKey {key}"))
             }
         }

--- a/crates/sink/http/README.md
+++ b/crates/sink/http/README.md
@@ -65,9 +65,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 | Variant | Fields | Description |
 |---------|--------|-------------|
 | `None` | -- | No authentication |
-| `Bearer` | `String` | Bearer token in the Authorization header |
-| `Basic` | `username: String`, `password: String` | HTTP Basic authentication |
-| `Custom` | `HeaderMap` | Custom headers for authentication (e.g. API keys). Not serializable; set via builder only. |
+| `Bearer { token }` | `String` | Bearer token in the Authorization header |
+| `Basic { username, password }` | `String`, `String` | HTTP Basic authentication |
+| `Custom { headers }` | `HashMap<String, String>` | Header name → value map attached to every request |
 
 The `Debug` implementation masks tokens and passwords with `***` to prevent credential leakage in logs.
 
@@ -89,7 +89,7 @@ use faucet_sink_http::{HttpSinkConfig, HttpSinkAuth, HttpBatchMode};
 
 let config = HttpSinkConfig::new("https://api.example.com/ingest")
     .method(reqwest::Method::PUT)
-    .auth(HttpSinkAuth::Bearer("my-token".into()))
+    .auth(HttpSinkAuth::Bearer { token: "my-token".into() })
     .batch_mode(HttpBatchMode::Array)
     .max_retries(3)
     .concurrency(20);
@@ -108,7 +108,7 @@ let config: HttpSinkConfig = load_json("config.json")?;
 let config: HttpSinkConfig = load_env_file(".env", "HTTP_SINK")?;
 ```
 
-Note: The `headers` field and `Custom` auth variant use `HeaderMap` which is not serializable. These must be set programmatically via builder methods.
+Note: The `headers` field on `HttpSinkConfig` is `HeaderMap` and remains `#[serde(skip)]` — set it programmatically. The `Custom` auth variant uses a `HashMap<String, String>` and round-trips through JSON/YAML.
 
 ### Example JSON config (Individual mode with Bearer auth)
 
@@ -118,7 +118,7 @@ Note: The `headers` field and `Custom` auth variant use `HeaderMap` which is not
   "method": "POST",
   "auth": {
     "type": "Bearer",
-    "0": "my-api-token"
+    "token": "my-api-token"
   },
   "batch_mode": {
     "type": "Individual"
@@ -152,7 +152,7 @@ Note: The `headers` field and `Custom` auth variant use `HeaderMap` which is not
 ```env
 HTTP_SINK_URL=https://api.example.com/ingest
 HTTP_SINK_METHOD=POST
-HTTP_SINK_AUTH='{"type":"Bearer","0":"my-api-token"}'
+HTTP_SINK_AUTH='{"type":"Bearer","token":"my-api-token"}'
 HTTP_SINK_BATCH_MODE='{"type":"Individual"}'
 HTTP_SINK_MAX_RETRIES=3
 HTTP_SINK_CONCURRENCY=10
@@ -195,7 +195,7 @@ println!("Forwarded {} records", result.records_written);
 
 ```rust
 let config = HttpSinkConfig::new("https://webhooks.example.com/event")
-    .auth(HttpSinkAuth::Bearer("webhook-token".into()))
+    .auth(HttpSinkAuth::Bearer { token: "webhook-token".into() })
     .batch_mode(HttpBatchMode::Individual)
     .concurrency(20)
     .max_retries(2);

--- a/crates/sink/http/src/config.rs
+++ b/crates/sink/http/src/config.rs
@@ -3,6 +3,7 @@
 use reqwest::header::HeaderMap;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 /// Authentication method for the HTTP sink.
 #[derive(Clone, Serialize, Deserialize, JsonSchema)]
@@ -11,7 +12,10 @@ pub enum HttpSinkAuth {
     /// No authentication.
     None,
     /// Bearer token in the Authorization header.
-    Bearer(String),
+    Bearer {
+        /// The token value (sent as `Authorization: Bearer <token>`).
+        token: String,
+    },
     /// HTTP Basic authentication.
     Basic {
         /// Username.
@@ -20,21 +24,23 @@ pub enum HttpSinkAuth {
         password: String,
     },
     /// Custom headers for authentication (e.g. API keys).
-    #[serde(skip)]
-    Custom(HeaderMap),
+    Custom {
+        /// Header name → value map applied to every request.
+        headers: HashMap<String, String>,
+    },
 }
 
 impl std::fmt::Debug for HttpSinkAuth {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::None => write!(f, "None"),
-            Self::Bearer(_) => f.debug_tuple("Bearer").field(&"***").finish(),
+            Self::Bearer { .. } => f.debug_tuple("Bearer").field(&"***").finish(),
             Self::Basic { username, .. } => f
                 .debug_struct("Basic")
                 .field("username", username)
                 .field("password", &"***")
                 .finish(),
-            Self::Custom(_) => f.debug_tuple("Custom").field(&"***").finish(),
+            Self::Custom { .. } => f.debug_tuple("Custom").field(&"***").finish(),
         }
     }
 }
@@ -154,7 +160,9 @@ mod tests {
     fn builder_methods() {
         let config = HttpSinkConfig::new("https://api.example.com/ingest")
             .method(reqwest::Method::PUT)
-            .auth(HttpSinkAuth::Bearer("token123".into()))
+            .auth(HttpSinkAuth::Bearer {
+                token: "token123".into(),
+            })
             .batch_mode(HttpBatchMode::Array)
             .max_retries(3);
         assert_eq!(config.method, reqwest::Method::PUT);
@@ -164,7 +172,9 @@ mod tests {
 
     #[test]
     fn auth_debug_masks_secrets() {
-        let bearer = HttpSinkAuth::Bearer("secret-token".into());
+        let bearer = HttpSinkAuth::Bearer {
+            token: "secret-token".into(),
+        };
         let debug = format!("{bearer:?}");
         assert!(debug.contains("***"));
         assert!(!debug.contains("secret-token"));
@@ -178,7 +188,9 @@ mod tests {
         assert!(debug.contains("***"));
         assert!(!debug.contains("secret-pass"));
 
-        let custom = HttpSinkAuth::Custom(HeaderMap::new());
+        let custom = HttpSinkAuth::Custom {
+            headers: HashMap::new(),
+        };
         let debug = format!("{custom:?}");
         assert!(debug.contains("***"));
     }

--- a/crates/sink/http/src/sink.rs
+++ b/crates/sink/http/src/sink.rs
@@ -22,7 +22,7 @@ impl HttpSink {
     }
 
     /// Build an HTTP request with auth and headers applied.
-    fn build_request(&self, body: &Value) -> reqwest::RequestBuilder {
+    fn build_request(&self, body: &Value) -> Result<reqwest::RequestBuilder, FaucetError> {
         let mut req = self
             .client
             .request(self.config.method.clone(), &self.config.url)
@@ -31,18 +31,29 @@ impl HttpSink {
 
         match &self.config.auth {
             HttpSinkAuth::None => {}
-            HttpSinkAuth::Bearer(token) => {
+            HttpSinkAuth::Bearer { token } => {
                 req = req.bearer_auth(token);
             }
             HttpSinkAuth::Basic { username, password } => {
                 req = req.basic_auth(username, Some(password));
             }
-            HttpSinkAuth::Custom(headers) => {
-                req = req.headers(headers.clone());
+            HttpSinkAuth::Custom { headers } => {
+                let mut hm = reqwest::header::HeaderMap::new();
+                for (name, value) in headers {
+                    let n =
+                        reqwest::header::HeaderName::from_bytes(name.as_bytes()).map_err(|e| {
+                            FaucetError::Auth(format!("invalid custom header name {name:?}: {e}"))
+                        })?;
+                    let v = reqwest::header::HeaderValue::from_str(value).map_err(|e| {
+                        FaucetError::Auth(format!("invalid custom header value for {name:?}: {e}"))
+                    })?;
+                    hm.insert(n, v);
+                }
+                req = req.headers(hm);
             }
         }
 
-        req
+        Ok(req)
     }
 
     /// Send a single request with retry logic.
@@ -50,7 +61,7 @@ impl HttpSink {
         let mut last_error = None;
 
         for attempt in 0..=self.config.max_retries {
-            let req = self.build_request(body);
+            let req = self.build_request(body)?;
 
             match req.send().await {
                 Ok(resp) => match check_http_response(resp, DEFAULT_ERROR_BODY_MAX_LEN).await {
@@ -149,12 +160,15 @@ mod tests {
 
     #[test]
     fn build_request_applies_bearer_auth() {
-        let config = HttpSinkConfig::new("https://api.example.com/ingest")
-            .auth(HttpSinkAuth::Bearer("my-token".into()));
+        let config =
+            HttpSinkConfig::new("https://api.example.com/ingest").auth(HttpSinkAuth::Bearer {
+                token: "my-token".into(),
+            });
         let sink = HttpSink::new(config);
 
         let req = sink
             .build_request(&serde_json::json!({"test": true}))
+            .unwrap()
             .build()
             .unwrap();
 
@@ -179,6 +193,7 @@ mod tests {
 
         let req = sink
             .build_request(&serde_json::json!({"test": true}))
+            .unwrap()
             .build()
             .unwrap();
 
@@ -199,6 +214,7 @@ mod tests {
 
         let req = sink
             .build_request(&serde_json::json!({"test": true}))
+            .unwrap()
             .build()
             .unwrap();
 

--- a/crates/source/elasticsearch/README.md
+++ b/crates/source/elasticsearch/README.md
@@ -71,8 +71,8 @@ The source uses the Elasticsearch scroll API for efficient retrieval of large re
 |---------|--------|-------------|
 | `None` | -- | No authentication |
 | `Basic { username, password }` | `String`, `String` | HTTP Basic authentication. Password is masked in debug output |
-| `Bearer(String)` | token | Bearer token in the `Authorization` header. Masked in debug output |
-| `ApiKey(String)` | key | API key sent as `ApiKey <key>` in the `Authorization` header. Masked in debug output |
+| `Bearer { token }` | `String` | Bearer token in the `Authorization` header. Masked in debug output |
+| `ApiKey { key }` | `String` | API key sent as `ApiKey <key>` in the `Authorization` header. Masked in debug output |
 
 ## Config Loading
 
@@ -102,10 +102,8 @@ let config: ElasticsearchSourceConfig = load_env_file(".env", "ES_SOURCE")?;
   "scroll_size": 5000,
   "auth": {
     "type": "Basic",
-    "value": {
-      "username": "elastic",
-      "password": "changeme"
-    }
+    "username": "elastic",
+    "password": "changeme"
   },
   "max_pages": 100
 }
@@ -165,7 +163,9 @@ let config = ElasticsearchSourceConfig::new(
         ]
     }
 }))
-.auth(ElasticsearchAuth::Bearer("your-token".into()))
+.auth(ElasticsearchAuth::Bearer {
+    token: "your-token".into(),
+})
 .scroll_size(2000)
 .scroll_timeout("5m")
 .max_pages(50);
@@ -196,7 +196,9 @@ let config = ElasticsearchSourceConfig::new(
         }
     }
 }))
-.auth(ElasticsearchAuth::ApiKey("base64-encoded-api-key".into()))
+.auth(ElasticsearchAuth::ApiKey {
+    key: "base64-encoded-api-key".into(),
+})
 .scroll_size(5000);
 
 let source = ElasticsearchSource::new(config);

--- a/crates/source/elasticsearch/src/config.rs
+++ b/crates/source/elasticsearch/src/config.rs
@@ -6,16 +6,16 @@ use serde_json::{Value, json};
 
 /// Authentication method for Elasticsearch.
 #[derive(Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(tag = "type", content = "value")]
+#[serde(tag = "type")]
 pub enum ElasticsearchAuth {
     /// No authentication.
     None,
     /// HTTP Basic authentication.
     Basic { username: String, password: String },
     /// Bearer token authentication.
-    Bearer(String),
+    Bearer { token: String },
     /// API key authentication (sent as `ApiKey` in the `Authorization` header).
-    ApiKey(String),
+    ApiKey { key: String },
 }
 
 impl std::fmt::Debug for ElasticsearchAuth {
@@ -27,8 +27,8 @@ impl std::fmt::Debug for ElasticsearchAuth {
                 .field("username", username)
                 .field("password", &"***")
                 .finish(),
-            Self::Bearer(_) => write!(f, "Bearer(***)"),
-            Self::ApiKey(_) => write!(f, "ApiKey(***)"),
+            Self::Bearer { .. } => write!(f, "Bearer(***)"),
+            Self::ApiKey { .. } => write!(f, "ApiKey(***)"),
         }
     }
 }
@@ -119,7 +119,9 @@ mod tests {
             .scroll_timeout("5m")
             .scroll_size(500)
             .max_pages(10)
-            .auth(ElasticsearchAuth::Bearer("tok".into()));
+            .auth(ElasticsearchAuth::Bearer {
+                token: "tok".into(),
+            });
         assert_eq!(config.base_url, "http://es:9200");
         assert_eq!(config.scroll_timeout, "5m");
         assert_eq!(config.scroll_size, 500);
@@ -140,12 +142,16 @@ mod tests {
         assert!(debug.contains("***"));
         assert!(!debug.contains("secret"));
 
-        let bearer = ElasticsearchAuth::Bearer("my-token".into());
+        let bearer = ElasticsearchAuth::Bearer {
+            token: "my-token".into(),
+        };
         let debug = format!("{bearer:?}");
         assert!(debug.contains("***"));
         assert!(!debug.contains("my-token"));
 
-        let api_key = ElasticsearchAuth::ApiKey("my-key".into());
+        let api_key = ElasticsearchAuth::ApiKey {
+            key: "my-key".into(),
+        };
         let debug = format!("{api_key:?}");
         assert!(debug.contains("***"));
         assert!(!debug.contains("my-key"));

--- a/crates/source/elasticsearch/src/stream.rs
+++ b/crates/source/elasticsearch/src/stream.rs
@@ -29,8 +29,10 @@ impl ElasticsearchSource {
             ElasticsearchAuth::Basic { username, password } => {
                 req.basic_auth(username, Some(password))
             }
-            ElasticsearchAuth::Bearer(token) => req.bearer_auth(token),
-            ElasticsearchAuth::ApiKey(key) => req.header("Authorization", format!("ApiKey {key}")),
+            ElasticsearchAuth::Bearer { token } => req.bearer_auth(token),
+            ElasticsearchAuth::ApiKey { key } => {
+                req.header("Authorization", format!("ApiKey {key}"))
+            }
         }
     }
 

--- a/crates/source/graphql/README.md
+++ b/crates/source/graphql/README.md
@@ -63,8 +63,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 | Variant | Description |
 |---------|-------------|
 | `None` | No authentication |
-| `Bearer(String)` | Bearer token in the `Authorization` header |
-| `Custom(HeaderMap)` | Custom headers (e.g. API keys, cookies). Not serializable |
+| `Bearer { token }` | Bearer token in the `Authorization` header |
+| `Custom { headers }` | Custom headers map (`HashMap<String, String>`) attached to every request |
 
 ### Pagination (GraphqlPagination)
 
@@ -101,7 +101,7 @@ let config: GraphqlStreamConfig = load_env_file(".env", "GRAPHQL")?;
   },
   "auth": {
     "type": "Bearer",
-    "value": "ghp_xxxxxxxxxxxx"
+    "token": "ghp_xxxxxxxxxxxx"
   },
   "records_path": "$.data.organization.repositories.edges[*].node",
   "pagination": {
@@ -147,7 +147,9 @@ let config = GraphqlStreamConfig::new(
     "query($id: ID!) { user(id: $id) { name email } }",
 )
 .variables(json!({"id": "user-123"}))
-.auth(GraphqlAuth::Bearer("your-token".into()));
+.auth(GraphqlAuth::Bearer {
+    token: "your-token".into(),
+});
 
 let stream = GraphqlStream::new(config);
 let records = stream.fetch_all().await?;
@@ -173,7 +175,9 @@ let config = GraphqlStreamConfig::new(
     }
     "#,
 )
-.auth(GraphqlAuth::Bearer("your-token".into()))
+.auth(GraphqlAuth::Bearer {
+    token: "your-token".into(),
+})
 .records_path("$.data.users.edges[*].node")
 .pagination(GraphqlPagination {
     has_next_page_path: "$.data.users.pageInfo.hasNextPage".into(),

--- a/crates/source/graphql/src/config.rs
+++ b/crates/source/graphql/src/config.rs
@@ -4,6 +4,7 @@ use reqwest::header::HeaderMap;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::collections::HashMap;
 
 /// Authentication for GraphQL endpoints.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -12,10 +13,9 @@ pub enum GraphqlAuth {
     /// No authentication.
     None,
     /// Bearer token in the Authorization header.
-    Bearer(String),
+    Bearer { token: String },
     /// Custom headers (e.g. API keys, cookies).
-    #[serde(skip)]
-    Custom(HeaderMap),
+    Custom { headers: HashMap<String, String> },
 }
 
 /// Cursor-based pagination configuration for GraphQL.
@@ -146,7 +146,9 @@ mod tests {
                 .variables(json!({"org": "acme"}))
                 .records_path("$.data.users.edges[*].node")
                 .max_pages(10)
-                .auth(GraphqlAuth::Bearer("token".into()));
+                .auth(GraphqlAuth::Bearer {
+                    token: "token".into(),
+                });
         assert_eq!(config.variables["org"], "acme");
         assert_eq!(config.records_path.unwrap(), "$.data.users.edges[*].node");
         assert_eq!(config.max_pages, Some(10));

--- a/crates/source/graphql/src/stream.rs
+++ b/crates/source/graphql/src/stream.rs
@@ -126,11 +126,22 @@ impl GraphqlStream {
         // Apply auth.
         match &self.config.auth {
             GraphqlAuth::None => {}
-            GraphqlAuth::Bearer(token) => {
+            GraphqlAuth::Bearer { token } => {
                 req = req.bearer_auth(token);
             }
-            GraphqlAuth::Custom(headers) => {
-                req = req.headers(headers.clone());
+            GraphqlAuth::Custom { headers } => {
+                let mut hm = reqwest::header::HeaderMap::new();
+                for (name, value) in headers {
+                    let n =
+                        reqwest::header::HeaderName::from_bytes(name.as_bytes()).map_err(|e| {
+                            FaucetError::Auth(format!("invalid custom header name {name:?}: {e}"))
+                        })?;
+                    let v = reqwest::header::HeaderValue::from_str(value).map_err(|e| {
+                        FaucetError::Auth(format!("invalid custom header value for {name:?}: {e}"))
+                    })?;
+                    hm.insert(n, v);
+                }
+                req = req.headers(hm);
             }
         }
 

--- a/crates/source/grpc/README.md
+++ b/crates/source/grpc/README.md
@@ -78,8 +78,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 | Variant | Fields | Description |
 |---------|--------|-------------|
 | `None` | -- | No authentication |
-| `Bearer(String)` | token | Bearer token sent as `authorization` metadata |
-| `Metadata(Vec<(String, String)>)` | key-value pairs | Custom metadata key-value pairs attached to the gRPC request |
+| `Bearer { token }` | `String` | Bearer token sent as `authorization` metadata |
+| `Metadata { entries }` | `Vec<MetadataEntry { key, value }>` | Custom metadata pairs attached to the gRPC request — `Vec` preserves order and allows duplicate keys (gRPC permits both) |
 
 ## Config Loading
 
@@ -105,7 +105,7 @@ let config: GrpcStreamConfig = load_env_file(".env", "GRPC")?;
   },
   "auth": {
     "type": "Bearer",
-    "value": "your-api-token"
+    "token": "your-api-token"
   },
   "tls": true,
   "records_path": "$.products[*]"
@@ -169,7 +169,9 @@ let config = GrpcStreamConfig::new(
     "end_time": "2025-02-01T00:00:00Z",
     "limit": 1000
 }))
-.auth(GrpcAuth::Bearer("your-bearer-token".into()))
+.auth(GrpcAuth::Bearer {
+    token: "your-bearer-token".into(),
+})
 .tls(true)
 .records_path("$.events[*]");
 
@@ -181,7 +183,7 @@ println!("Fetched {} events", events.len());
 ### Custom metadata authentication
 
 ```rust
-use faucet_source_grpc::{GrpcStream, GrpcStreamConfig, GrpcAuth};
+use faucet_source_grpc::{GrpcAuth, GrpcStream, GrpcStreamConfig, MetadataEntry};
 
 let config = GrpcStreamConfig::new(
     "http://localhost:50051",
@@ -189,10 +191,12 @@ let config = GrpcStreamConfig::new(
     "ListItems",
     "proto/descriptor.bin",
 )
-.auth(GrpcAuth::Metadata(vec![
-    ("x-api-key".into(), "my-secret-key".into()),
-    ("x-tenant-id".into(), "tenant-123".into()),
-]));
+.auth(GrpcAuth::Metadata {
+    entries: vec![
+        MetadataEntry { key: "x-api-key".into(), value: "my-secret-key".into() },
+        MetadataEntry { key: "x-tenant-id".into(), value: "tenant-123".into() },
+    ],
+});
 
 let stream = GrpcStream::new(config)?;
 let items = stream.fetch_all().await?;

--- a/crates/source/grpc/src/config.rs
+++ b/crates/source/grpc/src/config.rs
@@ -5,6 +5,16 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::path::PathBuf;
 
+/// A single piece of gRPC request metadata.
+///
+/// Use a `Vec<MetadataEntry>` rather than a map because gRPC allows duplicate
+/// keys and order is occasionally observable.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct MetadataEntry {
+    pub key: String,
+    pub value: String,
+}
+
 /// Authentication for gRPC endpoints.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "type")]
@@ -12,9 +22,9 @@ pub enum GrpcAuth {
     /// No authentication.
     None,
     /// Bearer token sent as `authorization` metadata.
-    Bearer(String),
+    Bearer { token: String },
     /// Custom metadata key-value pairs.
-    Metadata(Vec<(String, String)>),
+    Metadata { entries: Vec<MetadataEntry> },
 }
 
 /// Configuration for the gRPC source.
@@ -110,11 +120,13 @@ mod tests {
         let config =
             GrpcStreamConfig::new("https://grpc.example.com", "svc.Svc", "Get", "desc.bin")
                 .request(json!({"page_size": 100}))
-                .auth(GrpcAuth::Bearer("tok".into()))
+                .auth(GrpcAuth::Bearer {
+                    token: "tok".into(),
+                })
                 .tls(true)
                 .records_path("$.users[*]");
         assert_eq!(config.request["page_size"], 100);
-        assert!(matches!(config.auth, GrpcAuth::Bearer(_)));
+        assert!(matches!(config.auth, GrpcAuth::Bearer { .. }));
         assert_eq!(config.tls, Some(true));
         assert_eq!(config.records_path.unwrap(), "$.users[*]");
     }

--- a/crates/source/grpc/src/lib.rs
+++ b/crates/source/grpc/src/lib.rs
@@ -11,5 +11,5 @@ pub mod stream;
 
 pub use faucet_core::{FaucetError, Source};
 
-pub use config::{GrpcAuth, GrpcStreamConfig};
+pub use config::{GrpcAuth, GrpcStreamConfig, MetadataEntry};
 pub use stream::GrpcStream;

--- a/crates/source/grpc/src/stream.rs
+++ b/crates/source/grpc/src/stream.rs
@@ -115,19 +115,21 @@ impl GrpcStream {
         // Apply auth metadata.
         match &self.config.auth {
             GrpcAuth::None => {}
-            GrpcAuth::Bearer(token) => {
+            GrpcAuth::Bearer { token } => {
                 let val: tonic::metadata::MetadataValue<tonic::metadata::Ascii> =
                     format!("Bearer {token}")
                         .parse()
                         .map_err(|e| FaucetError::Auth(format!("invalid bearer token: {e}")))?;
                 request.metadata_mut().insert("authorization", val);
             }
-            GrpcAuth::Metadata(pairs) => {
-                for (key, value) in pairs {
-                    let val: tonic::metadata::MetadataValue<tonic::metadata::Ascii> = value
+            GrpcAuth::Metadata { entries } => {
+                for entry in entries {
+                    let val: tonic::metadata::MetadataValue<tonic::metadata::Ascii> = entry
+                        .value
                         .parse()
                         .map_err(|e| FaucetError::Auth(format!("invalid metadata value: {e}")))?;
-                    let key: tonic::metadata::MetadataKey<tonic::metadata::Ascii> = key
+                    let key: tonic::metadata::MetadataKey<tonic::metadata::Ascii> = entry
+                        .key
                         .parse()
                         .map_err(|e| FaucetError::Auth(format!("invalid metadata key: {e}")))?;
                     request.metadata_mut().insert(key, val);

--- a/crates/source/rest/README.md
+++ b/crates/source/rest/README.md
@@ -109,13 +109,13 @@ The `Auth` enum supports the following strategies:
 | Variant | Fields | Description |
 |---------|--------|-------------|
 | `None` | -- | No authentication |
-| `Bearer(token)` | `String` | Bearer token in the `Authorization` header |
+| `Bearer { token }` | `String` | Bearer token in the `Authorization` header |
 | `Basic { username, password }` | `String`, `String` | HTTP Basic authentication |
 | `ApiKey { header, value }` | `String`, `String` | API key sent in a custom request header |
 | `ApiKeyQuery { param, value }` | `String`, `String` | API key sent as a query parameter (e.g. `?api_key=secret`) |
 | `OAuth2 { token_url, client_id, client_secret, scopes, expiry_ratio }` | see below | Client credentials OAuth2 flow with token caching |
 | `TokenEndpoint { url, method, headers, body, token_path, expiry_path, expiry_ratio, response_validator }` | see below | Fetch token from an arbitrary HTTP endpoint |
-| `Custom(HeaderMap)` | `HeaderMap` | Arbitrary custom headers (not serializable) |
+| `Custom { headers }` | `HashMap<String, String>` | Arbitrary custom headers attached to every request |
 
 **OAuth2 fields:**
 - `token_url` (`String`): Token endpoint URL
@@ -171,7 +171,7 @@ let config: RestStreamConfig = load_env_file(".env", "REST")?;
   "method": "GET",
   "auth": {
     "type": "Bearer",
-    "value": "ghp_xxxxxxxxxxxx"
+    "token": "ghp_xxxxxxxxxxxx"
   },
   "query_params": {
     "state": "open",
@@ -234,7 +234,9 @@ println!("{}", serde_json::to_string_pretty(&schema)?);
 use faucet_source_rest::{RestStream, RestStreamConfig, Auth, PaginationStyle};
 
 let config = RestStreamConfig::new("https://api.example.com", "/v2/contacts")
-    .auth(Auth::Bearer("your-api-token".into()))
+    .auth(Auth::Bearer {
+        token: "your-api-token".into(),
+    })
     .pagination(PaginationStyle::Cursor {
         next_token_path: "$.meta.next_cursor".into(),
         param_name: "cursor".into(),
@@ -284,7 +286,9 @@ use std::collections::HashMap;
 use serde_json::json;
 
 let config = RestStreamConfig::new("https://api.example.com", "/orgs/{org_id}/members")
-    .auth(Auth::Bearer("token".into()))
+    .auth(Auth::Bearer {
+        token: "token".into(),
+    })
     .add_partition(HashMap::from([("org_id".into(), json!("acme"))]))
     .add_partition(HashMap::from([("org_id".into(), json!("globex"))]))
     .add_partition(HashMap::from([("org_id".into(), json!("initech"))]))

--- a/crates/source/rest/examples/cursor_pagination.rs
+++ b/crates/source/rest/examples/cursor_pagination.rs
@@ -8,7 +8,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let stream = RestStream::new(
         RestStreamConfig::new("https://api.example.com", "/v1/users")
-            .auth(Auth::Bearer("your-token-here".into()))
+            .auth(Auth::Bearer {
+                token: "your-token-here".into(),
+            })
             .records_path("$.data[*]")
             .pagination(PaginationStyle::Cursor {
                 next_token_path: "$.meta.next_cursor".into(),

--- a/crates/source/rest/examples/oauth2_flow.rs
+++ b/crates/source/rest/examples/oauth2_flow.rs
@@ -18,7 +18,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let stream = RestStream::new(
         RestStreamConfig::new("https://api.example.com", "/v1/resources")
-            .auth(Auth::Bearer(token))
+            .auth(Auth::Bearer { token })
             .records_path("$.data[*]")
             .pagination(PaginationStyle::Cursor {
                 next_token_path: "$.pagination.next".into(),

--- a/crates/source/rest/src/auth/custom.rs
+++ b/crates/source/rest/src/auth/custom.rs
@@ -1,32 +1,39 @@
 //! Custom header-based authentication.
 
-use reqwest::header::HeaderMap;
+use faucet_core::FaucetError;
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+use std::collections::HashMap;
 
-pub fn apply(headers: &mut HeaderMap, custom: &HeaderMap) {
-    headers.extend(custom.clone());
+pub fn apply(headers: &mut HeaderMap, custom: &HashMap<String, String>) -> Result<(), FaucetError> {
+    for (name, value) in custom {
+        let header_name = HeaderName::from_bytes(name.as_bytes())
+            .map_err(|e| FaucetError::Auth(format!("invalid custom header name {name:?}: {e}")))?;
+        let header_value = HeaderValue::from_str(value).map_err(|e| {
+            FaucetError::Auth(format!("invalid custom header value for {name:?}: {e}"))
+        })?;
+        headers.insert(header_name, header_value);
+    }
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use reqwest::header::{HeaderName, HeaderValue};
+    use reqwest::header::HeaderValue;
 
     #[test]
     fn apply_merges_custom_headers() {
         let mut headers = HeaderMap::new();
         headers.insert("existing", HeaderValue::from_static("keep"));
 
-        let mut custom = HeaderMap::new();
-        custom.insert(
-            HeaderName::from_static("x-custom"),
-            HeaderValue::from_static("val1"),
-        );
-        custom.insert(
-            HeaderName::from_static("x-another"),
-            HeaderValue::from_static("val2"),
-        );
+        let custom: HashMap<String, String> = [
+            ("x-custom".to_string(), "val1".to_string()),
+            ("x-another".to_string(), "val2".to_string()),
+        ]
+        .into_iter()
+        .collect();
 
-        apply(&mut headers, &custom);
+        apply(&mut headers, &custom).unwrap();
 
         assert_eq!(headers.get("existing").unwrap(), "keep");
         assert_eq!(headers.get("x-custom").unwrap(), "val1");
@@ -38,13 +45,11 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert("x-key", HeaderValue::from_static("old"));
 
-        let mut custom = HeaderMap::new();
-        custom.insert(
-            HeaderName::from_static("x-key"),
-            HeaderValue::from_static("new"),
-        );
+        let custom: HashMap<String, String> = [("x-key".to_string(), "new".to_string())]
+            .into_iter()
+            .collect();
 
-        apply(&mut headers, &custom);
+        apply(&mut headers, &custom).unwrap();
         assert_eq!(headers.get("x-key").unwrap(), "new");
     }
 
@@ -53,8 +58,26 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert("existing", HeaderValue::from_static("value"));
 
-        apply(&mut headers, &HeaderMap::new());
+        apply(&mut headers, &HashMap::new()).unwrap();
         assert_eq!(headers.len(), 1);
         assert_eq!(headers.get("existing").unwrap(), "value");
+    }
+
+    #[test]
+    fn apply_rejects_invalid_header_name() {
+        let mut headers = HeaderMap::new();
+        let custom: HashMap<String, String> = [("bad name".to_string(), "v".to_string())]
+            .into_iter()
+            .collect();
+        assert!(apply(&mut headers, &custom).is_err());
+    }
+
+    #[test]
+    fn apply_rejects_invalid_header_value() {
+        let mut headers = HeaderMap::new();
+        let custom: HashMap<String, String> = [("x-good".to_string(), "bad\nvalue".to_string())]
+            .into_iter()
+            .collect();
+        assert!(apply(&mut headers, &custom).is_err());
     }
 }

--- a/crates/source/rest/src/auth/mod.rs
+++ b/crates/source/rest/src/auth/mod.rs
@@ -11,6 +11,7 @@ use faucet_core::FaucetError;
 use reqwest::header::HeaderMap;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 pub use token_endpoint::ResponseValidator;
 
 /// Supported authentication methods.
@@ -18,7 +19,10 @@ pub use token_endpoint::ResponseValidator;
 #[serde(tag = "type")]
 pub enum Auth {
     None,
-    Bearer(String),
+    /// Bearer token in the `Authorization` header.
+    Bearer {
+        token: String,
+    },
     Basic {
         username: String,
         password: String,
@@ -80,8 +84,11 @@ pub enum Auth {
         #[serde(skip, default)]
         response_validator: Option<ResponseValidator>,
     },
-    #[serde(skip)]
-    Custom(HeaderMap),
+    /// Arbitrary headers attached to every request (e.g. multi-tenant routing,
+    /// API keys split across several headers).
+    Custom {
+        headers: HashMap<String, String>,
+    },
 }
 
 impl Auth {
@@ -92,7 +99,7 @@ impl Auth {
     pub fn apply(&self, headers: &mut HeaderMap) -> Result<(), FaucetError> {
         match self {
             Auth::None | Auth::ApiKeyQuery { .. } => Ok(()),
-            Auth::Bearer(token) => bearer::apply(headers, token),
+            Auth::Bearer { token } => bearer::apply(headers, token),
             Auth::Basic { username, password } => basic::apply(headers, username, password),
             Auth::ApiKey { header, value } => api_key::apply(headers, header, value),
             // OAuth2 is resolved to Auth::Bearer by RestStream before apply() is called.
@@ -101,20 +108,17 @@ impl Auth {
             Auth::OAuth2 { .. } => Err(FaucetError::Auth(
                 "OAuth2 auth must be resolved to a bearer token before applying; \
                  use RestStream (which resolves it automatically) or call \
-                 fetch_oauth2_token() and use Auth::Bearer"
+                 fetch_oauth2_token() and construct Auth::Bearer { token } directly"
                     .into(),
             )),
             // TokenEndpoint is resolved to Auth::Bearer by RestStream before apply().
             Auth::TokenEndpoint { .. } => Err(FaucetError::Auth(
                 "TokenEndpoint auth must be resolved to a bearer token before applying; \
                  use RestStream (which resolves it automatically) or call \
-                 fetch_token_from_endpoint() and use Auth::Bearer"
+                 fetch_token_from_endpoint() and construct Auth::Bearer { token } directly"
                     .into(),
             )),
-            Auth::Custom(h) => {
-                custom::apply(headers, h);
-                Ok(())
-            }
+            Auth::Custom { headers: extra } => custom::apply(headers, extra),
         }
     }
 }
@@ -136,7 +140,11 @@ mod tests {
     #[test]
     fn auth_bearer_sets_authorization_header() {
         let mut headers = HeaderMap::new();
-        Auth::Bearer("my-token".into()).apply(&mut headers).unwrap();
+        Auth::Bearer {
+            token: "my-token".into(),
+        }
+        .apply(&mut headers)
+        .unwrap();
         assert_eq!(headers.get("authorization").unwrap(), "Bearer my-token");
     }
 
@@ -212,14 +220,44 @@ mod tests {
 
     #[test]
     fn auth_custom_headers() {
-        let mut custom = HeaderMap::new();
-        custom.insert(
-            reqwest::header::HeaderName::from_static("x-custom"),
-            reqwest::header::HeaderValue::from_static("value"),
-        );
         let mut headers = HeaderMap::new();
-        Auth::Custom(custom).apply(&mut headers).unwrap();
+        let custom = Auth::Custom {
+            headers: [("x-custom".to_string(), "value".to_string())]
+                .into_iter()
+                .collect(),
+        };
+        custom.apply(&mut headers).unwrap();
         assert_eq!(headers.get("x-custom").unwrap(), "value");
+    }
+
+    #[test]
+    fn auth_custom_round_trips_through_json() {
+        let auth = Auth::Custom {
+            headers: [
+                ("x-tenant".to_string(), "acme".to_string()),
+                ("x-region".to_string(), "us".to_string()),
+            ]
+            .into_iter()
+            .collect(),
+        };
+        let json = serde_json::to_value(&auth).unwrap();
+        let restored: Auth = serde_json::from_value(json).unwrap();
+        let mut headers = HeaderMap::new();
+        restored.apply(&mut headers).unwrap();
+        assert_eq!(headers.get("x-tenant").unwrap(), "acme");
+        assert_eq!(headers.get("x-region").unwrap(), "us");
+    }
+
+    #[test]
+    fn auth_bearer_round_trips_through_json() {
+        let auth = Auth::Bearer {
+            token: "tok".into(),
+        };
+        let json = serde_json::to_value(&auth).unwrap();
+        let restored: Auth = serde_json::from_value(json).unwrap();
+        let mut headers = HeaderMap::new();
+        restored.apply(&mut headers).unwrap();
+        assert_eq!(headers.get("authorization").unwrap(), "Bearer tok");
     }
 
     #[test]
@@ -227,14 +265,18 @@ mod tests {
         let auth = Auth::None;
         assert_eq!(format!("{auth:?}"), "None");
 
-        let auth = Auth::Bearer("tok".into());
+        let auth = Auth::Bearer {
+            token: "tok".into(),
+        };
         let debug = format!("{auth:?}");
         assert!(debug.contains("Bearer"));
     }
 
     #[test]
     fn auth_clone() {
-        let auth = Auth::Bearer("token".into());
+        let auth = Auth::Bearer {
+            token: "token".into(),
+        };
         let cloned = auth.clone();
         let mut h = HeaderMap::new();
         cloned.apply(&mut h).unwrap();

--- a/crates/source/rest/src/stream.rs
+++ b/crates/source/rest/src/stream.rs
@@ -392,7 +392,7 @@ impl RestStream {
                         *expiry_ratio,
                     )
                     .await?;
-                Auth::Bearer(token)
+                Auth::Bearer { token }
             }
             Auth::TokenEndpoint {
                 url: token_url,
@@ -418,7 +418,7 @@ impl RestStream {
                         response_validator.as_ref(),
                     )
                     .await?;
-                Auth::Bearer(token)
+                Auth::Bearer { token }
             }
             other => other.clone(),
         };

--- a/crates/source/rest/tests/auth_test.rs
+++ b/crates/source/rest/tests/auth_test.rs
@@ -1,14 +1,16 @@
 use faucet_source_rest::{
     Auth, DEFAULT_EXPIRY_RATIO, DEFAULT_TOKEN_ENDPOINT_EXPIRY_RATIO, RestStream, RestStreamConfig,
 };
-use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+use reqwest::header::HeaderMap;
 
 #[test]
 fn bearer_auth_sets_header() {
     let mut headers = HeaderMap::new();
-    Auth::Bearer("test-token".into())
-        .apply(&mut headers)
-        .unwrap();
+    Auth::Bearer {
+        token: "test-token".into(),
+    }
+    .apply(&mut headers)
+    .unwrap();
     assert_eq!(headers.get("authorization").unwrap(), "Bearer test-token");
 }
 
@@ -59,18 +61,16 @@ fn api_key_query_is_noop_on_headers() {
 
 #[test]
 fn custom_auth_merges_headers() {
-    let mut custom = HeaderMap::new();
-    custom.insert(
-        HeaderName::from_static("x-custom-auth"),
-        HeaderValue::from_static("token-123"),
-    );
-    custom.insert(
-        HeaderName::from_static("x-tenant"),
-        HeaderValue::from_static("acme"),
-    );
-
     let mut headers = HeaderMap::new();
-    Auth::Custom(custom).apply(&mut headers).unwrap();
+    let custom: std::collections::HashMap<String, String> = [
+        ("x-custom-auth".to_string(), "token-123".to_string()),
+        ("x-tenant".to_string(), "acme".to_string()),
+    ]
+    .into_iter()
+    .collect();
+    Auth::Custom { headers: custom }
+        .apply(&mut headers)
+        .unwrap();
     assert_eq!(headers.get("x-custom-auth").unwrap(), "token-123");
     assert_eq!(headers.get("x-tenant").unwrap(), "acme");
 }

--- a/crates/source/rest/tests/stream_test.rs
+++ b/crates/source/rest/tests/stream_test.rs
@@ -259,7 +259,9 @@ async fn test_bearer_auth_sent() {
 
     let stream = RestStream::new(
         RestStreamConfig::new(&server.uri(), "/api/secure")
-            .auth(Auth::Bearer("my-secret-token".into()))
+            .auth(Auth::Bearer {
+                token: "my-secret-token".into(),
+            })
             .records_path("$.data[*]"),
     )
     .unwrap();

--- a/crates/source/xml/README.md
+++ b/crates/source/xml/README.md
@@ -62,9 +62,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 | Variant | Fields | Description |
 |---------|--------|-------------|
 | `None` | -- | No authentication |
-| `Bearer(String)` | token | Bearer token in the `Authorization` header |
+| `Bearer { token }` | `String` | Bearer token in the `Authorization` header |
 | `Basic { username, password }` | `String`, `String` | HTTP Basic authentication |
-| `Custom(HeaderMap)` | headers | Custom headers (e.g. SOAP action headers, API keys). Not serializable |
+| `Custom { headers }` | `HashMap<String, String>` | Custom headers (e.g. SOAP action headers, API keys) attached to every request |
 
 ### Pagination (XmlPagination)
 

--- a/crates/source/xml/src/config.rs
+++ b/crates/source/xml/src/config.rs
@@ -3,6 +3,7 @@
 use reqwest::header::HeaderMap;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 /// Authentication for XML API endpoints.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -11,12 +12,11 @@ pub enum XmlAuth {
     /// No authentication.
     None,
     /// Bearer token.
-    Bearer(String),
+    Bearer { token: String },
     /// Basic authentication.
     Basic { username: String, password: String },
     /// Custom headers (e.g. SOAP action headers, API keys).
-    #[serde(skip)]
-    Custom(HeaderMap),
+    Custom { headers: HashMap<String, String> },
 }
 
 /// Pagination configuration for XML APIs.

--- a/crates/source/xml/src/stream.rs
+++ b/crates/source/xml/src/stream.rs
@@ -170,14 +170,25 @@ impl XmlStream {
         // Apply auth.
         match &self.config.auth {
             XmlAuth::None => {}
-            XmlAuth::Bearer(token) => {
+            XmlAuth::Bearer { token } => {
                 req = req.bearer_auth(token);
             }
             XmlAuth::Basic { username, password } => {
                 req = req.basic_auth(username, Some(password));
             }
-            XmlAuth::Custom(headers) => {
-                req = req.headers(headers.clone());
+            XmlAuth::Custom { headers } => {
+                let mut hm = reqwest::header::HeaderMap::new();
+                for (name, value) in headers {
+                    let n =
+                        reqwest::header::HeaderName::from_bytes(name.as_bytes()).map_err(|e| {
+                            FaucetError::Auth(format!("invalid custom header name {name:?}: {e}"))
+                        })?;
+                    let v = reqwest::header::HeaderValue::from_str(value).map_err(|e| {
+                        FaucetError::Auth(format!("invalid custom header value for {name:?}: {e}"))
+                    })?;
+                    hm.insert(n, v);
+                }
+                req = req.headers(hm);
             }
         }
 

--- a/faucet-stream/README.md
+++ b/faucet-stream/README.md
@@ -92,7 +92,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Configure a source
     let source = RestStream::new(
         RestStreamConfig::new("https://api.example.com", "/v1/users")
-            .auth(Auth::Bearer("my-token".into()))
+            .auth(Auth::Bearer {
+                token: "my-token".into(),
+            })
             .records_path("$.data[*]")
             .pagination(PaginationStyle::Cursor {
                 next_token_path: "$.meta.next_cursor".into(),

--- a/faucet-stream/examples/dag_users_posts.rs
+++ b/faucet-stream/examples/dag_users_posts.rs
@@ -25,7 +25,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let users_source = RestStream::new(
         RestStreamConfig::new("https://api.example.com", "/v1/users")
             .name("users")
-            .auth(Auth::Bearer(std::env::var("API_TOKEN")?))
+            .auth(Auth::Bearer {
+                token: std::env::var("API_TOKEN")?,
+            })
             .header("X-Client", "faucet-stream")
             .query("active", "true")
             .records_path("$.data[*]")
@@ -45,7 +47,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let posts_source = RestStream::new(
         RestStreamConfig::new("https://api.example.com", "/v1/users/{user_id}/posts")
             .name("posts")
-            .auth(Auth::Bearer(std::env::var("API_TOKEN")?))
+            .auth(Auth::Bearer {
+                token: std::env::var("API_TOKEN")?,
+            })
             .records_path("$.data[*]")
             .pagination(PaginationStyle::Cursor {
                 next_token_path: "$.meta.next_cursor".into(),

--- a/faucet-stream/examples/elasticsearch_to_s3.rs
+++ b/faucet-stream/examples/elasticsearch_to_s3.rs
@@ -23,7 +23,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .query(json!({ "match": { "level": "error" } }))
             .scroll_timeout("2m")
             .scroll_size(2000)
-            .auth(ElasticsearchAuth::ApiKey(std::env::var("ES_API_KEY")?))
+            .auth(ElasticsearchAuth::ApiKey {
+                key: std::env::var("ES_API_KEY")?,
+            })
             .max_pages(usize::MAX),
     );
 

--- a/faucet-stream/examples/graphql_to_bigquery.rs
+++ b/faucet-stream/examples/graphql_to_bigquery.rs
@@ -38,7 +38,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let source = GraphqlStream::new(
         GraphqlStreamConfig::new("https://api.example.com/graphql", query)
             .variables(json!({ "first": 200 }))
-            .auth(GraphqlAuth::Custom(headers.clone()))
+            .auth(GraphqlAuth::Custom {
+                headers: [
+                    ("X-Api-Key".to_string(), std::env::var("API_KEY")?),
+                    ("X-Tenant".to_string(), "acme".to_string()),
+                ]
+                .into_iter()
+                .collect(),
+            })
             .headers(headers)
             .records_path("$.data.orders.edges[*].node")
             .pagination(GraphqlPagination {

--- a/faucet-stream/examples/graphql_to_postgres.rs
+++ b/faucet-stream/examples/graphql_to_postgres.rs
@@ -34,7 +34,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let source = GraphqlStream::new(
         GraphqlStreamConfig::new("https://api.example.com/graphql", query)
             .variables(json!({ "first": 100 }))
-            .auth(GraphqlAuth::Bearer(std::env::var("API_TOKEN")?))
+            .auth(GraphqlAuth::Bearer {
+                token: std::env::var("API_TOKEN")?,
+            })
             .headers(headers)
             .records_path("$.data.users.edges[*].node")
             .pagination(GraphqlPagination {

--- a/faucet-stream/examples/grpc_to_elasticsearch.rs
+++ b/faucet-stream/examples/grpc_to_elasticsearch.rs
@@ -13,7 +13,7 @@
 use faucet_stream::sink::elasticsearch::{
     ElasticsearchSink, ElasticsearchSinkAuth, ElasticsearchSinkConfig,
 };
-use faucet_stream::source::grpc::{GrpcAuth, GrpcStream, GrpcStreamConfig};
+use faucet_stream::source::grpc::{GrpcAuth, GrpcStream, GrpcStreamConfig, MetadataEntry};
 use faucet_stream::{Pipeline, json};
 
 #[tokio::main]
@@ -26,10 +26,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             "proto/events.bin",
         )
         .request(json!({ "since": "2026-01-01T00:00:00Z", "page_size": 1000 }))
-        .auth(GrpcAuth::Metadata(vec![
-            ("x-api-key".into(), std::env::var("GRPC_API_KEY")?),
-            ("x-tenant".into(), "acme".into()),
-        ]))
+        .auth(GrpcAuth::Metadata {
+            entries: vec![
+                MetadataEntry {
+                    key: "x-api-key".into(),
+                    value: std::env::var("GRPC_API_KEY")?,
+                },
+                MetadataEntry {
+                    key: "x-tenant".into(),
+                    value: "acme".into(),
+                },
+            ],
+        })
         .tls(true)
         .records_path("$.events[*]"),
     )?;

--- a/faucet-stream/examples/grpc_to_http.rs
+++ b/faucet-stream/examples/grpc_to_http.rs
@@ -33,7 +33,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             "proto/metrics.bin",
         )
         .request(json!({ "window": "1h" }))
-        .auth(GrpcAuth::Bearer(std::env::var("GRPC_TOKEN")?))
+        .auth(GrpcAuth::Bearer {
+            token: std::env::var("GRPC_TOKEN")?,
+        })
         .tls(true)
         .records_path("$.metrics[*]"),
     )?;
@@ -45,7 +47,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let sink = HttpSink::new(
         HttpSinkConfig::new("https://ingest.example.com/v1/events?tenant=acme")
             .method(reqwest::Method::POST)
-            .auth(HttpSinkAuth::Bearer(std::env::var("INGEST_TOKEN")?))
+            .auth(HttpSinkAuth::Bearer {
+                token: std::env::var("INGEST_TOKEN")?,
+            })
             .headers(headers)
             .batch_mode(HttpBatchMode::Array)
             .max_retries(3)

--- a/faucet-stream/examples/postgres_to_elasticsearch.rs
+++ b/faucet-stream/examples/postgres_to_elasticsearch.rs
@@ -30,7 +30,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let sink = ElasticsearchSink::new(
         ElasticsearchSinkConfig::new("https://es.example.com:9200", "articles")
-            .auth(ElasticsearchSinkAuth::ApiKey(std::env::var("ES_API_KEY")?))
+            .auth(ElasticsearchSinkAuth::ApiKey {
+                key: std::env::var("ES_API_KEY")?,
+            })
             .batch_size(500)
             .id_field("id"),
     );

--- a/faucet-stream/examples/rest_to_jsonl.rs
+++ b/faucet-stream/examples/rest_to_jsonl.rs
@@ -24,7 +24,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         RestStreamConfig::new("https://api.example.com", "/v1/orders")
             .name("orders")
             .method(reqwest::Method::GET)
-            .auth(Auth::Bearer(std::env::var("API_TOKEN")?))
+            .auth(Auth::Bearer {
+                token: std::env::var("API_TOKEN")?,
+            })
             .header("X-Client", "faucet-stream")
             .query("status", "completed")
             .records_path("$.data[*]")

--- a/faucet-stream/examples/webhook_to_http.rs
+++ b/faucet-stream/examples/webhook_to_http.rs
@@ -31,7 +31,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let sink = HttpSink::new(
         HttpSinkConfig::new("https://downstream.example.com/ingest")
             .method(reqwest::Method::POST)
-            .auth(HttpSinkAuth::Bearer(std::env::var("INGEST_TOKEN")?))
+            .auth(HttpSinkAuth::Bearer {
+                token: std::env::var("INGEST_TOKEN")?,
+            })
             .headers(headers)
             .batch_mode(HttpBatchMode::Individual)
             .max_retries(3)

--- a/faucet-stream/examples/xml_to_mongodb.rs
+++ b/faucet-stream/examples/xml_to_mongodb.rs
@@ -22,7 +22,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let source = XmlStream::new(
         XmlStreamConfig::new("https://feeds.example.com", "/catalog")
             .method(reqwest::Method::GET)
-            .auth(XmlAuth::Bearer(std::env::var("FEED_TOKEN")?))
+            .auth(XmlAuth::Bearer {
+                token: std::env::var("FEED_TOKEN")?,
+            })
             .headers(headers)
             .query_param("format", "xml")
             .records_element_path("catalog.products.product")


### PR DESCRIPTION
## Summary

Internally-tagged enums (`#[serde(tag = "type")]`) can't round-trip newtype variants through serde, so the CLI YAML/JSON layer couldn't express the most common auth mode (Bearer) for the REST, GraphQL, XML, gRPC, Elasticsearch (source + sink), and HTTP sink connectors. Custom-header auth was `#[serde(skip)]` and unavailable from YAML entirely, and gRPC `Metadata(Vec<(String, String)>)` was a newtype that also failed to round-trip.

This rewrites every affected variant to a struct form that round-trips through both `serde_json` and `serde_yaml`:

- `Bearer(String)` → `Bearer { token }`
- `Custom(HeaderMap)` (skipped) → `Custom { headers: HashMap<String, String> }`
- `Metadata(Vec<(K,V)>)` (gRPC) → `Metadata { entries: Vec<MetadataEntry { key, value }> }` — `Vec` preserves order and allows duplicate keys, both of which gRPC permits
- Elasticsearch source + sink: drops the `content = "value"` envelope and promotes `Bearer(String)` / `ApiKey(String)` to struct variants too, so their YAML shape matches every other connector

The YAML examples that previously documented "Bearer not expressible" or fell back to `ApiKey { header: Authorization, value: Bearer ${env:…} }` now use the natural `type: Bearer` shape. `graphql_to_bigquery`, `grpc_to_elasticsearch`, `grpc_to_http`, `webhook_to_http`, and `xml_to_mongodb` are now 1:1 with their `.rs` counterparts.

This is a breaking change with no backwards-compat shim. Rust callers update:

```rust
// before
.auth(Auth::Bearer("tok".into()))

// after
.auth(Auth::Bearer { token: "tok".into() })
```

YAML callers update:

```yaml
# before (REST)
auth:
  type: ApiKey
  header: Authorization
  value: Bearer ${env:TOKEN}

# after
auth:
  type: Bearer
  token: ${env:TOKEN}
```

```yaml
# before (Elasticsearch)
auth:
  type: Basic
  value:
    username: ${env:ES_USER}
    password: ${env:ES_PASS}

# after
auth:
  type: Basic
  username: ${env:ES_USER}
  password: ${env:ES_PASS}
```

Closes #40

## Test plan

- [x] `cargo build --workspace --all-features --examples` (clean)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` (clean)
- [x] `cargo test --workspace --all-features` (Docker-gated Kafka + postgres-cdc integration tests excluded; unit + non-Docker integration tests pass)
- [x] `faucet validate cli/examples/*.yaml` — all examples parse with the new shape
- [x] Round-trip tests for `Auth::Bearer` and `Auth::Custom` via serde_json added to `crates/source/rest/src/auth/mod.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)