### PR TITLE
fix(sinks): schema-scope Postgres AutoMap discovery + per-row HTTP DLQ (M13/M14, #146)

### DIFF
--- a/crates/sink/http/README.md
+++ b/crates/sink/http/README.md
@@ -268,8 +268,8 @@ let sink = HttpSink::new(config);
 ## How It Works
 
 - The HTTP client is created in `HttpSink::new()` and reused across all requests.
-- In **Individual** mode, each record is sent as a separate HTTP request. Requests are executed concurrently using a `tokio::sync::Semaphore` to limit the number of in-flight requests to the `concurrency` value. All requests must succeed; the first error aborts the batch via `try_join_all`.
-- In **Array** mode, all records are collected into a JSON array and sent as a single request body.
+- In **Individual** mode, each record is sent as a separate HTTP request. Requests are executed concurrently (bounded by `concurrency`). In `write_batch` the first error aborts the batch; when a [DLQ](https://pawansikawat.github.io/faucet-stream/cookbook/dlq.html) is configured the sink instead reports **per-row** outcomes (`write_batch_partial`), attempting every record and dead-lettering only the ones that actually failed — so already-delivered rows are never duplicated against a non-idempotent endpoint.
+- In **Array** mode, all records are collected into a JSON array and sent as a single request body. A failure can't be attributed to specific rows, so the whole array surfaces as an error (the DLQ `on_batch_error` policy decides whether to abort or dead-letter the batch).
 - Retry logic: on transient failures (network errors, retriable HTTP status codes), the request is retried up to `max_retries` times. Non-retriable errors (4xx client errors) are returned immediately.
 - Authentication and custom headers are applied to every request.
 - HTTP responses are validated using `check_http_response()` from `faucet-core`, which checks status codes and returns structured errors.

--- a/crates/sink/http/src/sink.rs
+++ b/crates/sink/http/src/sink.rs
@@ -293,8 +293,8 @@ impl faucet_core::Sink for HttpSink {
     ///
     /// In **Individual** mode every record is an independent POST, so each
     /// record's success/failure is attributable: we attempt *all* of them
-    /// (unlike [`write_batch`](Self::write_batch), whose `?` short-circuits on
-    /// the first failure) and return one `Ok`/`Err` per record. Without this
+    /// (unlike `write_batch`, whose `?` short-circuits on the first failure)
+    /// and return one `Ok`/`Err` per record. Without this
     /// override the default impl would surface the first error as an outer
     /// `Err`, and under `on_batch_error: dlq_all` the pipeline would route the
     /// *entire* batch to the DLQ — duplicating the already-delivered rows

--- a/crates/sink/http/src/sink.rs
+++ b/crates/sink/http/src/sink.rs
@@ -287,6 +287,69 @@ impl faucet_core::Sink for HttpSink {
             }
         }
     }
+
+    /// Report per-row outcomes so the DLQ router dead-letters only the records
+    /// that genuinely failed.
+    ///
+    /// In **Individual** mode every record is an independent POST, so each
+    /// record's success/failure is attributable: we attempt *all* of them
+    /// (unlike [`write_batch`](Self::write_batch), whose `?` short-circuits on
+    /// the first failure) and return one `Ok`/`Err` per record. Without this
+    /// override the default impl would surface the first error as an outer
+    /// `Err`, and under `on_batch_error: dlq_all` the pipeline would route the
+    /// *entire* batch to the DLQ — duplicating the already-delivered rows
+    /// against a non-idempotent endpoint (#146 M14).
+    ///
+    /// In **Array** mode a single array POST cannot attribute a failure to
+    /// specific rows, so it stays all-or-nothing (matches the default trait
+    /// impl): the whole batch surfaces as an outer `Err` and the router's
+    /// `on_batch_error` policy decides whether to abort or dead-letter it.
+    async fn write_batch_partial(
+        &self,
+        records: &[Value],
+    ) -> Result<Vec<faucet_core::RowOutcome>, FaucetError> {
+        if records.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let auth = self.resolve_auth().await?;
+
+        match &self.config.batch_mode {
+            HttpBatchMode::Individual => {
+                let concurrency = self.config.concurrency.max(1);
+                let auth = &auth;
+                // Attempt every record (failures don't short-circuit the
+                // siblings) with at most `concurrency` POSTs in flight. Tag each
+                // outcome with its index so we can restore record order after
+                // the unordered completion. The per-record futures are built
+                // eagerly (lazy, not yet polled) so `buffer_unordered` drives a
+                // single concrete future type.
+                let pending: Vec<_> =
+                    records
+                        .iter()
+                        .enumerate()
+                        .map(|(idx, record)| async move {
+                            (idx, self.send_with_retry(record, auth).await)
+                        })
+                        .collect();
+                let mut indexed: Vec<(usize, faucet_core::RowOutcome)> =
+                    futures::stream::iter(pending)
+                        .buffer_unordered(concurrency)
+                        .collect()
+                        .await;
+                indexed.sort_by_key(|(idx, _)| *idx);
+                tracing::debug!(
+                    records = records.len(),
+                    "HTTP individual partial batch written"
+                );
+                Ok(indexed.into_iter().map(|(_, outcome)| outcome).collect())
+            }
+            HttpBatchMode::Array => {
+                self.write_batch(records).await?;
+                Ok(records.iter().map(|_| Ok(())).collect())
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/sink/http/tests/partial_failures.rs
+++ b/crates/sink/http/tests/partial_failures.rs
@@ -1,0 +1,84 @@
+//! Integration tests for the HTTP sink's `write_batch_partial` (#146 M14).
+//!
+//! In Individual mode each record is an independent POST, so a partial
+//! failure must be reported per-row — only the genuinely failed record is
+//! dead-lettered, not the whole batch (which, under `dlq_all`, would duplicate
+//! the already-delivered rows against a non-idempotent endpoint). In Array
+//! mode a single array POST cannot attribute a failure to specific rows, so the
+//! whole batch surfaces as an outer error (the default all-or-nothing path).
+
+use faucet_core::Sink;
+use faucet_sink_http::{HttpBatchMode, HttpSink, HttpSinkConfig};
+use serde_json::json;
+use wiremock::matchers::{body_json, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test]
+async fn individual_mode_write_batch_partial_reports_only_the_failed_row() {
+    let server = MockServer::start().await;
+    // Exact per-record body matchers (mutually exclusive) so each POST matches
+    // exactly one mock. Record id=1 gets a non-retriable 400; the rest 200.
+    for id in [0_u64, 2, 3] {
+        Mock::given(method("POST"))
+            .and(path("/ingest"))
+            .and(body_json(json!({ "id": id })))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+    }
+    Mock::given(method("POST"))
+        .and(path("/ingest"))
+        .and(body_json(json!({ "id": 1 })))
+        .respond_with(ResponseTemplate::new(400))
+        .mount(&server)
+        .await;
+
+    let config = HttpSinkConfig::new(format!("{}/ingest", server.uri()))
+        .batch_mode(HttpBatchMode::Individual)
+        .concurrency(4);
+    let sink = HttpSink::new(config);
+
+    let records: Vec<_> = (0..4).map(|i| json!({ "id": i })).collect();
+    let outcomes = sink
+        .write_batch_partial(&records)
+        .await
+        .expect("partial write must not surface an outer error in Individual mode");
+
+    assert_eq!(outcomes.len(), 4, "one outcome per record");
+    assert!(outcomes[0].is_ok());
+    assert!(
+        outcomes[1].is_err(),
+        "only the 400 record (id=1) is a failure"
+    );
+    assert!(outcomes[2].is_ok());
+    assert!(outcomes[3].is_ok());
+
+    // All four records were actually POSTed (the failure did not short-circuit
+    // the siblings the way the first-error `?` in write_batch does).
+    let requests = server.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 4, "every record is POSTed exactly once");
+}
+
+#[tokio::test]
+async fn array_mode_write_batch_partial_surfaces_outer_error() {
+    // A single array POST can't attribute a failure to specific rows, so the
+    // whole batch fails as an outer error (the router then applies on_batch_error).
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/ingest"))
+        .respond_with(ResponseTemplate::new(400))
+        .mount(&server)
+        .await;
+
+    let config = HttpSinkConfig::new(format!("{}/ingest", server.uri()))
+        .batch_mode(HttpBatchMode::Array)
+        .with_batch_size(0);
+    let sink = HttpSink::new(config);
+
+    let records: Vec<_> = (0..3).map(|i| json!({ "id": i })).collect();
+    let result = sink.write_batch_partial(&records).await;
+    assert!(
+        result.is_err(),
+        "array-mode failure must surface as an outer error, not per-row outcomes"
+    );
+}

--- a/crates/sink/postgres/README.md
+++ b/crates/sink/postgres/README.md
@@ -57,6 +57,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 |-------|------|---------|-------------|
 | `connection_url` | `String` | *(required)* | PostgreSQL connection URL (e.g. `postgres://user:pass@host:5432/db`) |
 | `table_name` | `String` | *(required)* | Target table name |
+| `schema` | `Option<String>` | `null` | Schema (namespace) qualifying `table_name`. When set, both AutoMap column discovery and the `INSERT` target `schema.table_name` explicitly. When unset, the table resolves against the connection's `search_path` |
 | `column_mapping` | `PostgresColumnMapping` | `Jsonb { column: "data" }` | How to map JSON records to table columns (see below) |
 | `batch_size` | `usize` | `1000` | Maximum rows per multi-row `INSERT`. See [Streaming and batching](#streaming-and-batching) below |
 | `max_connections` | `u32` | `5` | Maximum number of connections in the connection pool |
@@ -92,7 +93,7 @@ quoting, and JSONB vs AutoMap behaviour are unchanged.
 | Variant | Description |
 |---------|-------------|
 | `Jsonb { column }` | Insert each record as a single `jsonb` column. The column name defaults to `"data"` but can be overridden. Uses PostgreSQL's `unnest($1::jsonb[])` for efficient batch inserts. |
-| `AutoMap` | Map top-level JSON keys directly to table columns. Column names are discovered from `information_schema.columns`. Only keys that match existing columns are inserted; extra keys are silently ignored. Records with no matching keys are skipped with a warning. |
+| `AutoMap` | Map top-level JSON keys directly to table columns. Column names are discovered from the PostgreSQL catalog, scoped (via `to_regclass`) to exactly the relation the `INSERT` targets — the configured `schema` if set, otherwise the `search_path`-resolved table. Only keys that match existing columns are inserted; extra keys are silently ignored. Records with no matching keys are skipped with a warning. |
 
 ### Builder Methods
 
@@ -272,7 +273,7 @@ let sink = PostgresSink::new(config).await?;
 - A connection pool is created in `PostgresSink::new()` using `sqlx::PgPool` with the configured `max_connections`.
 - `write_batch()` slices records into chunks of `batch_size` (or forwards the whole slice when `batch_size = 0`) and inserts each chunk using a single multi-row INSERT statement.
 - In JSONB mode, inserts use `INSERT INTO table (col) SELECT * FROM unnest($1::jsonb[])` for maximum efficiency.
-- In AutoMap mode, each column's name **and underlying type** (`udt_name`) are queried from `information_schema.columns`. A multi-row `INSERT INTO ... VALUES ($1::int4, $2::timestamptz), ...` is built dynamically with a per-column cast, and each value is bound as text so the destination column's input function parses it — numbers, booleans, timestamps, uuids land in their native column types, and `json`/`jsonb` columns receive JSON text. (Values are **not** bound as `jsonb` regardless of column type — doing so previously made the typed-column example above fail at runtime.) The column set is the **union** of record keys across the batch (in declared table order), so a field present only in a later record is still written; a row missing a column binds SQL `NULL`.
+- In AutoMap mode, each column's name **and underlying type** (`udt_name`) are queried from the PostgreSQL catalog, scoped via `to_regclass` to exactly the relation the `INSERT` targets (the configured `schema`, else the `search_path`-resolved table) — so a same-named table in another schema can't pollute the column set. A multi-row `INSERT INTO ... VALUES ($1::int4, $2::timestamptz), ...` is built dynamically with a per-column cast, and each value is bound as text so the destination column's input function parses it — numbers, booleans, timestamps, uuids land in their native column types, and `json`/`jsonb` columns receive JSON text. (Values are **not** bound as `jsonb` regardless of column type — doing so previously made the typed-column example above fail at runtime.) The column set is the **union** of record keys across the batch (in declared table order), so a field present only in a later record is still written; a row missing a column binds SQL `NULL`.
 - All identifiers (table names, column names) are quoted using `quote_ident()` to prevent SQL injection.
 
 ## License

--- a/crates/sink/postgres/src/config.rs
+++ b/crates/sink/postgres/src/config.rs
@@ -31,6 +31,16 @@ pub struct PostgresSinkConfig {
     pub connection_url: String,
     /// Target table name.
     pub table_name: String,
+    /// Optional schema (namespace) qualifying [`table_name`](Self::table_name).
+    ///
+    /// When set, both the AutoMap column-discovery probe and the `INSERT`
+    /// target `schema.table_name` explicitly. When unset (the default), the
+    /// table resolves against the connection's `search_path`, and column
+    /// discovery is scoped to whichever schema the `INSERT` actually resolves
+    /// to — so a same-named table in another schema no longer pollutes the
+    /// AutoMap column set (#146 M13).
+    #[serde(default)]
+    pub schema: Option<String>,
     /// How to map JSON records to columns.
     pub column_mapping: PostgresColumnMapping,
     /// Maximum rows per multi-row `INSERT` statement. Defaults to
@@ -68,6 +78,7 @@ impl std::fmt::Debug for PostgresSinkConfig {
         f.debug_struct("PostgresSinkConfig")
             .field("connection_url", &"***")
             .field("table_name", &self.table_name)
+            .field("schema", &self.schema)
             .field("column_mapping", &self.column_mapping)
             .field("batch_size", &self.batch_size)
             .field("max_connections", &self.max_connections)
@@ -81,10 +92,18 @@ impl PostgresSinkConfig {
         Self {
             connection_url: connection_url.into(),
             table_name: table_name.into(),
+            schema: None,
             column_mapping: PostgresColumnMapping::default(),
             batch_size: DEFAULT_BATCH_SIZE,
             max_connections: 5,
         }
+    }
+
+    /// Set the schema (namespace) that qualifies the table. When unset, the
+    /// table resolves against the connection's `search_path`.
+    pub fn with_schema(mut self, schema: impl Into<String>) -> Self {
+        self.schema = Some(schema.into());
+        self
     }
 
     /// Set the column mapping strategy.

--- a/crates/sink/postgres/src/sink.rs
+++ b/crates/sink/postgres/src/sink.rs
@@ -45,6 +45,23 @@ fn pg_bind_text(value: Option<&Value>, udt: &str) -> Option<String> {
     }
 }
 
+/// Build the SQL relation reference for the configured table, optionally
+/// schema-qualified.
+///
+/// Both the AutoMap column-discovery probe and the `INSERT` statements use this
+/// single helper, so column discovery is always scoped to the *exact* relation
+/// the `INSERT` targets (#146 M13). With no schema the bare quoted table name
+/// resolves against the connection's `search_path`; with a schema it becomes
+/// `"schema"."table"`, pinning both discovery and insert to that namespace —
+/// otherwise a table of the same name in another schema pollutes the
+/// AutoMap column set (duplicate / wrong columns).
+fn qualified_table_ref(schema: Option<&str>, table: &str) -> String {
+    match schema {
+        Some(s) => format!("{}.{}", quote_ident(s), quote_ident(table)),
+        None => quote_ident(table),
+    }
+}
+
 /// A sink that writes JSON records to a PostgreSQL table.
 pub struct PostgresSink {
     config: PostgresSinkConfig,
@@ -73,7 +90,7 @@ impl PostgresSink {
         let json_values: Vec<serde_json::Value> = records.to_vec();
         let query = format!(
             "INSERT INTO {} ({}) SELECT * FROM unnest($1::jsonb[])",
-            quote_ident(&self.config.table_name),
+            qualified_table_ref(self.config.schema.as_deref(), &self.config.table_name),
             quote_ident(column)
         );
 
@@ -102,24 +119,45 @@ impl PostgresSink {
             return Ok(0);
         }
 
-        // Get column names AND their underlying types from the table. `udt_name`
-        // is the concrete type (e.g. `int4`, `timestamptz`, `numeric`, `jsonb`,
-        // `uuid`, `text`) used as the per-placeholder cast target below.
+        // Get column names AND their underlying types for the *exact* relation
+        // the INSERT will target. Scoping by `to_regclass(<qualified ref>)`
+        // resolves the relation the same way the INSERT does — by the configured
+        // schema if set, otherwise by the connection's `search_path` — so a
+        // table of the same name in another schema can no longer pollute the
+        // column set with duplicate/wrong columns (#146 M13). The previous query
+        // filtered `information_schema.columns` by `table_name` alone (no schema
+        // predicate), merging every same-named table across all schemas.
+        //
+        // `pg_type.typname` is the concrete type (`int4`, `timestamptz`,
+        // `numeric`, `jsonb`, `uuid`, `text`, …) — identical to the old
+        // `information_schema.columns.udt_name` — used as the per-placeholder
+        // cast target below. `::text` casts the `name`-typed catalog columns so
+        // sqlx decodes them as `String`.
+        let table_ref = qualified_table_ref(self.config.schema.as_deref(), &self.config.table_name);
         let columns: Vec<(String, String)> = sqlx::query(
-            "SELECT column_name, udt_name FROM information_schema.columns WHERE table_name = $1 ORDER BY ordinal_position"
+            "SELECT a.attname::text AS column_name, t.typname::text AS udt_name \
+             FROM pg_catalog.pg_attribute a \
+             JOIN pg_catalog.pg_type t ON t.oid = a.atttypid \
+             WHERE a.attrelid = to_regclass($1)::oid \
+               AND a.attnum > 0 AND NOT a.attisdropped \
+             ORDER BY a.attnum",
         )
-        .bind(&self.config.table_name)
+        .bind(&table_ref)
         .fetch_all(&self.pool)
         .await
         .map_err(|e| FaucetError::Sink(format!("failed to query table columns: {e}")))?
         .iter()
-        .map(|row| (row.get::<String, _>("column_name"), row.get::<String, _>("udt_name")))
+        .map(|row| {
+            (
+                row.get::<String, _>("column_name"),
+                row.get::<String, _>("udt_name"),
+            )
+        })
         .collect();
 
         if columns.is_empty() {
             return Err(FaucetError::Sink(format!(
-                "table '{}' has no columns or does not exist",
-                self.config.table_name
+                "table {table_ref} has no columns or does not exist"
             )));
         }
 
@@ -196,7 +234,7 @@ impl PostgresSink {
 
             let query = format!(
                 "INSERT INTO {} ({}) VALUES {}",
-                quote_ident(&self.config.table_name),
+                table_ref,
                 col_names.join(", "),
                 value_tuples.join(", ")
             );
@@ -306,8 +344,33 @@ impl faucet_core::Sink for PostgresSink {
 
 #[cfg(test)]
 mod tests {
-    use super::pg_bind_text;
+    use super::{pg_bind_text, qualified_table_ref};
     use serde_json::json;
+
+    #[test]
+    fn qualified_table_ref_unqualified_is_bare_quoted_table() {
+        // No schema → bare quoted table, resolved against the search_path.
+        assert_eq!(qualified_table_ref(None, "events"), "\"events\"");
+    }
+
+    #[test]
+    fn qualified_table_ref_with_schema_is_schema_dot_table() {
+        // With a schema → "schema"."table", so discovery and INSERT both
+        // target the same explicit relation (#146 M13).
+        assert_eq!(
+            qualified_table_ref(Some("analytics"), "events"),
+            "\"analytics\".\"events\""
+        );
+    }
+
+    #[test]
+    fn qualified_table_ref_escapes_embedded_quotes() {
+        // SQL-injection safety: embedded double-quotes are doubled.
+        assert_eq!(
+            qualified_table_ref(Some("we\"ird"), "ta\"ble"),
+            "\"we\"\"ird\".\"ta\"\"ble\""
+        );
+    }
 
     #[test]
     fn null_and_absent_bind_sql_null() {

--- a/crates/sink/postgres/tests/batching.rs
+++ b/crates/sink/postgres/tests/batching.rs
@@ -371,3 +371,61 @@ async fn write_batch_auto_map_unions_columns_across_heterogeneous_batch() {
         "row missing the unioned column binds SQL NULL"
     );
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn auto_map_discovery_is_scoped_to_configured_schema() {
+    // M13 (audit #146): AutoMap column discovery previously filtered
+    // `information_schema.columns` by `table_name` alone, with no schema
+    // predicate, so a same-named table in another schema polluted the column
+    // set. Here two schemas each hold an `events` table with a DISTINCT extra
+    // column. Before the fix the probe returned the columns of BOTH tables —
+    // the shared `id`/`shared` columns appear twice, so the generated
+    // `INSERT INTO analytics.events (id, shared, id, shared, only_analytics)`
+    // fails with "column specified more than once". After the fix discovery is
+    // scoped via `to_regclass` to exactly the relation the INSERT targets, so
+    // only `analytics.events`' columns are used and the write succeeds.
+    let (_container, url) = start_postgres().await;
+    let pool = sqlx::PgPool::connect(&url).await.expect("pool connect");
+    for stmt in [
+        "CREATE SCHEMA staging",
+        "CREATE SCHEMA analytics",
+        "CREATE TABLE staging.events (id BIGINT, shared TEXT, only_staging TEXT)",
+        "CREATE TABLE analytics.events (id BIGINT, shared TEXT, only_analytics TEXT)",
+    ] {
+        sqlx::query(stmt).execute(&pool).await.expect("ddl");
+    }
+    pool.close().await;
+
+    let config = PostgresSinkConfig::new(&url, "events")
+        .with_schema("analytics")
+        .column_mapping(PostgresColumnMapping::AutoMap)
+        .with_batch_size(0);
+    let sink = PostgresSink::new(config).await.expect("sink new");
+
+    // `only_analytics` exists only in analytics.events; `only_staging` only in
+    // staging.events. The record carries the analytics-only column.
+    let records = vec![json!({ "id": 7, "shared": "s", "only_analytics": "a" })];
+    let written = sink
+        .write_batch(&records)
+        .await
+        .expect("write must target analytics.events only");
+    assert_eq!(written, 1);
+
+    let pool = sqlx::PgPool::connect(&url).await.expect("pool connect");
+    use sqlx::Row;
+    // The row landed in analytics.events with the analytics-only column set.
+    let row = sqlx::query("SELECT id, shared, only_analytics FROM analytics.events WHERE id = 7")
+        .fetch_one(&pool)
+        .await
+        .expect("row in analytics.events");
+    assert_eq!(row.get::<i64, _>("id"), 7);
+    assert_eq!(row.get::<String, _>("shared"), "s");
+    assert_eq!(row.get::<String, _>("only_analytics"), "a");
+    // staging.events is untouched.
+    let staging_count: i64 = sqlx::query_scalar("SELECT COUNT(*)::BIGINT FROM staging.events")
+        .fetch_one(&pool)
+        .await
+        .expect("count staging");
+    assert_eq!(staging_count, 0, "staging.events must not be written to");
+    pool.close().await;
+}

--- a/docs/book/src/cookbook/dlq.md
+++ b/docs/book/src/cookbook/dlq.md
@@ -40,9 +40,10 @@ For a sink that can only succeed or fail a whole batch (no per-row detail):
 - `propagate` — a batch failure aborts the run (the default, fail-fast behavior).
 - `dlq_all` — route every row in the failed batch to the DLQ and keep going.
 
-Sinks that *do* report per-row results (BigQuery, Elasticsearch) override the
-partial-write path so only the genuinely failed rows are dead-lettered — they are
-not duplicated into the DLQ.
+Sinks that *do* report per-row results (BigQuery, Elasticsearch, and the HTTP
+sink in `Individual` mode) override the partial-write path so only the genuinely
+failed rows are dead-lettered — the already-delivered rows are not duplicated
+into the DLQ.
 
 > The full design is in
 > [`docs/superpowers/specs/2026-05-24-dlq-design.md`](https://github.com/PawanSikawat/faucet-stream/blob/main/docs)


### PR DESCRIPTION
## Summary

Cluster 2/6 of the #146 medium backlog: **sink correctness** (M13 + M14).

### M13 — Postgres AutoMap discovery ignores schema

The AutoMap column-discovery probe filtered `information_schema.columns` by `table_name` alone (no schema predicate), so in a multi-schema DB a same-named table in another schema polluted the discovered column set — duplicate/wrong columns — while the `INSERT` targeted the `search_path`-resolved table. (MySQL was already correctly scoped via `AND TABLE_SCHEMA = DATABASE()`.)

**Fix:** add an optional `schema` config field, and scope discovery via `to_regclass(<qualified ref>)::oid` so the probe resolves the *exact* relation the `INSERT` targets — the configured `schema` if set, else the `search_path`-resolved table. A single `qualified_table_ref` helper builds the relation reference for both the JSONB-mode and AutoMap `INSERT`s and the discovery probe, so they can never diverge.

### M14 — HTTP sink duplicates delivered rows into the DLQ

The HTTP sink didn't override `write_batch_partial`. In Individual mode a partial failure surfaced as an outer error, so under `on_batch_error: dlq_all` the pipeline routed the **entire** batch to the DLQ — duplicating the rows that had already POSTed successfully against a non-idempotent endpoint.

**Fix:** override `write_batch_partial`. Individual mode now attempts *every* record (no first-error short-circuit) with bounded concurrency and reports per-row outcomes, so only the genuinely failed POSTs are dead-lettered. Array mode stays all-or-nothing — a single array POST can't attribute a failure to specific rows — matching the default trait behavior.

## Tests (TDD: red → green)

- `qualified_table_ref` unit tests (unqualified / schema-qualified / quote-escaping) — local red→green.
- `auto_map_discovery_is_scoped_to_configured_schema` — two schemas hold an `events` table with distinct extra columns; before the fix the merged column set produces a duplicate-column `INSERT` that errors; after, discovery is scoped to the configured schema and the write lands correctly. *(testcontainers — runs under Docker/CI.)*
- `individual_mode_write_batch_partial_reports_only_the_failed_row` — wiremock, one record gets a 400, asserts only that row is `Err` and all four were POSTed once. Red before the override.
- `array_mode_write_batch_partial_surfaces_outer_error` — regression guard for the array fallback.

Postgres unit suite + HTTP suite (incl. both new wiremock tests) green; clippy clean on both crates.

> Docker isn't available in my local env, so the Postgres multi-schema integration test was compile-checked locally and will execute in CI. The HTTP wiremock tests run locally and pass.

## Docs

- `crates/sink/postgres/README.md` — new `schema` field; AutoMap discovery description updated to the `to_regclass` scoping.
- `crates/sink/http/README.md` — corrected the stale "How It Works" note and documented the per-row DLQ behavior.
- `docs/book/src/cookbook/dlq.md` — HTTP (Individual mode) added to the per-row-capable sinks.

Part of #146.