### PR TITLE
ci+docs(gcs-common): backfill into release.yml ordering and project docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,7 @@ jobs:
             faucet-core
             faucet-kafka-common
             faucet-elasticsearch-common
+            faucet-gcs-common
             faucet-source-rest faucet-source-graphql faucet-source-xml
             faucet-source-grpc faucet-source-postgres faucet-source-postgres-cdc
             faucet-source-mysql
@@ -112,6 +113,7 @@ jobs:
           connectors=(
             faucet-kafka-common
             faucet-elasticsearch-common
+            faucet-gcs-common
             faucet-source-rest faucet-source-graphql faucet-source-xml
             faucet-source-grpc faucet-source-postgres faucet-source-postgres-cdc
             faucet-source-mysql
@@ -161,6 +163,7 @@ jobs:
             faucet-core
             faucet-kafka-common
             faucet-elasticsearch-common
+            faucet-gcs-common
             faucet-source-rest faucet-source-graphql faucet-source-xml
             faucet-source-grpc faucet-source-postgres faucet-source-postgres-cdc
             faucet-source-mysql
@@ -177,6 +180,7 @@ jobs:
           connectors=(
             faucet-kafka-common
             faucet-elasticsearch-common
+            faucet-gcs-common
             faucet-source-rest faucet-source-graphql faucet-source-xml
             faucet-source-grpc faucet-source-postgres faucet-source-postgres-cdc
             faucet-source-mysql

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ faucet-stream is a Cargo workspace with 35 crates — 15 sources, 14 sinks, 1 sh
 | [`faucet-sink-parquet`](crates/sink/parquet) | Apache Parquet — local file or S3; schema inference, compression, row/byte rollover |
 | **Shared libraries** | |
 | [`faucet-elasticsearch-common`](crates/elasticsearch-common) | Shared `ElasticsearchAuth` enum for Elasticsearch source/sink |
+| [`faucet-gcs-common`](crates/gcs-common) | Shared GCS types — credentials enum, Storage/StorageControl client builders |
 | [`faucet-kafka-common`](crates/kafka-common) | Shared Kafka types — auth, value formats, Schema Registry client |
 | **State stores** | |
 | [`faucet-state-redis`](crates/state/redis) | Redis-backed `StateStore` for persistent bookmarks |
@@ -961,6 +962,7 @@ crates/
     kafka/                    — Apache Kafka producer
     parquet/                  — Apache Parquet writer (local, S3)
   elasticsearch-common/       — faucet-elasticsearch-common: shared ElasticsearchAuth enum
+  gcs-common/                 — faucet-gcs-common: shared GCS credentials + client builders
   kafka-common/               — faucet-kafka-common: shared Kafka auth, formats, Schema Registry
   state/
     redis/                    — Redis-backed StateStore


### PR DESCRIPTION
## Summary

`faucet-gcs-common` was shipped at `0.2.0` in #66 but never added to the publish-ordering arrays in `.github/workflows/release.yml`, and never added to either the workspace table or the project-structure tree in the root `README.md`. Surfaced as a drive-by observation during #68.

- Add `faucet-gcs-common` to all 4 publish-ordering array slots in `release.yml` (same publish wave as `faucet-kafka-common` and `faucet-elasticsearch-common`).
- Add `faucet-gcs-common` to the **Shared libraries** workspace table and to the project-structure tree in root `README.md`.

No code changes.

## Test plan

- [x] `grep -c 'faucet-gcs-common' .github/workflows/release.yml` returns 4
- [x] `grep -c 'gcs-common' README.md` returns 2 (one table row, one tree line)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)