### PR TITLE
docs: connector capability matrix, selection guide & community scaffolding (WS-6 & WS-7 of #91)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,55 @@
+name: Bug report
+description: Report incorrect behavior in an existing connector or the CLI.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report! Please search [existing issues](https://github.com/PawanSikawat/faucet-stream/issues) first to avoid duplicates.
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: faucet-stream / faucet-cli version (or git commit).
+      placeholder: "0.2.0"
+    validations:
+      required: true
+  - type: input
+    id: connectors
+    attributes:
+      label: Affected connector(s)
+      description: Which source / sink / state backend is involved?
+      placeholder: "source-rest → sink-bigquery"
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you observe, and what did you expect instead?
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: A minimal config and the commands you ran. Redact secrets.
+      render: yaml
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / error output
+      description: Run with `--log-level debug` (or `FAUCET_LOG=debug`) if useful. Redact secrets.
+      render: shell
+    validations:
+      required: false
+  - type: input
+    id: env
+    attributes:
+      label: Environment
+      description: OS, architecture, Rust toolchain.
+      placeholder: "macOS 14 arm64, rustc 1.94"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or idea
+    url: https://github.com/PawanSikawat/faucet-stream/discussions
+    about: Ask a question or float an idea in Discussions before filing an issue.
+  - name: Report a security vulnerability
+    url: https://github.com/PawanSikawat/faucet-stream/security/advisories/new
+    about: Please report vulnerabilities privately — see SECURITY.md. Do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/connector_request.yml
+++ b/.github/ISSUE_TEMPLATE/connector_request.yml
@@ -1,0 +1,40 @@
+name: Connector request
+description: Request a new source or sink connector.
+labels: ["feature"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Want to build it yourself? See the [authoring guide](https://pawansikawat.github.io/faucet-stream/extending/authoring-connectors.html) — third-party `faucet-source-*` / `faucet-sink-*` crates are welcome.
+  - type: input
+    id: system
+    attributes:
+      label: System
+      description: What external system should this connect to?
+      placeholder: "ClickHouse, NATS, DynamoDB, …"
+    validations:
+      required: true
+  - type: dropdown
+    id: direction
+    attributes:
+      label: Direction
+      options:
+        - "Source (read from it)"
+        - "Sink (write to it)"
+        - "Both"
+    validations:
+      required: true
+  - type: textarea
+    id: usecase
+    attributes:
+      label: Use case
+      description: What pipeline would you build with it? What does it unlock?
+    validations:
+      required: true
+  - type: textarea
+    id: details
+    attributes:
+      label: Protocol / API details
+      description: API style (REST, gRPC, native driver), auth methods, pagination/streaming model, official client crate if one exists.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,49 @@
+name: Feature or enhancement
+description: Propose a new capability or an improvement to an existing one.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For a brand-new connector, please use the **Connector request** template instead.
+        Search [existing issues](https://github.com/PawanSikawat/faucet-stream/issues) and the roadmap epic (the `epic` label) first.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What are you trying to do, and why is it hard or impossible today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Concrete API / config shape if you have one. Example usage helps.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false
+  - type: dropdown
+    id: kind
+    attributes:
+      label: Type
+      options:
+        - "feature (brand-new capability)"
+        - "enhancement (improve an existing capability)"
+    validations:
+      required: true
+  - type: dropdown
+    id: tier
+    attributes:
+      label: Suggested priority tier
+      description: A rough sense of importance — maintainers may re-tier.
+      options:
+        - "tier-1 (critical / blocks a core use case)"
+        - "tier-2 (important / frequently useful)"
+        - "tier-3 (nice-to-have)"
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+<!-- Thanks for contributing! Keep PRs focused — one logical change per PR. -->
+
+## Summary
+
+<!-- What does this change and why? -->
+
+## Related issue
+
+<!-- Put the closing keyword in the body so GitHub links it: -->
+Closes #
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature / connector
+- [ ] Enhancement to existing capability
+- [ ] Docs only
+- [ ] Refactor / internal
+
+## Checklist
+
+- [ ] `cargo fmt --all --check` passes
+- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` passes
+- [ ] `cargo test --workspace --all-features` passes (new behavior has tests)
+- [ ] `cargo doc --workspace --all-features --no-deps` is warning-free
+- [ ] Updated the relevant crate `README.md` / root `README.md` / docs site if config, defaults, or behavior changed
+- [ ] If adding/removing a connector: updated the umbrella + CLI features and the `feature-check` matrix in `.github/workflows/ci.yml`
+
+## Notes for reviewers
+
+<!-- Anything that needs a closer look, tradeoffs, follow-ups. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,39 @@
+# Code of Conduct
+
+## Our pledge
+
+We are committed to making participation in the faucet-stream community a
+welcoming, respectful, and harassment-free experience for everyone, regardless
+of background or identity.
+
+## Our standard
+
+This project adopts the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.1, as its Code of Conduct. The full text is available at:
+
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct/>
+
+In short: be kind and constructive, assume good faith, give and accept feedback
+gracefully, and focus on what's best for the community. Behavior that harasses,
+demeans, or excludes others is not tolerated.
+
+## Scope
+
+This Code of Conduct applies within all project spaces — the repository, issues,
+pull requests, discussions — and when an individual is representing the project
+in public spaces.
+
+## Reporting
+
+If you experience or witness unacceptable behavior, report it privately to the
+maintainer at **pawanksikawat@gmail.com**. All reports will be reviewed and
+investigated promptly and fairly, and the reporter's privacy and safety will be
+respected.
+
+## Enforcement
+
+Maintainers are responsible for clarifying and enforcing this Code of Conduct and
+may take any action they deem appropriate — from a warning to a permanent ban —
+in response to behavior they consider inappropriate, threatening, or harmful.
+Enforcement follows the Contributor Covenant's
+[enforcement guidelines](https://www.contributor-covenant.org/version/2/1/code_of_conduct/#enforcement-guidelines).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,101 @@
+# Contributing to faucet-stream
+
+Thanks for your interest in contributing! faucet-stream is a Rust workspace of
+connector crates plus the `faucet` CLI, and it's designed as an ecosystem — both
+core changes and third-party connectors are welcome.
+
+By participating you agree to abide by our [Code of Conduct](./CODE_OF_CONDUCT.md).
+
+## Getting set up
+
+```bash
+git clone https://github.com/PawanSikawat/faucet-stream
+cd faucet-stream
+cargo build --workspace
+```
+
+The toolchain is pinned in `rust-toolchain.toml`. Some connectors link native
+libraries — the **Kafka** connectors build `librdkafka`, which needs `cmake` and
+a C toolchain (`libsasl2-dev libssl-dev libcurl4-openssl-dev` on Debian/Ubuntu).
+
+## Before you open a PR
+
+Run the same checks CI runs:
+
+```bash
+cargo fmt --all --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test --workspace --all-features        # Kafka integration tests need Docker
+cargo doc --workspace --all-features --no-deps   # must be warning-free
+```
+
+For pipelines that touch real services, the [`examples/`](./examples/) directory
+has a `docker compose` stack and `make demo` for a no-infrastructure smoke test.
+
+## Tests
+
+- New functions and behaviors **must** have tests — untested public API is a
+  liability. Unit tests live in `#[cfg(test)]` modules; HTTP-based connectors use
+  `wiremock` integration tests under the crate's `tests/`.
+- Don't blindly update an existing test to make it pass — if a change breaks a
+  test, investigate first; silently rewriting tests hides regressions.
+- Assert the specific outcome, not just "no panic".
+
+## Code quality
+
+- Every failure path maps to a typed `FaucetError` variant. No `.unwrap()` /
+  `.expect()` on anything that can fail at runtime.
+- No hardcoded credentials, tokens, or service URLs — ever.
+- Reuse clients/connections; pool database connections; prefer bulk/multi-row
+  APIs and streaming. Performance and reliability are the project's first
+  priority.
+
+## Adding a connector
+
+faucet-stream connectors follow a fixed shape. To add `faucet-source-foo` /
+`faucet-sink-foo`:
+
+1. **Crate layout** — `lib.rs` (re-exports), `config.rs` (config struct + enums,
+   no I/O), `stream.rs` / `sink.rs` (the only place that does I/O; create
+   clients/pools in `new()`).
+2. **Config** — derive `Serialize + Deserialize + JsonSchema`; implement
+   `config_schema()` via `schema_for!`.
+3. **docs.rs** — add `[package.metadata.docs.rs]` (`all-features = true`,
+   `rustdoc-args = ["--cfg", "docsrs"]`) and make the first line of `lib.rs`
+   `#![cfg_attr(docsrs, feature(doc_cfg))]`.
+4. **Tests** — unit + integration.
+5. **Wire it up** — add the feature to the umbrella crate, the CLI registry, and
+   the `feature-check` matrix in `.github/workflows/ci.yml`.
+6. **Docs** — a crate `README.md`, an entry in the root README + the docs-site
+   [connector catalog](./docs/book/src/reference/connectors.md), and a runnable
+   example under `cli/examples/`.
+
+Shared types for a source/sink pair (auth, formats) go in a
+`faucet-<name>-common` crate that both depend on. See `faucet-source-rest` for a
+reference implementation, and the docs-site
+[authoring guide](./docs/book/src/extending/authoring-connectors.md).
+
+## Filing issues
+
+Use the issue templates. We label every issue with:
+
+- **Type** — `feature` (new capability), `enhancement` (improve existing), or
+  `bug` (incorrect behavior).
+- **Tier** — `tier-1` (critical / blocks a core use case), `tier-2` (important),
+  or `tier-3` (nice-to-have).
+
+Search open issues before filing to avoid duplicates. Feature/enhancement issues
+are tracked in the roadmap epic (search the `epic` label).
+
+## Pull requests
+
+- Keep PRs focused; one logical change per PR.
+- Put `Closes #N` in the **PR body** (not just commit messages) to link the issue.
+- Update the relevant crate `README.md`, the root README, and the docs site when
+  you change config fields, defaults, or behavior.
+- Don't skip hooks (`--no-verify`) or CI; if a check fails, fix the root cause.
+
+## License
+
+By contributing, you agree that your contributions are licensed under both the
+MIT and Apache-2.0 licenses, matching the project's dual license.

--- a/README.md
+++ b/README.md
@@ -194,6 +194,11 @@ faucet-stream is a Cargo workspace with 45 crates — 19 sources, 16 sinks, 5 sh
 | **CLI** | |
 | [`faucet-cli`](cli) | `faucet` binary — YAML/JSON config-driven pipeline runner (`run`, `validate`, `schema`, `list`, `preview`, `init`) |
 
+See the [connector capability matrix](https://pawansikawat.github.io/faucet-stream/reference/connectors.html)
+(streaming, resumable state, compression, auth per connector) and the
+[choosing-a-connector guide](https://pawansikawat.github.io/faucet-stream/reference/choosing.html)
+for help picking between overlapping connectors (Postgres query vs CDC, S3 vs Parquet, Redis vs Kafka, …).
+
 Install only what you need:
 
 ```toml

--- a/README.md
+++ b/README.md
@@ -1089,6 +1089,16 @@ docs/
 .github/workflows/            — ci.yml, release.yml, docs.yml (mdBook → GitHub Pages)
 ```
 
+## Contributing
+
+Contributions — core changes and third-party connectors alike — are welcome. See
+[CONTRIBUTING.md](CONTRIBUTING.md) for setup, the checks CI runs, and the
+add-a-connector checklist, and the
+[authoring guide](https://pawansikawat.github.io/faucet-stream/extending/authoring-connectors.html)
+for building your own `faucet-source-*` / `faucet-sink-*` crate. Please review our
+[Code of Conduct](CODE_OF_CONDUCT.md). To report a vulnerability, see
+[SECURITY.md](SECURITY.md).
+
 ## License
 
 Licensed under either of

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,45 @@
+# Security Policy
+
+## Supported versions
+
+faucet-stream is pre-1.0 and under active development. Security fixes are applied
+to the latest published `0.x` release on crates.io and to `main`. Older versions
+are not maintained — please upgrade to the latest release before reporting.
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+discussions, or pull requests.**
+
+Report privately through either channel:
+
+1. **GitHub private vulnerability reporting** (preferred) — open the repository's
+   **Security** tab and click **"Report a vulnerability"**. This creates a private
+   advisory visible only to maintainers.
+2. **Email** — **pawanksikawat@gmail.com**.
+
+Please include:
+
+- a description of the vulnerability and its impact,
+- the affected crate(s) and version(s),
+- steps to reproduce or a proof of concept,
+- any suggested remediation.
+
+## What to expect
+
+- We aim to acknowledge a report within a few days.
+- We'll confirm the issue, determine affected versions, and work on a fix.
+- We'll keep you informed of progress and coordinate a disclosure timeline.
+- With your consent, we'll credit you in the advisory and release notes.
+
+## Scope notes
+
+faucet-stream moves data between external systems, so keep in mind:
+
+- **Credentials** belong in environment variables / secret files referenced via
+  `${env:VAR}` / `${file:PATH}` / `${secret:VAR}` — never commit them to config
+  files. A leaked credential in your own config is not a vulnerability in
+  faucet-stream.
+- SQL identifier handling (`quote_ident`), bind-parameter substitution, and
+  JSON-safe interpolation are security-relevant — bug reports about injection
+  vectors in these paths are especially welcome.

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -26,6 +26,7 @@
 # Reference
 
 - [Connector catalog](./reference/connectors.md)
+- [Choosing a connector](./reference/choosing.md)
 - [CLI commands](./reference/cli.md)
 - [Configuration file format](./reference/config.md)
 

--- a/docs/book/src/reference/choosing.md
+++ b/docs/book/src/reference/choosing.md
@@ -1,0 +1,90 @@
+# Choosing a connector
+
+Several connectors overlap. This page resolves the common "which one?" questions.
+For the full feature grid see the [connector catalog](./connectors.md).
+
+## PostgreSQL: query source vs. CDC
+
+- **`source-postgres`** runs a SQL query and returns the rows. Use it for
+  one-shot extracts, snapshots, or when you control an `updated_at` column and
+  parameterize the query yourself. Simple, no special Postgres config.
+- **`source-postgres-cdc`** streams every `INSERT`/`UPDATE`/`DELETE` from the
+  write-ahead log via logical replication. Use it when you need **every change**
+  (including deletes), low-latency capture, or resumability without a cursor
+  column. Requires `wal_level = logical` and a publication, and retains WAL
+  between runs. See the [CDC tutorial](../tutorials/postgres-cdc.md).
+
+**Rule of thumb:** periodic snapshot → query source; continuous change feed → CDC.
+
+## Object storage: S3/GCS source vs. Parquet source
+
+- **`source-s3` / `source-gcs`** read objects as JSONL, a JSON array, or raw
+  text. Use them for line-delimited JSON, logs, or text dumps.
+- **`source-parquet`** reads columnar Parquet (local, glob, or S3) with a
+  vectorized Arrow reader and column projection. Use it for analytical datasets —
+  it's far faster and can skip columns you don't need.
+
+**Rule of thumb:** the file is `.parquet` → Parquet source; it's JSON/text →
+S3/GCS source. (The Parquet source reads from S3 directly, so you don't need the
+S3 source in front of it.)
+
+## Streaming: Redis vs. Kafka
+
+- **`source-redis`** reads streams, lists, or key patterns. Great when Redis is
+  already in your stack and volumes are modest.
+- **`source-kafka`** is a real consumer with consumer-group offsets and
+  resumable bookmarks. Use it for high-throughput event pipelines and durable,
+  replayable streams.
+
+**Rule of thumb:** durable, high-volume event stream → Kafka; lightweight
+queue/cache already on hand → Redis.
+
+## HTTP APIs: REST vs. GraphQL vs. XML vs. gRPC
+
+- **`source-rest`** — JSON REST APIs. The most full-featured source: six
+  pagination styles, seven auth strategies, incremental replication, partitions.
+- **`source-graphql`** — GraphQL endpoints with cursor pagination and variable
+  injection.
+- **`source-xml`** — XML/SOAP APIs; converts XML to JSON with dot-path extraction.
+- **`source-grpc`** — gRPC services via dynamic protobuf (`prost-reflect`), unary
+  or server-streaming.
+
+**Rule of thumb:** match the protocol the API speaks. For incremental/resumable
+ingestion, REST has the richest support.
+
+## Warehouses: when to read with BigQuery / Snowflake sources
+
+Use **`source-bigquery`** / **`source-snowflake`** to *read out of* a warehouse
+(e.g. to move a query result elsewhere). To *load into* one, use the matching
+**sink**. To transform data already inside the warehouse, reach for
+[dbt](https://www.getdbt.com/) — that's not faucet's job.
+
+## Sinks: column-mapped vs. JSON blob (SQL databases)
+
+The Postgres/MySQL/SQLite sinks can write either:
+
+- **a single JSON/JSONB column** (`column_mapping: { type: jsonb, column: data }`)
+  — schemaless, no DDL coupling, easiest to start with; or
+- **auto-mapped columns** — one column per top-level field, for queryable
+  relational tables.
+
+**Rule of thumb:** exploratory / evolving schema → JSON column; stable schema you
+query with SQL → mapped columns.
+
+## File sinks: JSONL vs. CSV vs. Parquet vs. stdout
+
+- **`sink-stdout`** — debugging and pipelines (`faucet preview` uses it).
+- **`sink-jsonl`** — line-delimited JSON; lossless, streaming-friendly,
+  gzip/zstd-capable.
+- **`sink-csv`** — flat tabular output for spreadsheets/BI; nested fields flatten.
+- **`sink-parquet`** — columnar analytical output with built-in compression and
+  schema inference; best for large datasets consumed by analytics engines.
+
+**Rule of thumb:** machine-to-machine JSON → JSONL; tabular for humans → CSV;
+analytics at scale → Parquet.
+
+## Still unsure?
+
+Run `faucet list` to see what's installed, `faucet schema source <name>` to
+inspect a connector's config, and `faucet preview <config> --limit 10` to try a
+source without writing anywhere.

--- a/docs/book/src/reference/connectors.md
+++ b/docs/book/src/reference/connectors.md
@@ -2,63 +2,92 @@
 
 faucet-stream ships **19 sources** and **16 sinks**. Each is a Cargo feature
 (`source-<name>` / `sink-<name>`) and an independently published crate. Full API
-docs for every connector are on [docs.rs](https://docs.rs/faucet-stream).
+docs are on [docs.rs](https://docs.rs/faucet-stream).
 
 Run `faucet list` to see what's compiled into your binary, and
 `faucet schema source <name>` / `faucet schema sink <name>` for a connector's
-exact config fields.
+exact config fields. Not sure which to pick? See
+[Choosing a connector](./choosing.md).
+
+Legend: ✓ supported · ✗ not applicable.
 
 ## Sources
 
-| Connector | Feature | Notes |
-|-----------|---------|-------|
-| REST | `source-rest` | auth, 6 pagination styles, JSONPath extraction, schema inference, incremental |
-| GraphQL | `source-graphql` | cursor pagination, variable injection |
-| XML / SOAP | `source-xml` | XML→JSON, dot-path extraction |
-| gRPC | `source-grpc` | dynamic protobuf; unary + server-streaming |
-| PostgreSQL | `source-postgres` | run SQL, rows as JSON |
-| PostgreSQL CDC | `source-postgres-cdc` | logical replication, resumable |
-| MySQL | `source-mysql` | run SQL, rows as JSON |
-| SQLite | `source-sqlite` | run SQL, rows as JSON |
-| AWS S3 | `source-s3` | JSONL, JSON array, raw text |
-| Google Cloud Storage | `source-gcs` | JSONL, JSON array, raw text |
-| MongoDB | `source-mongodb` | `find()` with filter/projection/sort |
-| Redis | `source-redis` | streams, lists, key patterns |
-| Webhook | `source-webhook` | temporary HTTP server collecting POSTs |
-| CSV | `source-csv` | CSV files as JSON |
-| Elasticsearch | `source-elasticsearch` | search/scroll API |
-| Apache Kafka | `source-kafka` | consumer, idle/max-messages termination |
-| Apache Parquet | `source-parquet` | local/glob/S3, vectorized Arrow reader, projection |
-| BigQuery | `source-bigquery` | `jobs.query` + pageToken pagination |
-| Snowflake | `source-snowflake` | SQL REST API, server-side partitions, JWT/OAuth |
+| Connector | Feature | Streams¹ | Resumable² | Compression | Underlying primitive |
+|-----------|---------|:---:|:---:|:---:|----------------------|
+| REST | `source-rest` | ✓ | ✓ | ✗ | HTTP + 6 pagination styles, JSONPath extraction |
+| GraphQL | `source-graphql` | ✓ | ✗ | ✗ | cursor pagination, variable injection |
+| XML / SOAP | `source-xml` | ✓ | ✗ | ✗ | streaming XML→JSON, dot-path extraction |
+| gRPC | `source-grpc` | ✓³ | ✗ | ✗ | dynamic protobuf; unary + server-streaming |
+| PostgreSQL | `source-postgres` | ✓ | ✗ | ✗ | SQL query, rows as JSON |
+| PostgreSQL CDC | `source-postgres-cdc` | ✓ | ✓ | ✗ | logical replication (pgoutput), LSN bookmarks |
+| MySQL | `source-mysql` | ✓ | ✗ | ✗ | SQL query, rows as JSON |
+| SQLite | `source-sqlite` | ✓ | ✗ | ✗ | SQL query, rows as JSON |
+| AWS S3 | `source-s3` | ✓⁴ | ✗ | ✓ | object reader: JSONL, JSON array, raw text |
+| Google Cloud Storage | `source-gcs` | ✓⁴ | ✗ | ✓ | object reader: JSONL, JSON array, raw text |
+| MongoDB | `source-mongodb` | ✓ | ✗ | ✗ | `find()` with filter/projection/sort |
+| Redis | `source-redis` | ✓ | ✗ | ✗ | streams, lists, key patterns |
+| Webhook | `source-webhook` | ✗⁵ | ✗ | ✗ | temporary HTTP server collecting POSTs |
+| CSV | `source-csv` | ✓ | ✗ | ✓ | CSV files as JSON |
+| Elasticsearch | `source-elasticsearch` | ✓ | ✗ | ✗ | search/scroll API |
+| Apache Kafka | `source-kafka` | ✓ | ✓ | ✗ | consumer; idle/max-messages termination, offset bookmarks |
+| Apache Parquet | `source-parquet` | ✓ | ✗ | ✗ | local/glob/S3, vectorized Arrow reader, projection |
+| BigQuery | `source-bigquery` | ✓ | ✗ | ✗ | `jobs.query` + pageToken pagination |
+| Snowflake | `source-snowflake` | ✓ | ✗ | ✗ | SQL REST API, server-side partitions |
+
+¹ **Streams** = yields records in bounded-memory batches rather than buffering the
+whole result. ² **Resumable** = persists a bookmark to a [state store](../cookbook/state.md)
+so re-runs continue where they left off (incremental replication / CDC / Kafka
+offsets). ³ gRPC streams natively in *server-streaming* mode; unary buffers the
+single response. ⁴ S3/GCS stream in JSONL and raw-text modes; JSON-array mode
+buffers one object. ⁵ Webhook is buffer-shaped by nature (it collects POSTs over
+a window).
 
 ## Sinks
 
-| Connector | Feature | Notes |
-|-----------|---------|-------|
-| BigQuery | `sink-bigquery` | streaming inserts, per-row DLQ |
-| PostgreSQL | `sink-postgres` | JSONB or auto-mapped columns, multi-row INSERT |
-| JSON Lines | `sink-jsonl` | buffered file output |
-| Snowflake | `sink-snowflake` | SQL REST API, JWT/OAuth |
-| MySQL | `sink-mysql` | JSON column or auto-mapped columns |
-| SQLite | `sink-sqlite` | transaction-wrapped batches |
-| AWS S3 | `sink-s3` | JSONL files, parallel uploads |
-| Google Cloud Storage | `sink-gcs` | JSONL files |
-| MongoDB | `sink-mongodb` | `insert_many` |
-| Redis | `sink-redis` | streams, lists, key-value |
-| CSV | `sink-csv` | CSV rows, buffered |
-| Elasticsearch | `sink-elasticsearch` | `_bulk` API, per-row DLQ |
-| HTTP | `sink-http` | POST records, concurrent |
-| Stdout | `sink-stdout` | JSON Lines, pretty JSON, or TSV |
-| Apache Kafka | `sink-kafka` | producer, batched sends, multi-topic routing |
-| Apache Parquet | `sink-parquet` | local/S3, schema inference, row/byte rollover |
+Every sink exposes a `batch_size` knob for write-side re-chunking. For the
+file/append sinks (`jsonl`, `csv`, `stdout`) it's a no-op — they write per record.
 
-## Streaming & batching
+| Connector | Feature | `batch_size` | Compression | Write unit |
+|-----------|---------|:---:|:---:|------------|
+| BigQuery | `sink-bigquery` | ✓ | ✗ | `tabledata.insertAll` (per-row DLQ) |
+| PostgreSQL | `sink-postgres` | ✓ | ✗ | multi-row `INSERT` (JSONB or mapped cols) |
+| JSON Lines | `sink-jsonl` | no-op | ✓ | buffered file append |
+| Snowflake | `sink-snowflake` | ✓ | ✗ | SQL REST API |
+| MySQL | `sink-mysql` | ✓ | ✗ | multi-row `INSERT` |
+| SQLite | `sink-sqlite` | ✓ | ✗ | transaction-wrapped batch |
+| AWS S3 | `sink-s3` | ✓ | ✓ | JSONL objects, parallel uploads |
+| Google Cloud Storage | `sink-gcs` | ✓ | ✓ | JSONL objects |
+| MongoDB | `sink-mongodb` | ✓ | ✗ | `insert_many` |
+| Redis | `sink-redis` | ✓ | ✗ | streams, lists, key-value (pipelined) |
+| CSV | `sink-csv` | no-op | ✓ | buffered file rows |
+| Elasticsearch | `sink-elasticsearch` | ✓ | ✗ | `_bulk` NDJSON (per-row DLQ) |
+| HTTP | `sink-http` | ✓ | ✗ | POST, concurrent under a semaphore |
+| Stdout | `sink-stdout` | no-op | ✗ | JSON Lines / pretty JSON / TSV |
+| Apache Kafka | `sink-kafka` | ✓ | ✗ | producer, batched sends, multi-topic routing |
+| Apache Parquet | `sink-parquet` | ✓ | ✗⁶ | local/S3, schema inference, row/byte rollover |
 
-Most sources stream natively (bounded memory). Most sinks expose a `batch_size`
-that controls their natural write unit. The default batch size is 1000;
-`batch_size: 0` means "no batching" (one large request) — useful for small lookup
-tables or load-job-style sinks. See [Performance tuning](../operations/tuning.md).
+⁶ Parquet has internal columnar compression, so the file-level `compression`
+feature doesn't apply.
 
-> A capability matrix with per-connector streaming/state/auth/compression columns
-> is planned (WS-6 of the adoption roadmap).
+## Authentication at a glance
+
+| Family | Auth options |
+|--------|--------------|
+| REST / GraphQL / XML | Bearer, Basic, ApiKey (header), ApiKeyQuery, OAuth2 (client-credentials), TokenEndpoint, Custom headers — see [Auth cookbook](../cookbook/auth.md) |
+| BigQuery | service-account key (path or inline JSON), application-default credentials |
+| Snowflake | JWT key-pair, OAuth |
+| Kafka | SASL (PLAIN/SCRAM) + TLS |
+| Elasticsearch | basic, API key, bearer, none |
+| S3 / GCS | cloud SDK credential chains (env, profile, metadata) |
+| SQL databases | connection URL (with embedded credentials / TLS params) |
+
+Inspect any connector's exact auth shape with `faucet schema source <name>` /
+`faucet schema sink <name>`.
+
+## Batching
+
+Default `batch_size` is 1000; max is 1,000,000. `batch_size: 0` means "no
+batching" — the source emits the whole result set in one page and the sink writes
+it in one request (good for small lookup tables or load-job-style sinks). See
+[Performance tuning](../operations/tuning.md).


### PR DESCRIPTION
Workstreams **WS-6 and WS-7** of the adoption & DX epic (#91).

## WS-6 — connector catalog & selection guide
- Rewrote the docs-site connector catalog into real **capability matrices**:
  per-connector **Streams / Resumable / Compression / `batch_size`** columns plus
  the underlying primitive and an auth-at-a-glance table. **Columns are verified
  against the source**, not guessed — e.g. only `rest` / `postgres-cdc` / `kafka`
  are resumable; every source streams in batches except `webhook`; compression is
  on csv/s3/gcs sources + jsonl/csv/s3/gcs sinks.
- Added a **"Choosing a connector"** decision guide for overlapping cases:
  Postgres query vs CDC, S3/GCS vs Parquet, Redis vs Kafka, REST/GraphQL/XML/gRPC,
  warehouse read vs dbt, JSON-column vs mapped-column sinks, file-sink formats.
- Linked both from the README near the connector list.

## WS-7 — community & repo scaffolding
- **CONTRIBUTING.md** — setup, the exact checks CI runs, the add-a-connector
  checklist, the type+tier labeling convention, PR rules.
- **CODE_OF_CONDUCT.md** — adopts Contributor Covenant 2.1 by reference.
- **SECURITY.md** — private vulnerability reporting (GitHub advisories + email),
  supported versions, data-movement scope notes.
- **Issue templates** — `bug_report`, `feature_request` (type + tier dropdowns),
  `connector_request`, and a `config.yml` routing questions to Discussions and
  vulnerabilities to private reporting.
- **PULL_REQUEST_TEMPLATE.md** — checklist mirroring CI + the "Closes #N in body"
  rule.
- README gains a **Contributing** section.

## Verification
- mdBook builds clean; all issue-form + workflow YAML validated.
- Capability-matrix columns cross-checked against `stream_pages` overrides,
  replication/state references, and `compression`-gated config fields in the code.

## Owner follow-ups (can't be done in files)
- Enable **GitHub Discussions** (Settings → Features) — the issue config links to it.
- Triage a few **good first issue** / **help wanted** items.
- `FUNDING.yml` omitted (no sponsor account); add later if desired.

Part of #91 (WS-6, WS-7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)