### PR TITLE
ci: harden against transient crates.io download failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,13 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
   RUSTFLAGS: "-C debuginfo=0"
+  # Harden against transient crates.io connectivity drops seen on GitHub-hosted
+  # runners (`curl failed` / `SSL_read: unexpected eof` / connection reset) that
+  # abort cargo during dependency download. Retry more, and disable HTTP/2
+  # multiplexing to avoid the "Error in the HTTP2 framing layer" download
+  # failures specifically (forces HTTP/1.1).
+  CARGO_NET_RETRY: "10"
+  CARGO_HTTP_MULTIPLEXING: "false"
 
 jobs:
   fmt:


### PR DESCRIPTION
## Problem
GitHub-hosted runners have been intermittently dropping the crates.io connection during cargo's dependency-download phase, aborting jobs *before* any real work runs. Observed across multiple jobs (Clippy, several `feature-isolation` matrix entries) on both PR #182 and its main merge commit:

- `download of <crate> failed → curl failed → [16] Error in the HTTP2 framing layer`
- `curl failed → [56] OpenSSL SSL_read: unexpected eof while reading`
- `curl failed → Connection reset by peer`

These are pure network flakes (the jobs never reach compilation/linting), but they show up as red CI and require manual job re-runs.

## Fix
Add two cargo network settings to the workflow's top-level `env:` (applies to every job):

- `CARGO_NET_RETRY: "10"` — retry transient registry/download failures far more aggressively (cargo's default is 3).
- `CARGO_HTTP_MULTIPLEXING: "false"` — disable HTTP/2 multiplexing, which directly eliminates the `Error in the HTTP2 framing layer` download failures (forces HTTP/1.1).

No job logic changes; purely makes dependency fetches resilient to the runner↔crates.io connectivity drops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)