### PR TITLE
feat(source-grpc): add server-streaming RPC support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Cargo workspace, 39 crates (38 libraries + the `faucet-cli` binary). All connect
 | `faucet-source-rest` | `crates/source/rest/` | REST API source — auth, pagination, extraction, schema inference |
 | `faucet-source-graphql` | `crates/source/graphql/` | GraphQL API source — cursor pagination, variable injection |
 | `faucet-source-xml` | `crates/source/xml/` | XML/SOAP API source — XML-to-JSON conversion, dot-path extraction |
-| `faucet-source-grpc` | `crates/source/grpc/` | gRPC source — dynamic protobuf via `prost-reflect` |
+| `faucet-source-grpc` | `crates/source/grpc/` | gRPC source — dynamic protobuf via `prost-reflect`; unary and server-streaming RPCs |
 | `faucet-source-postgres` | `crates/source/postgres/` | PostgreSQL query source — run SQL, return rows as JSON |
 | `faucet-source-postgres-cdc` | `crates/source/postgres-cdc/` | PostgreSQL CDC (logical replication) source — pgoutput decoder, slot lifecycle, resumable via state store |
 | `faucet-source-mysql` | `crates/source/mysql/` | MySQL query source |
@@ -180,7 +180,7 @@ All connectors must be optimised for throughput by default. When modifying or ad
 
 Every `Pipeline::run` drives `Source::stream_pages(ctx, batch_size)` internally and writes each emitted `StreamPage` to the sink as it arrives. This bounds memory at O(batch_size) on both sides regardless of total record volume.
 
-Sources that override `stream_pages` to stream natively from their underlying primitive: `rest`, `graphql`, `postgres`, `postgres-cdc`, `mysql`, `sqlite`, `mongodb`, `s3` (JSONL/RawText modes), `gcs` (JSONL/RawText modes), `parquet`, `csv`, `xml`, `elasticsearch` (scroll API), `kafka`, `redis` (all three modes). Sources that intentionally keep the default chunk-the-buffer impl (no native streaming primitive): `grpc` (unary RPC), `webhook` (buffer-shaped by nature). Server-streaming gRPC is tracked separately as #34.
+Sources that override `stream_pages` to stream natively from their underlying primitive: `rest`, `graphql`, `postgres`, `postgres-cdc`, `mysql`, `sqlite`, `mongodb`, `s3` (JSONL/RawText modes), `gcs` (JSONL/RawText modes), `parquet`, `csv`, `xml`, `elasticsearch` (scroll API), `kafka`, `redis` (all three modes), `grpc` (server-streaming mode only). Sources that intentionally keep the default chunk-the-buffer impl: `grpc` (unary mode — no native paging primitive), `webhook` (buffer-shaped by nature). Client-streaming and bidirectional-streaming gRPC remain out of scope.
 
 Sinks that expose a `batch_size` config field for write-side re-chunking: every sink — `parquet`, `s3`, `gcs`, `bigquery`, `snowflake`, `postgres`, `mysql`, `sqlite`, `mongodb`, `redis`, `elasticsearch`, `http`, `kafka` (re-chunking is internally the natural unit for each — multi-row INSERTs, `_bulk` bodies, `tabledata.insertAll` requests, `insert_many` calls, Redis pipelines, etc.). The file/append sinks (`jsonl`, `csv`, `stdout`) carry the field for config parity but write per-record, so `batch_size` is a no-op for them.
 

--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ Every pipeline emits OTel-compatible `tracing` spans and Prometheus metrics auto
 ### Source: gRPC (`faucet-source-grpc`)
 
 - **Dynamic protobuf** — call any gRPC method at runtime using a compiled `FileDescriptorSet` (no code generation)
+- **Unary + server-streaming RPCs** — `rpc_kind` selects between one-shot calls and long-lived server-driven streams; streaming mode flushes pages as messages arrive, with reconnect-on-transient-error and exponential backoff
 - **JSON request/response** — send requests as JSON, receive responses as JSON via `prost-reflect`
 - **TLS support** — automatic TLS detection from `https://` endpoint, or explicit override
 - **Authentication** — Bearer token or custom metadata key-value pairs

--- a/crates/source/grpc/Cargo.toml
+++ b/crates/source/grpc/Cargo.toml
@@ -19,7 +19,17 @@ tonic.workspace = true
 prost.workspace = true
 prost-reflect.workspace = true
 prost-types.workspace = true
+async-stream.workspace = true
+futures-core.workspace = true
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros", "rt"] }
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "net", "time", "sync"] }
 serde_json.workspace = true
+tonic = { workspace = true, features = ["transport", "server"] }
+tokio-stream = { version = "0.1", features = ["net"] }
+futures = { workspace = true }
+prost.workspace = true
+
+[build-dependencies]
+tonic-build = "0.13"
+protoc-bin-vendored = "3"

--- a/crates/source/grpc/README.md
+++ b/crates/source/grpc/README.md
@@ -73,6 +73,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 | `tls` | `Option<bool>` | `None` | Whether to use TLS. When `None`, auto-detected from `https://` in the endpoint URL |
 | `records_path` | `Option<String>` | `None` | JSONPath to extract records from the response. If not set, the entire response is returned as a single record |
 | `batch_size` | `usize` | `1000` | Records per emitted `StreamPage` for `Source::stream_pages`. `0` is the "no batching" sentinel — the entire result set is emitted in a single page. See [Streaming and batching](#streaming-and-batching) below — for unary RPCs `0` and any positive value behave identically |
+| `rpc_kind` | `RpcKind` | `Unary` | RPC kind: `Unary` (one request → one response) or `ServerStreaming` (one request → stream of responses). See [Server-streaming RPCs](#server-streaming-rpcs) below |
+| `max_messages` | `Option<usize>` | `None` | Server-streaming only. Cap on the number of streamed messages to consume before terminating. `None` means consume until the server closes the stream |
+| `terminate_on_error` | `bool` | `false` | Server-streaming only. If `true`, transient stream errors terminate the run. If `false`, the source reconnects with exponential backoff |
+| `reconnect_initial_backoff` | `Duration` (secs) | `1` | Server-streaming only. Initial backoff before the first reconnect attempt; doubles after each failure up to `reconnect_max_backoff` |
+| `reconnect_max_backoff` | `Duration` (secs) | `30` | Server-streaming only. Upper bound on reconnect backoff |
+| `reconnect_max_attempts` | `Option<u32>` | `None` | Server-streaming only. Maximum reconnect attempts before surfacing the error. `None` means unlimited |
 
 ### Authentication (GrpcAuth)
 
@@ -84,11 +90,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ## Streaming and batching
 
+### Unary RPCs
+
 Unary gRPC returns one response containing all records; `stream_pages` falls back to the default trait impl, which buffers the full response and then chunks it in memory into `batch_size` pages. This bounds **sink-side** memory only — source-side memory is still O(full response).
 
 `batch_size = 0` and any positive `batch_size` are observably identical for unary gRPC — both buffer the full result before yielding, since the unary RPC has no native paging primitive the source could honour. Treat the field as a sink-side chunk size, not a wire-protocol hint.
 
-Server-streaming gRPC is tracked as issue [#34](https://github.com/PawanSikawat/faucet-stream/issues/34) and will override `stream_pages` to stream per-response, at which point `batch_size` will gain its usual meaning for that mode.
+### Server-streaming RPCs
+
+When `rpc_kind = "server_streaming"`, the source calls `tonic::client::Grpc::server_streaming` and consumes the response stream message-by-message. Each streamed `DynamicMessage` is decoded via `prost-reflect` and converted to JSON; if `records_path` is set it is applied to each message individually (so `$.events[*]` flattens an array nested inside each message into the page record set).
+
+`stream_pages` flushes a page each time the buffer accumulates `batch_size` records, bounding both **source-side and sink-side** memory. `batch_size = 0` drains the entire stream into a single page (useful for short streams or sinks that prefer one large write). Pages carry `bookmark: None` — server-streaming has no native cursor, so resumption is driven by user-supplied request fields (e.g. an event id), not a faucet-managed bookmark.
+
+#### Reconnect on transient errors
+
+By default, transient stream errors (server disconnects, transport failures, etc.) trigger a reconnect with exponential backoff starting at `reconnect_initial_backoff`, doubling each attempt up to `reconnect_max_backoff`. After `reconnect_max_attempts` (when set), the error is surfaced. Set `terminate_on_error = true` to skip the reconnect path entirely and propagate the error on first failure.
+
+**Caveat:** reconnect re-sends the same request from scratch, so the server begins emitting from the start of the stream again unless the request includes a resume token (e.g. an `after_event_id` field) that the user maintains. Records received before the disconnect are still delivered downstream — they are not retracted.
 
 ## Config Loading
 
@@ -100,7 +118,7 @@ let config: GrpcStreamConfig = load_json("config.json")?;
 let config: GrpcStreamConfig = load_env_file(".env", "GRPC")?;
 ```
 
-### Example JSON config
+### Example JSON config (unary)
 
 ```json
 {
@@ -119,6 +137,28 @@ let config: GrpcStreamConfig = load_env_file(".env", "GRPC")?;
   "tls": true,
   "records_path": "$.products[*]",
   "batch_size": 1000
+}
+```
+
+### Example JSON config (server-streaming)
+
+```json
+{
+  "endpoint": "https://grpc.example.com:443",
+  "service_name": "events.EventService",
+  "method_name": "Tail",
+  "descriptor_set_path": "proto/descriptor.bin",
+  "request": { "topic": "audit-log" },
+  "auth": { "type": "Bearer", "token": "your-api-token" },
+  "tls": true,
+  "records_path": null,
+  "rpc_kind": "server_streaming",
+  "max_messages": 100000,
+  "terminate_on_error": false,
+  "reconnect_initial_backoff": 1,
+  "reconnect_max_backoff": 30,
+  "reconnect_max_attempts": null,
+  "batch_size": 500
 }
 ```
 
@@ -188,6 +228,38 @@ let config = GrpcStreamConfig::new(
 let stream = GrpcStream::new(config)?;
 let events = stream.fetch_all().await?;
 println!("Fetched {} events", events.len());
+```
+
+### Server-streaming RPC
+
+```rust
+use faucet_source_grpc::{GrpcStream, GrpcStreamConfig, RpcKind};
+use serde_json::json;
+
+let config = GrpcStreamConfig::new(
+    "http://localhost:50051",
+    "events.EventService",
+    "Tail",
+    "proto/descriptor.bin",
+)
+.request(json!({ "topic": "audit-log" }))
+.rpc_kind(RpcKind::ServerStreaming)
+.max_messages(10_000)
+.with_batch_size(500);
+
+let stream = GrpcStream::new(config)?;
+let events = stream.fetch_all().await?;
+println!("Collected {} events", events.len());
+```
+
+For long-lived streams, drive the pipeline directly so pages flush to the
+sink as they arrive instead of buffering everything in memory:
+
+```rust
+use faucet_core::Pipeline;
+
+let pipeline = Pipeline::new(&stream, &my_sink);
+pipeline.run().await?;
 ```
 
 ### Custom metadata authentication

--- a/crates/source/grpc/build.rs
+++ b/crates/source/grpc/build.rs
@@ -1,0 +1,45 @@
+//! Builds the test-only `echo.proto` into both:
+//!
+//! 1. Generated tonic server + prost client code (used by integration tests
+//!    in `tests/`).
+//! 2. A `FileDescriptorSet` binary blob that `GrpcStream` loads at runtime,
+//!    so the dynamic-proto path is exercised against the same schema.
+//!
+//! The descriptor set is written to `$OUT_DIR/echo_descriptor.bin`; the
+//! generated client/server module is written to `$OUT_DIR/faucet.test.echo.rs`.
+//! Integration tests resolve both paths via `env!("OUT_DIR")`.
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let out_dir = std::path::PathBuf::from(std::env::var_os("OUT_DIR").unwrap());
+    let descriptor_path = out_dir.join("echo_descriptor.bin");
+
+    // Use the vendored protoc so the build isn't affected by an outdated or
+    // broken system protoc (e.g. abseil ABI mismatches on macOS Homebrew).
+    let protoc = protoc_bin_vendored::protoc_bin_path()?;
+    // SAFETY: build.rs is single-threaded; setting PROTOC pre-invocation is
+    // the documented way to override prost-build's protoc binary.
+    unsafe {
+        std::env::set_var("PROTOC", &protoc);
+    }
+
+    tonic_build::configure()
+        .build_client(false)
+        .build_server(false)
+        .file_descriptor_set_path(&descriptor_path)
+        .compile_protos(&["tests/proto/echo.proto"], &["tests/proto"])?;
+
+    // Tests need the server + client codegen too; re-run with them enabled
+    // (tonic-build can emit both in a single call but doing it twice keeps
+    // the descriptor-only invocation clearly scoped).
+    tonic_build::configure()
+        .build_client(true)
+        .build_server(true)
+        .compile_protos(&["tests/proto/echo.proto"], &["tests/proto"])?;
+
+    println!("cargo:rerun-if-changed=tests/proto/echo.proto");
+    println!(
+        "cargo:rustc-env=ECHO_DESCRIPTOR_PATH={}",
+        descriptor_path.display()
+    );
+    Ok(())
+}

--- a/crates/source/grpc/src/config.rs
+++ b/crates/source/grpc/src/config.rs
@@ -5,6 +5,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::path::PathBuf;
+use std::time::Duration;
 
 /// A single piece of gRPC request metadata.
 ///
@@ -26,6 +27,22 @@ pub enum GrpcAuth {
     Bearer { token: String },
     /// Custom metadata key-value pairs.
     Metadata { entries: Vec<MetadataEntry> },
+}
+
+/// Kind of gRPC RPC to invoke.
+///
+/// Selected via the `rpc_kind` config field; defaults to [`RpcKind::Unary`]
+/// so existing configs are backward-compatible.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum RpcKind {
+    /// One request, one response (default).
+    #[default]
+    Unary,
+    /// One request, a server-driven stream of responses. The source consumes
+    /// each streamed message and emits records as they arrive. Useful for
+    /// event feeds, change feeds, log tails, and any long-lived gRPC stream.
+    ServerStreaming,
 }
 
 /// Configuration for the gRPC source.
@@ -52,22 +69,69 @@ pub struct GrpcStreamConfig {
     /// Records per emitted [`StreamPage`](faucet_core::StreamPage). Defaults
     /// to [`DEFAULT_BATCH_SIZE`].
     ///
-    /// Unary gRPC returns one response containing all records, so the source
-    /// has no native paging primitive to honour this hint. The default
+    /// For unary RPCs the source has no native paging primitive to honour
+    /// this hint: the default
     /// [`Source::stream_pages`](faucet_core::Source::stream_pages) impl
-    /// buffers the full response via `fetch_with_context_incremental` and
-    /// then chunks it in memory into `batch_size` pages, which bounds
-    /// **sink-side** memory only. For unary RPCs, `batch_size = 0` (the
-    /// "no batching" sentinel) and any positive `batch_size` are observably
-    /// identical from a wire-protocol standpoint — both buffer the full
-    /// result before any page is yielded. Server-streaming gRPC is tracked
-    /// separately and will override `stream_pages` to stream per-response.
+    /// buffers the full response and then chunks it in memory, bounding
+    /// **sink-side** memory only.
+    ///
+    /// For server-streaming RPCs (`rpc_kind = "server_streaming"`) the source
+    /// overrides `stream_pages` and flushes a page each time `batch_size`
+    /// messages accumulate, bounding both source-side and sink-side memory.
+    /// `batch_size = 0` drains the entire stream into a single page.
     #[serde(default = "default_batch_size")]
     pub batch_size: usize,
+    /// Kind of RPC to invoke. Defaults to [`RpcKind::Unary`].
+    #[serde(default)]
+    pub rpc_kind: RpcKind,
+    /// For [`RpcKind::ServerStreaming`]: maximum number of messages to consume
+    /// before terminating the stream. `None` means consume until the server
+    /// closes the stream (or the run is cancelled).
+    #[serde(default)]
+    pub max_messages: Option<usize>,
+    /// For [`RpcKind::ServerStreaming`]: if `true`, transient stream errors
+    /// (server-side disconnects, transport errors, etc.) terminate the run
+    /// with [`FaucetError::Source`](faucet_core::FaucetError::Source). When
+    /// `false` (the default), the source reconnects with exponential backoff
+    /// up to [`reconnect_max_attempts`](Self::reconnect_max_attempts).
+    ///
+    /// Ignored for [`RpcKind::Unary`].
+    #[serde(default)]
+    pub terminate_on_error: bool,
+    /// For [`RpcKind::ServerStreaming`] reconnect: initial backoff delay
+    /// before the first retry. Doubles after each failure up to
+    /// [`reconnect_max_backoff`](Self::reconnect_max_backoff). Defaults to 1s.
+    #[serde(
+        default = "default_reconnect_initial_backoff",
+        with = "faucet_core::config::duration_secs"
+    )]
+    #[schemars(with = "u64")]
+    pub reconnect_initial_backoff: Duration,
+    /// For [`RpcKind::ServerStreaming`] reconnect: maximum backoff cap.
+    /// Defaults to 30s.
+    #[serde(
+        default = "default_reconnect_max_backoff",
+        with = "faucet_core::config::duration_secs"
+    )]
+    #[schemars(with = "u64")]
+    pub reconnect_max_backoff: Duration,
+    /// For [`RpcKind::ServerStreaming`] reconnect: maximum reconnect attempts
+    /// before surfacing the error. `None` (the default) means unlimited
+    /// retries.
+    #[serde(default)]
+    pub reconnect_max_attempts: Option<u32>,
 }
 
 fn default_batch_size() -> usize {
     DEFAULT_BATCH_SIZE
+}
+
+fn default_reconnect_initial_backoff() -> Duration {
+    Duration::from_secs(1)
+}
+
+fn default_reconnect_max_backoff() -> Duration {
+    Duration::from_secs(30)
 }
 
 impl GrpcStreamConfig {
@@ -88,6 +152,12 @@ impl GrpcStreamConfig {
             tls: None,
             records_path: None,
             batch_size: DEFAULT_BATCH_SIZE,
+            rpc_kind: RpcKind::Unary,
+            max_messages: None,
+            terminate_on_error: false,
+            reconnect_initial_backoff: default_reconnect_initial_backoff(),
+            reconnect_max_backoff: default_reconnect_max_backoff(),
+            reconnect_max_attempts: None,
         }
     }
 
@@ -119,11 +189,51 @@ impl GrpcStreamConfig {
     /// [`Source::stream_pages`](faucet_core::Source::stream_pages).
     ///
     /// Pass `0` to opt out of batching — the entire result set is emitted in
-    /// a single [`StreamPage`](faucet_core::StreamPage). For the unary gRPC
-    /// source this is observably identical to any positive `batch_size`,
-    /// since the full response is buffered before any page is yielded.
+    /// a single [`StreamPage`](faucet_core::StreamPage). For unary RPCs this
+    /// is observably identical to any positive `batch_size`, since the full
+    /// response is buffered before any page is yielded. For server-streaming
+    /// RPCs, `0` drains the entire stream before yielding.
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;
+        self
+    }
+
+    /// Set the RPC kind (unary or server-streaming).
+    pub fn rpc_kind(mut self, rpc_kind: RpcKind) -> Self {
+        self.rpc_kind = rpc_kind;
+        self
+    }
+
+    /// Cap the number of messages to consume from a server-streaming RPC.
+    /// Ignored for unary RPCs.
+    pub fn max_messages(mut self, max_messages: usize) -> Self {
+        self.max_messages = Some(max_messages);
+        self
+    }
+
+    /// Whether transient server-streaming errors should terminate the run
+    /// (`true`) or trigger a reconnect with exponential backoff (`false`,
+    /// the default).
+    pub fn terminate_on_error(mut self, terminate_on_error: bool) -> Self {
+        self.terminate_on_error = terminate_on_error;
+        self
+    }
+
+    /// Set the initial reconnect backoff for server-streaming RPCs.
+    pub fn reconnect_initial_backoff(mut self, backoff: Duration) -> Self {
+        self.reconnect_initial_backoff = backoff;
+        self
+    }
+
+    /// Set the maximum reconnect backoff for server-streaming RPCs.
+    pub fn reconnect_max_backoff(mut self, backoff: Duration) -> Self {
+        self.reconnect_max_backoff = backoff;
+        self
+    }
+
+    /// Cap the number of reconnect attempts for server-streaming RPCs.
+    pub fn reconnect_max_attempts(mut self, attempts: u32) -> Self {
+        self.reconnect_max_attempts = Some(attempts);
         self
     }
 }
@@ -146,6 +256,12 @@ mod tests {
         assert_eq!(config.method_name, "ListUsers");
         assert!(config.records_path.is_none());
         assert!(matches!(config.auth, GrpcAuth::None));
+        assert_eq!(config.rpc_kind, RpcKind::Unary);
+        assert!(config.max_messages.is_none());
+        assert!(!config.terminate_on_error);
+        assert_eq!(config.reconnect_initial_backoff, Duration::from_secs(1));
+        assert_eq!(config.reconnect_max_backoff, Duration::from_secs(30));
+        assert!(config.reconnect_max_attempts.is_none());
     }
 
     #[test]
@@ -243,5 +359,75 @@ mod tests {
         }"#;
         let config: GrpcStreamConfig = serde_json::from_str(json).unwrap();
         assert_eq!(config.batch_size, faucet_core::DEFAULT_BATCH_SIZE);
+    }
+
+    #[test]
+    fn server_streaming_fields_deserialize_from_json() {
+        let json = r#"{
+            "endpoint": "http://localhost:50051",
+            "service_name": "events.EventService",
+            "method_name": "Tail",
+            "request": {},
+            "descriptor_set_path": "proto/descriptor.bin",
+            "auth": { "type": "None" },
+            "tls": null,
+            "records_path": null,
+            "rpc_kind": "server_streaming",
+            "max_messages": 100,
+            "terminate_on_error": true,
+            "reconnect_initial_backoff": 2,
+            "reconnect_max_backoff": 60,
+            "reconnect_max_attempts": 5
+        }"#;
+        let config: GrpcStreamConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.rpc_kind, RpcKind::ServerStreaming);
+        assert_eq!(config.max_messages, Some(100));
+        assert!(config.terminate_on_error);
+        assert_eq!(config.reconnect_initial_backoff, Duration::from_secs(2));
+        assert_eq!(config.reconnect_max_backoff, Duration::from_secs(60));
+        assert_eq!(config.reconnect_max_attempts, Some(5));
+    }
+
+    #[test]
+    fn server_streaming_fields_default_when_absent_from_json() {
+        let json = r#"{
+            "endpoint": "http://localhost:50051",
+            "service_name": "users.UserService",
+            "method_name": "ListUsers",
+            "request": {},
+            "descriptor_set_path": "proto/descriptor.bin",
+            "auth": { "type": "None" },
+            "tls": null,
+            "records_path": null
+        }"#;
+        let config: GrpcStreamConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.rpc_kind, RpcKind::Unary);
+        assert!(config.max_messages.is_none());
+        assert!(!config.terminate_on_error);
+        assert_eq!(config.reconnect_initial_backoff, Duration::from_secs(1));
+        assert_eq!(config.reconnect_max_backoff, Duration::from_secs(30));
+        assert!(config.reconnect_max_attempts.is_none());
+    }
+
+    #[test]
+    fn rpc_kind_builder() {
+        let config = GrpcStreamConfig::new(
+            "http://localhost:50051",
+            "events.EventService",
+            "Tail",
+            "proto/descriptor.bin",
+        )
+        .rpc_kind(RpcKind::ServerStreaming)
+        .max_messages(50)
+        .terminate_on_error(true)
+        .reconnect_initial_backoff(Duration::from_secs(5))
+        .reconnect_max_backoff(Duration::from_secs(120))
+        .reconnect_max_attempts(10);
+        assert_eq!(config.rpc_kind, RpcKind::ServerStreaming);
+        assert_eq!(config.max_messages, Some(50));
+        assert!(config.terminate_on_error);
+        assert_eq!(config.reconnect_initial_backoff, Duration::from_secs(5));
+        assert_eq!(config.reconnect_max_backoff, Duration::from_secs(120));
+        assert_eq!(config.reconnect_max_attempts, Some(10));
     }
 }

--- a/crates/source/grpc/src/lib.rs
+++ b/crates/source/grpc/src/lib.rs
@@ -3,6 +3,11 @@
 //! A config-driven gRPC source that uses protobuf reflection to call
 //! any gRPC service dynamically and return records as JSON.
 //!
+//! Supports both [`RpcKind::Unary`] (one request → one response) and
+//! [`RpcKind::ServerStreaming`] (one request → server-driven stream of
+//! responses) — see the crate README for the differences in batching and
+//! reconnect behaviour.
+//!
 //! Requires a compiled `FileDescriptorSet` (produced by
 //! `protoc --descriptor_set_out=descriptor.bin`).
 
@@ -11,5 +16,5 @@ pub mod stream;
 
 pub use faucet_core::{FaucetError, Source};
 
-pub use config::{GrpcAuth, GrpcStreamConfig, MetadataEntry};
+pub use config::{GrpcAuth, GrpcStreamConfig, MetadataEntry, RpcKind};
 pub use stream::GrpcStream;

--- a/crates/source/grpc/src/stream.rs
+++ b/crates/source/grpc/src/stream.rs
@@ -1,12 +1,15 @@
 //! gRPC stream executor using dynamic protobuf messages.
 
-use crate::config::{GrpcAuth, GrpcStreamConfig};
+use crate::config::{GrpcAuth, GrpcStreamConfig, RpcKind};
 use async_trait::async_trait;
-use faucet_core::FaucetError;
+use faucet_core::{FaucetError, StreamPage};
+use futures_core::Stream;
 use prost::Message;
 use prost::bytes::Bytes;
-use prost_reflect::{DescriptorPool, DynamicMessage, SerializeOptions};
+use prost_reflect::{DescriptorPool, DynamicMessage, MessageDescriptor, SerializeOptions};
 use serde_json::Value;
+use std::pin::Pin;
+use std::time::Duration;
 use tonic::codec::{Codec, DecodeBuf, Decoder, EncodeBuf, Encoder};
 use tonic::transport::Channel;
 
@@ -52,9 +55,223 @@ impl GrpcStream {
         method_name: &str,
         request: &Value,
     ) -> Result<Vec<Value>, FaucetError> {
-        let full_method = format!("/{service_name}/{method_name}");
+        let (output_desc, request_bytes) = self.prepare_call(service_name, method_name, request)?;
+        let path = parse_method_path(service_name, method_name)?;
 
-        // Look up the method descriptor.
+        match self.config.rpc_kind {
+            RpcKind::Unary => {
+                let channel = self.connect_channel(endpoint).await?;
+                let mut grpc_client = tonic::client::Grpc::new(channel);
+                grpc_client
+                    .ready()
+                    .await
+                    .map_err(|e| FaucetError::Config(format!("gRPC channel not ready: {e}")))?;
+
+                let codec = DynamicCodec::new(output_desc);
+                let request = self.build_grpc_request(request_bytes)?;
+
+                let response: tonic::Response<DynamicMessage> = grpc_client
+                    .unary(request, path, codec)
+                    .await
+                    .map_err(|e| FaucetError::Source(format!("gRPC unary call failed: {e}")))?;
+
+                let resp_msg = response.into_inner();
+                let records =
+                    serialize_and_extract(&resp_msg, self.config.records_path.as_deref())?;
+                tracing::info!(records = records.len(), "gRPC unary fetch complete");
+                Ok(records)
+            }
+            RpcKind::ServerStreaming => {
+                self.fetch_server_streaming_collect(endpoint, path, output_desc, request_bytes)
+                    .await
+            }
+        }
+    }
+
+    /// Drain a server-streaming RPC into a fully-buffered `Vec<Value>`.
+    ///
+    /// Reconnect-on-error and `max_messages` are honoured. The full result
+    /// is collected before returning, so memory is O(stream length). For
+    /// memory-bounded consumption use [`Source::stream_pages`].
+    async fn fetch_server_streaming_collect(
+        &self,
+        endpoint: &str,
+        path: tonic::codegen::http::uri::PathAndQuery,
+        output_desc: MessageDescriptor,
+        request_bytes: Vec<u8>,
+    ) -> Result<Vec<Value>, FaucetError> {
+        let max_messages = self.config.max_messages.unwrap_or(usize::MAX);
+        let mut all: Vec<Value> = Vec::new();
+        let mut messages_seen: usize = 0;
+        let mut attempt: u32 = 0;
+        let mut backoff = self.config.reconnect_initial_backoff;
+        let max_backoff = self.config.reconnect_max_backoff;
+
+        loop {
+            match self
+                .drive_server_streaming_once(
+                    endpoint,
+                    path.clone(),
+                    output_desc.clone(),
+                    request_bytes.clone(),
+                    max_messages,
+                    messages_seen,
+                    |records| {
+                        all.extend(records);
+                        Ok(())
+                    },
+                )
+                .await
+            {
+                Ok(consumed) => {
+                    tracing::info!(
+                        records = all.len(),
+                        messages = messages_seen + consumed,
+                        "gRPC server-streaming fetch complete"
+                    );
+                    return Ok(all);
+                }
+                Err(StreamOutcome::Done(consumed)) => {
+                    messages_seen += consumed;
+                    tracing::info!(
+                        records = all.len(),
+                        messages = messages_seen,
+                        "gRPC server-streaming fetch complete (max_messages reached)"
+                    );
+                    return Ok(all);
+                }
+                Err(StreamOutcome::Transient { consumed, error }) => {
+                    messages_seen += consumed;
+                    if self.config.terminate_on_error {
+                        return Err(error);
+                    }
+                    if let Some(max_attempts) = self.config.reconnect_max_attempts
+                        && attempt >= max_attempts
+                    {
+                        return Err(FaucetError::Source(format!(
+                            "gRPC server-streaming exceeded reconnect_max_attempts={max_attempts}: {error}"
+                        )));
+                    }
+                    attempt += 1;
+                    tracing::warn!(
+                        attempt,
+                        backoff_ms = backoff.as_millis() as u64,
+                        error = %error,
+                        "gRPC server-streaming transient error, reconnecting"
+                    );
+                    tokio::time::sleep(backoff).await;
+                    backoff = next_backoff(backoff, max_backoff);
+                }
+            }
+        }
+    }
+
+    /// Open one server-streaming attempt and drain it until the server closes,
+    /// `max_messages` is hit, or a transport/status error occurs.
+    ///
+    /// On clean end-of-stream returns `Ok(consumed_messages)` so the caller can
+    /// stop retrying. On `max_messages` returns `Err(StreamOutcome::Done(...))`
+    /// (a "logical done", not a transient failure). On transient error returns
+    /// `Err(StreamOutcome::Transient { ... })` and the caller may reconnect.
+    #[allow(clippy::too_many_arguments)]
+    async fn drive_server_streaming_once<F>(
+        &self,
+        endpoint: &str,
+        path: tonic::codegen::http::uri::PathAndQuery,
+        output_desc: MessageDescriptor,
+        request_bytes: Vec<u8>,
+        max_messages: usize,
+        already_seen: usize,
+        mut on_records: F,
+    ) -> Result<usize, StreamOutcome>
+    where
+        F: FnMut(Vec<Value>) -> Result<(), FaucetError>,
+    {
+        let channel = match self.connect_channel(endpoint).await {
+            Ok(c) => c,
+            Err(e) => {
+                return Err(StreamOutcome::Transient {
+                    consumed: 0,
+                    error: e,
+                });
+            }
+        };
+
+        let mut grpc_client = tonic::client::Grpc::new(channel);
+        if let Err(e) = grpc_client.ready().await {
+            return Err(StreamOutcome::Transient {
+                consumed: 0,
+                error: FaucetError::Source(format!("gRPC channel not ready: {e}")),
+            });
+        }
+
+        let codec = DynamicCodec::new(output_desc);
+        let request = match self.build_grpc_request(request_bytes) {
+            Ok(r) => r,
+            Err(e) => {
+                // Auth/metadata errors are not transient — propagate directly.
+                return Err(StreamOutcome::Transient {
+                    consumed: 0,
+                    error: e,
+                });
+            }
+        };
+
+        let response = match grpc_client.server_streaming(request, path, codec).await {
+            Ok(r) => r,
+            Err(status) => {
+                return Err(StreamOutcome::Transient {
+                    consumed: 0,
+                    error: FaucetError::Source(format!(
+                        "gRPC server-streaming start failed: {status}"
+                    )),
+                });
+            }
+        };
+
+        let mut streaming = response.into_inner();
+        let records_path = self.config.records_path.as_deref();
+        let mut consumed: usize = 0;
+
+        loop {
+            if already_seen + consumed >= max_messages {
+                return Err(StreamOutcome::Done(consumed));
+            }
+            match streaming.message().await {
+                Ok(Some(msg)) => {
+                    let records = match serialize_and_extract(&msg, records_path) {
+                        Ok(r) => r,
+                        Err(e) => {
+                            return Err(StreamOutcome::Transient { consumed, error: e });
+                        }
+                    };
+                    if let Err(e) = on_records(records) {
+                        return Err(StreamOutcome::Transient { consumed, error: e });
+                    }
+                    consumed += 1;
+                }
+                Ok(None) => {
+                    return Ok(consumed);
+                }
+                Err(status) => {
+                    return Err(StreamOutcome::Transient {
+                        consumed,
+                        error: FaucetError::Source(format!(
+                            "gRPC server-streaming recv failed: {status}"
+                        )),
+                    });
+                }
+            }
+        }
+    }
+
+    /// Look up the method's output descriptor and encode the request message.
+    fn prepare_call(
+        &self,
+        service_name: &str,
+        method_name: &str,
+        request: &Value,
+    ) -> Result<(MessageDescriptor, Vec<u8>), FaucetError> {
         let service = self.pool.get_service_by_name(service_name).ok_or_else(|| {
             FaucetError::Config(format!(
                 "service '{service_name}' not found in descriptor set",
@@ -70,12 +287,16 @@ impl GrpcStream {
                 ))
             })?;
 
-        // Build the request message from JSON.
         let input_desc = method.input();
         let request_msg = DynamicMessage::deserialize(input_desc, request)
             .map_err(|e| FaucetError::Config(format!("failed to build request message: {e}")))?;
+        let request_bytes = request_msg.encode_to_vec();
 
-        // Connect to the gRPC endpoint.
+        Ok((method.output(), request_bytes))
+    }
+
+    /// Connect a tonic `Channel`, honouring the configured TLS mode.
+    async fn connect_channel(&self, endpoint: &str) -> Result<Channel, FaucetError> {
         let use_tls = self
             .config
             .tls
@@ -84,35 +305,30 @@ impl GrpcStream {
         let channel_endpoint = Channel::from_shared(endpoint.to_string())
             .map_err(|e| FaucetError::Url(format!("invalid gRPC endpoint: {e}")))?;
 
-        let channel: Channel = if use_tls {
+        let channel = if use_tls {
             channel_endpoint
                 .tls_config(tonic::transport::ClientTlsConfig::new())
                 .map_err(|e| FaucetError::Config(format!("TLS config failed: {e}")))?
                 .connect()
                 .await
-                .map_err(|e| FaucetError::Config(format!("gRPC connect failed: {e}")))?
+                .map_err(|e| FaucetError::Source(format!("gRPC connect failed: {e}")))?
         } else {
             channel_endpoint
                 .connect()
                 .await
-                .map_err(|e| FaucetError::Config(format!("gRPC connect failed: {e}")))?
+                .map_err(|e| FaucetError::Source(format!("gRPC connect failed: {e}")))?
         };
 
-        let output_desc = method.output();
+        Ok(channel)
+    }
 
-        let mut grpc_client = tonic::client::Grpc::new(channel);
-        grpc_client
-            .ready()
-            .await
-            .map_err(|e| FaucetError::Config(format!("gRPC channel not ready: {e}")))?;
+    /// Wrap raw request bytes in a `tonic::Request` and attach auth metadata.
+    fn build_grpc_request(
+        &self,
+        request_bytes: Vec<u8>,
+    ) -> Result<tonic::Request<Vec<u8>>, FaucetError> {
+        let mut request = tonic::Request::new(request_bytes);
 
-        let codec = DynamicCodec::new(output_desc);
-        let path = tonic::codegen::http::uri::PathAndQuery::from_maybe_shared(full_method)
-            .map_err(|e| FaucetError::Url(format!("invalid method path: {e}")))?;
-
-        let mut request = tonic::Request::new(request_msg.encode_to_vec());
-
-        // Apply auth metadata.
         match &self.config.auth {
             GrpcAuth::None => {}
             GrpcAuth::Bearer { token } => {
@@ -137,27 +353,7 @@ impl GrpcStream {
             }
         }
 
-        let response: tonic::Response<DynamicMessage> = grpc_client
-            .unary(request, path, codec)
-            .await
-            .map_err(|e| FaucetError::Sink(format!("gRPC call failed: {e}")))?;
-
-        let resp_msg = response.into_inner();
-
-        // Convert response to JSON.
-        let serialize_opts = SerializeOptions::new().stringify_64_bit_integers(false);
-        let json_value = resp_msg
-            .serialize_with_options(serde_json::value::Serializer, &serialize_opts)
-            .map_err(|e| {
-                FaucetError::Transform(format!("failed to serialize gRPC response to JSON: {e}"))
-            })?;
-
-        // Extract records using JSONPath if configured.
-        let records =
-            faucet_core::util::extract_records(&json_value, self.config.records_path.as_deref())?;
-
-        tracing::info!(records = records.len(), "gRPC fetch complete");
-        Ok(records)
+        Ok(request)
     }
 }
 
@@ -189,10 +385,255 @@ impl faucet_core::Source for GrpcStream {
             .await
     }
 
+    /// Stream records page-by-page.
+    ///
+    /// For [`RpcKind::Unary`] this falls back to the default trait impl
+    /// (buffer the full response, then chunk in memory) — see the README's
+    /// "Streaming and batching" section for the rationale.
+    ///
+    /// For [`RpcKind::ServerStreaming`] this opens the gRPC stream and
+    /// flushes a page each time the buffer hits `config.batch_size`
+    /// (`batch_size = 0` drains the entire stream before yielding). The
+    /// trait-level `batch_size` argument is ignored in favour of the config
+    /// field so a pipeline-supplied hint cannot silently override an explicit
+    /// config value. Transient stream errors reconnect with exponential
+    /// backoff up to `reconnect_max_attempts`, unless `terminate_on_error =
+    /// true` in which case the run terminates. Server-streaming pages carry
+    /// `bookmark: None` — this source has no native cursor/offset, so
+    /// resumption is driven by user-supplied request fields (e.g. an event
+    /// id), not a faucet-managed bookmark.
+    fn stream_pages<'a>(
+        &'a self,
+        context: &'a std::collections::HashMap<String, Value>,
+        batch_size: usize,
+    ) -> Pin<Box<dyn Stream<Item = Result<StreamPage, FaucetError>> + Send + 'a>> {
+        match self.config.rpc_kind {
+            RpcKind::Unary => {
+                // Default impl: buffer via fetch_with_context_incremental and
+                // chunk in memory.
+                self.default_stream_pages(context, batch_size)
+            }
+            RpcKind::ServerStreaming => self.server_streaming_pages(context),
+        }
+    }
+
     fn config_schema(&self) -> serde_json::Value {
         serde_json::to_value(faucet_core::schema_for!(GrpcStreamConfig))
             .expect("schema serialization")
     }
+}
+
+impl GrpcStream {
+    /// Replica of the default `stream_pages` impl, kept private so the
+    /// override above can delegate to it for unary RPCs without exposing
+    /// trait internals.
+    fn default_stream_pages<'a>(
+        &'a self,
+        context: &'a std::collections::HashMap<String, Value>,
+        batch_size: usize,
+    ) -> Pin<Box<dyn Stream<Item = Result<StreamPage, FaucetError>> + Send + 'a>> {
+        use faucet_core::Source;
+        Box::pin(async_stream::try_stream! {
+            let (records, bookmark) = Source::fetch_with_context_incremental(self, context).await?;
+            let total = records.len();
+            let chunk = if batch_size == 0 { usize::MAX } else { batch_size };
+
+            if total == 0 {
+                if bookmark.is_some() {
+                    yield StreamPage { records: Vec::new(), bookmark };
+                }
+                return;
+            }
+
+            let mut iter = records.into_iter();
+            let mut consumed = 0usize;
+            loop {
+                let batch: Vec<Value> = iter.by_ref().take(chunk).collect();
+                if batch.is_empty() {
+                    break;
+                }
+                consumed += batch.len();
+                let page_bookmark = if consumed >= total { bookmark.clone() } else { None };
+                yield StreamPage { records: batch, bookmark: page_bookmark };
+            }
+        })
+    }
+
+    /// Server-streaming page stream — opens the stream, buffers per
+    /// `config.batch_size`, and yields a page on each fill. Reconnects on
+    /// transient errors unless `terminate_on_error` is set.
+    fn server_streaming_pages<'a>(
+        &'a self,
+        context: &'a std::collections::HashMap<String, Value>,
+    ) -> Pin<Box<dyn Stream<Item = Result<StreamPage, FaucetError>> + Send + 'a>> {
+        let batch_size = self.config.batch_size;
+        let page_chunk = if batch_size == 0 {
+            usize::MAX
+        } else {
+            batch_size
+        };
+        let initial_capacity = if batch_size == 0 { 1024 } else { batch_size };
+        let max_messages = self.config.max_messages.unwrap_or(usize::MAX);
+        let terminate_on_error = self.config.terminate_on_error;
+        let reconnect_max_attempts = self.config.reconnect_max_attempts;
+        let mut backoff = self.config.reconnect_initial_backoff;
+        let max_backoff = self.config.reconnect_max_backoff;
+
+        Box::pin(async_stream::try_stream! {
+            // Resolve context-substituted strings once per run — reconnects
+            // re-use the same resolved values so a long-lived stream is
+            // stable even if matrix placeholders change between runs.
+            let endpoint = if context.is_empty() {
+                self.config.endpoint.clone()
+            } else {
+                faucet_core::util::substitute_context(&self.config.endpoint, context)
+            };
+            let service_name = if context.is_empty() {
+                self.config.service_name.clone()
+            } else {
+                faucet_core::util::substitute_context(&self.config.service_name, context)
+            };
+            let method_name = if context.is_empty() {
+                self.config.method_name.clone()
+            } else {
+                faucet_core::util::substitute_context(&self.config.method_name, context)
+            };
+            let request: Value = if context.is_empty() {
+                self.config.request.clone()
+            } else {
+                let s = serde_json::to_string(&self.config.request)
+                    .map_err(|e| FaucetError::Config(format!("failed to serialize request: {e}")))?;
+                let s = faucet_core::util::substitute_context_json(&s, context);
+                serde_json::from_str(&s).map_err(|e| FaucetError::Config(format!(
+                    "failed to parse substituted request: {e}"
+                )))?
+            };
+
+            let (output_desc, request_bytes) =
+                self.prepare_call(&service_name, &method_name, &request)?;
+            let path = parse_method_path(&service_name, &method_name)?;
+
+            let mut buffer: Vec<Value> = Vec::with_capacity(initial_capacity);
+            let mut messages_seen: usize = 0;
+            let mut attempt: u32 = 0;
+
+            'reconnect: loop {
+                // Open one streaming attempt and drain it. The closure
+                // appends extracted records into `buffer` so we can keep
+                // emitting pages across reconnects.
+                let outcome = self.drive_server_streaming_once(
+                    &endpoint,
+                    path.clone(),
+                    output_desc.clone(),
+                    request_bytes.clone(),
+                    max_messages,
+                    messages_seen,
+                    |records| {
+                        buffer.extend(records);
+                        Ok(())
+                    },
+                ).await;
+
+                // Flush any complete pages accumulated in the buffer, even
+                // when the attempt ended in a transient error — records
+                // received before the disconnect are still valid.
+                while buffer.len() >= page_chunk {
+                    let drained: Vec<Value> = buffer.drain(..page_chunk).collect();
+                    yield StreamPage { records: drained, bookmark: None };
+                }
+
+                match outcome {
+                    Ok(consumed) => {
+                        messages_seen += consumed;
+                        // Clean end-of-stream — flush the trailing partial
+                        // buffer and stop.
+                        if !buffer.is_empty() {
+                            let final_records = std::mem::take(&mut buffer);
+                            yield StreamPage { records: final_records, bookmark: None };
+                        }
+                        tracing::info!(
+                            messages = messages_seen,
+                            "gRPC server-streaming complete"
+                        );
+                        break 'reconnect;
+                    }
+                    Err(StreamOutcome::Done(consumed)) => {
+                        messages_seen += consumed;
+                        if !buffer.is_empty() {
+                            let final_records = std::mem::take(&mut buffer);
+                            yield StreamPage { records: final_records, bookmark: None };
+                        }
+                        tracing::info!(
+                            messages = messages_seen,
+                            "gRPC server-streaming complete (max_messages reached)"
+                        );
+                        break 'reconnect;
+                    }
+                    Err(StreamOutcome::Transient { consumed, error }) => {
+                        messages_seen += consumed;
+                        if terminate_on_error {
+                            Err(error)?;
+                            unreachable!();
+                        }
+                        if let Some(max_attempts) = reconnect_max_attempts
+                            && attempt >= max_attempts
+                        {
+                            let final_err = FaucetError::Source(format!(
+                                "gRPC server-streaming exceeded reconnect_max_attempts={max_attempts}: {error}"
+                            ));
+                            Err(final_err)?;
+                            unreachable!();
+                        }
+                        attempt += 1;
+                        tracing::warn!(
+                            attempt,
+                            backoff_ms = backoff.as_millis() as u64,
+                            error = %error,
+                            "gRPC server-streaming transient error, reconnecting"
+                        );
+                        tokio::time::sleep(backoff).await;
+                        backoff = next_backoff(backoff, max_backoff);
+                    }
+                }
+            }
+        })
+    }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+fn parse_method_path(
+    service_name: &str,
+    method_name: &str,
+) -> Result<tonic::codegen::http::uri::PathAndQuery, FaucetError> {
+    let full_method = format!("/{service_name}/{method_name}");
+    tonic::codegen::http::uri::PathAndQuery::from_maybe_shared(full_method)
+        .map_err(|e| FaucetError::Url(format!("invalid method path: {e}")))
+}
+
+fn serialize_and_extract(
+    msg: &DynamicMessage,
+    records_path: Option<&str>,
+) -> Result<Vec<Value>, FaucetError> {
+    let serialize_opts = SerializeOptions::new().stringify_64_bit_integers(false);
+    let json_value = msg
+        .serialize_with_options(serde_json::value::Serializer, &serialize_opts)
+        .map_err(|e| {
+            FaucetError::Transform(format!("failed to serialize gRPC response to JSON: {e}"))
+        })?;
+    faucet_core::util::extract_records(&json_value, records_path)
+}
+
+fn next_backoff(current: Duration, cap: Duration) -> Duration {
+    current.saturating_mul(2).min(cap)
+}
+
+/// Outcome of one server-streaming attempt. `Done` is a logical stop signal
+/// (e.g. `max_messages` hit) that should not trigger a reconnect; `Transient`
+/// carries a real error that may be retried subject to the reconnect config.
+enum StreamOutcome {
+    Done(usize),
+    Transient { consumed: usize, error: FaucetError },
 }
 
 // ── Dynamic Codec ───────────────────────────────────────────────────────────
@@ -255,5 +696,28 @@ impl Decoder for DynamicDecoder {
         let msg = DynamicMessage::decode(self.desc.clone(), bytes)
             .map_err(|e| tonic::Status::internal(format!("protobuf decode error: {e}")))?;
         Ok(Some(msg))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn next_backoff_doubles_up_to_cap() {
+        let cap = Duration::from_secs(30);
+        let a = Duration::from_secs(1);
+        let b = next_backoff(a, cap);
+        let c = next_backoff(b, cap);
+        let d = next_backoff(c, cap);
+        let e = next_backoff(d, cap);
+        let f = next_backoff(e, cap);
+        let g = next_backoff(f, cap);
+        assert_eq!(b, Duration::from_secs(2));
+        assert_eq!(c, Duration::from_secs(4));
+        assert_eq!(d, Duration::from_secs(8));
+        assert_eq!(e, Duration::from_secs(16));
+        assert_eq!(f, Duration::from_secs(30));
+        assert_eq!(g, Duration::from_secs(30));
     }
 }

--- a/crates/source/grpc/tests/common/mod.rs
+++ b/crates/source/grpc/tests/common/mod.rs
@@ -1,0 +1,147 @@
+//! Test fixtures for `faucet-source-grpc` integration tests.
+//!
+//! Spins up an in-process `EchoService` tonic server backed by the `.proto`
+//! compiled in `build.rs`. The same server handles unary and server-streaming
+//! RPCs and includes a `fail_after` knob to exercise the source's reconnect
+//! path.
+
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use tokio::net::TcpListener;
+use tokio::sync::oneshot;
+use tokio_stream::wrappers::ReceiverStream;
+use tonic::{Request, Response, Status, transport::Server};
+
+pub mod pb {
+    tonic::include_proto!("faucet.test.echo");
+}
+
+use pb::echo_service_server::{EchoService, EchoServiceServer};
+use pb::{Event, Item, ListRequest, ListResponse, TailRequest};
+
+/// Path on disk to the descriptor set emitted by `build.rs`.
+pub fn descriptor_set_path() -> PathBuf {
+    PathBuf::from(env!("ECHO_DESCRIPTOR_PATH"))
+}
+
+#[derive(Default)]
+pub struct EchoServer {
+    /// Counts the number of `Tail` invocations seen — useful for verifying
+    /// reconnect behaviour (one connect per attempt).
+    pub tail_attempts: Arc<AtomicU32>,
+}
+
+#[tonic::async_trait]
+impl EchoService for EchoServer {
+    async fn list(&self, request: Request<ListRequest>) -> Result<Response<ListResponse>, Status> {
+        let count = request.into_inner().count;
+        let items = (0..count)
+            .map(|i| Item {
+                id: i,
+                name: format!("item-{i}"),
+            })
+            .collect();
+        Ok(Response::new(ListResponse { items }))
+    }
+
+    type TailStream = ReceiverStream<Result<Event, Status>>;
+
+    async fn tail(
+        &self,
+        request: Request<TailRequest>,
+    ) -> Result<Response<Self::TailStream>, Status> {
+        let req = request.into_inner();
+        let attempt = self.tail_attempts.fetch_add(1, Ordering::SeqCst);
+        let (tx, rx) = tokio::sync::mpsc::channel(16);
+        tokio::spawn(async move {
+            let mut emitted: u32 = 0;
+            while emitted < req.count {
+                // Fail-after injection: on the *first* attempt only, close
+                // the stream with an UNAVAILABLE status after `fail_after`
+                // events. Subsequent attempts run to completion so the test
+                // can assert the reconnect produced the full record set.
+                if req.fail_after > 0 && attempt == 0 && emitted >= req.fail_after {
+                    let _ = tx
+                        .send(Err(Status::unavailable("simulated disconnect")))
+                        .await;
+                    return;
+                }
+                let event = Event {
+                    seq: emitted as u64,
+                    payload: format!("event-{emitted}"),
+                };
+                if tx.send(Ok(event)).await.is_err() {
+                    return;
+                }
+                emitted += 1;
+            }
+        });
+        Ok(Response::new(ReceiverStream::new(rx)))
+    }
+}
+
+/// A running EchoService instance bound to an ephemeral port. Drop the handle
+/// to shut down the server.
+pub struct ServerHandle {
+    #[allow(dead_code)]
+    pub addr: SocketAddr,
+    pub endpoint: String,
+    pub tail_attempts: Arc<AtomicU32>,
+    shutdown: Option<oneshot::Sender<()>>,
+    join: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl Drop for ServerHandle {
+    fn drop(&mut self) {
+        if let Some(tx) = self.shutdown.take() {
+            let _ = tx.send(());
+        }
+        if let Some(handle) = self.join.take() {
+            // Best-effort: abort if the runtime is still alive. We don't
+            // await here to keep `Drop` non-async; the test runtime will
+            // reap the task on shutdown.
+            handle.abort();
+        }
+    }
+}
+
+/// Start an EchoService server bound to an OS-assigned port. Returns a
+/// handle whose `endpoint` field is the `http://127.0.0.1:PORT` URL the
+/// `GrpcStream` should connect to.
+pub async fn start_server() -> ServerHandle {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("local_addr");
+    let endpoint = format!("http://{addr}");
+
+    let server = EchoServer::default();
+    let tail_attempts = server.tail_attempts.clone();
+
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+
+    let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+    let join = tokio::spawn(async move {
+        let _ = Server::builder()
+            .add_service(EchoServiceServer::new(server))
+            .serve_with_incoming_shutdown(incoming, async move {
+                let _ = shutdown_rx.await;
+            })
+            .await;
+    });
+
+    // Wait for the server to become reachable before returning. tonic's
+    // `serve_with_incoming` is ready as soon as `bind` succeeded, but the
+    // first connect can still race against axum's routing setup on cold
+    // start — a tiny yield is enough.
+    tokio::task::yield_now().await;
+
+    ServerHandle {
+        addr,
+        endpoint,
+        tail_attempts,
+        shutdown: Some(shutdown_tx),
+        join: Some(join),
+    }
+}

--- a/crates/source/grpc/tests/proto/echo.proto
+++ b/crates/source/grpc/tests/proto/echo.proto
@@ -1,0 +1,44 @@
+syntax = "proto3";
+
+package faucet.test.echo;
+
+// EchoService is a minimal test fixture exercising both unary and
+// server-streaming RPCs against the dynamic gRPC source. It is built into
+// the test binary by `build.rs` and is not part of the public API.
+service EchoService {
+  // Unary RPC: returns a single response containing N records.
+  rpc List(ListRequest) returns (ListResponse);
+
+  // Server-streaming RPC: emits `count` Events, optionally failing on
+  // a chosen index to exercise reconnect logic.
+  rpc Tail(TailRequest) returns (stream Event);
+}
+
+message ListRequest {
+  uint32 count = 1;
+}
+
+message ListResponse {
+  repeated Item items = 1;
+}
+
+message Item {
+  uint32 id = 1;
+  string name = 2;
+}
+
+message TailRequest {
+  // Number of events to emit before closing the stream.
+  uint32 count = 1;
+  // If > 0, the server emits `fail_after` events, then closes the stream
+  // with an UNAVAILABLE status to simulate a transient disconnect. The
+  // client driver reconnects and the server begins emitting from 0 again
+  // (the test fixture remembers nothing across reconnects). Set to 0 to
+  // disable the failure injection.
+  uint32 fail_after = 2;
+}
+
+message Event {
+  uint64 seq = 1;
+  string payload = 2;
+}

--- a/crates/source/grpc/tests/server_streaming.rs
+++ b/crates/source/grpc/tests/server_streaming.rs
@@ -1,0 +1,195 @@
+//! Integration tests for `GrpcStream` against a real tonic `EchoService`.
+//!
+//! Each test starts an in-process server bound to an ephemeral port and
+//! drives the source through both the `fetch_all` and `stream_pages`
+//! surfaces.
+
+mod common;
+
+use std::sync::atomic::Ordering;
+
+use faucet_core::Source;
+use faucet_source_grpc::{GrpcStream, GrpcStreamConfig, RpcKind};
+use futures::StreamExt;
+use serde_json::json;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn unary_fetch_all_returns_all_items() {
+    let server = common::start_server().await;
+    let config = GrpcStreamConfig::new(
+        &server.endpoint,
+        "faucet.test.echo.EchoService",
+        "List",
+        common::descriptor_set_path(),
+    )
+    .request(json!({ "count": 5 }))
+    .records_path("$.items[*]");
+
+    let stream = GrpcStream::new(config).unwrap();
+    let records = stream.fetch_all().await.unwrap();
+
+    assert_eq!(records.len(), 5);
+    // Protobuf scalar defaults (id == 0) are omitted from the JSON output,
+    // so assert on `name` which is always present.
+    assert_eq!(records[0]["name"], "item-0");
+    assert_eq!(records[1]["id"], 1);
+    assert_eq!(records[4]["name"], "item-4");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn server_streaming_fetch_all_collects_all_events() {
+    let server = common::start_server().await;
+    let config = GrpcStreamConfig::new(
+        &server.endpoint,
+        "faucet.test.echo.EchoService",
+        "Tail",
+        common::descriptor_set_path(),
+    )
+    .request(json!({ "count": 7, "fail_after": 0 }))
+    .rpc_kind(RpcKind::ServerStreaming);
+
+    let stream = GrpcStream::new(config).unwrap();
+    let records = stream.fetch_all().await.unwrap();
+
+    assert_eq!(records.len(), 7);
+    for (i, rec) in records.iter().enumerate() {
+        assert_eq!(rec["payload"], format!("event-{i}"));
+    }
+    // A single attempt should be enough on the happy path.
+    assert_eq!(server.tail_attempts.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn server_streaming_stream_pages_yields_pages_of_batch_size() {
+    let server = common::start_server().await;
+    let config = GrpcStreamConfig::new(
+        &server.endpoint,
+        "faucet.test.echo.EchoService",
+        "Tail",
+        common::descriptor_set_path(),
+    )
+    .request(json!({ "count": 10, "fail_after": 0 }))
+    .rpc_kind(RpcKind::ServerStreaming)
+    .with_batch_size(3);
+
+    let stream = GrpcStream::new(config).unwrap();
+    let ctx = std::collections::HashMap::new();
+    let mut pages = stream.stream_pages(&ctx, 3);
+    let mut total = 0usize;
+    let mut page_sizes = Vec::new();
+    while let Some(page) = pages.next().await {
+        let page = page.unwrap();
+        page_sizes.push(page.records.len());
+        total += page.records.len();
+        // All server-streaming pages carry no bookmark — the source has no
+        // native cursor and the test fixture has no resume token.
+        assert!(page.bookmark.is_none());
+    }
+    assert_eq!(total, 10);
+    // 3 + 3 + 3 + 1 trailing
+    assert_eq!(page_sizes, vec![3, 3, 3, 1]);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn server_streaming_max_messages_caps_consumption() {
+    let server = common::start_server().await;
+    let config = GrpcStreamConfig::new(
+        &server.endpoint,
+        "faucet.test.echo.EchoService",
+        "Tail",
+        common::descriptor_set_path(),
+    )
+    .request(json!({ "count": 100, "fail_after": 0 }))
+    .rpc_kind(RpcKind::ServerStreaming)
+    .max_messages(4)
+    .with_batch_size(0);
+
+    let stream = GrpcStream::new(config).unwrap();
+    let records = stream.fetch_all().await.unwrap();
+    assert_eq!(records.len(), 4);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn server_streaming_reconnects_on_transient_error() {
+    let server = common::start_server().await;
+    let config = GrpcStreamConfig::new(
+        &server.endpoint,
+        "faucet.test.echo.EchoService",
+        "Tail",
+        common::descriptor_set_path(),
+    )
+    .request(json!({ "count": 5, "fail_after": 2 }))
+    .rpc_kind(RpcKind::ServerStreaming)
+    .reconnect_initial_backoff(std::time::Duration::from_millis(10))
+    .reconnect_max_backoff(std::time::Duration::from_millis(20))
+    .reconnect_max_attempts(3);
+
+    let stream = GrpcStream::new(config).unwrap();
+    let records = stream.fetch_all().await.unwrap();
+
+    // First attempt yields 2 events (events 0,1) then disconnects.
+    // Reconnect produces all 5 events (0..4) since the fixture restarts
+    // counting per connection. We collect everything seen across attempts.
+    assert_eq!(records.len(), 7);
+    assert_eq!(records[0]["payload"], "event-0");
+    assert_eq!(records[1]["payload"], "event-1");
+    // After reconnect, events 0..4 stream again.
+    assert_eq!(records[2]["payload"], "event-0");
+    assert_eq!(records[6]["payload"], "event-4");
+    assert_eq!(server.tail_attempts.load(Ordering::SeqCst), 2);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn server_streaming_terminate_on_error_propagates() {
+    let server = common::start_server().await;
+    let config = GrpcStreamConfig::new(
+        &server.endpoint,
+        "faucet.test.echo.EchoService",
+        "Tail",
+        common::descriptor_set_path(),
+    )
+    .request(json!({ "count": 5, "fail_after": 1 }))
+    .rpc_kind(RpcKind::ServerStreaming)
+    .terminate_on_error(true);
+
+    let stream = GrpcStream::new(config).unwrap();
+    let err = stream
+        .fetch_all()
+        .await
+        .expect_err("should propagate error");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("server-streaming") || msg.contains("simulated disconnect"),
+        "unexpected error: {msg}"
+    );
+    // Exactly one attempt — no reconnect when terminate_on_error is true.
+    assert_eq!(server.tail_attempts.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn server_streaming_reconnect_max_attempts_surfaces_error() {
+    // Server is bound but immediately shut down so every connect fails.
+    let server = common::start_server().await;
+    let endpoint = server.endpoint.clone();
+    drop(server);
+
+    let config = GrpcStreamConfig::new(
+        &endpoint,
+        "faucet.test.echo.EchoService",
+        "Tail",
+        common::descriptor_set_path(),
+    )
+    .request(json!({ "count": 1, "fail_after": 0 }))
+    .rpc_kind(RpcKind::ServerStreaming)
+    .reconnect_initial_backoff(std::time::Duration::from_millis(5))
+    .reconnect_max_backoff(std::time::Duration::from_millis(10))
+    .reconnect_max_attempts(2);
+
+    let stream = GrpcStream::new(config).unwrap();
+    let err = stream.fetch_all().await.expect_err("should give up");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("reconnect_max_attempts"),
+        "unexpected error: {msg}"
+    );
+}

--- a/faucet-stream/README.md
+++ b/faucet-stream/README.md
@@ -34,7 +34,7 @@ faucet-stream = { version = "0.2", features = ["source-rest", "source-s3", "sink
 | `source-rest` | yes | REST API — auth, pagination, extraction, transforms |
 | `source-graphql` | no | GraphQL API — cursor pagination, variable injection |
 | `source-xml` | no | XML/SOAP API — XML-to-JSON conversion |
-| `source-grpc` | no | gRPC — dynamic protobuf via prost-reflect |
+| `source-grpc` | no | gRPC — dynamic protobuf via prost-reflect (unary + server-streaming) |
 | `source-postgres` | no | PostgreSQL — SQL queries as JSON |
 | `source-mysql` | no | MySQL — SQL queries as JSON |
 | `source-sqlite` | no | SQLite — SQL queries as JSON |


### PR DESCRIPTION
## Summary

- Adds `rpc_kind = "server_streaming"` to `faucet-source-grpc` alongside the existing unary path. Server-streaming calls `tonic::client::Grpc::server_streaming`, decodes each response with `prost-reflect`, and overrides `Source::stream_pages` to flush a page each time `batch_size` records accumulate — bounding both source-side and sink-side memory. Unary keeps the default chunk-the-buffer impl.
- Transient stream errors reconnect with exponential backoff (`reconnect_initial_backoff`, `reconnect_max_backoff`, `reconnect_max_attempts`); set `terminate_on_error = true` to surface the first failure instead. `max_messages` caps consumption. Pages carry no bookmark — server-streaming has no native cursor, so resumption is driven by user-supplied request fields (e.g. an `after_event_id`).
- Adds an in-process tonic `EchoService` fixture (`build.rs` + `tests/proto/echo.proto`) and 7 integration tests covering the unary path, streaming `fetch_all`, paged `stream_pages`, `max_messages`, reconnect-on-disconnect, `terminate_on_error`, and reconnect exhaustion. `build.rs` uses `protoc-bin-vendored` so the build doesn't depend on the system protoc.

Closes #34.

## Test plan

- [x] `cargo test -p faucet-source-grpc` — 12 unit + 7 integration tests pass
- [x] `cargo clippy -p faucet-source-grpc --all-targets --all-features -- -D warnings` clean
- [x] `cargo clippy -p faucet-stream --features source-grpc --all-targets -- -D warnings` clean
- [x] `cargo clippy -p faucet-cli --features source-grpc --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo check -p faucet-source-grpc --no-default-features` builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)