### PR TITLE
feat: faucet doctor — preflight probes for every connector (#126)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ as both a reusable library and a standalone CLI.
 cargo install faucet-cli
 faucet init my_pipeline --source postgres --sink bigquery   # scaffold pipeline.yaml from schemas
 faucet validate pipeline.yaml
+faucet doctor pipeline.yaml                                  # preflight: probe auth/network/permissions
 faucet run pipeline.yaml
 ```
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -28,8 +28,51 @@ cargo install faucet-cli --no-default-features \
 | `faucet list` | List every compiled-in source, sink, transform, and state-store backend. |
 | `faucet preview <config> --limit N` | Run only the source side and emit the first N records to stdout as JSONL. |
 | `faucet init [name] [--source X] [--sink Y]` | Scaffold a pipeline.yaml from each connector's JSON Schema. |
+| `faucet doctor <config> [--timeout-secs N] [--json]` | Probe every connector (auth/network/permissions/reachability) and print a checklist. Exits with the failed-probe count. |
 
 Pass `--log-level debug` (or set `FAUCET_LOG=debug`) for verbose tracing. Logs are written to stderr; pipeline records and command output go to stdout.
+
+### `faucet doctor`
+
+`faucet doctor <config>` runs a fast, **non-mutating** preflight against every connector in a config before you commit to a real run — so a misconfigured credential, an unreachable host, or a missing permission surfaces in seconds with a clear remediation hint, instead of failing mid-run and polluting your metrics.
+
+For each root invocation it probes the source, sink, and state store:
+
+- **Sources** reuse the real read path — the probe pulls a *single page* (DNS + TLS + auth + the first request + first-record decode) and stops, never paginating the full dataset. A handful of sources whose first page would block or have side effects use a targeted probe instead: `webhook` checks the port is bindable, `websocket` does a TCP connect, `postgres-cdc` checks the replication slot is reachable, `kafka` fetches cluster metadata.
+- **Sinks** run a non-mutating connect/auth/metadata call (e.g. `SELECT 1`, `HeadBucket`, `PING`, `tables.get`, cluster health, `fetch_metadata`) — never a real write. File sinks check the target directory is writable; `stdout` always passes.
+- **State stores** do a sentinel `put`/`get`/`delete` round-trip that leaves no residue.
+
+```bash
+faucet doctor pipeline.yaml                      # checklist, exit code = # of failed probes
+faucet doctor pipeline.yaml --timeout-secs 5     # per-probe timeout (default 10)
+faucet doctor pipeline.yaml --json               # machine-readable, for CI gating
+```
+
+Example output:
+
+```text
+✓ Config parses and interpolates                                 8 ms
+✓ Matrix expands to 2 invocations                    0 skipped (children)
+
+▸ Invocation default::us-east  (source=postgres, sink=bigquery)
+  ✓ source [postgres] read                                      42 ms
+  ✗ sink   [bigquery] auth (dataset us_east not found)         410 ms
+        hint: check bigquery credentials and that the dataset exists
+
+Summary: 1 passed, 1 failed, 0 skipped       total elapsed 0.5s
+```
+
+Flags:
+
+| Flag | Purpose |
+|------|---------|
+| `--timeout-secs <N>` | Per-probe timeout in seconds (default 10). |
+| `--json` | Emit a `{ config, invocations, summary }` JSON document instead of the checklist. |
+| `--env-file <path>` / `--no-env-file` | Same `.env` handling as `run` / `validate`. |
+
+**Exit code** = the number of failed probes, clamped to 255 (so `0` means all probes passed). **Child invocations** (parent/child matrix rows) are listed but not probed — their configs depend on parent records that only exist at run time. Probe `reason`/`hint` text is scrubbed for resolved secrets before printing, but third-party connectors should never place credentials in a probe message.
+
+**Probe contract for connector authors:** `Source::check` / `Sink::check` / `StateStore::check` (in `faucet-core`) default to a generic probe (source) or "not implemented" skip (sink / state). Override them with a probe that is **idempotent and side-effect-free** and never echoes credentials. Return probe-level failures as `ProbeStatus::Fail` inside an `Ok(CheckReport)`; reserve `Err` for "couldn't run any probe".
 
 ### `faucet init`
 

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -30,6 +30,30 @@ pub enum Command {
     Preview(PreviewArgs),
     /// Scaffold a starter `pipeline.yaml` to disk.
     Init(InitArgs),
+    /// Probe every connector in a config (auth / network / permissions) and
+    /// print a green/red checklist. Exits non-zero if any probe fails.
+    Doctor(DoctorArgs),
+}
+
+/// `faucet doctor` arguments.
+#[derive(Debug, Parser)]
+pub struct DoctorArgs {
+    /// Path to a `.yaml`, `.yml`, or `.json` pipeline config. If omitted,
+    /// auto-discover `faucet.yaml` / `faucet.yml` / `faucet.json` in cwd.
+    pub config: Option<PathBuf>,
+    /// Path to a `.env` file to load for `${env:VAR}` interpolation.
+    /// Defaults to `.env` in cwd if present.
+    #[arg(long, conflicts_with = "no_env_file")]
+    pub env_file: Option<PathBuf>,
+    /// Skip auto-loading `.env` from cwd.
+    #[arg(long)]
+    pub no_env_file: bool,
+    /// Per-probe timeout in seconds.
+    #[arg(long, default_value_t = 10)]
+    pub timeout_secs: u64,
+    /// Emit machine-readable JSON instead of the human checklist.
+    #[arg(long)]
+    pub json: bool,
 }
 
 /// `faucet run` arguments.

--- a/cli/src/commands/doctor.rs
+++ b/cli/src/commands/doctor.rs
@@ -129,7 +129,13 @@ pub async fn run(args: DoctorArgs) -> CliResult<()> {
             serde_json::to_string_pretty(&v).expect("doctor json serializes")
         );
     } else {
-        render_human(cfg_ms, roots.len(), n_children, overall.elapsed(), &invocations);
+        render_human(
+            cfg_ms,
+            roots.len(),
+            n_children,
+            overall.elapsed(),
+            &invocations,
+        );
     }
 
     if failed > 0 {
@@ -150,20 +156,22 @@ async fn probe_invocation(
     let mut probes = Vec::new();
 
     match build_source(&source.kind, source.config.clone(), auth).await {
-        Ok(src) => probes.extend(collect_probes("source", src.connector_name(), ctx, src.check(ctx)).await),
+        Ok(src) => {
+            probes.extend(collect_probes("source", src.connector_name(), ctx, src.check(ctx)).await)
+        }
         Err(e) => probes.push(construct_fail("source", &source.kind, &e)),
     }
 
     match build_sink(&sink.kind, sink.config.clone(), auth).await {
-        Ok(snk) => probes.extend(collect_probes("sink", snk.connector_name(), ctx, snk.check(ctx)).await),
+        Ok(snk) => {
+            probes.extend(collect_probes("sink", snk.connector_name(), ctx, snk.check(ctx)).await)
+        }
         Err(e) => probes.push(construct_fail("sink", &sink.kind, &e)),
     }
 
     if let Some(spec) = state {
         match build_state_store(&spec).await {
-            Ok(st) => {
-                probes.extend(collect_probes("state", &spec.kind, ctx, st.check(ctx)).await)
-            }
+            Ok(st) => probes.extend(collect_probes("state", &spec.kind, ctx, st.check(ctx)).await),
             Err(e) => probes.push(construct_fail("state", &spec.kind, &e)),
         }
     }
@@ -330,7 +338,13 @@ mod tests {
         let invs = vec![inv(vec![
             probe_out("source", "read", ProbeStatus::Pass),
             probe_out("sink", "auth", ProbeStatus::Fail { reason: "x".into() }),
-            probe_out("state", "sentinel", ProbeStatus::Skip { reason: "n/a".into() }),
+            probe_out(
+                "state",
+                "sentinel",
+                ProbeStatus::Skip {
+                    reason: "n/a".into(),
+                },
+            ),
             probe_out("sink", "schema", ProbeStatus::Fail { reason: "y".into() }),
         ])];
         assert_eq!(tally(&invs), (1, 2, 1));
@@ -364,11 +378,20 @@ mod tests {
         }])];
         redact_invocations(&mut invs);
         if let ProbeStatus::Fail { reason } = &invs[0].probes[0].status {
-            assert!(!reason.contains("supersecretvalue"), "reason not redacted: {reason}");
+            assert!(
+                !reason.contains("supersecretvalue"),
+                "reason not redacted: {reason}"
+            );
         } else {
             panic!("expected fail");
         }
-        assert!(!invs[0].probes[0].hint.as_ref().unwrap().contains("supersecretvalue"));
+        assert!(
+            !invs[0].probes[0]
+                .hint
+                .as_ref()
+                .unwrap()
+                .contains("supersecretvalue")
+        );
     }
 
     #[test]

--- a/cli/src/commands/doctor.rs
+++ b/cli/src/commands/doctor.rs
@@ -1,0 +1,382 @@
+//! `faucet doctor` — preflight probes for every connector in a config (#126).
+//!
+//! Expands the config, builds each **root** invocation's source / sink / state
+//! store, and runs their non-mutating `check()` probes concurrently (bounded by
+//! a semaphore, each wrapped in a per-probe timeout). Prints a green/red
+//! checklist (or `--json`) and exits with the number of failed probes
+//! (clamped to 255).
+//!
+//! Child invocations are listed but not probed: their configs depend on parent
+//! records that only exist at run time (same limitation as `faucet preview`).
+
+use crate::auth_catalog::{AuthCatalog, build_auth_catalog};
+use crate::cli::DoctorArgs;
+use crate::config::{ConnectorSpec, PipelineConfig, StateStoreSpec};
+use crate::error::{CliError, CliResult};
+use crate::expand::{ExpandedNode, NodeRole, expand};
+use crate::registry::{build_sink, build_source};
+use crate::secrets::registry::redact;
+use crate::state::build_state_store;
+use faucet_core::check::{CheckContext, CheckReport, Probe, ProbeStatus};
+use serde::Serialize;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::Semaphore;
+
+/// A single probe enriched with the role + connector it came from. This is the
+/// `--json` shape for each probe.
+#[derive(Debug, Serialize)]
+struct ProbeOut {
+    role: &'static str,
+    connector: String,
+    name: &'static str,
+    #[serde(flatten)]
+    status: ProbeStatus,
+    elapsed_ms: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    hint: Option<String>,
+}
+
+impl ProbeOut {
+    fn from_probe(role: &'static str, connector: String, p: Probe) -> Self {
+        Self {
+            role,
+            connector,
+            name: p.name,
+            status: p.status,
+            elapsed_ms: p.elapsed_ms,
+            hint: p.hint,
+        }
+    }
+}
+
+/// One expanded invocation and its probes (the `--json` per-invocation shape).
+#[derive(Debug, Serialize)]
+struct InvocationOut {
+    id: String,
+    probes: Vec<ProbeOut>,
+    // Connector kinds for the human header; not part of the JSON contract.
+    #[serde(skip)]
+    source_kind: String,
+    #[serde(skip)]
+    sink_kind: String,
+}
+
+/// Execute the `doctor` subcommand.
+pub async fn run(args: DoctorArgs) -> CliResult<()> {
+    let overall = Instant::now();
+    let cwd = std::env::current_dir()?;
+    let env_path =
+        crate::env_loader::resolve_env_file(args.env_file.as_deref(), args.no_env_file, &cwd)?;
+    crate::env_loader::load_env_file_if_present(env_path.as_deref())?;
+    let path = match args.config {
+        Some(p) => p,
+        None => crate::env_loader::discover_config_path(&cwd).ok_or(CliError::NoConfigOrFromEnv)?,
+    };
+
+    let t_cfg = Instant::now();
+    let cfg = PipelineConfig::from_path_async(&path).await?;
+    let cfg_ms = t_cfg.elapsed().as_millis();
+
+    let nodes = expand(&cfg)?;
+    let auth = build_auth_catalog(cfg.auth.as_ref())?;
+    let ctx = CheckContext {
+        timeout: Duration::from_secs(args.timeout_secs),
+    };
+
+    let roots: Vec<&ExpandedNode> = nodes
+        .iter()
+        .filter(|n| matches!(n.role, NodeRole::Root))
+        .collect();
+    let n_children = nodes.len() - roots.len();
+
+    let permits = cfg
+        .execution
+        .as_ref()
+        .and_then(|e| e.max_concurrent)
+        .filter(|n| *n > 0)
+        .unwrap_or(8);
+    let sem = Arc::new(Semaphore::new(permits));
+
+    let mut handles = Vec::with_capacity(roots.len());
+    for node in &roots {
+        let id = node.id.clone();
+        let source = node.source.clone();
+        let sink = node.sink.clone();
+        let state = node.state.clone();
+        let auth = auth.clone();
+        let ctx = ctx.clone();
+        let sem = sem.clone();
+        handles.push(tokio::spawn(async move {
+            let _permit = sem.acquire_owned().await.expect("semaphore not closed");
+            probe_invocation(id, source, sink, state, &auth, &ctx).await
+        }));
+    }
+
+    let mut invocations = Vec::with_capacity(handles.len());
+    for h in handles {
+        invocations.push(h.await.expect("doctor probe task panicked"));
+    }
+
+    redact_invocations(&mut invocations);
+    let (_passed, failed, _skipped) = tally(&invocations);
+
+    if args.json {
+        let v = build_json(&path, overall.elapsed().as_millis(), &invocations);
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&v).expect("doctor json serializes")
+        );
+    } else {
+        render_human(cfg_ms, roots.len(), n_children, overall.elapsed(), &invocations);
+    }
+
+    if failed > 0 {
+        return Err(CliError::DoctorFailed { failed });
+    }
+    Ok(())
+}
+
+/// Build the three connectors for one invocation and run their probes.
+async fn probe_invocation(
+    id: String,
+    source: ConnectorSpec,
+    sink: ConnectorSpec,
+    state: Option<StateStoreSpec>,
+    auth: &AuthCatalog,
+    ctx: &CheckContext,
+) -> InvocationOut {
+    let mut probes = Vec::new();
+
+    match build_source(&source.kind, source.config.clone(), auth).await {
+        Ok(src) => probes.extend(collect_probes("source", src.connector_name(), ctx, src.check(ctx)).await),
+        Err(e) => probes.push(construct_fail("source", &source.kind, &e)),
+    }
+
+    match build_sink(&sink.kind, sink.config.clone(), auth).await {
+        Ok(snk) => probes.extend(collect_probes("sink", snk.connector_name(), ctx, snk.check(ctx)).await),
+        Err(e) => probes.push(construct_fail("sink", &sink.kind, &e)),
+    }
+
+    if let Some(spec) = state {
+        match build_state_store(&spec).await {
+            Ok(st) => {
+                probes.extend(collect_probes("state", &spec.kind, ctx, st.check(ctx)).await)
+            }
+            Err(e) => probes.push(construct_fail("state", &spec.kind, &e)),
+        }
+    }
+
+    InvocationOut {
+        id,
+        probes,
+        source_kind: source.kind,
+        sink_kind: sink.kind,
+    }
+}
+
+/// Run one connector's `check()` future under the timeout, mapping the report
+/// (or an outer error / timeout) into role-tagged [`ProbeOut`]s.
+async fn collect_probes(
+    role: &'static str,
+    connector: &str,
+    ctx: &CheckContext,
+    fut: impl std::future::Future<Output = Result<CheckReport, faucet_core::FaucetError>>,
+) -> Vec<ProbeOut> {
+    let start = Instant::now();
+    let report = match tokio::time::timeout(ctx.timeout, fut).await {
+        Err(_) => CheckReport::single(Probe::fail("timeout", start.elapsed(), "check timed out")),
+        Ok(Ok(r)) => r,
+        Ok(Err(e)) => CheckReport::single(Probe::fail("check", start.elapsed(), e.to_string())),
+    };
+    report
+        .probes
+        .into_iter()
+        .map(|p| ProbeOut::from_probe(role, connector.to_string(), p))
+        .collect()
+}
+
+/// A `construct` failure: the connector could not even be built from its config.
+/// Accepts any `Display` error (build errors are `CliError`; the unit test uses
+/// `FaucetError`).
+fn construct_fail(role: &'static str, kind: &str, e: impl std::fmt::Display) -> ProbeOut {
+    ProbeOut::from_probe(
+        role,
+        kind.to_string(),
+        Probe::fail("construct", Duration::ZERO, e.to_string()),
+    )
+}
+
+/// Scrub resolved secrets out of every probe `reason` / `hint`.
+fn redact_invocations(invs: &mut [InvocationOut]) {
+    for inv in invs.iter_mut() {
+        for p in inv.probes.iter_mut() {
+            match &mut p.status {
+                ProbeStatus::Fail { reason } | ProbeStatus::Skip { reason } => {
+                    *reason = redact(reason).into_owned();
+                }
+                ProbeStatus::Pass => {}
+            }
+            if let Some(h) = &mut p.hint {
+                *h = redact(h).into_owned();
+            }
+        }
+    }
+}
+
+/// Count (passed, failed, skipped) probes across all invocations.
+fn tally(invs: &[InvocationOut]) -> (usize, usize, usize) {
+    let (mut p, mut f, mut s) = (0usize, 0usize, 0usize);
+    for inv in invs {
+        for pr in &inv.probes {
+            match pr.status {
+                ProbeStatus::Pass => p += 1,
+                ProbeStatus::Fail { .. } => f += 1,
+                ProbeStatus::Skip { .. } => s += 1,
+            }
+        }
+    }
+    (p, f, s)
+}
+
+/// Build the `--json` envelope.
+fn build_json(config: &Path, total_ms: u128, invs: &[InvocationOut]) -> serde_json::Value {
+    let (passed, failed, skipped) = tally(invs);
+    serde_json::json!({
+        "config": config.display().to_string(),
+        "invocations": invs,
+        "summary": {
+            "passed": passed,
+            "failed": failed,
+            "skipped": skipped,
+            "elapsed_ms": total_ms,
+        }
+    })
+}
+
+/// Render the human checklist to stdout.
+fn render_human(
+    cfg_ms: u128,
+    n_roots: usize,
+    n_children: usize,
+    total: Duration,
+    invs: &[InvocationOut],
+) {
+    println!("✓ Config parses and interpolates{:>34} ms", cfg_ms);
+    println!(
+        "✓ Matrix expands to {} invocation{}{:>22} skipped (children)",
+        n_roots,
+        if n_roots == 1 { "" } else { "s" },
+        n_children
+    );
+
+    for inv in invs {
+        println!();
+        println!(
+            "▸ Invocation {}  (source={}, sink={})",
+            inv.id, inv.source_kind, inv.sink_kind
+        );
+        for p in &inv.probes {
+            let (sym, extra) = match &p.status {
+                ProbeStatus::Pass => ("✓", String::new()),
+                ProbeStatus::Fail { reason } => ("✗", format!(" ({reason})")),
+                ProbeStatus::Skip { reason } => ("•", format!(" (skip: {reason})")),
+            };
+            println!(
+                "  {} {:6} [{}] {}{}{:>8} ms",
+                sym, p.role, p.connector, p.name, extra, p.elapsed_ms
+            );
+            if let Some(hint) = &p.hint {
+                println!("        hint: {hint}");
+            }
+        }
+    }
+
+    let (passed, failed, skipped) = tally(invs);
+    println!();
+    println!(
+        "Summary: {passed} passed, {failed} failed, {skipped} skipped       total elapsed {:.1}s",
+        total.as_secs_f64()
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn probe_out(role: &'static str, name: &'static str, status: ProbeStatus) -> ProbeOut {
+        ProbeOut {
+            role,
+            connector: "x".into(),
+            name,
+            status,
+            elapsed_ms: 1,
+            hint: None,
+        }
+    }
+
+    fn inv(probes: Vec<ProbeOut>) -> InvocationOut {
+        InvocationOut {
+            id: "default".into(),
+            probes,
+            source_kind: "rest".into(),
+            sink_kind: "stdout".into(),
+        }
+    }
+
+    #[test]
+    fn tally_counts_each_status() {
+        let invs = vec![inv(vec![
+            probe_out("source", "read", ProbeStatus::Pass),
+            probe_out("sink", "auth", ProbeStatus::Fail { reason: "x".into() }),
+            probe_out("state", "sentinel", ProbeStatus::Skip { reason: "n/a".into() }),
+            probe_out("sink", "schema", ProbeStatus::Fail { reason: "y".into() }),
+        ])];
+        assert_eq!(tally(&invs), (1, 2, 1));
+    }
+
+    #[test]
+    fn json_has_summary_and_invocations() {
+        let invs = vec![inv(vec![probe_out("source", "read", ProbeStatus::Pass)])];
+        let v = build_json(Path::new("pipeline.yaml"), 100, &invs);
+        assert_eq!(v["config"], "pipeline.yaml");
+        assert_eq!(v["invocations"][0]["id"], "default");
+        assert_eq!(v["invocations"][0]["probes"][0]["role"], "source");
+        assert_eq!(v["invocations"][0]["probes"][0]["status"], "pass");
+        assert_eq!(v["summary"]["passed"], 1);
+        assert_eq!(v["summary"]["failed"], 0);
+        assert_eq!(v["summary"]["elapsed_ms"], 100);
+    }
+
+    #[test]
+    fn redaction_scrubs_secret_in_reason_and_hint() {
+        crate::secrets::registry::register("supersecretvalue");
+        let mut invs = vec![inv(vec![ProbeOut {
+            role: "sink",
+            connector: "postgres".into(),
+            name: "auth",
+            status: ProbeStatus::Fail {
+                reason: "login failed for supersecretvalue".into(),
+            },
+            elapsed_ms: 5,
+            hint: Some("token supersecretvalue rejected".into()),
+        }])];
+        redact_invocations(&mut invs);
+        if let ProbeStatus::Fail { reason } = &invs[0].probes[0].status {
+            assert!(!reason.contains("supersecretvalue"), "reason not redacted: {reason}");
+        } else {
+            panic!("expected fail");
+        }
+        assert!(!invs[0].probes[0].hint.as_ref().unwrap().contains("supersecretvalue"));
+    }
+
+    #[test]
+    fn construct_fail_is_a_fail_probe() {
+        let e = faucet_core::FaucetError::Config("bad".into());
+        let p = construct_fail("sink", "postgres", &e);
+        assert_eq!(p.name, "construct");
+        assert!(matches!(p.status, ProbeStatus::Fail { .. }));
+        assert_eq!(p.connector, "postgres");
+    }
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 //! Subcommand implementations. Each module owns its `run(...)` entry point
 //! and stays free of clap so the integration tests can drive it directly.
 
+pub mod doctor;
 pub mod init;
 pub mod list;
 pub mod preview;

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -303,6 +303,12 @@ pub enum CliError {
          the async load path — load via `faucet run`/`validate`/`preview` rather than the sync API"
     )]
     SecretsRequireAsyncLoad,
+
+    /// One or more `faucet doctor` preflight probes failed. The checklist is
+    /// printed by the command; `main` maps this to an exit code equal to the
+    /// failed-probe count (clamped to 255).
+    #[error("{failed} preflight probe(s) failed")]
+    DoctorFailed { failed: usize },
 }
 
 impl From<faucet_core::InstallError> for CliError {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -3,6 +3,7 @@
 use clap::Parser;
 use faucet_cli::cli::{Cli, Command};
 use faucet_cli::commands;
+use faucet_cli::error::CliError;
 #[cfg(feature = "observability")]
 use tracing_subscriber::EnvFilter;
 
@@ -18,9 +19,15 @@ async fn main() {
         Command::List => commands::list::run().await,
         Command::Preview(args) => commands::preview::run(args).await,
         Command::Init(args) => commands::init::run(args).await,
+        Command::Doctor(args) => commands::doctor::run(args).await,
     };
 
     if let Err(err) = result {
+        // `doctor` already printed its checklist; surface the failure count as
+        // the exit code (clamped to 255) rather than the generic exit-1 path.
+        if let CliError::DoctorFailed { failed } = &err {
+            std::process::exit((*failed).min(255) as i32);
+        }
         commands::report(&err);
         std::process::exit(1);
     }

--- a/cli/tests/doctor.rs
+++ b/cli/tests/doctor.rs
@@ -101,7 +101,8 @@ async fn doctor_json_emits_parseable_summary() {
         .stdout
         .clone();
 
-    let v: serde_json::Value = serde_json::from_slice(&output).expect("doctor --json emits valid JSON");
+    let v: serde_json::Value =
+        serde_json::from_slice(&output).expect("doctor --json emits valid JSON");
     assert!(v["summary"]["failed"].as_u64().unwrap() >= 1);
     assert_eq!(v["invocations"][0]["probes"][0]["role"], "source");
 }

--- a/cli/tests/doctor.rs
+++ b/cli/tests/doctor.rs
@@ -1,0 +1,107 @@
+//! `faucet doctor` end-to-end: a reachable source probes green, an unreachable
+//! one probes red with a non-zero exit, and `--json` emits a parseable summary.
+
+use assert_cmd::Command;
+use predicates::str::contains;
+use std::fs;
+use tempfile::TempDir;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// A complete, valid REST source config pointed at `base`, paired with a stdout
+/// sink. `pagination: None` so the read probe pulls exactly one page.
+fn rest_to_stdout(base: &str) -> String {
+    format!(
+        r#"version: 1
+name: doctor_smoke
+pipeline:
+  source:
+    type: rest
+    config:
+      base_url: {base}
+      path: /things
+      method: GET
+      auth:
+        type: none
+      query_params: {{}}
+      pagination:
+        type: None
+      max_retries: 0
+      retry_backoff: 0
+      tolerated_http_errors: []
+      replication_method:
+        type: FullTable
+      primary_keys: []
+      partitions: []
+      schema_sample_size: 0
+  sink:
+    type: stdout
+    config: {{}}
+"#
+    )
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn doctor_passes_for_reachable_source() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/things"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([{"id": 1}])))
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().unwrap();
+    let cfg = dir.path().join("pipeline.yaml");
+    fs::write(&cfg, rest_to_stdout(&server.uri())).unwrap();
+
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["doctor"])
+        .arg(&cfg)
+        .args(["--timeout-secs", "10"])
+        .assert()
+        .success()
+        .stdout(contains("source"))
+        .stdout(contains("read"))
+        .stdout(contains("0 failed"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn doctor_fails_for_unreachable_source() {
+    // Port 9 (discard) on loopback: connection refused, fast and deterministic.
+    let dir = TempDir::new().unwrap();
+    let cfg = dir.path().join("pipeline.yaml");
+    fs::write(&cfg, rest_to_stdout("http://127.0.0.1:9")).unwrap();
+
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["doctor"])
+        .arg(&cfg)
+        .args(["--timeout-secs", "5"])
+        .assert()
+        .failure()
+        .stdout(contains("✗"))
+        .stdout(contains("read"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn doctor_json_emits_parseable_summary() {
+    let dir = TempDir::new().unwrap();
+    let cfg = dir.path().join("pipeline.yaml");
+    fs::write(&cfg, rest_to_stdout("http://127.0.0.1:9")).unwrap();
+
+    let output = Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["doctor"])
+        .arg(&cfg)
+        .args(["--timeout-secs", "5", "--json"])
+        .assert()
+        .failure()
+        .get_output()
+        .stdout
+        .clone();
+
+    let v: serde_json::Value = serde_json::from_slice(&output).expect("doctor --json emits valid JSON");
+    assert!(v["summary"]["failed"].as_u64().unwrap() >= 1);
+    assert_eq!(v["invocations"][0]["probes"][0]["role"], "source");
+}

--- a/crates/core/src/check.rs
+++ b/crates/core/src/check.rs
@@ -1,0 +1,184 @@
+//! Preflight check types for `faucet doctor` (#126).
+//!
+//! A connector's `check()` returns a [`CheckReport`] of [`Probe`]s. Probe-level
+//! failures are [`ProbeStatus::Fail`] inside an `Ok(report)`; an `Err` from
+//! `check()` means "couldn't run any probe" and is rendered as a single failure.
+
+use serde::Serialize;
+use std::time::Duration;
+
+/// Inputs a probe may need. The doctor command enforces `timeout` on the whole
+/// `check()` call; connectors may also use it to bound their own client calls.
+#[derive(Debug, Clone)]
+pub struct CheckContext {
+    /// Wall-clock budget for a single `check()` invocation.
+    pub timeout: Duration,
+}
+
+impl Default for CheckContext {
+    fn default() -> Self {
+        Self {
+            timeout: Duration::from_secs(10),
+        }
+    }
+}
+
+/// Outcome of a single probe.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum ProbeStatus {
+    /// The probe succeeded.
+    Pass,
+    /// The probe ran and the target is unhealthy / unreachable / misconfigured.
+    Fail { reason: String },
+    /// The probe was not applicable (no check implemented, optional target absent).
+    Skip { reason: String },
+}
+
+/// One named probe within a [`CheckReport`] (e.g. `"read"`, `"auth"`,
+/// `"network"`, `"permissions"`, `"schema"`, `"io"`, `"sentinel"`).
+#[derive(Debug, Clone, Serialize)]
+pub struct Probe {
+    /// Short, stable probe name.
+    pub name: &'static str,
+    /// The outcome; serialized inline as `status` (+ `reason` on fail/skip).
+    #[serde(flatten)]
+    pub status: ProbeStatus,
+    /// Wall-clock time the probe took.
+    pub elapsed_ms: u64,
+    /// Remediation hint shown on failure. Must never contain secrets.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hint: Option<String>,
+}
+
+impl Probe {
+    /// A passing probe.
+    pub fn pass(name: &'static str, elapsed: Duration) -> Self {
+        Self {
+            name,
+            status: ProbeStatus::Pass,
+            elapsed_ms: elapsed.as_millis() as u64,
+            hint: None,
+        }
+    }
+
+    /// A failing probe with a reason and no hint.
+    pub fn fail(name: &'static str, elapsed: Duration, reason: impl Into<String>) -> Self {
+        Self {
+            name,
+            status: ProbeStatus::Fail {
+                reason: reason.into(),
+            },
+            elapsed_ms: elapsed.as_millis() as u64,
+            hint: None,
+        }
+    }
+
+    /// A failing probe with a reason and a remediation hint.
+    pub fn fail_hint(
+        name: &'static str,
+        elapsed: Duration,
+        reason: impl Into<String>,
+        hint: impl Into<String>,
+    ) -> Self {
+        Self {
+            name,
+            status: ProbeStatus::Fail {
+                reason: reason.into(),
+            },
+            elapsed_ms: elapsed.as_millis() as u64,
+            hint: Some(hint.into()),
+        }
+    }
+
+    /// A skipped (not-applicable) probe.
+    pub fn skip(name: &'static str, reason: impl Into<String>) -> Self {
+        Self {
+            name,
+            status: ProbeStatus::Skip {
+                reason: reason.into(),
+            },
+            elapsed_ms: 0,
+            hint: None,
+        }
+    }
+}
+
+/// A connector's full preflight report.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct CheckReport {
+    /// The probes run, in order.
+    pub probes: Vec<Probe>,
+}
+
+impl CheckReport {
+    /// A report with a single probe.
+    pub fn single(probe: Probe) -> Self {
+        Self {
+            probes: vec![probe],
+        }
+    }
+
+    /// The default report for connectors that don't implement a probe.
+    pub fn not_implemented() -> Self {
+        Self::single(Probe::skip("check", "no check implemented"))
+    }
+
+    /// Number of `Fail` probes (used to compute the doctor exit code).
+    pub fn failed_count(&self) -> usize {
+        self.probes
+            .iter()
+            .filter(|p| matches!(p.status, ProbeStatus::Fail { .. }))
+            .count()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn pass_and_fail_constructors_set_status_and_elapsed() {
+        let p = Probe::pass("read", Duration::from_millis(42));
+        assert_eq!(p.name, "read");
+        assert!(matches!(p.status, ProbeStatus::Pass));
+        assert_eq!(p.elapsed_ms, 42);
+        assert!(p.hint.is_none());
+
+        let f = Probe::fail_hint("auth", Duration::from_millis(5), "bad token", "set TOKEN");
+        assert!(matches!(f.status, ProbeStatus::Fail { .. }));
+        assert_eq!(f.hint.as_deref(), Some("set TOKEN"));
+    }
+
+    #[test]
+    fn not_implemented_is_a_single_skip() {
+        let r = CheckReport::not_implemented();
+        assert_eq!(r.probes.len(), 1);
+        assert!(matches!(r.probes[0].status, ProbeStatus::Skip { .. }));
+        assert_eq!(r.failed_count(), 0);
+    }
+
+    #[test]
+    fn failed_count_counts_only_fail() {
+        let r = CheckReport {
+            probes: vec![
+                Probe::pass("a", Duration::ZERO),
+                Probe::fail("b", Duration::ZERO, "x"),
+                Probe::skip("c", "n/a"),
+                Probe::fail("d", Duration::ZERO, "y"),
+            ],
+        };
+        assert_eq!(r.failed_count(), 2);
+    }
+
+    #[test]
+    fn probe_serializes_status_inline() {
+        let p = Probe::fail("auth", Duration::from_millis(1), "nope");
+        let v = serde_json::to_value(&p).unwrap();
+        assert_eq!(v["name"], "auth");
+        assert_eq!(v["status"], "fail");
+        assert_eq!(v["reason"], "nope");
+        assert_eq!(v["elapsed_ms"], 1);
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -14,6 +14,7 @@
 //! - [`schema::infer_schema`] — JSON Schema inference from record samples
 
 pub mod auth;
+pub mod check;
 pub mod config;
 pub mod dlq;
 pub mod error;
@@ -35,6 +36,7 @@ pub mod util;
 pub mod compression;
 
 pub use auth::{AuthProvider, AuthReference, AuthSpec, Credential, SharedAuthProvider};
+pub use check::{CheckContext, CheckReport, Probe, ProbeStatus};
 pub use dlq::{DlqConfig, DlqReason, DlqStats, OnBatchError, build_envelope};
 pub use error::FaucetError;
 #[cfg(feature = "quality")]

--- a/crates/core/src/state.rs
+++ b/crates/core/src/state.rs
@@ -39,7 +39,24 @@ pub trait StateStore: Send + Sync {
 
     /// Remove the entry for `key`. A missing key is not an error.
     async fn delete(&self, key: &str) -> Result<(), FaucetError>;
+
+    /// Run a fast, non-mutating preflight probe (used by `faucet doctor`).
+    ///
+    /// The default returns
+    /// [`CheckReport::not_implemented`](crate::check::CheckReport::not_implemented).
+    /// Built-in stores override this with a reachability + sentinel
+    /// get/put/delete probe that leaves no residue.
+    async fn check(
+        &self,
+        _ctx: &crate::check::CheckContext,
+    ) -> Result<crate::check::CheckReport, FaucetError> {
+        Ok(crate::check::CheckReport::not_implemented())
+    }
 }
+
+/// Sentinel key used by state-store `check()` probes. Valid per
+/// [`validate_state_key`] and deleted after the probe so it leaves no residue.
+pub const DOCTOR_SENTINEL_KEY: &str = "faucet_doctor_probe";
 
 /// Reject keys that could escape the storage namespace or break filename
 /// rules on common filesystems. Allowed: ASCII letters, digits, `_`, `-`,
@@ -104,6 +121,17 @@ impl StateStore for MemoryStateStore {
         validate_state_key(key)?;
         self.inner.lock().await.remove(key);
         Ok(())
+    }
+
+    async fn check(
+        &self,
+        _ctx: &crate::check::CheckContext,
+    ) -> Result<crate::check::CheckReport, FaucetError> {
+        // In-process map — always reachable.
+        Ok(crate::check::CheckReport::single(crate::check::Probe::pass(
+            "sentinel",
+            std::time::Duration::ZERO,
+        )))
     }
 }
 
@@ -276,6 +304,45 @@ impl StateStore for FileStateStore {
                 "failed to delete state file {}: {e}",
                 path.display()
             ))),
+        }
+    }
+
+    async fn check(
+        &self,
+        _ctx: &crate::check::CheckContext,
+    ) -> Result<crate::check::CheckReport, FaucetError> {
+        use crate::check::{CheckReport, Probe};
+        // Exercise the real put → get → delete cycle on a sentinel key. `put`
+        // creates the root dir if needed, so this validates "dir exists +
+        // writable" via the actual code path and leaves no residue.
+        let start = std::time::Instant::now();
+        let probe = match self.sentinel_roundtrip().await {
+            Ok(()) => Probe::pass("sentinel", start.elapsed()),
+            Err(e) => Probe::fail_hint(
+                "sentinel",
+                start.elapsed(),
+                e.to_string(),
+                format!("ensure {} exists and is writable", self.root.display()),
+            ),
+        };
+        Ok(CheckReport::single(probe))
+    }
+}
+
+impl FileStateStore {
+    /// Write, read back, and delete a sentinel key — the body of the `check()`
+    /// probe, factored out so the happy path stays linear.
+    async fn sentinel_roundtrip(&self) -> Result<(), FaucetError> {
+        let probe = serde_json::json!({ "faucet_doctor": true });
+        self.put(DOCTOR_SENTINEL_KEY, &probe).await?;
+        let got = self.get(DOCTOR_SENTINEL_KEY).await?;
+        // Best-effort cleanup regardless of the read result.
+        let _ = self.delete(DOCTOR_SENTINEL_KEY).await;
+        match got {
+            Some(v) if v == probe => Ok(()),
+            _ => Err(FaucetError::State(
+                "sentinel readback did not match what was written".into(),
+            )),
         }
     }
 }
@@ -532,5 +599,42 @@ mod tests {
         let s: Box<dyn StateStore> = Box::new(FileStateStore::new(dir.path()));
         s.put("k", &json!(1)).await.unwrap();
         assert_eq!(s.get("k").await.unwrap().unwrap(), json!(1));
+    }
+
+    // ── check() ──────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn memory_check_passes() {
+        let s = MemoryStateStore::new();
+        let report = s.check(&crate::check::CheckContext::default()).await.unwrap();
+        assert_eq!(report.failed_count(), 0);
+        assert!(
+            report
+                .probes
+                .iter()
+                .all(|p| matches!(p.status, crate::check::ProbeStatus::Pass))
+        );
+    }
+
+    #[tokio::test]
+    async fn file_check_passes_for_writable_root() {
+        let dir = TempDir::new().unwrap();
+        let s = FileStateStore::new(dir.path());
+        let report = s.check(&crate::check::CheckContext::default()).await.unwrap();
+        assert_eq!(report.failed_count(), 0, "writable root should pass");
+        // The sentinel probe must leave no residue.
+        let leftovers: Vec<_> = std::fs::read_dir(dir.path()).unwrap().collect();
+        assert!(leftovers.is_empty(), "check() must not leave files behind");
+    }
+
+    #[tokio::test]
+    async fn file_check_fails_when_root_unusable() {
+        // Root whose parent is a regular file → create_dir_all fails.
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("not_a_dir");
+        std::fs::write(&file, b"x").unwrap();
+        let s = FileStateStore::new(file.join("state"));
+        let report = s.check(&crate::check::CheckContext::default()).await.unwrap();
+        assert_eq!(report.failed_count(), 1, "unusable root should fail");
     }
 }

--- a/crates/core/src/state.rs
+++ b/crates/core/src/state.rs
@@ -128,10 +128,9 @@ impl StateStore for MemoryStateStore {
         _ctx: &crate::check::CheckContext,
     ) -> Result<crate::check::CheckReport, FaucetError> {
         // In-process map — always reachable.
-        Ok(crate::check::CheckReport::single(crate::check::Probe::pass(
-            "sentinel",
-            std::time::Duration::ZERO,
-        )))
+        Ok(crate::check::CheckReport::single(
+            crate::check::Probe::pass("sentinel", std::time::Duration::ZERO),
+        ))
     }
 }
 
@@ -606,7 +605,10 @@ mod tests {
     #[tokio::test]
     async fn memory_check_passes() {
         let s = MemoryStateStore::new();
-        let report = s.check(&crate::check::CheckContext::default()).await.unwrap();
+        let report = s
+            .check(&crate::check::CheckContext::default())
+            .await
+            .unwrap();
         assert_eq!(report.failed_count(), 0);
         assert!(
             report
@@ -620,7 +622,10 @@ mod tests {
     async fn file_check_passes_for_writable_root() {
         let dir = TempDir::new().unwrap();
         let s = FileStateStore::new(dir.path());
-        let report = s.check(&crate::check::CheckContext::default()).await.unwrap();
+        let report = s
+            .check(&crate::check::CheckContext::default())
+            .await
+            .unwrap();
         assert_eq!(report.failed_count(), 0, "writable root should pass");
         // The sentinel probe must leave no residue.
         let leftovers: Vec<_> = std::fs::read_dir(dir.path()).unwrap().collect();
@@ -634,7 +639,10 @@ mod tests {
         let file = dir.path().join("not_a_dir");
         std::fs::write(&file, b"x").unwrap();
         let s = FileStateStore::new(file.join("state"));
-        let report = s.check(&crate::check::CheckContext::default()).await.unwrap();
+        let report = s
+            .check(&crate::check::CheckContext::default())
+            .await
+            .unwrap();
         assert_eq!(report.failed_count(), 1, "unusable root should fail");
     }
 }

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -157,6 +157,36 @@ pub trait Source: Send + Sync {
     fn connector_name(&self) -> &'static str {
         crate::observability::strip_type_name(std::any::type_name::<Self>())
     }
+
+    /// Run a fast, non-mutating preflight probe (used by `faucet doctor`).
+    ///
+    /// The default pulls a **single page** via
+    /// [`stream_pages`](Self::stream_pages) and reports success/failure — it
+    /// exercises the real read path (DNS, TLS, auth, the first request, the
+    /// first-record decode) but never paginates the full dataset and never
+    /// repeats. The page stream is dropped immediately after the first page.
+    ///
+    /// Sources whose first page *blocks* waiting for inbound data (webhook,
+    /// websocket) or has *side effects* (CDC consuming WAL) override this with a
+    /// cheaper, side-effect-free probe. Probe-level failures are returned as a
+    /// [`ProbeStatus::Fail`](crate::check::ProbeStatus) inside `Ok(report)`.
+    async fn check(
+        &self,
+        ctx: &crate::check::CheckContext,
+    ) -> Result<crate::check::CheckReport, FaucetError> {
+        use crate::check::{CheckReport, Probe};
+        use futures::StreamExt;
+
+        let empty = std::collections::HashMap::new();
+        let start = std::time::Instant::now();
+        let mut pages = self.stream_pages(&empty, 1);
+        let probe = match tokio::time::timeout(ctx.timeout, pages.next()).await {
+            Err(_) => Probe::fail("read", start.elapsed(), "timed out fetching first page"),
+            Ok(None) | Ok(Some(Ok(_))) => Probe::pass("read", start.elapsed()),
+            Ok(Some(Err(e))) => Probe::fail("read", start.elapsed(), e.to_string()),
+        };
+        Ok(CheckReport::single(probe))
+    }
 }
 
 /// Per-row outcome from [`Sink::write_batch_partial`].
@@ -210,6 +240,23 @@ pub trait Sink: Send + Sync {
     /// `connector` attribute on spans. See `Source::connector_name`.
     fn connector_name(&self) -> &'static str {
         crate::observability::strip_type_name(std::any::type_name::<Self>())
+    }
+
+    /// Run a fast, non-mutating preflight probe (used by `faucet doctor`).
+    ///
+    /// Unlike sources, a sink has no non-mutating "first page" equivalent
+    /// (`write_batch` mutates the destination), so the default returns
+    /// [`CheckReport::not_implemented`](crate::check::CheckReport::not_implemented).
+    /// Built-in sinks override this with a connect / auth / metadata probe.
+    ///
+    /// The probe **MUST be idempotent and side-effect-free** — no inserts, no
+    /// residual rows or objects — and must never put credentials or connection
+    /// strings in a probe `reason`/`hint`.
+    async fn check(
+        &self,
+        _ctx: &crate::check::CheckContext,
+    ) -> Result<crate::check::CheckReport, FaucetError> {
+        Ok(crate::check::CheckReport::not_implemented())
     }
 }
 
@@ -579,5 +626,70 @@ mod tests {
         let outcomes = sink.write_batch_partial(&records).await.unwrap();
         assert_eq!(outcomes.len(), 2);
         assert!(outcomes.iter().all(|o| o.is_ok()));
+    }
+
+    // ── check() tests ─────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn source_default_check_pulls_first_page_and_passes() {
+        let source = MockSource {
+            records: vec![json!({"id": 1}), json!({"id": 2})],
+        };
+        let report = source
+            .check(&crate::check::CheckContext::default())
+            .await
+            .unwrap();
+        assert_eq!(report.failed_count(), 0);
+        assert!(report.probes.iter().any(|p| p.name == "read"
+            && matches!(p.status, crate::check::ProbeStatus::Pass)));
+    }
+
+    #[tokio::test]
+    async fn source_default_check_passes_on_empty_source() {
+        let source = MockSource { records: vec![] };
+        let report = source
+            .check(&crate::check::CheckContext::default())
+            .await
+            .unwrap();
+        // Reachable but empty is still a healthy source.
+        assert_eq!(report.failed_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn source_default_check_fails_when_fetch_errors() {
+        let source = FailingSource;
+        let report = source
+            .check(&crate::check::CheckContext::default())
+            .await
+            .unwrap();
+        assert_eq!(report.failed_count(), 1);
+        assert!(report.probes.iter().any(|p| p.name == "read"
+            && matches!(p.status, crate::check::ProbeStatus::Fail { .. })));
+    }
+
+    #[tokio::test]
+    async fn sink_default_check_is_not_implemented_skip() {
+        let sink = MockSink::new();
+        let report = sink
+            .check(&crate::check::CheckContext::default())
+            .await
+            .unwrap();
+        assert_eq!(report.probes.len(), 1);
+        assert!(matches!(
+            report.probes[0].status,
+            crate::check::ProbeStatus::Skip { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn source_check_callable_through_trait_object() {
+        let source: Box<dyn Source> = Box::new(MockSource {
+            records: vec![json!({"id": 1})],
+        });
+        let report = source
+            .check(&crate::check::CheckContext::default())
+            .await
+            .unwrap();
+        assert_eq!(report.failed_count(), 0);
     }
 }

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -640,8 +640,12 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(report.failed_count(), 0);
-        assert!(report.probes.iter().any(|p| p.name == "read"
-            && matches!(p.status, crate::check::ProbeStatus::Pass)));
+        assert!(
+            report
+                .probes
+                .iter()
+                .any(|p| p.name == "read" && matches!(p.status, crate::check::ProbeStatus::Pass))
+        );
     }
 
     #[tokio::test]
@@ -663,8 +667,9 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(report.failed_count(), 1);
-        assert!(report.probes.iter().any(|p| p.name == "read"
-            && matches!(p.status, crate::check::ProbeStatus::Fail { .. })));
+        assert!(report.probes.iter().any(
+            |p| p.name == "read" && matches!(p.status, crate::check::ProbeStatus::Fail { .. })
+        ));
     }
 
     #[tokio::test]

--- a/crates/sink/bigquery/src/sink.rs
+++ b/crates/sink/bigquery/src/sink.rs
@@ -122,6 +122,64 @@ impl faucet_core::Sink for BigQuerySink {
             .expect("schema serialization")
     }
 
+    /// Preflight check (`faucet doctor`).
+    ///
+    /// Runs a single read-only `tables.get` against the configured
+    /// `project_id.dataset_id.table_id` using the already-authenticated
+    /// client built in [`BigQuerySink::new`]. This mints/uses the access
+    /// token and confirms the credentials can read the target table's
+    /// metadata — without inserting any rows. Auth, missing-dataset,
+    /// missing-table, and permission errors all surface as a `Fail` probe
+    /// with a remediation hint. The access token is never included in the
+    /// reason or hint.
+    async fn check(
+        &self,
+        ctx: &faucet_core::check::CheckContext,
+    ) -> Result<faucet_core::check::CheckReport, FaucetError> {
+        use faucet_core::check::{CheckReport, Probe};
+
+        let started = std::time::Instant::now();
+        let fqn = format!(
+            "{}.{}.{}",
+            self.config.project_id, self.config.dataset_id, self.config.table_id
+        );
+
+        let result = tokio::time::timeout(
+            ctx.timeout,
+            self.client.table().get(
+                &self.config.project_id,
+                &self.config.dataset_id,
+                &self.config.table_id,
+                Some(vec!["tableReference"]),
+            ),
+        )
+        .await;
+
+        let probe = match result {
+            Ok(Ok(_table)) => Probe::pass("auth", started.elapsed()),
+            Ok(Err(e)) => Probe::fail_hint(
+                "auth",
+                started.elapsed(),
+                format!("BigQuery tables.get on {fqn} failed: {e}"),
+                "Verify the service account has roles/bigquery.dataViewer (or \
+                 read access) on the dataset and that the project, dataset, and \
+                 table IDs are correct.",
+            ),
+            Err(_elapsed) => Probe::fail_hint(
+                "auth",
+                started.elapsed(),
+                format!(
+                    "BigQuery tables.get on {fqn} timed out after {:?}",
+                    ctx.timeout
+                ),
+                "Check network reachability to bigquery.googleapis.com and that \
+                 credentials can be minted within the timeout.",
+            ),
+        };
+
+        Ok(CheckReport::single(probe))
+    }
+
     /// Write records to BigQuery.
     ///
     /// When `config.batch_size > 0` and the input slice is larger than

--- a/crates/sink/csv/src/lib.rs
+++ b/crates/sink/csv/src/lib.rs
@@ -7,6 +7,7 @@
 //! Writes JSON records to a CSV file with configurable delimiter and headers.
 
 pub mod config;
+pub(crate) mod probe;
 pub mod sink;
 
 pub use faucet_core::{FaucetError, Sink};

--- a/crates/sink/csv/src/probe.rs
+++ b/crates/sink/csv/src/probe.rs
@@ -1,0 +1,71 @@
+//! Shared preflight-probe helper for the CSV file sink (`faucet doctor`).
+
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use faucet_core::check::Probe;
+
+/// Probe whether the parent directory of `path` exists and is writable.
+///
+/// Idempotent: creates a uniquely-named temp file in the parent directory and
+/// removes it immediately. Never touches the configured output file itself.
+///
+/// The filesystem work runs on the synchronous `std::fs` API so the probe does
+/// not depend on tokio's `fs` feature being enabled in this crate's non-dev
+/// build (the CSV sink already does all its I/O via `spawn_blocking`).
+///
+/// - Parent exists and a temp file can be created + removed → [`Probe::pass`].
+/// - Parent directory is missing → [`Probe::fail_hint`] naming the directory.
+/// - Parent exists but the temp file cannot be created → [`Probe::fail_hint`]
+///   surfacing the I/O error (e.g. permission denied, read-only filesystem).
+pub fn probe_parent_writable(path: &str, start: Instant) -> Probe {
+    // A path with no parent component (e.g. a bare filename) targets the
+    // current working directory.
+    let parent = match Path::new(path).parent() {
+        Some(p) if !p.as_os_str().is_empty() => p.to_path_buf(),
+        _ => PathBuf::from("."),
+    };
+
+    if !parent.is_dir() {
+        return Probe::fail_hint(
+            "io",
+            start.elapsed(),
+            format!("parent directory {} does not exist", parent.display()),
+            format!(
+                "create the directory {} before running the pipeline",
+                parent.display()
+            ),
+        );
+    }
+
+    // Unique temp file name so concurrent probes don't collide.
+    let probe_path = parent.join(format!(".faucet_doctor_probe-{}", uuid_like()));
+    match std::fs::File::create(&probe_path) {
+        Ok(_) => {
+            // Best-effort cleanup; a leftover empty probe file is harmless but
+            // we remove it to keep the directory clean.
+            let _ = std::fs::remove_file(&probe_path);
+            Probe::pass("io", start.elapsed())
+        }
+        Err(e) => Probe::fail_hint(
+            "io",
+            start.elapsed(),
+            format!("cannot write to directory {}: {e}", parent.display()),
+            "ensure the directory is writable by the current user",
+        ),
+    }
+}
+
+/// Cheap, dependency-free unique token for the temp-file name. Combines the
+/// process id, a monotonic counter, and the current nanosecond timestamp so
+/// concurrent probes within and across processes don't collide.
+fn uuid_like() -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    format!("{}-{}-{}", std::process::id(), n, nanos)
+}

--- a/crates/sink/csv/src/sink.rs
+++ b/crates/sink/csv/src/sink.rs
@@ -159,6 +159,26 @@ impl faucet_core::Sink for CsvSink {
         }
         Ok(())
     }
+
+    /// Preflight probe for `faucet doctor`. Verifies the configured output
+    /// path's parent directory exists and is writable by creating, then
+    /// immediately removing, a uniquely-named temp file there. Never touches
+    /// the user's actual output file, so it is fully idempotent.
+    async fn check(
+        &self,
+        _ctx: &faucet_core::check::CheckContext,
+    ) -> Result<faucet_core::check::CheckReport, FaucetError> {
+        use faucet_core::check::CheckReport;
+        let path = self.config.path.clone();
+        // The filesystem probe is synchronous; run it on a blocking thread to
+        // stay off the async runtime, matching how the sink does its I/O.
+        let probe = tokio::task::spawn_blocking(move || {
+            crate::probe::probe_parent_writable(&path, std::time::Instant::now())
+        })
+        .await
+        .map_err(|e| FaucetError::Sink(format!("CSV check task failed: {e}")))?;
+        Ok(CheckReport::single(probe))
+    }
 }
 
 /// Synchronous CSV writing logic, run inside `spawn_blocking`.
@@ -353,6 +373,36 @@ mod tests {
         let path = tmp.path().to_str().unwrap().to_string();
         let sink = CsvSink::new(CsvSinkConfig::new(&path));
         assert!(sink.flush().await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn check_passes_when_parent_dir_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("out.csv");
+        let path_str = path.to_str().unwrap().to_string();
+        let sink = CsvSink::new(CsvSinkConfig::new(&path_str));
+        let report = sink
+            .check(&faucet_core::check::CheckContext::default())
+            .await
+            .unwrap();
+        assert_eq!(report.failed_count(), 0);
+        assert_eq!(report.probes[0].name, "io");
+        // The probe must not have created the user's output file.
+        assert!(!path.exists(), "check() must not create the output file");
+    }
+
+    #[tokio::test]
+    async fn check_fails_when_parent_dir_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nope").join("out.csv");
+        let path_str = path.to_str().unwrap().to_string();
+        let sink = CsvSink::new(CsvSinkConfig::new(&path_str));
+        let report = sink
+            .check(&faucet_core::check::CheckContext::default())
+            .await
+            .unwrap();
+        assert_eq!(report.failed_count(), 1);
+        assert_eq!(report.probes[0].name, "io");
     }
 
     #[cfg(feature = "compression")]

--- a/crates/sink/elasticsearch/src/sink.rs
+++ b/crates/sink/elasticsearch/src/sink.rs
@@ -176,6 +176,97 @@ impl faucet_core::Sink for ElasticsearchSink {
             .expect("schema serialization")
     }
 
+    /// Non-mutating preflight probe.
+    ///
+    /// Runs `GET /_cluster/health` over the existing reqwest client (probe
+    /// name `"health"`). When an index is configured, a second probe
+    /// (`"schema"`) issues `HEAD /<index>`: a `404` is reported as a
+    /// [`Skip`](faucet_core::check::ProbeStatus::Skip) ("index not found"),
+    /// any other HTTP response is a pass, and a transport error is a failure.
+    async fn check(
+        &self,
+        ctx: &faucet_core::check::CheckContext,
+    ) -> Result<faucet_core::check::CheckReport, FaucetError> {
+        use faucet_core::check::{CheckReport, Probe};
+
+        // Auth is shared by both probes; if it can't be resolved the whole
+        // check fails on the `health` probe.
+        let auth = match self.resolve_auth().await {
+            Ok(a) => a,
+            Err(e) => {
+                return Ok(CheckReport::single(Probe::fail_hint(
+                    "health",
+                    std::time::Duration::ZERO,
+                    e.to_string(),
+                    "check the configured auth / that a shared auth provider is wired up",
+                )));
+            }
+        };
+
+        let mut probes = Vec::new();
+        let health_hint =
+            "check base_url / auth / that the Elasticsearch cluster is reachable and healthy";
+
+        // ── Probe 1: GET /_cluster/health ───────────────────────────────────
+        // The per-request `.timeout(ctx.timeout)` bounds the call; this crate
+        // has no direct `tokio` dependency so we rely on reqwest's own timeout.
+        let started = std::time::Instant::now();
+        let health_url = format!("{}/_cluster/health", self.config.base_url);
+        let req = Self::apply_auth_value(self.client.get(&health_url), &auth).timeout(ctx.timeout);
+        let health_probe = match req.send().await {
+            Ok(resp) => {
+                if resp.status().is_success() {
+                    Probe::pass("health", started.elapsed())
+                } else {
+                    Probe::fail_hint(
+                        "health",
+                        started.elapsed(),
+                        format!("cluster health returned HTTP {}", resp.status().as_u16()),
+                        health_hint,
+                    )
+                }
+            }
+            Err(e) if e.is_timeout() => {
+                Probe::fail_hint("health", started.elapsed(), "timed out", health_hint)
+            }
+            Err(e) => Probe::fail_hint("health", started.elapsed(), e.to_string(), health_hint),
+        };
+        let health_failed = matches!(
+            health_probe.status,
+            faucet_core::check::ProbeStatus::Fail { .. }
+        );
+        probes.push(health_probe);
+
+        // ── Probe 2 (optional): HEAD /<index> ───────────────────────────────
+        // Only run when the cluster itself is reachable — a transport failure
+        // on the index HEAD would just duplicate the health failure.
+        if !health_failed && !self.config.index.is_empty() {
+            let started = std::time::Instant::now();
+            let index_hint = "check that the index exists / base_url is correct";
+            let index_url = format!("{}/{}", self.config.base_url, self.config.index);
+            let req =
+                Self::apply_auth_value(self.client.head(&index_url), &auth).timeout(ctx.timeout);
+            let schema_probe = match req.send().await {
+                // 404 → index absent: report as Skip, not a failure (it may be
+                // auto-created on first write).
+                Ok(resp) if resp.status().as_u16() == 404 => {
+                    Probe::skip("schema", format!("index '{}' not found", self.config.index))
+                }
+                // Any other HTTP response means the host answered — the index
+                // exists (2xx) or the request was rejected for some non-404
+                // reason; either way the endpoint is reachable.
+                Ok(_) => Probe::pass("schema", started.elapsed()),
+                Err(e) if e.is_timeout() => {
+                    Probe::fail_hint("schema", started.elapsed(), "timed out", index_hint)
+                }
+                Err(e) => Probe::fail_hint("schema", started.elapsed(), e.to_string(), index_hint),
+            };
+            probes.push(schema_probe);
+        }
+
+        Ok(CheckReport { probes })
+    }
+
     /// Write records to Elasticsearch using the `_bulk` API.
     ///
     /// When `config.batch_size > 0` and the input slice is larger than

--- a/crates/sink/gcs/src/sink.rs
+++ b/crates/sink/gcs/src/sink.rs
@@ -3,7 +3,7 @@
 use crate::config::GcsSinkConfig;
 use async_trait::async_trait;
 use faucet_core::FaucetError;
-use faucet_gcs_common::build_storage;
+use faucet_gcs_common::{build_storage, build_storage_control};
 use futures::stream::{self, StreamExt, TryStreamExt};
 use google_cloud_storage::client::Storage;
 use serde_json::Value;
@@ -104,6 +104,61 @@ impl faucet_core::Sink for GcsSink {
 
     fn connector_name(&self) -> &'static str {
         "gcs"
+    }
+
+    /// Preflight probe: confirm the configured bucket is reachable and the
+    /// credentials work via a non-mutating `list_objects` call capped at a
+    /// single result. Writes nothing.
+    ///
+    /// The sink only holds a data-plane [`Storage`] client (which exposes no
+    /// list/get-bucket call), so the probe builds a control-plane
+    /// `StorageControl` client on demand using the same credentials.
+    async fn check(
+        &self,
+        ctx: &faucet_core::check::CheckContext,
+    ) -> Result<faucet_core::check::CheckReport, FaucetError> {
+        use faucet_core::check::{CheckReport, Probe};
+
+        let started = std::time::Instant::now();
+
+        // Build a control-plane client (the data-plane Storage client has no
+        // read-only list/get-bucket call). Credential/client-build failures
+        // surface as a failed probe rather than an Err.
+        let control =
+            match build_storage_control(&self.config.auth, self.config.storage_host.as_deref())
+                .await
+            {
+                Ok(c) => c,
+                Err(e) => {
+                    return Ok(CheckReport::single(Probe::fail_hint(
+                        "auth",
+                        started.elapsed(),
+                        e.to_string(),
+                        "check bucket name, credentials, and network",
+                    )));
+                }
+            };
+
+        let probe = match tokio::time::timeout(
+            ctx.timeout,
+            control
+                .list_objects()
+                .set_parent(self.bucket_path())
+                .set_page_size(1_i32)
+                .send(),
+        )
+        .await
+        {
+            Ok(Ok(_)) => Probe::pass("auth", started.elapsed()),
+            Ok(Err(e)) => Probe::fail_hint(
+                "auth",
+                started.elapsed(),
+                e.to_string(),
+                "check bucket name, credentials, and network",
+            ),
+            Err(_) => Probe::fail("network", started.elapsed(), "timed out"),
+        };
+        Ok(CheckReport::single(probe))
     }
 }
 

--- a/crates/sink/http/src/sink.rs
+++ b/crates/sink/http/src/sink.rs
@@ -169,6 +169,63 @@ impl faucet_core::Sink for HttpSink {
             .expect("schema serialization")
     }
 
+    /// Non-mutating preflight probe (probe name `"network"`).
+    ///
+    /// Issues a lightweight `HEAD` request to the configured endpoint over the
+    /// existing reqwest client. We only care that the host is reachable — that
+    /// DNS, TCP, TLS and the server all work — so **any** HTTP response (2xx,
+    /// 4xx including `405 Method Not Allowed`, or 5xx) counts as a pass. Only a
+    /// transport/connection error (no response at all) is a failure.
+    async fn check(
+        &self,
+        ctx: &faucet_core::check::CheckContext,
+    ) -> Result<faucet_core::check::CheckReport, FaucetError> {
+        use faucet_core::check::{CheckReport, Probe};
+
+        // Resolve auth so authenticated endpoints don't reject the connection
+        // before we learn the host is reachable. An unresolvable auth ref is a
+        // configuration failure surfaced on this probe.
+        let auth = match self.resolve_auth().await {
+            Ok(a) => a,
+            Err(e) => {
+                return Ok(CheckReport::single(Probe::fail_hint(
+                    "network",
+                    std::time::Duration::ZERO,
+                    e.to_string(),
+                    "check the configured auth / that a shared auth provider is wired up",
+                )));
+            }
+        };
+
+        let started = std::time::Instant::now();
+        let hint = "check the url / DNS / TLS / that the host is reachable";
+
+        let req = self
+            .client
+            .head(&self.config.url)
+            .headers(self.config.headers.clone());
+        let req = match self.apply_auth(req, &auth) {
+            Ok(r) => r,
+            Err(e) => {
+                return Ok(CheckReport::single(Probe::fail_hint(
+                    "network",
+                    started.elapsed(),
+                    e.to_string(),
+                    hint,
+                )));
+            }
+        };
+
+        let probe = match tokio::time::timeout(ctx.timeout, req.send()).await {
+            // Any HTTP response means DNS + TCP + TLS + the host all work.
+            Ok(Ok(_)) => Probe::pass("network", started.elapsed()),
+            // Transport/connection error: no response received.
+            Ok(Err(e)) => Probe::fail_hint("network", started.elapsed(), e.to_string(), hint),
+            Err(_) => Probe::fail_hint("network", started.elapsed(), "timed out", hint),
+        };
+        Ok(CheckReport::single(probe))
+    }
+
     async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
         if records.is_empty() {
             return Ok(0);

--- a/crates/sink/jsonl/src/lib.rs
+++ b/crates/sink/jsonl/src/lib.rs
@@ -8,6 +8,7 @@
 //! format (one JSON object per line).
 
 pub mod config;
+pub(crate) mod probe;
 pub mod sink;
 
 pub use faucet_core::{FaucetError, Sink};

--- a/crates/sink/jsonl/src/probe.rs
+++ b/crates/sink/jsonl/src/probe.rs
@@ -1,0 +1,67 @@
+//! Shared preflight-probe helper for the JSONL file sink (`faucet doctor`).
+
+use std::path::Path;
+use std::time::Instant;
+
+use faucet_core::check::Probe;
+
+/// Probe whether the parent directory of `path` exists and is writable.
+///
+/// Idempotent: creates a uniquely-named temp file in the parent directory and
+/// removes it immediately. Never touches the configured output file itself.
+///
+/// - Parent exists and a temp file can be created + removed → [`Probe::pass`].
+/// - Parent directory is missing → [`Probe::fail_hint`] naming the directory.
+/// - Parent exists but the temp file cannot be created → [`Probe::fail_hint`]
+///   surfacing the I/O error (e.g. permission denied, read-only filesystem).
+pub async fn probe_parent_writable(path: &Path, start: Instant) -> Probe {
+    // A path with no parent component (e.g. a bare filename) targets the
+    // current working directory.
+    let parent = match path.parent() {
+        Some(p) if !p.as_os_str().is_empty() => p.to_path_buf(),
+        _ => std::path::PathBuf::from("."),
+    };
+
+    if !tokio::fs::try_exists(&parent).await.unwrap_or(false) {
+        return Probe::fail_hint(
+            "io",
+            start.elapsed(),
+            format!("parent directory {} does not exist", parent.display()),
+            format!(
+                "create the directory {} before running the pipeline",
+                parent.display()
+            ),
+        );
+    }
+
+    // Unique temp file name so concurrent probes don't collide.
+    let probe_path = parent.join(format!(".faucet_doctor_probe-{}", uuid_like()));
+    match tokio::fs::write(&probe_path, b"").await {
+        Ok(()) => {
+            // Best-effort cleanup; a leftover empty probe file is harmless but
+            // we remove it to keep the directory clean.
+            let _ = tokio::fs::remove_file(&probe_path).await;
+            Probe::pass("io", start.elapsed())
+        }
+        Err(e) => Probe::fail_hint(
+            "io",
+            start.elapsed(),
+            format!("cannot write to directory {}: {e}", parent.display()),
+            "ensure the directory is writable by the current user",
+        ),
+    }
+}
+
+/// Cheap, dependency-free unique token for the temp-file name. Combines the
+/// process id, a monotonic counter, and the current nanosecond timestamp so
+/// concurrent probes within and across processes don't collide.
+fn uuid_like() -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    format!("{}-{}-{}", std::process::id(), n, nanos)
+}

--- a/crates/sink/jsonl/src/sink.rs
+++ b/crates/sink/jsonl/src/sink.rs
@@ -149,6 +149,20 @@ impl faucet_core::Sink for JsonlSink {
         }
         Ok(())
     }
+
+    /// Preflight probe for `faucet doctor`. Verifies the configured output
+    /// path's parent directory exists and is writable by creating, then
+    /// immediately removing, a uniquely-named temp file there. Never touches
+    /// the user's actual output file, so it is fully idempotent.
+    async fn check(
+        &self,
+        _ctx: &faucet_core::check::CheckContext,
+    ) -> Result<faucet_core::check::CheckReport, FaucetError> {
+        use faucet_core::check::CheckReport;
+        let start = std::time::Instant::now();
+        let probe = crate::probe::probe_parent_writable(&self.config.path, start).await;
+        Ok(CheckReport::single(probe))
+    }
 }
 
 #[cfg(test)]
@@ -239,6 +253,34 @@ mod tests {
         let tmp = NamedTempFile::new().unwrap();
         let sink = JsonlSink::new(JsonlSinkConfig::new(tmp.path()));
         assert_eq!(sink.connector_name(), "jsonl");
+    }
+
+    #[tokio::test]
+    async fn check_passes_when_parent_dir_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("out.jsonl");
+        let sink = JsonlSink::new(JsonlSinkConfig::new(&path));
+        let report = sink
+            .check(&faucet_core::check::CheckContext::default())
+            .await
+            .unwrap();
+        assert_eq!(report.failed_count(), 0);
+        assert_eq!(report.probes[0].name, "io");
+        // The probe must not have created the user's output file.
+        assert!(!path.exists(), "check() must not create the output file");
+    }
+
+    #[tokio::test]
+    async fn check_fails_when_parent_dir_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nope").join("out.jsonl");
+        let sink = JsonlSink::new(JsonlSinkConfig::new(&path));
+        let report = sink
+            .check(&faucet_core::check::CheckContext::default())
+            .await
+            .unwrap();
+        assert_eq!(report.failed_count(), 1);
+        assert_eq!(report.probes[0].name, "io");
     }
 
     #[cfg(feature = "compression")]

--- a/crates/sink/kafka/src/sink.rs
+++ b/crates/sink/kafka/src/sink.rs
@@ -284,6 +284,61 @@ impl Sink for KafkaSink {
         let schema = schemars::schema_for!(KafkaSinkConfig);
         serde_json::to_value(&schema).unwrap_or(Value::Null)
     }
+
+    /// Preflight check (`faucet doctor`).
+    ///
+    /// Fetches cluster metadata for all topics via the existing producer's
+    /// underlying client (`producer.client().fetch_metadata(None, timeout)`),
+    /// which validates broker connectivity and authentication without
+    /// producing any messages. `fetch_metadata` is a blocking librdkafka
+    /// call, so it runs on a blocking thread; the whole probe is bounded by
+    /// `ctx.timeout` (also passed to librdkafka as its own metadata timeout).
+    /// Connection/auth failures surface as a `Fail` probe with a hint; no
+    /// credentials are placed in the reason/hint.
+    async fn check(
+        &self,
+        ctx: &faucet_core::check::CheckContext,
+    ) -> Result<faucet_core::check::CheckReport, FaucetError> {
+        use faucet_core::check::{CheckReport, Probe};
+
+        let started = std::time::Instant::now();
+        let producer = self.producer.clone();
+        let timeout = ctx.timeout;
+
+        // `fetch_metadata` blocks (FFI into librdkafka), so run it off the
+        // async runtime. Bound the await with `ctx.timeout` as well, in case
+        // the blocking call ignores its own deadline.
+        let join = tokio::time::timeout(
+            timeout,
+            tokio::task::spawn_blocking(move || producer.client().fetch_metadata(None, timeout)),
+        )
+        .await;
+
+        let probe = match join {
+            Ok(Ok(Ok(_metadata))) => Probe::pass("metadata", started.elapsed()),
+            Ok(Ok(Err(e))) => Probe::fail_hint(
+                "metadata",
+                started.elapsed(),
+                format!("kafka fetch_metadata failed: {e}"),
+                "Verify the broker list is reachable and that any SASL/TLS \
+                 credentials and protocol settings are correct.",
+            ),
+            Ok(Err(join_err)) => Probe::fail(
+                "metadata",
+                started.elapsed(),
+                format!("kafka metadata probe task failed: {join_err}"),
+            ),
+            Err(_elapsed) => Probe::fail_hint(
+                "metadata",
+                started.elapsed(),
+                format!("kafka fetch_metadata timed out after {timeout:?}"),
+                "Check broker reachability and authentication; the cluster did \
+                 not return metadata within the timeout.",
+            ),
+        };
+
+        Ok(CheckReport::single(probe))
+    }
 }
 
 /// Send a single record, retrying on `QueueFull` up to `max_retries` times

--- a/crates/sink/mongodb/Cargo.toml
+++ b/crates/sink/mongodb/Cargo.toml
@@ -18,6 +18,7 @@ serde_json.workspace = true
 async-trait.workspace = true
 tracing.workspace = true
 mongodb = { workspace = true }
+tokio = { workspace = true, features = ["time"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }

--- a/crates/sink/mongodb/src/sink.rs
+++ b/crates/sink/mongodb/src/sink.rs
@@ -48,6 +48,27 @@ impl faucet_core::Sink for MongoSink {
             .expect("schema serialization")
     }
 
+    /// Non-mutating preflight probe: run the `ping` admin command against the
+    /// configured database via the existing client (probe name `"ping"`).
+    async fn check(
+        &self,
+        ctx: &faucet_core::check::CheckContext,
+    ) -> Result<faucet_core::check::CheckReport, FaucetError> {
+        use faucet_core::check::{CheckReport, Probe};
+
+        let started = std::time::Instant::now();
+        let hint = "check connection_uri / credentials / that the MongoDB server is reachable";
+
+        let db = self.client.database(&self.config.database);
+        let probe =
+            match tokio::time::timeout(ctx.timeout, db.run_command(bson::doc! {"ping": 1})).await {
+                Ok(Ok(_)) => Probe::pass("ping", started.elapsed()),
+                Ok(Err(e)) => Probe::fail_hint("ping", started.elapsed(), e.to_string(), hint),
+                Err(_) => Probe::fail_hint("ping", started.elapsed(), "timed out", hint),
+            };
+        Ok(CheckReport::single(probe))
+    }
+
     /// Write records to MongoDB.
     ///
     /// When `config.batch_size > 0` and the input slice is larger than

--- a/crates/sink/mysql/Cargo.toml
+++ b/crates/sink/mysql/Cargo.toml
@@ -18,6 +18,7 @@ serde_json.workspace = true
 async-trait.workspace = true
 tracing.workspace = true
 sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls", "mysql", "json"] }
+tokio.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/sink/mysql/src/sink.rs
+++ b/crates/sink/mysql/src/sink.rs
@@ -192,6 +192,39 @@ impl faucet_core::Sink for MysqlSink {
             .expect("schema serialization")
     }
 
+    /// Preflight connectivity probe (`faucet doctor`).
+    ///
+    /// Acquires a connection from the existing pool and runs `SELECT 1`. This
+    /// is non-mutating and idempotent — it validates that the database is
+    /// reachable and the credentials are accepted without writing anything.
+    async fn check(
+        &self,
+        ctx: &faucet_core::check::CheckContext,
+    ) -> Result<faucet_core::check::CheckReport, FaucetError> {
+        use faucet_core::check::{CheckReport, Probe};
+
+        let started = std::time::Instant::now();
+        let probe =
+            match tokio::time::timeout(ctx.timeout, sqlx::query("SELECT 1").execute(&self.pool))
+                .await
+            {
+                Ok(Ok(_)) => Probe::pass("auth", started.elapsed()),
+                Ok(Err(e)) => Probe::fail_hint(
+                    "auth",
+                    started.elapsed(),
+                    e.to_string(),
+                    "check connection_url / credentials / that the database is reachable",
+                ),
+                Err(_) => Probe::fail_hint(
+                    "auth",
+                    started.elapsed(),
+                    "timed out",
+                    "check connection_url / credentials / that the database is reachable",
+                ),
+            };
+        Ok(CheckReport::single(probe))
+    }
+
     /// Write records to MySQL.
     ///
     /// When `config.batch_size > 0` and the input slice is larger than

--- a/crates/sink/parquet/src/sink.rs
+++ b/crates/sink/parquet/src/sink.rs
@@ -314,6 +314,82 @@ impl faucet_core::Sink for ParquetSink {
         tracing::debug!(files = state.files_written, "Parquet sink flushed");
         Ok(())
     }
+
+    /// Preflight probe for `faucet doctor`.
+    ///
+    /// For a local destination, verifies the target's parent directory exists
+    /// and is writable by creating and immediately removing a uniquely-named
+    /// temp file there — never touching the user's actual output. For an S3
+    /// destination the probe is skipped: object-store targets are not probed by
+    /// the doctor.
+    async fn check(
+        &self,
+        _ctx: &faucet_core::check::CheckContext,
+    ) -> Result<faucet_core::check::CheckReport, FaucetError> {
+        use faucet_core::check::{CheckReport, Probe};
+
+        let path = match &self.config.destination {
+            ParquetDestination::S3(_) => {
+                return Ok(CheckReport::single(Probe::skip(
+                    "io",
+                    "object-store target not probed by doctor",
+                )));
+            }
+            ParquetDestination::LocalPath { path } => path.clone(),
+        };
+
+        // Guard against object-store URLs that slipped into a LocalPath
+        // destination (e.g. `s3://` / `gs://`): treat them as object-store
+        // targets and skip rather than mis-probing the local filesystem.
+        let lower = path.to_ascii_lowercase();
+        if lower.starts_with("s3://") || lower.starts_with("gs://") {
+            return Ok(CheckReport::single(Probe::skip(
+                "io",
+                "object-store target not probed by doctor",
+            )));
+        }
+
+        let start = std::time::Instant::now();
+
+        // Mirror `build_store`'s parent-directory derivation: a `.parquet`
+        // path is a single file whose parent is the target directory; any
+        // other path is itself the (directory) destination.
+        let target = FsPath::new(&path);
+        let parent = if target.extension().and_then(|e| e.to_str()) == Some("parquet") {
+            target.parent().map(|p| p.to_path_buf())
+        } else {
+            Some(PathBuf::from(&path))
+        }
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or_else(|| PathBuf::from("."));
+
+        if !tokio::fs::try_exists(&parent).await.unwrap_or(false) {
+            return Ok(CheckReport::single(Probe::fail_hint(
+                "io",
+                start.elapsed(),
+                format!("parent directory {} does not exist", parent.display()),
+                format!(
+                    "create the directory {} before running the pipeline",
+                    parent.display()
+                ),
+            )));
+        }
+
+        let probe_path = parent.join(format!(".faucet_doctor_probe-{}", Uuid::new_v4()));
+        let probe = match tokio::fs::write(&probe_path, b"").await {
+            Ok(()) => {
+                let _ = tokio::fs::remove_file(&probe_path).await;
+                Probe::pass("io", start.elapsed())
+            }
+            Err(e) => Probe::fail_hint(
+                "io",
+                start.elapsed(),
+                format!("cannot write to directory {}: {e}", parent.display()),
+                "ensure the directory is writable by the current user",
+            ),
+        };
+        Ok(CheckReport::single(probe))
+    }
 }
 
 /// Decide whether to start a new file before the current chunk.

--- a/crates/sink/postgres/src/sink.rs
+++ b/crates/sink/postgres/src/sink.rs
@@ -177,6 +177,39 @@ impl faucet_core::Sink for PostgresSink {
             .expect("schema serialization")
     }
 
+    /// Preflight connectivity probe (`faucet doctor`).
+    ///
+    /// Acquires a connection from the existing pool and runs `SELECT 1`. This
+    /// is non-mutating and idempotent — it validates that the database is
+    /// reachable and the credentials are accepted without writing anything.
+    async fn check(
+        &self,
+        ctx: &faucet_core::check::CheckContext,
+    ) -> Result<faucet_core::check::CheckReport, FaucetError> {
+        use faucet_core::check::{CheckReport, Probe};
+
+        let started = std::time::Instant::now();
+        let probe =
+            match tokio::time::timeout(ctx.timeout, sqlx::query("SELECT 1").execute(&self.pool))
+                .await
+            {
+                Ok(Ok(_)) => Probe::pass("auth", started.elapsed()),
+                Ok(Err(e)) => Probe::fail_hint(
+                    "auth",
+                    started.elapsed(),
+                    e.to_string(),
+                    "check connection_url / credentials / that the database is reachable",
+                ),
+                Err(_) => Probe::fail_hint(
+                    "auth",
+                    started.elapsed(),
+                    "timed out",
+                    "check connection_url / credentials / that the database is reachable",
+                ),
+            };
+        Ok(CheckReport::single(probe))
+    }
+
     /// Write records to PostgreSQL.
     ///
     /// When `config.batch_size > 0` and the input slice is larger than

--- a/crates/sink/redis/Cargo.toml
+++ b/crates/sink/redis/Cargo.toml
@@ -18,6 +18,7 @@ serde_json.workspace = true
 async-trait.workspace = true
 tracing.workspace = true
 redis = { workspace = true }
+tokio = { workspace = true, features = ["time"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }

--- a/crates/sink/redis/src/sink.rs
+++ b/crates/sink/redis/src/sink.rs
@@ -38,6 +38,32 @@ impl faucet_core::Sink for RedisSink {
             .expect("schema serialization")
     }
 
+    /// Non-mutating preflight probe: issue a Redis `PING` over the existing
+    /// multiplexed connection (probe name `"ping"`).
+    async fn check(
+        &self,
+        ctx: &faucet_core::check::CheckContext,
+    ) -> Result<faucet_core::check::CheckReport, FaucetError> {
+        use faucet_core::check::{CheckReport, Probe};
+
+        // MultiplexedConnection is cheaply cloneable; clone to satisfy &self.
+        let mut conn = self.conn.clone();
+        let started = std::time::Instant::now();
+        let hint = "check the Redis url / that the server is reachable and accepting connections";
+
+        let probe = match tokio::time::timeout(
+            ctx.timeout,
+            redis::cmd("PING").query_async::<String>(&mut conn),
+        )
+        .await
+        {
+            Ok(Ok(_)) => Probe::pass("ping", started.elapsed()),
+            Ok(Err(e)) => Probe::fail_hint("ping", started.elapsed(), e.to_string(), hint),
+            Err(_) => Probe::fail_hint("ping", started.elapsed(), "timed out", hint),
+        };
+        Ok(CheckReport::single(probe))
+    }
+
     async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
         if records.is_empty() {
             return Ok(0);

--- a/crates/sink/s3/src/sink.rs
+++ b/crates/sink/s3/src/sink.rs
@@ -87,6 +87,33 @@ impl faucet_core::Sink for S3Sink {
         serde_json::to_value(faucet_core::schema_for!(S3SinkConfig)).expect("schema serialization")
     }
 
+    /// Preflight probe: confirm the configured bucket is reachable and the
+    /// credentials work via a non-mutating `HeadBucket` call. Uploads nothing.
+    async fn check(
+        &self,
+        ctx: &faucet_core::check::CheckContext,
+    ) -> Result<faucet_core::check::CheckReport, FaucetError> {
+        use faucet_core::check::{CheckReport, Probe};
+
+        let started = std::time::Instant::now();
+        let probe = match tokio::time::timeout(
+            ctx.timeout,
+            self.client.head_bucket().bucket(&self.config.bucket).send(),
+        )
+        .await
+        {
+            Ok(Ok(_)) => Probe::pass("auth", started.elapsed()),
+            Ok(Err(e)) => Probe::fail_hint(
+                "auth",
+                started.elapsed(),
+                e.to_string(),
+                "check bucket name, credentials, and network",
+            ),
+            Err(_) => Probe::fail("network", started.elapsed(), "timed out"),
+        };
+        Ok(CheckReport::single(probe))
+    }
+
     async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
         if records.is_empty() {
             return Ok(0);

--- a/crates/sink/snowflake/src/sink.rs
+++ b/crates/sink/snowflake/src/sink.rs
@@ -269,6 +269,47 @@ impl faucet_core::Sink for SnowflakeSink {
             .expect("schema serialization")
     }
 
+    /// Preflight check (`faucet doctor`).
+    ///
+    /// Runs a single read-only `SELECT 1` through the existing SQL REST API
+    /// request path ([`execute_sql`](Self::execute_sql)), reusing the sink's
+    /// configured account/warehouse/auth. This resolves the effective
+    /// credential (inline or shared provider), builds the authorization
+    /// header, and confirms Snowflake accepts the session — without writing
+    /// any rows. Auth-resolution, network, and SQL-API errors surface as a
+    /// `Fail` probe with a hint. Tokens are never placed in the reason/hint.
+    async fn check(
+        &self,
+        ctx: &faucet_core::check::CheckContext,
+    ) -> Result<faucet_core::check::CheckReport, FaucetError> {
+        use faucet_core::check::{CheckReport, Probe};
+
+        let started = std::time::Instant::now();
+
+        let result = tokio::time::timeout(ctx.timeout, self.execute_sql("SELECT 1", None)).await;
+
+        let probe = match result {
+            Ok(Ok(())) => Probe::pass("auth", started.elapsed()),
+            Ok(Err(e)) => Probe::fail_hint(
+                "auth",
+                started.elapsed(),
+                format!("Snowflake SELECT 1 failed: {e}"),
+                "Verify the account identifier, warehouse, and credentials \
+                 (OAuth token or key-pair JWT) and that the role can use the \
+                 configured warehouse.",
+            ),
+            Err(_elapsed) => Probe::fail_hint(
+                "auth",
+                started.elapsed(),
+                format!("Snowflake SELECT 1 timed out after {:?}", ctx.timeout),
+                "Check network reachability to the Snowflake SQL REST API \
+                 endpoint and that the warehouse can resume within the timeout.",
+            ),
+        };
+
+        Ok(CheckReport::single(probe))
+    }
+
     async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
         if records.is_empty() {
             return Ok(0);

--- a/crates/sink/snowflake/src/sink.rs
+++ b/crates/sink/snowflake/src/sink.rs
@@ -272,7 +272,7 @@ impl faucet_core::Sink for SnowflakeSink {
     /// Preflight check (`faucet doctor`).
     ///
     /// Runs a single read-only `SELECT 1` through the existing SQL REST API
-    /// request path ([`execute_sql`](Self::execute_sql)), reusing the sink's
+    /// request path (`execute_sql`), reusing the sink's
     /// configured account/warehouse/auth. This resolves the effective
     /// credential (inline or shared provider), builds the authorization
     /// header, and confirms Snowflake accepts the session — without writing

--- a/crates/sink/sqlite/Cargo.toml
+++ b/crates/sink/sqlite/Cargo.toml
@@ -18,6 +18,7 @@ serde_json.workspace = true
 async-trait.workspace = true
 tracing.workspace = true
 sqlx = { workspace = true, features = ["runtime-tokio", "sqlite", "json"] }
+tokio.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/sink/sqlite/src/sink.rs
+++ b/crates/sink/sqlite/src/sink.rs
@@ -214,6 +214,39 @@ impl faucet_core::Sink for SqliteSink {
             .expect("schema serialization")
     }
 
+    /// Preflight connectivity probe (`faucet doctor`).
+    ///
+    /// Acquires a connection from the existing pool and runs `SELECT 1`. This
+    /// is non-mutating and idempotent — it validates that the database file /
+    /// connection opens without writing anything.
+    async fn check(
+        &self,
+        ctx: &faucet_core::check::CheckContext,
+    ) -> Result<faucet_core::check::CheckReport, FaucetError> {
+        use faucet_core::check::{CheckReport, Probe};
+
+        let started = std::time::Instant::now();
+        let probe =
+            match tokio::time::timeout(ctx.timeout, sqlx::query("SELECT 1").execute(&self.pool))
+                .await
+            {
+                Ok(Ok(_)) => Probe::pass("auth", started.elapsed()),
+                Ok(Err(e)) => Probe::fail_hint(
+                    "auth",
+                    started.elapsed(),
+                    e.to_string(),
+                    "check database_url / that the database file is reachable and openable",
+                ),
+                Err(_) => Probe::fail_hint(
+                    "auth",
+                    started.elapsed(),
+                    "timed out",
+                    "check database_url / that the database file is reachable and openable",
+                ),
+            };
+        Ok(CheckReport::single(probe))
+    }
+
     async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
         if records.is_empty() {
             return Ok(0);

--- a/crates/sink/stdout/src/sink.rs
+++ b/crates/sink/stdout/src/sink.rs
@@ -157,6 +157,20 @@ impl faucet_core::Sink for StdoutSink {
             .await
             .map_err(|e| FaucetError::Sink(format!("flush failed: {e}")))
     }
+
+    /// Preflight probe for `faucet doctor`. The standard streams are always
+    /// reachable (the OS hands them to every process), so there is nothing to
+    /// fail on — this always passes immediately.
+    async fn check(
+        &self,
+        _ctx: &faucet_core::check::CheckContext,
+    ) -> Result<faucet_core::check::CheckReport, FaucetError> {
+        use faucet_core::check::{CheckReport, Probe};
+        Ok(CheckReport::single(Probe::pass(
+            "io",
+            std::time::Duration::ZERO,
+        )))
+    }
 }
 
 #[cfg(test)]
@@ -368,5 +382,17 @@ mod tests {
         let schema = sink.config_schema();
         assert_eq!(schema["type"], "object");
         assert!(schema["properties"].is_object());
+    }
+
+    #[tokio::test]
+    async fn check_always_passes() {
+        let sink = StdoutSink::new(StdoutSinkConfig::new());
+        let report = sink
+            .check(&faucet_core::check::CheckContext::default())
+            .await
+            .unwrap();
+        assert_eq!(report.failed_count(), 0);
+        assert_eq!(report.probes.len(), 1);
+        assert_eq!(report.probes[0].name, "io");
     }
 }

--- a/crates/source/kafka/src/stream.rs
+++ b/crates/source/kafka/src/stream.rs
@@ -431,4 +431,64 @@ impl Source for KafkaSource {
         *guard = Some(parsed);
         Ok(())
     }
+
+    fn connector_name(&self) -> &'static str {
+        "kafka"
+    }
+
+    /// Preflight probe that does **not** consume any message.
+    ///
+    /// The default [`Source::check`] would call `stream_pages`, which polls for
+    /// a message and would block on an empty topic until the idle/max-message
+    /// terminator fires. Instead we fetch cluster metadata
+    /// (`fetch_metadata(None, timeout)`), which validates broker connectivity +
+    /// auth without consuming or committing anything.
+    ///
+    /// `fetch_metadata` is a blocking librdkafka call, so it runs on a blocking
+    /// thread; the whole probe is additionally bounded by `ctx.timeout`.
+    async fn check(
+        &self,
+        ctx: &faucet_core::check::CheckContext,
+    ) -> Result<faucet_core::check::CheckReport, FaucetError> {
+        use faucet_core::check::{CheckReport, Probe};
+        use rdkafka::util::Timeout;
+
+        let start = std::time::Instant::now();
+        let consumer = Arc::clone(&self.consumer);
+        let rd_timeout = Timeout::After(ctx.timeout);
+
+        // Run the blocking fetch_metadata off the async runtime, bounded by the
+        // same wall-clock budget so an unreachable broker can't hang the probe.
+        let fetch = tokio::task::spawn_blocking(move || {
+            consumer
+                .fetch_metadata(None, rd_timeout)
+                .map(|md| md.brokers().len())
+                .map_err(|e| e.to_string())
+        });
+
+        let probe = match tokio::time::timeout(ctx.timeout, fetch).await {
+            Ok(Ok(Ok(broker_count))) => {
+                tracing::debug!(broker_count, "kafka check: fetched cluster metadata");
+                Probe::pass("metadata", start.elapsed())
+            }
+            Ok(Ok(Err(e))) => Probe::fail_hint(
+                "metadata",
+                start.elapsed(),
+                e,
+                "verify brokers, network reachability, and auth (SASL/TLS) settings",
+            ),
+            Ok(Err(join_err)) => Probe::fail(
+                "metadata",
+                start.elapsed(),
+                format!("metadata fetch task failed: {join_err}"),
+            ),
+            Err(_elapsed) => Probe::fail_hint(
+                "metadata",
+                start.elapsed(),
+                "metadata fetch timed out",
+                "no broker responded within the check timeout",
+            ),
+        };
+        Ok(CheckReport::single(probe))
+    }
 }

--- a/crates/source/kafka/src/stream.rs
+++ b/crates/source/kafka/src/stream.rs
@@ -438,7 +438,7 @@ impl Source for KafkaSource {
 
     /// Preflight probe that does **not** consume any message.
     ///
-    /// The default [`Source::check`] would call `stream_pages`, which polls for
+    /// The default `Source::check` would call `stream_pages`, which polls for
     /// a message and would block on an empty topic until the idle/max-message
     /// terminator fires. Instead we fetch cluster metadata
     /// (`fetch_metadata(None, timeout)`), which validates broker connectivity +

--- a/crates/source/postgres-cdc/src/stream.rs
+++ b/crates/source/postgres-cdc/src/stream.rs
@@ -149,6 +149,98 @@ impl Source for PostgresCdcSource {
         *self.pending_bookmark.lock().await = Some(parsed);
         Ok(())
     }
+
+    fn connector_name(&self) -> &'static str {
+        "postgres-cdc"
+    }
+
+    /// Preflight probe that does **not** start replication.
+    ///
+    /// The default [`Source::check`] would call `stream_pages`, which opens the
+    /// replication stream and consumes/holds WAL (a side effect that pins server
+    /// resources) — unacceptable as a preflight. Instead we open a *normal*
+    /// (non-replication) SQL connection — the same connection style
+    /// `ensure_slot` uses — and inspect the slot catalog without touching the
+    /// replication protocol:
+    ///
+    /// - connection fails → `auth` probe `Fail` (could not connect / authenticate),
+    /// - connected but the slot row is absent → `slot` probe `Skip`
+    ///   (faucet can create it on the first run),
+    /// - slot present → `slot` probe `Pass`.
+    ///
+    /// The whole call is bounded by `ctx.timeout`.
+    async fn check(
+        &self,
+        ctx: &faucet_core::check::CheckContext,
+    ) -> Result<faucet_core::check::CheckReport, FaucetError> {
+        use faucet_core::check::{CheckReport, Probe};
+        use sqlx::ConnectOptions as _;
+        use sqlx::postgres::{PgConnectOptions, PgConnection};
+
+        let start = std::time::Instant::now();
+
+        // A bad connection URL is a config error, not an unreachable server.
+        let opts: PgConnectOptions = match self.config.connection_url.parse() {
+            Ok(o) => o,
+            Err(e) => {
+                return Ok(CheckReport::single(Probe::fail_hint(
+                    "auth",
+                    start.elapsed(),
+                    format!("invalid connection URL: {e}"),
+                    "connection_url must be a valid postgres:// URL",
+                )));
+            }
+        };
+
+        // Bound the whole connect+query under ctx.timeout so an unreachable
+        // host doesn't hang the probe.
+        let probe = async {
+            let mut conn: PgConnection = opts.connect().await.map_err(|e| {
+                Probe::fail_hint(
+                    "auth",
+                    start.elapsed(),
+                    format!("could not connect: {e}"),
+                    "verify the host is reachable and credentials are valid",
+                )
+            })?;
+
+            let row: Option<(String,)> = sqlx::query_as(
+                "SELECT slot_name::text FROM pg_replication_slots WHERE slot_name = $1",
+            )
+            .bind(&self.config.slot_name)
+            .fetch_optional(&mut conn)
+            .await
+            .map_err(|e| {
+                Probe::fail(
+                    "slot",
+                    start.elapsed(),
+                    format!("could not query pg_replication_slots: {e}"),
+                )
+            })?;
+
+            Ok::<Probe, Probe>(match row {
+                Some(_) => Probe::pass("slot", start.elapsed()),
+                None => Probe::skip(
+                    "slot",
+                    format!(
+                        "replication slot {} does not exist yet (faucet run can create it)",
+                        self.config.slot_name
+                    ),
+                ),
+            })
+        };
+
+        let probe = match tokio::time::timeout(ctx.timeout, probe).await {
+            Ok(Ok(p)) | Ok(Err(p)) => p,
+            Err(_elapsed) => Probe::fail_hint(
+                "auth",
+                start.elapsed(),
+                "connection timed out",
+                "the database did not respond within the check timeout",
+            ),
+        };
+        Ok(CheckReport::single(probe))
+    }
 }
 
 impl PostgresCdcSource {

--- a/crates/source/webhook/src/stream.rs
+++ b/crates/source/webhook/src/stream.rs
@@ -203,10 +203,10 @@ impl faucet_core::Source for WebhookSource {
 
     /// Preflight probe that does **not** start the receive loop.
     ///
-    /// The default [`Source::check`] would call `stream_pages`, which boots the
+    /// The default `Source::check` would call `stream_pages`, which boots the
     /// HTTP server and blocks for the whole receive window waiting for inbound
     /// POSTs — useless as a fast preflight. Instead we just verify the
-    /// configured `listen_addr` is bindable: bind a [`tokio::net::TcpListener`]
+    /// configured `listen_addr` is bindable: bind a `tokio::net::TcpListener`
     /// to it and immediately drop it. Success means the port is free; a bind
     /// error (port in use, permission denied, bad address) fails the probe.
     async fn check(

--- a/crates/source/webhook/src/stream.rs
+++ b/crates/source/webhook/src/stream.rs
@@ -196,6 +196,40 @@ impl faucet_core::Source for WebhookSource {
         serde_json::to_value(faucet_core::schema_for!(WebhookSourceConfig))
             .expect("schema serialization")
     }
+
+    fn connector_name(&self) -> &'static str {
+        "webhook"
+    }
+
+    /// Preflight probe that does **not** start the receive loop.
+    ///
+    /// The default [`Source::check`] would call `stream_pages`, which boots the
+    /// HTTP server and blocks for the whole receive window waiting for inbound
+    /// POSTs — useless as a fast preflight. Instead we just verify the
+    /// configured `listen_addr` is bindable: bind a [`tokio::net::TcpListener`]
+    /// to it and immediately drop it. Success means the port is free; a bind
+    /// error (port in use, permission denied, bad address) fails the probe.
+    async fn check(
+        &self,
+        _ctx: &faucet_core::check::CheckContext,
+    ) -> Result<faucet_core::check::CheckReport, FaucetError> {
+        use faucet_core::check::{CheckReport, Probe};
+
+        let start = std::time::Instant::now();
+        match tokio::net::TcpListener::bind(&self.config.listen_addr).await {
+            Ok(listener) => {
+                // Drop the listener immediately so we don't hold the port.
+                drop(listener);
+                Ok(CheckReport::single(Probe::pass("io", start.elapsed())))
+            }
+            Err(e) => Ok(CheckReport::single(Probe::fail_hint(
+                "io",
+                start.elapsed(),
+                e.to_string(),
+                format!("{} is not bindable", self.config.listen_addr),
+            ))),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -268,6 +302,53 @@ mod tests {
         assert_eq!(records.len(), 2);
         assert_eq!(records[0]["event"], "created");
         assert_eq!(records[1]["event"], "updated");
+    }
+
+    #[tokio::test]
+    async fn check_passes_when_port_is_bindable() {
+        use faucet_core::Source;
+        use faucet_core::check::{CheckContext, ProbeStatus};
+
+        // Port 0 = let the OS pick a free port, so the bind always succeeds.
+        let source = WebhookSource::new(WebhookSourceConfig::new().listen_addr("127.0.0.1:0"));
+        let report = source.check(&CheckContext::default()).await.unwrap();
+        assert_eq!(report.probes.len(), 1);
+        assert_eq!(report.probes[0].name, "io");
+        assert!(
+            matches!(report.probes[0].status, ProbeStatus::Pass),
+            "expected Pass, got {:?}",
+            report.probes[0].status
+        );
+        assert_eq!(report.failed_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn check_fails_when_port_is_already_bound() {
+        use faucet_core::Source;
+        use faucet_core::check::{CheckContext, ProbeStatus};
+
+        // Hold a real listener, then point the source at the same address so
+        // the probe's bind collides.
+        let held = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = held.local_addr().unwrap();
+
+        let source = WebhookSource::new(WebhookSourceConfig::new().listen_addr(addr.to_string()));
+        let report = source.check(&CheckContext::default()).await.unwrap();
+        assert_eq!(report.probes.len(), 1);
+        assert_eq!(report.probes[0].name, "io");
+        assert!(
+            matches!(report.probes[0].status, ProbeStatus::Fail { .. }),
+            "expected Fail, got {:?}",
+            report.probes[0].status
+        );
+        assert_eq!(report.failed_count(), 1);
+        assert!(
+            report.probes[0]
+                .hint
+                .as_deref()
+                .unwrap()
+                .contains("not bindable")
+        );
     }
 
     #[tokio::test]

--- a/crates/source/websocket/Cargo.toml
+++ b/crates/source/websocket/Cargo.toml
@@ -17,7 +17,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 async-trait.workspace = true
 tracing.workspace = true
-tokio = { workspace = true, features = ["time", "macros", "signal"] }
+tokio = { workspace = true, features = ["time", "macros", "signal", "net"] }
 tokio-tungstenite.workspace = true
 futures.workspace = true
 async-stream.workspace = true

--- a/crates/source/websocket/src/stream.rs
+++ b/crates/source/websocket/src/stream.rs
@@ -383,7 +383,7 @@ impl Source for WebsocketSource {
 
     /// Preflight probe that does **not** open the WebSocket stream.
     ///
-    /// The default [`Source::check`] would call `stream_pages`, which connects,
+    /// The default `Source::check` would call `stream_pages`, which connects,
     /// sends subscribe frames, and then blocks waiting for inbound frames until
     /// `max_messages` / `idle_timeout` — useless as a fast preflight. Instead we
     /// only verify TCP reachability of the configured endpoint: parse the

--- a/crates/source/websocket/src/stream.rs
+++ b/crates/source/websocket/src/stream.rs
@@ -380,6 +380,82 @@ impl Source for WebsocketSource {
     fn connector_name(&self) -> &'static str {
         "websocket"
     }
+
+    /// Preflight probe that does **not** open the WebSocket stream.
+    ///
+    /// The default [`Source::check`] would call `stream_pages`, which connects,
+    /// sends subscribe frames, and then blocks waiting for inbound frames until
+    /// `max_messages` / `idle_timeout` — useless as a fast preflight. Instead we
+    /// only verify TCP reachability of the configured endpoint: parse the
+    /// `ws://`/`wss://` URL, resolve host + port (default 80 for `ws`, 443 for
+    /// `wss`), open a [`tokio::net::TcpStream`] (no WS upgrade handshake, no
+    /// auth, no frames), and immediately drop it.
+    async fn check(
+        &self,
+        ctx: &faucet_core::check::CheckContext,
+    ) -> Result<faucet_core::check::CheckReport, FaucetError> {
+        use faucet_core::check::{CheckReport, Probe};
+
+        let start = std::time::Instant::now();
+
+        // Resolve host + port from the configured URL. The config is validated
+        // at construction (`ws://`/`wss://`), so parse failures here are
+        // probe-level failures, never panics.
+        let (host, port) = match resolve_host_port(&self.config.url) {
+            Ok(hp) => hp,
+            Err(reason) => {
+                return Ok(CheckReport::single(Probe::fail_hint(
+                    "network",
+                    start.elapsed(),
+                    reason,
+                    "url must be ws://host[:port]/... or wss://host[:port]/...",
+                )));
+            }
+        };
+
+        let connect = tokio::net::TcpStream::connect((host.as_str(), port));
+        match tokio::time::timeout(ctx.timeout, connect).await {
+            Ok(Ok(stream)) => {
+                drop(stream);
+                Ok(CheckReport::single(Probe::pass("network", start.elapsed())))
+            }
+            Ok(Err(e)) => Ok(CheckReport::single(Probe::fail_hint(
+                "network",
+                start.elapsed(),
+                e.to_string(),
+                format!("cannot reach {host}:{port} over TCP"),
+            ))),
+            Err(_elapsed) => Ok(CheckReport::single(Probe::fail_hint(
+                "network",
+                start.elapsed(),
+                format!("TCP connect to {host}:{port} timed out"),
+                format!("{host}:{port} did not accept a connection within the check timeout"),
+            ))),
+        }
+    }
+}
+
+/// Parse a `ws://`/`wss://` URL into `(host, port)`, applying the scheme's
+/// default port (80 for `ws`, 443 for `wss`) when none is specified.
+///
+/// Returns the human-readable reason string on failure (never leaks the full
+/// URL, which may carry query-string credentials — only the host is surfaced).
+fn resolve_host_port(url: &str) -> Result<(String, u16), String> {
+    let request = url
+        .into_client_request()
+        .map_err(|e| format!("invalid websocket url: {e}"))?;
+    let uri = request.uri();
+    let host = uri
+        .host()
+        .filter(|h| !h.is_empty())
+        .ok_or_else(|| "websocket url is missing a host".to_string())?
+        .to_string();
+    let default_port = match uri.scheme_str() {
+        Some("wss") => 443,
+        _ => 80,
+    };
+    let port = uri.port_u16().unwrap_or(default_port);
+    Ok((host, port))
 }
 
 #[cfg(test)]
@@ -436,5 +512,102 @@ mod tests {
                 headers: BTreeMap::from([("Authorization".into(), "Basic dXNlcjpwYXNz".into())])
             }
         );
+    }
+
+    #[test]
+    fn resolve_host_port_applies_scheme_defaults() {
+        assert_eq!(
+            resolve_host_port("ws://example.com/feed").unwrap(),
+            ("example.com".to_string(), 80)
+        );
+        assert_eq!(
+            resolve_host_port("wss://example.com/feed").unwrap(),
+            ("example.com".to_string(), 443)
+        );
+        assert_eq!(
+            resolve_host_port("wss://example.com:9443/feed").unwrap(),
+            ("example.com".to_string(), 9443)
+        );
+    }
+
+    #[tokio::test]
+    async fn check_passes_against_a_live_tcp_listener() {
+        use faucet_core::check::{CheckContext, ProbeStatus};
+
+        // Bind a real TCP listener and point the source's URL at it. The probe
+        // only needs the TCP handshake to succeed — no WS upgrade is performed,
+        // so a plain listener is enough.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let config = WebsocketSourceConfig {
+            url: format!("ws://{addr}/feed"),
+            auth: AuthSpec::Inline(WebsocketAuth::None),
+            subscribe_messages: vec![],
+            message_format: crate::config::WsMessageFormat::Json,
+            on_parse_error: crate::config::OnParseError::Fail,
+            envelope: false,
+            ping_interval: None,
+            max_messages: Some(1),
+            idle_timeout: None,
+            reconnect: false,
+            reconnect_backoff: Duration::from_secs(1),
+            max_reconnect_attempts: None,
+            max_message_bytes: None,
+            batch_size: faucet_core::DEFAULT_BATCH_SIZE,
+        };
+        let source = WebsocketSource::new(config).unwrap();
+        let report = source.check(&CheckContext::default()).await.unwrap();
+        assert_eq!(report.probes.len(), 1);
+        assert_eq!(report.probes[0].name, "network");
+        assert!(
+            matches!(report.probes[0].status, ProbeStatus::Pass),
+            "expected Pass, got {:?}",
+            report.probes[0].status
+        );
+    }
+
+    #[tokio::test]
+    async fn check_fails_against_a_closed_port() {
+        use faucet_core::check::{CheckContext, ProbeStatus};
+
+        // Bind then drop a listener to obtain a port that is (almost certainly)
+        // closed, so the connect is refused quickly.
+        let addr = {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            listener.local_addr().unwrap()
+        };
+
+        let config = WebsocketSourceConfig {
+            url: format!("ws://{addr}/feed"),
+            auth: AuthSpec::Inline(WebsocketAuth::None),
+            subscribe_messages: vec![],
+            message_format: crate::config::WsMessageFormat::Json,
+            on_parse_error: crate::config::OnParseError::Fail,
+            envelope: false,
+            ping_interval: None,
+            max_messages: Some(1),
+            idle_timeout: None,
+            reconnect: false,
+            reconnect_backoff: Duration::from_secs(1),
+            max_reconnect_attempts: None,
+            max_message_bytes: None,
+            batch_size: faucet_core::DEFAULT_BATCH_SIZE,
+        };
+        let source = WebsocketSource::new(config).unwrap();
+        let report = source
+            .check(&CheckContext {
+                timeout: Duration::from_secs(2),
+            })
+            .await
+            .unwrap();
+        assert_eq!(report.probes.len(), 1);
+        assert_eq!(report.probes[0].name, "network");
+        assert!(
+            matches!(report.probes[0].status, ProbeStatus::Fail { .. }),
+            "expected Fail, got {:?}",
+            report.probes[0].status
+        );
+        assert_eq!(report.failed_count(), 1);
     }
 }

--- a/crates/state/postgres/Cargo.toml
+++ b/crates/state/postgres/Cargo.toml
@@ -16,7 +16,7 @@ async-trait.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
 sqlx.workspace = true
-tokio = { workspace = true, features = ["sync"] }
+tokio = { workspace = true, features = ["sync", "time"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/state/postgres/src/store.rs
+++ b/crates/state/postgres/src/store.rs
@@ -1,7 +1,7 @@
 //! PostgreSQL-backed [`StateStore`].
 
 use async_trait::async_trait;
-use faucet_core::state::{StateStore, validate_state_key};
+use faucet_core::state::{DOCTOR_SENTINEL_KEY, StateStore, validate_state_key};
 use faucet_core::util::quote_ident;
 use faucet_core::{FaucetError, Value};
 use sqlx::postgres::PgPoolOptions;
@@ -180,6 +180,61 @@ impl StateStore for PostgresStateStore {
                 FaucetError::State(format!("Postgres DELETE for key '{key}' failed: {e}"))
             })?;
         Ok(())
+    }
+
+    async fn check(
+        &self,
+        ctx: &faucet_core::check::CheckContext,
+    ) -> Result<faucet_core::check::CheckReport, FaucetError> {
+        use faucet_core::check::{CheckReport, Probe};
+
+        // Exercise the real upsert → select → delete cycle on a sentinel key.
+        // This validates connectivity, auth, the table's existence, and
+        // read/write permissions through the actual code path and leaves no
+        // residue.
+        let start = std::time::Instant::now();
+        let probe = match tokio::time::timeout(ctx.timeout, self.sentinel_roundtrip()).await {
+            Ok(Ok(())) => Probe::pass("sentinel", start.elapsed()),
+            Ok(Err(e)) => Probe::fail_hint(
+                "sentinel",
+                start.elapsed(),
+                e.to_string(),
+                format!(
+                    "verify the server is reachable, the credentials grant read/write access, \
+                     and the '{}' table exists (call ensure_table or create it manually)",
+                    self.table
+                ),
+            ),
+            Err(_) => Probe::fail_hint(
+                "sentinel",
+                start.elapsed(),
+                format!(
+                    "round-trip timed out after {:?}; Postgres did not respond",
+                    ctx.timeout
+                ),
+                "verify the server is reachable or raise the check timeout",
+            ),
+        };
+        Ok(CheckReport::single(probe))
+    }
+}
+
+impl PostgresStateStore {
+    /// Write, read back, and delete a sentinel key — the body of the `check()`
+    /// probe, factored out so the happy path stays linear. Reuses the store's
+    /// own `put`/`get`/`delete` against the configured table.
+    async fn sentinel_roundtrip(&self) -> Result<(), FaucetError> {
+        let probe = serde_json::json!({ "faucet_doctor": true });
+        self.put(DOCTOR_SENTINEL_KEY, &probe).await?;
+        let got = self.get(DOCTOR_SENTINEL_KEY).await?;
+        // Best-effort cleanup regardless of the read result.
+        let _ = self.delete(DOCTOR_SENTINEL_KEY).await;
+        match got {
+            Some(v) if v == probe => Ok(()),
+            _ => Err(FaucetError::State(
+                "sentinel readback did not match what was written".into(),
+            )),
+        }
     }
 }
 

--- a/crates/state/redis/Cargo.toml
+++ b/crates/state/redis/Cargo.toml
@@ -16,7 +16,7 @@ async-trait.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
 redis.workspace = true
-tokio = { workspace = true, features = ["sync"] }
+tokio = { workspace = true, features = ["sync", "time"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/state/redis/src/store.rs
+++ b/crates/state/redis/src/store.rs
@@ -1,7 +1,7 @@
 //! Redis-backed [`StateStore`].
 
 use async_trait::async_trait;
-use faucet_core::state::{StateStore, validate_state_key};
+use faucet_core::state::{DOCTOR_SENTINEL_KEY, StateStore, validate_state_key};
 use faucet_core::{FaucetError, Value};
 use redis::AsyncCommands;
 
@@ -119,6 +119,56 @@ impl StateStore for RedisStateStore {
             .await
             .map_err(|e| FaucetError::State(format!("Redis DEL for key '{key}' failed: {e}")))?;
         Ok(())
+    }
+
+    async fn check(
+        &self,
+        ctx: &faucet_core::check::CheckContext,
+    ) -> Result<faucet_core::check::CheckReport, FaucetError> {
+        use faucet_core::check::{CheckReport, Probe};
+
+        // Exercise the real put → get → delete cycle on a sentinel key. This
+        // validates connectivity, auth, and read/write permissions through the
+        // actual code path and leaves no residue.
+        let start = std::time::Instant::now();
+        let probe = match tokio::time::timeout(ctx.timeout, self.sentinel_roundtrip()).await {
+            Ok(Ok(())) => Probe::pass("sentinel", start.elapsed()),
+            Ok(Err(e)) => Probe::fail_hint(
+                "sentinel",
+                start.elapsed(),
+                e.to_string(),
+                "verify the Redis server is reachable and the credentials grant read/write access",
+            ),
+            Err(_) => Probe::fail_hint(
+                "sentinel",
+                start.elapsed(),
+                format!(
+                    "round-trip timed out after {:?}; Redis did not respond",
+                    ctx.timeout
+                ),
+                "verify the Redis server is reachable or raise the check timeout",
+            ),
+        };
+        Ok(CheckReport::single(probe))
+    }
+}
+
+impl RedisStateStore {
+    /// Write, read back, and delete a sentinel key — the body of the `check()`
+    /// probe, factored out so the happy path stays linear. Reuses the store's
+    /// own `put`/`get`/`delete`, which already namespace the key.
+    async fn sentinel_roundtrip(&self) -> Result<(), FaucetError> {
+        let probe = serde_json::json!({ "faucet_doctor": true });
+        self.put(DOCTOR_SENTINEL_KEY, &probe).await?;
+        let got = self.get(DOCTOR_SENTINEL_KEY).await?;
+        // Best-effort cleanup regardless of the read result.
+        let _ = self.delete(DOCTOR_SENTINEL_KEY).await;
+        match got {
+            Some(v) if v == probe => Ok(()),
+            _ => Err(FaucetError::State(
+                "sentinel readback did not match what was written".into(),
+            )),
+        }
     }
 }
 

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -25,6 +25,7 @@
 - [Compression](./cookbook/compression.md)
 - [Record transforms](./cookbook/transforms.md)
 - [Secrets-manager interpolation](./cookbook/secrets.md)
+- [Troubleshooting with faucet doctor](./cookbook/troubleshooting.md)
 
 # Reference
 

--- a/docs/book/src/cookbook/troubleshooting.md
+++ b/docs/book/src/cookbook/troubleshooting.md
@@ -1,0 +1,98 @@
+# Troubleshooting with `faucet doctor`
+
+`faucet doctor` answers "why won't my pipeline run?" *before* you run it. It
+probes every connector in a config — auth, network, permissions, reachability —
+and prints a green/red checklist, exiting non-zero if anything fails. It is
+**non-mutating**: no data is written, no rows inserted, no objects uploaded.
+
+```bash
+faucet doctor pipeline.yaml
+```
+
+```text
+✓ Config parses and interpolates                                 8 ms
+✓ Matrix expands to 2 invocations                    0 skipped (children)
+
+▸ Invocation default::us-east  (source=postgres, sink=bigquery)
+  ✓ source [postgres] read                                      42 ms
+  ✓ sink   [bigquery] auth                                     280 ms
+  ✓ state  [redis] sentinel                                     14 ms
+
+▸ Invocation default::eu-west  (source=postgres, sink=bigquery)
+  ✓ source [postgres] read                                      39 ms
+  ✗ sink   [bigquery] auth (dataset eu_west not found)         410 ms
+        hint: check bigquery credentials and that the dataset exists
+
+Summary: 5 passed, 1 failed, 0 skipped       total elapsed 0.5s
+```
+
+The **exit code is the number of failed probes** (clamped to 255), so `doctor`
+drops straight into a CI gate or a deploy script:
+
+```bash
+faucet doctor pipeline.yaml || { echo "preflight failed"; exit 1; }
+```
+
+## What gets probed
+
+| Role | Probe |
+|------|-------|
+| **Source** (most) | Pulls a *single page* via the real read path (DNS + TLS + auth + first request) and stops — never the full dataset. |
+| `webhook` source | The configured port is bindable. |
+| `websocket` source | TCP connect to the host (no WebSocket handshake). |
+| `postgres-cdc` source | The replication slot is reachable (missing slot → `skip`, since `run` can create it). |
+| `kafka` source / sink | A cluster `metadata` request (validates brokers + auth without consuming/producing). |
+| SQL sinks (`postgres`/`mysql`/`sqlite`) | `SELECT 1` on the pool. |
+| `s3` / `gcs` sinks | Bucket head / metadata list. |
+| `bigquery` / `snowflake` sinks | Token mint + a read-only metadata call / `SELECT 1`. |
+| `redis` / `mongodb` / `elasticsearch` / `http` sinks | `PING` / `ping` / cluster health / a `HEAD` request. |
+| File sinks (`jsonl`/`csv`/`parquet`/`stdout`) | Target directory is writable (`stdout` always passes). |
+| State stores (`redis`/`postgres`/`file`/`memory`) | A sentinel `put`/`get`/`delete` that leaves no residue. |
+
+## Reading the result
+
+- **`✓ pass`** — the probe succeeded.
+- **`✗ fail`** — unreachable / unauthenticated / misconfigured. The parenthesized
+  reason and the `hint:` line tell you what to fix.
+- **`• skip`** — not applicable: an optional target is absent (e.g. a CDC slot not
+  yet created), a connector ships no probe, or an object-store path can't be
+  cheaply checked.
+
+## Flags
+
+| Flag | Purpose |
+|------|---------|
+| `--timeout-secs <N>` | Per-probe timeout in seconds (default 10). Lower it to fail fast against dead hosts. |
+| `--json` | Emit a `{ config, invocations, summary }` JSON document for tooling. |
+| `--env-file <path>` / `--no-env-file` | Same `.env` handling as `run`. |
+
+The `--json` shape:
+
+```json
+{
+  "config": "pipeline.yaml",
+  "invocations": [
+    {
+      "id": "default::eu-west",
+      "probes": [
+        { "role": "source", "connector": "postgres", "name": "read", "status": "pass", "elapsed_ms": 39 },
+        { "role": "sink", "connector": "bigquery", "name": "auth", "status": "fail",
+          "reason": "dataset eu_west not found", "elapsed_ms": 410,
+          "hint": "check bigquery credentials and that the dataset exists" }
+      ]
+    }
+  ],
+  "summary": { "passed": 5, "failed": 1, "skipped": 0, "elapsed_ms": 500 }
+}
+```
+
+## Limitations
+
+- **Child invocations** in a parent/child matrix are listed but not probed: their
+  configs depend on parent records that only exist at run time (same limitation
+  as `faucet preview`).
+- `doctor` needs real credentials — it resolves secrets like `run` does. Use
+  `faucet validate --no-secrets` for an offline grammar-only check.
+- Probe `reason`/`hint` text is scrubbed for resolved secrets, but don't run with
+  `FAUCET_LOG=debug` against a config holding live secrets (third-party connector
+  logging is outside faucet's redaction boundary).

--- a/docs/book/src/reference/cli.md
+++ b/docs/book/src/reference/cli.md
@@ -11,9 +11,10 @@ The `faucet` binary exposes these commands. Pass `--log-level <level>` (or set
 | `faucet schema <target>` | Print the JSON Schema for a connector, transform, or the DLQ. |
 | `faucet list` | List every compiled-in source, sink, and transform with a one-line description. |
 | `faucet init [name]` | Scaffold a commented config skeleton from connector schemas. |
+| `faucet doctor [config]` | Probe every connector (auth/network/permissions) and print a checklist. |
 
-`[config]` is optional for `run` / `validate` / `preview`: if omitted, faucet
-auto-discovers `faucet.yaml` → `.yml` → `.json` in the current directory.
+`[config]` is optional for `run` / `validate` / `preview` / `doctor`: if omitted,
+faucet auto-discovers `faucet.yaml` → `.yml` → `.json` in the current directory.
 
 ## `run`
 
@@ -89,6 +90,35 @@ faucet init my_pipeline --source postgres --sink bigquery
 Required fields are surfaced with a typed placeholder and a `# REQUIRED` marker;
 optional fields are commented out so connector defaults apply. The interactive
 mode (`--interactive`) is gated behind the `cli-interactive` feature.
+
+## `doctor`
+
+```bash
+faucet doctor pipeline.yaml                  # checklist; exit code = # of failed probes
+faucet doctor pipeline.yaml --timeout-secs 5 # per-probe timeout (default 10)
+faucet doctor pipeline.yaml --json           # machine-readable, for CI gating
+```
+
+Runs a fast, **non-mutating** preflight against every connector in the config so
+misconfiguration surfaces before a real run. For each root invocation it probes
+the source, sink, and state store and prints a green/red checklist with elapsed
+times; the **exit code equals the number of failed probes** (clamped to 255).
+
+- **Sources** reuse the real read path — the probe pulls a single page and stops
+  (never the full dataset). Sources whose first page would block or mutate use a
+  targeted probe instead: `webhook` (port bindable), `websocket` (TCP connect),
+  `postgres-cdc` (slot reachable), `kafka` (cluster metadata).
+- **Sinks** run a read-only connect/auth/metadata call — `SELECT 1`, `HeadBucket`,
+  `PING`, `tables.get`, cluster health, `fetch_metadata`, or a directory-writable
+  check for file sinks. Never a real write.
+- **State stores** do a sentinel `put`/`get`/`delete` that leaves no residue.
+
+Child invocations (parent/child matrix rows) are listed but not probed — their
+configs depend on parent records that only exist at run time. Probe messages are
+scrubbed for resolved secrets before printing.
+
+See the [Troubleshooting](../cookbook/troubleshooting.md) cookbook page for
+reading the output and common failures.
 
 ## Environment-only mode
 


### PR DESCRIPTION
## Summary

Implements **`faucet doctor`** (#126) — a preflight subcommand that probes every connector in a config (auth / network / permissions / reachability) and prints a green/red checklist, exiting with the number of failed probes. It catches the common "why won't my pipeline run?" failures *before* the first record moves, without a half-run polluting observability.

Per the agreed design, this PR delivers **full connector coverage** — every built-in source, sink, and state store has a real, non-mutating probe (no follow-up issues, no "skip: not implemented" gaps for built-ins).

## Design

**New `check()` trait method** (`faucet-core`, object-safe, defaulted → third-party connectors unaffected) on `Source`, `Sink`, and `StateStore`, returning a `CheckReport` of `Probe`s (`Pass` / `Fail { reason }` / `Skip { reason }`). New `crates/core/src/check.rs` holds `CheckContext` / `Probe` / `ProbeStatus` / `CheckReport`.

**Sources reuse the real read path.** `Source::check` defaults to pulling a *single page* via `stream_pages` and stopping — it exercises DNS + TLS + auth + the first request + first-record decode without paginating the full dataset, and needs **zero per-source code**. Four sources whose first page would block or mutate override it:
- `webhook` → port is bindable
- `websocket` → TCP connect (no WS handshake)
- `postgres-cdc` → replication slot reachable (missing slot → `skip`)
- `kafka` → cluster `metadata`

**Sinks** get a non-mutating `check()` each: `SELECT 1` (postgres/mysql/sqlite), `HeadBucket` (s3) / bucket list (gcs), `tables.get` (bigquery), `SELECT 1` (snowflake), `PING` (redis), `ping` (mongodb), cluster health + index HEAD (elasticsearch), `fetch_metadata` (kafka), `HEAD` (http), directory-writable (jsonl/csv/parquet), and always-pass (stdout).

**State stores** do a sentinel `put`/`get`/`delete` that leaves no residue (redis, postgres; memory always passes; file checks the dir).

**The `doctor` command** (`cli/src/commands/doctor.rs`) loads via `from_path_async` (real secrets), expands, and probes each **root** invocation's source/sink/state concurrently under a bounded semaphore, each `check()` wrapped in a `--timeout-secs` timeout. It redacts secrets from probe output, renders a checklist or `--json`, and `main` maps `DoctorFailed { failed }` to an exit code = failed-probe count (clamped to 255). Child invocations are listed but not probed (their configs need parent records, same as `preview`).

## Tests

- **faucet-core:** `check.rs` serde + helpers; `Source::check` first-page pass/fail; `Sink`/`StateStore` defaults; `MemoryStateStore`/`FileStateStore` probes (incl. unusable-root fail).
- **faucet-cli:** unit tests for tally / JSON shape / secret redaction / construct-fail; integration tests (`cli/tests/doctor.rs`) via wiremock — a reachable source passes (exit 0), an unreachable host fails (non-zero exit), and `--json` emits a parseable summary.
- **Connectors:** unit tests for the pure probes (stdout, jsonl/csv dir-writable, webhook bind, websocket connect).

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and the touched-crate test suites all pass locally (Kafka/CDC integration tests need Docker → covered by CI).

## Docs

- New `docs/book/src/cookbook/troubleshooting.md` (+ `SUMMARY.md`); `doctor` sections in `cli/README.md` and `docs/book/src/reference/cli.md`; root README quickstart; CLAUDE.md CLI list + trait-surface note.

Closes #126

Part of the roadmap epic #38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
