### PR TITLE
ci(coverage): measure unit + integration tests (fix under-reported coverage)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -402,12 +402,31 @@ jobs:
             target
           key: ${{ runner.os }}-coverage-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-coverage-
-      # Cover library unit tests only (`--lib`). The integration tests in
-      # `tests/` spin up Docker testcontainers (Kafka, etc.) whose image pulls
-      # are flaky and are already exercised by the `test` and `kafka-integration`
-      # jobs — running them here too made coverage non-deterministic.
-      - name: Generate coverage (lcov)
-        run: cargo llvm-cov --workspace --all-features --lib --lcov --output-path lcov.info
+      # Cover unit + integration tests. The integration tests boot Docker
+      # testcontainers whose image pulls intermittently flake, so retry the run
+      # like the `test` job does — the final successful attempt re-runs the whole
+      # suite, so the reported coverage is always complete. Split run
+      # (--no-report) from report so the suite can be retried without
+      # regenerating the report each attempt. (cargo-llvm-cov 0.8.5 forbids
+      # combining --no-report with --no-clean, so the run uses --no-report alone.)
+      - name: Collect coverage (unit + integration)
+        run: |
+          cargo llvm-cov clean --workspace
+          ok=0
+          for attempt in 1 2 3; do
+            echo "::group::instrumented tests (attempt $attempt)"
+            if cargo llvm-cov --no-report --workspace --all-features; then
+              echo "::endgroup::"; ok=1; break
+            fi
+            echo "::endgroup::"
+            echo "::warning::instrumented tests failed on attempt $attempt (often a flaky Docker image pull); retrying in 20s"
+            sleep 20
+          done
+          [ "$ok" = 1 ] || { echo "::error::instrumented tests failed after 3 attempts"; exit 1; }
+      - name: Generate lcov report
+        run: |
+          cargo llvm-cov report --lcov --output-path lcov.info \
+            --ignore-filename-regex '(/tests?/|/examples?/|/benches?/|build\.rs$)'
       - name: Upload to Codecov
         continue-on-error: true
         uses: codecov/codecov-action@v4

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,23 @@
+# Coverage is measured by the CI `coverage` job (unit + integration tests via
+# cargo-llvm-cov). See .github/workflows/ci.yml.
+coverage:
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 1%        # tolerate a <=1% drop without flipping the status red
+        informational: true  # report-only for now; a follow-up flips this to false once stably >=80%
+    patch:
+      default:
+        target: 80%
+        informational: true
+
+# Exclude non-library code from the coverage denominator. Mirrors the lcov
+# --ignore-filename-regex in the coverage job, with the umbrella crate added
+# (pure feature-gated `pub use` re-exports — no testable logic).
+ignore:
+  - "faucet-stream/**"
+  - "**/tests/**"
+  - "**/examples/**"
+  - "**/benches/**"
+  - "cli/examples/**"


### PR DESCRIPTION
## Summary
The `coverage` CI job ran `cargo llvm-cov --workspace --all-features --lib`, which measures only library unit tests and discards all 92 integration-test files that cover connector I/O. This under-reported coverage on Codecov even though the workspace has 2,380 tests.

## Evidence (measured locally)
| `faucet-source-rest` | line | `stream.rs` line |
|---|---|---|
| `--lib` only (old Codecov view) | 63.24% | 40.93% |
| lib + integration (this PR) | **87.25%** | 83.88% |

`faucet-core` is already at 91.5%. The `test` job already runs the full suite — the integration coverage was simply never instrumented.

## Changes
- **`coverage` job**: drop `--lib`; run the full suite via cargo-llvm-cov split run/report (`clean` → retry `--no-report` → `report --lcov`), reusing the `test` job's 3-attempt Docker-flake retry; exclude test/example/bench/build code from the lcov. Kept as a separate, non-blocking job.
- **`codecov.yml`** (new): 80% project+patch target, **informational** (report-only) for now; ignores the `faucet-stream` re-export umbrella, tests, examples, benches.
- Targeted tests for any crate below a 75% floor will be added if the honest CI report reveals them.

## Follow-up (out of scope)
Once the number is stably ≥80% over a few merges, flip `codecov.yml` `informational: false` and consider adding the Codecov status to required checks.

Closes #218