### PR TITLE
feat(cli): complete secrets interpolation — auth: catalog + vars: block (#134), Azure KV chain reuse (#135)

### DIFF
--- a/cli/src/interpolate.rs
+++ b/cli/src/interpolate.rs
@@ -305,6 +305,13 @@ pub fn resolve_config_refs(cfg: &mut crate::config::PipelineConfig) -> CliResult
     if let Some(d) = cfg.pipeline.dlq.as_mut() {
         resolve_value_full(&mut d.sink.config, vars_ref, &snapshot)?;
     }
+    // The shared `auth:` catalog is a first-class config location: provider
+    // specs may reference `${vars.X}` / `${sources.X.PATH}` like any other (#134).
+    if let Some(auth) = cfg.auth.as_mut() {
+        for (_name, spec) in auth.iter_mut() {
+            resolve_value_full(spec, vars_ref, &snapshot)?;
+        }
+    }
     for (i, row) in cfg.matrix.iter_mut().enumerate() {
         let _row_owner = row.id.clone().unwrap_or_else(|| format!("row-{i}"));
         if let Some(p) = row.source.as_mut()
@@ -1100,6 +1107,28 @@ pipeline:
         assert_eq!(
             cfg.pipeline.source.as_ref().unwrap().config["path"],
             "/v1/users/${users.id}/posts"
+        );
+    }
+
+    #[test]
+    fn resolves_vars_inside_auth_catalog() {
+        // The shared `auth:` catalog must be a first-class config location:
+        // ${vars.X} (and ${sources/sinks.X.PATH}) resolve there too (#134).
+        let cfg = load(
+            r#"
+version: 1
+vars:
+  idp_token: topsecret
+auth:
+  idp: { type: static, config: { token: "Bearer ${vars.idp_token}" } }
+pipeline:
+  source: { type: rest, config: { base_url: https://x } }
+  sink:   { type: jsonl, config: { path: ./o.jsonl } }
+"#,
+        );
+        assert_eq!(
+            cfg.auth.as_ref().unwrap()["idp"]["config"]["token"],
+            "Bearer topsecret"
         );
     }
 }

--- a/cli/src/secrets/azure_kv.rs
+++ b/cli/src/secrets/azure_kv.rs
@@ -14,6 +14,7 @@ use async_trait::async_trait;
 use azure_core::credentials::{AccessToken, Secret, TokenCredential, TokenRequestOptions};
 use azure_identity::{ClientSecretCredential, DeveloperToolsCredential, ManagedIdentityCredential};
 use std::sync::Arc;
+use tokio::sync::OnceCell;
 
 // ── Chained credential ────────────────────────────────────────────────────────
 
@@ -111,11 +112,30 @@ fn build_credential() -> CliResult<Arc<dyn TokenCredential>> {
 
 // ── Resolver ──────────────────────────────────────────────────────────────────
 
-pub struct AzureKvResolver;
+pub struct AzureKvResolver {
+    /// The Azure credential chain, built lazily on first resolve and reused
+    /// thereafter so the SDK's inner `TokenCache` survives across references
+    /// (#135). Errors are not cached — a failed build is retried next call.
+    credential: OnceCell<Arc<dyn TokenCredential>>,
+}
 
 impl AzureKvResolver {
     pub fn new() -> Self {
-        Self
+        Self {
+            credential: OnceCell::new(),
+        }
+    }
+
+    /// Build the Azure credential chain once and reuse it. The chain (and its
+    /// inner `TokenCache`) is constructed lazily on first use, so a config that
+    /// never references `azure-kv` pays nothing and auth failures are deferred
+    /// to the first fetch.
+    async fn credential(&self) -> CliResult<Arc<dyn TokenCredential>> {
+        let cred = self
+            .credential
+            .get_or_try_init(|| async { build_credential() })
+            .await?;
+        Ok(Arc::clone(cred))
     }
 }
 
@@ -155,7 +175,7 @@ impl SecretResolver for AzureKvResolver {
                 })?;
         let version = parts.next().filter(|s| !s.is_empty());
 
-        let credential = build_credential()?;
+        let credential = self.credential().await?;
 
         let vault_url = format!("https://{vault}.vault.azure.net/");
         let client =
@@ -194,5 +214,24 @@ impl SecretResolver for AzureKvResolver {
             scheme: "azure-kv".into(),
             reference: reference.into(),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn credential_chain_is_built_once() {
+        // #135: the credential chain (and its inner TokenCache) must be reused
+        // across resolve() calls, not rebuilt — and discarded — each time.
+        // Constructing the chain does no network I/O, so this is safe offline.
+        let resolver = AzureKvResolver::new();
+        let first = resolver.credential().await.expect("chain builds");
+        let second = resolver.credential().await.expect("chain builds");
+        assert!(
+            Arc::ptr_eq(&first, &second),
+            "credential chain should be built at most once and reused"
+        );
     }
 }

--- a/cli/src/secrets/mod.rs
+++ b/cli/src/secrets/mod.rs
@@ -171,6 +171,19 @@ fn make_resolver(scheme: &str) -> CliResult<Arc<dyn SecretResolver>> {
 /// Apply a read-only closure to every config `Value` location (mirrors
 /// `resolve_config_refs`'s traversal).
 fn visit_config_values<F: FnMut(&Value)>(cfg: &PipelineConfig, mut f: F) {
+    // The shared `auth:` catalog and the `vars:` block are first-class config
+    // locations: a secret placed in either must resolve before the auth catalog
+    // is built / vars are consumed (#134).
+    if let Some(auth) = cfg.auth.as_ref() {
+        for spec in auth.values() {
+            f(spec);
+        }
+    }
+    if let Some(vars) = cfg.vars.as_ref() {
+        for v in vars.values() {
+            f(v);
+        }
+    }
     for spec in cfg.pipeline.sources.values() {
         f(&spec.config);
     }
@@ -222,6 +235,18 @@ fn visit_config_values_mut<F: FnMut(&mut Value) -> CliResult<()>>(
     cfg: &mut PipelineConfig,
     mut f: F,
 ) -> CliResult<()> {
+    // See `visit_config_values`: the `auth:` catalog and `vars:` block are
+    // walked too so secrets resolve there before they are consumed (#134).
+    if let Some(auth) = cfg.auth.as_mut() {
+        for spec in auth.values_mut() {
+            f(spec)?;
+        }
+    }
+    if let Some(vars) = cfg.vars.as_mut() {
+        for v in vars.values_mut() {
+            f(v)?;
+        }
+    }
     for spec in cfg.pipeline.sources.values_mut() {
         f(&mut spec.config)?;
     }
@@ -437,6 +462,56 @@ pipeline:
         resolve_secrets_with(&mut cfg, &set).await.unwrap();
         let token = &cfg.pipeline.source.as_ref().unwrap().config["auth"]["config"]["token"];
         assert_eq!(token, "RESOLVED");
+    }
+
+    #[tokio::test]
+    async fn resolve_secrets_resolves_auth_catalog_and_vars_block() {
+        // A secret placed in the shared `auth:` catalog and in the `vars:` block
+        // must be resolved just like one in a connector config (#134). Without
+        // it, `build_auth_catalog` would receive a literal `${vault:…}` token.
+        let mut set = ResolverSet::default();
+        set.insert(Arc::new(FakeResolver {
+            scheme: "vault",
+            value: "RESOLVED".into(),
+        }));
+        let cfg_yaml = r#"
+version: 1
+vars:
+  shared_token: "${vault:secret/data/app#token}"
+auth:
+  idp: { type: static, config: { token: "${vault:secret/data/idp#token}" } }
+pipeline:
+  source: { type: rest, config: { base_url: https://x, auth: { ref: idp } } }
+  sink:   { type: jsonl, config: { path: ./o.jsonl } }
+"#;
+        let mut cfg = PipelineConfig::from_text(cfg_yaml, std::path::Path::new("p.yaml")).unwrap();
+        resolve_secrets_with(&mut cfg, &set).await.unwrap();
+
+        let auth_token = &cfg.auth.as_ref().unwrap()["idp"]["config"]["token"];
+        assert_eq!(auth_token, "RESOLVED", "auth-catalog secret should resolve");
+
+        let var_value = &cfg.vars.as_ref().unwrap()["shared_token"];
+        assert_eq!(var_value, "RESOLVED", "vars-block secret should resolve");
+    }
+
+    #[tokio::test]
+    async fn scan_config_collects_refs_from_auth_and_vars() {
+        // The preflight scan (used by `faucet validate`) must report secret
+        // references that live only in the auth catalog or vars block.
+        let cfg_yaml = r#"
+version: 1
+vars:
+  v: "${aws-sm:prod/api#key}"
+auth:
+  idp: { type: static, config: { token: "${vault:secret/data/idp#token}" } }
+pipeline:
+  source: { type: rest, config: { base_url: https://x, auth: { ref: idp } } }
+  sink:   { type: jsonl, config: { path: ./o.jsonl } }
+"#;
+        let cfg = PipelineConfig::from_text(cfg_yaml, std::path::Path::new("p.yaml")).unwrap();
+        let refs = scan_config(&cfg);
+        assert!(refs.contains(&("vault".into(), "secret/data/idp#token".into())));
+        assert!(refs.contains(&("aws-sm".into(), "prod/api#key".into())));
     }
 
     #[tokio::test]

--- a/docs/book/src/cookbook/secrets.md
+++ b/docs/book/src/cookbook/secrets.md
@@ -255,38 +255,50 @@ boundary. In particular:
   this boundary.
 - The scrubber does not redact values shorter than 4 characters.
 
-## Known limitation: `auth:` catalog and `vars:` block
+## Secrets in the `auth:` catalog and `vars:` block
 
-Secret directives are resolved in connector configs, transforms, state, dlq, and
-matrix rows — everywhere config interpolation runs. They are **not** resolved
-inside:
+Secret directives are resolved **everywhere** config interpolation runs:
+connector configs, transforms, state, dlq, matrix rows, the top-level
+**`auth:`** shared-provider catalog, and the top-level **`vars:`** block.
 
-- The top-level **`auth:`** shared-provider catalog.
-- The top-level **`vars:`** block.
-
-This is consistent with the scope of `${vars.X}` and `${sources.X}` — those are
-also not resolved inside `auth:` or `vars:` themselves.
-
-**Workaround:** put the secret directive directly in the connector's inline `auth:`
-block rather than in the shared catalog:
+Putting a secret in the shared `auth:` catalog is often the cleanest option — a
+single bearer token resolved once and shared across every matrix row that
+references it via `auth: { ref }` (one token cache, single-flight refresh):
 
 ```yaml
-# Works — inline auth resolves secrets
-pipeline:
-  source:
-    type: rest
-    config:
-      auth:
-        type: bearer
-        config:
-          token: "${vault:secret/data/app#token}"
-
-# Does NOT work — secrets are not resolved in the top-level auth: catalog
+# A secret in the shared catalog, resolved once and shared by reference.
 auth:
   api:
     type: static
     config:
-      token: "${vault:secret/data/app#token}"   # <-- not resolved
+      token: "${vault:secret/data/app#token}"
+
+pipeline:
+  sources:
+    orders:  { type: rest, config: { base_url: https://api.example.com/orders,  auth: { ref: api } } }
+    refunds: { type: rest, config: { base_url: https://api.example.com/refunds, auth: { ref: api } } }
+  sink: { type: jsonl, config: { path: ./out.jsonl } }
 ```
 
-This limitation may be lifted in a future release.
+A secret in the `vars:` block works the same way and can be reused through
+`${vars.X}`:
+
+```yaml
+vars:
+  db_password: "${aws-sm:prod/db#password}"
+
+pipeline:
+  source:
+    type: postgres
+    config:
+      connection_url: "postgres://app:${vars.db_password}@db.internal:5432/app"
+  sink: { type: jsonl, config: { path: ./rows.jsonl } }
+```
+
+The shared `auth:` catalog is a first-class config location in every respect:
+its provider specs can also reference `${vars.X}` and `${sources.X.PATH}`, not
+just secret directives.
+
+> Inline `auth:` blocks on individual connectors resolve secrets too — use the
+> shared catalog when several connectors share one credential, and inline auth
+> when a credential belongs to a single connector.


### PR DESCRIPTION
## Summary

Completes the secrets-manager interpolation feature (shipped in #133) by closing its two documented follow-ups, so the feature has no remaining "known limitation".

### #134 — secrets in the `auth:` catalog and `vars:` block

Secret directives (`${vault:…}` / `${aws-sm:…}` / `${gcp-sm:…}` / `${azure-kv:…}`) now resolve **everywhere** config interpolation runs, including the top-level `auth:` shared-provider catalog and the `vars:` block.

- Extended the secrets traversal (`visit_config_values` / `visit_config_values_mut`) to walk `cfg.auth` and `cfg.vars`.
- Extended `resolve_config_refs` to walk the `auth:` catalog too, so provider specs can reference `${vars.X}` / `${sources.X.PATH}` like any other location.
- **Ordering:** the secrets pass runs after `resolve_config_refs` and before `build_auth_catalog`, so an `auth:`-catalog secret is resolved *before* the catalog is built and is shared across matrix rows via `auth: { ref }` (one token cache, single-flight refresh).
- Redaction is automatic — resolved values flow through the same `fetch_all` → `registry::register` path.

### #135 — Azure KV credential chain built once

`AzureKvResolver` rebuilt the full `ChainedCredential` (discarding its inner `TokenCache`) on every `resolve()`, fetching a fresh Entra ID token per secret. It now caches the chain in a `tokio::sync::OnceCell` (mirroring the AWS/GCP resolvers) so it is built at most once and the SDK's `TokenCache` handles refresh. Build errors are not cached, preserving "auth failure deferred to first fetch".

## Tests (test-first / TDD)

- `secrets::tests::resolve_secrets_resolves_auth_catalog_and_vars_block`
- `secrets::tests::scan_config_collects_refs_from_auth_and_vars`
- `interpolate::tests::resolves_vars_inside_auth_catalog`
- `secrets::azure_kv::tests::credential_chain_is_built_once`

`cargo fmt --all --check`, `cargo clippy -p faucet-cli --features secrets --all-targets -- -D warnings`, and `cargo test -p faucet-cli --features secrets` all pass (251 lib + integration tests, 0 failures).

## Docs

- `docs/book/src/cookbook/secrets.md`: replaced the "known limitation" section with positive guidance + examples for secrets in the `auth:` catalog and `vars:` block.
- CLAUDE.md scope note updated (gitignored locally).

Closes #134
Closes #135

Part of the secrets work tracked in the roadmap epic #38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
