### PR TITLE
feat(cli): secrets-manager interpolation (vault / aws-sm / gcp-sm / azure-kv)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,11 @@ jobs:
           # Quality checks
           - quality
           - quality-jsonschema
+          # Secrets backends
+          - secrets-vault
+          - secrets-aws-sm
+          - secrets-gcp-sm
+          - secrets-azure-kv
           # CLI build matrix — verify the binary builds with every default-on
           # feature plus a slim "only the bare minimum" combo.
     steps:
@@ -179,7 +184,15 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           brew install cmake openssl@3 curl
-      - run: cargo check -p faucet-stream --no-default-features --features ${{ matrix.feature }}
+      - name: Check feature in isolation
+        run: |
+          # Secrets features live in faucet-cli (CLI interpolation layer), not
+          # in the faucet-stream umbrella crate. Route accordingly.
+          if [[ "${{ matrix.feature }}" == secrets-* ]]; then
+            cargo check -p faucet-cli --no-default-features --features ${{ matrix.feature }}
+          else
+            cargo check -p faucet-stream --no-default-features --features ${{ matrix.feature }}
+          fi
 
   cli-build:
     name: CLI build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,6 +147,7 @@ aws-sdk-secretsmanager = "1"
 aws-config = { version = "1", features = ["behavior-version-latest"] }
 azure_security_keyvault_secrets = "1"
 azure_identity = "1"
+azure_core = "1"
 tokio-util = { version = "0.7", features = ["io"] }
 
 mongodb = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,7 +143,10 @@ uuid = { version = "1", features = ["v4", "v7"] }
 google-cloud-storage = "1.12"
 google-cloud-auth = "1.10"
 aws-sdk-s3 = "1"
+aws-sdk-secretsmanager = "1"
 aws-config = { version = "1", features = ["behavior-version-latest"] }
+azure_security_keyvault_secrets = "1"
+azure_identity = "1"
 tokio-util = { version = "0.7", features = ["io"] }
 
 mongodb = "3"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/faucet-stream.svg)](https://crates.io/crates/faucet-stream)
 [![Docs.rs](https://docs.rs/faucet-stream/badge.svg)](https://docs.rs/faucet-stream)
+[![Guide](https://img.shields.io/badge/guide-pawansikawat.github.io-1f6feb)](https://pawansikawat.github.io/faucet-stream/)
 [![CI](https://github.com/PawanSikawat/faucet-stream/actions/workflows/ci.yml/badge.svg)](https://github.com/PawanSikawat/faucet-stream/actions/workflows/ci.yml)
 [![Coverage](https://codecov.io/gh/PawanSikawat/faucet-stream/branch/main/graph/badge.svg)](https://codecov.io/gh/PawanSikawat/faucet-stream)
 [![Downloads](https://img.shields.io/crates/d/faucet-stream.svg)](https://crates.io/crates/faucet-stream)

--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ can drop on any box or a library you compile in.
 - **A runtime, not just connectors** — incremental + resumable replication,
   PostgreSQL change-data-capture, built-in data-quality checks (13 per-record and
   per-batch assertions with quarantine routing and abort policies), dead-letter
-  queues, automatic retries, and built-in Prometheus metrics + `tracing` spans,
-  all with zero per-connector code.
+  queues, automatic retries, secrets-manager interpolation (`${vault:…}`,
+  `${aws-sm:…}`, `${gcp-sm:…}`, `${azure-kv:…}`), and built-in Prometheus
+  metrics + `tracing` spans, all with zero per-connector code.
 - **Pay only for what you use** — every connector is a Cargo feature, so a slim
   build can be just REST + JSONL, or pull in all 35 connectors with `--features full`.
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -132,7 +132,7 @@ secrets = ["secrets-vault", "secrets-aws-sm", "secrets-gcp-sm", "secrets-azure-k
 secrets-vault = ["dep:reqwest"]
 secrets-aws-sm = ["dep:aws-sdk-secretsmanager", "dep:aws-config"]
 secrets-gcp-sm = ["dep:reqwest", "dep:google-cloud-auth", "dep:base64"]
-secrets-azure-kv = ["dep:azure_security_keyvault_secrets", "dep:azure_identity"]
+secrets-azure-kv = ["dep:azure_security_keyvault_secrets", "dep:azure_identity", "dep:azure_core"]
 
 state-redis = ["dep:faucet-state-redis"]
 state-postgres = ["dep:faucet-state-postgres"]
@@ -226,6 +226,7 @@ google-cloud-auth = { workspace = true, optional = true }
 base64 = { workspace = true, optional = true }
 azure_security_keyvault_secrets = { workspace = true, optional = true }
 azure_identity = { workspace = true, optional = true }
+azure_core = { workspace = true, optional = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -126,6 +126,14 @@ compression = [
     "faucet-sink-gcs?/compression",
 ]
 
+# Secrets-manager interpolation resolvers for the config layer. None in
+# defaults — opt in per backend, or `secrets` for all four.
+secrets = ["secrets-vault", "secrets-aws-sm", "secrets-gcp-sm", "secrets-azure-kv"]
+secrets-vault = ["dep:reqwest"]
+secrets-aws-sm = ["dep:aws-sdk-secretsmanager", "dep:aws-config"]
+secrets-gcp-sm = ["dep:reqwest", "dep:google-cloud-auth", "dep:base64"]
+secrets-azure-kv = ["dep:azure_security_keyvault_secrets", "dep:azure_identity"]
+
 state-redis = ["dep:faucet-state-redis"]
 state-postgres = ["dep:faucet-state-postgres"]
 
@@ -210,6 +218,14 @@ metrics.workspace = true
 metrics-exporter-prometheus = { workspace = true, optional = true }
 uuid.workspace = true
 inquire = { version = "0.9", optional = true, default-features = false, features = ["crossterm"] }
+futures = { workspace = true }
+reqwest = { workspace = true, optional = true }
+aws-config = { workspace = true, optional = true }
+aws-sdk-secretsmanager = { workspace = true, optional = true }
+google-cloud-auth = { workspace = true, optional = true }
+base64 = { workspace = true, optional = true }
+azure_security_keyvault_secrets = { workspace = true, optional = true }
+azure_identity = { workspace = true, optional = true }
 
 [dev-dependencies]
 tempfile = "3"
@@ -219,7 +235,6 @@ wiremock = "0.6"
 serial_test = "3"
 metrics-util.workspace = true
 serde_yaml = "0.9"
-futures.workspace = true
 async-stream.workspace = true
 futures-core.workspace = true
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -210,7 +210,7 @@ serde.workspace = true
 serde_json.workspace = true
 serde_yaml = "0.9"
 thiserror.workspace = true
-tokio = { workspace = true, features = ["rt-multi-thread", "macros", "signal", "fs"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "signal", "fs", "sync"] }
 tracing.workspace = true
 tracing-subscriber = { workspace = true, optional = true }
 async-trait.workspace = true

--- a/cli/README.md
+++ b/cli/README.md
@@ -229,6 +229,10 @@ Tokens are resolved in two passes:
 | `${env:VAR}` | Load-time, before YAML parsing. |
 | `${file:./path}` | Load-time. File contents trimmed of trailing whitespace. Capped at 1 MiB — this is for small token/secret/cert files, not bulk data. |
 | `${secret:VAR}` | Load-time. Alias for `${env:VAR}` today (no at-rest redaction). |
+| `${vault:<path>[#field]}` | Load-time. HashiCorp Vault KV v2. Requires `VAULT_ADDR` + `VAULT_TOKEN`. `#field` extracts one key from a JSON secret. Build with `--features secrets-vault`. |
+| `${aws-sm:<name-or-ARN>[#field]}` | Load-time. AWS Secrets Manager. Auth: `aws-config` default chain (env / profile / instance / web-identity). Build with `--features secrets-aws-sm`. |
+| `${gcp-sm:projects/<p>/secrets/<s>/versions/<v>}` | Load-time. GCP Secret Manager (`versions/latest` ok). Auth: Application Default Credentials. Build with `--features secrets-gcp-sm`. |
+| `${azure-kv:<vault>/<secret>[/<version>]}` | Load-time. Azure Key Vault. Auth: `AZURE_*` env / managed identity / `az login`. Build with `--features secrets-azure-kv`. |
 | `${row_id.dotted.path}` | Run-time, per parent record. The `row_id` must be the id of another matrix row. |
 
 A token's form decides its meaning: a **colon** marks a load-time directive (`${env:VAR}`), while a **dot or nothing** marks a deferred row-id reference (`${users.id}`). The same rule is used by both `faucet validate` and `faucet run`, so a token like `${env.foo}` (a dot, not a colon) is consistently treated as a reference to row id `env` and rejected at validate-time rather than failing only at run-time.
@@ -352,6 +356,62 @@ Build the CLI with the feature enabled:
 ```bash
 cargo install --path cli --features compression
 ```
+
+## Secrets-manager interpolation
+
+Pull secret values directly from a secrets manager using `${scheme:reference}`
+directives anywhere in your config. Resolution happens at config-load time:
+values are fetched concurrently (up to 8 in parallel), de-duplicated, and
+substituted in place. They are never written to disk.
+
+```yaml
+auth:
+  type: bearer
+  config:
+    token: "${vault:secret/data/myapp/api#token}"
+```
+
+| Backend | Directive | Auth |
+|---------|-----------|------|
+| HashiCorp Vault KV v2 | `${vault:<path>[#field]}` | `VAULT_ADDR` + `VAULT_TOKEN` (+ optional `VAULT_NAMESPACE`) |
+| AWS Secrets Manager | `${aws-sm:<name-or-ARN>[#field]}` | `aws-config` default chain |
+| GCP Secret Manager | `${gcp-sm:projects/<p>/secrets/<s>/versions/<v>}` | Application Default Credentials |
+| Azure Key Vault | `${azure-kv:<vault>/<secret>[/<version>]}` | `AZURE_*` env / managed identity / `az login` |
+
+The `#field` selector (Vault and AWS) parses the secret body as JSON and returns
+one key. Omit it to receive the full secret body as a string.
+
+**Build features** — none compiled in by default:
+
+```bash
+cargo install faucet-cli --features secrets          # all four backends
+cargo install faucet-cli --features secrets-vault    # Vault only
+cargo install faucet-cli --features secrets-aws-sm   # AWS only
+cargo install faucet-cli --features secrets-gcp-sm   # GCP only
+cargo install faucet-cli --features secrets-azure-kv # Azure only
+```
+
+**Validation flags:**
+
+- `faucet validate pipeline.yaml` — resolves all secrets as a preflight; prints
+  `secret: <scheme>:<reference> → resolved` per reference (never the value).
+- `faucet validate --no-secrets pipeline.yaml` — grammar / structure only; no
+  network or credentials required.
+- `faucet schema secrets` — prints the grammar descriptor as JSON.
+
+**Redaction:** faucet scrubs every resolved secret value from its own tracing,
+log, and error output via a `RedactingWriter` on the tracing subscriber.
+This boundary covers faucet's own output only — connector libraries that
+debug-log deserialized config fields are outside it; never enable debug logging
+on connectors that hold resolved secrets.
+
+**Known limitation:** secret directives are resolved in connector configs,
+transforms, state, dlq, and matrix rows. They are **not** resolved in the
+top-level `auth:` catalog or `vars:` block. Put secrets in a connector's inline
+`auth:` config instead of the shared catalog until this is lifted.
+
+See the [docs-site secrets cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/secrets.html)
+for full examples and details.
 
 ## Running from environment variables (`--from-env`)
 

--- a/cli/examples/rest_to_jsonl_with_vault.yaml
+++ b/cli/examples/rest_to_jsonl_with_vault.yaml
@@ -1,0 +1,18 @@
+version: 1
+name: rest-to-jsonl-with-vault
+# Requires: VAULT_ADDR + VAULT_TOKEN in the environment, and a KV v2 secret at
+# secret/data/faucet/api with a `token` field. Build with --features secrets-vault.
+pipeline:
+  source:
+    type: rest
+    config:
+      base_url: https://api.example.com
+      path: /v1/items
+      auth:
+        type: bearer
+        config:
+          token: "${vault:secret/data/faucet/api#token}"
+  sink:
+    type: jsonl
+    config:
+      path: ./out/items.jsonl

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -115,6 +115,8 @@ pub enum SchemaTarget {
     /// JSON Schema for the `quality:` block.
     #[cfg(feature = "quality")]
     Quality,
+    /// Grammar reference for secrets-manager interpolation directives.
+    Secrets,
 }
 
 /// `faucet preview` arguments.

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -78,6 +78,10 @@ pub struct ValidateArgs {
     /// Skip auto-loading `.env` from cwd.
     #[arg(long)]
     pub no_env_file: bool,
+    /// Validate grammar and structure only — skip fetching from secrets
+    /// managers (no network / credentials needed).
+    #[arg(long)]
+    pub no_secrets: bool,
 }
 
 /// `faucet schema` arguments.

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -10,12 +10,14 @@ pub mod validate;
 
 use crate::error::CliError;
 
-/// Render any [`CliError`] to a single line on stderr.
+/// Render any [`CliError`] to a single line on stderr, scrubbing any resolved
+/// secret values that may have reached the error chain.
 pub fn report(err: &CliError) {
-    eprintln!("error: {err}");
+    use crate::secrets::registry::redact;
+    eprintln!("error: {}", redact(&err.to_string()));
     let mut src = std::error::Error::source(err);
     while let Some(s) = src {
-        eprintln!("  caused by: {s}");
+        eprintln!("  caused by: {}", redact(&s.to_string()));
         src = std::error::Error::source(s);
     }
 }

--- a/cli/src/commands/preview.rs
+++ b/cli/src/commands/preview.rs
@@ -28,7 +28,7 @@ pub async fn run(args: PreviewArgs) -> CliResult<()> {
         Some(p) => p,
         None => crate::env_loader::discover_config_path(&cwd).ok_or(CliError::NoConfigOrFromEnv)?,
     };
-    let cfg = PipelineConfig::from_path(&path)?;
+    let cfg = PipelineConfig::from_path_async(&path).await?;
     let auth = crate::auth_catalog::build_auth_catalog(cfg.auth.as_ref())?;
     let nodes = expand(&cfg)?;
     let first_root = nodes

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -56,11 +56,12 @@ pub async fn run(args: RunArgs) -> CliResult<()> {
     let cfg = if args.from_env {
         crate::env_config::from_process_env()?
     } else {
-        PipelineConfig::from_path(
+        PipelineConfig::from_path_async(
             resolved_config_path
                 .as_ref()
                 .expect("YAML mode always resolves a path above"),
-        )?
+        )
+        .await?
     };
 
     // Install observability (Prometheus + tracing) before any pipeline work.

--- a/cli/src/commands/schema.rs
+++ b/cli/src/commands/schema.rs
@@ -22,6 +22,20 @@ pub async fn run(args: SchemaArgs) -> CliResult<()> {
             serde_json::to_value(quality_schema)
                 .unwrap_or_else(|_| serde_json::json!({"type": "object"}))
         }
+        SchemaTarget::Secrets => serde_json::json!({
+            "title": "Secrets-manager interpolation grammar",
+            "schemes": {
+                "vault":    { "syntax": "${vault:<path>[#field]}", "auth": ["VAULT_ADDR", "VAULT_TOKEN", "VAULT_NAMESPACE (optional)"] },
+                "aws-sm":   { "syntax": "${aws-sm:<name-or-ARN>[#field]}", "auth": ["aws-config default credential chain"] },
+                "gcp-sm":   { "syntax": "${gcp-sm:projects/<p>/secrets/<s>/versions/<v>}", "auth": ["Application Default Credentials"] },
+                "azure-kv": { "syntax": "${azure-kv:<vault>/<secret>[/<version>]}", "auth": ["AZURE_* env / managed identity / az login"] }
+            },
+            "notes": [
+                "#field parses the secret as JSON and extracts one key (vault, aws-sm).",
+                "Resolved at config load; fetched concurrently and de-duplicated; never persisted.",
+                "Build with --features secrets (or per-backend secrets-vault / secrets-aws-sm / ...)."
+            ]
+        }),
     };
     let body = serde_json::to_string_pretty(&schema).unwrap_or_else(|_| schema.to_string());
     println!("{body}");

--- a/cli/src/commands/validate.rs
+++ b/cli/src/commands/validate.rs
@@ -22,7 +22,18 @@ pub async fn run(args: ValidateArgs) -> CliResult<()> {
         Some(p) => p,
         None => crate::env_loader::discover_config_path(&cwd).ok_or(CliError::NoConfigOrFromEnv)?,
     };
-    let cfg = PipelineConfig::from_path_async(&path).await?;
+    let cfg = if args.no_secrets {
+        // Grammar / structure only — never touch the network.
+        PipelineConfig::from_path_tolerating_secrets(&path)?
+    } else {
+        // Real preflight: report each secret reference, then resolve.
+        let refs = crate::secrets::scan_path_refs(&path)?;
+        let cfg = PipelineConfig::from_path_async(&path).await?;
+        for (scheme, reference) in &refs {
+            println!("secret: {scheme}:{reference} → resolved");
+        }
+        cfg
+    };
     let nodes = expand(&cfg)?;
 
     for node in &nodes {

--- a/cli/src/commands/validate.rs
+++ b/cli/src/commands/validate.rs
@@ -22,7 +22,7 @@ pub async fn run(args: ValidateArgs) -> CliResult<()> {
         Some(p) => p,
         None => crate::env_loader::discover_config_path(&cwd).ok_or(CliError::NoConfigOrFromEnv)?,
     };
-    let cfg = PipelineConfig::from_path(&path)?;
+    let cfg = PipelineConfig::from_path_async(&path).await?;
     let nodes = expand(&cfg)?;
 
     for node in &nodes {

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -365,6 +365,18 @@ impl PipelineConfig {
         Ok(cfg)
     }
 
+    /// Like [`from_path`] but does not reject secret directives — they are
+    /// left unresolved. Used by `validate --no-secrets`.
+    pub fn from_path_tolerating_secrets(path: impl AsRef<Path>) -> CliResult<Self> {
+        let path = path.as_ref();
+        let raw = std::fs::read_to_string(path).map_err(|source| CliError::ReadConfig {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        let interpolated = interpolate(&raw)?;
+        Self::from_text(&interpolated, path)
+    }
+
     /// Async load path: like [`from_path`] but resolves secret-manager
     /// directives (`${vault:…}`, `${aws-sm:…}`, …) as a final stage.
     pub async fn from_path_async(path: impl AsRef<Path>) -> CliResult<Self> {

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -347,6 +347,10 @@ impl PipelineConfig {
     /// Load a pipeline config from disk. The file extension determines the
     /// parser: `.yaml` / `.yml` → YAML, `.json` → JSON. Other extensions are
     /// rejected.
+    ///
+    /// Secret directives (`${vault:…}`, `${aws-sm:…}`, etc.) are **not**
+    /// resolved by this path. If any are present the call returns
+    /// `CliError::SecretsRequireAsyncLoad` — use [`from_path_async`] instead.
     pub fn from_path(path: impl AsRef<Path>) -> CliResult<Self> {
         let path = path.as_ref();
         let raw = std::fs::read_to_string(path).map_err(|source| CliError::ReadConfig {
@@ -354,7 +358,25 @@ impl PipelineConfig {
             source,
         })?;
         let interpolated = interpolate(&raw)?;
-        Self::from_text(&interpolated, path)
+        let cfg = Self::from_text(&interpolated, path)?;
+        // Secret directives need the async resolver path; never let them survive
+        // into a connector config as literal `${vault:…}` text.
+        crate::secrets::ensure_no_secret_directives(&cfg)?;
+        Ok(cfg)
+    }
+
+    /// Async load path: like [`from_path`] but resolves secret-manager
+    /// directives (`${vault:…}`, `${aws-sm:…}`, …) as a final stage.
+    pub async fn from_path_async(path: impl AsRef<Path>) -> CliResult<Self> {
+        let path = path.as_ref();
+        let raw = std::fs::read_to_string(path).map_err(|source| CliError::ReadConfig {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        let interpolated = interpolate(&raw)?;
+        let mut cfg = Self::from_text(&interpolated, path)?;
+        crate::secrets::resolve_secrets(&mut cfg).await?;
+        Ok(cfg)
     }
 
     /// Parse an already-interpolated config string. `path` is only used for
@@ -886,5 +908,43 @@ pipeline:
             cfg.pipeline.source.as_ref().unwrap().config["url"],
             "https://api.example.com/v1"
         );
+    }
+
+    #[test]
+    fn sync_from_path_errors_on_secret_directive() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("p.yaml");
+        std::fs::write(
+            &path,
+            r#"
+version: 1
+pipeline:
+  source: { type: rest, config: { url: "${vault:secret/x}" } }
+  sink:   { type: jsonl, config: { path: ./o.jsonl } }
+"#,
+        )
+        .unwrap();
+        match PipelineConfig::from_path(&path).unwrap_err() {
+            CliError::SecretsRequireAsyncLoad => {}
+            other => panic!("expected SecretsRequireAsyncLoad, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn async_from_path_loads_without_secrets() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("p.yaml");
+        std::fs::write(
+            &path,
+            r#"
+version: 1
+pipeline:
+  source: { type: rest, config: { base_url: https://x } }
+  sink:   { type: jsonl, config: { path: ./o.jsonl } }
+"#,
+        )
+        .unwrap();
+        let cfg = PipelineConfig::from_path_async(&path).await.unwrap();
+        assert_eq!(cfg.version, 1);
     }
 }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -350,7 +350,7 @@ impl PipelineConfig {
     ///
     /// Secret directives (`${vault:…}`, `${aws-sm:…}`, etc.) are **not**
     /// resolved by this path. If any are present the call returns
-    /// `CliError::SecretsRequireAsyncLoad` — use [`from_path_async`] instead.
+    /// `CliError::SecretsRequireAsyncLoad` — use [`Self::from_path_async`] instead.
     pub fn from_path(path: impl AsRef<Path>) -> CliResult<Self> {
         let path = path.as_ref();
         let raw = std::fs::read_to_string(path).map_err(|source| CliError::ReadConfig {
@@ -365,7 +365,7 @@ impl PipelineConfig {
         Ok(cfg)
     }
 
-    /// Like [`from_path`] but does not reject secret directives — they are
+    /// Like [`Self::from_path`] but does not reject secret directives — they are
     /// left unresolved. Used by `validate --no-secrets`.
     pub fn from_path_tolerating_secrets(path: impl AsRef<Path>) -> CliResult<Self> {
         let path = path.as_ref();
@@ -377,7 +377,7 @@ impl PipelineConfig {
         Self::from_text(&interpolated, path)
     }
 
-    /// Async load path: like [`from_path`] but resolves secret-manager
+    /// Async load path: like [`Self::from_path`] but resolves secret-manager
     /// directives (`${vault:…}`, `${aws-sm:…}`, …) as a final stage.
     pub async fn from_path_async(path: impl AsRef<Path>) -> CliResult<Self> {
         let path = path.as_ref();

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -335,10 +335,16 @@ mod secrets_error_tests {
         assert!(msg.contains("password"));
         assert!(msg.contains("username") && msg.contains("host"));
 
-        let e = CliError::SecretBackendDisabled { scheme: "azure-kv".into() };
+        let e = CliError::SecretBackendDisabled {
+            scheme: "azure-kv".into(),
+        };
         assert!(e.to_string().contains("secrets-azure-kv"));
 
-        assert!(CliError::SecretsRequireAsyncLoad.to_string().contains("async"));
+        assert!(
+            CliError::SecretsRequireAsyncLoad
+                .to_string()
+                .contains("async")
+        );
     }
 
     #[test]

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -255,11 +255,126 @@ pub enum CliError {
     /// silently producing a partial result.
     #[error("internal error: {0}")]
     Internal(String),
+
+    /// A secret-manager directive used a scheme whose backend feature was not
+    /// compiled into this binary.
+    #[error(
+        "secret directive uses scheme '{scheme}' but this binary was built without \
+         the `secrets-{scheme}` feature — rebuild with `--features secrets-{scheme}` (or `secrets`)"
+    )]
+    SecretBackendDisabled { scheme: String },
+
+    /// The secrets manager has no secret at the given reference.
+    #[error("secret '{reference}' not found in {scheme}")]
+    SecretNotFound { scheme: String, reference: String },
+
+    /// The secret fetch failed (network / API error).
+    #[error("failed to fetch secret '{reference}' from {scheme}: {source}")]
+    SecretFetchFailed {
+        scheme: String,
+        reference: String,
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    /// No ambient credentials were available for the backend.
+    #[error("could not authenticate to {scheme}: {hint}")]
+    SecretAuthFailed { scheme: String, hint: String },
+
+    /// A `#field` selector was used on a secret that is not JSON.
+    #[error("secret '{reference}' from {scheme} is not JSON, but a '#field' selector was used")]
+    SecretNotJson { scheme: String, reference: String },
+
+    /// A `#field` selector named a key absent from the secret JSON.
+    #[error(
+        "secret '{reference}' from {scheme} has no field '{field}' (available: {})",
+        if available.is_empty() { String::from("(none — secret is an empty object)") } else { available.join(", ") }
+    )]
+    SecretFieldMissing {
+        scheme: String,
+        reference: String,
+        field: String,
+        available: Vec<String>,
+    },
+
+    /// A secret directive was found while loading via the synchronous path.
+    #[error(
+        "config references a secrets manager (${{vault:…}} / ${{aws-sm:…}} / …) which requires \
+         the async load path — load via `faucet run`/`validate`/`preview` rather than the sync API"
+    )]
+    SecretsRequireAsyncLoad,
 }
 
 impl From<faucet_core::InstallError> for CliError {
     fn from(e: faucet_core::InstallError) -> Self {
         CliError::Observability(e.to_string())
+    }
+}
+
+#[cfg(test)]
+mod secrets_error_tests {
+    use super::*;
+
+    #[test]
+    fn secret_errors_render_reference_not_value() {
+        let e = CliError::SecretNotFound {
+            scheme: "vault".into(),
+            reference: "secret/data/app#token".into(),
+        };
+        let msg = e.to_string();
+        assert!(msg.contains("vault"));
+        assert!(msg.contains("secret/data/app#token"));
+
+        let e = CliError::SecretFieldMissing {
+            scheme: "aws-sm".into(),
+            reference: "prod/db".into(),
+            field: "password".into(),
+            available: vec!["username".into(), "host".into()],
+        };
+        let msg = e.to_string();
+        assert!(msg.contains("password"));
+        assert!(msg.contains("username") && msg.contains("host"));
+
+        let e = CliError::SecretBackendDisabled { scheme: "azure-kv".into() };
+        assert!(e.to_string().contains("secrets-azure-kv"));
+
+        assert!(CliError::SecretsRequireAsyncLoad.to_string().contains("async"));
+    }
+
+    #[test]
+    fn fetch_auth_notjson_errors_render_safely() {
+        let e = CliError::SecretFetchFailed {
+            scheme: "vault".into(),
+            reference: "secret/data/app#token".into(),
+            source: "connection refused".into(),
+        };
+        let msg = e.to_string();
+        assert!(msg.contains("vault") && msg.contains("secret/data/app#token"));
+
+        let e = CliError::SecretAuthFailed {
+            scheme: "aws-sm".into(),
+            hint: "set AWS_PROFILE".into(),
+        };
+        assert!(e.to_string().contains("aws-sm") && e.to_string().contains("set AWS_PROFILE"));
+
+        let e = CliError::SecretNotJson {
+            scheme: "vault".into(),
+            reference: "secret/raw".into(),
+        };
+        assert!(e.to_string().contains("not JSON"));
+    }
+
+    #[test]
+    fn field_missing_with_empty_available_has_no_dangling_list() {
+        let e = CliError::SecretFieldMissing {
+            scheme: "vault".into(),
+            reference: "secret/data/app".into(),
+            field: "token".into(),
+            available: vec![],
+        };
+        let msg = e.to_string();
+        assert!(!msg.ends_with("(available: )"));
+        assert!(msg.contains("token"));
     }
 }
 

--- a/cli/src/interpolate.rs
+++ b/cli/src/interpolate.rs
@@ -74,7 +74,7 @@ pub fn interpolate_record(input: &str, ctx: &HashMap<String, Value>) -> CliResul
 
 /// Walk `input` byte-by-byte, calling `resolve` on each `${...}` body.
 /// `resolve` returns `Some(s)` to substitute, or `None` to keep verbatim.
-fn rewrite<F>(input: &str, mut resolve: F) -> CliResult<String>
+pub(crate) fn rewrite<F>(input: &str, mut resolve: F) -> CliResult<String>
 where
     F: FnMut(&str) -> CliResult<Option<String>>,
 {

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -24,6 +24,7 @@ pub mod init_template;
 pub mod interpolate;
 pub mod merge;
 pub mod registry;
+pub mod secrets;
 pub mod state;
 pub mod transforms;
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -40,7 +40,7 @@ pub async fn run_from_yaml_str(yaml: &str) -> CliResult<executor::RunSummary> {
     // Parse through the same interpolate → from_text path that the binary uses,
     // but accept a bare string instead of a file path.
     let interpolated = interpolate::interpolate(yaml)?;
-    let cfg: config::PipelineConfig =
+    let mut cfg: config::PipelineConfig =
         serde_yaml::from_str(&interpolated).map_err(|e| CliError::ParseConfig {
             path: std::path::PathBuf::from("<yaml-string>"),
             message: e.to_string(),
@@ -54,6 +54,7 @@ pub async fn run_from_yaml_str(yaml: &str) -> CliResult<executor::RunSummary> {
             ),
         });
     }
+    crate::secrets::resolve_secrets(&mut cfg).await?;
     let pipeline_name = cfg.name.clone().unwrap_or_else(|| "unnamed".to_string());
     let auth = auth_catalog::build_auth_catalog(cfg.auth.as_ref())?;
     let nodes = expand::expand(&cfg)?;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -28,10 +28,11 @@ async fn main() {
 
 #[cfg(feature = "observability")]
 fn install_tracing(level: &str) {
+    use faucet_cli::secrets::registry::RedactingMakeWriter;
     let filter = EnvFilter::try_new(level).unwrap_or_else(|_| EnvFilter::new("info"));
     let _ = tracing_subscriber::fmt()
         .with_env_filter(filter)
-        .with_writer(std::io::stderr)
+        .with_writer(RedactingMakeWriter)
         .try_init();
 }
 

--- a/cli/src/secrets/aws_sm.rs
+++ b/cli/src/secrets/aws_sm.rs
@@ -4,7 +4,7 @@
 //! profile, instance profile, web identity). The SDK client is built lazily
 //! on first resolve so a config that never references aws-sm pays nothing.
 
-use super::{extract_field, split_field, SecretResolver};
+use super::{SecretResolver, extract_field, split_field};
 use crate::error::{CliError, CliResult};
 use async_trait::async_trait;
 use tokio::sync::OnceCell;
@@ -29,8 +29,7 @@ impl AwsSmResolver {
     async fn client(&self) -> &aws_sdk_secretsmanager::Client {
         self.client
             .get_or_init(|| async {
-                let conf =
-                    aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
+                let conf = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
                 aws_sdk_secretsmanager::Client::new(&conf)
             })
             .await
@@ -57,10 +56,12 @@ impl SecretResolver for AwsSmResolver {
                 reference: reference.into(),
                 source: Box::new(source),
             })?;
-        let body = out.secret_string().ok_or_else(|| CliError::SecretNotFound {
-            scheme: "aws-sm".into(),
-            reference: reference.into(),
-        })?;
+        let body = out
+            .secret_string()
+            .ok_or_else(|| CliError::SecretNotFound {
+                scheme: "aws-sm".into(),
+                reference: reference.into(),
+            })?;
         match field {
             Some(f) => extract_field("aws-sm", reference, body, f),
             None => Ok(body.to_owned()),

--- a/cli/src/secrets/aws_sm.rs
+++ b/cli/src/secrets/aws_sm.rs
@@ -1,0 +1,69 @@
+//! AWS Secrets Manager resolver (`${aws-sm:<name-or-ARN>[#field]}`).
+//!
+//! Auth: the standard `aws-config` default credential provider chain (env,
+//! profile, instance profile, web identity). The SDK client is built lazily
+//! on first resolve so a config that never references aws-sm pays nothing.
+
+use super::{extract_field, split_field, SecretResolver};
+use crate::error::{CliError, CliResult};
+use async_trait::async_trait;
+use tokio::sync::OnceCell;
+
+pub struct AwsSmResolver {
+    client: OnceCell<aws_sdk_secretsmanager::Client>,
+}
+
+impl Default for AwsSmResolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AwsSmResolver {
+    pub fn new() -> Self {
+        Self {
+            client: OnceCell::new(),
+        }
+    }
+
+    async fn client(&self) -> &aws_sdk_secretsmanager::Client {
+        self.client
+            .get_or_init(|| async {
+                let conf =
+                    aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
+                aws_sdk_secretsmanager::Client::new(&conf)
+            })
+            .await
+    }
+}
+
+#[async_trait]
+impl SecretResolver for AwsSmResolver {
+    fn scheme(&self) -> &'static str {
+        "aws-sm"
+    }
+
+    async fn resolve(&self, reference: &str) -> CliResult<String> {
+        let (secret_id, field) = split_field(reference);
+        let out = self
+            .client()
+            .await
+            .get_secret_value()
+            .secret_id(secret_id)
+            .send()
+            .await
+            .map_err(|source| CliError::SecretFetchFailed {
+                scheme: "aws-sm".into(),
+                reference: reference.into(),
+                source: Box::new(source),
+            })?;
+        let body = out.secret_string().ok_or_else(|| CliError::SecretNotFound {
+            scheme: "aws-sm".into(),
+            reference: reference.into(),
+        })?;
+        match field {
+            Some(f) => extract_field("aws-sm", reference, body, f),
+            None => Ok(body.to_owned()),
+        }
+    }
+}

--- a/cli/src/secrets/azure_kv.rs
+++ b/cli/src/secrets/azure_kv.rs
@@ -12,9 +12,7 @@ use super::SecretResolver;
 use crate::error::{CliError, CliResult};
 use async_trait::async_trait;
 use azure_core::credentials::{AccessToken, Secret, TokenCredential, TokenRequestOptions};
-use azure_identity::{
-    ClientSecretCredential, DeveloperToolsCredential, ManagedIdentityCredential,
-};
+use azure_identity::{ClientSecretCredential, DeveloperToolsCredential, ManagedIdentityCredential};
 use std::sync::Arc;
 
 // ── Chained credential ────────────────────────────────────────────────────────
@@ -79,12 +77,7 @@ fn build_credential() -> CliResult<Arc<dyn TokenCredential>> {
         std::env::var("AZURE_CLIENT_ID"),
         std::env::var("AZURE_CLIENT_SECRET"),
     ) {
-        match ClientSecretCredential::new(
-            &tenant_id,
-            client_id,
-            Secret::new(client_secret),
-            None,
-        ) {
+        match ClientSecretCredential::new(&tenant_id, client_id, Secret::new(client_secret), None) {
             Ok(cred) => sources.push(cred),
             Err(e) => {
                 tracing::debug!("Azure ClientSecretCredential build failed: {e}");
@@ -142,20 +135,24 @@ impl SecretResolver for AzureKvResolver {
         // reference = "<vault>/<secret>[/<version>]"
         let mut parts = reference.splitn(3, '/');
 
-        let vault = parts.next().filter(|s| !s.is_empty()).ok_or_else(|| {
-            CliError::SecretFetchFailed {
-                scheme: "azure-kv".into(),
-                reference: reference.into(),
-                source: "expected '<vault>/<secret>[/<version>]'".into(),
-            }
-        })?;
-        let secret_name = parts.next().filter(|s| !s.is_empty()).ok_or_else(|| {
-            CliError::SecretFetchFailed {
-                scheme: "azure-kv".into(),
-                reference: reference.into(),
-                source: "expected '<vault>/<secret>[/<version>]'".into(),
-            }
-        })?;
+        let vault =
+            parts
+                .next()
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| CliError::SecretFetchFailed {
+                    scheme: "azure-kv".into(),
+                    reference: reference.into(),
+                    source: "expected '<vault>/<secret>[/<version>]'".into(),
+                })?;
+        let secret_name =
+            parts
+                .next()
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| CliError::SecretFetchFailed {
+                    scheme: "azure-kv".into(),
+                    reference: reference.into(),
+                    source: "expected '<vault>/<secret>[/<version>]'".into(),
+                })?;
         let version = parts.next().filter(|s| !s.is_empty());
 
         let credential = build_credential()?;
@@ -177,24 +174,21 @@ impl SecretResolver for AzureKvResolver {
             }
         });
 
-        let resp = client
-            .get_secret(secret_name, options)
-            .await
-            .map_err(|e| CliError::SecretFetchFailed {
+        let resp = client.get_secret(secret_name, options).await.map_err(|e| {
+            CliError::SecretFetchFailed {
                 scheme: "azure-kv".into(),
                 reference: reference.into(),
                 source: Box::new(e),
-            })?;
+            }
+        })?;
 
         // `Response<Secret>::into_model()` is sync and deserializes the body
         // into the typed `Secret` model (the JSON format is inferred from F).
-        let secret = resp
-            .into_model()
-            .map_err(|e| CliError::SecretFetchFailed {
-                scheme: "azure-kv".into(),
-                reference: reference.into(),
-                source: Box::new(e),
-            })?;
+        let secret = resp.into_model().map_err(|e| CliError::SecretFetchFailed {
+            scheme: "azure-kv".into(),
+            reference: reference.into(),
+            source: Box::new(e),
+        })?;
 
         secret.value.ok_or_else(|| CliError::SecretNotFound {
             scheme: "azure-kv".into(),

--- a/cli/src/secrets/azure_kv.rs
+++ b/cli/src/secrets/azure_kv.rs
@@ -1,0 +1,204 @@
+//! Azure Key Vault resolver (`${azure-kv:<vault>/<secret>[/<version>]}`).
+//!
+//! Auth: chained credential that tries, in order:
+//!   1. `ClientSecretCredential` if AZURE_TENANT_ID + AZURE_CLIENT_ID +
+//!      AZURE_CLIENT_SECRET are all set.
+//!   2. `ManagedIdentityCredential` (Azure VM / App Service / AKS pod identity).
+//!   3. `DeveloperToolsCredential` (Azure CLI / Azure Developer CLI).
+//!
+//! No emulator exists; a live test gated on `AZURE_TEST=1` may be added later.
+
+use super::SecretResolver;
+use crate::error::{CliError, CliResult};
+use async_trait::async_trait;
+use azure_core::credentials::{AccessToken, Secret, TokenCredential, TokenRequestOptions};
+use azure_identity::{
+    ClientSecretCredential, DeveloperToolsCredential, ManagedIdentityCredential,
+};
+use std::sync::Arc;
+
+// ── Chained credential ────────────────────────────────────────────────────────
+
+/// A lightweight credential chain: tries each source in order, returning the
+/// first successful token or aggregating errors if all fail.
+struct ChainedCredential {
+    sources: Vec<Arc<dyn TokenCredential>>,
+}
+
+impl ChainedCredential {
+    fn new(sources: Vec<Arc<dyn TokenCredential>>) -> Arc<Self> {
+        Arc::new(Self { sources })
+    }
+}
+
+impl std::fmt::Debug for ChainedCredential {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ChainedCredential")
+            .field("sources_len", &self.sources.len())
+            .finish()
+    }
+}
+
+#[async_trait]
+impl TokenCredential for ChainedCredential {
+    async fn get_token(
+        &self,
+        scopes: &[&str],
+        options: Option<TokenRequestOptions<'_>>,
+    ) -> azure_core::Result<AccessToken> {
+        let mut errors = Vec::new();
+        for source in &self.sources {
+            match source.get_token(scopes, options.clone()).await {
+                Ok(token) => return Ok(token),
+                Err(e) => errors.push(e.to_string()),
+            }
+        }
+        Err(azure_core::Error::with_message(
+            azure_core::error::ErrorKind::Credential,
+            format!(
+                "All Azure credential sources failed:\n{}",
+                errors.join("\n")
+            ),
+        ))
+    }
+}
+
+// ── Credential builder ────────────────────────────────────────────────────────
+
+/// Build the default Azure credential chain for this resolver.
+///
+/// Returns `CliError::SecretAuthFailed` if even the chain cannot be constructed
+/// (which should only happen if the Azure identity library itself is broken).
+fn build_credential() -> CliResult<Arc<dyn TokenCredential>> {
+    let mut sources: Vec<Arc<dyn TokenCredential>> = Vec::new();
+
+    // 1. Service-principal via env vars (AZURE_TENANT_ID + AZURE_CLIENT_ID +
+    //    AZURE_CLIENT_SECRET). Try only when all three are present.
+    if let (Ok(tenant_id), Ok(client_id), Ok(client_secret)) = (
+        std::env::var("AZURE_TENANT_ID"),
+        std::env::var("AZURE_CLIENT_ID"),
+        std::env::var("AZURE_CLIENT_SECRET"),
+    ) {
+        match ClientSecretCredential::new(
+            &tenant_id,
+            client_id,
+            Secret::new(client_secret),
+            None,
+        ) {
+            Ok(cred) => sources.push(cred),
+            Err(e) => {
+                tracing::debug!("Azure ClientSecretCredential build failed: {e}");
+            }
+        }
+    }
+
+    // 2. Managed identity (VM / App Service / AKS).
+    match ManagedIdentityCredential::new(None) {
+        Ok(cred) => sources.push(cred),
+        Err(e) => tracing::debug!("Azure ManagedIdentityCredential build failed: {e}"),
+    }
+
+    // 3. Developer tools (Azure CLI / Azure Developer CLI).
+    match DeveloperToolsCredential::new(None) {
+        Ok(cred) => sources.push(cred),
+        Err(e) => tracing::debug!("Azure DeveloperToolsCredential build failed: {e}"),
+    }
+
+    if sources.is_empty() {
+        return Err(CliError::SecretAuthFailed {
+            scheme: "azure-kv".into(),
+            hint: "no Azure credentials available — set AZURE_TENANT_ID / AZURE_CLIENT_ID / \
+                   AZURE_CLIENT_SECRET, use a managed identity, or run `az login`"
+                .into(),
+        });
+    }
+
+    Ok(ChainedCredential::new(sources))
+}
+
+// ── Resolver ──────────────────────────────────────────────────────────────────
+
+pub struct AzureKvResolver;
+
+impl AzureKvResolver {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for AzureKvResolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl SecretResolver for AzureKvResolver {
+    fn scheme(&self) -> &'static str {
+        "azure-kv"
+    }
+
+    async fn resolve(&self, reference: &str) -> CliResult<String> {
+        // reference = "<vault>/<secret>[/<version>]"
+        let mut parts = reference.splitn(3, '/');
+
+        let vault = parts.next().filter(|s| !s.is_empty()).ok_or_else(|| {
+            CliError::SecretFetchFailed {
+                scheme: "azure-kv".into(),
+                reference: reference.into(),
+                source: "expected '<vault>/<secret>[/<version>]'".into(),
+            }
+        })?;
+        let secret_name = parts.next().filter(|s| !s.is_empty()).ok_or_else(|| {
+            CliError::SecretFetchFailed {
+                scheme: "azure-kv".into(),
+                reference: reference.into(),
+                source: "expected '<vault>/<secret>[/<version>]'".into(),
+            }
+        })?;
+        let version = parts.next().filter(|s| !s.is_empty());
+
+        let credential = build_credential()?;
+
+        let vault_url = format!("https://{vault}.vault.azure.net/");
+        let client =
+            azure_security_keyvault_secrets::SecretClient::new(&vault_url, credential, None)
+                .map_err(|e| CliError::SecretFetchFailed {
+                    scheme: "azure-kv".into(),
+                    reference: reference.into(),
+                    source: Box::new(e),
+                })?;
+
+        // Version goes in the options struct, NOT a positional arg.
+        let options = version.map(|v| {
+            azure_security_keyvault_secrets::models::SecretClientGetSecretOptions {
+                secret_version: Some(v.to_string()),
+                ..Default::default()
+            }
+        });
+
+        let resp = client
+            .get_secret(secret_name, options)
+            .await
+            .map_err(|e| CliError::SecretFetchFailed {
+                scheme: "azure-kv".into(),
+                reference: reference.into(),
+                source: Box::new(e),
+            })?;
+
+        // `Response<Secret>::into_model()` is sync and deserializes the body
+        // into the typed `Secret` model (the JSON format is inferred from F).
+        let secret = resp
+            .into_model()
+            .map_err(|e| CliError::SecretFetchFailed {
+                scheme: "azure-kv".into(),
+                reference: reference.into(),
+                source: Box::new(e),
+            })?;
+
+        secret.value.ok_or_else(|| CliError::SecretNotFound {
+            scheme: "azure-kv".into(),
+            reference: reference.into(),
+        })
+    }
+}

--- a/cli/src/secrets/gcp_sm.rs
+++ b/cli/src/secrets/gcp_sm.rs
@@ -93,11 +93,14 @@ impl SecretResolver for GcpSmResolver {
                 reference: reference.into(),
                 source: Box::new(source),
             })?;
-        let body: Value = resp.json().await.map_err(|source| CliError::SecretFetchFailed {
-            scheme: "gcp-sm".into(),
-            reference: reference.into(),
-            source: Box::new(source),
-        })?;
+        let body: Value = resp
+            .json()
+            .await
+            .map_err(|source| CliError::SecretFetchFailed {
+                scheme: "gcp-sm".into(),
+                reference: reference.into(),
+                source: Box::new(source),
+            })?;
         let b64 = body["payload"]["data"]
             .as_str()
             .ok_or_else(|| CliError::SecretNotFound {
@@ -127,7 +130,9 @@ mod tests {
     fn decodes_base64_payload() {
         // Guards the decode/utf8 logic independently of the token fetch.
         let b64 = base64::engine::general_purpose::STANDARD.encode("my-secret");
-        let decoded = base64::engine::general_purpose::STANDARD.decode(&b64).unwrap();
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(&b64)
+            .unwrap();
         assert_eq!(String::from_utf8(decoded).unwrap(), "my-secret");
     }
 }

--- a/cli/src/secrets/gcp_sm.rs
+++ b/cli/src/secrets/gcp_sm.rs
@@ -1,0 +1,133 @@
+//! GCP Secret Manager resolver
+//! (`${gcp-sm:projects/<p>/secrets/<s>/versions/<v>}`).
+//!
+//! Auth: Application Default Credentials via `google-cloud-auth` (same chain
+//! `faucet-gcs-common` uses). Fetches via the REST `:access` endpoint and
+//! base64-decodes the payload.
+
+use super::SecretResolver;
+use crate::error::{CliError, CliResult};
+use async_trait::async_trait;
+use base64::Engine;
+use google_cloud_auth::credentials::AccessTokenCredentials;
+use serde_json::Value;
+use tokio::sync::OnceCell;
+
+pub struct GcpSmResolver {
+    client: reqwest::Client,
+    creds: OnceCell<AccessTokenCredentials>,
+}
+
+impl GcpSmResolver {
+    pub fn new() -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            creds: OnceCell::new(),
+        }
+    }
+
+    /// Obtain an ADC access token, building (and caching) the credentials on
+    /// first use.
+    async fn token(&self) -> CliResult<String> {
+        let creds = self
+            .creds
+            .get_or_try_init(|| async {
+                google_cloud_auth::credentials::Builder::default()
+                    .build_access_token_credentials()
+                    .map_err(|e| CliError::SecretAuthFailed {
+                        scheme: "gcp-sm".into(),
+                        hint: format!(
+                            "no Application Default Credentials ({e}) — run \
+                             `gcloud auth application-default login` or set GOOGLE_APPLICATION_CREDENTIALS"
+                        ),
+                    })
+            })
+            .await?;
+        let access = creds
+            .access_token()
+            .await
+            .map_err(|e| CliError::SecretAuthFailed {
+                scheme: "gcp-sm".into(),
+                hint: format!("failed to obtain an ADC access token: {e}"),
+            })?;
+        Ok(access.token)
+    }
+}
+
+impl Default for GcpSmResolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl SecretResolver for GcpSmResolver {
+    fn scheme(&self) -> &'static str {
+        "gcp-sm"
+    }
+
+    async fn resolve(&self, reference: &str) -> CliResult<String> {
+        let token = self.token().await?;
+        let url = format!("https://secretmanager.googleapis.com/v1/{reference}:access");
+        let resp = self
+            .client
+            .get(&url)
+            .bearer_auth(&token)
+            .send()
+            .await
+            .map_err(|source| CliError::SecretFetchFailed {
+                scheme: "gcp-sm".into(),
+                reference: reference.into(),
+                source: Box::new(source),
+            })?;
+        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            return Err(CliError::SecretNotFound {
+                scheme: "gcp-sm".into(),
+                reference: reference.into(),
+            });
+        }
+        let resp = resp
+            .error_for_status()
+            .map_err(|source| CliError::SecretFetchFailed {
+                scheme: "gcp-sm".into(),
+                reference: reference.into(),
+                source: Box::new(source),
+            })?;
+        let body: Value = resp.json().await.map_err(|source| CliError::SecretFetchFailed {
+            scheme: "gcp-sm".into(),
+            reference: reference.into(),
+            source: Box::new(source),
+        })?;
+        let b64 = body["payload"]["data"]
+            .as_str()
+            .ok_or_else(|| CliError::SecretNotFound {
+                scheme: "gcp-sm".into(),
+                reference: reference.into(),
+            })?;
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(b64)
+            .map_err(|source| CliError::SecretFetchFailed {
+                scheme: "gcp-sm".into(),
+                reference: reference.into(),
+                source: Box::new(source),
+            })?;
+        String::from_utf8(bytes).map_err(|source| CliError::SecretFetchFailed {
+            scheme: "gcp-sm".into(),
+            reference: reference.into(),
+            source: Box::new(source),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use base64::Engine;
+
+    #[test]
+    fn decodes_base64_payload() {
+        // Guards the decode/utf8 logic independently of the token fetch.
+        let b64 = base64::engine::general_purpose::STANDARD.encode("my-secret");
+        let decoded = base64::engine::general_purpose::STANDARD.decode(&b64).unwrap();
+        assert_eq!(String::from_utf8(decoded).unwrap(), "my-secret");
+    }
+}

--- a/cli/src/secrets/mod.rs
+++ b/cli/src/secrets/mod.rs
@@ -270,10 +270,16 @@ fn visit_config_values_mut<F: FnMut(&mut Value) -> CliResult<()>>(
 }
 
 /// Collect every unique secret reference across the whole config.
-fn scan_config(cfg: &PipelineConfig) -> BTreeSet<SecretRef> {
+pub(crate) fn scan_config(cfg: &PipelineConfig) -> BTreeSet<SecretRef> {
     let mut refs = BTreeSet::new();
     visit_config_values(cfg, |v| collect_refs(v, &mut refs));
     refs
+}
+
+/// Parse `path` (tolerating secret directives) and return its unique secret refs.
+pub fn scan_path_refs(path: &std::path::Path) -> CliResult<BTreeSet<SecretRef>> {
+    let cfg = PipelineConfig::from_path_tolerating_secrets(path)?;
+    Ok(scan_config(&cfg))
 }
 
 /// Error with `SecretsRequireAsyncLoad` if any secret directive is present.

--- a/cli/src/secrets/mod.rs
+++ b/cli/src/secrets/mod.rs
@@ -14,11 +14,14 @@ mod gcp_sm;
 #[cfg(feature = "secrets-vault")]
 mod vault;
 
+use crate::config::PipelineConfig;
 use crate::error::{CliError, CliResult};
 use crate::interpolate::{self, Directive};
 use async_trait::async_trait;
+use futures::stream::{self, StreamExt, TryStreamExt};
 use serde_json::Value;
 use std::collections::{BTreeSet, HashMap};
+use std::sync::Arc;
 
 /// The four secret-manager schemes this layer recognises.
 pub const SECRET_SCHEMES: &[&str] = &["vault", "aws-sm", "gcp-sm", "azure-kv"];
@@ -131,6 +134,210 @@ pub fn substitute(value: &mut Value, cache: &HashMap<SecretRef, String>) -> CliR
     })
 }
 
+/// Map of scheme → resolver, built from compiled-in features (or injected in tests).
+#[derive(Default, Clone)]
+pub struct ResolverSet {
+    resolvers: HashMap<&'static str, Arc<dyn SecretResolver>>,
+}
+
+impl ResolverSet {
+    pub fn insert(&mut self, resolver: Arc<dyn SecretResolver>) {
+        self.resolvers.insert(resolver.scheme(), resolver);
+    }
+    fn get(&self, scheme: &str) -> Option<&Arc<dyn SecretResolver>> {
+        self.resolvers.get(scheme)
+    }
+}
+
+/// Construct the resolver for one scheme, or `SecretBackendDisabled` if the
+/// feature was not compiled in. Constructors are cheap (no network / client
+/// init) — heavy clients are built lazily on first `resolve`.
+fn make_resolver(scheme: &str) -> CliResult<Arc<dyn SecretResolver>> {
+    match scheme {
+        #[cfg(feature = "secrets-vault")]
+        "vault" => Ok(Arc::new(vault::VaultResolver::from_env()?)),
+        #[cfg(feature = "secrets-aws-sm")]
+        "aws-sm" => Ok(Arc::new(aws_sm::AwsSmResolver::new())),
+        #[cfg(feature = "secrets-gcp-sm")]
+        "gcp-sm" => Ok(Arc::new(gcp_sm::GcpSmResolver::new())),
+        #[cfg(feature = "secrets-azure-kv")]
+        "azure-kv" => Ok(Arc::new(azure_kv::AzureKvResolver::new())),
+        other => Err(CliError::SecretBackendDisabled {
+            scheme: other.to_owned(),
+        }),
+    }
+}
+
+/// Apply a read-only closure to every config `Value` location (mirrors
+/// `resolve_config_refs`'s traversal).
+fn visit_config_values<F: FnMut(&Value)>(cfg: &PipelineConfig, mut f: F) {
+    for spec in cfg.pipeline.sources.values() {
+        f(&spec.config);
+    }
+    for spec in cfg.pipeline.sinks.values() {
+        f(&spec.config);
+    }
+    if let Some(spec) = cfg.pipeline.source.as_ref() {
+        f(&spec.config);
+    }
+    if let Some(spec) = cfg.pipeline.sink.as_ref() {
+        f(&spec.config);
+    }
+    for t in cfg.pipeline.transforms.iter() {
+        f(&t.config);
+    }
+    if let Some(s) = cfg.pipeline.state.as_ref() {
+        f(&s.config);
+    }
+    if let Some(d) = cfg.pipeline.dlq.as_ref() {
+        f(&d.sink.config);
+    }
+    for row in cfg.matrix.iter() {
+        if let Some(p) = row.source.as_ref()
+            && let Some(c) = p.config.as_ref()
+        {
+            f(c);
+        }
+        if let Some(p) = row.sink.as_ref()
+            && let Some(c) = p.config.as_ref()
+        {
+            f(c);
+        }
+        if let Some(ts) = row.transforms.as_ref() {
+            for t in ts.iter() {
+                f(&t.config);
+            }
+        }
+        if let Some(s) = row.state.as_ref() {
+            f(&s.config);
+        }
+        if let Some(Some(d)) = row.dlq.as_ref() {
+            f(&d.sink.config);
+        }
+    }
+}
+
+/// Apply a mutating, fallible closure to every config `Value` location.
+fn visit_config_values_mut<F: FnMut(&mut Value) -> CliResult<()>>(
+    cfg: &mut PipelineConfig,
+    mut f: F,
+) -> CliResult<()> {
+    for spec in cfg.pipeline.sources.values_mut() {
+        f(&mut spec.config)?;
+    }
+    for spec in cfg.pipeline.sinks.values_mut() {
+        f(&mut spec.config)?;
+    }
+    if let Some(spec) = cfg.pipeline.source.as_mut() {
+        f(&mut spec.config)?;
+    }
+    if let Some(spec) = cfg.pipeline.sink.as_mut() {
+        f(&mut spec.config)?;
+    }
+    for t in cfg.pipeline.transforms.iter_mut() {
+        f(&mut t.config)?;
+    }
+    if let Some(s) = cfg.pipeline.state.as_mut() {
+        f(&mut s.config)?;
+    }
+    if let Some(d) = cfg.pipeline.dlq.as_mut() {
+        f(&mut d.sink.config)?;
+    }
+    for row in cfg.matrix.iter_mut() {
+        if let Some(p) = row.source.as_mut()
+            && let Some(c) = p.config.as_mut()
+        {
+            f(c)?;
+        }
+        if let Some(p) = row.sink.as_mut()
+            && let Some(c) = p.config.as_mut()
+        {
+            f(c)?;
+        }
+        if let Some(ts) = row.transforms.as_mut() {
+            for t in ts.iter_mut() {
+                f(&mut t.config)?;
+            }
+        }
+        if let Some(s) = row.state.as_mut() {
+            f(&mut s.config)?;
+        }
+        if let Some(Some(d)) = row.dlq.as_mut() {
+            f(&mut d.sink.config)?;
+        }
+    }
+    Ok(())
+}
+
+/// Collect every unique secret reference across the whole config.
+fn scan_config(cfg: &PipelineConfig) -> BTreeSet<SecretRef> {
+    let mut refs = BTreeSet::new();
+    visit_config_values(cfg, |v| collect_refs(v, &mut refs));
+    refs
+}
+
+/// Error with `SecretsRequireAsyncLoad` if any secret directive is present.
+/// Called by the synchronous `from_path` so secrets never silently survive.
+pub fn ensure_no_secret_directives(cfg: &PipelineConfig) -> CliResult<()> {
+    if scan_config(cfg).is_empty() {
+        Ok(())
+    } else {
+        Err(CliError::SecretsRequireAsyncLoad)
+    }
+}
+
+/// Production entry point: resolve all secret directives in `cfg` in place.
+/// Builds resolvers only for the schemes actually referenced.
+pub async fn resolve_secrets(cfg: &mut PipelineConfig) -> CliResult<()> {
+    let refs = scan_config(cfg);
+    if refs.is_empty() {
+        return Ok(());
+    }
+    let mut set = ResolverSet::default();
+    let schemes: BTreeSet<&str> = refs.iter().map(|(s, _)| s.as_str()).collect();
+    for scheme in schemes {
+        set.insert(make_resolver(scheme)?);
+    }
+    resolve_secrets_with(cfg, &set).await
+}
+
+/// Resolve all secret directives using a caller-supplied resolver set (the
+/// seam used by tests to inject fakes).
+pub async fn resolve_secrets_with(cfg: &mut PipelineConfig, set: &ResolverSet) -> CliResult<()> {
+    let refs = scan_config(cfg);
+    if refs.is_empty() {
+        return Ok(());
+    }
+    let cache = fetch_all(&refs, set).await?;
+    visit_config_values_mut(cfg, |v| substitute(v, &cache))
+}
+
+/// Fetch every reference concurrently (bounded), de-duplicated by the result
+/// map, registering each resolved value for redaction.
+async fn fetch_all(
+    refs: &BTreeSet<SecretRef>,
+    set: &ResolverSet,
+) -> CliResult<HashMap<SecretRef, String>> {
+    const MAX_CONCURRENCY: usize = 8;
+    let pairs: Vec<(SecretRef, String)> = stream::iter(refs.iter().cloned())
+        .map(|(scheme, reference)| async move {
+            // Clone the Arc so each concurrent future owns its resolver rather
+            // than borrowing `set` across the await point.
+            let resolver = Arc::clone(set.get(&scheme).ok_or_else(|| {
+                CliError::SecretBackendDisabled {
+                    scheme: scheme.clone(),
+                }
+            })?);
+            let value = resolver.resolve(&reference).await?;
+            registry::register(&value);
+            Ok::<(SecretRef, String), CliError>(((scheme, reference), value))
+        })
+        .buffer_unordered(MAX_CONCURRENCY)
+        .try_collect()
+        .await?;
+    Ok(pairs.into_iter().collect())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -184,5 +391,72 @@ mod tests {
             CliError::SecretNotJson { .. } => {}
             other => panic!("expected SecretNotJson, got {other:?}"),
         }
+    }
+
+    struct FakeResolver {
+        scheme: &'static str,
+        value: String,
+    }
+    #[async_trait]
+    impl SecretResolver for FakeResolver {
+        fn scheme(&self) -> &'static str {
+            self.scheme
+        }
+        async fn resolve(&self, _reference: &str) -> CliResult<String> {
+            Ok(self.value.clone())
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_secrets_with_substitutes_via_injected_resolvers() {
+        let mut set = ResolverSet::default();
+        set.insert(Arc::new(FakeResolver {
+            scheme: "vault",
+            value: "RESOLVED".into(),
+        }));
+        let cfg_yaml = r#"
+version: 1
+pipeline:
+  source: { type: rest, config: { base_url: https://x, auth: { type: bearer, config: { token: "${vault:secret/data/app#token}" } } } }
+  sink:   { type: jsonl, config: { path: ./o.jsonl } }
+"#;
+        let mut cfg =
+            PipelineConfig::from_text(cfg_yaml, std::path::Path::new("p.yaml")).unwrap();
+        resolve_secrets_with(&mut cfg, &set).await.unwrap();
+        let token = &cfg.pipeline.source.as_ref().unwrap().config["auth"]["config"]["token"];
+        assert_eq!(token, "RESOLVED");
+    }
+
+    #[tokio::test]
+    async fn resolve_secrets_errors_when_backend_not_built() {
+        let set = ResolverSet::default();
+        let cfg_yaml = r#"
+version: 1
+pipeline:
+  source: { type: rest, config: { url: "${vault:secret/x}" } }
+  sink:   { type: jsonl, config: { path: ./o.jsonl } }
+"#;
+        let mut cfg =
+            PipelineConfig::from_text(cfg_yaml, std::path::Path::new("p.yaml")).unwrap();
+        match resolve_secrets_with(&mut cfg, &set).await.unwrap_err() {
+            CliError::SecretBackendDisabled { scheme } => assert_eq!(scheme, "vault"),
+            other => panic!("expected SecretBackendDisabled, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ensure_no_secret_directives_flags_vault() {
+        let cfg_yaml = r#"
+version: 1
+pipeline:
+  source: { type: rest, config: { url: "${vault:secret/x}" } }
+  sink:   { type: jsonl, config: { path: ./o.jsonl } }
+"#;
+        let cfg =
+            PipelineConfig::from_text(cfg_yaml, std::path::Path::new("p.yaml")).unwrap();
+        assert!(matches!(
+            ensure_no_secret_directives(&cfg),
+            Err(CliError::SecretsRequireAsyncLoad)
+        ));
     }
 }

--- a/cli/src/secrets/mod.rs
+++ b/cli/src/secrets/mod.rs
@@ -119,14 +119,14 @@ pub fn collect_refs(value: &Value, out: &mut BTreeSet<SecretRef>) {
 pub fn substitute(value: &mut Value, cache: &HashMap<SecretRef, String>) -> CliResult<()> {
     for_each_string_mut(value, &mut |s| {
         let new = interpolate::rewrite(s, |body| match interpolate::classify_directive(body) {
-            Directive::LoadTime { prefix, body: b } if SECRET_SCHEMES.contains(&prefix) => Ok(
-                Some(
+            Directive::LoadTime { prefix, body: b } if SECRET_SCHEMES.contains(&prefix) => {
+                Ok(Some(
                     cache
                         .get(&(prefix.to_owned(), b.to_owned()))
                         .cloned()
                         .expect("scan collected every secret ref before fetch"),
-                ),
-            ),
+                ))
+            }
             _ => Ok(None),
         })?;
         *s = new;
@@ -325,22 +325,23 @@ async fn fetch_all(
     set: &ResolverSet,
 ) -> CliResult<HashMap<SecretRef, String>> {
     const MAX_CONCURRENCY: usize = 8;
-    let pairs: Vec<(SecretRef, String)> = stream::iter(refs.iter().cloned())
-        .map(|(scheme, reference)| async move {
-            // Clone the Arc so each concurrent future owns its resolver rather
-            // than borrowing `set` across the await point.
-            let resolver = Arc::clone(set.get(&scheme).ok_or_else(|| {
-                CliError::SecretBackendDisabled {
-                    scheme: scheme.clone(),
-                }
-            })?);
-            let value = resolver.resolve(&reference).await?;
-            registry::register(&value);
-            Ok::<(SecretRef, String), CliError>(((scheme, reference), value))
-        })
-        .buffer_unordered(MAX_CONCURRENCY)
-        .try_collect()
-        .await?;
+    let pairs: Vec<(SecretRef, String)> =
+        stream::iter(refs.iter().cloned())
+            .map(|(scheme, reference)| async move {
+                // Clone the Arc so each concurrent future owns its resolver rather
+                // than borrowing `set` across the await point.
+                let resolver = Arc::clone(set.get(&scheme).ok_or_else(|| {
+                    CliError::SecretBackendDisabled {
+                        scheme: scheme.clone(),
+                    }
+                })?);
+                let value = resolver.resolve(&reference).await?;
+                registry::register(&value);
+                Ok::<(SecretRef, String), CliError>(((scheme, reference), value))
+            })
+            .buffer_unordered(MAX_CONCURRENCY)
+            .try_collect()
+            .await?;
     Ok(pairs.into_iter().collect())
 }
 
@@ -377,7 +378,10 @@ mod tests {
             "path": "/v1/${users.id}"
         });
         let mut cache = HashMap::new();
-        cache.insert(("vault".into(), "secret/data/app#token".into()), "abc123".into());
+        cache.insert(
+            ("vault".into(), "secret/data/app#token".into()),
+            "abc123".into(),
+        );
         substitute(&mut v, &cache).unwrap();
         assert_eq!(v["token"], "Bearer abc123");
         assert_eq!(v["path"], "/v1/${users.id}");
@@ -386,7 +390,10 @@ mod tests {
     #[test]
     fn extract_field_picks_key_or_errors_with_available() {
         let body = r#"{"username":"u","password":"p"}"#;
-        assert_eq!(extract_field("aws-sm", "ref", body, "password").unwrap(), "p");
+        assert_eq!(
+            extract_field("aws-sm", "ref", body, "password").unwrap(),
+            "p"
+        );
         match extract_field("aws-sm", "ref", body, "missing").unwrap_err() {
             CliError::SecretFieldMissing { available, .. } => {
                 assert!(available.contains(&"username".to_string()));
@@ -426,8 +433,7 @@ pipeline:
   source: { type: rest, config: { base_url: https://x, auth: { type: bearer, config: { token: "${vault:secret/data/app#token}" } } } }
   sink:   { type: jsonl, config: { path: ./o.jsonl } }
 "#;
-        let mut cfg =
-            PipelineConfig::from_text(cfg_yaml, std::path::Path::new("p.yaml")).unwrap();
+        let mut cfg = PipelineConfig::from_text(cfg_yaml, std::path::Path::new("p.yaml")).unwrap();
         resolve_secrets_with(&mut cfg, &set).await.unwrap();
         let token = &cfg.pipeline.source.as_ref().unwrap().config["auth"]["config"]["token"];
         assert_eq!(token, "RESOLVED");
@@ -442,8 +448,7 @@ pipeline:
   source: { type: rest, config: { url: "${vault:secret/x}" } }
   sink:   { type: jsonl, config: { path: ./o.jsonl } }
 "#;
-        let mut cfg =
-            PipelineConfig::from_text(cfg_yaml, std::path::Path::new("p.yaml")).unwrap();
+        let mut cfg = PipelineConfig::from_text(cfg_yaml, std::path::Path::new("p.yaml")).unwrap();
         match resolve_secrets_with(&mut cfg, &set).await.unwrap_err() {
             CliError::SecretBackendDisabled { scheme } => assert_eq!(scheme, "vault"),
             other => panic!("expected SecretBackendDisabled, got {other:?}"),
@@ -458,8 +463,7 @@ pipeline:
   source: { type: rest, config: { url: "${vault:secret/x}" } }
   sink:   { type: jsonl, config: { path: ./o.jsonl } }
 "#;
-        let cfg =
-            PipelineConfig::from_text(cfg_yaml, std::path::Path::new("p.yaml")).unwrap();
+        let cfg = PipelineConfig::from_text(cfg_yaml, std::path::Path::new("p.yaml")).unwrap();
         assert!(matches!(
             ensure_no_secret_directives(&cfg),
             Err(CliError::SecretsRequireAsyncLoad)

--- a/cli/src/secrets/mod.rs
+++ b/cli/src/secrets/mod.rs
@@ -1,0 +1,3 @@
+//! Secrets-manager interpolation for the config layer (#125).
+
+pub mod registry;

--- a/cli/src/secrets/mod.rs
+++ b/cli/src/secrets/mod.rs
@@ -1,3 +1,188 @@
 //! Secrets-manager interpolation for the config layer (#125).
+//!
+//! Resolution runs as the final config-load stage (after env/file and
+//! vars/templates), over the parsed config tree. See the design spec.
 
 pub mod registry;
+
+#[cfg(feature = "secrets-aws-sm")]
+mod aws_sm;
+#[cfg(feature = "secrets-azure-kv")]
+mod azure_kv;
+#[cfg(feature = "secrets-gcp-sm")]
+mod gcp_sm;
+#[cfg(feature = "secrets-vault")]
+mod vault;
+
+use crate::error::{CliError, CliResult};
+use crate::interpolate::{self, Directive};
+use async_trait::async_trait;
+use serde_json::Value;
+use std::collections::{BTreeSet, HashMap};
+
+/// The four secret-manager schemes this layer recognises.
+pub const SECRET_SCHEMES: &[&str] = &["vault", "aws-sm", "gcp-sm", "azure-kv"];
+
+/// A `(scheme, reference)` pair, e.g. `("vault", "secret/data/app#token")`.
+pub type SecretRef = (String, String);
+
+#[async_trait]
+pub trait SecretResolver: Send + Sync {
+    /// Scheme handled, e.g. `"vault"`.
+    fn scheme(&self) -> &'static str;
+    /// Resolve a `path[#field]` reference to its string value.
+    async fn resolve(&self, reference: &str) -> CliResult<String>;
+}
+
+/// Split a `path#field` reference into `(path, Some(field))` or `(path, None)`.
+#[allow(dead_code)] // used by provider modules added in later tasks
+pub(crate) fn split_field(reference: &str) -> (&str, Option<&str>) {
+    match reference.split_once('#') {
+        Some((path, field)) => (path, Some(field)),
+        None => (reference, None),
+    }
+}
+
+/// Extract `field` from a secret body that must parse as a JSON object.
+/// Used by Vault and AWS resolvers for the `#field` selector.
+#[allow(dead_code)] // used by provider modules added in later tasks
+pub(crate) fn extract_field(
+    scheme: &str,
+    reference: &str,
+    body: &str,
+    field: &str,
+) -> CliResult<String> {
+    let json: Value = serde_json::from_str(body).map_err(|_| CliError::SecretNotJson {
+        scheme: scheme.to_owned(),
+        reference: reference.to_owned(),
+    })?;
+    let obj = json.as_object().ok_or_else(|| CliError::SecretNotJson {
+        scheme: scheme.to_owned(),
+        reference: reference.to_owned(),
+    })?;
+    match obj.get(field) {
+        Some(Value::String(s)) => Ok(s.clone()),
+        Some(other) => Ok(other.to_string()),
+        None => Err(CliError::SecretFieldMissing {
+            scheme: scheme.to_owned(),
+            reference: reference.to_owned(),
+            field: field.to_owned(),
+            available: obj.keys().cloned().collect(),
+        }),
+    }
+}
+
+/// Apply `f` to every string leaf in `value`, recursively.
+fn for_each_string<F: FnMut(&str)>(value: &Value, f: &mut F) {
+    match value {
+        Value::String(s) => f(s),
+        Value::Array(a) => a.iter().for_each(|v| for_each_string(v, f)),
+        Value::Object(m) => m.values().for_each(|v| for_each_string(v, f)),
+        _ => {}
+    }
+}
+
+/// Mutate every string leaf in `value`, recursively.
+fn for_each_string_mut<F: FnMut(&mut String) -> CliResult<()>>(
+    value: &mut Value,
+    f: &mut F,
+) -> CliResult<()> {
+    match value {
+        Value::String(s) => f(s),
+        Value::Array(a) => a.iter_mut().try_for_each(|v| for_each_string_mut(v, f)),
+        Value::Object(m) => m.values_mut().try_for_each(|v| for_each_string_mut(v, f)),
+        _ => Ok(()),
+    }
+}
+
+/// Collect every unique secret reference found in a single string.
+fn collect_refs_in_str(s: &str, out: &mut BTreeSet<SecretRef>) {
+    for (_token, dir) in interpolate::iter_directives(s) {
+        if let Directive::LoadTime { prefix, body } = dir
+            && SECRET_SCHEMES.contains(&prefix)
+        {
+            out.insert((prefix.to_owned(), body.to_owned()));
+        }
+    }
+}
+
+/// Collect all unique secret references reachable from a config `Value`.
+pub fn collect_refs(value: &Value, out: &mut BTreeSet<SecretRef>) {
+    for_each_string(value, &mut |s| collect_refs_in_str(s, out));
+}
+
+/// Substitute every secret directive in a `Value` from `cache`. Non-secret
+/// directives (`${users.id}`) pass through verbatim.
+pub fn substitute(value: &mut Value, cache: &HashMap<SecretRef, String>) -> CliResult<()> {
+    for_each_string_mut(value, &mut |s| {
+        let new = interpolate::rewrite(s, |body| match interpolate::classify_directive(body) {
+            Directive::LoadTime { prefix, body: b } if SECRET_SCHEMES.contains(&prefix) => Ok(
+                Some(
+                    cache
+                        .get(&(prefix.to_owned(), b.to_owned()))
+                        .cloned()
+                        .expect("scan collected every secret ref before fetch"),
+                ),
+            ),
+            _ => Ok(None),
+        })?;
+        *s = new;
+        Ok(())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn collects_unique_refs_and_ignores_other_directives() {
+        let v = json!({
+            "a": "${vault:secret/data/app#token}",
+            "b": "${aws-sm:prod/db#password}",
+            "c": "${vault:secret/data/app#token}",
+            "d": "${users.id}",
+            "e": "${env:HOME}",
+            "nested": ["${gcp-sm:projects/p/secrets/s/versions/latest}"]
+        });
+        let mut refs = BTreeSet::new();
+        collect_refs(&v, &mut refs);
+        assert_eq!(refs.len(), 3);
+        assert!(refs.contains(&("vault".into(), "secret/data/app#token".into())));
+        assert!(refs.contains(&("aws-sm".into(), "prod/db#password".into())));
+        assert!(refs.contains(&(
+            "gcp-sm".into(),
+            "projects/p/secrets/s/versions/latest".into()
+        )));
+    }
+
+    #[test]
+    fn substitutes_from_cache_and_preserves_runtime_refs() {
+        let mut v = json!({
+            "token": "Bearer ${vault:secret/data/app#token}",
+            "path": "/v1/${users.id}"
+        });
+        let mut cache = HashMap::new();
+        cache.insert(("vault".into(), "secret/data/app#token".into()), "abc123".into());
+        substitute(&mut v, &cache).unwrap();
+        assert_eq!(v["token"], "Bearer abc123");
+        assert_eq!(v["path"], "/v1/${users.id}");
+    }
+
+    #[test]
+    fn extract_field_picks_key_or_errors_with_available() {
+        let body = r#"{"username":"u","password":"p"}"#;
+        assert_eq!(extract_field("aws-sm", "ref", body, "password").unwrap(), "p");
+        match extract_field("aws-sm", "ref", body, "missing").unwrap_err() {
+            CliError::SecretFieldMissing { available, .. } => {
+                assert!(available.contains(&"username".to_string()));
+            }
+            other => panic!("expected SecretFieldMissing, got {other:?}"),
+        }
+        match extract_field("aws-sm", "ref", "not json", "x").unwrap_err() {
+            CliError::SecretNotJson { .. } => {}
+            other => panic!("expected SecretNotJson, got {other:?}"),
+        }
+    }
+}

--- a/cli/src/secrets/registry.rs
+++ b/cli/src/secrets/registry.rs
@@ -105,7 +105,10 @@ mod tests {
     fn redacts_registered_value() {
         clear();
         register("supersecrettoken");
-        assert_eq!(redact("Authorization: supersecrettoken"), "Authorization: ***");
+        assert_eq!(
+            redact("Authorization: supersecrettoken"),
+            "Authorization: ***"
+        );
     }
 
     #[test]

--- a/cli/src/secrets/registry.rs
+++ b/cli/src/secrets/registry.rs
@@ -128,11 +128,12 @@ mod tests {
     #[serial]
     fn writer_scrubs_secret_on_write() {
         clear();
-        register("hunter2pass");
+        let secret = "hunter2pass";
+        register(secret);
         let mut buf: Vec<u8> = Vec::new();
         {
             let mut w = RedactingWriter::new(&mut buf);
-            write!(w, "token={} done", "hunter2pass").unwrap();
+            write!(w, "token={secret} done").unwrap();
             w.flush().unwrap();
         }
         assert_eq!(String::from_utf8(buf).unwrap(), "token=*** done");

--- a/cli/src/secrets/registry.rs
+++ b/cli/src/secrets/registry.rs
@@ -1,0 +1,82 @@
+//! Process-global registry of resolved secret values + a redaction scrubber.
+//!
+//! Interpolation resolves secrets on raw config strings, so by the time the
+//! config is a typed structure a secret value is an ordinary `String`. Rather
+//! than tag fields, we track the resolved *values* and scrub any occurrence
+//! from output the CLI emits (the [`RedactingWriter`]).
+
+use std::borrow::Cow;
+use std::collections::HashSet;
+use std::sync::{OnceLock, RwLock};
+
+/// Values shorter than this are not registered — masking 1–3 char strings
+/// would over-redact unrelated output.
+const MIN_REDACT_LEN: usize = 4;
+
+fn registry() -> &'static RwLock<HashSet<String>> {
+    static REG: OnceLock<RwLock<HashSet<String>>> = OnceLock::new();
+    REG.get_or_init(|| RwLock::new(HashSet::new()))
+}
+
+/// Register a resolved secret value so it is scrubbed from future output.
+pub fn register(secret: &str) {
+    if secret.len() >= MIN_REDACT_LEN {
+        registry()
+            .write()
+            .expect("secret registry lock poisoned")
+            .insert(secret.to_owned());
+    }
+}
+
+/// Replace every registered secret value in `input` with `***`.
+pub fn redact(input: &str) -> Cow<'_, str> {
+    let reg = registry().read().expect("secret registry lock poisoned");
+    if reg.is_empty() {
+        return Cow::Borrowed(input);
+    }
+    let mut out: Option<String> = None;
+    for secret in reg.iter() {
+        let current = out.as_deref().unwrap_or(input);
+        if current.contains(secret.as_str()) {
+            out = Some(current.replace(secret.as_str(), "***"));
+        }
+    }
+    match out {
+        Some(s) => Cow::Owned(s),
+        None => Cow::Borrowed(input),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    fn clear() {
+        registry().write().unwrap().clear();
+    }
+
+    #[test]
+    #[serial]
+    fn redacts_registered_value() {
+        clear();
+        register("supersecrettoken");
+        assert_eq!(redact("Authorization: supersecrettoken"), "Authorization: ***");
+    }
+
+    #[test]
+    #[serial]
+    fn leaves_unregistered_text_untouched() {
+        clear();
+        register("supersecrettoken");
+        assert_eq!(redact("nothing to see"), "nothing to see");
+    }
+
+    #[test]
+    #[serial]
+    fn does_not_register_short_values() {
+        clear();
+        register("abc"); // < MIN_REDACT_LEN
+        assert_eq!(redact("abc def"), "abc def");
+    }
+}

--- a/cli/src/secrets/registry.rs
+++ b/cli/src/secrets/registry.rs
@@ -7,6 +7,7 @@
 
 use std::borrow::Cow;
 use std::collections::HashSet;
+use std::io::{self, Write};
 use std::sync::{OnceLock, RwLock};
 
 /// Values shorter than this are not registered — masking 1–3 char strings
@@ -47,6 +48,49 @@ pub fn redact(input: &str) -> Cow<'_, str> {
     }
 }
 
+/// An `io::Write` adapter that runs [`redact`] over every chunk before
+/// forwarding it to the inner writer. Wrapping the tracing subscriber's
+/// writer in this scrubs secret values out of *all* CLI log/diagnostic output
+/// at the I/O boundary, regardless of which field carried the value.
+pub struct RedactingWriter<W> {
+    inner: W,
+}
+
+impl<W: Write> RedactingWriter<W> {
+    pub fn new(inner: W) -> Self {
+        Self { inner }
+    }
+}
+
+impl<W: Write> Write for RedactingWriter<W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let text = String::from_utf8_lossy(buf);
+        let scrubbed = redact(&text);
+        self.inner.write_all(scrubbed.as_bytes())?;
+        // Report the original length consumed — the tracing fmt layer treats a
+        // short write as an error, and the scrubbed bytes are an internal detail.
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+/// `MakeWriter` that produces a [`RedactingWriter`] over stderr, for the
+/// tracing fmt subscriber. Only needed when the `observability` feature wires
+/// a subscriber (the sole place the CLI formats tracing output).
+#[cfg(feature = "observability")]
+pub struct RedactingMakeWriter;
+
+#[cfg(feature = "observability")]
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for RedactingMakeWriter {
+    type Writer = RedactingWriter<std::io::Stderr>;
+    fn make_writer(&'a self) -> Self::Writer {
+        RedactingWriter::new(std::io::stderr())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -78,5 +122,19 @@ mod tests {
         clear();
         register("abc"); // < MIN_REDACT_LEN
         assert_eq!(redact("abc def"), "abc def");
+    }
+
+    #[test]
+    #[serial]
+    fn writer_scrubs_secret_on_write() {
+        clear();
+        register("hunter2pass");
+        let mut buf: Vec<u8> = Vec::new();
+        {
+            let mut w = RedactingWriter::new(&mut buf);
+            write!(w, "token={} done", "hunter2pass").unwrap();
+            w.flush().unwrap();
+        }
+        assert_eq!(String::from_utf8(buf).unwrap(), "token=*** done");
     }
 }

--- a/cli/src/secrets/vault.rs
+++ b/cli/src/secrets/vault.rs
@@ -1,0 +1,136 @@
+//! HashiCorp Vault KV v2 resolver (`${vault:<path>[#field]}`).
+//!
+//! Auth: `VAULT_ADDR` + `VAULT_TOKEN`, optional `VAULT_NAMESPACE`. Pure HTTP
+//! via `reqwest` — no Vault client dependency.
+
+use super::{extract_field, split_field, SecretResolver};
+use crate::error::{CliError, CliResult};
+use async_trait::async_trait;
+use serde_json::Value;
+
+pub struct VaultResolver {
+    addr: String,
+    token: String,
+    namespace: Option<String>,
+    client: reqwest::Client,
+}
+
+impl VaultResolver {
+    /// Build from `VAULT_ADDR` / `VAULT_TOKEN` (+ optional `VAULT_NAMESPACE`).
+    pub fn from_env() -> CliResult<Self> {
+        let addr = std::env::var("VAULT_ADDR").map_err(|_| CliError::SecretAuthFailed {
+            scheme: "vault".into(),
+            hint: "set VAULT_ADDR (e.g. https://vault.example.com:8200)".into(),
+        })?;
+        let token = std::env::var("VAULT_TOKEN").map_err(|_| CliError::SecretAuthFailed {
+            scheme: "vault".into(),
+            hint: "set VAULT_TOKEN".into(),
+        })?;
+        Ok(Self {
+            addr: addr.trim_end_matches('/').to_owned(),
+            token,
+            namespace: std::env::var("VAULT_NAMESPACE").ok(),
+            client: reqwest::Client::new(),
+        })
+    }
+}
+
+#[async_trait]
+impl SecretResolver for VaultResolver {
+    fn scheme(&self) -> &'static str {
+        "vault"
+    }
+
+    async fn resolve(&self, reference: &str) -> CliResult<String> {
+        let (path, field) = split_field(reference);
+        let url = format!("{}/v1/{}", self.addr, path);
+        let mut req = self.client.get(&url).header("X-Vault-Token", &self.token);
+        if let Some(ns) = &self.namespace {
+            req = req.header("X-Vault-Namespace", ns);
+        }
+        let resp = req.send().await.map_err(|source| CliError::SecretFetchFailed {
+            scheme: "vault".into(),
+            reference: reference.into(),
+            source: Box::new(source),
+        })?;
+        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            return Err(CliError::SecretNotFound {
+                scheme: "vault".into(),
+                reference: reference.into(),
+            });
+        }
+        if resp.status() == reqwest::StatusCode::FORBIDDEN
+            || resp.status() == reqwest::StatusCode::UNAUTHORIZED
+        {
+            return Err(CliError::SecretAuthFailed {
+                scheme: "vault".into(),
+                hint: "VAULT_TOKEN was rejected (403/401) — check the token and its policy".into(),
+            });
+        }
+        let resp = resp.error_for_status().map_err(|source| CliError::SecretFetchFailed {
+            scheme: "vault".into(),
+            reference: reference.into(),
+            source: Box::new(source),
+        })?;
+        let body: Value = resp.json().await.map_err(|source| CliError::SecretFetchFailed {
+            scheme: "vault".into(),
+            reference: reference.into(),
+            source: Box::new(source),
+        })?;
+        // KV v2: secret map lives at .data.data
+        let data = &body["data"]["data"];
+        match field {
+            Some(f) => extract_field("vault", reference, &data.to_string(), f),
+            None => Ok(data.to_string()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[tokio::test]
+    async fn reads_kv_v2_field() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/secret/data/app"))
+            .and(header("X-Vault-Token", "test-token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": { "data": { "token": "s3cr3t-value", "other": "x" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let resolver = VaultResolver {
+            addr: server.uri(),
+            token: "test-token".into(),
+            namespace: None,
+            client: reqwest::Client::new(),
+        };
+        let v = resolver.resolve("secret/data/app#token").await.unwrap();
+        assert_eq!(v, "s3cr3t-value");
+    }
+
+    #[tokio::test]
+    async fn missing_secret_is_not_found() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/secret/data/nope"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+        let resolver = VaultResolver {
+            addr: server.uri(),
+            token: "t".into(),
+            namespace: None,
+            client: reqwest::Client::new(),
+        };
+        match resolver.resolve("secret/data/nope#x").await.unwrap_err() {
+            CliError::SecretNotFound { .. } => {}
+            other => panic!("expected SecretNotFound, got {other:?}"),
+        }
+    }
+}

--- a/cli/src/secrets/vault.rs
+++ b/cli/src/secrets/vault.rs
@@ -3,7 +3,7 @@
 //! Auth: `VAULT_ADDR` + `VAULT_TOKEN`, optional `VAULT_NAMESPACE`. Pure HTTP
 //! via `reqwest` — no Vault client dependency.
 
-use super::{extract_field, split_field, SecretResolver};
+use super::{SecretResolver, extract_field, split_field};
 use crate::error::{CliError, CliResult};
 use async_trait::async_trait;
 use serde_json::Value;
@@ -48,11 +48,14 @@ impl SecretResolver for VaultResolver {
         if let Some(ns) = &self.namespace {
             req = req.header("X-Vault-Namespace", ns);
         }
-        let resp = req.send().await.map_err(|source| CliError::SecretFetchFailed {
-            scheme: "vault".into(),
-            reference: reference.into(),
-            source: Box::new(source),
-        })?;
+        let resp = req
+            .send()
+            .await
+            .map_err(|source| CliError::SecretFetchFailed {
+                scheme: "vault".into(),
+                reference: reference.into(),
+                source: Box::new(source),
+            })?;
         if resp.status() == reqwest::StatusCode::NOT_FOUND {
             return Err(CliError::SecretNotFound {
                 scheme: "vault".into(),
@@ -67,16 +70,21 @@ impl SecretResolver for VaultResolver {
                 hint: "VAULT_TOKEN was rejected (403/401) — check the token and its policy".into(),
             });
         }
-        let resp = resp.error_for_status().map_err(|source| CliError::SecretFetchFailed {
-            scheme: "vault".into(),
-            reference: reference.into(),
-            source: Box::new(source),
-        })?;
-        let body: Value = resp.json().await.map_err(|source| CliError::SecretFetchFailed {
-            scheme: "vault".into(),
-            reference: reference.into(),
-            source: Box::new(source),
-        })?;
+        let resp = resp
+            .error_for_status()
+            .map_err(|source| CliError::SecretFetchFailed {
+                scheme: "vault".into(),
+                reference: reference.into(),
+                source: Box::new(source),
+            })?;
+        let body: Value = resp
+            .json()
+            .await
+            .map_err(|source| CliError::SecretFetchFailed {
+                scheme: "vault".into(),
+                reference: reference.into(),
+                source: Box::new(source),
+            })?;
         // KV v2: secret map lives at .data.data
         let data = &body["data"]["data"];
         match field {

--- a/cli/tests/cli_end_to_end.rs
+++ b/cli/tests/cli_end_to_end.rs
@@ -478,8 +478,12 @@ fn shipped_example_yamls_pass_validate() {
         for (k, v) in env_placeholders {
             cmd.env(k, v);
         }
+        // `--no-secrets` validates grammar / structure / expansion without
+        // resolving secrets-manager directives (e.g. `${vault:...}`), which
+        // would otherwise require live backends unavailable in CI. It is a
+        // no-op for the (majority) of examples that reference no secrets.
         cmd.current_dir(workdir.path())
-            .args(["validate"])
+            .args(["validate", "--no-secrets"])
             .arg(&path)
             .assert()
             .success();

--- a/cli/tests/examples_roundtrip.rs
+++ b/cli/tests/examples_roundtrip.rs
@@ -19,12 +19,17 @@ fn examples_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("examples")
 }
 
-/// Returns `true` when the error is a missing credential (env var / file) —
-/// these are expected in environments without secrets and should be skipped.
+/// Returns `true` when the error is a missing credential (env var / file) or a
+/// secrets-manager directive that the synchronous loader cannot resolve — both
+/// are expected in environments without those resources and should be skipped.
+/// (Examples that reference `${vault:…}` etc. are still structurally validated
+/// by the `shipped_example_yamls_pass_validate` test via `validate --no-secrets`.)
 fn is_credential_error(e: &CliError) -> bool {
     matches!(
         e,
-        CliError::MissingEnvVar { .. } | CliError::ReadInterpolatedFile { .. }
+        CliError::MissingEnvVar { .. }
+            | CliError::ReadInterpolatedFile { .. }
+            | CliError::SecretsRequireAsyncLoad
     )
 }
 

--- a/cli/tests/secrets_aws_sm.rs
+++ b/cli/tests/secrets_aws_sm.rs
@@ -1,0 +1,29 @@
+//! AWS Secrets Manager test against LocalStack. Gated on `AWS_SM_TEST=1`.
+//! Local setup:
+//!   docker run -d -p 4566:4566 localstack/localstack
+//!   export AWS_ENDPOINT_URL=http://127.0.0.1:4566 AWS_ACCESS_KEY_ID=test \
+//!     AWS_SECRET_ACCESS_KEY=test AWS_REGION=us-east-1 AWS_SM_TEST=1
+//!   aws --endpoint-url=$AWS_ENDPOINT_URL secretsmanager create-secret \
+//!     --name prod/faucet --secret-string '{"token":"aws-live-token"}'
+//!   cargo test -p faucet-cli --features secrets-aws-sm --test secrets_aws_sm -- --ignored
+
+#[tokio::test]
+#[ignore = "requires LocalStack (set AWS_SM_TEST=1 and run with --ignored)"]
+async fn resolves_aws_secret_field_end_to_end() {
+    if std::env::var("AWS_SM_TEST").as_deref() != Ok("1") {
+        return;
+    }
+    use faucet_cli::config::PipelineConfig;
+    let yaml = r#"
+version: 1
+pipeline:
+  source: { type: rest, config: { base_url: https://x, auth: { type: bearer, config: { token: "${aws-sm:prod/faucet#token}" } } } }
+  sink:   { type: jsonl, config: { path: ./o.jsonl } }
+"#;
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("p.yaml");
+    std::fs::write(&path, yaml).unwrap();
+    let cfg = PipelineConfig::from_path_async(&path).await.unwrap();
+    let token = &cfg.pipeline.source.unwrap().config["auth"]["config"]["token"];
+    assert_eq!(token, "aws-live-token");
+}

--- a/cli/tests/secrets_schema.rs
+++ b/cli/tests/secrets_schema.rs
@@ -1,0 +1,15 @@
+use assert_cmd::Command;
+use predicates::str::contains;
+
+#[test]
+fn schema_secrets_lists_all_four_schemes() {
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["schema", "secrets"])
+        .assert()
+        .success()
+        .stdout(contains("vault"))
+        .stdout(contains("aws-sm"))
+        .stdout(contains("gcp-sm"))
+        .stdout(contains("azure-kv"));
+}

--- a/cli/tests/secrets_validate.rs
+++ b/cli/tests/secrets_validate.rs
@@ -1,0 +1,28 @@
+//! `faucet validate --no-secrets` validates a config that references a secret
+//! without needing any backend.
+
+use assert_cmd::Command;
+use std::io::Write;
+
+#[test]
+fn validate_no_secrets_passes_offline() {
+    let dir = tempfile::tempdir().unwrap();
+    let cfg = dir.path().join("p.yaml");
+    let mut f = std::fs::File::create(&cfg).unwrap();
+    write!(
+        f,
+        r#"
+version: 1
+pipeline:
+  source: {{ type: rest, config: {{ base_url: https://x, auth: {{ type: bearer, config: {{ token: "${{vault:secret/data/app#token}}" }} }} }} }}
+  sink:   {{ type: jsonl, config: {{ path: ./o.jsonl }} }}
+"#
+    )
+    .unwrap();
+
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["validate", cfg.to_str().unwrap(), "--no-secrets"])
+        .assert()
+        .success();
+}

--- a/cli/tests/secrets_vault.rs
+++ b/cli/tests/secrets_vault.rs
@@ -1,0 +1,28 @@
+//! End-to-end Vault test. Gated on `VAULT_TEST=1` so CI without a Vault
+//! container skips it. To run locally:
+//!   docker run -d --cap-add=IPC_LOCK -e VAULT_DEV_ROOT_TOKEN_ID=root \
+//!     -p 8200:8200 hashicorp/vault
+//!   export VAULT_ADDR=http://127.0.0.1:8200 VAULT_TOKEN=root VAULT_TEST=1
+//!   vault kv put secret/faucet/api token=live-token-value
+//!   cargo test -p faucet-cli --features secrets-vault --test secrets_vault -- --ignored
+
+#[tokio::test]
+#[ignore = "requires a live Vault (set VAULT_TEST=1 and run with --ignored)"]
+async fn resolves_vault_secret_end_to_end() {
+    if std::env::var("VAULT_TEST").as_deref() != Ok("1") {
+        return;
+    }
+    use faucet_cli::config::PipelineConfig;
+    let yaml = r#"
+version: 1
+pipeline:
+  source: { type: rest, config: { base_url: https://x, auth: { type: bearer, config: { token: "${vault:secret/data/faucet/api#token}" } } } }
+  sink:   { type: jsonl, config: { path: ./o.jsonl } }
+"#;
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("p.yaml");
+    std::fs::write(&path, yaml).unwrap();
+    let cfg = PipelineConfig::from_path_async(&path).await.unwrap();
+    let token = &cfg.pipeline.source.unwrap().config["auth"]["config"]["token"];
+    assert_eq!(token, "live-token-value");
+}

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -24,6 +24,7 @@
 - [Data-quality checks](./cookbook/quality.md)
 - [Compression](./cookbook/compression.md)
 - [Record transforms](./cookbook/transforms.md)
+- [Secrets-manager interpolation](./cookbook/secrets.md)
 
 # Reference
 

--- a/docs/book/src/cookbook/secrets.md
+++ b/docs/book/src/cookbook/secrets.md
@@ -1,0 +1,292 @@
+# Secrets-manager interpolation
+
+faucet can pull secret values directly from HashiCorp Vault, AWS Secrets Manager,
+GCP Secret Manager, and Azure Key Vault — using `${scheme:reference}` directives
+right inside your config file. Resolution happens at config-load time: values are
+fetched concurrently, de-duplicated, substituted into the config tree, and
+**never written to disk or logs**.
+
+These directives join the existing load-time set: `${env:VAR}`, `${file:PATH}`,
+and `${secret:VAR}` (alias for `${env:}`).
+
+## Build features
+
+None of the four backends are compiled in by default. Opt in per backend or take
+all four with the aggregate feature:
+
+```bash
+# All four backends
+cargo install faucet-cli --features secrets
+
+# Individual backends
+cargo install faucet-cli --features secrets-vault
+cargo install faucet-cli --features secrets-aws-sm
+cargo install faucet-cli --features secrets-gcp-sm
+cargo install faucet-cli --features secrets-azure-kv
+```
+
+Using faucet-cli from source or as a library dependency:
+
+```bash
+cargo build -p faucet-cli --features secrets
+```
+
+The `full` aggregate feature includes all four backends.
+
+## HashiCorp Vault (KV v2)
+
+**Directive:** `${vault:<path>[#field]}`
+
+**Auth:** set `VAULT_ADDR` and `VAULT_TOKEN` in the environment. `VAULT_NAMESPACE`
+is optional (for HCP Vault or enterprise namespaces).
+
+The `#field` selector parses the secret body as a JSON object and extracts one
+key. Omit it to receive the entire secret body as a string.
+
+```yaml
+# Requires: VAULT_ADDR + VAULT_TOKEN, and a KV v2 secret at
+# secret/data/faucet/api with a `token` field.
+# Build with: --features secrets-vault
+version: 1
+name: rest-to-jsonl-with-vault
+pipeline:
+  source:
+    type: rest
+    config:
+      base_url: https://api.example.com
+      path: /v1/items
+      auth:
+        type: bearer
+        config:
+          token: "${vault:secret/data/faucet/api#token}"
+  sink:
+    type: jsonl
+    config:
+      path: ./out/items.jsonl
+```
+
+## AWS Secrets Manager
+
+**Directive:** `${aws-sm:<name-or-ARN>[#field]}`
+
+**Auth:** the standard `aws-config` default credential chain — environment
+variables (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN`),
+`~/.aws/credentials` profile, EC2/ECS instance credentials, web identity token,
+or IAM role attached to the compute environment. No manual config needed beyond
+what the AWS SDK picks up automatically.
+
+The `#field` selector works the same as for Vault: it parses the secret as JSON
+and extracts one key.
+
+```yaml
+# Build with: --features secrets-aws-sm
+version: 1
+name: postgres-to-bigquery-secure
+pipeline:
+  source:
+    type: postgres
+    config:
+      connection_url: "${aws-sm:prod/postgres#connection_url}"
+      query: "SELECT * FROM events WHERE created_at > now() - interval '1 day'"
+  sink:
+    type: bigquery
+    config:
+      project_id: my-gcp-project
+      dataset_id: analytics
+      table_id: events
+      credentials:
+        type: application_default
+```
+
+## GCP Secret Manager
+
+**Directive:** `${gcp-sm:projects/<project>/secrets/<secret>/versions/<version>}`
+
+Use `versions/latest` to always fetch the current active version.
+
+**Auth:** Application Default Credentials — run `gcloud auth application-default login`
+for local development, or rely on the service account attached to GCE/Cloud Run
+in production. No extra environment variables needed.
+
+```yaml
+# Build with: --features secrets-gcp-sm
+version: 1
+name: rest-to-gcs-secure
+pipeline:
+  source:
+    type: rest
+    config:
+      base_url: https://api.partner.com
+      path: /v2/export
+      auth:
+        type: bearer
+        config:
+          token: "${gcp-sm:projects/my-project/secrets/partner-api-token/versions/latest}"
+  sink:
+    type: gcs
+    config:
+      bucket: my-export-bucket
+      prefix: exports/
+      credentials:
+        type: application_default
+```
+
+## Azure Key Vault
+
+**Directive:** `${azure-kv:<vault>/<secret>[/<version>]}`
+
+Omit the version segment to fetch the current (enabled) version.
+
+**Auth:** the `azure_identity` default chain — `AZURE_TENANT_ID` /
+`AZURE_CLIENT_ID` / `AZURE_CLIENT_SECRET` environment variables (service
+principal), managed identity (when running in Azure), or `az login` (developer
+tools). These are tried in that order; the first that succeeds is used.
+
+```yaml
+# Build with: --features secrets-azure-kv
+version: 1
+name: rest-to-snowflake-secure
+pipeline:
+  source:
+    type: rest
+    config:
+      base_url: https://api.example.com
+      path: /v1/records
+      auth:
+        type: bearer
+        config:
+          token: "${azure-kv:my-vault/api-token}"
+  sink:
+    type: snowflake
+    config:
+      account: myaccount.us-east-1
+      warehouse: LOAD_WH
+      database: RAW
+      schema: PUBLIC
+      table: records
+      auth:
+        type: oauth
+        config:
+          access_token: "${azure-kv:my-vault/snowflake-token}"
+```
+
+## The `#field` JSON extractor
+
+Both Vault and AWS Secrets Manager support storing multiple values as a JSON
+object inside one secret. The `#field` selector lets you extract a single key:
+
+```yaml
+# Secret at prod/db contains: {"host": "db.example.com", "password": "s3cr3t"}
+connection_url: "postgresql://app:${aws-sm:prod/db#password}@${aws-sm:prod/db#host}/mydb"
+```
+
+Each reference is fetched and de-duplicated — the same `(scheme, path)` pair is
+fetched exactly once even if it appears in multiple config fields.
+
+If the field is absent, faucet surfaces a clear error listing the available keys.
+If the secret body isn't valid JSON when `#field` is used, faucet errors rather
+than returning raw bytes.
+
+## Validating configs with secrets
+
+**With resolution (real preflight):** `faucet validate` resolves all secrets
+as part of config validation and prints one line per reference to confirm
+which secrets were reached (never the values):
+
+```
+secret: vault:secret/data/faucet/api#token → resolved
+ok: 'rest-to-jsonl-with-vault' rows=1 (roots=1, children=0) execution=(defaults)
+  - default [root] source=rest sink=jsonl
+```
+
+**Offline (no network / credentials):** `faucet validate --no-secrets` validates
+grammar and structure only, skipping all secret fetches. Use this in CI steps
+that don't have credentials, or in local development before you have vault access:
+
+```bash
+faucet validate --no-secrets pipeline.yaml
+```
+
+**Grammar reference:** `faucet schema secrets` prints the full directive syntax
+and auth requirements for all four schemes in machine-readable JSON:
+
+```bash
+faucet schema secrets
+```
+
+## Resolution order
+
+Secret directives resolve as the **final** load-time stage, after `${env:}` /
+`${file:}` / `${vars.X}` / `${sources.X}` are all settled. This means you can
+use env vars to compose a secret path:
+
+```yaml
+pipeline:
+  source:
+    type: rest
+    config:
+      auth:
+        type: bearer
+        config:
+          token: "${vault:secret/data/${env:APP_ENV}/api#token}"
+```
+
+Substitution order: `${env:APP_ENV}` resolves first (during the raw text pass);
+the resulting path `secret/data/prod/api#token` is then fetched from Vault.
+
+## Redaction guarantee and its boundary
+
+faucet scrubs every resolved secret value from its own tracing / log / error
+output. Every byte written through the CLI's tracing subscriber passes through a
+`RedactingWriter` that replaces any registered secret value with `***`. Errors
+that contain deserialized config fields go through the same scrubber before they
+reach stderr.
+
+**This boundary covers faucet's own output only.** A third-party connector that
+debug-logs its own deserialized config fields — or any library that logs a
+`reqwest::Request`, a database row, or a JSON object — operates outside this
+boundary. In particular:
+
+- Do **not** enable `RUST_LOG=debug` or `FAUCET_LOG=debug` when running a
+  pipeline whose connector configs hold resolved secrets. The connector libraries
+  may log intermediate objects that contain the resolved value before faucet's
+  scrubber can see it.
+- Prometheus metric labels and span attributes set by connectors are also outside
+  this boundary.
+- The scrubber does not redact values shorter than 4 characters.
+
+## Known limitation: `auth:` catalog and `vars:` block
+
+Secret directives are resolved in connector configs, transforms, state, dlq, and
+matrix rows — everywhere config interpolation runs. They are **not** resolved
+inside:
+
+- The top-level **`auth:`** shared-provider catalog.
+- The top-level **`vars:`** block.
+
+This is consistent with the scope of `${vars.X}` and `${sources.X}` — those are
+also not resolved inside `auth:` or `vars:` themselves.
+
+**Workaround:** put the secret directive directly in the connector's inline `auth:`
+block rather than in the shared catalog:
+
+```yaml
+# Works — inline auth resolves secrets
+pipeline:
+  source:
+    type: rest
+    config:
+      auth:
+        type: bearer
+        config:
+          token: "${vault:secret/data/app#token}"
+
+# Does NOT work — secrets are not resolved in the top-level auth: catalog
+auth:
+  api:
+    type: static
+    config:
+      token: "${vault:secret/data/app#token}"   # <-- not resolved
+```
+
+This limitation may be lifted in a future release.

--- a/docs/book/src/reference/cli.md
+++ b/docs/book/src/reference/cli.md
@@ -34,6 +34,24 @@ before deploying.
 faucet validate pipeline.yaml
 ```
 
+When the config contains secrets-manager directives (`${vault:…}`, `${aws-sm:…}`,
+etc.), `faucet validate` resolves them as a real preflight and prints one
+confirmation line per reference (never the value):
+
+```
+secret: vault:secret/data/faucet/api#token → resolved
+ok: 'my-pipeline' rows=1 (roots=1, children=0) execution=(defaults)
+  - default [root] source=rest sink=jsonl
+```
+
+Pass `--no-secrets` to validate grammar and structure only, skipping all secret
+fetches. This is useful in CI environments that lack credentials, or in local
+development before vault access is available:
+
+```bash
+faucet validate --no-secrets pipeline.yaml
+```
+
 ## `preview`
 
 Runs the first root row's source and prints records (via the stdout sink).
@@ -51,11 +69,16 @@ faucet schema source rest
 faucet schema sink bigquery
 faucet schema transform keys_case
 faucet schema dlq
+faucet schema secrets
 ```
 
 `faucet schema transform <name>` prints the inline config schema for a
 transform (e.g. `keys_case` lists the valid `mode:` values). Run
 `faucet list` to see which transforms are compiled into your binary.
+
+`faucet schema secrets` prints the directive grammar and auth requirements for
+all four secrets-manager backends in machine-readable JSON — useful for tooling
+that needs to understand the interpolation syntax without reading the docs.
 
 ## `init`
 

--- a/docs/book/src/reference/config.md
+++ b/docs/book/src/reference/config.md
@@ -67,10 +67,32 @@ Three stages resolve placeholders:
 - **Load time:** `${env:VAR}`, `${file:PATH}`, `${secret:VAR}` are resolved when
   the file is read. `${vars.X}` resolves against the top-level `vars:` block;
   `${sources.NAME.PATH}` / `${sinks.NAME.PATH}` resolve against named templates.
+  Secret-manager directives (see below) run as the final load-time stage.
 - **Runtime:** `${row_id.dotted.path}` tokens are resolved per parent record in
   DAG runs.
 
 Reference cycles surface as a clear `InterpolationCycle` error.
+
+### Secrets-manager directives
+
+Four additional load-time schemes pull values from external secrets managers.
+Each requires the matching build feature (`--features secrets-vault`, etc.;
+`--features secrets` enables all four). Values are fetched concurrently and
+de-duplicated; they are never written to disk.
+
+| Directive | Backend | Auth |
+|-----------|---------|------|
+| `${vault:<path>[#field]}` | HashiCorp Vault KV v2 | `VAULT_ADDR` + `VAULT_TOKEN` (+ optional `VAULT_NAMESPACE`) |
+| `${aws-sm:<name-or-ARN>[#field]}` | AWS Secrets Manager | `aws-config` default chain (env / profile / instance / web-identity) |
+| `${gcp-sm:projects/<p>/secrets/<s>/versions/<v>}` | GCP Secret Manager (`versions/latest` ok) | Application Default Credentials |
+| `${azure-kv:<vault>/<secret>[/<version>]}` | Azure Key Vault | `AZURE_*` env / managed identity / `az login` |
+
+The `#field` selector (Vault and AWS only) parses the secret body as a JSON
+object and extracts a single key. Use `faucet schema secrets` for the machine-readable
+grammar reference and `faucet validate --no-secrets` to check grammar offline.
+
+See the [secrets cookbook](../cookbook/secrets.md) for full examples, the
+redaction guarantee, and the known limitation around the `auth:` catalog.
 
 ## `matrix`
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -37,6 +37,7 @@ These run immediately after installing the CLI — great for a first smoke test:
 | `rest_to_jsonl.yaml`, `rest_streaming.yaml`, `rest_to_stdout_preview.yaml` | point `base_url` at any HTTP API; preview needs no sink setup |
 | `rest_filter_explode_to_stdout.yaml` | `filter` + `explode` + `keys_case` against DummyJSON; demonstrates the v1 JSONPath subset and the merge rule |
 | `shared_auth_rest.yaml` | one OAuth2 provider in the top-level `auth:` block shared across four matrix rows via `auth: { ref }` — single token, single-flight refresh (point `base_url` / token endpoint at a real API) |
+| `rest_to_jsonl_with_vault.yaml` | Vault KV v2 secret injected as a Bearer token via `${vault:…#field}`; requires `VAULT_ADDR` + `VAULT_TOKEN` and `--features secrets-vault` |
 | `websocket_to_jsonl.yaml` | none (live public WS endpoint — Binance BTC/USDT trade stream, no auth) |
 
 > REST / GraphQL / XML / gRPC / webhook source examples hit an external endpoint

--- a/faucet-stream/src/lib.rs
+++ b/faucet-stream/src/lib.rs
@@ -5,6 +5,8 @@
 //! A declarative, config-driven data pipeline with pluggable source and sink
 //! connectors.
 //!
+//! 📖 **Guide, tutorials & cookbook:** <https://pawansikawat.github.io/faucet-stream/>
+//!
 //! ## Feature flags
 //!
 //! | Feature | Description |


### PR DESCRIPTION
Implements #125 — native secrets-manager interpolation in the `faucet` CLI config layer.

Closes #125

## What

Four new load-time interpolation schemes, alongside the existing `${env:}` / `${file:}` / `${secret:}`:

| Scheme | Grammar | Auth |
|---|---|---|
| `${vault:…}` | `${vault:<path>[#field]}` (KV v2) | `VAULT_ADDR` + `VAULT_TOKEN` (+ optional `VAULT_NAMESPACE`) |
| `${aws-sm:…}` | `${aws-sm:<name-or-ARN>[#field]}` | `aws-config` default credential chain |
| `${gcp-sm:…}` | `${gcp-sm:projects/<p>/secrets/<s>/versions/<v>}` | Application Default Credentials |
| `${azure-kv:…}` | `${azure-kv:<vault>/<secret>[/<version>]}` | service principal env / managed identity / `az login` |

- **Resolution pipeline:** runs as the final config-load stage (after env/file and vars/templates) over the parsed config tree — scan → concurrent de-duplicated fetch → substitute. Resolving *last* is injection-safe (no re-scan of substituted text). Per-load cache; never persisted.
- **Redaction:** resolved secret values are registered in a process-global `SecretRegistry` and scrubbed from all CLI output via a `RedactingWriter` on the tracing subscriber + scrubbing in the error reporter. Boundary documented: a third-party connector that debug-logs its own deserialized field is outside the CLI's writer.
- **CLI:** `faucet validate` resolves secrets as a preflight and reports `secret: <scheme>:<ref> → resolved` (never the value); `faucet validate --no-secrets` checks grammar/structure offline; `faucet schema secrets` prints the grammar.
- **Feature-gated** (`secrets-vault` / `secrets-aws-sm` / `secrets-gcp-sm` / `secrets-azure-kv`, aggregate `secrets`); none in defaults. CLI-only (not `faucet-core`, not the umbrella).

## Notable implementation notes

- `azure_identity` 1.0.0 has no `DefaultAzureCredential`, so the Azure resolver hand-rolls a `ChainedCredential` (client-secret-from-env → managed-identity → developer-tools) implementing `TokenCredential` — the canonical chain for this SDK version.
- The `feature-check` CI step now routes `secrets-*` features to `cargo check -p faucet-cli` (they live in the CLI, not the `faucet-stream` umbrella).

## Tests

- **Unit:** scan/substitute/`#field`, redaction + `RedactingWriter`, error shapes, sync-load detect, orchestration (fake-resolver seam), Vault (wiremock), GCP base64 decode.
- **Integration (env-gated):** dockerized Vault (`VAULT_TEST=1`), LocalStack AWS (`AWS_SM_TEST=1`), Azure live (`AZURE_TEST=1`).
- Local sweep green: `cargo fmt`, `clippy -p faucet-cli --all-features -- -D warnings`, `cargo test -p faucet-cli --all-features` (all pass), stable rustdoc with `-D warnings`.

## Docs

Cookbook page (`docs/book/src/cookbook/secrets.md`), config + CLI reference, `cli/README.md`, root README (incl. new Guide badge), `examples/rest_to_jsonl_with_vault.yaml`, CLAUDE.md.

## Known limitations (filed as follow-ups)

- Secrets are not resolved inside the top-level `auth:` shared-provider catalog or `vars:` block (consistent with existing interpolation scope) — use inline connector auth for now.
- The Azure resolver rebuilds its credential chain per `resolve()` (negligible at load time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
