### PR TITLE
fix(serve): idempotency & history correctness (M5/M6/M7/M8, #146)

### DIFF
--- a/cli/src/serve/error.rs
+++ b/cli/src/serve/error.rs
@@ -38,6 +38,9 @@ pub enum ServeError {
     QueueFull {
         retry_after_secs: u64,
     },
+    /// 503 — a required dependency is temporarily unavailable (e.g. idempotency
+    /// can't be honored while the run-history backend is degraded).
+    Unavailable(String),
     Internal(String),
 }
 
@@ -50,6 +53,7 @@ impl ServeError {
             ServeError::Unprocessable { .. } => StatusCode::UNPROCESSABLE_ENTITY,
             ServeError::Conflict(_) => StatusCode::CONFLICT,
             ServeError::QueueFull { .. } => StatusCode::TOO_MANY_REQUESTS,
+            ServeError::Unavailable(_) => StatusCode::SERVICE_UNAVAILABLE,
             ServeError::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
@@ -62,6 +66,7 @@ impl ServeError {
             ServeError::Unprocessable { .. } => "unprocessable",
             ServeError::Conflict(_) => "conflict",
             ServeError::QueueFull { .. } => "queue_full",
+            ServeError::Unavailable(_) => "unavailable",
             ServeError::Internal(_) => "internal",
         }
     }
@@ -74,6 +79,7 @@ impl ServeError {
             ServeError::Unprocessable { message, .. } => message.clone(),
             ServeError::Conflict(m) => m.clone(),
             ServeError::QueueFull { .. } => "run queue is full; retry later".into(),
+            ServeError::Unavailable(m) => m.clone(),
             ServeError::Internal(m) => m.clone(),
         }
     }

--- a/cli/src/serve/history/fallback.rs
+++ b/cli/src/serve/history/fallback.rs
@@ -93,9 +93,35 @@ impl RunHistory for FallbackHistory {
         run_id: &str,
         window: Duration,
     ) -> Result<Claim, HistoryError> {
-        via!(self,
-            p => p.claim_idempotency(key, fingerprint, run_id, window),
-            f => f.claim_idempotency(key, fingerprint, run_id, window))
+        // Idempotency is correctness-critical, so it does NOT use the generic
+        // `via!` fall-through. While the primary is healthy it is the
+        // authoritative claim store; its first error trips degraded.
+        if !self.is_degraded()
+            && let Some(p) = self.primary.as_ref()
+        {
+            match p.claim_idempotency(key, fingerprint, run_id, window).await {
+                Ok(v) => return Ok(v),
+                Err(e) => self.trip(&e),
+            }
+        }
+        // Tripped from a healthy primary: the in-memory fallback cannot see
+        // claims persisted to the primary before the trip, so serving a `Fresh`
+        // from memory could duplicate a run the primary already claimed.
+        // Fail closed — reject idempotent submissions while degraded rather than
+        // risk a silent duplicate (#146 M5). A submission with no idempotency
+        // key never reaches here. When the wrapper *started* degraded (`primary`
+        // is `None` — no primary ever held a claim), the in-memory store is the
+        // sole authoritative store, so its claims are safe to serve.
+        if self.primary.is_some() {
+            return Err(HistoryError::Degraded(
+                "idempotency unavailable: the run-history backend is degraded; retry once it \
+                 recovers, or resubmit without an idempotency key"
+                    .into(),
+            ));
+        }
+        self.fallback
+            .claim_idempotency(key, fingerprint, run_id, window)
+            .await
     }
 
     async fn upsert(&self, rec: &RunRecord) -> Result<(), HistoryError> {
@@ -188,6 +214,45 @@ mod tests {
         // Subsequent reads are served from the in-memory fallback.
         let got = fb.get("r1").await.unwrap();
         assert_eq!(got.unwrap().run_id, "r1");
+    }
+
+    #[tokio::test]
+    async fn claim_fails_closed_once_degraded_from_a_healthy_primary() {
+        // M5 (#146): the primary may hold claims the in-memory fallback can't
+        // see, so once it trips, an idempotency claim must fail CLOSED rather
+        // than return a `Fresh` from the empty memory store and duplicate a run.
+        let fb = FallbackHistory::healthy(Box::new(AlwaysFail), Duration::from_secs(60), "test");
+        let err = fb
+            .claim_idempotency("k", "fp", "r1", Duration::from_secs(60))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, HistoryError::Degraded(_)), "got {err:?}");
+        assert!(fb.degraded(), "the failed primary claim trips degraded");
+        // A second attempt (already degraded) also fails closed — never Fresh.
+        assert!(matches!(
+            fb.claim_idempotency("k", "fp", "r2", Duration::from_secs(60))
+                .await,
+            Err(HistoryError::Degraded(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn claim_uses_memory_when_started_degraded() {
+        // No primary ever existed → the in-memory store is authoritative, so
+        // idempotency works normally (no split is possible).
+        let fb = FallbackHistory::degraded_at_startup(Duration::from_secs(60), "test");
+        assert_eq!(
+            fb.claim_idempotency("k", "fp", "r1", Duration::from_secs(60))
+                .await
+                .unwrap(),
+            Claim::Fresh
+        );
+        assert_eq!(
+            fb.claim_idempotency("k", "fp", "r2", Duration::from_secs(60))
+                .await
+                .unwrap(),
+            Claim::Replay("r1".into())
+        );
     }
 
     #[tokio::test]

--- a/cli/src/serve/history/memory.rs
+++ b/cli/src/serve/history/memory.rs
@@ -129,14 +129,21 @@ impl RunHistory for MemoryHistory {
     }
 
     async fn delete(&self, id: &str) -> Result<DeleteOutcome, HistoryError> {
-        match self.runs.get(id).map(|r| r.status) {
-            None => Ok(DeleteOutcome::NotFound),
-            Some(s) if !s.is_terminal() => Ok(DeleteOutcome::StillRunning),
-            Some(_) => {
-                self.runs.remove(id);
-                Ok(DeleteOutcome::Deleted)
-            }
+        let Some(rec) = self.runs.get(id).map(|r| r.clone()) else {
+            return Ok(DeleteOutcome::NotFound);
+        };
+        if !rec.status.is_terminal() {
+            return Ok(DeleteOutcome::StillRunning);
         }
+        self.runs.remove(id);
+        // Also drop this run's idempotency claim so a replay of the key starts a
+        // fresh run instead of 404-ing on the now-deleted record until the claim
+        // self-expires (#146 M8). Only remove it if the claim still points at
+        // THIS run — a newer run may have re-claimed the key after expiry.
+        if let Some(key) = rec.idempotency_key.as_deref() {
+            self.idem.remove_if(key, |_, e| e.run_id == id);
+        }
+        Ok(DeleteOutcome::Deleted)
     }
 
     async fn purge_expired(&self, retain_for: Duration) -> Result<usize, HistoryError> {
@@ -235,6 +242,70 @@ mod tests {
             .unwrap();
         assert_eq!(h.delete("run").await.unwrap(), DeleteOutcome::Deleted);
         assert!(h.get("run").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn delete_also_removes_matching_idem_claim() {
+        // M8 (#146): deleting a run must drop its idempotency claim, so a later
+        // replay of the key starts a fresh run instead of 404-ing on the
+        // now-missing record until the claim self-expires.
+        let h = MemoryHistory::new(Duration::from_secs(3600));
+        let w = Duration::from_secs(3600);
+        assert_eq!(
+            h.claim_idempotency("k", "fp", "r1", w).await.unwrap(),
+            Claim::Fresh
+        );
+        let mut r = RunRecord::queued(
+            "r1".into(),
+            None,
+            BTreeMap::new(),
+            Some("k".into()),
+            Utc::now(),
+        );
+        r.status = RunStatus::Completed;
+        r.finished_at = Some(Utc::now());
+        h.upsert(&r).await.unwrap();
+
+        assert_eq!(h.delete("r1").await.unwrap(), DeleteOutcome::Deleted);
+        // The key is free again → fresh run, not a replay of the deleted one.
+        assert_eq!(
+            h.claim_idempotency("k", "fp", "r2", w).await.unwrap(),
+            Claim::Fresh
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_keeps_claim_owned_by_a_newer_run() {
+        // Guard: deleting an OLD run must not remove a claim a NEWER run owns.
+        let h = MemoryHistory::new(Duration::from_secs(3600));
+        h.claim_idempotency("k", "fp", "r1", Duration::from_secs(3600))
+            .await
+            .unwrap();
+        // r2 re-claims the key (force the prior claim stale with a zero window).
+        assert_eq!(
+            h.claim_idempotency("k", "fp", "r2", Duration::ZERO)
+                .await
+                .unwrap(),
+            Claim::Fresh
+        );
+        let mut r1 = RunRecord::queued(
+            "r1".into(),
+            None,
+            BTreeMap::new(),
+            Some("k".into()),
+            Utc::now(),
+        );
+        r1.status = RunStatus::Completed;
+        r1.finished_at = Some(Utc::now());
+        h.upsert(&r1).await.unwrap();
+        assert_eq!(h.delete("r1").await.unwrap(), DeleteOutcome::Deleted);
+        // The claim still belongs to r2.
+        assert_eq!(
+            h.claim_idempotency("k", "fp", "r3", Duration::from_secs(3600))
+                .await
+                .unwrap(),
+            Claim::Replay("r2".into())
+        );
     }
 
     #[tokio::test]

--- a/cli/src/serve/history/mod.rs
+++ b/cli/src/serve/history/mod.rs
@@ -159,6 +159,11 @@ pub struct ListPage {
 pub enum HistoryError {
     #[error("run-history backend error: {0}")]
     Backend(String),
+    /// The backend is degraded and the operation can't be honored safely
+    /// (e.g. an idempotency claim that would risk a duplicate run). Maps to a
+    /// `503` so the caller can retry once the backend recovers (#146 M5).
+    #[error("{0}")]
+    Degraded(String),
 }
 
 #[async_trait]

--- a/cli/src/serve/history/sql.rs
+++ b/cli/src/serve/history/sql.rs
@@ -61,6 +61,11 @@ pub struct Stmts {
     pub insert_idem: String,
     pub select_idem: String,
     pub takeover_idem: String,
+    /// Delete the idempotency claim(s) that point at a given run — used when a
+    /// run is deleted so a replay of the key starts fresh rather than 404-ing
+    /// on the missing record (#146 M8). Scoped by `run_id`, so a newer run that
+    /// re-claimed the same key keeps its claim.
+    pub delete_idem_by_run: String,
 }
 
 impl Stmts {
@@ -112,6 +117,7 @@ impl Stmts {
             takeover_idem: "UPDATE faucet_serve_idem \
                 SET run_id=$1,fingerprint=$2,claimed_at=$3 WHERE key=$4 AND claimed_at=$5"
                 .into(),
+            delete_idem_by_run: "DELETE FROM faucet_serve_idem WHERE run_id=$1".into(),
         }
     }
 
@@ -154,6 +160,7 @@ impl Stmts {
             takeover_idem: "UPDATE faucet_serve_idem \
                 SET run_id=?,fingerprint=?,claimed_at=? WHERE key=? AND claimed_at=?"
                 .into(),
+            delete_idem_by_run: "DELETE FROM faucet_serve_idem WHERE run_id=?".into(),
         }
     }
 }
@@ -462,6 +469,16 @@ macro_rules! impl_sql_history {
                     }
                     Some(_) => {
                         sqlx::query(&self.stmts.delete)
+                            .bind(id)
+                            .execute(&self.pool)
+                            .await
+                            .map_err(backend)?;
+                        // Drop the run's idempotency claim too, so a replay of
+                        // the key starts fresh instead of 404-ing on the deleted
+                        // record until the claim self-expires (#146 M8). Scoped
+                        // by run_id, so a newer run that re-claimed the same key
+                        // keeps its claim.
+                        sqlx::query(&self.stmts.delete_idem_by_run)
                             .bind(id)
                             .execute(&self.pool)
                             .await

--- a/cli/src/serve/idempotency.rs
+++ b/cli/src/serve/idempotency.rs
@@ -18,6 +18,45 @@ pub fn fingerprint(merged: &Value, name: Option<&str>) -> String {
     format!("{:x}", hasher.finalize())
 }
 
+/// Fold the run-affecting request fields into the config fingerprint.
+///
+/// The idempotency key identifies a *request*, not just a config: a key
+/// replayed with the same merged config but a different `clock`,
+/// `timeout_secs`, or `labels` is a genuinely different run and must be
+/// detected as a **conflict** (409), not silently replayed as the original
+/// (#146 M7). `clock` is the most important — it sets the `${now.*}` backfill
+/// window the run reads, so a retry that changes only the clock would otherwise
+/// return the original backfill's result.
+///
+/// `labels` is hashed in `BTreeMap` (sorted-key) order, so the result is stable
+/// regardless of insertion order.
+pub fn request_fingerprint(
+    config_fingerprint: &str,
+    clock: Option<&str>,
+    timeout_secs: Option<u64>,
+    labels: &std::collections::BTreeMap<String, String>,
+) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(config_fingerprint.as_bytes());
+    hasher.update([0u8]);
+    hasher.update(clock.unwrap_or("").as_bytes());
+    hasher.update([0u8]);
+    hasher.update(
+        timeout_secs
+            .map(|t| t.to_string())
+            .unwrap_or_default()
+            .as_bytes(),
+    );
+    hasher.update([0u8]);
+    for (k, v) in labels {
+        hasher.update(k.as_bytes());
+        hasher.update([0u8]);
+        hasher.update(v.as_bytes());
+        hasher.update([0u8]);
+    }
+    format!("{:x}", hasher.finalize())
+}
+
 /// Append a canonical (object keys sorted) JSON rendering of `v` to `out`.
 fn write_canonical(v: &Value, out: &mut String) {
     match v {
@@ -79,6 +118,45 @@ mod tests {
         assert_ne!(
             fingerprint(&json!([1, 2]), None),
             fingerprint(&json!([2, 1]), None)
+        );
+    }
+
+    #[test]
+    fn request_fingerprint_includes_run_affecting_fields() {
+        use std::collections::BTreeMap;
+        let cfg_fp = fingerprint(&json!({ "a": 1 }), Some("p"));
+        let empty = BTreeMap::new();
+        let base = request_fingerprint(&cfg_fp, None, None, &empty);
+
+        // Same inputs → same fingerprint.
+        assert_eq!(base, request_fingerprint(&cfg_fp, None, None, &empty));
+        // A different clock (backfill window) must change it (#146 M7).
+        assert_ne!(
+            base,
+            request_fingerprint(&cfg_fp, Some("2026-01-01T00:00:00Z"), None, &empty)
+        );
+        // timeout_secs is run-affecting.
+        assert_ne!(base, request_fingerprint(&cfg_fp, None, Some(30), &empty));
+        // labels are part of the request identity.
+        let mut labels = BTreeMap::new();
+        labels.insert("env".to_string(), "prod".to_string());
+        assert_ne!(base, request_fingerprint(&cfg_fp, None, None, &labels));
+        // A different config fingerprint still changes the result.
+        let other_cfg = fingerprint(&json!({ "a": 2 }), Some("p"));
+        assert_ne!(base, request_fingerprint(&other_cfg, None, None, &empty));
+    }
+
+    #[test]
+    fn request_fingerprint_label_value_is_significant() {
+        use std::collections::BTreeMap;
+        let cfg_fp = fingerprint(&json!({}), None);
+        let mut a = BTreeMap::new();
+        a.insert("k".to_string(), "v1".to_string());
+        let mut b = BTreeMap::new();
+        b.insert("k".to_string(), "v2".to_string());
+        assert_ne!(
+            request_fingerprint(&cfg_fp, None, None, &a),
+            request_fingerprint(&cfg_fp, None, None, &b)
         );
     }
 }

--- a/cli/src/serve/runner.rs
+++ b/cli/src/serve/runner.rs
@@ -87,13 +87,26 @@ pub async fn submit(state: ServerState, req: SubmitRequest) -> Result<SubmitResp
     // Idempotency claim (if a key was supplied).
     if let Some(key) = &req.idempotency_key {
         let merged = serde_json::to_value(&loaded.cfg).unwrap_or(serde_json::Value::Null);
-        let fp = idempotency::fingerprint(&merged, loaded.cfg.name.as_deref());
+        // Fold the run-affecting request fields (clock / timeout_secs / labels)
+        // into the fingerprint, not just the config — so a key replayed with a
+        // different backfill `clock` is a 409, not a replay of the original
+        // run's window (#146 M7).
+        let fp_config = idempotency::fingerprint(&merged, loaded.cfg.name.as_deref());
+        let fp = idempotency::request_fingerprint(
+            &fp_config,
+            req.clock.as_deref(),
+            req.timeout_secs,
+            &req.labels,
+        );
         match state
             .history()
             .claim_idempotency(key, &fp, &run_id, state.idempotency_retention())
             .await
-            .map_err(|e| ServeError::Internal(e.to_string()))?
-        {
+            .map_err(|e| match e {
+                // Degraded backend can't safely honor idempotency → 503, retry.
+                crate::serve::history::HistoryError::Degraded(m) => ServeError::Unavailable(m),
+                other => ServeError::Internal(other.to_string()),
+            })? {
             Claim::Fresh => {}
             Claim::Replay(existing) => {
                 metrics::record_idempotency_hit();
@@ -457,14 +470,43 @@ async fn finalize(state: &ServerState, run_id: &str, started: DateTime<Utc>, ter
     let finished = Utc::now();
     let elapsed = (finished - started).to_std().ok().map(|d| d.as_secs_f64());
     let (status, reason, records, invs, error) = term.into_parts();
-    if let Ok(Some(mut rec)) = state.history().get(run_id).await {
-        rec.status = status;
-        rec.finished_at = Some(finished);
-        rec.elapsed_secs = elapsed;
-        rec.records_written = records;
-        rec.invocations = invs;
-        rec.error = error;
-        let _ = state.history().upsert(&rec).await;
+    // Read-modify-write the existing record to preserve its metadata
+    // (name / labels / idempotency_key / submitted_at). If it can't be read —
+    // the backend errored, or the record was purged / landed in another store
+    // under degraded fallback — DON'T silently drop the terminal status (#146
+    // M6): reconstruct a minimal terminal record and upsert it, so the run
+    // never lingers non-terminal while `record_run_finished` has already fired.
+    let mut rec = match state.history().get(run_id).await {
+        Ok(Some(rec)) => rec,
+        Ok(None) => {
+            tracing::warn!(
+                run_id,
+                "finalize: run record not found; writing a fresh terminal record"
+            );
+            RunRecord::queued(run_id.to_string(), None, BTreeMap::new(), None, started)
+        }
+        Err(e) => {
+            tracing::warn!(
+                run_id,
+                error = %e,
+                "finalize: failed to read run record; writing a fresh terminal record"
+            );
+            RunRecord::queued(run_id.to_string(), None, BTreeMap::new(), None, started)
+        }
+    };
+    rec.status = status;
+    rec.started_at.get_or_insert(started);
+    rec.finished_at = Some(finished);
+    rec.elapsed_secs = elapsed;
+    rec.records_written = records;
+    rec.invocations = invs;
+    rec.error = error;
+    if let Err(e) = state.history().upsert(&rec).await {
+        tracing::error!(
+            run_id,
+            error = %e,
+            "finalize: failed to persist terminal run record"
+        );
     }
     metrics::record_run_finished(status, reason);
 }
@@ -595,5 +637,107 @@ mod tests {
         );
         // The reservation taken before the claim must have been released by the guard.
         assert_eq!(state.registry().queued(), 0);
+    }
+
+    /// A `ServerState` backed by an in-memory history, for finalize tests.
+    fn memory_state() -> crate::serve::state::ServerState {
+        use crate::serve::config::{AuthMode, HistoryBackendSpec, ServeConfig};
+        use crate::serve::history::RunHistory;
+        use crate::serve::history::memory::MemoryHistory;
+        use crate::serve::state::ServerState;
+        use std::sync::Arc;
+        use tokio_util::sync::CancellationToken;
+
+        let cfg = ServeConfig {
+            listen: "127.0.0.1:0".parse().unwrap(),
+            auth: AuthMode::None,
+            max_concurrent_runs: 4,
+            max_queued_runs: 4,
+            default_config_path: None,
+            history: HistoryBackendSpec::Memory,
+            cors_origins: vec![],
+            body_limit_bytes: 1_048_576,
+            shutdown_grace: Duration::from_secs(60),
+            retain_terminal_runs: Duration::from_secs(60),
+            idempotency_retention: Duration::from_secs(60),
+            probe_timeout: Duration::from_secs(10),
+            env_file: None,
+            no_env_file: false,
+            log_level: "info".into(),
+        };
+        let history = Arc::new(MemoryHistory::new(Duration::from_secs(60))) as Arc<dyn RunHistory>;
+        ServerState::new(
+            &cfg,
+            None,
+            CancellationToken::new(),
+            history,
+            crate::serve::logs::LogHub::new(),
+            None,
+        )
+    }
+
+    #[tokio::test]
+    async fn finalize_writes_terminal_record_when_record_is_missing() {
+        // M6 (#146): if the run record can't be read at finalize time (purged,
+        // or split to another store under degraded fallback), the terminal
+        // status must NOT be silently dropped — a fresh terminal record is
+        // written so the run never lingers non-terminal while the run-finished
+        // metric has already fired.
+        let state = memory_state();
+        let started = Utc::now();
+        finalize(
+            &state,
+            "ghost",
+            started,
+            Terminal::Failed {
+                reason: "boom".into(),
+                records: 0,
+                invs: Vec::new(),
+            },
+        )
+        .await;
+        let rec = state
+            .history()
+            .get("ghost")
+            .await
+            .unwrap()
+            .expect("finalize must create a terminal record even when none existed");
+        assert_eq!(rec.status, RunStatus::Failed);
+        assert!(rec.finished_at.is_some());
+        assert!(rec.started_at.is_some());
+        assert_eq!(rec.error.as_deref(), Some("boom"));
+    }
+
+    #[tokio::test]
+    async fn finalize_preserves_metadata_of_existing_record() {
+        // The happy path still read-modify-writes, preserving name/labels/key.
+        let state = memory_state();
+        let started = Utc::now();
+        let mut rec = RunRecord::queued(
+            "r1".into(),
+            Some("nightly".into()),
+            BTreeMap::new(),
+            Some("idem-k".into()),
+            started,
+        );
+        rec.status = RunStatus::Running;
+        rec.started_at = Some(started);
+        state.history().upsert(&rec).await.unwrap();
+
+        finalize(
+            &state,
+            "r1",
+            started,
+            Terminal::Completed {
+                records: 5,
+                invs: Vec::new(),
+            },
+        )
+        .await;
+        let got = state.history().get("r1").await.unwrap().unwrap();
+        assert_eq!(got.status, RunStatus::Completed);
+        assert_eq!(got.records_written, 5);
+        assert_eq!(got.name.as_deref(), Some("nightly"));
+        assert_eq!(got.idempotency_key.as_deref(), Some("idem-k"));
     }
 }

--- a/cli/tests/serve_history_sqlite.rs
+++ b/cli/tests/serve_history_sqlite.rs
@@ -346,3 +346,34 @@ async fn purge_drops_expired_terminal_runs() {
     assert!(h.get("old").await.unwrap().is_none());
     assert!(h.get("live").await.unwrap().is_some());
 }
+
+#[tokio::test]
+async fn delete_also_removes_matching_idem_claim_at_sql_layer() {
+    // M8 (#146): deleting a run drops its idempotency claim, so a replay of the
+    // key starts a fresh run instead of 404-ing on the missing record until the
+    // claim self-expires. Exercises the shared SQL `delete_idem_by_run`.
+    let dir = tempfile::tempdir().unwrap();
+    let h = store(&dir, "delete_idem.db").await;
+    let w = Duration::from_secs(3600);
+    assert_eq!(
+        h.claim_idempotency("k", "fp", "r1", w).await.unwrap(),
+        Claim::Fresh
+    );
+    let mut r = RunRecord::queued(
+        "r1".into(),
+        None,
+        BTreeMap::new(),
+        Some("k".into()),
+        Utc::now(),
+    );
+    r.status = RunStatus::Completed;
+    r.finished_at = Some(Utc::now());
+    h.upsert(&r).await.unwrap();
+
+    assert_eq!(h.delete("r1").await.unwrap(), DeleteOutcome::Deleted);
+    // The claim is gone → a fresh run, not a replay of the deleted one.
+    assert_eq!(
+        h.claim_idempotency("k", "fp", "r2", w).await.unwrap(),
+        Claim::Fresh
+    );
+}

--- a/docs/book/src/cookbook/serve.md
+++ b/docs/book/src/cookbook/serve.md
@@ -73,12 +73,26 @@ pipeline work ≈ `max-concurrent-runs × each config's execution.max_concurrent
 Supply `idempotency_key` to make retries safe (Stripe-style):
 
 - First submit with a key → runs normally.
-- Re-submit the **same key + same config** within `--idempotency-retention-secs`
+- Re-submit the **same key + same request** within `--idempotency-retention-secs`
   (default 24h) → returns the **original** `run_id` (replayed, no new run).
-- Same key + a **different** config → `409 Conflict`.
+- Same key + a **different** request → `409 Conflict`.
 - After the retention window, the key is re-usable for a fresh run.
+- Deleting a run also frees its idempotency key immediately — a later submit
+  with that key starts a fresh run rather than 404-ing on the deleted record.
+
+The "request" identity covers the merged config **and** the run-affecting
+request fields — `clock`, `timeout_secs`, and `labels`. In particular, a retry
+that reuses the key but changes the backfill `clock` is a `409`, not a replay of
+the original window (so you can't silently get the original clock's results).
 
 The claim is atomic, so concurrent retries can't both start a run.
+
+> **Degraded mode:** while the persistent history backend is degraded (see
+> [Run history](#run-history--persistence)), the in-memory fallback can't see
+> claims the database made before the outage. Rather than risk a duplicate run,
+> submissions **carrying an idempotency key are rejected with `503`** until the
+> backend recovers — retry then, or resubmit without a key if at-least-once is
+> acceptable. Submissions without a key are unaffected.
 
 ## Cancellation
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -42,6 +42,7 @@ paths:
         "413": { $ref: "#/components/responses/Error" }
         "422": { $ref: "#/components/responses/Error" }
         "429": { $ref: "#/components/responses/Error" }
+        "503": { $ref: "#/components/responses/Error" }
     get:
       summary: List runs
       operationId: listRuns


### PR DESCRIPTION
## Summary

Cluster 4/6 of the #146 medium backlog — **`faucet serve` idempotency & run-history correctness** (M5, M6, M7, M8).

### M5 — FallbackHistory split claim/record → duplicate run
`FallbackHistory` tripped one-way to in-memory on the first primary error, so a claim persisted to the SQL primary *before* the trip was invisible to memory afterward — a replay returned `Fresh` → a **duplicate run**, defeating idempotency exactly during a backend incident. `claim_idempotency` now probes the primary while healthy and, once tripped **from a healthy primary**, **fails closed**: idempotent submissions get a new `HistoryError::Degraded` → `503 Unavailable` rather than risking a silent duplicate. Submissions without an idempotency key, and the *started-degraded* case (memory is the sole authoritative store), are unaffected.

### M6 — finalize silently dropped terminal status
`finalize` updated the record only inside `if let Ok(Some(rec))`, so when `get` errored (degraded backend) or returned `None` (purged / split record) the run was left non-terminal forever while `record_run_finished` had already fired — a status/metric divergence. It now reconstructs and upserts a fresh terminal record on miss/error (with a warn), preserving metadata on the happy path.

### M7 — idempotency fingerprint ignored run-affecting fields
The fingerprint hashed only the merged config + `name`, so a retry reusing the key with the same config but a different backfill `clock` replayed the *original* window instead of 409-ing. New `request_fingerprint` folds `clock` / `timeout_secs` / `labels` into the hash.

### M8 — replay 404 after a run was deleted
Deleting a run left its idempotency claim live, so a replay 404'd on the now-missing record until the claim self-expired. `delete` now also drops the matching claim — memory via `remove_if` scoped to the run, SQL via a new `delete_idem_by_run` query — scoped by `run_id` so a newer run that re-claimed the same key keeps its claim.

## Tests (TDD: red → green; all DB-free or sqlite-embedded)

- **idempotency**: `request_fingerprint` differs on clock / timeout_secs / labels / config, stable otherwise.
- **memory**: `delete_also_removes_matching_idem_claim`, `delete_keeps_claim_owned_by_a_newer_run`.
- **sqlite**: `delete_also_removes_matching_idem_claim_at_sql_layer` (exercises the shared SQL machinery).
- **fallback**: `claim_fails_closed_once_degraded_from_a_healthy_primary`, `claim_uses_memory_when_started_degraded`.
- **runner**: `finalize_writes_terminal_record_when_record_is_missing`, `finalize_preserves_metadata_of_existing_record`.

Full CLI serve suite green (342 lib + all serve integration tests, 0 failures); clippy clean with `serve,serve-history-sqlite,serve-history-postgres`.

## Docs
`docs/book/src/cookbook/serve.md` (request-identity fields, delete-frees-key, degraded-mode 503) and `docs/openapi.yaml` (503 on `POST /v1/runs`).

## Note on the M5 tradeoff
Failing closed means an idempotent submission is rejected (`503`, retryable) while the persistent history backend is degraded — the correctness-preserving choice (no duplicate runs), with non-idempotent submissions still accepted so the server stays up. Happy to switch to best-effort-with-documentation if you'd prefer availability over the guarantee there.

Part of #146.