### PR TITLE
fix(core): commit DLQ page before honoring budget abort (M4, #146)

### DIFF
--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -606,7 +606,19 @@ where
                         envelopes.splice(0..0, quality_envelopes);
                         let page_failures = envelopes.len();
 
-                        // Budget checks — increment counter before returning.
+                        // Budget checks. `write_batch_partial` above already
+                        // committed this page's survivors to the main sink, so
+                        // we must NOT abort here: returning now would strand
+                        // those committed survivors without advancing the
+                        // bookmark (they would re-deliver on the next run) and
+                        // drop this page's failures before they reach the DLQ
+                        // (#146 M4). Instead, record the budget error, finish
+                        // committing the page below (route failures to the DLQ,
+                        // flush, persist the bookmark), and abort only once the
+                        // page is fully durable. The failed rows that crossed
+                        // the threshold are still written to the DLQ — losing
+                        // them would be strictly worse than the small overshoot.
+                        let mut budget_error: Option<FaucetError> = None;
                         if let Some(limit) = dlq_cfg.max_failures_per_page
                             && page_failures > limit
                         {
@@ -614,19 +626,20 @@ where
                             lbl.retain(|l| l.key() != "dlq_connector");
                             lbl.push(Label::new("scope", SharedString::const_str("per_page")));
                             counter!("faucet_sink_dlq_budget_exceeded_total", lbl).increment(1);
-                            return Err(FaucetError::Sink(format!(
+                            budget_error = Some(FaucetError::Sink(format!(
                                 "DLQ per-page budget exceeded: {page_failures} > {limit}"
                             )));
                         }
                         let new_total = dlq_stats.records_dlq + page_failures;
-                        if let Some(limit) = dlq_cfg.max_failures_total
+                        if budget_error.is_none()
+                            && let Some(limit) = dlq_cfg.max_failures_total
                             && new_total > limit
                         {
                             let mut lbl = metric_labels.clone();
                             lbl.retain(|l| l.key() != "dlq_connector");
                             lbl.push(Label::new("scope", SharedString::const_str("total")));
                             counter!("faucet_sink_dlq_budget_exceeded_total", lbl).increment(1);
-                            return Err(FaucetError::Sink(format!(
+                            budget_error = Some(FaucetError::Sink(format!(
                                 "DLQ total budget exceeded: {new_total} > {limit}"
                             )));
                         }
@@ -714,6 +727,16 @@ where
                                 store.put(key, &bookmark).await?;
                             }
                             last_bookmark = Some(bookmark);
+                        }
+
+                        // The page is now durable — survivors committed to the
+                        // main sink, failures routed to the DLQ, and (if the
+                        // page carried one) the bookmark persisted. Honor a
+                        // deferred DLQ-budget abort now, so the run still stops
+                        // as a circuit breaker but never re-delivers this
+                        // already-committed page (#146 M4).
+                        if let Some(e) = budget_error {
+                            return Err(e);
                         }
                     } else {
                         // ── DLQ-disabled path (today's behaviour) ──────────────
@@ -1917,6 +1940,80 @@ mod tests {
             matches!(&result, Err(FaucetError::Sink(m)) if m.contains("total budget exceeded")),
             "got: {result:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn dlq_per_page_budget_exceeded_commits_page_before_aborting() {
+        // M4 (#146): write_batch_partial already commits the survivors to the
+        // main sink. When the per-page budget then trips, the run must finish
+        // committing the page — route its failures to the DLQ and persist the
+        // bookmark — BEFORE aborting, so the committed survivors do NOT
+        // re-deliver on the next run and the failed rows are not lost.
+        let main = PartialSink::new(vec![1, 2]); // rows 1,2 fail; row 0 commits
+        let dlq = std::sync::Arc::new(MockSink::new());
+        let mut dlq_cfg = DlqConfig::new(dlq.clone());
+        dlq_cfg.max_failures_per_page = Some(1); // 2 failures > 1 → trips
+
+        let store: std::sync::Arc<dyn StateStore> = std::sync::Arc::new(MemoryStateStore::new());
+        let pages: Vec<Result<StreamPage, FaucetError>> = vec![Ok(StreamPage {
+            records: (0..3).map(|i| json!({ "i": i })).collect(),
+            bookmark: Some(json!("v1")),
+        })];
+        let stream = futures::stream::iter(pages);
+        let result = run_stream(
+            stream,
+            &main,
+            RunStreamOptions::new()
+                .with_dlq(dlq_cfg)
+                .with_state(std::sync::Arc::clone(&store), "k"),
+        )
+        .await;
+
+        // Run still aborts with the budget error.
+        assert!(
+            matches!(&result, Err(FaucetError::Sink(m)) if m.contains("per-page budget exceeded")),
+            "got: {result:?}"
+        );
+        // The survivor (row 0) was committed to the main sink.
+        assert_eq!(main.committed.lock().unwrap().len(), 1);
+        // The two failures were routed to the DLQ (not lost on abort).
+        assert_eq!(dlq.0.lock().unwrap().len(), 2);
+        // The bookmark was persisted, so the survivor will NOT re-deliver.
+        assert_eq!(store.get("k").await.unwrap(), Some(json!("v1")));
+    }
+
+    #[tokio::test]
+    async fn dlq_total_budget_exceeded_commits_tripping_page_before_aborting() {
+        // M4 (#146): same guarantee for the cumulative total budget — the page
+        // that crosses the threshold is committed fully (failures→DLQ, bookmark
+        // persisted) before the run aborts.
+        let main = PartialSink::new(vec![1, 2]); // rows 1,2 fail; row 0 commits
+        let dlq = std::sync::Arc::new(MockSink::new());
+        let mut dlq_cfg = DlqConfig::new(dlq.clone());
+        dlq_cfg.max_failures_total = Some(1); // 2 failures > 1 → trips
+
+        let store: std::sync::Arc<dyn StateStore> = std::sync::Arc::new(MemoryStateStore::new());
+        let pages: Vec<Result<StreamPage, FaucetError>> = vec![Ok(StreamPage {
+            records: (0..3).map(|i| json!({ "i": i })).collect(),
+            bookmark: Some(json!("v1")),
+        })];
+        let stream = futures::stream::iter(pages);
+        let result = run_stream(
+            stream,
+            &main,
+            RunStreamOptions::new()
+                .with_dlq(dlq_cfg)
+                .with_state(std::sync::Arc::clone(&store), "k"),
+        )
+        .await;
+
+        assert!(
+            matches!(&result, Err(FaucetError::Sink(m)) if m.contains("total budget exceeded")),
+            "got: {result:?}"
+        );
+        assert_eq!(main.committed.lock().unwrap().len(), 1);
+        assert_eq!(dlq.0.lock().unwrap().len(), 2);
+        assert_eq!(store.get("k").await.unwrap(), Some(json!("v1")));
     }
 
     /// DLQ sink that always fails. Used to assert the router does not

--- a/docs/book/src/cookbook/dlq.md
+++ b/docs/book/src/cookbook/dlq.md
@@ -44,6 +44,26 @@ Sinks that *do* report per-row results (BigQuery, Elasticsearch) override the
 partial-write path so only the genuinely failed rows are dead-lettered — they are
 not duplicated into the DLQ.
 
+## Failure budgets
+
+A DLQ keeps a run going through *occasional* bad rows, but a flood of failures
+usually means something is broken upstream. Two optional budgets turn the DLQ
+into a circuit breaker:
+
+```yaml
+  dlq:
+    sink: { type: jsonl, config: { path: ./dead-letters.jsonl } }
+    max_failures_per_page: 50    # abort if a single page dead-letters > 50 rows
+    max_failures_total: 500      # abort once the run has dead-lettered > 500 rows
+```
+
+When a budget trips, the run aborts — but only **after the page that crossed the
+threshold is fully committed**: its surviving rows are written to the main sink,
+its failed rows are routed to the DLQ, and (if the page carried one) the bookmark
+advances. So the committed survivors are *not* re-delivered when you fix the
+upstream problem and re-run, and the failed rows are preserved in the DLQ for
+replay rather than dropped. The run still stops, so you get alerted.
+
 > The full design is in
 > [`docs/superpowers/specs/2026-05-24-dlq-design.md`](https://github.com/PawanSikawat/faucet-stream/blob/main/docs)
 > and the `faucet_core::dlq` module on docs.rs.


### PR DESCRIPTION
## Summary

Addresses **M4** of the #146 pre-1.0 audit (medium cluster 1/6: *core DLQ ordering*).

The streaming DLQ router wrote a page's survivors to the main sink via `write_batch_partial`, then checked the per-page / total failure budgets and returned `Err` on overflow — **before** routing the page's failures to the DLQ and **before** advancing the bookmark (`crates/core/src/pipeline.rs`). On a budget overflow:

- the committed survivors were **re-delivered** on the next run (the bookmark never advanced), and
- the page's failed rows were **dropped** — they never reached the DLQ at all (the `return Err` fired ahead of the DLQ write).

## Fix

Defer the budget abort. On overflow we now record the error, finish committing the page — route its failures to the DLQ, flush both sinks, persist the bookmark — and abort only once the page is fully durable. The run still stops as a circuit breaker, but the already-committed page is durable, so survivors are not re-delivered and the failed rows are preserved in the DLQ for replay.

Per-page precedence over total is preserved; the `faucet_sink_dlq_budget_exceeded_total` counter still increments on the tripping page.

## Tests (TDD: red → green)

- `dlq_per_page_budget_exceeded_commits_page_before_aborting` — page carries a bookmark, per-page budget trips: asserts the run still errors, the survivor is committed, the failures land in the DLQ, **and** the bookmark is persisted.
- `dlq_total_budget_exceeded_commits_tripping_page_before_aborting` — same guarantee for the cumulative total budget.

Both failed before the change (failures absent from the DLQ, bookmark unpersisted) and pass after. All 25 existing DLQ tests + the full 437-test core suite stay green.

## Docs

Added a **Failure budgets** section to `docs/book/src/cookbook/dlq.md` documenting `max_failures_per_page` / `max_failures_total` and the commit-then-abort semantics (the fields were previously undocumented in the cookbook).

## Note on semantics

This makes a budget-overflow abort commit the *tripping* page in full (survivors → main sink, failures → DLQ, bookmark advanced) before stopping — consistent with the rest of the DLQ contract (failed rows go to the DLQ; the main stream advances). The alternative (abort without committing) is what caused the re-delivery bug. At-least-once is unchanged; this only removes the avoidable duplicate emission.

Part of #146.