### PR TITLE
Pre-1.0 hardening: 15 LOW-tier fixes (fully closes out #78)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -436,6 +436,8 @@ Always use the **highest available stable version** for every crate, the Rust to
 
 Key workspace deps: `serde` 1, `serde_json` 1, `schemars` 1.2, `async-trait` 0.1, `thiserror` 2, `reqwest` 0.13, `tokio` 1, `tracing` 0.1, `sqlx` 0.8, `dotenvy` 0.15, `envy` 0.4.
 
+> **`sqlx` is pinned at 0.8 by `pgwire-replication =0.3.2`** (the postgres-cdc replication glue), which depends on `sqlx 0.8`. Bumping `sqlx` to 0.9 requires `pgwire-replication` to support it first (or dropping/replacing that dependency) — otherwise the CDC crate fails to resolve. Verify `pgwire-replication` compatibility before bumping `sqlx`.
+
 ## Publishing
 
 Crates publish in dependency order, topologically sorted then pushed to crates.io in **waves of 5 with a 15-minute wait between waves** (so each wave's crates have propagated through the crates.io index before the next wave depends on them). `.github/workflows/release.yml` handles this; it is **`workflow_dispatch`-triggered** (manual run with `scope` = `all` / `custom`, a version-bump input, and a `dry_run` toggle), not tag-triggered.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,11 @@ edition = "2024"
 rust-version = "1.94"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/PawanSikawat/faucet-stream"
+# Shared crates.io discovery metadata, inherited by connector/state crates via
+# `keywords.workspace = true` / `categories.workspace = true` (#78 LOW). Crates
+# that want more specific keywords (cli, umbrella) set their own.
+keywords = ["etl", "data-pipeline", "streaming", "connector", "faucet"]
+categories = ["database", "asynchronous"]
 
 [workspace.dependencies]
 # Internal crates

--- a/cli/src/env_config.rs
+++ b/cli/src/env_config.rs
@@ -68,6 +68,14 @@ pub fn extract_scope(env: &HashMap<String, String>, prefix: &str) -> CliResult<V
 /// matches YAML's auto-typing so `30` becomes a number and `true` becomes a
 /// bool — the connector's `Deserialize` impl gets exactly what it would have
 /// gotten via YAML.
+///
+/// **Caveat:** a value that *looks* like JSON is auto-typed, so the literal
+/// strings `"true"` / `"false"` / `"null"` / `"123"` / `"1.5"` become a bool /
+/// null / number, not a string. When a connector field must stay a string with
+/// one of those values (e.g. an API key that is all digits, or a literal
+/// `"null"` token), set it via the `*_JSON` variant with the value quoted —
+/// e.g. `FAUCET_SOURCE_REST_TOKEN_JSON='"0123"'` — which bypasses this
+/// coercion (#78 LOW).
 fn coerce_scalar(s: &str) -> Value {
     serde_json::from_str::<Value>(s).unwrap_or_else(|_| Value::String(s.to_owned()))
 }

--- a/cli/src/executor.rs
+++ b/cli/src/executor.rs
@@ -80,12 +80,21 @@ impl RunSummary {
     }
 }
 
-/// Default concurrency when neither config nor flag specify one.
+/// Default number of matrix invocations to run in parallel when neither the
+/// config's `execution.max_concurrent` nor a flag specifies one.
+///
+/// Scales with the core count but is capped at 8. The cap is deliberate: each
+/// invocation is a *full pipeline* with its own connection pools / HTTP
+/// clients, and matrix rows often target the same external system (one API,
+/// one database), so an unbounded fan-out across, say, a 64-core box would
+/// blow through that system's connection or rate limits rather than going
+/// faster. Workloads that genuinely benefit from more parallelism set
+/// `execution.max_concurrent` explicitly to opt out of the cap (#78 LOW).
 fn default_concurrency() -> usize {
     std::thread::available_parallelism()
         .map(|n| n.get())
         .unwrap_or(4)
-        .clamp(1, 4)
+        .clamp(1, 8)
 }
 
 /// Execute every node in `nodes`. `nodes` must be in BFS order (roots first

--- a/crates/bigquery-common/Cargo.toml
+++ b/crates/bigquery-common/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Shared credentials and client construction for the faucet-stream BigQuery source and sink connectors"
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 faucet-core.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Shared types, traits, and utilities for the faucet-stream ecosystem"
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
 
 [features]
 default = ["transform-flatten", "transform-rename-keys", "transform-snake-case"]

--- a/crates/core/src/state.rs
+++ b/crates/core/src/state.rs
@@ -109,8 +109,19 @@ impl StateStore for MemoryStateStore {
 
 // ── FileStateStore ──────────────────────────────────────────────────────────
 
+/// Map a logical state key to a filesystem-safe filename stem. The key
+/// grammar allows `:` (used by the documented `pipeline:rest:issues`
+/// convention), but `:` is illegal in a filename on Windows/NTFS, so it is
+/// percent-encoded as `%3A`. This is collision-free because `%` can never
+/// appear in a valid key (see [`validate_state_key`]) (#78 LOW).
+fn safe_filename(key: &str) -> String {
+    key.replace(':', "%3A")
+}
+
 /// File-backed `StateStore`. Each key maps to a JSON file at
-/// `{root}/{key}.json`, written via atomic rename.
+/// `{root}/{safe_filename(key)}.json`, written via atomic rename. The
+/// filename stem percent-encodes `:` as `%3A` so keys using the
+/// `pipeline:rest:issues` convention are valid on Windows.
 ///
 /// Each `put` writes a temp file, fsyncs it, renames it over the final path,
 /// and (on Unix) fsyncs the parent directory — so once `put` returns the
@@ -136,11 +147,11 @@ impl FileStateStore {
     }
 
     fn entry_path(&self, key: &str) -> PathBuf {
-        self.root.join(format!("{key}.json"))
+        self.root.join(format!("{}.json", safe_filename(key)))
     }
 
     fn temp_path(&self, key: &str) -> PathBuf {
-        self.root.join(format!("{key}.json.tmp"))
+        self.root.join(format!("{}.json.tmp", safe_filename(key)))
     }
 
     async fn ensure_root(&self) -> Result<(), FaucetError> {
@@ -388,6 +399,36 @@ mod tests {
         s.put("github_issues", &value).await.unwrap();
         let got = s.get("github_issues").await.unwrap().unwrap();
         assert_eq!(got, value);
+    }
+
+    #[test]
+    fn safe_filename_percent_encodes_colon() {
+        assert_eq!(
+            safe_filename("pipeline:rest:issues"),
+            "pipeline%3Arest%3Aissues"
+        );
+        assert_eq!(safe_filename("plain_key-1.v2"), "plain_key-1.v2");
+    }
+
+    #[tokio::test]
+    async fn file_round_trips_colon_keys_with_safe_filename() {
+        // Regression for #78 LOW: the documented `pipeline:rest:issues` key
+        // convention must round-trip and produce a Windows-legal filename
+        // (no `:` on disk).
+        let dir = TempDir::new().unwrap();
+        let s = FileStateStore::new(dir.path());
+        let value = json!({"cursor": "z"});
+        s.put("pipeline:rest:issues", &value).await.unwrap();
+        assert_eq!(s.get("pipeline:rest:issues").await.unwrap().unwrap(), value);
+        // On-disk filename must not contain a colon.
+        assert!(dir.path().join("pipeline%3Arest%3Aissues.json").exists());
+        let mut has_colon = false;
+        for entry in std::fs::read_dir(dir.path()).unwrap() {
+            if entry.unwrap().file_name().to_string_lossy().contains(':') {
+                has_colon = true;
+            }
+        }
+        assert!(!has_colon, "no state filename may contain ':'");
     }
 
     #[tokio::test]

--- a/crates/elasticsearch-common/Cargo.toml
+++ b/crates/elasticsearch-common/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Shared configuration types for the faucet-stream Elasticsearch source and sink connectors"
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 serde = { workspace = true, features = ["derive"] }

--- a/crates/gcs-common/Cargo.toml
+++ b/crates/gcs-common/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Shared GCS credential and client types for the faucet-stream ecosystem"
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 faucet-core.workspace = true

--- a/crates/kafka-common/Cargo.toml
+++ b/crates/kafka-common/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Shared configuration types for the faucet-stream Kafka source and sink connectors"
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 faucet-core.workspace = true

--- a/crates/sink/bigquery/Cargo.toml
+++ b/crates/sink/bigquery/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "BigQuery sink connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 faucet-core.workspace = true

--- a/crates/sink/csv/Cargo.toml
+++ b/crates/sink/csv/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "CSV file sink connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 faucet-core.workspace = true

--- a/crates/sink/elasticsearch/Cargo.toml
+++ b/crates/sink/elasticsearch/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Elasticsearch sink connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 faucet-core.workspace = true

--- a/crates/sink/gcs/Cargo.toml
+++ b/crates/sink/gcs/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Google Cloud Storage sink connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 faucet-core.workspace = true

--- a/crates/sink/http/Cargo.toml
+++ b/crates/sink/http/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "HTTP POST sink connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 faucet-core.workspace = true

--- a/crates/sink/jsonl/Cargo.toml
+++ b/crates/sink/jsonl/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "JSON Lines file sink connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 faucet-core.workspace = true

--- a/crates/sink/kafka/Cargo.toml
+++ b/crates/sink/kafka/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Apache Kafka producer sink for the faucet-stream ecosystem"
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 faucet-core.workspace = true

--- a/crates/sink/mongodb/Cargo.toml
+++ b/crates/sink/mongodb/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "MongoDB sink connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 faucet-core.workspace = true

--- a/crates/sink/mysql/Cargo.toml
+++ b/crates/sink/mysql/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "MySQL sink connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 faucet-core.workspace = true

--- a/crates/sink/parquet/Cargo.toml
+++ b/crates/sink/parquet/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Apache Parquet file sink connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 faucet-core.workspace = true

--- a/crates/sink/parquet/README.md
+++ b/crates/sink/parquet/README.md
@@ -95,6 +95,19 @@ slightly exceed the limit by one batch worth of data.
 
 Setting neither produces a single file per sink instance (until `flush()`).
 
+> **`max_bytes_per_file` is approximate.** The threshold compares against an
+> estimate of the *in-memory Arrow* size of what's been written, not the
+> on-disk Parquet size. Column encoding + compression (see [Compression](#compression))
+> usually make the actual file substantially smaller, and rollover happens at
+> batch granularity. Treat it as a soft target, not a hard byte cap.
+
+> **A fixed `*.parquet` local path + a rollover threshold can't coexist.**
+> Single-file mode (a `foo.parquet` destination) requires *no* rollover
+> thresholds. If you set `max_rows_per_file` / `max_bytes_per_file` alongside
+> a fixed `.parquet` path, the sink logs a warning and falls back to writing
+> UUID-named files into the parent directory (the fixed filename is ignored).
+> Use a directory destination when you want rollover.
+
 ## Streaming and batching
 
 The sink accepts whatever the upstream pipeline hands it — the streaming

--- a/crates/sink/parquet/src/sink.rs
+++ b/crates/sink/parquet/src/sink.rs
@@ -65,6 +65,24 @@ impl ParquetSink {
             .validate()
             .map_err(|e| FaucetError::Config(format!("invalid parquet sink config: {e}")))?;
 
+        // A fixed `foo.parquet` local path combined with a rollover threshold
+        // is contradictory: rollover needs multiple files, so the sink falls
+        // back to UUID-named files in the *parent* directory and the fixed
+        // filename is silently ignored. Warn so the surprise is visible
+        // (#78 LOW).
+        if let ParquetDestination::LocalPath { path } = &config.destination
+            && FsPath::new(path).extension().and_then(|s| s.to_str()) == Some("parquet")
+            && (config.max_rows_per_file.is_some() || config.max_bytes_per_file.is_some())
+        {
+            tracing::warn!(
+                path = %path,
+                "parquet sink: a fixed '.parquet' path with max_rows_per_file / \
+                 max_bytes_per_file set cannot be honoured — rollover writes UUID-named \
+                 files into the parent directory and the fixed filename is ignored. Use a \
+                 directory destination, or drop the rollover thresholds for a single file."
+            );
+        }
+
         let (store, local_root) = build_store(&config.destination).await?;
 
         Ok(Self {
@@ -298,6 +316,14 @@ impl faucet_core::Sink for ParquetSink {
     }
 }
 
+/// Decide whether to start a new file before the current chunk.
+///
+/// **`max_bytes_per_file` is approximate.** `bytes_written` is an estimate of
+/// the *in-memory Arrow* size, checked after a chunk is appended; the actual
+/// on-disk Parquet file is typically much smaller (and varies) once column
+/// encoding + compression (`compression = Zstd/Snappy/…`) are applied, and
+/// rollover happens at chunk granularity rather than mid-chunk. Treat the
+/// threshold as a soft target, not a hard byte cap (#78 LOW).
 fn should_rollover(cfg: &ParquetSinkConfig, state: &WriterState, bytes_written: usize) -> bool {
     if let Some(max_rows) = cfg.max_rows_per_file
         && state.rows_in_current_file >= max_rows

--- a/crates/sink/postgres/Cargo.toml
+++ b/crates/sink/postgres/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "PostgreSQL sink connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 faucet-core.workspace = true

--- a/crates/sink/redis/Cargo.toml
+++ b/crates/sink/redis/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Redis sink connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 faucet-core.workspace = true

--- a/crates/sink/s3/Cargo.toml
+++ b/crates/sink/s3/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "AWS S3 sink connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 faucet-core.workspace = true

--- a/crates/sink/snowflake/Cargo.toml
+++ b/crates/sink/snowflake/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Snowflake sink connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 faucet-core.workspace = true

--- a/crates/sink/sqlite/Cargo.toml
+++ b/crates/sink/sqlite/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "SQLite sink connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 faucet-core.workspace = true

--- a/crates/sink/stdout/Cargo.toml
+++ b/crates/sink/stdout/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Stdout/stderr sink connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 faucet-core.workspace = true

--- a/crates/snowflake-common/Cargo.toml
+++ b/crates/snowflake-common/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Shared configuration types for the faucet-stream Snowflake source and sink connectors"
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 faucet-core.workspace = true

--- a/crates/source/bigquery/Cargo.toml
+++ b/crates/source/bigquery/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "BigQuery query source connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 faucet-core.workspace = true

--- a/crates/source/csv/Cargo.toml
+++ b/crates/source/csv/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "CSV file source connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
 
 [features]
 compression = ["faucet-core/compression"]

--- a/crates/source/elasticsearch/Cargo.toml
+++ b/crates/source/elasticsearch/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Elasticsearch source connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 faucet-core.workspace = true

--- a/crates/source/gcs/Cargo.toml
+++ b/crates/source/gcs/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Google Cloud Storage source connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 faucet-core.workspace = true

--- a/crates/source/gcs/src/stream.rs
+++ b/crates/source/gcs/src/stream.rs
@@ -303,13 +303,10 @@ impl faucet_core::Source for GcsSource {
                         })?;
                         let array = match value {
                             Value::Array(arr) => arr,
-                            other => {
-                                Err(FaucetError::Source(format!(
-                                    "GCS expected JSON array in '{key}', got {}",
-                                    value_type_name(&other)
-                                )))?;
-                                unreachable!()
-                            }
+                            other => Err(FaucetError::Source(format!(
+                                "GCS expected JSON array in '{key}', got {}",
+                                value_type_name(&other)
+                            )))?,
                         };
                         if batch_size == 0 {
                             if !buffer.is_empty() {

--- a/crates/source/graphql/Cargo.toml
+++ b/crates/source/graphql/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "GraphQL API source connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 faucet-core.workspace = true

--- a/crates/source/graphql/src/stream.rs
+++ b/crates/source/graphql/src/stream.rs
@@ -44,7 +44,6 @@ impl GraphqlStream {
         let mut all_records = Vec::new();
         let mut cursor: Option<String> = None;
         let mut pages_fetched = 0usize;
-        let mut prev_cursor: Option<String> = None;
 
         loop {
             if let Some(max) = self.config.max_pages
@@ -70,12 +69,15 @@ impl GraphqlStream {
                     if next_cursor.is_none() {
                         break;
                     }
-                    // Loop detection: stop if cursor hasn't changed.
-                    if next_cursor == prev_cursor {
+                    // Loop detection: if the server returns the same cursor we
+                    // just used, advancing would re-fetch the identical page —
+                    // stop now (compare against the just-used cursor, not a
+                    // lagged one, so no extra duplicate page is fetched first;
+                    // #78 LOW).
+                    if next_cursor == cursor {
                         tracing::warn!("cursor loop detected, stopping pagination");
                         break;
                     }
-                    prev_cursor = cursor;
                     cursor = next_cursor;
                 }
                 None => break,
@@ -256,7 +258,6 @@ impl GraphqlStream {
 
         Box::pin(async_stream::try_stream! {
             let mut cursor: Option<String> = None;
-            let mut prev_cursor: Option<String> = None;
             let mut pages_fetched = 0usize;
             // No incremental replication today — `running_max` stays `None`.
             // The structure mirrors the REST source so a future replication
@@ -287,12 +288,16 @@ impl GraphqlStream {
                             match next_cursor {
                                 None => false,
                                 Some(next_cursor) => {
-                                    // Loop detection: stop if cursor hasn't changed.
-                                    if Some(&next_cursor) == prev_cursor.as_ref() {
+                                    // Loop detection: if the server returns the
+                                    // same cursor we just used, advancing would
+                                    // re-fetch the identical page — stop now
+                                    // (comparing against the just-used cursor,
+                                    // not a lagged one, so we don't fetch an
+                                    // extra duplicate page first; #78 LOW).
+                                    if Some(&next_cursor) == cursor.as_ref() {
                                         tracing::warn!("cursor loop detected, stopping pagination");
                                         false
                                     } else {
-                                        prev_cursor = cursor.clone();
                                         cursor = Some(next_cursor);
                                         true
                                     }

--- a/crates/source/graphql/tests/streaming.rs
+++ b/crates/source/graphql/tests/streaming.rs
@@ -439,3 +439,33 @@ async fn stream_pages_default_batch_size_drives_first_variable() {
     assert_eq!(page.records.len(), 1);
     assert!(pages.next().await.is_none(), "single-page response ends");
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn stuck_cursor_stops_without_extra_duplicate_page() {
+    // Regression for #78 LOW: a server that keeps returning the same cursor
+    // with hasNextPage=true must be detected as a loop after exactly two
+    // requests (initial + the one that re-returns the same cursor), not three.
+    // The off-by-one previously fetched one extra duplicate page first.
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let server = MockServer::start().await;
+    let hits = Arc::new(AtomicUsize::new(0));
+    let hits_resp = hits.clone();
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .respond_with(move |_req: &Request| {
+            hits_resp.fetch_add(1, Ordering::SeqCst);
+            // Always claim there's a next page, always the same cursor.
+            ResponseTemplate::new(200).set_body_json(make_page(0, 1, Some("stuck")))
+        })
+        .mount(&server)
+        .await;
+
+    let source = GraphqlStream::new(relay_config(&server, 10));
+    let records = source.fetch_all().await.unwrap();
+
+    // Two requests: page 1 (cursor None→"stuck"), page 2 ("stuck"→"stuck" =
+    // loop). Each returns one record → 2 records, not an infinite/extra run.
+    assert_eq!(hits.load(Ordering::SeqCst), 2, "must stop after 2 requests");
+    assert_eq!(records.len(), 2);
+}

--- a/crates/source/grpc/Cargo.toml
+++ b/crates/source/grpc/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "gRPC API source connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 faucet-core.workspace = true

--- a/crates/source/grpc/src/stream.rs
+++ b/crates/source/grpc/src/stream.rs
@@ -608,8 +608,13 @@ impl GrpcStream {
                     Err(StreamOutcome::Transient { consumed, error }) => {
                         messages_seen += consumed;
                         if terminate_on_error {
+                            // `?` yields the error and ends the stream; the
+                            // trailing `return` both makes that explicit and
+                            // lets the borrow checker see this branch diverges
+                            // (so `error` is still available below). Replaces a
+                            // fragile `unreachable!()` (#78 LOW).
                             Err(error)?;
-                            unreachable!();
+                            return;
                         }
                         if let Some(max_attempts) = reconnect_max_attempts
                             && attempt >= max_attempts
@@ -618,7 +623,7 @@ impl GrpcStream {
                                 "gRPC server-streaming exceeded reconnect_max_attempts={max_attempts}: {error}"
                             ));
                             Err(final_err)?;
-                            unreachable!();
+                            return;
                         }
                         attempt += 1;
                         tracing::warn!(

--- a/crates/source/kafka/Cargo.toml
+++ b/crates/source/kafka/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Apache Kafka consumer source for the faucet-stream ecosystem"
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 faucet-core.workspace = true

--- a/crates/source/mongodb/Cargo.toml
+++ b/crates/source/mongodb/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "MongoDB source connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 faucet-core.workspace = true

--- a/crates/source/mysql/Cargo.toml
+++ b/crates/source/mysql/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "MySQL query source connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 faucet-core.workspace = true

--- a/crates/source/parquet/Cargo.toml
+++ b/crates/source/parquet/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Apache Parquet file source connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 faucet-core.workspace = true

--- a/crates/source/postgres-cdc/Cargo.toml
+++ b/crates/source/postgres-cdc/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "PostgreSQL logical replication (CDC) source for the faucet-stream ecosystem"
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 faucet-core.workspace = true

--- a/crates/source/postgres-cdc/src/stream.rs
+++ b/crates/source/postgres-cdc/src/stream.rs
@@ -478,6 +478,12 @@ fn handle_event(
             // record; advancing only to commit_lsn leaves the commit record
             // unconfirmed and Postgres redelivers the whole transaction
             // (#78/#1). `end_lsn` is the position a standby reports as flushed.
+            //
+            // The exactly-once-across-resume boundary (a transaction whose
+            // commit lands exactly at the persisted bookmark is delivered once,
+            // not skipped or duplicated) is exercised by the Docker integration
+            // tests `resume_from_bookmark_skips_already_consumed` and
+            // `lsn_not_advanced_without_durable_bookmark_redelivers` (#78 LOW).
             out.append(&mut state.staged);
             state.last_committed = Some(end_lsn.as_u64());
             state.in_txn = false;

--- a/crates/source/postgres/Cargo.toml
+++ b/crates/source/postgres/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "PostgreSQL query source connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 faucet-core.workspace = true

--- a/crates/source/redis/Cargo.toml
+++ b/crates/source/redis/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Redis source connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 faucet-core.workspace = true

--- a/crates/source/redis/src/stream.rs
+++ b/crates/source/redis/src/stream.rs
@@ -359,6 +359,13 @@ impl faucet_core::Source for RedisSource {
 /// Stream a Redis list via `LRANGE start stop`, sliding the window by
 /// `batch_size`. With `batch_size == 0`, drains the list in a single
 /// `LRANGE 0 -1` round-trip.
+///
+/// **Consistency caveat (#78 LOW):** index-based `LRANGE` paging is only
+/// stable if the list is not mutated mid-scan. A concurrent `LPUSH` / `LPOP`
+/// shifts every element's index, so a writer pushing/popping while this drains
+/// can make the source skip or duplicate elements across page boundaries. For
+/// a queue-style workload where the list is being consumed concurrently,
+/// prefer a Redis Stream (`XRANGE`/consumer groups) over a list.
 fn stream_list<'a>(
     conn: &'a mut redis::aio::MultiplexedConnection,
     key: &'a str,
@@ -501,74 +508,71 @@ fn stream_keys<'a>(
 ) -> impl Stream<Item = Result<StreamPage, FaucetError>> + 'a {
     use faucet_core::DEFAULT_BATCH_SIZE;
     async_stream::try_stream! {
-        // SCAN COUNT is a per-round-trip hint to the server, not a per-page
-        // record cap. Use batch_size as the hint when non-zero; default
-        // otherwise. SCAN may return more or fewer keys per call than COUNT,
-        // so we buffer client-side until batch_size keys are accumulated
-        // before issuing MGET.
+        // Drive the SCAN cursor manually (one `SCAN cursor MATCH .. COUNT ..`
+        // round-trip at a time) rather than via the buffering `AsyncIter`, so
+        // we can MGET + yield a page as soon as `batch_size` keys accumulate
+        // instead of materialising the entire matched keyset first (#78 LOW).
+        // SCAN COUNT is only a per-round-trip hint; a call may return more or
+        // fewer keys than the hint, so we still buffer until a full page.
         let scan_hint = if batch_size == 0 { DEFAULT_BATCH_SIZE } else { batch_size };
-        let opts = redis::ScanOptions::default()
-            .with_pattern(pattern)
-            .with_count(scan_hint);
+        // `batch_size == 0` is the "no batching" sentinel — accumulate the
+        // whole scan and emit one page (still one MGET).
+        let chunk_size = if batch_size == 0 { usize::MAX } else { batch_size };
+        let cap = max_records.unwrap_or(usize::MAX);
 
-        // We need to MGET in a separate scope so the iterator (which holds
-        // &mut conn) is dropped before we re-borrow conn for MGET.
-        let all_keys: Vec<String> = {
-            let mut iter: redis::AsyncIter<String> = conn
-                .scan_options(opts)
+        let mut cursor: u64 = 0;
+        let mut buffer: Vec<String> = Vec::new();
+        let mut emitted: usize = 0;
+
+        'scan: loop {
+            let (next_cursor, keys): (u64, Vec<String>) = redis::cmd("SCAN")
+                .arg(cursor)
+                .arg("MATCH")
+                .arg(pattern)
+                .arg("COUNT")
+                .arg(scan_hint)
+                .query_async(conn)
                 .await
                 .map_err(|e| FaucetError::Config(format!("SCAN failed with pattern '{pattern}': {e}")))?;
-            let mut collected = Vec::new();
-            while let Some(key) = iter.next_item().await {
-                collected.push(key);
-                if batch_size != 0
-                    && let Some(max) = max_records
-                    && collected.len() >= max
-                {
-                    break;
-                }
-            }
-            collected
-        };
+            cursor = next_cursor;
+            buffer.extend(keys);
 
-        if all_keys.is_empty() {
-            return;
+            // Flush as many full pages as the buffer now holds.
+            while emitted < cap && buffer.len() >= chunk_size {
+                let take = chunk_size.min(cap - emitted);
+                let page_keys: Vec<String> = buffer.drain(..take).collect();
+                let records = mget_records(conn, &page_keys).await?;
+                emitted += records.len();
+                yield StreamPage { records, bookmark: None };
+            }
+
+            if cursor == 0 || emitted >= cap {
+                break 'scan;
+            }
         }
 
-        if batch_size == 0 {
-            // Drain in one MGET.
-            let mut keys = all_keys;
-            if let Some(max) = max_records {
-                keys.truncate(max);
-            }
-            let values: Vec<Option<String>> = redis::cmd("MGET")
-                .arg(&keys)
-                .query_async(conn)
-                .await
-                .map_err(|e| FaucetError::Config(format!("MGET failed: {e}")))?;
-            let records = collect_kv_records(&keys, values);
-            yield StreamPage { records, bookmark: None };
-            return;
-        }
-
-        let mut emitted: usize = 0;
-        let cap = max_records.unwrap_or(usize::MAX);
-        for chunk in all_keys.chunks(batch_size) {
-            if emitted >= cap {
-                break;
-            }
-            let take = (cap - emitted).min(chunk.len());
-            let chunk = &chunk[..take];
-            let values: Vec<Option<String>> = redis::cmd("MGET")
-                .arg(chunk)
-                .query_async(conn)
-                .await
-                .map_err(|e| FaucetError::Config(format!("MGET failed: {e}")))?;
-            let records = collect_kv_records(chunk, values);
-            emitted += records.len();
+        // Trailing partial page (and the single page in the batch_size==0 case).
+        if emitted < cap && !buffer.is_empty() {
+            let take = (cap - emitted).min(buffer.len());
+            let page_keys: Vec<String> = buffer.drain(..take).collect();
+            let records = mget_records(conn, &page_keys).await?;
             yield StreamPage { records, bookmark: None };
         }
     }
+}
+
+/// `MGET` a slice of keys and pair them with their values via
+/// [`collect_kv_records`].
+async fn mget_records(
+    conn: &mut redis::aio::MultiplexedConnection,
+    keys: &[String],
+) -> Result<Vec<Value>, FaucetError> {
+    let values: Vec<Option<String>> = redis::cmd("MGET")
+        .arg(keys)
+        .query_async(conn)
+        .await
+        .map_err(|e| FaucetError::Config(format!("MGET failed: {e}")))?;
+    Ok(collect_kv_records(keys, values))
 }
 
 /// Pair `keys` with their `MGET`-returned values into `{ "key", "value" }`

--- a/crates/source/rest/Cargo.toml
+++ b/crates/source/rest/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "REST API source connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
 
 [features]
 default = ["transform-flatten", "transform-rename-keys", "transform-snake-case"]

--- a/crates/source/rest/src/auth/basic.rs
+++ b/crates/source/rest/src/auth/basic.rs
@@ -7,8 +7,11 @@ use reqwest::header::{HeaderMap, HeaderValue};
 pub fn apply(headers: &mut HeaderMap, username: &str, password: &str) -> Result<(), FaucetError> {
     let encoded =
         base64::engine::general_purpose::STANDARD.encode(format!("{username}:{password}"));
-    let val = HeaderValue::from_str(&format!("Basic {encoded}"))
+    let mut val = HeaderValue::from_str(&format!("Basic {encoded}"))
         .map_err(|e| FaucetError::Auth(format!("invalid basic auth value: {e}")))?;
+    // Mark the credential sensitive so reqwest/hyper redact it from trace/debug
+    // logging (#78 LOW).
+    val.set_sensitive(true);
     headers.insert("Authorization", val);
     Ok(())
 }

--- a/crates/source/rest/src/auth/bearer.rs
+++ b/crates/source/rest/src/auth/bearer.rs
@@ -4,8 +4,11 @@ use faucet_core::FaucetError;
 use reqwest::header::{HeaderMap, HeaderValue};
 
 pub fn apply(headers: &mut HeaderMap, token: &str) -> Result<(), FaucetError> {
-    let val = HeaderValue::from_str(&format!("Bearer {token}"))
+    let mut val = HeaderValue::from_str(&format!("Bearer {token}"))
         .map_err(|e| FaucetError::Auth(format!("invalid bearer token value: {e}")))?;
+    // Mark the token sensitive so reqwest/hyper redact it from trace/debug
+    // logging (#78 LOW).
+    val.set_sensitive(true);
     headers.insert("Authorization", val);
     Ok(())
 }

--- a/crates/source/rest/src/pagination/cursor.rs
+++ b/crates/source/rest/src/pagination/cursor.rs
@@ -24,18 +24,75 @@ pub fn advance(
         .query(next_token_path)
         .map_err(|e| FaucetError::JsonPath(format!("{e}")))?;
     match results.first() {
-        Some(v) => {
-            if v.is_null() || (v.is_string() && v.as_str().unwrap().is_empty()) {
+        // Null or empty string → last page.
+        Some(Value::Null) => {
+            *next_token = None;
+            Ok(false)
+        }
+        Some(Value::String(s)) => {
+            if s.is_empty() {
                 *next_token = None;
                 Ok(false)
             } else {
-                *next_token = Some(v.as_str().unwrap_or(&v.to_string()).to_string());
+                *next_token = Some(s.clone());
                 Ok(true)
             }
         }
+        // Numbers and booleans are scalar cursors — send their text form.
+        Some(v @ (Value::Number(_) | Value::Bool(_))) => {
+            *next_token = Some(v.to_string());
+            Ok(true)
+        }
+        // An array/object cursor would be serialized to JSON and sent as a
+        // query param, which is never what the API expects — almost always a
+        // misconfigured `next_token_path`. Fail loudly instead (#78 LOW).
+        Some(v @ (Value::Array(_) | Value::Object(_))) => Err(FaucetError::JsonPath(format!(
+            "cursor path '{next_token_path}' resolved to a non-scalar value ({}); a pagination \
+             cursor must be a string, number, or boolean",
+            if v.is_array() { "array" } else { "object" }
+        ))),
         None => {
             *next_token = None;
             Ok(false)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn string_cursor_advances() {
+        let body = json!({"next": "abc"});
+        let mut tok = None;
+        assert!(advance(&body, "$.next", &mut tok).unwrap());
+        assert_eq!(tok, Some("abc".into()));
+    }
+
+    #[test]
+    fn numeric_cursor_advances_as_string() {
+        let body = json!({"next": 42});
+        let mut tok = None;
+        assert!(advance(&body, "$.next", &mut tok).unwrap());
+        assert_eq!(tok, Some("42".into()));
+    }
+
+    #[test]
+    fn null_and_empty_stop() {
+        let mut tok = Some("stale".into());
+        assert!(!advance(&json!({"next": null}), "$.next", &mut tok).unwrap());
+        assert!(tok.is_none());
+        let mut tok2 = Some("stale".into());
+        assert!(!advance(&json!({"next": ""}), "$.next", &mut tok2).unwrap());
+        assert!(tok2.is_none());
+    }
+
+    #[test]
+    fn non_scalar_cursor_errors() {
+        let mut tok = None;
+        assert!(advance(&json!({"next": [1, 2]}), "$.next", &mut tok).is_err());
+        assert!(advance(&json!({"next": {"a": 1}}), "$.next", &mut tok).is_err());
     }
 }

--- a/crates/source/rest/src/pagination/link_header.rs
+++ b/crates/source/rest/src/pagination/link_header.rs
@@ -2,18 +2,71 @@
 
 use reqwest::header::HeaderMap;
 
-/// Extract the rel="next" URL from a Link header.
+/// Extract the `rel="next"` URL from a `Link` header (RFC 8288).
+///
+/// Parses each link-value into its `<URI-Reference>` and parameters, splitting
+/// on commas only *outside* the angle brackets (so a comma inside a URL does
+/// not split a link), and matches the `rel` parameter case-insensitively
+/// whether it is quoted (`rel="next"`) or unquoted (`rel=next`) and even when
+/// it carries multiple space-separated relations (`rel="prev next"`) (#78 LOW).
 pub fn extract_next_link(headers: &HeaderMap) -> Option<String> {
     let link = headers.get("link")?.to_str().ok()?;
-    for part in link.split(',') {
-        let part = part.trim();
-        if part.contains("rel=\"next\"") {
-            let start = part.find('<')? + 1;
-            let end = part.find('>')?;
-            return Some(part[start..end].to_string());
+    for (uri, rel) in parse_link_header(link) {
+        if rel
+            .split_whitespace()
+            .any(|tok| tok.eq_ignore_ascii_case("next"))
+        {
+            return Some(uri);
         }
     }
     None
+}
+
+/// Split a `Link` header into `(uri, rel)` pairs. Splits link-values on commas
+/// that are not inside an angle-bracketed URI, then extracts the `<...>` URI
+/// and the value of any `rel=` parameter (quoted or unquoted).
+fn parse_link_header(header: &str) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    let mut depth = 0i32; // inside <...>
+    let mut start = 0usize;
+    let bytes = header.as_bytes();
+    let mut segments: Vec<&str> = Vec::new();
+    for (i, &b) in bytes.iter().enumerate() {
+        match b {
+            b'<' => depth += 1,
+            b'>' => depth -= 1,
+            b',' if depth <= 0 => {
+                segments.push(&header[start..i]);
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    segments.push(&header[start..]);
+
+    for seg in segments {
+        let seg = seg.trim();
+        let Some(lt) = seg.find('<') else { continue };
+        let Some(gt) = seg[lt + 1..].find('>') else {
+            continue;
+        };
+        let uri = seg[lt + 1..lt + 1 + gt].trim().to_string();
+        // Parameters follow the `>`; find `rel=...`.
+        let params = &seg[lt + 1 + gt + 1..];
+        let mut rel = String::new();
+        for param in params.split(';') {
+            let param = param.trim();
+            if let Some(v) = param
+                .strip_prefix("rel=")
+                .or_else(|| param.strip_prefix("rel ="))
+            {
+                rel = v.trim().trim_matches('"').to_string();
+                break;
+            }
+        }
+        out.push((uri, rel));
+    }
+    out
 }
 
 #[cfg(test)]
@@ -50,5 +103,60 @@ mod tests {
     fn test_empty_headers() {
         let headers = HeaderMap::new();
         assert_eq!(extract_next_link(&headers), None);
+    }
+
+    #[test]
+    fn unquoted_rel_is_supported() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "link",
+            HeaderValue::from_static("<https://api.example.com/items?page=2>; rel=next"),
+        );
+        assert_eq!(
+            extract_next_link(&headers),
+            Some("https://api.example.com/items?page=2".to_string())
+        );
+    }
+
+    #[test]
+    fn multi_relation_rel_token_matches_next() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "link",
+            HeaderValue::from_static(r#"<https://api.example.com/p3>; rel="prev next""#),
+        );
+        assert_eq!(
+            extract_next_link(&headers),
+            Some("https://api.example.com/p3".to_string())
+        );
+    }
+
+    #[test]
+    fn comma_inside_url_does_not_split_link() {
+        // A query string containing a comma must not break link-value splitting.
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "link",
+            HeaderValue::from_static(
+                r#"<https://api.example.com/items?ids=1,2,3&page=2>; rel="next""#,
+            ),
+        );
+        assert_eq!(
+            extract_next_link(&headers),
+            Some("https://api.example.com/items?ids=1,2,3&page=2".to_string())
+        );
+    }
+
+    #[test]
+    fn rel_next_is_case_insensitive() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "link",
+            HeaderValue::from_static(r#"<https://api.example.com/x>; rel="NEXT""#),
+        );
+        assert_eq!(
+            extract_next_link(&headers),
+            Some("https://api.example.com/x".to_string())
+        );
     }
 }

--- a/crates/source/rest/src/pagination/next_link_body.rs
+++ b/crates/source/rest/src/pagination/next_link_body.rs
@@ -23,20 +23,27 @@ pub fn advance(
         .query(next_link_path)
         .map_err(|e| FaucetError::JsonPath(format!("{e}")))?;
     match results.first() {
-        Some(v) if !v.is_null() => {
-            let url = v.as_str().unwrap_or(&v.to_string()).to_string();
-            if url.is_empty() {
-                *next_link = None;
-                Ok(false)
-            } else {
-                *next_link = Some(url);
-                Ok(true)
-            }
-        }
-        _ => {
+        // Absent or null → last page.
+        None | Some(Value::Null) => {
             *next_link = None;
             Ok(false)
         }
+        Some(Value::String(s)) => {
+            if s.is_empty() {
+                *next_link = None;
+                Ok(false)
+            } else {
+                *next_link = Some(s.clone());
+                Ok(true)
+            }
+        }
+        // A next-page link must be a URL string; a number/bool/array/object at
+        // the path means a misconfigured `next_link_path`. Fail loudly rather
+        // than send a stringified JSON value as the next request URL (#78 LOW).
+        Some(_) => Err(FaucetError::JsonPath(format!(
+            "next-link path '{next_link_path}' resolved to a non-string value; the \
+             next-page link must be a URL string"
+        ))),
     }
 }
 
@@ -82,5 +89,21 @@ mod tests {
         let has_next = advance(&body, "$.next_link", &mut next_link).unwrap();
         assert!(!has_next);
         assert!(next_link.is_none());
+    }
+
+    #[test]
+    fn non_string_next_link_errors() {
+        // A numeric / object next_link is a misconfiguration — must error, not
+        // stringify and send as the next URL (#78 LOW).
+        let mut next_link = None;
+        assert!(advance(&json!({"next_link": 5}), "$.next_link", &mut next_link).is_err());
+        assert!(
+            advance(
+                &json!({"next_link": {"u": "x"}}),
+                "$.next_link",
+                &mut next_link
+            )
+            .is_err()
+        );
     }
 }

--- a/crates/source/s3/Cargo.toml
+++ b/crates/source/s3/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "AWS S3 source connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 faucet-core.workspace = true

--- a/crates/source/s3/src/stream.rs
+++ b/crates/source/s3/src/stream.rs
@@ -371,13 +371,10 @@ impl faucet_core::Source for S3Source {
                         })?;
                         let array = match value {
                             Value::Array(arr) => arr,
-                            other => {
-                                Err(FaucetError::Config(format!(
-                                    "S3 expected JSON array in '{key}', got {}",
-                                    value_type_name(&other)
-                                )))?;
-                                unreachable!()
-                            }
+                            other => Err(FaucetError::Config(format!(
+                                "S3 expected JSON array in '{key}', got {}",
+                                value_type_name(&other)
+                            )))?,
                         };
                         if batch_size == 0 {
                             // Flush any cross-object buffer first (none

--- a/crates/source/snowflake/Cargo.toml
+++ b/crates/source/snowflake/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Snowflake query source connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 faucet-core.workspace = true

--- a/crates/source/sqlite/Cargo.toml
+++ b/crates/source/sqlite/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "SQLite query source connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 faucet-core.workspace = true

--- a/crates/source/webhook/Cargo.toml
+++ b/crates/source/webhook/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Webhook receiver source connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 faucet-core.workspace = true

--- a/crates/source/xml/Cargo.toml
+++ b/crates/source/xml/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "XML API source connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 faucet-core.workspace = true

--- a/crates/state/postgres/Cargo.toml
+++ b/crates/state/postgres/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "PostgreSQL-backed StateStore for faucet-stream incremental replication"
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 faucet-core.workspace = true

--- a/crates/state/redis/Cargo.toml
+++ b/crates/state/redis/Cargo.toml
@@ -6,6 +6,9 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Redis-backed StateStore for faucet-stream incremental replication"
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 faucet-core.workspace = true


### PR DESCRIPTION
## Summary

Part of #78 — the final tier. Lands all 15 LOW-tier findings; with this merged, every finding in the #78 audit (CRITICAL → LOW) is resolved. Most are real code fixes with regression tests; a few are documentation of inherent behavior / `[S]` items that need a live system to fully verify.

| Finding | Area | Fix |
|---|---|---|
| REST auth headers | source-rest | `Authorization` (Basic/Bearer) values marked sensitive → reqwest/hyper redact them from trace logs |
| REST Link parser | source-rest | robust RFC-8288 parse: commas only split outside `<…>`, `rel` matched case-insensitively whether quoted/unquoted/multi-relation |
| REST non-scalar cursor | source-rest | cursor / next-link extraction errors on an array/object value instead of sending stringified JSON |
| GraphQL loop detection | source-graphql | compare next cursor against the *just-used* cursor (both fetch paths) → stuck cursor stops without an extra duplicate page |
| Redis `stream_keys` | source-redis | interleave manual-cursor `SCAN` with `MGET`+yield → O(batch_size) memory instead of materialising the whole keyset; document `LRANGE` list-paging instability under concurrent mutation |
| `unreachable!()` | source-s3/gcs/grpc | replaced the fragile `Err(…)?; unreachable!()` shape with a direct `?` (match arms) / explicit `return` (gRPC) |
| FileStateStore on Windows | core | percent-encode `:` → `%3A` in the on-disk filename so `pipeline:rest:issues` keys are NTFS-legal (logical key unchanged) |
| CLI concurrency | cli | default matrix concurrency scales with cores up to 8 (was hard-capped at 4); documented as intentional with `max_concurrent` override |
| CLI env auto-typing | cli | documented that `--from-env` auto-types `"true"`/`"123"`-looking values and the `*_JSON` quoted escape hatch |
| Parquet single-file + rollover | sink-parquet | warn when a fixed `.parquet` path is combined with rollover thresholds (UUID-file fallback); document `max_bytes_per_file` as an approximate in-memory estimate |
| sqlx pin | docs | CLAUDE.md notes `sqlx` is held at 0.8 by `pgwire-replication =0.3.2` |
| CDC resume boundary | source-postgres-cdc | code comment pointing to the integration tests that exercise exactly-once delivery across a resume |
| crate metadata | 43 crates | shared `keywords`/`categories` via `[workspace.package]` + per-crate `readme` so crates.io pages aren't bare |

## Test plan

- [ ] CI green across the full feature matrix (Docker-gated Redis/S3/etc. integration tests run in CI only)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] All non-Docker unit + integration tests pass locally; new regression tests added for the Link-header parser, non-scalar cursors, GraphQL stuck-cursor, and Windows-safe state filenames
- [x] `cargo metadata` validates the new workspace-inherited crate metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)