### PR TITLE
ci: serialize release-plz jobs to stop duplicate release PRs

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -27,6 +27,15 @@ jobs:
   release-plz-pr:
     name: Open / update release PR
     runs-on: ubuntu-latest
+    # Run AFTER release-plz-release so the per-crate tags it creates already
+    # exist before this job evaluates. Without this, a release-PR merge fires
+    # both jobs in parallel and this one can observe a just-bumped manifest
+    # whose tag release-plz-release hasn't created yet — concluding the version
+    # is unreleased and opening a redundant duplicate release PR (see #169,
+    # #172). `needs` serializes them; `!cancelled()` keeps this running even
+    # when the release job was a no-op (normal push) or failed.
+    needs: release-plz-release
+    if: ${{ !cancelled() }}
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Problem
`release-plz-pr` and `release-plz-release` both trigger on `push: [main]` and run **in parallel**. On a **release-PR merge**, that's a race: `release-plz-pr` can evaluate *before* `release-plz-release` has created the new per-crate `<crate>-v<version>` tags, see a just-bumped manifest with no matching tag, conclude the version is unreleased, and open a **redundant duplicate release PR** (changelog-only). This produced #169 (after #168) and #172 (after #171).

## Fix
Add `needs: release-plz-release` (+ `if: ${{ !cancelled() }}`) to the `release-plz-pr` job so it runs **after** the release job has created the tags. With the tags present, it sees manifest = tag = published and correctly opens nothing.

## Publish behavior is unchanged
`release_always = false` still governs publishing, so the intended two-step flow is preserved:
- **Normal PR merge → only create/update the release PR (no publish).**
- **Release PR merge → publish to crates.io.**

The `needs` only serializes the two jobs; `!cancelled()` keeps `release-plz-pr` running even when `release-plz-release` was a no-op (normal push) or failed.

Closes the duplicate-release-PR issue at the source. (Stale dup #172 closed separately, superseded by #171.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
