### PR TITLE
Pre-1.0 hardening: CRITICAL batch 1 (#78 findings #3, #4, #5, #6, #7, #8, #11)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,9 @@ on:
         required: true
         type: choice
         options:
-          - all         # bump + publish every crate (in rate-limited waves)
+          - all         # bump + publish every publishable crate (in rate-limited waves)
           - core        # faucet-core only
-          - connectors  # all sources + sinks (not core, not umbrella)
+          - connectors  # every publishable crate except faucet-core, the umbrella, and faucet-cli
           - umbrella    # faucet-stream umbrella only
           - custom      # specify crates in custom_crates input
       bump:
@@ -84,6 +84,41 @@ jobs:
       - name: Test
         run: cargo test --workspace --all-features
 
+      # ── Derive publishable crate lists from cargo metadata ────────────
+      #
+      # Single source of truth — never hand-maintain the list. The previous
+      # hardcoded arrays silently drifted and omitted 8 crates (parquet,
+      # gcs, sink-stdout, both state backends, faucet-cli), so `scope=all`
+      # would have shipped a broken release (#78/#11).
+      #
+      # `ordered_all` is every publishable workspace member (publish != false)
+      # in dependency order, computed with `tsort` over the intra-workspace
+      # normal/build deps so the wave-publish step never tries to publish a
+      # crate before its dependencies. `ordered_connectors` drops faucet-core,
+      # the umbrella, and the CLI binary.
+      - name: Compute publishable crate lists
+        run: |
+          metadata=$(cargo metadata --no-deps --format-version 1)
+          set_json=$(echo "$metadata" | jq '[.packages[] | select(.publish==null) | .name]')
+          ordered_all=$(
+            {
+              # Anchor every member to a synthetic root so isolated crates are
+              # still emitted, then add a "dep pkg" edge per intra-workspace
+              # (non-dev) dependency so tsort orders dependencies first.
+              echo "$set_json" | jq -r '.[] | "__root__ \(.)"'
+              echo "$metadata" | jq -r --argjson set "$set_json" '
+                .packages[] | select(.publish==null) as $p
+                | $p.dependencies[]? | select(.kind != "dev")
+                | select(.name as $n | $set | index($n))
+                | "\(.name) \($p.name)"'
+            } | tsort | grep -vx '__root__'
+          )
+          ordered_connectors=$(echo "$ordered_all" | grep -vxE 'faucet-core|faucet-stream|faucet-cli')
+          echo "Publishable crates in dependency order:"
+          echo "$ordered_all" | nl
+          echo "ordered_all=$(echo "$ordered_all" | tr '\n' ' ')" >> "$GITHUB_ENV"
+          echo "ordered_connectors=$(echo "$ordered_connectors" | tr '\n' ' ')" >> "$GITHUB_ENV"
+
       # ── Dry run ───────────────────────────────────────────────────────
       - name: Release (dry run)
         if: ${{ inputs.dry_run }}
@@ -91,51 +126,14 @@ jobs:
           SCOPE="${{ inputs.scope }}"
           BUMP="${{ inputs.bump }}"
 
-          # Dry run: bump versions locally, no publish, no git changes
-          all_crates=(
-            faucet-core
-            faucet-kafka-common
-            faucet-elasticsearch-common
-            faucet-gcs-common
-            faucet-bigquery-common
-            faucet-snowflake-common
-            faucet-source-rest faucet-source-graphql faucet-source-xml
-            faucet-source-grpc faucet-source-postgres faucet-source-postgres-cdc
-            faucet-source-mysql
-            faucet-source-sqlite faucet-source-s3 faucet-source-mongodb
-            faucet-source-redis faucet-source-webhook faucet-source-csv
-            faucet-source-elasticsearch faucet-source-kafka faucet-source-bigquery faucet-source-snowflake
-            faucet-sink-bigquery faucet-sink-postgres faucet-sink-jsonl
-            faucet-sink-snowflake faucet-sink-mysql faucet-sink-sqlite
-            faucet-sink-s3 faucet-sink-mongodb faucet-sink-redis
-            faucet-sink-csv faucet-sink-elasticsearch faucet-sink-http
-            faucet-sink-kafka
-            faucet-stream
-          )
-          connectors=(
-            faucet-kafka-common
-            faucet-elasticsearch-common
-            faucet-gcs-common
-            faucet-bigquery-common
-            faucet-snowflake-common
-            faucet-source-rest faucet-source-graphql faucet-source-xml
-            faucet-source-grpc faucet-source-postgres faucet-source-postgres-cdc
-            faucet-source-mysql
-            faucet-source-sqlite faucet-source-s3 faucet-source-mongodb
-            faucet-source-redis faucet-source-webhook faucet-source-csv
-            faucet-source-elasticsearch faucet-source-kafka faucet-source-bigquery faucet-source-snowflake
-            faucet-sink-bigquery faucet-sink-postgres faucet-sink-jsonl
-            faucet-sink-snowflake faucet-sink-mysql faucet-sink-sqlite
-            faucet-sink-s3 faucet-sink-mongodb faucet-sink-redis
-            faucet-sink-csv faucet-sink-elasticsearch faucet-sink-http
-            faucet-sink-kafka
-          )
+          read -ra all_crates <<< "$ordered_all"
+          read -ra connectors <<< "$ordered_connectors"
 
           case "$SCOPE" in
-            all)      selected=("${all_crates[@]}") ;;
-            core)     selected=(faucet-core) ;;
+            all)        selected=("${all_crates[@]}") ;;
+            core)       selected=(faucet-core) ;;
             connectors) selected=("${connectors[@]}") ;;
-            umbrella) selected=(faucet-stream) ;;
+            umbrella)   selected=(faucet-stream) ;;
             custom)
               IFS=',' read -ra selected <<< "${{ inputs.custom_crates }}"
               selected=("${selected[@]// /}")  # trim whitespace
@@ -163,44 +161,8 @@ jobs:
           SCOPE="${{ inputs.scope }}"
           BUMP="${{ inputs.bump }}"
 
-          all_crates=(
-            faucet-core
-            faucet-kafka-common
-            faucet-elasticsearch-common
-            faucet-gcs-common
-            faucet-bigquery-common
-            faucet-snowflake-common
-            faucet-source-rest faucet-source-graphql faucet-source-xml
-            faucet-source-grpc faucet-source-postgres faucet-source-postgres-cdc
-            faucet-source-mysql
-            faucet-source-sqlite faucet-source-s3 faucet-source-mongodb
-            faucet-source-redis faucet-source-webhook faucet-source-csv
-            faucet-source-elasticsearch faucet-source-kafka faucet-source-bigquery faucet-source-snowflake
-            faucet-sink-bigquery faucet-sink-postgres faucet-sink-jsonl
-            faucet-sink-snowflake faucet-sink-mysql faucet-sink-sqlite
-            faucet-sink-s3 faucet-sink-mongodb faucet-sink-redis
-            faucet-sink-csv faucet-sink-elasticsearch faucet-sink-http
-            faucet-sink-kafka
-            faucet-stream
-          )
-          connectors=(
-            faucet-kafka-common
-            faucet-elasticsearch-common
-            faucet-gcs-common
-            faucet-bigquery-common
-            faucet-snowflake-common
-            faucet-source-rest faucet-source-graphql faucet-source-xml
-            faucet-source-grpc faucet-source-postgres faucet-source-postgres-cdc
-            faucet-source-mysql
-            faucet-source-sqlite faucet-source-s3 faucet-source-mongodb
-            faucet-source-redis faucet-source-webhook faucet-source-csv
-            faucet-source-elasticsearch faucet-source-kafka faucet-source-bigquery faucet-source-snowflake
-            faucet-sink-bigquery faucet-sink-postgres faucet-sink-jsonl
-            faucet-sink-snowflake faucet-sink-mysql faucet-sink-sqlite
-            faucet-sink-s3 faucet-sink-mongodb faucet-sink-redis
-            faucet-sink-csv faucet-sink-elasticsearch faucet-sink-http
-            faucet-sink-kafka
-          )
+          read -ra all_crates <<< "$ordered_all"
+          read -ra connectors <<< "$ordered_connectors"
 
           case "$SCOPE" in
             all)        selected=("${all_crates[@]}") ;;

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -380,188 +380,224 @@ where
     let sink_name = sink.connector_name();
     let dlq_sink_name = dlq.as_ref().map(|d| d.sink.connector_name()).unwrap_or("");
 
-    loop {
-        let page = std::future::poll_fn(|cx| Pin::new(&mut pages).poll_next(cx)).await;
-        match page {
-            Some(Ok(page)) => {
-                if page.records.is_empty() && page.bookmark.is_none() {
-                    continue;
-                }
-
-                if let Some(ref dlq_cfg) = dlq {
-                    // ── DLQ-enabled path ───────────────────────────────────
-                    use crate::dlq::DlqReason;
-                    use metrics::{Label, SharedString, counter};
-                    let metric_labels: Vec<Label> = vec![
-                        Label::new("pipeline", SharedString::from(pipeline_name.clone())),
-                        Label::new("row", SharedString::from(row.clone())),
-                        Label::new("connector", SharedString::from(sink_name.to_string())),
-                        Label::new(
-                            "dlq_connector",
-                            SharedString::from(dlq_sink_name.to_string()),
-                        ),
-                    ];
-                    let span = tracing::info_span!(
-                        "faucet.dlq.route",
-                        pipeline = %pipeline_name,
-                        row = %row,
-                        run_id = %run_id,
-                        connector = %sink_name,
-                        dlq_connector = %dlq_sink_name,
-                    );
-                    let _enter = span.enter();
-
-                    let outcomes_result = if page.records.is_empty() {
-                        Ok(Vec::new())
-                    } else {
-                        sink.write_batch_partial(&page.records).await
-                    };
-                    let mut outer_err_recovered = false;
-                    let outcomes = match outcomes_result {
-                        Ok(o) => o,
-                        Err(e) => match dlq_cfg.on_batch_error {
-                            OnBatchError::Propagate => return Err(e),
-                            OnBatchError::DlqAll => {
-                                // Synthesize per-row failures echoing the
-                                // underlying message so envelopes carry it.
-                                // The flag distinguishes this from a sink
-                                // override that legitimately returned all
-                                // per-row Errs — that case keeps the
-                                // `partial` reason label.
-                                outer_err_recovered = true;
-                                let msg = e.to_string();
-                                (0..page.records.len())
-                                    .map(|_| Err(FaucetError::Sink(msg.clone())))
-                                    .collect()
-                            }
-                        },
-                    };
-
-                    // Partition into success count + failure envelopes.
-                    let mut envelopes: Vec<Value> = Vec::new();
-                    let mut page_success = 0usize;
-                    for (i, outcome) in outcomes.iter().enumerate() {
-                        match outcome {
-                            Ok(()) => page_success += 1,
-                            Err(err) => envelopes.push(build_envelope(
-                                &page.records[i],
-                                err,
-                                sink_name,
-                                &pipeline_name,
-                                &row,
-                                i,
-                            )),
-                        }
-                    }
-                    let page_failures = envelopes.len();
-
-                    // Budget checks — increment counter before returning.
-                    if let Some(limit) = dlq_cfg.max_failures_per_page
-                        && page_failures > limit
-                    {
-                        let mut lbl = metric_labels.clone();
-                        lbl.retain(|l| l.key() != "dlq_connector");
-                        lbl.push(Label::new("scope", SharedString::const_str("per_page")));
-                        counter!("faucet_sink_dlq_budget_exceeded_total", lbl).increment(1);
-                        return Err(FaucetError::Sink(format!(
-                            "DLQ per-page budget exceeded: {page_failures} > {limit}"
-                        )));
-                    }
-                    let new_total = dlq_stats.records_dlq + page_failures;
-                    if let Some(limit) = dlq_cfg.max_failures_total
-                        && new_total > limit
-                    {
-                        let mut lbl = metric_labels.clone();
-                        lbl.retain(|l| l.key() != "dlq_connector");
-                        lbl.push(Label::new("scope", SharedString::const_str("total")));
-                        counter!("faucet_sink_dlq_budget_exceeded_total", lbl).increment(1);
-                        return Err(FaucetError::Sink(format!(
-                            "DLQ total budget exceeded: {new_total} > {limit}"
-                        )));
+    // Drive the streaming loop inside an inner future so that EVERY early exit
+    // (a source error, a `?`-propagated write/flush/state failure, or a DLQ
+    // budget overflow) funnels through one place. On any error we best-effort
+    // flush the sinks before propagating, so a buffered sink that only commits
+    // on flush — Parquet writes its footer there; without it the whole file is
+    // unreadable — does not lose everything written so far (#78/#3).
+    let loop_result: Result<(), FaucetError> = async {
+        loop {
+            let page = std::future::poll_fn(|cx| Pin::new(&mut pages).poll_next(cx)).await;
+            match page {
+                Some(Ok(page)) => {
+                    if page.records.is_empty() && page.bookmark.is_none() {
+                        continue;
                     }
 
-                    // Write to DLQ sink. Errors here are fatal, no recursion.
-                    if !envelopes.is_empty() {
-                        let _dlq_write_timer = crate::observability::DurationGuard::new(
-                            "faucet_sink_dlq_write_duration_seconds",
-                            metric_labels.clone(),
+                    if let Some(ref dlq_cfg) = dlq {
+                        // ── DLQ-enabled path ───────────────────────────────────
+                        use crate::dlq::DlqReason;
+                        use metrics::{Label, SharedString, counter};
+                        let metric_labels: Vec<Label> = vec![
+                            Label::new("pipeline", SharedString::from(pipeline_name.clone())),
+                            Label::new("row", SharedString::from(row.clone())),
+                            Label::new("connector", SharedString::from(sink_name.to_string())),
+                            Label::new(
+                                "dlq_connector",
+                                SharedString::from(dlq_sink_name.to_string()),
+                            ),
+                        ];
+                        let span = tracing::info_span!(
+                            "faucet.dlq.route",
+                            pipeline = %pipeline_name,
+                            row = %row,
+                            run_id = %run_id,
+                            connector = %sink_name,
+                            dlq_connector = %dlq_sink_name,
                         );
-                        dlq_cfg.sink.write_batch(&envelopes).await.map_err(|e| {
-                            let mut lbl = metric_labels.clone();
-                            lbl.push(Label::new(
-                                "kind",
-                                SharedString::const_str(
-                                    crate::observability::decorator::error_kind(&e),
-                                ),
-                            ));
-                            counter!("faucet_sink_dlq_errors_total", lbl).increment(1);
-                            FaucetError::Sink(format!("DLQ sink write failed: {e}"))
-                        })?;
-                        dlq_stats.records_dlq += page_failures;
-                        dlq_stats.pages_with_failures += 1;
+                        let _enter = span.enter();
 
-                        let reason_label = if outer_err_recovered {
-                            DlqReason::DlqAll.as_str()
+                        let outcomes_result = if page.records.is_empty() {
+                            Ok(Vec::new())
                         } else {
-                            DlqReason::Partial.as_str()
+                            sink.write_batch_partial(&page.records).await
                         };
-                        counter!("faucet_sink_dlq_records_total", metric_labels.clone())
-                            .increment(page_failures as u64);
-                        let mut page_labels = metric_labels.clone();
-                        page_labels
-                            .push(Label::new("reason", SharedString::const_str(reason_label)));
-                        counter!("faucet_sink_dlq_pages_total", page_labels).increment(1);
-                    }
+                        let mut outer_err_recovered = false;
+                        let outcomes = match outcomes_result {
+                            Ok(o) => o,
+                            Err(e) => match dlq_cfg.on_batch_error {
+                                OnBatchError::Propagate => return Err(e),
+                                OnBatchError::DlqAll => {
+                                    // Synthesize per-row failures echoing the
+                                    // underlying message so envelopes carry it.
+                                    // The flag distinguishes this from a sink
+                                    // override that legitimately returned all
+                                    // per-row Errs — that case keeps the
+                                    // `partial` reason label.
+                                    outer_err_recovered = true;
+                                    let msg = e.to_string();
+                                    (0..page.records.len())
+                                        .map(|_| Err(FaucetError::Sink(msg.clone())))
+                                        .collect()
+                                }
+                            },
+                        };
 
-                    records_written += page_success;
+                        // Partition into success count + failure envelopes.
+                        let mut envelopes: Vec<Value> = Vec::new();
+                        let mut page_success = 0usize;
+                        for (i, outcome) in outcomes.iter().enumerate() {
+                            match outcome {
+                                Ok(()) => page_success += 1,
+                                Err(err) => envelopes.push(build_envelope(
+                                    &page.records[i],
+                                    err,
+                                    sink_name,
+                                    &pipeline_name,
+                                    &row,
+                                    i,
+                                )),
+                            }
+                        }
+                        let page_failures = envelopes.len();
 
-                    if let Some(bookmark) = page.bookmark {
-                        sink.flush().await?;
-                        let _dlq_flush_timer = crate::observability::DurationGuard::new(
-                            "faucet_sink_dlq_flush_duration_seconds",
-                            metric_labels.clone(),
-                        );
-                        dlq_cfg.sink.flush().await.map_err(|e| {
+                        // Budget checks — increment counter before returning.
+                        if let Some(limit) = dlq_cfg.max_failures_per_page
+                            && page_failures > limit
+                        {
                             let mut lbl = metric_labels.clone();
-                            lbl.push(Label::new(
-                                "kind",
-                                SharedString::const_str(
-                                    crate::observability::decorator::error_kind(&e),
-                                ),
-                            ));
-                            counter!("faucet_sink_dlq_errors_total", lbl).increment(1);
-                            FaucetError::Sink(format!("DLQ sink flush failed: {e}"))
-                        })?;
-                        let bm_labels =
-                            crate::observability::Labels::new(&*pipeline_name, &*row, &*run_id);
-                        crate::observability::update_bookmark_lag(&bookmark, &bm_labels);
-                        if let (Some(store), Some(key)) = (state_store.as_ref(), state_key.as_ref())
-                        {
-                            store.put(key, &bookmark).await?;
+                            lbl.retain(|l| l.key() != "dlq_connector");
+                            lbl.push(Label::new("scope", SharedString::const_str("per_page")));
+                            counter!("faucet_sink_dlq_budget_exceeded_total", lbl).increment(1);
+                            return Err(FaucetError::Sink(format!(
+                                "DLQ per-page budget exceeded: {page_failures} > {limit}"
+                            )));
                         }
-                        last_bookmark = Some(bookmark);
-                    }
-                } else {
-                    // ── DLQ-disabled path (today's behaviour) ──────────────
-                    if !page.records.is_empty() {
-                        records_written += sink.write_batch(&page.records).await?;
-                    }
-                    if let Some(bookmark) = page.bookmark {
-                        sink.flush().await?;
-                        let bm_labels =
-                            crate::observability::Labels::new(&*pipeline_name, &*row, &*run_id);
-                        crate::observability::update_bookmark_lag(&bookmark, &bm_labels);
-                        if let (Some(store), Some(key)) = (state_store.as_ref(), state_key.as_ref())
+                        let new_total = dlq_stats.records_dlq + page_failures;
+                        if let Some(limit) = dlq_cfg.max_failures_total
+                            && new_total > limit
                         {
-                            store.put(key, &bookmark).await?;
+                            let mut lbl = metric_labels.clone();
+                            lbl.retain(|l| l.key() != "dlq_connector");
+                            lbl.push(Label::new("scope", SharedString::const_str("total")));
+                            counter!("faucet_sink_dlq_budget_exceeded_total", lbl).increment(1);
+                            return Err(FaucetError::Sink(format!(
+                                "DLQ total budget exceeded: {new_total} > {limit}"
+                            )));
                         }
-                        last_bookmark = Some(bookmark);
+
+                        // Write to DLQ sink. Errors here are fatal, no recursion.
+                        if !envelopes.is_empty() {
+                            let _dlq_write_timer = crate::observability::DurationGuard::new(
+                                "faucet_sink_dlq_write_duration_seconds",
+                                metric_labels.clone(),
+                            );
+                            dlq_cfg.sink.write_batch(&envelopes).await.map_err(|e| {
+                                let mut lbl = metric_labels.clone();
+                                lbl.push(Label::new(
+                                    "kind",
+                                    SharedString::const_str(
+                                        crate::observability::decorator::error_kind(&e),
+                                    ),
+                                ));
+                                counter!("faucet_sink_dlq_errors_total", lbl).increment(1);
+                                FaucetError::Sink(format!("DLQ sink write failed: {e}"))
+                            })?;
+                            dlq_stats.records_dlq += page_failures;
+                            dlq_stats.pages_with_failures += 1;
+
+                            let reason_label = if outer_err_recovered {
+                                DlqReason::DlqAll.as_str()
+                            } else {
+                                DlqReason::Partial.as_str()
+                            };
+                            counter!("faucet_sink_dlq_records_total", metric_labels.clone())
+                                .increment(page_failures as u64);
+                            let mut page_labels = metric_labels.clone();
+                            page_labels
+                                .push(Label::new("reason", SharedString::const_str(reason_label)));
+                            counter!("faucet_sink_dlq_pages_total", page_labels).increment(1);
+                        }
+
+                        records_written += page_success;
+
+                        if let Some(bookmark) = page.bookmark {
+                            sink.flush().await?;
+                            let _dlq_flush_timer = crate::observability::DurationGuard::new(
+                                "faucet_sink_dlq_flush_duration_seconds",
+                                metric_labels.clone(),
+                            );
+                            dlq_cfg.sink.flush().await.map_err(|e| {
+                                let mut lbl = metric_labels.clone();
+                                lbl.push(Label::new(
+                                    "kind",
+                                    SharedString::const_str(
+                                        crate::observability::decorator::error_kind(&e),
+                                    ),
+                                ));
+                                counter!("faucet_sink_dlq_errors_total", lbl).increment(1);
+                                FaucetError::Sink(format!("DLQ sink flush failed: {e}"))
+                            })?;
+                            let bm_labels =
+                                crate::observability::Labels::new(&*pipeline_name, &*row, &*run_id);
+                            crate::observability::update_bookmark_lag(&bookmark, &bm_labels);
+                            if let (Some(store), Some(key)) =
+                                (state_store.as_ref(), state_key.as_ref())
+                            {
+                                store.put(key, &bookmark).await?;
+                            }
+                            last_bookmark = Some(bookmark);
+                        }
+                    } else {
+                        // ── DLQ-disabled path (today's behaviour) ──────────────
+                        if !page.records.is_empty() {
+                            records_written += sink.write_batch(&page.records).await?;
+                        }
+                        if let Some(bookmark) = page.bookmark {
+                            sink.flush().await?;
+                            let bm_labels =
+                                crate::observability::Labels::new(&*pipeline_name, &*row, &*run_id);
+                            crate::observability::update_bookmark_lag(&bookmark, &bm_labels);
+                            if let (Some(store), Some(key)) =
+                                (state_store.as_ref(), state_key.as_ref())
+                            {
+                                store.put(key, &bookmark).await?;
+                            }
+                            last_bookmark = Some(bookmark);
+                        }
                     }
                 }
+                Some(Err(e)) => return Err(e),
+                None => break,
             }
-            Some(Err(e)) => return Err(e),
-            None => break,
         }
+        Ok(())
+    }
+    .await;
+
+    // Error/early-return unwind: best-effort flush so any buffered output is
+    // made durable, then propagate the ORIGINAL error. Flush errors here are
+    // logged and swallowed — the source/sink error that triggered the unwind
+    // is the meaningful one to surface. DLQ is flushed first (mirroring the
+    // success path below): its records are only ever written here, whereas the
+    // next run re-reads post-bookmark records from the source.
+    if let Err(e) = loop_result {
+        if let Some(ref dlq_cfg) = dlq
+            && let Err(flush_err) = dlq_cfg.sink.flush().await
+        {
+            tracing::warn!(
+                error = %flush_err,
+                "DLQ sink flush failed during error unwind; original error preserved"
+            );
+        }
+        if let Err(flush_err) = sink.flush().await {
+            tracing::warn!(
+                error = %flush_err,
+                "sink flush failed during error unwind; original error preserved"
+            );
+        }
+        return Err(e);
     }
 
     // Flush the DLQ sink BEFORE the main sink so quarantined records are made
@@ -696,6 +732,43 @@ mod tests {
     impl Sink for FailingSink {
         async fn write_batch(&self, _records: &[Value]) -> Result<usize, FaucetError> {
             Err(FaucetError::Sink("write failed".into()))
+        }
+    }
+
+    /// Records writes and how many times `flush` was called. Used to assert the
+    /// pipeline flushes the sink on the error/early-return path so partial
+    /// output (e.g. a Parquet footer) is made durable before the error
+    /// propagates.
+    struct FlushTrackingSink {
+        written: std::sync::Mutex<Vec<Value>>,
+        flush_count: std::sync::atomic::AtomicUsize,
+    }
+
+    impl FlushTrackingSink {
+        fn new() -> Self {
+            Self {
+                written: std::sync::Mutex::new(Vec::new()),
+                flush_count: std::sync::atomic::AtomicUsize::new(0),
+            }
+        }
+        fn written(&self) -> Vec<Value> {
+            self.written.lock().unwrap().clone()
+        }
+        fn flush_count(&self) -> usize {
+            self.flush_count.load(std::sync::atomic::Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait]
+    impl Sink for FlushTrackingSink {
+        async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
+            self.written.lock().unwrap().extend(records.iter().cloned());
+            Ok(records.len())
+        }
+        async fn flush(&self) -> Result<(), FaucetError> {
+            self.flush_count
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(())
         }
     }
 
@@ -834,6 +907,34 @@ mod tests {
         assert_eq!(result.records_written, 3);
         assert!(result.bookmark.is_none());
         assert_eq!(sink.written().len(), 3);
+    }
+
+    #[tokio::test]
+    async fn stream_pipeline_flushes_sink_on_source_error() {
+        // Regression for #78/#3: a mid-stream source error must not skip the
+        // sink flush. Without flushing, a buffered sink (e.g. Parquet, whose
+        // footer is only written on flush) loses everything written so far.
+        let pages: Vec<Result<StreamPage, FaucetError>> = vec![
+            Ok(StreamPage {
+                records: vec![json!({"id": 1}), json!({"id": 2})],
+                bookmark: None,
+            }),
+            Err(FaucetError::Source("transient blip mid-stream".into())),
+        ];
+        let stream = futures::stream::iter(pages);
+        let sink = FlushTrackingSink::new();
+
+        let result = run_stream(stream, &sink, RunStreamOptions::new()).await;
+
+        // The original source error must still propagate.
+        assert!(matches!(result, Err(FaucetError::Source(_))));
+        // The good page must have been written before the error.
+        assert_eq!(sink.written().len(), 2);
+        // Crucially, the sink must have been flushed on the error path.
+        assert!(
+            sink.flush_count() >= 1,
+            "sink must be flushed on the error path so partial output is durable"
+        );
     }
 
     #[tokio::test]

--- a/crates/core/src/state.rs
+++ b/crates/core/src/state.rs
@@ -412,7 +412,9 @@ mod tests {
         // payload makes a partial/unflushed write detectable on read-back.
         let dir = TempDir::new().unwrap();
         let s = FileStateStore::new(dir.path());
-        let big: Vec<Value> = (0..1_000).map(|i| json!({"i": i, "s": "x".repeat(20)})).collect();
+        let big: Vec<Value> = (0..1_000)
+            .map(|i| json!({"i": i, "s": "x".repeat(20)}))
+            .collect();
         let value = json!({"cursor": "abc", "rows": big});
 
         s.put("github_issues", &value).await.unwrap();

--- a/crates/core/src/state.rs
+++ b/crates/core/src/state.rs
@@ -18,6 +18,7 @@ use async_trait::async_trait;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use tokio::io::AsyncWriteExt;
 use tokio::sync::Mutex;
 
 /// Persistent key/value store for replication bookmarks and pipeline checkpoints.
@@ -111,6 +112,11 @@ impl StateStore for MemoryStateStore {
 /// File-backed `StateStore`. Each key maps to a JSON file at
 /// `{root}/{key}.json`, written via atomic rename.
 ///
+/// Each `put` writes a temp file, fsyncs it, renames it over the final path,
+/// and (on Unix) fsyncs the parent directory — so once `put` returns the
+/// bookmark is durable across a crash or power loss, not merely sitting in the
+/// page cache.
+///
 /// The store creates its root directory on first use. All writes are
 /// serialized through a per-store mutex so two concurrent `put`s for the
 /// same key cannot race on the temp filename. Different processes pointing
@@ -184,12 +190,33 @@ impl StateStore for FileStateStore {
         })?;
         let final_path = self.entry_path(key);
         let tmp_path = self.temp_path(key);
-        tokio::fs::write(&tmp_path, &bytes).await.map_err(|e| {
-            FaucetError::State(format!(
-                "failed to write temp state file {}: {e}",
-                tmp_path.display()
-            ))
-        })?;
+
+        // Write the temp file and fsync it BEFORE the rename. `fs::write`
+        // alone leaves the bytes in the page cache: a crash after `put`
+        // returns could surface a zero-length or stale file, breaking the
+        // durability guarantee this store documents (#78/#8). `sync_all`
+        // flushes the file's data and metadata to disk.
+        {
+            let mut file = tokio::fs::File::create(&tmp_path).await.map_err(|e| {
+                FaucetError::State(format!(
+                    "failed to create temp state file {}: {e}",
+                    tmp_path.display()
+                ))
+            })?;
+            file.write_all(&bytes).await.map_err(|e| {
+                FaucetError::State(format!(
+                    "failed to write temp state file {}: {e}",
+                    tmp_path.display()
+                ))
+            })?;
+            file.sync_all().await.map_err(|e| {
+                FaucetError::State(format!(
+                    "failed to fsync temp state file {}: {e}",
+                    tmp_path.display()
+                ))
+            })?;
+        }
+
         tokio::fs::rename(&tmp_path, &final_path)
             .await
             .map_err(|e| {
@@ -198,6 +225,28 @@ impl StateStore for FileStateStore {
                     final_path.display()
                 ))
             })?;
+
+        // fsync the parent directory so the rename itself is durable — an
+        // atomic rename can still be lost on crash if the directory entry was
+        // never flushed. Directory fsync is a POSIX concept; on platforms that
+        // don't allow opening a directory as a file (e.g. Windows) it is
+        // skipped.
+        #[cfg(unix)]
+        {
+            let dir = tokio::fs::File::open(&self.root).await.map_err(|e| {
+                FaucetError::State(format!(
+                    "failed to open state dir {} for fsync: {e}",
+                    self.root.display()
+                ))
+            })?;
+            dir.sync_all().await.map_err(|e| {
+                FaucetError::State(format!(
+                    "failed to fsync state dir {}: {e}",
+                    self.root.display()
+                ))
+            })?;
+        }
+
         tracing::debug!(
             key,
             path = %final_path.display(),
@@ -351,6 +400,33 @@ mod tests {
         // The temp path must not be left behind.
         let leftover = dir.path().join("k.json.tmp");
         assert!(!leftover.exists());
+    }
+
+    #[tokio::test]
+    async fn file_put_writes_complete_durable_file_with_no_temp_residue() {
+        // Regression for #78/#8. `put` must produce a fully-written, parseable
+        // file and leave no temp file behind. (The fsync that makes this
+        // durable across a power loss can't be observed on a healthy
+        // filesystem, but a regression in the write/rename path — truncation,
+        // a leftover .tmp, or an unwritten file — is caught here.) A large
+        // payload makes a partial/unflushed write detectable on read-back.
+        let dir = TempDir::new().unwrap();
+        let s = FileStateStore::new(dir.path());
+        let big: Vec<Value> = (0..1_000).map(|i| json!({"i": i, "s": "x".repeat(20)})).collect();
+        let value = json!({"cursor": "abc", "rows": big});
+
+        s.put("github_issues", &value).await.unwrap();
+
+        // Read the raw file directly (bypassing get) to confirm it is complete.
+        let raw = tokio::fs::read(dir.path().join("github_issues.json"))
+            .await
+            .expect("state file must exist after put");
+        assert!(!raw.is_empty(), "state file must not be zero-length");
+        let parsed: Value = serde_json::from_slice(&raw).expect("state file must be valid JSON");
+        assert_eq!(parsed, value);
+
+        // No temp file left behind.
+        assert!(!dir.path().join("github_issues.json.tmp").exists());
     }
 
     #[tokio::test]

--- a/crates/sink/mysql/README.md
+++ b/crates/sink/mysql/README.md
@@ -90,7 +90,7 @@ quoting, and column-mapping behaviour are unchanged.
 | Variant | Description |
 |---------|-------------|
 | `Json { column }` | Insert each record as a serialized JSON string in a single column. The column name defaults to `"data"` but can be overridden. Uses a multi-row `INSERT INTO t (col) VALUES (?), (?), ...` for efficiency. |
-| `AutoMap` | Map top-level JSON keys directly to table columns. Column names are discovered from `INFORMATION_SCHEMA.COLUMNS`. Only keys that match existing columns are inserted; extra keys are silently ignored. Records with no matching keys are skipped with a warning. |
+| `AutoMap` | Map top-level JSON keys directly to table columns. Column names are discovered from `INFORMATION_SCHEMA.COLUMNS`. Values are bound as **native MySQL types** (strings as text, JSON numbers as integer/double, booleans as `TINYINT` 0/1, arrays/objects as JSON text), and a key present in the first record but missing from a later one is bound as SQL `NULL`. Only keys that match existing columns are inserted; extra keys are silently ignored. Records with no matching keys are skipped with a warning. |
 
 ### Builder Methods
 

--- a/crates/sink/mysql/src/sink.rs
+++ b/crates/sink/mysql/src/sink.rs
@@ -152,13 +152,28 @@ impl MysqlSink {
         for matched in &matched_rows {
             for col in &insert_columns {
                 let val = matched.iter().find(|(c, _)| *c == col).map(|(_, v)| *v);
-                let s = match val {
-                    Some(v) => serde_json::to_string(v).map_err(|e| {
-                        FaucetError::Sink(format!("failed to serialize column value: {e}"))
-                    })?,
-                    None => "null".to_string(),
+                // Bind native MySQL types. Binding every value as a JSON string
+                // (the old behaviour) stored `"Bob"` with embedded quotes,
+                // turned `true` into the text "true", and bound the literal
+                // text "null" for absent columns instead of SQL NULL (#78/#4).
+                q = match val {
+                    None | Some(Value::Null) => q.bind(None::<String>),
+                    Some(Value::Bool(b)) => q.bind(*b),
+                    Some(Value::Number(n)) => {
+                        if let Some(i) = n.as_i64() {
+                            q.bind(i)
+                        } else if let Some(f) = n.as_f64() {
+                            q.bind(f)
+                        } else {
+                            // u64 above i64::MAX — preserve exact text.
+                            q.bind(n.to_string())
+                        }
+                    }
+                    Some(Value::String(s)) => q.bind(s.clone()),
+                    // Arrays/objects have no scalar SQL representation — store
+                    // their JSON text (suitable for TEXT / JSON columns).
+                    Some(v) => q.bind(v.to_string()),
                 };
-                q = q.bind(s);
             }
         }
 

--- a/crates/sink/mysql/tests/batching.rs
+++ b/crates/sink/mysql/tests/batching.rs
@@ -195,6 +195,64 @@ async fn write_batch_sentinel_zero_emits_single_insert() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn auto_map_binds_native_types_not_json_strings() {
+    // Regression for #78/#4 (MySQL). AutoMap used to bind every value as
+    // serde_json::to_string(v): "Bob" became the quoted text "Bob", booleans
+    // became the text "true", and a column present in an earlier record but
+    // missing from a later one was bound as the literal text "null" instead of
+    // SQL NULL (insert_columns is fixed from the first matching record).
+    let (_container, url) = start_mysql().await;
+    {
+        let pool = sqlx::MySqlPool::connect(&url).await.expect("pool connect");
+        sqlx::query(
+            "CREATE TABLE people (\
+                 name VARCHAR(64),\
+                 active TINYINT,\
+                 score DOUBLE,\
+                 note VARCHAR(64)\
+             )",
+        )
+        .execute(&pool)
+        .await
+        .expect("create people table");
+        pool.close().await;
+    }
+
+    let config = MysqlSinkConfig::new(&url, "people").column_mapping(MysqlColumnMapping::AutoMap);
+    let sink = MysqlSink::new(config).await.unwrap();
+
+    let records = vec![
+        json!({"name": "Bob", "active": true, "score": 1.5, "note": "hi"}),
+        json!({"name": "Sue", "active": false, "score": 2.5}),
+    ];
+    sink.write_batch(&records).await.unwrap();
+
+    let pool = sqlx::MySqlPool::connect(&url).await.expect("verify pool");
+
+    // `name = 'Bob'` matches only if the string was stored unquoted.
+    let bob = sqlx::query("SELECT name, active, score, note FROM people WHERE name = 'Bob'")
+        .fetch_one(&pool)
+        .await
+        .expect("bob row — name must be stored without embedded JSON quotes");
+    assert_eq!(bob.get::<String, _>("name"), "Bob");
+    assert_eq!(bob.get::<i64, _>("active"), 1, "true must bind native 1");
+    assert_eq!(bob.get::<f64, _>("score"), 1.5);
+    assert_eq!(bob.get::<String, _>("note"), "hi");
+
+    let sue = sqlx::query("SELECT active, note FROM people WHERE name = 'Sue'")
+        .fetch_one(&pool)
+        .await
+        .expect("sue row");
+    assert_eq!(sue.get::<i64, _>("active"), 0, "false must bind native 0");
+    assert_eq!(
+        sue.get::<Option<String>, _>("note"),
+        None,
+        "missing column must bind SQL NULL, not the text 'null'"
+    );
+    pool.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn write_batch_empty_records_makes_no_inserts() {
     let (_container, url) = start_mysql().await;
     create_json_table(&url).await;

--- a/crates/sink/parquet/tests/roundtrip.rs
+++ b/crates/sink/parquet/tests/roundtrip.rs
@@ -296,6 +296,43 @@ async fn flush_makes_file_readable() {
 }
 
 #[tokio::test]
+async fn pipeline_flushes_parquet_on_mid_stream_source_error() {
+    // Regression for #78/#3. A Parquet file is only readable once its footer
+    // is written, which happens on flush(). If a source errors mid-stream and
+    // the pipeline returns without flushing, the multipart upload aborts and
+    // the *entire* file is lost (see `dropping_without_flush_*`). The pipeline
+    // now best-effort flushes the sink on the error path, so the rows written
+    // before the error survive and the file is readable.
+    use faucet_core::{FaucetError, RunStreamOptions, StreamPage, run_stream};
+
+    let tmp = TempDir::new().unwrap();
+    let sink = ParquetSink::new(cfg_dir(tmp.path())).await.unwrap();
+
+    let pages: Vec<Result<StreamPage, FaucetError>> = vec![
+        Ok(StreamPage {
+            records: vec![
+                json!({"id": 1, "name": "alice"}),
+                json!({"id": 2, "name": "bob"}),
+            ],
+            bookmark: None,
+        }),
+        Err(FaucetError::Source("transient blip mid-stream".into())),
+    ];
+    let stream = futures::stream::iter(pages);
+
+    let result = run_stream(stream, &sink, RunStreamOptions::new()).await;
+    assert!(
+        matches!(result, Err(FaucetError::Source(_))),
+        "the original source error must propagate, got {result:?}"
+    );
+
+    // Despite the error, the footer was written: the file is readable and
+    // holds the two rows from the good page.
+    let batches = read_all_local(tmp.path()).await;
+    assert_eq!(rows_in(&batches), 2);
+}
+
+#[tokio::test]
 async fn in_memory_object_store_path_round_trips() {
     // We can't easily run end-to-end through `ParquetSink::new` with an
     // arbitrary `Arc<dyn ObjectStore>` (it builds its own from config), but we

--- a/crates/sink/snowflake/README.md
+++ b/crates/sink/snowflake/README.md
@@ -5,7 +5,7 @@
 
 Snowflake sink connector for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
 
-Writes JSON records to a Snowflake table using the Snowflake SQL REST API. Supports JWT key-pair authentication and OAuth. Records are inserted using `PARSE_JSON` with `FLATTEN` for efficient batch loading. All table and schema identifiers are quoted to prevent SQL injection.
+Writes JSON records to a Snowflake table using the Snowflake SQL REST API. Supports JWT key-pair authentication and OAuth. Records are inserted using `PARSE_JSON` with `FLATTEN` for efficient batch loading; the JSON array is passed as a bound `TEXT` parameter (`PARSE_JSON(?)`) rather than interpolated into the SQL, so apostrophes and other quote characters in the data are safe and cannot inject SQL. All table and schema identifiers are quoted as well.
 
 ## Installation
 
@@ -265,7 +265,7 @@ let sink = SnowflakeSink::new(config);
 ## How It Works
 
 - `SnowflakeSink::new()` creates an HTTP client (reused across all requests) but does not make any network calls.
-- `write_batch()` splits records into chunks of `batch_size` (or forwards the entire slice in one request when `batch_size = 0`). For each chunk, it builds an INSERT statement using `PARSE_JSON` with `FLATTEN` to parse a JSON array and insert all rows in a single SQL statement.
+- `write_batch()` splits records into chunks of `batch_size` (or forwards the entire slice in one request when `batch_size = 0`). For each chunk, it builds an INSERT statement using `PARSE_JSON(?)` with `FLATTEN` and sends the chunk's JSON array as a bound `TEXT` parameter, parsing and inserting all rows in a single SQL statement without interpolating data into the SQL text.
 - The SQL statement targets the fully qualified table name `"database"."schema"."table"` with quoted identifiers.
 - Authentication headers are generated per request: JWT tokens for KeyPair auth (with 1-hour expiry), or the `Snowflake Token="..."` header for OAuth.
 - The Snowflake SQL REST API endpoint is `https://{account}.snowflakecomputing.com/api/v2/statements`.

--- a/crates/sink/snowflake/src/sink.rs
+++ b/crates/sink/snowflake/src/sink.rs
@@ -62,19 +62,23 @@ impl SnowflakeSink {
         authorization_header(&self.config.auth, &self.config.account)
     }
 
-    /// Execute a SQL statement via the REST API.
-    async fn execute_sql(&self, sql: &str) -> Result<(), FaucetError> {
+    /// Execute a SQL statement via the REST API, optionally with positional
+    /// bindings (`{"1": {"type": "TEXT", "value": ...}}`).
+    async fn execute_sql(&self, sql: &str, bindings: Option<Value>) -> Result<(), FaucetError> {
         let url = self.api_url();
         let auth = self.auth_header()?;
         let token_type = snowflake_token_type(&self.config.auth);
 
-        let body = json!({
+        let mut body = json!({
             "statement": sql,
             "timeout": 60,
             "database": self.config.database,
             "schema": self.config.schema,
             "warehouse": self.config.warehouse,
         });
+        if let Some(bindings) = bindings {
+            body["bindings"] = bindings;
+        }
 
         let resp = self
             .client
@@ -115,28 +119,28 @@ impl SnowflakeSink {
         Ok(())
     }
 
-    /// Build an INSERT statement for a batch of records using PARSE_JSON
-    /// with parameterised identifiers.
-    fn build_insert_sql(&self, records: &[Value]) -> Result<String, FaucetError> {
+    /// Build an INSERT statement plus the JSON payload to bind to its single
+    /// `PARSE_JSON(?)` parameter.
+    ///
+    /// The record array is passed as a bound `TEXT` parameter, never
+    /// interpolated into a SQL string literal: interpolation was a
+    /// SQL-injection vector and corrupted any value containing an apostrophe
+    /// (#78/#5). Returns `(sql, json_payload)`.
+    fn build_insert(&self, records: &[Value]) -> Result<(String, String), FaucetError> {
         for record in records {
             record.as_object().ok_or_else(|| {
                 FaucetError::Sink("Snowflake sink requires JSON object records".into())
             })?;
         }
 
-        // Serialize all records into a JSON array, then use FLATTEN to insert.
-        let json_array: Vec<String> = records
-            .iter()
-            .map(|r| serde_json::to_string(r).unwrap_or_default())
-            .collect();
-
-        Ok(format!(
-            "INSERT INTO {}.{}.{} (SELECT * FROM TABLE(FLATTEN(input => PARSE_JSON('[{}]'))))",
+        let payload = Value::Array(records.to_vec()).to_string();
+        let sql = format!(
+            "INSERT INTO {}.{}.{} (SELECT * FROM TABLE(FLATTEN(input => PARSE_JSON(?))))",
             quote_ident(&self.config.database),
             quote_ident(&self.config.schema),
             quote_ident(&self.config.table),
-            json_array.join(",")
-        ))
+        );
+        Ok((sql, payload))
     }
 }
 
@@ -165,8 +169,9 @@ impl faucet_core::Sink for SnowflakeSink {
 
         let mut total = 0;
         for chunk in records.chunks(effective_chunk) {
-            let sql = self.build_insert_sql(chunk)?;
-            self.execute_sql(&sql).await?;
+            let (sql, payload) = self.build_insert(chunk)?;
+            let bindings = json!({ "1": { "type": "TEXT", "value": payload } });
+            self.execute_sql(&sql, Some(bindings)).await?;
             total += chunk.len();
         }
 
@@ -239,7 +244,7 @@ mod tests {
     }
 
     #[test]
-    fn build_insert_sql_uses_quoted_identifiers() {
+    fn build_insert_uses_quoted_identifiers() {
         let config = SnowflakeSinkConfig::new(
             "acct",
             "wh",
@@ -250,7 +255,40 @@ mod tests {
         );
         let sink = SnowflakeSink::new(config);
         let records = vec![serde_json::json!({"id": 1})];
-        let sql = sink.build_insert_sql(&records).unwrap();
+        let (sql, _payload) = sink.build_insert(&records).unwrap();
         assert!(sql.contains("\"MY_DB\".\"PUBLIC\".\"events\""));
+    }
+
+    #[test]
+    fn build_insert_binds_payload_instead_of_interpolating() {
+        // Regression for #78/#5. The record JSON must travel as a bound TEXT
+        // parameter to PARSE_JSON(?), never interpolated into a SQL string
+        // literal — interpolation is a SQL-injection vector and breaks on any
+        // value containing an apostrophe.
+        let config = SnowflakeSinkConfig::new(
+            "acct",
+            "wh",
+            "db",
+            "schema",
+            "tbl",
+            SnowflakeAuth::OAuth { token: "t".into() },
+        );
+        let sink = SnowflakeSink::new(config);
+        let records = vec![
+            serde_json::json!({"name": "O'Brien"}),
+            serde_json::json!({"note": "'); DROP TABLE events;--"}),
+        ];
+        let (sql, payload) = sink.build_insert(&records).unwrap();
+
+        // SQL is a parameterised placeholder — no record data, no literal.
+        assert!(sql.contains("PARSE_JSON(?)"), "sql: {sql}");
+        assert!(!sql.contains('\''), "sql must not embed a quoted literal: {sql}");
+        assert!(!sql.contains("O'Brien"));
+        assert!(!sql.contains("DROP TABLE"));
+
+        // The payload is the JSON array, carrying the apostrophe data intact.
+        let parsed: Value = serde_json::from_str(&payload).unwrap();
+        assert_eq!(parsed[0]["name"], "O'Brien");
+        assert_eq!(parsed[1]["note"], "'); DROP TABLE events;--");
     }
 }

--- a/crates/sink/snowflake/src/sink.rs
+++ b/crates/sink/snowflake/src/sink.rs
@@ -282,7 +282,10 @@ mod tests {
 
         // SQL is a parameterised placeholder — no record data, no literal.
         assert!(sql.contains("PARSE_JSON(?)"), "sql: {sql}");
-        assert!(!sql.contains('\''), "sql must not embed a quoted literal: {sql}");
+        assert!(
+            !sql.contains('\''),
+            "sql must not embed a quoted literal: {sql}"
+        );
         assert!(!sql.contains("O'Brien"));
         assert!(!sql.contains("DROP TABLE"));
 

--- a/crates/sink/sqlite/README.md
+++ b/crates/sink/sqlite/README.md
@@ -249,7 +249,7 @@ let sink = SqliteSink::new(config).await?;
 - A connection pool is created in `SqliteSink::new()` using `sqlx::SqlitePool` with the configured `max_connections`.
 - `write_batch()` slices the input into `batch_size`-row chunks (or forwards the whole slice when `batch_size = 0`). Each chunk is inserted using a single multi-row INSERT statement wrapped in a `BEGIN`/`COMMIT` transaction for write performance.
 - In JSON mode, each record is serialized to a JSON string and inserted as `INSERT INTO t (col) VALUES (?), (?), ...`.
-- In AutoMap mode, column names are discovered using `PRAGMA table_info(table_name)`. A multi-row INSERT is built dynamically. Column values are serialized as JSON strings. Missing keys are bound as `"null"`.
+- In AutoMap mode, column names are discovered using `PRAGMA table_info(table_name)`. A multi-row INSERT is built dynamically. Column values are bound as **native SQLite types** — strings as `TEXT`, JSON numbers as `INTEGER`/`REAL`, booleans as `INTEGER` 0/1 — so column affinity and typed reads round-trip correctly. Arrays and objects (which have no scalar SQL representation) are bound as their JSON text. A key present in the first record but missing from a later one is bound as SQL `NULL`.
 - All identifiers (table names, column names) are quoted using `quote_ident()` (double-quote escaping) to prevent SQL injection.
 - Transaction wrapping ensures that either all rows in a batch are committed or none are, providing atomicity per batch.
 

--- a/crates/sink/sqlite/src/sink.rs
+++ b/crates/sink/sqlite/src/sink.rs
@@ -159,13 +159,29 @@ impl SqliteSink {
         for matched in &matched_rows {
             for col in &insert_columns {
                 let val = matched.iter().find(|(c, _)| *c == col).map(|(_, v)| *v);
-                let s = match val {
-                    Some(v) => serde_json::to_string(v).map_err(|e| {
-                        FaucetError::Sink(format!("failed to serialize column value: {e}"))
-                    })?,
-                    None => "null".to_string(),
+                // Bind native SQLite types so column affinity and typed reads
+                // round-trip correctly. Binding every value as a JSON string
+                // (the old behaviour) stored `"Bob"` with embedded quotes,
+                // turned `true` into the text "true", and bound the literal
+                // text "null" for absent columns instead of SQL NULL (#78/#4).
+                q = match val {
+                    None | Some(Value::Null) => q.bind(None::<String>),
+                    Some(Value::Bool(b)) => q.bind(*b),
+                    Some(Value::Number(n)) => {
+                        if let Some(i) = n.as_i64() {
+                            q.bind(i)
+                        } else if let Some(f) = n.as_f64() {
+                            q.bind(f)
+                        } else {
+                            // u64 above i64::MAX — preserve exact text.
+                            q.bind(n.to_string())
+                        }
+                    }
+                    Some(Value::String(s)) => q.bind(s.clone()),
+                    // Arrays/objects have no scalar SQL representation — store
+                    // their JSON text (suitable for TEXT / JSON columns).
+                    Some(v) => q.bind(v.to_string()),
                 };
-                q = q.bind(s);
             }
         }
 

--- a/crates/sink/sqlite/tests/batching.rs
+++ b/crates/sink/sqlite/tests/batching.rs
@@ -207,10 +207,11 @@ async fn auto_map_binds_native_types_not_json_strings() {
     assert_eq!(bob.get::<f64, _>("score"), 1.5);
     assert_eq!(bob.get::<String, _>("note"), "hi");
 
-    let sue = sqlx::query("SELECT active, note, typeof(note) AS tnote FROM people WHERE name = 'Sue'")
-        .fetch_one(&pool)
-        .await
-        .expect("sue row");
+    let sue =
+        sqlx::query("SELECT active, note, typeof(note) AS tnote FROM people WHERE name = 'Sue'")
+            .fetch_one(&pool)
+            .await
+            .expect("sue row");
     assert_eq!(sue.get::<i64, _>("active"), 0, "false must bind integer 0");
     assert_eq!(
         sue.get::<String, _>("tnote"),

--- a/crates/sink/sqlite/tests/batching.rs
+++ b/crates/sink/sqlite/tests/batching.rs
@@ -167,6 +167,62 @@ async fn auto_map_mode_rechunks_large_page() {
 }
 
 #[tokio::test]
+async fn auto_map_binds_native_types_not_json_strings() {
+    // Regression for #78/#4. AutoMap used to bind every value as
+    // serde_json::to_string(v), so "Bob" was stored as the 5-char string
+    // "Bob" (embedded quotes), `true` became the text "true", and a column
+    // present in an earlier record but missing from a later one was bound as
+    // the literal text "null" instead of SQL NULL.
+    let (_dir, url) =
+        fresh_db("CREATE TABLE people (name TEXT, active INTEGER, score REAL, note TEXT)").await;
+
+    let config = SqliteSinkConfig::new(&url, "people").column_mapping(SqliteColumnMapping::AutoMap);
+    let sink = SqliteSink::new(config).await.unwrap();
+
+    // First record defines `note`; second omits it so AutoMap must bind a real
+    // SQL NULL for the absent column (insert_columns is fixed from row 1).
+    let records = vec![
+        json!({"name": "Bob", "active": true, "score": 1.5, "note": "hi"}),
+        json!({"name": "Sue", "active": false, "score": 2.5}),
+    ];
+    sink.write_batch(&records).await.unwrap();
+
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect(&url)
+        .await
+        .expect("connect");
+
+    let bob = sqlx::query(
+        "SELECT name, active, score, note, typeof(name) AS tn, typeof(active) AS ta \
+         FROM people WHERE name = 'Bob'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("bob row (name must be stored unquoted)");
+    assert_eq!(bob.get::<String, _>("tn"), "text");
+    assert_eq!(bob.get::<String, _>("name"), "Bob");
+    assert_eq!(bob.get::<String, _>("ta"), "integer");
+    assert_eq!(bob.get::<i64, _>("active"), 1);
+    assert_eq!(bob.get::<f64, _>("score"), 1.5);
+    assert_eq!(bob.get::<String, _>("note"), "hi");
+
+    let sue = sqlx::query("SELECT active, note, typeof(note) AS tnote FROM people WHERE name = 'Sue'")
+        .fetch_one(&pool)
+        .await
+        .expect("sue row");
+    assert_eq!(sue.get::<i64, _>("active"), 0, "false must bind integer 0");
+    assert_eq!(
+        sue.get::<String, _>("tnote"),
+        "null",
+        "missing column must bind SQL NULL, not the text 'null'"
+    );
+    assert_eq!(sue.get::<Option<String>, _>("note"), None);
+
+    pool.close().await;
+}
+
+#[tokio::test]
 async fn auto_map_mode_batch_size_zero_passes_page_through() {
     // batch_size=0 in AutoMap mode writes the entire slice as a single
     // transaction.

--- a/crates/source/rest/README.md
+++ b/crates/source/rest/README.md
@@ -70,7 +70,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 | `timeout` | `Option<Duration>` | `Some(30s)` | HTTP request timeout per individual request |
 | `max_retries` | `u32` | `3` | Maximum number of retries on transient failures |
 | `retry_backoff` | `Duration` | `1s` | Base duration for exponential backoff between retries |
-| `tolerated_http_errors` | `Vec<u16>` | `[]` | HTTP status codes that should not cause an error; responses with these codes are treated as empty pages |
+| `tolerated_http_errors` | `Vec<u16>` | `[]` | HTTP status codes treated as an empty page **on the first request only** (i.e. a legitimately absent/empty resource). Mid-pagination a tolerated status is surfaced as an error instead of silently ending the stream — otherwise a transient failure on page _N_ would drop every later page as a "successful" run. Only safe for genuinely-empty resources. |
 
 ### Replication Fields
 
@@ -145,9 +145,9 @@ The `PaginationStyle` enum supports:
 | `LinkHeader` | -- | No `rel="next"` in the `Link` response header |
 | `NextLinkInBody { next_link_path }` | JSONPath to next page URL | URL is absent, null, or empty |
 | `PageNumber { param_name, start_page, page_size, page_size_param }` | Query param name, starting page number, optional page size and its param name | Response returns zero records |
-| `Offset { offset_param, limit_param, limit, total_path }` | Offset param, limit param, records per page, optional JSONPath to total count | Offset reaches total (via JSONPath) or fewer records than limit |
+| `Offset { offset_param, limit_param, limit, total_path }` | Offset param, limit param, records per page, optional JSONPath to total count | A zero-record page, offset reaches total (via JSONPath), or fewer records than limit |
 
-All styles include loop detection -- if the same cursor/link is returned twice in a row, pagination stops.
+`Cursor`, `LinkHeader`, and `NextLinkInBody` include loop detection -- if the same cursor/link is returned twice in a row, pagination stops. `Offset` stops on a zero-record page (so a stalled offset cannot loop forever), and `PageNumber` stops when a page returns zero records. For all styles, `max_pages` is a hard cap.
 
 ## Config Loading
 

--- a/crates/source/rest/src/pagination/offset.rs
+++ b/crates/source/rest/src/pagination/offset.rs
@@ -23,6 +23,12 @@ pub fn advance(
     limit: usize,
     total_path: Option<&str>,
 ) -> Result<bool, FaucetError> {
+    // A zero-record page is always the end: the offset would not advance, so
+    // honouring `total` here would re-issue the identical request forever
+    // (#78/#6). Stop regardless of what `total_path` reports.
+    if record_count == 0 {
+        return Ok(false);
+    }
     *offset += record_count;
     if let Some(tp) = total_path {
         let results = body
@@ -43,4 +49,46 @@ pub fn advance(
         }
     }
     Ok(record_count >= limit)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn zero_record_page_stops_even_when_offset_below_total() {
+        // Regression for #78/#6: a mid-stream empty page with `total_path` set
+        // and offset < total used to leave the offset unchanged and re-issue
+        // the identical request forever. It must stop instead.
+        let body = json!({ "total": 100 });
+        let mut offset = 50usize;
+        let has_next = advance(&body, &mut offset, 0, 20, Some("$.total")).unwrap();
+        assert!(!has_next, "a zero-record page must stop pagination");
+    }
+
+    #[test]
+    fn nonempty_page_below_total_continues() {
+        let body = json!({ "total": 100 });
+        let mut offset = 20usize;
+        let has_next = advance(&body, &mut offset, 20, 20, Some("$.total")).unwrap();
+        assert!(has_next, "more records remain below total");
+        assert_eq!(offset, 40);
+    }
+
+    #[test]
+    fn reaching_total_stops() {
+        let body = json!({ "total": 40 });
+        let mut offset = 20usize;
+        let has_next = advance(&body, &mut offset, 20, 20, Some("$.total")).unwrap();
+        assert!(!has_next, "offset reached total");
+    }
+
+    #[test]
+    fn heuristic_short_page_stops_without_total_path() {
+        let body = json!([]);
+        let mut offset = 20usize;
+        let has_next = advance(&body, &mut offset, 5, 20, None).unwrap();
+        assert!(!has_next, "fewer records than the limit means last page");
+    }
 }

--- a/crates/source/rest/src/stream.rs
+++ b/crates/source/rest/src/stream.rs
@@ -270,10 +270,18 @@ impl RestStream {
 
                 let params_clone = params.clone();
                 let ctx_ref = owned_context.as_ref();
+                let is_first_page = pages_fetched == 0;
                 let (body, resp_headers) = retry::execute_with_retry(
                     self.config.max_retries,
                     self.config.retry_backoff,
-                    || self.execute_request(&params_clone, url_override.as_deref(), ctx_ref),
+                    || {
+                        self.execute_request(
+                            &params_clone,
+                            url_override.as_deref(),
+                            ctx_ref,
+                            is_first_page,
+                        )
+                    },
                 )
                 .await?;
 
@@ -416,6 +424,7 @@ impl RestStream {
         params: &HashMap<String, String>,
         url_override: Option<&str>,
         path_context: Option<&HashMap<String, Value>>,
+        is_first_page: bool,
     ) -> Result<(Value, HeaderMap), FaucetError> {
         let use_override = url_override.is_some();
         let url = match url_override {
@@ -531,13 +540,26 @@ impl RestStream {
             return Err(FaucetError::RateLimited(wait));
         }
 
-        // Tolerated errors: treat as empty page.
-        if self.config.tolerated_http_errors.contains(&status.as_u16()) {
+        // Tolerated errors: treat as an empty page ONLY on the first request,
+        // where they legitimately mean "this resource is absent/empty". Mid-
+        // pagination, an empty page makes every pagination style read "last
+        // page" and stop, silently dropping every remaining page as a
+        // "successful" run (#78/#7). There we fall through to the real error
+        // path: the retry executor retries 5xx, and a persistent error fails
+        // loudly instead of truncating the stream.
+        if is_first_page && self.config.tolerated_http_errors.contains(&status.as_u16()) {
             tracing::debug!(
                 status = status.as_u16(),
-                "tolerated HTTP error; treating as empty page"
+                "tolerated HTTP error on first request; treating as empty page"
             );
             return Ok((Value::Array(vec![]), HeaderMap::new()));
+        }
+        if !is_first_page && self.config.tolerated_http_errors.contains(&status.as_u16()) {
+            tracing::warn!(
+                status = status.as_u16(),
+                "tolerated HTTP error mid-pagination; surfacing as an error to avoid \
+                 silently truncating the stream"
+            );
         }
 
         // For non-success responses, capture the body for debugging before

--- a/crates/source/rest/tests/stream_test.rs
+++ b/crates/source/rest/tests/stream_test.rs
@@ -522,6 +522,53 @@ async fn test_untolerated_http_error_propagates() {
     assert!(stream.fetch_all().await.is_err());
 }
 
+#[tokio::test]
+async fn test_tolerated_error_midpagination_does_not_silently_truncate() {
+    // Regression for #78/#7. A tolerated error is legitimate on the FIRST
+    // request (an absent/empty resource). Mid-pagination, swallowing it as an
+    // empty page makes every pagination style read "last page" and stop — so a
+    // transient 500 on page 2 of N silently drops pages 2..N and reports
+    // success. That must surface as an error instead.
+    let server = MockServer::start().await;
+
+    // Page 1 succeeds and points to page 2.
+    Mock::given(method("GET"))
+        .and(path("/api/items"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "items": [{"id": 1}],
+            "next_cursor": "page2"
+        })))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+
+    // Page 2 returns a tolerated 500 mid-pagination.
+    Mock::given(method("GET"))
+        .and(path("/api/items"))
+        .and(query_param("cursor", "page2"))
+        .respond_with(ResponseTemplate::new(500))
+        .mount(&server)
+        .await;
+
+    let stream = RestStream::new(
+        RestStreamConfig::new(&server.uri(), "/api/items")
+            .records_path("$.items[*]")
+            .pagination(PaginationStyle::Cursor {
+                next_token_path: "$.next_cursor".into(),
+                param_name: "cursor".into(),
+            })
+            .tolerate_http_error(500)
+            .max_retries(0),
+    )
+    .unwrap();
+
+    let result = stream.fetch_all().await;
+    assert!(
+        result.is_err(),
+        "a tolerated error mid-pagination must not silently truncate; got {result:?}"
+    );
+}
+
 // ── Metadata fields (compile-time / builder checks) ───────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

First batch of fixes from the pre-1.0 hardening audit (**#78**). Seven independent, verified findings — the largest remaining item, the CDC rewrite (#1/#2), is intentionally a **separate** follow-up PR. Each fix has a regression test (fail-before / pass-after where observable).

**Part of #78** — does not close it (CDC #1/#2, Kafka SR #9, CLI cross-template #10 remain).

### Findings fixed

- **#3 (core, CRITICAL)** — `run_stream` returned on a mid-stream source error (or any `?`-propagated failure) before the terminal `sink.flush()`, so a buffered sink lost everything written so far. For a Parquet sink the footer is only written on flush, so the *entire* file became unreadable. Now every early exit best-effort flushes the DLQ + main sink before propagating the original error.
- **#4 (mysql + sqlite sinks, CRITICAL)** — AutoMap bound every value as `serde_json::to_string` (a JSON string), so `"Bob"` was stored with embedded quotes, `true` became `"true"`, and a column missing from a later record was bound as the literal text `"null"`. Now binds native scalar types per column and a real SQL `NULL` for absent columns.
- **#5 (snowflake sink, CRITICAL)** — record JSON was interpolated into a `PARSE_JSON('...')` string literal: a SQL-injection vector that also broke on any apostrophe. Now passes the JSON array as a bound `TEXT` parameter to `PARSE_JSON(?)`.
- **#6 (rest source, CRITICAL)** — Offset pagination looped forever on a zero-record page when `total_path` was set and `offset < total`. Now stops on any zero-record page.
- **#7 (rest source, CRITICAL)** — a tolerated HTTP error mid-pagination was treated as an empty page, which every pagination style reads as "last page", silently dropping every later page as a successful run. Tolerated errors are now honoured only on the first request; mid-pagination they surface as an error.
- **#8 (core, CRITICAL)** — `FileStateStore::put` wrote the temp file with no fsync and renamed with no parent-dir fsync, so a crash could surface a zero-length/stale bookmark — violating the store's documented durability. Now fsyncs the temp file before rename and the parent dir after (Unix).
- **#11 (CI, CRITICAL)** — `release.yml` hardcoded the publish list in two drifted arrays (37 of 45 crates); the 8 missing crates (parquet ×2, gcs ×2, sink-stdout, both state backends, faucet-cli) were never published, so `scope=all` shipped a broken release. Now derives the list from `cargo metadata` + `tsort` (dependency order), so it can't drift.

## Test plan

- [x] `cargo test -p faucet-core` (flush-on-error + fsync regression tests)
- [x] `cargo test -p faucet-sink-sqlite` (typed-column AutoMap)
- [x] `cargo test -p faucet-sink-snowflake` (apostrophe / injection payload)
- [x] `cargo test -p faucet-source-rest` (Offset zero-page, tolerated-error truncation)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` (clean)
- [ ] `cargo test -p faucet-sink-mysql` — **requires Docker (testcontainers); not run locally, runs in CI.** Fix is logically identical to the SQLite one, which passes end-to-end.

## Notes

- READMEs updated for the rest / sqlite / mysql / snowflake behavior changes.
- True power-loss durability for #8 (the fsync itself) can't be observed on a healthy filesystem; verified by inspection, with a regression test for the durable-write contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)