### PR TITLE
Pre-1.0 hardening: CRITICAL #9 + 10 fixes (#78 findings #9,#10,#14,#15,#16,#18,#20,#21,#22,#27,#28)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,6 +247,7 @@ The only crate every connector depends on. Module layout:
 - `util.rs` — `quote_ident` (SQL injection prevention), `extract_records` (JSONPath), `check_http_response`, `substitute_context` (placeholder substitution for URLs/paths — NOT safe for SQL or JSON), `substitute_context_bind_params` (SQL-safe via bind markers), `substitute_context_json` (JSON-safe), `extract_context`.
 - `transform.rs` — `RecordTransform` / `CompiledTransform`: flatten, rename keys (regex), snake_case, custom closures. Built-in transforms are feature-gated.
 - `replication.rs` — `ReplicationMethod`, `filter_incremental`, `max_replication_value` for bookmark-based incremental replication.
+- `retry.rs` — shared `execute_with_retry` (exponential backoff + jitter, gated on `FaucetError::is_retriable`) used by HTTP sources (XML, GraphQL). The REST source keeps its own retry module with extra 429/`Retry-After` handling.
 - `schema.rs` — `infer_schema` from record samples with type merging and nullable detection.
 - `state.rs` — `StateStore` async trait (`get` / `put` / `delete` over `Value`) + built-in `MemoryStateStore` and `FileStateStore` (one JSON file per key, atomic rename). Keys validated by `validate_state_key`. Heavier backends (Redis, Postgres) live in their own crates.
 - `dlq.rs` — DLQ data types: `OnBatchError`, `DlqConfig`, `DlqStats`, `DlqReason`, `build_envelope`. The router itself lives in `pipeline.rs::run_stream`.

--- a/cli/README.md
+++ b/cli/README.md
@@ -113,7 +113,7 @@ Load-time interpolation runs in this order:
 
 1. `${env:VAR}` / `${file:PATH}` / `${secret:VAR}` — resolved during the raw text pass.
 2. `${vars.X}` — resolved against the top-level `vars:` block. Vars may reference other vars; cycles surface as `InterpolationCycle`.
-3. `${sources.NAME.PATH}` and `${sinks.NAME.PATH}` — resolved against the post-vars-substitution template body. Useful for copying constants between templates without restating them.
+3. `${sources.NAME.PATH}` and `${sinks.NAME.PATH}` — resolved against the post-vars-substitution template bodies. Useful for copying constants between templates without restating them. A template may reference another template (including across the source/sink namespaces), and such chains are followed to their terminal value; mutual or circular references surface as `InterpolationCycle` rather than resolving to literal token text.
 4. `${row_id.path}` — left literal; resolved at runtime against parent records (per-record fan-out).
 
 ### Backwards compatibility

--- a/cli/src/commands/preview.rs
+++ b/cli/src/commands/preview.rs
@@ -52,7 +52,7 @@ pub async fn run(args: PreviewArgs) -> CliResult<()> {
         records
             .into_iter()
             .map(|r| apply_all(r, &compiled))
-            .collect()
+            .collect::<Result<Vec<_>, _>>()?
     };
 
     let limited: Vec<_> = records.into_iter().take(args.limit).collect();

--- a/cli/src/executor.rs
+++ b/cli/src/executor.rs
@@ -578,18 +578,14 @@ impl Source for TransformingSource {
         ctx: &HashMap<String, Value>,
     ) -> Result<Vec<Value>, FaucetError> {
         let records = self.inner.fetch_with_context(ctx).await?;
-        Ok(instrumented_apply_all(
-            records,
-            &self.transforms,
-            &self.obs_labels,
-        ))
+        instrumented_apply_all(records, &self.transforms, &self.obs_labels)
     }
     async fn fetch_with_context_incremental(
         &self,
         ctx: &HashMap<String, Value>,
     ) -> Result<(Vec<Value>, Option<Value>), FaucetError> {
         let (records, bookmark) = self.inner.fetch_with_context_incremental(ctx).await?;
-        let transformed = instrumented_apply_all(records, &self.transforms, &self.obs_labels);
+        let transformed = instrumented_apply_all(records, &self.transforms, &self.obs_labels)?;
         Ok((transformed, bookmark))
     }
     fn connector_name(&self) -> &'static str {

--- a/cli/src/interpolate.rs
+++ b/cli/src/interpolate.rs
@@ -445,14 +445,24 @@ fn resolve_value_full(
                     return Ok(Some(value_to_string(val)));
                 }
                 if let Some(rest) = body.strip_prefix("sources.") {
+                    let mut visiting = Vec::new();
                     return Ok(Some(lookup_template_path(
                         &templates.sources,
+                        &templates.sinks,
                         "sources",
                         rest,
+                        &mut visiting,
                     )?));
                 }
                 if let Some(rest) = body.strip_prefix("sinks.") {
-                    return Ok(Some(lookup_template_path(&templates.sinks, "sinks", rest)?));
+                    let mut visiting = Vec::new();
+                    return Ok(Some(lookup_template_path(
+                        &templates.sources,
+                        &templates.sinks,
+                        "sinks",
+                        rest,
+                        &mut visiting,
+                    )?));
                 }
                 // Any other prefix (e.g. `${users.id}`) is a deferred row-id token —
                 // leave verbatim for runtime resolution.
@@ -475,13 +485,32 @@ fn resolve_value_full(
     Ok(())
 }
 
+/// Resolve a `${sources.X.PATH}` / `${sinks.X.PATH}` reference, following
+/// template-to-template chains to their terminal literal.
+///
+/// `visiting` is the DFS stack of `{kind}.{name}` keys currently being
+/// expanded; re-encountering a key on the stack is a cycle (e.g. `a → b → a`)
+/// and surfaces as [`CliError::InterpolationCycle`] rather than silently
+/// leaving each template holding the other's token text (#78/#10).
 fn lookup_template_path(
-    catalog: &HashMap<String, Value>,
+    sources: &HashMap<String, Value>,
+    sinks: &HashMap<String, Value>,
     kind: &str,
     rest: &str,
+    visiting: &mut Vec<String>,
 ) -> CliResult<String> {
     // `rest` is `<name>` or `<name>.<dotted.path>`
     let (name, path) = rest.split_once('.').unwrap_or((rest, ""));
+    let key = format!("{kind}.{name}");
+    if let Some(start) = visiting.iter().position(|k| *k == key) {
+        let chain: Vec<String> = visiting[start..]
+            .iter()
+            .cloned()
+            .chain(std::iter::once(key))
+            .collect();
+        return Err(CliError::InterpolationCycle { chain });
+    }
+    let catalog = if kind == "sources" { sources } else { sinks };
     let template = catalog
         .get(name)
         .ok_or_else(|| CliError::UnknownTemplateRef {
@@ -492,7 +521,28 @@ fn lookup_template_path(
         token: format!("${{{kind}.{rest}}}"),
         reason: format!("path '{path}' does not resolve inside {kind} template '{name}'"),
     })?;
-    Ok(value_to_string(&resolved))
+    // The looked-up value may itself contain `${sources/sinks.X}` tokens (a
+    // template referencing another template). Resolve them, following the
+    // chain, with `key` pushed so a cycle is detected. `${vars.X}` are already
+    // substituted (Phase 2); other prefixes are deferred row-id tokens and
+    // pass through verbatim.
+    let resolved_str = value_to_string(&resolved);
+    visiting.push(key);
+    let out = rewrite(&resolved_str, |body| {
+        if let Some(rest) = body.strip_prefix("sources.") {
+            return Ok(Some(lookup_template_path(
+                sources, sinks, "sources", rest, visiting,
+            )?));
+        }
+        if let Some(rest) = body.strip_prefix("sinks.") {
+            return Ok(Some(lookup_template_path(
+                sources, sinks, "sinks", rest, visiting,
+            )?));
+        }
+        Ok(None)
+    });
+    visiting.pop();
+    out
 }
 
 #[cfg(test)]
@@ -767,6 +817,77 @@ pipeline:
 "#,
         );
         assert_eq!(cfg.pipeline.sources["b"].config["host"], "api.example.com");
+    }
+
+    #[test]
+    fn resolves_chained_cross_template_reference() {
+        // a → b → c, where c holds the literal. A single resolution pass (as
+        // production runs via `from_text`) must follow the chain all the way
+        // to the literal, not stop at b's token text (#78/#10). NB: we use
+        // `parse_with_extension` directly (one pass) rather than the `load`
+        // helper, which resolves twice and would mask a single-pass gap.
+        let cfg = parse_with_extension(
+            r#"
+version: 1
+pipeline:
+  sources:
+    a: { type: rest, config: { host: "${sources.b.config.host}" } }
+    b: { type: rest, config: { host: "${sources.c.config.host}" } }
+    c: { type: rest, config: { host: db.example.com } }
+  sinks:
+    out: { type: jsonl, config: { path: ./o.jsonl } }
+"#,
+            "yaml",
+        )
+        .unwrap();
+        assert_eq!(cfg.pipeline.sources["a"].config["host"], "db.example.com");
+        assert_eq!(cfg.pipeline.sources["b"].config["host"], "db.example.com");
+    }
+
+    #[test]
+    fn resolves_cross_template_reference_across_kinds() {
+        // A sink template referencing a source template (cross-namespace).
+        let cfg = load(
+            r#"
+version: 1
+pipeline:
+  sources:
+    api: { type: rest, config: { host: api.example.com } }
+  sinks:
+    mirror: { type: http, config: { url: "${sources.api.config.host}" } }
+"#,
+        );
+        assert_eq!(
+            cfg.pipeline.sinks["mirror"].config["url"],
+            "api.example.com"
+        );
+    }
+
+    #[test]
+    fn detects_cross_template_cycle() {
+        // a → b → a is a mutual cycle and must error, not silently leave each
+        // template holding the other's literal token text (#78/#10).
+        let yaml = r#"
+version: 1
+pipeline:
+  sources:
+    a: { type: rest, config: { host: "${sources.b.config.host}" } }
+    b: { type: rest, config: { host: "${sources.a.config.host}" } }
+  sinks:
+    out: { type: jsonl, config: { path: ./o.jsonl } }
+"#;
+        let err = parse_with_extension(yaml, "yaml").unwrap_err();
+        match err {
+            CliError::InterpolationCycle { chain } => {
+                assert!(chain.first() == chain.last(), "chain: {chain:?}");
+                assert!(
+                    chain.iter().any(|c| c == "sources.a")
+                        && chain.iter().any(|c| c == "sources.b"),
+                    "chain must name both templates: {chain:?}"
+                );
+            }
+            other => panic!("expected InterpolationCycle, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -28,7 +28,7 @@ regex = { workspace = true, optional = true }
 futures-core.workspace = true
 futures.workspace = true
 async-stream = { workspace = true }
-tokio = { workspace = true, features = ["sync", "fs", "io-util"] }
+tokio = { workspace = true, features = ["sync", "fs", "io-util", "time"] }
 dotenvy = "0.15"
 envy = "0.4"
 metrics.workspace = true

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -17,6 +17,7 @@ pub mod error;
 pub mod observability;
 pub mod pipeline;
 pub mod replication;
+pub mod retry;
 pub mod schema;
 pub mod state;
 pub mod traits;
@@ -39,6 +40,7 @@ pub use pipeline::{
     validate_batch_size,
 };
 pub use replication::ReplicationMethod;
+pub use retry::execute_with_retry;
 pub use state::{FileStateStore, MemoryStateStore, StateStore};
 pub use traits::{RowOutcome, Sink, Source};
 pub use transform::RecordTransform;

--- a/crates/core/src/observability/transform.rs
+++ b/crates/core/src/observability/transform.rs
@@ -11,16 +11,14 @@ use tracing::info_span;
 /// Emits one `faucet.transform.apply` span and one
 /// `faucet_transform_records_total` counter increment per call (per page).
 ///
-/// `apply_all` is infallible (it returns the transformed `Value`); the
-/// `faucet_transform_errors_total` counter from the spec exists as a
-/// reserved name for future transform variants that may return `Result`.
-/// Today this function only emits the records counter and duration
-/// histogram.
+/// Returns [`FaucetError::Transform`](crate::FaucetError::Transform) if any
+/// record's transform would silently lose data (a `flatten` / `snake_case`
+/// key collision — #78/#28), incrementing `faucet_transform_errors_total`.
 pub fn instrumented_apply_all(
     records: Vec<Value>,
     transforms: &[CompiledTransform],
     labels: &Labels,
-) -> Vec<Value> {
+) -> Result<Vec<Value>, crate::FaucetError> {
     let n = records.len();
     let span = info_span!(
         "faucet.transform.apply",
@@ -36,12 +34,18 @@ pub fn instrumented_apply_all(
         Label::new("row", SharedString::from(labels.row.to_string())),
     ];
     let _timer = DurationGuard::new("faucet_transform_duration_seconds", metric_labels.clone());
-    let out: Vec<Value> = records
-        .into_iter()
-        .map(|r| apply_all(r, transforms))
-        .collect();
+    let mut out: Vec<Value> = Vec::with_capacity(n);
+    for r in records {
+        match apply_all(r, transforms) {
+            Ok(v) => out.push(v),
+            Err(e) => {
+                counter!("faucet_transform_errors_total", metric_labels.clone()).increment(1);
+                return Err(e);
+            }
+        }
+    }
     counter!("faucet_transform_records_total", metric_labels).increment(n as u64);
-    out
+    Ok(out)
 }
 
 #[cfg(test)]
@@ -63,7 +67,8 @@ mod tests {
             vec![json!({"FooBar": 1}), json!({"BazQux": 2})],
             &[t],
             &labels,
-        );
+        )
+        .expect("snake_case transform succeeds");
         assert_eq!(result.len(), 2, "all records returned");
         let snapshot = snap.snapshot();
         let found = snapshot.into_vec().into_iter().any(|(key, _u, _d, v)| {

--- a/crates/core/src/replication.rs
+++ b/crates/core/src/replication.rs
@@ -19,13 +19,29 @@ pub enum ReplicationMethod {
 
 /// Filter `records` to only those where `record[key] > start`.
 ///
-/// Records that are missing the key are excluded.
-/// String values are compared lexicographically (ISO-8601 dates compare correctly this way).
-/// Numeric values are compared as `f64`.
+/// Records missing the key are excluded. Strings compare lexicographically
+/// (ISO-8601 dates compare correctly this way); integers compare exactly
+/// (no `f64` precision loss); floats compare as `f64`.
+///
+/// If a record's key value is a *different JSON type* than `start` (e.g. a
+/// numeric key against a string bookmark), the comparison is not meaningful;
+/// rather than silently dropping the record — which is data loss (#78/#27) —
+/// it is **kept** and a warning is logged.
 pub fn filter_incremental(records: Vec<Value>, key: &str, start: &Value) -> Vec<Value> {
     records
         .into_iter()
-        .filter(|r| r.get(key).is_some_and(|v| json_gt(v, start)))
+        .filter(|r| match r.get(key) {
+            None => false,
+            Some(v) if type_rank(v) != type_rank(start) => {
+                tracing::warn!(
+                    key,
+                    "incremental replication: record key type does not match the bookmark \
+                     type; keeping the record to avoid silently dropping data"
+                );
+                true
+            }
+            Some(v) => json_gt(v, start),
+        })
         .collect()
 }
 
@@ -47,15 +63,72 @@ pub fn max_value(a: Value, b: Value) -> Value {
     }
 }
 
+/// Type-rank for a total ordering across JSON value kinds, so comparisons of
+/// differing types are deterministic instead of collapsing to `Equal`.
+fn type_rank(v: &Value) -> u8 {
+    match v {
+        Value::Null => 0,
+        Value::Bool(_) => 1,
+        Value::Number(_) => 2,
+        Value::String(_) => 3,
+        Value::Array(_) => 4,
+        Value::Object(_) => 5,
+    }
+}
+
+/// Exact integer view of a JSON number (`i64` or `u64`), widened to `i128` so
+/// both halves of the range compare without `f64` precision loss. `None` for
+/// non-integral (floating) numbers.
+fn number_as_i128(n: &serde_json::Number) -> Option<i128> {
+    n.as_i64()
+        .map(i128::from)
+        .or_else(|| n.as_u64().map(i128::from))
+}
+
+/// Total ordering over JSON values used for replication bookmarks.
+///
+/// - Numbers: compared exactly as `i128` when both are integral (so cursors
+///   above 2^53 don't lose precision); otherwise as `f64`, with NaN ordered
+///   last.
+/// - Same-type scalars/containers: natural ordering (strings lexicographic,
+///   bools `false < true`, arrays element-wise, objects by serialized form).
+/// - Different types: ordered by [`type_rank`] so the result is always total.
 pub(crate) fn json_compare(a: &Value, b: &Value) -> Ordering {
     match (a, b) {
         (Value::Number(an), Value::Number(bn)) => {
-            let af = an.as_f64().unwrap_or(f64::NEG_INFINITY);
-            let bf = bn.as_f64().unwrap_or(f64::NEG_INFINITY);
-            af.partial_cmp(&bf).unwrap_or(Ordering::Equal)
+            match (number_as_i128(an), number_as_i128(bn)) {
+                (Some(ai), Some(bi)) => ai.cmp(&bi),
+                _ => {
+                    let af = an.as_f64().unwrap_or(f64::NAN);
+                    let bf = bn.as_f64().unwrap_or(f64::NAN);
+                    af.partial_cmp(&bf).unwrap_or_else(|| {
+                        // At least one NaN — order NaN last, deterministically.
+                        match (af.is_nan(), bf.is_nan()) {
+                            (false, true) => Ordering::Less,
+                            (true, false) => Ordering::Greater,
+                            _ => Ordering::Equal,
+                        }
+                    })
+                }
+            }
         }
-        (Value::String(as_), Value::String(bs)) => as_.cmp(bs),
-        _ => Ordering::Equal,
+        (Value::String(x), Value::String(y)) => x.cmp(y),
+        (Value::Bool(x), Value::Bool(y)) => x.cmp(y),
+        (Value::Null, Value::Null) => Ordering::Equal,
+        (Value::Array(x), Value::Array(y)) => {
+            for (xi, yi) in x.iter().zip(y.iter()) {
+                let c = json_compare(xi, yi);
+                if c != Ordering::Equal {
+                    return c;
+                }
+            }
+            x.len().cmp(&y.len())
+        }
+        // Objects have no natural order; use the serialized form for a stable
+        // total order (objects as replication keys are pathological).
+        (Value::Object(_), Value::Object(_)) => a.to_string().cmp(&b.to_string()),
+        // Different JSON types — order by type rank so comparison is total.
+        _ => type_rank(a).cmp(&type_rank(b)),
     }
 }
 
@@ -158,7 +231,45 @@ mod tests {
 
     #[test]
     fn test_max_value_returns_a_on_type_mismatch() {
-        // Type mismatch falls back to a (json_compare returns Ordering::Equal).
+        // String outranks Number in the total type-rank ordering, so the
+        // larger (a) is returned.
         assert_eq!(max_value(json!("string"), json!(5)), json!("string"));
+    }
+
+    #[test]
+    fn filter_incremental_keeps_large_integer_beyond_f64_precision() {
+        // Regression for #78/#27: integer cursors above 2^53 lose precision
+        // when compared as f64, so a genuinely-greater value compared Equal
+        // and was silently dropped.
+        let two_pow_53 = 9_007_199_254_740_992_i64; // 2^53
+        let records = vec![
+            json!({"id": 1, "seq": two_pow_53 + 1}),
+            json!({"id": 2, "seq": two_pow_53 + 2}),
+        ];
+        let start = json!(two_pow_53);
+        let filtered = filter_incremental(records, "seq", &start);
+        assert_eq!(
+            filtered.len(),
+            2,
+            "both values are strictly greater than 2^53"
+        );
+    }
+
+    #[test]
+    fn json_compare_distinguishes_large_integers() {
+        let a = json!(9_007_199_254_740_993_i64); // 2^53 + 1
+        let b = json!(9_007_199_254_740_992_i64); // 2^53
+        assert_eq!(json_compare(&a, &b), Ordering::Greater);
+    }
+
+    #[test]
+    fn filter_incremental_keeps_records_on_type_mismatch() {
+        // Regression for #78/#27: a bookmark/key type mismatch must not be
+        // silently treated as "not greater" and the record dropped — that is
+        // data loss. Keep the record instead.
+        let records = vec![json!({"id": 1, "seq": 20_240_701})];
+        let start = json!("2024-06-01"); // string bookmark vs numeric key
+        let filtered = filter_incremental(records, "seq", &start);
+        assert_eq!(filtered.len(), 1, "type mismatch must not silently drop");
     }
 }

--- a/crates/core/src/retry.rs
+++ b/crates/core/src/retry.rs
@@ -1,0 +1,117 @@
+//! Shared exponential-backoff retry executor for HTTP-style sources.
+//!
+//! Connector authors can wrap any fallible async operation so transient
+//! failures (5xx, connection resets, timeouts — see
+//! [`FaucetError::is_retriable`]) are retried with jittered backoff, while
+//! non-retriable errors fail fast. Used by the XML, GraphQL, and other
+//! sources that talk to flaky HTTP endpoints.
+
+use crate::error::FaucetError;
+use std::future::Future;
+use std::time::Duration;
+
+/// Execute `operation` with up to `max_retries` retries on
+/// [retriable](FaucetError::is_retriable) errors, using exponential backoff
+/// (`base_backoff * 2^attempt`) with random jitter. Non-retriable errors
+/// return immediately; `Ok` returns immediately.
+pub async fn execute_with_retry<F, Fut, T>(
+    max_retries: u32,
+    base_backoff: Duration,
+    mut operation: F,
+) -> Result<T, FaucetError>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T, FaucetError>>,
+{
+    let mut attempt = 0u32;
+    loop {
+        match operation().await {
+            Ok(val) => return Ok(val),
+            Err(e) if e.is_retriable() && attempt < max_retries => {
+                let wait = backoff_with_jitter(base_backoff, attempt);
+                tracing::warn!(
+                    "request failed (attempt {}/{}), retrying in {wait:?}: {e}",
+                    attempt + 1,
+                    max_retries + 1
+                );
+                tokio::time::sleep(wait).await;
+                attempt += 1;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+}
+
+/// `base * 2^attempt` scaled by a random factor in `[0.5, 1.5)` to avoid a
+/// thundering herd.
+fn backoff_with_jitter(base: Duration, attempt: u32) -> Duration {
+    let exp = base.saturating_mul(2u32.saturating_pow(attempt));
+    let nanos = exp.as_nanos() as u64;
+    Duration::from_nanos((nanos as f64 * pseudo_random_factor()) as u64)
+}
+
+/// Cheap, non-cryptographic random factor in `[0.5, 1.5)` from the clock's
+/// sub-second component.
+fn pseudo_random_factor() -> f64 {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .subsec_nanos();
+    0.5 + (nanos as f64 / u32::MAX as f64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    #[tokio::test]
+    async fn returns_immediately_on_success() {
+        let calls = Arc::new(AtomicU32::new(0));
+        let c = calls.clone();
+        let r = execute_with_retry(3, Duration::from_millis(1), move || {
+            c.fetch_add(1, Ordering::SeqCst);
+            async { Ok::<_, FaucetError>(7) }
+        })
+        .await;
+        assert_eq!(r.unwrap(), 7);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn retries_then_succeeds_on_transient_5xx() {
+        let calls = Arc::new(AtomicU32::new(0));
+        let c = calls.clone();
+        let r = execute_with_retry(3, Duration::from_millis(1), move || {
+            let n = c.fetch_add(1, Ordering::SeqCst);
+            async move {
+                if n < 2 {
+                    Err::<i32, _>(FaucetError::HttpStatus {
+                        status: 503,
+                        url: "http://t".into(),
+                        body: "x".into(),
+                    })
+                } else {
+                    Ok(42)
+                }
+            }
+        })
+        .await;
+        assert_eq!(r.unwrap(), 42);
+        assert_eq!(calls.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn non_retriable_fails_immediately() {
+        let calls = Arc::new(AtomicU32::new(0));
+        let c = calls.clone();
+        let r = execute_with_retry(3, Duration::from_millis(1), move || {
+            c.fetch_add(1, Ordering::SeqCst);
+            async { Err::<i32, _>(FaucetError::Auth("nope".into())) }
+        })
+        .await;
+        assert!(r.is_err());
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+}

--- a/crates/core/src/transform.rs
+++ b/crates/core/src/transform.rs
@@ -242,38 +242,53 @@ pub fn compile(t: &RecordTransform) -> Result<CompiledTransform, FaucetError> {
 }
 
 /// Apply a slice of pre-compiled transforms to a record, in order.
-pub fn apply_all(record: Value, transforms: &[CompiledTransform]) -> Value {
-    transforms.iter().fold(record, apply_one)
+///
+/// Returns [`FaucetError::Transform`] if a transform would silently lose data
+/// — currently when `flatten` or `snake_case` collapse two distinct fields to
+/// the same key (#78/#28).
+pub fn apply_all(record: Value, transforms: &[CompiledTransform]) -> Result<Value, FaucetError> {
+    let mut acc = record;
+    for t in transforms {
+        acc = apply_one(acc, t)?;
+    }
+    Ok(acc)
 }
 
-fn apply_one(value: Value, t: &CompiledTransform) -> Value {
+fn apply_one(value: Value, t: &CompiledTransform) -> Result<Value, FaucetError> {
     match t {
         #[cfg(feature = "transform-flatten")]
         CompiledTransform::Flatten { separator } => flatten(value, separator),
         #[cfg(feature = "transform-rename-keys")]
-        CompiledTransform::RenameKeys { re, replacement } => rename_keys(value, re, replacement),
+        CompiledTransform::RenameKeys { re, replacement } => {
+            Ok(rename_keys(value, re, replacement))
+        }
         #[cfg(feature = "transform-snake-case")]
         CompiledTransform::KeysToSnakeCase => keys_to_snake_case(value),
-        CompiledTransform::Custom(f) => f(value),
+        CompiledTransform::Custom(f) => Ok(f(value)),
     }
 }
 
 // ── Flatten ───────────────────────────────────────────────────────────────────
 
 #[cfg(feature = "transform-flatten")]
-fn flatten(value: Value, separator: &str) -> Value {
+fn flatten(value: Value, separator: &str) -> Result<Value, FaucetError> {
     match value {
         Value::Object(_) => {
             let mut out = Map::new();
-            flatten_into(value, "", separator, &mut out);
-            Value::Object(out)
+            flatten_into(value, "", separator, &mut out)?;
+            Ok(Value::Object(out))
         }
-        other => other,
+        other => Ok(other),
     }
 }
 
 #[cfg(feature = "transform-flatten")]
-fn flatten_into(value: Value, prefix: &str, separator: &str, out: &mut Map<String, Value>) {
+fn flatten_into(
+    value: Value,
+    prefix: &str,
+    separator: &str,
+    out: &mut Map<String, Value>,
+) -> Result<(), FaucetError> {
     match value {
         Value::Object(map) => {
             for (k, v) in map {
@@ -282,13 +297,23 @@ fn flatten_into(value: Value, prefix: &str, separator: &str, out: &mut Map<Strin
                 } else {
                     format!("{prefix}{separator}{k}")
                 };
-                flatten_into(v, &key, separator, out);
+                flatten_into(v, &key, separator, out)?;
             }
         }
         other => {
+            // Erroring (rather than last-wins) avoids silently dropping a value
+            // when a nested path and a literal key collide, e.g.
+            // `{"a__b":1,"a":{"b":2}}` both map to `a__b` (#78/#28).
+            if out.contains_key(prefix) {
+                return Err(FaucetError::Transform(format!(
+                    "flatten produced a duplicate key '{prefix}'; two distinct fields collapse \
+                     to the same flattened key (separator '{separator}')"
+                )));
+            }
             out.insert(prefix.to_string(), other);
         }
     }
+    Ok(())
 }
 
 // ── Rename keys ───────────────────────────────────────────────────────────────
@@ -338,17 +363,37 @@ pub fn to_snake_case(key: &str) -> String {
 }
 
 #[cfg(feature = "transform-snake-case")]
-fn keys_to_snake_case(value: Value) -> Value {
+fn keys_to_snake_case(value: Value) -> Result<Value, FaucetError> {
     match value {
         Value::Object(map) => {
-            let new_map: Map<String, Value> = map
-                .into_iter()
-                .map(|(k, v)| (to_snake_case(&k), keys_to_snake_case(v)))
-                .collect();
-            Value::Object(new_map)
+            let mut new_map = Map::with_capacity(map.len());
+            for (k, v) in map {
+                // An all-special key like "!@#" snake_cases to "" — keep the
+                // original key instead of producing an empty/blank key.
+                let snaked = to_snake_case(&k);
+                let new_k = if snaked.is_empty() { k } else { snaked };
+                let new_v = keys_to_snake_case(v)?;
+                // Erroring (rather than last-wins) avoids silently dropping a
+                // value when two distinct keys snake_case to the same name,
+                // e.g. "last-name" and "lastName" both → "last_name" (#78/#28).
+                if new_map.contains_key(&new_k) {
+                    return Err(FaucetError::Transform(format!(
+                        "snake_case produced a duplicate key '{new_k}'; two distinct keys \
+                         normalise to the same name"
+                    )));
+                }
+                new_map.insert(new_k, new_v);
+            }
+            Ok(Value::Object(new_map))
         }
-        Value::Array(arr) => Value::Array(arr.into_iter().map(keys_to_snake_case).collect()),
-        other => other,
+        Value::Array(arr) => {
+            let mut out = Vec::with_capacity(arr.len());
+            for v in arr {
+                out.push(keys_to_snake_case(v)?);
+            }
+            Ok(Value::Array(out))
+        }
+        other => Ok(other),
     }
 }
 
@@ -358,6 +403,14 @@ fn keys_to_snake_case(value: Value) -> Value {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    /// Test-only wrapper that shadows [`super::apply_all`] and unwraps, so the
+    /// many existing success-path tests need no changes now that `apply_all`
+    /// returns `Result`. Collision tests call `super::apply_all` for the
+    /// `Result` directly.
+    fn apply_all(record: Value, transforms: &[CompiledTransform]) -> Value {
+        super::apply_all(record, transforms).expect("transform should succeed in this test")
+    }
 
     fn compiled(transforms: &[RecordTransform]) -> Vec<CompiledTransform> {
         transforms.iter().map(|t| compile(t).unwrap()).collect()
@@ -665,5 +718,48 @@ mod tests {
         assert_eq!(result["id"], 1);
         assert_eq!(result["value"], 200);
         assert!(result.get("raw_value").is_none());
+    }
+
+    // ── #78/#28: collisions must error, not silently drop ──────────────────
+
+    #[cfg(feature = "transform-flatten")]
+    #[test]
+    fn flatten_key_collision_errors() {
+        // `a__b` (literal) and `a.b` (nested) both flatten to `a__b`.
+        let record = json!({"a__b": 1, "a": {"b": 2}});
+        let err = super::apply_all(
+            record,
+            &compiled(&[RecordTransform::Flatten {
+                separator: "__".into(),
+            }]),
+        )
+        .expect_err("colliding flattened keys must error, not drop a value");
+        assert!(matches!(err, FaucetError::Transform(_)));
+        assert!(format!("{err}").contains("a__b"), "{err}");
+    }
+
+    #[cfg(feature = "transform-snake-case")]
+    #[test]
+    fn snake_case_key_collision_errors() {
+        // "last-name" (dash stripped) and "lastname" both snake_case to "lastname".
+        let record = json!({"last-name": "a", "lastname": "b"});
+        let err = super::apply_all(record, &compiled(&[RecordTransform::KeysToSnakeCase]))
+            .expect_err("colliding snake_case keys must error, not drop a value");
+        assert!(matches!(err, FaucetError::Transform(_)));
+        assert!(format!("{err}").contains("lastname"), "{err}");
+    }
+
+    #[cfg(feature = "transform-snake-case")]
+    #[test]
+    fn snake_case_empty_output_keeps_original_key() {
+        // A key that strips to "" must not become a blank key — keep it as-is.
+        let record = json!({"!@#": 1, "id": 2});
+        let result = super::apply_all(record, &compiled(&[RecordTransform::KeysToSnakeCase]))
+            .expect("no collision here");
+        assert_eq!(
+            result["!@#"], 1,
+            "original key retained when snake_case is empty"
+        );
+        assert_eq!(result["id"], 2);
     }
 }

--- a/crates/kafka-common/src/format.rs
+++ b/crates/kafka-common/src/format.rs
@@ -39,6 +39,28 @@ pub enum KafkaValueFormat {
     },
 }
 
+impl KafkaValueFormat {
+    /// True for Confluent Schema Registry wire formats (`ConfluentAvro`,
+    /// `ConfluentProtobuf`, `ConfluentJsonSchema`), which require a schema to
+    /// encode on the sink side. Always `false` when the `schema-registry`
+    /// feature is disabled (those variants don't exist).
+    pub fn is_schema_registry(&self) -> bool {
+        #[cfg(feature = "schema-registry")]
+        {
+            matches!(
+                self,
+                KafkaValueFormat::ConfluentAvro { .. }
+                    | KafkaValueFormat::ConfluentProtobuf { .. }
+                    | KafkaValueFormat::ConfluentJsonSchema { .. }
+            )
+        }
+        #[cfg(not(feature = "schema-registry"))]
+        {
+            false
+        }
+    }
+}
+
 /// Producer-side compression for outbound batches.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Default)]
 #[serde(rename_all = "lowercase")]

--- a/crates/sink/kafka/README.md
+++ b/crates/sink/kafka/README.md
@@ -106,6 +106,20 @@ Configured via `value_format` (and optionally `key_format`). All formats use a `
 
 The three Confluent formats require the `schema-registry` feature flag. Each takes a `schema_registry` block — see the [`faucet-kafka-common` README](../kafka-common/README.md#value-formats) for `SchemaRegistryConfig` options.
 
+When a Confluent format is used on the **sink** side you must also supply the schema text to register and encode against: set `value_schema` (for `value_format`) and/or `key_schema` (for `key_format`) to the Avro `.avsc` JSON, `.proto`, or JSON Schema document. They are registered under the `{topic}-value` / `{topic}-key` subjects on first use. The config is rejected at load time if a Confluent format is selected without its schema.
+
+```yaml
+sink:
+  type: kafka
+  config:
+    brokers: localhost:9092
+    topic: { type: fixed, name: events }
+    value_format:
+      type: confluent_avro
+      schema_registry: { url: http://localhost:8081 }
+    value_schema: '{"type":"record","name":"Event","fields":[{"name":"id","type":"long"}]}'
+```
+
 ---
 
 ## Key / partition / headers

--- a/crates/sink/kafka/src/config.rs
+++ b/crates/sink/kafka/src/config.rs
@@ -17,6 +17,18 @@ pub struct KafkaSinkConfig {
     pub value_format: KafkaValueFormat,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub key_format: Option<KafkaValueFormat>,
+    /// Schema text (Avro `.avsc` JSON, Protobuf `.proto`, or JSON Schema) for
+    /// the **value** when `value_format` is a Confluent Schema Registry format
+    /// (`confluent_avro` / `confluent_protobuf` / `confluent_json_schema`).
+    /// Registered under the `{topic}-value` subject on first use. Required for
+    /// those formats; ignored otherwise.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub value_schema: Option<String>,
+    /// Schema text for the **key**, used when `key_format` is a Confluent
+    /// Schema Registry format. Registered under `{topic}-key`. Required for
+    /// those key formats; ignored otherwise.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub key_schema: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub key_path: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -169,6 +181,28 @@ impl KafkaSinkConfig {
                 "kafka sink: max_in_flight must be at least 1".into(),
             ));
         }
+        // Confluent Schema Registry formats need a schema to encode against;
+        // without one the encoder fails on the first record (#78/#9). Catch it
+        // at config-load time with a clear message. (Both checks are no-ops
+        // when the schema-registry feature is off — `is_schema_registry`
+        // returns false.)
+        if self.value_format.is_schema_registry() && self.value_schema.is_none() {
+            return Err(FaucetError::Config(
+                "kafka sink: value_format is a Confluent Schema Registry format but \
+                 value_schema is not set"
+                    .into(),
+            ));
+        }
+        if let Some(kf) = &self.key_format
+            && kf.is_schema_registry()
+            && self.key_schema.is_none()
+        {
+            return Err(FaucetError::Config(
+                "kafka sink: key_format is a Confluent Schema Registry format but \
+                 key_schema is not set"
+                    .into(),
+            ));
+        }
         faucet_core::validate_batch_size(self.batch_size)?;
         Ok(())
     }
@@ -197,6 +231,8 @@ mod tests {
             auth: KafkaAuth::None,
             value_format: KafkaValueFormat::Json,
             key_format: None,
+            value_schema: None,
+            key_schema: None,
             key_path: None,
             partition_path: None,
             headers_path: None,
@@ -217,6 +253,25 @@ mod tests {
     #[test]
     fn validate_accepts_minimal() {
         assert!(minimal().validate().is_ok());
+    }
+
+    #[cfg(feature = "schema-registry")]
+    #[test]
+    fn validate_requires_schema_for_confluent_value_format() {
+        // Regression for #78/#9: a Confluent SR value_format with no
+        // value_schema must be rejected at config load, not fail per-record.
+        use faucet_kafka_common::SchemaRegistryConfig;
+        let mut c = minimal();
+        c.value_format = KafkaValueFormat::ConfluentAvro {
+            schema_registry: SchemaRegistryConfig::new("http://localhost:8081"),
+        };
+        c.value_schema = None;
+        let err = c.validate().unwrap_err();
+        assert!(format!("{err}").contains("value_schema"), "{err}");
+
+        // With a schema it validates.
+        c.value_schema = Some(r#"{"type":"record","name":"R","fields":[]}"#.into());
+        assert!(c.validate().is_ok());
     }
 
     #[test]

--- a/crates/sink/kafka/src/sink.rs
+++ b/crates/sink/kafka/src/sink.rs
@@ -96,12 +96,12 @@ impl KafkaSink {
         #[cfg(feature = "schema-registry")]
         let value_ctx = encode::SchemaContext {
             subject: format!("{topic}-value"),
-            schema_text: None,
+            schema_text: self.config.value_schema.clone(),
         };
         #[cfg(feature = "schema-registry")]
         let key_ctx = encode::SchemaContext {
             subject: format!("{topic}-key"),
-            schema_text: None,
+            schema_text: self.config.key_schema.clone(),
         };
 
         let value_bytes = encode::encode(

--- a/crates/sink/kafka/tests/integration.rs
+++ b/crates/sink/kafka/tests/integration.rs
@@ -40,6 +40,8 @@ fn sink_config(brokers: &str, topic: KafkaSinkTopic) -> KafkaSinkConfig {
         auth: KafkaAuth::None,
         value_format: KafkaValueFormat::Json,
         key_format: None,
+        value_schema: None,
+        key_schema: None,
         key_path: None,
         partition_path: None,
         headers_path: None,

--- a/crates/sink/mongodb/README.md
+++ b/crates/sink/mongodb/README.md
@@ -59,6 +59,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 | `database` | `String` | *(required)* | Database name |
 | `collection` | `String` | *(required)* | Collection name |
 | `batch_size` | `usize` | `1000` | Maximum number of documents per `insert_many` call. See [Streaming and batching](#streaming-and-batching) below |
+| `ordered` | `bool` | `false` | Whether `insert_many` is ordered. Default `false` (unordered) so one bad document — duplicate `_id`, validation error — doesn't drop the rest of the batch. Set `true` only if you require strict insertion order and want the batch to abort at the first failure. |
 
 The `Debug` implementation masks the `connection_uri` with `***` to prevent credential leakage in logs.
 

--- a/crates/sink/mongodb/src/config.rs
+++ b/crates/sink/mongodb/src/config.rs
@@ -39,6 +39,16 @@ pub struct MongoSinkConfig {
     /// flows through untouched.
     #[serde(default = "default_batch_size")]
     pub batch_size: usize,
+    /// Whether `insert_many` is **ordered**. Default `false` (unordered).
+    ///
+    /// With the MongoDB default of `ordered = true`, the first failing
+    /// document (a duplicate `_id`, a validation error, …) aborts the rest of
+    /// the batch — the documents before it commit, those after are silently
+    /// dropped. Unordered (`false`) instead attempts every document and only
+    /// the genuinely-bad ones fail, so a single poison record can't drop the
+    /// rest of the batch (#78/#20).
+    #[serde(default)]
+    pub ordered: bool,
 }
 
 fn default_batch_size() -> usize {
@@ -57,7 +67,14 @@ impl MongoSinkConfig {
             database: database.into(),
             collection: collection.into(),
             batch_size: DEFAULT_BATCH_SIZE,
+            ordered: false,
         }
+    }
+
+    /// Set whether `insert_many` is ordered (default `false`).
+    pub fn with_ordered(mut self, ordered: bool) -> Self {
+        self.ordered = ordered;
+        self
     }
 
     /// Set the maximum number of documents per `insert_many` call.
@@ -78,6 +95,7 @@ impl fmt::Debug for MongoSinkConfig {
             .field("database", &self.database)
             .field("collection", &self.collection)
             .field("batch_size", &self.batch_size)
+            .field("ordered", &self.ordered)
             .finish()
     }
 }

--- a/crates/sink/mongodb/src/sink.rs
+++ b/crates/sink/mongodb/src/sink.rs
@@ -83,8 +83,12 @@ impl faucet_core::Sink for MongoSink {
                 .map(Self::value_to_document)
                 .collect::<Result<Vec<_>, _>>()?;
 
+            let opts = mongodb::options::InsertManyOptions::builder()
+                .ordered(self.config.ordered)
+                .build();
             collection
                 .insert_many(&docs)
+                .with_options(opts)
                 .await
                 .map_err(|e| FaucetError::Sink(format!("MongoDB insert_many failed: {e}")))?;
 

--- a/crates/sink/mongodb/tests/batch_size.rs
+++ b/crates/sink/mongodb/tests/batch_size.rs
@@ -62,6 +62,31 @@ async fn write_batch_rechunks_into_batch_size_inserts() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn unordered_insert_lands_valid_docs_despite_a_duplicate() {
+    // Regression for #78/#20: the default is now unordered, so a single bad
+    // document (here a duplicate `_id`) does not drop the rest of the batch.
+    // Ordered would have committed `_id` 1 and 2, aborted on the duplicate,
+    // and dropped `_id` 3 → 2 docs; unordered lands all 3 distinct ids.
+    let (_container, uri) = start_mongo().await;
+    let config = MongoSinkConfig::new(&uri, "testdb", "events"); // ordered = false (default)
+    let sink = MongoSink::new(config).await.expect("sink new");
+
+    let records = vec![
+        json!({"_id": 1, "v": "a"}),
+        json!({"_id": 2, "v": "b"}),
+        json!({"_id": 2, "v": "c"}), // duplicate _id — only this one should fail
+        json!({"_id": 3, "v": "d"}),
+    ];
+    // The batch surfaces the duplicate-key error, but the valid docs land.
+    let _ = sink.write_batch(&records).await;
+    assert_eq!(
+        count_docs(&uri, "testdb", "events").await,
+        3,
+        "unordered insert must land the 3 distinct docs despite the duplicate _id"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn write_batch_exact_multiple_of_batch_size() {
     // 1000 records with batch_size = 1000 → 1 insert_many call.
     let (_container, uri) = start_mongo().await;

--- a/crates/sink/postgres/README.md
+++ b/crates/sink/postgres/README.md
@@ -72,16 +72,17 @@ bind-parameter limit.
 - **`batch_size > 0`** (default `1000`) — the sink slices the incoming
   slice into `batch_size`-row chunks and issues one multi-row `INSERT`
   per chunk. **Recommended value is `1000`**: Postgres' multi-row
-  `INSERT` sweet spot. Larger chunks rarely add throughput, and AutoMap
-  mode binds one parameter per column per row — exceeding the 65 535
-  bind-parameter ceiling (`batch_size * num_columns > 65_535`) causes
-  the server to reject the statement. JSONB mode is unaffected (it
-  binds a single `jsonb[]` array regardless of row count).
+  `INSERT` sweet spot. Larger chunks rarely add throughput. AutoMap mode
+  binds one parameter per column per row; the sink now splits each chunk
+  further so `rows × columns` never exceeds Postgres' 65 535 bind-parameter
+  ceiling, so a wide table no longer causes the server to reject the
+  statement regardless of `batch_size`. JSONB mode binds a single `jsonb[]`
+  array regardless of row count.
 - **`batch_size = 0`** — the "no batching" sentinel. The entire upstream
-  `StreamPage` is forwarded in a single `INSERT`. Use this when the
+  `StreamPage` is forwarded in a single logical write. Use this when the
   source already emits page sizes tuned for Postgres — for example a
-  REST source with `batch_size: 1000` feeding a JSONB table. Larger
-  pages risk hitting the 65 535-parameter ceiling in AutoMap mode.
+  REST source with `batch_size: 1000` feeding a JSONB table. AutoMap still
+  sub-splits internally to respect the 65 535-parameter ceiling.
 
 `batch_size` is purely a chunk-size knob — connection pooling, identifier
 quoting, and JSONB vs AutoMap behaviour are unchanged.

--- a/crates/sink/postgres/src/sink.rs
+++ b/crates/sink/postgres/src/sink.rs
@@ -127,35 +127,44 @@ impl PostgresSink {
         let num_rows = matched_rows.len();
         let col_names: Vec<String> = insert_columns.iter().map(|c| quote_ident(c)).collect();
 
-        // Build multi-row VALUES clause: ($1, $2), ($3, $4), ...
-        let mut value_tuples: Vec<String> = Vec::with_capacity(num_rows);
-        for row_idx in 0..num_rows {
-            let start = row_idx * num_cols + 1;
-            let placeholders: Vec<String> =
-                (start..start + num_cols).map(|i| format!("${i}")).collect();
-            value_tuples.push(format!("({})", placeholders.join(", ")));
-        }
+        // PostgreSQL caps bind parameters per statement at 65535. A multi-row
+        // INSERT binds `rows × num_cols` parameters, so a wide table at a large
+        // batch_size can exceed it and fail at runtime (#78/#21). Split into
+        // sub-INSERTs of at most floor(MAX_PARAMS / num_cols) rows.
+        const MAX_PG_PARAMS: usize = 65535;
+        let max_rows_per_insert = (MAX_PG_PARAMS / num_cols).max(1);
 
-        let query = format!(
-            "INSERT INTO {} ({}) VALUES {}",
-            quote_ident(&self.config.table_name),
-            col_names.join(", "),
-            value_tuples.join(", ")
-        );
-
-        let mut q = sqlx::query(&query);
-        for matched in &matched_rows {
-            // Bind values in the fixed column order. If a record is missing
-            // a column that appeared in the first record, bind null.
-            for col in &insert_columns {
-                let val = matched.iter().find(|(c, _)| *c == col).map(|(_, v)| *v);
-                q = q.bind(val.cloned());
+        for sub in matched_rows.chunks(max_rows_per_insert) {
+            // Build multi-row VALUES clause: ($1, $2), ($3, $4), ...
+            let mut value_tuples: Vec<String> = Vec::with_capacity(sub.len());
+            for row_idx in 0..sub.len() {
+                let start = row_idx * num_cols + 1;
+                let placeholders: Vec<String> =
+                    (start..start + num_cols).map(|i| format!("${i}")).collect();
+                value_tuples.push(format!("({})", placeholders.join(", ")));
             }
-        }
 
-        q.execute(&self.pool)
-            .await
-            .map_err(|e| FaucetError::Sink(format!("PostgreSQL insert failed: {e}")))?;
+            let query = format!(
+                "INSERT INTO {} ({}) VALUES {}",
+                quote_ident(&self.config.table_name),
+                col_names.join(", "),
+                value_tuples.join(", ")
+            );
+
+            let mut q = sqlx::query(&query);
+            for matched in sub {
+                // Bind values in the fixed column order. If a record is missing
+                // a column that appeared in the first record, bind null.
+                for col in &insert_columns {
+                    let val = matched.iter().find(|(c, _)| *c == col).map(|(_, v)| *v);
+                    q = q.bind(val.cloned());
+                }
+            }
+
+            q.execute(&self.pool)
+                .await
+                .map_err(|e| FaucetError::Sink(format!("PostgreSQL insert failed: {e}")))?;
+        }
 
         Ok(num_rows)
     }

--- a/crates/sink/postgres/tests/batching.rs
+++ b/crates/sink/postgres/tests/batching.rs
@@ -207,3 +207,53 @@ async fn write_batch_auto_map_re_chunks_when_input_exceeds_batch_size() {
          observed {calls}"
     );
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn auto_map_chunks_to_respect_postgres_param_limit() {
+    // Regression for #78/#21: Postgres caps bind parameters at 65535. A wide
+    // table at a large batch (70 cols × 1000 rows = 70_000 binds) in a single
+    // INSERT would fail; the sink must sub-chunk and still land every row.
+    let (_container, url) = start_postgres().await;
+    let cols: Vec<String> = (0..70).map(|i| format!("c{i}")).collect();
+    let create = format!(
+        "CREATE TABLE wide ({})",
+        cols.iter()
+            .map(|c| format!("{c} JSONB"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+    {
+        let pool = sqlx::PgPool::connect(&url).await.expect("pool connect");
+        sqlx::query(&create)
+            .execute(&pool)
+            .await
+            .expect("create wide table");
+        pool.close().await;
+    }
+
+    let config = PostgresSinkConfig::new(&url, "wide")
+        .column_mapping(PostgresColumnMapping::AutoMap)
+        .with_batch_size(0); // one slice → exercises the inner param-limit chunking
+    let sink = PostgresSink::new(config).await.expect("sink new");
+
+    let recs: Vec<Value> = (0..1_000)
+        .map(|r| {
+            let mut m = serde_json::Map::new();
+            for (i, c) in cols.iter().enumerate() {
+                m.insert(c.clone(), json!(r * 100 + i as i64));
+            }
+            Value::Object(m)
+        })
+        .collect();
+
+    let written = sink.write_batch(&recs).await.expect("write");
+    assert_eq!(written, 1_000);
+
+    let pool = sqlx::PgPool::connect(&url).await.expect("pool connect");
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*)::BIGINT FROM wide")
+        .fetch_one(&pool)
+        .await
+        .expect("count");
+    pool.close().await;
+    assert_eq!(count, 1_000);
+}

--- a/crates/sink/sqlite/README.md
+++ b/crates/sink/sqlite/README.md
@@ -68,9 +68,10 @@ and to amortise per-transaction overhead.
   chunk, each wrapped in its own `BEGIN`/`COMMIT` transaction.
   **Recommended value is `1000`**: large enough to amortise transaction
   overhead, small enough to stay well under SQLite's default
-  `SQLITE_MAX_VARIABLE_NUMBER` (32766 since 3.32.0). Drop it if rows have
-  many columns; raise it if rows are narrow and you've tuned
-  `max_variable_number` accordingly.
+  `SQLITE_MAX_VARIABLE_NUMBER` (32766 since 3.32.0). In AutoMap mode the
+  sink also splits each chunk further so `rows × columns` never exceeds that
+  limit, so a wide table no longer fails with "too many SQL variables"
+  regardless of `batch_size`.
 - **`batch_size = 0`** — the "no batching" sentinel. The entire upstream
   `StreamPage` is written in a single multi-row INSERT inside one
   transaction. Use this when the source already emits page sizes tuned for

--- a/crates/sink/sqlite/src/sink.rs
+++ b/crates/sink/sqlite/src/sink.rs
@@ -138,16 +138,13 @@ impl SqliteSink {
         let num_rows = matched_rows.len();
         let col_names: Vec<String> = insert_columns.iter().map(|c| quote_ident(c)).collect();
 
-        // Build multi-row VALUES clause: (?, ?), (?, ?), ...
-        let row_placeholder = format!("({})", vec!["?"; num_cols].join(", "));
-        let value_tuples: Vec<&str> = (0..num_rows).map(|_| row_placeholder.as_str()).collect();
-
-        let query = format!(
-            "INSERT INTO {} ({}) VALUES {}",
-            quote_ident(&self.config.table_name),
-            col_names.join(", "),
-            value_tuples.join(", ")
-        );
+        // SQLite caps bind parameters per statement at SQLITE_MAX_VARIABLE_NUMBER
+        // (32766 since 3.32). A multi-row INSERT binds `rows × num_cols`
+        // parameters, so a wide table at a large batch_size can exceed it and
+        // fail at runtime with "too many SQL variables" (#78/#21). Split into
+        // sub-INSERTs of at most floor(MAX_VARS / num_cols) rows.
+        const MAX_SQLITE_VARS: usize = 32766;
+        let max_rows_per_insert = (MAX_SQLITE_VARS / num_cols).max(1);
 
         let mut tx = self
             .pool
@@ -155,39 +152,52 @@ impl SqliteSink {
             .await
             .map_err(|e| FaucetError::Sink(format!("SQLite transaction begin failed: {e}")))?;
 
-        let mut q = sqlx::query(&query);
-        for matched in &matched_rows {
-            for col in &insert_columns {
-                let val = matched.iter().find(|(c, _)| *c == col).map(|(_, v)| *v);
-                // Bind native SQLite types so column affinity and typed reads
-                // round-trip correctly. Binding every value as a JSON string
-                // (the old behaviour) stored `"Bob"` with embedded quotes,
-                // turned `true` into the text "true", and bound the literal
-                // text "null" for absent columns instead of SQL NULL (#78/#4).
-                q = match val {
-                    None | Some(Value::Null) => q.bind(None::<String>),
-                    Some(Value::Bool(b)) => q.bind(*b),
-                    Some(Value::Number(n)) => {
-                        if let Some(i) = n.as_i64() {
-                            q.bind(i)
-                        } else if let Some(f) = n.as_f64() {
-                            q.bind(f)
-                        } else {
-                            // u64 above i64::MAX — preserve exact text.
-                            q.bind(n.to_string())
-                        }
-                    }
-                    Some(Value::String(s)) => q.bind(s.clone()),
-                    // Arrays/objects have no scalar SQL representation — store
-                    // their JSON text (suitable for TEXT / JSON columns).
-                    Some(v) => q.bind(v.to_string()),
-                };
-            }
-        }
+        for sub in matched_rows.chunks(max_rows_per_insert) {
+            // Build multi-row VALUES clause: (?, ?), (?, ?), ...
+            let row_placeholder = format!("({})", vec!["?"; num_cols].join(", "));
+            let value_tuples: Vec<&str> =
+                (0..sub.len()).map(|_| row_placeholder.as_str()).collect();
+            let query = format!(
+                "INSERT INTO {} ({}) VALUES {}",
+                quote_ident(&self.config.table_name),
+                col_names.join(", "),
+                value_tuples.join(", ")
+            );
 
-        q.execute(&mut *tx)
-            .await
-            .map_err(|e| FaucetError::Sink(format!("SQLite insert failed: {e}")))?;
+            let mut q = sqlx::query(&query);
+            for matched in sub {
+                for col in &insert_columns {
+                    let val = matched.iter().find(|(c, _)| *c == col).map(|(_, v)| *v);
+                    // Bind native SQLite types so column affinity and typed reads
+                    // round-trip correctly. Binding every value as a JSON string
+                    // (the old behaviour) stored `"Bob"` with embedded quotes,
+                    // turned `true` into the text "true", and bound the literal
+                    // text "null" for absent columns instead of SQL NULL (#78/#4).
+                    q = match val {
+                        None | Some(Value::Null) => q.bind(None::<String>),
+                        Some(Value::Bool(b)) => q.bind(*b),
+                        Some(Value::Number(n)) => {
+                            if let Some(i) = n.as_i64() {
+                                q.bind(i)
+                            } else if let Some(f) = n.as_f64() {
+                                q.bind(f)
+                            } else {
+                                // u64 above i64::MAX — preserve exact text.
+                                q.bind(n.to_string())
+                            }
+                        }
+                        Some(Value::String(s)) => q.bind(s.clone()),
+                        // Arrays/objects have no scalar SQL representation — store
+                        // their JSON text (suitable for TEXT / JSON columns).
+                        Some(v) => q.bind(v.to_string()),
+                    };
+                }
+            }
+
+            q.execute(&mut *tx)
+                .await
+                .map_err(|e| FaucetError::Sink(format!("SQLite insert failed: {e}")))?;
+        }
 
         tx.commit()
             .await

--- a/crates/sink/sqlite/tests/batching.rs
+++ b/crates/sink/sqlite/tests/batching.rs
@@ -224,6 +224,42 @@ async fn auto_map_binds_native_types_not_json_strings() {
 }
 
 #[tokio::test]
+async fn auto_map_chunks_to_respect_sqlite_var_limit() {
+    // Regression for #78/#21: SQLite caps bind variables at 32766. A wide
+    // table at a large batch (100 cols × 1000 rows = 100_000 binds) in a
+    // single INSERT would fail with "too many SQL variables"; the sink must
+    // sub-chunk and still land every row.
+    let cols: Vec<String> = (0..100).map(|i| format!("c{i}")).collect();
+    let create = format!(
+        "CREATE TABLE wide ({})",
+        cols.iter()
+            .map(|c| format!("{c} INTEGER"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+    let (_dir, url) = fresh_db(&create).await;
+
+    let config = SqliteSinkConfig::new(&url, "wide")
+        .column_mapping(SqliteColumnMapping::AutoMap)
+        .with_batch_size(0); // one slice → exercises the inner var-limit chunking
+    let sink = SqliteSink::new(config).await.unwrap();
+
+    let records: Vec<Value> = (0..1_000)
+        .map(|r| {
+            let mut m = serde_json::Map::new();
+            for (i, c) in cols.iter().enumerate() {
+                m.insert(c.clone(), json!(r * 100 + i as i64));
+            }
+            Value::Object(m)
+        })
+        .collect();
+
+    let n = sink.write_batch(&records).await.unwrap();
+    assert_eq!(n, 1_000);
+    assert_eq!(count_rows(&url, "wide").await, 1_000);
+}
+
+#[tokio::test]
 async fn auto_map_mode_batch_size_zero_passes_page_through() {
     // batch_size=0 in AutoMap mode writes the entire slice as a single
     // transaction.

--- a/crates/source/graphql/README.md
+++ b/crates/source/graphql/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/faucet-source-graphql.svg)](https://crates.io/crates/faucet-source-graphql)
 [![Docs.rs](https://docs.rs/faucet-source-graphql/badge.svg)](https://docs.rs/faucet-source-graphql)
 
-A config-driven GraphQL API source with cursor-based pagination, JSONPath record extraction, and pluggable authentication.
+A config-driven GraphQL API source with cursor-based pagination, JSONPath record extraction, and pluggable authentication. Transient HTTP failures (5xx / connection resets) are retried with exponential backoff.
 
 Part of the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
 

--- a/crates/source/graphql/src/stream.rs
+++ b/crates/source/graphql/src/stream.rs
@@ -8,6 +8,12 @@ use jsonpath_rust::JsonPath;
 use reqwest::Client;
 use serde_json::{Value, json};
 use std::pin::Pin;
+use std::time::Duration;
+
+/// Retries on transient (5xx / connection) failures before giving up.
+const RETRY_MAX_ATTEMPTS: u32 = 3;
+/// Base exponential-backoff delay between retries.
+const RETRY_BASE_BACKOFF: Duration = Duration::from_millis(500);
 
 /// A configured GraphQL source that handles pagination and extraction.
 pub struct GraphqlStream {
@@ -153,10 +159,23 @@ impl GraphqlStream {
             }
         }
 
-        let resp = req.send().await.map_err(FaucetError::Http)?;
-        let resp = util::check_http_response(resp, DEFAULT_ERROR_BODY_MAX_LEN).await?;
-
-        let body: Value = resp.json().await.map_err(FaucetError::Http)?;
+        // Retry transient failures (5xx / connection resets) with jittered
+        // backoff, matching the REST source's reliability layer (#78/#16).
+        // GraphQL-level `errors` in a 200 body are application errors and are
+        // handled below — they are not retried here.
+        let body: Value =
+            faucet_core::execute_with_retry(RETRY_MAX_ATTEMPTS, RETRY_BASE_BACKOFF, || {
+                let attempt = req.try_clone();
+                async move {
+                    let req = attempt.ok_or_else(|| {
+                        FaucetError::Source("graphql: request is not cloneable for retry".into())
+                    })?;
+                    let resp = req.send().await.map_err(FaucetError::Http)?;
+                    let resp = util::check_http_response(resp, DEFAULT_ERROR_BODY_MAX_LEN).await?;
+                    resp.json().await.map_err(FaucetError::Http)
+                }
+            })
+            .await?;
 
         // Check for GraphQL-level errors.
         if let Some(errors) = body.get("errors")

--- a/crates/source/graphql/tests/streaming.rs
+++ b/crates/source/graphql/tests/streaming.rs
@@ -108,6 +108,36 @@ fn relay_config(server: &MockServer, batch_size: usize) -> GraphqlStreamConfig {
     .with_batch_size(batch_size)
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn retries_transient_5xx_then_succeeds() {
+    // Regression for #78/#16: the GraphQL source previously did a single send
+    // with no retry, so any transient 5xx failed the run. Two 503s then a 200
+    // must now succeed.
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(503))
+        .up_to_n_times(2)
+        .expect(2)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(make_page(0, 3, None)))
+        .mount(&server)
+        .await;
+
+    let config =
+        GraphqlStreamConfig::new(server.uri(), "query { users { edges { node { id } } } }")
+            .records_path("$.data.users.edges[*].node");
+    let source = GraphqlStream::new(config);
+    let records = source
+        .fetch_all()
+        .await
+        .expect("should succeed after retries");
+    assert_eq!(records.len(), 3);
+}
+
 // ─── 1. Multi-page cursor pagination ─────────────────────────────────────────
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/source/redis/Cargo.toml
+++ b/crates/source/redis/Cargo.toml
@@ -15,7 +15,7 @@ serde_json.workspace = true
 async-trait.workspace = true
 tracing.workspace = true
 redis = { workspace = true }
-tokio.workspace = true
+tokio = { workspace = true, features = ["sync"] }
 async-stream = { workspace = true }
 futures.workspace = true
 

--- a/crates/source/redis/src/stream.rs
+++ b/crates/source/redis/src/stream.rs
@@ -10,23 +10,44 @@ use std::pin::Pin;
 /// A configured Redis source that reads records from Redis data structures.
 pub struct RedisSource {
     config: RedisSourceConfig,
+    /// Lazily-opened multiplexed connection, reused across every `fetch_all`
+    /// and `stream_pages` call instead of opening a fresh client + TCP/AUTH
+    /// handshake per call (#78/#22). `MultiplexedConnection` is cheap to clone
+    /// (it shares one underlying socket), so each call clones the cached one.
+    conn: tokio::sync::OnceCell<redis::aio::MultiplexedConnection>,
 }
 
 impl RedisSource {
-    /// Create a new Redis source from the given configuration.
+    /// Create a new Redis source from the given configuration. The connection
+    /// is opened lazily on first use (so construction stays infallible and
+    /// synchronous).
     pub fn new(config: RedisSourceConfig) -> Self {
-        Self { config }
+        Self {
+            config,
+            conn: tokio::sync::OnceCell::new(),
+        }
+    }
+
+    /// Return a clone of the shared multiplexed connection, opening it once on
+    /// first call.
+    async fn connection(&self) -> Result<redis::aio::MultiplexedConnection, FaucetError> {
+        let conn = self
+            .conn
+            .get_or_try_init(|| async {
+                let client = redis::Client::open(self.config.url.as_str())
+                    .map_err(|e| FaucetError::Config(format!("invalid Redis URL: {e}")))?;
+                client
+                    .get_multiplexed_async_connection()
+                    .await
+                    .map_err(|e| FaucetError::Config(format!("Redis connection failed: {e}")))
+            })
+            .await?;
+        Ok(conn.clone())
     }
 
     /// Fetch all records from the configured Redis source.
     pub async fn fetch_all(&self) -> Result<Vec<Value>, FaucetError> {
-        let client = redis::Client::open(self.config.url.as_str())
-            .map_err(|e| FaucetError::Config(format!("invalid Redis URL: {e}")))?;
-
-        let mut conn = client
-            .get_multiplexed_async_connection()
-            .await
-            .map_err(|e| FaucetError::Config(format!("Redis connection failed: {e}")))?;
+        let mut conn = self.connection().await?;
 
         let mut records = match &self.config.source_type {
             RedisSourceType::List { key } => self.fetch_list(&mut conn, key).await?,
@@ -210,13 +231,7 @@ impl faucet_core::Source for RedisSource {
             return RedisSource::fetch_all(self).await;
         }
 
-        let client = redis::Client::open(self.config.url.as_str())
-            .map_err(|e| FaucetError::Config(format!("invalid Redis URL: {e}")))?;
-
-        let mut conn = client
-            .get_multiplexed_async_connection()
-            .await
-            .map_err(|e| FaucetError::Config(format!("Redis connection failed: {e}")))?;
+        let mut conn = self.connection().await?;
 
         // Substitute context into the key/pattern of each source type variant.
         let mut records = match &self.config.source_type {
@@ -273,12 +288,7 @@ impl faucet_core::Source for RedisSource {
         let max_records = self.config.max_records;
 
         Box::pin(async_stream::try_stream! {
-            let client = redis::Client::open(self.config.url.as_str())
-                .map_err(|e| FaucetError::Config(format!("invalid Redis URL: {e}")))?;
-            let mut conn = client
-                .get_multiplexed_async_connection()
-                .await
-                .map_err(|e| FaucetError::Config(format!("Redis connection failed: {e}")))?;
+            let mut conn = self.connection().await?;
 
             let mut emitted: usize = 0;
 

--- a/crates/source/rest/README.md
+++ b/crates/source/rest/README.md
@@ -144,10 +144,10 @@ The `PaginationStyle` enum supports:
 | `Cursor { next_token_path, param_name }` | JSONPath to next token, query param name | Next token is null or absent, or loop detected |
 | `LinkHeader` | -- | No `rel="next"` in the `Link` response header |
 | `NextLinkInBody { next_link_path }` | JSONPath to next page URL | URL is absent, null, or empty |
-| `PageNumber { param_name, start_page, page_size, page_size_param }` | Query param name, starting page number, optional page size and its param name | Response returns zero records |
+| `PageNumber { param_name, start_page, page_size, page_size_param }` | Query param name, starting page number, optional page size and its param name | Response returns zero records, or the same page body is returned twice in a row |
 | `Offset { offset_param, limit_param, limit, total_path }` | Offset param, limit param, records per page, optional JSONPath to total count | A zero-record page, offset reaches total (via JSONPath), or fewer records than limit |
 
-`Cursor`, `LinkHeader`, and `NextLinkInBody` include loop detection -- if the same cursor/link is returned twice in a row, pagination stops. `Offset` stops on a zero-record page (so a stalled offset cannot loop forever), and `PageNumber` stops when a page returns zero records. For all styles, `max_pages` is a hard cap.
+`Cursor`, `LinkHeader`, and `NextLinkInBody` include loop detection -- if the same cursor/link is returned twice in a row, pagination stops. `Offset` stops on a zero-record page (so a stalled offset cannot loop forever). `PageNumber` stops when a page returns zero records, and additionally detects content stagnation -- if an API clamps an out-of-range page to the last page and re-returns the identical body, pagination stops rather than looping to `max_pages`. For all styles, `max_pages` is a hard cap.
 
 ## Config Loading
 

--- a/crates/source/rest/src/pagination/mod.rs
+++ b/crates/source/rest/src/pagination/mod.rs
@@ -56,6 +56,20 @@ pub struct PaginationState {
     /// is stuck and we stop rather than looping forever.
     #[doc(hidden)]
     pub previous_token: Option<String>,
+    /// Fingerprint of the previous page's body, used by `PageNumber` loop
+    /// detection: APIs that clamp an out-of-range page to the last page and
+    /// re-return it (non-empty) would otherwise loop until `max_pages`.
+    #[doc(hidden)]
+    pub previous_page_fingerprint: Option<u64>,
+}
+
+/// Cheap, stable fingerprint of a response body for content-stagnation
+/// loop detection.
+fn body_fingerprint(body: &Value) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    body.to_string().hash(&mut h);
+    h.finish()
 }
 
 impl PaginationStyle {
@@ -158,7 +172,22 @@ impl PaginationStyle {
             }
             PaginationStyle::PageNumber { .. } => {
                 state.page += 1;
-                Ok(record_count > 0)
+                if record_count == 0 {
+                    return Ok(false);
+                }
+                // Content-stagnation guard: some APIs clamp an out-of-range
+                // page to the last page and return it again (non-empty), which
+                // would loop until `max_pages` and duplicate records. Stop if
+                // this page's body is identical to the previous one (#78/#15).
+                let fp = body_fingerprint(body);
+                if state.previous_page_fingerprint == Some(fp) {
+                    tracing::warn!(
+                        "pagination loop detected: PageNumber returned an identical page — stopping"
+                    );
+                    return Ok(false);
+                }
+                state.previous_page_fingerprint = Some(fp);
+                Ok(true)
             }
             PaginationStyle::Offset {
                 limit, total_path, ..

--- a/crates/source/rest/src/retry/backoff.rs
+++ b/crates/source/rest/src/retry/backoff.rs
@@ -4,10 +4,19 @@ use faucet_core::FaucetError;
 use std::future::Future;
 use std::time::Duration;
 
+/// Hard cap on *consecutive* `RateLimited` (HTTP 429) responses before the
+/// executor gives up. A single transient 429 with a `Retry-After` is honoured
+/// and retried (not counting against `max_retries`), but a perpetually
+/// rate-limited endpoint must not loop forever (#78/#14). The counter resets
+/// whenever any non-429 outcome occurs.
+const MAX_CONSECUTIVE_RATE_LIMITS: u32 = 10;
+
 /// Execute an async operation with exponential backoff retries and jitter.
 ///
 /// - **`RateLimited`** errors sleep for the server-specified `Retry-After`
-///   duration and do **not** consume a retry slot.
+///   duration and do **not** consume a `max_retries` slot, but are bounded by
+///   [`MAX_CONSECUTIVE_RATE_LIMITS`] consecutive occurrences so a permanently
+///   throttled endpoint surfaces the `RateLimited` error instead of hanging.
 /// - **Retriable** errors (5xx, connection/timeout) use exponential backoff
 ///   with random jitter and count toward `max_retries`.
 /// - **Non-retriable** errors (4xx except 429, parse errors, etc.) fail
@@ -22,15 +31,25 @@ where
     Fut: Future<Output = Result<T, FaucetError>>,
 {
     let mut attempt = 0u32;
+    let mut rate_limited = 0u32;
     loop {
         match operation().await {
             Ok(val) => return Ok(val),
             Err(FaucetError::RateLimited(wait)) => {
-                tracing::warn!("rate limited; retrying after {wait:?}");
+                if rate_limited >= MAX_CONSECUTIVE_RATE_LIMITS {
+                    tracing::error!("rate limited {rate_limited} consecutive times; giving up");
+                    return Err(FaucetError::RateLimited(wait));
+                }
+                rate_limited += 1;
+                tracing::warn!(
+                    "rate limited; retrying after {wait:?} ({rate_limited}/{MAX_CONSECUTIVE_RATE_LIMITS})"
+                );
                 tokio::time::sleep(wait).await;
-                // Rate-limited waits do not count as a retry attempt.
+                // Rate-limited waits do not count as a `max_retries` attempt.
             }
             Err(e) if e.is_retriable() && attempt < max_retries => {
+                // A non-429 outcome breaks the consecutive-429 streak.
+                rate_limited = 0;
                 tracing::warn!(
                     "request failed (attempt {}/{}): {e}",
                     attempt + 1,
@@ -210,5 +229,27 @@ mod tests {
         // Even with 0 retries, RateLimited should retry (doesn't consume a slot).
         assert_eq!(result.unwrap(), 42);
         assert_eq!(call_count.load(std::sync::atomic::Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn execute_with_retry_perpetual_rate_limit_is_bounded() {
+        // Regression for #78/#14: a permanently rate-limited endpoint must not
+        // loop forever. After MAX_CONSECUTIVE_RATE_LIMITS retries the executor
+        // surfaces the RateLimited error.
+        let call_count = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let cc = call_count.clone();
+
+        let result = execute_with_retry(3, Duration::from_millis(1), move || {
+            cc.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            async { Err::<i32, _>(FaucetError::RateLimited(Duration::from_millis(1))) }
+        })
+        .await;
+
+        assert!(matches!(result, Err(FaucetError::RateLimited(_))));
+        // 1 initial call + MAX_CONSECUTIVE_RATE_LIMITS retries, then it gives up.
+        assert_eq!(
+            call_count.load(std::sync::atomic::Ordering::SeqCst),
+            MAX_CONSECUTIVE_RATE_LIMITS + 1
+        );
     }
 }

--- a/crates/source/rest/src/stream.rs
+++ b/crates/source/rest/src/stream.rs
@@ -305,7 +305,7 @@ impl RestStream {
                 let records: Vec<Value> = records
                     .into_iter()
                     .map(|rec| transform::apply_all(rec, &self.compiled_transforms))
-                    .collect();
+                    .collect::<Result<Vec<Value>, _>>()?;
 
                 // Track the running max replication value across pages so the
                 // final page can carry the consolidated bookmark.

--- a/crates/source/rest/tests/pagination_test.rs
+++ b/crates/source/rest/tests/pagination_test.rs
@@ -66,6 +66,47 @@ fn page_number_increments() {
 }
 
 #[test]
+fn page_number_stops_on_repeated_identical_page() {
+    // Regression for #78/#15: an API that clamps an out-of-range page to the
+    // last page and re-returns it (non-empty) must not loop forever.
+    let style = PaginationStyle::PageNumber {
+        param_name: "page".into(),
+        start_page: 1,
+        page_size: None,
+        page_size_param: None,
+    };
+    let mut state = PaginationState::default();
+    let body = json!({"items": [{"id": 1}, {"id": 2}]});
+
+    // First page is new content → continue.
+    assert!(style.advance(&body, &no_headers(), &mut state, 2).unwrap());
+    // Identical page returned again → stagnation detected → stop.
+    assert!(!style.advance(&body, &no_headers(), &mut state, 2).unwrap());
+}
+
+#[test]
+fn page_number_continues_on_distinct_pages() {
+    let style = PaginationStyle::PageNumber {
+        param_name: "page".into(),
+        start_page: 1,
+        page_size: None,
+        page_size_param: None,
+    };
+    let mut state = PaginationState::default();
+    assert!(
+        style
+            .advance(&json!({"items": [{"id": 1}]}), &no_headers(), &mut state, 1)
+            .unwrap()
+    );
+    // Different content → keep going.
+    assert!(
+        style
+            .advance(&json!({"items": [{"id": 2}]}), &no_headers(), &mut state, 1)
+            .unwrap()
+    );
+}
+
+#[test]
 fn page_number_stops_on_empty() {
     let style = PaginationStyle::PageNumber {
         param_name: "page".into(),

--- a/crates/source/snowflake/src/stream.rs
+++ b/crates/source/snowflake/src/stream.rs
@@ -120,12 +120,11 @@ impl SnowflakeSource {
 
     /// Build the JSON body for `POST /api/v2/statements`.
     ///
-    /// Bindings are sent as 1-based positional strings under the documented
-    /// `bindings: {"1": {"type": "TEXT", "value": "..."}}` shape. Every
-    /// value is stringified and tagged `TEXT`; Snowflake casts implicitly on
-    /// the server side. Non-string values (numbers, bools) are converted
-    /// with `Value::to_string`, which renders JSON syntax — sufficient for
-    /// the typical numeric / boolean cases used in matrix interpolation.
+    /// Bindings are sent as 1-based positional values under the documented
+    /// `bindings: {"1": {"type": "TEXT", "value": "..."}}` shape. Non-null
+    /// values are stringified and tagged `TEXT` (Snowflake casts implicitly);
+    /// a JSON `null` is bound as an explicit `{"type":"TEXT","value":null}` so
+    /// it keeps its positional slot rather than shifting later parameters.
     fn build_request_body(&self, bindings: &[Value]) -> Value {
         let mut body = json!({
             "statement": self.config.query,
@@ -142,15 +141,17 @@ impl SnowflakeSource {
         if !bindings.is_empty() {
             let mut map = Map::with_capacity(bindings.len());
             for (i, v) in bindings.iter().enumerate() {
-                let stringified = match v {
-                    Value::String(s) => s.clone(),
-                    Value::Null => continue, // Snowflake binds NULL via SQL literal; skip.
-                    other => other.to_string(),
+                // Bindings are 1-based positional (`?` markers). A NULL must be
+                // bound as an explicit `{"type":"TEXT","value":null}` rather
+                // than skipped — skipping leaves a gap that shifts every later
+                // parameter onto the wrong marker and corrupts the query
+                // (#78/#18).
+                let value = match v {
+                    Value::String(s) => Value::String(s.clone()),
+                    Value::Null => Value::Null,
+                    other => Value::String(other.to_string()),
                 };
-                map.insert(
-                    (i + 1).to_string(),
-                    json!({"type": "TEXT", "value": stringified}),
-                );
+                map.insert((i + 1).to_string(), json!({"type": "TEXT", "value": value}));
             }
             body["bindings"] = Value::Object(map);
         }
@@ -575,6 +576,23 @@ mod tests {
         assert_eq!(b["1"]["value"], "alice");
         assert_eq!(b["2"]["value"], "42");
         assert_eq!(b["3"]["value"], "true");
+    }
+
+    #[test]
+    fn build_request_body_null_binding_preserves_positional_alignment() {
+        // Regression for #78/#18: a NULL must occupy its positional slot as an
+        // explicit null-valued binding, not be skipped (which would shift "42"
+        // onto marker 1 and leave marker 2 unbound).
+        let src = SnowflakeSource::new(cfg());
+        let body = src.build_request_body(&[Value::Null, json!(42)]);
+        let b = &body["bindings"];
+        assert_eq!(b["1"]["type"], "TEXT");
+        assert_eq!(
+            b["1"]["value"],
+            Value::Null,
+            "position 1 must be a NULL binding"
+        );
+        assert_eq!(b["2"]["value"], "42", "position 2 must still be 42");
     }
 
     #[test]

--- a/crates/source/xml/README.md
+++ b/crates/source/xml/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/faucet-source-xml.svg)](https://crates.io/crates/faucet-source-xml)
 [![Docs.rs](https://docs.rs/faucet-source-xml/badge.svg)](https://docs.rs/faucet-source-xml)
 
-A config-driven XML/SOAP API source with automatic XML-to-JSON conversion, dot-path record extraction, and pluggable authentication.
+A config-driven XML/SOAP API source with automatic XML-to-JSON conversion, dot-path record extraction, and pluggable authentication. Transient HTTP failures (5xx / connection resets) are retried with exponential backoff.
 
 Part of the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
 

--- a/crates/source/xml/src/stream.rs
+++ b/crates/source/xml/src/stream.rs
@@ -10,6 +10,12 @@ use reqwest::Client;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::pin::Pin;
+use std::time::Duration;
+
+/// Retries on transient (5xx / connection) failures before giving up.
+const RETRY_MAX_ATTEMPTS: u32 = 3;
+/// Base exponential-backoff delay between retries.
+const RETRY_BASE_BACKOFF: Duration = Duration::from_millis(500);
 
 /// A configured XML API source that handles pagination and extraction.
 pub struct XmlStream {
@@ -206,9 +212,21 @@ impl XmlStream {
                 .body(resolved_body);
         }
 
-        let resp = req.send().await.map_err(FaucetError::Http)?;
-        let resp = util::check_http_response(resp, DEFAULT_ERROR_BODY_MAX_LEN).await?;
-        resp.text().await.map_err(FaucetError::Http)
+        // Retry transient failures (5xx / connection resets) with jittered
+        // backoff, matching the REST source's reliability layer (#78/#16).
+        // The request body is a String, so `try_clone` always succeeds.
+        faucet_core::execute_with_retry(RETRY_MAX_ATTEMPTS, RETRY_BASE_BACKOFF, || {
+            let attempt = req.try_clone();
+            async move {
+                let req = attempt.ok_or_else(|| {
+                    FaucetError::Source("xml: request is not cloneable for retry".into())
+                })?;
+                let resp = req.send().await.map_err(FaucetError::Http)?;
+                let resp = util::check_http_response(resp, DEFAULT_ERROR_BODY_MAX_LEN).await?;
+                resp.text().await.map_err(FaucetError::Http)
+            }
+        })
+        .await
     }
 }
 

--- a/crates/source/xml/tests/streaming.rs
+++ b/crates/source/xml/tests/streaming.rs
@@ -42,6 +42,38 @@ async fn serve_xml(body: String) -> MockServer {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn retries_transient_5xx_then_succeeds() {
+    // Regression for #78/#16: the XML source previously did a single send with
+    // no retry, so any transient 5xx failed the run. Two 503s then a 200 must
+    // now succeed.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/feed.xml"))
+        .respond_with(ResponseTemplate::new(503))
+        .up_to_n_times(2)
+        .expect(2)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/feed.xml"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Content-Type", "application/xml")
+                .set_body_string(build_doc(3)),
+        )
+        .mount(&server)
+        .await;
+
+    let config = XmlStreamConfig::new(server.uri(), "/feed.xml").records_element_path("root.item");
+    let source = XmlStream::new(config);
+    let records = source
+        .fetch_all()
+        .await
+        .expect("should succeed after retries");
+    assert_eq!(records.len(), 3);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn stream_pages_chunks_records_into_batch_sized_pages() {
     let server = serve_xml(build_doc(10_000)).await;
     let config = XmlStreamConfig::new(server.uri(), "/feed.xml")


### PR DESCRIPTION
## Summary

A batch of pre-1.0 hardening fixes from the audit (**#78**), bundled into one PR per the maintainer's request. **Part of #78** — does not close it (CDC slot/TLS #12/#13, async-polling #17, SF JWT #19, gRPC #23, executor #24, GCS/S3 buffering #25, webhook #26, and the MEDIUM/LOW backlog remain). Each fix has a regression test (Docker-gated suites run in CI).

### CRITICAL
- **#9** (sink-kafka) — schema-registry sink formats were dead (`schema_text: None`). Add `value_schema`/`key_schema` config, thread into the encoder, reject SR formats without a schema at config load.
- **#10** (cli) — cross-template `${sources/sinks.X}` refs resolved against a pre-resolution snapshot with no cycle detection; chained refs got literal token text, mutual refs silently broke. Recursive resolution with DFS cycle detection (`InterpolationCycle`).
- **#27** (core) — `json_compare` compared numbers as f64 (large-int cursors lost precision) and returned `Equal` for cross-type keys, so `filter_incremental` silently dropped rows. Total, integer-exact ordering; type-mismatch keeps the row.
- **#28** (core) — `flatten`/`snake_case` last-wins on key collisions silently dropped values. Now error (`FaucetError::Transform`); empty snake_case keeps the original key. (`apply_all` now returns `Result`.)

### HIGH
- **#14** (source-rest) — unbounded 429 retry could hang forever. Cap consecutive 429s at 10.
- **#15** (source-rest) — PageNumber had no loop detection. Stop on a repeated identical page body.
- **#16** (source-xml, source-graphql) — no retry layer. Shared `faucet_core::execute_with_retry`; retry transient 5xx/connection errors.
- **#18** (source-snowflake) — `Value::Null` bind was skipped, shifting later positional params → wrong results. Bind explicit typed NULL.
- **#20** (sink-mongodb) — ordered `insert_many` let one bad doc drop the rest. Default to unordered (`ordered: bool`).
- **#21** (sink-sqlite, sink-postgres) — AutoMap exceeded the driver bind-var limit (32766 / 65535) on wide tables. Sub-chunk by `floor(MAX_VARS/num_cols)`.
- **#22** (source-redis) — opened a new client+connection per call. Cache one multiplexed connection (lazy `OnceCell`), clone per call.

## Test plan
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] Locally-run suites green: faucet-core, source-rest, cli, sink-sqlite, source-snowflake, source-xml, source-graphql, sink-kafka (schema-registry)
- [ ] Docker-gated regression tests run in CI: sink-mysql/postgres (bind-var), sink-mongodb (unordered), source-redis, plus the full `--all-features` suite

## Notes
- Adds `faucet_core::retry` (shared executor) and the `time` tokio feature to faucet-core; the REST source keeps its own retry module (extra 429/Retry-After handling).
- READMEs + CLAUDE.md updated for each behavior/config change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)