### PR TITLE
fix(#146): LOW/NIT backlog — secrets & security hardening

### DIFF
--- a/cli/src/secrets/registry.rs
+++ b/cli/src/secrets/registry.rs
@@ -35,11 +35,18 @@ pub fn redact(input: &str) -> Cow<'_, str> {
     if reg.is_empty() {
         return Cow::Borrowed(input);
     }
+    // Process **longest secret first**: a secret that is a substring of another
+    // (e.g. `abcd` inside `abcdXYZW`) must be replaced *after* the longer one,
+    // otherwise replacing the shorter one first destroys the longer match and
+    // leaves its extra tail (`XYZW`) exposed. `HashSet` iteration order is
+    // randomized, so without this sort redaction is nondeterministic.
+    let mut secrets: Vec<&str> = reg.iter().map(String::as_str).collect();
+    secrets.sort_by(|a, b| b.len().cmp(&a.len()).then_with(|| a.cmp(b)));
     let mut out: Option<String> = None;
-    for secret in reg.iter() {
+    for secret in secrets {
         let current = out.as_deref().unwrap_or(input);
-        if current.contains(secret.as_str()) {
-            out = Some(current.replace(secret.as_str(), "***"));
+        if current.contains(secret) {
+            out = Some(current.replace(secret, "***"));
         }
     }
     match out {
@@ -48,32 +55,79 @@ pub fn redact(input: &str) -> Cow<'_, str> {
     }
 }
 
+/// Longest registered secret in bytes (0 if none). Sizes the [`RedactingWriter`]
+/// hold-back window so a secret split across two `write()` calls is still caught.
+fn max_secret_len() -> usize {
+    registry()
+        .read()
+        .expect("secret registry lock poisoned")
+        .iter()
+        .map(String::len)
+        .max()
+        .unwrap_or(0)
+}
+
 /// An `io::Write` adapter that runs [`redact`] over every chunk before
 /// forwarding it to the inner writer. Wrapping the tracing subscriber's
 /// writer in this scrubs secret values out of *all* CLI log/diagnostic output
 /// at the I/O boundary, regardless of which field carried the value.
-pub struct RedactingWriter<W> {
+pub struct RedactingWriter<W: Write> {
     inner: W,
+    /// Trailing bytes withheld from the previous `write` — the window that might
+    /// be the *start* of a secret completing in a later write. Bounded by the
+    /// longest registered secret; flushed on `flush`/drop.
+    pending: Vec<u8>,
 }
 
 impl<W: Write> RedactingWriter<W> {
     pub fn new(inner: W) -> Self {
-        Self { inner }
+        Self {
+            inner,
+            pending: Vec::new(),
+        }
     }
 }
 
 impl<W: Write> Write for RedactingWriter<W> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        let text = String::from_utf8_lossy(buf);
-        let scrubbed = redact(&text);
-        self.inner.write_all(scrubbed.as_bytes())?;
+        self.pending.extend_from_slice(buf);
+        // Withhold the last `max_secret_len - 1` bytes so a secret straddling
+        // this write and the next is scrubbed once the two are joined. Everything
+        // before that window is safe to emit: any *complete* secret in it has
+        // already been masked, and an *incomplete* prefix can only sit in the
+        // withheld tail.
+        let keep = max_secret_len().saturating_sub(1);
+        if self.pending.len() > keep {
+            // `into_owned` drops the borrow of `self.pending` so we can mutate it.
+            let scrubbed = redact(&String::from_utf8_lossy(&self.pending)).into_owned();
+            let mut split = scrubbed.len().saturating_sub(keep);
+            while split > 0 && !scrubbed.is_char_boundary(split) {
+                split -= 1;
+            }
+            self.inner.write_all(scrubbed[..split].as_bytes())?;
+            self.pending.clear();
+            self.pending.extend_from_slice(scrubbed[split..].as_bytes());
+        }
         // Report the original length consumed — the tracing fmt layer treats a
-        // short write as an error, and the scrubbed bytes are an internal detail.
+        // short write as an error, and the withheld bytes are an internal detail.
         Ok(buf.len())
     }
 
     fn flush(&mut self) -> io::Result<()> {
+        if !self.pending.is_empty() {
+            let scrubbed = redact(&String::from_utf8_lossy(&self.pending)).into_owned();
+            self.inner.write_all(scrubbed.as_bytes())?;
+            self.pending.clear();
+        }
         self.inner.flush()
+    }
+}
+
+impl<W: Write> Drop for RedactingWriter<W> {
+    fn drop(&mut self) {
+        // Emit any withheld tail so the final bytes of a stream (e.g. a log event
+        // formatted then dropped without an explicit flush) are never lost.
+        let _ = self.flush();
     }
 }
 
@@ -125,6 +179,41 @@ mod tests {
         clear();
         register("abc"); // < MIN_REDACT_LEN
         assert_eq!(redact("abc def"), "abc def");
+    }
+
+    #[test]
+    #[serial]
+    fn redact_handles_overlapping_secrets_longest_first() {
+        clear();
+        // A shorter secret that is a prefix of a longer one. Redacting the
+        // shorter first (unordered iteration) leaves the longer secret's tail
+        // ("XYZW") exposed; longest-first redaction must mask the whole thing.
+        register("abcd");
+        register("abcdXYZW");
+        let out = redact("value=abcdXYZW end");
+        assert!(!out.contains("XYZW"), "longer secret partially leaked: {out}");
+        assert_eq!(out, "value=*** end");
+    }
+
+    #[test]
+    #[serial]
+    fn writer_scrubs_secret_split_across_writes() {
+        clear();
+        register("supersecretvalue");
+        let mut buf: Vec<u8> = Vec::new();
+        {
+            let mut w = RedactingWriter::new(&mut buf);
+            // The secret straddles two separate write() calls.
+            w.write_all(b"token=supersec").unwrap();
+            w.write_all(b"retvalue done").unwrap();
+            w.flush().unwrap();
+        }
+        let out = String::from_utf8(buf).unwrap();
+        assert!(
+            !out.contains("supersecretvalue"),
+            "secret leaked across write boundary: {out}"
+        );
+        assert_eq!(out, "token=*** done");
     }
 
     #[test]

--- a/cli/src/secrets/registry.rs
+++ b/cli/src/secrets/registry.rs
@@ -191,7 +191,10 @@ mod tests {
         register("abcd");
         register("abcdXYZW");
         let out = redact("value=abcdXYZW end");
-        assert!(!out.contains("XYZW"), "longer secret partially leaked: {out}");
+        assert!(
+            !out.contains("XYZW"),
+            "longer secret partially leaked: {out}"
+        );
         assert_eq!(out, "value=*** end");
     }
 

--- a/cli/src/secrets/registry.rs
+++ b/cli/src/secrets/registry.rs
@@ -104,9 +104,12 @@ impl<W: Write> Write for RedactingWriter<W> {
             while split > 0 && !scrubbed.is_char_boundary(split) {
                 split -= 1;
             }
-            self.inner.write_all(scrubbed[..split].as_bytes())?;
+            // Snapped to a char boundary above, so the byte split is also a char
+            // boundary — emit the prefix, retain the suffix.
+            let bytes = scrubbed.as_bytes();
+            self.inner.write_all(&bytes[..split])?;
             self.pending.clear();
-            self.pending.extend_from_slice(scrubbed[split..].as_bytes());
+            self.pending.extend_from_slice(&bytes[split..]);
         }
         // Report the original length consumed — the tracing fmt layer treats a
         // short write as an error, and the withheld bytes are an internal detail.

--- a/cli/src/serve/config.rs
+++ b/cli/src/serve/config.rs
@@ -9,12 +9,25 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 /// How `/v1/*` requests are authenticated.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub enum AuthMode {
     /// Require `Authorization: Bearer <token>`.
     Token(String),
     /// Authentication explicitly disabled via `--no-auth`.
     None,
+}
+
+// Hand-written so `{:?}` of an `AuthMode` (or the `ServeConfig` that embeds one)
+// never prints the bearer token in clear. The token is also registered for
+// redaction in `ServeConfig::from_args`, but masking here closes the Debug path
+// directly.
+impl std::fmt::Debug for AuthMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AuthMode::Token(_) => f.debug_tuple("Token").field(&"***").finish(),
+            AuthMode::None => f.write_str("None"),
+        }
+    }
 }
 
 /// Run-history storage backend selection (parsed from `--history`).
@@ -73,7 +86,12 @@ impl ServeConfig {
                         .into(),
                 ));
             }
-            (Some(t), _) => AuthMode::Token(t),
+            (Some(t), _) => {
+                // Register so the RedactingWriter scrubs the token from any
+                // tracing/log/error output for the lifetime of the process.
+                crate::secrets::registry::register(&t);
+                AuthMode::Token(t)
+            }
             (None, true) => AuthMode::None,
             (None, false) => {
                 return Err(CliError::Serve(
@@ -187,6 +205,32 @@ mod tests {
         a.auth_token = Some("hunter2".into());
         let cfg = ServeConfig::from_args(a).unwrap();
         assert!(matches!(cfg.auth, AuthMode::Token(t) if t == "hunter2"));
+    }
+
+    #[test]
+    fn auth_mode_debug_masks_token() {
+        // ServeConfig derives Debug and embeds AuthMode; a {:?} must not print
+        // the bearer token in clear.
+        let s = format!("{:?}", AuthMode::Token("supersecrettoken".into()));
+        assert!(
+            !s.contains("supersecrettoken"),
+            "serve token leaked via Debug: {s}"
+        );
+        assert!(s.contains("***"), "token not masked: {s}");
+    }
+
+    #[test]
+    fn token_is_registered_for_redaction() {
+        let mut a = base_args();
+        a.auth_token = Some("uniqueserveauthsecret987".into());
+        let _cfg = ServeConfig::from_args(a).unwrap();
+        // The token must be registered so the RedactingWriter scrubs it from logs.
+        let scrubbed =
+            crate::secrets::registry::redact("hdr=uniqueserveauthsecret987 end").into_owned();
+        assert!(
+            !scrubbed.contains("uniqueserveauthsecret987"),
+            "serve token not registered for redaction: {scrubbed}"
+        );
     }
 
     #[test]

--- a/crates/auth/src/oauth2.rs
+++ b/crates/auth/src/oauth2.rs
@@ -17,7 +17,7 @@ use tokio::time::Instant;
 
 use crate::expiry_instant;
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
 struct TokenResponse {
     access_token: String,
     #[serde(default)]
@@ -29,7 +29,7 @@ struct TokenResponse {
     token_type: Option<String>,
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 struct CachedToken {
     access_token: Option<String>,
     expires_at: Option<Instant>,
@@ -46,7 +46,6 @@ impl CachedToken {
 }
 
 /// OAuth2 `client_credentials` grant provider.
-#[derive(Debug)]
 pub struct OAuth2ClientCredentialsProvider {
     http: Client,
     token_url: String,
@@ -55,6 +54,21 @@ pub struct OAuth2ClientCredentialsProvider {
     scopes: Vec<String>,
     expiry_ratio: f64,
     state: Mutex<CachedToken>,
+}
+
+// Hand-written so `{:?}` (the trait requires `AuthProvider: Debug`, and providers
+// are shared as `Arc<dyn AuthProvider>`) never prints the `client_secret` or the
+// cached access token in `state`.
+impl std::fmt::Debug for OAuth2ClientCredentialsProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OAuth2ClientCredentialsProvider")
+            .field("token_url", &self.token_url)
+            .field("client_id", &self.client_id)
+            .field("client_secret", &"***")
+            .field("scopes", &self.scopes)
+            .field("expiry_ratio", &self.expiry_ratio)
+            .finish_non_exhaustive()
+    }
 }
 
 impl OAuth2ClientCredentialsProvider {
@@ -120,7 +134,7 @@ impl AuthProvider for OAuth2ClientCredentialsProvider {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 struct RefreshState {
     access_token: Option<String>,
     expires_at: Option<Instant>,
@@ -128,7 +142,6 @@ struct RefreshState {
 }
 
 /// OAuth2 `refresh_token` grant provider with refresh-token rotation capture.
-#[derive(Debug)]
 pub struct OAuth2RefreshProvider {
     http: Client,
     token_url: String,
@@ -136,6 +149,19 @@ pub struct OAuth2RefreshProvider {
     client_secret: String,
     expiry_ratio: f64,
     state: Mutex<RefreshState>,
+}
+
+// Hand-written so `{:?}` never prints the `client_secret` or the `refresh_token`
+// / cached access token held in `state`.
+impl std::fmt::Debug for OAuth2RefreshProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OAuth2RefreshProvider")
+            .field("token_url", &self.token_url)
+            .field("client_id", &self.client_id)
+            .field("client_secret", &"***")
+            .field("expiry_ratio", &self.expiry_ratio)
+            .finish_non_exhaustive()
+    }
 }
 
 impl OAuth2RefreshProvider {
@@ -324,6 +350,32 @@ mod tests {
         let again = provider.invalidate(&first).await.unwrap();
         assert_eq!(again, Credential::Bearer("A2".into()));
         assert_eq!(hits.load(Ordering::SeqCst), 2, "stale CAS must not refetch");
+    }
+
+    #[test]
+    fn provider_debug_does_not_leak_secrets() {
+        // `AuthProvider: Debug`, and providers are held as `Arc<dyn AuthProvider>`,
+        // so a stray `{:?}` must never print the client secret / refresh token.
+        let cc = OAuth2ClientCredentialsProvider::from_config(&serde_json::json!({
+            "token_url": "https://idp.example/token",
+            "client_id": "id",
+            "client_secret": "topsecretclient",
+        }))
+        .unwrap();
+        let s = format!("{cc:?}");
+        assert!(!s.contains("topsecretclient"), "client_secret leaked: {s}");
+        assert!(s.contains("client_id"), "non-secret fields should remain: {s}");
+
+        let rf = OAuth2RefreshProvider::from_config(&serde_json::json!({
+            "token_url": "https://idp.example/token",
+            "client_id": "id",
+            "client_secret": "topsecretclient",
+            "refresh_token": "topsecretrefresh",
+        }))
+        .unwrap();
+        let s = format!("{rf:?}");
+        assert!(!s.contains("topsecretclient"), "client_secret leaked: {s}");
+        assert!(!s.contains("topsecretrefresh"), "refresh_token leaked: {s}");
     }
 
     #[tokio::test]

--- a/crates/auth/src/oauth2.rs
+++ b/crates/auth/src/oauth2.rs
@@ -364,7 +364,10 @@ mod tests {
         .unwrap();
         let s = format!("{cc:?}");
         assert!(!s.contains("topsecretclient"), "client_secret leaked: {s}");
-        assert!(s.contains("client_id"), "non-secret fields should remain: {s}");
+        assert!(
+            s.contains("client_id"),
+            "non-secret fields should remain: {s}"
+        );
 
         let rf = OAuth2RefreshProvider::from_config(&serde_json::json!({
             "token_url": "https://idp.example/token",

--- a/crates/auth/src/static_provider.rs
+++ b/crates/auth/src/static_provider.rs
@@ -106,4 +106,13 @@ mod tests {
     fn from_config_empty_errors() {
         assert!(StaticProvider::from_config(&serde_json::json!({})).is_err());
     }
+
+    #[test]
+    fn debug_does_not_leak_token() {
+        // `StaticProvider` derives `Debug`; it must inherit `Credential`'s
+        // redacting `Debug` rather than print the pre-minted token in clear.
+        let p = StaticProvider::bearer("supersecretstatic");
+        let s = format!("{p:?}");
+        assert!(!s.contains("supersecretstatic"), "static token leaked: {s}");
+    }
 }

--- a/crates/auth/src/token_endpoint.rs
+++ b/crates/auth/src/token_endpoint.rs
@@ -230,7 +230,10 @@ mod tests {
             !s.contains("topsecretbody"),
             "request body secret leaked: {s}"
         );
-        assert!(s.contains("token_path"), "non-secret fields should remain: {s}");
+        assert!(
+            s.contains("token_path"),
+            "non-secret fields should remain: {s}"
+        );
     }
 
     #[test]

--- a/crates/auth/src/token_endpoint.rs
+++ b/crates/auth/src/token_endpoint.rs
@@ -11,7 +11,7 @@ use tokio::time::Instant;
 
 use crate::expiry_instant;
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 struct CachedToken {
     token: Option<String>,
     expires_at: Option<Instant>,
@@ -20,7 +20,6 @@ struct CachedToken {
 /// Fetches a token from an arbitrary endpoint, extracts it via `token_path`
 /// (JSONPath), and caches it with optional expiry tracking. Single-flight
 /// refresh via an internal [`Mutex`].
-#[derive(Debug)]
 pub struct TokenEndpointProvider {
     http: Client,
     url: String,
@@ -30,6 +29,20 @@ pub struct TokenEndpointProvider {
     expiry_path: Option<String>,
     expiry_ratio: f64,
     state: Mutex<CachedToken>,
+}
+
+// Hand-written so `{:?}` never prints the cached token in `state` or the request
+// `body` (which can carry a `client_secret`). `finish_non_exhaustive` omits both.
+impl std::fmt::Debug for TokenEndpointProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TokenEndpointProvider")
+            .field("url", &self.url)
+            .field("method", &self.method)
+            .field("token_path", &self.token_path)
+            .field("expiry_path", &self.expiry_path)
+            .field("expiry_ratio", &self.expiry_ratio)
+            .finish_non_exhaustive()
+    }
 }
 
 impl TokenEndpointProvider {
@@ -200,6 +213,24 @@ mod tests {
             assert_eq!(r.as_ref().unwrap(), &Credential::Bearer("tok1".into()));
         }
         assert_eq!(hits.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn provider_debug_does_not_leak_body_secrets() {
+        // The request `body` may carry a client secret; a `{:?}` of the provider
+        // (held as `Arc<dyn AuthProvider>`) must not print it.
+        let p = TokenEndpointProvider::from_config(&serde_json::json!({
+            "url": "https://idp.example/token",
+            "token_path": "$.access_token",
+            "body": { "client_secret": "topsecretbody" },
+        }))
+        .unwrap();
+        let s = format!("{p:?}");
+        assert!(
+            !s.contains("topsecretbody"),
+            "request body secret leaked: {s}"
+        );
+        assert!(s.contains("token_path"), "non-secret fields should remain: {s}");
     }
 
     #[test]

--- a/crates/core/src/auth.rs
+++ b/crates/core/src/auth.rs
@@ -30,7 +30,7 @@ use std::sync::Arc;
 /// Intentionally **not** `#[non_exhaustive]`: connectors must map every variant,
 /// so adding one should be a compile error that forces correct handling rather
 /// than a silently-ignored fallback.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub enum Credential {
     /// `Authorization: Bearer <token>`.
     Bearer(String),
@@ -51,6 +51,31 @@ pub enum Credential {
     /// A raw token for connector-specific assembly (e.g. gRPC `authorization`
     /// metadata, Snowflake's `Authorization` with a token-type header).
     Token(String),
+}
+
+// `Debug` is hand-written (not derived) so a `{:?}` of a credential — or of any
+// struct that embeds one, e.g. a logged connector config or a `StaticProvider` —
+// never prints the secret in clear. The secret-bearing fields render as `"***"`;
+// the non-secret identifiers (header name, basic-auth username) stay visible so
+// the output is still useful for diagnostics. `Credential` is a 1.0-frozen public
+// type, so this redaction is part of its contract.
+impl std::fmt::Debug for Credential {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Credential::Bearer(_) => f.debug_tuple("Bearer").field(&"***").finish(),
+            Credential::Header { name, .. } => f
+                .debug_struct("Header")
+                .field("name", name)
+                .field("value", &"***")
+                .finish(),
+            Credential::Basic { username, .. } => f
+                .debug_struct("Basic")
+                .field("username", username)
+                .field("password", &"***")
+                .finish(),
+            Credential::Token(_) => f.debug_tuple("Token").field(&"***").finish(),
+        }
+    }
 }
 
 impl Credential {
@@ -260,6 +285,49 @@ mod tests {
         fn provider_name(&self) -> &'static str {
             "fixed"
         }
+    }
+
+    #[test]
+    fn credential_debug_redacts_secrets() {
+        // Bearer / Token fully redact the secret value.
+        let b = format!("{:?}", Credential::Bearer("supersecrettoken".into()));
+        assert!(!b.contains("supersecrettoken"), "bearer token leaked: {b}");
+        assert!(b.contains("***"), "bearer token not masked: {b}");
+
+        let t = format!("{:?}", Credential::Token("tok-supersecretxyz".into()));
+        assert!(!t.contains("tok-supersecretxyz"), "raw token leaked: {t}");
+        assert!(t.contains("***"), "raw token not masked: {t}");
+
+        // Basic redacts the password but keeps the (non-secret) username.
+        let basic = format!(
+            "{:?}",
+            Credential::Basic {
+                username: "alice".into(),
+                password: "hunter2secret".into(),
+            }
+        );
+        assert!(!basic.contains("hunter2secret"), "password leaked: {basic}");
+        assert!(
+            basic.contains("alice"),
+            "username should stay visible for diagnostics: {basic}"
+        );
+
+        // Header redacts the value but keeps the (non-secret) header name.
+        let header = format!(
+            "{:?}",
+            Credential::Header {
+                name: "X-Api-Key".into(),
+                value: "secretkeyvalue".into(),
+            }
+        );
+        assert!(
+            !header.contains("secretkeyvalue"),
+            "header value leaked: {header}"
+        );
+        assert!(
+            header.contains("X-Api-Key"),
+            "header name should stay visible for diagnostics: {header}"
+        );
     }
 
     #[tokio::test]

--- a/crates/source/webhook/Cargo.toml
+++ b/crates/source/webhook/Cargo.toml
@@ -19,6 +19,7 @@ async-trait.workspace = true
 tracing.workspace = true
 tokio = { workspace = true, features = ["time", "net", "sync", "macros"] }
 axum = { workspace = true }
+subtle.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt", "time", "net", "sync"] }

--- a/crates/source/webhook/README.md
+++ b/crates/source/webhook/README.md
@@ -66,7 +66,7 @@ The server responds with `200 OK` to valid requests and `400 Bad Request` for no
 | `max_payloads` | `Option<usize>` | `None` | Stop after receiving this many payloads. `None` means collect until timeout |
 | `timeout_secs` | `u64` | `30` | How long to listen before returning, in seconds |
 | `max_body_bytes` | `usize` | `1048576` | Max accepted request body size (1 MiB). Larger POSTs are rejected with `413` so one huge request can't exhaust memory. |
-| `auth_token` | `Option<String>` | `None` | Optional shared secret. When set, requests must send it in the `Authorization` header (raw or `Bearer <token>`); others get `401`. Strongly recommended whenever `listen_addr` isn't loopback. |
+| `auth_token` | `Option<String>` | `None` | Optional shared secret. When set, requests must send it in the `Authorization` header (raw or `Bearer <token>`); others get `401`. The comparison is constant-time (no timing side-channel). Strongly recommended whenever `listen_addr` isn't loopback. |
 | `batch_size` | `usize` | `1000` | Records per emitted `StreamPage`. `0` is the "no batching" sentinel — emit the full flush window in one page. See [Streaming and batching](#streaming-and-batching) |
 
 ## Streaming and batching

--- a/crates/source/webhook/src/stream.rs
+++ b/crates/source/webhook/src/stream.rs
@@ -258,7 +258,10 @@ mod tests {
 
     #[test]
     fn token_matches_accepts_raw_and_bearer() {
-        assert!(token_matches(Some("sekret-token-value"), "sekret-token-value"));
+        assert!(token_matches(
+            Some("sekret-token-value"),
+            "sekret-token-value"
+        ));
         assert!(token_matches(
             Some("Bearer sekret-token-value"),
             "sekret-token-value"
@@ -267,14 +270,20 @@ mod tests {
 
     #[test]
     fn token_matches_rejects_wrong_and_missing() {
-        assert!(!token_matches(Some("wrong-token-value"), "sekret-token-value"));
+        assert!(!token_matches(
+            Some("wrong-token-value"),
+            "sekret-token-value"
+        ));
         assert!(!token_matches(
             Some("Bearer wrong-token-value"),
             "sekret-token-value"
         ));
         assert!(!token_matches(None, "sekret-token-value"));
         // Differing length must reject (not panic).
-        assert!(!token_matches(Some("sekret-token-valu"), "sekret-token-value"));
+        assert!(!token_matches(
+            Some("sekret-token-valu"),
+            "sekret-token-value"
+        ));
     }
 
     #[tokio::test]

--- a/crates/source/webhook/src/stream.rs
+++ b/crates/source/webhook/src/stream.rs
@@ -6,6 +6,7 @@ use axum::{Router, extract::State, http::StatusCode, routing::post};
 use faucet_core::FaucetError;
 use serde_json::Value;
 use std::sync::Arc;
+use subtle::ConstantTimeEq;
 use tokio::sync::{Mutex, Notify};
 
 /// Shared state for the webhook HTTP handler.
@@ -94,6 +95,26 @@ impl WebhookSource {
     }
 }
 
+/// Constant-time check of an `Authorization` header value against the shared
+/// secret. Accepts either the raw token or a `Bearer <token>` form, matching the
+/// original behaviour. The comparison uses [`subtle::ConstantTimeEq`] and a
+/// non-short-circuiting `|` so neither *which* form matched nor *where* the first
+/// byte differs is observable via response timing — closing a side-channel that
+/// could otherwise leak the secret byte-by-byte. (Length difference short-circuits;
+/// the secret's length is not itself sensitive.)
+fn token_matches(provided: Option<&str>, expected: &str) -> bool {
+    let Some(p) = provided else {
+        return false;
+    };
+    let exp = expected.as_bytes();
+    let raw = bool::from(p.as_bytes().ct_eq(exp));
+    let stripped = p
+        .strip_prefix("Bearer ")
+        .map(|s| bool::from(s.as_bytes().ct_eq(exp)))
+        .unwrap_or(false);
+    raw | stripped
+}
+
 /// Axum handler for incoming webhook POST requests.
 async fn webhook_handler(
     State(state): State<Arc<AppState>>,
@@ -106,9 +127,7 @@ async fn webhook_handler(
         let provided = headers
             .get(axum::http::header::AUTHORIZATION)
             .and_then(|v| v.to_str().ok());
-        let authorized = provided
-            .is_some_and(|p| p == expected || p.strip_prefix("Bearer ") == Some(expected.as_str()));
-        if !authorized {
+        if !token_matches(provided, expected) {
             return StatusCode::UNAUTHORIZED;
         }
     }
@@ -236,6 +255,27 @@ impl faucet_core::Source for WebhookSource {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn token_matches_accepts_raw_and_bearer() {
+        assert!(token_matches(Some("sekret-token-value"), "sekret-token-value"));
+        assert!(token_matches(
+            Some("Bearer sekret-token-value"),
+            "sekret-token-value"
+        ));
+    }
+
+    #[test]
+    fn token_matches_rejects_wrong_and_missing() {
+        assert!(!token_matches(Some("wrong-token-value"), "sekret-token-value"));
+        assert!(!token_matches(
+            Some("Bearer wrong-token-value"),
+            "sekret-token-value"
+        ));
+        assert!(!token_matches(None, "sekret-token-value"));
+        // Differing length must reject (not panic).
+        assert!(!token_matches(Some("sekret-token-valu"), "sekret-token-value"));
+    }
 
     #[tokio::test]
     async fn webhook_collects_payloads() {

--- a/docs/book/src/cookbook/secrets.md
+++ b/docs/book/src/cookbook/secrets.md
@@ -246,7 +246,12 @@ Every resolution path registers its result for redaction — the secrets-manager
 directives (`${vault:…}`, `${aws-sm:…}`, …) **and** the load-time
 `${env:…}` / `${secret:…}` / `${file:…}` forms. A credential supplied via the
 common `${env:TOKEN}` form is therefore scrubbed exactly like a `${vault:…}` one
-(values shorter than 4 characters are not registered).
+(values shorter than 4 characters are not registered). The `faucet serve` bearer
+auth token (`--auth-token` / `FAUCET_SERVE_AUTH_TOKEN`) is registered the same way.
+The scrubber withholds a short trailing window between writes, so a secret split
+across two separate log writes is still masked. Independently, `faucet_core::Credential`
+and the built-in auth providers hand-write their `Debug` to print secrets as `***`,
+so a `{:?}` of a credential or shared provider never reveals the token.
 
 **This boundary covers faucet's own output only.** A third-party connector that
 debug-logs its own deserialized config fields — or any library that logs a


### PR DESCRIPTION
## Summary

First of the thematic PRs resolving the **confirmed-real LOW/NIT `[R]` backlog** from the round-2 hardening audit (#146). This one bundles the **security/secrets-hygiene** group — every item was first re-verified against `HEAD` (the audit's `[R]` items were finder-reported, "confirm before patching"), then fixed test-first.

Refs #146. (Does **not** close it — the remaining LOW/NIT groups land in follow-up PRs.)

## What's fixed

| Item | Area | Fix |
|------|------|-----|
| `Credential` + auth providers derive `Debug` printing tokens/secrets in clear | `core/auth`, `faucet-auth` | Hand-write `Debug` for `Credential` (mask token / password / header value; keep the non-secret header name + basic username) and for the three HTTP providers (mask `client_secret`, omit the token-bearing `state` and request `body` via `finish_non_exhaustive`). Drop the now-unreachable `Debug` derives on internal `CachedToken`/`RefreshState`/`TokenResponse`. `StaticProvider` inherits the redaction. |
| `redact()` processed the secret `HashSet` in randomized order → a secret that is a substring of a longer one could leave the longer one's tail exposed | `cli/secrets` | Sort **longest-first** before replacing (deterministic). |
| `RedactingWriter` scrubbed each `write()` chunk independently → a secret split across two writes leaked | `cli/secrets` | Withhold a trailing window (`longest secret − 1` bytes) across writes; flush it on `flush()`/`Drop`. Catches boundary-spanning secrets while preserving streaming + the full-length write contract. |
| Webhook shared-secret comparison used plain `==` (timing side-channel) | `source-webhook` | `token_matches()` helper using `subtle::ConstantTimeEq` + a non-short-circuiting `\|` over the raw and `Bearer`-stripped forms. Behaviour unchanged. |
| `faucet serve` bearer token: `Debug`-derived `AuthMode`/`ServeConfig` could print it, and it was never registered for redaction | `serve` | Mask `AuthMode`'s `Debug`; register the token via `secrets::registry` in `from_args` so it's scrubbed from all tracing/log/error output. |

## Notes

- These are all **internal/security** changes — no user-facing config or wire-format change.
- `subtle` (BSD-3-Clause, already allowed in `deny.toml` and present transitively) is added as a direct dep of `faucet-source-webhook`.
- Docs synced: webhook README (constant-time note) + secrets cookbook (serve-token / cross-write / `Credential` `Debug` redaction).

## Testing

- Test-first (RED→GREEN) for every item; each RED confirmed to fail for the right reason first (the redact-ordering RED is order-dependent — demonstrated failing ~5/8 runs under the bug, deterministic 12/12 after the sort).
- `cargo fmt --all --check` clean.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean.
- Touched suites pass: `faucet-core` (all-features, 438), `faucet-auth` (21), `faucet-source-webhook`, `faucet-cli` (incl. `serve`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
