### PR TITLE
docs: harden docs.rs rendering across all crates (WS-1 of #91)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,34 @@ jobs:
           restore-keys: ${{ runner.os }}-clippy-
       - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
+  docs:
+    name: Docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.94.0"
+      - name: Install librdkafka prerequisites
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libsasl2-dev libssl-dev libcurl4-openssl-dev cmake build-essential
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-docs-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-docs-
+      # Fail on any rustdoc warning (broken intra-doc links, etc.) so the
+      # docs.rs render stays clean. The `doc_cfg` feature-badge path itself is
+      # nightly-only and exercised by docs.rs, not here.
+      - name: Build docs
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+        run: cargo doc --workspace --all-features --no-deps
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -258,7 +258,7 @@ The only crate every connector depends on. Module layout:
 
 Every source/sink crate follows the same module layout. Stick to this when adding a new connector:
 
-- `lib.rs` — re-exports config + the `Source`/`Sink` type.
+- `lib.rs` — re-exports config + the `Source`/`Sink` type. **First line must be `#![cfg_attr(docsrs, feature(doc_cfg))]`** so docs.rs renders per-item feature badges (see [docs.rs build setup](#docsrs-build-setup)).
 - `config.rs` — config struct + auth/format/pagination sub-enums. Derives `Serialize + Deserialize + JsonSchema`. **No I/O or protocol logic here.**
 - `stream.rs` (source) / `sink.rs` (sink) — the one place that performs I/O. Holds reusable clients/pools created in `new()`. Implements `faucet_core::Source` / `Sink` including `config_schema()` via `schemars::schema_for!`.
 - Optional helper modules — `auth/`, `pagination/`, `extract/`, `retry/`, `convert.rs`, `schema.rs`, `decode.rs` / `encode.rs`, `state.rs` for bookmarks, `serde_helpers.rs` for non-serializable types (`reqwest::Method` etc.).
@@ -441,6 +441,28 @@ Key workspace deps: `serde` 1, `serde_json` 1, `schemars` 1.2, `async-trait` 0.1
 ## Publishing
 
 Crates publish in dependency order, topologically sorted then pushed to crates.io in **waves of 5 with a 15-minute wait between waves** (so each wave's crates have propagated through the crates.io index before the next wave depends on them). `.github/workflows/release.yml` handles this; it is **`workflow_dispatch`-triggered** (manual run with `scope` = `all` / `custom`, a version-bump input, and a `dry_run` toggle), not tag-triggered.
+
+### docs.rs build setup
+
+Every publishable crate is configured so docs.rs renders its **complete** API — including every optional connector — with a per-item "Available on crate feature X" badge. Two pieces, required on **every** crate:
+
+1. **Manifest** — a `[package.metadata.docs.rs]` block:
+   ```toml
+   [package.metadata.docs.rs]
+   all-features = true
+   rustdoc-args = ["--cfg", "docsrs"]
+   ```
+   `all-features = true` makes docs.rs document feature-gated code (without it, docs.rs builds default-features-only and hides optional connectors). `rustdoc-args` sets the `docsrs` cfg that gates the feature attribute below.
+
+2. **Crate root** — the first line of `lib.rs` (before the `//!` header):
+   ```rust
+   #![cfg_attr(docsrs, feature(doc_cfg))]
+   ```
+   On nightly (which docs.rs uses) this auto-applies feature badges to every `#[cfg(feature = "...")]` item. It is inert on stable because the `docsrs` cfg is never set outside docs.rs, so `cargo build` / CI on stable are unaffected.
+
+   **Use `doc_cfg`, not `doc_auto_cfg`.** The `doc_auto_cfg` feature was removed in Rust 1.92 and merged into `doc_cfg`; on a current nightly `feature(doc_auto_cfg)` is a hard compile error that fails the whole docs.rs build.
+
+Verify locally with: `RUSTDOCFLAGS="--cfg docsrs" rustup run nightly cargo doc --workspace --all-features --no-deps` (must be clean — broken intra-doc links surface here). New crates must add both pieces or they will be documented incompletely on docs.rs.
 
 ## Project Structure Sync
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -201,3 +201,7 @@ wiremock = "0.6"
 serial_test = "3"
 metrics-util.workspace = true
 serde_yaml = "0.9"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/cli/src/executor.rs
+++ b/cli/src/executor.rs
@@ -3,7 +3,7 @@
 //! Semantics:
 //!
 //! - Roots run concurrently under `Semaphore(max_concurrent)`.
-//! - Each root captures its written records (via a [`CapturingSink`] wrapper)
+//! - Each root captures its written records (via a `CapturingSink` wrapper)
 //!   so descendants can fan out per parent record.
 //! - For each child whose parent has finished successfully, one pipeline
 //!   invocation runs per parent record. `${parent.dotted.path}` tokens in the

--- a/cli/src/expand.rs
+++ b/cli/src/expand.rs
@@ -39,7 +39,7 @@ pub struct ExpandedNode {
     /// Resolved DLQ spec for this row, or `None` if no DLQ applies.
     pub dlq: Option<crate::config::DlqSpec>,
     /// Every `${id.path}` placeholder that survived load-time interpolation.
-    /// Populated by [`scan_deferred_refs`]; the executor uses this to know
+    /// Populated by `collect_deferred`; the executor uses this to know
     /// which parent record to feed which row.
     pub deferred_refs: Vec<DeferredRef>,
 }

--- a/cli/src/interpolate.rs
+++ b/cli/src/interpolate.rs
@@ -143,7 +143,7 @@ pub fn classify_directive(body: &str) -> Directive<'_> {
 /// (including `${` and `}`) and its [`Directive`] classification. `$${` is an
 /// escape and yields nothing; an unterminated `${` ends iteration. This is
 /// the shared tokenizer used by `expand.rs` validation so it scans and
-/// classifies tokens exactly as [`rewrite`] does during substitution.
+/// classifies tokens exactly as `rewrite` does during substitution.
 pub fn iter_directives(s: &str) -> impl Iterator<Item = (&str, Directive<'_>)> {
     let bytes = s.as_bytes();
     let mut i = 0;
@@ -238,7 +238,7 @@ fn value_to_string(v: &Value) -> String {
 // ── Post-parse load-time ref resolution ─────────────────────────────────────
 
 /// Resolve every `${vars.X}`, `${sources.X.PATH}`, `${sinks.X.PATH}` token
-/// found in a parsed [`PipelineConfig`].
+/// found in a parsed [`PipelineConfig`](crate::config::PipelineConfig).
 ///
 /// Order:
 /// 1. Resolve `${vars.X}` references *inside the vars block itself* (with

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! # faucet-cli
 //!
 //! A config-driven runner for [`faucet-stream`](https://docs.rs/faucet-stream)

--- a/crates/bigquery-common/Cargo.toml
+++ b/crates/bigquery-common/Cargo.toml
@@ -19,3 +19,7 @@ serde_json.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt"] }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/bigquery-common/src/lib.rs
+++ b/crates/bigquery-common/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! # faucet-bigquery-common
 //!
 //! Shared credential configuration and client construction for the

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -54,3 +54,7 @@ criterion = { workspace = true, features = ["async_tokio"] }
 [[bench]]
 name = "observability"
 harness = false
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! # faucet-core
 //!
 //! Shared types, traits, and utilities for the faucet-stream ecosystem.

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -1,7 +1,7 @@
 //! Source-to-sink pipeline orchestration.
 //!
-//! The [`Pipeline`] struct connects any [`Source`](crate::Source) to any
-//! [`Sink`](crate::Sink) and handles moving data between them.
+//! The [`Pipeline`] struct connects any [`Source`] to any
+//! [`Sink`] and handles moving data between them.
 //!
 //! # Batch mode
 //!
@@ -52,7 +52,7 @@ use std::sync::Arc;
 /// Default page size used when a caller does not specify one.
 ///
 /// Sources are free to override this from their own config when implementing
-/// [`Source::stream_pages`](crate::Source::stream_pages); the value passed
+/// [`Source::stream_pages`]; the value passed
 /// from the pipeline acts as a hint when no source-side preference exists.
 pub const DEFAULT_BATCH_SIZE: usize = 1000;
 
@@ -83,7 +83,7 @@ pub fn validate_batch_size(batch_size: usize) -> Result<usize, FaucetError> {
     Ok(batch_size)
 }
 
-/// One page emitted by [`Source::stream_pages`](crate::Source::stream_pages).
+/// One page emitted by [`Source::stream_pages`].
 ///
 /// `records` is the chunk of records for this page. `bookmark` is `Some` only
 /// when the source has a durable checkpoint to advance — most sources emit

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -186,7 +186,7 @@ pub trait Sink: Send + Sync {
     ///
     /// Sinks whose underlying API exposes per-row results (BigQuery
     /// `insertAll`, Elasticsearch `_bulk`) override this. The default
-    /// implementation delegates to [`write_batch`] and maps a single success
+    /// implementation delegates to [`Self::write_batch`] and maps a single success
     /// onto a uniform all-`Ok(())` vector. An outer failure is bubbled up
     /// unchanged so the pipeline's DLQ router can apply its `on_batch_error`
     /// policy at a single decision point.

--- a/crates/core/src/transform.rs
+++ b/crates/core/src/transform.rs
@@ -40,10 +40,11 @@ use std::sync::LazyLock;
 
 // ── Public config-facing type ─────────────────────────────────────────────────
 
-/// A transformation applied to every record fetched by a [`crate::stream::RestStream`].
+/// A transformation applied to every record fetched by a source (e.g. the REST
+/// source's `RestStream`).
 ///
-/// Transforms are applied in the order they are added via
-/// [`crate::config::RestStreamConfig::add_transform`].
+/// Transforms are applied in the order they are added via the owning source's
+/// configuration (e.g. `RestStreamConfig::add_transform`).
 ///
 /// The three built-in variants are each guarded by a Cargo feature flag
 /// (all enabled by default — see module-level docs).
@@ -196,9 +197,9 @@ impl RecordTransform {
 
 /// Pre-compiled form of a [`RecordTransform`].
 ///
-/// Stored inside [`crate::stream::RestStream`] so that regex patterns are
-/// compiled exactly once (at [`crate::stream::RestStream::new`] time) rather
-/// than once per record.
+/// Stored inside a source (e.g. the REST source's `RestStream`) so that regex
+/// patterns are compiled exactly once (at construction time) rather than once
+/// per record.
 pub enum CompiledTransform {
     #[cfg(feature = "transform-flatten")]
     Flatten {

--- a/crates/elasticsearch-common/Cargo.toml
+++ b/crates/elasticsearch-common/Cargo.toml
@@ -16,3 +16,7 @@ schemars.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/elasticsearch-common/src/lib.rs
+++ b/crates/elasticsearch-common/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! # faucet-elasticsearch-common
 //!
 //! Shared configuration types for the [`faucet-stream`](https://crates.io/crates/faucet-stream)

--- a/crates/gcs-common/Cargo.toml
+++ b/crates/gcs-common/Cargo.toml
@@ -18,3 +18,7 @@ serde_json.workspace = true
 google-cloud-storage.workspace = true
 google-cloud-auth.workspace = true
 tokio.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/gcs-common/src/lib.rs
+++ b/crates/gcs-common/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! Shared GCS credential and client construction for faucet source and
 //! sink connectors.
 

--- a/crates/kafka-common/Cargo.toml
+++ b/crates/kafka-common/Cargo.toml
@@ -53,3 +53,7 @@ schema-registry = [
     "dep:url",
     "dep:urlencoding",
 ]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/kafka-common/src/lib.rs
+++ b/crates/kafka-common/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! # faucet-kafka-common
 //!
 //! Shared configuration types for the [`faucet-stream`](https://crates.io/crates/faucet-stream)

--- a/crates/sink/bigquery/Cargo.toml
+++ b/crates/sink/bigquery/Cargo.toml
@@ -26,3 +26,7 @@ tokio = { version = "1", features = ["full", "test-util"] }
 wiremock = "0.6"
 tempfile = "3"
 serde = { workspace = true }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/sink/bigquery/src/lib.rs
+++ b/crates/sink/bigquery/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! # faucet-sink-bigquery
 //!
 //! BigQuery sink connector for the faucet-stream ecosystem.

--- a/crates/sink/bigquery/src/sink.rs
+++ b/crates/sink/bigquery/src/sink.rs
@@ -161,7 +161,7 @@ impl faucet_core::Sink for BigQuerySink {
 
     /// Write records to BigQuery, returning a per-row outcome vector.
     ///
-    /// Unlike [`write_batch`](Self::write_batch), which collapses all
+    /// Unlike [`write_batch`](faucet_core::Sink::write_batch), which collapses all
     /// `insertErrors` into a single `FaucetError`, this method maps each row
     /// to `Ok(())` if BigQuery accepted it or `Err(FaucetError::Sink(...))` if
     /// BigQuery reported a per-row error for it. This allows the pipeline's DLQ

--- a/crates/sink/csv/Cargo.toml
+++ b/crates/sink/csv/Cargo.toml
@@ -27,3 +27,7 @@ tempfile = "3"
 
 [features]
 compression = ["faucet-core/compression"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/sink/csv/src/lib.rs
+++ b/crates/sink/csv/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! # faucet-sink-csv
 //!
 //! CSV file sink connector for the faucet-stream ecosystem.

--- a/crates/sink/csv/src/sink.rs
+++ b/crates/sink/csv/src/sink.rs
@@ -28,7 +28,7 @@ struct WriterState {
 /// `write_batch` call. Subsequent records use the same column order; missing
 /// fields are written as empty strings.
 ///
-/// [`Sink::flush`] finalises the encoder (writes the trailer) and clears the
+/// [`Sink::flush`](faucet_core::Sink::flush) finalises the encoder (writes the trailer) and clears the
 /// writer slot — a subsequent `write_batch` reopens the file in append mode
 /// (independent of `config.append`) and starts a fresh encoder. This makes
 /// the per-page `flush` the pipeline emits for bookmarked pages safe for CDC

--- a/crates/sink/elasticsearch/Cargo.toml
+++ b/crates/sink/elasticsearch/Cargo.toml
@@ -24,3 +24,7 @@ reqwest.workspace = true
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
 serde_json.workspace = true
 wiremock = "0.6"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/sink/elasticsearch/src/lib.rs
+++ b/crates/sink/elasticsearch/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! # faucet-sink-elasticsearch
 //!
 //! Elasticsearch bulk index sink connector for the faucet-stream ecosystem.

--- a/crates/sink/elasticsearch/src/sink.rs
+++ b/crates/sink/elasticsearch/src/sink.rs
@@ -195,7 +195,7 @@ impl faucet_core::Sink for ElasticsearchSink {
 
     /// Write records using the `_bulk` API, returning a per-row outcome.
     ///
-    /// Unlike [`write_batch`](Self::write_batch), this method never collapses
+    /// Unlike [`write_batch`](faucet_core::Sink::write_batch), this method never collapses
     /// item-level Elasticsearch errors into a single outer `Err`. Each
     /// document maps to exactly one [`faucet_core::RowOutcome`]:
     ///

--- a/crates/sink/gcs/Cargo.toml
+++ b/crates/sink/gcs/Cargo.toml
@@ -35,3 +35,7 @@ faucet-source-gcs = { workspace = true }
 reqwest = { workspace = true }
 urlencoding.workspace = true
 futures.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/sink/gcs/src/lib.rs
+++ b/crates/sink/gcs/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! Google Cloud Storage sink connector.
 
 mod config;

--- a/crates/sink/http/Cargo.toml
+++ b/crates/sink/http/Cargo.toml
@@ -25,3 +25,7 @@ tokio.workspace = true
 tokio = { workspace = true, features = ["macros", "rt"] }
 serde_json.workspace = true
 wiremock = "0.6"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/sink/http/src/lib.rs
+++ b/crates/sink/http/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! # faucet-sink-http
 //!
 //! An HTTP POST sink connector that sends records to an HTTP endpoint,

--- a/crates/sink/jsonl/Cargo.toml
+++ b/crates/sink/jsonl/Cargo.toml
@@ -26,3 +26,7 @@ tempfile = "3"
 
 [features]
 compression = ["faucet-core/compression"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/sink/jsonl/src/lib.rs
+++ b/crates/sink/jsonl/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! # faucet-sink-jsonl
 //!
 //! JSON Lines file sink connector for the faucet-stream ecosystem.

--- a/crates/sink/jsonl/src/sink.rs
+++ b/crates/sink/jsonl/src/sink.rs
@@ -15,7 +15,7 @@ use tokio::sync::Mutex;
 ///
 /// With the `compression` feature, the writer transparently wraps the file
 /// with a gzip / zstd encoder based on the `compression` config field.
-/// [`Sink::flush`] finalises the encoder (writes the trailer) and clears the
+/// [`Sink::flush`](faucet_core::Sink::flush) finalises the encoder (writes the trailer) and clears the
 /// writer slot — a subsequent `write_batch` reopens the file in append mode
 /// (independent of `config.append`) and starts a fresh encoder, producing a
 /// multi-member compressed file that decoders read back correctly. This makes

--- a/crates/sink/kafka/Cargo.toml
+++ b/crates/sink/kafka/Cargo.toml
@@ -33,3 +33,7 @@ testcontainers-modules = { version = "0.15", features = ["kafka"] }
 [features]
 default = []
 schema-registry = ["faucet-kafka-common/schema-registry"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/sink/kafka/src/lib.rs
+++ b/crates/sink/kafka/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! # faucet-sink-kafka
 //!
 //! Apache Kafka producer sink for `faucet-stream`. Publishes records to one

--- a/crates/sink/mongodb/Cargo.toml
+++ b/crates/sink/mongodb/Cargo.toml
@@ -24,3 +24,7 @@ tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
 serde_json.workspace = true
 testcontainers = "0.27"
 testcontainers-modules = { version = "0.15", features = ["mongo"] }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/sink/mongodb/src/lib.rs
+++ b/crates/sink/mongodb/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! # faucet-sink-mongodb
 //!
 //! MongoDB sink connector for the faucet-stream ecosystem.

--- a/crates/sink/mysql/Cargo.toml
+++ b/crates/sink/mysql/Cargo.toml
@@ -24,3 +24,7 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 serde_json.workspace = true
 testcontainers = "0.27"
 testcontainers-modules = { version = "0.15", features = ["mysql"] }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/sink/mysql/src/lib.rs
+++ b/crates/sink/mysql/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! # faucet-sink-mysql
 //!
 //! MySQL sink connector for the faucet-stream ecosystem.

--- a/crates/sink/parquet/Cargo.toml
+++ b/crates/sink/parquet/Cargo.toml
@@ -31,3 +31,7 @@ bytes.workspace = true
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "fs", "io-util"] }
 serde_json.workspace = true
 tempfile = "3"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/sink/parquet/src/lib.rs
+++ b/crates/sink/parquet/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! Apache Parquet sink connector for the faucet-stream ecosystem.
 //!
 //! Writes JSON records as Apache Parquet files to a local filesystem path or

--- a/crates/sink/postgres/Cargo.toml
+++ b/crates/sink/postgres/Cargo.toml
@@ -25,3 +25,7 @@ tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
 serde_json.workspace = true
 testcontainers = "0.27"
 testcontainers-modules = { version = "0.15", features = ["postgres"] }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/sink/postgres/src/lib.rs
+++ b/crates/sink/postgres/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! # faucet-sink-postgres
 //!
 //! PostgreSQL sink connector for the faucet-stream ecosystem.

--- a/crates/sink/redis/Cargo.toml
+++ b/crates/sink/redis/Cargo.toml
@@ -24,3 +24,7 @@ tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
 serde_json.workspace = true
 testcontainers = "0.27"
 testcontainers-modules = { version = "0.15", features = ["redis"] }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/sink/redis/src/lib.rs
+++ b/crates/sink/redis/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! # faucet-sink-redis
 //!
 //! A config-driven Redis sink connector that writes to Redis streams,

--- a/crates/sink/s3/Cargo.toml
+++ b/crates/sink/s3/Cargo.toml
@@ -31,3 +31,7 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 serde_json.workspace = true
 testcontainers = "0.27"
 testcontainers-modules = { version = "0.15", features = ["minio"] }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/sink/s3/src/lib.rs
+++ b/crates/sink/s3/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! # faucet-sink-s3
 //!
 //! AWS S3 sink connector for the faucet-stream ecosystem.

--- a/crates/sink/snowflake/Cargo.toml
+++ b/crates/sink/snowflake/Cargo.toml
@@ -27,3 +27,7 @@ uuid.workspace = true
 tokio = { workspace = true, features = ["macros", "rt"] }
 serde_json.workspace = true
 wiremock = "0.6"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/sink/snowflake/src/lib.rs
+++ b/crates/sink/snowflake/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! # faucet-sink-snowflake
 //!
 //! Snowflake sink connector for the faucet-stream ecosystem.

--- a/crates/sink/sqlite/Cargo.toml
+++ b/crates/sink/sqlite/Cargo.toml
@@ -23,3 +23,7 @@ sqlx = { workspace = true, features = ["runtime-tokio", "sqlite", "json"] }
 tokio = { workspace = true, features = ["macros", "rt"] }
 serde_json.workspace = true
 tempfile = "3"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/sink/sqlite/src/lib.rs
+++ b/crates/sink/sqlite/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! # faucet-sink-sqlite
 //!
 //! SQLite sink connector for the faucet-stream ecosystem.

--- a/crates/sink/stdout/Cargo.toml
+++ b/crates/sink/stdout/Cargo.toml
@@ -22,3 +22,7 @@ tokio = { workspace = true, features = ["io-util", "io-std", "sync"] }
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt", "io-util", "sync"] }
 serde_json.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/sink/stdout/src/lib.rs
+++ b/crates/sink/stdout/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! # faucet-sink-stdout
 //!
 //! Stdout/stderr sink connector for the faucet-stream ecosystem.

--- a/crates/snowflake-common/Cargo.toml
+++ b/crates/snowflake-common/Cargo.toml
@@ -19,3 +19,7 @@ jsonwebtoken.workspace = true
 rsa = { workspace = true, features = ["sha2"] }
 sha2.workspace = true
 base64.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/snowflake-common/src/lib.rs
+++ b/crates/snowflake-common/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! # faucet-snowflake-common
 //!
 //! Shared configuration types and helpers for the

--- a/crates/source/bigquery/Cargo.toml
+++ b/crates/source/bigquery/Cargo.toml
@@ -28,3 +28,7 @@ futures.workspace = true
 wiremock = "0.6"
 tempfile = "3"
 serde = { workspace = true }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/source/bigquery/src/config.rs
+++ b/crates/source/bigquery/src/config.rs
@@ -75,7 +75,8 @@ pub struct BigQuerySourceConfig {
     pub statement_timeout: Duration,
     /// Maximum wall-clock time the source will spend polling
     /// `jobs.getQueryResults` for a job that keeps reporting
-    /// `jobComplete=false`, before giving up with [`FaucetError::Source`].
+    /// `jobComplete=false`, before giving up with
+    /// [`FaucetError::Source`](faucet_core::FaucetError::Source).
     /// Without this cap a job that never completes would loop forever.
     /// Defaults to 300 seconds. Set to `0` to disable the cap and poll
     /// indefinitely. Only the *completion* wait is bounded; once the job is

--- a/crates/source/bigquery/src/lib.rs
+++ b/crates/source/bigquery/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! # faucet-source-bigquery
 //!
 //! BigQuery query source connector for the faucet-stream ecosystem.

--- a/crates/source/csv/Cargo.toml
+++ b/crates/source/csv/Cargo.toml
@@ -30,3 +30,7 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 serde_json.workspace = true
 tempfile = "3"
 futures = { workspace = true }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/source/csv/src/lib.rs
+++ b/crates/source/csv/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! # faucet-source-csv
 //!
 //! CSV file source connector for the faucet-stream ecosystem.

--- a/crates/source/elasticsearch/Cargo.toml
+++ b/crates/source/elasticsearch/Cargo.toml
@@ -28,3 +28,7 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 serde_json.workspace = true
 futures.workspace = true
 wiremock = "0.6"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/source/elasticsearch/src/lib.rs
+++ b/crates/source/elasticsearch/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! # faucet-source-elasticsearch
 //!
 //! Elasticsearch search source connector for the faucet-stream ecosystem.

--- a/crates/source/gcs/Cargo.toml
+++ b/crates/source/gcs/Cargo.toml
@@ -36,3 +36,7 @@ futures.workspace = true
 testcontainers = "0.27"
 reqwest = { workspace = true }
 urlencoding.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/source/gcs/src/lib.rs
+++ b/crates/source/gcs/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! Google Cloud Storage source connector.
 //!
 //! See the crate-level README for usage and config-field reference.

--- a/crates/source/graphql/Cargo.toml
+++ b/crates/source/graphql/Cargo.toml
@@ -28,3 +28,7 @@ tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "time
 serde_json.workspace = true
 wiremock = "0.6"
 futures.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/source/graphql/src/lib.rs
+++ b/crates/source/graphql/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! # faucet-source-graphql
 //!
 //! A config-driven GraphQL API source with cursor-based pagination,

--- a/crates/source/grpc/Cargo.toml
+++ b/crates/source/grpc/Cargo.toml
@@ -36,3 +36,7 @@ prost.workspace = true
 [build-dependencies]
 tonic-build = "0.13"
 protoc-bin-vendored = "3"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/source/grpc/src/lib.rs
+++ b/crates/source/grpc/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! # faucet-source-grpc
 //!
 //! A config-driven gRPC source that uses protobuf reflection to call

--- a/crates/source/kafka/Cargo.toml
+++ b/crates/source/kafka/Cargo.toml
@@ -33,3 +33,7 @@ testcontainers-modules = { version = "0.15", features = ["kafka"] }
 [features]
 default = []
 schema-registry = ["faucet-kafka-common/schema-registry"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/source/kafka/src/lib.rs
+++ b/crates/source/kafka/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! # faucet-source-kafka
 //!
 //! Apache Kafka consumer source for `faucet-stream`. Subscribes to one or

--- a/crates/source/mongodb/Cargo.toml
+++ b/crates/source/mongodb/Cargo.toml
@@ -29,3 +29,7 @@ serde_json.workspace = true
 testcontainers = "0.27"
 testcontainers-modules = { version = "0.15", features = ["mongo"] }
 futures.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/source/mongodb/src/lib.rs
+++ b/crates/source/mongodb/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! # faucet-source-mongodb
 //!
 //! MongoDB source connector for the faucet-stream ecosystem.

--- a/crates/source/mysql/Cargo.toml
+++ b/crates/source/mysql/Cargo.toml
@@ -28,3 +28,7 @@ serde_json.workspace = true
 testcontainers = "0.27"
 testcontainers-modules = { version = "0.15", features = ["mysql"] }
 futures.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/source/mysql/src/lib.rs
+++ b/crates/source/mysql/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! # faucet-source-mysql
 //!
 //! MySQL query source connector for the faucet-stream ecosystem.

--- a/crates/source/parquet/Cargo.toml
+++ b/crates/source/parquet/Cargo.toml
@@ -33,3 +33,7 @@ tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "fs",
 serde_json.workspace = true
 futures.workspace = true
 tempfile = "3"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/source/parquet/src/config.rs
+++ b/crates/source/parquet/src/config.rs
@@ -29,7 +29,7 @@ pub struct ParquetSourceConfig {
     /// Arrow `RecordBatch` size used as the per-page hint when streaming.
     ///
     /// Passed verbatim to
-    /// [`ParquetRecordBatchStreamBuilder::with_batch_size`], which is itself
+    /// `ParquetRecordBatchStreamBuilder::with_batch_size`, which is itself
     /// only a hint — Arrow may emit smaller batches at row-group boundaries,
     /// so a single emitted [`faucet_core::StreamPage`] can hold fewer rows
     /// than this number. Larger values improve throughput at the cost of

--- a/crates/source/parquet/src/lib.rs
+++ b/crates/source/parquet/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! Apache Parquet source connector for the faucet-stream ecosystem.
 //!
 //! Reads Parquet files from local paths, glob patterns, or S3 and yields

--- a/crates/source/postgres-cdc/Cargo.toml
+++ b/crates/source/postgres-cdc/Cargo.toml
@@ -35,3 +35,7 @@ testcontainers = "0.27"
 testcontainers-modules = { version = "0.15", features = ["postgres"] }
 tokio-postgres = "0.7"
 hex = "0.4"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/source/postgres-cdc/src/config.rs
+++ b/crates/source/postgres-cdc/src/config.rs
@@ -110,7 +110,7 @@ pub struct PostgresCdcSourceConfig {
     /// `serde_json::Value` in RAM, which can OOM the process. This bound is a
     /// safety valve: when an in-progress transaction's staged record count
     /// exceeds it, the source aborts with a typed
-    /// [`FaucetError::Source`](faucet_core::FaucetError::Source) rather than
+    /// [`FaucetError::Source`] rather than
     /// being OOM-killed.
     ///
     /// `None` (the default) means unbounded — atomic delivery of arbitrarily

--- a/crates/source/postgres-cdc/src/lib.rs
+++ b/crates/source/postgres-cdc/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! PostgreSQL logical replication (CDC) source for `faucet-stream`.
 //!
 //! Subscribes to a Postgres logical replication slot using the `pgoutput`

--- a/crates/source/postgres/Cargo.toml
+++ b/crates/source/postgres/Cargo.toml
@@ -28,3 +28,7 @@ serde_json.workspace = true
 testcontainers = "0.27"
 testcontainers-modules = { version = "0.15", features = ["postgres"] }
 futures.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/source/postgres/src/lib.rs
+++ b/crates/source/postgres/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! # faucet-source-postgres
 //!
 //! PostgreSQL query source connector for the faucet-stream ecosystem.

--- a/crates/source/redis/Cargo.toml
+++ b/crates/source/redis/Cargo.toml
@@ -28,3 +28,7 @@ serde_json.workspace = true
 testcontainers = "0.27"
 testcontainers-modules = { version = "0.15", features = ["redis"] }
 futures.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/source/redis/src/lib.rs
+++ b/crates/source/redis/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! # faucet-source-redis
 //!
 //! A config-driven Redis source connector that reads from Redis streams,

--- a/crates/source/rest/Cargo.toml
+++ b/crates/source/rest/Cargo.toml
@@ -40,3 +40,7 @@ futures.workspace = true
 serde = { version = "1", features = ["derive"] }
 tempfile = "3"
 async-trait.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/source/rest/src/lib.rs
+++ b/crates/source/rest/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! # faucet-source-rest
 //!
 //! A declarative, config-driven REST API client with pluggable authentication,

--- a/crates/source/rest/src/retry/backoff.rs
+++ b/crates/source/rest/src/retry/backoff.rs
@@ -15,7 +15,7 @@ const MAX_CONSECUTIVE_RATE_LIMITS: u32 = 10;
 ///
 /// - **`RateLimited`** errors sleep for the server-specified `Retry-After`
 ///   duration and do **not** consume a `max_retries` slot, but are bounded by
-///   [`MAX_CONSECUTIVE_RATE_LIMITS`] consecutive occurrences so a permanently
+///   `MAX_CONSECUTIVE_RATE_LIMITS` consecutive occurrences so a permanently
 ///   throttled endpoint surfaces the `RateLimited` error instead of hanging.
 /// - **Retriable** errors (5xx, connection/timeout) use exponential backoff
 ///   with random jitter and count toward `max_retries`.

--- a/crates/source/s3/Cargo.toml
+++ b/crates/source/s3/Cargo.toml
@@ -32,3 +32,7 @@ serde_json.workspace = true
 futures.workspace = true
 testcontainers = "0.27"
 testcontainers-modules = { version = "0.15", features = ["minio"] }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/source/s3/src/lib.rs
+++ b/crates/source/s3/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! # faucet-source-s3
 //!
 //! AWS S3 source connector for the faucet-stream ecosystem.

--- a/crates/source/snowflake/Cargo.toml
+++ b/crates/source/snowflake/Cargo.toml
@@ -26,3 +26,7 @@ reqwest.workspace = true
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
 futures.workspace = true
 wiremock = "0.6"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/source/snowflake/src/config.rs
+++ b/crates/source/snowflake/src/config.rs
@@ -60,7 +60,8 @@ pub struct SnowflakeSourceConfig {
     pub statement_timeout: Duration,
     /// Maximum wall-clock time the source will spend polling an asynchronous
     /// statement (one for which the initial `POST /api/v2/statements`
-    /// returns HTTP 202) before giving up with [`FaucetError::Source`].
+    /// returns HTTP 202) before giving up with
+    /// [`FaucetError::Source`](faucet_core::FaucetError::Source).
     /// Without this cap a statement that never finishes would loop forever.
     /// Defaults to 300 seconds. Set to `0` to disable the cap and poll
     /// indefinitely.

--- a/crates/source/snowflake/src/lib.rs
+++ b/crates/source/snowflake/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! # faucet-source-snowflake
 //!
 //! Snowflake query source connector for the faucet-stream ecosystem.

--- a/crates/source/sqlite/Cargo.toml
+++ b/crates/source/sqlite/Cargo.toml
@@ -27,3 +27,7 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 serde_json.workspace = true
 tempfile = "3"
 futures.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/source/sqlite/src/lib.rs
+++ b/crates/source/sqlite/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! # faucet-source-sqlite
 //!
 //! SQLite query source connector for the faucet-stream ecosystem.

--- a/crates/source/webhook/Cargo.toml
+++ b/crates/source/webhook/Cargo.toml
@@ -24,3 +24,7 @@ axum = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt", "time", "net", "sync"] }
 serde_json.workspace = true
 reqwest.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/source/webhook/src/lib.rs
+++ b/crates/source/webhook/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! # faucet-source-webhook
 //!
 //! A webhook receiver source connector that starts a temporary HTTP server,

--- a/crates/source/xml/Cargo.toml
+++ b/crates/source/xml/Cargo.toml
@@ -29,3 +29,7 @@ serde_json.workspace = true
 futures.workspace = true
 tempfile = "3"
 wiremock = "0.6"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/source/xml/src/convert.rs
+++ b/crates/source/xml/src/convert.rs
@@ -137,7 +137,7 @@ pub fn xml_to_json(xml: &str) -> Result<Value, FaucetError> {
 /// are observed via the event stream but never accumulated, which bounds
 /// memory to one matched element + the path stack regardless of total
 /// document size. Combined with batched yielding in
-/// [`crate::stream::XmlStream::stream_pages`], this keeps client-side
+/// [`crate::stream::XmlStream`]'s `stream_pages`, this keeps client-side
 /// memory at `O(batch_size * record_size)` even for multi-gigabyte
 /// payloads.
 pub fn stream_extract<F: FnMut(Value)>(

--- a/crates/source/xml/src/lib.rs
+++ b/crates/source/xml/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! # faucet-source-xml
 //!
 //! A config-driven XML/SOAP API source with automatic XML-to-JSON conversion,

--- a/crates/state/postgres/Cargo.toml
+++ b/crates/state/postgres/Cargo.toml
@@ -20,3 +20,7 @@ tokio = { workspace = true, features = ["sync"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt"] }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/state/postgres/src/lib.rs
+++ b/crates/state/postgres/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! # faucet-state-postgres
 //!
 //! PostgreSQL-backed [`StateStore`](faucet_core::state::StateStore) for

--- a/crates/state/postgres/src/store.rs
+++ b/crates/state/postgres/src/store.rs
@@ -8,7 +8,7 @@ use sqlx::postgres::PgPoolOptions;
 use sqlx::{PgPool, Row};
 
 /// Default name for the state-store table. Override via
-/// [`PostgresStateStore::with_table`].
+/// [`PostgresStateStore::connect_with`].
 pub const DEFAULT_TABLE: &str = "faucet_state";
 
 /// A `StateStore` that persists each entry as a row in a single Postgres

--- a/crates/state/redis/Cargo.toml
+++ b/crates/state/redis/Cargo.toml
@@ -20,3 +20,7 @@ tokio = { workspace = true, features = ["sync"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt"] }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/state/redis/src/lib.rs
+++ b/crates/state/redis/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! # faucet-state-redis
 //!
 //! Redis-backed [`StateStore`](faucet_core::state::StateStore) for faucet-stream

--- a/faucet-stream/Cargo.toml
+++ b/faucet-stream/Cargo.toml
@@ -330,3 +330,7 @@ required-features = ["source-mongodb", "sink-postgres"]
 [[example]]
 name = "csv_to_bigquery"
 required-features = ["source-csv", "sink-bigquery"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/faucet-stream/src/lib.rs
+++ b/faucet-stream/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! # faucet-stream
 //!
 //! A declarative, config-driven data pipeline with pluggable source and sink


### PR DESCRIPTION
First workstream of the adoption & DX epic (#91): make docs.rs render the **complete** API — including every optional connector — with per-item feature badges, and stop broken intra-doc links from shipping.

## Why
docs.rs currently builds each crate with **default features only**, so every optional connector's API (BigQuery, Kafka, Parquet, etc.) is invisible to anyone evaluating the library there. This was the single highest-leverage gap identified in the audit.

## Summary
- **45 manifests** → `[package.metadata.docs.rs]` with `all-features = true` + `rustdoc-args = ["--cfg", "docsrs"]`, so docs.rs documents feature-gated code.
- **45 `lib.rs`** → `#![cfg_attr(docsrs, feature(doc_cfg))]` so feature-gated items get an "Available on crate feature X" badge. Inert on stable (the `docsrs` cfg is never set outside docs.rs), so `cargo build` / CI on stable are unaffected.
  - ⚠️ **Used `doc_cfg`, not `doc_auto_cfg`.** `doc_auto_cfg` was removed in Rust 1.92 and merged into `doc_cfg`; on the current nightly docs.rs uses, `feature(doc_auto_cfg)` is a hard compile error that would fail the entire docs.rs build. Verified `doc_cfg` auto-applies badges on nightly 1.98.
- **Fixed 25 broken/redundant intra-doc links** across `faucet-core` + 11 connector crates (cross-crate refs demoted to code spans, private-item links demoted, unresolved variant/method links given full paths, redundant explicit targets removed).
- **New `docs` CI job** (stable, `RUSTDOCFLAGS=-D warnings`) so future broken links fail CI.
- **CLAUDE.md** gains a "docs.rs build setup" section documenting the convention so new crates inherit both pieces.

## Verification
- Full **nightly `--cfg docsrs`** workspace doc build: clean, 46 crates, 0 warnings; feature badges confirmed rendering (`faucet-core` compression/transform; `faucet-source-kafka` + `faucet-kafka-common` schema-registry).
- Stable `cargo doc --workspace --all-features --no-deps` with `-D warnings` (the new CI command): clean.
- `cargo fmt --all --check`: clean.

## Test plan
- [ ] CI `docs` job passes (stable, `-D warnings`).
- [ ] CI fmt / clippy / test / feature-check jobs unaffected.
- [ ] After merge, confirm a docs.rs build shows optional-connector APIs with feature badges.

## Out of scope
Deferred to later #91 workstreams: `#![doc = include_str!("README.md")]` consolidation, exhaustive doc-comment coverage audit, the mdBook docs site, and per-crate "when to use" guidance.

Part of #91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)