### PR TITLE
docs: mdBook site + runnable examples & local Docker stack (WS-4 & WS-5 of #91)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,64 @@
+name: Docs site
+
+# Builds the mdBook in docs/book. On pull requests it only verifies the book
+# builds; on push to main it also deploys to GitHub Pages.
+#
+# NOTE: deployment requires Pages to be enabled for the repo with the source set
+# to "GitHub Actions" (Settings → Pages → Build and deployment → GitHub Actions).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/book/**"
+      - ".github/workflows/docs.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "docs/book/**"
+      - ".github/workflows/docs.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-pages
+  cancel-in-progress: false
+
+env:
+  MDBOOK_VERSION: "0.5.3"
+
+jobs:
+  build:
+    name: Build book
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install mdBook
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          url="https://github.com/rust-lang/mdBook/releases/download/v${MDBOOK_VERSION}/mdbook-v${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+          curl -sSL "$url" | tar -xz -C "$HOME/.local/bin"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Build
+        run: mdbook build docs/book
+      - name: Upload Pages artifact
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/book/book
+
+  deploy:
+    name: Deploy to GitHub Pages
+    if: github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ docs/superpowers/
 Cargo.lock
 doc/
 libtest_compile.rlib
+
+# mdBook rendered output (docs site source lives in docs/book/src)
+docs/book/book/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -464,6 +464,14 @@ Every publishable crate is configured so docs.rs renders its **complete** API �
 
 Verify locally with: `RUSTDOCFLAGS="--cfg docsrs" rustup run nightly cargo doc --workspace --all-features --no-deps` (must be clean — broken intra-doc links surface here). New crates must add both pieces or they will be documented incompletely on docs.rs.
 
+## Documentation Site (mdBook)
+
+The user-facing documentation site lives in **`docs/book/`** (an mdBook). Source pages are under `docs/book/src/` with the TOC in `SUMMARY.md`; config is `docs/book/book.toml`. **This is distinct from `docs/superpowers/`** (internal design specs — never user-facing). The rendered output (`docs/book/book/`) is gitignored.
+
+- Build locally with `mdbook build docs/book` (install via `cargo install mdbook`; the workspace was built with mdBook 0.5.x). The book uses **no preprocessors** (no mdbook-mermaid etc.) so a bare `mdbook` builds it.
+- `.github/workflows/docs.yml` builds the book on every PR (verify) and deploys it to **GitHub Pages** on push to `main`. Pages must be enabled in repo Settings with source = "GitHub Actions"; the published URL is `https://pawansikawat.github.io/faucet-stream/`.
+- **Keep the book in sync** when you change connector config, CLI commands, the config grammar, or add/remove connectors — update the relevant page under `docs/book/src/` alongside the crate README and this file. Content should stay grounded in real configs (reuse the `cli/examples/` YAMLs) rather than invented field names.
+
 ## Project Structure Sync
 
 **When adding, removing, or moving files or directories, update the Project Structure section in README.md to reflect the change.**

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+# Convenience targets for running the faucet-stream examples.
+# `make help` lists everything.
+
+COMPOSE := docker compose -f examples/docker-compose.yml
+# Slim feature set for the demo so it builds fast and needs no native libs
+# (avoids the Kafka/librdkafka cmake dependency in the full build).
+DEMO_FEATURES := source-csv,sink-jsonl,sink-stdout,transforms
+FAUCET_DEMO := cargo run -q -p faucet-cli --no-default-features --features "$(DEMO_FEATURES)" --
+
+.DEFAULT_GOAL := help
+
+.PHONY: help demo infra-up infra-down infra-logs infra-ps
+
+help: ## List available targets
+	@grep -hE '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) | sort | \
+		awk 'BEGIN {FS = ":.*?## "} {printf "  \033[36m%-14s\033[0m %s\n", $$1, $$2}'
+
+demo: ## Run a no-infrastructure smoke test (CSV -> JSONL)
+	@mkdir -p target/demo
+	$(FAUCET_DEMO) validate examples/demo/pipeline.yaml
+	$(FAUCET_DEMO) run examples/demo/pipeline.yaml
+	@echo "--- target/demo/out.jsonl ---"
+	@cat target/demo/out.jsonl
+
+infra-up: ## Start the local example stack (Postgres, MySQL, Kafka, Redis, Mongo, ES, MinIO)
+	$(COMPOSE) up -d
+
+infra-down: ## Stop the local stack and wipe its volumes
+	$(COMPOSE) down -v
+
+infra-ps: ## Show the status of the local stack
+	$(COMPOSE) ps
+
+infra-logs: ## Tail logs from the local stack
+	$(COMPOSE) logs -f

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ can drop on any box or a library you compile in.
 Inspired by [Meltano's Singer SDK](https://sdk.meltano.com/) — reimagined for Rust
 as both a reusable library and a standalone CLI.
 
+**Documentation:** the [faucet-stream guide](https://pawansikawat.github.io/faucet-stream/)
+(getting started, tutorials, cookbook, operations) · API reference on
+[docs.rs](https://docs.rs/faucet-stream) · [`cli/README.md`](cli/README.md) for the full config grammar.
+
 ## Run a pipeline from a YAML file (no Rust required)
 
 ```bash
@@ -1074,6 +1078,10 @@ cli/                          — faucet-cli: `faucet` binary, YAML/JSON pipelin
     commands/{run, validate, schema, list, preview, init}.rs
   examples/                   — ready-to-run pipeline YAMLs
   tests/                      — assert_cmd + wiremock integration tests
+examples/                     — repo-level examples: docker-compose infra stack + run index
+docs/
+  book/                       — mdBook documentation site (source under docs/book/src)
+.github/workflows/            — ci.yml, release.yml, docs.yml (mdBook → GitHub Pages)
 ```
 
 ## License

--- a/docs/book/book.toml
+++ b/docs/book/book.toml
@@ -1,0 +1,20 @@
+[book]
+title = "faucet-stream"
+description = "The fast, config-driven way to move data in Rust."
+authors = ["faucet-stream contributors"]
+language = "en"
+src = "src"
+
+[output.html]
+default-theme = "rust"
+preferred-dark-theme = "ayu"
+git-repository-url = "https://github.com/PawanSikawat/faucet-stream"
+edit-url-template = "https://github.com/PawanSikawat/faucet-stream/edit/main/docs/book/{path}"
+no-section-label = false
+
+[output.html.fold]
+enable = true
+level = 1
+
+[output.html.search]
+enable = true

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -1,0 +1,41 @@
+# Summary
+
+[Introduction](./introduction.md)
+
+# Getting Started
+
+- [Installation](./getting-started/installation.md)
+- [Your first pipeline](./getting-started/first-pipeline.md)
+- [Core concepts](./getting-started/concepts.md)
+
+# Tutorials
+
+- [REST API → BigQuery (incremental)](./tutorials/rest-to-bigquery.md)
+- [PostgreSQL CDC → JSONL](./tutorials/postgres-cdc.md)
+- [Multi-pipeline DAGs with `matrix`](./tutorials/matrix-dag.md)
+- [Embedding faucet as a Rust library](./tutorials/library.md)
+
+# Cookbook
+
+- [Pagination styles](./cookbook/pagination.md)
+- [Authentication](./cookbook/auth.md)
+- [Incremental replication & state](./cookbook/state.md)
+- [Dead-letter queues](./cookbook/dlq.md)
+- [Compression](./cookbook/compression.md)
+
+# Reference
+
+- [Connector catalog](./reference/connectors.md)
+- [CLI commands](./reference/cli.md)
+- [Configuration file format](./reference/config.md)
+
+# Operations
+
+- [Deploying faucet](./operations/deploying.md)
+- [Observability](./operations/observability.md)
+- [Performance tuning](./operations/tuning.md)
+- [Troubleshooting & FAQ](./operations/troubleshooting.md)
+
+# Extending
+
+- [Authoring a connector](./extending/authoring-connectors.md)

--- a/docs/book/src/cookbook/auth.md
+++ b/docs/book/src/cookbook/auth.md
@@ -1,0 +1,71 @@
+# Authentication
+
+The REST source supports several auth strategies via the `auth:` block. Always
+pull secrets from the environment with `${env:VAR}` (or `${file:PATH}` /
+`${secret:VAR}`) rather than hard-coding them in the config.
+
+## API key / header
+
+```yaml
+auth:
+  type: ApiKey
+  header: Authorization
+  value: "Bearer ${env:API_TOKEN}"
+```
+
+## Bearer token
+
+```yaml
+auth:
+  type: Bearer
+  token: ${env:API_TOKEN}
+```
+
+## Basic auth
+
+```yaml
+auth:
+  type: Basic
+  username: ${env:API_USER}
+  password: ${env:API_PASS}
+```
+
+## OAuth2 client credentials
+
+The source fetches and refreshes the token automatically, refreshing before
+expiry:
+
+```yaml
+auth:
+  type: OAuth2
+  token_url: https://auth.example.com/oauth/token
+  client_id: ${env:CLIENT_ID}
+  client_secret: ${env:CLIENT_SECRET}
+  scopes: ["read:events"]
+```
+
+## Custom token endpoint
+
+For non-standard token endpoints, `TokenEndpoint` lets you describe the request
+and point at the access-token and expiry fields in the response. See
+`faucet schema source rest` for the full field list.
+
+## Connector-specific auth
+
+Other connectors carry their own auth types, shared through a common crate where
+a source/sink pair exists:
+
+- **BigQuery** — `BigQueryCredentials`: service-account key path, inline JSON, or
+  application-default credentials.
+- **Snowflake** — `SnowflakeAuth`: JWT (key-pair) or OAuth.
+- **Kafka** — `KafkaAuth`: SASL mechanisms + TLS via `KafkaTlsConfig`.
+- **Elasticsearch** — `ElasticsearchAuth`: basic, API key, bearer, or none.
+
+Inspect any connector's auth shape with `faucet schema source <name>` /
+`faucet schema sink <name>`.
+
+## Secret interpolation
+
+`${env:VAR}` and `${file:PATH}` are resolved at config-load time, so secrets
+never need to appear in the file. A sibling `.env` is loaded automatically (use
+`--no-env-file` to disable, or `--env-file PATH` to point elsewhere).

--- a/docs/book/src/cookbook/compression.md
+++ b/docs/book/src/cookbook/compression.md
@@ -1,0 +1,51 @@
+# Compression
+
+The file-shaped connectors can read and write gzip / zstd transparently. Enable
+the `compression` feature, then set a `compression:` field on the connector.
+
+## Enable the feature
+
+```bash
+# CLI
+cargo install faucet-cli --features compression
+
+# Library (umbrella) — activates compression on whichever file connectors you've enabled
+faucet-stream = { version = "0.2", features = ["sink-jsonl", "source-csv", "compression"] }
+```
+
+The `compression` aggregate feature forwards to whichever of the supported
+connectors you've already opted into; it doesn't pull in connectors by itself.
+`full` includes compression.
+
+## Connectors that support it
+
+`source-csv`, `source-s3`, `source-gcs`, `sink-jsonl`, `sink-csv`, `sink-s3`,
+`sink-gcs`.
+
+## Config
+
+```yaml
+sink:
+  type: jsonl
+  config:
+    path: ./out/records.jsonl.gz
+    compression: auto      # none | gzip | zstd | auto (default)
+```
+
+- `auto` chooses from the filename suffix: `.gz` → gzip, `.zst` → zstd, anything
+  else → none.
+- Explicit `gzip` / `zstd` / `none` override the suffix.
+
+Auto-detection runs per file at I/O time, so one matrix run can read a mix of
+`.jsonl`, `.jsonl.gz`, and `.jsonl.zst` objects.
+
+## Notes
+
+- File sinks finalize the encoder on `flush()`; later writes reopen in append
+  mode, producing a multi-member compressed file that gzip/zstd decoders read
+  back transparently.
+- S3 and GCS sinks do **not** set a `Content-Encoding` header — consumers must
+  decompress explicitly.
+- Parquet, Kafka, HTTP, stdout, and the database sinks are intentionally out of
+  scope: Parquet has internal columnar compression and the others have native
+  protocol-level options.

--- a/docs/book/src/cookbook/dlq.md
+++ b/docs/book/src/cookbook/dlq.md
@@ -1,0 +1,49 @@
+# Dead-letter queues
+
+A dead-letter queue (DLQ) keeps a pipeline running when a handful of records
+fail to write, instead of aborting the whole run. Failing rows are wrapped in a
+fixed-shape envelope and routed to a separate DLQ sink before the page's bookmark
+advances.
+
+## When it helps
+
+Sinks whose underlying API reports **per-row** results — BigQuery `insertAll`,
+Elasticsearch `_bulk` — can tell exactly which records failed. The DLQ captures
+just those, while the good rows commit normally.
+
+## Configure a DLQ
+
+Add a `dlq:` block naming a sink to receive the bad rows and the policy for
+sinks that can't report per-row outcomes:
+
+```yaml
+pipeline:
+  source: { type: rest, config: { /* … */ } }
+  sink:   { type: bigquery, config: { /* … */ } }
+  dlq:
+    on_batch_error: dlq_all      # or `propagate`
+    sink:
+      type: jsonl
+      config:
+        path: ./dead-letters.jsonl
+```
+
+## The envelope
+
+Each dead-lettered record is wrapped with metadata — the original record, the
+reason it failed, and context — so you can inspect, fix, and replay it later.
+
+## `on_batch_error` policy
+
+For a sink that can only succeed or fail a whole batch (no per-row detail):
+
+- `propagate` — a batch failure aborts the run (the default, fail-fast behavior).
+- `dlq_all` — route every row in the failed batch to the DLQ and keep going.
+
+Sinks that *do* report per-row results (BigQuery, Elasticsearch) override the
+partial-write path so only the genuinely failed rows are dead-lettered — they are
+not duplicated into the DLQ.
+
+> The full design is in
+> [`docs/superpowers/specs/2026-05-24-dlq-design.md`](https://github.com/PawanSikawat/faucet-stream/blob/main/docs)
+> and the `faucet_core::dlq` module on docs.rs.

--- a/docs/book/src/cookbook/pagination.md
+++ b/docs/book/src/cookbook/pagination.md
@@ -18,8 +18,8 @@ every style has a loop/termination guard so a misbehaving API can't loop forever
 ```yaml
 pagination:
   type: Cursor
-  cursor_path: $.meta.next_cursor      # JSONPath to the next-page token
-  cursor_param: cursor                 # query param to send it back as
+  next_token_path: $.meta.next_cursor  # JSONPath to the next-page token
+  param_name: starting_after           # query param to send it back as
 ```
 
 ## Page number

--- a/docs/book/src/cookbook/pagination.md
+++ b/docs/book/src/cookbook/pagination.md
@@ -1,0 +1,63 @@
+# Pagination styles (REST source)
+
+The REST source walks multi-page responses automatically. Set `pagination.type`
+to one of the styles below. `max_pages` is a hard cap across all of them, and
+every style has a loop/termination guard so a misbehaving API can't loop forever.
+
+| Style | Stops when |
+|-------|-----------|
+| `None` | after the first page |
+| `Cursor` | the next-token JSONPath is null/absent (or repeats) |
+| `PageNumber` | a page returns zero records (or an identical body repeats) |
+| `Offset` | the offset reaches `total` (via `total_path`) or a short page arrives |
+| `LinkHeader` | there's no `rel="next"` in the `Link` response header |
+| `NextLinkInBody` | the next-page URL in the body is absent, null, or empty |
+
+## Cursor
+
+```yaml
+pagination:
+  type: Cursor
+  cursor_path: $.meta.next_cursor      # JSONPath to the next-page token
+  cursor_param: cursor                 # query param to send it back as
+```
+
+## Page number
+
+```yaml
+pagination:
+  type: PageNumber
+  param_name: page
+  start_page: 1
+  page_size: 500
+  page_size_param: per_page
+```
+
+## Offset / limit
+
+```yaml
+pagination:
+  type: Offset
+  limit: 1000
+  limit_param: limit
+  offset_param: offset
+  total_path: $.meta.total             # optional; enables an exact stop
+```
+
+## Link header
+
+```yaml
+pagination:
+  type: LinkHeader      # follows the RFC 5988 `Link: <…>; rel="next"` header
+```
+
+## Next link in body
+
+```yaml
+pagination:
+  type: NextLinkInBody
+  next_link_path: $.links.next         # JSONPath to the absolute next-page URL
+```
+
+> Use `faucet schema source rest` to see the exact fields and defaults for each
+> style in your installed version.

--- a/docs/book/src/cookbook/state.md
+++ b/docs/book/src/cookbook/state.md
@@ -1,0 +1,72 @@
+# Incremental replication & state
+
+For pipelines that run repeatedly, you usually want to fetch only what's new.
+That requires two things: an **incremental replication method** on the source and
+a **state store** to persist the bookmark between runs.
+
+## Replication methods
+
+- `FullTable` — fetch everything every run.
+- `Incremental` — track a high-water mark on a `cursor_field` (e.g. `updated_at`,
+  an auto-increment id) and only emit records past the last seen value.
+
+```yaml
+source:
+  type: rest
+  config:
+    # …
+    replication_method:
+      type: Incremental
+      cursor_field: updated_at
+    primary_keys: [id]
+```
+
+## State stores
+
+Attach a `state:` block so the bookmark survives between runs:
+
+```yaml
+state:
+  type: file          # built into faucet-core
+  config:
+    path: ./state
+```
+
+Available backends:
+
+| Backend | Crate | Use when |
+|---------|-------|----------|
+| `memory` | `faucet-core` | tests, one-shot runs (not persistent) |
+| `file` | `faucet-core` | single host; one JSON file per key, atomic writes |
+| `redis` | `faucet-state-redis` | shared/ephemeral state across hosts |
+| `postgres` | `faucet-state-postgres` | shared, durable, transactional state |
+
+```yaml
+# Redis
+state:
+  type: redis
+  config:
+    connection_url: redis://localhost:6379
+    namespace: faucet
+
+# Postgres
+state:
+  type: postgres
+  config:
+    connection_url: postgres://user:pass@localhost/faucet
+```
+
+## How bookmarks advance
+
+The pipeline reads the bookmark before fetching, and persists a new one **only
+after the sink confirms** the page. Most sources emit a bookmark on the final
+page; CDC-style sources emit one per committed transaction and get
+per-transaction durability automatically. Either way, a crash can never advance
+the bookmark past data that wasn't written — the next run re-fetches from the
+last confirmed point.
+
+## State keys
+
+Each invocation has a state key so concurrent matrix rows don't collide:
+`{name}::{row_id}` for roots and `{name}::{row_id}::{parent_record_key}` for DAG
+children. The CDC source uses `postgres-cdc:<slot>`.

--- a/docs/book/src/extending/authoring-connectors.md
+++ b/docs/book/src/extending/authoring-connectors.md
@@ -1,0 +1,96 @@
+# Authoring a connector
+
+faucet-stream is designed as an ecosystem: third parties can publish their own
+`faucet-source-*` / `faucet-sink-*` crates with minimal friction. **`faucet-core`
+is the only required dependency** — it re-exports everything a connector author
+needs (`async_trait`, `serde_json`, `schemars`).
+
+## The traits
+
+Implement `Source` or `Sink`. Both are object-safe (`Box<dyn Source>` works) and
+all newer methods have defaults, so a minimal connector is small.
+
+```rust,ignore
+use faucet_core::{async_trait, Source, Sink, FaucetError, Value};
+
+struct MySource { /* reusable client/pool created in new() */ }
+
+#[async_trait]
+impl Source for MySource {
+    // Primary entry point. (`fetch_all()` is a provided convenience.)
+    async fn fetch_with_context(&self) -> Result<Vec<Value>, FaucetError> {
+        todo!("fetch records from your system")
+    }
+}
+
+struct MySink { /* reusable client/pool */ }
+
+#[async_trait]
+impl Sink for MySink {
+    async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
+        todo!("write records to your system")
+    }
+}
+```
+
+Your connector now works with the `Pipeline` and every other connector:
+`Pipeline::new(&MySource { .. }, &MySink { .. }).run().await?`.
+
+## Crate layout
+
+Follow the same module layout as the built-in connectors:
+
+- **`lib.rs`** — re-export the config + the `Source`/`Sink` type. First line:
+  `#![cfg_attr(docsrs, feature(doc_cfg))]` (see below).
+- **`config.rs`** — the config struct + sub-enums, deriving
+  `Serialize + Deserialize + JsonSchema`. **No I/O here.**
+- **`stream.rs`** (source) / **`sink.rs`** (sink) — the one place that performs
+  I/O. Create reusable clients/pools in `new()` and store them; never reconnect
+  per call.
+
+## Make it fast
+
+Performance is the project's first principle. Reuse clients and connections,
+pool database connections, use multi-row inserts and bulk APIs, and prefer
+parallel I/O. Where it makes sense, override `stream_pages` to stream natively
+from your source's paging primitive so memory stays bounded.
+
+## Config schema introspection
+
+Implement `config_schema()` so `faucet schema` and `faucet init` work:
+
+```rust,ignore
+fn config_schema(&self) -> Value {
+    faucet_core::schema_for!(MyConfig).into()
+}
+```
+
+Derive `JsonSchema` on the config struct and all sub-types, and add
+`#[schemars(with = "String")]` for any custom-serde fields.
+
+## Errors
+
+Map every failure to a `FaucetError` variant. Third-party error types wrap into
+`FaucetError::Custom(Box<dyn Error + Send + Sync>)` without losing the chain.
+Never `.unwrap()` on anything that can fail at runtime.
+
+## docs.rs setup
+
+So docs.rs renders your full API with per-feature badges, add to `Cargo.toml`:
+
+```toml
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+```
+
+and make the first line of `lib.rs` `#![cfg_attr(docsrs, feature(doc_cfg))]`.
+
+## Naming & publishing
+
+Name crates `faucet-source-<name>` / `faucet-sink-<name>`. If you ship both a
+source and a sink for the same system, put shared types (auth, formats) in a
+`faucet-<name>-common` crate that both depend on and re-export.
+
+> See any built-in connector (e.g. `faucet-source-rest`) for a reference
+> implementation, and `CLAUDE.md` in the repo for the full conventions.

--- a/docs/book/src/getting-started/concepts.md
+++ b/docs/book/src/getting-started/concepts.md
@@ -1,0 +1,65 @@
+# Core concepts
+
+faucet-stream is built from a handful of small pieces. Understanding them makes
+both the YAML config and the Rust API obvious.
+
+## Source
+
+A **source** fetches records from an external system (a REST API, a database, a
+Kafka topic, an object store, …) and yields them as JSON values. Sources stream
+in batches via `stream_pages`, so memory stays bounded no matter how much data
+flows through.
+
+## Sink
+
+A **sink** writes records to an external system. Sinks accept batches and most
+expose a `batch_size` knob that controls the natural unit of work (a multi-row
+`INSERT`, a `_bulk` body, an `insertAll` request, and so on).
+
+## Transform
+
+An optional **transform** reshapes each record between source and sink. The
+config-exposed transforms are `flatten`, `rename_keys`, and `snake_case`;
+additional custom transforms are available from Rust.
+
+## Pipeline
+
+The **pipeline** connects a source to a sink. It drives the source's
+`stream_pages`, applies transforms, and writes each page to the sink as it
+arrives — then flushes and records progress. Memory is bounded at one
+`batch_size` page on both sides regardless of total volume.
+
+```rust,ignore
+let result = Pipeline::new(&source, &sink).run().await?;
+```
+
+## State store & bookmarks
+
+For incremental and resumable runs, a **state store** persists a *bookmark* after
+each page the sink confirms. On the next run the source resumes from that
+bookmark. Built-in backends are `memory` and `file` (in `faucet-core`); `redis`
+and `postgres` backends live in their own crates.
+
+This is what makes change-data-capture safe: the PostgreSQL CDC source only tells
+Postgres it can recycle write-ahead log up to a bookmark that has actually been
+persisted.
+
+## Dead-letter queue (DLQ)
+
+A pipeline can attach a **DLQ** sink. When a sink reports per-row failures, the
+failing rows are wrapped in a fixed-shape envelope and routed to the DLQ before
+the page's bookmark advances — so a few bad records don't abort the whole run.
+The `on_batch_error` policy (`propagate` vs `dlq_all`) decides what happens when
+a sink can't report per-row results.
+
+## Matrix & DAGs
+
+A single config can fan out into many invocations with a `matrix:` block — either
+independent rows or a parent/child **DAG** where a child runs once per record
+produced by its parent. See the [matrix DAG tutorial](../tutorials/matrix-dag.md).
+
+## Observability
+
+Every source, sink, transform, and state operation is automatically wrapped to
+emit `tracing` spans and `metrics` counters/histograms — no per-connector code.
+See [Observability](../operations/observability.md).

--- a/docs/book/src/getting-started/first-pipeline.md
+++ b/docs/book/src/getting-started/first-pipeline.md
@@ -1,0 +1,88 @@
+# Your first pipeline
+
+This walkthrough moves a local CSV file to JSON Lines — no external services
+required, so it works immediately after `cargo install faucet-cli`.
+
+## 1. Create some input
+
+```bash
+mkdir -p data out
+cat > data/input.csv <<'CSV'
+id,name,city
+1,Ada,London
+2,Grace,New York
+3,Linus,Helsinki
+CSV
+```
+
+## 2. Write a config
+
+Create `pipeline.yaml`:
+
+```yaml
+version: 1
+name: csv_to_jsonl
+
+pipeline:
+  source:
+    type: csv
+    config:
+      path: ./data/input.csv
+  sink:
+    type: jsonl
+    config:
+      path: ./out/records.jsonl
+```
+
+`faucet run` auto-discovers a `faucet.yaml` / `faucet.yml` / `faucet.json` in the
+current directory (and a sibling `.env`), so you can also name the file
+`faucet.yaml` and just run `faucet run`.
+
+## 3. Validate, then run
+
+```bash
+faucet validate pipeline.yaml
+faucet run pipeline.yaml
+```
+
+```bash
+$ cat out/records.jsonl
+{"id":"1","name":"Ada","city":"London"}
+{"id":"2","name":"Grace","city":"New York"}
+{"id":"3","name":"Linus","city":"Helsinki"}
+```
+
+## 4. Preview without writing
+
+To see what a source emits without touching a sink, use `preview` — it runs the
+source and prints records to stdout:
+
+```bash
+faucet preview pipeline.yaml --limit 5
+```
+
+## 5. Scaffold from a connector's schema
+
+`faucet init` generates a commented config skeleton from any connector's JSON
+schema, marking required fields and commenting out optional ones:
+
+```bash
+faucet init my_pipeline --source rest --sink postgres
+```
+
+## Add a transform
+
+Insert a `transforms:` list between source and sink to reshape records. For
+example, normalize keys to `snake_case`:
+
+```yaml
+pipeline:
+  source: { type: csv, config: { path: ./data/input.csv } }
+  transforms:
+    - type: snake_case
+  sink: { type: jsonl, config: { path: ./out/records.jsonl } }
+```
+
+Built-in config transforms are `flatten`, `rename_keys`, and `snake_case`.
+
+Next: [core concepts](./concepts.md).

--- a/docs/book/src/getting-started/installation.md
+++ b/docs/book/src/getting-started/installation.md
@@ -1,0 +1,58 @@
+# Installation
+
+## The `faucet` CLI
+
+The CLI is the fastest way to start. Install it from crates.io:
+
+```bash
+cargo install faucet-cli
+```
+
+This gives you a `faucet` binary with **every** first-party connector compiled in,
+so it can run any of the published example configs out of the box.
+
+### Slim builds
+
+Every connector is a Cargo feature, so you can build a smaller binary with only
+what you need:
+
+```bash
+cargo install faucet-cli --no-default-features \
+  --features "source-rest,sink-jsonl,sink-stdout,transforms"
+```
+
+Run `faucet list` to see which sources and sinks are compiled into your binary.
+
+## The library
+
+To embed pipelines in your own Rust program, depend on the umbrella crate and
+enable the connectors you need:
+
+```toml
+[dependencies]
+# Default features include the REST source only.
+faucet-stream = "0.2"
+
+# Or enable specific connectors:
+faucet-stream = { version = "0.2", features = ["source-rest", "sink-postgres", "sink-s3"] }
+
+# Or everything:
+faucet-stream = { version = "0.2", features = ["full"] }
+```
+
+Feature groups: `source` (all sources), `sink` (all sinks), `state` (all
+state-store backends), `full` (everything), and `compression` (gzip/zstd on the
+file-shaped connectors you've enabled).
+
+You can also depend on individual connector crates directly
+(`faucet-source-rest`, `faucet-sink-bigquery`, …) — each depends only on
+`faucet-core`.
+
+## Requirements
+
+- A recent stable Rust toolchain (see the repo's `rust-toolchain.toml` for the
+  current MSRV).
+- Some connectors link native libraries — the Kafka connectors build
+  `librdkafka` and need `cmake` and a C toolchain available at compile time.
+
+Next: [run your first pipeline](./first-pipeline.md).

--- a/docs/book/src/introduction.md
+++ b/docs/book/src/introduction.md
@@ -1,0 +1,51 @@
+# faucet-stream
+
+**The fast, config-driven way to move data in Rust.**
+
+faucet-stream wires **19 source** and **16 sink** connectors together with a single
+`faucet` binary that runs pipelines declaratively from a YAML/JSON file — no Rust
+code required. Or skip the binary and embed the same engine in your own service
+through the typed `Source` / `Sink` traits.
+
+```bash
+cargo install faucet-cli
+faucet init my_pipeline --source postgres --sink bigquery
+faucet validate pipeline.yaml
+faucet run pipeline.yaml
+```
+
+## What you get
+
+- **Fast and reliable by default** — native streaming with bounded memory,
+  connection pooling, multi-row inserts, bulk APIs, and parallel I/O.
+- **Config-driven _or_ embeddable** — run `faucet run pipeline.yaml`, or call
+  `Pipeline::new(&source, &sink).run().await?` from Rust.
+- **A runtime, not just connectors** — incremental + resumable replication,
+  PostgreSQL change-data-capture, dead-letter queues, automatic retries, and
+  built-in Prometheus metrics + `tracing` spans, all with zero per-connector code.
+- **Pay only for what you use** — every connector is a Cargo feature.
+
+## How this book is organized
+
+- **[Getting Started](./getting-started/installation.md)** — install, run your
+  first pipeline in five minutes, and learn the core concepts.
+- **[Tutorials](./tutorials/rest-to-bigquery.md)** — end-to-end walkthroughs of
+  real pipelines (incremental REST → BigQuery, Postgres CDC, DAGs, embedding).
+- **[Cookbook](./cookbook/pagination.md)** — short, task-oriented recipes for
+  pagination, auth, state, dead-letter queues, and compression.
+- **[Reference](./reference/connectors.md)** — the connector catalog, CLI
+  commands, and config-file grammar.
+- **[Operations](./operations/deploying.md)** — deploying, observability,
+  performance tuning, and troubleshooting.
+- **[Extending](./extending/authoring-connectors.md)** — author and publish your
+  own `faucet-source-*` / `faucet-sink-*` crate.
+
+## Where else to look
+
+- **API docs:** every crate is on [docs.rs](https://docs.rs/faucet-stream),
+  rendered with all features so optional connectors are visible.
+- **Source & issues:** [github.com/PawanSikawat/faucet-stream](https://github.com/PawanSikawat/faucet-stream).
+- **Runnable examples:** the [`cli/examples/`](https://github.com/PawanSikawat/faucet-stream/tree/main/cli/examples)
+  directory ships a config for nearly every connector pair, and
+  [`examples/`](https://github.com/PawanSikawat/faucet-stream/tree/main/examples)
+  has a `docker-compose` stack so they run locally.

--- a/docs/book/src/operations/deploying.md
+++ b/docs/book/src/operations/deploying.md
@@ -1,0 +1,55 @@
+# Deploying faucet
+
+faucet runs pipelines **to completion** — it's not a long-running daemon. That
+makes deployment simple: schedule the binary, point it at a config, and let it
+exit. Durable state (bookmarks) lets the next run pick up where the last left off.
+
+## Patterns
+
+### Cron / scheduled jobs
+
+The most common deployment. Run on an interval; incremental replication + a
+durable state store mean each run only fetches what's new.
+
+```bash
+# crontab: every 15 minutes
+*/15 * * * * faucet run /etc/faucet/events.yaml >> /var/log/faucet.log 2>&1
+```
+
+### Containers
+
+Build a slim image with only the connectors you need, and supply config via a
+mounted file or entirely from the environment:
+
+```dockerfile
+FROM rust:slim AS build
+RUN cargo install faucet-cli --no-default-features \
+    --features "source-rest,sink-bigquery,state-postgres,observability"
+
+FROM debian:stable-slim
+COPY --from=build /usr/local/cargo/bin/faucet /usr/local/bin/faucet
+ENTRYPOINT ["faucet", "run"]
+```
+
+With `faucet run --from-env` you can drive the whole pipeline from `FAUCET_*`
+environment variables — no config file in the image. See the
+[CLI reference](../reference/cli.md#environment-only-mode).
+
+### Kubernetes CronJob
+
+Wrap the container above in a `CronJob`. Use the `postgres` or `redis` state
+backend so bookmarks survive pod restarts, and scrape the metrics endpoint (see
+[Observability](./observability.md)).
+
+## Secrets
+
+Never commit secrets. Use `${env:VAR}` / `${file:PATH}` in the config and inject
+real values through your platform's secret mechanism (Kubernetes secrets, Docker
+secrets, a mounted `.env`, etc.).
+
+## Exit codes & retries
+
+`faucet run` exits non-zero when a pipeline fails (subject to the
+`execution.on_error` policy and any DLQ). Let your scheduler's retry/alert
+mechanism react to a non-zero exit; because bookmarks only advance after the sink
+confirms, a retried run resumes safely.

--- a/docs/book/src/operations/observability.md
+++ b/docs/book/src/operations/observability.md
@@ -1,0 +1,59 @@
+# Observability
+
+Every source, sink, transform, and state-store operation is automatically wrapped
+to emit `tracing` spans and `metrics` counters/histograms. Connector authors
+write no observability code — they only override `connector_name()` for a
+friendly label.
+
+## Enabling the Prometheus endpoint
+
+The CLI's `observability` feature (on by default in the full build) installs a
+Prometheus exporter. Configure it from the pipeline config or environment; once
+running, scrape the listen address with Prometheus.
+
+## Common labels
+
+`pipeline`, `row` (matrix row id; empty for non-matrix runs), and `connector`
+(from `connector_name()`). `run_id` is a span attribute only — it's high
+cardinality and never a Prometheus label.
+
+## Key metrics
+
+- **Source:** `faucet_source_records_total`, `faucet_source_errors_total{kind}`,
+  `faucet_source_page_duration_seconds`, `faucet_source_in_flight`.
+- **Sink:** `faucet_sink_records_total`, `faucet_sink_writes_total`,
+  `faucet_sink_errors_total`, `faucet_sink_write_duration_seconds`,
+  `faucet_sink_flush_duration_seconds`, `faucet_sink_in_flight`.
+- **Transform:** `faucet_transform_records_total`,
+  `faucet_transform_duration_seconds`.
+- **State:** `faucet_state_{get,put,delete}_total` (get carries
+  `outcome=hit|miss`), `faucet_state_errors_total{op,kind}`, plus duration
+  histograms.
+- **Pipeline:** `faucet_pipeline_runs_total{status=ok|err,kind}`,
+  `faucet_pipeline_run_duration_seconds`, `faucet_pipeline_in_flight`,
+  `faucet_pipeline_seconds_since_last_bookmark`,
+  `faucet_pipeline_last_bookmark_unix_seconds`.
+- **Build:** `faucet_build_info{version}` is set to `1` — `group_left` it onto
+  other metrics to annotate dashboards with the running version.
+
+## Reliability properties
+
+- **Drop-guard timers** sample durations even when a task is cancelled.
+- **Panic isolation** — a panicking connector surfaces as a `Panic` error kind
+  rather than crashing the process.
+- **Idempotent install** — installing the recorder/subscriber twice warns rather
+  than panics.
+
+## Cardinality rules
+
+Never use high-cardinality values (record ids, URLs, query strings) as metric
+labels. `parent_record_key` in a DAG is a span attribute only. Connector authors
+must return a non-empty `&'static str` from `connector_name()`.
+
+## Tracing
+
+Spans carry `run_id`, `pipeline`, `row`, and per-operation timing. Point a
+`tracing` subscriber at your logging/trace backend; control verbosity with
+`--log-level` or `FAUCET_LOG`.
+
+> Full design: `docs/superpowers/specs/2026-05-23-observability-otel-prometheus-design.md`.

--- a/docs/book/src/operations/troubleshooting.md
+++ b/docs/book/src/operations/troubleshooting.md
@@ -1,0 +1,60 @@
+# Troubleshooting & FAQ
+
+## My config won't parse / validate
+
+Run `faucet validate <config>` — it reports one line per expanded row. Common
+causes:
+
+- **`version` missing or not `1`** — the top-level `version: 1` is required.
+- **Old top-level `source:` / `sink:`** — these must live under `pipeline:`.
+  faucet rejects the pre-`pipeline:` shape with a hint.
+- **Unknown connector `type`** — run `faucet list` to see what's compiled in; you
+  may have a slim build without that feature.
+- **`InterpolationCycle`** — a `${vars.X}` / template reference forms a loop.
+
+## A `${env:VAR}` isn't being substituted
+
+Load-time interpolation reads the environment and a sibling `.env`. If the value
+is empty, the var isn't set (or `--no-env-file` disabled the `.env`). Use
+`--env-file PATH` to point at a specific file.
+
+## "feature not enabled" / connector missing
+
+Your binary was built without that connector. Reinstall with the feature:
+`cargo install faucet-cli --features "source-foo,sink-bar"`, or use the full
+build (the default `cargo install faucet-cli`).
+
+## docs.rs shows fewer APIs than I expected
+
+It shouldn't anymore — every crate is configured to build with all features. If
+you're looking at an old version, check the latest release.
+
+## Kafka connector fails to build
+
+The Kafka crates build `librdkafka`, which needs `cmake` and a C toolchain. Make
+sure those are installed in your build environment (CI installs
+`libsasl2-dev libssl-dev libcurl4-openssl-dev cmake build-essential`).
+
+## Postgres CDC retains a lot of WAL
+
+A CDC replication slot retains WAL until a run advances the bookmark. If you
+created a permanent slot and stopped running the pipeline, Postgres keeps WAL
+forever. Either run the pipeline regularly, drop the slot
+(`PostgresCdcSource::drop_slot()` or `SELECT pg_drop_replication_slot(...)`), or
+use `slot_type: temporary` for experiments. See the
+[CDC tutorial](../tutorials/postgres-cdc.md).
+
+## Some records failed but I don't want the run to abort
+
+Attach a [dead-letter queue](../cookbook/dlq.md) so failing rows are captured and
+the rest commit.
+
+## Run is slower / using more memory than expected
+
+Tune `batch_size` and concurrency — see [Performance tuning](./tuning.md). Use
+the [metrics](./observability.md) to find the bottleneck.
+
+## Where do I report a bug or request a connector?
+
+Open an issue at
+[github.com/PawanSikawat/faucet-stream/issues](https://github.com/PawanSikawat/faucet-stream/issues).

--- a/docs/book/src/operations/tuning.md
+++ b/docs/book/src/operations/tuning.md
@@ -1,0 +1,53 @@
+# Performance tuning
+
+faucet is built to be fast by default, but a few knobs let you trade memory for
+throughput on a given pipeline.
+
+## `batch_size`
+
+The single most important knob. It bounds how many records are buffered and sets
+each sink's natural write unit (multi-row `INSERT`, `_bulk` body, `insertAll`
+request, Redis pipeline, …).
+
+- **Default:** 1000. **Max:** 1,000,000.
+- **Larger** = fewer, bigger requests = more throughput, more memory per batch.
+- **`batch_size: 0`** = "no batching": the source emits the whole result set in
+  one page and the sink writes it in one request. Use it for small lookup tables,
+  or for sinks that prefer one large request (load-job-style ingestion).
+
+Set it on the sink (authoritative) and/or source. Streaming keeps memory at
+O(batch_size) on both sides regardless of total volume.
+
+## Connection pooling
+
+Database connectors use configurable pools — `max_connections` defaults to 10 for
+sources and 5 for sinks. Raise it for highly concurrent workloads; keep it under
+your database's connection limit.
+
+## Concurrency
+
+- The REST source can process partitions concurrently (`partition_concurrency`).
+- S3/GCS sources and sinks read/write objects in parallel
+  (`buffer_unordered`-style concurrency).
+- The HTTP sink sends per-record requests concurrently under a semaphore.
+- Kafka sink uses `FuturesUnordered` batched sends with QueueFull retry.
+- At the pipeline level, `execution.max_concurrent` bounds how many matrix rows
+  run at once.
+
+## Retries
+
+HTTP-based sources retry with exponential backoff + jitter on retriable failures;
+the REST source additionally honors `429` / `Retry-After`. Tune `max_retries` and
+`retry_backoff` per connector. A permanently throttled endpoint surfaces a
+`RateLimited` error rather than hanging.
+
+## Choosing values
+
+- **Many small rows, row-oriented sink (Postgres/MySQL):** larger `batch_size`
+  (5k–50k) for fat multi-row INSERTs.
+- **Large objects (Parquet/S3):** moderate `batch_size`; lean on parallel I/O.
+- **Tiny lookup tables / COPY-style loads:** `batch_size: 0`.
+- **Memory-constrained host:** smaller `batch_size` to cap per-batch footprint.
+
+Measure with the [metrics](./observability.md) — `faucet_sink_write_duration_seconds`
+and `faucet_source_page_duration_seconds` tell you where time goes.

--- a/docs/book/src/reference/cli.md
+++ b/docs/book/src/reference/cli.md
@@ -1,0 +1,73 @@
+# CLI commands
+
+The `faucet` binary exposes these commands. Pass `--log-level <level>` (or set
+`FAUCET_LOG`) to control logging.
+
+| Command | What it does |
+|---------|--------------|
+| `faucet run [config]` | Run the pipeline(s) in a config file. |
+| `faucet validate [config]` | Parse, expand, and validate a config without running it. |
+| `faucet preview [config]` | Run only the source side and print records to stdout. |
+| `faucet schema <target>` | Print the JSON Schema for a connector or the DLQ. |
+| `faucet list` | List every compiled-in source and sink with a one-line description. |
+| `faucet init [name]` | Scaffold a commented config skeleton from connector schemas. |
+
+`[config]` is optional for `run` / `validate` / `preview`: if omitted, faucet
+auto-discovers `faucet.yaml` → `.yml` → `.json` in the current directory.
+
+## `run`
+
+```bash
+faucet run pipeline.yaml
+faucet run                       # auto-discover faucet.yaml in cwd
+faucet run --from-env            # build the pipeline entirely from FAUCET_* env vars
+faucet run pipeline.yaml --env-file prod.env
+faucet run pipeline.yaml --no-env-file
+```
+
+## `validate`
+
+Reports one line per expanded matrix row. Use it in CI to catch config errors
+before deploying.
+
+```bash
+faucet validate pipeline.yaml
+```
+
+## `preview`
+
+Runs the first root row's source and prints records (via the stdout sink).
+Children aren't previewed because they need parent records to resolve
+`${parent.path}` tokens.
+
+```bash
+faucet preview pipeline.yaml --limit 10
+```
+
+## `schema`
+
+```bash
+faucet schema source rest
+faucet schema sink bigquery
+faucet schema dlq
+```
+
+## `init`
+
+```bash
+faucet init my_pipeline --source postgres --sink bigquery
+```
+
+Required fields are surfaced with a typed placeholder and a `# REQUIRED` marker;
+optional fields are commented out so connector defaults apply. The interactive
+mode (`--interactive`) is gated behind the `cli-interactive` feature.
+
+## Environment-only mode
+
+`faucet run --from-env` assembles a pipeline from a `FAUCET_*` snapshot
+(`FAUCET_SOURCE_*`, `FAUCET_SINK_*`, `FAUCET_STATE_*`, `FAUCET_TRANSFORM_<N>_*`),
+which is handy for containerized deployments where everything comes from the
+environment. Nested/tagged-enum fields use a `*_JSON` suffix.
+
+> The complete config grammar (matrix, templates, vars, execution) lives in
+> [`cli/README.md`](https://github.com/PawanSikawat/faucet-stream/blob/main/cli/README.md).

--- a/docs/book/src/reference/config.md
+++ b/docs/book/src/reference/config.md
@@ -1,0 +1,64 @@
+# Configuration file format
+
+A faucet config is a YAML or JSON document with this top-level shape:
+
+```yaml
+version: 1                 # required, must be 1
+name: my_pipeline          # optional; used in state keys and metrics
+vars: {}                   # optional; reusable values referenced as ${vars.X}
+pipeline:                  # required
+  source: { type: …, config: { … } }
+  transforms: []           # optional list
+  sink:   { type: …, config: { … } }
+  state:  { type: …, config: { … } }   # optional
+  dlq:    { … }            # optional dead-letter queue
+matrix: []                 # optional per-row overrides / DAG
+execution:                 # optional
+  max_concurrent: 4
+  on_error: continue       # continue | stop
+```
+
+## `pipeline`
+
+`source` and `sink` each take a `type` (the connector name) and a `config`
+object whose fields are that connector's schema — see `faucet schema source
+<name>`. `transforms` is an ordered list applied to every record. `state`
+attaches a [state store](../cookbook/state.md); `dlq` attaches a
+[dead-letter queue](../cookbook/dlq.md).
+
+## Interpolation
+
+Three stages resolve placeholders:
+
+- **Load time:** `${env:VAR}`, `${file:PATH}`, `${secret:VAR}` are resolved when
+  the file is read. `${vars.X}` resolves against the top-level `vars:` block;
+  `${sources.NAME.PATH}` / `${sinks.NAME.PATH}` resolve against named templates.
+- **Runtime:** `${row_id.dotted.path}` tokens are resolved per parent record in
+  DAG runs.
+
+Reference cycles surface as a clear `InterpolationCycle` error.
+
+## `matrix`
+
+Each row is deep-merged onto `pipeline` (scalars replace, objects merge, arrays
+replace). A row with `parent:` runs once per parent record. See the
+[matrix DAG tutorial](../tutorials/matrix-dag.md). For DRY configs with many
+rows, define named templates under `pipeline.sources` / `pipeline.sinks` and
+select them per row with `ref:`.
+
+## `execution`
+
+- `max_concurrent` — one shared concurrency budget across roots and child
+  fan-outs.
+- `on_error` — `continue` (siblings finish; failed subtree skipped) or `stop`
+  (abort pending and in-flight work on first failure).
+
+## Discovery & env files
+
+`run` / `validate` / `preview` auto-discover `faucet.yaml` → `.yml` → `.json` in
+the current directory, and load a sibling `.env` unless `--no-env-file` is given
+(`--env-file PATH` points elsewhere).
+
+> The authoritative, exhaustive grammar — including every matrix and template
+> edge case — is in
+> [`cli/README.md`](https://github.com/PawanSikawat/faucet-stream/blob/main/cli/README.md).

--- a/docs/book/src/reference/connectors.md
+++ b/docs/book/src/reference/connectors.md
@@ -1,0 +1,64 @@
+# Connector catalog
+
+faucet-stream ships **19 sources** and **16 sinks**. Each is a Cargo feature
+(`source-<name>` / `sink-<name>`) and an independently published crate. Full API
+docs for every connector are on [docs.rs](https://docs.rs/faucet-stream).
+
+Run `faucet list` to see what's compiled into your binary, and
+`faucet schema source <name>` / `faucet schema sink <name>` for a connector's
+exact config fields.
+
+## Sources
+
+| Connector | Feature | Notes |
+|-----------|---------|-------|
+| REST | `source-rest` | auth, 6 pagination styles, JSONPath extraction, schema inference, incremental |
+| GraphQL | `source-graphql` | cursor pagination, variable injection |
+| XML / SOAP | `source-xml` | XML→JSON, dot-path extraction |
+| gRPC | `source-grpc` | dynamic protobuf; unary + server-streaming |
+| PostgreSQL | `source-postgres` | run SQL, rows as JSON |
+| PostgreSQL CDC | `source-postgres-cdc` | logical replication, resumable |
+| MySQL | `source-mysql` | run SQL, rows as JSON |
+| SQLite | `source-sqlite` | run SQL, rows as JSON |
+| AWS S3 | `source-s3` | JSONL, JSON array, raw text |
+| Google Cloud Storage | `source-gcs` | JSONL, JSON array, raw text |
+| MongoDB | `source-mongodb` | `find()` with filter/projection/sort |
+| Redis | `source-redis` | streams, lists, key patterns |
+| Webhook | `source-webhook` | temporary HTTP server collecting POSTs |
+| CSV | `source-csv` | CSV files as JSON |
+| Elasticsearch | `source-elasticsearch` | search/scroll API |
+| Apache Kafka | `source-kafka` | consumer, idle/max-messages termination |
+| Apache Parquet | `source-parquet` | local/glob/S3, vectorized Arrow reader, projection |
+| BigQuery | `source-bigquery` | `jobs.query` + pageToken pagination |
+| Snowflake | `source-snowflake` | SQL REST API, server-side partitions, JWT/OAuth |
+
+## Sinks
+
+| Connector | Feature | Notes |
+|-----------|---------|-------|
+| BigQuery | `sink-bigquery` | streaming inserts, per-row DLQ |
+| PostgreSQL | `sink-postgres` | JSONB or auto-mapped columns, multi-row INSERT |
+| JSON Lines | `sink-jsonl` | buffered file output |
+| Snowflake | `sink-snowflake` | SQL REST API, JWT/OAuth |
+| MySQL | `sink-mysql` | JSON column or auto-mapped columns |
+| SQLite | `sink-sqlite` | transaction-wrapped batches |
+| AWS S3 | `sink-s3` | JSONL files, parallel uploads |
+| Google Cloud Storage | `sink-gcs` | JSONL files |
+| MongoDB | `sink-mongodb` | `insert_many` |
+| Redis | `sink-redis` | streams, lists, key-value |
+| CSV | `sink-csv` | CSV rows, buffered |
+| Elasticsearch | `sink-elasticsearch` | `_bulk` API, per-row DLQ |
+| HTTP | `sink-http` | POST records, concurrent |
+| Stdout | `sink-stdout` | JSON Lines, pretty JSON, or TSV |
+| Apache Kafka | `sink-kafka` | producer, batched sends, multi-topic routing |
+| Apache Parquet | `sink-parquet` | local/S3, schema inference, row/byte rollover |
+
+## Streaming & batching
+
+Most sources stream natively (bounded memory). Most sinks expose a `batch_size`
+that controls their natural write unit. The default batch size is 1000;
+`batch_size: 0` means "no batching" (one large request) — useful for small lookup
+tables or load-job-style sinks. See [Performance tuning](../operations/tuning.md).
+
+> A capability matrix with per-connector streaming/state/auth/compression columns
+> is planned (WS-6 of the adoption roadmap).

--- a/docs/book/src/tutorials/library.md
+++ b/docs/book/src/tutorials/library.md
@@ -1,0 +1,71 @@
+# Embedding faucet as a Rust library
+
+The `faucet` CLI is a thin wrapper over the same library you can use directly.
+Embedding gives you typed configs, compile-time connector selection, and the
+ability to build a `Source` or `Sink` from your own code.
+
+## Add the dependency
+
+```toml
+[dependencies]
+faucet-stream = { version = "0.2", features = ["source-rest", "sink-bigquery"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+```
+
+## Build and run a pipeline
+
+```rust,ignore
+use faucet_stream::source::rest::{RestStream, RestStreamConfig, Auth, PaginationStyle};
+use faucet_stream::sink::bigquery::{BigQuerySink, BigQuerySinkConfig};
+use faucet_stream::Pipeline;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let source = RestStream::new(RestStreamConfig {
+        base_url: "https://api.example.com".into(),
+        path: "/v1/events".into(),
+        auth: Auth::Bearer { token: std::env::var("API_TOKEN")? },
+        ..Default::default()
+    })?;
+
+    let sink = BigQuerySink::new(/* BigQuerySinkConfig { .. } */).await?;
+
+    let result = Pipeline::new(&source, &sink).run().await?;
+    println!("moved {} records", result.records_written);
+    Ok(())
+}
+```
+
+> Exact field names and constructors are documented per crate on
+> [docs.rs](https://docs.rs/faucet-stream) (rendered with all features, so every
+> connector's API is visible). Treat the snippet above as the shape, not the
+> literal field list.
+
+## Durable state and streaming
+
+Wire a state store for resumable runs, and use the streaming entry point when you
+want to control batching explicitly:
+
+```rust,ignore
+use std::sync::Arc;
+use faucet_stream::{Pipeline, FileStateStore};
+
+let state = Arc::new(FileStateStore::new("./state")?);
+let result = Pipeline::new(&source, &sink)
+    .with_state_store(state)
+    .run()
+    .await?;
+```
+
+The pipeline reads the bookmark before fetching and persists a new one only after
+the sink confirms each page — so a crash never loses unwritten data.
+
+## Why embed instead of shelling out to the CLI?
+
+- **Typed configs** — config structs implement `serde` + `JsonSchema`, so you get
+  compile-time checking and can generate UIs/forms from the schema.
+- **Custom connectors** — implement the `Source` / `Sink` traits for systems we
+  don't ship, and run them through the same `Pipeline`. See
+  [authoring a connector](../extending/authoring-connectors.md).
+- **One process** — no subprocess, no temp config files; integrate pipelines into
+  an existing service, job runner, or test harness.

--- a/docs/book/src/tutorials/matrix-dag.md
+++ b/docs/book/src/tutorials/matrix-dag.md
@@ -1,0 +1,77 @@
+# Multi-pipeline DAGs with `matrix`
+
+A single config can drive many pipeline invocations. The `matrix:` block lists
+rows that are each deep-merged onto the base `pipeline:`. Rows can be independent
+(fan-out) or form a parent/child **DAG** where a child runs once per record the
+parent produced.
+
+## Independent fan-out
+
+Each row overrides part of the pipeline and runs independently, bounded by
+`execution.max_concurrent`:
+
+```yaml
+version: 1
+name: multi_region
+pipeline:
+  source: { type: rest, config: { base_url: https://api.example.com, method: GET } }
+  sink:   { type: jsonl, config: {} }
+execution:
+  max_concurrent: 4
+  on_error: continue   # or `stop`
+matrix:
+  - id: us
+    source: { config: { path: /v1/us/events } }
+    sink:   { config: { path: us.jsonl } }
+  - id: eu
+    source: { config: { path: /v1/eu/events } }
+    sink:   { config: { path: eu.jsonl } }
+```
+
+## Parent/child DAG
+
+A row with `parent:` runs once per record produced by the parent. Tokens like
+`${parent_id.dotted.path}` are resolved per parent record at runtime:
+
+```yaml
+version: 1
+name: dag_users_posts
+pipeline:
+  source: { type: rest, config: { base_url: https://api.example.com, method: GET, records_path: $.data[*] } }
+  sink:   { type: jsonl, config: { append: false } }
+matrix:
+  # Root: fetch the users list once.
+  - id: users
+    source: { config: { path: /v1/users, name: users } }
+    sink:   { config: { path: users.jsonl } }
+  # Child: for each user record, fetch that user's posts.
+  - id: posts
+    parent: users
+    parent_key: id
+    source: { config: { path: /v1/users/${users.id}/posts, name: posts } }
+    sink:   { config: { path: posts-${users.id}.jsonl } }
+```
+
+The child's state key is suffixed with the parent record's key, so each per-user
+fetch resumes independently.
+
+## Merge semantics
+
+A row is deep-merged onto the base `pipeline`: scalars replace, objects merge
+recursively, and arrays replace wholesale. That single rule defines all override
+behavior.
+
+## Named templates (DRY)
+
+For many heterogeneous rows, define reusable source/sink templates under
+`pipeline.sources` / `pipeline.sinks` and a top-level `vars:` block, then select
+them per row with `ref:`. See [`cli/README.md`](https://github.com/PawanSikawat/faucet-stream/blob/main/cli/README.md)
+for the full grammar.
+
+## Error handling
+
+`execution.on_error: continue` lets sibling subtrees finish when one fails (the
+failed subtree is skipped); `stop` aborts pending and in-flight work on the first
+failure. `stop` cancels in-flight tasks at their next `await`, which can leave
+partial sink state — acceptable for idempotent sinks, something to know for
+others.

--- a/docs/book/src/tutorials/postgres-cdc.md
+++ b/docs/book/src/tutorials/postgres-cdc.md
@@ -1,0 +1,73 @@
+# PostgreSQL CDC → JSONL
+
+Change data capture (CDC) streams every `INSERT`/`UPDATE`/`DELETE` from a
+PostgreSQL table by reading its write-ahead log via logical replication — no
+polling, no `updated_at` column required.
+
+## Prepare Postgres
+
+CDC needs logical replication enabled (`wal_level = logical`) and a publication
+for the tables you want to follow:
+
+```sql
+CREATE TABLE IF NOT EXISTS users (id int4 PRIMARY KEY, name text);
+CREATE PUBLICATION faucet_pub FOR TABLE users;
+```
+
+The bundled [`examples/docker-compose.yml`](https://github.com/PawanSikawat/faucet-stream/tree/main/examples)
+starts a Postgres already configured for logical replication.
+
+## Config
+
+```yaml
+version: 1
+pipeline:
+  source:
+    type: postgres-cdc
+    config:
+      connection_url: postgres://faucet:faucet@localhost:5432/appdb
+      slot_name: faucet_slot
+      publication_name: faucet_pub
+      create_slot_if_missing: true
+      idle_timeout: 30
+  sink:
+    type: jsonl
+    config:
+      path: ./out/changes.jsonl
+      append: true
+  state:
+    type: file
+    config:
+      path: ./state
+```
+
+```bash
+faucet run postgres_cdc_to_jsonl.yaml
+```
+
+Open a `psql` session and `INSERT`/`UPDATE`/`DELETE` some rows — the connector
+drains them every fetch cycle until `idle_timeout` fires.
+
+## Why the state store matters here
+
+The CDC source advances Postgres's `confirmed_flush_lsn` (the point up to which
+Postgres may recycle WAL) **only from a durable bookmark** — i.e. after the
+pipeline has persisted the position. It never confirms WAL for changes that
+haven't been written to the sink. That means a crash mid-run cannot lose data:
+on restart the source resumes from the last persisted bookmark. The tradeoff is
+that WAL is retained until the next run advances the bookmark, so don't point a
+CDC slot at a table and then never run it.
+
+The state key is `postgres-cdc:<slot>`. Use a durable backend (`redis` /
+`postgres`) in production so the bookmark survives the loss of the local disk.
+
+## Slot lifecycle
+
+- `slot_type: temporary` drops the slot when the connection closes — good for
+  experiments. `permanent` (the default) keeps it, which retains WAL until you
+  drop it.
+- Free an abandoned slot's WAL with `PostgresCdcSource::drop_slot()` (library)
+  or by dropping the replication slot in Postgres.
+- `tls: disable | require | verify_ca | verify_full` configures the replication
+  connection (default `disable` = plaintext; use `verify_full` over untrusted
+  networks).

--- a/docs/book/src/tutorials/rest-to-bigquery.md
+++ b/docs/book/src/tutorials/rest-to-bigquery.md
@@ -1,0 +1,94 @@
+# REST API → BigQuery (incremental)
+
+This tutorial pulls records from a paginated REST API and streams them into a
+BigQuery table, then converts it to an **incremental** pipeline that only fetches
+new rows on each run.
+
+## Full-table version
+
+```yaml
+version: 1
+name: rest_to_bigquery
+
+pipeline:
+  source:
+    type: rest
+    config:
+      base_url: https://api.example.com
+      path: /v1/events
+      method: GET
+      name: events
+      auth:
+        type: Basic
+        username: ${env:API_USER}
+        password: ${env:API_PASS}
+      records_path: $.events[*]
+      pagination:
+        type: PageNumber
+        param_name: page
+        start_page: 1
+        page_size: 500
+        page_size_param: per_page
+      max_pages: 200
+      timeout: 45
+      max_retries: 5
+      retry_backoff: 2
+      tolerated_http_errors: [404]
+      replication_method:
+        type: FullTable
+      primary_keys: [event_id]
+      schema_sample_size: 100
+
+  sink:
+    type: bigquery
+    config:
+      project_id: my-gcp-project
+      dataset_id: analytics
+      table_id: events
+      credentials:
+        type: ServiceAccountKeyPath
+        value: service-account.json
+      batch_size: 1000
+```
+
+Secrets come from the environment via `${env:VAR}` — keep credentials out of the
+config file. Put them in a sibling `.env` or export them before running.
+
+```bash
+export API_USER=… API_PASS=…
+faucet run rest_to_bigquery.yaml
+```
+
+The `records_path` is a JSONPath that selects the array of records inside each
+response body; `pagination` walks pages until an empty page or `max_pages`. See
+the [pagination cookbook](../cookbook/pagination.md) for the other styles.
+
+## Make it incremental
+
+Switch `replication_method` from `FullTable` to a key-based incremental method
+and attach a state store so progress survives between runs:
+
+```yaml
+pipeline:
+  source:
+    type: rest
+    config:
+      # … as above …
+      replication_method:
+        type: Incremental
+        cursor_field: updated_at
+      primary_keys: [event_id]
+  sink:
+    # … as above …
+  state:
+    type: file
+    config:
+      path: ./state
+```
+
+Now each run records the maximum `updated_at` it saw; the next run resumes from
+that bookmark. Swap the `file` state store for `redis` or `postgres` for shared,
+durable state across machines — see [state](../cookbook/state.md).
+
+> **Tip:** run `faucet schema source rest` and `faucet schema sink bigquery` to
+> see every available config field with its type and default.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,83 @@
+# Examples
+
+Every connector pair ships a ready-to-run config in
+[`cli/examples/`](../cli/examples/). This directory adds the **local
+infrastructure** to actually run the ones that need a database, broker, or
+object store — one `docker compose up` brings up Postgres, MySQL, Kafka
+(Redpanda), Redis, MongoDB, Elasticsearch, and MinIO (S3-compatible).
+
+## Quick start
+
+```bash
+# 1. Build/install the CLI (full build, all connectors)
+cargo install --path cli            # or: cargo install faucet-cli
+
+# 2. Bring up the local stack
+docker compose -f examples/docker-compose.yml up -d
+
+# 3. Run an example (Postgres CDC → JSONL)
+faucet run cli/examples/postgres_cdc_to_jsonl.yaml
+
+# 4. Tear it down (and wipe volumes)
+docker compose -f examples/docker-compose.yml down -v
+```
+
+A `Makefile` wraps the common steps: `make demo` (no-infra smoke test),
+`make infra-up`, `make infra-down`.
+
+## No infrastructure required
+
+These run immediately after installing the CLI — great for a first smoke test:
+
+| Example | Notes |
+|---------|-------|
+| `csv_to_jsonl.yaml` | the canonical smoke test (`make demo` runs this) |
+| `csv_to_sqlite.yaml` | CSV → local SQLite file |
+| `sqlite_to_jsonl.yaml`, `sqlite_to_csv.yaml` | local SQLite → file |
+| `rest_to_jsonl.yaml`, `rest_streaming.yaml`, `rest_to_stdout_preview.yaml` | point `base_url` at any HTTP API; preview needs no sink setup |
+
+> REST / GraphQL / XML / gRPC / webhook source examples hit an external endpoint
+> (the configs use a placeholder `base_url`). Edit it to a real API — there's no
+> mock server in the stack.
+
+## Covered by the local Docker stack
+
+The service column lists what each example touches; all are provided by
+`docker-compose.yml`. **S3** examples use MinIO — set the S3 endpoint to
+`http://localhost:9000` with credentials `faucet` / `faucetfaucet`.
+
+| Example | Services |
+|---------|----------|
+| `postgres_cdc_to_jsonl.yaml` | postgres (logical replication preconfigured) |
+| `rest_to_postgres.yaml`, `mongodb_to_postgres.yaml`, `graphql_to_postgres.yaml`, `webhook_to_postgres.yaml` | postgres (+ source) |
+| `mysql_to_postgres.yaml` | mysql, postgres |
+| `csv_to_mysql.yaml`, `redis_to_mysql.yaml` | mysql (+ source) |
+| `redis_to_sqlite.yaml`, `mongodb_to_redis.yaml`, `elasticsearch_to_redis.yaml` | redis (+ source) |
+| `kafka_to_jsonl.yaml`, `rest_to_kafka.yaml` | redpanda (Kafka API) |
+| `mongodb_to_elasticsearch.yaml`, `postgres_to_elasticsearch.yaml`, `grpc_to_elasticsearch.yaml` | elasticsearch (+ source) |
+| `elasticsearch_to_s3.yaml`, `postgres_to_s3.yaml`, `rest_to_s3.yaml`, `xml_to_s3.yaml` | minio (S3) (+ source) |
+| `s3_to_postgres.yaml`, `s3_to_mongodb.yaml` | minio (S3), target |
+| `mongodb_to_redis.yaml`, `xml_to_mongodb.yaml` | mongodb (+ source) |
+| `webhook_to_csv.yaml`, `webhook_to_http.yaml`, `grpc_to_http.yaml` | none external beyond the source/HTTP target |
+| `dag_users_posts.yaml`, `rest_users_posts_dag.yaml`, `rest_to_bigquery_matrix.yaml`, `templates_*.yaml` | demonstrate matrix / DAG / template syntax (REST source) |
+
+## Cloud credentials required (not in the stack)
+
+BigQuery, Snowflake, and GCS need real cloud projects and credentials, so they
+can't run against local Docker. Provide credentials via env vars / service-account
+files as each config shows:
+
+`csv_to_bigquery.yaml`, `graphql_to_bigquery.yaml`, `mysql_to_bigquery.yaml`,
+`postgres_to_bigquery.yaml`, `rest_to_bigquery.yaml`, `s3_to_bigquery.yaml`,
+`mysql_to_snowflake.yaml`, `postgres_to_snowflake.yaml`, `s3_to_snowflake.yaml`.
+
+## Tips
+
+- `faucet validate <config>` checks any config without running it (and without
+  infra) — useful in CI.
+- `faucet preview <config> --limit 10` runs just the source and prints records.
+- Most examples read secrets from the environment via `${env:VAR}`; export them
+  or drop a sibling `.env` before running.
+- The Postgres service seeds a `users` table and a `faucet_pub` publication (see
+  [`infra/postgres-init.sql`](infra/postgres-init.sql)) so the CDC and query
+  examples work immediately.

--- a/examples/demo/input.csv
+++ b/examples/demo/input.csv
@@ -1,0 +1,4 @@
+id,name,city
+1,Ada,London
+2,Grace,New York
+3,Linus,Helsinki

--- a/examples/demo/pipeline.yaml
+++ b/examples/demo/pipeline.yaml
@@ -1,0 +1,14 @@
+# Self-contained no-infrastructure demo: CSV -> JSON Lines.
+# Run from the repo root with `make demo`, or directly:
+#   faucet run examples/demo/pipeline.yaml
+version: 1
+name: demo
+pipeline:
+  source:
+    type: csv
+    config:
+      path: examples/demo/input.csv
+  sink:
+    type: jsonl
+    config:
+      path: target/demo/out.jsonl

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -1,0 +1,129 @@
+# Local infrastructure for running the faucet-stream examples.
+#
+#   docker compose -f examples/docker-compose.yml up -d
+#   faucet run cli/examples/postgres_cdc_to_jsonl.yaml
+#   docker compose -f examples/docker-compose.yml down -v   # stop + wipe
+#
+# Every service binds to localhost on its default port and uses the
+# credentials baked into the example configs (user/pass: faucet/faucet where
+# applicable). This stack is for local development only — never production.
+#
+# See examples/README.md for which example needs which service.
+
+version: "3.8"
+
+name: faucet-examples
+
+services:
+  # PostgreSQL configured for logical replication so the postgres-cdc source
+  # works out of the box. The init script seeds a `users` table + publication.
+  postgres:
+    image: postgres:17
+    command:
+      - "postgres"
+      - "-c"
+      - "wal_level=logical"
+      - "-c"
+      - "max_replication_slots=10"
+      - "-c"
+      - "max_wal_senders=10"
+    environment:
+      POSTGRES_USER: faucet
+      POSTGRES_PASSWORD: faucet
+      POSTGRES_DB: appdb
+    ports:
+      - "5432:5432"
+    volumes:
+      - ./infra/postgres-init.sql:/docker-entrypoint-initdb.d/init.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U faucet -d appdb"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  mysql:
+    image: mysql:8
+    environment:
+      MYSQL_ROOT_PASSWORD: faucet
+      MYSQL_DATABASE: appdb
+      MYSQL_USER: faucet
+      MYSQL_PASSWORD: faucet
+    ports:
+      - "3306:3306"
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-pfaucet"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  # Redpanda speaks the Kafka API — lighter than Kafka + ZooKeeper for local use.
+  redpanda:
+    image: redpandadata/redpanda:latest
+    command:
+      - redpanda
+      - start
+      - --smp
+      - "1"
+      - --overprovisioned
+      - --kafka-addr
+      - PLAINTEXT://0.0.0.0:9092
+      - --advertise-kafka-addr
+      - PLAINTEXT://localhost:9092
+    ports:
+      - "9092:9092"
+    healthcheck:
+      test: ["CMD-SHELL", "rpk cluster health | grep -q 'Healthy:.*true'"]
+      interval: 5s
+      timeout: 5s
+      retries: 15
+
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  mongodb:
+    image: mongo:7
+    ports:
+      - "27017:27017"
+    healthcheck:
+      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand('ping')"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.15.0
+    environment:
+      discovery.type: single-node
+      xpack.security.enabled: "false"
+      ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+    ports:
+      - "9200:9200"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:9200/_cluster/health || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  # MinIO is S3-compatible — point the S3 source/sink at http://localhost:9000
+  # with an endpoint override and the credentials below.
+  minio:
+    image: minio/minio:latest
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: faucet
+      MINIO_ROOT_PASSWORD: faucetfaucet
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    healthcheck:
+      test: ["CMD-SHELL", "mc ready local || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 15

--- a/examples/infra/postgres-init.sql
+++ b/examples/infra/postgres-init.sql
@@ -1,0 +1,19 @@
+-- Seed data + logical-replication publication for the faucet-stream examples.
+-- Runs automatically on first start of the postgres service in docker-compose.yml.
+
+-- A simple table the query and CDC examples read from.
+CREATE TABLE IF NOT EXISTS users (
+    id   integer PRIMARY KEY,
+    name text NOT NULL,
+    city text
+);
+
+INSERT INTO users (id, name, city) VALUES
+    (1, 'Ada',   'London'),
+    (2, 'Grace', 'New York'),
+    (3, 'Linus', 'Helsinki')
+ON CONFLICT (id) DO NOTHING;
+
+-- Publication used by the postgres-cdc source (slot is created by the connector
+-- when create_slot_if_missing: true). Matches cli/examples/postgres_cdc_to_jsonl.yaml.
+CREATE PUBLICATION faucet_pub FOR TABLE users;


### PR DESCRIPTION
Workstreams **WS-4 and WS-5** of the adoption & DX epic (#91).

## WS-4 — documentation site (mdBook)
A navigable, searchable docs site under `docs/book/` (distinct from the internal
`docs/superpowers/` specs):

- **Getting Started** — installation, first pipeline (no-infra CSV→JSONL), core concepts.
- **Tutorials** — incremental REST→BigQuery, Postgres CDC→JSONL, matrix DAGs, embedding as a Rust library.
- **Cookbook** — pagination, auth, incremental state, dead-letter queues, compression.
- **Reference** — connector catalog, CLI commands, config-file grammar.
- **Operations** — deploying (cron/containers/k8s), observability, performance tuning, troubleshooting & FAQ.
- **Extending** — authoring & publishing a connector.

Content is grounded in the real `cli/examples/` configs and the source (config
field names verified against the code — this caught and fixed a wrong Cursor
pagination example).

**Deploy:** `.github/workflows/docs.yml` builds the book on every PR (verify) and
deploys to GitHub Pages on push to `main`. Rendered output is gitignored; the
book builds clean with mdBook 0.5.3.

> ⚠️ **Manual step required:** enable Pages in **Settings → Pages → Build and
> deployment → Source = GitHub Actions** for the deploy to publish at
> `https://pawansikawat.github.io/faucet-stream/` (the README links there).

## WS-5 — runnable examples + local infra
- **`examples/docker-compose.yml`** — one-command stack: Postgres (preconfigured
  for logical replication so `postgres-cdc` works out of the box), MySQL,
  Redpanda (Kafka API), Redis, MongoDB, Elasticsearch, MinIO (S3-compatible),
  each with a healthcheck. `examples/infra/postgres-init.sql` seeds a `users`
  table + `faucet_pub` publication.
- **`examples/README.md`** — maps every `cli/examples/*.yaml` to the infra it
  needs (no-infra / local-stack / cloud-credentials) with run commands.
- **`examples/demo/` + `make demo`** — a self-contained, no-infrastructure
  CSV→JSONL smoke test (slim CLI build, no native deps). The `Makefile` also
  wraps `infra-up` / `infra-down` / `infra-ps` / `infra-logs`.

## Verification
- `mdbook build docs/book` — clean, all TOC links resolve.
- `make demo` — runs end-to-end, wrote 3 records.
- `docker compose -f examples/docker-compose.yml config` — valid.
- Config field names (pagination, auth) verified against the source.

README Project Structure + docs link and CLAUDE.md updated. Part of #91 (WS-4, WS-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)