### PR TITLE
fix(streaming/auth): 429 retry, gRPC reconnect reset, auth timeout, PG param binding (H3/H8/H11/H12, #146)

### DIFF
--- a/crates/auth/src/lib.rs
+++ b/crates/auth/src/lib.rs
@@ -27,9 +27,24 @@ mod static_provider;
 mod token_endpoint;
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use faucet_core::{FaucetError, SharedAuthProvider};
 use serde_json::Value;
+
+/// Build the HTTP client the auth providers use, with a bounded request timeout.
+///
+/// Providers hold a single-flight mutex across the token-fetch network call, so
+/// a hung or unreachable IdP with no timeout would wedge that mutex — and thus
+/// every connector sharing the provider — indefinitely. A bounded timeout lets
+/// the fetch fail and release the lock so callers can retry (audit #146 H11).
+pub(crate) fn auth_http_client() -> reqwest::Client {
+    const AUTH_HTTP_TIMEOUT: Duration = Duration::from_secs(30);
+    reqwest::Client::builder()
+        .timeout(AUTH_HTTP_TIMEOUT)
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new())
+}
 
 pub use oauth2::{OAuth2ClientCredentialsProvider, OAuth2RefreshProvider};
 pub use static_provider::StaticProvider;

--- a/crates/auth/src/oauth2.rs
+++ b/crates/auth/src/oauth2.rs
@@ -62,7 +62,7 @@ impl OAuth2ClientCredentialsProvider {
     /// `client_secret`, optional `scopes` and `expiry_ratio`.
     pub fn from_config(config: &Value) -> Result<Self, FaucetError> {
         Ok(Self {
-            http: Client::new(),
+            http: crate::auth_http_client(),
             token_url: required_str(config, "token_url")?,
             client_id: required_str(config, "client_id")?,
             client_secret: required_str(config, "client_secret")?,
@@ -147,7 +147,7 @@ impl OAuth2RefreshProvider {
     pub fn from_config(config: &Value) -> Result<Self, FaucetError> {
         let refresh_token = required_str(config, "refresh_token")?;
         Ok(Self {
-            http: Client::new(),
+            http: crate::auth_http_client(),
             token_url: required_str(config, "token_url")?,
             client_id: required_str(config, "client_id")?,
             client_secret: required_str(config, "client_secret")?,

--- a/crates/auth/src/token_endpoint.rs
+++ b/crates/auth/src/token_endpoint.rs
@@ -58,7 +58,7 @@ impl TokenEndpointProvider {
             })?
             .to_string();
         Ok(Self {
-            http: Client::new(),
+            http: crate::auth_http_client(),
             url,
             method,
             body: config.get("body").cloned().filter(|v| !v.is_null()),

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -102,7 +102,11 @@ impl FaucetError {
                     true
                 }
             }
-            FaucetError::HttpStatus { status, .. } => *status >= 500,
+            // 5xx are retriable; 429 (Too Many Requests) is too — sources that
+            // surface a rate-limit as a plain HttpStatus rather than the
+            // dedicated RateLimited variant (XML, GraphQL) would otherwise abort
+            // on the first 429 (audit #146 H3).
+            FaucetError::HttpStatus { status, .. } => *status >= 500 || *status == 429,
             FaucetError::RateLimited(_) => true,
             _ => false,
         }
@@ -145,6 +149,18 @@ mod tests {
             body: "".into(),
         };
         assert!(!err.is_retriable());
+    }
+
+    #[test]
+    fn http_status_429_is_retriable() {
+        // H3 (audit #146): a 429 surfaced as a plain HttpStatus (XML/GraphQL
+        // sources) must be retriable, not aborted on the first hit.
+        let err = FaucetError::HttpStatus {
+            status: 429,
+            url: "https://example.com".into(),
+            body: "Too Many Requests".into(),
+        };
+        assert!(err.is_retriable());
     }
 
     #[test]

--- a/crates/source/grpc/src/stream.rs
+++ b/crates/source/grpc/src/stream.rs
@@ -164,6 +164,17 @@ impl GrpcStream {
                     if self.config.terminate_on_error {
                         return Err(error);
                     }
+                    // If this attempt delivered messages before failing, the
+                    // stream recovered and made progress — so this disconnect is
+                    // a fresh transient failure, not a consecutive one. Reset the
+                    // attempt counter and backoff; otherwise a healthy long-lived
+                    // stream is aborted once its *lifetime* reconnects reach
+                    // reconnect_max_attempts, and backoff stays pinned at the cap
+                    // after one early hiccup (audit #146 H8).
+                    if consumed > 0 {
+                        attempt = 0;
+                        backoff = self.config.reconnect_initial_backoff;
+                    }
                     if let Some(max_attempts) = self.config.reconnect_max_attempts
                         && attempt >= max_attempts
                     {
@@ -527,7 +538,8 @@ impl GrpcStream {
         let max_messages = self.config.max_messages.unwrap_or(usize::MAX);
         let terminate_on_error = self.config.terminate_on_error;
         let reconnect_max_attempts = self.config.reconnect_max_attempts;
-        let mut backoff = self.config.reconnect_initial_backoff;
+        let reconnect_initial_backoff = self.config.reconnect_initial_backoff;
+        let mut backoff = reconnect_initial_backoff;
         let max_backoff = self.config.reconnect_max_backoff;
 
         Box::pin(async_stream::try_stream! {
@@ -630,6 +642,14 @@ impl GrpcStream {
                             // fragile `unreachable!()` (#78 LOW).
                             Err(error)?;
                             return;
+                        }
+                        // Progress before the disconnect → the stream recovered,
+                        // so reset the attempt counter and backoff (count only
+                        // *consecutive* failures, don't pin backoff at the cap) —
+                        // audit #146 H8.
+                        if consumed > 0 {
+                            attempt = 0;
+                            backoff = reconnect_initial_backoff;
                         }
                         if let Some(max_attempts) = reconnect_max_attempts
                             && attempt >= max_attempts

--- a/crates/source/postgres/src/stream.rs
+++ b/crates/source/postgres/src/stream.rs
@@ -123,10 +123,13 @@ fn bind_params<'q>(
     config_params: &'q [Value],
     bind_values: &'q [Value],
 ) -> sqlx::query::Query<'q, sqlx::Postgres, sqlx::postgres::PgArguments> {
-    for param in config_params {
-        query = query.bind(param);
-    }
-    for value in bind_values {
+    // Bind the static config params and the per-context values as native
+    // scalar types, in positional order ($1, $2, …). Binding a raw
+    // `serde_json::Value` encodes it as `jsonb` (sqlx), which breaks comparisons
+    // against typed columns — e.g. `WHERE id = $1` against an integer column
+    // fails with "operator does not exist: integer = jsonb". config_params
+    // previously bound the raw Value and hit exactly this (audit #146 H12).
+    for value in config_params.iter().chain(bind_values) {
         query = match value {
             Value::String(s) => query.bind(s.clone()),
             Value::Number(n) if n.is_i64() => query.bind(n.as_i64().unwrap()),


### PR DESCRIPTION
## Summary

PR 3 of the HIGH-tier fixes from the #146 pre-1.0 audit — **streaming / auth reliability**. Builds on merged #147, #148, #149.

> Refs #146 (HIGH items H3, H8, H11, H12). **H9 (Kafka resume offset) is deferred to its own follow-up PR** — the correct fix needs careful rdkafka assignment/position handling plus a Kafka/Docker integration test, and warrants isolation rather than being rushed here.

## The fixes

### H3 — HTTP 429 was non-retriable for XML / GraphQL sources
`crates/core/src/error.rs`. `is_retriable()` retried only `>=500` and the dedicated `RateLimited` variant; XML/GraphQL surface a rate-limit as a plain `HttpStatus{429}`, so the shared retry executor aborted on the first 429. **Fix:** 429 is now retriable. REST is unaffected (it maps 429 → `RateLimited` itself). Unit test added.

### H8 — gRPC server-streaming reconnect counter/backoff never reset after recovery
`crates/source/grpc/src/stream.rs`. Both server-streaming paths grew the attempt counter and backoff monotonically and never reset them, so a healthy long-lived stream aborted once its *lifetime* disconnects reached `reconnect_max_attempts`, with backoff pinned at the cap after one early hiccup. **Fix:** when a disconnect delivered messages (`consumed > 0`) the stream recovered, so the attempt counter and backoff reset — only *consecutive* failures count.

### H11 — OAuth / token-endpoint providers had no HTTP timeout (hung IdP wedged every sharer)
`crates/auth/`. The providers built `Client::new()` (no timeout) and hold a single-flight mutex across the token-fetch await, so a hung/unreachable IdP would wedge that mutex — and every connector sharing the provider — indefinitely. **Fix:** all three providers build the client via a shared helper with a 30s request timeout, so a stuck fetch fails and releases the lock.

### H12 — Postgres source bound static `params` as jsonb
`crates/source/postgres/src/stream.rs`. `bind_params` bound the configured `params` as raw `serde_json::Value` → jsonb, so a parameterized `WHERE` against a typed column failed (`operator does not exist: integer = jsonb`). **Fix:** `config_params` now use the same native-scalar destructuring as the per-context `bind_values`, unified into one positional bind loop.

## Verification

- `cargo fmt --all --check` clean; `cargo clippy --all-targets --all-features -- -D warnings` clean on core / grpc / postgres / auth.
- H3 unit test (`http_status_429_is_retriable`) runs locally. H8/H11 are reconnect/timeout behavior (logic-level; integration in CI). H12 mirrors the already-tested `bind_values` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
