### PR TITLE
test(cli): de-flake on_error=stop abort test (#78 finding #24)

### DIFF
--- a/cli/src/executor.rs
+++ b/cli/src/executor.rs
@@ -897,10 +897,18 @@ matrix:
     }
 
     #[tokio::test]
-    async fn on_error_stop_aborts_pending_invocations() {
-        // First root writes to an invalid sink path. The second root would
-        // succeed but `on_error: stop` must abort it before its output file
-        // appears on disk.
+    async fn on_error_stop_reports_failure_and_runs_no_extra_work() {
+        // First root writes to an invalid sink path and fails. The second
+        // ("good") root would succeed. Under `on_error: stop` the executor
+        // calls `abort_all()` on the first failure, which cancels pending /
+        // in-flight tasks at their next await point — but that is
+        // best-effort: with `max_concurrent: 1` the two roots race for the
+        // single permit, so "good" may already have completed before "bad"
+        // fails. We therefore assert the guarantees that hold under *any*
+        // scheduling rather than an exact invocation count (which was racy,
+        // see issue #78 finding #24). The deterministic "stop actually
+        // cancels in-flight work" path is covered by
+        // `on_error_stop_under_parallelism_aborts_other_in_flight`.
         let dir = tempfile::tempdir().unwrap();
         let good_csv = dir.path().join("good.csv");
         std::fs::write(&good_csv, "x\n1\n").unwrap();
@@ -939,15 +947,36 @@ execution:
         .await
         .unwrap();
 
-        // bad spawned first, acquires the only permit, fails → abort_all()
-        // cancels good before it gets to write anything. Only bad shows up
-        // in the summary, and good's output file was never opened.
-        assert_eq!(summary.invocations.len(), 1);
-        assert_eq!(summary.invocations[0].row_id, "bad");
-        assert!(summary.had_failures());
+        // Invariants that hold regardless of which root won the permit race:
+        assert!(summary.had_failures(), "the failing root must be reported");
+
+        // "bad" ran exactly once and is recorded as a failure.
+        let bad: Vec<_> = summary
+            .invocations
+            .iter()
+            .filter(|o| o.row_id == "bad")
+            .collect();
+        assert_eq!(bad.len(), 1, "bad must run exactly once");
+        assert!(bad[0].error.is_some(), "bad must be recorded as a failure");
+
+        // No duplicate / extra invocations beyond the two work units.
         assert!(
-            !good_out.exists(),
-            "good's sink should never have been opened under on_error=stop"
+            summary.invocations.len() <= 2,
+            "at most the two roots may run, got {:?}",
+            summary.invocations
+        );
+
+        // "good" only appears in the summary if it actually completed (aborted
+        // tasks are dropped, not recorded). Its output file must exist exactly
+        // when it completed — never a partial/extra write.
+        let good_completed = summary
+            .invocations
+            .iter()
+            .any(|o| o.row_id == "good" && o.error.is_none());
+        assert_eq!(
+            good_out.exists(),
+            good_completed,
+            "good's output file must exist iff good completed"
         );
     }
 


### PR DESCRIPTION
## Summary

The CLI executor test `on_error_stop_aborts_pending_invocations` is flaky and intermittently fails CI (it failed on the run for #79). It asserted an **exact** invocation count of 1, but under `max_concurrent: 1` the two roots race for the single semaphore permit: the "good" root can acquire it and complete before "bad" fails and triggers `abort_all()`. `abort_all()` is best-effort (cancels at the next await point), so the surviving count is legitimately 1 **or** 2 depending on scheduling — this is the unreliable-cascade behavior tracked as **#78 finding #24**.

This rewrites the assertions to the invariants that hold under **any** scheduling:
- the run reports the failure (`had_failures()`),
- "bad" runs exactly once and is recorded as a failure,
- no more than the two work units run (no duplicate/extra invocations),
- "good"'s output file exists **iff** "good" actually completed (aborted tasks are dropped, not recorded).

The deterministic "stop actually cancels in-flight work" path is still covered by the sibling test `on_error_stop_under_parallelism_aborts_other_in_flight`.

**Part of #78** (finding #24). Does not change executor behavior — test-only change. The deeper #24 executor hardening (panic handling, cascade indexing, etc.) remains a separate follow-up.

## Test plan

- [x] Rewritten test passes 30/30 locally; the new assertions hold under any task-scheduling order by construction
- [x] `cargo test -p faucet-cli` (178 lib tests + integration) green
- [x] `cargo clippy -p faucet-cli --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)