### PR TITLE
feat(sources): add Snowflake + BigQuery query source connectors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,8 @@ jobs:
           - source-kafka
           - source-parquet
           - source-gcs
+          - source-bigquery
+          - source-snowflake
           # Sinks
           - sink-bigquery
           - sink-postgres

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,12 +97,14 @@ jobs:
             faucet-kafka-common
             faucet-elasticsearch-common
             faucet-gcs-common
+            faucet-bigquery-common
+            faucet-snowflake-common
             faucet-source-rest faucet-source-graphql faucet-source-xml
             faucet-source-grpc faucet-source-postgres faucet-source-postgres-cdc
             faucet-source-mysql
             faucet-source-sqlite faucet-source-s3 faucet-source-mongodb
             faucet-source-redis faucet-source-webhook faucet-source-csv
-            faucet-source-elasticsearch faucet-source-kafka
+            faucet-source-elasticsearch faucet-source-kafka faucet-source-bigquery faucet-source-snowflake
             faucet-sink-bigquery faucet-sink-postgres faucet-sink-jsonl
             faucet-sink-snowflake faucet-sink-mysql faucet-sink-sqlite
             faucet-sink-s3 faucet-sink-mongodb faucet-sink-redis
@@ -114,12 +116,14 @@ jobs:
             faucet-kafka-common
             faucet-elasticsearch-common
             faucet-gcs-common
+            faucet-bigquery-common
+            faucet-snowflake-common
             faucet-source-rest faucet-source-graphql faucet-source-xml
             faucet-source-grpc faucet-source-postgres faucet-source-postgres-cdc
             faucet-source-mysql
             faucet-source-sqlite faucet-source-s3 faucet-source-mongodb
             faucet-source-redis faucet-source-webhook faucet-source-csv
-            faucet-source-elasticsearch faucet-source-kafka
+            faucet-source-elasticsearch faucet-source-kafka faucet-source-bigquery faucet-source-snowflake
             faucet-sink-bigquery faucet-sink-postgres faucet-sink-jsonl
             faucet-sink-snowflake faucet-sink-mysql faucet-sink-sqlite
             faucet-sink-s3 faucet-sink-mongodb faucet-sink-redis
@@ -164,12 +168,14 @@ jobs:
             faucet-kafka-common
             faucet-elasticsearch-common
             faucet-gcs-common
+            faucet-bigquery-common
+            faucet-snowflake-common
             faucet-source-rest faucet-source-graphql faucet-source-xml
             faucet-source-grpc faucet-source-postgres faucet-source-postgres-cdc
             faucet-source-mysql
             faucet-source-sqlite faucet-source-s3 faucet-source-mongodb
             faucet-source-redis faucet-source-webhook faucet-source-csv
-            faucet-source-elasticsearch faucet-source-kafka
+            faucet-source-elasticsearch faucet-source-kafka faucet-source-bigquery faucet-source-snowflake
             faucet-sink-bigquery faucet-sink-postgres faucet-sink-jsonl
             faucet-sink-snowflake faucet-sink-mysql faucet-sink-sqlite
             faucet-sink-s3 faucet-sink-mongodb faucet-sink-redis
@@ -181,12 +187,14 @@ jobs:
             faucet-kafka-common
             faucet-elasticsearch-common
             faucet-gcs-common
+            faucet-bigquery-common
+            faucet-snowflake-common
             faucet-source-rest faucet-source-graphql faucet-source-xml
             faucet-source-grpc faucet-source-postgres faucet-source-postgres-cdc
             faucet-source-mysql
             faucet-source-sqlite faucet-source-s3 faucet-source-mongodb
             faucet-source-redis faucet-source-webhook faucet-source-csv
-            faucet-source-elasticsearch faucet-source-kafka
+            faucet-source-elasticsearch faucet-source-kafka faucet-source-bigquery faucet-source-snowflake
             faucet-sink-bigquery faucet-sink-postgres faucet-sink-jsonl
             faucet-sink-snowflake faucet-sink-mysql faucet-sink-sqlite
             faucet-sink-s3 faucet-sink-mongodb faucet-sink-redis

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ CLAUDE.md
 .claude/
 docs/superpowers/
 
+# Local scripts (one-off helpers, not part of the project)
+/scripts/
+
 # Cargo
 Cargo.lock
 doc/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ This workspace produces both library crates (`faucet-core` + every connector and
 
 ## Workspace Structure
 
-Cargo workspace, 35 crates (34 libraries + the `faucet-cli` binary). All connector crates depend only on `faucet-core`; the umbrella `faucet-stream` and the `faucet-cli` binary depend on every connector + state crate via optional features.
+Cargo workspace, 39 crates (38 libraries + the `faucet-cli` binary). All connector crates depend only on `faucet-core`; the umbrella `faucet-stream` and the `faucet-cli` binary depend on every connector + state crate via optional features.
 
 | Crate | Path | Description |
 |-------|------|-------------|
@@ -36,6 +36,8 @@ Cargo workspace, 35 crates (34 libraries + the `faucet-cli` binary). All connect
 | `faucet-source-elasticsearch` | `crates/source/elasticsearch/` | Elasticsearch source — search/scroll API |
 | `faucet-source-parquet` | `crates/source/parquet/` | Parquet source — local, glob, or S3; vectorized Arrow async reader, projection |
 | `faucet-source-kafka` | `crates/source/kafka/` | Kafka consumer — subscribes to topics, drains with idle/max-messages termination |
+| `faucet-source-bigquery` | `crates/source/bigquery/` | BigQuery query source — `jobs.query` + `jobs.getQueryResults`, pageToken pagination, type-aware row decoding |
+| `faucet-source-snowflake` | `crates/source/snowflake/` | Snowflake query source — SQL REST API with server-side partition pagination, JWT / OAuth auth |
 | `faucet-sink-bigquery` | `crates/sink/bigquery/` | BigQuery streaming insert sink |
 | `faucet-sink-postgres` | `crates/sink/postgres/` | PostgreSQL sink — JSONB or auto-mapped columns |
 | `faucet-sink-jsonl` | `crates/sink/jsonl/` | JSON Lines file sink |
@@ -52,9 +54,11 @@ Cargo workspace, 35 crates (34 libraries + the `faucet-cli` binary). All connect
 | `faucet-sink-stdout` | `crates/sink/stdout/` | Stdout/stderr sink — JSON Lines, pretty JSON, or TSV |
 | `faucet-sink-parquet` | `crates/sink/parquet/` | Parquet sink — local or S3; schema inference, compression, row/byte rollover |
 | `faucet-sink-kafka` | `crates/sink/kafka/` | Kafka producer — FuturesUnordered batched sends, QueueFull retry, multi-topic routing |
+| `faucet-bigquery-common` | `crates/bigquery-common/` | Shared `BigQueryCredentials` enum and `build_client` for BigQuery source/sink |
 | `faucet-elasticsearch-common` | `crates/elasticsearch-common/` | Shared `ElasticsearchAuth` enum for Elasticsearch source/sink |
 | `faucet-gcs-common` | `crates/gcs-common/` | Shared types for GCS source/sink — credentials enum, Storage/StorageControl client builders |
 | `faucet-kafka-common` | `crates/kafka-common/` | Shared types for Kafka source/sink — auth, value formats, Schema Registry client |
+| `faucet-snowflake-common` | `crates/snowflake-common/` | Shared `SnowflakeAuth` enum + `authorization_header` / `snowflake_token_type` helpers for Snowflake source/sink |
 | `faucet-state-redis` | `crates/state/redis/` | Redis-backed `StateStore` for replication bookmarks |
 | `faucet-state-postgres` | `crates/state/postgres/` | PostgreSQL-backed `StateStore` for replication bookmarks |
 | `faucet-stream` | `faucet-stream/` | Umbrella crate — feature-gated re-exports of all connectors and state backends |
@@ -342,7 +346,7 @@ When the user points out something fundamental about how code in this library sh
 
 When a connector ships both a `faucet-source-<name>` and a `faucet-sink-<name>` crate for the same external system, shared configuration types (auth, value formats, compression, TLS, etc.) live in a dedicated `faucet-<name>-common` crate. Both the source and sink crates depend on the common crate and re-export the shared types so end-user imports do not change. See `faucet-kafka-common` for the reference implementation.
 
-Existing pairs that predate this convention (`postgres`, `mysql`, `sqlite`, `redis`, `mongodb`, `s3`, `csv`) duplicate a tiny shared surface — typically just `connection_url` / `batch_size` / `max_connections`. The Elasticsearch pair tripped the backfill trigger in 2026-05 (a duplicated 4-variant auth enum) and was migrated to `faucet-elasticsearch-common`. The remaining seven pairs stay duplicated for now: backfill an existing pair only once it gains a second shared type (e.g. TLS settings, a credential enum, a compression enum), since the cost of a near-empty `-common` crate exceeds the benefit until then. New pairs must follow the convention from the start.
+Existing pairs that predate this convention (`postgres`, `mysql`, `sqlite`, `redis`, `mongodb`, `s3`, `csv`) duplicate a tiny shared surface — typically just `connection_url` / `batch_size` / `max_connections`. The Elasticsearch pair tripped the backfill trigger in 2026-05 (a duplicated 4-variant auth enum) and was migrated to `faucet-elasticsearch-common`. The Snowflake and BigQuery pairs were extracted to `faucet-snowflake-common` and `faucet-bigquery-common` when their respective sources landed (closing #29 and #30) — the sink already shipped a multi-variant auth/credentials enum each, so the new source picked up the shared types from the start. The remaining seven pairs stay duplicated for now: backfill an existing pair only once it gains a second shared type (e.g. TLS settings, a credential enum, a compression enum), since the cost of a near-empty `-common` crate exceeds the benefit until then. New pairs must follow the convention from the start.
 
 ### Config loading
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,11 @@
 resolver = "3"
 members = [
     "crates/core",
+    "crates/bigquery-common",
     "crates/elasticsearch-common",
     "crates/gcs-common",
     "crates/kafka-common",
+    "crates/snowflake-common",
     "crates/source/rest",
     "crates/source/graphql",
     "crates/source/xml",
@@ -23,6 +25,8 @@ members = [
     "crates/source/elasticsearch",
     "crates/source/parquet",
     "crates/source/postgres-cdc",
+    "crates/source/bigquery",
+    "crates/source/snowflake",
     "crates/sink/bigquery",
     "crates/sink/postgres",
     "crates/sink/jsonl",
@@ -55,9 +59,11 @@ repository = "https://github.com/PawanSikawat/faucet-stream"
 [workspace.dependencies]
 # Internal crates
 faucet-core = { path = "crates/core", version = "0.2.0" }
+faucet-bigquery-common = { path = "crates/bigquery-common", version = "0.1.0" }
 faucet-elasticsearch-common = { path = "crates/elasticsearch-common", version = "0.1.0" }
 faucet-gcs-common = { path = "crates/gcs-common", version = "0.2.0" }
 faucet-kafka-common = { path = "crates/kafka-common", version = "0.2.0" }
+faucet-snowflake-common = { path = "crates/snowflake-common", version = "0.1.0" }
 faucet-source-rest = { path = "crates/source/rest", version = "0.2.0" }
 faucet-source-graphql = { path = "crates/source/graphql", version = "0.2.0" }
 faucet-source-xml = { path = "crates/source/xml", version = "0.2.0" }
@@ -80,6 +86,8 @@ faucet-source-sqlite = { path = "crates/source/sqlite", version = "0.2.0" }
 faucet-source-csv = { path = "crates/source/csv", version = "0.2.0" }
 faucet-source-elasticsearch = { path = "crates/source/elasticsearch", version = "0.3.0" }
 faucet-source-parquet = { path = "crates/source/parquet", version = "0.2.0" }
+faucet-source-bigquery = { path = "crates/source/bigquery", version = "0.1.0" }
+faucet-source-snowflake = { path = "crates/source/snowflake", version = "0.1.0" }
 faucet-sink-mysql = { path = "crates/sink/mysql", version = "0.2.0" }
 faucet-sink-sqlite = { path = "crates/sink/sqlite", version = "0.2.0" }
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ faucet-stream is a Cargo workspace with 35 crates — 15 sources, 14 sinks, 1 sh
 | [`faucet-source-elasticsearch`](crates/source/elasticsearch) | Elasticsearch — search/scroll API |
 | [`faucet-source-kafka`](crates/source/kafka) | Apache Kafka — consumer with idle/max-messages termination |
 | [`faucet-source-parquet`](crates/source/parquet) | Apache Parquet — local file, glob, or S3; vectorized Arrow async reader, column projection |
+| [`faucet-source-bigquery`](crates/source/bigquery) | Google BigQuery — `jobs.query` + `jobs.getQueryResults`, type-aware row decoding |
+| [`faucet-source-snowflake`](crates/source/snowflake) | Snowflake — SQL REST API with server-side partition pagination, JWT / OAuth |
 | **Sinks** | |
 | [`faucet-sink-bigquery`](crates/sink/bigquery) | Google BigQuery — streaming inserts |
 | [`faucet-sink-postgres`](crates/sink/postgres) | PostgreSQL — JSONB or auto-mapped columns |
@@ -94,9 +96,11 @@ faucet-stream is a Cargo workspace with 35 crates — 15 sources, 14 sinks, 1 sh
 | [`faucet-sink-kafka`](crates/sink/kafka) | Apache Kafka — producer with FuturesUnordered batching, multi-topic routing |
 | [`faucet-sink-parquet`](crates/sink/parquet) | Apache Parquet — local file or S3; schema inference, compression, row/byte rollover |
 | **Shared libraries** | |
+| [`faucet-bigquery-common`](crates/bigquery-common) | Shared BigQuery types — `BigQueryCredentials` enum and `build_client` helper |
 | [`faucet-elasticsearch-common`](crates/elasticsearch-common) | Shared `ElasticsearchAuth` enum for Elasticsearch source/sink |
 | [`faucet-gcs-common`](crates/gcs-common) | Shared GCS types — credentials enum, Storage/StorageControl client builders |
 | [`faucet-kafka-common`](crates/kafka-common) | Shared Kafka types — auth, value formats, Schema Registry client |
+| [`faucet-snowflake-common`](crates/snowflake-common) | Shared Snowflake types — `SnowflakeAuth` enum + auth header helpers |
 | **State stores** | |
 | [`faucet-state-redis`](crates/state/redis) | Redis-backed `StateStore` for persistent bookmarks |
 | [`faucet-state-postgres`](crates/state/postgres) | PostgreSQL-backed `StateStore` for persistent bookmarks |
@@ -774,6 +778,8 @@ All pagination styles include loop detection — if the same cursor or link is r
 | `source-elasticsearch` | no | Elasticsearch source |
 | `source-kafka` | no | Apache Kafka consumer source |
 | `source-parquet` | no | Apache Parquet file source (local, glob, S3) |
+| `source-bigquery` | no | Google BigQuery query source |
+| `source-snowflake` | no | Snowflake query source |
 | `sink-bigquery` | no | Google BigQuery sink |
 | `sink-postgres` | no | PostgreSQL sink |
 | `sink-jsonl` | no | JSON Lines file sink |
@@ -944,6 +950,8 @@ crates/
     elasticsearch/            — Elasticsearch search/scroll
     kafka/                    — Apache Kafka consumer
     parquet/                  — Apache Parquet reader (local, glob, S3)
+    bigquery/                 — Google BigQuery query source
+    snowflake/                — Snowflake query source (SQL REST API)
   sink/
     bigquery/                 — Google BigQuery streaming inserts
     postgres/                 — PostgreSQL (JSONB or auto-map)
@@ -961,9 +969,11 @@ crates/
     stdout/                   — Stdout / stderr (JSON Lines, pretty JSON, TSV)
     kafka/                    — Apache Kafka producer
     parquet/                  — Apache Parquet writer (local, S3)
+  bigquery-common/            — faucet-bigquery-common: shared BigQueryCredentials + build_client
   elasticsearch-common/       — faucet-elasticsearch-common: shared ElasticsearchAuth enum
   gcs-common/                 — faucet-gcs-common: shared GCS credentials + client builders
   kafka-common/               — faucet-kafka-common: shared Kafka auth, formats, Schema Registry
+  snowflake-common/           — faucet-snowflake-common: shared SnowflakeAuth + JWT/OAuth header helpers
   state/
     redis/                    — Redis-backed StateStore
     postgres/                 — PostgreSQL-backed StateStore

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -39,6 +39,8 @@ source = [
     "source-kafka",
     "source-parquet",
     "source-gcs",
+    "source-bigquery",
+    "source-snowflake",
 ]
 sink = [
     "sink-bigquery",
@@ -77,6 +79,8 @@ source-elasticsearch = ["dep:faucet-source-elasticsearch"]
 source-kafka = ["dep:faucet-source-kafka"]
 source-parquet = ["dep:faucet-source-parquet"]
 source-gcs = ["dep:faucet-source-gcs"]
+source-bigquery = ["dep:faucet-source-bigquery"]
+source-snowflake = ["dep:faucet-source-snowflake"]
 
 sink-bigquery = ["dep:faucet-sink-bigquery"]
 sink-postgres = ["dep:faucet-sink-postgres"]
@@ -138,6 +142,8 @@ faucet-source-elasticsearch = { workspace = true, optional = true }
 faucet-source-kafka = { workspace = true, optional = true }
 faucet-source-parquet = { workspace = true, optional = true }
 faucet-source-gcs = { workspace = true, optional = true }
+faucet-source-bigquery = { workspace = true, optional = true }
+faucet-source-snowflake = { workspace = true, optional = true }
 faucet-sink-bigquery = { workspace = true, optional = true }
 faucet-sink-postgres = { workspace = true, optional = true }
 faucet-sink-jsonl = { workspace = true, optional = true }

--- a/cli/src/registry.rs
+++ b/cli/src/registry.rs
@@ -125,6 +125,24 @@ pub async fn build_source(kind: &str, config: Value) -> CliResult<Box<dyn Source
             let cfg = decode::<faucet_source_gcs::GcsSourceConfig>("source", "gcs", config)?;
             Ok(Box::new(faucet_source_gcs::GcsSource::new(cfg).await?))
         }
+        #[cfg(feature = "source-bigquery")]
+        "bigquery" => {
+            let cfg = decode::<faucet_source_bigquery::BigQuerySourceConfig>(
+                "source", "bigquery", config,
+            )?;
+            Ok(Box::new(
+                faucet_source_bigquery::BigQuerySource::new(cfg).await?,
+            ))
+        }
+        #[cfg(feature = "source-snowflake")]
+        "snowflake" => {
+            let cfg = decode::<faucet_source_snowflake::SnowflakeSourceConfig>(
+                "source",
+                "snowflake",
+                config,
+            )?;
+            Ok(Box::new(faucet_source_snowflake::SnowflakeSource::new(cfg)))
+        }
         other => Err(unknown(other, "source", source_kinds())),
     }
 }
@@ -268,6 +286,10 @@ pub fn source_schema(kind: &str) -> CliResult<Value> {
         "parquet" => Ok(schema::<faucet_source_parquet::ParquetSourceConfig>()),
         #[cfg(feature = "source-gcs")]
         "gcs" => Ok(schema::<faucet_source_gcs::GcsSourceConfig>()),
+        #[cfg(feature = "source-bigquery")]
+        "bigquery" => Ok(schema::<faucet_source_bigquery::BigQuerySourceConfig>()),
+        #[cfg(feature = "source-snowflake")]
+        "snowflake" => Ok(schema::<faucet_source_snowflake::SnowflakeSourceConfig>()),
         other => Err(unknown(other, "source", source_kinds())),
     }
 }
@@ -364,6 +386,16 @@ pub fn source_descriptions() -> Vec<(&'static str, &'static str)> {
     v.push((
         "gcs",
         "Google Cloud Storage source — JSONL, JSON array, or raw text",
+    ));
+    #[cfg(feature = "source-bigquery")]
+    v.push((
+        "bigquery",
+        "Google BigQuery query source (jobs.query + jobs.getQueryResults)",
+    ));
+    #[cfg(feature = "source-snowflake")]
+    v.push((
+        "snowflake",
+        "Snowflake query source (SQL REST API with partition paging)",
     ));
     v
 }

--- a/crates/bigquery-common/Cargo.toml
+++ b/crates/bigquery-common/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "faucet-bigquery-common"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Shared credentials and client construction for the faucet-stream BigQuery source and sink connectors"
+
+[dependencies]
+faucet-core.workspace = true
+gcp-bigquery-client = "0.28.0"
+schemars.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/bigquery-common/README.md
+++ b/crates/bigquery-common/README.md
@@ -1,0 +1,21 @@
+# faucet-bigquery-common
+
+Shared credential configuration and client construction for the BigQuery source and sink connectors in the [`faucet-stream`](https://crates.io/crates/faucet-stream) ecosystem.
+
+## Contents
+
+- `BigQueryCredentials` — credential source: `ServiceAccountKeyPath(String)`, `ServiceAccountKey(String)` (inline JSON), or `ApplicationDefault`. Derives `Serialize`, `Deserialize`, `JsonSchema`. Its `Debug` impl masks inline JSON as `"***"`.
+- `build_client(&BigQueryCredentials)` — async helper that turns a `BigQueryCredentials` into a ready-to-use `gcp_bigquery_client::Client`.
+
+## Usage
+
+Most users do not depend on this crate directly. It is re-exported by:
+
+- [`faucet-source-bigquery`](https://crates.io/crates/faucet-source-bigquery)
+- [`faucet-sink-bigquery`](https://crates.io/crates/faucet-sink-bigquery)
+
+Depend on this crate directly only if you are building a third-party connector that needs to accept the same credentials shape in its config.
+
+## License
+
+MIT OR Apache-2.0

--- a/crates/bigquery-common/src/lib.rs
+++ b/crates/bigquery-common/src/lib.rs
@@ -1,0 +1,133 @@
+//! # faucet-bigquery-common
+//!
+//! Shared credential configuration and client construction for the
+//! [`faucet-stream`](https://crates.io/crates/faucet-stream) BigQuery source
+//! and sink connectors.
+//!
+//! - [`BigQueryCredentials`] — service-account key file, inline service-account
+//!   JSON, or Application Default Credentials.
+//! - [`build_client`] — async helper that turns a [`BigQueryCredentials`] into
+//!   a ready-to-use [`gcp_bigquery_client::Client`].
+//!
+//! `BigQueryCredentials` derives `Serialize`, `Deserialize`, and `JsonSchema`
+//! so it round-trips through YAML/JSON configs and CLI introspection. Its
+//! `Debug` impl masks inline JSON as `"***"` while leaving the key path
+//! visible.
+
+use faucet_core::FaucetError;
+use gcp_bigquery_client::Client;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// How to authenticate with Google BigQuery.
+///
+/// **Wire-format note:** the `#[serde(tag = "type", content = "value")]`
+/// discriminator uses PascalCase variant names (`"ServiceAccountKeyPath"`,
+/// `"ServiceAccountKey"`, `"ApplicationDefault"`) for byte-compatibility with
+/// existing YAML configs that predate the extraction of this crate from
+/// `faucet-sink-bigquery`. Do not add `#[serde(rename_all = "snake_case")]`
+/// here — it would silently break those configs.
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "type", content = "value")]
+pub enum BigQueryCredentials {
+    /// Path to a service account JSON key file.
+    ServiceAccountKeyPath(String),
+    /// Inline service account JSON key content.
+    ServiceAccountKey(String),
+    /// Use application default credentials (e.g. workload identity, `gcloud auth`).
+    ApplicationDefault,
+}
+
+impl std::fmt::Debug for BigQueryCredentials {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ServiceAccountKeyPath(path) => {
+                f.debug_tuple("ServiceAccountKeyPath").field(path).finish()
+            }
+            Self::ServiceAccountKey(_) => write!(f, "ServiceAccountKey(***)"),
+            Self::ApplicationDefault => write!(f, "ApplicationDefault"),
+        }
+    }
+}
+
+/// Build a [`gcp_bigquery_client::Client`] from a faucet credential spec.
+///
+/// Returns [`FaucetError::Auth`] on authentication failures and on inline
+/// service-account JSON that fails to parse.
+pub async fn build_client(creds: &BigQueryCredentials) -> Result<Client, FaucetError> {
+    match creds {
+        BigQueryCredentials::ServiceAccountKeyPath(path) => {
+            Client::from_service_account_key_file(path)
+                .await
+                .map_err(|e| FaucetError::Auth(format!("BigQuery auth failed: {e}")))
+        }
+        BigQueryCredentials::ServiceAccountKey(json) => {
+            let sa_key = serde_json::from_str(json)
+                .map_err(|e| FaucetError::Auth(format!("invalid service account JSON: {e}")))?;
+            Client::from_service_account_key(sa_key, false)
+                .await
+                .map_err(|e| FaucetError::Auth(format!("BigQuery auth failed: {e}")))
+        }
+        BigQueryCredentials::ApplicationDefault => Client::from_application_default_credentials()
+            .await
+            .map_err(|e| FaucetError::Auth(format!("BigQuery auth failed: {e}"))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn debug_masks_inline_service_account_key() {
+        let creds = BigQueryCredentials::ServiceAccountKey("secret-json".into());
+        let debug = format!("{creds:?}");
+        assert!(debug.contains("***"));
+        assert!(!debug.contains("secret-json"));
+    }
+
+    #[test]
+    fn debug_does_not_mask_service_account_key_path() {
+        let creds = BigQueryCredentials::ServiceAccountKeyPath("/path/to/key.json".into());
+        let debug = format!("{creds:?}");
+        assert!(debug.contains("/path/to/key.json"));
+    }
+
+    #[test]
+    fn debug_application_default_is_plain() {
+        let creds = BigQueryCredentials::ApplicationDefault;
+        assert_eq!(format!("{creds:?}"), "ApplicationDefault");
+    }
+
+    #[test]
+    fn serde_round_trip_application_default() {
+        let json = serde_json::to_string(&BigQueryCredentials::ApplicationDefault).unwrap();
+        let parsed: BigQueryCredentials = serde_json::from_str(&json).unwrap();
+        assert!(matches!(parsed, BigQueryCredentials::ApplicationDefault));
+    }
+
+    #[test]
+    fn serde_round_trip_service_account_key_path() {
+        let creds = BigQueryCredentials::ServiceAccountKeyPath("/k.json".into());
+        let json = serde_json::to_string(&creds).unwrap();
+        assert_eq!(
+            json,
+            r#"{"type":"ServiceAccountKeyPath","value":"/k.json"}"#
+        );
+        let parsed: BigQueryCredentials = serde_json::from_str(&json).unwrap();
+        match parsed {
+            BigQueryCredentials::ServiceAccountKeyPath(p) => assert_eq!(p, "/k.json"),
+            _ => panic!("expected ServiceAccountKeyPath"),
+        }
+    }
+
+    #[tokio::test]
+    async fn build_client_with_invalid_inline_json_surfaces_auth_error() {
+        let creds = BigQueryCredentials::ServiceAccountKey("not-json".into());
+        match build_client(&creds).await {
+            Ok(_) => panic!("expected auth error"),
+            Err(FaucetError::Auth(_)) => {}
+            Err(other) => panic!("expected Auth error, got {other:?}"),
+        }
+    }
+}

--- a/crates/sink/bigquery/src/config.rs
+++ b/crates/sink/bigquery/src/config.rs
@@ -4,29 +4,9 @@ use faucet_core::DEFAULT_BATCH_SIZE;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-/// How to authenticate with Google BigQuery.
-#[derive(Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(tag = "type", content = "value")]
-pub enum BigQueryCredentials {
-    /// Path to a service account JSON key file.
-    ServiceAccountKeyPath(String),
-    /// Inline service account JSON key content.
-    ServiceAccountKey(String),
-    /// Use application default credentials (e.g. workload identity, `gcloud auth`).
-    ApplicationDefault,
-}
-
-impl std::fmt::Debug for BigQueryCredentials {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::ServiceAccountKeyPath(path) => {
-                f.debug_tuple("ServiceAccountKeyPath").field(path).finish()
-            }
-            Self::ServiceAccountKey(_) => write!(f, "ServiceAccountKey(***)"),
-            Self::ApplicationDefault => write!(f, "ApplicationDefault"),
-        }
-    }
-}
+// Re-export the shared credentials type so end-user imports remain stable
+// (`use faucet_sink_bigquery::BigQueryCredentials;` keeps working).
+pub use faucet_bigquery_common::BigQueryCredentials;
 
 /// Configuration for the BigQuery streaming insert sink.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -151,21 +131,6 @@ mod tests {
                 .with_batch_size(100)
                 .with_batch_size(250);
         assert_eq!(config.batch_size, 250);
-    }
-
-    #[test]
-    fn credentials_debug_masks_secrets() {
-        let creds = BigQueryCredentials::ApplicationDefault;
-        assert_eq!(format!("{creds:?}"), "ApplicationDefault");
-
-        let creds = BigQueryCredentials::ServiceAccountKey("secret-json".into());
-        let debug = format!("{creds:?}");
-        assert!(debug.contains("***"));
-        assert!(!debug.contains("secret-json"));
-
-        let creds = BigQueryCredentials::ServiceAccountKeyPath("/path/to/key.json".into());
-        let debug = format!("{creds:?}");
-        assert!(debug.contains("/path/to/key.json"));
     }
 
     #[test]

--- a/crates/sink/bigquery/src/sink.rs
+++ b/crates/sink/bigquery/src/sink.rs
@@ -1,7 +1,8 @@
 //! BigQuery streaming insert sink.
 
-use crate::config::{BigQueryCredentials, BigQuerySinkConfig};
+use crate::config::BigQuerySinkConfig;
 use async_trait::async_trait;
+use faucet_bigquery_common::build_client;
 use faucet_core::FaucetError;
 use gcp_bigquery_client::Client;
 use gcp_bigquery_client::model::table_data_insert_all_request::TableDataInsertAllRequest;
@@ -19,28 +20,9 @@ impl BigQuerySink {
     /// Create a new BigQuery sink from the given configuration.
     ///
     /// This initialises the BigQuery client and authenticates with GCP.
-    /// Returns a [`FaucetError::Sink`] if authentication fails.
+    /// Returns a [`FaucetError::Auth`] if authentication fails.
     pub async fn new(config: BigQuerySinkConfig) -> Result<Self, FaucetError> {
-        let client = match &config.credentials {
-            BigQueryCredentials::ServiceAccountKeyPath(path) => {
-                Client::from_service_account_key_file(path)
-                    .await
-                    .map_err(|e| FaucetError::Sink(format!("BigQuery auth failed: {e}")))?
-            }
-            BigQueryCredentials::ServiceAccountKey(json) => {
-                let sa_key = serde_json::from_str(json)
-                    .map_err(|e| FaucetError::Sink(format!("invalid service account JSON: {e}")))?;
-                Client::from_service_account_key(sa_key, false)
-                    .await
-                    .map_err(|e| FaucetError::Sink(format!("BigQuery auth failed: {e}")))?
-            }
-            BigQueryCredentials::ApplicationDefault => {
-                Client::from_application_default_credentials()
-                    .await
-                    .map_err(|e| FaucetError::Sink(format!("BigQuery auth failed: {e}")))?
-            }
-        };
-
+        let client = build_client(&config.credentials).await?;
         Ok(Self { config, client })
     }
 

--- a/crates/sink/snowflake/src/config.rs
+++ b/crates/sink/snowflake/src/config.rs
@@ -4,36 +4,9 @@ use faucet_core::DEFAULT_BATCH_SIZE;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-/// Authentication method for Snowflake.
-#[derive(Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(tag = "type")]
-pub enum SnowflakeAuth {
-    /// JWT key-pair authentication.
-    ///
-    /// Uses an RSA private key (PEM-encoded) to generate JWT tokens
-    /// for the Snowflake SQL REST API.
-    KeyPair {
-        /// The Snowflake user account name.
-        user: String,
-        /// PEM-encoded RSA private key.
-        private_key_pem: String,
-    },
-    /// OAuth2 bearer token (e.g. from an external identity provider).
-    OAuth { token: String },
-}
-
-impl std::fmt::Debug for SnowflakeAuth {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::KeyPair { user, .. } => f
-                .debug_struct("KeyPair")
-                .field("user", user)
-                .field("private_key_pem", &"***")
-                .finish(),
-            Self::OAuth { .. } => f.debug_struct("OAuth").field("token", &"***").finish(),
-        }
-    }
-}
+// Re-export the shared auth type so end-user imports remain stable
+// (`use faucet_sink_snowflake::SnowflakeAuth;` keeps working).
+pub use faucet_snowflake_common::SnowflakeAuth;
 
 /// Configuration for the Snowflake sink.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]

--- a/crates/sink/snowflake/src/sink.rs
+++ b/crates/sink/snowflake/src/sink.rs
@@ -1,9 +1,10 @@
 //! Snowflake SQL REST API sink.
 
-use crate::config::{SnowflakeAuth, SnowflakeSinkConfig};
+use crate::config::SnowflakeSinkConfig;
 use async_trait::async_trait;
 use faucet_core::FaucetError;
 use faucet_core::util::quote_ident;
+use faucet_snowflake_common::{authorization_header, snowflake_token_type};
 use reqwest::Client;
 use serde::Deserialize;
 use serde_json::{Value, json};
@@ -58,43 +59,14 @@ impl SnowflakeSink {
 
     /// Get the authorization header value.
     fn auth_header(&self) -> Result<String, FaucetError> {
-        match &self.config.auth {
-            SnowflakeAuth::KeyPair {
-                user,
-                private_key_pem,
-            } => {
-                let account_upper = self.config.account.to_uppercase();
-                let user_upper = user.to_uppercase();
-                let qualified_user = format!("{account_upper}.{user_upper}");
-
-                let now = jsonwebtoken::get_current_timestamp();
-                let claims = serde_json::json!({
-                    "iss": qualified_user,
-                    "sub": qualified_user,
-                    "iat": now,
-                    "exp": now + 3600,
-                });
-
-                let key = jsonwebtoken::EncodingKey::from_rsa_pem(private_key_pem.as_bytes())
-                    .map_err(|e| FaucetError::Auth(format!("invalid RSA key: {e}")))?;
-
-                let token = jsonwebtoken::encode(
-                    &jsonwebtoken::Header::new(jsonwebtoken::Algorithm::RS256),
-                    &claims,
-                    &key,
-                )
-                .map_err(|e| FaucetError::Auth(format!("JWT generation failed: {e}")))?;
-
-                Ok(format!("Bearer {token}"))
-            }
-            SnowflakeAuth::OAuth { token } => Ok(format!("Snowflake Token=\"{token}\"")),
-        }
+        authorization_header(&self.config.auth, &self.config.account)
     }
 
     /// Execute a SQL statement via the REST API.
     async fn execute_sql(&self, sql: &str) -> Result<(), FaucetError> {
         let url = self.api_url();
         let auth = self.auth_header()?;
+        let token_type = snowflake_token_type(&self.config.auth);
 
         let body = json!({
             "statement": sql,
@@ -110,7 +82,7 @@ impl SnowflakeSink {
             .header("Authorization", &auth)
             .header("Content-Type", "application/json")
             .header("Accept", "application/json")
-            .header("X-Snowflake-Authorization-Token-Type", "KEYPAIR_JWT")
+            .header("X-Snowflake-Authorization-Token-Type", token_type)
             .json(&body)
             .send()
             .await
@@ -213,6 +185,7 @@ impl faucet_core::Sink for SnowflakeSink {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::SnowflakeAuth;
 
     #[test]
     fn api_url_format() {

--- a/crates/snowflake-common/Cargo.toml
+++ b/crates/snowflake-common/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "faucet-snowflake-common"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Shared configuration types for the faucet-stream Snowflake source and sink connectors"
+
+[dependencies]
+faucet-core.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+schemars.workspace = true
+jsonwebtoken.workspace = true

--- a/crates/snowflake-common/README.md
+++ b/crates/snowflake-common/README.md
@@ -1,0 +1,22 @@
+# faucet-snowflake-common
+
+Shared configuration types and helpers for the Snowflake source and sink connectors in the [`faucet-stream`](https://crates.io/crates/faucet-stream) ecosystem.
+
+## Contents
+
+- `SnowflakeAuth` — JWT key-pair (`KeyPair { user, private_key_pem }`) or OAuth bearer (`OAuth { token }`). Derives `Serialize`, `Deserialize`, `JsonSchema`. Its `Debug` impl masks credentials as `"***"`.
+- `authorization_header(&SnowflakeAuth, account)` — produces the `Authorization` header value for a Snowflake SQL REST API request (`Bearer {jwt}` for `KeyPair`, `Snowflake Token="{token}"` for `OAuth`).
+- `snowflake_token_type(&SnowflakeAuth)` — matching `X-Snowflake-Authorization-Token-Type` header value (`KEYPAIR_JWT` / `OAUTH`).
+
+## Usage
+
+Most users do not depend on this crate directly. It is re-exported by:
+
+- [`faucet-source-snowflake`](https://crates.io/crates/faucet-source-snowflake)
+- [`faucet-sink-snowflake`](https://crates.io/crates/faucet-sink-snowflake)
+
+Depend on this crate directly only if you are building a third-party connector that needs to accept the same auth shape in its config.
+
+## License
+
+MIT OR Apache-2.0

--- a/crates/snowflake-common/src/lib.rs
+++ b/crates/snowflake-common/src/lib.rs
@@ -1,0 +1,200 @@
+//! # faucet-snowflake-common
+//!
+//! Shared configuration types and helpers for the
+//! [`faucet-stream`](https://crates.io/crates/faucet-stream)
+//! Snowflake source and sink connectors.
+//!
+//! - [`SnowflakeAuth`] — JWT key-pair or OAuth bearer authentication.
+//! - [`authorization_header`] — produces the `Authorization` header value the
+//!   Snowflake SQL REST API expects (JWT for `KeyPair`, `Snowflake Token=...`
+//!   for `OAuth`).
+//! - [`snowflake_token_type`] — the matching `X-Snowflake-Authorization-Token-Type`
+//!   header value (`KEYPAIR_JWT` for `KeyPair`, `OAUTH` for `OAuth`).
+//!
+//! `SnowflakeAuth` derives `Serialize`, `Deserialize`, and `JsonSchema` so it
+//! round-trips through YAML/JSON configs and CLI introspection. Its `Debug`
+//! impl masks credentials as `"***"`.
+
+use faucet_core::FaucetError;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Authentication method for Snowflake.
+///
+/// **Wire-format note:** the `#[serde(tag = "type")]` discriminator uses
+/// PascalCase variant names (`"KeyPair"`, `"OAuth"`) for byte-compatibility
+/// with existing YAML configs that predate the extraction of this crate
+/// from `faucet-sink-snowflake`. Do not add
+/// `#[serde(rename_all = "snake_case")]` here — it would silently break those
+/// configs.
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "type")]
+pub enum SnowflakeAuth {
+    /// JWT key-pair authentication.
+    ///
+    /// Uses an RSA private key (PEM-encoded) to generate JWT tokens for the
+    /// Snowflake SQL REST API.
+    KeyPair {
+        /// The Snowflake user account name.
+        user: String,
+        /// PEM-encoded RSA private key.
+        private_key_pem: String,
+    },
+    /// OAuth2 bearer token (e.g. from an external identity provider).
+    OAuth { token: String },
+}
+
+impl std::fmt::Debug for SnowflakeAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::KeyPair { user, .. } => f
+                .debug_struct("KeyPair")
+                .field("user", user)
+                .field("private_key_pem", &"***")
+                .finish(),
+            Self::OAuth { .. } => f.debug_struct("OAuth").field("token", &"***").finish(),
+        }
+    }
+}
+
+/// Build the `Authorization` header value for a Snowflake SQL REST API request.
+///
+/// For `KeyPair`, generates a fresh JWT signed with the configured RSA key
+/// (issuer/subject set to `{ACCOUNT_UPPER}.{USER_UPPER}`, 1-hour expiry) and
+/// wraps it as `Bearer {jwt}`. For `OAuth`, wraps the token as
+/// `Snowflake Token="{token}"`.
+///
+/// `account` is the Snowflake account identifier from the source/sink config
+/// (e.g. `"xy12345.us-east-1"`); only its uppercase form is used in the JWT
+/// claims.
+pub fn authorization_header(auth: &SnowflakeAuth, account: &str) -> Result<String, FaucetError> {
+    match auth {
+        SnowflakeAuth::KeyPair {
+            user,
+            private_key_pem,
+        } => {
+            let account_upper = account.to_uppercase();
+            let user_upper = user.to_uppercase();
+            let qualified_user = format!("{account_upper}.{user_upper}");
+
+            let now = jsonwebtoken::get_current_timestamp();
+            let claims = serde_json::json!({
+                "iss": qualified_user,
+                "sub": qualified_user,
+                "iat": now,
+                "exp": now + 3600,
+            });
+
+            let key = jsonwebtoken::EncodingKey::from_rsa_pem(private_key_pem.as_bytes())
+                .map_err(|e| FaucetError::Auth(format!("invalid RSA key: {e}")))?;
+
+            let token = jsonwebtoken::encode(
+                &jsonwebtoken::Header::new(jsonwebtoken::Algorithm::RS256),
+                &claims,
+                &key,
+            )
+            .map_err(|e| FaucetError::Auth(format!("JWT generation failed: {e}")))?;
+
+            Ok(format!("Bearer {token}"))
+        }
+        SnowflakeAuth::OAuth { token } => Ok(format!("Snowflake Token=\"{token}\"")),
+    }
+}
+
+/// The `X-Snowflake-Authorization-Token-Type` header value that pairs with the
+/// `Authorization` header produced by [`authorization_header`].
+pub fn snowflake_token_type(auth: &SnowflakeAuth) -> &'static str {
+    match auth {
+        SnowflakeAuth::KeyPair { .. } => "KEYPAIR_JWT",
+        SnowflakeAuth::OAuth { .. } => "OAUTH",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn debug_masks_key_pair_private_key() {
+        let auth = SnowflakeAuth::KeyPair {
+            user: "alice".into(),
+            private_key_pem: "PRIVATE-KEY-DATA".into(),
+        };
+        let debug = format!("{auth:?}");
+        assert!(debug.contains("alice"));
+        assert!(debug.contains("***"));
+        assert!(!debug.contains("PRIVATE-KEY-DATA"));
+    }
+
+    #[test]
+    fn debug_masks_oauth_token() {
+        let auth = SnowflakeAuth::OAuth {
+            token: "my-token".into(),
+        };
+        let debug = format!("{auth:?}");
+        assert!(debug.contains("***"));
+        assert!(!debug.contains("my-token"));
+    }
+
+    #[test]
+    fn serde_round_trip_oauth() {
+        let auth = SnowflakeAuth::OAuth { token: "t".into() };
+        let json = serde_json::to_string(&auth).unwrap();
+        assert_eq!(json, r#"{"type":"OAuth","token":"t"}"#);
+        let parsed: SnowflakeAuth = serde_json::from_str(&json).unwrap();
+        assert!(matches!(parsed, SnowflakeAuth::OAuth { .. }));
+    }
+
+    #[test]
+    fn serde_round_trip_key_pair() {
+        let json = r#"{"type":"KeyPair","user":"u","private_key_pem":"k"}"#;
+        let parsed: SnowflakeAuth = serde_json::from_str(json).unwrap();
+        match parsed {
+            SnowflakeAuth::KeyPair {
+                user,
+                private_key_pem,
+            } => {
+                assert_eq!(user, "u");
+                assert_eq!(private_key_pem, "k");
+            }
+            _ => panic!("expected KeyPair"),
+        }
+    }
+
+    #[test]
+    fn oauth_authorization_header_uses_snowflake_token_scheme() {
+        let auth = SnowflakeAuth::OAuth {
+            token: "my-token".into(),
+        };
+        let header = authorization_header(&auth, "acct").unwrap();
+        assert_eq!(header, "Snowflake Token=\"my-token\"");
+    }
+
+    #[test]
+    fn key_pair_with_invalid_pem_surfaces_auth_error() {
+        let auth = SnowflakeAuth::KeyPair {
+            user: "u".into(),
+            private_key_pem: "not-a-pem".into(),
+        };
+        let err = authorization_header(&auth, "acct").unwrap_err();
+        match err {
+            FaucetError::Auth(msg) => assert!(msg.contains("invalid RSA key")),
+            other => panic!("expected Auth error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn token_type_matches_variant() {
+        assert_eq!(
+            snowflake_token_type(&SnowflakeAuth::OAuth { token: "t".into() }),
+            "OAUTH"
+        );
+        assert_eq!(
+            snowflake_token_type(&SnowflakeAuth::KeyPair {
+                user: "u".into(),
+                private_key_pem: "k".into()
+            }),
+            "KEYPAIR_JWT"
+        );
+    }
+}

--- a/crates/source/bigquery/Cargo.toml
+++ b/crates/source/bigquery/Cargo.toml
@@ -1,25 +1,27 @@
 [package]
-name = "faucet-sink-bigquery"
-version = "0.2.0"
+name = "faucet-source-bigquery"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "BigQuery sink connector for the faucet-stream ecosystem"
+description = "BigQuery query source connector for the faucet-stream ecosystem"
 
 [dependencies]
 faucet-core.workspace = true
 faucet-bigquery-common.workspace = true
 gcp-bigquery-client = "0.28.0"
 schemars.workspace = true
-serde.workspace = true
+serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
-tokio.workspace = true
-tracing.workspace = true
 async-trait.workspace = true
+async-stream.workspace = true
+tracing.workspace = true
+tokio.workspace = true
 
 [dev-dependencies]
-tokio = { version = "1", features = ["full", "test-util"] }
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
+futures.workspace = true
 wiremock = "0.6"
 tempfile = "3"
 serde = { workspace = true }

--- a/crates/source/bigquery/README.md
+++ b/crates/source/bigquery/README.md
@@ -1,0 +1,71 @@
+# faucet-source-bigquery
+
+BigQuery query source connector for the [`faucet-stream`](https://crates.io/crates/faucet-stream) ecosystem. Runs a SQL statement against [BigQuery](https://cloud.google.com/bigquery/docs/reference/rest) via `jobs.query` + `jobs.getQueryResults` and streams the rows back as `serde_json::Value` records.
+
+## Features
+
+- **Three credential modes** — `ApplicationDefault`, `ServiceAccountKeyPath`, or inline `ServiceAccountKey`; the shared `BigQueryCredentials` enum is re-exported from [`faucet-bigquery-common`](https://crates.io/crates/faucet-bigquery-common) so it matches the BigQuery sink byte-for-byte.
+- **Sync + async result handling** — when BigQuery returns `jobComplete=false` (statement timeout exceeded), the source polls `getQueryResults` until the job finishes.
+- **Server-side pagination** — pages via `pageToken` for arbitrarily-large result sets; rows are re-framed into pages of `batch_size` for `Source::stream_pages`.
+- **Type-aware row decoding** — `INTEGER`/`INT64` → JSON number, `FLOAT`/`FLOAT64` → number, `BOOLEAN`/`BOOL` → bool, `NUMERIC`/`BIGNUMERIC` → string (full precision), `RECORD`/`STRUCT` → nested object, `REPEATED` → array, `JSON` → parsed value, everything else → string.
+- **Positional bind parameters** — `params` from config and `${parent.path}` matrix-context values are sent as `POSITIONAL` `STRING` parameters; BigQuery casts at execution time.
+- **Standard or legacy SQL** — `use_legacy_sql` toggle; defaults to Standard SQL.
+
+## Configuration
+
+```yaml
+type: bigquery
+config:
+  project_id: my-project
+  credentials:
+    type: ServiceAccountKeyPath
+    value: /etc/secrets/bigquery-sa.json
+  query: |
+    SELECT user_id, event_name, occurred_at
+    FROM `my-project.analytics.events`
+    WHERE occurred_at >= ?
+  params:
+    - "2026-01-01"
+  use_legacy_sql: false            # default
+  location: EU                     # optional; matches BigQuery dataset region
+  max_results_per_page: 1000       # default
+  statement_timeout: 60            # seconds, defaults to 60
+  batch_size: 1000                 # default, or 0 to disable re-chunking
+```
+
+### Other credential variants
+
+```yaml
+# Application Default Credentials (workload identity, gcloud auth).
+credentials:
+  type: ApplicationDefault
+```
+
+```yaml
+# Inline service-account JSON — handy with env-var indirection.
+credentials:
+  type: ServiceAccountKey
+  value: ${env:GCP_SERVICE_ACCOUNT_JSON}
+```
+
+## Library use
+
+```rust
+use faucet_core::Source;
+use faucet_source_bigquery::{BigQueryCredentials, BigQuerySource, BigQuerySourceConfig};
+
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let cfg = BigQuerySourceConfig::new(
+    "my-project",
+    BigQueryCredentials::ApplicationDefault,
+    "SELECT COUNT(*) AS n FROM analytics.events",
+);
+let rows = BigQuerySource::new(cfg).await?.fetch_all().await?;
+println!("rows: {rows:?}");
+# Ok(())
+# }
+```
+
+## License
+
+MIT OR Apache-2.0

--- a/crates/source/bigquery/src/config.rs
+++ b/crates/source/bigquery/src/config.rs
@@ -1,0 +1,261 @@
+//! BigQuery source configuration.
+
+use faucet_core::DEFAULT_BATCH_SIZE;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::time::Duration;
+
+// Re-export the shared credentials type so end-user imports remain stable.
+pub use faucet_bigquery_common::BigQueryCredentials;
+
+fn default_use_legacy_sql() -> bool {
+    false
+}
+
+fn default_max_results_per_page() -> i32 {
+    1000
+}
+
+fn default_statement_timeout() -> Duration {
+    Duration::from_secs(60)
+}
+
+fn default_batch_size() -> usize {
+    DEFAULT_BATCH_SIZE
+}
+
+/// Configuration for the BigQuery query source.
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
+pub struct BigQuerySourceConfig {
+    /// GCP project ID against which the query is billed and run.
+    pub project_id: String,
+    /// Authentication credentials.
+    pub credentials: BigQueryCredentials,
+    /// SQL statement to execute. May contain `${field.path}` placeholders that
+    /// are resolved against the parent-record context at runtime as
+    /// positional `?` markers; matched values are appended to
+    /// [`params`](Self::params) when the query is sent.
+    pub query: String,
+    /// Whether to use BigQuery's legacy SQL dialect. Defaults to `false`
+    /// (Standard SQL). Set to `true` only for tables that use legacy
+    /// `[project:dataset.table]` references.
+    #[serde(default = "default_use_legacy_sql")]
+    pub use_legacy_sql: bool,
+    /// Optional location override for non-`US` jobs (`"EU"`, `"asia-east1"`).
+    /// When `None`, BigQuery uses the default location for the queried tables.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub location: Option<String>,
+    /// Maximum rows per page when calling `jobs.getQueryResults`. Smaller
+    /// values trade more HTTP round-trips for lower memory; larger values
+    /// trade memory for fewer requests. Defaults to 1000.
+    #[serde(default = "default_max_results_per_page")]
+    pub max_results_per_page: i32,
+    /// Positional bind parameters for the query, sent as
+    /// [`POSITIONAL`](https://cloud.google.com/bigquery/docs/parameterized-queries)
+    /// query parameters in declaration order before any context-derived
+    /// values. Each value is shipped as a STRING parameter; BigQuery casts
+    /// as needed at execution time.
+    #[serde(default)]
+    pub params: Vec<Value>,
+    /// Per-statement server-side timeout. Forwarded to the
+    /// `timeoutMs` field on `jobs.query`. Defaults to 60 seconds. If
+    /// BigQuery does not finish the query within this window it responds
+    /// with `jobComplete=false`; the source then polls
+    /// `jobs.getQueryResults` until the job completes.
+    #[serde(
+        default = "default_statement_timeout",
+        with = "faucet_core::config::duration_secs"
+    )]
+    #[schemars(with = "u64")]
+    pub statement_timeout: Duration,
+    /// Records per emitted [`StreamPage`](faucet_core::StreamPage). Rows
+    /// returned by BigQuery are re-framed into pages of this size — every
+    /// time the buffer reaches `batch_size`, a page is yielded. Defaults to
+    /// [`DEFAULT_BATCH_SIZE`].
+    ///
+    /// `batch_size = 0` is the **"no batching" sentinel**: the entire
+    /// result set is buffered and emitted in a single page. Useful for
+    /// small lookup tables, or for sinks that prefer one large request to
+    /// many small ones.
+    #[serde(default = "default_batch_size")]
+    pub batch_size: usize,
+}
+
+impl std::fmt::Debug for BigQuerySourceConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BigQuerySourceConfig")
+            .field("project_id", &self.project_id)
+            .field("credentials", &self.credentials)
+            .field("query", &self.query)
+            .field("use_legacy_sql", &self.use_legacy_sql)
+            .field("location", &self.location)
+            .field("max_results_per_page", &self.max_results_per_page)
+            .field("params", &self.params)
+            .field("statement_timeout", &self.statement_timeout)
+            .field("batch_size", &self.batch_size)
+            .finish()
+    }
+}
+
+impl BigQuerySourceConfig {
+    /// Create a new config with required fields and sensible defaults.
+    pub fn new(
+        project_id: impl Into<String>,
+        credentials: BigQueryCredentials,
+        query: impl Into<String>,
+    ) -> Self {
+        Self {
+            project_id: project_id.into(),
+            credentials,
+            query: query.into(),
+            use_legacy_sql: default_use_legacy_sql(),
+            location: None,
+            max_results_per_page: default_max_results_per_page(),
+            params: Vec::new(),
+            statement_timeout: default_statement_timeout(),
+            batch_size: DEFAULT_BATCH_SIZE,
+        }
+    }
+
+    /// Enable BigQuery's legacy SQL dialect.
+    pub fn with_use_legacy_sql(mut self, use_legacy: bool) -> Self {
+        self.use_legacy_sql = use_legacy;
+        self
+    }
+
+    /// Pin the job to a specific location (e.g. `"EU"`).
+    pub fn with_location(mut self, location: impl Into<String>) -> Self {
+        self.location = Some(location.into());
+        self
+    }
+
+    /// Set the maximum row count per `getQueryResults` page.
+    pub fn with_max_results_per_page(mut self, max_results: i32) -> Self {
+        self.max_results_per_page = max_results;
+        self
+    }
+
+    /// Set the positional bind parameters for the query.
+    pub fn with_params(mut self, params: Vec<Value>) -> Self {
+        self.params = params;
+        self
+    }
+
+    /// Set the per-statement server-side timeout.
+    pub fn with_statement_timeout(mut self, timeout: Duration) -> Self {
+        self.statement_timeout = timeout;
+        self
+    }
+
+    /// Set the records-per-page hint for [`Source::stream_pages`](faucet_core::Source::stream_pages).
+    ///
+    /// Pass `0` to opt out of batching — the entire result set is emitted
+    /// in a single page.
+    pub fn with_batch_size(mut self, batch_size: usize) -> Self {
+        self.batch_size = batch_size;
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn sample() -> BigQuerySourceConfig {
+        BigQuerySourceConfig::new(
+            "my-project",
+            BigQueryCredentials::ApplicationDefault,
+            "SELECT id FROM events",
+        )
+    }
+
+    #[test]
+    fn default_config() {
+        let c = sample();
+        assert_eq!(c.project_id, "my-project");
+        assert!(!c.use_legacy_sql);
+        assert!(c.location.is_none());
+        assert_eq!(c.max_results_per_page, 1000);
+        assert!(c.params.is_empty());
+        assert_eq!(c.statement_timeout, Duration::from_secs(60));
+        assert_eq!(c.batch_size, faucet_core::DEFAULT_BATCH_SIZE);
+    }
+
+    #[test]
+    fn builder_chaining() {
+        let c = sample()
+            .with_use_legacy_sql(true)
+            .with_location("EU")
+            .with_max_results_per_page(500)
+            .with_params(vec![json!("us-east")])
+            .with_statement_timeout(Duration::from_secs(30))
+            .with_batch_size(250);
+        assert!(c.use_legacy_sql);
+        assert_eq!(c.location.as_deref(), Some("EU"));
+        assert_eq!(c.max_results_per_page, 500);
+        assert_eq!(c.params, vec![json!("us-east")]);
+        assert_eq!(c.statement_timeout, Duration::from_secs(30));
+        assert_eq!(c.batch_size, 250);
+    }
+
+    #[test]
+    fn deserializes_minimal_json() {
+        let json = r#"{
+            "project_id": "my-project",
+            "credentials": {"type": "ApplicationDefault"},
+            "query": "SELECT 1"
+        }"#;
+        let c: BigQuerySourceConfig = serde_json::from_str(json).unwrap();
+        assert!(!c.use_legacy_sql);
+        assert_eq!(c.batch_size, faucet_core::DEFAULT_BATCH_SIZE);
+        assert_eq!(c.statement_timeout, Duration::from_secs(60));
+        assert_eq!(c.max_results_per_page, 1000);
+    }
+
+    #[test]
+    fn deserializes_all_fields() {
+        let json = r#"{
+            "project_id": "p",
+            "credentials": {"type": "ApplicationDefault"},
+            "query": "SELECT 1",
+            "use_legacy_sql": true,
+            "location": "EU",
+            "max_results_per_page": 500,
+            "params": ["us-east"],
+            "statement_timeout": 30,
+            "batch_size": 250
+        }"#;
+        let c: BigQuerySourceConfig = serde_json::from_str(json).unwrap();
+        assert!(c.use_legacy_sql);
+        assert_eq!(c.location.as_deref(), Some("EU"));
+        assert_eq!(c.max_results_per_page, 500);
+        assert_eq!(c.statement_timeout, Duration::from_secs(30));
+        assert_eq!(c.batch_size, 250);
+    }
+
+    #[test]
+    fn batch_size_zero_is_accepted_as_no_batching_sentinel() {
+        let c = sample().with_batch_size(0);
+        assert!(faucet_core::validate_batch_size(c.batch_size).is_ok());
+    }
+
+    #[test]
+    fn batch_size_above_max_is_rejected_by_validate_batch_size() {
+        let c = sample().with_batch_size(faucet_core::MAX_BATCH_SIZE + 1);
+        assert!(faucet_core::validate_batch_size(c.batch_size).is_err());
+    }
+
+    #[test]
+    fn debug_masks_inline_credentials() {
+        let c = BigQuerySourceConfig::new(
+            "p",
+            BigQueryCredentials::ServiceAccountKey("secret".into()),
+            "SELECT 1",
+        );
+        let dbg = format!("{c:?}");
+        assert!(!dbg.contains("secret"));
+        assert!(dbg.contains("***"));
+    }
+}

--- a/crates/source/bigquery/src/convert.rs
+++ b/crates/source/bigquery/src/convert.rs
@@ -1,0 +1,277 @@
+//! Type-aware conversion from BigQuery `TableRow`s to JSON objects.
+//!
+//! BigQuery returns every scalar cell as a string regardless of declared
+//! type, with non-trivial structure (`RECORD`/`STRUCT`/`REPEATED`) reflected
+//! in nested cell shapes:
+//!
+//! - A `RECORD` cell carries `{"f": [...nested cells...]}` in its `value`
+//!   field.
+//! - A `REPEATED` cell carries `[{"v": ...cell...}, ...]` in its `value`
+//!   field — one element per array entry.
+//!
+//! This module walks the schema in lockstep with each row's cells and emits
+//! a `serde_json::Value::Object` keyed by column name, with each cell typed
+//! according to its `TableFieldSchema`.
+//!
+//! ## Type mapping
+//!
+//! | BigQuery type                          | JSON output                      |
+//! |----------------------------------------|----------------------------------|
+//! | `INTEGER` / `INT64`                    | `Number` (i64 if it fits, else f64) |
+//! | `FLOAT` / `FLOAT64`                    | `Number` (f64)                   |
+//! | `NUMERIC` / `BIGNUMERIC`               | `String` (full precision preserved) |
+//! | `BOOLEAN` / `BOOL`                     | `Bool`                           |
+//! | `RECORD` / `STRUCT`                    | nested `Object`                  |
+//! | `REPEATED <T>` mode                    | `Array<T>`                       |
+//! | `JSON`                                 | parsed `Value` (falls back to `String`) |
+//! | `STRING` / `BYTES` / `TIMESTAMP` / `DATE` / `TIME` / `DATETIME` / `GEOGRAPHY` / `INTERVAL` | `String` |
+//! | `NULL` cell                            | `Null`                           |
+
+use gcp_bigquery_client::model::field_type::FieldType;
+use gcp_bigquery_client::model::table_field_schema::TableFieldSchema;
+use gcp_bigquery_client::model::table_row::TableRow;
+use serde::Deserialize;
+use serde_json::{Map, Value};
+
+/// Convert a BigQuery `TableRow` into a JSON object using its schema.
+///
+/// `fields` and the row's `columns` are expected to line up positionally —
+/// the field at index `i` describes the cell at index `i`. Missing trailing
+/// cells map to `Null`.
+pub fn row_to_json(row: &TableRow, fields: &[TableFieldSchema]) -> Value {
+    let cells = row.columns.as_deref().unwrap_or(&[]);
+    let mut obj = Map::with_capacity(fields.len());
+    for (i, field) in fields.iter().enumerate() {
+        let raw = cells.get(i).and_then(|c| c.value.as_ref());
+        obj.insert(field.name.clone(), cell_to_json(raw, field));
+    }
+    Value::Object(obj)
+}
+
+/// Convert one `TableCell.value` (or `None` for a missing cell) to JSON,
+/// honouring `REPEATED` mode and `RECORD`/`STRUCT` nesting.
+fn cell_to_json(value: Option<&Value>, field: &TableFieldSchema) -> Value {
+    let Some(value) = value else {
+        return Value::Null;
+    };
+    if value.is_null() {
+        return Value::Null;
+    }
+
+    let repeated = field
+        .mode
+        .as_deref()
+        .map(|m| m.eq_ignore_ascii_case("REPEATED"))
+        .unwrap_or(false);
+
+    if repeated {
+        // Repeated cells are arrays of `{v: ...}` wrappers; recurse into
+        // each element as if it were a single non-repeated cell of the same
+        // field type.
+        let Some(array) = value.as_array() else {
+            // Shape we didn't expect — fall back to a single-element array
+            // carrying the raw value rather than dropping data on the floor.
+            return Value::Array(vec![scalar_or_record(value, field)]);
+        };
+        let items: Vec<Value> = array
+            .iter()
+            .map(|elem| {
+                // Each element is a `TableCell`-shaped wrapper; unwrap the
+                // `{"v": ...}` envelope if present, otherwise treat the
+                // element itself as the payload.
+                match elem.get("v") {
+                    Some(inner) => scalar_or_record(inner, field),
+                    None => scalar_or_record(elem, field),
+                }
+            })
+            .collect();
+        return Value::Array(items);
+    }
+
+    scalar_or_record(value, field)
+}
+
+/// Convert one already-unwrapped cell payload (no `REPEATED` wrapper) to JSON.
+fn scalar_or_record(payload: &Value, field: &TableFieldSchema) -> Value {
+    if matches!(field.r#type, FieldType::Record | FieldType::Struct) {
+        return record_to_json(payload, field);
+    }
+
+    let Some(s) = payload.as_str() else {
+        // BigQuery may already have typed numeric/bool values for certain
+        // formats; pass through unchanged.
+        return payload.clone();
+    };
+
+    match field.r#type {
+        FieldType::Integer | FieldType::Int64 => parse_integer(s),
+        FieldType::Float | FieldType::Float64 => parse_float(s),
+        FieldType::Boolean | FieldType::Bool => parse_bool(s),
+        FieldType::Json => serde_json::from_str(s).unwrap_or_else(|_| Value::String(s.to_owned())),
+        // STRING, BYTES, TIMESTAMP, DATE, TIME, DATETIME, NUMERIC,
+        // BIGNUMERIC, GEOGRAPHY, INTERVAL — keep as string for
+        // round-trip safety.
+        _ => Value::String(s.to_owned()),
+    }
+}
+
+/// Decode a RECORD/STRUCT cell. The payload is itself a `TableRow`-shaped
+/// object `{"f": [...]}`, so we deserialise it into a `TableRow` and recurse.
+fn record_to_json(payload: &Value, field: &TableFieldSchema) -> Value {
+    let row: TableRow = match TableRow::deserialize(payload.clone()) {
+        Ok(row) => row,
+        Err(_) => return payload.clone(),
+    };
+    let nested_fields = field.fields.as_deref().unwrap_or(&[]);
+    row_to_json(&row, nested_fields)
+}
+
+fn parse_integer(s: &str) -> Value {
+    if let Ok(i) = s.parse::<i64>() {
+        return Value::Number(i.into());
+    }
+    parse_float(s)
+}
+
+fn parse_float(s: &str) -> Value {
+    match s.parse::<f64>() {
+        Ok(f) => serde_json::Number::from_f64(f)
+            .map(Value::Number)
+            .unwrap_or_else(|| Value::String(s.to_owned())),
+        Err(_) => Value::String(s.to_owned()),
+    }
+}
+
+fn parse_bool(s: &str) -> Value {
+    match s {
+        "true" | "TRUE" | "1" => Value::Bool(true),
+        "false" | "FALSE" | "0" => Value::Bool(false),
+        other => Value::String(other.to_owned()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gcp_bigquery_client::model::field_type::FieldType;
+    use gcp_bigquery_client::model::table_cell::TableCell;
+    use serde_json::json;
+
+    fn field(name: &str, ty: FieldType) -> TableFieldSchema {
+        TableFieldSchema::new(name, ty)
+    }
+
+    fn repeated(mut f: TableFieldSchema) -> TableFieldSchema {
+        f.mode = Some("REPEATED".to_string());
+        f
+    }
+
+    fn cells(values: Vec<Value>) -> TableRow {
+        TableRow {
+            columns: Some(
+                values
+                    .into_iter()
+                    .map(|v| TableCell { value: Some(v) })
+                    .collect(),
+            ),
+        }
+    }
+
+    #[test]
+    fn integer_parses_as_number() {
+        let row = cells(vec![json!("42")]);
+        let fields = vec![field("id", FieldType::Integer)];
+        assert_eq!(row_to_json(&row, &fields), json!({"id": 42}));
+    }
+
+    #[test]
+    fn float_parses_as_number() {
+        let row = cells(vec![json!("2.5")]);
+        let fields = vec![field("ratio", FieldType::Float)];
+        assert_eq!(row_to_json(&row, &fields), json!({"ratio": 2.5}));
+    }
+
+    #[test]
+    fn boolean_parses_lowercase() {
+        let row = cells(vec![json!("true"), json!("false")]);
+        let fields = vec![field("a", FieldType::Boolean), field("b", FieldType::Bool)];
+        assert_eq!(row_to_json(&row, &fields), json!({"a": true, "b": false}));
+    }
+
+    #[test]
+    fn numeric_preserves_string_for_precision() {
+        let row = cells(vec![json!("1234567890123456789012345.6789")]);
+        let fields = vec![field("amount", FieldType::Numeric)];
+        assert_eq!(
+            row_to_json(&row, &fields),
+            json!({"amount": "1234567890123456789012345.6789"})
+        );
+    }
+
+    #[test]
+    fn timestamp_passes_through_as_string() {
+        let row = cells(vec![json!("1.7e9")]);
+        let fields = vec![field("ts", FieldType::Timestamp)];
+        assert_eq!(row_to_json(&row, &fields), json!({"ts": "1.7e9"}));
+    }
+
+    #[test]
+    fn null_cell_maps_to_null() {
+        let row = cells(vec![json!(null)]);
+        let fields = vec![field("x", FieldType::Integer)];
+        assert_eq!(row_to_json(&row, &fields), json!({"x": null}));
+    }
+
+    #[test]
+    fn missing_cell_maps_to_null() {
+        // Row has zero cells but the schema declares one field.
+        let row = TableRow {
+            columns: Some(vec![]),
+        };
+        let fields = vec![field("x", FieldType::String)];
+        assert_eq!(row_to_json(&row, &fields), json!({"x": null}));
+    }
+
+    #[test]
+    fn repeated_integers_become_array() {
+        let row = cells(vec![json!([{"v": "1"}, {"v": "2"}, {"v": "3"}])]);
+        let fields = vec![repeated(field("ids", FieldType::Integer))];
+        assert_eq!(row_to_json(&row, &fields), json!({"ids": [1, 2, 3]}));
+    }
+
+    #[test]
+    fn record_decodes_nested_object() {
+        let row = cells(vec![json!({"f": [{"v": "1"}, {"v": "alice"}]})]);
+        let mut record_field = field("user", FieldType::Record);
+        record_field.fields = Some(vec![
+            field("id", FieldType::Integer),
+            field("name", FieldType::String),
+        ]);
+        let fields = vec![record_field];
+        assert_eq!(
+            row_to_json(&row, &fields),
+            json!({"user": {"id": 1, "name": "alice"}})
+        );
+    }
+
+    #[test]
+    fn json_field_parses_inner_json() {
+        let row = cells(vec![json!(r#"{"k": 1}"#)]);
+        let fields = vec![field("payload", FieldType::Json)];
+        assert_eq!(row_to_json(&row, &fields), json!({"payload": {"k": 1}}));
+    }
+
+    #[test]
+    fn json_field_falls_back_to_string_on_invalid_json() {
+        let row = cells(vec![json!("not-json")]);
+        let fields = vec![field("payload", FieldType::Json)];
+        assert_eq!(row_to_json(&row, &fields), json!({"payload": "not-json"}));
+    }
+
+    #[test]
+    fn unparseable_integer_falls_back_to_string() {
+        let row = cells(vec![json!("abc")]);
+        let fields = vec![field("id", FieldType::Integer)];
+        assert_eq!(row_to_json(&row, &fields), json!({"id": "abc"}));
+    }
+}

--- a/crates/source/bigquery/src/lib.rs
+++ b/crates/source/bigquery/src/lib.rs
@@ -1,0 +1,15 @@
+//! # faucet-source-bigquery
+//!
+//! BigQuery query source connector for the faucet-stream ecosystem.
+//!
+//! Runs a SQL query against BigQuery via `jobs.query` + `jobs.getQueryResults`
+//! and streams the rows back as `serde_json::Value` records.
+
+pub mod config;
+pub mod convert;
+pub mod stream;
+
+pub use faucet_core::{FaucetError, Source};
+
+pub use config::{BigQueryCredentials, BigQuerySourceConfig};
+pub use stream::BigQuerySource;

--- a/crates/source/bigquery/src/stream.rs
+++ b/crates/source/bigquery/src/stream.rs
@@ -1,0 +1,454 @@
+//! BigQuery query source.
+//!
+//! Submits the configured SQL statement via `jobs.query` and pages through
+//! the result set via `jobs.getQueryResults`. The first response may carry
+//! `jobComplete=false` (statement still running on the server side); the
+//! source polls `getQueryResults` until BigQuery flips that flag, exactly
+//! mirroring the behaviour of `gcp_bigquery_client::Client::job().query_all`
+//! without giving up the row-level access we need for incremental
+//! [`StreamPage`]s.
+
+use crate::config::BigQuerySourceConfig;
+use crate::convert::row_to_json;
+use async_trait::async_trait;
+use faucet_bigquery_common::build_client;
+use faucet_core::util::substitute_context_bind_params;
+use faucet_core::{FaucetError, Stream, StreamPage};
+use gcp_bigquery_client::Client;
+use gcp_bigquery_client::model::get_query_results_parameters::GetQueryResultsParameters;
+use gcp_bigquery_client::model::query_parameter::QueryParameter;
+use gcp_bigquery_client::model::query_parameter_type::QueryParameterType;
+use gcp_bigquery_client::model::query_parameter_value::QueryParameterValue;
+use gcp_bigquery_client::model::query_request::QueryRequest;
+use gcp_bigquery_client::model::query_response::QueryResponse;
+use gcp_bigquery_client::model::table_field_schema::TableFieldSchema;
+use gcp_bigquery_client::model::table_row::TableRow;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::pin::Pin;
+use std::time::Duration;
+
+/// A source that runs a SQL query against BigQuery and yields rows as JSON.
+pub struct BigQuerySource {
+    config: BigQuerySourceConfig,
+    client: Client,
+}
+
+impl BigQuerySource {
+    /// Create a new BigQuery source from the given configuration.
+    ///
+    /// Initialises the underlying BigQuery client and exchanges credentials
+    /// for an OAuth token. Returns [`FaucetError::Auth`] on credential
+    /// failures.
+    pub async fn new(config: BigQuerySourceConfig) -> Result<Self, FaucetError> {
+        let client = build_client(&config.credentials).await?;
+        Ok(Self { config, client })
+    }
+
+    /// Construct a source from a pre-built BigQuery client.
+    ///
+    /// Low-level escape hatch for callers that build their own
+    /// [`gcp_bigquery_client::Client`] — for example to target the
+    /// [`bigquery-emulator`](https://github.com/goccy/bigquery-emulator) or
+    /// drive a wiremock-backed test fixture. Production code should prefer
+    /// [`BigQuerySource::new`], which handles credential loading.
+    #[doc(hidden)]
+    pub fn from_parts(config: BigQuerySourceConfig, client: Client) -> Self {
+        Self { config, client }
+    }
+
+    /// Resolve the final SQL statement and ordered bind values for a given
+    /// parent-record context.
+    fn resolve_query(&self, context: &HashMap<String, Value>) -> (String, Vec<Value>) {
+        let mut bindings = self.config.params.clone();
+        let (rewritten, context_values) = if context.is_empty() {
+            (self.config.query.clone(), Vec::new())
+        } else {
+            substitute_context_bind_params(&self.config.query, context, bindings.len() + 1, |_| {
+                "?".to_string()
+            })
+        };
+        bindings.extend(context_values);
+        (rewritten, bindings)
+    }
+
+    fn build_query_request(&self, query: String, bindings: &[Value]) -> QueryRequest {
+        build_query_request(&self.config, query, bindings)
+    }
+}
+
+/// Free-standing version of [`BigQuerySource::build_query_request`] — kept
+/// separate so unit tests can exercise it without spinning up a real
+/// `gcp_bigquery_client::Client`.
+fn build_query_request(
+    cfg: &BigQuerySourceConfig,
+    query: String,
+    bindings: &[Value],
+) -> QueryRequest {
+    let mut req = QueryRequest::new(query);
+    req.use_legacy_sql = cfg.use_legacy_sql;
+    req.timeout_ms = Some(clamp_timeout_ms(cfg.statement_timeout));
+    req.max_results = Some(cfg.max_results_per_page);
+    if let Some(location) = &cfg.location {
+        req.location = Some(location.clone());
+    }
+
+    if !bindings.is_empty() {
+        req.parameter_mode = Some("POSITIONAL".to_string());
+        req.query_parameters = Some(
+            bindings
+                .iter()
+                .map(|v| QueryParameter {
+                    name: None,
+                    parameter_type: Some(QueryParameterType {
+                        r#type: "STRING".to_string(),
+                        array_type: None,
+                        struct_types: None,
+                    }),
+                    parameter_value: Some(QueryParameterValue {
+                        value: Some(stringify_param(v)),
+                        array_values: None,
+                        struct_values: None,
+                    }),
+                })
+                .collect(),
+        );
+    }
+
+    req
+}
+
+fn stringify_param(v: &Value) -> String {
+    match v {
+        Value::String(s) => s.clone(),
+        other => other.to_string(),
+    }
+}
+
+fn clamp_timeout_ms(timeout: Duration) -> i32 {
+    let ms = timeout.as_millis();
+    if ms > i32::MAX as u128 {
+        i32::MAX
+    } else {
+        ms as i32
+    }
+}
+
+fn schema_fields(qr: &QueryResponse) -> Vec<TableFieldSchema> {
+    qr.schema
+        .as_ref()
+        .and_then(|s| s.fields.clone())
+        .unwrap_or_default()
+}
+
+fn job_reference(qr: &QueryResponse) -> Result<(String, Option<String>), FaucetError> {
+    let r = qr.job_reference.as_ref().ok_or_else(|| {
+        FaucetError::Source("BigQuery query response missing jobReference".into())
+    })?;
+    let job_id = r
+        .job_id
+        .clone()
+        .ok_or_else(|| FaucetError::Source("BigQuery jobReference missing jobId".into()))?;
+    Ok((job_id, r.location.clone()))
+}
+
+#[async_trait]
+impl faucet_core::Source for BigQuerySource {
+    fn connector_name(&self) -> &'static str {
+        "bigquery"
+    }
+
+    fn config_schema(&self) -> Value {
+        serde_json::to_value(faucet_core::schema_for!(BigQuerySourceConfig))
+            .expect("schema serialization")
+    }
+
+    async fn fetch_with_context(
+        &self,
+        context: &HashMap<String, Value>,
+    ) -> Result<Vec<Value>, FaucetError> {
+        let (query, bindings) = self.resolve_query(context);
+        let req = self.build_query_request(query, &bindings);
+
+        let initial = self
+            .client
+            .job()
+            .query(&self.config.project_id, req)
+            .await
+            .map_err(|e| FaucetError::Source(format!("BigQuery jobs.query failed: {e}")))?;
+
+        let fields = schema_fields(&initial);
+        let mut all_rows: Vec<Value> = rows_from_response(&initial, &fields);
+        let mut page_token = initial.page_token.clone();
+        let mut job_complete = initial.job_complete.unwrap_or(false);
+        let (job_id, job_location) = job_reference(&initial)?;
+        let mut fields = fields;
+
+        // Either keep polling until jobComplete, or keep paging until
+        // pageToken vanishes. The two reasons we'd loop again share one
+        // condition: we are not done.
+        while !job_complete || page_token.is_some() {
+            let params = GetQueryResultsParameters {
+                page_token: page_token.clone(),
+                max_results: Some(self.config.max_results_per_page),
+                location: job_location.clone(),
+                ..Default::default()
+            };
+
+            let resp = self
+                .client
+                .job()
+                .get_query_results(&self.config.project_id, &job_id, params)
+                .await
+                .map_err(|e| {
+                    FaucetError::Source(format!("BigQuery jobs.getQueryResults failed: {e}"))
+                })?;
+
+            job_complete = resp.job_complete.unwrap_or(false);
+            if !job_complete {
+                tokio::time::sleep(Duration::from_millis(200)).await;
+                continue;
+            }
+
+            // Fill in the schema from the first complete page if `jobs.query`
+            // returned 200 without one (happens when the statement timeout
+            // fires before completion).
+            if fields.is_empty()
+                && let Some(s) = resp.schema.as_ref()
+                && let Some(f) = s.fields.as_ref()
+            {
+                fields = f.clone();
+            }
+
+            for row in resp.rows.unwrap_or_default() {
+                all_rows.push(row_to_json(&row, &fields));
+            }
+            page_token = resp.page_token;
+            if page_token.is_none() {
+                break;
+            }
+        }
+
+        tracing::info!(
+            rows = all_rows.len(),
+            query = %self.config.query,
+            "BigQuery source fetch complete",
+        );
+        Ok(all_rows)
+    }
+
+    /// Stream rows page-by-page via `jobs.getQueryResults` without
+    /// buffering the full result set.
+    ///
+    /// The trait-level `batch_size` argument is ignored in favour of the
+    /// config field — the config is the user-facing knob the README
+    /// documents, and routing the pipeline-supplied hint through it would
+    /// silently override an explicit config value.
+    ///
+    /// `batch_size = 0` is the "no batching" sentinel: all rows from all
+    /// pages are concatenated and emitted as a single page. The source has
+    /// no incremental-replication mode today, so every emitted page carries
+    /// `bookmark: None`.
+    fn stream_pages<'a>(
+        &'a self,
+        context: &'a HashMap<String, Value>,
+        _batch_size: usize,
+    ) -> Pin<Box<dyn Stream<Item = Result<StreamPage, FaucetError>> + Send + 'a>> {
+        let batch_size = self.config.batch_size;
+
+        Box::pin(async_stream::try_stream! {
+            let (query, bindings) = self.resolve_query(context);
+            let req = self.build_query_request(query, &bindings);
+
+            let initial = self
+                .client
+                .job()
+                .query(&self.config.project_id, req)
+                .await
+                .map_err(|e| FaucetError::Source(format!("BigQuery jobs.query failed: {e}")))?;
+
+            let mut fields = schema_fields(&initial);
+            let mut buffer: Vec<Value> = if batch_size == 0 {
+                Vec::with_capacity(1024)
+            } else {
+                Vec::with_capacity(batch_size)
+            };
+            let chunk = if batch_size == 0 { usize::MAX } else { batch_size };
+
+            for row in rows_from_response_owned(&initial, &fields) {
+                buffer.push(row);
+                if buffer.len() >= chunk {
+                    let page = std::mem::replace(&mut buffer, Vec::with_capacity(chunk));
+                    yield StreamPage { records: page, bookmark: None };
+                }
+            }
+
+            let mut job_complete = initial.job_complete.unwrap_or(false);
+            let mut page_token = initial.page_token.clone();
+
+            // If the first response was incomplete, we have to know the job id
+            // to keep polling. If it was complete but had no further token,
+            // we're done after emitting the first batch.
+            let (job_id, job_location) = job_reference(&initial)?;
+
+            while !job_complete || page_token.is_some() {
+                let params = GetQueryResultsParameters {
+                    page_token: page_token.clone(),
+                    max_results: Some(self.config.max_results_per_page),
+                    location: job_location.clone(),
+                    ..Default::default()
+                };
+
+                let resp = self
+                    .client
+                    .job()
+                    .get_query_results(&self.config.project_id, &job_id, params)
+                    .await
+                    .map_err(|e| {
+                        FaucetError::Source(format!("BigQuery jobs.getQueryResults failed: {e}"))
+                    })?;
+
+                job_complete = resp.job_complete.unwrap_or(false);
+                if !job_complete {
+                    tokio::time::sleep(Duration::from_millis(200)).await;
+                    continue;
+                }
+
+                if fields.is_empty()
+                    && let Some(s) = resp.schema.as_ref()
+                    && let Some(f) = s.fields.as_ref()
+                {
+                    fields = f.clone();
+                }
+
+                for row in resp.rows.unwrap_or_default() {
+                    buffer.push(row_to_json(&row, &fields));
+                    if buffer.len() >= chunk {
+                        let page = std::mem::replace(&mut buffer, Vec::with_capacity(chunk));
+                        yield StreamPage { records: page, bookmark: None };
+                    }
+                }
+                page_token = resp.page_token;
+                if page_token.is_none() {
+                    break;
+                }
+            }
+
+            if !buffer.is_empty() {
+                yield StreamPage { records: buffer, bookmark: None };
+            }
+
+            tracing::info!(
+                batch_size,
+                query = %self.config.query,
+                "BigQuery source stream complete",
+            );
+        })
+    }
+}
+
+/// Borrow-based row extraction (used by `fetch_with_context`, which collects
+/// into a `Vec` anyway).
+fn rows_from_response(resp: &QueryResponse, fields: &[TableFieldSchema]) -> Vec<Value> {
+    resp.rows
+        .as_ref()
+        .map(|rows| rows.iter().map(|r| row_to_json(r, fields)).collect())
+        .unwrap_or_default()
+}
+
+/// Owned-iteration variant — clones each row out of the response so the
+/// streaming loop above doesn't have to keep a borrow open across yields.
+fn rows_from_response_owned(resp: &QueryResponse, fields: &[TableFieldSchema]) -> Vec<Value> {
+    let rows: &Vec<TableRow> = match resp.rows.as_ref() {
+        Some(r) => r,
+        None => return Vec::new(),
+    };
+    rows.iter().map(|r| row_to_json(r, fields)).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::BigQueryCredentials;
+    use serde_json::json;
+
+    fn cfg() -> BigQuerySourceConfig {
+        BigQuerySourceConfig::new(
+            "my-project",
+            BigQueryCredentials::ApplicationDefault,
+            "SELECT id FROM events",
+        )
+    }
+
+    #[test]
+    fn stringify_param_passes_strings_unquoted() {
+        assert_eq!(stringify_param(&json!("us-east")), "us-east");
+        assert_eq!(stringify_param(&json!(42)), "42");
+        assert_eq!(stringify_param(&json!(true)), "true");
+    }
+
+    #[test]
+    fn clamp_timeout_ms_handles_overflow() {
+        assert_eq!(clamp_timeout_ms(Duration::from_secs(1)), 1000);
+        assert_eq!(clamp_timeout_ms(Duration::from_secs(u64::MAX)), i32::MAX);
+    }
+
+    #[test]
+    fn build_request_no_params_omits_query_parameters() {
+        let c = cfg();
+        let req = build_query_request(&c, "SELECT id".to_string(), &[]);
+        assert_eq!(req.query, "SELECT id");
+        assert!(req.query_parameters.is_none());
+        assert!(req.parameter_mode.is_none());
+        assert!(!req.use_legacy_sql);
+        assert_eq!(req.max_results, Some(1000));
+    }
+
+    #[test]
+    fn build_request_with_params_uses_positional_string_binds() {
+        let c = cfg().with_params(vec![json!("us-east"), json!(42)]);
+        let req = build_query_request(&c, "SELECT * WHERE r = ? AND n > ?".to_string(), &c.params);
+        assert_eq!(req.parameter_mode.as_deref(), Some("POSITIONAL"));
+        let params = req.query_parameters.as_ref().unwrap();
+        assert_eq!(params.len(), 2);
+        assert_eq!(params[0].parameter_type.as_ref().unwrap().r#type, "STRING");
+        assert_eq!(
+            params[0].parameter_value.as_ref().unwrap().value.as_deref(),
+            Some("us-east")
+        );
+        assert_eq!(
+            params[1].parameter_value.as_ref().unwrap().value.as_deref(),
+            Some("42")
+        );
+    }
+
+    #[test]
+    fn build_request_propagates_location_and_legacy_flag() {
+        let c = cfg()
+            .with_location("EU")
+            .with_use_legacy_sql(true)
+            .with_max_results_per_page(250);
+        let req = build_query_request(&c, "SELECT 1".to_string(), &[]);
+        assert!(req.use_legacy_sql);
+        assert_eq!(req.location.as_deref(), Some("EU"));
+        assert_eq!(req.max_results, Some(250));
+    }
+
+    #[test]
+    fn resolve_query_substitutes_context_with_positional_markers() {
+        // Test resolve_query without needing a Client by mimicking its core.
+        let c = cfg();
+        let mut bindings = c.params.clone();
+        let mut ctx = HashMap::new();
+        ctx.insert("parent.id".to_string(), json!(7));
+        let (rewritten, extra) = substitute_context_bind_params(
+            "SELECT * FROM t WHERE id = {parent.id}",
+            &ctx,
+            bindings.len() + 1,
+            |_| "?".to_string(),
+        );
+        bindings.extend(extra);
+        assert_eq!(rewritten, "SELECT * FROM t WHERE id = ?");
+        assert_eq!(bindings, vec![json!(7)]);
+    }
+}

--- a/crates/source/bigquery/tests/bigquery_source.rs
+++ b/crates/source/bigquery/tests/bigquery_source.rs
@@ -1,0 +1,300 @@
+//! Integration tests for the BigQuery source.
+//!
+//! Drives [`BigQuerySource`] against a wiremock server mocking the BigQuery
+//! REST API. The same OAuth-token + service-account dance the sink tests
+//! use lets us run the real `gcp_bigquery_client` client end-to-end without
+//! reaching out to GCP — we just point both the auth and `v2` base URLs at
+//! the local mock.
+
+use std::collections::HashMap;
+
+use faucet_core::Source;
+use faucet_source_bigquery::{BigQueryCredentials, BigQuerySource, BigQuerySourceConfig};
+use futures::StreamExt;
+use gcp_bigquery_client::client_builder::ClientBuilder;
+use serde::Serialize;
+use serde_json::{Value, json};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const PROJECT_ID: &str = "test-project";
+const AUTH_TOKEN_PATH: &str = "/:o/oauth2/token";
+const AUTH_SCOPE_BASE: &str = "/auth/bigquery";
+
+#[derive(Serialize)]
+struct FakeToken {
+    access_token: &'static str,
+    token_type: &'static str,
+    expires_in: u32,
+}
+
+fn fake_token() -> FakeToken {
+    FakeToken {
+        access_token: "fake-token",
+        token_type: "bearer",
+        expires_in: 9_999_999,
+    }
+}
+
+fn dummy_service_account_json(oauth_server: &str) -> Value {
+    let token_uri = format!("{oauth_server}{AUTH_TOKEN_PATH}");
+    json!({
+        "type": "service_account",
+        "project_id": "dummy",
+        "private_key_id": "dummy",
+        "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQDNk6cKkWP/4NMu\nWb3s24YHfM639IXzPtTev06PUVVQnyHmT1bZgQ/XB6BvIRaReqAqnQd61PAGtX3e\n8XocTw+u/ZfiPJOf+jrXMkRBpiBh9mbyEIqBy8BC20OmsUc+O/YYh/qRccvRfPI7\n3XMabQ8eFWhI6z/t35oRpvEVFJnSIgyV4JR/L/cjtoKnxaFwjBzEnxPiwtdy4olU\nKO/1maklXexvlO7onC7CNmPAjuEZKzdMLzFszikCDnoKJC8k6+2GZh0/JDMAcAF4\nwxlKNQ89MpHVRXZ566uKZg0MqZqkq5RXPn6u7yvNHwZ0oahHT+8ixPPrAEjuPEKM\nUPzVRz71AgMBAAECggEAfdbVWLW5Befkvam3hea2+5xdmeN3n3elrJhkiXxbAhf3\nE1kbq9bCEHmdrokNnI34vz0SWBFCwIiWfUNJ4UxQKGkZcSZto270V8hwWdNMXUsM\npz6S2nMTxJkdp0s7dhAUS93o9uE2x4x5Z0XecJ2ztFGcXY6Lupu2XvnW93V9109h\nkY3uICLdbovJq7wS/fO/AL97QStfEVRWW2agIXGvoQG5jOwfPh86GZZRYP9b8VNw\ntkAUJe4qpzNbWs9AItXOzL+50/wsFkD/iWMGWFuU8DY5ZwsL434N+uzFlaD13wtZ\n63D+tNAxCSRBfZGQbd7WxJVFfZe/2vgjykKWsdyNAQKBgQDnEBgSI836HGSRk0Ub\nDwiEtdfh2TosV+z6xtyU7j/NwjugTOJEGj1VO/TMlZCEfpkYPLZt3ek2LdNL66n8\nDyxwzTT5Q3D/D0n5yE3mmxy13Qyya6qBYvqqyeWNwyotGM7hNNOix1v9lEMtH5Rd\nUT0gkThvJhtrV663bcAWCALmtQKBgQDjw2rYlMUp2TUIa2/E7904WOnSEG85d+nc\norhzthX8EWmPgw1Bbfo6NzH4HhebTw03j3NjZdW2a8TG/uEmZFWhK4eDvkx+rxAa\n6EwamS6cmQ4+vdep2Ac4QCSaTZj02YjHb06Be3gptvpFaFrotH2jnpXxggdiv8ul\n6x+ooCffQQKBgQCR3ykzGoOI6K/c75prELyR+7MEk/0TzZaAY1cSdq61GXBHLQKT\nd/VMgAN1vN51pu7DzGBnT/dRCvEgNvEjffjSZdqRmrAVdfN/y6LSeQ5RCfJgGXSV\nJoWVmMxhCNrxiX3h01Xgp/c9SYJ3VD54AzeR/dwg32/j/oEAsDraLciXGQKBgQDF\nMNc8k/DvfmJv27R06Ma6liA6AoiJVMxgfXD8nVUDW3/tBCVh1HmkFU1p54PArvxe\nchAQqoYQ3dUMBHeh6ZRJaYp2ATfxJlfnM99P1/eHFOxEXdBt996oUMBf53bZ5cyJ\n/lAVwnQSiZy8otCyUDHGivJ+mXkTgcIq8BoEwERFAQKBgQDmImBaFqoMSVihqHIf\nDa4WZqwM7ODqOx0JnBKrKO8UOc51J5e1vpwP/qRpNhUipoILvIWJzu4efZY7GN5C\nImF9sN3PP6Sy044fkVPyw4SYEisxbvp9tfw8Xmpj/pbmugkB2ut6lz5frmEBoJSN\n3osZlZTgx+pM3sO6ITV6U4ID2Q==\n-----END PRIVATE KEY-----\n",
+        "client_email": "dummy@developer.gserviceaccount.com",
+        "client_id": "dummy",
+        "auth_uri": format!("{oauth_server}/o/oauth2/auth"),
+        "token_uri": token_uri,
+        "auth_provider_x509_cert_url": format!("{oauth_server}/oauth2/v1/certs"),
+        "client_x509_cert_url": format!("{oauth_server}/robot/v1/metadata/x509/dummy"),
+    })
+}
+
+async fn mount_token(server: &MockServer) {
+    Mock::given(method("POST"))
+        .and(path(AUTH_TOKEN_PATH))
+        .respond_with(ResponseTemplate::new(200).set_body_json(fake_token()))
+        .mount(server)
+        .await;
+}
+
+async fn build_source(
+    server: &MockServer,
+    config: BigQuerySourceConfig,
+) -> (BigQuerySource, tempfile::NamedTempFile) {
+    let sa_json = dummy_service_account_json(&server.uri());
+    let sa_file = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(
+        sa_file.path(),
+        serde_json::to_string_pretty(&sa_json).unwrap(),
+    )
+    .unwrap();
+
+    let client = ClientBuilder::new()
+        .with_auth_base_url(format!("{}{AUTH_SCOPE_BASE}", server.uri()))
+        .with_v2_base_url(server.uri())
+        .build_from_service_account_key_file(sa_file.path().to_str().unwrap())
+        .await
+        .expect("build bigquery client against mock");
+
+    (BigQuerySource::from_parts(config, client), sa_file)
+}
+
+fn schema_two_cols() -> Value {
+    json!({
+        "fields": [
+            {"name": "id", "type": "INTEGER"},
+            {"name": "name", "type": "STRING"}
+        ]
+    })
+}
+
+fn rows(start: i64, count: i64) -> Vec<Value> {
+    (start..start + count)
+        .map(|i| json!({"f": [{"v": i.to_string()}, {"v": format!("name-{i}")}]}))
+        .collect()
+}
+
+fn default_config() -> BigQuerySourceConfig {
+    BigQuerySourceConfig::new(
+        PROJECT_ID,
+        BigQueryCredentials::ApplicationDefault,
+        "SELECT id, name FROM events",
+    )
+    .with_batch_size(10)
+}
+
+#[tokio::test]
+async fn fetch_all_returns_rows_when_first_response_is_complete() {
+    let server = MockServer::start().await;
+    mount_token(&server).await;
+    Mock::given(method("POST"))
+        .and(path(format!("/projects/{PROJECT_ID}/queries")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jobComplete": true,
+            "schema": schema_two_cols(),
+            "jobReference": {"projectId": PROJECT_ID, "jobId": "job-1"},
+            "rows": rows(0, 3),
+        })))
+        .mount(&server)
+        .await;
+
+    let (src, _f) = build_source(&server, default_config()).await;
+    let rows = src.fetch_all().await.unwrap();
+    assert_eq!(rows.len(), 3);
+    assert_eq!(rows[0], json!({"id": 0, "name": "name-0"}));
+    assert_eq!(rows[2], json!({"id": 2, "name": "name-2"}));
+}
+
+#[tokio::test]
+async fn fetch_all_paginates_via_page_token() {
+    let server = MockServer::start().await;
+    mount_token(&server).await;
+
+    // jobs.query: first page (rows 0..5) + pageToken.
+    Mock::given(method("POST"))
+        .and(path(format!("/projects/{PROJECT_ID}/queries")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jobComplete": true,
+            "schema": schema_two_cols(),
+            "jobReference": {"projectId": PROJECT_ID, "jobId": "job-page"},
+            "rows": rows(0, 5),
+            "pageToken": "tok-1",
+        })))
+        .mount(&server)
+        .await;
+
+    // getQueryResults: second page (rows 5..10) — final page (no further token).
+    Mock::given(method("GET"))
+        .and(path(format!("/projects/{PROJECT_ID}/queries/job-page")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jobComplete": true,
+            "schema": schema_two_cols(),
+            "rows": rows(5, 5),
+        })))
+        .mount(&server)
+        .await;
+
+    let (src, _f) = build_source(&server, default_config()).await;
+    let rows = src.fetch_all().await.unwrap();
+    assert_eq!(rows.len(), 10);
+    assert_eq!(rows[0]["id"], 0);
+    assert_eq!(rows[9]["id"], 9);
+}
+
+#[tokio::test]
+async fn stream_pages_chunks_by_batch_size() {
+    let server = MockServer::start().await;
+    mount_token(&server).await;
+    Mock::given(method("POST"))
+        .and(path(format!("/projects/{PROJECT_ID}/queries")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jobComplete": true,
+            "schema": schema_two_cols(),
+            "jobReference": {"projectId": PROJECT_ID, "jobId": "job-stream"},
+            "rows": rows(0, 13),
+        })))
+        .mount(&server)
+        .await;
+
+    // batch_size = 5 → 13 rows yield 3 pages of [5, 5, 3].
+    let (src, _f) = build_source(&server, default_config().with_batch_size(5)).await;
+    let ctx = HashMap::new();
+    let mut sizes = Vec::new();
+    let mut pages = src.stream_pages(&ctx, 0);
+    while let Some(page) = pages.next().await {
+        let page = page.unwrap();
+        assert!(page.bookmark.is_none());
+        sizes.push(page.records.len());
+    }
+    assert_eq!(sizes, vec![5, 5, 3]);
+}
+
+#[tokio::test]
+async fn stream_pages_batch_size_zero_emits_one_page() {
+    let server = MockServer::start().await;
+    mount_token(&server).await;
+    Mock::given(method("POST"))
+        .and(path(format!("/projects/{PROJECT_ID}/queries")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jobComplete": true,
+            "schema": schema_two_cols(),
+            "jobReference": {"projectId": PROJECT_ID, "jobId": "job-flat"},
+            "rows": rows(0, 7),
+        })))
+        .mount(&server)
+        .await;
+
+    let (src, _f) = build_source(&server, default_config().with_batch_size(0)).await;
+    let ctx = HashMap::new();
+    let pages: Vec<_> = src.stream_pages(&ctx, 0).collect().await;
+    assert_eq!(pages.len(), 1);
+    assert_eq!(pages[0].as_ref().unwrap().records.len(), 7);
+}
+
+#[tokio::test]
+async fn polls_until_job_complete_when_first_response_is_incomplete() {
+    let server = MockServer::start().await;
+    mount_token(&server).await;
+
+    // jobs.query returns jobComplete=false (statement still running).
+    Mock::given(method("POST"))
+        .and(path(format!("/projects/{PROJECT_ID}/queries")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jobComplete": false,
+            "jobReference": {"projectId": PROJECT_ID, "jobId": "job-poll"},
+        })))
+        .mount(&server)
+        .await;
+
+    // First poll: still not complete.
+    Mock::given(method("GET"))
+        .and(path(format!("/projects/{PROJECT_ID}/queries/job-poll")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jobComplete": false,
+        })))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    // Subsequent poll: complete with rows.
+    Mock::given(method("GET"))
+        .and(path(format!("/projects/{PROJECT_ID}/queries/job-poll")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jobComplete": true,
+            "schema": schema_two_cols(),
+            "rows": rows(0, 2),
+        })))
+        .mount(&server)
+        .await;
+
+    let (src, _f) = build_source(&server, default_config()).await;
+    let rows = src.fetch_all().await.unwrap();
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0]["id"], 0);
+}
+
+#[tokio::test]
+async fn submits_positional_bindings_for_params_and_context() {
+    let server = MockServer::start().await;
+    mount_token(&server).await;
+    Mock::given(method("POST"))
+        .and(path(format!("/projects/{PROJECT_ID}/queries")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jobComplete": true,
+            "schema": schema_two_cols(),
+            "jobReference": {"projectId": PROJECT_ID, "jobId": "job-binds"},
+            "rows": rows(0, 1),
+        })))
+        .mount(&server)
+        .await;
+
+    let cfg = default_config()
+        .with_params(vec![json!("us-east")])
+        .with_location("EU");
+    let mut cfg = cfg;
+    cfg.query = "SELECT * FROM events WHERE region = ? AND id > {parent.min_id}".into();
+    let (src, _f) = build_source(&server, cfg).await;
+
+    let mut ctx = HashMap::new();
+    ctx.insert("parent.min_id".to_string(), json!(100));
+    src.fetch_with_context(&ctx).await.unwrap();
+
+    let reqs = server.received_requests().await.unwrap();
+    let query_req = reqs
+        .iter()
+        .find(|r| r.url.path().ends_with("/queries"))
+        .expect("captured jobs.query request");
+    let body: Value = serde_json::from_slice(&query_req.body).unwrap();
+    assert_eq!(
+        body["query"],
+        "SELECT * FROM events WHERE region = ? AND id > ?"
+    );
+    assert_eq!(body["parameterMode"], "POSITIONAL");
+    let params = body["queryParameters"].as_array().unwrap();
+    assert_eq!(params.len(), 2);
+    assert_eq!(params[0]["parameterValue"]["value"], "us-east");
+    assert_eq!(params[1]["parameterValue"]["value"], "100");
+    assert_eq!(body["location"], "EU");
+}

--- a/crates/source/snowflake/Cargo.toml
+++ b/crates/source/snowflake/Cargo.toml
@@ -1,26 +1,25 @@
 [package]
-name = "faucet-sink-snowflake"
-version = "0.2.0"
+name = "faucet-source-snowflake"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "Snowflake sink connector for the faucet-stream ecosystem"
+description = "Snowflake query source connector for the faucet-stream ecosystem"
 
 [dependencies]
 faucet-core.workspace = true
 faucet-snowflake-common.workspace = true
 schemars.workspace = true
-serde.workspace = true
+serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 async-trait.workspace = true
+async-stream.workspace = true
 tracing.workspace = true
 tokio.workspace = true
 reqwest.workspace = true
-base64.workspace = true
-uuid.workspace = true
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros", "rt"] }
-serde_json.workspace = true
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
+futures.workspace = true
 wiremock = "0.6"

--- a/crates/source/snowflake/README.md
+++ b/crates/source/snowflake/README.md
@@ -1,0 +1,71 @@
+# faucet-source-snowflake
+
+Snowflake query source connector for the [`faucet-stream`](https://crates.io/crates/faucet-stream) ecosystem. Executes a SQL statement against Snowflake via the [SQL REST API](https://docs.snowflake.com/en/developer-guide/sql-api/intro) and streams rows back as `serde_json::Value` records.
+
+## Features
+
+- **JWT key-pair and OAuth bearer authentication** — `SnowflakeAuth` re-exported from [`faucet-snowflake-common`](https://crates.io/crates/faucet-snowflake-common); credentials are masked in `Debug` output.
+- **Server-side partitioning** — large result sets are paged via `GET /api/v2/statements/{handle}?partition=N`; one HTTP round-trip per partition, no client-side buffering of unrelated partitions.
+- **Configurable batching** — `batch_size` re-frames partitions into pages for `Source::stream_pages`; `batch_size = 0` opts out of re-chunking and emits the full result set as one page.
+- **Async / sync handling** — if Snowflake returns `202 Accepted` (statement still running), the source polls the handle until the result is ready.
+- **Bind parameters** — positional `params` from config are merged with `${parent.path}` tokens resolved from the matrix-row context. All bind values are sent as Snowflake `TEXT` binds; the server casts as needed.
+- **Type-aware row conversion** — `FIXED`, `REAL`, `BOOLEAN`, and `VARIANT`/`OBJECT`/`ARRAY` columns are parsed into native JSON shapes; everything else (timestamps, dates, binary) passes through as strings.
+
+## Configuration
+
+```yaml
+type: snowflake
+config:
+  account: xy12345.us-east-1
+  warehouse: COMPUTE_WH
+  database: ANALYTICS
+  schema: PUBLIC
+  role: ANALYST                     # optional
+  auth:
+    type: OAuth
+    token: ${env:SNOWFLAKE_OAUTH_TOKEN}
+  query: |
+    SELECT id, name, created_at
+    FROM events
+    WHERE created_at >= ?
+  params:
+    - "2026-01-01"
+  statement_timeout: 60             # seconds, defaults to 60
+  batch_size: 1000                  # default, or 0 to disable re-chunking
+```
+
+### Key-pair authentication
+
+```yaml
+auth:
+  type: KeyPair
+  user: SVC_LOAD
+  private_key_pem: ${file:/etc/secrets/snowflake.pem}
+```
+
+The source generates an RS256 JWT per request (1-hour expiry) signed with the configured PEM key and sends it in the `Authorization: Bearer ...` header along with `X-Snowflake-Authorization-Token-Type: KEYPAIR_JWT`.
+
+## Library use
+
+```rust
+use faucet_core::Source;
+use faucet_source_snowflake::{SnowflakeAuth, SnowflakeSource, SnowflakeSourceConfig};
+
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let cfg = SnowflakeSourceConfig::new(
+    "xy12345.us-east-1",
+    "COMPUTE_WH",
+    "ANALYTICS",
+    "PUBLIC",
+    SnowflakeAuth::OAuth { token: std::env::var("SNOWFLAKE_OAUTH_TOKEN")? },
+    "SELECT id, name FROM events LIMIT 10",
+);
+let rows = SnowflakeSource::new(cfg).fetch_all().await?;
+println!("got {} rows", rows.len());
+# Ok(())
+# }
+```
+
+## License
+
+MIT OR Apache-2.0

--- a/crates/source/snowflake/src/config.rs
+++ b/crates/source/snowflake/src/config.rs
@@ -1,0 +1,252 @@
+//! Snowflake source configuration.
+
+use faucet_core::DEFAULT_BATCH_SIZE;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::time::Duration;
+
+// Re-export the shared auth type so end-user imports remain stable.
+pub use faucet_snowflake_common::SnowflakeAuth;
+
+fn default_statement_timeout() -> Duration {
+    Duration::from_secs(60)
+}
+
+fn default_batch_size() -> usize {
+    DEFAULT_BATCH_SIZE
+}
+
+/// Configuration for the Snowflake query source.
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SnowflakeSourceConfig {
+    /// Snowflake account identifier (e.g. `"xy12345.us-east-1"`).
+    pub account: String,
+    /// Warehouse to use for the session.
+    pub warehouse: String,
+    /// Database name.
+    pub database: String,
+    /// Schema name.
+    pub schema: String,
+    /// Optional role to assume for the session.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+    /// Authentication credentials.
+    pub auth: SnowflakeAuth,
+    /// SQL statement to execute. May contain `${field.path}` placeholders that
+    /// are resolved against the parent-record context at runtime; resolved
+    /// values are sent as positional bind parameters appended after
+    /// [`params`](Self::params).
+    pub query: String,
+    /// Positional bind parameters for the query, applied in order before any
+    /// context-derived values. Snowflake's SQL REST API uses 1-based positional
+    /// binds in the JSON request body (see the `bindings` field in the
+    /// [SQL API docs](https://docs.snowflake.com/en/developer-guide/sql-api/submitting-requests#using-bind-variables-in-a-statement)).
+    #[serde(default)]
+    pub params: Vec<Value>,
+    /// Per-statement server-side timeout. Defaults to 60 seconds. Passed
+    /// through as the `timeout` field on the `POST /api/v2/statements` request
+    /// body. The HTTP-level timeout for each individual request is configured
+    /// separately by the source via the underlying `reqwest` client defaults.
+    #[serde(
+        default = "default_statement_timeout",
+        with = "faucet_core::config::duration_secs"
+    )]
+    #[schemars(with = "u64")]
+    pub statement_timeout: Duration,
+    /// Records per emitted [`StreamPage`](faucet_core::StreamPage).
+    ///
+    /// Snowflake's SQL REST API splits large result sets into *partitions* (one
+    /// chunk of rows per HTTP response). The source re-frames partitions into
+    /// `batch_size`-sized pages: rows accumulate in a buffer and are yielded as
+    /// soon as the buffer reaches `batch_size`. Defaults to
+    /// [`DEFAULT_BATCH_SIZE`].
+    ///
+    /// `batch_size = 0` is the **"no batching" sentinel**: the entire result
+    /// set is buffered and emitted in a single page. Useful for small lookup
+    /// tables, or for sinks (e.g. SQL `COPY`, BigQuery load jobs) that prefer
+    /// one large request to many small ones.
+    #[serde(default = "default_batch_size")]
+    pub batch_size: usize,
+}
+
+impl std::fmt::Debug for SnowflakeSourceConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SnowflakeSourceConfig")
+            .field("account", &self.account)
+            .field("warehouse", &self.warehouse)
+            .field("database", &self.database)
+            .field("schema", &self.schema)
+            .field("role", &self.role)
+            .field("auth", &self.auth)
+            .field("query", &self.query)
+            .field("params", &self.params)
+            .field("statement_timeout", &self.statement_timeout)
+            .field("batch_size", &self.batch_size)
+            .finish()
+    }
+}
+
+impl SnowflakeSourceConfig {
+    /// Create a new config with required fields and sensible defaults.
+    pub fn new(
+        account: impl Into<String>,
+        warehouse: impl Into<String>,
+        database: impl Into<String>,
+        schema: impl Into<String>,
+        auth: SnowflakeAuth,
+        query: impl Into<String>,
+    ) -> Self {
+        Self {
+            account: account.into(),
+            warehouse: warehouse.into(),
+            database: database.into(),
+            schema: schema.into(),
+            role: None,
+            auth,
+            query: query.into(),
+            params: Vec::new(),
+            statement_timeout: default_statement_timeout(),
+            batch_size: DEFAULT_BATCH_SIZE,
+        }
+    }
+
+    /// Set the session role.
+    pub fn with_role(mut self, role: impl Into<String>) -> Self {
+        self.role = Some(role.into());
+        self
+    }
+
+    /// Set positional bind parameters for the query.
+    pub fn with_params(mut self, params: Vec<Value>) -> Self {
+        self.params = params;
+        self
+    }
+
+    /// Set the per-statement server-side timeout.
+    pub fn with_statement_timeout(mut self, timeout: Duration) -> Self {
+        self.statement_timeout = timeout;
+        self
+    }
+
+    /// Set the records-per-page hint for [`Source::stream_pages`](faucet_core::Source::stream_pages).
+    ///
+    /// Pass `0` to opt out of batching — the entire result set is emitted in
+    /// a single page.
+    pub fn with_batch_size(mut self, batch_size: usize) -> Self {
+        self.batch_size = batch_size;
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn sample_config() -> SnowflakeSourceConfig {
+        SnowflakeSourceConfig::new(
+            "xy12345",
+            "COMPUTE_WH",
+            "MY_DB",
+            "PUBLIC",
+            SnowflakeAuth::OAuth { token: "t".into() },
+            "SELECT * FROM events",
+        )
+    }
+
+    #[test]
+    fn default_config() {
+        let cfg = sample_config();
+        assert_eq!(cfg.account, "xy12345");
+        assert_eq!(cfg.warehouse, "COMPUTE_WH");
+        assert_eq!(cfg.database, "MY_DB");
+        assert_eq!(cfg.schema, "PUBLIC");
+        assert!(cfg.role.is_none());
+        assert!(cfg.params.is_empty());
+        assert_eq!(cfg.statement_timeout, Duration::from_secs(60));
+        assert_eq!(cfg.batch_size, faucet_core::DEFAULT_BATCH_SIZE);
+    }
+
+    #[test]
+    fn builders_compose() {
+        let cfg = sample_config()
+            .with_role("ANALYST")
+            .with_params(vec![json!(42)])
+            .with_statement_timeout(Duration::from_secs(15))
+            .with_batch_size(500);
+        assert_eq!(cfg.role.as_deref(), Some("ANALYST"));
+        assert_eq!(cfg.params, vec![json!(42)]);
+        assert_eq!(cfg.statement_timeout, Duration::from_secs(15));
+        assert_eq!(cfg.batch_size, 500);
+    }
+
+    #[test]
+    fn batch_size_zero_is_accepted_as_no_batching_sentinel() {
+        let cfg = sample_config().with_batch_size(0);
+        assert_eq!(cfg.batch_size, 0);
+        assert!(faucet_core::validate_batch_size(cfg.batch_size).is_ok());
+    }
+
+    #[test]
+    fn batch_size_above_max_is_rejected_by_validate_batch_size() {
+        let cfg = sample_config().with_batch_size(faucet_core::MAX_BATCH_SIZE + 1);
+        assert!(faucet_core::validate_batch_size(cfg.batch_size).is_err());
+    }
+
+    #[test]
+    fn deserializes_minimal_json() {
+        let json = r#"{
+            "account": "xy12345",
+            "warehouse": "WH",
+            "database": "DB",
+            "schema": "PUBLIC",
+            "auth": {"type": "OAuth", "token": "t"},
+            "query": "SELECT 1"
+        }"#;
+        let cfg: SnowflakeSourceConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.batch_size, faucet_core::DEFAULT_BATCH_SIZE);
+        assert_eq!(cfg.statement_timeout, Duration::from_secs(60));
+        assert!(cfg.role.is_none());
+        assert!(cfg.params.is_empty());
+    }
+
+    #[test]
+    fn deserializes_all_optional_fields() {
+        let json = r#"{
+            "account": "xy12345",
+            "warehouse": "WH",
+            "database": "DB",
+            "schema": "PUBLIC",
+            "role": "ANALYST",
+            "auth": {"type": "OAuth", "token": "t"},
+            "query": "SELECT $1",
+            "params": [42],
+            "statement_timeout": 15,
+            "batch_size": 250
+        }"#;
+        let cfg: SnowflakeSourceConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.role.as_deref(), Some("ANALYST"));
+        assert_eq!(cfg.params, vec![json!(42)]);
+        assert_eq!(cfg.statement_timeout, Duration::from_secs(15));
+        assert_eq!(cfg.batch_size, 250);
+    }
+
+    #[test]
+    fn debug_masks_auth_secrets() {
+        let cfg = SnowflakeSourceConfig::new(
+            "acct",
+            "wh",
+            "db",
+            "schema",
+            SnowflakeAuth::KeyPair {
+                user: "alice".into(),
+                private_key_pem: "PRIVATE-KEY-DATA".into(),
+            },
+            "SELECT 1",
+        );
+        let dbg = format!("{cfg:?}");
+        assert!(dbg.contains("***"));
+        assert!(!dbg.contains("PRIVATE-KEY-DATA"));
+    }
+}

--- a/crates/source/snowflake/src/convert.rs
+++ b/crates/source/snowflake/src/convert.rs
@@ -1,0 +1,214 @@
+//! Type-aware conversion from Snowflake SQL REST API rows to JSON objects.
+//!
+//! The Snowflake SQL REST API returns every cell as a string, regardless of
+//! its column type, and ships a schema (`resultSetMetaData.rowType`) alongside
+//! the rows. This module pairs each cell with its column metadata and
+//! produces a `serde_json::Value::Object` per row.
+//!
+//! Type coverage (Snowflake's `type` field is lowercase in the JSON v2 format):
+//!
+//! | Snowflake type          | JSON output                              |
+//! |-------------------------|------------------------------------------|
+//! | `fixed`                 | `Number` (i64 if it fits, else f64)      |
+//! | `real`                  | `Number` (f64)                           |
+//! | `boolean`               | `Bool`                                   |
+//! | `text` / `binary`       | `String`                                 |
+//! | `date` / `time` / `timestamp_*` | `String` (ISO/Unix-seconds as-is) |
+//! | `variant` / `object` / `array` | parsed JSON value (falls back to `String`) |
+//! | anything else           | `String` (raw cell)                      |
+//!
+//! `null` cells map to `Value::Null` regardless of declared type.
+
+use serde::Deserialize;
+use serde_json::{Map, Value};
+
+/// One entry in `resultSetMetaData.rowType`. Only the fields we actually use
+/// are deserialised; everything else is ignored.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ColumnMeta {
+    /// Column name as Snowflake reports it. Typically uppercase for
+    /// unquoted identifiers; we keep the casing untouched.
+    pub name: String,
+    /// Low-level Snowflake type — lowercased identifiers like `"fixed"`,
+    /// `"text"`, `"boolean"`, `"variant"`, `"timestamp_ntz"`. See the
+    /// Snowflake [JSON v2 result format
+    /// docs](https://docs.snowflake.com/en/developer-guide/sql-api/handling-responses).
+    #[serde(rename = "type")]
+    pub ty: String,
+}
+
+/// Build a JSON object out of one Snowflake row (an array of string cells).
+///
+/// `row` is expected to have the same length as `columns`. If the row is
+/// shorter, missing trailing cells are treated as `null`; if it is longer,
+/// the extras are silently ignored.
+pub fn row_to_json(row: &[Value], columns: &[ColumnMeta]) -> Value {
+    let mut obj = Map::with_capacity(columns.len());
+    for (i, col) in columns.iter().enumerate() {
+        let cell = row.get(i);
+        obj.insert(col.name.clone(), cell_to_json(cell, &col.ty));
+    }
+    Value::Object(obj)
+}
+
+/// Convert a single Snowflake cell to a typed `serde_json::Value`.
+fn cell_to_json(cell: Option<&Value>, ty: &str) -> Value {
+    let Some(cell) = cell else {
+        return Value::Null;
+    };
+    // SQL REST API ships `null` as a JSON null in the array.
+    if cell.is_null() {
+        return Value::Null;
+    }
+    // Pre-typed values (already a JSON number / bool / object) are passed
+    // through verbatim. This is defensive — Snowflake's documented JSON v2
+    // format always wraps cells as strings, but tolerating already-typed
+    // values keeps the converter robust against future format tweaks.
+    let s = match cell {
+        Value::String(s) => s.as_str(),
+        other => return other.clone(),
+    };
+
+    match ty.to_ascii_lowercase().as_str() {
+        "fixed" => parse_number(s),
+        "real" => parse_real(s),
+        "boolean" => parse_bool(s),
+        "variant" | "object" | "array" => {
+            serde_json::from_str(s).unwrap_or_else(|_| Value::String(s.to_owned()))
+        }
+        _ => Value::String(s.to_owned()),
+    }
+}
+
+/// Parse an integer-valued column (`FIXED`/`NUMBER` with scale 0 ships an
+/// integer literal here; non-zero-scale columns ship a decimal string and
+/// fall back to `f64`).
+fn parse_number(s: &str) -> Value {
+    if let Ok(i) = s.parse::<i64>() {
+        return Value::Number(i.into());
+    }
+    parse_real(s)
+}
+
+/// Parse a floating-point column. Non-finite values (`Infinity`, `NaN`) are
+/// not representable in JSON and fall back to a string for round-trip safety.
+fn parse_real(s: &str) -> Value {
+    match s.parse::<f64>() {
+        Ok(f) => serde_json::Number::from_f64(f)
+            .map(Value::Number)
+            .unwrap_or_else(|| Value::String(s.to_owned())),
+        Err(_) => Value::String(s.to_owned()),
+    }
+}
+
+/// Parse a boolean column. Snowflake ships booleans as `"true"`/`"false"`
+/// (lowercase) in the JSON v2 format, but we accept the canonical Snowflake
+/// SQL forms (`"TRUE"`/`"FALSE"`, `"1"`/`"0"`) too.
+fn parse_bool(s: &str) -> Value {
+    match s {
+        "true" | "TRUE" | "1" => Value::Bool(true),
+        "false" | "FALSE" | "0" => Value::Bool(false),
+        other => Value::String(other.to_owned()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn col(name: &str, ty: &str) -> ColumnMeta {
+        ColumnMeta {
+            name: name.into(),
+            ty: ty.into(),
+        }
+    }
+
+    #[test]
+    fn fixed_parses_as_integer() {
+        let row = [json!("42")];
+        let cols = [col("ID", "fixed")];
+        assert_eq!(row_to_json(&row, &cols), json!({"ID": 42}));
+    }
+
+    #[test]
+    fn fixed_decimal_falls_back_to_float() {
+        let row = [json!("2.5")];
+        let cols = [col("RATIO", "fixed")];
+        assert_eq!(row_to_json(&row, &cols), json!({"RATIO": 2.5}));
+    }
+
+    #[test]
+    fn real_parses_as_float() {
+        let row = [json!("0.5")];
+        let cols = [col("X", "real")];
+        assert_eq!(row_to_json(&row, &cols), json!({"X": 0.5}));
+    }
+
+    #[test]
+    fn boolean_parses_lowercase() {
+        let row = [json!("true"), json!("false")];
+        let cols = [col("A", "boolean"), col("B", "boolean")];
+        assert_eq!(row_to_json(&row, &cols), json!({"A": true, "B": false}));
+    }
+
+    #[test]
+    fn variant_parses_inner_json() {
+        let row = [json!(r#"{"k":1}"#)];
+        let cols = [col("DATA", "variant")];
+        assert_eq!(row_to_json(&row, &cols), json!({"DATA": {"k": 1}}));
+    }
+
+    #[test]
+    fn variant_falls_back_to_string_on_invalid_json() {
+        let row = [json!("not-json")];
+        let cols = [col("DATA", "variant")];
+        assert_eq!(row_to_json(&row, &cols), json!({"DATA": "not-json"}));
+    }
+
+    #[test]
+    fn text_passes_through() {
+        let row = [json!("hello")];
+        let cols = [col("NAME", "text")];
+        assert_eq!(row_to_json(&row, &cols), json!({"NAME": "hello"}));
+    }
+
+    #[test]
+    fn null_cell_maps_to_null() {
+        let row = [json!(null)];
+        let cols = [col("X", "fixed")];
+        assert_eq!(row_to_json(&row, &cols), json!({"X": null}));
+    }
+
+    #[test]
+    fn missing_trailing_cell_maps_to_null() {
+        let row: [Value; 0] = [];
+        let cols = [col("X", "text")];
+        assert_eq!(row_to_json(&row, &cols), json!({"X": null}));
+    }
+
+    #[test]
+    fn timestamp_passes_through_as_string() {
+        let row = [json!("1700000000.000000000")];
+        let cols = [col("TS", "timestamp_ntz")];
+        assert_eq!(
+            row_to_json(&row, &cols),
+            json!({"TS": "1700000000.000000000"})
+        );
+    }
+
+    #[test]
+    fn unknown_type_passes_through_as_string() {
+        let row = [json!("0xDEADBEEF")];
+        let cols = [col("BLOB", "binary")];
+        assert_eq!(row_to_json(&row, &cols), json!({"BLOB": "0xDEADBEEF"}));
+    }
+
+    #[test]
+    fn non_finite_real_falls_back_to_string() {
+        let row = [json!("NaN")];
+        let cols = [col("X", "real")];
+        // NaN is not representable in JSON; round-trip-safe fallback.
+        assert_eq!(row_to_json(&row, &cols), json!({"X": "NaN"}));
+    }
+}

--- a/crates/source/snowflake/src/lib.rs
+++ b/crates/source/snowflake/src/lib.rs
@@ -1,0 +1,17 @@
+//! # faucet-source-snowflake
+//!
+//! Snowflake query source connector for the faucet-stream ecosystem.
+//!
+//! Executes a SQL statement against Snowflake via the
+//! [SQL REST API](https://docs.snowflake.com/en/developer-guide/sql-api/intro)
+//! and streams the result set as `serde_json::Value` records, one JSON
+//! object per row keyed by lowercased column name.
+
+pub mod config;
+pub mod convert;
+pub mod stream;
+
+pub use faucet_core::{FaucetError, Source};
+
+pub use config::{SnowflakeAuth, SnowflakeSourceConfig};
+pub use stream::SnowflakeSource;

--- a/crates/source/snowflake/src/stream.rs
+++ b/crates/source/snowflake/src/stream.rs
@@ -1,0 +1,599 @@
+//! Snowflake SQL REST API source.
+//!
+//! Executes the configured SQL statement against
+//! [`POST /api/v2/statements`](https://docs.snowflake.com/en/developer-guide/sql-api/submitting-requests)
+//! and streams the rows back as JSON. Large result sets are split server-side
+//! into partitions; the source fetches each subsequent partition via
+//! `GET /api/v2/statements/{handle}?partition={n}` and re-frames the rows
+//! into pages of [`SnowflakeSourceConfig::batch_size`].
+
+use crate::config::SnowflakeSourceConfig;
+use crate::convert::{ColumnMeta, row_to_json};
+use async_trait::async_trait;
+use faucet_core::util::substitute_context_bind_params;
+use faucet_core::{FaucetError, Stream, StreamPage};
+use faucet_snowflake_common::{authorization_header, snowflake_token_type};
+use reqwest::Client;
+use serde::Deserialize;
+use serde_json::{Map, Value, json};
+use std::collections::HashMap;
+use std::pin::Pin;
+use std::time::Duration;
+
+/// Snowflake API response envelope. Only the fields we need are pulled out;
+/// everything else (`createdOn`, `numRows`, `databaseProvider`, ...) is
+/// ignored.
+#[derive(Debug, Deserialize)]
+struct StatementResponse {
+    /// Snowflake SQL state code. `"090001"` means "statement executed
+    /// successfully"; anything else is an error.
+    #[serde(default)]
+    code: Option<String>,
+    /// Human-readable message paired with `code`.
+    #[serde(default)]
+    message: Option<String>,
+    /// Opaque handle for fetching additional partitions and re-polling
+    /// asynchronous results.
+    #[serde(rename = "statementHandle", default)]
+    statement_handle: Option<String>,
+    /// Result schema and partition manifest. Only present on the first
+    /// (synchronous) response or on the resync GET after async submission;
+    /// follow-up partition fetches omit it.
+    #[serde(rename = "resultSetMetaData", default)]
+    result_set_metadata: Option<ResultSetMetadata>,
+    /// One element per row, each a JSON array of stringified cells.
+    #[serde(default)]
+    data: Option<Vec<Vec<Value>>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ResultSetMetadata {
+    /// Per-column metadata. Required to map cell arrays back to JSON keys.
+    #[serde(rename = "rowType", default)]
+    row_type: Vec<ColumnMeta>,
+    /// One entry per partition. The first entry covers the rows in the
+    /// initial response; subsequent entries must be fetched individually.
+    #[serde(rename = "partitionInfo", default)]
+    partition_info: Vec<PartitionInfo>,
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)] // `rowCount` is informational; we drain partitions until empty.
+struct PartitionInfo {
+    #[serde(rename = "rowCount", default)]
+    row_count: u64,
+}
+
+/// A source that streams the rows of a Snowflake SQL statement via the SQL
+/// REST API.
+pub struct SnowflakeSource {
+    config: SnowflakeSourceConfig,
+    client: Client,
+    /// Optional explicit endpoint override (full base URL up to but not
+    /// including `/api/v2/statements`). When `None`, derived from
+    /// `config.account`. Intended for wiremock tests and private-link
+    /// deployments.
+    endpoint_base: Option<String>,
+}
+
+impl SnowflakeSource {
+    /// Create a new Snowflake source. Initialises the underlying HTTP
+    /// client; does not perform any I/O.
+    pub fn new(config: SnowflakeSourceConfig) -> Self {
+        Self {
+            config,
+            client: Client::new(),
+            endpoint_base: None,
+        }
+    }
+
+    /// Override the base URL used to reach the SQL REST API.
+    ///
+    /// Pass `http://127.0.0.1:1234` to point the source at a mock server —
+    /// the source will issue requests to `{base}/api/v2/statements` and
+    /// `{base}/api/v2/statements/{handle}?partition=N`. Useful for tests
+    /// and proxy/private-link setups.
+    pub fn with_endpoint_base(mut self, base: impl Into<String>) -> Self {
+        self.endpoint_base = Some(base.into());
+        self
+    }
+
+    fn base_url(&self) -> String {
+        match &self.endpoint_base {
+            Some(b) => b.trim_end_matches('/').to_owned(),
+            None => format!("https://{}.snowflakecomputing.com", self.config.account),
+        }
+    }
+
+    fn statements_url(&self) -> String {
+        format!("{}/api/v2/statements", self.base_url())
+    }
+
+    fn partition_url(&self, handle: &str, partition: usize) -> String {
+        format!(
+            "{}/api/v2/statements/{}?partition={}",
+            self.base_url(),
+            handle,
+            partition
+        )
+    }
+
+    /// Build the JSON body for `POST /api/v2/statements`.
+    ///
+    /// Bindings are sent as 1-based positional strings under the documented
+    /// `bindings: {"1": {"type": "TEXT", "value": "..."}}` shape. Every
+    /// value is stringified and tagged `TEXT`; Snowflake casts implicitly on
+    /// the server side. Non-string values (numbers, bools) are converted
+    /// with `Value::to_string`, which renders JSON syntax — sufficient for
+    /// the typical numeric / boolean cases used in matrix interpolation.
+    fn build_request_body(&self, bindings: &[Value]) -> Value {
+        let mut body = json!({
+            "statement": self.config.query,
+            "timeout": self.config.statement_timeout.as_secs(),
+            "database": self.config.database,
+            "schema": self.config.schema,
+            "warehouse": self.config.warehouse,
+        });
+
+        if let Some(role) = &self.config.role {
+            body["role"] = json!(role);
+        }
+
+        if !bindings.is_empty() {
+            let mut map = Map::with_capacity(bindings.len());
+            for (i, v) in bindings.iter().enumerate() {
+                let stringified = match v {
+                    Value::String(s) => s.clone(),
+                    Value::Null => continue, // Snowflake binds NULL via SQL literal; skip.
+                    other => other.to_string(),
+                };
+                map.insert(
+                    (i + 1).to_string(),
+                    json!({"type": "TEXT", "value": stringified}),
+                );
+            }
+            body["bindings"] = Value::Object(map);
+        }
+
+        body
+    }
+
+    /// Resolve the final SQL statement and ordered bind values for a given
+    /// parent-record context.
+    ///
+    /// `{key}` tokens whose key matches `context` are replaced with `?`
+    /// markers (Snowflake's positional binding form) and their values are
+    /// appended to the returned `Vec` after any [`config.params`](SnowflakeSourceConfig::params).
+    fn resolve_query(&self, context: &HashMap<String, Value>) -> (String, Vec<Value>) {
+        let mut bindings = self.config.params.clone();
+        let (rewritten, context_values) = if context.is_empty() {
+            (self.config.query.clone(), Vec::new())
+        } else {
+            substitute_context_bind_params(&self.config.query, context, bindings.len() + 1, |_| {
+                "?".to_string()
+            })
+        };
+        bindings.extend(context_values);
+        (rewritten, bindings)
+    }
+
+    /// Issue the initial `POST /api/v2/statements` request.
+    async fn submit_statement(
+        &self,
+        context: &HashMap<String, Value>,
+    ) -> Result<StatementResponse, FaucetError> {
+        let (query, bindings) = self.resolve_query(context);
+        let mut body = self.build_request_body(&bindings);
+        body["statement"] = Value::String(query);
+
+        let url = self.statements_url();
+        let auth = authorization_header(&self.config.auth, &self.config.account)?;
+        let token_type = snowflake_token_type(&self.config.auth);
+
+        let resp = self
+            .client
+            .post(&url)
+            .header("Authorization", &auth)
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json")
+            .header("X-Snowflake-Authorization-Token-Type", token_type)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| FaucetError::Source(format!("Snowflake request failed: {e}")))?;
+
+        let status = resp.status();
+        let async_pending = status.as_u16() == 202;
+        if !status.is_success() && !async_pending {
+            let text = resp.text().await.unwrap_or_default();
+            return Err(FaucetError::Source(format!(
+                "Snowflake SQL API returned HTTP {status}: {text}"
+            )));
+        }
+
+        let parsed: StatementResponse = resp
+            .json()
+            .await
+            .map_err(|e| FaucetError::Source(format!("failed to parse Snowflake response: {e}")))?;
+
+        if async_pending {
+            // Statement still running on the server. Poll until it completes.
+            let handle = parsed.statement_handle.clone().ok_or_else(|| {
+                FaucetError::Source(
+                    "Snowflake returned 202 without a statementHandle to poll".into(),
+                )
+            })?;
+            self.poll_until_ready(&handle, &auth, token_type).await
+        } else {
+            check_code(&parsed)?;
+            Ok(parsed)
+        }
+    }
+
+    /// Poll the same handle as a partition-less GET until the response is
+    /// 200 + `code: "090001"`. Used after a 202 from the initial POST.
+    async fn poll_until_ready(
+        &self,
+        handle: &str,
+        auth: &str,
+        token_type: &'static str,
+    ) -> Result<StatementResponse, FaucetError> {
+        let url = format!("{}/api/v2/statements/{}", self.base_url(), handle);
+        loop {
+            let resp = self
+                .client
+                .get(&url)
+                .header("Authorization", auth)
+                .header("Accept", "application/json")
+                .header("X-Snowflake-Authorization-Token-Type", token_type)
+                .send()
+                .await
+                .map_err(|e| FaucetError::Source(format!("Snowflake poll request failed: {e}")))?;
+
+            let status = resp.status();
+            if status.as_u16() == 202 {
+                tokio::time::sleep(Duration::from_millis(500)).await;
+                continue;
+            }
+            if !status.is_success() {
+                let text = resp.text().await.unwrap_or_default();
+                return Err(FaucetError::Source(format!(
+                    "Snowflake poll returned HTTP {status}: {text}"
+                )));
+            }
+            let parsed: StatementResponse = resp.json().await.map_err(|e| {
+                FaucetError::Source(format!("failed to parse Snowflake poll response: {e}"))
+            })?;
+            check_code(&parsed)?;
+            return Ok(parsed);
+        }
+    }
+
+    /// Fetch one additional partition's worth of rows.
+    async fn fetch_partition(
+        &self,
+        handle: &str,
+        partition: usize,
+        auth: &str,
+        token_type: &'static str,
+    ) -> Result<Vec<Vec<Value>>, FaucetError> {
+        let url = self.partition_url(handle, partition);
+        let resp = self
+            .client
+            .get(&url)
+            .header("Authorization", auth)
+            .header("Accept", "application/json")
+            .header("X-Snowflake-Authorization-Token-Type", token_type)
+            .send()
+            .await
+            .map_err(|e| {
+                FaucetError::Source(format!(
+                    "Snowflake partition fetch failed (partition {partition}): {e}"
+                ))
+            })?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let text = resp.text().await.unwrap_or_default();
+            return Err(FaucetError::Source(format!(
+                "Snowflake partition fetch returned HTTP {status} (partition {partition}): {text}"
+            )));
+        }
+
+        let parsed: StatementResponse = resp.json().await.map_err(|e| {
+            FaucetError::Source(format!(
+                "failed to parse Snowflake partition response (partition {partition}): {e}"
+            ))
+        })?;
+        check_code(&parsed)?;
+        Ok(parsed.data.unwrap_or_default())
+    }
+}
+
+/// Validate `code: "090001"` (statement executed successfully). Any other
+/// code surfaces as `FaucetError::Source` carrying Snowflake's message.
+fn check_code(resp: &StatementResponse) -> Result<(), FaucetError> {
+    if let Some(code) = &resp.code
+        && code != "090001"
+    {
+        return Err(FaucetError::Source(format!(
+            "Snowflake error {}: {}",
+            code,
+            resp.message.clone().unwrap_or_default()
+        )));
+    }
+    Ok(())
+}
+
+#[async_trait]
+impl faucet_core::Source for SnowflakeSource {
+    fn connector_name(&self) -> &'static str {
+        "snowflake"
+    }
+
+    fn config_schema(&self) -> Value {
+        serde_json::to_value(faucet_core::schema_for!(SnowflakeSourceConfig))
+            .expect("schema serialization")
+    }
+
+    async fn fetch_with_context(
+        &self,
+        context: &HashMap<String, Value>,
+    ) -> Result<Vec<Value>, FaucetError> {
+        let initial = self.submit_statement(context).await?;
+        let columns = initial
+            .result_set_metadata
+            .as_ref()
+            .map(|m| m.row_type.clone())
+            .unwrap_or_default();
+
+        if columns.is_empty() {
+            tracing::info!(
+                rows = 0,
+                query = %self.config.query,
+                "Snowflake source fetch returned no schema (likely no rows)",
+            );
+            return Ok(Vec::new());
+        }
+
+        let mut rows: Vec<Value> = initial
+            .data
+            .unwrap_or_default()
+            .iter()
+            .map(|r| row_to_json(r, &columns))
+            .collect();
+
+        let partition_count = initial
+            .result_set_metadata
+            .as_ref()
+            .map(|m| m.partition_info.len())
+            .unwrap_or(0);
+
+        if partition_count > 1 {
+            let handle = initial.statement_handle.ok_or_else(|| {
+                FaucetError::Source(
+                    "Snowflake reported >1 partition without a statementHandle to fetch them"
+                        .into(),
+                )
+            })?;
+            let auth = authorization_header(&self.config.auth, &self.config.account)?;
+            let token_type = snowflake_token_type(&self.config.auth);
+
+            for i in 1..partition_count {
+                let raw = self.fetch_partition(&handle, i, &auth, token_type).await?;
+                for r in raw {
+                    rows.push(row_to_json(&r, &columns));
+                }
+            }
+        }
+
+        tracing::info!(
+            rows = rows.len(),
+            query = %self.config.query,
+            "Snowflake source fetch complete",
+        );
+        Ok(rows)
+    }
+
+    /// Stream rows partition-by-partition without buffering the full result
+    /// set. Rows are accumulated into a per-page buffer of
+    /// [`SnowflakeSourceConfig::batch_size`] entries and yielded as soon as
+    /// the buffer is full.
+    ///
+    /// The trait-level `batch_size` argument is ignored in favour of the
+    /// config field — the config is the user-facing knob the README
+    /// documents, and routing the pipeline-supplied hint through it would
+    /// silently override an explicit config value.
+    ///
+    /// `batch_size = 0` drains every partition and emits the full result
+    /// set as a single page. The source has no incremental-replication mode
+    /// today, so every emitted page carries `bookmark: None`.
+    fn stream_pages<'a>(
+        &'a self,
+        context: &'a HashMap<String, Value>,
+        _batch_size: usize,
+    ) -> Pin<Box<dyn Stream<Item = Result<StreamPage, FaucetError>> + Send + 'a>> {
+        let batch_size = self.config.batch_size;
+
+        Box::pin(async_stream::try_stream! {
+            let initial = self.submit_statement(context).await?;
+            let columns = initial
+                .result_set_metadata
+                .as_ref()
+                .map(|m| m.row_type.clone())
+                .unwrap_or_default();
+
+            if columns.is_empty() {
+                // Either the query returned no schema or an empty result set
+                // with no metadata. Either way nothing to emit.
+                return;
+            }
+
+            let partition_count = initial
+                .result_set_metadata
+                .as_ref()
+                .map(|m| m.partition_info.len())
+                .unwrap_or(1);
+
+            let chunk = if batch_size == 0 { usize::MAX } else { batch_size };
+            let initial_capacity = if batch_size == 0 {
+                // Sum the row counts across partitions for a tight pre-allocation.
+                initial
+                    .result_set_metadata
+                    .as_ref()
+                    .map(|m| m.partition_info.iter().map(|p| p.row_count as usize).sum())
+                    .unwrap_or(1024)
+            } else {
+                batch_size
+            };
+
+            let mut buffer: Vec<Value> = Vec::with_capacity(initial_capacity);
+            let mut total = 0usize;
+
+            // First partition: rows come back in the POST response itself.
+            for raw in initial.data.unwrap_or_default() {
+                buffer.push(row_to_json(&raw, &columns));
+                if buffer.len() >= chunk {
+                    let page = std::mem::replace(&mut buffer, Vec::with_capacity(initial_capacity));
+                    total += page.len();
+                    yield StreamPage { records: page, bookmark: None };
+                }
+            }
+
+            // Remaining partitions: one GET each.
+            if partition_count > 1 {
+                let handle = initial.statement_handle.ok_or_else(|| {
+                    FaucetError::Source(
+                        "Snowflake reported >1 partition without a statementHandle".into(),
+                    )
+                })?;
+                let auth = authorization_header(&self.config.auth, &self.config.account)?;
+                let token_type = snowflake_token_type(&self.config.auth);
+
+                for i in 1..partition_count {
+                    let raw = self.fetch_partition(&handle, i, &auth, token_type).await?;
+                    for r in raw {
+                        buffer.push(row_to_json(&r, &columns));
+                        if buffer.len() >= chunk {
+                            let page = std::mem::replace(
+                                &mut buffer,
+                                Vec::with_capacity(initial_capacity),
+                            );
+                            total += page.len();
+                            yield StreamPage { records: page, bookmark: None };
+                        }
+                    }
+                }
+            }
+
+            if !buffer.is_empty() {
+                total += buffer.len();
+                yield StreamPage { records: buffer, bookmark: None };
+            }
+
+            tracing::info!(
+                rows = total,
+                batch_size,
+                query = %self.config.query,
+                "Snowflake source stream complete",
+            );
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::SnowflakeAuth;
+
+    fn cfg() -> SnowflakeSourceConfig {
+        SnowflakeSourceConfig::new(
+            "xy12345.us-east-1",
+            "WH",
+            "DB",
+            "PUBLIC",
+            SnowflakeAuth::OAuth { token: "t".into() },
+            "SELECT 1",
+        )
+    }
+
+    #[test]
+    fn statements_url_uses_account_when_no_override() {
+        let src = SnowflakeSource::new(cfg());
+        assert_eq!(
+            src.statements_url(),
+            "https://xy12345.us-east-1.snowflakecomputing.com/api/v2/statements"
+        );
+    }
+
+    #[test]
+    fn statements_url_uses_endpoint_override() {
+        let src = SnowflakeSource::new(cfg()).with_endpoint_base("http://127.0.0.1:9999");
+        assert_eq!(
+            src.statements_url(),
+            "http://127.0.0.1:9999/api/v2/statements"
+        );
+    }
+
+    #[test]
+    fn partition_url_includes_handle_and_index() {
+        let src = SnowflakeSource::new(cfg()).with_endpoint_base("http://srv");
+        assert_eq!(
+            src.partition_url("abc-123", 2),
+            "http://srv/api/v2/statements/abc-123?partition=2"
+        );
+    }
+
+    #[test]
+    fn build_request_body_minimal() {
+        let src = SnowflakeSource::new(cfg());
+        let body = src.build_request_body(&[]);
+        assert_eq!(body["statement"], "SELECT 1");
+        assert_eq!(body["timeout"], 60);
+        assert_eq!(body["database"], "DB");
+        assert_eq!(body["schema"], "PUBLIC");
+        assert_eq!(body["warehouse"], "WH");
+        assert!(body.get("bindings").is_none());
+        assert!(body.get("role").is_none());
+    }
+
+    #[test]
+    fn build_request_body_includes_role_when_set() {
+        let mut c = cfg();
+        c.role = Some("ANALYST".into());
+        let src = SnowflakeSource::new(c);
+        let body = src.build_request_body(&[]);
+        assert_eq!(body["role"], "ANALYST");
+    }
+
+    #[test]
+    fn build_request_body_serialises_bindings_as_text() {
+        let src = SnowflakeSource::new(cfg());
+        let body = src.build_request_body(&[Value::String("alice".into()), json!(42), json!(true)]);
+        let b = &body["bindings"];
+        assert_eq!(b["1"]["type"], "TEXT");
+        assert_eq!(b["1"]["value"], "alice");
+        assert_eq!(b["2"]["value"], "42");
+        assert_eq!(b["3"]["value"], "true");
+    }
+
+    #[test]
+    fn resolve_query_with_no_context_returns_input() {
+        let src = SnowflakeSource::new(cfg().with_params(vec![json!(7)]));
+        let (q, binds) = src.resolve_query(&HashMap::new());
+        assert_eq!(q, "SELECT 1");
+        assert_eq!(binds, vec![json!(7)]);
+    }
+
+    #[test]
+    fn resolve_query_substitutes_context_with_question_mark_markers() {
+        let mut c = cfg();
+        c.query = "SELECT * FROM t WHERE id = {parent.id}".into();
+        let src = SnowflakeSource::new(c);
+        let mut ctx = HashMap::new();
+        ctx.insert("parent.id".to_string(), json!(7));
+        let (q, binds) = src.resolve_query(&ctx);
+        assert_eq!(q, "SELECT * FROM t WHERE id = ?");
+        assert_eq!(binds, vec![json!(7)]);
+    }
+}

--- a/crates/source/snowflake/tests/snowflake_source.rs
+++ b/crates/source/snowflake/tests/snowflake_source.rs
@@ -1,0 +1,284 @@
+//! Integration tests for the Snowflake source.
+//!
+//! Drives [`SnowflakeSource`] against a wiremock server mocking the SQL REST
+//! API. Verifies that the source:
+//!
+//! - sends the right auth headers and request body shape,
+//! - paginates across all `partitionInfo` partitions,
+//! - re-frames partitions into pages of `batch_size`,
+//! - surfaces Snowflake error codes as `FaucetError::Source`.
+
+use std::collections::HashMap;
+
+use faucet_core::Source;
+use faucet_source_snowflake::{SnowflakeAuth, SnowflakeSource, SnowflakeSourceConfig};
+use futures::StreamExt;
+use serde_json::{Value, json};
+use wiremock::matchers::{header, method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn cfg() -> SnowflakeSourceConfig {
+    SnowflakeSourceConfig::new(
+        "xy12345",
+        "WH",
+        "DB",
+        "PUBLIC",
+        SnowflakeAuth::OAuth { token: "t".into() },
+        "SELECT id, name, active FROM events",
+    )
+    .with_role("ANALYST")
+    .with_batch_size(10)
+    .with_statement_timeout(std::time::Duration::from_secs(5))
+}
+
+fn build_source(cfg: SnowflakeSourceConfig, server: &MockServer) -> SnowflakeSource {
+    SnowflakeSource::new(cfg).with_endpoint_base(server.uri())
+}
+
+fn metadata(num_partitions: usize) -> Value {
+    let partition_info: Vec<Value> = (0..num_partitions)
+        .map(|_| json!({"rowCount": 5}))
+        .collect();
+    json!({
+        "rowType": [
+            {"name": "ID", "type": "fixed"},
+            {"name": "NAME", "type": "text"},
+            {"name": "ACTIVE", "type": "boolean"}
+        ],
+        "partitionInfo": partition_info,
+        "format": "jsonv2",
+        "numRows": (num_partitions * 5) as u64,
+    })
+}
+
+fn rows_for_partition(p: usize) -> Vec<Vec<Value>> {
+    (0..5)
+        .map(|i| {
+            let row_id = p * 5 + i;
+            vec![
+                json!(row_id.to_string()),
+                json!(format!("name-{row_id}")),
+                json!(if row_id.is_multiple_of(2) {
+                    "true"
+                } else {
+                    "false"
+                }),
+            ]
+        })
+        .collect()
+}
+
+#[tokio::test]
+async fn fetch_all_returns_first_partition_when_no_partitions() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/v2/statements"))
+        .and(header("Authorization", "Snowflake Token=\"t\""))
+        .and(header("X-Snowflake-Authorization-Token-Type", "OAUTH"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "code": "090001",
+            "statementHandle": "handle-1",
+            "resultSetMetaData": metadata(1),
+            "data": rows_for_partition(0),
+        })))
+        .mount(&server)
+        .await;
+
+    let src = build_source(cfg(), &server);
+    let rows = src.fetch_all().await.unwrap();
+    assert_eq!(rows.len(), 5);
+    assert_eq!(rows[0]["ID"], 0);
+    assert_eq!(rows[0]["NAME"], "name-0");
+    assert_eq!(rows[0]["ACTIVE"], true);
+    assert_eq!(rows[1]["ACTIVE"], false);
+}
+
+#[tokio::test]
+async fn fetch_all_paginates_across_partitions() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/v2/statements"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "code": "090001",
+            "statementHandle": "handle-1",
+            "resultSetMetaData": metadata(3),
+            "data": rows_for_partition(0),
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/api/v2/statements/handle-1"))
+        .and(query_param("partition", "1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "code": "090001",
+            "data": rows_for_partition(1),
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/api/v2/statements/handle-1"))
+        .and(query_param("partition", "2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "code": "090001",
+            "data": rows_for_partition(2),
+        })))
+        .mount(&server)
+        .await;
+
+    let src = build_source(cfg(), &server);
+    let rows = src.fetch_all().await.unwrap();
+    assert_eq!(rows.len(), 15);
+    assert_eq!(rows[0]["ID"], 0);
+    assert_eq!(rows[14]["ID"], 14);
+}
+
+#[tokio::test]
+async fn stream_pages_chunks_by_batch_size() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/v2/statements"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "code": "090001",
+            "statementHandle": "h",
+            "resultSetMetaData": metadata(3),
+            "data": rows_for_partition(0),
+        })))
+        .mount(&server)
+        .await;
+    for p in 1..3 {
+        Mock::given(method("GET"))
+            .and(path("/api/v2/statements/h"))
+            .and(query_param("partition", p.to_string()))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": "090001",
+                "data": rows_for_partition(p),
+            })))
+            .mount(&server)
+            .await;
+    }
+
+    // batch_size = 4 → 15 rows should yield ⌈15/4⌉ = 4 pages of [4, 4, 4, 3].
+    let mut c = cfg();
+    c.batch_size = 4;
+    let src = build_source(c, &server);
+    let ctx = HashMap::new();
+    let mut pages = src.stream_pages(&ctx, 0);
+    let mut sizes = Vec::new();
+    while let Some(page) = pages.next().await {
+        let page = page.unwrap();
+        assert!(page.bookmark.is_none());
+        sizes.push(page.records.len());
+    }
+    assert_eq!(sizes, vec![4, 4, 4, 3]);
+}
+
+#[tokio::test]
+async fn stream_pages_batch_size_zero_emits_one_page() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/v2/statements"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "code": "090001",
+            "statementHandle": "h",
+            "resultSetMetaData": metadata(2),
+            "data": rows_for_partition(0),
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/api/v2/statements/h"))
+        .and(query_param("partition", "1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "code": "090001",
+            "data": rows_for_partition(1),
+        })))
+        .mount(&server)
+        .await;
+
+    let mut c = cfg();
+    c.batch_size = 0;
+    let src = build_source(c, &server);
+    let ctx = HashMap::new();
+    let pages: Vec<_> = src.stream_pages(&ctx, 0).collect().await;
+    assert_eq!(pages.len(), 1);
+    assert_eq!(pages[0].as_ref().unwrap().records.len(), 10);
+}
+
+#[tokio::test]
+async fn submits_bindings_for_configured_params_and_context() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/v2/statements"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "code": "090001",
+            "statementHandle": "h",
+            "resultSetMetaData": metadata(1),
+            "data": rows_for_partition(0),
+        })))
+        .mount(&server)
+        .await;
+
+    let mut c = cfg();
+    c.query = "SELECT * FROM events WHERE region = ? AND id > {parent.min_id}".into();
+    c.params = vec![json!("us-east")];
+    let src = build_source(c, &server);
+
+    let mut ctx = HashMap::new();
+    ctx.insert("parent.min_id".to_string(), json!(100));
+    src.fetch_with_context(&ctx).await.unwrap();
+
+    let reqs = server.received_requests().await.unwrap();
+    let body: Value = serde_json::from_slice(&reqs[0].body).unwrap();
+    // Query should have the `{parent.min_id}` token replaced by `?`.
+    assert_eq!(
+        body["statement"],
+        "SELECT * FROM events WHERE region = ? AND id > ?"
+    );
+    let bindings = &body["bindings"];
+    assert_eq!(bindings["1"]["value"], "us-east");
+    assert_eq!(bindings["2"]["value"], "100");
+    assert_eq!(body["role"], "ANALYST");
+    assert_eq!(body["timeout"], 5);
+}
+
+#[tokio::test]
+async fn surfaces_non_success_code_as_source_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/v2/statements"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "code": "000604",
+            "message": "SQL execution canceled",
+        })))
+        .mount(&server)
+        .await;
+
+    let src = build_source(cfg(), &server);
+    let err = src.fetch_all().await.unwrap_err();
+    match err {
+        faucet_core::FaucetError::Source(msg) => {
+            assert!(msg.contains("000604"));
+            assert!(msg.contains("canceled"));
+        }
+        other => panic!("expected Source error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn http_error_surfaces_as_source_error_with_status() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/v2/statements"))
+        .respond_with(ResponseTemplate::new(401).set_body_string("unauthorized"))
+        .mount(&server)
+        .await;
+
+    let src = build_source(cfg(), &server);
+    let err = src.fetch_all().await.unwrap_err();
+    match err {
+        faucet_core::FaucetError::Source(msg) => {
+            assert!(msg.contains("401"));
+        }
+        other => panic!("expected Source error, got {other:?}"),
+    }
+}

--- a/faucet-stream/Cargo.toml
+++ b/faucet-stream/Cargo.toml
@@ -33,6 +33,8 @@ source = [
     "source-elasticsearch",
     "source-parquet",
     "source-gcs",
+    "source-bigquery",
+    "source-snowflake",
 ]
 ## All sink connectors.
 sink = [
@@ -79,6 +81,8 @@ source-elasticsearch = ["dep:faucet-source-elasticsearch"]
 source-kafka = ["dep:faucet-source-kafka", "dep:faucet-kafka-common"]
 source-parquet = ["dep:faucet-source-parquet"]
 source-gcs = ["dep:faucet-source-gcs", "dep:faucet-gcs-common"]
+source-bigquery = ["dep:faucet-source-bigquery", "dep:faucet-bigquery-common"]
+source-snowflake = ["dep:faucet-source-snowflake", "dep:faucet-snowflake-common"]
 
 ## Individual sink connectors.
 sink-bigquery = ["dep:faucet-sink-bigquery"]
@@ -118,8 +122,10 @@ transforms = ["faucet-source-rest?/transforms"]
 
 [dependencies]
 faucet-core.workspace = true
+faucet-bigquery-common = { workspace = true, optional = true }
 faucet-gcs-common = { workspace = true, optional = true }
 faucet-kafka-common = { workspace = true, optional = true }
+faucet-snowflake-common = { workspace = true, optional = true }
 faucet-source-rest = { workspace = true, optional = true }
 faucet-source-graphql = { workspace = true, optional = true }
 faucet-source-xml = { workspace = true, optional = true }
@@ -137,6 +143,8 @@ faucet-source-csv = { workspace = true, optional = true }
 faucet-source-elasticsearch = { workspace = true, optional = true }
 faucet-source-parquet = { workspace = true, optional = true }
 faucet-source-gcs = { workspace = true, optional = true }
+faucet-source-bigquery = { workspace = true, optional = true }
+faucet-source-snowflake = { workspace = true, optional = true }
 faucet-sink-bigquery = { workspace = true, optional = true }
 faucet-sink-postgres = { workspace = true, optional = true }
 faucet-sink-jsonl = { workspace = true, optional = true }


### PR DESCRIPTION
## Summary

- New `faucet-source-snowflake` and `faucet-source-bigquery` crates — symmetric counterparts to the existing sinks, unlocking reverse-ETL and cross-warehouse pipelines (e.g. Snowflake → BigQuery, BigQuery → Postgres).
- Extracted `SnowflakeAuth` / `BigQueryCredentials` (and a `build_client` helper for BigQuery) into new `faucet-snowflake-common` / `faucet-bigquery-common` crates per the connector-pair shared-config convention. Existing sinks refactored to consume them; original public imports remain stable via re-exports.
- Wired into the umbrella crate, CLI registry / `faucet list`, CI feature-check matrix, release ordering, root README, and CLAUDE.md.

Closes #29
Closes #30

## What's new

**`faucet-source-snowflake`**
- SQL REST API client (`POST /api/v2/statements` + per-partition `GET`s).
- Server-side partition pagination, `202 Accepted` polling, JWT key-pair + OAuth bearer auth.
- Type-aware row decoder (FIXED / REAL / BOOLEAN / VARIANT / OBJECT / ARRAY).
- `${parent.path}` matrix-context tokens become positional `?` bindings.
- Configurable `batch_size` (with `0` sentinel for no re-chunking), `statement_timeout`, optional `role`.

**`faucet-source-bigquery`**
- Uses `gcp-bigquery-client` (`jobs.query` + `jobs.getQueryResults`).
- `pageToken` pagination + `jobComplete=false` polling.
- Type-aware row decoder: INTEGER / INT64 / FLOAT / FLOAT64 → JSON number, BOOL → JSON bool, RECORD / STRUCT → nested object, REPEATED → array, JSON → parsed, NUMERIC / BIGNUMERIC → string (full precision), timestamps / dates → string.
- Three credential modes: `ApplicationDefault`, `ServiceAccountKeyPath`, inline `ServiceAccountKey`.
- Positional `STRING` bind parameters; optional `location`, `use_legacy_sql`, `max_results_per_page`.

**`faucet-snowflake-common`**
- `SnowflakeAuth` (KeyPair / OAuth) + `authorization_header` / `snowflake_token_type` helpers.

**`faucet-bigquery-common`**
- `BigQueryCredentials` + async `build_client` returning a `gcp_bigquery_client::Client`.

## Test plan

- [x] `cargo build -p faucet-cli` succeeds with all default features.
- [x] `./target/debug/faucet list` shows `bigquery` and `snowflake` in the Sources section.
- [x] `./target/debug/faucet schema source bigquery` and `... snowflake` emit valid JSON Schema.
- [x] `cargo fmt --all --check` clean.
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean.
- [x] `cargo test --workspace --all-features` — all new tests pass (snowflake-common 7, bigquery-common 7, source-snowflake 27 unit + 7 integration, source-bigquery 25 unit + 6 integration). Pre-existing Kafka integration tests fail locally because Docker isn't running (per CLAUDE.md, they require Docker).
- [x] Per-feature isolated builds (`--no-default-features --features source-{bigquery,snowflake}`) compile clean.
- [x] Existing sink tests (`-p faucet-sink-snowflake` / `-p faucet-sink-bigquery`) still pass after the `-common` extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)