### PR TITLE
crates.io keyword tuning + launch kit (WS-10 of #91)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,6 +260,7 @@ Every source/sink crate follows the same module layout. Stick to this when addin
 
 - `lib.rs` — re-exports config + the `Source`/`Sink` type. **First line must be `#![cfg_attr(docsrs, feature(doc_cfg))]`** so docs.rs renders per-item feature badges (see [docs.rs build setup](#docsrs-build-setup)).
 - `config.rs` — config struct + auth/format/pagination sub-enums. Derives `Serialize + Deserialize + JsonSchema`. **No I/O or protocol logic here.**
+- `Cargo.toml` — set **per-crate `keywords`** with the connector's system name first (e.g. `keywords = ["kafka", "streaming", "etl", "pipeline", "connector"]`) so it ranks on crates.io for that system; don't inherit the generic `keywords.workspace`. Keep `categories.workspace = true` (the workspace defaults are valid crates.io slugs — invalid category slugs aren't caught by `cargo publish --dry-run` and break the real publish). Rules: ≤5 keywords, each ≤20 chars, `^[a-z][a-z0-9_-]*$`.
 - `stream.rs` (source) / `sink.rs` (sink) — the one place that performs I/O. Holds reusable clients/pools created in `new()`. Implements `faucet_core::Source` / `Sink` including `config_schema()` via `schemars::schema_for!`.
 - Optional helper modules — `auth/`, `pagination/`, `extract/`, `retry/`, `convert.rs`, `schema.rs`, `decode.rs` / `encode.rs`, `state.rs` for bookmarks, `serde_helpers.rs` for non-serializable types (`reqwest::Method` etc.).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -473,6 +473,28 @@ The user-facing documentation site lives in **`docs/book/`** (an mdBook). Source
 - `.github/workflows/docs.yml` builds the book on every PR (verify) and deploys it to **GitHub Pages** on push to `main`. Pages must be enabled in repo Settings with source = "GitHub Actions"; the published URL is `https://pawansikawat.github.io/faucet-stream/`.
 - **Keep the book in sync** when you change connector config, CLI commands, the config grammar, or add/remove connectors — update the relevant page under `docs/book/src/` alongside the crate README and this file. Content should stay grounded in real configs (reuse the `cli/examples/` YAMLs) rather than invented field names.
 
+## Keeping Docs & Artifacts in Sync
+
+The adoption work in issue **#91** added many user-facing surfaces (docs.rs config, the mdBook docs site on GitHub Pages, the connector capability matrix, runnable examples + Docker stack, the CHANGELOG, supply-chain config, crates.io keywords, README hero/comparison). **These rot the moment the code changes unless updated alongside it.** On any change, work through this trigger → update table and update everything that applies, in the same PR.
+
+| If you change… | Also update (same PR) |
+|---|---|
+| **Add / remove / rename a connector** | umbrella + CLI features; CI `feature-check` matrix (`.github/workflows/ci.yml`); root README connector table **and the counts** (hero "19 sources / 16 sinks", architecture "45 crates — …"); docs-site catalog `docs/book/src/reference/connectors.md` (capability matrix) + `reference/choosing.md`; a `cli/examples/<src>_to_<sink>.yaml`; `examples/README.md` mapping (+ `examples/docker-compose.yml` and `examples/infra/` if it needs new local infra); per-crate crates.io `keywords` + `[package.metadata.docs.rs]` + `#![cfg_attr(docsrs, feature(doc_cfg))]`; the crate table in this file; README "Project Structure" |
+| **Change a connector's config fields / defaults / auth / pagination / behavior** | that crate's `README.md`; root README tables if user-facing; any docs-site page that mentions it (cookbook `auth`/`pagination`/`state`/`compression`, `reference/*`); affected `cli/examples/*.yaml`. (`faucet schema`/`init` are schema-driven — no manual update.) |
+| **Change a connector's streaming / resumable / compression support** | the capability-matrix columns in `docs/book/src/reference/connectors.md` (verify against the code — these were wrong once) |
+| **Change CLI commands or the config-file grammar** | `docs/book/src/reference/cli.md` + `reference/config.md`; `cli/README.md`; root README quickstart |
+| **Change `Source` / `Sink` / `Pipeline` / transform / `FaucetError` APIs** | the Architecture section here; docs-site `getting-started/concepts.md` + `tutorials/library.md`; affected crate READMEs |
+| **Add a dependency that introduces a new license** | `deny.toml` `allow` list (the `supply-chain` CI job enforces this; license rules differ by platform, so a Linux-only dep can fail CI even if local passes) |
+| **Add / move / remove files or directories** | README "Project Structure" (see below) |
+| **File a feature / enhancement issue** | cross-link it to the roadmap epic (the open `epic`-labelled issue, currently #38) |
+
+Key automation to rely on (don't hand-maintain):
+- **CHANGELOG.md is generated** from Conventional Commit messages via `git cliff` (`cliff.toml`) — never hand-edit it; just write `type(scope): summary` commit subjects so it groups correctly.
+- **The docs site auto-deploys** to GitHub Pages on push to `main` that touches `docs/book/**` (`.github/workflows/docs.yml`) — editing `docs/book/src/**` is all that's needed; no manual deploy.
+- **`faucet list` / `schema` / `init`** reflect compiled connectors and config schemas automatically.
+
+Docs-site content must stay **grounded in real configs** — reuse the `cli/examples/` YAMLs and verify field names against the source rather than inventing them.
+
 ## Project Structure Sync
 
 **When adding, removing, or moving files or directories, update the Project Structure section in README.md to reflect the change.**

--- a/README.md
+++ b/README.md
@@ -1089,6 +1089,7 @@ cli/                          — faucet-cli: `faucet` binary, YAML/JSON pipelin
 examples/                     — repo-level examples: docker-compose infra stack + run index
 docs/
   book/                       — mdBook documentation site (source under docs/book/src)
+  launch/                     — launch kit: blog draft + checklist/ready-to-post copy
 .github/workflows/            — ci.yml, release.yml, docs.yml (mdBook → GitHub Pages)
 ```
 

--- a/crates/bigquery-common/Cargo.toml
+++ b/crates/bigquery-common/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "Shared credentials and client construction for the faucet-stream BigQuery source and sink connectors"
 readme = "README.md"
-keywords.workspace = true
+keywords = ["bigquery", "gcp", "etl", "pipeline", "faucet"]
 categories.workspace = true
 
 [dependencies]

--- a/crates/elasticsearch-common/Cargo.toml
+++ b/crates/elasticsearch-common/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "Shared configuration types for the faucet-stream Elasticsearch source and sink connectors"
 readme = "README.md"
-keywords = ["elasticsearch", "search", "etl", "faucet"]
+keywords = ["elasticsearch", "search", "etl", "pipeline", "faucet"]
 categories.workspace = true
 
 [dependencies]

--- a/crates/elasticsearch-common/Cargo.toml
+++ b/crates/elasticsearch-common/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "Shared configuration types for the faucet-stream Elasticsearch source and sink connectors"
 readme = "README.md"
-keywords.workspace = true
+keywords = ["elasticsearch", "search", "etl", "faucet"]
 categories.workspace = true
 
 [dependencies]

--- a/crates/gcs-common/Cargo.toml
+++ b/crates/gcs-common/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "Shared GCS credential and client types for the faucet-stream ecosystem"
 readme = "README.md"
-keywords.workspace = true
+keywords = ["gcs", "gcp", "storage", "etl", "faucet"]
 categories.workspace = true
 
 [dependencies]

--- a/crates/kafka-common/Cargo.toml
+++ b/crates/kafka-common/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "Shared configuration types for the faucet-stream Kafka source and sink connectors"
 readme = "README.md"
-keywords.workspace = true
+keywords = ["kafka", "streaming", "etl", "pipeline", "faucet"]
 categories.workspace = true
 
 [dependencies]

--- a/crates/sink/bigquery/Cargo.toml
+++ b/crates/sink/bigquery/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "BigQuery sink connector for the faucet-stream ecosystem"
 readme = "README.md"
-keywords.workspace = true
+keywords = ["bigquery", "gcp", "etl", "sink", "pipeline"]
 categories.workspace = true
 
 [dependencies]

--- a/crates/sink/csv/Cargo.toml
+++ b/crates/sink/csv/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "CSV file sink connector for the faucet-stream ecosystem"
 readme = "README.md"
-keywords.workspace = true
+keywords = ["csv", "etl", "sink", "pipeline", "data"]
 categories.workspace = true
 
 [dependencies]

--- a/crates/sink/elasticsearch/Cargo.toml
+++ b/crates/sink/elasticsearch/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "Elasticsearch sink connector for the faucet-stream ecosystem"
 readme = "README.md"
-keywords.workspace = true
+keywords = ["elasticsearch", "search", "sink", "pipeline"]
 categories.workspace = true
 
 [dependencies]

--- a/crates/sink/elasticsearch/Cargo.toml
+++ b/crates/sink/elasticsearch/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "Elasticsearch sink connector for the faucet-stream ecosystem"
 readme = "README.md"
-keywords = ["elasticsearch", "search", "sink", "pipeline"]
+keywords = ["elasticsearch", "search", "sink", "pipeline", "connector"]
 categories.workspace = true
 
 [dependencies]

--- a/crates/sink/gcs/Cargo.toml
+++ b/crates/sink/gcs/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "Google Cloud Storage sink connector for the faucet-stream ecosystem"
 readme = "README.md"
-keywords.workspace = true
+keywords = ["gcs", "gcp", "storage", "sink", "pipeline"]
 categories.workspace = true
 
 [dependencies]

--- a/crates/sink/http/Cargo.toml
+++ b/crates/sink/http/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "HTTP POST sink connector for the faucet-stream ecosystem"
 readme = "README.md"
-keywords.workspace = true
+keywords = ["http", "rest", "api", "sink", "pipeline"]
 categories.workspace = true
 
 [dependencies]

--- a/crates/sink/jsonl/Cargo.toml
+++ b/crates/sink/jsonl/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "JSON Lines file sink connector for the faucet-stream ecosystem"
 readme = "README.md"
-keywords.workspace = true
+keywords = ["jsonl", "json", "etl", "sink", "pipeline"]
 categories.workspace = true
 
 [dependencies]

--- a/crates/sink/kafka/Cargo.toml
+++ b/crates/sink/kafka/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "Apache Kafka producer sink for the faucet-stream ecosystem"
 readme = "README.md"
-keywords.workspace = true
+keywords = ["kafka", "streaming", "producer", "sink", "pipeline"]
 categories.workspace = true
 
 [dependencies]

--- a/crates/sink/mongodb/Cargo.toml
+++ b/crates/sink/mongodb/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "MongoDB sink connector for the faucet-stream ecosystem"
 readme = "README.md"
-keywords.workspace = true
+keywords = ["mongodb", "nosql", "database", "sink", "pipeline"]
 categories.workspace = true
 
 [dependencies]

--- a/crates/sink/mysql/Cargo.toml
+++ b/crates/sink/mysql/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "MySQL sink connector for the faucet-stream ecosystem"
 readme = "README.md"
-keywords.workspace = true
+keywords = ["mysql", "sql", "database", "sink", "pipeline"]
 categories.workspace = true
 
 [dependencies]

--- a/crates/sink/parquet/Cargo.toml
+++ b/crates/sink/parquet/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "Apache Parquet file sink connector for the faucet-stream ecosystem"
 readme = "README.md"
-keywords.workspace = true
+keywords = ["parquet", "arrow", "sink", "pipeline", "connector"]
 categories.workspace = true
 
 [dependencies]

--- a/crates/sink/postgres/Cargo.toml
+++ b/crates/sink/postgres/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "PostgreSQL sink connector for the faucet-stream ecosystem"
 readme = "README.md"
-keywords.workspace = true
+keywords = ["postgres", "postgresql", "sql", "sink", "pipeline"]
 categories.workspace = true
 
 [dependencies]

--- a/crates/sink/redis/Cargo.toml
+++ b/crates/sink/redis/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "Redis sink connector for the faucet-stream ecosystem"
 readme = "README.md"
-keywords.workspace = true
+keywords = ["redis", "streaming", "sink", "pipeline", "connector"]
 categories.workspace = true
 
 [dependencies]

--- a/crates/sink/s3/Cargo.toml
+++ b/crates/sink/s3/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "AWS S3 sink connector for the faucet-stream ecosystem"
 readme = "README.md"
-keywords.workspace = true
+keywords = ["s3", "aws", "storage", "sink", "pipeline"]
 categories.workspace = true
 
 [dependencies]

--- a/crates/sink/snowflake/Cargo.toml
+++ b/crates/sink/snowflake/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "Snowflake sink connector for the faucet-stream ecosystem"
 readme = "README.md"
-keywords.workspace = true
+keywords = ["snowflake", "sql", "etl", "sink", "pipeline"]
 categories.workspace = true
 
 [dependencies]

--- a/crates/sink/sqlite/Cargo.toml
+++ b/crates/sink/sqlite/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "SQLite sink connector for the faucet-stream ecosystem"
 readme = "README.md"
-keywords.workspace = true
+keywords = ["sqlite", "sql", "database", "sink", "pipeline"]
 categories.workspace = true
 
 [dependencies]

--- a/crates/sink/stdout/Cargo.toml
+++ b/crates/sink/stdout/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "Stdout/stderr sink connector for the faucet-stream ecosystem"
 readme = "README.md"
-keywords.workspace = true
+keywords = ["stdout", "debug", "sink", "pipeline", "connector"]
 categories.workspace = true
 
 [dependencies]

--- a/crates/snowflake-common/Cargo.toml
+++ b/crates/snowflake-common/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "Shared configuration types for the faucet-stream Snowflake source and sink connectors"
 readme = "README.md"
-keywords.workspace = true
+keywords = ["snowflake", "sql", "etl", "pipeline", "faucet"]
 categories.workspace = true
 
 [dependencies]

--- a/crates/source/bigquery/Cargo.toml
+++ b/crates/source/bigquery/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "BigQuery query source connector for the faucet-stream ecosystem"
 readme = "README.md"
-keywords.workspace = true
+keywords = ["bigquery", "gcp", "etl", "pipeline", "connector"]
 categories.workspace = true
 
 [dependencies]

--- a/crates/source/csv/Cargo.toml
+++ b/crates/source/csv/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "CSV file source connector for the faucet-stream ecosystem"
 readme = "README.md"
-keywords.workspace = true
+keywords = ["csv", "etl", "pipeline", "connector", "data"]
 categories.workspace = true
 
 [features]

--- a/crates/source/elasticsearch/Cargo.toml
+++ b/crates/source/elasticsearch/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "Elasticsearch source connector for the faucet-stream ecosystem"
 readme = "README.md"
-keywords.workspace = true
+keywords = ["elasticsearch", "search", "etl", "pipeline"]
 categories.workspace = true
 
 [dependencies]

--- a/crates/source/elasticsearch/Cargo.toml
+++ b/crates/source/elasticsearch/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "Elasticsearch source connector for the faucet-stream ecosystem"
 readme = "README.md"
-keywords = ["elasticsearch", "search", "etl", "pipeline"]
+keywords = ["elasticsearch", "search", "etl", "pipeline", "connector"]
 categories.workspace = true
 
 [dependencies]

--- a/crates/source/gcs/Cargo.toml
+++ b/crates/source/gcs/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "Google Cloud Storage source connector for the faucet-stream ecosystem"
 readme = "README.md"
-keywords.workspace = true
+keywords = ["gcs", "gcp", "storage", "etl", "pipeline"]
 categories.workspace = true
 
 [dependencies]

--- a/crates/source/graphql/Cargo.toml
+++ b/crates/source/graphql/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "GraphQL API source connector for the faucet-stream ecosystem"
 readme = "README.md"
-keywords.workspace = true
+keywords = ["graphql", "api", "etl", "pipeline", "connector"]
 categories.workspace = true
 
 [dependencies]

--- a/crates/source/grpc/Cargo.toml
+++ b/crates/source/grpc/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "gRPC API source connector for the faucet-stream ecosystem"
 readme = "README.md"
-keywords.workspace = true
+keywords = ["grpc", "protobuf", "etl", "pipeline", "connector"]
 categories.workspace = true
 
 [dependencies]

--- a/crates/source/kafka/Cargo.toml
+++ b/crates/source/kafka/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "Apache Kafka consumer source for the faucet-stream ecosystem"
 readme = "README.md"
-keywords.workspace = true
+keywords = ["kafka", "streaming", "etl", "pipeline", "connector"]
 categories.workspace = true
 
 [dependencies]

--- a/crates/source/mongodb/Cargo.toml
+++ b/crates/source/mongodb/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "MongoDB source connector for the faucet-stream ecosystem"
 readme = "README.md"
-keywords.workspace = true
+keywords = ["mongodb", "nosql", "database", "etl", "pipeline"]
 categories.workspace = true
 
 [dependencies]

--- a/crates/source/mysql/Cargo.toml
+++ b/crates/source/mysql/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "MySQL query source connector for the faucet-stream ecosystem"
 readme = "README.md"
-keywords.workspace = true
+keywords = ["mysql", "sql", "database", "etl", "pipeline"]
 categories.workspace = true
 
 [dependencies]

--- a/crates/source/parquet/Cargo.toml
+++ b/crates/source/parquet/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "Apache Parquet file source connector for the faucet-stream ecosystem"
 readme = "README.md"
-keywords.workspace = true
+keywords = ["parquet", "arrow", "etl", "pipeline", "connector"]
 categories.workspace = true
 
 [dependencies]

--- a/crates/source/postgres-cdc/Cargo.toml
+++ b/crates/source/postgres-cdc/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "PostgreSQL logical replication (CDC) source for the faucet-stream ecosystem"
 readme = "README.md"
-keywords.workspace = true
+keywords = ["postgres", "cdc", "replication", "etl", "pipeline"]
 categories.workspace = true
 
 [dependencies]

--- a/crates/source/postgres/Cargo.toml
+++ b/crates/source/postgres/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "PostgreSQL query source connector for the faucet-stream ecosystem"
 readme = "README.md"
-keywords.workspace = true
+keywords = ["postgres", "postgresql", "sql", "etl", "pipeline"]
 categories.workspace = true
 
 [dependencies]

--- a/crates/source/redis/Cargo.toml
+++ b/crates/source/redis/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "Redis source connector for the faucet-stream ecosystem"
 readme = "README.md"
-keywords.workspace = true
+keywords = ["redis", "streaming", "etl", "pipeline", "connector"]
 categories.workspace = true
 
 [dependencies]

--- a/crates/source/rest/Cargo.toml
+++ b/crates/source/rest/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "REST API source connector for the faucet-stream ecosystem"
 readme = "README.md"
-keywords.workspace = true
+keywords = ["rest", "http", "api", "etl", "pipeline"]
 categories.workspace = true
 
 [features]

--- a/crates/source/s3/Cargo.toml
+++ b/crates/source/s3/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "AWS S3 source connector for the faucet-stream ecosystem"
 readme = "README.md"
-keywords.workspace = true
+keywords = ["s3", "aws", "storage", "etl", "pipeline"]
 categories.workspace = true
 
 [dependencies]

--- a/crates/source/snowflake/Cargo.toml
+++ b/crates/source/snowflake/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "Snowflake query source connector for the faucet-stream ecosystem"
 readme = "README.md"
-keywords.workspace = true
+keywords = ["snowflake", "sql", "etl", "pipeline", "connector"]
 categories.workspace = true
 
 [dependencies]

--- a/crates/source/sqlite/Cargo.toml
+++ b/crates/source/sqlite/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "SQLite query source connector for the faucet-stream ecosystem"
 readme = "README.md"
-keywords.workspace = true
+keywords = ["sqlite", "sql", "database", "etl", "pipeline"]
 categories.workspace = true
 
 [dependencies]

--- a/crates/source/webhook/Cargo.toml
+++ b/crates/source/webhook/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "Webhook receiver source connector for the faucet-stream ecosystem"
 readme = "README.md"
-keywords.workspace = true
+keywords = ["webhook", "http", "etl", "pipeline", "connector"]
 categories.workspace = true
 
 [dependencies]

--- a/crates/source/xml/Cargo.toml
+++ b/crates/source/xml/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "XML API source connector for the faucet-stream ecosystem"
 readme = "README.md"
-keywords.workspace = true
+keywords = ["xml", "soap", "etl", "pipeline", "connector"]
 categories.workspace = true
 
 [dependencies]

--- a/crates/state/postgres/Cargo.toml
+++ b/crates/state/postgres/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "PostgreSQL-backed StateStore for faucet-stream incremental replication"
 readme = "README.md"
-keywords.workspace = true
+keywords = ["postgres", "state", "bookmark", "etl", "faucet"]
 categories.workspace = true
 
 [dependencies]

--- a/crates/state/redis/Cargo.toml
+++ b/crates/state/redis/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 description = "Redis-backed StateStore for faucet-stream incremental replication"
 readme = "README.md"
-keywords.workspace = true
+keywords = ["redis", "state", "bookmark", "etl", "faucet"]
 categories.workspace = true
 
 [dependencies]

--- a/docs/launch/README.md
+++ b/docs/launch/README.md
@@ -1,0 +1,94 @@
+# Launch kit (WS-10)
+
+Ready-to-use copy and a checklist for the 1.0 launch. The drafts here are
+deliverables — **the actual posting/submitting is a manual step only the
+maintainer can do** (each lives on an external site or needs your account).
+
+## Pre-launch checklist (in-repo, mostly done)
+
+- [x] Per-crate crates.io **keywords** tuned so each connector ranks for its
+      system name (e.g. `faucet-source-kafka` → `kafka`). See each crate's
+      `Cargo.toml`.
+- [x] docs.rs renders the full API (WS-1); docs site live (WS-4); README hero +
+      comparison (WS-2); architecture diagram + badges (WS-3).
+- [ ] **Logo / social-preview banner** set in repo Settings → Social preview
+      (WS-3 — needs the logo asset).
+- [ ] Tag and publish a release (coordinate the posts below with the tag).
+
+## Manual launch steps (maintainer)
+
+### 1. awesome-rust PR
+
+Fork [`rust-unofficial/awesome-rust`](https://github.com/rust-unofficial/awesome-rust),
+add this line under a relevant section (e.g. *Database* → *ETL* or *Data
+processing*), and open a PR:
+
+```markdown
+* [faucet-stream](https://github.com/PawanSikawat/faucet-stream) — A fast, config-driven data-movement toolkit: 35 source/sink connectors wired by a single `faucet` binary (YAML) or embedded as a Rust library; streaming, CDC, DLQ, and built-in metrics.
+```
+
+Also consider [`awesome-data-engineering`](https://github.com/igorbarinov/awesome-data-engineering).
+
+### 2. This Week in Rust
+
+Submit via the ["Send us a PR" form / issue](https://github.com/rust-lang/this-week-in-rust)
+(Crate of the Week nominations + project updates). Suggested blurb:
+
+> **faucet-stream** — a config-driven data pipeline toolkit: 35 connectors, a
+> `faucet` CLI that runs pipelines from YAML, and an embeddable library, with
+> streaming, Postgres CDC, dead-letter queues, and built-in Prometheus/tracing.
+
+### 3. Show HN
+
+**Title:** `Show HN: faucet-stream – move data between APIs, DBs, and warehouses with one Rust binary`
+
+**Body:**
+
+> Hi HN — I built faucet-stream, a config-driven data-movement toolkit for Rust.
+> It's a single static binary that runs pipelines from a YAML file (no platform,
+> no Python, no daemon), or an embeddable library with typed Source/Sink traits.
+>
+> 35 connectors today (REST, GraphQL, gRPC, Kafka, Postgres incl. CDC, MySQL,
+> SQLite, S3/GCS, Parquet, MongoDB, Redis, Elasticsearch, BigQuery, Snowflake),
+> with native streaming (bounded memory), incremental/resumable replication,
+> dead-letter queues, retries, and built-in Prometheus metrics + tracing — no
+> per-connector code.
+>
+> It's the EL of ELT — I'm upfront in the README about where Meltano/Airbyte/dbt
+> fit better. Pre-1.0 and moving fast; connector requests welcome.
+>
+> Docs: https://pawansikawat.github.io/faucet-stream/
+> Repo: https://github.com/PawanSikawat/faucet-stream
+
+Post early in the US morning (Pacific) on a weekday; reply to comments quickly.
+
+### 4. Reddit — r/rust
+
+**Title:** `faucet-stream: a config-driven data-movement toolkit (35 connectors, streaming, CDC) — CLI or embeddable library`
+
+Lead with the Rust angle: single binary, typed traits, every connector a Cargo
+feature, performance-first design (connection reuse, multi-row inserts, bounded
+streaming). Link the repo + docs. (Follow r/rust self-promotion etiquette —
+frame it as "I built this, feedback welcome," not an ad.)
+
+### 5. Reddit — r/dataengineering
+
+**Title:** `Built an open-source, single-binary alternative to Meltano/Airbyte for moving data (Rust)`
+
+Lead with the data-engineering pain: no platform to operate, version-controlled
+YAML pipelines, runs on cron/CI, CDC + incremental + DLQ built in. Be honest
+about connector-count vs. incumbents (it's in the README comparison). Link repo +
+docs + the blog post.
+
+### 6. Blog post
+
+`blog-post.md` in this folder is a full draft ("Moving data in Rust shouldn't
+require a platform"). Publish on your blog / dev.to, then link it from the Show
+HN and Reddit threads.
+
+## Notes
+
+- Coordinate all posts with the release tag so first-time visitors land on a
+  tagged, installable version.
+- The repo's **social-preview image** (Settings → Social preview, 1280×640) is
+  what renders when these links are shared — set it before posting (WS-3).

--- a/docs/launch/blog-post.md
+++ b/docs/launch/blog-post.md
@@ -1,0 +1,72 @@
+# Moving data in Rust shouldn't require a platform — introducing faucet-stream
+
+*Draft launch post. Edit voice/details before publishing, then post to your blog / dev.to / Medium and link it from the Show HN and Reddit threads (see `README.md` in this folder).*
+
+---
+
+Every data team eventually hits the same wall: you need to move records from an
+API into a warehouse, from Postgres into Kafka, from S3 into Elasticsearch — and
+your options are a Python framework with a plugin runtime to operate, a hosted
+SaaS with per-row pricing, or a pile of one-off scripts that rot.
+
+**faucet-stream** is a different answer: a single fast Rust binary (and an
+embeddable library) that runs data pipelines from a YAML file.
+
+```bash
+cargo install faucet-cli
+faucet run pipeline.yaml
+```
+
+```yaml
+version: 1
+pipeline:
+  source: { type: postgres, config: { connection_url: "${env:PG_URL}", query: "select * from events" } }
+  transforms: [{ type: snake_case }]
+  sink: { type: bigquery, config: { project_id: my-proj, dataset_id: analytics, table_id: events } }
+```
+
+No daemon, no scheduler, no Python environment. Drop the binary on a box, point
+it at a config, run it on cron. Or `cargo add faucet-stream` and build the same
+pipeline from Rust with typed `Source`/`Sink` traits.
+
+## What's in the box
+
+- **35 connectors** across REST, GraphQL, gRPC, Kafka, Postgres/MySQL/SQLite,
+  Postgres CDC, S3/GCS, Parquet, MongoDB, Redis, Elasticsearch, BigQuery, and
+  Snowflake.
+- **A real runtime, not just connectors:** native streaming with bounded memory,
+  incremental + resumable replication, change-data-capture, dead-letter queues,
+  automatic retries, and built-in Prometheus metrics + `tracing` spans — with
+  zero per-connector code.
+- **Config-driven *or* embeddable:** the CLI and the library are the same engine.
+- **Pay only for what you compile:** every connector is a Cargo feature.
+
+## Why Rust
+
+Performance and reliability are the whole point. Every connector reuses
+connections, pools, batches into multi-row inserts and bulk APIs, and streams
+with bounded memory — so a pipeline is the fastest way to move its data in Rust,
+not a thin wrapper that falls over at scale. And because it's a single static
+binary, "deploying" is copying a file.
+
+## Where it fits (and where it doesn't)
+
+faucet-stream is for **moving** data — the EL of ELT. If you need a connector we
+don't ship yet, mature ecosystems like Meltano (600+ Singer taps) or Airbyte
+still have far broader catalogs today, and we're honest about that in the README.
+If your job is in-warehouse transformation, that's dbt's job — pair them. And if
+you need a long-running streaming *service*, Benthos/Redpanda Connect or Vector
+are purpose-built for that; faucet runs pipelines to completion.
+
+But if you want one fast, trustworthy binary to move data between the systems you
+already run — without standing up a platform — that's exactly what we built.
+
+## Try it
+
+- Docs: <https://pawansikawat.github.io/faucet-stream/>
+- Source: <https://github.com/PawanSikawat/faucet-stream>
+- Crates: <https://crates.io/crates/faucet-stream>
+
+It's pre-1.0 and moving fast. Connector requests and contributions welcome —
+there's a [contributing guide](https://github.com/PawanSikawat/faucet-stream/blob/main/CONTRIBUTING.md)
+and an authoring guide for building your own connector crates.


### PR DESCRIPTION
Final workstream of the adoption & DX epic (#91) — discoverability & launch prep. This is the in-repo half; the external posting steps are documented for the maintainer to execute.

## In-repo (this PR)
- **Per-crate crates.io `keywords`** tuned across all 42 connector / common / state crates so each ranks for its system name on crates.io — `faucet-source-kafka` → `kafka`, `faucet-sink-bigquery` → `bigquery`, etc. — instead of inheriting the generic workspace keywords. All sets validated against crates.io rules (≤5 keywords, ≤20 chars, valid charset).
  - `categories` deliberately **left at the validated workspace default**: invalid category slugs are **not** caught by `cargo publish --dry-run` (server-side validation only), so changing them risks breaking a real publish. Keywords carry the discoverability win.
- **`docs/launch/`** — a launch blog draft + a checklist with ready-to-post copy: awesome-rust entry line, This Week in Rust blurb, Show HN title+body, r/rust and r/dataengineering posts.
- CLAUDE.md documents the per-crate keyword convention; README project structure updated.

## Maintainer follow-ups (external — can't be done in a PR)
- Open the **awesome-rust** PR (entry text provided).
- Submit to **This Week in Rust**.
- Post **Show HN** + **r/rust** + **r/dataengineering**, coordinated with a release tag.
- Set the repo **social-preview image** (needs the WS-3 logo).

## Verification
- `cargo metadata` parses all manifests; a keyword-rules check confirms every set is ≤5 keywords / ≤20 chars / valid charset.

Part of #91 (WS-10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)