### PR TITLE
Public-facing polish: crates.io banner + Codecov token + 1.0 security policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,5 +344,6 @@ jobs:
         continue-on-error: true
         uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
           fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src=".github/assets/logo.svg" alt="faucet-stream logo" width="96" height="96">
+  <img src="https://raw.githubusercontent.com/PawanSikawat/faucet-stream/main/.github/assets/social-banner.png" alt="faucet-stream" width="640">
 </p>
 
 # faucet-stream

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,9 +2,10 @@
 
 ## Supported versions
 
-faucet-stream is pre-1.0 and under active development. Security fixes are applied
-to the latest published `0.x` release on crates.io and to `main`. Older versions
-are not maintained — please upgrade to the latest release before reporting.
+faucet-stream has reached **1.0**. Security fixes are applied to the latest
+published `1.x` release on crates.io and to `main`. Older releases — including
+all pre-1.0 (`0.x`) versions — are no longer maintained; please upgrade to the
+latest release before reporting.
 
 ## Reporting a vulnerability
 


### PR DESCRIPTION
Public-facing polish for the 1.0 release — three fixes to surfaces users actually see.

## 1. Broken crates.io hero image → absolute PNG banner
The README hero used a **relative-path SVG** (`.github/assets/logo.svg`). crates.io needs **absolute** image URLs and doesn't reliably render SVG through its image proxy, so the logo showed as broken on the crates.io page (it renders fine on GitHub, which resolves relative paths + SVG). Switched to the absolute **`social-banner.png`** (1280×640) raw URL, which renders on both GitHub and crates.io.

> Takes effect on crates.io only after `faucet-stream` is **republished** (1.0.2) — crates.io bakes the README HTML at publish time. Handled right after merge.

## 2. Codecov badge "unknown" → add upload token
The CI Coverage job uploads via `codecov/codecov-action@v4` but passed **no token**. v4 requires `CODECOV_TOKEN`, so the upload silently failed (`continue-on-error` / `fail_ci_if_error: false` — which is why the job stayed green while uploading nothing) and the badge read "unknown". Added `token: ${{ secrets.CODECOV_TOKEN }}`.

**Action required to light up the badge (only you can do these):**
1. Activate `PawanSikawat/faucet-stream` on codecov.io and copy the upload token.
2. Add it as the `CODECOV_TOKEN` repo Actions secret.

After that, the next push to `main` uploads coverage and the badge flips from "unknown" to the % — live, no republish needed.

## 3. `SECURITY.md` still said "pre-1.0"
The Security Policy's *Supported versions* section still described the project as pre-1.0 and pointed fixes at the "`0.x` release" — stale now that 1.0.0/1.0.1 are out. Updated it to: 1.0 reached; fixes applied to the latest `1.x` release + `main`; pre-1.0 (`0.x`) no longer maintained. (Repo meta file — read from `main` for the Security tab, so no republish needed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
