### PR TITLE
feat: gzip/zstd compression for file connectors (closes #33)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,7 @@ jobs:
           - sink
           - state
           - full
+          - compression
           # CLI build matrix — verify the binary builds with every default-on
           # feature plus a slim "only the bare minimum" combo.
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -323,6 +323,50 @@ State backends: `state-redis`, `state-postgres` (file + memory live in `faucet-c
 
 Aggregate features: `source` (all sources), `sink` (all sinks), `state` (all state backends), `full` (everything). Kafka-only: `kafka-schema-registry` enables Avro / Protobuf / JSON Schema via Confluent Schema Registry.
 
+## Compression
+
+`faucet-core` exposes a `compression` feature that pulls in `async-compression`
+(async streaming wrappers), `flate2` (sync gzip), and `zstd` (sync zstd). It
+surfaces a `faucet_core::compression` module with:
+
+- `CompressionConfig` — user-facing enum (`None | Gzip | Zstd | Auto`),
+  default `Auto`. Serializes as lowercase strings.
+- `Compression` — post-resolution enum (no `Auto`).
+- `CompressionConfig::resolve(path) -> Compression` — `Auto` consults the
+  filename suffix (`.gz` → Gzip, `.zst` → Zstd, anything else → None);
+  explicit variants pass through.
+- `wrap_async_reader` / `wrap_async_writer` — for streaming paths.
+- `wrap_sync_reader` / `wrap_sync_writer` — for `spawn_blocking` paths.
+- `compress_buf(data, codec)` — one-shot in-memory compression used by
+  S3/GCS sinks that upload a full `Vec<u8>` body.
+- `warn_mismatch(path, codec)` — logs once per `(path, codec)` pair when
+  the explicit codec disagrees with the filename suffix.
+
+Seven connectors gain a `compression` config field gated on a crate-local
+`compression` feature: `faucet-source-csv`, `faucet-source-s3`,
+`faucet-source-gcs`, `faucet-sink-jsonl`, `faucet-sink-csv`, `faucet-sink-s3`,
+`faucet-sink-gcs`. The `faucet-stream` umbrella exposes a `compression`
+aggregate feature that activates compression on whichever of those connectors
+the user has already opted into (it does **not** pull connectors itself —
+use the optional-dep `?` forwarding syntax). The `full` aggregate now
+includes compression. The `faucet-cli` binary mirrors the same shape, so
+`cargo install faucet-cli --features compression` enables it for every
+config-driven user.
+
+Auto resolution runs at I/O time (per-call, per-key) so matrix-row path
+interpolation works — the same source can read a mix of `.jsonl`,
+`.jsonl.gz`, and `.jsonl.zst` objects in one run.
+
+File sinks (`jsonl`, `csv`) finalise the encoder on `flush()`; subsequent
+writes reopen the file in append mode (independent of `config.append`),
+producing a multi-member compressed file that gzip / zstd decoders read
+back transparently. S3 and GCS sinks do **not** set the `Content-Encoding`
+header on uploads; consumers must decompress explicitly.
+
+Parquet, HTTP, stdout, Kafka, and the database sinks are intentionally out
+of scope (Parquet has internal columnar compression; the others have
+native protocol-level compression options).
+
 ## Pagination Styles (REST source)
 
 | Style | Stops When |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,4 +163,7 @@ criterion = { version = "0.8", default-features = false, features = ["cargo_benc
 arrow-json = "58"
 parquet = { version = "58", features = ["async", "object_store"] }
 object_store = "0.13"
+async-compression = { version = "0.4", features = ["tokio", "gzip", "zstd"] }
+flate2 = "1"
+zstd = "0.13"
 glob = "0.3"

--- a/README.md
+++ b/README.md
@@ -806,8 +806,13 @@ All pagination styles include loop detection — if the same cursor or link is r
 | `transform-flatten` | yes | Flatten nested objects (forwarded to source-rest) |
 | `transform-rename-keys` | yes | Regex key renaming (forwarded to source-rest) |
 | `transform-snake-case` | yes | Snake_case normalisation (forwarded to source-rest) |
+| `compression` | no | gzip / zstd read+write on JSONL/CSV/S3/GCS source and sink connectors |
 
 `RecordTransform::Custom` is always available regardless of feature flags.
+
+## Compression
+
+**Compression**: read/write `.gz` and `.zst` directly on the file-shaped connectors (JSONL/CSV/S3/GCS source and sink) — enable with the `compression` feature.
 
 ## Building Custom Connectors
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 # yields a binary that can run any of the published example YAMLs out of the box.
 default = ["observability", "full"]
 
-full = ["observability", "source", "sink", "state", "transforms"]
+full = ["observability", "source", "sink", "state", "transforms", "compression"]
 
 source = [
     "source-rest",
@@ -102,6 +102,20 @@ sink-gcs = ["dep:faucet-sink-gcs"]
 kafka-schema-registry = [
     "faucet-source-kafka?/schema-registry",
     "faucet-sink-kafka?/schema-registry",
+]
+
+## Enable gzip/zstd compression on every file-shaped connector that has been
+## opted in (via its per-connector feature). Forwards through to each
+## connector's `compression` feature using optional-dep syntax, so this
+## flag does not pull connectors the user has not requested.
+compression = [
+    "faucet-source-csv?/compression",
+    "faucet-source-s3?/compression",
+    "faucet-source-gcs?/compression",
+    "faucet-sink-jsonl?/compression",
+    "faucet-sink-csv?/compression",
+    "faucet-sink-s3?/compression",
+    "faucet-sink-gcs?/compression",
 ]
 
 state-redis = ["dep:faucet-state-redis"]

--- a/cli/README.md
+++ b/cli/README.md
@@ -303,6 +303,31 @@ transforms:
     config: { separator: "__" }
 ```
 
+### Compression
+
+File-shaped connectors (JSONL/CSV/S3/GCS source and sink) accept a `compression` field. Default `auto` detects `.gz` and `.zst` from the file path or object key.
+
+```yaml
+version: 1
+pipeline:
+  source:
+    kind: csv
+    config:
+      path: data.csv.gz
+      compression: auto      # or 'gzip', 'zstd', 'none'
+  sink:
+    kind: jsonl
+    config:
+      path: out.jsonl.zst
+      compression: auto
+```
+
+Build the CLI with the feature enabled:
+
+```bash
+cargo install --path cli --features compression
+```
+
 ## Running from environment variables (`--from-env`)
 
 `faucet` can build and run a pipeline entirely from `FAUCET_*` environment variables — no YAML file required. This mode is designed for container / Kubernetes / Airflow deployments where every config value naturally flows through the orchestrator's env-var interface.

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -14,6 +14,7 @@ transform-rename-keys = ["dep:regex"]
 transform-snake-case = ["dep:regex"]
 transforms = ["transform-flatten", "transform-rename-keys", "transform-snake-case"]
 observability-install = ["dep:metrics-exporter-prometheus", "dep:tracing-subscriber"]
+compression = ["dep:async-compression", "dep:flate2", "dep:zstd"]
 
 [dependencies]
 serde.workspace = true
@@ -35,6 +36,9 @@ schemars.workspace = true
 uuid.workspace = true
 metrics-exporter-prometheus = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }
+async-compression = { workspace = true, optional = true }
+flate2 = { workspace = true, optional = true }
+zstd = { workspace = true, optional = true }
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/crates/core/src/compression.rs
+++ b/crates/core/src/compression.rs
@@ -75,6 +75,8 @@ where
             dec.multiple_members(true);
             Box::pin(tokio::io::BufReader::new(dec))
         }
+        // zstd handles concatenated frames natively, so no `multiple_members`-
+        // equivalent flag is needed (the spec is part of zstd itself).
         Compression::Zstd => {
             let dec = async_compression::tokio::bufread::ZstdDecoder::new(r);
             Box::pin(tokio::io::BufReader::new(dec))
@@ -118,9 +120,16 @@ where
 ///
 /// The returned writer finalises the encoder when dropped (gzip writes its
 /// 8-byte trailer; zstd's `auto_finish` adapter writes the frame epilogue).
-/// To surface trailer-write I/O errors instead of swallowing them on drop,
-/// callers should explicitly `flush()` and then drop the returned `Box` from
-/// inside their `spawn_blocking` task.
+/// Because the concrete encoder type is erased behind `Box<dyn Write>`,
+/// callers cannot invoke `flate2`'s or `zstd`'s `finish()` to capture the
+/// trailer-write `io::Error`. Callers can `flush()` to drain the encoder's
+/// internal buffer mid-stream, but trailer-write errors on drop are
+/// negligibly rare and are silently swallowed.
+///
+/// Connectors using this wrapper should drop the box inside a
+/// `spawn_blocking` task body so the trailer write does not block the
+/// async runtime, and rely on the surrounding `write_all` / `flush` calls
+/// to surface earlier I/O errors.
 pub fn wrap_sync_writer<'a, W>(w: W, c: Compression) -> Box<dyn std::io::Write + Send + 'a>
 where
     W: std::io::Write + Send + 'a,
@@ -230,10 +239,18 @@ mod tests {
 
     #[test]
     fn config_serde_lowercase() {
-        let yaml: CompressionConfig = serde_json::from_str("\"gzip\"").unwrap();
-        assert_eq!(yaml, CompressionConfig::Gzip);
-        let s = serde_json::to_string(&CompressionConfig::Zstd).unwrap();
-        assert_eq!(s, "\"zstd\"");
+        // All four variants round-trip as lowercase strings.
+        for (variant, expected) in [
+            (CompressionConfig::None, "\"none\""),
+            (CompressionConfig::Gzip, "\"gzip\""),
+            (CompressionConfig::Zstd, "\"zstd\""),
+            (CompressionConfig::Auto, "\"auto\""),
+        ] {
+            let serialised = serde_json::to_string(&variant).unwrap();
+            assert_eq!(serialised, expected);
+            let deserialised: CompressionConfig = serde_json::from_str(expected).unwrap();
+            assert_eq!(deserialised, variant);
+        }
     }
 
     #[tokio::test]
@@ -286,8 +303,10 @@ mod tests {
         {
             let mut w = wrap_sync_writer(&mut buf, Compression::Gzip);
             w.write_all(&original).unwrap();
-            // GzEncoder finalises on drop; explicit flush makes the trailer
-            // observable to readers.
+            // GzEncoder finalises on drop (writes the 8-byte trailer).
+            // The explicit flush drains the deflate buffer; the drop at the
+            // end of this scope writes the trailer so the reader below
+            // sees a complete stream.
             w.flush().unwrap();
         }
         let mut r = wrap_sync_reader(&buf[..], Compression::Gzip);
@@ -373,5 +392,27 @@ mod tests {
         let mut r = wrap_async_reader(BufReader::new(&buf[..]), Compression::Gzip);
         let err = r.read_to_end(&mut decompressed).await.unwrap_err();
         assert_eq!(err.kind(), std::io::ErrorKind::UnexpectedEof);
+    }
+
+    #[test]
+    fn warn_mismatch_dedups_per_path_and_codec() {
+        // Calling twice with the same (path, declared) pair must produce a
+        // single log line. We verify via the internal HashSet: after two
+        // calls, the set contains exactly one entry. The static is shared
+        // across the whole process, so we use a unique path to avoid
+        // collisions with other tests.
+        let unique_path = format!("warn_mismatch_dedup_fixture_{}.txt", line!());
+        // First call: detected = None (no extension), declared = Gzip → mismatch, logs.
+        warn_mismatch(&unique_path, Compression::Gzip);
+        // Second call with identical args: must not log a second time.
+        warn_mismatch(&unique_path, Compression::Gzip);
+        // Third call with different declared: separate dedup key, logs once.
+        warn_mismatch(&unique_path, Compression::Zstd);
+        // Matching pair: no log (early-exit before touching the HashSet).
+        warn_mismatch("file.gz", Compression::Gzip);
+        // (Behaviour is verified through log absence in production. Here we
+        // only assert the function runs to completion without panicking,
+        // which exercises the OnceLock init, the Mutex acquisition, and the
+        // HashSet insertion paths.)
     }
 }

--- a/crates/core/src/compression.rs
+++ b/crates/core/src/compression.rs
@@ -1,0 +1,377 @@
+//! Transparent gzip / zstd compression wrappers for file-shaped connectors.
+//!
+//! Behind the `compression` feature. Exposes:
+//! - [`CompressionConfig`] — user-facing enum (`None`, `Gzip`, `Zstd`, `Auto`).
+//! - [`Compression`] — internal post-resolution enum (no `Auto`).
+//! - `wrap_async_reader` / `wrap_async_writer` — for `stream_pages` and async sinks.
+//! - `wrap_sync_reader` / `wrap_sync_writer` — for `spawn_blocking` paths.
+//! - [`compress_buf`] — one-shot in-memory compression for S3/GCS sink uploads.
+//! - [`warn_mismatch`] — log-once helper when explicit codec disagrees with the
+//!   filename extension.
+
+use crate::FaucetError;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::pin::Pin;
+use tokio::io::{AsyncBufRead, AsyncWrite};
+
+/// User-facing compression config. Defaults to [`Auto`](Self::Auto).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum CompressionConfig {
+    None,
+    Gzip,
+    Zstd,
+    /// Detect from filename suffix: `.gz` → Gzip, `.zst` → Zstd, anything else → None.
+    #[default]
+    Auto,
+}
+
+/// Internal post-resolution codec. No `Auto` variant — call [`CompressionConfig::resolve`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Compression {
+    None,
+    Gzip,
+    Zstd,
+}
+
+impl CompressionConfig {
+    /// Resolve `Auto` against a filename. Non-`Auto` variants pass through.
+    pub fn resolve(self, path: &str) -> Compression {
+        match self {
+            Self::None => Compression::None,
+            Self::Gzip => Compression::Gzip,
+            Self::Zstd => Compression::Zstd,
+            Self::Auto => detect_from_path(path),
+        }
+    }
+}
+
+/// Codec detection by filename suffix. Case-insensitive. Looks at the final
+/// extension only: `foo.csv.gz` → Gzip, `foo.gz.zst` → Zstd.
+pub fn detect_from_path(path: &str) -> Compression {
+    let lower = path.to_ascii_lowercase();
+    if lower.ends_with(".gz") {
+        Compression::Gzip
+    } else if lower.ends_with(".zst") {
+        Compression::Zstd
+    } else {
+        Compression::None
+    }
+}
+
+/// Wrap an async buffered reader with a streaming decoder. `None` passes through.
+pub fn wrap_async_reader<'a, R>(
+    r: R,
+    c: Compression,
+) -> Pin<Box<dyn AsyncBufRead + Send + Unpin + 'a>>
+where
+    R: AsyncBufRead + Send + Unpin + 'a,
+{
+    match c {
+        Compression::None => Box::pin(r),
+        Compression::Gzip => {
+            let mut dec = async_compression::tokio::bufread::GzipDecoder::new(r);
+            dec.multiple_members(true);
+            Box::pin(tokio::io::BufReader::new(dec))
+        }
+        Compression::Zstd => {
+            let dec = async_compression::tokio::bufread::ZstdDecoder::new(r);
+            Box::pin(tokio::io::BufReader::new(dec))
+        }
+    }
+}
+
+/// Wrap an async writer with a streaming encoder. `None` passes through.
+/// Callers must call [`tokio::io::AsyncWriteExt::shutdown`] on the returned
+/// writer to flush the trailer before the underlying writer is dropped.
+pub fn wrap_async_writer<'a, W>(
+    w: W,
+    c: Compression,
+) -> Pin<Box<dyn AsyncWrite + Send + Unpin + 'a>>
+where
+    W: AsyncWrite + Send + Unpin + 'a,
+{
+    match c {
+        Compression::None => Box::pin(w),
+        Compression::Gzip => Box::pin(async_compression::tokio::write::GzipEncoder::new(w)),
+        Compression::Zstd => Box::pin(async_compression::tokio::write::ZstdEncoder::new(w)),
+    }
+}
+
+/// Wrap a sync reader with a streaming decoder. `None` passes through.
+pub fn wrap_sync_reader<'a, R>(r: R, c: Compression) -> Box<dyn std::io::Read + Send + 'a>
+where
+    R: std::io::Read + Send + 'a,
+{
+    match c {
+        Compression::None => Box::new(r),
+        Compression::Gzip => Box::new(flate2::read::MultiGzDecoder::new(r)),
+        Compression::Zstd => Box::new(
+            zstd::stream::read::Decoder::new(r)
+                .expect("zstd decoder construction is infallible for any Read"),
+        ),
+    }
+}
+
+/// Wrap a sync writer with a streaming encoder. `None` passes through.
+///
+/// The returned writer finalises the encoder when dropped (gzip writes its
+/// 8-byte trailer; zstd's `auto_finish` adapter writes the frame epilogue).
+/// To surface trailer-write I/O errors instead of swallowing them on drop,
+/// callers should explicitly `flush()` and then drop the returned `Box` from
+/// inside their `spawn_blocking` task.
+pub fn wrap_sync_writer<'a, W>(w: W, c: Compression) -> Box<dyn std::io::Write + Send + 'a>
+where
+    W: std::io::Write + Send + 'a,
+{
+    match c {
+        Compression::None => Box::new(w),
+        Compression::Gzip => Box::new(flate2::write::GzEncoder::new(
+            w,
+            flate2::Compression::default(),
+        )),
+        Compression::Zstd => Box::new(
+            zstd::stream::write::Encoder::new(w, 0)
+                .expect("zstd encoder construction is infallible")
+                .auto_finish(),
+        ),
+    }
+}
+
+/// One-shot in-memory compression. Used by S3 and GCS sinks that build a full
+/// `Vec<u8>` body before upload.
+pub fn compress_buf(data: &[u8], c: Compression) -> Result<Vec<u8>, FaucetError> {
+    use std::io::Write;
+    match c {
+        Compression::None => Ok(data.to_vec()),
+        Compression::Gzip => {
+            let mut enc = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+            enc.write_all(data)
+                .map_err(|e| FaucetError::Sink(format!("gzip compress failed: {e}")))?;
+            enc.finish()
+                .map_err(|e| FaucetError::Sink(format!("gzip finalise failed: {e}")))
+        }
+        Compression::Zstd => zstd::stream::encode_all(data, 0)
+            .map_err(|e| FaucetError::Sink(format!("zstd compress failed: {e}"))),
+    }
+}
+
+/// Log a one-shot warning when the explicit codec disagrees with the
+/// filename's detected codec. Deduplicates per `(path, declared)` pair across
+/// the whole process so a million-object scan does not flood logs.
+pub fn warn_mismatch(path: &str, declared: Compression) {
+    use std::collections::HashSet;
+    use std::sync::{Mutex, OnceLock};
+    static SEEN: OnceLock<Mutex<HashSet<(String, Compression)>>> = OnceLock::new();
+    let detected = detect_from_path(path);
+    if detected == declared {
+        return;
+    }
+    let key = (path.to_string(), declared);
+    let mut seen = SEEN
+        .get_or_init(|| Mutex::new(HashSet::new()))
+        .lock()
+        .expect("compression mismatch log mutex poisoned");
+    if seen.insert(key) {
+        tracing::warn!(
+            path = %path,
+            declared = ?declared,
+            detected = ?detected,
+            "compression codec mismatch — explicit config wins, filename extension ignored",
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
+
+    #[test]
+    fn detect_extensions() {
+        assert_eq!(detect_from_path("foo.jsonl"), Compression::None);
+        assert_eq!(detect_from_path("foo.json.gz"), Compression::Gzip);
+        assert_eq!(detect_from_path("foo.csv.zst"), Compression::Zstd);
+        assert_eq!(detect_from_path("FOO.GZ"), Compression::Gzip);
+        assert_eq!(detect_from_path("a.gz.zst"), Compression::Zstd);
+        assert_eq!(detect_from_path(""), Compression::None);
+    }
+
+    #[test]
+    fn resolve_auto_uses_path() {
+        assert_eq!(
+            CompressionConfig::Auto.resolve("foo.gz"),
+            Compression::Gzip
+        );
+        assert_eq!(
+            CompressionConfig::Auto.resolve("foo.zst"),
+            Compression::Zstd
+        );
+        assert_eq!(CompressionConfig::Auto.resolve("foo"), Compression::None);
+    }
+
+    #[test]
+    fn resolve_explicit_ignores_path() {
+        assert_eq!(
+            CompressionConfig::Gzip.resolve("foo.txt"),
+            Compression::Gzip
+        );
+        assert_eq!(
+            CompressionConfig::None.resolve("foo.gz"),
+            Compression::None
+        );
+    }
+
+    #[test]
+    fn config_default_is_auto() {
+        assert_eq!(CompressionConfig::default(), CompressionConfig::Auto);
+    }
+
+    #[test]
+    fn config_serde_lowercase() {
+        let yaml: CompressionConfig = serde_json::from_str("\"gzip\"").unwrap();
+        assert_eq!(yaml, CompressionConfig::Gzip);
+        let s = serde_json::to_string(&CompressionConfig::Zstd).unwrap();
+        assert_eq!(s, "\"zstd\"");
+    }
+
+    #[tokio::test]
+    async fn async_roundtrip_gzip() {
+        let original = b"hello, compressed world!\n".repeat(100);
+        let mut buf = Vec::new();
+        {
+            let mut w = wrap_async_writer(&mut buf, Compression::Gzip);
+            w.write_all(&original).await.unwrap();
+            w.shutdown().await.unwrap();
+        }
+        let mut decompressed = Vec::new();
+        let mut r = wrap_async_reader(BufReader::new(&buf[..]), Compression::Gzip);
+        r.read_to_end(&mut decompressed).await.unwrap();
+        assert_eq!(decompressed, original);
+    }
+
+    #[tokio::test]
+    async fn async_roundtrip_zstd() {
+        let original = b"zstd payload\n".repeat(50);
+        let mut buf = Vec::new();
+        {
+            let mut w = wrap_async_writer(&mut buf, Compression::Zstd);
+            w.write_all(&original).await.unwrap();
+            w.shutdown().await.unwrap();
+        }
+        let mut decompressed = Vec::new();
+        let mut r = wrap_async_reader(BufReader::new(&buf[..]), Compression::Zstd);
+        r.read_to_end(&mut decompressed).await.unwrap();
+        assert_eq!(decompressed, original);
+    }
+
+    #[tokio::test]
+    async fn async_none_passthrough() {
+        let original = b"plain text";
+        let mut buf = Vec::new();
+        {
+            let mut w = wrap_async_writer(&mut buf, Compression::None);
+            w.write_all(original).await.unwrap();
+            w.shutdown().await.unwrap();
+        }
+        assert_eq!(&buf[..], original);
+    }
+
+    #[test]
+    fn sync_roundtrip_gzip() {
+        use std::io::{Read, Write};
+        let original = b"sync gzip data".repeat(20);
+        let mut buf = Vec::new();
+        {
+            let mut w = wrap_sync_writer(&mut buf, Compression::Gzip);
+            w.write_all(&original).unwrap();
+            // GzEncoder finalises on drop; explicit flush makes the trailer
+            // observable to readers.
+            w.flush().unwrap();
+        }
+        let mut r = wrap_sync_reader(&buf[..], Compression::Gzip);
+        let mut decompressed = Vec::new();
+        r.read_to_end(&mut decompressed).unwrap();
+        assert_eq!(decompressed, original);
+    }
+
+    #[test]
+    fn sync_roundtrip_zstd() {
+        use std::io::{Read, Write};
+        let original = b"sync zstd data".repeat(20);
+        let mut buf = Vec::new();
+        {
+            let mut w = wrap_sync_writer(&mut buf, Compression::Zstd);
+            w.write_all(&original).unwrap();
+            w.flush().unwrap();
+        }
+        let mut r = wrap_sync_reader(&buf[..], Compression::Zstd);
+        let mut decompressed = Vec::new();
+        r.read_to_end(&mut decompressed).unwrap();
+        assert_eq!(decompressed, original);
+    }
+
+    #[test]
+    fn compress_buf_roundtrip_gzip() {
+        use std::io::Read;
+        let original = b"buffer compression".repeat(10);
+        let compressed = compress_buf(&original, Compression::Gzip).unwrap();
+        assert_ne!(compressed, original);
+        let mut r = wrap_sync_reader(&compressed[..], Compression::Gzip);
+        let mut decompressed = Vec::new();
+        r.read_to_end(&mut decompressed).unwrap();
+        assert_eq!(decompressed, original);
+    }
+
+    #[test]
+    fn compress_buf_roundtrip_zstd() {
+        use std::io::Read;
+        let original = b"buffer zstd".repeat(10);
+        let compressed = compress_buf(&original, Compression::Zstd).unwrap();
+        assert_ne!(compressed, original);
+        let mut r = wrap_sync_reader(&compressed[..], Compression::Zstd);
+        let mut decompressed = Vec::new();
+        r.read_to_end(&mut decompressed).unwrap();
+        assert_eq!(decompressed, original);
+    }
+
+    #[test]
+    fn compress_buf_none_is_clone() {
+        let original = b"unchanged";
+        let out = compress_buf(original, Compression::None).unwrap();
+        assert_eq!(out, original);
+    }
+
+    #[tokio::test]
+    async fn empty_compressed_stream_yields_zero_bytes() {
+        // Produce a valid empty gzip stream.
+        let mut buf = Vec::new();
+        {
+            let mut w = wrap_async_writer(&mut buf, Compression::Gzip);
+            w.shutdown().await.unwrap();
+        }
+        // Decompressing it should yield zero bytes, not an error.
+        let mut decompressed = Vec::new();
+        let mut r = wrap_async_reader(BufReader::new(&buf[..]), Compression::Gzip);
+        r.read_to_end(&mut decompressed).await.unwrap();
+        assert!(decompressed.is_empty());
+    }
+
+    #[tokio::test]
+    async fn truncated_gzip_stream_errors() {
+        let original = b"this will be truncated mid-stream".repeat(50);
+        let mut buf = Vec::new();
+        {
+            let mut w = wrap_async_writer(&mut buf, Compression::Gzip);
+            w.write_all(&original).await.unwrap();
+            w.shutdown().await.unwrap();
+        }
+        // Truncate to half.
+        buf.truncate(buf.len() / 2);
+        let mut decompressed = Vec::new();
+        let mut r = wrap_async_reader(BufReader::new(&buf[..]), Compression::Gzip);
+        let err = r.read_to_end(&mut decompressed).await.unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::UnexpectedEof);
+    }
+}

--- a/crates/core/src/compression.rs
+++ b/crates/core/src/compression.rs
@@ -209,10 +209,7 @@ mod tests {
 
     #[test]
     fn resolve_auto_uses_path() {
-        assert_eq!(
-            CompressionConfig::Auto.resolve("foo.gz"),
-            Compression::Gzip
-        );
+        assert_eq!(CompressionConfig::Auto.resolve("foo.gz"), Compression::Gzip);
         assert_eq!(
             CompressionConfig::Auto.resolve("foo.zst"),
             Compression::Zstd
@@ -226,10 +223,7 @@ mod tests {
             CompressionConfig::Gzip.resolve("foo.txt"),
             Compression::Gzip
         );
-        assert_eq!(
-            CompressionConfig::None.resolve("foo.gz"),
-            Compression::None
-        );
+        assert_eq!(CompressionConfig::None.resolve("foo.gz"), Compression::None);
     }
 
     #[test]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -23,6 +23,9 @@ pub mod traits;
 pub mod transform;
 pub mod util;
 
+#[cfg(feature = "compression")]
+pub mod compression;
+
 pub use dlq::{DlqConfig, DlqReason, DlqStats, OnBatchError, build_envelope};
 pub use error::FaucetError;
 pub use observability::{
@@ -47,3 +50,6 @@ pub use async_trait::async_trait;
 pub use futures_core::{self, Stream};
 pub use schemars::{self, JsonSchema, schema_for};
 pub use serde_json::{self, Value, json};
+
+#[cfg(feature = "compression")]
+pub use compression::{Compression, CompressionConfig, compress_buf, warn_mismatch};

--- a/crates/sink/csv/Cargo.toml
+++ b/crates/sink/csv/Cargo.toml
@@ -21,3 +21,6 @@ tokio.workspace = true
 tokio = { workspace = true, features = ["macros", "rt", "fs"] }
 serde_json.workspace = true
 tempfile = "3"
+
+[features]
+compression = ["faucet-core/compression"]

--- a/crates/sink/csv/README.md
+++ b/crates/sink/csv/README.md
@@ -239,6 +239,23 @@ sink.flush().await?;
 - Multiple `write_batch()` calls accumulate rows in the same file using the same column order.
 - Call `flush()` to ensure all buffered data is written to disk before dropping the sink or reading the file.
 
+## Compression
+
+Behind the crate-local `compression` Cargo feature. Adds a `compression` config
+field with values `none`, `gzip`, `zstd`, or `auto` (the default — detects
+`.gz` / `.zst` from the file path / object key).
+
+YAML example:
+
+```yaml
+kind: csv
+config:
+  # ... existing fields ...
+  compression: auto  # or 'gzip' | 'zstd' | 'none'
+```
+
+`flush()` finalises the encoder via a blocking task drop; subsequent writes append a fresh member. Headers are emitted only on the first open.
+
 ## License
 
 Licensed under MIT or Apache-2.0.

--- a/crates/sink/csv/src/config.rs
+++ b/crates/sink/csv/src/config.rs
@@ -31,6 +31,13 @@ pub struct CsvSinkConfig {
     /// the page.
     #[serde(default = "default_batch_size")]
     pub batch_size: usize,
+    /// Compression codec for the output file. Defaults to
+    /// [`CompressionConfig::Auto`](faucet_core::CompressionConfig::Auto) —
+    /// `.gz` / `.zst` suffix selects gzip / zstd. Requires the crate-local
+    /// `compression` feature.
+    #[cfg(feature = "compression")]
+    #[serde(default)]
+    pub compression: faucet_core::CompressionConfig,
 }
 
 fn default_delimiter() -> u8 {
@@ -54,6 +61,8 @@ impl CsvSinkConfig {
             write_headers: true,
             append: false,
             batch_size: DEFAULT_BATCH_SIZE,
+            #[cfg(feature = "compression")]
+            compression: faucet_core::CompressionConfig::Auto,
         }
     }
 
@@ -85,6 +94,13 @@ impl CsvSinkConfig {
     /// BigQuery streaming inserts).
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;
+        self
+    }
+
+    /// Set the compression codec. Available only with the `compression` feature.
+    #[cfg(feature = "compression")]
+    pub fn compression(mut self, c: faucet_core::CompressionConfig) -> Self {
+        self.compression = c;
         self
     }
 }

--- a/crates/sink/csv/src/sink.rs
+++ b/crates/sink/csv/src/sink.rs
@@ -83,9 +83,7 @@ impl faucet_core::Sink for CsvSink {
             guard.take()
         };
 
-        let opened_before = self
-            .opened_once
-            .load(std::sync::atomic::Ordering::Relaxed);
+        let opened_before = self.opened_once.load(std::sync::atomic::Ordering::Relaxed);
 
         let result = tokio::task::spawn_blocking(move || {
             write_csv_blocking(config, current_state, &records, opened_before)
@@ -345,9 +343,7 @@ mod tests {
         use faucet_core::CompressionConfig;
         let tmp = NamedTempFile::with_suffix(".csv.gz").unwrap();
         let path = tmp.path().to_str().unwrap().to_string();
-        let sink = CsvSink::new(
-            CsvSinkConfig::new(&path).compression(CompressionConfig::Auto),
-        );
+        let sink = CsvSink::new(CsvSinkConfig::new(&path).compression(CompressionConfig::Auto));
 
         let records = vec![
             json!({"id": "1", "name": "Alice"}),
@@ -358,10 +354,8 @@ mod tests {
 
         let bytes = tokio::fs::read(&path).await.unwrap();
         use std::io::Read;
-        let mut r = faucet_core::compression::wrap_sync_reader(
-            &bytes[..],
-            faucet_core::Compression::Gzip,
-        );
+        let mut r =
+            faucet_core::compression::wrap_sync_reader(&bytes[..], faucet_core::Compression::Gzip);
         let mut text = String::new();
         r.read_to_string(&mut text).unwrap();
         let lines: Vec<&str> = text.trim().split('\n').collect();
@@ -375,19 +369,15 @@ mod tests {
         use faucet_core::CompressionConfig;
         let tmp = NamedTempFile::with_suffix(".csv.zst").unwrap();
         let path = tmp.path().to_str().unwrap().to_string();
-        let sink = CsvSink::new(
-            CsvSinkConfig::new(&path).compression(CompressionConfig::Auto),
-        );
+        let sink = CsvSink::new(CsvSinkConfig::new(&path).compression(CompressionConfig::Auto));
 
         sink.write_batch(&[json!({"x": "42"})]).await.unwrap();
         sink.flush().await.unwrap();
 
         let bytes = tokio::fs::read(&path).await.unwrap();
         use std::io::Read;
-        let mut r = faucet_core::compression::wrap_sync_reader(
-            &bytes[..],
-            faucet_core::Compression::Zstd,
-        );
+        let mut r =
+            faucet_core::compression::wrap_sync_reader(&bytes[..], faucet_core::Compression::Zstd);
         let mut text = String::new();
         r.read_to_string(&mut text).unwrap();
         let lines: Vec<&str> = text.trim().split('\n').collect();
@@ -413,7 +403,11 @@ mod tests {
         let content = tokio::fs::read_to_string(&path).await.unwrap();
         let lines: Vec<&str> = content.trim().split('\n').collect();
         // Header + 2 data rows (header is written only on the first open).
-        assert_eq!(lines.len(), 3, "both batches must survive the mid-stream flush");
+        assert_eq!(
+            lines.len(),
+            3,
+            "both batches must survive the mid-stream flush"
+        );
     }
 
     #[cfg(feature = "compression")]
@@ -425,9 +419,7 @@ mod tests {
         use faucet_core::CompressionConfig;
         let tmp = NamedTempFile::with_suffix(".csv.gz").unwrap();
         let path = tmp.path().to_str().unwrap().to_string();
-        let sink = CsvSink::new(
-            CsvSinkConfig::new(&path).compression(CompressionConfig::Auto),
-        );
+        let sink = CsvSink::new(CsvSinkConfig::new(&path).compression(CompressionConfig::Auto));
         sink.write_batch(&[json!({"id": "1"})]).await.unwrap();
         sink.flush().await.unwrap();
         sink.write_batch(&[json!({"id": "2"})]).await.unwrap();
@@ -435,10 +427,8 @@ mod tests {
 
         let bytes = tokio::fs::read(&path).await.unwrap();
         use std::io::Read;
-        let mut r = faucet_core::compression::wrap_sync_reader(
-            &bytes[..],
-            faucet_core::Compression::Gzip,
-        );
+        let mut r =
+            faucet_core::compression::wrap_sync_reader(&bytes[..], faucet_core::Compression::Gzip);
         let mut text = String::new();
         r.read_to_string(&mut text).unwrap();
         let lines: Vec<&str> = text.trim().split('\n').collect();

--- a/crates/sink/csv/src/sink.rs
+++ b/crates/sink/csv/src/sink.rs
@@ -18,9 +18,22 @@ struct WriterState {
 /// Column order is determined from the keys of the first record in the first
 /// `write_batch` call. Subsequent records use the same column order; missing
 /// fields are written as empty strings.
+///
+/// [`Sink::flush`] finalises the encoder (writes the trailer) and clears the
+/// writer slot — a subsequent `write_batch` reopens the file in append mode
+/// (independent of `config.append`) and starts a fresh encoder. This makes
+/// the per-page `flush` the pipeline emits for bookmarked pages safe for CDC
+/// sources — every transaction appends rather than truncates.
 pub struct CsvSink {
     config: CsvSinkConfig,
     state: Mutex<Option<WriterState>>,
+    /// Tracks whether the file has been opened at least once.
+    /// On re-opens (after `flush()` clears the writer), we always use
+    /// append mode regardless of `config.append` so the new gzip / zstd
+    /// member appends instead of truncating the file. Without this, the
+    /// pipeline's per-bookmark flush would silently lose data when
+    /// `config.append = false` (the default).
+    opened_once: std::sync::atomic::AtomicBool,
 }
 
 impl CsvSink {
@@ -29,6 +42,7 @@ impl CsvSink {
         Self {
             config,
             state: Mutex::new(None),
+            opened_once: std::sync::atomic::AtomicBool::new(false),
         }
     }
 
@@ -69,13 +83,21 @@ impl faucet_core::Sink for CsvSink {
             guard.take()
         };
 
+        let opened_before = self
+            .opened_once
+            .load(std::sync::atomic::Ordering::Relaxed);
+
         let result = tokio::task::spawn_blocking(move || {
-            write_csv_blocking(config, current_state, &records)
+            write_csv_blocking(config, current_state, &records, opened_before)
         })
         .await
         .map_err(|e| FaucetError::Sink(format!("CSV write task failed: {e}")))?;
 
         let (new_state, count) = result?;
+
+        // Mark opened. From now on, re-opens (after flush) use append mode.
+        self.opened_once
+            .store(true, std::sync::atomic::Ordering::Relaxed);
 
         // Put the state back.
         {
@@ -128,6 +150,7 @@ fn write_csv_blocking(
     config: CsvSinkConfig,
     existing_state: Option<WriterState>,
     records: &[Value],
+    opened_before: bool,
 ) -> Result<(WriterState, usize), FaucetError> {
     let mut state = match existing_state {
         Some(s) => s,
@@ -142,11 +165,20 @@ fn write_csv_blocking(
                 }
             };
 
+            // First open obeys `config.append`. Re-opens (after flush()
+            // cleared the writer) always append, so flush-then-write
+            // sequences do not truncate previously-written data.
+            let (append, truncate) = if opened_before {
+                (true, false)
+            } else {
+                (config.append, !config.append)
+            };
+
             let file = OpenOptions::new()
                 .create(true)
                 .write(true)
-                .append(config.append)
-                .truncate(!config.append)
+                .append(append)
+                .truncate(truncate)
                 .open(&config.path)
                 .map_err(|e| {
                     FaucetError::Sink(format!("failed to open CSV file '{}': {e}", config.path))
@@ -165,8 +197,8 @@ fn write_csv_blocking(
                 .delimiter(config.delimiter)
                 .from_writer(inner);
 
-            // Write header row if configured.
-            if config.write_headers && !config.append {
+            // Write header row if configured and this is the first open.
+            if config.write_headers && !append {
                 writer
                     .write_record(&columns)
                     .map_err(|e| FaucetError::Sink(format!("failed to write CSV headers: {e}")))?;
@@ -361,5 +393,57 @@ mod tests {
         let lines: Vec<&str> = text.trim().split('\n').collect();
         // Header + 1 row.
         assert_eq!(lines.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn write_flush_write_does_not_truncate() {
+        // Regression: flush() clears the writer; the next write_batch
+        // must reopen in append mode regardless of config.append (which
+        // defaults to false). Without the opened_once guard, the second
+        // open would truncate and lose the first batch's records.
+        let tmp = NamedTempFile::new().unwrap();
+        let path = tmp.path().to_str().unwrap().to_string();
+        let sink = CsvSink::new(CsvSinkConfig::new(&path));
+
+        sink.write_batch(&[json!({"id": "1"})]).await.unwrap();
+        sink.flush().await.unwrap();
+        sink.write_batch(&[json!({"id": "2"})]).await.unwrap();
+        sink.flush().await.unwrap();
+
+        let content = tokio::fs::read_to_string(&path).await.unwrap();
+        let lines: Vec<&str> = content.trim().split('\n').collect();
+        // Header + 2 data rows (header is written only on the first open).
+        assert_eq!(lines.len(), 3, "both batches must survive the mid-stream flush");
+    }
+
+    #[cfg(feature = "compression")]
+    #[tokio::test]
+    async fn write_flush_write_produces_multi_member_gzip_csv() {
+        // With compression, flush() finalises one gzip member; the
+        // next write_batch starts a fresh member appended after it.
+        // The decoder reads both members back correctly.
+        use faucet_core::CompressionConfig;
+        let tmp = NamedTempFile::with_suffix(".csv.gz").unwrap();
+        let path = tmp.path().to_str().unwrap().to_string();
+        let sink = CsvSink::new(
+            CsvSinkConfig::new(&path).compression(CompressionConfig::Auto),
+        );
+        sink.write_batch(&[json!({"id": "1"})]).await.unwrap();
+        sink.flush().await.unwrap();
+        sink.write_batch(&[json!({"id": "2"})]).await.unwrap();
+        sink.flush().await.unwrap();
+
+        let bytes = tokio::fs::read(&path).await.unwrap();
+        use std::io::Read;
+        let mut r = faucet_core::compression::wrap_sync_reader(
+            &bytes[..],
+            faucet_core::Compression::Gzip,
+        );
+        let mut text = String::new();
+        r.read_to_string(&mut text).unwrap();
+        let lines: Vec<&str> = text.trim().split('\n').collect();
+        // Header (from first open) + 2 data rows. The re-open uses
+        // append=true so no second header is written.
+        assert_eq!(lines.len(), 3);
     }
 }

--- a/crates/sink/csv/src/sink.rs
+++ b/crates/sink/csv/src/sink.rs
@@ -4,12 +4,12 @@ use crate::config::CsvSinkConfig;
 use async_trait::async_trait;
 use faucet_core::FaucetError;
 use serde_json::Value;
-use std::fs::{File, OpenOptions};
+use std::fs::OpenOptions;
 use std::sync::Mutex;
 
 /// State for the CSV writer, including the determined column order.
 struct WriterState {
-    writer: csv::Writer<File>,
+    writer: csv::Writer<Box<dyn std::io::Write + Send>>,
     columns: Vec<String>,
 }
 
@@ -90,15 +90,34 @@ impl faucet_core::Sink for CsvSink {
     }
 
     async fn flush(&self) -> Result<(), FaucetError> {
-        let mut guard = self
-            .state
-            .lock()
-            .map_err(|e| FaucetError::Sink(format!("CSV sink lock poisoned: {e}")))?;
-        if let Some(ref mut state) = *guard {
-            state
-                .writer
-                .flush()
-                .map_err(|e| FaucetError::Sink(format!("CSV flush failed: {e}")))?;
+        // Take the state out of the mutex so we can move it into a blocking
+        // task. Replacing it with None means the next write_batch reopens
+        // the file in append mode — for compressed output this starts a
+        // fresh gzip/zstd member, which decoders read back transparently.
+        let state = {
+            let mut guard = self
+                .state
+                .lock()
+                .map_err(|e| FaucetError::Sink(format!("CSV sink lock poisoned: {e}")))?;
+            guard.take()
+        };
+        if let Some(mut state) = state {
+            tokio::task::spawn_blocking(move || -> Result<(), FaucetError> {
+                state
+                    .writer
+                    .flush()
+                    .map_err(|e| FaucetError::Sink(format!("CSV flush failed: {e}")))?;
+                // Drop the csv::Writer (and the inner Box<dyn Write>) which
+                // finalises any compression encoder. flate2's GzEncoder writes
+                // the 8-byte trailer to the already-flushed inner Write on
+                // drop; zstd's auto_finish adapter does the same. Errors at
+                // trailer-write time are silently swallowed by the Box-erased
+                // encoder, which is documented in faucet_core::compression.
+                drop(state);
+                Ok(())
+            })
+            .await
+            .map_err(|e| FaucetError::Sink(format!("CSV flush task failed: {e}")))??;
         }
         Ok(())
     }
@@ -133,9 +152,18 @@ fn write_csv_blocking(
                     FaucetError::Sink(format!("failed to open CSV file '{}': {e}", config.path))
                 })?;
 
+            #[cfg(feature = "compression")]
+            let inner: Box<dyn std::io::Write + Send> = {
+                let codec = config.compression.resolve(&config.path);
+                faucet_core::compression::warn_mismatch(&config.path, codec);
+                faucet_core::compression::wrap_sync_writer(file, codec)
+            };
+            #[cfg(not(feature = "compression"))]
+            let inner: Box<dyn std::io::Write + Send> = Box::new(file);
+
             let mut writer = csv::WriterBuilder::new()
                 .delimiter(config.delimiter)
-                .from_writer(file);
+                .from_writer(inner);
 
             // Write header row if configured.
             if config.write_headers && !config.append {
@@ -277,5 +305,61 @@ mod tests {
         let path = tmp.path().to_str().unwrap().to_string();
         let sink = CsvSink::new(CsvSinkConfig::new(&path));
         assert!(sink.flush().await.is_ok());
+    }
+
+    #[cfg(feature = "compression")]
+    #[tokio::test]
+    async fn roundtrip_gzip() {
+        use faucet_core::CompressionConfig;
+        let tmp = NamedTempFile::with_suffix(".csv.gz").unwrap();
+        let path = tmp.path().to_str().unwrap().to_string();
+        let sink = CsvSink::new(
+            CsvSinkConfig::new(&path).compression(CompressionConfig::Auto),
+        );
+
+        let records = vec![
+            json!({"id": "1", "name": "Alice"}),
+            json!({"id": "2", "name": "Bob"}),
+        ];
+        sink.write_batch(&records).await.unwrap();
+        sink.flush().await.unwrap();
+
+        let bytes = tokio::fs::read(&path).await.unwrap();
+        use std::io::Read;
+        let mut r = faucet_core::compression::wrap_sync_reader(
+            &bytes[..],
+            faucet_core::Compression::Gzip,
+        );
+        let mut text = String::new();
+        r.read_to_string(&mut text).unwrap();
+        let lines: Vec<&str> = text.trim().split('\n').collect();
+        // Header + 2 rows.
+        assert_eq!(lines.len(), 3);
+    }
+
+    #[cfg(feature = "compression")]
+    #[tokio::test]
+    async fn roundtrip_zstd() {
+        use faucet_core::CompressionConfig;
+        let tmp = NamedTempFile::with_suffix(".csv.zst").unwrap();
+        let path = tmp.path().to_str().unwrap().to_string();
+        let sink = CsvSink::new(
+            CsvSinkConfig::new(&path).compression(CompressionConfig::Auto),
+        );
+
+        sink.write_batch(&[json!({"x": "42"})]).await.unwrap();
+        sink.flush().await.unwrap();
+
+        let bytes = tokio::fs::read(&path).await.unwrap();
+        use std::io::Read;
+        let mut r = faucet_core::compression::wrap_sync_reader(
+            &bytes[..],
+            faucet_core::Compression::Zstd,
+        );
+        let mut text = String::new();
+        r.read_to_string(&mut text).unwrap();
+        let lines: Vec<&str> = text.trim().split('\n').collect();
+        // Header + 1 row.
+        assert_eq!(lines.len(), 2);
     }
 }

--- a/crates/sink/gcs/Cargo.toml
+++ b/crates/sink/gcs/Cargo.toml
@@ -21,6 +21,9 @@ futures.workspace = true
 bytes.workspace = true
 uuid.workspace = true
 
+[features]
+compression = ["faucet-core/compression"]
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 serde_json.workspace = true

--- a/crates/sink/gcs/README.md
+++ b/crates/sink/gcs/README.md
@@ -93,12 +93,28 @@ control-plane calls (used during round-trip readback) need gRPC, and
 `h2 protocol error / GoAway`. Run with `--ignored` against a real GCS
 bucket or a gRPC-capable emulator when validating changes.
 
+## Compression
+
+Behind the crate-local `compression` Cargo feature. Adds a `compression` config
+field with values `none`, `gzip`, `zstd`, or `auto` (the default — detects
+`.gz` / `.zst` from the file path / object key).
+
+YAML example:
+
+```yaml
+kind: gcs
+config:
+  # ... existing fields ...
+  compression: auto  # or 'gzip' | 'zstd' | 'none'
+```
+
+Same as S3: codec resolves from `file_extension`, no `Content-Encoding` metadata set.
+
 ## Out of scope (v1)
 
 - Resumable uploads.
 - Signed URLs.
 - Custom object metadata or user headers.
-- Per-file gzip/zstd compression (tracked separately as #33).
 - KMS CMEK encryption configuration.
 
 ## License

--- a/crates/sink/gcs/src/config.rs
+++ b/crates/sink/gcs/src/config.rs
@@ -32,6 +32,15 @@ pub struct GcsSinkConfig {
     pub batch_size: usize,
     /// Optional storage-host override (integration-test escape hatch).
     pub storage_host: Option<String>,
+    /// Compression codec applied to each uploaded object body. Defaults to
+    /// [`CompressionConfig::Auto`](faucet_core::CompressionConfig::Auto) —
+    /// resolves against `file_extension` (so `.jsonl.gz` triggers gzip).
+    /// Requires the crate-local `compression` feature. Note: this sink does
+    /// **not** set the GCS `Content-Encoding` metadata, so consumers must
+    /// decompress explicitly.
+    #[cfg(feature = "compression")]
+    #[serde(default)]
+    pub compression: faucet_core::CompressionConfig,
 }
 
 fn default_file_extension() -> String {
@@ -55,6 +64,8 @@ impl GcsSinkConfig {
             concurrency: default_concurrency(),
             batch_size: default_batch_size(),
             storage_host: None,
+            #[cfg(feature = "compression")]
+            compression: faucet_core::CompressionConfig::Auto,
         }
     }
 
@@ -84,6 +95,13 @@ impl GcsSinkConfig {
     }
     pub fn storage_host(mut self, h: impl Into<String>) -> Self {
         self.storage_host = Some(h.into());
+        self
+    }
+
+    /// Set the compression codec. Available only with the `compression` feature.
+    #[cfg(feature = "compression")]
+    pub fn compression(mut self, c: faucet_core::CompressionConfig) -> Self {
+        self.compression = c;
         self
     }
 }
@@ -139,5 +157,29 @@ mod tests {
         }"#;
         let c: GcsSinkConfig = serde_json::from_str(json).unwrap();
         assert_eq!(c.batch_size, faucet_core::DEFAULT_BATCH_SIZE);
+    }
+
+    #[cfg(feature = "compression")]
+    #[test]
+    fn compression_default_is_auto() {
+        let cfg = GcsSinkConfig::new("bucket");
+        assert_eq!(cfg.compression, faucet_core::CompressionConfig::Auto);
+    }
+
+    #[cfg(feature = "compression")]
+    #[test]
+    fn compression_config_round_trips() {
+        let json = r#"{
+            "bucket": "b",
+            "prefix": "",
+            "file_extension": ".jsonl.gz",
+            "max_records_per_file": null,
+            "concurrency": 1,
+            "batch_size": 0,
+            "storage_host": null,
+            "compression": "gzip"
+        }"#;
+        let cfg: GcsSinkConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.compression, faucet_core::CompressionConfig::Gzip);
     }
 }

--- a/crates/sink/gcs/src/sink.rs
+++ b/crates/sink/gcs/src/sink.rs
@@ -44,6 +44,13 @@ impl GcsSink {
 
     /// Upload a single JSONL file to GCS.
     async fn upload_file(&self, key: &str, body: Vec<u8>) -> Result<(), FaucetError> {
+        #[cfg(feature = "compression")]
+        let body = {
+            let codec = self.config.compression.resolve(&self.config.file_extension);
+            faucet_core::compression::warn_mismatch(&self.config.file_extension, codec);
+            faucet_core::compression::compress_buf(&body, codec)?
+        };
+
         let payload = bytes::Bytes::from(body);
         self.storage
             .write_object(self.bucket_path(), key.to_string(), payload)
@@ -176,5 +183,16 @@ mod tests {
         // UUIDv7 keys are lexically comparable by time within the same
         // process: the second key generated should compare greater.
         assert!(a < b, "expected UUIDv7 keys to sort by generation order");
+    }
+
+    #[cfg(feature = "compression")]
+    #[test]
+    fn compress_buf_used_for_zstd_extension() {
+        let cfg = GcsSinkConfig::new("bucket").file_extension(".jsonl.zst");
+        let codec = cfg.compression.resolve(&cfg.file_extension);
+        assert_eq!(codec, faucet_core::Compression::Zstd);
+        let compressed = faucet_core::compression::compress_buf(b"hello\n", codec).unwrap();
+        // zstd magic bytes: 0x28 B5 2F FD.
+        assert_eq!(&compressed[..4], b"\x28\xb5\x2f\xfd");
     }
 }

--- a/crates/sink/jsonl/Cargo.toml
+++ b/crates/sink/jsonl/Cargo.toml
@@ -20,3 +20,6 @@ tokio = { workspace = true, features = ["fs", "io-util"] }
 tokio = { workspace = true, features = ["macros", "rt", "fs", "io-util"] }
 serde_json.workspace = true
 tempfile = "3"
+
+[features]
+compression = ["faucet-core/compression"]

--- a/crates/sink/jsonl/README.md
+++ b/crates/sink/jsonl/README.md
@@ -193,6 +193,23 @@ Output:
 - Call `flush()` to ensure all buffered data is written to disk. This is important before dropping the sink or reading the file.
 - In truncate mode (default), the file is emptied on first write. In append mode, new records are added after existing content.
 
+## Compression
+
+Behind the crate-local `compression` Cargo feature. Adds a `compression` config
+field with values `none`, `gzip`, `zstd`, or `auto` (the default — detects
+`.gz` / `.zst` from the file path / object key).
+
+YAML example:
+
+```yaml
+kind: jsonl
+config:
+  # ... existing fields ...
+  compression: auto  # or 'gzip' | 'zstd' | 'none'
+```
+
+`flush()` finalises the encoder; subsequent writes append a fresh gzip / zstd member (multi-member-decoder compatible).
+
 ## License
 
 Licensed under MIT or Apache-2.0.

--- a/crates/sink/jsonl/src/config.rs
+++ b/crates/sink/jsonl/src/config.rs
@@ -29,6 +29,13 @@ pub struct JsonlSinkConfig {
     /// the page.
     #[serde(default = "default_batch_size")]
     pub batch_size: usize,
+    /// Compression codec for the output file. Defaults to
+    /// [`CompressionConfig::Auto`](faucet_core::CompressionConfig::Auto) —
+    /// `.gz` / `.zst` suffix selects gzip / zstd, anything else writes
+    /// uncompressed. Requires the crate-local `compression` feature.
+    #[cfg(feature = "compression")]
+    #[serde(default)]
+    pub compression: faucet_core::CompressionConfig,
 }
 
 fn default_batch_size() -> usize {
@@ -43,6 +50,8 @@ impl JsonlSinkConfig {
             append: false,
             pretty: false,
             batch_size: DEFAULT_BATCH_SIZE,
+            #[cfg(feature = "compression")]
+            compression: faucet_core::CompressionConfig::Auto,
         }
     }
 
@@ -56,6 +65,13 @@ impl JsonlSinkConfig {
     /// but with indentation). Note: this breaks strict JSONL format.
     pub fn pretty(mut self, pretty: bool) -> Self {
         self.pretty = pretty;
+        self
+    }
+
+    /// Set the compression codec. Available only with the `compression` feature.
+    #[cfg(feature = "compression")]
+    pub fn compression(mut self, c: faucet_core::CompressionConfig) -> Self {
+        self.compression = c;
         self
     }
 

--- a/crates/sink/jsonl/src/sink.rs
+++ b/crates/sink/jsonl/src/sink.rs
@@ -12,10 +12,19 @@ use tokio::sync::Mutex;
 ///
 /// Each record is written as a single line of JSON followed by a newline.
 /// The file is opened lazily on the first `write_batch` call.
+///
+/// With the `compression` feature, the writer transparently wraps the file
+/// with a gzip / zstd encoder based on the `compression` config field.
+/// [`Sink::flush`] finalises the encoder (writes the trailer) and clears the
+/// writer slot — a subsequent `write_batch` reopens the file in append mode
+/// and starts a fresh encoder, producing a multi-member compressed file that
+/// decoders read back correctly. Pipelines call `flush` exactly once at
+/// end-of-run, so the multi-member case only arises for direct library users
+/// who interleave `flush` and `write_batch`.
 pub struct JsonlSink {
     config: JsonlSinkConfig,
     /// Mutex-protected writer for thread-safe concurrent writes.
-    writer: Mutex<Option<tokio::io::BufWriter<tokio::fs::File>>>,
+    writer: Mutex<Option<std::pin::Pin<Box<dyn tokio::io::AsyncWrite + Send + Unpin>>>>,
 }
 
 impl JsonlSink {
@@ -31,7 +40,10 @@ impl JsonlSink {
     async fn ensure_open(
         &self,
     ) -> Result<
-        tokio::sync::MutexGuard<'_, Option<tokio::io::BufWriter<tokio::fs::File>>>,
+        tokio::sync::MutexGuard<
+            '_,
+            Option<std::pin::Pin<Box<dyn tokio::io::AsyncWrite + Send + Unpin>>>,
+        >,
         FaucetError,
     > {
         let mut guard = self.writer.lock().await;
@@ -49,7 +61,18 @@ impl JsonlSink {
                         self.config.path.display()
                     ))
                 })?;
-            *guard = Some(tokio::io::BufWriter::new(file));
+            let buffered = tokio::io::BufWriter::new(file);
+            #[cfg(feature = "compression")]
+            let writer: std::pin::Pin<Box<dyn tokio::io::AsyncWrite + Send + Unpin>> = {
+                let path_str = self.config.path.to_string_lossy();
+                let codec = self.config.compression.resolve(&path_str);
+                faucet_core::compression::warn_mismatch(&path_str, codec);
+                faucet_core::compression::wrap_async_writer(buffered, codec)
+            };
+            #[cfg(not(feature = "compression"))]
+            let writer: std::pin::Pin<Box<dyn tokio::io::AsyncWrite + Send + Unpin>> =
+                Box::pin(buffered);
+            *guard = Some(writer);
         }
         Ok(guard)
     }
@@ -98,9 +121,10 @@ impl faucet_core::Sink for JsonlSink {
 
     async fn flush(&self) -> Result<(), FaucetError> {
         let mut guard = self.writer.lock().await;
-        if let Some(writer) = guard.as_mut() {
+        if let Some(mut writer) = guard.take() {
+            use tokio::io::AsyncWriteExt;
             writer
-                .flush()
+                .shutdown()
                 .await
                 .map_err(|e| FaucetError::Sink(format!("flush failed: {e}")))?;
         }
@@ -196,5 +220,63 @@ mod tests {
         let tmp = NamedTempFile::new().unwrap();
         let sink = JsonlSink::new(JsonlSinkConfig::new(tmp.path()));
         assert_eq!(sink.connector_name(), "jsonl");
+    }
+
+    #[cfg(feature = "compression")]
+    #[tokio::test]
+    async fn roundtrip_gzip() {
+        use faucet_core::CompressionConfig;
+        let tmp = NamedTempFile::with_suffix(".jsonl.gz").unwrap();
+        let path = tmp.path().to_path_buf();
+        let sink = JsonlSink::new(
+            JsonlSinkConfig::new(&path).compression(CompressionConfig::Auto),
+        );
+
+        let records = vec![
+            json!({"id": 1, "name": "Alice"}),
+            json!({"id": 2, "name": "Bob"}),
+        ];
+        sink.write_batch(&records).await.unwrap();
+        sink.flush().await.unwrap();
+
+        // Read raw bytes, decompress via faucet_core, parse JSONL.
+        let bytes = tokio::fs::read(&path).await.unwrap();
+        use tokio::io::AsyncReadExt;
+        let mut decoded = Vec::new();
+        let mut r = faucet_core::compression::wrap_async_reader(
+            tokio::io::BufReader::new(&bytes[..]),
+            faucet_core::Compression::Gzip,
+        );
+        r.read_to_end(&mut decoded).await.unwrap();
+        let text = String::from_utf8(decoded).unwrap();
+        let lines: Vec<&str> = text.trim().split('\n').collect();
+        assert_eq!(lines.len(), 2);
+        let first: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(first["id"], 1);
+    }
+
+    #[cfg(feature = "compression")]
+    #[tokio::test]
+    async fn roundtrip_zstd() {
+        use faucet_core::CompressionConfig;
+        let tmp = NamedTempFile::with_suffix(".jsonl.zst").unwrap();
+        let path = tmp.path().to_path_buf();
+        let sink = JsonlSink::new(
+            JsonlSinkConfig::new(&path).compression(CompressionConfig::Auto),
+        );
+        sink.write_batch(&[json!({"x": 42})]).await.unwrap();
+        sink.flush().await.unwrap();
+
+        let bytes = tokio::fs::read(&path).await.unwrap();
+        use tokio::io::AsyncReadExt;
+        let mut decoded = Vec::new();
+        let mut r = faucet_core::compression::wrap_async_reader(
+            tokio::io::BufReader::new(&bytes[..]),
+            faucet_core::Compression::Zstd,
+        );
+        r.read_to_end(&mut decoded).await.unwrap();
+        let text = String::from_utf8(decoded).unwrap();
+        let v: serde_json::Value = serde_json::from_str(text.trim()).unwrap();
+        assert_eq!(v["x"], 42);
     }
 }

--- a/crates/sink/jsonl/src/sink.rs
+++ b/crates/sink/jsonl/src/sink.rs
@@ -17,14 +17,21 @@ use tokio::sync::Mutex;
 /// with a gzip / zstd encoder based on the `compression` config field.
 /// [`Sink::flush`] finalises the encoder (writes the trailer) and clears the
 /// writer slot — a subsequent `write_batch` reopens the file in append mode
-/// and starts a fresh encoder, producing a multi-member compressed file that
-/// decoders read back correctly. Pipelines call `flush` exactly once at
-/// end-of-run, so the multi-member case only arises for direct library users
-/// who interleave `flush` and `write_batch`.
+/// (independent of `config.append`) and starts a fresh encoder, producing a
+/// multi-member compressed file that decoders read back correctly. This makes
+/// the per-page `flush` the pipeline emits for bookmarked pages safe for CDC
+/// sources — every transaction appends rather than truncates.
 pub struct JsonlSink {
     config: JsonlSinkConfig,
     /// Mutex-protected writer for thread-safe concurrent writes.
     writer: Mutex<Option<std::pin::Pin<Box<dyn tokio::io::AsyncWrite + Send + Unpin>>>>,
+    /// Tracks whether `ensure_open` has opened the file at least once.
+    /// On re-opens (after `flush()` clears the writer), we always use
+    /// append mode regardless of `config.append` so the new gzip / zstd
+    /// member appends instead of truncating the file. Without this, the
+    /// pipeline's per-bookmark flush would silently lose data when
+    /// `config.append = false` (the default).
+    opened_once: std::sync::atomic::AtomicBool,
 }
 
 impl JsonlSink {
@@ -33,6 +40,7 @@ impl JsonlSink {
         Self {
             config,
             writer: Mutex::new(None),
+            opened_once: std::sync::atomic::AtomicBool::new(false),
         }
     }
 
@@ -48,11 +56,22 @@ impl JsonlSink {
     > {
         let mut guard = self.writer.lock().await;
         if guard.is_none() {
+            let opened_before = self
+                .opened_once
+                .load(std::sync::atomic::Ordering::Relaxed);
+            // First open obeys `config.append`. Re-opens (after flush()
+            // cleared the writer) always append, so flush-then-write
+            // sequences do not truncate previously-written data.
+            let (append, truncate) = if opened_before {
+                (true, false)
+            } else {
+                (self.config.append, !self.config.append)
+            };
             let file = OpenOptions::new()
                 .create(true)
                 .write(true)
-                .append(self.config.append)
-                .truncate(!self.config.append)
+                .append(append)
+                .truncate(truncate)
                 .open(&self.config.path)
                 .await
                 .map_err(|e| {
@@ -61,6 +80,8 @@ impl JsonlSink {
                         self.config.path.display()
                     ))
                 })?;
+            self.opened_once
+                .store(true, std::sync::atomic::Ordering::Relaxed);
             let buffered = tokio::io::BufWriter::new(file);
             #[cfg(feature = "compression")]
             let writer: std::pin::Pin<Box<dyn tokio::io::AsyncWrite + Send + Unpin>> = {
@@ -278,5 +299,59 @@ mod tests {
         let text = String::from_utf8(decoded).unwrap();
         let v: serde_json::Value = serde_json::from_str(text.trim()).unwrap();
         assert_eq!(v["x"], 42);
+    }
+
+    #[tokio::test]
+    async fn write_flush_write_does_not_truncate() {
+        // Regression: flush() clears the writer; the next write_batch
+        // must reopen in append mode regardless of config.append (which
+        // defaults to false). Without the opened_once guard, the second
+        // open would truncate and lose the first batch's records.
+        let tmp = NamedTempFile::new().unwrap();
+        let path = tmp.path().to_path_buf();
+        let sink = JsonlSink::new(JsonlSinkConfig::new(&path));
+
+        sink.write_batch(&[json!({"first": 1})]).await.unwrap();
+        sink.flush().await.unwrap();
+        sink.write_batch(&[json!({"second": 2})]).await.unwrap();
+        sink.flush().await.unwrap();
+
+        let content = tokio::fs::read_to_string(&path).await.unwrap();
+        let lines: Vec<&str> = content.trim().split('\n').collect();
+        assert_eq!(lines.len(), 2, "both batches must survive the mid-stream flush");
+        let first: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(first["first"], 1);
+        let second: serde_json::Value = serde_json::from_str(lines[1]).unwrap();
+        assert_eq!(second["second"], 2);
+    }
+
+    #[cfg(feature = "compression")]
+    #[tokio::test]
+    async fn write_flush_write_produces_multi_member_gzip() {
+        // With compression, flush() finalises one gzip member; the
+        // next write_batch starts a fresh member appended after it.
+        // The decoder reads both members back correctly.
+        use faucet_core::CompressionConfig;
+        let tmp = NamedTempFile::with_suffix(".jsonl.gz").unwrap();
+        let path = tmp.path().to_path_buf();
+        let sink = JsonlSink::new(
+            JsonlSinkConfig::new(&path).compression(CompressionConfig::Auto),
+        );
+        sink.write_batch(&[json!({"first": 1})]).await.unwrap();
+        sink.flush().await.unwrap();
+        sink.write_batch(&[json!({"second": 2})]).await.unwrap();
+        sink.flush().await.unwrap();
+
+        let bytes = tokio::fs::read(&path).await.unwrap();
+        use tokio::io::AsyncReadExt;
+        let mut decoded = Vec::new();
+        let mut r = faucet_core::compression::wrap_async_reader(
+            tokio::io::BufReader::new(&bytes[..]),
+            faucet_core::Compression::Gzip,
+        );
+        r.read_to_end(&mut decoded).await.unwrap();
+        let text = String::from_utf8(decoded).unwrap();
+        let lines: Vec<&str> = text.trim().split('\n').collect();
+        assert_eq!(lines.len(), 2);
     }
 }

--- a/crates/sink/jsonl/src/sink.rs
+++ b/crates/sink/jsonl/src/sink.rs
@@ -56,9 +56,7 @@ impl JsonlSink {
     > {
         let mut guard = self.writer.lock().await;
         if guard.is_none() {
-            let opened_before = self
-                .opened_once
-                .load(std::sync::atomic::Ordering::Relaxed);
+            let opened_before = self.opened_once.load(std::sync::atomic::Ordering::Relaxed);
             // First open obeys `config.append`. Re-opens (after flush()
             // cleared the writer) always append, so flush-then-write
             // sequences do not truncate previously-written data.
@@ -249,9 +247,7 @@ mod tests {
         use faucet_core::CompressionConfig;
         let tmp = NamedTempFile::with_suffix(".jsonl.gz").unwrap();
         let path = tmp.path().to_path_buf();
-        let sink = JsonlSink::new(
-            JsonlSinkConfig::new(&path).compression(CompressionConfig::Auto),
-        );
+        let sink = JsonlSink::new(JsonlSinkConfig::new(&path).compression(CompressionConfig::Auto));
 
         let records = vec![
             json!({"id": 1, "name": "Alice"}),
@@ -282,9 +278,7 @@ mod tests {
         use faucet_core::CompressionConfig;
         let tmp = NamedTempFile::with_suffix(".jsonl.zst").unwrap();
         let path = tmp.path().to_path_buf();
-        let sink = JsonlSink::new(
-            JsonlSinkConfig::new(&path).compression(CompressionConfig::Auto),
-        );
+        let sink = JsonlSink::new(JsonlSinkConfig::new(&path).compression(CompressionConfig::Auto));
         sink.write_batch(&[json!({"x": 42})]).await.unwrap();
         sink.flush().await.unwrap();
 
@@ -318,7 +312,11 @@ mod tests {
 
         let content = tokio::fs::read_to_string(&path).await.unwrap();
         let lines: Vec<&str> = content.trim().split('\n').collect();
-        assert_eq!(lines.len(), 2, "both batches must survive the mid-stream flush");
+        assert_eq!(
+            lines.len(),
+            2,
+            "both batches must survive the mid-stream flush"
+        );
         let first: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
         assert_eq!(first["first"], 1);
         let second: serde_json::Value = serde_json::from_str(lines[1]).unwrap();
@@ -334,9 +332,7 @@ mod tests {
         use faucet_core::CompressionConfig;
         let tmp = NamedTempFile::with_suffix(".jsonl.gz").unwrap();
         let path = tmp.path().to_path_buf();
-        let sink = JsonlSink::new(
-            JsonlSinkConfig::new(&path).compression(CompressionConfig::Auto),
-        );
+        let sink = JsonlSink::new(JsonlSinkConfig::new(&path).compression(CompressionConfig::Auto));
         sink.write_batch(&[json!({"first": 1})]).await.unwrap();
         sink.flush().await.unwrap();
         sink.write_batch(&[json!({"second": 2})]).await.unwrap();

--- a/crates/sink/s3/Cargo.toml
+++ b/crates/sink/s3/Cargo.toml
@@ -20,6 +20,9 @@ aws-config = { workspace = true }
 uuid.workspace = true
 futures.workspace = true
 
+[features]
+compression = ["faucet-core/compression"]
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 serde_json.workspace = true

--- a/crates/sink/s3/README.md
+++ b/crates/sink/s3/README.md
@@ -239,6 +239,23 @@ sink.write_batch(&records).await?;
 - Objects are uploaded with `Content-Type: application/x-ndjson`.
 - AWS credentials are resolved via the standard AWS SDK credential chain (environment variables, shared credentials file, instance profiles, etc.).
 
+## Compression
+
+Behind the crate-local `compression` Cargo feature. Adds a `compression` config
+field with values `none`, `gzip`, `zstd`, or `auto` (the default — detects
+`.gz` / `.zst` from the file path / object key).
+
+YAML example:
+
+```yaml
+kind: s3
+config:
+  # ... existing fields ...
+  compression: auto  # or 'gzip' | 'zstd' | 'none'
+```
+
+The codec resolves from `file_extension`. Append `.gz` / `.zst` to `file_extension` so consumers can detect the codec from the object key. The S3 `Content-Encoding` header is deliberately unset — consumers must decompress explicitly.
+
 ## License
 
 Licensed under MIT or Apache-2.0.

--- a/crates/sink/s3/src/config.rs
+++ b/crates/sink/s3/src/config.rs
@@ -39,6 +39,15 @@ pub struct S3SinkConfig {
     /// effective per-object cap is `min(batch_size, max_records_per_file)`.
     #[serde(default = "default_batch_size")]
     pub batch_size: usize,
+    /// Compression codec applied to each uploaded object body. Defaults to
+    /// [`CompressionConfig::Auto`](faucet_core::CompressionConfig::Auto) —
+    /// resolves against `file_extension` (so `.jsonl.gz` triggers gzip).
+    /// Requires the crate-local `compression` feature. Note: this sink does
+    /// **not** set the S3 `Content-Encoding` header, so consumers must
+    /// decompress explicitly.
+    #[cfg(feature = "compression")]
+    #[serde(default)]
+    pub compression: faucet_core::CompressionConfig,
 }
 
 fn default_batch_size() -> usize {
@@ -57,6 +66,8 @@ impl S3SinkConfig {
             max_records_per_file: None,
             concurrency: 10,
             batch_size: DEFAULT_BATCH_SIZE,
+            #[cfg(feature = "compression")]
+            compression: faucet_core::CompressionConfig::Auto,
         }
     }
 
@@ -105,6 +116,13 @@ impl S3SinkConfig {
     /// because writing many small objects is an anti-pattern.
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;
+        self
+    }
+
+    /// Set the compression codec. Available only with the `compression` feature.
+    #[cfg(feature = "compression")]
+    pub fn compression(mut self, c: faucet_core::CompressionConfig) -> Self {
+        self.compression = c;
         self
     }
 }
@@ -199,5 +217,30 @@ mod tests {
         }"#;
         let config: S3SinkConfig = serde_json::from_str(json).unwrap();
         assert_eq!(config.batch_size, faucet_core::DEFAULT_BATCH_SIZE);
+    }
+
+    #[cfg(feature = "compression")]
+    #[test]
+    fn compression_config_round_trips() {
+        let json = r#"{
+            "bucket": "b",
+            "prefix": "",
+            "region": null,
+            "endpoint_url": null,
+            "file_extension": ".jsonl.gz",
+            "max_records_per_file": null,
+            "concurrency": 1,
+            "batch_size": 0,
+            "compression": "gzip"
+        }"#;
+        let config: S3SinkConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.compression, faucet_core::CompressionConfig::Gzip);
+    }
+
+    #[cfg(feature = "compression")]
+    #[test]
+    fn compression_default_is_auto() {
+        let cfg = S3SinkConfig::new("bucket");
+        assert_eq!(cfg.compression, faucet_core::CompressionConfig::Auto);
     }
 }

--- a/crates/sink/s3/src/sink.rs
+++ b/crates/sink/s3/src/sink.rs
@@ -39,14 +39,14 @@ impl S3Sink {
         Ok(client)
     }
 
-    /// Serialize a slice of records as a JSON Lines string.
-    fn serialize_jsonl(records: &[Value]) -> Result<String, FaucetError> {
-        let mut buf = String::new();
+    /// Serialize a slice of records as JSON Lines bytes.
+    fn serialize_jsonl(records: &[Value]) -> Result<Vec<u8>, FaucetError> {
+        let mut buf: Vec<u8> = Vec::new();
         for record in records {
-            let line = serde_json::to_string(record)
+            let line = serde_json::to_vec(record)
                 .map_err(|e| FaucetError::Sink(format!("JSON serialization failed: {e}")))?;
-            buf.push_str(&line);
-            buf.push('\n');
+            buf.extend_from_slice(&line);
+            buf.push(b'\n');
         }
         Ok(buf)
     }
@@ -58,12 +58,19 @@ impl S3Sink {
     }
 
     /// Upload a single JSONL file to S3.
-    async fn upload_file(&self, key: &str, body: String) -> Result<(), FaucetError> {
+    async fn upload_file(&self, key: &str, body: Vec<u8>) -> Result<(), FaucetError> {
+        #[cfg(feature = "compression")]
+        let body = {
+            let codec = self.config.compression.resolve(&self.config.file_extension);
+            faucet_core::compression::warn_mismatch(&self.config.file_extension, codec);
+            faucet_core::compression::compress_buf(&body, codec)?
+        };
+
         self.client
             .put_object()
             .bucket(&self.config.bucket)
             .key(key)
-            .body(body.into_bytes().into())
+            .body(body.into())
             .content_type("application/x-ndjson")
             .send()
             .await
@@ -107,7 +114,7 @@ impl faucet_core::Sink for S3Sink {
         let concurrency = self.config.concurrency.max(1);
 
         // Pre-serialize each chunk and generate keys before uploading.
-        let prepared: Vec<(String, String)> = chunks
+        let prepared: Vec<(String, Vec<u8>)> = chunks
             .iter()
             .map(|chunk| {
                 let body = Self::serialize_jsonl(chunk)?;
@@ -153,7 +160,8 @@ mod tests {
             json!({"id": 2, "name": "Bob"}),
         ];
         let result = S3Sink::serialize_jsonl(&records).unwrap();
-        let lines: Vec<&str> = result.trim().split('\n').collect();
+        let text = String::from_utf8(result).unwrap();
+        let lines: Vec<&str> = text.trim().split('\n').collect();
         assert_eq!(lines.len(), 2);
 
         let first: Value = serde_json::from_str(lines[0]).unwrap();
@@ -163,7 +171,7 @@ mod tests {
     #[test]
     fn serialize_jsonl_empty() {
         let result = S3Sink::serialize_jsonl(&[]).unwrap();
-        assert_eq!(result, "");
+        assert!(result.is_empty());
     }
 
     #[test]
@@ -187,5 +195,18 @@ mod tests {
         assert!(key.ends_with(".jsonl"));
         // No prefix means key starts with UUID
         assert!(!key.starts_with('/'));
+    }
+
+    #[cfg(feature = "compression")]
+    #[test]
+    fn compress_buf_used_for_gzip_extension() {
+        // White-box: confirm the codec resolved from file_extension is Gzip
+        // and that compress_buf produces a gzip-magic-prefixed buffer.
+        let cfg = S3SinkConfig::new("bucket").file_extension(".jsonl.gz");
+        let codec = cfg.compression.resolve(&cfg.file_extension);
+        assert_eq!(codec, faucet_core::Compression::Gzip);
+        let compressed = faucet_core::compression::compress_buf(b"hello\n", codec).unwrap();
+        // gzip magic bytes.
+        assert_eq!(&compressed[..2], b"\x1f\x8b");
     }
 }

--- a/crates/source/csv/Cargo.toml
+++ b/crates/source/csv/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 description = "CSV file source connector for the faucet-stream ecosystem"
 
+[features]
+compression = ["faucet-core/compression"]
+
 [dependencies]
 faucet-core.workspace = true
 schemars.workspace = true

--- a/crates/source/csv/README.md
+++ b/crates/source/csv/README.md
@@ -187,6 +187,23 @@ let source = CsvSource::new(config);
 let records = source.fetch_all().await?;
 ```
 
+## Compression
+
+Behind the crate-local `compression` Cargo feature. Adds a `compression` config
+field with values `none`, `gzip`, `zstd`, or `auto` (the default — detects
+`.gz` / `.zst` from the file path / object key).
+
+YAML example:
+
+```yaml
+kind: csv
+config:
+  # ... existing fields ...
+  compression: auto  # or 'gzip' | 'zstd' | 'none'
+```
+
+Compression is detected from the file path. Multi-line quoted fields (records with embedded newlines inside quotes) are not supported by the streaming path — applies regardless of compression.
+
 ## License
 
 Licensed under MIT or Apache-2.0.

--- a/crates/source/csv/src/config.rs
+++ b/crates/source/csv/src/config.rs
@@ -28,6 +28,13 @@ pub struct CsvSourceConfig {
     /// jobs) that prefer one large request to many small ones.
     #[serde(default = "default_batch_size")]
     pub batch_size: usize,
+    /// Compression codec for the input file. Defaults to
+    /// [`CompressionConfig::Auto`](faucet_core::CompressionConfig::Auto) —
+    /// `.gz` / `.zst` suffix selects gzip / zstd. Requires the crate-local
+    /// `compression` feature.
+    #[cfg(feature = "compression")]
+    #[serde(default)]
+    pub compression: faucet_core::CompressionConfig,
 }
 
 fn default_true() -> bool {
@@ -55,6 +62,8 @@ impl CsvSourceConfig {
             delimiter: b',',
             quote: b'"',
             batch_size: DEFAULT_BATCH_SIZE,
+            #[cfg(feature = "compression")]
+            compression: faucet_core::CompressionConfig::Auto,
         }
     }
 
@@ -82,6 +91,13 @@ impl CsvSourceConfig {
     /// single [`StreamPage`](faucet_core::StreamPage).
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;
+        self
+    }
+
+    /// Set the compression codec. Available only with the `compression` feature.
+    #[cfg(feature = "compression")]
+    pub fn compression(mut self, c: faucet_core::CompressionConfig) -> Self {
+        self.compression = c;
         self
     }
 }

--- a/crates/source/csv/src/stream.rs
+++ b/crates/source/csv/src/stream.rs
@@ -210,7 +210,6 @@ fn parse_csv_line(line: &str, config: &CsvSourceConfig) -> Result<Vec<String>, F
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -298,11 +297,8 @@ mod tests {
         let tmp = NamedTempFile::with_suffix(".csv.gz").unwrap();
         let path = tmp.path().to_str().unwrap().to_string();
         let plain = b"id,name\n1,Alice\n2,Bob\n";
-        let compressed = faucet_core::compression::compress_buf(
-            plain,
-            faucet_core::Compression::Gzip,
-        )
-        .unwrap();
+        let compressed =
+            faucet_core::compression::compress_buf(plain, faucet_core::Compression::Gzip).unwrap();
         tokio::fs::write(&path, &compressed).await.unwrap();
 
         let config = CsvSourceConfig::new(&path).compression(CompressionConfig::Auto);
@@ -320,11 +316,8 @@ mod tests {
         let tmp = NamedTempFile::with_suffix(".csv.zst").unwrap();
         let path = tmp.path().to_str().unwrap().to_string();
         let plain = b"id,name\n1,Carol\n";
-        let compressed = faucet_core::compression::compress_buf(
-            plain,
-            faucet_core::Compression::Zstd,
-        )
-        .unwrap();
+        let compressed =
+            faucet_core::compression::compress_buf(plain, faucet_core::Compression::Zstd).unwrap();
         tokio::fs::write(&path, &compressed).await.unwrap();
 
         let config = CsvSourceConfig::new(&path).compression(CompressionConfig::Auto);

--- a/crates/source/csv/src/stream.rs
+++ b/crates/source/csv/src/stream.rs
@@ -29,17 +29,14 @@ impl faucet_core::Source for CsvSource {
         &self,
         context: &std::collections::HashMap<String, serde_json::Value>,
     ) -> Result<Vec<Value>, FaucetError> {
-        let mut config = self.config.clone();
-
-        if !context.is_empty() {
-            config.path = faucet_core::util::substitute_context(&config.path, context);
+        use futures::StreamExt;
+        let mut all = Vec::new();
+        let mut s = self.stream_pages(context, self.config.batch_size);
+        while let Some(page) = s.next().await {
+            let page = page?;
+            all.extend(page.records);
         }
-
-        // CSV reading is synchronous I/O — run on a blocking thread to avoid
-        // starving the async runtime.
-        tokio::task::spawn_blocking(move || read_csv(&config))
-            .await
-            .map_err(|e| FaucetError::Config(format!("CSV read task failed: {e}")))?
+        Ok(all)
     }
 
     /// Stream rows from the CSV file without buffering the full result set.
@@ -63,9 +60,9 @@ impl faucet_core::Source for CsvSource {
     /// ## Multi-line records
     ///
     /// `AsyncBufReadExt::lines` splits on raw `\n`, so quoted fields that
-    /// contain embedded newlines are **not** supported by the streaming path
-    /// — they will be parsed as broken individual lines. Use `fetch_all` /
-    /// `fetch_with_context` for files that need multi-line records.
+    /// contain embedded newlines are **not** supported — they will be parsed
+    /// as broken individual lines. CSV files with multi-line quoted fields are
+    /// out of scope for this connector.
     fn stream_pages<'a>(
         &'a self,
         context: &'a std::collections::HashMap<String, Value>,
@@ -86,6 +83,12 @@ impl faucet_core::Source for CsvSource {
                 ))
             })?;
             let reader = tokio::io::BufReader::new(file);
+            #[cfg(feature = "compression")]
+            let reader = {
+                let codec = config.compression.resolve(&config.path);
+                faucet_core::compression::warn_mismatch(&config.path, codec);
+                faucet_core::compression::wrap_async_reader(reader, codec)
+            };
             let mut lines = reader.lines();
 
             // Read the header line first if configured, so we can key records
@@ -207,54 +210,6 @@ fn parse_csv_line(line: &str, config: &CsvSourceConfig) -> Result<Vec<String>, F
     }
 }
 
-/// Synchronous CSV reading logic.
-fn read_csv(config: &CsvSourceConfig) -> Result<Vec<Value>, FaucetError> {
-    let mut reader = csv::ReaderBuilder::new()
-        .has_headers(config.has_headers)
-        .delimiter(config.delimiter)
-        .quote(config.quote)
-        .from_path(&config.path)
-        .map_err(|e| {
-            FaucetError::Config(format!("failed to open CSV file '{}': {e}", config.path))
-        })?;
-
-    // Determine column names.
-    let headers: Vec<String> = if config.has_headers {
-        reader
-            .headers()
-            .map_err(|e| FaucetError::Config(format!("failed to read CSV headers: {e}")))?
-            .iter()
-            .map(|h| h.to_string())
-            .collect()
-    } else {
-        Vec::new()
-    };
-
-    let mut records = Vec::new();
-
-    for (row_idx, result) in reader.records().enumerate() {
-        let record = result.map_err(|e| {
-            FaucetError::Config(format!("CSV parse error at row {}: {e}", row_idx + 1))
-        })?;
-
-        let mut obj = Map::new();
-
-        for (col_idx, field) in record.iter().enumerate() {
-            let key = if col_idx < headers.len() {
-                headers[col_idx].clone()
-            } else {
-                format!("column_{col_idx}")
-            };
-            obj.insert(key, Value::String(field.to_string()));
-        }
-
-        records.push(Value::Object(obj));
-    }
-
-    tracing::debug!(records = records.len(), path = %config.path, "CSV file read complete");
-
-    Ok(records)
-}
 
 #[cfg(test)]
 mod tests {
@@ -334,5 +289,48 @@ mod tests {
         let result = source.fetch_all().await;
 
         assert!(result.is_err());
+    }
+
+    #[cfg(feature = "compression")]
+    #[tokio::test]
+    async fn roundtrip_gzip_via_stream_pages() {
+        use faucet_core::CompressionConfig;
+        let tmp = NamedTempFile::with_suffix(".csv.gz").unwrap();
+        let path = tmp.path().to_str().unwrap().to_string();
+        let plain = b"id,name\n1,Alice\n2,Bob\n";
+        let compressed = faucet_core::compression::compress_buf(
+            plain,
+            faucet_core::Compression::Gzip,
+        )
+        .unwrap();
+        tokio::fs::write(&path, &compressed).await.unwrap();
+
+        let config = CsvSourceConfig::new(&path).compression(CompressionConfig::Auto);
+        let source = CsvSource::new(config);
+        let records = source.fetch_all().await.unwrap();
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0]["name"], "Alice");
+        assert_eq!(records[1]["name"], "Bob");
+    }
+
+    #[cfg(feature = "compression")]
+    #[tokio::test]
+    async fn roundtrip_zstd_via_stream_pages() {
+        use faucet_core::CompressionConfig;
+        let tmp = NamedTempFile::with_suffix(".csv.zst").unwrap();
+        let path = tmp.path().to_str().unwrap().to_string();
+        let plain = b"id,name\n1,Carol\n";
+        let compressed = faucet_core::compression::compress_buf(
+            plain,
+            faucet_core::Compression::Zstd,
+        )
+        .unwrap();
+        tokio::fs::write(&path, &compressed).await.unwrap();
+
+        let config = CsvSourceConfig::new(&path).compression(CompressionConfig::Auto);
+        let source = CsvSource::new(config);
+        let records = source.fetch_all().await.unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0]["name"], "Carol");
     }
 }

--- a/crates/source/csv/src/stream.rs
+++ b/crates/source/csv/src/stream.rs
@@ -197,8 +197,8 @@ fn parse_csv_line(line: &str, config: &CsvSourceConfig) -> Result<Vec<String>, F
         .delimiter(config.delimiter)
         .quote(config.quote)
         // A single line cannot contain a flexible-width record set, but
-        // tolerating uneven field counts matches the lenient behaviour of
-        // the spawn_blocking path.
+        // tolerating uneven field counts preserves the lenient behaviour
+        // the connector has always had (uneven rows do not abort the run).
         .flexible(true)
         .from_reader(line.as_bytes());
 

--- a/crates/source/gcs/Cargo.toml
+++ b/crates/source/gcs/Cargo.toml
@@ -23,6 +23,9 @@ futures.workspace = true
 bytes.workspace = true
 tokio-util.workspace = true
 
+[features]
+compression = ["faucet-core/compression"]
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 serde_json.workspace = true

--- a/crates/source/gcs/README.md
+++ b/crates/source/gcs/README.md
@@ -121,13 +121,29 @@ the emulator fails with `h2 protocol error / GoAway`. Run the
 `--ignored` suite against a real GCS bucket or a gRPC-capable
 emulator when validating changes.
 
+## Compression
+
+Behind the crate-local `compression` Cargo feature. Adds a `compression` config
+field with values `none`, `gzip`, `zstd`, or `auto` (the default — detects
+`.gz` / `.zst` from the file path / object key).
+
+YAML example:
+
+```yaml
+kind: gcs
+config:
+  # ... existing fields ...
+  compression: auto  # or 'gzip' | 'zstd' | 'none'
+```
+
+The codec resolves per object key, so a single source can read a mix of compressed and uncompressed objects in one run.
+
 ## Out of scope (v1)
 
 - HMAC-key auth.
 - Signed URL generation.
 - Mid-scan resumable bookmarks (matches `faucet-source-s3` behaviour).
 - KMS CMEK encryption configuration.
-- Per-file gzip/zstd decompression (tracked separately as #33).
 - Server-streaming gRPC reads.
 
 ## License

--- a/crates/source/gcs/src/config.rs
+++ b/crates/source/gcs/src/config.rs
@@ -47,6 +47,14 @@ pub struct GcsSourceConfig {
     /// Optional storage-host override (e.g. `http://localhost:4443` for
     /// fake-gcs-server). Production users should leave this unset.
     pub storage_host: Option<String>,
+    /// Compression codec applied to each downloaded object. Defaults to
+    /// [`CompressionConfig::Auto`](faucet_core::CompressionConfig::Auto) —
+    /// the codec is resolved per-object-key, so a single source can read a
+    /// mix of compressed and uncompressed objects. Requires the
+    /// crate-local `compression` feature.
+    #[cfg(feature = "compression")]
+    #[serde(default)]
+    pub compression: faucet_core::CompressionConfig,
 }
 
 fn default_batch_size() -> usize {
@@ -69,6 +77,8 @@ impl GcsSourceConfig {
             concurrency: default_concurrency(),
             batch_size: default_batch_size(),
             storage_host: None,
+            #[cfg(feature = "compression")]
+            compression: faucet_core::CompressionConfig::default(),
         }
     }
 
@@ -109,6 +119,13 @@ impl GcsSourceConfig {
 
     pub fn storage_host(mut self, host: impl Into<String>) -> Self {
         self.storage_host = Some(host.into());
+        self
+    }
+
+    /// Set the compression codec. Available only with the `compression` feature.
+    #[cfg(feature = "compression")]
+    pub fn compression(mut self, c: faucet_core::CompressionConfig) -> Self {
+        self.compression = c;
         self
     }
 }
@@ -172,6 +189,13 @@ mod tests {
     fn batch_size_above_max_is_rejected() {
         let config = GcsSourceConfig::new("b").with_batch_size(faucet_core::MAX_BATCH_SIZE + 1);
         assert!(faucet_core::validate_batch_size(config.batch_size).is_err());
+    }
+
+    #[cfg(feature = "compression")]
+    #[test]
+    fn compression_default_is_auto() {
+        let cfg = GcsSourceConfig::new("bucket");
+        assert_eq!(cfg.compression, faucet_core::CompressionConfig::Auto);
     }
 
     #[test]

--- a/crates/source/gcs/src/stream.rs
+++ b/crates/source/gcs/src/stream.rs
@@ -106,10 +106,8 @@ impl GcsSource {
                 buf
             } else {
                 use std::io::Read;
-                let mut r = faucet_core::compression::wrap_sync_reader(
-                    std::io::Cursor::new(buf),
-                    codec,
-                );
+                let mut r =
+                    faucet_core::compression::wrap_sync_reader(std::io::Cursor::new(buf), codec);
                 let mut out = Vec::new();
                 r.read_to_end(&mut out).map_err(|e| {
                     FaucetError::Source(format!("decompression failed for key '{key}': {e}"))
@@ -129,10 +127,7 @@ impl GcsSource {
     async fn open_object_reader(
         &self,
         key: &str,
-    ) -> Result<
-        std::pin::Pin<Box<dyn tokio::io::AsyncBufRead + Send + Unpin>>,
-        FaucetError,
-    > {
+    ) -> Result<std::pin::Pin<Box<dyn tokio::io::AsyncBufRead + Send + Unpin>>, FaucetError> {
         let resp = self
             .storage
             .read_object(self.bucket_path(), key.to_string())
@@ -147,9 +142,7 @@ impl GcsSource {
         let bytes_stream = resp
             .into_stream()
             .map_err(|e| std::io::Error::other(e.to_string()));
-        let buffered = tokio::io::BufReader::new(
-            tokio_util::io::StreamReader::new(bytes_stream),
-        );
+        let buffered = tokio::io::BufReader::new(tokio_util::io::StreamReader::new(bytes_stream));
         #[cfg(feature = "compression")]
         {
             let codec = self.config.compression.resolve(key);

--- a/crates/source/gcs/src/stream.rs
+++ b/crates/source/gcs/src/stream.rs
@@ -98,6 +98,26 @@ impl GcsSource {
             buf.extend_from_slice(&bytes);
         }
 
+        #[cfg(feature = "compression")]
+        let buf = {
+            let codec = self.config.compression.resolve(key);
+            faucet_core::compression::warn_mismatch(key, codec);
+            if codec == faucet_core::Compression::None {
+                buf
+            } else {
+                use std::io::Read;
+                let mut r = faucet_core::compression::wrap_sync_reader(
+                    std::io::Cursor::new(buf),
+                    codec,
+                );
+                let mut out = Vec::new();
+                r.read_to_end(&mut out).map_err(|e| {
+                    FaucetError::Source(format!("decompression failed for key '{key}': {e}"))
+                })?;
+                out
+            }
+        };
+
         String::from_utf8(buf)
             .map_err(|e| FaucetError::Source(format!("GCS object '{key}' not valid UTF-8: {e}")))
     }
@@ -109,7 +129,10 @@ impl GcsSource {
     async fn open_object_reader(
         &self,
         key: &str,
-    ) -> Result<impl tokio::io::AsyncBufRead + Unpin, FaucetError> {
+    ) -> Result<
+        std::pin::Pin<Box<dyn tokio::io::AsyncBufRead + Send + Unpin>>,
+        FaucetError,
+    > {
         let resp = self
             .storage
             .read_object(self.bucket_path(), key.to_string())
@@ -124,9 +147,19 @@ impl GcsSource {
         let bytes_stream = resp
             .into_stream()
             .map_err(|e| std::io::Error::other(e.to_string()));
-        Ok(tokio::io::BufReader::new(
+        let buffered = tokio::io::BufReader::new(
             tokio_util::io::StreamReader::new(bytes_stream),
-        ))
+        );
+        #[cfg(feature = "compression")]
+        {
+            let codec = self.config.compression.resolve(key);
+            faucet_core::compression::warn_mismatch(key, codec);
+            Ok(faucet_core::compression::wrap_async_reader(buffered, codec))
+        }
+        #[cfg(not(feature = "compression"))]
+        {
+            Ok(Box::pin(buffered))
+        }
     }
 
     /// Parse file content into records based on the configured file format.
@@ -376,6 +409,13 @@ fn value_type_name(v: &Value) -> &'static str {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[cfg(feature = "compression")]
+    #[test]
+    fn compression_default_is_auto() {
+        let cfg = GcsSourceConfig::new("bucket");
+        assert_eq!(cfg.compression, faucet_core::CompressionConfig::Auto);
+    }
 
     /// Construct a parse-only test config — used by tests that don't touch
     /// the network. We can't easily construct a real `GcsSource` without

--- a/crates/source/s3/Cargo.toml
+++ b/crates/source/s3/Cargo.toml
@@ -20,6 +20,9 @@ aws-config = { workspace = true }
 async-stream = { workspace = true }
 futures.workspace = true
 
+[features]
+compression = ["faucet-core/compression"]
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 serde_json.workspace = true

--- a/crates/source/s3/README.md
+++ b/crates/source/s3/README.md
@@ -212,6 +212,23 @@ This source uses the standard AWS SDK credential chain. Credentials are resolved
 
 No credential fields are included in the config -- use the standard AWS environment instead.
 
+## Compression
+
+Behind the crate-local `compression` Cargo feature. Adds a `compression` config
+field with values `none`, `gzip`, `zstd`, or `auto` (the default — detects
+`.gz` / `.zst` from the file path / object key).
+
+YAML example:
+
+```yaml
+kind: s3
+config:
+  # ... existing fields ...
+  compression: auto  # or 'gzip' | 'zstd' | 'none'
+```
+
+The codec resolves per object key, so a single source can read a mix of compressed and uncompressed objects in one run.
+
 ## License
 
 Licensed under MIT or Apache-2.0.

--- a/crates/source/s3/src/config.rs
+++ b/crates/source/s3/src/config.rs
@@ -49,6 +49,14 @@ pub struct S3SourceConfig {
     /// that prefer one large request per file to many small ones.
     #[serde(default = "default_batch_size")]
     pub batch_size: usize,
+    /// Compression codec applied to each downloaded object. Defaults to
+    /// [`CompressionConfig::Auto`](faucet_core::CompressionConfig::Auto) —
+    /// the codec is resolved per-object-key, so a single source can read a
+    /// mix of compressed and uncompressed objects. Requires the
+    /// crate-local `compression` feature.
+    #[cfg(feature = "compression")]
+    #[serde(default)]
+    pub compression: faucet_core::CompressionConfig,
 }
 
 fn default_batch_size() -> usize {
@@ -67,6 +75,8 @@ impl S3SourceConfig {
             max_objects: None,
             concurrency: 10,
             batch_size: DEFAULT_BATCH_SIZE,
+            #[cfg(feature = "compression")]
+            compression: faucet_core::CompressionConfig::default(),
         }
     }
 
@@ -113,6 +123,13 @@ impl S3SourceConfig {
     /// S3 object.
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;
+        self
+    }
+
+    /// Set the compression codec. Available only with the `compression` feature.
+    #[cfg(feature = "compression")]
+    pub fn compression(mut self, c: faucet_core::CompressionConfig) -> Self {
+        self.compression = c;
         self
     }
 }
@@ -198,5 +215,12 @@ mod tests {
         }"#;
         let config: S3SourceConfig = serde_json::from_str(json).unwrap();
         assert_eq!(config.batch_size, 250);
+    }
+
+    #[cfg(feature = "compression")]
+    #[test]
+    fn compression_default_is_auto() {
+        let cfg = S3SourceConfig::new("bucket");
+        assert_eq!(cfg.compression, faucet_core::CompressionConfig::Auto);
     }
 }

--- a/crates/source/s3/src/stream.rs
+++ b/crates/source/s3/src/stream.rs
@@ -119,8 +119,31 @@ impl S3Source {
             response.body.collect().await.map_err(|e| {
                 FaucetError::Config(format!("S3 read body error for key '{key}': {e}"))
             })?;
+        let bytes = body.into_bytes();
 
-        String::from_utf8(body.into_bytes().to_vec())
+        #[cfg(feature = "compression")]
+        let bytes = {
+            let codec = self.config.compression.resolve(key);
+            faucet_core::compression::warn_mismatch(key, codec);
+            if codec == faucet_core::Compression::None {
+                bytes.to_vec()
+            } else {
+                use std::io::Read;
+                let mut r = faucet_core::compression::wrap_sync_reader(
+                    std::io::Cursor::new(bytes.to_vec()),
+                    codec,
+                );
+                let mut out = Vec::new();
+                r.read_to_end(&mut out).map_err(|e| {
+                    FaucetError::Source(format!("decompression failed for key '{key}': {e}"))
+                })?;
+                out
+            }
+        };
+        #[cfg(not(feature = "compression"))]
+        let bytes = bytes.to_vec();
+
+        String::from_utf8(bytes)
             .map_err(|e| FaucetError::Config(format!("S3 UTF-8 decode error for key '{key}': {e}")))
     }
 
@@ -131,7 +154,10 @@ impl S3Source {
     async fn open_object_reader(
         &self,
         key: &str,
-    ) -> Result<impl tokio::io::AsyncBufRead + Unpin, FaucetError> {
+    ) -> Result<
+        std::pin::Pin<Box<dyn tokio::io::AsyncBufRead + Send + Unpin>>,
+        FaucetError,
+    > {
         let response = self
             .client
             .get_object()
@@ -143,9 +169,19 @@ impl S3Source {
                 FaucetError::Config(format!("S3 get object error for key '{key}': {e}"))
             })?;
 
-        // `ByteStream::into_async_read` returns `impl AsyncBufRead`; wrap
-        // in a `BufReader` so `.lines()` is usable and ownership is `Unpin`.
-        Ok(tokio::io::BufReader::new(response.body.into_async_read()))
+        // `ByteStream::into_async_read` returns `impl AsyncRead`; wrap in a
+        // `BufReader` so `.lines()` is usable and ownership is `Unpin`.
+        let buffered = tokio::io::BufReader::new(response.body.into_async_read());
+        #[cfg(feature = "compression")]
+        {
+            let codec = self.config.compression.resolve(key);
+            faucet_core::compression::warn_mismatch(key, codec);
+            Ok(faucet_core::compression::wrap_async_reader(buffered, codec))
+        }
+        #[cfg(not(feature = "compression"))]
+        {
+            Ok(Box::pin(buffered))
+        }
     }
 
     /// Parse file content into records based on the configured file format.
@@ -516,5 +552,12 @@ mod tests {
             records[0],
             json!({"key": "data/file.txt", "content": "hello world\nline two"})
         );
+    }
+
+    #[cfg(feature = "compression")]
+    #[test]
+    fn compression_default_is_auto() {
+        let cfg = S3SourceConfig::new("bucket");
+        assert_eq!(cfg.compression, faucet_core::CompressionConfig::Auto);
     }
 }

--- a/crates/source/s3/src/stream.rs
+++ b/crates/source/s3/src/stream.rs
@@ -154,10 +154,7 @@ impl S3Source {
     async fn open_object_reader(
         &self,
         key: &str,
-    ) -> Result<
-        std::pin::Pin<Box<dyn tokio::io::AsyncBufRead + Send + Unpin>>,
-        FaucetError,
-    > {
+    ) -> Result<std::pin::Pin<Box<dyn tokio::io::AsyncBufRead + Send + Unpin>>, FaucetError> {
         let response = self
             .client
             .get_object()

--- a/faucet-stream/Cargo.toml
+++ b/faucet-stream/Cargo.toml
@@ -60,8 +60,21 @@ state = [
     "state-redis",
     "state-postgres",
 ]
+## Enable gzip/zstd compression on every file-shaped connector that has been
+## opted in (via its per-connector feature). Forwards through to each
+## connector's `compression` feature using optional-dep syntax, so this
+## flag does not pull connectors the user has not requested.
+compression = [
+    "faucet-source-csv?/compression",
+    "faucet-source-s3?/compression",
+    "faucet-source-gcs?/compression",
+    "faucet-sink-jsonl?/compression",
+    "faucet-sink-csv?/compression",
+    "faucet-sink-s3?/compression",
+    "faucet-sink-gcs?/compression",
+]
 ## Every connector and state backend.
-full = ["source", "sink", "state", "kafka-schema-registry"]
+full = ["source", "sink", "state", "kafka-schema-registry", "compression"]
 
 ## Individual source connectors.
 source-rest = ["dep:faucet-source-rest"]


### PR DESCRIPTION
## Summary

- New `faucet_core::compression` module behind a workspace `compression` feature, providing async + sync codec wrappers (gzip via flate2 / async-compression, zstd via zstd crate / async-compression) and a `compress_buf` helper for in-memory bodies.
- Seven file-shaped connectors gain a `compression: CompressionConfig` field (default `Auto`):
  - Sinks: `faucet-sink-jsonl`, `faucet-sink-csv`, `faucet-sink-s3`, `faucet-sink-gcs`
  - Sources: `faucet-source-csv`, `faucet-source-s3`, `faucet-source-gcs`
- `faucet-stream` and `faucet-cli` expose a `compression` aggregate feature that forwards through every affected connector via optional-dep `?` syntax (no connector pull-in).
- `CompressionConfig::Auto` resolves against the file path / object key at I/O time — matrix-row interpolation works, and a single S3/GCS source can read a mix of `.jsonl`, `.jsonl.gz`, `.jsonl.zst` objects in one run.

Closes #33

## Design notes

- File sinks (JSONL/CSV) finalise the encoder on `flush()`; subsequent writes reopen the file in append mode (independent of `config.append`), producing a multi-member compressed file that decoders read back transparently. This fixes a latent truncation bug where mid-stream flush followed by a subsequent write would discard prior data when `config.append == false` (the default).
- S3/GCS sinks do **not** set the `Content-Encoding` header — consumers must decompress explicitly. Documented in the affected READMEs.
- CSV source: `fetch_with_context` is collapsed onto `stream_pages`. The sync `read_csv` helper is removed. The accepted trade is that multi-line quoted fields (embedded newlines inside quoted strings) are no longer supported in `fetch_all` — the streaming path already didn't support them, so this aligns both paths.
- Parquet handles compression internally and is out of scope. HTTP, stdout, Kafka, and database sinks have native compression options and are also out of scope.

## Test plan

- [ ] `cargo fmt --all --check` passes
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` passes
- [ ] `cargo test --workspace --all-features` passes
- [ ] CI `feature-check` matrix passes including the new `compression` entry
- [ ] `cargo install --path cli --features compression` produces a working `faucet` binary that round-trips `.csv.gz` and `.jsonl.zst`

🤖 Generated with [Claude Code](https://claude.com/claude-code)