### PR TITLE
fix: resolve the 11 verified LOW items from the #146 hardening audit

### DIFF
--- a/cli/src/commands/schedule.rs
+++ b/cli/src/commands/schedule.rs
@@ -322,7 +322,11 @@ async fn run_loop(
                     return Err(CliError::ScheduleOverlapForbidden);
                 }
             }
-            next_due = match compiled.next_after(Utc::now()) {
+            // Advance from the tick that just fired (`next_due`), not from the
+            // wall clock — so a sub-minute occurrence isn't skipped just because
+            // dispatch latency pushed `now` past it. A long backlog (suspension)
+            // is collapsed to a single catch-up inside `next_due_after_tick`.
+            next_due = match compiled.next_due_after_tick(next_due, Utc::now()) {
                 Some(t) => t,
                 None => {
                     tracing::info!(pipeline = %pipeline_name, "no further scheduled occurrences; exiting");

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -152,6 +152,16 @@ pub enum CliError {
     )]
     DuplicateStateKey { id: String, state_key: String },
 
+    /// The state key derived from the pipeline name + row id (+ resolved
+    /// parent-key value) is not a valid state-store key. Caught up front at
+    /// unit construction rather than mid-run.
+    #[error("invalid state key '{state_key}' for row '{id}': {reason}")]
+    InvalidStateKey {
+        id: String,
+        state_key: String,
+        reason: String,
+    },
+
     /// One or more matrix invocations failed under `on_error: continue`.
     #[error("{count} pipeline invocation(s) failed (see logs above for details)")]
     PipelineHadFailures { count: usize },

--- a/cli/src/executor.rs
+++ b/cli/src/executor.rs
@@ -1216,7 +1216,9 @@ matrix:
             },
         )
         .await
-        .expect_err("an illegal parent-key value must be rejected up front when state is configured");
+        .expect_err(
+            "an illegal parent-key value must be rejected up front when state is configured",
+        );
         assert!(matches!(err, CliError::InvalidStateKey { .. }), "{err:?}");
     }
 

--- a/cli/src/executor.rs
+++ b/cli/src/executor.rs
@@ -231,7 +231,9 @@ pub async fn run_expanded(nodes: Vec<ExpandedNode>, opts: ExecuteOptions) -> Cli
             }
             match &node.role {
                 NodeRole::Root => {
+                    let uses_state = node.state.is_some() || opts.state_path_override.is_some();
                     let state_key = build_state_key(&opts.pipeline_name, &node.id, None);
+                    validate_unit_state_key(&node.id, uses_state, &state_key)?;
                     units.push(Unit {
                         node: node.clone(),
                         parent_record: None,
@@ -255,6 +257,7 @@ pub async fn run_expanded(nodes: Vec<ExpandedNode>, opts: ExecuteOptions) -> Cli
                         continue;
                     }
                     // Detect state-key collisions among siblings sharing one parent.
+                    let uses_state = node.state.is_some() || opts.state_path_override.is_some();
                     let mut seen_keys: HashSet<String> = HashSet::new();
                     for record in &parent_records {
                         let pk_value = resolve_parent_key(record, parent_key);
@@ -264,6 +267,7 @@ pub async fn run_expanded(nodes: Vec<ExpandedNode>, opts: ExecuteOptions) -> Cli
                             .unwrap_or_else(|| "(missing)".to_string());
                         let state_key =
                             build_state_key(&opts.pipeline_name, &node.id, Some(&pk_string));
+                        validate_unit_state_key(&node.id, uses_state, &state_key)?;
                         if !seen_keys.insert(state_key.clone()) {
                             return Err(CliError::DuplicateStateKey {
                                 id: node.id.clone(),
@@ -481,6 +485,23 @@ fn build_state_key(pipeline_name: &str, row_id: &str, parent_key: Option<&str>) 
         None => format!("{pipeline_name}::{row_id}"),
         Some(k) => format!("{pipeline_name}::{row_id}::{k}"),
     }
+}
+
+/// Reject an invalid state key up front (at unit construction) when the node
+/// will use a state store, so a bad pipeline name or parent-key value surfaces
+/// as a clear [`CliError::InvalidStateKey`] instead of a late mid-run
+/// `FaucetError::State` after connectors are built and the stream has started.
+fn validate_unit_state_key(node_id: &str, uses_state: bool, state_key: &str) -> CliResult<()> {
+    if uses_state {
+        faucet_core::state::validate_state_key(state_key).map_err(|e| {
+            CliError::InvalidStateKey {
+                id: node_id.to_owned(),
+                state_key: state_key.to_owned(),
+                reason: e.to_string(),
+            }
+        })?;
+    }
+    Ok(())
 }
 
 /// Walk the parent record by `parent_key` (a dotted path) and clone the value.
@@ -1108,6 +1129,95 @@ execution:
                 "a good that wrote records must have produced its output file"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn invalid_pipeline_name_with_state_errors_up_front() {
+        // A pipeline name that can't form a valid state key must fail up front
+        // (at unit construction) when state is configured — not deep mid-run
+        // as a `FaucetError::State`.
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("in.csv");
+        let output = dir.path().join("out.jsonl");
+        std::fs::write(&input, "name\nalice\n").unwrap();
+        let yaml = format!(
+            r#"version: 1
+pipeline:
+  source: {{ type: csv, config: {{ path: {input} }} }}
+  sink:   {{ type: jsonl, config: {{ path: {output} }} }}
+  state:  {{ type: memory }}
+"#,
+            input = input.display(),
+            output = output.display(),
+        );
+        let cfg = crate::config::parse_with_extension(&yaml, "yaml").unwrap();
+        let nodes = expand(&cfg).unwrap();
+        let err = run_expanded(
+            nodes,
+            ExecuteOptions {
+                pipeline_name: "bad name".into(), // space is illegal in a state key
+                execution: None,
+                dry_run: false,
+                limit: None,
+                state_path_override: None,
+                auth: Default::default(),
+                clock: chrono::Utc::now().fixed_offset(),
+                cancel: None,
+            },
+        )
+        .await
+        .expect_err("an invalid pipeline name must be rejected up front when state is configured");
+        assert!(matches!(err, CliError::InvalidStateKey { .. }), "{err:?}");
+    }
+
+    #[tokio::test]
+    async fn invalid_parent_key_value_with_state_errors_up_front() {
+        // A parent-record value that yields an illegal state-key suffix must
+        // fail up front at the child's unit construction, not mid-run.
+        let dir = tempfile::tempdir().unwrap();
+        let parent_csv = dir.path().join("parents.csv");
+        let child_csv = dir.path().join("child.csv");
+        // The parent `id` value contains a space — illegal in a state key.
+        std::fs::write(&parent_csv, "id\nbad id\n").unwrap();
+        std::fs::write(&child_csv, "x\nA\n").unwrap();
+        let parent_out = dir.path().join("parents.jsonl");
+        let child_out = dir.path().join("child.jsonl");
+        let yaml = format!(
+            r#"version: 1
+pipeline:
+  source: {{ type: csv, config: {{ path: {parent} }} }}
+  sink:   {{ type: jsonl, config: {{ path: {parent_out} }} }}
+  state:  {{ type: memory }}
+matrix:
+  - id: parents
+  - id: child
+    parent: parents
+    source: {{ config: {{ path: {child} }} }}
+    sink:   {{ config: {{ path: {child_out} }} }}
+"#,
+            parent = parent_csv.display(),
+            parent_out = parent_out.display(),
+            child = child_csv.display(),
+            child_out = child_out.display(),
+        );
+        let cfg = crate::config::parse_with_extension(&yaml, "yaml").unwrap();
+        let nodes = expand(&cfg).unwrap();
+        let err = run_expanded(
+            nodes,
+            ExecuteOptions {
+                pipeline_name: "ok".into(),
+                execution: None,
+                dry_run: false,
+                limit: None,
+                state_path_override: None,
+                auth: Default::default(),
+                clock: chrono::Utc::now().fixed_offset(),
+                cancel: None,
+            },
+        )
+        .await
+        .expect_err("an illegal parent-key value must be rejected up front when state is configured");
+        assert!(matches!(err, CliError::InvalidStateKey { .. }), "{err:?}");
     }
 
     #[tokio::test]

--- a/cli/src/schedule/compiled.rs
+++ b/cli/src/schedule/compiled.rs
@@ -102,6 +102,37 @@ impl CompiledSchedule {
             .ok()
             .map(|dt| dt.with_timezone(&Utc))
     }
+
+    /// The next due tick after firing the tick scheduled for `fired`, given the
+    /// current wall clock `now`.
+    ///
+    /// Advances from the *scheduled* tick (not wall-clock `now`) so an
+    /// occurrence isn't silently skipped merely because dispatch latency pushed
+    /// the clock past it — the loop fires the returned tick promptly even if it
+    /// is already slightly in the past (this is the sub-minute-skip fix). But if
+    /// firing that occurrence would still leave a *further* occurrence already
+    /// elapsed (the process was suspended across many ticks), the backlog is
+    /// collapsed to the next occurrence strictly after `now`, so a long sleep
+    /// produces a single catch-up run rather than a flood of backfilled runs.
+    /// Returns `None` when the schedule has no further occurrence.
+    pub fn next_due_after_tick(
+        &self,
+        fired: DateTime<Utc>,
+        now: DateTime<Utc>,
+    ) -> Option<DateTime<Utc>> {
+        let next = self.next_after(fired)?;
+        if next > now {
+            // On schedule: the next occurrence is still ahead.
+            return Some(next);
+        }
+        // `next` already elapsed. If the occurrence after it is *also* in the
+        // past we are badly behind — collapse the backlog. Otherwise run the
+        // single just-missed `next` (possibly a touch late) and resume.
+        match self.next_after(next) {
+            Some(after) if after <= now => self.next_after(now),
+            _ => Some(next),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -180,6 +211,43 @@ mod tests {
             c.next_after(just_before).unwrap(),
             Utc.with_ymd_and_hms(2026, 3, 11, 0, 0, 0).unwrap()
         );
+    }
+
+    #[test]
+    fn next_due_after_tick_runs_a_single_missed_sub_minute_occurrence() {
+        // Every-second cron. The tick scheduled for 06:00:00 fired, but
+        // dispatch latency pushed the clock to 06:00:01.3. The 06:00:01
+        // occurrence must still run (not be skipped) — that is the bug:
+        // recomputing from `now` would jump straight to 06:00:02.
+        let c = CompiledSchedule::compile(&spec("* * * * * *", "UTC")).unwrap();
+        let fired = Utc.with_ymd_and_hms(2026, 3, 10, 6, 0, 0).unwrap();
+        let now = Utc.with_ymd_and_hms(2026, 3, 10, 6, 0, 1).unwrap()
+            + chrono::Duration::milliseconds(300);
+        let due = c.next_due_after_tick(fired, now).unwrap();
+        assert_eq!(due, Utc.with_ymd_and_hms(2026, 3, 10, 6, 0, 1).unwrap());
+        // The old wall-clock recompute would have skipped to 06:00:02.
+        assert_ne!(due, c.next_after(now).unwrap());
+    }
+
+    #[test]
+    fn next_due_after_tick_returns_future_occurrence_when_on_schedule() {
+        let c = CompiledSchedule::compile(&spec("* * * * * *", "UTC")).unwrap();
+        let fired = Utc.with_ymd_and_hms(2026, 3, 10, 6, 0, 0).unwrap();
+        // Fired essentially on time.
+        let due = c.next_due_after_tick(fired, fired).unwrap();
+        assert_eq!(due, Utc.with_ymd_and_hms(2026, 3, 10, 6, 0, 1).unwrap());
+    }
+
+    #[test]
+    fn next_due_after_tick_collapses_a_long_backlog_to_one_catch_up() {
+        // The process was suspended for 100s on an every-second cron. Instead
+        // of replaying 100 ticks, collapse to the next future occurrence.
+        let c = CompiledSchedule::compile(&spec("* * * * * *", "UTC")).unwrap();
+        let fired = Utc.with_ymd_and_hms(2026, 3, 10, 6, 0, 0).unwrap();
+        let now = Utc.with_ymd_and_hms(2026, 3, 10, 6, 1, 40).unwrap(); // +100s
+        let due = c.next_due_after_tick(fired, now).unwrap();
+        assert_eq!(due, Utc.with_ymd_and_hms(2026, 3, 10, 6, 1, 41).unwrap());
+        assert!(due > now, "collapsed catch-up must be in the future");
     }
 
     #[test]

--- a/crates/core/src/adaptive.rs
+++ b/crates/core/src/adaptive.rs
@@ -76,9 +76,12 @@ pub struct AdaptiveBatchConfig {
     /// Per-batch error rate above which the controller shrinks.
     #[serde(default = "default_error_threshold")]
     pub error_threshold: f64,
-    /// Never grow past the source page size. v1 honors only `true`; `false`
-    /// logs a one-shot warning and behaves as `true` (cross-page buffering is
-    /// a future enhancement).
+    /// Never grow the effective batch past the source page size. Only `true`
+    /// is supported (the default) — `false` is rejected by [`validate`], since
+    /// cross-page buffering would have to hold records across source pages and
+    /// break the pipeline's O(batch_size) memory guarantee.
+    ///
+    /// [`validate`]: AdaptiveBatchConfig::validate
     #[serde(default = "default_true")]
     pub respect_source_max: bool,
     /// Emit a `tracing::info!` summary every N adjustments.
@@ -145,6 +148,14 @@ impl AdaptiveBatchConfig {
         {
             return Err(FaucetError::Config(
                 "adaptive_batch_size.target_latency_ms must be > 0 when set".into(),
+            ));
+        }
+        if !self.respect_source_max {
+            return Err(FaucetError::Config(
+                "adaptive_batch_size.respect_source_max=false is not supported \
+                 (cross-page buffering would violate the O(batch_size) memory \
+                 guarantee); remove the field or set it to true"
+                    .into(),
             ));
         }
         Ok(())
@@ -362,6 +373,16 @@ mod config_tests {
         assert!(c.respect_source_max);
         assert!(c.target_latency_ms.is_none());
         c.validate().unwrap();
+    }
+
+    #[test]
+    fn rejects_respect_source_max_false() {
+        // `false` was a frozen no-op (it warned, then behaved as `true`).
+        // Cross-page buffering would violate the O(batch_size) memory
+        // guarantee, so the knob is rejected rather than silently ignored.
+        let mut c = valid();
+        c.respect_source_max = false;
+        assert!(c.validate().is_err());
     }
 
     #[test]

--- a/crates/core/src/adaptive.rs
+++ b/crates/core/src/adaptive.rs
@@ -106,6 +106,20 @@ impl AdaptiveBatchConfig {
                 self.min, self.max
             )));
         }
+        if self.max > crate::MAX_BATCH_SIZE {
+            return Err(FaucetError::Config(format!(
+                "adaptive_batch_size.max ({}) must be <= {} (MAX_BATCH_SIZE)",
+                self.max,
+                crate::MAX_BATCH_SIZE
+            )));
+        }
+        if self.increase_step > crate::MAX_BATCH_SIZE {
+            return Err(FaucetError::Config(format!(
+                "adaptive_batch_size.increase_step ({}) must be <= {} (MAX_BATCH_SIZE)",
+                self.increase_step,
+                crate::MAX_BATCH_SIZE
+            )));
+        }
         if !(self.decrease_factor > 0.0 && self.decrease_factor < 1.0) {
             return Err(FaucetError::Config(
                 "adaptive_batch_size.decrease_factor must be in (0, 1)".into(),
@@ -302,7 +316,9 @@ impl AimdController {
     }
 
     fn grow(&mut self, reason: AdjustReason) -> Option<Adjustment> {
-        let new = (self.current + self.increase_step).min(self.max);
+        // `saturating_add` so a controller built directly with a large
+        // `increase_step` (bypassing `validate`) can't overflow `usize`.
+        let new = self.current.saturating_add(self.increase_step).min(self.max);
         if new == self.current {
             return None;
         }
@@ -367,6 +383,20 @@ mod config_tests {
     }
 
     #[test]
+    fn rejects_max_and_increase_step_above_max_batch_size() {
+        let mut c = valid();
+        c.max = crate::MAX_BATCH_SIZE + 1;
+        assert!(c.validate().is_err());
+        let mut c = valid();
+        c.increase_step = crate::MAX_BATCH_SIZE + 1;
+        assert!(c.validate().is_err());
+        // The ceiling itself is accepted.
+        let mut c = valid();
+        c.max = crate::MAX_BATCH_SIZE;
+        c.validate().unwrap();
+    }
+
+    #[test]
     fn rejects_out_of_range_factors() {
         let mut c = valid();
         c.decrease_factor = 1.5;
@@ -424,6 +454,22 @@ mod controller_tests {
         assert_eq!(c.current(), 1000);
         let c = AimdController::new(&cfg(), 500);
         assert_eq!(c.current(), 500);
+    }
+
+    #[test]
+    fn grow_saturates_instead_of_overflowing_usize() {
+        // A controller built directly (bypassing `validate`) with a huge
+        // increase_step must not overflow `usize` on growth — it saturates and
+        // clamps to `max`. Guards the `current + increase_step` arithmetic.
+        let cfg: AdaptiveBatchConfig = serde_json::from_value(serde_json::json!({
+            "enabled": true, "min": 1, "max": usize::MAX,
+            "increase_step": usize::MAX, "decrease_factor": 0.5
+        }))
+        .unwrap();
+        let mut c = AimdController::new(&cfg, 1);
+        let adj = c.observe(ok(1)).expect("growth should occur");
+        assert_eq!(adj.new_size, usize::MAX);
+        assert_eq!(c.current(), usize::MAX);
     }
 
     #[test]

--- a/crates/core/src/adaptive.rs
+++ b/crates/core/src/adaptive.rs
@@ -329,7 +329,10 @@ impl AimdController {
     fn grow(&mut self, reason: AdjustReason) -> Option<Adjustment> {
         // `saturating_add` so a controller built directly with a large
         // `increase_step` (bypassing `validate`) can't overflow `usize`.
-        let new = self.current.saturating_add(self.increase_step).min(self.max);
+        let new = self
+            .current
+            .saturating_add(self.increase_step)
+            .min(self.max);
         if new == self.current {
             return None;
         }

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -436,13 +436,11 @@ where
     let mut dlq_stats = DlqStats::default();
 
     let adaptive_cfg = options.adaptive.clone().filter(|c| c.enabled);
-    if let Some(cfg) = adaptive_cfg.as_ref()
-        && !cfg.respect_source_max
-    {
-        tracing::warn!(
-            "adaptive_batch_size.respect_source_max=false is not yet implemented \
-             (cross-page buffering); growth is capped at the source page size"
-        );
+    // Validate at the core boundary so library callers of `run_stream` (not
+    // just the CLI, which validates earlier) reject an invalid adaptive config
+    // — e.g. the rejected `respect_source_max=false` knob — up front.
+    if let Some(cfg) = adaptive_cfg.as_ref() {
+        cfg.validate()?;
     }
     let mut controller: Option<crate::adaptive::AimdController> = None;
     let mut warned_noop_sink = false;

--- a/crates/core/src/retry.rs
+++ b/crates/core/src/retry.rs
@@ -57,7 +57,15 @@ fn pseudo_random_factor() -> f64 {
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .subsec_nanos();
-    0.5 + (nanos as f64 / u32::MAX as f64)
+    jitter_factor(nanos)
+}
+
+/// Map a sub-second nanosecond count (`[0, 1_000_000_000)`) to a jitter factor
+/// in `[0.5, 1.5)`. `subsec_nanos()` is bounded by 1e9, so the divisor must be
+/// 1e9 — not `u32::MAX` (~4.29e9), which would cap the factor at ~0.733 and
+/// make every backoff shorter than documented.
+fn jitter_factor(nanos: u32) -> f64 {
+    0.5 + (nanos as f64 / 1_000_000_000.0)
 }
 
 #[cfg(test)]
@@ -100,6 +108,21 @@ mod tests {
         .await;
         assert_eq!(r.unwrap(), 42);
         assert_eq!(calls.load(Ordering::SeqCst), 3);
+    }
+
+    #[test]
+    fn jitter_factor_spans_documented_half_to_one_and_a_half_range() {
+        // The factor must span [0.5, 1.5): 0 nanos → 0.5, the midpoint → 1.0,
+        // and the maximum sub-second value → just under 1.5. A `u32::MAX`
+        // divisor caps the top at ~0.733, so backoff is always too short.
+        assert_eq!(jitter_factor(0), 0.5);
+        let mid = jitter_factor(500_000_000);
+        assert!((mid - 1.0).abs() < 1e-6, "midpoint factor was {mid}");
+        let hi = jitter_factor(999_999_999);
+        assert!(
+            (1.4..1.5).contains(&hi),
+            "factor at max sub-second nanos was {hi}, expected ~1.5"
+        );
     }
 
     #[tokio::test]

--- a/crates/core/src/schema.rs
+++ b/crates/core/src/schema.rs
@@ -204,8 +204,15 @@ fn add_null_type(schema: &mut Value) {
     }
     types.insert("null".to_string());
     let new_type = make_type_value(types.into_iter().collect());
-    if let Some(t) = schema.get_mut("type") {
-        *t = new_type;
+    match schema {
+        // Insert (not just overwrite) so a type-less `{}` fragment is still
+        // marked nullable instead of silently dropping the null.
+        Value::Object(map) => {
+            map.insert("type".to_string(), new_type);
+        }
+        // A non-object fragment (e.g. a bare `null`) becomes a minimal
+        // nullable object schema.
+        _ => *schema = json!({ "type": new_type }),
     }
 }
 
@@ -225,6 +232,30 @@ fn make_type_value(mut types: Vec<String>) -> Value {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn add_null_type_marks_typeless_schema_nullable() {
+        // A type-less `{}` fragment (an unknown field) must still be marked
+        // nullable when absent from some records — previously the missing
+        // `type` key meant the null was silently dropped.
+        let mut s = json!({});
+        add_null_type(&mut s);
+        assert_eq!(s, json!({"type": "null"}));
+    }
+
+    #[test]
+    fn add_null_type_adds_null_to_existing_type() {
+        let mut s = json!({"type": "string"});
+        add_null_type(&mut s);
+        assert_eq!(s["type"], json!(["null", "string"]));
+    }
+
+    #[test]
+    fn add_null_type_is_idempotent_when_already_nullable() {
+        let mut s = json!({"type": ["null", "string"]});
+        add_null_type(&mut s);
+        assert_eq!(s["type"], json!(["null", "string"]));
+    }
 
     #[test]
     fn test_infer_schema_basic_types() {

--- a/crates/core/src/transform.rs
+++ b/crates/core/src/transform.rs
@@ -1044,8 +1044,7 @@ fn cast_value(v: &Value, target: CastType) -> Result<Value, String> {
                 // with a zero fractional part round-trips losslessly.
                 match n.as_f64() {
                     Some(f)
-                        if f.fract() == 0.0
-                            && (-(2f64.powi(63))..2f64.powi(63)).contains(&f) =>
+                        if f.fract() == 0.0 && (-(2f64.powi(63))..2f64.powi(63)).contains(&f) =>
                     {
                         Ok(Value::Number((f as i64).into()))
                     }

--- a/crates/core/src/transform.rs
+++ b/crates/core/src/transform.rs
@@ -1032,11 +1032,29 @@ fn cast_fields(
 fn cast_value(v: &Value, target: CastType) -> Result<Value, String> {
     match target {
         CastType::Int => match v {
-            Value::Number(n) => n
-                .as_i64()
-                .map(|i| Value::Number(i.into()))
-                .or_else(|| n.as_f64().map(|f| Value::Number((f as i64).into())))
-                .ok_or_else(|| format!("number '{n}' is not representable as i64")),
+            Value::Number(n) => {
+                if let Some(i) = n.as_i64() {
+                    return Ok(Value::Number(i.into()));
+                }
+                // A float-backed number only converts when it is a whole
+                // number within i64 range. A fractional or out-of-range float
+                // is an error rather than a silent truncate/saturate — so
+                // `on_error` (error/null/skip) governs it as documented.
+                // `2^63` is the exact f64 just above i64::MAX; `[-2^63, 2^63)`
+                // with a zero fractional part round-trips losslessly.
+                match n.as_f64() {
+                    Some(f)
+                        if f.fract() == 0.0
+                            && (-(2f64.powi(63))..2f64.powi(63)).contains(&f) =>
+                    {
+                        Ok(Value::Number((f as i64).into()))
+                    }
+                    Some(f) => Err(format!(
+                        "float '{f}' is not a whole number representable as i64"
+                    )),
+                    None => Err(format!("number '{n}' is not representable as i64")),
+                }
+            }
             Value::String(s) => s
                 .trim()
                 .parse::<i64>()
@@ -1721,6 +1739,55 @@ mod tests {
             &compiled(&cast_specs("age", CastType::Int, CastOnError::Error)),
         );
         assert_eq!(result["age"], 42);
+    }
+
+    #[cfg(feature = "transform-cast")]
+    #[test]
+    fn cast_whole_number_float_to_int_succeeds() {
+        // A float with no fractional part and within i64 range converts.
+        let record = json!({"n": 5.0});
+        let result = apply_all(
+            record,
+            &compiled(&cast_specs("n", CastType::Int, CastOnError::Error)),
+        );
+        assert_eq!(result["n"], 5);
+    }
+
+    #[cfg(feature = "transform-cast")]
+    #[test]
+    fn cast_fractional_float_to_int_errors_under_on_error_error() {
+        // A fractional float must surface an error, not silently truncate to 3.
+        let record = json!({"n": 3.9});
+        let err = super::apply_all(
+            record,
+            &compiled(&cast_specs("n", CastType::Int, CastOnError::Error)),
+        )
+        .expect_err("a fractional float must not silently truncate to int");
+        assert!(matches!(err, FaucetError::Transform(_)), "{err}");
+    }
+
+    #[cfg(feature = "transform-cast")]
+    #[test]
+    fn cast_out_of_range_float_to_int_errors_under_on_error_error() {
+        // A float beyond i64 range must error, not silently saturate to i64::MAX.
+        let record = json!({"n": 1e30});
+        let err = super::apply_all(
+            record,
+            &compiled(&cast_specs("n", CastType::Int, CastOnError::Error)),
+        )
+        .expect_err("an out-of-range float must not silently saturate to i64::MAX");
+        assert!(matches!(err, FaucetError::Transform(_)), "{err}");
+    }
+
+    #[cfg(feature = "transform-cast")]
+    #[test]
+    fn cast_fractional_float_to_int_nulls_under_on_error_null() {
+        let record = json!({"n": 3.9});
+        let result = apply_all(
+            record,
+            &compiled(&cast_specs("n", CastType::Int, CastOnError::Null)),
+        );
+        assert_eq!(result["n"], Value::Null);
     }
 
     #[cfg(feature = "transform-cast")]

--- a/crates/source/grpc/README.md
+++ b/crates/source/grpc/README.md
@@ -76,7 +76,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 | `rpc_kind` | `RpcKind` | `Unary` | RPC kind: `Unary` (one request → one response) or `ServerStreaming` (one request → stream of responses). See [Server-streaming RPCs](#server-streaming-rpcs) below |
 | `max_messages` | `Option<usize>` | `None` | Server-streaming only. Cap on the number of streamed messages to consume before terminating. `None` means consume until the server closes the stream |
 | `terminate_on_error` | `bool` | `false` | Server-streaming only. If `true`, transient stream errors terminate the run. If `false`, the source reconnects with exponential backoff |
-| `reconnect_initial_backoff` | `Duration` (secs) | `1` | Server-streaming only. Initial backoff before the first reconnect attempt; doubles after each failure up to `reconnect_max_backoff` |
+| `reconnect_initial_backoff` | `Duration` (secs) | `1` | Server-streaming only. Initial backoff before the first reconnect attempt; doubles after each failure up to `reconnect_max_backoff`. Must be `> 0` (a zero backoff would busy-spin reconnects and is rejected at construction) |
 | `reconnect_max_backoff` | `Duration` (secs) | `30` | Server-streaming only. Upper bound on reconnect backoff |
 | `reconnect_max_attempts` | `Option<u32>` | `None` | Server-streaming only. Maximum reconnect attempts before surfacing the error. `None` means unlimited |
 | `reconnect_replay_from_start` | `bool` | `true` | Server-streaming only. Whether the server replays the stream from message 0 when the same request is re-issued on reconnect. `true` (default) skips already-emitted messages so each is delivered once; `false` emits every received message (at-least-once). See [Reconnect on transient errors](#reconnect-on-transient-errors) |

--- a/crates/source/grpc/src/stream.rs
+++ b/crates/source/grpc/src/stream.rs
@@ -975,9 +975,9 @@ mod tests {
             tmp.path().to_str().unwrap(),
         );
         config.reconnect_initial_backoff = std::time::Duration::ZERO;
-        let err = GrpcStream::new(config)
-            .err()
-            .expect("a zero reconnect_initial_backoff must be rejected (it busy-spins)");
+        let Err(err) = GrpcStream::new(config) else {
+            panic!("a zero reconnect_initial_backoff must be rejected (it busy-spins)");
+        };
         assert!(matches!(err, FaucetError::Config(_)), "{err:?}");
         assert!(
             err.to_string().contains("reconnect_initial_backoff"),

--- a/crates/source/grpc/src/stream.rs
+++ b/crates/source/grpc/src/stream.rs
@@ -27,6 +27,14 @@ pub struct GrpcStream {
 impl GrpcStream {
     /// Create a new gRPC stream. Loads the `FileDescriptorSet` from disk.
     pub fn new(config: GrpcStreamConfig) -> Result<Self, FaucetError> {
+        // A zero initial backoff makes `next_backoff(0, cap) == 0`, so a
+        // server-streaming reconnect loop would busy-spin with no delay.
+        if config.reconnect_initial_backoff.is_zero() {
+            return Err(FaucetError::Config(
+                "grpc reconnect_initial_backoff must be > 0 (a zero backoff busy-spins reconnects)"
+                    .into(),
+            ));
+        }
         let descriptor_bytes = std::fs::read(&config.descriptor_set_path).map_err(|e| {
             FaucetError::Config(format!(
                 "failed to read descriptor set at {}: {e}",
@@ -944,6 +952,37 @@ mod tests {
         );
         // `tmp` is dropped here but the bytes were already decoded by `new()`.
         GrpcStream::new(config).expect("new from in-memory descriptor")
+    }
+
+    #[test]
+    fn rejects_zero_reconnect_initial_backoff() {
+        use prost::Message;
+        // A valid descriptor on disk, so the only thing that can fail `new` is
+        // the backoff validation (not a missing-file read).
+        let fds_set = prost_types::FileDescriptorSet {
+            file: vec![prost_types::FileDescriptorProto {
+                name: Some("dummy.proto".into()),
+                syntax: Some("proto3".into()),
+                ..Default::default()
+            }],
+        };
+        let tmp = tempfile::NamedTempFile::new().expect("tempfile");
+        std::fs::write(tmp.path(), fds_set.encode_to_vec()).expect("write descriptor");
+        let mut config = GrpcStreamConfig::new(
+            "http://localhost:50051",
+            "dummy.Svc",
+            "Call",
+            tmp.path().to_str().unwrap(),
+        );
+        config.reconnect_initial_backoff = std::time::Duration::ZERO;
+        let err = GrpcStream::new(config)
+            .err()
+            .expect("a zero reconnect_initial_backoff must be rejected (it busy-spins)");
+        assert!(matches!(err, FaucetError::Config(_)), "{err:?}");
+        assert!(
+            err.to_string().contains("reconnect_initial_backoff"),
+            "{err}"
+        );
     }
 
     // ── Unresolved Reference error path ───────────────────────────────────────

--- a/crates/source/kafka/README.md
+++ b/crates/source/kafka/README.md
@@ -158,13 +158,13 @@ When a `StateStore` is wired into the pipeline (via `state:` in the YAML, or `Pi
 **State key format:**
 
 ```
-kafka:{group_id}:{topic1}.{topic2}...
+kafka:{group_id}:{topic1}:{topic2}...
 ```
 
-Topics are sorted alphabetically before joining, so the key is stable regardless of the order you list topics in the config. For example, `group_id = "my-group"` and `topics = ["beta", "alpha"]` produces:
+Topics are sorted alphabetically before joining, so the key is stable regardless of the order you list topics in the config. They are joined with `:` (not `.`) because a Kafka topic name may legally contain `.`, which would otherwise let `["a.b", "c"]` and `["a", "b.c"]` collide on the same `group_id`. For example, `group_id = "my-group"` and `topics = ["beta", "alpha"]` produces:
 
 ```
-kafka:my-group:alpha.beta
+kafka:my-group:alpha:beta
 ```
 
 **Delivery semantics:** Offsets are persisted via faucet-stream's state store only after the sink confirms a batch, and on restart the consumer seeds the partition assignment with the bookmarked offset *before* any message is fetched. End-to-end this is at-least-once if the sink can fail mid-batch; pair with idempotent sinks if you need stricter guarantees.

--- a/crates/source/kafka/src/state.rs
+++ b/crates/source/kafka/src/state.rs
@@ -102,14 +102,16 @@ impl Bookmark {
 
 /// Generate the `state_key` for a `(group_id, topics)` pair.
 ///
-/// Topics are sorted before joining so the key is stable regardless of
-/// config ordering. Allowed characters per
-/// [`faucet_core::state::validate_state_key`] are `[A-Za-z0-9_:.-]`, so we
-/// replace `,` with `.` when joining.
+/// Topics are sorted before joining so the key is stable regardless of config
+/// ordering. Topics are joined with `:` rather than `.`: a Kafka topic name may
+/// legally contain `.` (e.g. `orders.eu`), so a `.` join made `["a.b","c"]` and
+/// `["a","b.c"]` collide on a shared `group_id`. `:` is **not** a legal Kafka
+/// topic character, so it is an unambiguous separator — and it is permitted in a
+/// state key per [`faucet_core::state::validate_state_key`] (`[A-Za-z0-9_:.-]`).
 pub fn state_key(group_id: &str, topics: &[String]) -> String {
     let mut sorted = topics.to_vec();
     sorted.sort();
-    format!("kafka:{group_id}:{}", sorted.join("."))
+    format!("kafka:{group_id}:{}", sorted.join(":"))
 }
 
 #[cfg(test)]
@@ -158,13 +160,23 @@ mod tests {
     fn state_key_sorts_topics() {
         assert_eq!(
             state_key("g1", &["beta".into(), "alpha".into()]),
-            "kafka:g1:alpha.beta"
+            "kafka:g1:alpha:beta"
         );
     }
 
     #[test]
     fn state_key_single_topic() {
         assert_eq!(state_key("g1", &["only".into()]), "kafka:g1:only");
+    }
+
+    #[test]
+    fn state_key_distinguishes_topic_sets_containing_dots() {
+        // Topic names legally contain dots. Joining with '.' made
+        // ["a.b","c"] and ["a","b.c"] collide on a shared group_id, so two
+        // distinct subscriptions would clobber each other's bookmark.
+        let k1 = state_key("g", &["a.b".into(), "c".into()]);
+        let k2 = state_key("g", &["a".into(), "b.c".into()]);
+        assert_ne!(k1, k2, "topic sets with dots must not produce the same key");
     }
 
     #[test]

--- a/crates/source/postgres-cdc/src/pgoutput/decoder.rs
+++ b/crates/source/postgres-cdc/src/pgoutput/decoder.rs
@@ -203,6 +203,15 @@ fn decode_delete(c: &mut Cursor<&[u8]>) -> Result<Delete, FaucetError> {
 fn decode_truncate(c: &mut Cursor<&[u8]>) -> Result<Truncate, FaucetError> {
     let n = c.read_u32::<BigEndian>().map_err(io_err_in("TRUNCATE"))?;
     let flags = c.read_u8().map_err(io_err_in("TRUNCATE"))?;
+    // Each relation OID is 4 bytes; a wire-controlled `n` can't exceed the
+    // bytes that actually remain. Reject before reserving so a corrupt frame
+    // can't drive a huge pre-allocation.
+    let rem = remaining(c);
+    if (n as usize).saturating_mul(4) > rem {
+        return Err(FaucetError::Source(format!(
+            "pgoutput TRUNCATE: declared relation count {n} exceeds {rem} remaining bytes"
+        )));
+    }
     let mut oids = Vec::with_capacity(n as usize);
     for _ in 0..n {
         oids.push(c.read_u32::<BigEndian>().map_err(io_err_in("TRUNCATE"))?);
@@ -224,6 +233,14 @@ fn decode_tuple(c: &mut Cursor<&[u8]>) -> Result<TupleData, FaucetError> {
             b'u' => TupleCell::UnchangedToast,
             b't' => {
                 let len = c.read_u32::<BigEndian>().map_err(io_err_in("tuple"))?;
+                // Reject a wire-controlled length larger than the bytes that
+                // remain before allocating a buffer for it.
+                let rem = remaining(c);
+                if len as usize > rem {
+                    return Err(FaucetError::Source(format!(
+                        "pgoutput tuple: declared text length {len} exceeds {rem} remaining bytes"
+                    )));
+                }
                 let mut buf = vec![0u8; len as usize];
                 c.read_exact(&mut buf).map_err(io_err_in("tuple"))?;
                 TupleCell::Text(String::from_utf8(buf).map_err(|e| {
@@ -256,6 +273,12 @@ fn read_cstring(c: &mut Cursor<&[u8]>) -> Result<String, FaucetError> {
         out.push(b);
     }
     String::from_utf8(out).map_err(|e| FaucetError::Source(format!("pgoutput cstring: {e}")))
+}
+
+/// Bytes still unread in the cursor — used to bound wire-controlled
+/// allocations against the data that actually remains.
+fn remaining(c: &Cursor<&[u8]>) -> usize {
+    c.get_ref().len().saturating_sub(c.position() as usize)
 }
 
 fn io_err(e: std::io::Error) -> FaucetError {
@@ -297,6 +320,31 @@ mod tests {
         let k = PrimaryKeepAlive::decode(&bytes).unwrap();
         assert_eq!(k.wal_end, 0x0000_0000_016A_4F88);
         assert!(k.reply_requested);
+    }
+
+    #[test]
+    fn decode_tuple_rejects_text_length_exceeding_remaining() {
+        // n_cells=1, kind 't', declared text len=1000 (0x3E8), but only 2 bytes
+        // ("AB") follow. The declared length must be rejected against the bytes
+        // actually available *before* allocating a buffer for it.
+        let bytes = hex("00 01 74 00 00 03 E8 41 42");
+        let mut c = Cursor::new(bytes.as_slice());
+        let err = decode_tuple(&mut c)
+            .err()
+            .expect("an oversized declared text length must be rejected");
+        assert!(err.to_string().contains("exceeds"), "{err}");
+    }
+
+    #[test]
+    fn decode_truncate_rejects_relation_count_exceeding_remaining() {
+        // n=1_000_000 relations declared (4 MB of OIDs), flags=0, but only one
+        // 4-byte OID follows. Must be rejected before reserving for `n`.
+        let bytes = hex("00 0F 42 40 00 00 00 00 2A");
+        let mut c = Cursor::new(bytes.as_slice());
+        let err = decode_truncate(&mut c)
+            .err()
+            .expect("an oversized declared relation count must be rejected");
+        assert!(err.to_string().contains("exceeds"), "{err}");
     }
 
     #[test]

--- a/crates/source/postgres-cdc/src/pgoutput/decoder.rs
+++ b/crates/source/postgres-cdc/src/pgoutput/decoder.rs
@@ -329,9 +329,9 @@ mod tests {
         // actually available *before* allocating a buffer for it.
         let bytes = hex("00 01 74 00 00 03 E8 41 42");
         let mut c = Cursor::new(bytes.as_slice());
-        let err = decode_tuple(&mut c)
-            .err()
-            .expect("an oversized declared text length must be rejected");
+        let Err(err) = decode_tuple(&mut c) else {
+            panic!("an oversized declared text length must be rejected");
+        };
         assert!(err.to_string().contains("exceeds"), "{err}");
     }
 
@@ -341,9 +341,9 @@ mod tests {
         // 4-byte OID follows. Must be rejected before reserving for `n`.
         let bytes = hex("00 0F 42 40 00 00 00 00 2A");
         let mut c = Cursor::new(bytes.as_slice());
-        let err = decode_truncate(&mut c)
-            .err()
-            .expect("an oversized declared relation count must be rejected");
+        let Err(err) = decode_truncate(&mut c) else {
+            panic!("an oversized declared relation count must be rejected");
+        };
         assert!(err.to_string().contains("exceeds"), "{err}");
     }
 

--- a/crates/source/snowflake/README.md
+++ b/crates/source/snowflake/README.md
@@ -9,7 +9,7 @@ Snowflake query source connector for the [`faucet-stream`](https://crates.io/cra
 - **Configurable batching** — `batch_size` re-frames partitions into pages for `Source::stream_pages`; `batch_size = 0` opts out of re-chunking and emits the full result set as one page.
 - **Async / sync handling** — if Snowflake returns `202 Accepted` (statement still running), the source polls the handle until the result is ready, bounded by `poll_timeout` (default 300 s; `0` = poll forever) so a stuck statement fails instead of hanging.
 - **Bind parameters** — positional `params` from config are merged with `${parent.path}` tokens resolved from the matrix-row context. Each bind's Snowflake type is inferred from the JSON value (`FIXED` for integers, `REAL` for floats, `BOOLEAN` for bools, `TEXT` otherwise), so numeric/boolean binds compare against typed columns instead of being forced to `TEXT`.
-- **Type-aware row conversion** — `FIXED`, `REAL`, `BOOLEAN`, and `VARIANT`/`OBJECT`/`ARRAY` columns are parsed into native JSON shapes; everything else (timestamps, dates, binary) passes through as strings.
+- **Type-aware row conversion** — `FIXED`, `REAL`, `BOOLEAN`, and `VARIANT`/`OBJECT`/`ARRAY` columns are parsed into native JSON shapes; everything else (timestamps, dates, binary) passes through as strings. A scale-0 `FIXED`/`NUMBER` value beyond `u64` (e.g. `NUMBER(38,0)`) is kept as a **string** rather than a lossy `f64`, preserving full precision (the same approach as BigQuery NUMERIC).
 
 ## Configuration
 

--- a/crates/source/snowflake/src/convert.rs
+++ b/crates/source/snowflake/src/convert.rs
@@ -83,9 +83,23 @@ fn cell_to_json(cell: Option<&Value>, ty: &str) -> Value {
 /// Parse an integer-valued column (`FIXED`/`NUMBER` with scale 0 ships an
 /// integer literal here; non-zero-scale columns ship a decimal string and
 /// fall back to `f64`).
+///
+/// A scale-0 value beyond `i64`/`u64` (e.g. `NUMBER(38,0)`) would lose
+/// precision as `f64`, so it is kept as a string (lossless), matching how
+/// BigQuery NUMERIC is handled. Decimal/scientific literals (non-zero scale)
+/// still fall back to `f64`.
 fn parse_number(s: &str) -> Value {
     if let Ok(i) = s.parse::<i64>() {
         return Value::Number(i.into());
+    }
+    if let Ok(u) = s.parse::<u64>() {
+        return Value::Number(u.into());
+    }
+    // Past u64: only an integer literal stays a (lossless) string; a decimal or
+    // scientific value is genuinely floating-point, so let `parse_real` handle it.
+    let digits = s.trim().strip_prefix(['+', '-']).unwrap_or(s.trim());
+    if !digits.is_empty() && digits.bytes().all(|b| b.is_ascii_digit()) {
+        return Value::String(s.to_owned());
     }
     parse_real(s)
 }
@@ -136,6 +150,31 @@ mod tests {
         let row = [json!("2.5")];
         let cols = [col("RATIO", "fixed")];
         assert_eq!(row_to_json(&row, &cols), json!({"RATIO": 2.5}));
+    }
+
+    #[test]
+    fn fixed_past_i64_within_u64_stays_numeric() {
+        // A FIXED/NUMBER(20,0) value above i64::MAX but within u64 range is
+        // still losslessly representable as a JSON integer — keep it numeric
+        // instead of dropping precision through f64.
+        let row = [json!("18446744073709551615")]; // u64::MAX
+        let cols = [col("ID", "fixed")];
+        assert_eq!(
+            row_to_json(&row, &cols),
+            json!({"ID": 18446744073709551615u64})
+        );
+    }
+
+    #[test]
+    fn fixed_beyond_u64_kept_as_string_lossless() {
+        // A NUMBER(38,0) value beyond u64 can't be a JSON integer; keep it as a
+        // string (lossless) rather than a lossy f64.
+        let row = [json!("123456789012345678901234567890")];
+        let cols = [col("ID", "fixed")];
+        assert_eq!(
+            row_to_json(&row, &cols),
+            json!({"ID": "123456789012345678901234567890"})
+        );
     }
 
     #[test]

--- a/docs/book/src/cookbook/adaptive-batching.md
+++ b/docs/book/src/cookbook/adaptive-batching.md
@@ -104,14 +104,14 @@ below.
 | `enabled` | bool | `false` | Master switch. Set to `true` to activate the controller. |
 | `controller` | string | `"aimd"` | Algorithm. Only `"aimd"` is supported in v1. |
 | `min` | integer | `100` | Lower bound on effective batch size. Must be ≥ 1. |
-| `max` | integer | `50000` | Upper bound. Values above the source page size are inert (see Caveats). |
-| `increase_step` | integer | `250` | Rows added per clean, fast batch (additive growth). Must be ≥ 1. |
+| `max` | integer | `50000` | Upper bound. Must be ≤ 1,000,000. Values above the source page size are inert (see Caveats). |
+| `increase_step` | integer | `250` | Rows added per clean, fast batch (additive growth). Must be ≥ 1 and ≤ 1,000,000. |
 | `decrease_factor` | float | `0.5` | Multiplicative shrink factor on error or high latency. Must be in (0, 1). |
 | `cooldown_batches` | integer | `5` | Batches to skip after a shrink before allowing growth again. |
 | `target_latency_ms` | integer \| null | `null` | Optional target write latency (ms). `null` means react to errors only. |
 | `latency_window` | integer | `10` | Rolling window size (batches) for the p50 latency estimate. Must be ≥ 1. |
 | `error_threshold` | float | `0.01` | Per-batch error rate (0.0–1.0) above which the controller shrinks. |
-| `respect_source_max` | bool | `true` | Cap effective batch size at the source page size. `false` is not yet implemented (logs a warning and behaves as `true`). |
+| `respect_source_max` | bool | `true` | Cap effective batch size at the source page size. Must be `true`; `false` is rejected (cross-page buffering would break the O(batch_size) memory guarantee). |
 | `log_every` | integer | `50` | Emit a `tracing::info` summary every N adjustments (0 = never). |
 
 ## AIMD behavior
@@ -195,8 +195,10 @@ per call.
 `batch_size: 20000` on the postgres source config). Setting `max` higher than
 the source page size is harmless but inert.
 
-`respect_source_max: false` to cross page boundaries is planned but not yet
-implemented. Setting it logs a one-shot warning and behaves as `true`.
+`respect_source_max: false` to cross page boundaries is **rejected** at config
+load: cross-page buffering would have to hold records across source pages, which
+breaks the pipeline's O(batch_size) memory guarantee. Raise the source
+`batch_size` instead.
 
 ### No-op for per-record sinks
 

--- a/docs/book/src/cookbook/scheduling.md
+++ b/docs/book/src/cookbook/scheduling.md
@@ -95,9 +95,13 @@ by more than ~30 seconds.
 
 ## Missed-tick behavior
 
-If the process was down or a run took longer than one cron period, missed
-ticks are **skipped** — not backfilled. The scheduler fires once at the next
-due time and moves on. There is no catch-up storm.
+The scheduler advances from the **scheduled** tick, not the wall clock, so a
+single occurrence is **not skipped** just because dispatch latency pushed the
+clock a little past it — it fires promptly (slightly late) and the schedule
+resumes. But if many ticks elapsed (the process was down, or a run took longer
+than several cron periods), the backlog is **collapsed to a single catch-up**:
+the scheduler fires once at the next due time and moves on. There is no
+catch-up storm and no flood of backfilled runs.
 
 To find out how late a run fired, scrape
 `faucet_schedule_run_lateness_seconds` (histogram: `actual_start −

--- a/docs/book/src/cookbook/transforms.md
+++ b/docs/book/src/cookbook/transforms.md
@@ -303,7 +303,10 @@ overwriting a real value.
 Target types: `int` (i64), `float` (f64), `bool`, `string`, `timestamp`
 (RFC 3339). `bool` from a string accepts `true|false|1|0|yes|no`
 case-insensitively. `timestamp` parses RFC 3339 / ISO 8601 and
-normalises the output (so `+00:00` becomes `Z`).
+normalises the output (so `+00:00` becomes `Z`). Casting a **float to
+`int`** only succeeds for a whole number within i64 range — a fractional
+value (e.g. `3.9`) or one beyond ±9.2e18 is treated as uncastable (governed
+by `on_error`) rather than being silently truncated or saturated.
 
 Failure behaviour is controlled by `on_error`:
 


### PR DESCRIPTION
## Summary

Fixes the **11 verified LOW `[V]` items** from the round-2 pre-1.0 hardening audit (#146) — the last tier with confirmed-against-source findings. Each is a focused, test-first fix (one commit per item); the four CRITICAL, sixteen HIGH, and seventeen MEDIUM tiers already landed in earlier PRs.

Refs #146. (The finder-reported `[R]` LOW/NIT backlog is intentionally **not** in scope here — per the issue's own triage, those are "confirm before patching" and "can ride along in 1.x".)

## What's fixed

| Item | Area | Fix |
|------|------|-----|
| Retry jitter divisor `u32::MAX` → factor `[0.5, 0.733)` not `[0.5, 1.5)` | `core/retry` | divide `subsec_nanos` by `1e9`; extract testable `jitter_factor` |
| `AimdController::grow` `usize` overflow on config-valid huge `increase_step`/`max` | `core/adaptive` | `saturating_add(...).min(max)` + reject `max`/`increase_step` > `MAX_BATCH_SIZE` |
| `respect_source_max: false` frozen no-op knob | `core/adaptive` + `pipeline` | **reject `false`** at `validate()` (cross-page buffering would break the O(batch_size) memory guarantee); `run_stream` now validates at the core boundary |
| Pipeline name / parent-key value validated only mid-run | `cli/executor` | validate each per-unit state key up front (gated on the node using state) → new `CliError::InvalidStateKey` |
| Scheduler `next_due` recomputed from `Utc::now()` → sub-minute occurrences skipped | `cli/schedule` | new `next_due_after_tick(fired, now)`: advance from the **scheduled** tick (fixes the skip), collapse a long backlog to one catch-up (no flood) |
| gRPC `reconnect_initial_backoff: 0` busy-spins reconnects | `source/grpc` | reject zero backoff in `new()` |
| Kafka `state_key` joins topics with `.` → `["a.b","c"]`/`["a","b.c"]` collide | `source/kafka` | join with `:` (illegal in a Kafka topic name, so unambiguous) |
| `cast` int from float silently truncates/saturates under `on_error: error` | `core/transform` | only a whole number in `[-2^63, 2^63)` converts; else the documented uncastable error |
| Snowflake `NUMBER(38,0)` past i64 → lossy f64 | `source/snowflake` | i64 → u64 → lossless **string** (like BigQuery NUMERIC); decimals still f64 |
| postgres-cdc decoder pre-allocates a wire-controlled length before bounds-check | `source/postgres-cdc` | reject a declared length/count larger than the bytes remaining before allocating |
| `add_null_type` no-ops on a type-less `{}` schema | `core/schema` | insert the `type` when the key is absent so the field is still marked nullable |

## Behavior changes to note (all pre-1.0, intentional)

- **Kafka state-key format** changed from `.`-joined to `:`-joined. A multi-topic subscription's existing bookmark won't be found after upgrade and resumes from `auto.offset.reset`. (Single-topic keys are unchanged.)
- **`cast` float→int** now errors on a fractional/out-of-range float (previously truncated/saturated silently) — governed by `on_error`.
- **`adaptive_batch_size.respect_source_max: false`** is now rejected at config load (was a silent no-op).
- **Scheduler** now fires a single just-missed sub-minute occurrence (slightly late) instead of skipping it; large backlogs after a suspension still collapse to one catch-up.

## Testing

- Test-first (RED → GREEN) for every item; each RED was confirmed to fail for the right reason before the fix.
- `cargo fmt --all --check` clean.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean.
- Touched-crate test suites pass: `faucet-core` (all-features), `faucet-cli` (incl. `schedule`), `faucet-source-{grpc,kafka,snowflake,postgres-cdc}`.

Docs/READMEs updated alongside the code: adaptive-batching, transforms, scheduling cookbook pages; gRPC, Kafka, and Snowflake source READMEs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
