### PR TITLE
fix: ES resume-dup surfacing + Redis fetch_all drain + fan-out Arc<Value> (#160)

### DIFF
--- a/cli/src/executor.rs
+++ b/cli/src/executor.rs
@@ -36,6 +36,11 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 use tokio::sync::{Mutex, Semaphore};
+
+/// Captured fan-out records, keyed by node id. Records are held as `Arc<Value>`
+/// so the per-level snapshot and per-child-unit hand-off are pointer bumps, not
+/// deep clones of the JSON tree (#160).
+type CapturedRecords = Arc<Mutex<HashMap<String, Vec<Arc<Value>>>>>;
 use tokio_util::sync::CancellationToken;
 
 /// Knobs passed to [`run_expanded`].
@@ -151,8 +156,10 @@ pub async fn run_expanded(nodes: Vec<ExpandedNode>, opts: ExecuteOptions) -> Cli
     }
 
     // Captured records per node id. Only populated for nodes that have
-    // children (= are referenced by another node's `parent:`).
-    let captured: Arc<Mutex<HashMap<String, Vec<Value>>>> = Arc::new(Mutex::new(HashMap::new()));
+    // children (= are referenced by another node's `parent:`). Records are held
+    // as `Arc<Value>` so the per-level snapshot clone and the per-child-unit
+    // hand-off are pointer bumps, not deep clones of the JSON tree (#160).
+    let captured: CapturedRecords = Arc::new(Mutex::new(HashMap::new()));
     let nodes_with_descendants: HashSet<String> = children_of.keys().cloned().collect();
 
     let mut outcomes: Vec<InvocationOutcome> = Vec::new();
@@ -430,7 +437,7 @@ pub async fn run_expanded(nodes: Vec<ExpandedNode>, opts: ExecuteOptions) -> Cli
 /// record. Built by the level loop, consumed by [`run_unit`].
 struct Unit {
     node: ExpandedNode,
-    parent_record: Option<Value>,
+    parent_record: Option<Arc<Value>>,
     state_key: String,
     parent_record_key: Option<String>,
 }
@@ -438,13 +445,13 @@ struct Unit {
 async fn run_unit(
     unit: &Unit,
     needs_capture: bool,
-    captured: &Arc<Mutex<HashMap<String, Vec<Value>>>>,
+    captured: &CapturedRecords,
     opts: &ExecuteOptions,
     cancel: CancellationToken,
 ) -> InvocationOutcome {
     let result = run_one_invocation(
         &unit.node,
-        unit.parent_record.as_ref(),
+        unit.parent_record.as_deref(),
         &unit.state_key,
         needs_capture,
         opts,
@@ -461,7 +468,9 @@ async fn run_unit(
                     .await
                     .entry(row_id.clone())
                     .or_default()
-                    .extend(records);
+                    // Move each record into an `Arc` once here; downstream
+                    // per-level / per-unit hand-offs then clone only the pointer.
+                    .extend(records.into_iter().map(Arc::new));
             }
             InvocationOutcome {
                 row_id,

--- a/crates/sink/elasticsearch/src/config.rs
+++ b/crates/sink/elasticsearch/src/config.rs
@@ -40,7 +40,15 @@ pub struct ElasticsearchSinkConfig {
     #[serde(default = "default_batch_size")]
     pub batch_size: usize,
     /// Optional JSON field name to use as the document `_id`.
-    /// If `None`, Elasticsearch auto-generates IDs.
+    ///
+    /// If `None`, Elasticsearch auto-generates a fresh ID for every indexed
+    /// document. Under faucet's at-least-once contract that means a **resumed or
+    /// retried run re-indexes already-written records as duplicates** (a page
+    /// can partially commit across `_bulk` chunks before failing, and the
+    /// bookmark only advances once the whole page is written). Set `id_field` to
+    /// a stable business key so re-sends become **idempotent overwrites** (the
+    /// recommended setting for resumable pipelines); alternatively, configure a
+    /// DLQ, whose per-row `write_batch_partial` path avoids the whole-page re-send.
     pub id_field: Option<String>,
 }
 

--- a/crates/sink/elasticsearch/src/sink.rs
+++ b/crates/sink/elasticsearch/src/sink.rs
@@ -6,6 +6,19 @@ use faucet_core::util::{DEFAULT_ERROR_BODY_MAX_LEN, check_http_response};
 use faucet_core::{AuthSpec, FaucetError, SharedAuthProvider};
 use reqwest::Client;
 use serde_json::Value;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// True when a page is split into more than one `_bulk` chunk *and* documents
+/// get auto-generated IDs (no `id_field`). In that configuration an earlier
+/// chunk can commit before a later chunk fails; because the bookmark only
+/// advances after the whole page is written, a resumed run re-sends the earlier
+/// chunk, and auto-generated IDs make those re-sends **duplicates** rather than
+/// idempotent overwrites. Setting `id_field` (or configuring a DLQ, whose
+/// per-row `write_batch_partial` path avoids the whole-page re-send) makes
+/// resume idempotent.
+fn resume_dup_risk(chunk_count: usize, has_id_field: bool) -> bool {
+    chunk_count > 1 && !has_id_field
+}
 
 /// A sink that writes JSON records to an Elasticsearch index using the bulk API.
 pub struct ElasticsearchSink {
@@ -15,6 +28,9 @@ pub struct ElasticsearchSink {
     /// auth. Injected by the CLI (to resolve `auth: { ref }`) or directly by
     /// library callers who want to share one token across multiple sinks.
     auth_provider: Option<SharedAuthProvider>,
+    /// One-shot guard so the resume-duplication warning (see [`resume_dup_risk`])
+    /// is logged at most once per sink instance, not per page.
+    resume_dup_warned: AtomicBool,
 }
 
 impl ElasticsearchSink {
@@ -28,6 +44,7 @@ impl ElasticsearchSink {
             config,
             client: Client::new(),
             auth_provider: None,
+            resume_dup_warned: AtomicBool::new(false),
         })
     }
 
@@ -294,6 +311,23 @@ impl faucet_core::Sink for ElasticsearchSink {
             records.chunks(self.config.batch_size).collect()
         };
 
+        // At-least-once + auto-generated IDs + multi-chunk page = duplicates on a
+        // resumed run (an earlier chunk commits, a later one fails, the bookmark
+        // doesn't advance, and the re-sent earlier chunk is re-indexed under new
+        // IDs). Warn once so operators set `id_field` (idempotent overwrite) or a
+        // DLQ (per-row outcomes, no whole-page re-send).
+        if resume_dup_risk(chunks.len(), self.config.id_field.is_some())
+            && !self.resume_dup_warned.swap(true, Ordering::Relaxed)
+        {
+            tracing::warn!(
+                index = %self.config.index,
+                chunks = chunks.len(),
+                "Elasticsearch sink: a page split across multiple _bulk chunks with \
+                 auto-generated document IDs (no id_field) can produce DUPLICATES on a \
+                 resumed run. Set id_field for idempotent overwrites, or configure a DLQ.",
+            );
+        }
+
         for chunk in chunks {
             let resp_body = self.send_bulk_raw(chunk, &auth).await?;
 
@@ -410,6 +444,25 @@ impl faucet_core::Sink for ElasticsearchSink {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn resume_dup_risk_only_when_multichunk_and_no_id_field() {
+        // The duplication-on-resume risk exists only when a page splits into
+        // >1 _bulk chunk AND documents get auto-generated IDs.
+        assert!(
+            resume_dup_risk(2, false),
+            "multi-chunk + no id_field is risky"
+        );
+        assert!(
+            !resume_dup_risk(1, false),
+            "single chunk can't partially commit"
+        );
+        assert!(
+            !resume_dup_risk(5, true),
+            "id_field makes re-sends idempotent"
+        );
+        assert!(!resume_dup_risk(1, true));
+    }
     use serde_json::json;
 
     #[test]

--- a/crates/source/redis/src/stream.rs
+++ b/crates/source/redis/src/stream.rs
@@ -100,30 +100,59 @@ impl RedisSource {
         consumer: &Option<String>,
         count: &Option<usize>,
     ) -> Result<Vec<Value>, FaucetError> {
-        let entries: redis::streams::StreamReadReply = match (group, consumer) {
+        let mut records = Vec::new();
+        match (group, consumer) {
             (Some(group_name), Some(consumer_name)) => {
-                let opts = redis::streams::StreamReadOptions::default().count(count.unwrap_or(100));
-                conn.xread_options(&[key], &[">"], &opts.group(group_name, consumer_name))
-                    .await
-                    .map_err(|e| {
-                        FaucetError::Source(format!("XREADGROUP failed on '{key}': {e}"))
-                    })?
+                // Drain ALL currently-pending new messages for the group, not just
+                // the first `count`. A single XREADGROUP with the default
+                // `count = 100` silently truncated the rest (#146 narrowed); loop,
+                // consuming `>` until a short read (fewer than requested → the
+                // backlog is drained) or the `max_records` cap is hit.
+                let per_read = count.unwrap_or(100).max(1);
+                loop {
+                    let opts = redis::streams::StreamReadOptions::default().count(per_read);
+                    let reply: redis::streams::StreamReadReply = conn
+                        .xread_options(&[key], &[">"], &opts.group(group_name, consumer_name))
+                        .await
+                        .map_err(|e| {
+                            FaucetError::Source(format!("XREADGROUP failed on '{key}': {e}"))
+                        })?;
+                    let mut got = 0usize;
+                    for stream_key in &reply.keys {
+                        for entry in &stream_key.ids {
+                            records.push(stream_entry_to_json(&entry.id, &entry.map));
+                            got += 1;
+                        }
+                    }
+                    // A short read means Redis returned everything currently
+                    // pending — stop (also breaks at `got == 0`). This also avoids
+                    // spinning against a live producer.
+                    if got < per_read {
+                        break;
+                    }
+                    if let Some(max) = self.config.max_records
+                        && records.len() >= max
+                    {
+                        break;
+                    }
+                }
             }
             _ => {
+                // No consumer group: XREAD from `0` returns the whole stream when
+                // no `count` is set; an explicit `count` is the caller's own cap.
                 let mut opts = redis::streams::StreamReadOptions::default();
                 if let Some(c) = count {
                     opts = opts.count(*c);
                 }
-                conn.xread_options(&[key], &["0"], &opts)
+                let reply: redis::streams::StreamReadReply = conn
+                    .xread_options(&[key], &["0"], &opts)
                     .await
-                    .map_err(|e| FaucetError::Source(format!("XREAD failed on '{key}': {e}")))?
-            }
-        };
-
-        let mut records = Vec::new();
-        for stream_key in &entries.keys {
-            for entry in &stream_key.ids {
-                records.push(stream_entry_to_json(&entry.id, &entry.map));
+                    .map_err(|e| FaucetError::Source(format!("XREAD failed on '{key}': {e}")))?;
+                for stream_key in &reply.keys {
+                    for entry in &stream_key.ids {
+                        records.push(stream_entry_to_json(&entry.id, &entry.map));
+                    }
+                }
             }
         }
 

--- a/crates/source/redis/tests/streaming.rs
+++ b/crates/source/redis/tests/streaming.rs
@@ -248,6 +248,44 @@ async fn stream_stream_pages_chunks_into_batch_sized_pages() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn stream_fetch_all_with_group_drains_beyond_default_count() {
+    // Regression (#146 narrowed): the convenience fetch_all consumer-group path
+    // did a single XREADGROUP capped at the default count (100), silently
+    // truncating the rest. It must now drain the whole pending backlog.
+    let (_container, url) = start_redis().await;
+    let mut conn = open_conn(&url).await;
+    // Create the stream + a consumer group at the start, so every subsequently
+    // added entry is an undelivered (`>`) message for the group.
+    let _: () = redis::cmd("XGROUP")
+        .arg("CREATE")
+        .arg("evt")
+        .arg("g1")
+        .arg("0")
+        .arg("MKSTREAM")
+        .query_async(&mut conn)
+        .await
+        .expect("XGROUP CREATE");
+    seed_stream(&url, "evt", 150).await;
+
+    let config = RedisSourceConfig::new(
+        &url,
+        RedisSourceType::Stream {
+            key: "evt".into(),
+            group: Some("g1".into()),
+            consumer: Some("c1".into()),
+            count: None,
+        },
+    );
+    let source = RedisSource::new(config).unwrap();
+    let records = source.fetch_all().await.expect("fetch_all ok");
+    assert_eq!(
+        records.len(),
+        150,
+        "consumer-group fetch_all must drain all 150 entries, not truncate at the default 100"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn stream_stream_pages_partial_final_page() {
     let (_container, url) = start_redis().await;
     seed_stream(&url, "events", 2_500).await;


### PR DESCRIPTION
## Summary

Closes the two MEDIUM-tier "narrowed during verification" items from #146 that were left out of the medium batch, plus the fan-out memory optimisation from #160 — all test-first.

Refs #146. Refs #160.

## Fixes

**1. Elasticsearch sink — resume-duplication surfaced + documented** (`sink-elasticsearch`)
With auto-generated document IDs (no `id_field`), a page split across multiple `_bulk` chunks can partially commit before a later chunk fails; the bookmark only advances after the whole page is written, so a resumed run re-sends the earlier chunk and auto-IDs make those re-sends duplicates (at-least-once, not idempotent). This is inherent to non-idempotent IDs, so the fix makes it **visible and steers users to the idempotent path**: a one-shot `warn` fires in exactly the risky scenario (multi-chunk page + no `id_field`), and the `id_field` doc now explains that setting it gives idempotent overwrites on resume (or use a DLQ, whose per-row `write_batch_partial` avoids the whole-page re-send). Testable `resume_dup_risk()` predicate.

**2. Redis source — `fetch_all` drains the consumer-group backlog** (`source-redis`)
The convenience `fetch_all`/`fetch_with_context` consumer-group path issued a single `XREADGROUP` capped at `count.unwrap_or(100)`, silently truncating any backlog beyond 100. It now loops `XREADGROUP '>'` until a short read (drained) or the `max_records` cap. The pipeline `stream_pages` path already drained fully; the non-group `XREAD '0'` path is unchanged. Docker-gated regression test seeds 150 entries behind a group.

**3. Matrix fan-out holds captured records as `Arc<Value>`** (`cli/executor`, #160)
The parent/child fan-out deep-cloned captured records twice on the hot path — the whole captured map per BFS level, and each record per child unit (`O(full-record × N × levels)`). Records are now `Arc<Value>` (moved into the Arc once at capture), so those hand-offs are pointer bumps; the only deep clone left is the unavoidable per-child interpolation context. Implements #160's `Arc<Value>` acceptance criterion (the further field-projection optimisation is noted on #160).

## Testing
- `resume_dup_risk` predicate test; Redis consumer-group drain integration test (150 entries); existing matrix fan-out + state-key tests confirm the `Arc` change is behaviour-preserving.
- `cargo fmt --all --check` clean · `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean · `RUSTDOCFLAGS=-D warnings cargo doc --workspace --all-features --no-deps` clean · touched-crate suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
