### PR TITLE
fix(sources): REST 204, WS idle reset, Parquet up-front schema check, CDC slot retry (M9/M10/M11/M12, #146)

### DIFF
--- a/crates/source/parquet/README.md
+++ b/crates/source/parquet/README.md
@@ -143,10 +143,13 @@ memory is bounded by `batch_size * row_width` rather than the file size.
   Parquet row-group. Useful for sinks (SQL `COPY`, BigQuery load jobs)
   that prefer one large request per natural file boundary.
 - Multi-file scans (Glob / S3 prefix) flatten through the streaming
-  pipeline in sorted-path order. The first file's Arrow schema is the
-  reference; any subsequent file with a different schema surfaces as
-  `FaucetError::Source` naming both paths and the first diverging field
-  — matching the eager `fetch_with_context` behaviour.
+  pipeline in sorted-path order. **All files' Arrow schemas are validated
+  up front** — by a cheap footer-only metadata probe — before any rows are
+  yielded, so a schema mismatch on a later file fails *before* earlier
+  files' rows are committed downstream rather than after a partial write
+  (#146 M11). The first file's schema is the reference; any divergent file
+  surfaces as `FaucetError::Source` naming both paths and the first
+  diverging field — matching the eager `fetch_with_context` behaviour.
 - Every page carries `bookmark: None` — the Parquet source has no
   incremental-replication mode.
 - The trait-level `batch_size` argument that `Pipeline::run` passes is

--- a/crates/source/parquet/src/stream.rs
+++ b/crates/source/parquet/src/stream.rs
@@ -313,18 +313,18 @@ impl faucet_core::Source for ParquetSource {
                 return;
             }
 
-            let mut total_records = 0usize;
-            let mut total_pages = 0usize;
-            // Reference schema captured from the first opened file. Used to
-            // detect cross-file divergence in glob / S3-prefix scans —
-            // preserves the eager `fetch_with_context` failure mode.
+            // Validate every file's schema UP FRONT, before yielding any rows.
+            // A divergent schema on a *later* file must fail before earlier
+            // files' rows are committed downstream — otherwise the streaming
+            // path performs a partial, non-atomic write and only then aborts
+            // (#146 M11). Opening a target reads just the Parquet footer
+            // metadata (not row data), so this is a cheap probe; we drop each
+            // probe stream immediately. The cost is one extra footer read per
+            // file, paid once before streaming begins.
             let mut reference: Option<(String, arrow::datatypes::SchemaRef)> = None;
-
             for target in &targets {
-                let (mut batches, arrow_schema, display) =
-                    self.open_target_stream(target).await?;
-
-                if let Some((ref first_path, ref first_schema)) = reference {
+                let (_, arrow_schema, display) = self.open_target_stream(target).await?;
+                if let Some((first_path, first_schema)) = &reference {
                     if first_schema != &arrow_schema {
                         Err(FaucetError::Source(schema_mismatch_message_pair(
                             first_path,
@@ -334,9 +334,15 @@ impl faucet_core::Source for ParquetSource {
                         )))?;
                     }
                 } else {
-                    reference = Some((display.clone(), arrow_schema));
+                    reference = Some((display, arrow_schema));
                 }
+            }
 
+            // Schemas are consistent across all files; stream rows file by file.
+            let mut total_records = 0usize;
+            let mut total_pages = 0usize;
+            for target in &targets {
+                let (mut batches, _schema, display) = self.open_target_stream(target).await?;
                 while let Some(batch) = batches.next().await {
                     let batch = batch.map_err(|e| {
                         FaucetError::Source(format!(

--- a/crates/source/parquet/tests/streaming.rs
+++ b/crates/source/parquet/tests/streaming.rs
@@ -230,6 +230,56 @@ async fn stream_pages_multi_file_glob_flattens() {
 }
 
 #[tokio::test]
+async fn stream_pages_schema_mismatch_fails_before_yielding_any_rows() {
+    // M11 (#146): a schema mismatch on a *later* file must fail eagerly,
+    // before any earlier file's rows are yielded downstream. Under the old
+    // streaming path, file A's rows were yielded to the sink and only then was
+    // file B opened and its divergent schema detected — a partial, non-atomic
+    // write committed before the abort. Schemas are now validated up front, so
+    // the mismatch surfaces with zero pages emitted.
+    let dir = TempDir::new().unwrap();
+    let path_a = dir.path().join("a_part.parquet");
+    let path_b = dir.path().join("b_part.parquet");
+    // File A: (id, name). File B: a divergent schema (id only).
+    let (batch_a, _) = small_batch(300);
+    let schema_b = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
+    let batch_b = RecordBatch::try_new(
+        schema_b.clone(),
+        vec![Arc::new(Int64Array::from((0..300i64).collect::<Vec<_>>()))],
+    )
+    .unwrap();
+    write_single_row_group(&path_a, &batch_a);
+    write_single_row_group(&path_b, &batch_b);
+
+    let pattern = format!("{}/*_part.parquet", dir.path().display());
+    let source = ParquetSource::new(ParquetSourceConfig::glob(pattern).with_batch_size(100))
+        .await
+        .unwrap();
+
+    let ctx = std::collections::HashMap::new();
+    let mut stream = source.stream_pages(&ctx, 0);
+    let mut pages_before_error = 0usize;
+    let mut errored = false;
+    while let Some(item) = stream.next().await {
+        match item {
+            Ok(_) => pages_before_error += 1,
+            Err(_) => {
+                errored = true;
+                break;
+            }
+        }
+    }
+    assert!(
+        errored,
+        "a cross-file schema mismatch must surface as an error"
+    );
+    assert_eq!(
+        pages_before_error, 0,
+        "no rows may be yielded before the schema-mismatch abort (eager, atomic fail)"
+    );
+}
+
+#[tokio::test]
 async fn stream_pages_empty_file_yields_no_pages() {
     let dir = TempDir::new().unwrap();
     let path = dir.path().join("empty.parquet");

--- a/crates/source/postgres-cdc/README.md
+++ b/crates/source/postgres-cdc/README.md
@@ -127,6 +127,7 @@ The decoder fails fast (`FaucetError::Source`, which the pipeline restarts from 
 | `max_staged_records`        | usize?   | `null`  | Max change records buffered for a **single in-progress transaction** before the run aborts with a typed error. `null` = unbounded. A safety valve against OOM on huge bulk transactions — see [Transactional consistency](#transactional-consistency). |
 | `status_update_interval`    | seconds  | `10`    | Standby Status Update cadence. Must be `< idle_timeout` and well under the server's `wal_sender_timeout`. |
 | `tcp_keepalive`             | seconds  | `60`    | TCP keepalive on the replication connection. |
+| `slot_acquire_retries`      | u32      | `10`    | Retries when the slot is still **active** (held by a not-yet-released prior connection) on a rapid restart. Both the pre-stream slot advance and `START_REPLICATION` are retried with exponential backoff (250 ms, doubling, capped at 4 s). `0` = fail fast. |
 
 ---
 

--- a/crates/source/postgres-cdc/src/config.rs
+++ b/crates/source/postgres-cdc/src/config.rs
@@ -23,6 +23,9 @@ fn default_tcp_keepalive() -> Duration {
 fn default_batch_size() -> usize {
     DEFAULT_BATCH_SIZE
 }
+fn default_slot_acquire_retries() -> u32 {
+    10
+}
 
 /// Configuration for [`PostgresCdcSource`](crate::PostgresCdcSource).
 #[derive(Clone, Serialize, Deserialize, JsonSchema)]
@@ -154,6 +157,17 @@ pub struct PostgresCdcSourceConfig {
     /// initial-snapshot style runs.
     #[serde(default = "default_batch_size")]
     pub batch_size: usize,
+
+    /// Number of times to retry acquiring the replication slot when the server
+    /// reports it is still **active** (held by a not-yet-released prior
+    /// connection). On a rapid restart — a scheduler or `serve` re-running the
+    /// pipeline before the previous backend has dropped the slot — both the
+    /// pre-stream `pg_replication_slot_advance` and `START_REPLICATION` fail
+    /// with *"replication slot … is active for PID …"*. Each retry waits an
+    /// exponentially increasing backoff (250 ms, doubling, capped at 4 s).
+    /// `0` disables retries (fail fast). Defaults to 10.
+    #[serde(default = "default_slot_acquire_retries")]
+    pub slot_acquire_retries: u32,
 }
 
 /// Lifetime of a newly-created replication slot.
@@ -206,6 +220,7 @@ impl std::fmt::Debug for PostgresCdcSourceConfig {
             .field("status_update_interval", &self.status_update_interval)
             .field("tcp_keepalive", &self.tcp_keepalive)
             .field("batch_size", &self.batch_size)
+            .field("slot_acquire_retries", &self.slot_acquire_retries)
             .finish()
     }
 }
@@ -303,6 +318,7 @@ mod tests {
             status_update_interval: std::time::Duration::from_secs(10),
             tcp_keepalive: std::time::Duration::from_secs(60),
             batch_size: DEFAULT_BATCH_SIZE,
+            slot_acquire_retries: default_slot_acquire_retries(),
         }
     }
 

--- a/crates/source/postgres-cdc/src/replication.rs
+++ b/crates/source/postgres-cdc/src/replication.rs
@@ -500,6 +500,57 @@ fn quote_literal(s: &str) -> String {
 
 // ── Tests ──────────────────────────────────────────────────────────────────
 
+/// Returns `true` if `err` is Postgres reporting that the replication slot is
+/// still **active** — held by a backend that has not yet released it. Postgres
+/// raises *"replication slot \"…\" is active for PID …"* (SQLSTATE `55006`).
+///
+/// This is transient on a rapid restart: a scheduler or `serve` re-running the
+/// pipeline before the previous connection's backend has fully exited finds the
+/// slot momentarily still in use. It clears within a short window, so it is
+/// safe to retry after a backoff (#146 M12).
+pub fn is_slot_active_error(err: &FaucetError) -> bool {
+    let msg = err.to_string().to_ascii_lowercase();
+    msg.contains("is active") || msg.contains("55006")
+}
+
+/// Exponential backoff for slot-acquisition retries: `250ms · 2^attempt`,
+/// capped at 4 s.
+fn slot_acquire_backoff(attempt: u32) -> Duration {
+    let factor = 1u64.checked_shl(attempt).unwrap_or(u64::MAX);
+    let ms = 250u64.saturating_mul(factor).min(4000);
+    Duration::from_millis(ms)
+}
+
+/// Run `op`, retrying up to `max_retries` times with exponential backoff while
+/// it fails because the replication slot is still active (#146 M12). Any other
+/// error — and the final attempt's error after exhausting retries — is returned
+/// immediately. `max_retries = 0` preserves the previous fail-fast behaviour.
+pub async fn retry_on_slot_active<F, Fut, T>(max_retries: u32, op: F) -> Result<T, FaucetError>
+where
+    F: Fn() -> Fut,
+    Fut: std::future::Future<Output = Result<T, FaucetError>>,
+{
+    let mut attempt = 0u32;
+    loop {
+        match op().await {
+            Ok(value) => return Ok(value),
+            Err(e) if attempt < max_retries && is_slot_active_error(&e) => {
+                let backoff = slot_acquire_backoff(attempt);
+                tracing::warn!(
+                    attempt = attempt + 1,
+                    max_retries,
+                    backoff_ms = backoff.as_millis() as u64,
+                    error = %e,
+                    "postgres-cdc: replication slot still active; retrying after backoff"
+                );
+                tokio::time::sleep(backoff).await;
+                attempt += 1;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -586,5 +637,91 @@ mod tests {
     fn parse_url_rejects_missing_user() {
         let err = parse_url("postgres://db.example.com/analytics").unwrap_err();
         assert!(format!("{err}").contains("missing a user"), "{err}");
+    }
+
+    #[test]
+    fn is_slot_active_error_classifies_the_postgres_message() {
+        // The canonical Postgres message (SQLSTATE 55006).
+        assert!(is_slot_active_error(&FaucetError::Source(
+            "postgres-cdc start_replication: db error: ERROR: replication slot \"s\" \
+             is active for PID 4242"
+                .into()
+        )));
+        // SQLSTATE code present.
+        assert!(is_slot_active_error(&FaucetError::Source(
+            "55006: replication slot is in use".into()
+        )));
+        // Unrelated errors are NOT slot-active.
+        assert!(!is_slot_active_error(&FaucetError::Source(
+            "connection refused".into()
+        )));
+        assert!(!is_slot_active_error(&FaucetError::Config(
+            "bad url".into()
+        )));
+    }
+
+    #[test]
+    fn slot_acquire_backoff_grows_and_is_capped() {
+        assert_eq!(slot_acquire_backoff(0), Duration::from_millis(250));
+        assert_eq!(slot_acquire_backoff(1), Duration::from_millis(500));
+        assert_eq!(slot_acquire_backoff(2), Duration::from_millis(1000));
+        // Capped at 4s no matter how large the attempt.
+        assert_eq!(slot_acquire_backoff(20), Duration::from_millis(4000));
+        assert_eq!(slot_acquire_backoff(64), Duration::from_millis(4000));
+    }
+
+    #[tokio::test]
+    async fn retry_on_slot_active_retries_then_succeeds() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        let calls = AtomicU32::new(0);
+        let result = retry_on_slot_active(5, || {
+            let n = calls.fetch_add(1, Ordering::SeqCst);
+            async move {
+                if n < 2 {
+                    Err(FaucetError::Source(
+                        "replication slot \"s\" is active for PID 1".into(),
+                    ))
+                } else {
+                    Ok::<u32, FaucetError>(42)
+                }
+            }
+        })
+        .await;
+        assert_eq!(result.unwrap(), 42);
+        assert_eq!(calls.load(Ordering::SeqCst), 3, "2 failures + 1 success");
+    }
+
+    #[tokio::test]
+    async fn retry_on_slot_active_gives_up_after_max_retries() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        let calls = AtomicU32::new(0);
+        let result: Result<(), _> = retry_on_slot_active(2, || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            async { Err(FaucetError::Source("slot is active".into())) }
+        })
+        .await;
+        assert!(result.is_err());
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            3,
+            "initial attempt + 2 retries"
+        );
+    }
+
+    #[tokio::test]
+    async fn retry_on_slot_active_does_not_retry_unrelated_errors() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        let calls = AtomicU32::new(0);
+        let result: Result<(), _> = retry_on_slot_active(5, || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            async { Err(FaucetError::Source("connection refused".into())) }
+        })
+        .await;
+        assert!(result.is_err());
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "a non-slot-active error must not be retried"
+        );
     }
 }

--- a/crates/source/postgres-cdc/src/stream.rs
+++ b/crates/source/postgres-cdc/src/stream.rs
@@ -315,15 +315,25 @@ impl PostgresCdcSource {
             // do NOT advance, so an interrupted run with no persisted bookmark
             // redelivers rather than loses data (#78/#1).
             if let Some(lsn) = start_lsn {
-                replication::advance_slot(
-                    &self.config.connection_url,
-                    &self.config.slot_name,
-                    lsn,
-                )
+                // Both the slot advance and START_REPLICATION require the slot
+                // to be inactive; on a rapid re-run the prior connection may not
+                // have released it yet ("slot is active"). Retry with bounded
+                // backoff instead of failing the whole run (#146 M12).
+                replication::retry_on_slot_active(self.config.slot_acquire_retries, || {
+                    replication::advance_slot(
+                        &self.config.connection_url,
+                        &self.config.slot_name,
+                        lsn,
+                    )
+                })
                 .await?;
             }
 
-            let mut duplex = replication::start_replication(&client, &params).await?;
+            let mut duplex = replication::retry_on_slot_active(
+                self.config.slot_acquire_retries,
+                || replication::start_replication(&client, &params),
+            )
+            .await?;
 
             // Send an initial Standby Status Update advertising the same
             // durable position so the server's bookkeeping is consistent.

--- a/crates/source/postgres-cdc/tests/integration.rs
+++ b/crates/source/postgres-cdc/tests/integration.rs
@@ -79,6 +79,7 @@ fn cfg(url: &str, slot: &str, publication: &str) -> PostgresCdcSourceConfig {
         status_update_interval: Duration::from_secs(1),
         tcp_keepalive: Duration::from_secs(60),
         batch_size: faucet_core::DEFAULT_BATCH_SIZE,
+        slot_acquire_retries: 10,
     }
 }
 

--- a/crates/source/rest/README.md
+++ b/crates/source/rest/README.md
@@ -72,6 +72,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 | `retry_backoff` | `Duration` | `1s` | Base duration for exponential backoff between retries |
 | `tolerated_http_errors` | `Vec<u16>` | `[]` | HTTP status codes treated as an empty page **on the first request only** (i.e. a legitimately absent/empty resource). Mid-pagination a tolerated status is surfaced as an error instead of silently ending the stream — otherwise a transient failure on page _N_ would drop every later page as a "successful" run. Only safe for genuinely-empty resources. |
 
+A **`204 No Content`** response — or any `2xx` with an empty / whitespace-only
+body — is treated as an empty page ("no data"), not a parse error. A non-empty
+body that isn't valid JSON still fails loudly with `FaucetError::Json`.
+
 ### Replication Fields
 
 | Field | Type | Default | Description |

--- a/crates/source/rest/src/stream.rs
+++ b/crates/source/rest/src/stream.rs
@@ -633,7 +633,20 @@ impl RestStream {
         }
 
         let resp_headers = resp.headers().clone();
-        let body: Value = resp.json().await?;
+
+        // A 204 No Content — or any 2xx with an empty / whitespace-only body —
+        // carries no JSON to parse. `resp.json()` on such a response yields a
+        // non-retriable decode error ("EOF while parsing a value") that aborts
+        // the run; treat it as an empty page ("no data") instead (#146 M10). A
+        // non-empty body that isn't valid JSON still surfaces as a parse error.
+        if status == reqwest::StatusCode::NO_CONTENT {
+            return Ok((Value::Array(vec![]), resp_headers));
+        }
+        let bytes = resp.bytes().await?;
+        if bytes.iter().all(u8::is_ascii_whitespace) {
+            return Ok((Value::Array(vec![]), resp_headers));
+        }
+        let body: Value = serde_json::from_slice(&bytes)?;
         Ok((body, resp_headers))
     }
 }

--- a/crates/source/rest/tests/stream_test.rs
+++ b/crates/source/rest/tests/stream_test.rs
@@ -38,6 +38,80 @@ async fn test_single_page_fetch() {
 }
 
 #[tokio::test]
+async fn test_204_no_content_is_empty_page_not_error() {
+    // M10 (#146): a 204 No Content has no body. Calling resp.json() on it
+    // raises a non-retriable parse error that aborts the run; it must instead
+    // be treated as an empty page ("no data").
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/users"))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&server)
+        .await;
+
+    let stream = RestStream::new(
+        RestStreamConfig::new(&server.uri(), "/api/users")
+            .records_path("$.data[*]")
+            .pagination(PaginationStyle::None),
+    )
+    .unwrap();
+
+    let records = stream
+        .fetch_all()
+        .await
+        .expect("204 must be treated as an empty page, not a JSON error");
+    assert!(records.is_empty());
+}
+
+#[tokio::test]
+async fn test_empty_body_200_is_empty_page_not_error() {
+    // M10 (#146): an empty-body 200 likewise has nothing to parse.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/users"))
+        .respond_with(ResponseTemplate::new(200)) // no body set
+        .mount(&server)
+        .await;
+
+    let stream = RestStream::new(
+        RestStreamConfig::new(&server.uri(), "/api/users")
+            .records_path("$.data[*]")
+            .pagination(PaginationStyle::None),
+    )
+    .unwrap();
+
+    let records = stream
+        .fetch_all()
+        .await
+        .expect("empty 200 body must be treated as an empty page");
+    assert!(records.is_empty());
+}
+
+#[tokio::test]
+async fn test_malformed_nonempty_body_still_errors() {
+    // Guard: a non-empty body that isn't valid JSON must still error loudly —
+    // the empty-body tolerance must not swallow genuine parse failures.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/users"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("this is not json"))
+        .mount(&server)
+        .await;
+
+    let stream = RestStream::new(
+        RestStreamConfig::new(&server.uri(), "/api/users")
+            .records_path("$.data[*]")
+            .pagination(PaginationStyle::None),
+    )
+    .unwrap();
+
+    assert!(
+        stream.fetch_all().await.is_err(),
+        "a non-empty, non-JSON body must surface as an error"
+    );
+}
+
+#[tokio::test]
 async fn test_cursor_pagination() {
     let server = MockServer::start().await;
 

--- a/crates/source/websocket/README.md
+++ b/crates/source/websocket/README.md
@@ -58,7 +58,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 | `envelope` | bool | `false` | `true` → `{data,received_at,url}` |
 | `ping_interval` | secs | — | Client keepalive ping |
 | `max_messages` | int | — | At least one of `max_messages`/`idle_timeout` required |
-| `idle_timeout` | secs | — | Stop after this silence; also caps outages |
+| `idle_timeout` | secs | — | Stop after this long with no frame received. Reset by **any** inbound frame — data, ping/pong, or a frame dropped by `on_parse_error=skip` — so a live server streaming skippable frames does not trip it. Also caps outages |
 | `reconnect` | bool | `false` | Reconnect on drop / non-1000 close |
 | `reconnect_backoff` | secs | `1` | Fixed wait between attempts |
 | `max_reconnect_attempts` | int | — | Cap consecutive failures (`None` = unlimited) |

--- a/crates/source/websocket/src/stream.rs
+++ b/crates/source/websocket/src/stream.rs
@@ -255,11 +255,19 @@ impl Source for WebsocketSource {
                     // per-arm difference is `t.as_bytes()` vs `&b`, so both
                     // arms funnel through this single closure.
                     let mut handle_payload = |payload: &[u8]| {
+                        // A data frame (Text/Binary) arrived, so the server is
+                        // delivering — reset the idle timer here, before decode,
+                        // so a frame dropped by on_parse_error=skip (Ok(None))
+                        // still counts as activity (#146 M9). Control frames
+                        // (Ping/Pong/Close) deliberately do NOT reset it: a
+                        // client keepalive (ping_interval) elicits pongs, and
+                        // resetting on those would make idle_timeout unreachable
+                        // whenever ping_interval < idle_timeout.
+                        last_message_at = Instant::now();
                         match decode_frame(format, on_parse_error, payload) {
                             Ok(Some(v)) => {
                                 let now = if envelope { now_unix_ms() } else { 0 };
                                 buffer.push(shape_record(v, envelope, &resolved_url, now));
-                                last_message_at = Instant::now();
                                 reconnect_attempts = 0;
                                 total += 1;
                                 if total >= max_messages {

--- a/crates/source/websocket/tests/integration.rs
+++ b/crates/source/websocket/tests/integration.rs
@@ -139,6 +139,46 @@ async fn skip_drops_malformed_json() {
 }
 
 #[tokio::test]
+async fn skipped_frames_reset_idle_timeout() {
+    // M9 (#146): with on_parse_error=Skip, an unparseable frame yields no
+    // record but the connection is demonstrably alive — receiving any frame
+    // must reset the idle timer. Here the server sends one skippable frame at
+    // ~300ms (within the 400ms idle window), then a valid record at ~600ms.
+    // Before the fix the skip frame didn't reset `last_message_at`, so the run
+    // idle-timed-out at ~400ms and the valid record was never received (0
+    // records). After the fix the skip frame resets the timer, so the run stays
+    // alive long enough to receive the record.
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        if let Ok((stream, _)) = listener.accept().await {
+            let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+            tokio::time::sleep(Duration::from_millis(300)).await;
+            let _ = ws.send(Message::Text("not json".into())).await;
+            tokio::time::sleep(Duration::from_millis(300)).await;
+            let _ = ws.send(Message::Text(r#"{"id":99}"#.into())).await;
+            loop {
+                if ws.next().await.is_none() {
+                    break;
+                }
+            }
+        }
+    });
+    let mut cfg = base_config(&format!("ws://{addr}"));
+    cfg.on_parse_error = OnParseError::Skip;
+    cfg.idle_timeout = Some(Duration::from_millis(400));
+    cfg.max_messages = Some(1);
+    let src = WebsocketSource::new(cfg).unwrap();
+    let records = src.fetch_all().await.unwrap();
+    assert_eq!(
+        records.len(),
+        1,
+        "a skipped frame must reset idle_timeout so the later valid record is still received"
+    );
+    assert_eq!(records[0]["id"], 99);
+}
+
+#[tokio::test]
 async fn auth_header_is_sent() {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();


### PR DESCRIPTION
## Summary

Cluster 3/6 of the #146 medium backlog — **source reliability** (M9, M10, M11, M12).

### M10 — REST source aborts on a 204 / empty body
`resp.json()` ran unconditionally on any `2xx`, so a `204 No Content` or empty-body `200` produced a non-retriable JSON decode error (`EOF while parsing a value`) that aborted the run. Now a 204 / empty / whitespace-only body is treated as an empty page ("no data"); a non-empty body that isn't valid JSON still errors loudly.

### M9 — WebSocket idle_timeout fires on a busy connection
`last_message_at` reset only when a frame *decoded into a record*, so with `on_parse_error=skip` a server streaming unparseable frames tripped `idle_timeout` on a perfectly live connection. Now any **data** frame (Text/Binary) resets the timer *before* decode, so skipped frames count as activity. Control frames (Ping/Pong/Close) deliberately do **not** reset it — resetting on keepalive pongs would make `idle_timeout` unreachable whenever `ping_interval < idle_timeout` (caught by the existing keepalive test).

### M11 — Parquet multi-file schema mismatch commits earlier files first
The streaming path yielded each file's rows, then opened the next file and compared schemas — so a mismatch on a later file aborted *after* earlier files' rows were already committed downstream (a partial, non-atomic write). Now all files' schemas are validated **up front** via a cheap footer-only metadata probe, before any row is yielded, so the mismatch fails eagerly with nothing committed.

### M12 — postgres-cdc "slot is active" on rapid re-run
On a fast restart the previous connection may still hold the slot; both the pre-stream `pg_replication_slot_advance` and `START_REPLICATION` failed outright with no retry. Both are now retried with bounded exponential backoff (250 ms → ×2 → capped 4 s) via a new `slot_acquire_retries` config field (default 10; `0` = fail fast).

## Tests (TDD: red → green)

- **REST**: `test_204_no_content_is_empty_page_not_error`, `test_empty_body_200_is_empty_page_not_error`, and a guard `test_malformed_nonempty_body_still_errors` (wiremock).
- **WebSocket**: `skipped_frames_reset_idle_timeout` (red before fix); the full suite confirms `idle_timeout_terminates_quiet_stream` and the keepalive-ping test still behave correctly (the over-broad first cut hung the keepalive test — fixed by resetting only on data frames).
- **Parquet**: `stream_pages_schema_mismatch_fails_before_yielding_any_rows` (asserts 0 pages emitted before the abort; red before fix).
- **postgres-cdc**: `is_slot_active_error` classification, `slot_acquire_backoff` bounds, and three `retry_on_slot_active` loop tests (retries-then-succeeds / gives-up / no-retry-on-unrelated) — all DB-free.

All four crates' suites green; clippy clean. (CDC slot-active integration and the Parquet multi-schema test that needs Docker are compile-checked locally and run in CI.)

## Docs
Updated the REST, WebSocket, Parquet, and postgres-cdc crate READMEs for the new behavior / config field.

Part of #146.