### PR TITLE
fix(cli): config-validation & interpolation hardening (M1/M2/M3/M17, #146)

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -88,6 +88,7 @@ pub struct PipelineConfig {
 /// template catalogs below; the singular `source` / `sink` fields are the
 /// legacy way to declare a single template (internally named `default`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct PipelineSpec {
     /// Legacy singular source — registers as a template named `default`.
     /// Defining both `source` and `sources.default` is an error at expand time.
@@ -124,6 +125,7 @@ pub struct PipelineSpec {
 /// Source templates may additionally carry `transforms:` and
 /// `inherit_transforms:`. Both are rejected on sink templates at expand time.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[serde(deny_unknown_fields)]
 pub struct ConnectorSpec {
     /// Connector type — matches the suffix of the underlying crate
     /// (e.g. `rest` for `faucet-source-rest`).
@@ -155,6 +157,7 @@ pub struct ConnectorSpec {
 /// the row inherits the legacy singular `pipeline.source` / `pipeline.sink`
 /// (registered internally as a template named `default`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct PartialConnector {
     /// Name of the template under `pipeline.sources` / `pipeline.sinks` to
     /// instantiate. `None` falls back to the `default` template.
@@ -170,6 +173,7 @@ pub struct PartialConnector {
 
 /// A single transform declaration.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[serde(deny_unknown_fields)]
 pub struct TransformSpec {
     /// Built-in transform identifier. One of: `flatten`, `rename_keys`,
     /// `snake_case`, `select`, `drop`, `set`, `rename_field`, `cast`, `redact`,
@@ -185,6 +189,7 @@ pub struct TransformSpec {
 
 /// State-store backend selector.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct StateStoreSpec {
     /// Store type: `file`, `memory`, `redis`, or `postgres`.
     #[serde(rename = "type")]
@@ -197,6 +202,7 @@ pub struct StateStoreSpec {
 
 /// One row of the `matrix:` block.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct MatrixRow {
     /// Row identifier. Required for parent/child references and runtime
     /// `${id.path}` interpolation. Anonymous rows get a synthetic `row-N` id.
@@ -246,6 +252,7 @@ pub struct MatrixRow {
 
 /// Execution-time controls.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ExecutionSpec {
     /// Maximum concurrent pipeline invocations (root + per-parent-record
     /// child invocations all share this budget). Defaults to

--- a/cli/src/env_config.rs
+++ b/cli/src/env_config.rs
@@ -211,11 +211,34 @@ fn build_named_catalog(
         }
         kinds.insert(name_upper.to_ascii_lowercase(), value.clone());
     }
+    // All template scope prefixes, so each env var can be assigned to its
+    // LONGEST matching prefix. Without this, a template like `users` would
+    // absorb `users_api`'s vars, since `FAUCET_SOURCES_USERS_` is a prefix of
+    // `FAUCET_SOURCES_USERS_API_` — the shorter template silently gets the
+    // longer one's fields (#146 M17).
+    let scope_prefixes: Vec<String> = kinds
+        .keys()
+        .map(|name| format!("{prefix}{}_", name.to_ascii_uppercase()))
+        .collect();
+
     // Second sweep: harvest each template's config block.
     let mut out: HashMap<String, ConnectorSpec> = HashMap::new();
     for (name, kind) in kinds {
         let scope_prefix = format!("{prefix}{}_", name.to_ascii_uppercase());
-        let mut config = extract_scope(env, &scope_prefix)?;
+        // A view of `env` containing only the vars whose longest matching
+        // template prefix is THIS template's — i.e. drop any var that also
+        // matches a longer sibling prefix nested under this one.
+        let scoped: HashMap<String, String> = env
+            .iter()
+            .filter(|(k, _)| {
+                k.starts_with(&scope_prefix)
+                    && !scope_prefixes.iter().any(|other| {
+                        other.len() > scope_prefix.len() && k.starts_with(other.as_str())
+                    })
+            })
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        let mut config = extract_scope(&scoped, &scope_prefix)?;
         // Remove the `type` field — it's the selector, not a config field.
         if let Value::Object(m) = &mut config {
             m.remove("type");
@@ -337,6 +360,44 @@ mod tests {
         ]);
         let v = extract_scope(&e, "FAUCET_SOURCE_REST_").unwrap();
         assert_eq!(v, json!({"base_url": "https://x.example"}));
+    }
+
+    #[test]
+    fn named_templates_do_not_leak_across_prefix_overlapping_names() {
+        // M17 (#146): template `users` must NOT absorb `users_api`'s vars just
+        // because `FAUCET_SOURCES_USERS_` is a prefix of `FAUCET_SOURCES_USERS_API_`.
+        let e = env(&[
+            ("FAUCET_SOURCES_USERS_TYPE", "rest"),
+            ("FAUCET_SOURCES_USERS_BASE_URL", "https://u"),
+            ("FAUCET_SOURCES_USERS_API_TYPE", "rest"),
+            ("FAUCET_SOURCES_USERS_API_BASE_URL", "https://api"),
+            ("FAUCET_SOURCES_USERS_API_TIMEOUT", "30"),
+        ]);
+        let out = build_named_sources(&e).unwrap();
+
+        let users = out.get("users").expect("users template").config.clone();
+        let users = users.as_object().unwrap();
+        assert_eq!(
+            users.get("base_url").and_then(|v| v.as_str()),
+            Some("https://u")
+        );
+        assert!(
+            !users.contains_key("api_base_url"),
+            "users must not absorb users_api's vars"
+        );
+        assert!(!users.contains_key("api_timeout"));
+
+        let api = out
+            .get("users_api")
+            .expect("users_api template")
+            .config
+            .clone();
+        let api = api.as_object().unwrap();
+        assert_eq!(
+            api.get("base_url").and_then(|v| v.as_str()),
+            Some("https://api")
+        );
+        assert_eq!(api.get("timeout").and_then(|v| v.as_i64()), Some(30));
     }
 
     #[test]

--- a/cli/src/expand.rs
+++ b/cli/src/expand.rs
@@ -375,6 +375,23 @@ pub fn expand(cfg: &PipelineConfig) -> CliResult<Vec<ExpandedNode>> {
             }
         }
 
+        // Runtime interpolation (`${row.path}` parent refs and `${now.*}`) is
+        // resolved only in source/sink configs. A token in a transform / state
+        // / dlq config would otherwise reach the connector as a literal
+        // `${...}` string with no error (#146 M2) — reject it at expand time.
+        for (ti, t) in transforms.iter().enumerate() {
+            reject_runtime_tokens(
+                &t.config,
+                &format!("row `{row_id}` transform[{ti}] (`{}`)", t.kind),
+            )?;
+        }
+        if let Some(ref st) = state {
+            reject_runtime_tokens(&st.config, &format!("row `{row_id}` state config"))?;
+        }
+        if let Some(ref d) = dlq {
+            reject_runtime_tokens(&d.sink.config, &format!("row `{row_id}` dlq sink config"))?;
+        }
+
         // `quality:` is pipeline-level only in v1 (no matrix-row override), so
         // every node carries the same spec. Compile it once per node to (a)
         // surface invalid paths/regexes/bounds at expand time, and (b) fail
@@ -459,6 +476,28 @@ fn check_refs(value: &Value, id_set: &HashSet<&str>, owner: &str) -> CliResult<(
     })
 }
 
+/// Reject any runtime interpolation token (`${id.path}` parent-record refs and
+/// `${now.*}`) found in `value`. These resolve **only** in source/sink configs;
+/// elsewhere — transform / state / dlq bodies — they would silently reach the
+/// connector as a literal `${...}` string (#146 M2). Load-time directives
+/// (`${env:}`, `${vars.X}`, `${sources.X}`, …) are already resolved before
+/// expansion, so any deferred token still present here is genuinely
+/// unsupported in this location.
+fn reject_runtime_tokens(value: &Value, location: &str) -> CliResult<()> {
+    walk_strings(value, &mut |s| {
+        for (token, dir) in iter_directives(s) {
+            if let Directive::Deferred { .. } = dir {
+                return Err(CliError::Config(format!(
+                    "interpolation token `{token}` in {location} is not supported: \
+                     `${{...}}` runtime tokens (parent-record references and `${{now.*}}`) \
+                     resolve only in source/sink configs"
+                )));
+            }
+        }
+        Ok(())
+    })
+}
+
 fn collect_deferred(value: &Value, out: &mut Vec<DeferredRef>) {
     let _ = walk_strings(value, &mut |s| {
         for (token, dir) in iter_directives(s) {
@@ -515,6 +554,76 @@ pipeline:
         assert!(matches!(nodes[0].role, NodeRole::Root));
         assert_eq!(nodes[0].source.kind, "rest");
         assert_eq!(nodes[0].sink.kind, "jsonl");
+    }
+
+    #[test]
+    fn rejects_runtime_token_in_dlq_config() {
+        // M2 (#146): `${now.*}` / `${parent.path}` resolve only in source/sink
+        // configs. In a dlq config they would silently pass through as a literal
+        // `${...}` string — expand must reject them with a clear error.
+        let c = cfg(r#"
+version: 1
+pipeline:
+  source: { type: rest, config: { base_url: https://x } }
+  sink:   { type: jsonl, config: { path: ./o } }
+  dlq:
+    sink: { type: jsonl, config: { path: "dead-${now.date}.jsonl" } }
+"#);
+        let err = expand(&c).unwrap_err();
+        assert!(
+            matches!(&err, CliError::Config(m) if m.contains("now.date") && m.contains("dlq")),
+            "got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_runtime_token_in_state_config() {
+        let c = cfg(r#"
+version: 1
+pipeline:
+  source: { type: rest, config: { base_url: https://x } }
+  sink:   { type: jsonl, config: { path: ./o } }
+  state:
+    type: file
+    config: { path: "state-${now.date}" }
+"#);
+        let err = expand(&c).unwrap_err();
+        assert!(
+            matches!(&err, CliError::Config(m) if m.contains("state")),
+            "got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_runtime_token_in_transform_config() {
+        let c = cfg(r#"
+version: 1
+pipeline:
+  source: { type: rest, config: { base_url: https://x } }
+  sink:   { type: jsonl, config: { path: ./o } }
+  transforms:
+    - type: set
+      config: { field: ts, value: "${now.datetime}" }
+"#);
+        let err = expand(&c).unwrap_err();
+        assert!(
+            matches!(&err, CliError::Config(m) if m.contains("transform")),
+            "got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn allows_runtime_token_in_source_and_sink_configs() {
+        // The same tokens remain valid in source/sink configs (regression guard
+        // that M2's rejection didn't over-reach).
+        let c = cfg(r#"
+version: 1
+pipeline:
+  source: { type: rest, config: { base_url: "https://x?d=${now.date}" } }
+  sink:   { type: jsonl, config: { path: "out-${now.date}.jsonl" } }
+"#);
+        let nodes = expand(&c).unwrap();
+        assert_eq!(nodes.len(), 1);
     }
 
     #[test]

--- a/cli/src/interpolate.rs
+++ b/cli/src/interpolate.rs
@@ -33,13 +33,25 @@ use std::path::PathBuf;
 pub fn interpolate(input: &str) -> CliResult<String> {
     rewrite(input, |body| match classify_directive(body) {
         Directive::LoadTime { prefix, body } => match prefix {
-            "env" | "secret" => Ok(Some(std::env::var(body).map_err(|_| {
-                CliError::MissingEnvVar {
+            "env" | "secret" => {
+                let value = std::env::var(body).map_err(|_| CliError::MissingEnvVar {
                     var: body.to_owned(),
                     location: format!("${{{prefix}:{body}}}"),
-                }
-            })?)),
-            "file" => Ok(Some(read_file_trimmed(body)?)),
+                })?;
+                // Register the resolved value for redaction, exactly as the
+                // secrets-manager pass does for `${vault:…}` etc. — otherwise a
+                // credential supplied via the very common `${env:TOKEN}` /
+                // `${secret:VAR}` form leaks into tracing/log/error output while
+                // `${vault:…}` ones are scrubbed (an inconsistent boundary,
+                // #146 M3). `register` no-ops for values below the min length.
+                crate::secrets::registry::register(&value);
+                Ok(Some(value))
+            }
+            "file" => {
+                let value = read_file_trimmed(body)?;
+                crate::secrets::registry::register(&value);
+                Ok(Some(value))
+            }
             // Any other ${prefix:body} that isn't env/file/secret — leave it
             // literal so a downstream validator can flag truly bogus prefixes.
             _ => Ok(None),
@@ -702,6 +714,24 @@ mod tests {
         let out = interpolate("${secret:FAUCET_SECRET_VAR}").unwrap();
         assert_eq!(out, "shh");
         unsafe { std::env::remove_var("FAUCET_SECRET_VAR") };
+    }
+
+    #[test]
+    fn resolved_env_and_secret_values_are_registered_for_redaction() {
+        // M3 (#146): credentials supplied via ${env:}/${secret:} must be
+        // scrubbed from faucet's tracing/log/error output, just like
+        // ${vault:…} values — not left to leak.
+        let secret = "super-secret-token-abcdef-1234567890"; // >= MIN_REDACT_LEN
+        unsafe { std::env::set_var("FAUCET_M3_REDACT_TOKEN", secret) };
+        let out = interpolate("Authorization: Bearer ${env:FAUCET_M3_REDACT_TOKEN}").unwrap();
+        assert!(out.contains(secret));
+        let redacted = crate::secrets::registry::redact(&out);
+        assert!(
+            !redacted.contains(secret),
+            "resolved ${{env:}} value must be registered for redaction"
+        );
+        assert!(redacted.contains("***"));
+        unsafe { std::env::remove_var("FAUCET_M3_REDACT_TOKEN") };
     }
 
     #[test]

--- a/docs/book/src/cookbook/secrets.md
+++ b/docs/book/src/cookbook/secrets.md
@@ -242,6 +242,12 @@ output. Every byte written through the CLI's tracing subscriber passes through a
 that contain deserialized config fields go through the same scrubber before they
 reach stderr.
 
+Every resolution path registers its result for redaction — the secrets-manager
+directives (`${vault:…}`, `${aws-sm:…}`, …) **and** the load-time
+`${env:…}` / `${secret:…}` / `${file:…}` forms. A credential supplied via the
+common `${env:TOKEN}` form is therefore scrubbed exactly like a `${vault:…}` one
+(values shorter than 4 characters are not registered).
+
 **This boundary covers faucet's own output only.** A third-party connector that
 debug-logs its own deserialized config fields — or any library that logs a
 `reqwest::Request`, a database row, or a JSON object — operates outside this

--- a/docs/book/src/reference/config.md
+++ b/docs/book/src/reference/config.md
@@ -20,6 +20,12 @@ execution:                 # optional
   on_error: continue       # continue | stop
 ```
 
+> **Unknown keys are rejected.** The structural blocks (`pipeline`, each
+> `source`/`sink`/`transform`/`state` spec, `matrix` rows, `execution`) reject
+> unrecognized fields, so a typo like `transorms:` or `parnet:` is a load-time
+> error rather than a silently-ignored field. A connector's own `config: { … }`
+> object is still passed through verbatim to that connector.
+
 ## `pipeline`
 
 `source` and `sink` each take a `type` (the connector name) and a `config`
@@ -108,9 +114,12 @@ strftime format produces a clean config error rather than a panic.
   timezone the cron fires in (e.g. `America/Los_Angeles`), not UTC. Queued
   runs use their original scheduled time; `--once` uses the current wall clock.
 
-**Scope:** `${now.*}` tokens are resolved only in source and sink config values.
-They are **not** resolved in `state:`, `dlq:`, `transforms:`, or the top-level
-`auth:` / `vars:` blocks.
+**Scope:** `${now.*}` tokens (and `${row_id.path}` parent-record references) are
+resolved only in source and sink config values. Using one in a `state:`,
+`dlq:`, or `transforms:` config is a **config error at validate/expand time** —
+it is rejected rather than silently passed to the connector as a literal
+`${…}` string. (`${env:…}` / `${vars.X}` / `${sources.X}` still resolve
+everywhere.)
 
 **Reserved id:** `now` is a reserved matrix row id — a matrix row cannot be
 named `now`.


### PR DESCRIPTION
## Summary

Cluster 5/6 of the #146 medium backlog — **CLI config validation & interpolation** (M1, M2, M3, M17).

### M1 — typos silently change run semantics
The structural CLI config types (`PipelineSpec`, `ConnectorSpec`, `PartialConnector`, `TransformSpec`, `StateStoreSpec`, `MatrixRow`, `ExecutionSpec`) lacked `#[serde(deny_unknown_fields)]`, so a typo like `transorms:`, `parnet:`, or `max_concurent:` was silently dropped — a misspelled `parent` makes a child run as a *root*. All seven now reject unknown keys. A connector's free-form `config:` object is still passed through verbatim. *(No `flatten` fields, so `deny_unknown_fields` is safe.)*

### M2 — runtime tokens silently passed through in transform/state/dlq
`${row.path}` / `${now.*}` were neither validated nor resolved in `transform` / `state` / `dlq` configs — they reached the connector as a literal `${…}` string (e.g. a DLQ path of literal `out-${now.date}.jsonl`). These tokens resolve only in source/sink configs by design, so expand now **rejects** them in those locations with a clear error. `${env:}` / `${vars.X}` / `${sources.X}` still resolve everywhere (already done by `resolve_config_refs`, which walks those bodies).

### M3 — `${env:}`/`${secret:}`/`${file:}` values not redacted (security)
Only the secrets-manager pass registered resolved values for redaction, so a credential via the very common `${env:TOKEN}` / `${secret:VAR}` form leaked into tracing/log/error output while `${vault:…}` ones were scrubbed. All three load-time forms now register their resolved value (no-op below the 4-char min), closing the inconsistent boundary.

### M17 — pure-env templates leak across prefix-overlapping names
`FAUCET_SOURCES_USERS_` is a prefix of `FAUCET_SOURCES_USERS_API_`, so template `users` absorbed `users_api`'s vars (a spurious `api_base_url`, etc.). Each env var is now assigned to its **longest** matching template-name prefix.

## Tests (TDD: red → green)

- **M1**: covered by the deny_unknown_fields attribute through existing parse paths (full CLI suite + example-config validation stays green — no example had stray keys).
- **M2**: `rejects_runtime_token_in_{dlq,state,transform}_config` + `allows_runtime_token_in_source_and_sink_configs` (regression guard).
- **M3**: `resolved_env_and_secret_values_are_registered_for_redaction` (round-trips through `secrets::registry::redact`).
- **M17**: `named_templates_do_not_leak_across_prefix_overlapping_names` (`users` + `users_api`).

Full CLI suite green (default + `--all-features`); clippy clean.

## Docs
`docs/book/src/reference/config.md` (unknown-key rejection + runtime-token scope) and `docs/book/src/cookbook/secrets.md` (redaction now covers `${env:}`/`${secret:}`/`${file:}`).

Part of #146.