### PR TITLE
ci: run CI on pushes to main so Codecov gets main-branch coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 name: CI
 
 on:
+  # Run on PRs, and on pushes to main — the latter so the Coverage job uploads
+  # main-branch coverage to Codecov (the badge tracks branch/main) and so merge
+  # commits themselves get CI-verified (PR CI only tests the PR head).
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
## Problem
The Codecov badge reads **"unknown"** because `ci.yml` only triggered on `pull_request` — never on `push: [main]`. So the Coverage job (which uploads to Codecov) ran on PRs but **never on `main`**, and the badge tracks `branch/main`, which therefore had no data. (The `CODECOV_TOKEN` secret + the `token:` line added in #170 were necessary but **not sufficient** — without a `main` run there's nothing to upload for `main`.)

## Fix
Add a `push: [main]` trigger so the Coverage job runs on `main` after each merge → Codecov gets `main`-branch coverage → badge flips from "unknown" to the %.

**Self-activating:** merging this is itself a push to `main`, and the merge commit already carries the new trigger, so it kicks off the first `main` CI run immediately → first coverage upload → badge lights up. No follow-up needed.

Also closes a real gap: merge commits were never CI-tested before (only PR heads were); now `main` is verified post-merge too. Repo is public, so the extra `main` runs cost no Actions minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
