### PR TITLE
feat(serve): embedded web console (serve-ui)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,11 @@ jobs:
           done
           echo "::error::workspace tests failed after 3 attempts"
           exit 1
+      - name: Run serve-ui and serve-openapi tests in isolation
+        # Explicitly target the embedded-console tests with serve-ui so the
+        # feature-gated #![cfg(feature = "serve-ui")] gate is exercised and
+        # the OpenAPI two-way sync test runs against the console-enabled router.
+        run: cargo test -p faucet-cli --features serve-ui --test serve_ui --test serve_openapi
 
   # Verify each feature compiles in isolation (catches accidental cross-feature deps)
   feature-check:
@@ -197,10 +202,11 @@ jobs:
           - transform-sql
           # Scheduler (CLI-only)
           - schedule
-          # HTTP control plane (CLI-only) + its persistent run-history backends
+          # HTTP control plane (CLI-only) + its persistent run-history backends + embedded web console
           - serve
           - serve-history-postgres
           - serve-history-sqlite
+          - serve-ui
           # Secrets backends
           - secrets-vault
           - secrets-aws-sm

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ can drop on any box or a library you compile in.
   write batch size from sink latency and error rate), secrets-manager interpolation
   (`${vault:…}`, `${aws-sm:…}`, `${gcp-sm:…}`, `${azure-kv:…}`), cron scheduling
   (`faucet schedule`), an HTTP control plane (`faucet serve` — submit/poll/cancel
-  runs over REST), OpenLineage event emission (`lineage:` block — HTTP/file/Kafka transports, schema facets, column-level lineage), and built-in Prometheus metrics + `tracing` spans, all with
+  runs over REST, optional embedded web console via `serve-ui`), OpenLineage event emission (`lineage:` block — HTTP/file/Kafka transports, schema facets, column-level lineage), and built-in Prometheus metrics + `tracing` spans, all with
   zero per-connector code.
 - **Pay only for what you use** — every connector is a Cargo feature, so a slim
   build can be just REST + JSONL, or pull in all 38 connectors with `--features full`.

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -26,7 +26,7 @@ default = ["observability", "source", "sink", "state", "transforms", "compressio
 
 # Everything the default build ships, plus the long-running runtime modes:
 # `schedule` (cron scheduler) and `serve` (HTTP control plane).
-full = ["default", "schedule", "serve", "serve-history-postgres", "serve-history-sqlite", "lineage", "lineage-kafka", "transform-sql"]
+full = ["default", "schedule", "serve", "serve-ui", "serve-history-postgres", "serve-history-sqlite", "lineage", "lineage-kafka", "transform-sql"]
 
 # Data-quality checks (`quality:` config block). `quality-jsonschema` adds the
 # `json_schema` record check via a JSON Schema validator. Forwarded to
@@ -196,6 +196,9 @@ schedule = ["dep:croner", "dep:chrono-tz"]
 serve = ["observability", "tokio/net", "tokio/time", "dep:axum", "dep:tower-http", "dep:subtle", "dep:dashmap", "dep:sha2", "dep:async-stream"]
 serve-history-postgres = ["serve", "dep:sqlx"]
 serve-history-sqlite = ["serve", "dep:sqlx"]
+# Embedded web console (single-page UI) served by `faucet serve` at `/`.
+# Vanilla assets embedded via rust-embed; no JS build step. Implies `serve`.
+serve-ui = ["serve", "dep:rust-embed"]
 
 [dependencies]
 faucet-core.workspace = true
@@ -287,6 +290,8 @@ sha2 = { workspace = true, optional = true }
 # faucet serve SSE log streaming (Phase 4); only compiled with `serve`.
 async-stream = { workspace = true, optional = true }
 sqlx = { workspace = true, optional = true }
+# faucet serve embedded web console (serve-ui feature): compile-time asset embedding.
+rust-embed = { version = "8", optional = true, features = ["mime-guess"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/cli/README.md
+++ b/cli/README.md
@@ -217,6 +217,28 @@ cargo install faucet-cli --features serve
 cargo install faucet-cli --features "serve,serve-history-postgres,serve-history-sqlite"
 ```
 
+#### Optional embedded web console (`serve-ui`)
+
+Build with `serve-ui` to serve a browser-based web console at `/` alongside the
+REST API. The console gives you a Runs dashboard, Run detail with live SSE logs,
+a Submit view (raw YAML/JSON editor + schema-driven wizard), and a Schemas
+explorer — all backed by the same bearer-gated `/v1` API.
+
+```bash
+cargo install faucet-cli --features serve-ui    # serve-ui implies serve
+FAUCET_SERVE_AUTH_TOKEN=s3cret faucet serve --listen 127.0.0.1:8080
+# Open http://127.0.0.1:8080/ in a browser; paste the bearer token when prompted.
+```
+
+Pass `--no-ui` to disable the console at runtime without rebuilding. The `serve-ui`
+feature also adds three bearer-gated endpoints: `GET /v1/schemas` (connector
+catalog), `GET /v1/schemas/{kind}/{name}` (one JSON Schema), and `POST /v1/doctor`
+(validate + probe a config without running it). These endpoints are available
+regardless of `--no-ui`.
+
+See the [web console guide](https://pawansikawat.github.io/faucet-stream/cookbook/web-console.html)
+for the full walkthrough.
+
 ### `faucet init`
 
 `faucet init` writes a starter `pipeline.yaml` by walking each selected connector's JSON Schema. Required fields are surfaced with a `# REQUIRED` comment and a typed placeholder (`""`, `0`, `false`, `[]`, `{}`); optional fields are commented out so connector-level defaults stay in force. Enum-typed fields list valid values in the trailing comment. Tagged-enum blocks (the `#[serde(tag = "type")]` shape used by `auth:`, `pagination:`, BigQuery `credentials:`, etc.) inline the chosen variant and emit every other variant as a commented-out "Alternative variants" block right below it — so users can switch auth modes (or pagination, or credentials) without leaving the file to consult `faucet schema`. Run `faucet init --interactive` (requires `--features cli-interactive`) to be prompted for each variant up front.

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -141,6 +141,10 @@ pub struct ServeArgs {
     /// Skip auto-loading `.env` from cwd at startup.
     #[arg(long)]
     pub no_env_file: bool,
+    /// Disable serving the embedded web console (only meaningful in a build that
+    /// includes the `serve-ui` feature; the API is unaffected).
+    #[arg(long)]
+    pub no_ui: bool,
 }
 
 /// `faucet run` arguments.

--- a/cli/src/serve/config.rs
+++ b/cli/src/serve/config.rs
@@ -65,6 +65,10 @@ pub struct ServeConfig {
     /// Tracing filter directive for serve's own subscriber. Set from the
     /// clap-resolved `--log-level` / `FAUCET_LOG`; defaults to `"info"`.
     pub log_level: String,
+    /// Whether to serve the embedded web console. Built only when the `serve-ui`
+    /// feature is on; this gates serving at runtime (`--no-ui`).
+    #[cfg_attr(not(feature = "serve-ui"), allow(dead_code))]
+    pub ui_enabled: bool,
 }
 
 fn default_max_concurrent() -> usize {
@@ -169,6 +173,7 @@ impl ServeConfig {
             env_file: args.env_file,
             no_env_file: args.no_env_file,
             log_level: "info".to_string(),
+            ui_enabled: !args.no_ui,
         })
     }
 }
@@ -196,6 +201,7 @@ mod tests {
             probe_timeout_secs: 10,
             env_file: None,
             no_env_file: false,
+            no_ui: false,
         }
     }
 

--- a/cli/src/serve/handlers/doctor.rs
+++ b/cli/src/serve/handlers/doctor.rs
@@ -1,0 +1,30 @@
+//! `POST /v1/doctor` — validate + probe a submitted config WITHOUT running it.
+//! Reuses the same preflight as `doctor_first`: 200 with the report when all
+//! probes pass, 422 with the report as `details` when any fail.
+
+use crate::serve::error::ServeError;
+use crate::serve::load::load_submission;
+use crate::serve::runner::{ConfigFormatWire, run_doctor_first};
+use crate::serve::state::ServerState;
+use axum::Json;
+use axum::extract::State;
+use serde::Deserialize;
+use serde_json::Value;
+
+#[derive(Debug, Deserialize)]
+pub struct DoctorRequest {
+    pub config: String,
+    #[serde(default)]
+    pub config_format: ConfigFormatWire,
+}
+
+/// `POST /v1/doctor` → 200 report (all pass) / 422 report (any fail) / 400 (bad config).
+pub async fn doctor(
+    State(state): State<ServerState>,
+    Json(req): Json<DoctorRequest>,
+) -> Result<Json<Value>, ServeError> {
+    let loaded =
+        load_submission(&req.config, req.config_format.into(), state.default_base()).await?;
+    let report = run_doctor_first(&state, &loaded).await?;
+    Ok(Json(report))
+}

--- a/cli/src/serve/handlers/mod.rs
+++ b/cli/src/serve/handlers/mod.rs
@@ -1,4 +1,5 @@
 //! serve HTTP handlers.
+pub mod doctor;
 pub mod health;
 pub mod logs;
 pub mod runs;

--- a/cli/src/serve/handlers/mod.rs
+++ b/cli/src/serve/handlers/mod.rs
@@ -2,3 +2,4 @@
 pub mod health;
 pub mod logs;
 pub mod runs;
+pub mod schemas;

--- a/cli/src/serve/handlers/schemas.rs
+++ b/cli/src/serve/handlers/schemas.rs
@@ -1,0 +1,63 @@
+//! `GET /v1/schemas` (catalog) and `GET /v1/schemas/{kind}/{name}` (one JSON
+//! Schema). Read-only; reuses the CLI's schema introspection so the catalog
+//! always reflects the compiled connectors/transforms.
+
+use crate::serve::error::ServeError;
+use crate::serve::state::ServerState;
+use axum::Json;
+use axum::extract::{Path, State};
+use serde::Serialize;
+use serde_json::Value;
+
+#[derive(Debug, Serialize)]
+pub struct SchemaItem {
+    pub name: String,
+    pub description: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SchemasResponse {
+    pub sources: Vec<SchemaItem>,
+    pub sinks: Vec<SchemaItem>,
+    pub transforms: Vec<SchemaItem>,
+    pub state: Vec<String>,
+}
+
+fn items(pairs: Vec<(&'static str, &'static str)>) -> Vec<SchemaItem> {
+    pairs
+        .into_iter()
+        .map(|(name, description)| SchemaItem {
+            name: name.to_string(),
+            description: description.to_string(),
+        })
+        .collect()
+}
+
+/// `GET /v1/schemas` → catalog of compiled connectors/transforms + state kinds.
+pub async fn list_schemas(State(_state): State<ServerState>) -> Json<SchemasResponse> {
+    Json(SchemasResponse {
+        sources: items(crate::registry::source_descriptions()),
+        sinks: items(crate::registry::sink_descriptions()),
+        transforms: items(crate::transforms::transform_descriptions()),
+        state: crate::state::available_state_kinds()
+            .into_iter()
+            .map(String::from)
+            .collect(),
+    })
+}
+
+/// `GET /v1/schemas/{kind}/{name}` → the JSON Schema for one connector/transform.
+/// Unknown kind or name → 404.
+pub async fn get_schema(
+    State(_state): State<ServerState>,
+    Path((kind, name)): Path<(String, String)>,
+) -> Result<Json<Value>, ServeError> {
+    let schema = match kind.as_str() {
+        "source" => crate::registry::source_schema(&name),
+        "sink" => crate::registry::sink_schema(&name),
+        "transform" => crate::transforms::transform_schema(&name),
+        _ => return Err(ServeError::NotFound),
+    }
+    .map_err(|_| ServeError::NotFound)?;
+    Ok(Json(schema))
+}

--- a/cli/src/serve/mod.rs
+++ b/cli/src/serve/mod.rs
@@ -17,6 +17,8 @@ pub mod registry;
 pub mod runner;
 pub mod server;
 pub mod state;
+#[cfg(feature = "serve-ui")]
+pub mod ui_assets;
 
 pub use config::ServeConfig;
 

--- a/cli/src/serve/runner.rs
+++ b/cli/src/serve/runner.rs
@@ -183,7 +183,7 @@ pub async fn submit(state: ServerState, req: SubmitRequest) -> Result<SubmitResp
 /// Run the `doctor_first` probes. On success returns the (redacted) report so
 /// the caller can store it on the run record (`doctor_report`); on any probe
 /// failure returns 422 with the same redacted report as `details`.
-async fn run_doctor_first(
+pub(crate) async fn run_doctor_first(
     state: &ServerState,
     loaded: &LoadedSubmission,
 ) -> Result<serde_json::Value, ServeError> {

--- a/cli/src/serve/runner.rs
+++ b/cli/src/serve/runner.rs
@@ -717,6 +717,7 @@ mod tests {
             env_file: None,
             no_env_file: false,
             log_level: "info".into(),
+            ui_enabled: true,
         };
         let history = Arc::new(MemoryHistory::new(Duration::from_secs(60))) as Arc<dyn RunHistory>;
         let state = ServerState::new(
@@ -781,6 +782,7 @@ mod tests {
             env_file: None,
             no_env_file: false,
             log_level: "info".into(),
+            ui_enabled: true,
         };
         let history = Arc::new(MemoryHistory::new(Duration::from_secs(60))) as Arc<dyn RunHistory>;
         ServerState::new(

--- a/cli/src/serve/server.rs
+++ b/cli/src/serve/server.rs
@@ -2,7 +2,7 @@
 
 use crate::error::{CliError, CliResult};
 use crate::serve::config::ServeConfig;
-use crate::serve::handlers::{health, logs, runs, schemas};
+use crate::serve::handlers::{doctor, health, logs, runs, schemas};
 use crate::serve::history::RunHistory;
 use crate::serve::state::ServerState;
 use crate::serve::{auth, metrics};
@@ -31,6 +31,7 @@ pub fn build_router(state: ServerState, config: &ServeConfig) -> Router {
         .route("/v1/runs/{id}/logs", get(logs::stream_logs))
         .route("/v1/schemas", get(schemas::list_schemas))
         .route("/v1/schemas/{kind}/{name}", get(schemas::get_schema))
+        .route("/v1/doctor", post(doctor::doctor))
         .route_layer(axum::middleware::from_fn_with_state(
             state.clone(),
             auth::require_auth,

--- a/cli/src/serve/server.rs
+++ b/cli/src/serve/server.rs
@@ -2,7 +2,7 @@
 
 use crate::error::{CliError, CliResult};
 use crate::serve::config::ServeConfig;
-use crate::serve::handlers::{health, logs, runs};
+use crate::serve::handlers::{health, logs, runs, schemas};
 use crate::serve::history::RunHistory;
 use crate::serve::state::ServerState;
 use crate::serve::{auth, metrics};
@@ -29,6 +29,8 @@ pub fn build_router(state: ServerState, config: &ServeConfig) -> Router {
         .route("/v1/runs/{id}", get(runs::get_run).delete(runs::delete_run))
         .route("/v1/runs/{id}/cancel", post(runs::cancel_run))
         .route("/v1/runs/{id}/logs", get(logs::stream_logs))
+        .route("/v1/schemas", get(schemas::list_schemas))
+        .route("/v1/schemas/{kind}/{name}", get(schemas::get_schema))
         .route_layer(axum::middleware::from_fn_with_state(
             state.clone(),
             auth::require_auth,

--- a/cli/src/serve/server.rs
+++ b/cli/src/serve/server.rs
@@ -51,8 +51,18 @@ pub fn build_router(state: ServerState, config: &ServeConfig) -> Router {
         CorsLayer::new().allow_origin(AllowOrigin::list(origins))
     };
 
-    public
-        .merge(api)
+    let mut router = public.merge(api);
+
+    #[cfg(feature = "serve-ui")]
+    if config.ui_enabled {
+        use crate::serve::ui_assets;
+        router = router
+            .route("/", axum::routing::get(ui_assets::index))
+            .route("/assets/{*path}", axum::routing::get(ui_assets::asset))
+            .fallback(ui_assets::spa_fallback);
+    }
+
+    router
         .layer(RequestBodyLimitLayer::new(config.body_limit_bytes))
         .layer(axum::middleware::from_fn(metrics::track_metrics))
         .layer(cors)

--- a/cli/src/serve/state.rs
+++ b/cli/src/serve/state.rs
@@ -127,6 +127,7 @@ mod tests {
             env_file: None,
             no_env_file: false,
             log_level: "info".into(),
+            ui_enabled: true,
         }
     }
 

--- a/cli/src/serve/ui/api.js
+++ b/cli/src/serve/ui/api.js
@@ -1,0 +1,74 @@
+// Centralized API client: base path, bearer token (localStorage), error envelope.
+const TOKEN_KEY = "faucet.token";
+
+export const token = {
+  get: () => localStorage.getItem(TOKEN_KEY) || "",
+  set: (t) => localStorage.setItem(TOKEN_KEY, t),
+  clear: () => localStorage.removeItem(TOKEN_KEY),
+};
+
+// Listeners notified when a request gets a 401 (so the shell can open the modal).
+const unauthorizedHandlers = new Set();
+export const onUnauthorized = (fn) => unauthorizedHandlers.add(fn);
+
+export class ApiError extends Error {
+  constructor(status, code, message, details, retryAfter) {
+    super(message || code || `HTTP ${status}`);
+    this.status = status;
+    this.code = code;
+    this.details = details;
+    this.retryAfter = retryAfter;
+  }
+}
+
+export function authHeaders(extra = {}) {
+  const t = token.get();
+  return t ? { Authorization: `Bearer ${t}`, ...extra } : { ...extra };
+}
+
+export async function api(path, { method = "GET", body, headers } = {}) {
+  const opts = { method, headers: authHeaders(headers || {}) };
+  if (body !== undefined) {
+    opts.headers["Content-Type"] = "application/json";
+    opts.body = JSON.stringify(body);
+  }
+  const resp = await fetch(path, opts);
+  if (resp.status === 401) {
+    unauthorizedHandlers.forEach((fn) => fn());
+    throw new ApiError(401, "unauthorized", "authentication required");
+  }
+  if (resp.status === 204) return null;
+  const text = await resp.text();
+  const json = text ? safeJson(text) : null;
+  if (!resp.ok) {
+    const e = json && json.error ? json.error : {};
+    const retryAfter = Number(resp.headers.get("retry-after")) || undefined;
+    throw new ApiError(resp.status, e.code, e.message, e.details, retryAfter);
+  }
+  return json;
+}
+
+function safeJson(text) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+// Probe whether the server requires auth (used at boot). Returns true if a
+// tokenless GET /v1/runs is accepted (no-auth mode or token already valid).
+export async function authOk() {
+  const resp = await fetch("/v1/runs?limit=1", { headers: authHeaders() });
+  return resp.status !== 401;
+}
+
+export function toast(message, kind = "info") {
+  const host = document.getElementById("toasts");
+  if (!host) return;
+  const el = document.createElement("div");
+  el.className = `toast toast-${kind}`;
+  el.textContent = message;
+  host.appendChild(el);
+  setTimeout(() => el.remove(), 5000);
+}

--- a/cli/src/serve/ui/app.js
+++ b/cli/src/serve/ui/app.js
@@ -1,0 +1,2 @@
+// placeholder — replaced in Task 8
+document.getElementById("app").textContent = "faucet console";

--- a/cli/src/serve/ui/app.js
+++ b/cli/src/serve/ui/app.js
@@ -1,2 +1,69 @@
-// placeholder — replaced in Task 8
-document.getElementById("app").textContent = "faucet console";
+import { token, onUnauthorized, authOk } from "./api.js";
+import { startRouter, navigate } from "./router.js";
+import { renderRuns } from "./views/runs.js";
+import { renderDetail } from "./views/detail.js";
+import { renderSubmit } from "./views/submit.js";
+import { renderSchemas } from "./views/schemas.js";
+import { route } from "./router.js";
+
+// --- theme ---
+const THEME_KEY = "faucet.theme";
+function applyTheme(t) {
+  document.documentElement.dataset.theme = t;
+  localStorage.setItem(THEME_KEY, t);
+}
+function initTheme() {
+  applyTheme(localStorage.getItem(THEME_KEY) || "auto");
+}
+
+// --- token modal ---
+function openTokenModal() {
+  const modal = document.getElementById("token-modal");
+  modal.classList.add("open");
+  const input = document.getElementById("token-input");
+  input.value = token.get();
+  input.focus();
+}
+function closeTokenModal() {
+  document.getElementById("token-modal").classList.remove("open");
+}
+
+function wireChrome() {
+  document.getElementById("nav-runs").onclick = () => navigate("#/runs");
+  document.getElementById("nav-submit").onclick = () => navigate("#/submit");
+  document.getElementById("nav-schemas").onclick = () => navigate("#/schemas");
+  document.getElementById("theme-toggle").onclick = () => {
+    const cur = document.documentElement.dataset.theme;
+    applyTheme(cur === "dark" ? "light" : cur === "light" ? "auto" : "dark");
+  };
+  document.getElementById("token-btn").onclick = openTokenModal;
+  document.getElementById("token-save").onclick = () => {
+    const v = document.getElementById("token-input").value.trim();
+    if (v) token.set(v); else token.clear();
+    closeTokenModal();
+    location.reload();
+  };
+  document.getElementById("token-clear").onclick = () => {
+    token.clear();
+    closeTokenModal();
+    location.reload();
+  };
+  onUnauthorized(openTokenModal);
+}
+
+function registerRoutes() {
+  route("#/runs", renderRuns);
+  route("#/runs/:id", renderDetail);
+  route("#/submit", renderSubmit);
+  route("#/schemas", renderSchemas);
+}
+
+async function main() {
+  initTheme();
+  wireChrome();
+  registerRoutes();
+  // If the server requires auth and we have no valid token, prompt first.
+  if (!(await authOk())) openTokenModal();
+  startRouter(document.getElementById("view"));
+}
+main();

--- a/cli/src/serve/ui/index.html
+++ b/cli/src/serve/ui/index.html
@@ -1,3 +1,42 @@
 <!doctype html>
-<html lang="en"><head><meta charset="utf-8"><title>faucet stream — console</title></head>
-<body><div id="app">loading…</div></body></html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>faucet stream — console</title>
+    <link rel="icon" href="/assets/mark.svg" />
+    <link rel="stylesheet" href="/assets/styles.css" />
+  </head>
+  <body>
+    <header class="topbar">
+      <a class="brand" href="#/runs">
+        <img src="/assets/mark.svg" alt="" class="brand-mark" />
+        <span class="brand-name"><b>faucet</b> stream</span>
+      </a>
+      <nav class="nav">
+        <button id="nav-runs">Runs</button>
+        <button id="nav-submit">Submit</button>
+        <button id="nav-schemas">Schemas</button>
+      </nav>
+      <div class="spacer"></div>
+      <button id="theme-toggle" class="icon-btn" title="Toggle theme">◐</button>
+      <button id="token-btn" class="icon-btn" title="Access token">🔑</button>
+    </header>
+    <main id="view" class="view"><div class="empty">loading…</div></main>
+
+    <div id="token-modal" class="modal">
+      <div class="modal-card">
+        <h2>Access token</h2>
+        <p>This server requires a bearer token for the API.</p>
+        <input id="token-input" type="password" placeholder="paste bearer token" />
+        <div class="modal-actions">
+          <button id="token-clear" class="btn-ghost">Clear</button>
+          <button id="token-save" class="btn-primary">Save</button>
+        </div>
+      </div>
+    </div>
+
+    <div id="toasts" class="toasts"></div>
+    <script type="module" src="/assets/app.js"></script>
+  </body>
+</html>

--- a/cli/src/serve/ui/index.html
+++ b/cli/src/serve/ui/index.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>faucet stream — console</title></head>
+<body><div id="app">loading…</div></body></html>

--- a/cli/src/serve/ui/mark.svg
+++ b/cli/src/serve/ui/mark.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="6 11 112 112" width="128" height="128" role="img" aria-label="faucet-stream">
+  <title>faucet-stream</title>
+  <!-- Transparent mark: solid brand teal, no tile. Use this inline (READMEs, docs, slides). -->
+  <g fill="none" stroke="#14B8A6" stroke-width="13" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M55 40 V24"/>
+    <path d="M43 24 H67"/>
+    <path d="M32 40 H78 a15 15 0 0 1 15 15 V66"/>
+  </g>
+  <g fill="#14B8A6">
+    <circle cx="93" cy="82" r="6"/>
+    <circle cx="93" cy="99" r="5" opacity="0.7"/>
+    <circle cx="93" cy="112" r="4" opacity="0.45"/>
+  </g>
+</svg>

--- a/cli/src/serve/ui/router.js
+++ b/cli/src/serve/ui/router.js
@@ -1,0 +1,45 @@
+// Hash router. Routes call render(container, params) and return an optional
+// teardown() (used to stop log streams / polling on navigation).
+const routes = [];
+let teardown = null;
+
+export function route(pattern, render) {
+  // pattern like "#/runs/:id" → regex with named groups
+  const names = [];
+  const re = new RegExp(
+    "^" +
+      pattern.replace(/:[^/]+/g, (m) => {
+        names.push(m.slice(1));
+        return "([^/]+)";
+      }) +
+      "$",
+  );
+  routes.push({ re, names, render });
+}
+
+export function navigate(hash) {
+  window.location.hash = hash;
+}
+
+async function dispatch(container) {
+  if (teardown) {
+    try { teardown(); } catch { /* ignore */ }
+    teardown = null;
+  }
+  const hash = window.location.hash || "#/runs";
+  for (const r of routes) {
+    const m = hash.match(r.re);
+    if (m) {
+      const params = {};
+      r.names.forEach((n, i) => (params[n] = decodeURIComponent(m[i + 1])));
+      teardown = (await r.render(container, params)) || null;
+      return;
+    }
+  }
+  container.innerHTML = `<div class="empty">Not found</div>`;
+}
+
+export function startRouter(container) {
+  window.addEventListener("hashchange", () => dispatch(container));
+  dispatch(container);
+}

--- a/cli/src/serve/ui/schema-form.js
+++ b/cli/src/serve/ui/schema-form.js
@@ -4,8 +4,7 @@
 // "type" discriminator (the {type,config} auth pattern). Anything else falls
 // back to a raw-JSON textarea so no config is ever unreachable.
 
-let uid = 0;
-const nextId = () => `sf-${++uid}`;
+import { escapeHtml } from "./utils.js";
 
 function resolveRef(schema, root) {
   if (schema && schema.$ref) {
@@ -226,13 +225,8 @@ function firstSentence(s) {
   const m = s.split(/\.\s/)[0];
   return (m.length > 120 ? m.slice(0, 117) + "…" : m).replace(/\.$/, "");
 }
-function escapeHtml(s) {
-  return s.replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
-}
-
 // Public: render a form for `schema`; returns { el, read() } where read() yields
 // the config object.
 export function renderSchemaForm(schema, value) {
-  uid = 0;
   return build(schema, schema, value, true);
 }

--- a/cli/src/serve/ui/schema-form.js
+++ b/cli/src/serve/ui/schema-form.js
@@ -1,0 +1,238 @@
+// Render a form from a (schemars) JSON Schema and read a value back out.
+// Supports: object properties + required, primitives, enum→select, nested
+// objects→fieldsets, arrays→add/remove, $ref→$defs, oneOf/anyOf with a const
+// "type" discriminator (the {type,config} auth pattern). Anything else falls
+// back to a raw-JSON textarea so no config is ever unreachable.
+
+let uid = 0;
+const nextId = () => `sf-${++uid}`;
+
+function resolveRef(schema, root) {
+  if (schema && schema.$ref) {
+    const path = schema.$ref.replace(/^#\//, "").split("/");
+    let node = root;
+    for (const seg of path) node = node?.[seg];
+    return node ? { ...node, ...schema, $ref: undefined } : schema;
+  }
+  return schema;
+}
+
+// Build a control for `schema`; returns { el, read() }.
+function build(schema, root, value, required) {
+  schema = resolveRef(schema, root) || {};
+  const desc = schema.description ? `<small class="help">${escapeHtml(firstSentence(schema.description))}</small>` : "";
+
+  // Discriminated union: oneOf/anyOf whose branches each fix a `type` const.
+  const variants = schema.oneOf || schema.anyOf;
+  if (Array.isArray(variants) && variants.every((v) => discriminatorConst(resolveRef(v, root)))) {
+    return buildDiscriminated(variants, root, value, desc);
+  }
+
+  if (Array.isArray(schema.enum)) return buildEnum(schema, value, desc);
+
+  const type = jsonType(schema, value);
+  if (type === "object" && schema.properties) return buildObject(schema, root, value || {});
+  if (type === "array") return buildArray(schema, root, value || []);
+  if (type === "boolean") return buildBool(schema, value, desc);
+  if (type === "integer" || type === "number") return buildNumber(schema, value, type, desc);
+  if (type === "string") return buildString(schema, value, desc);
+  return buildRaw(value); // fallback
+}
+
+function buildObject(schema, root, value) {
+  const wrap = document.createElement("fieldset");
+  wrap.className = "sf-object";
+  const reqset = new Set(schema.required || []);
+  const readers = {};
+  for (const [key, sub] of Object.entries(schema.properties)) {
+    const row = document.createElement("div");
+    row.className = "sf-field";
+    const label = document.createElement("label");
+    label.textContent = key + (reqset.has(key) ? " *" : "");
+    const ctrl = build(sub, root, value[key], reqset.has(key));
+    row.appendChild(label);
+    row.appendChild(ctrl.el);
+    wrap.appendChild(row);
+    readers[key] = ctrl.read;
+  }
+  return {
+    el: wrap,
+    read() {
+      const out = {};
+      for (const [k, r] of Object.entries(readers)) {
+        const v = r();
+        if (v !== undefined && v !== "" && !(typeof v === "object" && v !== null && Object.keys(v).length === 0))
+          out[k] = v;
+      }
+      return out;
+    },
+  };
+}
+
+function buildArray(schema, root, value) {
+  const wrap = document.createElement("div");
+  wrap.className = "sf-array";
+  const list = document.createElement("div");
+  const readers = [];
+  const addItem = (v) => {
+    const item = document.createElement("div");
+    item.className = "sf-array-item";
+    const ctrl = build(schema.items || {}, root, v, false);
+    const del = document.createElement("button");
+    del.type = "button";
+    del.className = "btn-ghost";
+    del.textContent = "✕";
+    del.onclick = () => {
+      const i = readers.indexOf(ctrl.read);
+      if (i >= 0) readers.splice(i, 1);
+      item.remove();
+    };
+    item.appendChild(ctrl.el);
+    item.appendChild(del);
+    list.appendChild(item);
+    readers.push(ctrl.read);
+  };
+  (Array.isArray(value) ? value : []).forEach(addItem);
+  const add = document.createElement("button");
+  add.type = "button";
+  add.className = "btn-ghost";
+  add.textContent = "+ add";
+  add.onclick = () => addItem(undefined);
+  wrap.appendChild(list);
+  wrap.appendChild(add);
+  return { el: wrap, read: () => readers.map((r) => r()).filter((v) => v !== undefined && v !== "") };
+}
+
+function buildDiscriminated(variants, root, value, desc) {
+  const wrap = document.createElement("div");
+  wrap.className = "sf-union";
+  const select = document.createElement("select");
+  const bodies = {};
+  let current = null;
+  const render = (tag) => {
+    if (current) current.el.remove();
+    const variant = variants.map((v) => resolveRef(v, root)).find((v) => discriminatorConst(v) === tag);
+    // strip the const `type` prop; render the rest (usually a `config` object).
+    const sub = stripConst(variant);
+    current = build(sub, root, value && value.type === tag ? value : {}, false);
+    bodies[tag] = current;
+    wrap.appendChild(current.el);
+  };
+  for (const v of variants) {
+    const tag = discriminatorConst(resolveRef(v, root));
+    const opt = document.createElement("option");
+    opt.value = tag;
+    opt.textContent = tag;
+    select.appendChild(opt);
+  }
+  select.value = (value && value.type) || select.options[0]?.value;
+  select.onchange = () => render(select.value);
+  wrap.appendChild(select);
+  if (desc) wrap.insertAdjacentHTML("beforeend", desc);
+  render(select.value);
+  return {
+    el: wrap,
+    read() {
+      const tag = select.value;
+      return { type: tag, ...current.read() };
+    },
+  };
+}
+
+function buildEnum(schema, value, desc) {
+  const sel = document.createElement("select");
+  for (const v of schema.enum) {
+    const o = document.createElement("option");
+    o.value = String(v);
+    o.textContent = String(v);
+    sel.appendChild(o);
+  }
+  if (value !== undefined) sel.value = String(value);
+  else if (schema.default !== undefined) sel.value = String(schema.default);
+  return withHelp(sel, desc, () => sel.value);
+}
+
+function buildBool(schema, value, desc) {
+  const cb = document.createElement("input");
+  cb.type = "checkbox";
+  cb.checked = value !== undefined ? !!value : !!schema.default;
+  return withHelp(cb, desc, () => cb.checked);
+}
+
+function buildNumber(schema, value, type, desc) {
+  const inp = document.createElement("input");
+  inp.type = "number";
+  if (type === "integer") inp.step = "1";
+  if (value !== undefined) inp.value = value;
+  else if (schema.default !== undefined) inp.value = schema.default;
+  if (schema.description) inp.placeholder = firstSentence(schema.description);
+  return withHelp(inp, desc, () => (inp.value === "" ? undefined : Number(inp.value)));
+}
+
+function buildString(schema, value, desc) {
+  const inp = document.createElement("input");
+  inp.type = /password|secret|token|key/i.test(schema.title || "") ? "password" : "text";
+  if (value !== undefined) inp.value = value;
+  else if (schema.default !== undefined) inp.value = schema.default;
+  if (schema.description) inp.placeholder = firstSentence(schema.description);
+  return withHelp(inp, desc, () => (inp.value === "" ? undefined : inp.value));
+}
+
+function buildRaw(value) {
+  const ta = document.createElement("textarea");
+  ta.className = "sf-raw";
+  ta.placeholder = "raw JSON";
+  if (value !== undefined) ta.value = JSON.stringify(value, null, 2);
+  return {
+    el: ta,
+    read() {
+      if (!ta.value.trim()) return undefined;
+      try { return JSON.parse(ta.value); } catch { return ta.value; }
+    },
+  };
+}
+
+function withHelp(el, desc, read) {
+  if (!desc) return { el, read };
+  const wrap = document.createElement("div");
+  wrap.appendChild(el);
+  wrap.insertAdjacentHTML("beforeend", desc);
+  return { el: wrap, read };
+}
+
+// --- schema introspection helpers ---
+function jsonType(schema, value) {
+  if (typeof schema.type === "string") return schema.type;
+  if (Array.isArray(schema.type)) return schema.type.find((t) => t !== "null") || "string";
+  if (schema.properties) return "object";
+  if (schema.items) return "array";
+  if (schema.enum) return typeof schema.enum[0];
+  if (value !== undefined) return Array.isArray(value) ? "array" : typeof value;
+  return "string";
+}
+function discriminatorConst(variant) {
+  const p = variant && variant.properties && variant.properties.type;
+  if (!p) return null;
+  if (p.const !== undefined) return p.const;
+  if (Array.isArray(p.enum) && p.enum.length === 1) return p.enum[0];
+  return null;
+}
+function stripConst(variant) {
+  const props = { ...(variant.properties || {}) };
+  delete props.type;
+  return { type: "object", properties: props, required: (variant.required || []).filter((r) => r !== "type") };
+}
+function firstSentence(s) {
+  const m = s.split(/\.\s/)[0];
+  return (m.length > 120 ? m.slice(0, 117) + "…" : m).replace(/\.$/, "");
+}
+function escapeHtml(s) {
+  return s.replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
+}
+
+// Public: render a form for `schema`; returns { el, read() } where read() yields
+// the config object.
+export function renderSchemaForm(schema, value) {
+  uid = 0;
+  return build(schema, schema, value, true);
+}

--- a/cli/src/serve/ui/sse.js
+++ b/cli/src/serve/ui/sse.js
@@ -30,7 +30,7 @@ export function streamLogs(runId, handlers) {
       for (;;) {
         const { value, done } = await reader.read();
         if (done) break;
-        buf += decoder.decode(value, { stream: true });
+        buf += decoder.decode(value, { stream: true }).replace(/\r\n/g, "\n");
         let idx;
         while ((idx = buf.indexOf("\n\n")) !== -1) {
           dispatch(buf.slice(0, idx), handlers);

--- a/cli/src/serve/ui/sse.js
+++ b/cli/src/serve/ui/sse.js
@@ -1,0 +1,60 @@
+import { authHeaders } from "./api.js";
+
+// Stream a run's logs. Calls handlers.onLog(line) / onTruncated(msg) / onEnd()
+// / onError(err). Returns an AbortController — call .abort() to stop.
+export function streamLogs(runId, handlers) {
+  const ctrl = new AbortController();
+  (async () => {
+    let resp;
+    try {
+      resp = await fetch(`/v1/runs/${encodeURIComponent(runId)}/logs`, {
+        headers: authHeaders({ Accept: "text/event-stream" }),
+        signal: ctrl.signal,
+      });
+    } catch (err) {
+      if (!ctrl.signal.aborted) handlers.onError?.(err);
+      return;
+    }
+    if (resp.status === 404) {
+      handlers.onExpired?.();
+      return;
+    }
+    if (!resp.ok || !resp.body) {
+      handlers.onError?.(new Error(`logs HTTP ${resp.status}`));
+      return;
+    }
+    const reader = resp.body.getReader();
+    const decoder = new TextDecoder();
+    let buf = "";
+    try {
+      for (;;) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buf += decoder.decode(value, { stream: true });
+        let idx;
+        while ((idx = buf.indexOf("\n\n")) !== -1) {
+          dispatch(buf.slice(0, idx), handlers);
+          buf = buf.slice(idx + 2);
+        }
+      }
+    } catch (err) {
+      if (!ctrl.signal.aborted) handlers.onError?.(err);
+    }
+  })();
+  return ctrl;
+}
+
+// Parse one SSE frame ("event: X\ndata: Y" lines; data may span multiple lines).
+function dispatch(frame, handlers) {
+  let event = "message";
+  const data = [];
+  for (const line of frame.split("\n")) {
+    if (line.startsWith("event:")) event = line.slice(6).trim();
+    else if (line.startsWith("data:")) data.push(line.slice(5).replace(/^ /, ""));
+    // lines beginning with ":" are comments (keep-alive) — ignore.
+  }
+  const payload = data.join("\n");
+  if (event === "log") handlers.onLog?.(payload);
+  else if (event === "truncated") handlers.onTruncated?.(payload);
+  else if (event === "end") handlers.onEnd?.();
+}

--- a/cli/src/serve/ui/styles.css
+++ b/cli/src/serve/ui/styles.css
@@ -1,0 +1,2 @@
+/* placeholder — replaced in Task 13 */
+:root { color-scheme: light dark; }

--- a/cli/src/serve/ui/styles.css
+++ b/cli/src/serve/ui/styles.css
@@ -1,2 +1,751 @@
-/* placeholder — replaced in Task 13 */
-:root { color-scheme: light dark; }
+/* ============================================================================
+   faucet stream — console
+   Aesthetic: "instrument panel" — a precise technical control plane. Teal is the
+   signal color (flow/liquid). Monospace for IDs/metrics/logs. Dark-first with a
+   clean light mode. Offline: system font stacks only (no CDN).
+   ========================================================================== */
+
+/* ---- design tokens : light (default) ---- */
+:root,
+[data-theme="light"] {
+  color-scheme: light;
+
+  --bg: #eef2f3;
+  --bg-grad: radial-gradient(1200px 600px at 100% -10%, #dff0ee 0%, transparent 60%),
+             radial-gradient(900px 500px at -10% 0%, #e7eef0 0%, transparent 55%);
+  --surface: #ffffff;
+  --surface-2: #f6f9f9;
+  --surface-sunken: #eef2f3;
+  --border: #d6dee0;
+  --border-strong: #c2ced1;
+  --ink: #0f172a;
+  --ink-dim: #51616b;
+  --ink-faint: #8595a0;
+
+  --brand: #0d9488;
+  --brand-strong: #14b8a6;
+  --brand-tint: rgba(20, 184, 166, 0.10);
+  --brand-ring: rgba(20, 184, 166, 0.35);
+
+  --ok: #0e9f6e;
+  --fail: #e02424;
+  --queued: #c2700b;
+  --cancelled: #64748b;
+  --running: var(--brand-strong);
+
+  --term-bg: #0c1418;
+  --term-ink: #c7d6d2;
+
+  --shadow-1: 0 1px 2px rgba(15, 23, 42, 0.06), 0 1px 3px rgba(15, 23, 42, 0.08);
+  --shadow-2: 0 8px 24px rgba(15, 23, 42, 0.12);
+  --shadow-pop: 0 12px 40px rgba(15, 23, 42, 0.18);
+
+  --r-sm: 6px;
+  --r: 10px;
+  --r-lg: 16px;
+  --sp: 8px;
+
+  --font-sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --font-mono: ui-monospace, "SF Mono", "JetBrains Mono", "Cascadia Code", Menlo, Consolas, "Liberation Mono", monospace;
+}
+
+/* ---- design tokens : dark ---- */
+[data-theme="dark"] {
+  color-scheme: dark;
+
+  --bg: #070d11;
+  --bg-grad: radial-gradient(1100px 560px at 100% -10%, rgba(20, 184, 166, 0.10) 0%, transparent 55%),
+             radial-gradient(800px 500px at -5% -5%, rgba(20, 184, 166, 0.06) 0%, transparent 50%);
+  --surface: #0e171d;
+  --surface-2: #121e25;
+  --surface-sunken: #0a1116;
+  --border: #1d2c34;
+  --border-strong: #294049;
+  --ink: #e6f0ee;
+  --ink-dim: #93a7a3;
+  --ink-faint: #5f757a;
+
+  --brand: #14b8a6;
+  --brand-strong: #2dd4bf;
+  --brand-tint: rgba(45, 212, 191, 0.12);
+  --brand-ring: rgba(45, 212, 191, 0.40);
+
+  --ok: #34d399;
+  --fail: #f87171;
+  --queued: #fbbf24;
+  --cancelled: #94a3b8;
+  --running: var(--brand-strong);
+
+  --term-bg: #050a0d;
+  --term-ink: #b8ccc7;
+
+  --shadow-1: 0 1px 2px rgba(0, 0, 0, 0.4);
+  --shadow-2: 0 10px 30px rgba(0, 0, 0, 0.5);
+  --shadow-pop: 0 16px 50px rgba(0, 0, 0, 0.6);
+}
+
+/* auto = follow the OS when no explicit choice */
+@media (prefers-color-scheme: dark) {
+  [data-theme="auto"] {
+    color-scheme: dark;
+    --bg: #070d11;
+    --bg-grad: radial-gradient(1100px 560px at 100% -10%, rgba(20, 184, 166, 0.10) 0%, transparent 55%),
+               radial-gradient(800px 500px at -5% -5%, rgba(20, 184, 166, 0.06) 0%, transparent 50%);
+    --surface: #0e171d;
+    --surface-2: #121e25;
+    --surface-sunken: #0a1116;
+    --border: #1d2c34;
+    --border-strong: #294049;
+    --ink: #e6f0ee;
+    --ink-dim: #93a7a3;
+    --ink-faint: #5f757a;
+    --brand: #14b8a6;
+    --brand-strong: #2dd4bf;
+    --brand-tint: rgba(45, 212, 191, 0.12);
+    --brand-ring: rgba(45, 212, 191, 0.40);
+    --ok: #34d399;
+    --fail: #f87171;
+    --queued: #fbbf24;
+    --cancelled: #94a3b8;
+    --term-bg: #050a0d;
+    --term-ink: #b8ccc7;
+    --shadow-1: 0 1px 2px rgba(0, 0, 0, 0.4);
+    --shadow-2: 0 10px 30px rgba(0, 0, 0, 0.5);
+    --shadow-pop: 0 16px 50px rgba(0, 0, 0, 0.6);
+  }
+}
+
+/* ---- reset / base ---- */
+*,
+*::before,
+*::after { box-sizing: border-box; }
+
+html, body { height: 100%; }
+
+body {
+  margin: 0;
+  font-family: var(--font-sans);
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--ink);
+  background-color: var(--bg);
+  background-image: var(--bg-grad);
+  background-attachment: fixed;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+h1 { font-size: 1.5rem; font-weight: 650; letter-spacing: -0.02em; margin: 0; }
+h2 { font-size: 1.0rem; font-weight: 600; letter-spacing: -0.01em; margin: 1.6rem 0 0.6rem; color: var(--ink); }
+h3 { font-size: 0.82rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.08em; color: var(--ink-dim); margin: 0 0 0.5rem; }
+
+a { color: var(--brand); text-decoration: none; }
+button { font-family: inherit; }
+
+::selection { background: var(--brand-ring); color: var(--ink); }
+
+:focus-visible {
+  outline: 2px solid var(--brand-strong);
+  outline-offset: 2px;
+  border-radius: var(--r-sm);
+}
+
+/* scrollbars */
+* { scrollbar-width: thin; scrollbar-color: var(--border-strong) transparent; }
+*::-webkit-scrollbar { width: 10px; height: 10px; }
+*::-webkit-scrollbar-thumb { background: var(--border-strong); border-radius: 99px; border: 2px solid transparent; background-clip: content-box; }
+
+/* ============================================================================
+   top bar
+   ========================================================================== */
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  height: 56px;
+  padding: 0 20px;
+  background: color-mix(in srgb, var(--surface) 80%, transparent);
+  backdrop-filter: saturate(140%) blur(10px);
+  border-bottom: 1px solid var(--border);
+}
+/* a thin "flow" line of brand color under the bar */
+.topbar::after {
+  content: "";
+  position: absolute;
+  left: 0; right: 0; bottom: -1px;
+  height: 2px;
+  background: linear-gradient(90deg, transparent, var(--brand-strong), transparent);
+  opacity: 0.5;
+}
+
+.brand { display: inline-flex; align-items: center; gap: 10px; color: var(--ink); }
+.brand-mark {
+  width: 26px; height: 26px;
+  filter: drop-shadow(0 0 6px var(--brand-ring));
+}
+.brand-name { font-size: 1.02rem; letter-spacing: -0.01em; }
+.brand-name b { font-weight: 700; }
+.brand-name { color: var(--brand); font-weight: 400; }
+.brand-name b { color: var(--ink); }
+
+.nav { display: flex; gap: 2px; }
+.nav button {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--ink-dim);
+  font-size: 0.9rem;
+  font-weight: 550;
+  padding: 7px 12px;
+  border-radius: var(--r-sm);
+  cursor: pointer;
+  transition: color 0.15s, background 0.15s;
+}
+.nav button:hover { color: var(--ink); background: var(--surface-2); }
+
+.spacer { flex: 1; }
+
+.icon-btn {
+  appearance: none;
+  width: 34px; height: 34px;
+  display: inline-grid; place-items: center;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--ink-dim);
+  border-radius: var(--r-sm);
+  cursor: pointer;
+  font-size: 0.95rem;
+  transition: border-color 0.15s, color 0.15s, transform 0.08s;
+}
+.icon-btn:hover { color: var(--brand); border-color: var(--brand-ring); }
+.icon-btn:active { transform: translateY(1px); }
+
+/* ============================================================================
+   layout
+   ========================================================================== */
+.view { display: block; }
+.page {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 28px 24px 64px;
+  animation: rise 0.28s ease both;
+}
+@keyframes rise { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: none; } }
+
+.page-head {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-bottom: 18px;
+}
+.page-head h1 { margin-right: auto; }
+
+.empty {
+  color: var(--ink-faint);
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  text-align: center;
+  padding: 40px 16px;
+  border: 1px dashed var(--border);
+  border-radius: var(--r);
+  background: var(--surface);
+}
+
+/* ============================================================================
+   buttons
+   ========================================================================== */
+.btn-primary, .btn-ghost, .btn-danger {
+  appearance: none;
+  font-size: 0.88rem;
+  font-weight: 600;
+  padding: 8px 14px;
+  border-radius: var(--r-sm);
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: transform 0.08s, background 0.15s, border-color 0.15s, color 0.15s, box-shadow 0.15s;
+  white-space: nowrap;
+}
+.btn-primary {
+  background: var(--brand);
+  color: #fff;
+  box-shadow: 0 1px 0 rgba(0,0,0,0.05), 0 6px 18px var(--brand-tint);
+}
+.btn-primary:hover { background: var(--brand-strong); box-shadow: 0 0 0 4px var(--brand-tint); }
+.btn-primary:active { transform: translateY(1px); }
+
+.btn-ghost {
+  background: var(--surface);
+  color: var(--ink-dim);
+  border-color: var(--border);
+}
+.btn-ghost:hover { color: var(--ink); border-color: var(--border-strong); background: var(--surface-2); }
+.btn-ghost.active { color: var(--brand); border-color: var(--brand-ring); background: var(--brand-tint); }
+.btn-ghost:active { transform: translateY(1px); }
+
+.btn-danger {
+  background: transparent;
+  color: var(--fail);
+  border-color: color-mix(in srgb, var(--fail) 45%, transparent);
+}
+.btn-danger:hover { background: var(--fail); color: #fff; }
+
+/* ============================================================================
+   filters
+   ========================================================================== */
+.filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 16px;
+  padding: 12px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r);
+  box-shadow: var(--shadow-1);
+}
+
+input, select, textarea {
+  font-family: var(--font-sans);
+  font-size: 0.88rem;
+  color: var(--ink);
+  background: var(--surface-sunken);
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  padding: 7px 10px;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+input:focus, select:focus, textarea:focus {
+  outline: none;
+  border-color: var(--brand-ring);
+  box-shadow: 0 0 0 3px var(--brand-tint);
+}
+input::placeholder, textarea::placeholder { color: var(--ink-faint); }
+
+/* ============================================================================
+   runs list
+   ========================================================================== */
+.runs-list { display: flex; flex-direction: column; gap: 6px; }
+
+.run-row {
+  display: grid;
+  grid-template-columns: 120px 1fr auto auto auto;
+  align-items: center;
+  gap: 14px;
+  padding: 12px 16px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-left: 3px solid transparent;
+  border-radius: var(--r);
+  cursor: pointer;
+  transition: border-color 0.15s, transform 0.08s, box-shadow 0.15s, background 0.15s;
+}
+.run-row:hover {
+  border-color: var(--border-strong);
+  border-left-color: var(--brand-strong);
+  box-shadow: var(--shadow-1);
+  transform: translateX(2px);
+}
+.run-name { font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.run-meta {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--ink-dim);
+  text-align: right;
+}
+.run-time { color: var(--ink-faint); min-width: 150px; }
+
+#r-more { align-self: center; margin: 16px auto 0; }
+
+/* ============================================================================
+   status pills
+   ========================================================================== */
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  padding: 3px 9px;
+  border-radius: 99px;
+  border: 1px solid;
+  white-space: nowrap;
+}
+.pill::before {
+  content: "";
+  width: 6px; height: 6px;
+  border-radius: 99px;
+  background: currentColor;
+}
+.pill-completed { color: var(--ok);        border-color: color-mix(in srgb, var(--ok) 40%, transparent);        background: color-mix(in srgb, var(--ok) 12%, transparent); }
+.pill-failed    { color: var(--fail);      border-color: color-mix(in srgb, var(--fail) 40%, transparent);      background: color-mix(in srgb, var(--fail) 12%, transparent); }
+.pill-queued    { color: var(--queued);    border-color: color-mix(in srgb, var(--queued) 40%, transparent);    background: color-mix(in srgb, var(--queued) 12%, transparent); }
+.pill-cancelled { color: var(--cancelled); border-color: color-mix(in srgb, var(--cancelled) 40%, transparent); background: color-mix(in srgb, var(--cancelled) 12%, transparent); }
+.pill-running   { color: var(--running);   border-color: color-mix(in srgb, var(--running) 45%, transparent);   background: color-mix(in srgb, var(--running) 14%, transparent); }
+.pill-running::before { animation: pulse 1.4s ease-in-out infinite; }
+@keyframes pulse {
+  0%, 100% { box-shadow: 0 0 0 0 var(--running); opacity: 1; }
+  50%      { box-shadow: 0 0 0 4px transparent; opacity: 0.55; }
+}
+
+/* ============================================================================
+   run detail
+   ========================================================================== */
+.detail-actions { display: flex; gap: 8px; }
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 10px 18px;
+  padding: 16px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r);
+  box-shadow: var(--shadow-1);
+}
+.detail-grid > div { font-family: var(--font-mono); font-size: 0.82rem; color: var(--ink-dim); }
+.detail-grid > div b { color: var(--ink); }
+
+.error-box {
+  margin-top: 12px;
+  padding: 12px 14px;
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  color: var(--fail);
+  background: color-mix(in srgb, var(--fail) 8%, transparent);
+  border: 1px solid color-mix(in srgb, var(--fail) 30%, transparent);
+  border-radius: var(--r-sm);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* tables */
+.tbl {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.84rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r);
+  overflow: hidden;
+}
+.tbl th {
+  text-align: left;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--ink-faint);
+  font-weight: 600;
+  padding: 9px 12px;
+  background: var(--surface-2);
+  border-bottom: 1px solid var(--border);
+}
+.tbl td {
+  padding: 9px 12px;
+  border-bottom: 1px solid var(--border);
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--ink-dim);
+  vertical-align: top;
+}
+.tbl tbody tr:last-child td { border-bottom: 0; }
+.tbl tbody tr:hover td { background: var(--surface-2); }
+
+/* logs — terminal surface */
+.logs {
+  margin: 0;
+  max-height: 460px;
+  overflow: auto;
+  padding: 14px 16px;
+  background: var(--term-bg);
+  color: var(--term-ink);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--r);
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  line-height: 1.55;
+  white-space: pre-wrap;
+  word-break: break-word;
+  box-shadow: inset 0 0 60px rgba(0,0,0,0.35);
+}
+.logs .log-truncated { color: var(--queued); font-style: italic; }
+.logs .log-end { color: var(--brand-strong); font-weight: 600; }
+
+/* ============================================================================
+   submit
+   ========================================================================== */
+.mode-toggle { display: inline-flex; gap: 4px; padding: 3px; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--r); }
+.mode-toggle .btn-ghost { border-color: transparent; background: transparent; }
+
+.submit-mode { margin-top: 8px; }
+
+.code {
+  width: 100%;
+  min-height: 320px;
+  resize: vertical;
+  font-family: var(--font-mono);
+  font-size: 0.84rem;
+  line-height: 1.6;
+  tab-size: 2;
+  background: var(--term-bg);
+  color: var(--term-ink);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--r);
+  padding: 14px 16px;
+}
+
+.submit-opts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px 20px;
+  align-items: center;
+  margin: 18px 0;
+  padding: 14px 16px;
+  border: 1px solid var(--border);
+  border-radius: var(--r);
+  background: var(--surface);
+}
+.submit-opts label { display: inline-flex; align-items: center; gap: 8px; font-size: 0.84rem; color: var(--ink-dim); }
+.submit-opts input[type="text"], .submit-opts input:not([type="checkbox"]), .submit-opts select { min-width: 120px; }
+
+.submit-actions { display: flex; gap: 10px; }
+
+.submit-out {
+  margin-top: 16px;
+  padding: 14px 16px;
+  background: var(--term-bg);
+  color: var(--term-ink);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--r);
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 360px;
+  overflow: auto;
+}
+
+/* wizard */
+.wizard-step {
+  padding: 16px;
+  margin-bottom: 12px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r);
+  box-shadow: var(--shadow-1);
+}
+.wizard-step > label { display: flex; flex-direction: column; gap: 4px; max-width: 320px; font-size: 0.82rem; color: var(--ink-dim); margin-bottom: 10px; }
+.wizard-tx {
+  padding: 12px;
+  margin: 8px 0;
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--brand-ring);
+  border-radius: var(--r-sm);
+  background: var(--surface-2);
+}
+.wizard-tx > label { display: flex; flex-direction: column; gap: 4px; max-width: 320px; }
+.sf-host { margin-top: 10px; }
+
+/* ============================================================================
+   schema-form renderer
+   ========================================================================== */
+.sf-object {
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  padding: 12px 14px;
+  margin: 0;
+  background: var(--surface-sunken);
+}
+.sf-field {
+  display: grid;
+  grid-template-columns: 180px 1fr;
+  gap: 12px;
+  align-items: start;
+  padding: 7px 0;
+  border-bottom: 1px dashed var(--border);
+}
+.sf-field:last-child { border-bottom: 0; }
+.sf-field > label {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--ink-dim);
+  padding-top: 7px;
+  word-break: break-word;
+}
+.sf-field input:not([type="checkbox"]),
+.sf-field select,
+.sf-field textarea { width: 100%; }
+.sf-field input[type="checkbox"] { width: 16px; height: 16px; accent-color: var(--brand); }
+
+.sf-array { display: flex; flex-direction: column; gap: 6px; }
+.sf-array-item { display: flex; gap: 8px; align-items: flex-start; }
+.sf-array-item > :first-child { flex: 1; }
+.sf-array > .btn-ghost { align-self: flex-start; padding: 4px 10px; font-size: 0.8rem; }
+
+.sf-union { display: flex; flex-direction: column; gap: 8px; }
+.sf-union > select { max-width: 220px; }
+
+.sf-raw { width: 100%; min-height: 64px; font-family: var(--font-mono); font-size: 0.8rem; }
+
+.help { display: block; color: var(--ink-faint); font-size: 0.74rem; margin-top: 4px; line-height: 1.4; }
+
+/* ============================================================================
+   schema explorer
+   ========================================================================== */
+.schemas-page {
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  gap: 24px;
+  align-items: start;
+}
+.schema-list {
+  position: sticky;
+  top: 76px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  max-height: calc(100vh - 100px);
+  overflow: auto;
+  padding-right: 4px;
+}
+.schema-group { display: flex; flex-direction: column; gap: 3px; }
+.schema-item {
+  appearance: none;
+  text-align: left;
+  border: 0;
+  background: transparent;
+  color: var(--ink-dim);
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  padding: 6px 10px;
+  border-radius: var(--r-sm);
+  cursor: pointer;
+  border-left: 2px solid transparent;
+  transition: background 0.12s, color 0.12s, border-color 0.12s;
+}
+.schema-item:hover { background: var(--surface-2); color: var(--ink); }
+.schema-item.active { background: var(--brand-tint); color: var(--brand); border-left-color: var(--brand-strong); }
+.tag {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  color: var(--ink-dim);
+  padding: 2px 8px;
+  margin: 2px 4px 2px 0;
+  border: 1px solid var(--border);
+  border-radius: 99px;
+}
+.schema-view {
+  min-width: 0;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r);
+  padding: 18px 20px;
+  box-shadow: var(--shadow-1);
+}
+.schema-view h2 { margin-top: 0; font-family: var(--font-mono); }
+.raw { margin-top: 14px; }
+.raw summary { cursor: pointer; color: var(--ink-dim); font-size: 0.82rem; }
+.raw pre {
+  margin-top: 10px;
+  padding: 14px;
+  background: var(--term-bg);
+  color: var(--term-ink);
+  border-radius: var(--r-sm);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  overflow: auto;
+  max-height: 420px;
+}
+
+/* ============================================================================
+   token modal
+   ========================================================================== */
+.modal {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: none;
+  place-items: center;
+  background: rgba(4, 8, 11, 0.55);
+  backdrop-filter: blur(4px);
+  padding: 20px;
+}
+.modal.open { display: grid; animation: fade 0.18s ease both; }
+@keyframes fade { from { opacity: 0; } to { opacity: 1; } }
+
+.modal-card {
+  width: min(420px, 100%);
+  background: var(--surface);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--r-lg);
+  padding: 22px 22px 18px;
+  box-shadow: var(--shadow-pop);
+  animation: pop 0.2s cubic-bezier(0.2, 0.9, 0.3, 1.2) both;
+}
+@keyframes pop { from { opacity: 0; transform: translateY(8px) scale(0.98); } to { opacity: 1; transform: none; } }
+.modal-card h2 { margin: 0 0 6px; }
+.modal-card p { margin: 0 0 14px; color: var(--ink-dim); font-size: 0.86rem; }
+.modal-card input { width: 100%; }
+.modal-actions { display: flex; justify-content: flex-end; gap: 10px; margin-top: 16px; }
+
+/* ============================================================================
+   toasts
+   ========================================================================== */
+.toasts {
+  position: fixed;
+  right: 18px;
+  bottom: 18px;
+  z-index: 60;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-width: 360px;
+}
+.toast {
+  padding: 11px 14px;
+  font-size: 0.85rem;
+  background: var(--surface);
+  color: var(--ink);
+  border: 1px solid var(--border-strong);
+  border-left: 3px solid var(--brand-strong);
+  border-radius: var(--r-sm);
+  box-shadow: var(--shadow-2);
+  animation: toast-in 0.22s ease both;
+  word-break: break-word;
+}
+@keyframes toast-in { from { opacity: 0; transform: translateX(12px); } to { opacity: 1; transform: none; } }
+.toast-error { border-left-color: var(--fail); }
+.toast-info { border-left-color: var(--brand-strong); }
+
+/* ============================================================================
+   responsive
+   ========================================================================== */
+@media (max-width: 760px) {
+  .topbar { gap: 10px; padding: 0 12px; }
+  .brand-name { display: none; }
+  .page { padding: 18px 14px 48px; }
+  .run-row { grid-template-columns: auto 1fr; row-gap: 4px; }
+  .run-row .run-meta { text-align: left; }
+  .run-time { min-width: 0; }
+  .schemas-page { grid-template-columns: 1fr; }
+  .schema-list { position: static; max-height: none; }
+  .sf-field { grid-template-columns: 1fr; gap: 4px; }
+  .sf-field > label { padding-top: 0; }
+}
+
+/* ============================================================================
+   reduced motion
+   ========================================================================== */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+  }
+}

--- a/cli/src/serve/ui/utils.js
+++ b/cli/src/serve/ui/utils.js
@@ -1,0 +1,9 @@
+// Small shared helpers for the console UI.
+
+/** Escape a string for safe interpolation into innerHTML. */
+export function escapeHtml(s) {
+  return String(s ?? "").replace(
+    /[&<>"]/g,
+    (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" })[c],
+  );
+}

--- a/cli/src/serve/ui/views/detail.js
+++ b/cli/src/serve/ui/views/detail.js
@@ -1,0 +1,108 @@
+import { api, toast } from "../api.js";
+import { streamLogs } from "../sse.js";
+import { navigate } from "../router.js";
+import { fmtTime } from "./runs.js";
+
+const TERMINAL = ["completed", "failed", "cancelled"];
+
+export async function renderDetail(container, { id }) {
+  let pollTimer = null;
+  let logCtrl = null;
+
+  container.innerHTML = `
+    <div class="page">
+      <div class="page-head">
+        <button class="btn-ghost" id="back">← Runs</button>
+        <div class="detail-actions">
+          <button class="btn-ghost" id="cancel" hidden>Cancel</button>
+          <button class="btn-danger" id="delete" hidden>Delete</button>
+        </div>
+      </div>
+      <div id="detail-head"></div>
+      <h2>Invocations</h2>
+      <div id="invocations"></div>
+      <h2>Logs</h2>
+      <pre id="logs" class="logs"></pre>
+    </div>`;
+
+  container.querySelector("#back").onclick = () => navigate("#/runs");
+
+  const logsEl = container.querySelector("#logs");
+  function appendLog(text, cls = "") {
+    const atBottom = logsEl.scrollHeight - logsEl.scrollTop - logsEl.clientHeight < 40;
+    const span = document.createElement("span");
+    if (cls) span.className = cls;
+    span.textContent = text + "\n";
+    logsEl.appendChild(span);
+    if (atBottom) logsEl.scrollTop = logsEl.scrollHeight;
+  }
+
+  async function load() {
+    let rec;
+    try {
+      rec = await api(`/v1/runs/${encodeURIComponent(id)}`);
+    } catch (e) {
+      container.querySelector("#detail-head").innerHTML = `<div class="empty">${e.message}</div>`;
+      return;
+    }
+    renderHead(rec);
+    const live = !TERMINAL.includes(rec.status);
+    container.querySelector("#cancel").hidden = !(rec.status === "running" || rec.status === "queued");
+    container.querySelector("#delete").hidden = !TERMINAL.includes(rec.status);
+    if (live) {
+      clearTimeout(pollTimer);
+      pollTimer = setTimeout(load, 3000);
+    }
+  }
+
+  function renderHead(rec) {
+    const errors = rec.error ? `<div class="error-box">${escapeHtml(rec.error)}</div>` : "";
+    container.querySelector("#detail-head").innerHTML = `
+      <div class="detail-grid">
+        <div><span class="pill pill-${rec.status}">${rec.status}</span></div>
+        <div><b>${rec.name || rec.run_id}</b></div>
+        <div>submitted ${fmtTime(rec.submitted_at)}</div>
+        <div>started ${fmtTime(rec.started_at)}</div>
+        <div>finished ${fmtTime(rec.finished_at)}</div>
+        <div>${rec.records_written ?? 0} rows</div>
+        ${rec.idempotency_key ? `<div>idem: ${escapeHtml(rec.idempotency_key)}</div>` : ""}
+      </div>${errors}`;
+    const inv = container.querySelector("#invocations");
+    inv.innerHTML =
+      `<table class="tbl"><thead><tr><th>row</th><th>parent key</th><th>rows</th><th>error</th></tr></thead><tbody>` +
+      (rec.invocations || [])
+        .map(
+          (i) =>
+            `<tr><td>${escapeHtml(i.row_id)}</td><td>${escapeHtml(i.parent_record_key || "—")}</td><td>${i.records_written ?? 0}</td><td>${escapeHtml(i.error || "")}</td></tr>`,
+        )
+        .join("") +
+      `</tbody></table>`;
+  }
+
+  container.querySelector("#cancel").onclick = async () => {
+    try { await api(`/v1/runs/${encodeURIComponent(id)}/cancel`, { method: "POST" }); toast("cancel requested"); load(); }
+    catch (e) { toast(e.message, "error"); }
+  };
+  container.querySelector("#delete").onclick = async () => {
+    try { await api(`/v1/runs/${encodeURIComponent(id)}`, { method: "DELETE" }); navigate("#/runs"); }
+    catch (e) { toast(e.message, "error"); }
+  };
+
+  logCtrl = streamLogs(id, {
+    onLog: (l) => appendLog(l),
+    onTruncated: (m) => appendLog(`— ${m} —`, "log-truncated"),
+    onEnd: () => appendLog("— end of logs —", "log-end"),
+    onExpired: () => appendLog("— logs expired —", "log-end"),
+    onError: (e) => appendLog(`— log stream error: ${e.message} —`, "log-truncated"),
+  });
+
+  await load();
+  return () => {
+    clearTimeout(pollTimer);
+    logCtrl?.abort();
+  };
+}
+
+function escapeHtml(s) {
+  return String(s ?? "").replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
+}

--- a/cli/src/serve/ui/views/detail.js
+++ b/cli/src/serve/ui/views/detail.js
@@ -2,6 +2,7 @@ import { api, toast } from "../api.js";
 import { streamLogs } from "../sse.js";
 import { navigate } from "../router.js";
 import { fmtTime } from "./runs.js";
+import { escapeHtml } from "../utils.js";
 
 const TERMINAL = ["completed", "failed", "cancelled"];
 
@@ -42,7 +43,12 @@ export async function renderDetail(container, { id }) {
     try {
       rec = await api(`/v1/runs/${encodeURIComponent(id)}`);
     } catch (e) {
-      container.querySelector("#detail-head").innerHTML = `<div class="empty">${e.message}</div>`;
+      container.querySelector("#detail-head").innerHTML = `<div class="empty">${escapeHtml(e.message)}</div>`;
+      // Keep polling through a transient (network / 5xx) failure; stop on 4xx (e.g. a deleted run).
+      if (e.status === undefined || e.status >= 500) {
+        clearTimeout(pollTimer);
+        pollTimer = setTimeout(load, 3000);
+      }
       return;
     }
     renderHead(rec);
@@ -60,7 +66,7 @@ export async function renderDetail(container, { id }) {
     container.querySelector("#detail-head").innerHTML = `
       <div class="detail-grid">
         <div><span class="pill pill-${rec.status}">${rec.status}</span></div>
-        <div><b>${rec.name || rec.run_id}</b></div>
+        <div><b>${escapeHtml(rec.name || rec.run_id)}</b></div>
         <div>submitted ${fmtTime(rec.submitted_at)}</div>
         <div>started ${fmtTime(rec.started_at)}</div>
         <div>finished ${fmtTime(rec.finished_at)}</div>
@@ -101,8 +107,4 @@ export async function renderDetail(container, { id }) {
     clearTimeout(pollTimer);
     logCtrl?.abort();
   };
-}
-
-function escapeHtml(s) {
-  return String(s ?? "").replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
 }

--- a/cli/src/serve/ui/views/runs.js
+++ b/cli/src/serve/ui/views/runs.js
@@ -1,0 +1,97 @@
+import { api, toast } from "../api.js";
+import { navigate } from "../router.js";
+
+const STATUSES = ["", "queued", "running", "completed", "failed", "cancelled"];
+
+export async function renderRuns(container) {
+  let cursor = null;
+  let filters = { status: "", name: "", since: "", until: "" };
+  let pollTimer = null;
+
+  container.innerHTML = `
+    <div class="page">
+      <div class="page-head">
+        <h1>Runs</h1>
+        <button class="btn-primary" id="r-submit">+ Submit run</button>
+      </div>
+      <div class="filters">
+        <select id="f-status">${STATUSES.map((s) => `<option value="${s}">${s || "all statuses"}</option>`).join("")}</select>
+        <input id="f-name" placeholder="name" />
+        <input id="f-since" type="datetime-local" />
+        <input id="f-until" type="datetime-local" />
+        <button class="btn-ghost" id="f-apply">Apply</button>
+        <button class="btn-ghost" id="f-refresh">↻</button>
+      </div>
+      <div id="runs-list" class="runs-list"></div>
+      <button class="btn-ghost" id="r-more" hidden>Load more</button>
+    </div>`;
+
+  const list = container.querySelector("#runs-list");
+  container.querySelector("#r-submit").onclick = () => navigate("#/submit");
+
+  function query(reset) {
+    if (reset) cursor = null;
+    const p = new URLSearchParams();
+    if (filters.status) p.set("status", filters.status);
+    if (filters.name) p.set("name", filters.name);
+    if (filters.since) p.set("since", new Date(filters.since).toISOString());
+    if (filters.until) p.set("until", new Date(filters.until).toISOString());
+    p.set("limit", "50");
+    if (cursor) p.set("cursor", cursor);
+    return p.toString();
+  }
+
+  async function load(reset) {
+    try {
+      const data = await api(`/v1/runs?${query(reset)}`);
+      if (reset) list.innerHTML = "";
+      if (!data.runs.length && reset) list.innerHTML = `<div class="empty">No runs yet.</div>`;
+      for (const r of data.runs) list.appendChild(row(r));
+      cursor = data.next_cursor || null;
+      container.querySelector("#r-more").hidden = !cursor;
+      maybePoll(data.runs);
+    } catch (e) {
+      toast(e.message, "error");
+    }
+  }
+
+  function maybePoll(runs) {
+    const active = runs.some((r) => r.status === "running" || r.status === "queued");
+    clearTimeout(pollTimer);
+    if (active) pollTimer = setTimeout(() => load(true), 3000);
+  }
+
+  container.querySelector("#f-apply").onclick = () => {
+    filters = {
+      status: container.querySelector("#f-status").value,
+      name: container.querySelector("#f-name").value.trim(),
+      since: container.querySelector("#f-since").value,
+      until: container.querySelector("#f-until").value,
+    };
+    load(true);
+  };
+  container.querySelector("#f-refresh").onclick = () => load(true);
+  container.querySelector("#r-more").onclick = () => load(false);
+
+  await load(true);
+  return () => clearTimeout(pollTimer); // teardown
+}
+
+function row(r) {
+  const el = document.createElement("div");
+  el.className = "run-row";
+  el.onclick = () => navigate(`#/runs/${r.run_id}`);
+  const elapsed = r.elapsed_secs != null ? `${r.elapsed_secs.toFixed(1)}s` : "—";
+  el.innerHTML = `
+    <span class="pill pill-${r.status}">${r.status}</span>
+    <span class="run-name">${r.name || r.run_id}</span>
+    <span class="run-meta">${elapsed}</span>
+    <span class="run-meta">${r.records_written ?? 0} rows</span>
+    <span class="run-meta run-time">${fmtTime(r.submitted_at)}</span>`;
+  return el;
+}
+
+export function fmtTime(s) {
+  if (!s) return "—";
+  try { return new Date(s).toLocaleString(); } catch { return s; }
+}

--- a/cli/src/serve/ui/views/runs.js
+++ b/cli/src/serve/ui/views/runs.js
@@ -1,5 +1,6 @@
 import { api, toast } from "../api.js";
 import { navigate } from "../router.js";
+import { escapeHtml } from "../utils.js";
 
 const STATUSES = ["", "queued", "running", "completed", "failed", "cancelled"];
 
@@ -84,7 +85,7 @@ function row(r) {
   const elapsed = r.elapsed_secs != null ? `${r.elapsed_secs.toFixed(1)}s` : "—";
   el.innerHTML = `
     <span class="pill pill-${r.status}">${r.status}</span>
-    <span class="run-name">${r.name || r.run_id}</span>
+    <span class="run-name">${escapeHtml(r.name || r.run_id)}</span>
     <span class="run-meta">${elapsed}</span>
     <span class="run-meta">${r.records_written ?? 0} rows</span>
     <span class="run-meta run-time">${fmtTime(r.submitted_at)}</span>`;
@@ -93,5 +94,5 @@ function row(r) {
 
 export function fmtTime(s) {
   if (!s) return "—";
-  try { return new Date(s).toLocaleString(); } catch { return s; }
+  try { return new Date(s).toLocaleString(); } catch { return "—"; }
 }

--- a/cli/src/serve/ui/views/schemas.js
+++ b/cli/src/serve/ui/views/schemas.js
@@ -1,0 +1,56 @@
+import { api, toast } from "../api.js";
+
+export async function renderSchemas(container) {
+  let catalog = { sources: [], sinks: [], transforms: [], state: [] };
+  try { catalog = await api("/v1/schemas"); } catch (e) { toast(e.message, "error"); }
+
+  const group = (title, kind, items) =>
+    `<div class="schema-group"><h3>${title}</h3>${items
+      .map((i) => `<button class="schema-item" data-kind="${kind}" data-name="${i.name}" title="${escapeHtml(i.description)}">${i.name}</button>`)
+      .join("")}</div>`;
+
+  container.innerHTML = `
+    <div class="page schemas-page">
+      <aside class="schema-list">
+        ${group("Sources", "source", catalog.sources)}
+        ${group("Sinks", "sink", catalog.sinks)}
+        ${group("Transforms", "transform", catalog.transforms)}
+        <div class="schema-group"><h3>State stores</h3>${catalog.state.map((s) => `<span class="tag">${s}</span>`).join("")}</div>
+      </aside>
+      <section id="schema-view" class="schema-view"><div class="empty">Select a connector to view its schema.</div></section>
+    </div>`;
+
+  const view = container.querySelector("#schema-view");
+  container.querySelectorAll(".schema-item").forEach((btn) => {
+    btn.onclick = async () => {
+      container.querySelectorAll(".schema-item").forEach((b) => b.classList.remove("active"));
+      btn.classList.add("active");
+      view.innerHTML = `<div class="empty">loading…</div>`;
+      try {
+        const schema = await api(`/v1/schemas/${btn.dataset.kind}/${encodeURIComponent(btn.dataset.name)}`);
+        view.innerHTML = `<h2>${btn.dataset.kind}: ${btn.dataset.name}</h2>` + fieldTable(schema) +
+          `<details class="raw"><summary>raw JSON Schema</summary><pre>${escapeHtml(JSON.stringify(schema, null, 2))}</pre></details>`;
+      } catch (e) {
+        view.innerHTML = `<div class="empty">${e.message}</div>`;
+      }
+    };
+  });
+}
+
+function fieldTable(schema) {
+  const props = schema.properties || {};
+  const req = new Set(schema.required || []);
+  const rows = Object.entries(props)
+    .map(([name, p]) => {
+      const type = p.type || (p.$ref ? p.$ref.split("/").pop() : p.enum ? "enum" : p.oneOf || p.anyOf ? "union" : "object");
+      const def = p.default !== undefined ? `<code>${escapeHtml(JSON.stringify(p.default))}</code>` : "";
+      return `<tr><td>${name}${req.has(name) ? " *" : ""}</td><td>${escapeHtml(String(type))}</td><td>${def}</td><td>${escapeHtml(firstSentence(p.description || ""))}</td></tr>`;
+    })
+    .join("");
+  return `<table class="tbl"><thead><tr><th>field</th><th>type</th><th>default</th><th>description</th></tr></thead><tbody>${rows}</tbody></table>`;
+}
+
+function firstSentence(s) { return s ? s.split(/\.\s/)[0].slice(0, 160) : ""; }
+function escapeHtml(s) {
+  return String(s ?? "").replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
+}

--- a/cli/src/serve/ui/views/schemas.js
+++ b/cli/src/serve/ui/views/schemas.js
@@ -1,4 +1,5 @@
 import { api, toast } from "../api.js";
+import { escapeHtml } from "../utils.js";
 
 export async function renderSchemas(container) {
   let catalog = { sources: [], sinks: [], transforms: [], state: [] };
@@ -6,7 +7,7 @@ export async function renderSchemas(container) {
 
   const group = (title, kind, items) =>
     `<div class="schema-group"><h3>${title}</h3>${items
-      .map((i) => `<button class="schema-item" data-kind="${kind}" data-name="${i.name}" title="${escapeHtml(i.description)}">${i.name}</button>`)
+      .map((i) => `<button class="schema-item" data-kind="${kind}" data-name="${escapeHtml(i.name)}" title="${escapeHtml(i.description)}">${escapeHtml(i.name)}</button>`)
       .join("")}</div>`;
 
   container.innerHTML = `
@@ -15,7 +16,7 @@ export async function renderSchemas(container) {
         ${group("Sources", "source", catalog.sources)}
         ${group("Sinks", "sink", catalog.sinks)}
         ${group("Transforms", "transform", catalog.transforms)}
-        <div class="schema-group"><h3>State stores</h3>${catalog.state.map((s) => `<span class="tag">${s}</span>`).join("")}</div>
+        <div class="schema-group"><h3>State stores</h3>${catalog.state.map((s) => `<span class="tag">${escapeHtml(s)}</span>`).join("")}</div>
       </aside>
       <section id="schema-view" class="schema-view"><div class="empty">Select a connector to view its schema.</div></section>
     </div>`;
@@ -28,10 +29,10 @@ export async function renderSchemas(container) {
       view.innerHTML = `<div class="empty">loading…</div>`;
       try {
         const schema = await api(`/v1/schemas/${btn.dataset.kind}/${encodeURIComponent(btn.dataset.name)}`);
-        view.innerHTML = `<h2>${btn.dataset.kind}: ${btn.dataset.name}</h2>` + fieldTable(schema) +
+        view.innerHTML = `<h2>${escapeHtml(btn.dataset.kind)}: ${escapeHtml(btn.dataset.name)}</h2>` + fieldTable(schema) +
           `<details class="raw"><summary>raw JSON Schema</summary><pre>${escapeHtml(JSON.stringify(schema, null, 2))}</pre></details>`;
       } catch (e) {
-        view.innerHTML = `<div class="empty">${e.message}</div>`;
+        view.innerHTML = `<div class="empty">${escapeHtml(e.message)}</div>`;
       }
     };
   });
@@ -44,13 +45,10 @@ function fieldTable(schema) {
     .map(([name, p]) => {
       const type = p.type || (p.$ref ? p.$ref.split("/").pop() : p.enum ? "enum" : p.oneOf || p.anyOf ? "union" : "object");
       const def = p.default !== undefined ? `<code>${escapeHtml(JSON.stringify(p.default))}</code>` : "";
-      return `<tr><td>${name}${req.has(name) ? " *" : ""}</td><td>${escapeHtml(String(type))}</td><td>${def}</td><td>${escapeHtml(firstSentence(p.description || ""))}</td></tr>`;
+      return `<tr><td>${escapeHtml(name)}${req.has(name) ? " *" : ""}</td><td>${escapeHtml(String(type))}</td><td>${def}</td><td>${escapeHtml(firstSentence(p.description || ""))}</td></tr>`;
     })
     .join("");
   return `<table class="tbl"><thead><tr><th>field</th><th>type</th><th>default</th><th>description</th></tr></thead><tbody>${rows}</tbody></table>`;
 }
 
 function firstSentence(s) { return s ? s.split(/\.\s/)[0].slice(0, 160) : ""; }
-function escapeHtml(s) {
-  return String(s ?? "").replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
-}

--- a/cli/src/serve/ui/views/submit.js
+++ b/cli/src/serve/ui/views/submit.js
@@ -1,0 +1,181 @@
+import { api, toast } from "../api.js";
+import { renderSchemaForm } from "../schema-form.js";
+import { navigate } from "../router.js";
+
+export async function renderSubmit(container) {
+  let catalog = { sources: [], sinks: [], transforms: [], state: [] };
+  try { catalog = await api("/v1/schemas"); } catch (e) { toast(e.message, "error"); }
+
+  container.innerHTML = `
+    <div class="page">
+      <div class="page-head"><h1>Submit a run</h1>
+        <div class="mode-toggle">
+          <button id="mode-guided" class="btn-ghost active">Guided</button>
+          <button id="mode-editor" class="btn-ghost">Editor</button>
+        </div>
+      </div>
+      <div id="guided" class="submit-mode"></div>
+      <div id="editor" class="submit-mode" hidden>
+        <textarea id="cfg" class="code" spellcheck="false" placeholder="version: 1
+pipeline:
+  source: { kind: rest, config: { ... } }
+  sink: { kind: jsonl, config: { ... } }"></textarea>
+      </div>
+      <fieldset class="submit-opts">
+        <label>name <input id="o-name" /></label>
+        <label>format
+          <select id="o-format"><option value="yaml">yaml</option><option value="json">json</option></select>
+        </label>
+        <label>timeout (s) <input id="o-timeout" type="number" /></label>
+        <label><input id="o-doctor" type="checkbox" /> doctor first</label>
+        <label>idempotency key <input id="o-idem" /></label>
+      </fieldset>
+      <div class="submit-actions">
+        <button id="btn-check" class="btn-ghost">Check (doctor)</button>
+        <button id="btn-run" class="btn-primary">Run</button>
+      </div>
+      <pre id="submit-out" class="submit-out" hidden></pre>
+    </div>`;
+
+  const guided = container.querySelector("#guided");
+  const editor = container.querySelector("#editor");
+  const cfgEl = container.querySelector("#cfg");
+  const out = container.querySelector("#submit-out");
+
+  // --- guided wizard ---
+  let srcForm = null, sinkForm = null;
+  const txForms = [];
+
+  function selector(label, options) {
+    return `<label>${label}<select>${options.map((o) => `<option value="${o.name}">${o.name}</option>`).join("")}</select></label>`;
+  }
+
+  guided.innerHTML = `
+    <div class="wizard-step"><h3>Source</h3>${selector("kind", catalog.sources)}<div class="sf-host" id="src-form"></div></div>
+    <div class="wizard-step"><h3>Sink</h3>${selector("kind", catalog.sinks)}<div class="sf-host" id="sink-form"></div></div>
+    <div class="wizard-step"><h3>Transforms</h3><div id="tx-list"></div><button class="btn-ghost" id="tx-add">+ add transform</button></div>`;
+
+  const srcSel = guided.querySelector("#guided .wizard-step:nth-child(1) select") || guided.querySelectorAll("select")[0];
+  const sinkSel = guided.querySelectorAll("select")[1];
+
+  async function loadForm(kind, name, host, set) {
+    host.innerHTML = `<div class="empty">loading schema…</div>`;
+    try {
+      const schema = await api(`/v1/schemas/${kind}/${encodeURIComponent(name)}`);
+      host.innerHTML = "";
+      const form = renderSchemaForm(schema);
+      host.appendChild(form.el);
+      set(form);
+    } catch (e) {
+      host.innerHTML = `<div class="empty">${e.message}</div>`;
+    }
+  }
+
+  if (catalog.sources.length) {
+    srcSel.onchange = () => loadForm("source", srcSel.value, guided.querySelector("#src-form"), (f) => (srcForm = f));
+    await loadForm("source", srcSel.value, guided.querySelector("#src-form"), (f) => (srcForm = f));
+  }
+  if (catalog.sinks.length) {
+    sinkSel.onchange = () => loadForm("sink", sinkSel.value, guided.querySelector("#sink-form"), (f) => (sinkForm = f));
+    await loadForm("sink", sinkSel.value, guided.querySelector("#sink-form"), (f) => (sinkForm = f));
+  }
+
+  guided.querySelector("#tx-add").onclick = async () => {
+    const wrap = document.createElement("div");
+    wrap.className = "wizard-tx";
+    wrap.innerHTML = selector("transform", catalog.transforms);
+    const host = document.createElement("div");
+    host.className = "sf-host";
+    wrap.appendChild(host);
+    guided.querySelector("#tx-list").appendChild(wrap);
+    const sel = wrap.querySelector("select");
+    const entry = { kind: () => sel.value, form: null };
+    const reload = () => loadForm("transform", sel.value, host, (f) => (entry.form = f));
+    sel.onchange = reload;
+    await reload();
+    txForms.push(entry);
+  };
+
+  // Assemble the canonical config object from the wizard.
+  function buildConfig() {
+    const cfg = { version: 1, pipeline: {} };
+    if (srcForm) cfg.pipeline.source = { kind: srcSel.value, config: srcForm.read() };
+    if (sinkForm) cfg.pipeline.sink = { kind: sinkSel.value, config: sinkForm.read() };
+    const tx = txForms
+      .filter((t) => t.form)
+      .map((t) => ({ type: t.kind(), ...t.form.read() }));
+    if (tx.length) cfg.pipeline.transforms = tx;
+    const name = container.querySelector("#o-name").value.trim();
+    if (name) cfg.name = name;
+    return cfg;
+  }
+
+  function toYaml(obj) {
+    // Minimal, dependency-free YAML emitter for the preview/editor hand-off.
+    const dump = (v, ind) => {
+      const pad = "  ".repeat(ind);
+      if (v === null || v === undefined) return "null";
+      if (Array.isArray(v))
+        return v.length ? "\n" + v.map((i) => `${pad}- ${dump(i, ind + 1).replace(/^\n/, "")}`).join("\n") : "[]";
+      if (typeof v === "object")
+        return "\n" + Object.entries(v).map(([k, val]) => `${pad}${k}: ${dump(val, ind + 1)}`).join("\n");
+      if (typeof v === "string") return /[:#\n]/.test(v) ? JSON.stringify(v) : v;
+      return String(v);
+    };
+    return Object.entries(obj).map(([k, v]) => `${k}: ${dump(v, 1)}`).join("\n").replace(/: \n/g, ":\n") + "\n";
+  }
+
+  // --- mode toggle ---
+  const guidedBtn = container.querySelector("#mode-guided");
+  const editorBtn = container.querySelector("#mode-editor");
+  guidedBtn.onclick = () => { guided.hidden = false; editor.hidden = true; guidedBtn.classList.add("active"); editorBtn.classList.remove("active"); };
+  editorBtn.onclick = () => {
+    // Hand the assembled config to the raw editor for tweaks.
+    if (!cfgEl.value.trim()) {
+      cfgEl.value = toYaml(buildConfig());
+      container.querySelector("#o-format").value = "yaml";
+    }
+    guided.hidden = true; editor.hidden = false; editorBtn.classList.add("active"); guidedBtn.classList.remove("active");
+  };
+
+  // --- request building ---
+  function requestBody() {
+    const isEditor = !editor.hidden;
+    const format = container.querySelector("#o-format").value;
+    const config = isEditor ? cfgEl.value : (format === "json" ? JSON.stringify(buildConfig()) : toYaml(buildConfig()));
+    const body = { config, config_format: format };
+    const name = container.querySelector("#o-name").value.trim();
+    const timeout = container.querySelector("#o-timeout").value;
+    const idem = container.querySelector("#o-idem").value.trim();
+    if (name) body.name = name;
+    if (timeout) body.timeout_secs = Number(timeout);
+    if (container.querySelector("#o-doctor").checked) body.doctor_first = true;
+    if (idem) body.idempotency_key = idem;
+    return body;
+  }
+
+  container.querySelector("#btn-check").onclick = async () => {
+    out.hidden = false;
+    out.textContent = "running doctor…";
+    const b = requestBody();
+    try {
+      const rep = await api("/v1/doctor", { method: "POST", body: { config: b.config, config_format: b.config_format } });
+      out.textContent = "✓ all probes passed\n\n" + JSON.stringify(rep, null, 2);
+    } catch (e) {
+      out.textContent = `✗ ${e.message}\n\n` + (e.details ? JSON.stringify(e.details, null, 2) : "");
+    }
+  };
+
+  container.querySelector("#btn-run").onclick = async () => {
+    try {
+      const resp = await api("/v1/runs", { method: "POST", body: requestBody() });
+      toast(`run ${resp.run_id} ${resp.status}`);
+      navigate(`#/runs/${resp.run_id}`);
+    } catch (e) {
+      out.hidden = false;
+      const extra = e.retryAfter ? ` (retry in ${e.retryAfter}s)` : "";
+      out.textContent = `✗ ${e.message}${extra}\n\n` + (e.details ? JSON.stringify(e.details, null, 2) : "");
+      toast(e.message, "error");
+    }
+  };
+}

--- a/cli/src/serve/ui/views/submit.js
+++ b/cli/src/serve/ui/views/submit.js
@@ -1,5 +1,6 @@
 import { api, toast } from "../api.js";
 import { renderSchemaForm } from "../schema-form.js";
+import { escapeHtml } from "../utils.js";
 import { navigate } from "../router.js";
 
 export async function renderSubmit(container) {
@@ -18,8 +19,8 @@ export async function renderSubmit(container) {
       <div id="editor" class="submit-mode" hidden>
         <textarea id="cfg" class="code" spellcheck="false" placeholder="version: 1
 pipeline:
-  source: { kind: rest, config: { ... } }
-  sink: { kind: jsonl, config: { ... } }"></textarea>
+  source: { type: rest, config: { ... } }
+  sink: { type: jsonl, config: { ... } }"></textarea>
       </div>
       <fieldset class="submit-opts">
         <label>name <input id="o-name" /></label>
@@ -47,7 +48,7 @@ pipeline:
   const txForms = [];
 
   function selector(label, options) {
-    return `<label>${label}<select>${options.map((o) => `<option value="${o.name}">${o.name}</option>`).join("")}</select></label>`;
+    return `<label>${label}<select>${options.map((o) => `<option value="${escapeHtml(o.name)}">${escapeHtml(o.name)}</option>`).join("")}</select></label>`;
   }
 
   guided.innerHTML = `
@@ -67,7 +68,7 @@ pipeline:
       host.appendChild(form.el);
       set(form);
     } catch (e) {
-      host.innerHTML = `<div class="empty">${e.message}</div>`;
+      host.innerHTML = `<div class="empty">${escapeHtml(e.message)}</div>`;
     }
   }
 
@@ -99,11 +100,11 @@ pipeline:
   // Assemble the canonical config object from the wizard.
   function buildConfig() {
     const cfg = { version: 1, pipeline: {} };
-    if (srcForm) cfg.pipeline.source = { kind: srcSel.value, config: srcForm.read() };
-    if (sinkForm) cfg.pipeline.sink = { kind: sinkSel.value, config: sinkForm.read() };
+    if (srcForm) cfg.pipeline.source = { type: srcSel.value, config: srcForm.read() };
+    if (sinkForm) cfg.pipeline.sink = { type: sinkSel.value, config: sinkForm.read() };
     const tx = txForms
       .filter((t) => t.form)
-      .map((t) => ({ type: t.kind(), ...t.form.read() }));
+      .map((t) => ({ type: t.kind(), config: t.form.read() }));
     if (tx.length) cfg.pipeline.transforms = tx;
     const name = container.querySelector("#o-name").value.trim();
     if (name) cfg.name = name;

--- a/cli/src/serve/ui_assets.rs
+++ b/cli/src/serve/ui_assets.rs
@@ -1,0 +1,101 @@
+//! Embedded web-console assets (serve-ui feature). The static shell is PUBLIC;
+//! all data stays behind the bearer-gated `/v1` API. Assets are embedded at
+//! compile time from `src/serve/ui/` via `rust-embed`.
+
+use crate::serve::error::ServeError;
+use axum::extract::Path;
+use axum::http::{HeaderMap, StatusCode, header};
+use axum::response::{IntoResponse, Response};
+
+#[derive(rust_embed::RustEmbed)]
+#[folder = "src/serve/ui/"]
+struct UiAssets;
+
+/// Send embedded asset bytes with the right content-type and `no-cache`
+/// (assets are tiny + embedded; correctness over caching — see spec §11).
+fn serve_asset(path: &str) -> Response {
+    match UiAssets::get(path) {
+        Some(file) => {
+            let mime = file.metadata.mimetype();
+            (
+                StatusCode::OK,
+                [
+                    (header::CONTENT_TYPE, mime.to_string()),
+                    (header::CACHE_CONTROL, "no-cache".to_string()),
+                ],
+                file.data.into_owned(),
+            )
+                .into_response()
+        }
+        None => ServeError::NotFound.into_response(),
+    }
+}
+
+/// `GET /` → the SPA shell.
+pub async fn index() -> Response {
+    serve_asset("index.html")
+}
+
+/// `GET /assets/{*path}` → an embedded asset by relative path.
+pub async fn asset(Path(path): Path<String>) -> Response {
+    serve_asset(&path)
+}
+
+/// True when the request prefers an HTML document (so a deep-link / refresh of a
+/// client-side route should receive the SPA shell rather than a JSON 404).
+pub(crate) fn wants_html(headers: &HeaderMap) -> bool {
+    headers
+        .get(header::ACCEPT)
+        .and_then(|v| v.to_str().ok())
+        .map(|a| a.contains("text/html"))
+        .unwrap_or(false)
+}
+
+/// Router fallback: an HTML-accepting GET to an unmatched path returns the SPA
+/// shell (enables hash-route deep links); everything else gets the standard JSON
+/// 404 so the API's 404 shape is preserved.
+pub async fn spa_fallback(headers: HeaderMap) -> Response {
+    if wants_html(&headers) {
+        index().await
+    } else {
+        ServeError::NotFound.into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderValue;
+
+    #[test]
+    fn wants_html_true_for_browser_accept() {
+        let mut h = HeaderMap::new();
+        h.insert(
+            header::ACCEPT,
+            HeaderValue::from_static("text/html,application/xhtml+xml"),
+        );
+        assert!(wants_html(&h));
+    }
+
+    #[test]
+    fn wants_html_false_for_json_or_missing() {
+        let mut h = HeaderMap::new();
+        h.insert(header::ACCEPT, HeaderValue::from_static("application/json"));
+        assert!(!wants_html(&h));
+        assert!(!wants_html(&HeaderMap::new()));
+    }
+
+    #[test]
+    fn index_asset_is_embedded_and_html() {
+        let resp = serve_asset("index.html");
+        assert_eq!(resp.status(), StatusCode::OK);
+        let ct = resp.headers().get(header::CONTENT_TYPE).unwrap();
+        assert!(ct.to_str().unwrap().contains("text/html"));
+    }
+
+    #[test]
+    fn missing_asset_is_not_found() {
+        let resp = serve_asset("does-not-exist.xyz");
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+}

--- a/cli/src/serve/ui_assets.rs
+++ b/cli/src/serve/ui_assets.rs
@@ -4,7 +4,7 @@
 
 use crate::serve::error::ServeError;
 use axum::extract::Path;
-use axum::http::{HeaderMap, StatusCode, header};
+use axum::http::{HeaderMap, Method, StatusCode, header};
 use axum::response::{IntoResponse, Response};
 
 #[derive(rust_embed::RustEmbed)]
@@ -54,8 +54,8 @@ pub(crate) fn wants_html(headers: &HeaderMap) -> bool {
 /// Router fallback: an HTML-accepting GET to an unmatched path returns the SPA
 /// shell (enables hash-route deep links); everything else gets the standard JSON
 /// 404 so the API's 404 shape is preserved.
-pub async fn spa_fallback(headers: HeaderMap) -> Response {
-    if wants_html(&headers) {
+pub async fn spa_fallback(method: Method, headers: HeaderMap) -> Response {
+    if method == Method::GET && wants_html(&headers) {
         index().await
     } else {
         ServeError::NotFound.into_response()

--- a/cli/tests/serve_history_sqlite.rs
+++ b/cli/tests/serve_history_sqlite.rs
@@ -317,6 +317,7 @@ async fn server_with_sqlite_history_persists_runs() {
         probe_timeout_secs: 5,
         env_file: None,
         no_env_file: true,
+        no_ui: false,
     };
     let mut config = ServeConfig::from_args(args).unwrap();
     config.log_level = "warn".into();

--- a/cli/tests/serve_lifecycle.rs
+++ b/cli/tests/serve_lifecycle.rs
@@ -36,6 +36,7 @@ fn args_on(port: u16, token: Option<&str>) -> ServeArgs {
         probe_timeout_secs: 5,
         env_file: None,
         no_env_file: true,
+        no_ui: false,
     }
 }
 

--- a/cli/tests/serve_logs.rs
+++ b/cli/tests/serve_logs.rs
@@ -33,6 +33,7 @@ fn args_on(port: u16) -> ServeArgs {
         probe_timeout_secs: 5,
         env_file: None,
         no_env_file: true,
+        no_ui: false,
     }
 }
 

--- a/cli/tests/serve_metrics.rs
+++ b/cli/tests/serve_metrics.rs
@@ -30,6 +30,7 @@ fn args_on(port: u16, token: Option<&str>) -> ServeArgs {
         probe_timeout_secs: 5,
         env_file: None,
         no_env_file: true,
+        no_ui: false,
     }
 }
 

--- a/cli/tests/serve_openapi.rs
+++ b/cli/tests/serve_openapi.rs
@@ -27,6 +27,7 @@ const ROUTES: &[(&str, &str)] = &[
     ("GET", "/v1/runs/{id}/logs"),
     ("GET", "/v1/schemas"),
     ("GET", "/v1/schemas/{kind}/{name}"),
+    ("POST", "/v1/doctor"),
     ("GET", "/healthz"),
     ("GET", "/readyz"),
     ("GET", "/metrics"),

--- a/cli/tests/serve_openapi.rs
+++ b/cli/tests/serve_openapi.rs
@@ -98,6 +98,7 @@ async fn every_documented_route_is_wired_on_the_live_server() {
         probe_timeout_secs: 5,
         env_file: None,
         no_env_file: true,
+        no_ui: false,
     };
     let mut config = ServeConfig::from_args(args).unwrap();
     config.log_level = "warn".into();

--- a/cli/tests/serve_openapi.rs
+++ b/cli/tests/serve_openapi.rs
@@ -25,6 +25,8 @@ const ROUTES: &[(&str, &str)] = &[
     ("DELETE", "/v1/runs/{id}"),
     ("POST", "/v1/runs/{id}/cancel"),
     ("GET", "/v1/runs/{id}/logs"),
+    ("GET", "/v1/schemas"),
+    ("GET", "/v1/schemas/{kind}/{name}"),
     ("GET", "/healthz"),
     ("GET", "/readyz"),
     ("GET", "/metrics"),

--- a/cli/tests/serve_skeleton.rs
+++ b/cli/tests/serve_skeleton.rs
@@ -24,6 +24,7 @@ fn test_config(listen: &str) -> ServeConfig {
         probe_timeout_secs: 5,
         env_file: None,
         no_env_file: true,
+        no_ui: false,
     };
     ServeConfig::from_args(args).unwrap()
 }

--- a/cli/tests/serve_ui.rs
+++ b/cli/tests/serve_ui.rs
@@ -1,0 +1,110 @@
+//! Embedded web-console serving + auth-boundary tests (serve-ui feature).
+#![cfg(feature = "serve-ui")]
+
+use faucet_cli::cli::ServeArgs;
+use faucet_cli::serve::ServeConfig;
+use std::time::Duration;
+
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+fn args(port: u16) -> ServeArgs {
+    ServeArgs {
+        listen: format!("127.0.0.1:{port}"),
+        auth_token: None,
+        no_auth: true,
+        max_concurrent_runs: Some(2),
+        max_queued_runs: Some(8),
+        default_config: None,
+        history: None,
+        cors_origin: vec![],
+        body_limit_bytes: 1_048_576,
+        shutdown_grace_secs: 5,
+        retain_terminal_runs_secs: 604_800,
+        idempotency_retention_secs: 86_400,
+        lease_ttl_secs: 30,
+        probe_timeout_secs: 5,
+        env_file: None,
+        no_env_file: true,
+        no_ui: false,
+    }
+}
+
+async fn boot(args: ServeArgs) -> (String, reqwest::Client) {
+    let port = args.listen.rsplit(':').next().unwrap().to_string();
+    let mut config = ServeConfig::from_args(args).unwrap();
+    config.log_level = "warn".into();
+    tokio::spawn(async move {
+        let _ = faucet_cli::serve::run_server(config).await;
+    });
+    let client = reqwest::Client::new();
+    let base = format!("http://127.0.0.1:{port}");
+    for _ in 0..200 {
+        if client
+            .get(format!("{base}/healthz"))
+            .send()
+            .await
+            .map(|r| r.status().is_success())
+            .unwrap_or(false)
+        {
+            return (base, client);
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    panic!("server did not come up");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn serves_shell_assets_and_spa_fallback() {
+    let port = free_port();
+    let (base, client) = boot(args(port)).await;
+
+    let r = client.get(format!("{base}/")).send().await.unwrap();
+    assert_eq!(r.status(), 200);
+    assert!(
+        r.headers()["content-type"].to_str().unwrap().contains("text/html"),
+        "index should be html"
+    );
+
+    let r = client.get(format!("{base}/assets/styles.css")).send().await.unwrap();
+    assert_eq!(r.status(), 200);
+    assert!(r.headers()["content-type"].to_str().unwrap().contains("css"));
+
+    let r = client
+        .get(format!("{base}/runs"))
+        .header("accept", "text/html")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 200);
+    assert!(r.headers()["content-type"].to_str().unwrap().contains("text/html"));
+
+    let r = client
+        .get(format!("{base}/nope"))
+        .header("accept", "application/json")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 404);
+    assert!(r.text().await.unwrap().contains("\"error\""));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn ui_is_public_but_api_is_gated() {
+    let port = free_port();
+    let mut a = args(port);
+    a.no_auth = false;
+    a.auth_token = Some("s3cret".into());
+    let (base, client) = boot(a).await;
+
+    let r = client.get(format!("{base}/")).send().await.unwrap();
+    assert_eq!(r.status(), 200);
+
+    let r = client.get(format!("{base}/v1/runs")).send().await.unwrap();
+    assert_eq!(r.status(), 401);
+}

--- a/cli/tests/serve_ui.rs
+++ b/cli/tests/serve_ui.rs
@@ -67,13 +67,25 @@ async fn serves_shell_assets_and_spa_fallback() {
     let r = client.get(format!("{base}/")).send().await.unwrap();
     assert_eq!(r.status(), 200);
     assert!(
-        r.headers()["content-type"].to_str().unwrap().contains("text/html"),
+        r.headers()["content-type"]
+            .to_str()
+            .unwrap()
+            .contains("text/html"),
         "index should be html"
     );
 
-    let r = client.get(format!("{base}/assets/styles.css")).send().await.unwrap();
+    let r = client
+        .get(format!("{base}/assets/styles.css"))
+        .send()
+        .await
+        .unwrap();
     assert_eq!(r.status(), 200);
-    assert!(r.headers()["content-type"].to_str().unwrap().contains("css"));
+    assert!(
+        r.headers()["content-type"]
+            .to_str()
+            .unwrap()
+            .contains("css")
+    );
 
     let r = client
         .get(format!("{base}/runs"))
@@ -82,7 +94,12 @@ async fn serves_shell_assets_and_spa_fallback() {
         .await
         .unwrap();
     assert_eq!(r.status(), 200);
-    assert!(r.headers()["content-type"].to_str().unwrap().contains("text/html"));
+    assert!(
+        r.headers()["content-type"]
+            .to_str()
+            .unwrap()
+            .contains("text/html")
+    );
 
     let r = client
         .get(format!("{base}/nope"))
@@ -109,7 +126,11 @@ async fn ui_is_public_but_api_is_gated() {
     assert_eq!(r.status(), 401);
 
     // The new read/probe endpoints sit on the same gated sub-router.
-    let r = client.get(format!("{base}/v1/schemas")).send().await.unwrap();
+    let r = client
+        .get(format!("{base}/v1/schemas"))
+        .send()
+        .await
+        .unwrap();
     assert_eq!(r.status(), 401);
     let r = client
         .post(format!("{base}/v1/doctor"))
@@ -125,16 +146,28 @@ async fn schemas_catalog_and_one_schema() {
     let port = free_port();
     let (base, client) = boot(args(port)).await;
 
-    let r = client.get(format!("{base}/v1/schemas")).send().await.unwrap();
+    let r = client
+        .get(format!("{base}/v1/schemas"))
+        .send()
+        .await
+        .unwrap();
     assert_eq!(r.status(), 200);
     let body: serde_json::Value = r.json().await.unwrap();
     assert!(body["sources"].is_array() && body["sinks"].is_array());
 
-    let r = client.get(format!("{base}/v1/schemas/source/rest")).send().await.unwrap();
+    let r = client
+        .get(format!("{base}/v1/schemas/source/rest"))
+        .send()
+        .await
+        .unwrap();
     assert_eq!(r.status(), 200);
     assert!(r.json::<serde_json::Value>().await.unwrap().is_object());
 
-    let r = client.get(format!("{base}/v1/schemas/source/nope")).send().await.unwrap();
+    let r = client
+        .get(format!("{base}/v1/schemas/source/nope"))
+        .send()
+        .await
+        .unwrap();
     assert_eq!(r.status(), 404);
 }
 

--- a/cli/tests/serve_ui.rs
+++ b/cli/tests/serve_ui.rs
@@ -108,3 +108,21 @@ async fn ui_is_public_but_api_is_gated() {
     let r = client.get(format!("{base}/v1/runs")).send().await.unwrap();
     assert_eq!(r.status(), 401);
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn schemas_catalog_and_one_schema() {
+    let port = free_port();
+    let (base, client) = boot(args(port)).await;
+
+    let r = client.get(format!("{base}/v1/schemas")).send().await.unwrap();
+    assert_eq!(r.status(), 200);
+    let body: serde_json::Value = r.json().await.unwrap();
+    assert!(body["sources"].is_array() && body["sinks"].is_array());
+
+    let r = client.get(format!("{base}/v1/schemas/source/rest")).send().await.unwrap();
+    assert_eq!(r.status(), 200);
+    assert!(r.json::<serde_json::Value>().await.unwrap().is_object());
+
+    let r = client.get(format!("{base}/v1/schemas/source/nope")).send().await.unwrap();
+    assert_eq!(r.status(), 404);
+}

--- a/cli/tests/serve_ui.rs
+++ b/cli/tests/serve_ui.rs
@@ -126,3 +126,17 @@ async fn schemas_catalog_and_one_schema() {
     let r = client.get(format!("{base}/v1/schemas/source/nope")).send().await.unwrap();
     assert_eq!(r.status(), 404);
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn doctor_rejects_invalid_config() {
+    let port = free_port();
+    let (base, client) = boot(args(port)).await;
+    let r = client
+        .post(format!("{base}/v1/doctor"))
+        .json(&serde_json::json!({ "config": "::: not yaml :::" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 400);
+    assert!(r.text().await.unwrap().contains("\"error\""));
+}

--- a/cli/tests/serve_ui.rs
+++ b/cli/tests/serve_ui.rs
@@ -107,6 +107,17 @@ async fn ui_is_public_but_api_is_gated() {
 
     let r = client.get(format!("{base}/v1/runs")).send().await.unwrap();
     assert_eq!(r.status(), 401);
+
+    // The new read/probe endpoints sit on the same gated sub-router.
+    let r = client.get(format!("{base}/v1/schemas")).send().await.unwrap();
+    assert_eq!(r.status(), 401);
+    let r = client
+        .post(format!("{base}/v1/doctor"))
+        .json(&serde_json::json!({ "config": "version: 1" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 401);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -29,6 +29,7 @@
 - [Adaptive batching](./cookbook/adaptive-batching.md)
 - [Scheduling](./cookbook/scheduling.md)
 - [Running faucet as a service](./cookbook/serve.md)
+- [Web console (`serve-ui`)](./cookbook/web-console.md)
 - [Lineage (OpenLineage)](./cookbook/lineage.md)
 - [Troubleshooting with faucet doctor](./cookbook/troubleshooting.md)
 

--- a/docs/book/src/cookbook/web-console.md
+++ b/docs/book/src/cookbook/web-console.md
@@ -1,0 +1,118 @@
+# Web console (`serve-ui`)
+
+`faucet serve` optionally serves an embedded browser-based web console at `/`
+when built with the `serve-ui` Cargo feature. The console gives you a visual
+interface for the same HTTP API that `curl` or an orchestrator would use —
+useful for ad-hoc runs, browsing logs, and exploring connector schemas without
+leaving a browser tab.
+
+> The console is a thin static single-page application bundled into the binary
+> via `rust-embed`. There is no separate deployment and no network call during
+> startup.
+
+## Enabling the feature
+
+```bash
+# Install with the embedded console (add serve-ui to your --features list)
+cargo install faucet-cli --features serve-ui
+
+# Or build locally
+cargo build -p faucet-cli --features serve-ui
+```
+
+`serve-ui` implies `serve`, so you do not need to list both. The `full`
+aggregate already includes `serve-ui`.
+
+Once built, start the server normally:
+
+```bash
+FAUCET_SERVE_AUTH_TOKEN=s3cret faucet serve --listen 127.0.0.1:8080
+```
+
+Then open `http://127.0.0.1:8080/` in a browser.
+
+## Token flow
+
+The static shell at `/` is served **without authentication** so the browser can
+load the page before it has a token. All `/v1` API calls that populate the
+console's data are bearer-gated as usual.
+
+On first load (or after a 401) the console prompts you to paste the bearer
+token (the same value as `FAUCET_SERVE_AUTH_TOKEN` / `--auth-token`). The token
+is stored in browser `localStorage` and sent as `Authorization: Bearer <token>`
+on every subsequent `/v1` request. A key-icon button in the top bar lets you
+update or clear it at any time.
+
+> **Security:** the bearer token is as sensitive as the API itself — anyone who
+> obtains it can submit arbitrary pipeline configs with the server's identity
+> (see the [security model](./serve.md#️-security-model--read-before-exposing)).
+> Serve the console only over localhost or a TLS-terminating proxy; never paste
+> a production token into a browser tab on a shared machine.
+
+## Views
+
+### Runs dashboard
+
+Lists all runs with live status badges. You can:
+
+- Filter by name, status, or time range.
+- Page through history.
+- Click any row to open the run detail view.
+- Click **+ Submit run** to go directly to the Submit view.
+
+### Run detail
+
+Shows the full run record (status, timestamps, labels, config) plus every
+invocation in the matrix. For in-flight runs it streams structured log events
+live via SSE (the same `GET /v1/runs/{id}/logs` endpoint). You can cancel or
+delete a run from this view.
+
+### Submit
+
+Two modes for submitting a new pipeline run:
+
+- **Raw editor** — paste or type YAML/JSON directly into a text area. The same
+  format accepted by `POST /v1/runs`.
+- **Schema wizard** — select a source and sink from the compiled connector list,
+  fill in the generated form fields, and the wizard assembles a valid config.
+  The form is derived from the same JSON Schemas returned by
+  `GET /v1/schemas/{kind}/{name}`.
+
+### Schemas explorer
+
+Browses the connector catalog compiled into the running server
+(`GET /v1/schemas`). Click any source, sink, or transform to view its full
+JSON Schema — useful for checking config field names and types without leaving
+the browser.
+
+## Disabling the console at runtime
+
+If you built with `serve-ui` but want to serve only the API (no static assets),
+pass `--no-ui`:
+
+```bash
+FAUCET_SERVE_AUTH_TOKEN=s3cret faucet serve --no-ui
+```
+
+`/` and `/assets/*` return 404; the `/v1` API and the unauthenticated probes
+(`/healthz`, `/readyz`, `/metrics`) are unaffected.
+
+## New API endpoints
+
+The `serve-ui` feature ships three new bearer-gated endpoints that the console
+(and any other client) can call:
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/v1/schemas` | Catalog of all compiled sources, sinks, transforms, and state-store kinds. |
+| `GET` | `/v1/schemas/{kind}/{name}` | JSON Schema for one connector or transform (`kind` ∈ `source`/`sink`/`transform`). Returns 404 for unknown kind or name. |
+| `POST` | `/v1/doctor` | Validate and probe a submitted config without running it. Returns 200 (all probes pass) or 422 (any probe fails) with a probe report. Request body: `{ "config": "<yaml-or-json>", "config_format": "yaml" }`. |
+
+These endpoints require the `serve` feature and are available at runtime
+regardless of whether `--no-ui` was passed.
+
+## Related pages
+
+- [Running faucet as a service](./serve.md) — the full `faucet serve` guide.
+- [HTTP API reference](../reference/http-api.md) — complete endpoint/schema reference.
+- [`faucet serve` CLI flags](../reference/cli.md#serve) — all `faucet serve` flags.

--- a/docs/book/src/reference/cli.md
+++ b/docs/book/src/reference/cli.md
@@ -191,6 +191,37 @@ Selected flags (`faucet serve --help` for the full list):
 | `--cors-origin <origin>` | Allow-list a browser origin (repeatable; CORS off by default). |
 | `--lease-ttl-secs <n>` | Run-ownership lease TTL (default 30) for multi-instance orphan fencing on a shared persistent backend — set above worst-case stalls. See the [serve cookbook](../cookbook/serve.md#multi-instance-orphan-recovery-run-ownership-leases). |
 | `--body-limit-bytes` / `--shutdown-grace-secs` / `--retain-terminal-runs-secs` / `--idempotency-retention-secs` | Tuning knobs. |
+| `--no-ui` | Disable the embedded web console at runtime even when the binary was built with `serve-ui`. |
+
+### Optional embedded web console (`serve-ui`)
+
+When built with the `serve-ui` Cargo feature, `faucet serve` also serves a
+browser-based web console at `/` (and static assets at `/assets/*`):
+
+```bash
+cargo install faucet-cli --features serve-ui
+FAUCET_SERVE_AUTH_TOKEN=s3cret faucet serve --listen 127.0.0.1:8080
+# Open http://127.0.0.1:8080/ in a browser.
+```
+
+The static shell is public; all `/v1` data is bearer-gated as usual. The
+browser is prompted for the token on first load; it is stored in `localStorage`
+and sent on every `/v1` call. Pass `--no-ui` to disable the console at runtime
+without rebuilding.
+
+`serve-ui` implies `serve` and is included in the `full` aggregate. It ships
+three additional bearer-gated endpoints:
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/v1/schemas` | Catalog of compiled sources, sinks, transforms, and state-store kinds. |
+| `GET` | `/v1/schemas/{kind}/{name}` | JSON Schema for one connector or transform (`kind` ∈ `source`/`sink`/`transform`). 404 for unknown. |
+| `POST` | `/v1/doctor` | Validate + probe a submitted config without running it. 200 (pass) / 422 (fail). Body: `{ "config": "…", "config_format": "yaml" }`. |
+
+These endpoints require `serve` and are available regardless of `--no-ui`. See
+the [web console guide](../cookbook/web-console.md) for the full walkthrough and
+the [HTTP API reference](./http-api.md) for the complete endpoint/schema
+reference.
 
 > ⚠️ `serve` executes arbitrary client-supplied configs with the server's identity (secrets, files,
 > network egress). Run single-tenant, authenticated, behind egress controls. See the

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -143,6 +143,29 @@ paths:
           content: { application/json: { schema: { type: object } } }
         "401": { description: Missing or invalid bearer token }
         "404": { description: Unknown kind or name }
+  /v1/doctor:
+    post:
+      summary: Validate and probe a config without running it
+      security: [{ bearerAuth: [] }]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [config]
+              properties:
+                config: { type: string }
+                config_format: { type: string, enum: [yaml, json], default: yaml }
+      responses:
+        "200":
+          description: All probes passed; body is the doctor report
+          content: { application/json: { schema: { type: object } } }
+        "400": { description: Malformed config body }
+        "401": { description: Missing or invalid bearer token }
+        "422":
+          description: One or more probes failed; report in body
+          content: { application/json: { schema: { type: object } } }
   /healthz:
     get:
       summary: Liveness probe (unauthenticated)

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -113,6 +113,36 @@ paths:
               schema: { type: string }
         "401": { $ref: "#/components/responses/Error" }
         "404": { $ref: "#/components/responses/Error" }
+  /v1/schemas:
+    get:
+      summary: List compiled connector and transform schemas
+      security: [{ bearerAuth: [] }]
+      responses:
+        "200":
+          description: Catalog of sources, sinks, transforms, and state-store kinds
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  sources: { type: array, items: { type: object, properties: { name: { type: string }, description: { type: string } } } }
+                  sinks: { type: array, items: { type: object, properties: { name: { type: string }, description: { type: string } } } }
+                  transforms: { type: array, items: { type: object, properties: { name: { type: string }, description: { type: string } } } }
+                  state: { type: array, items: { type: string } }
+        "401": { description: Missing or invalid bearer token }
+  /v1/schemas/{kind}/{name}:
+    get:
+      summary: Get the JSON Schema for one connector or transform
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - { name: kind, in: path, required: true, schema: { type: string, enum: [source, sink, transform] } }
+        - { name: name, in: path, required: true, schema: { type: string } }
+      responses:
+        "200":
+          description: JSON Schema document
+          content: { application/json: { schema: { type: object } } }
+        "401": { description: Missing or invalid bearer token }
+        "404": { description: Unknown kind or name }
   /healthz:
     get:
       summary: Liveness probe (unauthenticated)


### PR DESCRIPTION
Embedded single-page web console for `faucet serve` (#199): runs dashboard, live log streaming, raw **and** interactive schema-driven submit, schema explorer, and a doctor preflight — vanilla HTML/CSS/ES-modules embedded via `rust-embed` behind the opt-in `serve-ui` feature (no JS build step; included in `full`).

Adds three bearer-gated endpoints reusing existing CLI code: `GET /v1/schemas`, `GET /v1/schemas/{kind}/{name}`, `POST /v1/doctor`. The static shell is public; all `/v1` data stays bearer-gated (token entered in-UI, stored in `localStorage`; logs streamed via `fetch`+`ReadableStream` so the bearer header attaches). Dark/light, brand-consistent "instrument-panel" UI. `--no-ui` disables serving at runtime; the default `serve` build is unchanged.

## Verified
- `clippy --features serve-ui --all-targets -D warnings` clean; default-build clippy clean
- `serve_ui` (serving + public-shell/gated-API boundary + schemas + doctor) and `serve_openapi` (route↔spec sync) tests pass
- Cross-feature compile clean (`serve-ui` + `serve-history-postgres`/`sqlite`); default build unaffected
- Browser-verified: runs / detail / submit (guided + editor) / schemas all render; the interactive wizard submits a valid `{type, config}` pipeline; XSS payloads in run names render escaped (not executed)

Closes #199