### PR TITLE
fix(#146): LOW/NIT backlog — core & connector correctness (retry/backoff + batch_size + connector bugs)

### DIFF
--- a/cli/src/registry.rs
+++ b/cli/src/registry.rs
@@ -112,7 +112,7 @@ pub async fn build_source(
         #[cfg(feature = "source-redis")]
         "redis" => {
             let cfg = decode::<faucet_source_redis::RedisSourceConfig>("source", "redis", config)?;
-            Ok(Box::new(faucet_source_redis::RedisSource::new(cfg)))
+            Ok(Box::new(faucet_source_redis::RedisSource::new(cfg)?))
         }
         #[cfg(feature = "source-webhook")]
         "webhook" => {
@@ -145,7 +145,7 @@ pub async fn build_source(
                 "elasticsearch",
                 config,
             )?;
-            let mut s = faucet_source_elasticsearch::ElasticsearchSource::new(cfg);
+            let mut s = faucet_source_elasticsearch::ElasticsearchSource::new(cfg)?;
             if let Some(name) = &auth_ref {
                 s = s.with_auth_provider(auth_catalog::resolve(auth, name)?);
             }
@@ -185,7 +185,7 @@ pub async fn build_source(
                 "snowflake",
                 config,
             )?;
-            let mut s = faucet_source_snowflake::SnowflakeSource::new(cfg);
+            let mut s = faucet_source_snowflake::SnowflakeSource::new(cfg)?;
             if let Some(name) = &auth_ref {
                 s = s.with_auth_provider(auth_catalog::resolve(auth, name)?);
             }

--- a/crates/core/src/retry.rs
+++ b/crates/core/src/retry.rs
@@ -164,7 +164,10 @@ mod tests {
         let d = backoff_with_jitter(Duration::from_secs(1), 60);
         assert!(d < Duration::from_secs(90), "backoff not capped: {d:?}");
         // …and never collapses to zero for a non-zero base.
-        assert!(d >= Duration::from_secs(30), "backoff unexpectedly tiny: {d:?}");
+        assert!(
+            d >= Duration::from_secs(30),
+            "backoff unexpectedly tiny: {d:?}"
+        );
     }
 
     #[test]
@@ -179,7 +182,10 @@ mod tests {
         assert_ne!(b, c);
         assert_ne!(a, c);
         for v in [a, b, c] {
-            assert!(v < 1_000_000_000, "decorrelate out of jitter_factor range: {v}");
+            assert!(
+                v < 1_000_000_000,
+                "decorrelate out of jitter_factor range: {v}"
+            );
         }
     }
 

--- a/crates/core/src/retry.rs
+++ b/crates/core/src/retry.rs
@@ -49,8 +49,8 @@ where
     }
 }
 
-/// `base * 2^attempt`, capped at [`MAX_BACKOFF`], scaled by a random factor in
-/// `[0.5, 1.5)` to avoid a thundering herd.
+/// `base * 2^attempt`, capped at `MAX_BACKOFF` (60s), scaled by a random factor
+/// in `[0.5, 1.5)` to avoid a thundering herd.
 ///
 /// Public so a connector with a bespoke retry loop (e.g. one that also honours
 /// `Retry-After`, like the REST source) reuses this one tested, capped,

--- a/crates/core/src/retry.rs
+++ b/crates/core/src/retry.rs
@@ -8,7 +8,14 @@
 
 use crate::error::FaucetError;
 use std::future::Future;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
+
+/// Hard cap on a single backoff sleep (before jitter). Bounds the exponential so
+/// a large `max_retries`/`attempt` can't produce multi-hour — or, once
+/// `2^attempt` saturates, effectively unbounded — sleeps. The jitter factor
+/// (`< 1.5`) keeps the realised sleep under ~1.5× this.
+const MAX_BACKOFF: Duration = Duration::from_secs(60);
 
 /// Execute `operation` with up to `max_retries` retries on
 /// [retriable](FaucetError::is_retriable) errors, using exponential backoff
@@ -42,22 +49,46 @@ where
     }
 }
 
-/// `base * 2^attempt` scaled by a random factor in `[0.5, 1.5)` to avoid a
-/// thundering herd.
-fn backoff_with_jitter(base: Duration, attempt: u32) -> Duration {
-    let exp = base.saturating_mul(2u32.saturating_pow(attempt));
+/// `base * 2^attempt`, capped at [`MAX_BACKOFF`], scaled by a random factor in
+/// `[0.5, 1.5)` to avoid a thundering herd.
+///
+/// Public so a connector with a bespoke retry loop (e.g. one that also honours
+/// `Retry-After`, like the REST source) reuses this one tested, capped,
+/// decorrelated backoff instead of re-implementing jitter — which is exactly
+/// how the range-bias / no-cap bugs crept into a copy.
+pub fn backoff_with_jitter(base: Duration, attempt: u32) -> Duration {
+    let exp = base
+        .saturating_mul(2u32.saturating_pow(attempt))
+        .min(MAX_BACKOFF);
     let nanos = exp.as_nanos() as u64;
     Duration::from_nanos((nanos as f64 * pseudo_random_factor()) as u64)
 }
 
-/// Cheap, non-cryptographic random factor in `[0.5, 1.5)` from the clock's
-/// sub-second component.
+/// Cheap, non-cryptographic random factor in `[0.5, 1.5)`.
 fn pseudo_random_factor() -> f64 {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
     let nanos = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .subsec_nanos();
-    jitter_factor(nanos)
+    let counter = COUNTER.fetch_add(1, Ordering::Relaxed);
+    jitter_factor(decorrelate(nanos, counter))
+}
+
+/// Mix the clock's sub-second component with a monotonic per-call counter so two
+/// retries firing in the *same* nanosecond (across tasks/connectors sharing the
+/// process) still draw different jitter — otherwise concurrent retries align and
+/// re-create the very thundering herd the jitter exists to break. Returns a
+/// value in `[0, 1_000_000_000)` for [`jitter_factor`]. splitmix64 finaliser:
+/// fast, non-cryptographic, well-distributed.
+fn decorrelate(nanos: u32, counter: u64) -> u32 {
+    let mut x = (nanos as u64) ^ counter.wrapping_mul(0x9E37_79B9_7F4A_7C15);
+    x ^= x >> 30;
+    x = x.wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    x ^= x >> 27;
+    x = x.wrapping_mul(0x94D0_49BB_1331_11EB);
+    x ^= x >> 31;
+    (x % 1_000_000_000) as u32
 }
 
 /// Map a sub-second nanosecond count (`[0, 1_000_000_000)`) to a jitter factor
@@ -123,6 +154,33 @@ mod tests {
             (1.4..1.5).contains(&hi),
             "factor at max sub-second nanos was {hi}, expected ~1.5"
         );
+    }
+
+    #[test]
+    fn backoff_is_capped_for_large_attempt() {
+        // Without a cap, `base * 2^attempt` saturates and the sleep becomes
+        // effectively unbounded (multi-century). It must stay under
+        // MAX_BACKOFF * max-jitter (<1.5) → < 90s for a 60s cap.
+        let d = backoff_with_jitter(Duration::from_secs(1), 60);
+        assert!(d < Duration::from_secs(90), "backoff not capped: {d:?}");
+        // …and never collapses to zero for a non-zero base.
+        assert!(d >= Duration::from_secs(30), "backoff unexpectedly tiny: {d:?}");
+    }
+
+    #[test]
+    fn decorrelate_diverges_for_same_nanos_concurrent_calls() {
+        // Two retries observing the *same* clock nanosecond but different
+        // per-call counters must draw different jitter, or concurrent retries
+        // re-align into the thundering herd the jitter exists to break.
+        let a = decorrelate(123_456_789, 0);
+        let b = decorrelate(123_456_789, 1);
+        let c = decorrelate(123_456_789, 2);
+        assert_ne!(a, b);
+        assert_ne!(b, c);
+        assert_ne!(a, c);
+        for v in [a, b, c] {
+            assert!(v < 1_000_000_000, "decorrelate out of jitter_factor range: {v}");
+        }
     }
 
     #[tokio::test]

--- a/crates/sink/mongodb/src/sink.rs
+++ b/crates/sink/mongodb/src/sink.rs
@@ -19,6 +19,7 @@ pub struct MongoSink {
 impl MongoSink {
     /// Create a new MongoDB sink, establishing the client connection.
     pub async fn new(config: MongoSinkConfig) -> Result<Self, FaucetError> {
+        faucet_core::validate_batch_size(config.batch_size)?;
         let client = Client::with_uri_str(&config.connection_uri)
             .await
             .map_err(|e| FaucetError::Config(format!("MongoDB connection failed: {e}")))?;
@@ -176,5 +177,17 @@ mod tests {
         let val = Value::Null;
         let result = MongoSink::value_to_document(&val);
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn new_rejects_out_of_range_batch_size() {
+        let mut config = MongoSinkConfig::new("mongodb://localhost:27017", "db", "c");
+        config.batch_size = faucet_core::MAX_BATCH_SIZE + 1;
+        match MongoSink::new(config).await {
+            Err(faucet_core::FaucetError::Config(m)) => {
+                assert!(m.contains("batch_size"), "got: {m}")
+            }
+            _ => panic!("expected a batch_size Config error"),
+        }
     }
 }

--- a/crates/sink/mssql/src/encode.rs
+++ b/crates/sink/mssql/src/encode.rs
@@ -23,7 +23,13 @@ impl BoundParam {
         match v {
             Value::String(s) => BoundParam::Str(s.clone()),
             Value::Number(n) if n.is_i64() => BoundParam::I64(n.as_i64().unwrap()),
-            Value::Number(n) if n.is_u64() => BoundParam::I64(n.as_u64().unwrap() as i64),
+            Value::Number(n) if n.is_u64() => match i64::try_from(n.as_u64().unwrap()) {
+                Ok(i) => BoundParam::I64(i),
+                // A u64 above i64::MAX would wrap to a negative i64; bind it as a
+                // string so MSSQL coerces to NUMERIC/DECIMAL instead of corrupting
+                // the value.
+                Err(_) => BoundParam::Str(n.as_u64().unwrap().to_string()),
+            },
             Value::Number(n) => BoundParam::F64(n.as_f64().unwrap_or(0.0)),
             Value::Bool(b) => BoundParam::Bool(*b),
             Value::Null => BoundParam::Null(None),
@@ -274,5 +280,21 @@ mod tests {
             BoundParam::from_value(&json!({"k":1})),
             BoundParam::Str(_)
         ));
+    }
+
+    #[test]
+    fn u64_above_i64_max_binds_as_string_not_wrapped() {
+        // A u64 that fits in i64 still binds as I64.
+        match BoundParam::from_value(&json!(i64::MAX as u64)) {
+            BoundParam::I64(v) => assert_eq!(v, i64::MAX),
+            _ => panic!("expected I64 for an in-range u64"),
+        }
+        // A u64 above i64::MAX must NOT wrap to a negative I64 — bind as a string
+        // so MSSQL coerces to NUMERIC/DECIMAL rather than corrupting the value.
+        match BoundParam::from_value(&json!(u64::MAX)) {
+            BoundParam::Str(s) => assert_eq!(s, "18446744073709551615"),
+            BoundParam::I64(v) => panic!("u64::MAX wrapped to negative I64({v})"),
+            _ => panic!("expected Str for u64 > i64::MAX"),
+        }
     }
 }

--- a/crates/sink/mssql/src/sink.rs
+++ b/crates/sink/mssql/src/sink.rs
@@ -11,9 +11,7 @@ use faucet_core::{FaucetError, RowOutcome, Sink};
 use serde_json::Value;
 use tiberius::ToSql;
 
-use faucet_mssql_common::{
-    MssqlPool, MssqlPooledConnection, build_pool, quote_ident_mssql, with_statement_timeout,
-};
+use faucet_mssql_common::{MssqlPool, MssqlPooledConnection, build_pool, quote_ident_mssql};
 
 use crate::config::{MssqlColumnMapping, MssqlSinkConfig};
 use crate::encode::{
@@ -140,11 +138,15 @@ impl MssqlSink {
                 let rows: Vec<Vec<BoundParam>> = chunk
                     .iter()
                     .map(|r| {
-                        vec![BoundParam::Str(
-                            serde_json::to_string(r).unwrap_or_default(),
-                        )]
+                        serde_json::to_string(r)
+                            .map(|s| vec![BoundParam::Str(s)])
+                            .map_err(|e| {
+                                FaucetError::Sink(format!(
+                                    "MSSQL json_column: failed to serialize record to JSON: {e}"
+                                ))
+                            })
                     })
-                    .collect();
+                    .collect::<Result<_, _>>()?;
                 Ok(Some((cols, rows)))
             }
             MssqlColumnMapping::AutoColumns { on_unknown_field } => {
@@ -200,17 +202,21 @@ impl MssqlSink {
                     .map(|_| ())
                     .map_err(|e| FaucetError::Sink(format!("MSSQL insert failed: {e}")))
             };
-            let result = match self.timeout() {
-                Some(t) => {
-                    with_statement_timeout(t, exec, || {
-                        FaucetError::Sink("MSSQL insert timed out".into())
-                    })
-                    .await
-                }
-                None => exec.await,
+            // Track whether the failure was a *timeout* specifically. On timeout
+            // the `exec` future is dropped mid-TDS, leaving an unread response on
+            // the wire — the connection is desynced and must NOT be reused (the
+            // pool helper's contract is "drop it"). Issuing ROLLBACK on it would
+            // run on a corrupt stream. A *normal* error leaves the connection in
+            // sync, so ROLLBACK is safe and releases the transaction promptly.
+            let (result, timed_out) = match self.timeout() {
+                Some(t) => match tokio::time::timeout(t, exec).await {
+                    Ok(inner) => (inner, false),
+                    Err(_) => (Err(FaucetError::Sink("MSSQL insert timed out".into())), true),
+                },
+                None => (exec.await, false),
             };
             if let Err(e) = result {
-                if txn {
+                if txn && !timed_out {
                     let _ = control(conn, "ROLLBACK TRAN").await;
                 }
                 return Err(e);

--- a/crates/sink/mssql/src/sink.rs
+++ b/crates/sink/mssql/src/sink.rs
@@ -211,7 +211,10 @@ impl MssqlSink {
             let (result, timed_out) = match self.timeout() {
                 Some(t) => match tokio::time::timeout(t, exec).await {
                     Ok(inner) => (inner, false),
-                    Err(_) => (Err(FaucetError::Sink("MSSQL insert timed out".into())), true),
+                    Err(_) => (
+                        Err(FaucetError::Sink("MSSQL insert timed out".into())),
+                        true,
+                    ),
                 },
                 None => (exec.await, false),
             };

--- a/crates/sink/redis/src/sink.rs
+++ b/crates/sink/redis/src/sink.rs
@@ -211,10 +211,8 @@ mod tests {
 
     #[tokio::test]
     async fn new_rejects_out_of_range_batch_size() {
-        let mut config = RedisSinkConfig::new(
-            "redis://localhost",
-            RedisSinkType::List { key: "k".into() },
-        );
+        let mut config =
+            RedisSinkConfig::new("redis://localhost", RedisSinkType::List { key: "k".into() });
         config.batch_size = faucet_core::MAX_BATCH_SIZE + 1;
         match RedisSink::new(config).await {
             Err(faucet_core::FaucetError::Config(m)) => {

--- a/crates/sink/redis/src/sink.rs
+++ b/crates/sink/redis/src/sink.rs
@@ -19,6 +19,7 @@ impl RedisSink {
     ///
     /// This opens a multiplexed async connection to Redis immediately.
     pub async fn new(config: RedisSinkConfig) -> Result<Self, FaucetError> {
+        faucet_core::validate_batch_size(config.batch_size)?;
         let client = redis::Client::open(config.url.as_str())
             .map_err(|e| FaucetError::Config(format!("invalid Redis URL: {e}")))?;
 
@@ -206,5 +207,20 @@ mod tests {
         assert_eq!(fields.len(), 1);
         assert_eq!(fields[0].0, "data");
         assert_eq!(fields[0].1, r#"{"nested":true}"#);
+    }
+
+    #[tokio::test]
+    async fn new_rejects_out_of_range_batch_size() {
+        let mut config = RedisSinkConfig::new(
+            "redis://localhost",
+            RedisSinkType::List { key: "k".into() },
+        );
+        config.batch_size = faucet_core::MAX_BATCH_SIZE + 1;
+        match RedisSink::new(config).await {
+            Err(faucet_core::FaucetError::Config(m)) => {
+                assert!(m.contains("batch_size"), "got: {m}")
+            }
+            _ => panic!("expected a batch_size Config error"),
+        }
     }
 }

--- a/crates/sink/s3/src/sink.rs
+++ b/crates/sink/s3/src/sink.rs
@@ -18,6 +18,7 @@ impl S3Sink {
     ///
     /// Builds the S3 client eagerly so it is reused across calls.
     pub async fn new(config: S3SinkConfig) -> Result<Self, FaucetError> {
+        faucet_core::validate_batch_size(config.batch_size)?;
         let client = Self::build_client(&config).await?;
         Ok(Self { config, client })
     }
@@ -222,6 +223,18 @@ mod tests {
         assert!(key.ends_with(".jsonl"));
         // No prefix means key starts with UUID
         assert!(!key.starts_with('/'));
+    }
+
+    #[tokio::test]
+    async fn new_rejects_out_of_range_batch_size() {
+        let mut config = S3SinkConfig::new("bucket");
+        config.batch_size = faucet_core::MAX_BATCH_SIZE + 1;
+        match S3Sink::new(config).await {
+            Err(faucet_core::FaucetError::Config(m)) => {
+                assert!(m.contains("batch_size"), "got: {m}")
+            }
+            _ => panic!("expected a batch_size Config error"),
+        }
     }
 
     #[cfg(feature = "compression")]

--- a/crates/sink/snowflake/src/sink.rs
+++ b/crates/sink/snowflake/src/sink.rs
@@ -184,7 +184,7 @@ impl SnowflakeSink {
                     "Snowflake returned HTTP 202 without a statementHandle to poll".into(),
                 )
             })?;
-            return self.poll_until_complete(&handle, &auth, token_type).await;
+            return self.poll_until_complete(&handle).await;
         }
 
         check_statement_code(&sf_resp)
@@ -192,20 +192,21 @@ impl SnowflakeSink {
 
     /// Poll `GET /api/v2/statements/{handle}` until the statement finishes
     /// executing (HTTP 200 + code `090001`), bounded by `poll_timeout`.
-    async fn poll_until_complete(
-        &self,
-        handle: &str,
-        auth: &str,
-        token_type: &'static str,
-    ) -> Result<(), FaucetError> {
+    async fn poll_until_complete(&self, handle: &str) -> Result<(), FaucetError> {
         let url = format!("{}/{}", self.api_url(), handle);
         let poll_timeout = self.config.poll_timeout;
         let started = std::time::Instant::now();
         loop {
+            // Re-resolve auth every iteration: a long-running async statement can
+            // outlive a short-lived OAuth token, so we re-ask the (single-flight,
+            // cached) provider for a current token rather than reusing the one
+            // minted at submit time — otherwise the poll 401s mid-run after a
+            // rotation (#146).
+            let (auth, token_type) = self.auth_header().await?;
             let resp = self
                 .client
                 .get(&url)
-                .header("Authorization", auth)
+                .header("Authorization", &auth)
                 .header("Accept", "application/json")
                 .header("X-Snowflake-Authorization-Token-Type", token_type)
                 .send()

--- a/crates/sink/sqlite/README.md
+++ b/crates/sink/sqlite/README.md
@@ -55,7 +55,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 | `table_name` | `String` | *(required)* | Target table name |
 | `column_mapping` | `SqliteColumnMapping` | `Json { column: "data" }` | How to map JSON records to table columns (see below) |
 | `batch_size` | `usize` | `1000` | Maximum number of rows per multi-row INSERT. See [Streaming and batching](#streaming-and-batching) below |
-| `max_connections` | `u32` | `5` | Maximum number of connections in the connection pool |
+| `max_connections` | `u32` | `1` | Maximum number of connections in the connection pool. SQLite serializes writers at the file level, so one writer is the safe default — a multi-connection pool against a single file races for the write lock and risks `SQLITE_BUSY`. The pool opens connections in WAL mode with a 5s `busy_timeout`, so raising this lets extra connections read concurrently with the single writer. |
 
 ### Streaming and batching
 
@@ -247,7 +247,7 @@ let sink = SqliteSink::new(config).await?;
 
 ## How It Works
 
-- A connection pool is created in `SqliteSink::new()` using `sqlx::SqlitePool` with the configured `max_connections`.
+- A connection pool is created in `SqliteSink::new()` using `sqlx::SqlitePool` with the configured `max_connections` (default `1`). Each connection is opened in WAL journal mode (`journal_mode = WAL`) with a 5-second `busy_timeout` and `create_if_missing`, so a writer and readers can proceed concurrently and lock contention waits-and-retries instead of failing immediately with `SQLITE_BUSY`. WAL on a `sqlite::memory:` database is a harmless no-op.
 - `write_batch()` slices the input into `batch_size`-row chunks (or forwards the whole slice when `batch_size = 0`). Each chunk is inserted using a single multi-row INSERT statement wrapped in a `BEGIN`/`COMMIT` transaction for write performance.
 - In JSON mode, each record is serialized to a JSON string and inserted as `INSERT INTO t (col) VALUES (?), (?), ...`.
 - In AutoMap mode, column names are discovered using `PRAGMA table_info(table_name)`. A multi-row INSERT is built dynamically. Column values are bound as **native SQLite types** — strings as `TEXT`, JSON numbers as `INTEGER`/`REAL`, booleans as `INTEGER` 0/1 — so column affinity and typed reads round-trip correctly. Arrays and objects (which have no scalar SQL representation) are bound as their JSON text. The INSERT column set is the **union** of record keys across the batch (in table order), so a field present only in a later record is still written; a row missing a column binds SQL `NULL`.

--- a/crates/sink/sqlite/src/config.rs
+++ b/crates/sink/sqlite/src/config.rs
@@ -48,12 +48,25 @@ pub struct SqliteSinkConfig {
     /// preserved exactly, no internal re-chunking is performed.
     #[serde(default = "default_batch_size")]
     pub batch_size: usize,
-    /// Maximum number of connections in the pool. Defaults to 5.
+    /// Maximum number of connections in the pool. Defaults to `1`.
+    ///
+    /// SQLite serializes writers at the file level, so a single SQLite file
+    /// can only ever have one writer at a time. A multi-connection pool against
+    /// one file therefore races for the write lock and risks `SQLITE_BUSY`
+    /// errors under concurrency; one writer is the safe default. Raise this only
+    /// if your workload is read-heavy against a WAL database (the sink opens the
+    /// pool in WAL mode with a `busy_timeout`, so extra connections can still
+    /// read concurrently with the single writer).
+    #[serde(default = "default_max_connections")]
     pub max_connections: u32,
 }
 
 fn default_batch_size() -> usize {
     DEFAULT_BATCH_SIZE
+}
+
+fn default_max_connections() -> u32 {
+    1
 }
 
 impl SqliteSinkConfig {
@@ -64,7 +77,7 @@ impl SqliteSinkConfig {
             table_name: table_name.into(),
             column_mapping: SqliteColumnMapping::default(),
             batch_size: DEFAULT_BATCH_SIZE,
-            max_connections: 5,
+            max_connections: default_max_connections(),
         }
     }
 
@@ -104,6 +117,26 @@ mod tests {
             config.column_mapping,
             SqliteColumnMapping::Json { ref column } if column == "data"
         ));
+    }
+
+    #[test]
+    fn default_max_connections_is_one() {
+        // SQLite serializes writers at the file level, so a single-writer pool
+        // is the safe default — a multi-connection pool against one SQLite file
+        // races for the write lock and risks SQLITE_BUSY (audit #146 LOW).
+        let config = SqliteSinkConfig::new("sqlite::memory:", "events");
+        assert_eq!(config.max_connections, 1);
+    }
+
+    #[test]
+    fn default_max_connections_deserializes_to_one_when_absent() {
+        let json = r#"{
+            "database_url": "sqlite::memory:",
+            "table_name": "events",
+            "column_mapping": {"json": {"column": "data"}}
+        }"#;
+        let config: SqliteSinkConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.max_connections, 1);
     }
 
     #[test]

--- a/crates/sink/sqlite/src/sink.rs
+++ b/crates/sink/sqlite/src/sink.rs
@@ -5,8 +5,10 @@ use async_trait::async_trait;
 use faucet_core::FaucetError;
 use faucet_core::util::quote_ident;
 use serde_json::Value;
-use sqlx::sqlite::SqlitePoolOptions;
+use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions};
 use sqlx::{Row, SqlitePool};
+use std::str::FromStr;
+use std::time::Duration;
 
 /// A sink that writes JSON records to a SQLite table.
 pub struct SqliteSink {
@@ -16,10 +18,24 @@ pub struct SqliteSink {
 
 impl SqliteSink {
     /// Create a new SQLite sink. Establishes a connection pool.
+    ///
+    /// The pool opens each connection with `journal_mode = WAL` and a 5-second
+    /// `busy_timeout`. WAL lets a writer and readers proceed concurrently
+    /// instead of locking each other out, and the busy timeout makes a
+    /// connection wait-and-retry for the write lock rather than failing
+    /// immediately with `SQLITE_BUSY` under contention. `create_if_missing`
+    /// preserves the previous behaviour of creating the database file on first
+    /// open. WAL on a `sqlite::memory:` database is a harmless no-op.
     pub async fn new(config: SqliteSinkConfig) -> Result<Self, FaucetError> {
+        let options = SqliteConnectOptions::from_str(&config.database_url)
+            .map_err(|e| FaucetError::Sink(format!("invalid SQLite database_url: {e}")))?
+            .create_if_missing(true)
+            .journal_mode(SqliteJournalMode::Wal)
+            .busy_timeout(Duration::from_secs(5));
+
         let pool = SqlitePoolOptions::new()
             .max_connections(config.max_connections)
-            .connect(&config.database_url)
+            .connect_with(options)
             .await
             .map_err(|e| FaucetError::Sink(format!("SQLite connection failed: {e}")))?;
 

--- a/crates/sink/sqlite/tests/batching.rs
+++ b/crates/sink/sqlite/tests/batching.rs
@@ -356,3 +356,104 @@ async fn batch_size_atomicity_per_chunk_preserved() {
     sink.write_batch(&second).await.unwrap();
     assert_eq!(count_rows(&url, "events").await, 1_100);
 }
+
+#[tokio::test]
+async fn wal_pool_writes_correctly_with_concurrent_reader() {
+    // Audit #146 LOW: the sink now opens its pool with journal_mode = WAL and a
+    // busy_timeout so a concurrent reader (or competing writer) doesn't trip an
+    // immediate SQLITE_BUSY. This test proves the WAL pool still writes
+    // correctly across two batches AND that a separate reader connection can
+    // observe committed rows while the sink holds its own pool open.
+    //
+    // Use a plain file path (no `?mode=rwc`) — the sink must create the file
+    // itself, exercising the real `SqliteConnectOptions::create_if_missing`
+    // path used in production.
+    let dir = TempDir::new().expect("tempdir");
+    let path = dir.path().join("wal.db");
+    let url = format!("sqlite://{}", path.display());
+
+    // The sink creates the file + table for us via its own pool.
+    {
+        let setup = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(&format!("{url}?mode=rwc"))
+            .await
+            .expect("setup connect");
+        sqlx::query("CREATE TABLE events (data TEXT NOT NULL)")
+            .execute(&setup)
+            .await
+            .expect("create table");
+        setup.close().await;
+    }
+
+    let config = SqliteSinkConfig::new(&url, "events")
+        .column_mapping(SqliteColumnMapping::Json {
+            column: "data".into(),
+        })
+        .with_batch_size(500);
+    let sink = SqliteSink::new(config).await.unwrap();
+
+    // Open a long-lived read-only reader concurrently with the sink's pool.
+    let reader = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect(&url)
+        .await
+        .expect("reader connect");
+
+    // First batch.
+    let first: Vec<Value> = (0..900).map(|i| json!({"i": i})).collect();
+    let n1 = sink.write_batch(&first).await.unwrap();
+    assert_eq!(n1, 900);
+
+    let n: i64 = sqlx::query("SELECT COUNT(*) AS n FROM events")
+        .fetch_one(&reader)
+        .await
+        .expect("reader sees first batch")
+        .get("n");
+    assert_eq!(n, 900, "concurrent reader must observe the committed batch");
+
+    // Second batch — writer keeps working while the reader connection is open.
+    let second: Vec<Value> = (0..600).map(|i| json!({"i": i + 10_000})).collect();
+    let n2 = sink.write_batch(&second).await.unwrap();
+    assert_eq!(n2, 600);
+
+    let n: i64 = sqlx::query("SELECT COUNT(*) AS n FROM events")
+        .fetch_one(&reader)
+        .await
+        .expect("reader sees both batches")
+        .get("n");
+    assert_eq!(n, 1_500);
+
+    // Confirm the sink's connection actually negotiated WAL journal mode.
+    let mode: String = sqlx::query("PRAGMA journal_mode")
+        .fetch_one(&reader)
+        .await
+        .expect("journal_mode")
+        .get(0);
+    assert_eq!(
+        mode.to_lowercase(),
+        "wal",
+        "the on-disk database must be in WAL mode"
+    );
+
+    reader.close().await;
+}
+
+#[tokio::test]
+async fn memory_url_still_writes_correctly() {
+    // The pool-options change must keep `sqlite::memory:` working — WAL on a
+    // memory DB is a no-op but must not error. Round-trip a batch through an
+    // in-memory sink (the table is created on the same single connection so it
+    // is visible to subsequent writes).
+    let config = SqliteSinkConfig::new("sqlite::memory:", "events").column_mapping(
+        SqliteColumnMapping::Json {
+            column: "data".into(),
+        },
+    );
+    let sink = SqliteSink::new(config).await.unwrap();
+
+    // A memory DB started empty — create the table via the sink's own pool so
+    // it lives on the same connection the writes use (max_connections = 1).
+    let n = sink.write_batch(&[]).await.unwrap();
+    assert_eq!(n, 0, "empty write is a no-op even on a memory DB");
+}

--- a/crates/source/bigquery/src/stream.rs
+++ b/crates/source/bigquery/src/stream.rs
@@ -41,6 +41,7 @@ impl BigQuerySource {
     /// for an OAuth token. Returns [`FaucetError::Auth`] on credential
     /// failures.
     pub async fn new(config: BigQuerySourceConfig) -> Result<Self, FaucetError> {
+        faucet_core::validate_batch_size(config.batch_size)?;
         let client = build_client(&config.auth).await?;
         Ok(Self { config, client })
     }
@@ -474,6 +475,22 @@ mod tests {
         assert!(req.use_legacy_sql);
         assert_eq!(req.location.as_deref(), Some("EU"));
         assert_eq!(req.max_results, Some(250));
+    }
+
+    #[tokio::test]
+    async fn new_rejects_out_of_range_batch_size() {
+        let mut config = BigQuerySourceConfig::new(
+            "my-project",
+            BigQueryCredentials::ApplicationDefault,
+            "SELECT id FROM events",
+        );
+        config.batch_size = faucet_core::MAX_BATCH_SIZE + 1;
+        match BigQuerySource::new(config).await {
+            Err(faucet_core::FaucetError::Config(m)) => {
+                assert!(m.contains("batch_size"), "got: {m}")
+            }
+            _ => panic!("expected a batch_size Config error"),
+        }
     }
 
     #[test]

--- a/crates/source/elasticsearch/src/stream.rs
+++ b/crates/source/elasticsearch/src/stream.rs
@@ -25,12 +25,15 @@ pub struct ElasticsearchSource {
 
 impl ElasticsearchSource {
     /// Create a new Elasticsearch source from the given configuration.
-    pub fn new(config: ElasticsearchSourceConfig) -> Self {
-        Self {
+    /// Construction does no I/O; it fails only on an invalid config (an
+    /// out-of-range `batch_size`).
+    pub fn new(config: ElasticsearchSourceConfig) -> Result<Self, FaucetError> {
+        faucet_core::validate_batch_size(config.batch_size)?;
+        Ok(Self {
             config,
             client: Client::new(),
             auth_provider: None,
-        }
+        })
     }
 
     /// Attach a shared [`AuthProvider`](faucet_core::AuthProvider). When set,
@@ -483,5 +486,20 @@ fn apply_auth_to(
         ElasticsearchAuth::Basic { username, password } => req.basic_auth(username, Some(password)),
         ElasticsearchAuth::Bearer { token } => req.bearer_auth(token),
         ElasticsearchAuth::ApiKey { key } => req.header("Authorization", format!("ApiKey {key}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_rejects_out_of_range_batch_size() {
+        let mut config = ElasticsearchSourceConfig::new("http://localhost:9200", "idx");
+        config.batch_size = faucet_core::MAX_BATCH_SIZE + 1;
+        match ElasticsearchSource::new(config) {
+            Err(FaucetError::Config(m)) => assert!(m.contains("batch_size"), "got: {m}"),
+            _ => panic!("expected a batch_size Config error"),
+        }
     }
 }

--- a/crates/source/elasticsearch/tests/shared_auth_test.rs
+++ b/crates/source/elasticsearch/tests/shared_auth_test.rs
@@ -83,6 +83,7 @@ async fn injected_provider_supplies_bearer_token() {
     let source = ElasticsearchSource::new(
         ElasticsearchSourceConfig::new(server.uri(), "my_index").with_batch_size(10),
     )
+    .unwrap()
     .with_auth_provider(provider);
 
     let records = source.fetch_all().await.unwrap();
@@ -99,7 +100,7 @@ async fn unresolved_auth_reference_errors() {
     config.auth = AuthSpec::Reference(AuthReference {
         name: "missing-provider".into(),
     });
-    let source = ElasticsearchSource::new(config);
+    let source = ElasticsearchSource::new(config).unwrap();
 
     let err = source.fetch_all().await.unwrap_err();
     assert!(

--- a/crates/source/elasticsearch/tests/streaming.rs
+++ b/crates/source/elasticsearch/tests/streaming.rs
@@ -154,7 +154,7 @@ async fn stream_pages_chunks_via_scroll() {
     mount_paged_responder(&server, PagedResponder::new(pages)).await;
 
     let config = ElasticsearchSourceConfig::new(server.uri(), "test").with_batch_size(1000);
-    let source = ElasticsearchSource::new(config);
+    let source = ElasticsearchSource::new(config).unwrap();
 
     let ctx: HashMap<String, Value> = HashMap::new();
     let mut pages = source.stream_pages(&ctx, 1000);
@@ -197,7 +197,7 @@ async fn stream_pages_partial_final_page() {
     mount_paged_responder(&server, PagedResponder::new(pages)).await;
 
     let config = ElasticsearchSourceConfig::new(server.uri(), "test").with_batch_size(1000);
-    let source = ElasticsearchSource::new(config);
+    let source = ElasticsearchSource::new(config).unwrap();
 
     let ctx: HashMap<String, Value> = HashMap::new();
     let mut pages = source.stream_pages(&ctx, 1000);
@@ -257,7 +257,7 @@ async fn stream_pages_batch_size_zero_uses_single_search_no_scroll() {
         .await;
 
     let config = ElasticsearchSourceConfig::new(server.uri(), "test").with_batch_size(0);
-    let source = ElasticsearchSource::new(config);
+    let source = ElasticsearchSource::new(config).unwrap();
 
     let ctx: HashMap<String, Value> = HashMap::new();
     let mut pages = source.stream_pages(&ctx, 0);
@@ -317,7 +317,7 @@ async fn fetch_all_with_batch_size_zero_returns_all_records() {
         .await;
 
     let config = ElasticsearchSourceConfig::new(server.uri(), "test").with_batch_size(0);
-    let source = ElasticsearchSource::new(config);
+    let source = ElasticsearchSource::new(config).unwrap();
     let records = source.fetch_all().await.unwrap();
     assert_eq!(records.len(), 3, "batch_size=0 must not send size=0");
 }
@@ -330,7 +330,7 @@ async fn stream_pages_empty_result_yields_no_pages() {
 
     let config =
         ElasticsearchSourceConfig::new(server.uri(), "test").with_batch_size(DEFAULT_BATCH_SIZE);
-    let source = ElasticsearchSource::new(config);
+    let source = ElasticsearchSource::new(config).unwrap();
 
     let ctx: HashMap<String, Value> = HashMap::new();
     let mut pages = source.stream_pages(&ctx, DEFAULT_BATCH_SIZE);
@@ -361,7 +361,7 @@ async fn stream_pages_preserves_doc_contents() {
     mount_paged_responder(&server, PagedResponder::new(pages)).await;
 
     let config = ElasticsearchSourceConfig::new(server.uri(), "test").with_batch_size(2);
-    let source = ElasticsearchSource::new(config);
+    let source = ElasticsearchSource::new(config).unwrap();
 
     let ctx: HashMap<String, Value> = HashMap::new();
     let mut pages = source.stream_pages(&ctx, 2);
@@ -404,7 +404,7 @@ async fn stream_pages_first_page_arrives_before_full_scroll_completes() {
     mount_paged_responder(&server, responder).await;
 
     let config = ElasticsearchSourceConfig::new(server.uri(), "test").with_batch_size(100);
-    let source = ElasticsearchSource::new(config);
+    let source = ElasticsearchSource::new(config).unwrap();
 
     let ctx: HashMap<String, Value> = HashMap::new();
     let start = Instant::now();
@@ -447,7 +447,7 @@ async fn stream_pages_respects_max_pages_cap() {
     let config = ElasticsearchSourceConfig::new(server.uri(), "test")
         .with_batch_size(100)
         .max_pages(3);
-    let source = ElasticsearchSource::new(config);
+    let source = ElasticsearchSource::new(config).unwrap();
 
     let ctx: HashMap<String, Value> = HashMap::new();
     let mut pages = source.stream_pages(&ctx, 100);

--- a/crates/source/gcs/src/stream.rs
+++ b/crates/source/gcs/src/stream.rs
@@ -43,7 +43,7 @@ impl GcsSource {
         prefix_override: Option<&str>,
     ) -> Result<Vec<String>, FaucetError> {
         if let Some(ref keys) = self.config.object_keys {
-            return Ok(keys.clone());
+            return Ok(cap_keys(keys.clone(), self.config.max_objects));
         }
 
         let effective_prefix = prefix_override.or(self.config.prefix.as_deref());
@@ -357,6 +357,19 @@ impl faucet_core::Source for GcsSource {
     }
 }
 
+/// Truncate an explicit object-key list to the `max_objects` cap.
+///
+/// `None` leaves the list untouched; `Some(n)` keeps at most the first `n`
+/// keys. This mirrors the cap the listing path applies while paginating, so
+/// `max_objects` is honoured whether keys come from `object_keys` or a live
+/// `list_objects` scan.
+fn cap_keys(mut keys: Vec<String>, max: Option<usize>) -> Vec<String> {
+    if let Some(n) = max {
+        keys.truncate(n);
+    }
+    keys
+}
+
 fn value_type_name(v: &Value) -> &'static str {
     match v {
         Value::Null => "null",
@@ -470,5 +483,26 @@ mod tests {
     fn parse_raw_text_yields_single_record() {
         let r = parse(GcsFileFormat::RawText, "p/f.txt", "hello").unwrap();
         assert_eq!(r, vec![json!({"key": "p/f.txt", "content": "hello"})]);
+    }
+
+    #[test]
+    fn cap_keys_truncates_explicit_list_to_max_objects() {
+        let keys = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+        let capped = cap_keys(keys, Some(2));
+        assert_eq!(capped, vec!["a".to_string(), "b".to_string()]);
+    }
+
+    #[test]
+    fn cap_keys_passes_through_when_no_max() {
+        let keys = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+        let capped = cap_keys(keys.clone(), None);
+        assert_eq!(capped, keys);
+    }
+
+    #[test]
+    fn cap_keys_noop_when_max_exceeds_len() {
+        let keys = vec!["a".to_string(), "b".to_string()];
+        let capped = cap_keys(keys.clone(), Some(10));
+        assert_eq!(capped, keys);
     }
 }

--- a/crates/source/graphql/src/stream.rs
+++ b/crates/source/graphql/src/stream.rs
@@ -287,10 +287,14 @@ impl GraphqlStream {
         match &self.config.records_path {
             Some(path) => util::extract_records(body, Some(path)),
             None => {
-                // GraphQL-specific: return the `data` field as a single record.
+                // GraphQL-specific: return the `data` field as a single
+                // record. A `data` that is JSON null (or absent entirely)
+                // means there is nothing to extract — emit an empty page
+                // rather than forwarding a bogus null record to the sink
+                // (#146 LOW).
                 match body.get("data") {
+                    Some(Value::Null) | None => Ok(Vec::new()),
                     Some(data) => Ok(vec![data.clone()]),
-                    None => Ok(vec![body.clone()]),
                 }
             }
         }
@@ -491,5 +495,36 @@ mod tests {
         let records = stream.extract_records(&body).unwrap();
         assert_eq!(records.len(), 1);
         assert_eq!(records[0]["user"]["id"], 1);
+    }
+
+    #[test]
+    fn extract_records_without_path_null_data_yields_empty() {
+        // A response of `{"data": null}` must NOT emit a bogus null record:
+        // `data` being JSON null means there is nothing to extract, so the
+        // page is empty (#146 LOW).
+        let config =
+            GraphqlStreamConfig::new("https://api.example.com/graphql", "query { user { id } }");
+        let stream = GraphqlStream::new(config);
+        let body = json!({ "data": null });
+        let records = stream.extract_records(&body).unwrap();
+        assert!(
+            records.is_empty(),
+            "expected empty Vec for null `data`, got {records:?}"
+        );
+    }
+
+    #[test]
+    fn extract_records_without_path_absent_data_yields_empty() {
+        // No `data` field at all → nothing to extract → empty page (matches
+        // the null-data case rather than forwarding the whole body).
+        let config =
+            GraphqlStreamConfig::new("https://api.example.com/graphql", "query { user { id } }");
+        let stream = GraphqlStream::new(config);
+        let body = json!({ "extensions": { "foo": 1 } });
+        let records = stream.extract_records(&body).unwrap();
+        assert!(
+            records.is_empty(),
+            "expected empty Vec when `data` is absent, got {records:?}"
+        );
     }
 }

--- a/crates/source/mongodb/src/stream.rs
+++ b/crates/source/mongodb/src/stream.rs
@@ -24,6 +24,7 @@ impl MongoSource {
     /// This establishes the MongoDB client (with its internal connection pool)
     /// immediately.
     pub async fn new(config: MongoSourceConfig) -> Result<Self, FaucetError> {
+        faucet_core::validate_batch_size(config.batch_size)?;
         let client = Client::with_uri_str(&config.connection_uri)
             .await
             .map_err(|e| FaucetError::Config(format!("MongoDB connection failed: {e}")))?;
@@ -360,5 +361,17 @@ mod tests {
         let val = json!({});
         let doc = json_value_to_document(&val).unwrap();
         assert!(doc.is_empty());
+    }
+
+    #[tokio::test]
+    async fn new_rejects_out_of_range_batch_size() {
+        let mut config = MongoSourceConfig::new("mongodb://localhost:27017", "db", "c");
+        config.batch_size = faucet_core::MAX_BATCH_SIZE + 1;
+        match MongoSource::new(config).await {
+            Err(faucet_core::FaucetError::Config(m)) => {
+                assert!(m.contains("batch_size"), "got: {m}")
+            }
+            _ => panic!("expected a batch_size Config error"),
+        }
     }
 }

--- a/crates/source/mongodb/src/stream.rs
+++ b/crates/source/mongodb/src/stream.rs
@@ -27,7 +27,7 @@ impl MongoSource {
         faucet_core::validate_batch_size(config.batch_size)?;
         let client = Client::with_uri_str(&config.connection_uri)
             .await
-            .map_err(|e| FaucetError::Config(format!("MongoDB connection failed: {e}")))?;
+            .map_err(|e| FaucetError::Source(format!("MongoDB connection failed: {e}")))?;
 
         Ok(Self { config, client })
     }
@@ -63,18 +63,18 @@ impl MongoSource {
             .find(filter.unwrap_or_default())
             .with_options(find_options)
             .await
-            .map_err(|e| FaucetError::Config(format!("MongoDB find failed: {e}")))?;
+            .map_err(|e| FaucetError::Source(format!("MongoDB find failed: {e}")))?;
 
         let mut records = Vec::new();
 
         while cursor
             .advance()
             .await
-            .map_err(|e| FaucetError::Config(format!("MongoDB cursor advance failed: {e}")))?
+            .map_err(|e| FaucetError::Source(format!("MongoDB cursor advance failed: {e}")))?
         {
             let doc = cursor
                 .deserialize_current()
-                .map_err(|e| FaucetError::Config(format!("MongoDB deserialization failed: {e}")))?;
+                .map_err(|e| FaucetError::Source(format!("MongoDB deserialization failed: {e}")))?;
 
             let value = bson_document_to_json_value(&doc)?;
             records.push(value);
@@ -129,17 +129,17 @@ impl faucet_core::Source for MongoSource {
             .find(filter_doc.unwrap_or_default())
             .with_options(find_options)
             .await
-            .map_err(|e| FaucetError::Config(format!("MongoDB find failed: {e}")))?;
+            .map_err(|e| FaucetError::Source(format!("MongoDB find failed: {e}")))?;
 
         let mut records = Vec::new();
         while cursor
             .advance()
             .await
-            .map_err(|e| FaucetError::Config(format!("MongoDB cursor advance failed: {e}")))?
+            .map_err(|e| FaucetError::Source(format!("MongoDB cursor advance failed: {e}")))?
         {
             let doc = cursor
                 .deserialize_current()
-                .map_err(|e| FaucetError::Config(format!("MongoDB deserialization failed: {e}")))?;
+                .map_err(|e| FaucetError::Source(format!("MongoDB deserialization failed: {e}")))?;
             records.push(bson_document_to_json_value(&doc)?);
         }
 
@@ -217,7 +217,7 @@ impl faucet_core::Source for MongoSource {
                 .find(filter_doc.unwrap_or_default())
                 .with_options(find_options)
                 .await
-                .map_err(|e| FaucetError::Config(format!("MongoDB find failed: {e}")))?;
+                .map_err(|e| FaucetError::Source(format!("MongoDB find failed: {e}")))?;
 
             let chunk = if batch_size == 0 { usize::MAX } else { batch_size };
             let initial_capacity = if batch_size == 0 { 1024 } else { batch_size };
@@ -227,11 +227,11 @@ impl faucet_core::Source for MongoSource {
             while cursor
                 .advance()
                 .await
-                .map_err(|e| FaucetError::Config(format!("MongoDB cursor advance failed: {e}")))?
+                .map_err(|e| FaucetError::Source(format!("MongoDB cursor advance failed: {e}")))?
             {
                 let doc = cursor
                     .deserialize_current()
-                    .map_err(|e| FaucetError::Config(format!("MongoDB deserialization failed: {e}")))?;
+                    .map_err(|e| FaucetError::Source(format!("MongoDB deserialization failed: {e}")))?;
                 buffer.push(bson_document_to_json_value(&doc)?);
                 if buffer.len() >= chunk {
                     let page = std::mem::replace(&mut buffer, Vec::with_capacity(initial_capacity));

--- a/crates/source/mysql/src/stream.rs
+++ b/crates/source/mysql/src/stream.rs
@@ -18,6 +18,8 @@ pub struct MysqlSource {
 impl MysqlSource {
     /// Create a new MySQL source. Establishes a connection pool.
     pub async fn new(config: MysqlSourceConfig) -> Result<Self, FaucetError> {
+        faucet_core::validate_batch_size(config.batch_size)?;
+
         let pool = MySqlPoolOptions::new()
             .max_connections(config.max_connections)
             .connect(&config.connection_url)
@@ -215,5 +217,22 @@ impl faucet_core::Source for MysqlSource {
     fn config_schema(&self) -> serde_json::Value {
         serde_json::to_value(faucet_core::schema_for!(MysqlSourceConfig))
             .expect("schema serialization")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn new_rejects_out_of_range_batch_size() {
+        let mut config = MysqlSourceConfig::new("mysql://localhost/test", "SELECT 1");
+        config.batch_size = faucet_core::MAX_BATCH_SIZE + 1;
+        match MysqlSource::new(config).await {
+            Err(faucet_core::FaucetError::Config(m)) => {
+                assert!(m.contains("batch_size"), "got: {m}")
+            }
+            _ => panic!("expected a batch_size Config error"),
+        }
     }
 }

--- a/crates/source/postgres/src/stream.rs
+++ b/crates/source/postgres/src/stream.rs
@@ -18,6 +18,8 @@ pub struct PostgresSource {
 impl PostgresSource {
     /// Create a new PostgreSQL source. Establishes a connection pool.
     pub async fn new(config: PostgresSourceConfig) -> Result<Self, FaucetError> {
+        faucet_core::validate_batch_size(config.batch_size)?;
+
         let pool = PgPoolOptions::new()
             .max_connections(config.max_connections)
             .connect(&config.connection_url)
@@ -235,5 +237,22 @@ impl faucet_core::Source for PostgresSource {
     fn config_schema(&self) -> serde_json::Value {
         serde_json::to_value(faucet_core::schema_for!(PostgresSourceConfig))
             .expect("schema serialization")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn new_rejects_out_of_range_batch_size() {
+        let mut config = PostgresSourceConfig::new("postgres://localhost/test", "SELECT 1");
+        config.batch_size = faucet_core::MAX_BATCH_SIZE + 1;
+        match PostgresSource::new(config).await {
+            Err(faucet_core::FaucetError::Config(m)) => {
+                assert!(m.contains("batch_size"), "got: {m}")
+            }
+            _ => panic!("expected a batch_size Config error"),
+        }
     }
 }

--- a/crates/source/redis/src/stream.rs
+++ b/crates/source/redis/src/stream.rs
@@ -40,7 +40,7 @@ impl RedisSource {
                 client
                     .get_multiplexed_async_connection()
                     .await
-                    .map_err(|e| FaucetError::Config(format!("Redis connection failed: {e}")))
+                    .map_err(|e| FaucetError::Source(format!("Redis connection failed: {e}")))
             })
             .await?;
         Ok(conn.clone())
@@ -81,7 +81,7 @@ impl RedisSource {
         let values: Vec<String> = conn
             .lrange(key, 0, -1)
             .await
-            .map_err(|e| FaucetError::Config(format!("LRANGE failed on '{key}': {e}")))?;
+            .map_err(|e| FaucetError::Source(format!("LRANGE failed on '{key}': {e}")))?;
 
         let records = values
             .into_iter()
@@ -106,7 +106,7 @@ impl RedisSource {
                 conn.xread_options(&[key], &[">"], &opts.group(group_name, consumer_name))
                     .await
                     .map_err(|e| {
-                        FaucetError::Config(format!("XREADGROUP failed on '{key}': {e}"))
+                        FaucetError::Source(format!("XREADGROUP failed on '{key}': {e}"))
                     })?
             }
             _ => {
@@ -116,7 +116,7 @@ impl RedisSource {
                 }
                 conn.xread_options(&[key], &["0"], &opts)
                     .await
-                    .map_err(|e| FaucetError::Config(format!("XREAD failed on '{key}': {e}")))?
+                    .map_err(|e| FaucetError::Source(format!("XREAD failed on '{key}': {e}")))?
             }
         };
 
@@ -140,7 +140,7 @@ impl RedisSource {
             let mut collected = Vec::new();
             let mut iter: redis::AsyncIter<String> =
                 conn.scan_match(pattern).await.map_err(|e| {
-                    FaucetError::Config(format!("SCAN failed with pattern '{pattern}': {e}"))
+                    FaucetError::Source(format!("SCAN failed with pattern '{pattern}': {e}"))
                 })?;
 
             while let Some(key) = iter.next_item().await {
@@ -157,7 +157,7 @@ impl RedisSource {
             .arg(&keys)
             .query_async(conn)
             .await
-            .map_err(|e| FaucetError::Config(format!("MGET failed: {e}")))?;
+            .map_err(|e| FaucetError::Source(format!("MGET failed: {e}")))?;
 
         let mut records = Vec::new();
         for (key, value) in keys.iter().zip(values.into_iter()) {
@@ -378,7 +378,7 @@ fn stream_list<'a>(
             let values: Vec<String> = conn
                 .lrange(key, 0, -1)
                 .await
-                .map_err(|e| FaucetError::Config(format!("LRANGE failed on '{key}': {e}")))?;
+                .map_err(|e| FaucetError::Source(format!("LRANGE failed on '{key}': {e}")))?;
             let mut records: Vec<Value> = values
                 .into_iter()
                 .map(|v| serde_json::from_str::<Value>(&v).unwrap_or_else(|_| Value::String(v.clone())))
@@ -397,7 +397,7 @@ fn stream_list<'a>(
             let values: Vec<String> = conn
                 .lrange(key, start, stop)
                 .await
-                .map_err(|e| FaucetError::Config(format!("LRANGE failed on '{key}': {e}")))?;
+                .map_err(|e| FaucetError::Source(format!("LRANGE failed on '{key}': {e}")))?;
             if values.is_empty() {
                 break;
             }
@@ -438,7 +438,7 @@ fn stream_xrange<'a>(
             let reply: redis::streams::StreamRangeReply = conn
                 .xrange_all(key)
                 .await
-                .map_err(|e| FaucetError::Config(format!("XRANGE failed on '{key}': {e}")))?;
+                .map_err(|e| FaucetError::Source(format!("XRANGE failed on '{key}': {e}")))?;
             let mut records: Vec<Value> = reply
                 .ids
                 .iter()
@@ -457,7 +457,7 @@ fn stream_xrange<'a>(
             let reply: redis::streams::StreamRangeReply = conn
                 .xrange_count(key, &start, "+", batch_size)
                 .await
-                .map_err(|e| FaucetError::Config(format!("XRANGE failed on '{key}': {e}")))?;
+                .map_err(|e| FaucetError::Source(format!("XRANGE failed on '{key}': {e}")))?;
 
             if reply.ids.is_empty() {
                 break;
@@ -534,7 +534,7 @@ fn stream_keys<'a>(
                 .arg(scan_hint)
                 .query_async(conn)
                 .await
-                .map_err(|e| FaucetError::Config(format!("SCAN failed with pattern '{pattern}': {e}")))?;
+                .map_err(|e| FaucetError::Source(format!("SCAN failed with pattern '{pattern}': {e}")))?;
             cursor = next_cursor;
             buffer.extend(keys);
 
@@ -572,7 +572,7 @@ async fn mget_records(
         .arg(keys)
         .query_async(conn)
         .await
-        .map_err(|e| FaucetError::Config(format!("MGET failed: {e}")))?;
+        .map_err(|e| FaucetError::Source(format!("MGET failed: {e}")))?;
     Ok(collect_kv_records(keys, values))
 }
 

--- a/crates/source/redis/src/stream.rs
+++ b/crates/source/redis/src/stream.rs
@@ -19,13 +19,14 @@ pub struct RedisSource {
 
 impl RedisSource {
     /// Create a new Redis source from the given configuration. The connection
-    /// is opened lazily on first use (so construction stays infallible and
-    /// synchronous).
-    pub fn new(config: RedisSourceConfig) -> Self {
-        Self {
+    /// is opened lazily on first use, so construction stays synchronous and does
+    /// no I/O; it fails only on an invalid config (an out-of-range `batch_size`).
+    pub fn new(config: RedisSourceConfig) -> Result<Self, FaucetError> {
+        faucet_core::validate_batch_size(config.batch_size)?;
+        Ok(Self {
             config,
             conn: tokio::sync::OnceCell::new(),
-        }
+        })
     }
 
     /// Return a clone of the shared multiplexed connection, opening it once on
@@ -602,7 +603,20 @@ mod tests {
             "redis://localhost",
             RedisSourceType::List { key: "test".into() },
         );
-        let _source = RedisSource::new(config);
+        let _source = RedisSource::new(config).unwrap();
+    }
+
+    #[test]
+    fn new_rejects_out_of_range_batch_size() {
+        let mut config = RedisSourceConfig::new(
+            "redis://localhost",
+            RedisSourceType::List { key: "test".into() },
+        );
+        config.batch_size = faucet_core::MAX_BATCH_SIZE + 1;
+        match RedisSource::new(config) {
+            Err(FaucetError::Config(m)) => assert!(m.contains("batch_size"), "got: {m}"),
+            other => panic!("expected a batch_size Config error, got {:?}", other.is_ok()),
+        }
     }
 
     #[test]

--- a/crates/source/redis/src/stream.rs
+++ b/crates/source/redis/src/stream.rs
@@ -615,7 +615,10 @@ mod tests {
         config.batch_size = faucet_core::MAX_BATCH_SIZE + 1;
         match RedisSource::new(config) {
             Err(FaucetError::Config(m)) => assert!(m.contains("batch_size"), "got: {m}"),
-            other => panic!("expected a batch_size Config error, got {:?}", other.is_ok()),
+            other => panic!(
+                "expected a batch_size Config error, got {:?}",
+                other.is_ok()
+            ),
         }
     }
 

--- a/crates/source/redis/tests/streaming.rs
+++ b/crates/source/redis/tests/streaming.rs
@@ -84,7 +84,7 @@ async fn keys_stream_pages_chunks_into_batch_sized_pages() {
         },
     )
     .with_batch_size(1000);
-    let source = RedisSource::new(config);
+    let source = RedisSource::new(config).unwrap();
 
     let ctx: HashMap<String, serde_json::Value> = HashMap::new();
     let mut pages = source.stream_pages(&ctx, 1000);
@@ -127,7 +127,7 @@ async fn keys_stream_pages_batch_size_zero_emits_single_page() {
         },
     )
     .with_batch_size(0);
-    let source = RedisSource::new(config);
+    let source = RedisSource::new(config).unwrap();
 
     let ctx: HashMap<String, serde_json::Value> = HashMap::new();
     let mut pages = source.stream_pages(&ctx, 0);
@@ -155,7 +155,7 @@ async fn keys_stream_pages_empty_pattern_yields_no_pages() {
         },
     )
     .with_batch_size(DEFAULT_BATCH_SIZE);
-    let source = RedisSource::new(config);
+    let source = RedisSource::new(config).unwrap();
 
     let ctx: HashMap<String, serde_json::Value> = HashMap::new();
     let mut pages = source.stream_pages(&ctx, DEFAULT_BATCH_SIZE);
@@ -183,7 +183,7 @@ async fn keys_stream_pages_preserves_key_value_pairs() {
         },
     )
     .with_batch_size(2);
-    let source = RedisSource::new(config);
+    let source = RedisSource::new(config).unwrap();
 
     let ctx: HashMap<String, serde_json::Value> = HashMap::new();
     let mut pages = source.stream_pages(&ctx, 2);
@@ -231,7 +231,7 @@ async fn stream_stream_pages_chunks_into_batch_sized_pages() {
         },
     )
     .with_batch_size(1000);
-    let source = RedisSource::new(config);
+    let source = RedisSource::new(config).unwrap();
 
     let ctx: HashMap<String, serde_json::Value> = HashMap::new();
     let mut pages = source.stream_pages(&ctx, 1000);
@@ -262,7 +262,7 @@ async fn stream_stream_pages_partial_final_page() {
         },
     )
     .with_batch_size(1000);
-    let source = RedisSource::new(config);
+    let source = RedisSource::new(config).unwrap();
 
     let ctx: HashMap<String, serde_json::Value> = HashMap::new();
     let mut pages = source.stream_pages(&ctx, 1000);
@@ -289,7 +289,7 @@ async fn stream_stream_pages_batch_size_zero_emits_single_page() {
         },
     )
     .with_batch_size(0);
-    let source = RedisSource::new(config);
+    let source = RedisSource::new(config).unwrap();
 
     let ctx: HashMap<String, serde_json::Value> = HashMap::new();
     let mut pages = source.stream_pages(&ctx, 0);
@@ -320,7 +320,7 @@ async fn stream_stream_pages_empty_stream_yields_no_pages() {
         },
     )
     .with_batch_size(DEFAULT_BATCH_SIZE);
-    let source = RedisSource::new(config);
+    let source = RedisSource::new(config).unwrap();
 
     let ctx: HashMap<String, serde_json::Value> = HashMap::new();
     let mut pages = source.stream_pages(&ctx, DEFAULT_BATCH_SIZE);
@@ -351,7 +351,7 @@ async fn stream_stream_pages_preserves_entry_ids_and_fields() {
         },
     )
     .with_batch_size(2);
-    let source = RedisSource::new(config);
+    let source = RedisSource::new(config).unwrap();
 
     let ctx: HashMap<String, serde_json::Value> = HashMap::new();
     let mut pages = source.stream_pages(&ctx, 2);
@@ -397,7 +397,7 @@ async fn list_stream_pages_chunks_into_batch_sized_pages() {
         },
     )
     .with_batch_size(1000);
-    let source = RedisSource::new(config);
+    let source = RedisSource::new(config).unwrap();
 
     let ctx: HashMap<String, serde_json::Value> = HashMap::new();
     let mut pages = source.stream_pages(&ctx, 1000);
@@ -423,7 +423,7 @@ async fn list_stream_pages_partial_final_page() {
         },
     )
     .with_batch_size(1000);
-    let source = RedisSource::new(config);
+    let source = RedisSource::new(config).unwrap();
 
     let ctx: HashMap<String, serde_json::Value> = HashMap::new();
     let mut pages = source.stream_pages(&ctx, 1000);
@@ -447,7 +447,7 @@ async fn list_stream_pages_batch_size_zero_emits_single_page() {
         },
     )
     .with_batch_size(0);
-    let source = RedisSource::new(config);
+    let source = RedisSource::new(config).unwrap();
 
     let ctx: HashMap<String, serde_json::Value> = HashMap::new();
     let mut pages = source.stream_pages(&ctx, 0);
@@ -475,7 +475,7 @@ async fn list_stream_pages_empty_list_yields_no_pages() {
         },
     )
     .with_batch_size(DEFAULT_BATCH_SIZE);
-    let source = RedisSource::new(config);
+    let source = RedisSource::new(config).unwrap();
 
     let ctx: HashMap<String, serde_json::Value> = HashMap::new();
     let mut pages = source.stream_pages(&ctx, DEFAULT_BATCH_SIZE);
@@ -505,7 +505,7 @@ async fn list_stream_pages_preserves_element_order() {
         },
     )
     .with_batch_size(2);
-    let source = RedisSource::new(config);
+    let source = RedisSource::new(config).unwrap();
 
     let ctx: HashMap<String, serde_json::Value> = HashMap::new();
     let mut pages = source.stream_pages(&ctx, 2);
@@ -544,7 +544,7 @@ async fn keys_first_page_completes_without_parsing_full_keyspace() {
         },
     )
     .with_batch_size(1000);
-    let source = RedisSource::new(config_full);
+    let source = RedisSource::new(config_full).unwrap();
     let start = Instant::now();
     let mut pages = source.stream_pages(&ctx, 1000);
     while let Some(page) = pages.next().await {
@@ -562,7 +562,7 @@ async fn keys_first_page_completes_without_parsing_full_keyspace() {
         },
     )
     .with_batch_size(1000);
-    let source = RedisSource::new(config_first);
+    let source = RedisSource::new(config_first).unwrap();
     let start = Instant::now();
     let mut pages = source.stream_pages(&ctx, 1000);
     let first = pages

--- a/crates/source/rest/Cargo.toml
+++ b/crates/source/rest/Cargo.toml
@@ -36,6 +36,7 @@ serde_json.workspace = true
 jsonpath-rust = "1"
 tokio = { version = "1", features = ["time"] }
 base64 = "0.22"
+httpdate = "1"
 tracing.workspace = true
 async-stream = { workspace = true }
 futures-core = "0.3.32"

--- a/crates/source/rest/README.md
+++ b/crates/source/rest/README.md
@@ -69,7 +69,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 |-------|------|---------|-------------|
 | `timeout` | `Option<Duration>` | `Some(30s)` | HTTP request timeout per individual request |
 | `max_retries` | `u32` | `3` | Maximum number of retries on transient failures |
-| `retry_backoff` | `Duration` | `1s` | Base duration for exponential backoff between retries |
+| `retry_backoff` | `Duration` | `1s` | Base duration for exponential backoff between retries. The per-attempt sleep is `retry_backoff × 2^attempt`, **capped at 60s** and scaled by random jitter in `[0.5, 1.5)` (decorrelated across concurrent retries) to avoid a thundering herd. On `429`, the server's `Retry-After` (delta-seconds **or** an RFC 7231 HTTP-date) is honored instead. |
 | `tolerated_http_errors` | `Vec<u16>` | `[]` | HTTP status codes treated as an empty page **on the first request only** (i.e. a legitimately absent/empty resource). Mid-pagination a tolerated status is surfaced as an error instead of silently ending the stream — otherwise a transient failure on page _N_ would drop every later page as a "successful" run. Only safe for genuinely-empty resources. |
 
 A **`204 No Content`** response — or any `2xx` with an empty / whitespace-only

--- a/crates/source/rest/src/retry/backoff.rs
+++ b/crates/source/rest/src/retry/backoff.rs
@@ -55,7 +55,7 @@ where
                     attempt + 1,
                     max_retries + 1
                 );
-                let wait = backoff_with_jitter(base_backoff, attempt);
+                let wait = faucet_core::retry::backoff_with_jitter(base_backoff, attempt);
                 tokio::time::sleep(wait).await;
                 attempt += 1;
             }
@@ -71,67 +71,19 @@ where
     }
 }
 
-/// Compute exponential backoff with random jitter.
-///
-/// `base * 2^attempt` gives the exponential component; a random factor
-/// between 0.5 and 1.5 is applied to spread out concurrent retries
-/// (avoids thundering-herd).
-fn backoff_with_jitter(base: Duration, attempt: u32) -> Duration {
-    let exp = base * 2u32.pow(attempt);
-    // Simple jitter: multiply by a random factor in [0.5, 1.5).
-    // Uses a lightweight approach — no extra crate dependency.
-    let nanos = exp.as_nanos() as u64;
-    let jitter_factor = pseudo_random_factor();
-    Duration::from_nanos((nanos as f64 * jitter_factor) as u64)
-}
-
-/// Returns a pseudo-random factor in [0.5, 1.5) using the current time's
-/// nanosecond component as entropy. Not cryptographically secure, but
-/// sufficient for retry jitter.
-fn pseudo_random_factor() -> f64 {
-    // Use the low bits of the current timestamp for cheap randomness.
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .subsec_nanos();
-    // Map to [0.5, 1.5)
-    0.5 + (nanos as f64 / u32::MAX as f64)
-}
+// Backoff + jitter now lives in `faucet_core::retry::backoff_with_jitter` (capped
+// at 60s, range-correct [0.5,1.5), decorrelated across concurrent retries). This
+// module keeps only the 429/`Retry-After`-aware loop and delegates the sleep
+// computation, so the jitter bug fixed in core can never diverge in a copy here.
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use faucet_core::FaucetError;
 
-    #[test]
-    fn backoff_with_jitter_increases_with_attempt() {
-        let base = Duration::from_millis(100);
-        let d0 = backoff_with_jitter(base, 0);
-        let _d1 = backoff_with_jitter(base, 1);
-        let d2 = backoff_with_jitter(base, 2);
-
-        // With jitter in [0.5, 1.5), the expected center doubles each attempt.
-        // d0 center: 100ms, d1 center: 200ms, d2 center: 400ms
-        // Even with worst-case jitter, d2 should be > d0's minimum.
-        assert!(
-            d0.as_millis() >= 50,
-            "d0 should be at least 50ms, got {d0:?}"
-        );
-        assert!(
-            d2.as_millis() >= 200,
-            "d2 should be at least 200ms, got {d2:?}"
-        );
-    }
-
-    #[test]
-    fn pseudo_random_factor_in_expected_range() {
-        // Call multiple times to increase confidence.
-        for _ in 0..100 {
-            let f = pseudo_random_factor();
-            assert!(f >= 0.5, "factor {f} < 0.5");
-            assert!(f < 1.5, "factor {f} >= 1.5");
-        }
-    }
+    // Backoff/jitter behaviour (range, cap, decorrelation) is tested in
+    // `faucet_core::retry`; this module now delegates to it. The tests below
+    // exercise the 429/`Retry-After`-aware retry loop that is unique to REST.
 
     #[tokio::test]
     async fn execute_with_retry_success_on_first_try() {

--- a/crates/source/rest/src/stream.rs
+++ b/crates/source/rest/src/stream.rs
@@ -651,15 +651,30 @@ impl RestStream {
     }
 }
 
-/// Parse the `Retry-After` header as a number of seconds.
-/// Falls back to 60 s if the header is absent or unparseable.
+/// Parse the `Retry-After` header. RFC 7231 permits **either** delta-seconds
+/// **or** an HTTP-date; we honour both. An HTTP-date in the past yields a zero
+/// wait (retry now). Falls back to 60 s only when the header is absent or in
+/// neither form.
 fn parse_retry_after(headers: &HeaderMap) -> Duration {
-    headers
+    const DEFAULT: Duration = Duration::from_secs(60);
+    let Some(raw) = headers
         .get(reqwest::header::RETRY_AFTER)
         .and_then(|v| v.to_str().ok())
-        .and_then(|s| s.parse::<u64>().ok())
-        .map(Duration::from_secs)
-        .unwrap_or(Duration::from_secs(60))
+        .map(str::trim)
+    else {
+        return DEFAULT;
+    };
+    // delta-seconds form.
+    if let Ok(secs) = raw.parse::<u64>() {
+        return Duration::from_secs(secs);
+    }
+    // HTTP-date form (IMF-fixdate / RFC 850 / asctime).
+    if let Ok(when) = httpdate::parse_http_date(raw) {
+        return when
+            .duration_since(std::time::SystemTime::now())
+            .unwrap_or(Duration::ZERO);
+    }
+    DEFAULT
 }
 
 #[async_trait]
@@ -786,6 +801,41 @@ mod tests {
             reqwest::header::HeaderValue::from_static("not-a-number"),
         );
         assert_eq!(parse_retry_after(&headers), Duration::from_secs(60));
+    }
+
+    #[test]
+    fn test_parse_retry_after_http_date() {
+        // RFC 7231 permits an HTTP-date form instead of delta-seconds.
+        let future = std::time::SystemTime::now() + Duration::from_secs(7200);
+        let date = httpdate::fmt_http_date(future);
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            reqwest::header::RETRY_AFTER,
+            reqwest::header::HeaderValue::from_str(&date).unwrap(),
+        );
+        let d = parse_retry_after(&headers);
+        // ~2 hours out — must not collapse to the 60s fallback.
+        assert!(
+            d > Duration::from_secs(3600),
+            "expected ~2h from HTTP-date, got {d:?}"
+        );
+        assert!(
+            d <= Duration::from_secs(7200),
+            "should not exceed the target instant, got {d:?}"
+        );
+    }
+
+    #[test]
+    fn test_parse_retry_after_past_http_date_is_zero() {
+        // A date already in the past → retry now (zero wait), not the fallback.
+        let past = std::time::SystemTime::now() - Duration::from_secs(3600);
+        let date = httpdate::fmt_http_date(past);
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            reqwest::header::RETRY_AFTER,
+            reqwest::header::HeaderValue::from_str(&date).unwrap(),
+        );
+        assert_eq!(parse_retry_after(&headers), Duration::ZERO);
     }
 
     #[test]

--- a/crates/source/s3/src/stream.rs
+++ b/crates/source/s3/src/stream.rs
@@ -66,7 +66,7 @@ impl S3Source {
             }
 
             let response = req.send().await.map_err(|e| {
-                FaucetError::Config(format!(
+                FaucetError::Source(format!(
                     "S3 list objects error for bucket '{}': {e}",
                     self.config.bucket
                 ))
@@ -114,7 +114,7 @@ impl S3Source {
         let mut reader = self.open_object_reader(key).await?;
         let mut text = String::new();
         reader.read_to_string(&mut text).await.map_err(|e| {
-            FaucetError::Config(format!(
+            FaucetError::Source(format!(
                 "S3 read/decode error for key '{key}' (not valid UTF-8?): {e}"
             ))
         })?;
@@ -137,7 +137,7 @@ impl S3Source {
             .send()
             .await
             .map_err(|e| {
-                FaucetError::Config(format!("S3 get object error for key '{key}': {e}"))
+                FaucetError::Source(format!("S3 get object error for key '{key}': {e}"))
             })?;
 
         // `ByteStream::into_async_read` returns `impl AsyncRead`; wrap in a
@@ -166,7 +166,7 @@ impl S3Source {
                         continue;
                     }
                     let value: Value = serde_json::from_str(trimmed).map_err(|e| {
-                        FaucetError::Config(format!(
+                        FaucetError::Source(format!(
                             "S3 JSON parse error in '{key}' at line {}: {e}",
                             line_num + 1
                         ))
@@ -177,11 +177,11 @@ impl S3Source {
             }
             S3FileFormat::JsonArray => {
                 let value: Value = serde_json::from_str(text).map_err(|e| {
-                    FaucetError::Config(format!("S3 JSON parse error in '{key}': {e}"))
+                    FaucetError::Source(format!("S3 JSON parse error in '{key}': {e}"))
                 })?;
                 match value {
                     Value::Array(arr) => Ok(arr),
-                    _ => Err(FaucetError::Config(format!(
+                    _ => Err(FaucetError::Source(format!(
                         "S3 expected JSON array in '{key}', got {}",
                         value_type_name(&value)
                     ))),
@@ -304,7 +304,7 @@ impl faucet_core::Source for S3Source {
                         while let Some(line) = lines
                             .next_line()
                             .await
-                            .map_err(|e| FaucetError::Config(format!(
+                            .map_err(|e| FaucetError::Source(format!(
                                 "S3 read body error for key '{key}': {e}"
                             )))?
                         {
@@ -315,7 +315,7 @@ impl faucet_core::Source for S3Source {
                             }
                             let value: Value =
                                 serde_json::from_str(trimmed).map_err(|e| {
-                                    FaucetError::Config(format!(
+                                    FaucetError::Source(format!(
                                         "S3 JSON parse error in '{key}' at line {line_num}: {e}",
                                     ))
                                 })?;
@@ -367,11 +367,11 @@ impl faucet_core::Source for S3Source {
                         // crate README.
                         let text = self.read_object_text(key).await?;
                         let value: Value = serde_json::from_str(&text).map_err(|e| {
-                            FaucetError::Config(format!("S3 JSON parse error in '{key}': {e}"))
+                            FaucetError::Source(format!("S3 JSON parse error in '{key}': {e}"))
                         })?;
                         let array = match value {
                             Value::Array(arr) => arr,
-                            other => Err(FaucetError::Config(format!(
+                            other => Err(FaucetError::Source(format!(
                                 "S3 expected JSON array in '{key}', got {}",
                                 value_type_name(&other)
                             )))?,

--- a/crates/source/snowflake/src/stream.rs
+++ b/crates/source/snowflake/src/stream.rs
@@ -611,7 +611,9 @@ mod tests {
 
     #[test]
     fn statements_url_uses_endpoint_override() {
-        let src = SnowflakeSource::new(cfg()).unwrap().with_endpoint_base("http://127.0.0.1:9999");
+        let src = SnowflakeSource::new(cfg())
+            .unwrap()
+            .with_endpoint_base("http://127.0.0.1:9999");
         assert_eq!(
             src.statements_url(),
             "http://127.0.0.1:9999/api/v2/statements"
@@ -620,7 +622,9 @@ mod tests {
 
     #[test]
     fn partition_url_includes_handle_and_index() {
-        let src = SnowflakeSource::new(cfg()).unwrap().with_endpoint_base("http://srv");
+        let src = SnowflakeSource::new(cfg())
+            .unwrap()
+            .with_endpoint_base("http://srv");
         assert_eq!(
             src.partition_url("abc-123", 2),
             "http://srv/api/v2/statements/abc-123?partition=2"

--- a/crates/source/snowflake/src/stream.rs
+++ b/crates/source/snowflake/src/stream.rs
@@ -83,15 +83,17 @@ pub struct SnowflakeSource {
 }
 
 impl SnowflakeSource {
-    /// Create a new Snowflake source. Initialises the underlying HTTP
-    /// client; does not perform any I/O.
-    pub fn new(config: SnowflakeSourceConfig) -> Self {
-        Self {
+    /// Create a new Snowflake source. Initialises the underlying HTTP client and
+    /// does no I/O; it fails only on an invalid config (an out-of-range
+    /// `batch_size`).
+    pub fn new(config: SnowflakeSourceConfig) -> Result<Self, FaucetError> {
+        faucet_core::validate_batch_size(config.batch_size)?;
+        Ok(Self {
             config,
             client: Client::new(),
             endpoint_base: None,
             auth_provider: None,
-        }
+        })
     }
 
     /// Attach a shared [`AuthProvider`](faucet_core::AuthProvider). When set,
@@ -589,8 +591,18 @@ mod tests {
     }
 
     #[test]
+    fn new_rejects_out_of_range_batch_size() {
+        let mut config = cfg();
+        config.batch_size = faucet_core::MAX_BATCH_SIZE + 1;
+        match SnowflakeSource::new(config) {
+            Err(FaucetError::Config(m)) => assert!(m.contains("batch_size"), "got: {m}"),
+            _ => panic!("expected a batch_size Config error"),
+        }
+    }
+
+    #[test]
     fn statements_url_uses_account_when_no_override() {
-        let src = SnowflakeSource::new(cfg());
+        let src = SnowflakeSource::new(cfg()).unwrap();
         assert_eq!(
             src.statements_url(),
             "https://xy12345.us-east-1.snowflakecomputing.com/api/v2/statements"
@@ -599,7 +611,7 @@ mod tests {
 
     #[test]
     fn statements_url_uses_endpoint_override() {
-        let src = SnowflakeSource::new(cfg()).with_endpoint_base("http://127.0.0.1:9999");
+        let src = SnowflakeSource::new(cfg()).unwrap().with_endpoint_base("http://127.0.0.1:9999");
         assert_eq!(
             src.statements_url(),
             "http://127.0.0.1:9999/api/v2/statements"
@@ -608,7 +620,7 @@ mod tests {
 
     #[test]
     fn partition_url_includes_handle_and_index() {
-        let src = SnowflakeSource::new(cfg()).with_endpoint_base("http://srv");
+        let src = SnowflakeSource::new(cfg()).unwrap().with_endpoint_base("http://srv");
         assert_eq!(
             src.partition_url("abc-123", 2),
             "http://srv/api/v2/statements/abc-123?partition=2"
@@ -617,7 +629,7 @@ mod tests {
 
     #[test]
     fn build_request_body_minimal() {
-        let src = SnowflakeSource::new(cfg());
+        let src = SnowflakeSource::new(cfg()).unwrap();
         let body = src.build_request_body(&[]);
         assert_eq!(body["statement"], "SELECT 1");
         assert_eq!(body["timeout"], 60);
@@ -632,7 +644,7 @@ mod tests {
     fn build_request_body_includes_role_when_set() {
         let mut c = cfg();
         c.role = Some("ANALYST".into());
-        let src = SnowflakeSource::new(c);
+        let src = SnowflakeSource::new(c).unwrap();
         let body = src.build_request_body(&[]);
         assert_eq!(body["role"], "ANALYST");
     }
@@ -641,7 +653,7 @@ mod tests {
     fn build_request_body_infers_binding_types() {
         // #78/#34: types are inferred from the JSON value (value still a
         // string), so numeric/boolean binds compare against typed columns.
-        let src = SnowflakeSource::new(cfg());
+        let src = SnowflakeSource::new(cfg()).unwrap();
         let body = src.build_request_body(&[
             Value::String("alice".into()),
             json!(42),
@@ -664,7 +676,7 @@ mod tests {
         // Regression for #78/#18: a NULL must occupy its positional slot as an
         // explicit null-valued binding, not be skipped (which would shift "42"
         // onto marker 1 and leave marker 2 unbound).
-        let src = SnowflakeSource::new(cfg());
+        let src = SnowflakeSource::new(cfg()).unwrap();
         let body = src.build_request_body(&[Value::Null, json!(42)]);
         let b = &body["bindings"];
         assert_eq!(b["1"]["type"], "TEXT");
@@ -678,7 +690,7 @@ mod tests {
 
     #[test]
     fn resolve_query_with_no_context_returns_input() {
-        let src = SnowflakeSource::new(cfg().with_params(vec![json!(7)]));
+        let src = SnowflakeSource::new(cfg().with_params(vec![json!(7)])).unwrap();
         let (q, binds) = src.resolve_query(&HashMap::new());
         assert_eq!(q, "SELECT 1");
         assert_eq!(binds, vec![json!(7)]);
@@ -688,7 +700,7 @@ mod tests {
     fn resolve_query_substitutes_context_with_question_mark_markers() {
         let mut c = cfg();
         c.query = "SELECT * FROM t WHERE id = {parent.id}".into();
-        let src = SnowflakeSource::new(c);
+        let src = SnowflakeSource::new(c).unwrap();
         let mut ctx = HashMap::new();
         ctx.insert("parent.id".to_string(), json!(7));
         let (q, binds) = src.resolve_query(&ctx);

--- a/crates/source/snowflake/tests/shared_auth_test.rs
+++ b/crates/source/snowflake/tests/shared_auth_test.rs
@@ -69,7 +69,7 @@ async fn injected_provider_supplies_oauth_token() {
         .await;
 
     let provider = Arc::new(FixedBearer("INJECTED"));
-    let src = SnowflakeSource::new(base_cfg())
+    let src = SnowflakeSource::new(base_cfg()).unwrap()
         .with_endpoint_base(server.uri())
         .with_auth_provider(provider);
 
@@ -102,7 +102,7 @@ async fn token_credential_maps_to_oauth() {
         }
     }
 
-    let src = SnowflakeSource::new(base_cfg())
+    let src = SnowflakeSource::new(base_cfg()).unwrap()
         .with_endpoint_base(server.uri())
         .with_auth_provider(Arc::new(FixedToken("TOKEN-CRED")));
 
@@ -119,7 +119,7 @@ async fn unresolved_auth_reference_errors() {
     config.auth = AuthSpec::Reference(AuthReference {
         name: "missing-provider".into(),
     });
-    let src = SnowflakeSource::new(config).with_endpoint_base(server.uri());
+    let src = SnowflakeSource::new(config).unwrap().with_endpoint_base(server.uri());
 
     let err = src.fetch_all().await.unwrap_err();
     assert!(
@@ -155,10 +155,10 @@ async fn one_provider_shared_across_two_sources() {
         .await;
 
     let provider = Arc::new(FixedBearer("SHARED"));
-    let a = SnowflakeSource::new(base_cfg())
+    let a = SnowflakeSource::new(base_cfg()).unwrap()
         .with_endpoint_base(server.uri())
         .with_auth_provider(provider.clone());
-    let b = SnowflakeSource::new(base_cfg())
+    let b = SnowflakeSource::new(base_cfg()).unwrap()
         .with_endpoint_base(server.uri())
         .with_auth_provider(provider.clone());
 

--- a/crates/source/snowflake/tests/shared_auth_test.rs
+++ b/crates/source/snowflake/tests/shared_auth_test.rs
@@ -69,7 +69,8 @@ async fn injected_provider_supplies_oauth_token() {
         .await;
 
     let provider = Arc::new(FixedBearer("INJECTED"));
-    let src = SnowflakeSource::new(base_cfg()).unwrap()
+    let src = SnowflakeSource::new(base_cfg())
+        .unwrap()
         .with_endpoint_base(server.uri())
         .with_auth_provider(provider);
 
@@ -102,7 +103,8 @@ async fn token_credential_maps_to_oauth() {
         }
     }
 
-    let src = SnowflakeSource::new(base_cfg()).unwrap()
+    let src = SnowflakeSource::new(base_cfg())
+        .unwrap()
         .with_endpoint_base(server.uri())
         .with_auth_provider(Arc::new(FixedToken("TOKEN-CRED")));
 
@@ -119,7 +121,9 @@ async fn unresolved_auth_reference_errors() {
     config.auth = AuthSpec::Reference(AuthReference {
         name: "missing-provider".into(),
     });
-    let src = SnowflakeSource::new(config).unwrap().with_endpoint_base(server.uri());
+    let src = SnowflakeSource::new(config)
+        .unwrap()
+        .with_endpoint_base(server.uri());
 
     let err = src.fetch_all().await.unwrap_err();
     assert!(
@@ -155,10 +159,12 @@ async fn one_provider_shared_across_two_sources() {
         .await;
 
     let provider = Arc::new(FixedBearer("SHARED"));
-    let a = SnowflakeSource::new(base_cfg()).unwrap()
+    let a = SnowflakeSource::new(base_cfg())
+        .unwrap()
         .with_endpoint_base(server.uri())
         .with_auth_provider(provider.clone());
-    let b = SnowflakeSource::new(base_cfg()).unwrap()
+    let b = SnowflakeSource::new(base_cfg())
+        .unwrap()
         .with_endpoint_base(server.uri())
         .with_auth_provider(provider.clone());
 

--- a/crates/source/snowflake/tests/snowflake_source.rs
+++ b/crates/source/snowflake/tests/snowflake_source.rs
@@ -32,7 +32,9 @@ fn cfg() -> SnowflakeSourceConfig {
 }
 
 fn build_source(cfg: SnowflakeSourceConfig, server: &MockServer) -> SnowflakeSource {
-    SnowflakeSource::new(cfg).unwrap().with_endpoint_base(server.uri())
+    SnowflakeSource::new(cfg)
+        .unwrap()
+        .with_endpoint_base(server.uri())
 }
 
 fn metadata(num_partitions: usize) -> Value {

--- a/crates/source/snowflake/tests/snowflake_source.rs
+++ b/crates/source/snowflake/tests/snowflake_source.rs
@@ -32,7 +32,7 @@ fn cfg() -> SnowflakeSourceConfig {
 }
 
 fn build_source(cfg: SnowflakeSourceConfig, server: &MockServer) -> SnowflakeSource {
-    SnowflakeSource::new(cfg).with_endpoint_base(server.uri())
+    SnowflakeSource::new(cfg).unwrap().with_endpoint_base(server.uri())
 }
 
 fn metadata(num_partitions: usize) -> Value {

--- a/crates/source/sqlite/src/stream.rs
+++ b/crates/source/sqlite/src/stream.rs
@@ -18,6 +18,8 @@ pub struct SqliteSource {
 impl SqliteSource {
     /// Create a new SQLite source. Establishes a connection pool.
     pub async fn new(config: SqliteSourceConfig) -> Result<Self, FaucetError> {
+        faucet_core::validate_batch_size(config.batch_size)?;
+
         let pool = SqlitePoolOptions::new()
             .max_connections(config.max_connections)
             .connect(&config.database_url)
@@ -314,5 +316,17 @@ mod tests {
         let records = source.fetch_with_context(&context).await.unwrap();
         assert_eq!(records.len(), 1);
         assert_eq!(records[0]["result"], "1; DROP TABLE test; --");
+    }
+
+    #[tokio::test]
+    async fn new_rejects_out_of_range_batch_size() {
+        let mut config = SqliteSourceConfig::new("sqlite::memory:", "SELECT 1");
+        config.batch_size = faucet_core::MAX_BATCH_SIZE + 1;
+        match SqliteSource::new(config).await {
+            Err(faucet_core::FaucetError::Config(m)) => {
+                assert!(m.contains("batch_size"), "got: {m}")
+            }
+            _ => panic!("expected a batch_size Config error"),
+        }
     }
 }

--- a/crates/source/webhook/src/stream.rs
+++ b/crates/source/webhook/src/stream.rs
@@ -115,6 +115,53 @@ fn token_matches(provided: Option<&str>, expected: &str) -> bool {
     raw | stripped
 }
 
+/// Decision for an incoming payload, given the current record count and the
+/// configured cap. Extracted as a pure function so the cap invariant can be
+/// tested deterministically without driving concurrent HTTP.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PayloadDecision {
+    /// Whether to store the just-received payload.
+    accept: bool,
+    /// Whether the receive loop is now done (cap reached) and `done` should be
+    /// notified.
+    done: bool,
+}
+
+/// Decide whether to store a payload and whether the cap is now satisfied.
+///
+/// `current_len` is the number of records already stored (observed under the
+/// records lock). With no cap, every payload is accepted and the loop never
+/// self-terminates. With a cap, the cap is **exact**: once `current_len` has
+/// reached `max`, further concurrently-accepted POSTs are dropped (so the Vec
+/// never exceeds `max`) while still notifying `done` so a slightly-late request
+/// doesn't wedge the receive loop (#146 LOW).
+fn decide_payload(current_len: usize, max_payloads: Option<usize>) -> PayloadDecision {
+    match max_payloads {
+        None => PayloadDecision {
+            accept: true,
+            done: false,
+        },
+        Some(max) => {
+            if current_len >= max {
+                // Already at (or somehow past) the cap — drop this payload and
+                // signal completion. Pushing here is what let concurrent
+                // in-flight POSTs overflow the Vec past `max`.
+                PayloadDecision {
+                    accept: false,
+                    done: true,
+                }
+            } else {
+                // Room for this one. Accept it; we're done once it fills the
+                // last slot.
+                PayloadDecision {
+                    accept: true,
+                    done: current_len + 1 >= max,
+                }
+            }
+        }
+    }
+}
+
 /// Axum handler for incoming webhook POST requests.
 async fn webhook_handler(
     State(state): State<Arc<AppState>>,
@@ -144,11 +191,15 @@ async fn webhook_handler(
     };
 
     let mut records = state.records.lock().await;
-    records.push(value);
-
-    if let Some(max) = state.max_payloads
-        && records.len() >= max
-    {
+    // Decide under the lock so the cap is exact: concurrent in-flight POSTs
+    // that have already been accepted can't push the Vec past `max_payloads`
+    // — once the cap is reached we drop the surplus payload instead of
+    // storing it (#146 LOW).
+    let decision = decide_payload(records.len(), state.max_payloads);
+    if decision.accept {
+        records.push(value);
+    }
+    if decision.done {
         state.done.notify_one();
     }
 
@@ -284,6 +335,118 @@ mod tests {
             Some("sekret-token-valu"),
             "sekret-token-value"
         ));
+    }
+
+    #[test]
+    fn decide_payload_no_cap_always_accepts() {
+        for len in [0usize, 1, 100, 10_000] {
+            assert_eq!(
+                decide_payload(len, None),
+                PayloadDecision {
+                    accept: true,
+                    done: false
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn decide_payload_accepts_until_cap_then_drops() {
+        let max = Some(2);
+        // 0 stored: accept, not yet done.
+        assert_eq!(
+            decide_payload(0, max),
+            PayloadDecision {
+                accept: true,
+                done: false
+            }
+        );
+        // 1 stored: accept the last slot, now done.
+        assert_eq!(
+            decide_payload(1, max),
+            PayloadDecision {
+                accept: true,
+                done: true
+            }
+        );
+        // 2 stored (at cap): drop, signal done.
+        assert_eq!(
+            decide_payload(2, max),
+            PayloadDecision {
+                accept: false,
+                done: true
+            }
+        );
+        // 3 stored (somehow past cap): still drop, still done.
+        assert_eq!(
+            decide_payload(3, max),
+            PayloadDecision {
+                accept: false,
+                done: true
+            }
+        );
+    }
+
+    #[test]
+    fn cap_invariant_never_exceeded_under_concurrent_arrivals() {
+        // Simulate many in-flight POSTs all racing the cap: the same record
+        // count can be observed by several requests before any of them push.
+        // Applying `decide_payload` per request must still bound the Vec at
+        // `max`, dropping the surplus rather than overflowing (#146 LOW).
+        let max = 2usize;
+        let mut records: Vec<Value> = Vec::new();
+        // 5 concurrent arrivals; each makes its decision against the current
+        // length and only pushes if accepted (mirroring the handler under the
+        // records lock).
+        for i in 0..5 {
+            let decision = decide_payload(records.len(), Some(max));
+            if decision.accept {
+                records.push(json!({ "id": i }));
+            }
+        }
+        assert_eq!(
+            records.len(),
+            max,
+            "Vec must never exceed max_payloads, got {}",
+            records.len()
+        );
+    }
+
+    #[tokio::test]
+    async fn handler_never_exceeds_cap_under_concurrent_posts() {
+        // Drive the real handler with many concurrent requests against one
+        // shared AppState. The records Vec must never exceed `max_payloads`,
+        // even though several requests are accepted in-flight before any of
+        // them observe the cap being hit (#146 LOW).
+        let max = 3usize;
+        let state = Arc::new(AppState {
+            records: Mutex::new(Vec::new()),
+            max_payloads: Some(max),
+            done: Notify::new(),
+            auth_token: None,
+        });
+
+        let mut handles = Vec::new();
+        for i in 0..50 {
+            let st = Arc::clone(&state);
+            handles.push(tokio::spawn(async move {
+                let body = axum::body::Bytes::from(format!("{{\"id\":{i}}}"));
+                webhook_handler(State(st), axum::http::HeaderMap::new(), body).await
+            }));
+        }
+        for h in handles {
+            // Every request returns 200 (accepted or gracefully dropped — we
+            // don't surface a different status for drops to keep clients happy).
+            assert_eq!(h.await.unwrap(), StatusCode::OK);
+        }
+
+        let records = state.records.lock().await;
+        assert_eq!(
+            records.len(),
+            max,
+            "Vec must never exceed max_payloads, got {}",
+            records.len()
+        );
     }
 
     #[tokio::test]

--- a/docs/book/src/operations/tuning.md
+++ b/docs/book/src/operations/tuning.md
@@ -36,10 +36,12 @@ your database's connection limit.
 
 ## Retries
 
-HTTP-based sources retry with exponential backoff + jitter on retriable failures;
-the REST source additionally honors `429` / `Retry-After`. Tune `max_retries` and
-`retry_backoff` per connector. A permanently throttled endpoint surfaces a
-`RateLimited` error rather than hanging.
+HTTP-based sources retry with exponential backoff + jitter on retriable failures.
+The backoff is capped at 60s and its jitter is decorrelated across concurrent
+retries (so a fleet of matrix rows doesn't re-align into a thundering herd). The
+REST source additionally honors `429` / `Retry-After` (delta-seconds **or** an
+RFC 7231 HTTP-date). Tune `max_retries` and `retry_backoff` per connector. A
+permanently throttled endpoint surfaces a `RateLimited` error rather than hanging.
 
 ## Choosing values
 

--- a/faucet-stream/examples/elasticsearch_to_redis.rs
+++ b/faucet-stream/examples/elasticsearch_to_redis.rs
@@ -28,7 +28,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 password: std::env::var("ES_PASS")?,
             })
             .max_pages(500),
-    );
+    )?;
 
     let sink = RedisSink::new(
         RedisSinkConfig::new(

--- a/faucet-stream/examples/elasticsearch_to_s3.rs
+++ b/faucet-stream/examples/elasticsearch_to_s3.rs
@@ -27,7 +27,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 key: std::env::var("ES_API_KEY")?,
             })
             .max_pages(usize::MAX),
-    );
+    )?;
 
     let sink = S3Sink::new(
         S3SinkConfig::new("my-es-backups")

--- a/faucet-stream/examples/redis_to_mysql.rs
+++ b/faucet-stream/examples/redis_to_mysql.rs
@@ -27,7 +27,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             },
         )
         .max_records(100_000),
-    );
+    )?;
 
     let sink = MysqlSink::new(
         MysqlSinkConfig::new("mysql://user:pass@localhost/archive", "events_raw")

--- a/faucet-stream/examples/redis_to_sqlite.rs
+++ b/faucet-stream/examples/redis_to_sqlite.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             },
         )
         .max_records(10_000),
-    );
+    )?;
 
     let sink = SqliteSink::new(
         SqliteSinkConfig::new("sqlite:./cache.db", "jobs")


### PR DESCRIPTION
## Summary

Consolidated thematic PR for the confirmed-real LOW/NIT `[R]` backlog from #146 — the **core & connector correctness** bucket (groups B + C + D of the triage). Every item was re-verified against `HEAD` (the audit's `[R]` items were finder-reported, "confirm before patching"), then fixed test-first.

Refs #146. (Sibling PR for serve/observability/scheduler + docs follows.)

## B — Retry / backoff
- `core::retry::execute_with_retry` had **no max-backoff cap** (`base*2^attempt` saturates → effectively unbounded sleeps) → cap the exponential at **60s**.
- Retry **jitter entropy** was the clock's sub-second component alone → two retries in the same nanosecond drew identical jitter (thundering herd). Mix in a monotonic per-call counter (splitmix64) so concurrent retries **decorrelate**.
- The **REST source duplicated** the jitter with the `u32::MAX` **range-bias** (factor ≤ ~0.733, never `[0.5,1.5)`) + a panicking `2u32.pow`. Promote `core::retry::backoff_with_jitter` to `pub` (one tested impl) and have REST delegate.
- REST `parse_retry_after` parsed **only delta-seconds**; now also honours the RFC 7231 **HTTP-date** form (`httpdate`), past date → zero wait.

## C — `batch_size` validation at construction (11 connectors)
Eight source/sink constructors never called `validate_batch_size`, silently accepting an out-of-range value. Added `faucet_core::validate_batch_size(config.batch_size)?` as the first statement of every connector's `new()`:
- Result-returning (inline): postgres, mysql, sqlite, bigquery, mongodb sources; s3, mongodb, redis sinks.
- Previously infallible `Self`-returning → now `Result<Self, FaucetError>` (no I/O): **snowflake, redis, elasticsearch** sources — `registry.rs`, integration-test, and umbrella-example call sites updated for the signature change.
- Each connector gains a `new_rejects_out_of_range_batch_size` test.

## D — Connector error-kind & reliability bugs
- **S3 / MongoDB / Redis sources**: runtime I/O failures were `FaucetError::Config` → remap to `FaucetError::Source` (Config reserved for validation; GCS is the reference). URL-parse stays `Config`.
- **GCS source**: `max_objects` ignored when `object_keys` set → apply the cap to the explicit list (testable `cap_keys`).
- **GraphQL source**: `data: null` emitted a bogus null record → now an empty page.
- **Webhook**: could exceed `max_payloads` under concurrent POSTs → exact cap via a testable `decide_payload` under the lock (+ concurrency test).
- **Snowflake sink**: poll loop reused the submit-time token → re-resolve auth each poll iteration (survives OAuth-token rotation on a long async statement).
- **MSSQL sink**: don't issue `ROLLBACK` on a connection desynced by a statement **timeout** (pool contract: drop it); ROLLBACK still runs on a normal in-sync error. `u64 > i64::MAX` no longer wraps to a negative `i64` (bind as string → NUMERIC). `json_column` serialize errors propagate instead of being swallowed to `""`.
- **SQLite sink**: default `max_connections` 5 → **1** (single-writer DB) + WAL journal mode + 5s busy_timeout.

## Notes & deferrals
- Two LOW `[R]` items were split out as standalone enhancement issues (real, but design-level): **#160** (matrix fan-out memory buffering) and **#161** (S3/GCS read checksum). Several finder items were dropped as already-fixed or false-positive (see #146 triage).
- `httpdate` (MIT/Apache, already transitive) added to `faucet-source-rest`.
- Docs synced: REST README + `operations/tuning.md` (backoff/Retry-After); SQLite-sink README (`max_connections` default + WAL).

## Testing
- Test-first (RED→GREEN) per item; backoff cap, jitter decorrelation, HTTP-date, GCS cap, GraphQL null, webhook cap, MSSQL u64, SQLite default all have focused tests.
- `cargo fmt --all --check` clean. `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps` clean. Every touched crate's test suite passes; the 3 signature-changed source crates' integration tests + the 4 umbrella examples compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
