### PR TITLE
feat(transform-sql): SQL-as-transform via embedded DuckDB (#129)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,8 @@ jobs:
           # OpenLineage emission
           - lineage
           - lineage-kafka
+          # SQL transform (embedded DuckDB)
+          - transform-sql
           # Scheduler (CLI-only)
           - schedule
           # HTTP control plane (CLI-only) + its persistent run-history backends

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/core",
     "crates/auth",
     "crates/lineage",
+    "crates/transform-sql",
     "crates/common/bigquery",
     "crates/common/elasticsearch",
     "crates/common/gcs",
@@ -127,6 +128,7 @@ faucet-sink-iceberg = { path = "crates/sink/iceberg", version = "1.0.0" }
 faucet-state-redis = { path = "crates/state/redis", version = "1.0.0" }
 faucet-state-postgres = { path = "crates/state/postgres", version = "1.0.0" }
 faucet-cli = { path = "cli", version = "1.0.1" }
+faucet-transform-sql = { path = "crates/transform-sql", version = "0.1.0" }
 
 # Shared external deps
 serde = { version = "1", features = ["derive"] }
@@ -212,3 +214,5 @@ async-compression = { version = "0.4", features = ["tokio", "gzip", "zstd"] }
 flate2 = "1"
 zstd = "0.13"
 glob = "0.3"
+duckdb = "1.10503"
+tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ runtime (bookmarks, dead-letter routing, metrics) so connectors stay simple:
 ```mermaid
 flowchart LR
     S["<b>Source</b><br/>REST · DB · CDC<br/>Kafka · S3 · Parquet"]
-    T["<b>Transforms</b><br/>flatten · rename · keys_case<br/>select · drop · set · cast<br/>redact · value_case · spell_symbols"]
+    T["<b>Transforms</b><br/>flatten · rename · keys_case<br/>select · drop · set · cast<br/>redact · value_case · spell_symbols<br/>sql (DuckDB, page-level)"]
     P{{"<b>Pipeline</b>"}}
     K["<b>Sink</b><br/>BigQuery · Postgres<br/>Parquet · Kafka · ..."]
     ST[("State store<br/>file · Redis · Postgres")]
@@ -157,7 +157,7 @@ flowchart LR
     P -.->|metrics + spans| O
 ```
 
-faucet-stream is a Cargo workspace with 54 crates — 23 sources, 18 sinks, 6 shared connector libraries, the shared auth-provider library, 2 state-store backends, the lineage crate, the shared core, the umbrella crate, and the CLI binary:
+faucet-stream is a Cargo workspace with 55 crates — 23 sources, 18 sinks, 6 shared connector libraries, the shared auth-provider library, 2 state-store backends, the lineage crate, the SQL transform crate, the shared core, the umbrella crate, and the CLI binary:
 
 | Crate | Description |
 |-------|-------------|
@@ -218,6 +218,8 @@ faucet-stream is a Cargo workspace with 54 crates — 23 sources, 18 sinks, 6 sh
 | [`faucet-state-postgres`](crates/state/postgres) | PostgreSQL-backed `StateStore` for persistent bookmarks |
 | **Lineage** | |
 | [`faucet-lineage`](crates/lineage) | OpenLineage event emission — HTTP/file/Kafka transports, schema facets, column-lineage analysis |
+| **Transforms** | |
+| [`faucet-transform-sql`](crates/transform-sql) | Embedded DuckDB SQL transform — run DuckDB SQL over each page (`batch` relation), reference relations (csv/jsonl/values), per-page semantics + `batch_size: 0` for global aggregation |
 | [`faucet-stream`](faucet-stream) | Umbrella crate — feature-gated re-exports of all connectors and state backends |
 | **CLI** | |
 | [`faucet-cli`](cli) | `faucet` binary — YAML/JSON config-driven pipeline runner (`run`, `validate`, `schema`, `list`, `preview`, `init`, `doctor`, `schedule`, `serve`) |
@@ -304,7 +306,7 @@ Every pipeline emits OTel-compatible `tracing` spans and Prometheus metrics auto
 - **Authentication** — Bearer, Basic, API Key (header or query param), OAuth2 (client credentials), Token Endpoint (fetch from any API), or custom headers
 - **Pagination** — cursor/token (JSONPath), page number, offset/limit, Link header, next-link-in-body
 - **JSONPath extraction** — point at where records live in any JSON response
-- **Record transforms** — flatten, rename keys (regex), `keys_case` (snake / camel / pascal / kebab / screaming_snake), plus config-exposed `select` / `drop` / `set` / `rename_field` / `cast` / `redact` / `value_case` / `spell_symbols`, or custom closures
+- **Record transforms** — flatten, rename keys (regex), `keys_case` (snake / camel / pascal / kebab / screaming_snake), plus config-exposed `select` / `drop` / `set` / `rename_field` / `cast` / `redact` / `value_case` / `spell_symbols` / `sql` (embedded DuckDB, page-level — `batch` relation), or custom closures
 - **Schema inference** — automatically derive a JSON Schema from sampled records
 - **Incremental replication** — bookmark-based filtering so you only fetch new records
 - **Partitions** — run the same stream across multiple contexts (e.g. per-org, per-repo)
@@ -965,6 +967,7 @@ Every pagination style has a termination/loop guard. `Cursor`, `LinkHeader`, and
 | `transform-value-case` | no | Lowercase / uppercase / trim string field values |
 | `transform-spell-symbols` | no | Spell out symbols in keys (`%` → `percent`, `#` → `number`, …) |
 | `transforms` | no | All built-in transforms above |
+| `transform-sql` | no | Embedded DuckDB SQL transform — run any DuckDB SQL query over each pipeline page via the `batch` relation (page-level; `batch_size: 0` for global aggregation) |
 | `compression` | no | gzip / zstd read+write on JSONL/CSV/S3/GCS source and sink connectors |
 
 `RecordTransform::Custom` is always available regardless of feature flags.
@@ -1149,6 +1152,7 @@ crates/
   state/
     redis/                    — Redis-backed StateStore
     postgres/                 — PostgreSQL-backed StateStore
+  transform-sql/              — faucet-transform-sql: embedded DuckDB SQL transform (batch relation, reference relations)
 faucet-stream/                — umbrella crate with feature-gated re-exports
 cli/                          — faucet-cli: `faucet` binary, YAML/JSON pipeline runner
   src/

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -26,7 +26,7 @@ default = ["observability", "source", "sink", "state", "transforms", "compressio
 
 # Everything the default build ships, plus the long-running runtime modes:
 # `schedule` (cron scheduler) and `serve` (HTTP control plane).
-full = ["default", "schedule", "serve", "serve-history-postgres", "serve-history-sqlite", "lineage", "lineage-kafka"]
+full = ["default", "schedule", "serve", "serve-history-postgres", "serve-history-sqlite", "lineage", "lineage-kafka", "transform-sql"]
 
 # Data-quality checks (`quality:` config block). `quality-jsonschema` adds the
 # `json_schema` record check via a JSON Schema validator. Forwarded to
@@ -177,6 +177,7 @@ transforms = [
 # asked for. The `transforms` aggregate above enables every transform at once.
 transform-filter = ["faucet-core/transform-filter"]
 transform-explode = ["faucet-core/transform-explode"]
+transform-sql = ["dep:faucet-transform-sql"]
 
 observability = [
     "faucet-core/observability-install",
@@ -243,6 +244,7 @@ faucet-sink-gcs = { workspace = true, optional = true }
 faucet-state-redis = { workspace = true, optional = true }
 faucet-state-postgres = { workspace = true, optional = true }
 faucet-lineage = { workspace = true, optional = true }
+faucet-transform-sql = { workspace = true, optional = true }
 
 clap = { version = "4", features = ["derive", "env"] }
 dotenvy = "0.15"

--- a/cli/examples/csv_to_jsonl_sql.yaml
+++ b/cli/examples/csv_to_jsonl_sql.yaml
@@ -1,0 +1,40 @@
+# Aggregate and enrich order data using embedded DuckDB SQL.
+#
+# The whole CSV is loaded as a single page (batch_size: 0) so the GROUP BY
+# runs across all rows. A reference CSV (countries) is joined at compile time.
+#
+#   faucet validate cli/examples/csv_to_jsonl_sql.yaml
+#   faucet run      cli/examples/csv_to_jsonl_sql.yaml   # requires --features transform-sql,source-csv,sink-jsonl
+version: 1
+name: csv_to_jsonl_sql
+
+pipeline:
+  source:
+    type: csv
+    config:
+      path: cli/examples/data/orders.csv
+      has_header: true
+      batch_size: 0          # whole file as one page → global GROUP BY
+
+  transforms:
+    - type: sql
+      config:
+        query: |
+          SELECT c.country,
+                 COUNT(*)                     AS order_count,
+                 SUM(CAST(o.amount AS DOUBLE)) AS total_amount
+          FROM   batch o
+          LEFT JOIN countries c ON o.country_code = c.code
+          GROUP BY c.country
+          ORDER BY c.country
+        relations:
+          - name: countries
+            source:
+              type: csv
+              path: cli/examples/data/countries.csv
+              has_header: true
+
+  sink:
+    type: jsonl
+    config:
+      path: /tmp/faucet_sql_demo.jsonl

--- a/cli/examples/data/countries.csv
+++ b/cli/examples/data/countries.csv
@@ -1,0 +1,4 @@
+code,country
+US,United States
+IN,India
+DE,Germany

--- a/cli/examples/data/orders.csv
+++ b/cli/examples/data/orders.csv
@@ -1,0 +1,5 @@
+order_id,country_code,amount
+1,US,10.0
+2,US,5.5
+3,IN,7.0
+4,DE,3.0

--- a/cli/src/transforms.rs
+++ b/cli/src/transforms.rs
@@ -363,18 +363,17 @@ fn registry() -> Vec<TransformDef> {
             schema_fn: || schema_sql(),
             compile_fn: |kind, config| {
                 let cfg: faucet_transform_sql::SqlTransformConfig = decode_sql(kind, config)?;
-                let transform =
-                    faucet_transform_sql::SqlTransform::compile(&cfg).map_err(|e| {
-                        let message = match &e {
-                            faucet_core::FaucetError::Transform(m)
-                            | faucet_core::FaucetError::Config(m) => m.clone(),
-                            other => format!("{other}"),
-                        };
-                        CliError::InvalidTransform {
-                            name: kind.to_owned(),
-                            message,
-                        }
-                    })?;
+                let transform = faucet_transform_sql::SqlTransform::compile(&cfg).map_err(|e| {
+                    let message = match &e {
+                        faucet_core::FaucetError::Transform(m)
+                        | faucet_core::FaucetError::Config(m) => m.clone(),
+                        other => format!("{other}"),
+                    };
+                    CliError::InvalidTransform {
+                        name: kind.to_owned(),
+                        message,
+                    }
+                })?;
                 Ok(transform.into_page_stage())
             },
         });
@@ -486,15 +485,14 @@ fn decode<T: serde::de::DeserializeOwned>(name: &str, config: Value) -> CliResul
 
 #[cfg(feature = "transform-sql")]
 fn schema_sql() -> Value {
-    serde_json::to_value(faucet_core::schema_for!(faucet_transform_sql::SqlTransformConfig))
-        .unwrap_or(Value::Null)
+    serde_json::to_value(faucet_core::schema_for!(
+        faucet_transform_sql::SqlTransformConfig
+    ))
+    .unwrap_or(Value::Null)
 }
 
 #[cfg(feature = "transform-sql")]
-fn decode_sql(
-    kind: &str,
-    config: Value,
-) -> CliResult<faucet_transform_sql::SqlTransformConfig> {
+fn decode_sql(kind: &str, config: Value) -> CliResult<faucet_transform_sql::SqlTransformConfig> {
     serde_json::from_value(config).map_err(|e| CliError::InvalidTransform {
         name: kind.to_owned(),
         message: e.to_string(),

--- a/cli/src/transforms.rs
+++ b/cli/src/transforms.rs
@@ -170,9 +170,11 @@ struct TransformDef {
 /// so each row stays a single self-contained record next to its sibling
 /// entries.
 fn registry() -> Vec<TransformDef> {
+    #[allow(unused_mut)]
+    let mut defs: Vec<TransformDef> = Vec::new();
     #[cfg(feature = "transforms")]
     {
-        vec![
+        defs.extend(vec![
             TransformDef {
                 kind: "flatten",
                 description: "Flatten nested objects into a single level (configurable separator).",
@@ -351,12 +353,33 @@ fn registry() -> Vec<TransformDef> {
                     Ok(stage)
                 },
             },
-        ]
+        ]);
     }
-    #[cfg(not(feature = "transforms"))]
+    #[cfg(feature = "transform-sql")]
     {
-        Vec::new()
+        defs.push(TransformDef {
+            kind: "sql",
+            description: "Run DuckDB SQL over the whole page; records are the `batch` relation.",
+            schema_fn: || schema_sql(),
+            compile_fn: |kind, config| {
+                let cfg: faucet_transform_sql::SqlTransformConfig = decode_sql(kind, config)?;
+                let transform =
+                    faucet_transform_sql::SqlTransform::compile(&cfg).map_err(|e| {
+                        let message = match &e {
+                            faucet_core::FaucetError::Transform(m)
+                            | faucet_core::FaucetError::Config(m) => m.clone(),
+                            other => format!("{other}"),
+                        };
+                        CliError::InvalidTransform {
+                            name: kind.to_owned(),
+                            message,
+                        }
+                    })?;
+                Ok(transform.into_page_stage())
+            },
+        });
     }
+    defs
 }
 
 /// Compile a list of [`TransformSpec`]s into [`TransformStage`]s in the
@@ -457,6 +480,23 @@ fn schema<T: JsonSchema>() -> Value {
 fn decode<T: serde::de::DeserializeOwned>(name: &str, config: Value) -> CliResult<T> {
     serde_json::from_value(config).map_err(|e| CliError::InvalidTransform {
         name: name.to_owned(),
+        message: e.to_string(),
+    })
+}
+
+#[cfg(feature = "transform-sql")]
+fn schema_sql() -> Value {
+    serde_json::to_value(faucet_core::schema_for!(faucet_transform_sql::SqlTransformConfig))
+        .unwrap_or(Value::Null)
+}
+
+#[cfg(feature = "transform-sql")]
+fn decode_sql(
+    kind: &str,
+    config: Value,
+) -> CliResult<faucet_transform_sql::SqlTransformConfig> {
+    serde_json::from_value(config).map_err(|e| CliError::InvalidTransform {
+        name: kind.to_owned(),
         message: e.to_string(),
     })
 }
@@ -852,6 +892,39 @@ mod tests {
             CliError::InvalidTransform { name, .. } => assert_eq!(name, "explode"),
             other => panic!("expected InvalidTransform, got {other:?}"),
         }
+    }
+
+    #[cfg(feature = "transform-sql")]
+    #[test]
+    fn compiles_sql_to_page_fn() {
+        let specs = vec![TransformSpec {
+            kind: "sql".into(),
+            config: json!({"query": "SELECT * FROM batch"}),
+        }];
+        let out = compile_transforms(&specs).unwrap();
+        assert_eq!(out.len(), 1);
+        assert!(matches!(out[0], faucet_core::TransformStage::PageFn(_)));
+    }
+
+    #[cfg(feature = "transform-sql")]
+    #[test]
+    fn sql_bad_query_is_invalid_transform() {
+        let specs = vec![TransformSpec {
+            kind: "sql".into(),
+            config: json!({"query": "SELEKT bad"}),
+        }];
+        let err = compile_transforms(&specs).unwrap_err();
+        match err {
+            CliError::InvalidTransform { name, .. } => assert_eq!(name, "sql"),
+            other => panic!("expected InvalidTransform, got {other:?}"),
+        }
+    }
+
+    #[cfg(feature = "transform-sql")]
+    #[test]
+    fn sql_schema_and_listing_present() {
+        assert!(transform_schema("sql").is_ok());
+        assert!(available_transforms().contains(&"sql"));
     }
 
     #[cfg(feature = "quality")]

--- a/cli/tests/sql_transform.rs
+++ b/cli/tests/sql_transform.rs
@@ -1,4 +1,8 @@
-#![cfg(all(feature = "transform-sql", feature = "source-csv", feature = "sink-jsonl"))]
+#![cfg(all(
+    feature = "transform-sql",
+    feature = "source-csv",
+    feature = "sink-jsonl"
+))]
 
 use faucet_cli::config::TransformSpec;
 use faucet_cli::transforms::compile_transforms;

--- a/cli/tests/sql_transform.rs
+++ b/cli/tests/sql_transform.rs
@@ -1,0 +1,98 @@
+#![cfg(all(feature = "transform-sql", feature = "source-csv", feature = "sink-jsonl"))]
+
+use faucet_cli::config::TransformSpec;
+use faucet_cli::transforms::compile_transforms;
+
+/// End-to-end pipeline: CSV orders + CSV countries reference, GROUP BY + JOIN
+/// via embedded DuckDB, output to JSONL. Verifies records are aggregated and
+/// joined correctly.
+#[tokio::test]
+async fn csv_groupby_join_to_jsonl() {
+    let dir = tempfile::tempdir().unwrap();
+    let orders = dir.path().join("orders.csv");
+    let countries = dir.path().join("countries.csv");
+    let out = dir.path().join("out.jsonl");
+
+    std::fs::write(
+        &orders,
+        "order_id,country_code,amount\n1,US,10\n2,US,5\n3,IN,7\n",
+    )
+    .unwrap();
+    std::fs::write(&countries, "code,country\nUS,United States\nIN,India\n").unwrap();
+
+    let yaml = format!(
+        r#"version: 1
+name: t
+pipeline:
+  source:
+    type: csv
+    config:
+      path: "{orders}"
+      has_header: true
+      batch_size: 0
+  transforms:
+    - type: sql
+      config:
+        query: |
+          SELECT c.country, COUNT(*) AS n, SUM(CAST(o.amount AS DOUBLE)) AS total
+          FROM batch o
+          JOIN countries c ON o.country_code = c.code
+          GROUP BY c.country
+          ORDER BY c.country
+        relations:
+          - name: countries
+            source:
+              type: csv
+              path: "{countries}"
+              has_header: true
+  sink:
+    type: jsonl
+    config:
+      path: "{out}"
+"#,
+        orders = orders.display(),
+        countries = countries.display(),
+        out = out.display(),
+    );
+
+    faucet_cli::run_from_yaml_str(&yaml)
+        .await
+        .expect("pipeline run");
+
+    let body = std::fs::read_to_string(&out).unwrap();
+    let rows: Vec<serde_json::Value> = body
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str(l).unwrap())
+        .collect();
+
+    // India: 1 order, total 7; United States: 2 orders, total 15.
+    let india = rows
+        .iter()
+        .find(|r| r["country"] == "India")
+        .expect("India row");
+    assert_eq!(india["n"], 1);
+
+    let us = rows
+        .iter()
+        .find(|r| r["country"] == "United States")
+        .expect("United States row");
+    assert_eq!(us["n"], 2);
+    assert_eq!(us["total"], 15.0);
+}
+
+/// `faucet validate` path: `compile_transforms` surfaces a query error for
+/// syntactically invalid SQL at config-load time.
+#[test]
+fn validate_reports_bad_sql() {
+    let specs = vec![TransformSpec {
+        kind: "sql".into(),
+        config: serde_json::json!({"query": "SELEKT oops"}),
+    }];
+    let err = compile_transforms(&specs).unwrap_err();
+    let msg = format!("{err}").to_lowercase();
+    assert!(
+        msg.contains("sel") || msg.contains("syntax") || msg.contains("invalid"),
+        "expected error message to mention the bad SQL token, got: {err}"
+    );
+}

--- a/crates/core/src/observability/transform.rs
+++ b/crates/core/src/observability/transform.rs
@@ -1,20 +1,21 @@
-//! Wraps `stage::apply_stages` with span + counter + histogram emission.
+//! Wraps `stage::apply_stages_to_page` with span + counter + histogram emission.
 
 use crate::observability::labels::Labels;
 use crate::observability::timer::DurationGuard;
-use crate::stage::{CompiledStage, apply_stages};
+use crate::stage::CompiledStage;
 use metrics::{Label, SharedString, counter};
 use serde_json::Value;
 use tracing::info_span;
 
-/// Apply a sequence of compiled stages to every record in `records`,
-/// flat-mapping per stage. Emits one `faucet.transform.apply` span and
-/// counters `faucet_transform_records_in_total` / `_records_out_total` per
-/// call (per page).
+/// Apply a sequence of compiled stages to `records` (a full page). Per-record
+/// stages flat-map over each record; `PageFn` stages transform the whole page
+/// at once. Emits one `faucet.transform.apply` span and counters
+/// `faucet_transform_records_in_total` / `_records_out_total` per call (per
+/// page).
 ///
 /// Returns [`FaucetError::Transform`](crate::FaucetError::Transform) if any
 /// stage errors (e.g. `flatten` key collision, `explode` duplicate key,
-/// `filter` JSONPath compile error), incrementing
+/// `filter` JSONPath compile error, `PageFn` runtime error), incrementing
 /// `faucet_transform_errors_total`.
 pub fn instrumented_apply_stages(
     records: Vec<Value>,
@@ -36,16 +37,14 @@ pub fn instrumented_apply_stages(
         Label::new("row", SharedString::from(labels.row.to_string())),
     ];
     let _timer = DurationGuard::new("faucet_transform_duration_seconds", metric_labels.clone());
-    let mut out: Vec<Value> = Vec::with_capacity(n_in);
-    for r in records {
-        match apply_stages(r, stages) {
-            Ok(vs) => out.extend(vs),
-            Err(e) => {
-                counter!("faucet_transform_errors_total", metric_labels.clone()).increment(1);
-                return Err(e);
-            }
+    use crate::stage::apply_stages_to_page;
+    let out = match apply_stages_to_page(records, stages) {
+        Ok(o) => o,
+        Err(e) => {
+            counter!("faucet_transform_errors_total", metric_labels.clone()).increment(1);
+            return Err(e);
         }
-    }
+    };
     counter!("faucet_transform_records_in_total", metric_labels.clone()).increment(n_in as u64);
     counter!("faucet_transform_records_out_total", metric_labels).increment(out.len() as u64);
     Ok(out)
@@ -55,7 +54,7 @@ pub fn instrumented_apply_stages(
 mod tests {
     use super::*;
     use crate::observability::decorator::source_tests::{LOCK, snapshotter};
-    use crate::stage::{TransformStage, compile_stage};
+    use crate::stage::{CompiledStage, TransformStage, compile_stage};
     use crate::transform::{KeyCaseMode, RecordTransform};
     use metrics_util::debugging::DebugValue;
     use serde_json::json;
@@ -87,5 +86,28 @@ mod tests {
         });
         assert!(in_found, "expected _records_in_total");
         assert!(out_found, "expected _records_out_total");
+    }
+
+    #[test]
+    fn page_fn_changes_row_count_counters() {
+        let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let snap = snapshotter();
+        let labels = Labels::new("p", "r", "rid");
+        let collapse = CompiledStage::PageFn(std::sync::Arc::new(|recs: Vec<serde_json::Value>| {
+            Ok(vec![json!({"n": recs.len()})])
+        }));
+        let out = instrumented_apply_stages(
+            vec![json!({"a": 1}), json!({"a": 2}), json!({"a": 3})],
+            &[collapse],
+            &labels,
+        )
+        .unwrap();
+        assert_eq!(out, vec![json!({"n": 3})]);
+        let snapshot = snap.snapshot().into_vec();
+        let out_one = snapshot.iter().any(|(key, _, _, v)| {
+            key.key().name() == "faucet_transform_records_out_total"
+                && matches!(v, DebugValue::Counter(c) if *c >= 1)
+        });
+        assert!(out_one, "out counter should record the single collapsed row");
     }
 }

--- a/crates/core/src/observability/transform.rs
+++ b/crates/core/src/observability/transform.rs
@@ -2,7 +2,7 @@
 
 use crate::observability::labels::Labels;
 use crate::observability::timer::DurationGuard;
-use crate::stage::CompiledStage;
+use crate::stage::{CompiledStage, apply_stages_to_page};
 use metrics::{Label, SharedString, counter};
 use serde_json::Value;
 use tracing::info_span;
@@ -37,7 +37,6 @@ pub fn instrumented_apply_stages(
         Label::new("row", SharedString::from(labels.row.to_string())),
     ];
     let _timer = DurationGuard::new("faucet_transform_duration_seconds", metric_labels.clone());
-    use crate::stage::apply_stages_to_page;
     let out = match apply_stages_to_page(records, stages) {
         Ok(o) => o,
         Err(e) => {

--- a/crates/core/src/observability/transform.rs
+++ b/crates/core/src/observability/transform.rs
@@ -92,9 +92,10 @@ mod tests {
         let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let snap = snapshotter();
         let labels = Labels::new("p", "r", "rid");
-        let collapse = CompiledStage::PageFn(std::sync::Arc::new(|recs: Vec<serde_json::Value>| {
-            Ok(vec![json!({"n": recs.len()})])
-        }));
+        let collapse =
+            CompiledStage::PageFn(std::sync::Arc::new(|recs: Vec<serde_json::Value>| {
+                Ok(vec![json!({"n": recs.len()})])
+            }));
         let out = instrumented_apply_stages(
             vec![json!({"a": 1}), json!({"a": 2}), json!({"a": 3})],
             &[collapse],
@@ -107,6 +108,9 @@ mod tests {
             key.key().name() == "faucet_transform_records_out_total"
                 && matches!(v, DebugValue::Counter(c) if *c >= 1)
         });
-        assert!(out_one, "out counter should record the single collapsed row");
+        assert!(
+            out_one,
+            "out counter should record the single collapsed row"
+        );
     }
 }

--- a/crates/core/src/stage.rs
+++ b/crates/core/src/stage.rs
@@ -1,4 +1,4 @@
-//! Pipeline-level transform stages. A [`TransformStage`] wraps one of four
+//! Pipeline-level transform stages. A [`TransformStage`] wraps one of five
 //! shapes:
 //!
 //! - [`TransformStage::Map`] holds an unchanged 1→1 [`RecordTransform`].
@@ -8,16 +8,26 @@
 //!   records (added in Task 5).
 //! - [`TransformStage::Custom`] is an `Fn(Value) -> Vec<Value>` closure
 //!   escape hatch for library callers.
+//! - [`TransformStage::PageFn`] is a `Fn(Vec<Value>) -> Result<Vec<Value>,
+//!   FaucetError>` whole-batch closure for transforms that need the full page
+//!   at once (SQL, sort, dedup, top-N). Not addressable from YAML.
 //!
-//! [`apply_stages`] is the per-record runner: it flat-maps stages left to
-//! right, so order matters (a `Filter` after an `Explode` filters children).
+//! [`apply_stages_to_page`] is the page-granular runner: per-record stages
+//! (`Map`/`Filter`/`Explode`/`Custom`) flat-map over each record in order,
+//! while `PageFn` stages receive and return the whole page slice. Declared
+//! order is preserved, so `filter → sql → select` works as expected.
 //! The observability wrapper [`crate::observability::instrumented_apply_stages`]
-//! calls this per record and aggregates the page-level counters.
+//! wraps `apply_stages_to_page` and aggregates per-page metrics.
 
 use crate::error::FaucetError;
 use crate::transform::{CompiledTransform, RecordTransform, compile as compile_record};
 use serde_json::Value;
 use std::sync::Arc;
+
+/// Type alias for the page-level transform closure stored in
+/// [`TransformStage::PageFn`] and [`CompiledStage::PageFn`].
+pub type PageFnBox =
+    Arc<dyn Fn(Vec<Value>) -> Result<Vec<Value>, FaucetError> + Send + Sync>;
 
 /// One stage in a transform pipeline.
 pub enum TransformStage {
@@ -38,7 +48,7 @@ pub enum TransformStage {
     /// The escape hatch for transforms that need the full batch at once (SQL,
     /// sort, dedup, top-N). Dependency-free; built by connectors/CLI, not
     /// addressable as a per-record stage.
-    PageFn(Arc<dyn Fn(Vec<Value>) -> Result<Vec<Value>, FaucetError> + Send + Sync>),
+    PageFn(PageFnBox),
 }
 
 impl std::fmt::Debug for TransformStage {
@@ -77,7 +87,7 @@ pub enum CompiledStage {
     #[cfg(feature = "transform-explode")]
     Explode(CompiledExplode),
     Custom(Arc<dyn Fn(Value) -> Vec<Value> + Send + Sync>),
-    PageFn(Arc<dyn Fn(Vec<Value>) -> Result<Vec<Value>, FaucetError> + Send + Sync>),
+    PageFn(PageFnBox),
 }
 
 impl std::fmt::Debug for CompiledStage {
@@ -1338,5 +1348,13 @@ mod tests {
         let err = apply_stages(json!({"a": 1}), &[page_count_stage()]).unwrap_err();
         assert!(matches!(err, FaucetError::Transform(_)));
         assert!(format!("{err}").contains("per-record"));
+    }
+
+    #[test]
+    fn page_fn_handles_empty_page() {
+        // An empty page through page_count_stage yields vec![{"n": 0}] — no panic,
+        // no error, and the PageFn closure correctly observes a zero-length slice.
+        let out = apply_stages_to_page(vec![], &[page_count_stage()]).unwrap();
+        assert_eq!(out, vec![json!({"n": 0})]);
     }
 }

--- a/crates/core/src/stage.rs
+++ b/crates/core/src/stage.rs
@@ -34,6 +34,11 @@ pub enum TransformStage {
     Explode(ExplodeSpec),
     /// Arbitrary 0..N closure for library callers (not addressable from YAML).
     Custom(Arc<dyn Fn(Value) -> Vec<Value> + Send + Sync>),
+    /// Page-level closure: sees the whole page, returns a new page; fallible.
+    /// The escape hatch for transforms that need the full batch at once (SQL,
+    /// sort, dedup, top-N). Dependency-free; built by connectors/CLI, not
+    /// addressable as a per-record stage.
+    PageFn(Arc<dyn Fn(Vec<Value>) -> Result<Vec<Value>, FaucetError> + Send + Sync>),
 }
 
 impl std::fmt::Debug for TransformStage {
@@ -45,6 +50,7 @@ impl std::fmt::Debug for TransformStage {
             #[cfg(feature = "transform-explode")]
             Self::Explode(s) => f.debug_tuple("Explode").field(s).finish(),
             Self::Custom(_) => write!(f, "Custom(<fn>)"),
+            Self::PageFn(_) => write!(f, "PageFn(<fn>)"),
         }
     }
 }
@@ -58,6 +64,7 @@ impl Clone for TransformStage {
             #[cfg(feature = "transform-explode")]
             Self::Explode(s) => Self::Explode(s.clone()),
             Self::Custom(f) => Self::Custom(Arc::clone(f)),
+            Self::PageFn(f) => Self::PageFn(Arc::clone(f)),
         }
     }
 }
@@ -70,6 +77,7 @@ pub enum CompiledStage {
     #[cfg(feature = "transform-explode")]
     Explode(CompiledExplode),
     Custom(Arc<dyn Fn(Value) -> Vec<Value> + Send + Sync>),
+    PageFn(Arc<dyn Fn(Vec<Value>) -> Result<Vec<Value>, FaucetError> + Send + Sync>),
 }
 
 impl std::fmt::Debug for CompiledStage {
@@ -81,6 +89,7 @@ impl std::fmt::Debug for CompiledStage {
             #[cfg(feature = "transform-explode")]
             Self::Explode(e) => f.debug_tuple("Explode").field(e).finish(),
             Self::Custom(_) => write!(f, "Custom(<fn>)"),
+            Self::PageFn(_) => write!(f, "PageFn(<fn>)"),
         }
     }
 }
@@ -103,6 +112,7 @@ impl Clone for CompiledStage {
                 on_missing: e.on_missing,
             }),
             Self::Custom(f) => Self::Custom(Arc::clone(f)),
+            Self::PageFn(f) => Self::PageFn(Arc::clone(f)),
         }
     }
 }
@@ -610,6 +620,7 @@ pub fn compile_stage(s: &TransformStage) -> Result<CompiledStage, FaucetError> {
             Ok(CompiledStage::Explode(CompiledExplode::compile(spec)?))
         }
         TransformStage::Custom(f) => Ok(CompiledStage::Custom(Arc::clone(f))),
+        TransformStage::PageFn(f) => Ok(CompiledStage::PageFn(Arc::clone(f))),
     }
 }
 
@@ -624,6 +635,30 @@ pub fn apply_stages(rec: Value, stages: &[CompiledStage]) -> Result<Vec<Value>, 
         acc = next;
     }
     Ok(acc)
+}
+
+/// Page-granular stage runner. Per-record stages (`Map`/`Filter`/`Explode`/
+/// `Custom`) flat-map over the current page; `PageFn` stages transform the whole
+/// page at once. Preserves declared order, so `filter → sql → select` works.
+pub fn apply_stages_to_page(
+    mut records: Vec<Value>,
+    stages: &[CompiledStage],
+) -> Result<Vec<Value>, FaucetError> {
+    for stage in stages {
+        match stage {
+            CompiledStage::PageFn(f) => {
+                records = f(records)?;
+            }
+            per_record => {
+                let mut next = Vec::with_capacity(records.len());
+                for r in records {
+                    next.extend(apply_one_stage(r, per_record)?);
+                }
+                records = next;
+            }
+        }
+    }
+    Ok(records)
 }
 
 fn apply_one_stage(rec: Value, stage: &CompiledStage) -> Result<Vec<Value>, FaucetError> {
@@ -643,6 +678,10 @@ fn apply_one_stage(rec: Value, stage: &CompiledStage) -> Result<Vec<Value>, Fauc
         #[cfg(feature = "transform-explode")]
         CompiledStage::Explode(e) => e.apply(rec),
         CompiledStage::Custom(f) => Ok(f(rec)),
+        CompiledStage::PageFn(_) => Err(FaucetError::Transform(
+            "PageFn is a page-level stage and cannot run in a per-record context; \
+             use apply_stages_to_page".to_owned(),
+        )),
     }
 }
 
@@ -1230,5 +1269,74 @@ mod tests {
         });
         let out = apply_stages(rec, &stages).unwrap();
         assert_eq!(out.len(), 3);
+    }
+
+    // ── PageFn ──
+
+    fn page_count_stage() -> CompiledStage {
+        // Collapse the whole page into a single {"n": <count>} record.
+        CompiledStage::PageFn(Arc::new(|recs: Vec<Value>| {
+            Ok(vec![json!({ "n": recs.len() })])
+        }))
+    }
+
+    #[test]
+    fn page_fn_sees_whole_page() {
+        let out = apply_stages_to_page(
+            vec![json!({"a": 1}), json!({"a": 2}), json!({"a": 3})],
+            &[page_count_stage()],
+        )
+        .unwrap();
+        assert_eq!(out, vec![json!({"n": 3})]);
+    }
+
+    #[cfg(feature = "transform-filter")]
+    #[test]
+    fn page_fn_interleaves_with_per_record_stages() {
+        // filter (drop a==2) → page-count → (map identity). Count must see 2 rows.
+        let compiled = compile(&[TransformStage::Filter(FilterSpec {
+            path: "a".into(),
+            op: FilterOp::Ne,
+            value: Some(json!(2)),
+        })]);
+        let mut stages = compiled;
+        stages.push(page_count_stage());
+        let out = apply_stages_to_page(
+            vec![json!({"a": 1}), json!({"a": 2}), json!({"a": 3})],
+            &stages,
+        )
+        .unwrap();
+        assert_eq!(out, vec![json!({"n": 2})]);
+    }
+
+    #[test]
+    fn page_fn_only_per_record_path_matches_flat_map() {
+        // A page of per-record stages routes identically through both runners.
+        let compiled = compile(&[TransformStage::Map(RecordTransform::KeysCase {
+            mode: KeyCaseMode::Snake,
+        })]);
+        let page = vec![json!({"FooBar": 1}), json!({"BazQux": 2})];
+        let via_page = apply_stages_to_page(page.clone(), &compiled).unwrap();
+        let mut via_record = Vec::new();
+        for r in page {
+            via_record.extend(apply_stages(r, &compiled).unwrap());
+        }
+        assert_eq!(via_page, via_record);
+    }
+
+    #[test]
+    fn page_fn_error_propagates() {
+        let boom: CompiledStage = CompiledStage::PageFn(Arc::new(|_| {
+            Err(FaucetError::Transform("boom".into()))
+        }));
+        let err = apply_stages_to_page(vec![json!({})], &[boom]).unwrap_err();
+        assert!(matches!(err, FaucetError::Transform(m) if m == "boom"));
+    }
+
+    #[test]
+    fn page_fn_in_per_record_context_errors() {
+        let err = apply_stages(json!({"a": 1}), &[page_count_stage()]).unwrap_err();
+        assert!(matches!(err, FaucetError::Transform(_)));
+        assert!(format!("{err}").contains("per-record"));
     }
 }

--- a/crates/core/src/stage.rs
+++ b/crates/core/src/stage.rs
@@ -26,8 +26,7 @@ use std::sync::Arc;
 
 /// Type alias for the page-level transform closure stored in
 /// [`TransformStage::PageFn`] and [`CompiledStage::PageFn`].
-pub type PageFnBox =
-    Arc<dyn Fn(Vec<Value>) -> Result<Vec<Value>, FaucetError> + Send + Sync>;
+pub type PageFnBox = Arc<dyn Fn(Vec<Value>) -> Result<Vec<Value>, FaucetError> + Send + Sync>;
 
 /// One stage in a transform pipeline.
 pub enum TransformStage {
@@ -690,7 +689,8 @@ fn apply_one_stage(rec: Value, stage: &CompiledStage) -> Result<Vec<Value>, Fauc
         CompiledStage::Custom(f) => Ok(f(rec)),
         CompiledStage::PageFn(_) => Err(FaucetError::Transform(
             "PageFn is a page-level stage and cannot run in a per-record context; \
-             use apply_stages_to_page".to_owned(),
+             use apply_stages_to_page"
+                .to_owned(),
         )),
     }
 }
@@ -1336,9 +1336,8 @@ mod tests {
 
     #[test]
     fn page_fn_error_propagates() {
-        let boom: CompiledStage = CompiledStage::PageFn(Arc::new(|_| {
-            Err(FaucetError::Transform("boom".into()))
-        }));
+        let boom: CompiledStage =
+            CompiledStage::PageFn(Arc::new(|_| Err(FaucetError::Transform("boom".into()))));
         let err = apply_stages_to_page(vec![json!({})], &[boom]).unwrap_err();
         assert!(matches!(err, FaucetError::Transform(m) if m == "boom"));
     }

--- a/crates/transform-sql/Cargo.toml
+++ b/crates/transform-sql/Cargo.toml
@@ -10,9 +10,6 @@ categories.workspace = true
 keywords = ["sql", "duckdb", "transform", "pipeline", "etl"]
 description = "SQL-as-transform for faucet-stream — run DuckDB SQL over each pipeline page (the `batch` relation)."
 
-[lib]
-doctest = false
-
 [dependencies]
 faucet-core.workspace = true
 duckdb = { workspace = true, features = ["bundled", "vtab-arrow"] }

--- a/crates/transform-sql/Cargo.toml
+++ b/crates/transform-sql/Cargo.toml
@@ -22,7 +22,7 @@ tracing.workspace = true
 
 [dev-dependencies]
 criterion.workspace = true
-tempfile = "3"
+tempfile.workspace = true
 
 [[bench]]
 name = "sql_transform"

--- a/crates/transform-sql/Cargo.toml
+++ b/crates/transform-sql/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "faucet-transform-sql"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+documentation = "https://docs.rs/faucet-transform-sql"
+categories.workspace = true
+keywords = ["sql", "duckdb", "transform", "pipeline", "etl"]
+description = "SQL-as-transform for faucet-stream — run DuckDB SQL over each pipeline page (the `batch` relation)."
+
+[lib]
+doctest = false
+
+[dependencies]
+faucet-core.workspace = true
+duckdb = { workspace = true, features = ["bundled", "vtab-arrow"] }
+arrow.workspace = true
+arrow-json.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+schemars.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+criterion.workspace = true
+tempfile = "3"
+
+[[bench]]
+name = "sql_transform"
+harness = false
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/transform-sql/README.md
+++ b/crates/transform-sql/README.md
@@ -1,0 +1,307 @@
+# faucet-transform-sql
+
+SQL-as-transform for faucet-stream — run DuckDB SQL over each pipeline page. The
+page's records are exposed as the relation `batch`; the result set replaces the page.
+
+```toml
+[dependencies]
+faucet-transform-sql = "0.1"
+```
+
+Enable in the umbrella crate or CLI:
+
+```toml
+faucet-stream = { version = "1.0", features = ["transform-sql"] }
+```
+
+## What it does
+
+Every pipeline page passes through the SQL query as a temporary in-memory DuckDB
+table named `batch`. The result set of the query becomes the new page — each result
+row becomes one output JSON record. Column name → JSON key; `NULL` → JSON `null`;
+`STRUCT`/`LIST`/`MAP` → nested JSON.
+
+This makes it straightforward to filter, reshape, aggregate, and join inline data
+without a separate warehouse step.
+
+## Config
+
+```yaml
+- type: sql
+  config:
+    query: "SELECT id, upper(name) AS name FROM batch WHERE active"
+```
+
+Wire shape: `{ type: sql, config: { query, relations?, memory_limit?, threads? } }`.
+
+### Field reference
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `query` | string | yes | The SQL statement. `batch` is the page's records as a table. |
+| `relations` | list | no | Reference relations loaded at compile time and joinable by name. |
+| `memory_limit` | string | no | DuckDB `memory_limit` pragma (e.g. `"1GB"`). Default: DuckDB's own. |
+| `threads` | integer | no | DuckDB `threads` pragma. Default: DuckDB's own. Set to 1–2 in high-fan-out matrices to avoid CPU over-subscription. |
+
+## Reference relations
+
+Pre-load static lookup data (CSV, JSONL, or inline values) that your query can `JOIN`
+against. Relations are loaded **once at compile time** (when `faucet validate` /
+`faucet run` first reads the config) and remain resident for the lifetime of the
+transform.
+
+```yaml
+- type: sql
+  config:
+    query: |
+      SELECT b.id, c.country
+      FROM batch b
+      LEFT JOIN countries c ON b.code = c.code
+    relations:
+      - name: countries
+        source:
+          type: csv
+          path: data/countries.csv
+          has_header: true        # default true
+```
+
+### Relation source types
+
+| `type` | Fields | Description |
+|---|---|---|
+| `csv` | `path` (string, required), `has_header` (bool, default `true`) | Loaded via DuckDB `read_csv_auto`. |
+| `jsonl` | `path` (string, required) | Loaded via DuckDB `read_json_auto`. |
+| `values` | `columns` (list of strings), `rows` (list of lists) | Inline data; no file I/O. |
+
+Inline `values` example:
+
+```yaml
+relations:
+  - name: tiers
+    source:
+      type: values
+      columns: [id, label]
+      rows:
+        - [1, gold]
+        - [2, silver]
+        - [3, bronze]
+```
+
+### `reload_on_change`
+
+```yaml
+relations:
+  - name: prices
+    source:
+      type: csv
+      path: data/prices.csv
+    reload_on_change: true   # re-read when the file's mtime changes
+```
+
+When `true`, faucet stats the file before each page and rebuilds the relation
+atomically if the mtime changed. Defaults to `false`. Ignored for `values`.
+
+### Reserved name
+
+The name `batch` is reserved for the page relation. Using it as a relation name
+is a compile-time error.
+
+## Per-page semantics and `batch_size: 0`
+
+**This is the most important thing to understand about the SQL transform.**
+
+The transform runs once **per page**, not once across the whole stream. With the
+default `batch_size` of 1000, `GROUP BY` and window functions aggregate within a
+single 1000-row page — not across all pages.
+
+```yaml
+# BAD: GROUP BY runs per-page, giving partial aggregates.
+pipeline:
+  source:
+    type: csv
+    config:
+      path: data/orders.csv
+  transforms:
+    - type: sql
+      config:
+        query: "SELECT country, SUM(amount) AS total FROM batch GROUP BY country"
+```
+
+**To aggregate across the whole dataset**, set the source's `batch_size: 0` so the
+entire result set arrives as one page:
+
+```yaml
+# CORRECT: batch_size: 0 loads the whole file as one page → global GROUP BY.
+pipeline:
+  source:
+    type: csv
+    config:
+      path: data/orders.csv
+      batch_size: 0
+  transforms:
+    - type: sql
+      config:
+        query: "SELECT country, SUM(amount) AS total FROM batch GROUP BY country"
+```
+
+`batch_size: 0` means "no batching" — the source emits the entire result set as a
+single `StreamPage`. All sources support it; it is appropriate for small lookup
+tables and for aggregating transforms like this one.
+
+When an aggregating query receives a second page (i.e. `batch_size` was not set to
+`0`), faucet emits a one-time warning:
+
+```
+WARN faucet::transform::sql: sql transform with aggregation received multiple pages;
+aggregation is per-page — set batch_size: 0 for global aggregation
+```
+
+## Error handling and validation
+
+**At config load time** (`faucet validate` / start of `faucet run`):
+
+- The query is parse/bind-checked inside DuckDB. Syntax errors report line and
+  column number.
+- Reference-relation files that do not exist cause an immediate error (before any
+  page is processed).
+- A relation named `batch` is rejected.
+
+**At runtime** (per page):
+
+- A query that fails mid-run aborts the pipeline immediately (`FaucetError::Transform`).
+- Runtime query errors are **not** routed to the dead-letter queue — they follow the
+  same fail-fast policy as every other built-in transform.
+
+Empty result sets are valid: a query that matches zero rows produces zero output
+records for that page.
+
+## Runnable example
+
+The file `cli/examples/csv_to_jsonl_sql.yaml` groups order CSV data by country and
+joins to a reference countries CSV, writing JSONL output:
+
+```yaml
+version: 1
+name: csv_to_jsonl_sql
+
+pipeline:
+  source:
+    type: csv
+    config:
+      path: cli/examples/data/orders.csv
+      has_header: true
+      batch_size: 0          # whole file as one page → global GROUP BY
+
+  transforms:
+    - type: sql
+      config:
+        query: |
+          SELECT c.country,
+                 COUNT(*)                     AS order_count,
+                 SUM(CAST(o.amount AS DOUBLE)) AS total_amount
+          FROM   batch o
+          LEFT JOIN countries c ON o.country_code = c.code
+          GROUP BY c.country
+          ORDER BY c.country
+        relations:
+          - name: countries
+            source:
+              type: csv
+              path: cli/examples/data/countries.csv
+              has_header: true
+
+  sink:
+    type: jsonl
+    config:
+      path: /tmp/faucet_sql_demo.jsonl
+```
+
+Run it (requires the `transform-sql`, `source-csv`, and `sink-jsonl` features):
+
+```bash
+faucet run cli/examples/csv_to_jsonl_sql.yaml
+```
+
+Output rows look like:
+
+```json
+{"country":"Germany","order_count":1,"total_amount":3.0}
+{"country":"India","order_count":1,"total_amount":7.0}
+{"country":"United States","order_count":2,"total_amount":15.5}
+```
+
+## Feature flag
+
+`transform-sql` — not in the default build; included in `full`.
+
+```toml
+# Enable only the SQL transform
+faucet-stream = { version = "1.0", features = ["transform-sql"] }
+
+# Enable together with specific connectors
+faucet-stream = { version = "1.0", features = ["source-csv", "sink-jsonl", "transform-sql"] }
+
+# Enable everything
+faucet-stream = { version = "1.0", features = ["full"] }
+```
+
+CLI:
+
+```bash
+cargo install faucet-cli --features transform-sql
+```
+
+## JSON columns
+
+DuckDB's `json_extract` works on string or JSON columns. If a field is a JSON
+string, use it directly:
+
+```sql
+SELECT json_extract(payload, '$.user.id') AS user_id FROM batch
+```
+
+Or cast it first:
+
+```sql
+SELECT json_extract(payload::JSON, '$.user.id') AS user_id FROM batch
+```
+
+## Timestamp / timezone note
+
+DuckDB's `TIMESTAMP` type is timezone-naive. faucet JSON timestamps are RFC 3339
+strings (e.g. `"2026-01-01T12:00:00Z"`). To compare or cast them:
+
+```sql
+-- Parse an RFC 3339 string into a DuckDB TIMESTAMP (drops the offset)
+SELECT CAST(created_at AS TIMESTAMP) AS ts FROM batch
+WHERE CAST(created_at AS TIMESTAMP) > '2026-01-01'::TIMESTAMP
+
+-- Keep the string form, compare lexicographically (safe for UTC-only data)
+SELECT * FROM batch WHERE created_at > '2026-01-01T00:00:00Z'
+```
+
+If your timestamps include non-UTC offsets, normalise them to UTC with `cast` before
+passing to the SQL transform, or parse with `strptime`.
+
+## Library usage
+
+```rust
+use faucet_transform_sql::{SqlTransform, SqlTransformConfig};
+use faucet_core::stage::{compile_stage, apply_stages_to_page};
+
+let cfg = SqlTransformConfig {
+    query: "SELECT id, upper(name) AS name FROM batch".into(),
+    relations: vec![],
+    memory_limit: None,
+    threads: None,
+};
+
+let t = SqlTransform::compile(&cfg)?;
+let stage = compile_stage(&t.into_page_stage())?;
+
+let output = apply_stages_to_page(records, &[stage])?;
+```
+
+## License
+
+Licensed under either of Apache License 2.0 or MIT license at your option.

--- a/crates/transform-sql/benches/sql_transform.rs
+++ b/crates/transform-sql/benches/sql_transform.rs
@@ -1,0 +1,2 @@
+// Benchmarks filled in Task 4.
+fn main() {}

--- a/crates/transform-sql/benches/sql_transform.rs
+++ b/crates/transform-sql/benches/sql_transform.rs
@@ -1,2 +1,41 @@
-// Benchmarks filled in Task 4.
-fn main() {}
+use criterion::{Criterion, criterion_group, criterion_main};
+use faucet_core::stage::{apply_stages_to_page, compile_stage};
+use faucet_transform_sql::{SqlTransform, SqlTransformConfig};
+use serde_json::{Value, json};
+
+fn make_stage(query: &str) -> faucet_core::stage::CompiledStage {
+    let cfg = SqlTransformConfig {
+        query: query.into(),
+        relations: vec![],
+        memory_limit: None,
+        threads: Some(1),
+    };
+    compile_stage(&SqlTransform::compile(&cfg).unwrap().into_page_stage()).unwrap()
+}
+
+fn page(n: usize) -> Vec<Value> {
+    (0..n)
+        .map(|i| json!({"k": i % 8, "v": i as f64}))
+        .collect()
+}
+
+fn bench(c: &mut Criterion) {
+    for &n in &[100usize, 1_000, 10_000] {
+        let p = page(n);
+
+        let passthrough = make_stage("SELECT * FROM batch");
+        c.bench_function(&format!("passthrough/{n}"), |b| {
+            b.iter(|| {
+                apply_stages_to_page(p.clone(), std::slice::from_ref(&passthrough)).unwrap()
+            })
+        });
+
+        let agg = make_stage("SELECT k, SUM(v) AS total FROM batch GROUP BY k");
+        c.bench_function(&format!("groupby/{n}"), |b| {
+            b.iter(|| apply_stages_to_page(p.clone(), std::slice::from_ref(&agg)).unwrap())
+        });
+    }
+}
+
+criterion_group!(benches, bench);
+criterion_main!(benches);

--- a/crates/transform-sql/benches/sql_transform.rs
+++ b/crates/transform-sql/benches/sql_transform.rs
@@ -14,9 +14,7 @@ fn make_stage(query: &str) -> faucet_core::stage::CompiledStage {
 }
 
 fn page(n: usize) -> Vec<Value> {
-    (0..n)
-        .map(|i| json!({"k": i % 8, "v": i as f64}))
-        .collect()
+    (0..n).map(|i| json!({"k": i % 8, "v": i as f64})).collect()
 }
 
 fn bench(c: &mut Criterion) {
@@ -25,9 +23,7 @@ fn bench(c: &mut Criterion) {
 
         let passthrough = make_stage("SELECT * FROM batch");
         c.bench_function(&format!("passthrough/{n}"), |b| {
-            b.iter(|| {
-                apply_stages_to_page(p.clone(), std::slice::from_ref(&passthrough)).unwrap()
-            })
+            b.iter(|| apply_stages_to_page(p.clone(), std::slice::from_ref(&passthrough)).unwrap())
         });
 
         let agg = make_stage("SELECT k, SUM(v) AS total FROM batch GROUP BY k");

--- a/crates/transform-sql/src/compile.rs
+++ b/crates/transform-sql/src/compile.rs
@@ -1,0 +1,171 @@
+//! Connection setup, reference-relation loading, and query validation.
+
+use crate::config::{RelationSource, RelationSpec, SqlTransformConfig};
+use crate::shovel::values_to_record_batch;
+use duckdb::Connection;
+use duckdb::vtab::arrow::{ArrowVTab, arrow_recordbatch_to_query_params};
+use faucet_core::FaucetError;
+
+const RESERVED: &str = "batch";
+
+fn cfg_err(msg: impl Into<String>) -> FaucetError {
+    FaucetError::Config(format!("sql transform: {}", msg.into()))
+}
+
+/// A relation we may need to reload on mtime change.
+pub(crate) struct Reloadable {
+    pub name: String,
+    pub path: String,
+    pub has_header: bool,
+    pub is_csv: bool,
+    pub last_mtime: Option<std::time::SystemTime>,
+}
+
+/// Open an in-memory connection, apply pragmas, register the Arrow VTab, and
+/// load every reference relation. Returns the connection + reload tracking.
+pub(crate) fn build_connection(
+    cfg: &SqlTransformConfig,
+) -> Result<(Connection, Vec<Reloadable>), FaucetError> {
+    let conn = Connection::open_in_memory().map_err(|e| cfg_err(format!("open duckdb: {e}")))?;
+    if let Some(ref m) = cfg.memory_limit {
+        conn.execute_batch(&format!("SET memory_limit='{}';", sql_escape(m)))
+            .map_err(|e| cfg_err(format!("memory_limit: {e}")))?;
+    }
+    if let Some(t) = cfg.threads {
+        conn.execute_batch(&format!("SET threads={t};"))
+            .map_err(|e| cfg_err(format!("threads: {e}")))?;
+    }
+    conn.register_table_function::<ArrowVTab>("arrow")
+        .map_err(|e| cfg_err(format!("register arrow vtab: {e}")))?;
+
+    let mut reloadables = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for rel in &cfg.relations {
+        validate_ident(&rel.name)?;
+        if rel.name.eq_ignore_ascii_case(RESERVED) {
+            return Err(cfg_err("relation name 'batch' is reserved for the page"));
+        }
+        if !seen.insert(rel.name.clone()) {
+            return Err(cfg_err(format!("duplicate relation name '{}'", rel.name)));
+        }
+        load_relation(&conn, rel)?;
+        if rel.reload_on_change
+            && let Some(r) = reloadable_for(rel)?
+        {
+            reloadables.push(r);
+        }
+    }
+    Ok((conn, reloadables))
+}
+
+fn validate_ident(name: &str) -> Result<(), FaucetError> {
+    let ok = !name.is_empty()
+        && name
+            .chars()
+            .next()
+            .map(|c| c.is_ascii_alphabetic() || c == '_')
+            .unwrap_or(false)
+        && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_');
+    if ok {
+        Ok(())
+    } else {
+        Err(cfg_err(format!("invalid relation name '{name}'")))
+    }
+}
+
+fn load_relation(conn: &Connection, rel: &RelationSpec) -> Result<(), FaucetError> {
+    match &rel.source {
+        RelationSource::Csv { path, has_header } => {
+            check_exists(path)?;
+            conn.execute_batch(&format!(
+                "CREATE OR REPLACE TABLE \"{}\" AS SELECT * FROM read_csv_auto('{}', header={});",
+                rel.name,
+                sql_escape(path),
+                has_header
+            ))
+            .map_err(|e| cfg_err(format!("load csv relation '{}': {e}", rel.name)))
+        }
+        RelationSource::Jsonl { path } => {
+            check_exists(path)?;
+            conn.execute_batch(&format!(
+                "CREATE OR REPLACE TABLE \"{}\" AS SELECT * FROM read_json_auto('{}', format='newline_delimited');",
+                rel.name,
+                sql_escape(path)
+            ))
+            .map_err(|e| cfg_err(format!("load jsonl relation '{}': {e}", rel.name)))
+        }
+        RelationSource::Values { columns, rows } => {
+            if columns.is_empty() {
+                return Err(cfg_err(format!(
+                    "values relation '{}' has no columns",
+                    rel.name
+                )));
+            }
+            let batch = values_to_record_batch(columns, rows)?;
+            let params = arrow_recordbatch_to_query_params(batch);
+            conn.execute(
+                &format!(
+                    "CREATE OR REPLACE TABLE \"{}\" AS SELECT * FROM arrow(?, ?)",
+                    rel.name
+                ),
+                params,
+            )
+            .map_err(|e| cfg_err(format!("load values relation '{}': {e}", rel.name)))?;
+            Ok(())
+        }
+    }
+}
+
+fn reloadable_for(rel: &RelationSpec) -> Result<Option<Reloadable>, FaucetError> {
+    let (path, has_header, is_csv) = match &rel.source {
+        RelationSource::Csv { path, has_header } => (path.clone(), *has_header, true),
+        RelationSource::Jsonl { path } => (path.clone(), false, false),
+        RelationSource::Values { .. } => return Ok(None),
+    };
+    let last_mtime = std::fs::metadata(&path).and_then(|m| m.modified()).ok();
+    Ok(Some(Reloadable {
+        name: rel.name.clone(),
+        path,
+        has_header,
+        is_csv,
+        last_mtime,
+    }))
+}
+
+fn check_exists(path: &str) -> Result<(), FaucetError> {
+    if std::path::Path::new(path).exists() {
+        Ok(())
+    } else {
+        Err(cfg_err(format!(
+            "reference relation file does not exist: {path}"
+        )))
+    }
+}
+
+fn sql_escape(s: &str) -> String {
+    s.replace('\'', "''")
+}
+
+/// Validate the query: parse + bind, tolerating the not-yet-existing `batch`.
+pub(crate) fn validate_query(conn: &Connection, query: &str) -> Result<(), FaucetError> {
+    match conn.prepare(query) {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            let msg = e.to_string();
+            let lower = msg.to_lowercase();
+            // Tolerate binder errors that are only about the missing `batch`.
+            let about_batch = lower.contains("batch")
+                && (lower.contains("does not exist")
+                    || lower.contains("not found")
+                    || lower.contains("referenced")
+                    || lower.contains("no such table"));
+            if about_batch {
+                Ok(())
+            } else {
+                Err(FaucetError::Transform(format!(
+                    "sql transform: invalid query: {msg}"
+                )))
+            }
+        }
+    }
+}

--- a/crates/transform-sql/src/compile.rs
+++ b/crates/transform-sql/src/compile.rs
@@ -142,7 +142,9 @@ fn check_exists(path: &str) -> Result<(), FaucetError> {
     }
 }
 
-fn sql_escape(s: &str) -> String {
+/// Escape a string literal for safe interpolation inside a single-quoted SQL
+/// string (e.g. a file path passed to `read_csv_auto('…')`).
+pub(crate) fn sql_escape(s: &str) -> String {
     s.replace('\'', "''")
 }
 

--- a/crates/transform-sql/src/config.rs
+++ b/crates/transform-sql/src/config.rs
@@ -1,0 +1,83 @@
+//! Config types for the SQL transform. No I/O or DuckDB here.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Configuration for the `sql` transform.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SqlTransformConfig {
+    /// The SQL statement. The page's records are the relation `batch`. Must
+    /// produce a result set; each result row becomes one output record.
+    pub query: String,
+    /// Reference relations loaded once at compile time and joinable by name.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub relations: Vec<RelationSpec>,
+    /// Optional DuckDB `memory_limit` pragma (e.g. "1GB"). Default: DuckDB's own.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory_limit: Option<String>,
+    /// Optional DuckDB `threads` pragma. Default: DuckDB's own. Set to 1–2 for
+    /// high-fan-out matrices to avoid CPU over-subscription across rows.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub threads: Option<usize>,
+}
+
+/// A reference relation registered before the first page.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct RelationSpec {
+    /// Relation name as referenced in the query. Must be a safe SQL identifier
+    /// and must not be `batch` (reserved for the page).
+    pub name: String,
+    /// Where the relation's data comes from.
+    pub source: RelationSource,
+    /// Re-stat the file's mtime before each page; rebuild + atomic swap if it
+    /// changed. Default false. Ignored for `values`.
+    #[serde(default)]
+    pub reload_on_change: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+/// The data source for a reference relation.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum RelationSource {
+    /// Delimited file loaded via DuckDB `read_csv_auto`.
+    Csv {
+        path: String,
+        #[serde(default = "default_true")]
+        has_header: bool,
+    },
+    /// Newline-delimited JSON loaded via DuckDB `read_json_auto`.
+    Jsonl { path: String },
+    /// Inline rows materialized into a table.
+    Values {
+        columns: Vec<String>,
+        rows: Vec<Vec<Value>>,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_round_trips_and_schema_builds() {
+        let cfg: SqlTransformConfig = serde_json::from_value(serde_json::json!({
+            "query": "SELECT * FROM batch",
+            "relations": [
+                {"name": "countries",
+                 "source": {"type": "csv", "path": "c.csv", "has_header": true}}
+            ]
+        }))
+        .unwrap();
+        assert_eq!(cfg.relations.len(), 1);
+        assert!(matches!(cfg.relations[0].source, RelationSource::Csv { .. }));
+        // schema_for! must succeed (used by `faucet schema transform sql`).
+        let schema = schemars::schema_for!(SqlTransformConfig);
+        let json = serde_json::to_value(&schema).unwrap();
+        assert!(json.get("properties").and_then(|p| p.get("query")).is_some());
+    }
+}

--- a/crates/transform-sql/src/config.rs
+++ b/crates/transform-sql/src/config.rs
@@ -36,6 +36,7 @@ pub struct RelationSpec {
     pub reload_on_change: bool,
 }
 
+// serde `default = "..."` needs a function, not a literal.
 fn default_true() -> bool {
     true
 }
@@ -46,15 +47,22 @@ fn default_true() -> bool {
 pub enum RelationSource {
     /// Delimited file loaded via DuckDB `read_csv_auto`.
     Csv {
+        /// Filesystem path to the CSV file (absolute, or relative to the working directory).
         path: String,
+        /// Whether the first row is a header row. Default: `true`.
         #[serde(default = "default_true")]
         has_header: bool,
     },
     /// Newline-delimited JSON loaded via DuckDB `read_json_auto`.
-    Jsonl { path: String },
+    Jsonl {
+        /// Filesystem path to the JSONL file (absolute, or relative to the working directory).
+        path: String,
+    },
     /// Inline rows materialized into a table.
     Values {
+        /// Column names, in declaration order.
         columns: Vec<String>,
+        /// Rows of cell values; each inner row must have the same length as `columns`.
         rows: Vec<Vec<Value>>,
     },
 }

--- a/crates/transform-sql/src/config.rs
+++ b/crates/transform-sql/src/config.rs
@@ -82,10 +82,17 @@ mod tests {
         }))
         .unwrap();
         assert_eq!(cfg.relations.len(), 1);
-        assert!(matches!(cfg.relations[0].source, RelationSource::Csv { .. }));
+        assert!(matches!(
+            cfg.relations[0].source,
+            RelationSource::Csv { .. }
+        ));
         // schema_for! must succeed (used by `faucet schema transform sql`).
         let schema = schemars::schema_for!(SqlTransformConfig);
         let json = serde_json::to_value(&schema).unwrap();
-        assert!(json.get("properties").and_then(|p| p.get("query")).is_some());
+        assert!(
+            json.get("properties")
+                .and_then(|p| p.get("query"))
+                .is_some()
+        );
     }
 }

--- a/crates/transform-sql/src/lib.rs
+++ b/crates/transform-sql/src/lib.rs
@@ -4,10 +4,13 @@
 //! Each pipeline page is exposed to a SQL query as the relation `batch`; the
 //! result set becomes the new page. [`SqlTransformConfig`] is the user-facing
 //! config (the `query` plus optional reference [`RelationSpec`]s, whose data
-//! comes from a [`RelationSource`]). The compiled runtime that runs the query
-//! per page is added in a later module.
+//! comes from a [`RelationSource`]). [`SqlTransform`] is the compiled runtime
+//! that owns the DuckDB connection and runs the query per page.
 
+mod compile;
 mod config;
+mod runtime;
 mod shovel;
 
 pub use config::{RelationSource, RelationSpec, SqlTransformConfig};
+pub use runtime::SqlTransform;

--- a/crates/transform-sql/src/lib.rs
+++ b/crates/transform-sql/src/lib.rs
@@ -1,0 +1,6 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+//! SQL-as-transform for faucet-stream, backed by embedded DuckDB.
+
+mod config;
+
+pub use config::{RelationSource, RelationSpec, SqlTransformConfig};

--- a/crates/transform-sql/src/lib.rs
+++ b/crates/transform-sql/src/lib.rs
@@ -8,5 +8,6 @@
 //! per page is added in a later module.
 
 mod config;
+mod shovel;
 
 pub use config::{RelationSource, RelationSpec, SqlTransformConfig};

--- a/crates/transform-sql/src/lib.rs
+++ b/crates/transform-sql/src/lib.rs
@@ -1,5 +1,11 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 //! SQL-as-transform for faucet-stream, backed by embedded DuckDB.
+//!
+//! Each pipeline page is exposed to a SQL query as the relation `batch`; the
+//! result set becomes the new page. [`SqlTransformConfig`] is the user-facing
+//! config (the `query` plus optional reference [`RelationSpec`]s, whose data
+//! comes from a [`RelationSource`]). The compiled runtime that runs the query
+//! per page is added in a later module.
 
 mod config;
 

--- a/crates/transform-sql/src/runtime.rs
+++ b/crates/transform-sql/src/runtime.rs
@@ -1,6 +1,6 @@
 //! The compiled SQL transform: owns the DuckDB connection and runs each page.
 
-use crate::compile::{Reloadable, build_connection, validate_query};
+use crate::compile::{Reloadable, build_connection, sql_escape, validate_query};
 use crate::config::SqlTransformConfig;
 use crate::shovel::{infer_schema, json_to_record_batch, record_batches_to_json, schema_eq};
 use arrow::array::RecordBatch;
@@ -72,13 +72,14 @@ fn execute_page(st: &mut State, records: Vec<Value>) -> Result<Vec<Value>, Fauce
     }
     reload_relations(st)?;
 
-    // Schema cache: re-infer only on drift.
+    // Schema cache: infer once per page, reuse the cached schema on a match,
+    // otherwise adopt the freshly inferred one (first page or drift).
+    let fresh = infer_schema(&records)?;
     let schema = match &st.cached_schema {
-        Some(s) if schema_eq(s, &*infer_schema(&records)?) => s.clone(),
+        Some(s) if schema_eq(s, &fresh) => s.clone(),
         _ => {
-            let s = infer_schema(&records)?;
-            st.cached_schema = Some(s.clone());
-            s
+            st.cached_schema = Some(fresh.clone());
+            fresh
         }
     };
     let batch = json_to_record_batch(&records, schema)?;
@@ -126,14 +127,14 @@ fn reload_relations(st: &mut State) -> Result<(), FaucetError> {
                 format!(
                     "CREATE OR REPLACE TABLE \"{}\" AS SELECT * FROM read_csv_auto('{}', header={});",
                     r.name,
-                    r.path.replace('\'', "''"),
+                    sql_escape(&r.path),
                     r.has_header
                 )
             } else {
                 format!(
                     "CREATE OR REPLACE TABLE \"{}\" AS SELECT * FROM read_json_auto('{}', format='newline_delimited');",
                     r.name,
-                    r.path.replace('\'', "''")
+                    sql_escape(&r.path)
                 )
             };
             st.conn.execute_batch(&stmt).map_err(|e| {

--- a/crates/transform-sql/src/runtime.rs
+++ b/crates/transform-sql/src/runtime.rs
@@ -1,0 +1,163 @@
+//! The compiled SQL transform: owns the DuckDB connection and runs each page.
+
+use crate::compile::{Reloadable, build_connection, validate_query};
+use crate::config::SqlTransformConfig;
+use crate::shovel::{infer_schema, json_to_record_batch, record_batches_to_json, schema_eq};
+use arrow::array::RecordBatch;
+use arrow::datatypes::SchemaRef;
+use duckdb::Connection;
+use duckdb::vtab::arrow::arrow_recordbatch_to_query_params;
+use faucet_core::FaucetError;
+use faucet_core::stage::TransformStage;
+use serde_json::Value;
+use std::sync::{Arc, Mutex};
+
+struct State {
+    conn: Connection,
+    query: String,
+    reloadables: Vec<Reloadable>,
+    cached_schema: Option<SchemaRef>,
+    pages_seen: u64,
+    aggregates: Option<bool>,
+    warned: bool,
+}
+
+/// A compiled SQL transform. One DuckDB connection, reused across the row's pages.
+pub struct SqlTransform {
+    state: Arc<Mutex<State>>,
+}
+
+impl std::fmt::Debug for SqlTransform {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut d = f.debug_struct("SqlTransform");
+        match self.state.lock() {
+            Ok(st) => d.field("query", &st.query),
+            Err(e) => d.field("query", &e.into_inner().query),
+        };
+        d.finish_non_exhaustive()
+    }
+}
+
+impl SqlTransform {
+    /// Build the connection, load reference relations, and validate the query.
+    pub fn compile(cfg: &SqlTransformConfig) -> Result<Self, FaucetError> {
+        let (conn, reloadables) = build_connection(cfg)?;
+        validate_query(&conn, &cfg.query)?;
+        Ok(Self {
+            state: Arc::new(Mutex::new(State {
+                conn,
+                query: cfg.query.clone(),
+                reloadables,
+                cached_schema: None,
+                pages_seen: 0,
+                aggregates: None,
+                warned: false,
+            })),
+        })
+    }
+
+    /// Consume into a page-level transform stage.
+    pub fn into_page_stage(self) -> TransformStage {
+        let state = self.state;
+        TransformStage::PageFn(Arc::new(move |records: Vec<Value>| {
+            let mut st = state.lock().unwrap_or_else(|e| e.into_inner());
+            execute_page(&mut st, records)
+        }))
+    }
+}
+
+fn execute_page(st: &mut State, records: Vec<Value>) -> Result<Vec<Value>, FaucetError> {
+    if records.is_empty() {
+        return Ok(Vec::new());
+    }
+    reload_relations(st)?;
+
+    // Schema cache: re-infer only on drift.
+    let schema = match &st.cached_schema {
+        Some(s) if schema_eq(s, &*infer_schema(&records)?) => s.clone(),
+        _ => {
+            let s = infer_schema(&records)?;
+            st.cached_schema = Some(s.clone());
+            s
+        }
+    };
+    let batch = json_to_record_batch(&records, schema)?;
+    let params = arrow_recordbatch_to_query_params(batch);
+    st.conn
+        .execute(
+            "CREATE OR REPLACE TEMP TABLE batch AS SELECT * FROM arrow(?, ?)",
+            params,
+        )
+        .map_err(|e| FaucetError::Transform(format!("sql transform: register batch: {e}")))?;
+
+    // First-page aggregation detection (now that `batch` exists).
+    if st.aggregates.is_none() {
+        st.aggregates = Some(plan_has_aggregate(&st.conn, &st.query));
+    }
+    st.pages_seen += 1;
+    if st.pages_seen >= 2 && st.aggregates == Some(true) && !st.warned {
+        st.warned = true;
+        tracing::warn!(
+            target: "faucet::transform::sql",
+            "sql transform with aggregation received multiple pages; aggregation is \
+             per-page — set batch_size: 0 for global aggregation"
+        );
+    }
+
+    let out = {
+        let mut stmt = st
+            .conn
+            .prepare(&st.query)
+            .map_err(|e| FaucetError::Transform(format!("sql transform: prepare: {e}")))?;
+        let batches: Vec<RecordBatch> = stmt
+            .query_arrow([])
+            .map_err(|e| FaucetError::Transform(format!("sql transform: execute: {e}")))?
+            .collect();
+        record_batches_to_json(&batches)?
+    };
+    Ok(out)
+}
+
+fn reload_relations(st: &mut State) -> Result<(), FaucetError> {
+    for r in st.reloadables.iter_mut() {
+        let cur = std::fs::metadata(&r.path).and_then(|m| m.modified()).ok();
+        if cur != r.last_mtime {
+            let stmt = if r.is_csv {
+                format!(
+                    "CREATE OR REPLACE TABLE \"{}\" AS SELECT * FROM read_csv_auto('{}', header={});",
+                    r.name,
+                    r.path.replace('\'', "''"),
+                    r.has_header
+                )
+            } else {
+                format!(
+                    "CREATE OR REPLACE TABLE \"{}\" AS SELECT * FROM read_json_auto('{}', format='newline_delimited');",
+                    r.name,
+                    r.path.replace('\'', "''")
+                )
+            };
+            st.conn.execute_batch(&stmt).map_err(|e| {
+                FaucetError::Transform(format!("sql transform: reload '{}': {e}", r.name))
+            })?;
+            r.last_mtime = cur;
+        }
+    }
+    Ok(())
+}
+
+fn plan_has_aggregate(conn: &Connection, query: &str) -> bool {
+    let explain = format!("EXPLAIN {query}");
+    let mut found = false;
+    if let Ok(mut stmt) = conn.prepare(&explain)
+        && let Ok(rows) = stmt.query_map([], |row| row.get::<_, String>(1))
+    {
+        for r in rows.flatten() {
+            let u = r.to_uppercase();
+            if u.contains("AGGREGATE") || u.contains("WINDOW") {
+                found = true;
+                break;
+            }
+        }
+    }
+    found
+}

--- a/crates/transform-sql/src/shovel.rs
+++ b/crates/transform-sql/src/shovel.rs
@@ -37,9 +37,7 @@ pub fn json_to_record_batch(
     let mut decoder = arrow_json::ReaderBuilder::new(schema.clone())
         .build_decoder()
         .map_err(|e| te("decoder build", e))?;
-    decoder
-        .serialize(records)
-        .map_err(|e| te("encode", e))?;
+    decoder.serialize(records).map_err(|e| te("encode", e))?;
     let mut batches = Vec::new();
     while let Some(b) = decoder.flush().map_err(|e| te("flush", e))? {
         batches.push(b);

--- a/crates/transform-sql/src/shovel.rs
+++ b/crates/transform-sql/src/shovel.rs
@@ -1,0 +1,154 @@
+//! JSON ↔ Arrow conversion. `arrow-json` for both directions; `arrow` for
+//! concatenation. All errors surface as `FaucetError::Transform` (or
+//! `FaucetError::Config` for arity mismatches in the inline `values` relation).
+// The public helpers in this module are consumed by `runtime.rs` (Task 4).
+// Until that module is wired in, suppress the dead-code lint.
+#![allow(dead_code)]
+
+use arrow::array::RecordBatch;
+use arrow::datatypes::{Schema, SchemaRef};
+use faucet_core::FaucetError;
+use serde_json::{Map, Value};
+use std::sync::Arc;
+
+/// Map any display-able error into a `FaucetError::Transform` with context.
+fn te<E: std::fmt::Display>(ctx: &str, e: E) -> FaucetError {
+    FaucetError::Transform(format!("sql transform: {ctx}: {e}"))
+}
+
+/// Infer an Arrow [`Schema`] from a slice of JSON records.
+///
+/// Each element must be a JSON object. Returns the inferred schema wrapped in
+/// an [`Arc`]. On an empty slice the result is a schema with no fields.
+pub fn infer_schema(records: &[Value]) -> Result<SchemaRef, FaucetError> {
+    let iter = records
+        .iter()
+        .map(|v| Ok::<_, arrow::error::ArrowError>(v.clone()));
+    let schema = arrow_json::reader::infer_json_schema_from_iterator(iter)
+        .map_err(|e| te("schema inference", e))?;
+    Ok(Arc::new(schema))
+}
+
+/// Encode a slice of JSON records into a single [`RecordBatch`] against `schema`.
+///
+/// Uses the `arrow-json` decoder (`ReaderBuilder → build_decoder → serialize →
+/// flush`). Returns an empty batch if `records` is empty.
+pub fn json_to_record_batch(
+    records: &[Value],
+    schema: SchemaRef,
+) -> Result<RecordBatch, FaucetError> {
+    let mut decoder = arrow_json::ReaderBuilder::new(schema.clone())
+        .build_decoder()
+        .map_err(|e| te("decoder build", e))?;
+    decoder
+        .serialize(records)
+        .map_err(|e| te("encode", e))?;
+    let mut batches = Vec::new();
+    while let Some(b) = decoder.flush().map_err(|e| te("flush", e))? {
+        batches.push(b);
+    }
+    if batches.is_empty() {
+        return Ok(RecordBatch::new_empty(schema));
+    }
+    if batches.len() == 1 {
+        return Ok(batches.pop().unwrap());
+    }
+    arrow::compute::concat_batches(&schema, &batches).map_err(|e| te("concat", e))
+}
+
+/// Decode one or more [`RecordBatch`]es into JSON objects (one per row).
+///
+/// Uses `arrow-json`'s [`ArrayWriter`][arrow_json::ArrayWriter], which produces
+/// a JSON array. An empty input returns an empty `Vec`.
+pub fn record_batches_to_json(batches: &[RecordBatch]) -> Result<Vec<Value>, FaucetError> {
+    let mut buf = Vec::new();
+    {
+        let mut writer = arrow_json::ArrayWriter::new(&mut buf);
+        for b in batches {
+            writer.write(b).map_err(|e| te("json write", e))?;
+        }
+        writer.finish().map_err(|e| te("json finish", e))?;
+    }
+    if buf.is_empty() {
+        return Ok(Vec::new());
+    }
+    let rows: Vec<Value> = serde_json::from_slice(&buf).map_err(|e| te("json parse", e))?;
+    Ok(rows)
+}
+
+/// Build a [`RecordBatch`] from inline `columns` + `rows` (the `values` relation).
+///
+/// Each row is zipped with `columns` to produce a JSON object, and the resulting
+/// objects are passed through [`infer_schema`] + [`json_to_record_batch`]. A row
+/// whose length differs from `columns` is rejected with [`FaucetError::Config`].
+pub fn values_to_record_batch(
+    columns: &[String],
+    rows: &[Vec<Value>],
+) -> Result<RecordBatch, FaucetError> {
+    let mut objs = Vec::with_capacity(rows.len());
+    for (i, row) in rows.iter().enumerate() {
+        if row.len() != columns.len() {
+            return Err(FaucetError::Config(format!(
+                "sql transform: values relation row {i} has {} cells, expected {}",
+                row.len(),
+                columns.len()
+            )));
+        }
+        let mut m = Map::new();
+        for (c, v) in columns.iter().zip(row.iter()) {
+            m.insert(c.clone(), v.clone());
+        }
+        objs.push(Value::Object(m));
+    }
+    let schema = infer_schema(&objs)?;
+    json_to_record_batch(&objs, schema)
+}
+
+/// Compare two schemas for field-level equality (name + data-type + nullability).
+///
+/// Used by the per-page schema cache in the runtime to detect schema drift
+/// between pages.
+pub fn schema_eq(a: &Schema, b: &Schema) -> bool {
+    a.fields() == b.fields()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn round_trip_scalars_nulls_nested() {
+        let recs = vec![
+            json!({"id": 1, "name": "a", "score": 1.5, "ok": true, "tags": ["x", "y"]}),
+            json!({"id": 2, "name": null, "score": null, "ok": false, "tags": []}),
+        ];
+        let schema = infer_schema(&recs).unwrap();
+        let batch = json_to_record_batch(&recs, schema).unwrap();
+        assert_eq!(batch.num_rows(), 2);
+        let back = record_batches_to_json(&[batch]).unwrap();
+        assert_eq!(back[0]["id"], json!(1));
+        assert_eq!(back[0]["tags"], json!(["x", "y"]));
+        assert_eq!(back[1]["name"], json!(null));
+    }
+
+    #[test]
+    fn values_to_batch_builds_named_columns() {
+        let batch = values_to_record_batch(
+            &["id".to_string(), "label".to_string()],
+            &[vec![json!(1), json!("NA")], vec![json!(2), json!("EU")]],
+        )
+        .unwrap();
+        assert_eq!(batch.num_rows(), 2);
+        assert_eq!(batch.num_columns(), 2);
+        let back = record_batches_to_json(&[batch]).unwrap();
+        assert_eq!(back[1]["label"], json!("EU"));
+    }
+
+    #[test]
+    fn schema_drift_changes_inferred_schema() {
+        let a = infer_schema(&[json!({"a": 1})]).unwrap();
+        let b = infer_schema(&[json!({"a": 1, "b": "x"})]).unwrap();
+        assert_ne!(a.fields().len(), b.fields().len());
+    }
+}

--- a/crates/transform-sql/src/shovel.rs
+++ b/crates/transform-sql/src/shovel.rs
@@ -1,9 +1,6 @@
 //! JSON ↔ Arrow conversion. `arrow-json` for both directions; `arrow` for
 //! concatenation. All errors surface as `FaucetError::Transform` (or
 //! `FaucetError::Config` for arity mismatches in the inline `values` relation).
-// The public helpers in this module are consumed by `runtime.rs` (Task 4).
-// Until that module is wired in, suppress the dead-code lint.
-#![allow(dead_code)]
 
 use arrow::array::RecordBatch;
 use arrow::datatypes::{Schema, SchemaRef};
@@ -68,9 +65,6 @@ pub fn record_batches_to_json(batches: &[RecordBatch]) -> Result<Vec<Value>, Fau
             writer.write(b).map_err(|e| te("json write", e))?;
         }
         writer.finish().map_err(|e| te("json finish", e))?;
-    }
-    if buf.is_empty() {
-        return Ok(Vec::new());
     }
     let rows: Vec<Value> = serde_json::from_slice(&buf).map_err(|e| te("json parse", e))?;
     Ok(rows)

--- a/crates/transform-sql/tests/data/countries.csv
+++ b/crates/transform-sql/tests/data/countries.csv
@@ -1,0 +1,4 @@
+code,country
+US,United States
+IN,India
+DE,Germany

--- a/crates/transform-sql/tests/runtime.rs
+++ b/crates/transform-sql/tests/runtime.rs
@@ -1,0 +1,226 @@
+//! Integration tests for the compiled `SqlTransform`: per-page execution,
+//! reference relations, schema drift, validation, and connection reuse.
+
+use faucet_core::stage::{CompiledStage, apply_stages_to_page, compile_stage};
+use faucet_transform_sql::{RelationSource, RelationSpec, SqlTransform, SqlTransformConfig};
+use serde_json::{Value, json};
+
+/// Compile a config into a runnable page stage.
+fn stage(cfg: SqlTransformConfig) -> CompiledStage {
+    compile_stage(&SqlTransform::compile(&cfg).unwrap().into_page_stage()).unwrap()
+}
+
+/// Convenience: compile a bare query (no relations) and run one page through it.
+fn run(query: &str, page: Vec<Value>) -> Vec<Value> {
+    let s = stage(SqlTransformConfig {
+        query: query.into(),
+        relations: vec![],
+        memory_limit: None,
+        threads: None,
+    });
+    apply_stages_to_page(page, &[s]).unwrap()
+}
+
+#[test]
+fn select_passthrough_and_projection() {
+    let out = run(
+        "SELECT id, upper(name) AS name FROM batch WHERE id > 1",
+        vec![json!({"id": 1, "name": "a"}), json!({"id": 2, "name": "b"})],
+    );
+    assert_eq!(out, vec![json!({"id": 2, "name": "B"})]);
+}
+
+#[test]
+fn group_by_aggregation_within_page() {
+    let out = run(
+        "SELECT k, SUM(v) AS total FROM batch GROUP BY k ORDER BY k",
+        vec![
+            json!({"k": "a", "v": 1}),
+            json!({"k": "a", "v": 2}),
+            json!({"k": "b", "v": 5}),
+        ],
+    );
+    assert_eq!(
+        out,
+        vec![
+            json!({"k": "a", "total": 3}),
+            json!({"k": "b", "total": 5})
+        ]
+    );
+}
+
+#[test]
+fn empty_page_returns_empty_without_error() {
+    let out = run("SELECT * FROM batch", vec![]);
+    assert!(out.is_empty());
+}
+
+#[test]
+fn empty_result_set_is_valid() {
+    let out = run("SELECT * FROM batch WHERE false", vec![json!({"a": 1})]);
+    assert!(out.is_empty());
+}
+
+#[test]
+fn schema_drift_recreates_batch() {
+    let s = stage(SqlTransformConfig {
+        query: "SELECT * FROM batch".into(),
+        relations: vec![],
+        memory_limit: None,
+        threads: None,
+    });
+    let p1 = apply_stages_to_page(vec![json!({"a": 1})], std::slice::from_ref(&s)).unwrap();
+    let p2 =
+        apply_stages_to_page(vec![json!({"a": 2, "b": "x"})], std::slice::from_ref(&s)).unwrap();
+    assert_eq!(p1[0]["a"], json!(1));
+    assert_eq!(p2[0]["b"], json!("x"));
+}
+
+#[test]
+fn join_to_csv_reference_relation() {
+    let path = format!("{}/tests/data/countries.csv", env!("CARGO_MANIFEST_DIR"));
+    let s = stage(SqlTransformConfig {
+        query: "SELECT b.id, c.country FROM batch b LEFT JOIN countries c ON b.code = c.code ORDER BY b.id".into(),
+        relations: vec![RelationSpec {
+            name: "countries".into(),
+            source: RelationSource::Csv { path, has_header: true },
+            reload_on_change: false,
+        }],
+        memory_limit: None,
+        threads: None,
+    });
+    let out = apply_stages_to_page(
+        vec![json!({"id": 1, "code": "US"}), json!({"id": 2, "code": "IN"})],
+        &[s],
+    )
+    .unwrap();
+    assert_eq!(out[0]["country"], json!("United States"));
+    assert_eq!(out[1]["country"], json!("India"));
+}
+
+#[test]
+fn values_relation_join() {
+    let s = stage(SqlTransformConfig {
+        query: "SELECT b.id, t.label FROM batch b JOIN tiers t ON b.tier = t.id ORDER BY b.id"
+            .into(),
+        relations: vec![RelationSpec {
+            name: "tiers".into(),
+            source: RelationSource::Values {
+                columns: vec!["id".into(), "label".into()],
+                rows: vec![
+                    vec![json!(1), json!("gold")],
+                    vec![json!(2), json!("silver")],
+                ],
+            },
+            reload_on_change: false,
+        }],
+        memory_limit: None,
+        threads: None,
+    });
+    let out = apply_stages_to_page(vec![json!({"id": 9, "tier": 2})], &[s]).unwrap();
+    assert_eq!(out[0]["label"], json!("silver"));
+}
+
+#[test]
+fn bad_query_fails_at_compile_with_message() {
+    let err = SqlTransform::compile(&SqlTransformConfig {
+        query: "SELEKT * FROM batch".into(), // syntax error
+        relations: vec![],
+        memory_limit: None,
+        threads: None,
+    })
+    .unwrap_err();
+    let msg = format!("{err}").to_lowercase();
+    assert!(msg.contains("sel") || msg.contains("syntax"), "got: {err}");
+}
+
+#[test]
+fn query_referencing_only_batch_compiles() {
+    // `batch` doesn't exist yet at compile — referencing only its columns must
+    // be tolerated (the binder error is about `batch` missing).
+    SqlTransform::compile(&SqlTransformConfig {
+        query: "SELECT x, y FROM batch WHERE z > 1".into(),
+        relations: vec![],
+        memory_limit: None,
+        threads: None,
+    })
+    .expect("references only batch columns -> tolerated at compile");
+}
+
+#[test]
+fn reserved_relation_name_batch_rejected() {
+    let err = SqlTransform::compile(&SqlTransformConfig {
+        query: "SELECT * FROM batch".into(),
+        relations: vec![RelationSpec {
+            name: "batch".into(),
+            source: RelationSource::Values {
+                columns: vec!["a".into()],
+                rows: vec![],
+            },
+            reload_on_change: false,
+        }],
+        memory_limit: None,
+        threads: None,
+    })
+    .unwrap_err();
+    assert!(format!("{err}").contains("batch"));
+}
+
+#[test]
+fn missing_reference_file_fails_at_compile() {
+    let err = SqlTransform::compile(&SqlTransformConfig {
+        query: "SELECT * FROM batch JOIN nope USING (id)".into(),
+        relations: vec![RelationSpec {
+            name: "nope".into(),
+            source: RelationSource::Csv {
+                path: "/does/not/exist.csv".into(),
+                has_header: true,
+            },
+            reload_on_change: false,
+        }],
+        memory_limit: None,
+        threads: None,
+    })
+    .unwrap_err();
+    let msg = format!("{err}").to_lowercase();
+    assert!(
+        msg.contains("exist") || msg.contains("no such") || msg.contains("nope"),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn connection_reused_across_pages() {
+    let s = stage(SqlTransformConfig {
+        query: "SELECT count(*) AS n FROM batch".into(),
+        relations: vec![],
+        memory_limit: None,
+        threads: None,
+    });
+    for i in 1..=3 {
+        let out = apply_stages_to_page(
+            (0..i).map(|j| json!({"x": j})).collect(),
+            std::slice::from_ref(&s),
+        )
+        .unwrap();
+        assert_eq!(out[0]["n"], json!(i));
+    }
+}
+
+#[test]
+fn aggregation_is_per_page_over_two_pages() {
+    let s = stage(SqlTransformConfig {
+        query: "SELECT SUM(v) AS total FROM batch".into(),
+        relations: vec![],
+        memory_limit: None,
+        threads: None,
+    });
+    let p1 = apply_stages_to_page(
+        vec![json!({"v": 1}), json!({"v": 2})],
+        std::slice::from_ref(&s),
+    )
+    .unwrap();
+    let p2 = apply_stages_to_page(vec![json!({"v": 10})], std::slice::from_ref(&s)).unwrap();
+    assert_eq!(p1[0]["total"], json!(3)); // per-page, not global
+    assert_eq!(p2[0]["total"], json!(10));
+}

--- a/crates/transform-sql/tests/runtime.rs
+++ b/crates/transform-sql/tests/runtime.rs
@@ -42,10 +42,7 @@ fn group_by_aggregation_within_page() {
     );
     assert_eq!(
         out,
-        vec![
-            json!({"k": "a", "total": 3}),
-            json!({"k": "b", "total": 5})
-        ]
+        vec![json!({"k": "a", "total": 3}), json!({"k": "b", "total": 5})]
     );
 }
 
@@ -90,7 +87,10 @@ fn join_to_csv_reference_relation() {
         threads: None,
     });
     let out = apply_stages_to_page(
-        vec![json!({"id": 1, "code": "US"}), json!({"id": 2, "code": "IN"})],
+        vec![
+            json!({"id": 1, "code": "US"}),
+            json!({"id": 2, "code": "IN"}),
+        ],
         &[s],
     )
     .unwrap();

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -24,6 +24,7 @@
 - [Data-quality checks](./cookbook/quality.md)
 - [Compression](./cookbook/compression.md)
 - [Record transforms](./cookbook/transforms.md)
+- [SQL transform](./cookbook/sql-transform.md)
 - [Secrets-manager interpolation](./cookbook/secrets.md)
 - [Adaptive batching](./cookbook/adaptive-batching.md)
 - [Scheduling](./cookbook/scheduling.md)

--- a/docs/book/src/cookbook/sql-transform.md
+++ b/docs/book/src/cookbook/sql-transform.md
@@ -1,0 +1,317 @@
+# SQL transform
+
+Run embedded DuckDB SQL over each pipeline page. Each page's records are exposed as
+the relation `batch`; the query result replaces the page. Column name becomes JSON
+key; `NULL` becomes JSON `null`; `STRUCT`/`LIST`/`MAP` become nested JSON.
+
+Requires the `transform-sql` Cargo feature (CLI + umbrella; not in defaults; in `full`).
+
+## Overview
+
+The `sql` transform embeds DuckDB in-process — no external database, no network
+round-trip. Every time a page of records arrives from the source, faucet registers
+that page as a temporary Arrow-backed relation named `batch` and executes your
+query. The result set is the new page forwarded to the next transform or to the sink.
+
+Config shape:
+
+```yaml
+transforms:
+  - type: sql
+    config:
+      query: "SELECT id, upper(name) AS name FROM batch WHERE active"
+```
+
+All standard DuckDB SQL is available: filtering, projection, type casting,
+aggregation, window functions, `regexp_replace`, `json_extract`, date/time
+arithmetic, and `JOIN` to reference relations (see below).
+
+## The `batch` relation
+
+When your query runs, `batch` contains the current page's records as a table.
+Column types are inferred from the JSON values in each record:
+
+| JSON type | DuckDB type |
+|---|---|
+| integer | `BIGINT` |
+| float | `DOUBLE` |
+| string | `VARCHAR` |
+| boolean | `BOOLEAN` |
+| null | nullable column |
+| array | `LIST` |
+| object | `STRUCT` |
+
+You can `SELECT *`, project individual columns, rename with `AS`, cast types, add
+computed columns — anything DuckDB supports as a `SELECT` statement.
+
+`batch` is reserved. Using it as a reference relation name is a compile-time error.
+
+## Per-page semantics and `batch_size: 0`
+
+**This is the most important thing to know about the SQL transform.**
+
+The query runs **once per page**, not once across the whole stream. `GROUP BY`,
+`COUNT(*)`, window functions, and any other aggregation operate within a single
+page only.
+
+With the default `batch_size` of 1000, a GROUP BY across 10,000 records runs on
+10 separate pages of 1000 rows each — giving 10 sets of partial results rather than
+one global result.
+
+```yaml
+# WRONG for global aggregation — GROUP BY sees only one page at a time.
+transforms:
+  - type: sql
+    config:
+      query: "SELECT country, COUNT(*) AS n FROM batch GROUP BY country"
+```
+
+**To aggregate globally, set `batch_size: 0` on the source.** This is the sentinel
+value meaning "no batching" — the source emits the entire result set as a single
+page, so the SQL transform sees all rows at once.
+
+```yaml
+pipeline:
+  source:
+    type: csv
+    config:
+      path: data/orders.csv
+      batch_size: 0          # ← load everything as one page
+  transforms:
+    - type: sql
+      config:
+        query: "SELECT country, COUNT(*) AS n FROM batch GROUP BY country"
+```
+
+`batch_size: 0` is supported by every source. It is appropriate when the full
+dataset fits in memory and you need global semantics.
+
+When an aggregating query receives a second page without `batch_size: 0`, faucet
+logs a one-time warning to help you catch the footgun:
+
+```
+WARN faucet::transform::sql: sql transform with aggregation received multiple pages;
+aggregation is per-page — set batch_size: 0 for global aggregation
+```
+
+## Reference relations
+
+Join pre-loaded lookup data against `batch`:
+
+```yaml
+transforms:
+  - type: sql
+    config:
+      query: |
+        SELECT b.id, c.country
+        FROM batch b
+        LEFT JOIN countries c ON b.code = c.code
+      relations:
+        - name: countries
+          source:
+            type: csv
+            path: data/countries.csv
+            has_header: true   # default true
+```
+
+Reference relations are loaded **once at compile time** (the moment `faucet validate`
+or `faucet run` reads the config) and remain resident for the run. Missing files
+are caught at load time — not mid-run.
+
+### Source types
+
+| `type` | Required fields | Notes |
+|---|---|---|
+| `csv` | `path` | `has_header` defaults to `true` |
+| `jsonl` | `path` | Loaded via DuckDB `read_json_auto` |
+| `values` | `columns`, `rows` | Inline; no file I/O |
+
+Inline values:
+
+```yaml
+relations:
+  - name: tiers
+    source:
+      type: values
+      columns: [id, label]
+      rows:
+        - [1, gold]
+        - [2, silver]
+```
+
+### `reload_on_change`
+
+```yaml
+relations:
+  - name: prices
+    source:
+      type: csv
+      path: data/prices.csv
+    reload_on_change: true
+```
+
+When `true`, faucet stats the file's mtime before each page and rebuilds the
+relation if it changed. Useful for reference files that are updated while the
+pipeline is running (e.g. a nightly price list). Default `false`. Ignored for
+`values`.
+
+## JSON columns
+
+Use `json_extract` on string fields that contain JSON:
+
+```sql
+-- Extract a nested field
+SELECT json_extract(payload, '$.user.id') AS user_id,
+       json_extract(payload, '$.event.name') AS event_name
+FROM batch
+```
+
+For explicit typing:
+
+```sql
+SELECT CAST(json_extract(payload, '$.amount') AS DOUBLE) AS amount
+FROM batch
+```
+
+If the field is typed as `JSON` rather than `VARCHAR`, omit the cast:
+
+```sql
+SELECT payload.user.id AS user_id FROM batch
+```
+
+## Timestamp and timezone
+
+DuckDB's `TIMESTAMP` type is timezone-naive. faucet JSON timestamps are RFC 3339
+strings (e.g. `"2026-01-01T12:00:00Z"`).
+
+**UTC-only data** — compare lexicographically or cast:
+
+```sql
+SELECT * FROM batch
+WHERE created_at > '2026-01-01T00:00:00Z'
+-- or
+WHERE CAST(created_at AS TIMESTAMP) > '2026-01-01'::TIMESTAMP
+```
+
+**Data with non-UTC offsets** — normalise upstream with the `cast` transform or
+`TIMESTAMPTZ`:
+
+```sql
+SELECT TIMESTAMPTZ created_at AT TIME ZONE 'UTC' AS created_utc FROM batch
+```
+
+The safest approach is to normalise timestamps to UTC strings before they reach the
+SQL transform, using the `cast` built-in transform upstream.
+
+## Validation with `faucet validate`
+
+```bash
+faucet validate pipeline.yaml
+```
+
+`faucet validate` runs the SQL transform's compile step: DuckDB parse/bind-checks
+the query and reports syntax errors with line and column number before any data is
+touched. Reference-relation files that do not exist are also caught here.
+
+Example error output:
+
+```
+error: sql transform: invalid query: Parser Error: syntax error at or near "SELEKT"
+  --> line 1, col 1
+```
+
+Runtime errors (e.g. type mismatches that only appear with real data) abort the
+run and are reported as `FaucetError::Transform`.
+
+## Full example — GROUP BY and JOIN
+
+The runnable file is `cli/examples/csv_to_jsonl_sql.yaml`.
+
+Data:
+
+```
+# cli/examples/data/orders.csv
+order_id,country_code,amount
+1,US,10.0
+2,US,5.5
+3,IN,7.0
+4,DE,3.0
+```
+
+```
+# cli/examples/data/countries.csv
+code,country
+US,United States
+IN,India
+DE,Germany
+```
+
+Config:
+
+```yaml
+version: 1
+name: csv_to_jsonl_sql
+
+pipeline:
+  source:
+    type: csv
+    config:
+      path: cli/examples/data/orders.csv
+      has_header: true
+      batch_size: 0          # whole file as one page → global GROUP BY
+
+  transforms:
+    - type: sql
+      config:
+        query: |
+          SELECT c.country,
+                 COUNT(*)                     AS order_count,
+                 SUM(CAST(o.amount AS DOUBLE)) AS total_amount
+          FROM   batch o
+          LEFT JOIN countries c ON o.country_code = c.code
+          GROUP BY c.country
+          ORDER BY c.country
+        relations:
+          - name: countries
+            source:
+              type: csv
+              path: cli/examples/data/countries.csv
+              has_header: true
+
+  sink:
+    type: jsonl
+    config:
+      path: /tmp/faucet_sql_demo.jsonl
+```
+
+Run it:
+
+```bash
+faucet validate cli/examples/csv_to_jsonl_sql.yaml
+faucet run     cli/examples/csv_to_jsonl_sql.yaml
+```
+
+Output (`/tmp/faucet_sql_demo.jsonl`):
+
+```json
+{"country":"Germany","order_count":1,"total_amount":3.0}
+{"country":"India","order_count":1,"total_amount":7.0}
+{"country":"United States","order_count":2,"total_amount":15.5}
+```
+
+## SQL vs. built-in transforms
+
+| Situation | Recommended approach |
+|---|---|
+| Rename, drop, select, cast a few fields | Built-in `rename_field` / `drop` / `select` / `cast` — lighter, no DuckDB overhead |
+| PII redaction | Built-in `redact` |
+| Re-case keys | Built-in `keys_case` |
+| Complex reshape, JOIN, computed columns | `sql` |
+| Global aggregation / GROUP BY | `sql` with `batch_size: 0` |
+| Window functions | `sql` with `batch_size: 0` if global; `sql` as-is if per-page windowing is what you want |
+| Live-updating lookup join | `sql` with `reload_on_change: true` on the reference relation |
+
+Use the built-in transforms for simple field-level operations — they are
+always-on, have no external dependencies, and carry zero extra compile weight.
+Reach for `sql` when you need expressive SQL semantics: multi-table joins,
+aggregation, window functions, or any computation the built-ins cannot express.

--- a/docs/book/src/cookbook/transforms.md
+++ b/docs/book/src/cookbook/transforms.md
@@ -23,6 +23,7 @@ them are listed in `faucet list` and dispatchable as `type:` values.
 | `cast` | Coerce per-field types | `fields: {name: type}`, `on_error` |
 | `redact` | Replace listed field values with a mask | `fields: [..]`, `mask` |
 | `value_case` | Lowercase / uppercase / trim string values | `fields: [..]`, `mode` |
+| `sql` | Run DuckDB SQL over the whole page; records are the `batch` relation | `query`, `relations?`, `memory_limit?`, `threads?` · page-level (sees the whole batch) · needs `transform-sql` feature · [cookbook](./sql-transform.md) |
 
 The field-targeting transforms (`select`, `drop`, `set`, `rename_field`,
 `cast`, `redact`, `value_case`) act on **top-level** fields only —

--- a/examples/README.md
+++ b/examples/README.md
@@ -32,6 +32,7 @@ These run immediately after installing the CLI — great for a first smoke test:
 | Example | Notes |
 |---------|-------|
 | `csv_to_jsonl.yaml` | the canonical smoke test (`make demo` runs this) |
+| `csv_to_jsonl_sql.yaml` | CSV → SQL GROUP BY + LEFT JOIN (embedded DuckDB) → JSONL; requires `--features transform-sql` |
 | `csv_to_sqlite.yaml` | CSV → local SQLite file |
 | `sqlite_to_jsonl.yaml`, `sqlite_to_csv.yaml` | local SQLite → file |
 | `rest_to_jsonl.yaml`, `rest_streaming.yaml`, `rest_to_stdout_preview.yaml` | point `base_url` at any HTTP API; preview needs no sink setup |

--- a/faucet-stream/Cargo.toml
+++ b/faucet-stream/Cargo.toml
@@ -91,8 +91,10 @@ quality-jsonschema = ["quality", "faucet-core/quality-jsonschema"]
 ## Kafka transport. Forwarded to `faucet-lineage`.
 lineage = ["dep:faucet-lineage"]
 lineage-kafka = ["lineage", "faucet-lineage/transport-kafka"]
+## SQL-as-transform via embedded DuckDB.
+transform-sql = ["dep:faucet-transform-sql"]
 ## Every connector and state backend.
-full = ["source", "sink", "state", "auth", "kafka-schema-registry", "compression", "quality", "quality-jsonschema", "lineage", "lineage-kafka"]
+full = ["source", "sink", "state", "auth", "kafka-schema-registry", "compression", "quality", "quality-jsonschema", "lineage", "lineage-kafka", "transform-sql"]
 
 ## Individual source connectors.
 source-rest = ["dep:faucet-source-rest"]
@@ -225,6 +227,7 @@ faucet-state-redis = { workspace = true, optional = true }
 faucet-state-postgres = { workspace = true, optional = true }
 
 faucet-lineage = { workspace = true, optional = true }
+faucet-transform-sql = { workspace = true, optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/faucet-stream/src/lib.rs
+++ b/faucet-stream/src/lib.rs
@@ -421,3 +421,11 @@ pub mod state {
 /// [`lineage::LineageEmitter`] directly.
 #[cfg(feature = "lineage")]
 pub use faucet_lineage as lineage;
+
+// ── SQL transform (embedded DuckDB) ──────────────────────────────────────────
+/// SQL-as-transform: run DuckDB SQL over each pipeline page (the `batch`
+/// relation). Enable the `transform-sql` feature. The CLI wires this via the
+/// `sql` transform; library callers build [`transform_sql::SqlTransform`] and
+/// attach it with [`TransformingSource`].
+#[cfg(feature = "transform-sql")]
+pub use faucet_transform_sql as transform_sql;


### PR DESCRIPTION
Implements the `sql` transform (issue #129): a **page-level** transform backed by embedded **DuckDB** that exposes each pipeline page as the relation `batch`. Unlocks the full DuckDB SQL surface — joins, aggregates, window functions, CTEs, JSON/regex/date functions — for the existing `transforms:` list.

```yaml
transforms:
  - type: sql
    config:
      query: |
        SELECT c.country, COUNT(*) AS order_count, SUM(o.amount) AS total
        FROM batch o LEFT JOIN countries c ON o.country_code = c.code
        GROUP BY c.country
      relations:
        - name: countries
          source: { type: csv, path: ./countries.csv, has_header: true }
```

## What's included
- **`faucet-core`**: a generic, dependency-free `TransformStage::PageFn` (whole-page `Vec<Value> -> Result<Vec<Value>>` closure) + `apply_stages_to_page` page-granular runner. No DuckDB/arrow in core. Per-record stages still flat-map; page-level stages see the whole page; arbitrary interleaving (`filter → sql → select`) preserved.
- **New crate `faucet-transform-sql`** (`crates/transform-sql/`): DuckDB (`bundled` + `vtab-arrow`; pins `arrow = 58`, matching the workspace). JSON↔Arrow shovel via `arrow-json`; compile-time parse/bind validation; per-page execute (`CREATE TEMP TABLE batch AS SELECT * FROM arrow(?, ?)` — TABLE not VIEW, avoiding the duckdb-rs#648 dangling-pointer segfault); reference relations (`csv`/`jsonl`/`values`, optional `reload_on_change`).
- **CLI** `sql` transform (feature `transform-sql`); `faucet schema/list/validate` support it automatically.
- **Umbrella** re-export, **CI** feature-isolation entry, **deny.toml** license check (DuckDB is MIT, already allowed).
- **Docs** (crate README, mdBook cookbook + transforms table + SUMMARY, root README), a runnable example (`cli/examples/csv_to_jsonl_sql.yaml`), an end-to-end CLI integration test, and a criterion benchmark.

## Design decisions
- **Fail-fast, not DLQ.** Queries are parse/bind-validated at config load (`faucet validate` reports syntax errors with line/column); runtime query errors **abort** the run, consistent with every existing transform — no transform→DLQ plumbing.
- **Per-page aggregation.** `GROUP BY`/window functions aggregate within a page; `batch_size: 0` makes the whole stream one page for global aggregation. An aggregating query emits a one-time warning when it sees a 2nd page.

## Testing
`faucet-core` stage/observability tests (incl. a regression proving the runner refactor preserves per-record behavior); `faucet-transform-sql` unit + integration tests (round-trip, schema drift, empty page/result, GROUP BY, JOIN to csv/values relations, reserved-name/missing-file errors, connection reuse); a CLI end-to-end test (CSV → SQL GROUP BY + JOIN → JSONL). fmt clean, clippy clean (core + crate), feature-isolation clean, `cargo deny` licenses ok.

> Note: the full `cargo publish --dry-run -p faucet-transform-sql` only succeeds after `faucet-core` ships the new `PageFn` API (release-plz publishes in dependency order); packaging (`--no-verify`) is verified.

Closes #129