### PR TITLE
feat(source-websocket): WebSocket streaming source connector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,7 @@ jobs:
           - source-mongodb
           - source-redis
           - source-webhook
+          - source-websocket
           - source-csv
           - source-elasticsearch
           - source-kafka

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ This workspace produces both library crates (`faucet-core` + every connector and
 
 ## Workspace Structure
 
-Cargo workspace, 45 crates (44 libraries + the `faucet-cli` binary). All connector crates depend only on `faucet-core`; the umbrella `faucet-stream` and the `faucet-cli` binary depend on every connector + state crate via optional features.
+Cargo workspace, 46 crates (45 libraries + the `faucet-cli` binary). All connector crates depend only on `faucet-core`; the umbrella `faucet-stream` and the `faucet-cli` binary depend on every connector + state crate via optional features.
 
 | Crate | Path | Description |
 |-------|------|-------------|
@@ -32,6 +32,7 @@ Cargo workspace, 45 crates (44 libraries + the `faucet-cli` binary). All connect
 | `faucet-source-mongodb` | `crates/source/mongodb/` | MongoDB source — find() with filter/projection/sort |
 | `faucet-source-redis` | `crates/source/redis/` | Redis source — streams, lists, key patterns |
 | `faucet-source-webhook` | `crates/source/webhook/` | Webhook source — temporary HTTP server collecting POSTs |
+| `faucet-source-websocket` | `crates/source/websocket/` | WebSocket source — live streaming, subscription frames, reconnect |
 | `faucet-source-csv` | `crates/source/csv/` | CSV file source |
 | `faucet-source-elasticsearch` | `crates/source/elasticsearch/` | Elasticsearch source — search/scroll API |
 | `faucet-source-parquet` | `crates/source/parquet/` | Parquet source — local, glob, or S3; vectorized Arrow async reader, projection |
@@ -180,7 +181,7 @@ All connectors must be optimised for throughput by default. When modifying or ad
 
 Every `Pipeline::run` drives `Source::stream_pages(ctx, batch_size)` internally and writes each emitted `StreamPage` to the sink as it arrives. This bounds memory at O(batch_size) on both sides regardless of total record volume.
 
-Sources that override `stream_pages` to stream natively from their underlying primitive: `rest`, `graphql`, `postgres`, `postgres-cdc`, `mysql`, `sqlite`, `mongodb`, `s3` (JSONL/RawText modes), `gcs` (JSONL/RawText modes), `parquet`, `csv`, `xml`, `elasticsearch` (scroll API), `kafka`, `redis` (all three modes), `grpc` (server-streaming mode only). Sources that intentionally keep the default chunk-the-buffer impl: `grpc` (unary mode — no native paging primitive), `webhook` (buffer-shaped by nature). Client-streaming and bidirectional-streaming gRPC remain out of scope.
+Sources that override `stream_pages` to stream natively from their underlying primitive: `rest`, `graphql`, `postgres`, `postgres-cdc`, `mysql`, `sqlite`, `mongodb`, `s3` (JSONL/RawText modes), `gcs` (JSONL/RawText modes), `parquet`, `csv`, `xml`, `elasticsearch` (scroll API), `kafka`, `websocket`, `redis` (all three modes), `grpc` (server-streaming mode only). Sources that intentionally keep the default chunk-the-buffer impl: `grpc` (unary mode — no native paging primitive), `webhook` (buffer-shaped by nature). Client-streaming and bidirectional-streaming gRPC remain out of scope.
 
 Sinks that expose a `batch_size` config field for write-side re-chunking: every sink — `parquet`, `s3`, `gcs`, `bigquery`, `snowflake`, `postgres`, `mysql`, `sqlite`, `mongodb`, `redis`, `elasticsearch`, `http`, `kafka` (re-chunking is internally the natural unit for each — multi-row INSERTs, `_bulk` bodies, `tabledata.insertAll` requests, `insert_many` calls, Redis pipelines, etc.). The file/append sinks (`jsonl`, `csv`, `stdout`) carry the field for config parity but write per-record, so `batch_size` is a no-op for them.
 
@@ -323,7 +324,7 @@ Pipelines emit `tracing` spans and `metrics` counters/histograms automatically �
 
 Default features: `source-rest`, `transform-flatten`, `transform-rename-keys`, `transform-keys-case`.
 
-Each connector has its own feature: `source-<name>` / `sink-<name>` (`rest`, `graphql`, `xml`, `grpc`, `postgres`, `postgres-cdc`, `mysql`, `sqlite`, `s3`, `mongodb`, `redis`, `webhook`, `csv`, `elasticsearch`, `parquet`, `kafka` for sources; `bigquery`, `postgres`, `jsonl`, `snowflake`, `mysql`, `sqlite`, `s3`, `mongodb`, `redis`, `csv`, `elasticsearch`, `http`, `stdout`, `parquet`, `kafka` for sinks).
+Each connector has its own feature: `source-<name>` / `sink-<name>` (`rest`, `graphql`, `xml`, `grpc`, `postgres`, `postgres-cdc`, `mysql`, `sqlite`, `s3`, `mongodb`, `redis`, `webhook`, `websocket`, `csv`, `elasticsearch`, `parquet`, `kafka` for sources; `bigquery`, `postgres`, `jsonl`, `snowflake`, `mysql`, `sqlite`, `s3`, `mongodb`, `redis`, `csv`, `elasticsearch`, `http`, `stdout`, `parquet`, `kafka` for sinks).
 
 State backends: `state-redis`, `state-postgres` (file + memory live in `faucet-core`).
 
@@ -447,7 +448,7 @@ Key workspace deps: `serde` 1, `serde_json` 1, `schemars` 1.2, `async-trait` 0.1
 
 The default release path is **[release-plz](https://release-plz.dev/)** (`release-plz.toml` + `.github/workflows/release-plz.yml`). On every push to `main` release-plz scans for `feat` / `fix` / `perf` commits since each crate's last `<crate>-v<X.Y.Z>` tag and opens (or updates) a `chore: release` PR that bumps the affected crates, prepends per-crate sections to `CHANGELOG.md`, and leaves untouched crates alone. Merging that PR publishes to crates.io in dependency order (release-plz waits for sparse-index propagation between dependents) and pushes per-crate tags. Independent per-crate versions are the release-plz default; `docs`/`chore`/`refactor`/`test`/`ci`/`build` commits are filtered out of version bumps via `release_commits = "^(feat|fix|perf)"` so README-only edits don't trigger a publish. Tokens: `CARGO_REGISTRY_TOKEN` is required; `RELEASE_PLZ_TOKEN` (PAT or GitHub App) is recommended so the release PR triggers CI — the default `GITHUB_TOKEN` is forbidden by GitHub from triggering downstream workflows.
 
-`.github/workflows/release.yml` (`Release (manual fallback)`) is retained as a `workflow_dispatch` workflow for ad-hoc / bulk re-publishes (registry incidents, re-publish all 45 crates from a known-good revision). It still bumps with `cargo-release` and publishes in **waves of 5 with a 15-minute wait between waves**. Use it only as a fallback; day-to-day releases go through release-plz. Both workflows share the same per-crate tag format (`<crate>-v<X.Y.Z>`) so they don't fight each other.
+`.github/workflows/release.yml` (`Release (manual fallback)`) is retained as a `workflow_dispatch` workflow for ad-hoc / bulk re-publishes (registry incidents, re-publish all 46 crates from a known-good revision). It still bumps with `cargo-release` and publishes in **waves of 5 with a 15-minute wait between waves**. Use it only as a fallback; day-to-day releases go through release-plz. Both workflows share the same per-crate tag format (`<crate>-v<X.Y.Z>`) so they don't fight each other.
 
 ### docs.rs build setup
 
@@ -485,7 +486,7 @@ The adoption work in issue **#91** added many user-facing surfaces (docs.rs conf
 
 | If you change… | Also update (same PR) |
 |---|---|
-| **Add / remove / rename a connector** | umbrella + CLI features; CI `feature-check` matrix (`.github/workflows/ci.yml`); root README connector table **and the counts** (hero "19 sources / 16 sinks", architecture "45 crates — …"); docs-site catalog `docs/book/src/reference/connectors.md` (capability matrix) + `reference/choosing.md`; a `cli/examples/<src>_to_<sink>.yaml`; `examples/README.md` mapping (+ `examples/docker-compose.yml` and `examples/infra/` if it needs new local infra); per-crate crates.io `keywords` + `[package.metadata.docs.rs]` + `#![cfg_attr(docsrs, feature(doc_cfg))]`; the crate table in this file; README "Project Structure" |
+| **Add / remove / rename a connector** | umbrella + CLI features; CI `feature-check` matrix (`.github/workflows/ci.yml`); root README connector table **and the counts** (hero "20 sources / 16 sinks", architecture "46 crates — …"); docs-site catalog `docs/book/src/reference/connectors.md` (capability matrix) + `reference/choosing.md`; a `cli/examples/<src>_to_<sink>.yaml`; `examples/README.md` mapping (+ `examples/docker-compose.yml` and `examples/infra/` if it needs new local infra); per-crate crates.io `keywords` + `[package.metadata.docs.rs]` + `#![cfg_attr(docsrs, feature(doc_cfg))]`; the crate table in this file; README "Project Structure" |
 | **Change a connector's config fields / defaults / auth / pagination / behavior** | that crate's `README.md`; root README tables if user-facing; any docs-site page that mentions it (cookbook `auth`/`pagination`/`state`/`compression`, `reference/*`); affected `cli/examples/*.yaml`. (`faucet schema`/`init` are schema-driven — no manual update.) |
 | **Change a connector's streaming / resumable / compression support** | the capability-matrix columns in `docs/book/src/reference/connectors.md` (verify against the code — these were wrong once) |
 | **Change CLI commands or the config-file grammar** | `docs/book/src/reference/cli.md` + `reference/config.md`; `cli/README.md`; root README quickstart |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,7 +146,7 @@ README-only edit never causes a spurious publish.
 
 **Manual fallback.** `.github/workflows/release.yml` (`Release (manual fallback)`)
 is kept as a `workflow_dispatch` workflow for ad-hoc / bulk re-publishes (e.g.
-after a registry incident, or to re-publish all 45 crates from a known-good
+after a registry incident, or to re-publish all 46 crates from a known-good
 revision). Day-to-day releases should go through release-plz.
 
 **Dry-run locally.** Before relying on a release PR, you can preview what

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "crates/source/mongodb",
     "crates/source/redis",
     "crates/source/webhook",
+    "crates/source/websocket",
     "crates/source/sqlite",
     "crates/source/csv",
     "crates/source/elasticsearch",
@@ -87,6 +88,7 @@ faucet-source-s3 = { path = "crates/source/s3", version = "0.2.0" }
 faucet-source-mongodb = { path = "crates/source/mongodb", version = "0.2.0" }
 faucet-source-redis = { path = "crates/source/redis", version = "0.2.0" }
 faucet-source-webhook = { path = "crates/source/webhook", version = "0.2.0" }
+faucet-source-websocket = { path = "crates/source/websocket", version = "0.1.0" }
 faucet-source-sqlite = { path = "crates/source/sqlite", version = "0.2.0" }
 faucet-source-csv = { path = "crates/source/csv", version = "0.2.0" }
 faucet-source-elasticsearch = { path = "crates/source/elasticsearch", version = "0.3.0" }
@@ -147,6 +149,7 @@ csv = "1.3"
 csv-async = { version = "1.3", features = ["tokio"] }
 redis = { version = "0.29", features = ["tokio-comp", "aio"] }
 axum = "0.8"
+tokio-tungstenite = { version = "0.29", default-features = false, features = ["connect", "rustls-tls-webpki-roots"] }
 schemars = "1.2.1"
 futures = "0.3"
 async-stream = "0.3"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 **The fast, config-driven way to move data in Rust.**
 
-faucet-stream wires **19 source** and **16 sink** connectors together with a single
+faucet-stream wires **20 source** and **16 sink** connectors together with a single
 `faucet` binary that runs pipelines declaratively from a YAML/JSON file — no Rust
 code required. Or skip the binary and embed the same engine in your own service
 through the typed `Source` / `Sink` traits. One toolkit, whether you want a CLI you
@@ -146,7 +146,7 @@ flowchart LR
     P -.->|metrics + spans| O
 ```
 
-faucet-stream is a Cargo workspace with 45 crates — 19 sources, 16 sinks, 5 shared connector libraries, 2 state-store backends, the shared core, the umbrella crate, and the CLI binary:
+faucet-stream is a Cargo workspace with 46 crates — 20 sources, 16 sinks, 5 shared connector libraries, 2 state-store backends, the shared core, the umbrella crate, and the CLI binary:
 
 | Crate | Description |
 |-------|-------------|
@@ -165,6 +165,7 @@ faucet-stream is a Cargo workspace with 45 crates — 19 sources, 16 sinks, 5 sh
 | [`faucet-source-mongodb`](crates/source/mongodb) | MongoDB — find() with filter, projection, sort |
 | [`faucet-source-redis`](crates/source/redis) | Redis — read from streams, lists, or key patterns |
 | [`faucet-source-webhook`](crates/source/webhook) | Webhook — temporary HTTP server collecting POST payloads |
+| [`faucet-source-websocket`](crates/source/websocket) | WebSocket — live streaming feed; subscribe frames, reconnect, ping keepalive |
 | [`faucet-source-csv`](crates/source/csv) | CSV — read CSV files as JSON objects |
 | [`faucet-source-elasticsearch`](crates/source/elasticsearch) | Elasticsearch — search/scroll API |
 | [`faucet-source-kafka`](crates/source/kafka) | Apache Kafka — consumer with idle/max-messages termination |
@@ -883,6 +884,7 @@ Every pagination style has a termination/loop guard. `Cursor`, `LinkHeader`, and
 | `source-mongodb` | no | MongoDB query source |
 | `source-redis` | no | Redis source |
 | `source-webhook` | no | Webhook HTTP receiver |
+| `source-websocket` | no | WebSocket live streaming source |
 | `source-csv` | no | CSV file source |
 | `source-elasticsearch` | no | Elasticsearch source |
 | `source-kafka` | no | Apache Kafka consumer source |
@@ -1069,6 +1071,7 @@ crates/
     mongodb/                  — MongoDB find()
     redis/                    — Redis streams/lists/keys
     webhook/                  — HTTP webhook receiver
+    websocket/                — WebSocket live streaming source
     csv/                      — CSV file reader
     elasticsearch/            — Elasticsearch search/scroll
     kafka/                    — Apache Kafka consumer

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -34,6 +34,7 @@ source = [
     "source-mongodb",
     "source-redis",
     "source-webhook",
+    "source-websocket",
     "source-csv",
     "source-elasticsearch",
     "source-kafka",
@@ -74,6 +75,7 @@ source-s3 = ["dep:faucet-source-s3"]
 source-mongodb = ["dep:faucet-source-mongodb"]
 source-redis = ["dep:faucet-source-redis"]
 source-webhook = ["dep:faucet-source-webhook"]
+source-websocket = ["dep:faucet-source-websocket"]
 source-csv = ["dep:faucet-source-csv"]
 source-elasticsearch = ["dep:faucet-source-elasticsearch"]
 source-kafka = ["dep:faucet-source-kafka"]
@@ -159,6 +161,7 @@ faucet-source-s3 = { workspace = true, optional = true }
 faucet-source-mongodb = { workspace = true, optional = true }
 faucet-source-redis = { workspace = true, optional = true }
 faucet-source-webhook = { workspace = true, optional = true }
+faucet-source-websocket = { workspace = true, optional = true }
 faucet-source-csv = { workspace = true, optional = true }
 faucet-source-elasticsearch = { workspace = true, optional = true }
 faucet-source-kafka = { workspace = true, optional = true }

--- a/cli/examples/websocket_to_jsonl.yaml
+++ b/cli/examples/websocket_to_jsonl.yaml
@@ -1,0 +1,30 @@
+version: 1
+# Stream messages from a WebSocket endpoint and write each as one JSON line.
+#
+# Run:
+#   faucet run cli/examples/websocket_to_jsonl.yaml
+#
+# Prereqs:
+#   - A reachable WebSocket endpoint. The default targets Binance's public
+#     BTC/USDT trade stream (no auth, no infra needed). Replace `url` with your
+#     own feed as needed.
+
+pipeline:
+  source:
+    type: websocket
+    config:
+      url: "wss://stream.binance.com:9443/ws/btcusdt@trade"
+      message_format: json
+      # Stop when either condition fires.
+      max_messages: 100
+      idle_timeout: 30
+      # Keep the connection alive through proxies.
+      ping_interval: 20
+      batch_size: 50
+
+  sink:
+    type: jsonl
+    config:
+      path: ./out/trades.jsonl
+      append: false
+      pretty: false

--- a/cli/src/registry.rs
+++ b/cli/src/registry.rs
@@ -91,6 +91,15 @@ pub async fn build_source(kind: &str, config: Value) -> CliResult<Box<dyn Source
                 decode::<faucet_source_webhook::WebhookSourceConfig>("source", "webhook", config)?;
             Ok(Box::new(faucet_source_webhook::WebhookSource::new(cfg)))
         }
+        #[cfg(feature = "source-websocket")]
+        "websocket" => {
+            let cfg = decode::<faucet_source_websocket::WebsocketSourceConfig>(
+                "source",
+                "websocket",
+                config,
+            )?;
+            Ok(Box::new(faucet_source_websocket::WebsocketSource::new(cfg)?))
+        }
         #[cfg(feature = "source-csv")]
         "csv" => {
             let cfg = decode::<faucet_source_csv::CsvSourceConfig>("source", "csv", config)?;
@@ -274,6 +283,8 @@ pub fn source_schema(kind: &str) -> CliResult<Value> {
         "redis" => Ok(schema::<faucet_source_redis::RedisSourceConfig>()),
         #[cfg(feature = "source-webhook")]
         "webhook" => Ok(schema::<faucet_source_webhook::WebhookSourceConfig>()),
+        #[cfg(feature = "source-websocket")]
+        "websocket" => Ok(schema::<faucet_source_websocket::WebsocketSourceConfig>()),
         #[cfg(feature = "source-csv")]
         "csv" => Ok(schema::<faucet_source_csv::CsvSourceConfig>()),
         #[cfg(feature = "source-elasticsearch")]
@@ -374,6 +385,11 @@ pub fn source_descriptions() -> Vec<(&'static str, &'static str)> {
     v.push(("redis", "Redis (streams, lists, keys) source"));
     #[cfg(feature = "source-webhook")]
     v.push(("webhook", "Webhook HTTP receiver source"));
+    #[cfg(feature = "source-websocket")]
+    v.push((
+        "websocket",
+        "WebSocket streaming source — connects, subscribes, streams each message as a record",
+    ));
     #[cfg(feature = "source-csv")]
     v.push(("csv", "CSV file source"));
     #[cfg(feature = "source-elasticsearch")]

--- a/cli/src/registry.rs
+++ b/cli/src/registry.rs
@@ -98,7 +98,9 @@ pub async fn build_source(kind: &str, config: Value) -> CliResult<Box<dyn Source
                 "websocket",
                 config,
             )?;
-            Ok(Box::new(faucet_source_websocket::WebsocketSource::new(cfg)?))
+            Ok(Box::new(faucet_source_websocket::WebsocketSource::new(
+                cfg,
+            )?))
         }
         #[cfg(feature = "source-csv")]
         "csv" => {

--- a/crates/source/websocket/Cargo.toml
+++ b/crates/source/websocket/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "faucet-source-websocket"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "WebSocket streaming source connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords = ["websocket", "streaming", "etl", "pipeline", "connector"]
+categories.workspace = true
+
+[dependencies]
+faucet-core.workspace = true
+schemars.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+async-trait.workspace = true
+tracing.workspace = true
+tokio = { workspace = true, features = ["time", "macros", "signal"] }
+tokio-tungstenite.workspace = true
+futures.workspace = true
+async-stream.workspace = true
+base64.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "time", "net", "signal"] }
+tokio-tungstenite.workspace = true
+futures.workspace = true
+serde_json.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/source/websocket/README.md
+++ b/crates/source/websocket/README.md
@@ -1,0 +1,79 @@
+# faucet-source-websocket
+
+[![Crates.io](https://img.shields.io/crates/v/faucet-source-websocket.svg)](https://crates.io/crates/faucet-source-websocket)
+[![Docs.rs](https://docs.rs/faucet-source-websocket/badge.svg)](https://docs.rs/faucet-source-websocket)
+
+A WebSocket streaming source: connects to a `ws://`/`wss://` endpoint,
+optionally sends subscription frames, and streams each incoming message as a
+record until `max_messages`, `idle_timeout`, or Ctrl-C ends the run.
+
+Part of the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
+
+## Installation
+
+```toml
+[dependencies]
+faucet-source-websocket = "0.1"
+tokio = { version = "1", features = ["full"] }
+```
+
+Or via the umbrella crate:
+```toml
+faucet-stream = { version = "0.2", features = ["source-websocket"] }
+```
+
+## Quick Start — Binance trade stream
+
+```rust
+use faucet_source_websocket::{WebsocketSource, WebsocketSourceConfig, WsMessageFormat};
+use faucet_core::Source;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let config = WebsocketSourceConfig {
+        url: "wss://stream.binance.com:9443/ws/btcusdt@trade".into(),
+        message_format: WsMessageFormat::Json,
+        max_messages: Some(100),
+        idle_timeout: Some(std::time::Duration::from_secs(30)),
+        ..serde_json::from_value(serde_json::json!({
+            "url": "wss://stream.binance.com:9443/ws/btcusdt@trade"
+        }))?
+    };
+    let source = WebsocketSource::new(config)?;
+    let records = source.fetch_all().await?;
+    println!("got {} trades", records.len());
+    Ok(())
+}
+```
+
+## Config
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `url` | string | — | `ws://` or `wss://`; supports `{ctx}` substitution |
+| `auth` | enum | `none` | `none` / `bearer{token}` / `custom{headers}` |
+| `subscribe_messages` | string[] | `[]` | Sent in order on every (re)connect |
+| `message_format` | enum | `json` | `json` / `raw_string` / `binary` (base64) |
+| `on_parse_error` | enum | `fail` | `fail` / `skip` (json mode) |
+| `envelope` | bool | `false` | `true` → `{data,received_at,url}` |
+| `ping_interval` | secs | — | Client keepalive ping |
+| `max_messages` | int | — | At least one of `max_messages`/`idle_timeout` required |
+| `idle_timeout` | secs | — | Stop after this silence; also caps outages |
+| `reconnect` | bool | `false` | Reconnect on drop / non-1000 close |
+| `reconnect_backoff` | secs | `1` | Fixed wait between attempts |
+| `max_reconnect_attempts` | int | — | Cap consecutive failures (`None` = unlimited) |
+| `max_message_bytes` | int | — | Bound frame/message size |
+| `batch_size` | int | `1000` | Records per `StreamPage`; `0` = one page |
+
+## Behavior
+
+- **Streaming:** `stream_pages` yields a page each `batch_size` records; the
+  sink receives data continuously throughout the run.
+- **Not resumable:** a live feed has no replayable offset, so there is no
+  state/bookmark — on reconnect the source resubscribes to the live stream.
+- **Termination:** `max_messages`, `idle_timeout`, Ctrl-C, or a clean `1000`
+  close with `reconnect=false`.
+
+## License
+
+MIT OR Apache-2.0

--- a/crates/source/websocket/src/config.rs
+++ b/crates/source/websocket/src/config.rs
@@ -1,0 +1,342 @@
+//! Configuration types for the WebSocket source.
+
+use base64::Engine;
+use faucet_core::{DEFAULT_BATCH_SIZE, FaucetError};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+/// Configuration for the WebSocket source.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct WebsocketSourceConfig {
+    /// WebSocket endpoint, `ws://` or `wss://`. Supports `{placeholder}`
+    /// parent-matrix context substitution.
+    pub url: String,
+
+    /// Authentication applied to the HTTP upgrade request.
+    #[serde(default)]
+    pub auth: WebsocketAuth,
+
+    /// Subscription frames sent (in order) immediately after every
+    /// (re)connect. Empty = send nothing.
+    #[serde(default)]
+    pub subscribe_messages: Vec<String>,
+
+    /// How to interpret each incoming frame.
+    #[serde(default)]
+    pub message_format: WsMessageFormat,
+
+    /// In `Json` mode, what to do when a frame is not valid JSON.
+    #[serde(default)]
+    pub on_parse_error: OnParseError,
+
+    /// `false` (default) emits the record raw; `true` wraps it as
+    /// `{ data, received_at, url }`.
+    #[serde(default)]
+    pub envelope: bool,
+
+    /// If set, send a WebSocket Ping frame on this interval (seconds) to keep
+    /// the connection alive through proxies/load balancers.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "faucet_core::config::duration_secs_option"
+    )]
+    #[schemars(with = "Option<u64>")]
+    pub ping_interval: Option<Duration>,
+
+    /// Stop after this many messages. At least one of `max_messages` /
+    /// `idle_timeout` must be set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_messages: Option<usize>,
+
+    /// Stop after this many seconds with no message. The idle clock keeps
+    /// ticking across reconnect gaps, so it also caps a connection outage.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "faucet_core::config::duration_secs_option"
+    )]
+    #[schemars(with = "Option<u64>")]
+    pub idle_timeout: Option<Duration>,
+
+    /// Reconnect on transport error / non-1000 close.
+    #[serde(default)]
+    pub reconnect: bool,
+
+    /// Fixed wait (seconds) between reconnect attempts. Default 1s.
+    #[serde(
+        default = "default_backoff",
+        with = "faucet_core::config::duration_secs"
+    )]
+    #[schemars(with = "u64")]
+    pub reconnect_backoff: Duration,
+
+    /// Cap on *consecutive* failed reconnects (resets on any received
+    /// message). `None` = unlimited (then `idle_timeout` is the natural cap).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_reconnect_attempts: Option<usize>,
+
+    /// Bound the max WebSocket message/frame size (bytes) to prevent runaway
+    /// memory. `None` = tungstenite default (64 MiB message / 16 MiB frame).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_message_bytes: Option<usize>,
+
+    /// Records per emitted [`StreamPage`](faucet_core::StreamPage). Default
+    /// [`DEFAULT_BATCH_SIZE`]. `0` drains the entire run window into a single
+    /// page (same sentinel as the Kafka source).
+    #[serde(default = "default_batch_size")]
+    pub batch_size: usize,
+}
+
+fn default_backoff() -> Duration {
+    Duration::from_secs(1)
+}
+
+fn default_batch_size() -> usize {
+    DEFAULT_BATCH_SIZE
+}
+
+/// Authentication for the WebSocket upgrade request.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum WebsocketAuth {
+    /// No authentication (default).
+    #[default]
+    None,
+    /// `Authorization: Bearer <token>`.
+    Bearer { token: String },
+    /// Arbitrary request headers.
+    Custom { headers: BTreeMap<String, String> },
+}
+
+/// How each incoming frame is converted into a record.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WsMessageFormat {
+    /// Parse the frame payload as JSON (default).
+    #[default]
+    Json,
+    /// Emit the frame payload as a UTF-8 string (lossy for invalid UTF-8).
+    RawString,
+    /// Base64-encode the frame payload as a string.
+    Binary,
+}
+
+/// What to do when a `Json`-mode frame is not valid JSON.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum OnParseError {
+    /// Abort the run with a [`FaucetError::Source`] (default).
+    #[default]
+    Fail,
+    /// Log a warning and drop the frame.
+    Skip,
+}
+
+impl WebsocketSourceConfig {
+    /// Validate the config at construction time. Called by `WebsocketSource::new`.
+    pub fn validate(&self) -> Result<(), FaucetError> {
+        let url = self.url.trim();
+        if url.is_empty() {
+            return Err(FaucetError::Config(
+                "websocket source: url must not be empty".into(),
+            ));
+        }
+        if !(url.starts_with("ws://") || url.starts_with("wss://")) {
+            return Err(FaucetError::Config(format!(
+                "websocket source: url must start with ws:// or wss:// (got {url})"
+            )));
+        }
+        if self.max_messages.is_none() && self.idle_timeout.is_none() {
+            return Err(FaucetError::Config(
+                "websocket source: at least one of max_messages or idle_timeout must be set".into(),
+            ));
+        }
+        faucet_core::validate_batch_size(self.batch_size)?;
+        Ok(())
+    }
+
+    /// Set the per-page record count for
+    /// [`Source::stream_pages`](faucet_core::Source::stream_pages). Pass `0` to
+    /// drain the entire run window into a single page.
+    pub fn with_batch_size(mut self, batch_size: usize) -> Self {
+        self.batch_size = batch_size;
+        self
+    }
+}
+
+/// Convert a data-frame payload into a record value per `format`.
+///
+/// Returns `Ok(None)` only when `on_parse_error == Skip` swallows an invalid
+/// `Json` frame; the caller drops it. Used for both Text and Binary frames —
+/// `payload` is the raw frame bytes (for Text frames, the UTF-8 bytes).
+pub(crate) fn decode_frame(
+    format: WsMessageFormat,
+    on_parse_error: OnParseError,
+    payload: &[u8],
+) -> Result<Option<Value>, FaucetError> {
+    match format {
+        WsMessageFormat::Json => match serde_json::from_slice::<Value>(payload) {
+            Ok(v) => Ok(Some(v)),
+            Err(e) => match on_parse_error {
+                OnParseError::Fail => Err(FaucetError::Source(format!("websocket json parse: {e}"))),
+                OnParseError::Skip => {
+                    tracing::warn!(error = %e, "websocket source: dropping non-JSON frame");
+                    Ok(None)
+                }
+            },
+        },
+        WsMessageFormat::RawString => Ok(Some(Value::String(
+            String::from_utf8_lossy(payload).into_owned(),
+        ))),
+        WsMessageFormat::Binary => {
+            let encoded = base64::engine::general_purpose::STANDARD.encode(payload);
+            Ok(Some(Value::String(encoded)))
+        }
+    }
+}
+
+/// Wrap (or not) the decoded value into the emitted record shape.
+///
+/// `now_ms` is injected so the function stays pure and testable; the stream
+/// loop passes `now_unix_ms()` only when `envelope` is true.
+pub(crate) fn shape_record(value: Value, envelope: bool, url: &str, now_ms: u64) -> Value {
+    if envelope {
+        json!({ "data": value, "received_at": now_ms, "url": url })
+    } else {
+        value
+    }
+}
+
+#[cfg(test)]
+mod config_tests {
+    use super::*;
+
+    fn minimal() -> WebsocketSourceConfig {
+        WebsocketSourceConfig {
+            url: "wss://example.com/ws".into(),
+            auth: WebsocketAuth::None,
+            subscribe_messages: vec![],
+            message_format: WsMessageFormat::Json,
+            on_parse_error: OnParseError::Fail,
+            envelope: false,
+            ping_interval: None,
+            max_messages: Some(10),
+            idle_timeout: None,
+            reconnect: false,
+            reconnect_backoff: Duration::from_secs(1),
+            max_reconnect_attempts: None,
+            max_message_bytes: None,
+            batch_size: DEFAULT_BATCH_SIZE,
+        }
+    }
+
+    #[test]
+    fn validate_accepts_minimal() {
+        assert!(minimal().validate().is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_empty_url() {
+        let mut c = minimal();
+        c.url = "  ".into();
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_non_ws_scheme() {
+        let mut c = minimal();
+        c.url = "https://example.com".into();
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_no_termination() {
+        let mut c = minimal();
+        c.max_messages = None;
+        c.idle_timeout = None;
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn validate_accepts_idle_only() {
+        let mut c = minimal();
+        c.max_messages = None;
+        c.idle_timeout = Some(Duration::from_secs(5));
+        assert!(c.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_oversize_batch() {
+        let mut c = minimal();
+        c.batch_size = faucet_core::MAX_BATCH_SIZE + 1;
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn auth_bearer_round_trips_as_internally_tagged() {
+        let json = serde_json::json!({"type": "bearer", "token": "abc"});
+        let auth: WebsocketAuth = serde_json::from_value(json).unwrap();
+        assert_eq!(auth, WebsocketAuth::Bearer { token: "abc".into() });
+    }
+}
+
+#[cfg(test)]
+mod helper_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn decode_json_object() {
+        let v = decode_frame(WsMessageFormat::Json, OnParseError::Fail, br#"{"a":1}"#)
+            .unwrap()
+            .unwrap();
+        assert_eq!(v, json!({"a": 1}));
+    }
+
+    #[test]
+    fn decode_json_invalid_fails() {
+        let r = decode_frame(WsMessageFormat::Json, OnParseError::Fail, b"not json");
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn decode_json_invalid_skipped_yields_none() {
+        let r = decode_frame(WsMessageFormat::Json, OnParseError::Skip, b"not json").unwrap();
+        assert!(r.is_none());
+    }
+
+    #[test]
+    fn decode_raw_string() {
+        let v = decode_frame(WsMessageFormat::RawString, OnParseError::Fail, b"hello")
+            .unwrap()
+            .unwrap();
+        assert_eq!(v, json!("hello"));
+    }
+
+    #[test]
+    fn decode_binary_base64() {
+        let v = decode_frame(WsMessageFormat::Binary, OnParseError::Fail, b"hello")
+            .unwrap()
+            .unwrap();
+        assert_eq!(v, json!("aGVsbG8=")); // base64("hello")
+    }
+
+    #[test]
+    fn shape_raw_passthrough() {
+        let v = shape_record(json!({"a": 1}), false, "wss://x", 123);
+        assert_eq!(v, json!({"a": 1}));
+    }
+
+    #[test]
+    fn shape_enveloped() {
+        let v = shape_record(json!({"a": 1}), true, "wss://x", 123);
+        assert_eq!(
+            v,
+            json!({"data": {"a": 1}, "received_at": 123, "url": "wss://x"})
+        );
+    }
+}

--- a/crates/source/websocket/src/config.rs
+++ b/crates/source/websocket/src/config.rs
@@ -182,7 +182,9 @@ pub(crate) fn decode_frame(
         WsMessageFormat::Json => match serde_json::from_slice::<Value>(payload) {
             Ok(v) => Ok(Some(v)),
             Err(e) => match on_parse_error {
-                OnParseError::Fail => Err(FaucetError::Source(format!("websocket json parse: {e}"))),
+                OnParseError::Fail => {
+                    Err(FaucetError::Source(format!("websocket json parse: {e}")))
+                }
                 OnParseError::Skip => {
                     tracing::warn!(error = %e, "websocket source: dropping non-JSON frame");
                     Ok(None)
@@ -280,7 +282,12 @@ mod config_tests {
     fn auth_bearer_round_trips_as_internally_tagged() {
         let json = serde_json::json!({"type": "bearer", "token": "abc"});
         let auth: WebsocketAuth = serde_json::from_value(json).unwrap();
-        assert_eq!(auth, WebsocketAuth::Bearer { token: "abc".into() });
+        assert_eq!(
+            auth,
+            WebsocketAuth::Bearer {
+                token: "abc".into()
+            }
+        );
     }
 }
 

--- a/crates/source/websocket/src/lib.rs
+++ b/crates/source/websocket/src/lib.rs
@@ -1,0 +1,16 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+//! # faucet-source-websocket
+//!
+//! A WebSocket streaming source connector. Connects to a `ws://` or `wss://`
+//! endpoint, optionally sends one or more subscription frames, and streams
+//! each incoming message as a record until `max_messages`, `idle_timeout`, or
+//! Ctrl-C terminates the run.
+
+pub mod config;
+pub mod stream;
+
+pub use faucet_core::{FaucetError, Source};
+
+pub use config::{OnParseError, WebsocketAuth, WebsocketSourceConfig, WsMessageFormat};
+pub use stream::WebsocketSource;

--- a/crates/source/websocket/src/stream.rs
+++ b/crates/source/websocket/src/stream.rs
@@ -109,7 +109,11 @@ impl Source for WebsocketSource {
     ) -> Pin<Box<dyn Stream<Item = Result<StreamPage, FaucetError>> + Send + 'a>> {
         let resolved_url = faucet_core::util::substitute_context(&self.config.url, context);
         let batch_size = self.config.batch_size;
-        let page_chunk = if batch_size == 0 { usize::MAX } else { batch_size };
+        let page_chunk = if batch_size == 0 {
+            usize::MAX
+        } else {
+            batch_size
+        };
         let max_messages = self.config.max_messages.unwrap_or(usize::MAX);
         let idle_timeout = self.config.idle_timeout;
         let reconnect = self.config.reconnect;

--- a/crates/source/websocket/src/stream.rs
+++ b/crates/source/websocket/src/stream.rs
@@ -90,6 +90,10 @@ impl WebsocketSource {
 
 #[async_trait]
 impl Source for WebsocketSource {
+    /// Drain the entire run window into memory. This buffers every record the
+    /// run produces (bounded only by `max_messages` / `idle_timeout`); prefer
+    /// [`Source::stream_pages`] for large or long-running feeds so memory stays
+    /// bounded at `batch_size`.
     async fn fetch_with_context(
         &self,
         context: &HashMap<String, Value>,
@@ -160,7 +164,12 @@ impl Source for WebsocketSource {
                 };
 
                 let (mut write, mut read) = ws.split();
-                let mut ping_timer = ping_interval.map(tokio::time::interval);
+                // Start one interval out so the first `tick()` does not fire
+                // immediately (which would send a Ping before any read on every
+                // (re)connect). `tokio::time::interval` ticks at t=0.
+                let mut ping_timer = ping_interval.map(|interval| {
+                    tokio::time::interval_at(tokio::time::Instant::now() + interval, interval)
+                });
 
                 loop {
                     let idle_deadline = idle_timeout.map(|t| last_message_at + t);
@@ -174,6 +183,27 @@ impl Source for WebsocketSource {
                     let mut stop = false;
                     let mut fatal: Option<FaucetError> = None;
                     let mut reconnect_now = false;
+
+                    // Decode a data-frame payload (Text or Binary), shape it,
+                    // push it, and update the run-window counters. The only
+                    // per-arm difference is `t.as_bytes()` vs `&b`, so both
+                    // arms funnel through this single closure.
+                    let mut handle_payload = |payload: &[u8]| {
+                        match decode_frame(format, on_parse_error, payload) {
+                            Ok(Some(v)) => {
+                                let now = if envelope { now_unix_ms() } else { 0 };
+                                buffer.push(shape_record(v, envelope, &resolved_url, now));
+                                last_message_at = Instant::now();
+                                reconnect_attempts = 0;
+                                total += 1;
+                                if total >= max_messages {
+                                    stop = true;
+                                }
+                            }
+                            Ok(None) => {}
+                            Err(e) => fatal = Some(e),
+                        }
+                    };
 
                     tokio::select! {
                         biased;
@@ -191,34 +221,8 @@ impl Source for WebsocketSource {
                             match recv {
                                 Ok(Some(Ok(msg))) => {
                                     match msg {
-                                        Message::Text(t) => {
-                                            match decode_frame(format, on_parse_error, t.as_bytes()) {
-                                                Ok(Some(v)) => {
-                                                    let now = if envelope { now_unix_ms() } else { 0 };
-                                                    buffer.push(shape_record(v, envelope, &resolved_url, now));
-                                                    last_message_at = Instant::now();
-                                                    reconnect_attempts = 0;
-                                                    total += 1;
-                                                    if total >= max_messages { stop = true; }
-                                                }
-                                                Ok(None) => {}
-                                                Err(e) => fatal = Some(e),
-                                            }
-                                        }
-                                        Message::Binary(b) => {
-                                            match decode_frame(format, on_parse_error, &b) {
-                                                Ok(Some(v)) => {
-                                                    let now = if envelope { now_unix_ms() } else { 0 };
-                                                    buffer.push(shape_record(v, envelope, &resolved_url, now));
-                                                    last_message_at = Instant::now();
-                                                    reconnect_attempts = 0;
-                                                    total += 1;
-                                                    if total >= max_messages { stop = true; }
-                                                }
-                                                Ok(None) => {}
-                                                Err(e) => fatal = Some(e),
-                                            }
-                                        }
+                                        Message::Text(t) => handle_payload(t.as_bytes()),
+                                        Message::Binary(b) => handle_payload(&b),
                                         Message::Ping(payload) => {
                                             if let Err(e) = write.send(Message::Pong(payload)).await {
                                                 tracing::warn!(error = %e, "websocket source: pong failed");

--- a/crates/source/websocket/src/stream.rs
+++ b/crates/source/websocket/src/stream.rs
@@ -1,0 +1,309 @@
+//! WebSocket source stream executor.
+
+use crate::config::{WebsocketAuth, WebsocketSourceConfig, decode_frame, shape_record};
+use async_trait::async_trait;
+use faucet_core::{FaucetError, Source, Stream, StreamPage};
+use futures::{SinkExt, StreamExt};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::pin::Pin;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use tokio::net::TcpStream;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::tungstenite::handshake::client::Request;
+use tokio_tungstenite::tungstenite::http::{HeaderName, HeaderValue, header};
+use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
+use tokio_tungstenite::tungstenite::protocol::{Message, WebSocketConfig};
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async_with_config};
+
+type WsStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
+
+fn now_unix_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Apply `auth` to the HTTP upgrade `request`.
+pub(crate) fn apply_auth(request: &mut Request, auth: &WebsocketAuth) -> Result<(), FaucetError> {
+    let headers = request.headers_mut();
+    match auth {
+        WebsocketAuth::None => {}
+        WebsocketAuth::Bearer { token } => {
+            let value = HeaderValue::from_str(&format!("Bearer {token}"))
+                .map_err(|e| FaucetError::Config(format!("websocket bearer header: {e}")))?;
+            headers.insert(header::AUTHORIZATION, value);
+        }
+        WebsocketAuth::Custom { headers: custom } => {
+            for (k, v) in custom {
+                let name = HeaderName::from_bytes(k.as_bytes())
+                    .map_err(|e| FaucetError::Config(format!("websocket header name {k}: {e}")))?;
+                let value = HeaderValue::from_str(v)
+                    .map_err(|e| FaucetError::Config(format!("websocket header value {k}: {e}")))?;
+                headers.insert(name, value);
+            }
+        }
+    }
+    Ok(())
+}
+
+/// A WebSocket streaming source.
+pub struct WebsocketSource {
+    config: WebsocketSourceConfig,
+}
+
+impl WebsocketSource {
+    /// Create a new WebSocket source. Validates the config; the connection is
+    /// established lazily inside the stream loop (so reconnect can re-establish
+    /// it mid-run).
+    pub fn new(config: WebsocketSourceConfig) -> Result<Self, FaucetError> {
+        config.validate()?;
+        Ok(Self { config })
+    }
+
+    /// Connect, apply auth + size limits, and send the subscribe frames.
+    async fn connect(&self, url: &str) -> Result<WsStream, FaucetError> {
+        let mut request = url
+            .into_client_request()
+            .map_err(|e| FaucetError::Config(format!("websocket url {url}: {e}")))?;
+        apply_auth(&mut request, &self.config.auth)?;
+
+        let ws_config = self.config.max_message_bytes.map(|n| {
+            WebSocketConfig::default()
+                .max_message_size(Some(n))
+                .max_frame_size(Some(n))
+        });
+
+        let (mut ws, _resp) = connect_async_with_config(request, ws_config, false)
+            .await
+            .map_err(|e| FaucetError::Source(format!("websocket connect {url}: {e}")))?;
+
+        for msg in &self.config.subscribe_messages {
+            ws.send(Message::Text(msg.clone().into()))
+                .await
+                .map_err(|e| FaucetError::Source(format!("websocket subscribe: {e}")))?;
+        }
+        Ok(ws)
+    }
+}
+
+#[async_trait]
+impl Source for WebsocketSource {
+    async fn fetch_with_context(
+        &self,
+        context: &HashMap<String, Value>,
+    ) -> Result<Vec<Value>, FaucetError> {
+        let mut out = Vec::new();
+        let mut pages = self.stream_pages(context, self.config.batch_size);
+        while let Some(page) = pages.next().await {
+            out.extend(page?.records);
+        }
+        Ok(out)
+    }
+
+    fn stream_pages<'a>(
+        &'a self,
+        context: &'a HashMap<String, Value>,
+        _batch_size: usize,
+    ) -> Pin<Box<dyn Stream<Item = Result<StreamPage, FaucetError>> + Send + 'a>> {
+        let resolved_url = faucet_core::util::substitute_context(&self.config.url, context);
+        let batch_size = self.config.batch_size;
+        let page_chunk = if batch_size == 0 { usize::MAX } else { batch_size };
+        let max_messages = self.config.max_messages.unwrap_or(usize::MAX);
+        let idle_timeout = self.config.idle_timeout;
+        let reconnect = self.config.reconnect;
+        let backoff = self.config.reconnect_backoff;
+        let max_attempts = self.config.max_reconnect_attempts;
+        let ping_interval = self.config.ping_interval;
+        let format = self.config.message_format;
+        let on_parse_error = self.config.on_parse_error;
+        let envelope = self.config.envelope;
+
+        Box::pin(async_stream::try_stream! {
+            let mut buffer: Vec<Value> = Vec::new();
+            let mut total: usize = 0;
+            let mut last_message_at = Instant::now();
+            let mut reconnect_attempts: usize = 0;
+
+            'outer: loop {
+                // Idle cap also bounds connect-failure spins and reconnect gaps.
+                if let Some(t) = idle_timeout
+                    && Instant::now() >= last_message_at + t
+                {
+                    tracing::debug!("websocket source: idle_timeout reached, stopping");
+                    break 'outer;
+                }
+
+                // (Re)connect.
+                let ws = match self.connect(&resolved_url).await {
+                    Ok(ws) => {
+                        reconnect_attempts = 0;
+                        ws
+                    }
+                    Err(e) => {
+                        if reconnect
+                            && max_attempts.is_none_or(|m| reconnect_attempts < m)
+                        {
+                            reconnect_attempts += 1;
+                            tracing::warn!(error = %e, attempt = reconnect_attempts, "websocket source: connect failed, retrying");
+                            tokio::time::sleep(backoff).await;
+                            continue 'outer;
+                        }
+                        Err(e)?;
+                        break 'outer; // unreachable; satisfies the type checker
+                    }
+                };
+
+                let (mut write, mut read) = ws.split();
+                let mut ping_timer = ping_interval.map(tokio::time::interval);
+
+                loop {
+                    let idle_deadline = idle_timeout.map(|t| last_message_at + t);
+                    let poll_budget = match idle_deadline {
+                        Some(d) => d.saturating_duration_since(Instant::now()),
+                        None => Duration::from_secs(3600),
+                    };
+
+                    // Flags collected from the select arms; `?` cannot cross
+                    // the select match boundary into the try_stream! body.
+                    let mut stop = false;
+                    let mut fatal: Option<FaucetError> = None;
+                    let mut reconnect_now = false;
+
+                    tokio::select! {
+                        biased;
+                        _ = tokio::signal::ctrl_c() => {
+                            tracing::info!("websocket source: ctrl_c received, stopping cleanly");
+                            stop = true;
+                        }
+                        _ = async { ping_timer.as_mut().unwrap().tick().await }, if ping_timer.is_some() => {
+                            if let Err(e) = write.send(Message::Ping(Vec::new().into())).await {
+                                tracing::warn!(error = %e, "websocket source: ping failed, treating as disconnect");
+                                reconnect_now = true;
+                            }
+                        }
+                        recv = tokio::time::timeout(poll_budget, read.next()) => {
+                            match recv {
+                                Ok(Some(Ok(msg))) => {
+                                    match msg {
+                                        Message::Text(t) => {
+                                            match decode_frame(format, on_parse_error, t.as_bytes()) {
+                                                Ok(Some(v)) => {
+                                                    let now = if envelope { now_unix_ms() } else { 0 };
+                                                    buffer.push(shape_record(v, envelope, &resolved_url, now));
+                                                    last_message_at = Instant::now();
+                                                    reconnect_attempts = 0;
+                                                    total += 1;
+                                                    if total >= max_messages { stop = true; }
+                                                }
+                                                Ok(None) => {}
+                                                Err(e) => fatal = Some(e),
+                                            }
+                                        }
+                                        Message::Binary(b) => {
+                                            match decode_frame(format, on_parse_error, &b) {
+                                                Ok(Some(v)) => {
+                                                    let now = if envelope { now_unix_ms() } else { 0 };
+                                                    buffer.push(shape_record(v, envelope, &resolved_url, now));
+                                                    last_message_at = Instant::now();
+                                                    reconnect_attempts = 0;
+                                                    total += 1;
+                                                    if total >= max_messages { stop = true; }
+                                                }
+                                                Ok(None) => {}
+                                                Err(e) => fatal = Some(e),
+                                            }
+                                        }
+                                        Message::Ping(payload) => {
+                                            if let Err(e) = write.send(Message::Pong(payload)).await {
+                                                tracing::warn!(error = %e, "websocket source: pong failed");
+                                                reconnect_now = true;
+                                            }
+                                        }
+                                        Message::Pong(_) | Message::Frame(_) => {}
+                                        Message::Close(frame) => {
+                                            let clean = frame
+                                                .as_ref()
+                                                .map(|f| f.code == CloseCode::Normal)
+                                                .unwrap_or(true);
+                                            if clean && !reconnect {
+                                                tracing::info!("websocket source: server closed (1000), stopping");
+                                                stop = true;
+                                            } else {
+                                                tracing::warn!(?frame, "websocket source: connection closed");
+                                                reconnect_now = true;
+                                            }
+                                        }
+                                    }
+                                }
+                                Ok(Some(Err(e))) => {
+                                    tracing::warn!(error = %e, "websocket source: read error");
+                                    reconnect_now = true;
+                                }
+                                Ok(None) => {
+                                    tracing::warn!("websocket source: stream ended");
+                                    reconnect_now = true;
+                                }
+                                Err(_elapsed) => {
+                                    if let Some(d) = idle_deadline
+                                        && Instant::now() >= d
+                                    {
+                                        tracing::debug!("websocket source: idle_timeout reached, stopping");
+                                        stop = true;
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    if let Some(e) = fatal {
+                        Err(e)?;
+                    }
+
+                    if !buffer.is_empty() && buffer.len() >= page_chunk {
+                        let page = std::mem::take(&mut buffer);
+                        yield StreamPage { records: page, bookmark: None };
+                    }
+
+                    if stop {
+                        break 'outer;
+                    }
+
+                    if reconnect_now {
+                        if reconnect && max_attempts.is_none_or(|m| reconnect_attempts < m) {
+                            reconnect_attempts += 1;
+                            tracing::warn!(attempt = reconnect_attempts, "websocket source: reconnecting");
+                            tokio::time::sleep(backoff).await;
+                            continue 'outer;
+                        } else if reconnect {
+                            Err(FaucetError::Source(format!(
+                                "websocket source: exceeded max_reconnect_attempts ({})",
+                                max_attempts.unwrap_or(0)
+                            )))?;
+                        } else {
+                            Err(FaucetError::Source(
+                                "websocket source: connection closed and reconnect=false".into(),
+                            ))?;
+                        }
+                    }
+                }
+            }
+
+            if !buffer.is_empty() {
+                yield StreamPage { records: buffer, bookmark: None };
+            }
+
+            tracing::info!(messages = total, "websocket source: stream complete");
+        })
+    }
+
+    fn config_schema(&self) -> Value {
+        let schema = schemars::schema_for!(WebsocketSourceConfig);
+        serde_json::to_value(&schema).unwrap_or(Value::Null)
+    }
+
+    fn connector_name(&self) -> &'static str {
+        "websocket"
+    }
+}

--- a/crates/source/websocket/tests/integration.rs
+++ b/crates/source/websocket/tests/integration.rs
@@ -1,0 +1,224 @@
+//! Integration tests against an in-process tokio-tungstenite server.
+
+use faucet_core::Source;
+use faucet_source_websocket::{
+    OnParseError, WebsocketAuth, WebsocketSource, WebsocketSourceConfig, WsMessageFormat,
+};
+use futures::{SinkExt, StreamExt};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+use tokio::net::TcpListener;
+use tokio_tungstenite::tungstenite::Message;
+
+fn base_config(url: &str) -> WebsocketSourceConfig {
+    WebsocketSourceConfig {
+        url: url.to_string(),
+        auth: WebsocketAuth::None,
+        subscribe_messages: vec![],
+        message_format: WsMessageFormat::Json,
+        on_parse_error: OnParseError::Fail,
+        envelope: false,
+        ping_interval: None,
+        max_messages: None,
+        idle_timeout: None,
+        reconnect: false,
+        reconnect_backoff: Duration::from_millis(50),
+        max_reconnect_attempts: None,
+        max_message_bytes: None,
+        batch_size: 1000,
+    }
+}
+
+/// Spawn a server that pushes `messages` then holds the connection open.
+async fn spawn_pushing_server(messages: Vec<String>) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        if let Ok((stream, _)) = listener.accept().await {
+            let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+            for m in messages {
+                if ws.send(Message::Text(m.into())).await.is_err() {
+                    return;
+                }
+            }
+            // Keep the connection open so the client terminates via its own
+            // limit, not a server close.
+            loop {
+                if ws.next().await.is_none() {
+                    break;
+                }
+            }
+        }
+    });
+    format!("ws://{addr}")
+}
+
+#[tokio::test]
+async fn collects_up_to_max_messages() {
+    let url = spawn_pushing_server(vec![
+        r#"{"id":1}"#.into(),
+        r#"{"id":2}"#.into(),
+        r#"{"id":3}"#.into(),
+    ])
+    .await;
+    let mut cfg = base_config(&url);
+    cfg.max_messages = Some(3);
+    cfg.idle_timeout = Some(Duration::from_secs(5));
+    let src = WebsocketSource::new(cfg).unwrap();
+    let records = src.fetch_all().await.unwrap();
+    assert_eq!(records.len(), 3);
+    assert_eq!(records[0]["id"], 1);
+    assert_eq!(records[2]["id"], 3);
+}
+
+#[tokio::test]
+async fn idle_timeout_terminates_quiet_stream() {
+    // Server pushes 2 then goes silent; idle_timeout ends the run.
+    let url = spawn_pushing_server(vec![r#"{"id":1}"#.into(), r#"{"id":2}"#.into()]).await;
+    let mut cfg = base_config(&url);
+    cfg.idle_timeout = Some(Duration::from_millis(300));
+    let src = WebsocketSource::new(cfg).unwrap();
+    let records = src.fetch_all().await.unwrap();
+    assert_eq!(records.len(), 2);
+}
+
+#[tokio::test]
+async fn binary_frames_base64_encoded() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        if let Ok((stream, _)) = listener.accept().await {
+            let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+            let _ = ws.send(Message::Binary(b"hello".to_vec().into())).await;
+            loop {
+                if ws.next().await.is_none() {
+                    break;
+                }
+            }
+        }
+    });
+    let mut cfg = base_config(&format!("ws://{addr}"));
+    cfg.message_format = WsMessageFormat::Binary;
+    cfg.max_messages = Some(1);
+    cfg.idle_timeout = Some(Duration::from_secs(5));
+    let src = WebsocketSource::new(cfg).unwrap();
+    let records = src.fetch_all().await.unwrap();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0], serde_json::json!("aGVsbG8="));
+}
+
+#[tokio::test]
+async fn envelope_mode_wraps_record() {
+    let url = spawn_pushing_server(vec![r#"{"id":1}"#.into()]).await;
+    let mut cfg = base_config(&url);
+    cfg.envelope = true;
+    cfg.max_messages = Some(1);
+    cfg.idle_timeout = Some(Duration::from_secs(5));
+    let src = WebsocketSource::new(cfg).unwrap();
+    let records = src.fetch_all().await.unwrap();
+    assert_eq!(records[0]["data"], serde_json::json!({"id": 1}));
+    assert!(records[0]["received_at"].is_number());
+    assert_eq!(records[0]["url"], url);
+}
+
+#[tokio::test]
+async fn skip_drops_malformed_json() {
+    let url = spawn_pushing_server(vec!["not json".into(), r#"{"id":2}"#.into()]).await;
+    let mut cfg = base_config(&url);
+    cfg.on_parse_error = OnParseError::Skip;
+    cfg.max_messages = Some(1); // the one valid record
+    cfg.idle_timeout = Some(Duration::from_secs(5));
+    let src = WebsocketSource::new(cfg).unwrap();
+    let records = src.fetch_all().await.unwrap();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0]["id"], 2);
+}
+
+#[tokio::test]
+async fn auth_header_is_sent() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let seen = Arc::new(AtomicUsize::new(0));
+    let seen2 = Arc::clone(&seen);
+    tokio::spawn(async move {
+        if let Ok((stream, _)) = listener.accept().await {
+            // The `accept_hdr_async` callback's return type is fixed by the
+            // tungstenite `Callback` trait (`Response<Option<String>>` is large
+            // by value); we cannot box it here, so allow the lint test-side.
+            #[allow(clippy::result_large_err)]
+            let callback = |req: &tokio_tungstenite::tungstenite::handshake::server::Request,
+                            resp: tokio_tungstenite::tungstenite::handshake::server::Response| {
+                if req
+                    .headers()
+                    .get("authorization")
+                    .and_then(|v| v.to_str().ok())
+                    == Some("Bearer secret")
+                {
+                    seen2.store(1, Ordering::SeqCst);
+                }
+                Ok(resp)
+            };
+            let mut ws = tokio_tungstenite::accept_hdr_async(stream, callback)
+                .await
+                .unwrap();
+            let _ = ws.send(Message::Text(r#"{"id":1}"#.into())).await;
+            loop {
+                if ws.next().await.is_none() {
+                    break;
+                }
+            }
+        }
+    });
+    let mut cfg = base_config(&format!("ws://{addr}"));
+    cfg.auth = WebsocketAuth::Bearer {
+        token: "secret".into(),
+    };
+    cfg.max_messages = Some(1);
+    cfg.idle_timeout = Some(Duration::from_secs(5));
+    let src = WebsocketSource::new(cfg).unwrap();
+    let records = src.fetch_all().await.unwrap();
+    assert_eq!(records.len(), 1);
+    assert_eq!(
+        seen.load(Ordering::SeqCst),
+        1,
+        "server did not see the Authorization header"
+    );
+}
+
+#[tokio::test]
+async fn reconnect_resumes_after_drop() {
+    // Server closes after the first message on the first connection, then
+    // serves a second message on the next connection. Count connections.
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let mut conn = 0u32;
+        loop {
+            let Ok((stream, _)) = listener.accept().await else {
+                return;
+            };
+            conn += 1;
+            let n = conn;
+            tokio::spawn(async move {
+                let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+                // Each connection sends one message tagged with the conn number,
+                // then closes (drops) to force the client to reconnect.
+                let _ = ws
+                    .send(Message::Text(format!(r#"{{"conn":{n}}}"#).into()))
+                    .await;
+                let _ = ws.close(None).await;
+            });
+        }
+    });
+    let mut cfg = base_config(&format!("ws://{addr}"));
+    cfg.reconnect = true;
+    cfg.reconnect_backoff = Duration::from_millis(20);
+    cfg.max_messages = Some(2);
+    cfg.idle_timeout = Some(Duration::from_secs(5));
+    let src = WebsocketSource::new(cfg).unwrap();
+    let records = src.fetch_all().await.unwrap();
+    assert_eq!(records.len(), 2);
+    assert_eq!(records[0]["conn"], 1);
+    assert_eq!(records[1]["conn"], 2);
+}

--- a/crates/source/websocket/tests/integration.rs
+++ b/crates/source/websocket/tests/integration.rs
@@ -5,6 +5,7 @@ use faucet_source_websocket::{
     OnParseError, WebsocketAuth, WebsocketSource, WebsocketSourceConfig, WsMessageFormat,
 };
 use futures::{SinkExt, StreamExt};
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
@@ -221,4 +222,125 @@ async fn reconnect_resumes_after_drop() {
     assert_eq!(records.len(), 2);
     assert_eq!(records[0]["conn"], 1);
     assert_eq!(records[1]["conn"], 2);
+}
+
+#[tokio::test]
+async fn custom_headers_auth_is_sent() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let seen = Arc::new(AtomicUsize::new(0));
+    let seen2 = Arc::clone(&seen);
+    tokio::spawn(async move {
+        if let Ok((stream, _)) = listener.accept().await {
+            // The `accept_hdr_async` callback's return type is fixed by the
+            // tungstenite `Callback` trait (`Response<Option<String>>` is large
+            // by value); we cannot box it here, so allow the lint test-side.
+            #[allow(clippy::result_large_err)]
+            let callback = |req: &tokio_tungstenite::tungstenite::handshake::server::Request,
+                            resp: tokio_tungstenite::tungstenite::handshake::server::Response| {
+                if req.headers().get("x-api-key").and_then(|v| v.to_str().ok()) == Some("k123") {
+                    seen2.store(1, Ordering::SeqCst);
+                }
+                Ok(resp)
+            };
+            let mut ws = tokio_tungstenite::accept_hdr_async(stream, callback)
+                .await
+                .unwrap();
+            let _ = ws.send(Message::Text(r#"{"id":1}"#.into())).await;
+            loop {
+                if ws.next().await.is_none() {
+                    break;
+                }
+            }
+        }
+    });
+    let mut headers = BTreeMap::new();
+    headers.insert("x-api-key".to_string(), "k123".to_string());
+    let mut cfg = base_config(&format!("ws://{addr}"));
+    cfg.auth = WebsocketAuth::Custom { headers };
+    cfg.max_messages = Some(1);
+    cfg.idle_timeout = Some(Duration::from_secs(5));
+    let src = WebsocketSource::new(cfg).unwrap();
+    let records = src.fetch_all().await.unwrap();
+    assert_eq!(records.len(), 1);
+    assert_eq!(
+        seen.load(Ordering::SeqCst),
+        1,
+        "server did not see the custom x-api-key header"
+    );
+}
+
+#[tokio::test]
+async fn ping_keepalive_is_sent() {
+    // Server reads incoming control frames and records whether it sees a Ping.
+    // It sends no data, so the client never hits max_messages; it terminates
+    // via idle_timeout. The ping_interval (~100ms) fires before idle_timeout,
+    // so the server must observe a Ping.
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let saw_ping = Arc::new(AtomicUsize::new(0));
+    let saw_ping2 = Arc::clone(&saw_ping);
+    tokio::spawn(async move {
+        if let Ok((stream, _)) = listener.accept().await {
+            let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+            // Drain incoming frames; flag the first Ping we observe.
+            while let Some(msg) = ws.next().await {
+                match msg {
+                    Ok(Message::Ping(_)) => {
+                        saw_ping2.store(1, Ordering::SeqCst);
+                    }
+                    Ok(Message::Close(_)) | Err(_) => break,
+                    _ => {}
+                }
+            }
+        }
+    });
+    let mut cfg = base_config(&format!("ws://{addr}"));
+    cfg.ping_interval = Some(Duration::from_millis(100));
+    cfg.idle_timeout = Some(Duration::from_secs(1));
+    cfg.max_messages = Some(1); // server sends nothing, so this never fires
+    let src = WebsocketSource::new(cfg).unwrap();
+    let _ = src.fetch_all().await.unwrap();
+    assert_eq!(
+        saw_ping.load(Ordering::SeqCst),
+        1,
+        "server did not observe a keepalive Ping within the idle window"
+    );
+}
+
+#[tokio::test]
+async fn pages_flush_at_batch_size() {
+    // Server pushes 5 JSON messages; batch_size=2 should yield pages of 2,2,1.
+    let url = spawn_pushing_server(vec![
+        r#"{"id":1}"#.into(),
+        r#"{"id":2}"#.into(),
+        r#"{"id":3}"#.into(),
+        r#"{"id":4}"#.into(),
+        r#"{"id":5}"#.into(),
+    ])
+    .await;
+    let mut cfg = base_config(&url);
+    cfg.batch_size = 2;
+    cfg.max_messages = Some(5);
+    cfg.idle_timeout = Some(Duration::from_secs(1));
+    let src = WebsocketSource::new(cfg).unwrap();
+    let ctx = std::collections::HashMap::new();
+    let mut pages = src.stream_pages(&ctx, 2);
+    let mut page_sizes = Vec::new();
+    let mut total = 0usize;
+    while let Some(page) = pages.next().await {
+        let page = page.unwrap();
+        assert!(
+            page.bookmark.is_none(),
+            "websocket pages must carry no bookmark"
+        );
+        total += page.records.len();
+        page_sizes.push(page.records.len());
+    }
+    assert_eq!(total, 5, "all 5 records must arrive");
+    assert!(
+        page_sizes.len() >= 2,
+        "batch_size=2 over 5 records must produce multiple pages, got {page_sizes:?}"
+    );
+    assert_eq!(page_sizes, vec![2, 2, 1]);
 }

--- a/docs/book/src/reference/choosing.md
+++ b/docs/book/src/reference/choosing.md
@@ -28,6 +28,23 @@ For the full feature grid see the [connector catalog](./connectors.md).
 S3/GCS source. (The Parquet source reads from S3 directly, so you don't need the
 S3 source in front of it.)
 
+## Live feeds: WebSocket vs. Webhook vs. Kafka/Redis
+
+- **`source-websocket`** — connects *out* to a live push endpoint (`ws://`/`wss://`),
+  optionally sends subscription frames, and streams each incoming message as a record.
+  Use it for market data, chat feeds, telemetry, or any server that pushes over WebSocket.
+  Live-only — no replay, no durable offset.
+- **`source-webhook`** — opens a temporary HTTP server and *receives* inbound HTTP
+  POSTs from external systems over a time window. Use it when the remote system pushes
+  to you over HTTP rather than WebSocket.
+- **`source-kafka`** / **`source-redis`** — broker-backed streaming with durable,
+  replayable offsets and resumable bookmarks. Use these when you need guaranteed delivery
+  and the ability to continue from where a previous run left off.
+
+**Rule of thumb:** connecting out to a live WebSocket feed → `source-websocket`; receiving
+inbound HTTP POST payloads → `source-webhook`; durable, replayable event stream →
+`source-kafka` or `source-redis`.
+
 ## Streaming: Redis vs. Kafka
 
 - **`source-redis`** reads streams, lists, or key patterns. Great when Redis is

--- a/docs/book/src/reference/connectors.md
+++ b/docs/book/src/reference/connectors.md
@@ -1,6 +1,6 @@
 # Connector catalog
 
-faucet-stream ships **19 sources** and **16 sinks**. Each is a Cargo feature
+faucet-stream ships **20 sources** and **16 sinks**. Each is a Cargo feature
 (`source-<name>` / `sink-<name>`) and an independently published crate. Full API
 docs are on [docs.rs](https://docs.rs/faucet-stream).
 
@@ -28,6 +28,7 @@ Legend: ✓ supported · ✗ not applicable.
 | MongoDB | `source-mongodb` | ✓ | ✗ | ✗ | `find()` with filter/projection/sort |
 | Redis | `source-redis` | ✓ | ✗ | ✗ | streams, lists, key patterns |
 | Webhook | `source-webhook` | ✗⁵ | ✗ | ✗ | temporary HTTP server collecting POSTs |
+| WebSocket | `source-websocket` | ✓ | ✗ | ✗ | live push feed; subscribe frames, reconnect, ping keepalive |
 | CSV | `source-csv` | ✓ | ✗ | ✓ | CSV files as JSON |
 | Elasticsearch | `source-elasticsearch` | ✓ | ✗ | ✗ | search/scroll API |
 | Apache Kafka | `source-kafka` | ✓ | ✓ | ✗ | consumer; idle/max-messages termination, offset bookmarks |
@@ -78,6 +79,7 @@ feature doesn't apply.
 | BigQuery | service-account key (path or inline JSON), application-default credentials |
 | Snowflake | JWT key-pair, OAuth |
 | Kafka | SASL (PLAIN/SCRAM) + TLS |
+| WebSocket | none, Bearer token, Custom headers |
 | Elasticsearch | basic, API key, bearer, none |
 | S3 / GCS | cloud SDK credential chains (env, profile, metadata) |
 | SQL databases | connection URL (with embedded credentials / TLS params) |

--- a/examples/README.md
+++ b/examples/README.md
@@ -36,6 +36,7 @@ These run immediately after installing the CLI — great for a first smoke test:
 | `sqlite_to_jsonl.yaml`, `sqlite_to_csv.yaml` | local SQLite → file |
 | `rest_to_jsonl.yaml`, `rest_streaming.yaml`, `rest_to_stdout_preview.yaml` | point `base_url` at any HTTP API; preview needs no sink setup |
 | `rest_filter_explode_to_stdout.yaml` | `filter` + `explode` + `keys_case` against DummyJSON; demonstrates the v1 JSONPath subset and the merge rule |
+| `websocket_to_jsonl.yaml` | none (live public WS endpoint — Binance BTC/USDT trade stream, no auth) |
 
 > REST / GraphQL / XML / gRPC / webhook source examples hit an external endpoint
 > (the configs use a placeholder `base_url`). Edit it to a real API — there's no

--- a/faucet-stream/Cargo.toml
+++ b/faucet-stream/Cargo.toml
@@ -29,6 +29,7 @@ source = [
     "source-mongodb",
     "source-redis",
     "source-webhook",
+    "source-websocket",
     "source-csv",
     "source-elasticsearch",
     "source-parquet",
@@ -89,6 +90,7 @@ source-s3 = ["dep:faucet-source-s3"]
 source-mongodb = ["dep:faucet-source-mongodb"]
 source-redis = ["dep:faucet-source-redis"]
 source-webhook = ["dep:faucet-source-webhook"]
+source-websocket = ["dep:faucet-source-websocket"]
 source-csv = ["dep:faucet-source-csv"]
 source-elasticsearch = ["dep:faucet-source-elasticsearch"]
 source-kafka = ["dep:faucet-source-kafka", "dep:faucet-kafka-common"]
@@ -162,6 +164,7 @@ faucet-source-s3 = { workspace = true, optional = true }
 faucet-source-mongodb = { workspace = true, optional = true }
 faucet-source-redis = { workspace = true, optional = true }
 faucet-source-webhook = { workspace = true, optional = true }
+faucet-source-websocket = { workspace = true, optional = true }
 faucet-source-csv = { workspace = true, optional = true }
 faucet-source-elasticsearch = { workspace = true, optional = true }
 faucet-source-parquet = { workspace = true, optional = true }

--- a/faucet-stream/src/lib.rs
+++ b/faucet-stream/src/lib.rs
@@ -22,6 +22,7 @@
 //! | `source-mongodb` | MongoDB query source |
 //! | `source-redis` | Redis source (streams, lists, keys) |
 //! | `source-webhook` | Webhook HTTP receiver source |
+//! | `source-websocket` | WebSocket streaming source |
 //! | `source-csv` | CSV file source |
 //! | `source-elasticsearch` | Elasticsearch search/scroll source |
 //! | `source-kafka` | Apache Kafka consumer source |
@@ -117,6 +118,11 @@ pub mod source {
         pub use faucet_source_webhook::*;
     }
 
+    #[cfg(feature = "source-websocket")]
+    pub mod websocket {
+        pub use faucet_source_websocket::*;
+    }
+
     #[cfg(feature = "source-csv")]
     pub mod csv {
         pub use faucet_source_csv::*;
@@ -199,6 +205,11 @@ pub mod source {
     #[cfg(feature = "source-webhook")]
     pub mod webhook {
         pub use faucet_source_webhook::*;
+    }
+
+    #[cfg(feature = "source-websocket")]
+    pub mod websocket {
+        pub use faucet_source_websocket::*;
     }
 
     #[cfg(feature = "source-csv")]


### PR DESCRIPTION
## Summary

Adds `faucet-source-websocket`, a live streaming source that connects to a `ws://`/`wss://` endpoint, optionally sends subscription frames, and streams each incoming message as a record. Modeled on the Kafka source's `stream_pages` poll loop (Ctrl-C / `max_messages` / `idle_timeout` termination, buffered into `StreamPage`s of `batch_size`).

- **Records:** raw by default; opt-in `{data, received_at, url}` envelope. Three formats — `json` / `raw_string` / `binary` (base64) — with `on_parse_error: fail|skip` for JSON.
- **Auth:** `none` / `bearer` / `custom` headers on the upgrade request.
- **Reliability:** reconnect with fixed backoff + optional attempt cap (resets on any received message); the single idle clock bounds quiet streams, connect-failure spins, and reconnect gaps. Client `ping_interval` keepalive; `max_message_bytes` bounds memory.
- **Not resumable:** a live feed has no replayable offset, so there is no state/bookmark — every page carries `bookmark: None`.

Design spec: `docs/superpowers/specs/2026-05-29-websocket-source-design.md`.

## Wiring & docs

- New crate `crates/source/websocket/` (+ workspace member, `tokio-tungstenite` 0.29/rustls dep).
- Umbrella `faucet-stream` feature `source-websocket` (+ `source` aggregate, re-export); CLI feature (in the default set) + `registry.rs` arms; CI `feature-check` matrix.
- Crate README (Binance worked example), `cli/examples/websocket_to_jsonl.yaml`, `examples/README.md` mapping, CLAUDE.md crate table/streaming/feature-flags, root README + docs-site capability matrix & decision guide. All crate/source counts bumped (46 crates, 20 sources).

## Test plan

- **Unit (14):** config validation (empty/bad-scheme url, require-one-of max_messages/idle_timeout, batch_size, auth round-trip); `decode_frame` (json/raw_string/binary + skip/fail); `shape_record` (raw vs envelope).
- **Integration (10, in-process tokio-tungstenite server, no infra):** max_messages, idle_timeout, binary→base64, envelope, on_parse_error=skip, Bearer auth header sent, Custom-headers auth, multi-page paging via `stream_pages`, ping keepalive, reconnect-resume.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean; `cargo fmt --all --check` clean; crate doc build (`-D warnings`) clean.

> Note: `cargo publish --dry-run` for this crate (and every other crate using the post-0.2.0 `faucet-core` API, e.g. `faucet-source-kafka`) fails its compile-verify step locally because it resolves against the published `faucet-core` 0.2.0. release-plz publishes the bumped `faucet-core` first in dependency order, so this is a known repo property, not a defect.

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)