### PR TITLE
feat(serve): run lifecycle + idempotency + doctor_first (Phase 2+3 of #127)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,6 +141,7 @@ jsonwebtoken = "9"
 base64 = "0.22"
 rsa = "0.9"
 sha2 = "0.10"
+dashmap = "6"
 uuid = { version = "1", features = ["v4", "v7"] }
 google-cloud-storage = "1.12"
 google-cloud-auth = "1.10"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -270,6 +270,7 @@ serde_yaml = "0.9"
 async-stream.workspace = true
 futures-core.workspace = true
 reqwest = { workspace = true, features = ["json"] }
+tower = { version = "0.5", features = ["util"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -176,7 +176,7 @@ schedule = ["dep:croner", "dep:chrono-tz"]
 # Enables `observability` (serve renders /metrics on its own port). Gates the
 # tokio net/time features here (rather than the base dep) so slim non-serve
 # builds don't link the TCP stack.
-serve = ["observability", "tokio/net", "tokio/time", "dep:axum", "dep:tower-http", "dep:tokio-util", "dep:subtle"]
+serve = ["observability", "tokio/net", "tokio/time", "dep:axum", "dep:tower-http", "dep:tokio-util", "dep:subtle", "dep:dashmap", "dep:sha2"]
 serve-history-postgres = ["serve", "dep:sqlx"]
 serve-history-sqlite = ["serve", "dep:sqlx"]
 
@@ -253,6 +253,10 @@ axum = { workspace = true, optional = true }
 tower-http = { workspace = true, optional = true }
 tokio-util = { workspace = true, optional = true }
 subtle = { workspace = true, optional = true }
+# faucet serve run registry (Phase 2+); only compiled with the `serve` feature.
+dashmap = { workspace = true, optional = true }
+# faucet serve idempotency-key hashing (Phase 2+); only compiled with `serve`.
+sha2 = { workspace = true, optional = true }
 sqlx = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,9 +17,16 @@ path = "src/main.rs"
 [features]
 # Default: every first-party source, sink, and state backend so `cargo install`
 # yields a binary that can run any of the published example YAMLs out of the box.
-default = ["observability", "full", "quality"]
+# The two long-running runtime modes are intentionally excluded from this one-shot
+# runner: `schedule` (cron scheduler; pulls a cron parser + IANA timezone db) and
+# `serve` (HTTP control plane; links a web-server dependency tree and opens a
+# network listener). Opt in with `--features schedule` / `--features serve`, or
+# take everything with `--features full`.
+default = ["observability", "source", "sink", "state", "transforms", "compression", "quality"]
 
-full = ["observability", "source", "sink", "state", "transforms", "compression", "quality", "schedule", "serve"]
+# Everything the default build ships, plus the long-running runtime modes:
+# `schedule` (cron scheduler) and `serve` (HTTP control plane).
+full = ["default", "schedule", "serve"]
 
 # Data-quality checks (`quality:` config block). `quality-jsonschema` adds the
 # `json_schema` record check via a JSON Schema validator. Forwarded to

--- a/cli/src/commands/doctor.rs
+++ b/cli/src/commands/doctor.rs
@@ -422,7 +422,11 @@ mod tests {
                 probe_out("source", "read", ProbeStatus::Pass),
                 probe_out("sink", "auth", ProbeStatus::Fail { reason: "x".into() }),
             ]),
-            inv(vec![probe_out("sink", "auth", ProbeStatus::Fail { reason: "y".into() })]),
+            inv(vec![probe_out(
+                "sink",
+                "auth",
+                ProbeStatus::Fail { reason: "y".into() },
+            )]),
         ];
         assert_eq!(count_failures(&invs), 2);
     }

--- a/cli/src/commands/doctor.rs
+++ b/cli/src/commands/doctor.rs
@@ -27,15 +27,15 @@ use tokio::sync::Semaphore;
 /// A single probe enriched with the role + connector it came from. This is the
 /// `--json` shape for each probe.
 #[derive(Debug, Serialize)]
-struct ProbeOut {
-    role: &'static str,
-    connector: String,
-    name: &'static str,
+pub struct ProbeOut {
+    pub role: &'static str,
+    pub connector: String,
+    pub name: &'static str,
     #[serde(flatten)]
-    status: ProbeStatus,
-    elapsed_ms: u64,
+    pub status: ProbeStatus,
+    pub elapsed_ms: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
-    hint: Option<String>,
+    pub hint: Option<String>,
 }
 
 impl ProbeOut {
@@ -53,14 +53,14 @@ impl ProbeOut {
 
 /// One expanded invocation and its probes (the `--json` per-invocation shape).
 #[derive(Debug, Serialize)]
-struct InvocationOut {
-    id: String,
-    probes: Vec<ProbeOut>,
+pub struct InvocationOut {
+    pub id: String,
+    pub probes: Vec<ProbeOut>,
     // Connector kinds for the human header; not part of the JSON contract.
     #[serde(skip)]
-    source_kind: String,
+    pub source_kind: String,
     #[serde(skip)]
-    sink_kind: String,
+    pub sink_kind: String,
 }
 
 /// Execute the `doctor` subcommand.
@@ -91,33 +91,7 @@ pub async fn run(args: DoctorArgs) -> CliResult<()> {
         .collect();
     let n_children = nodes.len() - roots.len();
 
-    let permits = cfg
-        .execution
-        .as_ref()
-        .and_then(|e| e.max_concurrent)
-        .filter(|n| *n > 0)
-        .unwrap_or(8);
-    let sem = Arc::new(Semaphore::new(permits));
-
-    let mut handles = Vec::with_capacity(roots.len());
-    for node in &roots {
-        let id = node.id.clone();
-        let source = node.source.clone();
-        let sink = node.sink.clone();
-        let state = node.state.clone();
-        let auth = auth.clone();
-        let ctx = ctx.clone();
-        let sem = sem.clone();
-        handles.push(tokio::spawn(async move {
-            let _permit = sem.acquire_owned().await.expect("semaphore not closed");
-            probe_invocation(id, source, sink, state, &auth, &ctx).await
-        }));
-    }
-
-    let mut invocations = Vec::with_capacity(handles.len());
-    for h in handles {
-        invocations.push(h.await.expect("doctor probe task panicked"));
-    }
+    let mut invocations = probe_roots(&nodes, &auth, &ctx).await;
 
     redact_invocations(&mut invocations);
     let (_passed, failed, _skipped) = tally(&invocations);
@@ -145,7 +119,7 @@ pub async fn run(args: DoctorArgs) -> CliResult<()> {
 }
 
 /// Build the three connectors for one invocation and run their probes.
-async fn probe_invocation(
+pub async fn probe_invocation(
     id: String,
     source: ConnectorSpec,
     sink: ConnectorSpec,
@@ -184,6 +158,44 @@ async fn probe_invocation(
     }
 }
 
+/// Probe every *root* invocation's source/sink/state concurrently (bounded).
+/// Child invocations are skipped — their configs need parent records. Reused by
+/// `faucet doctor` and serve's `doctor_first` preflight.
+pub async fn probe_roots(
+    nodes: &[ExpandedNode],
+    auth: &AuthCatalog,
+    ctx: &CheckContext,
+) -> Vec<InvocationOut> {
+    let sem = Arc::new(Semaphore::new(8));
+    let mut handles = Vec::new();
+    for node in nodes.iter().filter(|n| matches!(n.role, NodeRole::Root)) {
+        let id = node.id.clone();
+        let source = node.source.clone();
+        let sink = node.sink.clone();
+        let state = node.state.clone();
+        let auth = auth.clone();
+        let ctx = ctx.clone();
+        let sem = sem.clone();
+        handles.push(tokio::spawn(async move {
+            let _permit = sem.acquire_owned().await.expect("semaphore not closed");
+            probe_invocation(id, source, sink, state, &auth, &ctx).await
+        }));
+    }
+    let mut out = Vec::with_capacity(handles.len());
+    for h in handles {
+        out.push(h.await.expect("doctor probe task panicked"));
+    }
+    out
+}
+
+/// Total number of failed probes across all invocations.
+pub fn count_failures(invs: &[InvocationOut]) -> usize {
+    invs.iter()
+        .flat_map(|i| &i.probes)
+        .filter(|p| matches!(p.status, ProbeStatus::Fail { .. }))
+        .count()
+}
+
 /// Run one connector's `check()` future under the timeout, mapping the report
 /// (or an outer error / timeout) into role-tagged [`ProbeOut`]s.
 async fn collect_probes(
@@ -217,7 +229,7 @@ fn construct_fail(role: &'static str, kind: &str, e: impl std::fmt::Display) -> 
 }
 
 /// Scrub resolved secrets out of every probe `reason` / `hint`.
-fn redact_invocations(invs: &mut [InvocationOut]) {
+pub fn redact_invocations(invs: &mut [InvocationOut]) {
     for inv in invs.iter_mut() {
         for p in inv.probes.iter_mut() {
             match &mut p.status {
@@ -401,5 +413,17 @@ mod tests {
         assert_eq!(p.name, "construct");
         assert!(matches!(p.status, ProbeStatus::Fail { .. }));
         assert_eq!(p.connector, "postgres");
+    }
+
+    #[test]
+    fn count_failures_sums_across_invocations() {
+        let invs = vec![
+            inv(vec![
+                probe_out("source", "read", ProbeStatus::Pass),
+                probe_out("sink", "auth", ProbeStatus::Fail { reason: "x".into() }),
+            ]),
+            inv(vec![probe_out("sink", "auth", ProbeStatus::Fail { reason: "y".into() })]),
+        ];
+        assert_eq!(count_failures(&invs), 2);
     }
 }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -408,7 +408,7 @@ impl PipelineConfig {
             .extension()
             .and_then(|e| e.to_str())
             .map(str::to_ascii_lowercase);
-        let mut cfg: PipelineConfig = match ext.as_deref() {
+        let cfg: PipelineConfig = match ext.as_deref() {
             Some("yaml" | "yml") => {
                 serde_yaml::from_str(text).map_err(|e| CliError::ParseConfig {
                     path: path.to_path_buf(),
@@ -425,6 +425,28 @@ impl PipelineConfig {
                 });
             }
         };
+        Self::finish(cfg, path)
+    }
+
+    /// Build a config from an already-parsed JSON value (used by `faucet serve`,
+    /// which merges a submitted body onto a `--default-config` base). Runs the
+    /// same version check + structural `${...}` ref resolution as [`Self::from_text`].
+    ///
+    /// **Note:** load-time `${env:VAR}` / `${file:PATH}` / `${secret:VAR}` directives
+    /// are **not** resolved here — the caller must pre-resolve them (e.g. by running
+    /// `interpolate` on the source text) before building the `Value`.
+    pub fn from_value(value: serde_json::Value) -> CliResult<Self> {
+        let synthetic = Path::new("<submitted>");
+        let cfg: PipelineConfig =
+            serde_json::from_value(value).map_err(|e| CliError::ParseConfig {
+                path: synthetic.to_path_buf(),
+                message: friendly_parse_error(&e.to_string()),
+            })?;
+        Self::finish(cfg, synthetic)
+    }
+
+    /// Shared post-parse tail: version gate + structural `${...}` ref resolution.
+    fn finish(mut cfg: PipelineConfig, path: &Path) -> CliResult<Self> {
         if cfg.version != 1 {
             return Err(CliError::ParseConfig {
                 path: path.to_path_buf(),
@@ -992,6 +1014,33 @@ pipeline:
         match PipelineConfig::from_path(&path).unwrap_err() {
             CliError::SecretsRequireAsyncLoad => {}
             other => panic!("expected SecretsRequireAsyncLoad, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn from_value_accepts_v1_and_resolves_refs() {
+        let v = serde_json::json!({
+            "version": 1,
+            "vars": { "out": "resolved.jsonl" },
+            "pipeline": {
+                "source": { "type": "csv",  "config": { "path": "x.csv" } },
+                "sink":   { "type": "jsonl", "config": { "path": "${vars.out}" } }
+            }
+        });
+        let cfg = PipelineConfig::from_value(v).unwrap();
+        assert_eq!(cfg.version, 1);
+        // structural ${vars.*} refs are resolved by from_value (via finish → resolve_config_refs)
+        assert_eq!(cfg.pipeline.sink.unwrap().config["path"], "resolved.jsonl");
+    }
+
+    #[test]
+    fn from_value_rejects_non_v1() {
+        // structurally valid config; only the version is wrong
+        let v = serde_json::json!({ "version": 99, "pipeline": {} });
+        let err = PipelineConfig::from_value(v).unwrap_err();
+        match err {
+            CliError::ParseConfig { message, .. } => assert!(message.contains("version 99")),
+            other => panic!("expected ParseConfig, got {other:?}"),
         }
     }
 

--- a/cli/src/serve/error.rs
+++ b/cli/src/serve/error.rs
@@ -16,15 +16,28 @@ pub struct ApiError {
 pub struct ApiErrorBody {
     pub code: String,
     pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub details: Option<serde_json::Value>,
 }
 
-/// All error outcomes a serve handler can produce. (More variants — 413, 429,
-/// 409, 422 — arrive with the endpoints that raise them in later phases.)
+/// All error outcomes a serve handler can produce.
 #[derive(Debug)]
 pub enum ServeError {
     Unauthorized,
     NotFound,
     BadConfig(String),
+    /// 422 — expand/validation failure or a failed `doctor_first` preflight;
+    /// `details` carries the doctor report when present.
+    Unprocessable {
+        message: String,
+        details: Option<serde_json::Value>,
+    },
+    /// 409 — delete on a running run, or idempotency key reused with a new payload.
+    Conflict(String),
+    /// 429 — the run queue is full.
+    QueueFull {
+        retry_after_secs: u64,
+    },
     Internal(String),
 }
 
@@ -34,6 +47,9 @@ impl ServeError {
             ServeError::Unauthorized => StatusCode::UNAUTHORIZED,
             ServeError::NotFound => StatusCode::NOT_FOUND,
             ServeError::BadConfig(_) => StatusCode::BAD_REQUEST,
+            ServeError::Unprocessable { .. } => StatusCode::UNPROCESSABLE_ENTITY,
+            ServeError::Conflict(_) => StatusCode::CONFLICT,
+            ServeError::QueueFull { .. } => StatusCode::TOO_MANY_REQUESTS,
             ServeError::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
@@ -43,6 +59,9 @@ impl ServeError {
             ServeError::Unauthorized => "unauthorized",
             ServeError::NotFound => "not_found",
             ServeError::BadConfig(_) => "bad_config",
+            ServeError::Unprocessable { .. } => "unprocessable",
+            ServeError::Conflict(_) => "conflict",
+            ServeError::QueueFull { .. } => "queue_full",
             ServeError::Internal(_) => "internal",
         }
     }
@@ -52,17 +71,33 @@ impl ServeError {
             ServeError::Unauthorized => "missing or invalid bearer token".into(),
             ServeError::NotFound => "not found".into(),
             ServeError::BadConfig(m) => m.clone(),
+            ServeError::Unprocessable { message, .. } => message.clone(),
+            ServeError::Conflict(m) => m.clone(),
+            ServeError::QueueFull { .. } => "run queue is full; retry later".into(),
             ServeError::Internal(m) => m.clone(),
         }
     }
 
+    fn details(&self) -> Option<serde_json::Value> {
+        match self {
+            ServeError::Unprocessable { details, .. } => details.clone(),
+            _ => None,
+        }
+    }
+
     pub fn api_error(&self) -> ApiError {
-        // Scrub any resolved secret that reached the message.
+        // Scrub any resolved secret that reached the message or details.
         let message = crate::secrets::registry::redact(&self.message()).into_owned();
+        let details = self.details().map(|d| {
+            let scrubbed = crate::secrets::registry::redact(&d.to_string()).into_owned();
+            serde_json::from_str(&scrubbed)
+                .unwrap_or_else(|_| serde_json::json!({ "redacted": true }))
+        });
         ApiError {
             error: ApiErrorBody {
                 code: self.code().to_string(),
                 message,
+                details,
             },
         }
     }
@@ -70,7 +105,14 @@ impl ServeError {
 
 impl IntoResponse for ServeError {
     fn into_response(self) -> Response {
-        (self.status(), Json(self.api_error())).into_response()
+        let status = self.status();
+        let mut resp = (status, Json(self.api_error())).into_response();
+        if let ServeError::QueueFull { retry_after_secs } = &self
+            && let Ok(v) = axum::http::HeaderValue::from_str(&retry_after_secs.to_string())
+        {
+            resp.headers_mut().insert(axum::http::header::RETRY_AFTER, v);
+        }
+        resp
     }
 }
 
@@ -116,5 +158,48 @@ mod tests {
         let body = ServeError::Internal("boom".into()).api_error();
         assert_eq!(body.error.code, "internal");
         assert_eq!(body.error.message, "boom");
+    }
+
+    #[test]
+    fn new_variants_map_to_status_codes() {
+        assert_eq!(
+            ServeError::Unprocessable { message: "x".into(), details: None }.status(),
+            StatusCode::UNPROCESSABLE_ENTITY
+        );
+        assert_eq!(ServeError::Conflict("x".into()).status(), StatusCode::CONFLICT);
+        assert_eq!(
+            ServeError::QueueFull { retry_after_secs: 5 }.status(),
+            StatusCode::TOO_MANY_REQUESTS
+        );
+    }
+
+    #[test]
+    fn unprocessable_carries_details() {
+        let body = ServeError::Unprocessable {
+            message: "doctor failed".into(),
+            details: Some(serde_json::json!({"invocations": []})),
+        }
+        .api_error();
+        assert_eq!(body.error.code, "unprocessable");
+        assert!(body.error.details.is_some());
+    }
+
+    #[test]
+    fn phase1_variants_omit_details_on_the_wire() {
+        // details uses skip_serializing_if=Option::is_none, so non-422 variants
+        // must not emit a "details" key (backward-compatible wire shape).
+        let body = ServeError::NotFound.api_error();
+        let v = serde_json::to_value(&body).unwrap();
+        assert!(v["error"].get("details").is_none());
+    }
+
+    #[tokio::test]
+    async fn queue_full_sets_retry_after_header() {
+        let resp = ServeError::QueueFull { retry_after_secs: 7 }.into_response();
+        assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(
+            resp.headers().get(axum::http::header::RETRY_AFTER).unwrap(),
+            "7"
+        );
     }
 }

--- a/cli/src/serve/error.rs
+++ b/cli/src/serve/error.rs
@@ -110,7 +110,8 @@ impl IntoResponse for ServeError {
         if let ServeError::QueueFull { retry_after_secs } = &self
             && let Ok(v) = axum::http::HeaderValue::from_str(&retry_after_secs.to_string())
         {
-            resp.headers_mut().insert(axum::http::header::RETRY_AFTER, v);
+            resp.headers_mut()
+                .insert(axum::http::header::RETRY_AFTER, v);
         }
         resp
     }
@@ -163,12 +164,22 @@ mod tests {
     #[test]
     fn new_variants_map_to_status_codes() {
         assert_eq!(
-            ServeError::Unprocessable { message: "x".into(), details: None }.status(),
+            ServeError::Unprocessable {
+                message: "x".into(),
+                details: None
+            }
+            .status(),
             StatusCode::UNPROCESSABLE_ENTITY
         );
-        assert_eq!(ServeError::Conflict("x".into()).status(), StatusCode::CONFLICT);
         assert_eq!(
-            ServeError::QueueFull { retry_after_secs: 5 }.status(),
+            ServeError::Conflict("x".into()).status(),
+            StatusCode::CONFLICT
+        );
+        assert_eq!(
+            ServeError::QueueFull {
+                retry_after_secs: 5
+            }
+            .status(),
             StatusCode::TOO_MANY_REQUESTS
         );
     }
@@ -195,7 +206,10 @@ mod tests {
 
     #[tokio::test]
     async fn queue_full_sets_retry_after_header() {
-        let resp = ServeError::QueueFull { retry_after_secs: 7 }.into_response();
+        let resp = ServeError::QueueFull {
+            retry_after_secs: 7,
+        }
+        .into_response();
         assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
         assert_eq!(
             resp.headers().get(axum::http::header::RETRY_AFTER).unwrap(),

--- a/cli/src/serve/handlers/health.rs
+++ b/cli/src/serve/handlers/health.rs
@@ -13,9 +13,16 @@ pub async fn healthz() -> impl IntoResponse {
     StatusCode::OK
 }
 
-/// Readiness: ready to accept work. Phase 1 is unconditionally ready.
-pub async fn readyz() -> impl IntoResponse {
-    StatusCode::OK
+/// Readiness: 503 if the history backend is degraded or the queue is full
+/// (cannot accept new work), else 200.
+pub async fn readyz(State(state): State<ServerState>) -> impl IntoResponse {
+    let history_ok = !state.history().degraded();
+    let queue_ok = !state.registry().is_full();
+    if history_ok && queue_ok {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    }
 }
 
 /// Prometheus exposition rendered from serve's own recorder handle.

--- a/cli/src/serve/handlers/mod.rs
+++ b/cli/src/serve/handlers/mod.rs
@@ -1,2 +1,3 @@
 //! serve HTTP handlers.
 pub mod health;
+pub mod runs;

--- a/cli/src/serve/handlers/runs.rs
+++ b/cli/src/serve/handlers/runs.rs
@@ -47,8 +47,13 @@ pub async fn get_run(
         .await
         .map_err(|e| ServeError::Internal(e.to_string()))?
         .ok_or(ServeError::NotFound)?;
-    if rec.status == RunStatus::Running && let Some(started) = rec.started_at {
-        rec.elapsed_secs = (Utc::now() - started).to_std().ok().map(|d| d.as_secs_f64());
+    if rec.status == RunStatus::Running
+        && let Some(started) = rec.started_at
+    {
+        rec.elapsed_secs = (Utc::now() - started)
+            .to_std()
+            .ok()
+            .map(|d| d.as_secs_f64());
     }
     redact_record(&mut rec);
     Ok(Json(rec))
@@ -185,7 +190,9 @@ mod tests {
             serde_json::from_value(serde_json::json!("2026-01-01T00:00:00Z")).unwrap();
         assert_eq!(
             zulu.0,
-            chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z").unwrap().to_utc()
+            chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+                .unwrap()
+                .to_utc()
         );
     }
 

--- a/cli/src/serve/handlers/runs.rs
+++ b/cli/src/serve/handlers/runs.rs
@@ -1,0 +1,215 @@
+//! `/v1/runs*` HTTP handlers. Thin glue: deserialize, call into `runner`/history,
+//! map to status codes. All run-mutating logic lives in `runner.rs`.
+
+use crate::serve::error::ServeError;
+use crate::serve::history::{DeleteOutcome, ListFilter, RunRecord, RunStatus};
+use crate::serve::runner::{self, SubmitRequest, SubmitResponse};
+use crate::serve::state::ServerState;
+use axum::Json;
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Scrub any resolved secret that reached a run's error fields before the record
+/// is serialized into an HTTP response. The serve log subscriber's redaction
+/// writer only covers tracing/log output — API response bodies are a separate
+/// egress and must be scrubbed here.
+fn redact_record(rec: &mut RunRecord) {
+    if let Some(e) = &rec.error {
+        rec.error = Some(crate::secrets::registry::redact(e).into_owned());
+    }
+    for inv in &mut rec.invocations {
+        if let Some(e) = &inv.error {
+            inv.error = Some(crate::secrets::registry::redact(e).into_owned());
+        }
+    }
+}
+
+/// `POST /v1/runs` → 202.
+pub async fn submit_run(
+    State(state): State<ServerState>,
+    Json(req): Json<SubmitRequest>,
+) -> Result<(StatusCode, Json<SubmitResponse>), ServeError> {
+    let resp = runner::submit(state, req).await?;
+    Ok((StatusCode::ACCEPTED, Json(resp)))
+}
+
+/// `GET /v1/runs/{id}` → 200 RunRecord. Fills live `elapsed_secs` for running runs.
+pub async fn get_run(
+    State(state): State<ServerState>,
+    Path(id): Path<String>,
+) -> Result<Json<RunRecord>, ServeError> {
+    let mut rec = state
+        .history()
+        .get(&id)
+        .await
+        .map_err(|e| ServeError::Internal(e.to_string()))?
+        .ok_or(ServeError::NotFound)?;
+    if rec.status == RunStatus::Running && let Some(started) = rec.started_at {
+        rec.elapsed_secs = (Utc::now() - started).to_std().ok().map(|d| d.as_secs_f64());
+    }
+    redact_record(&mut rec);
+    Ok(Json(rec))
+}
+
+/// `POST /v1/runs/{id}/cancel` → 202 (in-flight) / 200 (terminal no-op) / 404.
+pub async fn cancel_run(
+    State(state): State<ServerState>,
+    Path(id): Path<String>,
+) -> Result<impl IntoResponse, ServeError> {
+    // A live (queued/running) token → request cancellation.
+    if state.registry().cancel(&id) {
+        return Ok(StatusCode::ACCEPTED);
+    }
+    // Otherwise: terminal no-op if the record exists, else 404.
+    match state
+        .history()
+        .get(&id)
+        .await
+        .map_err(|e| ServeError::Internal(e.to_string()))?
+    {
+        Some(_) => Ok(StatusCode::OK),
+        None => Err(ServeError::NotFound),
+    }
+}
+
+/// `DELETE /v1/runs/{id}` → 204 / 404 / 409 (still running).
+pub async fn delete_run(
+    State(state): State<ServerState>,
+    Path(id): Path<String>,
+) -> Result<StatusCode, ServeError> {
+    match state
+        .history()
+        .delete(&id)
+        .await
+        .map_err(|e| ServeError::Internal(e.to_string()))?
+    {
+        DeleteOutcome::Deleted => Ok(StatusCode::NO_CONTENT),
+        DeleteOutcome::NotFound => Err(ServeError::NotFound),
+        DeleteOutcome::StillRunning => Err(ServeError::Conflict(
+            "run is still in flight — cancel it before deleting".into(),
+        )),
+    }
+}
+
+/// Query-param wrapper for an RFC3339 timestamp. `application/x-www-form-urlencoded`
+/// decodes `+` as a space, which corrupts explicit UTC offsets like `+05:30`; we
+/// restore the `+` before parsing, so both `…Z` and `…+05:30` query values work.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct DateTimeUtcParam(DateTime<Utc>);
+
+impl<'de> Deserialize<'de> for DateTimeUtcParam {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let raw = String::deserialize(d)?;
+        // Undo form-encoding's '+' → ' ' substitution before RFC3339 parsing.
+        let restored = raw.replace(' ', "+");
+        DateTime::parse_from_rfc3339(&restored)
+            .map(|dt| DateTimeUtcParam(dt.to_utc()))
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+/// `GET /v1/runs` query string.
+#[derive(Debug, Deserialize)]
+pub struct ListQuery {
+    pub status: Option<RunStatus>,
+    pub name: Option<String>,
+    pub(crate) since: Option<DateTimeUtcParam>,
+    pub(crate) until: Option<DateTimeUtcParam>,
+    pub limit: Option<usize>,
+    pub cursor: Option<String>,
+}
+
+/// `GET /v1/runs` response body.
+#[derive(Debug, Serialize)]
+pub struct ListResponse {
+    pub runs: Vec<RunRecord>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<String>,
+}
+
+const DEFAULT_LIMIT: usize = 50;
+const MAX_LIMIT: usize = 500;
+
+impl ListQuery {
+    fn into_filter(self) -> ListFilter {
+        ListFilter {
+            status: self.status,
+            name: self.name,
+            since: self.since.map(|p| p.0),
+            until: self.until.map(|p| p.0),
+            limit: self.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT),
+            cursor: self.cursor,
+        }
+    }
+}
+
+/// `GET /v1/runs` → 200.
+pub async fn list_runs(
+    State(state): State<ServerState>,
+    Query(query): Query<ListQuery>,
+) -> Result<Json<ListResponse>, ServeError> {
+    let page = state
+        .history()
+        .list(&query.into_filter())
+        .await
+        .map_err(|e| ServeError::Internal(e.to_string()))?;
+    let mut runs = page.runs;
+    for rec in &mut runs {
+        redact_record(rec);
+    }
+    Ok(Json(ListResponse {
+        runs,
+        next_cursor: page.next_cursor,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn datetime_param_restores_form_encoded_plus() {
+        // form-encoding turns the '+' of an offset into a space; the wrapper must
+        // restore it so both offset and Z forms parse to the same UTC instant.
+        let spaced: DateTimeUtcParam =
+            serde_json::from_value(serde_json::json!("2026-01-01T00:00:00 05:30")).unwrap();
+        let plus = chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00+05:30")
+            .unwrap()
+            .to_utc();
+        assert_eq!(spaced.0, plus);
+
+        let zulu: DateTimeUtcParam =
+            serde_json::from_value(serde_json::json!("2026-01-01T00:00:00Z")).unwrap();
+        assert_eq!(
+            zulu.0,
+            chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z").unwrap().to_utc()
+        );
+    }
+
+    #[test]
+    fn list_query_clamps_limit() {
+        let q = ListQuery {
+            status: None,
+            name: None,
+            since: None,
+            until: None,
+            limit: Some(99999),
+            cursor: None,
+        };
+        assert_eq!(q.into_filter().limit, MAX_LIMIT);
+        let q = ListQuery {
+            status: Some(RunStatus::Failed),
+            name: None,
+            since: None,
+            until: None,
+            limit: None,
+            cursor: None,
+        };
+        let f = q.into_filter();
+        assert_eq!(f.limit, DEFAULT_LIMIT);
+        assert_eq!(f.status, Some(RunStatus::Failed));
+    }
+}

--- a/cli/src/serve/history/memory.rs
+++ b/cli/src/serve/history/memory.rs
@@ -94,7 +94,12 @@ impl RunHistory for MemoryHistory {
             .iter()
             .map(|r| r.clone())
             .filter(|r| filter.status.is_none_or(|s| r.status == s))
-            .filter(|r| filter.name.as_deref().is_none_or(|n| r.name.as_deref() == Some(n)))
+            .filter(|r| {
+                filter
+                    .name
+                    .as_deref()
+                    .is_none_or(|n| r.name.as_deref() == Some(n))
+            })
             .filter(|r| filter.since.is_none_or(|t| r.submitted_at >= t))
             .filter(|r| filter.until.is_none_or(|t| r.submitted_at <= t))
             .collect();
@@ -186,14 +191,20 @@ mod tests {
     async fn idempotency_fresh_replay_conflict() {
         let h = MemoryHistory::new(Duration::from_secs(60));
         let w = Duration::from_secs(60);
-        assert_eq!(h.claim_idempotency("k", "fp1", "run1", w).await.unwrap(), Claim::Fresh);
+        assert_eq!(
+            h.claim_idempotency("k", "fp1", "run1", w).await.unwrap(),
+            Claim::Fresh
+        );
         // Same key + same fingerprint → replay the first run id.
         assert_eq!(
             h.claim_idempotency("k", "fp1", "run2", w).await.unwrap(),
             Claim::Replay("run1".into())
         );
         // Same key + different fingerprint → conflict.
-        assert_eq!(h.claim_idempotency("k", "fp2", "run3", w).await.unwrap(), Claim::Conflict);
+        assert_eq!(
+            h.claim_idempotency("k", "fp2", "run3", w).await.unwrap(),
+            Claim::Conflict
+        );
     }
 
     #[tokio::test]
@@ -201,17 +212,27 @@ mod tests {
         let h = MemoryHistory::new(Duration::from_secs(60));
         // Zero window → any prior claim is immediately expired.
         let w = Duration::ZERO;
-        assert_eq!(h.claim_idempotency("k", "fp1", "run1", w).await.unwrap(), Claim::Fresh);
-        assert_eq!(h.claim_idempotency("k", "fp2", "run2", w).await.unwrap(), Claim::Fresh);
+        assert_eq!(
+            h.claim_idempotency("k", "fp1", "run1", w).await.unwrap(),
+            Claim::Fresh
+        );
+        assert_eq!(
+            h.claim_idempotency("k", "fp2", "run2", w).await.unwrap(),
+            Claim::Fresh
+        );
     }
 
     #[tokio::test]
     async fn delete_respects_terminal_state() {
         let h = MemoryHistory::new(Duration::from_secs(60));
-        h.upsert(&rec("run", RunStatus::Running, Utc::now())).await.unwrap();
+        h.upsert(&rec("run", RunStatus::Running, Utc::now()))
+            .await
+            .unwrap();
         assert_eq!(h.delete("run").await.unwrap(), DeleteOutcome::StillRunning);
         assert_eq!(h.delete("nope").await.unwrap(), DeleteOutcome::NotFound);
-        h.upsert(&rec("run", RunStatus::Completed, Utc::now())).await.unwrap();
+        h.upsert(&rec("run", RunStatus::Completed, Utc::now()))
+            .await
+            .unwrap();
         assert_eq!(h.delete("run").await.unwrap(), DeleteOutcome::Deleted);
         assert!(h.get("run").await.unwrap().is_none());
     }
@@ -221,23 +242,47 @@ mod tests {
         let h = MemoryHistory::new(Duration::from_secs(60));
         let t0 = Utc::now();
         for (i, id) in ["a", "b", "c"].iter().enumerate() {
-            h.upsert(&rec(id, RunStatus::Completed, t0 + chrono::Duration::seconds(i as i64)))
-                .await
-                .unwrap();
+            h.upsert(&rec(
+                id,
+                RunStatus::Completed,
+                t0 + chrono::Duration::seconds(i as i64),
+            ))
+            .await
+            .unwrap();
         }
         // Newest first → c, b, a. Page size 2.
         let page = h
-            .list(&ListFilter { limit: 2, ..Default::default() })
+            .list(&ListFilter {
+                limit: 2,
+                ..Default::default()
+            })
             .await
             .unwrap();
-        assert_eq!(page.runs.iter().map(|r| r.run_id.clone()).collect::<Vec<_>>(), vec!["c", "b"]);
+        assert_eq!(
+            page.runs
+                .iter()
+                .map(|r| r.run_id.clone())
+                .collect::<Vec<_>>(),
+            vec!["c", "b"]
+        );
         assert_eq!(page.next_cursor.as_deref(), Some("b"));
         // Next page from the cursor → a.
         let page2 = h
-            .list(&ListFilter { limit: 2, cursor: Some("b".into()), ..Default::default() })
+            .list(&ListFilter {
+                limit: 2,
+                cursor: Some("b".into()),
+                ..Default::default()
+            })
             .await
             .unwrap();
-        assert_eq!(page2.runs.iter().map(|r| r.run_id.clone()).collect::<Vec<_>>(), vec!["a"]);
+        assert_eq!(
+            page2
+                .runs
+                .iter()
+                .map(|r| r.run_id.clone())
+                .collect::<Vec<_>>(),
+            vec!["a"]
+        );
         assert!(page2.next_cursor.is_none());
     }
 
@@ -247,16 +292,26 @@ mod tests {
         let mut r = rec("x", RunStatus::Failed, Utc::now());
         r.name = Some("nightly".into());
         h.upsert(&r).await.unwrap();
-        h.upsert(&rec("y", RunStatus::Completed, Utc::now())).await.unwrap();
+        h.upsert(&rec("y", RunStatus::Completed, Utc::now()))
+            .await
+            .unwrap();
         let only_failed = h
-            .list(&ListFilter { status: Some(RunStatus::Failed), limit: 50, ..Default::default() })
+            .list(&ListFilter {
+                status: Some(RunStatus::Failed),
+                limit: 50,
+                ..Default::default()
+            })
             .await
             .unwrap();
         assert_eq!(only_failed.runs.len(), 1);
         assert_eq!(only_failed.runs[0].run_id, "x");
         // Name filter also works.
         let by_name = h
-            .list(&ListFilter { name: Some("nightly".into()), limit: 50, ..Default::default() })
+            .list(&ListFilter {
+                name: Some("nightly".into()),
+                limit: 50,
+                ..Default::default()
+            })
             .await
             .unwrap();
         assert_eq!(by_name.runs.len(), 1);
@@ -266,10 +321,16 @@ mod tests {
     #[tokio::test]
     async fn purge_drops_expired_terminal_runs() {
         let h = MemoryHistory::new(Duration::from_secs(60));
-        h.upsert(&rec("old", RunStatus::Completed, Utc::now() - chrono::Duration::seconds(10)))
+        h.upsert(&rec(
+            "old",
+            RunStatus::Completed,
+            Utc::now() - chrono::Duration::seconds(10),
+        ))
+        .await
+        .unwrap();
+        h.upsert(&rec("live", RunStatus::Running, Utc::now()))
             .await
             .unwrap();
-        h.upsert(&rec("live", RunStatus::Running, Utc::now())).await.unwrap();
         // retain_for = 0 → every terminal record is expired; running is kept.
         let removed = h.purge_expired(Duration::ZERO).await.unwrap();
         assert_eq!(removed, 1);

--- a/cli/src/serve/history/memory.rs
+++ b/cli/src/serve/history/memory.rs
@@ -1,0 +1,1 @@
+//! In-memory backend — implemented in the next task.

--- a/cli/src/serve/history/memory.rs
+++ b/cli/src/serve/history/memory.rs
@@ -1,1 +1,279 @@
-//! In-memory backend — implemented in the next task.
+//! `DashMap`-backed run history (default backend). Lost on restart; that is the
+//! documented memory-backend trade-off. Idempotency claims live in a second map
+//! and are pruned both lazily (on re-claim) and by `purge_expired`.
+
+use super::{Claim, DeleteOutcome, HistoryError, ListFilter, ListPage, RunHistory, RunRecord};
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use dashmap::DashMap;
+use std::time::Duration;
+
+struct IdemEntry {
+    run_id: String,
+    fingerprint: String,
+    claimed_at: DateTime<Utc>,
+}
+
+pub struct MemoryHistory {
+    runs: DashMap<String, RunRecord>,
+    idem: DashMap<String, IdemEntry>,
+    /// Retention window for idempotency claims (separate from run retention).
+    idem_retention: Duration,
+}
+
+impl MemoryHistory {
+    pub fn new(idem_retention: Duration) -> Self {
+        Self {
+            runs: DashMap::new(),
+            idem: DashMap::new(),
+            idem_retention,
+        }
+    }
+}
+
+/// True when `claimed_at` is older than `window` relative to `now`. A claim
+/// timestamped in the future (clock skew) is treated as *not* expired.
+fn is_expired(claimed_at: DateTime<Utc>, now: DateTime<Utc>, window: Duration) -> bool {
+    now.signed_duration_since(claimed_at)
+        .to_std()
+        .map(|age| age >= window)
+        .unwrap_or(false)
+}
+
+#[async_trait]
+impl RunHistory for MemoryHistory {
+    async fn claim_idempotency(
+        &self,
+        key: &str,
+        fingerprint: &str,
+        run_id: &str,
+        window: Duration,
+    ) -> Result<Claim, HistoryError> {
+        use dashmap::mapref::entry::Entry;
+        let now = Utc::now();
+        // Holding the entry locks the shard, so claim is atomic under contention.
+        match self.idem.entry(key.to_string()) {
+            Entry::Occupied(mut e) => {
+                let expired = is_expired(e.get().claimed_at, now, window);
+                if expired {
+                    e.insert(IdemEntry {
+                        run_id: run_id.to_string(),
+                        fingerprint: fingerprint.to_string(),
+                        claimed_at: now,
+                    });
+                    Ok(Claim::Fresh)
+                } else if e.get().fingerprint == fingerprint {
+                    Ok(Claim::Replay(e.get().run_id.clone()))
+                } else {
+                    Ok(Claim::Conflict)
+                }
+            }
+            Entry::Vacant(v) => {
+                v.insert(IdemEntry {
+                    run_id: run_id.to_string(),
+                    fingerprint: fingerprint.to_string(),
+                    claimed_at: now,
+                });
+                Ok(Claim::Fresh)
+            }
+        }
+    }
+
+    async fn upsert(&self, rec: &RunRecord) -> Result<(), HistoryError> {
+        self.runs.insert(rec.run_id.clone(), rec.clone());
+        Ok(())
+    }
+
+    async fn get(&self, id: &str) -> Result<Option<RunRecord>, HistoryError> {
+        Ok(self.runs.get(id).map(|r| r.clone()))
+    }
+
+    async fn list(&self, filter: &ListFilter) -> Result<ListPage, HistoryError> {
+        let mut rows: Vec<RunRecord> = self
+            .runs
+            .iter()
+            .map(|r| r.clone())
+            .filter(|r| filter.status.is_none_or(|s| r.status == s))
+            .filter(|r| filter.name.as_deref().is_none_or(|n| r.name.as_deref() == Some(n)))
+            .filter(|r| filter.since.is_none_or(|t| r.submitted_at >= t))
+            .filter(|r| filter.until.is_none_or(|t| r.submitted_at <= t))
+            .collect();
+        // (submitted_at DESC, run_id DESC)
+        rows.sort_by(|a, b| {
+            b.submitted_at
+                .cmp(&a.submitted_at)
+                .then_with(|| b.run_id.cmp(&a.run_id))
+        });
+        // Cursor = last run_id seen on the previous page; skip past it.
+        if let Some(cursor) = &filter.cursor
+            && let Some(pos) = rows.iter().position(|r| &r.run_id == cursor)
+        {
+            rows.drain(..=pos);
+        }
+        let limit = filter.limit.max(1);
+        let next_cursor = if rows.len() > limit {
+            Some(rows[limit - 1].run_id.clone())
+        } else {
+            None
+        };
+        rows.truncate(limit);
+        Ok(ListPage {
+            runs: rows,
+            next_cursor,
+        })
+    }
+
+    async fn delete(&self, id: &str) -> Result<DeleteOutcome, HistoryError> {
+        match self.runs.get(id).map(|r| r.status) {
+            None => Ok(DeleteOutcome::NotFound),
+            Some(s) if !s.is_terminal() => Ok(DeleteOutcome::StillRunning),
+            Some(_) => {
+                self.runs.remove(id);
+                Ok(DeleteOutcome::Deleted)
+            }
+        }
+    }
+
+    async fn purge_expired(&self, retain_for: Duration) -> Result<usize, HistoryError> {
+        let now = Utc::now();
+        let before = self.runs.len();
+        self.runs.retain(|_, r| {
+            !r.status.is_terminal()
+                || r.finished_at
+                    .map(|f| !is_expired(f, now, retain_for))
+                    .unwrap_or(true)
+        });
+        // Also drop stale idempotency claims so the map stays bounded.
+        self.idem
+            .retain(|_, e| !is_expired(e.claimed_at, now, self.idem_retention));
+        Ok(before.saturating_sub(self.runs.len()))
+    }
+
+    async fn recover_orphans(&self) -> Result<usize, HistoryError> {
+        Ok(0)
+    }
+
+    fn degraded(&self) -> bool {
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::serve::history::RunStatus;
+    use std::collections::BTreeMap;
+
+    fn rec(id: &str, status: RunStatus, submitted: DateTime<Utc>) -> RunRecord {
+        let mut r = RunRecord::queued(id.into(), None, BTreeMap::new(), None, submitted);
+        r.status = status;
+        if status.is_terminal() {
+            r.finished_at = Some(submitted);
+        }
+        r
+    }
+
+    #[tokio::test]
+    async fn upsert_then_get_roundtrips() {
+        let h = MemoryHistory::new(Duration::from_secs(60));
+        let r = rec("a", RunStatus::Queued, Utc::now());
+        h.upsert(&r).await.unwrap();
+        assert_eq!(h.get("a").await.unwrap().unwrap().run_id, "a");
+        assert!(h.get("missing").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn idempotency_fresh_replay_conflict() {
+        let h = MemoryHistory::new(Duration::from_secs(60));
+        let w = Duration::from_secs(60);
+        assert_eq!(h.claim_idempotency("k", "fp1", "run1", w).await.unwrap(), Claim::Fresh);
+        // Same key + same fingerprint → replay the first run id.
+        assert_eq!(
+            h.claim_idempotency("k", "fp1", "run2", w).await.unwrap(),
+            Claim::Replay("run1".into())
+        );
+        // Same key + different fingerprint → conflict.
+        assert_eq!(h.claim_idempotency("k", "fp2", "run3", w).await.unwrap(), Claim::Conflict);
+    }
+
+    #[tokio::test]
+    async fn expired_claim_is_reclaimable() {
+        let h = MemoryHistory::new(Duration::from_secs(60));
+        // Zero window → any prior claim is immediately expired.
+        let w = Duration::ZERO;
+        assert_eq!(h.claim_idempotency("k", "fp1", "run1", w).await.unwrap(), Claim::Fresh);
+        assert_eq!(h.claim_idempotency("k", "fp2", "run2", w).await.unwrap(), Claim::Fresh);
+    }
+
+    #[tokio::test]
+    async fn delete_respects_terminal_state() {
+        let h = MemoryHistory::new(Duration::from_secs(60));
+        h.upsert(&rec("run", RunStatus::Running, Utc::now())).await.unwrap();
+        assert_eq!(h.delete("run").await.unwrap(), DeleteOutcome::StillRunning);
+        assert_eq!(h.delete("nope").await.unwrap(), DeleteOutcome::NotFound);
+        h.upsert(&rec("run", RunStatus::Completed, Utc::now())).await.unwrap();
+        assert_eq!(h.delete("run").await.unwrap(), DeleteOutcome::Deleted);
+        assert!(h.get("run").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn list_orders_desc_and_paginates() {
+        let h = MemoryHistory::new(Duration::from_secs(60));
+        let t0 = Utc::now();
+        for (i, id) in ["a", "b", "c"].iter().enumerate() {
+            h.upsert(&rec(id, RunStatus::Completed, t0 + chrono::Duration::seconds(i as i64)))
+                .await
+                .unwrap();
+        }
+        // Newest first → c, b, a. Page size 2.
+        let page = h
+            .list(&ListFilter { limit: 2, ..Default::default() })
+            .await
+            .unwrap();
+        assert_eq!(page.runs.iter().map(|r| r.run_id.clone()).collect::<Vec<_>>(), vec!["c", "b"]);
+        assert_eq!(page.next_cursor.as_deref(), Some("b"));
+        // Next page from the cursor → a.
+        let page2 = h
+            .list(&ListFilter { limit: 2, cursor: Some("b".into()), ..Default::default() })
+            .await
+            .unwrap();
+        assert_eq!(page2.runs.iter().map(|r| r.run_id.clone()).collect::<Vec<_>>(), vec!["a"]);
+        assert!(page2.next_cursor.is_none());
+    }
+
+    #[tokio::test]
+    async fn list_filters_by_status_and_name() {
+        let h = MemoryHistory::new(Duration::from_secs(60));
+        let mut r = rec("x", RunStatus::Failed, Utc::now());
+        r.name = Some("nightly".into());
+        h.upsert(&r).await.unwrap();
+        h.upsert(&rec("y", RunStatus::Completed, Utc::now())).await.unwrap();
+        let only_failed = h
+            .list(&ListFilter { status: Some(RunStatus::Failed), limit: 50, ..Default::default() })
+            .await
+            .unwrap();
+        assert_eq!(only_failed.runs.len(), 1);
+        assert_eq!(only_failed.runs[0].run_id, "x");
+        // Name filter also works.
+        let by_name = h
+            .list(&ListFilter { name: Some("nightly".into()), limit: 50, ..Default::default() })
+            .await
+            .unwrap();
+        assert_eq!(by_name.runs.len(), 1);
+        assert_eq!(by_name.runs[0].run_id, "x");
+    }
+
+    #[tokio::test]
+    async fn purge_drops_expired_terminal_runs() {
+        let h = MemoryHistory::new(Duration::from_secs(60));
+        h.upsert(&rec("old", RunStatus::Completed, Utc::now() - chrono::Duration::seconds(10)))
+            .await
+            .unwrap();
+        h.upsert(&rec("live", RunStatus::Running, Utc::now())).await.unwrap();
+        // retain_for = 0 → every terminal record is expired; running is kept.
+        let removed = h.purge_expired(Duration::ZERO).await.unwrap();
+        assert_eq!(removed, 1);
+        assert!(h.get("old").await.unwrap().is_none());
+        assert!(h.get("live").await.unwrap().is_some());
+    }
+}

--- a/cli/src/serve/history/mod.rs
+++ b/cli/src/serve/history/mod.rs
@@ -1,0 +1,208 @@
+//! Run-history storage. The trait is defined in full now (Phase 2/3 ships only
+//! the in-memory backend in `memory.rs`); Phase 5 adds Postgres/SQLite as new
+//! impls with no trait change. See spec §11 + §20.
+
+pub mod memory;
+
+use crate::executor::InvocationOutcome;
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+/// Lifecycle state of a submitted run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RunStatus {
+    Queued,
+    Running,
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+impl RunStatus {
+    pub fn is_terminal(self) -> bool {
+        matches!(self, Self::Completed | Self::Failed | Self::Cancelled)
+    }
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Queued => "queued",
+            Self::Running => "running",
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+        }
+    }
+}
+
+/// Serializable mirror of one pipeline invocation's outcome.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InvocationRecord {
+    pub row_id: String,
+    pub parent_record_key: Option<String>,
+    pub records_written: usize,
+    pub error: Option<String>,
+}
+
+impl From<&InvocationOutcome> for InvocationRecord {
+    fn from(o: &InvocationOutcome) -> Self {
+        Self {
+            row_id: o.row_id.clone(),
+            parent_record_key: o.parent_record_key.clone(),
+            records_written: o.records_written,
+            error: o.error.clone(),
+        }
+    }
+}
+
+/// One run's full record — the GET / list element (spec §6).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunRecord {
+    pub run_id: String,
+    pub name: Option<String>,
+    pub labels: BTreeMap<String, String>,
+    pub status: RunStatus,
+    pub submitted_at: DateTime<Utc>,
+    pub started_at: Option<DateTime<Utc>>,
+    pub finished_at: Option<DateTime<Utc>>,
+    pub elapsed_secs: Option<f64>,
+    pub records_written: u64,
+    pub invocations: Vec<InvocationRecord>,
+    pub error: Option<String>,
+    pub idempotency_key: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub doctor_report: Option<serde_json::Value>,
+}
+
+impl RunRecord {
+    /// A freshly-submitted run, before it acquires an execution slot.
+    pub fn queued(
+        run_id: String,
+        name: Option<String>,
+        labels: BTreeMap<String, String>,
+        idempotency_key: Option<String>,
+        submitted_at: DateTime<Utc>,
+    ) -> Self {
+        Self {
+            run_id,
+            name,
+            labels,
+            status: RunStatus::Queued,
+            submitted_at,
+            started_at: None,
+            finished_at: None,
+            elapsed_secs: None,
+            records_written: 0,
+            invocations: Vec::new(),
+            error: None,
+            idempotency_key,
+            doctor_report: None,
+        }
+    }
+}
+
+/// Result of an atomic idempotency-key claim.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Claim {
+    /// Key is new (or its prior claim expired) — caller owns it for `run_id`.
+    Fresh,
+    /// Key was already claimed with a matching payload — replay this run id.
+    Replay(String),
+    /// Key was claimed with a *different* payload — 409.
+    Conflict,
+}
+
+/// Result of a delete attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeleteOutcome {
+    Deleted,
+    NotFound,
+    StillRunning,
+}
+
+/// Filter + pagination for `list`. `limit`/`cursor` are resolved by the handler.
+#[derive(Debug, Default, Clone)]
+pub struct ListFilter {
+    pub status: Option<RunStatus>,
+    pub name: Option<String>,
+    pub since: Option<DateTime<Utc>>,
+    pub until: Option<DateTime<Utc>>,
+    pub limit: usize,
+    pub cursor: Option<String>,
+}
+
+/// One page of `list` results, ordered `(submitted_at DESC, run_id DESC)`.
+#[derive(Debug)]
+pub struct ListPage {
+    pub runs: Vec<RunRecord>,
+    pub next_cursor: Option<String>,
+}
+
+/// Backend failure. The memory backend never returns one; the variant exists so
+/// the async trait stays fallible for the Phase 5 SQL backends.
+#[derive(Debug, thiserror::Error)]
+pub enum HistoryError {
+    #[error("run-history backend error: {0}")]
+    Backend(String),
+}
+
+#[async_trait]
+pub trait RunHistory: Send + Sync {
+    /// Atomically claim `key` for `run_id` (or report a replay/conflict). A prior
+    /// claim older than `window` is treated as expired and re-claimable.
+    async fn claim_idempotency(
+        &self,
+        key: &str,
+        fingerprint: &str,
+        run_id: &str,
+        window: Duration,
+    ) -> Result<Claim, HistoryError>;
+
+    /// Insert or replace a run record.
+    async fn upsert(&self, rec: &RunRecord) -> Result<(), HistoryError>;
+
+    async fn get(&self, id: &str) -> Result<Option<RunRecord>, HistoryError>;
+
+    async fn list(&self, filter: &ListFilter) -> Result<ListPage, HistoryError>;
+
+    /// Delete a terminal run. Non-terminal → `StillRunning` (caller maps to 409).
+    async fn delete(&self, id: &str) -> Result<DeleteOutcome, HistoryError>;
+
+    /// Drop terminal records finished longer than `retain_for` ago. Returns the
+    /// number removed.
+    async fn purge_expired(&self, retain_for: Duration) -> Result<usize, HistoryError>;
+
+    /// Mark any non-terminal record left over from a previous process as failed.
+    /// The memory backend has nothing to recover (returns 0).
+    async fn recover_orphans(&self) -> Result<usize, HistoryError>;
+
+    /// True when the backend is in fallback mode (drives `/readyz`). Always false
+    /// for memory.
+    fn degraded(&self) -> bool;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn terminal_classification() {
+        assert!(!RunStatus::Queued.is_terminal());
+        assert!(!RunStatus::Running.is_terminal());
+        assert!(RunStatus::Completed.is_terminal());
+        assert!(RunStatus::Failed.is_terminal());
+        assert!(RunStatus::Cancelled.is_terminal());
+    }
+
+    #[test]
+    fn run_record_serializes_status_snake_case() {
+        let rec = RunRecord::queued("r1".into(), Some("n".into()), Default::default(), None, Utc::now());
+        let v = serde_json::to_value(&rec).unwrap();
+        assert_eq!(v["status"], "queued");
+        assert_eq!(v["run_id"], "r1");
+        // doctor_report is skipped when None.
+        assert!(v.get("doctor_report").is_none());
+    }
+}

--- a/cli/src/serve/history/mod.rs
+++ b/cli/src/serve/history/mod.rs
@@ -198,7 +198,13 @@ mod tests {
 
     #[test]
     fn run_record_serializes_status_snake_case() {
-        let rec = RunRecord::queued("r1".into(), Some("n".into()), Default::default(), None, Utc::now());
+        let rec = RunRecord::queued(
+            "r1".into(),
+            Some("n".into()),
+            Default::default(),
+            None,
+            Utc::now(),
+        );
         let v = serde_json::to_value(&rec).unwrap();
         assert_eq!(v["status"], "queued");
         assert_eq!(v["run_id"], "r1");

--- a/cli/src/serve/idempotency.rs
+++ b/cli/src/serve/idempotency.rs
@@ -76,6 +76,9 @@ mod tests {
 
     #[test]
     fn array_order_is_significant() {
-        assert_ne!(fingerprint(&json!([1, 2]), None), fingerprint(&json!([2, 1]), None));
+        assert_ne!(
+            fingerprint(&json!([1, 2]), None),
+            fingerprint(&json!([2, 1]), None)
+        );
     }
 }

--- a/cli/src/serve/idempotency.rs
+++ b/cli/src/serve/idempotency.rs
@@ -1,0 +1,81 @@
+//! Stable content fingerprint for idempotency replay-vs-conflict detection. A
+//! key replayed with the *same* merged config returns the existing run; reused
+//! with a *different* config is a 409. The hash is order-independent for object
+//! keys (canonical JSON) and stable across process restarts (sha256), so the
+//! Phase 5 SQL backends can store and compare it unchanged.
+
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+/// Fingerprint of a merged, resolved config plus its pipeline `name`.
+pub fn fingerprint(merged: &Value, name: Option<&str>) -> String {
+    let mut canon = String::new();
+    write_canonical(merged, &mut canon);
+    let mut hasher = Sha256::new();
+    hasher.update(name.unwrap_or("").as_bytes());
+    hasher.update([0u8]); // separator so name|config can't collide across the boundary
+    hasher.update(canon.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+/// Append a canonical (object keys sorted) JSON rendering of `v` to `out`.
+fn write_canonical(v: &Value, out: &mut String) {
+    match v {
+        Value::Object(map) => {
+            let mut keys: Vec<&String> = map.keys().collect();
+            keys.sort_unstable();
+            out.push('{');
+            for (i, k) in keys.iter().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                out.push_str(&serde_json::to_string(k).expect("string key serializes"));
+                out.push(':');
+                write_canonical(&map[*k], out);
+            }
+            out.push('}');
+        }
+        Value::Array(items) => {
+            out.push('[');
+            for (i, item) in items.iter().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                write_canonical(item, out);
+            }
+            out.push(']');
+        }
+        other => out.push_str(&serde_json::to_string(other).expect("scalar serializes")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn stable_and_order_independent() {
+        let a = json!({ "b": 1, "a": [1, 2], "c": { "y": true, "x": null } });
+        let b = json!({ "c": { "x": null, "y": true }, "a": [1, 2], "b": 1 });
+        assert_eq!(fingerprint(&a, Some("p")), fingerprint(&b, Some("p")));
+    }
+
+    #[test]
+    fn differs_on_value_change() {
+        let a = json!({ "a": 1 });
+        let b = json!({ "a": 2 });
+        assert_ne!(fingerprint(&a, Some("p")), fingerprint(&b, Some("p")));
+    }
+
+    #[test]
+    fn differs_on_name() {
+        let v = json!({ "a": 1 });
+        assert_ne!(fingerprint(&v, Some("p1")), fingerprint(&v, Some("p2")));
+    }
+
+    #[test]
+    fn array_order_is_significant() {
+        assert_ne!(fingerprint(&json!([1, 2]), None), fingerprint(&json!([2, 1]), None));
+    }
+}

--- a/cli/src/serve/load.rs
+++ b/cli/src/serve/load.rs
@@ -100,7 +100,9 @@ mod tests {
     #[tokio::test]
     async fn submitted_overrides_default() {
         let body = r#"{ "pipeline": { "source": { "config": { "path": "OVERRIDE.csv" } } } }"#;
-        let loaded = load_submission(body, ConfigFormat::Json, Some(&base())).await.unwrap();
+        let loaded = load_submission(body, ConfigFormat::Json, Some(&base()))
+            .await
+            .unwrap();
         // The override wins; the default sink survives the merge.
         let node = &loaded.nodes[0];
         assert_eq!(node.source.config["path"], "OVERRIDE.csv");
@@ -112,8 +114,13 @@ mod tests {
         // version defaults to 1 via serde, so this exercises the expand/validation
         // failure path (pipeline with no source/sink). Accept either layer's error.
         let body = r#"{ "pipeline": {} }"#;
-        let err = load_submission(body, ConfigFormat::Json, None).await.unwrap_err();
-        assert!(matches!(err, ServeError::Unprocessable { .. } | ServeError::BadConfig(_)));
+        let err = load_submission(body, ConfigFormat::Json, None)
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            ServeError::Unprocessable { .. } | ServeError::BadConfig(_)
+        ));
     }
 
     #[cfg(feature = "schedule")]
@@ -128,7 +135,9 @@ schedule:
   cron: "0 * * * *"
   timezone: UTC
 "#;
-        let err = load_submission(body, ConfigFormat::Yaml, None).await.unwrap_err();
+        let err = load_submission(body, ConfigFormat::Yaml, None)
+            .await
+            .unwrap_err();
         match err {
             ServeError::BadConfig(m) => assert!(m.contains("schedule:")),
             other => panic!("expected BadConfig, got {other:?}"),
@@ -137,7 +146,9 @@ schedule:
 
     #[tokio::test]
     async fn invalid_yaml_is_bad_config() {
-        let err = load_submission("{[bad", ConfigFormat::Yaml, None).await.unwrap_err();
+        let err = load_submission("{[bad", ConfigFormat::Yaml, None)
+            .await
+            .unwrap_err();
         assert!(matches!(err, ServeError::BadConfig(_)));
     }
 }

--- a/cli/src/serve/load.rs
+++ b/cli/src/serve/load.rs
@@ -1,0 +1,143 @@
+//! Turn a submitted config body into expanded nodes, applying the workspace
+//! `--default-config` base. Mirrors `PipelineConfig::from_path_async` but merges
+//! a base `Value` and uses `from_value`. All `${env}`/`${file}`/`${secret}` and
+//! `${vault:…}`-style directives resolve against the *server's* environment and
+//! credentials (the documented privilege surface — spec §13).
+
+use crate::config::PipelineConfig;
+use crate::expand::{ExpandedNode, expand};
+use crate::serve::error::ServeError;
+use serde_json::Value;
+
+/// Wire format of a submitted config body.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ConfigFormat {
+    #[default]
+    Yaml,
+    Json,
+}
+
+/// A loaded submission: the merged/resolved config and its expanded nodes.
+#[derive(Debug)]
+pub struct LoadedSubmission {
+    pub cfg: PipelineConfig,
+    pub nodes: Vec<ExpandedNode>,
+}
+
+/// Load + merge + expand a submitted config body.
+pub async fn load_submission(
+    body: &str,
+    format: ConfigFormat,
+    default_base: Option<&Value>,
+) -> Result<LoadedSubmission, ServeError> {
+    // 1. ${env}/${file}/${secret} interpolation against the server's env/fs.
+    let interpolated =
+        crate::interpolate::interpolate(body).map_err(|e| ServeError::BadConfig(e.to_string()))?;
+
+    // 2. Parse to a Value per the declared format.
+    let submitted: Value = match format {
+        ConfigFormat::Yaml => serde_yaml::from_str(&interpolated)
+            .map_err(|e| ServeError::BadConfig(format!("invalid YAML: {e}")))?,
+        ConfigFormat::Json => serde_json::from_str(&interpolated)
+            .map_err(|e| ServeError::BadConfig(format!("invalid JSON: {e}")))?,
+    };
+
+    // 3. Merge onto the workspace default (submitted wins; see merge.rs semantics).
+    let merged = match default_base {
+        Some(base) => {
+            let mut m = base.clone();
+            crate::merge::merge_value(&mut m, submitted);
+            m
+        }
+        None => submitted,
+    };
+
+    // 4. Version gate + structural-ref resolution.
+    let mut cfg = PipelineConfig::from_value(merged).map_err(|e| ServeError::Unprocessable {
+        message: e.to_string(),
+        details: None,
+    })?;
+
+    // serve runs once per submission; a schedule: block is a category error.
+    #[cfg(feature = "schedule")]
+    if cfg.schedule.is_some() {
+        return Err(ServeError::BadConfig(
+            "submitted config contains a `schedule:` block — serve runs once per \
+             submission; use `faucet schedule` for cron scheduling"
+                .into(),
+        ));
+    }
+
+    // 5. Secret-manager directives (${vault:…} etc.) with the server's creds.
+    crate::secrets::resolve_secrets(&mut cfg)
+        .await
+        .map_err(|e| ServeError::BadConfig(e.to_string()))?;
+
+    // 6. Expand the matrix.
+    let nodes = expand(&cfg).map_err(|e| ServeError::Unprocessable {
+        message: e.to_string(),
+        details: None,
+    })?;
+
+    Ok(LoadedSubmission { cfg, nodes })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn base() -> Value {
+        json!({
+            "version": 1,
+            "pipeline": {
+                "source": { "type": "csv", "config": { "path": "DEFAULT.csv" } },
+                "sink": { "type": "jsonl", "config": { "path": "out.jsonl" } }
+            }
+        })
+    }
+
+    #[tokio::test]
+    async fn submitted_overrides_default() {
+        let body = r#"{ "pipeline": { "source": { "config": { "path": "OVERRIDE.csv" } } } }"#;
+        let loaded = load_submission(body, ConfigFormat::Json, Some(&base())).await.unwrap();
+        // The override wins; the default sink survives the merge.
+        let node = &loaded.nodes[0];
+        assert_eq!(node.source.config["path"], "OVERRIDE.csv");
+        assert_eq!(node.sink.config["path"], "out.jsonl");
+    }
+
+    #[tokio::test]
+    async fn missing_version_without_base_is_unprocessable() {
+        // version defaults to 1 via serde, so this exercises the expand/validation
+        // failure path (pipeline with no source/sink). Accept either layer's error.
+        let body = r#"{ "pipeline": {} }"#;
+        let err = load_submission(body, ConfigFormat::Json, None).await.unwrap_err();
+        assert!(matches!(err, ServeError::Unprocessable { .. } | ServeError::BadConfig(_)));
+    }
+
+    #[cfg(feature = "schedule")]
+    #[tokio::test]
+    async fn schedule_block_is_rejected() {
+        let body = r#"
+version: 1
+pipeline:
+  source: { type: csv, config: { path: x.csv } }
+  sink: { type: jsonl, config: { path: out.jsonl } }
+schedule:
+  cron: "0 * * * *"
+  timezone: UTC
+"#;
+        let err = load_submission(body, ConfigFormat::Yaml, None).await.unwrap_err();
+        match err {
+            ServeError::BadConfig(m) => assert!(m.contains("schedule:")),
+            other => panic!("expected BadConfig, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn invalid_yaml_is_bad_config() {
+        let err = load_submission("{[bad", ConfigFormat::Yaml, None).await.unwrap_err();
+        assert!(matches!(err, ServeError::BadConfig(_)));
+    }
+}

--- a/cli/src/serve/metrics.rs
+++ b/cli/src/serve/metrics.rs
@@ -4,6 +4,8 @@
 use axum::extract::{MatchedPath, Request};
 use axum::middleware::Next;
 use axum::response::Response;
+use crate::serve::history::RunStatus;
+use crate::serve::state::ServerState;
 use std::time::Instant;
 
 /// The matched route template for a request, or `<unmatched>` for a 404.
@@ -40,6 +42,27 @@ pub async fn track_metrics(req: Request, next: Next) -> Response {
     resp
 }
 
+/// Refresh the queue-depth + in-flight gauges from the registry. Called on every
+/// queue transition (submit, queued→running, finish).
+pub fn set_run_gauges(state: &ServerState) {
+    metrics::gauge!("faucet_serve_runs_queued").set(state.registry().queued() as f64);
+    metrics::gauge!("faucet_serve_runs_in_flight").set(state.registry().in_flight() as f64);
+}
+
+/// Count a run reaching a terminal state, labelled by status + a finer reason.
+pub fn record_run_finished(status: RunStatus, reason: &'static str) {
+    metrics::counter!(
+        "faucet_serve_runs_total",
+        "status" => status.as_str(), "reason" => reason
+    )
+    .increment(1);
+}
+
+/// Count an idempotency-key replay hit.
+pub fn record_idempotency_hit() {
+    metrics::counter!("faucet_serve_idempotency_hits_total").increment(1);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -52,5 +75,13 @@ mod tests {
             .body(axum::body::Body::empty())
             .unwrap();
         assert_eq!(matched_path_label(&req), "<unmatched>");
+    }
+
+    #[test]
+    fn run_finished_label_strings_are_stable() {
+        // Guards against accidental relabeling (which would split Prometheus series).
+        use crate::serve::history::RunStatus;
+        assert_eq!(RunStatus::Completed.as_str(), "completed");
+        assert_eq!(RunStatus::Cancelled.as_str(), "cancelled");
     }
 }

--- a/cli/src/serve/metrics.rs
+++ b/cli/src/serve/metrics.rs
@@ -1,11 +1,11 @@
 //! `faucet_serve_*` request metrics. The `path` label is the *matched route
 //! template* (`/v1/runs/{id}`), never the raw path — cardinality safety.
 
+use crate::serve::history::RunStatus;
+use crate::serve::state::ServerState;
 use axum::extract::{MatchedPath, Request};
 use axum::middleware::Next;
 use axum::response::Response;
-use crate::serve::history::RunStatus;
-use crate::serve::state::ServerState;
 use std::time::Instant;
 
 /// The matched route template for a request, or `<unmatched>` for a 404.

--- a/cli/src/serve/metrics.rs
+++ b/cli/src/serve/metrics.rs
@@ -84,4 +84,50 @@ mod tests {
         assert_eq!(RunStatus::Completed.as_str(), "completed");
         assert_eq!(RunStatus::Cancelled.as_str(), "cancelled");
     }
+
+    /// Regression guard: axum 0.8 populates `MatchedPath` *before* middleware
+    /// fires even for outer `.layer()` middleware (axum 0.8 changed this from
+    /// 0.7 where outer layers ran before routing). Verifies the cardinality-safe
+    /// matched-path design works correctly in `build_router`'s outer-layer
+    /// position and that the `path` label is never stuck at `"<unmatched>"` for
+    /// routed requests.
+    #[tokio::test]
+    async fn matched_path_captured_in_outer_layer_position() {
+        use axum::routing::get;
+        use std::sync::{Arc, Mutex};
+        use tower::util::ServiceExt;
+
+        // Capture the path label that track_metrics sees from an outer .layer()
+        // — the same position used by build_router.
+        let captured: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+        let captured2 = captured.clone();
+
+        let capture_middleware = axum::middleware::from_fn(move |req: Request, next: Next| {
+            let captured = captured2.clone();
+            async move {
+                let label = matched_path_label(&req);
+                *captured.lock().unwrap() = Some(label);
+                next.run(req).await
+            }
+        });
+
+        // Mirrors build_router: outer .layer() on the merged router.
+        let router = axum::Router::new()
+            .route("/v1/runs/{id}", get(|| async { "ok" }))
+            .layer(capture_middleware);
+
+        let req = Request::builder()
+            .uri("/v1/runs/abc-123")
+            .body(axum::body::Body::empty())
+            .unwrap();
+        let _resp: axum::response::Response = router.oneshot(req).await.unwrap();
+
+        let label = captured.lock().unwrap().clone().unwrap();
+        // axum 0.8: MatchedPath is populated before the outer layer runs.
+        assert_eq!(
+            label, "/v1/runs/{id}",
+            "MatchedPath must be the route template, not '<unmatched>' — \
+             axum 0.8 outer .layer() correctly sees MatchedPath"
+        );
+    }
 }

--- a/cli/src/serve/mod.rs
+++ b/cli/src/serve/mod.rs
@@ -9,6 +9,7 @@ pub mod error;
 pub mod handlers;
 pub mod history;
 pub mod idempotency;
+pub mod load;
 pub mod metrics;
 pub mod observability;
 pub mod registry;

--- a/cli/src/serve/mod.rs
+++ b/cli/src/serve/mod.rs
@@ -13,6 +13,7 @@ pub mod load;
 pub mod metrics;
 pub mod observability;
 pub mod registry;
+pub mod runner;
 pub mod server;
 pub mod state;
 

--- a/cli/src/serve/mod.rs
+++ b/cli/src/serve/mod.rs
@@ -11,6 +11,7 @@ pub mod history;
 pub mod idempotency;
 pub mod metrics;
 pub mod observability;
+pub mod registry;
 pub mod server;
 pub mod state;
 

--- a/cli/src/serve/mod.rs
+++ b/cli/src/serve/mod.rs
@@ -7,6 +7,7 @@ pub mod auth;
 pub mod config;
 pub mod error;
 pub mod handlers;
+pub mod history;
 pub mod metrics;
 pub mod observability;
 pub mod server;

--- a/cli/src/serve/mod.rs
+++ b/cli/src/serve/mod.rs
@@ -8,6 +8,7 @@ pub mod config;
 pub mod error;
 pub mod handlers;
 pub mod history;
+pub mod idempotency;
 pub mod metrics;
 pub mod observability;
 pub mod server;

--- a/cli/src/serve/registry.rs
+++ b/cli/src/serve/registry.rs
@@ -1,0 +1,154 @@
+//! In-flight run registry. Tracks per-run cancellation tokens and the queue /
+//! in-flight counters that drive backpressure (429), the `faucet_serve_runs_*`
+//! gauges, `/readyz`, and the shutdown drain. A "queued" run is one that has been
+//! spawned but has not yet acquired an execution permit.
+
+use dashmap::DashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use tokio::sync::Notify;
+use tokio_util::sync::CancellationToken;
+
+pub struct Registry {
+    tokens: DashMap<String, CancellationToken>,
+    queued: AtomicUsize,
+    in_flight: AtomicUsize,
+    max_queued: usize,
+    drained: Notify,
+}
+
+impl Registry {
+    pub fn new(max_queued: usize) -> Self {
+        Self {
+            tokens: DashMap::new(),
+            queued: AtomicUsize::new(0),
+            in_flight: AtomicUsize::new(0),
+            max_queued: max_queued.max(1),
+            drained: Notify::new(),
+        }
+    }
+
+    /// Reserve a queue slot. Returns `true` if a slot was reserved, or `false`
+    /// if the queue is full. Atomic against concurrent submits via a CAS loop.
+    pub fn try_reserve(&self) -> bool {
+        let mut cur = self.queued.load(Ordering::Acquire);
+        loop {
+            if cur >= self.max_queued {
+                return false;
+            }
+            match self.queued.compare_exchange_weak(
+                cur,
+                cur + 1,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return true,
+                Err(actual) => cur = actual,
+            }
+        }
+    }
+
+    /// Release a slot reserved by `try_reserve` that will not be spawned
+    /// (idempotency replay/conflict).
+    pub fn release_reservation(&self) {
+        self.queued.fetch_sub(1, Ordering::AcqRel);
+    }
+
+    pub fn register(&self, run_id: String, token: CancellationToken) {
+        self.tokens.insert(run_id, token);
+    }
+
+    /// Queued → running: the run acquired its execution permit.
+    pub fn mark_running(&self) {
+        self.queued.fetch_sub(1, Ordering::AcqRel);
+        self.in_flight.fetch_add(1, Ordering::AcqRel);
+    }
+
+    /// Running → terminal: drop the token and wake any shutdown drain waiter.
+    pub fn mark_finished(&self, run_id: &str) {
+        self.in_flight.fetch_sub(1, Ordering::AcqRel);
+        self.tokens.remove(run_id);
+        self.drained.notify_waiters();
+    }
+
+    /// Cancel a live run. Returns `true` if a live token existed.
+    pub fn cancel(&self, run_id: &str) -> bool {
+        if let Some(t) = self.tokens.get(run_id) {
+            t.cancel();
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn queued(&self) -> usize {
+        self.queued.load(Ordering::Acquire)
+    }
+
+    pub fn in_flight(&self) -> usize {
+        self.in_flight.load(Ordering::Acquire)
+    }
+
+    pub fn is_full(&self) -> bool {
+        self.queued() >= self.max_queued
+    }
+
+    /// Resolve once no run is in flight. Arms the notification *before*
+    /// re-checking the counter to avoid a missed wake-up.
+    pub async fn wait_drained(&self) {
+        loop {
+            if self.in_flight() == 0 {
+                return;
+            }
+            let notified = self.drained.notified();
+            if self.in_flight() == 0 {
+                return;
+            }
+            notified.await;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reserve_respects_capacity() {
+        let r = Registry::new(2);
+        assert!(r.try_reserve());
+        assert!(r.try_reserve());
+        assert!(!r.try_reserve());
+        assert!(r.is_full());
+        r.release_reservation();
+        assert!(r.try_reserve());
+    }
+
+    #[test]
+    fn running_transition_moves_counters() {
+        let r = Registry::new(4);
+        r.try_reserve();
+        assert_eq!(r.queued(), 1);
+        r.mark_running();
+        assert_eq!(r.queued(), 0);
+        assert_eq!(r.in_flight(), 1);
+        r.mark_finished("x");
+        assert_eq!(r.in_flight(), 0);
+    }
+
+    #[test]
+    fn cancel_reports_presence() {
+        let r = Registry::new(4);
+        let token = CancellationToken::new();
+        r.register("run1".into(), token.clone());
+        assert!(r.cancel("run1"));
+        assert!(token.is_cancelled());
+        assert!(!r.cancel("missing"));
+    }
+
+    #[tokio::test]
+    async fn wait_drained_returns_when_idle() {
+        let r = Registry::new(4);
+        // No in-flight work → resolves immediately.
+        r.wait_drained().await;
+    }
+}

--- a/cli/src/serve/registry.rs
+++ b/cli/src/serve/registry.rs
@@ -92,15 +92,15 @@ impl Registry {
         self.queued() >= self.max_queued
     }
 
-    /// Resolve once no run is in flight. Arms the notification *before*
-    /// re-checking the counter to avoid a missed wake-up.
+    /// Resolve once no run is queued or in flight. Arms the notification *before*
+    /// re-checking so a transition can't be missed.
     pub async fn wait_drained(&self) {
         loop {
-            if self.in_flight() == 0 {
+            if self.queued() == 0 && self.in_flight() == 0 {
                 return;
             }
             let notified = self.drained.notified();
-            if self.in_flight() == 0 {
+            if self.queued() == 0 && self.in_flight() == 0 {
                 return;
             }
             notified.await;
@@ -143,6 +143,15 @@ mod tests {
         assert!(r.cancel("run1"));
         assert!(token.is_cancelled());
         assert!(!r.cancel("missing"));
+    }
+
+    #[test]
+    fn is_not_idle_while_queued() {
+        let r = Registry::new(4);
+        r.try_reserve();
+        // queued=1, in_flight=0 — must NOT be considered drained.
+        assert_eq!(r.queued(), 1);
+        assert_eq!(r.in_flight(), 0);
     }
 
     #[tokio::test]

--- a/cli/src/serve/runner.rs
+++ b/cli/src/serve/runner.rs
@@ -134,7 +134,14 @@ pub async fn submit(state: ServerState, req: SubmitRequest) -> Result<SubmitResp
 
     // The spawned task now owns the queued→running→finished lifecycle.
     reservation.defuse();
-    spawn_run(state.clone(), loaded, req, run_id.clone(), run_token, submitted_at);
+    spawn_run(
+        state.clone(),
+        loaded,
+        req,
+        run_id.clone(),
+        run_token,
+        submitted_at,
+    );
 
     Ok(SubmitResponse {
         run_id,
@@ -144,11 +151,19 @@ pub async fn submit(state: ServerState, req: SubmitRequest) -> Result<SubmitResp
 }
 
 /// Run the `doctor_first` probes; on any failure return 422 with the report.
-async fn run_doctor_first(state: &ServerState, loaded: &LoadedSubmission) -> Result<(), ServeError> {
+async fn run_doctor_first(
+    state: &ServerState,
+    loaded: &LoadedSubmission,
+) -> Result<(), ServeError> {
     use faucet_core::check::CheckContext;
-    let auth = build_auth_catalog(loaded.cfg.auth.as_ref())
-        .map_err(|e| ServeError::Unprocessable { message: e.to_string(), details: None })?;
-    let ctx = CheckContext { timeout: state.probe_timeout() };
+    let auth =
+        build_auth_catalog(loaded.cfg.auth.as_ref()).map_err(|e| ServeError::Unprocessable {
+            message: e.to_string(),
+            details: None,
+        })?;
+    let ctx = CheckContext {
+        timeout: state.probe_timeout(),
+    };
     let mut invs = crate::commands::doctor::probe_roots(&loaded.nodes, &auth, &ctx).await;
     let failed = crate::commands::doctor::count_failures(&invs);
     if failed > 0 {
@@ -223,21 +238,42 @@ impl Drop for InFlightGuard {
 
 /// Terminal classification of a run task.
 enum Terminal {
-    Completed { records: u64, invs: Vec<InvocationRecord> },
-    Failed { reason: String, records: u64, invs: Vec<InvocationRecord> },
-    Timeout { secs: u64 },
+    Completed {
+        records: u64,
+        invs: Vec<InvocationRecord>,
+    },
+    Failed {
+        reason: String,
+        records: u64,
+        invs: Vec<InvocationRecord>,
+    },
+    Timeout {
+        secs: u64,
+    },
     Cancelled,
     ShutdownFailed,
 }
 
 impl Terminal {
     /// (status, metric reason label, records, invocations, error message)
-    fn into_parts(self) -> (RunStatus, &'static str, u64, Vec<InvocationRecord>, Option<String>) {
+    fn into_parts(
+        self,
+    ) -> (
+        RunStatus,
+        &'static str,
+        u64,
+        Vec<InvocationRecord>,
+        Option<String>,
+    ) {
         match self {
-            Terminal::Completed { records, invs } => (RunStatus::Completed, "ok", records, invs, None),
-            Terminal::Failed { reason, records, invs } => {
-                (RunStatus::Failed, "error", records, invs, Some(reason))
+            Terminal::Completed { records, invs } => {
+                (RunStatus::Completed, "ok", records, invs, None)
             }
+            Terminal::Failed {
+                reason,
+                records,
+                invs,
+            } => (RunStatus::Failed, "error", records, invs, Some(reason)),
             Terminal::Timeout { secs } => (
                 RunStatus::Failed,
                 "timeout",
@@ -261,9 +297,16 @@ impl Terminal {
 fn classify_run(result: crate::error::CliResult<RunSummary>) -> Terminal {
     match result {
         Ok(summary) => {
-            let records: u64 = summary.invocations.iter().map(|i| i.records_written as u64).sum();
-            let invs: Vec<InvocationRecord> =
-                summary.invocations.iter().map(InvocationRecord::from).collect();
+            let records: u64 = summary
+                .invocations
+                .iter()
+                .map(|i| i.records_written as u64)
+                .sum();
+            let invs: Vec<InvocationRecord> = summary
+                .invocations
+                .iter()
+                .map(InvocationRecord::from)
+                .collect();
             if summary.had_failures() {
                 Terminal::Failed {
                     reason: format!("{} invocation(s) failed", summary.failure_count()),
@@ -274,12 +317,19 @@ fn classify_run(result: crate::error::CliResult<RunSummary>) -> Terminal {
                 Terminal::Completed { records, invs }
             }
         }
-        Err(e) => Terminal::Failed { reason: e.to_string(), records: 0, invs: Vec::new() },
+        Err(e) => Terminal::Failed {
+            reason: e.to_string(),
+            records: 0,
+            invs: Vec::new(),
+        },
     }
 }
 
 /// Parse the optional request `clock` (RFC3339), defaulting to `submitted_at`.
-fn resolve_clock(flag: Option<&str>, default: DateTime<Utc>) -> Result<DateTime<FixedOffset>, ServeError> {
+fn resolve_clock(
+    flag: Option<&str>,
+    default: DateTime<Utc>,
+) -> Result<DateTime<FixedOffset>, ServeError> {
     match flag {
         None => Ok(default.fixed_offset()),
         Some(s) => DateTime::parse_from_rfc3339(s)
@@ -327,11 +377,16 @@ fn spawn_run(
         let auth = match build_auth_catalog(cfg.auth.as_ref()) {
             Ok(a) => a,
             Err(e) => {
-                finalize(&state, &run_id, started, Terminal::Failed {
-                    reason: format!("auth catalog: {e}"),
-                    records: 0,
-                    invs: Vec::new(),
-                })
+                finalize(
+                    &state,
+                    &run_id,
+                    started,
+                    Terminal::Failed {
+                        reason: format!("auth catalog: {e}"),
+                        records: 0,
+                        invs: Vec::new(),
+                    },
+                )
                 .await;
                 return;
             }
@@ -339,11 +394,16 @@ fn spawn_run(
         let clock = match resolve_clock(req.clock.as_deref(), submitted_at) {
             Ok(c) => c,
             Err(e) => {
-                finalize(&state, &run_id, started, Terminal::Failed {
-                    reason: e.api_error().error.message,
-                    records: 0,
-                    invs: Vec::new(),
-                })
+                finalize(
+                    &state,
+                    &run_id,
+                    started,
+                    Terminal::Failed {
+                        reason: e.api_error().error.message,
+                        records: 0,
+                        invs: Vec::new(),
+                    },
+                )
                 .await;
                 return;
             }
@@ -450,7 +510,10 @@ mod tests {
     #[test]
     fn resolve_clock_defaults_and_parses() {
         let default = Utc::now();
-        assert_eq!(resolve_clock(None, default).unwrap(), default.fixed_offset());
+        assert_eq!(
+            resolve_clock(None, default).unwrap(),
+            default.fixed_offset()
+        );
         assert!(resolve_clock(Some("2026-01-31T00:00:00Z"), default).is_ok());
         assert!(resolve_clock(Some("not-a-time"), default).is_err());
     }
@@ -503,7 +566,10 @@ mod tests {
         };
 
         let err = submit(state.clone(), req).await.unwrap_err();
-        assert!(matches!(err, ServeError::Conflict(_)), "expected Conflict, got {err:?}");
+        assert!(
+            matches!(err, ServeError::Conflict(_)),
+            "expected Conflict, got {err:?}"
+        );
         // The reservation taken before the claim must have been released by the guard.
         assert_eq!(state.registry().queued(), 0);
     }

--- a/cli/src/serve/runner.rs
+++ b/cli/src/serve/runner.rs
@@ -1,0 +1,510 @@
+//! The run lifecycle: validate + queue a submission (`submit`), then run it under
+//! a permit inside a 3-arm `select!` (user-cancel token / server-shutdown token /
+//! timeout) and finalize an authoritative terminal status. See spec §7 + §20.
+
+use crate::auth_catalog::build_auth_catalog;
+use crate::executor::{ExecuteOptions, RunSummary, run_expanded};
+use crate::serve::error::ServeError;
+use crate::serve::history::{Claim, InvocationRecord, RunRecord, RunStatus};
+use crate::serve::load::{ConfigFormat, LoadedSubmission, load_submission};
+use crate::serve::state::ServerState;
+use crate::serve::{idempotency, metrics};
+use chrono::{DateTime, FixedOffset, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::time::Duration;
+use tokio_util::sync::CancellationToken;
+use tracing::Instrument;
+
+/// `Retry-After` advertised when the queue is full.
+const QUEUE_FULL_RETRY_AFTER_SECS: u64 = 5;
+
+/// `POST /v1/runs` request body.
+#[derive(Debug, Deserialize)]
+pub struct SubmitRequest {
+    pub config: String,
+    #[serde(default)]
+    pub config_format: ConfigFormatWire,
+    pub name: Option<String>,
+    #[serde(default)]
+    pub labels: BTreeMap<String, String>,
+    pub timeout_secs: Option<u64>,
+    #[serde(default)]
+    pub doctor_first: bool,
+    pub idempotency_key: Option<String>,
+    pub clock: Option<String>,
+}
+
+/// Wire enum mirroring `load::ConfigFormat` with serde rename.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ConfigFormatWire {
+    #[default]
+    Yaml,
+    Json,
+}
+
+impl From<ConfigFormatWire> for ConfigFormat {
+    fn from(w: ConfigFormatWire) -> Self {
+        match w {
+            ConfigFormatWire::Yaml => ConfigFormat::Yaml,
+            ConfigFormatWire::Json => ConfigFormat::Json,
+        }
+    }
+}
+
+/// `POST /v1/runs` success body (202).
+#[derive(Debug, Serialize)]
+pub struct SubmitResponse {
+    pub run_id: String,
+    pub status: RunStatus,
+    pub submitted_at: DateTime<Utc>,
+}
+
+/// Validate, idempotency-claim, queue, and spawn a submission.
+pub async fn submit(state: ServerState, req: SubmitRequest) -> Result<SubmitResponse, ServeError> {
+    let format: ConfigFormat = req.config_format.into();
+    let loaded = load_submission(&req.config, format, state.default_base()).await?;
+
+    // doctor_first preflight (before reserving any slot or claiming the key).
+    if req.doctor_first {
+        run_doctor_first(&state, &loaded).await?;
+    }
+
+    // Reserve a queue slot first, so a Fresh idempotency claim is always followed
+    // by a spawned run (no orphaned claims — spec §20.2).
+    if !state.registry().try_reserve() {
+        return Err(ServeError::QueueFull {
+            retry_after_secs: QUEUE_FULL_RETRY_AFTER_SECS,
+        });
+    }
+    // Releases the reservation on ANY early return below (replay / conflict /
+    // claim or upsert error). Defused just before the run is spawned.
+    let reservation = ReservationGuard::new(state.clone());
+
+    let run_id = uuid::Uuid::now_v7().to_string();
+
+    // Idempotency claim (if a key was supplied).
+    if let Some(key) = &req.idempotency_key {
+        let merged = serde_json::to_value(&loaded.cfg).unwrap_or(serde_json::Value::Null);
+        let fp = idempotency::fingerprint(&merged, loaded.cfg.name.as_deref());
+        match state
+            .history()
+            .claim_idempotency(key, &fp, &run_id, state.idempotency_retention())
+            .await
+            .map_err(|e| ServeError::Internal(e.to_string()))?
+        {
+            Claim::Fresh => {}
+            Claim::Replay(existing) => {
+                metrics::record_idempotency_hit();
+                return replay_response(&state, &existing).await;
+            }
+            Claim::Conflict => {
+                return Err(ServeError::Conflict(
+                    "idempotency key reused with a different payload".into(),
+                ));
+            }
+        }
+        // NOTE (Phase 5 / SQL backends): a `Fresh` claim is recorded BEFORE the
+        // record upsert below. The memory backend's `upsert` is infallible, so the
+        // claim and record are always consistent today. A future fallible backend
+        // whose `upsert` errors here would leave an orphaned claim (a replay of the
+        // key returns 404 until the claim self-expires within the retention
+        // window). When SQL backends land, claim after a successful upsert, or add
+        // a claim-release to RunHistory.
+    }
+
+    let submitted_at = Utc::now();
+    let rec = RunRecord::queued(
+        run_id.clone(),
+        req.name.clone(),
+        req.labels.clone(),
+        req.idempotency_key.clone(),
+        submitted_at,
+    );
+    state
+        .history()
+        .upsert(&rec)
+        .await
+        .map_err(|e| ServeError::Internal(e.to_string()))?;
+
+    let run_token = CancellationToken::new();
+    state.registry().register(run_id.clone(), run_token.clone());
+    metrics::set_run_gauges(&state);
+
+    // The spawned task now owns the queued→running→finished lifecycle.
+    reservation.defuse();
+    spawn_run(state.clone(), loaded, req, run_id.clone(), run_token, submitted_at);
+
+    Ok(SubmitResponse {
+        run_id,
+        status: RunStatus::Queued,
+        submitted_at,
+    })
+}
+
+/// Run the `doctor_first` probes; on any failure return 422 with the report.
+async fn run_doctor_first(state: &ServerState, loaded: &LoadedSubmission) -> Result<(), ServeError> {
+    use faucet_core::check::CheckContext;
+    let auth = build_auth_catalog(loaded.cfg.auth.as_ref())
+        .map_err(|e| ServeError::Unprocessable { message: e.to_string(), details: None })?;
+    let ctx = CheckContext { timeout: state.probe_timeout() };
+    let mut invs = crate::commands::doctor::probe_roots(&loaded.nodes, &auth, &ctx).await;
+    let failed = crate::commands::doctor::count_failures(&invs);
+    if failed > 0 {
+        crate::commands::doctor::redact_invocations(&mut invs);
+        return Err(ServeError::Unprocessable {
+            message: format!("doctor_first preflight failed: {failed} probe(s) failed"),
+            details: Some(serde_json::json!({ "invocations": invs })),
+        });
+    }
+    Ok(())
+}
+
+/// Build the replay response for an idempotency hit (the existing run's status).
+async fn replay_response(state: &ServerState, run_id: &str) -> Result<SubmitResponse, ServeError> {
+    let rec = state
+        .history()
+        .get(run_id)
+        .await
+        .map_err(|e| ServeError::Internal(e.to_string()))?
+        .ok_or(ServeError::NotFound)?;
+    Ok(SubmitResponse {
+        run_id: rec.run_id,
+        status: rec.status,
+        submitted_at: rec.submitted_at,
+    })
+}
+
+/// Releases a queue reservation on drop unless [`Self::defuse`]d. Guarantees the
+/// `queued` counter is balanced on every early-return path (replay / conflict /
+/// claim-or-upsert error) without a manual `release_reservation` at each site.
+/// Defused once the run is handed to the spawned task, which then owns the
+/// queued→running transition via `mark_running`.
+struct ReservationGuard {
+    state: Option<ServerState>,
+}
+
+impl ReservationGuard {
+    fn new(state: ServerState) -> Self {
+        Self { state: Some(state) }
+    }
+
+    /// Hand the reservation off to the spawned task (no release on drop).
+    fn defuse(mut self) {
+        self.state = None;
+    }
+}
+
+impl Drop for ReservationGuard {
+    fn drop(&mut self) {
+        if let Some(state) = self.state.take() {
+            state.registry().release_reservation();
+            metrics::set_run_gauges(&state);
+        }
+    }
+}
+
+/// Releases the in-flight slot (decrement `in_flight`, drop the cancel token, wake
+/// the shutdown drain) on drop — on EVERY path including panic. Without this, a
+/// panic between `mark_running` and a manual `mark_finished` would leak the
+/// counter and hang graceful shutdown forever.
+struct InFlightGuard {
+    state: ServerState,
+    run_id: String,
+}
+
+impl Drop for InFlightGuard {
+    fn drop(&mut self) {
+        self.state.registry().mark_finished(&self.run_id);
+        metrics::set_run_gauges(&self.state);
+    }
+}
+
+/// Terminal classification of a run task.
+enum Terminal {
+    Completed { records: u64, invs: Vec<InvocationRecord> },
+    Failed { reason: String, records: u64, invs: Vec<InvocationRecord> },
+    Timeout { secs: u64 },
+    Cancelled,
+    ShutdownFailed,
+}
+
+impl Terminal {
+    /// (status, metric reason label, records, invocations, error message)
+    fn into_parts(self) -> (RunStatus, &'static str, u64, Vec<InvocationRecord>, Option<String>) {
+        match self {
+            Terminal::Completed { records, invs } => (RunStatus::Completed, "ok", records, invs, None),
+            Terminal::Failed { reason, records, invs } => {
+                (RunStatus::Failed, "error", records, invs, Some(reason))
+            }
+            Terminal::Timeout { secs } => (
+                RunStatus::Failed,
+                "timeout",
+                0,
+                Vec::new(),
+                Some(format!("run exceeded timeout_secs ({secs}s)")),
+            ),
+            Terminal::Cancelled => (RunStatus::Cancelled, "cancelled", 0, Vec::new(), None),
+            Terminal::ShutdownFailed => (
+                RunStatus::Failed,
+                "server_shutdown",
+                0,
+                Vec::new(),
+                Some("server shutdown before the run finished".into()),
+            ),
+        }
+    }
+}
+
+/// Classify a finished `run_expanded` result into a `Terminal`.
+fn classify_run(result: crate::error::CliResult<RunSummary>) -> Terminal {
+    match result {
+        Ok(summary) => {
+            let records: u64 = summary.invocations.iter().map(|i| i.records_written as u64).sum();
+            let invs: Vec<InvocationRecord> =
+                summary.invocations.iter().map(InvocationRecord::from).collect();
+            if summary.had_failures() {
+                Terminal::Failed {
+                    reason: format!("{} invocation(s) failed", summary.failure_count()),
+                    records,
+                    invs,
+                }
+            } else {
+                Terminal::Completed { records, invs }
+            }
+        }
+        Err(e) => Terminal::Failed { reason: e.to_string(), records: 0, invs: Vec::new() },
+    }
+}
+
+/// Parse the optional request `clock` (RFC3339), defaulting to `submitted_at`.
+fn resolve_clock(flag: Option<&str>, default: DateTime<Utc>) -> Result<DateTime<FixedOffset>, ServeError> {
+    match flag {
+        None => Ok(default.fixed_offset()),
+        Some(s) => DateTime::parse_from_rfc3339(s)
+            .map_err(|_| ServeError::BadConfig(format!("clock '{s}' is not RFC3339"))),
+    }
+}
+
+/// Spawn the detached run task: acquire a permit, run under the 3-arm select,
+/// finalize the terminal status.
+fn spawn_run(
+    state: ServerState,
+    loaded: LoadedSubmission,
+    req: SubmitRequest,
+    run_id: String,
+    run_token: CancellationToken,
+    submitted_at: DateTime<Utc>,
+) {
+    let server_shutdown = state.shutdown_token();
+    let LoadedSubmission { cfg, nodes } = loaded;
+
+    tokio::spawn(async move {
+        let _permit = state
+            .semaphore()
+            .acquire_owned()
+            .await
+            .expect("semaphore not closed");
+
+        // Queued → running. From here the guard guarantees `mark_finished` (and a
+        // gauge refresh) on EVERY exit, including early returns and panics.
+        state.registry().mark_running();
+        let _guard = InFlightGuard {
+            state: state.clone(),
+            run_id: run_id.clone(),
+        };
+        let started = Utc::now();
+        if let Ok(Some(mut rec)) = state.history().get(&run_id).await {
+            rec.status = RunStatus::Running;
+            rec.started_at = Some(started);
+            let _ = state.history().upsert(&rec).await;
+        }
+        metrics::set_run_gauges(&state);
+
+        // Build execution options (auth/clock failures finalize as Failed).
+        let pipeline_name = cfg.name.clone().unwrap_or_else(|| "serve".to_string());
+        let auth = match build_auth_catalog(cfg.auth.as_ref()) {
+            Ok(a) => a,
+            Err(e) => {
+                finalize(&state, &run_id, started, Terminal::Failed {
+                    reason: format!("auth catalog: {e}"),
+                    records: 0,
+                    invs: Vec::new(),
+                })
+                .await;
+                return;
+            }
+        };
+        let clock = match resolve_clock(req.clock.as_deref(), submitted_at) {
+            Ok(c) => c,
+            Err(e) => {
+                finalize(&state, &run_id, started, Terminal::Failed {
+                    reason: e.api_error().error.message,
+                    records: 0,
+                    invs: Vec::new(),
+                })
+                .await;
+                return;
+            }
+        };
+
+        let opts = ExecuteOptions {
+            pipeline_name,
+            execution: cfg.execution.clone(),
+            dry_run: false,
+            limit: None,
+            state_path_override: None,
+            auth,
+            clock,
+        };
+        let timeout = req.timeout_secs.map(Duration::from_secs);
+
+        let span = tracing::info_span!("faucet.serve.run", serve_run_id = %run_id);
+        let work = async move {
+            match timeout {
+                Some(d) => match tokio::time::timeout(d, run_expanded(nodes, opts)).await {
+                    Ok(r) => classify_run(r),
+                    Err(_) => Terminal::Timeout { secs: d.as_secs() },
+                },
+                None => classify_run(run_expanded(nodes, opts).await),
+            }
+        }
+        .instrument(span);
+
+        // Cooperative cancel: dropping `work` cancels in-flight pipeline work at
+        // its next await; the task stays alive to write its own terminal status.
+        let terminal = tokio::select! {
+            _ = run_token.cancelled() => Terminal::Cancelled,
+            _ = server_shutdown.cancelled() => Terminal::ShutdownFailed,
+            t = work => t,
+        };
+
+        finalize(&state, &run_id, started, terminal).await;
+        // `_guard` drops here → mark_finished + gauge refresh.
+    });
+}
+
+/// Write the authoritative terminal record + the run-finished metric.
+async fn finalize(state: &ServerState, run_id: &str, started: DateTime<Utc>, term: Terminal) {
+    let finished = Utc::now();
+    let elapsed = (finished - started).to_std().ok().map(|d| d.as_secs_f64());
+    let (status, reason, records, invs, error) = term.into_parts();
+    if let Ok(Some(mut rec)) = state.history().get(run_id).await {
+        rec.status = status;
+        rec.finished_at = Some(finished);
+        rec.elapsed_secs = elapsed;
+        rec.records_written = records;
+        rec.invocations = invs;
+        rec.error = error;
+        let _ = state.history().upsert(&rec).await;
+    }
+    metrics::record_run_finished(status, reason);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_ok_no_failures_is_completed() {
+        let summary = RunSummary {
+            invocations: vec![crate::executor::InvocationOutcome {
+                row_id: "r".into(),
+                parent_record_key: None,
+                records_written: 3,
+                error: None,
+            }],
+        };
+        let (status, reason, records, _, error) = classify_run(Ok(summary)).into_parts();
+        assert_eq!(status, RunStatus::Completed);
+        assert_eq!(reason, "ok");
+        assert_eq!(records, 3);
+        assert!(error.is_none());
+    }
+
+    #[test]
+    fn classify_ok_with_failures_is_failed() {
+        let summary = RunSummary {
+            invocations: vec![crate::executor::InvocationOutcome {
+                row_id: "r".into(),
+                parent_record_key: None,
+                records_written: 0,
+                error: Some("boom".into()),
+            }],
+        };
+        let (status, reason, _, _, error) = classify_run(Ok(summary)).into_parts();
+        assert_eq!(status, RunStatus::Failed);
+        assert_eq!(reason, "error");
+        assert!(error.unwrap().contains("invocation(s) failed"));
+    }
+
+    #[test]
+    fn timeout_maps_to_failed_with_timeout_reason() {
+        let (status, reason, _, _, error) = Terminal::Timeout { secs: 30 }.into_parts();
+        assert_eq!(status, RunStatus::Failed);
+        assert_eq!(reason, "timeout");
+        assert!(error.unwrap().contains("30s"));
+    }
+
+    #[test]
+    fn resolve_clock_defaults_and_parses() {
+        let default = Utc::now();
+        assert_eq!(resolve_clock(None, default).unwrap(), default.fixed_offset());
+        assert!(resolve_clock(Some("2026-01-31T00:00:00Z"), default).is_ok());
+        assert!(resolve_clock(Some("not-a-time"), default).is_err());
+    }
+
+    #[tokio::test]
+    async fn conflict_releases_reservation() {
+        use crate::serve::config::{AuthMode, HistoryBackendSpec, ServeConfig};
+        use crate::serve::history::RunHistory;
+        use crate::serve::history::memory::MemoryHistory;
+        use crate::serve::state::ServerState;
+        use std::sync::Arc;
+        use tokio_util::sync::CancellationToken;
+
+        let cfg = ServeConfig {
+            listen: "127.0.0.1:0".parse().unwrap(),
+            auth: AuthMode::None,
+            max_concurrent_runs: 4,
+            max_queued_runs: 4,
+            default_config_path: None,
+            history: HistoryBackendSpec::Memory,
+            cors_origins: vec![],
+            body_limit_bytes: 1_048_576,
+            shutdown_grace: Duration::from_secs(60),
+            retain_terminal_runs: Duration::from_secs(60),
+            idempotency_retention: Duration::from_secs(60),
+            probe_timeout: Duration::from_secs(10),
+            env_file: None,
+            no_env_file: false,
+            log_level: "info".into(),
+        };
+        let history = Arc::new(MemoryHistory::new(Duration::from_secs(60))) as Arc<dyn RunHistory>;
+        let state = ServerState::new(&cfg, None, CancellationToken::new(), history, None);
+
+        // Pre-claim the key with a DIFFERENT fingerprint so submit() hits Conflict.
+        state
+            .history()
+            .claim_idempotency("k", "different-fp", "prior", Duration::from_secs(60))
+            .await
+            .unwrap();
+
+        let req = SubmitRequest {
+            config: "version: 1\npipeline:\n  source: { type: csv, config: { path: x.csv } }\n  sink: { type: jsonl, config: { path: out.jsonl } }\n".into(),
+            config_format: ConfigFormatWire::Yaml,
+            name: None,
+            labels: BTreeMap::new(),
+            timeout_secs: None,
+            doctor_first: false,
+            idempotency_key: Some("k".into()),
+            clock: None,
+        };
+
+        let err = submit(state.clone(), req).await.unwrap_err();
+        assert!(matches!(err, ServeError::Conflict(_)), "expected Conflict, got {err:?}");
+        // The reservation taken before the claim must have been released by the guard.
+        assert_eq!(state.registry().queued(), 0);
+    }
+}

--- a/cli/src/serve/server.rs
+++ b/cli/src/serve/server.rs
@@ -122,14 +122,18 @@ pub async fn serve(config: ServeConfig) -> CliResult<()> {
         .map_err(|e| CliError::Serve(format!("server error: {e}")))?;
 
     // Now drain run tasks: wait up to the grace window, then cancel the rest.
-    let drained = tokio::time::timeout(config.shutdown_grace, state.registry().wait_drained()).await;
+    let drained =
+        tokio::time::timeout(config.shutdown_grace, state.registry().wait_drained()).await;
     if drained.is_err() {
         let remaining = state.registry().in_flight();
         tracing::warn!(remaining, "grace window expired; cancelling in-flight runs");
         shutdown.cancel();
         // Give cancelled tasks a brief moment to write their terminal status.
-        let _ = tokio::time::timeout(std::time::Duration::from_secs(5), state.registry().wait_drained())
-            .await;
+        let _ = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            state.registry().wait_drained(),
+        )
+        .await;
     }
     tracing::info!("faucet serve stopped");
     Ok(())

--- a/cli/src/serve/server.rs
+++ b/cli/src/serve/server.rs
@@ -1,45 +1,38 @@
 //! axum router assembly and the bind / graceful-shutdown serve loop.
 
 use crate::error::{CliError, CliResult};
-use crate::serve::config::ServeConfig;
-use crate::serve::handlers::health;
-use crate::serve::history::memory::MemoryHistory;
+use crate::serve::config::{HistoryBackendSpec, ServeConfig};
+use crate::serve::handlers::{health, runs};
 use crate::serve::history::RunHistory;
+use crate::serve::history::memory::MemoryHistory;
 use crate::serve::state::ServerState;
 use crate::serve::{auth, metrics};
 use axum::Router;
-use axum::routing::get;
+use axum::routing::{get, post};
+use serde_json::Value;
 use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 use tower_http::cors::{AllowOrigin, CorsLayer};
 use tower_http::limit::RequestBodyLimitLayer;
 
-/// Build the full router. `/v1/*` routes are added in a later phase; here the
-/// API sub-router is empty but carries the auth layer, and health/metrics are
-/// public. The middleware stack (body-limit, request metrics, CORS) is wired
-/// from the start so its ordering is correct.
-///
-/// Note: axum 0.8 rejects `route_layer` on a `Router` with no routes, so the
-/// auth middleware is attached via `.layer(...)` on the empty api sub-router.
-/// TODO(phase 2): switch /v1 routes to `route_layer` once routes land.
+/// Build the full router: unauthenticated probes + the bearer-guarded `/v1` API.
 pub fn build_router(state: ServerState, config: &ServeConfig) -> Router {
-    // Unauthenticated probe/scrape endpoints.
     let public = Router::new()
         .route("/healthz", get(health::healthz))
         .route("/readyz", get(health::readyz))
         .route("/metrics", get(health::metrics));
 
-    // Authenticated API surface (routes land in a later phase).
-    // Using `.layer(...)` rather than `route_layer` because axum 0.8 rejects
-    // `route_layer` on a Router with no routes.
-    let api = Router::new().layer(axum::middleware::from_fn_with_state(
-        state.clone(),
-        auth::require_auth,
-    ));
+    // `/v1` routes guarded by the bearer middleware via `route_layer` (only runs
+    // for matched routes; OPTIONS preflight is allowed through inside the layer).
+    let api = Router::new()
+        .route("/v1/runs", post(runs::submit_run).get(runs::list_runs))
+        .route("/v1/runs/{id}", get(runs::get_run).delete(runs::delete_run))
+        .route("/v1/runs/{id}/cancel", post(runs::cancel_run))
+        .route_layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            auth::require_auth,
+        ));
 
-    // No origins configured → `CorsLayer::new()` emits no `Access-Control-*`
-    // headers, so browsers block cross-origin requests (CORS effectively off).
-    // The layer is a cheap pass-through for non-browser clients.
     let cors = if config.cors_origins.is_empty() {
         CorsLayer::new()
     } else {
@@ -65,17 +58,50 @@ pub fn build_router(state: ServerState, config: &ServeConfig) -> Router {
         .with_state(state)
 }
 
-/// Boot the server: install observability, build the router, bind the listener,
-/// and serve until SIGTERM / SIGINT, then drain.
+/// Construct the run-history backend. Phase 2/3 supports only memory; the
+/// Postgres/SQLite specs return a typed "not yet implemented" error (Phase 5).
+async fn build_history(config: &ServeConfig) -> CliResult<Arc<dyn RunHistory>> {
+    match &config.history {
+        HistoryBackendSpec::Memory => {
+            Ok(Arc::new(MemoryHistory::new(config.idempotency_retention)) as Arc<dyn RunHistory>)
+        }
+        HistoryBackendSpec::Postgres(_) | HistoryBackendSpec::Sqlite(_) => Err(CliError::Serve(
+            "persistent run history (postgres/sqlite) is not yet available — \
+             omit --history to use the in-memory backend (tracking: #127 Phase 5)"
+                .into(),
+        )),
+    }
+}
+
+/// Load the optional `--default-config` once at startup, fully resolved, as a
+/// merge base `Value`.
+async fn load_default_base(config: &ServeConfig) -> CliResult<Option<Value>> {
+    match &config.default_config_path {
+        None => Ok(None),
+        Some(path) => {
+            let cfg = crate::config::PipelineConfig::from_path_async(path).await?;
+            Ok(Some(serde_json::to_value(&cfg).map_err(|e| {
+                CliError::Serve(format!("serializing --default-config: {e}"))
+            })?))
+        }
+    }
+}
+
+/// Boot the server: install observability, build state + router, bind, serve
+/// until SIGTERM/SIGINT, then drain in-flight runs up to the grace window.
 pub async fn serve(config: ServeConfig) -> CliResult<()> {
     let prom = crate::serve::observability::install(&config.log_level);
 
+    let history = build_history(&config).await?;
+    history
+        .recover_orphans()
+        .await
+        .map_err(|e| CliError::Serve(format!("history recovery: {e}")))?;
+    let default_base = load_default_base(&config).await?;
+
     let shutdown = CancellationToken::new();
-    let history: Arc<dyn RunHistory> =
-        Arc::new(MemoryHistory::new(config.idempotency_retention));
-    let default_base = None; // populated in a later phase via --default-config
     let state = ServerState::new(&config, prom, shutdown.clone(), history, default_base);
-    let app = build_router(state, &config);
+    let app = build_router(state.clone(), &config);
 
     let listener = tokio::net::TcpListener::bind(config.listen)
         .await
@@ -85,17 +111,27 @@ pub async fn serve(config: ServeConfig) -> CliResult<()> {
         .map_err(|e| CliError::Serve(e.to_string()))?;
     tracing::info!(listen = %local, "faucet serve listening");
 
-    let shutdown_for_axum = shutdown.clone();
+    // The HTTP graceful-shutdown future resolves on signal and stops accepting
+    // new connections / drains in-flight HTTP — it does NOT cancel run tasks.
     axum::serve(listener, app)
         .with_graceful_shutdown(async move {
             wait_for_signal().await;
-            tracing::info!("shutdown signal received; draining");
-            shutdown_for_axum.cancel();
+            tracing::info!("shutdown signal received; draining in-flight runs");
         })
         .await
         .map_err(|e| CliError::Serve(format!("server error: {e}")))?;
 
-    // A later phase awaits in-flight run tasks up to config.shutdown_grace, then cancels.
+    // Now drain run tasks: wait up to the grace window, then cancel the rest.
+    let drained = tokio::time::timeout(config.shutdown_grace, state.registry().wait_drained()).await;
+    if drained.is_err() {
+        let remaining = state.registry().in_flight();
+        tracing::warn!(remaining, "grace window expired; cancelling in-flight runs");
+        shutdown.cancel();
+        // Give cancelled tasks a brief moment to write their terminal status.
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(5), state.registry().wait_drained())
+            .await;
+    }
+    tracing::info!("faucet serve stopped");
     Ok(())
 }
 

--- a/cli/src/serve/server.rs
+++ b/cli/src/serve/server.rs
@@ -3,10 +3,13 @@
 use crate::error::{CliError, CliResult};
 use crate::serve::config::ServeConfig;
 use crate::serve::handlers::health;
+use crate::serve::history::memory::MemoryHistory;
+use crate::serve::history::RunHistory;
 use crate::serve::state::ServerState;
 use crate::serve::{auth, metrics};
 use axum::Router;
 use axum::routing::get;
+use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 use tower_http::cors::{AllowOrigin, CorsLayer};
 use tower_http::limit::RequestBodyLimitLayer;
@@ -68,7 +71,10 @@ pub async fn serve(config: ServeConfig) -> CliResult<()> {
     let prom = crate::serve::observability::install(&config.log_level);
 
     let shutdown = CancellationToken::new();
-    let state = ServerState::new(&config, prom, shutdown.clone());
+    let history: Arc<dyn RunHistory> =
+        Arc::new(MemoryHistory::new(config.idempotency_retention));
+    let default_base = None; // populated in a later phase via --default-config
+    let state = ServerState::new(&config, prom, shutdown.clone(), history, default_base);
     let app = build_router(state, &config);
 
     let listener = tokio::net::TcpListener::bind(config.listen)

--- a/cli/src/serve/state.rs
+++ b/cli/src/serve/state.rs
@@ -1,10 +1,16 @@
 //! Shared, cheaply-cloneable server state handed to every handler via
-//! `axum::extract::State`. Phase 1 holds auth + the Prometheus render handle +
-//! the server-wide shutdown token. Later phases add the run registry + history.
+//! `axum::extract::State`. Holds auth, the Prometheus render handle, the
+//! server-wide shutdown token, the run registry, the execution semaphore, the
+//! run-history backend, and the `--default-config` merge base.
 
 use crate::serve::config::{AuthMode, ServeConfig};
+use crate::serve::history::RunHistory;
+use crate::serve::registry::Registry;
 use metrics_exporter_prometheus::PrometheusHandle;
+use serde_json::Value;
 use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Semaphore;
 use tokio_util::sync::CancellationToken;
 
 #[derive(Clone)]
@@ -16,6 +22,12 @@ struct Inner {
     auth: AuthMode,
     prometheus: Option<PrometheusHandle>,
     shutdown: CancellationToken,
+    registry: Registry,
+    semaphore: Arc<Semaphore>,
+    history: Arc<dyn RunHistory>,
+    default_base: Option<Value>,
+    idempotency_retention: Duration,
+    probe_timeout: Duration,
 }
 
 impl ServerState {
@@ -23,17 +35,24 @@ impl ServerState {
         config: &ServeConfig,
         prometheus: Option<PrometheusHandle>,
         shutdown: CancellationToken,
+        history: Arc<dyn RunHistory>,
+        default_base: Option<Value>,
     ) -> Self {
         Self {
             inner: Arc::new(Inner {
                 auth: config.auth.clone(),
                 prometheus,
                 shutdown,
+                registry: Registry::new(config.max_queued_runs),
+                semaphore: Arc::new(Semaphore::new(config.max_concurrent_runs)),
+                history,
+                default_base,
+                idempotency_retention: config.idempotency_retention,
+                probe_timeout: config.probe_timeout,
             }),
         }
     }
 
-    /// The expected bearer token, or `None` when started with `--no-auth`.
     pub fn auth_token(&self) -> Option<&str> {
         match &self.inner.auth {
             AuthMode::Token(t) => Some(t),
@@ -41,8 +60,6 @@ impl ServerState {
         }
     }
 
-    /// Render the current Prometheus exposition, or `None` if no recorder handle
-    /// was installed (e.g. a second server in the same test process).
     pub fn render_metrics(&self) -> Option<String> {
         self.inner.prometheus.as_ref().map(|h| h.render())
     }
@@ -50,13 +67,37 @@ impl ServerState {
     pub fn shutdown_token(&self) -> CancellationToken {
         self.inner.shutdown.clone()
     }
+
+    pub fn registry(&self) -> &Registry {
+        &self.inner.registry
+    }
+
+    pub fn semaphore(&self) -> Arc<Semaphore> {
+        Arc::clone(&self.inner.semaphore)
+    }
+
+    pub fn history(&self) -> Arc<dyn RunHistory> {
+        Arc::clone(&self.inner.history)
+    }
+
+    pub fn default_base(&self) -> Option<&Value> {
+        self.inner.default_base.as_ref()
+    }
+
+    pub fn idempotency_retention(&self) -> Duration {
+        self.inner.idempotency_retention
+    }
+
+    pub fn probe_timeout(&self) -> Duration {
+        self.inner.probe_timeout
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::serve::config::HistoryBackendSpec;
-    use std::time::Duration;
+    use crate::serve::history::memory::MemoryHistory;
 
     fn cfg(auth: AuthMode) -> ServeConfig {
         ServeConfig {
@@ -78,21 +119,26 @@ mod tests {
         }
     }
 
+    fn state(auth: AuthMode) -> ServerState {
+        let history = Arc::new(MemoryHistory::new(Duration::from_secs(60))) as Arc<dyn RunHistory>;
+        ServerState::new(&cfg(auth), None, CancellationToken::new(), history, None)
+    }
+
     #[test]
     fn auth_token_reflects_mode() {
-        let s = ServerState::new(
-            &cfg(AuthMode::Token("x".into())),
-            None,
-            CancellationToken::new(),
-        );
-        assert_eq!(s.auth_token(), Some("x"));
-        let s = ServerState::new(&cfg(AuthMode::None), None, CancellationToken::new());
-        assert_eq!(s.auth_token(), None);
+        assert_eq!(state(AuthMode::Token("x".into())).auth_token(), Some("x"));
+        assert_eq!(state(AuthMode::None).auth_token(), None);
     }
 
     #[test]
     fn render_metrics_none_without_handle() {
-        let s = ServerState::new(&cfg(AuthMode::None), None, CancellationToken::new());
-        assert!(s.render_metrics().is_none());
+        assert!(state(AuthMode::None).render_metrics().is_none());
+    }
+
+    #[test]
+    fn registry_starts_empty() {
+        let s = state(AuthMode::None);
+        assert_eq!(s.registry().queued(), 0);
+        assert_eq!(s.registry().in_flight(), 0);
     }
 }

--- a/cli/tests/cli_end_to_end.rs
+++ b/cli/tests/cli_end_to_end.rs
@@ -478,10 +478,12 @@ fn shipped_example_yamls_pass_validate() {
         // specific test runs (e.g. `--features serve`) must not trip on
         // example YAMLs that need the orthogonal `schedule` feature (or vice
         // versa).
-        let yaml_text = fs::read_to_string(&path).unwrap_or_default();
         #[cfg(not(feature = "schedule"))]
-        if yaml_text.contains("\nschedule:") || yaml_text.starts_with("schedule:") {
-            continue;
+        {
+            let yaml_text = fs::read_to_string(&path).unwrap_or_default();
+            if yaml_text.contains("\nschedule:") || yaml_text.starts_with("schedule:") {
+                continue;
+            }
         }
         count += 1;
         let mut cmd = Command::cargo_bin("faucet").unwrap();

--- a/cli/tests/cli_end_to_end.rs
+++ b/cli/tests/cli_end_to_end.rs
@@ -473,6 +473,16 @@ fn shipped_example_yamls_pass_validate() {
         if path.extension().and_then(|e| e.to_str()) != Some("yaml") {
             continue;
         }
+        // Skip examples that require a feature the test binary wasn't built
+        // with.  In CI `--all-features` covers everything; local feature-
+        // specific test runs (e.g. `--features serve`) must not trip on
+        // example YAMLs that need the orthogonal `schedule` feature (or vice
+        // versa).
+        let yaml_text = fs::read_to_string(&path).unwrap_or_default();
+        #[cfg(not(feature = "schedule"))]
+        if yaml_text.contains("\nschedule:") || yaml_text.starts_with("schedule:") {
+            continue;
+        }
         count += 1;
         let mut cmd = Command::cargo_bin("faucet").unwrap();
         for (k, v) in env_placeholders {

--- a/cli/tests/examples_roundtrip.rs
+++ b/cli/tests/examples_roundtrip.rs
@@ -51,11 +51,13 @@ fn every_example_loads_and_expands() {
         // binary.  In CI `--all-features` covers everything; local single-
         // feature runs must not fail on example YAMLs that need an orthogonal
         // feature (e.g. `schedule:` requires `--features schedule`).
-        let yaml_text = std::fs::read_to_string(&path).unwrap_or_default();
         #[cfg(not(feature = "schedule"))]
-        if yaml_text.contains("\nschedule:") || yaml_text.starts_with("schedule:") {
-            skipped += 1;
-            continue;
+        {
+            let yaml_text = std::fs::read_to_string(&path).unwrap_or_default();
+            if yaml_text.contains("\nschedule:") || yaml_text.starts_with("schedule:") {
+                skipped += 1;
+                continue;
+            }
         }
         count += 1;
         let cfg = match PipelineConfig::from_path(&path) {

--- a/cli/tests/examples_roundtrip.rs
+++ b/cli/tests/examples_roundtrip.rs
@@ -47,6 +47,16 @@ fn every_example_loads_and_expands() {
         if !matches!(ext, "yaml" | "yml" | "json") {
             continue;
         }
+        // Skip examples that rely on a feature not compiled into this test
+        // binary.  In CI `--all-features` covers everything; local single-
+        // feature runs must not fail on example YAMLs that need an orthogonal
+        // feature (e.g. `schedule:` requires `--features schedule`).
+        let yaml_text = std::fs::read_to_string(&path).unwrap_or_default();
+        #[cfg(not(feature = "schedule"))]
+        if yaml_text.contains("\nschedule:") || yaml_text.starts_with("schedule:") {
+            skipped += 1;
+            continue;
+        }
         count += 1;
         let cfg = match PipelineConfig::from_path(&path) {
             Ok(c) => c,

--- a/cli/tests/serve_lifecycle.rs
+++ b/cli/tests/serve_lifecycle.rs
@@ -1,0 +1,292 @@
+//! Lifecycle, auth, idempotency, doctor_first, and cancel integration tests for
+//! `faucet serve`. These tests never assert /metrics CONTENT (only status codes
+//! and run lifecycle), so they are safe to run in parallel within one process —
+//! they don't depend on being the first installer of the Prometheus recorder.
+//! Requires the `serve` feature.
+#![cfg(feature = "serve")]
+
+use faucet_cli::cli::ServeArgs;
+use faucet_cli::serve::ServeConfig;
+use std::time::Duration;
+
+// ── shared helpers ────────────────────────────────────────────────────────────
+
+fn free_port() -> u16 {
+    // The TcpListener is dropped immediately after obtaining the port. There is a
+    // small TOCTOU window; acceptable for integration tests on a loopback interface.
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.local_addr().unwrap().port()
+}
+
+fn args_on(port: u16, token: Option<&str>) -> ServeArgs {
+    ServeArgs {
+        listen: format!("127.0.0.1:{port}"),
+        auth_token: token.map(|t| t.to_string()),
+        no_auth: token.is_none(),
+        max_concurrent_runs: Some(4),
+        max_queued_runs: Some(16),
+        default_config: None,
+        history: None,
+        cors_origin: vec![],
+        body_limit_bytes: 1_048_576,
+        shutdown_grace_secs: 5,
+        retain_terminal_runs_secs: 604_800,
+        idempotency_retention_secs: 86_400,
+        probe_timeout_secs: 5,
+        env_file: None,
+        no_env_file: true,
+    }
+}
+
+async fn spawn_server(port: u16, token: Option<&str>) {
+    let mut config = ServeConfig::from_args(args_on(port, token)).unwrap();
+    config.log_level = "warn".into();
+    tokio::spawn(async move {
+        let _ = faucet_cli::serve::run_server(config).await;
+    });
+    let client = reqwest::Client::new();
+    for _ in 0..100 {
+        if client
+            .get(format!("http://127.0.0.1:{port}/healthz"))
+            .send()
+            .await
+            .map(|r| r.status().is_success())
+            .unwrap_or(false)
+        {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    panic!("server did not become healthy on port {port}");
+}
+
+fn csv_to_jsonl_yaml(input: &std::path::Path, output: &std::path::Path) -> String {
+    format!(
+        "version: 1\npipeline:\n  source: {{ type: csv, config: {{ path: \"{}\" }} }}\n  sink: {{ type: jsonl, config: {{ path: \"{}\" }} }}\n",
+        input.display(),
+        output.display()
+    )
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+/// Auth middleware: /healthz is public; /v1/* requires a valid Bearer token.
+#[tokio::test]
+async fn auth_required_when_token_set() {
+    let port = free_port();
+    spawn_server(port, Some("s3cret")).await;
+    let client = reqwest::Client::new();
+    let base = format!("http://127.0.0.1:{port}");
+
+    // /healthz is always unauthenticated.
+    assert!(
+        client
+            .get(format!("{base}/healthz"))
+            .send()
+            .await
+            .unwrap()
+            .status()
+            .is_success(),
+        "/healthz must not require auth"
+    );
+
+    // /v1/runs without a token returns 401.
+    assert_eq!(
+        client
+            .get(format!("{base}/v1/runs"))
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        401,
+        "missing token must yield 401"
+    );
+
+    // /v1/runs with the correct token returns 200.
+    let ok = client
+        .get(format!("{base}/v1/runs"))
+        .bearer_auth("s3cret")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(ok.status(), 200, "correct bearer token must yield 200");
+}
+
+/// Same idempotency key + same payload → replay (same run_id).
+/// Same key + different payload → 409 Conflict.
+#[tokio::test]
+async fn idempotency_replays_and_conflicts() {
+    let port = free_port();
+    spawn_server(port, None).await;
+    let client = reqwest::Client::new();
+    let base = format!("http://127.0.0.1:{port}");
+
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("in.csv");
+    let output = dir.path().join("out.jsonl");
+    std::fs::write(&input, "name\nalice\n").unwrap();
+    let cfg = csv_to_jsonl_yaml(&input, &output);
+    let body = serde_json::json!({ "config": cfg, "idempotency_key": "k1" });
+
+    let first: serde_json::Value = client
+        .post(format!("{base}/v1/runs"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let second: serde_json::Value = client
+        .post(format!("{base}/v1/runs"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(
+        first["run_id"], second["run_id"],
+        "same key + same payload must replay the original run_id"
+    );
+
+    // Different payload with the same key must conflict.
+    let other_cfg = csv_to_jsonl_yaml(&input, &dir.path().join("other.jsonl"));
+    let conflict = client
+        .post(format!("{base}/v1/runs"))
+        .json(&serde_json::json!({ "config": other_cfg, "idempotency_key": "k1" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        conflict.status(),
+        409,
+        "different payload with same idempotency key must return 409"
+    );
+}
+
+/// `doctor_first: true` with a source pointing at a nonexistent file must reject
+/// the submit with 422 Unprocessable, carrying an `invocations` details array.
+#[tokio::test]
+async fn doctor_first_rejects_bad_connector() {
+    let port = free_port();
+    spawn_server(port, None).await;
+    let client = reqwest::Client::new();
+    let base = format!("http://127.0.0.1:{port}");
+
+    let body = serde_json::json!({
+        "config": "version: 1\npipeline:\n  source: { type: csv, config: { path: /no/such/file.csv } }\n  sink: { type: jsonl, config: { path: /tmp/out.jsonl } }\n",
+        "doctor_first": true
+    });
+    let resp = client
+        .post(format!("{base}/v1/runs"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        422,
+        "doctor_first failure must return 422 Unprocessable"
+    );
+    let err: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(
+        err["error"]["code"], "unprocessable",
+        "error code must be 'unprocessable'"
+    );
+    assert!(
+        err["error"]["details"]["invocations"].is_array(),
+        "details must contain an invocations array; got:\n{err:#}"
+    );
+}
+
+/// A run that blocks (webhook source with a long timeout and no senders) can be
+/// cancelled: after POST /v1/runs/{id}/cancel the status converges to "cancelled".
+///
+/// Blocking strategy: webhook source bound to a free port with `timeout_secs`
+/// long enough that the test completes the cancel interaction before it fires.
+/// We never send a POST to the webhook, so the run stays "running" indefinitely
+/// until the cancellation token fires.
+#[tokio::test(flavor = "multi_thread")]
+async fn cancel_transitions_to_cancelled() {
+    let port = free_port();
+    spawn_server(port, None).await;
+    let client = reqwest::Client::new();
+    let base = format!("http://127.0.0.1:{port}");
+
+    // The webhook source binds an ephemeral port chosen via free_port() and then
+    // blocks waiting for POSTs that never arrive (timeout_secs is large), so the
+    // run stays `running` until we cancel it. The test never sends POSTs, so the
+    // exact port is irrelevant beyond needing to bind successfully.
+    let webhook_port = free_port();
+    let dir = tempfile::tempdir().unwrap();
+    let output = dir.path().join("out.jsonl");
+    let config_yaml = format!(
+        "version: 1\npipeline:\n  source:\n    type: webhook\n    config:\n      listen_addr: \"127.0.0.1:{webhook_port}\"\n      timeout_secs: 3600\n  sink:\n    type: jsonl\n    config:\n      path: \"{output}\"\n",
+        webhook_port = webhook_port,
+        output = output.display(),
+    );
+    let body = serde_json::json!({ "config": config_yaml });
+
+    let submit: serde_json::Value = client
+        .post(format!("{base}/v1/runs"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let run_id = submit["run_id"].as_str().unwrap().to_string();
+
+    // Wait for the run to reach "running" (webhook source has started its server
+    // and is blocking inside the receive loop).
+    for _ in 0..200 {
+        let rec: serde_json::Value = client
+            .get(format!("{base}/v1/runs/{run_id}"))
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        let s = rec["status"].as_str().unwrap_or("");
+        if s == "running" || s == "completed" || s == "failed" || s == "cancelled" {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+
+    // Issue cancel. The run must be running (or queued) here; 202 means in-flight
+    // cancellation was requested.
+    let cancel_resp = client
+        .post(format!("{base}/v1/runs/{run_id}/cancel"))
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        cancel_resp.status() == 202 || cancel_resp.status() == 200,
+        "cancel must return 202 (in-flight) or 200 (terminal no-op), got {}",
+        cancel_resp.status()
+    );
+
+    // Poll until cancelled (or any terminal state so the test doesn't hang forever).
+    let mut status = String::new();
+    for _ in 0..400 {
+        let rec: serde_json::Value = client
+            .get(format!("{base}/v1/runs/{run_id}"))
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        status = rec["status"].as_str().unwrap_or("").to_string();
+        if status == "cancelled" || status == "completed" || status == "failed" {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    assert_eq!(status, "cancelled", "run must transition to 'cancelled'");
+}

--- a/cli/tests/serve_metrics.rs
+++ b/cli/tests/serve_metrics.rs
@@ -109,15 +109,28 @@ async fn submit_poll_get_completes_and_records_metrics() {
         }
         tokio::time::sleep(Duration::from_millis(25)).await;
     }
-    assert_eq!(status, "completed", "run did not complete within poll window");
+    assert_eq!(
+        status, "completed",
+        "run did not complete within poll window"
+    );
     assert!(output.exists(), "sink output file was not created");
 
     // Assert /metrics contains the expected metric names.
     let metrics_resp = client.get(format!("{base}/metrics")).send().await.unwrap();
-    assert_eq!(metrics_resp.status(), 200, "/metrics should render (recorder installed)");
+    assert_eq!(
+        metrics_resp.status(),
+        200,
+        "/metrics should render (recorder installed)"
+    );
     let metrics = metrics_resp.text().await.unwrap();
-    assert!(metrics.contains("faucet_serve_runs_total"), "metrics missing runs_total:\n{metrics}");
-    assert!(metrics.contains("faucet_serve_requests_total"), "metrics missing requests_total");
+    assert!(
+        metrics.contains("faucet_serve_runs_total"),
+        "metrics missing runs_total:\n{metrics}"
+    );
+    assert!(
+        metrics.contains("faucet_serve_requests_total"),
+        "metrics missing requests_total"
+    );
 
     // Verify GET /v1/runs lists the completed run.
     let list: serde_json::Value = client

--- a/cli/tests/serve_metrics.rs
+++ b/cli/tests/serve_metrics.rs
@@ -1,0 +1,151 @@
+//! `/metrics` integration test for `faucet serve` — ISOLATED in its own test
+//! binary because the Prometheus recorder is a process-global singleton (only the
+//! first server in a process gets a render handle). Requires the `serve` feature.
+#![cfg(feature = "serve")]
+
+use faucet_cli::cli::ServeArgs;
+use faucet_cli::serve::ServeConfig;
+use std::time::Duration;
+
+fn free_port() -> u16 {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.local_addr().unwrap().port()
+}
+
+fn args_on(port: u16, token: Option<&str>) -> ServeArgs {
+    ServeArgs {
+        listen: format!("127.0.0.1:{port}"),
+        auth_token: token.map(|t| t.to_string()),
+        no_auth: token.is_none(),
+        max_concurrent_runs: Some(4),
+        max_queued_runs: Some(16),
+        default_config: None,
+        history: None,
+        cors_origin: vec![],
+        body_limit_bytes: 1_048_576,
+        shutdown_grace_secs: 5,
+        retain_terminal_runs_secs: 604_800,
+        idempotency_retention_secs: 86_400,
+        probe_timeout_secs: 5,
+        env_file: None,
+        no_env_file: true,
+    }
+}
+
+async fn spawn_server(port: u16, token: Option<&str>) {
+    let mut config = ServeConfig::from_args(args_on(port, token)).unwrap();
+    config.log_level = "warn".into();
+    tokio::spawn(async move {
+        let _ = faucet_cli::serve::run_server(config).await;
+    });
+    let client = reqwest::Client::new();
+    for _ in 0..100 {
+        if client
+            .get(format!("http://127.0.0.1:{port}/healthz"))
+            .send()
+            .await
+            .map(|r| r.status().is_success())
+            .unwrap_or(false)
+        {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    panic!("server did not become healthy on port {port}");
+}
+
+fn csv_to_jsonl_yaml(input: &std::path::Path, output: &std::path::Path) -> String {
+    format!(
+        "version: 1\npipeline:\n  source: {{ type: csv, config: {{ path: \"{}\" }} }}\n  sink: {{ type: jsonl, config: {{ path: \"{}\" }} }}\n",
+        input.display(),
+        output.display()
+    )
+}
+
+/// Submit a run, poll until complete, then assert /metrics contains the expected
+/// counters. Isolated here so this process is the first (and only) to install
+/// the Prometheus recorder — the /metrics endpoint returns 200 with content.
+#[tokio::test]
+async fn submit_poll_get_completes_and_records_metrics() {
+    let port = free_port();
+    spawn_server(port, None).await;
+    let client = reqwest::Client::new();
+    let base = format!("http://127.0.0.1:{port}");
+
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("in.csv");
+    let output = dir.path().join("out.jsonl");
+    std::fs::write(&input, "name\nalice\nbob\n").unwrap();
+    let body = serde_json::json!({
+        "config": csv_to_jsonl_yaml(&input, &output),
+        "config_format": "yaml"
+    });
+
+    let resp = client
+        .post(format!("{base}/v1/runs"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 202, "expected 202 Accepted on submit");
+    let submit: serde_json::Value = resp.json().await.unwrap();
+    let run_id = submit["run_id"].as_str().unwrap().to_string();
+    assert_eq!(submit["status"], "queued");
+
+    // Poll until the run reaches a terminal state.
+    let mut status = String::new();
+    for _ in 0..200 {
+        let rec: serde_json::Value = client
+            .get(format!("{base}/v1/runs/{run_id}"))
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        status = rec["status"].as_str().unwrap().to_string();
+        if status == "completed" || status == "failed" {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    assert_eq!(status, "completed", "run did not complete within poll window");
+    assert!(output.exists(), "sink output file was not created");
+
+    // Assert /metrics contains the expected metric names.
+    let metrics_resp = client.get(format!("{base}/metrics")).send().await.unwrap();
+    assert_eq!(metrics_resp.status(), 200, "/metrics should render (recorder installed)");
+    let metrics = metrics_resp.text().await.unwrap();
+    assert!(metrics.contains("faucet_serve_runs_total"), "metrics missing runs_total:\n{metrics}");
+    assert!(metrics.contains("faucet_serve_requests_total"), "metrics missing requests_total");
+
+    // Verify GET /v1/runs lists the completed run.
+    let list: serde_json::Value = client
+        .get(format!("{base}/v1/runs"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert!(
+        list["runs"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|r| r["run_id"] == run_id),
+        "completed run not found in GET /v1/runs listing"
+    );
+
+    // GET /v1/runs/<nonexistent> must return 404.
+    assert_eq!(
+        client
+            .get(format!("{base}/v1/runs/does-not-exist"))
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        404,
+        "missing run must return 404"
+    );
+}


### PR DESCRIPTION
## Summary

Phases **2 (run lifecycle)** and **3 (idempotency + `doctor_first` + `--default-config`)** of `faucet serve` (#127), building on the Phase 1 skeleton (#140). The HTTP control plane can now accept pipeline configs over HTTP and run them in-process under bounded concurrency.

This PR also drops **`serve` and `schedule` from the CLI `default` feature set** — both are long-running runtime modes the one-shot pipeline runner never needs (a web-server dep tree / cron + IANA tz database). `full` now expands to `default + schedule + serve`; opt in with `--features serve` / `--features schedule`.

Phase 2+3 of #127 — Phases 4–6 follow, so this does **not** close the issue.

## What's included

- **Run lifecycle** — `POST/GET/DELETE /v1/runs`, `GET /v1/runs` (status/name/since/until/limit/cursor filters + uuid-v7 cursor pagination), `POST /v1/runs/{id}/cancel`. Bounded `Semaphore` + queue with `429 + Retry-After` backpressure.
- **Execution & cancellation** — runs go through `executor::run_expanded` inside a 3-arm `select!` (user-cancel token / server-shutdown token / per-run `timeout_secs`). Cooperative cancel (drop the future), authoritative terminal status written by the task itself. RAII guards make the queued/in-flight counters leak-free and panic-safe; graceful shutdown drains in-flight runs up to the grace window before cancelling.
- **Run history** — full `RunHistory` trait + in-memory `DashMap` backend (default). `/readyz` reports 503 when degraded or queue-full.
- **Idempotency** — atomic claim + sha256 config fingerprint; replay returns the existing `run_id`, payload mismatch → `409`.
- **`doctor_first`** — preflight probes (reuses `commands::doctor::probe_roots`); any failure → `422` with the (redacted) probe report in `error.details`.
- **`--default-config`** — workspace-default config merged under every submission.
- **Metrics** — `faucet_serve_runs_queued`, `faucet_serve_runs_in_flight`, `faucet_serve_runs_total{status,reason}`, `faucet_serve_idempotency_hits_total` (request metrics already shipped in Phase 1).
- **Security** — bearer auth `route_layer`-scoped to `/v1` (health/metrics public); secret redaction at both the error boundary and the run-record serving boundary.

## Deferred (later phases of #127)

- **Phase 4** — SSE log streaming (`/v1/runs/{id}/logs`).
- **Phase 5** — Postgres/SQLite history backends + crash recovery (the `--history` flag returns a typed "not yet available" error today).
- **Phase 6** — OpenAPI spec + CI route↔spec check + docs site + CLAUDE.md (in-repo).

## Testing

- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.
- `cargo build -p faucet-cli --features serve` and `--features serve,serve-history-postgres,serve-history-sqlite` — clean.
- serve unit + integration tests pass: lifecycle (submit→poll→completed→GET + metrics), auth (401/200 + public health), idempotency (replay + 409 conflict), `doctor_first` (422 + report), cancel (blocking run → `cancelled`).
- Default build still excludes serve+schedule (no axum/croner direct deps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)