### PR TITLE
Exactly-once / idempotent delivery mode

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1139,6 +1139,9 @@ matrix:
 "#;
         let cfg3 = parse_with_extension(yaml3, "yaml").unwrap();
         assert_eq!(cfg3.matrix[0].delivery, None);
-        assert_eq!(cfg3.matrix[1].delivery, Some(faucet_core::DeliveryMode::ExactlyOnce));
+        assert_eq!(
+            cfg3.matrix[1].delivery,
+            Some(faucet_core::DeliveryMode::ExactlyOnce)
+        );
     }
 }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -77,6 +77,13 @@ pub struct PipelineConfig {
     #[serde(default)]
     pub observability: Option<ObservabilitySpec>,
 
+    /// Delivery guarantee for every row (overridable per matrix row). Default
+    /// `at_least_once` — no behaviour change for existing configs. `exactly_once`
+    /// requires an idempotent sink, a deterministic-replay source, and a state
+    /// store (enforced at expand time).
+    #[serde(default)]
+    pub delivery: faucet_core::DeliveryMode,
+
     /// Optional cron schedule. Only consumed by `faucet schedule`; ignored by
     /// `faucet run`. Presence makes the config runnable on a schedule.
     #[cfg(feature = "schedule")]
@@ -253,6 +260,10 @@ pub struct MatrixRow {
     /// - `dlq: { ... }` → `Some(Some(spec))` — replace base DLQ wholesale
     #[serde(default, deserialize_with = "deserialize_dlq_override")]
     pub dlq: Option<Option<DlqSpec>>,
+
+    /// Per-row delivery override. `None` inherits the top-level `delivery`.
+    #[serde(default)]
+    pub delivery: Option<faucet_core::DeliveryMode>,
 }
 
 /// Execution-time controls.
@@ -1089,5 +1100,45 @@ pipeline:
         let cfg = parse_with_extension(yaml, "yaml").unwrap();
         let l = cfg.lineage.expect("lineage parsed");
         assert_eq!(l.namespace, "prod");
+    }
+
+    #[test]
+    fn delivery_defaults_to_at_least_once_and_parses_exactly_once() {
+        // Default when omitted: top-level delivery should be AtLeastOnce.
+        let yaml = r#"
+version: 1
+pipeline:
+  source: { type: rest, config: {} }
+  sink:   { type: jsonl, config: { path: ./o.jsonl } }
+"#;
+        let cfg = parse_with_extension(yaml, "yaml").unwrap();
+        assert_eq!(cfg.delivery, faucet_core::DeliveryMode::AtLeastOnce);
+
+        // Explicit exactly_once at top level.
+        let yaml2 = r#"
+version: 1
+delivery: exactly_once
+pipeline:
+  source: { type: rest, config: {} }
+  sink:   { type: jsonl, config: { path: ./o.jsonl } }
+"#;
+        let cfg2 = parse_with_extension(yaml2, "yaml").unwrap();
+        assert_eq!(cfg2.delivery, faucet_core::DeliveryMode::ExactlyOnce);
+
+        // Matrix row: absent delivery inherits (None), explicit overrides.
+        let yaml3 = r#"
+version: 1
+delivery: at_least_once
+pipeline:
+  source: { type: rest, config: {} }
+  sink:   { type: jsonl, config: { path: ./o.jsonl } }
+matrix:
+  - id: a
+  - id: b
+    delivery: exactly_once
+"#;
+        let cfg3 = parse_with_extension(yaml3, "yaml").unwrap();
+        assert_eq!(cfg3.matrix[0].delivery, None);
+        assert_eq!(cfg3.matrix[1].delivery, Some(faucet_core::DeliveryMode::ExactlyOnce));
     }
 }

--- a/cli/src/env_config.rs
+++ b/cli/src/env_config.rs
@@ -321,6 +321,7 @@ pub fn build_pipeline_config(env: &HashMap<String, String>) -> CliResult<Pipelin
         matrix: Vec::new(),
         execution: None,
         observability: None,
+        delivery: faucet_core::DeliveryMode::default(),
         #[cfg(feature = "schedule")]
         schedule: None,
         #[cfg(feature = "lineage")]

--- a/cli/src/executor.rs
+++ b/cli/src/executor.rs
@@ -1874,6 +1874,7 @@ matrix:
                 transforms: Vec::new(),
                 state: None,
                 dlq: None,
+                delivery: faucet_core::DeliveryMode::AtLeastOnce,
                 #[cfg(feature = "quality")]
                 quality: None,
                 deferred_refs: refs
@@ -1935,6 +1936,7 @@ matrix:
             transforms: Vec::new(),
             state: None,
             dlq: None,
+            delivery: faucet_core::DeliveryMode::AtLeastOnce,
             #[cfg(feature = "quality")]
             quality: None,
             deferred_refs: vec![DeferredRef {

--- a/cli/src/executor.rs
+++ b/cli/src/executor.rs
@@ -1282,6 +1282,7 @@ mod tests {
             matrix: Vec::new(),
             execution: None,
             observability: None,
+            delivery: faucet_core::DeliveryMode::default(),
             #[cfg(feature = "schedule")]
             schedule: None,
             #[cfg(feature = "lineage")]

--- a/cli/src/executor.rs
+++ b/cli/src/executor.rs
@@ -876,6 +876,9 @@ async fn run_one_invocation(
     } else {
         pipeline
     };
+    // Delivery guarantee (exactly-once resume/skip when the node opted in; the
+    // expand gate already verified source/sink/state support).
+    let pipeline = pipeline.with_delivery(node.delivery);
     // ── Lineage: START + heartbeat + terminal ────────────────────────────────
     #[cfg(feature = "lineage")]
     let lineage_ctx = match (&lineage, &lineage_cfg) {

--- a/cli/src/expand.rs
+++ b/cli/src/expand.rs
@@ -215,6 +215,7 @@ pub fn expand(cfg: &PipelineConfig) -> CliResult<Vec<ExpandedNode>> {
             inherit_transforms: true,
             state: None,
             dlq: None,
+            delivery: None,
         }];
         &synthetic_row
     } else {

--- a/cli/src/expand.rs
+++ b/cli/src/expand.rs
@@ -1523,8 +1523,14 @@ pipeline:
         let err = expand(&cfg).unwrap_err();
         match &err {
             CliError::Config(msg) => {
-                assert!(msg.contains("rest"), "expected source kind in error, got: {msg}");
-                assert!(msg.contains("exactly_once") || msg.contains("not supported"), "got: {msg}");
+                assert!(
+                    msg.contains("rest"),
+                    "expected source kind in error, got: {msg}"
+                );
+                assert!(
+                    msg.contains("exactly_once") || msg.contains("not supported"),
+                    "got: {msg}"
+                );
             }
             other => panic!("expected Config error, got {other:?}"),
         }
@@ -1547,8 +1553,14 @@ pipeline:
         let err = expand(&cfg).unwrap_err();
         match &err {
             CliError::Config(msg) => {
-                assert!(msg.contains("stdout"), "expected sink kind in error, got: {msg}");
-                assert!(msg.contains("exactly_once") || msg.contains("not supported"), "got: {msg}");
+                assert!(
+                    msg.contains("stdout"),
+                    "expected sink kind in error, got: {msg}"
+                );
+                assert!(
+                    msg.contains("exactly_once") || msg.contains("not supported"),
+                    "got: {msg}"
+                );
             }
             other => panic!("expected Config error, got {other:?}"),
         }

--- a/cli/src/expand.rs
+++ b/cli/src/expand.rs
@@ -42,6 +42,9 @@ pub struct ExpandedNode {
     /// matrix-row override in v1, so this is `cfg.pipeline.quality` verbatim.
     #[cfg(feature = "quality")]
     pub quality: Option<faucet_core::QualitySpec>,
+    /// Delivery guarantee for this row. Resolved from the row's override or
+    /// falls back to the top-level `cfg.delivery`.
+    pub delivery: faucet_core::DeliveryMode,
     /// Every `${id.path}` placeholder that survived load-time interpolation.
     /// Populated by `collect_deferred`; the executor uses this to know
     /// which parent record to feed which row.
@@ -348,6 +351,8 @@ pub fn expand(cfg: &PipelineConfig) -> CliResult<Vec<ExpandedNode>> {
             transforms.extend(row_ts.iter().cloned());
         }
         let state = row.state.clone().or_else(|| cfg.pipeline.state.clone());
+        // Row override wins; fall back to the top-level delivery mode.
+        let delivery = row.delivery.unwrap_or(cfg.delivery);
         // Three-state match: Some(None) = disable, Some(Some(spec)) = replace,
         // None = inherit. The naive `.flatten().or_else()` would conflate
         // disable and absent, silently inheriting on explicit null.
@@ -414,6 +419,38 @@ pub fn expand(cfg: &PipelineConfig) -> CliResult<Vec<ExpandedNode>> {
             }
         }
 
+        // Exactly-once delivery gate: enforce source, sink, state, and DLQ
+        // compatibility at config-load time so `faucet validate` catches
+        // unsupported combinations before any run starts.
+        if delivery == faucet_core::DeliveryMode::ExactlyOnce {
+            if !crate::registry::source_supports_exactly_once(&merged_source.kind) {
+                return Err(CliError::Config(format!(
+                    "row '{}': delivery: exactly_once is not supported by source '{}' \
+                     (deterministic-replay sources only: postgres-cdc, mysql-cdc, mongodb-cdc)",
+                    ids[i], merged_source.kind
+                )));
+            }
+            if !crate::registry::sink_supports_idempotent_writes(&merged_sink.kind) {
+                return Err(CliError::Config(format!(
+                    "row '{}': delivery: exactly_once is not supported by sink '{}' \
+                     (idempotent sinks only: sqlite, postgres, mysql, mssql, iceberg)",
+                    ids[i], merged_sink.kind
+                )));
+            }
+            if state.is_none() {
+                return Err(CliError::Config(format!(
+                    "row '{}': delivery: exactly_once requires a state store",
+                    ids[i]
+                )));
+            }
+            if dlq.is_some() {
+                return Err(CliError::Config(format!(
+                    "row '{}': delivery: exactly_once is not compatible with a DLQ in this version",
+                    ids[i]
+                )));
+            }
+        }
+
         out.push(ExpandedNode {
             id: ids[i].clone(),
             row_index: i,
@@ -423,6 +460,7 @@ pub fn expand(cfg: &PipelineConfig) -> CliResult<Vec<ExpandedNode>> {
             transforms,
             state,
             dlq,
+            delivery,
             #[cfg(feature = "quality")]
             quality,
             deferred_refs: deferred,
@@ -1464,5 +1502,97 @@ execution:
 "#;
         let cfg = parse_with_extension(yaml, "yaml").unwrap();
         assert!(expand(&cfg).is_ok());
+    }
+
+    // --- exactly-once delivery gate tests ---
+
+    #[test]
+    fn exactly_once_rejects_non_cdc_source() {
+        // rest→stdout with exactly_once must fail: rest is not replay-capable.
+        let yaml = r#"
+version: 1
+delivery: exactly_once
+pipeline:
+  source: { type: rest, config: { base_url: https://x } }
+  sink:   { type: stdout, config: {} }
+  state:
+    type: memory
+    config: {}
+"#;
+        let cfg = parse_with_extension(yaml, "yaml").unwrap();
+        let err = expand(&cfg).unwrap_err();
+        match &err {
+            CliError::Config(msg) => {
+                assert!(msg.contains("rest"), "expected source kind in error, got: {msg}");
+                assert!(msg.contains("exactly_once") || msg.contains("not supported"), "got: {msg}");
+            }
+            other => panic!("expected Config error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn exactly_once_rejects_non_idempotent_sink() {
+        // postgres-cdc→stdout: source is OK but stdout is not idempotent.
+        let yaml = r#"
+version: 1
+delivery: exactly_once
+pipeline:
+  source: { type: postgres-cdc, config: {} }
+  sink:   { type: stdout, config: {} }
+  state:
+    type: memory
+    config: {}
+"#;
+        let cfg = parse_with_extension(yaml, "yaml").unwrap();
+        let err = expand(&cfg).unwrap_err();
+        match &err {
+            CliError::Config(msg) => {
+                assert!(msg.contains("stdout"), "expected sink kind in error, got: {msg}");
+                assert!(msg.contains("exactly_once") || msg.contains("not supported"), "got: {msg}");
+            }
+            other => panic!("expected Config error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn exactly_once_accepted_with_cdc_source_idempotent_sink_and_state() {
+        // postgres-cdc → sqlite + state → must expand successfully.
+        let yaml = r#"
+version: 1
+delivery: exactly_once
+pipeline:
+  source: { type: postgres-cdc, config: {} }
+  sink:   { type: sqlite, config: {} }
+  state:
+    type: memory
+    config: {}
+"#;
+        let cfg = parse_with_extension(yaml, "yaml").unwrap();
+        let nodes = expand(&cfg).unwrap();
+        assert_eq!(nodes.len(), 1);
+        assert_eq!(nodes[0].delivery, faucet_core::DeliveryMode::ExactlyOnce);
+    }
+
+    #[test]
+    fn exactly_once_rejects_missing_state_store() {
+        // Valid CDC pair but no state block → must fail with "requires a state store".
+        let yaml = r#"
+version: 1
+delivery: exactly_once
+pipeline:
+  source: { type: postgres-cdc, config: {} }
+  sink:   { type: sqlite, config: {} }
+"#;
+        let cfg = parse_with_extension(yaml, "yaml").unwrap();
+        let err = expand(&cfg).unwrap_err();
+        match &err {
+            CliError::Config(msg) => {
+                assert!(
+                    msg.contains("state store") || msg.contains("state"),
+                    "expected state-store mention in error, got: {msg}"
+                );
+            }
+            other => panic!("expected Config error, got {other:?}"),
+        }
     }
 }

--- a/cli/src/registry.rs
+++ b/cli/src/registry.rs
@@ -340,6 +340,20 @@ pub async fn build_sink(kind: &str, config: Value, auth: &AuthCatalog) -> CliRes
     }
 }
 
+/// Source connector kinds that deterministically replay (exactly-once-capable).
+/// Mirrors `Source::supports_exactly_once` overrides — keep in sync when a new
+/// source opts in. See docs/superpowers/plans/2026-06-09-exactly-once-delivery.md.
+pub fn source_supports_exactly_once(kind: &str) -> bool {
+    matches!(kind, "postgres-cdc" | "mysql-cdc" | "mongodb-cdc")
+}
+
+/// Sink connector kinds that can durably commit a token atomically with data.
+/// Mirrors `Sink::supports_idempotent_writes` overrides — keep in sync when a
+/// new sink opts in.
+pub fn sink_supports_idempotent_writes(kind: &str) -> bool {
+    matches!(kind, "sqlite" | "postgres" | "mysql" | "mssql" | "iceberg")
+}
+
 /// Return the JSON Schema for the named source's config struct.
 pub fn source_schema(kind: &str) -> CliResult<Value> {
     match kind {

--- a/crates/core/src/idempotency.rs
+++ b/crates/core/src/idempotency.rs
@@ -11,7 +11,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 /// Delivery guarantee for a pipeline run.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[derive(
+    Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum DeliveryMode {
     /// Today's behaviour: a page may be re-delivered after a crash between the
@@ -70,7 +72,11 @@ pub fn unwrap_state(value: &Value) -> (Option<Value>, u64) {
         return (bookmark, seq);
     }
     // Legacy bare bookmark.
-    let bookmark = if value.is_null() { None } else { Some(value.clone()) };
+    let bookmark = if value.is_null() {
+        None
+    } else {
+        Some(value.clone())
+    };
     (bookmark, 0)
 }
 
@@ -153,7 +159,10 @@ mod tests {
     #[test]
     fn delivery_mode_serde_is_snake_case_and_defaults_at_least_once() {
         assert_eq!(DeliveryMode::default(), DeliveryMode::AtLeastOnce);
-        assert_eq!(serde_json::to_string(&DeliveryMode::ExactlyOnce).unwrap(), "\"exactly_once\"");
+        assert_eq!(
+            serde_json::to_string(&DeliveryMode::ExactlyOnce).unwrap(),
+            "\"exactly_once\""
+        );
         let m: DeliveryMode = serde_json::from_str("\"at_least_once\"").unwrap();
         assert_eq!(m, DeliveryMode::AtLeastOnce);
     }

--- a/crates/core/src/idempotency.rs
+++ b/crates/core/src/idempotency.rs
@@ -1,0 +1,160 @@
+//! Exactly-once / idempotent delivery primitives.
+//!
+//! The pipeline issues a monotonic **commit token** for every page that carries
+//! a bookmark. The token is persisted in the [`StateStore`](crate::state::StateStore)
+//! value next to the bookmark and committed inside the sink's own transaction,
+//! so a crash between "sink durably wrote" and "state persisted" is resolved on
+//! resume by skipping pages the sink already committed. See
+//! `docs/superpowers/specs/2026-06-09-exactly-once-delivery-design.md`.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Delivery guarantee for a pipeline run.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum DeliveryMode {
+    /// Today's behaviour: a page may be re-delivered after a crash between the
+    /// sink write and the bookmark persist. Downstream must tolerate duplicates.
+    #[default]
+    AtLeastOnce,
+    /// The sink durably records a per-page commit token atomically with the
+    /// data; on resume the pipeline skips already-committed pages. Requires a
+    /// state store, an idempotent sink, and a deterministic-replay source.
+    ExactlyOnce,
+}
+
+/// Reserved key marking the exactly-once state wrapper object.
+const EO_MARKER: &str = "__faucet_eo";
+const EO_BOOKMARK: &str = "bookmark";
+const EO_SEQ: &str = "seq";
+
+/// Width of the zero-padded decimal token. `u64::MAX` is 20 digits, so 20 makes
+/// lexicographic order match numeric order for the full `u64` range.
+const TOKEN_WIDTH: usize = 20;
+
+/// Render a page sequence as a fixed-width, lexicographically-ordered token.
+pub fn format_token(seq: u64) -> String {
+    format!("{seq:0TOKEN_WIDTH$}")
+}
+
+/// Parse a token produced by [`format_token`]. Returns `None` on garbage.
+pub fn parse_token(s: &str) -> Option<u64> {
+    s.trim().parse::<u64>().ok()
+}
+
+/// Wrap a bookmark + sequence into the exactly-once state value.
+pub fn wrap_state(bookmark: Option<&Value>, seq: u64) -> Value {
+    serde_json::json!({
+        EO_MARKER: 1,
+        EO_BOOKMARK: bookmark.cloned().unwrap_or(Value::Null),
+        EO_SEQ: seq,
+    })
+}
+
+/// Unwrap a stored state value into `(bookmark, seq)`.
+///
+/// A value that is the exactly-once wrapper object unwraps to its inner
+/// bookmark + seq. Anything else is treated as a legacy/at-least-once **bare
+/// bookmark** with `seq = 0` — so switching an existing pipeline to
+/// `exactly_once` resumes cleanly (the sink's own watermark is authoritative).
+pub fn unwrap_state(value: &Value) -> (Option<Value>, u64) {
+    if let Value::Object(map) = value
+        && map.get(EO_MARKER).and_then(Value::as_u64) == Some(1)
+    {
+        let bookmark = match map.get(EO_BOOKMARK) {
+            None | Some(Value::Null) => None,
+            Some(v) => Some(v.clone()),
+        };
+        let seq = map.get(EO_SEQ).and_then(Value::as_u64).unwrap_or(0);
+        return (bookmark, seq);
+    }
+    // Legacy bare bookmark.
+    let bookmark = if value.is_null() { None } else { Some(value.clone()) };
+    (bookmark, 0)
+}
+
+/// Canonical watermark table the SQL sinks UPSERT the commit token into.
+pub const COMMIT_TOKEN_TABLE: &str = "_faucet_commit_token";
+/// Watermark column holding the pipeline state-key (`{name}::{row_id}`).
+pub const COMMIT_TOKEN_SCOPE_COL: &str = "scope";
+/// Watermark column holding the latest committed token.
+pub const COMMIT_TOKEN_TOKEN_COL: &str = "token";
+
+/// Iceberg snapshot summary property names.
+pub const ICEBERG_SCOPE_PROP: &str = "faucet.commit-scope";
+pub const ICEBERG_TOKEN_PROP: &str = "faucet.commit-token";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn token_round_trips_and_orders_lexicographically() {
+        assert_eq!(format_token(42).len(), TOKEN_WIDTH);
+        assert_eq!(parse_token(&format_token(42)), Some(42));
+        assert_eq!(parse_token(&format_token(0)), Some(0));
+        assert_eq!(parse_token(&format_token(u64::MAX)), Some(u64::MAX));
+        assert!(format_token(9) < format_token(10));
+        assert!(format_token(2) < format_token(1000));
+    }
+
+    #[test]
+    fn parse_token_rejects_garbage() {
+        assert_eq!(parse_token("abc"), None);
+        assert_eq!(parse_token(""), None);
+    }
+
+    #[test]
+    fn wrap_then_unwrap_preserves_bookmark_and_seq() {
+        let bm = json!({"lsn": "0/16B2D58"});
+        let wrapped = wrap_state(Some(&bm), 7);
+        let (got_bm, got_seq) = unwrap_state(&wrapped);
+        assert_eq!(got_bm, Some(bm));
+        assert_eq!(got_seq, 7);
+    }
+
+    #[test]
+    fn wrap_none_bookmark_unwraps_to_none() {
+        let wrapped = wrap_state(None, 3);
+        let (got_bm, got_seq) = unwrap_state(&wrapped);
+        assert_eq!(got_bm, None);
+        assert_eq!(got_seq, 3);
+    }
+
+    #[test]
+    fn legacy_bare_bookmark_unwraps_with_seq_zero() {
+        let (bm, seq) = unwrap_state(&json!("2024-12-01"));
+        assert_eq!(bm, Some(json!("2024-12-01")));
+        assert_eq!(seq, 0);
+        let (bm2, seq2) = unwrap_state(&json!({"updated_at": "2024-12-01"}));
+        assert_eq!(bm2, Some(json!({"updated_at": "2024-12-01"})));
+        assert_eq!(seq2, 0);
+    }
+
+    #[test]
+    fn object_with_non_sentinel_marker_is_treated_as_bare_bookmark() {
+        // A legacy/user object that merely contains the key must NOT be misread
+        // as an EO wrapper — only the typed sentinel `1` counts.
+        let v = json!({"__faucet_eo": null, "offset": 500});
+        let (bm, seq) = unwrap_state(&v);
+        assert_eq!(bm, Some(v));
+        assert_eq!(seq, 0);
+    }
+
+    #[test]
+    fn null_value_unwraps_to_none_seq_zero() {
+        let (bm, seq) = unwrap_state(&json!(null));
+        assert_eq!(bm, None);
+        assert_eq!(seq, 0);
+    }
+
+    #[test]
+    fn delivery_mode_serde_is_snake_case_and_defaults_at_least_once() {
+        assert_eq!(DeliveryMode::default(), DeliveryMode::AtLeastOnce);
+        assert_eq!(serde_json::to_string(&DeliveryMode::ExactlyOnce).unwrap(), "\"exactly_once\"");
+        let m: DeliveryMode = serde_json::from_str("\"at_least_once\"").unwrap();
+        assert_eq!(m, DeliveryMode::AtLeastOnce);
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -19,6 +19,7 @@ pub mod check;
 pub mod config;
 pub mod dlq;
 pub mod error;
+pub mod idempotency;
 pub mod observability;
 pub mod pipeline;
 #[cfg(feature = "quality")]
@@ -43,6 +44,7 @@ pub use auth::{AuthProvider, AuthReference, AuthSpec, Credential, SharedAuthProv
 pub use check::{CheckContext, CheckReport, Probe, ProbeStatus};
 pub use dlq::{DlqConfig, DlqReason, DlqStats, OnBatchError, build_envelope};
 pub use error::FaucetError;
+pub use idempotency::{DeliveryMode, format_token, parse_token, unwrap_state, wrap_state};
 #[cfg(feature = "quality")]
 pub use observability::instrumented_apply_quality;
 pub use observability::{

--- a/crates/core/src/observability/options.rs
+++ b/crates/core/src/observability/options.rs
@@ -26,6 +26,12 @@ pub struct RunStreamOptions {
     /// orphaning the file), and returns the partial result. Without this, a
     /// dropped run future loses everything written-but-unflushed (#146 H16).
     pub cancel: Option<CancellationToken>,
+    /// Delivery guarantee. `AtLeastOnce` (default) leaves the write path
+    /// unchanged. `ExactlyOnce` enables the resume/skip + atomic-token path.
+    pub delivery: crate::idempotency::DeliveryMode,
+    /// Resume sequence read from the (unwrapped) exactly-once state value.
+    /// Ignored unless `delivery == ExactlyOnce`. Defaults to 0.
+    pub start_seq: u64,
 }
 
 impl RunStreamOptions {
@@ -77,6 +83,19 @@ impl RunStreamOptions {
         quality: std::sync::Arc<crate::quality::CompiledQuality>,
     ) -> Self {
         self.quality = Some(quality);
+        self
+    }
+
+    /// Set the delivery mode.
+    pub fn with_delivery(mut self, mode: crate::idempotency::DeliveryMode) -> Self {
+        self.delivery = mode;
+        self
+    }
+
+    /// Set the resume sequence (exactly-once). Normally derived by
+    /// `Pipeline::run` from the unwrapped state value.
+    pub fn with_start_seq(mut self, seq: u64) -> Self {
+        self.start_seq = seq;
         self
     }
 }

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -334,10 +334,19 @@ impl<'a, So: Source + ?Sized, Si: Sink + ?Sized> Pipeline<'a, So, Si> {
             // Bookmark resume — goes through the wrapped state store so the
             // get is instrumented too.
             let state_key = self.source.state_key();
+            let mut start_seq = 0u64;
             if let (Some(store), Some(key)) = (wrapped_state_store.as_ref(), state_key.as_ref()) {
                 validate_state_key(key)?;
                 if let Some(prior) = store.get(key).await? {
-                    wrapped_source.apply_start_bookmark(prior).await?;
+                    if self.delivery == crate::idempotency::DeliveryMode::ExactlyOnce {
+                        let (bookmark, seq) = crate::idempotency::unwrap_state(&prior);
+                        start_seq = seq;
+                        if let Some(bm) = bookmark {
+                            wrapped_source.apply_start_bookmark(bm).await?;
+                        }
+                    } else {
+                        wrapped_source.apply_start_bookmark(prior).await?;
+                    }
                 }
             }
 
@@ -364,6 +373,7 @@ impl<'a, So: Source + ?Sized, Si: Sink + ?Sized> Pipeline<'a, So, Si> {
             if let Some(cancel) = self.cancel.clone() {
                 opts = opts.with_cancel(cancel);
             }
+            opts = opts.with_delivery(self.delivery).with_start_seq(start_seq);
 
             run_stream(pages, &wrapped_sink, opts).await
         }
@@ -441,6 +451,37 @@ where
     if let Some(key) = state_key.as_ref() {
         validate_state_key(key)?;
     }
+
+    // ── Exactly-once gates + resume ──────────────────────────────────────────
+    let exactly_once = options.delivery == crate::idempotency::DeliveryMode::ExactlyOnce;
+    if exactly_once {
+        if !sink.supports_idempotent_writes() {
+            return Err(FaucetError::Config(format!(
+                "delivery: exactly_once requires an idempotent sink, but '{}' does not support it",
+                sink.connector_name()
+            )));
+        }
+        if state_store.is_none() || state_key.is_none() {
+            return Err(FaucetError::Config(
+                "delivery: exactly_once requires a state store".into(),
+            ));
+        }
+        if dlq.is_some() {
+            return Err(FaucetError::Config(
+                "delivery: exactly_once is not compatible with a DLQ in this version".into(),
+            ));
+        }
+    }
+    let scope = state_key.clone().unwrap_or_default();
+    let mut next_seq = options.start_seq;
+    let committed_seq = if exactly_once {
+        sink.last_committed_token(&scope)
+            .await?
+            .and_then(|t| crate::idempotency::parse_token(&t))
+            .unwrap_or(0)
+    } else {
+        0
+    };
 
     let mut records_written = 0usize;
     let mut last_bookmark: Option<Value> = None;
@@ -788,6 +829,53 @@ where
                         if let Some(e) = budget_error {
                             return Err(e);
                         }
+                    } else if exactly_once {
+                        // ── Exactly-once path ──────────────────────────────────
+                        // A token is issued only for bookmark-carrying pages, so
+                        // (seq, bookmark) advance together and realign on resume.
+                        if let Some(bookmark) = page.bookmark {
+                            next_seq += 1;
+                            let token = crate::idempotency::format_token(next_seq);
+                            if next_seq <= committed_seq {
+                                // Sink already durably committed this page. Skip
+                                // the write; advance state so a later crash does
+                                // not re-skip it.
+                                use metrics::{Label, SharedString, counter};
+                                let skip_labels: Vec<Label> = vec![
+                                    Label::new(
+                                        "pipeline",
+                                        SharedString::from(pipeline_name.clone()),
+                                    ),
+                                    Label::new("row", SharedString::from(row.clone())),
+                                ];
+                                counter!("faucet_pipeline_pages_skipped_total", skip_labels)
+                                    .increment(1);
+                            } else {
+                                records_written += sink
+                                    .write_batch_idempotent(&page.records, &scope, &token)
+                                    .await?;
+                            }
+                            sink.flush().await?;
+                            let bm_labels =
+                                crate::observability::Labels::new(&*pipeline_name, &*row, &*run_id);
+                            crate::observability::update_bookmark_lag(&bookmark, &bm_labels);
+                            if let (Some(store), Some(key)) =
+                                (state_store.as_ref(), state_key.as_ref())
+                            {
+                                store
+                                    .put(
+                                        key,
+                                        &crate::idempotency::wrap_state(Some(&bookmark), next_seq),
+                                    )
+                                    .await?;
+                            }
+                            last_bookmark = Some(bookmark);
+                        } else if !page.records.is_empty() {
+                            // No bookmark → not individually checkpointed; write
+                            // as-is (rare for EO sources, which bookmark every
+                            // page). Stays at-least-once for this page.
+                            records_written += sink.write_batch(&page.records).await?;
+                        }
                     } else {
                         // ── DLQ-disabled path (today's behaviour) ──────────────
                         debug_assert!(
@@ -1097,6 +1185,149 @@ mod tests {
                 .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             Ok(())
         }
+    }
+
+    // ── Exactly-once test doubles ────────────────────────────────────────────
+
+    /// In-memory sink that commits rows + a per-scope token atomically.
+    struct IdempotentMockSink {
+        rows: std::sync::Mutex<Vec<Value>>,
+        tokens: std::sync::Mutex<std::collections::HashMap<String, String>>,
+    }
+    impl IdempotentMockSink {
+        fn new() -> Self {
+            Self {
+                rows: std::sync::Mutex::new(Vec::new()),
+                tokens: std::sync::Mutex::new(std::collections::HashMap::new()),
+            }
+        }
+        fn rows(&self) -> Vec<Value> {
+            self.rows.lock().unwrap().clone()
+        }
+    }
+    #[async_trait]
+    impl Sink for IdempotentMockSink {
+        async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
+            self.rows.lock().unwrap().extend(records.iter().cloned());
+            Ok(records.len())
+        }
+        fn supports_idempotent_writes(&self) -> bool {
+            true
+        }
+        async fn write_batch_idempotent(
+            &self,
+            records: &[Value],
+            scope: &str,
+            token: &str,
+        ) -> Result<usize, FaucetError> {
+            self.rows.lock().unwrap().extend(records.iter().cloned());
+            self.tokens
+                .lock()
+                .unwrap()
+                .insert(scope.to_string(), token.to_string());
+            Ok(records.len())
+        }
+        async fn last_committed_token(&self, scope: &str) -> Result<Option<String>, FaucetError> {
+            Ok(self.tokens.lock().unwrap().get(scope).cloned())
+        }
+    }
+
+    fn eo_opts(store: Arc<dyn StateStore>, key: &str, start_seq: u64) -> RunStreamOptions {
+        RunStreamOptions::new()
+            .with_state(store, key)
+            .with_delivery(crate::idempotency::DeliveryMode::ExactlyOnce)
+            .with_start_seq(start_seq)
+    }
+
+    #[tokio::test]
+    async fn exactly_once_writes_pages_and_persists_wrapped_state() {
+        let pages = vec![
+            Ok(StreamPage {
+                records: vec![json!({"id": 1})],
+                bookmark: Some(json!("b1")),
+            }),
+            Ok(StreamPage {
+                records: vec![json!({"id": 2})],
+                bookmark: Some(json!("b2")),
+            }),
+        ];
+        let sink = IdempotentMockSink::new();
+        let store: Arc<dyn StateStore> = Arc::new(crate::state::MemoryStateStore::new());
+        let r = run_stream(
+            futures::stream::iter(pages),
+            &sink,
+            eo_opts(store.clone(), "k", 0),
+        )
+        .await
+        .unwrap();
+        assert_eq!(r.records_written, 2);
+        let (bm, seq) = crate::idempotency::unwrap_state(&store.get("k").await.unwrap().unwrap());
+        assert_eq!(bm, Some(json!("b2")));
+        assert_eq!(seq, 2);
+        assert_eq!(
+            sink.last_committed_token("k").await.unwrap(),
+            Some(crate::idempotency::format_token(2))
+        );
+    }
+
+    #[tokio::test]
+    async fn exactly_once_skips_already_committed_pages_on_resume() {
+        let sink = IdempotentMockSink::new();
+        // Run 1: commit page seq 1 directly (simulate crash: state lost).
+        sink.write_batch_idempotent(
+            &[json!({"id": 1})],
+            "k",
+            &crate::idempotency::format_token(1),
+        )
+        .await
+        .unwrap();
+        assert_eq!(sink.rows().len(), 1);
+        // Run 2 (resume): fresh state, full replay. Page 1 must be skipped.
+        let pages = vec![
+            Ok(StreamPage {
+                records: vec![json!({"id": 1})],
+                bookmark: Some(json!("b1")),
+            }),
+            Ok(StreamPage {
+                records: vec![json!({"id": 2})],
+                bookmark: Some(json!("b2")),
+            }),
+        ];
+        let store: Arc<dyn StateStore> = Arc::new(crate::state::MemoryStateStore::new());
+        let r = run_stream(futures::stream::iter(pages), &sink, eo_opts(store, "k", 0))
+            .await
+            .unwrap();
+        assert_eq!(r.records_written, 1);
+        let rows = sink.rows();
+        assert_eq!(rows.len(), 2, "exactly one row per id — no duplicate of id=1");
+        assert_eq!(rows.iter().filter(|v| v["id"] == 1).count(), 1);
+    }
+
+    #[tokio::test]
+    async fn exactly_once_rejects_non_idempotent_sink() {
+        let pages: Vec<Result<StreamPage, FaucetError>> = vec![];
+        let store: Arc<dyn StateStore> = Arc::new(crate::state::MemoryStateStore::new());
+        let r = run_stream(
+            futures::stream::iter(pages),
+            &MockSink::new(),
+            eo_opts(store, "k", 0),
+        )
+        .await;
+        assert!(matches!(r, Err(FaucetError::Config(_))));
+    }
+
+    #[tokio::test]
+    async fn exactly_once_rejects_missing_state_store() {
+        let pages: Vec<Result<StreamPage, FaucetError>> = vec![];
+        let opts =
+            RunStreamOptions::new().with_delivery(crate::idempotency::DeliveryMode::ExactlyOnce);
+        let r = run_stream(
+            futures::stream::iter(pages),
+            &IdempotentMockSink::new(),
+            opts,
+        )
+        .await;
+        assert!(matches!(r, Err(FaucetError::Config(_))));
     }
 
     // ── StreamPage / batch_size tests ───────────────────────────────────────

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -1299,7 +1299,11 @@ mod tests {
             .unwrap();
         assert_eq!(r.records_written, 1);
         let rows = sink.rows();
-        assert_eq!(rows.len(), 2, "exactly one row per id — no duplicate of id=1");
+        assert_eq!(
+            rows.len(),
+            2,
+            "exactly one row per id — no duplicate of id=1"
+        );
         assert_eq!(rows.iter().filter(|v| v["id"] == 1).count(), 1);
     }
 

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -133,6 +133,7 @@ pub struct Pipeline<'a, So: Source + ?Sized, Si: Sink + ?Sized> {
     quality: Option<Arc<crate::quality::CompiledQuality>>,
     adaptive: Option<crate::adaptive::AdaptiveBatchConfig>,
     cancel: Option<tokio_util::sync::CancellationToken>,
+    delivery: crate::idempotency::DeliveryMode,
 }
 
 impl<'a, So: Source + ?Sized, Si: Sink + ?Sized> Pipeline<'a, So, Si> {
@@ -150,6 +151,7 @@ impl<'a, So: Source + ?Sized, Si: Sink + ?Sized> Pipeline<'a, So, Si> {
             quality: None,
             adaptive: None,
             cancel: None,
+            delivery: crate::idempotency::DeliveryMode::AtLeastOnce,
         }
     }
 
@@ -221,6 +223,15 @@ impl<'a, So: Source + ?Sized, Si: Sink + ?Sized> Pipeline<'a, So, Si> {
     /// instead of leaving the file unreadable (#146 H16).
     pub fn with_cancel(mut self, cancel: tokio_util::sync::CancellationToken) -> Self {
         self.cancel = Some(cancel);
+        self
+    }
+
+    /// Set the delivery guarantee. `ExactlyOnce` requires a state store, an
+    /// idempotent sink (`Sink::supports_idempotent_writes`), and a
+    /// deterministic-replay source — otherwise `run` returns
+    /// `FaucetError::Config`.
+    pub fn with_delivery(mut self, mode: crate::idempotency::DeliveryMode) -> Self {
+        self.delivery = mode;
         self
     }
 

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -147,6 +147,18 @@ pub trait Source: Send + Sync {
         Ok(())
     }
 
+    /// Whether this source **deterministically replays** the same page sequence
+    /// from a given bookmark — the requirement for exactly-once delivery (a
+    /// non-deterministic replay could cause the pipeline to skip a page whose
+    /// contents differ from the one already committed). Default: `false`.
+    ///
+    /// Sources with a durable monotonic position and per-page bookmarks (CDC)
+    /// override this to return `true`. The pipeline rejects
+    /// `DeliveryMode::ExactlyOnce` against a source that returns `false`.
+    fn supports_exactly_once(&self) -> bool {
+        false
+    }
+
     /// Stable identifier used as the `connector` label on metrics and the
     /// `connector` attribute on spans. Defaults to the final segment of
     /// `std::any::type_name::<Self>()`, e.g. `"RestSource"`. Built-in
@@ -234,6 +246,42 @@ pub trait Sink: Send + Sync {
     async fn write_batch_partial(&self, records: &[Value]) -> Result<Vec<RowOutcome>, FaucetError> {
         self.write_batch(records).await?;
         Ok(records.iter().map(|_| Ok(())).collect())
+    }
+
+    /// Whether this sink can durably commit a page's rows **and** a commit token
+    /// in a single atomic transaction. Default: `false` (at-least-once only).
+    ///
+    /// Only return `true` from a sink that genuinely commits both atomically —
+    /// see [`write_batch_idempotent`](Self::write_batch_idempotent). The pipeline
+    /// rejects `DeliveryMode::ExactlyOnce` against a sink that returns `false`.
+    fn supports_idempotent_writes(&self) -> bool {
+        false
+    }
+
+    /// Write `records` AND durably record `token` for `scope`, atomically.
+    ///
+    /// `scope` namespaces the watermark (the pipeline passes the per-row state
+    /// key, e.g. `"{name}::{row_id}"`). `token` is a monotonic, fixed-width
+    /// string (see [`format_token`](crate::format_token)).
+    ///
+    /// The default is **not** idempotent: it ignores the token and delegates to
+    /// [`write_batch`](Self::write_batch). Override only when the commit is
+    /// genuinely atomic (and return `true` from `supports_idempotent_writes`).
+    async fn write_batch_idempotent(
+        &self,
+        records: &[Value],
+        scope: &str,
+        token: &str,
+    ) -> Result<usize, FaucetError> {
+        let _ = (scope, token);
+        self.write_batch(records).await
+    }
+
+    /// The last token durably committed for `scope`, or `None` if this sink has
+    /// never committed under that scope. Default: `None`.
+    async fn last_committed_token(&self, scope: &str) -> Result<Option<String>, FaucetError> {
+        let _ = scope;
+        Ok(None)
     }
 
     /// Return a JSON Schema describing the configuration this sink accepts.
@@ -730,5 +778,27 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(report.failed_count(), 0);
+    }
+
+    // ── idempotent-write / exactly-once capability tests ──────────────────────
+
+    #[tokio::test]
+    async fn sink_default_is_not_idempotent() {
+        let sink = MockSink::new();
+        assert!(!sink.supports_idempotent_writes());
+        // Default write_batch_idempotent ignores the token and delegates.
+        let n = sink
+            .write_batch_idempotent(&[json!({"id": 1})], "scope::a", "00000000000000000001")
+            .await
+            .unwrap();
+        assert_eq!(n, 1);
+        assert_eq!(sink.last_committed_token("scope::a").await.unwrap(), None);
+        assert_eq!(sink.written.lock().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn source_default_does_not_support_exactly_once() {
+        let source = MockSource { records: vec![] };
+        assert!(!source.supports_exactly_once());
     }
 }

--- a/crates/sink/iceberg/README.md
+++ b/crates/sink/iceberg/README.md
@@ -237,6 +237,42 @@ pipeline:
       batch_size: 10000
 ```
 
+## Exactly-once delivery
+
+`IcebergSink` implements `Sink::supports_idempotent_writes` (returns `true`) and the two companion hooks:
+
+- `write_batch_idempotent(records, scope, token)` — writes `records` and records the `token` as Iceberg **snapshot summary properties** (`faucet.commit-scope` and `faucet.commit-token`) on the committed snapshot, so both are durable in the same atomic catalog operation.
+- `last_committed_token(scope)` — scans recent snapshots for a matching `faucet.commit-scope` entry to let the pipeline skip already-committed pages on resume.
+
+To use exactly-once delivery, set `delivery: exactly_once` in your pipeline config and pair this sink with one of the CDC sources (`postgres-cdc`, `mysql-cdc`, `mongodb-cdc`) plus a `state:` block. A DLQ is not permitted in exactly-once mode. All four requirements are validated at config-load time (`faucet validate`) before any run starts.
+
+```yaml
+pipeline:
+  source:
+    type: postgres-cdc
+    config:
+      connection_url: postgres://faucet:faucet@localhost:5432/appdb
+      slot_name: faucet_slot
+      publication_name: faucet_pub
+  sink:
+    type: iceberg
+    config:
+      catalog:
+        type: rest
+        uri: http://catalog.example.com
+        warehouse: s3://lake/warehouse
+      namespace: ["analytics"]
+      table: change_events
+      create_if_missing: true
+  state:
+    type: file
+    config:
+      path: ./state
+delivery: exactly_once
+```
+
+See the [Exactly-once delivery cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/state.html#exactly-once-delivery) for full rationale and the supported source/sink set.
+
 ## Lineage dataset URI
 
 `iceberg://<catalog_type>/<namespace>.<table>` — e.g. `iceberg://rest/prod.events` (catalog type is `rest`, `glue`, `sql`, or `hms`).

--- a/crates/sink/iceberg/src/sink.rs
+++ b/crates/sink/iceberg/src/sink.rs
@@ -68,6 +68,10 @@ struct SinkState {
 
     /// `DataFile`s accumulated from closed writers, awaiting the next commit.
     pending_files: Vec<DataFile>,
+
+    /// Exactly-once commit token to stamp onto the next committed snapshot.
+    /// Set by `write_batch_idempotent` and consumed (cleared) by `commit_pending`.
+    pending_commit: Option<(String, String)>,
 }
 
 impl SinkState {
@@ -76,6 +80,7 @@ impl SinkState {
             table: preloaded,
             writer: None,
             pending_files: Vec::new(),
+            pending_commit: None,
         }
     }
 }
@@ -316,6 +321,35 @@ impl IcebergSink {
         Ok(())
     }
 
+    /// Load the table read-only from the catalog, without creating it.
+    ///
+    /// Returns `Ok(None)` if the table does not exist yet (first run before any
+    /// data has been written), `Ok(Some(table))` if it exists, or `Err` on a
+    /// catalog communication failure.
+    async fn load_table_readonly(&self) -> Result<Option<Table>, FaucetError> {
+        let ns = NamespaceIdent::from_strs(self.config.namespace.iter().map(String::as_str))
+            .map_err(|e| FaucetError::Sink(format!("iceberg: invalid namespace: {e}")))?;
+        let tid = TableIdent::new(ns, self.config.table.clone());
+
+        let exists = self
+            .catalog
+            .table_exists(&tid)
+            .await
+            .map_err(|e| FaucetError::Sink(format!("iceberg: table_exists check failed: {e}")))?;
+
+        if !exists {
+            return Ok(None);
+        }
+
+        let table = self
+            .catalog
+            .load_table(&tid)
+            .await
+            .map_err(|e| FaucetError::Sink(format!("iceberg: load_table failed: {e}")))?;
+
+        Ok(Some(table))
+    }
+
     /// Commit all pending data files as a single `fast_append` snapshot.
     ///
     /// `Transaction::commit` in iceberg 0.9.1 already includes an internal
@@ -340,10 +374,25 @@ impl IcebergSink {
             .clone();
 
         let tx = Transaction::new(&table);
-        let mut action = tx.fast_append().add_data_files(files);
 
-        if !self.config.snapshot_properties.is_empty() {
-            action = action.set_snapshot_properties(self.config.snapshot_properties.clone());
+        // Merge config snapshot properties with the exactly-once commit token (if any).
+        // The token is taken out of state so it is stamped exactly once, atomically
+        // with the data files in this fast_append commit.
+        let mut props = self.config.snapshot_properties.clone();
+        if let Some((scope, token)) = state.pending_commit.take() {
+            props.insert(
+                faucet_core::idempotency::ICEBERG_SCOPE_PROP.to_string(),
+                scope,
+            );
+            props.insert(
+                faucet_core::idempotency::ICEBERG_TOKEN_PROP.to_string(),
+                token,
+            );
+        }
+
+        let mut action = tx.fast_append().add_data_files(files);
+        if !props.is_empty() {
+            action = action.set_snapshot_properties(props);
         }
 
         let tx = action
@@ -440,6 +489,65 @@ impl faucet_core::Sink for IcebergSink {
         };
 
         Ok(CheckReport::single(probe))
+    }
+
+    fn supports_idempotent_writes(&self) -> bool {
+        true
+    }
+
+    /// Write `records` and durably record the exactly-once `(scope, token)` in
+    /// the same atomic `fast_append` snapshot commit.
+    ///
+    /// The token is stashed on `SinkState::pending_commit` here and merged into
+    /// the snapshot's summary properties inside `commit_pending` (called from
+    /// `flush`). Both the data files and the token properties land in the same
+    /// `Transaction::fast_append` commit, so they are atomic by Iceberg's
+    /// optimistic-concurrency guarantee.
+    async fn write_batch_idempotent(
+        &self,
+        records: &[Value],
+        scope: &str,
+        token: &str,
+    ) -> Result<usize, FaucetError> {
+        let n = self.write_batch(records).await?;
+        let mut state = self.state.lock().await;
+        state.pending_commit = Some((scope.to_string(), token.to_string()));
+        Ok(n)
+    }
+
+    /// Return the last commit token recorded for `scope` in this table's
+    /// snapshot history, or `None` if no token has been committed yet.
+    ///
+    /// Snapshots are scanned newest-first; the first snapshot whose
+    /// `faucet.commit-scope` property matches `scope` wins.  If the table does
+    /// not yet exist `Ok(None)` is returned immediately.
+    async fn last_committed_token(&self, scope: &str) -> Result<Option<String>, FaucetError> {
+        let table = match self.load_table_readonly().await? {
+            Some(t) => t,
+            None => return Ok(None),
+        };
+
+        let meta = table.metadata();
+        let mut snaps: Vec<_> = meta.snapshots().collect();
+        // Sort newest-first so we return the most recent matching token.
+        snaps.sort_by_key(|s| std::cmp::Reverse(s.timestamp_ms()));
+
+        for snap in snaps {
+            let summary = snap.summary();
+            if summary
+                .additional_properties
+                .get(faucet_core::idempotency::ICEBERG_SCOPE_PROP)
+                .map(String::as_str)
+                == Some(scope)
+            {
+                return Ok(summary
+                    .additional_properties
+                    .get(faucet_core::idempotency::ICEBERG_TOKEN_PROP)
+                    .cloned());
+            }
+        }
+
+        Ok(None)
     }
 
     /// Write a batch of records to the Iceberg table.

--- a/crates/sink/iceberg/src/sink.rs
+++ b/crates/sink/iceberg/src/sink.rs
@@ -331,11 +331,10 @@ impl IcebergSink {
             .map_err(|e| FaucetError::Sink(format!("iceberg: invalid namespace: {e}")))?;
         let tid = TableIdent::new(ns, self.config.table.clone());
 
-        let exists = self
-            .catalog
-            .table_exists(&tid)
-            .await
-            .map_err(|e| FaucetError::Sink(format!("iceberg: table_exists check failed: {e}")))?;
+        let exists =
+            self.catalog.table_exists(&tid).await.map_err(|e| {
+                FaucetError::Sink(format!("iceberg: table_exists check failed: {e}"))
+            })?;
 
         if !exists {
             return Ok(None);

--- a/crates/sink/mssql/README.md
+++ b/crates/sink/mssql/README.md
@@ -93,6 +93,41 @@ authentication and Azure AD / Managed Identity are out of scope.
 Unit tests run with `cargo test -p faucet-sink-mssql --lib`. The integration
 tests (`--test integration`) require Docker.
 
+## Exactly-once delivery
+
+`MssqlSink` implements `Sink::supports_idempotent_writes` (returns `true`) and the two companion hooks:
+
+- `write_batch_idempotent(records, scope, token)` — writes `records` and UPSERTs the `token` into a `_faucet_commit_token(scope NVARCHAR, token NVARCHAR)` watermark table inside the **same transaction** (respecting `transaction_per_batch`), so both either commit together or neither does.
+- `last_committed_token(scope)` — reads the current watermark to let the pipeline skip already-committed pages on resume.
+
+To use exactly-once delivery, set `delivery: exactly_once` in your pipeline config and pair this sink with one of the CDC sources (`postgres-cdc`, `mysql-cdc`, `mongodb-cdc`) plus a `state:` block. A DLQ is not permitted in exactly-once mode. All four requirements are validated at config-load time (`faucet validate`) before any run starts.
+
+```yaml
+pipeline:
+  source:
+    type: mongodb-cdc
+    config:
+      connection_uri: "mongodb://localhost:27017/?replicaSet=rs0"
+      scope:
+        type: collection
+        database: appdb
+        collection: orders
+  sink:
+    type: mssql
+    config:
+      connection_url: "mssql://sa:Str0ng%40Pass@localhost:1433/warehouse"
+      table: "dbo.change_events"
+      column_mapping:
+        type: auto_columns
+  state:
+    type: file
+    config:
+      path: ./state
+delivery: exactly_once
+```
+
+See the [Exactly-once delivery cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/state.html#exactly-once-delivery) for full rationale and the supported source/sink set.
+
 ## Lineage dataset URI
 
 `<connection_url_or_string>?table=<table>` (password redacted) — e.g. `Server=tcp:host,1433;Database=db;User Id=sa;Password=***;?table=orders`.

--- a/crates/sink/mssql/src/sink.rs
+++ b/crates/sink/mssql/src/sink.rs
@@ -162,6 +162,77 @@ impl MssqlSink {
         }
     }
 
+    /// Insert rows within an **already-open** transaction — caller owns
+    /// `BEGIN TRAN`/`COMMIT TRAN`/`ROLLBACK TRAN`.  Splits into ≤2100-param
+    /// sub-INSERTs but does NOT issue any transaction-control statements.
+    ///
+    /// Used by `write_batch_idempotent` so the data INSERTs and the commit-token
+    /// MERGE share one externally-managed transaction.
+    ///
+    /// Returns `Err((error, timed_out))`. When `timed_out` is `true` the `exec`
+    /// future was dropped mid-TDS, leaving the connection desynced — the caller
+    /// must NOT issue ROLLBACK on it (mirrors `insert_chunk`).
+    async fn insert_rows_no_txn(
+        &self,
+        conn: &mut MssqlPooledConnection<'_>,
+        cols: &[String],
+        rows: &[Vec<BoundParam>],
+    ) -> Result<usize, (FaucetError, bool)> {
+        if rows.is_empty() {
+            return Ok(0);
+        }
+        let cols_quoted: Vec<String> = cols
+            .iter()
+            .map(|c| quote_ident_mssql(c))
+            .collect::<Result<_, _>>()
+            .map_err(|e| (e, false))?;
+        let per_insert = max_rows_per_insert(cols_quoted.len());
+        for sub in rows.chunks(per_insert) {
+            let sql = build_insert_sql(&self.table_quoted, &cols_quoted, sub.len());
+            let owned: Vec<&BoundParam> = sub.iter().flatten().collect();
+            let refs: Vec<&dyn ToSql> = owned.iter().map(|p| p.as_tosql()).collect();
+            let exec = async {
+                conn.execute(sql.as_str(), &refs)
+                    .await
+                    .map(|_| ())
+                    .map_err(|e| FaucetError::Sink(format!("MSSQL insert failed: {e}")))
+            };
+            // On timeout the `exec` future is dropped mid-TDS, desyncing the
+            // connection — the caller must NOT issue ROLLBACK on it (mirrors
+            // `insert_chunk`).
+            let (result, timed_out) = match self.timeout() {
+                Some(t) => match tokio::time::timeout(t, exec).await {
+                    Ok(inner) => (inner, false),
+                    Err(_) => (Err(FaucetError::Sink("MSSQL insert timed out".into())), true),
+                },
+                None => (exec.await, false),
+            };
+            if let Err(e) = result {
+                return Err((e, timed_out));
+            }
+        }
+        Ok(rows.len())
+    }
+
+    /// Ensure the per-sink commit-token watermark table exists.
+    /// Uses `IF OBJECT_ID … IS NULL CREATE TABLE` so it is idempotent.
+    async fn ensure_commit_table(
+        &self,
+        conn: &mut MssqlPooledConnection<'_>,
+    ) -> Result<(), FaucetError> {
+        // NVARCHAR(450) is the maximum SQL Server index key byte budget (900 B /
+        // 2 bytes-per-char = 450 chars). The table / column names are the fixed
+        // constants — no user-controlled input in this string.
+        let sql = format!(
+            "IF OBJECT_ID(N'{tbl}', N'U') IS NULL \
+             CREATE TABLE [{tbl}] ([scope] NVARCHAR(450) PRIMARY KEY, \
+             [token] NVARCHAR(32) NOT NULL, \
+             [updated_at] DATETIME2 DEFAULT SYSUTCDATETIME())",
+            tbl = faucet_core::idempotency::COMMIT_TOKEN_TABLE,
+        );
+        control(conn, &sql).await
+    }
+
     /// Insert one chunk, splitting into ≤2100-parameter sub-INSERTs wrapped in a
     /// single transaction (when `transaction_per_batch`). Returns rows inserted.
     async fn insert_chunk(
@@ -365,6 +436,82 @@ impl Sink for MssqlSink {
         Ok(())
     }
 
+    fn supports_idempotent_writes(&self) -> bool {
+        true
+    }
+
+    async fn last_committed_token(&self, scope: &str) -> Result<Option<String>, FaucetError> {
+        let mut conn = self.checkout().await?;
+        self.ensure_commit_table(&mut conn).await?;
+        let scope_owned = scope.to_string();
+        let rows = conn
+            .query(
+                &format!(
+                    "SELECT [token] FROM [{}] WHERE [scope] = @P1",
+                    faucet_core::idempotency::COMMIT_TOKEN_TABLE
+                ),
+                &[&scope_owned],
+            )
+            .await
+            .map_err(|e| FaucetError::Sink(format!("MSSQL token read failed: {e}")))?
+            .into_first_result()
+            .await
+            .map_err(|e| FaucetError::Sink(format!("MSSQL token read failed: {e}")))?;
+        Ok(rows
+            .first()
+            .and_then(|r| r.get::<&str, _>("token"))
+            .map(str::to_string))
+    }
+
+    async fn write_batch_idempotent(
+        &self,
+        records: &[Value],
+        scope: &str,
+        token: &str,
+    ) -> Result<usize, FaucetError> {
+        let mut conn = self.checkout().await?;
+        self.ensure_commit_table(&mut conn).await?;
+        control(&mut conn, "BEGIN TRAN").await?;
+
+        let written = match self.prepare_chunk(records).await {
+            Ok(Some((cols, rows))) => match self.insert_rows_no_txn(&mut conn, &cols, &rows).await {
+                Ok(n) => n,
+                Err((e, timed_out)) => {
+                    // Desynced connection on timeout — ROLLBACK would run on a
+                    // corrupt stream (mirrors insert_chunk). Drop the conn instead.
+                    if !timed_out {
+                        let _ = control(&mut conn, "ROLLBACK TRAN").await;
+                    }
+                    return Err(e);
+                }
+            },
+            Ok(None) => 0,
+            Err(e) => {
+                let _ = control(&mut conn, "ROLLBACK TRAN").await;
+                return Err(e);
+            }
+        };
+
+        // UPSERT the commit token atomically with the data rows.
+        let merge = format!(
+            "MERGE [{tbl}] AS t \
+             USING (SELECT @P1 AS [scope], @P2 AS [token]) AS s \
+             ON t.[scope] = s.[scope] \
+             WHEN MATCHED THEN UPDATE SET t.[token] = s.[token], t.[updated_at] = SYSUTCDATETIME() \
+             WHEN NOT MATCHED THEN INSERT ([scope], [token]) VALUES (s.[scope], s.[token]);",
+            tbl = faucet_core::idempotency::COMMIT_TOKEN_TABLE,
+        );
+        let (scope_owned, token_owned) = (scope.to_string(), token.to_string());
+        let refs: Vec<&dyn ToSql> = vec![&scope_owned, &token_owned];
+        if let Err(e) = conn.execute(merge.as_str(), &refs).await {
+            let _ = control(&mut conn, "ROLLBACK TRAN").await;
+            return Err(FaucetError::Sink(format!("MSSQL token merge failed: {e}")));
+        }
+
+        control(&mut conn, "COMMIT TRAN").await?;
+        Ok(written)
+    }
+
     fn config_schema(&self) -> Value {
         serde_json::to_value(faucet_core::schema_for!(MssqlSinkConfig))
             .expect("schema serialization")
@@ -424,6 +571,28 @@ mod tests {
         assert_eq!(
             quote_table("my.sales.events").unwrap(),
             "[my].[sales].[events]"
+        );
+    }
+
+    #[test]
+    fn idempotency_constant_names() {
+        // The commit table and column constants used in ensure_commit_table,
+        // last_committed_token, and write_batch_idempotent must match the
+        // canonical values from faucet_core::idempotency.
+        assert_eq!(
+            faucet_core::idempotency::COMMIT_TOKEN_TABLE,
+            "_faucet_commit_token",
+            "COMMIT_TOKEN_TABLE name changed — update DDL and queries"
+        );
+        assert_eq!(
+            faucet_core::idempotency::COMMIT_TOKEN_SCOPE_COL,
+            "scope",
+            "COMMIT_TOKEN_SCOPE_COL name changed — update DDL and queries"
+        );
+        assert_eq!(
+            faucet_core::idempotency::COMMIT_TOKEN_TOKEN_COL,
+            "token",
+            "COMMIT_TOKEN_TOKEN_COL name changed — update DDL and queries"
         );
     }
 

--- a/crates/sink/mssql/src/sink.rs
+++ b/crates/sink/mssql/src/sink.rs
@@ -203,7 +203,10 @@ impl MssqlSink {
             let (result, timed_out) = match self.timeout() {
                 Some(t) => match tokio::time::timeout(t, exec).await {
                     Ok(inner) => (inner, false),
-                    Err(_) => (Err(FaucetError::Sink("MSSQL insert timed out".into())), true),
+                    Err(_) => (
+                        Err(FaucetError::Sink("MSSQL insert timed out".into())),
+                        true,
+                    ),
                 },
                 None => (exec.await, false),
             };
@@ -474,17 +477,19 @@ impl Sink for MssqlSink {
         control(&mut conn, "BEGIN TRAN").await?;
 
         let written = match self.prepare_chunk(records).await {
-            Ok(Some((cols, rows))) => match self.insert_rows_no_txn(&mut conn, &cols, &rows).await {
-                Ok(n) => n,
-                Err((e, timed_out)) => {
-                    // Desynced connection on timeout — ROLLBACK would run on a
-                    // corrupt stream (mirrors insert_chunk). Drop the conn instead.
-                    if !timed_out {
-                        let _ = control(&mut conn, "ROLLBACK TRAN").await;
+            Ok(Some((cols, rows))) => {
+                match self.insert_rows_no_txn(&mut conn, &cols, &rows).await {
+                    Ok(n) => n,
+                    Err((e, timed_out)) => {
+                        // Desynced connection on timeout — ROLLBACK would run on a
+                        // corrupt stream (mirrors insert_chunk). Drop the conn instead.
+                        if !timed_out {
+                            let _ = control(&mut conn, "ROLLBACK TRAN").await;
+                        }
+                        return Err(e);
                     }
-                    return Err(e);
                 }
-            },
+            }
             Ok(None) => 0,
             Err(e) => {
                 let _ = control(&mut conn, "ROLLBACK TRAN").await;

--- a/crates/sink/mysql/README.md
+++ b/crates/sink/mysql/README.md
@@ -269,6 +269,37 @@ let sink = MysqlSink::new(config).await?;
 - In AutoMap mode, column names are queried from `INFORMATION_SCHEMA.COLUMNS` for the current database. A multi-row INSERT is built dynamically with `?` placeholders. Column values are bound as **native MySQL types** (#78/#4). The column set is the **union** of record keys across the batch, so a field present only in a later record is still written; a row missing a column binds SQL `NULL`. The INSERT is sub-chunked so `rows × columns` never exceeds MySQL's 65,535-placeholder limit.
 - All identifiers (table names, column names) are quoted with backticks using MySQL-safe escaping (embedded backticks are doubled).
 
+## Exactly-once delivery
+
+`MysqlSink` implements `Sink::supports_idempotent_writes` (returns `true`) and the two companion hooks:
+
+- `write_batch_idempotent(records, scope, token)` — writes `records` and UPSERTs the `token` into a `_faucet_commit_token(scope VARCHAR, token VARCHAR)` watermark table inside the **same transaction**, so both either commit together or neither does.
+- `last_committed_token(scope)` — reads the current watermark to let the pipeline skip already-committed pages on resume.
+
+To use exactly-once delivery, set `delivery: exactly_once` in your pipeline config and pair this sink with one of the CDC sources (`postgres-cdc`, `mysql-cdc`, `mongodb-cdc`) plus a `state:` block. A DLQ is not permitted in exactly-once mode. All four requirements are validated at config-load time (`faucet validate`) before any run starts.
+
+```yaml
+pipeline:
+  source:
+    type: mysql-cdc
+    config:
+      connection_url: mysql://faucet:faucet@localhost:3306/appdb
+      server_id: 1
+  sink:
+    type: mysql
+    config:
+      connection_url: mysql://writer:pass@localhost:3306/warehouse
+      table_name: change_events
+      column_mapping: auto_map
+  state:
+    type: file
+    config:
+      path: ./state
+delivery: exactly_once
+```
+
+See the [Exactly-once delivery cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/state.html#exactly-once-delivery) for full rationale and the supported source/sink set.
+
 ## Lineage dataset URI
 
 `mysql://<host>:<port>/<db>?table=<table>` (credentials stripped) — e.g. `mysql://host:3306/app?table=orders`.

--- a/crates/sink/mysql/src/sink.rs
+++ b/crates/sink/mysql/src/sink.rs
@@ -403,7 +403,10 @@ mod tests {
 
     #[test]
     fn commit_token_table_is_the_shared_constant() {
-        assert_eq!(faucet_core::idempotency::COMMIT_TOKEN_TABLE, "_faucet_commit_token");
+        assert_eq!(
+            faucet_core::idempotency::COMMIT_TOKEN_TABLE,
+            "_faucet_commit_token"
+        );
     }
 
     #[test]

--- a/crates/sink/mysql/src/sink.rs
+++ b/crates/sink/mysql/src/sink.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use faucet_core::FaucetError;
 use serde_json::Value;
 use sqlx::mysql::MySqlPoolOptions;
-use sqlx::{MySqlPool, Row};
+use sqlx::{MySqlConnection, MySqlPool, Row};
 
 /// A sink that writes JSON records to a MySQL table.
 pub struct MysqlSink {
@@ -34,8 +34,16 @@ impl MysqlSink {
     }
 
     /// Insert a batch of records using JSON column mode.
+    ///
+    /// Executes on the provided connection (a bare pool connection for
+    /// `write_batch`, or a `&mut *tx` transaction for `write_batch_idempotent`).
     /// Uses a single multi-row INSERT for efficiency.
-    async fn insert_json(&self, records: &[Value], column: &str) -> Result<usize, FaucetError> {
+    async fn insert_json(
+        &self,
+        conn: &mut MySqlConnection,
+        records: &[Value],
+        column: &str,
+    ) -> Result<usize, FaucetError> {
         if records.is_empty() {
             return Ok(0);
         }
@@ -56,7 +64,7 @@ impl MysqlSink {
             q = q.bind(json_str);
         }
 
-        q.execute(&self.pool)
+        q.execute(&mut *conn)
             .await
             .map_err(|e| FaucetError::Sink(format!("MySQL insert failed: {e}")))?;
 
@@ -65,9 +73,15 @@ impl MysqlSink {
 
     /// Insert a batch of records using auto-mapped columns.
     ///
-    /// Discovers column names from INFORMATION_SCHEMA and maps
-    /// top-level JSON fields to columns. Uses a single multi-row INSERT.
-    async fn insert_auto_map(&self, records: &[Value]) -> Result<usize, FaucetError> {
+    /// Discovers column names from INFORMATION_SCHEMA and maps top-level JSON
+    /// fields to columns. Executes on the provided connection (a bare pool
+    /// connection for `write_batch`, or a `&mut *tx` transaction for
+    /// `write_batch_idempotent`). Uses a single multi-row INSERT.
+    async fn insert_auto_map(
+        &self,
+        conn: &mut MySqlConnection,
+        records: &[Value],
+    ) -> Result<usize, FaucetError> {
         if records.is_empty() {
             return Ok(0);
         }
@@ -77,7 +91,7 @@ impl MysqlSink {
             "SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = ? AND TABLE_SCHEMA = DATABASE() ORDER BY ORDINAL_POSITION"
         )
         .bind(&self.config.table_name)
-        .fetch_all(&self.pool)
+        .fetch_all(&mut *conn)
         .await
         .map_err(|e| FaucetError::Sink(format!("failed to query table columns: {e}")))?
         .iter()
@@ -193,12 +207,31 @@ impl MysqlSink {
                 }
             }
 
-            q.execute(&self.pool)
+            q.execute(&mut *conn)
                 .await
                 .map_err(|e| FaucetError::Sink(format!("MySQL insert failed: {e}")))?;
         }
 
         Ok(num_rows)
+    }
+
+    /// Create the commit-token watermark table if it does not yet exist.
+    ///
+    /// The table holds one row per pipeline scope (state key). MySQL requires a
+    /// fixed-length column as the primary key, so `scope` is `VARCHAR(255)` and
+    /// `token` is `VARCHAR(32)` (tokens are 20-char ulids, 32 chars is ample).
+    async fn ensure_commit_table(&self) -> Result<(), FaucetError> {
+        let sql = format!(
+            "CREATE TABLE IF NOT EXISTS {t} ({s} VARCHAR(255) PRIMARY KEY, {k} VARCHAR(32) NOT NULL, updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)",
+            t = quote_ident_mysql(faucet_core::idempotency::COMMIT_TOKEN_TABLE),
+            s = quote_ident_mysql(faucet_core::idempotency::COMMIT_TOKEN_SCOPE_COL),
+            k = quote_ident_mysql(faucet_core::idempotency::COMMIT_TOKEN_TOKEN_COL),
+        );
+        sqlx::query(&sql)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| FaucetError::Sink(format!("MySQL commit-table create failed: {e}")))?;
+        Ok(())
     }
 }
 
@@ -258,10 +291,20 @@ impl faucet_core::Sink for MysqlSink {
     /// `config.batch_size == 0`, the entire slice is sent in a single
     /// multi-row `INSERT` — useful when upstream `StreamPage`s are already
     /// sized for MySQL's `max_allowed_packet` limit.
+    ///
+    /// Acquires a single connection from the pool and sends every chunk
+    /// through it under autocommit (no explicit transaction), preserving the
+    /// pre-refactor observable behaviour.
     async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
         if records.is_empty() {
             return Ok(0);
         }
+
+        let mut conn = self
+            .pool
+            .acquire()
+            .await
+            .map_err(|e| FaucetError::Sink(format!("MySQL pool acquire failed: {e}")))?;
 
         let chunks: Vec<&[Value]> = if self.config.batch_size == 0 {
             // Sentinel: pass the entire upstream page through in a single
@@ -275,8 +318,10 @@ impl faucet_core::Sink for MysqlSink {
         let mut total = 0;
         for chunk in chunks {
             total += match &self.config.column_mapping {
-                MysqlColumnMapping::Json { column } => self.insert_json(chunk, column).await?,
-                MysqlColumnMapping::AutoMap => self.insert_auto_map(chunk).await?,
+                MysqlColumnMapping::Json { column } => {
+                    self.insert_json(&mut conn, chunk, column).await?
+                }
+                MysqlColumnMapping::AutoMap => self.insert_auto_map(&mut conn, chunk).await?,
             };
         }
 
@@ -287,6 +332,66 @@ impl faucet_core::Sink for MysqlSink {
         );
         Ok(total)
     }
+
+    fn supports_idempotent_writes(&self) -> bool {
+        true
+    }
+
+    async fn last_committed_token(&self, scope: &str) -> Result<Option<String>, FaucetError> {
+        self.ensure_commit_table().await?;
+        let sql = format!(
+            "SELECT {k} FROM {t} WHERE {s} = ?",
+            t = quote_ident_mysql(faucet_core::idempotency::COMMIT_TOKEN_TABLE),
+            k = quote_ident_mysql(faucet_core::idempotency::COMMIT_TOKEN_TOKEN_COL),
+            s = quote_ident_mysql(faucet_core::idempotency::COMMIT_TOKEN_SCOPE_COL),
+        );
+        let row = sqlx::query(&sql)
+            .bind(scope)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| FaucetError::Sink(format!("MySQL token read failed: {e}")))?;
+        Ok(row.map(|r| r.get::<String, _>(0)))
+    }
+
+    async fn write_batch_idempotent(
+        &self,
+        records: &[Value],
+        scope: &str,
+        token: &str,
+    ) -> Result<usize, FaucetError> {
+        self.ensure_commit_table().await?;
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| FaucetError::Sink(format!("MySQL transaction begin failed: {e}")))?;
+
+        let written = match &self.config.column_mapping {
+            MysqlColumnMapping::Json { column } => {
+                self.insert_json(&mut tx, records, column).await?
+            }
+            MysqlColumnMapping::AutoMap => self.insert_auto_map(&mut tx, records).await?,
+        };
+
+        let upsert = format!(
+            "INSERT INTO {t} ({s}, {k}) VALUES (?, ?) ON DUPLICATE KEY UPDATE {k} = VALUES({k})",
+            t = quote_ident_mysql(faucet_core::idempotency::COMMIT_TOKEN_TABLE),
+            s = quote_ident_mysql(faucet_core::idempotency::COMMIT_TOKEN_SCOPE_COL),
+            k = quote_ident_mysql(faucet_core::idempotency::COMMIT_TOKEN_TOKEN_COL),
+        );
+        sqlx::query(&upsert)
+            .bind(scope)
+            .bind(token)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| FaucetError::Sink(format!("MySQL token upsert failed: {e}")))?;
+
+        tx.commit()
+            .await
+            .map_err(|e| FaucetError::Sink(format!("MySQL transaction commit failed: {e}")))?;
+
+        Ok(written)
+    }
 }
 
 #[cfg(test)]
@@ -295,6 +400,11 @@ mod tests {
 
     // dataset_uri test is skipped: MysqlSink::new() requires a live pool
     // (connects to MySQL in new()), and no offline constructor exists.
+
+    #[test]
+    fn commit_token_table_is_the_shared_constant() {
+        assert_eq!(faucet_core::idempotency::COMMIT_TOKEN_TABLE, "_faucet_commit_token");
+    }
 
     #[test]
     fn quote_ident_mysql_simple() {

--- a/crates/sink/postgres/README.md
+++ b/crates/sink/postgres/README.md
@@ -276,6 +276,38 @@ let sink = PostgresSink::new(config).await?;
 - In AutoMap mode, each column's name **and underlying type** (`udt_name`) are queried from the PostgreSQL catalog, scoped via `to_regclass` to exactly the relation the `INSERT` targets (the configured `schema`, else the `search_path`-resolved table) — so a same-named table in another schema can't pollute the column set. A multi-row `INSERT INTO ... VALUES ($1::int4, $2::timestamptz), ...` is built dynamically with a per-column cast, and each value is bound as text so the destination column's input function parses it — numbers, booleans, timestamps, uuids land in their native column types, and `json`/`jsonb` columns receive JSON text. (Values are **not** bound as `jsonb` regardless of column type — doing so previously made the typed-column example above fail at runtime.) The column set is the **union** of record keys across the batch (in declared table order), so a field present only in a later record is still written; a row missing a column binds SQL `NULL`.
 - All identifiers (table names, column names) are quoted using `quote_ident()` to prevent SQL injection.
 
+## Exactly-once delivery
+
+`PostgresSink` implements `Sink::supports_idempotent_writes` (returns `true`) and the two companion hooks:
+
+- `write_batch_idempotent(records, scope, token)` — writes `records` and UPSERTs the `token` into a `_faucet_commit_token(scope TEXT, token TEXT)` watermark table inside the **same transaction**, so both either commit together or neither does.
+- `last_committed_token(scope)` — reads the current watermark to let the pipeline skip already-committed pages on resume.
+
+To use exactly-once delivery, set `delivery: exactly_once` in your pipeline config and pair this sink with one of the CDC sources (`postgres-cdc`, `mysql-cdc`, `mongodb-cdc`) plus a `state:` block. A DLQ is not permitted in exactly-once mode. All four requirements are validated at config-load time (`faucet validate`) before any run starts.
+
+```yaml
+pipeline:
+  source:
+    type: postgres-cdc
+    config:
+      connection_url: postgres://faucet:faucet@localhost:5432/appdb
+      slot_name: faucet_slot
+      publication_name: faucet_pub
+  sink:
+    type: postgres
+    config:
+      connection_url: postgres://writer:pass@localhost:5432/warehouse
+      table_name: change_events
+      column_mapping: auto_map
+  state:
+    type: file
+    config:
+      path: ./state
+delivery: exactly_once
+```
+
+See the [Exactly-once delivery cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/state.html#exactly-once-delivery) for full rationale and the supported source/sink set.
+
 ## Lineage dataset URI
 
 `postgres://<host>:<port>/<db>?table=<schema.table>` (credentials stripped) — e.g. `postgres://host:5432/app?table=public.orders`.

--- a/crates/sink/postgres/src/sink.rs
+++ b/crates/sink/postgres/src/sink.rs
@@ -80,8 +80,18 @@ impl PostgresSink {
         Ok(Self { config, pool })
     }
 
-    /// Insert a batch of records using JSONB column mode.
-    async fn insert_jsonb(&self, records: &[Value], column: &str) -> Result<usize, FaucetError> {
+    /// Insert a batch of records using JSONB column mode, on the given connection.
+    ///
+    /// Accepts `&mut sqlx::PgConnection` so the same logic runs both standalone
+    /// (via a pool-acquired connection, autocommit) and inside the idempotent
+    /// transaction (where `&mut *tx` is passed — `Transaction<'_, Postgres>`
+    /// derefs to `PgConnection`).
+    async fn insert_jsonb(
+        &self,
+        conn: &mut sqlx::PgConnection,
+        records: &[Value],
+        column: &str,
+    ) -> Result<usize, FaucetError> {
         if records.is_empty() {
             return Ok(0);
         }
@@ -96,14 +106,20 @@ impl PostgresSink {
 
         sqlx::query(&query)
             .bind(json_values)
-            .execute(&self.pool)
+            .execute(&mut *conn)
             .await
             .map_err(|e| FaucetError::Sink(format!("PostgreSQL insert failed: {e}")))?;
 
         Ok(records.len())
     }
 
-    /// Insert a batch of records using auto-mapped columns.
+    /// Insert a batch of records using auto-mapped columns, on the given connection.
+    ///
+    /// Accepts `&mut sqlx::PgConnection` so the same logic runs both standalone
+    /// (via a pool-acquired connection, autocommit) and inside the idempotent
+    /// transaction (where `&mut *tx` is passed — `Transaction<'_, Postgres>`
+    /// derefs to `PgConnection`). Running the column-discovery query on the same
+    /// connection is harmless and avoids any cross-connection visibility surprise.
     ///
     /// Discovers each column's name *and* underlying type (`udt_name`) from the
     /// table schema and maps top-level JSON fields to columns. Each placeholder
@@ -114,7 +130,11 @@ impl PostgresSink {
     /// which sqlx encodes as `jsonb`, so an insert into any non-`jsonb` column
     /// failed at runtime — audit #146 C1.) Uses a single multi-row INSERT
     /// (sub-chunked at the 65535-parameter cap) for efficiency.
-    async fn insert_auto_map(&self, records: &[Value]) -> Result<usize, FaucetError> {
+    async fn insert_auto_map(
+        &self,
+        conn: &mut sqlx::PgConnection,
+        records: &[Value],
+    ) -> Result<usize, FaucetError> {
         if records.is_empty() {
             return Ok(0);
         }
@@ -143,7 +163,7 @@ impl PostgresSink {
              ORDER BY a.attnum",
         )
         .bind(&table_ref)
-        .fetch_all(&self.pool)
+        .fetch_all(&mut *conn)
         .await
         .map_err(|e| FaucetError::Sink(format!("failed to query table columns: {e}")))?
         .iter()
@@ -253,12 +273,27 @@ impl PostgresSink {
                 }
             }
 
-            q.execute(&self.pool)
+            q.execute(&mut *conn)
                 .await
                 .map_err(|e| FaucetError::Sink(format!("PostgreSQL insert failed: {e}")))?;
         }
 
         Ok(num_rows)
+    }
+
+    /// Ensure the commit-token watermark table exists.
+    async fn ensure_commit_table(&self) -> Result<(), FaucetError> {
+        let sql = format!(
+            "CREATE TABLE IF NOT EXISTS {t} ({s} TEXT PRIMARY KEY, {k} TEXT NOT NULL, updated_at TIMESTAMPTZ DEFAULT now())",
+            t = quote_ident(faucet_core::idempotency::COMMIT_TOKEN_TABLE),
+            s = quote_ident(faucet_core::idempotency::COMMIT_TOKEN_SCOPE_COL),
+            k = quote_ident(faucet_core::idempotency::COMMIT_TOKEN_TOKEN_COL),
+        );
+        sqlx::query(&sql)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| FaucetError::Sink(format!("PostgreSQL commit-table create failed: {e}")))?;
+        Ok(())
     }
 }
 
@@ -323,6 +358,12 @@ impl faucet_core::Sink for PostgresSink {
     /// `INSERT` — useful when upstream `StreamPage`s are already sized for
     /// Postgres' per-statement bind-parameter limit (~65 535 / num_columns
     /// in AutoMap mode).
+    ///
+    /// Acquires one connection from the pool and routes all chunks through it.
+    /// Each INSERT executes as its own autocommit statement — identical
+    /// observable behaviour to executing directly on the pool, while keeping the
+    /// same connection for the entire call (avoids repeated pool-checkout
+    /// overhead on large batches).
     async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
         if records.is_empty() {
             return Ok(0);
@@ -337,11 +378,21 @@ impl faucet_core::Sink for PostgresSink {
             records.chunks(self.config.batch_size).collect()
         };
 
+        // Acquire once; reuse for all chunks (each statement autocommits —
+        // no BEGIN is issued, so behaviour is identical to using the pool).
+        let mut conn = self
+            .pool
+            .acquire()
+            .await
+            .map_err(|e| FaucetError::Sink(format!("PostgreSQL pool acquire failed: {e}")))?;
+
         let mut total = 0;
         for chunk in chunks {
             total += match &self.config.column_mapping {
-                PostgresColumnMapping::Jsonb { column } => self.insert_jsonb(chunk, column).await?,
-                PostgresColumnMapping::AutoMap => self.insert_auto_map(chunk).await?,
+                PostgresColumnMapping::Jsonb { column } => {
+                    self.insert_jsonb(&mut conn, chunk, column).await?
+                }
+                PostgresColumnMapping::AutoMap => self.insert_auto_map(&mut conn, chunk).await?,
             };
         }
 
@@ -352,12 +403,80 @@ impl faucet_core::Sink for PostgresSink {
         );
         Ok(total)
     }
+
+    fn supports_idempotent_writes(&self) -> bool {
+        true
+    }
+
+    async fn last_committed_token(&self, scope: &str) -> Result<Option<String>, FaucetError> {
+        self.ensure_commit_table().await?;
+        let sql = format!(
+            "SELECT {k} FROM {t} WHERE {s} = $1",
+            t = quote_ident(faucet_core::idempotency::COMMIT_TOKEN_TABLE),
+            k = quote_ident(faucet_core::idempotency::COMMIT_TOKEN_TOKEN_COL),
+            s = quote_ident(faucet_core::idempotency::COMMIT_TOKEN_SCOPE_COL),
+        );
+        let row = sqlx::query(&sql)
+            .bind(scope)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| FaucetError::Sink(format!("PostgreSQL token read failed: {e}")))?;
+        Ok(row.map(|r| r.get::<String, _>(0)))
+    }
+
+    async fn write_batch_idempotent(
+        &self,
+        records: &[Value],
+        scope: &str,
+        token: &str,
+    ) -> Result<usize, FaucetError> {
+        self.ensure_commit_table().await?;
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| FaucetError::Sink(format!("PostgreSQL transaction begin failed: {e}")))?;
+
+        // Data insert(s) and the commit-token upsert share ONE transaction so
+        // the page is committed atomically with its watermark: on crash either
+        // both land or neither does, which is what makes a replay skip-on-resume
+        // produce zero duplicates.
+        let written = match &self.config.column_mapping {
+            PostgresColumnMapping::Jsonb { column } => {
+                self.insert_jsonb(&mut tx, records, column).await?
+            }
+            PostgresColumnMapping::AutoMap => self.insert_auto_map(&mut tx, records).await?,
+        };
+
+        let upsert = format!(
+            "INSERT INTO {t} ({s}, {k}) VALUES ($1, $2) ON CONFLICT ({s}) DO UPDATE SET {k} = EXCLUDED.{k}, updated_at = now()",
+            t = quote_ident(faucet_core::idempotency::COMMIT_TOKEN_TABLE),
+            s = quote_ident(faucet_core::idempotency::COMMIT_TOKEN_SCOPE_COL),
+            k = quote_ident(faucet_core::idempotency::COMMIT_TOKEN_TOKEN_COL),
+        );
+        sqlx::query(&upsert)
+            .bind(scope)
+            .bind(token)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| FaucetError::Sink(format!("PostgreSQL token upsert failed: {e}")))?;
+
+        tx.commit()
+            .await
+            .map_err(|e| FaucetError::Sink(format!("PostgreSQL transaction commit failed: {e}")))?;
+        Ok(written)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::{pg_bind_text, qualified_table_ref};
     use serde_json::json;
+
+    #[test]
+    fn commit_token_table_is_the_shared_constant() {
+        assert_eq!(faucet_core::idempotency::COMMIT_TOKEN_TABLE, "_faucet_commit_token");
+    }
 
     // dataset_uri test is skipped: PostgresSink::new() requires a live pool
     // (connects to PostgreSQL in new()), and no offline constructor exists.

--- a/crates/sink/postgres/src/sink.rs
+++ b/crates/sink/postgres/src/sink.rs
@@ -289,10 +289,9 @@ impl PostgresSink {
             s = quote_ident(faucet_core::idempotency::COMMIT_TOKEN_SCOPE_COL),
             k = quote_ident(faucet_core::idempotency::COMMIT_TOKEN_TOKEN_COL),
         );
-        sqlx::query(&sql)
-            .execute(&self.pool)
-            .await
-            .map_err(|e| FaucetError::Sink(format!("PostgreSQL commit-table create failed: {e}")))?;
+        sqlx::query(&sql).execute(&self.pool).await.map_err(|e| {
+            FaucetError::Sink(format!("PostgreSQL commit-table create failed: {e}"))
+        })?;
         Ok(())
     }
 }
@@ -431,11 +430,10 @@ impl faucet_core::Sink for PostgresSink {
         token: &str,
     ) -> Result<usize, FaucetError> {
         self.ensure_commit_table().await?;
-        let mut tx = self
-            .pool
-            .begin()
-            .await
-            .map_err(|e| FaucetError::Sink(format!("PostgreSQL transaction begin failed: {e}")))?;
+        let mut tx =
+            self.pool.begin().await.map_err(|e| {
+                FaucetError::Sink(format!("PostgreSQL transaction begin failed: {e}"))
+            })?;
 
         // Data insert(s) and the commit-token upsert share ONE transaction so
         // the page is committed atomically with its watermark: on crash either
@@ -475,7 +473,10 @@ mod tests {
 
     #[test]
     fn commit_token_table_is_the_shared_constant() {
-        assert_eq!(faucet_core::idempotency::COMMIT_TOKEN_TABLE, "_faucet_commit_token");
+        assert_eq!(
+            faucet_core::idempotency::COMMIT_TOKEN_TABLE,
+            "_faucet_commit_token"
+        );
     }
 
     // dataset_uri test is skipped: PostgresSink::new() requires a live pool

--- a/crates/sink/sqlite/Cargo.toml
+++ b/crates/sink/sqlite/Cargo.toml
@@ -21,9 +21,13 @@ sqlx = { workspace = true, features = ["runtime-tokio", "sqlite", "json"] }
 tokio.workspace = true
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros", "rt"] }
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
 serde_json.workspace = true
 tempfile = "3"
+futures.workspace = true
+async-trait.workspace = true
+faucet-core.workspace = true
+sqlx = { workspace = true, features = ["runtime-tokio", "sqlite", "json"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/sink/sqlite/README.md
+++ b/crates/sink/sqlite/README.md
@@ -254,6 +254,38 @@ let sink = SqliteSink::new(config).await?;
 - All identifiers (table names, column names) are quoted using `quote_ident()` (double-quote escaping) to prevent SQL injection.
 - Transaction wrapping ensures that either all rows in a batch are committed or none are, providing atomicity per batch.
 
+## Exactly-once delivery
+
+`SqliteSink` implements `Sink::supports_idempotent_writes` (returns `true`) and the two companion hooks:
+
+- `write_batch_idempotent(records, scope, token)` — writes `records` and UPSERTs the `token` into a `_faucet_commit_token(scope TEXT, token TEXT)` watermark table inside the **same `BEGIN`/`COMMIT` transaction**, so both either commit together or neither does.
+- `last_committed_token(scope)` — reads the current watermark to let the pipeline skip already-committed pages on resume.
+
+To use exactly-once delivery, set `delivery: exactly_once` in your pipeline config and pair this sink with one of the CDC sources (`postgres-cdc`, `mysql-cdc`, `mongodb-cdc`) plus a `state:` block. A DLQ is not permitted in exactly-once mode. All four requirements are validated at config-load time (`faucet validate`) before any run starts.
+
+```yaml
+pipeline:
+  source:
+    type: postgres-cdc
+    config:
+      connection_url: postgres://faucet:faucet@localhost:5432/appdb
+      slot_name: faucet_slot
+      publication_name: faucet_pub
+  sink:
+    type: sqlite
+    config:
+      database_url: /data/warehouse.db
+      table_name: change_events
+      column_mapping: auto_map
+  state:
+    type: file
+    config:
+      path: ./state
+delivery: exactly_once
+```
+
+See the [Exactly-once delivery cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/state.html#exactly-once-delivery) for full rationale and the supported source/sink set.
+
 ## Lineage dataset URI
 
 `sqlite://<path>?table=<table>` — e.g. `sqlite:///tmp/test.db?table=events`.

--- a/crates/sink/sqlite/src/sink.rs
+++ b/crates/sink/sqlite/src/sink.rs
@@ -42,44 +42,58 @@ impl SqliteSink {
         Ok(Self { config, pool })
     }
 
+    /// Insert JSON-column records within an existing transaction, sub-chunking
+    /// at SQLite's bind-variable cap. JSON mode binds one variable per row.
+    async fn insert_json_tx(
+        &self,
+        tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+        records: &[Value],
+        column: &str,
+    ) -> Result<usize, FaucetError> {
+        if records.is_empty() {
+            return Ok(0);
+        }
+        // SQLite caps bind params per statement at 32766 (>=3.32). JSON mode
+        // binds one variable per row, so chunk at that cap.
+        const MAX_SQLITE_VARS: usize = 32766;
+        for chunk in records.chunks(MAX_SQLITE_VARS) {
+            let placeholders: Vec<&str> = chunk.iter().map(|_| "(?)").collect();
+            let insert_sql = format!(
+                "INSERT INTO {} ({}) VALUES {}",
+                quote_ident(&self.config.table_name),
+                quote_ident(column),
+                placeholders.join(", ")
+            );
+            let mut q = sqlx::query(&insert_sql);
+            for record in chunk {
+                let json_str = serde_json::to_string(record)
+                    .map_err(|e| FaucetError::Sink(format!("failed to serialize record: {e}")))?;
+                q = q.bind(json_str);
+            }
+            q.execute(&mut **tx)
+                .await
+                .map_err(|e| FaucetError::Sink(format!("SQLite insert failed: {e}")))?;
+        }
+        Ok(records.len())
+    }
+
     /// Insert a batch of records using JSON column mode.
-    /// Uses a single multi-row INSERT wrapped in a transaction.
+    /// Opens its own `BEGIN`/`COMMIT` transaction and delegates to
+    /// [`Self::insert_json_tx`], which sub-chunks at SQLite's bind-variable cap.
     async fn insert_json(&self, records: &[Value], column: &str) -> Result<usize, FaucetError> {
         if records.is_empty() {
             return Ok(0);
         }
-
-        // Build multi-row INSERT: INSERT INTO t (col) VALUES (?), (?), ...
-        let placeholders: Vec<&str> = records.iter().map(|_| "(?)").collect();
-        let insert_sql = format!(
-            "INSERT INTO {} ({}) VALUES {}",
-            quote_ident(&self.config.table_name),
-            quote_ident(column),
-            placeholders.join(", ")
-        );
-
         let mut tx = self
             .pool
             .begin()
             .await
             .map_err(|e| FaucetError::Sink(format!("SQLite transaction begin failed: {e}")))?;
-
-        let mut q = sqlx::query(&insert_sql);
-        for record in records {
-            let json_str = serde_json::to_string(record)
-                .map_err(|e| FaucetError::Sink(format!("failed to serialize record: {e}")))?;
-            q = q.bind(json_str);
-        }
-
-        q.execute(&mut *tx)
-            .await
-            .map_err(|e| FaucetError::Sink(format!("SQLite insert failed: {e}")))?;
-
+        let n = self.insert_json_tx(&mut tx, records, column).await?;
         tx.commit()
             .await
             .map_err(|e| FaucetError::Sink(format!("SQLite transaction commit failed: {e}")))?;
-
-        Ok(records.len())
+        Ok(n)
     }
 
     /// Insert a batch of records using auto-mapped columns.
@@ -92,12 +106,46 @@ impl SqliteSink {
             return Ok(0);
         }
 
-        // Get column names from the table using pragma_table_info.
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| FaucetError::Sink(format!("SQLite transaction begin failed: {e}")))?;
+
+        let written = self.insert_auto_map_tx(&mut tx, records).await?;
+
+        tx.commit()
+            .await
+            .map_err(|e| FaucetError::Sink(format!("SQLite transaction commit failed: {e}")))?;
+
+        Ok(written)
+    }
+
+    /// Auto-map insert against an in-progress transaction.
+    ///
+    /// This is the reusable core shared by [`Self::insert_auto_map`] (which
+    /// opens its own `BEGIN`/`COMMIT`) and [`faucet_core::Sink::write_batch_idempotent`]
+    /// (which folds the insert and the commit-token upsert into one
+    /// transaction). The read-only `PRAGMA table_info` column-discovery query
+    /// runs on the transaction's own connection (`&mut **tx`), not on
+    /// `&self.pool` — otherwise, with the default single-connection pool, it
+    /// would deadlock waiting for a connection the open transaction is holding.
+    async fn insert_auto_map_tx(
+        &self,
+        tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+        records: &[Value],
+    ) -> Result<usize, FaucetError> {
+        if records.is_empty() {
+            return Ok(0);
+        }
+
+        // Get column names from the table using pragma_table_info. Use the
+        // transaction's connection so a single-connection pool doesn't deadlock.
         let columns: Vec<String> = sqlx::query(&format!(
             "PRAGMA table_info({})",
             quote_ident(&self.config.table_name)
         ))
-        .fetch_all(&self.pool)
+        .fetch_all(&mut **tx)
         .await
         .map_err(|e| FaucetError::Sink(format!("failed to query table columns: {e}")))?
         .iter()
@@ -168,12 +216,6 @@ impl SqliteSink {
         const MAX_SQLITE_VARS: usize = 32766;
         let max_rows_per_insert = (MAX_SQLITE_VARS / num_cols).max(1);
 
-        let mut tx = self
-            .pool
-            .begin()
-            .await
-            .map_err(|e| FaucetError::Sink(format!("SQLite transaction begin failed: {e}")))?;
-
         for sub in matched_rows.chunks(max_rows_per_insert) {
             // Build multi-row VALUES clause: (?, ?), (?, ?), ...
             let row_placeholder = format!("({})", vec!["?"; num_cols].join(", "));
@@ -216,16 +258,27 @@ impl SqliteSink {
                 }
             }
 
-            q.execute(&mut *tx)
+            q.execute(&mut **tx)
                 .await
                 .map_err(|e| FaucetError::Sink(format!("SQLite insert failed: {e}")))?;
         }
 
-        tx.commit()
-            .await
-            .map_err(|e| FaucetError::Sink(format!("SQLite transaction commit failed: {e}")))?;
-
         Ok(num_rows)
+    }
+
+    /// Ensure the commit-token watermark table exists.
+    async fn ensure_commit_table(&self) -> Result<(), FaucetError> {
+        let sql = format!(
+            "CREATE TABLE IF NOT EXISTS {t} ({s} TEXT PRIMARY KEY, {k} TEXT NOT NULL, updated_at TEXT DEFAULT (datetime('now')))",
+            t = quote_ident(faucet_core::idempotency::COMMIT_TOKEN_TABLE),
+            s = quote_ident(faucet_core::idempotency::COMMIT_TOKEN_SCOPE_COL),
+            k = quote_ident(faucet_core::idempotency::COMMIT_TOKEN_TOKEN_COL),
+        );
+        sqlx::query(&sql)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| FaucetError::Sink(format!("SQLite commit-table create failed: {e}")))?;
+        Ok(())
     }
 }
 
@@ -308,6 +361,69 @@ impl faucet_core::Sink for SqliteSink {
             "SQLite write complete"
         );
         Ok(total)
+    }
+
+    fn supports_idempotent_writes(&self) -> bool {
+        true
+    }
+
+    async fn last_committed_token(&self, scope: &str) -> Result<Option<String>, FaucetError> {
+        self.ensure_commit_table().await?;
+        let sql = format!(
+            "SELECT {k} FROM {t} WHERE {s} = ?",
+            t = quote_ident(faucet_core::idempotency::COMMIT_TOKEN_TABLE),
+            k = quote_ident(faucet_core::idempotency::COMMIT_TOKEN_TOKEN_COL),
+            s = quote_ident(faucet_core::idempotency::COMMIT_TOKEN_SCOPE_COL),
+        );
+        let row = sqlx::query(&sql)
+            .bind(scope)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| FaucetError::Sink(format!("SQLite token read failed: {e}")))?;
+        Ok(row.map(|r| r.get::<String, _>(0)))
+    }
+
+    async fn write_batch_idempotent(
+        &self,
+        records: &[Value],
+        scope: &str,
+        token: &str,
+    ) -> Result<usize, FaucetError> {
+        self.ensure_commit_table().await?;
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| FaucetError::Sink(format!("SQLite transaction begin failed: {e}")))?;
+
+        // Data insert and the commit-token upsert share ONE transaction so the
+        // page is committed atomically with its watermark: on crash either both
+        // land or neither does, which is what makes a replay skip-on-resume
+        // produce zero duplicates.
+        let written = match &self.config.column_mapping {
+            SqliteColumnMapping::Json { column } => {
+                self.insert_json_tx(&mut tx, records, column).await?
+            }
+            SqliteColumnMapping::AutoMap => self.insert_auto_map_tx(&mut tx, records).await?,
+        };
+
+        let upsert = format!(
+            "INSERT INTO {t} ({s}, {k}) VALUES (?, ?) ON CONFLICT({s}) DO UPDATE SET {k} = excluded.{k}, updated_at = datetime('now')",
+            t = quote_ident(faucet_core::idempotency::COMMIT_TOKEN_TABLE),
+            s = quote_ident(faucet_core::idempotency::COMMIT_TOKEN_SCOPE_COL),
+            k = quote_ident(faucet_core::idempotency::COMMIT_TOKEN_TOKEN_COL),
+        );
+        sqlx::query(&upsert)
+            .bind(scope)
+            .bind(token)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| FaucetError::Sink(format!("SQLite token upsert failed: {e}")))?;
+
+        tx.commit()
+            .await
+            .map_err(|e| FaucetError::Sink(format!("SQLite transaction commit failed: {e}")))?;
+        Ok(written)
     }
 }
 

--- a/crates/sink/sqlite/tests/exactly_once.rs
+++ b/crates/sink/sqlite/tests/exactly_once.rs
@@ -1,0 +1,92 @@
+//! Acceptance test (#188): a crash between sink-write and bookmark-persist must
+//! produce ZERO duplicate rows on resume for the idempotent SQLite sink.
+
+use async_trait::async_trait;
+use faucet_core::pipeline::{StreamPage, run_stream};
+use faucet_core::state::{MemoryStateStore, StateStore};
+use faucet_core::{DeliveryMode, FaucetError, RunStreamOptions, Source, Value};
+use faucet_sink_sqlite::{SqliteColumnMapping, SqliteSink, SqliteSinkConfig};
+use serde_json::json;
+use sqlx::Row;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// Deterministic CDC-like source: replays the same pages, each with a bookmark.
+struct ReplaySource {
+    pages: Vec<(Vec<Value>, Value)>,
+}
+#[async_trait]
+impl Source for ReplaySource {
+    async fn fetch_with_context(&self, _c: &HashMap<String, Value>) -> Result<Vec<Value>, FaucetError> {
+        Ok(self.pages.iter().flat_map(|(r, _)| r.clone()).collect())
+    }
+    fn supports_exactly_once(&self) -> bool { true }
+}
+
+fn pages(src: &ReplaySource) -> Vec<Result<StreamPage, FaucetError>> {
+    src.pages
+        .iter()
+        .map(|(r, b)| Ok(StreamPage { records: r.clone(), bookmark: Some(b.clone()) }))
+        .collect()
+}
+
+async fn count_id(sink_url: &str, id: i64) -> i64 {
+    let pool = sqlx::SqlitePool::connect(sink_url).await.unwrap();
+    let row = sqlx::query("SELECT COUNT(*) AS n FROM events WHERE json_extract(data, '$.id') = ?")
+        .bind(id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    row.get::<i64, _>("n")
+}
+
+#[tokio::test]
+async fn crash_between_write_and_bookmark_yields_no_duplicates() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("eo.db");
+    let url = format!("sqlite://{}", db.display());
+
+    {
+        let pool = sqlx::SqlitePool::connect(&format!("{url}?mode=rwc")).await.unwrap();
+        sqlx::query("CREATE TABLE events (data TEXT)").execute(&pool).await.unwrap();
+    }
+
+    let cfg = SqliteSinkConfig {
+        column_mapping: SqliteColumnMapping::Json { column: "data".into() },
+        ..SqliteSinkConfig::new(&url, "events")
+    };
+    let sink = SqliteSink::new(cfg).await.unwrap();
+
+    let source = ReplaySource {
+        pages: vec![
+            (vec![json!({"id": 1})], json!("b1")),
+            (vec![json!({"id": 2})], json!("b2")),
+        ],
+    };
+
+    // Run 1: commit only page 1, then simulate a crash (state never persisted).
+    struct DroppingStore;
+    #[async_trait]
+    impl StateStore for DroppingStore {
+        async fn get(&self, _k: &str) -> Result<Option<Value>, FaucetError> { Ok(None) }
+        async fn put(&self, _k: &str, _v: &Value) -> Result<(), FaucetError> { Ok(()) }
+        async fn delete(&self, _k: &str) -> Result<(), FaucetError> { Ok(()) }
+    }
+    let opts1 = RunStreamOptions::new()
+        .with_state(Arc::new(DroppingStore), "events::r1")
+        .with_delivery(DeliveryMode::ExactlyOnce);
+    let first_page: Vec<Result<StreamPage, FaucetError>> =
+        vec![Ok(StreamPage { records: vec![json!({"id": 1})], bookmark: Some(json!("b1")) })];
+    run_stream(futures::stream::iter(first_page), &sink, opts1).await.unwrap();
+    assert_eq!(count_id(&format!("{url}?mode=rwc"), 1).await, 1);
+
+    // Run 2 (resume): fresh state, full replay. Page 1 must be skipped.
+    let store: Arc<dyn StateStore> = Arc::new(MemoryStateStore::new());
+    let opts2 = RunStreamOptions::new()
+        .with_state(store, "events::r1")
+        .with_delivery(DeliveryMode::ExactlyOnce);
+    run_stream(futures::stream::iter(pages(&source)), &sink, opts2).await.unwrap();
+
+    assert_eq!(count_id(&format!("{url}?mode=rwc"), 1).await, 1, "id=1 must NOT be duplicated");
+    assert_eq!(count_id(&format!("{url}?mode=rwc"), 2).await, 1, "id=2 written once");
+}

--- a/crates/sink/sqlite/tests/exactly_once.rs
+++ b/crates/sink/sqlite/tests/exactly_once.rs
@@ -17,16 +17,26 @@ struct ReplaySource {
 }
 #[async_trait]
 impl Source for ReplaySource {
-    async fn fetch_with_context(&self, _c: &HashMap<String, Value>) -> Result<Vec<Value>, FaucetError> {
+    async fn fetch_with_context(
+        &self,
+        _c: &HashMap<String, Value>,
+    ) -> Result<Vec<Value>, FaucetError> {
         Ok(self.pages.iter().flat_map(|(r, _)| r.clone()).collect())
     }
-    fn supports_exactly_once(&self) -> bool { true }
+    fn supports_exactly_once(&self) -> bool {
+        true
+    }
 }
 
 fn pages(src: &ReplaySource) -> Vec<Result<StreamPage, FaucetError>> {
     src.pages
         .iter()
-        .map(|(r, b)| Ok(StreamPage { records: r.clone(), bookmark: Some(b.clone()) }))
+        .map(|(r, b)| {
+            Ok(StreamPage {
+                records: r.clone(),
+                bookmark: Some(b.clone()),
+            })
+        })
         .collect()
 }
 
@@ -47,12 +57,19 @@ async fn crash_between_write_and_bookmark_yields_no_duplicates() {
     let url = format!("sqlite://{}", db.display());
 
     {
-        let pool = sqlx::SqlitePool::connect(&format!("{url}?mode=rwc")).await.unwrap();
-        sqlx::query("CREATE TABLE events (data TEXT)").execute(&pool).await.unwrap();
+        let pool = sqlx::SqlitePool::connect(&format!("{url}?mode=rwc"))
+            .await
+            .unwrap();
+        sqlx::query("CREATE TABLE events (data TEXT)")
+            .execute(&pool)
+            .await
+            .unwrap();
     }
 
     let cfg = SqliteSinkConfig {
-        column_mapping: SqliteColumnMapping::Json { column: "data".into() },
+        column_mapping: SqliteColumnMapping::Json {
+            column: "data".into(),
+        },
         ..SqliteSinkConfig::new(&url, "events")
     };
     let sink = SqliteSink::new(cfg).await.unwrap();
@@ -68,16 +85,26 @@ async fn crash_between_write_and_bookmark_yields_no_duplicates() {
     struct DroppingStore;
     #[async_trait]
     impl StateStore for DroppingStore {
-        async fn get(&self, _k: &str) -> Result<Option<Value>, FaucetError> { Ok(None) }
-        async fn put(&self, _k: &str, _v: &Value) -> Result<(), FaucetError> { Ok(()) }
-        async fn delete(&self, _k: &str) -> Result<(), FaucetError> { Ok(()) }
+        async fn get(&self, _k: &str) -> Result<Option<Value>, FaucetError> {
+            Ok(None)
+        }
+        async fn put(&self, _k: &str, _v: &Value) -> Result<(), FaucetError> {
+            Ok(())
+        }
+        async fn delete(&self, _k: &str) -> Result<(), FaucetError> {
+            Ok(())
+        }
     }
     let opts1 = RunStreamOptions::new()
         .with_state(Arc::new(DroppingStore), "events::r1")
         .with_delivery(DeliveryMode::ExactlyOnce);
-    let first_page: Vec<Result<StreamPage, FaucetError>> =
-        vec![Ok(StreamPage { records: vec![json!({"id": 1})], bookmark: Some(json!("b1")) })];
-    run_stream(futures::stream::iter(first_page), &sink, opts1).await.unwrap();
+    let first_page: Vec<Result<StreamPage, FaucetError>> = vec![Ok(StreamPage {
+        records: vec![json!({"id": 1})],
+        bookmark: Some(json!("b1")),
+    })];
+    run_stream(futures::stream::iter(first_page), &sink, opts1)
+        .await
+        .unwrap();
     assert_eq!(count_id(&format!("{url}?mode=rwc"), 1).await, 1);
 
     // Run 2 (resume): fresh state, full replay. Page 1 must be skipped.
@@ -85,8 +112,18 @@ async fn crash_between_write_and_bookmark_yields_no_duplicates() {
     let opts2 = RunStreamOptions::new()
         .with_state(store, "events::r1")
         .with_delivery(DeliveryMode::ExactlyOnce);
-    run_stream(futures::stream::iter(pages(&source)), &sink, opts2).await.unwrap();
+    run_stream(futures::stream::iter(pages(&source)), &sink, opts2)
+        .await
+        .unwrap();
 
-    assert_eq!(count_id(&format!("{url}?mode=rwc"), 1).await, 1, "id=1 must NOT be duplicated");
-    assert_eq!(count_id(&format!("{url}?mode=rwc"), 2).await, 1, "id=2 written once");
+    assert_eq!(
+        count_id(&format!("{url}?mode=rwc"), 1).await,
+        1,
+        "id=1 must NOT be duplicated"
+    );
+    assert_eq!(
+        count_id(&format!("{url}?mode=rwc"), 2).await,
+        1,
+        "id=2 written once"
+    );
 }

--- a/crates/source/mongodb-cdc/src/stream.rs
+++ b/crates/source/mongodb-cdc/src/stream.rs
@@ -205,6 +205,12 @@ impl Source for MongoCdcSource {
         Ok(())
     }
 
+    fn supports_exactly_once(&self) -> bool {
+        // Durable resumeToken + deterministic replay from it + per-event
+        // (per-page) bookmarks — the requirements for exactly-once delivery.
+        true
+    }
+
     fn connector_name(&self) -> &'static str {
         "mongodb-cdc"
     }

--- a/crates/source/mysql-cdc/src/stream.rs
+++ b/crates/source/mysql-cdc/src/stream.rs
@@ -123,6 +123,13 @@ impl Source for MysqlCdcSource {
         Ok(())
     }
 
+    fn supports_exactly_once(&self) -> bool {
+        // Durable monotonic binlog file/pos + deterministic replay from it +
+        // per-transaction (per-page) bookmarks — the requirements for
+        // exactly-once delivery.
+        true
+    }
+
     fn connector_name(&self) -> &'static str {
         "mysql-cdc"
     }

--- a/crates/source/postgres-cdc/src/stream.rs
+++ b/crates/source/postgres-cdc/src/stream.rs
@@ -150,6 +150,13 @@ impl Source for PostgresCdcSource {
         Ok(())
     }
 
+    fn supports_exactly_once(&self) -> bool {
+        // Durable monotonic LSN + deterministic replay from it + per-transaction
+        // (per-page) bookmarks persisted only after the sink confirms — the
+        // requirements for exactly-once delivery.
+        true
+    }
+
     fn connector_name(&self) -> &'static str {
         "postgres-cdc"
     }

--- a/docs/book/src/cookbook/state.md
+++ b/docs/book/src/cookbook/state.md
@@ -70,3 +70,96 @@ last confirmed point.
 Each invocation has a state key so concurrent matrix rows don't collide:
 `{name}::{row_id}` for roots and `{name}::{row_id}::{parent_record_key}` for DAG
 children. The CDC source uses `postgres-cdc:<slot>`.
+
+## Exactly-once delivery
+
+### The at-least-once crash window
+
+By default (`delivery: at_least_once`) the pipeline persists the bookmark
+*after* the sink confirms the write. A crash in the small window between
+"sink durably wrote the page" and "state store persisted the bookmark" causes the
+page to be re-delivered on the next run. For most workloads, duplicates in the
+destination can be handled by upsert logic or deduplication downstream.
+
+For CDC pipelines landing into SQL databases or Iceberg, faucet can close that
+window entirely.
+
+### How exactly-once closes the gap
+
+When `delivery: exactly_once`, the pipeline issues a monotonic **commit token** for
+every bookmark-carrying page. Instead of a plain `write_batch`, it calls
+`write_batch_idempotent(records, scope, token)`. The sink commits both the
+records and the token atomically inside its own transaction:
+
+- **SQL sinks** (postgres, mysql, mssql, sqlite) — an in-transaction `UPSERT`
+  into a `_faucet_commit_token(scope TEXT, token TEXT)` watermark table.
+- **Iceberg sink** — the token is written as snapshot summary properties
+  `faucet.commit-scope` and `faucet.commit-token` on the committed snapshot.
+
+On the *next run*, before writing each page, the pipeline reads the sink's
+`last_committed_token` for the current scope. If the stored token is greater
+than or equal to the page's own token, the sink already durably committed that
+page — the pipeline **skips the write** and advances the state store. Zero
+duplicates result from a crash at any point in the sequence.
+
+### Supported sources and sinks
+
+Only certain connectors are allowed in an exactly-once pipeline:
+
+| Role | Allowed connectors | Why others are excluded |
+|------|--------------------|------------------------|
+| Source | `postgres-cdc`, `mysql-cdc`, `mongodb-cdc` | The source must deterministically replay the same pages from a given bookmark. Non-CDC / batch sources (REST, SQL query, etc.) do not replay deterministically — a different page on resume would cause the pipeline to silently skip records it never wrote. |
+| Sink | `sqlite`, `postgres`, `mysql`, `mssql`, `iceberg` | The sink must be able to commit data and a watermark token atomically in a single transaction or snapshot. Sinks without transaction support cannot provide this guarantee. |
+
+A DLQ (`dlq:` block) is incompatible with `exactly_once` in this version.
+
+### Hard gate at config-load time
+
+The four requirements (CDC source, idempotent sink, state store, no DLQ) are
+validated when the config is loaded — `faucet validate` will report a clear
+`config error` naming the offending row before any run starts. There is no
+runtime fallback.
+
+### Example: PostgreSQL CDC → PostgreSQL sink
+
+```yaml
+version: 1
+name: cdc_exactly_once
+
+pipeline:
+  source:
+    type: postgres-cdc
+    config:
+      connection_url: postgres://faucet:faucet@localhost:5432/appdb
+      slot_name: faucet_slot
+      publication_name: faucet_pub
+      create_slot_if_missing: true
+      idle_timeout: 30
+  sink:
+    type: postgres
+    config:
+      connection_url: postgres://writer:pass@localhost:5432/warehouse
+      table_name: change_events
+      column_mapping: auto_map
+      batch_size: 1000
+  state:
+    type: file
+    config:
+      path: ./state
+
+delivery: exactly_once
+```
+
+Validate the config before the first run:
+
+```bash
+faucet validate pipeline.yaml
+```
+
+### Monitoring
+
+The `faucet_pipeline_pages_skipped_total{pipeline,row}` counter increments
+each time the pipeline skips a page on resume because the sink already
+committed it. A non-zero value on the first run after a crash is expected; a
+persistently non-zero value on steady-state runs may indicate a state-store
+or sink connectivity issue worth investigating.

--- a/docs/book/src/reference/config.md
+++ b/docs/book/src/reference/config.md
@@ -178,6 +178,44 @@ auth:
       refresh_token: ${secret:API_REFRESH_TOKEN}
 ```
 
+## `delivery`
+
+Controls the delivery guarantee for every pipeline row.
+
+```yaml
+delivery: at_least_once   # default — no behaviour change
+# or:
+delivery: exactly_once
+```
+
+| Value | Behaviour |
+|-------|-----------|
+| `at_least_once` | Default. A crash between the sink write and the bookmark persist causes the page to be re-delivered on the next run. Downstream must tolerate duplicates. |
+| `exactly_once` | The sink durably records a per-page commit token atomically with the data inside its own transaction. On resume the pipeline reads the sink's last committed token and skips already-committed pages, giving zero duplicates after a crash. |
+
+**Per-row override:** set `delivery:` directly on a matrix row to override the top-level value for that row.
+
+```yaml
+delivery: at_least_once    # top-level default
+
+matrix:
+  - id: critical_row
+    delivery: exactly_once  # this row uses exactly-once
+  - id: best_effort_row
+    # inherits top-level at_least_once
+```
+
+### Requirements for `exactly_once`
+
+All four conditions are validated at config-load time (`faucet validate` and `faucet run`). A violation is a hard `config error` naming the offending row — no run is started.
+
+1. **Deterministic-replay source** — the source must be one of: `postgres-cdc`, `mysql-cdc`, `mongodb-cdc`. Non-CDC sources are rejected because a different page content on replay would cause the pipeline to silently skip records it never wrote.
+2. **Idempotent sink** — the sink must be one of: `sqlite`, `postgres`, `mysql`, `mssql`, `iceberg`. These sinks atomically commit both the data and a watermark token inside the same transaction or snapshot.
+3. **State store** — a `state:` block is required. The pipeline stores the per-page sequence number alongside the bookmark so it can detect already-committed pages on resume.
+4. **No DLQ** — a `dlq:` block is incompatible with `exactly_once` in this version. Per-row error routing and the idempotency watermark interact in ways not yet resolved.
+
+See the [Exactly-once delivery cookbook](../cookbook/state.md#exactly-once-delivery) for a worked example and the full rationale.
+
 ## `execution`
 
 - `max_concurrent` — one shared concurrency budget across roots and child

--- a/docs/book/src/reference/connectors.md
+++ b/docs/book/src/reference/connectors.md
@@ -13,39 +13,42 @@ Legend: ✓ supported · ✗ not applicable.
 
 ## Sources
 
-| Connector | Feature | Streams¹ | Resumable² | Compression | Underlying primitive |
-|-----------|---------|:---:|:---:|:---:|----------------------|
-| REST | `source-rest` | ✓ | ✓ | ✗ | HTTP + 6 pagination styles, JSONPath extraction |
-| GraphQL | `source-graphql` | ✓ | ✗ | ✗ | cursor pagination, variable injection |
-| XML / SOAP | `source-xml` | ✓ | ✗ | ✗ | streaming XML→JSON, dot-path extraction |
-| gRPC | `source-grpc` | ✓³ | ✗ | ✗ | dynamic protobuf; unary + server-streaming |
-| PostgreSQL | `source-postgres` | ✓ | ✗ | ✗ | SQL query, rows as JSON |
-| PostgreSQL CDC | `source-postgres-cdc` | ✓ | ✓ | ✗ | logical replication (pgoutput), LSN bookmarks |
-| MySQL | `source-mysql` | ✓ | ✗ | ✗ | SQL query, rows as JSON |
-| MySQL CDC | `source-mysql-cdc` | ✓ | ✓ | ✗ | binlog row events, file/pos or GTID bookmarks |
-| Microsoft SQL Server | `source-mssql` | ✓ | ✓⁷ | ✗ | SQL query (tiberius), rows as JSON |
-| SQLite | `source-sqlite` | ✓ | ✗ | ✗ | SQL query, rows as JSON |
-| AWS S3 | `source-s3` | ✓⁴ | ✗ | ✓ | object reader: JSONL, JSON array, raw text |
-| Google Cloud Storage | `source-gcs` | ✓⁴ | ✗ | ✓ | object reader: JSONL, JSON array, raw text |
-| MongoDB | `source-mongodb` | ✓ | ✗ | ✗ | `find()` with filter/projection/sort |
-| MongoDB CDC | `source-mongodb-cdc` | ✓ | ✓ | ✗ | Change Streams, resumeToken bookmarks |
-| Redis | `source-redis` | ✓ | ✗ | ✗ | streams, lists, key patterns |
-| Webhook | `source-webhook` | ✗⁵ | ✗ | ✗ | temporary HTTP server collecting POSTs |
-| WebSocket | `source-websocket` | ✓ | ✗ | ✗ | live push feed; subscribe frames, reconnect, ping keepalive |
-| CSV | `source-csv` | ✓ | ✗ | ✓ | CSV files as JSON |
-| Elasticsearch | `source-elasticsearch` | ✓ | ✗ | ✗ | search/scroll API |
-| Apache Kafka | `source-kafka` | ✓ | ✓ | ✗ | consumer; idle/max-messages termination, offset bookmarks |
-| Apache Parquet | `source-parquet` | ✓ | ✗ | ✗ | local/glob/S3, vectorized Arrow reader, projection |
-| BigQuery | `source-bigquery` | ✓ | ✗ | ✗ | `jobs.query` + pageToken pagination |
-| Snowflake | `source-snowflake` | ✓ | ✗ | ✗ | SQL REST API, server-side partitions |
+| Connector | Feature | Streams¹ | Resumable² | Exactly-once³ | Compression | Underlying primitive |
+|-----------|---------|:---:|:---:|:---:|:---:|----------------------|
+| REST | `source-rest` | ✓ | ✓ | ✗ | ✗ | HTTP + 6 pagination styles, JSONPath extraction |
+| GraphQL | `source-graphql` | ✓ | ✗ | ✗ | ✗ | cursor pagination, variable injection |
+| XML / SOAP | `source-xml` | ✓ | ✗ | ✗ | ✗ | streaming XML→JSON, dot-path extraction |
+| gRPC | `source-grpc` | ✓⁴ | ✗ | ✗ | ✗ | dynamic protobuf; unary + server-streaming |
+| PostgreSQL | `source-postgres` | ✓ | ✗ | ✗ | ✗ | SQL query, rows as JSON |
+| PostgreSQL CDC | `source-postgres-cdc` | ✓ | ✓ | **✓** | ✗ | logical replication (pgoutput), LSN bookmarks |
+| MySQL | `source-mysql` | ✓ | ✗ | ✗ | ✗ | SQL query, rows as JSON |
+| MySQL CDC | `source-mysql-cdc` | ✓ | ✓ | **✓** | ✗ | binlog row events, file/pos or GTID bookmarks |
+| Microsoft SQL Server | `source-mssql` | ✓ | ✓⁸ | ✗ | ✗ | SQL query (tiberius), rows as JSON |
+| SQLite | `source-sqlite` | ✓ | ✗ | ✗ | ✗ | SQL query, rows as JSON |
+| AWS S3 | `source-s3` | ✓⁵ | ✗ | ✗ | ✓ | object reader: JSONL, JSON array, raw text |
+| Google Cloud Storage | `source-gcs` | ✓⁵ | ✗ | ✗ | ✓ | object reader: JSONL, JSON array, raw text |
+| MongoDB | `source-mongodb` | ✓ | ✗ | ✗ | ✗ | `find()` with filter/projection/sort |
+| MongoDB CDC | `source-mongodb-cdc` | ✓ | ✓ | **✓** | ✗ | Change Streams, resumeToken bookmarks |
+| Redis | `source-redis` | ✓ | ✗ | ✗ | ✗ | streams, lists, key patterns |
+| Webhook | `source-webhook` | ✗⁶ | ✗ | ✗ | ✗ | temporary HTTP server collecting POSTs |
+| WebSocket | `source-websocket` | ✓ | ✗ | ✗ | ✗ | live push feed; subscribe frames, reconnect, ping keepalive |
+| CSV | `source-csv` | ✓ | ✗ | ✗ | ✓ | CSV files as JSON |
+| Elasticsearch | `source-elasticsearch` | ✓ | ✗ | ✗ | ✗ | search/scroll API |
+| Apache Kafka | `source-kafka` | ✓ | ✓ | ✗ | ✗ | consumer; idle/max-messages termination, offset bookmarks |
+| Apache Parquet | `source-parquet` | ✓ | ✗ | ✗ | ✗ | local/glob/S3, vectorized Arrow reader, projection |
+| BigQuery | `source-bigquery` | ✓ | ✗ | ✗ | ✗ | `jobs.query` + pageToken pagination |
+| Snowflake | `source-snowflake` | ✓ | ✗ | ✗ | ✗ | SQL REST API, server-side partitions |
 
 ¹ **Streams** = yields records in bounded-memory batches rather than buffering the
 whole result. ² **Resumable** = persists a bookmark to a [state store](../cookbook/state.md)
 so re-runs continue where they left off (incremental replication / CDC / Kafka
-offsets). ³ gRPC streams natively in *server-streaming* mode; unary buffers the
-single response. ⁴ S3/GCS stream in JSONL and raw-text modes; JSON-array mode
-buffers one object. ⁵ Webhook is buffer-shaped by nature (it collects POSTs over
-a window). ⁷ MSSQL is resumable only in `replication: incremental` mode (it
+offsets). ³ **Exactly-once** = deterministically replays the same page sequence
+from a given bookmark; required for `delivery: exactly_once` — see
+[Exactly-once delivery](../cookbook/state.md#exactly-once-delivery).
+⁴ gRPC streams natively in *server-streaming* mode; unary buffers the
+single response. ⁵ S3/GCS stream in JSONL and raw-text modes; JSON-array mode
+buffers one object. ⁶ Webhook is buffer-shaped by nature (it collects POSTs over
+a window). ⁸ MSSQL is resumable only in `replication: incremental` mode (it
 persists a tracking-column bookmark); in `full` mode it is not.
 
 ## Sinks
@@ -53,29 +56,32 @@ persists a tracking-column bookmark); in `full` mode it is not.
 Every sink exposes a `batch_size` knob for write-side re-chunking. For the
 file/append sinks (`jsonl`, `csv`, `stdout`) it's a no-op — they write per record.
 
-| Connector | Feature | `batch_size` | Compression | Write unit |
-|-----------|---------|:---:|:---:|------------|
-| BigQuery | `sink-bigquery` | ✓ | ✗ | `tabledata.insertAll` (per-row DLQ) |
-| PostgreSQL | `sink-postgres` | ✓ | ✗ | multi-row `INSERT` (JSONB or mapped cols) |
-| JSON Lines | `sink-jsonl` | no-op | ✓ | buffered file append |
-| Snowflake | `sink-snowflake` | ✓ | ✗ | SQL REST API |
-| MySQL | `sink-mysql` | ✓ | ✗ | multi-row `INSERT` |
-| Microsoft SQL Server | `sink-mssql` | ✓ | ✗ | multi-row `INSERT` (2100-param auto-split, per-row DLQ) |
-| SQLite | `sink-sqlite` | ✓ | ✗ | transaction-wrapped batch |
-| AWS S3 | `sink-s3` | ✓ | ✓ | JSONL objects, parallel uploads |
-| Google Cloud Storage | `sink-gcs` | ✓ | ✓ | JSONL objects |
-| MongoDB | `sink-mongodb` | ✓ | ✗ | `insert_many` |
-| Redis | `sink-redis` | ✓ | ✗ | streams, lists, key-value (pipelined) |
-| CSV | `sink-csv` | no-op | ✓ | buffered file rows |
-| Elasticsearch | `sink-elasticsearch` | ✓ | ✗ | `_bulk` NDJSON (per-row DLQ) |
-| HTTP | `sink-http` | ✓ | ✗ | POST, concurrent under a semaphore |
-| Stdout | `sink-stdout` | no-op | ✗ | JSON Lines / pretty JSON / TSV |
-| Apache Kafka | `sink-kafka` | ✓ | ✗ | producer, batched sends, multi-topic routing |
-| Apache Parquet | `sink-parquet` | ✓ | ✗⁶ | local/S3, schema inference, row/byte rollover |
-| Apache Iceberg | `sink-iceberg` | ✓ | ✗⁶ | REST/Glue/SQL/HMS catalog, local + cloud (S3/GCS) warehouses, `fast_append` snapshot, Parquet data files |
+| Connector | Feature | `batch_size` | Compression | Exactly-once⁷ | Write unit |
+|-----------|---------|:---:|:---:|:---:|------------|
+| BigQuery | `sink-bigquery` | ✓ | ✗ | ✗ | `tabledata.insertAll` (per-row DLQ) |
+| PostgreSQL | `sink-postgres` | ✓ | ✗ | **✓** | multi-row `INSERT` (JSONB or mapped cols) |
+| JSON Lines | `sink-jsonl` | no-op | ✓ | ✗ | buffered file append |
+| Snowflake | `sink-snowflake` | ✓ | ✗ | ✗ | SQL REST API |
+| MySQL | `sink-mysql` | ✓ | ✗ | **✓** | multi-row `INSERT` |
+| Microsoft SQL Server | `sink-mssql` | ✓ | ✗ | **✓** | multi-row `INSERT` (2100-param auto-split, per-row DLQ) |
+| SQLite | `sink-sqlite` | ✓ | ✗ | **✓** | transaction-wrapped batch |
+| AWS S3 | `sink-s3` | ✓ | ✓ | ✗ | JSONL objects, parallel uploads |
+| Google Cloud Storage | `sink-gcs` | ✓ | ✓ | ✗ | JSONL objects |
+| MongoDB | `sink-mongodb` | ✓ | ✗ | ✗ | `insert_many` |
+| Redis | `sink-redis` | ✓ | ✗ | ✗ | streams, lists, key-value (pipelined) |
+| CSV | `sink-csv` | no-op | ✓ | ✗ | buffered file rows |
+| Elasticsearch | `sink-elasticsearch` | ✓ | ✗ | ✗ | `_bulk` NDJSON (per-row DLQ) |
+| HTTP | `sink-http` | ✓ | ✗ | ✗ | POST, concurrent under a semaphore |
+| Stdout | `sink-stdout` | no-op | ✗ | ✗ | JSON Lines / pretty JSON / TSV |
+| Apache Kafka | `sink-kafka` | ✓ | ✗ | ✗ | producer, batched sends, multi-topic routing |
+| Apache Parquet | `sink-parquet` | ✓ | ✗⁶ | ✗ | local/S3, schema inference, row/byte rollover |
+| Apache Iceberg | `sink-iceberg` | ✓ | ✗⁶ | **✓** | REST/Glue/SQL/HMS catalog, local + cloud (S3/GCS) warehouses, `fast_append` snapshot, Parquet data files |
 
 ⁶ Parquet and Iceberg both handle compression internally at the Parquet column
 level, so the file-level `compression` feature doesn't apply to either.
+⁷ **Exactly-once** = commits data and a watermark token atomically; required for
+`delivery: exactly_once`. BigQuery and Kafka are at-least-once only in this
+version. See [Exactly-once delivery](../cookbook/state.md#exactly-once-delivery).
 
 ## Authentication at a glance
 


### PR DESCRIPTION
## Summary

Adds an opt-in **`delivery: exactly_once`** mode so crash-resume and retry never duplicate rows in the sink. Today the streaming loop persists a per-page `StateStore` bookmark only *after* the sink confirms a batch — at-least-once: a crash between the sink write and the bookmark persist replays that page on the next run. This closes that window for sinks that can durably commit a token atomically with the data, and **degrades explicitly (load-time error), never silently**, for connectors that can't.

Default is unchanged (`at_least_once`) — zero behaviour change for existing configs.

## Mechanism (all in `faucet-core`)

- A monotonic per-page **commit token** (issued only on bookmark-carrying pages) is persisted in the `StateStore` value next to the bookmark, and committed **atomically with the data inside the sink's own transaction**.
- On resume, `run_stream` reads the sink's `last_committed_token` and **skips already-committed pages** → zero duplicates. The token is issued only alongside a bookmark, so `(seq, bookmark)` advance in lockstep and re-align deterministically on resume.
- New `faucet_core::idempotency` module (`DeliveryMode`, token format/parse, state wrap/unwrap, shared watermark constants); three object-safe `Sink` hooks (`supports_idempotent_writes` / `write_batch_idempotent` / `last_committed_token`) and `Source::supports_exactly_once` — all defaulted, so no existing or third-party connector breaks.

## Supported set (hard-gated at config load)

`exactly_once` requires **all** of: a deterministic-replay **source** (`postgres-cdc`, `mysql-cdc`, `mongodb-cdc`), an idempotent **sink** (`sqlite`, `postgres`, `mysql`, `mssql`, `iceberg`), a configured **state store**, and **no DLQ** — otherwise `faucet validate`/run fails fast with `FaucetError::Config` naming the offender. SQL sinks commit an in-transaction UPSERT into `_faucet_commit_token(scope, token)`; Iceberg writes `faucet.commit-scope`/`faucet.commit-token` snapshot summary properties on the same `fast_append`.

BigQuery and Kafka are deferred (their dedup needs a distinct, non-streaming design): #215 (BigQuery load-job/MERGE) and #216 (Kafka transactional EOS).

## Test plan

- [x] **Acceptance criterion** — `crates/sink/sqlite/tests/exactly_once.rs`: a real-SQLite kill/resume harness (crash simulated between sink-write and bookmark-persist) asserts **zero duplicate rows** on resume.
- [x] Core unit tests: token round-trip, state wrap/unwrap + legacy compat, resume/skip logic, gate rejections (unsupported sink / missing state).
- [x] CLI expand-gate tests: reject non-CDC source, reject non-idempotent sink, reject missing state; accept CDC→sqlite+state.
- [x] All 5 sinks + 3 CDC sources build + unit tests + `clippy -D warnings` clean; DB/Iceberg live paths exercised by Docker-gated integration tests (compile-verified here).
- [x] Workspace `cargo clippy --all-features -D warnings` clean; `cargo fmt`; mdBook builds.
- [x] No change to default `at_least_once` behaviour; no new Cargo feature flag.

## Docs

`reference/config.md` (`delivery:`), `cookbook/state.md` (exactly-once section + example), `reference/connectors.md` (capability matrix), the 5 sink READMEs, and CLAUDE.md.

Closes #188