### PR TITLE
feat: faucet-elasticsearch-common shared auth crate (closes #43)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,3 +232,5 @@ jobs:
         run: cargo test -p faucet-sink-kafka --test integration -- --test-threads=1
       - name: Run kafka schema-registry-enabled tests
         run: cargo test -p faucet-kafka-common --all-features
+      - name: Run elasticsearch-common tests
+        run: cargo test -p faucet-elasticsearch-common

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,7 @@ jobs:
           all_crates=(
             faucet-core
             faucet-kafka-common
+            faucet-elasticsearch-common
             faucet-source-rest faucet-source-graphql faucet-source-xml
             faucet-source-grpc faucet-source-postgres faucet-source-postgres-cdc
             faucet-source-mysql
@@ -110,6 +111,7 @@ jobs:
           )
           connectors=(
             faucet-kafka-common
+            faucet-elasticsearch-common
             faucet-source-rest faucet-source-graphql faucet-source-xml
             faucet-source-grpc faucet-source-postgres faucet-source-postgres-cdc
             faucet-source-mysql
@@ -158,6 +160,7 @@ jobs:
           all_crates=(
             faucet-core
             faucet-kafka-common
+            faucet-elasticsearch-common
             faucet-source-rest faucet-source-graphql faucet-source-xml
             faucet-source-grpc faucet-source-postgres faucet-source-postgres-cdc
             faucet-source-mysql
@@ -173,6 +176,7 @@ jobs:
           )
           connectors=(
             faucet-kafka-common
+            faucet-elasticsearch-common
             faucet-source-rest faucet-source-graphql faucet-source-xml
             faucet-source-grpc faucet-source-postgres faucet-source-postgres-cdc
             faucet-source-mysql

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,8 +52,9 @@ Cargo workspace, 35 crates (34 libraries + the `faucet-cli` binary). All connect
 | `faucet-sink-stdout` | `crates/sink/stdout/` | Stdout/stderr sink — JSON Lines, pretty JSON, or TSV |
 | `faucet-sink-parquet` | `crates/sink/parquet/` | Parquet sink — local or S3; schema inference, compression, row/byte rollover |
 | `faucet-sink-kafka` | `crates/sink/kafka/` | Kafka producer — FuturesUnordered batched sends, QueueFull retry, multi-topic routing |
-| `faucet-kafka-common` | `crates/kafka-common/` | Shared types for Kafka source/sink — auth, value formats, Schema Registry client |
+| `faucet-elasticsearch-common` | `crates/elasticsearch-common/` | Shared `ElasticsearchAuth` enum for Elasticsearch source/sink |
 | `faucet-gcs-common` | `crates/gcs-common/` | Shared types for GCS source/sink — credentials enum, Storage/StorageControl client builders |
+| `faucet-kafka-common` | `crates/kafka-common/` | Shared types for Kafka source/sink — auth, value formats, Schema Registry client |
 | `faucet-state-redis` | `crates/state/redis/` | Redis-backed `StateStore` for replication bookmarks |
 | `faucet-state-postgres` | `crates/state/postgres/` | PostgreSQL-backed `StateStore` for replication bookmarks |
 | `faucet-stream` | `faucet-stream/` | Umbrella crate — feature-gated re-exports of all connectors and state backends |
@@ -342,7 +343,7 @@ When the user points out something fundamental about how code in this library sh
 
 When a connector ships both a `faucet-source-<name>` and a `faucet-sink-<name>` crate for the same external system, shared configuration types (auth, value formats, compression, TLS, etc.) live in a dedicated `faucet-<name>-common` crate. Both the source and sink crates depend on the common crate and re-export the shared types so end-user imports do not change. See `faucet-kafka-common` for the reference implementation.
 
-Existing pairs (`postgres`, `mysql`, `sqlite`, `redis`, `mongodb`, `s3`, `csv`, `elasticsearch`) predate this convention and currently duplicate their tiny shared config surface; backfilling them is tracked separately (#43). New pairs must follow the convention from the start.
+Existing pairs that predate this convention (`postgres`, `mysql`, `sqlite`, `redis`, `mongodb`, `s3`, `csv`) duplicate a tiny shared surface — typically just `connection_url` / `batch_size` / `max_connections`. The Elasticsearch pair tripped the backfill trigger in 2026-05 (a duplicated 4-variant auth enum) and was migrated to `faucet-elasticsearch-common`. The remaining seven pairs stay duplicated for now: backfill an existing pair only once it gains a second shared type (e.g. TLS settings, a credential enum, a compression enum), since the cost of a near-empty `-common` crate exceeds the benefit until then. New pairs must follow the convention from the start.
 
 ### Config loading
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "3"
 members = [
     "crates/core",
+    "crates/elasticsearch-common",
     "crates/gcs-common",
     "crates/kafka-common",
     "crates/source/rest",
@@ -54,6 +55,7 @@ repository = "https://github.com/PawanSikawat/faucet-stream"
 [workspace.dependencies]
 # Internal crates
 faucet-core = { path = "crates/core", version = "0.2.0" }
+faucet-elasticsearch-common = { path = "crates/elasticsearch-common", version = "0.1.0" }
 faucet-gcs-common = { path = "crates/gcs-common", version = "0.2.0" }
 faucet-kafka-common = { path = "crates/kafka-common", version = "0.2.0" }
 faucet-source-rest = { path = "crates/source/rest", version = "0.2.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ faucet-source-redis = { path = "crates/source/redis", version = "0.2.0" }
 faucet-source-webhook = { path = "crates/source/webhook", version = "0.2.0" }
 faucet-source-sqlite = { path = "crates/source/sqlite", version = "0.2.0" }
 faucet-source-csv = { path = "crates/source/csv", version = "0.2.0" }
-faucet-source-elasticsearch = { path = "crates/source/elasticsearch", version = "0.2.0" }
+faucet-source-elasticsearch = { path = "crates/source/elasticsearch", version = "0.3.0" }
 faucet-source-parquet = { path = "crates/source/parquet", version = "0.2.0" }
 faucet-sink-mysql = { path = "crates/sink/mysql", version = "0.2.0" }
 faucet-sink-sqlite = { path = "crates/sink/sqlite", version = "0.2.0" }
@@ -88,7 +88,7 @@ faucet-sink-s3 = { path = "crates/sink/s3", version = "0.2.0" }
 faucet-sink-mongodb = { path = "crates/sink/mongodb", version = "0.2.0" }
 faucet-sink-redis = { path = "crates/sink/redis", version = "0.2.0" }
 faucet-sink-csv = { path = "crates/sink/csv", version = "0.2.0" }
-faucet-sink-elasticsearch = { path = "crates/sink/elasticsearch", version = "0.2.0" }
+faucet-sink-elasticsearch = { path = "crates/sink/elasticsearch", version = "0.3.0" }
 faucet-sink-http = { path = "crates/sink/http", version = "0.2.0" }
 faucet-sink-kafka = { path = "crates/sink/kafka", version = "0.2.0" }
 faucet-sink-stdout = { path = "crates/sink/stdout", version = "0.2.0" }

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ faucet-stream is a Cargo workspace with 35 crates — 15 sources, 14 sinks, 1 sh
 | [`faucet-sink-kafka`](crates/sink/kafka) | Apache Kafka — producer with FuturesUnordered batching, multi-topic routing |
 | [`faucet-sink-parquet`](crates/sink/parquet) | Apache Parquet — local file or S3; schema inference, compression, row/byte rollover |
 | **Shared libraries** | |
+| [`faucet-elasticsearch-common`](crates/elasticsearch-common) | Shared `ElasticsearchAuth` enum for Elasticsearch source/sink |
 | [`faucet-kafka-common`](crates/kafka-common) | Shared Kafka types — auth, value formats, Schema Registry client |
 | **State stores** | |
 | [`faucet-state-redis`](crates/state/redis) | Redis-backed `StateStore` for persistent bookmarks |
@@ -959,6 +960,7 @@ crates/
     stdout/                   — Stdout / stderr (JSON Lines, pretty JSON, TSV)
     kafka/                    — Apache Kafka producer
     parquet/                  — Apache Parquet writer (local, S3)
+  elasticsearch-common/       — faucet-elasticsearch-common: shared ElasticsearchAuth enum
   kafka-common/               — faucet-kafka-common: shared Kafka auth, formats, Schema Registry
   state/
     redis/                    — Redis-backed StateStore

--- a/crates/core/src/observability/decorator.rs
+++ b/crates/core/src/observability/decorator.rs
@@ -625,18 +625,32 @@ mod sink_tests {
             .unwrap();
 
         // faucet_sink_records_total should reflect 2 (Ok count), not 3.
+        // Filter to this test's own labels (connector="mixed") — prior tests in
+        // the same `mod sink_tests` (e.g. records_writes_and_records_counters
+        // for connector="mock-sink") leave entries in the shared global
+        // recorder, and the HashMap-iteration order of `Snapshot::into_vec()`
+        // is non-deterministic, so a naïve `find_map` returns an arbitrary
+        // entry.
         let snapshot = snap.snapshot();
-        let v = snapshot
+        let records: u64 = snapshot
             .into_vec()
             .into_iter()
-            .find_map(|(k, _u, _d, v): (metrics_util::CompositeKey, _, _, _)| {
-                if k.key().name() == "faucet_sink_records_total" {
-                    Some(v)
+            .filter_map(|(k, _u, _d, v): (metrics_util::CompositeKey, _, _, _)| {
+                if k.key().name() == "faucet_sink_records_total"
+                    && k.key()
+                        .labels()
+                        .any(|l| l.key() == "connector" && l.value() == "mixed")
+                    && let DebugValue::Counter(c) = v
+                {
+                    Some(c)
                 } else {
                     None
                 }
             })
-            .expect("records_total recorded");
-        assert!(matches!(v, DebugValue::Counter(c) if c >= 2));
+            .sum();
+        assert!(
+            records >= 2,
+            "expected faucet_sink_records_total{{connector=mixed}} >= 2, got {records}"
+        );
     }
 }

--- a/crates/elasticsearch-common/Cargo.toml
+++ b/crates/elasticsearch-common/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "faucet-elasticsearch-common"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Shared configuration types for the faucet-stream Elasticsearch source and sink connectors"
+
+[dependencies]
+serde = { workspace = true, features = ["derive"] }
+schemars.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true

--- a/crates/elasticsearch-common/README.md
+++ b/crates/elasticsearch-common/README.md
@@ -1,0 +1,20 @@
+# faucet-elasticsearch-common
+
+Shared configuration types for the Elasticsearch source and sink connectors in the [`faucet-stream`](https://crates.io/crates/faucet-stream) ecosystem.
+
+## Types
+
+- `ElasticsearchAuth` — authentication mode: `None`, `Basic`, `Bearer`, or `ApiKey`. Derives `Serialize`, `Deserialize`, `JsonSchema`. Its `Debug` impl masks credentials as `"***"`.
+
+## Usage
+
+Most users do not depend on this crate directly. It is re-exported by:
+
+- [`faucet-source-elasticsearch`](https://crates.io/crates/faucet-source-elasticsearch)
+- [`faucet-sink-elasticsearch`](https://crates.io/crates/faucet-sink-elasticsearch)
+
+Depend on this crate directly only if you are building a third-party connector that needs to accept the same auth shape in its config.
+
+## License
+
+MIT OR Apache-2.0

--- a/crates/elasticsearch-common/src/lib.rs
+++ b/crates/elasticsearch-common/src/lib.rs
@@ -1,0 +1,102 @@
+//! # faucet-elasticsearch-common
+//!
+//! Shared configuration types for the [`faucet-stream`](https://crates.io/crates/faucet-stream)
+//! Elasticsearch source and sink connectors.
+//!
+//! - [`ElasticsearchAuth`] — authentication modes (None, Basic, Bearer, ApiKey)
+//!
+//! The enum derives `Serialize`, `Deserialize`, and `JsonSchema` so it round-trips
+//! through YAML/JSON configs and CLI introspection. Its `Debug` impl masks
+//! credentials (`password`, `token`, `key`) as `"***"` so accidental logging of a
+//! config value never leaks secrets.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Authentication method for Elasticsearch.
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "type")]
+pub enum ElasticsearchAuth {
+    /// No authentication.
+    None,
+    /// HTTP Basic authentication.
+    Basic { username: String, password: String },
+    /// Bearer token authentication.
+    Bearer { token: String },
+    /// API key authentication (sent as `ApiKey` in the `Authorization` header).
+    ApiKey { key: String },
+}
+
+impl std::fmt::Debug for ElasticsearchAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "None"),
+            Self::Basic { username, .. } => f
+                .debug_struct("Basic")
+                .field("username", username)
+                .field("password", &"***")
+                .finish(),
+            Self::Bearer { .. } => write!(f, "Bearer(***)"),
+            Self::ApiKey { .. } => write!(f, "ApiKey(***)"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn debug_masks_basic_password() {
+        let auth = ElasticsearchAuth::Basic {
+            username: "user".into(),
+            password: "secret".into(),
+        };
+        let debug = format!("{auth:?}");
+        assert!(debug.contains("user"));
+        assert!(debug.contains("***"));
+        assert!(!debug.contains("secret"));
+    }
+
+    #[test]
+    fn debug_masks_bearer_token() {
+        let auth = ElasticsearchAuth::Bearer { token: "my-token".into() };
+        let debug = format!("{auth:?}");
+        assert!(debug.contains("***"));
+        assert!(!debug.contains("my-token"));
+    }
+
+    #[test]
+    fn debug_masks_api_key() {
+        let auth = ElasticsearchAuth::ApiKey { key: "my-key".into() };
+        let debug = format!("{auth:?}");
+        assert!(debug.contains("***"));
+        assert!(!debug.contains("my-key"));
+    }
+
+    #[test]
+    fn debug_none_renders_unit() {
+        let auth = ElasticsearchAuth::None;
+        assert_eq!(format!("{auth:?}"), "None");
+    }
+
+    #[test]
+    fn serde_round_trip_basic() {
+        let auth = ElasticsearchAuth::Basic {
+            username: "u".into(),
+            password: "p".into(),
+        };
+        let json = serde_json::to_string(&auth).unwrap();
+        assert_eq!(json, r#"{"type":"Basic","username":"u","password":"p"}"#);
+        let parsed: ElasticsearchAuth = serde_json::from_str(&json).unwrap();
+        assert!(matches!(parsed, ElasticsearchAuth::Basic { .. }));
+    }
+
+    #[test]
+    fn serde_round_trip_none() {
+        let json = serde_json::to_string(&ElasticsearchAuth::None).unwrap();
+        assert_eq!(json, r#"{"type":"None"}"#);
+        let parsed: ElasticsearchAuth = serde_json::from_str(&json).unwrap();
+        assert!(matches!(parsed, ElasticsearchAuth::None));
+    }
+}

--- a/crates/elasticsearch-common/src/lib.rs
+++ b/crates/elasticsearch-common/src/lib.rs
@@ -67,7 +67,9 @@ mod tests {
 
     #[test]
     fn debug_masks_bearer_token() {
-        let auth = ElasticsearchAuth::Bearer { token: "my-token".into() };
+        let auth = ElasticsearchAuth::Bearer {
+            token: "my-token".into(),
+        };
         let debug = format!("{auth:?}");
         assert!(debug.contains("***"));
         assert!(!debug.contains("my-token"));
@@ -75,7 +77,9 @@ mod tests {
 
     #[test]
     fn debug_masks_api_key() {
-        let auth = ElasticsearchAuth::ApiKey { key: "my-key".into() };
+        let auth = ElasticsearchAuth::ApiKey {
+            key: "my-key".into(),
+        };
         let debug = format!("{auth:?}");
         assert!(debug.contains("***"));
         assert!(!debug.contains("my-key"));

--- a/crates/elasticsearch-common/src/lib.rs
+++ b/crates/elasticsearch-common/src/lib.rs
@@ -14,6 +14,13 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// Authentication method for Elasticsearch.
+///
+/// **Wire-format note:** the `#[serde(tag = "type")]` discriminator uses
+/// PascalCase variant names (`"None"`, `"Basic"`, `"Bearer"`, `"ApiKey"`)
+/// for byte-compatibility with existing YAML configs that predate the
+/// extraction of this crate from `faucet-source-elasticsearch` and
+/// `faucet-sink-elasticsearch`. Do not add `#[serde(rename_all = "snake_case")]`
+/// here — it would silently break those configs.
 #[derive(Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "type")]
 pub enum ElasticsearchAuth {
@@ -98,5 +105,23 @@ mod tests {
         assert_eq!(json, r#"{"type":"None"}"#);
         let parsed: ElasticsearchAuth = serde_json::from_str(&json).unwrap();
         assert!(matches!(parsed, ElasticsearchAuth::None));
+    }
+
+    #[test]
+    fn serde_round_trip_bearer() {
+        let auth = ElasticsearchAuth::Bearer { token: "t".into() };
+        let json = serde_json::to_string(&auth).unwrap();
+        assert_eq!(json, r#"{"type":"Bearer","token":"t"}"#);
+        let parsed: ElasticsearchAuth = serde_json::from_str(&json).unwrap();
+        assert!(matches!(parsed, ElasticsearchAuth::Bearer { .. }));
+    }
+
+    #[test]
+    fn serde_round_trip_api_key() {
+        let auth = ElasticsearchAuth::ApiKey { key: "k".into() };
+        let json = serde_json::to_string(&auth).unwrap();
+        assert_eq!(json, r#"{"type":"ApiKey","key":"k"}"#);
+        let parsed: ElasticsearchAuth = serde_json::from_str(&json).unwrap();
+        assert!(matches!(parsed, ElasticsearchAuth::ApiKey { .. }));
     }
 }

--- a/crates/sink/elasticsearch/Cargo.toml
+++ b/crates/sink/elasticsearch/Cargo.toml
@@ -9,6 +9,7 @@ description = "Elasticsearch sink connector for the faucet-stream ecosystem"
 
 [dependencies]
 faucet-core.workspace = true
+faucet-elasticsearch-common.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/sink/elasticsearch/Cargo.toml
+++ b/crates/sink/elasticsearch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "faucet-sink-elasticsearch"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/sink/elasticsearch/README.md
+++ b/crates/sink/elasticsearch/README.md
@@ -58,7 +58,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 |-------|------|---------|-------------|
 | `base_url` | `String` | *(required)* | Base URL of the Elasticsearch cluster (e.g. `"http://localhost:9200"`). Trailing slashes are stripped automatically. |
 | `index` | `String` | *(required)* | Target index name |
-| `auth` | `ElasticsearchSinkAuth` | `None` | Authentication method (see below) |
+| `auth` | `ElasticsearchAuth` | `None` | Authentication method (see below) |
 | `batch_size` | `usize` | `1000` | Maximum documents per `_bulk` request. See [Streaming and batching](#streaming-and-batching) below |
 | `id_field` | `Option<String>` | `None` | JSON field name to use as the document `_id`. If `None`, Elasticsearch auto-generates IDs. |
 
@@ -98,7 +98,7 @@ size.
 inspection of the `_bulk` response and the "first item that failed"
 error message are unchanged.
 
-### Authentication (`ElasticsearchSinkAuth`)
+### Authentication (`ElasticsearchAuth`)
 
 | Variant | Fields | Description |
 |---------|--------|-------------|
@@ -120,10 +120,10 @@ When `id_field` is set, the sink extracts the document `_id` from each record:
 ### Builder Methods
 
 ```rust
-use faucet_sink_elasticsearch::{ElasticsearchSinkConfig, ElasticsearchSinkAuth};
+use faucet_sink_elasticsearch::{ElasticsearchSinkConfig, ElasticsearchAuth};
 
 let config = ElasticsearchSinkConfig::new("http://localhost:9200", "events")
-    .auth(ElasticsearchSinkAuth::Basic {
+    .auth(ElasticsearchAuth::Basic {
         username: "elastic".into(),
         password: "changeme".into(),
     })
@@ -268,7 +268,7 @@ let config = ElasticsearchSinkConfig::new(
     "https://my-deployment.es.us-east-1.aws.found.io:9243",
     "application-events",
 )
-.auth(ElasticsearchSinkAuth::ApiKey {
+.auth(ElasticsearchAuth::ApiKey {
     key: std::env::var("ES_API_KEY")?,
 })
 .with_batch_size(2000);
@@ -298,6 +298,12 @@ failures from Elasticsearch's `_bulk` response items. Configure a DLQ
 at the pipeline level (see [cli/README.md — dlq:](../../../cli/README.md))
 and only the documents Elasticsearch actually rejected will be routed
 there — already-indexed items stay in the main sink with no duplicates.
+
+## Shared types
+
+`ElasticsearchAuth` lives in [`faucet-elasticsearch-common`](../../elasticsearch-common) and is shared with `faucet-source-elasticsearch`. The sink re-exports it as `faucet_sink_elasticsearch::ElasticsearchAuth`.
+
+> **Deprecation:** the previous name `ElasticsearchSinkAuth` is retained as a deprecated type alias in `0.3.x` and removed in `0.4.0`. Migrate imports to `ElasticsearchAuth` at your convenience.
 
 ## License
 

--- a/crates/sink/elasticsearch/src/config.rs
+++ b/crates/sink/elasticsearch/src/config.rs
@@ -4,34 +4,12 @@ use faucet_core::DEFAULT_BATCH_SIZE;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-/// Authentication method for the Elasticsearch sink.
-#[derive(Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(tag = "type")]
-pub enum ElasticsearchSinkAuth {
-    /// No authentication.
-    None,
-    /// HTTP Basic authentication.
-    Basic { username: String, password: String },
-    /// Bearer token authentication.
-    Bearer { token: String },
-    /// API key authentication (sent as `ApiKey` in the `Authorization` header).
-    ApiKey { key: String },
-}
+pub use faucet_elasticsearch_common::ElasticsearchAuth;
 
-impl std::fmt::Debug for ElasticsearchSinkAuth {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::None => write!(f, "None"),
-            Self::Basic { username, .. } => f
-                .debug_struct("Basic")
-                .field("username", username)
-                .field("password", &"***")
-                .finish(),
-            Self::Bearer { .. } => write!(f, "Bearer(***)"),
-            Self::ApiKey { .. } => write!(f, "ApiKey(***)"),
-        }
-    }
-}
+/// Deprecated alias retained for one minor release. Removed in `0.4.0`.
+#[allow(deprecated)]
+#[deprecated(since = "0.3.0", note = "renamed to `ElasticsearchAuth`")]
+pub type ElasticsearchSinkAuth = ElasticsearchAuth;
 
 /// Configuration for the Elasticsearch bulk index sink.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -41,7 +19,7 @@ pub struct ElasticsearchSinkConfig {
     /// Target index name.
     pub index: String,
     /// Authentication method.
-    pub auth: ElasticsearchSinkAuth,
+    pub auth: ElasticsearchAuth,
     /// Maximum documents per `_bulk` HTTP request. Defaults to
     /// [`DEFAULT_BATCH_SIZE`].
     ///
@@ -76,14 +54,14 @@ impl ElasticsearchSinkConfig {
         Self {
             base_url: base_url.into().trim_end_matches('/').to_string(),
             index: index.into(),
-            auth: ElasticsearchSinkAuth::None,
+            auth: ElasticsearchAuth::None,
             batch_size: DEFAULT_BATCH_SIZE,
             id_field: None,
         }
     }
 
     /// Set the authentication method.
-    pub fn auth(mut self, a: ElasticsearchSinkAuth) -> Self {
+    pub fn auth(mut self, a: ElasticsearchAuth) -> Self {
         self.auth = a;
         self
     }
@@ -125,41 +103,12 @@ mod tests {
         let config = ElasticsearchSinkConfig::new("http://es:9200/", "idx")
             .with_batch_size(100)
             .id_field("doc_id")
-            .auth(ElasticsearchSinkAuth::Bearer {
+            .auth(ElasticsearchAuth::Bearer {
                 token: "tok".into(),
             });
         assert_eq!(config.base_url, "http://es:9200");
         assert_eq!(config.batch_size, 100);
         assert_eq!(config.id_field.as_deref(), Some("doc_id"));
-    }
-
-    #[test]
-    fn auth_debug_masks_credentials() {
-        let none = ElasticsearchSinkAuth::None;
-        assert_eq!(format!("{none:?}"), "None");
-
-        let basic = ElasticsearchSinkAuth::Basic {
-            username: "user".into(),
-            password: "secret".into(),
-        };
-        let debug = format!("{basic:?}");
-        assert!(debug.contains("user"));
-        assert!(debug.contains("***"));
-        assert!(!debug.contains("secret"));
-
-        let bearer = ElasticsearchSinkAuth::Bearer {
-            token: "my-token".into(),
-        };
-        let debug = format!("{bearer:?}");
-        assert!(debug.contains("***"));
-        assert!(!debug.contains("my-token"));
-
-        let api_key = ElasticsearchSinkAuth::ApiKey {
-            key: "my-key".into(),
-        };
-        let debug = format!("{api_key:?}");
-        assert!(debug.contains("***"));
-        assert!(!debug.contains("my-key"));
     }
 
     #[test]
@@ -213,5 +162,14 @@ mod tests {
         }"#;
         let config: ElasticsearchSinkConfig = serde_json::from_str(json).unwrap();
         assert_eq!(config.batch_size, faucet_core::DEFAULT_BATCH_SIZE);
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn deprecated_sink_auth_alias_is_canonical_type() {
+        // Compile-time check: assignment proves the alias resolves to the
+        // canonical `ElasticsearchAuth` type. Removed in 0.4.0 together with
+        // the alias itself.
+        let _: ElasticsearchSinkAuth = ElasticsearchAuth::None;
     }
 }

--- a/crates/sink/elasticsearch/src/config.rs
+++ b/crates/sink/elasticsearch/src/config.rs
@@ -7,7 +7,6 @@ use serde::{Deserialize, Serialize};
 pub use faucet_elasticsearch_common::ElasticsearchAuth;
 
 /// Deprecated alias retained for one minor release. Removed in `0.4.0`.
-#[allow(deprecated)]
 #[deprecated(since = "0.3.0", note = "renamed to `ElasticsearchAuth`")]
 pub type ElasticsearchSinkAuth = ElasticsearchAuth;
 

--- a/crates/sink/elasticsearch/src/lib.rs
+++ b/crates/sink/elasticsearch/src/lib.rs
@@ -9,5 +9,7 @@ pub mod sink;
 
 pub use faucet_core::{FaucetError, Sink};
 
-pub use config::{ElasticsearchSinkAuth, ElasticsearchSinkConfig};
+#[allow(deprecated)]
+pub use config::ElasticsearchSinkAuth;
+pub use config::{ElasticsearchAuth, ElasticsearchSinkConfig};
 pub use sink::ElasticsearchSink;

--- a/crates/sink/elasticsearch/src/sink.rs
+++ b/crates/sink/elasticsearch/src/sink.rs
@@ -1,6 +1,6 @@
 //! Elasticsearch bulk index sink.
 
-use crate::config::{ElasticsearchSinkAuth, ElasticsearchSinkConfig};
+use crate::config::{ElasticsearchAuth, ElasticsearchSinkConfig};
 use async_trait::async_trait;
 use faucet_core::FaucetError;
 use faucet_core::util::{DEFAULT_ERROR_BODY_MAX_LEN, check_http_response};
@@ -25,12 +25,12 @@ impl ElasticsearchSink {
     /// Apply the configured authentication to a request builder.
     fn apply_auth(&self, req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
         match &self.config.auth {
-            ElasticsearchSinkAuth::None => req,
-            ElasticsearchSinkAuth::Basic { username, password } => {
+            ElasticsearchAuth::None => req,
+            ElasticsearchAuth::Basic { username, password } => {
                 req.basic_auth(username, Some(password))
             }
-            ElasticsearchSinkAuth::Bearer { token } => req.bearer_auth(token),
-            ElasticsearchSinkAuth::ApiKey { key } => {
+            ElasticsearchAuth::Bearer { token } => req.bearer_auth(token),
+            ElasticsearchAuth::ApiKey { key } => {
                 req.header("Authorization", format!("ApiKey {key}"))
             }
         }

--- a/crates/source/elasticsearch/Cargo.toml
+++ b/crates/source/elasticsearch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "faucet-source-elasticsearch"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/source/elasticsearch/Cargo.toml
+++ b/crates/source/elasticsearch/Cargo.toml
@@ -9,6 +9,7 @@ description = "Elasticsearch source connector for the faucet-stream ecosystem"
 
 [dependencies]
 faucet-core.workspace = true
+faucet-elasticsearch-common.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/source/elasticsearch/README.md
+++ b/crates/source/elasticsearch/README.md
@@ -215,6 +215,10 @@ let source = ElasticsearchSource::new(config);
 let metrics = source.fetch_all().await?;
 ```
 
+## Shared types
+
+`ElasticsearchAuth` lives in [`faucet-elasticsearch-common`](../../elasticsearch-common) and is shared with `faucet-sink-elasticsearch`. The source re-exports it for convenience, so `faucet_source_elasticsearch::ElasticsearchAuth` continues to work unchanged.
+
 ## License
 
 Licensed under MIT or Apache-2.0.

--- a/crates/source/elasticsearch/src/config.rs
+++ b/crates/source/elasticsearch/src/config.rs
@@ -5,34 +5,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
-/// Authentication method for Elasticsearch.
-#[derive(Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(tag = "type")]
-pub enum ElasticsearchAuth {
-    /// No authentication.
-    None,
-    /// HTTP Basic authentication.
-    Basic { username: String, password: String },
-    /// Bearer token authentication.
-    Bearer { token: String },
-    /// API key authentication (sent as `ApiKey` in the `Authorization` header).
-    ApiKey { key: String },
-}
-
-impl std::fmt::Debug for ElasticsearchAuth {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::None => write!(f, "None"),
-            Self::Basic { username, .. } => f
-                .debug_struct("Basic")
-                .field("username", username)
-                .field("password", &"***")
-                .finish(),
-            Self::Bearer { .. } => write!(f, "Bearer(***)"),
-            Self::ApiKey { .. } => write!(f, "ApiKey(***)"),
-        }
-    }
-}
+pub use faucet_elasticsearch_common::ElasticsearchAuth;
 
 /// Configuration for the Elasticsearch search source.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -146,35 +119,6 @@ mod tests {
         assert_eq!(config.base_url, "http://es:9200");
         assert_eq!(config.scroll_timeout, "5m");
         assert_eq!(config.max_pages, Some(10));
-    }
-
-    #[test]
-    fn auth_debug_masks_credentials() {
-        let none = ElasticsearchAuth::None;
-        assert_eq!(format!("{none:?}"), "None");
-
-        let basic = ElasticsearchAuth::Basic {
-            username: "user".into(),
-            password: "secret".into(),
-        };
-        let debug = format!("{basic:?}");
-        assert!(debug.contains("user"));
-        assert!(debug.contains("***"));
-        assert!(!debug.contains("secret"));
-
-        let bearer = ElasticsearchAuth::Bearer {
-            token: "my-token".into(),
-        };
-        let debug = format!("{bearer:?}");
-        assert!(debug.contains("***"));
-        assert!(!debug.contains("my-token"));
-
-        let api_key = ElasticsearchAuth::ApiKey {
-            key: "my-key".into(),
-        };
-        let debug = format!("{api_key:?}");
-        assert!(debug.contains("***"));
-        assert!(!debug.contains("my-key"));
     }
 
     #[test]

--- a/faucet-stream/examples/grpc_to_elasticsearch.rs
+++ b/faucet-stream/examples/grpc_to_elasticsearch.rs
@@ -11,7 +11,7 @@
 //! ```
 
 use faucet_stream::sink::elasticsearch::{
-    ElasticsearchSink, ElasticsearchSinkAuth, ElasticsearchSinkConfig,
+    ElasticsearchAuth, ElasticsearchSink, ElasticsearchSinkConfig,
 };
 use faucet_stream::source::grpc::{GrpcAuth, GrpcStream, GrpcStreamConfig, MetadataEntry};
 use faucet_stream::{Pipeline, json};
@@ -44,7 +44,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let sink = ElasticsearchSink::new(
         ElasticsearchSinkConfig::new("https://es.example.com:9200", "events")
-            .auth(ElasticsearchSinkAuth::Basic {
+            .auth(ElasticsearchAuth::Basic {
                 username: std::env::var("ES_USER")?,
                 password: std::env::var("ES_PASS")?,
             })

--- a/faucet-stream/examples/mongodb_to_elasticsearch.rs
+++ b/faucet-stream/examples/mongodb_to_elasticsearch.rs
@@ -11,7 +11,7 @@
 //! ```
 
 use faucet_stream::sink::elasticsearch::{
-    ElasticsearchSink, ElasticsearchSinkAuth, ElasticsearchSinkConfig,
+    ElasticsearchAuth, ElasticsearchSink, ElasticsearchSinkConfig,
 };
 use faucet_stream::source::mongodb::{MongoSource, MongoSourceConfig};
 use faucet_stream::{Pipeline, json};
@@ -30,7 +30,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let sink = ElasticsearchSink::new(
         ElasticsearchSinkConfig::new("https://es.example.com:9200", "products")
-            .auth(ElasticsearchSinkAuth::Basic {
+            .auth(ElasticsearchAuth::Basic {
                 username: std::env::var("ES_USER")?,
                 password: std::env::var("ES_PASS")?,
             })

--- a/faucet-stream/examples/postgres_to_elasticsearch.rs
+++ b/faucet-stream/examples/postgres_to_elasticsearch.rs
@@ -11,7 +11,7 @@
 //! ```
 
 use faucet_stream::sink::elasticsearch::{
-    ElasticsearchSink, ElasticsearchSinkAuth, ElasticsearchSinkConfig,
+    ElasticsearchAuth, ElasticsearchSink, ElasticsearchSinkConfig,
 };
 use faucet_stream::source::postgres::{PostgresSource, PostgresSourceConfig};
 use faucet_stream::{Pipeline, json};
@@ -30,7 +30,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let sink = ElasticsearchSink::new(
         ElasticsearchSinkConfig::new("https://es.example.com:9200", "articles")
-            .auth(ElasticsearchSinkAuth::ApiKey {
+            .auth(ElasticsearchAuth::ApiKey {
                 key: std::env::var("ES_API_KEY")?,
             })
             .with_batch_size(500)


### PR DESCRIPTION
## Summary

- Extract the duplicated `ElasticsearchAuth` enum (4 variants + credential-masking `Debug` impl) from `faucet-source-elasticsearch` and `faucet-sink-elasticsearch` into a new `faucet-elasticsearch-common` crate, matching the convention already used by `faucet-kafka-common` and `faucet-gcs-common`.
- Bump both source and sink to `0.3.0`. New common crate ships at `0.1.0`.
- Retain `ElasticsearchSinkAuth` as a `#[deprecated]` type alias on the sink side; removed in `0.4.0`.
- Refine the project-wide convention in `CLAUDE.md`: backfill an existing pair only once it gains a second shared type. Investigation of the other seven candidate pairs in #43 confirmed they share only `connection_url` / `batch_size` / `max_connections` today — not enough to justify near-empty `-common` crates. Decision posted as a closing comment on #43.

Closes #43

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean (6m17s)
- [x] `cargo test -p faucet-elasticsearch-common -p faucet-source-elasticsearch -p faucet-sink-elasticsearch` — all pass (8 + 20 + 15)
- [x] Workspace tests pass for all non-Docker crates; Docker-dependent integration tests (kafka, postgres, mongodb, etc.) need CI
- [x] `cargo publish --dry-run -p faucet-elasticsearch-common` clean
- [ ] CI green, including the new dedicated `faucet-elasticsearch-common` test step

> `cargo publish --dry-run` for `faucet-source-elasticsearch` and `faucet-sink-elasticsearch` cannot succeed locally because `faucet-elasticsearch-common@0.1.0` isn't on crates.io yet — known cargo limitation with sibling deps. The release workflow handles this by publishing the common crate first in its publish wave.

## Drive-bys observed (NOT fixed in this PR — flagging for follow-up)

- `faucet-gcs-common` is missing from the publish-ordering arrays in `.github/workflows/release.yml` (both dry-run and real-release blocks).
- `faucet-gcs-common` is missing from both the workspace-table and the project-structure tree in `README.md` (root).

🤖 Generated with [Claude Code](https://claude.com/claude-code)