### PR TITLE
CHANGELOG, versioning policy + supply-chain & coverage CI (WS-8 & WS-9 of #91)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,3 +265,54 @@ jobs:
         run: cargo test -p faucet-kafka-common --all-features
       - name: Run elasticsearch-common tests
         run: cargo test -p faucet-elasticsearch-common
+
+  supply-chain:
+    name: Supply chain (cargo-deny)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Hard gate: licenses, banned crates, and dependency sources are
+      # deterministic and in our control.
+      - name: Licenses / bans / sources
+        uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check bans licenses sources
+      # Informational: RustSec advisories. Non-blocking because nearly all live
+      # in transitive deps we don't control and the advisory DB updates daily;
+      # see the note in deny.toml.
+      - name: Advisories (informational)
+        continue-on-error: true
+        uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check advisories
+
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.94.0"
+          components: llvm-tools-preview
+      - name: Install librdkafka prerequisites
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libsasl2-dev libssl-dev libcurl4-openssl-dev cmake build-essential
+      - uses: taiki-e/install-action@cargo-llvm-cov
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-coverage-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-coverage-
+      - name: Generate coverage (lcov)
+        run: cargo llvm-cov --workspace --all-features --lcov --output-path lcov.info
+      - name: Upload to Codecov
+        continue-on-error: true
+        uses: codecov/codecov-action@v4
+        with:
+          files: lcov.info
+          fail_ci_if_error: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,8 +308,12 @@ jobs:
             target
           key: ${{ runner.os }}-coverage-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-coverage-
+      # Cover library unit tests only (`--lib`). The integration tests in
+      # `tests/` spin up Docker testcontainers (Kafka, etc.) whose image pulls
+      # are flaky and are already exercised by the `test` and `kafka-integration`
+      # jobs — running them here too made coverage non-deterministic.
       - name: Generate coverage (lcov)
-        run: cargo llvm-cov --workspace --all-features --lcov --output-path lcov.info
+        run: cargo llvm-cov --workspace --all-features --lib --lcov --output-path lcov.info
       - name: Upload to Codecov
         continue-on-error: true
         uses: codecov/codecov-action@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,164 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+(see the versioning policy in CONTRIBUTING.md — connector crates version
+independently).
+## [Unreleased]
+
+### Bug Fixes
+
+- Add multi-parent DAG validation and move futures to workspace deps
+- Resolve SQL injection, JSON corruption, and semaphore deadlock
+- Seek to bookmark in rebalance, eliminate restart duplicate (#50)
+- Durable LSN feedback + transaction buffer cap (#78 findings #1, #2) (#81)
+
+### CI & Build
+
+- Backfill into release.yml ordering and project docs (#69)
+- Fail fast if the derived publish list is incomplete (part of #78) (#90)
+
+### Documentation
+
+- Update CLAUDE.md and verify umbrella crate for SourceDAG
+- Add runnable examples for pipeline, streaming, and DAG
+- Cover the source × sink connector matrix
+- Add 10 more popular source-sink combinations
+- Exercise the full builder surface in every example
+- Add cleanup-after-PR-merge rule to CLAUDE.md (#47)
+- Condense CLAUDE.md, drop redundant per-crate enumeration (#51)
+- Harden docs.rs rendering across all crates (WS-1 of #91) (#92)
+- Positioning, comparison, architecture diagram + de-flake test (WS-2 & WS-3 of #91) (#93)
+- MdBook site + runnable examples & local Docker stack (WS-4 & WS-5 of #91) (#94)
+- Connector capability matrix, selection guide & community scaffolding (WS-6 & WS-7 of #91) (#95)
+
+### Features
+
+- Add substitute_context and extract_context utilities
+- Make fetch_with_context the primary Source trait method
+- Migrate all source crates to fetch_with_context
+- Add SourceDAG data structures and builder
+- Implement SourceDAG::run() execution engine
+- Wire parent context into REST, DB, GraphQL, and S3 sources
+- Wire parent context into remaining 7 source connectors
+- Stdout/stderr sink + pluggable replication state stores
+- Wire state-store resume into RestStream
+- Add 'faucet' config-driven pipeline runner binary (#41)
+- Apache Kafka source + sink + common crate (#46)
+- Apache Parquet source + sink connectors (#48)
+- PostgreSQL logical replication source (#49)
+- --from-env pipeline mode (Closes #42) (#53)
+- Pipeline+matrix config and cwd auto-discovery (#56)
+- Streaming Pipeline::run with Source::stream_pages contract (#58)
+- Observability — OTel-compatible tracing + Prometheus metrics (Closes #31) (#63)
+- Dead-letter queue support for sinks (#65)
+- GCS source + sink connectors (Closes #26, #27) (#66)
+- Schema-driven faucet init --source X --sink Y scaffolder (#67)
+- Faucet-elasticsearch-common shared auth crate (closes #43) (#68)
+- Named source/sink templates + matrix `ref:` syntax (#73)
+- Add Snowflake + BigQuery query source connectors (#75)
+- Gzip/zstd compression for file connectors (closes #33) (#76)
+- Add server-streaming RPC support (closes #34) (#77)
+
+### Miscellaneous
+
+- Increase publish wave wait to 15 minutes
+- Ignore docs/superpowers/ AI workflow artifacts
+
+### Other
+
+- Pre-1.0 hardening: CRITICAL batch 1 (#78 findings #3, #4, #5, #6, #7, #8, #11) (#79)
+- Pre-1.0 hardening: CRITICAL #9 + 10 fixes (#78 findings #9,#10,#14,#15,#16,#18,#20,#21,#22,#27,#28) (#86)
+- Pre-1.0 hardening: 10 HIGH-tier fixes (part of #78) (#87)
+- Pre-1.0 hardening: 17 MEDIUM-tier fixes (closes out #78) (#88)
+- Pre-1.0 hardening: 15 LOW-tier fixes (fully closes out #78) (#89)
+
+### Refactor
+
+- Replace local resolve_path with faucet_core::util::substitute_context
+- Struct variants for newtype auth enums (Closes #40) (#52)
+- Remove unused SourceDAG executor (closes #62) (#74)
+
+### Testing
+
+- Add GitHub-style integration test for SourceDAG
+- De-flake on_error=stop abort test (part of #78 finding #24) (#80)
+
+## [0.2.0] - 2026-04-03
+
+### Bug Fixes
+
+- Fix security issues, error semantics, and code quality across workspace
+- Fix CI: install libcurl-dev for rdkafka-sys build
+- Fix release.toml: remove invalid publish-delay key
+- Fix release workflow: publish in waves to respect crates.io rate limit
+
+### Miscellaneous
+
+- Bump version to 0.1.4
+- Set faucet-stream version to 0.1.0
+
+### Other
+
+- Add Auth::TokenEndpoint with ResponseValidator for fetching credentials from APIs
+- Restructure into multi-crate workspace with source/sink categories and add comprehensive test coverage
+- Add Pipeline orchestration for source-to-sink data transfer
+- Add 6 new connectors: GraphQL, XML, gRPC sources and Postgres, JSONL, Snowflake sinks
+- Extract shared utilities into faucet-core::util module
+- Add 18 new connectors: 9 sources + 9 sinks
+- Remove Kafka source+sink (rdkafka C dependency too heavy for CI)
+- Add SQLite source connector (faucet-source-sqlite)
+- Improve third-party connector developer experience
+- Optimize all connectors for throughput
+- Add config loading from JSON files and env vars
+- Add config_schema() to Source and Sink traits via schemars
+- Update README with config loading, schema introspection, and version fixes
+- Add extensive README for every source, sink, core, and umbrella crate
+- Add automated release workflow with cargo-release
+- Add crate README update rule to CLAUDE.md
+- Remove old publish.yml, replaced by release.yml
+- Restrict releases to main branch only
+- Optimize CI: parallelize jobs and test all features in isolation
+- {{crate_name}} v{{version}}
+
+## [0.1.4] - 2026-03-25
+
+### Other
+
+- Add all features from reststream meltano
+- Update readme and docs for all meltano features
+
+## [0.1.3] - 2026-03-23
+
+### Bug Fixes
+
+- Reduce keywords to crates.io limit of 5
+
+### Miscellaneous
+
+- Bump version to 0.1.3
+
+### Other
+
+- Add wf for crates publish
+- Add support for next link
+- Add support for next link
+- Automatic update of crate version
+
+## [0.1.2] - 2026-03-23
+
+### Other
+
+- Initial code for faucet-stream
+- Add CI workflow
+- Add precommit
+- Add precommit
+- Precommit run
+- Add support for docs
+- Add stream pages support
+- Add wf for crates publish
+- Add wf for crates publish
+
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,26 @@ are tracked in the roadmap epic (search the `epic` label).
   you change config fields, defaults, or behavior.
 - Don't skip hooks (`--no-verify`) or CI; if a check fails, fix the root cause.
 
+## Versioning & MSRV
+
+- **Semantic Versioning.** The project follows [SemVer](https://semver.org/).
+  While pre-1.0, breaking changes may land in minor (`0.x`) releases, but we call
+  them out in the changelog. For a connector, a **breaking change** includes
+  renaming/removing a config field, changing a field's type, or changing a
+  default in a way that alters behavior — not just Rust API changes.
+- **Independent crate versions.** Connector crates version independently on
+  crates.io, so `faucet-source-rest` and `faucet-sink-bigquery` may sit at
+  different versions. The repo-level `vX.Y.Z` tags track the overall release line.
+- **Changelog.** Notable changes are recorded in [CHANGELOG.md](./CHANGELOG.md),
+  generated from Conventional Commit messages via
+  [git-cliff](https://git-cliff.org) (`cliff.toml`). Write commit subjects as
+  `type(scope): summary` (`feat`, `fix`, `perf`, `refactor`, `docs`, `test`,
+  `ci`, `chore`) so they're grouped correctly.
+- **MSRV.** The minimum supported Rust version is pinned in
+  `rust-toolchain.toml` and enforced by CI (fmt/clippy/test/docs all run on it).
+  Bumping the MSRV is itself a notable change — raise it only when needed and
+  note it in the changelog.
+
 ## License
 
 By contributing, you agree that your contributions are licensed under both the

--- a/README.md
+++ b/README.md
@@ -3,9 +3,12 @@
 [![Crates.io](https://img.shields.io/crates/v/faucet-stream.svg)](https://crates.io/crates/faucet-stream)
 [![Docs.rs](https://docs.rs/faucet-stream/badge.svg)](https://docs.rs/faucet-stream)
 [![CI](https://github.com/PawanSikawat/faucet-stream/actions/workflows/ci.yml/badge.svg)](https://github.com/PawanSikawat/faucet-stream/actions/workflows/ci.yml)
+[![Coverage](https://codecov.io/gh/PawanSikawat/faucet-stream/branch/main/graph/badge.svg)](https://codecov.io/gh/PawanSikawat/faucet-stream)
 [![Downloads](https://img.shields.io/crates/d/faucet-stream.svg)](https://crates.io/crates/faucet-stream)
 [![MSRV](https://img.shields.io/crates/msrv/faucet-stream.svg)](rust-toolchain.toml)
+[![Dependencies](https://img.shields.io/badge/deps-cargo--deny-blue)](deny.toml)
 [![License](https://img.shields.io/crates/l/faucet-stream.svg)](#license)
+[![Changelog](https://img.shields.io/badge/changelog-keep%20a%20changelog-orange)](CHANGELOG.md)
 
 **The fast, config-driven way to move data in Rust.**
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,58 @@
+# git-cliff configuration — generates CHANGELOG.md from Conventional Commits.
+#   git cliff -o CHANGELOG.md            # regenerate the whole file
+#   git cliff --unreleased --prepend CHANGELOG.md   # add the unreleased section
+# See https://git-cliff.org
+
+[changelog]
+header = """
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+(see the versioning policy in CONTRIBUTING.md — connector crates version
+independently).
+"""
+body = """
+{% if version %}\
+## [{{ version | split(pat="v") | last }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+## [Unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+{% for commit in commits %}
+- {{ commit.message | split(pat="\n") | first | trim | upper_first }}
+{%- endfor %}
+{% endfor %}\n
+"""
+trim = true
+footer = ""
+
+[git]
+conventional_commits = true
+filter_unconventional = false
+split_commits = false
+commit_parsers = [
+    { message = "^Merge (pull request|branch|remote)", skip = true },
+    { message = "^feat", group = "Features" },
+    { message = "^fix", group = "Bug Fixes" },
+    { message = "^perf", group = "Performance" },
+    { message = "^refactor", group = "Refactor" },
+    { message = "^docs", group = "Documentation" },
+    { message = "^test", group = "Testing" },
+    { message = "^ci", group = "CI & Build" },
+    { message = "^build", group = "CI & Build" },
+    { message = "^chore\\(release\\)", skip = true },
+    { message = "^chore\\(deps\\)", skip = true },
+    { message = "^chore", group = "Miscellaneous" },
+    { message = ".*", group = "Other" },
+]
+protect_breaking_commits = false
+filter_commits = false
+# Only treat the repo-level vX.Y.Z tags as releases; per-crate tags
+# (e.g. faucet-source-rest-v0.2.0) would otherwise create dozens of sections.
+tag_pattern = "v[0-9]+\\.[0-9]+\\.[0-9]+"
+topo_order = false
+sort_commits = "oldest"

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,53 @@
+# cargo-deny configuration — supply-chain checks run in CI.
+#   cargo deny check
+# See https://embarkstudios.github.io/cargo-deny/
+
+[advisories]
+version = 2
+# Security advisories from the RustSec database. Yanked crates are denied by
+# default. "unmaintained" is a warning, not an error — those advisories are
+# noisy (e.g. proc-macro helpers) and rarely actionable for transitive deps.
+#
+# NOTE: in CI the `advisories` check runs as an *informational* step
+# (non-blocking) because nearly every advisory here lives in a transitive
+# dependency we don't control (the AWS SDK's pinned rustls, a DNS library,
+# `paste`), and the RustSec database updates daily — gating hard on it would
+# break CI on days nothing changed. License / bans / sources ARE hard-gated.
+unmaintained = "workspace"
+ignore = []
+
+[licenses]
+version = 2
+# Permissive licenses we accept across the dependency tree. Keep this list tight;
+# add a license only after confirming the dependency that needs it.
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "Zlib",
+    "MPL-2.0",
+    "CC0-1.0",
+    "BSL-1.0",
+    "CDLA-Permissive-2.0",
+]
+confidence-threshold = 0.8
+# Per-crate license clarifications go here if a crate's license can't be detected.
+exceptions = []
+
+[bans]
+# Duplicate dependency versions and wildcard version requirements are warnings,
+# not errors — a large connector tree legitimately pulls multiple versions.
+multiple-versions = "warn"
+wildcards = "warn"
+allow = []
+deny = []
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]

--- a/deny.toml
+++ b/deny.toml
@@ -22,6 +22,7 @@ version = 2
 # add a license only after confirming the dependency that needs it.
 allow = [
     "MIT",
+    "MIT-0",
     "Apache-2.0",
     "Apache-2.0 WITH LLVM-exception",
     "BSD-2-Clause",

--- a/docs/book/src/operations/tuning.md
+++ b/docs/book/src/operations/tuning.md
@@ -51,3 +51,16 @@ the REST source additionally honors `429` / `Retry-After`. Tune `max_retries` an
 
 Measure with the [metrics](./observability.md) — `faucet_sink_write_duration_seconds`
 and `faucet_source_page_duration_seconds` tell you where time goes.
+
+## Benchmarks
+
+`faucet-core` ships a [criterion](https://github.com/bheisler/criterion.rs)
+benchmark of the observability hot path, and CI guards it against a 5% regression
+on every PR. Run it locally with:
+
+```bash
+cargo bench -p faucet-core --bench observability
+```
+
+Numbers are hardware-dependent, so run the benchmark on your target machine
+rather than relying on published figures.


### PR DESCRIPTION
Workstreams **WS-8 and WS-9** of the adoption & DX epic (#91).

## WS-8 — CHANGELOG, versioning & release notes
- **CHANGELOG.md** (Keep a Changelog) generated from the real commit history with
  **git-cliff**, grouped by Conventional Commit type — sections for Unreleased /
  0.2.0 / 0.1.4 / 0.1.3 / 0.1.2.
- **cliff.toml** so it regenerates from commit messages (`git cliff -o CHANGELOG.md`):
  merge commits skipped, subject-line only, per-crate tags excluded from release
  sections.
- **SemVer + independent-crate-versioning + MSRV policy** documented in CONTRIBUTING.md.

## WS-9 — trust & supply-chain signals
- **deny.toml + `supply-chain` CI job.** Licenses / bans / sources are a **hard
  gate** (verified locally to pass — added `CDLA-Permissive-2.0` to the allow
  list). RustSec **advisories run informational / non-blocking**: every flagged
  CVE is in a transitive dep we don't control (the AWS SDK's pinned rustls 0.21,
  a DNS library, `paste`), and the advisory DB updates daily — gating hard on it
  would break CI on days nothing changed. Rationale is documented in deny.toml.
- **`coverage` CI job** — cargo-llvm-cov → Codecov, upload non-blocking
  (`fail_ci_if_error: false`).
- **Badges** — coverage (Codecov), cargo-deny, and changelog.
- **Benchmarks** — a tuning-guide section pointing at the existing criterion
  bench + 5% regression gate (no fabricated numbers).

## Verification
- `cargo deny check bans licenses sources` → **ok** locally.
- `git cliff` regenerates a clean CHANGELOG; `mdbook build` clean; all workflow
  YAML validated.

## Owner follow-ups (external setup)
- **Codecov**: connect the repo at codecov.io for the coverage badge to populate
  (the upload step is already non-blocking, so CI is green regardless).
- The advisories step is intentionally informational — revisit if/when the AWS
  SDK and DNS deps publish updates that drop the transitive CVEs.

Part of #91 (WS-8, WS-9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)