### PR TITLE
feat(serve): complete `faucet serve` — SSE logs, persistent history, OpenAPI + docs (Phases 4–6 of #127)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,8 +157,10 @@ jobs:
           - quality-jsonschema
           # Scheduler (CLI-only)
           - schedule
-          # HTTP control plane (CLI-only)
+          # HTTP control plane (CLI-only) + its persistent run-history backends
           - serve
+          - serve-history-postgres
+          - serve-history-sqlite
           # Secrets backends
           - secrets-vault
           - secrets-aws-sm

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ can drop on any box or a library you compile in.
   queues, automatic retries, adaptive batch sizing (AIMD controller that tunes
   write batch size from sink latency and error rate), secrets-manager interpolation
   (`${vault:…}`, `${aws-sm:…}`, `${gcp-sm:…}`, `${azure-kv:…}`), cron scheduling
-  (`faucet schedule`), and built-in Prometheus metrics + `tracing` spans, all with
+  (`faucet schedule`), an HTTP control plane (`faucet serve` — submit/poll/cancel
+  runs over REST), and built-in Prometheus metrics + `tracing` spans, all with
   zero per-connector code.
 - **Pay only for what you use** — every connector is a Cargo feature, so a slim
   build can be just REST + JSONL, or pull in all 35 connectors with `--features full`.
@@ -55,6 +56,7 @@ faucet validate pipeline.yaml
 faucet doctor pipeline.yaml                                  # preflight: probe auth/network/permissions
 faucet run pipeline.yaml
 faucet schedule pipeline.yaml                               # run on cron schedule (add a schedule: block)
+faucet serve --no-auth                                      # HTTP control plane: submit/poll/cancel runs over REST
 ```
 
 ```yaml
@@ -129,7 +131,7 @@ is its most common runtime.
 - You need a connector faucet-stream **doesn't ship yet and can't write** — [Meltano](https://meltano.com/) (600+ Singer taps) and [Airbyte](https://airbyte.com/) (350+) have far broader catalogs today.
 - You want a **fully-managed, hosted service** with a UI and a team operating it — Fivetran or Airbyte Cloud.
 - Your job is **in-warehouse transformation** — use dbt, and pair it with faucet-stream for the extract/load.
-- You need a **long-running streaming service or agent topology** — [Benthos / Redpanda Connect](https://www.redpanda.com/connect) and [Vector](https://vector.dev/) are purpose-built for that; faucet-stream runs pipelines to completion rather than as a daemon.
+- You need a **continuous record-by-record streaming processor** — [Benthos / Redpanda Connect](https://www.redpanda.com/connect) and [Vector](https://vector.dev/) are purpose-built for that. faucet-stream runs discrete pipelines to completion; even the long-running modes (`faucet schedule`, `faucet serve`) orchestrate complete runs rather than a never-ending stream.
 
 ## Architecture
 
@@ -210,7 +212,7 @@ faucet-stream is a Cargo workspace with 47 crates — 20 sources, 16 sinks, 5 sh
 | [`faucet-state-postgres`](crates/state/postgres) | PostgreSQL-backed `StateStore` for persistent bookmarks |
 | [`faucet-stream`](faucet-stream) | Umbrella crate — feature-gated re-exports of all connectors and state backends |
 | **CLI** | |
-| [`faucet-cli`](cli) | `faucet` binary — YAML/JSON config-driven pipeline runner (`run`, `validate`, `schema`, `list`, `preview`, `init`, `doctor`, `schedule`) |
+| [`faucet-cli`](cli) | `faucet` binary — YAML/JSON config-driven pipeline runner (`run`, `validate`, `schema`, `list`, `preview`, `init`, `doctor`, `schedule`, `serve`) |
 
 See the [connector capability matrix](https://pawansikawat.github.io/faucet-stream/reference/connectors.html)
 (streaming, resumable state, compression, auth per connector) and the

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -176,7 +176,7 @@ schedule = ["dep:croner", "dep:chrono-tz"]
 # Enables `observability` (serve renders /metrics on its own port). Gates the
 # tokio net/time features here (rather than the base dep) so slim non-serve
 # builds don't link the TCP stack.
-serve = ["observability", "tokio/net", "tokio/time", "dep:axum", "dep:tower-http", "dep:tokio-util", "dep:subtle", "dep:dashmap", "dep:sha2"]
+serve = ["observability", "tokio/net", "tokio/time", "dep:axum", "dep:tower-http", "dep:tokio-util", "dep:subtle", "dep:dashmap", "dep:sha2", "dep:async-stream"]
 serve-history-postgres = ["serve", "dep:sqlx"]
 serve-history-sqlite = ["serve", "dep:sqlx"]
 
@@ -257,6 +257,8 @@ subtle = { workspace = true, optional = true }
 dashmap = { workspace = true, optional = true }
 # faucet serve idempotency-key hashing (Phase 2+); only compiled with `serve`.
 sha2 = { workspace = true, optional = true }
+# faucet serve SSE log streaming (Phase 4); only compiled with `serve`.
+async-stream = { workspace = true, optional = true }
 sqlx = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -26,7 +26,7 @@ default = ["observability", "source", "sink", "state", "transforms", "compressio
 
 # Everything the default build ships, plus the long-running runtime modes:
 # `schedule` (cron scheduler) and `serve` (HTTP control plane).
-full = ["default", "schedule", "serve"]
+full = ["default", "schedule", "serve", "serve-history-postgres", "serve-history-sqlite"]
 
 # Data-quality checks (`quality:` config block). `quality-jsonschema` adds the
 # `json_schema` record check via a JSON Schema validator. Forwarded to

--- a/cli/README.md
+++ b/cli/README.md
@@ -177,6 +177,46 @@ cargo install faucet-cli                         # schedule included (in full)
 cargo install faucet-cli --features schedule     # explicit, no-default-features build
 ```
 
+### `faucet serve`
+
+`faucet serve` runs a **long-running HTTP control plane**: it accepts pipeline configs over REST, executes them under bounded concurrency (reusing the same executor as `faucet run`), and exposes submit / poll / list / cancel / SSE-log endpoints plus `/healthz`, `/readyz`, and `/metrics`. It takes **no config file** — configs arrive per request.
+
+```bash
+FAUCET_SERVE_AUTH_TOKEN=s3cret faucet serve --listen 0.0.0.0:8080      # bearer auth (preferred)
+faucet serve --no-auth                                                 # explicit no-auth opt-in (required if no token)
+faucet serve --history sqlite:/var/lib/faucet/runs.db                  # durable run history
+faucet serve --default-config defaults.yaml                            # merge workspace defaults under every run
+```
+
+Auth is mandatory: without `--auth-token`/`FAUCET_SERVE_AUTH_TOKEN` **and** without `--no-auth`, startup fails (an unauthenticated server is never accidental). The default bind is loopback.
+
+| Flag | Purpose |
+|------|---------|
+| `--listen <addr>` | Bind address (default `127.0.0.1:8080`; env `FAUCET_SERVE_LISTEN`). |
+| `--auth-token <t>` / `--no-auth` | Bearer token (prefer the env var) or explicit no-auth opt-in. |
+| `--max-concurrent-runs` / `--max-queued-runs` | Concurrency + queue caps (submit past the queue → 429 + `Retry-After`). |
+| `--history <url>` | `postgres://…` / `sqlite:…` for durable history (`serve-history-postgres` / `serve-history-sqlite`; default in-memory). |
+| `--default-config <path>` | Workspace defaults merged **under** every submitted run. |
+| `--cors-origin <o>` | Allow-list a browser origin (repeatable; CORS off by default). |
+| `--body-limit-bytes`, `--shutdown-grace-secs`, `--retain-terminal-runs-secs`, `--idempotency-retention-secs`, `--probe-timeout-secs` | Tuning knobs. |
+
+Submit a run:
+
+```bash
+curl -XPOST localhost:8080/v1/runs -H "Authorization: Bearer s3cret" \
+  -H 'content-type: application/json' \
+  -d '{"config":"version: 1\npipeline:\n  source: {type: csv, config: {path: in.csv}}\n  sink: {type: jsonl, config: {path: out.jsonl}}\n","name":"adhoc","idempotency_key":"k1"}'
+```
+
+> ⚠️ **Security:** `serve` executes arbitrary client-supplied configs with the server's identity — secrets, files, and network egress (SSRF). Run single-tenant, authenticated, behind egress controls; terminate TLS at a proxy. See the [serve cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/serve.html) and [HTTP API reference](https://pawansikawat.github.io/faucet-stream/reference/http-api.html).
+
+Requires the `serve` Cargo feature (included in `full`):
+
+```bash
+cargo install faucet-cli --features serve
+cargo install faucet-cli --features "serve,serve-history-postgres,serve-history-sqlite"
+```
+
 ### `faucet init`
 
 `faucet init` writes a starter `pipeline.yaml` by walking each selected connector's JSON Schema. Required fields are surfaced with a `# REQUIRED` comment and a typed placeholder (`""`, `0`, `false`, `[]`, `{}`); optional fields are commented out so connector-level defaults stay in force. Enum-typed fields list valid values in the trailing comment. Tagged-enum blocks (the `#[serde(tag = "type")]` shape used by `auth:`, `pagination:`, BigQuery `credentials:`, etc.) inline the chosen variant and emit every other variant as a commented-out "Alternative variants" block right below it — so users can switch auth modes (or pagination, or credentials) without leaving the file to consult `faucet schema`. Run `faucet init --interactive` (requires `--features cli-interactive`) to be prompted for each variant up front.

--- a/cli/examples/serve_minimal.yaml
+++ b/cli/examples/serve_minimal.yaml
@@ -1,0 +1,29 @@
+# `faucet serve --default-config` — workspace defaults merged UNDER every
+# submitted run. Submitted configs win on conflicts (objects merge; scalars and
+# arrays replace). This lets an operator pin shared state, execution, and other
+# cross-cutting settings once instead of repeating them in every HTTP request.
+#
+#   faucet serve --no-auth --default-config cli/examples/serve_minimal.yaml
+#
+# Then submit runs that only need to specify their source/sink:
+#
+#   curl -XPOST localhost:8080/v1/runs -H 'content-type: application/json' \
+#     -d '{"config":"version: 1\npipeline:\n  source: {type: csv, config: {path: in.csv}}\n  sink: {type: jsonl, config: {path: out.jsonl}}\n","name":"adhoc"}'
+#
+# This file is a partial pipeline config: it carries no source/sink (those come
+# from each submission) — only the defaults to fold in.
+version: 1
+
+pipeline:
+  # Durable replication bookmarks shared by every run, so incremental/CDC
+  # pipelines resume across submissions. State keys are namespaced per run name.
+  state:
+    type: file
+    config:
+      path: /var/lib/faucet/state
+
+# Per-run pipeline concurrency + error policy (independent of the server's
+# --max-concurrent-runs, which bounds how many runs execute at once).
+execution:
+  max_concurrent: 4
+  on_error: continue

--- a/cli/src/serve/handlers/logs.rs
+++ b/cli/src/serve/handlers/logs.rs
@@ -1,0 +1,65 @@
+//! `GET /v1/runs/{id}/logs` — Server-Sent Events stream of a run's captured log
+//! lines. Replays the run's ring buffer, then forwards the live tail until the
+//! run reaches a terminal state. Thin glue over [`crate::serve::logs`].
+
+use crate::serve::error::ServeError;
+use crate::serve::logs::{LogEvent, log_events};
+use crate::serve::state::ServerState;
+use axum::extract::{Path, State};
+use axum::response::Sse;
+use axum::response::sse::{Event, KeepAlive};
+use futures::{Stream, StreamExt};
+use std::convert::Infallible;
+use std::time::Duration;
+use tokio::sync::broadcast;
+
+/// Keep-alive comment interval — defeats idle-timeout proxies on a quiet stream.
+const KEEP_ALIVE_SECS: u64 = 15;
+
+/// `GET /v1/runs/{id}/logs` → `text/event-stream`.
+///
+/// Events: `event: log` (a line), `event: truncated` (the reader fell behind and
+/// lines were dropped — rely on the centralized log sink), `event: end` (the run
+/// finished; the stream closes). 404 if the run is entirely unknown; a known run
+/// whose buffer has expired yields a single `end`.
+pub async fn stream_logs(
+    State(state): State<ServerState>,
+    Path(id): Path<String>,
+) -> Result<Sse<impl Stream<Item = Result<Event, Infallible>>>, ServeError> {
+    let (snapshot, rx, ended) = match state.log_hub().reader(&id) {
+        Some(reader) => reader,
+        None => {
+            // No buffer: 404 for an unknown run, or an immediate `end` for a known
+            // run whose logs have already been dropped after the drain window.
+            let known = state
+                .history()
+                .get(&id)
+                .await
+                .map_err(|e| ServeError::Internal(e.to_string()))?
+                .is_some();
+            if !known {
+                return Err(ServeError::NotFound);
+            }
+            // A dropped sender's receiver is never polled (ended == true).
+            (Vec::new(), broadcast::channel(1).1, true)
+        }
+    };
+
+    let stream =
+        log_events(snapshot, rx, ended).map(|ev| Ok::<Event, Infallible>(to_sse_event(ev)));
+    Ok(
+        Sse::new(stream)
+            .keep_alive(KeepAlive::new().interval(Duration::from_secs(KEEP_ALIVE_SECS))),
+    )
+}
+
+/// Map an internal [`LogEvent`] to an SSE wire event.
+fn to_sse_event(ev: LogEvent) -> Event {
+    match ev {
+        LogEvent::Log(line) => Event::default().event("log").data(line),
+        LogEvent::Truncated(n) => Event::default().event("truncated").data(format!(
+            "{n} log line(s) dropped; rely on the centralized log sink"
+        )),
+        LogEvent::End => Event::default().event("end").data("done"),
+    }
+}

--- a/cli/src/serve/handlers/mod.rs
+++ b/cli/src/serve/handlers/mod.rs
@@ -1,3 +1,4 @@
 //! serve HTTP handlers.
 pub mod health;
+pub mod logs;
 pub mod runs;

--- a/cli/src/serve/history/fallback.rs
+++ b/cli/src/serve/history/fallback.rs
@@ -1,0 +1,213 @@
+//! Degradation wrapper around a persistent run-history backend (Phase 5 of
+//! #127). While the primary (Postgres/SQLite) backend is healthy, every call
+//! goes to it. The first time a call errors — or if the backend could not be
+//! reached at startup — the wrapper flips to **degraded**: it logs once, sets
+//! the `faucet_serve_history_degraded` gauge, surfaces `503` on `/readyz` via
+//! [`RunHistory::degraded`], and serves all subsequent calls from an in-memory
+//! backend so the server stays up (spec §11). Data already in the primary is not
+//! migrated — degraded mode is a stay-alive fallback, not a replica.
+
+use super::memory::MemoryHistory;
+use super::{Claim, DeleteOutcome, HistoryError, ListFilter, ListPage, RunHistory, RunRecord};
+use async_trait::async_trait;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+pub struct FallbackHistory {
+    /// Persistent backend; `None` when it was unreachable at startup.
+    primary: Option<Box<dyn RunHistory>>,
+    fallback: MemoryHistory,
+    degraded: AtomicBool,
+    /// `"postgres"` / `"sqlite"` — for log + metric context.
+    label: &'static str,
+}
+
+impl FallbackHistory {
+    /// Wrap a healthy primary backend.
+    pub fn healthy(
+        primary: Box<dyn RunHistory>,
+        idem_retention: Duration,
+        label: &'static str,
+    ) -> Self {
+        Self {
+            primary: Some(primary),
+            fallback: MemoryHistory::new(idem_retention),
+            degraded: AtomicBool::new(false),
+            label,
+        }
+    }
+
+    /// Start already degraded: the primary backend was unreachable at startup.
+    pub fn degraded_at_startup(idem_retention: Duration, label: &'static str) -> Self {
+        crate::serve::metrics::set_history_degraded(true);
+        Self {
+            primary: None,
+            fallback: MemoryHistory::new(idem_retention),
+            degraded: AtomicBool::new(true),
+            label,
+        }
+    }
+
+    fn is_degraded(&self) -> bool {
+        self.primary.is_none() || self.degraded.load(Ordering::Acquire)
+    }
+
+    /// Record a primary-backend failure and flip to degraded (log + metric once).
+    fn trip(&self, err: &HistoryError) {
+        if !self.degraded.swap(true, Ordering::AcqRel) {
+            tracing::error!(
+                backend = self.label,
+                error = %err,
+                "run-history backend failed; falling back to in-memory store (DEGRADED — \
+                 persisted run records are no longer served; /readyz now reports 503)"
+            );
+            crate::serve::metrics::set_history_degraded(true);
+        }
+    }
+}
+
+/// Run `$call` against the primary backend; on the first error, trip into
+/// degraded mode and re-run it against the in-memory fallback. Once degraded,
+/// skip the primary entirely.
+macro_rules! via {
+    ($self:ident, $primary:ident => $pcall:expr, $fb:ident => $fcall:expr) => {{
+        if !$self.is_degraded()
+            && let Some($primary) = $self.primary.as_ref()
+        {
+            match $pcall.await {
+                Ok(v) => return Ok(v),
+                Err(e) => $self.trip(&e),
+            }
+        }
+        let $fb = &$self.fallback;
+        $fcall.await
+    }};
+}
+
+#[async_trait]
+impl RunHistory for FallbackHistory {
+    async fn claim_idempotency(
+        &self,
+        key: &str,
+        fingerprint: &str,
+        run_id: &str,
+        window: Duration,
+    ) -> Result<Claim, HistoryError> {
+        via!(self,
+            p => p.claim_idempotency(key, fingerprint, run_id, window),
+            f => f.claim_idempotency(key, fingerprint, run_id, window))
+    }
+
+    async fn upsert(&self, rec: &RunRecord) -> Result<(), HistoryError> {
+        via!(self, p => p.upsert(rec), f => f.upsert(rec))
+    }
+
+    async fn get(&self, id: &str) -> Result<Option<RunRecord>, HistoryError> {
+        via!(self, p => p.get(id), f => f.get(id))
+    }
+
+    async fn list(&self, filter: &ListFilter) -> Result<ListPage, HistoryError> {
+        via!(self, p => p.list(filter), f => f.list(filter))
+    }
+
+    async fn delete(&self, id: &str) -> Result<DeleteOutcome, HistoryError> {
+        via!(self, p => p.delete(id), f => f.delete(id))
+    }
+
+    async fn purge_expired(&self, retain_for: Duration) -> Result<usize, HistoryError> {
+        via!(self, p => p.purge_expired(retain_for), f => f.purge_expired(retain_for))
+    }
+
+    async fn recover_orphans(&self) -> Result<usize, HistoryError> {
+        via!(self, p => p.recover_orphans(), f => f.recover_orphans())
+    }
+
+    fn degraded(&self) -> bool {
+        self.is_degraded()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::serve::history::RunStatus;
+
+    /// A primary backend whose every call fails — drives the degrade path.
+    struct AlwaysFail;
+
+    #[async_trait]
+    impl RunHistory for AlwaysFail {
+        async fn claim_idempotency(
+            &self,
+            _: &str,
+            _: &str,
+            _: &str,
+            _: Duration,
+        ) -> Result<Claim, HistoryError> {
+            Err(HistoryError::Backend("down".into()))
+        }
+        async fn upsert(&self, _: &RunRecord) -> Result<(), HistoryError> {
+            Err(HistoryError::Backend("down".into()))
+        }
+        async fn get(&self, _: &str) -> Result<Option<RunRecord>, HistoryError> {
+            Err(HistoryError::Backend("down".into()))
+        }
+        async fn list(&self, _: &ListFilter) -> Result<ListPage, HistoryError> {
+            Err(HistoryError::Backend("down".into()))
+        }
+        async fn delete(&self, _: &str) -> Result<DeleteOutcome, HistoryError> {
+            Err(HistoryError::Backend("down".into()))
+        }
+        async fn purge_expired(&self, _: Duration) -> Result<usize, HistoryError> {
+            Err(HistoryError::Backend("down".into()))
+        }
+        async fn recover_orphans(&self) -> Result<usize, HistoryError> {
+            Err(HistoryError::Backend("down".into()))
+        }
+        fn degraded(&self) -> bool {
+            false
+        }
+    }
+
+    #[tokio::test]
+    async fn trips_to_fallback_on_primary_error_and_serves_from_memory() {
+        let fb = FallbackHistory::healthy(Box::new(AlwaysFail), Duration::from_secs(60), "test");
+        assert!(!fb.degraded(), "starts healthy");
+
+        // First write fails on the primary, trips degraded, lands in memory.
+        let rec = RunRecord::queued(
+            "r1".into(),
+            None,
+            Default::default(),
+            None,
+            chrono::Utc::now(),
+        );
+        fb.upsert(&rec).await.unwrap();
+        assert!(fb.degraded(), "primary error must flip degraded");
+
+        // Subsequent reads are served from the in-memory fallback.
+        let got = fb.get("r1").await.unwrap();
+        assert_eq!(got.unwrap().run_id, "r1");
+    }
+
+    #[tokio::test]
+    async fn degraded_at_startup_uses_memory_only() {
+        let fb = FallbackHistory::degraded_at_startup(Duration::from_secs(60), "test");
+        assert!(fb.degraded());
+        let mut rec = RunRecord::queued(
+            "r2".into(),
+            None,
+            Default::default(),
+            None,
+            chrono::Utc::now(),
+        );
+        rec.status = RunStatus::Completed;
+        rec.finished_at = Some(chrono::Utc::now());
+        fb.upsert(&rec).await.unwrap();
+        assert_eq!(
+            fb.get("r2").await.unwrap().unwrap().status,
+            RunStatus::Completed
+        );
+        assert_eq!(fb.delete("r2").await.unwrap(), DeleteOutcome::Deleted);
+    }
+}

--- a/cli/src/serve/history/mod.rs
+++ b/cli/src/serve/history/mod.rs
@@ -1,14 +1,27 @@
-//! Run-history storage. The trait is defined in full now (Phase 2/3 ships only
-//! the in-memory backend in `memory.rs`); Phase 5 adds Postgres/SQLite as new
-//! impls with no trait change. See spec §11 + §20.
+//! Run-history storage. The trait is defined in full now; the in-memory backend
+//! lives in `memory.rs`, and the feature-gated SQL backends (`postgres.rs` /
+//! `sqlite.rs`, sharing `sql.rs`) wrap themselves in `fallback.rs` so an
+//! unreachable backend degrades to in-memory rather than refusing to start.
+//! See spec §11 + §20.
 
+#[cfg(any(feature = "serve-history-postgres", feature = "serve-history-sqlite"))]
+pub mod fallback;
 pub mod memory;
+#[cfg(feature = "serve-history-postgres")]
+pub mod postgres;
+#[cfg(any(feature = "serve-history-postgres", feature = "serve-history-sqlite"))]
+pub mod sql;
+#[cfg(feature = "serve-history-sqlite")]
+pub mod sqlite;
 
+use crate::error::CliResult;
 use crate::executor::InvocationOutcome;
+use crate::serve::config::HistoryBackendSpec;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
+use std::sync::Arc;
 use std::time::Duration;
 
 /// Lifecycle state of a submitted run.
@@ -181,6 +194,83 @@ pub trait RunHistory: Send + Sync {
     /// True when the backend is in fallback mode (drives `/readyz`). Always false
     /// for memory.
     fn degraded(&self) -> bool;
+}
+
+/// Build the configured run-history backend. `Memory` is always available; the
+/// SQL backends require their respective `serve-history-*` build features (a
+/// clear error otherwise). A SQL backend that fails to connect at startup
+/// degrades to in-memory (via `FallbackHistory`) rather than aborting boot.
+pub async fn connect(
+    spec: &HistoryBackendSpec,
+    idem_retention: Duration,
+) -> CliResult<Arc<dyn RunHistory>> {
+    match spec {
+        HistoryBackendSpec::Memory => {
+            Ok(Arc::new(memory::MemoryHistory::new(idem_retention)) as Arc<dyn RunHistory>)
+        }
+        HistoryBackendSpec::Postgres(url) => connect_postgres(url, idem_retention).await,
+        HistoryBackendSpec::Sqlite(url) => connect_sqlite(url, idem_retention).await,
+    }
+}
+
+#[cfg(feature = "serve-history-postgres")]
+async fn connect_postgres(url: &str, idem: Duration) -> CliResult<Arc<dyn RunHistory>> {
+    Ok(into_history(
+        postgres::PostgresHistory::connect(url, idem).await,
+        idem,
+        "postgres",
+    ))
+}
+
+#[cfg(not(feature = "serve-history-postgres"))]
+async fn connect_postgres(_url: &str, _idem: Duration) -> CliResult<Arc<dyn RunHistory>> {
+    Err(crate::error::CliError::Serve(
+        "persistent Postgres run history requires building faucet with the \
+         `serve-history-postgres` feature"
+            .into(),
+    ))
+}
+
+#[cfg(feature = "serve-history-sqlite")]
+async fn connect_sqlite(url: &str, idem: Duration) -> CliResult<Arc<dyn RunHistory>> {
+    Ok(into_history(
+        sqlite::SqliteHistory::connect(url, idem).await,
+        idem,
+        "sqlite",
+    ))
+}
+
+#[cfg(not(feature = "serve-history-sqlite"))]
+async fn connect_sqlite(_url: &str, _idem: Duration) -> CliResult<Arc<dyn RunHistory>> {
+    Err(crate::error::CliError::Serve(
+        "persistent SQLite run history requires building faucet with the \
+         `serve-history-sqlite` feature"
+            .into(),
+    ))
+}
+
+/// Wrap a SQL backend in `FallbackHistory`: healthy on success; degraded-on-
+/// in-memory (server stays up, `/readyz` reports 503) on a connect failure.
+#[cfg(any(feature = "serve-history-postgres", feature = "serve-history-sqlite"))]
+fn into_history<H: RunHistory + 'static>(
+    result: Result<H, HistoryError>,
+    idem: Duration,
+    label: &'static str,
+) -> Arc<dyn RunHistory> {
+    match result {
+        Ok(backend) => Arc::new(fallback::FallbackHistory::healthy(
+            Box::new(backend),
+            idem,
+            label,
+        )),
+        Err(e) => {
+            tracing::error!(
+                backend = label, error = %e,
+                "run-history backend unavailable at startup; starting DEGRADED on in-memory store"
+            );
+            Arc::new(fallback::FallbackHistory::degraded_at_startup(idem, label))
+        }
+    }
 }
 
 #[cfg(test)]

--- a/cli/src/serve/history/postgres.rs
+++ b/cli/src/serve/history/postgres.rs
@@ -1,0 +1,32 @@
+//! Postgres-backed run history (`serve-history-postgres`, Phase 5 of #127).
+//! Connection setup only — the schema, statements, and `RunHistory` impl are
+//! shared with SQLite via [`impl_sql_history!`](super::sql).
+
+use super::HistoryError;
+use super::sql::{DDL, Dialect, Stmts, impl_sql_history};
+use sqlx::postgres::PgPoolOptions;
+use std::time::Duration;
+
+impl_sql_history!(PostgresHistory, sqlx::PgPool);
+
+impl PostgresHistory {
+    /// Connect, create the schema if absent, and return the backend.
+    pub async fn connect(url: &str, idem_retention: Duration) -> Result<Self, HistoryError> {
+        let pool = PgPoolOptions::new()
+            .max_connections(5)
+            .connect(url)
+            .await
+            .map_err(|e| HistoryError::Backend(format!("Postgres connection failed: {e}")))?;
+        for stmt in DDL {
+            sqlx::query(stmt)
+                .execute(&pool)
+                .await
+                .map_err(|e| HistoryError::Backend(format!("creating run-history schema: {e}")))?;
+        }
+        Ok(Self::from_parts(
+            pool,
+            idem_retention,
+            Stmts::new(Dialect::Postgres),
+        ))
+    }
+}

--- a/cli/src/serve/history/sql.rs
+++ b/cli/src/serve/history/sql.rs
@@ -2,7 +2,7 @@
 //! (Phase 5, #127). Both backends are identical except for the connection setup
 //! and the placeholder dialect (`$n` vs `?`), so the schema, prepared-statement
 //! text, pure helpers, and the entire `RunHistory` impl live here once and are
-//! instantiated for each concrete `sqlx` pool via [`impl_sql_history!`].
+//! instantiated for each concrete `sqlx` pool via the `impl_sql_history!` macro.
 //!
 //! **Portability:** every column is `TEXT` (timestamps are stored as fixed-width
 //! RFC3339 with nanosecond precision + `Z`, which sorts lexicographically in

--- a/cli/src/serve/history/sql.rs
+++ b/cli/src/serve/history/sql.rs
@@ -1,0 +1,606 @@
+//! Shared SQL run-history machinery for the Postgres and SQLite backends
+//! (Phase 5, #127). Both backends are identical except for the connection setup
+//! and the placeholder dialect (`$n` vs `?`), so the schema, prepared-statement
+//! text, pure helpers, and the entire `RunHistory` impl live here once and are
+//! instantiated for each concrete `sqlx` pool via [`impl_sql_history!`].
+//!
+//! **Portability:** every column is `TEXT` (timestamps are stored as fixed-width
+//! RFC3339 with nanosecond precision + `Z`, which sorts lexicographically in
+//! chronological order, so keyset pagination and expiry comparisons work without
+//! any database date type — and thus without the `sqlx` `chrono` feature). The
+//! whole `RunRecord` is serialized into the `body` column (the source of truth on
+//! read); the dedicated columns exist only for filtering, ordering, and expiry.
+//!
+//! **Idempotency** lives in a separate `faucet_serve_idem` table whose `key`
+//! primary key is the required unique index (spec §10/§11). The claim is atomic
+//! via `INSERT … ON CONFLICT DO NOTHING` plus an optimistic, expiry-guarded
+//! takeover `UPDATE`, mirroring the memory backend's shard-locked semantics.
+
+use super::{HistoryError, RunRecord, RunStatus};
+use chrono::{DateTime, Utc};
+use std::time::Duration;
+
+/// DDL run at connect time. Valid verbatim on both Postgres and SQLite (only
+/// `TEXT` columns, `IF NOT EXISTS`, and standard indexes).
+pub const DDL: &[&str] = &[
+    "CREATE TABLE IF NOT EXISTS faucet_serve_runs (\
+        run_id TEXT PRIMARY KEY,\
+        name TEXT,\
+        status TEXT NOT NULL,\
+        submitted_at TEXT NOT NULL,\
+        finished_at TEXT,\
+        idempotency_key TEXT,\
+        body TEXT NOT NULL)",
+    "CREATE INDEX IF NOT EXISTS faucet_serve_runs_submitted_idx \
+        ON faucet_serve_runs (submitted_at)",
+    "CREATE TABLE IF NOT EXISTS faucet_serve_idem (\
+        key TEXT PRIMARY KEY,\
+        run_id TEXT NOT NULL,\
+        fingerprint TEXT NOT NULL,\
+        claimed_at TEXT NOT NULL)",
+];
+
+/// SQL placeholder dialect.
+#[derive(Clone, Copy, Debug)]
+pub enum Dialect {
+    Postgres,
+    Sqlite,
+}
+
+/// Prepared-statement text for a backend, built once per dialect at connect time.
+pub struct Stmts {
+    pub upsert: String,
+    pub select_body: String,
+    pub select_status: String,
+    pub select_submitted: String,
+    pub delete: String,
+    pub list: String,
+    pub purge_runs: String,
+    pub purge_idem: String,
+    pub select_orphans: String,
+    pub insert_idem: String,
+    pub select_idem: String,
+    pub takeover_idem: String,
+}
+
+impl Stmts {
+    pub fn new(dialect: Dialect) -> Self {
+        match dialect {
+            Dialect::Postgres => Self::postgres(),
+            Dialect::Sqlite => Self::sqlite(),
+        }
+    }
+
+    fn postgres() -> Self {
+        Self {
+            upsert: "INSERT INTO faucet_serve_runs \
+                (run_id,name,status,submitted_at,finished_at,idempotency_key,body) \
+                VALUES ($1,$2,$3,$4,$5,$6,$7) \
+                ON CONFLICT (run_id) DO UPDATE SET \
+                name=excluded.name,status=excluded.status,submitted_at=excluded.submitted_at,\
+                finished_at=excluded.finished_at,idempotency_key=excluded.idempotency_key,\
+                body=excluded.body"
+                .into(),
+            select_body: "SELECT body FROM faucet_serve_runs WHERE run_id=$1".into(),
+            select_status: "SELECT status FROM faucet_serve_runs WHERE run_id=$1".into(),
+            select_submitted: "SELECT submitted_at FROM faucet_serve_runs WHERE run_id=$1".into(),
+            delete: "DELETE FROM faucet_serve_runs WHERE run_id=$1".into(),
+            // Casts make the parameter types explicit so `$n IS NULL` cannot trip
+            // Postgres' "could not determine data type of parameter" check.
+            list: "SELECT body FROM faucet_serve_runs \
+                WHERE ($1::text IS NULL OR status = $2::text) \
+                AND ($3::text IS NULL OR name = $4::text) \
+                AND ($5::text IS NULL OR submitted_at >= $6::text) \
+                AND ($7::text IS NULL OR submitted_at <= $8::text) \
+                AND ($9::text IS NULL OR (submitted_at < $10::text \
+                    OR (submitted_at = $11::text AND run_id < $12::text))) \
+                ORDER BY submitted_at DESC, run_id DESC LIMIT $13"
+                .into(),
+            purge_runs: "DELETE FROM faucet_serve_runs \
+                WHERE status IN ('completed','failed','cancelled') \
+                AND finished_at IS NOT NULL AND finished_at < $1"
+                .into(),
+            purge_idem: "DELETE FROM faucet_serve_idem WHERE claimed_at < $1".into(),
+            select_orphans: "SELECT body FROM faucet_serve_runs \
+                WHERE status IN ('queued','running')"
+                .into(),
+            insert_idem: "INSERT INTO faucet_serve_idem (key,run_id,fingerprint,claimed_at) \
+                VALUES ($1,$2,$3,$4) ON CONFLICT (key) DO NOTHING"
+                .into(),
+            select_idem: "SELECT run_id,fingerprint,claimed_at FROM faucet_serve_idem WHERE key=$1"
+                .into(),
+            takeover_idem: "UPDATE faucet_serve_idem \
+                SET run_id=$1,fingerprint=$2,claimed_at=$3 WHERE key=$4 AND claimed_at=$5"
+                .into(),
+        }
+    }
+
+    fn sqlite() -> Self {
+        Self {
+            upsert: "INSERT INTO faucet_serve_runs \
+                (run_id,name,status,submitted_at,finished_at,idempotency_key,body) \
+                VALUES (?,?,?,?,?,?,?) \
+                ON CONFLICT (run_id) DO UPDATE SET \
+                name=excluded.name,status=excluded.status,submitted_at=excluded.submitted_at,\
+                finished_at=excluded.finished_at,idempotency_key=excluded.idempotency_key,\
+                body=excluded.body"
+                .into(),
+            select_body: "SELECT body FROM faucet_serve_runs WHERE run_id=?".into(),
+            select_status: "SELECT status FROM faucet_serve_runs WHERE run_id=?".into(),
+            select_submitted: "SELECT submitted_at FROM faucet_serve_runs WHERE run_id=?".into(),
+            delete: "DELETE FROM faucet_serve_runs WHERE run_id=?".into(),
+            list: "SELECT body FROM faucet_serve_runs \
+                WHERE (? IS NULL OR status = ?) \
+                AND (? IS NULL OR name = ?) \
+                AND (? IS NULL OR submitted_at >= ?) \
+                AND (? IS NULL OR submitted_at <= ?) \
+                AND (? IS NULL OR (submitted_at < ? \
+                    OR (submitted_at = ? AND run_id < ?))) \
+                ORDER BY submitted_at DESC, run_id DESC LIMIT ?"
+                .into(),
+            purge_runs: "DELETE FROM faucet_serve_runs \
+                WHERE status IN ('completed','failed','cancelled') \
+                AND finished_at IS NOT NULL AND finished_at < ?"
+                .into(),
+            purge_idem: "DELETE FROM faucet_serve_idem WHERE claimed_at < ?".into(),
+            select_orphans: "SELECT body FROM faucet_serve_runs \
+                WHERE status IN ('queued','running')"
+                .into(),
+            insert_idem: "INSERT INTO faucet_serve_idem (key,run_id,fingerprint,claimed_at) \
+                VALUES (?,?,?,?) ON CONFLICT (key) DO NOTHING"
+                .into(),
+            select_idem: "SELECT run_id,fingerprint,claimed_at FROM faucet_serve_idem WHERE key=?"
+                .into(),
+            takeover_idem: "UPDATE faucet_serve_idem \
+                SET run_id=?,fingerprint=?,claimed_at=? WHERE key=? AND claimed_at=?"
+                .into(),
+        }
+    }
+}
+
+/// Bounded retry count for the atomic idempotency claim (handles a claim being
+/// purged concurrently between the insert attempt and the read-back).
+pub const CLAIM_ATTEMPTS: usize = 4;
+
+/// Fixed-width RFC3339 (nanoseconds + `Z`) — lexicographically sortable.
+pub fn fmt_ts(dt: DateTime<Utc>) -> String {
+    dt.to_rfc3339_opts(chrono::SecondsFormat::Nanos, true)
+}
+
+/// True when a claim timestamped `claimed_at` (RFC3339) is older than `window`.
+/// An unparseable or future timestamp is treated as **not** expired (safe: it
+/// won't be silently re-claimed).
+pub fn is_expired(claimed_at: &str, now: DateTime<Utc>, window: Duration) -> bool {
+    match DateTime::parse_from_rfc3339(claimed_at) {
+        Ok(t) => now
+            .signed_duration_since(t.with_timezone(&Utc))
+            .to_std()
+            .map(|age| age >= window)
+            .unwrap_or(false),
+        Err(_) => false,
+    }
+}
+
+/// RFC3339 timestamp `window` before `now` (the purge / expiry threshold).
+pub fn threshold(now: DateTime<Utc>, window: Duration) -> String {
+    let delta =
+        chrono::Duration::from_std(window).unwrap_or_else(|_| chrono::Duration::days(36_500));
+    fmt_ts(now - delta)
+}
+
+pub fn encode_body(rec: &RunRecord) -> Result<String, HistoryError> {
+    serde_json::to_string(rec).map_err(|e| HistoryError::Backend(format!("encode run record: {e}")))
+}
+
+pub fn decode_body(body: &str) -> Result<RunRecord, HistoryError> {
+    serde_json::from_str(body).map_err(|e| HistoryError::Backend(format!("decode run record: {e}")))
+}
+
+pub fn parse_status(s: &str) -> RunStatus {
+    match s {
+        "queued" => RunStatus::Queued,
+        "running" => RunStatus::Running,
+        "completed" => RunStatus::Completed,
+        "cancelled" => RunStatus::Cancelled,
+        _ => RunStatus::Failed,
+    }
+}
+
+/// Generate a concrete `RunHistory` implementation over a specific `sqlx` pool.
+/// `$name` is the backend struct, `$pool` its `sqlx` pool type. The struct holds
+/// the pool, the idempotency retention window, and the dialect's [`Stmts`].
+macro_rules! impl_sql_history {
+    ($name:ident, $pool:ty) => {
+        /// SQL-backed [`RunHistory`](crate::serve::history::RunHistory). See
+        /// [`crate::serve::history::sql`] for the shared schema + semantics.
+        pub struct $name {
+            pool: $pool,
+            idem_retention: std::time::Duration,
+            stmts: $crate::serve::history::sql::Stmts,
+        }
+
+        impl $name {
+            /// Assemble from an already-connected pool (used by `connect`).
+            pub fn from_parts(
+                pool: $pool,
+                idem_retention: std::time::Duration,
+                stmts: $crate::serve::history::sql::Stmts,
+            ) -> Self {
+                Self {
+                    pool,
+                    idem_retention,
+                    stmts,
+                }
+            }
+
+            /// Borrow the underlying pool (tests close it to exercise fallback).
+            pub fn pool(&self) -> &$pool {
+                &self.pool
+            }
+        }
+
+        #[async_trait::async_trait]
+        impl $crate::serve::history::RunHistory for $name {
+            async fn claim_idempotency(
+                &self,
+                key: &str,
+                fingerprint: &str,
+                run_id: &str,
+                window: std::time::Duration,
+            ) -> Result<$crate::serve::history::Claim, $crate::serve::history::HistoryError> {
+                use sqlx::Row as _;
+                use $crate::serve::history::Claim;
+                use $crate::serve::history::HistoryError;
+                use $crate::serve::history::sql;
+
+                let now = chrono::Utc::now();
+                let now_s = sql::fmt_ts(now);
+                let backend = |e: sqlx::Error| HistoryError::Backend(e.to_string());
+
+                for _ in 0..sql::CLAIM_ATTEMPTS {
+                    // 1) Atomic first-claim: the winner inserts exactly one row.
+                    let inserted = sqlx::query(&self.stmts.insert_idem)
+                        .bind(key)
+                        .bind(run_id)
+                        .bind(fingerprint)
+                        .bind(&now_s)
+                        .execute(&self.pool)
+                        .await
+                        .map_err(backend)?
+                        .rows_affected();
+                    if inserted == 1 {
+                        return Ok(Claim::Fresh);
+                    }
+                    // 2) Conflict: inspect the existing claim.
+                    let Some(row) = sqlx::query(&self.stmts.select_idem)
+                        .bind(key)
+                        .fetch_optional(&self.pool)
+                        .await
+                        .map_err(backend)?
+                    else {
+                        // Vanished between the insert and the read — retry.
+                        continue;
+                    };
+                    let existing_run: String = row.try_get("run_id").map_err(backend)?;
+                    let existing_fp: String = row.try_get("fingerprint").map_err(backend)?;
+                    let claimed_at: String = row.try_get("claimed_at").map_err(backend)?;
+
+                    if sql::is_expired(&claimed_at, now, window) {
+                        // 3) Optimistic, expiry-guarded takeover: only the request
+                        // that still sees `claimed_at` succeeds.
+                        let took = sqlx::query(&self.stmts.takeover_idem)
+                            .bind(run_id)
+                            .bind(fingerprint)
+                            .bind(&now_s)
+                            .bind(key)
+                            .bind(&claimed_at)
+                            .execute(&self.pool)
+                            .await
+                            .map_err(backend)?
+                            .rows_affected();
+                        if took == 1 {
+                            return Ok(Claim::Fresh);
+                        }
+                        continue; // lost the race; re-evaluate
+                    }
+                    return Ok(if existing_fp == fingerprint {
+                        Claim::Replay(existing_run)
+                    } else {
+                        Claim::Conflict
+                    });
+                }
+                // Pathological contention only. Conservative: a 409 is safer than
+                // risking a duplicate run.
+                tracing::warn!(
+                    key,
+                    "idempotency claim exhausted retries; reporting conflict"
+                );
+                Ok(Claim::Conflict)
+            }
+
+            async fn upsert(
+                &self,
+                rec: &$crate::serve::history::RunRecord,
+            ) -> Result<(), $crate::serve::history::HistoryError> {
+                use $crate::serve::history::HistoryError;
+                use $crate::serve::history::sql;
+                let body = sql::encode_body(rec)?;
+                let submitted = sql::fmt_ts(rec.submitted_at);
+                let finished = rec.finished_at.map(sql::fmt_ts);
+                sqlx::query(&self.stmts.upsert)
+                    .bind(&rec.run_id)
+                    .bind(rec.name.as_deref())
+                    .bind(rec.status.as_str())
+                    .bind(&submitted)
+                    .bind(finished.as_deref())
+                    .bind(rec.idempotency_key.as_deref())
+                    .bind(&body)
+                    .execute(&self.pool)
+                    .await
+                    .map_err(|e| HistoryError::Backend(e.to_string()))?;
+                Ok(())
+            }
+
+            async fn get(
+                &self,
+                id: &str,
+            ) -> Result<
+                Option<$crate::serve::history::RunRecord>,
+                $crate::serve::history::HistoryError,
+            > {
+                use sqlx::Row as _;
+                use $crate::serve::history::HistoryError;
+                use $crate::serve::history::sql;
+                let row = sqlx::query(&self.stmts.select_body)
+                    .bind(id)
+                    .fetch_optional(&self.pool)
+                    .await
+                    .map_err(|e| HistoryError::Backend(e.to_string()))?;
+                match row {
+                    None => Ok(None),
+                    Some(r) => {
+                        let body: String = r
+                            .try_get("body")
+                            .map_err(|e| HistoryError::Backend(e.to_string()))?;
+                        Ok(Some(sql::decode_body(&body)?))
+                    }
+                }
+            }
+
+            async fn list(
+                &self,
+                filter: &$crate::serve::history::ListFilter,
+            ) -> Result<$crate::serve::history::ListPage, $crate::serve::history::HistoryError>
+            {
+                use sqlx::Row as _;
+                use $crate::serve::history::HistoryError;
+                use $crate::serve::history::ListPage;
+                use $crate::serve::history::sql;
+                let backend = |e: sqlx::Error| HistoryError::Backend(e.to_string());
+
+                // Resolve the cursor's submitted_at for keyset pagination. An
+                // unknown cursor is ignored (page starts from the top), matching
+                // the memory backend.
+                let cursor_ts: Option<String> = match &filter.cursor {
+                    None => None,
+                    Some(c) => sqlx::query(&self.stmts.select_submitted)
+                        .bind(c)
+                        .fetch_optional(&self.pool)
+                        .await
+                        .map_err(backend)?
+                        .map(|r| r.try_get::<String, _>("submitted_at"))
+                        .transpose()
+                        .map_err(backend)?,
+                };
+                let cur_id = if cursor_ts.is_some() {
+                    filter.cursor.as_deref()
+                } else {
+                    None
+                };
+
+                let status_s = filter.status.map(|s| s.as_str());
+                let name_s = filter.name.as_deref();
+                let since_s = filter.since.map(sql::fmt_ts);
+                let until_s = filter.until.map(sql::fmt_ts);
+                let limit = filter.limit.max(1);
+                let fetch_n = limit as i64 + 1; // +1 to detect a next page
+
+                let rows = sqlx::query(&self.stmts.list)
+                    .bind(status_s)
+                    .bind(status_s)
+                    .bind(name_s)
+                    .bind(name_s)
+                    .bind(since_s.as_deref())
+                    .bind(since_s.as_deref())
+                    .bind(until_s.as_deref())
+                    .bind(until_s.as_deref())
+                    .bind(cursor_ts.as_deref())
+                    .bind(cursor_ts.as_deref())
+                    .bind(cursor_ts.as_deref())
+                    .bind(cur_id)
+                    .bind(fetch_n)
+                    .fetch_all(&self.pool)
+                    .await
+                    .map_err(backend)?;
+
+                let mut runs = Vec::with_capacity(rows.len());
+                for r in &rows {
+                    let body: String = r.try_get("body").map_err(backend)?;
+                    runs.push(sql::decode_body(&body)?);
+                }
+                let next_cursor = if runs.len() > limit {
+                    Some(runs[limit - 1].run_id.clone())
+                } else {
+                    None
+                };
+                runs.truncate(limit);
+                Ok(ListPage { runs, next_cursor })
+            }
+
+            async fn delete(
+                &self,
+                id: &str,
+            ) -> Result<$crate::serve::history::DeleteOutcome, $crate::serve::history::HistoryError>
+            {
+                use sqlx::Row as _;
+                use $crate::serve::history::DeleteOutcome;
+                use $crate::serve::history::HistoryError;
+                use $crate::serve::history::sql;
+                let backend = |e: sqlx::Error| HistoryError::Backend(e.to_string());
+                let status: Option<String> = sqlx::query(&self.stmts.select_status)
+                    .bind(id)
+                    .fetch_optional(&self.pool)
+                    .await
+                    .map_err(backend)?
+                    .map(|r| r.try_get::<String, _>("status"))
+                    .transpose()
+                    .map_err(backend)?;
+                match status {
+                    None => Ok(DeleteOutcome::NotFound),
+                    Some(s) if !sql::parse_status(&s).is_terminal() => {
+                        Ok(DeleteOutcome::StillRunning)
+                    }
+                    Some(_) => {
+                        sqlx::query(&self.stmts.delete)
+                            .bind(id)
+                            .execute(&self.pool)
+                            .await
+                            .map_err(backend)?;
+                        Ok(DeleteOutcome::Deleted)
+                    }
+                }
+            }
+
+            async fn purge_expired(
+                &self,
+                retain_for: std::time::Duration,
+            ) -> Result<usize, $crate::serve::history::HistoryError> {
+                use $crate::serve::history::HistoryError;
+                use $crate::serve::history::sql;
+                let backend = |e: sqlx::Error| HistoryError::Backend(e.to_string());
+                let now = chrono::Utc::now();
+                let removed = sqlx::query(&self.stmts.purge_runs)
+                    .bind(sql::threshold(now, retain_for))
+                    .execute(&self.pool)
+                    .await
+                    .map_err(backend)?
+                    .rows_affected() as usize;
+                // Drop expired idempotency claims too (best-effort).
+                let _ = sqlx::query(&self.stmts.purge_idem)
+                    .bind(sql::threshold(now, self.idem_retention))
+                    .execute(&self.pool)
+                    .await;
+                Ok(removed)
+            }
+
+            async fn recover_orphans(&self) -> Result<usize, $crate::serve::history::HistoryError> {
+                use sqlx::Row as _;
+                use $crate::serve::history::HistoryError;
+                use $crate::serve::history::RunStatus;
+                use $crate::serve::history::sql;
+                let backend = |e: sqlx::Error| HistoryError::Backend(e.to_string());
+                let rows = sqlx::query(&self.stmts.select_orphans)
+                    .fetch_all(&self.pool)
+                    .await
+                    .map_err(backend)?;
+                let now = chrono::Utc::now();
+                let mut count = 0usize;
+                for r in &rows {
+                    let body: String = r.try_get("body").map_err(backend)?;
+                    let mut rec = sql::decode_body(&body)?;
+                    rec.status = RunStatus::Failed;
+                    rec.finished_at = Some(now);
+                    rec.error = Some("server restarted before the run finished".into());
+                    if rec.elapsed_secs.is_none()
+                        && let Some(started) = rec.started_at
+                    {
+                        rec.elapsed_secs = (now - started).to_std().ok().map(|d| d.as_secs_f64());
+                    }
+                    self.upsert(&rec).await?;
+                    count += 1;
+                }
+                Ok(count)
+            }
+
+            fn degraded(&self) -> bool {
+                // A live SQL backend is never self-degraded; the FallbackHistory
+                // wrapper owns degradation when the backend becomes unreachable.
+                false
+            }
+        }
+    };
+}
+
+pub(crate) use impl_sql_history;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fmt_ts_is_fixed_width_and_sortable() {
+        let a = fmt_ts(
+            DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+                .unwrap()
+                .to_utc(),
+        );
+        let b = fmt_ts(
+            DateTime::parse_from_rfc3339("2026-01-01T00:00:01Z")
+                .unwrap()
+                .to_utc(),
+        );
+        assert!(a.ends_with('Z'));
+        assert_eq!(a.len(), b.len(), "fixed width");
+        assert!(a < b, "lexicographic order matches chronological order");
+    }
+
+    #[test]
+    fn is_expired_respects_window() {
+        let now = Utc::now();
+        let old = fmt_ts(now - chrono::Duration::seconds(120));
+        assert!(is_expired(&old, now, Duration::from_secs(60)));
+        assert!(!is_expired(&old, now, Duration::from_secs(600)));
+        // Unparseable → not expired (conservative).
+        assert!(!is_expired("not-a-timestamp", now, Duration::ZERO));
+    }
+
+    #[test]
+    fn parse_status_round_trips_known_and_defaults_failed() {
+        for s in [
+            RunStatus::Queued,
+            RunStatus::Running,
+            RunStatus::Completed,
+            RunStatus::Failed,
+            RunStatus::Cancelled,
+        ] {
+            assert_eq!(parse_status(s.as_str()), s);
+        }
+        assert_eq!(parse_status("garbage"), RunStatus::Failed);
+    }
+
+    #[test]
+    fn body_round_trips() {
+        let rec = RunRecord::queued(
+            "r1".into(),
+            Some("n".into()),
+            Default::default(),
+            Some("idem".into()),
+            Utc::now(),
+        );
+        let encoded = encode_body(&rec).unwrap();
+        let decoded = decode_body(&encoded).unwrap();
+        assert_eq!(decoded.run_id, "r1");
+        assert_eq!(decoded.idempotency_key.as_deref(), Some("idem"));
+    }
+
+    #[test]
+    fn postgres_and_sqlite_statements_differ_only_in_placeholders() {
+        let pg = Stmts::new(Dialect::Postgres);
+        let lite = Stmts::new(Dialect::Sqlite);
+        assert!(pg.upsert.contains("$1") && lite.upsert.contains('?'));
+        assert!(pg.list.contains("$13") && lite.list.contains('?'));
+        // Both target the same tables / conflict targets.
+        assert!(pg.insert_idem.contains("ON CONFLICT (key) DO NOTHING"));
+        assert!(lite.insert_idem.contains("ON CONFLICT (key) DO NOTHING"));
+    }
+}

--- a/cli/src/serve/history/sqlite.rs
+++ b/cli/src/serve/history/sqlite.rs
@@ -1,0 +1,40 @@
+//! SQLite-backed run history (`serve-history-sqlite`, Phase 5 of #127).
+//! Connection setup only — the schema, statements, and `RunHistory` impl are
+//! shared with Postgres via [`impl_sql_history!`](super::sql).
+
+use super::HistoryError;
+use super::sql::{DDL, Dialect, Stmts, impl_sql_history};
+use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions};
+use std::str::FromStr;
+use std::time::Duration;
+
+impl_sql_history!(SqliteHistory, sqlx::SqlitePool);
+
+impl SqliteHistory {
+    /// Connect (creating the database file if missing), create the schema if
+    /// absent, and return the backend. WAL + a busy timeout let the connection
+    /// pool tolerate concurrent run writes.
+    pub async fn connect(url: &str, idem_retention: Duration) -> Result<Self, HistoryError> {
+        let opts = SqliteConnectOptions::from_str(url)
+            .map_err(|e| HistoryError::Backend(format!("invalid sqlite url '{url}': {e}")))?
+            .create_if_missing(true)
+            .journal_mode(SqliteJournalMode::Wal)
+            .busy_timeout(Duration::from_secs(5));
+        let pool = SqlitePoolOptions::new()
+            .max_connections(5)
+            .connect_with(opts)
+            .await
+            .map_err(|e| HistoryError::Backend(format!("SQLite connection failed: {e}")))?;
+        for stmt in DDL {
+            sqlx::query(stmt)
+                .execute(&pool)
+                .await
+                .map_err(|e| HistoryError::Backend(format!("creating run-history schema: {e}")))?;
+        }
+        Ok(Self::from_parts(
+            pool,
+            idem_retention,
+            Stmts::new(Dialect::Sqlite),
+        ))
+    }
+}

--- a/cli/src/serve/logs.rs
+++ b/cli/src/serve/logs.rs
@@ -1,0 +1,467 @@
+//! Per-run log capture for SSE streaming (`GET /v1/runs/{id}/logs`, spec §12).
+//!
+//! [`RunLogLayer`] is a `tracing` `Layer` added to serve's global subscriber. It
+//! tags every span that carries a `serve_run_id` field (the
+//! `faucet.serve.run` span each run executes inside — see `runner.rs`) and, for
+//! every event in such a span's scope, formats a redacted line and pushes it into
+//! that run's [`RunBuffer`]: a bounded ring (for backfill) plus a `broadcast`
+//! channel (for the live tail). The `/logs` handler replays the ring, then
+//! streams the live tail via [`log_events`].
+//!
+//! **Ephemeral lifecycle.** Buffers live while a run is active plus a short drain
+//! window ([`LOG_DRAIN`]) for late fetchers, then are dropped regardless of
+//! `--retain-terminal-runs-secs` — only `RunRecord` metadata honours that
+//! retention. Bulk/historic logs belong in the centralized tracing sink.
+
+use dashmap::DashMap;
+use std::collections::VecDeque;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::Duration;
+use tokio::sync::broadcast;
+
+/// Per-run ring-buffer capacity (lines). Past this the oldest line is evicted and
+/// late `/logs` subscribers see a `truncated` event.
+pub const RING_CAPACITY: usize = 10_000;
+
+/// Live-tail broadcast channel depth. A `/logs` reader that falls this far behind
+/// gets a `truncated` event rather than blocking producers.
+pub const BROADCAST_CAPACITY: usize = 1024;
+
+/// How long a run's log buffer survives after the run reaches a terminal state,
+/// so a late `/logs` fetcher can still replay it. Independent of run-record
+/// retention (spec §12).
+pub const LOG_DRAIN: Duration = Duration::from_secs(60);
+
+/// A single captured log line, tagged with a monotonic sequence number so a late
+/// `/logs` subscriber can de-duplicate ring backfill against the live tail.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LogLine {
+    pub seq: u64,
+    pub line: String,
+}
+
+/// A message on a run's live-tail broadcast channel.
+#[derive(Clone, Debug)]
+pub enum LogMsg {
+    /// A newly captured log line.
+    Line(LogLine),
+    /// The run reached a terminal state; no further lines will arrive.
+    End,
+}
+
+/// One run's bounded log buffer: a ring for backfill + a broadcast for live tail.
+struct RunBuffer {
+    ring: Mutex<VecDeque<LogLine>>,
+    seq: AtomicU64,
+    tx: broadcast::Sender<LogMsg>,
+    ended: AtomicBool,
+}
+
+impl RunBuffer {
+    fn new() -> Self {
+        let (tx, _rx) = broadcast::channel(BROADCAST_CAPACITY);
+        Self {
+            ring: Mutex::new(VecDeque::with_capacity(64)),
+            seq: AtomicU64::new(0),
+            tx,
+            ended: AtomicBool::new(false),
+        }
+    }
+
+    /// Append a line: assign a sequence, push to the ring (evicting the oldest
+    /// past the cap), and best-effort broadcast to live subscribers.
+    fn push(&self, line: String) {
+        let seq = self.seq.fetch_add(1, Ordering::Relaxed);
+        let entry = LogLine { seq, line };
+        {
+            let mut ring = self.ring.lock().expect("log ring poisoned");
+            if ring.len() == RING_CAPACITY {
+                ring.pop_front();
+            }
+            ring.push_back(entry.clone());
+        }
+        // No live subscribers → Err; the ring still holds the line for backfill.
+        let _ = self.tx.send(LogMsg::Line(entry));
+    }
+
+    fn snapshot(&self) -> Vec<LogLine> {
+        self.ring
+            .lock()
+            .expect("log ring poisoned")
+            .iter()
+            .cloned()
+            .collect()
+    }
+
+    /// Mark the run terminal and notify live subscribers. `ended` is stored
+    /// **before** the broadcast so a reader that misses the `End` message always
+    /// observes `is_ended() == true` (see [`LogHub::reader`]).
+    fn finish(&self) {
+        self.ended.store(true, Ordering::SeqCst);
+        let _ = self.tx.send(LogMsg::End);
+    }
+}
+
+/// Shared, cheaply-cloneable registry of per-run log buffers. One instance is
+/// created at subscriber install and shared between [`RunLogLayer`] and the
+/// `/logs` handler via `ServerState`.
+#[derive(Clone, Default)]
+pub struct LogHub {
+    inner: Arc<DashMap<String, Arc<RunBuffer>>>,
+}
+
+impl LogHub {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Get-or-create the buffer for a run (lazily, on first captured event).
+    fn buffer(&self, run_id: &str) -> Arc<RunBuffer> {
+        if let Some(b) = self.inner.get(run_id) {
+            return Arc::clone(b.value());
+        }
+        Arc::clone(
+            self.inner
+                .entry(run_id.to_string())
+                .or_insert_with(|| Arc::new(RunBuffer::new()))
+                .value(),
+        )
+    }
+
+    /// Append a captured line for a run (called by [`RunLogLayer::on_event`]).
+    pub fn append(&self, run_id: &str, line: String) {
+        self.buffer(run_id).push(line);
+    }
+
+    /// Open a `/logs` reader: returns the ring snapshot, a live-tail receiver, and
+    /// whether the run has already ended. `None` means no buffer exists for the
+    /// run (never logged, or already dropped after the drain window).
+    ///
+    /// Subscribe-then-snapshot-then-load-`ended` ordering is deliberate: a reader
+    /// that misses the `End` broadcast still observes `ended == true`, so the
+    /// stream can close without hanging. Backfill/live duplicates are removed by
+    /// sequence number in [`log_events`].
+    pub fn reader(
+        &self,
+        run_id: &str,
+    ) -> Option<(Vec<LogLine>, broadcast::Receiver<LogMsg>, bool)> {
+        let buf = Arc::clone(self.inner.get(run_id)?.value());
+        let rx = buf.tx.subscribe();
+        let snapshot = buf.snapshot();
+        let ended = buf.ended.load(Ordering::SeqCst);
+        Some((snapshot, rx, ended))
+    }
+
+    /// Mark a run terminal: broadcast `End` so live readers can close.
+    pub fn finish(&self, run_id: &str) {
+        if let Some(buf) = self.inner.get(run_id) {
+            buf.finish();
+        }
+    }
+
+    /// Drop a run's buffer, freeing its ring (called after the drain window).
+    pub fn drop_run(&self, run_id: &str) {
+        self.inner.remove(run_id);
+    }
+}
+
+/// An SSE-bound log event, decoupled from `axum`'s `Event` so the streaming logic
+/// (ring replay → live tail, de-dup, lag handling) is unit-testable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LogEvent {
+    /// A log line.
+    Log(String),
+    /// `n` live-tail lines were dropped because the reader fell behind.
+    Truncated(u64),
+    /// Terminal: the run finished and the stream should close.
+    End,
+}
+
+/// Build the ordered event stream for a `/logs` request: replay the ring
+/// snapshot, then forward the live tail, de-duplicating against the snapshot by
+/// sequence number and mapping `broadcast` lag to [`LogEvent::Truncated`].
+pub fn log_events(
+    snapshot: Vec<LogLine>,
+    mut rx: broadcast::Receiver<LogMsg>,
+    ended: bool,
+) -> impl futures::Stream<Item = LogEvent> {
+    use tokio::sync::broadcast::error::RecvError;
+    async_stream::stream! {
+        let mut last_seq: Option<u64> = None;
+        for entry in snapshot {
+            last_seq = Some(entry.seq);
+            yield LogEvent::Log(entry.line);
+        }
+        // The run already ended before we subscribed: the ring is the whole story.
+        if ended {
+            yield LogEvent::End;
+            return;
+        }
+        loop {
+            match rx.recv().await {
+                Ok(LogMsg::Line(entry)) => {
+                    if last_seq.is_none_or(|s| entry.seq > s) {
+                        last_seq = Some(entry.seq);
+                        yield LogEvent::Log(entry.line);
+                    }
+                }
+                Ok(LogMsg::End) => {
+                    yield LogEvent::End;
+                    break;
+                }
+                Err(RecvError::Lagged(n)) => {
+                    yield LogEvent::Truncated(n);
+                }
+                Err(RecvError::Closed) => {
+                    yield LogEvent::End;
+                    break;
+                }
+            }
+        }
+    }
+}
+
+// ── tracing layer ───────────────────────────────────────────────────────────
+
+use tracing::field::{Field, Visit};
+use tracing::span::{Attributes, Id};
+use tracing::{Event, Subscriber};
+use tracing_subscriber::layer::{Context, Layer};
+use tracing_subscriber::registry::LookupSpan;
+
+/// Span extension marking a span (and, via scope walking, its descendants) as
+/// belonging to a serve run.
+#[derive(Clone)]
+struct RunIdExt(String);
+
+/// Extracts a `serve_run_id` field value from span attributes.
+#[derive(Default)]
+struct RunIdVisitor(Option<String>);
+
+impl Visit for RunIdVisitor {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == "serve_run_id" {
+            self.0 = Some(value.to_string());
+        }
+    }
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        // `%run_id` records via Display → Debug-of-DisplayValue, i.e. unquoted.
+        if field.name() == "serve_run_id" && self.0.is_none() {
+            self.0 = Some(format!("{value:?}"));
+        }
+    }
+}
+
+/// Formats an event's fields into a single log line: the `message` field, then
+/// any remaining `key=value` fields.
+#[derive(Default)]
+struct EventLineVisitor {
+    message: String,
+    fields: String,
+}
+
+impl Visit for EventLineVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        use std::fmt::Write;
+        if field.name() == "message" {
+            let _ = write!(self.message, "{value:?}");
+        } else {
+            let _ = write!(self.fields, " {}={:?}", field.name(), value);
+        }
+    }
+}
+
+impl EventLineVisitor {
+    fn finish(self) -> String {
+        if self.fields.is_empty() {
+            self.message
+        } else {
+            format!("{}{}", self.message, self.fields)
+        }
+    }
+}
+
+/// Tracing layer that captures events tagged with a `serve_run_id` into the
+/// [`LogHub`] for SSE streaming. Added to serve's global subscriber alongside the
+/// redacting fmt layer (`observability.rs`).
+pub struct RunLogLayer {
+    hub: LogHub,
+}
+
+impl RunLogLayer {
+    pub fn new(hub: LogHub) -> Self {
+        Self { hub }
+    }
+}
+
+impl<S> Layer<S> for RunLogLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+        let mut visitor = RunIdVisitor::default();
+        attrs.record(&mut visitor);
+        if let Some(run_id) = visitor.0
+            && let Some(span) = ctx.span(id)
+        {
+            span.extensions_mut().insert(RunIdExt(run_id));
+        }
+    }
+
+    fn on_event(&self, event: &Event<'_>, ctx: Context<'_, S>) {
+        let Some(run_id) = ctx.event_scope(event).and_then(|scope| {
+            scope
+                .from_root()
+                .find_map(|span| span.extensions().get::<RunIdExt>().map(|ext| ext.0.clone()))
+        }) else {
+            return;
+        };
+        let mut visitor = EventLineVisitor::default();
+        event.record(&mut visitor);
+        let meta = event.metadata();
+        let line = format!("{} {}: {}", meta.level(), meta.target(), visitor.finish());
+        let line = crate::secrets::registry::redact(&line).into_owned();
+        self.hub.append(&run_id, line);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::StreamExt;
+
+    #[test]
+    fn ring_caps_and_orders_by_seq() {
+        let hub = LogHub::new();
+        for i in 0..(RING_CAPACITY + 5) {
+            hub.append("r", format!("line-{i}"));
+        }
+        let (snapshot, _rx, _ended) = hub.reader("r").unwrap();
+        assert_eq!(snapshot.len(), RING_CAPACITY, "ring must cap at capacity");
+        // The five oldest lines were evicted; line-5 is now the front.
+        assert_eq!(snapshot.first().unwrap().line, "line-5");
+        assert!(
+            snapshot.windows(2).all(|w| w[0].seq < w[1].seq),
+            "sequence numbers must be strictly increasing"
+        );
+    }
+
+    #[test]
+    fn reader_none_for_unknown_run() {
+        let hub = LogHub::new();
+        assert!(hub.reader("nope").is_none());
+    }
+
+    #[test]
+    fn finish_sets_ended_flag() {
+        let hub = LogHub::new();
+        hub.append("r", "x".into());
+        hub.finish("r");
+        let (snapshot, _rx, ended) = hub.reader("r").unwrap();
+        assert!(ended, "reader must observe ended after finish");
+        assert_eq!(snapshot.len(), 1);
+    }
+
+    #[test]
+    fn drop_run_frees_buffer() {
+        let hub = LogHub::new();
+        hub.append("r", "x".into());
+        assert!(hub.reader("r").is_some());
+        hub.drop_run("r");
+        assert!(hub.reader("r").is_none());
+    }
+
+    #[tokio::test]
+    async fn ended_buffer_streams_snapshot_then_end() {
+        let hub = LogHub::new();
+        hub.append("r", "a".into());
+        hub.append("r", "b".into());
+        hub.finish("r");
+        let (snapshot, rx, ended) = hub.reader("r").unwrap();
+        let events: Vec<LogEvent> = log_events(snapshot, rx, ended).collect().await;
+        assert_eq!(
+            events,
+            vec![
+                LogEvent::Log("a".into()),
+                LogEvent::Log("b".into()),
+                LogEvent::End
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn snapshot_then_live_dedups_by_seq() {
+        let (tx, rx) = broadcast::channel(8);
+        // seq 0 lands in BOTH the snapshot and the broadcast — must not duplicate.
+        let _ = tx.send(LogMsg::Line(LogLine {
+            seq: 0,
+            line: "a".into(),
+        }));
+        let _ = tx.send(LogMsg::Line(LogLine {
+            seq: 1,
+            line: "b".into(),
+        }));
+        let _ = tx.send(LogMsg::End);
+        let snapshot = vec![LogLine {
+            seq: 0,
+            line: "a".into(),
+        }];
+        let events: Vec<LogEvent> = log_events(snapshot, rx, false).collect().await;
+        assert_eq!(
+            events,
+            vec![
+                LogEvent::Log("a".into()),
+                LogEvent::Log("b".into()),
+                LogEvent::End
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn truncated_emitted_on_broadcast_lag() {
+        // Fill the channel past capacity before the receiver reads → Lagged.
+        let (tx, rx) = broadcast::channel(2);
+        for i in 0..5u64 {
+            let _ = tx.send(LogMsg::Line(LogLine {
+                seq: i,
+                line: format!("l{i}"),
+            }));
+        }
+        let _ = tx.send(LogMsg::End);
+        let events: Vec<LogEvent> = log_events(vec![], rx, false).collect().await;
+        assert!(
+            events.iter().any(|e| matches!(e, LogEvent::Truncated(_))),
+            "a lagging reader must get a Truncated event: {events:?}"
+        );
+        assert_eq!(events.last(), Some(&LogEvent::End));
+    }
+
+    #[test]
+    fn layer_captures_events_in_run_span_only() {
+        use tracing_subscriber::layer::SubscriberExt;
+        let hub = LogHub::new();
+        let subscriber = tracing_subscriber::registry().with(RunLogLayer::new(hub.clone()));
+        tracing::subscriber::with_default(subscriber, || {
+            // An event outside any serve-run span is ignored.
+            tracing::info!("orphan event");
+            let span = tracing::info_span!("faucet.serve.run", serve_run_id = "run-xyz");
+            let _g = span.enter();
+            tracing::info!("hello from the run");
+        });
+        let (snapshot, _rx, _ended) = hub.reader("run-xyz").expect("buffer for the run exists");
+        assert!(
+            snapshot
+                .iter()
+                .any(|l| l.line.contains("hello from the run")),
+            "in-span event must be captured: {snapshot:?}"
+        );
+        assert!(
+            snapshot.iter().all(|l| !l.line.contains("orphan")),
+            "events outside the run span must not be captured"
+        );
+        // No buffer is created for events that never had a serve_run_id span.
+        assert!(hub.reader("nonexistent").is_none());
+    }
+}

--- a/cli/src/serve/logs.rs
+++ b/cli/src/serve/logs.rs
@@ -4,7 +4,7 @@
 //! tags every span that carries a `serve_run_id` field (the
 //! `faucet.serve.run` span each run executes inside — see `runner.rs`) and, for
 //! every event in such a span's scope, formats a redacted line and pushes it into
-//! that run's [`RunBuffer`]: a bounded ring (for backfill) plus a `broadcast`
+//! that run's per-run buffer: a bounded ring (for backfill) plus a `broadcast`
 //! channel (for the live tail). The `/logs` handler replays the ring, then
 //! streams the live tail via [`log_events`].
 //!

--- a/cli/src/serve/metrics.rs
+++ b/cli/src/serve/metrics.rs
@@ -63,6 +63,12 @@ pub fn record_idempotency_hit() {
     metrics::counter!("faucet_serve_idempotency_hits_total").increment(1);
 }
 
+/// Set the run-history degraded gauge (`1` once the persistent backend has
+/// fallen back to in-memory; drives alerting alongside `/readyz`).
+pub fn set_history_degraded(degraded: bool) {
+    metrics::gauge!("faucet_serve_history_degraded").set(if degraded { 1.0 } else { 0.0 });
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/cli/src/serve/mod.rs
+++ b/cli/src/serve/mod.rs
@@ -10,6 +10,7 @@ pub mod handlers;
 pub mod history;
 pub mod idempotency;
 pub mod load;
+pub mod logs;
 pub mod metrics;
 pub mod observability;
 pub mod registry;

--- a/cli/src/serve/observability.rs
+++ b/cli/src/serve/observability.rs
@@ -1,14 +1,26 @@
 //! serve-owned observability: install the Prometheus recorder (returning a
 //! render handle for the `/metrics` route) and a tracing subscriber whose fmt
-//! layer routes through the secret-redacting writer. Both are process-global and
-//! set-once; a second install in the same process is tolerated (returns no
-//! handle / leaves the existing subscriber).
+//! layer routes through the secret-redacting writer and whose [`RunLogLayer`]
+//! feeds the per-run SSE log buffers. Both are process-global and set-once; a
+//! second install in the same process is tolerated (returns no handle / leaves
+//! the existing subscriber). The returned [`LogHub`] is shared with
+//! `ServerState` so the `/logs` handler reads the same buffers the layer writes.
 
+use crate::serve::logs::LogHub;
 use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
+use std::sync::OnceLock;
 
-/// Install the recorder + tracing subscriber. Returns the render handle when
-/// this call installed the recorder; `None` if a recorder was already present.
-pub fn install(level: &str) -> Option<PrometheusHandle> {
+/// The tracing subscriber is process-global and set-once, so the [`LogHub`] wired
+/// into it is too. A second `serve` in the same process (e.g. multiple tests)
+/// reuses this hub rather than getting a detached one whose lines are never
+/// captured by the live subscriber.
+static LOG_HUB: OnceLock<LogHub> = OnceLock::new();
+
+/// Install the recorder + tracing subscriber. Returns the Prometheus render
+/// handle (when this call installed the recorder; `None` if one was already
+/// present) and the process-global [`LogHub`] wired into the subscriber's
+/// [`RunLogLayer`].
+pub fn install(level: &str) -> (Option<PrometheusHandle>, LogHub) {
     let handle = match PrometheusBuilder::new().install_recorder() {
         Ok(h) => Some(h),
         Err(e) => {
@@ -19,13 +31,17 @@ pub fn install(level: &str) -> Option<PrometheusHandle> {
     // Register faucet_build_info into whatever recorder is now global.
     faucet_core::register_build_info();
 
-    install_subscriber(level);
-    handle
+    let hub = LOG_HUB.get_or_init(LogHub::new).clone();
+    // Only the first call's `try_init` succeeds; subsequent calls leave the
+    // already-installed subscriber (which holds this same hub) in place.
+    install_subscriber(level, hub.clone());
+    (handle, hub)
 }
 
 #[cfg(feature = "observability")]
-fn install_subscriber(level: &str) {
+fn install_subscriber(level: &str, hub: LogHub) {
     use crate::secrets::registry::RedactingMakeWriter;
+    use crate::serve::logs::RunLogLayer;
     use tracing_subscriber::EnvFilter;
     use tracing_subscriber::layer::SubscriberExt;
     use tracing_subscriber::util::SubscriberInitExt;
@@ -33,12 +49,12 @@ fn install_subscriber(level: &str) {
     let filter = EnvFilter::try_new(level).unwrap_or_else(|_| EnvFilter::new("info"));
     let registry = tracing_subscriber::registry()
         .with(filter)
-        .with(tracing_subscriber::fmt::layer().with_writer(RedactingMakeWriter));
-    // A later phase adds the per-run SSE log layer here.
+        .with(tracing_subscriber::fmt::layer().with_writer(RedactingMakeWriter))
+        .with(RunLogLayer::new(hub));
     if registry.try_init().is_err() {
         tracing::warn!("tracing subscriber already installed; continuing");
     }
 }
 
 #[cfg(not(feature = "observability"))]
-fn install_subscriber(_level: &str) {}
+fn install_subscriber(_level: &str, _hub: LogHub) {}

--- a/cli/src/serve/observability.rs
+++ b/cli/src/serve/observability.rs
@@ -1,6 +1,6 @@
 //! serve-owned observability: install the Prometheus recorder (returning a
 //! render handle for the `/metrics` route) and a tracing subscriber whose fmt
-//! layer routes through the secret-redacting writer and whose [`RunLogLayer`]
+//! layer routes through the secret-redacting writer and whose `RunLogLayer`
 //! feeds the per-run SSE log buffers. Both are process-global and set-once; a
 //! second install in the same process is tolerated (returns no handle / leaves
 //! the existing subscriber). The returned [`LogHub`] is shared with
@@ -19,7 +19,7 @@ static LOG_HUB: OnceLock<LogHub> = OnceLock::new();
 /// Install the recorder + tracing subscriber. Returns the Prometheus render
 /// handle (when this call installed the recorder; `None` if one was already
 /// present) and the process-global [`LogHub`] wired into the subscriber's
-/// [`RunLogLayer`].
+/// `RunLogLayer`.
 pub fn install(level: &str) -> (Option<PrometheusHandle>, LogHub) {
     let handle = match PrometheusBuilder::new().install_recorder() {
         Ok(h) => Some(h),

--- a/cli/src/serve/runner.rs
+++ b/cli/src/serve/runner.rs
@@ -422,6 +422,9 @@ fn spawn_run(
 
         let span = tracing::info_span!("faucet.serve.run", serve_run_id = %run_id);
         let work = async move {
+            // Emitted inside the run span so it is captured by the SSE log layer
+            // (and gives every `/logs` reader at least one line to anchor on).
+            tracing::info!("pipeline run starting");
             match timeout {
                 Some(d) => match tokio::time::timeout(d, run_expanded(nodes, opts)).await {
                     Ok(r) => classify_run(r),
@@ -441,6 +444,10 @@ fn spawn_run(
         };
 
         finalize(&state, &run_id, started, terminal).await;
+        // Signal `/logs` readers the run is done, then drop the buffer after a
+        // drain window so a late fetcher can still replay it (spec §12).
+        state.log_hub().finish(&run_id);
+        schedule_log_drop(state.clone(), run_id.clone());
         // `_guard` drops here → mark_finished + gauge refresh.
     });
 }
@@ -460,6 +467,15 @@ async fn finalize(state: &ServerState, run_id: &str, started: DateTime<Utc>, ter
         let _ = state.history().upsert(&rec).await;
     }
     metrics::record_run_finished(status, reason);
+}
+
+/// Spawn a detached timer that drops a finished run's log buffer after the drain
+/// window, freeing its ring once late `/logs` fetchers have had a chance to read.
+fn schedule_log_drop(state: ServerState, run_id: String) {
+    tokio::spawn(async move {
+        tokio::time::sleep(crate::serve::logs::LOG_DRAIN).await;
+        state.log_hub().drop_run(&run_id);
+    });
 }
 
 #[cfg(test)]
@@ -545,7 +561,14 @@ mod tests {
             log_level: "info".into(),
         };
         let history = Arc::new(MemoryHistory::new(Duration::from_secs(60))) as Arc<dyn RunHistory>;
-        let state = ServerState::new(&cfg, None, CancellationToken::new(), history, None);
+        let state = ServerState::new(
+            &cfg,
+            None,
+            CancellationToken::new(),
+            history,
+            crate::serve::logs::LogHub::new(),
+            None,
+        );
 
         // Pre-claim the key with a DIFFERENT fingerprint so submit() hits Conflict.
         state

--- a/cli/src/serve/server.rs
+++ b/cli/src/serve/server.rs
@@ -1,16 +1,13 @@
 //! axum router assembly and the bind / graceful-shutdown serve loop.
 
 use crate::error::{CliError, CliResult};
-use crate::serve::config::{HistoryBackendSpec, ServeConfig};
+use crate::serve::config::ServeConfig;
 use crate::serve::handlers::{health, logs, runs};
-use crate::serve::history::RunHistory;
-use crate::serve::history::memory::MemoryHistory;
 use crate::serve::state::ServerState;
 use crate::serve::{auth, metrics};
 use axum::Router;
 use axum::routing::{get, post};
 use serde_json::Value;
-use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 use tower_http::cors::{AllowOrigin, CorsLayer};
 use tower_http::limit::RequestBodyLimitLayer;
@@ -59,21 +56,6 @@ pub fn build_router(state: ServerState, config: &ServeConfig) -> Router {
         .with_state(state)
 }
 
-/// Construct the run-history backend. Phase 2/3 supports only memory; the
-/// Postgres/SQLite specs return a typed "not yet implemented" error (Phase 5).
-async fn build_history(config: &ServeConfig) -> CliResult<Arc<dyn RunHistory>> {
-    match &config.history {
-        HistoryBackendSpec::Memory => {
-            Ok(Arc::new(MemoryHistory::new(config.idempotency_retention)) as Arc<dyn RunHistory>)
-        }
-        HistoryBackendSpec::Postgres(_) | HistoryBackendSpec::Sqlite(_) => Err(CliError::Serve(
-            "persistent run history (postgres/sqlite) is not yet available — \
-             omit --history to use the in-memory backend (tracking: #127 Phase 5)"
-                .into(),
-        )),
-    }
-}
-
 /// Load the optional `--default-config` once at startup, fully resolved, as a
 /// merge base `Value`.
 async fn load_default_base(config: &ServeConfig) -> CliResult<Option<Value>> {
@@ -93,11 +75,18 @@ async fn load_default_base(config: &ServeConfig) -> CliResult<Option<Value>> {
 pub async fn serve(config: ServeConfig) -> CliResult<()> {
     let (prom, log_hub) = crate::serve::observability::install(&config.log_level);
 
-    let history = build_history(&config).await?;
-    history
+    let history =
+        crate::serve::history::connect(&config.history, config.idempotency_retention).await?;
+    let recovered = history
         .recover_orphans()
         .await
         .map_err(|e| CliError::Serve(format!("history recovery: {e}")))?;
+    if recovered > 0 {
+        tracing::warn!(
+            recovered,
+            "marked orphaned non-terminal runs as failed (server restart)"
+        );
+    }
     let default_base = load_default_base(&config).await?;
 
     let shutdown = CancellationToken::new();

--- a/cli/src/serve/server.rs
+++ b/cli/src/serve/server.rs
@@ -2,7 +2,7 @@
 
 use crate::error::{CliError, CliResult};
 use crate::serve::config::{HistoryBackendSpec, ServeConfig};
-use crate::serve::handlers::{health, runs};
+use crate::serve::handlers::{health, logs, runs};
 use crate::serve::history::RunHistory;
 use crate::serve::history::memory::MemoryHistory;
 use crate::serve::state::ServerState;
@@ -28,6 +28,7 @@ pub fn build_router(state: ServerState, config: &ServeConfig) -> Router {
         .route("/v1/runs", post(runs::submit_run).get(runs::list_runs))
         .route("/v1/runs/{id}", get(runs::get_run).delete(runs::delete_run))
         .route("/v1/runs/{id}/cancel", post(runs::cancel_run))
+        .route("/v1/runs/{id}/logs", get(logs::stream_logs))
         .route_layer(axum::middleware::from_fn_with_state(
             state.clone(),
             auth::require_auth,
@@ -90,7 +91,7 @@ async fn load_default_base(config: &ServeConfig) -> CliResult<Option<Value>> {
 /// Boot the server: install observability, build state + router, bind, serve
 /// until SIGTERM/SIGINT, then drain in-flight runs up to the grace window.
 pub async fn serve(config: ServeConfig) -> CliResult<()> {
-    let prom = crate::serve::observability::install(&config.log_level);
+    let (prom, log_hub) = crate::serve::observability::install(&config.log_level);
 
     let history = build_history(&config).await?;
     history
@@ -100,7 +101,14 @@ pub async fn serve(config: ServeConfig) -> CliResult<()> {
     let default_base = load_default_base(&config).await?;
 
     let shutdown = CancellationToken::new();
-    let state = ServerState::new(&config, prom, shutdown.clone(), history, default_base);
+    let state = ServerState::new(
+        &config,
+        prom,
+        shutdown.clone(),
+        history,
+        log_hub,
+        default_base,
+    );
     let app = build_router(state.clone(), &config);
 
     let listener = tokio::net::TcpListener::bind(config.listen)

--- a/cli/src/serve/state.rs
+++ b/cli/src/serve/state.rs
@@ -5,6 +5,7 @@
 
 use crate::serve::config::{AuthMode, ServeConfig};
 use crate::serve::history::RunHistory;
+use crate::serve::logs::LogHub;
 use crate::serve::registry::Registry;
 use metrics_exporter_prometheus::PrometheusHandle;
 use serde_json::Value;
@@ -25,17 +26,20 @@ struct Inner {
     registry: Registry,
     semaphore: Arc<Semaphore>,
     history: Arc<dyn RunHistory>,
+    log_hub: LogHub,
     default_base: Option<Value>,
     idempotency_retention: Duration,
     probe_timeout: Duration,
 }
 
 impl ServerState {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         config: &ServeConfig,
         prometheus: Option<PrometheusHandle>,
         shutdown: CancellationToken,
         history: Arc<dyn RunHistory>,
+        log_hub: LogHub,
         default_base: Option<Value>,
     ) -> Self {
         Self {
@@ -46,6 +50,7 @@ impl ServerState {
                 registry: Registry::new(config.max_queued_runs),
                 semaphore: Arc::new(Semaphore::new(config.max_concurrent_runs)),
                 history,
+                log_hub,
                 default_base,
                 idempotency_retention: config.idempotency_retention,
                 probe_timeout: config.probe_timeout,
@@ -78,6 +83,11 @@ impl ServerState {
 
     pub fn history(&self) -> Arc<dyn RunHistory> {
         Arc::clone(&self.inner.history)
+    }
+
+    /// The per-run log buffer registry shared with the tracing [`LogHub`] layer.
+    pub fn log_hub(&self) -> &LogHub {
+        &self.inner.log_hub
     }
 
     pub fn default_base(&self) -> Option<&Value> {
@@ -120,8 +130,16 @@ mod tests {
     }
 
     fn state(auth: AuthMode) -> ServerState {
+        use crate::serve::logs::LogHub;
         let history = Arc::new(MemoryHistory::new(Duration::from_secs(60))) as Arc<dyn RunHistory>;
-        ServerState::new(&cfg(auth), None, CancellationToken::new(), history, None)
+        ServerState::new(
+            &cfg(auth),
+            None,
+            CancellationToken::new(),
+            history,
+            LogHub::new(),
+            None,
+        )
     }
 
     #[test]

--- a/cli/tests/cli_end_to_end.rs
+++ b/cli/tests/cli_end_to_end.rs
@@ -473,6 +473,12 @@ fn shipped_example_yamls_pass_validate() {
         if path.extension().and_then(|e| e.to_str()) != Some("yaml") {
             continue;
         }
+        // serve_minimal.yaml is a `faucet serve --default-config` partial: it
+        // carries workspace defaults only (no source/sink — those arrive per
+        // HTTP request), so it intentionally does not pass standalone expand.
+        if path.file_name().and_then(|f| f.to_str()) == Some("serve_minimal.yaml") {
+            continue;
+        }
         // Skip examples that require a feature the test binary wasn't built
         // with.  In CI `--all-features` covers everything; local feature-
         // specific test runs (e.g. `--features serve`) must not trip on

--- a/cli/tests/examples_roundtrip.rs
+++ b/cli/tests/examples_roundtrip.rs
@@ -47,6 +47,13 @@ fn every_example_loads_and_expands() {
         if !matches!(ext, "yaml" | "yml" | "json") {
             continue;
         }
+        // serve_minimal.yaml is a `faucet serve --default-config` partial
+        // (workspace defaults only, no source/sink), so it does not expand on
+        // its own — it is merged under each submitted run at request time.
+        if path.file_name().and_then(|f| f.to_str()) == Some("serve_minimal.yaml") {
+            skipped += 1;
+            continue;
+        }
         // Skip examples that rely on a feature not compiled into this test
         // binary.  In CI `--all-features` covers everything; local single-
         // feature runs must not fail on example YAMLs that need an orthogonal
@@ -87,4 +94,14 @@ fn every_example_loads_and_expands() {
         failures.len(),
         failures.join("\n")
     );
+}
+
+/// The `serve --default-config` partial is excluded from the expand loop above
+/// (no source/sink), so check it parses as a structurally valid `PipelineConfig`
+/// here — this still catches bad YAML / unknown fields in the example.
+#[test]
+fn serve_minimal_default_config_parses() {
+    let path = examples_dir().join("serve_minimal.yaml");
+    PipelineConfig::from_path(&path)
+        .expect("serve_minimal.yaml must parse as a valid PipelineConfig");
 }

--- a/cli/tests/serve_history_postgres.rs
+++ b/cli/tests/serve_history_postgres.rs
@@ -1,0 +1,111 @@
+//! Postgres run-history backend integration test (Phase 5, #127).
+//!
+//! Requires a reachable Postgres: set `FAUCET_TEST_POSTGRES_URL` to a
+//! `postgres://…` URL (e.g. `docker run -e POSTGRES_PASSWORD=pw -p 5432:5432
+//! postgres:16`). The test **skips** (with a printed notice) when the variable
+//! is unset, so CI stays green without a database. It exercises the Postgres
+//! dialect of the shared `history::sql` machinery (`$n` placeholders + `::text`
+//! casts) that the SQLite tests cannot cover.
+#![cfg(feature = "serve-history-postgres")]
+
+use chrono::Utc;
+use faucet_cli::serve::history::postgres::PostgresHistory;
+use faucet_cli::serve::history::{
+    Claim, DeleteOutcome, ListFilter, RunHistory, RunRecord, RunStatus,
+};
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+fn rec(id: &str, status: RunStatus) -> RunRecord {
+    let now = Utc::now();
+    let mut r = RunRecord::queued(
+        id.into(),
+        Some("pg-test".into()),
+        BTreeMap::new(),
+        None,
+        now,
+    );
+    r.status = status;
+    if status.is_terminal() {
+        r.finished_at = Some(now);
+    }
+    r
+}
+
+#[tokio::test]
+async fn postgres_backend_full_lifecycle() {
+    let Ok(url) = std::env::var("FAUCET_TEST_POSTGRES_URL") else {
+        eprintln!(
+            "SKIP postgres_backend_full_lifecycle: set FAUCET_TEST_POSTGRES_URL to a \
+             reachable postgres:// URL to run this test"
+        );
+        return;
+    };
+
+    let h = PostgresHistory::connect(&url, Duration::from_secs(3600))
+        .await
+        .expect("connect postgres history (is FAUCET_TEST_POSTGRES_URL reachable?)");
+
+    // Unique id prefix so repeated runs against a shared DB don't collide.
+    let p = format!("pg-{}", Utc::now().timestamp_nanos_opt().unwrap_or(0));
+    let id = |s: &str| format!("{p}-{s}");
+
+    // upsert → get
+    h.upsert(&rec(&id("1"), RunStatus::Running)).await.unwrap();
+    let got = h.get(&id("1")).await.unwrap().expect("present");
+    assert_eq!(got.status, RunStatus::Running);
+    assert!(h.get(&id("missing")).await.unwrap().is_none());
+
+    // idempotency: Fresh → Replay → Conflict (atomic INSERT ON CONFLICT path)
+    let key = id("k");
+    let w = Duration::from_secs(3600);
+    assert_eq!(
+        h.claim_idempotency(&key, "fp1", &id("r1"), w)
+            .await
+            .unwrap(),
+        Claim::Fresh
+    );
+    assert_eq!(
+        h.claim_idempotency(&key, "fp1", &id("r2"), w)
+            .await
+            .unwrap(),
+        Claim::Replay(id("r1"))
+    );
+    assert_eq!(
+        h.claim_idempotency(&key, "fp2", &id("r3"), w)
+            .await
+            .unwrap(),
+        Claim::Conflict
+    );
+
+    // list with a name filter + the keyset/cast SQL path
+    let page = h
+        .list(&ListFilter {
+            name: Some("pg-test".into()),
+            limit: 100,
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert!(page.runs.iter().any(|r| r.run_id == id("1")));
+
+    // delete: running → 409-equivalent; terminal → deleted
+    assert_eq!(
+        h.delete(&id("1")).await.unwrap(),
+        DeleteOutcome::StillRunning
+    );
+    h.upsert(&rec(&id("1"), RunStatus::Completed))
+        .await
+        .unwrap();
+    assert_eq!(h.delete(&id("1")).await.unwrap(), DeleteOutcome::Deleted);
+
+    // recover_orphans marks the leftover Running run failed
+    h.upsert(&rec(&id("orphan"), RunStatus::Running))
+        .await
+        .unwrap();
+    assert!(h.recover_orphans().await.unwrap() >= 1);
+    assert_eq!(
+        h.get(&id("orphan")).await.unwrap().unwrap().status,
+        RunStatus::Failed
+    );
+}

--- a/cli/tests/serve_history_sqlite.rs
+++ b/cli/tests/serve_history_sqlite.rs
@@ -1,0 +1,348 @@
+//! SQLite run-history backend integration tests (Phase 5, #127). SQLite is
+//! embedded, so these exercise the *shared* SQL machinery (`history::sql`) used
+//! by the Postgres backend too — against a real database file, no server needed.
+//! Requires the `serve-history-sqlite` feature.
+#![cfg(feature = "serve-history-sqlite")]
+
+use chrono::{Duration as ChronoDuration, Utc};
+use faucet_cli::serve::history::sqlite::SqliteHistory;
+use faucet_cli::serve::history::{
+    Claim, DeleteOutcome, ListFilter, RunHistory, RunRecord, RunStatus,
+};
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+async fn store(dir: &tempfile::TempDir, file: &str) -> SqliteHistory {
+    let path = dir.path().join(file);
+    SqliteHistory::connect(
+        &format!("sqlite:{}", path.display()),
+        Duration::from_secs(3600),
+    )
+    .await
+    .expect("connect sqlite history")
+}
+
+fn rec(id: &str, status: RunStatus, submitted: chrono::DateTime<Utc>) -> RunRecord {
+    let mut r = RunRecord::queued(id.into(), None, BTreeMap::new(), None, submitted);
+    r.status = status;
+    if status.is_terminal() {
+        r.finished_at = Some(submitted);
+    }
+    r
+}
+
+#[tokio::test]
+async fn upsert_get_and_missing() {
+    let dir = tempfile::tempdir().unwrap();
+    let h = store(&dir, "a.db").await;
+    let mut r = rec("run-1", RunStatus::Running, Utc::now());
+    r.name = Some("nightly".into());
+    r.records_written = 7;
+    h.upsert(&r).await.unwrap();
+
+    let got = h.get("run-1").await.unwrap().expect("present");
+    assert_eq!(got.run_id, "run-1");
+    assert_eq!(got.status, RunStatus::Running);
+    assert_eq!(got.name.as_deref(), Some("nightly"));
+    assert_eq!(got.records_written, 7);
+    assert!(h.get("missing").await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn idempotency_fresh_replay_conflict_at_sql_layer() {
+    let dir = tempfile::tempdir().unwrap();
+    let h = store(&dir, "idem.db").await;
+    let w = Duration::from_secs(3600);
+    assert_eq!(
+        h.claim_idempotency("k", "fp1", "run1", w).await.unwrap(),
+        Claim::Fresh
+    );
+    assert_eq!(
+        h.claim_idempotency("k", "fp1", "run2", w).await.unwrap(),
+        Claim::Replay("run1".into())
+    );
+    assert_eq!(
+        h.claim_idempotency("k", "fp2", "run3", w).await.unwrap(),
+        Claim::Conflict
+    );
+    // Expired prior claim (zero window) is re-claimable.
+    assert_eq!(
+        h.claim_idempotency("k2", "fpa", "r1", Duration::ZERO)
+            .await
+            .unwrap(),
+        Claim::Fresh
+    );
+    assert_eq!(
+        h.claim_idempotency("k2", "fpb", "r2", Duration::ZERO)
+            .await
+            .unwrap(),
+        Claim::Fresh
+    );
+}
+
+#[tokio::test]
+async fn list_orders_desc_filters_and_paginates() {
+    let dir = tempfile::tempdir().unwrap();
+    let h = store(&dir, "list.db").await;
+    let t0 = Utc::now();
+    for (i, id) in ["a", "b", "c"].iter().enumerate() {
+        h.upsert(&rec(
+            id,
+            RunStatus::Completed,
+            t0 + ChronoDuration::seconds(i as i64),
+        ))
+        .await
+        .unwrap();
+    }
+    // Newest first, page size 2 → [c, b], cursor = b.
+    let page = h
+        .list(&ListFilter {
+            limit: 2,
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        page.runs
+            .iter()
+            .map(|r| r.run_id.clone())
+            .collect::<Vec<_>>(),
+        vec!["c", "b"]
+    );
+    assert_eq!(page.next_cursor.as_deref(), Some("b"));
+    // Next page from the cursor → [a].
+    let page2 = h
+        .list(&ListFilter {
+            limit: 2,
+            cursor: Some("b".into()),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        page2
+            .runs
+            .iter()
+            .map(|r| r.run_id.clone())
+            .collect::<Vec<_>>(),
+        vec!["a"]
+    );
+    assert!(page2.next_cursor.is_none());
+
+    // Status filter.
+    h.upsert(&rec(
+        "x",
+        RunStatus::Failed,
+        t0 + ChronoDuration::seconds(10),
+    ))
+    .await
+    .unwrap();
+    let failed = h
+        .list(&ListFilter {
+            status: Some(RunStatus::Failed),
+            limit: 50,
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert_eq!(failed.runs.len(), 1);
+    assert_eq!(failed.runs[0].run_id, "x");
+}
+
+#[tokio::test]
+async fn delete_respects_terminal_state() {
+    let dir = tempfile::tempdir().unwrap();
+    let h = store(&dir, "del.db").await;
+    h.upsert(&rec("run", RunStatus::Running, Utc::now()))
+        .await
+        .unwrap();
+    assert_eq!(h.delete("run").await.unwrap(), DeleteOutcome::StillRunning);
+    assert_eq!(h.delete("nope").await.unwrap(), DeleteOutcome::NotFound);
+    h.upsert(&rec("run", RunStatus::Completed, Utc::now()))
+        .await
+        .unwrap();
+    assert_eq!(h.delete("run").await.unwrap(), DeleteOutcome::Deleted);
+    assert!(h.get("run").await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn recover_orphans_marks_non_terminal_failed_across_restart() {
+    let dir = tempfile::tempdir().unwrap();
+    {
+        let h = store(&dir, "recover.db").await;
+        h.upsert(&rec("orphan", RunStatus::Running, Utc::now()))
+            .await
+            .unwrap();
+        h.upsert(&rec("done", RunStatus::Completed, Utc::now()))
+            .await
+            .unwrap();
+    } // drop the first "process"
+
+    // Reconnect to the same file (simulating a restart) and recover.
+    let h2 = store(&dir, "recover.db").await;
+    let recovered = h2.recover_orphans().await.unwrap();
+    assert_eq!(recovered, 1, "only the non-terminal run is recovered");
+    let orphan = h2.get("orphan").await.unwrap().unwrap();
+    assert_eq!(orphan.status, RunStatus::Failed);
+    assert!(orphan.error.as_deref().unwrap().contains("server restart"));
+    // The already-terminal run is untouched.
+    assert_eq!(
+        h2.get("done").await.unwrap().unwrap().status,
+        RunStatus::Completed
+    );
+    // Idempotent: a second pass finds nothing.
+    assert_eq!(h2.recover_orphans().await.unwrap(), 0);
+}
+
+/// End-to-end: boot `faucet serve --history sqlite:…`, submit a run over HTTP,
+/// and confirm it is persisted through the SQLite-backed history (GET + list).
+/// Proves the `history::connect` → `FallbackHistory` → handler path is wired.
+#[tokio::test(flavor = "multi_thread")]
+async fn server_with_sqlite_history_persists_runs() {
+    use faucet_cli::cli::ServeArgs;
+    use faucet_cli::serve::ServeConfig;
+
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("serve.db");
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+
+    let args = ServeArgs {
+        listen: format!("127.0.0.1:{port}"),
+        auth_token: None,
+        no_auth: true,
+        max_concurrent_runs: Some(2),
+        max_queued_runs: Some(8),
+        default_config: None,
+        history: Some(format!("sqlite:{}", db.display())),
+        cors_origin: vec![],
+        body_limit_bytes: 1_048_576,
+        shutdown_grace_secs: 5,
+        retain_terminal_runs_secs: 604_800,
+        idempotency_retention_secs: 86_400,
+        probe_timeout_secs: 5,
+        env_file: None,
+        no_env_file: true,
+    };
+    let mut config = ServeConfig::from_args(args).unwrap();
+    config.log_level = "warn".into();
+    tokio::spawn(async move {
+        let _ = faucet_cli::serve::run_server(config).await;
+    });
+
+    let client = reqwest::Client::new();
+    let base = format!("http://127.0.0.1:{port}");
+    // Wait for liveness.
+    let mut up = false;
+    for _ in 0..200 {
+        if client
+            .get(format!("{base}/healthz"))
+            .send()
+            .await
+            .map(|r| r.status().is_success())
+            .unwrap_or(false)
+        {
+            up = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    assert!(up, "server did not come up");
+    // /readyz must be 200 — the SQLite backend connected (not degraded).
+    assert_eq!(
+        client
+            .get(format!("{base}/readyz"))
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        200,
+        "readyz must be 200 with a healthy sqlite backend"
+    );
+
+    // Submit a trivial run (connectors may be absent in this build → it ends
+    // 'failed', but the record is still persisted by the history backend).
+    let body = serde_json::json!({
+        "config": "version: 1\npipeline:\n  source: { type: csv, config: { path: in.csv } }\n  sink: { type: jsonl, config: { path: out.jsonl } }\n"
+    });
+    let submit: serde_json::Value = client
+        .post(format!("{base}/v1/runs"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let run_id = submit["run_id"].as_str().unwrap().to_string();
+
+    // Poll until terminal.
+    let mut terminal = false;
+    for _ in 0..400 {
+        let rec: serde_json::Value = client
+            .get(format!("{base}/v1/runs/{run_id}"))
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        if matches!(
+            rec["status"].as_str().unwrap_or(""),
+            "completed" | "failed" | "cancelled"
+        ) {
+            terminal = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    assert!(terminal, "run never reached a terminal state");
+
+    // The run is retrievable and appears in the list — i.e. it was persisted via
+    // the SQLite backend, then read back through it.
+    let listed: serde_json::Value = client
+        .get(format!("{base}/v1/runs"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert!(
+        listed["runs"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|r| r["run_id"] == run_id),
+        "submitted run must be listed from the sqlite-backed history"
+    );
+
+    // The row really is in the database file.
+    let h = store(&dir, "serve.db").await;
+    assert!(
+        h.get(&run_id).await.unwrap().is_some(),
+        "run must be physically present in the sqlite file"
+    );
+}
+
+#[tokio::test]
+async fn purge_drops_expired_terminal_runs() {
+    let dir = tempfile::tempdir().unwrap();
+    let h = store(&dir, "purge.db").await;
+    h.upsert(&rec(
+        "old",
+        RunStatus::Completed,
+        Utc::now() - ChronoDuration::seconds(120),
+    ))
+    .await
+    .unwrap();
+    h.upsert(&rec("live", RunStatus::Running, Utc::now()))
+        .await
+        .unwrap();
+    // retain_for = 0 → every terminal record is expired; running is kept.
+    let removed = h.purge_expired(Duration::ZERO).await.unwrap();
+    assert_eq!(removed, 1);
+    assert!(h.get("old").await.unwrap().is_none());
+    assert!(h.get("live").await.unwrap().is_some());
+}

--- a/cli/tests/serve_logs.rs
+++ b/cli/tests/serve_logs.rs
@@ -1,0 +1,165 @@
+//! SSE log-streaming integration tests for `faucet serve` (Phase 4, #127).
+//!
+//! These run in their own test binary so this process is the first (and only)
+//! installer of the global tracing subscriber — the `RunLogLayer` must be wired
+//! in for `/logs` to capture anything. The server runs at `log_level = info` so
+//! the run-start line passes the `EnvFilter`. Requires the `serve` feature.
+#![cfg(feature = "serve")]
+
+use faucet_cli::cli::ServeArgs;
+use faucet_cli::serve::ServeConfig;
+use std::time::Duration;
+
+fn free_port() -> u16 {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.local_addr().unwrap().port()
+}
+
+fn args_on(port: u16) -> ServeArgs {
+    ServeArgs {
+        listen: format!("127.0.0.1:{port}"),
+        auth_token: None,
+        no_auth: true,
+        max_concurrent_runs: Some(4),
+        max_queued_runs: Some(16),
+        default_config: None,
+        history: None,
+        cors_origin: vec![],
+        body_limit_bytes: 1_048_576,
+        shutdown_grace_secs: 5,
+        retain_terminal_runs_secs: 604_800,
+        idempotency_retention_secs: 86_400,
+        probe_timeout_secs: 5,
+        env_file: None,
+        no_env_file: true,
+    }
+}
+
+async fn spawn_server(port: u16) {
+    let mut config = ServeConfig::from_args(args_on(port)).unwrap();
+    // `info` so the run-start line is captured by the SSE log layer.
+    config.log_level = "info".into();
+    tokio::spawn(async move {
+        let _ = faucet_cli::serve::run_server(config).await;
+    });
+    let client = reqwest::Client::new();
+    for _ in 0..100 {
+        if client
+            .get(format!("http://127.0.0.1:{port}/healthz"))
+            .send()
+            .await
+            .map(|r| r.status().is_success())
+            .unwrap_or(false)
+        {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    panic!("server did not become healthy on port {port}");
+}
+
+fn csv_to_jsonl_yaml(input: &std::path::Path, output: &std::path::Path) -> String {
+    format!(
+        "version: 1\npipeline:\n  source: {{ type: csv, config: {{ path: \"{}\" }} }}\n  sink: {{ type: jsonl, config: {{ path: \"{}\" }} }}\n",
+        input.display(),
+        output.display()
+    )
+}
+
+/// Submit a run, wait for it to finish, then stream `/logs`: the SSE body must
+/// contain the captured run-start line and terminate with an `end` event.
+#[tokio::test(flavor = "multi_thread")]
+async fn logs_stream_replays_and_ends() {
+    let port = free_port();
+    spawn_server(port).await;
+    let client = reqwest::Client::new();
+    let base = format!("http://127.0.0.1:{port}");
+
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("in.csv");
+    let output = dir.path().join("out.jsonl");
+    std::fs::write(&input, "name\nalice\nbob\n").unwrap();
+    let body = serde_json::json!({ "config": csv_to_jsonl_yaml(&input, &output) });
+
+    let submit: serde_json::Value = client
+        .post(format!("{base}/v1/runs"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let run_id = submit["run_id"].as_str().unwrap().to_string();
+
+    // Wait for the run to reach a terminal state so all log lines are captured
+    // and the buffer's `ended` flag is set (buffer survives the drain window).
+    for _ in 0..400 {
+        let rec: serde_json::Value = client
+            .get(format!("{base}/v1/runs/{run_id}"))
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        if matches!(
+            rec["status"].as_str().unwrap_or(""),
+            "completed" | "failed" | "cancelled"
+        ) {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+
+    // Stream the logs. The stream closes when the run's `end` event is emitted,
+    // so `.text()` returns the full body; the timeout guards against a hang.
+    let resp = client
+        .get(format!("{base}/v1/runs/{run_id}/logs"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "/logs must return 200");
+    assert!(
+        resp.headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .map(|ct| ct.contains("text/event-stream"))
+            .unwrap_or(false),
+        "/logs must be text/event-stream"
+    );
+
+    let body = tokio::time::timeout(Duration::from_secs(10), resp.text())
+        .await
+        .expect("log stream did not terminate within 10s")
+        .unwrap();
+
+    assert!(
+        body.contains("event: log"),
+        "expected at least one `log` event; body:\n{body}"
+    );
+    assert!(
+        body.contains("pipeline run starting"),
+        "expected the captured run-start line; body:\n{body}"
+    );
+    assert!(
+        body.contains("event: end"),
+        "stream must terminate with an `end` event; body:\n{body}"
+    );
+}
+
+/// `/logs` for an unknown run id returns 404.
+#[tokio::test]
+async fn logs_unknown_run_is_404() {
+    let port = free_port();
+    spawn_server(port).await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!(
+            "http://127.0.0.1:{port}/v1/runs/does-not-exist/logs"
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 404, "unknown run must yield 404");
+}

--- a/cli/tests/serve_openapi.rs
+++ b/cli/tests/serve_openapi.rs
@@ -1,0 +1,154 @@
+//! Keeps `docs/openapi.yaml` in two-way sync with the live `faucet serve`
+//! router (Phase 6, #127):
+//!
+//! 1. The documented `(method, path)` set equals the canonical route list below
+//!    (which mirrors `serve::server::build_router`).
+//! 2. Every canonical route is actually wired on a booted server — a request
+//!    reaches a handler (never a bare axum routing 404 or a 405).
+//!
+//! Together these bind the spec to the real router. Residual gap (axum cannot
+//! enumerate its routes): a route added to `build_router` but to neither this
+//! list nor the spec would slip through — so a reviewer must update both when
+//! adding an endpoint. Requires the `serve` feature.
+#![cfg(feature = "serve")]
+
+use faucet_cli::cli::ServeArgs;
+use faucet_cli::serve::ServeConfig;
+use std::collections::BTreeSet;
+use std::time::Duration;
+
+/// Canonical (METHOD, path-template) set — mirrors `serve::server::build_router`.
+const ROUTES: &[(&str, &str)] = &[
+    ("POST", "/v1/runs"),
+    ("GET", "/v1/runs"),
+    ("GET", "/v1/runs/{id}"),
+    ("DELETE", "/v1/runs/{id}"),
+    ("POST", "/v1/runs/{id}/cancel"),
+    ("GET", "/v1/runs/{id}/logs"),
+    ("GET", "/healthz"),
+    ("GET", "/readyz"),
+    ("GET", "/metrics"),
+];
+
+fn openapi_routes() -> BTreeSet<(String, String)> {
+    let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../docs/openapi.yaml");
+    let text = std::fs::read_to_string(path).expect("read docs/openapi.yaml");
+    let doc: serde_yaml::Value = serde_yaml::from_str(&text).expect("parse openapi.yaml");
+    let methods = ["get", "post", "put", "delete", "patch", "head", "options"];
+    let mut set = BTreeSet::new();
+    let paths = doc["paths"].as_mapping().expect("paths mapping");
+    for (path, ops) in paths {
+        let path = path.as_str().unwrap().to_string();
+        let ops = ops.as_mapping().unwrap();
+        for (method, _) in ops {
+            let m = method.as_str().unwrap().to_ascii_lowercase();
+            if methods.contains(&m.as_str()) {
+                set.insert((m.to_ascii_uppercase(), path.clone()));
+            }
+        }
+    }
+    set
+}
+
+#[test]
+fn openapi_paths_match_canonical_routes() {
+    let documented = openapi_routes();
+    let canonical: BTreeSet<(String, String)> = ROUTES
+        .iter()
+        .map(|(m, p)| (m.to_string(), p.to_string()))
+        .collect();
+
+    let undocumented: Vec<_> = canonical.difference(&documented).collect();
+    let unrouted: Vec<_> = documented.difference(&canonical).collect();
+    assert!(
+        undocumented.is_empty(),
+        "routes missing from docs/openapi.yaml: {undocumented:?}"
+    );
+    assert!(
+        unrouted.is_empty(),
+        "openapi.yaml documents paths that are not routed: {unrouted:?}"
+    );
+}
+
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn every_documented_route_is_wired_on_the_live_server() {
+    let port = free_port();
+    let args = ServeArgs {
+        listen: format!("127.0.0.1:{port}"),
+        auth_token: None,
+        no_auth: true,
+        max_concurrent_runs: Some(2),
+        max_queued_runs: Some(8),
+        default_config: None,
+        history: None,
+        cors_origin: vec![],
+        body_limit_bytes: 1_048_576,
+        shutdown_grace_secs: 5,
+        retain_terminal_runs_secs: 604_800,
+        idempotency_retention_secs: 86_400,
+        probe_timeout_secs: 5,
+        env_file: None,
+        no_env_file: true,
+    };
+    let mut config = ServeConfig::from_args(args).unwrap();
+    config.log_level = "warn".into();
+    tokio::spawn(async move {
+        let _ = faucet_cli::serve::run_server(config).await;
+    });
+
+    let client = reqwest::Client::new();
+    let base = format!("http://127.0.0.1:{port}");
+    let mut up = false;
+    for _ in 0..200 {
+        if client
+            .get(format!("{base}/healthz"))
+            .send()
+            .await
+            .map(|r| r.status().is_success())
+            .unwrap_or(false)
+        {
+            up = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    assert!(up, "server did not come up");
+
+    for (method, template) in ROUTES {
+        // Unknown id so {id} routes hit their handler's NotFound, not bare 404.
+        let path = template.replace("{id}", "probe-missing-run");
+        let url = format!("{base}{path}");
+        let m: reqwest::Method = method.parse().unwrap();
+        let mut req = client.request(m, &url);
+        if *method == "POST" {
+            // `{}` fails SubmitRequest validation → a handler error, never 404/405.
+            req = req.json(&serde_json::json!({}));
+        }
+        let resp = req
+            .send()
+            .await
+            .unwrap_or_else(|e| panic!("{method} {path}: {e}"));
+        let status = resp.status().as_u16();
+        assert_ne!(
+            status, 405,
+            "{method} {template} returned 405 — method not routed on this path"
+        );
+        if status == 404 {
+            // A handler 404 carries the ApiError JSON envelope; a bare axum
+            // routing 404 (no such route) does not.
+            let body = resp.text().await.unwrap_or_default();
+            assert!(
+                body.contains("\"error\""),
+                "{method} {template} returned a bare 404 (route not wired); body: {body:?}"
+            );
+        }
+    }
+}

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -27,6 +27,7 @@
 - [Secrets-manager interpolation](./cookbook/secrets.md)
 - [Adaptive batching](./cookbook/adaptive-batching.md)
 - [Scheduling](./cookbook/scheduling.md)
+- [Running faucet as a service](./cookbook/serve.md)
 - [Troubleshooting with faucet doctor](./cookbook/troubleshooting.md)
 
 # Reference
@@ -35,6 +36,7 @@
 - [Choosing a connector](./reference/choosing.md)
 - [CLI commands](./reference/cli.md)
 - [Configuration file format](./reference/config.md)
+- [HTTP API (`faucet serve`)](./reference/http-api.md)
 
 # Operations
 

--- a/docs/book/src/cookbook/serve.md
+++ b/docs/book/src/cookbook/serve.md
@@ -1,0 +1,133 @@
+# Running faucet as a service (`faucet serve`)
+
+`faucet serve` turns faucet from a one-shot CLI into a long-running HTTP control
+plane: an orchestrator (Airflow, Temporal, Dagster, Argo) submits pipeline
+configs over HTTP, polls status, cancels runs, and streams logs — while faucet
+amortizes startup (TLS handshakes, connection pools, schema introspection)
+across many runs in one process. It is the second supported runtime mode
+alongside one-shot [`faucet run`](../reference/cli.md) and the cron
+[`faucet schedule`](./scheduling.md).
+
+The full endpoint/schema reference is in [HTTP API reference](../reference/http-api.md);
+this page is the guided tour. `serve` requires the `serve` Cargo feature
+(`cargo install faucet-cli --features serve`, or `--features full`).
+
+## Quickstart
+
+```bash
+# Start the server (loopback by default). Auth is mandatory — see below.
+FAUCET_SERVE_AUTH_TOKEN=s3cret faucet serve --listen 127.0.0.1:8080
+```
+
+```bash
+# Submit a run.
+curl -XPOST http://127.0.0.1:8080/v1/runs \
+  -H "Authorization: Bearer s3cret" -H 'content-type: application/json' \
+  -d '{"config":"version: 1\npipeline:\n  source: {type: csv, config: {path: in.csv}}\n  sink: {type: jsonl, config: {path: out.jsonl}}\n","name":"adhoc"}'
+# → {"run_id":"0192…","status":"queued","submitted_at":"…"}
+
+# Poll it to completion.
+curl -H "Authorization: Bearer s3cret" http://127.0.0.1:8080/v1/runs/0192…
+
+# Tail its logs (SSE).
+curl -N -H "Authorization: Bearer s3cret" http://127.0.0.1:8080/v1/runs/0192…/logs
+```
+
+## ⚠️ Security model — read before exposing
+
+`serve` executes **arbitrary client-supplied pipeline configs with the server's
+identity**. That is a real privilege surface:
+
+- **Full interpolation:** submitted configs resolve `${env:…}`, `${file:…}`,
+  `${secret:…}`, and `${vault:…}`/`${aws-sm:…}`/… **against the server's**
+  environment, filesystem, and credentials — exactly like `faucet run`. An
+  authenticated caller can read any secret the server can reach.
+- **SSRF / egress:** a submitted REST/HTTP source can be pointed at
+  `169.254.169.254` or internal services and will be fetched with the server's
+  network identity.
+
+Mitigations are deployment-level and **mandatory**:
+
+- Never run with `--no-auth` on a non-loopback bind. The no-auth gate is
+  explicit: without `--auth-token`/`FAUCET_SERVE_AUTH_TOKEN` **and** without
+  `--no-auth`, startup fails.
+- Run single-tenant, behind authentication, behind egress controls / network
+  policy. The default loopback bind (`127.0.0.1`) is deliberate — exposing
+  externally is an explicit choice.
+- Terminate TLS at a proxy/ingress (serve speaks plain HTTP).
+- Prefer `FAUCET_SERVE_AUTH_TOKEN` over `--auth-token` (the latter leaks through
+  `ps`/`/proc`).
+- Never run a serve process at `FAUCET_LOG=debug` when submitted configs hold
+  resolved secrets — only faucet's own log output is redacted, not third-party
+  connector debug logging.
+
+## Bounded concurrency & backpressure
+
+`--max-concurrent-runs` (default `min(16, cpu_count())`) bounds how many runs
+execute at once; `--max-queued-runs` (default 8×) bounds the queue. A submit
+past the queue cap returns `429` with `Retry-After`. Note that total concurrent
+pipeline work ≈ `max-concurrent-runs × each config's execution.max_concurrent`.
+
+## Idempotency
+
+Supply `idempotency_key` to make retries safe (Stripe-style):
+
+- First submit with a key → runs normally.
+- Re-submit the **same key + same config** within `--idempotency-retention-secs`
+  (default 24h) → returns the **original** `run_id` (replayed, no new run).
+- Same key + a **different** config → `409 Conflict`.
+- After the retention window, the key is re-usable for a fresh run.
+
+The claim is atomic, so concurrent retries can't both start a run.
+
+## Cancellation
+
+`POST /v1/runs/{id}/cancel` cooperatively cancels an in-flight run (202); on an
+already-terminal run it's a 200 no-op. Cancellation drops the pipeline future at
+its next `.await` — the same partial-sink-state trade-off as `on_error: stop`.
+
+## `--default-config` (workspace defaults)
+
+Pass `--default-config <file>` to merge shared settings **under** every submitted
+run (submitted values win; objects merge, scalars/arrays replace). Pin `state:`,
+`execution:`, and the `auth:` catalog once instead of repeating them per request.
+See [`cli/examples/serve_minimal.yaml`](https://github.com/PawanSikawat/faucet-stream/blob/main/cli/examples/serve_minimal.yaml).
+
+> **Cardinality:** a config's `name:` field drives the metric `pipeline` label and
+> the state-key prefix. Use a **stable** `name:` per logical pipeline — never an
+> ad-hoc per-run string — or Prometheus cardinality blows up. The request-level
+> `name`/`labels` are run-record metadata only, never metric labels.
+
+## Run history & persistence
+
+By default run records live in memory and are lost on restart. For durable
+history across restarts, point `--history` at a database (requires the matching
+build feature):
+
+```bash
+# Postgres (feature: serve-history-postgres)
+faucet serve --history 'postgres://user:pw@db/faucet'
+# SQLite (feature: serve-history-sqlite)
+faucet serve --history 'sqlite:/var/lib/faucet/runs.db'
+```
+
+Both create their schema on first connect. On startup, any run left
+non-terminal by a previous process is marked `failed` (no cross-process resume —
+re-submit to retry). If the backend is unreachable at startup, or fails at
+runtime, serve **degrades to the in-memory store** so it stays up: it logs once,
+sets the `faucet_serve_history_degraded` gauge, and `/readyz` returns `503`.
+Persisted records are not migrated into the fallback — degraded mode is a
+stay-alive, not a replica. Terminal records are retained for
+`--retain-terminal-runs-secs` (default 7 days).
+
+## Graceful shutdown
+
+`SIGTERM`/`SIGINT` stops accepting new connections, drains in-flight runs up to
+`--shutdown-grace-secs` (default 60), then cancels the remainder (marked failed).
+
+## Health & observability
+
+- `/healthz` — liveness (always 200 while serving).
+- `/readyz` — 503 when history is degraded or the queue is full.
+- `/metrics` — Prometheus, including `faucet_serve_*` series. `/metrics` is
+  unauthenticated; restrict it at the network layer if its labels are sensitive.

--- a/docs/book/src/reference/cli.md
+++ b/docs/book/src/reference/cli.md
@@ -13,6 +13,7 @@ The `faucet` binary exposes these commands. Pass `--log-level <level>` (or set
 | `faucet init [name]` | Scaffold a commented config skeleton from connector schemas. |
 | `faucet doctor [config]` | Probe every connector (auth/network/permissions) and print a checklist. |
 | `faucet schedule [config]` | Run a pipeline on a cron schedule (long-running foreground process). |
+| `faucet serve` | Run a long-running HTTP control plane: submit / poll / cancel pipeline runs over REST. |
 
 `[config]` is optional for `run` / `validate` / `preview` / `doctor` / `schedule`: if omitted,
 faucet auto-discovers `faucet.yaml` → `.yml` → `.json` in the current directory.
@@ -160,6 +161,40 @@ Flags:
 
 See the [scheduling cookbook](../cookbook/scheduling.md) for worked examples, the overlap-policy
 decision tree, the resilience/supervisor model, and the full metric set to scrape.
+
+## `serve`
+
+```bash
+FAUCET_SERVE_AUTH_TOKEN=s3cret faucet serve --listen 0.0.0.0:8080
+faucet serve --no-auth                             # explicit opt-in; required if no token
+faucet serve --history sqlite:/var/lib/faucet/runs.db --default-config defaults.yaml
+```
+
+Runs a **long-running HTTP control plane** that accepts pipeline configs over REST, executes them
+under bounded concurrency (reusing the same executor as `faucet run`), and exposes status / cancel /
+list / SSE-logs endpoints plus `/healthz`, `/readyz`, and `/metrics`. Requires the `serve` Cargo
+feature (included in `full`).
+
+Unlike the other commands, `serve` takes **no config file** — configs arrive per request. Auth is
+mandatory: pass `--auth-token`/`FAUCET_SERVE_AUTH_TOKEN`, or `--no-auth` to explicitly disable it
+(absent both, startup fails).
+
+Selected flags (`faucet serve --help` for the full list):
+
+| Flag | Purpose |
+|------|---------|
+| `--listen <addr>` | Bind address (default `127.0.0.1:8080`; env `FAUCET_SERVE_LISTEN`). |
+| `--auth-token <t>` / `--no-auth` | Bearer token (prefer the env var) or explicit no-auth opt-in. |
+| `--max-concurrent-runs <n>` / `--max-queued-runs <n>` | Concurrency + queue caps (429 past the queue). |
+| `--history <url>` | `postgres://…` / `sqlite:…` for durable run history (feature-gated; default in-memory). |
+| `--default-config <path>` | Workspace defaults merged under every submitted run. |
+| `--cors-origin <origin>` | Allow-list a browser origin (repeatable; CORS off by default). |
+| `--body-limit-bytes` / `--shutdown-grace-secs` / `--retain-terminal-runs-secs` / `--idempotency-retention-secs` | Tuning knobs. |
+
+> ⚠️ `serve` executes arbitrary client-supplied configs with the server's identity (secrets, files,
+> network egress). Run single-tenant, authenticated, behind egress controls. See the
+> [serve cookbook](../cookbook/serve.md) for the security model and the
+> [HTTP API reference](./http-api.md) for endpoints.
 
 ## Environment-only mode
 

--- a/docs/book/src/reference/http-api.md
+++ b/docs/book/src/reference/http-api.md
@@ -1,0 +1,156 @@
+# HTTP API reference (`faucet serve`)
+
+`faucet serve` exposes a JSON REST control plane for submitting, polling,
+listing, cancelling, and streaming the logs of pipeline runs, plus
+unauthenticated health and Prometheus endpoints. A machine-readable
+[`docs/openapi.yaml`](https://github.com/PawanSikawat/faucet-stream/blob/main/docs/openapi.yaml)
+spec ships alongside this page and is kept in sync with the router by a CI test.
+
+See the [serve cookbook](../cookbook/serve.md) for a guided quickstart, the
+security model, and operational guidance. This page is the endpoint reference.
+
+## Authentication
+
+All `/v1/*` endpoints require `Authorization: Bearer <token>` unless the server
+was started with `--no-auth`. The token is compared in constant time; the
+`Authorization` header is the only accepted credential (no query-string auth).
+`/healthz`, `/readyz`, and `/metrics` are always unauthenticated (probes /
+scrapers). `OPTIONS` preflight bypasses auth so browsers behind a CORS policy
+work.
+
+## Endpoints
+
+| Method | Path | Success | Notes |
+|--------|------|---------|-------|
+| `POST` | `/v1/runs` | `202` | Submit a run; config validated synchronously |
+| `GET` | `/v1/runs` | `200` | List runs (filters below) |
+| `GET` | `/v1/runs/{id}` | `200` | Get one run record |
+| `DELETE` | `/v1/runs/{id}` | `204` | Remove a terminal run from history |
+| `POST` | `/v1/runs/{id}/cancel` | `202` / `200` | Request cancel (202) or no-op if terminal (200) |
+| `GET` | `/v1/runs/{id}/logs` | `200` | Stream the run's logs as `text/event-stream` |
+| `GET` | `/healthz` | `200` | Liveness (unauthenticated) |
+| `GET` | `/readyz` | `200`/`503` | Readiness (unauthenticated) |
+| `GET` | `/metrics` | `200` | Prometheus exposition (unauthenticated) |
+
+### `POST /v1/runs`
+
+Request body:
+
+```json
+{
+  "config": "version: 1\npipeline:\n  source: {...}\n  sink: {...}\n",
+  "config_format": "yaml",
+  "name": "nightly-rollup",
+  "labels": {"requester": "airflow"},
+  "timeout_secs": 3600,
+  "doctor_first": true,
+  "idempotency_key": "airflow-task-123-attempt-2",
+  "clock": "2026-05-29T00:00:00Z"
+}
+```
+
+- **`config`** (required) — the YAML or JSON pipeline body.
+- **`config_format`** — `yaml` (default) or `json`.
+- **`name`** — metadata; also drives the **state-key and metric identity** (see
+  the cookbook's cardinality note). Two submissions sharing a `name` share
+  replication bookmarks.
+- **`labels`** — arbitrary string metadata, stored on the run record only.
+- **`timeout_secs`** — wall-clock cap; on expiry the run is marked failed.
+- **`doctor_first`** — run preflight probes before executing; on any failure the
+  submit returns `422` with the doctor report in `error.details`.
+- **`idempotency_key`** — replay protection (see cookbook).
+- **`clock`** — overrides the `${now.*}` clock for backfills (default: submit time).
+
+Response (`202`):
+
+```json
+{ "run_id": "0192…", "status": "queued", "submitted_at": "2026-05-29T12:00:00Z" }
+```
+
+A `--default-config` (if the server was started with one) is merged **under** the
+submitted config (submitted values win).
+
+### `GET /v1/runs`
+
+Query parameters: `status`, `name`, `since`, `until` (RFC3339), `limit` (default
+50, max 500), `cursor`. Ordering is `(submitted_at DESC, run_id DESC)`; `cursor`
+is the last `run_id` from the previous page.
+
+```json
+{ "runs": [ { "run_id": "…", "status": "completed", … } ], "next_cursor": "0192…" }
+```
+
+### `GET /v1/runs/{id}` → `RunRecord`
+
+```json
+{
+  "run_id": "0192…",
+  "name": "nightly-rollup",
+  "labels": {"requester": "airflow"},
+  "status": "completed",
+  "submitted_at": "…", "started_at": "…", "finished_at": "…",
+  "elapsed_secs": 12.4,
+  "records_written": 4096,
+  "invocations": [
+    {"row_id": "default", "parent_record_key": null, "records_written": 4096, "error": null}
+  ],
+  "error": null,
+  "idempotency_key": "airflow-task-123-attempt-2",
+  "doctor_report": null
+}
+```
+
+`status` is one of `queued`, `running`, `completed`, `failed`, `cancelled`.
+`elapsed_secs` is filled live for running runs.
+
+> **Bookmarks:** run records carry record counts + per-row outcomes, not
+> replication bookmarks. Bookmark state is per-row/per-state-key and lives in the
+> configured [state backend](../cookbook/state.md), not in the run record.
+
+### `GET /v1/runs/{id}/logs` (SSE)
+
+`text/event-stream`. The server replays the run's bounded ring buffer, then
+streams the live tail. Event types:
+
+- `event: log` — one captured log line (subject to the server's `FAUCET_LOG`
+  level; secrets are redacted).
+- `event: truncated` — the reader fell behind and lines were dropped; rely on
+  the centralized log sink for the full history.
+- `event: end` — the run reached a terminal state; the stream closes.
+
+Log buffers are **ephemeral**: they survive a short drain window after the run
+finishes (independent of run-record retention), then are dropped. A known run
+whose buffer has expired yields a single `end`.
+
+```bash
+curl -N -H "Authorization: Bearer $TOKEN" \
+  http://127.0.0.1:8080/v1/runs/0192…/logs
+```
+
+## Error envelope
+
+Every error is a JSON `ApiError`:
+
+```json
+{ "error": { "code": "unprocessable", "message": "…", "details": { } } }
+```
+
+| Status | When |
+|--------|------|
+| `400` | Malformed body / parse / interpolation failure; a `schedule:` block in the config |
+| `401` | Missing/invalid bearer token |
+| `404` | Unknown `run_id` |
+| `409` | `DELETE` on a running run; idempotency key reused with a different payload |
+| `413` | Body exceeds `--body-limit-bytes` |
+| `422` | Expand/validation failure; `doctor_first` failed (report in `details`) |
+| `429` | Run queue full (carries `Retry-After`) |
+| `500` | Internal error |
+
+## Metrics
+
+`/metrics` serves the standard `faucet_*` pipeline metrics plus serve-specific
+series: `faucet_serve_requests_total{method,path,status}`,
+`faucet_serve_request_duration_seconds{method,path}`, `faucet_serve_runs_queued`,
+`faucet_serve_runs_in_flight`, `faucet_serve_runs_total{status,reason}`,
+`faucet_serve_idempotency_hits_total`, and `faucet_serve_history_degraded`. See
+[Observability](../operations/observability.md).

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,226 @@
+openapi: 3.0.3
+info:
+  title: faucet serve — HTTP control plane
+  description: >
+    The `faucet serve` REST API (#127). Submit pipeline configs over HTTP, poll
+    run status, list/cancel/delete runs, and stream per-run logs over SSE, plus
+    unauthenticated health and Prometheus endpoints. All `/v1/*` endpoints
+    require a bearer token unless the server was started with `--no-auth`.
+
+    This spec is kept in two-way sync with the live router by
+    `cli/tests/serve_openapi.rs` (every documented path is routable; every route
+    is documented).
+  version: "1.0.0"
+servers:
+  - url: http://127.0.0.1:8080
+    description: Default loopback bind
+security:
+  - bearerAuth: []
+paths:
+  /v1/runs:
+    post:
+      summary: Submit a pipeline run
+      description: >
+        Validate + interpolate the config synchronously (4xx on error), then
+        queue the run and return immediately. Long-running execution is
+        asynchronous — poll `GET /v1/runs/{id}`.
+      operationId: submitRun
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/SubmitRequest" }
+      responses:
+        "202":
+          description: Run queued (or an idempotency replay of an existing run).
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SubmitResponse" }
+        "400": { $ref: "#/components/responses/Error" }
+        "401": { $ref: "#/components/responses/Error" }
+        "409": { $ref: "#/components/responses/Error" }
+        "413": { $ref: "#/components/responses/Error" }
+        "422": { $ref: "#/components/responses/Error" }
+        "429": { $ref: "#/components/responses/Error" }
+    get:
+      summary: List runs
+      operationId: listRuns
+      parameters:
+        - { name: status, in: query, schema: { $ref: "#/components/schemas/RunStatus" } }
+        - { name: name, in: query, schema: { type: string } }
+        - { name: since, in: query, schema: { type: string, format: date-time } }
+        - { name: until, in: query, schema: { type: string, format: date-time } }
+        - { name: limit, in: query, schema: { type: integer, default: 50, maximum: 500 } }
+        - { name: cursor, in: query, schema: { type: string }, description: "Last run_id from the previous page." }
+      responses:
+        "200":
+          description: A page of runs, newest first.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ListResponse" }
+        "401": { $ref: "#/components/responses/Error" }
+  /v1/runs/{id}:
+    get:
+      summary: Get a run record
+      operationId: getRun
+      parameters: [ { $ref: "#/components/parameters/RunId" } ]
+      responses:
+        "200":
+          description: The run record.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/RunRecord" }
+        "401": { $ref: "#/components/responses/Error" }
+        "404": { $ref: "#/components/responses/Error" }
+    delete:
+      summary: Delete a terminal run from history
+      description: Does not cancel a running run; returns 409 if it is still in flight.
+      operationId: deleteRun
+      parameters: [ { $ref: "#/components/parameters/RunId" } ]
+      responses:
+        "204": { description: Deleted. }
+        "401": { $ref: "#/components/responses/Error" }
+        "404": { $ref: "#/components/responses/Error" }
+        "409": { $ref: "#/components/responses/Error" }
+  /v1/runs/{id}/cancel:
+    post:
+      summary: Cancel a run
+      description: 202 if cancellation was requested for an in-flight run; 200 (no-op) if already terminal.
+      operationId: cancelRun
+      parameters: [ { $ref: "#/components/parameters/RunId" } ]
+      responses:
+        "200": { description: Already terminal — no-op. }
+        "202": { description: Cancellation requested. }
+        "401": { $ref: "#/components/responses/Error" }
+        "404": { $ref: "#/components/responses/Error" }
+  /v1/runs/{id}/logs:
+    get:
+      summary: Stream a run's logs (SSE)
+      description: >
+        `text/event-stream`. Replays the run's ring buffer, then streams the live
+        tail. Events: `log` (a line), `truncated` (the reader fell behind —
+        rely on the centralized log sink), `end` (the run finished; the stream
+        closes). Log buffers are ephemeral (a short drain window after the run
+        ends); a known run whose buffer expired yields a single `end`.
+      operationId: streamRunLogs
+      parameters: [ { $ref: "#/components/parameters/RunId" } ]
+      responses:
+        "200":
+          description: SSE stream.
+          content:
+            text/event-stream:
+              schema: { type: string }
+        "401": { $ref: "#/components/responses/Error" }
+        "404": { $ref: "#/components/responses/Error" }
+  /healthz:
+    get:
+      summary: Liveness probe (unauthenticated)
+      operationId: healthz
+      security: []
+      responses:
+        "200": { description: The process is alive. }
+  /readyz:
+    get:
+      summary: Readiness probe (unauthenticated)
+      description: 503 when the history backend is degraded or the run queue is full.
+      operationId: readyz
+      security: []
+      responses:
+        "200": { description: Ready to accept work. }
+        "503": { description: Not ready (history degraded or queue full). }
+  /metrics:
+    get:
+      summary: Prometheus metrics (unauthenticated)
+      operationId: metrics
+      security: []
+      responses:
+        "200":
+          description: Prometheus text exposition.
+          content:
+            text/plain: { schema: { type: string } }
+        "503": { description: Metrics recorder unavailable in this process. }
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+  parameters:
+    RunId:
+      name: id
+      in: path
+      required: true
+      schema: { type: string }
+  responses:
+    Error:
+      description: Error envelope.
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/ApiError" }
+  schemas:
+    RunStatus:
+      type: string
+      enum: [queued, running, completed, failed, cancelled]
+    SubmitRequest:
+      type: object
+      required: [config]
+      properties:
+        config: { type: string, description: "YAML or JSON pipeline body." }
+        config_format: { type: string, enum: [yaml, json], default: yaml }
+        name: { type: string, description: "Metadata + state-key/metric identity. Reused name = shared bookmarks." }
+        labels: { type: object, additionalProperties: { type: string } }
+        timeout_secs: { type: integer, nullable: true }
+        doctor_first: { type: boolean, default: false, description: "Run doctor probes first; 422 with report on failure." }
+        idempotency_key: { type: string, nullable: true }
+        clock: { type: string, format: date-time, description: "Override the ${now.*} clock (backfills)." }
+    SubmitResponse:
+      type: object
+      required: [run_id, status, submitted_at]
+      properties:
+        run_id: { type: string }
+        status: { $ref: "#/components/schemas/RunStatus" }
+        submitted_at: { type: string, format: date-time }
+    InvocationRecord:
+      type: object
+      properties:
+        row_id: { type: string }
+        parent_record_key: { type: string, nullable: true }
+        records_written: { type: integer }
+        error: { type: string, nullable: true }
+    RunRecord:
+      type: object
+      required: [run_id, status, submitted_at, records_written, invocations, labels]
+      properties:
+        run_id: { type: string }
+        name: { type: string, nullable: true }
+        labels: { type: object, additionalProperties: { type: string } }
+        status: { $ref: "#/components/schemas/RunStatus" }
+        submitted_at: { type: string, format: date-time }
+        started_at: { type: string, format: date-time, nullable: true }
+        finished_at: { type: string, format: date-time, nullable: true }
+        elapsed_secs: { type: number, nullable: true }
+        records_written: { type: integer }
+        invocations:
+          type: array
+          items: { $ref: "#/components/schemas/InvocationRecord" }
+        error: { type: string, nullable: true }
+        idempotency_key: { type: string, nullable: true }
+        doctor_report: { type: object, nullable: true }
+    ListResponse:
+      type: object
+      required: [runs]
+      properties:
+        runs:
+          type: array
+          items: { $ref: "#/components/schemas/RunRecord" }
+        next_cursor: { type: string, nullable: true }
+    ApiError:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: object
+          required: [code, message]
+          properties:
+            code: { type: string }
+            message: { type: string }
+            details: { type: object, nullable: true }


### PR DESCRIPTION
## Summary

Completes the `faucet serve` HTTP control plane (#127) — the remaining three phases of the six-phase plan, delivered together in this PR (Phases 1–3, the skeleton + run lifecycle + idempotency/doctor_first/default-config, already merged via #140 and #143).

This takes `faucet serve` from "runs work, no logs/persistence/docs" to feature-complete: live log streaming, durable run history, and the full documented + machine-readable API surface.

## Phase 4 — SSE per-run log streaming

- `serve/logs.rs`: a process-global `LogHub` (`DashMap<run_id, RunBuffer>` of a bounded ring + a `broadcast` channel) wired into the serve subscriber as a `RunLogLayer` tracing layer. It captures every event in a run's `faucet.serve.run` span scope, **redacted at capture**.
- `GET /v1/runs/{id}/logs` (`serve/handlers/logs.rs`) replays the ring, then streams the live tail as `text/event-stream` (`log` / `truncated` / `end` events). Buffers are ephemeral (60s drain window after the run ends, independent of run-record retention).
- Race-free reader (subscribe → snapshot → load `ended`; sequence-number de-dup), so a reader that misses the broadcast `End` still closes cleanly.

## Phase 5 — Persistent run history (Postgres + SQLite)

- Feature-gated `serve-history-postgres` / `serve-history-sqlite`. The two backends share one schema, statement set, and the **entire** `RunHistory` impl via the `impl_sql_history!` macro in `history/sql.rs` — they differ only in connection setup and the `$n` vs `?` dialect, so the SQLite tests exercise the Postgres logic too.
- Portable all-`TEXT` schema: timestamps are fixed-width RFC3339 (sort lexicographically → keyset pagination + expiry need no DB date type, hence no sqlx `chrono` feature); the whole `RunRecord` lives in a `body` column.
- Atomic idempotency claim (`INSERT … ON CONFLICT DO NOTHING` + expiry-guarded optimistic takeover) in a separate `faucet_serve_idem` table whose `key` PK is the required unique index.
- `recover_orphans` marks non-terminal rows failed at startup; `purge_expired` drops aged terminal rows + stale claims.
- `FallbackHistory`: a backend unreachable at startup or failing at runtime trips to the in-memory store (logs once, sets `faucet_serve_history_degraded`, `/readyz` → 503) so the server stays up.

## Phase 6 — OpenAPI + docs + artifacts

- `docs/openapi.yaml` (OpenAPI 3.0), kept in **two-way sync** with the live router by `cli/tests/serve_openapi.rs` (documented paths == canonical routes; every route is wired on a booted server).
- Docs site: `reference/http-api.md` + `cookbook/serve.md` (security model — server-side interpolation + SSRF; idempotency; cancellation; `--default-config` + cardinality; persistent history); `SUMMARY.md` + `reference/cli.md` updated.
- `cli/README.md` + root README serve sections; `cli/examples/serve_minimal.yaml`; CI `feature-check` matrix gains both history backends; `full` includes them.
- CLAUDE.md (gitignored) refreshed for Phases 4–6. `deny.toml` needs no change — all new deps' licenses (MIT/BSD-3) are already in the allow-list.

## Tests

- **Unit:** `serve::logs` (ring cap/order, finish/ended, drop, dedup, lag→truncated, in-span capture); `serve::history::sql` helpers; `serve::history::fallback` (trip-on-error, degraded-at-startup).
- **Integration:** `serve_logs` (submit → stream replays + ends; unknown → 404); `serve_history_sqlite` (round-trip, idempotency, keyset pagination/filters, delete, recover-across-restart, purge, and an end-to-end `serve --history sqlite:` HTTP submit→persist→list); `serve_openapi` (route↔spec coverage). A `serve_history_postgres` test exercises the `$n`/`::text` dialect, gated on `FAUCET_TEST_POSTGRES_URL` (skips in CI without a DB).
- Green under `--all-features`; `clippy --all-features -D warnings` clean.

Closes #127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)