### PR TITLE
fix(#146): LOW/NIT backlog — serve/scheduler/observability + doctor probe + docs

### DIFF
--- a/cli/src/commands/schedule.rs
+++ b/cli/src/commands/schedule.rs
@@ -281,6 +281,15 @@ async fn run_loop(
         "scheduler started (Ctrl-C / SIGTERM to stop)"
     );
 
+    // Register HELP text and pre-emit the two run-state gauges at 0 so both
+    // series exist in `/metrics` from t=0 — the `metrics` exporter only renders
+    // a series after its first emission, and these gauges are otherwise first
+    // touched mid/post-run, leaving a pre-first-run scrape blind to them
+    // (#146 R NIT).
+    m::describe();
+    m::in_flight(&pipeline_name, 0);
+    m::consecutive_failures(&pipeline_name, 0);
+
     loop {
         let now = Utc::now();
 
@@ -319,6 +328,10 @@ async fn run_loop(
                 }
                 TickAction::ForbidAbort => {
                     m::overlap(&pipeline_name, "forbid");
+                    // A prior `Dispatch` set the in-flight gauge to 1; reset it
+                    // before we bail so `/metrics` doesn't read a stuck 1 after
+                    // the scheduler exits (#146 R LOW).
+                    m::in_flight(&pipeline_name, 0);
                     return Err(CliError::ScheduleOverlapForbidden);
                 }
             }

--- a/cli/src/schedule/metrics.rs
+++ b/cli/src/schedule/metrics.rs
@@ -3,8 +3,54 @@
 //! metrics in `faucet-core`. No-ops when no recorder is installed.
 
 use chrono::{DateTime, Utc};
-use metrics::{counter, gauge, histogram};
+use metrics::{counter, describe_counter, describe_gauge, describe_histogram, gauge, histogram};
 use std::time::Duration;
+
+/// Register HELP text for every scheduler metric. Idempotent — safe to call
+/// more than once. Called from the scheduler loop at startup so the series'
+/// descriptions are present in `/metrics` from t=0, even before the first tick.
+pub fn describe() {
+    describe_counter!(
+        "faucet_schedule_runs_total",
+        "Scheduled pipeline runs, by outcome (ok|err|skipped)."
+    );
+    describe_counter!(
+        "faucet_schedule_overlaps_total",
+        "Scheduler ticks that overlapped an in-flight run, by policy (skip|queue|forbid)."
+    );
+    describe_gauge!(
+        "faucet_schedule_next_tick_unix_seconds",
+        "Unix timestamp of the next scheduled tick."
+    );
+    describe_gauge!(
+        "faucet_schedule_runs_in_flight",
+        "Scheduled runs currently executing (0 or 1)."
+    );
+    describe_gauge!(
+        "faucet_schedule_consecutive_failures",
+        "Consecutive failed scheduled runs since the last success."
+    );
+    describe_gauge!(
+        "faucet_schedule_heartbeat_unix_seconds",
+        "Unix timestamp the scheduler loop last ran (alert if it stalls)."
+    );
+    describe_gauge!(
+        "faucet_schedule_last_run_started_unix_seconds",
+        "Unix timestamp the most recent run started."
+    );
+    describe_gauge!(
+        "faucet_schedule_last_run_completed_unix_seconds",
+        "Unix timestamp the most recent run completed."
+    );
+    describe_gauge!(
+        "faucet_schedule_last_run_duration_seconds",
+        "Wall-clock duration of the most recent run."
+    );
+    describe_histogram!(
+        "faucet_schedule_run_lateness_seconds",
+        "How late each run started relative to its scheduled tick."
+    );
+}
 
 /// `outcome ∈ {"ok", "err", "skipped"}`.
 pub fn run_outcome(pipeline: &str, outcome: &'static str) {
@@ -57,4 +103,89 @@ pub fn lateness(pipeline: &str, late: chrono::Duration) {
     let secs = (late.num_milliseconds() as f64 / 1000.0).max(0.0);
     histogram!("faucet_schedule_run_lateness_seconds", "pipeline" => pipeline.to_string())
         .record(secs);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use metrics::with_local_recorder;
+    use metrics_util::debugging::{DebugValue, DebuggingRecorder};
+
+    /// Find the latest gauge value emitted for `name` with the given `pipeline`
+    /// label in a `DebuggingRecorder` snapshot.
+    fn gauge_value(
+        snapshot: metrics_util::debugging::Snapshot,
+        name: &str,
+        pipeline: &str,
+    ) -> Option<f64> {
+        snapshot
+            .into_vec()
+            .into_iter()
+            .find_map(|(key, _u, _d, v)| {
+                let k = key.key();
+                let labelled = k
+                    .labels()
+                    .any(|l| l.key() == "pipeline" && l.value() == pipeline);
+                if k.name() == name && labelled {
+                    match v {
+                        DebugValue::Gauge(g) => Some(g.into_inner()),
+                        _ => None,
+                    }
+                } else {
+                    None
+                }
+            })
+    }
+
+    #[test]
+    fn in_flight_sets_gauge() {
+        let recorder = DebuggingRecorder::new();
+        let snap = recorder.snapshotter();
+        with_local_recorder(&recorder, || {
+            in_flight("p", 1);
+            in_flight("p", 0);
+        });
+        assert_eq!(
+            gauge_value(snap.snapshot(), "faucet_schedule_runs_in_flight", "p"),
+            Some(0.0),
+            "in_flight(0) must leave the gauge at 0"
+        );
+    }
+
+    #[test]
+    fn consecutive_failures_sets_gauge() {
+        let recorder = DebuggingRecorder::new();
+        let snap = recorder.snapshotter();
+        with_local_recorder(&recorder, || {
+            consecutive_failures("p", 0);
+        });
+        assert_eq!(
+            gauge_value(snap.snapshot(), "faucet_schedule_consecutive_failures", "p"),
+            Some(0.0),
+            "consecutive_failures(0) must register the series at 0"
+        );
+    }
+
+    /// Mirrors what the scheduler does at startup (item 2): pre-emit both gauges
+    /// so the series exist in `/metrics` before the first dispatch.
+    #[test]
+    fn startup_preemit_registers_both_gauges_at_zero() {
+        let recorder = DebuggingRecorder::new();
+        let snap = recorder.snapshotter();
+        with_local_recorder(&recorder, || {
+            describe();
+            in_flight("p", 0);
+            consecutive_failures("p", 0);
+        });
+        assert_eq!(
+            gauge_value(snap.snapshot(), "faucet_schedule_runs_in_flight", "p"),
+            Some(0.0),
+            "runs_in_flight must exist at 0 from startup"
+        );
+        assert_eq!(
+            gauge_value(snap.snapshot(), "faucet_schedule_consecutive_failures", "p"),
+            Some(0.0),
+            "consecutive_failures must exist at 0 from startup"
+        );
+    }
 }

--- a/cli/src/serve/config.rs
+++ b/cli/src/serve/config.rs
@@ -129,6 +129,20 @@ impl ServeConfig {
             ));
         }
 
+        // A zero drain window makes graceful shutdown `timeout(Duration::ZERO,
+        // wait_drained())` time out instantly and cancel in-flight runs —
+        // defeating the drain. Reject it (mirroring the lease-ttl gate).
+        // `--idempotency-retention-secs == 0` is NOT rejected: it is an explicit
+        // "dedup disabled" sentinel (every prior claim is immediately expired).
+        if args.shutdown_grace_secs == 0 {
+            return Err(CliError::Serve(
+                "--shutdown-grace-secs must be > 0 (0 makes graceful shutdown cancel \
+                 in-flight runs immediately instead of draining them; use a small \
+                 value like 1)"
+                    .into(),
+            ));
+        }
+
         let max_concurrent_runs = args
             .max_concurrent_runs
             .unwrap_or_else(default_max_concurrent)
@@ -307,5 +321,37 @@ mod tests {
         a.lease_ttl_secs = 45;
         let cfg = ServeConfig::from_args(a).unwrap();
         assert_eq!(cfg.lease_ttl, Duration::from_secs(45));
+    }
+
+    #[test]
+    fn zero_shutdown_grace_is_rejected() {
+        // A zero drain window makes graceful shutdown `timeout(Duration::ZERO,
+        // wait_drained())` cancel in-flight runs instantly — defeating the
+        // drain. Reject it the same way the lease-ttl gate does.
+        let mut a = base_args();
+        a.no_auth = true;
+        a.shutdown_grace_secs = 0;
+        let err = ServeConfig::from_args(a).unwrap_err();
+        assert!(err.to_string().contains("--shutdown-grace-secs"), "{err}");
+    }
+
+    #[test]
+    fn nonzero_shutdown_grace_is_accepted() {
+        let mut a = base_args();
+        a.no_auth = true;
+        a.shutdown_grace_secs = 5;
+        let cfg = ServeConfig::from_args(a).unwrap();
+        assert_eq!(cfg.shutdown_grace, Duration::from_secs(5));
+    }
+
+    #[test]
+    fn zero_idempotency_retention_is_accepted_as_dedup_disabled_sentinel() {
+        // `idempotency_retention_secs == 0` is an explicit "dedup disabled"
+        // sentinel (every prior claim is immediately expired), NOT an error.
+        let mut a = base_args();
+        a.no_auth = true;
+        a.idempotency_retention_secs = 0;
+        let cfg = ServeConfig::from_args(a).unwrap();
+        assert_eq!(cfg.idempotency_retention, Duration::ZERO);
     }
 }

--- a/cli/src/serve/registry.rs
+++ b/cli/src/serve/registry.rs
@@ -70,6 +70,17 @@ impl Registry {
         self.drained.notify_waiters();
     }
 
+    /// Queued → terminal: a run was cancelled (or the server shut down) while
+    /// still waiting for an execution permit, so it never became in-flight.
+    /// Release its **queue** slot (not `in_flight`), drop the token, and wake any
+    /// drain waiter. Distinct from [`Self::mark_finished`], which decrements
+    /// `in_flight` (#146 R: a cancel on a queued run now takes effect at once).
+    pub fn mark_queued_cancelled(&self, run_id: &str) {
+        self.queued.fetch_sub(1, Ordering::AcqRel);
+        self.tokens.remove(run_id);
+        self.drained.notify_waiters();
+    }
+
     /// Cancel a live run. Returns `true` if a live token existed.
     pub fn cancel(&self, run_id: &str) -> bool {
         if let Some(t) = self.tokens.get(run_id) {

--- a/cli/src/serve/runner.rs
+++ b/cli/src/serve/runner.rs
@@ -75,11 +75,6 @@ pub async fn submit(state: ServerState, req: SubmitRequest) -> Result<SubmitResp
     let format: ConfigFormat = req.config_format.into();
     let loaded = load_submission(&req.config, format, state.default_base()).await?;
 
-    // doctor_first preflight (before reserving any slot or claiming the key).
-    if req.doctor_first {
-        run_doctor_first(&state, &loaded).await?;
-    }
-
     // Reserve a queue slot first, so a Fresh idempotency claim is always followed
     // by a spawned run (no orphaned claims — spec §20.2).
     if !state.registry().try_reserve() {
@@ -87,9 +82,20 @@ pub async fn submit(state: ServerState, req: SubmitRequest) -> Result<SubmitResp
             retry_after_secs: QUEUE_FULL_RETRY_AFTER_SECS,
         });
     }
-    // Releases the reservation on ANY early return below (replay / conflict /
-    // claim or upsert error). Defused just before the run is spawned.
+    // Releases the reservation on ANY early return below (doctor_first 422 /
+    // replay / conflict / claim or upsert error). Defused just before spawn.
     let reservation = ReservationGuard::new(state.clone());
+
+    // doctor_first preflight — run BEHIND the reservation so concurrent preflight
+    // probing is bounded by `max_queued_runs` rather than running unthrottled
+    // before any limit applies (#146 R). On failure the guard releases the slot
+    // via the early `?`. The (redacted) report is stored on the run record below
+    // so `GET /v1/runs/{id}` exposes it (#146 R: doctor_report was never set).
+    let doctor_report = if req.doctor_first {
+        Some(run_doctor_first(&state, &loaded).await?)
+    } else {
+        None
+    };
 
     let run_id = uuid::Uuid::now_v7().to_string();
 
@@ -137,13 +143,14 @@ pub async fn submit(state: ServerState, req: SubmitRequest) -> Result<SubmitResp
     }
 
     let submitted_at = Utc::now();
-    let rec = RunRecord::queued(
+    let mut rec = RunRecord::queued(
         run_id.clone(),
         req.name.clone(),
         req.labels.clone(),
         req.idempotency_key.clone(),
         submitted_at,
     );
+    rec.doctor_report = doctor_report;
     state
         .history()
         .upsert(&rec)
@@ -173,10 +180,13 @@ pub async fn submit(state: ServerState, req: SubmitRequest) -> Result<SubmitResp
 }
 
 /// Run the `doctor_first` probes; on any failure return 422 with the report.
+/// Run the `doctor_first` probes. On success returns the (redacted) report so
+/// the caller can store it on the run record (`doctor_report`); on any probe
+/// failure returns 422 with the same redacted report as `details`.
 async fn run_doctor_first(
     state: &ServerState,
     loaded: &LoadedSubmission,
-) -> Result<(), ServeError> {
+) -> Result<serde_json::Value, ServeError> {
     use faucet_core::check::CheckContext;
     let auth =
         build_auth_catalog(loaded.cfg.auth.as_ref()).map_err(|e| ServeError::Unprocessable {
@@ -188,14 +198,17 @@ async fn run_doctor_first(
     };
     let mut invs = crate::commands::doctor::probe_roots(&loaded.nodes, &auth, &ctx).await;
     let failed = crate::commands::doctor::count_failures(&invs);
+    // Redact regardless of outcome — the report is surfaced either way (as the
+    // 422 `details` on failure, or stored on the run record on success).
+    crate::commands::doctor::redact_invocations(&mut invs);
+    let report = serde_json::json!({ "invocations": invs });
     if failed > 0 {
-        crate::commands::doctor::redact_invocations(&mut invs);
         return Err(ServeError::Unprocessable {
             message: format!("doctor_first preflight failed: {failed} probe(s) failed"),
-            details: Some(serde_json::json!({ "invocations": invs })),
+            details: Some(report),
         });
     }
-    Ok(())
+    Ok(report)
 }
 
 /// Build the replay response for an idempotency hit (the existing run's status).
@@ -373,11 +386,23 @@ fn spawn_run(
     let LoadedSubmission { cfg, nodes } = loaded;
 
     tokio::spawn(async move {
-        let _permit = state
-            .semaphore()
-            .acquire_owned()
-            .await
-            .expect("semaphore not closed");
+        // Race the permit acquisition against cancel / shutdown so a run
+        // cancelled while STILL QUEUED (before any permit frees) is finalized
+        // immediately, instead of only after it eventually acquires a permit
+        // (#146 R). `biased` prefers the cancel/shutdown signals over a
+        // simultaneously-available permit.
+        let _permit = tokio::select! {
+            biased;
+            _ = run_token.cancelled() => {
+                finalize_queued_cancel(&state, &run_id, submitted_at, Terminal::Cancelled).await;
+                return;
+            }
+            _ = server_shutdown.cancelled() => {
+                finalize_queued_cancel(&state, &run_id, submitted_at, Terminal::ShutdownFailed).await;
+                return;
+            }
+            permit = state.semaphore().acquire_owned() => permit.expect("semaphore not closed"),
+        };
 
         // Queued → running. From here the guard guarantees `mark_finished` (and a
         // gauge refresh) on EVERY exit, including early returns and panics.
@@ -556,6 +581,24 @@ async fn finalize(state: &ServerState, run_id: &str, started: DateTime<Utc>, ter
         );
     }
     metrics::record_run_finished(status, reason);
+}
+
+/// Finalize a run that was cancelled / hit shutdown while still QUEUED (before
+/// it acquired an execution permit, so it never became in-flight and has no
+/// `InFlightGuard`). Releases the queue slot, writes the terminal record, closes
+/// the log buffer, and refreshes the gauges — the queued-path analogue of the
+/// normal `finalize` + `InFlightGuard`-drop cleanup.
+async fn finalize_queued_cancel(
+    state: &ServerState,
+    run_id: &str,
+    submitted_at: DateTime<Utc>,
+    term: Terminal,
+) {
+    state.registry().mark_queued_cancelled(run_id);
+    finalize(state, run_id, submitted_at, term).await;
+    state.log_hub().finish(run_id);
+    schedule_log_drop(state.clone(), run_id.to_string());
+    metrics::set_run_gauges(state);
 }
 
 /// Spawn a detached timer that drops a finished run's log buffer after the drain

--- a/cli/tests/serve_lifecycle.rs
+++ b/cli/tests/serve_lifecycle.rs
@@ -291,3 +291,176 @@ async fn cancel_transitions_to_cancelled() {
     }
     assert_eq!(status, "cancelled", "run must transition to 'cancelled'");
 }
+
+/// `doctor_first: true` against a healthy pipeline must store the (redacted)
+/// preflight report on the run record, so `GET /v1/runs/{id}` exposes
+/// `doctor_report` (#146 R: the field was declared but never populated).
+#[tokio::test]
+async fn doctor_first_success_populates_doctor_report() {
+    let port = free_port();
+    spawn_server(port, None).await;
+    let client = reqwest::Client::new();
+    let base = format!("http://127.0.0.1:{port}");
+
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("in.csv");
+    std::fs::write(&input, "name\nalice\n").unwrap();
+    let output = dir.path().join("out.jsonl");
+    let body = serde_json::json!({
+        "config": csv_to_jsonl_yaml(&input, &output),
+        "doctor_first": true,
+    });
+    let submit: serde_json::Value = client
+        .post(format!("{base}/v1/runs"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let run_id = submit["run_id"].as_str().unwrap().to_string();
+
+    let rec: serde_json::Value = client
+        .get(format!("{base}/v1/runs/{run_id}"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert!(
+        rec["doctor_report"]["invocations"].is_array(),
+        "a doctor_first run must expose its preflight report; got:\n{rec:#}"
+    );
+}
+
+/// Cancelling a run that is still QUEUED (no execution permit yet) must finalize
+/// it as `cancelled` promptly — not only after a permit frees. With
+/// `max_concurrent_runs=1`, a blocking run holds the sole permit so a second run
+/// stays queued; before the #146 fix the queued run's cancel was ignored until
+/// the permit freed (here: never, since the blocker runs for an hour), so this
+/// test would hang/fail.
+#[tokio::test(flavor = "multi_thread")]
+async fn cancel_of_queued_run_transitions_to_cancelled() {
+    let port = free_port();
+    let mut config = ServeConfig::from_args({
+        let mut a = args_on(port, None);
+        a.max_concurrent_runs = Some(1);
+        a
+    })
+    .unwrap();
+    config.log_level = "warn".into();
+    tokio::spawn(async move {
+        let _ = faucet_cli::serve::run_server(config).await;
+    });
+    let client = reqwest::Client::new();
+    for _ in 0..100 {
+        if client
+            .get(format!("http://127.0.0.1:{port}/healthz"))
+            .send()
+            .await
+            .map(|r| r.status().is_success())
+            .unwrap_or(false)
+        {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    let base = format!("http://127.0.0.1:{port}");
+
+    // Run A: a webhook source that blocks for an hour, taking the only permit.
+    let webhook_port = free_port();
+    let dir = tempfile::tempdir().unwrap();
+    let block_cfg = format!(
+        "version: 1\npipeline:\n  source:\n    type: webhook\n    config:\n      listen_addr: \"127.0.0.1:{webhook_port}\"\n      timeout_secs: 3600\n  sink:\n    type: jsonl\n    config:\n      path: \"{}\"\n",
+        dir.path().join("a.jsonl").display(),
+    );
+    let a_id = client
+        .post(format!("{base}/v1/runs"))
+        .json(&serde_json::json!({ "config": block_cfg }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap()["run_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    for _ in 0..200 {
+        let rec: serde_json::Value = client
+            .get(format!("{base}/v1/runs/{a_id}"))
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        if rec["status"] == "running" {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+
+    // Run B: a trivial csv→jsonl run that stays QUEUED behind A's permit.
+    let input = dir.path().join("in.csv");
+    std::fs::write(&input, "name\nbob\n").unwrap();
+    let b_id = client
+        .post(format!("{base}/v1/runs"))
+        .json(&serde_json::json!({ "config": csv_to_jsonl_yaml(&input, &dir.path().join("b.jsonl")) }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap()["run_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    let b_rec: serde_json::Value = client
+        .get(format!("{base}/v1/runs/{b_id}"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(
+        b_rec["status"], "queued",
+        "B must be queued behind the single permit; got:\n{b_rec:#}"
+    );
+
+    // Cancel the QUEUED run → must converge to cancelled while A still blocks.
+    let c = client
+        .post(format!("{base}/v1/runs/{b_id}/cancel"))
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        c.status() == 202 || c.status() == 200,
+        "cancel status {}",
+        c.status()
+    );
+    let mut status = String::new();
+    for _ in 0..200 {
+        let rec: serde_json::Value = client
+            .get(format!("{base}/v1/runs/{b_id}"))
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        status = rec["status"].as_str().unwrap_or("").to_string();
+        if status == "cancelled" {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    assert_eq!(
+        status, "cancelled",
+        "a queued run must cancel promptly without waiting for a permit (#146 R E6)"
+    );
+}

--- a/crates/core/src/observability/bookmark.rs
+++ b/crates/core/src/observability/bookmark.rs
@@ -3,6 +3,18 @@
 //! `faucet_pipeline_last_bookmark_unix_seconds` (epoch seconds of the
 //! bookmark) and `faucet_pipeline_seconds_since_last_bookmark` (now - that).
 //! Non-string / non-RFC3339 bookmarks leave the gauges untouched.
+//!
+//! **Intentional staleness of `faucet_pipeline_seconds_since_last_bookmark`.**
+//! That gauge is computed *only at bookmark-write time*, so it captures the lag
+//! observed at the moment the last bookmark was persisted — it does **not**
+//! advance on its own between writes. When a pipeline stalls (no new bookmarks),
+//! this gauge freezes at its last value rather than climbing, by design: it
+//! reports recency-at-write, not live lag, and recomputing it on every scrape
+//! would require a background ticker this layer intentionally avoids. For live
+//! stall detection, alert on the freshness of the absolute timestamp instead —
+//! `time() - faucet_pipeline_last_bookmark_unix_seconds` grows continuously
+//! while a pipeline is wedged (Prometheus evaluates `time()` at scrape time, so
+//! no in-process ticker is needed).
 
 use crate::observability::labels::Labels;
 use metrics::{Label, SharedString, gauge};

--- a/crates/core/src/observability/decorator.rs
+++ b/crates/core/src/observability/decorator.rs
@@ -18,6 +18,25 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use tracing::{Instrument, info_span};
 
+/// Guard an inner connector's `connector_name()` so an empty string maps to
+/// the `"unknown"` fallback. Used both for the `connector` metric label and the
+/// `connector_name()` passthrough so the two never disagree.
+fn guarded_connector_name(raw: &'static str) -> &'static str {
+    if raw.is_empty() { "unknown" } else { raw }
+}
+
+/// Build the base `pipeline` / `row` / `connector` label vec once. The two
+/// `pipeline` / `row` heap allocations and the vec construction happen a single
+/// time at decorator construction; per-call sites `clone()` this instead of
+/// rebuilding from the `Arc<str>` labels on every page / write / flush.
+fn base_metric_labels(labels: &Labels, connector: &SharedString) -> Vec<Label> {
+    vec![
+        Label::new("pipeline", SharedString::from(labels.pipeline.to_string())),
+        Label::new("row", SharedString::from(labels.row.to_string())),
+        Label::new("connector", connector.clone()),
+    ]
+}
+
 /// Wraps a `&dyn Source` (or any `&S: Source`) and emits spans + metrics
 /// around every call. Constructed by `Pipeline::run` and never exposed to
 /// end users; the wrapped source remains the user-facing object.
@@ -25,6 +44,8 @@ pub struct InstrumentedSource<'a, S: Source + ?Sized> {
     inner: &'a S,
     labels: Labels,
     connector: SharedString,
+    /// Precomputed `pipeline` / `row` / `connector` labels, cloned per call.
+    base_labels: Vec<Label>,
     page_index: Arc<AtomicUsize>,
 }
 
@@ -35,25 +56,19 @@ impl<'a, S: Source + ?Sized> InstrumentedSource<'a, S> {
             !raw.is_empty(),
             "connector_name() must return a non-empty string"
         );
-        let connector: SharedString =
-            SharedString::const_str(if raw.is_empty() { "unknown" } else { raw });
+        let connector: SharedString = SharedString::const_str(guarded_connector_name(raw));
+        let base_labels = base_metric_labels(&labels, &connector);
         Self {
             inner,
             labels,
             connector,
+            base_labels,
             page_index: Arc::new(AtomicUsize::new(0)),
         }
     }
 
     fn metric_labels(&self) -> Vec<Label> {
-        vec![
-            Label::new(
-                "pipeline",
-                SharedString::from(self.labels.pipeline.to_string()),
-            ),
-            Label::new("row", SharedString::from(self.labels.row.to_string())),
-            Label::new("connector", self.connector.clone()),
-        ]
+        self.base_labels.clone()
     }
 
     /// Returns `metric_labels()` with an additional `kind` label appended.
@@ -70,7 +85,10 @@ impl<'a, S: Source + ?Sized> InstrumentedSource<'a, S> {
 #[async_trait]
 impl<'a, S: Source + ?Sized> Source for InstrumentedSource<'a, S> {
     fn connector_name(&self) -> &'static str {
-        self.inner.connector_name()
+        // Return the guarded name so an inner connector that returns "" maps to
+        // the "unknown" fallback — keeping this passthrough consistent with the
+        // `connector` metric label rather than leaking an empty string.
+        guarded_connector_name(self.inner.connector_name())
     }
 
     fn state_key(&self) -> Option<String> {
@@ -132,7 +150,11 @@ impl<'a, S: Source + ?Sized> Source for InstrumentedSource<'a, S> {
                     connector = %connector,
                     page_index = idx,
                 );
-                let _timer = DurationGuard::new(
+                // Armed across the poll so a cancelled / panicking page-fetch
+                // still records the time spent. Disarmed on the terminal empty
+                // poll (`Ok(None)`) so end-of-stream doesn't record a spurious
+                // ~0 sample into the page-duration histogram.
+                let mut _timer = DurationGuard::new(
                     "faucet_source_page_duration_seconds",
                     metric_labels.clone(),
                 );
@@ -158,7 +180,10 @@ impl<'a, S: Source + ?Sized> Source for InstrumentedSource<'a, S> {
                         counter!("faucet_source_errors_total", l).increment(1);
                         Err(e)?;
                     }
-                    Ok(None) => break,
+                    Ok(None) => {
+                        _timer.disarm();
+                        break;
+                    }
                     Err(panic) => {
                         let mut l = metric_labels.clone();
                         l.push(Label::new("kind", SharedString::const_str("Panic")));
@@ -201,6 +226,8 @@ pub struct InstrumentedSink<'a, S: Sink + ?Sized> {
     inner: &'a S,
     labels: Labels,
     connector: SharedString,
+    /// Precomputed `pipeline` / `row` / `connector` labels, cloned per call.
+    base_labels: Vec<Label>,
 }
 
 impl<'a, S: Sink + ?Sized> InstrumentedSink<'a, S> {
@@ -210,24 +237,18 @@ impl<'a, S: Sink + ?Sized> InstrumentedSink<'a, S> {
             !raw.is_empty(),
             "connector_name() must return a non-empty string"
         );
-        let connector: SharedString =
-            SharedString::const_str(if raw.is_empty() { "unknown" } else { raw });
+        let connector: SharedString = SharedString::const_str(guarded_connector_name(raw));
+        let base_labels = base_metric_labels(&labels, &connector);
         Self {
             inner,
             labels,
             connector,
+            base_labels,
         }
     }
 
     fn metric_labels(&self) -> Vec<Label> {
-        vec![
-            Label::new(
-                "pipeline",
-                SharedString::from(self.labels.pipeline.to_string()),
-            ),
-            Label::new("row", SharedString::from(self.labels.row.to_string())),
-            Label::new("connector", self.connector.clone()),
-        ]
+        self.base_labels.clone()
     }
 
     fn error_labels(&self, kind: &'static str) -> Vec<Label> {
@@ -240,7 +261,10 @@ impl<'a, S: Sink + ?Sized> InstrumentedSink<'a, S> {
 #[async_trait]
 impl<'a, S: Sink + ?Sized> Sink for InstrumentedSink<'a, S> {
     fn connector_name(&self) -> &'static str {
-        self.inner.connector_name()
+        // Return the guarded name so an inner connector that returns "" maps to
+        // the "unknown" fallback — keeping this passthrough consistent with the
+        // `connector` metric label rather than leaking an empty string.
+        guarded_connector_name(self.inner.connector_name())
     }
 
     async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
@@ -462,6 +486,43 @@ pub(crate) mod source_tests {
         }
     }
 
+    // Inner connector that returns an empty name. The instrumented wrapper must
+    // map this to the `"unknown"` fallback so the `connector_name()` passthrough
+    // never disagrees with the `connector` metric label.
+    struct EmptyNameSource;
+    #[async_trait]
+    impl Source for EmptyNameSource {
+        async fn fetch_with_context(
+            &self,
+            _: &HashMap<String, Value>,
+        ) -> Result<Vec<Value>, FaucetError> {
+            Ok(vec![])
+        }
+        fn connector_name(&self) -> &'static str {
+            ""
+        }
+    }
+
+    #[test]
+    fn empty_inner_connector_name_falls_back_to_unknown() {
+        let inner = EmptyNameSource;
+        // `InstrumentedSource::new` debug_asserts on an empty inner name, so
+        // build the wrapper directly with the fallback name to exercise the
+        // passthrough without tripping the assertion in debug builds.
+        let wrapped = InstrumentedSource {
+            inner: &inner,
+            labels: labels(),
+            connector: SharedString::const_str("unknown"),
+            base_labels: Vec::new(),
+            page_index: Arc::new(AtomicUsize::new(0)),
+        };
+        assert_eq!(
+            Source::connector_name(&wrapped),
+            "unknown",
+            "instrumented source must not leak an empty connector name"
+        );
+    }
+
     #[tokio::test]
     #[allow(clippy::await_holding_lock)]
     async fn records_records_counter_per_page() {
@@ -488,6 +549,63 @@ pub(crate) mod source_tests {
         assert!(
             records >= 5,
             "expected at least 5 records counted, got {records}"
+        );
+    }
+
+    // Source with a unique connector name so the page-duration histogram for
+    // this run can be isolated in the shared global recorder.
+    struct PageCountSource(Vec<Value>);
+    #[async_trait]
+    impl Source for PageCountSource {
+        async fn fetch_with_context(
+            &self,
+            _: &HashMap<String, Value>,
+        ) -> Result<Vec<Value>, FaucetError> {
+            Ok(self.0.clone())
+        }
+        fn connector_name(&self) -> &'static str {
+            "page-count-probe"
+        }
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn page_duration_records_one_sample_per_yielded_page() {
+        // 5 records at batch_size 2 → pages [2, 2, 1] = 3 yielded pages. The
+        // terminal empty poll must NOT add a 4th (spurious ~0) sample.
+        let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let snap = snapshotter();
+        let inner = PageCountSource((0..5).map(|i| json!({"i": i})).collect());
+        let wrapped = InstrumentedSource::new(&inner, labels());
+        let ctx = HashMap::new();
+        let mut s = wrapped.stream_pages(&ctx, 2);
+        let mut pages = 0usize;
+        while s.next().await.is_some() {
+            pages += 1;
+        }
+        assert_eq!(pages, 3, "expected 3 yielded pages");
+
+        let snapshot = snap.snapshot();
+        let samples: usize = snapshot
+            .into_vec()
+            .into_iter()
+            .filter_map(|(key, _u, _d, v)| {
+                if key.key().name() == "faucet_source_page_duration_seconds"
+                    && key
+                        .key()
+                        .labels()
+                        .any(|l| l.key() == "connector" && l.value() == "page-count-probe")
+                    && let DebugValue::Histogram(h) = v
+                {
+                    return Some(h.len());
+                }
+                None
+            })
+            .sum();
+        assert_eq!(
+            samples, pages,
+            "page-duration histogram must have exactly one sample per yielded \
+             page ({pages}), not page+1 (no spurious terminal sample)"
         );
     }
 
@@ -538,6 +656,36 @@ mod sink_tests {
         fn connector_name(&self) -> &'static str {
             "failing-sink"
         }
+    }
+
+    struct EmptyNameSink;
+    #[async_trait]
+    impl Sink for EmptyNameSink {
+        async fn write_batch(&self, _: &[Value]) -> Result<usize, FaucetError> {
+            Ok(0)
+        }
+        fn connector_name(&self) -> &'static str {
+            ""
+        }
+    }
+
+    #[test]
+    fn empty_inner_connector_name_falls_back_to_unknown() {
+        let inner = EmptyNameSink;
+        // `InstrumentedSink::new` debug_asserts on an empty inner name, so build
+        // the wrapper directly with the fallback name to exercise the
+        // passthrough without tripping the assertion in debug builds.
+        let wrapped = InstrumentedSink {
+            inner: &inner,
+            labels: labels(),
+            connector: SharedString::const_str("unknown"),
+            base_labels: Vec::new(),
+        };
+        assert_eq!(
+            Sink::connector_name(&wrapped),
+            "unknown",
+            "instrumented sink must not leak an empty connector name"
+        );
     }
 
     #[tokio::test]

--- a/crates/core/src/observability/install.rs
+++ b/crates/core/src/observability/install.rs
@@ -54,8 +54,10 @@ pub enum InstallError {
 /// Behavior:
 /// - If `prometheus` is set, builds a `PrometheusBuilder` and installs the
 ///   recorder + HTTP `/metrics` endpoint at the configured listen address.
-///   Already-installed recorder is logged via `tracing::warn!` and continues.
-///   Listen-parse / bind failures return `InstallError`.
+///   Already-installed recorder (typed `BuildError::FailedToSetGlobalRecorder`)
+///   is logged via `tracing::warn!` and continues. Listen-address parse failures
+///   and HTTP-listener bind failures (e.g. port-in-use, typed
+///   `BuildError::FailedToCreateHTTPListener`) return `InstallError::PrometheusBind`.
 /// - If `tracing` is set, installs a `tracing-subscriber` registry with the
 ///   given env-filter directive as the default subscriber. Already-set-default
 ///   is logged via `tracing::warn!` and continues.
@@ -64,7 +66,7 @@ pub fn install_observability(cfg: &ObservabilityConfig) -> Result<InstallReport,
     let mut report = InstallReport::default();
 
     if let Some(p) = cfg.prometheus.as_ref() {
-        use metrics_exporter_prometheus::PrometheusBuilder;
+        use metrics_exporter_prometheus::{BuildError, PrometheusBuilder};
 
         let listen: std::net::SocketAddr =
             p.listen.parse().map_err(|e: std::net::AddrParseError| {
@@ -86,22 +88,29 @@ pub fn install_observability(cfg: &ObservabilityConfig) -> Result<InstallReport,
 
         match builder.install() {
             Ok(()) => report.prometheus_listen = Some(p.listen.clone()),
-            Err(e) => {
-                let msg = e.to_string();
-                // metrics-exporter-prometheus surfaces "already initialized"
-                // via BuildError::FailedToSetGlobalRecorder(SetRecorderError)
-                // whose Display is:
-                //   "attempted to set a recorder after the metrics system was
-                //    already initialized"
-                if msg.to_lowercase().contains("already")
-                    && msg.to_lowercase().contains("initialized")
-                {
+            // Match the TYPED `BuildError` variant rather than scraping its
+            // Display string — the latter breaks silently if the upstream
+            // wording changes.
+            Err(e) => match e {
+                // Recorder already installed (e.g. a prior `install` call or a
+                // test harness). Idempotent: warn and continue.
+                BuildError::FailedToSetGlobalRecorder(_) => {
                     tracing::warn!("Prometheus recorder already installed; continuing");
                     report.prometheus_already_installed = true;
-                } else {
-                    return Err(InstallError::PrometheusInstall(msg));
                 }
-            }
+                // The HTTP `/metrics` listener could not bind. This is where a
+                // genuine bind failure (e.g. EADDRINUSE / port-in-use) lands,
+                // since the real `TcpListener::bind` happens inside `install()`,
+                // not in the address parse above. Surface it as the dedicated
+                // bind error so port-in-use is reported correctly.
+                BuildError::FailedToCreateHTTPListener(msg) => {
+                    return Err(InstallError::PrometheusBind {
+                        listen: p.listen.clone(),
+                        source: std::io::Error::other(msg),
+                    });
+                }
+                other => return Err(InstallError::PrometheusInstall(other.to_string())),
+            },
         }
     }
 

--- a/crates/core/src/observability/timer.rs
+++ b/crates/core/src/observability/timer.rs
@@ -12,6 +12,7 @@ pub struct DurationGuard {
     name: KeyName,
     labels: Vec<Label>,
     started_at: Instant,
+    armed: bool,
 }
 
 impl DurationGuard {
@@ -20,7 +21,16 @@ impl DurationGuard {
             name: name.into(),
             labels,
             started_at: Instant::now(),
+            armed: true,
         }
+    }
+
+    /// Disarm the guard so dropping it records nothing. Used when the timed
+    /// span turns out not to represent real work — e.g. the terminal empty
+    /// poll at the end of a source page stream, which would otherwise record a
+    /// spurious ~0 sample into the page-duration histogram.
+    pub fn disarm(&mut self) {
+        self.armed = false;
     }
 
     /// Build the canonical (name, pipeline, row, connector) label trio.
@@ -43,6 +53,9 @@ impl DurationGuard {
 
 impl Drop for DurationGuard {
     fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
         let elapsed = self.started_at.elapsed().as_secs_f64();
         histogram!(self.name.clone(), self.labels.clone()).record(elapsed);
     }

--- a/crates/sink/s3/src/config.rs
+++ b/crates/sink/s3/src/config.rs
@@ -17,7 +17,10 @@ pub struct S3SinkConfig {
     pub endpoint_url: Option<String>,
     /// File extension for written objects (default: `.jsonl`).
     pub file_extension: String,
-    /// Maximum records per file. `None` writes all records to a single file.
+    /// Maximum records per file. `None` removes the per-file record cap — but
+    /// the sink still writes **one object per `write_batch` call** (i.e. one per
+    /// upstream page), and `batch_size` may chunk a call further; it does not
+    /// coalesce a streaming run into a single object.
     pub max_records_per_file: Option<usize>,
     /// Maximum number of concurrent file uploads (default: 10).
     pub concurrency: usize,

--- a/crates/source/bigquery/src/stream.rs
+++ b/crates/source/bigquery/src/stream.rs
@@ -188,6 +188,44 @@ impl faucet_core::Source for BigQuerySource {
             .expect("schema serialization")
     }
 
+    /// Preflight probe for `faucet doctor`. Overrides the default (which pulls a
+    /// page via `stream_pages` and would run the configured query — a **billed**
+    /// execution). Instead submits the same query with `dryRun: true`, which
+    /// validates auth, SQL syntax, and table/permission access **without
+    /// executing or billing** it.
+    async fn check(
+        &self,
+        ctx: &faucet_core::check::CheckContext,
+    ) -> Result<faucet_core::check::CheckReport, FaucetError> {
+        use faucet_core::check::{CheckReport, Probe};
+        let start = std::time::Instant::now();
+        let mut req =
+            build_query_request(&self.config, self.config.query.clone(), &self.config.params);
+        req.dry_run = Some(true);
+
+        let probe = async {
+            match self.client.job().query(&self.config.project_id, req).await {
+                Ok(_) => Ok::<Probe, Probe>(Probe::pass("query", start.elapsed())),
+                Err(e) => Err(Probe::fail_hint(
+                    "query",
+                    start.elapsed(),
+                    format!("BigQuery dry-run failed: {e}"),
+                    "verify credentials, project_id, dataset/table access, and the SQL",
+                )),
+            }
+        };
+        let probe = match tokio::time::timeout(ctx.timeout, probe).await {
+            Ok(Ok(p)) | Ok(Err(p)) => p,
+            Err(_elapsed) => Probe::fail_hint(
+                "query",
+                start.elapsed(),
+                "BigQuery dry-run timed out",
+                "BigQuery did not respond within the check timeout",
+            ),
+        };
+        Ok(CheckReport::single(probe))
+    }
+
     async fn fetch_with_context(
         &self,
         context: &HashMap<String, Value>,
@@ -445,6 +483,21 @@ mod tests {
         assert!(req.parameter_mode.is_none());
         assert!(!req.use_legacy_sql);
         assert_eq!(req.max_results, Some(1000));
+    }
+
+    #[test]
+    fn doctor_probe_request_is_dry_run() {
+        // The `faucet doctor` `check()` probe submits the configured query with
+        // dryRun=true so it validates auth/SQL/permissions without a billed
+        // execution — mirror that construction here to guard the field name.
+        let c = cfg();
+        let mut req = build_query_request(&c, "SELECT 1".to_string(), &[]);
+        req.dry_run = Some(true);
+        assert_eq!(
+            req.dry_run,
+            Some(true),
+            "doctor probe must dry-run (no billing)"
+        );
     }
 
     #[test]

--- a/crates/source/csv/src/stream.rs
+++ b/crates/source/csv/src/stream.rs
@@ -122,8 +122,11 @@ impl faucet_core::Source for CsvSource {
 
             while let Some(rec) = records.next().await {
                 let record = rec.map_err(|e| FaucetError::Config(format!(
-                    "CSV parse error at row {} in '{}': {e}",
-                    row_idx + 1,
+                    "CSV parse error at line {} in '{}': {e}",
+                    // Physical file line: `row_idx` is the 0-based *data* row, so
+                    // +1 for 1-based, and +1 more when a header row was consumed —
+                    // otherwise the first data row (file line 2) is misreported as 1.
+                    row_idx + 1 + usize::from(config.has_headers),
                     config.path
                 )))?;
 

--- a/crates/source/postgres-cdc/src/state.rs
+++ b/crates/source/postgres-cdc/src/state.rs
@@ -6,9 +6,11 @@
 //! { "last_lsn": "0/16A4F88" }
 //! ```
 //!
-//! `last_lsn` is the `commit_lsn` of the last transaction whose change
-//! records have been written to the sink — i.e. the position to resume
-//! *after* on the next `START_REPLICATION`.
+//! `last_lsn` is the **`end_lsn`** of the last committed transaction whose
+//! change records have been written to the sink — the WAL position immediately
+//! *after* that commit record, i.e. exactly where the next `START_REPLICATION`
+//! resumes. (It is the commit's `end_lsn`, not its `commit_lsn`; see the
+//! persist site in `stream.rs`.)
 
 use faucet_core::FaucetError;
 use serde::{Deserialize, Serialize};

--- a/crates/source/snowflake/src/stream.rs
+++ b/crates/source/snowflake/src/stream.rs
@@ -407,6 +407,74 @@ impl faucet_core::Source for SnowflakeSource {
             .expect("schema serialization")
     }
 
+    /// Preflight probe for `faucet doctor`. Overrides the default (which pulls a
+    /// page via `stream_pages` and would **execute the configured query**).
+    /// Instead submits a cheap `SELECT 1` so doctor validates auth, warehouse,
+    /// and connectivity without running the user's real statement.
+    async fn check(
+        &self,
+        ctx: &faucet_core::check::CheckContext,
+    ) -> Result<faucet_core::check::CheckReport, FaucetError> {
+        use faucet_core::check::{CheckReport, Probe};
+        let start = std::time::Instant::now();
+        let probe = async {
+            let mut body = self.build_request_body(&[]);
+            body["statement"] = Value::String("SELECT 1".to_string());
+            let url = self.statements_url();
+            let effective = self.resolve_auth().await.map_err(|e| {
+                Probe::fail_hint(
+                    "auth",
+                    start.elapsed(),
+                    e.to_string(),
+                    "verify the Snowflake credentials / shared auth provider",
+                )
+            })?;
+            let auth = authorization_header(&effective, &self.config.account)
+                .map_err(|e| Probe::fail("auth", start.elapsed(), e.to_string()))?;
+            let token_type = snowflake_token_type(&effective);
+            let resp = self
+                .client
+                .post(&url)
+                .header("Authorization", &auth)
+                .header("Content-Type", "application/json")
+                .header("Accept", "application/json")
+                .header("X-Snowflake-Authorization-Token-Type", token_type)
+                .json(&body)
+                .send()
+                .await
+                .map_err(|e| {
+                    Probe::fail_hint(
+                        "query",
+                        start.elapsed(),
+                        format!("Snowflake request failed: {e}"),
+                        "verify the account endpoint is reachable",
+                    )
+                })?;
+            let status = resp.status();
+            if status.is_success() || status.as_u16() == 202 {
+                Ok::<Probe, Probe>(Probe::pass("query", start.elapsed()))
+            } else {
+                let text = resp.text().await.unwrap_or_default();
+                Err(Probe::fail_hint(
+                    "query",
+                    start.elapsed(),
+                    format!("Snowflake SQL API returned HTTP {status}: {text}"),
+                    "verify credentials, warehouse, database/schema, and role",
+                ))
+            }
+        };
+        let probe = match tokio::time::timeout(ctx.timeout, probe).await {
+            Ok(Ok(p)) | Ok(Err(p)) => p,
+            Err(_elapsed) => Probe::fail_hint(
+                "query",
+                start.elapsed(),
+                "Snowflake probe timed out",
+                "Snowflake did not respond within the check timeout",
+            ),
+        };
+        Ok(CheckReport::single(probe))
+    }
+
     async fn fetch_with_context(
         &self,
         context: &HashMap<String, Value>,

--- a/crates/source/snowflake/tests/snowflake_source.rs
+++ b/crates/source/snowflake/tests/snowflake_source.rs
@@ -71,6 +71,35 @@ fn rows_for_partition(p: usize) -> Vec<Vec<Value>> {
 }
 
 #[tokio::test]
+async fn check_probes_with_select_1_not_the_configured_query() {
+    use faucet_core::check::{CheckContext, ProbeStatus};
+    use wiremock::matchers::body_partial_json;
+
+    let server = MockServer::start().await;
+    // Mock matches ONLY a `SELECT 1` statement body. If `check()` submitted the
+    // configured query ("SELECT id, name, active FROM events") — i.e. a billed
+    // execution — this mock would not match, wiremock would 404, and the probe
+    // would fail. A passing probe therefore proves the cheap `SELECT 1` is used.
+    Mock::given(method("POST"))
+        .and(path("/api/v2/statements"))
+        .and(body_partial_json(json!({"statement": "SELECT 1"})))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"code": "090001"})))
+        .mount(&server)
+        .await;
+
+    let source = build_source(cfg(), &server);
+    let report = source.check(&CheckContext::default()).await.unwrap();
+    assert!(
+        report
+            .probes
+            .iter()
+            .all(|p| matches!(p.status, ProbeStatus::Pass)),
+        "doctor probe must pass against the SELECT 1 mock (proving it didn't run \
+         the configured query): {report:?}"
+    );
+}
+
+#[tokio::test]
 async fn fetch_all_returns_first_partition_when_no_partitions() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))

--- a/crates/source/websocket/src/stream.rs
+++ b/crates/source/websocket/src/stream.rs
@@ -353,6 +353,12 @@ impl Source for WebsocketSource {
                     }
 
                     if reconnect_now {
+                        // At-most-once across a reconnect: a live WebSocket has no
+                        // replayable offset, so `continue 'outer` re-connects and
+                        // re-subscribes to the *current* stream — any frames the
+                        // server pushed during the disconnect gap are not replayed
+                        // and are lost. Inherent to live feeds (documented in the
+                        // README under "Not resumable"), not a bug.
                         if reconnect && max_attempts.is_none_or(|m| reconnect_attempts < m) {
                             reconnect_attempts += 1;
                             tracing::warn!(attempt = reconnect_attempts, "websocket source: reconnecting");


### PR DESCRIPTION
## Summary

Final thematic PR for the confirmed-real LOW/NIT `[R]` backlog from #146 — the **runtime surface (serve / scheduler / observability) + doctor probe + docs** bucket (groups E + F). Every item was re-verified against `HEAD` before patching (the triage was stale for a few — E8/E10/E11 turned out already-partially-addressed and were completed/verified here), then fixed test-first where the surface allows.

Refs #146. With this, the entire CRITICAL→…→LOW/NIT audit backlog is resolved (criticals #147; highs #148–#151,#158; mediums #152–#157; LOW `[V]` #159; LOW/NIT `[R]` across #162, #163, and this PR — minus the two design-level items split to #160/#161).

## E — observability / serve / scheduler
- **Core metrics/install:** page-duration histogram no longer records a spurious ~0 sample on the terminal end-of-stream poll (`DurationGuard::disarm`); `metric_labels()` precomputes the base label vec once instead of reallocating per page/write/flush; `connector_name()` passthrough routes through the same `"unknown"` fallback as the metric label; Prometheus install matches the **typed** `BuildError` (idempotent `FailedToSetGlobalRecorder`; port-in-use `FailedToCreateHTTPListener` → the dedicated `PrometheusBind` variant) instead of scraping a Display string.
- **Scheduler:** reset `faucet_schedule_runs_in_flight` to 0 on `overlap_policy: forbid` exit; pre-emit the run-state gauges (and HELP) at startup so a pre-first-run scrape sees them.
- **Serve:** reject `--shutdown-grace-secs=0` (documents `--idempotency-retention-secs=0` as a dedup-disabled sentinel); cancel a **queued** run promptly instead of only after a permit frees (new `Registry::mark_queued_cancelled`); run `doctor_first` **behind** the queue reservation so concurrent preflight probing is bounded; populate the previously-dead `doctor_report` response field from the (redacted) preflight report.

## F — doctor cheap-probe + docs
- **BigQuery / Snowflake `check()`:** override the default (which ran the configured query — a **billed** BQ execution / real Snowflake statement) with a cheap probe: BQ `dryRun: true`, Snowflake `SELECT 1`.
- **Docs/nits:** postgres-cdc bookmark doc (`commit_lsn`→`end_lsn`); CSV parse-error now reports the physical file line (header-aware); S3-sink `max_records_per_file=None` doc corrected; websocket at-most-once reconnect comment; bookmark-lag gauge staleness documented.

## Testing
- Test-first where the surface allows: `page_duration` snapshotter test, `connector_name` fallback tests, serve `shutdown_grace`/`idempotency_retention` config tests, **queued-run cancel** integration test (`max_concurrent_runs=1`; would hang before the fix), `doctor_first` success **populates `doctor_report`** integration test, Snowflake `check()` wiremock asserting the probe is `SELECT 1`.
- `cargo fmt --all --check` clean. `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean. `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps` clean. Touched-crate suites pass (faucet-core, faucet-cli serve+schedule incl. integration, bigquery, snowflake, csv).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
