### PR TITLE
ci(release): automate per-crate releases with release-plz

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,105 @@
+name: release-plz
+
+# Automates per-crate version bumps, changelog entries, and crates.io
+# publishing for the 45-crate workspace.
+#
+# - `release-plz-pr` (every push to main): opens or updates a "chore: release"
+#   PR that bumps versions and prepends changelog entries for every crate with
+#   feat/fix/perf commits since its last per-crate tag. Review the PR like any
+#   other change; merging it triggers the publish job.
+# - `release-plz-release` (every push to main): after a release PR merges and
+#   the new commits are on `main`, publishes the bumped crates to crates.io
+#   in dependency order, creates per-crate GitHub releases, and pushes
+#   per-crate `<crate>-v<X.Y.Z>` tags.
+#
+# Config lives in /release-plz.toml. The legacy manual `release.yml`
+# (`workflow_dispatch` waves-of-5) is retained as a fallback only — see
+# CONTRIBUTING.md for when to use it.
+
+on:
+  push:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  release-plz-pr:
+    name: Open / update release PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    # Only one release-PR job at a time so concurrent merges to main don't race
+    # on the same release branch.
+    concurrency:
+      group: release-plz-pr-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      # Required by `rdkafka` (faucet-source-kafka / faucet-sink-kafka) and the
+      # OpenSSL-backed reqwest variants. release-plz runs `cargo publish` for
+      # each bumped crate, which compiles the crate; the build fails without
+      # these system libraries.
+      - name: Install librdkafka prerequisites
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libsasl2-dev libssl-dev libcurl4-openssl-dev cmake build-essential
+
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+          config: release-plz.toml
+        env:
+          # Use `RELEASE_PLZ_TOKEN` (a PAT or GitHub App token with
+          # `contents: write` + `pull-requests: write`) when set, falling back
+          # to the default `GITHUB_TOKEN`. Note: PRs opened by the default
+          # `GITHUB_TOKEN` do NOT trigger downstream workflow runs (i.e. CI
+          # won't run on the release PR) — set `RELEASE_PLZ_TOKEN` to a PAT or
+          # App token to get CI on the release PR.
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN || secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  release-plz-release:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    # Serialize publishes against each other — release-plz handles dependency
+    # ordering internally, but two concurrent runs would race on the registry.
+    concurrency:
+      group: release-plz-release-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install librdkafka prerequisites
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libsasl2-dev libssl-dev libcurl4-openssl-dev cmake build-essential
+
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+          config: release-plz.toml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,13 @@
-name: Release
+name: Release (manual fallback)
+
+# Manual release workflow — retained as a fallback for ad-hoc / partial
+# releases. The default release path is now `release-plz.yml`, which runs
+# automatically on every push to `main` (opens a release PR; publishes on
+# merge). Use this workflow only when:
+#   - release-plz is unavailable, or
+#   - you need a one-off bulk re-publish (e.g. scope=all after a registry
+#     incident or a CI regression that broke the automatic flow).
+# See CONTRIBUTING.md (#release-process) for the recommended flow.
 
 on:
   workflow_dispatch:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -441,7 +441,9 @@ Key workspace deps: `serde` 1, `serde_json` 1, `schemars` 1.2, `async-trait` 0.1
 
 ## Publishing
 
-Crates publish in dependency order, topologically sorted then pushed to crates.io in **waves of 5 with a 15-minute wait between waves** (so each wave's crates have propagated through the crates.io index before the next wave depends on them). `.github/workflows/release.yml` handles this; it is **`workflow_dispatch`-triggered** (manual run with `scope` = `all` / `custom`, a version-bump input, and a `dry_run` toggle), not tag-triggered.
+The default release path is **[release-plz](https://release-plz.dev/)** (`release-plz.toml` + `.github/workflows/release-plz.yml`). On every push to `main` release-plz scans for `feat` / `fix` / `perf` commits since each crate's last `<crate>-v<X.Y.Z>` tag and opens (or updates) a `chore: release` PR that bumps the affected crates, prepends per-crate sections to `CHANGELOG.md`, and leaves untouched crates alone. Merging that PR publishes to crates.io in dependency order (release-plz waits for sparse-index propagation between dependents) and pushes per-crate tags. Independent per-crate versions are the release-plz default; `docs`/`chore`/`refactor`/`test`/`ci`/`build` commits are filtered out of version bumps via `release_commits = "^(feat|fix|perf)"` so README-only edits don't trigger a publish. Tokens: `CARGO_REGISTRY_TOKEN` is required; `RELEASE_PLZ_TOKEN` (PAT or GitHub App) is recommended so the release PR triggers CI — the default `GITHUB_TOKEN` is forbidden by GitHub from triggering downstream workflows.
+
+`.github/workflows/release.yml` (`Release (manual fallback)`) is retained as a `workflow_dispatch` workflow for ad-hoc / bulk re-publishes (registry incidents, re-publish all 45 crates from a known-good revision). It still bumps with `cargo-release` and publishes in **waves of 5 with a 15-minute wait between waves**. Use it only as a fallback; day-to-day releases go through release-plz. Both workflows share the same per-crate tag format (`<crate>-v<X.Y.Z>`) so they don't fight each other.
 
 ### docs.rs build setup
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,16 +104,67 @@ are tracked in the roadmap epic (search the `epic` label).
   default in a way that alters behavior — not just Rust API changes.
 - **Independent crate versions.** Connector crates version independently on
   crates.io, so `faucet-source-rest` and `faucet-sink-bigquery` may sit at
-  different versions. The repo-level `vX.Y.Z` tags track the overall release line.
-- **Changelog.** Notable changes are recorded in [CHANGELOG.md](./CHANGELOG.md),
-  generated from Conventional Commit messages via
-  [git-cliff](https://git-cliff.org) (`cliff.toml`). Write commit subjects as
-  `type(scope): summary` (`feat`, `fix`, `perf`, `refactor`, `docs`, `test`,
-  `ci`, `chore`) so they're grouped correctly.
+  different versions. Per-crate tags use the form `<crate>-v<X.Y.Z>` (e.g.
+  `faucet-source-rest-v0.2.0`); the repo-level `vX.Y.Z` tags track the overall
+  release line.
+- **Changelog.** Notable changes are recorded in [CHANGELOG.md](./CHANGELOG.md).
+  release-plz appends a per-crate section every time it opens a release PR,
+  reading the commit log via git-cliff internals; `cliff.toml` is retained for
+  manual `git cliff` invocations on demand but is no longer the auto-generation
+  path. Write commit subjects as `type(scope): summary` (`feat`, `fix`, `perf`,
+  `refactor`, `docs`, `test`, `ci`, `chore`) so they're grouped correctly.
 - **MSRV.** The minimum supported Rust version is pinned in
   `rust-toolchain.toml` and enforced by CI (fmt/clippy/test/docs all run on it).
   Bumping the MSRV is itself a notable change — raise it only when needed and
   note it in the changelog.
+
+## Release process
+
+The default release path is automated by [release-plz](https://release-plz.dev/)
+(`release-plz.toml` + `.github/workflows/release-plz.yml`).
+
+1. **Push to `main`** (typically via merging a feature PR). release-plz scans
+   for `feat` / `fix` / `perf` commits since each crate's last `<crate>-v<X.Y.Z>`
+   tag and opens (or updates) a `chore: release` PR that:
+   - bumps the version of every crate with qualifying commits,
+   - prepends a per-crate section to `CHANGELOG.md`,
+   - leaves the other 44 crates untouched.
+2. **Review the release PR** like any other change. Edit the changelog text if
+   you want different wording; the version bumps follow SemVer from the commit
+   prefixes (`feat` → minor, `fix` / `perf` → patch, anything tagged
+   `BREAKING CHANGE` → major).
+3. **Merge the release PR.** release-plz then publishes the bumped crates to
+   crates.io in dependency order (`faucet-core` and the `*-common` crates
+   before connectors before `faucet-stream` and `faucet-cli`), waits for the
+   sparse index to propagate between dependents, creates per-crate GitHub
+   releases, and pushes the `<crate>-v<X.Y.Z>` tags.
+
+**Commits that don't bump versions.** `docs`, `chore`, `refactor`, `test`, `ci`,
+and `build` commits are included in the changelog body for completeness but do
+not trigger a version bump (`release_commits` filter in `release-plz.toml`). A
+README-only edit never causes a spurious publish.
+
+**Manual fallback.** `.github/workflows/release.yml` (`Release (manual fallback)`)
+is kept as a `workflow_dispatch` workflow for ad-hoc / bulk re-publishes (e.g.
+after a registry incident, or to re-publish all 45 crates from a known-good
+revision). Day-to-day releases should go through release-plz.
+
+**Dry-run locally.** Before relying on a release PR, you can preview what
+release-plz would do:
+
+```bash
+cargo install release-plz --locked
+release-plz release-pr --dry-run     # prints the diff it would commit
+release-plz release    --dry-run     # prints what it would publish, in order
+```
+
+**Tokens required (configured in repo Settings → Secrets).**
+- `CARGO_REGISTRY_TOKEN` — crates.io API token with publish scope for every
+  `faucet-*` crate.
+- `RELEASE_PLZ_TOKEN` (optional but recommended) — a PAT or GitHub App token
+  with `contents: write` + `pull-requests: write`. Without it the release PR
+  is opened by the default `GITHUB_TOKEN`, which by GitHub policy does **not**
+  trigger downstream workflow runs — CI won't run on the release PR.
 
 ## License
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,6 +1,14 @@
-# git-cliff configuration — generates CHANGELOG.md from Conventional Commits.
-#   git cliff -o CHANGELOG.md            # regenerate the whole file
-#   git cliff --unreleased --prepend CHANGELOG.md   # add the unreleased section
+# git-cliff configuration — manual `git cliff` invocations only.
+#
+# As of #97, `CHANGELOG.md` is auto-maintained by release-plz on every
+# release PR (config: /release-plz.toml, [changelog] block). This file is
+# retained for one-off `git cliff` runs (e.g. regenerating the full history
+# from scratch, or previewing the unreleased section locally without going
+# through release-plz):
+#
+#   git cliff -o CHANGELOG.md                       # regenerate the whole file
+#   git cliff --unreleased --prepend CHANGELOG.md   # preview unreleased section
+#
 # See https://git-cliff.org
 
 [changelog]

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,94 @@
+# release-plz configuration — automates per-crate version bumps, per-crate
+# changelog entries, and crates.io publishing for the 45-crate workspace.
+#
+# Docs: https://release-plz.dev/docs/config
+#
+# Companion workflow: .github/workflows/release-plz.yml runs `release-pr` on
+# every push to main (opens/updates a "chore: release" PR with the bumped
+# versions + changelog entries) and `release` on PR merge (publishes the
+# bumped crates to crates.io and creates per-crate GitHub releases).
+#
+# The legacy manual `.github/workflows/release.yml` (`workflow_dispatch` with
+# waves-of-5 publishing) is retained as a fallback for ad-hoc / partial
+# releases; release-plz is the default path. See CONTRIBUTING.md.
+
+[workspace]
+# Independent per-crate versioning is release-plz's default — no opt-in
+# needed. Each crate bumps only when there are conventional commits touching
+# its directory since its last per-crate tag.
+
+# Match the existing tag format produced by the legacy `cargo-release` flow
+# (`<crate>-v<X.Y.Z>`, e.g. `faucet-source-rest-v0.2.0`) so release-plz reads
+# the correct "last release" state for every crate without retagging history.
+# This is also the default for workspaces with multiple publishable packages,
+# but we pin it explicitly to future-proof against default changes.
+git_tag_name = "{{ package }}-v{{ version }}"
+
+# Create a per-crate GitHub release for each crate that bumps. The release
+# notes use the changelog body template below.
+git_release_enable = true
+
+# Aggregate every bumped crate's changelog entries into the single root
+# CHANGELOG.md (already managed by the project today). Per-crate
+# CHANGELOG.md files in 45 separate locations would be noisy for a
+# marketplace-style workspace; one repo-level file matches the existing
+# layout and CHANGELOG.md badge in the README.
+changelog_path = "./CHANGELOG.md"
+
+# Crates.io sparse-index propagation: release-plz publishes in dependency
+# order and polls between dependent publishes until each new version is
+# visible in the index. 30 minutes is the action's default and is more than
+# enough for the deepest dependency chain in the workspace (faucet-core →
+# common → connector → umbrella → cli). Pinning makes the expectation
+# explicit; with this in place the manual workflow's waves-of-5/15-minute
+# pacing is no longer required.
+publish_timeout = "30m"
+
+# Only feat / fix / perf commits trigger a version bump. docs / chore /
+# refactor / test / ci / build commits still appear in the changelog body
+# (so the rendered diff is complete) but won't cause a spurious bump on a
+# README-only edit. Aligns with the "version reflects user-visible
+# behaviour" stance in CONTRIBUTING.md.
+release_commits = "^(feat|fix|perf)"
+
+# Changelog body template — mirrors cliff.toml so rendered output looks the
+# same as past entries. release-plz uses git-cliff internally but no longer
+# honours the deprecated `changelog_config = "cliff.toml"` pointer, so the
+# template is inlined here. `cliff.toml` is retained for manual `git cliff`
+# invocations on demand.
+[changelog]
+header = """# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+(see the versioning policy in CONTRIBUTING.md — connector crates version
+independently).
+"""
+
+body = """
+## `{{ package }}` — [{{ version }}]{%- if release_link %}({{ release_link }}){% endif %} - {{ timestamp | date(format="%Y-%m-%d") }}
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+{% for commit in commits %}
+- {% if commit.scope %}*({{ commit.scope }})* {% endif %}{% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message | split(pat="\n") | first | trim | upper_first }}
+{%- endfor %}
+{% endfor %}
+"""
+
+commit_parsers = [
+    { message = "^Merge (pull request|branch|remote)", skip = true },
+    { message = "^feat", group = "Features" },
+    { message = "^fix", group = "Bug Fixes" },
+    { message = "^perf", group = "Performance" },
+    { message = "^refactor", group = "Refactor" },
+    { message = "^docs", group = "Documentation" },
+    { message = "^test", group = "Testing" },
+    { message = "^ci", group = "CI & Build" },
+    { message = "^build", group = "CI & Build" },
+    { message = "^chore\\(release\\)", skip = true },
+    { message = "^chore\\(deps\\)", skip = true },
+    { message = "^chore", group = "Miscellaneous" },
+    { message = ".*", group = "Other" },
+]


### PR DESCRIPTION
## Summary

Adopts [release-plz](https://release-plz.dev/) to drive per-crate version bumps, changelog updates, and crates.io publishing automatically — addressing the manual judgment currently required to decide which of the 45 crates to release after a change.

- **`release-plz.toml`** — independent per-crate versions (release-plz default), existing `<crate>-v<X.Y.Z>` tag format pinned explicitly, `publish_timeout = "30m"` for sparse-index propagation between dependents, `release_commits = "^(feat|fix|perf)"` so docs/chore/refactor/test/ci/build commits never trigger a bump, and an inline `[changelog]` body mirroring `cliff.toml` (release-plz deprecated the `changelog_config = "cliff.toml"` pointer).
- **`.github/workflows/release-plz.yml`** — split `release-pr` and `release` jobs. Triggers on push to `main`; the PR job opens/updates a `chore: release` PR, the release job publishes on merge in dependency order, polls the sparse index between dependents, creates per-crate GitHub releases, and pushes `<crate>-v<X.Y.Z>` tags. Includes the apt prereqs (`libsasl2-dev`, `libssl-dev`, `libcurl4-openssl-dev`, `cmake`, `build-essential`) that `rdkafka` needs at `cargo publish` time. Falls back to `GITHUB_TOKEN` if `RELEASE_PLZ_TOKEN` isn't set, with a comment about CI not running on the release PR in that case.
- **`.github/workflows/release.yml`** — renamed to `Release (manual fallback)` with a header comment explaining it's now `workflow_dispatch`-only. Kept intact (no logic change) for ad-hoc / bulk re-publishes after registry incidents.
- **`CONTRIBUTING.md`** — new "Release process" section walks through the release-plz flow, lists the required secrets, documents the dry-run path, and points to the manual fallback. Versioning section updated to mention the `<crate>-v<X.Y.Z>` tag form.
- **`CLAUDE.md`** — "Publishing" section rewritten to reflect release-plz as primary; manual `release.yml` documented as fallback.
- **`cliff.toml`** — header comment clarifies it's now manual-only; release-plz owns `CHANGELOG.md` auto-generation.

## Why

> Crates version independently … after changing one connector you must work out the smallest correct bump and whether dependents need their dependency requirement bumped + re-released. Getting this wrong means either churn (re-publishing all 45 crates) or a broken release.
> — #97

release-plz removes the judgment call: it diffs each crate against its last published version, bumps only what changed (plus dependents whose requirements need it), opens a release PR, and publishes on merge.

## Acceptance criteria (from #97)

- [x] A change to a single connector results in a release PR that bumps only that crate (+ dependents that genuinely need it), not all 45. (release-plz's independent-versioning default — verified against the docs.)
- [x] Per-crate changelogs generated from Conventional Commits. (`[changelog]` block in `release-plz.toml`.)
- [x] Dry-run path documented. (`release-plz release-pr --dry-run` / `release --dry-run` in `CONTRIBUTING.md`.)
- [x] Publish ordering respects crates.io index propagation. (release-plz publishes in topological dependency order and uses `publish_timeout` to poll the sparse index.)
- [x] `CONTRIBUTING.md` documents the new release flow.

## Required setup (out of PR scope — repo owner)

Before the workflow can actually publish, two secrets need to be configured in repo Settings → Secrets and variables → Actions:
- `CARGO_REGISTRY_TOKEN` — crates.io API token with publish scope on every `faucet-*` crate.
- `RELEASE_PLZ_TOKEN` — recommended PAT or GitHub App token (`contents: write`, `pull-requests: write`) so the release PR triggers downstream CI. Falls back to `GITHUB_TOKEN`, which by GitHub policy cannot trigger workflow runs.

The first release PR after merge will include any conventional commits made since each crate's last manual tag.

## Test plan

- [ ] CI passes (fmt / clippy / test / docs).
- [ ] After merge, the `release-plz-pr` job opens a `chore: release` PR within ~1 minute.
- [ ] Inspect the first release PR — verify only crates with `feat`/`fix`/`perf` commits since their last tag are bumped, and the changelog body looks like `cliff.toml`'s.
- [ ] Owner configures `CARGO_REGISTRY_TOKEN` and (recommended) `RELEASE_PLZ_TOKEN` in repo secrets.

Closes #97