### PR TITLE
fix(sources): CSV/XML/REST data-loss + pagination reliability (H2/H4/H5/H13/H15, #146)

### DIFF
--- a/crates/sink/csv/README.md
+++ b/crates/sink/csv/README.md
@@ -5,7 +5,7 @@
 
 CSV file sink connector for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
 
-Writes JSON records to a CSV file. Column order is determined from the keys of the first record. Supports configurable delimiters, optional header rows, and append mode. Uses `spawn_blocking` to avoid blocking the async runtime during file I/O.
+Writes JSON records to a CSV file. Column order is the union of keys across the records of the first `write_batch()` call. Supports configurable delimiters, optional header rows, and append mode. Uses `spawn_blocking` to avoid blocking the async runtime during file I/O.
 
 ## Installation
 
@@ -75,10 +75,10 @@ let config = CsvSinkConfig::new("/data/output.tsv")
 
 ### Column Order and Missing Fields
 
-- Column order is determined by the keys of the **first record** in the first `write_batch()` call.
+- Column order is the **union of keys across all records in the first** `write_batch()` call, in first-seen order — so a field present only in a later record of that batch is still captured (audit #146 H2).
 - All subsequent records use the same column order, regardless of their key order.
 - If a record is missing a field that exists in the column list, an empty string is written for that cell.
-- Extra keys in subsequent records that were not in the first record are ignored.
+- Keys that appear only in a **later** `write_batch()` call (after the header is written) are still ignored — the header is fixed once on the first call.
 
 ### Value Conversion
 
@@ -232,7 +232,7 @@ sink.flush().await?;
 
 ## How It Works
 
-- The file is opened lazily on the first `write_batch()` call. Column order is determined from the keys of the first record.
+- The file is opened lazily on the first `write_batch()` call. Column order is the union of keys across the records of the first `write_batch()` call.
 - Missing parent directories of `path` are created automatically (equivalent to `mkdir -p`) before the file is opened, matching the behaviour of the parquet sink. Dated-subdirectory paths such as `./data/dt=2026-03-08/part.csv` work without any pre-creation step.
 - All CSV I/O runs inside `tokio::task::spawn_blocking` to avoid blocking the async runtime.
 - A `Mutex` protects the writer state (column order + csv::Writer) for thread-safe access.

--- a/crates/sink/csv/src/sink.rs
+++ b/crates/sink/csv/src/sink.rs
@@ -24,9 +24,10 @@ struct WriterState {
 
 /// A sink that writes JSON records to a CSV file.
 ///
-/// Column order is determined from the keys of the first record in the first
-/// `write_batch` call. Subsequent records use the same column order; missing
-/// fields are written as empty strings.
+/// Column order is the union of keys across the records of the first
+/// `write_batch` call, in first-seen order (so a field present only in a later
+/// record of that batch is still captured). Subsequent records use the same
+/// column order; missing fields are written as empty strings.
 ///
 /// [`Sink::flush`](faucet_core::Sink::flush) finalises the encoder (writes the trailer) and clears the
 /// writer slot — a subsequent `write_batch` reopens the file in append mode
@@ -191,15 +192,30 @@ fn write_csv_blocking(
     let mut state = match existing_state {
         Some(s) => s,
         None => {
-            // Determine columns from the first record.
-            let columns: Vec<String> = match &records[0] {
-                Value::Object(map) => map.keys().cloned().collect(),
-                _ => {
-                    return Err(FaucetError::Sink(
-                        "CSV sink expects JSON objects, got non-object record".into(),
-                    ));
+            // Determine columns from the UNION of keys across the first batch's
+            // records, in first-seen order — not just `records[0]`. Otherwise a
+            // field present only in a later record of the first batch would be
+            // absent from the header and silently dropped from every row (audit
+            // #146 H2). (A later flush-segment cannot change the already-written
+            // header — that is a separate, documented limitation.)
+            let mut columns: Vec<String> = Vec::new();
+            let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
+            for record in records {
+                match record {
+                    Value::Object(map) => {
+                        for k in map.keys() {
+                            if seen.insert(k.as_str()) {
+                                columns.push(k.clone());
+                            }
+                        }
+                    }
+                    _ => {
+                        return Err(FaucetError::Sink(
+                            "CSV sink expects JSON objects, got non-object record".into(),
+                        ));
+                    }
                 }
-            };
+            }
 
             // First open obeys `config.append`. Re-opens (after flush()
             // cleared the writer) always append, so flush-then-write
@@ -305,6 +321,40 @@ mod tests {
         let lines: Vec<&str> = content.trim().split('\n').collect();
         // Header + 2 data rows.
         assert_eq!(lines.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn columns_union_across_first_batch_not_just_first_record() {
+        // H2 (audit #146): column order is the union of keys across the first
+        // batch's records. The first record lacks `email`; before the fix the
+        // header was fixed from record 0 and `email` was silently dropped from
+        // every row. After the fix `email` is a column and the second record's
+        // value appears (the first row leaves it empty).
+        let tmp = NamedTempFile::new().unwrap();
+        let path = tmp.path().to_str().unwrap().to_string();
+        let sink = CsvSink::new(CsvSinkConfig::new(&path));
+
+        let records = vec![
+            json!({ "id": 1, "name": "Alice" }),
+            json!({ "id": 2, "name": "Bob", "email": "bob@x.y" }),
+        ];
+        sink.write_batch(&records).await.unwrap();
+        sink.flush().await.unwrap();
+
+        let content = tokio::fs::read_to_string(&path).await.unwrap();
+        let lines: Vec<&str> = content.trim().split('\n').collect();
+        assert_eq!(lines.len(), 3, "header + 2 rows");
+        assert!(
+            lines[0].contains("email"),
+            "header must include the later-record-only column: {}",
+            lines[0]
+        );
+        // Row 2 carries the email value; row 1 leaves it empty.
+        assert!(
+            lines[2].contains("bob@x.y"),
+            "second row must carry the unioned column value: {}",
+            lines[2]
+        );
     }
 
     #[tokio::test]

--- a/crates/source/rest/src/stream.rs
+++ b/crates/source/rest/src/stream.rs
@@ -268,6 +268,27 @@ impl RestStream {
             let mut running_max: Option<Value> = effective_start.clone();
             let mut bookmark_emitted = false;
 
+            // H13 (audit #146): combining `max_pages` with incremental
+            // replication only makes safe forward progress when the API returns
+            // rows ordered ascending by the replication key. On truncation we
+            // advance the bookmark to the max key seen so far (so the next run
+            // resumes past it — without this the stream would re-read the same
+            // first `max_pages` window forever and never progress); but if the
+            // feed is unordered, unfetched later pages may hold lower keys that
+            // resuming past `running_max` would then drop. Warn loudly so the
+            // requirement is explicit rather than a silent data-loss edge.
+            if self.config.max_pages.is_some()
+                && self.config.replication_method == ReplicationMethod::Incremental
+                && self.config.replication_key.is_some()
+            {
+                tracing::warn!(
+                    "max_pages combined with incremental replication assumes the API returns rows \
+                     ordered ascending by the replication key; an unordered feed can drop unfetched \
+                     lower-key records on resume. Ensure ordering, or remove max_pages for a full \
+                     incremental sweep."
+                );
+            }
+
             loop {
                 if let Some(max) = self.config.max_pages
                     && pages_fetched >= max
@@ -368,6 +389,8 @@ impl RestStream {
             // zero pages fetched and a seeded start bookmark), emit one empty
             // page carrying the consolidated bookmark so the pipeline still
             // persists incremental progress and the next run resumes from here.
+            // (Safe forward progress under max_pages assumes ascending order by
+            // the replication key — see the warning emitted above, audit #146 H13.)
             if !bookmark_emitted && running_max.is_some() {
                 yield faucet_core::StreamPage {
                     records: Vec::new(),

--- a/crates/source/xml/src/convert.rs
+++ b/crates/source/xml/src/convert.rs
@@ -80,6 +80,34 @@ pub fn xml_to_json(xml: &str) -> Result<Value, FaucetError> {
                     }
                 }
             }
+            Ok(Event::CData(e)) => {
+                // CDATA is literal (un-escaped) text that quick_xml emits as a
+                // separate event; without this arm the content was silently
+                // dropped — data loss for SOAP / feed APIs that wrap markup in
+                // CDATA (audit #146 H15). Decode and append to `#text` exactly
+                // like Event::Text.
+                let text = e
+                    .decode()
+                    .map_err(|err| {
+                        FaucetError::Transform(format!("XML CDATA decode error: {err}"))
+                    })?
+                    .trim()
+                    .to_string();
+
+                if !text.is_empty()
+                    && let Some(current) = stack.last_mut()
+                {
+                    match current.1.get_mut("#text") {
+                        Some(Value::String(s)) => {
+                            s.push(' ');
+                            s.push_str(&text);
+                        }
+                        _ => {
+                            current.1.insert("#text".into(), Value::String(text));
+                        }
+                    }
+                }
+            }
             Ok(Event::Empty(e)) => {
                 let name = String::from_utf8_lossy(e.name().as_ref()).into_owned();
                 let mut obj = Map::new();
@@ -332,8 +360,48 @@ pub fn stream_extract<F: FnMut(Value)>(
                     }
                 }
             }
+            Ok(Event::CData(e)) => {
+                // CDATA is literal text emitted as its own event; capture it
+                // instead of dropping it — data loss for CDATA-wrapped markup
+                // (audit #146 H15). Decode and append to `#text` like Text.
+                let text = e
+                    .decode()
+                    .map_err(|err| {
+                        FaucetError::Transform(format!("XML CDATA decode error: {err}"))
+                    })?
+                    .trim()
+                    .to_string();
+                if text.is_empty() {
+                    continue;
+                }
+                if let Some(doc) = full_doc.as_mut() {
+                    if let Some(current) = doc.last_mut() {
+                        match current.1.get_mut("#text") {
+                            Some(Value::String(s)) => {
+                                s.push(' ');
+                                s.push_str(&text);
+                            }
+                            _ => {
+                                current.1.insert("#text".into(), Value::String(text));
+                            }
+                        }
+                    }
+                } else if start_depth.is_some()
+                    && let Some(current) = subtree.last_mut()
+                {
+                    match current.1.get_mut("#text") {
+                        Some(Value::String(s)) => {
+                            s.push(' ');
+                            s.push_str(&text);
+                        }
+                        _ => {
+                            current.1.insert("#text".into(), Value::String(text));
+                        }
+                    }
+                }
+            }
             Ok(Event::Eof) => break,
-            Ok(_) => {} // Comments, PIs, CDATA boundaries, etc.
+            Ok(_) => {} // Comments, PIs, etc.
             Err(e) => {
                 return Err(FaucetError::Transform(format!("XML parse error: {e}")));
             }
@@ -408,6 +476,24 @@ mod tests {
         let xml = r#"<root><user><address><city>NYC</city></address></user></root>"#;
         let json = xml_to_json(xml).unwrap();
         assert_eq!(json["root"]["user"]["address"]["city"], "NYC");
+    }
+
+    #[test]
+    fn cdata_content_is_captured_not_dropped() {
+        // H15 (audit #146): quick_xml emits CDATA as a separate event; it must
+        // be captured into #text, not silently dropped (it was, before the fix).
+        let xml = r#"<root><body><![CDATA[<b>hi</b> & bye]]></body></root>"#;
+        let json = xml_to_json(xml).unwrap();
+        assert_eq!(json["root"]["body"], "<b>hi</b> & bye");
+    }
+
+    #[test]
+    fn cdata_content_captured_in_streaming_path() {
+        // H15: the streaming converter must also capture CDATA.
+        let xml = r#"<feed><item><html><![CDATA[<p>x</p>]]></html></item></feed>"#;
+        let recs = collect_stream_extract(xml, Some("feed.item"));
+        assert_eq!(recs.len(), 1);
+        assert_eq!(recs[0]["html"], "<p>x</p>");
     }
 
     #[test]

--- a/crates/source/xml/src/stream.rs
+++ b/crates/source/xml/src/stream.rs
@@ -12,6 +12,22 @@ use std::collections::HashMap;
 use std::pin::Pin;
 use std::time::Duration;
 
+/// Content fingerprint of a fetched page, used as a pagination loop guard: a
+/// server that ignores the page/offset parameter (or clamps to the last page)
+/// returns the same non-empty page on every request, which would otherwise loop
+/// forever. Stopping when two consecutive pages fingerprint identically mirrors
+/// the REST source's body-fingerprint guard (audit #146 H4/H5).
+fn page_fingerprint(records: &[Value]) -> u64 {
+    use std::hash::{Hash, Hasher};
+    // `serde_json::Value` is not `Hash`; hash its canonical string form.
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    records.len().hash(&mut hasher);
+    for r in records {
+        r.to_string().hash(&mut hasher);
+    }
+    hasher.finish()
+}
+
 /// Retries on transient (5xx / connection) failures before giving up.
 const RETRY_MAX_ATTEMPTS: u32 = 3;
 /// Base exponential-backoff delay between retries.
@@ -78,7 +94,7 @@ impl XmlStream {
         let mut pages_fetched = 0usize;
         let mut offset = 0usize;
         let mut page_number = None;
-        let mut prev_record_count: Option<usize> = None;
+        let mut prev_fingerprint: Option<u64> = None;
 
         // Initialize pagination state.
         if let Some(XmlPagination::PageNumber { start_page, .. }) = &self.config.pagination {
@@ -105,8 +121,20 @@ impl XmlStream {
             };
 
             let record_count = records.len();
+            let fingerprint = page_fingerprint(&records);
             all_records.extend(records);
             pages_fetched += 1;
+
+            // Loop guard: a server that ignores the page/offset parameter (or
+            // clamps to the last page) returns the same non-empty page forever.
+            // Stop when two consecutive pages are identical (audit #146 H4/H5).
+            if record_count > 0 && prev_fingerprint == Some(fingerprint) {
+                tracing::warn!(
+                    "XML pagination returned an identical page; stopping to avoid an infinite loop"
+                );
+                break;
+            }
+            prev_fingerprint = Some(fingerprint);
 
             // Advance pagination or stop.
             match &self.config.pagination {
@@ -126,16 +154,10 @@ impl XmlStream {
                     if record_count < *limit {
                         break;
                     }
-                    // Loop detection: stop if record count is identical and offset hasn't advanced.
-                    if prev_record_count == Some(record_count) && record_count == 0 {
-                        tracing::warn!("offset pagination loop detected, stopping");
-                        break;
-                    }
                     offset += record_count;
                 }
                 None => break,
             }
-            prev_record_count = Some(record_count);
         }
 
         tracing::info!(
@@ -327,7 +349,7 @@ impl faucet_core::Source for XmlStream {
             let mut pages_fetched = 0usize;
             let mut offset = 0usize;
             let mut page_number = None;
-            let mut prev_record_count: Option<usize> = None;
+            let mut prev_fingerprint: Option<u64> = None;
 
             if let Some(XmlPagination::PageNumber { start_page, .. }) =
                 &self.config.pagination
@@ -362,6 +384,7 @@ impl faucet_core::Source for XmlStream {
                 )?;
 
                 let record_count = page_records.len();
+                let fingerprint = page_fingerprint(&page_records);
 
                 for rec in page_records.drain(..) {
                     buffer.push(rec);
@@ -372,6 +395,17 @@ impl faucet_core::Source for XmlStream {
                     }
                 }
                 pages_fetched += 1;
+
+                // Loop guard: stop when two consecutive pages are identical — a
+                // server ignoring the page/offset parameter (or clamping to the
+                // last page) returns the same non-empty page forever (#146 H4/H5).
+                if record_count > 0 && prev_fingerprint == Some(fingerprint) {
+                    tracing::warn!(
+                        "XML pagination returned an identical page; stopping to avoid an infinite loop"
+                    );
+                    break;
+                }
+                prev_fingerprint = Some(fingerprint);
 
                 // Advance pagination using the same rules as
                 // `fetch_all_with_context`.
@@ -391,15 +425,10 @@ impl faucet_core::Source for XmlStream {
                         if record_count < *limit {
                             break;
                         }
-                        if prev_record_count == Some(record_count) && record_count == 0 {
-                            tracing::warn!("offset pagination loop detected, stopping");
-                            break;
-                        }
                         offset += record_count;
                     }
                     None => break,
                 }
-                prev_record_count = Some(record_count);
             }
 
             if !buffer.is_empty() {


### PR DESCRIPTION
## Summary

PR 2 of the HIGH-tier fixes from the #146 pre-1.0 audit — **source-connector data-loss and reliability**. Builds on merged #147 (criticals) and #148 (SQL sinks).

> Refs #146 (HIGH items H2, H4, H5, H13, H15). Not auto-closing #146.

## The fixes

### H2 — CSV sink dropped fields absent from the first record
`crates/sink/csv/src/sink.rs`. The header/column set was derived from `records[0]`, so a field present only in a later record of the first batch was silently dropped from every row.
**Fix:** column set is now the **union** of keys across the first batch's records (first-seen order); a row missing a column writes an empty cell. (Test runs locally.)

### H15 — XML source silently dropped all CDATA content (data loss)
`crates/source/xml/src/convert.rs`. `quick_xml` emits CDATA as a separate `Event::CData`; both converters handled only `Event::Text` and routed CDATA into the catch-all, so CDATA-wrapped markup (common in SOAP / RSS feeds) was lost.
**Fix:** both the eager and streaming converters decode CDATA and append it to `#text` like `Text`. (Eager + streaming unit tests run locally.)

### H4 / H5 — XML pagination could loop forever
`crates/source/xml/src/stream.rs`. `PageNumber` had no guard when `page_size` was `None`, and the `Offset` loop-detection was dead code, so a server that ignores the page/offset parameter (or clamps to the last page) returned the same non-empty page forever — infinite loop + unbounded memory.
**Fix:** both loops stop when two consecutive pages fingerprint identically (mirrors the REST source's body-fingerprint guard).

### H13 — REST `max_pages` + incremental ordering requirement
`crates/source/rest/src/stream.rs`. On `max_pages` truncation the bookmark advances to the max replication key seen. **Investigation note:** the audit suggested *not* advancing on truncation — but that would make the stream re-read the same first window every run and **never progress**, so it's the wrong fix. Advancing is required for progress; it's only *safe* when the API returns rows ordered ascending by the replication key (otherwise unfetched lower-key rows are dropped on resume).
**Fix:** keep advancing (no behavior change, no progress regression — the #78/#15 regression test stays valid), but emit a **loud one-shot warning** when `max_pages` + incremental + a replication key are combined, making the ordering requirement explicit. Documented as a known requirement rather than a silent data-loss edge.

## Verification

- `cargo fmt --all --check` clean; `cargo clippy --all-targets -- -D warnings` clean on csv / xml / rest.
- New tests (run locally, no Docker): CSV heterogeneous-batch (H2); XML eager + streaming CDATA (H15).
- H4/H5 covered by the page-fingerprint guard (analogous to the REST guard); H13 keeps the existing `max_pages_bookmark_test` passing (behavior unchanged).
- READMEs updated (CSV column behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
