### PR TITLE
feat(serve): faucet serve — HTTP control-plane skeleton (Phase 1 of #127)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,8 @@ jobs:
           - quality-jsonschema
           # Scheduler (CLI-only)
           - schedule
+          # HTTP control plane (CLI-only)
+          - serve
           # Secrets backends
           - secrets-vault
           - secrets-aws-sm
@@ -190,7 +192,7 @@ jobs:
         run: |
           # Secrets and schedule features live in faucet-cli (CLI layer), not
           # in the faucet-stream umbrella crate. Route accordingly.
-          if [[ "${{ matrix.feature }}" == secrets-* || "${{ matrix.feature }}" == "schedule" ]]; then
+          if [[ "${{ matrix.feature }}" == secrets-* || "${{ matrix.feature }}" == "schedule" || "${{ matrix.feature }}" == serve* ]]; then
             cargo check -p faucet-cli --no-default-features --features ${{ matrix.feature }}
           else
             cargo check -p faucet-stream --no-default-features --features ${{ matrix.feature }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,8 +190,8 @@ jobs:
           brew install cmake openssl@3 curl
       - name: Check feature in isolation
         run: |
-          # Secrets and schedule features live in faucet-cli (CLI layer), not
-          # in the faucet-stream umbrella crate. Route accordingly.
+          # Secrets, schedule, and serve features live in faucet-cli (CLI layer),
+          # not in the faucet-stream umbrella crate. Route accordingly.
           if [[ "${{ matrix.feature }}" == secrets-* || "${{ matrix.feature }}" == "schedule" || "${{ matrix.feature }}" == serve* ]]; then
             cargo check -p faucet-cli --no-default-features --features ${{ matrix.feature }}
           else

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,7 +157,6 @@ csv = "1.3"
 csv-async = { version = "1.3", features = ["tokio"] }
 redis = { version = "0.29", features = ["tokio-comp", "aio"] }
 axum = "0.8"
-dashmap = "6"
 subtle = "2"
 tower-http = { version = "0.6", features = ["limit", "cors", "trace", "request-id", "util"] }
 tokio-tungstenite = { version = "0.29", default-features = false, features = ["connect", "rustls-tls-webpki-roots"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,6 +157,9 @@ csv = "1.3"
 csv-async = { version = "1.3", features = ["tokio"] }
 redis = { version = "0.29", features = ["tokio-comp", "aio"] }
 axum = "0.8"
+dashmap = "6"
+subtle = "2"
+tower-http = { version = "0.6", features = ["limit", "cors", "trace", "request-id", "util"] }
 tokio-tungstenite = { version = "0.29", default-features = false, features = ["connect", "rustls-tls-webpki-roots"] }
 schemars = "1.2.1"
 futures = "0.3"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -166,8 +166,10 @@ observability = [
 schedule = ["dep:croner", "dep:chrono-tz"]
 
 # HTTP control plane (`faucet serve`). Pulls axum + an in-process run registry.
-# Enables `observability` (serve renders /metrics on its own port).
-serve = ["observability", "dep:axum", "dep:tower-http", "dep:dashmap", "dep:tokio-util", "dep:subtle"]
+# Enables `observability` (serve renders /metrics on its own port). Gates the
+# tokio net/time features here (rather than the base dep) so slim non-serve
+# builds don't link the TCP stack.
+serve = ["observability", "tokio/net", "tokio/time", "dep:axum", "dep:tower-http", "dep:dashmap", "dep:tokio-util", "dep:subtle"]
 serve-history-postgres = ["serve", "dep:sqlx"]
 serve-history-sqlite = ["serve", "dep:sqlx"]
 
@@ -220,7 +222,7 @@ serde.workspace = true
 serde_json.workspace = true
 serde_yaml = "0.9"
 thiserror.workspace = true
-tokio = { workspace = true, features = ["rt-multi-thread", "macros", "signal", "fs", "sync", "net", "time"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "signal", "fs", "sync"] }
 tracing.workspace = true
 tracing-subscriber = { workspace = true, optional = true }
 async-trait.workspace = true

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 # yields a binary that can run any of the published example YAMLs out of the box.
 default = ["observability", "full", "quality"]
 
-full = ["observability", "source", "sink", "state", "transforms", "compression", "quality", "schedule"]
+full = ["observability", "source", "sink", "state", "transforms", "compression", "quality", "schedule", "serve"]
 
 # Data-quality checks (`quality:` config block). `quality-jsonschema` adds the
 # `json_schema` record check via a JSON Schema validator. Forwarded to
@@ -165,6 +165,12 @@ observability = [
 # Pulls a cron parser + IANA timezone db; opt out of it for slim builds.
 schedule = ["dep:croner", "dep:chrono-tz"]
 
+# HTTP control plane (`faucet serve`). Pulls axum + an in-process run registry.
+# Enables `observability` (serve renders /metrics on its own port).
+serve = ["observability", "dep:axum", "dep:tower-http", "dep:dashmap", "dep:tokio-util", "dep:subtle"]
+serve-history-postgres = ["serve", "dep:sqlx"]
+serve-history-sqlite = ["serve", "dep:sqlx"]
+
 [dependencies]
 faucet-core.workspace = true
 faucet-auth.workspace = true
@@ -214,7 +220,7 @@ serde.workspace = true
 serde_json.workspace = true
 serde_yaml = "0.9"
 thiserror.workspace = true
-tokio = { workspace = true, features = ["rt-multi-thread", "macros", "signal", "fs", "sync"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "signal", "fs", "sync", "net", "time"] }
 tracing.workspace = true
 tracing-subscriber = { workspace = true, optional = true }
 async-trait.workspace = true
@@ -234,6 +240,12 @@ azure_core = { workspace = true, optional = true }
 chrono = { workspace = true }
 chrono-tz = { workspace = true, optional = true }
 croner = { workspace = true, optional = true }
+axum = { workspace = true, optional = true }
+tower-http = { workspace = true, optional = true }
+dashmap = { workspace = true, optional = true }
+tokio-util = { workspace = true, optional = true }
+subtle = { workspace = true, optional = true }
+sqlx = { workspace = true, optional = true }
 
 [dev-dependencies]
 tempfile = "3"
@@ -245,6 +257,7 @@ metrics-util.workspace = true
 serde_yaml = "0.9"
 async-stream.workspace = true
 futures-core.workspace = true
+reqwest = { workspace = true, features = ["json"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -169,7 +169,7 @@ schedule = ["dep:croner", "dep:chrono-tz"]
 # Enables `observability` (serve renders /metrics on its own port). Gates the
 # tokio net/time features here (rather than the base dep) so slim non-serve
 # builds don't link the TCP stack.
-serve = ["observability", "tokio/net", "tokio/time", "dep:axum", "dep:tower-http", "dep:dashmap", "dep:tokio-util", "dep:subtle"]
+serve = ["observability", "tokio/net", "tokio/time", "dep:axum", "dep:tower-http", "dep:tokio-util", "dep:subtle"]
 serve-history-postgres = ["serve", "dep:sqlx"]
 serve-history-sqlite = ["serve", "dep:sqlx"]
 
@@ -244,7 +244,6 @@ chrono-tz = { workspace = true, optional = true }
 croner = { workspace = true, optional = true }
 axum = { workspace = true, optional = true }
 tower-http = { workspace = true, optional = true }
-dashmap = { workspace = true, optional = true }
 tokio-util = { workspace = true, optional = true }
 subtle = { workspace = true, optional = true }
 sqlx = { workspace = true, optional = true }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -79,6 +79,59 @@ pub struct ScheduleArgs {
     pub once: bool,
 }
 
+/// `faucet serve` arguments.
+#[cfg(feature = "serve")]
+#[derive(Debug, Clone, Parser)]
+pub struct ServeArgs {
+    /// Bind address. Defaults to loopback; set 0.0.0.0:PORT to expose externally.
+    #[arg(long, env = "FAUCET_SERVE_LISTEN", default_value = "127.0.0.1:8080")]
+    pub listen: String,
+    /// Bearer token required on /v1/* requests. Prefer the env var (avoids `ps` leakage).
+    #[arg(long, env = "FAUCET_SERVE_AUTH_TOKEN", conflicts_with = "no_auth")]
+    pub auth_token: Option<String>,
+    /// Explicitly disable authentication. Required if no token is set, so an
+    /// unauthenticated server is never accidental.
+    #[arg(long)]
+    pub no_auth: bool,
+    /// Max pipeline runs executing at once. Default: min(16, cpu count).
+    #[arg(long)]
+    pub max_concurrent_runs: Option<usize>,
+    /// Max queued (not-yet-running) runs before POST /v1/runs returns 429.
+    /// Default: 8 × max-concurrent-runs.
+    #[arg(long)]
+    pub max_queued_runs: Option<usize>,
+    /// Workspace-default config merged under every submitted run.
+    #[arg(long)]
+    pub default_config: Option<std::path::PathBuf>,
+    /// Run-history backend URL: omitted = in-memory; postgres://… ; sqlite:… .
+    #[arg(long)]
+    pub history: Option<String>,
+    /// CORS allow-list origin (repeatable). Omitted = CORS disabled.
+    #[arg(long)]
+    pub cors_origin: Vec<String>,
+    /// Max POST /v1/runs body size in bytes (413 on exceed).
+    #[arg(long, default_value_t = 1_048_576)]
+    pub body_limit_bytes: usize,
+    /// SIGTERM/SIGINT drain window in seconds.
+    #[arg(long, default_value_t = 60)]
+    pub shutdown_grace_secs: u64,
+    /// Retain terminal run records this long (seconds).
+    #[arg(long, default_value_t = 604_800)]
+    pub retain_terminal_runs_secs: u64,
+    /// Idempotency-key replay window (seconds).
+    #[arg(long, default_value_t = 86_400)]
+    pub idempotency_retention_secs: u64,
+    /// Per-probe timeout for `doctor_first` preflight (seconds).
+    #[arg(long, default_value_t = 10)]
+    pub probe_timeout_secs: u64,
+    /// Path to a `.env` file loaded for the server's own startup interpolation.
+    #[arg(long, conflicts_with = "no_env_file")]
+    pub env_file: Option<std::path::PathBuf>,
+    /// Skip auto-loading `.env` from cwd at startup.
+    #[arg(long)]
+    pub no_env_file: bool,
+}
+
 /// `faucet run` arguments.
 #[derive(Debug, Parser)]
 pub struct RunArgs {

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -36,6 +36,9 @@ pub enum Command {
     /// Run a pipeline on a cron schedule (long-running; Ctrl-C / SIGTERM to stop).
     #[cfg(feature = "schedule")]
     Schedule(ScheduleArgs),
+    /// Run a long-running HTTP control plane (submit / poll / cancel pipeline runs).
+    #[cfg(feature = "serve")]
+    Serve(ServeArgs),
 }
 
 /// `faucet doctor` arguments.

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -8,6 +8,8 @@ pub mod preview;
 pub mod run;
 #[cfg(feature = "schedule")]
 pub mod schedule;
+#[cfg(feature = "serve")]
+pub mod serve;
 pub mod schema;
 pub mod validate;
 

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -8,9 +8,9 @@ pub mod preview;
 pub mod run;
 #[cfg(feature = "schedule")]
 pub mod schedule;
+pub mod schema;
 #[cfg(feature = "serve")]
 pub mod serve;
-pub mod schema;
 pub mod validate;
 
 use crate::error::CliError;

--- a/cli/src/commands/serve.rs
+++ b/cli/src/commands/serve.rs
@@ -1,0 +1,15 @@
+//! `faucet serve` — thin command layer: parse args into a `ServeConfig`, load
+//! the startup `.env`, and hand off to `serve::run_server`.
+
+use crate::cli::ServeArgs;
+use crate::error::CliResult;
+use crate::serve::ServeConfig;
+
+pub async fn run(args: ServeArgs) -> CliResult<()> {
+    let cwd = std::env::current_dir()?;
+    let env_path =
+        crate::env_loader::resolve_env_file(args.env_file.as_deref(), args.no_env_file, &cwd)?;
+    crate::env_loader::load_env_file_if_present(env_path.as_deref())?;
+    let config = ServeConfig::from_args(args)?;
+    crate::serve::run_server(config).await
+}

--- a/cli/src/commands/serve.rs
+++ b/cli/src/commands/serve.rs
@@ -5,11 +5,12 @@ use crate::cli::ServeArgs;
 use crate::error::CliResult;
 use crate::serve::ServeConfig;
 
-pub async fn run(args: ServeArgs) -> CliResult<()> {
+pub async fn run(args: ServeArgs, log_level: String) -> CliResult<()> {
     let cwd = std::env::current_dir()?;
     let env_path =
         crate::env_loader::resolve_env_file(args.env_file.as_deref(), args.no_env_file, &cwd)?;
     crate::env_loader::load_env_file_if_present(env_path.as_deref())?;
-    let config = ServeConfig::from_args(args)?;
+    let mut config = ServeConfig::from_args(args)?;
+    config.log_level = log_level;
     crate::serve::run_server(config).await
 }

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -310,6 +310,10 @@ pub enum CliError {
     #[error("{failed} preflight probe(s) failed")]
     DoctorFailed { failed: usize },
 
+    /// A `faucet serve` startup or runtime failure (bind, auth gate, etc.).
+    #[error("serve error: {0}")]
+    Serve(String),
+
     /// `overlap_policy: forbid` saw a tick fire while a run was still in flight.
     #[error("scheduled run overlap with overlap_policy: forbid — previous run still in progress")]
     ScheduleOverlapForbidden,

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -27,6 +27,8 @@ pub mod obs;
 pub mod registry;
 #[cfg(feature = "schedule")]
 pub mod schedule;
+#[cfg(feature = "serve")]
+pub mod serve;
 pub mod secrets;
 pub mod state;
 pub mod transforms;

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -27,9 +27,9 @@ pub mod obs;
 pub mod registry;
 #[cfg(feature = "schedule")]
 pub mod schedule;
+pub mod secrets;
 #[cfg(feature = "serve")]
 pub mod serve;
-pub mod secrets;
 pub mod state;
 pub mod transforms;
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -10,7 +10,13 @@ use tracing_subscriber::EnvFilter;
 #[tokio::main]
 async fn main() {
     let cli = Cli::parse();
-    install_tracing(&cli.log_level);
+    #[cfg(feature = "serve")]
+    let is_serve = matches!(cli.command, Command::Serve(_));
+    #[cfg(not(feature = "serve"))]
+    let is_serve = false;
+    if !is_serve {
+        install_tracing(&cli.log_level);
+    }
 
     let result = match cli.command {
         Command::Run(args) => commands::run::run(args).await,
@@ -22,6 +28,8 @@ async fn main() {
         Command::Doctor(args) => commands::doctor::run(args).await,
         #[cfg(feature = "schedule")]
         Command::Schedule(args) => commands::schedule::run(args).await,
+        #[cfg(feature = "serve")]
+        Command::Serve(args) => commands::serve::run(args).await,
     };
 
     if let Err(err) = result {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -17,6 +17,8 @@ async fn main() {
     if !is_serve {
         install_tracing(&cli.log_level);
     }
+    #[cfg(feature = "serve")]
+    let serve_log_level = cli.log_level.clone();
 
     let result = match cli.command {
         Command::Run(args) => commands::run::run(args).await,
@@ -29,7 +31,7 @@ async fn main() {
         #[cfg(feature = "schedule")]
         Command::Schedule(args) => commands::schedule::run(args).await,
         #[cfg(feature = "serve")]
-        Command::Serve(args) => commands::serve::run(args).await,
+        Command::Serve(args) => commands::serve::run(args, serve_log_level).await,
     };
 
     if let Err(err) = result {

--- a/cli/src/serve/auth.rs
+++ b/cli/src/serve/auth.rs
@@ -1,0 +1,1 @@
+//! Placeholder — implemented in Task 4.

--- a/cli/src/serve/auth.rs
+++ b/cli/src/serve/auth.rs
@@ -1,1 +1,72 @@
-//! Placeholder — implemented in Task 4.
+//! Bearer-token authentication for `/v1/*`. Constant-time comparison via
+//! `subtle`; the `Authorization` header is the only accepted credential.
+
+use crate::serve::error::ServeError;
+use crate::serve::state::ServerState;
+use axum::extract::{Request, State};
+use axum::middleware::Next;
+use axum::response::Response;
+use subtle::ConstantTimeEq;
+
+/// Timing-safe byte-slice equality (length-aware: differing lengths never match,
+/// and the comparison does not early-exit on the first mismatching byte).
+pub fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    a.ct_eq(b).into()
+}
+
+/// Validate a raw `Authorization` header value against the expected token.
+pub fn authorize_header(header: Option<&str>, expected: &str) -> Result<(), ServeError> {
+    let value = header.ok_or(ServeError::Unauthorized)?;
+    let token = value.strip_prefix("Bearer ").ok_or(ServeError::Unauthorized)?;
+    if constant_time_eq(token.as_bytes(), expected.as_bytes()) {
+        Ok(())
+    } else {
+        Err(ServeError::Unauthorized)
+    }
+}
+
+/// Axum middleware enforcing bearer auth on `/v1/*`. A no-op when the server was
+/// started with `--no-auth`. CORS preflight (`OPTIONS`) is allowed through so
+/// browsers (which omit `Authorization` on preflight) work behind a CORS policy.
+pub async fn require_auth(
+    State(state): State<ServerState>,
+    req: Request,
+    next: Next,
+) -> Result<Response, ServeError> {
+    if req.method() == axum::http::Method::OPTIONS {
+        return Ok(next.run(req).await);
+    }
+    if let Some(expected) = state.auth_token() {
+        let header = req
+            .headers()
+            .get(axum::http::header::AUTHORIZATION)
+            .and_then(|v| v.to_str().ok());
+        authorize_header(header, expected)?;
+    }
+    Ok(next.run(req).await)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn constant_time_eq_matches_only_identical() {
+        assert!(constant_time_eq(b"abc123", b"abc123"));
+        assert!(!constant_time_eq(b"abc123", b"abc124"));
+        assert!(!constant_time_eq(b"abc", b"abc123")); // length differs
+    }
+
+    #[test]
+    fn authorize_accepts_correct_bearer() {
+        assert!(authorize_header(Some("Bearer s3cret"), "s3cret").is_ok());
+    }
+
+    #[test]
+    fn authorize_rejects_wrong_or_missing() {
+        assert!(authorize_header(Some("Bearer nope"), "s3cret").is_err());
+        assert!(authorize_header(None, "s3cret").is_err());
+        assert!(authorize_header(Some("s3cret"), "s3cret").is_err()); // no "Bearer " prefix
+        assert!(authorize_header(Some("Basic s3cret"), "s3cret").is_err());
+    }
+}

--- a/cli/src/serve/auth.rs
+++ b/cli/src/serve/auth.rs
@@ -8,9 +8,11 @@ use axum::middleware::Next;
 use axum::response::Response;
 use subtle::ConstantTimeEq;
 
-/// Timing-safe byte-slice equality (length-aware: differing lengths never match,
-/// and the comparison does not early-exit on the first mismatching byte).
-pub fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+/// Timing-safe byte-slice equality. Differing lengths return `false` after a
+/// constant-time length check (subtle short-circuits unequal lengths — this
+/// leaks only the token *length*, never its content); equal-length inputs are
+/// compared byte-by-byte with no early exit on the first mismatch.
+pub(crate) fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
     a.ct_eq(b).into()
 }
 

--- a/cli/src/serve/auth.rs
+++ b/cli/src/serve/auth.rs
@@ -19,7 +19,9 @@ pub(crate) fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
 /// Validate a raw `Authorization` header value against the expected token.
 pub fn authorize_header(header: Option<&str>, expected: &str) -> Result<(), ServeError> {
     let value = header.ok_or(ServeError::Unauthorized)?;
-    let token = value.strip_prefix("Bearer ").ok_or(ServeError::Unauthorized)?;
+    let token = value
+        .strip_prefix("Bearer ")
+        .ok_or(ServeError::Unauthorized)?;
     if constant_time_eq(token.as_bytes(), expected.as_bytes()) {
         Ok(())
     } else {

--- a/cli/src/serve/config.rs
+++ b/cli/src/serve/config.rs
@@ -56,8 +56,7 @@ fn default_max_concurrent() -> usize {
     std::thread::available_parallelism()
         .map(|n| n.get())
         .unwrap_or(4)
-        .min(16)
-        .max(1)
+        .clamp(1, 16)
 }
 
 impl ServeConfig {

--- a/cli/src/serve/config.rs
+++ b/cli/src/serve/config.rs
@@ -1,1 +1,193 @@
-//! Placeholder — implemented in Task 2.
+//! `ServeConfig` — the validated, runtime-ready server configuration built from
+//! `ServeArgs`. The no-auth gate lives here so an unauthenticated server can
+//! never start silently.
+
+use crate::cli::ServeArgs;
+use crate::error::{CliError, CliResult};
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::time::Duration;
+
+/// How `/v1/*` requests are authenticated.
+#[derive(Debug, Clone)]
+pub enum AuthMode {
+    /// Require `Authorization: Bearer <token>`.
+    Token(String),
+    /// Authentication explicitly disabled via `--no-auth`.
+    None,
+}
+
+/// Run-history storage backend selection (parsed from `--history`).
+#[derive(Debug, Clone)]
+pub enum HistoryBackendSpec {
+    /// In-process `DashMap`; lost on restart (default).
+    Memory,
+    /// Postgres connection URL.
+    Postgres(String),
+    /// SQLite path / URL.
+    Sqlite(String),
+}
+
+/// Validated server configuration.
+#[derive(Debug, Clone)]
+pub struct ServeConfig {
+    pub listen: SocketAddr,
+    pub auth: AuthMode,
+    pub max_concurrent_runs: usize,
+    pub max_queued_runs: usize,
+    pub default_config_path: Option<PathBuf>,
+    pub history: HistoryBackendSpec,
+    pub cors_origins: Vec<String>,
+    pub body_limit_bytes: usize,
+    pub shutdown_grace: Duration,
+    pub retain_terminal_runs: Duration,
+    pub idempotency_retention: Duration,
+    pub probe_timeout: Duration,
+    pub env_file: Option<PathBuf>,
+    pub no_env_file: bool,
+}
+
+fn default_max_concurrent() -> usize {
+    std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(4)
+        .min(16)
+        .max(1)
+}
+
+impl ServeConfig {
+    /// Build + validate a `ServeConfig` from parsed CLI args. Enforces the
+    /// no-auth gate: a server with neither a token nor `--no-auth` refuses to start.
+    pub fn from_args(args: ServeArgs) -> CliResult<Self> {
+        let auth = match (args.auth_token, args.no_auth) {
+            (Some(t), _) => AuthMode::Token(t),
+            (None, true) => AuthMode::None,
+            (None, false) => {
+                return Err(CliError::Serve(
+                    "refusing to start without authentication: pass --auth-token \
+                     (or FAUCET_SERVE_AUTH_TOKEN), or --no-auth to explicitly disable it"
+                        .into(),
+                ));
+            }
+        };
+
+        let listen: SocketAddr = args
+            .listen
+            .parse()
+            .map_err(|e| CliError::Serve(format!("invalid --listen '{}': {e}", args.listen)))?;
+
+        let history = match args.history {
+            None => HistoryBackendSpec::Memory,
+            Some(u) if u.starts_with("postgres://") || u.starts_with("postgresql://") => {
+                HistoryBackendSpec::Postgres(u)
+            }
+            Some(u) if u.starts_with("sqlite:") => {
+                HistoryBackendSpec::Sqlite(u.trim_start_matches("sqlite:").to_string())
+            }
+            Some(u) => {
+                return Err(CliError::Serve(format!(
+                    "unrecognised --history '{u}': use a postgres:// URL or sqlite:<path>"
+                )));
+            }
+        };
+
+        let max_concurrent_runs = args
+            .max_concurrent_runs
+            .unwrap_or_else(default_max_concurrent)
+            .max(1);
+        let max_queued_runs = args
+            .max_queued_runs
+            .unwrap_or(max_concurrent_runs * 8)
+            .max(1);
+
+        Ok(Self {
+            listen,
+            auth,
+            max_concurrent_runs,
+            max_queued_runs,
+            default_config_path: args.default_config,
+            history,
+            cors_origins: args.cors_origin,
+            body_limit_bytes: args.body_limit_bytes,
+            shutdown_grace: Duration::from_secs(args.shutdown_grace_secs),
+            retain_terminal_runs: Duration::from_secs(args.retain_terminal_runs_secs),
+            idempotency_retention: Duration::from_secs(args.idempotency_retention_secs),
+            probe_timeout: Duration::from_secs(args.probe_timeout_secs),
+            env_file: args.env_file,
+            no_env_file: args.no_env_file,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::SocketAddr;
+
+    fn base_args() -> crate::cli::ServeArgs {
+        crate::cli::ServeArgs {
+            listen: "127.0.0.1:8080".into(),
+            auth_token: None,
+            no_auth: false,
+            max_concurrent_runs: None,
+            max_queued_runs: None,
+            default_config: None,
+            history: None,
+            cors_origin: vec![],
+            body_limit_bytes: 1_048_576,
+            shutdown_grace_secs: 60,
+            retain_terminal_runs_secs: 604_800,
+            idempotency_retention_secs: 86_400,
+            probe_timeout_secs: 10,
+            env_file: None,
+            no_env_file: false,
+        }
+    }
+
+    #[test]
+    fn no_auth_gate_rejects_silent_unauthenticated_start() {
+        let err = ServeConfig::from_args(base_args()).unwrap_err();
+        assert!(err.to_string().contains("--no-auth"), "{err}");
+    }
+
+    #[test]
+    fn explicit_no_auth_is_allowed() {
+        let mut a = base_args();
+        a.no_auth = true;
+        let cfg = ServeConfig::from_args(a).unwrap();
+        assert!(matches!(cfg.auth, AuthMode::None));
+    }
+
+    #[test]
+    fn token_sets_token_auth() {
+        let mut a = base_args();
+        a.auth_token = Some("hunter2".into());
+        let cfg = ServeConfig::from_args(a).unwrap();
+        assert!(matches!(cfg.auth, AuthMode::Token(t) if t == "hunter2"));
+    }
+
+    #[test]
+    fn listen_parses_to_socket_addr() {
+        let mut a = base_args();
+        a.no_auth = true;
+        a.listen = "0.0.0.0:9999".into();
+        let cfg = ServeConfig::from_args(a).unwrap();
+        assert_eq!(cfg.listen, "0.0.0.0:9999".parse::<SocketAddr>().unwrap());
+    }
+
+    #[test]
+    fn history_url_selects_backend() {
+        let mut a = base_args();
+        a.no_auth = true;
+        a.history = Some("postgres://localhost/db".into());
+        assert!(matches!(
+            ServeConfig::from_args(a.clone()).unwrap().history,
+            HistoryBackendSpec::Postgres(_)
+        ));
+        a.history = Some("sqlite:runs.db".into());
+        assert!(matches!(
+            ServeConfig::from_args(a).unwrap().history,
+            HistoryBackendSpec::Sqlite(_)
+        ));
+    }
+}

--- a/cli/src/serve/config.rs
+++ b/cli/src/serve/config.rs
@@ -22,9 +22,11 @@ pub enum AuthMode {
 pub enum HistoryBackendSpec {
     /// In-process `DashMap`; lost on restart (default).
     Memory,
-    /// Postgres connection URL.
+    /// Postgres connection URL (stored verbatim, e.g. `postgres://host/db`).
     Postgres(String),
-    /// SQLite path / URL.
+    /// SQLite connection URL, stored verbatim including the `sqlite:` scheme
+    /// (e.g. `sqlite:runs.db`, `sqlite::memory:`) so the backend can hand it
+    /// straight to `sqlx` without re-deriving the form.
     Sqlite(String),
 }
 
@@ -60,6 +62,13 @@ impl ServeConfig {
     /// no-auth gate: a server with neither a token nor `--no-auth` refuses to start.
     pub fn from_args(args: ServeArgs) -> CliResult<Self> {
         let auth = match (args.auth_token, args.no_auth) {
+            (Some(t), _) if t.is_empty() => {
+                return Err(CliError::Serve(
+                    "--auth-token / FAUCET_SERVE_AUTH_TOKEN must not be empty \
+                     (use --no-auth to explicitly disable authentication)"
+                        .into(),
+                ));
+            }
             (Some(t), _) => AuthMode::Token(t),
             (None, true) => AuthMode::None,
             (None, false) => {
@@ -81,9 +90,7 @@ impl ServeConfig {
             Some(u) if u.starts_with("postgres://") || u.starts_with("postgresql://") => {
                 HistoryBackendSpec::Postgres(u)
             }
-            Some(u) if u.starts_with("sqlite:") => {
-                HistoryBackendSpec::Sqlite(u.trim_start_matches("sqlite:").to_string())
-            }
+            Some(u) if u.starts_with("sqlite:") => HistoryBackendSpec::Sqlite(u),
             Some(u) => {
                 return Err(CliError::Serve(format!(
                     "unrecognised --history '{u}': use a postgres:// URL or sqlite:<path>"
@@ -97,7 +104,7 @@ impl ServeConfig {
             .max(1);
         let max_queued_runs = args
             .max_queued_runs
-            .unwrap_or(max_concurrent_runs * 8)
+            .unwrap_or_else(|| max_concurrent_runs.saturating_mul(8))
             .max(1);
 
         Ok(Self {
@@ -184,10 +191,43 @@ mod tests {
             ServeConfig::from_args(a.clone()).unwrap().history,
             HistoryBackendSpec::Postgres(_)
         ));
-        a.history = Some("sqlite:runs.db".into());
+        // The `postgresql://` alias maps to the same backend.
+        a.history = Some("postgresql://localhost/db".into());
         assert!(matches!(
-            ServeConfig::from_args(a).unwrap().history,
-            HistoryBackendSpec::Sqlite(_)
+            ServeConfig::from_args(a.clone()).unwrap().history,
+            HistoryBackendSpec::Postgres(_)
         ));
+        // SQLite is stored verbatim, scheme included (for direct sqlx use).
+        a.history = Some("sqlite:runs.db".into());
+        match ServeConfig::from_args(a).unwrap().history {
+            HistoryBackendSpec::Sqlite(url) => assert_eq!(url, "sqlite:runs.db"),
+            other => panic!("expected Sqlite, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn empty_token_is_rejected() {
+        let mut a = base_args();
+        a.auth_token = Some(String::new());
+        let err = ServeConfig::from_args(a).unwrap_err();
+        assert!(err.to_string().contains("must not be empty"), "{err}");
+    }
+
+    #[test]
+    fn invalid_listen_returns_error() {
+        let mut a = base_args();
+        a.no_auth = true;
+        a.listen = "not-a-socket".into();
+        let err = ServeConfig::from_args(a).unwrap_err();
+        assert!(err.to_string().contains("invalid --listen"), "{err}");
+    }
+
+    #[test]
+    fn unrecognised_history_scheme_returns_error() {
+        let mut a = base_args();
+        a.no_auth = true;
+        a.history = Some("mysql://localhost/db".into());
+        let err = ServeConfig::from_args(a).unwrap_err();
+        assert!(err.to_string().contains("unrecognised --history"), "{err}");
     }
 }

--- a/cli/src/serve/config.rs
+++ b/cli/src/serve/config.rs
@@ -47,6 +47,9 @@ pub struct ServeConfig {
     pub probe_timeout: Duration,
     pub env_file: Option<PathBuf>,
     pub no_env_file: bool,
+    /// Tracing filter directive for serve's own subscriber. Set from the
+    /// clap-resolved `--log-level` / `FAUCET_LOG`; defaults to `"info"`.
+    pub log_level: String,
 }
 
 fn default_max_concurrent() -> usize {
@@ -122,6 +125,7 @@ impl ServeConfig {
             probe_timeout: Duration::from_secs(args.probe_timeout_secs),
             env_file: args.env_file,
             no_env_file: args.no_env_file,
+            log_level: "info".to_string(),
         })
     }
 }

--- a/cli/src/serve/config.rs
+++ b/cli/src/serve/config.rs
@@ -1,0 +1,1 @@
+//! Placeholder — implemented in Task 2.

--- a/cli/src/serve/error.rs
+++ b/cli/src/serve/error.rs
@@ -98,5 +98,23 @@ mod tests {
         let body = ServeError::NotFound.api_error();
         assert_eq!(body.error.code, "not_found");
         assert!(!body.error.message.is_empty());
+
+        // Fixed-message variant carries the expected static text.
+        let body = ServeError::Unauthorized.api_error();
+        assert_eq!(body.error.code, "unauthorized");
+        assert_eq!(body.error.message, "missing or invalid bearer token");
+    }
+
+    #[test]
+    fn dynamic_message_variants_round_trip_to_body() {
+        // BadConfig / Internal carry caller-supplied text — confirm it reaches
+        // the body intact (the redaction pass leaves non-secret text unchanged).
+        let body = ServeError::BadConfig("bad thing".into()).api_error();
+        assert_eq!(body.error.code, "bad_config");
+        assert_eq!(body.error.message, "bad thing");
+
+        let body = ServeError::Internal("boom".into()).api_error();
+        assert_eq!(body.error.code, "internal");
+        assert_eq!(body.error.message, "boom");
     }
 }

--- a/cli/src/serve/error.rs
+++ b/cli/src/serve/error.rs
@@ -1,0 +1,1 @@
+//! Placeholder — implemented in Task 3.

--- a/cli/src/serve/error.rs
+++ b/cli/src/serve/error.rs
@@ -1,1 +1,102 @@
-//! Placeholder — implemented in Task 3.
+//! HTTP-facing error type. Every fallible serve handler returns `ServeError`,
+//! which renders to a JSON `ApiError` body with the right status code.
+
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use serde::Serialize;
+
+/// JSON error envelope: `{ "error": { "code": "...", "message": "..." } }`.
+#[derive(Debug, Serialize)]
+pub struct ApiError {
+    pub error: ApiErrorBody,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ApiErrorBody {
+    pub code: String,
+    pub message: String,
+}
+
+/// All error outcomes a serve handler can produce. (More variants — 413, 429,
+/// 409, 422 — arrive with the endpoints that raise them in later phases.)
+#[derive(Debug)]
+pub enum ServeError {
+    Unauthorized,
+    NotFound,
+    BadConfig(String),
+    Internal(String),
+}
+
+impl ServeError {
+    pub fn status(&self) -> StatusCode {
+        match self {
+            ServeError::Unauthorized => StatusCode::UNAUTHORIZED,
+            ServeError::NotFound => StatusCode::NOT_FOUND,
+            ServeError::BadConfig(_) => StatusCode::BAD_REQUEST,
+            ServeError::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+
+    fn code(&self) -> &'static str {
+        match self {
+            ServeError::Unauthorized => "unauthorized",
+            ServeError::NotFound => "not_found",
+            ServeError::BadConfig(_) => "bad_config",
+            ServeError::Internal(_) => "internal",
+        }
+    }
+
+    fn message(&self) -> String {
+        match self {
+            ServeError::Unauthorized => "missing or invalid bearer token".into(),
+            ServeError::NotFound => "not found".into(),
+            ServeError::BadConfig(m) => m.clone(),
+            ServeError::Internal(m) => m.clone(),
+        }
+    }
+
+    pub fn api_error(&self) -> ApiError {
+        // Scrub any resolved secret that reached the message.
+        let message = crate::secrets::registry::redact(&self.message()).into_owned();
+        ApiError {
+            error: ApiErrorBody {
+                code: self.code().to_string(),
+                message,
+            },
+        }
+    }
+}
+
+impl IntoResponse for ServeError {
+    fn into_response(self) -> Response {
+        (self.status(), Json(self.api_error())).into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::StatusCode;
+
+    #[test]
+    fn maps_variants_to_status_codes() {
+        assert_eq!(ServeError::Unauthorized.status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(ServeError::NotFound.status(), StatusCode::NOT_FOUND);
+        assert_eq!(
+            ServeError::BadConfig("nope".into()).status(),
+            StatusCode::BAD_REQUEST
+        );
+        assert_eq!(
+            ServeError::Internal("boom".into()).status(),
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
+    }
+
+    #[test]
+    fn body_carries_code_and_message() {
+        let body = ServeError::NotFound.api_error();
+        assert_eq!(body.error.code, "not_found");
+        assert!(!body.error.message.is_empty());
+    }
+}

--- a/cli/src/serve/error.rs
+++ b/cli/src/serve/error.rs
@@ -1,9 +1,9 @@
 //! HTTP-facing error type. Every fallible serve handler returns `ServeError`,
 //! which renders to a JSON `ApiError` body with the right status code.
 
+use axum::Json;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use axum::Json;
 use serde::Serialize;
 
 /// JSON error envelope: `{ "error": { "code": "...", "message": "..." } }`.

--- a/cli/src/serve/handlers/health.rs
+++ b/cli/src/serve/handlers/health.rs
@@ -26,8 +26,13 @@ pub async fn metrics(State(state): State<ServerState>) -> Response {
             body,
         )
             .into_response(),
+        // 503 (not 200) so a Prometheus scraper marks the target down rather
+        // than silently recording a successful scrape with zero metrics. This
+        // only fires if the recorder failed to install (e.g. a second server in
+        // one process); in normal operation `render_metrics()` is `Some`.
         None => (
-            StatusCode::OK,
+            StatusCode::SERVICE_UNAVAILABLE,
+            [(header::CONTENT_TYPE, "text/plain; version=0.0.4")],
             "# metrics recorder not installed in this process\n",
         )
             .into_response(),

--- a/cli/src/serve/handlers/health.rs
+++ b/cli/src/serve/handlers/health.rs
@@ -1,1 +1,35 @@
-//! Health / metrics endpoints — implemented in Task 6.
+//! Liveness (`/healthz`), readiness (`/readyz`), and Prometheus (`/metrics`)
+//! endpoints. All three are unauthenticated (probes / scrapers). Phase 1
+//! `/readyz` is always-ready; it gains history-degraded / queue-full checks in
+//! later phases.
+
+use crate::serve::state::ServerState;
+use axum::extract::State;
+use axum::http::{header, StatusCode};
+use axum::response::{IntoResponse, Response};
+
+/// Liveness: a responding handler means the process is alive.
+pub async fn healthz() -> impl IntoResponse {
+    StatusCode::OK
+}
+
+/// Readiness: ready to accept work. Phase 1 is unconditionally ready.
+pub async fn readyz() -> impl IntoResponse {
+    StatusCode::OK
+}
+
+/// Prometheus exposition rendered from serve's own recorder handle.
+pub async fn metrics(State(state): State<ServerState>) -> Response {
+    match state.render_metrics() {
+        Some(body) => (
+            [(header::CONTENT_TYPE, "text/plain; version=0.0.4")],
+            body,
+        )
+            .into_response(),
+        None => (
+            StatusCode::OK,
+            "# metrics recorder not installed in this process\n",
+        )
+            .into_response(),
+    }
+}

--- a/cli/src/serve/handlers/health.rs
+++ b/cli/src/serve/handlers/health.rs
@@ -1,0 +1,1 @@
+//! Health / metrics endpoints — implemented in Task 6.

--- a/cli/src/serve/handlers/health.rs
+++ b/cli/src/serve/handlers/health.rs
@@ -5,7 +5,7 @@
 
 use crate::serve::state::ServerState;
 use axum::extract::State;
-use axum::http::{header, StatusCode};
+use axum::http::{StatusCode, header};
 use axum::response::{IntoResponse, Response};
 
 /// Liveness: a responding handler means the process is alive.
@@ -21,11 +21,7 @@ pub async fn readyz() -> impl IntoResponse {
 /// Prometheus exposition rendered from serve's own recorder handle.
 pub async fn metrics(State(state): State<ServerState>) -> Response {
     match state.render_metrics() {
-        Some(body) => (
-            [(header::CONTENT_TYPE, "text/plain; version=0.0.4")],
-            body,
-        )
-            .into_response(),
+        Some(body) => ([(header::CONTENT_TYPE, "text/plain; version=0.0.4")], body).into_response(),
         // 503 (not 200) so a Prometheus scraper marks the target down rather
         // than silently recording a successful scrape with zero metrics. This
         // only fires if the recorder failed to install (e.g. a second server in

--- a/cli/src/serve/handlers/mod.rs
+++ b/cli/src/serve/handlers/mod.rs
@@ -1,0 +1,2 @@
+//! serve HTTP handlers.
+pub mod health;

--- a/cli/src/serve/metrics.rs
+++ b/cli/src/serve/metrics.rs
@@ -47,7 +47,10 @@ mod tests {
 
     #[test]
     fn unmatched_path_falls_back_to_sentinel() {
-        let req = Request::builder().uri("/whatever").body(axum::body::Body::empty()).unwrap();
+        let req = Request::builder()
+            .uri("/whatever")
+            .body(axum::body::Body::empty())
+            .unwrap();
         assert_eq!(matched_path_label(&req), "<unmatched>");
     }
 }

--- a/cli/src/serve/metrics.rs
+++ b/cli/src/serve/metrics.rs
@@ -1,1 +1,50 @@
-//! Placeholder — implemented in Task 5.
+//! `faucet_serve_*` request metrics. The `path` label is the *matched route
+//! template* (`/v1/runs/{id}`), never the raw path — cardinality safety.
+
+use axum::extract::{MatchedPath, Request};
+use axum::middleware::Next;
+use axum::response::Response;
+use std::time::Instant;
+
+/// The matched route template for a request, or `<unmatched>` for a 404.
+pub fn matched_path_label(req: &Request) -> String {
+    req.extensions()
+        .get::<MatchedPath>()
+        .map(|m| m.as_str().to_owned())
+        .unwrap_or_else(|| "<unmatched>".to_string())
+}
+
+/// Middleware: count every request + record its duration, labelled by method,
+/// matched-path template, and response status.
+pub async fn track_metrics(req: Request, next: Next) -> Response {
+    let method = req.method().as_str().to_owned();
+    let path = matched_path_label(&req);
+    let start = Instant::now();
+    let resp = next.run(req).await;
+    let status = resp.status().as_u16().to_string();
+
+    metrics::counter!(
+        "faucet_serve_requests_total",
+        "method" => method.clone(), "path" => path.clone(), "status" => status
+    )
+    .increment(1);
+    metrics::histogram!(
+        "faucet_serve_request_duration_seconds",
+        "method" => method, "path" => path
+    )
+    .record(start.elapsed().as_secs_f64());
+
+    resp
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::extract::Request;
+
+    #[test]
+    fn unmatched_path_falls_back_to_sentinel() {
+        let req = Request::builder().uri("/whatever").body(axum::body::Body::empty()).unwrap();
+        assert_eq!(matched_path_label(&req), "<unmatched>");
+    }
+}

--- a/cli/src/serve/metrics.rs
+++ b/cli/src/serve/metrics.rs
@@ -1,0 +1,1 @@
+//! Placeholder — implemented in Task 5.

--- a/cli/src/serve/metrics.rs
+++ b/cli/src/serve/metrics.rs
@@ -28,6 +28,9 @@ pub async fn track_metrics(req: Request, next: Next) -> Response {
         "method" => method.clone(), "path" => path.clone(), "status" => status
     )
     .increment(1);
+    // `status` is intentionally omitted from the histogram to cap series count
+    // (a duration histogram per status code multiplies time-series); join with
+    // the counter when a status breakdown is needed.
     metrics::histogram!(
         "faucet_serve_request_duration_seconds",
         "method" => method, "path" => path

--- a/cli/src/serve/mod.rs
+++ b/cli/src/serve/mod.rs
@@ -13,3 +13,10 @@ pub mod server;
 pub mod state;
 
 pub use config::ServeConfig;
+
+use crate::error::CliResult;
+
+/// Boot the HTTP control plane and serve until SIGTERM/SIGINT.
+pub async fn run_server(config: ServeConfig) -> CliResult<()> {
+    server::serve(config).await
+}

--- a/cli/src/serve/mod.rs
+++ b/cli/src/serve/mod.rs
@@ -11,3 +11,5 @@ pub mod metrics;
 pub mod observability;
 pub mod server;
 pub mod state;
+
+pub use config::ServeConfig;

--- a/cli/src/serve/mod.rs
+++ b/cli/src/serve/mod.rs
@@ -1,0 +1,13 @@
+//! `faucet serve` — HTTP control plane (#127). Runs pipeline configs submitted
+//! over HTTP, reusing `executor::run_expanded`. Feature-gated on `serve`;
+//! structured like `cli/src/schedule/`. See
+//! `docs/superpowers/specs/2026-05-30-faucet-serve-design.md`.
+
+pub mod auth;
+pub mod config;
+pub mod error;
+pub mod handlers;
+pub mod metrics;
+pub mod observability;
+pub mod server;
+pub mod state;

--- a/cli/src/serve/observability.rs
+++ b/cli/src/serve/observability.rs
@@ -1,0 +1,1 @@
+//! Placeholder — implemented in Task 7.

--- a/cli/src/serve/observability.rs
+++ b/cli/src/serve/observability.rs
@@ -1,1 +1,44 @@
-//! Placeholder — implemented in Task 7.
+//! serve-owned observability: install the Prometheus recorder (returning a
+//! render handle for the `/metrics` route) and a tracing subscriber whose fmt
+//! layer routes through the secret-redacting writer. Both are process-global and
+//! set-once; a second install in the same process is tolerated (returns no
+//! handle / leaves the existing subscriber).
+
+use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
+
+/// Install the recorder + tracing subscriber. Returns the render handle when
+/// this call installed the recorder; `None` if a recorder was already present.
+pub fn install(level: &str) -> Option<PrometheusHandle> {
+    let handle = match PrometheusBuilder::new().install_recorder() {
+        Ok(h) => Some(h),
+        Err(e) => {
+            tracing::warn!("Prometheus recorder already installed or failed: {e}");
+            None
+        }
+    };
+    // Register faucet_build_info into whatever recorder is now global.
+    faucet_core::register_build_info();
+
+    install_subscriber(level);
+    handle
+}
+
+#[cfg(feature = "observability")]
+fn install_subscriber(level: &str) {
+    use crate::secrets::registry::RedactingMakeWriter;
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::util::SubscriberInitExt;
+    use tracing_subscriber::EnvFilter;
+
+    let filter = EnvFilter::try_new(level).unwrap_or_else(|_| EnvFilter::new("info"));
+    let registry = tracing_subscriber::registry()
+        .with(filter)
+        .with(tracing_subscriber::fmt::layer().with_writer(RedactingMakeWriter));
+    // A later phase adds the per-run SSE log layer here.
+    if registry.try_init().is_err() {
+        tracing::warn!("tracing subscriber already installed; continuing");
+    }
+}
+
+#[cfg(not(feature = "observability"))]
+fn install_subscriber(_level: &str) {}

--- a/cli/src/serve/observability.rs
+++ b/cli/src/serve/observability.rs
@@ -26,9 +26,9 @@ pub fn install(level: &str) -> Option<PrometheusHandle> {
 #[cfg(feature = "observability")]
 fn install_subscriber(level: &str) {
     use crate::secrets::registry::RedactingMakeWriter;
+    use tracing_subscriber::EnvFilter;
     use tracing_subscriber::layer::SubscriberExt;
     use tracing_subscriber::util::SubscriberInitExt;
-    use tracing_subscriber::EnvFilter;
 
     let filter = EnvFilter::try_new(level).unwrap_or_else(|_| EnvFilter::new("info"));
     let registry = tracing_subscriber::registry()

--- a/cli/src/serve/server.rs
+++ b/cli/src/serve/server.rs
@@ -5,8 +5,8 @@ use crate::serve::config::ServeConfig;
 use crate::serve::handlers::health;
 use crate::serve::state::ServerState;
 use crate::serve::{auth, metrics};
-use axum::routing::get;
 use axum::Router;
+use axum::routing::get;
 use tokio_util::sync::CancellationToken;
 use tower_http::cors::{AllowOrigin, CorsLayer};
 use tower_http::limit::RequestBodyLimitLayer;
@@ -97,7 +97,7 @@ pub async fn serve(config: ServeConfig) -> CliResult<()> {
 async fn wait_for_signal() {
     #[cfg(unix)]
     {
-        use tokio::signal::unix::{signal, SignalKind};
+        use tokio::signal::unix::{SignalKind, signal};
         let mut term = match signal(SignalKind::terminate()) {
             Ok(s) => s,
             Err(_) => {

--- a/cli/src/serve/server.rs
+++ b/cli/src/serve/server.rs
@@ -33,6 +33,9 @@ pub fn build_router(state: ServerState, config: &ServeConfig) -> Router {
         auth::require_auth,
     ));
 
+    // No origins configured → `CorsLayer::new()` emits no `Access-Control-*`
+    // headers, so browsers block cross-origin requests (CORS effectively off).
+    // The layer is a cheap pass-through for non-browser clients.
     let cors = if config.cors_origins.is_empty() {
         CorsLayer::new()
     } else {

--- a/cli/src/serve/server.rs
+++ b/cli/src/serve/server.rs
@@ -43,7 +43,13 @@ pub fn build_router(state: ServerState, config: &ServeConfig) -> Router {
         let origins: Vec<axum::http::HeaderValue> = config
             .cors_origins
             .iter()
-            .filter_map(|o| o.parse().ok())
+            .filter_map(|o| match o.parse() {
+                Ok(v) => Some(v),
+                Err(e) => {
+                    tracing::warn!(origin = %o, error = %e, "ignoring invalid --cors-origin");
+                    None
+                }
+            })
             .collect();
         CorsLayer::new().allow_origin(AllowOrigin::list(origins))
     };
@@ -59,8 +65,7 @@ pub fn build_router(state: ServerState, config: &ServeConfig) -> Router {
 /// Boot the server: install observability, build the router, bind the listener,
 /// and serve until SIGTERM / SIGINT, then drain.
 pub async fn serve(config: ServeConfig) -> CliResult<()> {
-    let level = std::env::var("FAUCET_LOG").unwrap_or_else(|_| "info".to_string());
-    let prom = crate::serve::observability::install(&level);
+    let prom = crate::serve::observability::install(&config.log_level);
 
     let shutdown = CancellationToken::new();
     let state = ServerState::new(&config, prom, shutdown.clone());

--- a/cli/src/serve/server.rs
+++ b/cli/src/serve/server.rs
@@ -1,0 +1,1 @@
+//! Placeholder — implemented in Task 6/7.

--- a/cli/src/serve/server.rs
+++ b/cli/src/serve/server.rs
@@ -1,1 +1,53 @@
-//! Placeholder — implemented in Task 6/7.
+//! axum router assembly. The bind / graceful-shutdown serve loop is added in
+//! the next task; this file currently only builds the router.
+
+use crate::serve::config::ServeConfig;
+use crate::serve::handlers::health;
+use crate::serve::state::ServerState;
+use crate::serve::{auth, metrics};
+use axum::routing::get;
+use axum::Router;
+use tower_http::cors::{AllowOrigin, CorsLayer};
+use tower_http::limit::RequestBodyLimitLayer;
+
+/// Build the full router. `/v1/*` routes are added in a later phase; here the
+/// API sub-router is empty but carries the auth layer, and health/metrics are
+/// public. The middleware stack (body-limit, request metrics, CORS) is wired
+/// from the start so its ordering is correct.
+///
+/// Note: axum 0.8 rejects `route_layer` on a `Router` with no routes, so the
+/// auth middleware is attached via `.layer(...)` on the empty api sub-router.
+/// TODO(phase 2): switch /v1 routes to `route_layer` once routes land.
+pub fn build_router(state: ServerState, config: &ServeConfig) -> Router {
+    // Unauthenticated probe/scrape endpoints.
+    let public = Router::new()
+        .route("/healthz", get(health::healthz))
+        .route("/readyz", get(health::readyz))
+        .route("/metrics", get(health::metrics));
+
+    // Authenticated API surface (routes land in a later phase).
+    // Using `.layer(...)` rather than `route_layer` because axum 0.8 rejects
+    // `route_layer` on a Router with no routes.
+    let api = Router::new().layer(axum::middleware::from_fn_with_state(
+        state.clone(),
+        auth::require_auth,
+    ));
+
+    let cors = if config.cors_origins.is_empty() {
+        CorsLayer::new()
+    } else {
+        let origins: Vec<axum::http::HeaderValue> = config
+            .cors_origins
+            .iter()
+            .filter_map(|o| o.parse().ok())
+            .collect();
+        CorsLayer::new().allow_origin(AllowOrigin::list(origins))
+    };
+
+    public
+        .merge(api)
+        .layer(RequestBodyLimitLayer::new(config.body_limit_bytes))
+        .layer(axum::middleware::from_fn(metrics::track_metrics))
+        .layer(cors)
+        .with_state(state)
+}

--- a/cli/src/serve/server.rs
+++ b/cli/src/serve/server.rs
@@ -1,12 +1,13 @@
-//! axum router assembly. The bind / graceful-shutdown serve loop is added in
-//! the next task; this file currently only builds the router.
+//! axum router assembly and the bind / graceful-shutdown serve loop.
 
+use crate::error::{CliError, CliResult};
 use crate::serve::config::ServeConfig;
 use crate::serve::handlers::health;
 use crate::serve::state::ServerState;
 use crate::serve::{auth, metrics};
 use axum::routing::get;
 use axum::Router;
+use tokio_util::sync::CancellationToken;
 use tower_http::cors::{AllowOrigin, CorsLayer};
 use tower_http::limit::RequestBodyLimitLayer;
 
@@ -53,4 +54,59 @@ pub fn build_router(state: ServerState, config: &ServeConfig) -> Router {
         .layer(axum::middleware::from_fn(metrics::track_metrics))
         .layer(cors)
         .with_state(state)
+}
+
+/// Boot the server: install observability, build the router, bind the listener,
+/// and serve until SIGTERM / SIGINT, then drain.
+pub async fn serve(config: ServeConfig) -> CliResult<()> {
+    let level = std::env::var("FAUCET_LOG").unwrap_or_else(|_| "info".to_string());
+    let prom = crate::serve::observability::install(&level);
+
+    let shutdown = CancellationToken::new();
+    let state = ServerState::new(&config, prom, shutdown.clone());
+    let app = build_router(state, &config);
+
+    let listener = tokio::net::TcpListener::bind(config.listen)
+        .await
+        .map_err(|e| CliError::Serve(format!("failed to bind {}: {e}", config.listen)))?;
+    let local = listener
+        .local_addr()
+        .map_err(|e| CliError::Serve(e.to_string()))?;
+    tracing::info!(listen = %local, "faucet serve listening");
+
+    let shutdown_for_axum = shutdown.clone();
+    axum::serve(listener, app)
+        .with_graceful_shutdown(async move {
+            wait_for_signal().await;
+            tracing::info!("shutdown signal received; draining");
+            shutdown_for_axum.cancel();
+        })
+        .await
+        .map_err(|e| CliError::Serve(format!("server error: {e}")))?;
+
+    // A later phase awaits in-flight run tasks up to config.shutdown_grace, then cancels.
+    Ok(())
+}
+
+/// Resolve on SIGTERM (Unix) or Ctrl-C (any platform).
+async fn wait_for_signal() {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{signal, SignalKind};
+        let mut term = match signal(SignalKind::terminate()) {
+            Ok(s) => s,
+            Err(_) => {
+                let _ = tokio::signal::ctrl_c().await;
+                return;
+            }
+        };
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {}
+            _ = term.recv() => {}
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = tokio::signal::ctrl_c().await;
+    }
 }

--- a/cli/src/serve/state.rs
+++ b/cli/src/serve/state.rs
@@ -1,0 +1,1 @@
+//! Placeholder — implemented in Task 6.

--- a/cli/src/serve/state.rs
+++ b/cli/src/serve/state.rs
@@ -74,6 +74,7 @@ mod tests {
             probe_timeout: Duration::from_secs(10),
             env_file: None,
             no_env_file: false,
+            log_level: "info".into(),
         }
     }
 

--- a/cli/src/serve/state.rs
+++ b/cli/src/serve/state.rs
@@ -1,1 +1,93 @@
-//! Placeholder — implemented in Task 6.
+//! Shared, cheaply-cloneable server state handed to every handler via
+//! `axum::extract::State`. Phase 1 holds auth + the Prometheus render handle +
+//! the server-wide shutdown token. Later phases add the run registry + history.
+
+use crate::serve::config::{AuthMode, ServeConfig};
+use metrics_exporter_prometheus::PrometheusHandle;
+use std::sync::Arc;
+use tokio_util::sync::CancellationToken;
+
+#[derive(Clone)]
+pub struct ServerState {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    auth: AuthMode,
+    prometheus: Option<PrometheusHandle>,
+    shutdown: CancellationToken,
+}
+
+impl ServerState {
+    pub fn new(
+        config: &ServeConfig,
+        prometheus: Option<PrometheusHandle>,
+        shutdown: CancellationToken,
+    ) -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                auth: config.auth.clone(),
+                prometheus,
+                shutdown,
+            }),
+        }
+    }
+
+    /// The expected bearer token, or `None` when started with `--no-auth`.
+    pub fn auth_token(&self) -> Option<&str> {
+        match &self.inner.auth {
+            AuthMode::Token(t) => Some(t),
+            AuthMode::None => None,
+        }
+    }
+
+    /// Render the current Prometheus exposition, or `None` if no recorder handle
+    /// was installed (e.g. a second server in the same test process).
+    pub fn render_metrics(&self) -> Option<String> {
+        self.inner.prometheus.as_ref().map(|h| h.render())
+    }
+
+    pub fn shutdown_token(&self) -> CancellationToken {
+        self.inner.shutdown.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::serve::config::HistoryBackendSpec;
+    use std::time::Duration;
+
+    fn cfg(auth: AuthMode) -> ServeConfig {
+        ServeConfig {
+            listen: "127.0.0.1:0".parse().unwrap(),
+            auth,
+            max_concurrent_runs: 4,
+            max_queued_runs: 32,
+            default_config_path: None,
+            history: HistoryBackendSpec::Memory,
+            cors_origins: vec![],
+            body_limit_bytes: 1_048_576,
+            shutdown_grace: Duration::from_secs(60),
+            retain_terminal_runs: Duration::from_secs(60),
+            idempotency_retention: Duration::from_secs(60),
+            probe_timeout: Duration::from_secs(10),
+            env_file: None,
+            no_env_file: false,
+        }
+    }
+
+    #[test]
+    fn auth_token_reflects_mode() {
+        let s = ServerState::new(&cfg(AuthMode::Token("x".into())), None, CancellationToken::new());
+        assert_eq!(s.auth_token(), Some("x"));
+        let s = ServerState::new(&cfg(AuthMode::None), None, CancellationToken::new());
+        assert_eq!(s.auth_token(), None);
+    }
+
+    #[test]
+    fn render_metrics_none_without_handle() {
+        let s = ServerState::new(&cfg(AuthMode::None), None, CancellationToken::new());
+        assert!(s.render_metrics().is_none());
+    }
+}

--- a/cli/src/serve/state.rs
+++ b/cli/src/serve/state.rs
@@ -80,7 +80,11 @@ mod tests {
 
     #[test]
     fn auth_token_reflects_mode() {
-        let s = ServerState::new(&cfg(AuthMode::Token("x".into())), None, CancellationToken::new());
+        let s = ServerState::new(
+            &cfg(AuthMode::Token("x".into())),
+            None,
+            CancellationToken::new(),
+        );
         assert_eq!(s.auth_token(), Some("x"));
         let s = ServerState::new(&cfg(AuthMode::None), None, CancellationToken::new());
         assert_eq!(s.auth_token(), None);

--- a/cli/tests/serve_skeleton.rs
+++ b/cli/tests/serve_skeleton.rs
@@ -1,0 +1,60 @@
+//! Phase-1 smoke test: the server boots on an ephemeral port, answers
+//! `/healthz` and `/metrics` without auth, and shuts down on signal.
+#![cfg(feature = "serve")]
+
+use faucet_cli::serve::{run_server, ServeConfig};
+use std::time::Duration;
+
+/// Build a ServeConfig bound to a given address with auth disabled.
+fn test_config(listen: &str) -> ServeConfig {
+    let args = faucet_cli::cli::ServeArgs {
+        listen: listen.into(),
+        auth_token: None,
+        no_auth: true,
+        max_concurrent_runs: Some(2),
+        max_queued_runs: Some(8),
+        default_config: None,
+        history: None,
+        cors_origin: vec![],
+        body_limit_bytes: 1_048_576,
+        shutdown_grace_secs: 5,
+        retain_terminal_runs_secs: 60,
+        idempotency_retention_secs: 60,
+        probe_timeout_secs: 5,
+        env_file: None,
+        no_env_file: true,
+    };
+    ServeConfig::from_args(args).unwrap()
+}
+
+#[tokio::test]
+async fn healthz_is_reachable_without_auth() {
+    // Bind a throwaway listener to grab a free port, then release it.
+    let probe = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = probe.local_addr().unwrap().port();
+    drop(probe);
+    let listen = format!("127.0.0.1:{port}");
+
+    let cfg = test_config(&listen);
+    let server = tokio::spawn(run_server(cfg));
+
+    let url = format!("http://{listen}");
+    let client = reqwest::Client::new();
+    let mut ok = false;
+    for _ in 0..50 {
+        if let Ok(resp) = client.get(format!("{url}/healthz")).send().await {
+            assert_eq!(resp.status(), 200);
+            ok = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    assert!(ok, "server never became reachable on {listen}");
+
+    // /metrics is reachable unauthenticated too (200 since the recorder installs
+    // in this single-server test process).
+    let resp = client.get(format!("{url}/metrics")).send().await.unwrap();
+    assert_eq!(resp.status(), 200);
+
+    server.abort();
+}

--- a/cli/tests/serve_skeleton.rs
+++ b/cli/tests/serve_skeleton.rs
@@ -29,7 +29,10 @@ fn test_config(listen: &str) -> ServeConfig {
 
 #[tokio::test]
 async fn healthz_is_reachable_without_auth() {
-    // Bind a throwaway listener to grab a free port, then release it.
+    // Grab a free port via a throwaway listener, then bind serve to it. There is
+    // a small TOCTOU window where another process could claim the port between
+    // drop and re-bind; acceptable for a smoke test. A later phase can have
+    // `serve()` bind `:0` and report the chosen address to remove the window.
     let probe = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
     let port = probe.local_addr().unwrap().port();
     drop(probe);

--- a/cli/tests/serve_skeleton.rs
+++ b/cli/tests/serve_skeleton.rs
@@ -2,7 +2,7 @@
 //! `/healthz` and `/metrics` without auth, and shuts down on signal.
 #![cfg(feature = "serve")]
 
-use faucet_cli::serve::{run_server, ServeConfig};
+use faucet_cli::serve::{ServeConfig, run_server};
 use std::time::Duration;
 
 /// Build a ServeConfig bound to a given address with auth disabled.


### PR DESCRIPTION
## Summary

Phase 1 of `faucet serve` (#127) — a long-running HTTP control-plane mode for the `faucet` CLI. This is the **shippable skeleton**: the server boots, enforces auth, serves health/metrics, wires the middleware stack, and shuts down gracefully. The run-execution surface (`POST /v1/runs`, history, idempotency, SSE logs) is **intentionally deferred to Phases 2–6**.

This is **Phase 1 of 6** for #127 — the issue stays open; subsequent phases land as follow-up PRs.

## Placement decision (supersedes the issue's "new crate" text)

`serve` is built as a feature-gated subsystem **inside the `faucet-cli` crate** (`cli/src/serve/`), mirroring how `faucet schedule` lives in `cli/src/schedule/`. A standalone `faucet-serve` crate would create a dependency cycle (it needs the executor/expand/config that live in `faucet-cli`, which must also dispatch into serve). Design spec: `docs/superpowers/specs/2026-05-30-faucet-serve-design.md`.

## What's included

- `serve` Cargo feature (CLI-only, in `full`); optional deps `axum 0.8` / `tower-http` / `tokio-util` / `subtle`; `serve-history-postgres` / `serve-history-sqlite` feature stubs.
- `ServeConfig` + `ServeArgs` with a **mandatory no-auth gate** (refuses to start without `--auth-token`/`FAUCET_SERVE_AUTH_TOKEN` or an explicit `--no-auth`), empty-token rejection, loopback-default bind.
- Bearer auth middleware (constant-time compare via `subtle`, OPTIONS preflight bypass), `ServeError` → JSON `ApiError` with secret redaction.
- Request metrics (`faucet_serve_requests_total` / `_request_duration_seconds`) labelled by matched-route template (cardinality-safe).
- `/healthz`, `/readyz`, `/metrics` (unauthenticated); serve-owned Prometheus recorder rendered on its own port; serve-owned redacting tracing subscriber honoring `--log-level`.
- Graceful shutdown (SIGTERM + Ctrl-C → `CancellationToken` → axum drain).
- `faucet serve` subcommand wired in `main.rs`; CI `feature-check` matrix entry + CLI-only routing.

## Testing

- 17 unit tests (config / error / state / auth / metrics) + 1 integration smoke test (boots on an ephemeral port, `/healthz` + `/metrics` reachable unauthenticated).
- `cargo build`/`clippy --all-features -D warnings`/`fmt --check` clean.

## Out of scope (Phases 2–6)

Run lifecycle + history backends, idempotency + `doctor_first` + `--default-config`, SSE log streaming, persistent Postgres/SQLite history, OpenAPI + docs + CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)