### PR TITLE
fix(#146): quality-DLQ record_index, warn_mismatch cap, GCS-sink batch_size (missed-item follow-up)

### DIFF
--- a/crates/core/src/compression.rs
+++ b/crates/core/src/compression.rs
@@ -234,17 +234,29 @@ pub fn compress_buf(data: &[u8], c: Compression) -> Result<Vec<u8>, FaucetError>
 pub fn warn_mismatch(path: &str, declared: Compression) {
     use std::collections::HashSet;
     use std::sync::{Mutex, OnceLock};
+    /// Hard cap on the dedup set so a run touching an unbounded number of
+    /// *distinct* mismatched paths can't leak memory for the process lifetime
+    /// (#146 R). Beyond this, mismatches re-warn rather than being tracked —
+    /// hitting thousands of distinct mismatched paths is already pathological.
+    const MAX_SEEN: usize = 4096;
     static SEEN: OnceLock<Mutex<HashSet<(String, Compression)>>> = OnceLock::new();
     let detected = detect_from_path(path);
     if detected == declared {
         return;
     }
     let key = (path.to_string(), declared);
-    let mut seen = SEEN
-        .get_or_init(|| Mutex::new(HashSet::new()))
-        .lock()
-        .expect("compression mismatch log mutex poisoned");
-    if seen.insert(key) {
+    let should_warn = {
+        let mut seen = SEEN
+            .get_or_init(|| Mutex::new(HashSet::new()))
+            .lock()
+            .expect("compression mismatch log mutex poisoned");
+        if seen.len() >= MAX_SEEN {
+            true
+        } else {
+            seen.insert(key)
+        }
+    };
+    if should_warn {
         tracing::warn!(
             path = %path,
             declared = ?declared,

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -483,32 +483,40 @@ where
 
                     // ── Quality pass (after transforms, before sink) ─────────
                     #[cfg(feature = "quality")]
-                    let (records, quality_envelopes): (Vec<Value>, Vec<Value>) = if let Some(q) =
-                        quality.as_ref()
-                    {
-                        let labels =
-                            crate::observability::Labels::new(&*pipeline_name, &*row, &*run_id);
-                        let outcome = crate::observability::instrumented_apply_quality(
-                            page.records,
-                            q,
-                            &labels,
-                        )?;
-                        let envelopes: Vec<Value> = outcome
-                            .quarantined
-                            .iter()
-                            .enumerate()
-                            .map(|(i, qr)| {
-                                let err = FaucetError::QualityFailure {
-                                    check: qr.check.to_string(),
-                                    message: qr.message.clone(),
-                                };
-                                build_envelope(&qr.record, &err, sink_name, &pipeline_name, &row, i)
-                            })
-                            .collect();
-                        (outcome.survivors, envelopes)
-                    } else {
-                        (page.records, Vec::new())
-                    };
+                    let (records, quality_envelopes): (Vec<Value>, Vec<Value>) =
+                        if let Some(q) = quality.as_ref() {
+                            let labels =
+                                crate::observability::Labels::new(&*pipeline_name, &*row, &*run_id);
+                            let outcome = crate::observability::instrumented_apply_quality(
+                                page.records,
+                                q,
+                                &labels,
+                            )?;
+                            let envelopes: Vec<Value> = outcome
+                                .quarantined
+                                .iter()
+                                .map(|qr| {
+                                    let err = FaucetError::QualityFailure {
+                                        check: qr.check.to_string(),
+                                        message: qr.message.clone(),
+                                    };
+                                    // `record_index` is the position within the PAGE
+                                    // (the frozen envelope contract), not the index in
+                                    // the quarantine list (#146 R).
+                                    build_envelope(
+                                        &qr.record,
+                                        &err,
+                                        sink_name,
+                                        &pipeline_name,
+                                        &row,
+                                        qr.page_index,
+                                    )
+                                })
+                                .collect();
+                            (outcome.survivors, envelopes)
+                        } else {
+                            (page.records, Vec::new())
+                        };
                     #[cfg(not(feature = "quality"))]
                     let (records, quality_envelopes): (Vec<Value>, Vec<Value>) =
                         (page.records, Vec::new());

--- a/crates/core/src/quality/mod.rs
+++ b/crates/core/src/quality/mod.rs
@@ -30,6 +30,10 @@ pub struct QuarantinedRecord {
     pub field: Option<String>,
     /// Human-readable failure message (goes into the DLQ envelope error).
     pub message: String,
+    /// 0-based position **within the original page** (not within the quarantine
+    /// list). This is the value the DLQ envelope's `record_index` must carry —
+    /// the frozen contract is "position within the page that failed".
+    pub page_index: usize,
 }
 
 /// Per-check counters + elapsed time, keyed by check name. Emitted as metrics
@@ -79,9 +83,13 @@ pub fn apply_quality(
     q: &CompiledQuality,
 ) -> Result<QualityOutcome, FaucetError> {
     let mut out = QualityOutcome::default();
+    // Original page index of each survivor, kept in lockstep with
+    // `out.survivors`, so a record quarantined later by a *batch* check still
+    // carries its true page position (not its index within the survivor slice).
+    let mut survivor_idx: Vec<usize> = Vec::new();
 
     // ── Per-record pass ───────────────────────────────────────────────
-    'next_record: for rec in records {
+    'next_record: for (page_index, rec) in records.into_iter().enumerate() {
         for check in &q.record {
             // Per-check timing feeds the per-page duration histogram (catches slow
             // checks like json_schema). The per-record Instant overhead is negligible
@@ -107,6 +115,7 @@ pub fn apply_quality(
                                 check: check.name,
                                 field: check.field.clone(),
                                 message: field_msg(&check.field, &message),
+                                page_index,
                             });
                             continue 'next_record;
                         }
@@ -115,6 +124,7 @@ pub fn apply_quality(
             }
         }
         out.survivors.push(rec);
+        survivor_idx.push(page_index);
     }
 
     // ── Per-batch pass over survivors ─────────────────────────────────
@@ -139,6 +149,8 @@ pub fn apply_quality(
                     // quarantine the duplicate occurrences (keep first).
                     let dup_set: std::collections::HashSet<usize> = dups.into_iter().collect();
                     let mut survivors = Vec::with_capacity(out.survivors.len());
+                    let mut new_idx = Vec::with_capacity(survivor_idx.len());
+                    let old_idx = std::mem::take(&mut survivor_idx);
                     for (i, rec) in std::mem::take(&mut out.survivors).into_iter().enumerate() {
                         if dup_set.contains(&i) {
                             out.quarantined.push(QuarantinedRecord {
@@ -146,12 +158,15 @@ pub fn apply_quality(
                                 check: check.name,
                                 field: check.field.clone(),
                                 message: field_msg(&check.field, "duplicate key"),
+                                page_index: old_idx[i],
                             });
                         } else {
                             survivors.push(rec);
+                            new_idx.push(old_idx[i]);
                         }
                     }
                     out.survivors = survivors;
+                    survivor_idx = new_idx;
                 }
             }
         } else {
@@ -170,12 +185,16 @@ pub fn apply_quality(
                         }
                         // quarantine_batch: route all survivors to the DLQ.
                         _ => {
-                            for rec in std::mem::take(&mut out.survivors) {
+                            let old_idx = std::mem::take(&mut survivor_idx);
+                            for (rec, page_index) in
+                                std::mem::take(&mut out.survivors).into_iter().zip(old_idx)
+                            {
                                 out.quarantined.push(QuarantinedRecord {
                                     record: rec,
                                     check: check.name,
                                     field: check.field.clone(),
                                     message: field_msg(&check.field, &message),
+                                    page_index,
                                 });
                             }
                         }
@@ -221,6 +240,63 @@ mod tests {
         assert_eq!(out.quarantined.len(), 1);
         assert_eq!(out.quarantined[0].check, "not_null");
         assert_eq!(out.quarantined[0].field.as_deref(), Some("id"));
+    }
+
+    #[test]
+    fn quarantined_records_carry_page_index_not_list_index() {
+        // Records at page positions 1 and 3 fail; their `page_index` must be 1
+        // and 3 (the frozen DLQ `record_index` contract), NOT the quarantine-list
+        // indices 0 and 1 (#146 R).
+        let q = compiled(QualitySpec {
+            record: vec![RecordCheck::NotNull {
+                field: "id".into(),
+                treat_missing_as_null: true,
+                on_failure: OnFailure::Quarantine,
+            }],
+            batch: vec![],
+        });
+        let page = vec![
+            json!({"id": 0}),
+            json!({"id": null}),
+            json!({"id": 2}),
+            json!({"id": null}),
+        ];
+        let out = apply_quality(page, &q).unwrap();
+        let idxs: Vec<usize> = out.quarantined.iter().map(|qr| qr.page_index).collect();
+        assert_eq!(
+            idxs,
+            vec![1, 3],
+            "quarantined records must carry their original page position"
+        );
+    }
+
+    #[test]
+    fn batch_quarantined_records_carry_page_index() {
+        // A unique check: positions 1 and 3 duplicate position 0's key. They
+        // survive the (empty) per-record pass and are quarantined by the BATCH
+        // pass, yet must still carry page positions 1 and 3 — proving the page
+        // index survives the survivor-slice re-indexing.
+        let q = compiled(QualitySpec {
+            record: vec![],
+            batch: vec![BatchCheck::Unique {
+                fields: vec!["k".into()],
+                on_failure: OnFailure::Quarantine,
+            }],
+        });
+        let page = vec![
+            json!({"k": "a"}),
+            json!({"k": "a"}),
+            json!({"k": "b"}),
+            json!({"k": "a"}),
+        ];
+        let out = apply_quality(page, &q).unwrap();
+        let mut idxs: Vec<usize> = out.quarantined.iter().map(|qr| qr.page_index).collect();
+        idxs.sort_unstable();
+        assert_eq!(
+            idxs,
+            vec![1, 3],
+            "batch-quarantined duplicates must carry their original page positions"
+        );
     }
 
     #[test]

--- a/crates/sink/gcs/src/sink.rs
+++ b/crates/sink/gcs/src/sink.rs
@@ -16,6 +16,7 @@ pub struct GcsSink {
 
 impl GcsSink {
     pub async fn new(config: GcsSinkConfig) -> Result<Self, FaucetError> {
+        faucet_core::validate_batch_size(config.batch_size)?;
         let storage = build_storage(&config.auth, config.storage_host.as_deref()).await?;
         Ok(Self { config, storage })
     }
@@ -184,6 +185,17 @@ fn generate_object_key(prefix: &str, file_extension: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn new_rejects_out_of_range_batch_size() {
+        // Validation runs before any GCS client setup, so this needs no backend.
+        let mut config = GcsSinkConfig::new("bucket");
+        config.batch_size = faucet_core::MAX_BATCH_SIZE + 1;
+        match GcsSink::new(config).await {
+            Err(FaucetError::Config(m)) => assert!(m.contains("batch_size"), "got: {m}"),
+            _ => panic!("expected a batch_size Config error"),
+        }
+    }
     use serde_json::json;
 
     #[test]


### PR DESCRIPTION
## Summary

A short follow-up closing **three confirmed-real LOW/NIT `[R]` items from #146 that I missed when grouping the earlier PRs** (#162/#163/#164) — caught while preparing the per-item issue annotation. Test-first.

Refs #146.

## Fixes
- **Quality DLQ `record_index` (api-stability).** Quality-quarantined records were sent to the DLQ with the **quarantine-list** index (`0..N`) as `record_index`, violating the frozen envelope contract ("position within the page that failed"). Thread the original page index through `apply_quality` — `QuarantinedRecord.page_index`, kept in lockstep with `survivors` so a record quarantined by a *batch* check (which runs over the already-filtered survivor slice) still reports its true page position — and use it in the envelope. Tests cover both the per-record and batch-quarantine paths.
- **`compression::warn_mismatch` unbounded `SEEN` set (resource-leak).** The process-global dedup set grew without bound across distinct mismatched `(path, codec)` pairs. Cap it at 4096 (beyond which a mismatch re-warns rather than leaking for the process lifetime).
- **GCS sink `batch_size` validation (NIT).** `GcsSink::new` never called `validate_batch_size` — the batch-size sweep in #163 covered the S3/MongoDB/Redis sinks but not GCS (the NIT flagged "S3/**GCS** sink"). Added + a rejection test.

## Testing
- `quarantined_records_carry_page_index_not_list_index` and `batch_quarantined_records_carry_page_index` (page positions survive survivor-slice re-indexing); GCS-sink `new_rejects_out_of_range_batch_size`.
- `cargo fmt --all --check` clean; `cargo clippy -p faucet-core -p faucet-sink-gcs --all-targets --all-features -- -D warnings` clean; `RUSTDOCFLAGS=-D warnings cargo doc -p faucet-core` clean; `faucet-core` all-features (445) + `faucet-sink-gcs` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
