### PR TITLE
feat(cli): faucet schedule cron scheduler + ${now.*} run-clock interpolation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,8 @@ jobs:
           # Quality checks
           - quality
           - quality-jsonschema
+          # Scheduler (CLI-only)
+          - schedule
           # Secrets backends
           - secrets-vault
           - secrets-aws-sm
@@ -186,9 +188,9 @@ jobs:
           brew install cmake openssl@3 curl
       - name: Check feature in isolation
         run: |
-          # Secrets features live in faucet-cli (CLI interpolation layer), not
+          # Secrets and schedule features live in faucet-cli (CLI layer), not
           # in the faucet-stream umbrella crate. Route accordingly.
-          if [[ "${{ matrix.feature }}" == secrets-* ]]; then
+          if [[ "${{ matrix.feature }}" == secrets-* || "${{ matrix.feature }}" == "schedule" ]]; then
             cargo check -p faucet-cli --no-default-features --features ${{ matrix.feature }}
           else
             cargo check -p faucet-stream --no-default-features --features ${{ matrix.feature }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,6 +135,8 @@ sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls", "postgres",
 pgwire-replication = "=0.3.2"
 byteorder = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
+chrono-tz = "0.10"
+croner = "3"
 jsonwebtoken = "9"
 base64 = "0.22"
 rsa = "0.9"

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ can drop on any box or a library you compile in.
   PostgreSQL change-data-capture, built-in data-quality checks (13 per-record and
   per-batch assertions with quarantine routing and abort policies), dead-letter
   queues, automatic retries, secrets-manager interpolation (`${vault:…}`,
-  `${aws-sm:…}`, `${gcp-sm:…}`, `${azure-kv:…}`), and built-in Prometheus
-  metrics + `tracing` spans, all with zero per-connector code.
+  `${aws-sm:…}`, `${gcp-sm:…}`, `${azure-kv:…}`), cron scheduling (`faucet schedule`),
+  and built-in Prometheus metrics + `tracing` spans, all with zero per-connector code.
 - **Pay only for what you use** — every connector is a Cargo feature, so a slim
   build can be just REST + JSONL, or pull in all 35 connectors with `--features full`.
 
@@ -52,6 +52,7 @@ faucet init my_pipeline --source postgres --sink bigquery   # scaffold pipeline.
 faucet validate pipeline.yaml
 faucet doctor pipeline.yaml                                  # preflight: probe auth/network/permissions
 faucet run pipeline.yaml
+faucet schedule pipeline.yaml                               # run on cron schedule (add a schedule: block)
 ```
 
 ```yaml
@@ -207,7 +208,7 @@ faucet-stream is a Cargo workspace with 47 crates — 20 sources, 16 sinks, 5 sh
 | [`faucet-state-postgres`](crates/state/postgres) | PostgreSQL-backed `StateStore` for persistent bookmarks |
 | [`faucet-stream`](faucet-stream) | Umbrella crate — feature-gated re-exports of all connectors and state backends |
 | **CLI** | |
-| [`faucet-cli`](cli) | `faucet` binary — YAML/JSON config-driven pipeline runner (`run`, `validate`, `schema`, `list`, `preview`, `init`) |
+| [`faucet-cli`](cli) | `faucet` binary — YAML/JSON config-driven pipeline runner (`run`, `validate`, `schema`, `list`, `preview`, `init`, `doctor`, `schedule`) |
 
 See the [connector capability matrix](https://pawansikawat.github.io/faucet-stream/reference/connectors.html)
 (streaming, resumable state, compression, auth per connector) and the

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -163,7 +163,7 @@ observability = [
 
 # Built-in cron scheduler (`faucet schedule` + the `schedule:` config block).
 # Pulls a cron parser + IANA timezone db; opt out of it for slim builds.
-schedule = ["dep:croner", "dep:chrono-tz", "dep:chrono"]
+schedule = ["dep:croner", "dep:chrono-tz"]
 
 [dependencies]
 faucet-core.workspace = true
@@ -231,7 +231,7 @@ base64 = { workspace = true, optional = true }
 azure_security_keyvault_secrets = { workspace = true, optional = true }
 azure_identity = { workspace = true, optional = true }
 azure_core = { workspace = true, optional = true }
-chrono = { workspace = true, optional = true }
+chrono = { workspace = true }
 chrono-tz = { workspace = true, optional = true }
 croner = { workspace = true, optional = true }
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 # yields a binary that can run any of the published example YAMLs out of the box.
 default = ["observability", "full", "quality"]
 
-full = ["observability", "source", "sink", "state", "transforms", "compression", "quality"]
+full = ["observability", "source", "sink", "state", "transforms", "compression", "quality", "schedule"]
 
 # Data-quality checks (`quality:` config block). `quality-jsonschema` adds the
 # `json_schema` record check via a JSON Schema validator. Forwarded to
@@ -161,6 +161,10 @@ observability = [
     "dep:tracing-subscriber",
 ]
 
+# Built-in cron scheduler (`faucet schedule` + the `schedule:` config block).
+# Pulls a cron parser + IANA timezone db; opt out of it for slim builds.
+schedule = ["dep:croner", "dep:chrono-tz", "dep:chrono"]
+
 [dependencies]
 faucet-core.workspace = true
 faucet-auth.workspace = true
@@ -227,6 +231,9 @@ base64 = { workspace = true, optional = true }
 azure_security_keyvault_secrets = { workspace = true, optional = true }
 azure_identity = { workspace = true, optional = true }
 azure_core = { workspace = true, optional = true }
+chrono = { workspace = true, optional = true }
+chrono-tz = { workspace = true, optional = true }
+croner = { workspace = true, optional = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/cli/README.md
+++ b/cli/README.md
@@ -380,10 +380,44 @@ Tokens are resolved in two passes:
 | `${gcp-sm:projects/<p>/secrets/<s>/versions/<v>}` | Load-time. GCP Secret Manager (`versions/latest` ok). Auth: Application Default Credentials. Build with `--features secrets-gcp-sm`. |
 | `${azure-kv:<vault>/<secret>[/<version>]}` | Load-time. Azure Key Vault. Auth: `AZURE_*` env / managed identity / `az login`. Build with `--features secrets-azure-kv`. |
 | `${row_id.dotted.path}` | Run-time, per parent record. The `row_id` must be the id of another matrix row. |
+| `${now.*}` | Run-time, per invocation. Injects the run's wall time into source and sink config values. See below. |
 
 A token's form decides its meaning: a **colon** marks a load-time directive (`${env:VAR}`), while a **dot or nothing** marks a deferred row-id reference (`${users.id}`). The same rule is used by both `faucet validate` and `faucet run`, so a token like `${env.foo}` (a dot, not a colon) is consistently treated as a reference to row id `env` and rejected at validate-time rather than failing only at run-time.
 
-`$${` escapes a literal `${`. Reserved row ids that can never appear in `matrix.id`: `env`, `file`, `secret`, `matrix`, `pipeline`.
+`$${` escapes a literal `${`. Reserved row ids that can never appear in `matrix.id`: `env`, `file`, `secret`, `matrix`, `pipeline`, `now`.
+
+#### `${now.*}` — run-clock interpolation
+
+Inject the invocation's wall time into any **source or sink** config value. Common use case: writing to a dated output path so each scheduled run lands in its own partition.
+
+| Token | Example | Notes |
+|-------|---------|-------|
+| `${now.date}` | `2026-03-08` | `YYYY-MM-DD` |
+| `${now.datetime}` / `${now.iso}` | `2026-03-08T14:05:09+00:00` | RFC 3339 |
+| `${now.year}` | `2026` | Zero-padded |
+| `${now.month}` | `03` | Zero-padded (01–12) |
+| `${now.day}` | `08` | Zero-padded (01–31) |
+| `${now.hour}` | `14` | Zero-padded (00–23) |
+| `${now.minute}` | `05` | Zero-padded (00–59) |
+| `${now.second}` | `09` | Zero-padded (00–59) |
+| `${now.unix}` | `1741442709` | Epoch seconds |
+| `${now.strftime.<fmt>}` | `2026/03/08/14` | Arbitrary chrono strftime, e.g. `${now.strftime.%Y/%m/%d/%H}` |
+
+An unknown token (e.g. `${now.foo}`) is a config error at run time. `${now.*}` is **not** resolved in `state:`, `dlq:`, `transforms:`, or the `auth:` / `vars:` blocks.
+
+**Clock source:**
+
+- `faucet run` — process start time in UTC, or `--clock <RFC3339|YYYY-MM-DD>` for backfills (a bare date means midnight UTC).
+- `faucet schedule` — the tick's scheduled time in the schedule's `timezone`; `${now.date}` therefore matches the timezone the cron fires in, not UTC.
+
+**Backfills:**
+
+```bash
+faucet run --clock 2026-03-01 pipeline.yaml          # midnight UTC
+faucet run --clock 2026-03-01T02:00:00-08:00 pipeline.yaml  # precise timestamp
+```
+
+**Local file sinks** (JSONL, CSV) create missing parent directories automatically, so dated subdirectory paths like `./data/dt=${now.date}/part.jsonl` work without pre-creating the tree.
 
 **Security note.** Pipeline configs are trusted input: `${file:...}` reads any path the process can access (capped at 1 MiB), and `${env:}`/`${secret:}` inject process environment values. Connector-config deserialization errors are scrubbed (double-quoted values redacted, length-capped) before they reach logs so an injected secret can't leak through an error message, but treat configs and their resolved values as sensitive.
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -29,6 +29,7 @@ cargo install faucet-cli --no-default-features \
 | `faucet preview <config> --limit N` | Run only the source side and emit the first N records to stdout as JSONL. |
 | `faucet init [name] [--source X] [--sink Y]` | Scaffold a pipeline.yaml from each connector's JSON Schema. |
 | `faucet doctor <config> [--timeout-secs N] [--json]` | Probe every connector (auth/network/permissions/reachability) and print a checklist. Exits with the failed-probe count. |
+| `faucet schedule <config> [--once]` | Run a pipeline on a cron schedule (long-running foreground process). Requires a `schedule:` block. |
 
 Pass `--log-level debug` (or set `FAUCET_LOG=debug`) for verbose tracing. Logs are written to stderr; pipeline records and command output go to stdout.
 
@@ -73,6 +74,108 @@ Flags:
 **Exit code** = the number of failed probes, clamped to 255 (so `0` means all probes passed). **Child invocations** (parent/child matrix rows) are listed but not probed — their configs depend on parent records that only exist at run time. Probe `reason`/`hint` text is scrubbed for resolved secrets before printing, but third-party connectors should never place credentials in a probe message.
 
 **Probe contract for connector authors:** `Source::check` / `Sink::check` / `StateStore::check` (in `faucet-core`) default to a generic probe (source) or "not implemented" skip (sink / state). Override them with a probe that is **idempotent and side-effect-free** and never echoes credentials. Return probe-level failures as `ProbeStatus::Fail` inside an `Ok(CheckReport)`; reserve `Err` for "couldn't run any probe".
+
+### `faucet schedule`
+
+`faucet schedule <config>` runs a pipeline on a cron schedule in a **long-running foreground process**. Stop it with Ctrl-C or SIGTERM; an in-flight run drains gracefully before the process exits.
+
+```bash
+faucet schedule pipeline.yaml                        # run on cron schedule, foreground
+faucet schedule pipeline.yaml --once                 # run exactly once now, then exit
+faucet schedule pipeline.yaml --env-file prod.env    # inject env before loading config
+faucet schedule pipeline.yaml --no-env-file          # disable .env auto-loading
+```
+
+The config must contain a top-level `schedule:` block (a config without one is rejected with a clear hint pointing to `faucet run`). Requires the `schedule` Cargo feature (included in the default `full` build).
+
+#### `schedule:` block grammar
+
+```yaml
+schedule:
+  cron: "0 2 * * *"               # REQUIRED. 5-field standard Unix cron, or 6-field with leading seconds.
+  timezone: "UTC"                 # IANA name (e.g. America/Los_Angeles). Default UTC.
+  overlap_policy: skip            # skip (default) | queue | forbid
+  max_runs: null                  # null = forever; N = stop cleanly (exit 0) after N *successful* runs
+  max_consecutive_failures: null  # null = never exit on failure; N = exit non-zero after N straight failures
+  on_failure: continue            # continue (default) | stop (exit non-zero on first failed run)
+  start_immediately: false        # run once on startup before waiting for the first tick
+  run_timeout_secs: null          # optional per-run kill switch (seconds); a timed-out run counts as failed
+  shutdown_grace_secs: 30         # SIGTERM: await the in-flight run this long, then abort
+```
+
+**Cron syntax:** standard 5-field Unix cron (`MIN HOUR DOM MON DOW`) or 6-field with a leading seconds field (`SEC MIN HOUR DOM MON DOW`). Examples:
+
+| Expression | Meaning |
+|------------|---------|
+| `0 2 * * *` | Every night at 02:00 |
+| `*/15 * * * *` | Every 15 minutes |
+| `0 9 * * 1-5` | Weekdays at 09:00 |
+| `*/30 * * * * *` | Every 30 seconds (6-field) |
+
+Bad cron expressions, unknown timezones, `max_runs: 0`, and a cron that can never fire all fail fast with a clear `config error: schedule: …` message.
+
+**Timezone and DST:** all ticks are computed on UTC instants with timezone-correct wall times via `chrono-tz`. Fall-back repeated hours fire once; spring-forward skipped hours roll to the next valid time. The loop re-checks the wall clock every ≤30 s so NTP steps and VM freezes can't drift a fire by more than ~30 s.
+
+**Missed ticks:** skipped, not backfilled. If a run ran long or the box was down, the scheduler fires at the next due time — no catch-up storm.
+
+#### Overlap policy
+
+| Policy | Behaviour |
+|--------|-----------|
+| `skip` (default) | Drop the tick if a run is already in flight. Increment `faucet_schedule_overlaps_total`. |
+| `queue` | Buffer one missed tick; run it when the current run finishes. Further misses collapse to one queued tick (in-memory only — lost on restart). |
+| `forbid` | Exit non-zero immediately if a second run would overlap. |
+
+#### Failure model
+
+Two independent knobs control what happens when a run fails:
+
+| `on_failure` | `max_consecutive_failures` | Behaviour |
+|---|---|---|
+| `continue` (default) | `null` | Tolerates all failures; never exits on failure alone. Alert on `faucet_schedule_consecutive_failures`. |
+| `continue` | `N` | Tolerates up to N−1 straight failures; exits non-zero after N consecutive failures (a success resets the counter). Pair with a supervisor (`systemd Restart=on-failure`, Kubernetes) for "tolerate blips, restart on sustained outage". |
+| `stop` | any | Exits non-zero on the **first** failed run. |
+
+#### Connectors and state
+
+Connectors are rebuilt fresh per run so no idle connections pool up. The shared `auth:` catalog (cached tokens) is reused across ticks. Resumability rides faucet's existing per-page `StateStore` bookmark: the scheduler itself keeps no run-state across restarts, so a crash or SIGKILL resume from the last persisted bookmark on the next start.
+
+#### Metrics
+
+All metrics carry the `{pipeline}` label. Register a Prometheus listener via the `observability:` block as usual.
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `faucet_schedule_runs_total{pipeline,outcome}` | Counter | `outcome` ∈ `{ok, err, skipped}` |
+| `faucet_schedule_overlaps_total{pipeline,policy}` | Counter | Overlap events; `policy` ∈ `{skip, queue, forbid}` |
+| `faucet_schedule_next_tick_unix_seconds{pipeline}` | Gauge | Unix timestamp of the next scheduled tick |
+| `faucet_schedule_runs_in_flight{pipeline}` | Gauge | 0 or 1 — whether a run is currently executing |
+| `faucet_schedule_consecutive_failures{pipeline}` | Gauge | Resets to 0 on a successful run |
+| `faucet_schedule_heartbeat_unix_seconds{pipeline}` | Gauge | Updated every loop wake (≤30 s); alert `time() − heartbeat > 90` to detect a stuck scheduler |
+| `faucet_schedule_last_run_started_unix_seconds{pipeline}` | Gauge | |
+| `faucet_schedule_last_run_completed_unix_seconds{pipeline}` | Gauge | |
+| `faucet_schedule_last_run_duration_seconds{pipeline}` | Gauge | |
+| `faucet_schedule_run_lateness_seconds{pipeline}` | Histogram | `actual_start − scheduled_for` — how late the run fired |
+
+Each run also emits a `faucet.schedule.run` tracing span (attributes: `run_ordinal`, `scheduled_for_unix_seconds`, `tick_unix_seconds`) wrapping the inner pipeline spans.
+
+#### Exit codes
+
+| Condition | Exit code |
+|-----------|-----------|
+| `max_runs` reached | 0 |
+| SIGTERM / SIGINT graceful drain | 0 |
+| `on_failure: stop` — first run failed | non-zero |
+| `max_consecutive_failures` reached | non-zero |
+| `overlap_policy: forbid` overlap | non-zero |
+| Bad cron / timezone / config | non-zero |
+
+#### Build feature
+
+```bash
+cargo install faucet-cli                         # schedule included (in full)
+cargo install faucet-cli --features schedule     # explicit, no-default-features build
+```
 
 ### `faucet init`
 

--- a/cli/examples/scheduled_nightly.yaml
+++ b/cli/examples/scheduled_nightly.yaml
@@ -1,6 +1,13 @@
 # Run a CSV→JSONL pipeline every night at 02:00 America/Los_Angeles.
 # Start it with:  faucet schedule cli/examples/scheduled_nightly.yaml
 # Stop it with Ctrl-C (or SIGTERM); the in-flight run drains first.
+#
+# ${now.date} resolves to the tick's scheduled date in the schedule's timezone
+# (America/Los_Angeles), so each nightly run writes to its own dated partition.
+# Example: ./warehouse/dt=2026-03-08/events.jsonl
+#
+# To backfill a specific date without changing this file:
+#   faucet run --clock 2026-03-01 cli/examples/scheduled_nightly.yaml
 version: 1
 name: nightly-rollup
 
@@ -20,4 +27,5 @@ pipeline:
   sink:
     type: jsonl
     config:
-      path: ./events.jsonl
+      # Dated partition — parent directory is created automatically.
+      path: "./warehouse/dt=${now.date}/events.jsonl"

--- a/cli/examples/scheduled_nightly.yaml
+++ b/cli/examples/scheduled_nightly.yaml
@@ -1,0 +1,23 @@
+# Run a CSV→JSONL pipeline every night at 02:00 America/Los_Angeles.
+# Start it with:  faucet schedule cli/examples/scheduled_nightly.yaml
+# Stop it with Ctrl-C (or SIGTERM); the in-flight run drains first.
+version: 1
+name: nightly-rollup
+
+schedule:
+  cron: "0 2 * * *"
+  timezone: "America/Los_Angeles"
+  overlap_policy: skip            # don't pile up if a run runs long
+  max_consecutive_failures: 5     # exit non-zero after 5 straight failures (supervisor restarts)
+  on_failure: continue
+  shutdown_grace_secs: 30
+
+pipeline:
+  source:
+    type: csv
+    config:
+      path: ./events.csv
+  sink:
+    type: jsonl
+    config:
+      path: ./events.jsonl

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -33,6 +33,9 @@ pub enum Command {
     /// Probe every connector in a config (auth / network / permissions) and
     /// print a green/red checklist. Exits non-zero if any probe fails.
     Doctor(DoctorArgs),
+    /// Run a pipeline on a cron schedule (long-running; Ctrl-C / SIGTERM to stop).
+    #[cfg(feature = "schedule")]
+    Schedule(ScheduleArgs),
 }
 
 /// `faucet doctor` arguments.
@@ -54,6 +57,26 @@ pub struct DoctorArgs {
     /// Emit machine-readable JSON instead of the human checklist.
     #[arg(long)]
     pub json: bool,
+}
+
+/// `faucet schedule` arguments.
+#[cfg(feature = "schedule")]
+#[derive(Debug, Parser)]
+pub struct ScheduleArgs {
+    /// Path to a `.yaml`, `.yml`, or `.json` pipeline config with a `schedule:`
+    /// block. If omitted, auto-discover `faucet.yaml` / `.yml` / `.json` in cwd.
+    pub config: Option<PathBuf>,
+    /// Path to a `.env` file to load for `${env:VAR}` interpolation.
+    /// Defaults to `.env` in cwd if present.
+    #[arg(long, conflicts_with = "no_env_file")]
+    pub env_file: Option<PathBuf>,
+    /// Skip auto-loading `.env` from cwd.
+    #[arg(long)]
+    pub no_env_file: bool,
+    /// Run exactly one pipeline run immediately, then exit (ignores cron timing).
+    /// Useful for platform-driven invocation (k8s CronJob / systemd OnCalendar).
+    #[arg(long)]
+    pub once: bool,
 }
 
 /// `faucet run` arguments.
@@ -141,6 +164,9 @@ pub enum SchemaTarget {
     Quality,
     /// Grammar reference for secrets-manager interpolation directives.
     Secrets,
+    /// JSON Schema for the `schedule:` block.
+    #[cfg(feature = "schedule")]
+    Schedule,
 }
 
 /// `faucet preview` arguments.

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -110,6 +110,11 @@ pub struct RunArgs {
     /// Override the state-store directory (file backend only).
     #[arg(long)]
     pub state_path: Option<PathBuf>,
+    /// Override the `${now.*}` interpolation clock (RFC3339 like
+    /// `2026-01-31T00:00:00Z`, or a date `2026-01-31`). Default: process start (UTC).
+    /// Use for backfills.
+    #[arg(long)]
+    pub clock: Option<String>,
 }
 
 /// `faucet validate` arguments.

--- a/cli/src/commands/list.rs
+++ b/cli/src/commands/list.rs
@@ -26,6 +26,8 @@ pub async fn run() -> CliResult<()> {
         println!();
     }
     println!("State stores: {}", available_state_kinds().join(", "));
+    #[cfg(feature = "schedule")]
+    println!("Scheduler:    compiled in (run `faucet schedule --help`, `faucet schema schedule`)");
     Ok(())
 }
 

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -6,6 +6,8 @@ pub mod init;
 pub mod list;
 pub mod preview;
 pub mod run;
+#[cfg(feature = "schedule")]
+pub mod schedule;
 pub mod schema;
 pub mod validate;
 

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -6,34 +6,6 @@ use crate::config::PipelineConfig;
 use crate::error::{CliError, CliResult};
 use crate::executor::{ExecuteOptions, run_expanded};
 use crate::expand::expand;
-use faucet_core::{ObservabilityConfig, PrometheusConfig, TracingConfig, install_observability};
-
-/// Resolve the effective `tracing-subscriber` env-filter directive using
-/// the documented precedence:
-///   `--log-level` flag > `FAUCET_LOG` > `RUST_LOG` > YAML `observability.tracing.level` > `None`
-///
-/// Returns `None` when nothing is set (caller falls back to the default).
-///
-/// Note: `cli_flag` is `None` when called from `run` because the top-level
-/// `Cli.log_level` (already applied by `main.rs`) is not forwarded through
-/// `RunArgs`. Pass `Some(level)` in tests or future call-sites that do have
-/// the CLI value available.
-fn resolve_tracing_level(cli_flag: Option<&str>, yaml_level: Option<&str>) -> Option<String> {
-    if let Some(l) = cli_flag {
-        return Some(l.to_string());
-    }
-    if let Ok(l) = std::env::var("FAUCET_LOG")
-        && !l.is_empty()
-    {
-        return Some(l);
-    }
-    if let Ok(l) = std::env::var("RUST_LOG")
-        && !l.is_empty()
-    {
-        return Some(l);
-    }
-    yaml_level.map(|s| s.to_string())
-}
 
 /// Execute the `run` subcommand.
 pub async fn run(args: RunArgs) -> CliResult<()> {
@@ -64,48 +36,7 @@ pub async fn run(args: RunArgs) -> CliResult<()> {
         .await?
     };
 
-    // Install observability (Prometheus + tracing) before any pipeline work.
-    // `main.rs` already called `install_tracing` from `Cli.log_level`, so
-    // the tracing subscriber is likely already set; `install_observability`
-    // is idempotent — it logs a warning and continues rather than panicking.
-    //
-    // Tracing-level precedence for the YAML-block tracing config:
-    //   --log-level flag (in Cli, not in RunArgs) > FAUCET_LOG > RUST_LOG
-    //   > YAML observability.tracing.level > None (main.rs default applies)
-    let level = resolve_tracing_level(
-        // `RunArgs` does not carry `log_level`; the top-level `Cli.log_level`
-        // (already consumed in main.rs) is not forwarded here, so pass `None`.
-        None,
-        cfg.observability
-            .as_ref()
-            .and_then(|o| o.tracing.as_ref())
-            .and_then(|t| t.level.as_deref()),
-    );
-    let obs_cfg = ObservabilityConfig {
-        prometheus: cfg
-            .observability
-            .as_ref()
-            .and_then(|o| o.prometheus.as_ref())
-            .map(|p| PrometheusConfig {
-                listen: p.listen.clone(),
-                buckets: p.buckets.clone(),
-            }),
-        tracing: level.map(|l| TracingConfig { level: l }),
-    };
-    let report = install_observability(&obs_cfg)?;
-    if let Some(addr) = report.prometheus_listen.as_deref() {
-        tracing::info!("Prometheus /metrics listening on {addr}");
-    }
-    if report.prometheus_already_installed {
-        tracing::warn!(
-            "Prometheus recorder already installed; metrics route through the existing recorder"
-        );
-    }
-    if report.tracing_already_installed {
-        tracing::warn!(
-            "tracing subscriber already installed; logs route through the existing subscriber"
-        );
-    }
+    crate::obs::install(&cfg)?;
 
     let pipeline_name = cfg.name.clone().unwrap_or_else(|| {
         resolved_config_path
@@ -166,81 +97,4 @@ pub async fn run(args: RunArgs) -> CliResult<()> {
         return Err(CliError::PipelineHadFailures { count: failed });
     }
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    // The env tests share process-global state — serialize them via a mutex.
-    use std::sync::Mutex;
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
-
-    fn with_clean_env<F: FnOnce()>(f: F) {
-        let _g = ENV_LOCK.lock().unwrap();
-        // Rust 2024: set_var/remove_var are unsafe (touch process-wide state).
-        unsafe {
-            std::env::remove_var("FAUCET_LOG");
-            std::env::remove_var("RUST_LOG");
-        }
-        f();
-    }
-
-    #[test]
-    fn cli_flag_beats_env_and_yaml() {
-        with_clean_env(|| {
-            unsafe {
-                std::env::set_var("FAUCET_LOG", "debug");
-                std::env::set_var("RUST_LOG", "trace");
-            }
-            assert_eq!(
-                resolve_tracing_level(Some("error"), Some("info")).as_deref(),
-                Some("error")
-            );
-        });
-    }
-
-    #[test]
-    fn faucet_log_beats_rust_log_and_yaml() {
-        with_clean_env(|| {
-            unsafe {
-                std::env::set_var("FAUCET_LOG", "debug");
-                std::env::set_var("RUST_LOG", "trace");
-            }
-            assert_eq!(
-                resolve_tracing_level(None, Some("info")).as_deref(),
-                Some("debug")
-            );
-        });
-    }
-
-    #[test]
-    fn rust_log_beats_yaml() {
-        with_clean_env(|| {
-            unsafe {
-                std::env::set_var("RUST_LOG", "trace");
-            }
-            assert_eq!(
-                resolve_tracing_level(None, Some("info")).as_deref(),
-                Some("trace")
-            );
-        });
-    }
-
-    #[test]
-    fn yaml_used_when_no_flag_or_env() {
-        with_clean_env(|| {
-            assert_eq!(
-                resolve_tracing_level(None, Some("info")).as_deref(),
-                Some("info")
-            );
-        });
-    }
-
-    #[test]
-    fn none_returned_when_nothing_set() {
-        with_clean_env(|| {
-            assert_eq!(resolve_tracing_level(None, None), None);
-        });
-    }
 }

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -7,6 +7,27 @@ use crate::error::{CliError, CliResult};
 use crate::executor::{ExecuteOptions, run_expanded};
 use crate::expand::expand;
 
+/// Parse the optional `--clock` override (RFC3339 or `YYYY-MM-DD`), or default
+/// to process start. Returned as a UTC fixed-offset clock for `${now.*}`.
+fn resolve_run_clock(flag: Option<&str>) -> CliResult<chrono::DateTime<chrono::FixedOffset>> {
+    use chrono::{DateTime, NaiveDate, TimeZone, Utc};
+    match flag {
+        None => Ok(Utc::now().fixed_offset()),
+        Some(s) => {
+            if let Ok(dt) = DateTime::parse_from_rfc3339(s) {
+                return Ok(dt);
+            }
+            if let Ok(d) = NaiveDate::parse_from_str(s, "%Y-%m-%d") {
+                let ndt = d.and_hms_opt(0, 0, 0).expect("00:00:00 is valid");
+                return Ok(Utc.from_utc_datetime(&ndt).fixed_offset());
+            }
+            Err(CliError::Config(format!(
+                "--clock '{s}' is not RFC3339 (2026-01-31T00:00:00Z) or a date (2026-01-31)"
+            )))
+        }
+    }
+}
+
 /// Execute the `run` subcommand.
 pub async fn run(args: RunArgs) -> CliResult<()> {
     let cwd = std::env::current_dir()?;
@@ -58,6 +79,7 @@ pub async fn run(args: RunArgs) -> CliResult<()> {
             limit: args.limit,
             state_path_override: args.state_path.clone(),
             auth,
+            clock: resolve_run_clock(args.clock.as_deref())?,
         },
     )
     .await?;
@@ -97,4 +119,24 @@ pub async fn run(args: RunArgs) -> CliResult<()> {
         return Err(CliError::PipelineHadFailures { count: failed });
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn run_clock_parses_rfc3339_date_and_defaults() {
+        // RFC3339
+        let c = resolve_run_clock(Some("2026-01-31T12:00:00Z")).unwrap();
+        assert_eq!(c.format("%Y-%m-%d %H:%M").to_string(), "2026-01-31 12:00");
+        // date-only → midnight UTC
+        let c = resolve_run_clock(Some("2026-01-31")).unwrap();
+        assert_eq!(c.format("%Y-%m-%d %H:%M").to_string(), "2026-01-31 00:00");
+        // default = now (just assert it's Ok / recent year)
+        let c = resolve_run_clock(None).unwrap();
+        assert!(c.format("%Y").to_string().parse::<i32>().unwrap() >= 2025);
+        // bad input errors
+        assert!(resolve_run_clock(Some("not-a-date")).is_err());
+    }
 }

--- a/cli/src/commands/schedule.rs
+++ b/cli/src/commands/schedule.rs
@@ -287,7 +287,12 @@ async fn run_loop(
             match state.on_tick(running.is_some()) {
                 TickAction::Dispatch => {
                     run_ordinal += 1;
-                    let opts = make_opts(&pipeline_name, &execution, &auth, compiled.clock_at(next_due));
+                    let opts = make_opts(
+                        &pipeline_name,
+                        &execution,
+                        &auth,
+                        compiled.clock_at(next_due),
+                    );
                     let span = run_span(run_ordinal, next_due, now);
                     let handle = spawn_run(nodes.clone(), opts, compiled.run_timeout, span);
                     m::in_flight(&pipeline_name, 1);

--- a/cli/src/commands/schedule.rs
+++ b/cli/src/commands/schedule.rs
@@ -1,9 +1,395 @@
-//! `faucet schedule` — cron-driven long-running pipeline runner.
+//! `faucet schedule` — run a pipeline on a cron schedule in one long-running
+//! process. Reuses `expand` + `executor::run_expanded` per tick; keeps no state
+//! of its own (resumability rides the pipeline's per-page bookmark). See
+//! `docs/superpowers/specs/2026-05-30-faucet-schedule-design.md`.
 
+use crate::auth_catalog::{AuthCatalog, build_auth_catalog};
 use crate::cli::ScheduleArgs;
-use crate::error::CliResult;
+use crate::config::PipelineConfig;
+use crate::error::{CliError, CliResult};
+use crate::executor::{ExecuteOptions, RunSummary, run_expanded};
+use crate::expand::{ExpandedNode, expand};
+use crate::schedule::compiled::CompiledSchedule;
+use crate::schedule::metrics as m;
+use crate::schedule::state::{AfterRun, RunOutcome, SchedulerState, TickAction};
+use chrono::{DateTime, Utc};
+use std::time::Duration;
+use tokio::task::JoinHandle;
+use tokio::time::Instant;
+use tracing::Instrument;
 
-/// Execute the `schedule` subcommand. (Implemented in Task 9.)
-pub async fn run(_args: ScheduleArgs) -> CliResult<()> {
-    unimplemented!("faucet schedule — implemented in Task 9")
+/// An in-flight run.
+struct RunningRun {
+    handle: JoinHandle<CliResult<RunSummary>>,
+    started: Instant,
+}
+
+/// The data the loop needs after a run finishes.
+struct RunFinished {
+    outcome: RunOutcome,
+    duration: Duration,
+    detail: Option<String>,
+}
+
+/// Cross-platform shutdown-signal source, registered once.
+struct Shutdown {
+    #[cfg(unix)]
+    sigterm: tokio::signal::unix::Signal,
+}
+
+impl Shutdown {
+    fn new() -> CliResult<Self> {
+        #[cfg(unix)]
+        {
+            use tokio::signal::unix::{SignalKind, signal};
+            let sigterm = signal(SignalKind::terminate())
+                .map_err(|e| CliError::Internal(format!("failed to install SIGTERM handler: {e}")))?;
+            Ok(Self { sigterm })
+        }
+        #[cfg(not(unix))]
+        {
+            Ok(Self {})
+        }
+    }
+
+    /// Resolve when SIGTERM (Unix) or Ctrl-C (any platform) is received.
+    async fn recv(&mut self) {
+        #[cfg(unix)]
+        {
+            tokio::select! {
+                _ = tokio::signal::ctrl_c() => {}
+                _ = self.sigterm.recv() => {}
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = tokio::signal::ctrl_c().await;
+        }
+    }
+}
+
+/// Max time to sleep before re-reading the wall clock. Caps clock-step / DST
+/// drift to one chunk and keeps the heartbeat fresh.
+const MAX_SLEEP: Duration = Duration::from_secs(30);
+
+/// Execute the `schedule` subcommand.
+pub async fn run(args: ScheduleArgs) -> CliResult<()> {
+    let cwd = std::env::current_dir()?;
+    let env_path =
+        crate::env_loader::resolve_env_file(args.env_file.as_deref(), args.no_env_file, &cwd)?;
+    crate::env_loader::load_env_file_if_present(env_path.as_deref())?;
+    let path = match args.config {
+        Some(p) => p,
+        None => crate::env_loader::discover_config_path(&cwd).ok_or(CliError::NoConfigOrFromEnv)?,
+    };
+
+    let cfg = PipelineConfig::from_path_async(&path).await?;
+    let spec = cfg.schedule.as_ref().ok_or_else(|| {
+        CliError::Config(
+            "no `schedule:` block in config — use `faucet run` for a one-shot run, or add a `schedule:` block"
+                .into(),
+        )
+    })?;
+    let compiled = CompiledSchedule::compile(spec)?;
+    let cron = spec.cron.clone();
+    let timezone = spec.timezone.clone();
+
+    crate::obs::install(&cfg)?;
+
+    let pipeline_name = cfg.name.clone().unwrap_or_else(|| {
+        path.file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("pipeline")
+            .to_owned()
+    });
+
+    let auth = build_auth_catalog(cfg.auth.as_ref())?;
+    let nodes = expand(&cfg)?; // validate once; cloned per tick
+    let execution = cfg.execution.clone();
+
+    if args.once {
+        return run_once(&nodes, &auth, &execution, &compiled, &pipeline_name).await;
+    }
+
+    run_loop(compiled, nodes, auth, execution, pipeline_name, cron, timezone).await
+}
+
+/// Build a fresh `ExecuteOptions` for one tick (connectors are rebuilt per run;
+/// the auth catalog is shared so cached tokens survive across ticks).
+fn make_opts(
+    pipeline_name: &str,
+    execution: &Option<crate::config::ExecutionSpec>,
+    auth: &AuthCatalog,
+) -> ExecuteOptions {
+    ExecuteOptions {
+        pipeline_name: pipeline_name.to_string(),
+        execution: execution.clone(),
+        dry_run: false,
+        limit: None,
+        state_path_override: None,
+        auth: auth.clone(),
+    }
+}
+
+/// The per-run tracing span. Wraps the inner pipeline spans so a scheduled run
+/// is correlatable in distributed tracing. `scheduled_for` is the cron-intended
+/// instant; `tick` is when the run actually started.
+fn run_span(run_ordinal: u64, scheduled_for: DateTime<Utc>, tick: DateTime<Utc>) -> tracing::Span {
+    tracing::info_span!(
+        "faucet.schedule.run",
+        run_ordinal,
+        scheduled_for_unix_seconds = scheduled_for.timestamp(),
+        tick_unix_seconds = tick.timestamp(),
+    )
+}
+
+/// Spawn one pipeline run, wrapping it in the optional run timeout and the
+/// per-run span.
+fn spawn_run(
+    nodes: Vec<ExpandedNode>,
+    opts: ExecuteOptions,
+    timeout: Option<Duration>,
+    span: tracing::Span,
+) -> JoinHandle<CliResult<RunSummary>> {
+    tokio::spawn(
+        async move {
+            match timeout {
+                Some(d) => match tokio::time::timeout(d, run_expanded(nodes, opts)).await {
+                    Ok(r) => r,
+                    Err(_) => Err(CliError::Internal(format!(
+                        "scheduled run exceeded run_timeout_secs ({}s) and was aborted",
+                        d.as_secs()
+                    ))),
+                },
+                None => run_expanded(nodes, opts).await,
+            }
+        }
+        .instrument(span),
+    )
+}
+
+/// Classify a joined run task into a scheduler outcome + a log detail.
+fn classify(joined: Result<CliResult<RunSummary>, tokio::task::JoinError>) -> RunFinished {
+    let (outcome, detail) = match joined {
+        Ok(Ok(summary)) if summary.had_failures() => (
+            RunOutcome::Failure,
+            Some(format!("{} invocation(s) failed", summary.failure_count())),
+        ),
+        Ok(Ok(_)) => (RunOutcome::Success, None),
+        Ok(Err(e)) => (RunOutcome::Failure, Some(e.to_string())),
+        Err(je) => (RunOutcome::Failure, Some(format!("run task panicked: {je}"))),
+    };
+    RunFinished { outcome, duration: Duration::ZERO, detail }
+}
+
+/// `--once`: run exactly one pipeline run now and map its result to an exit.
+async fn run_once(
+    nodes: &[ExpandedNode],
+    auth: &AuthCatalog,
+    execution: &Option<crate::config::ExecutionSpec>,
+    compiled: &CompiledSchedule,
+    pipeline_name: &str,
+) -> CliResult<()> {
+    tracing::info!(pipeline = %pipeline_name, "schedule --once: running one pipeline now");
+    let opts = make_opts(pipeline_name, execution, auth);
+    let fut = run_expanded(nodes.to_vec(), opts);
+    let summary = match compiled.run_timeout {
+        Some(d) => tokio::time::timeout(d, fut)
+            .await
+            .map_err(|_| {
+                CliError::Internal(format!("--once run exceeded run_timeout_secs ({}s)", d.as_secs()))
+            })??,
+        None => fut.await?,
+    };
+    if summary.had_failures() {
+        return Err(CliError::PipelineHadFailures { count: summary.failure_count() });
+    }
+    Ok(())
+}
+
+/// The scheduling loop.
+#[allow(clippy::too_many_arguments)]
+async fn run_loop(
+    compiled: CompiledSchedule,
+    nodes: Vec<ExpandedNode>,
+    auth: AuthCatalog,
+    execution: Option<crate::config::ExecutionSpec>,
+    pipeline_name: String,
+    cron: String,
+    timezone: String,
+) -> CliResult<()> {
+    let mut state = SchedulerState::new(&compiled);
+    let mut shutdown = Shutdown::new()?;
+    let mut running: Option<RunningRun> = None;
+    let mut pending_scheduled_for: Option<DateTime<Utc>> = None;
+    let mut run_ordinal: u64 = 0;
+
+    let mut next_due = if compiled.start_immediately {
+        Utc::now()
+    } else {
+        compiled
+            .next_after(Utc::now())
+            .ok_or_else(|| CliError::Config("schedule: no upcoming occurrence".into()))?
+    };
+
+    // Startup banner: cron, timezone, and the next few firing times so an
+    // operator can confirm at a glance the schedule is configured correctly.
+    let upcoming: Vec<String> = {
+        let mut t = Utc::now();
+        let mut v = Vec::with_capacity(3);
+        while v.len() < 3 {
+            match compiled.next_after(t) {
+                Some(n) => {
+                    v.push(n.to_rfc3339());
+                    t = n;
+                }
+                None => break,
+            }
+        }
+        v
+    };
+    tracing::info!(
+        pipeline = %pipeline_name,
+        cron = %cron,
+        timezone = %timezone,
+        next_occurrences = ?upcoming,
+        "scheduler started (Ctrl-C / SIGTERM to stop)"
+    );
+
+    loop {
+        let now = Utc::now();
+
+        if now >= next_due {
+            match state.on_tick(running.is_some()) {
+                TickAction::Dispatch => {
+                    run_ordinal += 1;
+                    let opts = make_opts(&pipeline_name, &execution, &auth);
+                    let span = run_span(run_ordinal, next_due, now);
+                    let handle = spawn_run(nodes.clone(), opts, compiled.run_timeout, span);
+                    m::in_flight(&pipeline_name, 1);
+                    m::last_run_started(&pipeline_name, now);
+                    m::lateness(&pipeline_name, now - next_due);
+                    tracing::info!(pipeline = %pipeline_name, run_ordinal, scheduled_for = %next_due, "run started");
+                    running = Some(RunningRun { handle, started: Instant::now() });
+                }
+                TickAction::Skip => {
+                    m::overlap(&pipeline_name, "skip");
+                    m::run_outcome(&pipeline_name, "skipped");
+                    tracing::warn!(pipeline = %pipeline_name, scheduled_for = %next_due, "tick skipped — previous run still in progress");
+                }
+                TickAction::Queue => {
+                    m::overlap(&pipeline_name, "queue");
+                    if pending_scheduled_for.is_none() {
+                        pending_scheduled_for = Some(next_due);
+                    }
+                    tracing::warn!(pipeline = %pipeline_name, scheduled_for = %next_due, "tick queued — will run after current run finishes");
+                }
+                TickAction::ForbidAbort => {
+                    m::overlap(&pipeline_name, "forbid");
+                    return Err(CliError::ScheduleOverlapForbidden);
+                }
+            }
+            next_due = match compiled.next_after(Utc::now()) {
+                Some(t) => t,
+                None => {
+                    tracing::info!(pipeline = %pipeline_name, "no further scheduled occurrences; exiting");
+                    return Ok(());
+                }
+            };
+        }
+
+        let now2 = Utc::now();
+        m::heartbeat(&pipeline_name, now2);
+        m::next_tick(&pipeline_name, next_due);
+        let chunk = (next_due - now2).to_std().unwrap_or(Duration::ZERO).min(MAX_SLEEP);
+
+        tokio::select! {
+            biased;
+
+            _ = shutdown.recv() => {
+                tracing::info!(pipeline = %pipeline_name, "shutdown signal received; draining in-flight run");
+                graceful_shutdown(running.take(), compiled.shutdown_grace, &pipeline_name).await;
+                return Ok(());
+            }
+
+            finished = wait_for_run(&mut running) => {
+                let mut finished = finished;
+                if let Some(rr) = running.take() {
+                    finished.duration = rr.started.elapsed();
+                }
+                m::in_flight(&pipeline_name, 0);
+                let done_at = Utc::now();
+                m::last_run_completed(&pipeline_name, done_at);
+                m::last_run_duration(&pipeline_name, finished.duration);
+                m::run_outcome(&pipeline_name, match finished.outcome {
+                    RunOutcome::Success => "ok",
+                    RunOutcome::Failure => "err",
+                });
+                match finished.outcome {
+                    RunOutcome::Success => tracing::info!(
+                        pipeline = %pipeline_name, secs = finished.duration.as_secs_f64(), "run completed"
+                    ),
+                    RunOutcome::Failure => tracing::error!(
+                        pipeline = %pipeline_name, detail = finished.detail.as_deref().unwrap_or("unknown"),
+                        "run failed"
+                    ),
+                }
+
+                let after = state.on_run_finished(finished.outcome);
+                m::consecutive_failures(&pipeline_name, state.consecutive_failures());
+                match after {
+                    AfterRun::ExitOk => {
+                        tracing::info!(pipeline = %pipeline_name, "max_runs reached; exiting");
+                        return Ok(());
+                    }
+                    AfterRun::ExitFailure { consecutive } => {
+                        return Err(CliError::PipelineHadFailures { count: consecutive as usize });
+                    }
+                    AfterRun::Continue { dispatch_pending } => {
+                        if dispatch_pending {
+                            run_ordinal += 1;
+                            let sched_for = pending_scheduled_for.take().unwrap_or(done_at);
+                            let opts = make_opts(&pipeline_name, &execution, &auth);
+                            let span = run_span(run_ordinal, sched_for, done_at);
+                            let handle = spawn_run(nodes.clone(), opts, compiled.run_timeout, span);
+                            m::in_flight(&pipeline_name, 1);
+                            m::last_run_started(&pipeline_name, done_at);
+                            m::lateness(&pipeline_name, done_at - sched_for);
+                            tracing::info!(pipeline = %pipeline_name, run_ordinal, scheduled_for = %sched_for, "queued run started");
+                            running = Some(RunningRun { handle, started: Instant::now() });
+                        }
+                    }
+                }
+            }
+
+            _ = tokio::time::sleep(chunk) => { /* re-loop: re-read wall clock */ }
+        }
+    }
+}
+
+/// Await the in-flight run (or never resolve when idle). Returns the classified
+/// outcome; the caller fills in `duration` from the `RunningRun`.
+async fn wait_for_run(running: &mut Option<RunningRun>) -> RunFinished {
+    match running {
+        Some(rr) => classify((&mut rr.handle).await),
+        None => std::future::pending().await,
+    }
+}
+
+/// On shutdown, await the in-flight run up to `grace`, then abort it.
+async fn graceful_shutdown(running: Option<RunningRun>, grace: Duration, pipeline_name: &str) {
+    if let Some(mut rr) = running {
+        match tokio::time::timeout(grace, &mut rr.handle).await {
+            Ok(_) => tracing::info!(pipeline = %pipeline_name, "in-flight run finished during shutdown grace"),
+            Err(_) => {
+                rr.handle.abort();
+                tracing::warn!(
+                    pipeline = %pipeline_name,
+                    grace_secs = grace.as_secs(),
+                    "in-flight run exceeded shutdown grace; aborted (partial sink state possible; bookmark preserved for the next run)"
+                );
+            }
+        }
+        m::in_flight(pipeline_name, 0);
+    }
 }

--- a/cli/src/commands/schedule.rs
+++ b/cli/src/commands/schedule.rs
@@ -130,6 +130,7 @@ fn make_opts(
     pipeline_name: &str,
     execution: &Option<crate::config::ExecutionSpec>,
     auth: &AuthCatalog,
+    clock: chrono::DateTime<chrono::FixedOffset>,
 ) -> ExecuteOptions {
     ExecuteOptions {
         pipeline_name: pipeline_name.to_string(),
@@ -138,6 +139,7 @@ fn make_opts(
         limit: None,
         state_path_override: None,
         auth: auth.clone(),
+        clock,
     }
 }
 
@@ -208,7 +210,7 @@ async fn run_once(
     pipeline_name: &str,
 ) -> CliResult<()> {
     tracing::info!(pipeline = %pipeline_name, "schedule --once: running one pipeline now");
-    let opts = make_opts(pipeline_name, execution, auth);
+    let opts = make_opts(pipeline_name, execution, auth, compiled.clock_at(chrono::Utc::now()));
     let fut = run_expanded(nodes.to_vec(), opts);
     let summary = match compiled.run_timeout {
         Some(d) => tokio::time::timeout(d, fut).await.map_err(|_| {
@@ -283,7 +285,7 @@ async fn run_loop(
             match state.on_tick(running.is_some()) {
                 TickAction::Dispatch => {
                     run_ordinal += 1;
-                    let opts = make_opts(&pipeline_name, &execution, &auth);
+                    let opts = make_opts(&pipeline_name, &execution, &auth, compiled.clock_at(next_due));
                     let span = run_span(run_ordinal, next_due, now);
                     let handle = spawn_run(nodes.clone(), opts, compiled.run_timeout, span);
                     m::in_flight(&pipeline_name, 1);
@@ -375,7 +377,7 @@ async fn run_loop(
                         if dispatch_pending {
                             run_ordinal += 1;
                             let sched_for = pending_scheduled_for.take().unwrap_or(done_at);
-                            let opts = make_opts(&pipeline_name, &execution, &auth);
+                            let opts = make_opts(&pipeline_name, &execution, &auth, compiled.clock_at(sched_for));
                             let span = run_span(run_ordinal, sched_for, done_at);
                             let handle = spawn_run(nodes.clone(), opts, compiled.run_timeout, span);
                             m::in_flight(&pipeline_name, 1);

--- a/cli/src/commands/schedule.rs
+++ b/cli/src/commands/schedule.rs
@@ -1,0 +1,9 @@
+//! `faucet schedule` — cron-driven long-running pipeline runner.
+
+use crate::cli::ScheduleArgs;
+use crate::error::CliResult;
+
+/// Execute the `schedule` subcommand. (Implemented in Task 9.)
+pub async fn run(_args: ScheduleArgs) -> CliResult<()> {
+    unimplemented!("faucet schedule — implemented in Task 9")
+}

--- a/cli/src/commands/schedule.rs
+++ b/cli/src/commands/schedule.rs
@@ -210,8 +210,10 @@ async fn run_once(
     pipeline_name: &str,
 ) -> CliResult<()> {
     tracing::info!(pipeline = %pipeline_name, "schedule --once: running one pipeline now");
-    let opts = make_opts(pipeline_name, execution, auth, compiled.clock_at(chrono::Utc::now()));
-    let fut = run_expanded(nodes.to_vec(), opts);
+    let now = chrono::Utc::now();
+    let opts = make_opts(pipeline_name, execution, auth, compiled.clock_at(now));
+    let span = run_span(1, now, now);
+    let fut = run_expanded(nodes.to_vec(), opts).instrument(span);
     let summary = match compiled.run_timeout {
         Some(d) => tokio::time::timeout(d, fut).await.map_err(|_| {
             CliError::Internal(format!(

--- a/cli/src/commands/schedule.rs
+++ b/cli/src/commands/schedule.rs
@@ -42,8 +42,9 @@ impl Shutdown {
         #[cfg(unix)]
         {
             use tokio::signal::unix::{SignalKind, signal};
-            let sigterm = signal(SignalKind::terminate())
-                .map_err(|e| CliError::Internal(format!("failed to install SIGTERM handler: {e}")))?;
+            let sigterm = signal(SignalKind::terminate()).map_err(|e| {
+                CliError::Internal(format!("failed to install SIGTERM handler: {e}"))
+            })?;
             Ok(Self { sigterm })
         }
         #[cfg(not(unix))]
@@ -111,7 +112,16 @@ pub async fn run(args: ScheduleArgs) -> CliResult<()> {
         return run_once(&nodes, &auth, &execution, &compiled, &pipeline_name).await;
     }
 
-    run_loop(compiled, nodes, auth, execution, pipeline_name, cron, timezone).await
+    run_loop(
+        compiled,
+        nodes,
+        auth,
+        execution,
+        pipeline_name,
+        cron,
+        timezone,
+    )
+    .await
 }
 
 /// Build a fresh `ExecuteOptions` for one tick (connectors are rebuilt per run;
@@ -177,9 +187,16 @@ fn classify(joined: Result<CliResult<RunSummary>, tokio::task::JoinError>) -> Ru
         ),
         Ok(Ok(_)) => (RunOutcome::Success, None),
         Ok(Err(e)) => (RunOutcome::Failure, Some(e.to_string())),
-        Err(je) => (RunOutcome::Failure, Some(format!("run task panicked: {je}"))),
+        Err(je) => (
+            RunOutcome::Failure,
+            Some(format!("run task panicked: {je}")),
+        ),
     };
-    RunFinished { outcome, duration: Duration::ZERO, detail }
+    RunFinished {
+        outcome,
+        duration: Duration::ZERO,
+        detail,
+    }
 }
 
 /// `--once`: run exactly one pipeline run now and map its result to an exit.
@@ -194,15 +211,18 @@ async fn run_once(
     let opts = make_opts(pipeline_name, execution, auth);
     let fut = run_expanded(nodes.to_vec(), opts);
     let summary = match compiled.run_timeout {
-        Some(d) => tokio::time::timeout(d, fut)
-            .await
-            .map_err(|_| {
-                CliError::Internal(format!("--once run exceeded run_timeout_secs ({}s)", d.as_secs()))
-            })??,
+        Some(d) => tokio::time::timeout(d, fut).await.map_err(|_| {
+            CliError::Internal(format!(
+                "--once run exceeded run_timeout_secs ({}s)",
+                d.as_secs()
+            ))
+        })??,
         None => fut.await?,
     };
     if summary.had_failures() {
-        return Err(CliError::PipelineHadFailures { count: summary.failure_count() });
+        return Err(CliError::PipelineHadFailures {
+            count: summary.failure_count(),
+        });
     }
     Ok(())
 }
@@ -270,7 +290,10 @@ async fn run_loop(
                     m::last_run_started(&pipeline_name, now);
                     m::lateness(&pipeline_name, now - next_due);
                     tracing::info!(pipeline = %pipeline_name, run_ordinal, scheduled_for = %next_due, "run started");
-                    running = Some(RunningRun { handle, started: Instant::now() });
+                    running = Some(RunningRun {
+                        handle,
+                        started: Instant::now(),
+                    });
                 }
                 TickAction::Skip => {
                     m::overlap(&pipeline_name, "skip");
@@ -301,7 +324,10 @@ async fn run_loop(
         let now2 = Utc::now();
         m::heartbeat(&pipeline_name, now2);
         m::next_tick(&pipeline_name, next_due);
-        let chunk = (next_due - now2).to_std().unwrap_or(Duration::ZERO).min(MAX_SLEEP);
+        let chunk = (next_due - now2)
+            .to_std()
+            .unwrap_or(Duration::ZERO)
+            .min(MAX_SLEEP);
 
         tokio::select! {
             biased;
@@ -380,7 +406,9 @@ async fn wait_for_run(running: &mut Option<RunningRun>) -> RunFinished {
 async fn graceful_shutdown(running: Option<RunningRun>, grace: Duration, pipeline_name: &str) {
     if let Some(mut rr) = running {
         match tokio::time::timeout(grace, &mut rr.handle).await {
-            Ok(_) => tracing::info!(pipeline = %pipeline_name, "in-flight run finished during shutdown grace"),
+            Ok(_) => {
+                tracing::info!(pipeline = %pipeline_name, "in-flight run finished during shutdown grace")
+            }
             Err(_) => {
                 rr.handle.abort();
                 tracing::warn!(

--- a/cli/src/commands/schema.rs
+++ b/cli/src/commands/schema.rs
@@ -22,6 +22,11 @@ pub async fn run(args: SchemaArgs) -> CliResult<()> {
             serde_json::to_value(quality_schema)
                 .unwrap_or_else(|_| serde_json::json!({"type": "object"}))
         }
+        #[cfg(feature = "schedule")]
+        SchemaTarget::Schedule => {
+            let s = faucet_core::schema_for!(crate::schedule::spec::ScheduleSpec);
+            serde_json::to_value(s).unwrap_or_else(|_| serde_json::json!({"type": "object"}))
+        }
         SchemaTarget::Secrets => serde_json::json!({
             "title": "Secrets-manager interpolation grammar",
             "schemes": {

--- a/cli/src/commands/validate.rs
+++ b/cli/src/commands/validate.rs
@@ -41,7 +41,10 @@ pub async fn run(args: ValidateArgs) -> CliResult<()> {
     #[cfg(feature = "schedule")]
     if let Some(spec) = &cfg.schedule {
         crate::schedule::compiled::CompiledSchedule::compile(spec)?;
-        println!("schedule: cron '{}' tz '{}' — valid", spec.cron, spec.timezone);
+        println!(
+            "schedule: cron '{}' tz '{}' — valid",
+            spec.cron, spec.timezone
+        );
     }
 
     for node in &nodes {

--- a/cli/src/commands/validate.rs
+++ b/cli/src/commands/validate.rs
@@ -36,6 +36,14 @@ pub async fn run(args: ValidateArgs) -> CliResult<()> {
     };
     let nodes = expand(&cfg)?;
 
+    // Validate the schedule block (cron / timezone / bounds) so `faucet validate`
+    // catches schedule misconfiguration in CI without running. Offline-safe.
+    #[cfg(feature = "schedule")]
+    if let Some(spec) = &cfg.schedule {
+        crate::schedule::compiled::CompiledSchedule::compile(spec)?;
+        println!("schedule: cron '{}' tz '{}' — valid", spec.cron, spec.timezone);
+    }
+
     for node in &nodes {
         // Verifying the schema lookup also catches unknown connector kinds.
         source_schema(&node.source.kind)?;

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -76,6 +76,12 @@ pub struct PipelineConfig {
     /// Optional observability configuration (Prometheus + tracing).
     #[serde(default)]
     pub observability: Option<ObservabilitySpec>,
+
+    /// Optional cron schedule. Only consumed by `faucet schedule`; ignored by
+    /// `faucet run`. Presence makes the config runnable on a schedule.
+    #[cfg(feature = "schedule")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub schedule: Option<crate::schedule::spec::ScheduleSpec>,
 }
 
 /// The base pipeline definition. Each matrix row is resolved against the
@@ -710,6 +716,27 @@ pipeline:
             cfg.pipeline.source.as_ref().unwrap().config["path"],
             "/v1/users/${users.id}/posts"
         );
+    }
+
+    #[cfg(feature = "schedule")]
+    #[test]
+    fn parses_schedule_block() {
+        let yaml = r#"
+version: 1
+schedule:
+  cron: "0 2 * * *"
+  timezone: "America/Los_Angeles"
+  overlap_policy: skip
+  max_consecutive_failures: 5
+pipeline:
+  source: { type: rest, config: {} }
+  sink:   { type: jsonl, config: { path: ./o.jsonl } }
+"#;
+        let cfg = parse_with_extension(yaml, "yaml").unwrap();
+        let s = cfg.schedule.expect("schedule parsed");
+        assert_eq!(s.cron, "0 2 * * *");
+        assert_eq!(s.timezone, "America/Los_Angeles");
+        assert_eq!(s.max_consecutive_failures, Some(5));
     }
 
     #[cfg(feature = "quality")]

--- a/cli/src/env_config.rs
+++ b/cli/src/env_config.rs
@@ -298,6 +298,8 @@ pub fn build_pipeline_config(env: &HashMap<String, String>) -> CliResult<Pipelin
         matrix: Vec::new(),
         execution: None,
         observability: None,
+        #[cfg(feature = "schedule")]
+        schedule: None,
     })
 }
 

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -309,6 +309,10 @@ pub enum CliError {
     /// failed-probe count (clamped to 255).
     #[error("{failed} preflight probe(s) failed")]
     DoctorFailed { failed: usize },
+
+    /// `overlap_policy: forbid` saw a tick fire while a run was still in flight.
+    #[error("scheduled run overlap with overlap_policy: forbid — previous run still in progress")]
+    ScheduleOverlapForbidden,
 }
 
 impl From<faucet_core::InstallError> for CliError {

--- a/cli/src/executor.rs
+++ b/cli/src/executor.rs
@@ -610,7 +610,9 @@ fn resolve_now_inplace(value: &mut Value, clock: DateTime<FixedOffset>) -> CliRe
             Ok(())
         }
         Value::Array(a) => a.iter_mut().try_for_each(|v| resolve_now_inplace(v, clock)),
-        Value::Object(m) => m.values_mut().try_for_each(|v| resolve_now_inplace(v, clock)),
+        Value::Object(m) => m
+            .values_mut()
+            .try_for_each(|v| resolve_now_inplace(v, clock)),
         _ => Ok(()),
     }
 }

--- a/cli/src/executor.rs
+++ b/cli/src/executor.rs
@@ -26,6 +26,7 @@ use crate::registry::{build_sink, build_source};
 use crate::state::build_state_store;
 use crate::transforms::compile_transforms;
 use async_trait::async_trait;
+use chrono::{DateTime, FixedOffset};
 use faucet_core::observability::Labels;
 use faucet_core::{DlqConfig, FaucetError, OnBatchError, Pipeline, Sink, Source, StateStore};
 use serde_json::Value;
@@ -53,6 +54,10 @@ pub struct ExecuteOptions {
     /// that reference one via `auth: { ref }` resolve against this catalog;
     /// every row sharing a provider gets the same `Arc` (one token, shared).
     pub auth: AuthCatalog,
+    /// Wall-clock instant for `${now.*}` interpolation in this run's configs.
+    /// `faucet run` sets process-start (or `--clock`); `faucet schedule` sets
+    /// the tick's scheduled time in the schedule timezone.
+    pub clock: DateTime<FixedOffset>,
 }
 
 /// One pipeline invocation's outcome.
@@ -453,6 +458,12 @@ async fn run_one_invocation(
     // 1) Resolve `${parent.path}` in the per-row source + sink configs.
     let mut source_cfg = node.source.config.clone();
     let mut sink_cfg = node.sink.config.clone();
+
+    // Resolve `${now.*}` run-clock tokens for every invocation (root + child),
+    // before the parent-record pass. Leaves all other tokens verbatim.
+    resolve_now_inplace(&mut source_cfg, opts.clock)?;
+    resolve_now_inplace(&mut sink_cfg, opts.clock)?;
+
     if let (Some(record), NodeRole::Child { parent_id, .. }) = (parent_record, &node.role) {
         let ctx: HashMap<String, Value> = HashMap::from([(parent_id.clone(), record.clone())]);
         resolve_inplace(&mut source_cfg, &ctx)?;
@@ -588,6 +599,20 @@ pub async fn build_dlq_config(spec: &crate::config::DlqSpec) -> CliResult<DlqCon
         max_failures_total: spec.max_failures_total,
         include_original_payload: spec.include_original_payload,
     })
+}
+
+/// In-place `${now.*}` resolution against the run clock. Walks every string
+/// leaf and rewrites `${now.<token>}`; all other `${...}` tokens are untouched.
+fn resolve_now_inplace(value: &mut Value, clock: DateTime<FixedOffset>) -> CliResult<()> {
+    match value {
+        Value::String(s) => {
+            *s = crate::interpolate::resolve_now(s, clock)?;
+            Ok(())
+        }
+        Value::Array(a) => a.iter_mut().try_for_each(|v| resolve_now_inplace(v, clock)),
+        Value::Object(m) => m.values_mut().try_for_each(|v| resolve_now_inplace(v, clock)),
+        _ => Ok(()),
+    }
 }
 
 /// In-place runtime interpolation against a parent-record context. Walks every
@@ -803,6 +828,7 @@ mod tests {
                 limit: None,
                 state_path_override: None,
                 auth: Default::default(),
+                clock: chrono::Utc::now().fixed_offset(),
             },
         )
         .await
@@ -852,6 +878,7 @@ matrix:
                 limit: None,
                 state_path_override: None,
                 auth: Default::default(),
+                clock: chrono::Utc::now().fixed_offset(),
             },
         )
         .await
@@ -901,6 +928,7 @@ matrix:
                 limit: None,
                 state_path_override: None,
                 auth: Default::default(),
+                clock: chrono::Utc::now().fixed_offset(),
             },
         )
         .await
@@ -960,6 +988,7 @@ execution:
                 limit: None,
                 state_path_override: None,
                 auth: Default::default(),
+                clock: chrono::Utc::now().fixed_offset(),
             },
         )
         .await
@@ -1050,6 +1079,7 @@ execution:
                 limit: None,
                 state_path_override: None,
                 auth: Default::default(),
+                clock: chrono::Utc::now().fixed_offset(),
             },
         )
         .await
@@ -1108,6 +1138,7 @@ matrix:
                 limit: None,
                 state_path_override: None,
                 auth: Default::default(),
+                clock: chrono::Utc::now().fixed_offset(),
             },
         )
         .await

--- a/cli/src/executor.rs
+++ b/cli/src/executor.rs
@@ -781,6 +781,8 @@ mod tests {
             matrix: Vec::new(),
             execution: None,
             observability: None,
+            #[cfg(feature = "schedule")]
+            schedule: None,
         }
     }
 

--- a/cli/src/expand.rs
+++ b/cli/src/expand.rs
@@ -24,7 +24,7 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 
 /// Row ids that callers can never use because they collide with
 /// load-time interpolation prefixes or future runtime scopes.
-pub const RESERVED_IDS: &[&str] = &["env", "file", "secret", "matrix", "pipeline"];
+pub const RESERVED_IDS: &[&str] = &["env", "file", "secret", "matrix", "pipeline", "now"];
 
 /// One fully-merged matrix row, ready for the executor.
 #[derive(Debug, Clone)]
@@ -430,7 +430,9 @@ fn check_refs(value: &Value, id_set: &HashSet<&str>, owner: &str) -> CliResult<(
             // Load-time / template directives (`${env:..}`, `${vars.X}`, …) are
             // resolved before expansion; only deferred `${id.path}` references
             // are validated here, against the known row ids.
+            // `now` is a reserved built-in deferred id resolved at run time.
             if let Directive::Deferred { id, .. } = dir
+                && id != "now"
                 && !id_set.contains(id)
             {
                 return Err(CliError::UnknownInterpolationId {
@@ -447,6 +449,12 @@ fn collect_deferred(value: &Value, out: &mut Vec<DeferredRef>) {
     let _ = walk_strings(value, &mut |s| {
         for (token, dir) in iter_directives(s) {
             if let Directive::Deferred { id, path } = dir {
+                // `now` is a reserved built-in resolved at run time, not a
+                // parent-record dependency — skip it so the executor doesn't
+                // treat it as a deferred parent-record reference.
+                if id == "now" {
+                    continue;
+                }
                 out.push(DeferredRef {
                     referenced_id: id.to_owned(),
                     dotted_path: path.to_owned(),
@@ -1259,5 +1267,36 @@ matrix:
             .unwrap();
         let nodes = crate::expand::expand(&cfg).unwrap();
         assert!(nodes[0].transforms.is_empty());
+    }
+
+    #[test]
+    fn now_is_a_valid_builtin_ref_not_an_unknown_id() {
+        // A root pipeline referencing ${now.date} must pass expand validation.
+        let yaml = r#"
+version: 1
+pipeline:
+  source: { type: rest, config: {} }
+  sink:   { type: jsonl, config: { path: "out-${now.date}.jsonl" } }
+"#;
+        let cfg = parse_with_extension(yaml, "yaml").unwrap();
+        // expand must NOT raise UnknownInterpolationId for `now`.
+        assert!(expand(&cfg).is_ok());
+    }
+
+    #[test]
+    fn now_is_a_reserved_row_id() {
+        let yaml = r#"
+version: 1
+pipeline:
+  source: { type: rest, config: {} }
+  sink:   { type: jsonl, config: { path: ./o.jsonl } }
+matrix:
+  - id: now
+"#;
+        let cfg = parse_with_extension(yaml, "yaml").unwrap();
+        match expand(&cfg).unwrap_err() {
+            CliError::ReservedRowId { id } => assert_eq!(id, "now"),
+            other => panic!("expected ReservedRowId, got {other:?}"),
+        }
     }
 }

--- a/cli/src/interpolate.rs
+++ b/cli/src/interpolate.rs
@@ -22,6 +22,7 @@
 //! deferred to record-time. A literal `${` is written `$${`.
 
 use crate::error::{CliError, CliResult};
+use chrono::{DateTime, FixedOffset};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -70,6 +71,53 @@ pub fn interpolate_record(input: &str, ctx: &HashMap<String, Value>) -> CliResul
             Ok(Some(value_to_string(&resolved)))
         }
     })
+}
+
+/// Resolve `${now.<token>}` references in `input` against the run clock. Every
+/// other `${...}` token (env/file/secret/vars/sources/sinks/row-id) is left
+/// verbatim. `now` is a reserved built-in id (see `expand.rs`). An unknown
+/// `${now.<bad>}` token is a config error (never silently passed through).
+pub fn resolve_now(input: &str, clock: DateTime<FixedOffset>) -> CliResult<String> {
+    rewrite(input, |body| {
+        if let Directive::Deferred { id: "now", path } = classify_directive(body) {
+            return Ok(Some(now_token(path, clock)?));
+        }
+        Ok(None)
+    })
+}
+
+/// Render one `${now.<path>}` token. `path` is the text after `now.`.
+fn now_token(path: &str, clock: DateTime<FixedOffset>) -> CliResult<String> {
+    // Arbitrary chrono strftime via the dot-form `${now.strftime.<fmt>}`.
+    if let Some(fmt) = path.strip_prefix("strftime.") {
+        // Pre-validate: a bad specifier yields `Item::Error`, and rendering it
+        // would panic in `to_string()`. Reject it as a config error instead.
+        use chrono::format::{Item, StrftimeItems};
+        let items: Vec<Item> = StrftimeItems::new(fmt).collect();
+        if items.iter().any(|i| matches!(i, Item::Error)) {
+            return Err(CliError::Config(format!(
+                "invalid strftime format in `${{now.strftime.{fmt}}}`"
+            )));
+        }
+        return Ok(clock.format_with_items(items.iter()).to_string());
+    }
+    let rendered = match path {
+        "date" => clock.format("%Y-%m-%d").to_string(),
+        "datetime" | "iso" => clock.to_rfc3339(),
+        "year" => clock.format("%Y").to_string(),
+        "month" => clock.format("%m").to_string(),
+        "day" => clock.format("%d").to_string(),
+        "hour" => clock.format("%H").to_string(),
+        "minute" => clock.format("%M").to_string(),
+        "second" => clock.format("%S").to_string(),
+        "unix" => clock.timestamp().to_string(),
+        other => {
+            return Err(CliError::Config(format!(
+                "unknown `${{now.{other}}}` token — valid: date, datetime, iso, year, month, day, hour, minute, second, unix, strftime.<fmt>"
+            )));
+        }
+    };
+    Ok(rendered)
 }
 
 /// Walk `input` byte-by-byte, calling `resolve` on each `${...}` body.
@@ -1129,6 +1177,68 @@ pipeline:
         assert_eq!(
             cfg.auth.as_ref().unwrap()["idp"]["config"]["token"],
             "Bearer topsecret"
+        );
+    }
+
+    // ── resolve_now tests ────────────────────────────────────────────────────
+
+    fn fixed_clock() -> chrono::DateTime<chrono::FixedOffset> {
+        use chrono::TimeZone;
+        // 2026-03-08 14:05:09 +00:00
+        chrono::FixedOffset::east_opt(0)
+            .unwrap()
+            .with_ymd_and_hms(2026, 3, 8, 14, 5, 9)
+            .unwrap()
+    }
+
+    #[test]
+    fn now_named_tokens_render() {
+        let c = fixed_clock();
+        assert_eq!(resolve_now("${now.date}", c).unwrap(), "2026-03-08");
+        assert_eq!(resolve_now("${now.year}", c).unwrap(), "2026");
+        assert_eq!(resolve_now("${now.month}", c).unwrap(), "03");
+        assert_eq!(resolve_now("${now.day}", c).unwrap(), "08");
+        assert_eq!(resolve_now("${now.hour}", c).unwrap(), "14");
+        assert_eq!(resolve_now("${now.minute}", c).unwrap(), "05");
+        assert_eq!(resolve_now("${now.second}", c).unwrap(), "09");
+        assert_eq!(resolve_now("${now.unix}", c).unwrap(), c.timestamp().to_string());
+        assert!(resolve_now("${now.iso}", c).unwrap().starts_with("2026-03-08T14:05:09"));
+        assert_eq!(resolve_now("${now.datetime}", c).unwrap(), resolve_now("${now.iso}", c).unwrap());
+    }
+
+    #[test]
+    fn now_in_a_path_template() {
+        let c = fixed_clock();
+        assert_eq!(
+            resolve_now("s3://bucket/dt=${now.date}/part.jsonl", c).unwrap(),
+            "s3://bucket/dt=2026-03-08/part.jsonl"
+        );
+    }
+
+    #[test]
+    fn now_strftime_renders_and_rejects_bad_format() {
+        let c = fixed_clock();
+        assert_eq!(resolve_now("${now.strftime.%Y/%m/%d}", c).unwrap(), "2026/03/08");
+        // A bogus specifier must be a clean config error, NOT a panic.
+        // `%Q` is not a valid strftime specifier in chrono and produces Item::Error.
+        let err = resolve_now("${now.strftime.%Q}", c).unwrap_err();
+        assert!(err.to_string().contains("strftime"));
+    }
+
+    #[test]
+    fn now_unknown_token_errors() {
+        let c = fixed_clock();
+        let err = resolve_now("${now.bogus}", c).unwrap_err();
+        assert!(err.to_string().contains("now.bogus"));
+    }
+
+    #[test]
+    fn now_leaves_other_tokens_verbatim() {
+        let c = fixed_clock();
+        // env/row-id/vars tokens must survive the now-pass untouched.
+        assert_eq!(
+            resolve_now("${env:VAR}/${users.id}/${now.date}", c).unwrap(),
+            "${env:VAR}/${users.id}/2026-03-08"
         );
     }
 }

--- a/cli/src/interpolate.rs
+++ b/cli/src/interpolate.rs
@@ -1201,9 +1201,19 @@ pipeline:
         assert_eq!(resolve_now("${now.hour}", c).unwrap(), "14");
         assert_eq!(resolve_now("${now.minute}", c).unwrap(), "05");
         assert_eq!(resolve_now("${now.second}", c).unwrap(), "09");
-        assert_eq!(resolve_now("${now.unix}", c).unwrap(), c.timestamp().to_string());
-        assert!(resolve_now("${now.iso}", c).unwrap().starts_with("2026-03-08T14:05:09"));
-        assert_eq!(resolve_now("${now.datetime}", c).unwrap(), resolve_now("${now.iso}", c).unwrap());
+        assert_eq!(
+            resolve_now("${now.unix}", c).unwrap(),
+            c.timestamp().to_string()
+        );
+        assert!(
+            resolve_now("${now.iso}", c)
+                .unwrap()
+                .starts_with("2026-03-08T14:05:09")
+        );
+        assert_eq!(
+            resolve_now("${now.datetime}", c).unwrap(),
+            resolve_now("${now.iso}", c).unwrap()
+        );
     }
 
     #[test]
@@ -1218,7 +1228,10 @@ pipeline:
     #[test]
     fn now_strftime_renders_and_rejects_bad_format() {
         let c = fixed_clock();
-        assert_eq!(resolve_now("${now.strftime.%Y/%m/%d}", c).unwrap(), "2026/03/08");
+        assert_eq!(
+            resolve_now("${now.strftime.%Y/%m/%d}", c).unwrap(),
+            "2026/03/08"
+        );
         // A bogus specifier must be a clean config error, NOT a panic.
         // `%Q` is not a valid strftime specifier in chrono and produces Item::Error.
         let err = resolve_now("${now.strftime.%Q}", c).unwrap_err();

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -23,6 +23,7 @@ pub mod expand;
 pub mod init_template;
 pub mod interpolate;
 pub mod merge;
+pub mod obs;
 pub mod registry;
 #[cfg(feature = "schedule")]
 pub mod schedule;

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -70,6 +70,7 @@ pub async fn run_from_yaml_str(yaml: &str) -> CliResult<executor::RunSummary> {
             limit: None,
             state_path_override: None,
             auth,
+            clock: chrono::Utc::now().fixed_offset(),
         },
     )
     .await

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -24,6 +24,8 @@ pub mod init_template;
 pub mod interpolate;
 pub mod merge;
 pub mod registry;
+#[cfg(feature = "schedule")]
+pub mod schedule;
 pub mod secrets;
 pub mod state;
 pub mod transforms;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -20,6 +20,8 @@ async fn main() {
         Command::Preview(args) => commands::preview::run(args).await,
         Command::Init(args) => commands::init::run(args).await,
         Command::Doctor(args) => commands::doctor::run(args).await,
+        #[cfg(feature = "schedule")]
+        Command::Schedule(args) => commands::schedule::run(args).await,
     };
 
     if let Err(err) = result {

--- a/cli/src/obs.rs
+++ b/cli/src/obs.rs
@@ -1,0 +1,139 @@
+//! Shared observability setup (Prometheus + tracing) used by `run` and
+//! `schedule`. `install_observability` is idempotent, so calling this once per
+//! process is safe even though `main.rs` already installed a basic subscriber.
+
+use crate::config::PipelineConfig;
+use crate::error::CliResult;
+use faucet_core::{ObservabilityConfig, PrometheusConfig, TracingConfig, install_observability};
+
+/// Resolve the effective tracing level using the documented precedence:
+/// `FAUCET_LOG` > `RUST_LOG` > YAML `observability.tracing.level` > `None`.
+/// (`cli_flag` is reserved for a future call-site that forwards `--log-level`.)
+pub fn resolve_tracing_level(cli_flag: Option<&str>, yaml_level: Option<&str>) -> Option<String> {
+    if let Some(l) = cli_flag {
+        return Some(l.to_string());
+    }
+    if let Ok(l) = std::env::var("FAUCET_LOG")
+        && !l.is_empty()
+    {
+        return Some(l);
+    }
+    if let Ok(l) = std::env::var("RUST_LOG")
+        && !l.is_empty()
+    {
+        return Some(l);
+    }
+    yaml_level.map(|s| s.to_string())
+}
+
+/// Install Prometheus + tracing from the config's `observability:` block. Logs
+/// (does not fail) when a recorder/subscriber is already installed.
+pub fn install(cfg: &PipelineConfig) -> CliResult<()> {
+    let level = resolve_tracing_level(
+        None,
+        cfg.observability
+            .as_ref()
+            .and_then(|o| o.tracing.as_ref())
+            .and_then(|t| t.level.as_deref()),
+    );
+    let obs_cfg = ObservabilityConfig {
+        prometheus: cfg
+            .observability
+            .as_ref()
+            .and_then(|o| o.prometheus.as_ref())
+            .map(|p| PrometheusConfig {
+                listen: p.listen.clone(),
+                buckets: p.buckets.clone(),
+            }),
+        tracing: level.map(|l| TracingConfig { level: l }),
+    };
+    let report = install_observability(&obs_cfg)?;
+    if let Some(addr) = report.prometheus_listen.as_deref() {
+        tracing::info!("Prometheus /metrics listening on {addr}");
+    }
+    if report.prometheus_already_installed {
+        tracing::warn!(
+            "Prometheus recorder already installed; metrics route through the existing recorder"
+        );
+    }
+    if report.tracing_already_installed {
+        tracing::warn!(
+            "tracing subscriber already installed; logs route through the existing subscriber"
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_clean_env<F: FnOnce()>(f: F) {
+        let _g = ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::remove_var("FAUCET_LOG");
+            std::env::remove_var("RUST_LOG");
+        }
+        f();
+    }
+
+    #[test]
+    fn cli_flag_beats_env_and_yaml() {
+        with_clean_env(|| {
+            unsafe {
+                std::env::set_var("FAUCET_LOG", "debug");
+                std::env::set_var("RUST_LOG", "trace");
+            }
+            assert_eq!(
+                resolve_tracing_level(Some("error"), Some("info")).as_deref(),
+                Some("error")
+            );
+        });
+    }
+
+    #[test]
+    fn faucet_log_beats_rust_log_and_yaml() {
+        with_clean_env(|| {
+            unsafe {
+                std::env::set_var("FAUCET_LOG", "debug");
+                std::env::set_var("RUST_LOG", "trace");
+            }
+            assert_eq!(
+                resolve_tracing_level(None, Some("info")).as_deref(),
+                Some("debug")
+            );
+        });
+    }
+
+    #[test]
+    fn rust_log_beats_yaml() {
+        with_clean_env(|| {
+            unsafe {
+                std::env::set_var("RUST_LOG", "trace");
+            }
+            assert_eq!(
+                resolve_tracing_level(None, Some("info")).as_deref(),
+                Some("trace")
+            );
+        });
+    }
+
+    #[test]
+    fn yaml_used_when_no_flag_or_env() {
+        with_clean_env(|| {
+            assert_eq!(
+                resolve_tracing_level(None, Some("info")).as_deref(),
+                Some("info")
+            );
+        });
+    }
+
+    #[test]
+    fn none_returned_when_nothing_set() {
+        with_clean_env(|| {
+            assert_eq!(resolve_tracing_level(None, None), None);
+        });
+    }
+}

--- a/cli/src/schedule/compiled.rs
+++ b/cli/src/schedule/compiled.rs
@@ -6,8 +6,8 @@ use crate::error::{CliError, CliResult};
 use crate::schedule::spec::{OverlapPolicy, ScheduleOnFailure, ScheduleSpec};
 use chrono::{DateTime, Utc};
 use chrono_tz::Tz;
-use croner::parser::{CronParser, Seconds};
 use croner::Cron;
+use croner::parser::{CronParser, Seconds};
 use std::time::Duration;
 
 /// A `ScheduleSpec` whose cron + timezone have been parsed and whose invariants
@@ -28,10 +28,9 @@ pub struct CompiledSchedule {
 impl CompiledSchedule {
     /// Validate + compile. Every problem surfaces here, never mid-run.
     pub fn compile(spec: &ScheduleSpec) -> CliResult<Self> {
-        let tz: Tz = spec
-            .timezone
-            .parse()
-            .map_err(|_| CliError::Config(format!("schedule: unknown timezone '{}'", spec.timezone)))?;
+        let tz: Tz = spec.timezone.parse().map_err(|_| {
+            CliError::Config(format!("schedule: unknown timezone '{}'", spec.timezone))
+        })?;
 
         let cron = CronParser::builder()
             .seconds(Seconds::Optional)
@@ -168,7 +167,9 @@ mod tests {
         let c = CompiledSchedule::compile(&spec("30 2 * * *", "America/Los_Angeles")).unwrap();
         // 2026-03-08 09:00Z == 01:00 PST, before the skipped 02:30 local.
         let after = Utc.with_ymd_and_hms(2026, 3, 8, 9, 0, 0).unwrap();
-        let next = c.next_after(after).expect("must produce a valid occurrence");
+        let next = c
+            .next_after(after)
+            .expect("must produce a valid occurrence");
         // Must be strictly after `after` and exist as a real instant.
         assert!(next > after);
     }

--- a/cli/src/schedule/compiled.rs
+++ b/cli/src/schedule/compiled.rs
@@ -1,0 +1,191 @@
+//! Validated, compiled form of a [`ScheduleSpec`]: the parsed cron + timezone
+//! plus the numeric knobs. `next_after` is pure (no wall clock) and is the
+//! single source of truth for "when does the next run fire".
+
+use crate::error::{CliError, CliResult};
+use crate::schedule::spec::{OverlapPolicy, ScheduleOnFailure, ScheduleSpec};
+use chrono::{DateTime, Utc};
+use chrono_tz::Tz;
+use croner::parser::{CronParser, Seconds};
+use croner::Cron;
+use std::time::Duration;
+
+/// A `ScheduleSpec` whose cron + timezone have been parsed and whose invariants
+/// have been checked. Built once at startup; `next_after` is called per tick.
+#[derive(Debug)]
+pub struct CompiledSchedule {
+    cron: Cron,
+    tz: Tz,
+    pub overlap_policy: OverlapPolicy,
+    pub on_failure: ScheduleOnFailure,
+    pub max_runs: Option<u64>,
+    pub max_consecutive_failures: Option<u64>,
+    pub start_immediately: bool,
+    pub run_timeout: Option<Duration>,
+    pub shutdown_grace: Duration,
+}
+
+impl CompiledSchedule {
+    /// Validate + compile. Every problem surfaces here, never mid-run.
+    pub fn compile(spec: &ScheduleSpec) -> CliResult<Self> {
+        let tz: Tz = spec
+            .timezone
+            .parse()
+            .map_err(|_| CliError::Config(format!("schedule: unknown timezone '{}'", spec.timezone)))?;
+
+        let cron = CronParser::builder()
+            .seconds(Seconds::Optional)
+            .build()
+            .parse(&spec.cron)
+            .map_err(|e| {
+                CliError::Config(format!("schedule: invalid cron '{}': {e}", spec.cron))
+            })?;
+
+        if matches!(spec.max_runs, Some(0)) {
+            return Err(CliError::Config(
+                "schedule: max_runs must be >= 1 (use `faucet schedule --once` for a single run, or remove the schedule block)".into(),
+            ));
+        }
+        if matches!(spec.max_consecutive_failures, Some(0)) {
+            return Err(CliError::Config(
+                "schedule: max_consecutive_failures must be >= 1".into(),
+            ));
+        }
+
+        let compiled = Self {
+            cron,
+            tz,
+            overlap_policy: spec.overlap_policy,
+            on_failure: spec.on_failure,
+            max_runs: spec.max_runs,
+            max_consecutive_failures: spec.max_consecutive_failures,
+            start_immediately: spec.start_immediately,
+            run_timeout: spec.run_timeout_secs.map(Duration::from_secs),
+            shutdown_grace: Duration::from_secs(spec.shutdown_grace_secs),
+        };
+
+        // Reject a cron that can never fire (e.g. Feb 30): if there is no
+        // occurrence at all, croner returns no next, so guard against a spin.
+        if compiled.next_after(Utc::now()).is_none() {
+            return Err(CliError::Config(format!(
+                "schedule: cron '{}' has no upcoming occurrence in timezone '{}'",
+                spec.cron, spec.timezone
+            )));
+        }
+        Ok(compiled)
+    }
+
+    /// The next UTC instant strictly after `after` that matches the cron in the
+    /// configured timezone. `None` when there is no such occurrence.
+    ///
+    /// Operating on strictly-increasing UTC instants gives the production-cron
+    /// semantics: a DST fall-back repeated hour fires once, a spring-forward
+    /// skipped hour rolls to the next valid time, and occurrences that elapsed
+    /// between two `after` values are simply skipped (no backfill).
+    pub fn next_after(&self, after: DateTime<Utc>) -> Option<DateTime<Utc>> {
+        let local = after.with_timezone(&self.tz);
+        self.cron
+            .find_next_occurrence(&local, false)
+            .ok()
+            .map(|dt| dt.with_timezone(&Utc))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schedule::spec::ScheduleSpec;
+    use chrono::TimeZone;
+
+    fn spec(cron: &str, tz: &str) -> ScheduleSpec {
+        serde_yaml::from_str(&format!("cron: \"{cron}\"\ntimezone: \"{tz}\"\n")).unwrap()
+    }
+
+    #[test]
+    fn compiles_standard_five_field_cron() {
+        assert!(CompiledSchedule::compile(&spec("0 2 * * *", "UTC")).is_ok());
+    }
+
+    #[test]
+    fn compiles_six_field_seconds_cron() {
+        assert!(CompiledSchedule::compile(&spec("*/30 * * * * *", "UTC")).is_ok());
+    }
+
+    #[test]
+    fn rejects_bad_cron() {
+        let err = CompiledSchedule::compile(&spec("not a cron", "UTC")).unwrap_err();
+        assert!(err.to_string().contains("invalid cron"));
+    }
+
+    #[test]
+    fn rejects_unknown_timezone() {
+        let err = CompiledSchedule::compile(&spec("0 2 * * *", "Mars/Olympus")).unwrap_err();
+        assert!(err.to_string().contains("unknown timezone"));
+    }
+
+    #[test]
+    fn rejects_zero_max_runs() {
+        let mut s = spec("0 2 * * *", "UTC");
+        s.max_runs = Some(0);
+        let err = CompiledSchedule::compile(&s).unwrap_err();
+        assert!(err.to_string().contains("max_runs"));
+    }
+
+    #[test]
+    fn rejects_zero_max_consecutive_failures() {
+        let mut s = spec("0 2 * * *", "UTC");
+        s.max_consecutive_failures = Some(0);
+        let err = CompiledSchedule::compile(&s).unwrap_err();
+        assert!(err.to_string().contains("max_consecutive_failures"));
+    }
+
+    #[test]
+    fn rejects_never_firing_cron() {
+        // Feb 30 never exists.
+        let err = CompiledSchedule::compile(&spec("0 0 30 2 *", "UTC")).unwrap_err();
+        assert!(err.to_string().contains("no upcoming occurrence"));
+    }
+
+    #[test]
+    fn next_after_is_strictly_after_and_skips_missed() {
+        let c = CompiledSchedule::compile(&spec("0 0 * * *", "UTC")).unwrap(); // midnight daily
+        // 2026-03-10 06:00Z → next midnight is 2026-03-11 00:00Z.
+        let after = Utc.with_ymd_and_hms(2026, 3, 10, 6, 0, 0).unwrap();
+        let next = c.next_after(after).unwrap();
+        assert_eq!(next, Utc.with_ymd_and_hms(2026, 3, 11, 0, 0, 0).unwrap());
+        // From just before midnight we still get this midnight (strictly after).
+        let just_before = Utc.with_ymd_and_hms(2026, 3, 10, 23, 59, 59).unwrap();
+        assert_eq!(
+            c.next_after(just_before).unwrap(),
+            Utc.with_ymd_and_hms(2026, 3, 11, 0, 0, 0).unwrap()
+        );
+    }
+
+    #[test]
+    fn dst_spring_forward_rolls_to_next_valid_time() {
+        // America/Los_Angeles springs forward 2026-03-08 02:00→03:00. A 02:30
+        // daily job has no 02:30 that day; it must roll forward, not vanish.
+        let c = CompiledSchedule::compile(&spec("30 2 * * *", "America/Los_Angeles")).unwrap();
+        // 2026-03-08 09:00Z == 01:00 PST, before the skipped 02:30 local.
+        let after = Utc.with_ymd_and_hms(2026, 3, 8, 9, 0, 0).unwrap();
+        let next = c.next_after(after).expect("must produce a valid occurrence");
+        // Must be strictly after `after` and exist as a real instant.
+        assert!(next > after);
+    }
+
+    #[test]
+    fn dst_fall_back_does_not_double_fire() {
+        // America/Los_Angeles falls back 2026-11-01 02:00→01:00 (01:xx repeats).
+        // A 01:30 daily job must fire once, not twice. We assert the next two
+        // occurrences computed monotonically are >= 23h apart (i.e. next day),
+        // proving the repeated local hour did not yield a second same-day fire.
+        let c = CompiledSchedule::compile(&spec("30 1 * * *", "America/Los_Angeles")).unwrap();
+        let after = Utc.with_ymd_and_hms(2026, 11, 1, 8, 0, 0).unwrap(); // 01:00 PDT
+        let first = c.next_after(after).unwrap();
+        let second = c.next_after(first).unwrap();
+        assert!(
+            (second - first) >= chrono::Duration::hours(23),
+            "fall-back produced a duplicate same-day fire: {first} -> {second}"
+        );
+    }
+}

--- a/cli/src/schedule/compiled.rs
+++ b/cli/src/schedule/compiled.rs
@@ -50,6 +50,11 @@ impl CompiledSchedule {
                 "schedule: max_consecutive_failures must be >= 1".into(),
             ));
         }
+        if matches!(spec.run_timeout_secs, Some(0)) {
+            return Err(CliError::Config(
+                "schedule: run_timeout_secs must be >= 1 (omit it for no timeout)".into(),
+            ));
+        }
 
         let compiled = Self {
             cron,
@@ -142,6 +147,14 @@ mod tests {
         s.max_consecutive_failures = Some(0);
         let err = CompiledSchedule::compile(&s).unwrap_err();
         assert!(err.to_string().contains("max_consecutive_failures"));
+    }
+
+    #[test]
+    fn rejects_zero_run_timeout() {
+        let mut s = spec("0 2 * * *", "UTC");
+        s.run_timeout_secs = Some(0);
+        let err = CompiledSchedule::compile(&s).unwrap_err();
+        assert!(err.to_string().contains("run_timeout_secs"));
     }
 
     #[test]

--- a/cli/src/schedule/compiled.rs
+++ b/cli/src/schedule/compiled.rs
@@ -81,7 +81,10 @@ impl CompiledSchedule {
 
     /// Render a UTC instant in the schedule's timezone, as a fixed-offset clock
     /// for `${now.*}` interpolation.
-    pub fn clock_at(&self, at: chrono::DateTime<chrono::Utc>) -> chrono::DateTime<chrono::FixedOffset> {
+    pub fn clock_at(
+        &self,
+        at: chrono::DateTime<chrono::Utc>,
+    ) -> chrono::DateTime<chrono::FixedOffset> {
         at.with_timezone(&self.tz).fixed_offset()
     }
 

--- a/cli/src/schedule/compiled.rs
+++ b/cli/src/schedule/compiled.rs
@@ -74,6 +74,12 @@ impl CompiledSchedule {
         Ok(compiled)
     }
 
+    /// Render a UTC instant in the schedule's timezone, as a fixed-offset clock
+    /// for `${now.*}` interpolation.
+    pub fn clock_at(&self, at: chrono::DateTime<chrono::Utc>) -> chrono::DateTime<chrono::FixedOffset> {
+        at.with_timezone(&self.tz).fixed_offset()
+    }
+
     /// The next UTC instant strictly after `after` that matches the cron in the
     /// configured timezone. `None` when there is no such occurrence.
     ///

--- a/cli/src/schedule/metrics.rs
+++ b/cli/src/schedule/metrics.rs
@@ -1,0 +1,60 @@
+//! Scheduler metrics, emitted via the `metrics` facade. `pipeline` is the only
+//! label (low cardinality); per-row outcomes are covered by the pipeline-run
+//! metrics in `faucet-core`. No-ops when no recorder is installed.
+
+use chrono::{DateTime, Utc};
+use metrics::{counter, gauge, histogram};
+use std::time::Duration;
+
+/// `outcome ∈ {"ok", "err", "skipped"}`.
+pub fn run_outcome(pipeline: &str, outcome: &'static str) {
+    counter!("faucet_schedule_runs_total", "pipeline" => pipeline.to_string(), "outcome" => outcome)
+        .increment(1);
+}
+
+/// `policy ∈ {"skip", "queue", "forbid"}`.
+pub fn overlap(pipeline: &str, policy: &'static str) {
+    counter!("faucet_schedule_overlaps_total", "pipeline" => pipeline.to_string(), "policy" => policy)
+        .increment(1);
+}
+
+pub fn next_tick(pipeline: &str, when: DateTime<Utc>) {
+    gauge!("faucet_schedule_next_tick_unix_seconds", "pipeline" => pipeline.to_string())
+        .set(when.timestamp() as f64);
+}
+
+pub fn in_flight(pipeline: &str, n: u64) {
+    gauge!("faucet_schedule_runs_in_flight", "pipeline" => pipeline.to_string()).set(n as f64);
+}
+
+pub fn consecutive_failures(pipeline: &str, n: u64) {
+    gauge!("faucet_schedule_consecutive_failures", "pipeline" => pipeline.to_string())
+        .set(n as f64);
+}
+
+pub fn heartbeat(pipeline: &str, now: DateTime<Utc>) {
+    gauge!("faucet_schedule_heartbeat_unix_seconds", "pipeline" => pipeline.to_string())
+        .set(now.timestamp() as f64);
+}
+
+pub fn last_run_started(pipeline: &str, when: DateTime<Utc>) {
+    gauge!("faucet_schedule_last_run_started_unix_seconds", "pipeline" => pipeline.to_string())
+        .set(when.timestamp() as f64);
+}
+
+pub fn last_run_completed(pipeline: &str, when: DateTime<Utc>) {
+    gauge!("faucet_schedule_last_run_completed_unix_seconds", "pipeline" => pipeline.to_string())
+        .set(when.timestamp() as f64);
+}
+
+pub fn last_run_duration(pipeline: &str, d: Duration) {
+    gauge!("faucet_schedule_last_run_duration_seconds", "pipeline" => pipeline.to_string())
+        .set(d.as_secs_f64());
+}
+
+/// `late` may be negative if a run started slightly early; clamp to 0.
+pub fn lateness(pipeline: &str, late: chrono::Duration) {
+    let secs = (late.num_milliseconds() as f64 / 1000.0).max(0.0);
+    histogram!("faucet_schedule_run_lateness_seconds", "pipeline" => pipeline.to_string())
+        .record(secs);
+}

--- a/cli/src/schedule/mod.rs
+++ b/cli/src/schedule/mod.rs
@@ -6,4 +6,5 @@
 //! state machine (state — added in Task 4), and the metric emitters
 //! (metrics — added in Task 5).
 
+pub mod compiled;
 pub mod spec;

--- a/cli/src/schedule/mod.rs
+++ b/cli/src/schedule/mod.rs
@@ -1,0 +1,9 @@
+//! `faucet schedule` — built-in cron scheduler.
+//!
+//! The runtime loop lives in `crate::commands::schedule`; this module holds
+//! the pure, unit-tested pieces it drives: the config types ([`spec`]),
+//! the validated/compiled schedule (compiled — added in Task 3), the decision
+//! state machine (state — added in Task 4), and the metric emitters
+//! (metrics — added in Task 5).
+
+pub mod spec;

--- a/cli/src/schedule/mod.rs
+++ b/cli/src/schedule/mod.rs
@@ -7,5 +7,6 @@
 //! (metrics — added in Task 5).
 
 pub mod compiled;
+pub mod metrics;
 pub mod spec;
 pub mod state;

--- a/cli/src/schedule/mod.rs
+++ b/cli/src/schedule/mod.rs
@@ -8,3 +8,4 @@
 
 pub mod compiled;
 pub mod spec;
+pub mod state;

--- a/cli/src/schedule/spec.rs
+++ b/cli/src/schedule/spec.rs
@@ -101,10 +101,9 @@ mod tests {
 
     #[test]
     fn enums_use_lowercase_wire_form() {
-        let spec: ScheduleSpec = serde_yaml::from_str(
-            "cron: \"* * * * *\"\noverlap_policy: queue\non_failure: stop\n",
-        )
-        .unwrap();
+        let spec: ScheduleSpec =
+            serde_yaml::from_str("cron: \"* * * * *\"\noverlap_policy: queue\non_failure: stop\n")
+                .unwrap();
         assert_eq!(spec.overlap_policy, OverlapPolicy::Queue);
         assert_eq!(spec.on_failure, ScheduleOnFailure::Stop);
     }

--- a/cli/src/schedule/spec.rs
+++ b/cli/src/schedule/spec.rs
@@ -1,0 +1,111 @@
+//! Config types for the `schedule:` block.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Top-level `schedule:` block. Presence of this block is what makes a config
+/// runnable by `faucet schedule`.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ScheduleSpec {
+    /// Cron expression. 5-field standard Unix cron (`minute hour day-of-month
+    /// month day-of-week`), or 6-field with a leading seconds field for
+    /// sub-minute schedules.
+    pub cron: String,
+
+    /// IANA timezone name (e.g. `America/Los_Angeles`). Default `UTC`.
+    #[serde(default = "default_timezone")]
+    pub timezone: String,
+
+    /// What to do when a tick fires while the previous run is still in flight.
+    #[serde(default)]
+    pub overlap_policy: OverlapPolicy,
+
+    /// Stop cleanly after this many *successful* runs. `None` = run forever.
+    #[serde(default)]
+    pub max_runs: Option<u64>,
+
+    /// Exit non-zero after this many *consecutive* failed runs (so a supervisor
+    /// restarts / pages). A success resets the counter. `None` = never exit on
+    /// failure (alert via the `consecutive_failures` gauge instead).
+    #[serde(default)]
+    pub max_consecutive_failures: Option<u64>,
+
+    /// Per-run failure policy.
+    #[serde(default)]
+    pub on_failure: ScheduleOnFailure,
+
+    /// Run once on startup before waiting for the first scheduled tick.
+    #[serde(default)]
+    pub start_immediately: bool,
+
+    /// Optional per-run kill switch (seconds). A run exceeding this is aborted
+    /// and counts as a failed run.
+    #[serde(default)]
+    pub run_timeout_secs: Option<u64>,
+
+    /// On SIGTERM/SIGINT, await the in-flight run this many seconds before
+    /// aborting it. Default 30 (matches Kubernetes' default termination grace).
+    #[serde(default = "default_shutdown_grace_secs")]
+    pub shutdown_grace_secs: u64,
+}
+
+/// Behaviour when a tick fires while a run is still in progress.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum OverlapPolicy {
+    /// Drop the overlapping tick (default).
+    #[default]
+    Skip,
+    /// Buffer one missed tick and run it when the current run finishes.
+    Queue,
+    /// Treat an overlap as fatal — exit non-zero.
+    Forbid,
+}
+
+/// Per-run failure policy.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ScheduleOnFailure {
+    /// Log the failure and wait for the next tick (default).
+    #[default]
+    Continue,
+    /// Exit non-zero on the first failed run.
+    Stop,
+}
+
+fn default_timezone() -> String {
+    "UTC".to_string()
+}
+fn default_shutdown_grace_secs() -> u64 {
+    30
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_apply_when_only_cron_given() {
+        let spec: ScheduleSpec = serde_yaml::from_str("cron: \"0 2 * * *\"").unwrap();
+        assert_eq!(spec.cron, "0 2 * * *");
+        assert_eq!(spec.timezone, "UTC");
+        assert_eq!(spec.overlap_policy, OverlapPolicy::Skip);
+        assert_eq!(spec.on_failure, ScheduleOnFailure::Continue);
+        assert_eq!(spec.max_runs, None);
+        assert_eq!(spec.max_consecutive_failures, None);
+        assert!(!spec.start_immediately);
+        assert_eq!(spec.run_timeout_secs, None);
+        assert_eq!(spec.shutdown_grace_secs, 30);
+    }
+
+    #[test]
+    fn enums_use_lowercase_wire_form() {
+        let spec: ScheduleSpec = serde_yaml::from_str(
+            "cron: \"* * * * *\"\noverlap_policy: queue\non_failure: stop\n",
+        )
+        .unwrap();
+        assert_eq!(spec.overlap_policy, OverlapPolicy::Queue);
+        assert_eq!(spec.on_failure, ScheduleOnFailure::Stop);
+    }
+}

--- a/cli/src/schedule/state.rs
+++ b/cli/src/schedule/state.rs
@@ -141,12 +141,16 @@ mod tests {
         assert_eq!(s.on_tick(true), TickAction::Queue);
         assert_eq!(
             s.on_run_finished(RunOutcome::Success),
-            AfterRun::Continue { dispatch_pending: true }
+            AfterRun::Continue {
+                dispatch_pending: true
+            }
         );
         // Pending consumed exactly once.
         assert_eq!(
             s.on_run_finished(RunOutcome::Success),
-            AfterRun::Continue { dispatch_pending: false }
+            AfterRun::Continue {
+                dispatch_pending: false
+            }
         );
     }
 
@@ -161,11 +165,15 @@ mod tests {
         let mut s = state("cron: \"* * * * *\"\nmax_runs: 2");
         assert_eq!(
             s.on_run_finished(RunOutcome::Failure),
-            AfterRun::Continue { dispatch_pending: false }
+            AfterRun::Continue {
+                dispatch_pending: false
+            }
         );
         assert_eq!(
             s.on_run_finished(RunOutcome::Success),
-            AfterRun::Continue { dispatch_pending: false }
+            AfterRun::Continue {
+                dispatch_pending: false
+            }
         );
         assert_eq!(s.on_run_finished(RunOutcome::Success), AfterRun::ExitOk);
     }
@@ -184,20 +192,28 @@ mod tests {
         let mut s = state("cron: \"* * * * *\"\nmax_consecutive_failures: 3");
         assert_eq!(
             s.on_run_finished(RunOutcome::Failure),
-            AfterRun::Continue { dispatch_pending: false }
+            AfterRun::Continue {
+                dispatch_pending: false
+            }
         );
         assert_eq!(
             s.on_run_finished(RunOutcome::Success),
-            AfterRun::Continue { dispatch_pending: false }
+            AfterRun::Continue {
+                dispatch_pending: false
+            }
         );
         // Counter reset by the success above.
         assert_eq!(
             s.on_run_finished(RunOutcome::Failure),
-            AfterRun::Continue { dispatch_pending: false }
+            AfterRun::Continue {
+                dispatch_pending: false
+            }
         );
         assert_eq!(
             s.on_run_finished(RunOutcome::Failure),
-            AfterRun::Continue { dispatch_pending: false }
+            AfterRun::Continue {
+                dispatch_pending: false
+            }
         );
         assert_eq!(
             s.on_run_finished(RunOutcome::Failure),

--- a/cli/src/schedule/state.rs
+++ b/cli/src/schedule/state.rs
@@ -1,0 +1,207 @@
+//! The scheduler's decision state machine. Pure — no clock, no tasks, no IO —
+//! so every overlap / failure / cap transition is unit-tested deterministically.
+
+use crate::schedule::compiled::CompiledSchedule;
+use crate::schedule::spec::{OverlapPolicy, ScheduleOnFailure};
+
+/// What the loop should do when a scheduled tick fires.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TickAction {
+    /// Start a run now.
+    Dispatch,
+    /// Drop this tick (overlap, policy = skip).
+    Skip,
+    /// Remember this tick; run it when the current run finishes (policy = queue).
+    Queue,
+    /// Fatal overlap (policy = forbid) — exit non-zero.
+    ForbidAbort,
+}
+
+/// Outcome of a finished run, as seen by the state machine.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RunOutcome {
+    Success,
+    Failure,
+}
+
+/// What the loop should do after a run finishes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AfterRun {
+    /// Keep scheduling. `dispatch_pending` = a queued tick should run now.
+    Continue { dispatch_pending: bool },
+    /// Stop cleanly (`max_runs` reached).
+    ExitOk,
+    /// Stop non-zero; carries the consecutive-failure count for the error.
+    ExitFailure { consecutive: u64 },
+}
+
+/// Mutable scheduler counters + policy.
+pub struct SchedulerState {
+    overlap: OverlapPolicy,
+    on_failure: ScheduleOnFailure,
+    max_runs: Option<u64>,
+    max_consecutive_failures: Option<u64>,
+    successful_runs: u64,
+    consecutive_failures: u64,
+    pending: bool,
+}
+
+impl SchedulerState {
+    pub fn new(c: &CompiledSchedule) -> Self {
+        Self {
+            overlap: c.overlap_policy,
+            on_failure: c.on_failure,
+            max_runs: c.max_runs,
+            max_consecutive_failures: c.max_consecutive_failures,
+            successful_runs: 0,
+            consecutive_failures: 0,
+            pending: false,
+        }
+    }
+
+    pub fn consecutive_failures(&self) -> u64 {
+        self.consecutive_failures
+    }
+
+    /// A scheduled tick fired. `running` = a run is currently in flight.
+    pub fn on_tick(&mut self, running: bool) -> TickAction {
+        if !running {
+            return TickAction::Dispatch;
+        }
+        match self.overlap {
+            OverlapPolicy::Skip => TickAction::Skip,
+            OverlapPolicy::Queue => {
+                self.pending = true;
+                TickAction::Queue
+            }
+            OverlapPolicy::Forbid => TickAction::ForbidAbort,
+        }
+    }
+
+    /// An in-flight run finished.
+    pub fn on_run_finished(&mut self, outcome: RunOutcome) -> AfterRun {
+        match outcome {
+            RunOutcome::Success => {
+                self.consecutive_failures = 0;
+                self.successful_runs += 1;
+                if let Some(max) = self.max_runs
+                    && self.successful_runs >= max
+                {
+                    return AfterRun::ExitOk;
+                }
+            }
+            RunOutcome::Failure => {
+                self.consecutive_failures += 1;
+                if matches!(self.on_failure, ScheduleOnFailure::Stop) {
+                    return AfterRun::ExitFailure {
+                        consecutive: self.consecutive_failures,
+                    };
+                }
+                if let Some(max) = self.max_consecutive_failures
+                    && self.consecutive_failures >= max
+                {
+                    return AfterRun::ExitFailure {
+                        consecutive: self.consecutive_failures,
+                    };
+                }
+            }
+        }
+        let dispatch_pending = self.pending;
+        self.pending = false;
+        AfterRun::Continue { dispatch_pending }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schedule::spec::ScheduleSpec;
+
+    fn state(yaml: &str) -> SchedulerState {
+        let spec: ScheduleSpec = serde_yaml::from_str(yaml).unwrap();
+        let compiled = CompiledSchedule::compile(&spec).unwrap();
+        SchedulerState::new(&compiled)
+    }
+
+    #[test]
+    fn dispatches_when_idle() {
+        let mut s = state("cron: \"* * * * *\"");
+        assert_eq!(s.on_tick(false), TickAction::Dispatch);
+    }
+
+    #[test]
+    fn skip_policy_drops_overlapping_tick() {
+        let mut s = state("cron: \"* * * * *\"\noverlap_policy: skip");
+        assert_eq!(s.on_tick(true), TickAction::Skip);
+    }
+
+    #[test]
+    fn queue_policy_buffers_and_dispatches_on_completion() {
+        let mut s = state("cron: \"* * * * *\"\noverlap_policy: queue");
+        assert_eq!(s.on_tick(true), TickAction::Queue);
+        assert_eq!(
+            s.on_run_finished(RunOutcome::Success),
+            AfterRun::Continue { dispatch_pending: true }
+        );
+        // Pending consumed exactly once.
+        assert_eq!(
+            s.on_run_finished(RunOutcome::Success),
+            AfterRun::Continue { dispatch_pending: false }
+        );
+    }
+
+    #[test]
+    fn forbid_policy_aborts_on_overlap() {
+        let mut s = state("cron: \"* * * * *\"\noverlap_policy: forbid");
+        assert_eq!(s.on_tick(true), TickAction::ForbidAbort);
+    }
+
+    #[test]
+    fn max_runs_counts_successes_only() {
+        let mut s = state("cron: \"* * * * *\"\nmax_runs: 2");
+        assert_eq!(
+            s.on_run_finished(RunOutcome::Failure),
+            AfterRun::Continue { dispatch_pending: false }
+        );
+        assert_eq!(
+            s.on_run_finished(RunOutcome::Success),
+            AfterRun::Continue { dispatch_pending: false }
+        );
+        assert_eq!(s.on_run_finished(RunOutcome::Success), AfterRun::ExitOk);
+    }
+
+    #[test]
+    fn on_failure_stop_exits_on_first_failure() {
+        let mut s = state("cron: \"* * * * *\"\non_failure: stop");
+        assert_eq!(
+            s.on_run_finished(RunOutcome::Failure),
+            AfterRun::ExitFailure { consecutive: 1 }
+        );
+    }
+
+    #[test]
+    fn max_consecutive_failures_trips_and_success_resets() {
+        let mut s = state("cron: \"* * * * *\"\nmax_consecutive_failures: 3");
+        assert_eq!(
+            s.on_run_finished(RunOutcome::Failure),
+            AfterRun::Continue { dispatch_pending: false }
+        );
+        assert_eq!(
+            s.on_run_finished(RunOutcome::Success),
+            AfterRun::Continue { dispatch_pending: false }
+        );
+        // Counter reset by the success above.
+        assert_eq!(
+            s.on_run_finished(RunOutcome::Failure),
+            AfterRun::Continue { dispatch_pending: false }
+        );
+        assert_eq!(
+            s.on_run_finished(RunOutcome::Failure),
+            AfterRun::Continue { dispatch_pending: false }
+        );
+        assert_eq!(
+            s.on_run_finished(RunOutcome::Failure),
+            AfterRun::ExitFailure { consecutive: 3 }
+        );
+    }
+}

--- a/cli/tests/now_interpolation.rs
+++ b/cli/tests/now_interpolation.rs
@@ -1,0 +1,35 @@
+//! `${now.*}` interpolation end-to-end via `faucet run --clock`.
+use assert_cmd::Command;
+
+#[test]
+fn now_date_resolves_in_sink_path_with_clock_override() {
+    let dir = tempfile::tempdir().unwrap();
+    let csv = dir.path().join("in.csv");
+    std::fs::write(&csv, "name\nalice\n").unwrap();
+    // Sink path templated with ${now.date}; --clock makes it deterministic.
+    // Note: the jsonl sink does NOT create missing parent directories, so we
+    // use a flat path (no subdirectory) to avoid an I/O error.
+    let cfg = dir.path().join("pipeline.yaml");
+    std::fs::write(
+        &cfg,
+        format!(
+            "version: 1\npipeline:\n  source: {{ type: csv, config: {{ path: \"{csv}\" }} }}\n  sink: {{ type: jsonl, config: {{ path: \"{out}\" }} }}\n",
+            csv = csv.display(),
+            out = dir.path().join("out-${now.date}.jsonl").display(),
+        ),
+    )
+    .unwrap();
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .arg("run")
+        .arg(&cfg)
+        .arg("--clock")
+        .arg("2026-03-08")
+        .assert()
+        .success();
+    let expected = dir.path().join("out-2026-03-08.jsonl");
+    assert!(
+        expected.exists(),
+        "expected dated sink path {expected:?} to be created"
+    );
+}

--- a/cli/tests/schedule.rs
+++ b/cli/tests/schedule.rs
@@ -88,3 +88,27 @@ fn missing_schedule_block_is_a_clear_error() {
         .failure()
         .stderr(predicates::str::contains("schedule"));
 }
+
+#[test]
+fn validate_rejects_bad_schedule_cron() {
+    let dir = tempfile::tempdir().unwrap();
+    let csv = dir.path().join("in.csv");
+    std::fs::write(&csv, "name\nx\n").unwrap();
+    let cfg = dir.path().join("pipeline.yaml");
+    std::fs::write(
+        &cfg,
+        format!(
+            "version: 1\nschedule:\n  cron: \"not a cron\"\npipeline:\n  source: {{ type: csv, config: {{ path: {csv} }} }}\n  sink: {{ type: jsonl, config: {{ path: {out} }} }}\n",
+            csv = csv.display(),
+            out = dir.path().join("o.jsonl").display(),
+        ),
+    )
+    .unwrap();
+    assert_cmd::Command::cargo_bin("faucet")
+        .unwrap()
+        .arg("validate")
+        .arg(&cfg)
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("cron"));
+}

--- a/cli/tests/schedule.rs
+++ b/cli/tests/schedule.rs
@@ -42,13 +42,18 @@ fn once_runs_one_pipeline_and_exits_zero() {
         .assert()
         .success();
     let out = std::fs::read_to_string(dir.path().join("out.jsonl")).unwrap();
-    assert_eq!(out.lines().count(), 2, "expected the two CSV rows written once");
+    assert_eq!(
+        out.lines().count(),
+        2,
+        "expected the two CSV rows written once"
+    );
 }
 
 #[test]
 fn max_runs_stops_the_loop() {
     // Seconds-cron firing every second; stop after 2 successful runs.
-    let (dir, cfg) = fixture("  cron: \"*/1 * * * * *\"\n  max_runs: 2\n  start_immediately: true\n");
+    let (dir, cfg) =
+        fixture("  cron: \"*/1 * * * * *\"\n  max_runs: 2\n  start_immediately: true\n");
     Command::cargo_bin("faucet")
         .unwrap()
         .arg("schedule")

--- a/cli/tests/schedule.rs
+++ b/cli/tests/schedule.rs
@@ -1,0 +1,85 @@
+//! End-to-end tests for `faucet schedule`. Gated on the feature so non-schedule
+//! builds skip them.
+#![cfg(feature = "schedule")]
+
+use assert_cmd::Command;
+use std::time::Duration;
+
+/// Write a CSV + a schedule config into a temp dir; return (dir, config path).
+fn fixture(schedule_block: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    let csv = dir.path().join("in.csv");
+    std::fs::write(&csv, "name\nalice\nbob\n").unwrap();
+    let out = dir.path().join("out.jsonl");
+    let cfg = dir.path().join("pipeline.yaml");
+    std::fs::write(
+        &cfg,
+        format!(
+            r#"version: 1
+name: sched-test
+schedule:
+{schedule_block}
+pipeline:
+  source: {{ type: csv, config: {{ path: {csv} }} }}
+  sink:   {{ type: jsonl, config: {{ path: {out} }} }}
+"#,
+            csv = csv.display(),
+            out = out.display(),
+        ),
+    )
+    .unwrap();
+    (dir, cfg)
+}
+
+#[test]
+fn once_runs_one_pipeline_and_exits_zero() {
+    let (dir, cfg) = fixture("  cron: \"0 2 * * *\"\n");
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .arg("schedule")
+        .arg(&cfg)
+        .arg("--once")
+        .assert()
+        .success();
+    let out = std::fs::read_to_string(dir.path().join("out.jsonl")).unwrap();
+    assert_eq!(out.lines().count(), 2, "expected the two CSV rows written once");
+}
+
+#[test]
+fn max_runs_stops_the_loop() {
+    // Seconds-cron firing every second; stop after 2 successful runs.
+    let (dir, cfg) = fixture("  cron: \"*/1 * * * * *\"\n  max_runs: 2\n  start_immediately: true\n");
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .arg("schedule")
+        .arg(&cfg)
+        .timeout(Duration::from_secs(20))
+        .assert()
+        .success();
+    // The loop terminated on its own (max_runs) — the output file exists.
+    assert!(dir.path().join("out.jsonl").exists());
+}
+
+#[test]
+fn missing_schedule_block_is_a_clear_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let csv = dir.path().join("in.csv");
+    std::fs::write(&csv, "name\nx\n").unwrap();
+    let cfg = dir.path().join("pipeline.yaml");
+    std::fs::write(
+        &cfg,
+        format!(
+            "version: 1\npipeline:\n  source: {{ type: csv, config: {{ path: {csv} }} }}\n  sink: {{ type: stdout, config: {{}} }}\n",
+            csv = csv.display()
+        ),
+    )
+    .unwrap();
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .arg("schedule")
+        .arg(&cfg)
+        .arg("--once")
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("schedule"));
+}

--- a/crates/sink/csv/README.md
+++ b/crates/sink/csv/README.md
@@ -233,6 +233,7 @@ sink.flush().await?;
 ## How It Works
 
 - The file is opened lazily on the first `write_batch()` call. Column order is determined from the keys of the first record.
+- Missing parent directories of `path` are created automatically (equivalent to `mkdir -p`) before the file is opened, matching the behaviour of the parquet sink. Dated-subdirectory paths such as `./data/dt=2026-03-08/part.csv` work without any pre-creation step.
 - All CSV I/O runs inside `tokio::task::spawn_blocking` to avoid blocking the async runtime.
 - A `Mutex` protects the writer state (column order + csv::Writer) for thread-safe access.
 - Headers are written only on file creation (not in append mode) when `write_headers` is `true`.

--- a/crates/sink/csv/src/sink.rs
+++ b/crates/sink/csv/src/sink.rs
@@ -210,6 +210,16 @@ fn write_csv_blocking(
                 (config.append, !config.append)
             };
 
+            if let Some(parent) = std::path::Path::new(&config.path).parent()
+                && !parent.as_os_str().is_empty()
+            {
+                std::fs::create_dir_all(parent).map_err(|e| {
+                    FaucetError::Sink(format!(
+                        "failed to create parent directory '{}': {e}",
+                        parent.display()
+                    ))
+                })?;
+            }
             let file = OpenOptions::new()
                 .create(true)
                 .write(true)
@@ -403,6 +413,25 @@ mod tests {
             .unwrap();
         assert_eq!(report.failed_count(), 1);
         assert_eq!(report.probes[0].name, "io");
+    }
+
+    #[tokio::test]
+    async fn creates_missing_parent_directories() {
+        let dir = tempfile::tempdir().unwrap();
+        let nested = dir.path().join("a").join("b").join("out.csv");
+        let path_str = nested.to_str().unwrap().to_string();
+        let sink = CsvSink::new(CsvSinkConfig::new(&path_str));
+
+        let records = vec![json!({"id": "1", "name": "Alice"})];
+        let count = sink.write_batch(&records).await.unwrap();
+        sink.flush().await.unwrap();
+
+        assert_eq!(count, 1);
+        assert!(nested.exists(), "output file must exist after write");
+        let content = tokio::fs::read_to_string(&nested).await.unwrap();
+        let lines: Vec<&str> = content.trim().split('\n').collect();
+        // Header + 1 data row.
+        assert_eq!(lines.len(), 2);
     }
 
     #[cfg(feature = "compression")]

--- a/crates/sink/jsonl/README.md
+++ b/crates/sink/jsonl/README.md
@@ -187,6 +187,7 @@ Output:
 ## How It Works
 
 - The file is opened lazily on the first `write_batch()` call and wrapped in a `tokio::io::BufWriter` for efficient buffered writes.
+- Missing parent directories of `path` are created automatically (equivalent to `mkdir -p`) before the file is opened, matching the behaviour of the parquet sink. Dated-subdirectory paths such as `./data/dt=2026-03-08/part.jsonl` work without any pre-creation step.
 - A `Mutex` protects the writer for thread-safe concurrent access.
 - Each record is serialized to a single JSON line (or pretty-printed if configured) followed by a newline character.
 - Multiple `write_batch()` calls accumulate data in the same file without re-opening it.

--- a/crates/sink/jsonl/src/sink.rs
+++ b/crates/sink/jsonl/src/sink.rs
@@ -65,6 +65,16 @@ impl JsonlSink {
             } else {
                 (self.config.append, !self.config.append)
             };
+            if let Some(parent) = self.config.path.parent()
+                && !parent.as_os_str().is_empty()
+            {
+                tokio::fs::create_dir_all(parent).await.map_err(|e| {
+                    FaucetError::Sink(format!(
+                        "failed to create parent directory '{}': {e}",
+                        parent.display()
+                    ))
+                })?;
+            }
             let file = OpenOptions::new()
                 .create(true)
                 .write(true)
@@ -281,6 +291,23 @@ mod tests {
             .unwrap();
         assert_eq!(report.failed_count(), 1);
         assert_eq!(report.probes[0].name, "io");
+    }
+
+    #[tokio::test]
+    async fn creates_missing_parent_directories() {
+        let dir = tempfile::tempdir().unwrap();
+        let nested = dir.path().join("a").join("b").join("out.jsonl");
+        let sink = JsonlSink::new(JsonlSinkConfig::new(&nested));
+
+        let records = vec![json!({"id": 1})];
+        let count = sink.write_batch(&records).await.unwrap();
+        sink.flush().await.unwrap();
+
+        assert_eq!(count, 1);
+        assert!(nested.exists(), "output file must exist after write");
+        let content = tokio::fs::read_to_string(&nested).await.unwrap();
+        let first: Value = serde_json::from_str(content.trim()).unwrap();
+        assert_eq!(first["id"], 1);
     }
 
     #[cfg(feature = "compression")]

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -25,6 +25,7 @@
 - [Compression](./cookbook/compression.md)
 - [Record transforms](./cookbook/transforms.md)
 - [Secrets-manager interpolation](./cookbook/secrets.md)
+- [Scheduling](./cookbook/scheduling.md)
 - [Troubleshooting with faucet doctor](./cookbook/troubleshooting.md)
 
 # Reference

--- a/docs/book/src/cookbook/scheduling.md
+++ b/docs/book/src/cookbook/scheduling.md
@@ -1,0 +1,240 @@
+# Scheduling pipelines with `faucet schedule`
+
+`faucet schedule` runs a pipeline on a cron schedule in a **long-running
+foreground process**. It is designed for server-side deployment: drop it into
+systemd, Kubernetes, or any supervisor that can restart it on failure, and the
+pipeline fires on time every time.
+
+```bash
+faucet schedule pipeline.yaml           # foreground; Ctrl-C or SIGTERM to stop
+faucet schedule pipeline.yaml --once    # run exactly once now, then exit
+```
+
+The config must include a `schedule:` block alongside the usual `pipeline:`.
+Configs without one are rejected with a hint to use `faucet run` instead.
+
+## A runnable example
+
+The following config runs a CSV→JSONL pipeline every night at 02:00
+America/Los_Angeles. Save it as `nightly.yaml` and start it with
+`faucet schedule nightly.yaml`:
+
+```yaml
+# nightly.yaml — run at 02:00 Pacific every night
+version: 1
+name: nightly-rollup
+
+schedule:
+  cron: "0 2 * * *"
+  timezone: "America/Los_Angeles"
+  overlap_policy: skip            # don't pile up if a run runs long
+  max_consecutive_failures: 5     # exit non-zero after 5 straight failures (supervisor restarts)
+  on_failure: continue
+  shutdown_grace_secs: 30
+
+pipeline:
+  source:
+    type: csv
+    config:
+      path: ./events.csv
+  sink:
+    type: jsonl
+    config:
+      path: ./events.jsonl
+```
+
+See [`cli/examples/scheduled_nightly.yaml`](https://github.com/PawanSikawat/faucet-stream/blob/main/cli/examples/scheduled_nightly.yaml)
+for the canonical copy.
+
+## Cron syntax
+
+faucet uses a standard Unix cron expression, validated at config-load time.
+A bad expression or an expression that can never fire produces a clear error
+before the process starts.
+
+**5-field form** (`MIN HOUR DOM MON DOW`):
+
+| Expression | Meaning |
+|------------|---------|
+| `0 2 * * *` | Every night at 02:00 |
+| `*/15 * * * *` | Every 15 minutes |
+| `0 9 * * 1-5` | Weekdays at 09:00 |
+| `0 0 1 * *` | First of every month at midnight |
+| `0 */6 * * *` | Every 6 hours |
+
+**6-field form** (`SEC MIN HOUR DOM MON DOW`) — add a leading seconds field
+for sub-minute intervals:
+
+| Expression | Meaning |
+|------------|---------|
+| `*/30 * * * * *` | Every 30 seconds |
+| `0 */5 * * * *` | Every 5 minutes (explicit seconds=0) |
+
+Field ranges follow standard cron semantics: `*` (every), `*/N` (every N),
+`a-b` (range), `a,b,c` (list). Month and day-of-week names (`JAN`, `MON`,
+etc.) are accepted. Special strings like `@daily` and `@hourly` are **not**
+supported — use the numeric form.
+
+## Timezone and DST
+
+Set `timezone` to any [IANA timezone name](https://www.iana.org/time-zones)
+(e.g. `America/Los_Angeles`, `Europe/Berlin`, `Asia/Tokyo`). The default is
+`UTC`.
+
+All tick times are computed on UTC monotonic instants with timezone-correct
+wall-clock interpretation, so DST transitions behave correctly:
+
+- **Fall-back (clocks go back):** a repeated wall-clock hour fires **once**.
+- **Spring-forward (clocks skip ahead):** a wall-clock time in the skipped
+  hour is treated as if it were in the hour immediately after the gap — the
+  next valid tick.
+
+The scheduler loop re-checks the wall clock at least every 30 seconds, so
+NTP steps, VM freeze/thaw, and DST shifts can never drift a scheduled fire
+by more than ~30 seconds.
+
+## Missed-tick behavior
+
+If the process was down or a run took longer than one cron period, missed
+ticks are **skipped** — not backfilled. The scheduler fires once at the next
+due time and moves on. There is no catch-up storm.
+
+To find out how late a run fired, scrape
+`faucet_schedule_run_lateness_seconds` (histogram: `actual_start −
+scheduled_for`).
+
+## Overlap policy
+
+The overlap policy controls what happens when a tick fires while a run is
+already executing.
+
+| Policy | When to use |
+|--------|-------------|
+| `skip` (default) | The tick is dropped and a `faucet_schedule_overlaps_total{policy=skip}` counter is incremented. Use when it is acceptable to miss a cycle if the previous one ran long. Most pipelines. |
+| `queue` | One missed tick is buffered and fires immediately when the current run finishes. Further misses during that same run collapse into the single queued tick (in-memory only — lost on restart). Use when missing a cycle is unacceptable but strict concurrency still must be preserved. |
+| `forbid` | The process exits non-zero the moment an overlap would occur. Use when overlapping runs would produce corrupt output or you want a hard guarantee that no two instances run simultaneously — pair with a supervisor that alerts or pages on non-zero exit. |
+
+**Choosing between skip and queue:** if your pipeline is idempotent and
+catching up after a long run matters (e.g. incremental replication with
+state), use `queue`. If occasional missed cycles are harmless and you prefer
+simplicity, use `skip`.
+
+## Failure model and supervisor integration
+
+Two independent knobs govern what happens when a run fails:
+
+| `on_failure` | `max_consecutive_failures` | Behaviour |
+|---|---|---|
+| `continue` (default) | `null` | Tolerates all failures indefinitely. Alert via `faucet_schedule_consecutive_failures` gauge. |
+| `continue` | `N` | Tolerates up to N−1 straight failures; exits non-zero when the Nth consecutive failure occurs. A successful run resets the counter to 0. |
+| `stop` | any | Exits non-zero immediately on the **first** failure. |
+
+The recommended production pattern is `on_failure: continue` with
+`max_consecutive_failures: N` (5–10 depending on how quickly you want a
+supervisor restart):
+
+```yaml
+schedule:
+  cron: "*/5 * * * *"
+  on_failure: continue
+  max_consecutive_failures: 5   # restart after 5 straight failures
+```
+
+### Systemd unit example
+
+```ini
+# /etc/systemd/system/nightly-rollup.service
+[Unit]
+Description=faucet nightly rollup
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/faucet schedule /opt/pipelines/nightly.yaml
+Restart=on-failure
+RestartSec=30s
+# Env vars for the pipeline
+EnvironmentFile=/opt/pipelines/nightly.env
+
+[Install]
+WantedBy=multi-user.target
+```
+
+`Restart=on-failure` means systemd restarts the process whenever it exits
+with a non-zero code, which is exactly the condition `max_consecutive_failures`
+produces. `RestartSec=30s` adds a brief cooldown between restarts to avoid
+hammering a broken upstream.
+
+### Kubernetes CronJob vs long-running Deployment
+
+`faucet schedule` is designed for a **Deployment** (or long-running Pod):
+one process, always running, fires on cron. This keeps token caches warm
+and avoids cold-start latency on every tick.
+
+If you need Kubernetes to manage the schedule itself, use a Kubernetes
+**CronJob** with `faucet run` instead — each invocation is ephemeral and
+the scheduler handles missed/overlapping pods at the platform level.
+
+## Graceful shutdown and SIGTERM
+
+On SIGTERM or Ctrl-C:
+
+1. faucet stops accepting new ticks.
+2. If a run is in flight, it waits up to `shutdown_grace_secs` (default 30)
+   for it to finish.
+3. If the run finishes within the grace period, the process exits 0.
+4. If the run is still running after the grace period, it is aborted. The
+   per-page `StateStore` bookmark means the next start resumes from the last
+   confirmed write — no data is lost, but the partial page since the last
+   bookmark is re-fetched on the next run. Whether that causes duplicates
+   depends on your sink's idempotency.
+
+Increase `shutdown_grace_secs` for long-running pages (e.g. a BigQuery batch
+that takes several minutes to flush):
+
+```yaml
+schedule:
+  cron: "0 * * * *"
+  shutdown_grace_secs: 120
+```
+
+## Health metrics to scrape
+
+Register a Prometheus listener via the `observability:` block:
+
+```yaml
+observability:
+  prometheus:
+    listen: "127.0.0.1:9464"
+```
+
+Key metrics for a scheduling health dashboard:
+
+| Metric | What to alert on |
+|--------|-----------------|
+| `faucet_schedule_heartbeat_unix_seconds` | `time() - value > 90` → scheduler loop is stuck or process crashed |
+| `faucet_schedule_consecutive_failures` | `> 0` → at least one recent failure; `>= max_consecutive_failures` → imminent exit |
+| `faucet_schedule_next_tick_unix_seconds` | `value - time() > 2 * expected_interval` → scheduler is not advancing |
+| `faucet_schedule_runs_total{outcome="err"}` | Increasing counter → runs are failing |
+| `faucet_schedule_overlaps_total` | Repeated increments → runs are taking longer than the cron period |
+| `faucet_schedule_run_lateness_seconds` | p99 > threshold → runs are starting significantly late |
+
+Full metric reference:
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `faucet_schedule_runs_total{pipeline,outcome}` | Counter | `outcome` ∈ `{ok, err, skipped}` |
+| `faucet_schedule_overlaps_total{pipeline,policy}` | Counter | Overlap events by policy |
+| `faucet_schedule_next_tick_unix_seconds{pipeline}` | Gauge | Unix timestamp of the next scheduled tick |
+| `faucet_schedule_runs_in_flight{pipeline}` | Gauge | 0 or 1 |
+| `faucet_schedule_consecutive_failures{pipeline}` | Gauge | Resets to 0 on success |
+| `faucet_schedule_heartbeat_unix_seconds{pipeline}` | Gauge | Updated every loop wake (≤30 s) |
+| `faucet_schedule_last_run_started_unix_seconds{pipeline}` | Gauge | |
+| `faucet_schedule_last_run_completed_unix_seconds{pipeline}` | Gauge | |
+| `faucet_schedule_last_run_duration_seconds{pipeline}` | Gauge | |
+| `faucet_schedule_run_lateness_seconds{pipeline}` | Histogram | `actual_start − scheduled_for` |
+
+Each run also emits a `faucet.schedule.run` tracing span (attributes:
+`run_ordinal`, `scheduled_for_unix_seconds`, `tick_unix_seconds`) that wraps
+the inner pipeline spans, so distributed tracing carries the scheduling
+context through the full pipeline.

--- a/docs/book/src/cookbook/scheduling.md
+++ b/docs/book/src/cookbook/scheduling.md
@@ -198,6 +198,83 @@ schedule:
   shutdown_grace_secs: 120
 ```
 
+## Dated outputs with `${now.*}`
+
+`${now.*}` tokens let you inject the run's wall time into source and sink config
+values — so a scheduled pipeline can write to a different file or object-storage
+prefix on every tick without any manual bookkeeping.
+
+The headline use case is a dated partition path:
+
+```yaml
+# nightly_partitioned.yaml — write to a new dated partition every night
+version: 1
+name: nightly-events
+
+schedule:
+  cron: "0 2 * * *"
+  timezone: "America/Los_Angeles"
+  overlap_policy: skip
+  max_consecutive_failures: 5
+
+pipeline:
+  source:
+    type: rest
+    config:
+      base_url: https://api.example.com
+      path: /v1/events
+  sink:
+    type: jsonl
+    config:
+      # ${now.date} reflects the schedule's timezone (America/Los_Angeles),
+      # so the partition label matches the business date of the run.
+      path: "./warehouse/dt=${now.date}/events.jsonl"
+```
+
+When the cron fires at 02:00 on 2026-03-09 Pacific time, `${now.date}` resolves
+to `2026-03-09` and faucet writes to `./warehouse/dt=2026-03-09/events.jsonl`.
+The parent directory is created automatically — local file sinks (JSONL, CSV)
+create missing parent directories so dated subdirectory paths work without
+pre-creating the tree.
+
+The full token set:
+
+| Token | Example | Use case |
+|-------|---------|----------|
+| `${now.date}` | `2026-03-08` | Daily partition key |
+| `${now.year}` / `${now.month}` / `${now.day}` | `2026` / `03` / `08` | Hive-style `year=…/month=…/day=…` paths |
+| `${now.hour}` | `14` | Hourly partitions |
+| `${now.unix}` | `1741442709` | Unique epoch-based filenames |
+| `${now.strftime.<fmt>}` | `2026/03/08/14` | Arbitrary layout — e.g. `${now.strftime.%Y/%m/%d/%H}` |
+| `${now.datetime}` / `${now.iso}` | `2026-03-08T14:05:09+00:00` | RFC 3339 timestamp in a filename or object key |
+
+### Clock semantics
+
+`faucet schedule` uses the **tick's scheduled time** rendered in the schedule's
+`timezone` — not the actual wall clock when the run started. This means
+`${now.date}` is deterministic: re-running the same tick (e.g. after a restart)
+produces the same path.
+
+`faucet schedule --once` uses the current wall clock in the schedule's timezone.
+
+### Backfilling with `faucet run --clock`
+
+To backfill a range of dates, use `faucet run` with the `--clock` flag instead
+of `faucet schedule`. `--clock` overrides the process start time used by
+`${now.*}`:
+
+```bash
+# Backfill three nightly partitions
+faucet run --clock 2026-03-01 nightly_partitioned.yaml
+faucet run --clock 2026-03-02 nightly_partitioned.yaml
+faucet run --clock 2026-03-03 nightly_partitioned.yaml
+```
+
+A bare date (`2026-03-01`) is treated as midnight UTC. An RFC 3339 timestamp
+(`2026-03-01T02:00:00-08:00`) sets the clock precisely. Unknown `${now.*}`
+tokens are config errors; the token set is validated at run start before any
+I/O begins.
+
 ## Health metrics to scrape
 
 Register a Prometheus listener via the `observability:` block:

--- a/docs/book/src/reference/cli.md
+++ b/docs/book/src/reference/cli.md
@@ -21,11 +21,21 @@ faucet auto-discovers `faucet.yaml` → `.yml` → `.json` in the current direct
 
 ```bash
 faucet run pipeline.yaml
-faucet run                       # auto-discover faucet.yaml in cwd
-faucet run --from-env            # build the pipeline entirely from FAUCET_* env vars
+faucet run                              # auto-discover faucet.yaml in cwd
+faucet run --from-env                   # build the pipeline entirely from FAUCET_* env vars
 faucet run pipeline.yaml --env-file prod.env
 faucet run pipeline.yaml --no-env-file
+faucet run pipeline.yaml --clock 2026-03-01          # backfill: set ${now.*} clock to midnight UTC
+faucet run pipeline.yaml --clock 2026-03-01T02:00:00-08:00  # backfill: precise RFC 3339 timestamp
 ```
+
+Flags:
+
+| Flag | Purpose |
+|------|---------|
+| `--clock <value>` | Override the clock used by `${now.*}` tokens. Accepts an RFC 3339 timestamp (`2026-03-01T00:00:00Z`) or a bare date (`2026-03-01`, treated as midnight UTC). Default: process start time in UTC. Use this for backfills — run the same config with a different date without changing the file. |
+| `--env-file <path>` / `--no-env-file` | Same `.env` handling as `validate` / `preview`. |
+| `--from-env` | Build the pipeline entirely from `FAUCET_*` environment variables; mutually exclusive with a positional config path. |
 
 ## `validate`
 

--- a/docs/book/src/reference/cli.md
+++ b/docs/book/src/reference/cli.md
@@ -12,8 +12,9 @@ The `faucet` binary exposes these commands. Pass `--log-level <level>` (or set
 | `faucet list` | List every compiled-in source, sink, and transform with a one-line description. |
 | `faucet init [name]` | Scaffold a commented config skeleton from connector schemas. |
 | `faucet doctor [config]` | Probe every connector (auth/network/permissions) and print a checklist. |
+| `faucet schedule [config]` | Run a pipeline on a cron schedule (long-running foreground process). |
 
-`[config]` is optional for `run` / `validate` / `preview` / `doctor`: if omitted,
+`[config]` is optional for `run` / `validate` / `preview` / `doctor` / `schedule`: if omitted,
 faucet auto-discovers `faucet.yaml` → `.yml` → `.json` in the current directory.
 
 ## `run`
@@ -119,6 +120,36 @@ scrubbed for resolved secrets before printing.
 
 See the [Troubleshooting](../cookbook/troubleshooting.md) cookbook page for
 reading the output and common failures.
+
+## `schedule`
+
+```bash
+faucet schedule pipeline.yaml                  # run on cron schedule, foreground; Ctrl-C to stop
+faucet schedule pipeline.yaml --once           # run exactly once now, then exit
+faucet schedule pipeline.yaml --env-file prod.env
+faucet schedule pipeline.yaml --no-env-file
+```
+
+Runs a pipeline on a recurring cron schedule in a **long-running foreground process**. The config
+must contain a top-level `schedule:` block (without one, faucet errors and suggests `faucet run`).
+Requires the `schedule` Cargo feature (included in `full`).
+
+- Stop with Ctrl-C or SIGTERM; the in-flight run drains for up to `shutdown_grace_secs` (default 30)
+  before the process exits.
+- `--once` ignores cron timing and runs the pipeline exactly once immediately — handy for testing
+  a scheduled config or for one-shot container invocations.
+- Missed ticks are skipped, not backfilled. A run that starts late emits
+  `faucet_schedule_run_lateness_seconds` for monitoring.
+
+Flags:
+
+| Flag | Purpose |
+|------|---------|
+| `--once` | Run exactly once now, then exit. Ignores cron timing. |
+| `--env-file <path>` / `--no-env-file` | Same `.env` handling as `run` / `validate`. |
+
+See the [scheduling cookbook](../cookbook/scheduling.md) for worked examples, the overlap-policy
+decision tree, the resilience/supervisor model, and the full metric set to scrape.
 
 ## Environment-only mode
 

--- a/docs/book/src/reference/config.md
+++ b/docs/book/src/reference/config.md
@@ -70,9 +70,56 @@ Three stages resolve placeholders:
   `${sources.NAME.PATH}` / `${sinks.NAME.PATH}` resolve against named templates.
   Secret-manager directives (see below) run as the final load-time stage.
 - **Runtime:** `${row_id.dotted.path}` tokens are resolved per parent record in
-  DAG runs.
+  DAG runs. `${now.*}` tokens are resolved per invocation at run time (see
+  below).
 
 Reference cycles surface as a clear `InterpolationCycle` error.
+
+### `${now.*}` — run-clock interpolation
+
+`${now.*}` tokens inject the current wall time into **source and sink config
+values**. Each invocation evaluates them once at run time:
+
+| Token | Example output | Notes |
+|-------|---------------|-------|
+| `${now.date}` | `2026-03-08` | `YYYY-MM-DD` |
+| `${now.datetime}` | `2026-03-08T14:05:09+00:00` | RFC 3339; alias: `${now.iso}` |
+| `${now.iso}` | `2026-03-08T14:05:09+00:00` | Alias for `${now.datetime}` |
+| `${now.year}` | `2026` | Zero-padded 4-digit year |
+| `${now.month}` | `03` | Zero-padded month (01–12) |
+| `${now.day}` | `08` | Zero-padded day (01–31) |
+| `${now.hour}` | `14` | Zero-padded hour (00–23) |
+| `${now.minute}` | `05` | Zero-padded minute (00–59) |
+| `${now.second}` | `09` | Zero-padded second (00–59) |
+| `${now.unix}` | `1741442709` | Unix epoch seconds |
+| `${now.strftime.<fmt>}` | `2026/03/08/14` | Arbitrary [chrono strftime](https://docs.rs/chrono/latest/chrono/format/strftime/index.html) — e.g. `${now.strftime.%Y/%m/%d/%H}` |
+
+An unknown token (e.g. `${now.foo}`) is a config error at run time. An invalid
+strftime format produces a clean config error rather than a panic.
+
+**Clock source:**
+
+- **`faucet run`** — the process start time in UTC. Override with
+  `--clock <value>` for backfills: an RFC 3339 timestamp
+  (`2026-03-01T00:00:00Z`) or a bare date (`2026-03-01`, treated as midnight
+  UTC). See the [`run` command reference](cli.md#run).
+- **`faucet schedule`** — the tick's **scheduled time**, rendered in the
+  schedule's `timezone`. `${now.date}` therefore reflects the date in the
+  timezone the cron fires in (e.g. `America/Los_Angeles`), not UTC. Queued
+  runs use their original scheduled time; `--once` uses the current wall clock.
+
+**Scope:** `${now.*}` tokens are resolved only in source and sink config values.
+They are **not** resolved in `state:`, `dlq:`, `transforms:`, or the top-level
+`auth:` / `vars:` blocks.
+
+**Reserved id:** `now` is a reserved matrix row id — a matrix row cannot be
+named `now`.
+
+**SQL caveat:** `${now.*}` substitutes as plain text into config values — the
+same semantics as `${row_id.path}` tokens. For SQL sources that interpolate
+`${now.*}` into a query string, prefer the connector's bind-parameter path
+(`substitute_context_bind_params`) over raw text substitution to avoid
+injection risk.
 
 ### Secrets-manager directives
 

--- a/docs/book/src/reference/config.md
+++ b/docs/book/src/reference/config.md
@@ -7,6 +7,7 @@ version: 1                 # required, must be 1
 name: my_pipeline          # optional; used in state keys and metrics
 vars: {}                   # optional; reusable values referenced as ${vars.X}
 auth: {}                   # optional; named shared auth providers (see below)
+schedule: {}               # optional; cron schedule for faucet schedule (see below)
 pipeline:                  # required
   source: { type: …, config: { … } }
   transforms: []           # optional list
@@ -128,9 +129,47 @@ auth:
 - `on_error` — `continue` (siblings finish; failed subtree skipped) or `stop`
   (abort pending and in-flight work on first failure).
 
+## `schedule`
+
+Present only when you run `faucet schedule`. Absent configs are rejected by that
+command with a hint to use `faucet run` instead. All fields except `cron` are
+optional.
+
+```yaml
+schedule:
+  cron: "0 2 * * *"               # REQUIRED. Standard 5-field cron, or 6-field with leading seconds.
+  timezone: "UTC"                 # IANA timezone name. Default UTC.
+  overlap_policy: skip            # skip | queue | forbid. Default skip.
+  max_runs: null                  # null = run forever; N = exit 0 after N successful runs.
+  max_consecutive_failures: null  # null = never exit on failure; N = exit non-zero after N straight failures.
+  on_failure: continue            # continue | stop. Default continue.
+  start_immediately: false        # Run once on startup before waiting for the first tick. Default false.
+  run_timeout_secs: null          # Per-run wall-clock kill switch (seconds). Timed-out runs count as failed.
+  shutdown_grace_secs: 30         # SIGTERM: wait this long for the in-flight run before aborting. Default 30.
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `cron` | string | **required** | 5-field standard Unix cron (`MIN HOUR DOM MON DOW`) or 6-field with a leading seconds field (`SEC MIN HOUR DOM MON DOW`). Validated at load time. |
+| `timezone` | string | `"UTC"` | IANA timezone name (e.g. `"America/Los_Angeles"`, `"Europe/Berlin"`). Affects how the cron expression is interpreted. |
+| `overlap_policy` | `skip` \| `queue` \| `forbid` | `skip` | What to do when a tick fires while a run is already in flight. `skip` drops the tick; `queue` buffers one missed tick (in-memory only, lost on restart); `forbid` exits non-zero. |
+| `max_runs` | integer \| null | `null` | Stop the scheduler cleanly (exit 0) after this many *successful* runs. `null` means run forever. `0` is rejected as a config error. |
+| `max_consecutive_failures` | integer \| null | `null` | Exit non-zero after this many consecutive failed runs without a success in between. A successful run resets the counter. `null` means never exit on failures alone. |
+| `on_failure` | `continue` \| `stop` | `continue` | `stop` exits non-zero immediately after the first failed run. `continue` keeps scheduling; use `max_consecutive_failures` to bound sustained outages. |
+| `start_immediately` | bool | `false` | When `true`, the first run fires right on startup before the cron clock reaches its first tick. |
+| `run_timeout_secs` | integer \| null | `null` | Per-run time limit in seconds. A run that exceeds this is killed and counts as a failure. `null` means no timeout. |
+| `shutdown_grace_secs` | integer | `30` | On SIGTERM/SIGINT, wait this many seconds for the in-flight run to finish before forcibly aborting it. |
+
+**Validation:** `faucet validate pipeline.yaml` checks the `schedule:` block at parse time — bad cron
+syntax, unknown timezone names, `max_runs: 0`, and a cron expression that can never fire all produce
+a clear `config error: schedule: …` message before any run starts.
+
+See the [scheduling cookbook](../cookbook/scheduling.md) for worked examples, the DST/timezone
+details, the overlap-policy decision tree, and the full Prometheus metric set.
+
 ## Discovery & env files
 
-`run` / `validate` / `preview` auto-discover `faucet.yaml` → `.yml` → `.json` in
+`run` / `validate` / `preview` / `schedule` auto-discover `faucet.yaml` → `.yml` → `.json` in
 the current directory, and load a sibling `.env` unless `--no-env-file` is given
 (`--env-file PATH` points elsewhere).
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -39,6 +39,7 @@ These run immediately after installing the CLI — great for a first smoke test:
 | `shared_auth_rest.yaml` | one OAuth2 provider in the top-level `auth:` block shared across four matrix rows via `auth: { ref }` — single token, single-flight refresh (point `base_url` / token endpoint at a real API) |
 | `rest_to_jsonl_with_vault.yaml` | Vault KV v2 secret injected as a Bearer token via `${vault:…#field}`; requires `VAULT_ADDR` + `VAULT_TOKEN` and `--features secrets-vault` |
 | `websocket_to_jsonl.yaml` | none (live public WS endpoint — Binance BTC/USDT trade stream, no auth) |
+| `scheduled_nightly.yaml` | `faucet schedule` — CSV→JSONL pipeline on a nightly cron at 02:00 Pacific; demonstrates timezone, overlap_policy, and max_consecutive_failures |
 
 > REST / GraphQL / XML / gRPC / webhook source examples hit an external endpoint
 > (the configs use a placeholder `base_url`). Edit it to a real API — there's no


### PR DESCRIPTION
## Summary

Adds **`faucet schedule`** — a production-grade, long-running cron scheduler subcommand — and **`${now.*}` run-clock interpolation** for dated outputs. Designed for an unattended ETL scheduler running for weeks on an EC2 box / in a container, not a cron-loop demo.

Closes #121. Closes #138.

Design spec + addendum: `docs/superpowers/specs/2026-05-30-faucet-schedule-design.md`.

## `faucet schedule`

`faucet schedule [<config>] [--once]` runs a pipeline on a cron schedule via a new top-level `schedule:` block:

```yaml
schedule:
  cron: "0 2 * * *"               # 5-field standard Unix cron, or 6-field with seconds
  timezone: "America/Los_Angeles" # IANA; default UTC
  overlap_policy: skip            # skip | queue | forbid
  max_runs: null                  # stop after N successful runs
  max_consecutive_failures: null  # exit non-zero after N straight failures (supervisor restarts)
  on_failure: continue            # continue | stop
  start_immediately: false
  run_timeout_secs: null
  shutdown_grace_secs: 30
```

Production-hardening built in:
- **Clock-resilient loop** — bounded ≤30s re-check survives NTP steps / VM freezes / DST; missed ticks are skipped, never backfilled; DST fall-back fires once, spring-forward rolls forward.
- **`croner`** parses standard 5-field cron natively (+ optional seconds); a hand-rolled `tokio::select!` loop owns overlap/timeout/shutdown — no `tokio-cron-scheduler`.
- **`max_consecutive_failures`** — tolerate transient blips, exit loudly on a sustained outage so systemd/k8s restarts.
- **Graceful SIGTERM/SIGINT drain** within `shutdown_grace_secs`, else abort; resumability rides the pipeline's existing per-page `StateStore` bookmark, so the scheduler keeps no state of its own.
- **Fresh connectors per run** (no stale idle pools); the shared `auth:` catalog is reused.
- 10 `faucet_schedule_*` Prometheus metrics (heartbeat, next_tick, in_flight, consecutive_failures, lateness, …) + a per-run `faucet.schedule.run` tracing span.

## `${now.*}` run-clock interpolation (#138, folded in)

Dated outputs / time-window params, the reason a scheduler is useful for ETL:

```yaml
sink: { type: jsonl, config: { path: "./warehouse/dt=${now.date}/events.jsonl" } }
```

Tokens (resolved per-invocation in source + sink configs): `date`, `datetime`/`iso`, `year`/`month`/`day`/`hour`/`minute`/`second`, `unix`, `strftime.<fmt>` (panic-safe). The clock is the tick's scheduled time in the schedule timezone for `schedule`, or process start (UTC) for `run` — with a new `faucet run --clock <RFC3339|YYYY-MM-DD>` backfill override. `now` is a reserved id.

The **jsonl + csv sinks now create missing parent directories** (matching the parquet sink) so dated *subdirectory* paths work for local file sinks.

## Architectural principle

**Zero `faucet-core` changes** — the scheduler is a CLI-layer loop reusing `expand` + `executor::run_expanded`; `${now.*}` reuses the existing interpolation tokenizer (`now` as a reserved built-in deferred id). All scheduler-specific surface is gated behind a new `schedule` Cargo feature (in `full`); `chrono` became a base CLI dep so `${now.*}` works in `run` too.

## Testing

- Pure unit tests: `ScheduleSpec`, `CompiledSchedule` (cron/tz validation incl. **DST spring-forward & fall-back**, never-fires, all `*:0` rejections), `SchedulerState` (every overlap/failure/cap transition), `resolve_now` (every token + panic-safe strftime + unknown-token error + leaves-other-tokens-verbatim), `--clock` parsing.
- Integration: `faucet schedule --once`, `max_runs` self-exit, missing-`schedule:` error, `faucet validate` rejects bad cron, `${now.date}` resolves end-to-end via `--clock`.
- `faucet validate` now compiles the `schedule:` block (CI preflight catches bad cron/tz/bounds offline).
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean.

## Docs

`schedule:` + `${now.*}` documented in `cli/README.md`, the docs-site config/cli references, a new `cookbook/scheduling.md`, a runnable `cli/examples/scheduled_nightly.yaml`, root README, and `CLAUDE.md`. CI `feature-check` matrix gains a `schedule` row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
