### PR TITLE
test: raise straggler-crate coverage above the 80% target

### DIFF
--- a/crates/common/gcs/src/lib.rs
+++ b/crates/common/gcs/src/lib.rs
@@ -216,8 +216,11 @@ mod tests {
         // be the service-account build error, proving the read + parse lines
         // ran successfully first.
         let path = std::env::temp_dir().join(format!("faucet_gcs_sa_{}.json", std::process::id()));
-        std::fs::write(&path, br#"{"type":"service_account","client_email":"x@y.iam"}"#)
-            .expect("write temp sa file");
+        std::fs::write(
+            &path,
+            br#"{"type":"service_account","client_email":"x@y.iam"}"#,
+        )
+        .expect("write temp sa file");
         let creds = GcsCredentials::ServiceAccountJsonFile {
             path: path.to_string_lossy().into_owned(),
         };

--- a/crates/common/gcs/src/lib.rs
+++ b/crates/common/gcs/src/lib.rs
@@ -206,4 +206,81 @@ mod tests {
         let err = build_credentials(&creds).await.unwrap_err();
         assert!(matches!(err, FaucetError::Auth(_)));
     }
+
+    #[tokio::test]
+    async fn build_credentials_reads_file_and_gets_past_parse() {
+        // A real, readable file containing parseable JSON exercises the
+        // file-read + JSON-parse branch (the missing-file test only covers the
+        // read error). The JSON is a structurally-valid-but-incomplete service
+        // account, so the SDK build may fail — but if it does, the error must
+        // be the service-account build error, proving the read + parse lines
+        // ran successfully first.
+        let path = std::env::temp_dir().join(format!("faucet_gcs_sa_{}.json", std::process::id()));
+        std::fs::write(&path, br#"{"type":"service_account","client_email":"x@y.iam"}"#)
+            .expect("write temp sa file");
+        let creds = GcsCredentials::ServiceAccountJsonFile {
+            path: path.to_string_lossy().into_owned(),
+        };
+        let result = build_credentials(&creds).await;
+        let _ = std::fs::remove_file(&path);
+        match result {
+            Ok(_) => {} // built a (lazy) credential — read + parse path ran
+            Err(FaucetError::Auth(msg)) => assert!(
+                !msg.contains("could not read") && !msg.contains("not valid JSON"),
+                "read + parse should have succeeded, got: {msg}"
+            ),
+            Err(other) => panic!("unexpected error variant: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn build_credentials_inline_valid_json_gets_past_parse() {
+        // Valid JSON (vs. the rejects_invalid_inline_json case) exercises the
+        // inline parse-success + build branch.
+        let creds = GcsCredentials::ServiceAccountJsonInline {
+            json: r#"{"type":"service_account","client_email":"x@y.iam"}"#.into(),
+        };
+        match build_credentials(&creds).await {
+            Ok(_) => {}
+            Err(FaucetError::Auth(msg)) => assert!(
+                !msg.contains("not valid JSON"),
+                "inline JSON should have parsed, got: {msg}"
+            ),
+            Err(other) => panic!("unexpected error variant: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn build_credentials_application_default_does_not_panic() {
+        // ADC resolution either yields a lazy credential handle or an Auth
+        // error depending on the environment; either is acceptable. The point
+        // is that the ApplicationDefault arm executes and maps any failure to
+        // FaucetError::Auth rather than panicking.
+        match build_credentials(&GcsCredentials::ApplicationDefault).await {
+            Ok(_) | Err(FaucetError::Auth(_)) => {}
+            Err(other) => panic!("unexpected error variant: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn build_storage_constructs_client_with_endpoint_override() {
+        // Anonymous credentials + an endpoint override exercise the data-plane
+        // client builder (including the with_endpoint branch) without needing
+        // GCP credentials or a live connection. The client is constructed
+        // lazily, so success is expected; any failure must still map to Auth.
+        match build_storage(&GcsCredentials::Anonymous, Some("http://localhost:4443")).await {
+            Ok(_) | Err(FaucetError::Auth(_)) => {}
+            Err(other) => panic!("unexpected error variant: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn build_storage_control_constructs_client_with_endpoint_override() {
+        // Same as above for the control-plane client.
+        match build_storage_control(&GcsCredentials::Anonymous, Some("http://localhost:4443")).await
+        {
+            Ok(_) | Err(FaucetError::Auth(_)) => {}
+            Err(other) => panic!("unexpected error variant: {other:?}"),
+        }
+    }
 }

--- a/crates/source/gcs/src/stream.rs
+++ b/crates/source/gcs/src/stream.rs
@@ -426,7 +426,8 @@ mod tests {
 
     #[test]
     fn parse_json_lines() {
-        let r = parse_file_content(&GcsFileFormat::JsonLines, "t", "{\"id\":1}\n{\"id\":2}\n").unwrap();
+        let r =
+            parse_file_content(&GcsFileFormat::JsonLines, "t", "{\"id\":1}\n{\"id\":2}\n").unwrap();
         assert_eq!(r.len(), 2);
         assert_eq!(r[0]["id"], 1);
     }
@@ -444,7 +445,8 @@ mod tests {
 
     #[test]
     fn parse_json_lines_reports_line_number() {
-        let err = parse_file_content(&GcsFileFormat::JsonLines, "t", "{\"id\":1}\nbad-line\n").unwrap_err();
+        let err = parse_file_content(&GcsFileFormat::JsonLines, "t", "{\"id\":1}\nbad-line\n")
+            .unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("line 2"), "unexpected: {msg}");
     }
@@ -462,7 +464,8 @@ mod tests {
 
     #[test]
     fn parse_json_array_rejects_non_array() {
-        let err = parse_file_content(&GcsFileFormat::JsonArray, "t.json", "{\"id\":1}").unwrap_err();
+        let err =
+            parse_file_content(&GcsFileFormat::JsonArray, "t.json", "{\"id\":1}").unwrap_err();
         assert!(err.to_string().contains("expected JSON array"));
     }
 

--- a/crates/source/gcs/src/stream.rs
+++ b/crates/source/gcs/src/stream.rs
@@ -130,41 +130,55 @@ impl GcsSource {
 
     /// Parse file content into records based on the configured file format.
     fn parse_content(&self, key: &str, text: &str) -> Result<Vec<Value>, FaucetError> {
-        match self.config.file_format {
-            GcsFileFormat::JsonLines => {
-                let mut records = Vec::new();
-                for (line_num, line) in text.lines().enumerate() {
-                    let trimmed = line.trim();
-                    if trimmed.is_empty() {
-                        continue;
-                    }
-                    let value: Value = serde_json::from_str(trimmed).map_err(|e| {
-                        FaucetError::Source(format!(
-                            "GCS JSON parse error in '{key}' at line {}: {e}",
-                            line_num + 1
-                        ))
-                    })?;
-                    records.push(value);
+        parse_file_content(&self.config.file_format, key, text)
+    }
+}
+
+/// Parse file content into records for a given format. Free function (vs. a
+/// `GcsSource` method) so it is unit-testable without a GCS client — the
+/// parsing logic is pure. Previously this logic lived only inside the
+/// `parse_content` method and was duplicated by a copy in the test module;
+/// that copy could silently drift from production since the integration tests
+/// that would have caught it are `#[ignore]`d (no gRPC emulator exists).
+pub(crate) fn parse_file_content(
+    format: &GcsFileFormat,
+    key: &str,
+    text: &str,
+) -> Result<Vec<Value>, FaucetError> {
+    match format {
+        GcsFileFormat::JsonLines => {
+            let mut records = Vec::new();
+            for (line_num, line) in text.lines().enumerate() {
+                let trimmed = line.trim();
+                if trimmed.is_empty() {
+                    continue;
                 }
-                Ok(records)
-            }
-            GcsFileFormat::JsonArray => {
-                let value: Value = serde_json::from_str(text).map_err(|e| {
-                    FaucetError::Source(format!("GCS JSON parse error in '{key}': {e}"))
+                let value: Value = serde_json::from_str(trimmed).map_err(|e| {
+                    FaucetError::Source(format!(
+                        "GCS JSON parse error in '{key}' at line {}: {e}",
+                        line_num + 1
+                    ))
                 })?;
-                match value {
-                    Value::Array(arr) => Ok(arr),
-                    other => Err(FaucetError::Source(format!(
-                        "GCS expected JSON array in '{key}', got {}",
-                        value_type_name(&other)
-                    ))),
-                }
+                records.push(value);
             }
-            GcsFileFormat::RawText => Ok(vec![serde_json::json!({
-                "key": key,
-                "content": text,
-            })]),
+            Ok(records)
         }
+        GcsFileFormat::JsonArray => {
+            let value: Value = serde_json::from_str(text).map_err(|e| {
+                FaucetError::Source(format!("GCS JSON parse error in '{key}': {e}"))
+            })?;
+            match value {
+                Value::Array(arr) => Ok(arr),
+                other => Err(FaucetError::Source(format!(
+                    "GCS expected JSON array in '{key}', got {}",
+                    value_type_name(&other)
+                ))),
+            }
+        }
+        GcsFileFormat::RawText => Ok(vec![serde_json::json!({
+            "key": key,
+            "content": text,
+        })]),
     }
 }
 
@@ -400,61 +414,27 @@ mod tests {
         assert_eq!(cfg.compression, faucet_core::CompressionConfig::Auto);
     }
 
-    /// Construct a parse-only test config — used by tests that don't touch
-    /// the network. We can't easily construct a real `GcsSource` without
-    /// a runtime, so we test `parse_content` via a free helper that
-    /// inlines the same logic with an explicit `format` argument.
-    fn parse(format: GcsFileFormat, key: &str, text: &str) -> Result<Vec<Value>, FaucetError> {
-        // Mirror the implementation in `parse_content`. Kept in sync with
-        // production code via the integration test suite.
-        match format {
-            GcsFileFormat::JsonLines => {
-                let mut records = Vec::new();
-                for (line_num, line) in text.lines().enumerate() {
-                    let trimmed = line.trim();
-                    if trimmed.is_empty() {
-                        continue;
-                    }
-                    let value: Value = serde_json::from_str(trimmed).map_err(|e| {
-                        FaucetError::Source(format!(
-                            "GCS JSON parse error in '{key}' at line {}: {e}",
-                            line_num + 1
-                        ))
-                    })?;
-                    records.push(value);
-                }
-                Ok(records)
-            }
-            GcsFileFormat::JsonArray => {
-                let value: Value = serde_json::from_str(text).map_err(|e| {
-                    FaucetError::Source(format!("GCS JSON parse error in '{key}': {e}"))
-                })?;
-                match value {
-                    Value::Array(arr) => Ok(arr),
-                    other => Err(FaucetError::Source(format!(
-                        "GCS expected JSON array in '{key}', got {}",
-                        value_type_name(&other)
-                    ))),
-                }
-            }
-            GcsFileFormat::RawText => Ok(vec![json!({
-                "key": key,
-                "content": text,
-            })]),
-        }
+    #[test]
+    fn value_type_name_covers_all_json_variants() {
+        assert_eq!(value_type_name(&Value::Null), "null");
+        assert_eq!(value_type_name(&json!(true)), "boolean");
+        assert_eq!(value_type_name(&json!(7)), "number");
+        assert_eq!(value_type_name(&json!("s")), "string");
+        assert_eq!(value_type_name(&json!([1, 2])), "array");
+        assert_eq!(value_type_name(&json!({"k": 1})), "object");
     }
 
     #[test]
     fn parse_json_lines() {
-        let r = parse(GcsFileFormat::JsonLines, "t", "{\"id\":1}\n{\"id\":2}\n").unwrap();
+        let r = parse_file_content(&GcsFileFormat::JsonLines, "t", "{\"id\":1}\n{\"id\":2}\n").unwrap();
         assert_eq!(r.len(), 2);
         assert_eq!(r[0]["id"], 1);
     }
 
     #[test]
     fn parse_json_lines_skips_blanks() {
-        let r = parse(
-            GcsFileFormat::JsonLines,
+        let r = parse_file_content(
+            &GcsFileFormat::JsonLines,
             "t",
             "{\"id\":1}\n\n{\"id\":2}\n\n",
         )
@@ -464,15 +444,15 @@ mod tests {
 
     #[test]
     fn parse_json_lines_reports_line_number() {
-        let err = parse(GcsFileFormat::JsonLines, "t", "{\"id\":1}\nbad-line\n").unwrap_err();
+        let err = parse_file_content(&GcsFileFormat::JsonLines, "t", "{\"id\":1}\nbad-line\n").unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("line 2"), "unexpected: {msg}");
     }
 
     #[test]
     fn parse_json_array() {
-        let r = parse(
-            GcsFileFormat::JsonArray,
+        let r = parse_file_content(
+            &GcsFileFormat::JsonArray,
             "t.json",
             "[{\"id\":1},{\"id\":2}]",
         )
@@ -482,13 +462,13 @@ mod tests {
 
     #[test]
     fn parse_json_array_rejects_non_array() {
-        let err = parse(GcsFileFormat::JsonArray, "t.json", "{\"id\":1}").unwrap_err();
+        let err = parse_file_content(&GcsFileFormat::JsonArray, "t.json", "{\"id\":1}").unwrap_err();
         assert!(err.to_string().contains("expected JSON array"));
     }
 
     #[test]
     fn parse_raw_text_yields_single_record() {
-        let r = parse(GcsFileFormat::RawText, "p/f.txt", "hello").unwrap();
+        let r = parse_file_content(&GcsFileFormat::RawText, "p/f.txt", "hello").unwrap();
         assert_eq!(r, vec![json!({"key": "p/f.txt", "content": "hello"})]);
     }
 

--- a/crates/source/mysql/tests/streaming.rs
+++ b/crates/source/mysql/tests/streaming.rs
@@ -276,3 +276,101 @@ async fn stream_pages_preserves_row_contents() {
     assert_eq!(all_records[0]["name"], "alpha");
     assert_eq!(all_records[2]["name"], "gamma");
 }
+
+/// Exercises the type arms of `mysql_value_to_json` by selecting one row whose
+/// columns span the supported MySQL types. Without this, the converter's
+/// float / temporal / decimal / blob / json branches were never executed (the
+/// other tests only use BIGINT and VARCHAR).
+#[tokio::test(flavor = "multi_thread")]
+async fn all_column_types_decode_to_expected_json() {
+    let (_container, url) = start_mysql().await;
+    let pool = sqlx::MySqlPool::connect(&url).await.expect("pool connect");
+    sqlx::query(
+        "CREATE TABLE types_t (
+            jb JSON, t VARCHAR(32), big BIGINT,
+            dp DOUBLE, fl FLOAT,
+            dt DATETIME, d DATE, tm TIME,
+            dec_col DECIMAL(10,2), bl BLOB
+        )",
+    )
+    .execute(&pool)
+    .await
+    .expect("create table");
+    sqlx::query(
+        "INSERT INTO types_t VALUES (
+            '{\"k\": 1}', 'hello', 9223372036854775807,
+            3.5, 1.5,
+            '2024-01-02 03:04:05', '2024-01-02', '03:04:05',
+            123.45, x'68690a'
+        )",
+    )
+    .execute(&pool)
+    .await
+    .expect("insert");
+    pool.close().await;
+
+    let config = MysqlSourceConfig::new(url, "SELECT * FROM types_t");
+    let source = MysqlSource::new(config).await.expect("source new");
+    let ctx: HashMap<String, serde_json::Value> = HashMap::new();
+    let mut pages = source.stream_pages(&ctx, DEFAULT_BATCH_SIZE);
+    let page = pages.next().await.expect("one page").expect("page ok");
+    assert_eq!(page.records.len(), 1);
+    let row = &page.records[0];
+
+    assert_eq!(row["jb"], serde_json::json!({"k": 1}));
+    assert_eq!(row["t"], "hello");
+    assert_eq!(row["big"], 9223372036854775807i64);
+    assert_eq!(row["dp"], 3.5);
+    assert_eq!(row["fl"], 1.5);
+    // MySQL DATETIME decodes via sqlx as DateTime<Utc> -> RFC3339.
+    assert!(
+        row["dt"]
+            .as_str()
+            .unwrap()
+            .starts_with("2024-01-02T03:04:05"),
+        "DATETIME should render as RFC3339, got {:?}",
+        row["dt"]
+    );
+    assert_eq!(row["d"], "2024-01-02");
+    assert_eq!(row["tm"], "03:04:05");
+    // DECIMAL -> string, preserving precision (assert the meaningful prefix to
+    // be robust to any trailing-zero scale padding).
+    assert!(
+        row["dec_col"].as_str().unwrap().starts_with("123.45"),
+        "DECIMAL should render as a precise decimal string, got {:?}",
+        row["dec_col"]
+    );
+    assert_eq!(row["bl"], "aGkK"); // BLOB 0x68690a ("hi\n") -> base64
+}
+
+/// Context tokens (`{key}`) must become `?` bind markers bound as native scalar
+/// types — exercising `resolve_query`'s context branch and the typed arms of
+/// `bind_params` (integer + bool).
+#[tokio::test(flavor = "multi_thread")]
+async fn context_tokens_bind_as_typed_params() {
+    let (_container, url) = start_mysql().await;
+    let pool = sqlx::MySqlPool::connect(&url).await.expect("pool connect");
+    sqlx::query("CREATE TABLE acct (id BIGINT, name VARCHAR(32), active BOOLEAN)")
+        .execute(&pool)
+        .await
+        .expect("create table");
+    sqlx::query("INSERT INTO acct VALUES (1, 'alice', true), (2, 'bob', false)")
+        .execute(&pool)
+        .await
+        .expect("insert");
+    pool.close().await;
+
+    let config = MysqlSourceConfig::new(
+        url,
+        "SELECT name FROM acct WHERE id = {id} AND active = {active} ORDER BY name",
+    );
+    let source = MysqlSource::new(config).await.expect("source new");
+    let mut ctx: HashMap<String, serde_json::Value> = HashMap::new();
+    ctx.insert("id".into(), serde_json::json!(1));
+    ctx.insert("active".into(), serde_json::json!(true));
+
+    let mut pages = source.stream_pages(&ctx, DEFAULT_BATCH_SIZE);
+    let page = pages.next().await.expect("one page").expect("page ok");
+    assert_eq!(page.records.len(), 1, "only account id=1 is active");
+    assert_eq!(page.records[0]["name"], "alice");
+}

--- a/crates/source/postgres/tests/streaming.rs
+++ b/crates/source/postgres/tests/streaming.rs
@@ -245,3 +245,109 @@ async fn stream_pages_preserves_row_contents() {
     assert_eq!(all_records[0]["name"], "alpha");
     assert_eq!(all_records[2]["name"], "gamma");
 }
+
+/// Exercises every arm of `pg_value_to_json` by selecting one row whose columns
+/// span the full set of supported Postgres types. Without this, the converter's
+/// integer-width / float / temporal / uuid / numeric / bytea branches were
+/// never executed (the other tests only use BIGINT and TEXT).
+#[tokio::test(flavor = "multi_thread")]
+async fn all_column_types_decode_to_expected_json() {
+    let (_container, url) = start_postgres().await;
+    let pool = sqlx::PgPool::connect(&url).await.expect("pool connect");
+    sqlx::query(
+        "CREATE TABLE types_t (
+            jb JSONB, t TEXT, big BIGINT, i4 INT, sm SMALLINT,
+            dp DOUBLE PRECISION, r REAL, b BOOLEAN,
+            tstz TIMESTAMPTZ, ts TIMESTAMP, d DATE, tm TIME,
+            u UUID, num NUMERIC, by BYTEA
+        )",
+    )
+    .execute(&pool)
+    .await
+    .expect("create table");
+    sqlx::query(
+        "INSERT INTO types_t VALUES (
+            '{\"nested\":[1,2],\"ok\":true}'::jsonb, 'hello',
+            9223372036854775807, 2147483647, 32767,
+            3.5, 1.5, true,
+            '2024-01-02T03:04:05Z'::timestamptz, '2024-01-02 03:04:05'::timestamp,
+            '2024-01-02'::date, '03:04:05'::time,
+            '00000000-0000-0000-0000-000000000001'::uuid, '123.45'::numeric,
+            '\\x68690a'::bytea
+        )",
+    )
+    .execute(&pool)
+    .await
+    .expect("insert");
+    pool.close().await;
+
+    let config = PostgresSourceConfig::new(url, "SELECT * FROM types_t");
+    let source = PostgresSource::new(config).await.expect("source new");
+    let ctx: HashMap<String, serde_json::Value> = HashMap::new();
+    let mut pages = source.stream_pages(&ctx, DEFAULT_BATCH_SIZE);
+    let page = pages.next().await.expect("one page").expect("page ok");
+    assert_eq!(page.records.len(), 1);
+    let row = &page.records[0];
+
+    assert_eq!(row["jb"], serde_json::json!({"nested": [1, 2], "ok": true}));
+    assert_eq!(row["t"], "hello");
+    assert_eq!(row["big"], 9223372036854775807i64);
+    assert_eq!(row["i4"], 2147483647);
+    assert_eq!(row["sm"], 32767);
+    assert_eq!(row["dp"], 3.5);
+    assert_eq!(row["r"], 1.5);
+    assert_eq!(row["b"], true);
+    assert!(
+        row["tstz"]
+            .as_str()
+            .unwrap()
+            .starts_with("2024-01-02T03:04:05"),
+        "timestamptz should render as RFC3339, got {:?}",
+        row["tstz"]
+    );
+    assert_eq!(row["ts"], "2024-01-02 03:04:05");
+    assert_eq!(row["d"], "2024-01-02");
+    assert_eq!(row["tm"], "03:04:05");
+    assert_eq!(row["u"], "00000000-0000-0000-0000-000000000001");
+    // NUMERIC -> string, preserving precision. sqlx's PgNumeric -> BigDecimal
+    // conversion pads the scale to a multiple of 4 ("123.4500"), so assert on
+    // the meaningful prefix rather than an exact rendering.
+    assert!(
+        row["num"].as_str().unwrap().starts_with("123.45"),
+        "NUMERIC should render as a precise decimal string, got {:?}",
+        row["num"]
+    );
+    assert_eq!(row["by"], "aGkK"); // BYTEA 0x68690a ("hi\n") -> base64
+}
+
+/// Context tokens (`{key}`) must become positional bind markers bound as native
+/// scalar types — exercising `resolve_query`'s context branch and the typed
+/// arms of `bind_params` (integer + bool), not a raw jsonb bind.
+#[tokio::test(flavor = "multi_thread")]
+async fn context_tokens_bind_as_typed_params() {
+    let (_container, url) = start_postgres().await;
+    let pool = sqlx::PgPool::connect(&url).await.expect("pool connect");
+    sqlx::query("CREATE TABLE acct (id BIGINT, name TEXT, active BOOLEAN)")
+        .execute(&pool)
+        .await
+        .expect("create table");
+    sqlx::query("INSERT INTO acct VALUES (1, 'alice', true), (2, 'bob', false)")
+        .execute(&pool)
+        .await
+        .expect("insert");
+    pool.close().await;
+
+    let config = PostgresSourceConfig::new(
+        url,
+        "SELECT name FROM acct WHERE id = {id} AND active = {active} ORDER BY name",
+    );
+    let source = PostgresSource::new(config).await.expect("source new");
+    let mut ctx: HashMap<String, serde_json::Value> = HashMap::new();
+    ctx.insert("id".into(), serde_json::json!(1));
+    ctx.insert("active".into(), serde_json::json!(true));
+
+    let mut pages = source.stream_pages(&ctx, DEFAULT_BATCH_SIZE);
+    let page = pages.next().await.expect("one page").expect("page ok");
+    assert_eq!(page.records.len(), 1, "only account id=1 is active");
+    assert_eq!(page.records[0]["name"], "alice");
+}

--- a/crates/state/postgres/Cargo.toml
+++ b/crates/state/postgres/Cargo.toml
@@ -19,7 +19,9 @@ sqlx.workspace = true
 tokio = { workspace = true, features = ["sync", "time"] }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros", "rt"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+testcontainers = "0.27"
+testcontainers-modules = { version = "0.15", features = ["postgres"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/state/postgres/tests/integration.rs
+++ b/crates/state/postgres/tests/integration.rs
@@ -1,0 +1,129 @@
+//! Integration tests for `PostgresStateStore` against a real Postgres instance
+//! via testcontainers.
+//!
+//! These tests require Docker. Each test boots its own container so they are
+//! fully isolated and safe to run in parallel.
+
+use faucet_core::check::{CheckContext, ProbeStatus};
+use faucet_core::state::StateStore;
+use faucet_state_postgres::PostgresStateStore;
+use serde_json::json;
+use testcontainers::{ContainerAsync, ImageExt, runners::AsyncRunner};
+use testcontainers_modules::postgres::Postgres;
+
+/// Start a Postgres container and return the handle (keeps it alive) plus a
+/// connection URL.
+async fn start_postgres() -> (ContainerAsync<Postgres>, String) {
+    let image = Postgres::default().with_tag("16-alpine");
+    let container = image.start().await.expect("postgres container start");
+    let port = container
+        .get_host_port_ipv4(5432)
+        .await
+        .expect("postgres port");
+    let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
+    (container, url)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn full_lifecycle_get_put_overwrite_delete() {
+    let (_container, url) = start_postgres().await;
+    let store = PostgresStateStore::connect(&url).await.expect("connect");
+
+    // ensure_table must be idempotent — calling it twice is a no-op.
+    store.ensure_table().await.expect("ensure_table #1");
+    store.ensure_table().await.expect("ensure_table #2");
+
+    // A key that was never written reads back as None.
+    assert_eq!(store.get("missing").await.expect("get missing"), None);
+
+    // Write then read back the exact value.
+    let v1 = json!({"page": 1, "cursor": "abc"});
+    store.put("bookmark", &v1).await.expect("put v1");
+    assert_eq!(
+        store.get("bookmark").await.expect("get v1"),
+        Some(v1),
+        "get must return the value that was put"
+    );
+
+    // Overwriting an existing key (UPSERT) replaces the value.
+    let v2 = json!({"page": 2, "cursor": "def"});
+    store.put("bookmark", &v2).await.expect("put v2");
+    assert_eq!(
+        store.get("bookmark").await.expect("get v2"),
+        Some(v2),
+        "second put must overwrite the first via ON CONFLICT DO UPDATE"
+    );
+
+    // Delete removes the key; subsequent get is None.
+    store.delete("bookmark").await.expect("delete");
+    assert_eq!(
+        store.get("bookmark").await.expect("get after delete"),
+        None,
+        "get after delete must return None"
+    );
+
+    // Deleting an absent key is a no-op (no error).
+    store.delete("bookmark").await.expect("delete idempotent");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn nested_json_value_roundtrips_exactly() {
+    let (_container, url) = start_postgres().await;
+    let store = PostgresStateStore::connect(&url).await.expect("connect");
+    store.ensure_table().await.expect("ensure_table");
+
+    let nested = json!({
+        "lsn": "0/1A2B3C",
+        "tables": ["public.users", "public.orders"],
+        "meta": {"committed": true, "rows": 42, "ratio": 0.75, "note": null}
+    });
+    store.put("cdc", &nested).await.expect("put nested");
+    assert_eq!(
+        store.get("cdc").await.expect("get nested"),
+        Some(nested),
+        "nested JSON must survive a JSONB round-trip byte-for-byte"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn check_probe_passes_against_live_db() {
+    let (_container, url) = start_postgres().await;
+    let store = PostgresStateStore::connect(&url).await.expect("connect");
+    store.ensure_table().await.expect("ensure_table");
+
+    let report = store
+        .check(&CheckContext::default())
+        .await
+        .expect("check returns Ok");
+    assert_eq!(report.failed_count(), 0, "sentinel probe should pass");
+    assert_eq!(report.probes.len(), 1);
+    assert!(
+        matches!(report.probes[0].status, ProbeStatus::Pass),
+        "expected a passing probe, got {:?}",
+        report.probes[0].status
+    );
+
+    // The sentinel round-trip must leave no residue behind.
+    assert_eq!(
+        store
+            .get(faucet_core::state::DOCTOR_SENTINEL_KEY)
+            .await
+            .expect("get sentinel"),
+        None,
+        "check() must clean up its sentinel key"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn from_pool_with_custom_table_name() {
+    let (_container, url) = start_postgres().await;
+    let pool = sqlx::PgPool::connect(&url).await.expect("pool connect");
+    let store =
+        PostgresStateStore::from_pool(pool, "custom_state").expect("from_pool with valid name");
+    assert_eq!(store.table(), "custom_state");
+
+    store.ensure_table().await.expect("ensure custom table");
+    let v = json!({"ok": true});
+    store.put("k", &v).await.expect("put");
+    assert_eq!(store.get("k").await.expect("get"), Some(v));
+}

--- a/crates/state/redis/Cargo.toml
+++ b/crates/state/redis/Cargo.toml
@@ -19,7 +19,9 @@ redis.workspace = true
 tokio = { workspace = true, features = ["sync", "time"] }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros", "rt"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+testcontainers = "0.27"
+testcontainers-modules = { version = "0.15", features = ["redis"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/state/redis/tests/integration.rs
+++ b/crates/state/redis/tests/integration.rs
@@ -1,0 +1,143 @@
+//! Integration tests for `RedisStateStore` against a real Redis instance via
+//! testcontainers.
+//!
+//! These tests require Docker. Each test boots its own container so they are
+//! fully isolated and safe to run in parallel.
+
+use faucet_core::check::{CheckContext, ProbeStatus};
+use faucet_core::state::StateStore;
+use faucet_state_redis::RedisStateStore;
+use serde_json::json;
+use testcontainers::{ContainerAsync, runners::AsyncRunner};
+use testcontainers_modules::redis::Redis;
+
+/// Start a Redis container and return the handle (keeps it alive) plus a URL.
+async fn start_redis() -> (ContainerAsync<Redis>, String) {
+    let container = Redis::default().start().await.expect("redis container start");
+    let port = container.get_host_port_ipv4(6379).await.expect("redis port");
+    let url = format!("redis://127.0.0.1:{port}");
+    (container, url)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn full_lifecycle_get_put_overwrite_delete() {
+    let (_container, url) = start_redis().await;
+    let store = RedisStateStore::connect(&url, "faucet")
+        .await
+        .expect("connect");
+
+    // A key that was never written reads back as None.
+    assert_eq!(store.get("missing").await.expect("get missing"), None);
+
+    // Write then read back the exact value.
+    let v1 = json!({"page": 1, "cursor": "abc"});
+    store.put("bookmark", &v1).await.expect("put v1");
+    assert_eq!(
+        store.get("bookmark").await.expect("get v1"),
+        Some(v1),
+        "get must return the value that was put"
+    );
+
+    // Overwriting an existing key replaces the value.
+    let v2 = json!({"page": 2, "cursor": "def"});
+    store.put("bookmark", &v2).await.expect("put v2");
+    assert_eq!(
+        store.get("bookmark").await.expect("get v2"),
+        Some(v2),
+        "second put must overwrite the first"
+    );
+
+    // Delete removes the key; subsequent get is None.
+    store.delete("bookmark").await.expect("delete");
+    assert_eq!(
+        store.get("bookmark").await.expect("get after delete"),
+        None,
+        "get after delete must return None"
+    );
+
+    // Deleting an absent key is a no-op (no error).
+    store.delete("bookmark").await.expect("delete idempotent");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn nested_json_value_roundtrips_exactly() {
+    let (_container, url) = start_redis().await;
+    let store = RedisStateStore::connect(&url, "faucet")
+        .await
+        .expect("connect");
+
+    let nested = json!({
+        "offset": 12345,
+        "partitions": [0, 1, 2],
+        "meta": {"done": false, "ratio": 0.5, "note": null}
+    });
+    store.put("kafka", &nested).await.expect("put nested");
+    assert_eq!(
+        store.get("kafka").await.expect("get nested"),
+        Some(nested),
+        "nested JSON must survive the serialize/deserialize round-trip"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn check_probe_passes_against_live_redis() {
+    let (_container, url) = start_redis().await;
+    let store = RedisStateStore::connect(&url, "faucet")
+        .await
+        .expect("connect");
+
+    let report = store
+        .check(&CheckContext::default())
+        .await
+        .expect("check returns Ok");
+    assert_eq!(report.failed_count(), 0, "sentinel probe should pass");
+    assert_eq!(report.probes.len(), 1);
+    assert!(
+        matches!(report.probes[0].status, ProbeStatus::Pass),
+        "expected a passing probe, got {:?}",
+        report.probes[0].status
+    );
+
+    // The sentinel round-trip must leave no residue behind.
+    assert_eq!(
+        store
+            .get(faucet_core::state::DOCTOR_SENTINEL_KEY)
+            .await
+            .expect("get sentinel"),
+        None,
+        "check() must clean up its sentinel key"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn from_connection_and_namespace_isolation() {
+    let (_container, url) = start_redis().await;
+    // Build a raw multiplexed connection and share it across two stores that
+    // use different namespaces.
+    let client = redis::Client::open(url).expect("client open");
+    let conn = client
+        .get_multiplexed_async_connection()
+        .await
+        .expect("multiplexed connection");
+    let team_a = RedisStateStore::from_connection(conn.clone(), "team_a").expect("store a");
+    let team_b = RedisStateStore::from_connection(conn, "team_b").expect("store b");
+
+    // The namespace prefixes the physical Redis key.
+    assert_eq!(team_a.redis_key("cursor"), "team_a:cursor");
+    assert_eq!(team_b.redis_key("cursor"), "team_b:cursor");
+
+    // Writing the same logical key under one namespace does not leak into the
+    // other.
+    let value = json!({"v": 7});
+    team_a.put("cursor", &value).await.expect("put a");
+    assert_eq!(
+        team_a.get("cursor").await.expect("get a"),
+        Some(value),
+        "team_a sees its own value"
+    );
+    assert_eq!(
+        team_b.get("cursor").await.expect("get b"),
+        None,
+        "team_b must not see team_a's namespaced key"
+    );
+}

--- a/crates/state/redis/tests/integration.rs
+++ b/crates/state/redis/tests/integration.rs
@@ -13,8 +13,14 @@ use testcontainers_modules::redis::Redis;
 
 /// Start a Redis container and return the handle (keeps it alive) plus a URL.
 async fn start_redis() -> (ContainerAsync<Redis>, String) {
-    let container = Redis::default().start().await.expect("redis container start");
-    let port = container.get_host_port_ipv4(6379).await.expect("redis port");
+    let container = Redis::default()
+        .start()
+        .await
+        .expect("redis container start");
+    let port = container
+        .get_host_port_ipv4(6379)
+        .await
+        .expect("redis port");
     let url = format!("redis://127.0.0.1:{port}");
     (container, url)
 }


### PR DESCRIPTION
## Summary
Follow-up to #218 (which fixed the coverage *measurement*). With the honest per-crate numbers from Codecov, this PR tops up the crates that landed below a 75% floor by adding targeted tests.

## Results
| Crate | Before | After |
|---|---|---|
| `common/gcs` | 66.9% | **92.8%** |
| `source/postgres` | 71.8% | **89.6%** |
| `source/mysql` | 71.2% | **85.7%** |
| `state/postgres` | 62.9% | **84.5%** |
| `state/redis` | 57.0% | **83.6%** |
| `source/gcs` | 42.2% | 45.1% (capped — see below) |

**5 of 6 stragglers now clear 80%.**

## What was added
- **state/redis, state/postgres**: testcontainer integration tests (these crates had none) covering the `StateStore` get/put/delete/check I/O, UPSERT/overwrite, nested-JSON fidelity, and the `from_pool`/`from_connection`/namespace paths.
- **source/postgres, source/mysql**: an all-column-types integration test exercising every `*_value_to_json` arm (int widths, floats, timestamps, date/time, uuid, numeric, bytea/blob), plus a context-token test covering `resolve_query` + typed `bind_params`. (Found and asserted two real type behaviors: Postgres NUMERIC scale-padding, MySQL DATETIME → RFC3339.)
- **common/gcs**: tests for the `build_credentials` branches and the `build_storage`/`build_storage_control` client builders.
- **source/gcs**: extracted the format-parsing logic into a pure, testable `parse_file_content` free function — removing a silent test/prod duplication — and covered it + `value_type_name`.

## Known limitation
`source/gcs` cannot reach 80% in CI: its bulk is gRPC object I/O and `fake-gcs-server` is REST-only, so the integration tests are permanently `#[ignore]`d. Tracked in #220.

Refs #218