### PR TITLE
feat(iceberg): cloud-warehouse (S3/GCS) storage for SQL/Glue/HMS catalogs

### DIFF
--- a/crates/sink/iceberg/Cargo.toml
+++ b/crates/sink/iceberg/Cargo.toml
@@ -13,9 +13,12 @@ categories.workspace = true
 [features]
 default = ["catalog-rest"]
 catalog-rest = ["dep:iceberg-catalog-rest"]
-catalog-glue = ["dep:iceberg-catalog-glue"]
-catalog-sql  = ["dep:iceberg-catalog-sql"]
-catalog-hms  = ["dep:iceberg-catalog-hms"]
+catalog-glue = ["dep:iceberg-catalog-glue", "storage-opendal"]
+catalog-sql  = ["dep:iceberg-catalog-sql",  "storage-opendal"]
+catalog-hms  = ["dep:iceberg-catalog-hms",  "storage-opendal"]
+# Cloud-warehouse storage (S3/GCS/local) for the non-REST catalogs, via an
+# OpenDAL-backed StorageFactory. Auto-enabled by each non-REST catalog feature.
+storage-opendal = ["dep:iceberg-storage-opendal", "dep:typetag"]
 
 [dependencies]
 faucet-core.workspace = true
@@ -36,6 +39,8 @@ iceberg-catalog-rest = { version = "0.9.1", optional = true }
 iceberg-catalog-glue = { version = "0.9.1", optional = true }
 iceberg-catalog-sql  = { version = "0.9.1", optional = true }
 iceberg-catalog-hms  = { version = "0.9.1", optional = true }
+iceberg-storage-opendal = { version = "0.9.1", default-features = false, features = ["opendal-s3", "opendal-gcs", "opendal-fs"], optional = true }
+typetag = { version = "0.2", optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time", "test-util"] }
@@ -48,6 +53,10 @@ iceberg-catalog-sql = "0.9.1"
 # feature must be enabled".
 sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "sqlite", "any"] }
 serde_json.workspace = true
+testcontainers = "0.27"
+testcontainers-modules = { version = "0.15", features = ["minio"] }
+aws-config = { workspace = true }
+aws-sdk-s3 = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/sink/iceberg/README.md
+++ b/crates/sink/iceberg/README.md
@@ -27,12 +27,28 @@ transaction action.
 | SQL-backed (Postgres, SQLite, …) | `sql` | `catalog-sql` | no |
 | Hive Metastore | `hms` | `catalog-hms` | no |
 
-**Warehouse storage (v1):** the **REST** catalog supports both cloud object stores
-(S3/GCS — the catalog server resolves FileIO from the catalog config + `s3.*`
-properties) and local filesystems. The **SQL / Glue / HMS** catalogs currently
-write to a **local-filesystem warehouse** (`file://…`); cloud-warehouse support
-for those catalogs (via an OpenDAL storage factory) is tracked as a follow-up.
-For an S3/GCS lakehouse today, use the REST catalog.
+**Warehouse storage:** all catalogs support both cloud object stores and local
+filesystems. The **REST** catalog resolves FileIO server-side from the catalog
+config + `s3.*` properties. The **SQL / Glue / HMS** catalogs select an
+OpenDAL-backed storage factory from the `warehouse` URI scheme:
+
+| Warehouse scheme | Storage |
+|---|---|
+| `file://…` / bare path | local filesystem |
+| `s3://…` / `s3a://…` | Amazon S3 / S3-compatible (MinIO, …) |
+| `gs://…` | Google Cloud Storage |
+
+Cloud storage is enabled automatically when you enable a non-REST catalog
+feature (each of `catalog-glue` / `catalog-sql` / `catalog-hms` also enables the
+`storage-opendal` feature). Pass storage credentials and options through
+`catalog.properties`:
+
+- **S3:** `s3.region`, `s3.endpoint` (for S3-compatible stores), `s3.access-key-id`,
+  `s3.secret-access-key`, `s3.path-style-access`, `s3.disable-config-load`.
+- **GCS:** `gcs.credentials-json`, `gcs.no-auth`, `gcs.service.path`.
+
+Schemes without a built-in factory (e.g. `oss://`, `abfss://`) are rejected at
+config-load time; use the REST catalog for those object stores.
 
 Install only what you need:
 
@@ -114,6 +130,25 @@ Every catalog variant shares the same inner fields:
 | `warehouse` | Object-storage warehouse root, e.g. `s3://lake/warehouse/` |
 | `credential` | REST bearer token or other catalog-specific credential. Redacted in `Debug` output |
 | `properties` | Arbitrary key-value pairs forwarded to the catalog builder (e.g. `s3.region`, `s3.endpoint`) |
+
+Example — SQL catalog (Postgres metadata) writing to an S3 warehouse:
+
+```yaml
+sink:
+  type: iceberg
+  config:
+    catalog:
+      type: sql
+      uri: "postgres://meta:meta@localhost:5432/iceberg"
+      warehouse: "s3://lake/warehouse"
+      properties:
+        s3.region: "us-east-1"
+        s3.access-key-id: "${env:AWS_ACCESS_KEY_ID}"
+        s3.secret-access-key: "${env:AWS_SECRET_ACCESS_KEY}"
+    namespace: ["analytics"]
+    table: "events"
+    create_if_missing: true
+```
 
 ### Partition transforms
 

--- a/crates/sink/iceberg/src/catalog.rs
+++ b/crates/sink/iceberg/src/catalog.rs
@@ -89,7 +89,10 @@ async fn build_glue(inner: &CatalogInner) -> Result<Arc<dyn Catalog>, FaucetErro
         props.insert("uri".to_string(), uri.clone());
     }
 
+    let storage_factory = crate::storage_factory::select_storage_factory(inner)?;
+
     let catalog = GlueCatalogBuilder::default()
+        .with_storage_factory(storage_factory)
         .load("faucet-iceberg", props)
         .await
         .map_err(|e| FaucetError::Config(format!("iceberg: Glue catalog init failed: {e}")))?;
@@ -109,7 +112,6 @@ async fn build_glue(_inner: &CatalogInner) -> Result<Arc<dyn Catalog>, FaucetErr
 #[cfg(feature = "catalog-sql")]
 async fn build_sql(inner: &CatalogInner) -> Result<Arc<dyn Catalog>, FaucetError> {
     use iceberg::CatalogBuilder;
-    use iceberg::io::LocalFsStorageFactory;
     use iceberg_catalog_sql::{
         SQL_CATALOG_PROP_BIND_STYLE, SQL_CATALOG_PROP_URI, SQL_CATALOG_PROP_WAREHOUSE,
         SqlBindStyle, SqlCatalogBuilder,
@@ -143,17 +145,9 @@ async fn build_sql(inner: &CatalogInner) -> Result<Arc<dyn Catalog>, FaucetError
         );
     }
 
-    // The SQL catalog requires a `StorageFactory` to perform object-storage I/O
-    // for table metadata and data files.
-    //
-    // `LocalFsStorageFactory` handles `file://` and bare absolute paths.
-    // Cloud warehouses (s3://, gcs://, etc.) need `iceberg-storage-opendal`;
-    // users with a cloud warehouse + SQL catalog must pass an opendal-backed
-    // factory via `properties` until first-class support is added.  For now
-    // we always supply `LocalFsStorageFactory`; cloud-scheme users will get a
-    // clear error from the iceberg SDK at I/O time rather than a cryptic
-    // "StorageFactory must be provided" panic.
-    let storage_factory: Arc<dyn iceberg::io::StorageFactory> = Arc::new(LocalFsStorageFactory);
+    // Select the storage factory from the warehouse URI scheme: local FS for
+    // file:// / bare paths, OpenDAL S3/GCS for cloud warehouses. (#181)
+    let storage_factory = crate::storage_factory::select_storage_factory(inner)?;
 
     let catalog = SqlCatalogBuilder::default()
         .with_storage_factory(storage_factory)
@@ -189,7 +183,10 @@ async fn build_hms(inner: &CatalogInner) -> Result<Arc<dyn Catalog>, FaucetError
         props.insert(HMS_CATALOG_PROP_WAREHOUSE.to_string(), warehouse.clone());
     }
 
+    let storage_factory = crate::storage_factory::select_storage_factory(inner)?;
+
     let catalog = HmsCatalogBuilder::default()
+        .with_storage_factory(storage_factory)
         .load("faucet-iceberg", props)
         .await
         .map_err(|e| FaucetError::Config(format!("iceberg: HMS catalog init failed: {e}")))?;

--- a/crates/sink/iceberg/src/config.rs
+++ b/crates/sink/iceberg/src/config.rs
@@ -13,6 +13,45 @@ use faucet_core::FaucetError;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+// ── Warehouse scheme classification ─────────────────────────────────────────
+
+/// Classification of a warehouse URI by scheme, used to select an Iceberg
+/// `StorageFactory` (see `crate::storage_factory`) and to validate configs.
+///
+/// The set of recognised schemes is intentionally small and feature-independent:
+/// it is the set faucet's storage-factory selector understands. REST catalogs
+/// resolve FileIO server-side and are exempt from this classification.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum WarehouseScheme {
+    /// No scheme, a bare path, or `file://` — local filesystem.
+    Local,
+    /// `s3://` or `s3a://`. Carries the exact scheme string ("s3" / "s3a"),
+    /// which the OpenDAL S3 operator requires to match the warehouse URI.
+    S3(&'static str),
+    /// `gs://` — Google Cloud Storage.
+    Gcs,
+    /// Any other scheme (e.g. `oss`, `abfss`) — no storage factory available.
+    Unsupported(String),
+}
+
+/// Classify a warehouse URI by its scheme.
+///
+/// A URI with no `://` (empty, bare path, or relative path) is treated as a
+/// local-filesystem warehouse. Scheme matching is case-insensitive.
+pub(crate) fn warehouse_scheme(warehouse: &str) -> WarehouseScheme {
+    let scheme = match warehouse.trim().split_once("://") {
+        Some((s, _)) => s.to_ascii_lowercase(),
+        None => return WarehouseScheme::Local,
+    };
+    match scheme.as_str() {
+        "file" => WarehouseScheme::Local,
+        "s3" => WarehouseScheme::S3("s3"),
+        "s3a" => WarehouseScheme::S3("s3a"),
+        "gs" => WarehouseScheme::Gcs,
+        other => WarehouseScheme::Unsupported(other.to_string()),
+    }
+}
+
 // ── Catalog config ────────────────────────────────────────────────────────────
 
 /// Configuration fields shared by every catalog variant.
@@ -681,5 +720,57 @@ mod tests {
             !debug_str.contains("user:pass"),
             "uri userinfo must be redacted: {debug_str}"
         );
+    }
+
+    // ── warehouse scheme classification ───────────────────────────────────────
+
+    #[test]
+    fn warehouse_scheme_local_variants() {
+        use super::{warehouse_scheme, WarehouseScheme};
+        for w in ["", "/tmp/warehouse", "./wh", "relative/dir", "file:///tmp/wh"] {
+            assert!(
+                matches!(warehouse_scheme(w), WarehouseScheme::Local),
+                "{w:?} should be Local"
+            );
+        }
+    }
+
+    #[test]
+    fn warehouse_scheme_s3_preserves_scheme() {
+        use super::{warehouse_scheme, WarehouseScheme};
+        assert!(matches!(
+            warehouse_scheme("s3://bucket/wh"),
+            WarehouseScheme::S3("s3")
+        ));
+        assert!(matches!(
+            warehouse_scheme("s3a://bucket/wh"),
+            WarehouseScheme::S3("s3a")
+        ));
+        assert!(matches!(
+            warehouse_scheme("S3://bucket/wh"),
+            WarehouseScheme::S3("s3")
+        ));
+    }
+
+    #[test]
+    fn warehouse_scheme_gcs() {
+        use super::{warehouse_scheme, WarehouseScheme};
+        assert!(matches!(
+            warehouse_scheme("gs://bucket/wh"),
+            WarehouseScheme::Gcs
+        ));
+    }
+
+    #[test]
+    fn warehouse_scheme_unsupported() {
+        use super::{warehouse_scheme, WarehouseScheme};
+        match warehouse_scheme("oss://bucket/wh") {
+            WarehouseScheme::Unsupported(s) => assert_eq!(s, "oss"),
+            other => panic!("expected Unsupported, got {other:?}"),
+        }
+        assert!(matches!(
+            warehouse_scheme("abfss://x/y"),
+            WarehouseScheme::Unsupported(_)
+        ));
     }
 }

--- a/crates/sink/iceberg/src/config.rs
+++ b/crates/sink/iceberg/src/config.rs
@@ -21,9 +21,6 @@ use serde::{Deserialize, Serialize};
 /// The set of recognised schemes is intentionally small and feature-independent:
 /// it is the set faucet's storage-factory selector understands. REST catalogs
 /// resolve FileIO server-side and are exempt from this classification.
-// `select_storage_factory` (the sole consumer) is gated on `storage-opendal`,
-// so this is dead code in non-`storage-opendal` builds.
-#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum WarehouseScheme {
     /// No scheme, a bare path, or `file://` — local filesystem.
@@ -41,8 +38,6 @@ pub(crate) enum WarehouseScheme {
 ///
 /// A URI with no `://` (empty, bare path, or relative path) is treated as a
 /// local-filesystem warehouse. Scheme matching is case-insensitive.
-// Consumed by `select_storage_factory`, which is gated on `storage-opendal`.
-#[allow(dead_code)]
 pub(crate) fn warehouse_scheme(warehouse: &str) -> WarehouseScheme {
     let scheme = match warehouse.trim().split_once("://") {
         Some((s, _)) => s.to_ascii_lowercase(),
@@ -397,6 +392,20 @@ impl IcebergSinkConfig {
             )));
         }
 
+        // Warehouse scheme: the non-REST catalogs build FileIO in-process, so
+        // faucet must have a storage factory for the scheme. REST resolves
+        // FileIO server-side and may use any scheme. (#181)
+        if !matches!(self.catalog, CatalogConfig::Rest(_)) {
+            let warehouse = self.catalog.inner().warehouse.as_deref().unwrap_or("");
+            if let WarehouseScheme::Unsupported(s) = warehouse_scheme(warehouse) {
+                return Err(FaucetError::Config(format!(
+                    "iceberg: warehouse scheme '{s}://' is not supported for the \
+                     '{kind}' catalog; use file://, s3://, s3a://, or gs:// (or the \
+                     REST catalog for other object stores)"
+                )));
+            }
+        }
+
         // Target file size: 0 would make iceberg's rolling writer roll a new
         // (tiny) data file on every batch — almost certainly a misconfiguration.
         if self.target_file_size_mb == 0 {
@@ -661,6 +670,43 @@ mod tests {
             "table": "events"
         }));
         assert!(cfg.validate().is_ok());
+    }
+
+    // ── warehouse scheme validation ───────────────────────────────────────────
+
+    #[test]
+    fn sql_catalog_rejects_unsupported_warehouse_scheme() {
+        let cfg = parse(serde_json::json!({
+            "catalog": { "type": "sql", "uri": "sqlite::memory:", "warehouse": "oss://bucket/wh" },
+            "namespace": ["analytics"],
+            "table": "events"
+        }));
+        let err = cfg.validate().unwrap_err();
+        assert!(matches!(err, FaucetError::Config(_)));
+        let msg = err.to_string();
+        assert!(msg.contains("oss"), "should name the bad scheme: {msg}");
+    }
+
+    #[test]
+    fn sql_catalog_accepts_cloud_and_local_warehouses() {
+        for w in ["s3://bucket/wh", "s3a://bucket/wh", "gs://bucket/wh", "file:///tmp/wh", "/tmp/wh"] {
+            let cfg = parse(serde_json::json!({
+                "catalog": { "type": "sql", "uri": "sqlite::memory:", "warehouse": w },
+                "namespace": ["analytics"],
+                "table": "events"
+            }));
+            cfg.validate().unwrap_or_else(|e| panic!("{w} should validate: {e}"));
+        }
+    }
+
+    #[test]
+    fn rest_catalog_allows_any_warehouse_scheme() {
+        let cfg = parse(serde_json::json!({
+            "catalog": { "type": "rest", "uri": "http://localhost:8181", "warehouse": "oss://bucket/wh" },
+            "namespace": ["analytics"],
+            "table": "events"
+        }));
+        cfg.validate().expect("REST should accept any warehouse scheme");
     }
 
     // ── batch_size bounds ─────────────────────────────────────────────────────

--- a/crates/sink/iceberg/src/config.rs
+++ b/crates/sink/iceberg/src/config.rs
@@ -689,13 +689,20 @@ mod tests {
 
     #[test]
     fn sql_catalog_accepts_cloud_and_local_warehouses() {
-        for w in ["s3://bucket/wh", "s3a://bucket/wh", "gs://bucket/wh", "file:///tmp/wh", "/tmp/wh"] {
+        for w in [
+            "s3://bucket/wh",
+            "s3a://bucket/wh",
+            "gs://bucket/wh",
+            "file:///tmp/wh",
+            "/tmp/wh",
+        ] {
             let cfg = parse(serde_json::json!({
                 "catalog": { "type": "sql", "uri": "sqlite::memory:", "warehouse": w },
                 "namespace": ["analytics"],
                 "table": "events"
             }));
-            cfg.validate().unwrap_or_else(|e| panic!("{w} should validate: {e}"));
+            cfg.validate()
+                .unwrap_or_else(|e| panic!("{w} should validate: {e}"));
         }
     }
 
@@ -706,7 +713,8 @@ mod tests {
             "namespace": ["analytics"],
             "table": "events"
         }));
-        cfg.validate().expect("REST should accept any warehouse scheme");
+        cfg.validate()
+            .expect("REST should accept any warehouse scheme");
     }
 
     // ── batch_size bounds ─────────────────────────────────────────────────────
@@ -777,8 +785,14 @@ mod tests {
 
     #[test]
     fn warehouse_scheme_local_variants() {
-        use super::{warehouse_scheme, WarehouseScheme};
-        for w in ["", "/tmp/warehouse", "./wh", "relative/dir", "file:///tmp/wh"] {
+        use super::{WarehouseScheme, warehouse_scheme};
+        for w in [
+            "",
+            "/tmp/warehouse",
+            "./wh",
+            "relative/dir",
+            "file:///tmp/wh",
+        ] {
             assert!(
                 matches!(warehouse_scheme(w), WarehouseScheme::Local),
                 "{w:?} should be Local"
@@ -788,7 +802,7 @@ mod tests {
 
     #[test]
     fn warehouse_scheme_s3_preserves_scheme() {
-        use super::{warehouse_scheme, WarehouseScheme};
+        use super::{WarehouseScheme, warehouse_scheme};
         assert!(matches!(
             warehouse_scheme("s3://bucket/wh"),
             WarehouseScheme::S3("s3")
@@ -805,7 +819,7 @@ mod tests {
 
     #[test]
     fn warehouse_scheme_gcs() {
-        use super::{warehouse_scheme, WarehouseScheme};
+        use super::{WarehouseScheme, warehouse_scheme};
         assert!(matches!(
             warehouse_scheme("gs://bucket/wh"),
             WarehouseScheme::Gcs
@@ -814,7 +828,7 @@ mod tests {
 
     #[test]
     fn warehouse_scheme_unsupported() {
-        use super::{warehouse_scheme, WarehouseScheme};
+        use super::{WarehouseScheme, warehouse_scheme};
         match warehouse_scheme("oss://bucket/wh") {
             WarehouseScheme::Unsupported(s) => assert_eq!(s, "oss"),
             other => panic!("expected Unsupported, got {other:?}"),

--- a/crates/sink/iceberg/src/config.rs
+++ b/crates/sink/iceberg/src/config.rs
@@ -21,6 +21,9 @@ use serde::{Deserialize, Serialize};
 /// The set of recognised schemes is intentionally small and feature-independent:
 /// it is the set faucet's storage-factory selector understands. REST catalogs
 /// resolve FileIO server-side and are exempt from this classification.
+// `select_storage_factory` (the sole consumer) is gated on `storage-opendal`,
+// so this is dead code in non-`storage-opendal` builds.
+#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum WarehouseScheme {
     /// No scheme, a bare path, or `file://` — local filesystem.
@@ -38,6 +41,8 @@ pub(crate) enum WarehouseScheme {
 ///
 /// A URI with no `://` (empty, bare path, or relative path) is treated as a
 /// local-filesystem warehouse. Scheme matching is case-insensitive.
+// Consumed by `select_storage_factory`, which is gated on `storage-opendal`.
+#[allow(dead_code)]
 pub(crate) fn warehouse_scheme(warehouse: &str) -> WarehouseScheme {
     let scheme = match warehouse.trim().split_once("://") {
         Some((s, _)) => s.to_ascii_lowercase(),

--- a/crates/sink/iceberg/src/lib.rs
+++ b/crates/sink/iceberg/src/lib.rs
@@ -4,7 +4,7 @@ pub(crate) mod catalog;
 pub mod config;
 pub(crate) mod schema;
 pub mod sink;
-#[cfg(feature = "storage-opendal")]
+#[cfg(any(feature = "catalog-glue", feature = "catalog-sql", feature = "catalog-hms"))]
 pub(crate) mod storage_factory;
 pub(crate) mod writer;
 

--- a/crates/sink/iceberg/src/lib.rs
+++ b/crates/sink/iceberg/src/lib.rs
@@ -4,6 +4,8 @@ pub(crate) mod catalog;
 pub mod config;
 pub(crate) mod schema;
 pub mod sink;
+#[cfg(feature = "storage-opendal")]
+pub(crate) mod storage_factory;
 pub(crate) mod writer;
 
 pub use config::{CatalogConfig, IcebergSinkConfig, ParquetOpts, PartitionField, WriteMode};

--- a/crates/sink/iceberg/src/lib.rs
+++ b/crates/sink/iceberg/src/lib.rs
@@ -4,7 +4,11 @@ pub(crate) mod catalog;
 pub mod config;
 pub(crate) mod schema;
 pub mod sink;
-#[cfg(any(feature = "catalog-glue", feature = "catalog-sql", feature = "catalog-hms"))]
+#[cfg(any(
+    feature = "catalog-glue",
+    feature = "catalog-sql",
+    feature = "catalog-hms"
+))]
 pub(crate) mod storage_factory;
 pub(crate) mod writer;
 

--- a/crates/sink/iceberg/src/storage_factory.rs
+++ b/crates/sink/iceberg/src/storage_factory.rs
@@ -13,11 +13,6 @@
 //! storage layer. The wrapper re-supplies them, letting the catalog-threaded
 //! props (Glue/HMS) overlay on top.
 
-// `select_storage_factory` and its helpers are consumed by the catalog/sink
-// wiring (landed in a follow-up task); until then they are dead code in a
-// non-test build.
-#![allow(dead_code)]
-
 use std::collections::HashMap;
 use std::sync::Arc;
 

--- a/crates/sink/iceberg/src/storage_factory.rs
+++ b/crates/sink/iceberg/src/storage_factory.rs
@@ -21,7 +21,7 @@ use iceberg::io::{LocalFsStorageFactory, Storage, StorageConfig, StorageFactory}
 use iceberg_storage_opendal::OpenDalStorageFactory;
 use serde::{Deserialize, Serialize};
 
-use crate::config::{warehouse_scheme, CatalogInner, WarehouseScheme};
+use crate::config::{CatalogInner, WarehouseScheme, warehouse_scheme};
 
 /// Merge faucet's configured catalog properties (`base`) with the properties
 /// the catalog threads into its `FileIO` (`overlay`). The overlay wins on key
@@ -153,7 +153,8 @@ mod tests {
         assert!(dbg.contains("configured_scheme: \"s3\""), "got {dbg}");
         assert!(dbg.contains("s3.region"), "props must be threaded: {dbg}");
 
-        let f_a = select_storage_factory(&inner_with_warehouse(Some("s3a://bucket/wh"))).expect("ok");
+        let f_a =
+            select_storage_factory(&inner_with_warehouse(Some("s3a://bucket/wh"))).expect("ok");
         assert!(
             format!("{f_a:?}").contains("configured_scheme: \"s3a\""),
             "s3a scheme must be preserved (Glue bug fix)"
@@ -168,10 +169,14 @@ mod tests {
 
     #[test]
     fn select_unsupported_scheme_errors() {
-        let err = select_storage_factory(&inner_with_warehouse(Some("oss://bucket/wh"))).unwrap_err();
+        let err =
+            select_storage_factory(&inner_with_warehouse(Some("oss://bucket/wh"))).unwrap_err();
         assert!(matches!(err, FaucetError::Config(_)));
         let msg = err.to_string();
         assert!(msg.contains("oss"), "should name the scheme: {msg}");
-        assert!(msg.contains("s3://"), "should list supported schemes: {msg}");
+        assert!(
+            msg.contains("s3://"),
+            "should list supported schemes: {msg}"
+        );
     }
 }

--- a/crates/sink/iceberg/src/storage_factory.rs
+++ b/crates/sink/iceberg/src/storage_factory.rs
@@ -13,6 +13,11 @@
 //! storage layer. The wrapper re-supplies them, letting the catalog-threaded
 //! props (Glue/HMS) overlay on top.
 
+// `select_storage_factory` and its helpers are consumed by the catalog/sink
+// wiring (landed in a follow-up task); until then they are dead code in a
+// non-test build.
+#![allow(dead_code)]
+
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -58,6 +63,51 @@ impl StorageFactory for OpendalPropInjector {
     }
 }
 
+/// Build an S3 OpenDAL factory for the given scheme ("s3" or "s3a"), threading
+/// faucet's `catalog.properties`.
+fn cloud_factory_s3(
+    scheme: &'static str,
+    props: &HashMap<String, String>,
+) -> Arc<dyn StorageFactory> {
+    Arc::new(OpendalPropInjector::new(
+        OpenDalStorageFactory::S3 {
+            configured_scheme: scheme.to_string(),
+            customized_credential_load: None,
+        },
+        props.clone(),
+    ))
+}
+
+/// Build a GCS OpenDAL factory, threading faucet's `catalog.properties`.
+fn cloud_factory_gcs(props: &HashMap<String, String>) -> Arc<dyn StorageFactory> {
+    Arc::new(OpendalPropInjector::new(
+        OpenDalStorageFactory::Gcs,
+        props.clone(),
+    ))
+}
+
+/// Select an Iceberg `StorageFactory` from a catalog's warehouse URI scheme.
+///
+/// - local (`file://` / bare path / none) → `LocalFsStorageFactory`
+/// - `s3://` / `s3a://` → OpenDAL S3 (scheme matched to the URI)
+/// - `gs://` → OpenDAL GCS
+/// - anything else → `FaucetError::Config`
+pub(crate) fn select_storage_factory(
+    inner: &CatalogInner,
+) -> Result<Arc<dyn StorageFactory>, FaucetError> {
+    let warehouse = inner.warehouse.as_deref().unwrap_or("");
+    match warehouse_scheme(warehouse) {
+        WarehouseScheme::Local => Ok(Arc::new(LocalFsStorageFactory)),
+        WarehouseScheme::S3(scheme) => Ok(cloud_factory_s3(scheme, &inner.properties)),
+        WarehouseScheme::Gcs => Ok(cloud_factory_gcs(&inner.properties)),
+        WarehouseScheme::Unsupported(s) => Err(FaucetError::Config(format!(
+            "iceberg: warehouse scheme '{s}://' has no storage factory; supported \
+             schemes are file://, s3://, s3a://, gs:// (use the REST catalog for \
+             other object stores)"
+        ))),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -79,5 +129,54 @@ mod tests {
         let base = HashMap::from([("s3.region".to_string(), "eu-west-1".to_string())]);
         let merged = merge_props(&base, &HashMap::new());
         assert_eq!(merged.get("s3.region").unwrap(), "eu-west-1");
+    }
+
+    fn inner_with_warehouse(warehouse: Option<&str>) -> CatalogInner {
+        CatalogInner {
+            uri: None,
+            warehouse: warehouse.map(str::to_string),
+            credential: None,
+            properties: HashMap::from([("s3.region".to_string(), "us-east-1".to_string())]),
+        }
+    }
+
+    #[test]
+    fn select_local_for_file_and_bare_paths() {
+        for w in [None, Some("/tmp/wh"), Some("file:///tmp/wh")] {
+            let f = select_storage_factory(&inner_with_warehouse(w)).expect("ok");
+            assert!(
+                format!("{f:?}").contains("LocalFsStorageFactory"),
+                "expected LocalFs for {w:?}, got {f:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn select_s3_preserves_scheme_and_threads_props() {
+        let f = select_storage_factory(&inner_with_warehouse(Some("s3://bucket/wh"))).expect("ok");
+        let dbg = format!("{f:?}");
+        assert!(dbg.contains("configured_scheme: \"s3\""), "got {dbg}");
+        assert!(dbg.contains("s3.region"), "props must be threaded: {dbg}");
+
+        let f_a = select_storage_factory(&inner_with_warehouse(Some("s3a://bucket/wh"))).expect("ok");
+        assert!(
+            format!("{f_a:?}").contains("configured_scheme: \"s3a\""),
+            "s3a scheme must be preserved (Glue bug fix)"
+        );
+    }
+
+    #[test]
+    fn select_gcs() {
+        let f = select_storage_factory(&inner_with_warehouse(Some("gs://bucket/wh"))).expect("ok");
+        assert!(format!("{f:?}").contains("Gcs"), "got {f:?}");
+    }
+
+    #[test]
+    fn select_unsupported_scheme_errors() {
+        let err = select_storage_factory(&inner_with_warehouse(Some("oss://bucket/wh"))).unwrap_err();
+        assert!(matches!(err, FaucetError::Config(_)));
+        let msg = err.to_string();
+        assert!(msg.contains("oss"), "should name the scheme: {msg}");
+        assert!(msg.contains("s3://"), "should list supported schemes: {msg}");
     }
 }

--- a/crates/sink/iceberg/src/storage_factory.rs
+++ b/crates/sink/iceberg/src/storage_factory.rs
@@ -1,0 +1,83 @@
+//! Iceberg `StorageFactory` selection for the non-REST catalogs.
+//!
+//! REST catalogs resolve `FileIO` server-side. The SQL / Glue / HMS catalogs
+//! build `FileIO` in-process and need an explicit `StorageFactory`:
+//!
+//! - Local (`file://` / bare path) warehouses → `iceberg::io::LocalFsStorageFactory`.
+//! - Cloud (`s3://` / `s3a://` / `gs://`) warehouses → an [`OpendalPropInjector`]
+//!   wrapping `iceberg_storage_opendal::OpenDalStorageFactory`.
+//!
+//! The wrapper exists because `iceberg-catalog-sql` builds its `FileIO` with
+//! **empty** properties, so the user's `catalog.properties` (`s3.region`,
+//! `s3.endpoint`, `gcs.credentials-json`, …) would otherwise never reach the
+//! storage layer. The wrapper re-supplies them, letting the catalog-threaded
+//! props (Glue/HMS) overlay on top.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use faucet_core::FaucetError;
+use iceberg::io::{LocalFsStorageFactory, Storage, StorageConfig, StorageFactory};
+use iceberg_storage_opendal::OpenDalStorageFactory;
+use serde::{Deserialize, Serialize};
+
+use crate::config::{warehouse_scheme, CatalogInner, WarehouseScheme};
+
+/// Merge faucet's configured catalog properties (`base`) with the properties
+/// the catalog threads into its `FileIO` (`overlay`). The overlay wins on key
+/// collisions: for SQL the overlay is empty (faucet props win); for Glue/HMS
+/// the overlay carries the catalog's own threaded + enriched props.
+fn merge_props(
+    base: &HashMap<String, String>,
+    overlay: &HashMap<String, String>,
+) -> HashMap<String, String> {
+    let mut merged = base.clone();
+    merged.extend(overlay.iter().map(|(k, v)| (k.clone(), v.clone())));
+    merged
+}
+
+/// A `StorageFactory` that injects faucet's configured `catalog.properties`
+/// into the `StorageConfig` before delegating to an OpenDAL-backed factory.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct OpendalPropInjector {
+    inner: OpenDalStorageFactory,
+    props: HashMap<String, String>,
+}
+
+impl OpendalPropInjector {
+    fn new(inner: OpenDalStorageFactory, props: HashMap<String, String>) -> Self {
+        Self { inner, props }
+    }
+}
+
+#[typetag::serde(name = "faucet-opendal-prop-injector")]
+impl StorageFactory for OpendalPropInjector {
+    fn build(&self, config: &StorageConfig) -> iceberg::Result<Arc<dyn Storage>> {
+        let merged = merge_props(&self.props, config.props());
+        self.inner.build(&StorageConfig::from_props(merged))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn merge_props_overlay_wins() {
+        let base = HashMap::from([
+            ("s3.region".to_string(), "us-east-1".to_string()),
+            ("s3.endpoint".to_string(), "http://base".to_string()),
+        ]);
+        let overlay = HashMap::from([("s3.endpoint".to_string(), "http://overlay".to_string())]);
+        let merged = merge_props(&base, &overlay);
+        assert_eq!(merged.get("s3.region").unwrap(), "us-east-1");
+        assert_eq!(merged.get("s3.endpoint").unwrap(), "http://overlay");
+    }
+
+    #[test]
+    fn merge_props_empty_overlay_keeps_base() {
+        let base = HashMap::from([("s3.region".to_string(), "eu-west-1".to_string())]);
+        let merged = merge_props(&base, &HashMap::new());
+        assert_eq!(merged.get("s3.region").unwrap(), "eu-west-1");
+    }
+}

--- a/crates/sink/iceberg/tests/integration_s3.rs
+++ b/crates/sink/iceberg/tests/integration_s3.rs
@@ -40,7 +40,10 @@ const BUCKET: &str = "faucet-iceberg-tests";
 /// Start a MinIO container; return the handle + `http://127.0.0.1:port` endpoint.
 async fn start_minio() -> (ContainerAsync<MinIO>, String) {
     let container = MinIO::default().start().await.expect("minio start");
-    let port = container.get_host_port_ipv4(9000).await.expect("minio port");
+    let port = container
+        .get_host_port_ipv4(9000)
+        .await
+        .expect("minio port");
     (container, format!("http://127.0.0.1:{port}"))
 }
 
@@ -108,7 +111,10 @@ async fn open_reader_catalog(
 ) -> impl Catalog {
     let cat_props = HashMap::from([
         (SQL_CATALOG_PROP_URI.to_string(), db_uri.to_string()),
-        (SQL_CATALOG_PROP_WAREHOUSE.to_string(), warehouse.to_string()),
+        (
+            SQL_CATALOG_PROP_WAREHOUSE.to_string(),
+            warehouse.to_string(),
+        ),
         (
             SQL_CATALOG_PROP_BIND_STYLE.to_string(),
             SqlBindStyle::QMark.to_string(),
@@ -164,7 +170,10 @@ async fn sql_catalog_s3_warehouse_commits_snapshot() {
         NamespaceIdent::from_strs(["db"]).unwrap(),
         "events".to_string(),
     );
-    let table = reader.load_table(&tid).await.expect("load_table after flush");
+    let table = reader
+        .load_table(&tid)
+        .await
+        .expect("load_table after flush");
     let meta = table.metadata();
 
     assert_eq!(meta.snapshots().count(), 1, "expected exactly one snapshot");

--- a/crates/sink/iceberg/tests/integration_s3.rs
+++ b/crates/sink/iceberg/tests/integration_s3.rs
@@ -1,0 +1,180 @@
+//! Integration test: `IcebergSink` with a SQLite SQL catalog writing to an
+//! `s3://` warehouse, exercised against a real S3-compatible endpoint (MinIO)
+//! via testcontainers.
+//!
+//! Requires Docker and the `catalog-sql` feature:
+//!   cargo test -p faucet-sink-iceberg --test integration_s3 --features catalog-sql
+//!
+//! This proves the OpenDAL-backed StorageFactory selection (#181): the sink's
+//! `catalog.properties` (endpoint/creds/region/path-style) reach the storage
+//! layer even though `iceberg-catalog-sql` builds its FileIO with empty props.
+
+#![cfg(feature = "catalog-sql")]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use aws_config::BehaviorVersion;
+use aws_sdk_s3::config::Credentials;
+use aws_sdk_s3::{Client, Config as S3Config};
+use faucet_core::Sink;
+use faucet_sink_iceberg::{IcebergSink, IcebergSinkConfig};
+use iceberg::io::{Storage, StorageConfig, StorageFactory};
+use iceberg::{Catalog, CatalogBuilder, NamespaceIdent, TableIdent};
+use iceberg_catalog_sql::{
+    SQL_CATALOG_PROP_BIND_STYLE, SQL_CATALOG_PROP_URI, SQL_CATALOG_PROP_WAREHOUSE, SqlBindStyle,
+    SqlCatalogBuilder,
+};
+use iceberg_storage_opendal::OpenDalStorageFactory;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use tempfile::TempDir;
+use testcontainers::{ContainerAsync, runners::AsyncRunner};
+use testcontainers_modules::minio::MinIO;
+
+const ACCESS_KEY: &str = "minioadmin";
+const SECRET_KEY: &str = "minioadmin";
+const REGION: &str = "us-east-1";
+const BUCKET: &str = "faucet-iceberg-tests";
+
+/// Start a MinIO container; return the handle + `http://127.0.0.1:port` endpoint.
+async fn start_minio() -> (ContainerAsync<MinIO>, String) {
+    let container = MinIO::default().start().await.expect("minio start");
+    let port = container.get_host_port_ipv4(9000).await.expect("minio port");
+    (container, format!("http://127.0.0.1:{port}"))
+}
+
+/// Create the test bucket via a path-style aws-sdk-s3 admin client.
+async fn create_bucket(endpoint: &str) {
+    let creds = Credentials::new(ACCESS_KEY, SECRET_KEY, None, None, "test");
+    let sdk_config = aws_config::defaults(BehaviorVersion::latest())
+        .region(aws_config::Region::new(REGION))
+        .endpoint_url(endpoint)
+        .credentials_provider(creds)
+        .load()
+        .await;
+    let s3_config = S3Config::from(&sdk_config)
+        .to_builder()
+        .force_path_style(true)
+        .build();
+    Client::from_conf(s3_config)
+        .create_bucket()
+        .bucket(BUCKET)
+        .send()
+        .await
+        .expect("create bucket");
+}
+
+/// S3 `catalog.properties` pointing OpenDAL at the MinIO endpoint, with config
+/// loading disabled so the test never touches real AWS.
+fn s3_props(endpoint: &str) -> serde_json::Value {
+    json!({
+        "s3.endpoint": endpoint,
+        "s3.access-key-id": ACCESS_KEY,
+        "s3.secret-access-key": SECRET_KEY,
+        "s3.region": REGION,
+        "s3.path-style-access": "true",
+        "s3.disable-config-load": "true",
+        "s3.disable-ec2-metadata": "true"
+    })
+}
+
+/// Test-local prop-injecting S3 factory for the *reader* catalog. The SQL
+/// catalog drops FileIO props, so the reader needs them re-supplied the same
+/// way the sink does internally.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct S3PropFactory {
+    props: HashMap<String, String>,
+}
+
+#[typetag::serde(name = "faucet-test-s3-prop-factory")]
+impl StorageFactory for S3PropFactory {
+    fn build(&self, config: &StorageConfig) -> iceberg::Result<Arc<dyn Storage>> {
+        let mut merged = self.props.clone();
+        merged.extend(config.props().iter().map(|(k, v)| (k.clone(), v.clone())));
+        OpenDalStorageFactory::S3 {
+            configured_scheme: "s3".to_string(),
+            customized_credential_load: None,
+        }
+        .build(&StorageConfig::from_props(merged))
+    }
+}
+
+/// Open a reader `SqlCatalog` against the same SQLite DB + s3 warehouse.
+async fn open_reader_catalog(
+    db_uri: &str,
+    warehouse: &str,
+    props: HashMap<String, String>,
+) -> impl Catalog {
+    let cat_props = HashMap::from([
+        (SQL_CATALOG_PROP_URI.to_string(), db_uri.to_string()),
+        (SQL_CATALOG_PROP_WAREHOUSE.to_string(), warehouse.to_string()),
+        (
+            SQL_CATALOG_PROP_BIND_STYLE.to_string(),
+            SqlBindStyle::QMark.to_string(),
+        ),
+    ]);
+    SqlCatalogBuilder::default()
+        .with_storage_factory(Arc::new(S3PropFactory { props }))
+        .load("faucet-iceberg", cat_props)
+        .await
+        .expect("reader catalog open")
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn sql_catalog_s3_warehouse_commits_snapshot() {
+    let (_container, endpoint) = start_minio().await;
+    create_bucket(&endpoint).await;
+
+    let dir = TempDir::new().expect("tempdir");
+    let db_file = dir.path().join("catalog.db");
+    let sqlite_uri = format!("sqlite:{}?mode=rwc", db_file.display());
+    let warehouse = format!("s3://{BUCKET}/warehouse");
+
+    let mut catalog = json!({
+        "type": "sql",
+        "uri": sqlite_uri,
+        "warehouse": warehouse,
+    });
+    catalog["properties"] = s3_props(&endpoint);
+
+    let cfg: IcebergSinkConfig = serde_json::from_value(json!({
+        "catalog": catalog,
+        "namespace": ["db"],
+        "table": "events",
+        "create_if_missing": true,
+        "batch_size": 0
+    }))
+    .expect("sink config parse");
+
+    let sink = IcebergSink::new(cfg).await.expect("IcebergSink::new");
+
+    let records: Vec<serde_json::Value> = (0u64..50)
+        .map(|i| json!({ "id": i, "name": format!("n{i}") }))
+        .collect();
+    let written = sink.write_batch(&records).await.expect("write_batch");
+    assert_eq!(written, 50);
+    sink.flush().await.expect("flush");
+
+    // Reopen via a reader catalog and assert exactly one snapshot landed in S3.
+    let props: HashMap<String, String> =
+        serde_json::from_value(s3_props(&endpoint)).expect("props map");
+    let reader = open_reader_catalog(&sqlite_uri, &warehouse, props).await;
+    let tid = TableIdent::new(
+        NamespaceIdent::from_strs(["db"]).unwrap(),
+        "events".to_string(),
+    );
+    let table = reader.load_table(&tid).await.expect("load_table after flush");
+    let meta = table.metadata();
+
+    assert_eq!(meta.snapshots().count(), 1, "expected exactly one snapshot");
+    assert!(
+        meta.current_snapshot_id().is_some(),
+        "current snapshot must be set"
+    );
+    assert!(
+        meta.location().starts_with(&warehouse),
+        "table location {} must be under {warehouse}",
+        meta.location()
+    );
+}

--- a/docs/book/src/reference/connectors.md
+++ b/docs/book/src/reference/connectors.md
@@ -72,7 +72,7 @@ file/append sinks (`jsonl`, `csv`, `stdout`) it's a no-op — they write per rec
 | Stdout | `sink-stdout` | no-op | ✗ | JSON Lines / pretty JSON / TSV |
 | Apache Kafka | `sink-kafka` | ✓ | ✗ | producer, batched sends, multi-topic routing |
 | Apache Parquet | `sink-parquet` | ✓ | ✗⁶ | local/S3, schema inference, row/byte rollover |
-| Apache Iceberg | `sink-iceberg` | ✓ | ✗⁶ | REST/Glue/SQL/HMS catalog, `fast_append` snapshot, Parquet data files |
+| Apache Iceberg | `sink-iceberg` | ✓ | ✗⁶ | REST/Glue/SQL/HMS catalog, local + cloud (S3/GCS) warehouses, `fast_append` snapshot, Parquet data files |
 
 ⁶ Parquet and Iceberg both handle compression internally at the Parquet column
 level, so the file-level `compression` feature doesn't apply to either.


### PR DESCRIPTION
## Summary

Adds first-class cloud-warehouse (S3 / `s3a` / GCS) support to the **SQL, Glue, and HMS** Iceberg catalogs — the REST catalog already had it (FileIO resolved server-side). A single scheme-driven selector picks the storage factory from the `warehouse` URI:

- `file://` / bare path → `iceberg::io::LocalFsStorageFactory`
- `s3://` / `s3a://` → OpenDAL S3 (scheme matched to the URI)
- `gs://` → OpenDAL GCS
- anything else → typed `FaucetError::Config` at config-load time

Because `iceberg-catalog-sql` builds its `FileIO` with **empty** properties, a small `OpendalPropInjector` `StorageFactory` wrapper re-injects the user's `catalog.properties` (`s3.*` / `gcs.*`) so they actually reach the storage layer (Glue/HMS thread their own props, which overlay on top — one tested path for all three).

Cloud support is **auto-enabled**: each of `catalog-glue` / `catalog-sql` / `catalog-hms` now also enables a new `storage-opendal` feature (pulls `iceberg-storage-opendal`). No second flag to discover.

### Bonus bug fixes (same code path, in scope by completeness)

- **HMS was completely broken:** faucet never supplied a `StorageFactory`, so `HmsCatalog::new` always returned `"StorageFactory must be provided"`. Now fixed.
- **Glue rejected `s3://`:** it defaulted to an `s3a`-only scheme, so a `s3://` warehouse failed with `"Invalid s3 url … should start with s3a://"`. The selector now matches the scheme to the warehouse URI.

## Changes

- `crates/sink/iceberg/Cargo.toml` — `storage-opendal` feature + `iceberg-storage-opendal`/`typetag` deps; MinIO test dev-deps.
- `src/config.rs` — `warehouse_scheme()` classifier + fail-fast scheme validation for non-REST catalogs.
- `src/storage_factory.rs` (new) — `OpendalPropInjector` + `select_storage_factory()`.
- `src/catalog.rs` — `build_sql`/`build_glue`/`build_hms` use the selector.
- `README.md` + `docs/book/.../connectors.md` — document cloud-warehouse support (removed the stale "SQL/Glue/HMS = local-FS only" note).

## Test Plan

- [x] Unit tests: scheme classification, prop-merge precedence, factory selection (s3/s3a scheme preserved), unsupported-scheme error, config validation accept/reject (66 unit tests pass).
- [x] Local-FS integration test still passes (no regression).
- [x] **MinIO integration test (Docker/testcontainers):** SQL catalog (SQLite) + `s3://` warehouse writes + commits exactly one snapshot, verified via a reader catalog; data lands under the S3 warehouse.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean; `cargo fmt` clean.
- [x] Feature-isolation builds: default (REST), `catalog-sql`, `catalog-glue`, `catalog-hms` each build alone.
- [x] docs.rs nightly build (`--cfg docsrs`, all-features) clean.

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)