### PR TITLE
feat: built-in data-quality checks (per-record + per-batch) with DLQ routing (#122)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,9 @@ jobs:
           - auth
           - full
           - compression
+          # Quality checks
+          - quality
+          - quality-jsonschema
           # CLI build matrix — verify the binary builds with every default-on
           # feature plus a slim "only the bare minimum" combo.
     steps:

--- a/README.md
+++ b/README.md
@@ -28,8 +28,10 @@ can drop on any box or a library you compile in.
 - **Config-driven _or_ embeddable** — run `faucet run pipeline.yaml`, or call
   `Pipeline::new(&source, &sink).run().await?` from Rust. Same orchestration either way.
 - **A runtime, not just connectors** — incremental + resumable replication,
-  PostgreSQL change-data-capture, dead-letter queues, automatic retries, and
-  built-in Prometheus metrics + `tracing` spans, all with zero per-connector code.
+  PostgreSQL change-data-capture, built-in data-quality checks (13 per-record and
+  per-batch assertions with quarantine routing and abort policies), dead-letter
+  queues, automatic retries, and built-in Prometheus metrics + `tracing` spans,
+  all with zero per-connector code.
 - **Pay only for what you use** — every connector is a Cargo feature, so a slim
   build can be just REST + JSONL, or pull in all 35 connectors with `--features full`.
 
@@ -95,6 +97,7 @@ when you want to compile pipelines into your own service.
 | Connector count | 35, growing | 600+ taps | 350+ | dozens | dozens | 500+ |
 | Change data capture | ✓ PostgreSQL | partial¹ | ✓ | partial | ✗ | ✓ |
 | Incremental + resumable state | ✓ | ✓ | ✓ | partial | n/a | ✓ |
+| Built-in data-quality checks | ✓ native | ✗ | paywalled add-on | ✗ | ✗ | paywalled add-on |
 | Built-in metrics + tracing | ✓ Prometheus + `tracing` | partial | ✓ (platform) | ✓ | ✓ | ✓ (hosted) |
 | Self-hosted, no daemon | ✓ run-to-completion | ✓ | ✗ needs platform | usually a service | agent | ✗ SaaS |
 | License | MIT / Apache-2.0 | MIT | ELv2 + MIT | Apache-2.0 / source-available² | MPL-2.0 | Proprietary |
@@ -112,7 +115,7 @@ is its most common runtime.
 
 - You want **one fast static binary** (or a Rust library) to move data between APIs, databases, object stores, and warehouses — without standing up a platform, scheduler, or Python environment.
 - You want **version-controlled, config-driven pipelines** you can run anywhere: locally, in CI, behind cron, or inside another service.
-- You need **streaming with bounded memory, incremental/resumable replication, CDC, retries, dead-letter queues, and metrics** without hand-writing that plumbing.
+- You need **streaming with bounded memory, incremental/resumable replication, CDC, data-quality assertions, retries, dead-letter queues, and metrics** without hand-writing that plumbing.
 - You're **already in Rust** and want typed `Source`/`Sink` traits you can embed and extend.
 
 **Look elsewhere (for now) when:**

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,9 +17,15 @@ path = "src/main.rs"
 [features]
 # Default: every first-party source, sink, and state backend so `cargo install`
 # yields a binary that can run any of the published example YAMLs out of the box.
-default = ["observability", "full"]
+default = ["observability", "full", "quality"]
 
-full = ["observability", "source", "sink", "state", "transforms", "compression"]
+full = ["observability", "source", "sink", "state", "transforms", "compression", "quality"]
+
+# Data-quality checks (`quality:` config block). `quality-jsonschema` adds the
+# `json_schema` record check via a JSON Schema validator. Forwarded to
+# `faucet-core`.
+quality = ["faucet-core/quality"]
+quality-jsonschema = ["quality", "faucet-core/quality-jsonschema"]
 
 source = [
     "source-rest",

--- a/cli/examples/rest_to_postgres_with_quality.yaml
+++ b/cli/examples/rest_to_postgres_with_quality.yaml
@@ -1,0 +1,115 @@
+# REST API → PostgreSQL with built-in data-quality checks and a dead-letter queue.
+#
+# The `quality:` block asserts invariants on every page of records — per-record
+# checks run first (partitioning the page into survivors and quarantined rows),
+# then per-batch checks run over the survivors. Quarantined rows are routed to
+# the DLQ sink before the page bookmark advances.
+#
+# Required env vars:
+#   PG_URL            — connection URL, e.g. postgres://user:pass@localhost/app
+#   API_TOKEN         — bearer token for the source REST API
+#   PG_DLQ_URL        — connection URL for the DLQ Postgres table (may be the
+#                       same PG_URL if you want quarantined rows in the same DB)
+version: 1
+name: users_api_to_postgres_with_quality
+
+pipeline:
+  source:
+    type: rest
+    config:
+      base_url: https://api.example.com/v1
+      path: /users
+      method: GET
+      auth:
+        type: bearer
+        config:
+          token: ${env:API_TOKEN}
+      query_params:
+        per_page: "100"
+      pagination:
+        type: Cursor
+        next_token_path: $.meta.next_cursor
+        param_name: cursor
+      max_retries: 3
+      retry_backoff: 2
+      tolerated_http_errors: []
+      replication_method:
+        type: Incremental
+      replication_key: updated_at
+      primary_keys: ["id"]
+      partitions: []
+      schema_sample_size: 100
+      state_key: users_api:users
+
+  transforms:
+    - type: keys_case
+      config: { mode: snake }
+
+  quality:
+    record:
+      # Every user must have an id — abort the run if we ever see a null id
+      # (that indicates a serious upstream data issue, not a bad single row).
+      - type: not_null
+        field: id
+        on_failure: abort
+
+      # email must be present and non-null; route bad rows to the DLQ.
+      - type: not_null
+        field: email
+        on_failure: quarantine
+
+      # email must look like an email address.
+      - type: regex_match
+        field: email
+        pattern: '^[^@\s]+@[^@\s]+\.[^@\s]+$'
+        on_failure: quarantine
+
+      # status must be one of the known lifecycle values.
+      - type: value_in_set
+        field: status
+        values: ["active", "inactive", "pending", "suspended"]
+        on_failure: quarantine
+
+      # age, when present, must be a non-negative number.
+      - type: compare
+        field: age
+        op: gte
+        value: 0
+        on_failure: quarantine
+
+    batch:
+      # Each page must carry at least one survivor (empty pages likely mean
+      # the source is misconfigured or the API returned an unexpected shape).
+      - type: row_count
+        min: 1
+        on_failure: abort
+
+      # id must be unique within each page.
+      - type: unique
+        fields: [id]
+        on_failure: quarantine
+
+  dlq:
+    sink:
+      type: jsonl
+      config:
+        path: ./dlq/users_quality_failures.jsonl
+    on_batch_error: propagate
+    max_failures_per_page: 50
+    max_failures_total: 500
+
+  sink:
+    type: postgres
+    config:
+      connection_url: ${env:PG_URL}
+      table_name: users
+      column_mapping:
+        type: jsonb
+        column: data
+      batch_size: 500
+      max_connections: 5
+
+  state:
+    type: file
+    config:
+      path: ./.faucet-state

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -109,6 +109,7 @@ pub enum SchemaTarget {
     /// JSON Schema for the DLQ (Dead Letter Queue) specification.
     Dlq,
     /// JSON Schema for the `quality:` block.
+    #[cfg(feature = "quality")]
     Quality,
 }
 

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -108,6 +108,8 @@ pub enum SchemaTarget {
     },
     /// JSON Schema for the DLQ (Dead Letter Queue) specification.
     Dlq,
+    /// JSON Schema for the `quality:` block.
+    Quality,
 }
 
 /// `faucet preview` arguments.

--- a/cli/src/commands/list.rs
+++ b/cli/src/commands/list.rs
@@ -4,7 +4,9 @@
 use crate::error::CliResult;
 use crate::registry::{sink_descriptions, source_descriptions};
 use crate::state::available_state_kinds;
-use crate::transforms::{quality_descriptions, transform_descriptions};
+#[cfg(feature = "quality")]
+use crate::transforms::quality_descriptions;
+use crate::transforms::transform_descriptions;
 
 /// Execute the `list` subcommand.
 pub async fn run() -> CliResult<()> {
@@ -17,9 +19,12 @@ pub async fn run() -> CliResult<()> {
     println!("Transforms:");
     print_two_column(&transform_descriptions());
     println!();
-    println!("Quality checks:");
-    print_two_column(&quality_descriptions());
-    println!();
+    #[cfg(feature = "quality")]
+    {
+        println!("Quality checks:");
+        print_two_column(&quality_descriptions());
+        println!();
+    }
     println!("State stores: {}", available_state_kinds().join(", "));
     Ok(())
 }

--- a/cli/src/commands/list.rs
+++ b/cli/src/commands/list.rs
@@ -4,7 +4,7 @@
 use crate::error::CliResult;
 use crate::registry::{sink_descriptions, source_descriptions};
 use crate::state::available_state_kinds;
-use crate::transforms::transform_descriptions;
+use crate::transforms::{quality_descriptions, transform_descriptions};
 
 /// Execute the `list` subcommand.
 pub async fn run() -> CliResult<()> {
@@ -16,6 +16,9 @@ pub async fn run() -> CliResult<()> {
     println!();
     println!("Transforms:");
     print_two_column(&transform_descriptions());
+    println!();
+    println!("Quality checks:");
+    print_two_column(&quality_descriptions());
     println!();
     println!("State stores: {}", available_state_kinds().join(", "));
     Ok(())

--- a/cli/src/commands/schema.rs
+++ b/cli/src/commands/schema.rs
@@ -16,6 +16,7 @@ pub async fn run(args: SchemaArgs) -> CliResult<()> {
             serde_json::to_value(dlq_schema)
                 .unwrap_or_else(|_| serde_json::json!({"type": "object"}))
         }
+        #[cfg(feature = "quality")]
         SchemaTarget::Quality => {
             let quality_schema = faucet_core::schema_for!(faucet_core::QualitySpec);
             serde_json::to_value(quality_schema)

--- a/cli/src/commands/schema.rs
+++ b/cli/src/commands/schema.rs
@@ -16,6 +16,11 @@ pub async fn run(args: SchemaArgs) -> CliResult<()> {
             serde_json::to_value(dlq_schema)
                 .unwrap_or_else(|_| serde_json::json!({"type": "object"}))
         }
+        SchemaTarget::Quality => {
+            let quality_schema = faucet_core::schema_for!(faucet_core::QualitySpec);
+            serde_json::to_value(quality_schema)
+                .unwrap_or_else(|_| serde_json::json!({"type": "object"}))
+        }
     };
     let body = serde_json::to_string_pretty(&schema).unwrap_or_else(|_| schema.to_string());
     println!("{body}");

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -108,6 +108,7 @@ pub struct PipelineSpec {
     pub dlq: Option<DlqSpec>,
 
     /// Data-quality checks (pipeline-level; no matrix-row override in v1).
+    #[cfg(feature = "quality")]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub quality: Option<faucet_core::QualitySpec>,
 }
@@ -677,6 +678,7 @@ pipeline:
         );
     }
 
+    #[cfg(feature = "quality")]
     #[test]
     fn parses_quality_block() {
         let yaml = r#"

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -106,6 +106,10 @@ pub struct PipelineSpec {
     pub state: Option<StateStoreSpec>,
     #[serde(default)]
     pub dlq: Option<DlqSpec>,
+
+    /// Data-quality checks (pipeline-level; no matrix-row override in v1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub quality: Option<faucet_core::QualitySpec>,
 }
 
 /// A `{ type, config }` block, the universal shape for both sources and sinks.
@@ -671,6 +675,22 @@ pipeline:
             cfg.pipeline.source.as_ref().unwrap().config["path"],
             "/v1/users/${users.id}/posts"
         );
+    }
+
+    #[test]
+    fn parses_quality_block() {
+        let yaml = r#"
+version: 1
+pipeline:
+  source: { type: rest, config: { url: "https://x" } }
+  quality:
+    record:
+      - { type: not_null, field: id, on_failure: abort }
+  sink: { type: stdout, config: {} }
+"#;
+        let cfg = parse_with_extension(yaml, "yaml").unwrap();
+        let q = cfg.pipeline.quality.expect("quality parsed");
+        assert_eq!(q.record.len(), 1);
     }
 
     #[test]

--- a/cli/src/env_config.rs
+++ b/cli/src/env_config.rs
@@ -292,6 +292,7 @@ pub fn build_pipeline_config(env: &HashMap<String, String>) -> CliResult<Pipelin
             transforms,
             state,
             dlq: None,
+            #[cfg(feature = "quality")]
             quality: None,
         },
         matrix: Vec::new(),

--- a/cli/src/env_config.rs
+++ b/cli/src/env_config.rs
@@ -292,6 +292,7 @@ pub fn build_pipeline_config(env: &HashMap<String, String>) -> CliResult<Pipelin
             transforms,
             state,
             dlq: None,
+            quality: None,
         },
         matrix: Vec::new(),
         execution: None,

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -233,6 +233,12 @@ pub enum CliError {
     #[error("failed to build auth provider '{name}': {message}")]
     AuthProviderBuild { name: String, message: String },
 
+    /// A config-level validation failure that isn't covered by a more specific
+    /// variant (e.g. an invalid `quality:` block, or a quality check that
+    /// requires a DLQ when none is configured).
+    #[error("config error: {0}")]
+    Config(String),
+
     /// Pass-through for failures bubbling up from `faucet-core` or a connector.
     #[error(transparent)]
     Faucet(#[from] faucet_core::FaucetError),

--- a/cli/src/executor.rs
+++ b/cli/src/executor.rs
@@ -520,6 +520,7 @@ async fn run_one_invocation(
     // Pipeline-level quality checks (v1: no matrix-row override). `expand`
     // already validated this spec, but compile again here to obtain the
     // runtime `CompiledQuality`; map any error to a config-level failure.
+    #[cfg(feature = "quality")]
     let pipeline = if let Some(ref quality_spec) = node.quality {
         let compiled = Arc::new(
             faucet_core::CompiledQuality::compile(quality_spec)
@@ -774,6 +775,7 @@ mod tests {
                 transforms: Vec::new(),
                 state: None,
                 dlq: None,
+                #[cfg(feature = "quality")]
                 quality: None,
             },
             matrix: Vec::new(),

--- a/cli/src/executor.rs
+++ b/cli/src/executor.rs
@@ -517,6 +517,18 @@ async fn run_one_invocation(
     } else {
         pipeline
     };
+    // Pipeline-level quality checks (v1: no matrix-row override). `expand`
+    // already validated this spec, but compile again here to obtain the
+    // runtime `CompiledQuality`; map any error to a config-level failure.
+    let pipeline = if let Some(ref quality_spec) = node.quality {
+        let compiled = Arc::new(
+            faucet_core::CompiledQuality::compile(quality_spec)
+                .map_err(|e| CliError::Config(format!("quality: {e}")))?,
+        );
+        pipeline.with_quality(compiled)
+    } else {
+        pipeline
+    };
     let result = pipeline.run().await?;
     sink.flush().await?;
 
@@ -762,6 +774,7 @@ mod tests {
                 transforms: Vec::new(),
                 state: None,
                 dlq: None,
+                quality: None,
             },
             matrix: Vec::new(),
             execution: None,

--- a/cli/src/expand.rs
+++ b/cli/src/expand.rs
@@ -38,6 +38,9 @@ pub struct ExpandedNode {
     pub state: Option<StateStoreSpec>,
     /// Resolved DLQ spec for this row, or `None` if no DLQ applies.
     pub dlq: Option<crate::config::DlqSpec>,
+    /// Pipeline-level quality spec, shared by every node. `quality:` has no
+    /// matrix-row override in v1, so this is `cfg.pipeline.quality` verbatim.
+    pub quality: Option<faucet_core::QualitySpec>,
     /// Every `${id.path}` placeholder that survived load-time interpolation.
     /// Populated by `collect_deferred`; the executor uses this to know
     /// which parent record to feed which row.
@@ -357,6 +360,25 @@ pub fn expand(cfg: &PipelineConfig) -> CliResult<Vec<ExpandedNode>> {
             }
         }
 
+        // `quality:` is pipeline-level only in v1 (no matrix-row override), so
+        // every node carries the same spec. Compile it once per node to (a)
+        // surface invalid paths/regexes/bounds at expand time, and (b) fail
+        // fast when a quarantine check has no DLQ to route to — the core guards
+        // this at run start too, but catching it here makes `faucet validate`
+        // a friendly, fast failure.
+        let quality = cfg.pipeline.quality.clone();
+        if let Some(ref spec) = quality {
+            let compiled = faucet_core::CompiledQuality::compile(spec)
+                .map_err(|e| CliError::Config(format!("quality (row `{row_id}`): {e}")))?;
+            if compiled.requires_dlq() && dlq.is_none() {
+                return Err(CliError::Config(format!(
+                    "row `{row_id}`: a quality check uses `on_failure: quarantine` \
+                     but no DLQ is configured — add a `dlq:` block (or change the \
+                     check's `on_failure` to `abort`)"
+                )));
+            }
+        }
+
         out.push(ExpandedNode {
             id: ids[i].clone(),
             row_index: i,
@@ -366,6 +388,7 @@ pub fn expand(cfg: &PipelineConfig) -> CliResult<Vec<ExpandedNode>> {
             transforms,
             state,
             dlq,
+            quality,
             deferred_refs: deferred,
         });
     }
@@ -732,6 +755,67 @@ pipeline:
         let cfg = parse_with_extension(yaml, "yaml").unwrap();
         let err = expand(&cfg).unwrap_err();
         assert!(matches!(err, CliError::UnknownDlqSinkKind { .. }));
+    }
+
+    #[test]
+    fn expand_rejects_quarantine_without_dlq() {
+        // A quality check with `on_failure: quarantine` needs a DLQ to route to.
+        // `expand` must reject the config so `faucet validate` fails fast.
+        let yaml = r#"
+version: 1
+pipeline:
+  source: { type: rest, config: {} }
+  sink:   { type: jsonl, config: { path: ./o.jsonl } }
+  quality:
+    record:
+      - { type: not_null, field: id, on_failure: quarantine }
+"#;
+        let cfg = parse_with_extension(yaml, "yaml").unwrap();
+        let err = expand(&cfg).unwrap_err();
+        match err {
+            CliError::Config(msg) => {
+                assert!(msg.contains("quarantine"), "{msg}");
+                assert!(msg.contains("DLQ") || msg.contains("dlq"), "{msg}");
+            }
+            other => panic!("expected Config error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn expand_accepts_quarantine_with_dlq() {
+        let yaml = r#"
+version: 1
+pipeline:
+  source: { type: rest, config: {} }
+  sink:   { type: jsonl, config: { path: ./o.jsonl } }
+  dlq:
+    sink: { type: jsonl, config: { path: ./dlq.jsonl } }
+  quality:
+    record:
+      - { type: not_null, field: id, on_failure: quarantine }
+"#;
+        let cfg = parse_with_extension(yaml, "yaml").unwrap();
+        let nodes = expand(&cfg).unwrap();
+        assert_eq!(nodes.len(), 1);
+        let q = nodes[0].quality.as_ref().expect("quality threaded onto node");
+        assert_eq!(q.record.len(), 1);
+    }
+
+    #[test]
+    fn expand_accepts_abort_quality_without_dlq() {
+        // `on_failure: abort` does not route to a DLQ, so no DLQ is required.
+        let yaml = r#"
+version: 1
+pipeline:
+  source: { type: rest, config: {} }
+  sink:   { type: jsonl, config: { path: ./o.jsonl } }
+  quality:
+    record:
+      - { type: not_null, field: id, on_failure: abort }
+"#;
+        let cfg = parse_with_extension(yaml, "yaml").unwrap();
+        let nodes = expand(&cfg).unwrap();
+        assert!(nodes[0].quality.is_some());
     }
 
     #[test]

--- a/cli/src/expand.rs
+++ b/cli/src/expand.rs
@@ -797,7 +797,10 @@ pipeline:
         let cfg = parse_with_extension(yaml, "yaml").unwrap();
         let nodes = expand(&cfg).unwrap();
         assert_eq!(nodes.len(), 1);
-        let q = nodes[0].quality.as_ref().expect("quality threaded onto node");
+        let q = nodes[0]
+            .quality
+            .as_ref()
+            .expect("quality threaded onto node");
         assert_eq!(q.record.len(), 1);
     }
 

--- a/cli/src/expand.rs
+++ b/cli/src/expand.rs
@@ -40,6 +40,7 @@ pub struct ExpandedNode {
     pub dlq: Option<crate::config::DlqSpec>,
     /// Pipeline-level quality spec, shared by every node. `quality:` has no
     /// matrix-row override in v1, so this is `cfg.pipeline.quality` verbatim.
+    #[cfg(feature = "quality")]
     pub quality: Option<faucet_core::QualitySpec>,
     /// Every `${id.path}` placeholder that survived load-time interpolation.
     /// Populated by `collect_deferred`; the executor uses this to know
@@ -366,7 +367,9 @@ pub fn expand(cfg: &PipelineConfig) -> CliResult<Vec<ExpandedNode>> {
         // fast when a quarantine check has no DLQ to route to — the core guards
         // this at run start too, but catching it here makes `faucet validate`
         // a friendly, fast failure.
+        #[cfg(feature = "quality")]
         let quality = cfg.pipeline.quality.clone();
+        #[cfg(feature = "quality")]
         if let Some(ref spec) = quality {
             let compiled = faucet_core::CompiledQuality::compile(spec)
                 .map_err(|e| CliError::Config(format!("quality (row `{row_id}`): {e}")))?;
@@ -388,6 +391,7 @@ pub fn expand(cfg: &PipelineConfig) -> CliResult<Vec<ExpandedNode>> {
             transforms,
             state,
             dlq,
+            #[cfg(feature = "quality")]
             quality,
             deferred_refs: deferred,
         });
@@ -757,6 +761,7 @@ pipeline:
         assert!(matches!(err, CliError::UnknownDlqSinkKind { .. }));
     }
 
+    #[cfg(feature = "quality")]
     #[test]
     fn expand_rejects_quarantine_without_dlq() {
         // A quality check with `on_failure: quarantine` needs a DLQ to route to.
@@ -781,6 +786,7 @@ pipeline:
         }
     }
 
+    #[cfg(feature = "quality")]
     #[test]
     fn expand_accepts_quarantine_with_dlq() {
         let yaml = r#"
@@ -804,6 +810,7 @@ pipeline:
         assert_eq!(q.record.len(), 1);
     }
 
+    #[cfg(feature = "quality")]
     #[test]
     fn expand_accepts_abort_quality_without_dlq() {
         // `on_failure: abort` does not route to a DLQ, so no DLQ is required.

--- a/cli/src/transforms.rs
+++ b/cli/src/transforms.rs
@@ -392,6 +392,29 @@ pub fn available_transforms() -> Vec<&'static str> {
     registry().into_iter().map(|t| t.kind).collect()
 }
 
+// Keep in sync with faucet_core::{RecordCheck, BatchCheck} — one entry per check variant.
+/// One-line descriptions of the available quality checks, for `faucet list`.
+pub fn quality_descriptions() -> Vec<(&'static str, &'static str)> {
+    vec![
+        ("not_null", "field present and non-null"),
+        ("not_empty", "string non-empty after trim"),
+        ("regex_match", "string matches a regex"),
+        ("value_in_set", "value is in an allowed set"),
+        ("not_in_set", "value is not in a forbidden set"),
+        ("compare", "numeric/scalar comparison (gt/gte/lt/lte/eq/ne)"),
+        ("type_is", "value is of an expected JSON type"),
+        ("string_length", "string length within [min,max]"),
+        (
+            "json_schema",
+            "record validates against a JSON Schema (feature-gated)",
+        ),
+        ("row_count", "batch row count within [min,max]"),
+        ("null_rate", "batch null rate of a field <= max"),
+        ("unique", "composite key unique within the batch"),
+        ("distinct_count", "distinct values of a field within [min,max]"),
+    ]
+}
+
 /// Return the JSON Schema for the named transform's config. Mirrors
 /// `registry::source_schema` / `sink_schema` so `faucet schema transform <name>`
 /// reads symmetrically with the connector variants.
@@ -819,5 +842,13 @@ mod tests {
             CliError::InvalidTransform { name, .. } => assert_eq!(name, "explode"),
             other => panic!("expected InvalidTransform, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn quality_descriptions_has_one_entry_per_check() {
+        // 9 per-record checks (incl. json_schema) + 4 per-batch checks = 13.
+        // If you add a RecordCheck/BatchCheck variant in faucet-core, add its
+        // description here too.
+        assert_eq!(quality_descriptions().len(), 13);
     }
 }

--- a/cli/src/transforms.rs
+++ b/cli/src/transforms.rs
@@ -411,7 +411,10 @@ pub fn quality_descriptions() -> Vec<(&'static str, &'static str)> {
         ("row_count", "batch row count within [min,max]"),
         ("null_rate", "batch null rate of a field <= max"),
         ("unique", "composite key unique within the batch"),
-        ("distinct_count", "distinct values of a field within [min,max]"),
+        (
+            "distinct_count",
+            "distinct values of a field within [min,max]",
+        ),
     ]
 }
 

--- a/cli/src/transforms.rs
+++ b/cli/src/transforms.rs
@@ -394,8 +394,11 @@ pub fn available_transforms() -> Vec<&'static str> {
 
 // Keep in sync with faucet_core::{RecordCheck, BatchCheck} — one entry per check variant.
 /// One-line descriptions of the available quality checks, for `faucet list`.
+/// The `json_schema` entry only appears when the `quality-jsonschema` feature
+/// is enabled, mirroring `faucet schema quality` so `list` and `schema` agree.
+#[cfg(feature = "quality")]
 pub fn quality_descriptions() -> Vec<(&'static str, &'static str)> {
-    vec![
+    let mut checks = vec![
         ("not_null", "field present and non-null"),
         ("not_empty", "string non-empty after trim"),
         ("regex_match", "string matches a regex"),
@@ -404,10 +407,13 @@ pub fn quality_descriptions() -> Vec<(&'static str, &'static str)> {
         ("compare", "numeric/scalar comparison (gt/gte/lt/lte/eq/ne)"),
         ("type_is", "value is of an expected JSON type"),
         ("string_length", "string length within [min,max]"),
-        (
-            "json_schema",
-            "record validates against a JSON Schema (feature-gated)",
-        ),
+    ];
+    #[cfg(feature = "quality-jsonschema")]
+    checks.push((
+        "json_schema",
+        "record validates against a JSON Schema (feature-gated)",
+    ));
+    checks.extend([
         ("row_count", "batch row count within [min,max]"),
         ("null_rate", "batch null rate of a field <= max"),
         ("unique", "composite key unique within the batch"),
@@ -415,7 +421,8 @@ pub fn quality_descriptions() -> Vec<(&'static str, &'static str)> {
             "distinct_count",
             "distinct values of a field within [min,max]",
         ),
-    ]
+    ]);
+    checks
 }
 
 /// Return the JSON Schema for the named transform's config. Mirrors
@@ -847,11 +854,17 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "quality")]
     #[test]
     fn quality_descriptions_has_one_entry_per_check() {
-        // 9 per-record checks (incl. json_schema) + 4 per-batch checks = 13.
-        // If you add a RecordCheck/BatchCheck variant in faucet-core, add its
-        // description here too.
+        // 8 always-on per-record checks + 4 per-batch checks = 12; the
+        // `json_schema` per-record check is only present (→ 13) when the
+        // `quality-jsonschema` feature is enabled, matching `faucet schema
+        // quality`. If you add a RecordCheck/BatchCheck variant in faucet-core,
+        // add its description here too.
+        #[cfg(feature = "quality-jsonschema")]
         assert_eq!(quality_descriptions().len(), 13);
+        #[cfg(not(feature = "quality-jsonschema"))]
+        assert_eq!(quality_descriptions().len(), 12);
     }
 }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -42,6 +42,8 @@ transforms = [
 ]
 observability-install = ["dep:metrics-exporter-prometheus", "dep:tracing-subscriber"]
 compression = ["dep:async-compression", "dep:flate2", "dep:zstd"]
+quality = ["dep:regex"]
+quality-jsonschema = ["quality", "dep:jsonschema"]
 
 [dependencies]
 serde.workspace = true
@@ -67,6 +69,7 @@ async-compression = { workspace = true, optional = true }
 flate2 = { workspace = true, optional = true }
 zstd = { workspace = true, optional = true }
 chrono = { workspace = true, optional = true }
+jsonschema = { workspace = true, optional = true }
 
 [dev-dependencies]
 serde_json.workspace = true
@@ -79,6 +82,11 @@ criterion = { workspace = true, features = ["async_tokio"] }
 [[bench]]
 name = "observability"
 harness = false
+
+[[bench]]
+name = "quality"
+harness = false
+required-features = ["quality", "quality-jsonschema"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/core/README.md
+++ b/crates/core/README.md
@@ -215,6 +215,142 @@ let json = serde_json::to_value(schema)?;
 | `serde_json`, `Value`, `json!` | `serde_json` |
 | `schemars`, `JsonSchema`, `schema_for!` | `schemars` |
 
+### Quality checks
+
+Add a `quality:` block (sibling of `transforms:` and `dlq:` under `pipeline:`) to
+assert invariants on every page of records before they reach the sink. The quality
+pass runs **after** transforms and **before** `write_batch`; per-record checks
+partition the page into survivors and quarantined rows, then per-batch checks run
+over the survivors. Quarantined rows are routed to the DLQ sink.
+
+Enable with the `quality` Cargo feature (base) or `quality-jsonschema` to add the
+`json_schema` record check.
+
+#### Check catalog
+
+**Per-record checks** — each record is evaluated in declared order; first failure
+wins. `on_failure` may be `quarantine` (route the row to the DLQ) or `abort` (fail
+the run immediately with `FaucetError::QualityFailure`).
+
+| Check | Key config fields | Passes when | Missing field |
+|---|---|---|---|
+| `not_null` | `field`, `treat_missing_as_null` (default `true`) | value present and non-null | fail (pass iff `treat_missing_as_null: false`) |
+| `not_empty` | `field` | value is a non-empty string after `trim()` | fail |
+| `regex_match` | `field`, `pattern` | value is a string matching `pattern` | fail |
+| `value_in_set` | `field`, `values: [...]` | value is in `values` (exact JSON equality) | fail |
+| `not_in_set` | `field`, `values: [...]` | value is NOT in `values` | pass (trivially not in set) |
+| `compare` | `field`, `op` (`gt`/`gte`/`lt`/`lte`/`eq`/`ne`), `value` | ordering or equality holds | fail |
+| `type_is` | `field`, `expected` (`boolean`/`number`/`string`/`array`/`object`/`null`) | JSON type matches | fail |
+| `string_length` | `field`, `min?`, `max?` (at least one required) | char count in `[min, max]` | fail |
+| `json_schema` *(quality-jsonschema feature)* | `schema` (JSON Schema doc) | record validates against `schema` | (whole-record check; always evaluated) |
+
+`json_schema` is the most expressive check; its cost scales with schema
+complexity — for very large or deeply nested schemas on hot paths, prefer the
+granular checks above and benchmark your case.
+
+**Per-batch checks** — evaluated per page over the survivors (records that passed
+the per-record pass). `on_failure` for aggregate checks (`row_count`, `null_rate`,
+`distinct_count`) may be `abort` or `quarantine_batch` (route all current survivors
+to the DLQ, write nothing this page). `unique` is row-attributable and accepts
+`quarantine` (route the duplicate rows) or `abort`.
+
+| Check | Key config fields | Passes when |
+|---|---|---|
+| `row_count` | `min?`, `max?` (at least one required) | survivor count in `[min, max]` |
+| `null_rate` | `field`, `max: f64` (0.0–1.0) | null-or-missing rate ≤ `max`; zero survivors → 0.0 → pass |
+| `unique` | `fields: [...]` (composite key, ≥1) | every survivor's key is unique within the page |
+| `distinct_count` | `field`, `min?`, `max?` | distinct values of `field` in `[min, max]` |
+
+#### `on_failure` policies
+
+| Policy | Meaning | Allowed on |
+|---|---|---|
+| `quarantine` | Route the specific offending row(s) to the DLQ; keep the rest | per-record checks; `unique` |
+| `quarantine_batch` | Route all survivors of the page to the DLQ; write nothing this page | aggregate batch checks |
+| `abort` | Surface `FaucetError::QualityFailure` and fail the run | every check |
+
+**`quarantine` and `quarantine_batch` require a DLQ sink.** Configuring either
+without a `dlq:` block is rejected at config-load time with `FaucetError::Config`.
+
+#### Example
+
+```yaml
+pipeline:
+  source:
+    type: rest
+    config:
+      base_url: https://api.example.com/v1
+      path: /users
+      method: GET
+      auth: { type: bearer, config: { token: "${env:API_TOKEN}" } }
+      pagination: { type: Cursor, next_token_path: $.meta.next_cursor, param_name: cursor }
+      max_retries: 3
+      retry_backoff: 2
+      tolerated_http_errors: []
+      replication_method: { type: Incremental }
+      replication_key: updated_at
+      primary_keys: ["id"]
+      partitions: []
+      schema_sample_size: 100
+
+  transforms:
+    - type: keys_case
+      config: { mode: snake }
+
+  quality:
+    record:
+      - type: not_null
+        field: id
+        on_failure: abort
+      - type: not_null
+        field: email
+        on_failure: quarantine
+      - type: regex_match
+        field: email
+        pattern: '^[^@\s]+@[^@\s]+\.[^@\s]+$'
+        on_failure: quarantine
+      - type: value_in_set
+        field: status
+        values: ["active", "inactive", "pending", "suspended"]
+        on_failure: quarantine
+    batch:
+      - type: row_count
+        min: 1
+        on_failure: abort
+      - type: unique
+        fields: [id]
+        on_failure: quarantine
+
+  dlq:
+    sink:
+      type: jsonl
+      config: { path: ./dlq/quality_failures.jsonl }
+    max_failures_per_page: 50
+    max_failures_total: 500
+
+  sink:
+    type: postgres
+    config:
+      connection_url: "${env:PG_URL}"
+      table_name: users
+      column_mapping: { type: jsonb, column: data }
+      batch_size: 500
+```
+
+#### Rust API
+
+```rust
+use faucet_core::{Pipeline, CompiledQuality, QualitySpec};
+
+let quality_spec: QualitySpec = serde_json::from_value(/* ... */)?;
+let compiled = CompiledQuality::compile(&quality_spec)?;
+let result = Pipeline::new(&source, &sink)
+    .with_dlq(dlq_config)   // required when any check uses quarantine
+    .with_quality(compiled)
+    .run()
+    .await?;
+```
+
 ## Modules
 
 | Module | Contents |
@@ -227,6 +363,7 @@ let json = serde_json::to_value(schema)?;
 | `replication` | `ReplicationMethod`, `filter_incremental`, `max_replication_value` |
 | `schema` | `infer_schema` |
 | `stage` | `TransformStage`, `FilterSpec`, `ExplodeSpec`, `OnMissing`. The pipeline-level stage type that wraps `RecordTransform` (1→1) and adds filter (1→0\|1) and explode (1→0..N). See `docs/book/src/cookbook/transforms.md` for the merge rule and JSONPath subset. |
+| `quality` | Per-record and per-batch data-quality checks: `QualitySpec` config, `CompiledQuality`, `apply_quality`, `QualityOutcome`. Gated on the `quality` / `quality-jsonschema` features. |
 | `util` | `quote_ident`, `extract_records`, `check_http_response` |
 
 ## License

--- a/crates/core/benches/quality.rs
+++ b/crates/core/benches/quality.rs
@@ -1,2 +1,42 @@
-// placeholder — filled in a later task
-fn main() {}
+//! Compares json_schema validation vs the equivalent granular checks per record.
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use faucet_core::quality::{CompiledQuality, apply_quality};
+use faucet_core::{OnFailure, QualitySpec, RecordCheck};
+use serde_json::json;
+use std::hint::black_box;
+
+fn bench_quality(c: &mut Criterion) {
+    let records: Vec<_> = (0..1000)
+        .map(|i| json!({"id": i, "age": 30, "email": "a@b.com"}))
+        .collect();
+
+    let granular = CompiledQuality::compile(&QualitySpec {
+        record: vec![
+            RecordCheck::NotNull { field: "id".into(), treat_missing_as_null: true, on_failure: OnFailure::Abort },
+            RecordCheck::Compare { field: "age".into(), op: faucet_core::CompareOp::Gte, value: json!(0), on_failure: OnFailure::Abort },
+        ],
+        batch: vec![],
+    })
+    .unwrap();
+
+    c.bench_function("quality_granular_1k", |b| {
+        b.iter(|| apply_quality(black_box(records.clone()), &granular).unwrap())
+    });
+
+    let schema = CompiledQuality::compile(&QualitySpec {
+        record: vec![RecordCheck::JsonSchema {
+            schema: json!({"type":"object","required":["id"],"properties":{"id":{"type":"integer"},"age":{"type":"integer","minimum":0}}}),
+            on_failure: OnFailure::Abort,
+        }],
+        batch: vec![],
+    })
+    .unwrap();
+
+    c.bench_function("quality_json_schema_1k", |b| {
+        b.iter(|| apply_quality(black_box(records.clone()), &schema).unwrap())
+    });
+}
+
+criterion_group!(benches, bench_quality);
+criterion_main!(benches);

--- a/crates/core/benches/quality.rs
+++ b/crates/core/benches/quality.rs
@@ -1,0 +1,2 @@
+// placeholder — filled in a later task
+fn main() {}

--- a/crates/core/benches/quality.rs
+++ b/crates/core/benches/quality.rs
@@ -13,8 +13,17 @@ fn bench_quality(c: &mut Criterion) {
 
     let granular = CompiledQuality::compile(&QualitySpec {
         record: vec![
-            RecordCheck::NotNull { field: "id".into(), treat_missing_as_null: true, on_failure: OnFailure::Abort },
-            RecordCheck::Compare { field: "age".into(), op: faucet_core::CompareOp::Gte, value: json!(0), on_failure: OnFailure::Abort },
+            RecordCheck::NotNull {
+                field: "id".into(),
+                treat_missing_as_null: true,
+                on_failure: OnFailure::Abort,
+            },
+            RecordCheck::Compare {
+                field: "age".into(),
+                op: faucet_core::CompareOp::Gte,
+                value: json!(0),
+                on_failure: OnFailure::Abort,
+            },
         ],
         batch: vec![],
     })

--- a/crates/core/src/dlq.rs
+++ b/crates/core/src/dlq.rs
@@ -92,15 +92,18 @@ pub enum DlqReason {
     /// The whole batch failed and the configured policy was
     /// [`OnBatchError::DlqAll`].
     DlqAll,
+    /// A record was quarantined (or batch-quarantined) by a data-quality check.
+    Quality,
 }
 
 impl DlqReason {
     /// Returns the stable Prometheus label value for this reason.
-    /// Closed-set values: `"partial"` or `"dlq_all"`.
+    /// Closed-set values: `"partial"`, `"dlq_all"`, or `"quality"`.
     pub fn as_str(self) -> &'static str {
         match self {
             DlqReason::Partial => "partial",
             DlqReason::DlqAll => "dlq_all",
+            DlqReason::Quality => "quality",
         }
     }
 }
@@ -206,5 +209,10 @@ mod tests {
     fn dlq_reason_strings() {
         assert_eq!(DlqReason::Partial.as_str(), "partial");
         assert_eq!(DlqReason::DlqAll.as_str(), "dlq_all");
+    }
+
+    #[test]
+    fn dlq_reason_quality_string() {
+        assert_eq!(DlqReason::Quality.as_str(), "quality");
     }
 }

--- a/crates/core/src/dlq.rs
+++ b/crates/core/src/dlq.rs
@@ -39,8 +39,17 @@ pub struct DlqConfig {
     /// What to do when the main sink fails wholesale.
     pub on_batch_error: OnBatchError,
     /// Per-page failure budget. `None` = unlimited.
+    ///
+    /// This budget is **shared across both sink-side row failures and
+    /// quality-check quarantines**: a record routed to the DLQ by a
+    /// `quarantine` quality check counts against it just as a sink-side
+    /// row failure does.
     pub max_failures_per_page: Option<usize>,
     /// Cumulative failure budget across the run. `None` = unlimited.
+    ///
+    /// This budget is **shared across both sink-side row failures and
+    /// quality-check quarantines**: records quarantined by the quality pass
+    /// accumulate in this counter alongside sink-side failures.
     pub max_failures_total: Option<usize>,
     /// Always `true` in v1. Reserved for a future "headers-only" mode.
     pub include_original_payload: bool,

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -56,6 +56,10 @@ pub enum FaucetError {
     #[error("Sink error: {0}")]
     Sink(String),
 
+    /// A data-quality check failed under an `abort` policy.
+    #[error("Quality check '{check}' failed: {message}")]
+    QualityFailure { check: String, message: String },
+
     /// A state-store operation failed (read/write/delete of a replication
     /// bookmark, checkpoint, or other persisted pipeline state).
     #[error("State error: {0}")]
@@ -247,5 +251,17 @@ mod tests {
     fn sink_error_display() {
         let err = FaucetError::Sink("connection refused".into());
         assert_eq!(err.to_string(), "Sink error: connection refused");
+    }
+
+    #[test]
+    fn quality_failure_is_not_retriable_and_displays() {
+        let err = FaucetError::QualityFailure {
+            check: "not_null".into(),
+            message: "field 'user_id' was null".into(),
+        };
+        assert!(!err.is_retriable());
+        let s = err.to_string();
+        assert!(s.contains("not_null"));
+        assert!(s.contains("user_id"));
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -37,14 +37,14 @@ pub mod compression;
 pub use auth::{AuthProvider, AuthReference, AuthSpec, Credential, SharedAuthProvider};
 pub use dlq::{DlqConfig, DlqReason, DlqStats, OnBatchError, build_envelope};
 pub use error::FaucetError;
+#[cfg(feature = "quality")]
+pub use observability::instrumented_apply_quality;
 pub use observability::{
     DurationGuard, InstallError, InstallReport, InstrumentedSink, InstrumentedSource,
     InstrumentedStateStore, Labels, ObservabilityConfig, PrometheusConfig, RunStreamOptions,
     TracingConfig, install_observability, instrumented_apply_stages, register_build_info,
     update_bookmark_lag,
 };
-#[cfg(feature = "quality")]
-pub use observability::instrumented_apply_quality;
 pub use pipeline::{
     DEFAULT_BATCH_SIZE, MAX_BATCH_SIZE, Pipeline, PipelineResult, StreamPage, run_stream,
     validate_batch_size,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -77,4 +77,6 @@ pub use serde_json::{self, Value, json};
 pub use compression::{Compression, CompressionConfig, compress_buf, warn_mismatch};
 
 #[cfg(feature = "quality")]
-pub use quality::{BatchCheck, CompareOp, JsonType, OnFailure, QualitySpec, RecordCheck};
+pub use quality::{
+    BatchCheck, CompareOp, CompiledQuality, JsonType, OnFailure, QualitySpec, RecordCheck,
+};

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -78,5 +78,6 @@ pub use compression::{Compression, CompressionConfig, compress_buf, warn_mismatc
 
 #[cfg(feature = "quality")]
 pub use quality::{
-    BatchCheck, CompareOp, CompiledQuality, JsonType, OnFailure, QualitySpec, RecordCheck,
+    BatchCheck, CheckTally, CompareOp, CompiledQuality, JsonType, OnFailure, QualityOutcome,
+    QualitySpec, QuarantinedRecord, RecordCheck, apply_quality,
 };

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -19,6 +19,8 @@ pub mod dlq;
 pub mod error;
 pub mod observability;
 pub mod pipeline;
+#[cfg(feature = "quality")]
+pub mod quality;
 pub mod replication;
 pub mod retry;
 pub mod schema;
@@ -73,3 +75,6 @@ pub use serde_json::{self, Value, json};
 
 #[cfg(feature = "compression")]
 pub use compression::{Compression, CompressionConfig, compress_buf, warn_mismatch};
+
+#[cfg(feature = "quality")]
+pub use quality::{CompareOp, JsonType, OnFailure};

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -77,4 +77,4 @@ pub use serde_json::{self, Value, json};
 pub use compression::{Compression, CompressionConfig, compress_buf, warn_mismatch};
 
 #[cfg(feature = "quality")]
-pub use quality::{CompareOp, JsonType, OnFailure};
+pub use quality::{BatchCheck, CompareOp, JsonType, OnFailure, QualitySpec, RecordCheck};

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -43,6 +43,8 @@ pub use observability::{
     TracingConfig, install_observability, instrumented_apply_stages, register_build_info,
     update_bookmark_lag,
 };
+#[cfg(feature = "quality")]
+pub use observability::instrumented_apply_quality;
 pub use pipeline::{
     DEFAULT_BATCH_SIZE, MAX_BATCH_SIZE, Pipeline, PipelineResult, StreamPage, run_stream,
     validate_batch_size,

--- a/crates/core/src/observability/decorator.rs
+++ b/crates/core/src/observability/decorator.rs
@@ -189,6 +189,7 @@ pub(crate) fn error_kind(e: &FaucetError) -> &'static str {
         FaucetError::Config(_) => "Config",
         FaucetError::Source(_) => "Source",
         FaucetError::Sink(_) => "Sink",
+        FaucetError::QualityFailure { .. } => "QualityFailure",
         FaucetError::State(_) => "State",
         FaucetError::Custom(_) => "Custom",
     }

--- a/crates/core/src/observability/mod.rs
+++ b/crates/core/src/observability/mod.rs
@@ -23,9 +23,9 @@ pub use install::{
 };
 pub use labels::Labels;
 pub use options::RunStreamOptions;
+#[cfg(feature = "quality")]
+pub use quality::instrumented_apply_quality;
 pub use state::InstrumentedStateStore;
 pub use strip::strip_type_name;
 pub use timer::DurationGuard;
 pub use transform::instrumented_apply_stages;
-#[cfg(feature = "quality")]
-pub use quality::instrumented_apply_quality;

--- a/crates/core/src/observability/mod.rs
+++ b/crates/core/src/observability/mod.rs
@@ -8,6 +8,8 @@ pub(crate) mod decorator;
 mod install;
 mod labels;
 mod options;
+#[cfg(feature = "quality")]
+mod quality;
 mod state;
 mod strip;
 mod timer;
@@ -25,3 +27,5 @@ pub use state::InstrumentedStateStore;
 pub use strip::strip_type_name;
 pub use timer::DurationGuard;
 pub use transform::instrumented_apply_stages;
+#[cfg(feature = "quality")]
+pub use quality::instrumented_apply_quality;

--- a/crates/core/src/observability/options.rs
+++ b/crates/core/src/observability/options.rs
@@ -14,6 +14,8 @@ pub struct RunStreamOptions {
     pub row: Option<String>,
     pub run_id: Option<String>,
     pub dlq: Option<DlqConfig>,
+    #[cfg(feature = "quality")]
+    pub quality: Option<std::sync::Arc<crate::quality::CompiledQuality>>,
 }
 
 impl RunStreamOptions {
@@ -44,6 +46,15 @@ impl RunStreamOptions {
 
     pub fn with_dlq(mut self, dlq: DlqConfig) -> Self {
         self.dlq = Some(dlq);
+        self
+    }
+
+    #[cfg(feature = "quality")]
+    pub fn with_quality(
+        mut self,
+        quality: std::sync::Arc<crate::quality::CompiledQuality>,
+    ) -> Self {
+        self.quality = Some(quality);
         self
     }
 }

--- a/crates/core/src/observability/quality.rs
+++ b/crates/core/src/observability/quality.rs
@@ -4,7 +4,7 @@
 
 use crate::error::FaucetError;
 use crate::observability::Labels;
-use crate::quality::{apply_quality, CompiledQuality, QualityOutcome};
+use crate::quality::{CompiledQuality, QualityOutcome, apply_quality};
 use metrics::{Label, SharedString, counter, histogram};
 use serde_json::Value;
 
@@ -138,8 +138,14 @@ mod tests {
                     .any(|l| l.key() == "outcome" && l.value() == "fail")
                 && matches!(v, DebugValue::Counter(c) if *c >= 1)
         });
-        assert!(pass_found, "expected faucet_quality_checks_total{{outcome=pass}} >= 2");
-        assert!(fail_found, "expected faucet_quality_checks_total{{outcome=fail}} >= 1");
+        assert!(
+            pass_found,
+            "expected faucet_quality_checks_total{{outcome=pass}} >= 2"
+        );
+        assert!(
+            fail_found,
+            "expected faucet_quality_checks_total{{outcome=fail}} >= 1"
+        );
     }
 
     #[test]
@@ -170,7 +176,10 @@ mod tests {
                     .any(|l| l.key() == "field" && l.value() == "user_id")
                 && matches!(v, DebugValue::Counter(c) if *c >= 1)
         });
-        assert!(found, "expected faucet_quality_records_quarantined_total with field=user_id");
+        assert!(
+            found,
+            "expected faucet_quality_records_quarantined_total with field=user_id"
+        );
     }
 
     #[test]
@@ -202,6 +211,9 @@ mod tests {
                     .any(|l| l.key() == "check" && l.value() == "not_null")
                 && matches!(v, DebugValue::Counter(c) if *c >= 1)
         });
-        assert!(found, "expected faucet_quality_aborts_total with check=not_null");
+        assert!(
+            found,
+            "expected faucet_quality_aborts_total with check=not_null"
+        );
     }
 }

--- a/crates/core/src/observability/quality.rs
+++ b/crates/core/src/observability/quality.rs
@@ -1,0 +1,207 @@
+//! Observability wrapper around `quality::apply_quality`. Emits the
+//! `faucet_quality_*` metrics from the returned outcome/tally. The pure logic
+//! lives in `crate::quality`.
+
+use crate::error::FaucetError;
+use crate::observability::Labels;
+use crate::quality::{apply_quality, CompiledQuality, QualityOutcome};
+use metrics::{Label, SharedString, counter, histogram};
+use serde_json::Value;
+
+/// Apply the quality pass and emit metrics. Returns the same outcome as
+/// [`apply_quality`]; on abort, increments `faucet_quality_aborts_total` before
+/// propagating the error.
+pub fn instrumented_apply_quality(
+    records: Vec<Value>,
+    quality: &CompiledQuality,
+    labels: &Labels,
+) -> Result<QualityOutcome, FaucetError> {
+    let records_in = records.len();
+    let span = tracing::info_span!(
+        "faucet.quality.apply",
+        pipeline = %labels.pipeline,
+        row = %labels.row,
+        run_id = %labels.run_id,
+        records_in,
+    );
+    let _enter = span.enter();
+
+    let base = |check: &str| -> Vec<Label> {
+        vec![
+            Label::new("pipeline", SharedString::from(labels.pipeline.to_string())),
+            Label::new("row", SharedString::from(labels.row.to_string())),
+            Label::new("check", SharedString::from(check.to_string())),
+        ]
+    };
+
+    let result = apply_quality(records, quality);
+
+    match &result {
+        Ok(outcome) => {
+            for (check, t) in &outcome.tally {
+                let base_labels = base(check);
+                let mut pass = base_labels.clone();
+                pass.push(Label::new("outcome", SharedString::const_str("pass")));
+                if t.pass > 0 {
+                    counter!("faucet_quality_checks_total", pass).increment(t.pass);
+                }
+                let mut fail = base_labels.clone();
+                fail.push(Label::new("outcome", SharedString::const_str("fail")));
+                if t.fail > 0 {
+                    counter!("faucet_quality_checks_total", fail).increment(t.fail);
+                }
+                histogram!("faucet_quality_check_duration_seconds", base_labels)
+                    .record(t.elapsed.as_secs_f64());
+            }
+            for q in &outcome.quarantined {
+                let mut lbl = base(q.check);
+                lbl.push(Label::new(
+                    "field",
+                    SharedString::from(q.field.clone().unwrap_or_default()),
+                ));
+                counter!("faucet_quality_records_quarantined_total", lbl).increment(1);
+            }
+        }
+        Err(FaucetError::QualityFailure { check, .. }) => {
+            counter!("faucet_quality_aborts_total", base(check)).increment(1);
+        }
+        Err(_) => {}
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::observability::decorator::source_tests::{LOCK, snapshotter};
+    use crate::quality::config::{OnFailure, QualitySpec, RecordCheck};
+    use metrics_util::debugging::DebugValue;
+    use serde_json::json;
+
+    #[test]
+    fn instrumented_returns_same_outcome() {
+        let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _snap = snapshotter();
+        let q = CompiledQuality::compile(&QualitySpec {
+            record: vec![RecordCheck::NotNull {
+                field: "id".into(),
+                treat_missing_as_null: true,
+                on_failure: OnFailure::Quarantine,
+            }],
+            batch: vec![],
+        })
+        .unwrap();
+        let out = instrumented_apply_quality(
+            vec![json!({"id": 1}), json!({"id": null})],
+            &q,
+            &Labels::for_named("test"),
+        )
+        .unwrap();
+        assert_eq!(out.survivors.len(), 1);
+        assert_eq!(out.quarantined.len(), 1);
+    }
+
+    #[test]
+    fn emits_pass_fail_counters() {
+        let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let snap = snapshotter();
+        let q = CompiledQuality::compile(&QualitySpec {
+            record: vec![RecordCheck::NotNull {
+                field: "id".into(),
+                treat_missing_as_null: true,
+                on_failure: OnFailure::Quarantine,
+            }],
+            batch: vec![],
+        })
+        .unwrap();
+        instrumented_apply_quality(
+            vec![json!({"id": 1}), json!({"id": null}), json!({"id": 2})],
+            &q,
+            &Labels::for_named("test_counters"),
+        )
+        .unwrap();
+        let snapshot = snap.snapshot().into_vec();
+        let pass_found = snapshot.iter().any(|(key, _, _, v)| {
+            key.key().name() == "faucet_quality_checks_total"
+                && key
+                    .key()
+                    .labels()
+                    .any(|l| l.key() == "outcome" && l.value() == "pass")
+                && matches!(v, DebugValue::Counter(c) if *c >= 2)
+        });
+        let fail_found = snapshot.iter().any(|(key, _, _, v)| {
+            key.key().name() == "faucet_quality_checks_total"
+                && key
+                    .key()
+                    .labels()
+                    .any(|l| l.key() == "outcome" && l.value() == "fail")
+                && matches!(v, DebugValue::Counter(c) if *c >= 1)
+        });
+        assert!(pass_found, "expected faucet_quality_checks_total{{outcome=pass}} >= 2");
+        assert!(fail_found, "expected faucet_quality_checks_total{{outcome=fail}} >= 1");
+    }
+
+    #[test]
+    fn emits_quarantined_counter() {
+        let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let snap = snapshotter();
+        let q = CompiledQuality::compile(&QualitySpec {
+            record: vec![RecordCheck::NotNull {
+                field: "user_id".into(),
+                treat_missing_as_null: true,
+                on_failure: OnFailure::Quarantine,
+            }],
+            batch: vec![],
+        })
+        .unwrap();
+        instrumented_apply_quality(
+            vec![json!({"user_id": null})],
+            &q,
+            &Labels::for_named("test_quarantine"),
+        )
+        .unwrap();
+        let snapshot = snap.snapshot().into_vec();
+        let found = snapshot.iter().any(|(key, _, _, v)| {
+            key.key().name() == "faucet_quality_records_quarantined_total"
+                && key
+                    .key()
+                    .labels()
+                    .any(|l| l.key() == "field" && l.value() == "user_id")
+                && matches!(v, DebugValue::Counter(c) if *c >= 1)
+        });
+        assert!(found, "expected faucet_quality_records_quarantined_total with field=user_id");
+    }
+
+    #[test]
+    fn emits_aborts_total_on_quality_failure() {
+        let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let snap = snapshotter();
+        let q = CompiledQuality::compile(&QualitySpec {
+            record: vec![RecordCheck::NotNull {
+                field: "id".into(),
+                treat_missing_as_null: true,
+                on_failure: OnFailure::Abort,
+            }],
+            batch: vec![],
+        })
+        .unwrap();
+        let err = instrumented_apply_quality(
+            vec![json!({"id": null})],
+            &q,
+            &Labels::for_named("test_abort"),
+        )
+        .unwrap_err();
+        assert!(matches!(err, FaucetError::QualityFailure { .. }));
+        let snapshot = snap.snapshot().into_vec();
+        let found = snapshot.iter().any(|(key, _, _, v)| {
+            key.key().name() == "faucet_quality_aborts_total"
+                && key
+                    .key()
+                    .labels()
+                    .any(|l| l.key() == "check" && l.value() == "not_null")
+                && matches!(v, DebugValue::Counter(c) if *c >= 1)
+        });
+        assert!(found, "expected faucet_quality_aborts_total with check=not_null");
+    }
+}

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -129,6 +129,8 @@ pub struct Pipeline<'a, So: Source + ?Sized, Si: Sink + ?Sized> {
     row: Option<String>,
     run_id: Option<String>,
     dlq: Option<DlqConfig>,
+    #[cfg(feature = "quality")]
+    quality: Option<Arc<crate::quality::CompiledQuality>>,
 }
 
 impl<'a, So: Source + ?Sized, Si: Sink + ?Sized> Pipeline<'a, So, Si> {
@@ -142,6 +144,8 @@ impl<'a, So: Source + ?Sized, Si: Sink + ?Sized> Pipeline<'a, So, Si> {
             row: None,
             run_id: None,
             dlq: None,
+            #[cfg(feature = "quality")]
+            quality: None,
         }
     }
 
@@ -188,6 +192,14 @@ impl<'a, So: Source + ?Sized, Si: Sink + ?Sized> Pipeline<'a, So, Si> {
     /// Attach a DLQ for per-row failure routing.
     pub fn with_dlq(mut self, dlq: DlqConfig) -> Self {
         self.dlq = Some(dlq);
+        self
+    }
+
+    /// Attach a compiled quality spec. Checks run after transforms, before the
+    /// sink, per page.
+    #[cfg(feature = "quality")]
+    pub fn with_quality(mut self, quality: Arc<crate::quality::CompiledQuality>) -> Self {
+        self.quality = Some(quality);
         self
     }
 
@@ -310,6 +322,10 @@ impl<'a, So: Source + ?Sized, Si: Sink + ?Sized> Pipeline<'a, So, Si> {
             if let Some(dlq) = self.dlq.clone() {
                 opts = opts.with_dlq(dlq);
             }
+            #[cfg(feature = "quality")]
+            if let Some(q) = self.quality.clone() {
+                opts = opts.with_quality(q);
+            }
 
             run_stream(pages, &wrapped_sink, opts).await
         }
@@ -369,6 +385,20 @@ where
     let run_id = options.run_id.unwrap_or_default();
     let dlq = options.dlq.clone();
 
+    #[cfg(feature = "quality")]
+    let quality = options.quality.clone();
+
+    // Fail fast: quarantine requires a DLQ sink.
+    #[cfg(feature = "quality")]
+    if let Some(q) = quality.as_ref()
+        && q.requires_dlq()
+        && dlq.is_none()
+    {
+        return Err(FaucetError::Config(
+            "quality: on_failure 'quarantine'/'quarantine_batch' requires a DLQ sink".into(),
+        ));
+    }
+
     if let Some(key) = state_key.as_ref() {
         validate_state_key(key)?;
     }
@@ -394,6 +424,43 @@ where
                     if page.records.is_empty() && page.bookmark.is_none() {
                         continue;
                     }
+
+                    // ── Quality pass (after transforms, before sink) ─────────
+                    #[cfg(feature = "quality")]
+                    let (records, quality_envelopes): (Vec<Value>, Vec<Value>) = if let Some(q) =
+                        quality.as_ref()
+                    {
+                        let labels =
+                            crate::observability::Labels::new(&*pipeline_name, &*row, &*run_id);
+                        let outcome = crate::observability::instrumented_apply_quality(
+                            page.records,
+                            q,
+                            &labels,
+                        )?;
+                        let envelopes: Vec<Value> = outcome
+                            .quarantined
+                            .iter()
+                            .enumerate()
+                            .map(|(i, qr)| {
+                                let err = FaucetError::QualityFailure {
+                                    check: qr.check.to_string(),
+                                    message: qr.message.clone(),
+                                };
+                                build_envelope(&qr.record, &err, sink_name, &pipeline_name, &row, i)
+                            })
+                            .collect();
+                        (outcome.survivors, envelopes)
+                    } else {
+                        (page.records, Vec::new())
+                    };
+                    #[cfg(not(feature = "quality"))]
+                    let (records, quality_envelopes): (Vec<Value>, Vec<Value>) =
+                        (page.records, Vec::new());
+
+                    let page = StreamPage {
+                        records,
+                        bookmark: page.bookmark,
+                    };
 
                     if let Some(ref dlq_cfg) = dlq {
                         // ── DLQ-enabled path ───────────────────────────────────
@@ -460,6 +527,8 @@ where
                                 )),
                             }
                         }
+                        // Quality-quarantined records share the DLQ budget/write.
+                        envelopes.splice(0..0, quality_envelopes);
                         let page_failures = envelopes.len();
 
                         // Budget checks — increment counter before returning.
@@ -551,6 +620,10 @@ where
                         }
                     } else {
                         // ── DLQ-disabled path (today's behaviour) ──────────────
+                        debug_assert!(
+                            quality_envelopes.is_empty(),
+                            "quality quarantine without DLQ should have been rejected at run start"
+                        );
                         if !page.records.is_empty() {
                             records_written += sink.write_batch(&page.records).await?;
                         }
@@ -1925,5 +1998,91 @@ mod tests {
             let dlq_records = dlq.0.lock().unwrap();
             assert_eq!(dlq_records.len(), 1);
         }
+    }
+
+    // ── Quality routing tests ──────────────────────────────────────────────
+
+    #[cfg(feature = "quality")]
+    #[tokio::test]
+    async fn quality_quarantines_to_dlq_and_writes_survivors() {
+        use crate::dlq::DlqConfig;
+        use crate::quality::{CompiledQuality, OnFailure, QualitySpec, RecordCheck};
+
+        let main = Arc::new(MockSink::new());
+        let dlq_sink = Arc::new(MockSink::new());
+        let spec = QualitySpec {
+            record: vec![RecordCheck::NotNull {
+                field: "id".into(),
+                treat_missing_as_null: true,
+                on_failure: OnFailure::Quarantine,
+            }],
+            batch: vec![],
+        };
+        let quality = Arc::new(CompiledQuality::compile(&spec).unwrap());
+        let pages: Vec<Result<StreamPage, FaucetError>> = vec![Ok(StreamPage {
+            records: vec![json!({"id": 1}), json!({"id": null}), json!({"id": 3})],
+            bookmark: None,
+        })];
+        let opts = RunStreamOptions::new()
+            .with_dlq(DlqConfig::new(dlq_sink.clone()))
+            .with_quality(quality);
+        let result = run_stream(futures::stream::iter(pages), main.as_ref(), opts)
+            .await
+            .unwrap();
+
+        assert_eq!(result.records_written, 2); // survivors
+        assert_eq!(main.written(), vec![json!({"id": 1}), json!({"id": 3})]);
+        // one quarantined record reached the DLQ with a QualityFailure envelope
+        let dlq = dlq_sink.written();
+        assert_eq!(dlq.len(), 1);
+        assert_eq!(dlq[0]["error"]["kind"], "QualityFailure");
+        assert_eq!(result.dlq.unwrap().records_dlq, 1);
+    }
+
+    #[cfg(feature = "quality")]
+    #[tokio::test]
+    async fn quality_abort_fails_run() {
+        use crate::quality::{BatchCheck, CompiledQuality, OnFailure, QualitySpec};
+        let main = MockSink::new();
+        let spec = QualitySpec {
+            record: vec![],
+            batch: vec![BatchCheck::RowCount {
+                min: Some(5),
+                max: None,
+                on_failure: OnFailure::Abort,
+            }],
+        };
+        let quality = Arc::new(CompiledQuality::compile(&spec).unwrap());
+        let pages: Vec<Result<StreamPage, FaucetError>> = vec![Ok(StreamPage {
+            records: vec![json!({"id": 1})],
+            bookmark: None,
+        })];
+        let opts = RunStreamOptions::new().with_quality(quality);
+        let result = run_stream(futures::stream::iter(pages), &main, opts).await;
+        assert!(matches!(result, Err(FaucetError::QualityFailure { .. })));
+    }
+
+    #[cfg(feature = "quality")]
+    #[tokio::test]
+    async fn quality_quarantine_without_dlq_is_rejected() {
+        use crate::quality::{CompiledQuality, OnFailure, QualitySpec, RecordCheck};
+        let main = MockSink::new();
+        let spec = QualitySpec {
+            record: vec![RecordCheck::NotNull {
+                field: "id".into(),
+                treat_missing_as_null: true,
+                on_failure: OnFailure::Quarantine,
+            }],
+            batch: vec![],
+        };
+        let quality = Arc::new(CompiledQuality::compile(&spec).unwrap());
+        let pages: Vec<Result<StreamPage, FaucetError>> = vec![Ok(StreamPage {
+            records: vec![json!({"id": null})],
+            bookmark: None,
+        })];
+        // No .with_dlq(...) — must be rejected up front.
+        let opts = RunStreamOptions::new().with_quality(quality);
+        let result = run_stream(futures::stream::iter(pages), &main, opts).await;
+        assert!(matches!(result, Err(FaucetError::Config(_))));
     }
 }

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -528,6 +528,13 @@ where
                             }
                         }
                         // Quality-quarantined records share the DLQ budget/write.
+                        // Capture the quality count BEFORE the splice — the splice
+                        // moves `quality_envelopes`, so its length is unavailable
+                        // afterward. Used below to pick the page `reason` label.
+                        #[cfg(feature = "quality")]
+                        let quality_count = quality_envelopes.len();
+                        #[cfg(not(feature = "quality"))]
+                        let quality_count = 0usize;
                         envelopes.splice(0..0, quality_envelopes);
                         let page_failures = envelopes.len();
 
@@ -576,10 +583,24 @@ where
                             dlq_stats.records_dlq += page_failures;
                             dlq_stats.pages_with_failures += 1;
 
+                            // Page `reason` label, 3-way:
+                            //  - `dlq_all`  — the whole page was synthesized from a
+                            //    single outer sink error (OnBatchError::DlqAll).
+                            //  - `partial`  — at least one row failed on the SINK
+                            //    side (`page_failures > quality_count`). A mixed
+                            //    page carrying both sink failures and quality
+                            //    quarantines is labeled `partial`: the sink failure
+                            //    dominates.
+                            //  - `quality`  — every envelope is quality-sourced
+                            //    (no sink-side failures on this page).
+                            // The per-row quality volume is separately exposed via
+                            // `faucet_quality_records_quarantined_total`.
                             let reason_label = if outer_err_recovered {
                                 DlqReason::DlqAll.as_str()
-                            } else {
+                            } else if page_failures > quality_count {
                                 DlqReason::Partial.as_str()
+                            } else {
+                                DlqReason::Quality.as_str()
                             };
                             counter!("faucet_sink_dlq_records_total", metric_labels.clone())
                                 .increment(page_failures as u64);
@@ -2037,6 +2058,63 @@ mod tests {
         assert_eq!(dlq.len(), 1);
         assert_eq!(dlq[0]["error"]["kind"], "QualityFailure");
         assert_eq!(result.dlq.unwrap().records_dlq, 1);
+    }
+
+    #[cfg(feature = "quality")]
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn quality_only_page_emits_quality_reason() {
+        // A page whose DLQ traffic is entirely quality-sourced (the main sink
+        // accepts every survivor) must label `faucet_sink_dlq_pages_total`
+        // with `reason="quality"`, not `partial`.
+        use crate::dlq::DlqConfig;
+        use crate::observability::decorator::source_tests::{LOCK, snapshotter};
+        use crate::quality::{CompiledQuality, OnFailure, QualitySpec, RecordCheck};
+        use metrics_util::debugging::DebugValue;
+
+        let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let snap = snapshotter();
+
+        // MockSink accepts everything → no sink-side failures, so the only DLQ
+        // traffic comes from the quality quarantine.
+        let main = Arc::new(MockSink::new());
+        let dlq_sink = Arc::new(MockSink::new());
+        let spec = QualitySpec {
+            record: vec![RecordCheck::NotNull {
+                field: "id".into(),
+                treat_missing_as_null: true,
+                on_failure: OnFailure::Quarantine,
+            }],
+            batch: vec![],
+        };
+        let quality = Arc::new(CompiledQuality::compile(&spec).unwrap());
+        let pages: Vec<Result<StreamPage, FaucetError>> = vec![Ok(StreamPage {
+            records: vec![json!({"id": 1}), json!({"id": null}), json!({"id": 3})],
+            bookmark: None,
+        })];
+        let opts = RunStreamOptions::new()
+            .with_name("p_quality_reason")
+            .with_dlq(DlqConfig::new(dlq_sink.clone()))
+            .with_quality(quality);
+        let _ = run_stream(futures::stream::iter(pages), main.as_ref(), opts)
+            .await
+            .unwrap();
+
+        let snapshot = snap.snapshot();
+        let saw_quality_reason = snapshot.into_vec().into_iter().any(|(k, _, _, v)| {
+            k.key().name() == "faucet_sink_dlq_pages_total"
+                && k.key()
+                    .labels()
+                    .any(|l| l.key() == "pipeline" && l.value() == "p_quality_reason")
+                && k.key()
+                    .labels()
+                    .any(|l| l.key() == "reason" && l.value() == "quality")
+                && matches!(v, DebugValue::Counter(c) if c >= 1)
+        });
+        assert!(
+            saw_quality_reason,
+            "expected faucet_sink_dlq_pages_total with reason=\"quality\""
+        );
     }
 
     #[cfg(feature = "quality")]

--- a/crates/core/src/quality/batch.rs
+++ b/crates/core/src/quality/batch.rs
@@ -1,1 +1,221 @@
-//! (placeholder — filled in a later task)
+//! Per-batch check evaluation over the survivor slice. Aggregate checks return
+//! a single pass/fail; `unique` returns the indices of the duplicate rows
+//! (row-attributable).
+
+use crate::quality::compile::{CompiledBatchCheck, CompiledBatchKind};
+use serde_json::Value;
+use std::collections::HashSet;
+
+/// Evaluate an aggregate per-batch check (`row_count` / `null_rate` /
+/// `distinct_count`) over the survivors. `Ok(())` = pass; `Err(message)` =
+/// fail. **Not** valid for `unique` (use [`evaluate_unique_check`]).
+pub fn evaluate_aggregate_check(c: &CompiledBatchCheck, survivors: &[Value]) -> Result<(), String> {
+    match &c.kind {
+        CompiledBatchKind::RowCount { min, max } => {
+            let n = survivors.len();
+            if let Some(lo) = min
+                && n < *lo
+            {
+                return Err(format!("row count {n} < min {lo}"));
+            }
+            if let Some(hi) = max
+                && n > *hi
+            {
+                return Err(format!("row count {n} > max {hi}"));
+            }
+            Ok(())
+        }
+        CompiledBatchKind::NullRate { path, max } => {
+            let n = survivors.len();
+            if n == 0 {
+                return Ok(()); // 0/0 -> 0.0
+            }
+            let nulls = survivors
+                .iter()
+                .filter(|r| matches!(path.resolve(r).ok().flatten(), None | Some(Value::Null)))
+                .count();
+            #[allow(clippy::cast_precision_loss)] // survivors.len() is far below 2^53 in any realistic batch
+            let rate = nulls as f64 / n as f64;
+            if rate <= *max {
+                Ok(())
+            } else {
+                Err(format!("null rate {rate:.4} > max {max}"))
+            }
+        }
+        CompiledBatchKind::DistinctCount { path, min, max } => {
+            let distinct: HashSet<String> = survivors
+                .iter()
+                .map(|r| value_key(path.resolve(r).ok().flatten()))
+                .collect();
+            let n = distinct.len();
+            if let Some(lo) = min
+                && n < *lo
+            {
+                return Err(format!("distinct count {n} < min {lo}"));
+            }
+            if let Some(hi) = max
+                && n > *hi
+            {
+                return Err(format!("distinct count {n} > max {hi}"));
+            }
+            Ok(())
+        }
+        CompiledBatchKind::Unique { .. } => {
+            // Caller bug: unique is row-attributable, not aggregate.
+            Err("internal: unique evaluated as aggregate".into())
+        }
+    }
+}
+
+/// Evaluate a `unique` check. Returns the indices of the **duplicate**
+/// occurrences (the first occurrence of each key is kept). Empty = no dupes.
+pub fn evaluate_unique_check(c: &CompiledBatchCheck, survivors: &[Value]) -> Vec<usize> {
+    let CompiledBatchKind::Unique { paths } = &c.kind else {
+        return Vec::new();
+    };
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut dups = Vec::new();
+    for (i, rec) in survivors.iter().enumerate() {
+        let mut joined = String::new();
+        for (j, p) in paths.iter().enumerate() {
+            if j > 0 {
+                joined.push('\u{1f}'); // unit separator, unambiguous composite key
+            }
+            joined.push_str(&value_key(p.resolve(rec).ok().flatten()));
+        }
+        if !seen.insert(joined) {
+            dups.push(i);
+        }
+    }
+    dups
+}
+
+/// Canonical string key for a JSON value used in distinct/unique sets. Missing
+/// is distinct from explicit null.
+fn value_key(v: Option<&Value>) -> String {
+    match v {
+        None => "\u{0}__missing__".into(),
+        Some(val) => val.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::quality::compile::CompiledQuality;
+    use crate::quality::config::{BatchCheck, OnFailure, QualitySpec};
+    use serde_json::json;
+
+    fn one_batch(check: BatchCheck) -> crate::quality::compile::CompiledBatchCheck {
+        let spec = QualitySpec {
+            record: vec![],
+            batch: vec![check],
+        };
+        CompiledQuality::compile(&spec).unwrap().batch.pop().unwrap()
+    }
+
+    #[test]
+    fn row_count() {
+        let c = one_batch(BatchCheck::RowCount {
+            min: Some(1),
+            max: Some(2),
+            on_failure: OnFailure::Abort,
+        });
+        assert!(evaluate_aggregate_check(&c, &[json!({}), json!({})]).is_ok());
+        assert!(evaluate_aggregate_check(&c, &[]).is_err());
+        assert!(evaluate_aggregate_check(&c, &[json!({}), json!({}), json!({})]).is_err());
+    }
+
+    #[test]
+    fn null_rate_zero_rows_passes() {
+        let c = one_batch(BatchCheck::NullRate {
+            field: "name".into(),
+            max: 0.5,
+            on_failure: OnFailure::Abort,
+        });
+        assert!(evaluate_aggregate_check(&c, &[]).is_ok()); // 0/0 -> 0.0
+        let rows = vec![json!({"name": "a"}), json!({"name": null}), json!({})];
+        // 2 null-or-missing of 3 = 0.67 > 0.5 -> fail
+        assert!(evaluate_aggregate_check(&c, &rows).is_err());
+        let rows_ok = vec![json!({"name": "a"}), json!({"name": "b"}), json!({"name": null})];
+        // 1/3 = 0.33 <= 0.5 -> pass
+        assert!(evaluate_aggregate_check(&c, &rows_ok).is_ok());
+    }
+
+    #[test]
+    fn distinct_count() {
+        let c = one_batch(BatchCheck::DistinctCount {
+            field: "tenant".into(),
+            min: Some(2),
+            max: Some(3),
+            on_failure: OnFailure::Abort,
+        });
+        let rows = vec![json!({"tenant": "a"}), json!({"tenant": "b"})];
+        assert!(evaluate_aggregate_check(&c, &rows).is_ok());
+        let rows_one = vec![json!({"tenant": "a"}), json!({"tenant": "a"})];
+        assert!(evaluate_aggregate_check(&c, &rows_one).is_err()); // 1 < min 2
+    }
+
+    #[test]
+    fn unique_returns_duplicate_indices_keeping_first() {
+        let c = one_batch(BatchCheck::Unique {
+            fields: vec!["id".into()],
+            on_failure: OnFailure::Quarantine,
+        });
+        let rows = vec![
+            json!({"id": 1}),
+            json!({"id": 2}),
+            json!({"id": 1}), // dup of index 0
+            json!({"id": 2}), // dup of index 1
+        ];
+        let dups = evaluate_unique_check(&c, &rows);
+        assert_eq!(dups, vec![2, 3]);
+    }
+
+    #[test]
+    fn unique_composite_key() {
+        let c = one_batch(BatchCheck::Unique {
+            fields: vec!["a".into(), "b".into()],
+            on_failure: OnFailure::Quarantine,
+        });
+        let rows = vec![
+            json!({"a": 1, "b": 1}),
+            json!({"a": 1, "b": 2}),
+            json!({"a": 1, "b": 1}), // dup
+        ];
+        assert_eq!(evaluate_unique_check(&c, &rows), vec![2]);
+    }
+
+    #[test]
+    fn aggregate_check_on_unique_kind_returns_err_not_panic() {
+        let c = one_batch(BatchCheck::Unique {
+            fields: vec!["id".into()],
+            on_failure: OnFailure::Quarantine,
+        });
+        // evaluate_aggregate_check is not valid for the Unique kind: defensive Err, no panic.
+        assert!(evaluate_aggregate_check(&c, &[json!({"id": 1})]).is_err());
+    }
+
+    #[test]
+    fn unique_check_on_non_unique_kind_returns_empty() {
+        let c = one_batch(BatchCheck::RowCount {
+            min: Some(1),
+            max: None,
+            on_failure: OnFailure::Abort,
+        });
+        assert!(evaluate_unique_check(&c, &[json!({"id": 1})]).is_empty());
+    }
+
+    #[test]
+    fn distinct_count_treats_missing_as_one_bucket() {
+        let c = one_batch(BatchCheck::DistinctCount {
+            field: "tenant".into(),
+            min: Some(2),
+            max: None,
+            on_failure: OnFailure::Abort,
+        });
+        // Two rows both missing 'tenant' => 1 distinct ("missing") bucket => fails min=2.
+        let rows = vec![json!({}), json!({})];
+        assert!(evaluate_aggregate_check(&c, &rows).is_err());
+    }
+}

--- a/crates/core/src/quality/batch.rs
+++ b/crates/core/src/quality/batch.rs
@@ -34,7 +34,8 @@ pub fn evaluate_aggregate_check(c: &CompiledBatchCheck, survivors: &[Value]) -> 
                 .iter()
                 .filter(|r| matches!(path.resolve(r).ok().flatten(), None | Some(Value::Null)))
                 .count();
-            #[allow(clippy::cast_precision_loss)] // survivors.len() is far below 2^53 in any realistic batch
+            #[allow(clippy::cast_precision_loss)]
+            // survivors.len() is far below 2^53 in any realistic batch
             let rate = nulls as f64 / n as f64;
             if rate <= *max {
                 Ok(())
@@ -111,7 +112,11 @@ mod tests {
             record: vec![],
             batch: vec![check],
         };
-        CompiledQuality::compile(&spec).unwrap().batch.pop().unwrap()
+        CompiledQuality::compile(&spec)
+            .unwrap()
+            .batch
+            .pop()
+            .unwrap()
     }
 
     #[test]
@@ -137,7 +142,11 @@ mod tests {
         let rows = vec![json!({"name": "a"}), json!({"name": null}), json!({})];
         // 2 null-or-missing of 3 = 0.67 > 0.5 -> fail
         assert!(evaluate_aggregate_check(&c, &rows).is_err());
-        let rows_ok = vec![json!({"name": "a"}), json!({"name": "b"}), json!({"name": null})];
+        let rows_ok = vec![
+            json!({"name": "a"}),
+            json!({"name": "b"}),
+            json!({"name": null}),
+        ];
         // 1/3 = 0.33 <= 0.5 -> pass
         assert!(evaluate_aggregate_check(&c, &rows_ok).is_ok());
     }

--- a/crates/core/src/quality/batch.rs
+++ b/crates/core/src/quality/batch.rs
@@ -1,0 +1,1 @@
+//! (placeholder — filled in a later task)

--- a/crates/core/src/quality/compile.rs
+++ b/crates/core/src/quality/compile.rs
@@ -1,1 +1,571 @@
-//! (placeholder — filled in a later task)
+//! Compile a `QualitySpec` into a `CompiledQuality`: parse paths/regexes/
+//! schemas once, validate the `on_failure` subset and numeric bounds. Failures
+//! surface as `FaucetError::Config`.
+
+use crate::error::FaucetError;
+use crate::quality::config::{
+    BatchCheck, CompareOp, JsonType, OnFailure, QualitySpec, RecordCheck,
+};
+use crate::stage::CompiledPath;
+use serde_json::Value;
+
+/// A fully compiled quality spec. Built once via [`CompiledQuality::compile`].
+#[derive(Debug)]
+pub struct CompiledQuality {
+    pub record: Vec<CompiledRecordCheck>,
+    pub batch: Vec<CompiledBatchCheck>,
+}
+
+/// One compiled per-record check: the check kind plus its failure policy and
+/// labelling metadata.
+#[derive(Debug)]
+pub struct CompiledRecordCheck {
+    pub kind: CompiledRecordKind,
+    pub on_failure: OnFailure,
+    /// Stable metric-label name, e.g. `"not_null"`.
+    pub name: &'static str,
+    /// Addressed field (for envelope/metric `field` label); `None` for whole-
+    /// record checks like `json_schema`.
+    pub field: Option<String>,
+}
+
+/// Compiled form of a per-record check, keyed by check kind.
+#[derive(Debug)]
+pub enum CompiledRecordKind {
+    NotNull {
+        path: CompiledPath,
+        treat_missing_as_null: bool,
+    },
+    NotEmpty {
+        path: CompiledPath,
+    },
+    RegexMatch {
+        path: CompiledPath,
+        re: regex::Regex,
+    },
+    ValueInSet {
+        path: CompiledPath,
+        values: Vec<Value>,
+    },
+    NotInSet {
+        path: CompiledPath,
+        values: Vec<Value>,
+    },
+    Compare {
+        path: CompiledPath,
+        op: CompareOp,
+        value: Value,
+    },
+    TypeIs {
+        path: CompiledPath,
+        expected: JsonType,
+    },
+    StringLength {
+        path: CompiledPath,
+        min: Option<usize>,
+        max: Option<usize>,
+    },
+    #[cfg(feature = "quality-jsonschema")]
+    JsonSchema {
+        validator: jsonschema::Validator,
+    },
+}
+
+/// One compiled per-batch check.
+#[derive(Debug)]
+pub struct CompiledBatchCheck {
+    pub kind: CompiledBatchKind,
+    pub on_failure: OnFailure,
+    pub name: &'static str,
+    pub field: Option<String>,
+}
+
+/// Compiled form of a per-batch check, keyed by check kind.
+#[derive(Debug)]
+pub enum CompiledBatchKind {
+    RowCount {
+        min: Option<usize>,
+        max: Option<usize>,
+    },
+    NullRate {
+        path: CompiledPath,
+        max: f64,
+    },
+    Unique {
+        paths: Vec<CompiledPath>,
+    },
+    DistinctCount {
+        path: CompiledPath,
+        min: Option<usize>,
+        max: Option<usize>,
+    },
+}
+
+fn config_err(msg: impl Into<String>) -> FaucetError {
+    FaucetError::Config(format!("quality: {}", msg.into()))
+}
+
+fn compile_path(field: &str) -> Result<CompiledPath, FaucetError> {
+    CompiledPath::compile(field).map_err(|e| config_err(format!("invalid field '{field}': {e}")))
+}
+
+/// Per-record checks accept only `quarantine` / `abort`.
+fn check_record_policy(name: &str, on_failure: OnFailure) -> Result<(), FaucetError> {
+    match on_failure {
+        OnFailure::Quarantine | OnFailure::Abort => Ok(()),
+        OnFailure::QuarantineBatch => Err(config_err(format!(
+            "check '{name}': on_failure 'quarantine_batch' is only valid on aggregate batch checks"
+        ))),
+    }
+}
+
+impl CompiledQuality {
+    /// Compile and validate a [`QualitySpec`]. Returns [`FaucetError::Config`]
+    /// on any invalid path, regex, schema, bound, or `on_failure` choice.
+    pub fn compile(spec: &QualitySpec) -> Result<Self, FaucetError> {
+        let record = spec
+            .record
+            .iter()
+            .map(compile_record_check)
+            .collect::<Result<_, _>>()?;
+        let batch = spec
+            .batch
+            .iter()
+            .map(compile_batch_check)
+            .collect::<Result<_, _>>()?;
+        Ok(Self { record, batch })
+    }
+
+    /// True if any check would route records to the DLQ (so a DLQ sink is
+    /// required). Checked by the pipeline at run start.
+    pub fn requires_dlq(&self) -> bool {
+        self.record
+            .iter()
+            .any(|c| matches!(c.on_failure, OnFailure::Quarantine))
+            || self.batch.iter().any(|c| {
+                matches!(c.on_failure, OnFailure::Quarantine | OnFailure::QuarantineBatch)
+            })
+    }
+}
+
+fn compile_record_check(c: &RecordCheck) -> Result<CompiledRecordCheck, FaucetError> {
+    Ok(match c {
+        RecordCheck::NotNull {
+            field,
+            treat_missing_as_null,
+            on_failure,
+        } => {
+            check_record_policy("not_null", *on_failure)?;
+            CompiledRecordCheck {
+                kind: CompiledRecordKind::NotNull {
+                    path: compile_path(field)?,
+                    treat_missing_as_null: *treat_missing_as_null,
+                },
+                on_failure: *on_failure,
+                name: "not_null",
+                field: Some(field.clone()),
+            }
+        }
+        RecordCheck::NotEmpty { field, on_failure } => {
+            check_record_policy("not_empty", *on_failure)?;
+            CompiledRecordCheck {
+                kind: CompiledRecordKind::NotEmpty {
+                    path: compile_path(field)?,
+                },
+                on_failure: *on_failure,
+                name: "not_empty",
+                field: Some(field.clone()),
+            }
+        }
+        RecordCheck::RegexMatch {
+            field,
+            pattern,
+            on_failure,
+        } => {
+            check_record_policy("regex_match", *on_failure)?;
+            let re = regex::Regex::new(pattern)
+                .map_err(|e| config_err(format!("regex_match: invalid pattern '{pattern}': {e}")))?;
+            CompiledRecordCheck {
+                kind: CompiledRecordKind::RegexMatch {
+                    path: compile_path(field)?,
+                    re,
+                },
+                on_failure: *on_failure,
+                name: "regex_match",
+                field: Some(field.clone()),
+            }
+        }
+        RecordCheck::ValueInSet {
+            field,
+            values,
+            on_failure,
+        } => {
+            check_record_policy("value_in_set", *on_failure)?;
+            if values.is_empty() {
+                return Err(config_err("value_in_set: `values` must be non-empty"));
+            }
+            CompiledRecordCheck {
+                kind: CompiledRecordKind::ValueInSet {
+                    path: compile_path(field)?,
+                    values: values.clone(),
+                },
+                on_failure: *on_failure,
+                name: "value_in_set",
+                field: Some(field.clone()),
+            }
+        }
+        RecordCheck::NotInSet {
+            field,
+            values,
+            on_failure,
+        } => {
+            check_record_policy("not_in_set", *on_failure)?;
+            if values.is_empty() {
+                return Err(config_err("not_in_set: `values` must be non-empty"));
+            }
+            CompiledRecordCheck {
+                kind: CompiledRecordKind::NotInSet {
+                    path: compile_path(field)?,
+                    values: values.clone(),
+                },
+                on_failure: *on_failure,
+                name: "not_in_set",
+                field: Some(field.clone()),
+            }
+        }
+        RecordCheck::Compare {
+            field,
+            op,
+            value,
+            on_failure,
+        } => {
+            check_record_policy("compare", *on_failure)?;
+            // Ordering ops require a numeric configured value.
+            if matches!(op, CompareOp::Gt | CompareOp::Gte | CompareOp::Lt | CompareOp::Lte)
+                && !value.is_number()
+            {
+                return Err(config_err(format!(
+                    "compare: op '{op}' requires a numeric `value`"
+                )));
+            }
+            CompiledRecordCheck {
+                kind: CompiledRecordKind::Compare {
+                    path: compile_path(field)?,
+                    op: *op,
+                    value: value.clone(),
+                },
+                on_failure: *on_failure,
+                name: "compare",
+                field: Some(field.clone()),
+            }
+        }
+        RecordCheck::TypeIs {
+            field,
+            expected,
+            on_failure,
+        } => {
+            check_record_policy("type_is", *on_failure)?;
+            CompiledRecordCheck {
+                kind: CompiledRecordKind::TypeIs {
+                    path: compile_path(field)?,
+                    expected: *expected,
+                },
+                on_failure: *on_failure,
+                name: "type_is",
+                field: Some(field.clone()),
+            }
+        }
+        RecordCheck::StringLength {
+            field,
+            min,
+            max,
+            on_failure,
+        } => {
+            check_record_policy("string_length", *on_failure)?;
+            if min.is_none() && max.is_none() {
+                return Err(config_err("string_length: at least one of `min`/`max` is required"));
+            }
+            if let (Some(lo), Some(hi)) = (min, max)
+                && lo > hi
+            {
+                return Err(config_err("string_length: `min` must be <= `max`"));
+            }
+            CompiledRecordCheck {
+                kind: CompiledRecordKind::StringLength {
+                    path: compile_path(field)?,
+                    min: *min,
+                    max: *max,
+                },
+                on_failure: *on_failure,
+                name: "string_length",
+                field: Some(field.clone()),
+            }
+        }
+        #[cfg(feature = "quality-jsonschema")]
+        RecordCheck::JsonSchema { schema, on_failure } => {
+            check_record_policy("json_schema", *on_failure)?;
+            let validator = jsonschema::validator_for(schema)
+                .map_err(|e| config_err(format!("json_schema: invalid schema: {e}")))?;
+            CompiledRecordCheck {
+                kind: CompiledRecordKind::JsonSchema { validator },
+                on_failure: *on_failure,
+                name: "json_schema",
+                field: None,
+            }
+        }
+    })
+}
+
+fn compile_batch_check(c: &BatchCheck) -> Result<CompiledBatchCheck, FaucetError> {
+    // Aggregate batch checks accept only `abort` / `quarantine_batch`.
+    fn check_aggregate_policy(name: &str, on_failure: OnFailure) -> Result<(), FaucetError> {
+        match on_failure {
+            OnFailure::Abort | OnFailure::QuarantineBatch => Ok(()),
+            OnFailure::Quarantine => Err(config_err(format!(
+                "check '{name}': on_failure 'quarantine' is not row-attributable here; \
+                 use 'quarantine_batch' or 'abort'"
+            ))),
+        }
+    }
+
+    Ok(match c {
+        BatchCheck::RowCount {
+            min,
+            max,
+            on_failure,
+        } => {
+            check_aggregate_policy("row_count", *on_failure)?;
+            if min.is_none() && max.is_none() {
+                return Err(config_err("row_count: at least one of `min`/`max` is required"));
+            }
+            if let (Some(lo), Some(hi)) = (min, max)
+                && lo > hi
+            {
+                return Err(config_err("row_count: `min` must be <= `max`"));
+            }
+            CompiledBatchCheck {
+                kind: CompiledBatchKind::RowCount {
+                    min: *min,
+                    max: *max,
+                },
+                on_failure: *on_failure,
+                name: "row_count",
+                field: None,
+            }
+        }
+        BatchCheck::NullRate {
+            field,
+            max,
+            on_failure,
+        } => {
+            check_aggregate_policy("null_rate", *on_failure)?;
+            if !(0.0..=1.0).contains(max) {
+                return Err(config_err("null_rate: `max` must be within [0.0, 1.0]"));
+            }
+            CompiledBatchCheck {
+                kind: CompiledBatchKind::NullRate {
+                    path: compile_path(field)?,
+                    max: *max,
+                },
+                on_failure: *on_failure,
+                name: "null_rate",
+                field: Some(field.clone()),
+            }
+        }
+        BatchCheck::Unique { fields, on_failure } => {
+            // Unique IS row-attributable: accept quarantine / abort.
+            check_record_policy("unique", *on_failure)?;
+            if fields.is_empty() {
+                return Err(config_err("unique: `fields` must be non-empty"));
+            }
+            let paths = fields
+                .iter()
+                .map(|f| compile_path(f))
+                .collect::<Result<_, _>>()?;
+            CompiledBatchCheck {
+                kind: CompiledBatchKind::Unique { paths },
+                on_failure: *on_failure,
+                name: "unique",
+                field: Some(fields.join(",")),
+            }
+        }
+        BatchCheck::DistinctCount {
+            field,
+            min,
+            max,
+            on_failure,
+        } => {
+            check_aggregate_policy("distinct_count", *on_failure)?;
+            if min.is_none() && max.is_none() {
+                return Err(config_err("distinct_count: at least one of `min`/`max` is required"));
+            }
+            if let (Some(lo), Some(hi)) = (min, max)
+                && lo > hi
+            {
+                return Err(config_err("distinct_count: `min` must be <= `max`"));
+            }
+            CompiledBatchCheck {
+                kind: CompiledBatchKind::DistinctCount {
+                    path: compile_path(field)?,
+                    min: *min,
+                    max: *max,
+                },
+                on_failure: *on_failure,
+                name: "distinct_count",
+                field: Some(field.clone()),
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::quality::config::{BatchCheck, CompareOp, OnFailure, QualitySpec, RecordCheck};
+    use serde_json::json;
+
+    fn compile(spec: QualitySpec) -> Result<CompiledQuality, crate::FaucetError> {
+        CompiledQuality::compile(&spec)
+    }
+
+    #[test]
+    fn compiles_valid_spec() {
+        let spec = QualitySpec {
+            record: vec![RecordCheck::NotNull {
+                field: "user_id".into(),
+                treat_missing_as_null: true,
+                on_failure: OnFailure::Quarantine,
+            }],
+            batch: vec![BatchCheck::RowCount {
+                min: Some(1),
+                max: Some(10),
+                on_failure: OnFailure::Abort,
+            }],
+        };
+        let c = compile(spec).unwrap();
+        assert_eq!(c.record.len(), 1);
+        assert_eq!(c.batch.len(), 1);
+        assert!(c.requires_dlq());
+    }
+
+    #[test]
+    fn rejects_bad_regex_at_compile() {
+        let spec = QualitySpec {
+            record: vec![RecordCheck::RegexMatch {
+                field: "email".into(),
+                pattern: "[invalid".into(),
+                on_failure: OnFailure::Quarantine,
+            }],
+            batch: vec![],
+        };
+        assert!(matches!(compile(spec), Err(crate::FaucetError::Config(_))));
+    }
+
+    #[test]
+    fn rejects_disallowed_on_failure_for_record_check() {
+        // quarantine_batch is not valid on a per-record check.
+        let spec = QualitySpec {
+            record: vec![RecordCheck::NotEmpty {
+                field: "name".into(),
+                on_failure: OnFailure::QuarantineBatch,
+            }],
+            batch: vec![],
+        };
+        assert!(matches!(compile(spec), Err(crate::FaucetError::Config(_))));
+    }
+
+    #[test]
+    fn rejects_disallowed_on_failure_for_aggregate_batch_check() {
+        // quarantine (row-attributable) is not valid on row_count.
+        let spec = QualitySpec {
+            record: vec![],
+            batch: vec![BatchCheck::RowCount {
+                min: Some(1),
+                max: None,
+                on_failure: OnFailure::Quarantine,
+            }],
+        };
+        assert!(matches!(compile(spec), Err(crate::FaucetError::Config(_))));
+    }
+
+    #[test]
+    fn rejects_empty_bounds() {
+        let spec = QualitySpec {
+            record: vec![RecordCheck::StringLength {
+                field: "name".into(),
+                min: None,
+                max: None,
+                on_failure: OnFailure::Quarantine,
+            }],
+            batch: vec![],
+        };
+        assert!(matches!(compile(spec), Err(crate::FaucetError::Config(_))));
+    }
+
+    #[test]
+    fn rejects_non_numeric_compare_value_for_ordering_op() {
+        let spec = QualitySpec {
+            record: vec![RecordCheck::Compare {
+                field: "age".into(),
+                op: CompareOp::Gte,
+                value: json!("not a number"),
+                on_failure: OnFailure::Abort,
+            }],
+            batch: vec![],
+        };
+        assert!(matches!(compile(spec), Err(crate::FaucetError::Config(_))));
+    }
+
+    #[test]
+    fn rejects_null_rate_out_of_range() {
+        let spec = QualitySpec {
+            record: vec![],
+            batch: vec![BatchCheck::NullRate {
+                field: "name".into(),
+                max: 1.5,
+                on_failure: OnFailure::Abort,
+            }],
+        };
+        assert!(matches!(compile(spec), Err(crate::FaucetError::Config(_))));
+    }
+
+    #[test]
+    fn requires_dlq_false_when_only_abort() {
+        let spec = QualitySpec {
+            record: vec![RecordCheck::NotNull {
+                field: "id".into(),
+                treat_missing_as_null: true,
+                on_failure: OnFailure::Abort,
+            }],
+            batch: vec![],
+        };
+        assert!(!compile(spec).unwrap().requires_dlq());
+    }
+
+    #[test]
+    fn rejects_row_count_min_gt_max() {
+        let spec = QualitySpec {
+            record: vec![],
+            batch: vec![BatchCheck::RowCount {
+                min: Some(100),
+                max: Some(1),
+                on_failure: OnFailure::Abort,
+            }],
+        };
+        assert!(matches!(compile(spec), Err(crate::FaucetError::Config(_))));
+    }
+
+    #[test]
+    fn rejects_distinct_count_min_gt_max() {
+        let spec = QualitySpec {
+            record: vec![],
+            batch: vec![BatchCheck::DistinctCount {
+                field: "x".into(),
+                min: Some(5),
+                max: Some(2),
+                on_failure: OnFailure::Abort,
+            }],
+        };
+        assert!(matches!(compile(spec), Err(crate::FaucetError::Config(_))));
+    }
+}

--- a/crates/core/src/quality/compile.rs
+++ b/crates/core/src/quality/compile.rs
@@ -143,7 +143,10 @@ impl CompiledQuality {
             .iter()
             .any(|c| matches!(c.on_failure, OnFailure::Quarantine))
             || self.batch.iter().any(|c| {
-                matches!(c.on_failure, OnFailure::Quarantine | OnFailure::QuarantineBatch)
+                matches!(
+                    c.on_failure,
+                    OnFailure::Quarantine | OnFailure::QuarantineBatch
+                )
             })
     }
 }
@@ -183,8 +186,9 @@ fn compile_record_check(c: &RecordCheck) -> Result<CompiledRecordCheck, FaucetEr
             on_failure,
         } => {
             check_record_policy("regex_match", *on_failure)?;
-            let re = regex::Regex::new(pattern)
-                .map_err(|e| config_err(format!("regex_match: invalid pattern '{pattern}': {e}")))?;
+            let re = regex::Regex::new(pattern).map_err(|e| {
+                config_err(format!("regex_match: invalid pattern '{pattern}': {e}"))
+            })?;
             CompiledRecordCheck {
                 kind: CompiledRecordKind::RegexMatch {
                     path: compile_path(field)?,
@@ -241,8 +245,10 @@ fn compile_record_check(c: &RecordCheck) -> Result<CompiledRecordCheck, FaucetEr
         } => {
             check_record_policy("compare", *on_failure)?;
             // Ordering ops require a numeric configured value.
-            if matches!(op, CompareOp::Gt | CompareOp::Gte | CompareOp::Lt | CompareOp::Lte)
-                && !value.is_number()
+            if matches!(
+                op,
+                CompareOp::Gt | CompareOp::Gte | CompareOp::Lt | CompareOp::Lte
+            ) && !value.is_number()
             {
                 return Err(config_err(format!(
                     "compare: op '{op}' requires a numeric `value`"
@@ -283,7 +289,9 @@ fn compile_record_check(c: &RecordCheck) -> Result<CompiledRecordCheck, FaucetEr
         } => {
             check_record_policy("string_length", *on_failure)?;
             if min.is_none() && max.is_none() {
-                return Err(config_err("string_length: at least one of `min`/`max` is required"));
+                return Err(config_err(
+                    "string_length: at least one of `min`/`max` is required",
+                ));
             }
             if let (Some(lo), Some(hi)) = (min, max)
                 && lo > hi
@@ -336,7 +344,9 @@ fn compile_batch_check(c: &BatchCheck) -> Result<CompiledBatchCheck, FaucetError
         } => {
             check_aggregate_policy("row_count", *on_failure)?;
             if min.is_none() && max.is_none() {
-                return Err(config_err("row_count: at least one of `min`/`max` is required"));
+                return Err(config_err(
+                    "row_count: at least one of `min`/`max` is required",
+                ));
             }
             if let (Some(lo), Some(hi)) = (min, max)
                 && lo > hi
@@ -397,7 +407,9 @@ fn compile_batch_check(c: &BatchCheck) -> Result<CompiledBatchCheck, FaucetError
         } => {
             check_aggregate_policy("distinct_count", *on_failure)?;
             if min.is_none() && max.is_none() {
-                return Err(config_err("distinct_count: at least one of `min`/`max` is required"));
+                return Err(config_err(
+                    "distinct_count: at least one of `min`/`max` is required",
+                ));
             }
             if let (Some(lo), Some(hi)) = (min, max)
                 && lo > hi

--- a/crates/core/src/quality/compile.rs
+++ b/crates/core/src/quality/compile.rs
@@ -1,0 +1,1 @@
+//! (placeholder — filled in a later task)

--- a/crates/core/src/quality/config.rs
+++ b/crates/core/src/quality/config.rs
@@ -4,6 +4,7 @@
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 /// What to do when a check fails. The allowed subset is validated per check
 /// at compile time (see `compile.rs`).
@@ -22,11 +23,17 @@ pub enum OnFailure {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum CompareOp {
+    /// Greater than: `field > value`. Both must be JSON numbers.
     Gt,
+    /// Greater than or equal: `field >= value`. Both must be JSON numbers.
     Gte,
+    /// Less than: `field < value`. Both must be JSON numbers.
     Lt,
+    /// Less than or equal: `field <= value`. Both must be JSON numbers.
     Lte,
+    /// Exact JSON equality (no type coercion: string `"5"` != number `5`).
     Eq,
+    /// Exact JSON inequality (no type coercion).
     Ne,
 }
 
@@ -34,12 +41,132 @@ pub enum CompareOp {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum JsonType {
+    /// JSON boolean (`true` / `false`).
     Boolean,
+    /// JSON number (integer or float).
     Number,
+    /// JSON string.
     String,
+    /// JSON array.
     Array,
+    /// JSON object.
     Object,
+    /// JSON null. Note: a *missing* field is distinct from an explicit `null`.
     Null,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+/// The `quality:` config block. Per-record checks run first (partitioning the
+/// page into survivors + quarantined); per-batch checks then run over the
+/// survivors.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+pub struct QualitySpec {
+    /// Per-record checks, evaluated in declared order (first failure wins).
+    #[serde(default)]
+    pub record: Vec<RecordCheck>,
+    /// Per-batch checks, evaluated per page over the survivors.
+    #[serde(default)]
+    pub batch: Vec<BatchCheck>,
+}
+
+/// A per-record check. Addressed field accepts the filter/explode path subset
+/// (bare key, `dot.path`, `$['bracketed']`).
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum RecordCheck {
+    /// Field present and non-null.
+    NotNull {
+        field: String,
+        /// When `true` (default) a missing field fails; when `false` only an
+        /// explicit JSON `null` fails.
+        #[serde(default = "default_true")]
+        treat_missing_as_null: bool,
+        on_failure: OnFailure,
+    },
+    /// Field is a string, non-empty after `trim()`.
+    NotEmpty { field: String, on_failure: OnFailure },
+    /// Field is a string matching `pattern`.
+    RegexMatch {
+        field: String,
+        pattern: String,
+        on_failure: OnFailure,
+    },
+    /// Field value is a member of `values` (exact JSON equality).
+    ValueInSet {
+        field: String,
+        values: Vec<Value>,
+        on_failure: OnFailure,
+    },
+    /// Field value is NOT a member of `values` (exact JSON equality).
+    NotInSet {
+        field: String,
+        values: Vec<Value>,
+        on_failure: OnFailure,
+    },
+    /// Field value compares against `value` under `op`.
+    Compare {
+        field: String,
+        op: CompareOp,
+        value: Value,
+        on_failure: OnFailure,
+    },
+    /// Field's JSON type equals `expected`.
+    TypeIs {
+        field: String,
+        expected: JsonType,
+        on_failure: OnFailure,
+    },
+    /// Field is a string whose char count is within `[min, max]`.
+    StringLength {
+        field: String,
+        #[serde(default)]
+        min: Option<usize>,
+        #[serde(default)]
+        max: Option<usize>,
+        on_failure: OnFailure,
+    },
+    /// The whole record validates against a JSON Schema document.
+    #[cfg(feature = "quality-jsonschema")]
+    JsonSchema { schema: Value, on_failure: OnFailure },
+}
+
+/// A per-batch check, evaluated per page over the survivors of the per-record
+/// pass.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum BatchCheck {
+    /// Survivor count is within `[min, max]` (at least one bound required).
+    RowCount {
+        #[serde(default)]
+        min: Option<usize>,
+        #[serde(default)]
+        max: Option<usize>,
+        on_failure: OnFailure,
+    },
+    /// Null-or-missing rate of `field` across survivors is `<= max`.
+    NullRate {
+        field: String,
+        /// Maximum allowed null-or-missing proportion, in `[0.0, 1.0]`. Out-of-range values are rejected at compile time.
+        max: f64,
+        on_failure: OnFailure,
+    },
+    /// The composite `fields` tuple is unique across survivors.
+    Unique {
+        fields: Vec<String>,
+        on_failure: OnFailure,
+    },
+    /// Distinct values of `field` across survivors is within `[min, max]`.
+    DistinctCount {
+        field: String,
+        #[serde(default)]
+        min: Option<usize>,
+        #[serde(default)]
+        max: Option<usize>,
+        on_failure: OnFailure,
+    },
 }
 
 #[cfg(test)]
@@ -64,5 +191,37 @@ mod tests {
     fn json_type_round_trips() {
         let t: JsonType = serde_json::from_str("\"boolean\"").unwrap();
         assert_eq!(t, JsonType::Boolean);
+    }
+
+    #[test]
+    fn parses_full_quality_block() {
+        let spec: QualitySpec = serde_json::from_value(serde_json::json!({
+            "record": [
+                { "type": "not_null", "field": "user_id", "on_failure": "quarantine" },
+                { "type": "compare", "field": "age", "op": "gte", "value": 0, "on_failure": "abort" },
+                { "type": "string_length", "field": "name", "min": 1, "max": 256, "on_failure": "quarantine" }
+            ],
+            "batch": [
+                { "type": "row_count", "min": 1, "max": 100000, "on_failure": "abort" },
+                { "type": "unique", "fields": ["id"], "on_failure": "quarantine" }
+            ]
+        }))
+        .unwrap();
+        assert_eq!(spec.record.len(), 3);
+        assert_eq!(spec.batch.len(), 2);
+        assert!(matches!(spec.record[0], RecordCheck::NotNull { .. }));
+        assert!(matches!(spec.batch[1], BatchCheck::Unique { .. }));
+        if let RecordCheck::NotNull { treat_missing_as_null, .. } = &spec.record[0] {
+            assert!(*treat_missing_as_null, "treat_missing_as_null defaults to true");
+        } else {
+            panic!("expected first record check to be NotNull");
+        }
+    }
+
+    #[test]
+    fn empty_quality_block_defaults_to_no_checks() {
+        let spec: QualitySpec = serde_json::from_str("{}").unwrap();
+        assert!(spec.record.is_empty());
+        assert!(spec.batch.is_empty());
     }
 }

--- a/crates/core/src/quality/config.rs
+++ b/crates/core/src/quality/config.rs
@@ -1,0 +1,68 @@
+//! Config-shaped types for the data-quality layer. Pure declarations — no
+//! evaluation logic (that lives in `record.rs` / `batch.rs`) and no
+//! compilation (that lives in `compile.rs`).
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// What to do when a check fails. The allowed subset is validated per check
+/// at compile time (see `compile.rs`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum OnFailure {
+    /// Route the specific offending row(s) to the DLQ; keep the rest.
+    Quarantine,
+    /// Route all survivors of the page to the DLQ; write nothing this page.
+    QuarantineBatch,
+    /// Surface `FaucetError::QualityFailure` and fail the run.
+    Abort,
+}
+
+/// Ordering / equality operator for the `compare` check.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum CompareOp {
+    Gt,
+    Gte,
+    Lt,
+    Lte,
+    Eq,
+    Ne,
+}
+
+/// Expected JSON type for the `type_is` check.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum JsonType {
+    Boolean,
+    Number,
+    String,
+    Array,
+    Object,
+    Null,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn on_failure_serializes_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&OnFailure::QuarantineBatch).unwrap(),
+            "\"quarantine_batch\""
+        );
+    }
+
+    #[test]
+    fn compare_op_round_trips() {
+        let op: CompareOp = serde_json::from_str("\"gte\"").unwrap();
+        assert_eq!(op, CompareOp::Gte);
+    }
+
+    #[test]
+    fn json_type_round_trips() {
+        let t: JsonType = serde_json::from_str("\"boolean\"").unwrap();
+        assert_eq!(t, JsonType::Boolean);
+    }
+}

--- a/crates/core/src/quality/config.rs
+++ b/crates/core/src/quality/config.rs
@@ -37,6 +37,19 @@ pub enum CompareOp {
     Ne,
 }
 
+impl std::fmt::Display for CompareOp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            CompareOp::Gt => "gt",
+            CompareOp::Gte => "gte",
+            CompareOp::Lt => "lt",
+            CompareOp::Lte => "lte",
+            CompareOp::Eq => "eq",
+            CompareOp::Ne => "ne",
+        })
+    }
+}
+
 /// Expected JSON type for the `type_is` check.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]

--- a/crates/core/src/quality/config.rs
+++ b/crates/core/src/quality/config.rs
@@ -113,7 +113,10 @@ pub enum RecordCheck {
         on_failure: OnFailure,
     },
     /// Field is a string, non-empty after `trim()`.
-    NotEmpty { field: String, on_failure: OnFailure },
+    NotEmpty {
+        field: String,
+        on_failure: OnFailure,
+    },
     /// Field is a string matching `pattern`.
     RegexMatch {
         field: String,
@@ -156,7 +159,10 @@ pub enum RecordCheck {
     },
     /// The whole record validates against a JSON Schema document.
     #[cfg(feature = "quality-jsonschema")]
-    JsonSchema { schema: Value, on_failure: OnFailure },
+    JsonSchema {
+        schema: Value,
+        on_failure: OnFailure,
+    },
 }
 
 /// A per-batch check, evaluated per page over the survivors of the per-record
@@ -237,8 +243,15 @@ mod tests {
         assert_eq!(spec.batch.len(), 2);
         assert!(matches!(spec.record[0], RecordCheck::NotNull { .. }));
         assert!(matches!(spec.batch[1], BatchCheck::Unique { .. }));
-        if let RecordCheck::NotNull { treat_missing_as_null, .. } = &spec.record[0] {
-            assert!(*treat_missing_as_null, "treat_missing_as_null defaults to true");
+        if let RecordCheck::NotNull {
+            treat_missing_as_null,
+            ..
+        } = &spec.record[0]
+        {
+            assert!(
+                *treat_missing_as_null,
+                "treat_missing_as_null defaults to true"
+            );
         } else {
             panic!("expected first record check to be NotNull");
         }

--- a/crates/core/src/quality/config.rs
+++ b/crates/core/src/quality/config.rs
@@ -68,6 +68,19 @@ pub enum JsonType {
     Null,
 }
 
+impl std::fmt::Display for JsonType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            JsonType::Boolean => "boolean",
+            JsonType::Number => "number",
+            JsonType::String => "string",
+            JsonType::Array => "array",
+            JsonType::Object => "object",
+            JsonType::Null => "null",
+        })
+    }
+}
+
 fn default_true() -> bool {
     true
 }

--- a/crates/core/src/quality/mod.rs
+++ b/crates/core/src/quality/mod.rs
@@ -9,4 +9,5 @@ pub mod compile;
 pub mod config;
 pub mod record;
 
+pub use compile::CompiledQuality;
 pub use config::{BatchCheck, CompareOp, JsonType, OnFailure, QualitySpec, RecordCheck};

--- a/crates/core/src/quality/mod.rs
+++ b/crates/core/src/quality/mod.rs
@@ -257,7 +257,9 @@ mod tests {
         });
         let page = vec![json!({"id": 1}), json!({"id": null})];
         let err = apply_quality(page, &q).unwrap_err();
-        assert!(matches!(err, crate::FaucetError::QualityFailure { check, .. } if check == "row_count"));
+        assert!(
+            matches!(err, crate::FaucetError::QualityFailure { check, .. } if check == "row_count")
+        );
     }
 
     #[test]

--- a/crates/core/src/quality/mod.rs
+++ b/crates/core/src/quality/mod.rs
@@ -11,3 +11,301 @@ pub mod record;
 
 pub use compile::CompiledQuality;
 pub use config::{BatchCheck, CompareOp, JsonType, OnFailure, QualitySpec, RecordCheck};
+
+use crate::error::FaucetError;
+use crate::quality::batch::{evaluate_aggregate_check, evaluate_unique_check};
+use crate::quality::compile::CompiledBatchKind;
+use crate::quality::record::evaluate_record_check;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+/// A record removed from the page by a quality check, destined for the DLQ.
+#[derive(Debug, Clone)]
+pub struct QuarantinedRecord {
+    pub record: Value,
+    /// Check name (stable metric-label value), e.g. `"not_null"`.
+    pub check: &'static str,
+    /// Addressed field, if any (for the metric/envelope `field` label).
+    pub field: Option<String>,
+    /// Human-readable failure message (goes into the DLQ envelope error).
+    pub message: String,
+}
+
+/// Per-check counters + elapsed time, keyed by check name. Emitted as metrics
+/// by the observability wrapper.
+///
+/// Note: for per-record checks `pass`/`fail` count individual records; for
+/// per-batch checks they count check *evaluations* (at most one per page).
+/// Per-record quarantine volume for batch checks is exposed separately via
+/// the `faucet_quality_records_quarantined_total` metric.
+#[derive(Debug, Clone, Default)]
+pub struct CheckTally {
+    pub pass: u64,
+    pub fail: u64,
+    pub elapsed: Duration,
+}
+
+/// Result of applying the quality pass to one page.
+#[derive(Debug, Clone, Default)]
+pub struct QualityOutcome {
+    /// Records that passed all checks and should be written to the sink.
+    pub survivors: Vec<Value>,
+    /// Records routed to the DLQ.
+    pub quarantined: Vec<QuarantinedRecord>,
+    /// Per-check pass/fail/elapsed tally.
+    pub tally: HashMap<&'static str, CheckTally>,
+}
+
+impl QualityOutcome {
+    fn bump(&mut self, name: &'static str, passed: bool, elapsed: Duration) {
+        let e = self.tally.entry(name).or_default();
+        if passed {
+            e.pass += 1;
+        } else {
+            e.fail += 1;
+        }
+        e.elapsed += elapsed;
+    }
+}
+
+/// Apply the full per-page quality pass. Pure: no metrics, no DLQ I/O.
+///
+/// Order: per-record checks (first-failure-wins) partition the page into
+/// survivors + quarantined; per-batch checks then run over the survivors.
+/// Returns `Err(FaucetError::QualityFailure)` on any `abort`.
+pub fn apply_quality(
+    records: Vec<Value>,
+    q: &CompiledQuality,
+) -> Result<QualityOutcome, FaucetError> {
+    let mut out = QualityOutcome::default();
+
+    // ── Per-record pass ───────────────────────────────────────────────
+    'next_record: for rec in records {
+        for check in &q.record {
+            // Per-check timing feeds the per-page duration histogram (catches slow
+            // checks like json_schema). The per-record Instant overhead is negligible
+            // relative to a real check; cheap checks dominate it but the loop is cheap.
+            let start = Instant::now();
+            let result = evaluate_record_check(check, &rec);
+            let elapsed = start.elapsed();
+            match result {
+                Ok(()) => out.bump(check.name, true, elapsed),
+                Err(message) => {
+                    out.bump(check.name, false, elapsed);
+                    match check.on_failure {
+                        OnFailure::Abort => {
+                            return Err(FaucetError::QualityFailure {
+                                check: check.name.to_string(),
+                                message: field_msg(&check.field, &message),
+                            });
+                        }
+                        OnFailure::Quarantine | OnFailure::QuarantineBatch => {
+                            // (compile guarantees record checks are quarantine/abort)
+                            out.quarantined.push(QuarantinedRecord {
+                                record: rec,
+                                check: check.name,
+                                field: check.field.clone(),
+                                message: field_msg(&check.field, &message),
+                            });
+                            continue 'next_record;
+                        }
+                    }
+                }
+            }
+        }
+        out.survivors.push(rec);
+    }
+
+    // ── Per-batch pass over survivors ─────────────────────────────────
+    for check in &q.batch {
+        let start = Instant::now();
+        if matches!(check.kind, CompiledBatchKind::Unique { .. }) {
+            let dups = evaluate_unique_check(check, &out.survivors);
+            let elapsed = start.elapsed();
+            let passed = dups.is_empty();
+            out.bump(check.name, passed, elapsed);
+            if passed {
+                continue;
+            }
+            match check.on_failure {
+                OnFailure::Abort => {
+                    return Err(FaucetError::QualityFailure {
+                        check: check.name.to_string(),
+                        message: format!("{} duplicate row(s)", dups.len()),
+                    });
+                }
+                _ => {
+                    // quarantine the duplicate occurrences (keep first).
+                    let dup_set: std::collections::HashSet<usize> = dups.into_iter().collect();
+                    let mut survivors = Vec::with_capacity(out.survivors.len());
+                    for (i, rec) in std::mem::take(&mut out.survivors).into_iter().enumerate() {
+                        if dup_set.contains(&i) {
+                            out.quarantined.push(QuarantinedRecord {
+                                record: rec,
+                                check: check.name,
+                                field: check.field.clone(),
+                                message: field_msg(&check.field, "duplicate key"),
+                            });
+                        } else {
+                            survivors.push(rec);
+                        }
+                    }
+                    out.survivors = survivors;
+                }
+            }
+        } else {
+            let result = evaluate_aggregate_check(check, &out.survivors);
+            let elapsed = start.elapsed();
+            match result {
+                Ok(()) => out.bump(check.name, true, elapsed),
+                Err(message) => {
+                    out.bump(check.name, false, elapsed);
+                    match check.on_failure {
+                        OnFailure::Abort => {
+                            return Err(FaucetError::QualityFailure {
+                                check: check.name.to_string(),
+                                message: field_msg(&check.field, &message),
+                            });
+                        }
+                        // quarantine_batch: route all survivors to the DLQ.
+                        _ => {
+                            for rec in std::mem::take(&mut out.survivors) {
+                                out.quarantined.push(QuarantinedRecord {
+                                    record: rec,
+                                    check: check.name,
+                                    field: check.field.clone(),
+                                    message: field_msg(&check.field, &message),
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(out)
+}
+
+fn field_msg(field: &Option<String>, message: &str) -> String {
+    match field {
+        Some(f) => format!("field '{f}': {message}"),
+        None => message.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::quality::config::{BatchCheck, CompareOp, OnFailure, RecordCheck};
+    use serde_json::json;
+
+    fn compiled(spec: QualitySpec) -> CompiledQuality {
+        CompiledQuality::compile(&spec).unwrap()
+    }
+
+    #[test]
+    fn per_record_quarantine_partitions_page() {
+        let q = compiled(QualitySpec {
+            record: vec![RecordCheck::NotNull {
+                field: "id".into(),
+                treat_missing_as_null: true,
+                on_failure: OnFailure::Quarantine,
+            }],
+            batch: vec![],
+        });
+        let page = vec![json!({"id": 1}), json!({"id": null}), json!({"id": 3})];
+        let out = apply_quality(page, &q).unwrap();
+        assert_eq!(out.survivors, vec![json!({"id": 1}), json!({"id": 3})]);
+        assert_eq!(out.quarantined.len(), 1);
+        assert_eq!(out.quarantined[0].check, "not_null");
+        assert_eq!(out.quarantined[0].field.as_deref(), Some("id"));
+    }
+
+    #[test]
+    fn per_record_abort_returns_err() {
+        let q = compiled(QualitySpec {
+            record: vec![RecordCheck::Compare {
+                field: "age".into(),
+                op: CompareOp::Gte,
+                value: json!(0),
+                on_failure: OnFailure::Abort,
+            }],
+            batch: vec![],
+        });
+        let page = vec![json!({"age": 5}), json!({"age": -1})];
+        let err = apply_quality(page, &q).unwrap_err();
+        assert!(matches!(err, crate::FaucetError::QualityFailure { .. }));
+    }
+
+    #[test]
+    fn batch_eval_runs_over_survivors() {
+        // not_null quarantines the null id; row_count(min:2) then sees only 1
+        // survivor and aborts.
+        let q = compiled(QualitySpec {
+            record: vec![RecordCheck::NotNull {
+                field: "id".into(),
+                treat_missing_as_null: true,
+                on_failure: OnFailure::Quarantine,
+            }],
+            batch: vec![BatchCheck::RowCount {
+                min: Some(2),
+                max: None,
+                on_failure: OnFailure::Abort,
+            }],
+        });
+        let page = vec![json!({"id": 1}), json!({"id": null})];
+        let err = apply_quality(page, &q).unwrap_err();
+        assert!(matches!(err, crate::FaucetError::QualityFailure { check, .. } if check == "row_count"));
+    }
+
+    #[test]
+    fn unique_quarantine_routes_dupes_keeps_first() {
+        let q = compiled(QualitySpec {
+            record: vec![],
+            batch: vec![BatchCheck::Unique {
+                fields: vec!["id".into()],
+                on_failure: OnFailure::Quarantine,
+            }],
+        });
+        let page = vec![json!({"id": 1}), json!({"id": 1}), json!({"id": 2})];
+        let out = apply_quality(page, &q).unwrap();
+        assert_eq!(out.survivors, vec![json!({"id": 1}), json!({"id": 2})]);
+        assert_eq!(out.quarantined.len(), 1);
+        assert_eq!(out.quarantined[0].check, "unique");
+    }
+
+    #[test]
+    fn quarantine_batch_routes_all_survivors() {
+        let q = compiled(QualitySpec {
+            record: vec![],
+            batch: vec![BatchCheck::RowCount {
+                min: Some(10),
+                max: None,
+                on_failure: OnFailure::QuarantineBatch,
+            }],
+        });
+        let page = vec![json!({"id": 1}), json!({"id": 2})];
+        let out = apply_quality(page, &q).unwrap();
+        assert!(out.survivors.is_empty());
+        assert_eq!(out.quarantined.len(), 2);
+    }
+
+    #[test]
+    fn tally_counts_pass_and_fail() {
+        let q = compiled(QualitySpec {
+            record: vec![RecordCheck::NotNull {
+                field: "id".into(),
+                treat_missing_as_null: true,
+                on_failure: OnFailure::Quarantine,
+            }],
+            batch: vec![],
+        });
+        let page = vec![json!({"id": 1}), json!({"id": null})];
+        let out = apply_quality(page, &q).unwrap();
+        let t = out.tally.get("not_null").unwrap();
+        assert_eq!(t.pass, 1);
+        assert_eq!(t.fail, 1);
+    }
+}

--- a/crates/core/src/quality/mod.rs
+++ b/crates/core/src/quality/mod.rs
@@ -9,4 +9,4 @@ pub mod compile;
 pub mod config;
 pub mod record;
 
-pub use config::{CompareOp, JsonType, OnFailure};
+pub use config::{BatchCheck, CompareOp, JsonType, OnFailure, QualitySpec, RecordCheck};

--- a/crates/core/src/quality/mod.rs
+++ b/crates/core/src/quality/mod.rs
@@ -1,0 +1,12 @@
+//! Data-quality checks: declarative per-record and per-batch assertions that
+//! quarantine violating records to the DLQ or abort the run. Pure evaluation;
+//! the pipeline wires the DLQ routing in `run_stream`.
+//!
+//! See `docs/superpowers/specs/2026-05-29-quality-checks-design.md`.
+
+pub mod batch;
+pub mod compile;
+pub mod config;
+pub mod record;
+
+pub use config::{CompareOp, JsonType, OnFailure};

--- a/crates/core/src/quality/record.rs
+++ b/crates/core/src/quality/record.rs
@@ -1,1 +1,328 @@
-//! (placeholder — filled in a later task)
+//! Per-record check evaluation. Pure functions over `&Value`. A check returns
+//! `Ok(())` on pass or `Err(message)` on fail; the message is surfaced in the
+//! DLQ envelope or the abort error.
+
+use crate::quality::compile::{CompiledRecordCheck, CompiledRecordKind};
+use crate::quality::config::{CompareOp, JsonType};
+use serde_json::Value;
+
+/// Evaluate one compiled per-record check against a record. `Ok(())` = pass;
+/// `Err(message)` = fail (message is human-readable, used in DLQ/abort text).
+pub fn evaluate_record_check(c: &CompiledRecordCheck, rec: &Value) -> Result<(), String> {
+    match &c.kind {
+        CompiledRecordKind::NotNull {
+            path,
+            treat_missing_as_null,
+        } => {
+            match path.resolve(rec).ok().flatten() {
+                Some(Value::Null) => Err("value was null".into()),
+                Some(_) => Ok(()),
+                None => {
+                    if *treat_missing_as_null {
+                        Err("field was missing".into())
+                    } else {
+                        Ok(())
+                    }
+                }
+            }
+        }
+        CompiledRecordKind::NotEmpty { path } => match path.resolve(rec).ok().flatten() {
+            Some(Value::String(s)) if !s.trim().is_empty() => Ok(()),
+            Some(Value::String(_)) => Err("string was empty/whitespace".into()),
+            Some(Value::Null) => Err("value was null".into()),
+            Some(_) => Err("value was not a string".into()),
+            None => Err("field was missing".into()),
+        },
+        CompiledRecordKind::RegexMatch { path, re } => match path.resolve(rec).ok().flatten() {
+            Some(Value::String(s)) if re.is_match(s) => Ok(()),
+            Some(Value::String(_)) => Err("value did not match pattern".into()),
+            Some(_) => Err("value was not a string".into()),
+            None => Err("field was missing".into()),
+        },
+        CompiledRecordKind::ValueInSet { path, values } => {
+            match path.resolve(rec).ok().flatten() {
+                Some(v) if values.contains(v) => Ok(()),
+                Some(_) => Err("value not in allowed set".into()),
+                None => Err("field was missing".into()),
+            }
+        }
+        CompiledRecordKind::NotInSet { path, values } => match path.resolve(rec).ok().flatten() {
+            Some(v) if values.contains(v) => Err("value is in the forbidden set".into()),
+            // present-and-not-in-set OR missing -> pass
+            _ => Ok(()),
+        },
+        CompiledRecordKind::Compare { path, op, value } => {
+            let resolved = path.resolve(rec).ok().flatten();
+            let Some(actual) = resolved else {
+                return Err("field was missing".into());
+            };
+            evaluate_compare(*op, actual, value)
+        }
+        CompiledRecordKind::TypeIs { path, expected } => {
+            match path.resolve(rec).ok().flatten() {
+                Some(v) if json_type_matches(v, *expected) => Ok(()),
+                Some(_) => Err(format!("value was not of type {expected}")),
+                None => Err("field was missing".into()),
+            }
+        }
+        CompiledRecordKind::StringLength { path, min, max } => {
+            match path.resolve(rec).ok().flatten() {
+                Some(Value::String(s)) => {
+                    let len = s.chars().count();
+                    if let Some(lo) = min
+                        && len < *lo
+                    {
+                        return Err(format!("string length {len} < min {lo}"));
+                    }
+                    if let Some(hi) = max
+                        && len > *hi
+                    {
+                        return Err(format!("string length {len} > max {hi}"));
+                    }
+                    Ok(())
+                }
+                Some(_) => Err("value was not a string".into()),
+                None => Err("field was missing".into()),
+            }
+        }
+        #[cfg(feature = "quality-jsonschema")]
+        CompiledRecordKind::JsonSchema { validator } => {
+            if validator.is_valid(rec) {
+                Ok(())
+            } else {
+                let msg = validator
+                    .iter_errors(rec)
+                    .next()
+                    .map(|e| e.to_string())
+                    .unwrap_or_else(|| "record did not validate against schema".into());
+                Err(msg)
+            }
+        }
+    }
+}
+
+/// Evaluate a `compare` check. Note: ordering ops (`gt`/`gte`/`lt`/`lte`)
+/// convert both operands via `as_f64()`, which loses precision for integer
+/// magnitudes above 2^53; `eq`/`ne` use exact structural JSON equality.
+fn evaluate_compare(op: CompareOp, actual: &Value, expected: &Value) -> Result<(), String> {
+    match op {
+        CompareOp::Eq => {
+            if actual == expected {
+                Ok(())
+            } else {
+                Err("values were not equal".into())
+            }
+        }
+        CompareOp::Ne => {
+            if actual != expected {
+                Ok(())
+            } else {
+                Err("values were equal".into())
+            }
+        }
+        CompareOp::Gt | CompareOp::Gte | CompareOp::Lt | CompareOp::Lte => {
+            let (Some(a), Some(b)) = (actual.as_f64(), expected.as_f64()) else {
+                return Err("value was not numeric".into());
+            };
+            let ok = match op {
+                CompareOp::Gt => a > b,
+                CompareOp::Gte => a >= b,
+                CompareOp::Lt => a < b,
+                CompareOp::Lte => a <= b,
+                _ => unreachable!(),
+            };
+            if ok {
+                Ok(())
+            } else {
+                Err(format!("comparison {a} {op} {b} failed"))
+            }
+        }
+    }
+}
+
+fn json_type_matches(v: &Value, expected: JsonType) -> bool {
+    matches!(
+        (v, expected),
+        (Value::Bool(_), JsonType::Boolean)
+            | (Value::Number(_), JsonType::Number)
+            | (Value::String(_), JsonType::String)
+            | (Value::Array(_), JsonType::Array)
+            | (Value::Object(_), JsonType::Object)
+            | (Value::Null, JsonType::Null)
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::quality::compile::CompiledQuality;
+    use crate::quality::config::{CompareOp, JsonType, OnFailure, QualitySpec, RecordCheck};
+    use serde_json::json;
+
+    fn one(check: RecordCheck) -> crate::quality::compile::CompiledRecordCheck {
+        let spec = QualitySpec {
+            record: vec![check],
+            batch: vec![],
+        };
+        CompiledQuality::compile(&spec).unwrap().record.pop().unwrap()
+    }
+
+    #[test]
+    fn not_null_passes_present_fails_missing_and_null() {
+        let c = one(RecordCheck::NotNull {
+            field: "id".into(),
+            treat_missing_as_null: true,
+            on_failure: OnFailure::Quarantine,
+        });
+        assert!(evaluate_record_check(&c, &json!({"id": 1})).is_ok());
+        assert!(evaluate_record_check(&c, &json!({"id": null})).is_err());
+        assert!(evaluate_record_check(&c, &json!({})).is_err());
+    }
+
+    #[test]
+    fn not_null_treat_missing_false_only_explicit_null_fails() {
+        let c = one(RecordCheck::NotNull {
+            field: "id".into(),
+            treat_missing_as_null: false,
+            on_failure: OnFailure::Quarantine,
+        });
+        assert!(evaluate_record_check(&c, &json!({})).is_ok()); // missing -> pass
+        assert!(evaluate_record_check(&c, &json!({"id": null})).is_err());
+    }
+
+    #[test]
+    fn not_empty() {
+        let c = one(RecordCheck::NotEmpty {
+            field: "name".into(),
+            on_failure: OnFailure::Quarantine,
+        });
+        assert!(evaluate_record_check(&c, &json!({"name": "x"})).is_ok());
+        assert!(evaluate_record_check(&c, &json!({"name": "  "})).is_err());
+        assert!(evaluate_record_check(&c, &json!({"name": ""})).is_err());
+        assert!(evaluate_record_check(&c, &json!({"name": 5})).is_err()); // non-string
+        assert!(evaluate_record_check(&c, &json!({})).is_err()); // missing
+    }
+
+    #[test]
+    fn regex_match() {
+        let c = one(RecordCheck::RegexMatch {
+            field: "email".into(),
+            pattern: r"^[^@]+@[^@]+\.[^@]+$".into(),
+            on_failure: OnFailure::Quarantine,
+        });
+        assert!(evaluate_record_check(&c, &json!({"email": "a@b.com"})).is_ok());
+        assert!(evaluate_record_check(&c, &json!({"email": "nope"})).is_err());
+        assert!(evaluate_record_check(&c, &json!({"email": 1})).is_err());
+        assert!(evaluate_record_check(&c, &json!({})).is_err());
+    }
+
+    #[test]
+    fn value_in_set_and_not_in_set_missing_handling() {
+        let in_set = one(RecordCheck::ValueInSet {
+            field: "status".into(),
+            values: vec![json!("active"), json!("closed")],
+            on_failure: OnFailure::Quarantine,
+        });
+        assert!(evaluate_record_check(&in_set, &json!({"status": "active"})).is_ok());
+        assert!(evaluate_record_check(&in_set, &json!({"status": "x"})).is_err());
+        assert!(evaluate_record_check(&in_set, &json!({})).is_err()); // missing -> fail
+
+        let not_in = one(RecordCheck::NotInSet {
+            field: "status".into(),
+            values: vec![json!("banned")],
+            on_failure: OnFailure::Quarantine,
+        });
+        assert!(evaluate_record_check(&not_in, &json!({"status": "active"})).is_ok());
+        assert!(evaluate_record_check(&not_in, &json!({"status": "banned"})).is_err());
+        assert!(evaluate_record_check(&not_in, &json!({})).is_ok()); // missing -> pass
+    }
+
+    #[test]
+    fn compare_ordering_and_equality() {
+        let gte = one(RecordCheck::Compare {
+            field: "age".into(),
+            op: CompareOp::Gte,
+            value: json!(0),
+            on_failure: OnFailure::Abort,
+        });
+        assert!(evaluate_record_check(&gte, &json!({"age": 0})).is_ok());
+        assert!(evaluate_record_check(&gte, &json!({"age": -1})).is_err());
+        assert!(evaluate_record_check(&gte, &json!({"age": "x"})).is_err()); // non-numeric
+        assert!(evaluate_record_check(&gte, &json!({})).is_err()); // missing
+
+        let eq = one(RecordCheck::Compare {
+            field: "v".into(),
+            op: CompareOp::Eq,
+            value: json!(5),
+            on_failure: OnFailure::Abort,
+        });
+        assert!(evaluate_record_check(&eq, &json!({"v": 5})).is_ok());
+        assert!(evaluate_record_check(&eq, &json!({"v": "5"})).is_err()); // no coercion
+
+        let ne = one(RecordCheck::Compare {
+            field: "v".into(),
+            op: CompareOp::Ne,
+            value: json!(5),
+            on_failure: OnFailure::Abort,
+        });
+        assert!(evaluate_record_check(&ne, &json!({"v": 6})).is_ok()); // 6 != 5 -> pass
+        assert!(evaluate_record_check(&ne, &json!({"v": 5})).is_err()); // 5 == 5 -> fail
+    }
+
+    #[test]
+    fn not_empty_null_reports_null() {
+        let c = one(RecordCheck::NotEmpty {
+            field: "name".into(),
+            on_failure: OnFailure::Quarantine,
+        });
+        let err = evaluate_record_check(&c, &json!({"name": null})).unwrap_err();
+        assert!(err.contains("null"));
+    }
+
+    #[test]
+    fn type_is() {
+        let b = one(RecordCheck::TypeIs {
+            field: "active".into(),
+            expected: JsonType::Boolean,
+            on_failure: OnFailure::Quarantine,
+        });
+        assert!(evaluate_record_check(&b, &json!({"active": true})).is_ok());
+        assert!(evaluate_record_check(&b, &json!({"active": 1})).is_err());
+        assert!(evaluate_record_check(&b, &json!({})).is_err());
+
+        let n = one(RecordCheck::TypeIs {
+            field: "x".into(),
+            expected: JsonType::Null,
+            on_failure: OnFailure::Quarantine,
+        });
+        assert!(evaluate_record_check(&n, &json!({"x": null})).is_ok());
+        assert!(evaluate_record_check(&n, &json!({})).is_err()); // missing != null
+    }
+
+    #[test]
+    fn string_length() {
+        let c = one(RecordCheck::StringLength {
+            field: "name".into(),
+            min: Some(1),
+            max: Some(3),
+            on_failure: OnFailure::Quarantine,
+        });
+        assert!(evaluate_record_check(&c, &json!({"name": "ab"})).is_ok());
+        assert!(evaluate_record_check(&c, &json!({"name": ""})).is_err());
+        assert!(evaluate_record_check(&c, &json!({"name": "abcd"})).is_err());
+        assert!(evaluate_record_check(&c, &json!({"name": "é"})).is_ok()); // 1 char
+        assert!(evaluate_record_check(&c, &json!({"name": 5})).is_err());
+    }
+
+    #[cfg(feature = "quality-jsonschema")]
+    #[test]
+    fn json_schema() {
+        let c = one(RecordCheck::JsonSchema {
+            schema: json!({"type": "object", "required": ["id"], "properties": {"id": {"type": "integer"}}}),
+            on_failure: OnFailure::Quarantine,
+        });
+        assert!(evaluate_record_check(&c, &json!({"id": 1})).is_ok());
+        assert!(evaluate_record_check(&c, &json!({"id": "x"})).is_err());
+        assert!(evaluate_record_check(&c, &json!({})).is_err());
+    }
+}

--- a/crates/core/src/quality/record.rs
+++ b/crates/core/src/quality/record.rs
@@ -13,19 +13,17 @@ pub fn evaluate_record_check(c: &CompiledRecordCheck, rec: &Value) -> Result<(),
         CompiledRecordKind::NotNull {
             path,
             treat_missing_as_null,
-        } => {
-            match path.resolve(rec).ok().flatten() {
-                Some(Value::Null) => Err("value was null".into()),
-                Some(_) => Ok(()),
-                None => {
-                    if *treat_missing_as_null {
-                        Err("field was missing".into())
-                    } else {
-                        Ok(())
-                    }
+        } => match path.resolve(rec).ok().flatten() {
+            Some(Value::Null) => Err("value was null".into()),
+            Some(_) => Ok(()),
+            None => {
+                if *treat_missing_as_null {
+                    Err("field was missing".into())
+                } else {
+                    Ok(())
                 }
             }
-        }
+        },
         CompiledRecordKind::NotEmpty { path } => match path.resolve(rec).ok().flatten() {
             Some(Value::String(s)) if !s.trim().is_empty() => Ok(()),
             Some(Value::String(_)) => Err("string was empty/whitespace".into()),
@@ -39,13 +37,11 @@ pub fn evaluate_record_check(c: &CompiledRecordCheck, rec: &Value) -> Result<(),
             Some(_) => Err("value was not a string".into()),
             None => Err("field was missing".into()),
         },
-        CompiledRecordKind::ValueInSet { path, values } => {
-            match path.resolve(rec).ok().flatten() {
-                Some(v) if values.contains(v) => Ok(()),
-                Some(_) => Err("value not in allowed set".into()),
-                None => Err("field was missing".into()),
-            }
-        }
+        CompiledRecordKind::ValueInSet { path, values } => match path.resolve(rec).ok().flatten() {
+            Some(v) if values.contains(v) => Ok(()),
+            Some(_) => Err("value not in allowed set".into()),
+            None => Err("field was missing".into()),
+        },
         CompiledRecordKind::NotInSet { path, values } => match path.resolve(rec).ok().flatten() {
             Some(v) if values.contains(v) => Err("value is in the forbidden set".into()),
             // present-and-not-in-set OR missing -> pass
@@ -58,13 +54,11 @@ pub fn evaluate_record_check(c: &CompiledRecordCheck, rec: &Value) -> Result<(),
             };
             evaluate_compare(*op, actual, value)
         }
-        CompiledRecordKind::TypeIs { path, expected } => {
-            match path.resolve(rec).ok().flatten() {
-                Some(v) if json_type_matches(v, *expected) => Ok(()),
-                Some(_) => Err(format!("value was not of type {expected}")),
-                None => Err("field was missing".into()),
-            }
-        }
+        CompiledRecordKind::TypeIs { path, expected } => match path.resolve(rec).ok().flatten() {
+            Some(v) if json_type_matches(v, *expected) => Ok(()),
+            Some(_) => Err(format!("value was not of type {expected}")),
+            None => Err("field was missing".into()),
+        },
         CompiledRecordKind::StringLength { path, min, max } => {
             match path.resolve(rec).ok().flatten() {
                 Some(Value::String(s)) => {
@@ -164,7 +158,11 @@ mod tests {
             record: vec![check],
             batch: vec![],
         };
-        CompiledQuality::compile(&spec).unwrap().record.pop().unwrap()
+        CompiledQuality::compile(&spec)
+            .unwrap()
+            .record
+            .pop()
+            .unwrap()
     }
 
     #[test]

--- a/crates/core/src/quality/record.rs
+++ b/crates/core/src/quality/record.rs
@@ -1,0 +1,1 @@
+//! (placeholder — filled in a later task)

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -21,6 +21,7 @@
 - [Authentication](./cookbook/auth.md)
 - [Incremental replication & state](./cookbook/state.md)
 - [Dead-letter queues](./cookbook/dlq.md)
+- [Data-quality checks](./cookbook/quality.md)
 - [Compression](./cookbook/compression.md)
 - [Record transforms](./cookbook/transforms.md)
 

--- a/docs/book/src/cookbook/quality.md
+++ b/docs/book/src/cookbook/quality.md
@@ -1,0 +1,200 @@
+# Data-quality checks
+
+Add a `quality:` block under `pipeline:` to assert invariants on every page of
+records as they flow through the pipeline. The quality pass runs **after**
+transforms and **before** the sink write:
+
+1. **Per-record checks** partition the page into survivors and quarantined rows
+   (first-failure-wins per record).
+2. **Per-batch checks** run over the survivors.
+3. Quarantined rows are routed to the DLQ sink; survivors flow to the main sink.
+4. The page bookmark advances only after the sink confirms — an `abort` never
+   commits partial progress.
+
+Quality checks require the `quality` Cargo feature (included in `full` and in
+`faucet-cli`'s default build). The `json_schema` check additionally requires
+`quality-jsonschema`.
+
+## Full example
+
+The following config fetches users from a REST API, normalises keys to snake_case,
+and enforces several quality invariants before writing survivors to PostgreSQL.
+Quarantined rows land in a local JSONL file.
+
+```yaml
+# rest_to_postgres_with_quality.yaml
+version: 1
+name: users_api_to_postgres_with_quality
+
+pipeline:
+  source:
+    type: rest
+    config:
+      base_url: https://api.example.com/v1
+      path: /users
+      method: GET
+      auth:
+        type: bearer
+        config:
+          token: ${env:API_TOKEN}
+      query_params:
+        per_page: "100"
+      pagination:
+        type: Cursor
+        next_token_path: $.meta.next_cursor
+        param_name: cursor
+      max_retries: 3
+      retry_backoff: 2
+      tolerated_http_errors: []
+      replication_method:
+        type: Incremental
+      replication_key: updated_at
+      primary_keys: ["id"]
+      partitions: []
+      schema_sample_size: 100
+      state_key: users_api:users
+
+  transforms:
+    - type: keys_case
+      config: { mode: snake }
+
+  quality:
+    record:
+      - type: not_null
+        field: id
+        on_failure: abort             # abort: a null id is a catastrophic upstream bug
+      - type: not_null
+        field: email
+        on_failure: quarantine        # quarantine: route bad rows to the DLQ
+      - type: regex_match
+        field: email
+        pattern: '^[^@\s]+@[^@\s]+\.[^@\s]+$'
+        on_failure: quarantine
+      - type: value_in_set
+        field: status
+        values: ["active", "inactive", "pending", "suspended"]
+        on_failure: quarantine
+      - type: compare
+        field: age
+        op: gte
+        value: 0
+        on_failure: quarantine
+    batch:
+      - type: row_count
+        min: 1
+        on_failure: abort             # empty pages indicate a misconfigured source
+      - type: unique
+        fields: [id]
+        on_failure: quarantine        # route duplicate ids to the DLQ
+
+  dlq:
+    sink:
+      type: jsonl
+      config:
+        path: ./dlq/users_quality_failures.jsonl
+    on_batch_error: propagate
+    max_failures_per_page: 50
+    max_failures_total: 500
+
+  sink:
+    type: postgres
+    config:
+      connection_url: ${env:PG_URL}
+      table_name: users
+      column_mapping:
+        type: jsonb
+        column: data
+      batch_size: 500
+      max_connections: 5
+
+  state:
+    type: file
+    config:
+      path: ./.faucet-state
+```
+
+## Check catalog
+
+### Per-record checks
+
+Evaluated in declared order; **first failure wins** for a given record.
+`on_failure` may be `quarantine` (route the row to the DLQ) or `abort` (raise
+`FaucetError::QualityFailure` and stop the run immediately).
+
+| Check | Key fields | Passes when | Missing field |
+|---|---|---|---|
+| `not_null` | `field`, `treat_missing_as_null` (default `true`) | value present and non-null | fail (pass iff `treat_missing_as_null: false`) |
+| `not_empty` | `field` | value is a non-empty string after trimming whitespace | fail |
+| `regex_match` | `field`, `pattern` | value is a string matching `pattern` | fail |
+| `value_in_set` | `field`, `values: [...]` | value is in the allowed set (exact JSON equality) | fail |
+| `not_in_set` | `field`, `values: [...]` | value is NOT in the forbidden set | pass (trivially not in set) |
+| `compare` | `field`, `op`, `value` | ordering or equality holds (see below) | fail |
+| `type_is` | `field`, `expected` | JSON type of the value matches `expected` | fail |
+| `string_length` | `field`, `min?`, `max?` | char count in `[min, max]` (at least one bound required) | fail |
+| `json_schema` | `schema` | whole record validates against a JSON Schema document | (whole-record check) |
+
+**`compare` operators:** `gt`, `gte`, `lt`, `lte` require both the field value and
+the configured `value` to be JSON numbers (compared as `f64`); `eq` and `ne` do
+exact JSON equality with no type coercion.
+
+**`json_schema`** requires the `quality-jsonschema` Cargo feature. It is the most
+expressive check; its cost scales with schema complexity — for very large or deeply
+nested schemas on hot paths, prefer the granular checks above and benchmark your
+case.
+
+### Per-batch checks
+
+Evaluated per page over the **survivors** (records that passed all per-record
+checks). Aggregate checks (`row_count`, `null_rate`, `distinct_count`) are not
+row-attributable, so they offer `quarantine_batch` (route all survivors to the DLQ,
+write nothing this page) or `abort`. `unique` is row-attributable and accepts
+`quarantine` (route the duplicate rows) or `abort`.
+
+| Check | Key fields | Passes when |
+|---|---|---|
+| `row_count` | `min?`, `max?` (at least one required) | survivor count in `[min, max]` |
+| `null_rate` | `field`, `max` (0.0–1.0) | null-or-missing rate ≤ `max`; zero survivors → 0.0 → pass |
+| `unique` | `fields: [...]` (composite key) | every survivor's composite key is unique within the page |
+| `distinct_count` | `field`, `min?`, `max?` | distinct values of `field` in `[min, max]` |
+
+## Failure policies
+
+| Policy | Meaning | Allowed on |
+|---|---|---|
+| `quarantine` | Route the specific offending row(s) to the DLQ; keep the rest as survivors | per-record checks; `unique` |
+| `quarantine_batch` | Route all current survivors of the page to the DLQ; nothing written this page | aggregate batch checks (`row_count`, `null_rate`, `distinct_count`) |
+| `abort` | Raise `FaucetError::QualityFailure` and stop the run | every check |
+
+## DLQ requirement
+
+Any check that uses `quarantine` or `quarantine_batch` requires a `dlq:` block.
+Omitting it is rejected at config-load time:
+
+```
+error: quality: on_failure 'quarantine' requires a DLQ sink
+```
+
+See the [Dead-letter queues](./dlq.md) cookbook page for `dlq:` options.
+
+## Observability
+
+The quality pass emits `faucet_quality_*` metrics automatically:
+
+- `faucet_quality_checks_total{pipeline,row,check,outcome=pass|fail}`
+- `faucet_quality_records_quarantined_total{pipeline,row,check,field}`
+- `faucet_quality_aborts_total{pipeline,row,check}`
+- `faucet_quality_check_duration_seconds{check}`
+
+These are available alongside the standard `faucet_source_*`, `faucet_sink_*`, and
+`faucet_transform_*` metrics. See [Observability](../operations/observability.md)
+for the full metrics reference.
+
+## Validate the config
+
+```bash
+faucet validate rest_to_postgres_with_quality.yaml
+# ok: 'users_api_to_postgres_with_quality' rows=1 (roots=1, children=0)
+```
+
+`faucet schema quality` prints the full JSON Schema for the `quality:` block, and
+`faucet list` shows all available checks with descriptions.

--- a/docs/book/src/cookbook/quality.md
+++ b/docs/book/src/cookbook/quality.md
@@ -168,11 +168,9 @@ write nothing this page) or `abort`. `unique` is row-attributable and accepts
 ## DLQ requirement
 
 Any check that uses `quarantine` or `quarantine_batch` requires a `dlq:` block.
-Omitting it is rejected at config-load time:
-
-```
-error: quality: on_failure 'quarantine' requires a DLQ sink
-```
+Omitting it fails validation with an error explaining that a `dlq:` block is
+required (`faucet validate` catches this before the run starts; the core
+guards it again at run start).
 
 See the [Dead-letter queues](./dlq.md) cookbook page for `dlq:` options.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -52,7 +52,7 @@ The service column lists what each example touches; all are provided by
 | Example | Services |
 |---------|----------|
 | `postgres_cdc_to_jsonl.yaml` | postgres (logical replication preconfigured) |
-| `rest_to_postgres.yaml`, `mongodb_to_postgres.yaml`, `graphql_to_postgres.yaml`, `webhook_to_postgres.yaml` | postgres (+ source) |
+| `rest_to_postgres.yaml`, `rest_to_postgres_with_quality.yaml`, `mongodb_to_postgres.yaml`, `graphql_to_postgres.yaml`, `webhook_to_postgres.yaml` | postgres (+ source) |
 | `mysql_to_postgres.yaml` | mysql, postgres |
 | `csv_to_mysql.yaml`, `redis_to_mysql.yaml` | mysql (+ source) |
 | `redis_to_sqlite.yaml`, `mongodb_to_redis.yaml`, `elasticsearch_to_redis.yaml` | redis (+ source) |

--- a/faucet-stream/Cargo.toml
+++ b/faucet-stream/Cargo.toml
@@ -77,8 +77,13 @@ compression = [
 ## Shared, single-flight auth providers (OAuth2 client-credentials / refresh,
 ## token-endpoint) usable across connectors via `auth: { ref }`.
 auth = ["dep:faucet-auth"]
+## Data-quality checks (`quality:` config block). `quality-jsonschema` adds the
+## `json_schema` record check via a JSON Schema validator. Forwarded to
+## `faucet-core`.
+quality = ["faucet-core/quality"]
+quality-jsonschema = ["quality", "faucet-core/quality-jsonschema"]
 ## Every connector and state backend.
-full = ["source", "sink", "state", "auth", "kafka-schema-registry", "compression"]
+full = ["source", "sink", "state", "auth", "kafka-schema-registry", "compression", "quality", "quality-jsonschema"]
 
 ## Individual source connectors.
 source-rest = ["dep:faucet-source-rest"]


### PR DESCRIPTION
## Summary

Adds a built-in, config-driven **data-quality layer** to faucet-stream: declarative per-record and per-batch assertions that route violating records to the DLQ or abort the run. Configured via a new pipeline-level `quality:` block. Closes #122.

```yaml
pipeline:
  source: { ... }
  transforms: [ flatten ]
  quality:
    record:
      - { type: not_null, field: user_id, on_failure: quarantine }
      - { type: compare, field: age, op: gte, value: 0, on_failure: quarantine }
      - { type: regex_match, field: email, pattern: '^[^@]+@[^@]+\.[^@]+$', on_failure: quarantine }
    batch:
      - { type: row_count, min: 1, max: 100000, on_failure: abort }
      - { type: unique, fields: [id], on_failure: quarantine }
  dlq: { sink: { type: jsonl, config: { path: ./dlq.jsonl } } }
  sink: { ... }
```

## What changed

- **13 checks** — per-record: `not_null`, `not_empty`, `regex_match`, `value_in_set`, `not_in_set`, `compare` (gt/gte/lt/lte/eq/ne), `type_is`, `string_length`, plus `json_schema` (gated on `quality-jsonschema`); per-batch: `row_count`, `null_rate`, `unique`, `distinct_count`.
- **Failure policies** — `quarantine` (route offending row to DLQ), `quarantine_batch` (route all survivors of the page), `abort` (`FaucetError::QualityFailure`). The allowed subset is validated per check at compile time. `quarantine`/`quarantine_batch` **require a DLQ** — rejected fast at config load (`faucet validate`) and at run start.
- **Pipeline integration** — a dedicated quality pass in `run_stream`, after transforms and before the sink, per page: per-record checks (first-failure-wins) partition the page into survivors + quarantined; per-batch checks run **over survivors**; quarantined rows flow to the existing DLQ sink (sharing the `max_failures_*` budget); survivors continue to the sink. The bookmark only advances after survivors are durably written. No changes to the `Source`/`Sink`/`StreamPage`/`apply_stages` contracts.
- **Observability** — `faucet_quality_checks_total{check,outcome}`, `faucet_quality_records_quarantined_total{check,field}`, `faucet_quality_aborts_total{check}`, `faucet_quality_check_duration_seconds{check}`, plus a `faucet.quality.apply` span and a new `DlqReason::Quality` page-label.
- **CLI** — `faucet schema quality`, a "Quality checks" section in `faucet list`, and `quality:` config wiring (pipeline-level only in v1; no matrix-row override).
- **Features** — `quality` + `quality-jsonschema` on `faucet-core`, the `faucet-stream` umbrella, and `faucet-cli` (`full` includes both); CI `feature-check` matrix updated.
- **Docs** — `crates/core/README.md` section, new `docs/book/src/cookbook/quality.md`, root README, runnable `cli/examples/rest_to_postgres_with_quality.yaml`, criterion bench.

## Architecture note (divergence from the issue)

Issue #122 proposed `quality` as an `assert` variant of `TransformStage`. That doesn't fit the current code: transform stages run inside the source wrapper (`TransformingSource`) with no access to the DLQ, and the per-record stage runner has no page-level visibility (so per-batch checks couldn't be a transform stage at all). This PR instead implements a pipeline-level `quality:` pass in `run_stream`, where the DLQ and page granularity already live. Full rationale in the design spec.

## Test plan

- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — zero warnings
- [x] `cargo test -p faucet-core --all-features` — 394 lib + 3 integration + 9 doctests pass (covers every check × policy, missing-field matrix, compile-time rejections, the orchestrator partition, and run_stream quarantine→DLQ / abort / quarantine-without-DLQ-rejected)
- [x] `cargo test -p faucet-cli` — 229 pass (config parse, `faucet validate` quarantine-without-DLQ rejection, schema/list)
- [x] Slim CLI builds (`--no-default-features --features "source-rest,…"`, with and without observability) compile — quality refs are feature-gated
- [x] `cargo fmt --all` clean; default-feature (`quality`-off) path is behavior-identical (268 baseline tests unchanged)
- [x] `faucet validate cli/examples/rest_to_postgres_with_quality.yaml` validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)
