### PR TITLE
feat(mssql): Microsoft SQL Server source + sink connectors (#119, #120)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,7 @@ jobs:
           - source-postgres
           - source-postgres-cdc
           - source-mysql
+          - source-mssql
           - source-sqlite
           - source-s3
           - source-mongodb
@@ -129,6 +130,7 @@ jobs:
           - sink-jsonl
           - sink-snowflake
           - sink-mysql
+          - sink-mssql
           - sink-sqlite
           - sink-s3
           - sink-mongodb

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/gcs-common",
     "crates/kafka-common",
     "crates/snowflake-common",
+    "crates/mssql-common",
     "crates/source/rest",
     "crates/source/graphql",
     "crates/source/xml",
@@ -15,6 +16,7 @@ members = [
     "crates/source/kafka",
     "crates/source/postgres",
     "crates/source/mysql",
+    "crates/source/mssql",
 
     "crates/source/gcs",
     "crates/source/s3",
@@ -35,6 +37,7 @@ members = [
     "crates/sink/snowflake",
     "crates/sink/mysql",
     "crates/sink/sqlite",
+    "crates/sink/mssql",
 
     "crates/sink/gcs",
     "crates/sink/s3",
@@ -72,6 +75,7 @@ faucet-elasticsearch-common = { path = "crates/elasticsearch-common", version = 
 faucet-gcs-common = { path = "crates/gcs-common", version = "0.2.0" }
 faucet-kafka-common = { path = "crates/kafka-common", version = "0.2.0" }
 faucet-snowflake-common = { path = "crates/snowflake-common", version = "0.1.0" }
+faucet-mssql-common = { path = "crates/mssql-common", version = "0.1.0" }
 faucet-source-rest = { path = "crates/source/rest", version = "0.2.0" }
 faucet-source-graphql = { path = "crates/source/graphql", version = "0.2.0" }
 faucet-source-xml = { path = "crates/source/xml", version = "0.2.0" }
@@ -84,6 +88,7 @@ faucet-sink-snowflake = { path = "crates/sink/snowflake", version = "0.2.0" }
 faucet-source-postgres = { path = "crates/source/postgres", version = "0.2.0" }
 faucet-source-postgres-cdc = { path = "crates/source/postgres-cdc", version = "0.2.0" }
 faucet-source-mysql = { path = "crates/source/mysql", version = "0.2.0" }
+faucet-source-mssql = { path = "crates/source/mssql", version = "0.1.0" }
 
 faucet-source-gcs = { path = "crates/source/gcs", version = "0.2.0" }
 faucet-source-s3 = { path = "crates/source/s3", version = "0.2.0" }
@@ -99,6 +104,7 @@ faucet-source-bigquery = { path = "crates/source/bigquery", version = "0.1.0" }
 faucet-source-snowflake = { path = "crates/source/snowflake", version = "0.1.0" }
 faucet-sink-mysql = { path = "crates/sink/mysql", version = "0.2.0" }
 faucet-sink-sqlite = { path = "crates/sink/sqlite", version = "0.2.0" }
+faucet-sink-mssql = { path = "crates/sink/mssql", version = "0.1.0" }
 
 faucet-sink-gcs = { path = "crates/sink/gcs", version = "0.2.0" }
 faucet-sink-s3 = { path = "crates/sink/s3", version = "0.2.0" }
@@ -132,6 +138,13 @@ prost = "0.13"
 prost-reflect = { version = "0.15", features = ["serde"] }
 prost-types = "0.13"
 sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls", "postgres", "mysql", "sqlite", "json"] }
+# MSSQL stack. tiberius default features (native-tls, winauth) are off so the
+# tree stays on rustls; bb8-tiberius supplies the tokio runtime glue + the
+# `tls = ["tiberius/rustls"]` passthrough and never enables native-tls.
+tiberius = { version = "0.12", default-features = false, features = ["rustls", "chrono", "rust_decimal", "tds73"] }
+bb8 = "0.9"
+bb8-tiberius = { version = "0.16", default-features = false, features = ["with-tokio", "tds73", "tls"] }
+rust_decimal = "1"
 pgwire-replication = "=0.3.2"
 byteorder = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
@@ -178,6 +191,7 @@ metrics-exporter-prometheus = { version = "0.18", default-features = false, feat
 metrics-util = "0.20"
 bytes = "1"
 url = "2"
+percent-encoding = "2"
 urlencoding = "2"
 protox = "0.9"
 arrow = "58"

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ flowchart LR
     P -.->|metrics + spans| O
 ```
 
-faucet-stream is a Cargo workspace with 47 crates — 20 sources, 16 sinks, 5 shared connector libraries, the shared auth-provider library, 2 state-store backends, the shared core, the umbrella crate, and the CLI binary:
+faucet-stream is a Cargo workspace with 50 crates — 21 sources, 17 sinks, 6 shared connector libraries, the shared auth-provider library, 2 state-store backends, the shared core, the umbrella crate, and the CLI binary:
 
 | Crate | Description |
 |-------|-------------|
@@ -171,6 +171,7 @@ faucet-stream is a Cargo workspace with 47 crates — 20 sources, 16 sinks, 5 sh
 | [`faucet-source-postgres`](crates/source/postgres) | PostgreSQL — run SQL queries, return rows as JSON |
 | [`faucet-source-postgres-cdc`](crates/source/postgres-cdc) | PostgreSQL CDC — logical replication via pgoutput, resumable with any StateStore |
 | [`faucet-source-mysql`](crates/source/mysql) | MySQL — run SQL queries, return rows as JSON |
+| [`faucet-source-mssql`](crates/source/mssql) | Microsoft SQL Server — run SQL queries (streaming, incremental), rows as JSON |
 | [`faucet-source-sqlite`](crates/source/sqlite) | SQLite — run SQL queries, return rows as JSON |
 | [`faucet-source-s3`](crates/source/s3) | AWS S3 — read objects as JSONL, JSON array, or raw text |
 | [`faucet-source-gcs`](crates/source/gcs) | Google Cloud Storage — read objects as JSONL, JSON array, or raw text |
@@ -190,6 +191,7 @@ faucet-stream is a Cargo workspace with 47 crates — 20 sources, 16 sinks, 5 sh
 | [`faucet-sink-jsonl`](crates/sink/jsonl) | JSON Lines — file output with append/truncate |
 | [`faucet-sink-snowflake`](crates/sink/snowflake) | Snowflake — SQL REST API with JWT/OAuth |
 | [`faucet-sink-mysql`](crates/sink/mysql) | MySQL — JSON column or auto-mapped columns |
+| [`faucet-sink-mssql`](crates/sink/mssql) | Microsoft SQL Server — JSON column or auto-mapped columns |
 | [`faucet-sink-sqlite`](crates/sink/sqlite) | SQLite — JSON column or auto-mapped columns |
 | [`faucet-sink-s3`](crates/sink/s3) | AWS S3 — write JSONL files to bucket |
 | [`faucet-sink-gcs`](crates/sink/gcs) | Google Cloud Storage — write JSONL files to bucket |
@@ -207,6 +209,7 @@ faucet-stream is a Cargo workspace with 47 crates — 20 sources, 16 sinks, 5 sh
 | [`faucet-gcs-common`](crates/gcs-common) | Shared GCS types — credentials enum, Storage/StorageControl client builders |
 | [`faucet-kafka-common`](crates/kafka-common) | Shared Kafka types — auth, value formats, Schema Registry client |
 | [`faucet-snowflake-common`](crates/snowflake-common) | Shared Snowflake types — `SnowflakeAuth` enum + auth header helpers |
+| [`faucet-mssql-common`](crates/mssql-common) | Shared MSSQL types — connection/TLS config, `tiberius`+`bb8` pool builder, identifier quoting |
 | **State stores** | |
 | [`faucet-state-redis`](crates/state/redis) | Redis-backed `StateStore` for persistent bookmarks |
 | [`faucet-state-postgres`](crates/state/postgres) | PostgreSQL-backed `StateStore` for persistent bookmarks |
@@ -250,9 +253,9 @@ Every connector is optimised for throughput out of the box:
 | Technique | Where |
 |-----------|-------|
 | **Parallel I/O** | S3 reads/writes objects concurrently (configurable `concurrency`); HTTP sink sends requests in parallel; REST source processes partitions concurrently |
-| **Multi-row INSERT** | PostgreSQL, MySQL, and SQLite sinks batch records into single INSERT statements instead of one per row |
+| **Multi-row INSERT** | PostgreSQL, MySQL, SQLite, and SQL Server sinks batch records into single INSERT statements instead of one per row (MSSQL auto-splits at the 2100-parameter limit) |
 | **Transaction wrapping** | SQLite sink wraps batches in `BEGIN`/`COMMIT` for 10-50x write speedup |
-| **Connection pooling** | All database connectors (PostgreSQL, MySQL, SQLite) use connection pools with configurable `max_connections` |
+| **Connection pooling** | All database connectors (PostgreSQL, MySQL, SQLite, SQL Server) use connection pools with configurable `max_connections` |
 | **Connection reuse** | S3, MongoDB, Redis, Elasticsearch, and HTTP connectors create clients once and reuse across all operations |
 | **Redis pipelining** | Redis sink batches commands with `pipe()`; Redis source uses `MGET` for bulk key reads |
 | **Bulk APIs** | Elasticsearch uses the bulk NDJSON API; BigQuery uses `insertAll`; MongoDB uses `insert_many` |
@@ -371,6 +374,13 @@ Every pipeline emits OTel-compatible `tracing` spans and Prometheus metrics auto
 - **SQL queries** — run any SQL query and get results as JSON records
 - **Connection pooling** — built on `sqlx` with `MySqlPool`
 
+### Source: Microsoft SQL Server (`faucet-source-mssql`)
+
+- **SQL queries** — run any SQL query and get results as JSON records
+- **Streaming + connection pooling** — built on `tiberius` + `bb8`, streams rows page-by-page
+- **Incremental replication** — tracking-column bookmark with an `@bookmark` token for server-side pushdown
+- **Type-aware decoding** — DECIMAL/MONEY → precision-preserving strings, DATETIMEOFFSET keeps its offset, binary → base64
+
 ### Source: SQLite (`faucet-source-sqlite`)
 
 - **SQL queries** — run any SQL query and get results as JSON records
@@ -415,6 +425,13 @@ Every pipeline emits OTel-compatible `tracing` spans and Prometheus metrics auto
 - **JSON mode** — insert records as JSON strings into a column
 - **Auto-map mode** — discover columns from INFORMATION_SCHEMA, map JSON fields automatically
 - **Connection pooling** — built on `sqlx` with `MySqlPool`
+
+### Sink: Microsoft SQL Server (`faucet-sink-mssql`)
+
+- **JSON mode** — insert records as JSON strings into a single column (optionally auto-creating the table)
+- **Auto-map mode** — discover columns from `sys.columns` (IDENTITY columns skipped), map JSON fields automatically
+- **2100-parameter auto-split** — multi-row INSERTs split to stay within MSSQL's per-request limit, wrapped in a transaction
+- **Row-isolation DLQ** — on batch failure, retries row-by-row so only the offending row is dead-lettered
 
 ### Sink: SQLite (`faucet-sink-sqlite`)
 
@@ -890,6 +907,7 @@ Every pagination style has a termination/loop guard. `Cursor`, `LinkHeader`, and
 | `source-postgres` | no | PostgreSQL query source |
 | `source-postgres-cdc` | no | PostgreSQL CDC source (logical replication) |
 | `source-mysql` | no | MySQL query source |
+| `source-mssql` | no | Microsoft SQL Server query source |
 | `source-sqlite` | no | SQLite query source |
 | `source-s3` | no | AWS S3 file source |
 | `source-gcs` | no | Google Cloud Storage file source |
@@ -908,6 +926,7 @@ Every pagination style has a termination/loop guard. `Cursor`, `LinkHeader`, and
 | `sink-jsonl` | no | JSON Lines file sink |
 | `sink-snowflake` | no | Snowflake sink |
 | `sink-mysql` | no | MySQL sink |
+| `sink-mssql` | no | Microsoft SQL Server sink |
 | `sink-sqlite` | no | SQLite sink |
 | `sink-s3` | no | AWS S3 file sink |
 | `sink-gcs` | no | Google Cloud Storage file sink |
@@ -1077,6 +1096,7 @@ crates/
     postgres/                 — PostgreSQL queries
     postgres-cdc/             — PostgreSQL CDC (logical replication)
     mysql/                    — MySQL queries
+    mssql/                    — Microsoft SQL Server queries (streaming, incremental)
     sqlite/                   — SQLite queries
 
     s3/                       — AWS S3 object reader
@@ -1096,6 +1116,7 @@ crates/
     jsonl/                    — JSON Lines file output
     snowflake/                — Snowflake SQL REST API
     mysql/                    — MySQL (JSON or auto-map)
+    mssql/                    — Microsoft SQL Server (JSON or auto-map, 2100-param split)
     sqlite/                   — SQLite (JSON or auto-map)
 
     s3/                       — AWS S3 JSONL writer
@@ -1112,6 +1133,7 @@ crates/
   gcs-common/                 — faucet-gcs-common: shared GCS credentials + client builders
   kafka-common/               — faucet-kafka-common: shared Kafka auth, formats, Schema Registry
   snowflake-common/           — faucet-snowflake-common: shared SnowflakeAuth + JWT/OAuth header helpers
+  mssql-common/               — faucet-mssql-common: shared MSSQL connection/TLS config + tiberius/bb8 pool
   state/
     redis/                    — Redis-backed StateStore
     postgres/                 — PostgreSQL-backed StateStore

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -42,6 +42,7 @@ source = [
     "source-postgres",
     "source-postgres-cdc",
     "source-mysql",
+    "source-mssql",
     "source-sqlite",
     "source-s3",
     "source-mongodb",
@@ -62,6 +63,7 @@ sink = [
     "sink-jsonl",
     "sink-snowflake",
     "sink-mysql",
+    "sink-mssql",
     "sink-sqlite",
     "sink-s3",
     "sink-mongodb",
@@ -83,6 +85,7 @@ source-grpc = ["dep:faucet-source-grpc"]
 source-postgres = ["dep:faucet-source-postgres"]
 source-postgres-cdc = ["dep:faucet-source-postgres-cdc"]
 source-mysql = ["dep:faucet-source-mysql"]
+source-mssql = ["dep:faucet-source-mssql"]
 source-sqlite = ["dep:faucet-source-sqlite"]
 source-s3 = ["dep:faucet-source-s3"]
 source-mongodb = ["dep:faucet-source-mongodb"]
@@ -102,6 +105,7 @@ sink-postgres = ["dep:faucet-sink-postgres"]
 sink-jsonl = ["dep:faucet-sink-jsonl"]
 sink-snowflake = ["dep:faucet-sink-snowflake"]
 sink-mysql = ["dep:faucet-sink-mysql"]
+sink-mssql = ["dep:faucet-sink-mssql"]
 sink-sqlite = ["dep:faucet-sink-sqlite"]
 sink-s3 = ["dep:faucet-sink-s3"]
 sink-mongodb = ["dep:faucet-sink-mongodb"]
@@ -190,6 +194,7 @@ faucet-source-grpc = { workspace = true, optional = true }
 faucet-source-postgres = { workspace = true, optional = true }
 faucet-source-postgres-cdc = { workspace = true, optional = true }
 faucet-source-mysql = { workspace = true, optional = true }
+faucet-source-mssql = { workspace = true, optional = true }
 faucet-source-sqlite = { workspace = true, optional = true }
 faucet-source-s3 = { workspace = true, optional = true }
 faucet-source-mongodb = { workspace = true, optional = true }
@@ -208,6 +213,7 @@ faucet-sink-postgres = { workspace = true, optional = true }
 faucet-sink-jsonl = { workspace = true, optional = true }
 faucet-sink-snowflake = { workspace = true, optional = true }
 faucet-sink-mysql = { workspace = true, optional = true }
+faucet-sink-mssql = { workspace = true, optional = true }
 faucet-sink-sqlite = { workspace = true, optional = true }
 faucet-sink-s3 = { workspace = true, optional = true }
 faucet-sink-mongodb = { workspace = true, optional = true }

--- a/cli/examples/kafka_to_mssql.yaml
+++ b/cli/examples/kafka_to_mssql.yaml
@@ -1,0 +1,45 @@
+# Apache Kafka -> Microsoft SQL Server (auto-mapped columns).
+#
+# Drains a topic and lands each message as a row, mapping top-level JSON keys to
+# same-named columns. The sink batches into multi-row INSERTs, auto-splitting to
+# stay within MSSQL's 2100-parameter limit, and wraps each batch in a transaction.
+#
+# Run:
+#   faucet run cli/examples/kafka_to_mssql.yaml
+#
+# Prereqs:
+#   - A Kafka/Redpanda broker on localhost:9092 with an `events` topic.
+#   - SQL Server with a `dbo.events` table whose columns match the message keys.
+
+version: 1
+name: kafka_to_mssql
+pipeline:
+  source:
+    type: kafka
+    config:
+      brokers: "localhost:9092"
+      topics: ["events"]
+      group_id: "faucet-kafka-to-mssql"
+      value_format: {type: json}
+      auto_offset_reset: earliest
+      max_messages: 5000
+      idle_timeout: 10
+
+  sink:
+    type: mssql
+    config:
+      connection_url: "mssql://sa:Str0ng%40Pass@localhost:1433/analytics"
+      table: dbo.events
+      column_mapping:
+        type: auto_columns
+        on_unknown_field: warn
+      batch_size: 500
+      transaction_per_batch: true
+      isolate_row_failures: true
+      tls:
+        type: trust_server_certificate
+
+  state:
+    type: file
+    config:
+      path: ./.faucet-state

--- a/cli/examples/mssql_to_jsonl.yaml
+++ b/cli/examples/mssql_to_jsonl.yaml
@@ -1,0 +1,42 @@
+# Microsoft SQL Server -> JSONL, with incremental replication.
+#
+# Each run emits only rows whose `updated_at` is greater than the bookmark
+# persisted in the file state store, so re-runs continue where they left off.
+# The `@bookmark` token is bound as a parameter for server-side filtering; the
+# source also filters client-side as a correctness backstop.
+#
+# Run:
+#   faucet run cli/examples/mssql_to_jsonl.yaml
+#
+# Prereqs:
+#   - SQL Server reachable on localhost:1433 with a `sales` database and a
+#     `dbo.users (id, email, updated_at)` table.
+#   - URL credentials are percent-encoded (@ -> %40, : -> %3A, / -> %2F).
+
+version: 1
+name: mssql_to_jsonl
+pipeline:
+  source:
+    type: mssql
+    config:
+      connection_url: "mssql://sa:Str0ng%40Pass@localhost:1433/sales"
+      query: "SELECT id, email, updated_at FROM dbo.users WHERE updated_at > @bookmark ORDER BY updated_at"
+      batch_size: 1000
+      # Self-signed dev cert: trust it. Use `prefer`/`require` in production.
+      tls:
+        type: trust_server_certificate
+      replication:
+        type: incremental
+        column: updated_at
+        initial_value: "1970-01-01T00:00:00Z"
+
+  sink:
+    type: jsonl
+    config:
+      path: ./out/users.jsonl
+      append: true
+
+  state:
+    type: file
+    config:
+      path: ./.faucet-state

--- a/cli/examples/rest_to_mssql.yaml
+++ b/cli/examples/rest_to_mssql.yaml
@@ -1,0 +1,41 @@
+# REST API -> Microsoft SQL Server (single JSON column).
+#
+# Pulls records from a paginated REST API and stores each one as a JSON string
+# in a single NVARCHAR(MAX) column. `create_table: true` creates the table
+# (id IDENTITY + payload NVARCHAR(MAX)) if it doesn't exist — schema-agnostic
+# landing with no DDL coupling.
+#
+# Run:
+#   faucet run cli/examples/rest_to_mssql.yaml
+#
+# Point `base_url` at any JSON HTTP API and adjust the records path.
+
+version: 1
+name: rest_to_mssql
+pipeline:
+  source:
+    type: rest
+    config:
+      base_url: "https://dummyjson.com"
+      path: "/products"
+      method: GET
+      records_path: "products"
+      pagination:
+        type: offset
+        limit_param: limit
+        offset_param: skip
+        limit: 30
+        total_path: total
+
+  sink:
+    type: mssql
+    config:
+      connection_url: "mssql://sa:Str0ng%40Pass@localhost:1433/raw"
+      table: dbo.products_raw
+      column_mapping:
+        type: json_column
+        column: payload
+      create_table: true
+      batch_size: 500
+      tls:
+        type: trust_server_certificate

--- a/cli/src/registry.rs
+++ b/cli/src/registry.rs
@@ -83,6 +83,11 @@ pub async fn build_source(
             let cfg = decode::<faucet_source_mysql::MysqlSourceConfig>("source", "mysql", config)?;
             Ok(Box::new(faucet_source_mysql::MysqlSource::new(cfg).await?))
         }
+        #[cfg(feature = "source-mssql")]
+        "mssql" => {
+            let cfg = decode::<faucet_source_mssql::MssqlSourceConfig>("source", "mssql", config)?;
+            Ok(Box::new(faucet_source_mssql::MssqlSource::new(cfg).await?))
+        }
         #[cfg(feature = "source-sqlite")]
         "sqlite" => {
             let cfg =
@@ -232,6 +237,11 @@ pub async fn build_sink(kind: &str, config: Value, auth: &AuthCatalog) -> CliRes
             let cfg = decode::<faucet_sink_mysql::MysqlSinkConfig>("sink", "mysql", config)?;
             Ok(Box::new(faucet_sink_mysql::MysqlSink::new(cfg).await?))
         }
+        #[cfg(feature = "sink-mssql")]
+        "mssql" => {
+            let cfg = decode::<faucet_sink_mssql::MssqlSinkConfig>("sink", "mssql", config)?;
+            Ok(Box::new(faucet_sink_mssql::MssqlSink::new(cfg).await?))
+        }
         #[cfg(feature = "sink-sqlite")]
         "sqlite" => {
             let cfg = decode::<faucet_sink_sqlite::SqliteSinkConfig>("sink", "sqlite", config)?;
@@ -320,6 +330,8 @@ pub fn source_schema(kind: &str) -> CliResult<Value> {
         "postgres-cdc" => Ok(schema::<faucet_source_postgres_cdc::PostgresCdcSourceConfig>()),
         #[cfg(feature = "source-mysql")]
         "mysql" => Ok(schema::<faucet_source_mysql::MysqlSourceConfig>()),
+        #[cfg(feature = "source-mssql")]
+        "mssql" => Ok(schema::<faucet_source_mssql::MssqlSourceConfig>()),
         #[cfg(feature = "source-sqlite")]
         "sqlite" => Ok(schema::<faucet_source_sqlite::SqliteSourceConfig>()),
         #[cfg(feature = "source-s3")]
@@ -375,6 +387,8 @@ pub fn sink_schema(kind: &str) -> CliResult<Value> {
         "snowflake" => Ok(schema::<faucet_sink_snowflake::SnowflakeSinkConfig>()),
         #[cfg(feature = "sink-mysql")]
         "mysql" => Ok(schema::<faucet_sink_mysql::MysqlSinkConfig>()),
+        #[cfg(feature = "sink-mssql")]
+        "mssql" => Ok(schema::<faucet_sink_mssql::MssqlSinkConfig>()),
         #[cfg(feature = "sink-sqlite")]
         "sqlite" => Ok(schema::<faucet_sink_sqlite::SqliteSinkConfig>()),
         #[cfg(feature = "sink-s3")]
@@ -422,6 +436,8 @@ pub fn source_descriptions() -> Vec<(&'static str, &'static str)> {
     ));
     #[cfg(feature = "source-mysql")]
     v.push(("mysql", "MySQL query source"));
+    #[cfg(feature = "source-mssql")]
+    v.push(("mssql", "Microsoft SQL Server query source"));
     #[cfg(feature = "source-sqlite")]
     v.push(("sqlite", "SQLite query source"));
     #[cfg(feature = "source-s3")]
@@ -477,6 +493,8 @@ pub fn sink_descriptions() -> Vec<(&'static str, &'static str)> {
     v.push(("snowflake", "Snowflake SQL REST API sink"));
     #[cfg(feature = "sink-mysql")]
     v.push(("mysql", "MySQL sink"));
+    #[cfg(feature = "sink-mssql")]
+    v.push(("mssql", "Microsoft SQL Server sink (auto-mapped columns or JSON column)"));
     #[cfg(feature = "sink-sqlite")]
     v.push(("sqlite", "SQLite sink"));
     #[cfg(feature = "sink-s3")]

--- a/cli/src/registry.rs
+++ b/cli/src/registry.rs
@@ -494,7 +494,10 @@ pub fn sink_descriptions() -> Vec<(&'static str, &'static str)> {
     #[cfg(feature = "sink-mysql")]
     v.push(("mysql", "MySQL sink"));
     #[cfg(feature = "sink-mssql")]
-    v.push(("mssql", "Microsoft SQL Server sink (auto-mapped columns or JSON column)"));
+    v.push((
+        "mssql",
+        "Microsoft SQL Server sink (auto-mapped columns or JSON column)",
+    ));
     #[cfg(feature = "sink-sqlite")]
     v.push(("sqlite", "SQLite sink"));
     #[cfg(feature = "sink-s3")]

--- a/crates/mssql-common/Cargo.toml
+++ b/crates/mssql-common/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "faucet-mssql-common"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Shared configuration, TLS, and connection-pool types for the faucet-stream MSSQL source and sink connectors"
+readme = "README.md"
+keywords = ["mssql", "sqlserver", "tiberius", "etl", "pipeline"]
+categories.workspace = true
+
+[dependencies]
+faucet-core.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+schemars.workspace = true
+tiberius.workspace = true
+bb8.workspace = true
+bb8-tiberius.workspace = true
+tokio.workspace = true
+url.workspace = true
+percent-encoding.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "time"] }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/mssql-common/README.md
+++ b/crates/mssql-common/README.md
@@ -1,0 +1,63 @@
+# faucet-mssql-common
+
+Shared configuration, TLS, and connection-pool types for the
+[`faucet-stream`](https://crates.io/crates/faucet-stream) Microsoft SQL Server
+**source** ([`faucet-source-mssql`](https://crates.io/crates/faucet-source-mssql))
+and **sink** ([`faucet-sink-mssql`](https://crates.io/crates/faucet-sink-mssql))
+connectors. Built on [`tiberius`](https://crates.io/crates/tiberius) +
+[`bb8-tiberius`](https://crates.io/crates/bb8-tiberius).
+
+You normally don't depend on this crate directly — both connectors re-export the
+types you configure. It exists so the source and sink share one connection /
+TLS / pooling implementation (per the faucet "source/sink pair shares a
+`-common` crate" convention).
+
+## What's here
+
+| Item | Purpose |
+|------|---------|
+| `MssqlConnectionConfig` | `connection_url` **or** `connection_string` (exactly one) + a `tls` block. Flattened into both end configs. |
+| `MssqlTls` / `MssqlTlsMode` | Encryption mode (`prefer` / `require` / `trust_server_certificate` / `disable`) + optional `ca_cert_path`. |
+| `build_config` | `MssqlConnectionConfig` → `tiberius::Config` (URL parse, ADO passthrough, TLS). |
+| `build_pool` | Builds a `bb8` pool and eagerly validates one connection (fail-fast). |
+| `with_statement_timeout` | Wraps a query future in a timeout. |
+| `quote_ident_mssql` | `[bracket]` identifier quoting (doubles interior `]`). |
+| `PARAM_LIMIT` | `2100` — MSSQL's per-request bind-parameter ceiling. |
+
+## Connection
+
+```yaml
+# URL form — faucet parses host/port/database/credentials; the tls block
+# governs encryption.
+connection_url: "mssql://sa:Str0ng%40Pass@localhost:1433/sales"
+tls:
+  type: prefer          # prefer | require | trust_server_certificate | disable
+  ca_cert_path: null
+
+# …or an ADO.NET-style string handed straight to tiberius:
+connection_string: "Server=tcp:localhost,1433;Database=sales;User Id=sa;Password=...;"
+```
+
+Special characters in URL credentials must be percent-encoded
+(`@` → `%40`, `:` → `%3A`, `/` → `%2F`).
+
+### TLS modes
+
+| Mode | `tiberius` encryption | Notes |
+|------|-----------------------|-------|
+| `prefer` (default) | `On` | Encrypt the connection (safe modern default). |
+| `require` | `Required` | Fail if the server doesn't offer TLS. |
+| `trust_server_certificate` | `On` + `trust_cert()` | Accepts self-signed certs. **Insecure against MITM — dev only.** |
+| `disable` | `NotSupported` | No transport encryption. |
+
+`ca_cert_path` trusts a specific CA certificate for server validation (ignored
+when `disable`).
+
+## Auth
+
+SQL Server authentication (username + password) only. Windows / Integrated
+authentication and Azure AD / Managed Identity are out of scope for v1.
+
+## License
+
+MIT OR Apache-2.0.

--- a/crates/mssql-common/src/config.rs
+++ b/crates/mssql-common/src/config.rs
@@ -1,0 +1,247 @@
+//! Shared MSSQL connection configuration and pure parsing/quoting helpers.
+//!
+//! No I/O lives here — connecting and pooling are in [`crate::pool`]. This
+//! module only holds the serde config types and the pure logic the source and
+//! sink both need (URL parsing, identifier quoting, the parameter ceiling).
+
+use std::path::PathBuf;
+
+use faucet_core::FaucetError;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// MSSQL's hard ceiling on bind parameters per request. A multi-row `INSERT`
+/// binds `rows * columns` parameters, so the sink auto-splits a batch into
+/// multiple statements whenever it would exceed this.
+pub const PARAM_LIMIT: usize = 2100;
+
+/// Shared connection configuration for the MSSQL source and sink.
+///
+/// Exactly one of [`connection_url`](Self::connection_url) or
+/// [`connection_string`](Self::connection_string) must be set. The
+/// `connection_url` form is parsed by faucet (host/port/database/credentials)
+/// and the [`tls`](Self::tls) block governs encryption. The `connection_string`
+/// form is an ADO.NET-style string handed straight to `tiberius`, with the
+/// `tls` block applied on top.
+///
+/// `max_connections` and `statement_timeout_secs` are intentionally *not* here —
+/// they default differently for the source (10 / 300) and sink (5 / 300), so
+/// each end owns them and passes them to [`crate::pool::build_pool`] /
+/// [`crate::pool::with_statement_timeout`].
+#[derive(Clone, Serialize, Deserialize, JsonSchema, Default)]
+pub struct MssqlConnectionConfig {
+    /// `mssql://user:pass@host:1433/database` URL form. Mutually exclusive with
+    /// [`connection_string`](Self::connection_string).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub connection_url: Option<String>,
+    /// ADO.NET-style connection string handed straight to `tiberius`, e.g.
+    /// `Server=tcp:host,1433;Database=db;User Id=sa;Password=...;`. Mutually
+    /// exclusive with [`connection_url`](Self::connection_url).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub connection_string: Option<String>,
+    /// TLS / encryption settings. Defaults to [`MssqlTlsMode::Prefer`].
+    #[serde(default)]
+    pub tls: MssqlTls,
+}
+
+/// TLS configuration for an MSSQL connection.
+///
+/// Matches the YAML shape `tls: { type: <mode>, ca_cert_path: <path> }`.
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, Default, PartialEq, Eq)]
+pub struct MssqlTls {
+    /// Encryption mode. Defaults to [`MssqlTlsMode::Prefer`].
+    #[serde(rename = "type", default)]
+    pub mode: MssqlTlsMode,
+    /// Optional path to a CA certificate (PEM/DER) to trust for server
+    /// validation. Ignored when `mode` is [`MssqlTlsMode::Disable`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ca_cert_path: Option<PathBuf>,
+}
+
+/// MSSQL encryption mode.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, JsonSchema, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum MssqlTlsMode {
+    /// Encrypt the connection if the server supports it (the safe modern
+    /// default). Maps to `tiberius` `EncryptionLevel::On`.
+    #[default]
+    Prefer,
+    /// Require encryption; fail if the server does not offer it. Maps to
+    /// `EncryptionLevel::Required`.
+    Require,
+    /// Encrypt and accept the server certificate without validating its chain
+    /// (self-signed dev servers). Maps to `EncryptionLevel::On` + `trust_cert()`.
+    /// **Insecure against MITM — never use in production.**
+    TrustServerCertificate,
+    /// No transport encryption. Maps to `EncryptionLevel::NotSupported`.
+    Disable,
+}
+
+/// Parsed parts of a `mssql://` connection URL.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ConnectionParts {
+    pub host: String,
+    pub port: u16,
+    pub database: Option<String>,
+    pub username: String,
+    pub password: String,
+}
+
+impl MssqlConnectionConfig {
+    /// Validate that exactly one of `connection_url` / `connection_string` is
+    /// set.
+    pub fn validate(&self) -> Result<(), FaucetError> {
+        match (&self.connection_url, &self.connection_string) {
+            (Some(_), Some(_)) => Err(FaucetError::Config(
+                "MSSQL config sets both `connection_url` and `connection_string`; set exactly one"
+                    .into(),
+            )),
+            (None, None) => Err(FaucetError::Config(
+                "MSSQL config requires either `connection_url` or `connection_string`".into(),
+            )),
+            _ => Ok(()),
+        }
+    }
+}
+
+/// Parse a `mssql://user:password@host:port/database` URL into its parts.
+///
+/// The port defaults to 1433. The database is the first path segment (optional).
+/// Credentials are percent-decoded. Returns [`FaucetError::Config`] on a
+/// malformed URL or a missing host.
+pub(crate) fn parse_connection_url(raw: &str) -> Result<ConnectionParts, FaucetError> {
+    let url = url::Url::parse(raw)
+        .map_err(|e| FaucetError::Config(format!("invalid MSSQL connection_url: {e}")))?;
+
+    if url.scheme() != "mssql" && url.scheme() != "sqlserver" {
+        return Err(FaucetError::Config(format!(
+            "MSSQL connection_url scheme must be `mssql://`, got `{}://`",
+            url.scheme()
+        )));
+    }
+
+    let host = url
+        .host_str()
+        .filter(|h| !h.is_empty())
+        .ok_or_else(|| FaucetError::Config("MSSQL connection_url is missing a host".into()))?
+        .to_string();
+
+    let port = url.port().unwrap_or(1433);
+
+    let database = {
+        let seg = url.path().trim_start_matches('/');
+        if seg.is_empty() {
+            None
+        } else {
+            Some(
+                percent_decode(seg)
+                    .map_err(|e| FaucetError::Config(format!("invalid database in URL: {e}")))?,
+            )
+        }
+    };
+
+    let username = percent_decode(url.username())
+        .map_err(|e| FaucetError::Config(format!("invalid username in URL: {e}")))?;
+    let password = percent_decode(url.password().unwrap_or(""))
+        .map_err(|e| FaucetError::Config(format!("invalid password in URL: {e}")))?;
+
+    Ok(ConnectionParts {
+        host,
+        port,
+        database,
+        username,
+        password,
+    })
+}
+
+fn percent_decode(s: &str) -> Result<String, std::str::Utf8Error> {
+    percent_encoding::percent_decode_str(s)
+        .decode_utf8()
+        .map(|c| c.into_owned())
+}
+
+/// Quote an MSSQL identifier with bracket quoting (`[name]`), doubling any
+/// interior `]` per T-SQL rules. Rejects identifiers containing a NUL byte.
+///
+/// MSSQL idiom is `[brackets]`; this is why the source/sink do not reuse
+/// `faucet_core::util::quote_ident` (double-quote quoting).
+pub fn quote_ident_mssql(name: &str) -> Result<String, FaucetError> {
+    if name.contains('\0') {
+        return Err(FaucetError::Config(format!(
+            "invalid MSSQL identifier (contains NUL): {name:?}"
+        )));
+    }
+    Ok(format!("[{}]", name.replace(']', "]]")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_accepts_exactly_one() {
+        let url_only = MssqlConnectionConfig {
+            connection_url: Some("mssql://sa:pw@host/db".into()),
+            ..Default::default()
+        };
+        assert!(url_only.validate().is_ok());
+
+        let str_only = MssqlConnectionConfig {
+            connection_string: Some("Server=host;Database=db".into()),
+            ..Default::default()
+        };
+        assert!(str_only.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_both_and_neither() {
+        let both = MssqlConnectionConfig {
+            connection_url: Some("mssql://sa:pw@host/db".into()),
+            connection_string: Some("Server=host".into()),
+            ..Default::default()
+        };
+        assert!(both.validate().is_err());
+
+        let neither = MssqlConnectionConfig::default();
+        assert!(neither.validate().is_err());
+    }
+
+    #[test]
+    fn parse_url_extracts_all_parts() {
+        let parts = parse_connection_url("mssql://sa:s3cret@db.example.com:1433/sales").unwrap();
+        assert_eq!(parts.host, "db.example.com");
+        assert_eq!(parts.port, 1433);
+        assert_eq!(parts.database.as_deref(), Some("sales"));
+        assert_eq!(parts.username, "sa");
+        assert_eq!(parts.password, "s3cret");
+    }
+
+    #[test]
+    fn parse_url_defaults_port_and_optional_database() {
+        let parts = parse_connection_url("mssql://sa:pw@localhost").unwrap();
+        assert_eq!(parts.port, 1433);
+        assert_eq!(parts.database, None);
+    }
+
+    #[test]
+    fn parse_url_percent_decodes_credentials() {
+        // password "p@ss:w/rd" percent-encoded
+        let parts = parse_connection_url("mssql://us%65r:p%40ss%3Aw%2Frd@host/db").unwrap();
+        assert_eq!(parts.username, "user");
+        assert_eq!(parts.password, "p@ss:w/rd");
+    }
+
+    #[test]
+    fn parse_url_rejects_wrong_scheme_and_missing_host() {
+        assert!(parse_connection_url("postgres://sa:pw@host/db").is_err());
+        assert!(parse_connection_url("not a url").is_err());
+    }
+
+    #[test]
+    fn quote_ident_brackets_and_doubles_closing_bracket() {
+        assert_eq!(quote_ident_mssql("events").unwrap(), "[events]");
+        assert_eq!(quote_ident_mssql("dbo.events").unwrap(), "[dbo.events]");
+        assert_eq!(quote_ident_mssql("we[i]rd").unwrap(), "[we[i]]rd]");
+        assert!(quote_ident_mssql("bad\0name").is_err());
+    }
+}

--- a/crates/mssql-common/src/lib.rs
+++ b/crates/mssql-common/src/lib.rs
@@ -22,4 +22,6 @@ mod config;
 mod pool;
 
 pub use config::{MssqlConnectionConfig, MssqlTls, MssqlTlsMode, PARAM_LIMIT, quote_ident_mssql};
-pub use pool::{MssqlPool, MssqlPooledConnection, build_config, build_pool, with_statement_timeout};
+pub use pool::{
+    MssqlPool, MssqlPooledConnection, build_config, build_pool, with_statement_timeout,
+};

--- a/crates/mssql-common/src/lib.rs
+++ b/crates/mssql-common/src/lib.rs
@@ -1,0 +1,25 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+//! # faucet-mssql-common
+//!
+//! Shared configuration, TLS, and connection-pool types for the
+//! [`faucet-stream`](https://crates.io/crates/faucet-stream) Microsoft SQL
+//! Server source and sink connectors.
+//!
+//! - [`MssqlConnectionConfig`] — `connection_url` **or** `connection_string`,
+//!   plus a [`MssqlTls`] block. Flattened into both end configs so the wire
+//!   shape matches the other SQL connectors.
+//! - [`build_config`] / [`build_pool`] — the single place a `tiberius`
+//!   [`tiberius::Config`] and a `bb8` connection pool are constructed.
+//! - [`with_statement_timeout`] — wraps a query future in a timeout.
+//! - [`quote_ident_mssql`] — `[bracket]` identifier quoting (T-SQL idiom).
+//! - [`PARAM_LIMIT`] — MSSQL's 2100-parameter-per-request ceiling.
+//!
+//! Auth is SQL Server authentication (username + password) only in v1;
+//! Windows/Integrated and Azure AD auth are out of scope.
+
+mod config;
+mod pool;
+
+pub use config::{MssqlConnectionConfig, MssqlTls, MssqlTlsMode, PARAM_LIMIT, quote_ident_mssql};
+pub use pool::{MssqlPool, MssqlPooledConnection, build_config, build_pool, with_statement_timeout};

--- a/crates/mssql-common/src/pool.rs
+++ b/crates/mssql-common/src/pool.rs
@@ -62,13 +62,13 @@ fn apply_tls(config: &mut Config, tls: &MssqlTls) -> Result<(), FaucetError> {
         }
     }
 
-    if tls.mode != MssqlTlsMode::Disable {
-        if let Some(path) = &tls.ca_cert_path {
-            let p = path.to_str().ok_or_else(|| {
-                FaucetError::Config("MSSQL tls.ca_cert_path is not valid UTF-8".into())
-            })?;
-            config.trust_cert_ca(p);
-        }
+    if tls.mode != MssqlTlsMode::Disable
+        && let Some(path) = &tls.ca_cert_path
+    {
+        let p = path.to_str().ok_or_else(|| {
+            FaucetError::Config("MSSQL tls.ca_cert_path is not valid UTF-8".into())
+        })?;
+        config.trust_cert_ca(p);
     }
     Ok(())
 }
@@ -120,12 +120,11 @@ mod tests {
 
     #[tokio::test]
     async fn timeout_passes_through_completed_future() {
-        let out: Result<i32, FaucetError> = with_statement_timeout(
-            Duration::from_secs(5),
-            async { Ok(42) },
-            || FaucetError::Source("unused".into()),
-        )
-        .await;
+        let out: Result<i32, FaucetError> =
+            with_statement_timeout(Duration::from_secs(5), async { Ok(42) }, || {
+                FaucetError::Source("unused".into())
+            })
+            .await;
         assert_eq!(out.unwrap(), 42);
     }
 

--- a/crates/mssql-common/src/pool.rs
+++ b/crates/mssql-common/src/pool.rs
@@ -1,0 +1,168 @@
+//! Connection / pool construction over `tiberius` + `bb8-tiberius`.
+//!
+//! This is the only module in the workspace that builds a `tiberius`
+//! [`tiberius::Config`] or an MSSQL connection pool — both the source and the
+//! sink go through here so TLS, auth, and pooling behave identically.
+
+use std::future::Future;
+use std::time::Duration;
+
+use bb8::{Pool, PooledConnection};
+use bb8_tiberius::ConnectionManager;
+use faucet_core::FaucetError;
+use tiberius::{AuthMethod, Config, EncryptionLevel};
+
+use crate::config::{MssqlConnectionConfig, MssqlTls, MssqlTlsMode, parse_connection_url};
+
+/// A `bb8` pool of `tiberius` clients.
+pub type MssqlPool = Pool<ConnectionManager>;
+/// A connection checked out of an [`MssqlPool`]; derefs to a `tiberius::Client`.
+pub type MssqlPooledConnection<'a> = PooledConnection<'a, ConnectionManager>;
+
+/// Build a `tiberius` [`Config`] from a [`MssqlConnectionConfig`].
+///
+/// Parses the `connection_url` (host / port / database / credentials) or hands
+/// the `connection_string` to `tiberius`' ADO.NET parser, then applies the
+/// [`MssqlTls`] block. Validates that exactly one connection source is set.
+pub fn build_config(cfg: &MssqlConnectionConfig) -> Result<Config, FaucetError> {
+    cfg.validate()?;
+
+    let mut config = if let Some(url) = &cfg.connection_url {
+        let parts = parse_connection_url(url)?;
+        let mut c = Config::new();
+        c.host(parts.host);
+        c.port(parts.port);
+        if let Some(db) = parts.database {
+            c.database(db);
+        }
+        c.authentication(AuthMethod::sql_server(parts.username, parts.password));
+        c
+    } else {
+        let s = cfg
+            .connection_string
+            .as_ref()
+            .expect("validate() guarantees one of url/string is set");
+        Config::from_ado_string(s)
+            .map_err(|e| FaucetError::Config(format!("invalid MSSQL connection_string: {e}")))?
+    };
+
+    apply_tls(&mut config, &cfg.tls)?;
+    config.application_name("faucet");
+    Ok(config)
+}
+
+fn apply_tls(config: &mut Config, tls: &MssqlTls) -> Result<(), FaucetError> {
+    match tls.mode {
+        MssqlTlsMode::Prefer => config.encryption(EncryptionLevel::On),
+        MssqlTlsMode::Require => config.encryption(EncryptionLevel::Required),
+        MssqlTlsMode::Disable => config.encryption(EncryptionLevel::NotSupported),
+        MssqlTlsMode::TrustServerCertificate => {
+            config.encryption(EncryptionLevel::On);
+            config.trust_cert();
+        }
+    }
+
+    if tls.mode != MssqlTlsMode::Disable {
+        if let Some(path) = &tls.ca_cert_path {
+            let p = path.to_str().ok_or_else(|| {
+                FaucetError::Config("MSSQL tls.ca_cert_path is not valid UTF-8".into())
+            })?;
+            config.trust_cert_ca(p);
+        }
+    }
+    Ok(())
+}
+
+/// Build a connection pool and eagerly validate one connection so bad
+/// credentials / an unreachable host fail fast in the connector's `new()`.
+pub async fn build_pool(
+    cfg: &MssqlConnectionConfig,
+    max_connections: u32,
+) -> Result<MssqlPool, FaucetError> {
+    let config = build_config(cfg)?;
+    let manager = ConnectionManager::new(config);
+    let pool = Pool::builder()
+        .max_size(max_connections.max(1))
+        .build(manager)
+        .await
+        .map_err(|e| FaucetError::Config(format!("MSSQL pool build failed: {e}")))?;
+
+    // Fail fast on auth / reachability, mirroring the postgres source's eager
+    // `connect()`.
+    pool.get()
+        .await
+        .map_err(|e| FaucetError::Config(format!("MSSQL connection failed: {e}")))?;
+
+    Ok(pool)
+}
+
+/// Run a query future under `timeout`. On elapse, returns the error produced by
+/// `make_timeout_err` (so the source maps to [`FaucetError::Source`] and the
+/// sink to [`FaucetError::Sink`]); the caller drops the connection rather than
+/// returning a half-used one to the pool.
+pub async fn with_statement_timeout<F, T>(
+    timeout: Duration,
+    fut: F,
+    make_timeout_err: impl FnOnce() -> FaucetError,
+) -> Result<T, FaucetError>
+where
+    F: Future<Output = Result<T, FaucetError>>,
+{
+    match tokio::time::timeout(timeout, fut).await {
+        Ok(inner) => inner,
+        Err(_) => Err(make_timeout_err()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn timeout_passes_through_completed_future() {
+        let out: Result<i32, FaucetError> = with_statement_timeout(
+            Duration::from_secs(5),
+            async { Ok(42) },
+            || FaucetError::Source("unused".into()),
+        )
+        .await;
+        assert_eq!(out.unwrap(), 42);
+    }
+
+    #[tokio::test]
+    async fn timeout_fires_on_slow_future() {
+        let out: Result<i32, FaucetError> = with_statement_timeout(
+            Duration::from_millis(10),
+            async {
+                tokio::time::sleep(Duration::from_secs(30)).await;
+                Ok(1)
+            },
+            || FaucetError::Sink("query timed out".into()),
+        )
+        .await;
+        let err = out.unwrap_err();
+        assert!(matches!(err, FaucetError::Sink(_)));
+        assert!(err.to_string().contains("timed out"));
+    }
+
+    #[test]
+    fn build_config_rejects_invalid_source_combo() {
+        let both = MssqlConnectionConfig {
+            connection_url: Some("mssql://sa:pw@h/db".into()),
+            connection_string: Some("Server=h".into()),
+            ..Default::default()
+        };
+        assert!(build_config(&both).is_err());
+    }
+
+    #[test]
+    fn build_config_from_url_succeeds() {
+        let cfg = MssqlConnectionConfig {
+            connection_url: Some("mssql://sa:pw@localhost:1433/sales".into()),
+            ..Default::default()
+        };
+        // We can't assert tiberius Config internals (no public getters), but
+        // building must not error for a well-formed URL.
+        assert!(build_config(&cfg).is_ok());
+    }
+}

--- a/crates/sink/mssql/Cargo.toml
+++ b/crates/sink/mssql/Cargo.toml
@@ -26,7 +26,7 @@ chrono.workspace = true
 tokio.workspace = true
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync"] }
 serde_json.workspace = true
 testcontainers = "0.27"
 testcontainers-modules = { version = "0.15", features = ["mssql_server"] }

--- a/crates/sink/mssql/Cargo.toml
+++ b/crates/sink/mssql/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "faucet-sink-mssql"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Microsoft SQL Server sink connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords = ["mssql", "sqlserver", "sql", "sink", "pipeline"]
+categories.workspace = true
+
+[dependencies]
+faucet-core.workspace = true
+faucet-mssql-common.workspace = true
+schemars.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+async-trait.workspace = true
+tracing.workspace = true
+tiberius.workspace = true
+bb8.workspace = true
+bb8-tiberius.workspace = true
+rust_decimal.workspace = true
+chrono.workspace = true
+tokio.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+serde_json.workspace = true
+testcontainers = "0.27"
+testcontainers-modules = { version = "0.15", features = ["mssql_server"] }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/sink/mssql/README.md
+++ b/crates/sink/mssql/README.md
@@ -1,0 +1,95 @@
+# faucet-sink-mssql
+
+Microsoft SQL Server sink for the
+[`faucet-stream`](https://crates.io/crates/faucet-stream) ecosystem. Inserts
+records via parameterized multi-row `INSERT`s with auto-mapped columns or a
+single JSON column. Built on [`tiberius`](https://crates.io/crates/tiberius) +
+[`bb8-tiberius`](https://crates.io/crates/bb8-tiberius).
+
+## Config
+
+```yaml
+sink:
+  type: mssql
+  config:
+    connection_url: "mssql://sa:Str0ng%40Pass@localhost:1433/sales"
+    # connection_string: "Server=tcp:localhost,1433;Database=sales;User Id=sa;Password=...;"
+
+    table: "dbo.events"
+
+    column_mapping:
+      type: auto_columns          # auto_columns | json_column
+      on_unknown_field: warn      # warn | drop | error  (auto_columns only)
+    # column_mapping: { type: json_column, column: "payload" }
+
+    batch_size: 500               # rows per multi-row INSERT (auto-split at the 2100-param limit)
+    max_connections: 5
+    transaction_per_batch: true   # wrap each batch in BEGIN/COMMIT TRAN
+    isolate_row_failures: true    # retry row-by-row on batch failure so only the bad row is DLQ'd
+    statement_timeout_secs: 300   # 0 disables
+    create_table: false           # json_column only: create (id IDENTITY, <column> NVARCHAR(MAX)) if absent
+
+    tls:
+      type: prefer                # prefer | require | trust_server_certificate | disable
+      ca_cert_path: null
+```
+
+See [`faucet-mssql-common`](https://crates.io/crates/faucet-mssql-common) for the
+full connection / TLS reference.
+
+## Write modes
+
+- **`auto_columns`** — top-level JSON keys map to same-named table columns. The
+  column set is fixed from the first record (missing keys → SQL `NULL`).
+  `IDENTITY` columns are skipped automatically (the server generates them) — do
+  **not** put identity values in your records unless you've set
+  `SET IDENTITY_INSERT <table> ON` yourself. Keys with no matching column are
+  handled by `on_unknown_field` (`warn` / `drop` / `error`).
+- **`json_column`** — each record is serialized to JSON and inserted into a
+  single `NVARCHAR(MAX)` (or native Azure SQL `JSON`) column. Schema-agnostic.
+  `create_table: true` will create the table if absent.
+
+`auto_columns` + `create_table` is rejected — schema inference for MSSQL types is
+unsafe, so create the table yourself first.
+
+## Batching, transactions, and the 2100-parameter limit
+
+MSSQL caps a request at **2100 parameters**. A multi-row `INSERT` binds
+`rows × columns` parameters, so the sink auto-splits a batch into multiple
+`INSERT` statements (all within one transaction when `transaction_per_batch`) so
+the limit is never exceeded. `MERGE`/`UPSERT` and bulk-copy (`BCP`) are out of
+scope for v1 — this is an append-only sink.
+
+## Partial failures (DLQ)
+
+With `isolate_row_failures: true` (default) a batch that fails is rolled back and
+retried one row at a time: the good rows land and only the offending row is
+returned as an error for dead-letter routing. Transient errors (deadlock,
+lock-timeout, connection drops) are retried with backoff and otherwise
+propagated so the pipeline's `on_batch_error` policy decides. Set
+`isolate_row_failures: false` to fail the whole batch on the first bad row
+(fewer round-trips).
+
+## Security
+
+`tls.type: trust_server_certificate` and `TrustServerCertificate=true` in a
+connection string disable certificate-chain validation — they accept **any**
+server certificate, which is vulnerable to man-in-the-middle attacks. Use them
+only against trusted dev servers. In production use `prefer`/`require` with a
+proper certificate, or pin a CA via `tls.ca_cert_path`. Never hard-code
+credentials — supply `connection_url` / `connection_string` via secrets-manager
+interpolation or environment variables.
+
+## Auth
+
+SQL Server authentication (username + password) only in v1. Windows / Integrated
+authentication and Azure AD / Managed Identity are out of scope.
+
+## Testing
+
+Unit tests run with `cargo test -p faucet-sink-mssql --lib`. The integration
+tests (`--test integration`) require Docker.
+
+## License
+
+MIT OR Apache-2.0.

--- a/crates/sink/mssql/README.md
+++ b/crates/sink/mssql/README.md
@@ -52,13 +52,15 @@ full connection / TLS reference.
 `auto_columns` + `create_table` is rejected — schema inference for MSSQL types is
 unsafe, so create the table yourself first.
 
-## Batching, transactions, and the 2100-parameter limit
+## Batching, transactions, and MSSQL's statement limits
 
-MSSQL caps a request at **2100 parameters**. A multi-row `INSERT` binds
-`rows × columns` parameters, so the sink auto-splits a batch into multiple
-`INSERT` statements (all within one transaction when `transaction_per_batch`) so
-the limit is never exceeded. `MERGE`/`UPSERT` and bulk-copy (`BCP`) are out of
-scope for v1 — this is an append-only sink.
+MSSQL enforces two caps on a multi-row `INSERT`: at most **2100 parameters** per
+request (and `tiberius` spends 2 of them on its `sp_executesql` wrapper, so the
+usable budget is 2098), and at most **1000 row expressions** in a `VALUES`
+clause. The sink auto-splits a batch into multiple `INSERT` statements that stay
+within *both* limits — `min(2098 / columns, 1000)` rows each — all within one
+transaction when `transaction_per_batch`. `MERGE`/`UPSERT` and bulk-copy (`BCP`)
+are out of scope for v1 — this is an append-only sink.
 
 ## Partial failures (DLQ)
 

--- a/crates/sink/mssql/src/config.rs
+++ b/crates/sink/mssql/src/config.rs
@@ -136,7 +136,8 @@ impl MssqlSinkConfig {
         if self.table.trim().is_empty() {
             return Err(FaucetError::Config("MSSQL sink requires a `table`".into()));
         }
-        if self.create_table && matches!(self.column_mapping, MssqlColumnMapping::AutoColumns { .. })
+        if self.create_table
+            && matches!(self.column_mapping, MssqlColumnMapping::AutoColumns { .. })
         {
             return Err(FaucetError::Config(
                 "MSSQL sink `create_table` is only supported with `json_column` mode \

--- a/crates/sink/mssql/src/config.rs
+++ b/crates/sink/mssql/src/config.rs
@@ -1,0 +1,240 @@
+//! Configuration for the MSSQL sink.
+
+use faucet_core::{FaucetError, validate_batch_size};
+use faucet_mssql_common::MssqlConnectionConfig;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+fn default_batch_size() -> usize {
+    500
+}
+fn default_max_connections() -> u32 {
+    5
+}
+fn default_statement_timeout_secs() -> u64 {
+    300
+}
+fn default_true() -> bool {
+    true
+}
+
+/// What to do with record keys that don't match a table column (`auto_columns`).
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, JsonSchema, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum OnUnknownField {
+    /// Log a one-shot warning and drop the unknown keys (default).
+    #[default]
+    Warn,
+    /// Silently drop the unknown keys.
+    Drop,
+    /// Fail the write with [`FaucetError::Sink`].
+    Error,
+}
+
+/// How records map onto table columns.
+///
+/// Serializes as `{ type: json_column, column: "data" }` (default) or
+/// `{ type: auto_columns, on_unknown_field: warn }`.
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum MssqlColumnMapping {
+    /// Map top-level JSON keys to same-named table columns. IDENTITY columns are
+    /// skipped (the server generates them).
+    AutoColumns {
+        #[serde(default)]
+        on_unknown_field: OnUnknownField,
+    },
+    /// Serialize each record to a JSON string inserted into a single
+    /// `NVARCHAR(MAX)` (or native `JSON`) column.
+    JsonColumn { column: String },
+}
+
+impl Default for MssqlColumnMapping {
+    fn default() -> Self {
+        Self::JsonColumn {
+            column: "data".into(),
+        }
+    }
+}
+
+/// Configuration for [`MssqlSink`](crate::MssqlSink).
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
+pub struct MssqlSinkConfig {
+    /// Connection + TLS settings (`connection_url` or `connection_string`).
+    #[serde(flatten)]
+    pub connection: MssqlConnectionConfig,
+    /// Target table, optionally schema-qualified (e.g. `dbo.events`).
+    pub table: String,
+    /// How records map onto columns. Defaults to a single `data` JSON column.
+    #[serde(default)]
+    pub column_mapping: MssqlColumnMapping,
+    /// Rows per multi-row `INSERT`. Auto-split further so `rows * columns` stays
+    /// within MSSQL's 2100-parameter limit. `0` sends the whole page (still
+    /// param-split). Defaults to 500.
+    #[serde(default = "default_batch_size")]
+    pub batch_size: usize,
+    /// Maximum pooled connections. Defaults to 5.
+    #[serde(default = "default_max_connections")]
+    pub max_connections: u32,
+    /// Wrap each batch's INSERTs in `BEGIN TRAN` / `COMMIT TRAN`. Defaults to true.
+    #[serde(default = "default_true")]
+    pub transaction_per_batch: bool,
+    /// On a batch failure, retry row-by-row to isolate the offender so good rows
+    /// still land and only the bad row is DLQ-routed. When false, one bad row
+    /// fails the whole batch (fewer round-trips). Defaults to true.
+    #[serde(default = "default_true")]
+    pub isolate_row_failures: bool,
+    /// Per-statement timeout in seconds (`0` disables). Defaults to 300.
+    #[serde(default = "default_statement_timeout_secs")]
+    pub statement_timeout_secs: u64,
+    /// In `json_column` mode only, create the table if absent as
+    /// `(id BIGINT IDENTITY PRIMARY KEY, <column> NVARCHAR(MAX))`. Rejected with
+    /// `auto_columns` (schema inference is unsafe for MSSQL types). Defaults to false.
+    #[serde(default)]
+    pub create_table: bool,
+}
+
+impl std::fmt::Debug for MssqlSinkConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MssqlSinkConfig")
+            .field("connection", &"***")
+            .field("table", &self.table)
+            .field("column_mapping", &self.column_mapping)
+            .field("batch_size", &self.batch_size)
+            .field("max_connections", &self.max_connections)
+            .field("transaction_per_batch", &self.transaction_per_batch)
+            .field("isolate_row_failures", &self.isolate_row_failures)
+            .field("statement_timeout_secs", &self.statement_timeout_secs)
+            .field("create_table", &self.create_table)
+            .finish()
+    }
+}
+
+impl MssqlSinkConfig {
+    /// Build a config from a connection URL and table, with defaults elsewhere.
+    pub fn new(connection_url: impl Into<String>, table: impl Into<String>) -> Self {
+        Self {
+            connection: MssqlConnectionConfig {
+                connection_url: Some(connection_url.into()),
+                ..Default::default()
+            },
+            table: table.into(),
+            column_mapping: MssqlColumnMapping::default(),
+            batch_size: default_batch_size(),
+            max_connections: default_max_connections(),
+            transaction_per_batch: true,
+            isolate_row_failures: true,
+            statement_timeout_secs: default_statement_timeout_secs(),
+            create_table: false,
+        }
+    }
+
+    /// Validate connection source, batch size, table, and mode combination.
+    pub fn validate(&self) -> Result<(), FaucetError> {
+        self.connection.validate()?;
+        validate_batch_size(self.batch_size)?;
+        if self.table.trim().is_empty() {
+            return Err(FaucetError::Config("MSSQL sink requires a `table`".into()));
+        }
+        if self.create_table && matches!(self.column_mapping, MssqlColumnMapping::AutoColumns { .. })
+        {
+            return Err(FaucetError::Config(
+                "MSSQL sink `create_table` is only supported with `json_column` mode \
+                 (schema inference for auto_columns is unsafe — create the table first)"
+                    .into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn json_column_is_default() {
+        assert_eq!(
+            MssqlColumnMapping::default(),
+            MssqlColumnMapping::JsonColumn {
+                column: "data".into()
+            }
+        );
+    }
+
+    #[test]
+    fn column_mapping_round_trips() {
+        let auto: MssqlColumnMapping =
+            serde_json::from_value(json!({"type": "auto_columns", "on_unknown_field": "error"}))
+                .unwrap();
+        assert_eq!(
+            auto,
+            MssqlColumnMapping::AutoColumns {
+                on_unknown_field: OnUnknownField::Error
+            }
+        );
+
+        let jc: MssqlColumnMapping =
+            serde_json::from_value(json!({"type": "json_column", "column": "payload"})).unwrap();
+        assert_eq!(
+            jc,
+            MssqlColumnMapping::JsonColumn {
+                column: "payload".into()
+            }
+        );
+    }
+
+    #[test]
+    fn auto_columns_defaults_unknown_field_to_warn() {
+        let auto: MssqlColumnMapping =
+            serde_json::from_value(json!({"type": "auto_columns"})).unwrap();
+        assert_eq!(
+            auto,
+            MssqlColumnMapping::AutoColumns {
+                on_unknown_field: OnUnknownField::Warn
+            }
+        );
+    }
+
+    #[test]
+    fn config_defaults() {
+        let cfg: MssqlSinkConfig = serde_json::from_value(json!({
+            "connection_url": "mssql://sa:pw@h/db",
+            "table": "dbo.events",
+        }))
+        .unwrap();
+        assert_eq!(cfg.batch_size, 500);
+        assert_eq!(cfg.max_connections, 5);
+        assert!(cfg.transaction_per_batch);
+        assert!(cfg.isolate_row_failures);
+        assert_eq!(cfg.statement_timeout_secs, 300);
+        assert!(!cfg.create_table);
+    }
+
+    #[test]
+    fn validate_rejects_auto_columns_with_create_table() {
+        let cfg = MssqlSinkConfig {
+            column_mapping: MssqlColumnMapping::AutoColumns {
+                on_unknown_field: OnUnknownField::Warn,
+            },
+            create_table: true,
+            ..MssqlSinkConfig::new("mssql://sa:pw@h/db", "dbo.events")
+        };
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_empty_table() {
+        let cfg = MssqlSinkConfig::new("mssql://sa:pw@h/db", "  ");
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn debug_masks_connection() {
+        let cfg = MssqlSinkConfig::new("mssql://sa:secret@h/db", "dbo.t");
+        let dbg = format!("{cfg:?}");
+        assert!(dbg.contains("***"));
+        assert!(!dbg.contains("secret"));
+    }
+}

--- a/crates/sink/mssql/src/encode.rs
+++ b/crates/sink/mssql/src/encode.rs
@@ -44,13 +44,19 @@ impl BoundParam {
     }
 }
 
-/// Maximum rows per `INSERT` so `rows * num_cols` stays within
-/// [`PARAM_LIMIT`]. Always at least 1.
+/// `tiberius` routes parameterized statements through `sp_executesql`, which
+/// consumes two of the 2100 parameters itself (the statement text and the
+/// parameter-declaration string). So the usable budget for bind values is
+/// `PARAM_LIMIT - 2` — sending a full 2100 bind values overflows by two.
+const SP_EXECUTESQL_RESERVED: usize = 2;
+
+/// Maximum rows per `INSERT` so the request stays within MSSQL's 2100-parameter
+/// limit, accounting for the `sp_executesql` overhead. Always at least 1.
 pub(crate) fn max_rows_per_insert(num_cols: usize) -> usize {
     if num_cols == 0 {
         return 1;
     }
-    (PARAM_LIMIT / num_cols).max(1)
+    (PARAM_LIMIT.saturating_sub(SP_EXECUTESQL_RESERVED) / num_cols).max(1)
 }
 
 /// Build a multi-row `INSERT` with `@P`-numbered placeholders:
@@ -154,13 +160,20 @@ mod tests {
 
     #[test]
     fn param_split_respects_2100_limit() {
-        // 1 col -> 2100 rows; 3 cols -> 700; 2101 cols -> at least 1.
-        assert_eq!(max_rows_per_insert(1), 2100);
-        assert_eq!(max_rows_per_insert(3), 700);
+        // Usable budget is PARAM_LIMIT - 2 (sp_executesql overhead).
+        // 1 col -> 2098 rows; 3 cols -> 699; wide tables -> at least 1.
+        assert_eq!(max_rows_per_insert(1), 2098);
+        assert_eq!(max_rows_per_insert(3), 699);
         assert_eq!(max_rows_per_insert(0), 1);
         assert_eq!(max_rows_per_insert(5000), 1);
-        // a 10-col table never exceeds the limit in one statement
-        assert!(max_rows_per_insert(10) * 10 <= PARAM_LIMIT);
+        // For any column count, rows*cols PLUS the 2 sp_executesql params must
+        // stay within the hard 2100 limit (this is what the server enforces).
+        for cols in 1..=64 {
+            assert!(
+                max_rows_per_insert(cols) * cols + SP_EXECUTESQL_RESERVED <= PARAM_LIMIT,
+                "cols={cols} exceeds the 2100 limit"
+            );
+        }
     }
 
     #[test]

--- a/crates/sink/mssql/src/encode.rs
+++ b/crates/sink/mssql/src/encode.rs
@@ -50,13 +50,21 @@ impl BoundParam {
 /// `PARAM_LIMIT - 2` — sending a full 2100 bind values overflows by two.
 const SP_EXECUTESQL_RESERVED: usize = 2;
 
-/// Maximum rows per `INSERT` so the request stays within MSSQL's 2100-parameter
-/// limit, accounting for the `sp_executesql` overhead. Always at least 1.
+/// MSSQL's table value constructor (the `VALUES (…), (…), …` clause) allows at
+/// most 1000 row expressions per statement — a separate limit from the 2100
+/// parameters. For narrow tables (1–2 columns) this binds before the parameter
+/// budget does.
+const MAX_VALUES_ROWS: usize = 1000;
+
+/// Maximum rows per `INSERT` so the request stays within **both** of MSSQL's
+/// limits: the 2100-parameter cap (minus the `sp_executesql` overhead) and the
+/// 1000-row-values cap on a `VALUES` clause. Always at least 1.
 pub(crate) fn max_rows_per_insert(num_cols: usize) -> usize {
     if num_cols == 0 {
         return 1;
     }
-    (PARAM_LIMIT.saturating_sub(SP_EXECUTESQL_RESERVED) / num_cols).max(1)
+    let by_params = (PARAM_LIMIT.saturating_sub(SP_EXECUTESQL_RESERVED) / num_cols).max(1);
+    by_params.min(MAX_VALUES_ROWS)
 }
 
 /// Build a multi-row `INSERT` with `@P`-numbered placeholders:
@@ -159,19 +167,25 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn param_split_respects_2100_limit() {
-        // Usable budget is PARAM_LIMIT - 2 (sp_executesql overhead).
-        // 1 col -> 2098 rows; 3 cols -> 699; wide tables -> at least 1.
-        assert_eq!(max_rows_per_insert(1), 2098);
-        assert_eq!(max_rows_per_insert(3), 699);
+    fn param_split_respects_both_mssql_limits() {
+        // Narrow tables are capped by the 1000-row-values limit; wider tables by
+        // the parameter budget (PARAM_LIMIT - 2 sp_executesql params).
+        assert_eq!(max_rows_per_insert(1), 1000); // 2098 params allowed, but row cap is 1000
+        assert_eq!(max_rows_per_insert(2), 1000); // 1049 params allowed, row cap 1000
+        assert_eq!(max_rows_per_insert(3), 699); // 2098/3 = 699 < 1000
         assert_eq!(max_rows_per_insert(0), 1);
         assert_eq!(max_rows_per_insert(5000), 1);
-        // For any column count, rows*cols PLUS the 2 sp_executesql params must
-        // stay within the hard 2100 limit (this is what the server enforces).
+        // For any column count, a single INSERT must satisfy BOTH limits:
+        // (rows*cols + 2 sp params) <= 2100, and rows <= 1000.
         for cols in 1..=64 {
+            let rows = max_rows_per_insert(cols);
             assert!(
-                max_rows_per_insert(cols) * cols + SP_EXECUTESQL_RESERVED <= PARAM_LIMIT,
-                "cols={cols} exceeds the 2100 limit"
+                rows <= MAX_VALUES_ROWS,
+                "cols={cols} exceeds 1000 row values"
+            );
+            assert!(
+                rows * cols + SP_EXECUTESQL_RESERVED <= PARAM_LIMIT,
+                "cols={cols} exceeds the 2100 parameter limit"
             );
         }
     }

--- a/crates/sink/mssql/src/encode.rs
+++ b/crates/sink/mssql/src/encode.rs
@@ -67,7 +67,9 @@ pub(crate) fn build_insert_sql(
     let mut tuples = Vec::with_capacity(num_rows);
     for row in 0..num_rows {
         let start = row * num_cols + 1;
-        let placeholders: Vec<String> = (start..start + num_cols).map(|i| format!("@P{i}")).collect();
+        let placeholders: Vec<String> = (start..start + num_cols)
+            .map(|i| format!("@P{i}"))
+            .collect();
         tuples.push(format!("({})", placeholders.join(", ")));
     }
     format!(
@@ -111,7 +113,10 @@ pub(crate) fn resolve_insert_columns(
                 )));
             }
             OnUnknownField::Warn => {
-                tracing::warn!(?unknown, "auto_columns: dropping record keys with no matching column");
+                tracing::warn!(
+                    ?unknown,
+                    "auto_columns: dropping record keys with no matching column"
+                );
             }
             OnUnknownField::Drop => {}
         }
@@ -195,12 +200,30 @@ mod tests {
 
     #[test]
     fn bound_param_classifies_json() {
-        assert!(matches!(BoundParam::from_value(&json!("s")), BoundParam::Str(_)));
-        assert!(matches!(BoundParam::from_value(&json!(7)), BoundParam::I64(7)));
-        assert!(matches!(BoundParam::from_value(&json!(1.5)), BoundParam::F64(_)));
-        assert!(matches!(BoundParam::from_value(&json!(true)), BoundParam::Bool(true)));
-        assert!(matches!(BoundParam::from_value(&Value::Null), BoundParam::Null(None)));
+        assert!(matches!(
+            BoundParam::from_value(&json!("s")),
+            BoundParam::Str(_)
+        ));
+        assert!(matches!(
+            BoundParam::from_value(&json!(7)),
+            BoundParam::I64(7)
+        ));
+        assert!(matches!(
+            BoundParam::from_value(&json!(1.5)),
+            BoundParam::F64(_)
+        ));
+        assert!(matches!(
+            BoundParam::from_value(&json!(true)),
+            BoundParam::Bool(true)
+        ));
+        assert!(matches!(
+            BoundParam::from_value(&Value::Null),
+            BoundParam::Null(None)
+        ));
         // nested -> serialized string
-        assert!(matches!(BoundParam::from_value(&json!({"k":1})), BoundParam::Str(_)));
+        assert!(matches!(
+            BoundParam::from_value(&json!({"k":1})),
+            BoundParam::Str(_)
+        ));
     }
 }

--- a/crates/sink/mssql/src/encode.rs
+++ b/crates/sink/mssql/src/encode.rs
@@ -1,0 +1,206 @@
+//! Pure helpers for turning JSON records into MSSQL `INSERT` statements and
+//! bound parameters. No I/O — all unit-testable.
+
+use faucet_core::FaucetError;
+use faucet_mssql_common::PARAM_LIMIT;
+use serde_json::Value;
+use tiberius::ToSql;
+
+use crate::config::OnUnknownField;
+
+/// An owned bind parameter, so the `&dyn ToSql` slice handed to `tiberius`
+/// borrows from a value that outlives the call.
+pub(crate) enum BoundParam {
+    I64(i64),
+    F64(f64),
+    Bool(bool),
+    Str(String),
+    Null(Option<i32>),
+}
+
+impl BoundParam {
+    pub(crate) fn from_value(v: &Value) -> Self {
+        match v {
+            Value::String(s) => BoundParam::Str(s.clone()),
+            Value::Number(n) if n.is_i64() => BoundParam::I64(n.as_i64().unwrap()),
+            Value::Number(n) if n.is_u64() => BoundParam::I64(n.as_u64().unwrap() as i64),
+            Value::Number(n) => BoundParam::F64(n.as_f64().unwrap_or(0.0)),
+            Value::Bool(b) => BoundParam::Bool(*b),
+            Value::Null => BoundParam::Null(None),
+            // Arrays/objects are serialized; for a json_column this is the whole
+            // record, for auto_columns it's a nested value bound as NVARCHAR.
+            other => BoundParam::Str(other.to_string()),
+        }
+    }
+
+    pub(crate) fn as_tosql(&self) -> &dyn ToSql {
+        match self {
+            BoundParam::I64(v) => v,
+            BoundParam::F64(v) => v,
+            BoundParam::Bool(v) => v,
+            BoundParam::Str(v) => v,
+            BoundParam::Null(v) => v,
+        }
+    }
+}
+
+/// Maximum rows per `INSERT` so `rows * num_cols` stays within
+/// [`PARAM_LIMIT`]. Always at least 1.
+pub(crate) fn max_rows_per_insert(num_cols: usize) -> usize {
+    if num_cols == 0 {
+        return 1;
+    }
+    (PARAM_LIMIT / num_cols).max(1)
+}
+
+/// Build a multi-row `INSERT` with `@P`-numbered placeholders:
+/// `INSERT INTO <table> (c1, c2) VALUES (@P1, @P2), (@P3, @P4), …`.
+///
+/// `table_quoted` and the `cols_quoted` entries must already be quoted via
+/// `quote_ident_mssql`.
+pub(crate) fn build_insert_sql(
+    table_quoted: &str,
+    cols_quoted: &[String],
+    num_rows: usize,
+) -> String {
+    let num_cols = cols_quoted.len();
+    let mut tuples = Vec::with_capacity(num_rows);
+    for row in 0..num_rows {
+        let start = row * num_cols + 1;
+        let placeholders: Vec<String> = (start..start + num_cols).map(|i| format!("@P{i}")).collect();
+        tuples.push(format!("({})", placeholders.join(", ")));
+    }
+    format!(
+        "INSERT INTO {} ({}) VALUES {}",
+        table_quoted,
+        cols_quoted.join(", "),
+        tuples.join(", ")
+    )
+}
+
+/// Decide the fixed column list for an `auto_columns` batch.
+///
+/// `insertable` is the set of writable table columns (IDENTITY columns already
+/// excluded), in table order. The column list is the insertable columns present
+/// in the first record. Record keys that match no insertable column are
+/// "unknown" and handled per `on_unknown`.
+pub(crate) fn resolve_insert_columns(
+    insertable: &[String],
+    records: &[Value],
+    on_unknown: OnUnknownField,
+) -> Result<Vec<String>, FaucetError> {
+    let insertable_set: std::collections::HashSet<&str> =
+        insertable.iter().map(|s| s.as_str()).collect();
+
+    // Detect unknown keys across the batch.
+    let mut unknown: Vec<String> = Vec::new();
+    for record in records {
+        if let Some(obj) = record.as_object() {
+            for key in obj.keys() {
+                if !insertable_set.contains(key.as_str()) && !unknown.contains(key) {
+                    unknown.push(key.clone());
+                }
+            }
+        }
+    }
+    if !unknown.is_empty() {
+        match on_unknown {
+            OnUnknownField::Error => {
+                return Err(FaucetError::Sink(format!(
+                    "auto_columns: record keys {unknown:?} do not match any writable column"
+                )));
+            }
+            OnUnknownField::Warn => {
+                tracing::warn!(?unknown, "auto_columns: dropping record keys with no matching column");
+            }
+            OnUnknownField::Drop => {}
+        }
+    }
+
+    // Fix the column set from the first record that has any matching key.
+    let first = records.iter().find_map(|r| r.as_object());
+    let columns: Vec<String> = match first {
+        Some(obj) => insertable
+            .iter()
+            .filter(|c| obj.contains_key(c.as_str()))
+            .cloned()
+            .collect(),
+        None => Vec::new(),
+    };
+    Ok(columns)
+}
+
+/// Bind one record's values in `columns` order (SQL NULL for missing keys).
+pub(crate) fn auto_row_params(record: &Value, columns: &[String]) -> Vec<BoundParam> {
+    let obj = record.as_object();
+    columns
+        .iter()
+        .map(|c| {
+            let v = obj.and_then(|o| o.get(c)).unwrap_or(&Value::Null);
+            BoundParam::from_value(v)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn param_split_respects_2100_limit() {
+        // 1 col -> 2100 rows; 3 cols -> 700; 2101 cols -> at least 1.
+        assert_eq!(max_rows_per_insert(1), 2100);
+        assert_eq!(max_rows_per_insert(3), 700);
+        assert_eq!(max_rows_per_insert(0), 1);
+        assert_eq!(max_rows_per_insert(5000), 1);
+        // a 10-col table never exceeds the limit in one statement
+        assert!(max_rows_per_insert(10) * 10 <= PARAM_LIMIT);
+    }
+
+    #[test]
+    fn insert_sql_numbers_placeholders_across_rows() {
+        let sql = build_insert_sql("[dbo].[events]", &["[a]".into(), "[b]".into()], 2);
+        assert_eq!(
+            sql,
+            "INSERT INTO [dbo].[events] ([a], [b]) VALUES (@P1, @P2), (@P3, @P4)"
+        );
+    }
+
+    #[test]
+    fn resolve_columns_fixes_from_first_record() {
+        let insertable = vec!["id".to_string(), "name".to_string(), "age".to_string()];
+        let records = vec![json!({"id": 1, "name": "a"}), json!({"id": 2, "name": "b"})];
+        let cols = resolve_insert_columns(&insertable, &records, OnUnknownField::Warn).unwrap();
+        assert_eq!(cols, vec!["id".to_string(), "name".to_string()]);
+    }
+
+    #[test]
+    fn resolve_columns_errors_on_unknown_when_configured() {
+        let insertable = vec!["id".to_string()];
+        let records = vec![json!({"id": 1, "extra": "x"})];
+        assert!(resolve_insert_columns(&insertable, &records, OnUnknownField::Error).is_err());
+        // Warn/Drop tolerate it.
+        assert!(resolve_insert_columns(&insertable, &records, OnUnknownField::Drop).is_ok());
+    }
+
+    #[test]
+    fn auto_row_params_binds_null_for_missing_keys() {
+        let columns = vec!["id".to_string(), "name".to_string()];
+        let params = auto_row_params(&json!({"id": 7}), &columns);
+        assert_eq!(params.len(), 2);
+        assert!(matches!(params[0], BoundParam::I64(7)));
+        assert!(matches!(params[1], BoundParam::Null(None)));
+    }
+
+    #[test]
+    fn bound_param_classifies_json() {
+        assert!(matches!(BoundParam::from_value(&json!("s")), BoundParam::Str(_)));
+        assert!(matches!(BoundParam::from_value(&json!(7)), BoundParam::I64(7)));
+        assert!(matches!(BoundParam::from_value(&json!(1.5)), BoundParam::F64(_)));
+        assert!(matches!(BoundParam::from_value(&json!(true)), BoundParam::Bool(true)));
+        assert!(matches!(BoundParam::from_value(&Value::Null), BoundParam::Null(None)));
+        // nested -> serialized string
+        assert!(matches!(BoundParam::from_value(&json!({"k":1})), BoundParam::Str(_)));
+    }
+}

--- a/crates/sink/mssql/src/lib.rs
+++ b/crates/sink/mssql/src/lib.rs
@@ -2,5 +2,37 @@
 
 //! # faucet-sink-mssql
 //!
-//! Microsoft SQL Server sink for the faucet-stream ecosystem.
-//! (Implementation in progress.)
+//! Microsoft SQL Server sink for the
+//! [`faucet-stream`](https://crates.io/crates/faucet-stream) ecosystem, built on
+//! [`tiberius`](https://crates.io/crates/tiberius) +
+//! [`bb8-tiberius`](https://crates.io/crates/bb8-tiberius).
+//!
+//! Inserts records via parameterized multi-row `INSERT` statements with
+//! auto-mapped columns or a single JSON column, mirroring `faucet-sink-postgres`
+//! / `mysql` / `sqlite`. Multi-row INSERTs auto-split to stay within MSSQL's
+//! 2100-parameter limit, batches are transaction-wrapped, and per-row failures
+//! are isolated for DLQ routing.
+//!
+//! ```no_run
+//! # use faucet_sink_mssql::{MssqlSink, MssqlSinkConfig};
+//! # async fn run() -> Result<(), faucet_core::FaucetError> {
+//! let cfg = MssqlSinkConfig::new(
+//!     "mssql://sa:Str0ng%40Pass@localhost:1433/sales",
+//!     "dbo.events",
+//! );
+//! let sink = MssqlSink::new(cfg).await?;
+//! # let _ = sink;
+//! # Ok(())
+//! # }
+//! ```
+
+mod config;
+mod encode;
+mod sink;
+
+pub use config::{MssqlColumnMapping, MssqlSinkConfig, OnUnknownField};
+pub use sink::MssqlSink;
+
+// Re-export the shared connection/TLS types so users configure the sink without
+// depending on `faucet-mssql-common` directly.
+pub use faucet_mssql_common::{MssqlConnectionConfig, MssqlTls, MssqlTlsMode};

--- a/crates/sink/mssql/src/lib.rs
+++ b/crates/sink/mssql/src/lib.rs
@@ -1,0 +1,6 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+//! # faucet-sink-mssql
+//!
+//! Microsoft SQL Server sink for the faucet-stream ecosystem.
+//! (Implementation in progress.)

--- a/crates/sink/mssql/src/sink.rs
+++ b/crates/sink/mssql/src/sink.rs
@@ -1,0 +1,396 @@
+//! The MSSQL [`Sink`] implementation — connection pool, transaction-wrapped
+//! multi-row `INSERT` with 2100-parameter auto-splitting, and row-isolation
+//! partial-failure handling for DLQ routing.
+
+use std::sync::Mutex;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use faucet_core::check::{CheckContext, CheckReport, Probe};
+use faucet_core::{FaucetError, RowOutcome, Sink};
+use serde_json::Value;
+use tiberius::ToSql;
+
+use faucet_mssql_common::{
+    MssqlPool, MssqlPooledConnection, build_pool, quote_ident_mssql, with_statement_timeout,
+};
+
+use crate::config::{MssqlColumnMapping, MssqlSinkConfig};
+use crate::encode::{
+    BoundParam, auto_row_params, build_insert_sql, max_rows_per_insert, resolve_insert_columns,
+};
+
+/// Microsoft SQL Server sink.
+pub struct MssqlSink {
+    config: MssqlSinkConfig,
+    pool: MssqlPool,
+    table_quoted: String,
+    /// Cached writable (non-IDENTITY) columns for `auto_columns` mode.
+    columns_cache: Mutex<Option<Vec<String>>>,
+}
+
+impl MssqlSink {
+    /// Connect, validate, build the pool, and (in `json_column` + `create_table`
+    /// mode) create the table if it doesn't exist.
+    pub async fn new(config: MssqlSinkConfig) -> Result<Self, FaucetError> {
+        config.validate()?;
+        let table_quoted = quote_table(&config.table)?;
+        let pool = build_pool(&config.connection, config.max_connections).await?;
+
+        let sink = Self {
+            config,
+            pool,
+            table_quoted,
+            columns_cache: Mutex::new(None),
+        };
+        sink.maybe_create_table().await?;
+        Ok(sink)
+    }
+
+    fn timeout(&self) -> Option<Duration> {
+        match self.config.statement_timeout_secs {
+            0 => None,
+            secs => Some(Duration::from_secs(secs)),
+        }
+    }
+
+    async fn maybe_create_table(&self) -> Result<(), FaucetError> {
+        if !self.config.create_table {
+            return Ok(());
+        }
+        let MssqlColumnMapping::JsonColumn { column } = &self.config.column_mapping else {
+            return Ok(()); // validated: create_table only with json_column
+        };
+        let col = quote_ident_mssql(column)?;
+        let sql = format!(
+            "IF OBJECT_ID(N'{}', N'U') IS NULL \
+             CREATE TABLE {} (id BIGINT IDENTITY(1,1) PRIMARY KEY, {} NVARCHAR(MAX))",
+            self.config.table.replace('\'', "''"),
+            self.table_quoted,
+            col
+        );
+        let mut conn = self.checkout().await?;
+        conn.simple_query(sql.as_str())
+            .await
+            .map_err(|e| FaucetError::Sink(format!("MSSQL create_table failed: {e}")))?
+            .into_results()
+            .await
+            .map_err(|e| FaucetError::Sink(format!("MSSQL create_table failed: {e}")))?;
+        Ok(())
+    }
+
+    async fn checkout(&self) -> Result<MssqlPooledConnection<'_>, FaucetError> {
+        self.pool
+            .get()
+            .await
+            .map_err(|e| FaucetError::Sink(format!("MSSQL pool checkout failed: {e}")))
+    }
+
+    /// Writable (non-IDENTITY) table columns, discovered once and cached.
+    async fn insertable_columns(&self) -> Result<Vec<String>, FaucetError> {
+        if let Some(cols) = self.columns_cache.lock().expect("columns mutex").clone() {
+            return Ok(cols);
+        }
+        let cols = self.discover_columns().await?;
+        *self.columns_cache.lock().expect("columns mutex") = Some(cols.clone());
+        Ok(cols)
+    }
+
+    async fn discover_columns(&self) -> Result<Vec<String>, FaucetError> {
+        let mut conn = self.checkout().await?;
+        let table: &str = &self.config.table;
+        let rows = conn
+            .query(
+                "SELECT c.name AS name FROM sys.columns c \
+                 WHERE c.object_id = OBJECT_ID(@P1) AND c.is_identity = 0 \
+                 ORDER BY c.column_id",
+                &[&table],
+            )
+            .await
+            .map_err(|e| FaucetError::Sink(format!("MSSQL column discovery failed: {e}")))?
+            .into_first_result()
+            .await
+            .map_err(|e| FaucetError::Sink(format!("MSSQL column discovery failed: {e}")))?;
+
+        let mut cols = Vec::with_capacity(rows.len());
+        for row in &rows {
+            if let Some(name) = row.get::<&str, _>("name") {
+                cols.push(name.to_string());
+            }
+        }
+        if cols.is_empty() {
+            return Err(FaucetError::Sink(format!(
+                "MSSQL table '{}' has no writable columns or does not exist",
+                self.config.table
+            )));
+        }
+        Ok(cols)
+    }
+
+    /// Resolve the column list + per-row owned params for one chunk.
+    /// Returns `None` when there is nothing to insert (e.g. auto_columns with no
+    /// matching keys).
+    async fn prepare_chunk(
+        &self,
+        chunk: &[Value],
+    ) -> Result<Option<(Vec<String>, Vec<Vec<BoundParam>>)>, FaucetError> {
+        match &self.config.column_mapping {
+            MssqlColumnMapping::JsonColumn { column } => {
+                let cols = vec![column.clone()];
+                let rows: Vec<Vec<BoundParam>> = chunk
+                    .iter()
+                    .map(|r| vec![BoundParam::Str(serde_json::to_string(r).unwrap_or_default())])
+                    .collect();
+                Ok(Some((cols, rows)))
+            }
+            MssqlColumnMapping::AutoColumns { on_unknown_field } => {
+                let insertable = self.insertable_columns().await?;
+                let cols = resolve_insert_columns(&insertable, chunk, *on_unknown_field)?;
+                if cols.is_empty() {
+                    return Ok(None);
+                }
+                let rows: Vec<Vec<BoundParam>> =
+                    chunk.iter().map(|r| auto_row_params(r, &cols)).collect();
+                Ok(Some((cols, rows)))
+            }
+        }
+    }
+
+    /// Insert one chunk, splitting into ≤2100-parameter sub-INSERTs wrapped in a
+    /// single transaction (when `transaction_per_batch`). Returns rows inserted.
+    async fn insert_chunk(
+        &self,
+        conn: &mut MssqlPooledConnection<'_>,
+        cols: &[String],
+        rows: &[Vec<BoundParam>],
+    ) -> Result<usize, FaucetError> {
+        if rows.is_empty() {
+            return Ok(0);
+        }
+        let cols_quoted: Vec<String> = cols
+            .iter()
+            .map(|c| quote_ident_mssql(c))
+            .collect::<Result<_, _>>()?;
+        let per_insert = max_rows_per_insert(cols_quoted.len());
+
+        let txn = self.config.transaction_per_batch;
+        if txn {
+            control(conn, "BEGIN TRAN").await?;
+        }
+
+        for sub in rows.chunks(per_insert) {
+            let sql = build_insert_sql(&self.table_quoted, &cols_quoted, sub.len());
+            let owned: Vec<&BoundParam> = sub.iter().flatten().collect();
+            let refs: Vec<&dyn ToSql> = owned.iter().map(|p| p.as_tosql()).collect();
+
+            let exec = async {
+                conn.execute(sql.as_str(), &refs)
+                    .await
+                    .map(|_| ())
+                    .map_err(|e| FaucetError::Sink(format!("MSSQL insert failed: {e}")))
+            };
+            let result = match self.timeout() {
+                Some(t) => {
+                    with_statement_timeout(t, exec, || {
+                        FaucetError::Sink("MSSQL insert timed out".into())
+                    })
+                    .await
+                }
+                None => exec.await,
+            };
+            if let Err(e) = result {
+                if txn {
+                    let _ = control(conn, "ROLLBACK TRAN").await;
+                }
+                return Err(e);
+            }
+        }
+
+        if txn {
+            control(conn, "COMMIT TRAN").await?;
+        }
+        Ok(rows.len())
+    }
+}
+
+/// Run a transaction-control statement and drain its (empty) result.
+async fn control(conn: &mut MssqlPooledConnection<'_>, stmt: &str) -> Result<(), FaucetError> {
+    conn.simple_query(stmt)
+        .await
+        .map_err(|e| FaucetError::Sink(format!("MSSQL {stmt} failed: {e}")))?
+        .into_results()
+        .await
+        .map_err(|e| FaucetError::Sink(format!("MSSQL {stmt} failed: {e}")))?;
+    Ok(())
+}
+
+/// Quote a (possibly schema-qualified) table name: `dbo.events` → `[dbo].[events]`.
+fn quote_table(table: &str) -> Result<String, FaucetError> {
+    let parts: Vec<String> = table
+        .split('.')
+        .map(quote_ident_mssql)
+        .collect::<Result<_, _>>()?;
+    Ok(parts.join("."))
+}
+
+/// Heuristic for transient errors that warrant a batch-level retry / outer-Err
+/// propagation rather than per-row DLQ isolation.
+fn is_transient_error(msg: &str) -> bool {
+    let m = msg.to_ascii_lowercase();
+    m.contains("deadlock")
+        || m.contains("timed out")
+        || m.contains("timeout")
+        || m.contains("connection")
+        || m.contains("transport")
+        || m.contains("link failure")
+        || m.contains("1205")
+}
+
+const TRANSIENT_RETRIES: usize = 3;
+
+#[async_trait]
+impl Sink for MssqlSink {
+    async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
+        if records.is_empty() {
+            return Ok(0);
+        }
+        let chunks: Vec<&[Value]> = if self.config.batch_size == 0 {
+            vec![records]
+        } else {
+            records.chunks(self.config.batch_size).collect()
+        };
+
+        let mut total = 0usize;
+        for chunk in chunks {
+            let Some((cols, rows)) = self.prepare_chunk(chunk).await? else {
+                continue;
+            };
+            // Bounded retry on transient (deadlock / lock-timeout) errors.
+            let mut attempt = 0;
+            loop {
+                let mut conn = self.checkout().await?;
+                match self.insert_chunk(&mut conn, &cols, &rows).await {
+                    Ok(n) => {
+                        total += n;
+                        break;
+                    }
+                    Err(e) if is_transient_error(&e.to_string()) && attempt < TRANSIENT_RETRIES => {
+                        attempt += 1;
+                        let backoff = Duration::from_millis(50 * (1 << attempt));
+                        tracing::warn!(attempt, error = %e, "MSSQL transient error; retrying batch");
+                        tokio::time::sleep(backoff).await;
+                    }
+                    Err(e) => return Err(e),
+                }
+            }
+        }
+        tracing::info!(table = %self.config.table, rows = total, "MSSQL write complete");
+        Ok(total)
+    }
+
+    async fn write_batch_partial(&self, records: &[Value]) -> Result<Vec<RowOutcome>, FaucetError> {
+        if records.is_empty() {
+            return Ok(Vec::new());
+        }
+        let chunks: Vec<&[Value]> = if self.config.batch_size == 0 {
+            vec![records]
+        } else {
+            records.chunks(self.config.batch_size).collect()
+        };
+
+        let mut outcomes: Vec<RowOutcome> = Vec::with_capacity(records.len());
+        for chunk in chunks {
+            let Some((cols, rows)) = self.prepare_chunk(chunk).await? else {
+                // Nothing to insert for this chunk (no matching columns): the
+                // rows were effectively dropped per on_unknown_field; report Ok.
+                outcomes.extend(chunk.iter().map(|_| Ok(())));
+                continue;
+            };
+
+            let mut conn = self.checkout().await?;
+            match self.insert_chunk(&mut conn, &cols, &rows).await {
+                Ok(_) => outcomes.extend(chunk.iter().map(|_| Ok(()))),
+                Err(e) if is_transient_error(&e.to_string()) => {
+                    // Infra/transient — not row-specific. Propagate so the
+                    // pipeline's on_batch_error policy decides.
+                    return Err(e);
+                }
+                Err(_) if !self.config.isolate_row_failures => {
+                    // One bad row fails the whole batch (caller's choice).
+                    return Err(FaucetError::Sink(
+                        "MSSQL batch insert failed and isolate_row_failures is disabled".into(),
+                    ));
+                }
+                Err(_) => {
+                    // Row-isolate: retry each row alone to find the offender.
+                    for (i, row) in rows.iter().enumerate() {
+                        let single = std::slice::from_ref(row);
+                        let single_cols = cols.clone();
+                        match self.insert_chunk(&mut conn, &single_cols, single).await {
+                            Ok(_) => outcomes.push(Ok(())),
+                            Err(e) if is_transient_error(&e.to_string()) => return Err(e),
+                            Err(e) => {
+                                tracing::warn!(row = i, error = %e, "MSSQL row rejected; routing to DLQ");
+                                outcomes.push(Err(e));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Ok(outcomes)
+    }
+
+    async fn flush(&self) -> Result<(), FaucetError> {
+        Ok(())
+    }
+
+    fn config_schema(&self) -> Value {
+        serde_json::to_value(faucet_core::schema_for!(MssqlSinkConfig)).expect("schema serialization")
+    }
+
+    fn connector_name(&self) -> &'static str {
+        "mssql"
+    }
+
+    async fn check(&self, ctx: &CheckContext) -> Result<CheckReport, FaucetError> {
+        let started = std::time::Instant::now();
+        let probe = match tokio::time::timeout(ctx.timeout, self.pool.get()).await {
+            Ok(Ok(_conn)) => Probe::pass("connect", started.elapsed()),
+            Ok(Err(e)) => Probe::fail_hint(
+                "connect",
+                started.elapsed(),
+                e.to_string(),
+                "check connection_url / credentials / TLS / that the server is reachable",
+            ),
+            Err(_) => Probe::fail_hint(
+                "connect",
+                started.elapsed(),
+                "timed out",
+                "check connection_url / credentials / TLS / that the server is reachable",
+            ),
+        };
+        Ok(CheckReport::single(probe))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quote_table_handles_schema_qualified() {
+        assert_eq!(quote_table("dbo.events").unwrap(), "[dbo].[events]");
+        assert_eq!(quote_table("events").unwrap(), "[events]");
+        assert_eq!(quote_table("my.sales.events").unwrap(), "[my].[sales].[events]");
+    }
+
+    #[test]
+    fn transient_classifier() {
+        assert!(is_transient_error("Transaction (Process ID 55) was deadlocked"));
+        assert!(is_transient_error("Lock request time out period exceeded (1205)"));
+        assert!(is_transient_error("connection reset by peer"));
+        assert!(!is_transient_error("Violation of PRIMARY KEY constraint"));
+        assert!(!is_transient_error("Conversion failed when converting date"));
+    }
+}

--- a/crates/sink/mssql/src/sink.rs
+++ b/crates/sink/mssql/src/sink.rs
@@ -139,7 +139,11 @@ impl MssqlSink {
                 let cols = vec![column.clone()];
                 let rows: Vec<Vec<BoundParam>> = chunk
                     .iter()
-                    .map(|r| vec![BoundParam::Str(serde_json::to_string(r).unwrap_or_default())])
+                    .map(|r| {
+                        vec![BoundParam::Str(
+                            serde_json::to_string(r).unwrap_or_default(),
+                        )]
+                    })
                     .collect();
                 Ok(Some((cols, rows)))
             }
@@ -346,7 +350,8 @@ impl Sink for MssqlSink {
     }
 
     fn config_schema(&self) -> Value {
-        serde_json::to_value(faucet_core::schema_for!(MssqlSinkConfig)).expect("schema serialization")
+        serde_json::to_value(faucet_core::schema_for!(MssqlSinkConfig))
+            .expect("schema serialization")
     }
 
     fn connector_name(&self) -> &'static str {
@@ -382,15 +387,24 @@ mod tests {
     fn quote_table_handles_schema_qualified() {
         assert_eq!(quote_table("dbo.events").unwrap(), "[dbo].[events]");
         assert_eq!(quote_table("events").unwrap(), "[events]");
-        assert_eq!(quote_table("my.sales.events").unwrap(), "[my].[sales].[events]");
+        assert_eq!(
+            quote_table("my.sales.events").unwrap(),
+            "[my].[sales].[events]"
+        );
     }
 
     #[test]
     fn transient_classifier() {
-        assert!(is_transient_error("Transaction (Process ID 55) was deadlocked"));
-        assert!(is_transient_error("Lock request time out period exceeded (1205)"));
+        assert!(is_transient_error(
+            "Transaction (Process ID 55) was deadlocked"
+        ));
+        assert!(is_transient_error(
+            "Lock request time out period exceeded (1205)"
+        ));
         assert!(is_transient_error("connection reset by peer"));
         assert!(!is_transient_error("Violation of PRIMARY KEY constraint"));
-        assert!(!is_transient_error("Conversion failed when converting date"));
+        assert!(!is_transient_error(
+            "Conversion failed when converting date"
+        ));
     }
 }

--- a/crates/sink/mssql/tests/integration.rs
+++ b/crates/sink/mssql/tests/integration.rs
@@ -1,0 +1,152 @@
+//! Integration tests against a real Microsoft SQL Server in Docker.
+//!
+//! Requires Docker (the `mcr.microsoft.com/mssql/server` image). Run with:
+//! `cargo test -p faucet-sink-mssql --test integration`.
+
+use faucet_core::Sink;
+use faucet_mssql_common::{MssqlConnectionConfig, MssqlPool, MssqlTls, MssqlTlsMode, build_pool};
+use faucet_sink_mssql::{MssqlColumnMapping, MssqlSink, MssqlSinkConfig};
+use serde_json::{Value, json};
+use testcontainers_modules::mssql_server::MssqlServer;
+use testcontainers_modules::testcontainers::ContainerAsync;
+use testcontainers_modules::testcontainers::runners::AsyncRunner;
+
+const ENCODED_PW: &str = "yourStrong%28%21%29Password";
+
+async fn start_mssql() -> (ContainerAsync<MssqlServer>, u16) {
+    let container = MssqlServer::default()
+        .with_accept_eula()
+        .start()
+        .await
+        .expect("start mssql container");
+    let port = container
+        .get_host_port_ipv4(1433)
+        .await
+        .expect("mssql host port");
+    (container, port)
+}
+
+fn conn_cfg(port: u16) -> MssqlConnectionConfig {
+    MssqlConnectionConfig {
+        connection_url: Some(format!("mssql://sa:{ENCODED_PW}@127.0.0.1:{port}/master")),
+        connection_string: None,
+        tls: MssqlTls {
+            mode: MssqlTlsMode::TrustServerCertificate,
+            ca_cert_path: None,
+        },
+    }
+}
+
+async fn exec(pool: &MssqlPool, sql: &str) {
+    let mut conn = pool.get().await.expect("checkout");
+    conn.execute(sql, &[]).await.expect("execute setup sql");
+}
+
+async fn count(pool: &MssqlPool, table: &str) -> i32 {
+    let mut conn = pool.get().await.expect("checkout");
+    let rows = conn
+        .query(format!("SELECT COUNT(*) AS c FROM {table}"), &[])
+        .await
+        .expect("count query")
+        .into_first_result()
+        .await
+        .expect("count result");
+    rows[0].get::<i32, _>("c").expect("count value")
+}
+
+fn sink_cfg(cfg: &MssqlConnectionConfig, table: &str) -> MssqlSinkConfig {
+    let mut s = MssqlSinkConfig::new(cfg.connection_url.clone().unwrap(), table);
+    s.connection.tls = cfg.tls.clone();
+    s
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn auto_columns_bulk_write_splits_param_limit() {
+    let (_c, port) = start_mssql().await;
+    let cfg = conn_cfg(port);
+    let pool = build_pool(&cfg, 4).await.expect("pool");
+
+    exec(&pool, "CREATE TABLE dbo.bulk (id INT, name NVARCHAR(50))").await;
+
+    let mut scfg = sink_cfg(&cfg, "dbo.bulk");
+    scfg.column_mapping = MssqlColumnMapping::AutoColumns {
+        on_unknown_field: faucet_sink_mssql::OnUnknownField::Warn,
+    };
+    // batch_size 0 forces the whole 5000-row page through one write_batch, so
+    // the 2100-parameter auto-split (5000 rows * 2 cols = 10000 params) is hit.
+    scfg.batch_size = 0;
+    let sink = MssqlSink::new(scfg).await.expect("sink");
+
+    let records: Vec<Value> = (1..=5000)
+        .map(|i| json!({"id": i, "name": format!("user-{i}")}))
+        .collect();
+    let written = sink.write_batch(&records).await.expect("write");
+    assert_eq!(written, 5000);
+    assert_eq!(count(&pool, "dbo.bulk").await, 5000);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn row_isolation_routes_only_the_bad_row() {
+    let (_c, port) = start_mssql().await;
+    let cfg = conn_cfg(port);
+    let pool = build_pool(&cfg, 4).await.expect("pool");
+
+    exec(&pool, "CREATE TABLE dbo.strict (id INT NOT NULL, n INT NOT NULL)").await;
+
+    let mut scfg = sink_cfg(&cfg, "dbo.strict");
+    scfg.column_mapping = MssqlColumnMapping::AutoColumns {
+        on_unknown_field: faucet_sink_mssql::OnUnknownField::Warn,
+    };
+    let sink = MssqlSink::new(scfg).await.expect("sink");
+
+    // Row 3 is missing `n` -> binds NULL -> violates NOT NULL.
+    let records = vec![
+        json!({"id": 1, "n": 10}),
+        json!({"id": 2, "n": 20}),
+        json!({"id": 3}),
+    ];
+    let outcomes = sink.write_batch_partial(&records).await.expect("partial write");
+    assert_eq!(outcomes.len(), 3);
+    assert!(outcomes[0].is_ok(), "row 1 ok");
+    assert!(outcomes[1].is_ok(), "row 2 ok");
+    assert!(outcomes[2].is_err(), "row 3 (NULL into NOT NULL) -> DLQ");
+
+    // Only the two good rows persisted.
+    assert_eq!(count(&pool, "dbo.strict").await, 2);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn json_column_with_create_table() {
+    let (_c, port) = start_mssql().await;
+    let cfg = conn_cfg(port);
+    let pool = build_pool(&cfg, 4).await.expect("pool");
+
+    let mut scfg = sink_cfg(&cfg, "dbo.payloads");
+    scfg.column_mapping = MssqlColumnMapping::JsonColumn {
+        column: "body".into(),
+    };
+    scfg.create_table = true;
+    // new() should create the table (id IDENTITY + body NVARCHAR(MAX)).
+    let sink = MssqlSink::new(scfg).await.expect("sink creates table");
+
+    let written = sink
+        .write_batch(&[json!({"a": 1, "nested": {"x": true}}), json!({"b": 2})])
+        .await
+        .expect("write");
+    assert_eq!(written, 2);
+    assert_eq!(count(&pool, "dbo.payloads").await, 2);
+
+    // The body column holds the serialized JSON.
+    let mut conn = pool.get().await.unwrap();
+    let rows = conn
+        .query("SELECT body FROM dbo.payloads ORDER BY id", &[])
+        .await
+        .unwrap()
+        .into_first_result()
+        .await
+        .unwrap();
+    let first: &str = rows[0].get("body").unwrap();
+    let parsed: Value = serde_json::from_str(first).unwrap();
+    assert_eq!(parsed["a"], json!(1));
+    assert_eq!(parsed["nested"]["x"], json!(true));
+}

--- a/crates/sink/mssql/tests/integration.rs
+++ b/crates/sink/mssql/tests/integration.rs
@@ -72,9 +72,9 @@ async fn auto_columns_bulk_write_splits_param_limit() {
     let cfg = conn_cfg(port);
     let pool = build_pool(&cfg, 4).await.expect("pool");
 
-    exec(&pool, "CREATE TABLE dbo.bulk (id INT, name NVARCHAR(50))").await;
+    exec(&pool, "CREATE TABLE dbo.bulk_rows (id INT, name NVARCHAR(50))").await;
 
-    let mut scfg = sink_cfg(&cfg, "dbo.bulk");
+    let mut scfg = sink_cfg(&cfg, "dbo.bulk_rows");
     scfg.column_mapping = MssqlColumnMapping::AutoColumns {
         on_unknown_field: faucet_sink_mssql::OnUnknownField::Warn,
     };
@@ -88,7 +88,7 @@ async fn auto_columns_bulk_write_splits_param_limit() {
         .collect();
     let written = sink.write_batch(&records).await.expect("write");
     assert_eq!(written, 5000);
-    assert_eq!(count(&pool, "dbo.bulk").await, 5000);
+    assert_eq!(count(&pool, "dbo.bulk_rows").await, 5000);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/sink/mssql/tests/integration.rs
+++ b/crates/sink/mssql/tests/integration.rs
@@ -72,7 +72,11 @@ async fn auto_columns_bulk_write_splits_param_limit() {
     let cfg = conn_cfg(port);
     let pool = build_pool(&cfg, 4).await.expect("pool");
 
-    exec(&pool, "CREATE TABLE dbo.bulk_rows (id INT, name NVARCHAR(50))").await;
+    exec(
+        &pool,
+        "CREATE TABLE dbo.bulk_rows (id INT, name NVARCHAR(50))",
+    )
+    .await;
 
     let mut scfg = sink_cfg(&cfg, "dbo.bulk_rows");
     scfg.column_mapping = MssqlColumnMapping::AutoColumns {

--- a/crates/sink/mssql/tests/integration.rs
+++ b/crates/sink/mssql/tests/integration.rs
@@ -13,6 +13,11 @@ use testcontainers_modules::testcontainers::runners::AsyncRunner;
 
 const ENCODED_PW: &str = "yourStrong%28%21%29Password";
 
+// SQL Server containers need ~2 GB RAM each. `cargo test` runs a binary's tests
+// in parallel, so without this guard all three would start a container at once
+// and exhaust the CI runner. Serialize them: at most one container at a time.
+static SERIAL: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
 async fn start_mssql() -> (ContainerAsync<MssqlServer>, u16) {
     let container = MssqlServer::default()
         .with_accept_eula()
@@ -62,6 +67,7 @@ fn sink_cfg(cfg: &MssqlConnectionConfig, table: &str) -> MssqlSinkConfig {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn auto_columns_bulk_write_splits_param_limit() {
+    let _serial = SERIAL.lock().await;
     let (_c, port) = start_mssql().await;
     let cfg = conn_cfg(port);
     let pool = build_pool(&cfg, 4).await.expect("pool");
@@ -87,6 +93,7 @@ async fn auto_columns_bulk_write_splits_param_limit() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn row_isolation_routes_only_the_bad_row() {
+    let _serial = SERIAL.lock().await;
     let (_c, port) = start_mssql().await;
     let cfg = conn_cfg(port);
     let pool = build_pool(&cfg, 4).await.expect("pool");
@@ -124,6 +131,7 @@ async fn row_isolation_routes_only_the_bad_row() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn json_column_with_create_table() {
+    let _serial = SERIAL.lock().await;
     let (_c, port) = start_mssql().await;
     let cfg = conn_cfg(port);
     let pool = build_pool(&cfg, 4).await.expect("pool");

--- a/crates/sink/mssql/tests/integration.rs
+++ b/crates/sink/mssql/tests/integration.rs
@@ -91,7 +91,11 @@ async fn row_isolation_routes_only_the_bad_row() {
     let cfg = conn_cfg(port);
     let pool = build_pool(&cfg, 4).await.expect("pool");
 
-    exec(&pool, "CREATE TABLE dbo.strict (id INT NOT NULL, n INT NOT NULL)").await;
+    exec(
+        &pool,
+        "CREATE TABLE dbo.strict (id INT NOT NULL, n INT NOT NULL)",
+    )
+    .await;
 
     let mut scfg = sink_cfg(&cfg, "dbo.strict");
     scfg.column_mapping = MssqlColumnMapping::AutoColumns {
@@ -105,7 +109,10 @@ async fn row_isolation_routes_only_the_bad_row() {
         json!({"id": 2, "n": 20}),
         json!({"id": 3}),
     ];
-    let outcomes = sink.write_batch_partial(&records).await.expect("partial write");
+    let outcomes = sink
+        .write_batch_partial(&records)
+        .await
+        .expect("partial write");
     assert_eq!(outcomes.len(), 3);
     assert!(outcomes[0].is_ok(), "row 1 ok");
     assert!(outcomes[1].is_ok(), "row 2 ok");

--- a/crates/source/mssql/Cargo.toml
+++ b/crates/source/mssql/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "faucet-source-mssql"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Microsoft SQL Server query source connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords = ["mssql", "sqlserver", "sql", "etl", "pipeline"]
+categories.workspace = true
+
+[dependencies]
+faucet-core.workspace = true
+faucet-mssql-common.workspace = true
+schemars.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+async-trait.workspace = true
+tracing.workspace = true
+tiberius.workspace = true
+bb8.workspace = true
+bb8-tiberius.workspace = true
+rust_decimal.workspace = true
+chrono.workspace = true
+uuid.workspace = true
+base64.workspace = true
+async-stream.workspace = true
+futures.workspace = true
+tokio.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+serde_json.workspace = true
+futures.workspace = true
+testcontainers = "0.27"
+testcontainers-modules = { version = "0.15", features = ["mssql_server"] }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/source/mssql/Cargo.toml
+++ b/crates/source/mssql/Cargo.toml
@@ -31,7 +31,7 @@ url.workspace = true
 tokio.workspace = true
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync"] }
 serde_json.workspace = true
 futures.workspace = true
 testcontainers = "0.27"

--- a/crates/source/mssql/Cargo.toml
+++ b/crates/source/mssql/Cargo.toml
@@ -27,6 +27,7 @@ uuid.workspace = true
 base64.workspace = true
 async-stream.workspace = true
 futures.workspace = true
+url.workspace = true
 tokio.workspace = true
 
 [dev-dependencies]

--- a/crates/source/mssql/README.md
+++ b/crates/source/mssql/README.md
@@ -1,0 +1,88 @@
+# faucet-source-mssql
+
+Microsoft SQL Server query source for the
+[`faucet-stream`](https://crates.io/crates/faucet-stream) ecosystem. Runs
+parameterized SQL, streams rows as JSON, and supports incremental replication
+via a tracking column. Built on [`tiberius`](https://crates.io/crates/tiberius)
++ [`bb8-tiberius`](https://crates.io/crates/bb8-tiberius).
+
+## Config
+
+```yaml
+source:
+  type: mssql
+  config:
+    # connection_url OR connection_string (exactly one)
+    connection_url: "mssql://sa:Str0ng%40Pass@localhost:1433/sales"
+    # connection_string: "Server=tcp:localhost,1433;Database=sales;User Id=sa;Password=...;"
+
+    query: "SELECT id, email, updated_at FROM dbo.users WHERE updated_at > @bookmark"
+
+    params: []                 # positional @P1, @P2, … bind params
+    max_connections: 10
+    batch_size: 1000           # rows per emitted page; 0 = whole result set in one page
+    statement_timeout_secs: 300  # 0 disables
+
+    tls:
+      type: prefer             # prefer | require | trust_server_certificate | disable
+      ca_cert_path: null
+
+    replication:
+      type: incremental        # full | incremental
+      column: updated_at
+      initial_value: "1970-01-01T00:00:00Z"
+```
+
+URL credentials with special characters must be percent-encoded
+(`@`→`%40`, `:`→`%3A`, `/`→`%2F`). See
+[`faucet-mssql-common`](https://crates.io/crates/faucet-mssql-common) for the
+full connection / TLS reference.
+
+## Incremental replication
+
+Set `replication.type: incremental` with a `column` (the cursor) and an
+`initial_value` (the lower bound on the first run). Across runs the source emits
+only rows whose `column` is strictly greater than the stored bookmark, and
+persists the new maximum on the final page.
+
+- **Server-side pushdown:** put the literal token `@bookmark` in your `WHERE`
+  clause (e.g. `WHERE updated_at > @bookmark`). The source binds the cursor
+  there so SQL Server does the filtering.
+- **Backstop:** whether or not you use `@bookmark`, the source *also* filters
+  client-side, so correctness never depends on the query text. (Without
+  `@bookmark` the full result set is fetched and filtered in memory — fine for
+  small tables, but prefer `@bookmark` for large ones.)
+
+`@bookmark` is a reserved token; don't use it as an identifier.
+
+## Type mapping
+
+| MSSQL | JSON |
+|-------|------|
+| TINYINT / SMALLINT / INT / BIGINT | number |
+| REAL / FLOAT | number |
+| BIT | bool |
+| DECIMAL / NUMERIC / MONEY | string (precision-preserving) |
+| CHAR / VARCHAR / NCHAR / NVARCHAR / TEXT / NTEXT / XML | string |
+| DATE | `YYYY-MM-DD` |
+| TIME | ISO time |
+| DATETIME / DATETIME2 / SMALLDATETIME | ISO 8601 (no offset) |
+| DATETIMEOFFSET | RFC 3339 (offset preserved) |
+| UNIQUEIDENTIFIER | hyphenated string |
+| BINARY / VARBINARY / IMAGE | base64 string |
+| SQL NULL | `null` |
+
+## Auth
+
+SQL Server authentication (username + password) only in v1. Windows / Integrated
+authentication and Azure AD / Managed Identity are out of scope.
+
+## Testing
+
+Unit tests run with `cargo test -p faucet-source-mssql --lib`. The integration
+tests (`--test integration`) require Docker (the `mcr.microsoft.com/mssql/server`
+image).
+
+## License
+
+MIT OR Apache-2.0.

--- a/crates/source/mssql/src/config.rs
+++ b/crates/source/mssql/src/config.rs
@@ -109,12 +109,12 @@ impl MssqlSourceConfig {
     pub fn validate(&self) -> Result<(), FaucetError> {
         self.connection.validate()?;
         validate_batch_size(self.batch_size)?;
-        if let MssqlReplication::Incremental { column, .. } = &self.replication {
-            if column.trim().is_empty() {
-                return Err(FaucetError::Config(
-                    "MSSQL incremental replication requires a non-empty `column`".into(),
-                ));
-            }
+        if let MssqlReplication::Incremental { column, .. } = &self.replication
+            && column.trim().is_empty()
+        {
+            return Err(FaucetError::Config(
+                "MSSQL incremental replication requires a non-empty `column`".into(),
+            ));
         }
         Ok(())
     }

--- a/crates/source/mssql/src/config.rs
+++ b/crates/source/mssql/src/config.rs
@@ -1,0 +1,196 @@
+//! Configuration for the MSSQL query source.
+
+use faucet_core::{DEFAULT_BATCH_SIZE, FaucetError, validate_batch_size};
+use faucet_mssql_common::MssqlConnectionConfig;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+fn default_max_connections() -> u32 {
+    10
+}
+fn default_batch_size() -> usize {
+    DEFAULT_BATCH_SIZE
+}
+fn default_statement_timeout_secs() -> u64 {
+    300
+}
+
+/// How the source replicates rows across runs.
+///
+/// Serializes as `{ type: full }` or
+/// `{ type: incremental, column: "...", initial_value: ... }`.
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, Default, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum MssqlReplication {
+    /// Every run fetches the full result set (default).
+    #[default]
+    Full,
+    /// Only rows whose `column` is strictly greater than the stored bookmark
+    /// (or `initial_value` on the first run) are emitted.
+    ///
+    /// The bookmark is applied two ways: if the query contains the literal
+    /// token `@bookmark`, it is bound as a parameter so the server filters
+    /// (efficient); the source *also* filters client-side as a correctness
+    /// backstop. The new maximum of `column` is persisted on the final page.
+    Incremental {
+        /// Column whose value is the replication cursor (e.g. `updated_at`).
+        column: String,
+        /// Lower bound used on the first run, before any bookmark is stored.
+        initial_value: Value,
+    },
+}
+
+/// Configuration for [`MssqlSource`](crate::MssqlSource).
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
+pub struct MssqlSourceConfig {
+    /// Connection + TLS settings (`connection_url` or `connection_string`).
+    #[serde(flatten)]
+    pub connection: MssqlConnectionConfig,
+    /// SQL query to run. Use `@P1`, `@P2`, … for [`params`](Self::params), and
+    /// the literal `@bookmark` token to bind the incremental cursor server-side.
+    pub query: String,
+    /// Positional bind parameters for the query (`@P1`…`@Pn`). Defaults to empty.
+    #[serde(default)]
+    pub params: Vec<Value>,
+    /// Maximum pooled connections. Defaults to 10.
+    #[serde(default = "default_max_connections")]
+    pub max_connections: u32,
+    /// Records per emitted [`StreamPage`](faucet_core::StreamPage). `0` emits the
+    /// whole result set as a single page. Defaults to [`DEFAULT_BATCH_SIZE`].
+    #[serde(default = "default_batch_size")]
+    pub batch_size: usize,
+    /// Per-query timeout in seconds (`0` disables). Defaults to 300.
+    #[serde(default = "default_statement_timeout_secs")]
+    pub statement_timeout_secs: u64,
+    /// Replication mode. Defaults to [`MssqlReplication::Full`].
+    #[serde(default)]
+    pub replication: MssqlReplication,
+    /// Explicit state-store key for the bookmark. When unset, a key is derived
+    /// from the connection host and a query fingerprint.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state_key: Option<String>,
+}
+
+impl std::fmt::Debug for MssqlSourceConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MssqlSourceConfig")
+            .field("connection", &"***")
+            .field("query", &self.query)
+            .field("params", &self.params)
+            .field("max_connections", &self.max_connections)
+            .field("batch_size", &self.batch_size)
+            .field("statement_timeout_secs", &self.statement_timeout_secs)
+            .field("replication", &self.replication)
+            .field("state_key", &self.state_key)
+            .finish()
+    }
+}
+
+impl MssqlSourceConfig {
+    /// Build a config from a connection URL and query, with defaults elsewhere.
+    pub fn new(connection_url: impl Into<String>, query: impl Into<String>) -> Self {
+        Self {
+            connection: MssqlConnectionConfig {
+                connection_url: Some(connection_url.into()),
+                ..Default::default()
+            },
+            query: query.into(),
+            params: Vec::new(),
+            max_connections: default_max_connections(),
+            batch_size: default_batch_size(),
+            statement_timeout_secs: default_statement_timeout_secs(),
+            replication: MssqlReplication::Full,
+            state_key: None,
+        }
+    }
+
+    /// Validate connection source, batch size, and replication settings.
+    pub fn validate(&self) -> Result<(), FaucetError> {
+        self.connection.validate()?;
+        validate_batch_size(self.batch_size)?;
+        if let MssqlReplication::Incremental { column, .. } = &self.replication {
+            if column.trim().is_empty() {
+                return Err(FaucetError::Config(
+                    "MSSQL incremental replication requires a non-empty `column`".into(),
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn replication_full_is_default_and_round_trips() {
+        let r: MssqlReplication = serde_json::from_value(json!({"type": "full"})).unwrap();
+        assert_eq!(r, MssqlReplication::Full);
+        assert_eq!(MssqlReplication::default(), MssqlReplication::Full);
+    }
+
+    #[test]
+    fn replication_incremental_parses_column_and_initial_value() {
+        let r: MssqlReplication = serde_json::from_value(json!({
+            "type": "incremental",
+            "column": "updated_at",
+            "initial_value": "1970-01-01T00:00:00Z"
+        }))
+        .unwrap();
+        assert_eq!(
+            r,
+            MssqlReplication::Incremental {
+                column: "updated_at".into(),
+                initial_value: json!("1970-01-01T00:00:00Z"),
+            }
+        );
+    }
+
+    #[test]
+    fn config_flattens_connection_fields() {
+        let cfg: MssqlSourceConfig = serde_json::from_value(json!({
+            "connection_url": "mssql://sa:pw@host:1433/db",
+            "query": "SELECT 1",
+        }))
+        .unwrap();
+        assert_eq!(
+            cfg.connection.connection_url.as_deref(),
+            Some("mssql://sa:pw@host:1433/db")
+        );
+        assert_eq!(cfg.batch_size, DEFAULT_BATCH_SIZE);
+        assert_eq!(cfg.max_connections, 10);
+        assert_eq!(cfg.statement_timeout_secs, 300);
+    }
+
+    #[test]
+    fn validate_rejects_incremental_without_column() {
+        let cfg = MssqlSourceConfig {
+            replication: MssqlReplication::Incremental {
+                column: "  ".into(),
+                initial_value: json!(0),
+            },
+            ..MssqlSourceConfig::new("mssql://sa:pw@h/db", "SELECT 1")
+        };
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_bad_batch_size() {
+        let cfg = MssqlSourceConfig {
+            batch_size: faucet_core::MAX_BATCH_SIZE + 1,
+            ..MssqlSourceConfig::new("mssql://sa:pw@h/db", "SELECT 1")
+        };
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn debug_masks_connection() {
+        let cfg = MssqlSourceConfig::new("mssql://sa:secret@h/db", "SELECT 1");
+        let dbg = format!("{cfg:?}");
+        assert!(dbg.contains("***"));
+        assert!(!dbg.contains("secret"));
+    }
+}

--- a/crates/source/mssql/src/convert.rs
+++ b/crates/source/mssql/src/convert.rs
@@ -1,0 +1,184 @@
+//! Decode a `tiberius` [`Row`] into a `serde_json` object.
+//!
+//! Non-temporal columns are decoded directly from their [`ColumnData`] variant
+//! (the variant carries the exact width, so there's no integer-size guessing).
+//! Temporal columns are decoded through [`Row::try_get`] with `chrono` target
+//! types so the conversion uses `tiberius`' own (correct) epoch math rather than
+//! a re-implementation here.
+
+use base64::Engine;
+use chrono::{FixedOffset, NaiveDate, NaiveDateTime, NaiveTime};
+use faucet_core::FaucetError;
+use serde_json::{Map, Value, json};
+use tiberius::numeric::Numeric;
+use tiberius::{ColumnData, Row};
+
+/// Decode every column of `row` into a JSON object keyed by column name.
+pub fn row_to_json(row: &Row) -> Result<Value, FaucetError> {
+    let mut map = Map::with_capacity(row.columns().len());
+    // Collect names up front (cells borrows the row immutably for the iterator;
+    // we also call try_get — another shared borrow — for temporal columns).
+    let names: Vec<String> = row.columns().iter().map(|c| c.name().to_string()).collect();
+    for (i, (_col, data)) in row.cells().enumerate() {
+        let value = match scalar_to_json(data) {
+            Some(v) => v,
+            None => decode_temporal(row, i, data)?,
+        };
+        map.insert(names[i].clone(), value);
+    }
+    Ok(Value::Object(map))
+}
+
+/// Convert a non-temporal [`ColumnData`] to JSON.
+///
+/// Returns `Some(Value::Null)` for a SQL NULL in a non-temporal column, and
+/// `None` for temporal variants — the caller decodes those via
+/// [`decode_temporal`] (which needs the [`Row`] for `try_get`).
+fn scalar_to_json(data: &ColumnData<'_>) -> Option<Value> {
+    let v = match data {
+        ColumnData::U8(o) => o.map(|n| json!(n)),
+        ColumnData::I16(o) => o.map(|n| json!(n)),
+        ColumnData::I32(o) => o.map(|n| json!(n)),
+        ColumnData::I64(o) => o.map(|n| json!(n)),
+        ColumnData::F32(o) => o.map(|f| json!(f)),
+        ColumnData::F64(o) => o.map(|f| json!(f)),
+        ColumnData::Bit(o) => o.map(|b| json!(b)),
+        ColumnData::String(o) => o.as_ref().map(|s| json!(s.as_ref())),
+        ColumnData::Guid(o) => o.map(|g| json!(g.to_string())),
+        ColumnData::Binary(o) => o
+            .as_ref()
+            .map(|b| json!(base64::engine::general_purpose::STANDARD.encode(b.as_ref()))),
+        ColumnData::Numeric(o) => o.map(|n| json!(numeric_to_string(n))),
+        ColumnData::Xml(o) => o.as_ref().map(|x| json!(x.as_ref().clone().into_string())),
+        // Temporal variants are decoded by the caller via try_get.
+        ColumnData::DateTime(_)
+        | ColumnData::SmallDateTime(_)
+        | ColumnData::Date(_)
+        | ColumnData::Time(_)
+        | ColumnData::DateTime2(_)
+        | ColumnData::DateTimeOffset(_) => return None,
+    };
+    // A present non-temporal column yields its value; a NULL yields JSON null.
+    Some(v.unwrap_or(Value::Null))
+}
+
+fn decode_temporal(row: &Row, idx: usize, data: &ColumnData<'_>) -> Result<Value, FaucetError> {
+    let conv = |e: tiberius::error::Error| {
+        FaucetError::Source(format!("MSSQL column {idx} temporal decode failed: {e}"))
+    };
+    let value = match data {
+        ColumnData::Date(_) => row
+            .try_get::<NaiveDate, _>(idx)
+            .map_err(conv)?
+            .map(|d| json!(d.to_string())),
+        ColumnData::Time(_) => row
+            .try_get::<NaiveTime, _>(idx)
+            .map_err(conv)?
+            .map(|t| json!(t.to_string())),
+        ColumnData::DateTime(_) | ColumnData::SmallDateTime(_) | ColumnData::DateTime2(_) => row
+            .try_get::<NaiveDateTime, _>(idx)
+            .map_err(conv)?
+            .map(|dt| json!(dt.format("%Y-%m-%dT%H:%M:%S%.f").to_string())),
+        ColumnData::DateTimeOffset(_) => row
+            .try_get::<chrono::DateTime<FixedOffset>, _>(idx)
+            .map_err(conv)?
+            .map(|dt| json!(dt.to_rfc3339())),
+        _ => unreachable!("decode_temporal called on a non-temporal column"),
+    };
+    Ok(value.unwrap_or(Value::Null))
+}
+
+/// Format an MSSQL DECIMAL/NUMERIC value as a precision-preserving string
+/// (JSON numbers can't represent arbitrary-precision decimals — mirrors the
+/// postgres source's NUMERIC-as-string behaviour).
+pub(crate) fn numeric_to_string(n: Numeric) -> String {
+    let scale = n.scale() as usize;
+    let mantissa = n.value();
+    if scale == 0 {
+        return mantissa.to_string();
+    }
+    let negative = mantissa < 0;
+    // unsigned_abs avoids i128::MIN overflow.
+    let mut digits = mantissa.unsigned_abs().to_string();
+    if digits.len() <= scale {
+        // pad with leading zeros so there is at least one integer digit.
+        digits = format!("{:0>width$}", digits, width = scale + 1);
+    }
+    let split = digits.len() - scale;
+    let (int_part, frac_part) = digits.split_at(split);
+    format!(
+        "{}{}.{}",
+        if negative { "-" } else { "" },
+        int_part,
+        frac_part
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::borrow::Cow;
+
+    #[test]
+    fn numeric_formats_with_scale() {
+        assert_eq!(numeric_to_string(Numeric::new_with_scale(12345, 2)), "123.45");
+        assert_eq!(numeric_to_string(Numeric::new_with_scale(100, 0)), "100");
+        // value < 1 must keep a leading zero
+        assert_eq!(numeric_to_string(Numeric::new_with_scale(5, 2)), "0.05");
+        // negatives must not corrupt the fractional part
+        assert_eq!(numeric_to_string(Numeric::new_with_scale(-150, 2)), "-1.50");
+        assert_eq!(numeric_to_string(Numeric::new_with_scale(-5, 2)), "-0.05");
+    }
+
+    #[test]
+    fn scalar_integers_and_floats() {
+        assert_eq!(scalar_to_json(&ColumnData::I32(Some(42))), Some(json!(42)));
+        assert_eq!(scalar_to_json(&ColumnData::U8(Some(7))), Some(json!(7)));
+        assert_eq!(scalar_to_json(&ColumnData::I16(Some(-3))), Some(json!(-3)));
+        assert_eq!(
+            scalar_to_json(&ColumnData::I64(Some(9_000_000_000))),
+            Some(json!(9_000_000_000i64))
+        );
+        assert_eq!(scalar_to_json(&ColumnData::F64(Some(1.5))), Some(json!(1.5)));
+    }
+
+    #[test]
+    fn scalar_bool_string_guid() {
+        assert_eq!(scalar_to_json(&ColumnData::Bit(Some(true))), Some(json!(true)));
+        assert_eq!(
+            scalar_to_json(&ColumnData::String(Some(Cow::Borrowed("hi")))),
+            Some(json!("hi"))
+        );
+        let id = tiberius::Uuid::nil();
+        assert_eq!(
+            scalar_to_json(&ColumnData::Guid(Some(id))),
+            Some(json!("00000000-0000-0000-0000-000000000000"))
+        );
+    }
+
+    #[test]
+    fn scalar_binary_is_base64() {
+        // bytes [1,2,3] -> base64 "AQID"
+        let data = ColumnData::Binary(Some(Cow::Borrowed(&[1u8, 2, 3][..])));
+        assert_eq!(scalar_to_json(&data), Some(json!("AQID")));
+    }
+
+    #[test]
+    fn scalar_numeric_is_string() {
+        let data = ColumnData::Numeric(Some(Numeric::new_with_scale(12345, 2)));
+        assert_eq!(scalar_to_json(&data), Some(json!("123.45")));
+    }
+
+    #[test]
+    fn scalar_null_is_json_null_not_temporal_none() {
+        assert_eq!(scalar_to_json(&ColumnData::I32(None)), Some(Value::Null));
+        assert_eq!(scalar_to_json(&ColumnData::String(None)), Some(Value::Null));
+    }
+
+    #[test]
+    fn temporal_variants_defer_to_caller() {
+        assert_eq!(scalar_to_json(&ColumnData::Date(None)), None);
+        assert_eq!(scalar_to_json(&ColumnData::DateTime2(None)), None);
+        assert_eq!(scalar_to_json(&ColumnData::DateTimeOffset(None)), None);
+    }
+}

--- a/crates/source/mssql/src/convert.rs
+++ b/crates/source/mssql/src/convert.rs
@@ -121,7 +121,10 @@ mod tests {
 
     #[test]
     fn numeric_formats_with_scale() {
-        assert_eq!(numeric_to_string(Numeric::new_with_scale(12345, 2)), "123.45");
+        assert_eq!(
+            numeric_to_string(Numeric::new_with_scale(12345, 2)),
+            "123.45"
+        );
         assert_eq!(numeric_to_string(Numeric::new_with_scale(100, 0)), "100");
         // value < 1 must keep a leading zero
         assert_eq!(numeric_to_string(Numeric::new_with_scale(5, 2)), "0.05");
@@ -139,12 +142,18 @@ mod tests {
             scalar_to_json(&ColumnData::I64(Some(9_000_000_000))),
             Some(json!(9_000_000_000i64))
         );
-        assert_eq!(scalar_to_json(&ColumnData::F64(Some(1.5))), Some(json!(1.5)));
+        assert_eq!(
+            scalar_to_json(&ColumnData::F64(Some(1.5))),
+            Some(json!(1.5))
+        );
     }
 
     #[test]
     fn scalar_bool_string_guid() {
-        assert_eq!(scalar_to_json(&ColumnData::Bit(Some(true))), Some(json!(true)));
+        assert_eq!(
+            scalar_to_json(&ColumnData::Bit(Some(true))),
+            Some(json!(true))
+        );
         assert_eq!(
             scalar_to_json(&ColumnData::String(Some(Cow::Borrowed("hi")))),
             Some(json!("hi"))

--- a/crates/source/mssql/src/lib.rs
+++ b/crates/source/mssql/src/lib.rs
@@ -2,5 +2,36 @@
 
 //! # faucet-source-mssql
 //!
-//! Microsoft SQL Server query source for the faucet-stream ecosystem.
-//! (Implementation in progress.)
+//! Microsoft SQL Server query source for the
+//! [`faucet-stream`](https://crates.io/crates/faucet-stream) ecosystem, built on
+//! [`tiberius`](https://crates.io/crates/tiberius) +
+//! [`bb8-tiberius`](https://crates.io/crates/bb8-tiberius).
+//!
+//! Runs parameterized SQL, streams rows as JSON [`StreamPage`](faucet_core::StreamPage)s
+//! through a connection pool, and supports incremental replication via a tracking
+//! column (see [`MssqlReplication`]). Mirrors the `faucet-source-postgres` /
+//! `mysql` / `sqlite` query sources.
+//!
+//! ```no_run
+//! # use faucet_source_mssql::{MssqlSource, MssqlSourceConfig};
+//! # async fn run() -> Result<(), faucet_core::FaucetError> {
+//! let cfg = MssqlSourceConfig::new(
+//!     "mssql://sa:Str0ng%40Pass@localhost:1433/sales",
+//!     "SELECT id, email, updated_at FROM dbo.users",
+//! );
+//! let source = MssqlSource::new(cfg).await?;
+//! # let _ = source;
+//! # Ok(())
+//! # }
+//! ```
+
+mod config;
+mod convert;
+mod stream;
+
+pub use config::{MssqlReplication, MssqlSourceConfig};
+pub use stream::MssqlSource;
+
+// Re-export the shared connection/TLS types so users configure the source
+// without depending on `faucet-mssql-common` directly.
+pub use faucet_mssql_common::{MssqlConnectionConfig, MssqlTls, MssqlTlsMode};

--- a/crates/source/mssql/src/lib.rs
+++ b/crates/source/mssql/src/lib.rs
@@ -1,0 +1,6 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+//! # faucet-source-mssql
+//!
+//! Microsoft SQL Server query source for the faucet-stream ecosystem.
+//! (Implementation in progress.)

--- a/crates/source/mssql/src/stream.rs
+++ b/crates/source/mssql/src/stream.rs
@@ -95,7 +95,9 @@ fn build_query_and_params(
             column,
             initial_value,
         } => {
-            let start = start_bookmark.cloned().unwrap_or_else(|| initial_value.clone());
+            let start = start_bookmark
+                .cloned()
+                .unwrap_or_else(|| initial_value.clone());
             // Server-side pushdown: bind the cursor where the user wrote
             // `@bookmark`. If absent, only the client-side filter applies.
             if query.contains("@bookmark") {
@@ -164,7 +166,13 @@ fn default_state_key(config: &MssqlSourceConfig) -> String {
     // Host may contain dots (allowed mid-key); sanitise anything else.
     let host: String = host
         .chars()
-        .map(|c| if c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.') { c } else { '_' })
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.') {
+                c
+            } else {
+                '_'
+            }
+        })
         .collect();
     format!("mssql:{host}:{fingerprint:016x}")
 }
@@ -191,7 +199,11 @@ impl Source for MssqlSource {
         _batch_size: usize,
     ) -> Pin<Box<dyn Stream<Item = Result<StreamPage, FaucetError>> + Send + 'a>> {
         let batch_size = self.config.batch_size;
-        let chunk = if batch_size == 0 { usize::MAX } else { batch_size };
+        let chunk = if batch_size == 0 {
+            usize::MAX
+        } else {
+            batch_size
+        };
         let cap = if batch_size == 0 { 1024 } else { batch_size };
         let start = self.current_start();
         let (query, values, incr) = build_query_and_params(&self.config, context, start.as_ref());
@@ -259,7 +271,8 @@ impl Source for MssqlSource {
     }
 
     fn config_schema(&self) -> Value {
-        serde_json::to_value(faucet_core::schema_for!(MssqlSourceConfig)).expect("schema serialization")
+        serde_json::to_value(faucet_core::schema_for!(MssqlSourceConfig))
+            .expect("schema serialization")
     }
 
     fn connector_name(&self) -> &'static str {
@@ -279,7 +292,10 @@ impl Source for MssqlSource {
     }
 
     async fn apply_start_bookmark(&self, bookmark: Value) -> Result<(), FaucetError> {
-        *self.start_bookmark.lock().expect("start_bookmark mutex poisoned") = Some(bookmark);
+        *self
+            .start_bookmark
+            .lock()
+            .expect("start_bookmark mutex poisoned") = Some(bookmark);
         Ok(())
     }
 
@@ -455,17 +471,38 @@ mod tests {
 
     #[test]
     fn owned_param_classifies_json() {
-        assert!(matches!(OwnedParam::from_value(&json!("s")), OwnedParam::Str(_)));
-        assert!(matches!(OwnedParam::from_value(&json!(7)), OwnedParam::I64(7)));
-        assert!(matches!(OwnedParam::from_value(&json!(1.5)), OwnedParam::F64(_)));
-        assert!(matches!(OwnedParam::from_value(&json!(true)), OwnedParam::Bool(true)));
-        assert!(matches!(OwnedParam::from_value(&Value::Null), OwnedParam::Null(None)));
-        assert!(matches!(OwnedParam::from_value(&json!({"a":1})), OwnedParam::Str(_)));
+        assert!(matches!(
+            OwnedParam::from_value(&json!("s")),
+            OwnedParam::Str(_)
+        ));
+        assert!(matches!(
+            OwnedParam::from_value(&json!(7)),
+            OwnedParam::I64(7)
+        ));
+        assert!(matches!(
+            OwnedParam::from_value(&json!(1.5)),
+            OwnedParam::F64(_)
+        ));
+        assert!(matches!(
+            OwnedParam::from_value(&json!(true)),
+            OwnedParam::Bool(true)
+        ));
+        assert!(matches!(
+            OwnedParam::from_value(&Value::Null),
+            OwnedParam::Null(None)
+        ));
+        assert!(matches!(
+            OwnedParam::from_value(&json!({"a":1})),
+            OwnedParam::Str(_)
+        ));
     }
 
     #[test]
     fn apply_incremental_filters_and_tracks_max() {
-        let ctx = IncrementalCtx { column: "c".into(), start: json!(10) };
+        let ctx = IncrementalCtx {
+            column: "c".into(),
+            start: json!(10),
+        };
         let mut running = None;
         let page = vec![json!({"c": 5}), json!({"c": 15}), json!({"c": 20})];
         let kept = apply_incremental(page, Some(&ctx), &mut running);

--- a/crates/source/mssql/src/stream.rs
+++ b/crates/source/mssql/src/stream.rs
@@ -1,0 +1,494 @@
+//! The MSSQL [`Source`] implementation — connection pool, query execution,
+//! streaming, and incremental-replication bookkeeping.
+
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
+use std::pin::Pin;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use faucet_core::check::{CheckContext, CheckReport, Probe};
+use faucet_core::replication::{filter_incremental, max_replication_value, max_value};
+use faucet_core::{FaucetError, Source, StreamPage};
+use futures::{Stream, TryStreamExt};
+use serde_json::Value;
+use tiberius::{QueryItem, ToSql};
+
+use faucet_mssql_common::{MssqlPool, build_pool, with_statement_timeout};
+
+use crate::config::{MssqlReplication, MssqlSourceConfig};
+use crate::convert::row_to_json;
+
+/// Microsoft SQL Server query source.
+pub struct MssqlSource {
+    config: MssqlSourceConfig,
+    pool: MssqlPool,
+    /// Bookmark loaded via [`Source::apply_start_bookmark`]; overrides the
+    /// configured `initial_value` for incremental runs.
+    start_bookmark: Mutex<Option<Value>>,
+}
+
+impl MssqlSource {
+    /// Connect, validate the config, and build the connection pool.
+    pub async fn new(config: MssqlSourceConfig) -> Result<Self, FaucetError> {
+        config.validate()?;
+        let pool = build_pool(&config.connection, config.max_connections).await?;
+        Ok(Self {
+            config,
+            pool,
+            start_bookmark: Mutex::new(None),
+        })
+    }
+
+    fn timeout(&self) -> Option<Duration> {
+        match self.config.statement_timeout_secs {
+            0 => None,
+            secs => Some(Duration::from_secs(secs)),
+        }
+    }
+
+    fn current_start(&self) -> Option<Value> {
+        self.start_bookmark
+            .lock()
+            .expect("start_bookmark mutex poisoned")
+            .clone()
+    }
+}
+
+/// Incremental-replication context resolved for one run.
+#[derive(Debug, Clone, PartialEq)]
+struct IncrementalCtx {
+    column: String,
+    start: Value,
+}
+
+/// Build the final query string, the ordered bind values, and (for incremental
+/// runs) the client-side filter context.
+///
+/// Pure function (no pool) so it is unit-testable. Param order is:
+/// `config.params` → context-substituted values → the incremental bookmark
+/// (only when the query contains the `@bookmark` token).
+fn build_query_and_params(
+    config: &MssqlSourceConfig,
+    context: &HashMap<String, Value>,
+    start_bookmark: Option<&Value>,
+) -> (String, Vec<Value>, Option<IncrementalCtx>) {
+    // Resolve parent-context placeholders to positional @P markers.
+    let (mut query, mut values) = if context.is_empty() {
+        (config.query.clone(), config.params.clone())
+    } else {
+        let (q, ctx_values) = faucet_core::util::substitute_context_bind_params(
+            &config.query,
+            context,
+            config.params.len() + 1,
+            |i| format!("@P{i}"),
+        );
+        let mut v = config.params.clone();
+        v.extend(ctx_values);
+        (q, v)
+    };
+
+    let incremental = match &config.replication {
+        MssqlReplication::Full => None,
+        MssqlReplication::Incremental {
+            column,
+            initial_value,
+        } => {
+            let start = start_bookmark.cloned().unwrap_or_else(|| initial_value.clone());
+            // Server-side pushdown: bind the cursor where the user wrote
+            // `@bookmark`. If absent, only the client-side filter applies.
+            if query.contains("@bookmark") {
+                let idx = values.len() + 1;
+                query = query.replace("@bookmark", &format!("@P{idx}"));
+                values.push(start.clone());
+            }
+            Some(IncrementalCtx {
+                column: column.clone(),
+                start,
+            })
+        }
+    };
+
+    (query, values, incremental)
+}
+
+/// Owned bind parameter, so the borrowed `&dyn ToSql` slice handed to
+/// `tiberius` outlives nothing it shouldn't.
+enum OwnedParam {
+    I64(i64),
+    F64(f64),
+    Bool(bool),
+    Str(String),
+    Null(Option<i32>),
+}
+
+impl OwnedParam {
+    fn from_value(v: &Value) -> Self {
+        match v {
+            Value::String(s) => OwnedParam::Str(s.clone()),
+            Value::Number(n) if n.is_i64() => OwnedParam::I64(n.as_i64().unwrap()),
+            Value::Number(n) if n.is_u64() => OwnedParam::I64(n.as_u64().unwrap() as i64),
+            Value::Number(n) => OwnedParam::F64(n.as_f64().unwrap_or(0.0)),
+            Value::Bool(b) => OwnedParam::Bool(*b),
+            Value::Null => OwnedParam::Null(None),
+            other => OwnedParam::Str(other.to_string()),
+        }
+    }
+
+    fn as_tosql(&self) -> &dyn ToSql {
+        match self {
+            OwnedParam::I64(v) => v,
+            OwnedParam::F64(v) => v,
+            OwnedParam::Bool(v) => v,
+            OwnedParam::Str(v) => v,
+            OwnedParam::Null(v) => v,
+        }
+    }
+}
+
+/// Derive a default state-store key from the connection host + a query
+/// fingerprint, stable across runs.
+fn default_state_key(config: &MssqlSourceConfig) -> String {
+    let host = config
+        .connection
+        .connection_url
+        .as_deref()
+        .and_then(|u| url::Url::parse(u).ok())
+        .and_then(|u| u.host_str().map(|h| h.to_string()))
+        .unwrap_or_else(|| "mssql".to_string());
+
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    config.query.hash(&mut hasher);
+    let fingerprint = hasher.finish();
+    // Host may contain dots (allowed mid-key); sanitise anything else.
+    let host: String = host
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.') { c } else { '_' })
+        .collect();
+    format!("mssql:{host}:{fingerprint:016x}")
+}
+
+#[async_trait]
+impl Source for MssqlSource {
+    async fn fetch_with_context(
+        &self,
+        context: &HashMap<String, Value>,
+    ) -> Result<Vec<Value>, FaucetError> {
+        Ok(self.collect_all(context).await?.0)
+    }
+
+    async fn fetch_with_context_incremental(
+        &self,
+        context: &HashMap<String, Value>,
+    ) -> Result<(Vec<Value>, Option<Value>), FaucetError> {
+        self.collect_all(context).await
+    }
+
+    fn stream_pages<'a>(
+        &'a self,
+        context: &'a HashMap<String, Value>,
+        _batch_size: usize,
+    ) -> Pin<Box<dyn Stream<Item = Result<StreamPage, FaucetError>> + Send + 'a>> {
+        let batch_size = self.config.batch_size;
+        let chunk = if batch_size == 0 { usize::MAX } else { batch_size };
+        let cap = if batch_size == 0 { 1024 } else { batch_size };
+        let start = self.current_start();
+        let (query, values, incr) = build_query_and_params(&self.config, context, start.as_ref());
+
+        Box::pin(async_stream::try_stream! {
+            let mut conn = self
+                .pool
+                .get()
+                .await
+                .map_err(|e| FaucetError::Source(format!("MSSQL pool checkout failed: {e}")))?;
+
+            // Scope the borrowed param slice to the query() call — the
+            // QueryStream borrows the connection, not the params.
+            let mut stream = {
+                let owned: Vec<OwnedParam> = values.iter().map(OwnedParam::from_value).collect();
+                let refs: Vec<&dyn ToSql> = owned.iter().map(OwnedParam::as_tosql).collect();
+                let query_fut = conn.query(&query, &refs);
+                match self.timeout() {
+                    Some(t) => {
+                        with_statement_timeout(t, async {
+                            query_fut.await.map_err(|e| {
+                                FaucetError::Source(format!("MSSQL query failed: {e}"))
+                            })
+                        }, || FaucetError::Source("MSSQL query timed out".into()))
+                        .await?
+                    }
+                    None => query_fut
+                        .await
+                        .map_err(|e| FaucetError::Source(format!("MSSQL query failed: {e}")))?,
+                }
+            };
+
+            let mut buffer: Vec<Value> = Vec::with_capacity(cap);
+            let mut running_max: Option<Value> = None;
+            let mut total = 0usize;
+
+            while let Some(item) = stream
+                .try_next()
+                .await
+                .map_err(|e| FaucetError::Source(format!("MSSQL row stream failed: {e}")))?
+            {
+                let QueryItem::Row(row) = item else { continue };
+                buffer.push(row_to_json(&row)?);
+                if buffer.len() >= chunk {
+                    let page = std::mem::replace(&mut buffer, Vec::with_capacity(cap));
+                    let kept = apply_incremental(page, incr.as_ref(), &mut running_max);
+                    total += kept.len();
+                    if !kept.is_empty() {
+                        yield StreamPage { records: kept, bookmark: None };
+                    }
+                }
+            }
+
+            // Final page carries the bookmark so the pipeline persists only
+            // after everything before it has been written.
+            let kept = apply_incremental(buffer, incr.as_ref(), &mut running_max);
+            total += kept.len();
+            let bookmark = if incr.is_some() { running_max.clone() } else { None };
+            if !kept.is_empty() || bookmark.is_some() {
+                yield StreamPage { records: kept, bookmark };
+            }
+
+            tracing::info!(rows = total, query = %self.config.query, "MSSQL source stream complete");
+        })
+    }
+
+    fn config_schema(&self) -> Value {
+        serde_json::to_value(faucet_core::schema_for!(MssqlSourceConfig)).expect("schema serialization")
+    }
+
+    fn connector_name(&self) -> &'static str {
+        "mssql"
+    }
+
+    fn state_key(&self) -> Option<String> {
+        match &self.config.replication {
+            MssqlReplication::Full => None,
+            MssqlReplication::Incremental { .. } => Some(
+                self.config
+                    .state_key
+                    .clone()
+                    .unwrap_or_else(|| default_state_key(&self.config)),
+            ),
+        }
+    }
+
+    async fn apply_start_bookmark(&self, bookmark: Value) -> Result<(), FaucetError> {
+        *self.start_bookmark.lock().expect("start_bookmark mutex poisoned") = Some(bookmark);
+        Ok(())
+    }
+
+    async fn check(&self, ctx: &CheckContext) -> Result<CheckReport, FaucetError> {
+        let started = std::time::Instant::now();
+        let probe = match tokio::time::timeout(ctx.timeout, self.pool.get()).await {
+            Ok(Ok(_conn)) => Probe::pass("connect", started.elapsed()),
+            Ok(Err(e)) => Probe::fail_hint(
+                "connect",
+                started.elapsed(),
+                e.to_string(),
+                "check connection_url / credentials / TLS / that the server is reachable",
+            ),
+            Err(_) => Probe::fail_hint(
+                "connect",
+                started.elapsed(),
+                "timed out",
+                "check connection_url / credentials / TLS / that the server is reachable",
+            ),
+        };
+        Ok(CheckReport::single(probe))
+    }
+}
+
+impl MssqlSource {
+    /// Run the query and return all decoded rows plus (for incremental) the new
+    /// bookmark. Used by the non-streaming convenience methods.
+    async fn collect_all(
+        &self,
+        context: &HashMap<String, Value>,
+    ) -> Result<(Vec<Value>, Option<Value>), FaucetError> {
+        let start = self.current_start();
+        let (query, values, incr) = build_query_and_params(&self.config, context, start.as_ref());
+
+        let mut conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| FaucetError::Source(format!("MSSQL pool checkout failed: {e}")))?;
+
+        let rows = {
+            let owned: Vec<OwnedParam> = values.iter().map(OwnedParam::from_value).collect();
+            let refs: Vec<&dyn ToSql> = owned.iter().map(OwnedParam::as_tosql).collect();
+            let run = async {
+                conn.query(&query, &refs)
+                    .await
+                    .map_err(|e| FaucetError::Source(format!("MSSQL query failed: {e}")))?
+                    .into_first_result()
+                    .await
+                    .map_err(|e| FaucetError::Source(format!("MSSQL result read failed: {e}")))
+            };
+            match self.timeout() {
+                Some(t) => {
+                    with_statement_timeout(t, run, || {
+                        FaucetError::Source("MSSQL query timed out".into())
+                    })
+                    .await?
+                }
+                None => run.await?,
+            }
+        };
+
+        let mut records = Vec::with_capacity(rows.len());
+        for row in &rows {
+            records.push(row_to_json(row)?);
+        }
+
+        let mut running_max: Option<Value> = None;
+        let records = apply_incremental(records, incr.as_ref(), &mut running_max);
+        let bookmark = if incr.is_some() { running_max } else { None };
+        Ok((records, bookmark))
+    }
+}
+
+/// Filter a page for incremental replication and advance `running_max`.
+/// For full replication the page passes through unchanged.
+fn apply_incremental(
+    page: Vec<Value>,
+    incr: Option<&IncrementalCtx>,
+    running_max: &mut Option<Value>,
+) -> Vec<Value> {
+    match incr {
+        None => page,
+        Some(ctx) => {
+            let kept = filter_incremental(page, &ctx.column, &ctx.start);
+            if let Some(m) = max_replication_value(&kept, &ctx.column) {
+                let m = m.clone();
+                *running_max = Some(match running_max.take() {
+                    Some(prev) => max_value(prev, m),
+                    None => m,
+                });
+            }
+            kept
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn full_cfg() -> MssqlSourceConfig {
+        MssqlSourceConfig::new("mssql://sa:pw@db.example.com:1433/sales", "SELECT * FROM t")
+    }
+
+    #[test]
+    fn build_full_returns_query_and_params_unchanged() {
+        let mut cfg = full_cfg();
+        cfg.params = vec![json!(1), json!("x")];
+        let (q, v, incr) = build_query_and_params(&cfg, &HashMap::new(), None);
+        assert_eq!(q, "SELECT * FROM t");
+        assert_eq!(v, vec![json!(1), json!("x")]);
+        assert!(incr.is_none());
+    }
+
+    #[test]
+    fn build_incremental_binds_bookmark_token() {
+        let cfg = MssqlSourceConfig {
+            query: "SELECT * FROM t WHERE updated_at > @bookmark".into(),
+            replication: MssqlReplication::Incremental {
+                column: "updated_at".into(),
+                initial_value: json!("1970-01-01"),
+            },
+            ..full_cfg()
+        };
+        let (q, v, incr) = build_query_and_params(&cfg, &HashMap::new(), None);
+        assert_eq!(q, "SELECT * FROM t WHERE updated_at > @P1");
+        assert_eq!(v, vec![json!("1970-01-01")]);
+        assert_eq!(
+            incr,
+            Some(IncrementalCtx {
+                column: "updated_at".into(),
+                start: json!("1970-01-01")
+            })
+        );
+    }
+
+    #[test]
+    fn build_incremental_uses_stored_bookmark_over_initial() {
+        let cfg = MssqlSourceConfig {
+            query: "SELECT * FROM t WHERE c > @bookmark".into(),
+            params: vec![json!("p0")],
+            replication: MssqlReplication::Incremental {
+                column: "c".into(),
+                initial_value: json!(0),
+            },
+            ..full_cfg()
+        };
+        let stored = json!(500);
+        let (q, v, incr) = build_query_and_params(&cfg, &HashMap::new(), Some(&stored));
+        // bookmark bound after the one configured param → @P2
+        assert_eq!(q, "SELECT * FROM t WHERE c > @P2");
+        assert_eq!(v, vec![json!("p0"), json!(500)]);
+        assert_eq!(incr.unwrap().start, json!(500));
+    }
+
+    #[test]
+    fn build_incremental_without_token_still_returns_filter_ctx() {
+        let cfg = MssqlSourceConfig {
+            query: "SELECT * FROM t".into(),
+            replication: MssqlReplication::Incremental {
+                column: "c".into(),
+                initial_value: json!(0),
+            },
+            ..full_cfg()
+        };
+        let (q, v, incr) = build_query_and_params(&cfg, &HashMap::new(), None);
+        assert_eq!(q, "SELECT * FROM t");
+        assert!(v.is_empty());
+        assert!(incr.is_some(), "client-side filter must still run");
+    }
+
+    #[test]
+    fn owned_param_classifies_json() {
+        assert!(matches!(OwnedParam::from_value(&json!("s")), OwnedParam::Str(_)));
+        assert!(matches!(OwnedParam::from_value(&json!(7)), OwnedParam::I64(7)));
+        assert!(matches!(OwnedParam::from_value(&json!(1.5)), OwnedParam::F64(_)));
+        assert!(matches!(OwnedParam::from_value(&json!(true)), OwnedParam::Bool(true)));
+        assert!(matches!(OwnedParam::from_value(&Value::Null), OwnedParam::Null(None)));
+        assert!(matches!(OwnedParam::from_value(&json!({"a":1})), OwnedParam::Str(_)));
+    }
+
+    #[test]
+    fn apply_incremental_filters_and_tracks_max() {
+        let ctx = IncrementalCtx { column: "c".into(), start: json!(10) };
+        let mut running = None;
+        let page = vec![json!({"c": 5}), json!({"c": 15}), json!({"c": 20})];
+        let kept = apply_incremental(page, Some(&ctx), &mut running);
+        assert_eq!(kept.len(), 2);
+        assert_eq!(running, Some(json!(20)));
+    }
+
+    #[test]
+    fn apply_incremental_full_passes_through() {
+        let mut running = None;
+        let page = vec![json!({"c": 1}), json!({"c": 2})];
+        let kept = apply_incremental(page, None, &mut running);
+        assert_eq!(kept.len(), 2);
+        assert_eq!(running, None);
+    }
+
+    #[test]
+    fn default_state_key_is_stable_and_valid() {
+        let cfg = full_cfg();
+        let k1 = default_state_key(&cfg);
+        let k2 = default_state_key(&cfg);
+        assert_eq!(k1, k2);
+        assert!(k1.starts_with("mssql:db.example.com:"));
+        faucet_core::state::validate_state_key(&k1).expect("derived key must be valid");
+    }
+}

--- a/crates/source/mssql/tests/integration.rs
+++ b/crates/source/mssql/tests/integration.rs
@@ -16,6 +16,11 @@ use testcontainers_modules::testcontainers::runners::AsyncRunner;
 /// `yourStrong(!)Password` percent-encoded for a URL userinfo segment.
 const ENCODED_PW: &str = "yourStrong%28%21%29Password";
 
+// SQL Server containers need ~2 GB RAM each. `cargo test` runs a binary's tests
+// in parallel; serialize them so at most one container runs at a time and the
+// CI runner doesn't run out of memory.
+static SERIAL: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
 async fn start_mssql() -> (ContainerAsync<MssqlServer>, u16) {
     let container = MssqlServer::default()
         .with_accept_eula()
@@ -47,6 +52,7 @@ async fn exec(pool: &faucet_mssql_common::MssqlPool, sql: &str) {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn decodes_column_types_and_streams_pages() {
+    let _serial = SERIAL.lock().await;
     let (_c, port) = start_mssql().await;
     let cfg = conn_cfg(port);
     let pool = build_pool(&cfg, 4).await.expect("pool");
@@ -135,6 +141,7 @@ async fn decodes_column_types_and_streams_pages() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn incremental_resumes_without_duplicates() {
+    let _serial = SERIAL.lock().await;
     let (_c, port) = start_mssql().await;
     let cfg = conn_cfg(port);
     let pool = build_pool(&cfg, 4).await.expect("pool");

--- a/crates/source/mssql/tests/integration.rs
+++ b/crates/source/mssql/tests/integration.rs
@@ -92,11 +92,17 @@ async fn decodes_column_types_and_streams_pages() {
     assert_eq!(r["price"], Value::from("19.99")); // DECIMAL -> string
     assert_eq!(r["active"], Value::from(true)); // BIT -> bool
     assert!(
-        r["created"].as_str().unwrap().starts_with("2024-01-02T03:04:05"),
+        r["created"]
+            .as_str()
+            .unwrap()
+            .starts_with("2024-01-02T03:04:05"),
         "datetime2 -> {}",
         r["created"]
     );
-    assert_eq!(r["uid"], Value::from("00000000-0000-0000-0000-000000000001"));
+    assert_eq!(
+        r["uid"],
+        Value::from("00000000-0000-0000-0000-000000000001")
+    );
     assert_eq!(r["payload"], Value::from("AQID")); // 0x010203 -> base64
     assert_eq!(r["big"], Value::from(9_000_000_000_i64));
     assert_eq!(r["ratio"], Value::from(1.5));
@@ -133,7 +139,11 @@ async fn incremental_resumes_without_duplicates() {
     let cfg = conn_cfg(port);
     let pool = build_pool(&cfg, 4).await.expect("pool");
 
-    exec(&pool, "CREATE TABLE dbo.events (id INT, updated_at NVARCHAR(30))").await;
+    exec(
+        &pool,
+        "CREATE TABLE dbo.events (id INT, updated_at NVARCHAR(30))",
+    )
+    .await;
     for (id, ts) in [(1, "2024-01-01"), (2, "2024-02-01"), (3, "2024-03-01")] {
         exec(
             &pool,
@@ -160,7 +170,10 @@ async fn incremental_resumes_without_duplicates() {
     assert_eq!(bookmark, Some(Value::from("2024-03-01")));
 
     // Persist the bookmark, add a newer row, run again.
-    source.apply_start_bookmark(bookmark.unwrap()).await.unwrap();
+    source
+        .apply_start_bookmark(bookmark.unwrap())
+        .await
+        .unwrap();
     exec(
         &pool,
         "INSERT INTO dbo.events (id, updated_at) VALUES (4, '2024-04-01')",

--- a/crates/source/mssql/tests/integration.rs
+++ b/crates/source/mssql/tests/integration.rs
@@ -1,0 +1,175 @@
+//! Integration tests against a real Microsoft SQL Server in Docker.
+//!
+//! Requires Docker (the `mcr.microsoft.com/mssql/server` image). Run with:
+//! `cargo test -p faucet-source-mssql --test integration`. These are skipped by
+//! a plain `cargo test --lib` (unit tests), mirroring the postgres/kafka pattern.
+
+use faucet_core::Source;
+use faucet_mssql_common::{MssqlConnectionConfig, MssqlTls, MssqlTlsMode, build_pool};
+use faucet_source_mssql::{MssqlReplication, MssqlSource, MssqlSourceConfig};
+use futures::StreamExt;
+use serde_json::Value;
+use testcontainers_modules::mssql_server::MssqlServer;
+use testcontainers_modules::testcontainers::ContainerAsync;
+use testcontainers_modules::testcontainers::runners::AsyncRunner;
+
+/// `yourStrong(!)Password` percent-encoded for a URL userinfo segment.
+const ENCODED_PW: &str = "yourStrong%28%21%29Password";
+
+async fn start_mssql() -> (ContainerAsync<MssqlServer>, u16) {
+    let container = MssqlServer::default()
+        .with_accept_eula()
+        .start()
+        .await
+        .expect("start mssql container");
+    let port = container
+        .get_host_port_ipv4(1433)
+        .await
+        .expect("mssql host port");
+    (container, port)
+}
+
+fn conn_cfg(port: u16) -> MssqlConnectionConfig {
+    MssqlConnectionConfig {
+        connection_url: Some(format!("mssql://sa:{ENCODED_PW}@127.0.0.1:{port}/master")),
+        connection_string: None,
+        tls: MssqlTls {
+            mode: MssqlTlsMode::TrustServerCertificate,
+            ca_cert_path: None,
+        },
+    }
+}
+
+async fn exec(pool: &faucet_mssql_common::MssqlPool, sql: &str) {
+    let mut conn = pool.get().await.expect("checkout");
+    conn.execute(sql, &[]).await.expect("execute setup sql");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn decodes_column_types_and_streams_pages() {
+    let (_c, port) = start_mssql().await;
+    let cfg = conn_cfg(port);
+    let pool = build_pool(&cfg, 4).await.expect("pool");
+
+    exec(
+        &pool,
+        "CREATE TABLE dbo.types_test (
+            id INT NOT NULL,
+            name NVARCHAR(50),
+            price DECIMAL(10,2),
+            active BIT,
+            created DATETIME2,
+            uid UNIQUEIDENTIFIER,
+            payload VARBINARY(8),
+            big BIGINT,
+            ratio FLOAT,
+            maybe INT
+        )",
+    )
+    .await;
+    exec(
+        &pool,
+        "INSERT INTO dbo.types_test
+            (id, name, price, active, created, uid, payload, big, ratio, maybe)
+         VALUES
+            (1, N'alice', 19.99, 1, '2024-01-02T03:04:05',
+             '00000000-0000-0000-0000-000000000001', 0x010203, 9000000000, 1.5, NULL)",
+    )
+    .await;
+
+    let mut scfg = MssqlSourceConfig::new(
+        cfg.connection_url.clone().unwrap(),
+        "SELECT id, name, price, active, created, uid, payload, big, ratio, maybe FROM dbo.types_test",
+    );
+    scfg.connection.tls = cfg.tls.clone();
+    let source = MssqlSource::new(scfg).await.expect("source");
+
+    let rows = source.fetch_all().await.expect("fetch");
+    assert_eq!(rows.len(), 1);
+    let r = &rows[0];
+    assert_eq!(r["id"], Value::from(1));
+    assert_eq!(r["name"], Value::from("alice"));
+    assert_eq!(r["price"], Value::from("19.99")); // DECIMAL -> string
+    assert_eq!(r["active"], Value::from(true)); // BIT -> bool
+    assert!(
+        r["created"].as_str().unwrap().starts_with("2024-01-02T03:04:05"),
+        "datetime2 -> {}",
+        r["created"]
+    );
+    assert_eq!(r["uid"], Value::from("00000000-0000-0000-0000-000000000001"));
+    assert_eq!(r["payload"], Value::from("AQID")); // 0x010203 -> base64
+    assert_eq!(r["big"], Value::from(9_000_000_000_i64));
+    assert_eq!(r["ratio"], Value::from(1.5));
+    assert_eq!(r["maybe"], Value::Null);
+
+    // Streaming: 5 rows at batch_size 2 -> pages of 2,2,1.
+    exec(&pool, "CREATE TABLE dbo.nums (n INT)").await;
+    for n in 1..=5 {
+        exec(&pool, &format!("INSERT INTO dbo.nums (n) VALUES ({n})")).await;
+    }
+    let mut scfg = MssqlSourceConfig::new(
+        cfg.connection_url.clone().unwrap(),
+        "SELECT n FROM dbo.nums ORDER BY n",
+    );
+    scfg.connection.tls = cfg.tls.clone();
+    scfg.batch_size = 2;
+    let source = MssqlSource::new(scfg).await.expect("source");
+
+    let ctx = std::collections::HashMap::new();
+    let pages: Vec<_> = source
+        .stream_pages(&ctx, 2)
+        .map(|p| p.expect("page"))
+        .collect()
+        .await;
+    let sizes: Vec<usize> = pages.iter().map(|p| p.records.len()).collect();
+    assert_eq!(sizes, vec![2, 2, 1], "batch_size=2 over 5 rows");
+    let total: usize = pages.iter().map(|p| p.records.len()).sum();
+    assert_eq!(total, 5);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn incremental_resumes_without_duplicates() {
+    let (_c, port) = start_mssql().await;
+    let cfg = conn_cfg(port);
+    let pool = build_pool(&cfg, 4).await.expect("pool");
+
+    exec(&pool, "CREATE TABLE dbo.events (id INT, updated_at NVARCHAR(30))").await;
+    for (id, ts) in [(1, "2024-01-01"), (2, "2024-02-01"), (3, "2024-03-01")] {
+        exec(
+            &pool,
+            &format!("INSERT INTO dbo.events (id, updated_at) VALUES ({id}, '{ts}')"),
+        )
+        .await;
+    }
+
+    let mut scfg = MssqlSourceConfig::new(
+        cfg.connection_url.clone().unwrap(),
+        "SELECT id, updated_at FROM dbo.events WHERE updated_at > @bookmark ORDER BY updated_at",
+    );
+    scfg.connection.tls = cfg.tls.clone();
+    scfg.replication = MssqlReplication::Incremental {
+        column: "updated_at".into(),
+        initial_value: Value::from("2024-01-15"),
+    };
+    let source = MssqlSource::new(scfg).await.expect("source");
+
+    // Run 1: initial_value=2024-01-15 -> rows 2024-02-01 and 2024-03-01.
+    let (rows, bookmark) = source.fetch_all_incremental().await.expect("run 1");
+    let ids: Vec<i64> = rows.iter().map(|r| r["id"].as_i64().unwrap()).collect();
+    assert_eq!(ids, vec![2, 3], "run 1 honours initial_value");
+    assert_eq!(bookmark, Some(Value::from("2024-03-01")));
+
+    // Persist the bookmark, add a newer row, run again.
+    source.apply_start_bookmark(bookmark.unwrap()).await.unwrap();
+    exec(
+        &pool,
+        "INSERT INTO dbo.events (id, updated_at) VALUES (4, '2024-04-01')",
+    )
+    .await;
+
+    // Run 2: only the strictly-newer row, no duplicates of 2/3.
+    let (rows2, bookmark2) = source.fetch_all_incremental().await.expect("run 2");
+    let ids2: Vec<i64> = rows2.iter().map(|r| r["id"].as_i64().unwrap()).collect();
+    assert_eq!(ids2, vec![4], "run 2 resumes from bookmark, no duplicates");
+    assert_eq!(bookmark2, Some(Value::from("2024-04-01")));
+}

--- a/docs/book/src/reference/choosing.md
+++ b/docs/book/src/reference/choosing.md
@@ -78,7 +78,7 @@ Use **`source-bigquery`** / **`source-snowflake`** to *read out of* a warehouse
 
 ## Sinks: column-mapped vs. JSON blob (SQL databases)
 
-The Postgres/MySQL/SQLite sinks can write either:
+The Postgres/MySQL/SQLite/SQL Server sinks can write either:
 
 - **a single JSON/JSONB column** (`column_mapping: { type: jsonb, column: data }`)
   — schemaless, no DDL coupling, easiest to start with; or

--- a/docs/book/src/reference/connectors.md
+++ b/docs/book/src/reference/connectors.md
@@ -1,6 +1,6 @@
 # Connector catalog
 
-faucet-stream ships **20 sources** and **16 sinks**. Each is a Cargo feature
+faucet-stream ships **21 sources** and **17 sinks**. Each is a Cargo feature
 (`source-<name>` / `sink-<name>`) and an independently published crate. Full API
 docs are on [docs.rs](https://docs.rs/faucet-stream).
 
@@ -22,6 +22,7 @@ Legend: ✓ supported · ✗ not applicable.
 | PostgreSQL | `source-postgres` | ✓ | ✗ | ✗ | SQL query, rows as JSON |
 | PostgreSQL CDC | `source-postgres-cdc` | ✓ | ✓ | ✗ | logical replication (pgoutput), LSN bookmarks |
 | MySQL | `source-mysql` | ✓ | ✗ | ✗ | SQL query, rows as JSON |
+| Microsoft SQL Server | `source-mssql` | ✓ | ✓⁷ | ✗ | SQL query (tiberius), rows as JSON |
 | SQLite | `source-sqlite` | ✓ | ✗ | ✗ | SQL query, rows as JSON |
 | AWS S3 | `source-s3` | ✓⁴ | ✗ | ✓ | object reader: JSONL, JSON array, raw text |
 | Google Cloud Storage | `source-gcs` | ✓⁴ | ✗ | ✓ | object reader: JSONL, JSON array, raw text |
@@ -42,7 +43,8 @@ so re-runs continue where they left off (incremental replication / CDC / Kafka
 offsets). ³ gRPC streams natively in *server-streaming* mode; unary buffers the
 single response. ⁴ S3/GCS stream in JSONL and raw-text modes; JSON-array mode
 buffers one object. ⁵ Webhook is buffer-shaped by nature (it collects POSTs over
-a window).
+a window). ⁷ MSSQL is resumable only in `replication: incremental` mode (it
+persists a tracking-column bookmark); in `full` mode it is not.
 
 ## Sinks
 
@@ -56,6 +58,7 @@ file/append sinks (`jsonl`, `csv`, `stdout`) it's a no-op — they write per rec
 | JSON Lines | `sink-jsonl` | no-op | ✓ | buffered file append |
 | Snowflake | `sink-snowflake` | ✓ | ✗ | SQL REST API |
 | MySQL | `sink-mysql` | ✓ | ✗ | multi-row `INSERT` |
+| Microsoft SQL Server | `sink-mssql` | ✓ | ✗ | multi-row `INSERT` (2100-param auto-split, per-row DLQ) |
 | SQLite | `sink-sqlite` | ✓ | ✗ | transaction-wrapped batch |
 | AWS S3 | `sink-s3` | ✓ | ✓ | JSONL objects, parallel uploads |
 | Google Cloud Storage | `sink-gcs` | ✓ | ✓ | JSONL objects |

--- a/examples/README.md
+++ b/examples/README.md
@@ -57,6 +57,9 @@ The service column lists what each example touches; all are provided by
 | `rest_to_postgres.yaml`, `rest_to_postgres_with_quality.yaml`, `mongodb_to_postgres.yaml`, `graphql_to_postgres.yaml`, `webhook_to_postgres.yaml` | postgres (+ source) |
 | `mysql_to_postgres.yaml` | mysql, postgres |
 | `csv_to_mysql.yaml`, `redis_to_mysql.yaml` | mysql (+ source) |
+| `mssql_to_jsonl.yaml` | mssql + mssql-init (incremental source; seeds `sales.dbo.users`) |
+| `kafka_to_mssql.yaml` | mssql + mssql-init, redpanda (produce JSON to `events` matching `analytics.dbo.events`) |
+| `rest_to_mssql.yaml` | mssql + mssql-init (json_column; auto-creates `raw.dbo.products_raw`) |
 | `redis_to_sqlite.yaml`, `mongodb_to_redis.yaml`, `elasticsearch_to_redis.yaml` | redis (+ source) |
 | `kafka_to_jsonl.yaml`, `rest_to_kafka.yaml` | redpanda (Kafka API) |
 | `mongodb_to_elasticsearch.yaml`, `postgres_to_elasticsearch.yaml`, `grpc_to_elasticsearch.yaml` | elasticsearch (+ source) |

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -127,3 +127,42 @@ services:
       interval: 5s
       timeout: 5s
       retries: 15
+
+  # Microsoft SQL Server (Developer edition) for the mssql source/sink examples.
+  # ~1.5 GB image — start it explicitly (`docker compose up -d mssql mssql-init`)
+  # if you only want this one.
+  mssql:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    environment:
+      ACCEPT_EULA: "Y"
+      MSSQL_SA_PASSWORD: "Str0ng@Pass"
+      MSSQL_PID: "Developer"
+    ports:
+      - "1433:1433"
+    healthcheck:
+      # The server image doesn't bundle sqlcmd; a bash /dev/tcp probe confirms
+      # the TDS port is accepting connections.
+      test: ["CMD-SHELL", "bash -c 'echo > /dev/tcp/localhost/1433' || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+
+  # One-shot: waits for SQL Server, then creates the `sales` / `analytics` / `raw`
+  # databases and the sample tables the mssql examples use.
+  mssql-init:
+    image: mcr.microsoft.com/mssql-tools
+    depends_on:
+      mssql:
+        condition: service_healthy
+    volumes:
+      - ./infra/mssql-init.sql:/init.sql:ro
+    entrypoint:
+      - bash
+      - -c
+      - >
+        for i in $$(seq 1 30); do
+          /opt/mssql-tools/bin/sqlcmd -S mssql -U sa -P "Str0ng@Pass" -b -Q "SELECT 1" && break;
+          echo "waiting for sql server ($$i)..."; sleep 2;
+        done;
+        /opt/mssql-tools/bin/sqlcmd -S mssql -U sa -P "Str0ng@Pass" -b -i /init.sql
+    restart: "no"

--- a/examples/infra/mssql-init.sql
+++ b/examples/infra/mssql-init.sql
@@ -1,0 +1,36 @@
+-- Databases + sample tables for the faucet-stream MSSQL examples.
+-- Run automatically by the `mssql-init` sidecar in docker-compose.yml.
+
+IF DB_ID('sales') IS NULL CREATE DATABASE sales;
+IF DB_ID('analytics') IS NULL CREATE DATABASE analytics;
+IF DB_ID('raw') IS NULL CREATE DATABASE raw;
+GO
+
+-- sales.dbo.users — source for mssql_to_jsonl.yaml (incremental on updated_at).
+USE sales;
+IF OBJECT_ID('dbo.users', 'U') IS NULL
+  CREATE TABLE dbo.users (
+    id INT PRIMARY KEY,
+    email NVARCHAR(255),
+    updated_at DATETIME2
+  );
+IF NOT EXISTS (SELECT 1 FROM dbo.users)
+  INSERT INTO dbo.users (id, email, updated_at) VALUES
+    (1, 'alice@example.com', '2024-01-01T00:00:00'),
+    (2, 'bob@example.com',   '2024-06-01T12:00:00'),
+    (3, 'carol@example.com', '2024-12-15T08:30:00');
+GO
+
+-- analytics.dbo.events — target for kafka_to_mssql.yaml (auto_columns). Adjust
+-- the columns to match your Kafka message keys.
+USE analytics;
+IF OBJECT_ID('dbo.events', 'U') IS NULL
+  CREATE TABLE dbo.events (
+    id INT,
+    name NVARCHAR(100),
+    payload NVARCHAR(MAX)
+  );
+GO
+
+-- raw.dbo.products_raw is auto-created by rest_to_mssql.yaml (create_table: true),
+-- so only the `raw` database needs to exist here.

--- a/faucet-stream/Cargo.toml
+++ b/faucet-stream/Cargo.toml
@@ -24,6 +24,7 @@ source = [
     "source-postgres",
     "source-postgres-cdc",
     "source-mysql",
+    "source-mssql",
     "source-sqlite",
     "source-s3",
     "source-mongodb",
@@ -45,6 +46,7 @@ sink = [
     "sink-snowflake",
     "sink-kafka",
     "sink-mysql",
+    "sink-mssql",
     "sink-sqlite",
     "sink-s3",
     "sink-mongodb",
@@ -93,6 +95,7 @@ source-grpc = ["dep:faucet-source-grpc"]
 source-postgres = ["dep:faucet-source-postgres"]
 source-postgres-cdc = ["dep:faucet-source-postgres-cdc"]
 source-mysql = ["dep:faucet-source-mysql"]
+source-mssql = ["dep:faucet-source-mssql"]
 source-sqlite = ["dep:faucet-source-sqlite"]
 source-s3 = ["dep:faucet-source-s3"]
 source-mongodb = ["dep:faucet-source-mongodb"]
@@ -113,6 +116,7 @@ sink-postgres = ["dep:faucet-sink-postgres"]
 sink-jsonl = ["dep:faucet-sink-jsonl"]
 sink-snowflake = ["dep:faucet-sink-snowflake"]
 sink-mysql = ["dep:faucet-sink-mysql"]
+sink-mssql = ["dep:faucet-sink-mssql"]
 sink-sqlite = ["dep:faucet-sink-sqlite"]
 
 sink-s3 = ["dep:faucet-sink-s3"]
@@ -168,6 +172,7 @@ faucet-source-kafka = { workspace = true, optional = true }
 faucet-source-postgres = { workspace = true, optional = true }
 faucet-source-postgres-cdc = { workspace = true, optional = true }
 faucet-source-mysql = { workspace = true, optional = true }
+faucet-source-mssql = { workspace = true, optional = true }
 faucet-source-sqlite = { workspace = true, optional = true }
 faucet-source-s3 = { workspace = true, optional = true }
 faucet-source-mongodb = { workspace = true, optional = true }
@@ -186,6 +191,7 @@ faucet-sink-jsonl = { workspace = true, optional = true }
 faucet-sink-snowflake = { workspace = true, optional = true }
 faucet-sink-kafka = { workspace = true, optional = true }
 faucet-sink-mysql = { workspace = true, optional = true }
+faucet-sink-mssql = { workspace = true, optional = true }
 faucet-sink-sqlite = { workspace = true, optional = true }
 
 faucet-sink-s3 = { workspace = true, optional = true }

--- a/faucet-stream/src/lib.rs
+++ b/faucet-stream/src/lib.rs
@@ -18,6 +18,7 @@
 //! | `source-postgres` | PostgreSQL query source |
 //! | `source-postgres-cdc` | PostgreSQL CDC source (logical replication) |
 //! | `source-mysql` | MySQL query source |
+//! | `source-mssql` | Microsoft SQL Server query source |
 //! | `source-sqlite` | SQLite query source |
 
 //! | `source-s3` | AWS S3 file source |
@@ -34,6 +35,7 @@
 //! | `sink-jsonl` | JSON Lines file sink |
 //! | `sink-snowflake` | Snowflake SQL REST API sink |
 //! | `sink-mysql` | MySQL sink |
+//! | `sink-mssql` | Microsoft SQL Server sink |
 //! | `sink-sqlite` | SQLite sink |
 
 //! | `sink-s3` | AWS S3 file sink |
@@ -102,6 +104,11 @@ pub mod source {
     #[cfg(feature = "source-mysql")]
     pub mod mysql {
         pub use faucet_source_mysql::*;
+    }
+
+    #[cfg(feature = "source-mssql")]
+    pub mod mssql {
+        pub use faucet_source_mssql::*;
     }
 
     #[cfg(feature = "source-sqlite")]
@@ -191,6 +198,11 @@ pub mod source {
     #[cfg(feature = "source-mysql")]
     pub mod mysql {
         pub use faucet_source_mysql::*;
+    }
+
+    #[cfg(feature = "source-mssql")]
+    pub mod mssql {
+        pub use faucet_source_mssql::*;
     }
 
     #[cfg(feature = "source-sqlite")]
@@ -283,6 +295,11 @@ pub mod sink {
     #[cfg(feature = "sink-mysql")]
     pub mod mysql {
         pub use faucet_sink_mysql::*;
+    }
+
+    #[cfg(feature = "sink-mssql")]
+    pub mod mssql {
+        pub use faucet_sink_mssql::*;
     }
 
     #[cfg(feature = "sink-sqlite")]


### PR DESCRIPTION
Adds first-class Microsoft SQL Server support on both ends, in one PR (paired source+sink share a `-common` crate per the workspace convention).

Closes #119
Closes #120

## What's new

Three new crates, built on **`tiberius` 0.12 + `bb8-tiberius` 0.16** with **rustls** TLS (tiberius default features off — no native-tls/winauth). `sqlx` dropped MSSQL after 0.6, which is why this uses tiberius rather than the postgres/mysql `sqlx` stack.

| Crate | Role |
|-------|------|
| `faucet-mssql-common` | Shared `MssqlConnectionConfig` (URL **or** ADO string, exactly one) + `MssqlTls`, the single `tiberius`+`bb8` pool builder, `quote_ident_mssql` (`[bracket]` quoting), `PARAM_LIMIT = 2100`, statement-timeout helper |
| `faucet-source-mssql` | Query source — streams rows page-by-page, incremental replication via a tracking column |
| `faucet-sink-mssql` | Multi-row INSERT sink — 2100-param auto-split, transaction-wrapped, row-isolation DLQ |

### Source (#119)
- Flattens the shared connection config + `query` / `params` (`@P1`…) / `batch_size` / `statement_timeout_secs` / `replication`.
- Native streaming via the tiberius `QueryStream` → `StreamPage`s (O(batch_size) memory).
- Type-aware decoding: DECIMAL/NUMERIC/MONEY → precision-preserving strings, DATETIMEOFFSET keeps its offset, DATETIME2/etc. → ISO 8601, UNIQUEIDENTIFIER → hyphenated string, BINARY → base64.
- **Incremental replication**: a literal `@bookmark` token in the query enables server-side pushdown (bound as a param); `filter_incremental` always runs client-side as a correctness backstop; `max_replication_value` rides the final page. `state_key` defaults to `mssql:<host>:<query-fingerprint>`.

### Sink (#120)
- `column_mapping`: `auto_columns` (keys → columns, IDENTITY columns skipped, `on_unknown_field` warn/drop/error) or `json_column` (NVARCHAR(MAX); optional `create_table`).
- Multi-row INSERT **auto-split at the 2100-parameter limit**, each batch wrapped in `BEGIN`/`COMMIT TRAN`.
- `write_batch_partial` row-isolation: on batch failure, retry row-by-row so only the offending row is dead-lettered; transient (deadlock/lock-timeout) errors get bounded backoff + outer-Err propagation.
- README documents the `TrustServerCertificate` MITM caveat.

> Note: the sink config field is named `column_mapping` (consistent with the postgres/mysql/sqlite sinks) rather than the issue's tentative `write_mode`.

## Wiring & docs
- Umbrella `faucet-stream` (`source-mssql`/`sink-mssql` features + gated re-exports, in `source`/`sink`/`full` aggregates), CLI (`registry` dispatch + schema + `faucet list`), CI `feature-check` matrix.
- Root README (tables, counts → 50 crates / 21 sources / 17 sinks, perf, feature flags, project structure), docs-site capability matrix + `choosing.md`, `cli/examples/{mssql_to_jsonl,kafka_to_mssql,rest_to_mssql}.yaml`, and an `mssql` + `mssql-init` service in the examples Docker stack (`examples/infra/mssql-init.sql`).

## Out of scope (documented follow-ups, not partial edges)
MSSQL CDC; Windows/Integrated & Azure AD auth; bulk-copy (BCP); MERGE/UPSERT; auto-create in `auto_columns` mode.

## Testing / verification
- **47 unit tests** across the three crates (URL parsing, TLS mapping, identifier quoting, type conversion, `@P`/`@bookmark` query build, bookmark tracking, 2100-param split, column resolution, transient classifier).
- **Docker-gated integration tests** (testcontainers `mssql_server`): source type-coverage + streaming chunking + resumable incremental (no-dup/no-loss); sink 5k-row auto-columns w/ param-split, json_column + create_table, row-isolation → DLQ. They compile locally and run in CI's `test` job (no Docker in the dev sandbox).
- Verified locally: `cargo fmt --all`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo doc -D warnings`, `faucet list` / `faucet schema source|sink mssql`, all three example YAMLs `faucet validate`, feature-isolation checks, and `cargo publish --dry-run -p faucet-mssql-common`. New transitive deps all carry allow-listed licenses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)