### PR TITLE
ci(release): fail fast if the derived publish list is incomplete (part of #78)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,36 @@ jobs:
             } | tsort | grep -vx '__root__'
           )
           ordered_connectors=$(echo "$ordered_all" | grep -vxE 'faucet-core|faucet-stream|faucet-cli')
-          echo "Publishable crates in dependency order:"
+
+          # Fail fast if the derivation dropped or duplicated a crate (a tsort
+          # cycle, a jq-filter regression, a malformed dependency edge). The
+          # whole point of deriving the list from `cargo metadata` is that a
+          # `scope=all` publish covers *every* publishable member — never ship
+          # a silently-partial set the way the old hardcoded arrays did
+          # (#78/#11).
+          expected=$(echo "$set_json" | jq 'length')
+          actual=$(echo "$ordered_all" | grep -c .)
+          if [ "$actual" -ne "$expected" ]; then
+            echo "ERROR: dependency-ordered list has $actual crate(s) but cargo metadata reports $expected publishable member(s) — tsort dropped or duplicated a crate." >&2
+            echo "Derived order was:" >&2
+            echo "$ordered_all" | nl >&2
+            exit 1
+          fi
+          dupes=$(echo "$ordered_all" | sort | uniq -d)
+          if [ -n "$dupes" ]; then
+            echo "ERROR: duplicate crate(s) in the dependency-ordered publish list:" >&2
+            echo "$dupes" >&2
+            exit 1
+          fi
+          # The three structural anchors must always be present and publishable.
+          for anchor in faucet-core faucet-stream faucet-cli; do
+            if ! echo "$ordered_all" | grep -qx "$anchor"; then
+              echo "ERROR: expected publishable crate '$anchor' is missing from the derived list — check its 'publish' setting." >&2
+              exit 1
+            fi
+          done
+
+          echo "Publishable crates in dependency order ($actual total):"
           echo "$ordered_all" | nl
           echo "ordered_all=$(echo "$ordered_all" | tr '\n' ' ')" >> "$GITHUB_ENV"
           echo "ordered_connectors=$(echo "$ordered_connectors" | tr '\n' ' ')" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary

Hardens the `workflow_dispatch` release pipeline so a `scope=all` run can never ship a silently-partial set of crates — the failure class behind #78 finding #11.

`release.yml` already derives its publishable crate list from `cargo metadata` + `tsort` (added by the #11 fix in #79), replacing the old hand-maintained arrays. This adds a fail-fast guard to that derivation step:

- assert the dependency-ordered list count equals `cargo metadata`'s publishable-member count (catches a `tsort` cycle / `jq` regression that drops a crate);
- reject duplicates in the ordered list;
- require the `faucet-core` / `faucet-stream` / `faucet-cli` anchors to be present.

Any of these aborts the release run with a clear error instead of publishing a subset.

This closes the remaining #78 acceptance-criteria item: *"`release.yml` crate lists derived from `cargo metadata`; a dry `scope=all` run resolves every umbrella feature."* (The `--all-features` umbrella build is already exercised by the workflow's `Test` step.)

## Test plan

- [x] YAML structure unchanged (addition lives inside the existing `run: |` block at matching indentation)
- [x] Derivation + guard logic simulated against the live workspace: 45 publishable members, 45 ordered, 0 duplicates, all three anchors present → guard passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)