### PR TITLE
fix(auth): TokenEndpoint force-refresh + expiry_ratio validation (M15/M16, #146)

### DIFF
--- a/crates/auth/README.md
+++ b/crates/auth/README.md
@@ -18,6 +18,20 @@ racing to refresh a single-active / rotating token.
 | `oauth2_refresh` | `OAuth2RefreshProvider`           | OAuth2 `refresh_token` grant with refresh-token **rotation capture**. |
 | `token_endpoint` | `TokenEndpointProvider`           | Fetch a token from any HTTP endpoint, extract via JSONPath. |
 
+### Token caching & refresh
+
+The three fetching providers (`oauth2`, `oauth2_refresh`, `token_endpoint`)
+cache the token until `expires_in × expiry_ratio` has elapsed, then refresh
+single-flight. All three also support **force-refresh on rejection**: a
+connector that gets a `401` calls `invalidate(stale)` and receives a
+freshly-fetched token (concurrent invalidations of the same token collapse into
+one refresh).
+
+`expiry_ratio` (default `0.9`) must be a finite number in `(0, 1]` — it is
+validated at construction. A value `≤ 0` would expire every token immediately
+(defeating the cache); a value `> 1` would use a token past its real expiry
+(causing `401`s mid-use).
+
 ## CLI usage
 
 Define a provider once in the top-level `auth:` catalog and reference it from any

--- a/crates/auth/src/lib.rs
+++ b/crates/auth/src/lib.rs
@@ -93,6 +93,34 @@ pub(crate) fn expiry_instant(
     })
 }
 
+/// Parse and validate the optional `expiry_ratio` config field, shared by every
+/// provider that caches a token. Must be a finite number in `(0, 1]`; defaults
+/// to [`DEFAULT_EXPIRY_RATIO`] when absent or null.
+///
+/// Out-of-range values silently break token caching (#146 M16): `≤ 0` or `NaN`
+/// makes the effective expiry `0`, so every call refetches (defeating the cache
+/// and single-flight refresh); `> 1` treats the token as valid past its real
+/// expiry, causing 401s mid-use. Rejecting at construction surfaces the mistake
+/// at config-load time instead.
+pub(crate) fn parse_expiry_ratio(config: &Value) -> Result<f64, FaucetError> {
+    match config.get("expiry_ratio") {
+        None | Some(Value::Null) => Ok(DEFAULT_EXPIRY_RATIO),
+        Some(v) => {
+            let r = v.as_f64().ok_or_else(|| {
+                FaucetError::Config(format!(
+                    "auth provider: `expiry_ratio` must be a number in (0, 1], got {v}"
+                ))
+            })?;
+            if !r.is_finite() || r <= 0.0 || r > 1.0 {
+                return Err(FaucetError::Config(format!(
+                    "auth provider: `expiry_ratio` must be a finite number in (0, 1], got {r}"
+                )));
+            }
+            Ok(r)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -117,6 +145,46 @@ mod tests {
     #[test]
     fn build_provider_missing_type_errors() {
         let spec = serde_json::json!({ "config": {} });
+        assert!(build_provider(&spec).is_err());
+    }
+
+    #[test]
+    fn parse_expiry_ratio_validates_range() {
+        use serde_json::json;
+        // Absent / null → default.
+        assert_eq!(
+            parse_expiry_ratio(&json!({})).unwrap(),
+            DEFAULT_EXPIRY_RATIO
+        );
+        assert_eq!(
+            parse_expiry_ratio(&json!({ "expiry_ratio": null })).unwrap(),
+            DEFAULT_EXPIRY_RATIO
+        );
+        // In-range values pass.
+        assert_eq!(
+            parse_expiry_ratio(&json!({ "expiry_ratio": 0.5 })).unwrap(),
+            0.5
+        );
+        assert_eq!(
+            parse_expiry_ratio(&json!({ "expiry_ratio": 1.0 })).unwrap(),
+            1.0
+        );
+        // Out-of-range / non-numeric are rejected (#146 M16).
+        assert!(parse_expiry_ratio(&json!({ "expiry_ratio": 0 })).is_err());
+        assert!(parse_expiry_ratio(&json!({ "expiry_ratio": -0.5 })).is_err());
+        assert!(parse_expiry_ratio(&json!({ "expiry_ratio": 1.5 })).is_err());
+        assert!(parse_expiry_ratio(&json!({ "expiry_ratio": "0.5" })).is_err());
+    }
+
+    #[test]
+    fn build_provider_rejects_out_of_range_expiry_ratio() {
+        let spec = serde_json::json!({
+            "type": "oauth2",
+            "config": {
+                "token_url": "http://x", "client_id": "id",
+                "client_secret": "sec", "expiry_ratio": 2.0
+            }
+        });
         assert!(build_provider(&spec).is_err());
     }
 }

--- a/crates/auth/src/oauth2.rs
+++ b/crates/auth/src/oauth2.rs
@@ -15,7 +15,7 @@ use serde_json::Value;
 use tokio::sync::Mutex;
 use tokio::time::Instant;
 
-use crate::{DEFAULT_EXPIRY_RATIO, expiry_instant};
+use crate::expiry_instant;
 
 #[derive(Debug, Deserialize)]
 struct TokenResponse {
@@ -67,10 +67,7 @@ impl OAuth2ClientCredentialsProvider {
             client_id: required_str(config, "client_id")?,
             client_secret: required_str(config, "client_secret")?,
             scopes: string_array(config, "scopes"),
-            expiry_ratio: config
-                .get("expiry_ratio")
-                .and_then(Value::as_f64)
-                .unwrap_or(DEFAULT_EXPIRY_RATIO),
+            expiry_ratio: crate::parse_expiry_ratio(config)?,
             state: Mutex::new(CachedToken::default()),
         })
     }
@@ -151,10 +148,7 @@ impl OAuth2RefreshProvider {
             token_url: required_str(config, "token_url")?,
             client_id: required_str(config, "client_id")?,
             client_secret: required_str(config, "client_secret")?,
-            expiry_ratio: config
-                .get("expiry_ratio")
-                .and_then(Value::as_f64)
-                .unwrap_or(DEFAULT_EXPIRY_RATIO),
+            expiry_ratio: crate::parse_expiry_ratio(config)?,
             state: Mutex::new(RefreshState {
                 refresh_token,
                 ..Default::default()

--- a/crates/auth/src/token_endpoint.rs
+++ b/crates/auth/src/token_endpoint.rs
@@ -9,7 +9,7 @@ use serde_json::Value;
 use tokio::sync::Mutex;
 use tokio::time::Instant;
 
-use crate::{DEFAULT_EXPIRY_RATIO, expiry_instant};
+use crate::expiry_instant;
 
 #[derive(Debug, Default)]
 struct CachedToken {
@@ -67,10 +67,7 @@ impl TokenEndpointProvider {
                 .get("expiry_path")
                 .and_then(Value::as_str)
                 .map(str::to_string),
-            expiry_ratio: config
-                .get("expiry_ratio")
-                .and_then(Value::as_f64)
-                .unwrap_or(DEFAULT_EXPIRY_RATIO),
+            expiry_ratio: crate::parse_expiry_ratio(config)?,
             state: Mutex::new(CachedToken::default()),
         })
     }
@@ -114,6 +111,31 @@ impl AuthProvider for TokenEndpointProvider {
         };
         if still_valid {
             return Ok(Credential::Bearer(state.token.clone().unwrap()));
+        }
+        let (token, expires_in) = self.fetch().await?;
+        state.token = Some(token.clone());
+        state.expires_at = expiry_instant(expires_in, self.expiry_ratio);
+        Ok(Credential::Bearer(token))
+    }
+
+    async fn invalidate(&self, stale: &Credential) -> Result<Credential, FaucetError> {
+        let mut state = self.state.lock().await;
+        // CAS: if the cache already holds a *different* still-valid token, a
+        // concurrent caller already refreshed after the same 401 — hand that
+        // back instead of fetching again (single-flight). Only refetch when the
+        // cached token is the stale one (or itself expired). Without this
+        // override the default `invalidate` just returns `credential()`, which
+        // serves the still-cached stale token straight back, so a connector that
+        // hit a 401 can never force a refresh (#146 M15).
+        let current_valid = match (&state.token, state.expires_at) {
+            (Some(t), Some(exp)) if Instant::now() < exp => Some(t.clone()),
+            (Some(t), None) => Some(t.clone()),
+            _ => None,
+        };
+        if let (Some(cur), Credential::Bearer(stale_tok)) = (&current_valid, stale)
+            && cur != stale_tok
+        {
+            return Ok(Credential::Bearer(cur.clone()));
         }
         let (token, expires_in) = self.fetch().await?;
         state.token = Some(token.clone());
@@ -184,6 +206,102 @@ mod tests {
     fn missing_url_errors() {
         assert!(
             TokenEndpointProvider::from_config(&serde_json::json!({"token_path": "$.t"})).is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn invalidate_forces_a_refresh_of_the_stale_token() {
+        // M15 (#146): a connector that hit a 401 calls invalidate(stale) and
+        // must get a freshly-fetched token — not the cached stale one back.
+        let server = MockServer::start().await;
+        let hits = Arc::new(AtomicUsize::new(0));
+        Mock::given(method("POST"))
+            .respond_with(Counting(hits.clone()))
+            .mount(&server)
+            .await;
+        let p = TokenEndpointProvider::from_config(&serde_json::json!({
+            "url": server.uri(),
+            "token_path": "$.auth.access_token",
+            "expiry_path": "$.ttl",
+        }))
+        .unwrap();
+
+        assert_eq!(
+            p.credential().await.unwrap(),
+            Credential::Bearer("tok1".into())
+        );
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
+
+        // invalidate(tok1) must refetch → tok2.
+        assert_eq!(
+            p.invalidate(&Credential::Bearer("tok1".into()))
+                .await
+                .unwrap(),
+            Credential::Bearer("tok2".into())
+        );
+        assert_eq!(hits.load(Ordering::SeqCst), 2);
+
+        // The refreshed token is now cached — no extra fetch.
+        assert_eq!(
+            p.credential().await.unwrap(),
+            Credential::Bearer("tok2".into())
+        );
+        assert_eq!(hits.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn invalidate_short_circuits_when_token_already_rotated() {
+        // CAS: if the cache already holds a token different from the stale one,
+        // a concurrent caller already refreshed — return it without refetching.
+        let server = MockServer::start().await;
+        let hits = Arc::new(AtomicUsize::new(0));
+        Mock::given(method("POST"))
+            .respond_with(Counting(hits.clone()))
+            .mount(&server)
+            .await;
+        let p = TokenEndpointProvider::from_config(&serde_json::json!({
+            "url": server.uri(),
+            "token_path": "$.auth.access_token",
+            "expiry_path": "$.ttl",
+        }))
+        .unwrap();
+
+        assert_eq!(
+            p.credential().await.unwrap(),
+            Credential::Bearer("tok1".into())
+        );
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
+        // Invalidating an already-superseded token returns cached tok1, no fetch.
+        assert_eq!(
+            p.invalidate(&Credential::Bearer("old-token".into()))
+                .await
+                .unwrap(),
+            Credential::Bearer("tok1".into())
+        );
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn rejects_out_of_range_expiry_ratio() {
+        // M16 (#146): an out-of-range expiry_ratio breaks caching — reject it.
+        assert!(
+            TokenEndpointProvider::from_config(&serde_json::json!({
+                "url": "http://x", "token_path": "$.t", "expiry_ratio": 0
+            }))
+            .is_err()
+        );
+        assert!(
+            TokenEndpointProvider::from_config(&serde_json::json!({
+                "url": "http://x", "token_path": "$.t", "expiry_ratio": 1.5
+            }))
+            .is_err()
+        );
+        // A valid ratio still constructs.
+        assert!(
+            TokenEndpointProvider::from_config(&serde_json::json!({
+                "url": "http://x", "token_path": "$.t", "expiry_ratio": 0.5
+            }))
+            .is_ok()
         );
     }
 }


### PR DESCRIPTION
## Summary

Cluster 6/6 (final) of the #146 medium backlog — **shared auth providers** (M15, M16).

### M15 — `TokenEndpointProvider` can't force-refresh after a 401
It didn't override `invalidate`, so the default impl returned `credential()` — the still-cached token. A connector that hit a `401`, called `invalidate(stale)`, and retried got the **same stale token** back until natural expiry, so the refresh-on-rejection path was dead. Added a CAS-guarded `invalidate` (mirroring both OAuth2 providers): it refetches when the cache still holds the stale token, and returns an already-rotated token without a redundant fetch when a concurrent caller refreshed first (single-flight).

### M16 — `expiry_ratio` has no range validation
It was read via `as_f64().unwrap_or(DEFAULT)` with no check: `≤ 0` / NaN makes the effective expiry `0` so every call refetches (defeating the cache + single-flight refresh); `> 1` treats the token as valid past its real expiry, causing `401`s mid-use. A shared `parse_expiry_ratio` now validates it is a **finite number in `(0, 1]`** at construction, across all three fetching providers (`oauth2`, `oauth2_refresh`, `token_endpoint`).

## Tests (TDD: red → green)

- `invalidate_forces_a_refresh_of_the_stale_token` and `invalidate_short_circuits_when_token_already_rotated` (wiremock, request-counted via the existing `Counting` responder).
- `parse_expiry_ratio_validates_range` (default / in-range / `≤0` / `>1` / non-numeric).
- `build_provider_rejects_out_of_range_expiry_ratio` + `token_endpoint::rejects_out_of_range_expiry_ratio`.

All 18 auth tests green (incl. the pre-existing OAuth2 invalidate CAS test); clippy clean.

## Docs
`crates/auth/README.md` documents the token caching / force-refresh-on-401 contract and the `expiry_ratio ∈ (0, 1]` constraint.

Part of #146.