### PR TITLE
feat(core): adaptive AIMD batch sizing (#128)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,11 @@ can drop on any box or a library you compile in.
 - **A runtime, not just connectors** — incremental + resumable replication,
   PostgreSQL change-data-capture, built-in data-quality checks (13 per-record and
   per-batch assertions with quarantine routing and abort policies), dead-letter
-  queues, automatic retries, secrets-manager interpolation (`${vault:…}`,
-  `${aws-sm:…}`, `${gcp-sm:…}`, `${azure-kv:…}`), cron scheduling (`faucet schedule`),
-  and built-in Prometheus metrics + `tracing` spans, all with zero per-connector code.
+  queues, automatic retries, adaptive batch sizing (AIMD controller that tunes
+  write batch size from sink latency and error rate), secrets-manager interpolation
+  (`${vault:…}`, `${aws-sm:…}`, `${gcp-sm:…}`, `${azure-kv:…}`), cron scheduling
+  (`faucet schedule`), and built-in Prometheus metrics + `tracing` spans, all with
+  zero per-connector code.
 - **Pay only for what you use** — every connector is a Cargo feature, so a slim
   build can be just REST + JSONL, or pull in all 35 connectors with `--features full`.
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -429,6 +429,38 @@ faucet run --clock 2026-03-01T02:00:00-08:00 pipeline.yaml  # precise timestamp
 
 > **Caveat for `stop`:** cancelling a task mid-write may leave partial state in the sink — a half-flushed file, an open transaction, a connection that closed before the server's response was read. Idempotent sinks (JSONL append, S3 put with a fixed key, BigQuery streaming insert with `insertId`, upsert-style writes) handle re-runs cleanly. Non-idempotent sinks (`HTTP POST` without dedupe headers, `INSERT` with auto-id) may double-write on retry. If you can't tolerate that, prefer `on_error: continue` and reconcile failed rows after the fact.
 
+#### Adaptive batch sizing
+
+The optional `adaptive_batch_size:` sub-block under `execution:` enables the
+AIMD controller that auto-tunes the effective write batch size from observed sink
+latency and error rate. Default `enabled: false` (opt-in).
+
+```yaml
+execution:
+  adaptive_batch_size:
+    enabled: true
+    min: 500               # lower bound (rows)
+    max: 10000             # upper bound; inert above the source page size
+    increase_step: 500     # additive growth per clean, fast batch
+    decrease_factor: 0.5   # multiplicative shrink on error or high latency
+    cooldown_batches: 5    # batches to skip after a shrink before growing again
+    target_latency_ms: 1000  # optional write-latency target (ms)
+    error_threshold: 0.01  # per-batch error rate that triggers a shrink
+```
+
+**Caveats:**
+
+- **Error-driven shrink requires a `dlq:` block.** The error signal comes from
+  per-row outcomes reported via the DLQ path. Without a DLQ the controller sees
+  no errors; only `target_latency_ms` can drive shrinks.
+- **Effective ceiling = source page size (within-page only in v1).** The
+  controller reslices pages it already received — it cannot buffer across pages.
+  Raise the source `batch_size` to allow bigger write batches.
+
+See the [Adaptive batching cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/adaptive-batching.html)
+for the full field reference, AIMD trajectory example, and the four Prometheus
+metrics (`faucet_pipeline_adaptive_batch_*`).
+
 #### State keys
 
 - Root invocations: `{name}::{row_id}`.

--- a/cli/examples/postgres_to_bigquery_adaptive.yaml
+++ b/cli/examples/postgres_to_bigquery_adaptive.yaml
@@ -1,0 +1,85 @@
+# PostgreSQL → BigQuery with adaptive batch sizing.
+#
+# The `execution.adaptive_batch_size` block enables the AIMD controller: the
+# pipeline starts at the source page size, grows the write batch additively on
+# clean, fast pages, and shrinks multiplicatively when the BigQuery insertAll
+# response latency exceeds the target or when per-row errors are reported.
+#
+# Error-driven shrink requires a `dlq:` block so the pipeline can observe
+# per-row outcomes from BigQuery's partial-write API. Remove `dlq:` (and set
+# `error_threshold` to 0.0 or rely on latency alone) if you do not want a DLQ.
+#
+# Required env vars:
+#   PG_URL        — connection URL, e.g. postgres://user:pass@localhost/app
+#   GCP_KEY_JSON  — GCP service-account key (full JSON string)
+
+version: 1
+name: postgres_to_bigquery_adaptive
+
+pipeline:
+  source:
+    type: postgres
+    config:
+      connection_url: ${env:PG_URL}
+      query: SELECT id, created_at, payload FROM orders WHERE created_at > $1
+      params:
+        - "2026-01-01T00:00:00Z"
+      # batch_size controls the source page size; the adaptive controller's
+      # effective ceiling is min(max, page_size).  Raise this to allow bigger
+      # write batches.
+      batch_size: 5000
+      max_connections: 8
+
+  sink:
+    type: bigquery
+    config:
+      project_id: my-gcp-project
+      dataset_id: warehouse
+      table_id: orders
+      auth:
+        type: service_account_key
+        config:
+          json: ${env:GCP_KEY_JSON}
+      # batch_size here is the initial write size; the controller will tune it
+      # at runtime between `min` and `max` (capped at the source page size).
+      batch_size: 1000
+
+  dlq:
+    # BigQuery's insertAll API reports per-row failures; the DLQ captures just
+    # those rows.  The adaptive controller uses the per-row error signal to
+    # decide when to shrink the batch.
+    sink:
+      type: jsonl
+      config:
+        path: ./dlq/orders_failed.jsonl
+    on_batch_error: dlq_all
+
+execution:
+  adaptive_batch_size:
+    enabled: true
+    # Controller algorithm (only "aimd" is supported in v1).
+    controller: aimd
+    # Hard lower bound: never write fewer than 500 rows per batch.
+    min: 500
+    # Hard upper bound: never write more than 10 000 rows per batch.
+    # Values above the source batch_size (5 000) are inert under within-page
+    # reslicing, so the effective ceiling here is 5 000.
+    max: 10000
+    # Grow by 500 rows on each clean, fast batch.
+    increase_step: 500
+    # Shrink to 50 % of current size on errors or high latency.
+    decrease_factor: 0.5
+    # After a shrink, skip this many batches before allowing growth again.
+    cooldown_batches: 5
+    # Target BigQuery write latency.  The controller shrinks when the rolling
+    # p50 exceeds 1.2 × target (1 200 ms) and grows when it falls below
+    # 0.5 × target (500 ms).
+    target_latency_ms: 1000
+    # Rolling window size (batches) for the p50 latency estimate.
+    latency_window: 10
+    # Per-batch error rate above which the controller shrinks.  0.01 = 1 %.
+    error_threshold: 0.01
+    # Cap effective batch size at the source page size (within-page only in v1).
+    respect_source_max: true
+    # Emit a tracing::info summary every 50 adjustments.
+    log_every: 50

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -256,6 +256,10 @@ pub struct ExecutionSpec {
     /// What to do when a pipeline invocation fails.
     #[serde(default)]
     pub on_error: OnError,
+
+    /// Adaptive batch-size controller (opt-in). See `faucet_core::AdaptiveBatchConfig`.
+    #[serde(default)]
+    pub adaptive_batch_size: Option<faucet_core::AdaptiveBatchConfig>,
 }
 
 /// Failure-handling policy across the matrix.
@@ -737,6 +741,28 @@ pipeline:
         assert_eq!(s.cron, "0 2 * * *");
         assert_eq!(s.timezone, "America/Los_Angeles");
         assert_eq!(s.max_consecutive_failures, Some(5));
+    }
+
+    #[test]
+    fn execution_spec_parses_adaptive_block() {
+        let yaml = r#"
+version: 1
+pipeline:
+  source: { type: rest, config: { base_url: https://api.example.com } }
+  sink:   { type: jsonl, config: { path: ./out.jsonl } }
+execution:
+  adaptive_batch_size:
+    enabled: true
+    min: 200
+    max: 4000
+    target_latency_ms: 800
+"#;
+        let cfg = crate::config::parse_with_extension(yaml, "yaml").unwrap();
+        let ab = cfg.execution.unwrap().adaptive_batch_size.unwrap();
+        assert!(ab.enabled);
+        assert_eq!(ab.min, 200);
+        assert_eq!(ab.target_latency_ms, Some(800));
+        ab.validate().unwrap();
     }
 
     #[cfg(feature = "quality")]

--- a/cli/src/executor.rs
+++ b/cli/src/executor.rs
@@ -541,6 +541,18 @@ async fn run_one_invocation(
     } else {
         pipeline
     };
+    // Execution-level adaptive batch-size controller (shared by all rows).
+    let pipeline = if let Some(ab) = opts
+        .execution
+        .as_ref()
+        .and_then(|e| e.adaptive_batch_size.clone())
+    {
+        ab.validate()
+            .map_err(|e| CliError::Config(format!("adaptive_batch_size: {e}")))?;
+        pipeline.with_adaptive(ab)
+    } else {
+        pipeline
+    };
     let result = pipeline.run().await?;
     sink.flush().await?;
 

--- a/cli/src/expand.rs
+++ b/cli/src/expand.rs
@@ -188,6 +188,20 @@ impl<'a> Registry<'a> {
 /// Expand `cfg` into a topologically valid list of nodes. Roots come first,
 /// then children in BFS order.
 pub fn expand(cfg: &PipelineConfig) -> CliResult<Vec<ExpandedNode>> {
+    // Fail-fast at config load: validate the execution-level adaptive
+    // batch-size controller here (the shared `validate`/`run`/`preview`/
+    // `doctor`/`schedule` gate) so `faucet validate` rejects a bad block
+    // rather than only surfacing it mid-run in the executor.
+    if let Some(ab) = cfg
+        .execution
+        .as_ref()
+        .and_then(|e| e.adaptive_batch_size.as_ref())
+    {
+        // `validate()` returns `FaucetError::Config` whose message already names
+        // the offending field; propagate it directly (CliError: From<FaucetError>).
+        ab.validate()?;
+    }
+
     // Implicit single-row case: empty matrix → run pipeline once with no merge.
     let synthetic_row;
     let rows: &[MatrixRow] = if cfg.matrix.is_empty() {
@@ -1298,5 +1312,47 @@ matrix:
             CliError::ReservedRowId { id } => assert_eq!(id, "now"),
             other => panic!("expected ReservedRowId, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn expand_rejects_invalid_adaptive_batch_size_at_load() {
+        // Fail-fast: an invalid execution.adaptive_batch_size block must be
+        // rejected by `expand` (the gate `faucet validate` uses), not only at
+        // run time in the executor.
+        let yaml = r#"
+version: 1
+pipeline:
+  source: { type: rest, config: {} }
+  sink:   { type: jsonl, config: { path: ./o.jsonl } }
+execution:
+  adaptive_batch_size:
+    enabled: true
+    min: 5000
+    max: 100
+"#;
+        let cfg = parse_with_extension(yaml, "yaml").unwrap();
+        let err = expand(&cfg).unwrap_err();
+        assert!(
+            err.to_string().contains("adaptive_batch_size.min"),
+            "expected adaptive validation error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn expand_accepts_valid_adaptive_batch_size() {
+        let yaml = r#"
+version: 1
+pipeline:
+  source: { type: rest, config: {} }
+  sink:   { type: jsonl, config: { path: ./o.jsonl } }
+execution:
+  adaptive_batch_size:
+    enabled: true
+    min: 100
+    max: 5000
+    target_latency_ms: 500
+"#;
+        let cfg = parse_with_extension(yaml, "yaml").unwrap();
+        assert!(expand(&cfg).is_ok());
     }
 }

--- a/crates/core/src/adaptive.rs
+++ b/crates/core/src/adaptive.rs
@@ -130,7 +130,7 @@ mod config_tests {
         assert_eq!(c.min, 100);
         assert_eq!(c.max, 50_000);
         assert!(c.respect_source_max);
-        assert!(!c.target_latency_ms.is_some());
+        assert!(c.target_latency_ms.is_none());
         c.validate().unwrap();
     }
 
@@ -165,6 +165,17 @@ mod config_tests {
         assert!(c.validate().is_err());
         let mut c = valid();
         c.target_latency_ms = Some(0);
+        assert!(c.validate().is_err());
+        // decrease_factor is an *exclusive* (0, 1) range — both bounds invalid.
+        let mut c = valid();
+        c.decrease_factor = 0.0;
+        assert!(c.validate().is_err());
+        let mut c = valid();
+        c.decrease_factor = 1.0;
+        assert!(c.validate().is_err());
+        // latency_window must be >= 1.
+        let mut c = valid();
+        c.latency_window = 0;
         assert!(c.validate().is_err());
     }
 }

--- a/crates/core/src/adaptive.rs
+++ b/crates/core/src/adaptive.rs
@@ -1,0 +1,170 @@
+//! Adaptive batch sizing — an AIMD controller that auto-tunes the effective
+//! write batch size per pipeline row from observed sink latency + error rate.
+//! Pure logic (no I/O); `run_stream` feeds it observations and emits metrics.
+//! See `docs/superpowers/specs/2026-05-31-adaptive-batch-sizing-design.md`.
+
+use crate::error::FaucetError;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+fn default_controller() -> String { "aimd".to_string() }
+fn default_min() -> usize { 100 }
+fn default_max() -> usize { 50_000 }
+fn default_increase_step() -> usize { 250 }
+fn default_decrease_factor() -> f64 { 0.5 }
+fn default_cooldown_batches() -> usize { 5 }
+fn default_latency_window() -> usize { 10 }
+fn default_error_threshold() -> f64 { 0.01 }
+fn default_true() -> bool { true }
+fn default_log_every() -> usize { 50 }
+
+/// Configuration for the adaptive batch-size controller. Lives under
+/// `execution.adaptive_batch_size`. Default `enabled = false` (opt-in); when
+/// disabled the pipeline writes each page exactly as before.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct AdaptiveBatchConfig {
+    /// Master switch. Default `false`.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Controller algorithm. Only `"aimd"` is implemented in v1.
+    #[serde(default = "default_controller")]
+    pub controller: String,
+    /// Lower bound on the effective batch size.
+    #[serde(default = "default_min")]
+    pub min: usize,
+    /// Upper bound. Under within-page reslicing the effective ceiling is
+    /// `min(max, page_len)`; values above the source page size are inert.
+    #[serde(default = "default_max")]
+    pub max: usize,
+    /// Additive growth per clean+fast batch.
+    #[serde(default = "default_increase_step")]
+    pub increase_step: usize,
+    /// Multiplicative shrink factor on error / high latency (0 < f < 1).
+    #[serde(default = "default_decrease_factor")]
+    pub decrease_factor: f64,
+    /// Batches to wait after a shrink before allowing growth.
+    #[serde(default = "default_cooldown_batches")]
+    pub cooldown_batches: usize,
+    /// Optional latency target in ms. `None` = react to errors only.
+    #[serde(default)]
+    pub target_latency_ms: Option<u64>,
+    /// Rolling window size for the p50 batch-write latency.
+    #[serde(default = "default_latency_window")]
+    pub latency_window: usize,
+    /// Per-batch error rate above which the controller shrinks.
+    #[serde(default = "default_error_threshold")]
+    pub error_threshold: f64,
+    /// Never grow past the source page size. v1 honors only `true`; `false`
+    /// logs a one-shot warning and behaves as `true` (cross-page buffering is
+    /// a future enhancement).
+    #[serde(default = "default_true")]
+    pub respect_source_max: bool,
+    /// Emit a `tracing::info!` summary every N adjustments.
+    #[serde(default = "default_log_every")]
+    pub log_every: usize,
+}
+
+impl AdaptiveBatchConfig {
+    /// Fail-fast validation, surfaced as `FaucetError::Config` at config load.
+    pub fn validate(&self) -> Result<(), FaucetError> {
+        if self.controller != "aimd" {
+            return Err(FaucetError::Config(format!(
+                "adaptive_batch_size.controller '{}' is not supported (only 'aimd')",
+                self.controller
+            )));
+        }
+        if self.min < 1 {
+            return Err(FaucetError::Config(
+                "adaptive_batch_size.min must be >= 1".into(),
+            ));
+        }
+        if self.min > self.max {
+            return Err(FaucetError::Config(format!(
+                "adaptive_batch_size.min ({}) must be <= max ({})",
+                self.min, self.max
+            )));
+        }
+        if !(self.decrease_factor > 0.0 && self.decrease_factor < 1.0) {
+            return Err(FaucetError::Config(
+                "adaptive_batch_size.decrease_factor must be in (0, 1)".into(),
+            ));
+        }
+        if self.increase_step < 1 {
+            return Err(FaucetError::Config(
+                "adaptive_batch_size.increase_step must be >= 1".into(),
+            ));
+        }
+        if !(0.0..=1.0).contains(&self.error_threshold) {
+            return Err(FaucetError::Config(
+                "adaptive_batch_size.error_threshold must be in [0, 1]".into(),
+            ));
+        }
+        if self.latency_window < 1 {
+            return Err(FaucetError::Config(
+                "adaptive_batch_size.latency_window must be >= 1".into(),
+            ));
+        }
+        if let Some(t) = self.target_latency_ms
+            && t == 0
+        {
+            return Err(FaucetError::Config(
+                "adaptive_batch_size.target_latency_ms must be > 0 when set".into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod config_tests {
+    use super::*;
+
+    fn valid() -> AdaptiveBatchConfig {
+        serde_json::from_value(serde_json::json!({"enabled": true})).unwrap()
+    }
+
+    #[test]
+    fn defaults_are_sane_and_valid() {
+        let c = valid();
+        assert_eq!(c.controller, "aimd");
+        assert_eq!(c.min, 100);
+        assert_eq!(c.max, 50_000);
+        assert!(c.respect_source_max);
+        assert!(!c.target_latency_ms.is_some());
+        c.validate().unwrap();
+    }
+
+    #[test]
+    fn rejects_unknown_controller() {
+        let mut c = valid();
+        c.controller = "pid".into();
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_min_gt_max_and_zero_min() {
+        let mut c = valid();
+        c.min = 10;
+        c.max = 5;
+        assert!(c.validate().is_err());
+        let mut c = valid();
+        c.min = 0;
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_out_of_range_factors() {
+        let mut c = valid();
+        c.decrease_factor = 1.5;
+        assert!(c.validate().is_err());
+        let mut c = valid();
+        c.error_threshold = 2.0;
+        assert!(c.validate().is_err());
+        let mut c = valid();
+        c.increase_step = 0;
+        assert!(c.validate().is_err());
+        let mut c = valid();
+        c.target_latency_ms = Some(0);
+        assert!(c.validate().is_err());
+    }
+}

--- a/crates/core/src/adaptive.rs
+++ b/crates/core/src/adaptive.rs
@@ -9,16 +9,36 @@ use serde::{Deserialize, Serialize};
 use std::collections::VecDeque;
 use std::time::Duration;
 
-fn default_controller() -> String { "aimd".to_string() }
-fn default_min() -> usize { 100 }
-fn default_max() -> usize { 50_000 }
-fn default_increase_step() -> usize { 250 }
-fn default_decrease_factor() -> f64 { 0.5 }
-fn default_cooldown_batches() -> usize { 5 }
-fn default_latency_window() -> usize { 10 }
-fn default_error_threshold() -> f64 { 0.01 }
-fn default_true() -> bool { true }
-fn default_log_every() -> usize { 50 }
+fn default_controller() -> String {
+    "aimd".to_string()
+}
+fn default_min() -> usize {
+    100
+}
+fn default_max() -> usize {
+    50_000
+}
+fn default_increase_step() -> usize {
+    250
+}
+fn default_decrease_factor() -> f64 {
+    0.5
+}
+fn default_cooldown_batches() -> usize {
+    5
+}
+fn default_latency_window() -> usize {
+    10
+}
+fn default_error_threshold() -> f64 {
+    0.01
+}
+fn default_true() -> bool {
+    true
+}
+fn default_log_every() -> usize {
+    50
+}
 
 /// Configuration for the adaptive batch-size controller. Lives under
 /// `execution.adaptive_batch_size`. Default `enabled = false` (opt-in); when
@@ -119,16 +139,26 @@ impl AdaptiveBatchConfig {
 
 /// Direction of a batch-size adjustment (metric label).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum AdjustDirection { Up, Down }
+pub enum AdjustDirection {
+    Up,
+    Down,
+}
 impl AdjustDirection {
     pub fn as_str(&self) -> &'static str {
-        match self { AdjustDirection::Up => "up", AdjustDirection::Down => "down" }
+        match self {
+            AdjustDirection::Up => "up",
+            AdjustDirection::Down => "down",
+        }
     }
 }
 
 /// Why an adjustment happened (metric label).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum AdjustReason { Success, Error, Latency }
+pub enum AdjustReason {
+    Success,
+    Error,
+    Latency,
+}
 impl AdjustReason {
     pub fn as_str(&self) -> &'static str {
         match self {
@@ -196,8 +226,12 @@ impl AimdController {
         }
     }
 
-    pub fn current(&self) -> usize { self.current }
-    pub fn cooldown_active(&self) -> bool { self.cooldown > 0 }
+    pub fn current(&self) -> usize {
+        self.current
+    }
+    pub fn cooldown_active(&self) -> bool {
+        self.cooldown > 0
+    }
 
     /// p50 of the rolling latency window (ms), if any samples present.
     pub fn p50_latency_ms(&self) -> Option<u64> {
@@ -260,7 +294,11 @@ impl AimdController {
         }
         self.current = new;
         self.bump_log(AdjustDirection::Down, reason);
-        Some(Adjustment { new_size: new, direction: AdjustDirection::Down, reason })
+        Some(Adjustment {
+            new_size: new,
+            direction: AdjustDirection::Down,
+            reason,
+        })
     }
 
     fn grow(&mut self, reason: AdjustReason) -> Option<Adjustment> {
@@ -270,7 +308,11 @@ impl AimdController {
         }
         self.current = new;
         self.bump_log(AdjustDirection::Up, reason);
-        Some(Adjustment { new_size: new, direction: AdjustDirection::Up, reason })
+        Some(Adjustment {
+            new_size: new,
+            direction: AdjustDirection::Up,
+            reason,
+        })
     }
 
     fn bump_log(&mut self, direction: AdjustDirection, reason: AdjustReason) {
@@ -367,7 +409,11 @@ mod controller_tests {
     }
 
     fn ok(len: usize) -> Observation {
-        Observation { batch_len: len, errors: 0, latency: Duration::from_millis(1) }
+        Observation {
+            batch_len: len,
+            errors: 0,
+            latency: Duration::from_millis(1),
+        }
     }
 
     #[test]
@@ -397,7 +443,13 @@ mod controller_tests {
     #[test]
     fn shrinks_multiplicatively_on_error_and_arms_cooldown() {
         let mut c = AimdController::new(&cfg(), 800);
-        let a = c.observe(Observation { batch_len: 100, errors: 20, latency: Duration::from_millis(1) }).unwrap();
+        let a = c
+            .observe(Observation {
+                batch_len: 100,
+                errors: 20,
+                latency: Duration::from_millis(1),
+            })
+            .unwrap();
         assert_eq!(a.new_size, 400); // floor(800*0.5)
         assert_eq!(a.direction, AdjustDirection::Down);
         assert_eq!(a.reason, AdjustReason::Error);
@@ -413,7 +465,11 @@ mod controller_tests {
     #[test]
     fn does_not_shrink_below_min_and_warns_once() {
         let mut c = AimdController::new(&cfg(), 100); // == min
-        let bad = Observation { batch_len: 100, errors: 100, latency: Duration::from_millis(1) };
+        let bad = Observation {
+            batch_len: 100,
+            errors: 100,
+            latency: Duration::from_millis(1),
+        };
         // Already at min: shrink is a no-op (no adjustment), cooldown still arms.
         assert!(c.observe(bad).is_none());
         assert_eq!(c.current(), 100);
@@ -426,21 +482,41 @@ mod controller_tests {
                 "enabled": true, "min": 100, "max": 1000, "increase_step": 100,
                 "decrease_factor": 0.5, "cooldown_batches": 0,
                 "target_latency_ms": 500, "latency_window": 1
-            })).unwrap(),
+            }))
+            .unwrap(),
             800,
         );
         // p50 = 700ms > 500*1.2=600 -> shrink
-        let a = c.observe(Observation { batch_len: 800, errors: 0, latency: Duration::from_millis(700) }).unwrap();
+        let a = c
+            .observe(Observation {
+                batch_len: 800,
+                errors: 0,
+                latency: Duration::from_millis(700),
+            })
+            .unwrap();
         assert_eq!(a.reason, AdjustReason::Latency);
         assert_eq!(a.direction, AdjustDirection::Down);
         assert_eq!(c.current(), 400);
         // p50 = 100ms < 500*0.5=250 -> grow
-        let a = c.observe(Observation { batch_len: 400, errors: 0, latency: Duration::from_millis(100) }).unwrap();
+        let a = c
+            .observe(Observation {
+                batch_len: 400,
+                errors: 0,
+                latency: Duration::from_millis(100),
+            })
+            .unwrap();
         assert_eq!(a.direction, AdjustDirection::Up);
         assert_eq!(a.reason, AdjustReason::Latency);
         assert_eq!(c.current(), 500);
         // p50 = 500ms in deadband [250,600] -> no change
-        assert!(c.observe(Observation { batch_len: 500, errors: 0, latency: Duration::from_millis(500) }).is_none());
+        assert!(
+            c.observe(Observation {
+                batch_len: 500,
+                errors: 0,
+                latency: Duration::from_millis(500)
+            })
+            .is_none()
+        );
     }
 
     #[test]
@@ -448,7 +524,11 @@ mod controller_tests {
         // The spec's distinctive invariant: error shrink fires BEFORE the
         // cooldown gate, so a mid-cooldown error shrinks again + re-arms.
         let mut c = AimdController::new(&cfg(), 800);
-        let bad = Observation { batch_len: 100, errors: 50, latency: Duration::from_millis(1) };
+        let bad = Observation {
+            batch_len: 100,
+            errors: 50,
+            latency: Duration::from_millis(1),
+        };
         let a = c.observe(bad).unwrap(); // 800 -> 400, cooldown armed (2)
         assert_eq!(a.new_size, 400);
         assert!(c.cooldown_active());
@@ -466,17 +546,26 @@ mod controller_tests {
                 "enabled": true, "min": 100, "max": 1000, "increase_step": 100,
                 "decrease_factor": 0.5, "cooldown_batches": 0,
                 "target_latency_ms": 500, "latency_window": 5
-            })).unwrap(),
+            }))
+            .unwrap(),
             800,
         );
         // Feed five fast samples (10ms): p50 = 10ms < 250 -> grows each time.
         for _ in 0..5 {
-            c.observe(Observation { batch_len: 800, errors: 0, latency: Duration::from_millis(10) });
+            c.observe(Observation {
+                batch_len: 800,
+                errors: 0,
+                latency: Duration::from_millis(10),
+            });
         }
         assert_eq!(c.p50_latency_ms(), Some(10));
         // One slow sample doesn't move the median of a 5-window enough to flip it
         // (sorted [10,10,10,10,900] -> p50 = 10), so still in grow/deadband territory.
-        c.observe(Observation { batch_len: 800, errors: 0, latency: Duration::from_millis(900) });
+        c.observe(Observation {
+            batch_len: 800,
+            errors: 0,
+            latency: Duration::from_millis(900),
+        });
         assert_eq!(c.p50_latency_ms(), Some(10));
     }
 }

--- a/crates/core/src/adaptive.rs
+++ b/crates/core/src/adaptive.rs
@@ -275,7 +275,7 @@ impl AimdController {
 
     fn bump_log(&mut self, direction: AdjustDirection, reason: AdjustReason) {
         self.adjustments += 1;
-        if self.log_every > 0 && self.adjustments % self.log_every as u64 == 0 {
+        if self.log_every > 0 && self.adjustments.is_multiple_of(self.log_every as u64) {
             tracing::info!(
                 current = self.current,
                 direction = direction.as_str(),
@@ -441,5 +441,42 @@ mod controller_tests {
         assert_eq!(c.current(), 500);
         // p50 = 500ms in deadband [250,600] -> no change
         assert!(c.observe(Observation { batch_len: 500, errors: 0, latency: Duration::from_millis(500) }).is_none());
+    }
+
+    #[test]
+    fn error_during_cooldown_reshrinks_and_rearms() {
+        // The spec's distinctive invariant: error shrink fires BEFORE the
+        // cooldown gate, so a mid-cooldown error shrinks again + re-arms.
+        let mut c = AimdController::new(&cfg(), 800);
+        let bad = Observation { batch_len: 100, errors: 50, latency: Duration::from_millis(1) };
+        let a = c.observe(bad).unwrap(); // 800 -> 400, cooldown armed (2)
+        assert_eq!(a.new_size, 400);
+        assert!(c.cooldown_active());
+        // Still in cooldown, but another error shrinks again (400 -> 200) and re-arms.
+        let a = c.observe(bad).unwrap();
+        assert_eq!(a.new_size, 200);
+        assert_eq!(a.reason, AdjustReason::Error);
+        assert!(c.cooldown_active());
+    }
+
+    #[test]
+    fn p50_uses_median_of_multi_sample_window() {
+        let mut c = AimdController::new(
+            &serde_json::from_value(serde_json::json!({
+                "enabled": true, "min": 100, "max": 1000, "increase_step": 100,
+                "decrease_factor": 0.5, "cooldown_batches": 0,
+                "target_latency_ms": 500, "latency_window": 5
+            })).unwrap(),
+            800,
+        );
+        // Feed five fast samples (10ms): p50 = 10ms < 250 -> grows each time.
+        for _ in 0..5 {
+            c.observe(Observation { batch_len: 800, errors: 0, latency: Duration::from_millis(10) });
+        }
+        assert_eq!(c.p50_latency_ms(), Some(10));
+        // One slow sample doesn't move the median of a 5-window enough to flip it
+        // (sorted [10,10,10,10,900] -> p50 = 10), so still in grow/deadband territory.
+        c.observe(Observation { batch_len: 800, errors: 0, latency: Duration::from_millis(900) });
+        assert_eq!(c.p50_latency_ms(), Some(10));
     }
 }

--- a/crates/core/src/adaptive.rs
+++ b/crates/core/src/adaptive.rs
@@ -6,6 +6,8 @@
 use crate::error::FaucetError;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::collections::VecDeque;
+use std::time::Duration;
 
 fn default_controller() -> String { "aimd".to_string() }
 fn default_min() -> usize { 100 }
@@ -115,6 +117,176 @@ impl AdaptiveBatchConfig {
     }
 }
 
+/// Direction of a batch-size adjustment (metric label).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AdjustDirection { Up, Down }
+impl AdjustDirection {
+    pub fn as_str(&self) -> &'static str {
+        match self { AdjustDirection::Up => "up", AdjustDirection::Down => "down" }
+    }
+}
+
+/// Why an adjustment happened (metric label).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AdjustReason { Success, Error, Latency }
+impl AdjustReason {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            AdjustReason::Success => "success",
+            AdjustReason::Error => "error",
+            AdjustReason::Latency => "latency",
+        }
+    }
+}
+
+/// One observed sub-batch write outcome fed to the controller.
+#[derive(Debug, Clone, Copy)]
+pub struct Observation {
+    pub batch_len: usize,
+    pub errors: usize,
+    pub latency: Duration,
+}
+
+/// A size change the controller decided on.
+#[derive(Debug, Clone, Copy)]
+pub struct Adjustment {
+    pub new_size: usize,
+    pub direction: AdjustDirection,
+    pub reason: AdjustReason,
+}
+
+/// Additive-increase / multiplicative-decrease controller. Pure + deterministic.
+pub struct AimdController {
+    min: usize,
+    max: usize,
+    increase_step: usize,
+    decrease_factor: f64,
+    cooldown_batches: usize,
+    target_latency_ms: Option<u64>,
+    latency_window: usize,
+    error_threshold: f64,
+    log_every: usize,
+
+    current: usize,
+    cooldown: usize,
+    latencies: VecDeque<u64>,
+    floor_warned: bool,
+    adjustments: u64,
+}
+
+impl AimdController {
+    /// Build a controller. `initial` is clamped into `[min, max]` (cold-start =
+    /// the source's actual page size when `run_stream` passes the first page len).
+    pub fn new(cfg: &AdaptiveBatchConfig, initial: usize) -> Self {
+        Self {
+            min: cfg.min,
+            max: cfg.max,
+            increase_step: cfg.increase_step,
+            decrease_factor: cfg.decrease_factor,
+            cooldown_batches: cfg.cooldown_batches,
+            target_latency_ms: cfg.target_latency_ms,
+            latency_window: cfg.latency_window.max(1),
+            error_threshold: cfg.error_threshold,
+            log_every: cfg.log_every,
+            current: initial.clamp(cfg.min, cfg.max),
+            cooldown: 0,
+            latencies: VecDeque::new(),
+            floor_warned: false,
+            adjustments: 0,
+        }
+    }
+
+    pub fn current(&self) -> usize { self.current }
+    pub fn cooldown_active(&self) -> bool { self.cooldown > 0 }
+
+    /// p50 of the rolling latency window (ms), if any samples present.
+    pub fn p50_latency_ms(&self) -> Option<u64> {
+        if self.latencies.is_empty() {
+            return None;
+        }
+        let mut v: Vec<u64> = self.latencies.iter().copied().collect();
+        v.sort_unstable();
+        Some(v[v.len() / 2])
+    }
+
+    /// Feed one sub-batch observation; returns `Some(Adjustment)` when the size
+    /// changed. First-match-wins: error shrink → cooldown → latency target →
+    /// success growth.
+    pub fn observe(&mut self, obs: Observation) -> Option<Adjustment> {
+        // 1. Error shrink (always, even during cooldown).
+        if obs.batch_len > 0 {
+            let rate = obs.errors as f64 / obs.batch_len as f64;
+            if rate > self.error_threshold {
+                return self.shrink(AdjustReason::Error);
+            }
+        }
+        // 2. Cooldown blocks growth.
+        if self.cooldown > 0 {
+            self.cooldown -= 1;
+            return None;
+        }
+        // 3. Latency target.
+        if let Some(target) = self.target_latency_ms {
+            self.latencies.push_back(obs.latency.as_millis() as u64);
+            while self.latencies.len() > self.latency_window {
+                self.latencies.pop_front();
+            }
+            let p50 = self.p50_latency_ms().unwrap_or(0) as f64;
+            let t = target as f64;
+            if p50 > t * 1.2 {
+                return self.shrink(AdjustReason::Latency);
+            } else if p50 < t * 0.5 {
+                return self.grow(AdjustReason::Latency);
+            }
+            return None;
+        }
+        // 4. Success growth.
+        self.grow(AdjustReason::Success)
+    }
+
+    fn shrink(&mut self, reason: AdjustReason) -> Option<Adjustment> {
+        let new = ((self.current as f64 * self.decrease_factor).floor() as usize).max(self.min);
+        self.cooldown = self.cooldown_batches;
+        if new == self.current {
+            if reason == AdjustReason::Error && self.current == self.min && !self.floor_warned {
+                tracing::warn!(
+                    batch_size = self.current,
+                    "adaptive batch size at floor (min) and still seeing errors; \
+                     consider lowering `min` or investigating the sink"
+                );
+                self.floor_warned = true;
+            }
+            return None;
+        }
+        self.current = new;
+        self.bump_log(AdjustDirection::Down, reason);
+        Some(Adjustment { new_size: new, direction: AdjustDirection::Down, reason })
+    }
+
+    fn grow(&mut self, reason: AdjustReason) -> Option<Adjustment> {
+        let new = (self.current + self.increase_step).min(self.max);
+        if new == self.current {
+            return None;
+        }
+        self.current = new;
+        self.bump_log(AdjustDirection::Up, reason);
+        Some(Adjustment { new_size: new, direction: AdjustDirection::Up, reason })
+    }
+
+    fn bump_log(&mut self, direction: AdjustDirection, reason: AdjustReason) {
+        self.adjustments += 1;
+        if self.log_every > 0 && self.adjustments % self.log_every as u64 == 0 {
+            tracing::info!(
+                current = self.current,
+                direction = direction.as_str(),
+                reason = reason.as_str(),
+                adjustments = self.adjustments,
+                "adaptive batch size adjusted"
+            );
+        }
+    }
+}
+
 #[cfg(test)]
 mod config_tests {
     use super::*;
@@ -177,5 +349,97 @@ mod config_tests {
         let mut c = valid();
         c.latency_window = 0;
         assert!(c.validate().is_err());
+    }
+}
+
+#[cfg(test)]
+mod controller_tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn cfg() -> AdaptiveBatchConfig {
+        serde_json::from_value(serde_json::json!({
+            "enabled": true, "min": 100, "max": 1000,
+            "increase_step": 100, "decrease_factor": 0.5,
+            "cooldown_batches": 2, "error_threshold": 0.1
+        }))
+        .unwrap()
+    }
+
+    fn ok(len: usize) -> Observation {
+        Observation { batch_len: len, errors: 0, latency: Duration::from_millis(1) }
+    }
+
+    #[test]
+    fn cold_start_clamps_initial_to_bounds() {
+        let c = AimdController::new(&cfg(), 50); // below min
+        assert_eq!(c.current(), 100);
+        let c = AimdController::new(&cfg(), 99_999); // above max
+        assert_eq!(c.current(), 1000);
+        let c = AimdController::new(&cfg(), 500);
+        assert_eq!(c.current(), 500);
+    }
+
+    #[test]
+    fn grows_additively_on_success_up_to_max() {
+        let mut c = AimdController::new(&cfg(), 800);
+        let a = c.observe(ok(800)).unwrap();
+        assert_eq!(a.new_size, 900);
+        assert_eq!(a.direction, AdjustDirection::Up);
+        assert_eq!(a.reason, AdjustReason::Success);
+        c.observe(ok(900)); // -> 1000 (max)
+        assert_eq!(c.current(), 1000);
+        // At max: no further growth, no adjustment.
+        assert!(c.observe(ok(1000)).is_none());
+        assert_eq!(c.current(), 1000);
+    }
+
+    #[test]
+    fn shrinks_multiplicatively_on_error_and_arms_cooldown() {
+        let mut c = AimdController::new(&cfg(), 800);
+        let a = c.observe(Observation { batch_len: 100, errors: 20, latency: Duration::from_millis(1) }).unwrap();
+        assert_eq!(a.new_size, 400); // floor(800*0.5)
+        assert_eq!(a.direction, AdjustDirection::Down);
+        assert_eq!(a.reason, AdjustReason::Error);
+        assert!(c.cooldown_active());
+        // Cooldown blocks growth for cooldown_batches observations.
+        assert!(c.observe(ok(400)).is_none());
+        assert!(c.observe(ok(400)).is_none());
+        // After cooldown drains, growth resumes.
+        let a = c.observe(ok(400)).unwrap();
+        assert_eq!(a.new_size, 500);
+    }
+
+    #[test]
+    fn does_not_shrink_below_min_and_warns_once() {
+        let mut c = AimdController::new(&cfg(), 100); // == min
+        let bad = Observation { batch_len: 100, errors: 100, latency: Duration::from_millis(1) };
+        // Already at min: shrink is a no-op (no adjustment), cooldown still arms.
+        assert!(c.observe(bad).is_none());
+        assert_eq!(c.current(), 100);
+    }
+
+    #[test]
+    fn latency_target_shrinks_when_slow_grows_when_fast() {
+        let mut c: AimdController = AimdController::new(
+            &serde_json::from_value(serde_json::json!({
+                "enabled": true, "min": 100, "max": 1000, "increase_step": 100,
+                "decrease_factor": 0.5, "cooldown_batches": 0,
+                "target_latency_ms": 500, "latency_window": 1
+            })).unwrap(),
+            800,
+        );
+        // p50 = 700ms > 500*1.2=600 -> shrink
+        let a = c.observe(Observation { batch_len: 800, errors: 0, latency: Duration::from_millis(700) }).unwrap();
+        assert_eq!(a.reason, AdjustReason::Latency);
+        assert_eq!(a.direction, AdjustDirection::Down);
+        assert_eq!(c.current(), 400);
+        // p50 = 100ms < 500*0.5=250 -> grow
+        let a = c.observe(Observation { batch_len: 400, errors: 0, latency: Duration::from_millis(100) }).unwrap();
+        assert_eq!(a.direction, AdjustDirection::Up);
+        assert_eq!(a.reason, AdjustReason::Latency);
+        assert_eq!(c.current(), 500);
+        // p50 = 500ms in deadband [250,600] -> no change
+        assert!(c.observe(Observation { batch_len: 500, errors: 0, latency: Duration::from_millis(500) }).is_none());
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -36,7 +36,7 @@ pub mod util;
 #[cfg(feature = "compression")]
 pub mod compression;
 
-pub use adaptive::AdaptiveBatchConfig;
+pub use adaptive::{AdaptiveBatchConfig, AdjustDirection, AdjustReason, Adjustment, AimdController, Observation};
 pub use auth::{AuthProvider, AuthReference, AuthSpec, Credential, SharedAuthProvider};
 pub use check::{CheckContext, CheckReport, Probe, ProbeStatus};
 pub use dlq::{DlqConfig, DlqReason, DlqStats, OnBatchError, build_envelope};

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -36,7 +36,9 @@ pub mod util;
 #[cfg(feature = "compression")]
 pub mod compression;
 
-pub use adaptive::{AdaptiveBatchConfig, AdjustDirection, AdjustReason, Adjustment, AimdController, Observation};
+pub use adaptive::{
+    AdaptiveBatchConfig, AdjustDirection, AdjustReason, Adjustment, AimdController, Observation,
+};
 pub use auth::{AuthProvider, AuthReference, AuthSpec, Credential, SharedAuthProvider};
 pub use check::{CheckContext, CheckReport, Probe, ProbeStatus};
 pub use dlq::{DlqConfig, DlqReason, DlqStats, OnBatchError, build_envelope};

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -13,6 +13,7 @@
 //! - [`ReplicationMethod`] — incremental replication support
 //! - [`schema::infer_schema`] — JSON Schema inference from record samples
 
+pub mod adaptive;
 pub mod auth;
 pub mod check;
 pub mod config;
@@ -35,6 +36,7 @@ pub mod util;
 #[cfg(feature = "compression")]
 pub mod compression;
 
+pub use adaptive::AdaptiveBatchConfig;
 pub use auth::{AuthProvider, AuthReference, AuthSpec, Credential, SharedAuthProvider};
 pub use check::{CheckContext, CheckReport, Probe, ProbeStatus};
 pub use dlq::{DlqConfig, DlqReason, DlqStats, OnBatchError, build_envelope};

--- a/crates/core/src/observability/options.rs
+++ b/crates/core/src/observability/options.rs
@@ -16,6 +16,9 @@ pub struct RunStreamOptions {
     pub dlq: Option<DlqConfig>,
     #[cfg(feature = "quality")]
     pub quality: Option<std::sync::Arc<crate::quality::CompiledQuality>>,
+    /// Adaptive batch-size controller config; `None` (or `enabled = false`)
+    /// leaves the per-page write path unchanged.
+    pub adaptive: Option<crate::adaptive::AdaptiveBatchConfig>,
 }
 
 impl RunStreamOptions {
@@ -46,6 +49,12 @@ impl RunStreamOptions {
 
     pub fn with_dlq(mut self, dlq: DlqConfig) -> Self {
         self.dlq = Some(dlq);
+        self
+    }
+
+    /// Attach an adaptive batch-size controller config.
+    pub fn with_adaptive(mut self, cfg: crate::adaptive::AdaptiveBatchConfig) -> Self {
+        self.adaptive = Some(cfg);
         self
     }
 

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -548,21 +548,23 @@ where
                             // `reason` label accurate when adaptive reslicing
                             // mixes a synthesized chunk with partial-failure
                             // chunks on the same page.
-                            let (chunk_outcomes, chunk_synthesized): (Vec<crate::RowOutcome>, bool) =
-                                match chunk_outcomes_result {
-                                    Ok(o) => (o, false),
-                                    Err(e) => match dlq_cfg.on_batch_error {
-                                        OnBatchError::Propagate => return Err(e),
-                                        OnBatchError::DlqAll => {
-                                            outer_err_recovered = true;
-                                            let msg = e.to_string();
-                                            let synth = (0..chunk.len())
-                                                .map(|_| Err(FaucetError::Sink(msg.clone())))
-                                                .collect();
-                                            (synth, true)
-                                        }
-                                    },
-                                };
+                            let (chunk_outcomes, chunk_synthesized): (
+                                Vec<crate::RowOutcome>,
+                                bool,
+                            ) = match chunk_outcomes_result {
+                                Ok(o) => (o, false),
+                                Err(e) => match dlq_cfg.on_batch_error {
+                                    OnBatchError::Propagate => return Err(e),
+                                    OnBatchError::DlqAll => {
+                                        outer_err_recovered = true;
+                                        let msg = e.to_string();
+                                        let synth = (0..chunk.len())
+                                            .map(|_| Err(FaucetError::Sink(msg.clone())))
+                                            .collect();
+                                        (synth, true)
+                                    }
+                                },
+                            };
                             let mut chunk_errors = 0usize;
                             for (j, outcome) in chunk_outcomes.iter().enumerate() {
                                 match outcome {
@@ -727,7 +729,8 @@ where
                                 maybe_warn_noop_sink(sink_name, &mut warned_noop_sink);
                                 let mut offset = 0;
                                 while offset < page.records.len() {
-                                    let size = ctrl.current().max(1).min(page.records.len() - offset);
+                                    let size =
+                                        ctrl.current().max(1).min(page.records.len() - offset);
                                     let chunk = &page.records[offset..offset + size];
                                     let t0 = std::time::Instant::now();
                                     let n = sink.write_batch(chunk).await?;
@@ -857,10 +860,17 @@ fn emit_adaptive_metrics(
         Label::new("row", SharedString::from(row.to_string())),
     ];
     gauge!("faucet_pipeline_adaptive_batch_size", base.clone()).set(ctrl.current() as f64);
-    gauge!("faucet_pipeline_adaptive_batch_cooldown_active", base.clone())
-        .set(if ctrl.cooldown_active() { 1.0 } else { 0.0 });
+    gauge!(
+        "faucet_pipeline_adaptive_batch_cooldown_active",
+        base.clone()
+    )
+    .set(if ctrl.cooldown_active() { 1.0 } else { 0.0 });
     if let Some(p50) = ctrl.p50_latency_ms() {
-        gauge!("faucet_pipeline_adaptive_batch_p50_latency_ms", base.clone()).set(p50 as f64);
+        gauge!(
+            "faucet_pipeline_adaptive_batch_p50_latency_ms",
+            base.clone()
+        )
+        .set(p50 as f64);
     }
     if let Some(a) = adj {
         let mut lbl = base;
@@ -2308,21 +2318,42 @@ mod tests {
 
     /// Sink whose write_batch_partial fails every Nth record; drives the
     /// error-rate signal. Requires a DLQ in run_stream.
-    struct FlakySink { every: usize, calls: std::sync::Mutex<Vec<usize>> }
+    struct FlakySink {
+        every: usize,
+        calls: std::sync::Mutex<Vec<usize>>,
+    }
     impl FlakySink {
-        fn new(every: usize) -> Self { Self { every, calls: std::sync::Mutex::new(Vec::new()) } }
-        fn call_sizes(&self) -> Vec<usize> { self.calls.lock().unwrap().clone() }
+        fn new(every: usize) -> Self {
+            Self {
+                every,
+                calls: std::sync::Mutex::new(Vec::new()),
+            }
+        }
+        fn call_sizes(&self) -> Vec<usize> {
+            self.calls.lock().unwrap().clone()
+        }
     }
     #[async_trait]
     impl Sink for FlakySink {
         async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
             Ok(records.len())
         }
-        async fn write_batch_partial(&self, records: &[Value]) -> Result<Vec<crate::RowOutcome>, FaucetError> {
+        async fn write_batch_partial(
+            &self,
+            records: &[Value],
+        ) -> Result<Vec<crate::RowOutcome>, FaucetError> {
             self.calls.lock().unwrap().push(records.len());
-            Ok(records.iter().enumerate().map(|(i, _)| {
-                if (i + 1) % self.every == 0 { Err(FaucetError::Sink("synthetic".into())) } else { Ok(()) }
-            }).collect())
+            Ok(records
+                .iter()
+                .enumerate()
+                .map(|(i, _)| {
+                    if (i + 1) % self.every == 0 {
+                        Err(FaucetError::Sink("synthetic".into()))
+                    } else {
+                        Ok(())
+                    }
+                })
+                .collect())
         }
     }
 
@@ -2334,7 +2365,10 @@ mod tests {
         // adaptive_shrinks_under_latency_target_then_smaller_chunks. After
         // page 1 (single 400-record chunk, 25% error rate > threshold 0.1),
         // the controller shrinks and subsequent pages get smaller sub-batches.
-        let mk = || StreamPage { records: (0..400).map(|i| json!({"i": i})).collect(), bookmark: None };
+        let mk = || StreamPage {
+            records: (0..400).map(|i| json!({"i": i})).collect(),
+            bookmark: None,
+        };
         let stream = futures::stream::iter(vec![Ok(mk()), Ok(mk()), Ok(mk())]);
         let sink = FlakySink::new(4); // 25% error rate > threshold 0.1
         let dlq_sink: Arc<dyn Sink> = Arc::new(MockSink::new());
@@ -2348,7 +2382,8 @@ mod tests {
         let cfg: AdaptiveBatchConfig = serde_json::from_value(json!({
             "enabled": true, "min": 50, "max": 400,
             "decrease_factor": 0.5, "cooldown_batches": 0, "error_threshold": 0.1
-        })).unwrap();
+        }))
+        .unwrap();
         let opts = RunStreamOptions::new().with_dlq(dlq).with_adaptive(cfg);
         let result = run_stream(stream, &sink, opts).await.unwrap();
         // 3 × 400 = 1200 records total; FlakySink(4) fails every 4th record
@@ -2357,11 +2392,21 @@ mod tests {
         // rate: page 1 = one 400-record chunk (300 written, 100 DLQ); pages
         // 2–3 = smaller sub-batches; overall >≈75% of 1200 commit and ~25% go
         // to the DLQ.
-        assert!(result.records_written >= 900, "expected ≥900 written, got {}", result.records_written);
+        assert!(
+            result.records_written >= 900,
+            "expected ≥900 written, got {}",
+            result.records_written
+        );
         let sizes = sink.call_sizes();
         assert_eq!(sizes[0], 400, "first chunk is the full page");
-        assert!(sizes.last().unwrap() < &400, "controller should shrink under errors: {sizes:?}");
-        assert!(result.dlq.unwrap().records_dlq >= 250, "expected ≥250 DLQ records");
+        assert!(
+            sizes.last().unwrap() < &400,
+            "controller should shrink under errors: {sizes:?}"
+        );
+        assert!(
+            result.dlq.unwrap().records_dlq >= 250,
+            "expected ≥250 DLQ records"
+        );
     }
 
     // ── Adaptive batch-size tests ──────────────────────────────────────────
@@ -2374,9 +2419,14 @@ mod tests {
     }
     impl RecordingSink {
         fn new(latency_ms: u64) -> Self {
-            Self { calls: std::sync::Mutex::new(Vec::new()), latency: std::time::Duration::from_millis(latency_ms) }
+            Self {
+                calls: std::sync::Mutex::new(Vec::new()),
+                latency: std::time::Duration::from_millis(latency_ms),
+            }
         }
-        fn call_sizes(&self) -> Vec<usize> { self.calls.lock().unwrap().clone() }
+        fn call_sizes(&self) -> Vec<usize> {
+            self.calls.lock().unwrap().clone()
+        }
     }
     #[async_trait]
     impl Sink for RecordingSink {
@@ -2409,21 +2459,28 @@ mod tests {
     #[tokio::test]
     async fn adaptive_shrinks_under_latency_target_then_smaller_chunks() {
         use crate::adaptive::AdaptiveBatchConfig;
-        let mk = || StreamPage { records: (0..400).map(|i| json!({"i": i})).collect(), bookmark: None };
+        let mk = || StreamPage {
+            records: (0..400).map(|i| json!({"i": i})).collect(),
+            bookmark: None,
+        };
         let stream = futures::stream::iter(vec![Ok(mk()), Ok(mk()), Ok(mk())]);
         let sink = RecordingSink::new(50);
         let cfg: AdaptiveBatchConfig = serde_json::from_value(json!({
             "enabled": true, "min": 50, "max": 400,
             "decrease_factor": 0.5, "cooldown_batches": 0,
             "target_latency_ms": 10, "latency_window": 1
-        })).unwrap();
+        }))
+        .unwrap();
         let result = run_stream(stream, &sink, RunStreamOptions::new().with_adaptive(cfg))
             .await
             .unwrap();
         assert_eq!(result.records_written, 1200);
         let sizes = sink.call_sizes();
         assert_eq!(sizes[0], 400);
-        assert!(sizes.last().unwrap() < &400, "controller should have shrunk: {sizes:?}");
+        assert!(
+            sizes.last().unwrap() < &400,
+            "controller should have shrunk: {sizes:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -421,6 +421,14 @@ where
     let mut dlq_stats = DlqStats::default();
 
     let adaptive_cfg = options.adaptive.clone().filter(|c| c.enabled);
+    if let Some(cfg) = adaptive_cfg.as_ref()
+        && !cfg.respect_source_max
+    {
+        tracing::warn!(
+            "adaptive_batch_size.respect_source_max=false is not yet implemented \
+             (cross-page buffering); growth is capped at the source page size"
+        );
+    }
     let mut controller: Option<crate::adaptive::AimdController> = None;
     let mut warned_noop_sink = false;
 
@@ -576,12 +584,12 @@ where
                                 }
                             }
                             if let Some(ctrl) = controller.as_mut() {
-                                let _adj = ctrl.observe(crate::adaptive::Observation {
+                                let adj = ctrl.observe(crate::adaptive::Observation {
                                     batch_len: chunk.len(),
                                     errors: chunk_errors,
                                     latency,
                                 });
-                                // (metric emission added in a later task)
+                                emit_adaptive_metrics(ctrl, adj, &pipeline_name, &row);
                             }
                             offset += size;
                         }
@@ -726,12 +734,12 @@ where
                                     let latency = t0.elapsed();
                                     records_written += n;
                                     offset += size;
-                                    let _adj = ctrl.observe(crate::adaptive::Observation {
+                                    let adj = ctrl.observe(crate::adaptive::Observation {
                                         batch_len: chunk.len(),
                                         errors: 0,
                                         latency,
                                     });
-                                    // (metric emission added in a later task)
+                                    emit_adaptive_metrics(ctrl, adj, &pipeline_name, &row);
                                 }
                             } else {
                                 records_written += sink.write_batch(&page.records).await?;
@@ -833,6 +841,39 @@ where
         bookmark: last_bookmark,
         dlq: dlq.is_some().then_some(dlq_stats),
     })
+}
+
+/// Emit the adaptive controller's current state + any adjustment as metrics.
+/// Labels are `pipeline,row` only (the controller is pipeline-scoped).
+fn emit_adaptive_metrics(
+    ctrl: &crate::adaptive::AimdController,
+    adj: Option<crate::adaptive::Adjustment>,
+    pipeline: &str,
+    row: &str,
+) {
+    use metrics::{Label, SharedString, counter, gauge};
+    let base = vec![
+        Label::new("pipeline", SharedString::from(pipeline.to_string())),
+        Label::new("row", SharedString::from(row.to_string())),
+    ];
+    gauge!("faucet_pipeline_adaptive_batch_size", base.clone()).set(ctrl.current() as f64);
+    gauge!("faucet_pipeline_adaptive_batch_cooldown_active", base.clone())
+        .set(if ctrl.cooldown_active() { 1.0 } else { 0.0 });
+    if let Some(p50) = ctrl.p50_latency_ms() {
+        gauge!("faucet_pipeline_adaptive_batch_p50_latency_ms", base.clone()).set(p50 as f64);
+    }
+    if let Some(a) = adj {
+        let mut lbl = base;
+        lbl.push(Label::new(
+            "direction",
+            SharedString::const_str(a.direction.as_str()),
+        ));
+        lbl.push(Label::new(
+            "reason",
+            SharedString::const_str(a.reason.as_str()),
+        ));
+        counter!("faucet_pipeline_adaptive_batch_adjustments_total", lbl).increment(1);
+    }
 }
 
 /// One-shot info when adaptive sizing targets a per-record sink that ignores
@@ -2383,5 +2424,79 @@ mod tests {
         let sizes = sink.call_sizes();
         assert_eq!(sizes[0], 400);
         assert!(sizes.last().unwrap() < &400, "controller should have shrunk: {sizes:?}");
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn adaptive_emits_batch_size_and_adjustments_metrics() {
+        // Mirror the same LOCK+snapshotter pattern used by
+        // `pipeline_run_increments_runs_total` and `dlq_emits_records_total_and_pages_total`.
+        use crate::adaptive::AdaptiveBatchConfig;
+        use crate::observability::decorator::source_tests::{LOCK, snapshotter};
+        use metrics_util::debugging::DebugValue;
+
+        let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let snap = snapshotter();
+
+        // Three pages of 400 records. RecordingSink(50) reports 50ms latency.
+        // Config: target_latency_ms=10, latency_window=1, cooldown_batches=0 so
+        // p50 (50ms) > 10*1.2=12ms on every batch → controller shrinks each time,
+        // guaranteeing at least one `faucet_pipeline_adaptive_batch_adjustments_total`
+        // is emitted.
+        let mk = || StreamPage {
+            records: (0..400).map(|i| json!({"i": i})).collect(),
+            bookmark: None,
+        };
+        let stream = futures::stream::iter(vec![Ok(mk()), Ok(mk()), Ok(mk())]);
+        let sink = RecordingSink::new(50);
+        let cfg: AdaptiveBatchConfig = serde_json::from_value(json!({
+            "enabled": true, "min": 50, "max": 400,
+            "decrease_factor": 0.5, "cooldown_batches": 0,
+            "target_latency_ms": 10, "latency_window": 1
+        }))
+        .unwrap();
+
+        let _ = run_stream(
+            stream,
+            &sink,
+            RunStreamOptions::new()
+                .with_adaptive(cfg)
+                .with_name("p")
+                .with_row("r"),
+        )
+        .await
+        .unwrap();
+
+        let snapshot = snap.snapshot();
+        let mut saw_batch_size = false;
+        let mut saw_adjustments = false;
+        for (k, _u, _d, v) in snapshot.into_vec() {
+            let key = k.key();
+            let labels = key.labels().collect::<Vec<_>>();
+            let has = |k: &str, val: &str| labels.iter().any(|l| l.key() == k && l.value() == val);
+
+            if key.name() == "faucet_pipeline_adaptive_batch_size"
+                && has("pipeline", "p")
+                && has("row", "r")
+                && matches!(v, DebugValue::Gauge(_))
+            {
+                saw_batch_size = true;
+            }
+            if key.name() == "faucet_pipeline_adaptive_batch_adjustments_total"
+                && has("pipeline", "p")
+                && has("row", "r")
+                && matches!(v, DebugValue::Counter(c) if c >= 1)
+            {
+                saw_adjustments = true;
+            }
+        }
+        assert!(
+            saw_batch_size,
+            "expected faucet_pipeline_adaptive_batch_size gauge with pipeline=p, row=r"
+        );
+        assert!(
+            saw_adjustments,
+            "expected faucet_pipeline_adaptive_batch_adjustments_total counter with pipeline=p, row=r"
+        );
     }
 }

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -131,6 +131,7 @@ pub struct Pipeline<'a, So: Source + ?Sized, Si: Sink + ?Sized> {
     dlq: Option<DlqConfig>,
     #[cfg(feature = "quality")]
     quality: Option<Arc<crate::quality::CompiledQuality>>,
+    adaptive: Option<crate::adaptive::AdaptiveBatchConfig>,
 }
 
 impl<'a, So: Source + ?Sized, Si: Sink + ?Sized> Pipeline<'a, So, Si> {
@@ -146,6 +147,7 @@ impl<'a, So: Source + ?Sized, Si: Sink + ?Sized> Pipeline<'a, So, Si> {
             dlq: None,
             #[cfg(feature = "quality")]
             quality: None,
+            adaptive: None,
         }
     }
 
@@ -200,6 +202,14 @@ impl<'a, So: Source + ?Sized, Si: Sink + ?Sized> Pipeline<'a, So, Si> {
     #[cfg(feature = "quality")]
     pub fn with_quality(mut self, quality: Arc<crate::quality::CompiledQuality>) -> Self {
         self.quality = Some(quality);
+        self
+    }
+
+    /// Attach an adaptive batch-size controller (opt-in). When `enabled`, the
+    /// pipeline reslices each source page into sub-batches whose size the
+    /// controller tunes from observed sink latency + error rate.
+    pub fn with_adaptive(mut self, cfg: crate::adaptive::AdaptiveBatchConfig) -> Self {
+        self.adaptive = Some(cfg);
         self
     }
 
@@ -325,6 +335,9 @@ impl<'a, So: Source + ?Sized, Si: Sink + ?Sized> Pipeline<'a, So, Si> {
             #[cfg(feature = "quality")]
             if let Some(q) = self.quality.clone() {
                 opts = opts.with_quality(q);
+            }
+            if let Some(ad) = self.adaptive.clone() {
+                opts = opts.with_adaptive(ad);
             }
 
             run_stream(pages, &wrapped_sink, opts).await

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -502,47 +502,76 @@ where
                         );
                         let _enter = span.enter();
 
-                        let outcomes_result = if page.records.is_empty() {
-                            Ok(Vec::new())
-                        } else {
-                            sink.write_batch_partial(&page.records).await
-                        };
-                        let mut outer_err_recovered = false;
-                        let outcomes = match outcomes_result {
-                            Ok(o) => o,
-                            Err(e) => match dlq_cfg.on_batch_error {
-                                OnBatchError::Propagate => return Err(e),
-                                OnBatchError::DlqAll => {
-                                    // Synthesize per-row failures echoing the
-                                    // underlying message so envelopes carry it.
-                                    // The flag distinguishes this from a sink
-                                    // override that legitimately returned all
-                                    // per-row Errs — that case keeps the
-                                    // `partial` reason label.
-                                    outer_err_recovered = true;
-                                    let msg = e.to_string();
-                                    (0..page.records.len())
-                                        .map(|_| Err(FaucetError::Sink(msg.clone())))
-                                        .collect()
-                                }
-                            },
-                        };
-
-                        // Partition into success count + failure envelopes.
+                        // Reslice the page into sub-batches driven by the
+                        // adaptive controller (or write the whole page in one
+                        // shot when adaptive is disabled — same as before).
                         let mut envelopes: Vec<Value> = Vec::new();
                         let mut page_success = 0usize;
-                        for (i, outcome) in outcomes.iter().enumerate() {
-                            match outcome {
-                                Ok(()) => page_success += 1,
-                                Err(err) => envelopes.push(build_envelope(
-                                    &page.records[i],
-                                    err,
-                                    sink_name,
-                                    &pipeline_name,
-                                    &row,
-                                    i,
-                                )),
+                        let mut outer_err_recovered = false;
+                        let records_len = page.records.len();
+                        let mut offset = 0usize;
+                        while offset < records_len {
+                            let size = match adaptive_cfg.as_ref() {
+                                Some(cfg) => {
+                                    let ctrl = controller.get_or_insert_with(|| {
+                                        crate::adaptive::AimdController::new(cfg, records_len)
+                                    });
+                                    ctrl.current().max(1).min(records_len - offset)
+                                }
+                                None => records_len - offset, // whole page = today's behavior
+                            };
+                            if adaptive_cfg.is_some() {
+                                maybe_warn_noop_sink(sink_name, &mut warned_noop_sink);
                             }
+                            let chunk = &page.records[offset..offset + size];
+                            let t0 = std::time::Instant::now();
+                            let chunk_outcomes_result = sink.write_batch_partial(chunk).await;
+                            let latency = t0.elapsed();
+                            let chunk_outcomes = match chunk_outcomes_result {
+                                Ok(o) => o,
+                                Err(e) => match dlq_cfg.on_batch_error {
+                                    OnBatchError::Propagate => return Err(e),
+                                    OnBatchError::DlqAll => {
+                                        // Synthesize per-row failures echoing the
+                                        // underlying message so envelopes carry it.
+                                        // The flag distinguishes this from a sink
+                                        // override that legitimately returned all
+                                        // per-row Errs — that case keeps the
+                                        // `partial` reason label.
+                                        outer_err_recovered = true;
+                                        let msg = e.to_string();
+                                        (0..chunk.len())
+                                            .map(|_| Err(FaucetError::Sink(msg.clone())))
+                                            .collect()
+                                    }
+                                },
+                            };
+                            let mut chunk_errors = 0usize;
+                            for (j, outcome) in chunk_outcomes.iter().enumerate() {
+                                match outcome {
+                                    Ok(()) => page_success += 1,
+                                    Err(err) => {
+                                        chunk_errors += 1;
+                                        envelopes.push(build_envelope(
+                                            &chunk[j],
+                                            err,
+                                            sink_name,
+                                            &pipeline_name,
+                                            &row,
+                                            offset + j,
+                                        ));
+                                    }
+                                }
+                            }
+                            if let Some(ctrl) = controller.as_mut() {
+                                let _adj = ctrl.observe(crate::adaptive::Observation {
+                                    batch_len: chunk.len(),
+                                    errors: chunk_errors,
+                                    latency,
+                                });
+                                // (metric emission added in a later task)
+                            }
+                            offset += size;
                         }
                         // Quality-quarantined records share the DLQ budget/write.
                         // Capture the quality count BEFORE the splice — the splice
@@ -2214,6 +2243,64 @@ mod tests {
         let opts = RunStreamOptions::new().with_quality(quality);
         let result = run_stream(futures::stream::iter(pages), &main, opts).await;
         assert!(matches!(result, Err(FaucetError::Config(_))));
+    }
+
+    /// Sink whose write_batch_partial fails every Nth record; drives the
+    /// error-rate signal. Requires a DLQ in run_stream.
+    struct FlakySink { every: usize, calls: std::sync::Mutex<Vec<usize>> }
+    impl FlakySink {
+        fn new(every: usize) -> Self { Self { every, calls: std::sync::Mutex::new(Vec::new()) } }
+        fn call_sizes(&self) -> Vec<usize> { self.calls.lock().unwrap().clone() }
+    }
+    #[async_trait]
+    impl Sink for FlakySink {
+        async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
+            Ok(records.len())
+        }
+        async fn write_batch_partial(&self, records: &[Value]) -> Result<Vec<crate::RowOutcome>, FaucetError> {
+            self.calls.lock().unwrap().push(records.len());
+            Ok(records.iter().enumerate().map(|(i, _)| {
+                if (i + 1) % self.every == 0 { Err(FaucetError::Sink("synthetic".into())) } else { Ok(()) }
+            }).collect())
+        }
+    }
+
+    #[tokio::test]
+    async fn adaptive_shrinks_under_errors_on_dlq_path() {
+        use crate::adaptive::AdaptiveBatchConfig;
+        use crate::dlq::{DlqConfig, OnBatchError};
+        // Three pages of 400 records each, matching the pattern used by
+        // adaptive_shrinks_under_latency_target_then_smaller_chunks. After
+        // page 1 (single 400-record chunk, 25% error rate > threshold 0.1),
+        // the controller shrinks and subsequent pages get smaller sub-batches.
+        let mk = || StreamPage { records: (0..400).map(|i| json!({"i": i})).collect(), bookmark: None };
+        let stream = futures::stream::iter(vec![Ok(mk()), Ok(mk()), Ok(mk())]);
+        let sink = FlakySink::new(4); // 25% error rate > threshold 0.1
+        let dlq_sink: Arc<dyn Sink> = Arc::new(MockSink::new());
+        let dlq = DlqConfig {
+            sink: dlq_sink,
+            on_batch_error: OnBatchError::Propagate,
+            max_failures_per_page: None,
+            max_failures_total: None,
+            include_original_payload: true,
+        };
+        let cfg: AdaptiveBatchConfig = serde_json::from_value(json!({
+            "enabled": true, "min": 50, "max": 400,
+            "decrease_factor": 0.5, "cooldown_batches": 0, "error_threshold": 0.1
+        })).unwrap();
+        let opts = RunStreamOptions::new().with_dlq(dlq).with_adaptive(cfg);
+        let result = run_stream(stream, &sink, opts).await.unwrap();
+        // 3 × 400 = 1200 records total; FlakySink(4) fails every 4th record
+        // per-chunk (floor(n/4)), so exact counts depend on chunk sizes due to
+        // integer arithmetic. With the controller shrinking under 25% error
+        // rate: page 1 = one 400-record chunk (300 written, 100 DLQ); pages
+        // 2–3 = smaller sub-batches; overall >≈75% of 1200 commit and ~25% go
+        // to the DLQ.
+        assert!(result.records_written >= 900, "expected ≥900 written, got {}", result.records_written);
+        let sizes = sink.call_sizes();
+        assert_eq!(sizes[0], 400, "first chunk is the full page");
+        assert!(sizes.last().unwrap() < &400, "controller should shrink under errors: {sizes:?}");
+        assert!(result.dlq.unwrap().records_dlq >= 250, "expected ≥250 DLQ records");
     }
 
     // ── Adaptive batch-size tests ──────────────────────────────────────────

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -420,6 +420,10 @@ where
     let mut last_bookmark: Option<Value> = None;
     let mut dlq_stats = DlqStats::default();
 
+    let adaptive_cfg = options.adaptive.clone().filter(|c| c.enabled);
+    let mut controller: Option<crate::adaptive::AimdController> = None;
+    let mut warned_noop_sink = false;
+
     let sink_name = sink.connector_name();
     let dlq_sink_name = dlq.as_ref().map(|d| d.sink.connector_name()).unwrap_or("");
 
@@ -659,7 +663,30 @@ where
                             "quality quarantine without DLQ should have been rejected at run start"
                         );
                         if !page.records.is_empty() {
-                            records_written += sink.write_batch(&page.records).await?;
+                            if let Some(cfg) = adaptive_cfg.as_ref() {
+                                let ctrl = controller.get_or_insert_with(|| {
+                                    crate::adaptive::AimdController::new(cfg, page.records.len())
+                                });
+                                maybe_warn_noop_sink(sink_name, &mut warned_noop_sink);
+                                let mut offset = 0;
+                                while offset < page.records.len() {
+                                    let size = ctrl.current().max(1).min(page.records.len() - offset);
+                                    let chunk = &page.records[offset..offset + size];
+                                    let t0 = std::time::Instant::now();
+                                    let n = sink.write_batch(chunk).await?;
+                                    let latency = t0.elapsed();
+                                    records_written += n;
+                                    offset += size;
+                                    let _adj = ctrl.observe(crate::adaptive::Observation {
+                                        batch_len: chunk.len(),
+                                        errors: 0,
+                                        latency,
+                                    });
+                                    // (metric emission added in a later task)
+                                }
+                            } else {
+                                records_written += sink.write_batch(&page.records).await?;
+                            }
                         }
                         if let Some(bookmark) = page.bookmark {
                             sink.flush().await?;
@@ -757,6 +784,18 @@ where
         bookmark: last_bookmark,
         dlq: dlq.is_some().then_some(dlq_stats),
     })
+}
+
+/// One-shot info when adaptive sizing targets a per-record sink that ignores
+/// `batch_size` (its adjustments are harmless no-ops).
+fn maybe_warn_noop_sink(sink_name: &str, warned: &mut bool) {
+    if !*warned && matches!(sink_name, "jsonl" | "csv" | "stdout") {
+        tracing::info!(
+            sink = sink_name,
+            "adaptive batch sizing is a no-op for this per-record sink"
+        );
+        *warned = true;
+    }
 }
 
 #[cfg(test)]
@@ -2175,5 +2214,67 @@ mod tests {
         let opts = RunStreamOptions::new().with_quality(quality);
         let result = run_stream(futures::stream::iter(pages), &main, opts).await;
         assert!(matches!(result, Err(FaucetError::Config(_))));
+    }
+
+    // ── Adaptive batch-size tests ──────────────────────────────────────────
+
+    /// A sink that records each write_batch call's size and reports a fixed
+    /// per-call latency, so we can assert the adaptive controller resliced.
+    struct RecordingSink {
+        calls: std::sync::Mutex<Vec<usize>>,
+        latency: std::time::Duration,
+    }
+    impl RecordingSink {
+        fn new(latency_ms: u64) -> Self {
+            Self { calls: std::sync::Mutex::new(Vec::new()), latency: std::time::Duration::from_millis(latency_ms) }
+        }
+        fn call_sizes(&self) -> Vec<usize> { self.calls.lock().unwrap().clone() }
+    }
+    #[async_trait]
+    impl Sink for RecordingSink {
+        async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
+            tokio::time::sleep(self.latency).await;
+            self.calls.lock().unwrap().push(records.len());
+            Ok(records.len())
+        }
+    }
+
+    #[tokio::test]
+    async fn adaptive_reslices_non_dlq_page_into_subbatches() {
+        use crate::adaptive::AdaptiveBatchConfig;
+        let page = StreamPage {
+            records: (0..1000).map(|i| json!({ "i": i })).collect(),
+            bookmark: None,
+        };
+        let stream = futures::stream::iter(vec![Ok(page)]);
+        let sink = RecordingSink::new(0);
+        let cfg: AdaptiveBatchConfig =
+            serde_json::from_value(json!({"enabled": true, "min": 100, "max": 1000})).unwrap();
+        let result = run_stream(stream, &sink, RunStreamOptions::new().with_adaptive(cfg))
+            .await
+            .unwrap();
+        assert_eq!(result.records_written, 1000);
+        // current starts at min(max, page_len)=1000 → one chunk (no regression).
+        assert_eq!(sink.call_sizes(), vec![1000]);
+    }
+
+    #[tokio::test]
+    async fn adaptive_shrinks_under_latency_target_then_smaller_chunks() {
+        use crate::adaptive::AdaptiveBatchConfig;
+        let mk = || StreamPage { records: (0..400).map(|i| json!({"i": i})).collect(), bookmark: None };
+        let stream = futures::stream::iter(vec![Ok(mk()), Ok(mk()), Ok(mk())]);
+        let sink = RecordingSink::new(50);
+        let cfg: AdaptiveBatchConfig = serde_json::from_value(json!({
+            "enabled": true, "min": 50, "max": 400,
+            "decrease_factor": 0.5, "cooldown_batches": 0,
+            "target_latency_ms": 10, "latency_window": 1
+        })).unwrap();
+        let result = run_stream(stream, &sink, RunStreamOptions::new().with_adaptive(cfg))
+            .await
+            .unwrap();
+        assert_eq!(result.records_written, 1200);
+        let sizes = sink.call_sizes();
+        assert_eq!(sizes[0], 400);
+        assert!(sizes.last().unwrap() < &400, "controller should have shrunk: {sizes:?}");
     }
 }

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -508,6 +508,11 @@ where
                         let mut envelopes: Vec<Value> = Vec::new();
                         let mut page_success = 0usize;
                         let mut outer_err_recovered = false;
+                        // True if any chunk reported genuine per-row sink `Err`s
+                        // (as opposed to a chunk wholly synthesized from an outer
+                        // error under `DlqAll`). Drives the `partial` label when a
+                        // resliced page mixes the two failure modes.
+                        let mut had_per_row_sink_failure = false;
                         let records_len = page.records.len();
                         let mut offset = 0usize;
                         while offset < records_len {
@@ -527,31 +532,38 @@ where
                             let t0 = std::time::Instant::now();
                             let chunk_outcomes_result = sink.write_batch_partial(chunk).await;
                             let latency = t0.elapsed();
-                            let chunk_outcomes = match chunk_outcomes_result {
-                                Ok(o) => o,
-                                Err(e) => match dlq_cfg.on_batch_error {
-                                    OnBatchError::Propagate => return Err(e),
-                                    OnBatchError::DlqAll => {
-                                        // Synthesize per-row failures echoing the
-                                        // underlying message so envelopes carry it.
-                                        // The flag distinguishes this from a sink
-                                        // override that legitimately returned all
-                                        // per-row Errs — that case keeps the
-                                        // `partial` reason label.
-                                        outer_err_recovered = true;
-                                        let msg = e.to_string();
-                                        (0..chunk.len())
-                                            .map(|_| Err(FaucetError::Sink(msg.clone())))
-                                            .collect()
-                                    }
-                                },
-                            };
+                            // `chunk_synthesized` is true only when this chunk's
+                            // outcomes were fabricated from a single outer
+                            // `write_batch_partial` error under `DlqAll` — as
+                            // opposed to genuine per-row `Err`s the sink
+                            // reported. Tracking it per chunk keeps the page
+                            // `reason` label accurate when adaptive reslicing
+                            // mixes a synthesized chunk with partial-failure
+                            // chunks on the same page.
+                            let (chunk_outcomes, chunk_synthesized): (Vec<crate::RowOutcome>, bool) =
+                                match chunk_outcomes_result {
+                                    Ok(o) => (o, false),
+                                    Err(e) => match dlq_cfg.on_batch_error {
+                                        OnBatchError::Propagate => return Err(e),
+                                        OnBatchError::DlqAll => {
+                                            outer_err_recovered = true;
+                                            let msg = e.to_string();
+                                            let synth = (0..chunk.len())
+                                                .map(|_| Err(FaucetError::Sink(msg.clone())))
+                                                .collect();
+                                            (synth, true)
+                                        }
+                                    },
+                                };
                             let mut chunk_errors = 0usize;
                             for (j, outcome) in chunk_outcomes.iter().enumerate() {
                                 match outcome {
                                     Ok(()) => page_success += 1,
                                     Err(err) => {
                                         chunk_errors += 1;
+                                        if !chunk_synthesized {
+                                            had_per_row_sink_failure = true;
+                                        }
                                         envelopes.push(build_envelope(
                                             &chunk[j],
                                             err,
@@ -629,19 +641,27 @@ where
                             dlq_stats.records_dlq += page_failures;
                             dlq_stats.pages_with_failures += 1;
 
-                            // Page `reason` label, 3-way:
-                            //  - `dlq_all`  — the whole page was synthesized from a
-                            //    single outer sink error (OnBatchError::DlqAll).
-                            //  - `partial`  — at least one row failed on the SINK
-                            //    side (`page_failures > quality_count`). A mixed
-                            //    page carrying both sink failures and quality
-                            //    quarantines is labeled `partial`: the sink failure
-                            //    dominates.
+                            // Page `reason` label, 3-way (precedence: partial > dlq_all > quality):
+                            //  - `partial`  — at least one chunk reported genuine
+                            //    per-row sink `Err`s. Checked FIRST so a resliced
+                            //    page that mixes a synthesized chunk (DlqAll) with
+                            //    partial-failure chunks is labeled `partial` — the
+                            //    real per-row failure dominates. (For a
+                            //    non-resliced page this is equivalent to the old
+                            //    `page_failures > quality_count` test, since a
+                            //    single chunk is either all-synthesized or all
+                            //    per-row.)
+                            //  - `dlq_all`  — every sink-side failure on the page
+                            //    was synthesized from an outer `write_batch_partial`
+                            //    error (OnBatchError::DlqAll); no genuine per-row
+                            //    failures occurred.
                             //  - `quality`  — every envelope is quality-sourced
                             //    (no sink-side failures on this page).
                             // The per-row quality volume is separately exposed via
                             // `faucet_quality_records_quarantined_total`.
-                            let reason_label = if outer_err_recovered {
+                            let reason_label = if had_per_row_sink_failure {
+                                DlqReason::Partial.as_str()
+                            } else if outer_err_recovered {
                                 DlqReason::DlqAll.as_str()
                             } else if page_failures > quality_count {
                                 DlqReason::Partial.as_str()

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -25,6 +25,7 @@
 - [Compression](./cookbook/compression.md)
 - [Record transforms](./cookbook/transforms.md)
 - [Secrets-manager interpolation](./cookbook/secrets.md)
+- [Adaptive batching](./cookbook/adaptive-batching.md)
 - [Scheduling](./cookbook/scheduling.md)
 - [Troubleshooting with faucet doctor](./cookbook/troubleshooting.md)
 

--- a/docs/book/src/cookbook/adaptive-batching.md
+++ b/docs/book/src/cookbook/adaptive-batching.md
@@ -1,0 +1,207 @@
+# Adaptive batch sizing
+
+Adaptive batch sizing lets faucet automatically tune how many records it sends to
+the sink in each write, instead of using a fixed `batch_size`. The built-in
+**AIMD controller** (Additive Increase / Multiplicative Decrease) starts at the
+source page size, grows the batch additively when writes are clean and fast, and
+shrinks it multiplicatively when errors appear or write latency rises above a
+target.
+
+## When to use it
+
+Useful when the optimal write batch size changes over time or varies by data
+shape:
+
+- **Spiky data volumes** — smaller batches during large-row bursts; bigger ones
+  for narrow rows.
+- **Sink rate limits / quotas** — back off automatically when the API starts
+  returning errors or timing out.
+- **Latency-sensitive pipelines** — keep each write inside a target window
+  (e.g. `target_latency_ms: 1000`) rather than guessing a fixed size.
+
+Adaptive batch sizing is pure write-side tuning: the source page size is
+unchanged, and the controller simply reslices each page into sub-batches of the
+current effective size.
+
+## Configuration
+
+Add an `execution.adaptive_batch_size:` block to your config file:
+
+```yaml
+execution:
+  adaptive_batch_size:
+    enabled: true
+    min: 500
+    max: 10000
+    increase_step: 500
+    decrease_factor: 0.5
+    cooldown_batches: 5
+    target_latency_ms: 1000
+    latency_window: 10
+    error_threshold: 0.01
+    respect_source_max: true
+    log_every: 50
+```
+
+### Full example
+
+The [`postgres_to_bigquery_adaptive.yaml`](https://github.com/PawanSikawat/faucet-stream/blob/main/cli/examples/postgres_to_bigquery_adaptive.yaml)
+example pairs a PostgreSQL source with a BigQuery sink and a JSONL DLQ:
+
+```yaml
+# postgres_to_bigquery_adaptive.yaml  (abbreviated)
+version: 1
+name: postgres_to_bigquery_adaptive
+
+pipeline:
+  source:
+    type: postgres
+    config:
+      connection_url: ${env:PG_URL}
+      query: SELECT id, created_at, payload FROM orders WHERE created_at > $1
+      params: ["2026-01-01T00:00:00Z"]
+      batch_size: 5000   # source page size — also the effective upper ceiling
+      max_connections: 8
+
+  sink:
+    type: bigquery
+    config:
+      project_id: my-gcp-project
+      dataset_id: warehouse
+      table_id: orders
+      auth:
+        type: service_account_key
+        config:
+          json: ${env:GCP_KEY_JSON}
+      batch_size: 1000   # starting write size; the controller tunes this
+
+  dlq:
+    sink:
+      type: jsonl
+      config:
+        path: ./dlq/orders_failed.jsonl
+    on_batch_error: dlq_all
+
+execution:
+  adaptive_batch_size:
+    enabled: true
+    min: 500
+    max: 10000
+    increase_step: 500
+    decrease_factor: 0.5
+    cooldown_batches: 5
+    target_latency_ms: 1000
+    error_threshold: 0.01
+```
+
+## Config field reference
+
+All fields are optional except `enabled`. Unset fields take the defaults shown
+below.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `false` | Master switch. Set to `true` to activate the controller. |
+| `controller` | string | `"aimd"` | Algorithm. Only `"aimd"` is supported in v1. |
+| `min` | integer | `100` | Lower bound on effective batch size. Must be ≥ 1. |
+| `max` | integer | `50000` | Upper bound. Values above the source page size are inert (see Caveats). |
+| `increase_step` | integer | `250` | Rows added per clean, fast batch (additive growth). Must be ≥ 1. |
+| `decrease_factor` | float | `0.5` | Multiplicative shrink factor on error or high latency. Must be in (0, 1). |
+| `cooldown_batches` | integer | `5` | Batches to skip after a shrink before allowing growth again. |
+| `target_latency_ms` | integer \| null | `null` | Optional target write latency (ms). `null` means react to errors only. |
+| `latency_window` | integer | `10` | Rolling window size (batches) for the p50 latency estimate. Must be ≥ 1. |
+| `error_threshold` | float | `0.01` | Per-batch error rate (0.0–1.0) above which the controller shrinks. |
+| `respect_source_max` | bool | `true` | Cap effective batch size at the source page size. `false` is not yet implemented (logs a warning and behaves as `true`). |
+| `log_every` | integer | `50` | Emit a `tracing::info` summary every N adjustments (0 = never). |
+
+## AIMD behavior
+
+The controller follows a strict priority order for each sub-batch observation:
+
+1. **Error shrink (always fires, even during cooldown)** — if the per-batch error
+   rate exceeds `error_threshold`, the current size is multiplied by
+   `decrease_factor` (floor-rounded, clamped to `min`), and `cooldown_batches`
+   is armed.
+2. **Cooldown gate** — if cooldown is active, decrement the counter and skip
+   growth. A new error during cooldown fires rule 1 again and re-arms the counter.
+3. **Latency target (when `target_latency_ms` is set)** — evaluate the rolling
+   p50 latency:
+   - p50 > 1.2 × `target_latency_ms` → shrink.
+   - p50 < 0.5 × `target_latency_ms` → grow.
+   - Otherwise, stay (dead-band prevents oscillation).
+4. **Success growth** — add `increase_step` to the current size (clamped to
+   `max`).
+
+### Cold start
+
+The controller initialises to the first source page length, clamped into
+`[min, max]`. If the first page is smaller than `min`, the effective size starts
+at `min`.
+
+### Example trajectory
+
+With `min=500`, `max=5000`, `increase_step=500`, `decrease_factor=0.5`,
+`cooldown_batches=2`:
+
+```
+batch 1: size=1000, ok, fast  → grow  → 1500
+batch 2: size=1500, ok, fast  → grow  → 2000
+batch 3: size=2000, 3% errors → shrink→ 1000, cooldown armed (2)
+batch 4: size=1000, cooldown  → skip  → 1000
+batch 5: size=1000, cooldown  → skip  → 1000
+batch 6: size=1000, ok, fast  → grow  → 1500
+```
+
+## Metrics
+
+Four per-pipeline-row gauges / counters are emitted automatically:
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `faucet_pipeline_adaptive_batch_size` | gauge | Current effective batch size. |
+| `faucet_pipeline_adaptive_batch_adjustments_total` | counter | Total adjustments, labeled `direction=up\|down` and `reason=success\|error\|latency`. |
+| `faucet_pipeline_adaptive_batch_cooldown_active` | gauge | `1` while cooldown is active, `0` otherwise. |
+| `faucet_pipeline_adaptive_batch_p50_latency_ms` | gauge | Rolling p50 write latency (ms); absent until the window fills. |
+
+All four carry the standard `pipeline` and `row` labels.
+
+Example PromQL to alert when the controller is stuck shrinking:
+
+```promql
+# Shrink rate over the last 5 minutes
+rate(faucet_pipeline_adaptive_batch_adjustments_total{direction="down"}[5m])
+  > 0.5
+```
+
+## Caveats
+
+### Error-driven shrink requires a DLQ
+
+The error signal comes from per-row outcomes reported via the DLQ path
+(`Sink::write_batch_partial`). If no `dlq:` block is present, the controller
+sees zero errors regardless of the sink response — only `target_latency_ms`
+can drive shrinks. Add a `dlq:` block with `on_batch_error: dlq_all` if you
+want the controller to react to sink-side write errors.
+
+### Within-page ceiling: `max` is capped at the source page size
+
+In v1 the controller reslices pages it already received from the source — it
+cannot buffer records across pages. The effective upper bound is therefore
+`min(max, source_page_size)`. If you set `max: 50000` but the source emits
+pages of 1 000 records, the controller will never write more than 1 000 rows
+per call.
+
+**To allow bigger write batches, raise the source's `batch_size`** (e.g.
+`batch_size: 20000` on the postgres source config). Setting `max` higher than
+the source page size is harmless but inert.
+
+`respect_source_max: false` to cross page boundaries is planned but not yet
+implemented. Setting it logs a one-shot warning and behaves as `true`.
+
+### No-op for per-record sinks
+
+`jsonl`, `csv`, and `stdout` write one record at a time regardless of
+`batch_size`. Adaptive sizing is active but harmless for these sinks — the
+controller adjusts its internal state normally, but the actual write granularity
+is unchanged. A one-time `tracing::info` message notes this when the pipeline
+starts.

--- a/docs/book/src/reference/config.md
+++ b/docs/book/src/reference/config.md
@@ -176,6 +176,45 @@ auth:
 - `on_error` — `continue` (siblings finish; failed subtree skipped) or `stop`
   (abort pending and in-flight work on first failure).
 
+### Adaptive batch sizing
+
+The optional `adaptive_batch_size:` sub-block enables the AIMD controller that
+auto-tunes the effective write batch size from observed sink latency and error
+rate. Default `enabled: false` (opt-in).
+
+```yaml
+execution:
+  adaptive_batch_size:
+    enabled: true          # master switch
+    controller: aimd       # only "aimd" is supported in v1
+    min: 100               # lower bound (rows)
+    max: 50000             # upper bound; inert above the source page size
+    increase_step: 250     # additive growth per clean batch
+    decrease_factor: 0.5   # multiplicative shrink on error/high latency  (0, 1)
+    cooldown_batches: 5    # batches to skip after a shrink
+    target_latency_ms: null  # optional write-latency target (ms)
+    latency_window: 10     # rolling window size for p50 latency
+    error_threshold: 0.01  # per-batch error rate that triggers a shrink
+    respect_source_max: true  # cap at source page size (see Caveats)
+    log_every: 50          # tracing::info every N adjustments
+```
+
+**Key caveats:**
+
+- **Error-driven shrink requires a `dlq:` block.** Without one the controller
+  sees no per-row errors; only `target_latency_ms` can drive shrinks.
+- **Effective ceiling = source page size.** In v1 the controller reslices pages
+  in-memory — it cannot buffer across pages. Setting `max` higher than the
+  source `batch_size` is harmless but inert. Raise the source `batch_size` to
+  allow bigger write batches.
+- **No-op for per-record sinks.** `jsonl`, `csv`, and `stdout` write one record
+  at a time; the controller adjusts normally but the write granularity is
+  unchanged.
+
+See the [Adaptive batching cookbook](../cookbook/adaptive-batching.md) for a
+full worked example, the AIMD trajectory, and the four Prometheus metrics
+(`faucet_pipeline_adaptive_batch_*`).
+
 ## `schedule`
 
 Present only when you run `faucet schedule`. Absent configs are rejected by that


### PR DESCRIPTION
## Summary

Closes #128. Adds an **opt-in AIMD controller** that auto-tunes the effective write batch size per pipeline row from observed sink latency + per-batch error rate. Configured via a top-level `execution.adaptive_batch_size:` block. Default **off** → the streaming write path is byte-for-byte unchanged.

## What's included

- **`faucet-core::AdaptiveBatchConfig`** (serde + JsonSchema + fail-fast `validate()`) and **`AimdController`** — a pure, deterministic state machine (`crates/core/src/adaptive.rs`): additive grow on clean/fast batches, multiplicative shrink on errors/high-latency, `cooldown_batches` after a shrink, optional `target_latency_ms` deadband, bounds `[min, max]`.
- **`run_stream` reslicing** (both DLQ and non-DLQ paths): each source page is resliced into `controller.current()`-sized sub-batches, each sink write timed, `(latency, errors)` fed back. **Within-page only** — the effective ceiling is the source page size.
- **Four metrics** (`faucet_pipeline_adaptive_batch_{size,adjustments_total,cooldown_active,p50_latency_ms}`), labeled `pipeline,row` only (cardinality-safe).
- **CLI:** `execution.adaptive_batch_size` on `ExecutionSpec`; validated fail-fast at config load (in `expand`, so `faucet validate` rejects a bad block) and attached per row.
- Cookbook page, config reference, example (`postgres_to_bigquery_adaptive.yaml`), READMEs.

## Design divergences from the issue (all documented)

- **Signals measured directly** in `run_stream` (the pipeline can't read its own Prometheus metrics back).
- **Error-driven shrink requires a DLQ** (per-row outcomes come from the DLQ `write_batch_partial` path); latency-targeting + success-growth work without one.
- **Within-page v1:** `max` above the source page size is inert; `respect_source_max:false` (cross-page buffering) is deferred — it logs a one-shot warning and behaves as `true`. This avoided adding a bookmark-safety state machine to the streaming loop.

## Testing

- AIMD state-machine unit tests (grow/shrink/cooldown/latency-deadband/bounds/floor-warn/error-during-cooldown/multi-sample p50) + config validation tests.
- Integration tests: non-DLQ latency-shrink, DLQ error-shrink (page-scoped budget + page-relative envelope index preserved), metrics emission.
- All pre-existing pipeline/DLQ/quality tests pass unchanged (disabled-path invariant). `clippy --all-features -D warnings` + `fmt` clean.

## Follow-up

- #141 — `faucet schema execution` (the issue assumed it existed; a general ExecutionSpec introspection target, deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)