### PR TITLE
docs: add logo to the mdBook landing page

### DIFF
--- a/docs/book/src/assets/logo.svg
+++ b/docs/book/src/assets/logo.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="128" height="128" role="img" aria-label="faucet-stream logo">
+  <title>faucet-stream</title>
+  <!-- Tile background: solid teal -->
+  <rect x="6" y="6" width="116" height="116" rx="28" fill="#14B8A6"/>
+  <!-- Faucet spout + valve handle, white on teal -->
+  <g fill="none" stroke="#ffffff" stroke-width="11" stroke-linecap="round" stroke-linejoin="round" transform="translate(-2,2)">
+    <path d="M55 40 V26"/>
+    <path d="M44 26 H66"/>
+    <path d="M34 40 H76 a14 14 0 0 1 14 14 V64"/>
+  </g>
+  <!-- Data stream: white droplets fading as they fall -->
+  <g fill="#ffffff" transform="translate(-2,2)">
+    <circle cx="90" cy="79" r="5.5"/>
+    <circle cx="90" cy="95" r="4.6" opacity="0.85"/>
+    <circle cx="90" cy="108" r="3.6" opacity="0.6"/>
+  </g>
+</svg>

--- a/docs/book/src/introduction.md
+++ b/docs/book/src/introduction.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="assets/logo.svg" alt="faucet-stream logo" width="112" height="112">
+</p>
+
 # faucet-stream
 
 **The fast, config-driven way to move data in Rust.**


### PR DESCRIPTION
The README got the brand logo in #103, but the docs site at <https://pawansikawat.github.io/faucet-stream/> still had zero brand presence — visitors landing there saw only mdBook's default chrome.

This adds the solid-teal tile centered above the title on the **Introduction page** (the docs landing page). mdBook copies `docs/book/src/assets/logo.svg` to the rendered output and the relative `src="assets/logo.svg"` resolves cleanly from the intro page.

**Skipped for now** (deliberately, to keep this risk-free):

- **Site-wide menu-bar logo** — would need `additional-js` to inject `<img>` into every page's menu, plus path-resolution code per page depth.
- **Favicon override** — mdBook 0.5 dropped the clean `theme/favicon.*` path; the workaround is either an `additional-js` DOM hack or a post-build sed in `docs.yml`. Both add fragility.

Both can be follow-ups when there's a reason to invest. The brand favicon files already sit in `.github/assets/` ready when we wire it.

Will auto-deploy to GitHub Pages on merge (the `docs.yml` workflow triggers on `docs/book/**`).

Part of #91 (WS-3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)