### PR TITLE
feat: add MongoDB Change Streams (CDC) source connector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,7 @@ jobs:
           - source-sqlite
           - source-s3
           - source-mongodb
+          - source-mongodb-cdc
           - source-redis
           - source-webhook
           - source-websocket

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
     "crates/source/gcs",
     "crates/source/s3",
     "crates/source/mongodb",
+    "crates/source/mongodb-cdc",
     "crates/source/redis",
     "crates/source/webhook",
     "crates/source/websocket",
@@ -93,6 +94,7 @@ faucet-source-mssql = { path = "crates/source/mssql", version = "1.0.1" }
 faucet-source-gcs = { path = "crates/source/gcs", version = "1.0.1" }
 faucet-source-s3 = { path = "crates/source/s3", version = "1.0.0" }
 faucet-source-mongodb = { path = "crates/source/mongodb", version = "1.0.0" }
+faucet-source-mongodb-cdc = { path = "crates/source/mongodb-cdc", version = "1.0.0" }
 faucet-source-redis = { path = "crates/source/redis", version = "1.0.0" }
 faucet-source-webhook = { path = "crates/source/webhook", version = "1.0.0" }
 faucet-source-websocket = { path = "crates/source/websocket", version = "1.0.0" }

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 **The fast, config-driven way to move data in Rust.**
 
-faucet-stream wires **21 source** and **17 sink** connectors together with a single
+faucet-stream wires **22 source** and **17 sink** connectors together with a single
 `faucet` binary that runs pipelines declaratively from a YAML/JSON file — no Rust
 code required. Or skip the binary and embed the same engine in your own service
 through the typed `Source` / `Sink` traits. One toolkit, whether you want a CLI you
@@ -157,7 +157,7 @@ flowchart LR
     P -.->|metrics + spans| O
 ```
 
-faucet-stream is a Cargo workspace with 50 crates — 21 sources, 17 sinks, 6 shared connector libraries, the shared auth-provider library, 2 state-store backends, the shared core, the umbrella crate, and the CLI binary:
+faucet-stream is a Cargo workspace with 51 crates — 22 sources, 17 sinks, 6 shared connector libraries, the shared auth-provider library, 2 state-store backends, the shared core, the umbrella crate, and the CLI binary:
 
 | Crate | Description |
 |-------|-------------|
@@ -170,6 +170,7 @@ faucet-stream is a Cargo workspace with 50 crates — 21 sources, 17 sinks, 6 sh
 | [`faucet-source-grpc`](crates/source/grpc) | gRPC — dynamic protobuf via `prost-reflect`, TLS support |
 | [`faucet-source-postgres`](crates/source/postgres) | PostgreSQL — run SQL queries, return rows as JSON |
 | [`faucet-source-postgres-cdc`](crates/source/postgres-cdc) | PostgreSQL CDC — logical replication via pgoutput, resumable with any StateStore |
+| [`faucet-source-mongodb-cdc`](crates/source/mongodb-cdc) | MongoDB CDC — Change Streams, resumable via resumeToken bookmarks |
 | [`faucet-source-mysql`](crates/source/mysql) | MySQL — run SQL queries, return rows as JSON |
 | [`faucet-source-mssql`](crates/source/mssql) | Microsoft SQL Server — run SQL queries (streaming, incremental), rows as JSON |
 | [`faucet-source-sqlite`](crates/source/sqlite) | SQLite — run SQL queries, return rows as JSON |
@@ -906,6 +907,7 @@ Every pagination style has a termination/loop guard. `Cursor`, `LinkHeader`, and
 | `source-grpc` | no | gRPC source |
 | `source-postgres` | no | PostgreSQL query source |
 | `source-postgres-cdc` | no | PostgreSQL CDC source (logical replication) |
+| `source-mongodb-cdc` | no | MongoDB CDC source (Change Streams) |
 | `source-mysql` | no | MySQL query source |
 | `source-mssql` | no | Microsoft SQL Server query source |
 | `source-sqlite` | no | SQLite query source |
@@ -1095,6 +1097,7 @@ crates/
     grpc/                     — gRPC (dynamic protobuf)
     postgres/                 — PostgreSQL queries
     postgres-cdc/             — PostgreSQL CDC (logical replication)
+    mongodb-cdc/              — MongoDB CDC (Change Streams)
     mysql/                    — MySQL queries
     mssql/                    — Microsoft SQL Server queries (streaming, incremental)
     sqlite/                   — SQLite queries

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -46,6 +46,7 @@ source = [
     "source-sqlite",
     "source-s3",
     "source-mongodb",
+    "source-mongodb-cdc",
     "source-redis",
     "source-webhook",
     "source-websocket",
@@ -89,6 +90,7 @@ source-mssql = ["dep:faucet-source-mssql"]
 source-sqlite = ["dep:faucet-source-sqlite"]
 source-s3 = ["dep:faucet-source-s3"]
 source-mongodb = ["dep:faucet-source-mongodb"]
+source-mongodb-cdc = ["dep:faucet-source-mongodb-cdc"]
 source-redis = ["dep:faucet-source-redis"]
 source-webhook = ["dep:faucet-source-webhook"]
 source-websocket = ["dep:faucet-source-websocket"]
@@ -198,6 +200,7 @@ faucet-source-mssql = { workspace = true, optional = true }
 faucet-source-sqlite = { workspace = true, optional = true }
 faucet-source-s3 = { workspace = true, optional = true }
 faucet-source-mongodb = { workspace = true, optional = true }
+faucet-source-mongodb-cdc = { workspace = true, optional = true }
 faucet-source-redis = { workspace = true, optional = true }
 faucet-source-webhook = { workspace = true, optional = true }
 faucet-source-websocket = { workspace = true, optional = true }

--- a/cli/examples/mongodb_cdc_to_jsonl.yaml
+++ b/cli/examples/mongodb_cdc_to_jsonl.yaml
@@ -1,0 +1,24 @@
+version: 1
+name: mongodb-cdc-to-jsonl
+pipeline:
+  source:
+    type: mongodb-cdc
+    config:
+      connection_uri: "mongodb://localhost:27017/?replicaSet=rs0"
+      scope:
+        type: collection
+        database: app
+        collection: users
+      full_document: when_available
+      start_from:
+        type: now
+      idle_timeout: 30
+      batch_size: 1000
+  sink:
+    type: jsonl
+    config:
+      path: ./out/mongodb_cdc.jsonl
+  state:
+    type: file
+    config:
+      path: ./state/mongodb_cdc.json

--- a/cli/src/registry.rs
+++ b/cli/src/registry.rs
@@ -109,6 +109,17 @@ pub async fn build_source(
                 faucet_source_mongodb::MongoSource::new(cfg).await?,
             ))
         }
+        #[cfg(feature = "source-mongodb-cdc")]
+        "mongodb-cdc" => {
+            let cfg = decode::<faucet_source_mongodb_cdc::MongoCdcSourceConfig>(
+                "source",
+                "mongodb-cdc",
+                config,
+            )?;
+            Ok(Box::new(
+                faucet_source_mongodb_cdc::MongoCdcSource::new(cfg).await?,
+            ))
+        }
         #[cfg(feature = "source-redis")]
         "redis" => {
             let cfg = decode::<faucet_source_redis::RedisSourceConfig>("source", "redis", config)?;
@@ -338,6 +349,8 @@ pub fn source_schema(kind: &str) -> CliResult<Value> {
         "s3" => Ok(schema::<faucet_source_s3::S3SourceConfig>()),
         #[cfg(feature = "source-mongodb")]
         "mongodb" => Ok(schema::<faucet_source_mongodb::MongoSourceConfig>()),
+        #[cfg(feature = "source-mongodb-cdc")]
+        "mongodb-cdc" => Ok(schema::<faucet_source_mongodb_cdc::MongoCdcSourceConfig>()),
         #[cfg(feature = "source-redis")]
         "redis" => Ok(schema::<faucet_source_redis::RedisSourceConfig>()),
         #[cfg(feature = "source-webhook")]
@@ -444,6 +457,8 @@ pub fn source_descriptions() -> Vec<(&'static str, &'static str)> {
     v.push(("s3", "AWS S3 object source"));
     #[cfg(feature = "source-mongodb")]
     v.push(("mongodb", "MongoDB query source"));
+    #[cfg(feature = "source-mongodb-cdc")]
+    v.push(("mongodb-cdc", "MongoDB CDC source (Change Streams)"));
     #[cfg(feature = "source-redis")]
     v.push(("redis", "Redis (streams, lists, keys) source"));
     #[cfg(feature = "source-webhook")]

--- a/crates/source/mongodb-cdc/Cargo.toml
+++ b/crates/source/mongodb-cdc/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "faucet-source-mongodb-cdc"
+version = "1.0.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "MongoDB Change Streams (CDC) source for the faucet-stream ecosystem"
+readme = "README.md"
+keywords = ["mongodb", "cdc", "changestream", "etl", "pipeline"]
+categories.workspace = true
+
+[dependencies]
+faucet-core.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+schemars.workspace = true
+async-trait.workspace = true
+tracing.workspace = true
+mongodb = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }
+futures.workspace = true
+async-stream = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time", "test-util"] }
+testcontainers = "0.27"
+testcontainers-modules = { version = "0.15", features = ["mongo"] }
+futures.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/source/mongodb-cdc/README.md
+++ b/crates/source/mongodb-cdc/README.md
@@ -1,0 +1,209 @@
+# faucet-source-mongodb-cdc
+
+MongoDB CDC (Change Data Capture) source for [`faucet-stream`](https://github.com/PawanSikawat/faucet-stream). Tails a MongoDB [Change Stream](https://www.mongodb.com/docs/manual/changeStreams/) and emits each per-document change event (insert, update, replace, delete, DDL) as a JSON record. The opaque `resumeToken` is persisted via any `faucet-core` `StateStore`, so pipelines resume exactly where they left off after a restart — no duplicates, no gap.
+
+**Requires a replica set or sharded cluster.** Standalone `mongod` instances do not support Change Streams; the connector fails fast in `new()` with a clear error if a standalone is detected.
+
+---
+
+## Quick start
+
+```yaml
+# pipeline.yaml
+version: 1
+source:
+  type: mongodb-cdc
+  config:
+    connection_uri: mongodb://user:pass@localhost:27017/?replicaSet=rs0
+    scope:
+      type: collection
+      database: appdb
+      collection: orders
+    full_document: update_lookup
+    idle_timeout: 30
+sink:
+  type: jsonl
+  config:
+    path: ./changes.jsonl
+state:
+  type: file
+  config: { path: ./state }
+```
+
+```bash
+faucet run pipeline.yaml
+```
+
+---
+
+## Output record schema
+
+Every change event is one JSON object:
+
+```json
+{
+  "op": "c",
+  "ts_ms": 1779019200000,
+  "namespace": { "db": "appdb", "coll": "orders" },
+  "document_key": { "_id": "6654a1b2c3d4e5f600000001" },
+  "before": null,
+  "after": {
+    "_id": "6654a1b2c3d4e5f600000001",
+    "status": "shipped",
+    "total": 49.99
+  },
+  "update_description": null,
+  "resume_token": { "_data": "826654A1B20000000..." }
+}
+```
+
+### Field reference
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `op` | string | Operation type: `c` (insert), `u` (update), `r` (replace), `d` (delete), `ddl` (drop / rename / dropDatabase / invalidate) |
+| `ts_ms` | number | Wall-clock time of the change in Unix-epoch milliseconds (from `clusterTime`) |
+| `namespace` | object \| null | `{ "db": "…", "coll": "…" }`. `null` for cluster-scope events that carry no namespace (e.g. cluster-level invalidate) |
+| `document_key` | object \| null | Document identity key (typically `{ "_id": … }`) |
+| `before` | object \| null | Pre-image of the document. Populated only when `full_document_before_change` is enabled and the collection has `changeStreamPreAndPostImages` turned on (MongoDB 6.0+). |
+| `after` | object \| null | Post-image of the document. Populated on inserts, replaces, and updates when `full_document` is `update_lookup`, `when_available`, or `required`. `null` on deletes. |
+| `update_description` | object \| null | Present on `u` events: `{ "updated_fields": {…}, "removed_fields": ["…"], "truncated_arrays": [{…}] }`. `null` for all other op types. |
+| `resume_token` | object | Opaque server-assigned token. The pipeline persists this as the page bookmark and passes it to `startAfter` on the next run. |
+
+### op mapping
+
+| MongoDB `operationType` | `op` value |
+|------------------------|-----------|
+| `insert` | `c` |
+| `update` | `u` |
+| `replace` | `r` |
+| `delete` | `d` |
+| `drop`, `rename`, `dropDatabase`, `invalidate` | `ddl` |
+
+---
+
+## Configuration
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `connection_uri` | string | — | MongoDB connection URI. Must point at a replica set (`?replicaSet=rs0`) or sharded cluster. A standalone `mongod` URI causes a hard error at startup. |
+| `scope` | enum | `{ type: cluster }` | Change Stream scope: `{ type: cluster }` (all databases), `{ type: database, database: "mydb" }` (one database), or `{ type: collection, database: "mydb", collection: "mycoll" }` (one collection). |
+| `operation_types` | string[] | `[]` (all) | Server-side `$match` on `operationType`. Empty = all. Example: `["insert", "update", "delete"]`. |
+| `full_document` | enum | `off` | Post-image delivery: `off` (no full doc), `when_available` (include when available), `required` (fail if unavailable), `update_lookup` (re-read from server at event time — at-least-once / read-skew caveat, see below). |
+| `full_document_before_change` | enum | `off` | Pre-image delivery: `off`, `when_available`, or `required`. Requires MongoDB 6.0+ and `changeStreamPreAndPostImages` enabled on the collection. |
+| `start_from` | enum | `{ type: now }` | Where to start if no persisted bookmark exists: `{ type: now }` (new events only), `{ type: earliest }` (from the oldest available oplog entry — errors if the oplog has rolled past), `{ type: resume_token, token: {…} }` (explicit token, always used regardless of any persisted bookmark), or `{ type: timestamp, timestamp_secs: N }` (cluster time in seconds, always used regardless of any persisted bookmark). |
+| `aggregation_pipeline` | object[] | `[]` | Extra aggregation stages appended **after** the internal `$match` on `operation_types`. Use for server-side field projection, filtering, or transformation. |
+| `idle_timeout` | seconds | `30` | Terminate the current fetch cycle after this long with no new events. The page accumulated so far is flushed and the bookmark is saved. |
+| `max_await_time_ms` | u64 | `1000` | Server-side `maxAwaitTimeMS` on `getMore` requests. Controls how long the server blocks before returning an empty batch. Must be less than `idle_timeout` (in milliseconds). |
+| `batch_size` | usize | `1000` | Records per emitted `StreamPage`. `0` = no batching — drain until idle and emit one page. |
+
+---
+
+## Resumability and state key
+
+The connector is fully resumable. After each emitted page the pipeline writes the `resume_token` of the last event in that page to the configured `StateStore` (per-batch durability). On the next run, `apply_start_bookmark` restores the token and the Change Stream opens with `startAfter: <token>` — MongoDB delivers events from exactly that point onwards with no duplicates and no gap.
+
+**`start_from` precedence:**
+
+- `resume_token` and `timestamp` variants **always** override a persisted bookmark — they force an explicit start position regardless of what the state store holds.
+- `now` and `earliest` variants **yield** to a persisted bookmark: if one exists the connector resumes from it; if none exists the specified variant is used as the initial position.
+
+State keys used (one per scope):
+
+| Scope | State key |
+|-------|-----------|
+| Cluster | `mongodb-cdc:cluster` |
+| Database `mydb` | `mongodb-cdc:db:mydb` |
+| Collection `mydb.mycoll` | `mongodb-cdc:coll:mydb.mycoll` |
+
+---
+
+## invalidate events
+
+An `invalidate` event (emitted when a watched collection or database is dropped while the stream is open) is delivered as a `ddl` record and then **terminates the stream**. The connector closes the stream and returns; a fresh `faucet run` is needed to start a new Change Stream. Persisted bookmarks from before the invalidate are discarded by MongoDB — use `start_from: { type: now }` or `{ type: earliest }` on the next run.
+
+---
+
+## Caveats
+
+- **Replica set or sharded cluster required.** Standalone `mongod` instances do not support Change Streams. The connector validates this at startup and returns a typed `FaucetError::Config` immediately.
+- **`full_document: update_lookup` has at-least-once / read-skew semantics.** The document is re-read from the primary at event delivery time, not at the time of the original change. If the document has been further modified or deleted between the change and the lookup, the `after` image will reflect the later state (or be absent). Do not rely on `after` for exactly-once semantics when using `update_lookup`.
+- **`start_from: earliest` may error.** If the oplog has rolled past the earliest available timestamp (common on busy clusters with a short oplog window), MongoDB returns an error. Use `{ type: now }` for new deployments and keep your oplog window large enough for your expected downtime.
+- **`full_document_before_change` requires MongoDB 6.0+ and per-collection configuration.** Enable pre-images on the collection before starting the stream:
+  ```js
+  db.runCommand({
+    collMod: "mycoll",
+    changeStreamPreAndPostImages: { enabled: true }
+  });
+  ```
+  Without this, `required` will error; `when_available` will produce `before: null`.
+- **DDL events are best-effort.** Schema changes (collection drops, renames) arrive as `ddl` records, but the Change Stream does not replicate index operations or user-visible `collMod` changes that don't appear in the oplog.
+- **Per-batch durability, not per-event.** The bookmark is saved once per emitted page (every `batch_size` events), not after every individual event. A crash mid-page replays at most `batch_size` events.
+
+---
+
+## Example: capture all changes to a collection
+
+```yaml
+version: 1
+source:
+  type: mongodb-cdc
+  config:
+    connection_uri: mongodb://faucet:secret@mongo1:27017,mongo2:27017/?replicaSet=rs0&authSource=admin
+    scope:
+      type: collection
+      database: myapp
+      collection: events
+    operation_types: ["insert", "update", "replace", "delete"]
+    full_document: when_available
+    full_document_before_change: off
+    idle_timeout: 60
+    max_await_time_ms: 500
+    batch_size: 500
+sink:
+  type: bigquery
+  config:
+    project_id: my-gcp-project
+    dataset_id: cdc
+    table_id: events_stream
+    credentials:
+      type: service_account_file
+      config: { path: /secrets/bq-sa.json }
+state:
+  type: redis
+  config:
+    url: redis://localhost:6379
+    namespace: faucet-cdc
+```
+
+---
+
+## Example: cluster-wide CDC with operation filtering
+
+```yaml
+version: 1
+source:
+  type: mongodb-cdc
+  config:
+    connection_uri: mongodb://faucet:secret@mongos:27017/?tls=true
+    scope:
+      type: cluster
+    operation_types: ["insert", "delete"]
+    idle_timeout: 30
+sink:
+  type: stdout
+  config:
+    format: pretty
+state:
+  type: file
+  config: { path: ./state/mongodb-cdc }
+```
+
+---
+
+## See also
+
+- `crates/source/mongodb/` — query-mode MongoDB source (snapshots via `find()`).
+- `crates/state/redis/` — Redis-backed `StateStore` for durable resumeToken bookmarks.
+- `crates/state/postgres/` — PostgreSQL-backed `StateStore` alternative.
+- `crates/source/postgres-cdc/` — PostgreSQL CDC for comparison (LSN bookmarks, pgoutput).

--- a/crates/source/mongodb-cdc/README.md
+++ b/crates/source/mongodb-cdc/README.md
@@ -68,7 +68,7 @@ Every change event is one JSON object:
 | `before` | object \| null | Pre-image of the document. Populated only when `full_document_before_change` is enabled and the collection has `changeStreamPreAndPostImages` turned on (MongoDB 6.0+). |
 | `after` | object \| null | Post-image of the document. Populated on inserts, replaces, and updates when `full_document` is `update_lookup`, `when_available`, or `required`. `null` on deletes. |
 | `update_description` | object \| null | Present on `u` events: `{ "updated_fields": {…}, "removed_fields": ["…"], "truncated_arrays": [{…}] }`. `null` for all other op types. |
-| `resume_token` | object | Opaque server-assigned token. The pipeline persists this as the page bookmark and passes it to `startAfter` on the next run. |
+| `resume_token` | object | Opaque server-assigned token. The pipeline persists this as the page bookmark and passes it to `resumeAfter` on the next run. |
 
 ### op mapping
 
@@ -101,7 +101,7 @@ Every change event is one JSON object:
 
 ## Resumability and state key
 
-The connector is fully resumable. After each emitted page the pipeline writes the `resume_token` of the last event in that page to the configured `StateStore` (per-batch durability). On the next run, `apply_start_bookmark` restores the token and the Change Stream opens with `startAfter: <token>` — MongoDB delivers events from exactly that point onwards with no duplicates and no gap.
+The connector is fully resumable. After each emitted page the pipeline writes the `resume_token` of the last event in that page to the configured `StateStore` (per-batch durability). On the next run, `apply_start_bookmark` restores the token and the Change Stream opens with `resumeAfter: <token>` — MongoDB delivers events from exactly that point onwards with no duplicates and no gap.
 
 **`start_from` precedence:**
 
@@ -126,7 +126,7 @@ An `invalidate` event (emitted when a watched collection or database is dropped 
 
 ## Caveats
 
-- **Replica set or sharded cluster required.** Standalone `mongod` instances do not support Change Streams. The connector validates this at startup and returns a typed `FaucetError::Config` immediately.
+- **Replica set or sharded cluster required.** Standalone `mongod` instances do not support Change Streams. The connector validates this at startup and returns a typed `FaucetError::Source` immediately.
 - **`full_document: update_lookup` has at-least-once / read-skew semantics.** The document is re-read from the primary at event delivery time, not at the time of the original change. If the document has been further modified or deleted between the change and the lookup, the `after` image will reflect the later state (or be absent). Do not rely on `after` for exactly-once semantics when using `update_lookup`.
 - **`start_from: earliest` may error.** If the oplog has rolled past the earliest available timestamp (common on busy clusters with a short oplog window), MongoDB returns an error. Use `{ type: now }` for new deployments and keep your oplog window large enough for your expected downtime.
 - **`full_document_before_change` requires MongoDB 6.0+ and per-collection configuration.** Enable pre-images on the collection before starting the stream:

--- a/crates/source/mongodb-cdc/src/config.rs
+++ b/crates/source/mongodb-cdc/src/config.rs
@@ -22,7 +22,10 @@ fn default_batch_size() -> usize {
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum Scope {
     /// Watch one collection.
-    Collection { database: String, collection: String },
+    Collection {
+        database: String,
+        collection: String,
+    },
     /// Watch every collection in one database.
     Database { database: String },
     /// Watch the whole deployment.
@@ -124,7 +127,10 @@ impl MongoCdcSourceConfig {
             ));
         }
         match &self.scope {
-            Scope::Collection { database, collection } => {
+            Scope::Collection {
+                database,
+                collection,
+            } => {
                 if database.trim().is_empty() || collection.trim().is_empty() {
                     return Err(FaucetError::Config(
                         "mongodb-cdc: scope.database and scope.collection must not be empty".into(),
@@ -168,7 +174,10 @@ impl fmt::Debug for MongoCdcSourceConfig {
             .field("scope", &self.scope)
             .field("operation_types", &self.operation_types)
             .field("full_document", &self.full_document)
-            .field("full_document_before_change", &self.full_document_before_change)
+            .field(
+                "full_document_before_change",
+                &self.full_document_before_change,
+            )
             .field("start_from", &self.start_from)
             .field("aggregation_pipeline", &self.aggregation_pipeline)
             .field("idle_timeout", &self.idle_timeout)

--- a/crates/source/mongodb-cdc/src/config.rs
+++ b/crates/source/mongodb-cdc/src/config.rs
@@ -18,7 +18,7 @@ fn default_batch_size() -> usize {
 }
 
 /// Which change stream to open.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum Scope {
     /// Watch one collection.
@@ -26,20 +26,16 @@ pub enum Scope {
     /// Watch every collection in one database.
     Database { database: String },
     /// Watch the whole deployment.
+    #[default]
     Cluster,
 }
 
-impl Default for Scope {
-    fn default() -> Self {
-        Scope::Cluster
-    }
-}
-
 /// Where to start the change stream on a fresh run (no persisted bookmark).
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum StartFrom {
     /// Start at the current cluster time (default — do not replay history).
+    #[default]
     Now,
     /// Start at the earliest retained oplog entry (errors if it has rolled).
     Earliest,
@@ -47,12 +43,6 @@ pub enum StartFrom {
     ResumeToken { token: Value },
     /// Start at a wall-clock second. Overrides a persisted bookmark.
     Timestamp { timestamp_secs: u32 },
-}
-
-impl Default for StartFrom {
-    fn default() -> Self {
-        StartFrom::Now
-    }
 }
 
 /// Post-image inclusion mode (maps to the driver `FullDocumentType`).
@@ -245,6 +235,23 @@ mod tests {
         }))
         .unwrap();
         assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_empty_database_scope() {
+        let c: MongoCdcSourceConfig = serde_json::from_value(json!({
+            "connection_uri": "mongodb://h/?replicaSet=rs0",
+            "scope": { "type": "database", "database": "" }
+        }))
+        .unwrap();
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn validate_accepts_batch_size_zero_sentinel() {
+        let mut c = minimal();
+        c.batch_size = 0;
+        assert!(c.validate().is_ok());
     }
 
     #[test]

--- a/crates/source/mongodb-cdc/src/config.rs
+++ b/crates/source/mongodb-cdc/src/config.rs
@@ -1,0 +1,275 @@
+//! Configuration for [`MongoCdcSource`](crate::MongoCdcSource).
+
+use faucet_core::{DEFAULT_BATCH_SIZE, FaucetError};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::fmt;
+use std::time::Duration;
+
+fn default_idle_timeout() -> Duration {
+    Duration::from_secs(30)
+}
+fn default_max_await_time_ms() -> u64 {
+    1000
+}
+fn default_batch_size() -> usize {
+    DEFAULT_BATCH_SIZE
+}
+
+/// Which change stream to open.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Scope {
+    /// Watch one collection.
+    Collection { database: String, collection: String },
+    /// Watch every collection in one database.
+    Database { database: String },
+    /// Watch the whole deployment.
+    Cluster,
+}
+
+impl Default for Scope {
+    fn default() -> Self {
+        Scope::Cluster
+    }
+}
+
+/// Where to start the change stream on a fresh run (no persisted bookmark).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum StartFrom {
+    /// Start at the current cluster time (default — do not replay history).
+    Now,
+    /// Start at the earliest retained oplog entry (errors if it has rolled).
+    Earliest,
+    /// Resume after a specific opaque token. Overrides a persisted bookmark.
+    ResumeToken { token: Value },
+    /// Start at a wall-clock second. Overrides a persisted bookmark.
+    Timestamp { timestamp_secs: u32 },
+}
+
+impl Default for StartFrom {
+    fn default() -> Self {
+        StartFrom::Now
+    }
+}
+
+/// Post-image inclusion mode (maps to the driver `FullDocumentType`).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum FullDocument {
+    /// Do not request the post-image (default). `after` is null on update/replace.
+    #[default]
+    Off,
+    /// Include the post-image when the server can supply it.
+    WhenAvailable,
+    /// Require the post-image (errors if unavailable).
+    Required,
+    /// Look up the current full document at emit time (read-skew caveat).
+    UpdateLookup,
+}
+
+/// Pre-image inclusion mode (maps to the driver `FullDocumentBeforeChangeType`).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum FullDocumentBeforeChange {
+    /// Do not request the pre-image (default).
+    #[default]
+    Off,
+    /// Include the pre-image when available (MongoDB 6.0+, pre-images enabled).
+    WhenAvailable,
+    /// Require the pre-image (errors if unavailable).
+    Required,
+}
+
+/// Configuration for [`MongoCdcSource`](crate::MongoCdcSource).
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
+pub struct MongoCdcSourceConfig {
+    /// MongoDB connection URI. Must point at a replica set or sharded cluster.
+    pub connection_uri: String,
+    /// Which change stream to open.
+    #[serde(default)]
+    pub scope: Scope,
+    /// Allowlist of operation types (`insert`/`update`/`replace`/`delete`/...).
+    /// Empty = all. Prepended server-side as a `$match` on `operationType`.
+    #[serde(default)]
+    pub operation_types: Vec<String>,
+    /// Post-image inclusion mode.
+    #[serde(default)]
+    pub full_document: FullDocument,
+    /// Pre-image inclusion mode (MongoDB 6.0+).
+    #[serde(default)]
+    pub full_document_before_change: FullDocumentBeforeChange,
+    /// Start position on a fresh run (ignored once a bookmark exists, except an
+    /// explicit `resume_token`/`timestamp` which overrides the bookmark).
+    #[serde(default)]
+    pub start_from: StartFrom,
+    /// Optional extra aggregation-pipeline stages, each a JSON object, appended
+    /// after the operation-type `$match`.
+    #[serde(default)]
+    pub aggregation_pipeline: Vec<Value>,
+    /// Terminator: flush the buffer and end the fetch cycle after this much
+    /// quiet. Default 30s.
+    #[serde(
+        default = "default_idle_timeout",
+        with = "faucet_core::config::duration_secs"
+    )]
+    #[schemars(with = "u64")]
+    pub idle_timeout: Duration,
+    /// Server-side blocking `getMore` wait. Must be `< idle_timeout`. Default 1000.
+    #[serde(default = "default_max_await_time_ms")]
+    pub max_await_time_ms: u64,
+    /// Records per emitted `StreamPage`. `0` = drain until idle into one page.
+    #[serde(default = "default_batch_size")]
+    pub batch_size: usize,
+}
+
+impl MongoCdcSourceConfig {
+    /// Validate fail-fast invariants. Called from `MongoCdcSource::new`.
+    pub fn validate(&self) -> Result<(), FaucetError> {
+        if self.connection_uri.trim().is_empty() {
+            return Err(FaucetError::Config(
+                "mongodb-cdc: connection_uri must not be empty".into(),
+            ));
+        }
+        match &self.scope {
+            Scope::Collection { database, collection } => {
+                if database.trim().is_empty() || collection.trim().is_empty() {
+                    return Err(FaucetError::Config(
+                        "mongodb-cdc: scope.database and scope.collection must not be empty".into(),
+                    ));
+                }
+            }
+            Scope::Database { database } => {
+                if database.trim().is_empty() {
+                    return Err(FaucetError::Config(
+                        "mongodb-cdc: scope.database must not be empty".into(),
+                    ));
+                }
+            }
+            Scope::Cluster => {}
+        }
+        let idle_ms = self.idle_timeout.as_millis();
+        if idle_ms == 0 {
+            return Err(FaucetError::Config(
+                "mongodb-cdc: idle_timeout must be > 0".into(),
+            ));
+        }
+        if u128::from(self.max_await_time_ms) >= idle_ms {
+            return Err(FaucetError::Config(format!(
+                "mongodb-cdc: max_await_time_ms ({}) must be strictly less than \
+                 idle_timeout ({}ms)",
+                self.max_await_time_ms, idle_ms
+            )));
+        }
+        faucet_core::validate_batch_size(self.batch_size)?;
+        // Validate the derived state key is store-safe.
+        let key = crate::state::state_key(&self.scope);
+        faucet_core::state::validate_state_key(&key)?;
+        Ok(())
+    }
+}
+
+impl fmt::Debug for MongoCdcSourceConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MongoCdcSourceConfig")
+            .field("connection_uri", &"***")
+            .field("scope", &self.scope)
+            .field("operation_types", &self.operation_types)
+            .field("full_document", &self.full_document)
+            .field("full_document_before_change", &self.full_document_before_change)
+            .field("start_from", &self.start_from)
+            .field("aggregation_pipeline", &self.aggregation_pipeline)
+            .field("idle_timeout", &self.idle_timeout)
+            .field("max_await_time_ms", &self.max_await_time_ms)
+            .field("batch_size", &self.batch_size)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn minimal() -> MongoCdcSourceConfig {
+        serde_json::from_value(json!({
+            "connection_uri": "mongodb://localhost:27017/?replicaSet=rs0",
+            "scope": { "type": "collection", "database": "app", "collection": "users" }
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn defaults_via_serde() {
+        let c = minimal();
+        assert_eq!(c.idle_timeout.as_secs(), 30);
+        assert_eq!(c.max_await_time_ms, 1000);
+        assert_eq!(c.batch_size, DEFAULT_BATCH_SIZE);
+        assert_eq!(c.start_from, StartFrom::Now);
+        assert_eq!(c.full_document, FullDocument::Off);
+        assert!(c.operation_types.is_empty());
+    }
+
+    #[test]
+    fn scope_tagged_enum_round_trips() {
+        let c: MongoCdcSourceConfig = serde_json::from_value(json!({
+            "connection_uri": "mongodb://h/?replicaSet=rs0",
+            "scope": { "type": "cluster" }
+        }))
+        .unwrap();
+        assert_eq!(c.scope, Scope::Cluster);
+    }
+
+    #[test]
+    fn validate_rejects_empty_uri() {
+        let mut c = minimal();
+        c.connection_uri = "  ".into();
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_max_await_ge_idle() {
+        let mut c = minimal();
+        c.idle_timeout = Duration::from_millis(500);
+        c.max_await_time_ms = 500;
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_empty_collection() {
+        let c: MongoCdcSourceConfig = serde_json::from_value(json!({
+            "connection_uri": "mongodb://h/?replicaSet=rs0",
+            "scope": { "type": "collection", "database": "app", "collection": "" }
+        }))
+        .unwrap();
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn validate_accepts_minimal() {
+        assert!(minimal().validate().is_ok());
+    }
+
+    #[test]
+    fn debug_redacts_connection_uri() {
+        let c: MongoCdcSourceConfig = serde_json::from_value(json!({
+            "connection_uri": "mongodb://user:secret@h:27017/?replicaSet=rs0",
+            "scope": { "type": "cluster" }
+        }))
+        .unwrap();
+        let dbg = format!("{c:?}");
+        assert!(dbg.contains("***"));
+        assert!(!dbg.contains("secret"));
+    }
+
+    #[test]
+    fn schema_includes_connection_uri_required() {
+        let schema = schemars::schema_for!(MongoCdcSourceConfig);
+        let v = serde_json::to_value(&schema).unwrap();
+        let req = v["required"].as_array().unwrap();
+        let names: Vec<_> = req.iter().filter_map(|x| x.as_str()).collect();
+        assert!(names.contains(&"connection_uri"));
+    }
+}

--- a/crates/source/mongodb-cdc/src/envelope.rs
+++ b/crates/source/mongodb-cdc/src/envelope.rs
@@ -1,0 +1,147 @@
+//! Convert a driver `ChangeStreamEvent` into the faucet CDC envelope.
+
+use crate::state::Bookmark;
+use faucet_core::FaucetError;
+use mongodb::bson::{Bson, Document};
+use mongodb::change_stream::event::{ChangeStreamEvent, OperationType};
+use serde_json::{json, Value};
+
+/// Map a driver `OperationType` to the envelope `op` string.
+pub fn op_str(op: &OperationType) -> &'static str {
+    match op {
+        OperationType::Insert => "c",
+        OperationType::Update => "u",
+        OperationType::Replace => "r",
+        OperationType::Delete => "d",
+        OperationType::Drop
+        | OperationType::Rename
+        | OperationType::DropDatabase
+        | OperationType::Invalidate => "ddl",
+        _ => "ddl",
+    }
+}
+
+fn doc_to_json(doc: &Document) -> Value {
+    Bson::Document(doc.clone()).into_relaxed_extjson()
+}
+
+/// Build the CDC envelope for one change event. `bookmark` carries the event's
+/// resume token serialized to JSON.
+pub fn to_envelope(
+    event: &ChangeStreamEvent<Document>,
+    bookmark: &Bookmark,
+) -> Result<Value, FaucetError> {
+    let mut obj = serde_json::Map::new();
+    obj.insert("op".into(), json!(op_str(&event.operation_type)));
+
+    if let Some(ts) = &event.cluster_time {
+        obj.insert("ts_ms".into(), json!(i64::from(ts.time) * 1000));
+    } else {
+        obj.insert("ts_ms".into(), Value::Null);
+    }
+
+    let mut ns = serde_json::Map::new();
+    if let Some(n) = &event.ns {
+        ns.insert("db".into(), json!(n.db));
+        ns.insert("coll".into(), n.coll.clone().map(Value::String).unwrap_or(Value::Null));
+    }
+    obj.insert("namespace".into(), Value::Object(ns));
+
+    obj.insert(
+        "document_key".into(),
+        event.document_key.as_ref().map(doc_to_json).unwrap_or(Value::Null),
+    );
+    obj.insert(
+        "before".into(),
+        event.full_document_before_change.as_ref().map(doc_to_json).unwrap_or(Value::Null),
+    );
+    obj.insert(
+        "after".into(),
+        event.full_document.as_ref().map(doc_to_json).unwrap_or(Value::Null),
+    );
+
+    if let Some(ud) = &event.update_description {
+        obj.insert(
+            "update_description".into(),
+            json!({
+                "updated_fields": doc_to_json(&ud.updated_fields),
+                "removed_fields": ud.removed_fields,
+            }),
+        );
+    }
+
+    obj.insert("resume_token".into(), bookmark.resume_token.clone());
+    Ok(Value::Object(obj))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mongodb::bson;
+    use serde_json::json;
+
+    fn event_from_json(v: Value) -> ChangeStreamEvent<Document> {
+        let bson = bson::to_bson(&v).unwrap();
+        bson::from_bson(bson).unwrap()
+    }
+
+    fn fixture(op: &str) -> Value {
+        json!({
+            "_id": { "_data": "8264AB00" },
+            "operationType": op,
+            "clusterTime": { "$timestamp": { "t": 1716700000_u32, "i": 1 } },
+            "ns": { "db": "app", "coll": "users" },
+            "documentKey": { "_id": 42 },
+            "fullDocument": { "_id": 42, "name": "Alice" }
+        })
+    }
+
+    fn bookmark() -> Bookmark {
+        Bookmark { resume_token: json!({ "_data": "8264AB00" }) }
+    }
+
+    #[test]
+    fn insert_maps_to_c() {
+        let e = event_from_json(fixture("insert"));
+        let env = to_envelope(&e, &bookmark()).unwrap();
+        assert_eq!(env["op"], "c");
+        assert_eq!(env["ts_ms"], json!(1716700000_i64 * 1000));
+        assert_eq!(env["namespace"]["db"], "app");
+        assert_eq!(env["namespace"]["coll"], "users");
+        assert_eq!(env["after"]["name"], "Alice");
+        assert_eq!(env["resume_token"]["_data"], "8264AB00");
+    }
+
+    #[test]
+    fn update_maps_to_u_with_description() {
+        let mut v = fixture("update");
+        v["updateDescription"] = json!({
+            "updatedFields": { "name": "Bob" },
+            "removedFields": ["legacy"]
+        });
+        let e = event_from_json(v);
+        let env = to_envelope(&e, &bookmark()).unwrap();
+        assert_eq!(env["op"], "u");
+        assert_eq!(env["update_description"]["updated_fields"]["name"], "Bob");
+        assert_eq!(env["update_description"]["removed_fields"][0], "legacy");
+    }
+
+    #[test]
+    fn replace_and_delete_map() {
+        assert_eq!(to_envelope(&event_from_json(fixture("replace")), &bookmark()).unwrap()["op"], "r");
+        let mut del = fixture("delete");
+        del.as_object_mut().unwrap().remove("fullDocument");
+        let env = to_envelope(&event_from_json(del), &bookmark()).unwrap();
+        assert_eq!(env["op"], "d");
+        assert_eq!(env["after"], Value::Null);
+    }
+
+    #[test]
+    fn drop_maps_to_ddl() {
+        let mut v = fixture("drop");
+        v.as_object_mut().unwrap().remove("documentKey");
+        v.as_object_mut().unwrap().remove("fullDocument");
+        let env = to_envelope(&event_from_json(v), &bookmark()).unwrap();
+        assert_eq!(env["op"], "ddl");
+    }
+}

--- a/crates/source/mongodb-cdc/src/envelope.rs
+++ b/crates/source/mongodb-cdc/src/envelope.rs
@@ -4,7 +4,7 @@ use crate::state::Bookmark;
 use faucet_core::FaucetError;
 use mongodb::bson::{Bson, Document};
 use mongodb::change_stream::event::{ChangeStreamEvent, OperationType};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 /// Map a driver `OperationType` to the envelope `op` string.
 pub fn op_str(op: &OperationType) -> &'static str {
@@ -56,15 +56,27 @@ pub fn to_envelope(
 
     obj.insert(
         "document_key".into(),
-        event.document_key.as_ref().map(doc_to_json).unwrap_or(Value::Null),
+        event
+            .document_key
+            .as_ref()
+            .map(doc_to_json)
+            .unwrap_or(Value::Null),
     );
     obj.insert(
         "before".into(),
-        event.full_document_before_change.as_ref().map(doc_to_json).unwrap_or(Value::Null),
+        event
+            .full_document_before_change
+            .as_ref()
+            .map(doc_to_json)
+            .unwrap_or(Value::Null),
     );
     obj.insert(
         "after".into(),
-        event.full_document.as_ref().map(doc_to_json).unwrap_or(Value::Null),
+        event
+            .full_document
+            .as_ref()
+            .map(doc_to_json)
+            .unwrap_or(Value::Null),
     );
 
     if let Some(ud) = &event.update_description {
@@ -75,9 +87,7 @@ pub fn to_envelope(
             ud_obj.insert(
                 "truncated_arrays".into(),
                 serde_json::to_value(truncated).map_err(|e| {
-                    FaucetError::Source(format!(
-                        "mongodb-cdc: serialize truncated_arrays: {e}"
-                    ))
+                    FaucetError::Source(format!("mongodb-cdc: serialize truncated_arrays: {e}"))
                 })?,
             );
         }
@@ -111,7 +121,9 @@ mod tests {
     }
 
     fn bookmark() -> Bookmark {
-        Bookmark { resume_token: json!({ "_data": "8264AB00" }) }
+        Bookmark {
+            resume_token: json!({ "_data": "8264AB00" }),
+        }
     }
 
     #[test]
@@ -142,7 +154,10 @@ mod tests {
 
     #[test]
     fn replace_and_delete_map() {
-        assert_eq!(to_envelope(&event_from_json(fixture("replace")), &bookmark()).unwrap()["op"], "r");
+        assert_eq!(
+            to_envelope(&event_from_json(fixture("replace")), &bookmark()).unwrap()["op"],
+            "r"
+        );
         let mut del = fixture("delete");
         del.as_object_mut().unwrap().remove("fullDocument");
         let env = to_envelope(&event_from_json(del), &bookmark()).unwrap();

--- a/crates/source/mongodb-cdc/src/envelope.rs
+++ b/crates/source/mongodb-cdc/src/envelope.rs
@@ -17,6 +17,9 @@ pub fn op_str(op: &OperationType) -> &'static str {
         | OperationType::Rename
         | OperationType::DropDatabase
         | OperationType::Invalidate => "ddl",
+        // `OperationType` is `#[non_exhaustive]`; any future / expanded-event
+        // operation type (e.g. `create`, `createIndexes`, `modify` surfaced as
+        // `Other(String)`) is treated as a schema/DDL-like event.
         _ => "ddl",
     }
 }
@@ -40,12 +43,16 @@ pub fn to_envelope(
         obj.insert("ts_ms".into(), Value::Null);
     }
 
-    let mut ns = serde_json::Map::new();
-    if let Some(n) = &event.ns {
-        ns.insert("db".into(), json!(n.db));
-        ns.insert("coll".into(), n.coll.clone().map(Value::String).unwrap_or(Value::Null));
-    }
-    obj.insert("namespace".into(), Value::Object(ns));
+    // `namespace` is null for events without a namespace (e.g. a cluster-scope
+    // `invalidate`), so consumers can distinguish "no namespace" from an empty
+    // object.
+    obj.insert(
+        "namespace".into(),
+        match &event.ns {
+            Some(n) => json!({ "db": n.db, "coll": n.coll }),
+            None => Value::Null,
+        },
+    );
 
     obj.insert(
         "document_key".into(),
@@ -61,13 +68,20 @@ pub fn to_envelope(
     );
 
     if let Some(ud) = &event.update_description {
-        obj.insert(
-            "update_description".into(),
-            json!({
-                "updated_fields": doc_to_json(&ud.updated_fields),
-                "removed_fields": ud.removed_fields,
-            }),
-        );
+        let mut ud_obj = serde_json::Map::new();
+        ud_obj.insert("updated_fields".into(), doc_to_json(&ud.updated_fields));
+        ud_obj.insert("removed_fields".into(), json!(ud.removed_fields));
+        if let Some(truncated) = &ud.truncated_arrays {
+            ud_obj.insert(
+                "truncated_arrays".into(),
+                serde_json::to_value(truncated).map_err(|e| {
+                    FaucetError::Source(format!(
+                        "mongodb-cdc: serialize truncated_arrays: {e}"
+                    ))
+                })?,
+            );
+        }
+        obj.insert("update_description".into(), Value::Object(ud_obj));
     }
 
     obj.insert("resume_token".into(), bookmark.resume_token.clone());
@@ -143,5 +157,33 @@ mod tests {
         v.as_object_mut().unwrap().remove("fullDocument");
         let env = to_envelope(&event_from_json(v), &bookmark()).unwrap();
         assert_eq!(env["op"], "ddl");
+    }
+
+    #[test]
+    fn namespace_is_null_when_ns_absent() {
+        // A cluster-scope invalidate carries no `ns`.
+        let mut v = fixture("invalidate");
+        let o = v.as_object_mut().unwrap();
+        o.remove("ns");
+        o.remove("documentKey");
+        o.remove("fullDocument");
+        let env = to_envelope(&event_from_json(v), &bookmark()).unwrap();
+        assert_eq!(env["op"], "ddl");
+        assert_eq!(env["namespace"], Value::Null);
+    }
+
+    #[test]
+    fn update_includes_truncated_arrays_when_present() {
+        let mut v = fixture("update");
+        v["updateDescription"] = json!({
+            "updatedFields": { "name": "Bob" },
+            "removedFields": [],
+            "truncatedArrays": [{ "field": "tags", "newSize": 2 }]
+        });
+        let e = event_from_json(v);
+        let env = to_envelope(&e, &bookmark()).unwrap();
+        let truncated = &env["update_description"]["truncated_arrays"];
+        assert!(truncated.is_array());
+        assert_eq!(truncated[0]["field"], "tags");
     }
 }

--- a/crates/source/mongodb-cdc/src/lib.rs
+++ b/crates/source/mongodb-cdc/src/lib.rs
@@ -7,6 +7,8 @@
 mod config;
 mod envelope;
 mod state;
+mod stream;
 
 pub use config::{FullDocument, FullDocumentBeforeChange, MongoCdcSourceConfig, Scope, StartFrom};
 pub use state::{state_key, Bookmark};
+pub use stream::MongoCdcSource;

--- a/crates/source/mongodb-cdc/src/lib.rs
+++ b/crates/source/mongodb-cdc/src/lib.rs
@@ -1,0 +1,12 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+//! MongoDB Change Streams (CDC) source for the faucet-stream ecosystem.
+//!
+//! Tails a collection / database / cluster change stream and emits per-document
+//! change events as a CDC envelope, resumable via the opaque `resumeToken`.
+
+mod config;
+mod envelope;
+mod state;
+
+pub use config::{FullDocument, FullDocumentBeforeChange, MongoCdcSourceConfig, Scope, StartFrom};
+pub use state::{state_key, Bookmark};

--- a/crates/source/mongodb-cdc/src/lib.rs
+++ b/crates/source/mongodb-cdc/src/lib.rs
@@ -10,5 +10,5 @@ mod state;
 mod stream;
 
 pub use config::{FullDocument, FullDocumentBeforeChange, MongoCdcSourceConfig, Scope, StartFrom};
-pub use state::{state_key, Bookmark};
+pub use state::{Bookmark, state_key};
 pub use stream::MongoCdcSource;

--- a/crates/source/mongodb-cdc/src/state.rs
+++ b/crates/source/mongodb-cdc/src/state.rs
@@ -1,0 +1,121 @@
+//! State key derivation and resume-token bookmark serialization.
+//!
+//! Bookmark shape (round-trips through `serde_json::Value`):
+//!
+//! ```json
+//! { "resume_token": { "_data": "8264..." } }
+//! ```
+
+use crate::config::Scope;
+use faucet_core::FaucetError;
+use mongodb::bson::{self, Bson};
+use mongodb::change_stream::event::ResumeToken;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// State key for a given watch scope.
+///
+/// `cluster` → `mongodb-cdc:cluster`
+/// `database` → `mongodb-cdc:db:<database>`
+/// `collection` → `mongodb-cdc:coll:<database>.<collection>`
+pub fn state_key(scope: &Scope) -> String {
+    match scope {
+        Scope::Cluster => "mongodb-cdc:cluster".to_string(),
+        Scope::Database { database } => format!("mongodb-cdc:db:{database}"),
+        Scope::Collection { database, collection } => {
+            format!("mongodb-cdc:coll:{database}.{collection}")
+        }
+    }
+}
+
+/// Durable bookmark wrapping a resume token.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct Bookmark {
+    /// The opaque resume token as relaxed extended JSON (e.g. `{"_data": "..."}`).
+    pub resume_token: Value,
+}
+
+impl Bookmark {
+    /// Build a bookmark from a driver `ResumeToken`.
+    pub fn from_token(token: &ResumeToken) -> Result<Self, FaucetError> {
+        let bson = bson::to_bson(token).map_err(|e| {
+            FaucetError::State(format!("mongodb-cdc resume token serialize: {e}"))
+        })?;
+        Ok(Self {
+            resume_token: bson.into_relaxed_extjson(),
+        })
+    }
+
+    /// Parse a bookmark previously emitted by `to_value`.
+    pub fn from_value(v: Value) -> Result<Self, FaucetError> {
+        serde_json::from_value(v)
+            .map_err(|e| FaucetError::State(format!("mongodb-cdc bookmark parse: {e}")))
+    }
+
+    /// Serialize for the state store.
+    pub fn to_value(&self) -> Result<Value, FaucetError> {
+        serde_json::to_value(self)
+            .map_err(|e| FaucetError::State(format!("mongodb-cdc bookmark serialize: {e}")))
+    }
+
+    /// Decode the stored resume token back into a driver `ResumeToken`.
+    pub fn to_token(&self) -> Result<ResumeToken, FaucetError> {
+        let bson: Bson = bson::to_bson(&self.resume_token).map_err(|e| {
+            FaucetError::State(format!("mongodb-cdc resume token to bson: {e}"))
+        })?;
+        bson::from_bson(bson)
+            .map_err(|e| FaucetError::State(format!("mongodb-cdc resume token decode: {e}")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn state_key_cluster() {
+        assert_eq!(state_key(&Scope::Cluster), "mongodb-cdc:cluster");
+    }
+
+    #[test]
+    fn state_key_database() {
+        assert_eq!(
+            state_key(&Scope::Database { database: "app".into() }),
+            "mongodb-cdc:db:app"
+        );
+    }
+
+    #[test]
+    fn state_key_collection() {
+        assert_eq!(
+            state_key(&Scope::Collection {
+                database: "app".into(),
+                collection: "users".into()
+            }),
+            "mongodb-cdc:coll:app.users"
+        );
+    }
+
+    #[test]
+    fn bookmark_value_round_trip() {
+        let b = Bookmark { resume_token: json!({ "_data": "8264AB" }) };
+        let v = b.to_value().unwrap();
+        let parsed = Bookmark::from_value(v).unwrap();
+        assert_eq!(parsed, b);
+    }
+
+    #[test]
+    fn bookmark_token_round_trip() {
+        let b = Bookmark { resume_token: json!({ "_data": "8264AB00" }) };
+        let token = b.to_token().unwrap();
+        let b2 = Bookmark::from_token(&token).unwrap();
+        assert_eq!(b2.resume_token["_data"], json!("8264AB00"));
+    }
+
+    #[test]
+    fn from_value_rejects_garbage() {
+        assert!(Bookmark::from_value(json!({})).is_err());
+        assert!(Bookmark::from_value(json!("bare")).is_err());
+    }
+}

--- a/crates/source/mongodb-cdc/src/state.rs
+++ b/crates/source/mongodb-cdc/src/state.rs
@@ -22,7 +22,10 @@ pub fn state_key(scope: &Scope) -> String {
     match scope {
         Scope::Cluster => "mongodb-cdc:cluster".to_string(),
         Scope::Database { database } => format!("mongodb-cdc:db:{database}"),
-        Scope::Collection { database, collection } => {
+        Scope::Collection {
+            database,
+            collection,
+        } => {
             format!("mongodb-cdc:coll:{database}.{collection}")
         }
     }
@@ -38,9 +41,8 @@ pub struct Bookmark {
 impl Bookmark {
     /// Build a bookmark from a driver `ResumeToken`.
     pub fn from_token(token: &ResumeToken) -> Result<Self, FaucetError> {
-        let bson = bson::to_bson(token).map_err(|e| {
-            FaucetError::State(format!("mongodb-cdc resume token serialize: {e}"))
-        })?;
+        let bson = bson::to_bson(token)
+            .map_err(|e| FaucetError::State(format!("mongodb-cdc resume token serialize: {e}")))?;
         Ok(Self {
             resume_token: bson.into_relaxed_extjson(),
         })
@@ -60,9 +62,8 @@ impl Bookmark {
 
     /// Decode the stored resume token back into a driver `ResumeToken`.
     pub fn to_token(&self) -> Result<ResumeToken, FaucetError> {
-        let bson: Bson = bson::to_bson(&self.resume_token).map_err(|e| {
-            FaucetError::State(format!("mongodb-cdc resume token to bson: {e}"))
-        })?;
+        let bson: Bson = bson::to_bson(&self.resume_token)
+            .map_err(|e| FaucetError::State(format!("mongodb-cdc resume token to bson: {e}")))?;
         bson::from_bson(bson)
             .map_err(|e| FaucetError::State(format!("mongodb-cdc resume token decode: {e}")))
     }
@@ -81,7 +82,9 @@ mod tests {
     #[test]
     fn state_key_database() {
         assert_eq!(
-            state_key(&Scope::Database { database: "app".into() }),
+            state_key(&Scope::Database {
+                database: "app".into()
+            }),
             "mongodb-cdc:db:app"
         );
     }
@@ -99,7 +102,9 @@ mod tests {
 
     #[test]
     fn bookmark_value_round_trip() {
-        let b = Bookmark { resume_token: json!({ "_data": "8264AB" }) };
+        let b = Bookmark {
+            resume_token: json!({ "_data": "8264AB" }),
+        };
         let v = b.to_value().unwrap();
         let parsed = Bookmark::from_value(v).unwrap();
         assert_eq!(parsed, b);
@@ -107,7 +112,9 @@ mod tests {
 
     #[test]
     fn bookmark_token_round_trip() {
-        let b = Bookmark { resume_token: json!({ "_data": "8264AB00" }) };
+        let b = Bookmark {
+            resume_token: json!({ "_data": "8264AB00" }),
+        };
         let token = b.to_token().unwrap();
         let b2 = Bookmark::from_token(&token).unwrap();
         assert_eq!(b2.resume_token["_data"], json!("8264AB00"));

--- a/crates/source/mongodb-cdc/src/stream.rs
+++ b/crates/source/mongodb-cdc/src/stream.rs
@@ -2,7 +2,7 @@
 
 use crate::config::{MongoCdcSourceConfig, StartFrom};
 use crate::envelope::to_envelope;
-use crate::state::{state_key, Bookmark};
+use crate::state::{Bookmark, state_key};
 use async_trait::async_trait;
 use faucet_core::{FaucetError, Source, Stream, StreamPage};
 use mongodb::Client;
@@ -35,7 +35,9 @@ pub(crate) fn resolve_start(
 ) -> Result<StartPosition, FaucetError> {
     match start_from {
         StartFrom::ResumeToken { token } => {
-            let b = Bookmark { resume_token: token.clone() };
+            let b = Bookmark {
+                resume_token: token.clone(),
+            };
             Ok(StartPosition::ResumeAfter(b.to_token()?))
         }
         StartFrom::Timestamp { timestamp_secs } => Ok(StartPosition::AtOperationTime(Timestamp {
@@ -47,7 +49,10 @@ pub(crate) fn resolve_start(
                 Ok(StartPosition::ResumeAfter(b.to_token()?))
             } else if matches!(start_from, StartFrom::Earliest) {
                 // Earliest retained oplog entry (errors at open if rolled).
-                Ok(StartPosition::AtOperationTime(Timestamp { time: 1, increment: 1 }))
+                Ok(StartPosition::AtOperationTime(Timestamp {
+                    time: 1,
+                    increment: 1,
+                }))
             } else {
                 Ok(StartPosition::Now)
             }
@@ -109,7 +114,10 @@ async fn ensure_changestream_capable(client: &Client) -> Result<(), FaucetError>
 /// Classify a `hello` response: replica-set (`setName`) or sharded (`msg=isdbgrid`).
 pub(crate) fn is_changestream_topology(hello: &Document) -> bool {
     hello.get_str("setName").is_ok()
-        || hello.get_str("msg").map(|m| m == "isdbgrid").unwrap_or(false)
+        || hello
+            .get_str("msg")
+            .map(|m| m == "isdbgrid")
+            .unwrap_or(false)
 }
 
 /// Map the config post-image mode to the driver type (`None` = don't request).
@@ -419,29 +427,50 @@ mod tests {
 
     #[test]
     fn explicit_timestamp_overrides_bookmark() {
-        let pending = Bookmark { resume_token: json!({ "_data": "AA" }) };
-        let pos =
-            resolve_start(&StartFrom::Timestamp { timestamp_secs: 100 }, Some(&pending)).unwrap();
-        assert_eq!(pos, StartPosition::AtOperationTime(Timestamp { time: 100, increment: 0 }));
+        let pending = Bookmark {
+            resume_token: json!({ "_data": "AA" }),
+        };
+        let pos = resolve_start(
+            &StartFrom::Timestamp {
+                timestamp_secs: 100,
+            },
+            Some(&pending),
+        )
+        .unwrap();
+        assert_eq!(
+            pos,
+            StartPosition::AtOperationTime(Timestamp {
+                time: 100,
+                increment: 0
+            })
+        );
     }
 
     #[test]
     fn now_yields_to_bookmark() {
-        let pending = Bookmark { resume_token: json!({ "_data": "8264AB00" }) };
+        let pending = Bookmark {
+            resume_token: json!({ "_data": "8264AB00" }),
+        };
         let pos = resolve_start(&StartFrom::Now, Some(&pending)).unwrap();
         assert!(matches!(pos, StartPosition::ResumeAfter(_)));
     }
 
     #[test]
     fn now_without_bookmark_is_now() {
-        assert_eq!(resolve_start(&StartFrom::Now, None).unwrap(), StartPosition::Now);
+        assert_eq!(
+            resolve_start(&StartFrom::Now, None).unwrap(),
+            StartPosition::Now
+        );
     }
 
     #[test]
     fn earliest_without_bookmark_uses_operation_time() {
         assert_eq!(
             resolve_start(&StartFrom::Earliest, None).unwrap(),
-            StartPosition::AtOperationTime(Timestamp { time: 1, increment: 1 })
+            StartPosition::AtOperationTime(Timestamp {
+                time: 1,
+                increment: 1
+            })
         );
     }
 

--- a/crates/source/mongodb-cdc/src/stream.rs
+++ b/crates/source/mongodb-cdc/src/stream.rs
@@ -1,0 +1,442 @@
+//! MongoDB change-stream executor.
+
+use crate::config::{MongoCdcSourceConfig, StartFrom};
+use crate::envelope::to_envelope;
+use crate::state::{state_key, Bookmark};
+use async_trait::async_trait;
+use faucet_core::{FaucetError, Source, Stream, StreamPage};
+use mongodb::Client;
+use mongodb::bson::{self, Document, Timestamp};
+use mongodb::change_stream::event::ResumeToken;
+use mongodb::options::{FullDocumentBeforeChangeType, FullDocumentType};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::pin::Pin;
+use tokio::sync::Mutex;
+
+/// Effective start position resolved for a given fetch cycle.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum StartPosition {
+    /// Server default (current cluster time).
+    Now,
+    /// `start_at_operation_time`.
+    AtOperationTime(Timestamp),
+    /// `resume_after(token)`.
+    ResumeAfter(ResumeToken),
+}
+
+/// Resolve the effective start position from config + any persisted bookmark.
+///
+/// Precedence: explicit `resume_token`/`timestamp` win over a persisted
+/// bookmark; `now`/`earliest` yield to a persisted bookmark.
+pub(crate) fn resolve_start(
+    start_from: &StartFrom,
+    pending: Option<&Bookmark>,
+) -> Result<StartPosition, FaucetError> {
+    match start_from {
+        StartFrom::ResumeToken { token } => {
+            let b = Bookmark { resume_token: token.clone() };
+            Ok(StartPosition::ResumeAfter(b.to_token()?))
+        }
+        StartFrom::Timestamp { timestamp_secs } => Ok(StartPosition::AtOperationTime(Timestamp {
+            time: *timestamp_secs,
+            increment: 0,
+        })),
+        StartFrom::Now | StartFrom::Earliest => {
+            if let Some(b) = pending {
+                Ok(StartPosition::ResumeAfter(b.to_token()?))
+            } else if matches!(start_from, StartFrom::Earliest) {
+                // Earliest retained oplog entry (errors at open if rolled).
+                Ok(StartPosition::AtOperationTime(Timestamp { time: 1, increment: 1 }))
+            } else {
+                Ok(StartPosition::Now)
+            }
+        }
+    }
+}
+
+/// A configured MongoDB CDC source.
+pub struct MongoCdcSource {
+    config: MongoCdcSourceConfig,
+    client: Client,
+    state_key_value: String,
+    pending_bookmark: Mutex<Option<Bookmark>>,
+}
+
+impl MongoCdcSource {
+    /// Connect, validate config + topology, and build the source.
+    pub async fn new(config: MongoCdcSourceConfig) -> Result<Self, FaucetError> {
+        config.validate()?;
+        let client = Client::with_uri_str(&config.connection_uri)
+            .await
+            .map_err(|e| FaucetError::Source(format!("MongoDB connection failed: {e}")))?;
+        ensure_changestream_capable(&client).await?;
+        if config.full_document_before_change != crate::config::FullDocumentBeforeChange::Off {
+            tracing::warn!(
+                "mongodb-cdc: full_document_before_change requires MongoDB 6.0+ and the \
+                 collection's changeStreamPreAndPostImages enabled; the server will error \
+                 at stream open if unavailable"
+            );
+        }
+        let state_key_value = state_key(&config.scope);
+        Ok(Self {
+            config,
+            client,
+            state_key_value,
+            pending_bookmark: Mutex::new(None),
+        })
+    }
+}
+
+/// Run `hello` and assert the deployment supports change streams.
+async fn ensure_changestream_capable(client: &Client) -> Result<(), FaucetError> {
+    let hello = client
+        .database("admin")
+        .run_command(bson::doc! { "hello": 1 })
+        .await
+        .map_err(|e| FaucetError::Source(format!("mongodb-cdc hello failed: {e}")))?;
+    if is_changestream_topology(&hello) {
+        Ok(())
+    } else {
+        Err(FaucetError::Source(
+            "mongodb-cdc: Change Streams require a replica set or sharded cluster; \
+             the target appears to be a standalone mongod"
+                .into(),
+        ))
+    }
+}
+
+/// Classify a `hello` response: replica-set (`setName`) or sharded (`msg=isdbgrid`).
+pub(crate) fn is_changestream_topology(hello: &Document) -> bool {
+    hello.get_str("setName").is_ok()
+        || hello.get_str("msg").map(|m| m == "isdbgrid").unwrap_or(false)
+}
+
+/// Map the config post-image mode to the driver type (`None` = don't request).
+pub(crate) fn full_document_type(fd: crate::config::FullDocument) -> Option<FullDocumentType> {
+    use crate::config::FullDocument as F;
+    match fd {
+        F::Off => None,
+        F::WhenAvailable => Some(FullDocumentType::WhenAvailable),
+        F::Required => Some(FullDocumentType::Required),
+        F::UpdateLookup => Some(FullDocumentType::UpdateLookup),
+    }
+}
+
+/// Map the config pre-image mode to the driver type (`None` = don't request).
+pub(crate) fn full_document_before_type(
+    fd: crate::config::FullDocumentBeforeChange,
+) -> Option<FullDocumentBeforeChangeType> {
+    use crate::config::FullDocumentBeforeChange as F;
+    match fd {
+        F::Off => None,
+        F::WhenAvailable => Some(FullDocumentBeforeChangeType::WhenAvailable),
+        F::Required => Some(FullDocumentBeforeChangeType::Required),
+    }
+}
+
+/// Build the server-side pipeline: operation-type `$match` + user stages.
+pub(crate) fn build_pipeline(config: &MongoCdcSourceConfig) -> Result<Vec<Document>, FaucetError> {
+    let mut pipeline: Vec<Document> = Vec::new();
+    if !config.operation_types.is_empty() {
+        pipeline.push(bson::doc! {
+            "$match": { "operationType": { "$in": config.operation_types.clone() } }
+        });
+    }
+    for (i, stage) in config.aggregation_pipeline.iter().enumerate() {
+        let b = bson::to_bson(stage)
+            .map_err(|e| FaucetError::Config(format!("mongodb-cdc: pipeline stage {i}: {e}")))?;
+        match b {
+            bson::Bson::Document(d) => pipeline.push(d),
+            other => {
+                return Err(FaucetError::Config(format!(
+                    "mongodb-cdc: aggregation_pipeline[{i}] must be an object, got {other:?}"
+                )));
+            }
+        }
+    }
+    Ok(pipeline)
+}
+
+#[async_trait]
+impl Source for MongoCdcSource {
+    async fn fetch_with_context(
+        &self,
+        ctx: &HashMap<String, Value>,
+    ) -> Result<Vec<Value>, FaucetError> {
+        use futures::StreamExt;
+        let mut pages = self.stream_pages(ctx, 0);
+        let mut all = Vec::new();
+        while let Some(page) = pages.next().await {
+            all.extend(page?.records);
+        }
+        Ok(all)
+    }
+
+    fn stream_pages<'a>(
+        &'a self,
+        ctx: &'a HashMap<String, Value>,
+        _batch_size: usize,
+    ) -> Pin<Box<dyn Stream<Item = Result<StreamPage, FaucetError>> + Send + 'a>> {
+        self.stream_pages_impl(ctx, self.config.batch_size)
+    }
+
+    fn config_schema(&self) -> Value {
+        serde_json::to_value(schemars::schema_for!(MongoCdcSourceConfig)).unwrap_or(Value::Null)
+    }
+
+    fn state_key(&self) -> Option<String> {
+        Some(self.state_key_value.clone())
+    }
+
+    async fn apply_start_bookmark(&self, bookmark: Value) -> Result<(), FaucetError> {
+        let b = Bookmark::from_value(bookmark)?;
+        // Round-trip-validate the token now so a corrupt bookmark fails fast.
+        b.to_token()?;
+        *self.pending_bookmark.lock().await = Some(b);
+        Ok(())
+    }
+
+    fn connector_name(&self) -> &'static str {
+        "mongodb-cdc"
+    }
+
+    async fn check(
+        &self,
+        ctx: &faucet_core::check::CheckContext,
+    ) -> Result<faucet_core::check::CheckReport, FaucetError> {
+        use faucet_core::check::{CheckReport, Probe};
+        let start = std::time::Instant::now();
+        let probe = async {
+            let hello = self
+                .client
+                .database("admin")
+                .run_command(bson::doc! { "hello": 1 })
+                .await
+                .map_err(|e| {
+                    Probe::fail_hint(
+                        "connection",
+                        start.elapsed(),
+                        format!("could not run hello: {e}"),
+                        "verify the URI is reachable and credentials are valid",
+                    )
+                })?;
+            Ok::<Probe, Probe>(if is_changestream_topology(&hello) {
+                Probe::pass("topology", start.elapsed())
+            } else {
+                Probe::fail_hint(
+                    "topology",
+                    start.elapsed(),
+                    "target is a standalone mongod",
+                    "Change Streams require a replica set or sharded cluster",
+                )
+            })
+        };
+        let probe = match tokio::time::timeout(ctx.timeout, probe).await {
+            Ok(Ok(p)) | Ok(Err(p)) => p,
+            Err(_) => Probe::fail_hint(
+                "connection",
+                start.elapsed(),
+                "connection timed out",
+                "the server did not respond within the check timeout",
+            ),
+        };
+        Ok(CheckReport::single(probe))
+    }
+}
+
+impl MongoCdcSource {
+    /// Open the change stream and drain it with an idle-timeout terminator.
+    fn stream_pages_impl<'a>(
+        &'a self,
+        _ctx: &'a HashMap<String, Value>,
+        batch_size: usize,
+    ) -> Pin<Box<dyn Stream<Item = Result<StreamPage, FaucetError>> + Send + 'a>> {
+        let idle_timeout = self.config.idle_timeout;
+        let max_await = std::time::Duration::from_millis(self.config.max_await_time_ms);
+        let per_batch = batch_size != 0;
+
+        Box::pin(async_stream::try_stream! {
+            use futures::StreamExt;
+
+            let pending = self.pending_bookmark.lock().await.take();
+            let start = resolve_start(&self.config.start_from, pending.as_ref())?;
+            let pipeline = build_pipeline(&self.config)?;
+
+            // Open the change stream scoped to collection, database, or cluster.
+            // Each arm resolves to a ChangeStream<ChangeStreamEvent<Document>>.
+            let change_stream: mongodb::change_stream::ChangeStream<
+                mongodb::change_stream::event::ChangeStreamEvent<Document>,
+            > = match &self.config.scope {
+                crate::config::Scope::Collection { database, collection } => {
+                    let coll: mongodb::Collection<Document> =
+                        self.client.database(database).collection(collection);
+                    let mut w = coll
+                        .watch()
+                        .pipeline(pipeline)
+                        .max_await_time(max_await);
+                    if let Some(fd) = full_document_type(self.config.full_document) {
+                        w = w.full_document(fd);
+                    }
+                    if let Some(fb) =
+                        full_document_before_type(self.config.full_document_before_change)
+                    {
+                        w = w.full_document_before_change(fb);
+                    }
+                    w = match &start {
+                        StartPosition::Now => w,
+                        StartPosition::AtOperationTime(ts) => w.start_at_operation_time(*ts),
+                        StartPosition::ResumeAfter(tok) => w.resume_after(tok.clone()),
+                    };
+                    w.await
+                        .map_err(|e| FaucetError::Source(format!("mongodb-cdc watch failed: {e}")))?
+                }
+                crate::config::Scope::Database { database } => {
+                    let db = self.client.database(database);
+                    let mut w = db
+                        .watch()
+                        .pipeline(pipeline)
+                        .max_await_time(max_await);
+                    if let Some(fd) = full_document_type(self.config.full_document) {
+                        w = w.full_document(fd);
+                    }
+                    if let Some(fb) =
+                        full_document_before_type(self.config.full_document_before_change)
+                    {
+                        w = w.full_document_before_change(fb);
+                    }
+                    w = match &start {
+                        StartPosition::Now => w,
+                        StartPosition::AtOperationTime(ts) => w.start_at_operation_time(*ts),
+                        StartPosition::ResumeAfter(tok) => w.resume_after(tok.clone()),
+                    };
+                    w.await
+                        .map_err(|e| FaucetError::Source(format!("mongodb-cdc watch failed: {e}")))?
+                }
+                crate::config::Scope::Cluster => {
+                    let mut w = self.client
+                        .watch()
+                        .pipeline(pipeline)
+                        .max_await_time(max_await);
+                    if let Some(fd) = full_document_type(self.config.full_document) {
+                        w = w.full_document(fd);
+                    }
+                    if let Some(fb) =
+                        full_document_before_type(self.config.full_document_before_change)
+                    {
+                        w = w.full_document_before_change(fb);
+                    }
+                    w = match &start {
+                        StartPosition::Now => w,
+                        StartPosition::AtOperationTime(ts) => w.start_at_operation_time(*ts),
+                        StartPosition::ResumeAfter(tok) => w.resume_after(tok.clone()),
+                    };
+                    w.await
+                        .map_err(|e| FaucetError::Source(format!("mongodb-cdc watch failed: {e}")))?
+                }
+            };
+            let mut change_stream = std::pin::pin!(change_stream);
+
+            let chunk = if per_batch { batch_size } else { usize::MAX };
+            let mut buffer: Vec<Value> = Vec::new();
+            let mut last_token: Option<ResumeToken> = None;
+
+            loop {
+                match tokio::time::timeout(idle_timeout, change_stream.next()).await {
+                    Ok(Some(Ok(event))) => {
+                        let token = event.id.clone();
+                        let bookmark = Bookmark::from_token(&token)?;
+                        let is_invalidate = matches!(
+                            event.operation_type,
+                            mongodb::change_stream::event::OperationType::Invalidate
+                        );
+                        buffer.push(to_envelope(&event, &bookmark)?);
+                        last_token = Some(token);
+
+                        if is_invalidate {
+                            // Safe unwrap: we just set last_token = Some(...) above.
+                            let tok = last_token.as_ref().expect("last_token set above");
+                            let bm = Bookmark::from_token(tok)?.to_value()?;
+                            yield StreamPage { records: std::mem::take(&mut buffer), bookmark: Some(bm) };
+                            break;
+                        }
+                        if per_batch && buffer.len() >= chunk {
+                            let tok = last_token.as_ref().expect("last_token set above");
+                            let bm = Bookmark::from_token(tok)?.to_value()?;
+                            yield StreamPage { records: std::mem::take(&mut buffer), bookmark: Some(bm) };
+                        }
+                    }
+                    Ok(Some(Err(e))) => {
+                        Err(FaucetError::Source(format!("mongodb-cdc stream error: {e}")))?;
+                    }
+                    Ok(None) | Err(_) => {
+                        if !buffer.is_empty() {
+                            let bm = match last_token.as_ref() {
+                                Some(t) => Some(Bookmark::from_token(t)?.to_value()?),
+                                None => None,
+                            };
+                            yield StreamPage { records: std::mem::take(&mut buffer), bookmark: bm };
+                        }
+                        break;
+                    }
+                }
+            }
+
+            tracing::info!(connector = "mongodb-cdc", "change stream fetch cycle complete");
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn explicit_timestamp_overrides_bookmark() {
+        let pending = Bookmark { resume_token: json!({ "_data": "AA" }) };
+        let pos =
+            resolve_start(&StartFrom::Timestamp { timestamp_secs: 100 }, Some(&pending)).unwrap();
+        assert_eq!(pos, StartPosition::AtOperationTime(Timestamp { time: 100, increment: 0 }));
+    }
+
+    #[test]
+    fn now_yields_to_bookmark() {
+        let pending = Bookmark { resume_token: json!({ "_data": "8264AB00" }) };
+        let pos = resolve_start(&StartFrom::Now, Some(&pending)).unwrap();
+        assert!(matches!(pos, StartPosition::ResumeAfter(_)));
+    }
+
+    #[test]
+    fn now_without_bookmark_is_now() {
+        assert_eq!(resolve_start(&StartFrom::Now, None).unwrap(), StartPosition::Now);
+    }
+
+    #[test]
+    fn earliest_without_bookmark_uses_operation_time() {
+        assert_eq!(
+            resolve_start(&StartFrom::Earliest, None).unwrap(),
+            StartPosition::AtOperationTime(Timestamp { time: 1, increment: 1 })
+        );
+    }
+
+    #[test]
+    fn topology_classification() {
+        assert!(is_changestream_topology(&bson::doc! { "setName": "rs0" }));
+        assert!(is_changestream_topology(&bson::doc! { "msg": "isdbgrid" }));
+        assert!(!is_changestream_topology(&bson::doc! { "ok": 1.0 }));
+    }
+
+    #[test]
+    fn pipeline_prepends_operation_match() {
+        let c: MongoCdcSourceConfig = serde_json::from_value(json!({
+            "connection_uri": "mongodb://h/?replicaSet=rs0",
+            "scope": { "type": "cluster" },
+            "operation_types": ["insert", "delete"]
+        }))
+        .unwrap();
+        let p = build_pipeline(&c).unwrap();
+        assert_eq!(p.len(), 1);
+        assert!(p[0].contains_key("$match"));
+    }
+}

--- a/crates/source/mongodb-cdc/src/stream.rs
+++ b/crates/source/mongodb-cdc/src/stream.rs
@@ -207,41 +207,54 @@ impl Source for MongoCdcSource {
     ) -> Result<faucet_core::check::CheckReport, FaucetError> {
         use faucet_core::check::{CheckReport, Probe};
         let start = std::time::Instant::now();
-        let probe = async {
-            let hello = self
-                .client
+
+        // Run `hello` once under the probe timeout, then derive two probes from
+        // the outcome: `connection` (could we reach + auth to the server?) and
+        // `topology` (does it support change streams?). On a connection
+        // failure/timeout the topology probe cannot run, so only `connection`
+        // is reported.
+        let hello = tokio::time::timeout(
+            ctx.timeout,
+            self.client
                 .database("admin")
-                .run_command(bson::doc! { "hello": 1 })
-                .await
-                .map_err(|e| {
-                    Probe::fail_hint(
-                        "connection",
-                        start.elapsed(),
-                        format!("could not run hello: {e}"),
-                        "verify the URI is reachable and credentials are valid",
-                    )
-                })?;
-            Ok::<Probe, Probe>(if is_changestream_topology(&hello) {
-                Probe::pass("topology", start.elapsed())
-            } else {
-                Probe::fail_hint(
-                    "topology",
+                .run_command(bson::doc! { "hello": 1 }),
+        )
+        .await;
+
+        let hello = match hello {
+            Ok(Ok(doc)) => doc,
+            Ok(Err(e)) => {
+                return Ok(CheckReport::single(Probe::fail_hint(
+                    "connection",
                     start.elapsed(),
-                    "target is a standalone mongod",
-                    "Change Streams require a replica set or sharded cluster",
-                )
-            })
+                    format!("could not run hello: {e}"),
+                    "verify the URI is reachable and credentials are valid",
+                )));
+            }
+            Err(_elapsed) => {
+                return Ok(CheckReport::single(Probe::fail_hint(
+                    "connection",
+                    start.elapsed(),
+                    "connection timed out",
+                    "the server did not respond within the check timeout",
+                )));
+            }
         };
-        let probe = match tokio::time::timeout(ctx.timeout, probe).await {
-            Ok(Ok(p)) | Ok(Err(p)) => p,
-            Err(_) => Probe::fail_hint(
-                "connection",
+
+        let connection = Probe::pass("connection", start.elapsed());
+        let topology = if is_changestream_topology(&hello) {
+            Probe::pass("topology", start.elapsed())
+        } else {
+            Probe::fail_hint(
+                "topology",
                 start.elapsed(),
-                "connection timed out",
-                "the server did not respond within the check timeout",
-            ),
+                "target is a standalone mongod",
+                "Change Streams require a replica set or sharded cluster",
+            )
         };
-        Ok(CheckReport::single(probe))
+        Ok(CheckReport {
+            probes: vec![connection, topology],
+        })
     }
 }
 
@@ -438,5 +451,16 @@ mod tests {
         let p = build_pipeline(&c).unwrap();
         assert_eq!(p.len(), 1);
         assert!(p[0].contains_key("$match"));
+    }
+
+    #[test]
+    fn pipeline_rejects_non_object_stage() {
+        let c: MongoCdcSourceConfig = serde_json::from_value(json!({
+            "connection_uri": "mongodb://h/?replicaSet=rs0",
+            "scope": { "type": "cluster" },
+            "aggregation_pipeline": [[1, 2, 3]]
+        }))
+        .unwrap();
+        assert!(matches!(build_pipeline(&c), Err(FaucetError::Config(_))));
     }
 }

--- a/crates/source/mongodb-cdc/src/stream.rs
+++ b/crates/source/mongodb-cdc/src/stream.rs
@@ -352,43 +352,55 @@ impl MongoCdcSource {
 
             let chunk = if per_batch { batch_size } else { usize::MAX };
             let mut buffer: Vec<Value> = Vec::new();
-            let mut last_token: Option<ResumeToken> = None;
+            // Bookmark of the last record currently in `buffer`. `None` only when
+            // the buffer is empty (no events seen this cycle).
+            let mut last_bookmark: Option<Value> = None;
 
+            // Graceful shutdown is handled one layer up: `run_stream`'s page loop
+            // `biased`-`select!`s the pipeline cancel token (Pipeline::with_cancel,
+            // #146) against polling this stream for its next page, so a cancel
+            // mid-idle-wait stops at the page boundary and flushes the sinks — no
+            // source-side signal handling needed. Nothing is persisted until a
+            // page yields, so a dropped in-flight buffer is simply re-fetched
+            // (the resume token has not advanced).
             loop {
                 match tokio::time::timeout(idle_timeout, change_stream.next()).await {
                     Ok(Some(Ok(event))) => {
-                        let token = event.id.clone();
-                        let bookmark = Bookmark::from_token(&token)?;
+                        let bookmark = Bookmark::from_token(&event.id)?;
                         let is_invalidate = matches!(
                             event.operation_type,
                             mongodb::change_stream::event::OperationType::Invalidate
                         );
                         buffer.push(to_envelope(&event, &bookmark)?);
-                        last_token = Some(token);
+                        last_bookmark = Some(bookmark.to_value()?);
 
+                        // An invalidate closes the stream server-side: flush the
+                        // page (including the invalidate event) and end.
                         if is_invalidate {
-                            // Safe unwrap: we just set last_token = Some(...) above.
-                            let tok = last_token.as_ref().expect("last_token set above");
-                            let bm = Bookmark::from_token(tok)?.to_value()?;
-                            yield StreamPage { records: std::mem::take(&mut buffer), bookmark: Some(bm) };
+                            yield StreamPage {
+                                records: std::mem::take(&mut buffer),
+                                bookmark: last_bookmark.take(),
+                            };
                             break;
                         }
                         if per_batch && buffer.len() >= chunk {
-                            let tok = last_token.as_ref().expect("last_token set above");
-                            let bm = Bookmark::from_token(tok)?.to_value()?;
-                            yield StreamPage { records: std::mem::take(&mut buffer), bookmark: Some(bm) };
+                            yield StreamPage {
+                                records: std::mem::take(&mut buffer),
+                                bookmark: last_bookmark.take(),
+                            };
                         }
                     }
                     Ok(Some(Err(e))) => {
                         Err(FaucetError::Source(format!("mongodb-cdc stream error: {e}")))?;
                     }
+                    // Idle (timeout) or cursor closed: flush whatever we have and
+                    // end this fetch cycle.
                     Ok(None) | Err(_) => {
                         if !buffer.is_empty() {
-                            let bm = match last_token.as_ref() {
-                                Some(t) => Some(Bookmark::from_token(t)?.to_value()?),
-                                None => None,
+                            yield StreamPage {
+                                records: std::mem::take(&mut buffer),
+                                bookmark: last_bookmark.take(),
                             };
-                            yield StreamPage { records: std::mem::take(&mut buffer), bookmark: bm };
                         }
                         break;
                     }

--- a/crates/source/mongodb-cdc/tests/integration.rs
+++ b/crates/source/mongodb-cdc/tests/integration.rs
@@ -1,0 +1,169 @@
+//! Integration tests for `MongoCdcSource` against a real MongoDB single-node
+//! replica set via testcontainers.
+//!
+//! These tests require Docker (matching the kafka / postgres-cdc convention).
+//! Change Streams require a replica set, so the container is started with
+//! `Mongo::repl_set()`, which boots `mongod --replSet rs`, runs
+//! `rs.initiate()`, and waits for the primary to be elected. We connect with
+//! `directConnection=true`.
+//!
+//! The test opens a change stream, then a concurrent writer performs
+//! insert / update / delete after a warm-up delay (so the stream is open and
+//! `start_from = now` captures the writes), and asserts the emitted CDC
+//! envelopes. It then resumes from the captured bookmark and asserts that a
+//! subsequent write — and only that write — is delivered (no replay).
+
+use faucet_core::Source;
+use faucet_source_mongodb_cdc::{MongoCdcSource, MongoCdcSourceConfig};
+use futures::StreamExt;
+use mongodb::Client;
+use mongodb::bson::{Document, doc};
+use serde_json::{Value, json};
+use std::collections::HashMap;
+use std::time::Duration;
+use testcontainers::ContainerAsync;
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::mongo::Mongo;
+
+const DB: &str = "app";
+const COLL: &str = "users";
+
+/// Start a single-node replica set and return the container handle + URI.
+async fn start_repl_set() -> (ContainerAsync<Mongo>, String) {
+    let container = Mongo::repl_set()
+        .start()
+        .await
+        .expect("mongo replica-set container start");
+    let port = container
+        .get_host_port_ipv4(27017)
+        .await
+        .expect("mongo port");
+    let uri = format!("mongodb://127.0.0.1:{port}/?directConnection=true");
+    (container, uri)
+}
+
+fn config(uri: &str) -> MongoCdcSourceConfig {
+    serde_json::from_value(json!({
+        "connection_uri": uri,
+        "scope": { "type": "collection", "database": DB, "collection": COLL },
+        "full_document": "update_lookup",
+        "start_from": { "type": "now" },
+        "idle_timeout_secs": 5,
+        "max_await_time_ms": 500,
+        "batch_size": 0
+    }))
+    .expect("config")
+}
+
+/// Drain a single fetch cycle into a flat `Vec` of records plus the bookmark of
+/// the last page that carried one. The cycle ends after `idle_timeout` of quiet.
+async fn drain(source: &MongoCdcSource) -> (Vec<Value>, Option<Value>) {
+    let ctx: HashMap<String, Value> = HashMap::new();
+    let mut pages = source.stream_pages(&ctx, 0);
+    let mut records = Vec::new();
+    let mut bookmark = None;
+    while let Some(page) = pages.next().await {
+        let page = page.expect("page");
+        records.extend(page.records);
+        if page.bookmark.is_some() {
+            bookmark = page.bookmark;
+        }
+    }
+    (records, bookmark)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cdc_captures_crud_then_resumes_without_replay() {
+    let (_container, uri) = start_repl_set().await;
+
+    // Create the collection up front (before the change stream opens) so the
+    // single-collection watch has an existing namespace. This seed insert
+    // happens before `start_from = now`, so it is not captured.
+    {
+        let client = Client::with_uri_str(&uri).await.expect("seed client");
+        client
+            .database(DB)
+            .collection::<Document>(COLL)
+            .insert_one(doc! { "_id": 0, "seed": true })
+            .await
+            .expect("seed insert");
+    }
+
+    let source = MongoCdcSource::new(config(&uri)).await.expect("source");
+
+    // Concurrent writer: wait for the stream to open, then c / u / d on _id=1.
+    let writer_uri = uri.clone();
+    let writer = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        let client = Client::with_uri_str(&writer_uri).await.expect("writer client");
+        let coll = client.database(DB).collection::<Document>(COLL);
+        coll.insert_one(doc! { "_id": 1, "name": "alice" })
+            .await
+            .expect("insert");
+        coll.update_one(doc! { "_id": 1 }, doc! { "$set": { "name": "bob" } })
+            .await
+            .expect("update");
+        coll.delete_one(doc! { "_id": 1 }).await.expect("delete");
+    });
+
+    let (records, bookmark) = drain(&source).await;
+    writer.await.expect("writer task");
+
+    // We must have observed the create, update, and delete for _id=1.
+    let ops: Vec<&str> = records
+        .iter()
+        .map(|r| r["op"].as_str().unwrap_or(""))
+        .collect();
+    assert!(ops.contains(&"c"), "expected a create op, got {ops:?}");
+    assert!(ops.contains(&"u"), "expected an update op, got {ops:?}");
+    assert!(ops.contains(&"d"), "expected a delete op, got {ops:?}");
+
+    // The create envelope should carry the full document (update_lookup) and
+    // the correct namespace.
+    let create = records
+        .iter()
+        .find(|r| r["op"] == "c")
+        .expect("create record");
+    assert_eq!(create["namespace"]["db"], DB);
+    assert_eq!(create["namespace"]["coll"], COLL);
+    assert_eq!(create["after"]["name"], "alice");
+    assert!(create["resume_token"]["_data"].is_string());
+
+    let bookmark = bookmark.expect("cycle 1 produced a bookmark");
+
+    // Resume after the last event of cycle 1, then write a NEW document.
+    source
+        .apply_start_bookmark(bookmark)
+        .await
+        .expect("apply bookmark");
+
+    let writer_uri = uri.clone();
+    let writer2 = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        let client = Client::with_uri_str(&writer_uri).await.expect("writer2 client");
+        client
+            .database(DB)
+            .collection::<Document>(COLL)
+            .insert_one(doc! { "_id": 2, "name": "carol" })
+            .await
+            .expect("insert2");
+    });
+
+    let (records2, _bm2) = drain(&source).await;
+    writer2.await.expect("writer2 task");
+
+    // Resume must not replay _id=1's events; only the _id=2 insert appears.
+    assert!(
+        !records2.is_empty(),
+        "expected the post-bookmark insert to be delivered"
+    );
+    for r in &records2 {
+        let key = &r["document_key"]["_id"];
+        assert_eq!(
+            key,
+            &json!(2),
+            "resume replayed a pre-bookmark event: {r:?}"
+        );
+    }
+    assert!(records2.iter().any(|r| r["op"] == "c"));
+}

--- a/crates/source/mongodb-cdc/tests/integration.rs
+++ b/crates/source/mongodb-cdc/tests/integration.rs
@@ -48,7 +48,7 @@ fn config(uri: &str) -> MongoCdcSourceConfig {
         "scope": { "type": "collection", "database": DB, "collection": COLL },
         "full_document": "update_lookup",
         "start_from": { "type": "now" },
-        "idle_timeout_secs": 5,
+        "idle_timeout": 5,
         "max_await_time_ms": 500,
         "batch_size": 0
     }))

--- a/crates/source/mongodb-cdc/tests/integration.rs
+++ b/crates/source/mongodb-cdc/tests/integration.rs
@@ -95,7 +95,9 @@ async fn cdc_captures_crud_then_resumes_without_replay() {
     let writer_uri = uri.clone();
     let writer = tokio::spawn(async move {
         tokio::time::sleep(Duration::from_secs(2)).await;
-        let client = Client::with_uri_str(&writer_uri).await.expect("writer client");
+        let client = Client::with_uri_str(&writer_uri)
+            .await
+            .expect("writer client");
         let coll = client.database(DB).collection::<Document>(COLL);
         coll.insert_one(doc! { "_id": 1, "name": "alice" })
             .await
@@ -140,7 +142,9 @@ async fn cdc_captures_crud_then_resumes_without_replay() {
     let writer_uri = uri.clone();
     let writer2 = tokio::spawn(async move {
         tokio::time::sleep(Duration::from_secs(2)).await;
-        let client = Client::with_uri_str(&writer_uri).await.expect("writer2 client");
+        let client = Client::with_uri_str(&writer_uri)
+            .await
+            .expect("writer2 client");
         client
             .database(DB)
             .collection::<Document>(COLL)

--- a/docs/book/src/reference/connectors.md
+++ b/docs/book/src/reference/connectors.md
@@ -1,6 +1,6 @@
 # Connector catalog
 
-faucet-stream ships **21 sources** and **17 sinks**. Each is a Cargo feature
+faucet-stream ships **22 sources** and **17 sinks**. Each is a Cargo feature
 (`source-<name>` / `sink-<name>`) and an independently published crate. Full API
 docs are on [docs.rs](https://docs.rs/faucet-stream).
 
@@ -27,6 +27,7 @@ Legend: ✓ supported · ✗ not applicable.
 | AWS S3 | `source-s3` | ✓⁴ | ✗ | ✓ | object reader: JSONL, JSON array, raw text |
 | Google Cloud Storage | `source-gcs` | ✓⁴ | ✗ | ✓ | object reader: JSONL, JSON array, raw text |
 | MongoDB | `source-mongodb` | ✓ | ✗ | ✗ | `find()` with filter/projection/sort |
+| MongoDB CDC | `source-mongodb-cdc` | ✓ | ✓ | ✗ | Change Streams, resumeToken bookmarks |
 | Redis | `source-redis` | ✓ | ✗ | ✗ | streams, lists, key patterns |
 | Webhook | `source-webhook` | ✗⁵ | ✗ | ✗ | temporary HTTP server collecting POSTs |
 | WebSocket | `source-websocket` | ✓ | ✗ | ✗ | live push feed; subscribe frames, reconnect, ping keepalive |

--- a/examples/README.md
+++ b/examples/README.md
@@ -54,6 +54,7 @@ The service column lists what each example touches; all are provided by
 | Example | Services |
 |---------|----------|
 | `postgres_cdc_to_jsonl.yaml` | postgres (logical replication preconfigured) |
+| `mongodb_cdc_to_jsonl.yaml` | mongodb (single-node replica set preconfigured; Change Streams) |
 | `rest_to_postgres.yaml`, `rest_to_postgres_with_quality.yaml`, `mongodb_to_postgres.yaml`, `graphql_to_postgres.yaml`, `webhook_to_postgres.yaml` | postgres (+ source) |
 | `mysql_to_postgres.yaml` | mysql, postgres |
 | `csv_to_mysql.yaml`, `redis_to_mysql.yaml` | mysql (+ source) |
@@ -65,7 +66,7 @@ The service column lists what each example touches; all are provided by
 | `mongodb_to_elasticsearch.yaml`, `postgres_to_elasticsearch.yaml`, `grpc_to_elasticsearch.yaml` | elasticsearch (+ source) |
 | `elasticsearch_to_s3.yaml`, `postgres_to_s3.yaml`, `rest_to_s3.yaml`, `xml_to_s3.yaml` | minio (S3) (+ source) |
 | `s3_to_postgres.yaml`, `s3_to_mongodb.yaml` | minio (S3), target |
-| `mongodb_to_redis.yaml`, `xml_to_mongodb.yaml` | mongodb (+ source) |
+| `mongodb_to_redis.yaml`, `xml_to_mongodb.yaml` | mongodb (single-node replica set; query mode connects to the primary) |
 | `webhook_to_csv.yaml`, `webhook_to_http.yaml`, `grpc_to_http.yaml` | none external beyond the source/HTTP target |
 | `dag_users_posts.yaml`, `rest_users_posts_dag.yaml`, `rest_to_bigquery_matrix.yaml`, `templates_*.yaml` | demonstrate matrix / DAG / template syntax (REST source) |
 

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -87,15 +87,28 @@ services:
       timeout: 5s
       retries: 10
 
+  # MongoDB as a single-node replica set so the mongodb-cdc source (Change
+  # Streams require a replica set) works out of the box. The healthcheck
+  # self-initiates the set on first run. Query-mode mongodb examples connect to
+  # the primary without the `?replicaSet=` param and work unchanged.
   mongodb:
     image: mongo:7
+    command: ["--replSet", "rs0", "--bind_ip_all"]
     ports:
       - "27017:27017"
     healthcheck:
-      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand('ping')"]
+      # Idempotent: initiates the replica set on the first check, then reports
+      # healthy once a primary is writable.
+      test:
+        - "CMD"
+        - "mongosh"
+        - "--quiet"
+        - "--eval"
+        - "try { db.hello().isWritablePrimary } catch (e) { rs.initiate({ _id: 'rs0', members: [{ _id: 0, host: 'localhost:27017' }] }) } finally { quit(db.hello().isWritablePrimary ? 0 : 1) }"
       interval: 5s
       timeout: 5s
-      retries: 10
+      retries: 30
+      start_period: 5s
 
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.15.0

--- a/faucet-stream/Cargo.toml
+++ b/faucet-stream/Cargo.toml
@@ -28,6 +28,7 @@ source = [
     "source-sqlite",
     "source-s3",
     "source-mongodb",
+    "source-mongodb-cdc",
     "source-redis",
     "source-webhook",
     "source-websocket",
@@ -99,6 +100,7 @@ source-mssql = ["dep:faucet-source-mssql"]
 source-sqlite = ["dep:faucet-source-sqlite"]
 source-s3 = ["dep:faucet-source-s3"]
 source-mongodb = ["dep:faucet-source-mongodb"]
+source-mongodb-cdc = ["dep:faucet-source-mongodb-cdc"]
 source-redis = ["dep:faucet-source-redis"]
 source-webhook = ["dep:faucet-source-webhook"]
 source-websocket = ["dep:faucet-source-websocket"]
@@ -176,6 +178,7 @@ faucet-source-mssql = { workspace = true, optional = true }
 faucet-source-sqlite = { workspace = true, optional = true }
 faucet-source-s3 = { workspace = true, optional = true }
 faucet-source-mongodb = { workspace = true, optional = true }
+faucet-source-mongodb-cdc = { workspace = true, optional = true }
 faucet-source-redis = { workspace = true, optional = true }
 faucet-source-webhook = { workspace = true, optional = true }
 faucet-source-websocket = { workspace = true, optional = true }

--- a/faucet-stream/src/lib.rs
+++ b/faucet-stream/src/lib.rs
@@ -23,6 +23,7 @@
 
 //! | `source-s3` | AWS S3 file source |
 //! | `source-mongodb` | MongoDB query source |
+//! | `source-mongodb-cdc` | MongoDB CDC source (Change Streams) |
 //! | `source-redis` | Redis source (streams, lists, keys) |
 //! | `source-webhook` | Webhook HTTP receiver source |
 //! | `source-websocket` | WebSocket streaming source |
@@ -126,6 +127,11 @@ pub mod source {
         pub use faucet_source_mongodb::*;
     }
 
+    #[cfg(feature = "source-mongodb-cdc")]
+    pub mod mongodb_cdc {
+        pub use faucet_source_mongodb_cdc::*;
+    }
+
     #[cfg(feature = "source-redis")]
     pub mod redis {
         pub use faucet_source_redis::*;
@@ -218,6 +224,11 @@ pub mod source {
     #[cfg(feature = "source-mongodb")]
     pub mod mongodb {
         pub use faucet_source_mongodb::*;
+    }
+
+    #[cfg(feature = "source-mongodb-cdc")]
+    pub mod mongodb_cdc {
+        pub use faucet_source_mongodb_cdc::*;
     }
 
     #[cfg(feature = "source-redis")]


### PR DESCRIPTION
Closes #115

Adds **`faucet-source-mongodb-cdc`** — a resumable CDC source that tails MongoDB Change Streams and emits per-document change events as a CDC envelope, bookmarked via the opaque `resumeToken`. Third leg of the CDC trio alongside `postgres-cdc` (and the upcoming `mysql-cdc`).

## What it does
- Watches a **collection / database / cluster** (`scope`) change stream.
- Emits a Debezium-style envelope: `{ op: c|u|r|d|ddl, ts_ms, namespace, document_key, before, after, update_description, resume_token }`.
- **Idle-timeout terminator** so one-shot `faucet run` returns; emits a `StreamPage` every `batch_size` events and on idle, each carrying `bookmark = Some(<last event's resume token>)` (per-batch durability). `batch_size = 0` drains to a single page.
- **`start_from` precedence**: an explicit `resume_token`/`timestamp` overrides a persisted bookmark; `now` (default) / `earliest` yield to the bookmark (normal resumability). Resume uses `resumeAfter` → no replay, no gap.
- `full_document` (`update_lookup` etc.) and `full_document_before_change` (6.0+) supported; optional `operation_types` filter + extra `aggregation_pipeline` stages pushed server-side.
- Fail-fast preflight: requires a replica set / sharded cluster (standalone → typed `FaucetError::Source`); non-mutating two-probe `check()` (connection + topology) for `faucet doctor`.
- State key: `mongodb-cdc:cluster` | `:db:<db>` | `:coll:<db>.<coll>`.

## Tests
- 29 unit tests: envelope decode (insert/update/replace/delete/ddl, truncated_arrays, null namespace), resume-token serde round-trip, `start_from` precedence, topology classification, pipeline construction, config validation/redaction.
- Integration test (`tests/integration.rs`) against a Dockerised **single-node replica set** (`Mongo::repl_set()`): insert/update/delete capture + resume-from-bookmark-without-replay. Gated like the kafka/postgres-cdc tests.

## Wiring & docs
- Registered in the CLI (`faucet list` / `schema` / `run`) and the `faucet-stream` umbrella behind `source-mongodb-cdc`; added to the CI `feature-check` matrix.
- Crate README, root README (counts 21→22 sources, 50→51 crates), docs-site capability matrix, and a runnable `cli/examples/mongodb_cdc_to_jsonl.yaml`.
- `examples/docker-compose.yml` mongo service converted to a self-initiating single-node replica set so the example runs out of the box (query-mode mongodb examples unaffected).

## Notes
- No `faucet-core` changes — pure connector + CLI wiring.
- No `faucet-mongodb-common` extraction: the CDC config types aren't shared with the existing mongodb source/sink (they still only share `connection_uri`), so the shared-crate threshold isn't met.
- Integration test requires Docker; verified locally up to `--no-run` (Docker unavailable in the dev env), runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)