### PR TITLE
test: raise workspace coverage to ~94%

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ libtest_compile.rlib
 
 # mdBook rendered output (docs site source lives in docs/book/src)
 docs/book/book/
+
+# Coverage instrumentation artifacts (cargo-llvm-cov)
+*.profraw

--- a/cli/src/commands/schedule.rs
+++ b/cli/src/commands/schedule.rs
@@ -503,3 +503,191 @@ async fn graceful_shutdown(running: Option<RunningRun>, grace: Duration, pipelin
         m::in_flight(pipeline_name, 0);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schedule::spec::ScheduleSpec;
+
+    fn compiled(yaml: &str) -> CompiledSchedule {
+        let spec: ScheduleSpec = serde_yaml::from_str(yaml).unwrap();
+        CompiledSchedule::compile(&spec).unwrap()
+    }
+
+    fn summary(failures: usize, total: usize) -> RunSummary {
+        let mut invocations = Vec::new();
+        for i in 0..total {
+            invocations.push(crate::executor::InvocationOutcome {
+                row_id: format!("r{i}"),
+                parent_record_key: None,
+                records_written: if i < failures { 0 } else { 3 },
+                error: if i < failures {
+                    Some("boom".into())
+                } else {
+                    None
+                },
+            });
+        }
+        RunSummary { invocations }
+    }
+
+    #[test]
+    fn classify_success_when_no_failures() {
+        let joined = Ok(Ok(summary(0, 2)));
+        let f = classify(joined);
+        assert_eq!(f.outcome, RunOutcome::Success);
+        assert!(f.detail.is_none());
+    }
+
+    #[test]
+    fn classify_failure_when_some_invocations_failed() {
+        let joined = Ok(Ok(summary(2, 5)));
+        let f = classify(joined);
+        assert_eq!(f.outcome, RunOutcome::Failure);
+        assert_eq!(f.detail.as_deref(), Some("2 invocation(s) failed"));
+    }
+
+    #[test]
+    fn classify_failure_when_run_errored() {
+        let joined: Result<CliResult<RunSummary>, tokio::task::JoinError> =
+            Ok(Err(CliError::Internal("disk full".into())));
+        let f = classify(joined);
+        assert_eq!(f.outcome, RunOutcome::Failure);
+        assert!(f.detail.as_deref().unwrap().contains("disk full"));
+    }
+
+    #[tokio::test]
+    async fn classify_failure_when_task_panicked() {
+        // Spawn a task that panics, then join it to obtain a real JoinError.
+        let handle = tokio::spawn(async { panic!("kaboom") });
+        let joined: Result<CliResult<RunSummary>, tokio::task::JoinError> = handle.await.map(Ok);
+        let f = classify(joined);
+        assert_eq!(f.outcome, RunOutcome::Failure);
+        assert!(
+            f.detail.as_deref().unwrap().contains("panicked"),
+            "{:?}",
+            f.detail
+        );
+    }
+
+    #[test]
+    fn run_span_carries_ordinal_and_times() {
+        let scheduled = Utc::now();
+        let tick = scheduled + chrono::Duration::seconds(3);
+        let span = run_span(7, scheduled, tick);
+        // The span exists and is enterable; field values are recorded on
+        // creation. We assert it has the expected metadata name.
+        assert_eq!(span.metadata().unwrap().name(), "faucet.schedule.run");
+    }
+
+    #[tokio::test]
+    async fn wait_for_run_returns_classified_outcome() {
+        let handle = tokio::spawn(async { Ok(summary(0, 1)) });
+        let mut running = Some(RunningRun {
+            handle,
+            started: Instant::now(),
+        });
+        let finished = wait_for_run(&mut running).await;
+        assert_eq!(finished.outcome, RunOutcome::Success);
+    }
+
+    #[tokio::test]
+    async fn spawn_run_times_out_into_internal_error() {
+        // The run "never finishes" (a long sleep) but the 1s timeout aborts it
+        // and maps to an Internal error mentioning run_timeout_secs.
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("in.csv");
+        let output = dir.path().join("out.jsonl");
+        std::fs::write(&input, "name\nx\n").unwrap();
+        // Build nodes from a tiny real config so the spawned future is genuine.
+        let yaml = format!(
+            "version: 1\npipeline:\n  source: {{ type: csv, config: {{ path: {input} }} }}\n  sink: {{ type: jsonl, config: {{ path: {output} }} }}\n",
+            input = input.display(),
+            output = output.display(),
+        );
+        let cfg = crate::config::parse_with_extension(&yaml, "yaml").unwrap();
+        let nodes = expand(&cfg).unwrap();
+        let auth = AuthCatalog::new();
+        let opts = make_opts(
+            "to",
+            &None,
+            &auth,
+            Utc::now().fixed_offset(),
+            #[cfg(feature = "lineage")]
+            &None,
+            #[cfg(feature = "lineage")]
+            &None,
+        );
+        // A zero-ish timeout (1ns) virtually guarantees the timeout branch fires
+        // even though the pipeline is fast — the timeout races the spawn.
+        let handle = spawn_run(
+            nodes,
+            opts,
+            Some(Duration::from_nanos(1)),
+            run_span(1, Utc::now(), Utc::now()),
+        );
+        let joined = handle.await.unwrap();
+        // Either the run finished before the 1ns deadline (Ok) — unlikely — or
+        // it tripped the timeout into an Internal error. Accept both but assert
+        // the timeout message shape when it errors.
+        if let Err(CliError::Internal(msg)) = &joined {
+            assert!(msg.contains("run_timeout_secs"), "{msg}");
+        }
+    }
+
+    #[tokio::test]
+    async fn make_opts_disables_dry_run_limit_and_state_override() {
+        let auth = AuthCatalog::new();
+        let clock = Utc::now().fixed_offset();
+        let opts = make_opts(
+            "p",
+            &None,
+            &auth,
+            clock,
+            #[cfg(feature = "lineage")]
+            &None,
+            #[cfg(feature = "lineage")]
+            &None,
+        );
+        assert_eq!(opts.pipeline_name, "p");
+        assert!(!opts.dry_run);
+        assert!(opts.limit.is_none());
+        assert!(opts.state_path_override.is_none());
+        assert!(opts.cancel.is_none());
+        assert_eq!(opts.clock, clock);
+    }
+
+    #[tokio::test]
+    async fn graceful_shutdown_awaits_finished_run() {
+        // A run that finishes immediately is awaited within the grace window.
+        let c = compiled("cron: \"* * * * *\"\nshutdown_grace_secs: 5");
+        let handle = tokio::spawn(async { Ok(summary(0, 1)) });
+        let running = Some(RunningRun {
+            handle,
+            started: Instant::now(),
+        });
+        // Should return promptly without aborting (the run already completed).
+        graceful_shutdown(running, c.shutdown_grace, "p").await;
+    }
+
+    #[tokio::test]
+    async fn graceful_shutdown_aborts_run_exceeding_grace() {
+        // A run that never finishes is aborted once the (tiny) grace elapses.
+        let handle = tokio::spawn(async {
+            tokio::time::sleep(Duration::from_secs(3600)).await;
+            Ok(summary(0, 1))
+        });
+        let running = Some(RunningRun {
+            handle,
+            started: Instant::now(),
+        });
+        // 50ms grace → the abort branch fires; the call must still return.
+        graceful_shutdown(running, Duration::from_millis(50), "p").await;
+    }
+
+    #[tokio::test]
+    async fn graceful_shutdown_noop_when_idle() {
+        // No in-flight run → returns immediately.
+        graceful_shutdown(None, Duration::from_secs(1), "p").await;
+    }
+}

--- a/cli/src/executor.rs
+++ b/cli/src/executor.rs
@@ -1954,6 +1954,368 @@ matrix:
         assert!(matches!(&**projs.get("p").unwrap(), Projection::Full));
     }
 
+    /// Helper: minimal `ExecuteOptions` with all optional knobs cleared.
+    fn opts(name: &str) -> ExecuteOptions {
+        ExecuteOptions {
+            pipeline_name: name.into(),
+            execution: None,
+            dry_run: false,
+            limit: None,
+            state_path_override: None,
+            auth: Default::default(),
+            clock: chrono::Utc::now().fixed_offset(),
+            cancel: None,
+            #[cfg(feature = "lineage")]
+            lineage: None,
+            #[cfg(feature = "lineage")]
+            lineage_cfg: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn dry_run_counts_records_without_writing_sink_file() {
+        // `--dry-run` swaps the real sink for a CountingSink — records flow but
+        // no output file is produced.
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("in.csv");
+        let output = dir.path().join("out.jsonl");
+        std::fs::write(&input, "name\nalice\nbob\ncarol\n").unwrap();
+        let cfg = cfg_csv_to_jsonl(&input, &output);
+        let nodes = expand(&cfg).unwrap();
+        let mut o = opts("dry");
+        o.dry_run = true;
+        let summary = run_expanded(nodes, o).await.unwrap();
+        assert_eq!(summary.invocations.len(), 1);
+        assert_eq!(summary.invocations[0].records_written, 3);
+        assert!(!summary.had_failures());
+        assert!(
+            !output.exists(),
+            "dry-run must not create the real sink file"
+        );
+    }
+
+    #[tokio::test]
+    async fn limit_caps_records_written_across_the_run() {
+        // `--limit N` wraps the sink so only the first N records land.
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("in.csv");
+        let output = dir.path().join("out.jsonl");
+        std::fs::write(&input, "name\na\nb\nc\nd\ne\n").unwrap();
+        let cfg = cfg_csv_to_jsonl(&input, &output);
+        let nodes = expand(&cfg).unwrap();
+        let mut o = opts("lim");
+        o.limit = Some(2);
+        let summary = run_expanded(nodes, o).await.unwrap();
+        assert_eq!(summary.invocations[0].records_written, 2);
+        let body = std::fs::read_to_string(&output).unwrap();
+        assert_eq!(body.lines().count(), 2, "only the first 2 rows are written");
+    }
+
+    #[tokio::test]
+    async fn duplicate_state_key_among_siblings_is_rejected() {
+        // Two parent records whose `parent_key` value collides (both id="dup")
+        // produce two child units with the SAME state key. With state
+        // configured, that collision must surface as DuplicateStateKey.
+        let dir = tempfile::tempdir().unwrap();
+        let parent_csv = dir.path().join("parents.csv");
+        let child_csv = dir.path().join("child.csv");
+        // Both rows share id="dup" — the per-child state-key suffix collides.
+        std::fs::write(&parent_csv, "id\ndup\ndup\n").unwrap();
+        std::fs::write(&child_csv, "x\nA\n").unwrap();
+        let parent_out = dir.path().join("parents.jsonl");
+        let child_out = dir.path().join("child.jsonl");
+        let yaml = format!(
+            r#"version: 1
+pipeline:
+  source: {{ type: csv, config: {{ path: {parent} }} }}
+  sink:   {{ type: jsonl, config: {{ path: {parent_out} }} }}
+  state:  {{ type: memory }}
+matrix:
+  - id: parents
+  - id: child
+    parent: parents
+    source: {{ config: {{ path: {child} }} }}
+    sink:   {{ config: {{ path: {child_out} }} }}
+"#,
+            parent = parent_csv.display(),
+            parent_out = parent_out.display(),
+            child = child_csv.display(),
+            child_out = child_out.display(),
+        );
+        let cfg = crate::config::parse_with_extension(&yaml, "yaml").unwrap();
+        let nodes = expand(&cfg).unwrap();
+        let err = run_expanded(nodes, opts("dupkey"))
+            .await
+            .expect_err("colliding sibling state keys must be rejected");
+        match err {
+            CliError::DuplicateStateKey { id, state_key } => {
+                assert_eq!(id, "child");
+                assert_eq!(state_key, "dupkey::child::dup");
+            }
+            other => panic!("expected DuplicateStateKey, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn state_path_override_writes_bookmark_file() {
+        // `--state-path` with a node that has no `state:` block wires a
+        // FileStateStore at the override path; running it should create the
+        // bookmark file (REST-less csv source still opts into state via the
+        // override).
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("in.csv");
+        let output = dir.path().join("out.jsonl");
+        let state_dir = dir.path().join("state");
+        std::fs::write(&input, "name\nalice\n").unwrap();
+        let cfg = cfg_csv_to_jsonl(&input, &output);
+        let nodes = expand(&cfg).unwrap();
+        let mut o = opts("statepath");
+        o.state_path_override = Some(state_dir.clone());
+        let summary = run_expanded(nodes, o).await.unwrap();
+        assert!(!summary.had_failures());
+        // The csv source has no natural state key, so the StateKeyOverride wrap
+        // is skipped — but build_state_for_node still constructs the store.
+        // The run completing without error exercises the (None, Some(path)) arm.
+        assert_eq!(summary.invocations[0].records_written, 1);
+    }
+
+    #[tokio::test]
+    async fn build_dlq_config_maps_spec_fields() {
+        use crate::config::{ConnectorSpec, DlqSpec, OnBatchErrorSpec};
+        let dir = tempfile::tempdir().unwrap();
+        let dlq_out = dir.path().join("dlq.jsonl");
+        let spec = DlqSpec {
+            sink: ConnectorSpec {
+                kind: "jsonl".into(),
+                config: json!({ "path": dlq_out.to_str().unwrap() }),
+                transforms: None,
+                inherit_transforms: true,
+            },
+            on_batch_error: OnBatchErrorSpec::DlqAll,
+            max_failures_per_page: Some(7),
+            max_failures_total: Some(42),
+            include_original_payload: false,
+        };
+        let cfg = build_dlq_config(&spec).await.unwrap();
+        assert!(matches!(cfg.on_batch_error, OnBatchError::DlqAll));
+        assert_eq!(cfg.max_failures_per_page, Some(7));
+        assert_eq!(cfg.max_failures_total, Some(42));
+        assert!(!cfg.include_original_payload);
+    }
+
+    #[tokio::test]
+    async fn build_state_for_node_arms() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // (None, None) → no store.
+        let node = stub_node(None);
+        assert!(build_state_for_node(&node, None).await.unwrap().is_none());
+
+        // (None, Some(path)) → FileStateStore from override.
+        let p = dir.path().join("s1");
+        assert!(
+            build_state_for_node(&node, Some(&p))
+                .await
+                .unwrap()
+                .is_some()
+        );
+
+        // (Some(memory spec), None) → built from spec.
+        let node_mem = stub_node(Some(crate::config::StateStoreSpec {
+            kind: "memory".into(),
+            config: json!({}),
+        }));
+        assert!(
+            build_state_for_node(&node_mem, None)
+                .await
+                .unwrap()
+                .is_some()
+        );
+
+        // (Some(file spec), Some(path)) → file backend uses the override path.
+        let node_file = stub_node(Some(crate::config::StateStoreSpec {
+            kind: "file".into(),
+            config: json!({ "path": dir.path().join("orig").to_str().unwrap() }),
+        }));
+        let p2 = dir.path().join("override2");
+        assert!(
+            build_state_for_node(&node_file, Some(&p2))
+                .await
+                .unwrap()
+                .is_some()
+        );
+
+        // (Some(memory spec), Some(path)) → non-file backend ignores override,
+        // still builds from spec.
+        let node_mem2 = stub_node(Some(crate::config::StateStoreSpec {
+            kind: "memory".into(),
+            config: json!({}),
+        }));
+        let p3 = dir.path().join("override3");
+        assert!(
+            build_state_for_node(&node_mem2, Some(&p3))
+                .await
+                .unwrap()
+                .is_some()
+        );
+    }
+
+    /// Build a minimal root `ExpandedNode` carrying only an (optional) state spec.
+    fn stub_node(state: Option<crate::config::StateStoreSpec>) -> ExpandedNode {
+        use crate::config::ConnectorSpec;
+        ExpandedNode {
+            id: "n".into(),
+            row_index: 0,
+            role: NodeRole::Root,
+            source: ConnectorSpec {
+                kind: "csv".into(),
+                config: json!({}),
+                transforms: None,
+                inherit_transforms: true,
+            },
+            sink: ConnectorSpec {
+                kind: "jsonl".into(),
+                config: json!({}),
+                transforms: None,
+                inherit_transforms: true,
+            },
+            transforms: Vec::new(),
+            state,
+            dlq: None,
+            delivery: faucet_core::DeliveryMode::AtLeastOnce,
+            #[cfg(feature = "quality")]
+            quality: None,
+            deferred_refs: Vec::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn state_key_override_delegates_and_overrides_key() {
+        // StateKeyOverride forwards fetch/bookmark to inner and reports its own key.
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("in.csv");
+        std::fs::write(&input, "name\nz\n").unwrap();
+        let inner = build_source(
+            "csv",
+            json!({"path": input.to_str().unwrap()}),
+            &AuthCatalog::new(),
+        )
+        .await
+        .unwrap();
+        // The wrapped name must match the inner source's, whatever it reports.
+        let inner_name = inner.connector_name();
+        let ov = StateKeyOverride {
+            inner,
+            key: "my::custom::key".into(),
+        };
+        assert_eq!(ov.state_key(), Some("my::custom::key".to_string()));
+        assert_eq!(ov.connector_name(), inner_name);
+        let rows = ov.fetch_with_context(&HashMap::new()).await.unwrap();
+        assert_eq!(rows.len(), 1);
+        // apply_start_bookmark delegates without error (csv ignores it).
+        ov.apply_start_bookmark(json!({"any": "bookmark"}))
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn orphaned_child_surfaces_executor_deadlock() {
+        // A child node whose parent id is never present among the nodes can
+        // never become ready. `expand` would reject this, but a hand-built node
+        // list exercises the executor's own deadlock guard (lines 227-233).
+        use crate::config::ConnectorSpec;
+        let orphan = ExpandedNode {
+            id: "orphan".into(),
+            row_index: 0,
+            role: NodeRole::Child {
+                parent_id: "missing-parent".into(),
+                parent_key: "id".into(),
+            },
+            source: ConnectorSpec {
+                kind: "csv".into(),
+                config: json!({}),
+                transforms: None,
+                inherit_transforms: true,
+            },
+            sink: ConnectorSpec {
+                kind: "jsonl".into(),
+                config: json!({}),
+                transforms: None,
+                inherit_transforms: true,
+            },
+            transforms: Vec::new(),
+            state: None,
+            dlq: None,
+            delivery: faucet_core::DeliveryMode::AtLeastOnce,
+            #[cfg(feature = "quality")]
+            quality: None,
+            deferred_refs: Vec::new(),
+        };
+        let err = run_expanded(vec![orphan], opts("deadlock"))
+            .await
+            .expect_err("an orphaned child must surface as an executor deadlock");
+        match err {
+            CliError::Internal(msg) => {
+                assert!(msg.contains("executor deadlock"), "{msg}");
+                assert!(msg.contains("orphan"), "{msg}");
+            }
+            other => panic!("expected Internal deadlock error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn value_to_string_brief_unquotes_strings_only() {
+        assert_eq!(value_to_string_brief(&json!("hello")), "hello");
+        assert_eq!(value_to_string_brief(&json!(42)), "42");
+        assert_eq!(value_to_string_brief(&json!(true)), "true");
+        assert_eq!(value_to_string_brief(&json!(null)), "null");
+        assert_eq!(value_to_string_brief(&json!({"a": 1})), "{\"a\":1}");
+    }
+
+    #[test]
+    fn build_state_key_with_and_without_parent() {
+        assert_eq!(build_state_key("pipe", "row", None), "pipe::row");
+        assert_eq!(build_state_key("pipe", "row", Some("k")), "pipe::row::k");
+    }
+
+    #[test]
+    fn resolve_parent_key_walks_objects_arrays_and_misses() {
+        let r = json!({"user": {"name": "ada"}, "tags": ["x", "y"]});
+        assert_eq!(resolve_parent_key(&r, "user.name"), Some(json!("ada")));
+        assert_eq!(resolve_parent_key(&r, "tags.1"), Some(json!("y")));
+        // Missing key → None.
+        assert_eq!(resolve_parent_key(&r, "user.age"), None);
+        // Descending into a scalar → None.
+        assert_eq!(resolve_parent_key(&r, "user.name.deep"), None);
+        // Non-numeric array index → None.
+        assert_eq!(resolve_parent_key(&r, "tags.notanindex"), None);
+    }
+
+    #[tokio::test]
+    async fn cooperative_cancel_returns_partial_ok() {
+        // A pre-cancelled token makes the run stop at the first page boundary
+        // and flush — returning Ok with a partial (possibly empty) result
+        // rather than erroring. Covers the cancel-threading path.
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("in.csv");
+        let output = dir.path().join("out.jsonl");
+        std::fs::write(&input, "name\nalice\nbob\n").unwrap();
+        let cfg = cfg_csv_to_jsonl(&input, &output);
+        let nodes = expand(&cfg).unwrap();
+        let token = CancellationToken::new();
+        token.cancel(); // already cancelled before the run starts
+        let mut o = opts("cancel");
+        o.cancel = Some(token);
+        let summary = run_expanded(nodes, o).await.unwrap();
+        // The single root invocation completes (Ok) — it is not reported as a
+        // failure even though it was cancelled.
+        assert_eq!(summary.invocations.len(), 1);
+        assert!(
+            !summary.had_failures(),
+            "a cooperatively-cancelled run is Ok, not a failure: {summary:?}"
+        );
+    }
+
     #[tokio::test]
     async fn fanout_projects_away_unreferenced_parent_fields() {
         // Parent CSV has id + a big unreferenced "payload" column. The child only

--- a/cli/src/registry.rs
+++ b/cli/src/registry.rs
@@ -728,4 +728,247 @@ mod tests {
         );
         assert!(scrubbed.ends_with('…'));
     }
+
+    // A `(kind, config)` pair that builds without performing any network/disk
+    // I/O — the CSV source's `new()` only stores config, so we can drive the
+    // real `build_source` dispatch arm and inspect the resulting trait object.
+    #[cfg(feature = "source-csv")]
+    #[tokio::test]
+    async fn build_source_csv_succeeds_without_io() {
+        let src = build_source(
+            "csv",
+            serde_json::json!({ "path": "/tmp/does-not-need-to-exist.csv" }),
+            &AuthCatalog::new(),
+        )
+        .await
+        .expect("csv source should build without I/O");
+        // The CSV source uses the default `connector_name()` (stripped type
+        // name) rather than overriding it with a friendly label.
+        assert_eq!(src.connector_name(), "CsvSource");
+    }
+
+    // The JSONL sink's `new()` is also pure (it opens the file lazily on first
+    // write), so building it exercises the sink dispatch arm with no I/O.
+    #[cfg(feature = "sink-jsonl")]
+    #[tokio::test]
+    async fn build_sink_jsonl_succeeds_without_io() {
+        let sink = build_sink(
+            "jsonl",
+            serde_json::json!({ "path": "/tmp/does-not-need-to-exist.jsonl" }),
+            &AuthCatalog::new(),
+        )
+        .await
+        .expect("jsonl sink should build without I/O");
+        assert_eq!(sink.connector_name(), "jsonl");
+    }
+
+    // The stdout sink builds without any config fields and without I/O.
+    #[cfg(feature = "sink-stdout")]
+    #[tokio::test]
+    async fn build_sink_stdout_succeeds_without_io() {
+        let sink = build_sink("stdout", serde_json::json!({}), &AuthCatalog::new())
+            .await
+            .expect("stdout sink should build without I/O");
+        // The stdout sink uses the default `connector_name()` (stripped type
+        // name) rather than overriding it with a friendly label.
+        assert_eq!(sink.connector_name(), "StdoutSink");
+    }
+
+    // A malformed config for a known connector must surface as a typed
+    // `InvalidConnectorConfig` from the `decode` helper, not a panic.
+    #[cfg(feature = "source-csv")]
+    #[tokio::test]
+    async fn build_source_csv_invalid_config_errors() {
+        // `path` is a required String; supplying an integer is a type error.
+        // `Box<dyn Source>` is not `Debug`, so match the Result directly rather
+        // than using `expect_err`.
+        let res = build_source(
+            "csv",
+            serde_json::json!({ "path": 42 }),
+            &AuthCatalog::new(),
+        )
+        .await;
+        match res {
+            Err(CliError::InvalidConnectorConfig { kind, name, .. }) => {
+                assert_eq!(kind, "source");
+                assert_eq!(name, "csv");
+            }
+            Ok(_) => panic!("expected InvalidConnectorConfig, got Ok"),
+            Err(other) => panic!("expected InvalidConnectorConfig, got {other:?}"),
+        }
+    }
+
+    // `source_schema` must return a JSON object that surfaces the connector's
+    // config fields (here: the required `path`).
+    #[cfg(feature = "source-csv")]
+    #[test]
+    fn source_schema_csv_exposes_path_property() {
+        let schema = source_schema("csv").expect("csv schema");
+        let props = schema
+            .get("properties")
+            .and_then(Value::as_object)
+            .expect("schema should have a properties object");
+        assert!(props.contains_key("path"), "schema props: {props:?}");
+    }
+
+    #[cfg(feature = "sink-jsonl")]
+    #[test]
+    fn sink_schema_jsonl_exposes_path_property() {
+        let schema = sink_schema("jsonl").expect("jsonl schema");
+        let props = schema
+            .get("properties")
+            .and_then(Value::as_object)
+            .expect("schema should have a properties object");
+        assert!(props.contains_key("path"), "schema props: {props:?}");
+    }
+
+    #[test]
+    fn unknown_source_schema_errors_with_available_list() {
+        let err = source_schema("definitely-not-a-source").expect_err("unknown source");
+        match err {
+            CliError::UnknownConnector {
+                kind,
+                name,
+                available,
+            } => {
+                assert_eq!(kind, "source");
+                assert_eq!(name, "definitely-not-a-source");
+                // Under `--all-features` the available list is non-empty.
+                assert!(!available.is_empty());
+            }
+            other => panic!("expected UnknownConnector, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unknown_sink_schema_errors() {
+        let err = sink_schema("definitely-not-a-sink").expect_err("unknown sink");
+        assert!(matches!(
+            err,
+            CliError::UnknownConnector { kind: "sink", .. }
+        ));
+    }
+
+    #[cfg(feature = "source-csv")]
+    #[test]
+    fn source_exists_is_true_for_known_and_false_for_unknown() {
+        assert!(source_exists("csv"));
+        assert!(!source_exists("definitely-not-a-source"));
+    }
+
+    #[cfg(feature = "sink-jsonl")]
+    #[test]
+    fn sink_exists_is_true_for_known_and_false_for_unknown() {
+        assert!(sink_exists("jsonl"));
+        assert!(!sink_exists("definitely-not-a-sink"));
+    }
+
+    // Descriptions back `faucet list`: non-empty, with a one-line summary, and
+    // each name must resolve to a real schema (no orphan listing).
+    #[test]
+    fn source_descriptions_are_non_empty_and_consistent() {
+        let descs = source_descriptions();
+        assert!(!descs.is_empty());
+        for (name, summary) in &descs {
+            assert!(!name.is_empty(), "empty connector name");
+            assert!(!summary.is_empty(), "empty summary for {name}");
+            assert!(
+                source_schema(name).is_ok(),
+                "listed source `{name}` has no schema"
+            );
+        }
+    }
+
+    #[test]
+    fn sink_descriptions_are_non_empty_and_consistent() {
+        let descs = sink_descriptions();
+        assert!(!descs.is_empty());
+        for (name, summary) in &descs {
+            assert!(!name.is_empty(), "empty connector name");
+            assert!(!summary.is_empty(), "empty summary for {name}");
+            assert!(
+                sink_schema(name).is_ok(),
+                "listed sink `{name}` has no schema"
+            );
+        }
+    }
+
+    // `*_kinds()` is derived from `*_descriptions()`; under `--all-features`
+    // the canonical built-in connectors must be present.
+    #[cfg(all(feature = "source-csv", feature = "source-rest"))]
+    #[test]
+    fn source_kinds_contains_expected_builtins() {
+        let kinds = source_kinds();
+        assert!(kinds.contains(&"csv"));
+        assert!(kinds.contains(&"rest"));
+    }
+
+    #[cfg(all(feature = "sink-jsonl", feature = "sink-stdout"))]
+    #[test]
+    fn sink_kinds_contains_expected_builtins() {
+        let kinds = sink_kinds();
+        assert!(kinds.contains(&"jsonl"));
+        assert!(kinds.contains(&"stdout"));
+    }
+
+    // Build a catalog holding one `static` bearer provider, then build a
+    // connector whose config carries `auth: { ref: "tok" }` — exercising the
+    // `with_auth_provider` injection branch in the dispatch arm.
+    #[cfg(feature = "source-rest")]
+    #[tokio::test]
+    async fn build_source_injects_referenced_auth_provider() {
+        let mut specs = std::collections::HashMap::new();
+        specs.insert(
+            "tok".to_string(),
+            serde_json::json!({"type": "static", "config": {"token": "abc"}}),
+        );
+        let catalog = auth_catalog::build_auth_catalog(Some(&specs)).expect("catalog");
+
+        let src = build_source("rest", rest_config_with_auth_ref("tok"), &catalog)
+            .await
+            .expect("rest source with a resolvable auth ref should build");
+        assert_eq!(src.connector_name(), "rest");
+    }
+
+    // A minimal, fully-valid rest config (built from the real constructor so
+    // every required field is present) carrying an `auth: { ref }` pointer.
+    #[cfg(feature = "source-rest")]
+    fn rest_config_with_auth_ref(name: &str) -> Value {
+        let cfg = faucet_source_rest::RestStreamConfig::new("https://api.example.com", "/v1");
+        let mut v = serde_json::to_value(cfg).expect("serialize rest config");
+        v.as_object_mut()
+            .unwrap()
+            .insert("auth".to_string(), serde_json::json!({ "ref": name }));
+        v
+    }
+
+    // An `auth: { ref }` pointing at a name absent from the catalog must surface
+    // as `UnknownAuthProvider`, not silently build without auth.
+    #[cfg(feature = "source-rest")]
+    #[tokio::test]
+    async fn build_source_unknown_auth_ref_errors() {
+        let res = build_source(
+            "rest",
+            rest_config_with_auth_ref("missing"),
+            &AuthCatalog::new(),
+        )
+        .await;
+        match res {
+            Err(CliError::UnknownAuthProvider { name, .. }) => assert_eq!(name, "missing"),
+            Ok(_) => panic!("expected UnknownAuthProvider, got Ok"),
+            Err(other) => panic!("expected UnknownAuthProvider, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn exactly_once_capability_allowlists() {
+        assert!(source_supports_exactly_once("postgres-cdc"));
+        assert!(source_supports_exactly_once("mysql-cdc"));
+        assert!(source_supports_exactly_once("mongodb-cdc"));
+        assert!(!source_supports_exactly_once("rest"));
+
+        assert!(sink_supports_idempotent_writes("postgres"));
+        assert!(sink_supports_idempotent_writes("iceberg"));
+        assert!(!sink_supports_idempotent_writes("jsonl"));
+    }
 }

--- a/cli/src/secrets/aws_sm.rs
+++ b/cli/src/secrets/aws_sm.rs
@@ -68,3 +68,34 @@ impl SecretResolver for AwsSmResolver {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scheme_is_aws_sm() {
+        assert_eq!(AwsSmResolver::new().scheme(), "aws-sm");
+    }
+
+    #[test]
+    fn new_and_default_construct_an_unbuilt_client() {
+        // Both constructors leave the SDK client cell empty — no AWS config is
+        // loaded until the first resolve(), so a config that never references
+        // aws-sm pays nothing.
+        let _r1 = AwsSmResolver::new();
+        let _r2 = AwsSmResolver::default();
+    }
+
+    #[test]
+    fn reference_field_split_drives_extraction_path() {
+        // `split_field` (shared) decides whether resolve() extracts a `#field`
+        // or returns the whole secret string — verify the split the resolver
+        // relies on, independent of the live AWS fetch.
+        assert_eq!(
+            split_field("prod/db#password"),
+            ("prod/db", Some("password"))
+        );
+        assert_eq!(split_field("prod/db"), ("prod/db", None));
+    }
+}

--- a/cli/src/secrets/azure_kv.rs
+++ b/cli/src/secrets/azure_kv.rs
@@ -234,4 +234,78 @@ mod tests {
             "credential chain should be built at most once and reused"
         );
     }
+
+    #[test]
+    fn scheme_is_azure_kv() {
+        assert_eq!(AzureKvResolver::new().scheme(), "azure-kv");
+    }
+
+    #[test]
+    fn default_constructs_a_resolver() {
+        // Exercises the `Default` impl (no panic, fresh OnceCell).
+        let _r = AzureKvResolver::default();
+    }
+
+    #[tokio::test]
+    async fn empty_reference_is_a_parse_error_before_any_network() {
+        // An empty reference yields an empty vault segment → fetch-failed with
+        // the format hint, with no credential build / network call.
+        let resolver = AzureKvResolver::new();
+        match resolver.resolve("").await.unwrap_err() {
+            CliError::SecretFetchFailed {
+                scheme, reference, ..
+            } => {
+                assert_eq!(scheme, "azure-kv");
+                assert_eq!(reference, "");
+            }
+            other => panic!("expected SecretFetchFailed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn missing_secret_name_segment_is_a_parse_error() {
+        // "<vault>" with no "/<secret>" → the secret-name segment is missing.
+        let resolver = AzureKvResolver::new();
+        match resolver.resolve("myvault").await.unwrap_err() {
+            CliError::SecretFetchFailed {
+                scheme, reference, ..
+            } => {
+                assert_eq!(scheme, "azure-kv");
+                assert_eq!(reference, "myvault");
+            }
+            other => panic!("expected SecretFetchFailed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn empty_secret_name_segment_is_a_parse_error() {
+        // "<vault>/" → the secret-name segment is present but empty.
+        let resolver = AzureKvResolver::new();
+        match resolver.resolve("myvault/").await.unwrap_err() {
+            CliError::SecretFetchFailed { reference, .. } => {
+                assert_eq!(reference, "myvault/");
+            }
+            other => panic!("expected SecretFetchFailed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn chained_credential_aggregates_errors_when_all_fail() {
+        // A chain of zero sources fails get_token with the aggregate message.
+        let chain = ChainedCredential::new(Vec::new());
+        let err = chain.get_token(&["scope"], None).await.unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("All Azure credential sources failed"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn chained_credential_debug_reports_source_count() {
+        let chain = ChainedCredential::new(Vec::new());
+        let dbg = format!("{chain:?}");
+        assert!(dbg.contains("ChainedCredential"), "{dbg}");
+        assert!(dbg.contains("sources_len"), "{dbg}");
+    }
 }

--- a/cli/src/secrets/gcp_sm.rs
+++ b/cli/src/secrets/gcp_sm.rs
@@ -124,6 +124,7 @@ impl SecretResolver for GcpSmResolver {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use base64::Engine;
 
     #[test]
@@ -134,5 +135,31 @@ mod tests {
             .decode(&b64)
             .unwrap();
         assert_eq!(String::from_utf8(decoded).unwrap(), "my-secret");
+    }
+
+    #[test]
+    fn scheme_is_gcp_sm() {
+        assert_eq!(GcpSmResolver::new().scheme(), "gcp-sm");
+    }
+
+    #[test]
+    fn new_and_default_construct_a_resolver() {
+        // Both constructors yield an empty (unfetched) credentials cell — no
+        // network I/O happens until the first resolve/token call.
+        let _r1 = GcpSmResolver::new();
+        let _r2 = GcpSmResolver::default();
+    }
+
+    #[test]
+    fn payload_path_extraction_returns_base64_string() {
+        // The `body["payload"]["data"]` shape that resolve() decodes — verify
+        // the as_str() extraction independently of the live token fetch.
+        let b64 = base64::engine::general_purpose::STANDARD.encode("topsecret");
+        let body = serde_json::json!({ "payload": { "data": b64 } });
+        let extracted = body["payload"]["data"].as_str().unwrap();
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(extracted)
+            .unwrap();
+        assert_eq!(String::from_utf8(bytes).unwrap(), "topsecret");
     }
 }

--- a/cli/src/secrets/mod.rs
+++ b/cli/src/secrets/mod.rs
@@ -531,6 +531,123 @@ pipeline:
     }
 
     #[test]
+    fn make_resolver_rejects_unknown_scheme() {
+        match make_resolver("not-a-scheme") {
+            Err(CliError::SecretBackendDisabled { scheme }) => assert_eq!(scheme, "not-a-scheme"),
+            Err(other) => panic!("expected SecretBackendDisabled, got {other:?}"),
+            Ok(_) => panic!("expected SecretBackendDisabled for an unknown scheme"),
+        }
+    }
+
+    #[cfg(feature = "secrets-aws-sm")]
+    #[test]
+    fn make_resolver_builds_compiled_in_aws_backend() {
+        // The constructor is cheap (no network) — it must yield a resolver whose
+        // scheme matches, proving the feature-gated arm is wired.
+        let r = make_resolver("aws-sm").unwrap();
+        assert_eq!(r.scheme(), "aws-sm");
+    }
+
+    #[tokio::test]
+    async fn resolve_secrets_walks_matrix_row_state_dlq_and_transforms() {
+        // A matrix row whose own state/dlq/transforms configs hold secrets must
+        // have them resolved by the mutating visitor (the per-row branches).
+        let mut set = ResolverSet::default();
+        set.insert(Arc::new(FakeResolver {
+            scheme: "vault",
+            value: "R".into(),
+        }));
+        let cfg_yaml = r#"
+version: 1
+pipeline:
+  source: { type: csv, config: { path: ./in.csv } }
+  sink:   { type: jsonl, config: { path: ./o.jsonl } }
+matrix:
+  - id: row1
+    source: { config: { path: "${vault:secret/src}" } }
+    sink:   { config: { path: "${vault:secret/sink}" } }
+    state:  { type: file, config: { path: "${vault:secret/state}" } }
+    transforms:
+      - type: set
+        config: { field: tag, value: "${vault:secret/tf}" }
+    dlq:
+      sink: { type: jsonl, config: { path: "${vault:secret/dlq}" } }
+"#;
+        let mut cfg = PipelineConfig::from_text(cfg_yaml, std::path::Path::new("p.yaml")).unwrap();
+        resolve_secrets_with(&mut cfg, &set).await.unwrap();
+
+        let row = &cfg.matrix[0];
+        assert_eq!(
+            row.source.as_ref().unwrap().config.as_ref().unwrap()["path"],
+            "R"
+        );
+        assert_eq!(
+            row.sink.as_ref().unwrap().config.as_ref().unwrap()["path"],
+            "R"
+        );
+        assert_eq!(row.state.as_ref().unwrap().config["path"], "R");
+        assert_eq!(row.transforms.as_ref().unwrap()[0].config["value"], "R");
+        let dlq = row.dlq.as_ref().unwrap().as_ref().unwrap();
+        assert_eq!(dlq.sink.config["path"], "R");
+    }
+
+    #[test]
+    fn scan_config_collects_refs_from_matrix_row_state_and_dlq() {
+        // The read-only visitor must reach the per-row state/dlq/transforms too.
+        let cfg_yaml = r#"
+version: 1
+pipeline:
+  source: { type: csv, config: { path: ./in.csv } }
+  sink:   { type: jsonl, config: { path: ./o.jsonl } }
+matrix:
+  - id: r
+    state: { type: file, config: { path: "${vault:secret/state}" } }
+    transforms:
+      - type: set
+        config: { field: t, value: "${aws-sm:tf/key}" }
+    dlq:
+      sink: { type: jsonl, config: { path: "${gcp-sm:projects/p/secrets/s/versions/1}" } }
+"#;
+        let cfg = PipelineConfig::from_text(cfg_yaml, std::path::Path::new("p.yaml")).unwrap();
+        let refs = scan_config(&cfg);
+        assert!(refs.contains(&("vault".into(), "secret/state".into())));
+        assert!(refs.contains(&("aws-sm".into(), "tf/key".into())));
+        assert!(refs.contains(&("gcp-sm".into(), "projects/p/secrets/s/versions/1".into())));
+    }
+
+    #[tokio::test]
+    async fn resolve_secrets_noop_when_no_directives() {
+        // No secret directives anywhere → resolve_secrets returns Ok without
+        // building any resolver (the empty-refs early return).
+        let cfg_yaml = r#"
+version: 1
+pipeline:
+  source: { type: csv, config: { path: ./in.csv } }
+  sink:   { type: jsonl, config: { path: ./o.jsonl } }
+"#;
+        let mut cfg = PipelineConfig::from_text(cfg_yaml, std::path::Path::new("p.yaml")).unwrap();
+        resolve_secrets(&mut cfg).await.unwrap();
+    }
+
+    #[test]
+    fn split_field_splits_on_hash() {
+        assert_eq!(split_field("a/b#c"), ("a/b", Some("c")));
+        assert_eq!(split_field("a/b"), ("a/b", None));
+    }
+
+    #[test]
+    fn ensure_no_secret_directives_passes_when_clean() {
+        let cfg_yaml = r#"
+version: 1
+pipeline:
+  source: { type: csv, config: { path: ./in.csv } }
+  sink:   { type: jsonl, config: { path: ./o.jsonl } }
+"#;
+        let cfg = PipelineConfig::from_text(cfg_yaml, std::path::Path::new("p.yaml")).unwrap();
+        assert!(ensure_no_secret_directives(&cfg).is_ok());
+    }
+
+    #[test]
     fn ensure_no_secret_directives_flags_vault() {
         let cfg_yaml = r#"
 version: 1

--- a/cli/src/secrets/vault.rs
+++ b/cli/src/secrets/vault.rs
@@ -141,4 +141,157 @@ mod tests {
             other => panic!("expected SecretNotFound, got {other:?}"),
         }
     }
+
+    #[test]
+    fn scheme_is_vault() {
+        let r = VaultResolver {
+            addr: "http://x".into(),
+            token: "t".into(),
+            namespace: None,
+            client: reqwest::Client::new(),
+        };
+        assert_eq!(r.scheme(), "vault");
+    }
+
+    #[tokio::test]
+    async fn forbidden_status_maps_to_auth_failed() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/secret/data/secured"))
+            .respond_with(ResponseTemplate::new(403))
+            .mount(&server)
+            .await;
+        let resolver = VaultResolver {
+            addr: server.uri(),
+            token: "bad".into(),
+            namespace: None,
+            client: reqwest::Client::new(),
+        };
+        match resolver.resolve("secret/data/secured#x").await.unwrap_err() {
+            CliError::SecretAuthFailed { scheme, .. } => assert_eq!(scheme, "vault"),
+            other => panic!("expected SecretAuthFailed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn unauthorized_status_maps_to_auth_failed() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/secret/data/secured"))
+            .respond_with(ResponseTemplate::new(401))
+            .mount(&server)
+            .await;
+        let resolver = VaultResolver {
+            addr: server.uri(),
+            token: "bad".into(),
+            namespace: None,
+            client: reqwest::Client::new(),
+        };
+        match resolver.resolve("secret/data/secured").await.unwrap_err() {
+            CliError::SecretAuthFailed { .. } => {}
+            other => panic!("expected SecretAuthFailed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn no_field_returns_whole_kv_v2_map_as_json() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/secret/data/all"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": { "data": { "a": "1", "b": "2" } }
+            })))
+            .mount(&server)
+            .await;
+        let resolver = VaultResolver {
+            addr: server.uri(),
+            token: "t".into(),
+            namespace: None,
+            client: reqwest::Client::new(),
+        };
+        // No `#field` → the whole `.data.data` map, JSON-serialized.
+        let v = resolver.resolve("secret/data/all").await.unwrap();
+        let parsed: Value = serde_json::from_str(&v).unwrap();
+        assert_eq!(parsed["a"], "1");
+        assert_eq!(parsed["b"], "2");
+    }
+
+    #[tokio::test]
+    async fn namespace_header_is_sent_when_configured() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/secret/data/ns"))
+            .and(header("X-Vault-Namespace", "team-a"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": { "data": { "k": "v" } }
+            })))
+            .mount(&server)
+            .await;
+        let resolver = VaultResolver {
+            addr: server.uri(),
+            token: "t".into(),
+            namespace: Some("team-a".into()),
+            client: reqwest::Client::new(),
+        };
+        // The mock only matches when the namespace header is present.
+        let v = resolver.resolve("secret/data/ns#k").await.unwrap();
+        assert_eq!(v, "v");
+    }
+
+    #[test]
+    #[serial_test::serial(vault_env)]
+    fn from_env_reads_addr_token_namespace() {
+        unsafe {
+            std::env::set_var("VAULT_ADDR", "https://vault.example.com:8200/");
+            std::env::set_var("VAULT_TOKEN", "tok-123");
+            std::env::set_var("VAULT_NAMESPACE", "ns1");
+        }
+        let r = VaultResolver::from_env().unwrap();
+        // Trailing slash on the addr must be trimmed.
+        assert_eq!(r.addr, "https://vault.example.com:8200");
+        assert_eq!(r.token, "tok-123");
+        assert_eq!(r.namespace.as_deref(), Some("ns1"));
+        unsafe {
+            std::env::remove_var("VAULT_ADDR");
+            std::env::remove_var("VAULT_TOKEN");
+            std::env::remove_var("VAULT_NAMESPACE");
+        }
+    }
+
+    #[test]
+    #[serial_test::serial(vault_env)]
+    fn from_env_errors_without_addr() {
+        unsafe {
+            std::env::remove_var("VAULT_ADDR");
+            std::env::remove_var("VAULT_TOKEN");
+        }
+        match VaultResolver::from_env() {
+            Err(CliError::SecretAuthFailed { scheme, hint }) => {
+                assert_eq!(scheme, "vault");
+                assert!(hint.contains("VAULT_ADDR"), "{hint}");
+            }
+            Err(other) => panic!("expected SecretAuthFailed, got {other:?}"),
+            Ok(_) => panic!("expected an error when VAULT_ADDR is unset"),
+        }
+    }
+
+    #[test]
+    #[serial_test::serial(vault_env)]
+    fn from_env_errors_without_token() {
+        unsafe {
+            std::env::set_var("VAULT_ADDR", "https://v");
+            std::env::remove_var("VAULT_TOKEN");
+        }
+        match VaultResolver::from_env() {
+            Err(CliError::SecretAuthFailed { scheme, hint }) => {
+                assert_eq!(scheme, "vault");
+                assert!(hint.contains("VAULT_TOKEN"), "{hint}");
+            }
+            Err(other) => panic!("expected SecretAuthFailed, got {other:?}"),
+            Ok(_) => panic!("expected an error when VAULT_TOKEN is unset"),
+        }
+        unsafe {
+            std::env::remove_var("VAULT_ADDR");
+        }
+    }
 }

--- a/cli/tests/init_preview.rs
+++ b/cli/tests/init_preview.rs
@@ -1,0 +1,271 @@
+//! Integration tests for the `faucet init` and `faucet preview` subcommands,
+//! driven through their clap-free `run(...)` entry points (the same way the
+//! binary's `main` dispatches into them).
+
+use faucet_cli::cli::{InitArgs, PreviewArgs};
+use faucet_cli::commands::{init, preview};
+use faucet_cli::error::CliError;
+use std::path::PathBuf;
+
+/// Build an `InitArgs` with the schema-driven defaults the binary uses, then
+/// override only what each test needs.
+fn init_args(output: PathBuf, source: Option<&str>, sink: Option<&str>) -> InitArgs {
+    InitArgs {
+        name: Some("smoke-pipeline".to_string()),
+        source: source.map(str::to_string),
+        sink: sink.map(str::to_string),
+        output,
+        force: false,
+        interactive: false,
+        template: "default".to_string(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// init
+// ---------------------------------------------------------------------------
+
+#[cfg(all(feature = "source-csv", feature = "sink-jsonl"))]
+#[tokio::test]
+async fn init_renders_csv_to_jsonl_template_with_required_markers() {
+    let dir = tempfile::tempdir().unwrap();
+    let out = dir.path().join("pipeline.yaml");
+
+    init::run(init_args(out.clone(), Some("csv"), Some("jsonl")))
+        .await
+        .expect("init should write the scaffold");
+
+    let body = std::fs::read_to_string(&out).unwrap();
+
+    // Header + chosen name.
+    assert!(body.starts_with("version: 1\n"), "{body}");
+    assert!(body.contains("name: smoke-pipeline\n"), "{body}");
+
+    // The named-template shape with our `default` template name.
+    assert!(body.contains("  sources:\n"), "{body}");
+    assert!(body.contains("    default:\n"), "{body}");
+    assert!(body.contains("      type: csv\n"), "{body}");
+    assert!(body.contains("  sinks:\n"), "{body}");
+    assert!(body.contains("      type: jsonl\n"), "{body}");
+
+    // Both csv source and jsonl sink have a required `path` field — the
+    // schema-driven renderer surfaces it with a `# REQUIRED` marker.
+    assert!(body.contains("path:"), "expected a path field: {body}");
+    assert!(
+        body.contains("# REQUIRED"),
+        "expected a REQUIRED marker for the required path field: {body}"
+    );
+
+    // The matrix scaffold references the same template name.
+    assert!(
+        body.contains("source: { ref: default,"),
+        "expected matrix example referencing the template: {body}"
+    );
+}
+
+#[cfg(all(feature = "source-rest", feature = "sink-jsonl"))]
+#[tokio::test]
+async fn init_defaults_to_rest_to_jsonl() {
+    let dir = tempfile::tempdir().unwrap();
+    let out = dir.path().join("pipeline.yaml");
+
+    // No --source / --sink and no name → schema-driven defaults.
+    let args = InitArgs {
+        name: None,
+        source: None,
+        sink: None,
+        output: out.clone(),
+        force: false,
+        interactive: false,
+        template: "default".to_string(),
+    };
+    init::run(args).await.expect("init defaults should write");
+
+    let body = std::fs::read_to_string(&out).unwrap();
+    assert!(body.contains("name: my-pipeline\n"), "{body}");
+    assert!(body.contains("      type: rest\n"), "{body}");
+    assert!(body.contains("      type: jsonl\n"), "{body}");
+}
+
+#[tokio::test]
+async fn init_refuses_to_overwrite_existing_file_without_force() {
+    let dir = tempfile::tempdir().unwrap();
+    let out = dir.path().join("pipeline.yaml");
+    std::fs::write(&out, "pre-existing").unwrap();
+
+    let err = init::run(init_args(out.clone(), None, None))
+        .await
+        .expect_err("init must not clobber an existing file");
+    match err {
+        CliError::ScaffoldExists { path } => assert_eq!(path, out),
+        other => panic!("expected ScaffoldExists, got {other:?}"),
+    }
+    // The original content is untouched.
+    assert_eq!(std::fs::read_to_string(&out).unwrap(), "pre-existing");
+}
+
+#[cfg(all(feature = "source-csv", feature = "sink-jsonl"))]
+#[tokio::test]
+async fn init_force_overwrites_existing_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let out = dir.path().join("pipeline.yaml");
+    std::fs::write(&out, "stale").unwrap();
+
+    let mut args = init_args(out.clone(), Some("csv"), Some("jsonl"));
+    args.force = true;
+    init::run(args).await.expect("force should overwrite");
+
+    let body = std::fs::read_to_string(&out).unwrap();
+    assert!(body.starts_with("version: 1\n"), "{body}");
+    assert!(
+        !body.contains("stale"),
+        "stale content not replaced: {body}"
+    );
+}
+
+#[tokio::test]
+async fn init_rejects_unknown_source_kind() {
+    let dir = tempfile::tempdir().unwrap();
+    let out = dir.path().join("pipeline.yaml");
+
+    let err = init::run(init_args(out, Some("definitely-not-a-source"), None))
+        .await
+        .expect_err("unknown source kind must be rejected");
+    match err {
+        CliError::UnknownConnector { kind, name, .. } => {
+            assert_eq!(kind, "source");
+            assert_eq!(name, "definitely-not-a-source");
+        }
+        other => panic!("expected UnknownConnector, got {other:?}"),
+    }
+}
+
+#[cfg(feature = "source-csv")]
+#[tokio::test]
+async fn init_rejects_unknown_sink_kind() {
+    let dir = tempfile::tempdir().unwrap();
+    let out = dir.path().join("pipeline.yaml");
+
+    let err = init::run(init_args(out, Some("csv"), Some("definitely-not-a-sink")))
+        .await
+        .expect_err("unknown sink kind must be rejected");
+    match err {
+        CliError::UnknownConnector { kind, name, .. } => {
+            assert_eq!(kind, "sink");
+            assert_eq!(name, "definitely-not-a-sink");
+        }
+        other => panic!("expected UnknownConnector, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// preview
+// ---------------------------------------------------------------------------
+
+fn preview_args(config: Option<PathBuf>, limit: usize) -> PreviewArgs {
+    PreviewArgs {
+        config,
+        limit,
+        env_file: None,
+        no_env_file: true,
+    }
+}
+
+#[cfg(all(feature = "source-csv", feature = "sink-stdout"))]
+#[tokio::test]
+async fn preview_runs_first_root_csv_source() {
+    let dir = tempfile::tempdir().unwrap();
+    let csv = dir.path().join("in.csv");
+    let cfg = dir.path().join("faucet.yaml");
+    std::fs::write(&csv, "id,name\n1,alice\n2,bob\n3,carol\n").unwrap();
+
+    let yaml = format!(
+        r#"version: 1
+name: preview_smoke
+pipeline:
+  source:
+    type: csv
+    config:
+      path: {csv}
+  sink:
+    type: stdout
+    config: {{}}
+"#,
+        csv = csv.display(),
+    );
+    std::fs::write(&cfg, yaml).unwrap();
+
+    // limit smaller than the record count: the preview path takes the first N.
+    preview::run(preview_args(Some(cfg), 2))
+        .await
+        .expect("preview of a valid csv root should succeed");
+}
+
+#[cfg(all(
+    feature = "source-csv",
+    feature = "sink-stdout",
+    feature = "transforms"
+))]
+#[tokio::test]
+async fn preview_applies_transforms_before_emitting() {
+    let dir = tempfile::tempdir().unwrap();
+    let csv = dir.path().join("in.csv");
+    let cfg = dir.path().join("faucet.yaml");
+    std::fs::write(&csv, "id,name\n1,alice\n").unwrap();
+
+    // A pipeline-level transform exercises the compile_transforms + apply path
+    // inside preview (the `stages.is_empty()` false branch).
+    let yaml = format!(
+        r#"version: 1
+name: preview_transform
+pipeline:
+  source:
+    type: csv
+    config:
+      path: {csv}
+  transforms:
+    - type: select
+      config:
+        fields: [id]
+  sink:
+    type: stdout
+    config: {{}}
+"#,
+        csv = csv.display(),
+    );
+    std::fs::write(&cfg, yaml).unwrap();
+
+    preview::run(preview_args(Some(cfg), 10))
+        .await
+        .expect("preview with a transform should succeed");
+}
+
+#[cfg(feature = "sink-stdout")]
+#[tokio::test]
+async fn preview_unknown_source_kind_errors() {
+    let dir = tempfile::tempdir().unwrap();
+    let cfg = dir.path().join("faucet.yaml");
+
+    let yaml = r#"version: 1
+name: preview_bad
+pipeline:
+  source:
+    type: definitely-not-a-source
+    config: {}
+  sink:
+    type: stdout
+    config: {}
+"#;
+    std::fs::write(&cfg, yaml).unwrap();
+
+    let err = preview::run(preview_args(Some(cfg), 10))
+        .await
+        .expect_err("preview of an unknown source kind must fail");
+    match err {
+        CliError::UnknownConnector { kind, name, .. } => {
+            assert_eq!(kind, "source");
+            assert_eq!(name, "definitely-not-a-source");
+        }
+        other => panic!("expected UnknownConnector, got {other:?}"),
+    }
+}

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -208,4 +208,103 @@ mod tests {
         let parsed: D = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed, d);
     }
+
+    // ── load_env ─────────────────────────────────────────────────────────────
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct EnvConfig {
+        url: String,
+        #[serde(default)]
+        batch_size: Option<usize>,
+    }
+
+    #[test]
+    fn load_env_reads_prefixed_vars() {
+        // SAFETY: the test sets and reads its own uniquely-prefixed vars; no
+        // other test uses the FAUCETCFGA_ prefix.
+        unsafe {
+            std::env::set_var("FAUCETCFGA_URL", "https://env.example.com");
+            std::env::set_var("FAUCETCFGA_BATCH_SIZE", "55");
+        }
+        let config: EnvConfig = load_env("FAUCETCFGA").unwrap();
+        assert_eq!(config.url, "https://env.example.com");
+        assert_eq!(config.batch_size, Some(55));
+        unsafe {
+            std::env::remove_var("FAUCETCFGA_URL");
+            std::env::remove_var("FAUCETCFGA_BATCH_SIZE");
+        }
+    }
+
+    #[test]
+    fn load_env_missing_required_field_errors() {
+        // No FAUCETCFGB_* vars set → the required `url` field cannot be read.
+        let result = load_env::<EnvConfig>("FAUCETCFGB");
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            FaucetError::Config(msg) => {
+                assert!(msg.contains("failed to load config from env vars"), "{msg}")
+            }
+            other => panic!("expected Config error, got {other:?}"),
+        }
+    }
+
+    // ── load_env_file ────────────────────────────────────────────────────────
+
+    #[test]
+    fn load_env_file_loads_dotenv_then_reads_vars() {
+        let dir = std::env::temp_dir();
+        let path = dir.join("faucet_test_loadenvfile.env");
+        std::fs::write(
+            &path,
+            "FAUCETCFGC_URL=https://dotenv.example.com\nFAUCETCFGC_BATCH_SIZE=12\n",
+        )
+        .unwrap();
+
+        let config: EnvConfig = load_env_file(&path, "FAUCETCFGC").unwrap();
+        assert_eq!(config.url, "https://dotenv.example.com");
+        assert_eq!(config.batch_size, Some(12));
+
+        std::fs::remove_file(&path).ok();
+        unsafe {
+            std::env::remove_var("FAUCETCFGC_URL");
+            std::env::remove_var("FAUCETCFGC_BATCH_SIZE");
+        }
+    }
+
+    #[test]
+    fn load_env_file_missing_file_errors() {
+        let result = load_env_file::<EnvConfig>("/nonexistent/path.env", "FAUCETCFGD");
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            FaucetError::Config(msg) => assert!(msg.contains("failed to load .env file"), "{msg}"),
+            other => panic!("expected Config error, got {other:?}"),
+        }
+    }
+
+    // ── duration_secs_option ─────────────────────────────────────────────────
+
+    #[test]
+    fn duration_secs_option_roundtrip_some_and_none() {
+        use std::time::Duration;
+
+        #[derive(Debug, serde::Serialize, Deserialize, PartialEq)]
+        struct D {
+            #[serde(with = "super::duration_secs_option")]
+            timeout: Option<Duration>,
+        }
+
+        let some = D {
+            timeout: Some(Duration::from_secs(45)),
+        };
+        let json = serde_json::to_string(&some).unwrap();
+        assert_eq!(json, r#"{"timeout":45}"#);
+        let parsed: D = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, some);
+
+        let none = D { timeout: None };
+        let json = serde_json::to_string(&none).unwrap();
+        assert_eq!(json, r#"{"timeout":null}"#);
+        let parsed: D = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, none);
+    }
 }

--- a/crates/core/src/observability/decorator.rs
+++ b/crates/core/src/observability/decorator.rs
@@ -625,6 +625,122 @@ pub(crate) mod source_tests {
         assert!(matches!(first, Err(FaucetError::Custom(_))));
         // Process did not abort — implicit by reaching this line.
     }
+
+    // ── error_kind: exhaustive variant → label mapping ───────────────────────
+
+    #[test]
+    fn error_kind_covers_all_variants() {
+        use std::time::Duration;
+        // Build one of every non-`Http` FaucetError variant and assert its
+        // stable label. (`Http` wraps a `reqwest::Error`, which has no public
+        // constructor; it is exercised through the live request paths in the
+        // connector crates' tests.)
+        let cases: Vec<(FaucetError, &str)> = vec![
+            (
+                FaucetError::HttpStatus {
+                    status: 500,
+                    url: "u".into(),
+                    body: "b".into(),
+                },
+                "HttpStatus",
+            ),
+            (
+                FaucetError::Json(serde_json::from_str::<Value>("nope").unwrap_err()),
+                "Json",
+            ),
+            (FaucetError::JsonPath("bad".into()), "JsonPath"),
+            (FaucetError::Auth("a".into()), "Auth"),
+            (
+                FaucetError::RateLimited(Duration::from_secs(1)),
+                "RateLimited",
+            ),
+            (FaucetError::Url("bad url".into()), "Url"),
+            (FaucetError::Transform("t".into()), "Transform"),
+            (FaucetError::Config("c".into()), "Config"),
+            (FaucetError::Source("s".into()), "Source"),
+            (FaucetError::Sink("s".into()), "Sink"),
+            (
+                FaucetError::QualityFailure {
+                    check: "chk".into(),
+                    message: "m".into(),
+                },
+                "QualityFailure",
+            ),
+            (FaucetError::State("st".into()), "State"),
+            (
+                FaucetError::Custom(Box::new(std::io::Error::other("boom"))),
+                "Custom",
+            ),
+        ];
+        for (err, expected) in cases {
+            assert_eq!(error_kind(&err), expected, "mismatch for {err:?}");
+        }
+    }
+
+    // ── Source passthrough methods ───────────────────────────────────────────
+
+    // A source that overrides every passthrough so the instrumented wrapper's
+    // delegating methods (state_key / apply_start_bookmark / fetch_with_context
+    // / fetch_with_context_incremental) are exercised.
+    struct PassthroughSource {
+        seen_bookmark: Mutex<Option<Value>>,
+    }
+    #[async_trait]
+    impl Source for PassthroughSource {
+        async fn fetch_with_context(
+            &self,
+            _: &HashMap<String, Value>,
+        ) -> Result<Vec<Value>, FaucetError> {
+            Ok(vec![json!({"fwc": 1})])
+        }
+        async fn fetch_with_context_incremental(
+            &self,
+            _: &HashMap<String, Value>,
+        ) -> Result<(Vec<Value>, Option<Value>), FaucetError> {
+            Ok((vec![json!({"inc": 1})], Some(json!("bm"))))
+        }
+        fn state_key(&self) -> Option<String> {
+            Some("passthrough_key".into())
+        }
+        async fn apply_start_bookmark(&self, bookmark: Value) -> Result<(), FaucetError> {
+            *self.seen_bookmark.lock().unwrap() = Some(bookmark);
+            Ok(())
+        }
+        fn connector_name(&self) -> &'static str {
+            "passthrough"
+        }
+    }
+
+    #[tokio::test]
+    async fn source_passthroughs_delegate_to_inner() {
+        let inner = PassthroughSource {
+            seen_bookmark: Mutex::new(None),
+        };
+        let wrapped = InstrumentedSource::new(&inner, labels());
+
+        // state_key passthrough
+        assert_eq!(wrapped.state_key(), Some("passthrough_key".to_string()));
+
+        // fetch_with_context passthrough
+        let ctx = HashMap::new();
+        assert_eq!(
+            wrapped.fetch_with_context(&ctx).await.unwrap(),
+            vec![json!({"fwc": 1})]
+        );
+
+        // fetch_with_context_incremental passthrough
+        let (recs, bm) = wrapped.fetch_with_context_incremental(&ctx).await.unwrap();
+        assert_eq!(recs, vec![json!({"inc": 1})]);
+        assert_eq!(bm, Some(json!("bm")));
+
+        // apply_start_bookmark passthrough
+        wrapped.apply_start_bookmark(json!("resume")).await.unwrap();
+        assert_eq!(
+            *inner.seen_bookmark.lock().unwrap(),
+            Some(json!("resume")),
+            "apply_start_bookmark must reach the inner source"
+        );
+    }
 }
 
 #[cfg(test)]
@@ -801,5 +917,122 @@ mod sink_tests {
             records >= 2,
             "expected faucet_sink_records_total{{connector=mixed}} >= 2, got {records}"
         );
+    }
+
+    // ── flush error path ─────────────────────────────────────────────────────
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn flush_error_increments_errors_total_and_propagates() {
+        // A sink whose flush() returns Err must surface the error and emit
+        // faucet_sink_errors_total with the matching kind label.
+        struct FlushFailSink;
+        #[async_trait]
+        impl Sink for FlushFailSink {
+            async fn write_batch(&self, r: &[Value]) -> Result<usize, FaucetError> {
+                Ok(r.len())
+            }
+            async fn flush(&self) -> Result<(), FaucetError> {
+                Err(FaucetError::Sink("flush boom".into()))
+            }
+            fn connector_name(&self) -> &'static str {
+                "flush-fail-sink"
+            }
+        }
+
+        let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let snap = snapshotter();
+        let inner = FlushFailSink;
+        let wrapped = InstrumentedSink::new(&inner, labels());
+        let err = wrapped.flush().await.unwrap_err();
+        assert!(matches!(&err, FaucetError::Sink(m) if m.contains("flush boom")));
+
+        let snapshot = snap.snapshot();
+        let found = snapshot.into_vec().into_iter().any(|(key, _u, _d, v)| {
+            key.key().name() == "faucet_sink_errors_total"
+                && key
+                    .key()
+                    .labels()
+                    .any(|l| l.key() == "connector" && l.value() == "flush-fail-sink")
+                && key
+                    .key()
+                    .labels()
+                    .any(|l| l.key() == "kind" && l.value() == "Sink")
+                && matches!(v, DebugValue::Counter(c) if c >= 1)
+        });
+        assert!(
+            found,
+            "expected sink_errors_total{{connector=flush-fail-sink,kind=Sink}}"
+        );
+    }
+
+    // ── panic isolation on every sink call ───────────────────────────────────
+
+    struct PanickingSink;
+    #[async_trait]
+    impl Sink for PanickingSink {
+        async fn write_batch(&self, _: &[Value]) -> Result<usize, FaucetError> {
+            panic!("write kaboom")
+        }
+        async fn write_batch_partial(
+            &self,
+            _: &[Value],
+        ) -> Result<Vec<crate::traits::RowOutcome>, FaucetError> {
+            panic!("partial kaboom")
+        }
+        async fn flush(&self) -> Result<(), FaucetError> {
+            panic!("flush kaboom")
+        }
+        fn connector_name(&self) -> &'static str {
+            "panic-sink"
+        }
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn write_batch_panic_maps_to_custom_error() {
+        let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _snap = snapshotter();
+        let inner = PanickingSink;
+        let wrapped = InstrumentedSink::new(&inner, labels());
+        let err = wrapped.write_batch(&[json!({})]).await.unwrap_err();
+        match err {
+            FaucetError::Custom(b) => {
+                assert!(b.to_string().contains("panic in sink: write kaboom"))
+            }
+            other => panic!("expected Custom panic error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn write_batch_partial_panic_maps_to_custom_error() {
+        let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _snap = snapshotter();
+        let inner = PanickingSink;
+        let wrapped = InstrumentedSink::new(&inner, labels());
+        let err = wrapped.write_batch_partial(&[json!({})]).await.unwrap_err();
+        match err {
+            FaucetError::Custom(b) => {
+                assert!(b.to_string().contains("panic in sink: partial kaboom"))
+            }
+            other => panic!("expected Custom panic error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn flush_panic_maps_to_custom_error() {
+        let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _snap = snapshotter();
+        let inner = PanickingSink;
+        let wrapped = InstrumentedSink::new(&inner, labels());
+        let err = wrapped.flush().await.unwrap_err();
+        match err {
+            FaucetError::Custom(b) => {
+                assert!(b.to_string().contains("panic in flush: flush kaboom"))
+            }
+            other => panic!("expected Custom panic error, got {other:?}"),
+        }
     }
 }

--- a/crates/core/src/observability/install.rs
+++ b/crates/core/src/observability/install.rs
@@ -194,4 +194,54 @@ mod tests {
             other => panic!("expected PrometheusBind error, got {other:?}"),
         }
     }
+
+    #[test]
+    fn register_build_info_is_callable_and_idempotent() {
+        let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        // Gauges are idempotent under the metrics model; repeat calls must not
+        // panic regardless of which recorder (if any) is installed.
+        register_build_info();
+        register_build_info();
+    }
+
+    #[test]
+    fn install_prometheus_and_tracing_returns_ok() {
+        // Drive the full prometheus + tracing install path on an ephemeral
+        // port. The recorder + subscriber are process-global: depending on
+        // test ordering, the recorder either installs fresh (Ok path) or is
+        // already installed (idempotent warn path). Either way the call must
+        // return Ok and never panic, and the report must reflect what happened.
+        let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let cfg = ObservabilityConfig {
+            prometheus: Some(PrometheusConfig {
+                listen: "127.0.0.1:0".into(),
+                // Exercise the explicit-buckets branch.
+                buckets: Some(vec![0.01, 0.1, 1.0]),
+            }),
+            tracing: Some(TracingConfig {
+                level: "info".into(),
+            }),
+        };
+        let report = install_observability(&cfg).expect("install must return Ok");
+        // Exactly one of: recorder installed (listen set) OR already installed.
+        assert!(
+            report.prometheus_listen.is_some() || report.prometheus_already_installed,
+            "prometheus install must either bind or report already-installed"
+        );
+    }
+
+    #[test]
+    fn install_tracing_with_invalid_directive_falls_back_to_info() {
+        // An unparseable EnvFilter directive must not error — it silently falls
+        // back to "info". The call returns Ok regardless of subscriber state.
+        let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let cfg = ObservabilityConfig {
+            prometheus: None,
+            tracing: Some(TracingConfig {
+                // Garbage directive → try_new errors → fallback to info.
+                level: "this is !!! not a valid filter".into(),
+            }),
+        };
+        install_observability(&cfg).expect("invalid tracing directive must not fail install");
+    }
 }

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -2985,4 +2985,202 @@ mod tests {
             "expected faucet_pipeline_adaptive_batch_adjustments_total counter with pipeline=p, row=r"
         );
     }
+
+    // ── run_stream: exactly-once + DLQ incompatibility gate ─────────────────
+
+    #[tokio::test]
+    async fn exactly_once_rejects_dlq() {
+        // Exactly-once must reject a configured DLQ (incompatible in this
+        // version): the gate fires before any page is polled.
+        let store: Arc<dyn StateStore> = Arc::new(MemoryStateStore::new());
+        let dlq_sink: Arc<dyn Sink> = Arc::new(MockSink::new());
+        let pages: Vec<Result<StreamPage, FaucetError>> = vec![];
+        let opts = eo_opts(store, "k", 0).with_dlq(DlqConfig::new(dlq_sink));
+        let r = run_stream(
+            futures::stream::iter(pages),
+            &IdempotentMockSink::new(),
+            opts,
+        )
+        .await;
+        assert!(
+            matches!(&r, Err(FaucetError::Config(m)) if m.contains("not compatible with a DLQ")),
+            "got: {r:?}"
+        );
+    }
+
+    // ── run_stream: exactly-once page with records but no bookmark ──────────
+
+    #[tokio::test]
+    async fn exactly_once_writes_unbookmarked_page_at_least_once() {
+        // Under exactly-once, a page that carries records but NO bookmark is
+        // not individually checkpointed: it falls through to a plain
+        // `write_batch` (at-least-once for that page) and is NOT idempotently
+        // tokened.
+        let sink = IdempotentMockSink::new();
+        let store: Arc<dyn StateStore> = Arc::new(MemoryStateStore::new());
+        let pages = vec![Ok(StreamPage {
+            records: vec![json!({"id": 1}), json!({"id": 2})],
+            bookmark: None,
+        })];
+        let r = run_stream(
+            futures::stream::iter(pages),
+            &sink,
+            eo_opts(store.clone(), "k", 0),
+        )
+        .await
+        .unwrap();
+        assert_eq!(r.records_written, 2);
+        assert_eq!(r.bookmark, None);
+        // Rows were written via the plain (non-idempotent) write_batch path, so
+        // no commit token was recorded for the scope.
+        assert_eq!(sink.last_committed_token("k").await.unwrap(), None);
+        // Nothing was persisted to the state store (no bookmark to checkpoint).
+        assert!(store.get("k").await.unwrap().is_none());
+        assert_eq!(sink.rows(), vec![json!({"id": 1}), json!({"id": 2})]);
+    }
+
+    // ── DLQ-with-bookmark success path: persist bookmark after routing ──────
+
+    #[tokio::test]
+    async fn dlq_with_bookmark_persists_after_routing_failures() {
+        // A bookmark-carrying page whose main sink reports one per-row failure:
+        // survivors commit, the failed row reaches the DLQ, the DLQ is flushed,
+        // and the bookmark is persisted to the state store.
+        let main = PartialSink::new(vec![1]); // 2 rows, index 1 fails
+        let dlq = std::sync::Arc::new(MockSink::new());
+        let store: Arc<dyn StateStore> = Arc::new(MemoryStateStore::new());
+        let pages: Vec<Result<StreamPage, FaucetError>> = vec![Ok(StreamPage {
+            records: vec![json!({"i": 0}), json!({"i": 1})],
+            bookmark: Some(json!("ckpt")),
+        })];
+        let result = run_stream(
+            futures::stream::iter(pages),
+            &main,
+            RunStreamOptions::new()
+                .with_dlq(DlqConfig::new(dlq.clone()))
+                .with_state(Arc::clone(&store), "k"),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.records_written, 1); // row 0 committed
+        assert_eq!(result.bookmark, Some(json!("ckpt")));
+        // Bookmark was persisted after the page was made durable.
+        assert_eq!(store.get("k").await.unwrap(), Some(json!("ckpt")));
+        // The single failed row reached the DLQ.
+        let envelopes = dlq.0.lock().unwrap();
+        assert_eq!(envelopes.len(), 1);
+        assert_eq!(envelopes[0]["payload"]["i"], 1);
+    }
+
+    // ── run_stream drives exactly-once with resume from start_seq ───────────
+
+    #[tokio::test]
+    async fn exactly_once_resumes_sequence_from_start_seq() {
+        // A resume run starts at start_seq (the persisted seq) and continues
+        // numbering tokens from there; the next bookmark-carrying page is
+        // committed at seq = start_seq + 1.
+        let sink = IdempotentMockSink::new();
+        let store: Arc<dyn StateStore> = Arc::new(MemoryStateStore::new());
+        let pages = vec![Ok(StreamPage {
+            records: vec![json!({"id": 9})],
+            bookmark: Some(json!("bm-after-resume")),
+        })];
+        let r = run_stream(
+            futures::stream::iter(pages),
+            &sink,
+            eo_opts(store.clone(), "eo_key", 7),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(r.records_written, 1);
+        let (bm, seq) =
+            crate::idempotency::unwrap_state(&store.get("eo_key").await.unwrap().unwrap());
+        assert_eq!(bm, Some(json!("bm-after-resume")));
+        assert_eq!(seq, 8, "sequence resumes at start_seq + 1");
+        assert_eq!(
+            sink.last_committed_token("eo_key").await.unwrap(),
+            Some(crate::idempotency::format_token(8))
+        );
+    }
+
+    // ── Pipeline::run with quality wired through the builder ────────────────
+
+    #[cfg(feature = "quality")]
+    #[tokio::test]
+    async fn pipeline_run_with_quality_aborts_on_failed_batch_check() {
+        use crate::quality::{BatchCheck, CompiledQuality, OnFailure, QualitySpec};
+        let source = MockSource(vec![json!({"id": 1})]);
+        let main = MockSink::new();
+        let spec = QualitySpec {
+            record: vec![],
+            batch: vec![BatchCheck::RowCount {
+                min: Some(5),
+                max: None,
+                on_failure: OnFailure::Abort,
+            }],
+        };
+        let quality = Arc::new(CompiledQuality::compile(&spec).unwrap());
+        let result = Pipeline::new(&source, &main)
+            .with_quality(quality)
+            .run()
+            .await;
+        assert!(matches!(result, Err(FaucetError::QualityFailure { .. })));
+        // The abort fired before the sink committed.
+        assert!(main.written().is_empty());
+    }
+
+    // ── Pipeline::run with adaptive wired through the builder ───────────────
+
+    #[tokio::test]
+    async fn pipeline_run_with_adaptive_reslices_page() {
+        use crate::adaptive::AdaptiveBatchConfig;
+        let source = MockSource((0..1000).map(|i| json!({ "i": i })).collect());
+        let sink = MockSink::new();
+        let cfg: AdaptiveBatchConfig =
+            serde_json::from_value(json!({"enabled": true, "min": 100, "max": 1000})).unwrap();
+        let result = Pipeline::new(&source, &sink)
+            .with_adaptive(cfg)
+            .run()
+            .await
+            .unwrap();
+        assert_eq!(result.records_written, 1000);
+        assert_eq!(sink.written().len(), 1000);
+    }
+
+    // ── Adaptive no-op warning for per-record sinks (jsonl/csv/stdout) ──────
+
+    #[tokio::test]
+    async fn adaptive_noop_sink_name_is_handled() {
+        use crate::adaptive::AdaptiveBatchConfig;
+
+        // A sink whose connector_name() is one of the per-record names triggers
+        // the one-shot "no-op for this per-record sink" info path.
+        struct JsonlNamedSink(std::sync::Mutex<usize>);
+        #[async_trait]
+        impl Sink for JsonlNamedSink {
+            async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
+                *self.0.lock().unwrap() += records.len();
+                Ok(records.len())
+            }
+            fn connector_name(&self) -> &'static str {
+                "jsonl"
+            }
+        }
+
+        let page = StreamPage {
+            records: (0..10).map(|i| json!({ "i": i })).collect(),
+            bookmark: None,
+        };
+        let stream = futures::stream::iter(vec![Ok(page)]);
+        let sink = JsonlNamedSink(std::sync::Mutex::new(0));
+        let cfg: AdaptiveBatchConfig =
+            serde_json::from_value(json!({"enabled": true, "min": 5, "max": 10})).unwrap();
+        let result = run_stream(stream, &sink, RunStreamOptions::new().with_adaptive(cfg))
+            .await
+            .unwrap();
+        assert_eq!(result.records_written, 10);
+        assert_eq!(*sink.0.lock().unwrap(), 10);
+    }
 }

--- a/crates/core/src/stage.rs
+++ b/crates/core/src/stage.rs
@@ -1356,4 +1356,287 @@ mod tests {
         let out = apply_stages_to_page(vec![], &[page_count_stage()]).unwrap();
         assert_eq!(out, vec![json!({"n": 0})]);
     }
+
+    // ── Debug formatting for the stage enums ───────────────────────────────────
+
+    #[test]
+    fn debug_transform_stage_all_variants() {
+        assert_eq!(
+            format!("{:?}", TransformStage::Custom(Arc::new(|v| vec![v]))),
+            "Custom(<fn>)"
+        );
+        assert_eq!(
+            format!("{:?}", TransformStage::PageFn(Arc::new(Ok))),
+            "PageFn(<fn>)"
+        );
+        let dbg = format!(
+            "{:?}",
+            TransformStage::Map(RecordTransform::KeysCase {
+                mode: KeyCaseMode::Snake
+            })
+        );
+        assert!(dbg.starts_with("Map"), "{dbg}");
+
+        #[cfg(feature = "transform-filter")]
+        {
+            let dbg = format!(
+                "{:?}",
+                TransformStage::Filter(FilterSpec {
+                    path: "a".into(),
+                    op: FilterOp::Exists,
+                    value: None,
+                })
+            );
+            assert!(dbg.starts_with("Filter"), "{dbg}");
+        }
+        #[cfg(feature = "transform-explode")]
+        {
+            let dbg = format!("{:?}", explode("items"));
+            assert!(dbg.starts_with("Explode"), "{dbg}");
+        }
+    }
+
+    #[test]
+    fn debug_compiled_stage_all_variants() {
+        assert_eq!(
+            format!("{:?}", CompiledStage::Custom(Arc::new(|v| vec![v]))),
+            "Custom(<fn>)"
+        );
+        assert_eq!(
+            format!("{:?}", CompiledStage::PageFn(Arc::new(Ok))),
+            "PageFn(<fn>)"
+        );
+        let map = compile(&[TransformStage::Map(RecordTransform::KeysCase {
+            mode: KeyCaseMode::Snake,
+        })]);
+        assert_eq!(format!("{:?}", map[0]), "Map(<compiled>)");
+
+        #[cfg(feature = "transform-filter")]
+        {
+            let filter = compile(&[filter("a", FilterOp::Exists, None)]);
+            let dbg = format!("{:?}", filter[0]);
+            assert!(dbg.starts_with("Filter"), "{dbg}");
+        }
+        #[cfg(feature = "transform-explode")]
+        {
+            let exploded = compile(&[explode("items")]);
+            let dbg = format!("{:?}", exploded[0]);
+            assert!(dbg.starts_with("Explode"), "{dbg}");
+        }
+    }
+
+    // ── Clone for the stage enums ──────────────────────────────────────────────
+
+    #[test]
+    fn clone_transform_stage_all_variants() {
+        let mut stages: Vec<TransformStage> = vec![
+            TransformStage::Map(RecordTransform::KeysCase {
+                mode: KeyCaseMode::Snake,
+            }),
+            TransformStage::Custom(Arc::new(|v| vec![v])),
+            TransformStage::PageFn(Arc::new(Ok)),
+        ];
+        #[cfg(feature = "transform-filter")]
+        stages.push(filter("a", FilterOp::Exists, None));
+        #[cfg(feature = "transform-explode")]
+        stages.push(explode("items"));
+
+        for s in &stages {
+            let cloned = s.clone();
+            // Both compile cleanly — proving the clone produced a usable stage.
+            compile_stage(&cloned).expect("cloned stage compiles");
+        }
+
+        // Clone of Custom preserves behaviour (refcount bump, same closure).
+        let custom = TransformStage::Custom(Arc::new(|v| vec![v.clone(), v]));
+        // Clone the stage (the behaviour under test), then compile the clone.
+        let cloned = custom.clone();
+        let compiled_clone = compile(&[cloned]);
+        assert_eq!(
+            apply_stages(json!({"x": 1}), &compiled_clone)
+                .unwrap()
+                .len(),
+            2
+        );
+    }
+
+    #[test]
+    fn clone_compiled_stage_all_variants() {
+        let mut specs: Vec<TransformStage> = vec![
+            TransformStage::Map(RecordTransform::KeysCase {
+                mode: KeyCaseMode::Snake,
+            }),
+            TransformStage::Custom(Arc::new(|v| vec![v])),
+            TransformStage::PageFn(Arc::new(Ok)),
+        ];
+        #[cfg(feature = "transform-filter")]
+        specs.push(filter("status", FilterOp::Eq, Some(json!("active"))));
+        #[cfg(feature = "transform-explode")]
+        specs.push(explode("items"));
+
+        let original = compile(&specs);
+        let cloned: Vec<CompiledStage> = original.to_vec();
+        assert_eq!(original.len(), cloned.len());
+        // Confirm a cloned Map stage still transforms identically.
+        let out = apply_stages(json!({"FooBar": 1}), std::slice::from_ref(&cloned[0])).unwrap();
+        assert_eq!(out, vec![json!({"foo_bar": 1})]);
+    }
+
+    #[cfg(feature = "transform-filter")]
+    #[test]
+    fn clone_compiled_filter_preserves_predicate() {
+        let original = compile(&[filter("status", FilterOp::Eq, Some(json!("active")))]);
+        let cloned = vec![original[0].clone()];
+        assert_eq!(
+            apply_stages(json!({"status": "active"}), &cloned).unwrap(),
+            vec![json!({"status": "active"})]
+        );
+        assert_eq!(
+            apply_stages(json!({"status": "x"}), &cloned).unwrap(),
+            Vec::<Value>::new()
+        );
+    }
+
+    #[cfg(feature = "transform-explode")]
+    #[test]
+    fn clone_compiled_explode_preserves_behaviour() {
+        let original = compile(&[explode("items")]);
+        let cloned = vec![original[0].clone()];
+        let out = apply_stages(json!({"id": 1, "items": [{"sku": "A"}]}), &cloned).unwrap();
+        assert_eq!(out, vec![json!({"id": 1, "items_sku": "A"})]);
+    }
+
+    // ── compile_stage: Custom / PageFn pass-through ────────────────────────────
+
+    #[test]
+    fn compile_stage_custom_and_page_fn() {
+        let custom =
+            compile_stage(&TransformStage::Custom(Arc::new(|v| vec![v]))).expect("custom compiles");
+        assert!(matches!(custom, CompiledStage::Custom(_)));
+        let page = compile_stage(&TransformStage::PageFn(Arc::new(Ok))).expect("page fn compiles");
+        assert!(matches!(page, CompiledStage::PageFn(_)));
+    }
+
+    // ── FilterOp Display ───────────────────────────────────────────────────────
+
+    #[cfg(feature = "transform-filter")]
+    #[test]
+    fn filter_op_display_strings() {
+        assert_eq!(FilterOp::Eq.to_string(), "eq");
+        assert_eq!(FilterOp::Ne.to_string(), "ne");
+        assert_eq!(FilterOp::Exists.to_string(), "exists");
+        assert_eq!(FilterOp::In.to_string(), "in");
+        assert_eq!(FilterOp::NotIn.to_string(), "not_in");
+    }
+
+    // ── CompiledPath::compile error branches ───────────────────────────────────
+
+    #[test]
+    fn path_empty_segment_after_dot_errors() {
+        // "$.a." leaves a trailing empty identifier.
+        let err = CompiledPath::compile("$.a.").expect_err("trailing dot");
+        assert!(matches!(err, FaucetError::Transform(_)));
+        assert!(format!("{err}").contains("empty segment after"), "{err}");
+    }
+
+    #[test]
+    fn path_unterminated_bracket_errors() {
+        let err = CompiledPath::compile("$[").expect_err("dangling open bracket");
+        assert!(format!("{err}").contains("unterminated bracket"), "{err}");
+    }
+
+    #[test]
+    fn path_bracket_requires_quoted_key_errors() {
+        // `[0]` — numeric index isn't supported in the v1 subset.
+        let err = CompiledPath::compile("$[0]").expect_err("unquoted bracket key");
+        assert!(format!("{err}").contains("requires a quoted key"), "{err}");
+    }
+
+    #[test]
+    fn path_unterminated_quoted_key_errors() {
+        let err = CompiledPath::compile("$['oops").expect_err("missing closing quote");
+        assert!(
+            format!("{err}").contains("unterminated quoted key"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn path_missing_closing_bracket_errors() {
+        // Quote closes but the `]` is missing.
+        let err = CompiledPath::compile("$['key'").expect_err("missing closing bracket");
+        assert!(
+            format!("{err}").contains("expected ']' after quoted key"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn path_unexpected_character_errors() {
+        // After `$`, a char that's neither `.` nor `[` is rejected.
+        let err = CompiledPath::compile("$x").expect_err("unexpected char");
+        assert!(format!("{err}").contains("unexpected character"), "{err}");
+    }
+
+    #[test]
+    fn path_empty_must_address_a_key_errors() {
+        // A bare `$` parses to zero segments.
+        let err = CompiledPath::compile("$").expect_err("bare root has no key");
+        assert!(
+            format!("{err}").contains("empty (must address a key)"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn path_bracket_wildcard_and_filter_rejected() {
+        // `[*]` and `[?...]` are caught as v1-syntax errors at the bracket layer.
+        for p in &["$[*]", "$[?(@.x)]"] {
+            let err = CompiledPath::compile(p).expect_err(p);
+            assert!(
+                format!("{err}").contains("not allowed")
+                    || format!("{err}").contains("single-node"),
+                "{p} → {err}"
+            );
+        }
+    }
+
+    // ── resolve_segments_mut branches ──────────────────────────────────────────
+
+    #[test]
+    fn resolve_segments_mut_returns_object_container() {
+        let p = CompiledPath::compile("$.user").unwrap();
+        let mut rec = json!({"user": {"name": "A"}});
+        let map = CompiledPath::resolve_segments_mut(&mut rec, p.segments())
+            .unwrap()
+            .expect("user is an object container");
+        map.insert("added".into(), json!(1));
+        assert_eq!(rec, json!({"user": {"name": "A", "added": 1}}));
+    }
+
+    #[test]
+    fn resolve_segments_mut_missing_intermediate_is_none() {
+        let p = CompiledPath::compile("$.user.profile").unwrap();
+        let mut rec = json!({"other": 1});
+        let result = CompiledPath::resolve_segments_mut(&mut rec, p.segments()).unwrap();
+        assert!(result.is_none(), "missing intermediate key → None");
+    }
+
+    #[test]
+    fn resolve_segments_mut_through_non_object_is_none() {
+        // Walking into a scalar mid-path yields None.
+        let p = CompiledPath::compile("$.user.profile").unwrap();
+        let mut rec = json!({"user": 5});
+        let result = CompiledPath::resolve_segments_mut(&mut rec, p.segments()).unwrap();
+        assert!(result.is_none(), "non-object intermediate → None");
+    }
+
+    #[test]
+    fn resolve_segments_mut_leaf_non_object_is_none() {
+        // The final value exists but isn't an object container.
+        let p = CompiledPath::compile("$.name").unwrap();
+        let mut rec = json!({"name": "scalar"});
+        let result = CompiledPath::resolve_segments_mut(&mut rec, p.segments()).unwrap();
+        assert!(result.is_none(), "scalar leaf is not an object container");
+    }
 }

--- a/crates/core/src/state.rs
+++ b/crates/core/src/state.rs
@@ -677,6 +677,46 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn file_store_root_returns_configured_directory() {
+        let dir = TempDir::new().unwrap();
+        let s = FileStateStore::new(dir.path());
+        assert_eq!(s.root(), dir.path());
+    }
+
+    #[tokio::test]
+    async fn default_check_reports_not_implemented() {
+        // A StateStore that does not override `check()` falls back to the
+        // trait default, which yields a single not-implemented (skipped) probe.
+        struct BareStore;
+        #[async_trait]
+        impl StateStore for BareStore {
+            async fn get(&self, _key: &str) -> Result<Option<Value>, FaucetError> {
+                Ok(None)
+            }
+            async fn put(&self, _key: &str, _value: &Value) -> Result<(), FaucetError> {
+                Ok(())
+            }
+            async fn delete(&self, _key: &str) -> Result<(), FaucetError> {
+                Ok(())
+            }
+        }
+        let s = BareStore;
+        let report = s
+            .check(&crate::check::CheckContext::default())
+            .await
+            .unwrap();
+        // not_implemented() reports no failures and is not a pass.
+        assert_eq!(report.failed_count(), 0);
+        assert!(
+            report
+                .probes
+                .iter()
+                .any(|p| matches!(p.status, crate::check::ProbeStatus::Skip { .. })),
+            "default check must surface a skipped (not-implemented) probe"
+        );
+    }
+
+    #[tokio::test]
     async fn file_check_fails_when_root_unusable() {
         // Root whose parent is a regular file → create_dir_all fails.
         let dir = TempDir::new().unwrap();

--- a/crates/core/src/transform.rs
+++ b/crates/core/src/transform.rs
@@ -2211,4 +2211,729 @@ mod tests {
         assert!(key.contains("café"), "key was {key:?}");
         assert!(key.contains("percent"), "key was {key:?}");
     }
+
+    // ── Debug formatting for every RecordTransform variant ─────────────────────
+
+    #[test]
+    fn debug_record_transform_all_variants() {
+        // Custom is always available.
+        let dbg = format!("{:?}", RecordTransform::custom(|v| v));
+        assert_eq!(dbg, "Custom(<fn>)");
+
+        #[cfg(feature = "transform-flatten")]
+        {
+            let dbg = format!(
+                "{:?}",
+                RecordTransform::Flatten {
+                    separator: "__".into()
+                }
+            );
+            assert!(dbg.starts_with("Flatten"), "{dbg}");
+            assert!(dbg.contains("separator"), "{dbg}");
+            assert!(dbg.contains("__"), "{dbg}");
+        }
+        #[cfg(feature = "transform-rename-keys")]
+        {
+            let dbg = format!(
+                "{:?}",
+                RecordTransform::RenameKeys {
+                    pattern: "p".into(),
+                    replacement: "r".into(),
+                }
+            );
+            assert!(dbg.starts_with("RenameKeys"), "{dbg}");
+            assert!(dbg.contains("pattern"), "{dbg}");
+            assert!(dbg.contains("replacement"), "{dbg}");
+        }
+        #[cfg(feature = "transform-keys-case")]
+        {
+            let dbg = format!(
+                "{:?}",
+                RecordTransform::KeysCase {
+                    mode: KeyCaseMode::Snake
+                }
+            );
+            assert!(dbg.starts_with("KeysCase"), "{dbg}");
+            assert!(dbg.contains("Snake"), "{dbg}");
+        }
+        #[cfg(feature = "transform-select")]
+        {
+            let dbg = format!(
+                "{:?}",
+                RecordTransform::Select {
+                    fields: vec!["a".into()]
+                }
+            );
+            assert!(dbg.starts_with("Select"), "{dbg}");
+            assert!(dbg.contains("fields"), "{dbg}");
+        }
+        #[cfg(feature = "transform-drop")]
+        {
+            let dbg = format!(
+                "{:?}",
+                RecordTransform::Drop {
+                    fields: vec!["a".into()]
+                }
+            );
+            assert!(dbg.starts_with("Drop"), "{dbg}");
+        }
+        #[cfg(feature = "transform-set")]
+        {
+            let mut values = Map::new();
+            values.insert("k".into(), json!("v"));
+            let dbg = format!("{:?}", RecordTransform::Set { values });
+            assert!(dbg.starts_with("Set"), "{dbg}");
+            assert!(dbg.contains("values"), "{dbg}");
+        }
+        #[cfg(feature = "transform-rename-field")]
+        {
+            let mut fields = HashMap::new();
+            fields.insert("a".to_owned(), "b".to_owned());
+            let dbg = format!("{:?}", RecordTransform::RenameField { fields });
+            assert!(dbg.starts_with("RenameField"), "{dbg}");
+        }
+        #[cfg(feature = "transform-cast")]
+        {
+            let mut fields = HashMap::new();
+            fields.insert("a".to_owned(), CastType::Int);
+            let dbg = format!(
+                "{:?}",
+                RecordTransform::Cast {
+                    fields,
+                    on_error: CastOnError::Error,
+                }
+            );
+            assert!(dbg.starts_with("Cast"), "{dbg}");
+            assert!(dbg.contains("on_error"), "{dbg}");
+        }
+        #[cfg(feature = "transform-redact")]
+        {
+            let dbg = format!(
+                "{:?}",
+                RecordTransform::Redact {
+                    fields: vec!["a".into()],
+                    mask: json!("***"),
+                }
+            );
+            assert!(dbg.starts_with("Redact"), "{dbg}");
+            assert!(dbg.contains("mask"), "{dbg}");
+        }
+        #[cfg(feature = "transform-value-case")]
+        {
+            let dbg = format!(
+                "{:?}",
+                RecordTransform::ValueCase {
+                    fields: vec!["a".into()],
+                    mode: ValueCaseMode::Lower,
+                }
+            );
+            assert!(dbg.starts_with("ValueCase"), "{dbg}");
+            assert!(dbg.contains("mode"), "{dbg}");
+        }
+        #[cfg(feature = "transform-spell-symbols")]
+        {
+            let dbg = format!(
+                "{:?}",
+                RecordTransform::SpellSymbols {
+                    extra: HashMap::new(),
+                    separator: " ".into(),
+                }
+            );
+            assert!(dbg.starts_with("SpellSymbols"), "{dbg}");
+            assert!(dbg.contains("separator"), "{dbg}");
+        }
+    }
+
+    // ── Clone for every RecordTransform variant (refcount bump on Custom) ──────
+
+    #[test]
+    fn clone_record_transform_custom_preserves_behaviour() {
+        let original = RecordTransform::custom(|mut v| {
+            if let Value::Object(ref mut m) = v {
+                m.insert("cloned".into(), json!(true));
+            }
+            v
+        });
+        let cloned = original.clone();
+        assert_eq!(format!("{cloned:?}"), "Custom(<fn>)");
+        let out = apply_all(json!({"id": 1}), &compiled(&[cloned]));
+        assert_eq!(out["cloned"], true);
+        assert_eq!(out["id"], 1);
+    }
+
+    #[test]
+    // Every push below is #[cfg(feature)]-gated, so a vec![] literal can't
+    // express this; suppress the vec-init-then-push lint for the whole test.
+    #[allow(clippy::vec_init_then_push)]
+    fn clone_record_transform_all_builtin_variants() {
+        let mut variants: Vec<RecordTransform> = Vec::new();
+        #[cfg(feature = "transform-flatten")]
+        variants.push(RecordTransform::Flatten {
+            separator: "__".into(),
+        });
+        #[cfg(feature = "transform-rename-keys")]
+        variants.push(RecordTransform::RenameKeys {
+            pattern: "p".into(),
+            replacement: "r".into(),
+        });
+        #[cfg(feature = "transform-keys-case")]
+        variants.push(RecordTransform::KeysCase {
+            mode: KeyCaseMode::Snake,
+        });
+        #[cfg(feature = "transform-select")]
+        variants.push(RecordTransform::Select {
+            fields: vec!["a".into()],
+        });
+        #[cfg(feature = "transform-drop")]
+        variants.push(RecordTransform::Drop {
+            fields: vec!["a".into()],
+        });
+        #[cfg(feature = "transform-set")]
+        {
+            let mut values = Map::new();
+            values.insert("k".into(), json!("v"));
+            variants.push(RecordTransform::Set { values });
+        }
+        #[cfg(feature = "transform-rename-field")]
+        {
+            let mut fields = HashMap::new();
+            fields.insert("a".to_owned(), "b".to_owned());
+            variants.push(RecordTransform::RenameField { fields });
+        }
+        #[cfg(feature = "transform-cast")]
+        {
+            let mut fields = HashMap::new();
+            fields.insert("a".to_owned(), CastType::Int);
+            variants.push(RecordTransform::Cast {
+                fields,
+                on_error: CastOnError::Error,
+            });
+        }
+        #[cfg(feature = "transform-redact")]
+        variants.push(RecordTransform::Redact {
+            fields: vec!["a".into()],
+            mask: json!("***"),
+        });
+        #[cfg(feature = "transform-value-case")]
+        variants.push(RecordTransform::ValueCase {
+            fields: vec!["a".into()],
+            mode: ValueCaseMode::Lower,
+        });
+        #[cfg(feature = "transform-spell-symbols")]
+        variants.push(RecordTransform::SpellSymbols {
+            extra: HashMap::new(),
+            separator: " ".into(),
+        });
+
+        // The clone's Debug must match the original's Debug exactly.
+        for v in &variants {
+            let cloned = v.clone();
+            assert_eq!(format!("{v:?}"), format!("{cloned:?}"));
+        }
+    }
+
+    #[test]
+    fn clone_compiled_transform_all_variants() {
+        let mut specs: Vec<RecordTransform> = vec![RecordTransform::custom(|v| v)];
+        #[cfg(feature = "transform-flatten")]
+        specs.push(RecordTransform::Flatten {
+            separator: "__".into(),
+        });
+        #[cfg(feature = "transform-rename-keys")]
+        specs.push(RecordTransform::RenameKeys {
+            pattern: "p".into(),
+            replacement: "r".into(),
+        });
+        #[cfg(feature = "transform-keys-case")]
+        specs.push(RecordTransform::KeysCase {
+            mode: KeyCaseMode::Camel,
+        });
+        #[cfg(feature = "transform-select")]
+        specs.push(RecordTransform::Select {
+            fields: vec!["a".into()],
+        });
+        #[cfg(feature = "transform-drop")]
+        specs.push(RecordTransform::Drop {
+            fields: vec!["a".into()],
+        });
+        #[cfg(feature = "transform-set")]
+        {
+            let mut values = Map::new();
+            values.insert("k".into(), json!("v"));
+            specs.push(RecordTransform::Set { values });
+        }
+        #[cfg(feature = "transform-rename-field")]
+        {
+            let mut fields = HashMap::new();
+            fields.insert("a".to_owned(), "b".to_owned());
+            specs.push(RecordTransform::RenameField { fields });
+        }
+        #[cfg(feature = "transform-cast")]
+        {
+            let mut fields = HashMap::new();
+            fields.insert("a".to_owned(), CastType::Int);
+            specs.push(RecordTransform::Cast {
+                fields,
+                on_error: CastOnError::Null,
+            });
+        }
+        #[cfg(feature = "transform-redact")]
+        specs.push(RecordTransform::Redact {
+            fields: vec!["a".into()],
+            mask: json!("***"),
+        });
+        #[cfg(feature = "transform-value-case")]
+        specs.push(RecordTransform::ValueCase {
+            fields: vec!["a".into()],
+            mode: ValueCaseMode::Upper,
+        });
+        #[cfg(feature = "transform-spell-symbols")]
+        specs.push(RecordTransform::SpellSymbols {
+            extra: HashMap::new(),
+            separator: " ".into(),
+        });
+
+        // Compile each, clone the compiled form, and confirm the cloned slice
+        // still transforms a record identically to the original slice.
+        let original = compiled(&specs);
+        let cloned: Vec<CompiledTransform> = original.to_vec();
+        assert_eq!(original.len(), cloned.len());
+        let record = json!({"a": "1", "k": "x"});
+        let out_orig = super::apply_all(record.clone(), &original);
+        let out_clone = super::apply_all(record, &cloned);
+        assert_eq!(
+            out_orig.is_ok(),
+            out_clone.is_ok(),
+            "clone must transform identically"
+        );
+        if let (Ok(a), Ok(b)) = (out_orig, out_clone) {
+            assert_eq!(a, b);
+        }
+    }
+
+    // ── Non-object records pass through every object-only transform ────────────
+
+    #[cfg(feature = "transform-flatten")]
+    #[test]
+    fn flatten_passes_through_non_object() {
+        let record = json!([1, 2, 3]);
+        let result = apply_all(
+            record.clone(),
+            &compiled(&[RecordTransform::Flatten {
+                separator: "__".into(),
+            }]),
+        );
+        assert_eq!(result, record);
+        // A bare scalar too.
+        let scalar = json!(42);
+        let result = apply_all(
+            scalar.clone(),
+            &compiled(&[RecordTransform::Flatten {
+                separator: "__".into(),
+            }]),
+        );
+        assert_eq!(result, scalar);
+    }
+
+    #[cfg(feature = "transform-drop")]
+    #[test]
+    fn drop_passes_through_non_object() {
+        let record = json!([1, 2]);
+        let result = apply_all(
+            record.clone(),
+            &compiled(&[RecordTransform::Drop {
+                fields: vec!["a".into()],
+            }]),
+        );
+        assert_eq!(result, record);
+    }
+
+    #[cfg(feature = "transform-set")]
+    #[test]
+    fn set_passes_through_non_object() {
+        let mut values = Map::new();
+        values.insert("k".into(), json!("v"));
+        let record = json!("scalar");
+        let result = apply_all(
+            record.clone(),
+            &compiled(&[RecordTransform::Set { values }]),
+        );
+        assert_eq!(result, record);
+    }
+
+    #[cfg(feature = "transform-rename-field")]
+    #[test]
+    fn rename_field_passes_through_non_object() {
+        let mut fields = HashMap::new();
+        fields.insert("a".to_owned(), "b".to_owned());
+        let record = json!([1, 2]);
+        let result = apply_all(
+            record.clone(),
+            &compiled(&[RecordTransform::RenameField { fields }]),
+        );
+        assert_eq!(result, record);
+    }
+
+    #[cfg(feature = "transform-rename-field")]
+    #[test]
+    fn rename_field_same_name_is_skipped() {
+        // from == to short-circuits (continue) and leaves the field intact.
+        let mut fields = HashMap::new();
+        fields.insert("a".to_owned(), "a".to_owned());
+        let record = json!({"a": 1});
+        let result = apply_all(
+            record,
+            &compiled(&[RecordTransform::RenameField { fields }]),
+        );
+        assert_eq!(result["a"], 1);
+    }
+
+    #[cfg(feature = "transform-cast")]
+    #[test]
+    fn cast_passes_through_non_object() {
+        let record = json!([1, 2]);
+        let result = apply_all(
+            record.clone(),
+            &compiled(&cast_specs("a", CastType::Int, CastOnError::Error)),
+        );
+        assert_eq!(result, record);
+    }
+
+    #[cfg(feature = "transform-redact")]
+    #[test]
+    fn redact_passes_through_non_object() {
+        let record = json!("scalar");
+        let result = apply_all(
+            record.clone(),
+            &compiled(&[RecordTransform::Redact {
+                fields: vec!["a".into()],
+                mask: json!("***"),
+            }]),
+        );
+        assert_eq!(result, record);
+    }
+
+    #[cfg(feature = "transform-value-case")]
+    #[test]
+    fn value_case_passes_through_non_object() {
+        let record = json!([1, 2]);
+        let result = apply_all(
+            record.clone(),
+            &compiled(&[RecordTransform::ValueCase {
+                fields: vec!["a".into()],
+                mode: ValueCaseMode::Lower,
+            }]),
+        );
+        assert_eq!(result, record);
+    }
+
+    // ── Cast: exhaustive per-type / per-source-value matrix ────────────────────
+
+    #[cfg(feature = "transform-cast")]
+    #[test]
+    fn cast_integer_number_to_int_is_identity() {
+        // Number that is already an i64 takes the `as_i64()` Some branch.
+        let record = json!({"n": 7});
+        let result = apply_all(
+            record,
+            &compiled(&cast_specs("n", CastType::Int, CastOnError::Error)),
+        );
+        assert_eq!(result["n"], 7);
+    }
+
+    #[cfg(feature = "transform-cast")]
+    #[test]
+    fn cast_bool_to_int() {
+        let record = json!({"t": true, "f": false});
+        let mut fields = HashMap::new();
+        fields.insert("t".to_owned(), CastType::Int);
+        fields.insert("f".to_owned(), CastType::Int);
+        let result = apply_all(
+            record,
+            &compiled(&[RecordTransform::Cast {
+                fields,
+                on_error: CastOnError::Error,
+            }]),
+        );
+        assert_eq!(result["t"], 1);
+        assert_eq!(result["f"], 0);
+    }
+
+    #[cfg(feature = "transform-cast")]
+    #[test]
+    fn cast_null_to_int_errors() {
+        let record = json!({"n": null});
+        let err = super::apply_all(
+            record,
+            &compiled(&cast_specs("n", CastType::Int, CastOnError::Error)),
+        )
+        .expect_err("null cannot become int");
+        assert!(
+            format!("{err}").contains("null cannot be cast to int"),
+            "{err}"
+        );
+    }
+
+    #[cfg(feature = "transform-cast")]
+    #[test]
+    fn cast_composite_to_int_errors() {
+        let record = json!({"n": [1, 2]});
+        let err = super::apply_all(
+            record,
+            &compiled(&cast_specs("n", CastType::Int, CastOnError::Error)),
+        )
+        .expect_err("array cannot become int");
+        assert!(format!("{err}").contains("composite"), "{err}");
+    }
+
+    #[cfg(feature = "transform-cast")]
+    #[test]
+    fn cast_number_to_float() {
+        let record = json!({"n": 5});
+        let result = apply_all(
+            record,
+            &compiled(&cast_specs("n", CastType::Float, CastOnError::Error)),
+        );
+        assert_eq!(result["n"], 5.0);
+    }
+
+    #[cfg(feature = "transform-cast")]
+    #[test]
+    fn cast_bool_to_float() {
+        let record = json!({"t": true, "f": false});
+        let mut fields = HashMap::new();
+        fields.insert("t".to_owned(), CastType::Float);
+        fields.insert("f".to_owned(), CastType::Float);
+        let result = apply_all(
+            record,
+            &compiled(&[RecordTransform::Cast {
+                fields,
+                on_error: CastOnError::Error,
+            }]),
+        );
+        assert_eq!(result["t"], 1.0);
+        assert_eq!(result["f"], 0.0);
+    }
+
+    #[cfg(feature = "transform-cast")]
+    #[test]
+    fn cast_null_to_float_errors() {
+        let record = json!({"n": null});
+        let err = super::apply_all(
+            record,
+            &compiled(&cast_specs("n", CastType::Float, CastOnError::Error)),
+        )
+        .expect_err("null cannot become float");
+        assert!(
+            format!("{err}").contains("null cannot be cast to float"),
+            "{err}"
+        );
+    }
+
+    #[cfg(feature = "transform-cast")]
+    #[test]
+    fn cast_composite_to_float_errors() {
+        let record = json!({"n": {"x": 1}});
+        let err = super::apply_all(
+            record,
+            &compiled(&cast_specs("n", CastType::Float, CastOnError::Error)),
+        )
+        .expect_err("object cannot become float");
+        assert!(format!("{err}").contains("composite"), "{err}");
+    }
+
+    #[cfg(feature = "transform-cast")]
+    #[test]
+    fn cast_string_to_float_invalid_errors() {
+        let record = json!({"n": "not a float"});
+        let err = super::apply_all(
+            record,
+            &compiled(&cast_specs("n", CastType::Float, CastOnError::Error)),
+        )
+        .expect_err("non-numeric string cannot become float");
+        assert!(format!("{err}").contains("is not a float"), "{err}");
+    }
+
+    #[cfg(feature = "transform-cast")]
+    #[test]
+    fn cast_bool_to_bool_is_identity() {
+        let record = json!({"b": true});
+        let result = apply_all(
+            record,
+            &compiled(&cast_specs("b", CastType::Bool, CastOnError::Error)),
+        );
+        assert_eq!(result["b"], true);
+    }
+
+    #[cfg(feature = "transform-cast")]
+    #[test]
+    fn cast_number_to_bool() {
+        let record = json!({"on": 1, "off": 0});
+        let mut fields = HashMap::new();
+        fields.insert("on".to_owned(), CastType::Bool);
+        fields.insert("off".to_owned(), CastType::Bool);
+        let result = apply_all(
+            record,
+            &compiled(&[RecordTransform::Cast {
+                fields,
+                on_error: CastOnError::Error,
+            }]),
+        );
+        assert_eq!(result["on"], true);
+        assert_eq!(result["off"], false);
+    }
+
+    #[cfg(feature = "transform-cast")]
+    #[test]
+    fn cast_integer_other_than_zero_one_to_bool_errors() {
+        let record = json!({"n": 7});
+        let err = super::apply_all(
+            record,
+            &compiled(&cast_specs("n", CastType::Bool, CastOnError::Error)),
+        )
+        .expect_err("only 0/1 convert to bool");
+        assert!(format!("{err}").contains("not 0 or 1"), "{err}");
+    }
+
+    #[cfg(feature = "transform-cast")]
+    #[test]
+    fn cast_float_number_to_bool_errors() {
+        // A fractional number takes the non-i64 branch ("number ... is not 0 or 1").
+        let record = json!({"n": 1.5});
+        let err = super::apply_all(
+            record,
+            &compiled(&cast_specs("n", CastType::Bool, CastOnError::Error)),
+        )
+        .expect_err("fractional number cannot become bool");
+        assert!(format!("{err}").contains("not 0 or 1"), "{err}");
+    }
+
+    #[cfg(feature = "transform-cast")]
+    #[test]
+    fn cast_unrecognised_string_to_bool_errors() {
+        let record = json!({"flag": "maybe"});
+        let err = super::apply_all(
+            record,
+            &compiled(&cast_specs("flag", CastType::Bool, CastOnError::Error)),
+        )
+        .expect_err("'maybe' is not a boolean");
+        assert!(
+            format!("{err}").contains("not a recognised boolean"),
+            "{err}"
+        );
+    }
+
+    #[cfg(feature = "transform-cast")]
+    #[test]
+    fn cast_null_to_bool_errors() {
+        let record = json!({"b": null});
+        let err = super::apply_all(
+            record,
+            &compiled(&cast_specs("b", CastType::Bool, CastOnError::Error)),
+        )
+        .expect_err("null cannot become bool");
+        assert!(
+            format!("{err}").contains("null cannot be cast to bool"),
+            "{err}"
+        );
+    }
+
+    #[cfg(feature = "transform-cast")]
+    #[test]
+    fn cast_composite_to_bool_errors() {
+        let record = json!({"b": [true]});
+        let err = super::apply_all(
+            record,
+            &compiled(&cast_specs("b", CastType::Bool, CastOnError::Error)),
+        )
+        .expect_err("array cannot become bool");
+        assert!(format!("{err}").contains("composite"), "{err}");
+    }
+
+    #[cfg(feature = "transform-cast")]
+    #[test]
+    fn cast_string_to_string_is_identity() {
+        let record = json!({"s": "hello"});
+        let result = apply_all(
+            record,
+            &compiled(&cast_specs("s", CastType::String, CastOnError::Error)),
+        );
+        assert_eq!(result["s"], "hello");
+    }
+
+    #[cfg(feature = "transform-cast")]
+    #[test]
+    fn cast_bool_to_string() {
+        let record = json!({"b": true});
+        let result = apply_all(
+            record,
+            &compiled(&cast_specs("b", CastType::String, CastOnError::Error)),
+        );
+        assert_eq!(result["b"], "true");
+    }
+
+    #[cfg(feature = "transform-cast")]
+    #[test]
+    fn cast_null_to_string_errors() {
+        let record = json!({"s": null});
+        let err = super::apply_all(
+            record,
+            &compiled(&cast_specs("s", CastType::String, CastOnError::Error)),
+        )
+        .expect_err("null cannot become string");
+        assert!(
+            format!("{err}").contains("null cannot be cast to string"),
+            "{err}"
+        );
+    }
+
+    #[cfg(feature = "transform-cast")]
+    #[test]
+    fn cast_composite_to_string_errors() {
+        let record = json!({"s": {"a": 1}});
+        let err = super::apply_all(
+            record,
+            &compiled(&cast_specs("s", CastType::String, CastOnError::Error)),
+        )
+        .expect_err("object cannot become string");
+        assert!(format!("{err}").contains("composite"), "{err}");
+    }
+
+    #[cfg(feature = "transform-cast")]
+    #[test]
+    fn cast_invalid_timestamp_string_errors() {
+        let record = json!({"ts": "not a date"});
+        let err = super::apply_all(
+            record,
+            &compiled(&cast_specs("ts", CastType::Timestamp, CastOnError::Error)),
+        )
+        .expect_err("invalid timestamp string");
+        assert!(format!("{err}").contains("RFC 3339"), "{err}");
+    }
+
+    #[cfg(feature = "transform-cast")]
+    #[test]
+    fn cast_non_string_to_timestamp_names_the_type() {
+        // Each non-string source exercises a distinct arm of value_type_name.
+        for (val, ty_name) in [
+            (json!(null), "null"),
+            (json!(true), "bool"),
+            (json!(42), "number"),
+            (json!([1, 2]), "array"),
+            (json!({"a": 1}), "object"),
+        ] {
+            let record = json!({ "ts": val });
+            let err = super::apply_all(
+                record,
+                &compiled(&cast_specs("ts", CastType::Timestamp, CastOnError::Error)),
+            )
+            .expect_err("non-string cannot become timestamp");
+            let msg = format!("{err}");
+            assert!(msg.contains("timestamp"), "{msg}");
+            assert!(
+                msg.contains(ty_name),
+                "expected type name {ty_name:?} in: {msg}"
+            );
+        }
+    }
 }

--- a/crates/lineage/tests/emitter_events.rs
+++ b/crates/lineage/tests/emitter_events.rs
@@ -1,0 +1,481 @@
+//! Emitter behaviour tests — no live services.
+//!
+//! Builds `RunEvent`s via the public `LineageEmitter` API and asserts the
+//! emitted OpenLineage JSON for every lifecycle event (START/RUNNING/COMPLETE/
+//! ABORT/FAIL), the schema / column-lineage / source-code / parent facets, and
+//! that a failing transport is dropped (never propagated). The file transport
+//! is pointed at a tempfile; the HTTP transport is exercised with wiremock.
+
+use faucet_lineage::*;
+use std::path::PathBuf;
+use std::time::Duration;
+
+fn file_cfg(path: PathBuf) -> LineageConfig {
+    LineageConfig {
+        kind: Default::default(),
+        namespace: "ns".into(),
+        transport: Transport::File { path },
+        job_name: "j".into(),
+        parent_job: None,
+        include_column_lineage: false,
+        include_schema_facet: false,
+        include_source_code_facet: false,
+        emit_on: EmitOn::default(),
+        sample_records: 100,
+        heartbeat_interval: Duration::from_secs(30),
+    }
+}
+
+fn lifecycle() -> RunLifecycle {
+    RunLifecycle {
+        job_namespace: "ns".into(),
+        job_name: "j".into(),
+        run_id: "r1".into(),
+        parent: None,
+        input: DatasetRef {
+            namespace: "ns".into(),
+            name: "postgres://h/db".into(),
+        },
+        output: DatasetRef {
+            namespace: "ns".into(),
+            name: "bigquery://p.d.t".into(),
+        },
+        started_at: chrono::Utc::now(),
+        finished_at: None,
+        records: 0,
+        error: None,
+        input_schema: None,
+        output_schema: None,
+        column_lineage: None,
+        source_code: None,
+    }
+}
+
+/// Read every JSON line emitted to `path`.
+fn read_lines(path: &PathBuf) -> Vec<serde_json::Value> {
+    std::fs::read_to_string(path)
+        .unwrap()
+        .lines()
+        .map(|l| serde_json::from_str(l).unwrap())
+        .collect()
+}
+
+#[tokio::test]
+async fn complete_event_emits_terminal_event_type() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("ol.jsonl");
+    let em = LineageEmitter::new(file_cfg(path.clone())).unwrap();
+    let mut done = lifecycle();
+    done.finished_at = Some(chrono::Utc::now());
+    done.records = 42;
+    em.emit(EventType::Complete, &done).await;
+    let events = read_lines(&path);
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0]["eventType"], "COMPLETE");
+    assert_eq!(events[0]["job"]["name"], "j");
+    assert_eq!(events[0]["job"]["namespace"], "ns");
+    assert_eq!(events[0]["run"]["runId"], "r1");
+    assert_eq!(events[0]["outputs"][0]["name"], "bigquery://p.d.t");
+    // finished_at present → eventTime is the finish time, nominalEndTime set.
+    assert!(events[0]["run"]["facets"]["nominalTime"]["nominalEndTime"].is_string());
+}
+
+#[tokio::test]
+async fn abort_event_emits_abort_type() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("ol.jsonl");
+    let em = LineageEmitter::new(file_cfg(path.clone())).unwrap();
+    em.emit(EventType::Abort, &lifecycle()).await;
+    let events = read_lines(&path);
+    assert_eq!(events[0]["eventType"], "ABORT");
+}
+
+#[tokio::test]
+async fn fail_event_emits_fail_type() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("ol.jsonl");
+    let em = LineageEmitter::new(file_cfg(path.clone())).unwrap();
+    em.emit(EventType::Fail, &lifecycle()).await;
+    let events = read_lines(&path);
+    assert_eq!(events[0]["eventType"], "FAIL");
+}
+
+#[tokio::test]
+async fn running_event_emits_when_enabled() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("ol.jsonl");
+    let mut cfg = file_cfg(path.clone());
+    cfg.emit_on.running = true; // default is false
+    let em = LineageEmitter::new(cfg).unwrap();
+    em.emit(EventType::Running, &lifecycle()).await;
+    let events = read_lines(&path);
+    assert_eq!(events[0]["eventType"], "RUNNING");
+}
+
+#[tokio::test]
+async fn schema_facet_emitted_on_terminal_event_when_enabled() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("ol.jsonl");
+    let mut cfg = file_cfg(path.clone());
+    cfg.include_schema_facet = true;
+    let em = LineageEmitter::new(cfg).unwrap();
+    let mut done = lifecycle();
+    done.finished_at = Some(chrono::Utc::now());
+    done.input_schema = Some(InferredSchema {
+        fields: vec![
+            ("id".into(), "integer".into()),
+            ("name".into(), "string".into()),
+        ],
+    });
+    done.output_schema = Some(InferredSchema {
+        fields: vec![("id".into(), "integer".into())],
+    });
+    em.emit(EventType::Complete, &done).await;
+    let events = read_lines(&path);
+    let inp = &events[0]["inputs"][0]["facets"]["schema"]["fields"];
+    assert_eq!(inp[0]["name"], "id");
+    assert_eq!(inp[0]["type"], "integer");
+    assert_eq!(inp[1]["name"], "name");
+    assert_eq!(inp[1]["type"], "string");
+    let out = &events[0]["outputs"][0]["facets"]["schema"]["fields"];
+    assert_eq!(out[0]["name"], "id");
+}
+
+#[tokio::test]
+async fn schema_facet_suppressed_on_start_even_when_enabled() {
+    // Schema facets only attach on terminal events (Complete/Abort/Fail).
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("ol.jsonl");
+    let mut cfg = file_cfg(path.clone());
+    cfg.include_schema_facet = true;
+    let em = LineageEmitter::new(cfg).unwrap();
+    let mut start = lifecycle();
+    start.input_schema = Some(InferredSchema {
+        fields: vec![("id".into(), "integer".into())],
+    });
+    em.emit(EventType::Start, &start).await;
+    let events = read_lines(&path);
+    assert_eq!(events[0]["eventType"], "START");
+    // No facets object on the input dataset (empty facets are skipped).
+    assert!(events[0]["inputs"][0].get("facets").is_none());
+}
+
+#[tokio::test]
+async fn column_lineage_facet_emitted_for_supported_ops() {
+    // rename + select chain: a supported (non-opaque) op chain.
+    let inputs = vec!["id".to_string(), "email".to_string(), "name".to_string()];
+    let ops = [
+        ColumnOp::Rename(vec![("email".into(), "contact".into())]),
+        ColumnOp::Select(vec!["id".into(), "contact".into()]),
+    ];
+    let cl = derive_column_lineage(&inputs, &ops).expect("supported ops derive lineage");
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("ol.jsonl");
+    let mut cfg = file_cfg(path.clone());
+    cfg.include_column_lineage = true;
+    let em = LineageEmitter::new(cfg).unwrap();
+    let mut done = lifecycle();
+    done.finished_at = Some(chrono::Utc::now());
+    done.column_lineage = Some(cl);
+    em.emit(EventType::Complete, &done).await;
+
+    let events = read_lines(&path);
+    let fields = &events[0]["outputs"][0]["facets"]["columnLineage"]["fields"];
+    // `contact` derives from input field `email` in the input dataset.
+    // (`ColumnLineageFieldEntry` serializes `input_fields` as-is, not camelCase.)
+    assert_eq!(fields["contact"]["input_fields"][0]["field"], "email");
+    assert_eq!(
+        fields["contact"]["input_fields"][0]["name"],
+        "postgres://h/db"
+    );
+    assert_eq!(fields["contact"]["input_fields"][0]["namespace"], "ns");
+    // `id` survives select, maps to itself.
+    assert_eq!(fields["id"]["input_fields"][0]["field"], "id");
+    // `name` was dropped by select → not present.
+    assert!(fields.get("name").is_none());
+}
+
+#[tokio::test]
+async fn column_lineage_set_literal_has_no_input_edge() {
+    // A `set` field is a literal — no upstream edge, so it is omitted from the
+    // emitted facet (column_facet skips empty source lists).
+    let inputs = vec!["id".to_string()];
+    let ops = [ColumnOp::Set(vec!["created_at".into()])];
+    let cl = derive_column_lineage(&inputs, &ops).unwrap();
+    // The derived lineage records the literal field with an empty source list.
+    assert!(cl.edges.get("created_at").unwrap().is_empty());
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("ol.jsonl");
+    let mut cfg = file_cfg(path.clone());
+    cfg.include_column_lineage = true;
+    let em = LineageEmitter::new(cfg).unwrap();
+    let mut done = lifecycle();
+    done.finished_at = Some(chrono::Utc::now());
+    done.column_lineage = Some(cl);
+    em.emit(EventType::Complete, &done).await;
+
+    let events = read_lines(&path);
+    let fields = &events[0]["outputs"][0]["facets"]["columnLineage"]["fields"];
+    // The literal `created_at` has no upstream edge → suppressed in the facet.
+    assert!(fields.get("created_at").is_none());
+    // `id` (identity passthrough) is present.
+    assert_eq!(fields["id"]["input_fields"][0]["field"], "id");
+}
+
+#[tokio::test]
+async fn identity_ops_preserve_all_columns() {
+    // cast / redact / value_case / spell_symbols all map to ColumnOp::Identity.
+    let inputs = vec!["a".to_string(), "b".to_string()];
+    let cl = derive_column_lineage(
+        &inputs,
+        &[ColumnOp::Identity, ColumnOp::Identity, ColumnOp::Identity],
+    )
+    .unwrap();
+    assert_eq!(cl.edges.get("a").unwrap(), &vec!["a".to_string()]);
+    assert_eq!(cl.edges.get("b").unwrap(), &vec!["b".to_string()]);
+    assert_eq!(cl.edges.len(), 2);
+}
+
+#[tokio::test]
+async fn drop_op_removes_column_from_lineage() {
+    let inputs = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+    let cl = derive_column_lineage(&inputs, &[ColumnOp::Drop(vec!["b".into()])]).unwrap();
+    assert!(!cl.edges.contains_key("b"));
+    assert_eq!(cl.edges.len(), 2);
+}
+
+#[tokio::test]
+async fn opaque_op_suppresses_column_lineage_facet() {
+    // An opaque op (flatten/explode/keys_case/rename_keys/custom) → derive None.
+    let inputs = vec!["id".to_string()];
+    assert!(derive_column_lineage(&inputs, &[ColumnOp::Opaque]).is_none());
+    assert!(
+        derive_column_lineage(&inputs, &[ColumnOp::Rename(vec![]), ColumnOp::Opaque]).is_none()
+    );
+
+    // With include_column_lineage on but no column_lineage on the context (the
+    // CLI sets None when the chain is opaque), no columnLineage facet appears.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("ol.jsonl");
+    let mut cfg = file_cfg(path.clone());
+    cfg.include_column_lineage = true;
+    let em = LineageEmitter::new(cfg).unwrap();
+    let mut done = lifecycle();
+    done.finished_at = Some(chrono::Utc::now());
+    done.column_lineage = None; // opaque chain → no lineage
+    em.emit(EventType::Complete, &done).await;
+
+    let events = read_lines(&path);
+    // No facets object at all (schema disabled, column-lineage None → empty).
+    assert!(events[0]["outputs"][0].get("facets").is_none());
+}
+
+#[tokio::test]
+async fn source_code_facet_emitted_when_enabled() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("ol.jsonl");
+    let mut cfg = file_cfg(path.clone());
+    cfg.include_source_code_facet = true; // triggers the constructor warn branch
+    let em = LineageEmitter::new(cfg).unwrap();
+    let mut ctx = lifecycle();
+    ctx.source_code = Some("source: { type: rest }".into());
+    em.emit(EventType::Start, &ctx).await;
+    let events = read_lines(&path);
+    let sc = &events[0]["job"]["facets"]["sourceCode"];
+    assert_eq!(sc["language"], "yaml");
+    assert_eq!(sc["sourceCode"], "source: { type: rest }");
+}
+
+#[tokio::test]
+async fn parent_run_facet_built_from_parent_job() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("ol.jsonl");
+    let em = LineageEmitter::new(file_cfg(path.clone())).unwrap();
+    let mut ctx = lifecycle();
+    ctx.parent = Some(ParentJob {
+        namespace: "airflow".into(),
+        name: "dag.task".into(),
+        run_id: Some("parent-run-99".into()),
+    });
+    em.emit(EventType::Start, &ctx).await;
+    let events = read_lines(&path);
+    let parent = &events[0]["run"]["facets"]["parent"];
+    assert_eq!(parent["job"]["namespace"], "airflow");
+    assert_eq!(parent["job"]["name"], "dag.task");
+    assert_eq!(parent["run"]["runId"], "parent-run-99");
+}
+
+#[tokio::test]
+async fn parent_run_facet_falls_back_to_run_id_when_parent_run_id_absent() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("ol.jsonl");
+    let em = LineageEmitter::new(file_cfg(path.clone())).unwrap();
+    let mut ctx = lifecycle();
+    ctx.parent = Some(ParentJob {
+        namespace: "airflow".into(),
+        name: "dag.task".into(),
+        run_id: None, // → falls back to ctx.run_id ("r1")
+    });
+    em.emit(EventType::Start, &ctx).await;
+    let events = read_lines(&path);
+    assert_eq!(events[0]["run"]["facets"]["parent"]["run"]["runId"], "r1");
+}
+
+#[tokio::test]
+async fn disabled_event_is_dropped_not_emitted() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("ol.jsonl");
+    let mut cfg = file_cfg(path.clone());
+    cfg.emit_on.complete = false;
+    let em = LineageEmitter::new(cfg).unwrap();
+    em.emit(EventType::Complete, &lifecycle()).await;
+    // Disabled → nothing written, no panic.
+    assert!(!path.exists() || std::fs::read_to_string(&path).unwrap().is_empty());
+}
+
+// ---- HTTP transport (wiremock) ----
+
+#[tokio::test]
+async fn http_transport_posts_event_body() {
+    use wiremock::matchers::{header, method, path as wm_path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(wm_path("/api/v1/lineage"))
+        .and(header("content-type", "application/json"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let cfg = LineageConfig {
+        kind: Default::default(),
+        namespace: "ns".into(),
+        transport: Transport::Http {
+            url: format!("{}/api/v1/lineage", server.uri()),
+            timeout_secs: Duration::from_secs(5),
+            auth: None,
+        },
+        job_name: "j".into(),
+        parent_job: None,
+        include_column_lineage: false,
+        include_schema_facet: false,
+        include_source_code_facet: false,
+        emit_on: EmitOn::default(),
+        sample_records: 100,
+        heartbeat_interval: Duration::from_secs(30),
+    };
+    let em = LineageEmitter::new(cfg).unwrap();
+    em.emit(EventType::Start, &lifecycle()).await;
+
+    // Inspect the actually-received request body.
+    let received = server.received_requests().await.unwrap();
+    assert_eq!(received.len(), 1);
+    let body: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+    assert_eq!(body["eventType"], "START");
+    assert_eq!(body["job"]["name"], "j");
+    assert_eq!(body["inputs"][0]["name"], "postgres://h/db");
+}
+
+#[tokio::test]
+async fn http_transport_sends_bearer_auth_header() {
+    use wiremock::matchers::{header, method};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(header("authorization", "Bearer s3cr3t"))
+        .respond_with(ResponseTemplate::new(201))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let cfg = LineageConfig {
+        kind: Default::default(),
+        namespace: "ns".into(),
+        transport: Transport::Http {
+            url: server.uri(),
+            timeout_secs: Duration::from_secs(5),
+            auth: Some(HttpAuth::Bearer {
+                token: "s3cr3t".into(),
+            }),
+        },
+        job_name: "j".into(),
+        parent_job: None,
+        include_column_lineage: false,
+        include_schema_facet: false,
+        include_source_code_facet: false,
+        emit_on: EmitOn::default(),
+        sample_records: 100,
+        heartbeat_interval: Duration::from_secs(30),
+    };
+    let em = LineageEmitter::new(cfg).unwrap();
+    em.emit(EventType::Start, &lifecycle()).await;
+    // The .expect(1) on the mock asserts exactly one matching (authed) request
+    // on server drop.
+}
+
+#[tokio::test]
+async fn http_transport_error_is_dropped_not_propagated() {
+    // A 500 from the endpoint makes the transport return Err; the emitter must
+    // log + count it (faucet_lineage_dropped_total) and return without
+    // propagating — emit() has no Result and must not panic.
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(500))
+        .mount(&server)
+        .await;
+
+    let cfg = LineageConfig {
+        kind: Default::default(),
+        namespace: "ns".into(),
+        transport: Transport::Http {
+            url: server.uri(),
+            timeout_secs: Duration::from_secs(5),
+            auth: None,
+        },
+        job_name: "j".into(),
+        parent_job: None,
+        include_column_lineage: false,
+        include_schema_facet: false,
+        include_source_code_facet: false,
+        emit_on: EmitOn::default(),
+        sample_records: 100,
+        heartbeat_interval: Duration::from_secs(30),
+    };
+    let em = LineageEmitter::new(cfg).unwrap();
+    // Returns (), must not panic, despite the 500.
+    em.emit(EventType::Start, &lifecycle()).await;
+}
+
+#[tokio::test]
+async fn http_transport_connection_failure_is_dropped() {
+    // Point at an unroutable / closed address: the request fails at the network
+    // layer (reqwest error). The emitter must still swallow it.
+    let cfg = LineageConfig {
+        kind: Default::default(),
+        namespace: "ns".into(),
+        transport: Transport::Http {
+            // 127.0.0.1:1 — nothing listens; connection refused.
+            url: "http://127.0.0.1:1/api/v1/lineage".into(),
+            timeout_secs: Duration::from_secs(2),
+            auth: None,
+        },
+        job_name: "j".into(),
+        parent_job: None,
+        include_column_lineage: false,
+        include_schema_facet: false,
+        include_source_code_facet: false,
+        emit_on: EmitOn::default(),
+        sample_records: 100,
+        heartbeat_interval: Duration::from_secs(30),
+    };
+    let em = LineageEmitter::new(cfg).unwrap();
+    em.emit(EventType::Start, &lifecycle()).await; // must not panic
+}

--- a/crates/sink/bigquery/tests/write_batch_partial.rs
+++ b/crates/sink/bigquery/tests/write_batch_partial.rs
@@ -265,6 +265,218 @@ async fn write_batch_partial_sends_skip_invalid_rows_true() {
 }
 
 #[tokio::test]
+async fn insert_request_body_carries_rows_in_json_envelope() {
+    // Assert the exact `tabledata.insertAll` request body shape: a `rows`
+    // array where each entry wraps the record under `json`.
+    let server = MockServer::start().await;
+    mount_token_endpoint(&server).await;
+    Mock::given(method("POST"))
+        .and(path(insert_path()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .mount(&server)
+        .await;
+
+    let (sink, _sa_file) = build_sink(&server, 0).await;
+    let records = vec![json!({"a": 1, "b": "x"}), json!({"a": 2, "b": "y"})];
+    let written = sink.write_batch(&records).await.expect("write_batch");
+    assert_eq!(written, 2);
+
+    let bodies = captured_insert_bodies(&server).await;
+    assert_eq!(bodies.len(), 1);
+    let rows = bodies[0]["rows"].as_array().expect("rows array");
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0]["json"], json!({"a": 1, "b": "x"}));
+    assert_eq!(rows[1]["json"], json!({"a": 2, "b": "y"}));
+    // No insert_id_field configured → no insertId on any row.
+    assert!(rows[0].get("insertId").is_none());
+    assert!(rows[1].get("insertId").is_none());
+}
+
+#[tokio::test]
+async fn insert_id_field_populates_per_row_insert_id() {
+    // With `insert_id_field` set, each row's `insertId` is the field's value.
+    // A row missing the field is sent without an insertId.
+    let server = MockServer::start().await;
+    mount_token_endpoint(&server).await;
+    Mock::given(method("POST"))
+        .and(path(insert_path()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .mount(&server)
+        .await;
+
+    let sa_json = dummy_service_account_json(&server.uri());
+    let sa_file = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(
+        sa_file.path(),
+        serde_json::to_string_pretty(&sa_json).unwrap(),
+    )
+    .unwrap();
+    let client = ClientBuilder::new()
+        .with_auth_base_url(format!("{}{AUTH_SCOPE_BASE}", server.uri()))
+        .with_v2_base_url(server.uri())
+        .build_from_service_account_key_file(sa_file.path().to_str().unwrap())
+        .await
+        .unwrap();
+    let config = BigQuerySinkConfig::new(
+        PROJECT_ID,
+        DATASET_ID,
+        TABLE_ID,
+        BigQueryCredentials::ApplicationDefault,
+    )
+    .with_batch_size(0)
+    .with_insert_id_field("event_id");
+    let sink = BigQuerySink::from_parts(config, client);
+
+    // First row has a string event_id, second a numeric one (stringified),
+    // third lacks the field entirely.
+    let records = vec![
+        json!({"event_id": "evt-1", "v": 1}),
+        json!({"event_id": 99, "v": 2}),
+        json!({"v": 3}),
+    ];
+    let written = sink.write_batch(&records).await.expect("write_batch");
+    assert_eq!(written, 3);
+
+    let bodies = captured_insert_bodies(&server).await;
+    assert_eq!(bodies.len(), 1);
+    let rows = bodies[0]["rows"].as_array().unwrap();
+    assert_eq!(rows.len(), 3);
+    assert_eq!(rows[0]["insertId"], "evt-1");
+    // A non-string field value is stringified.
+    assert_eq!(rows[1]["insertId"], "99");
+    // Missing field → no insertId for that row.
+    assert!(rows[2].get("insertId").is_none(), "row 2: {:?}", rows[2]);
+}
+
+#[tokio::test]
+async fn write_batch_collapses_insert_errors_into_single_err() {
+    // The all-or-nothing `write_batch` path turns any `insertErrors` in the
+    // 200 body into a single FaucetError::Sink (aborting before the bookmark
+    // advances), naming the failing-row count and the first message.
+    let server = MockServer::start().await;
+    mount_token_endpoint(&server).await;
+    Mock::given(method("POST"))
+        .and(path(insert_path()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "insertErrors": [
+                { "index": 0, "errors": [{ "reason": "invalid", "message": "missing required field foo" }] },
+                { "index": 2, "errors": [{ "reason": "invalid", "message": "bad value" }] }
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let (sink, _sa_file) = build_sink(&server, 0).await;
+    let records: Vec<_> = (0..3).map(|i| json!({"i": i})).collect();
+    match sink.write_batch(&records).await {
+        Err(faucet_core::FaucetError::Sink(m)) => {
+            assert!(m.contains("2 row(s) failed"), "got: {m}");
+            assert!(m.contains("missing required field foo"), "got: {m}");
+        }
+        other => panic!("expected Sink error, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn write_batch_http_failure_bubbles_outer_err() {
+    let server = MockServer::start().await;
+    mount_token_endpoint(&server).await;
+    Mock::given(method("POST"))
+        .and(path(insert_path()))
+        .respond_with(ResponseTemplate::new(503).set_body_string("unavailable"))
+        .mount(&server)
+        .await;
+
+    let (sink, _sa_file) = build_sink(&server, 0).await;
+    match sink.write_batch(&[json!({"a": 1})]).await {
+        Err(faucet_core::FaucetError::Sink(m)) => {
+            assert!(m.contains("insertAll failed"), "got: {m}");
+        }
+        other => panic!("expected Sink error, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn connector_name_schema_and_dataset_uri_are_exposed() {
+    let server = MockServer::start().await;
+    mount_token_endpoint(&server).await;
+    let (sink, _sa_file) = build_sink(&server, 0).await;
+
+    assert_eq!(sink.connector_name(), "bigquery");
+    assert_eq!(
+        sink.dataset_uri(),
+        format!("bigquery://{PROJECT_ID}.{DATASET_ID}.{TABLE_ID}")
+    );
+    let schema = sink.config_schema();
+    assert!(
+        schema.get("properties").is_some() || schema.get("$ref").is_some(),
+        "config_schema should be a JSON Schema object: {schema}"
+    );
+}
+
+fn tables_get_path() -> String {
+    format!("/projects/{PROJECT_ID}/datasets/{DATASET_ID}/tables/{TABLE_ID}")
+}
+
+#[tokio::test]
+async fn check_probe_passes_on_successful_tables_get() {
+    use faucet_core::check::{CheckContext, ProbeStatus};
+    let server = MockServer::start().await;
+    mount_token_endpoint(&server).await;
+    // The doctor probe runs a read-only tables.get for table metadata.
+    Mock::given(method("GET"))
+        .and(path(tables_get_path()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "schema": {},
+            "tableReference": {
+                "projectId": PROJECT_ID,
+                "datasetId": DATASET_ID,
+                "tableId": TABLE_ID
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let (sink, _sa_file) = build_sink(&server, 0).await;
+    let report = sink.check(&CheckContext::default()).await.unwrap();
+    assert_eq!(report.probes.len(), 1);
+    assert_eq!(report.probes[0].name, "auth");
+    assert!(
+        matches!(report.probes[0].status, ProbeStatus::Pass),
+        "expected Pass, got: {:?}",
+        report.probes[0].status
+    );
+}
+
+#[tokio::test]
+async fn check_probe_fails_on_tables_get_error() {
+    use faucet_core::check::{CheckContext, ProbeStatus};
+    let server = MockServer::start().await;
+    mount_token_endpoint(&server).await;
+    Mock::given(method("GET"))
+        .and(path(tables_get_path()))
+        .respond_with(ResponseTemplate::new(404).set_body_json(json!({
+            "error": {"code": 404, "message": "Not found: Table"}
+        })))
+        .mount(&server)
+        .await;
+
+    let (sink, _sa_file) = build_sink(&server, 0).await;
+    let report = sink.check(&CheckContext::default()).await.unwrap();
+    assert_eq!(report.probes.len(), 1);
+    match &report.probes[0].status {
+        ProbeStatus::Fail { reason } => {
+            assert!(reason.contains("tables.get"), "got: {reason}");
+        }
+        other => panic!("expected Fail, got: {other:?}"),
+    }
+    assert!(
+        report.probes[0].hint.is_some(),
+        "a failing probe must carry a remediation hint"
+    );
+}
+
+#[tokio::test]
 async fn write_batch_keeps_all_or_nothing_skip_invalid_rows_false() {
     // The non-DLQ `write_batch` path stays all-or-nothing: skipInvalidRows=false
     // so a single bad row fails the whole request (no partial commit to resume

--- a/crates/sink/http/tests/coverage.rs
+++ b/crates/sink/http/tests/coverage.rs
@@ -1,0 +1,342 @@
+//! Additional coverage tests for `HttpSink` driven against a wiremock POST
+//! endpoint (no live services).
+//!
+//! These exercise paths the existing `batch_size.rs` / `partial_failures.rs` /
+//! `shared_auth_test.rs` suites leave uncovered:
+//!   * `Custom` header auth applied to outbound requests, and the invalid
+//!     header-name error path;
+//!   * `Basic` auth over the wire;
+//!   * the retry loop on a retriable 5xx (retry-then-succeed) and retry
+//!     exhaustion (final error returned), plus the no-retry non-2xx path;
+//!   * the `credential_to_auth` mapping for every shared-provider `Credential`
+//!     variant (Token / Basic / Header);
+//!   * `config_schema` introspection.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use faucet_core::{AuthProvider, Credential, FaucetError, Sink};
+use faucet_sink_http::{HttpBatchMode, HttpSink, HttpSinkAuth, HttpSinkConfig};
+use serde_json::json;
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, Request, ResponseTemplate};
+
+fn url(server: &MockServer) -> String {
+    format!("{}/ingest", server.uri())
+}
+
+// ─── Custom header auth ──────────────────────────────────────────────────────
+
+/// `Custom` header auth applies each configured header to every request.
+#[tokio::test]
+async fn custom_header_auth_is_applied() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/ingest"))
+        .and(header("x-api-key", "secret-key"))
+        .and(header("x-tenant", "acme"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+
+    let mut headers = HashMap::new();
+    headers.insert("X-API-Key".to_string(), "secret-key".to_string());
+    headers.insert("X-Tenant".to_string(), "acme".to_string());
+
+    let config = HttpSinkConfig::new(url(&server)).auth(HttpSinkAuth::Custom { headers });
+    let sink = HttpSink::new(config);
+
+    let written = sink
+        .write_batch(&[json!({ "id": 1 })])
+        .await
+        .expect("custom-header write must succeed");
+    assert_eq!(written, 1);
+
+    let requests = server.received_requests().await.unwrap();
+    assert_eq!(
+        requests.len(),
+        1,
+        "request matched only with both custom headers"
+    );
+}
+
+/// A `Custom` header with an invalid header *name* surfaces as
+/// `FaucetError::Auth` rather than silently sending an unauthenticated request.
+#[tokio::test]
+async fn custom_header_auth_invalid_name_errors() {
+    let server = MockServer::start().await;
+    // No mock mounted — the request must never be sent.
+
+    let mut headers = HashMap::new();
+    headers.insert("Bad Header".to_string(), "value".to_string());
+
+    let config = HttpSinkConfig::new(url(&server)).auth(HttpSinkAuth::Custom { headers });
+    let sink = HttpSink::new(config);
+
+    let err = sink
+        .write_batch(&[json!({ "id": 1 })])
+        .await
+        .expect_err("invalid header name must error");
+    assert!(matches!(err, FaucetError::Auth(_)), "got {err:?}");
+
+    let requests = server.received_requests().await.unwrap();
+    assert!(
+        requests.is_empty(),
+        "no request leaks on invalid header name"
+    );
+}
+
+// ─── Basic auth over the wire ────────────────────────────────────────────────
+
+/// `Basic` auth sends a base64-encoded `Authorization: Basic` header.
+#[tokio::test]
+async fn basic_auth_is_applied_over_the_wire() {
+    let server = MockServer::start().await;
+    // base64("alice:s3cr3t") == "YWxpY2U6czNjcjN0"
+    Mock::given(method("POST"))
+        .and(path("/ingest"))
+        .and(header("authorization", "Basic YWxpY2U6czNjcjN0"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+
+    let config = HttpSinkConfig::new(url(&server)).auth(HttpSinkAuth::Basic {
+        username: "alice".into(),
+        password: "s3cr3t".into(),
+    });
+    let sink = HttpSink::new(config);
+
+    let written = sink
+        .write_batch(&[json!({ "id": 1 })])
+        .await
+        .expect("basic-auth write ok");
+    assert_eq!(written, 1);
+
+    let requests = server.received_requests().await.unwrap();
+    assert_eq!(
+        requests.len(),
+        1,
+        "request matched only with the basic-auth header"
+    );
+}
+
+// ─── Retry behaviour ─────────────────────────────────────────────────────────
+
+/// A retriable 5xx followed by a 200 succeeds when `max_retries` allows it.
+/// The first attempt 503s; the second attempt 200s; total two requests.
+#[tokio::test]
+async fn retries_transient_5xx_then_succeeds() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/ingest"))
+        .respond_with(ResponseTemplate::new(503))
+        .up_to_n_times(1)
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/ingest"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let config = HttpSinkConfig::new(url(&server))
+        .batch_mode(HttpBatchMode::Individual)
+        .max_retries(2);
+    let sink = HttpSink::new(config);
+
+    let written = sink
+        .write_batch(&[json!({ "id": 1 })])
+        .await
+        .expect("must succeed once the retry hits the 200");
+    assert_eq!(written, 1);
+
+    let requests = server.received_requests().await.unwrap();
+    assert_eq!(
+        requests.len(),
+        2,
+        "one failed attempt + one successful retry"
+    );
+}
+
+/// When every attempt returns a retriable 5xx, the sink exhausts its retries
+/// and surfaces the final `FaucetError::HttpStatus` carrying the 503 status.
+#[tokio::test]
+async fn retry_exhaustion_surfaces_final_error() {
+    let server = MockServer::start().await;
+    let hits = Arc::new(AtomicUsize::new(0));
+    let hits_resp = hits.clone();
+    Mock::given(method("POST"))
+        .and(path("/ingest"))
+        .respond_with(move |_req: &Request| {
+            hits_resp.fetch_add(1, Ordering::SeqCst);
+            ResponseTemplate::new(503)
+        })
+        .mount(&server)
+        .await;
+
+    let config = HttpSinkConfig::new(url(&server))
+        .batch_mode(HttpBatchMode::Individual)
+        .max_retries(2);
+    let sink = HttpSink::new(config);
+
+    let err = sink
+        .write_batch(&[json!({ "id": 1 })])
+        .await
+        .expect_err("all-503 must fail after retries are exhausted");
+    match err {
+        FaucetError::HttpStatus { status, .. } => {
+            assert_eq!(status, 503, "the last 503 must be surfaced");
+        }
+        other => panic!("expected HttpStatus(503), got {other:?}"),
+    }
+
+    // 1 initial attempt + 2 retries == 3 total requests.
+    assert_eq!(
+        hits.load(Ordering::SeqCst),
+        3,
+        "initial attempt + max_retries(2)"
+    );
+}
+
+/// A non-retriable non-2xx response (400) fails immediately, with no retries
+/// attempted even when `max_retries` is non-zero.
+#[tokio::test]
+async fn non_retriable_4xx_fails_without_retrying() {
+    let server = MockServer::start().await;
+    let hits = Arc::new(AtomicUsize::new(0));
+    let hits_resp = hits.clone();
+    Mock::given(method("POST"))
+        .and(path("/ingest"))
+        .respond_with(move |_req: &Request| {
+            hits_resp.fetch_add(1, Ordering::SeqCst);
+            ResponseTemplate::new(400)
+        })
+        .mount(&server)
+        .await;
+
+    let config = HttpSinkConfig::new(url(&server))
+        .batch_mode(HttpBatchMode::Individual)
+        .max_retries(3);
+    let sink = HttpSink::new(config);
+
+    let err = sink
+        .write_batch(&[json!({ "id": 1 })])
+        .await
+        .expect_err("400 must fail");
+    match err {
+        FaucetError::HttpStatus { status, .. } => assert_eq!(status, 400),
+        other => panic!("expected HttpStatus(400), got {other:?}"),
+    }
+    assert_eq!(
+        hits.load(Ordering::SeqCst),
+        1,
+        "a non-retriable 400 must not be retried"
+    );
+}
+
+// ─── credential_to_auth mapping for every shared-provider variant ────────────
+
+/// A provider returning an arbitrary [`Credential`] for `credential_to_auth`.
+#[derive(Debug)]
+struct FixedCredential(Credential);
+
+#[async_trait::async_trait]
+impl AuthProvider for FixedCredential {
+    async fn credential(&self) -> Result<Credential, FaucetError> {
+        Ok(self.0.clone())
+    }
+    fn provider_name(&self) -> &'static str {
+        "fixed-credential"
+    }
+}
+
+async fn run_with_provider_expecting_header(
+    cred: Credential,
+    header_name: &str,
+    header_value: &str,
+) {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/ingest"))
+        .and(header(header_name, header_value))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+
+    let provider = Arc::new(FixedCredential(cred));
+    let sink = HttpSink::new(HttpSinkConfig::new(url(&server))).with_auth_provider(provider);
+
+    let written = sink
+        .write_batch(&[json!({ "id": 1 })])
+        .await
+        .expect("provider-auth write ok");
+    assert_eq!(
+        written, 1,
+        "request matched only with the expected auth header"
+    );
+}
+
+/// `Credential::Token` maps to a raw `Authorization` header value.
+#[tokio::test]
+async fn provider_token_credential_sets_authorization_header() {
+    run_with_provider_expecting_header(
+        Credential::Token("raw-token-123".to_string()),
+        "authorization",
+        "raw-token-123",
+    )
+    .await;
+}
+
+/// `Credential::Basic` maps to a base64-encoded `Authorization: Basic` header.
+#[tokio::test]
+async fn provider_basic_credential_sets_basic_authorization_header() {
+    // base64("bob:hunter2") == "Ym9iOmh1bnRlcjI="
+    run_with_provider_expecting_header(
+        Credential::Basic {
+            username: "bob".to_string(),
+            password: "hunter2".to_string(),
+        },
+        "authorization",
+        "Basic Ym9iOmh1bnRlcjI=",
+    )
+    .await;
+}
+
+/// `Credential::Header` maps to a custom header with the given name/value.
+#[tokio::test]
+async fn provider_header_credential_sets_named_header() {
+    run_with_provider_expecting_header(
+        Credential::Header {
+            name: "X-Api-Token".to_string(),
+            value: "hv-789".to_string(),
+        },
+        "x-api-token",
+        "hv-789",
+    )
+    .await;
+}
+
+// ─── config schema introspection ─────────────────────────────────────────────
+
+/// `config_schema()` returns a JSON object describing `HttpSinkConfig`.
+#[tokio::test]
+async fn config_schema_describes_the_config_struct() {
+    let sink = HttpSink::new(HttpSinkConfig::new("https://api.example.com/ingest"));
+    let schema = sink.config_schema();
+    let props = schema
+        .get("properties")
+        .and_then(|p| p.as_object())
+        .expect("schema has a properties object");
+    assert!(props.contains_key("url"), "schema documents `url`");
+    assert!(
+        props.contains_key("batch_mode"),
+        "schema documents `batch_mode`"
+    );
+    assert!(
+        props.contains_key("max_retries"),
+        "schema documents `max_retries`"
+    );
+}

--- a/crates/sink/kafka/src/encode.rs
+++ b/crates/sink/kafka/src/encode.rs
@@ -156,4 +156,157 @@ mod tests {
         .unwrap_err();
         assert!(format!("{err}").contains("base64"));
     }
+
+    #[cfg(feature = "schema-registry")]
+    mod schema_registry {
+        use super::*;
+        use faucet_common_kafka::SchemaRegistryConfig;
+        use faucet_common_kafka::schema_registry::client::SchemaRegistryClient;
+
+        fn avro_format() -> KafkaValueFormat {
+            KafkaValueFormat::ConfluentAvro {
+                schema_registry: SchemaRegistryConfig::new("http://localhost:8081"),
+            }
+        }
+
+        fn protobuf_format() -> KafkaValueFormat {
+            KafkaValueFormat::ConfluentProtobuf {
+                schema_registry: SchemaRegistryConfig::new("http://localhost:8081"),
+            }
+        }
+
+        fn json_schema_format() -> KafkaValueFormat {
+            KafkaValueFormat::ConfluentJsonSchema {
+                schema_registry: SchemaRegistryConfig::new("http://localhost:8081"),
+                validate: false,
+            }
+        }
+
+        /// A `SchemaRegistryClient::new` only builds the HTTP client and
+        /// validates the URL — no network I/O — so it is safe to construct
+        /// offline for the "client present but schema_text missing" branch.
+        fn offline_client() -> SchemaRegistryClient {
+            SchemaRegistryClient::new(&SchemaRegistryConfig::new("http://localhost:8081"))
+                .expect("offline client builds")
+        }
+
+        #[tokio::test]
+        async fn encode_confluent_avro_without_client_is_config_error() {
+            let err = encode(
+                &json!({"a": 1}),
+                &avro_format(),
+                None,
+                &SchemaContext::default(),
+            )
+            .await
+            .unwrap_err();
+            match err {
+                FaucetError::Config(msg) => assert!(
+                    msg.contains("ConfluentAvro") && msg.contains("no SchemaRegistryClient"),
+                    "unexpected message: {msg}"
+                ),
+                other => panic!("expected Config error, got {other:?}"),
+            }
+        }
+
+        #[tokio::test]
+        async fn encode_confluent_protobuf_without_client_is_config_error() {
+            let err = encode(
+                &json!({"a": 1}),
+                &protobuf_format(),
+                None,
+                &SchemaContext::default(),
+            )
+            .await
+            .unwrap_err();
+            match err {
+                FaucetError::Config(msg) => assert!(
+                    msg.contains("ConfluentProtobuf") && msg.contains("no SchemaRegistryClient"),
+                    "unexpected message: {msg}"
+                ),
+                other => panic!("expected Config error, got {other:?}"),
+            }
+        }
+
+        #[tokio::test]
+        async fn encode_confluent_json_schema_without_client_is_config_error() {
+            let err = encode(
+                &json!({"a": 1}),
+                &json_schema_format(),
+                None,
+                &SchemaContext::default(),
+            )
+            .await
+            .unwrap_err();
+            match err {
+                FaucetError::Config(msg) => assert!(
+                    msg.contains("ConfluentJsonSchema") && msg.contains("no SchemaRegistryClient"),
+                    "unexpected message: {msg}"
+                ),
+                other => panic!("expected Config error, got {other:?}"),
+            }
+        }
+
+        #[tokio::test]
+        async fn encode_confluent_avro_without_schema_text_is_config_error() {
+            let client = offline_client();
+            // schema_text defaults to None — the schema_text guard fires before
+            // any registry network call.
+            let err = encode(
+                &json!({"a": 1}),
+                &avro_format(),
+                Some(&client),
+                &SchemaContext::default(),
+            )
+            .await
+            .unwrap_err();
+            match err {
+                FaucetError::Config(msg) => assert!(
+                    msg.contains("ConfluentAvro") && msg.contains("schema_text"),
+                    "unexpected message: {msg}"
+                ),
+                other => panic!("expected Config error, got {other:?}"),
+            }
+        }
+
+        #[tokio::test]
+        async fn encode_confluent_protobuf_without_schema_text_is_config_error() {
+            let client = offline_client();
+            let err = encode(
+                &json!({"a": 1}),
+                &protobuf_format(),
+                Some(&client),
+                &SchemaContext::default(),
+            )
+            .await
+            .unwrap_err();
+            match err {
+                FaucetError::Config(msg) => assert!(
+                    msg.contains("ConfluentProtobuf") && msg.contains("schema_text"),
+                    "unexpected message: {msg}"
+                ),
+                other => panic!("expected Config error, got {other:?}"),
+            }
+        }
+
+        #[tokio::test]
+        async fn encode_confluent_json_schema_without_schema_text_is_config_error() {
+            let client = offline_client();
+            let err = encode(
+                &json!({"a": 1}),
+                &json_schema_format(),
+                Some(&client),
+                &SchemaContext::default(),
+            )
+            .await
+            .unwrap_err();
+            match err {
+                FaucetError::Config(msg) => assert!(
+                    msg.contains("ConfluentJsonSchema") && msg.contains("schema_text"),
+                    "unexpected message: {msg}"
+                ),
+                other => panic!("expected Config error, got {other:?}"),
+            }
+        }
+    }
 }

--- a/crates/sink/kafka/src/sink.rs
+++ b/crates/sink/kafka/src/sink.rs
@@ -426,4 +426,70 @@ mod tests {
     // dataset_uri test is skipped: KafkaSink::new() requires a live Kafka
     // broker (creates a FutureProducer in new()), and no offline constructor
     // exists.
+
+    #[cfg(feature = "schema-registry")]
+    mod sr_client {
+        use crate::sink::build_sr_client;
+        use faucet_common_kafka::{KafkaValueFormat, SchemaRegistryConfig};
+
+        #[test]
+        fn build_sr_client_none_for_plain_formats() {
+            assert!(
+                build_sr_client(&KafkaValueFormat::Json, None)
+                    .unwrap()
+                    .is_none()
+            );
+            assert!(
+                build_sr_client(&KafkaValueFormat::RawString, Some(&KafkaValueFormat::Bytes))
+                    .unwrap()
+                    .is_none()
+            );
+        }
+
+        #[test]
+        fn build_sr_client_some_for_confluent_avro_value() {
+            let format = KafkaValueFormat::ConfluentAvro {
+                schema_registry: SchemaRegistryConfig::new("http://localhost:8081"),
+            };
+            assert!(build_sr_client(&format, None).unwrap().is_some());
+        }
+
+        #[test]
+        fn build_sr_client_some_for_confluent_protobuf_value() {
+            let format = KafkaValueFormat::ConfluentProtobuf {
+                schema_registry: SchemaRegistryConfig::new("http://localhost:8081"),
+            };
+            assert!(build_sr_client(&format, None).unwrap().is_some());
+        }
+
+        #[test]
+        fn build_sr_client_some_for_confluent_json_schema_value() {
+            let format = KafkaValueFormat::ConfluentJsonSchema {
+                schema_registry: SchemaRegistryConfig::new("http://localhost:8081"),
+                validate: false,
+            };
+            assert!(build_sr_client(&format, None).unwrap().is_some());
+        }
+
+        #[test]
+        fn build_sr_client_falls_back_to_key_format() {
+            let key = KafkaValueFormat::ConfluentProtobuf {
+                schema_registry: SchemaRegistryConfig::new("http://localhost:8081"),
+            };
+            assert!(
+                build_sr_client(&KafkaValueFormat::Json, Some(&key))
+                    .unwrap()
+                    .is_some()
+            );
+        }
+
+        #[test]
+        fn build_sr_client_propagates_invalid_url() {
+            let format = KafkaValueFormat::ConfluentJsonSchema {
+                schema_registry: SchemaRegistryConfig::new("not-a-url"),
+                validate: false,
+            };
+            assert!(build_sr_client(&format, None).is_err());
+        }
+    }
 }

--- a/crates/sink/kafka/tests/coverage.rs
+++ b/crates/sink/kafka/tests/coverage.rs
@@ -1,0 +1,306 @@
+//! Additional `KafkaSink` integration tests targeting branches the existing
+//! `integration.rs` suite does not exercise: `key_path` + `key_format`
+//! JSON-key encoding, the `OnKeyError::Fail` / `OnKeyError::Skip` paths through
+//! `handle_key_extract`, partition routing, the `check()` metadata probe (pass
+//! and fail), and `dataset_uri` for both topic modes.
+//!
+//! Each test boots its own container so they are isolated and parallel-safe.
+
+use faucet_common_kafka::{CompressionType, KafkaAuth, KafkaValueFormat, OnKeyError};
+use faucet_core::check::{CheckContext, ProbeStatus};
+use faucet_core::{DEFAULT_BATCH_SIZE, Sink};
+use faucet_sink_kafka::{Acks, KafkaSink, KafkaSinkConfig, KafkaSinkTopic};
+use rdkafka::ClientConfig;
+use rdkafka::Message;
+use rdkafka::consumer::{Consumer, StreamConsumer};
+use serde_json::json;
+use std::collections::BTreeMap;
+use std::time::Duration;
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::kafka::apache::{KAFKA_PORT, Kafka};
+
+async fn start_kafka() -> (testcontainers::ContainerAsync<Kafka>, String) {
+    let container = Kafka::default()
+        .start()
+        .await
+        .expect("kafka container start");
+    let port = container
+        .get_host_port_ipv4(KAFKA_PORT)
+        .await
+        .expect("kafka port");
+    (container, format!("127.0.0.1:{port}"))
+}
+
+fn sink_config(brokers: &str, topic: KafkaSinkTopic) -> KafkaSinkConfig {
+    KafkaSinkConfig {
+        brokers: brokers.into(),
+        topic,
+        auth: KafkaAuth::None,
+        value_format: KafkaValueFormat::Json,
+        key_format: None,
+        value_schema: None,
+        key_schema: None,
+        key_path: None,
+        partition_path: None,
+        headers_path: None,
+        on_key_error: OnKeyError::Fail,
+        compression: CompressionType::None,
+        acks: Acks::All,
+        idempotent: true,
+        linger: Duration::from_millis(5),
+        batch_size: DEFAULT_BATCH_SIZE,
+        message_timeout: Duration::from_secs(10),
+        max_in_flight: 50,
+        queue_full_backoff: Duration::from_millis(100),
+        queue_full_max_retries: 3,
+        extra_client_config: BTreeMap::new(),
+    }
+}
+
+/// Drain `expect` messages and return (key_utf8, payload_utf8, partition).
+async fn drain_keyed(
+    brokers: &str,
+    topic: &str,
+    expect: usize,
+) -> Vec<(Option<String>, String, i32)> {
+    let consumer: StreamConsumer = ClientConfig::new()
+        .set("bootstrap.servers", brokers)
+        .set("group.id", format!("test-consumer-{topic}"))
+        .set("auto.offset.reset", "earliest")
+        .set("enable.auto.commit", "false")
+        .create()
+        .expect("consumer init");
+    consumer.subscribe(&[topic]).expect("subscribe");
+    let mut out = Vec::new();
+    while out.len() < expect {
+        let msg = tokio::time::timeout(Duration::from_secs(30), consumer.recv())
+            .await
+            .expect("recv timeout")
+            .expect("recv");
+        let key = msg.key().map(|b| String::from_utf8_lossy(b).to_string());
+        let payload = msg
+            .payload()
+            .map(|b| String::from_utf8_lossy(b).to_string())
+            .unwrap_or_default();
+        out.push((key, payload, msg.partition()));
+    }
+    out
+}
+
+/// `key_path` + `key_format = Json` extracts the sub-value at the path and
+/// encodes it via the JSON encoder (the `(Some(path), Some(fmt))` arm of
+/// `build_record_bytes`).
+#[tokio::test(flavor = "multi_thread")]
+async fn key_path_with_json_key_format_encodes_subvalue() {
+    let (_c, brokers) = start_kafka().await;
+    let topic = "cov-key-json";
+    let mut cfg = sink_config(&brokers, KafkaSinkTopic::Fixed { name: topic.into() });
+    cfg.key_path = Some("$.k".into());
+    cfg.key_format = Some(KafkaValueFormat::Json);
+    let sink = KafkaSink::new(cfg).await.unwrap();
+    let n = sink
+        .write_batch(&[json!({"k": {"id": 7}, "v": 1})])
+        .await
+        .unwrap();
+    assert_eq!(n, 1);
+    sink.flush().await.unwrap();
+    let msgs = drain_keyed(&brokers, topic, 1).await;
+    // The key bytes are the JSON encoding of the sub-object `{"id":7}`.
+    assert_eq!(msgs[0].0.as_deref(), Some(r#"{"id":7}"#));
+}
+
+/// `key_path` + `key_format = None` uses the extracted string directly as the
+/// raw key bytes (the `(Some(path), None)` arm).
+#[tokio::test(flavor = "multi_thread")]
+async fn key_path_without_key_format_uses_string_directly() {
+    let (_c, brokers) = start_kafka().await;
+    let topic = "cov-key-string";
+    let mut cfg = sink_config(&brokers, KafkaSinkTopic::Fixed { name: topic.into() });
+    cfg.key_path = Some("$.user_id".into());
+    let sink = KafkaSink::new(cfg).await.unwrap();
+    let n = sink
+        .write_batch(&[json!({"user_id": "alice", "v": 1})])
+        .await
+        .unwrap();
+    assert_eq!(n, 1);
+    sink.flush().await.unwrap();
+    let msgs = drain_keyed(&brokers, topic, 1).await;
+    assert_eq!(msgs[0].0.as_deref(), Some("alice"));
+}
+
+/// `key_path` + `key_format = None` with a missing key and `OnKeyError::Fail`
+/// returns a `Sink` error (the `(Some(path), None)` → `Fail` arm).
+#[tokio::test(flavor = "multi_thread")]
+async fn missing_string_key_with_fail_errors() {
+    let (_c, brokers) = start_kafka().await;
+    let topic = "cov-key-fail";
+    let mut cfg = sink_config(&brokers, KafkaSinkTopic::Fixed { name: topic.into() });
+    cfg.key_path = Some("$.user_id".into());
+    cfg.on_key_error = OnKeyError::Fail;
+    let sink = KafkaSink::new(cfg).await.unwrap();
+    let err = sink.write_batch(&[json!({"v": 1})]).await.unwrap_err();
+    assert!(
+        format!("{err}").contains("key_path"),
+        "expected key_path failure, got {err}"
+    );
+}
+
+/// `key_path` + `key_format = Json` with a missing key and `OnKeyError::Fail`
+/// goes through `handle_key_extract` and returns a `Sink` error.
+#[tokio::test(flavor = "multi_thread")]
+async fn missing_json_key_with_fail_errors() {
+    let (_c, brokers) = start_kafka().await;
+    let topic = "cov-key-json-fail";
+    let mut cfg = sink_config(&brokers, KafkaSinkTopic::Fixed { name: topic.into() });
+    cfg.key_path = Some("$.k".into());
+    cfg.key_format = Some(KafkaValueFormat::Json);
+    cfg.on_key_error = OnKeyError::Fail;
+    let sink = KafkaSink::new(cfg).await.unwrap();
+    let err = sink.write_batch(&[json!({"v": 1})]).await.unwrap_err();
+    assert!(
+        format!("{err}").contains("key_path") && format!("{err}").contains("fail"),
+        "expected handle_key_extract failure, got {err}"
+    );
+}
+
+/// `key_path` + `key_format = Json` with a missing key and `OnKeyError::Skip`
+/// goes through `handle_key_extract` returning `None` (the `Skip => Ok(None)`
+/// branch); `key_bytes` is then `None`, so the record is dropped by the
+/// skip-drop guard. A record with a present key is kept, so the keyed record
+/// alone is produced.
+#[tokio::test(flavor = "multi_thread")]
+async fn missing_json_key_with_skip_drops_record() {
+    let (_c, brokers) = start_kafka().await;
+    let topic = "cov-key-json-skip";
+    let mut cfg = sink_config(&brokers, KafkaSinkTopic::Fixed { name: topic.into() });
+    cfg.key_path = Some("$.k".into());
+    cfg.key_format = Some(KafkaValueFormat::Json);
+    cfg.on_key_error = OnKeyError::Skip;
+    let sink = KafkaSink::new(cfg).await.unwrap();
+    let n = sink
+        .write_batch(&[json!({"v": 1}), json!({"k": 5, "v": 2})])
+        .await
+        .unwrap();
+    assert_eq!(n, 1, "the keyless record is dropped, the keyed one is kept");
+    sink.flush().await.unwrap();
+    let msgs = drain_keyed(&brokers, topic, 1).await;
+    assert_eq!(
+        msgs[0].0.as_deref(),
+        Some("5"),
+        "only the keyed record survives"
+    );
+    assert_eq!(msgs[0].1, r#"{"k":5,"v":2}"#);
+}
+
+/// `partition_path` routes a record to an explicit partition (the
+/// `Some(p) => extract::partition_at(...)` arm). Topic is created with 3
+/// partitions so partition 2 is valid.
+#[tokio::test(flavor = "multi_thread")]
+async fn partition_path_routes_to_explicit_partition() {
+    use rdkafka::admin::{AdminClient, AdminOptions, NewTopic, TopicReplication};
+    use rdkafka::client::DefaultClientContext;
+
+    let (_c, brokers) = start_kafka().await;
+    let topic = "cov-partition";
+    let admin: AdminClient<DefaultClientContext> = ClientConfig::new()
+        .set("bootstrap.servers", &brokers)
+        .create()
+        .expect("admin");
+    admin
+        .create_topics(
+            &[NewTopic::new(topic, 3, TopicReplication::Fixed(1))],
+            &AdminOptions::new(),
+        )
+        .await
+        .expect("create topic");
+
+    let mut cfg = sink_config(&brokers, KafkaSinkTopic::Fixed { name: topic.into() });
+    cfg.partition_path = Some("$.p".into());
+    let sink = KafkaSink::new(cfg).await.unwrap();
+    let n = sink.write_batch(&[json!({"p": 2, "v": 1})]).await.unwrap();
+    assert_eq!(n, 1);
+    sink.flush().await.unwrap();
+    let msgs = drain_keyed(&brokers, topic, 1).await;
+    assert_eq!(msgs[0].2, 2, "record must land on partition 2");
+}
+
+/// `check()` returns a single passing `metadata` probe against a reachable
+/// broker.
+#[tokio::test(flavor = "multi_thread")]
+async fn check_passes_against_reachable_broker() {
+    let (_c, brokers) = start_kafka().await;
+    let sink = KafkaSink::new(sink_config(
+        &brokers,
+        KafkaSinkTopic::Fixed {
+            name: "cov-check".into(),
+        },
+    ))
+    .await
+    .unwrap();
+    let report = sink.check(&CheckContext::default()).await.unwrap();
+    assert_eq!(report.probes.len(), 1);
+    assert_eq!(report.probes[0].name, "metadata");
+    assert!(
+        matches!(report.probes[0].status, ProbeStatus::Pass),
+        "expected a passing metadata probe, got {:?}",
+        report.probes[0].status
+    );
+}
+
+/// `check()` fails (rather than hanging) when the broker is unreachable.
+#[tokio::test(flavor = "multi_thread")]
+async fn check_fails_against_unreachable_broker() {
+    let sink = KafkaSink::new(sink_config(
+        "127.0.0.1:1",
+        KafkaSinkTopic::Fixed {
+            name: "cov-check-bad".into(),
+        },
+    ))
+    .await
+    .unwrap();
+    let ctx = CheckContext {
+        timeout: Duration::from_secs(3),
+    };
+    let report = sink.check(&ctx).await.unwrap();
+    assert_eq!(report.probes.len(), 1);
+    assert_eq!(report.probes[0].name, "metadata");
+    assert!(
+        matches!(report.probes[0].status, ProbeStatus::Fail { .. }),
+        "expected a failing metadata probe, got {:?}",
+        report.probes[0].status
+    );
+}
+
+/// `dataset_uri` renders the fixed-topic and from-path topic modes.
+#[tokio::test(flavor = "multi_thread")]
+async fn dataset_uri_for_both_topic_modes() {
+    let (_c, brokers) = start_kafka().await;
+
+    let fixed = KafkaSink::new(sink_config(
+        &brokers,
+        KafkaSinkTopic::Fixed {
+            name: "orders".into(),
+        },
+    ))
+    .await
+    .unwrap();
+    let uri = fixed.dataset_uri();
+    assert!(
+        uri.starts_with("kafka://") && uri.ends_with("?topic=orders"),
+        "unexpected fixed dataset_uri: {uri}"
+    );
+
+    let from_path = KafkaSink::new(sink_config(
+        &brokers,
+        KafkaSinkTopic::FromPath {
+            path: "$.dest".into(),
+        },
+    ))
+    .await
+    .unwrap();
+    let uri = from_path.dataset_uri();
+    assert!(
+        uri.ends_with("?topic=(from_path:$.dest)"),
+        "unexpected from_path dataset_uri: {uri}"
+    );
+}

--- a/crates/sink/mysql/tests/idempotency.rs
+++ b/crates/sink/mysql/tests/idempotency.rs
@@ -1,0 +1,351 @@
+//! Integration tests for [`MysqlSink`]'s exactly-once / idempotent write path,
+//! its AutoMap edge/error branches, native-type binding edge cases, and the
+//! preflight `check()`, against a real MySQL instance via testcontainers.
+//!
+//! These tests require Docker. Each test boots its own container and seeds its
+//! own table so they are fully isolated and safe to run in parallel.
+
+use faucet_core::Sink;
+use faucet_core::check::ProbeStatus;
+use faucet_core::idempotency::{
+    COMMIT_TOKEN_SCOPE_COL, COMMIT_TOKEN_TABLE, COMMIT_TOKEN_TOKEN_COL, format_token,
+};
+use faucet_sink_mysql::{MysqlColumnMapping, MysqlSink, MysqlSinkConfig};
+use serde_json::{Value, json};
+use sqlx::Row;
+use std::sync::OnceLock;
+use testcontainers::{ContainerAsync, runners::AsyncRunner};
+use testcontainers_modules::mysql::Mysql;
+use tokio::sync::Semaphore;
+
+/// Bounds concurrent MySQL container startups (see `batching.rs` for rationale).
+fn startup_limit() -> &'static Semaphore {
+    static SEM: OnceLock<Semaphore> = OnceLock::new();
+    SEM.get_or_init(|| Semaphore::new(2))
+}
+
+async fn start_mysql() -> (ContainerAsync<Mysql>, String) {
+    let _permit = startup_limit()
+        .acquire()
+        .await
+        .expect("startup semaphore closed");
+    let image = Mysql::default();
+    let container: ContainerAsync<Mysql> = image.start().await.expect("mysql container start");
+    let port = container
+        .get_host_port_ipv4(3306)
+        .await
+        .expect("mysql port");
+    let url = format!("mysql://root@127.0.0.1:{port}/test");
+    (container, url)
+}
+
+async fn create_json_table(url: &str) {
+    let pool = sqlx::MySqlPool::connect(url).await.expect("pool connect");
+    sqlx::query("CREATE TABLE events (id BIGINT AUTO_INCREMENT PRIMARY KEY, data JSON NOT NULL)")
+        .execute(&pool)
+        .await
+        .expect("create table");
+    pool.close().await;
+}
+
+async fn count_events(url: &str) -> i64 {
+    let pool = sqlx::MySqlPool::connect(url).await.expect("verify pool");
+    let count: i64 = sqlx::query("SELECT COUNT(*) FROM events")
+        .fetch_one(&pool)
+        .await
+        .expect("select count")
+        .get(0);
+    pool.close().await;
+    count
+}
+
+/// Read the stored commit token for `scope` directly from the watermark table.
+async fn stored_token(url: &str, scope: &str) -> Option<String> {
+    let pool = sqlx::MySqlPool::connect(url).await.expect("pool connect");
+    let sql = format!(
+        "SELECT `{COMMIT_TOKEN_TOKEN_COL}` FROM `{COMMIT_TOKEN_TABLE}` \
+         WHERE `{COMMIT_TOKEN_SCOPE_COL}` = ?"
+    );
+    let row = sqlx::query(&sql)
+        .bind(scope)
+        .fetch_optional(&pool)
+        .await
+        .expect("token read");
+    pool.close().await;
+    row.map(|r| r.get::<String, _>(0))
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn idempotent_write_persists_data_and_token_atomically() {
+    let (_container, url) = start_mysql().await;
+    create_json_table(&url).await;
+
+    let config = MysqlSinkConfig::new(&url, "events")
+        .column_mapping(MysqlColumnMapping::Json {
+            column: "data".into(),
+        })
+        .with_batch_size(0);
+    let sink = MysqlSink::new(config).await.expect("sink new");
+
+    assert!(
+        sink.supports_idempotent_writes(),
+        "mysql sink advertises idempotent writes"
+    );
+    assert_eq!(
+        sink.last_committed_token("scope-a").await.expect("read"),
+        None,
+        "fresh scope has no committed token"
+    );
+
+    let token = format_token(1);
+    let written = sink
+        .write_batch_idempotent(&[json!({"k": 1}), json!({"k": 2})], "scope-a", &token)
+        .await
+        .expect("idempotent write");
+    assert_eq!(written, 2);
+    assert_eq!(count_events(&url).await, 2);
+    assert_eq!(
+        sink.last_committed_token("scope-a")
+            .await
+            .expect("read")
+            .as_deref(),
+        Some(token.as_str())
+    );
+    assert_eq!(
+        stored_token(&url, "scope-a").await.as_deref(),
+        Some(token.as_str())
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn idempotent_write_upserts_token_on_repeat_scope() {
+    let (_container, url) = start_mysql().await;
+    create_json_table(&url).await;
+
+    let config = MysqlSinkConfig::new(&url, "events")
+        .column_mapping(MysqlColumnMapping::Json {
+            column: "data".into(),
+        })
+        .with_batch_size(0);
+    let sink = MysqlSink::new(config).await.expect("sink new");
+
+    let t1 = format_token(1);
+    let t2 = format_token(2);
+    sink.write_batch_idempotent(&[json!({"n": 1})], "s", &t1)
+        .await
+        .expect("write 1");
+    sink.write_batch_idempotent(&[json!({"n": 2})], "s", &t2)
+        .await
+        .expect("write 2");
+
+    assert_eq!(count_events(&url).await, 2);
+    assert_eq!(
+        sink.last_committed_token("s")
+            .await
+            .expect("read")
+            .as_deref(),
+        Some(t2.as_str()),
+        "ON DUPLICATE KEY UPDATE must advance the watermark"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn idempotent_write_auto_map_mode_commits_data_and_token() {
+    let (_container, url) = start_mysql().await;
+    {
+        let pool = sqlx::MySqlPool::connect(&url).await.expect("pool");
+        sqlx::query("CREATE TABLE rows_t (id BIGINT, name VARCHAR(32))")
+            .execute(&pool)
+            .await
+            .expect("create table");
+        pool.close().await;
+    }
+
+    let config = MysqlSinkConfig::new(&url, "rows_t")
+        .column_mapping(MysqlColumnMapping::AutoMap)
+        .with_batch_size(0);
+    let sink = MysqlSink::new(config).await.expect("sink new");
+
+    let token = format_token(7);
+    let written = sink
+        .write_batch_idempotent(&[json!({"id": 3, "name": "q"})], "auto", &token)
+        .await
+        .expect("idempotent automap write");
+    assert_eq!(written, 1);
+
+    let pool = sqlx::MySqlPool::connect(&url).await.expect("pool");
+    let name: String = sqlx::query("SELECT name FROM rows_t WHERE id = 3")
+        .fetch_one(&pool)
+        .await
+        .expect("read back")
+        .get("name");
+    pool.close().await;
+    assert_eq!(name, "q");
+    assert_eq!(
+        sink.last_committed_token("auto")
+            .await
+            .expect("read")
+            .as_deref(),
+        Some(token.as_str())
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn auto_map_into_missing_table_errors_with_no_columns() {
+    let (_container, url) = start_mysql().await;
+
+    let config =
+        MysqlSinkConfig::new(&url, "does_not_exist").column_mapping(MysqlColumnMapping::AutoMap);
+    let sink = MysqlSink::new(config).await.expect("sink new");
+
+    let err = sink
+        .write_batch(&[json!({"a": 1})])
+        .await
+        .expect_err("missing table must error");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("has no columns or does not exist"),
+        "must surface the missing-table error; got: {msg}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn auto_map_skips_records_with_no_matching_columns_then_noop() {
+    let (_container, url) = start_mysql().await;
+    {
+        let pool = sqlx::MySqlPool::connect(&url).await.expect("pool");
+        sqlx::query("CREATE TABLE t (id BIGINT, name VARCHAR(32))")
+            .execute(&pool)
+            .await
+            .expect("create table");
+        pool.close().await;
+    }
+
+    let config = MysqlSinkConfig::new(&url, "t").column_mapping(MysqlColumnMapping::AutoMap);
+    let sink = MysqlSink::new(config).await.expect("sink new");
+
+    let written = sink
+        .write_batch(&[json!({"nope": 1}), json!({"other": 2})])
+        .await
+        .expect("write");
+    assert_eq!(written, 0, "all records skipped → zero written");
+
+    let pool = sqlx::MySqlPool::connect(&url).await.expect("pool");
+    let count: i64 = sqlx::query("SELECT COUNT(*) FROM t")
+        .fetch_one(&pool)
+        .await
+        .expect("count")
+        .get(0);
+    pool.close().await;
+    assert_eq!(count, 0, "no INSERT issued when nothing matches");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn auto_map_non_object_record_errors() {
+    let (_container, url) = start_mysql().await;
+    {
+        let pool = sqlx::MySqlPool::connect(&url).await.expect("pool");
+        sqlx::query("CREATE TABLE t (id BIGINT)")
+            .execute(&pool)
+            .await
+            .expect("create table");
+        pool.close().await;
+    }
+
+    let config = MysqlSinkConfig::new(&url, "t").column_mapping(MysqlColumnMapping::AutoMap);
+    let sink = MysqlSink::new(config).await.expect("sink new");
+
+    let err = sink
+        .write_batch(&[json!("scalar")])
+        .await
+        .expect_err("non-object must error");
+    assert!(
+        err.to_string()
+            .contains("AutoMap requires JSON object records"),
+        "got: {err}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn auto_map_binds_float_and_nested_json_as_text() {
+    // Covers the Number-as-f64 binding branch and the array/object branch:
+    //  - a fractional number binds via the native f64 path,
+    //  - an object/array has no scalar SQL form so its JSON text is bound.
+    let (_container, url) = start_mysql().await;
+    {
+        let pool = sqlx::MySqlPool::connect(&url).await.expect("pool");
+        sqlx::query("CREATE TABLE t (amount DOUBLE, nested JSON, list JSON)")
+            .execute(&pool)
+            .await
+            .expect("create table");
+        pool.close().await;
+    }
+
+    let config = MysqlSinkConfig::new(&url, "t").column_mapping(MysqlColumnMapping::AutoMap);
+    let sink = MysqlSink::new(config).await.expect("sink new");
+
+    let records = vec![json!({
+        "amount": 1234.5,
+        "nested": {"a": [1, 2]},
+        "list": [1, 2, 3]
+    })];
+    assert_eq!(sink.write_batch(&records).await.expect("write"), 1);
+
+    let pool = sqlx::MySqlPool::connect(&url).await.expect("pool");
+    let row = sqlx::query("SELECT amount, nested, list FROM t")
+        .fetch_one(&pool)
+        .await
+        .expect("read back");
+    let amount: f64 = row.get("amount");
+    // The JSON columns round-trip the object/array as parsed JSON.
+    let nested: Value = row.get("nested");
+    let list: Value = row.get("list");
+    pool.close().await;
+
+    assert!(
+        (amount - 1234.5).abs() < 1e-9,
+        "fractional number must bind via the native f64 path; got {amount}"
+    );
+    assert_eq!(
+        nested,
+        json!({"a": [1, 2]}),
+        "nested object must be stored as JSON text and parse back"
+    );
+    assert_eq!(
+        list,
+        json!([1, 2, 3]),
+        "array must be stored as JSON text and parse back"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn check_passes_against_live_server_and_metadata_methods() {
+    let (_container, url) = start_mysql().await;
+    create_json_table(&url).await;
+
+    let config = MysqlSinkConfig::new(&url, "events");
+    let sink = MysqlSink::new(config).await.expect("sink new");
+
+    let schema = sink.config_schema();
+    assert!(schema.get("properties").is_some(), "schema: {schema}");
+
+    let uri = sink.dataset_uri();
+    assert!(
+        uri.contains("table=events"),
+        "dataset_uri must carry the table: {uri}"
+    );
+
+    let report = sink
+        .check(&faucet_core::check::CheckContext::default())
+        .await
+        .expect("check");
+    assert_eq!(report.probes.len(), 1);
+    assert_eq!(report.probes[0].name, "auth");
+    assert!(
+        matches!(report.probes[0].status, ProbeStatus::Pass),
+        "auth probe must pass: {:?}",
+        report.probes[0].status
+    );
+
+    assert_eq!(sink.write_batch(&[]).await.expect("empty"), 0);
+}

--- a/crates/sink/parquet/tests/coverage.rs
+++ b/crates/sink/parquet/tests/coverage.rs
@@ -1,0 +1,312 @@
+//! Additional coverage tests for `faucet-sink-parquet`.
+//!
+//! These exercise branches not covered by `roundtrip.rs`: single-file mode
+//! (a fixed `.parquet` path), the doctor `check()` probe paths, the explicit
+//! schema rejection, the S3 `dataset_uri` / config-build branches, and the
+//! unsigned-integer / float JSON type-name reporting on a type-drift error.
+//! As in `roundtrip.rs`, we read the written Parquet back through the raw
+//! `parquet` + `arrow` APIs (no dependency on `faucet-source-parquet`).
+
+use arrow::record_batch::RecordBatch;
+use faucet_core::Sink;
+use faucet_core::check::{CheckContext, ProbeStatus};
+use faucet_sink_parquet::{
+    ParquetDestination, ParquetS3Destination, ParquetSink, ParquetSinkConfig,
+};
+use futures::TryStreamExt;
+use parquet::arrow::ParquetRecordBatchStreamBuilder;
+use serde_json::{Value, json};
+use tempfile::TempDir;
+
+fn rows_in(batches: &[RecordBatch]) -> usize {
+    batches.iter().map(|b| b.num_rows()).sum()
+}
+
+/// Read a single concrete `.parquet` file path back into record batches.
+async fn read_file(path: &std::path::Path) -> Vec<RecordBatch> {
+    let file = tokio::fs::File::open(path).await.unwrap();
+    let builder = ParquetRecordBatchStreamBuilder::new(file).await.unwrap();
+    let stream = builder.build().unwrap();
+    stream.try_collect().await.unwrap()
+}
+
+#[tokio::test]
+async fn single_file_mode_writes_to_the_exact_fixed_path() {
+    // A `.parquet` path with no rollover thresholds is single-file mode:
+    // `next_object_path` must return that exact path (not a UUID name in the
+    // parent dir), so the file lands at precisely the configured location.
+    let tmp = TempDir::new().unwrap();
+    let target = tmp.path().join("out.parquet");
+    let cfg = ParquetSinkConfig::local(target.to_string_lossy().to_string());
+    let sink = ParquetSink::new(cfg).await.unwrap();
+
+    sink.write_batch(&[
+        json!({"id": 1, "name": "alice"}),
+        json!({"id": 2, "name": "bob"}),
+    ])
+    .await
+    .unwrap();
+    sink.flush().await.unwrap();
+
+    assert!(
+        target.is_file(),
+        "single-file mode must write the exact path"
+    );
+    // No stray UUID-named files should appear alongside it.
+    let parquet_files: Vec<_> = std::fs::read_dir(tmp.path())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().and_then(|x| x.to_str()) == Some("parquet"))
+        .collect();
+    assert_eq!(
+        parquet_files.len(),
+        1,
+        "exactly one file: {parquet_files:?}"
+    );
+    assert_eq!(parquet_files[0], target);
+
+    let batches = read_file(&target).await;
+    assert_eq!(rows_in(&batches), 2);
+}
+
+#[tokio::test]
+async fn fixed_parquet_path_with_rollover_falls_back_to_uuid_files() {
+    // A fixed `.parquet` path combined with a rollover threshold is the
+    // contradictory case that emits a one-shot warn and falls back to
+    // UUID-named files in the *parent* directory (the configured filename is
+    // ignored). Exercises both the constructor warn branch and the
+    // `single_file_mode() == false` path of `next_object_path`.
+    let tmp = TempDir::new().unwrap();
+    let target = tmp.path().join("ignored.parquet");
+    let cfg = ParquetSinkConfig::local(target.to_string_lossy().to_string()).max_rows_per_file(2);
+    let sink = ParquetSink::new(cfg).await.unwrap();
+
+    // Rollover fires after each `write_chunk` whose counter reaches the cap, so
+    // write the rows in 3 separate batches of 2 to roll over three times.
+    for chunk in 0..3 {
+        let records: Vec<Value> = (0..2)
+            .map(|j| json!({"i": (chunk * 2 + j) as i64}))
+            .collect();
+        sink.write_batch(&records).await.unwrap();
+    }
+    sink.flush().await.unwrap();
+
+    // The fixed `ignored.parquet` name must NOT be the file that was written.
+    assert!(
+        !target.is_file(),
+        "the fixed filename must be ignored under rollover"
+    );
+    let files: Vec<_> = std::fs::read_dir(tmp.path())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().and_then(|x| x.to_str()) == Some("parquet"))
+        .collect();
+    // 3 batches of 2 rows with max_rows=2 → 3 rolled-over UUID files.
+    assert_eq!(
+        files.len(),
+        3,
+        "rollover should produce 3 UUID-named files, got {files:?}"
+    );
+    for f in &files {
+        let stem = f.file_stem().and_then(|s| s.to_str()).unwrap();
+        assert_ne!(stem, "ignored", "UUID name expected, not the fixed stem");
+    }
+    let total: usize = {
+        let mut t = 0;
+        for f in &files {
+            t += rows_in(&read_file(f).await);
+        }
+        t
+    };
+    assert_eq!(total, 6);
+}
+
+#[tokio::test]
+async fn explicit_schema_is_rejected_on_first_write() {
+    // The `SchemaSource::Explicit {}` branch is reserved for a future revision
+    // and must surface as a `FaucetError::Config` the first time a batch needs
+    // a schema (i.e. on the first non-empty write_chunk).
+    use faucet_sink_parquet::SchemaSource;
+
+    let tmp = TempDir::new().unwrap();
+    let cfg = ParquetSinkConfig::local(tmp.path().to_string_lossy().to_string())
+        .schema(SchemaSource::Explicit {});
+    let sink = ParquetSink::new(cfg).await.unwrap();
+
+    let err = sink
+        .write_batch(&[json!({"id": 1})])
+        .await
+        .expect_err("explicit schema must be rejected");
+    match err {
+        faucet_core::FaucetError::Config(msg) => {
+            assert!(msg.contains("explicit"), "got: {msg}");
+        }
+        other => panic!("expected Config error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn doctor_check_passes_for_writable_directory() {
+    // The local `check()` probe creates and removes a temp file in the target
+    // directory. A fresh temp dir is writable, so the probe must Pass.
+    let tmp = TempDir::new().unwrap();
+    let cfg = ParquetSinkConfig::local(tmp.path().to_string_lossy().to_string());
+    let sink = ParquetSink::new(cfg).await.unwrap();
+
+    let report = sink.check(&CheckContext::default()).await.unwrap();
+    assert_eq!(report.probes.len(), 1);
+    assert_eq!(report.probes[0].name, "io");
+    assert!(
+        matches!(report.probes[0].status, ProbeStatus::Pass),
+        "writable dir must pass, got {:?}",
+        report.probes[0].status
+    );
+    // No temp probe file should be left behind.
+    let leftovers: Vec<_> = std::fs::read_dir(tmp.path())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            e.file_name()
+                .to_str()
+                .map(|n| n.starts_with(".faucet_doctor_probe"))
+                .unwrap_or(false)
+        })
+        .collect();
+    assert!(leftovers.is_empty(), "probe file must be removed");
+}
+
+#[tokio::test]
+async fn doctor_check_fails_when_parent_directory_missing() {
+    // A `.parquet` single-file path whose parent dir does not exist must Fail
+    // with a hint to create the directory. We point at a nonexistent subdir.
+    let tmp = TempDir::new().unwrap();
+    let missing = tmp.path().join("no_such_dir").join("out.parquet");
+    let cfg = ParquetSinkConfig::local(missing.to_string_lossy().to_string());
+    // `new()` calls build_store which create_dir_all's the parent — so to keep
+    // the parent missing for the probe we build the sink, then remove the dir.
+    let sink = ParquetSink::new(cfg).await.unwrap();
+    std::fs::remove_dir_all(tmp.path().join("no_such_dir")).unwrap();
+
+    let report = sink.check(&CheckContext::default()).await.unwrap();
+    assert_eq!(report.probes.len(), 1);
+    match &report.probes[0].status {
+        ProbeStatus::Fail { reason } => {
+            assert!(reason.contains("does not exist"), "got: {reason}");
+            assert!(report.probes[0].hint.is_some(), "fail must carry a hint");
+        }
+        other => panic!("expected Fail, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn doctor_check_skips_s3_destination() {
+    // For an S3 destination the doctor probe is skipped — object-store targets
+    // are not probed.
+    let cfg = ParquetSinkConfig::new(ParquetDestination::S3(ParquetS3Destination {
+        bucket: "b".to_string(),
+        prefix: "p/".to_string(),
+        region: Some("us-east-1".to_string()),
+        endpoint_url: Some("http://localhost:4566".to_string()),
+        allow_http: true,
+    }));
+    // SAFETY: constants; concurrent writes converge to the same value (mirrors
+    // the existing `s3_destination_builds_*` test in roundtrip.rs).
+    unsafe {
+        std::env::set_var("AWS_ACCESS_KEY_ID", "test");
+        std::env::set_var("AWS_SECRET_ACCESS_KEY", "test");
+    }
+    let sink = ParquetSink::new(cfg).await.unwrap();
+
+    let report = sink.check(&CheckContext::default()).await.unwrap();
+    assert_eq!(report.probes.len(), 1);
+    assert!(
+        matches!(report.probes[0].status, ProbeStatus::Skip { .. }),
+        "S3 target must be skipped, got {:?}",
+        report.probes[0].status
+    );
+
+    // The S3 dataset_uri branch.
+    assert_eq!(sink.dataset_uri(), "s3://b/p/");
+    // config_schema serialises without panicking.
+    assert!(sink.config_schema().is_object());
+}
+
+#[tokio::test]
+async fn doctor_check_skips_object_store_url_in_local_path() {
+    // An `s3://` URL that slipped into a LocalPath destination is treated as an
+    // object-store target and skipped, not mis-probed on the local FS.
+    let cfg = ParquetSinkConfig::local("s3://bucket/key.parquet");
+    let sink = ParquetSink::new(cfg).await.unwrap();
+    let report = sink.check(&CheckContext::default()).await.unwrap();
+    assert!(
+        matches!(report.probes[0].status, ProbeStatus::Skip { .. }),
+        "s3:// in a local path must be skipped, got {:?}",
+        report.probes[0].status
+    );
+}
+
+#[tokio::test]
+async fn type_drift_reports_float_json_type_name() {
+    // The float branch of `json_value_type_name` / `sample_field_type` is hit
+    // when a field locked in as Utf8 (string) later receives a JSON float:
+    // `matches_data_type(Utf8, Number)` is false, so `guess_drifting_field`
+    // flags the field and `sample_field_type` reports its type as a float.
+    let tmp = TempDir::new().unwrap();
+    let cfg = ParquetSinkConfig::local(tmp.path().to_string_lossy().to_string());
+    let sink = ParquetSink::new(cfg).await.unwrap();
+
+    // First batch locks `n` in as a string column.
+    sink.write_batch(&[json!({"n": "label"})]).await.unwrap();
+    // A subsequent float for the same field drifts.
+    let err = sink
+        .write_batch(&[json!({"n": 2.5})])
+        .await
+        .expect_err("string→float drift must error");
+    match err {
+        faucet_core::FaucetError::Sink(msg) => {
+            assert!(
+                msg.contains("'n'") || msg.contains("n"),
+                "field named: {msg}"
+            );
+            assert!(
+                msg.contains("float") || msg.contains("Utf8"),
+                "drift message should describe the float record type / utf8 schema: {msg}"
+            );
+        }
+        other => panic!("expected Sink error, got {other:?}"),
+    }
+    sink.flush().await.unwrap();
+}
+
+#[tokio::test]
+async fn lazy_writer_opens_on_first_batch_inferring_schema_from_records() {
+    // Before any write there is no file; after the first batch + flush the
+    // schema is inferred from the real records (id:Int64, name:Utf8). This
+    // documents the lazy-open contract end-to-end.
+    let tmp = TempDir::new().unwrap();
+    let target = tmp.path().join("lazy.parquet");
+    let cfg = ParquetSinkConfig::local(target.to_string_lossy().to_string());
+    let sink = ParquetSink::new(cfg).await.unwrap();
+
+    // No batch written yet → no file.
+    assert!(!target.is_file());
+
+    sink.write_batch(&[json!({"id": 1, "name": "x"})])
+        .await
+        .unwrap();
+    sink.flush().await.unwrap();
+
+    let batches = read_file(&target).await;
+    assert_eq!(rows_in(&batches), 1);
+    let schema = batches[0].schema();
+    assert_eq!(
+        schema.field_with_name("id").unwrap().data_type(),
+        &arrow::datatypes::DataType::Int64
+    );
+    assert_eq!(
+        schema.field_with_name("name").unwrap().data_type(),
+        &arrow::datatypes::DataType::Utf8
+    );
+}

--- a/crates/sink/postgres/tests/idempotency.rs
+++ b/crates/sink/postgres/tests/idempotency.rs
@@ -1,0 +1,308 @@
+//! Integration tests for [`PostgresSink`]'s exactly-once / idempotent write
+//! path and its AutoMap edge/error branches, against a real Postgres instance
+//! via testcontainers.
+//!
+//! These tests require Docker. Each test boots its own container so they are
+//! fully isolated and safe to run in parallel.
+
+use faucet_core::Sink;
+use faucet_core::check::ProbeStatus;
+use faucet_core::idempotency::{
+    COMMIT_TOKEN_SCOPE_COL, COMMIT_TOKEN_TABLE, COMMIT_TOKEN_TOKEN_COL, format_token,
+};
+use faucet_sink_postgres::{PostgresColumnMapping, PostgresSink, PostgresSinkConfig};
+use serde_json::json;
+use sqlx::Row;
+use testcontainers::{ContainerAsync, ImageExt, runners::AsyncRunner};
+use testcontainers_modules::postgres::Postgres;
+
+/// Start a Postgres container and return both the container handle and a
+/// connection URL.
+async fn start_postgres() -> (ContainerAsync<Postgres>, String) {
+    let image = Postgres::default().with_tag("16-alpine");
+    let container: ContainerAsync<Postgres> =
+        image.start().await.expect("postgres container start");
+    let port = container
+        .get_host_port_ipv4(5432)
+        .await
+        .expect("postgres port");
+    let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
+    (container, url)
+}
+
+/// Create a single-JSONB-column `events` table.
+async fn create_jsonb_table(url: &str) {
+    let pool = sqlx::PgPool::connect(url).await.expect("pool connect");
+    sqlx::query("CREATE TABLE events (data JSONB NOT NULL)")
+        .execute(&pool)
+        .await
+        .expect("create table");
+    pool.close().await;
+}
+
+async fn jsonb_row_count(url: &str) -> i64 {
+    let pool = sqlx::PgPool::connect(url).await.expect("pool connect");
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*)::BIGINT FROM events")
+        .fetch_one(&pool)
+        .await
+        .expect("count");
+    pool.close().await;
+    count
+}
+
+/// Read the stored commit token for `scope` directly from the watermark table.
+async fn stored_token(url: &str, scope: &str) -> Option<String> {
+    let pool = sqlx::PgPool::connect(url).await.expect("pool connect");
+    let sql = format!(
+        "SELECT \"{COMMIT_TOKEN_TOKEN_COL}\" FROM \"{COMMIT_TOKEN_TABLE}\" \
+         WHERE \"{COMMIT_TOKEN_SCOPE_COL}\" = $1"
+    );
+    let row = sqlx::query(&sql)
+        .bind(scope)
+        .fetch_optional(&pool)
+        .await
+        .expect("token read");
+    pool.close().await;
+    row.map(|r| r.get::<String, _>(0))
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn idempotent_write_persists_data_and_token_atomically() {
+    let (_container, url) = start_postgres().await;
+    create_jsonb_table(&url).await;
+
+    let config = PostgresSinkConfig::new(&url, "events").with_batch_size(0);
+    let sink = PostgresSink::new(config).await.expect("sink new");
+
+    assert!(
+        sink.supports_idempotent_writes(),
+        "postgres sink advertises idempotent writes"
+    );
+
+    // No token committed yet for a fresh scope.
+    assert_eq!(
+        sink.last_committed_token("scope-a")
+            .await
+            .expect("token read"),
+        None,
+        "fresh scope has no committed token"
+    );
+
+    let token = format_token(1);
+    let records = vec![json!({"k": "v1"}), json!({"k": "v2"})];
+    let written = sink
+        .write_batch_idempotent(&records, "scope-a", &token)
+        .await
+        .expect("idempotent write");
+    assert_eq!(written, 2);
+
+    // Data landed.
+    assert_eq!(jsonb_row_count(&url).await, 2);
+    // Token landed in the same commit and is readable both via the trait and
+    // directly from the watermark table.
+    assert_eq!(
+        sink.last_committed_token("scope-a")
+            .await
+            .expect("token read")
+            .as_deref(),
+        Some(token.as_str())
+    );
+    assert_eq!(
+        stored_token(&url, "scope-a").await.as_deref(),
+        Some(token.as_str())
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn idempotent_write_upserts_token_on_repeat_scope() {
+    let (_container, url) = start_postgres().await;
+    create_jsonb_table(&url).await;
+
+    let config = PostgresSinkConfig::new(&url, "events").with_batch_size(0);
+    let sink = PostgresSink::new(config).await.expect("sink new");
+
+    let t1 = format_token(1);
+    let t2 = format_token(2);
+    sink.write_batch_idempotent(&[json!({"n": 1})], "s", &t1)
+        .await
+        .expect("write 1");
+    sink.write_batch_idempotent(&[json!({"n": 2})], "s", &t2)
+        .await
+        .expect("write 2");
+
+    // Both inserts landed; the watermark advanced to the newer token (ON
+    // CONFLICT DO UPDATE), not duplicated.
+    assert_eq!(jsonb_row_count(&url).await, 2);
+    assert_eq!(
+        sink.last_committed_token("s")
+            .await
+            .expect("read")
+            .as_deref(),
+        Some(t2.as_str()),
+        "watermark must advance to the latest token"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn idempotent_write_auto_map_mode_commits_data_and_token() {
+    // Exercises the AutoMap branch inside write_batch_idempotent's transaction.
+    let (_container, url) = start_postgres().await;
+    let pool = sqlx::PgPool::connect(&url).await.expect("pool connect");
+    sqlx::query("CREATE TABLE rows_t (id BIGINT, name TEXT)")
+        .execute(&pool)
+        .await
+        .expect("create table");
+    pool.close().await;
+
+    let config = PostgresSinkConfig::new(&url, "rows_t")
+        .column_mapping(PostgresColumnMapping::AutoMap)
+        .with_batch_size(0);
+    let sink = PostgresSink::new(config).await.expect("sink new");
+
+    let token = format_token(5);
+    let written = sink
+        .write_batch_idempotent(&[json!({"id": 9, "name": "z"})], "auto-scope", &token)
+        .await
+        .expect("idempotent automap write");
+    assert_eq!(written, 1);
+
+    let pool = sqlx::PgPool::connect(&url).await.expect("pool connect");
+    let name: String = sqlx::query_scalar("SELECT name FROM rows_t WHERE id = 9")
+        .fetch_one(&pool)
+        .await
+        .expect("read back");
+    pool.close().await;
+    assert_eq!(name, "z");
+    assert_eq!(
+        sink.last_committed_token("auto-scope")
+            .await
+            .expect("read")
+            .as_deref(),
+        Some(token.as_str())
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn auto_map_into_missing_table_errors_with_no_columns() {
+    // AutoMap discovery against a non-existent relation returns zero columns,
+    // surfacing the typed "no columns or does not exist" error.
+    let (_container, url) = start_postgres().await;
+
+    let config = PostgresSinkConfig::new(&url, "does_not_exist")
+        .column_mapping(PostgresColumnMapping::AutoMap)
+        .with_batch_size(0);
+    let sink = PostgresSink::new(config).await.expect("sink new");
+
+    let err = sink
+        .write_batch(&[json!({"a": 1})])
+        .await
+        .expect_err("missing table must error");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("no columns or does not exist"),
+        "must surface the missing-table error; got: {msg}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn auto_map_skips_records_with_no_matching_columns_then_noop() {
+    // A record whose keys match no table column is skipped (logged warn). When
+    // EVERY record is skipped, matched_rows is empty and write_batch returns 0
+    // without issuing an INSERT.
+    let (_container, url) = start_postgres().await;
+    let pool = sqlx::PgPool::connect(&url).await.expect("pool connect");
+    sqlx::query("CREATE TABLE t (id BIGINT, name TEXT)")
+        .execute(&pool)
+        .await
+        .expect("create table");
+    pool.close().await;
+
+    let config = PostgresSinkConfig::new(&url, "t")
+        .column_mapping(PostgresColumnMapping::AutoMap)
+        .with_batch_size(0);
+    let sink = PostgresSink::new(config).await.expect("sink new");
+
+    // Neither key matches `id`/`name`.
+    let written = sink
+        .write_batch(&[json!({"nope": 1}), json!({"other": 2})])
+        .await
+        .expect("write");
+    assert_eq!(written, 0, "all records skipped → zero written");
+
+    let pool = sqlx::PgPool::connect(&url).await.expect("pool connect");
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*)::BIGINT FROM t")
+        .fetch_one(&pool)
+        .await
+        .expect("count");
+    pool.close().await;
+    assert_eq!(count, 0, "no INSERT issued when nothing matches");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn auto_map_non_object_record_errors() {
+    // AutoMap requires JSON object records; a scalar surfaces a typed error.
+    let (_container, url) = start_postgres().await;
+    let pool = sqlx::PgPool::connect(&url).await.expect("pool connect");
+    sqlx::query("CREATE TABLE t (id BIGINT)")
+        .execute(&pool)
+        .await
+        .expect("create table");
+    pool.close().await;
+
+    let config = PostgresSinkConfig::new(&url, "t")
+        .column_mapping(PostgresColumnMapping::AutoMap)
+        .with_batch_size(0);
+    let sink = PostgresSink::new(config).await.expect("sink new");
+
+    let err = sink
+        .write_batch(&[json!(42)])
+        .await
+        .expect_err("non-object must error");
+    assert!(
+        err.to_string()
+            .contains("AutoMap requires JSON object records"),
+        "got: {err}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn check_passes_against_live_server_and_metadata_methods() {
+    let (_container, url) = start_postgres().await;
+    create_jsonb_table(&url).await;
+
+    let config = PostgresSinkConfig::new(&url, "events").with_schema("public");
+    let sink = PostgresSink::new(config).await.expect("sink new");
+
+    // config_schema is a JSON object schema.
+    let schema = sink.config_schema();
+    assert!(schema.get("properties").is_some(), "schema: {schema}");
+
+    // dataset_uri redacts credentials and includes the schema-qualified table.
+    let uri = sink.dataset_uri();
+    assert!(
+        !uri.contains("postgres:postgres"),
+        "credentials leaked: {uri}"
+    );
+    assert!(
+        uri.contains("table=public.events"),
+        "dataset_uri must carry the schema-qualified table: {uri}"
+    );
+
+    // check(): SELECT 1 against a reachable DB → single passing "auth" probe.
+    let report = sink
+        .check(&faucet_core::check::CheckContext::default())
+        .await
+        .expect("check");
+    assert_eq!(report.probes.len(), 1);
+    assert_eq!(report.probes[0].name, "auth");
+    assert!(
+        matches!(report.probes[0].status, ProbeStatus::Pass),
+        "auth probe must pass: {:?}",
+        report.probes[0].status
+    );
+
+    // write_batch with empty input is a no-op returning 0.
+    assert_eq!(sink.write_batch(&[]).await.expect("empty"), 0);
+    // A Value::Null record contributes nothing under JSONB unnest semantics but
+    // the call still succeeds; assert the empty fast-path explicitly above.
+}

--- a/crates/sink/redis/tests/paths.rs
+++ b/crates/sink/redis/tests/paths.rs
@@ -1,0 +1,293 @@
+//! Integration tests for the Redis sink's per-mode write paths, the
+//! `dataset_uri` / `config_schema` introspection surface, and the `check`
+//! preflight probe. Each test boots its own Redis container via
+//! testcontainers, drives the sink, and asserts the resulting Redis state or
+//! the exact returned value / error.
+//!
+//! These tests require Docker.
+
+use faucet_core::Sink;
+use faucet_sink_redis::{RedisSink, RedisSinkConfig, RedisSinkType};
+use redis::AsyncCommands;
+use serde_json::{Value, json};
+use testcontainers::{ContainerAsync, runners::AsyncRunner};
+use testcontainers_modules::redis::{REDIS_PORT, Redis};
+
+/// Boot a Redis container, return both the handle (keep alive for the
+/// container's lifetime) and a verified connection URL.
+async fn start_redis() -> (ContainerAsync<Redis>, String) {
+    let container: ContainerAsync<Redis> = Redis::default()
+        .start()
+        .await
+        .expect("redis container start");
+    let host = container.get_host().await.expect("redis host");
+    let port = container
+        .get_host_port_ipv4(REDIS_PORT)
+        .await
+        .expect("redis port");
+    let url = format!("redis://{host}:{port}");
+    let _ = open_conn(&url).await;
+    (container, url)
+}
+
+/// Multiplexed connection with short retry — the testcontainers
+/// "Ready to accept connections" log line can race with port binding.
+async fn open_conn(url: &str) -> redis::aio::MultiplexedConnection {
+    let client = redis::Client::open(url).expect("redis client open");
+    let mut last_err: Option<redis::RedisError> = None;
+    for _ in 0..30 {
+        match client.get_multiplexed_async_connection().await {
+            Ok(conn) => return conn,
+            Err(e) => {
+                last_err = Some(e);
+                tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            }
+        }
+    }
+    panic!("redis connect: {:?}", last_err);
+}
+
+// ── Introspection: dataset_uri / config_schema ────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn dataset_uri_exposes_key_for_each_mode() {
+    // The container is unauthenticated, so we can't inject credentials into the
+    // URL (new() would fail auth). Credential redaction itself lives in
+    // `faucet_core::redact_uri_credentials` (unit-tested there); here we cover
+    // all three `dataset_uri` match arms and confirm the key/key_field suffix.
+    let (_container, url) = start_redis().await;
+
+    let list = RedisSink::new(RedisSinkConfig::new(
+        &url,
+        RedisSinkType::List {
+            key: "mylist".into(),
+        },
+    ))
+    .await
+    .expect("sink build");
+    let uri = list.dataset_uri();
+    assert!(
+        uri.ends_with("?key=mylist"),
+        "list uri exposes the key: {uri}"
+    );
+    assert!(
+        uri.starts_with("redis://"),
+        "uri keeps the redis scheme: {uri}"
+    );
+
+    let stream = RedisSink::new(RedisSinkConfig::new(
+        &url,
+        RedisSinkType::Stream {
+            key: "mystream".into(),
+        },
+    ))
+    .await
+    .expect("sink build");
+    assert!(
+        stream.dataset_uri().ends_with("?key=mystream"),
+        "stream uri exposes the key"
+    );
+
+    let kv = RedisSink::new(RedisSinkConfig::new(
+        &url,
+        RedisSinkType::KeyValue {
+            key_field: "id".into(),
+        },
+    ))
+    .await
+    .expect("sink build");
+    assert!(
+        kv.dataset_uri().ends_with("?key_field=id"),
+        "key-value uri exposes the key_field"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn config_schema_describes_redis_sink_config() {
+    let (_container, url) = start_redis().await;
+    let sink = RedisSink::new(RedisSinkConfig::new(
+        &url,
+        RedisSinkType::List { key: "k".into() },
+    ))
+    .await
+    .expect("sink build");
+    let schema = sink.config_schema();
+    let props = &schema["properties"];
+    assert!(props.get("url").is_some(), "schema exposes 'url'");
+    assert!(
+        props.get("sink_type").is_some(),
+        "schema exposes 'sink_type'"
+    );
+    assert!(
+        props.get("batch_size").is_some(),
+        "schema exposes 'batch_size'"
+    );
+}
+
+// ── check() preflight probe ───────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn check_passes_against_live_redis() {
+    use faucet_core::check::{CheckContext, ProbeStatus};
+    let (_container, url) = start_redis().await;
+    let sink = RedisSink::new(RedisSinkConfig::new(
+        &url,
+        RedisSinkType::List { key: "k".into() },
+    ))
+    .await
+    .expect("sink build");
+
+    let ctx = CheckContext {
+        timeout: std::time::Duration::from_secs(5),
+    };
+    let report = sink.check(&ctx).await.expect("check ok");
+    assert_eq!(report.probes.len(), 1);
+    assert_eq!(report.probes[0].name, "ping");
+    assert!(
+        matches!(report.probes[0].status, ProbeStatus::Pass),
+        "PING against a live container must pass, got {:?}",
+        report.probes[0].status
+    );
+}
+
+// ── Stream mode: XADD with flattened fields ───────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn stream_write_batch_xadds_flattened_fields() {
+    let (_container, url) = start_redis().await;
+    let sink = RedisSink::new(RedisSinkConfig::new(
+        &url,
+        RedisSinkType::Stream {
+            key: "events".into(),
+        },
+    ))
+    .await
+    .expect("sink build");
+
+    let records = vec![json!({"name": "Alice", "age": 30})];
+    let written = sink.write_batch(&records).await.unwrap();
+    assert_eq!(written, 1);
+
+    // Read the single entry back and confirm the object's fields became the
+    // stream entry's field map (object → XADD field/value pairs).
+    let mut conn = open_conn(&url).await;
+    let reply: redis::streams::StreamRangeReply = conn.xrange_all("events").await.expect("xrange");
+    assert_eq!(reply.ids.len(), 1, "exactly one stream entry");
+    let entry = &reply.ids[0];
+    let name: String = entry.get("name").expect("name field present");
+    assert_eq!(name, "Alice");
+    let age: String = entry.get("age").expect("age field present");
+    assert_eq!(age, "30", "non-string values are stringified");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn stream_write_batch_non_object_uses_data_field_fallback() {
+    // A non-object record flattens to no fields; XADD requires ≥1 field, so
+    // the sink falls back to a single `_data` field holding the serialized
+    // record.
+    let (_container, url) = start_redis().await;
+    let sink = RedisSink::new(RedisSinkConfig::new(
+        &url,
+        RedisSinkType::Stream {
+            key: "scalars".into(),
+        },
+    ))
+    .await
+    .expect("sink build");
+
+    let records = vec![json!("just a string")];
+    let written = sink.write_batch(&records).await.unwrap();
+    assert_eq!(written, 1);
+
+    let mut conn = open_conn(&url).await;
+    let reply: redis::streams::StreamRangeReply = conn.xrange_all("scalars").await.expect("xrange");
+    assert_eq!(reply.ids.len(), 1);
+    let data: String = reply.ids[0].get("_data").expect("_data field present");
+    assert_eq!(
+        data, "\"just a string\"",
+        "the whole record is serialized into the _data field"
+    );
+}
+
+// ── KeyValue mode: SET keyed by a record field ────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn key_value_write_batch_sets_string_keyed_records() {
+    let (_container, url) = start_redis().await;
+    let sink = RedisSink::new(RedisSinkConfig::new(
+        &url,
+        RedisSinkType::KeyValue {
+            key_field: "id".into(),
+        },
+    ))
+    .await
+    .expect("sink build");
+
+    // One string-valued key, one numeric key (numeric is stringified via
+    // `other.to_string()`).
+    let records = vec![json!({"id": "alpha", "v": 1}), json!({"id": 99, "v": 2})];
+    let written = sink.write_batch(&records).await.unwrap();
+    assert_eq!(written, 2);
+
+    let mut conn = open_conn(&url).await;
+    let alpha: String = conn.get("alpha").await.expect("get alpha");
+    let parsed: Value = serde_json::from_str(&alpha).unwrap();
+    assert_eq!(parsed["v"], json!(1));
+    // A numeric key field becomes the string "99".
+    let ninety_nine: String = conn.get("99").await.expect("get 99");
+    let parsed: Value = serde_json::from_str(&ninety_nine).unwrap();
+    assert_eq!(parsed["v"], json!(2));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn key_value_write_batch_missing_key_field_errors() {
+    let (_container, url) = start_redis().await;
+    let sink = RedisSink::new(RedisSinkConfig::new(
+        &url,
+        RedisSinkType::KeyValue {
+            key_field: "id".into(),
+        },
+    ))
+    .await
+    .expect("sink build");
+
+    // Record lacks the configured `id` key field → typed Sink error.
+    let records = vec![json!({"name": "no-id-here"})];
+    match sink.write_batch(&records).await {
+        Err(faucet_core::FaucetError::Sink(m)) => {
+            assert!(
+                m.contains("missing key field 'id'"),
+                "error must name the missing field, got: {m}"
+            );
+        }
+        other => panic!("expected a Sink error, got {other:?}"),
+    }
+
+    // Nothing should have been written.
+    let mut conn = open_conn(&url).await;
+    let size: usize = redis::cmd("DBSIZE")
+        .query_async(&mut conn)
+        .await
+        .expect("dbsize");
+    assert_eq!(size, 0, "the failed batch must not write any keys");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn stream_write_batch_empty_input_is_zero_writes() {
+    let (_container, url) = start_redis().await;
+    let sink = RedisSink::new(RedisSinkConfig::new(
+        &url,
+        RedisSinkType::Stream {
+            key: "untouched".into(),
+        },
+    ))
+    .await
+    .expect("sink build");
+
+    let written = sink.write_batch(&[]).await.unwrap();
+    assert_eq!(written, 0);
+
+    let mut conn = open_conn(&url).await;
+    let exists: bool = conn.exists("untouched").await.expect("exists");
+    assert!(!exists, "empty input must create no stream");
+}

--- a/crates/sink/snowflake/src/sink.rs
+++ b/crates/sink/snowflake/src/sink.rs
@@ -598,6 +598,81 @@ mod tests {
     }
 
     #[test]
+    fn check_statement_code_maps_non_success_code_to_sink_error() {
+        // The error branch of `check_statement_code`: any code other than
+        // 090001 surfaces as a `FaucetError::Sink` carrying the code + message.
+        let resp = SnowflakeResponse {
+            message: Some("Object does not exist".into()),
+            code: Some("002003".into()),
+            statement_handle: None,
+        };
+        match check_statement_code(&resp) {
+            Err(FaucetError::Sink(msg)) => {
+                assert!(msg.contains("002003"), "msg: {msg}");
+                assert!(msg.contains("Object does not exist"), "msg: {msg}");
+            }
+            other => panic!("expected a Sink error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn check_statement_code_accepts_success_and_missing_code() {
+        let ok = SnowflakeResponse {
+            message: None,
+            code: Some("090001".into()),
+            statement_handle: None,
+        };
+        assert!(check_statement_code(&ok).is_ok());
+        let no_code = SnowflakeResponse {
+            message: None,
+            code: None,
+            statement_handle: None,
+        };
+        assert!(check_statement_code(&no_code).is_ok());
+    }
+
+    #[test]
+    fn build_insert_rejects_non_object_record() {
+        // A non-object record (here a JSON array) must surface a typed Sink
+        // error rather than panicking.
+        let config = SnowflakeSinkConfig::new(
+            "acct",
+            "wh",
+            "db",
+            "schema",
+            "events",
+            SnowflakeAuth::OAuth { token: "t".into() },
+        );
+        let sink = SnowflakeSink::new(config).unwrap();
+        let records = vec![serde_json::json!([1, 2, 3])];
+        match sink.build_insert(&records) {
+            Err(FaucetError::Sink(msg)) => {
+                assert!(msg.contains("requires JSON object records"), "msg: {msg}")
+            }
+            other => panic!("expected a Sink error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn config_schema_reports_required_fields() {
+        let config = SnowflakeSinkConfig::new(
+            "acct",
+            "wh",
+            "db",
+            "schema",
+            "events",
+            SnowflakeAuth::OAuth { token: "t".into() },
+        );
+        let sink = SnowflakeSink::new(config).unwrap();
+        let schema = sink.config_schema();
+        assert!(schema["properties"]["account"].is_object());
+        assert!(schema["properties"]["table"].is_object());
+        let required = schema["required"].as_array().expect("required array");
+        assert!(required.iter().any(|v| v == "account"));
+        assert!(required.iter().any(|v| v == "table"));
+    }
+
+    #[test]
     fn build_insert_rejects_all_empty_records() {
         let config = SnowflakeSinkConfig::new(
             "acct",

--- a/crates/sink/snowflake/tests/error_paths.rs
+++ b/crates/sink/snowflake/tests/error_paths.rs
@@ -1,0 +1,193 @@
+//! Integration tests for the Snowflake sink's error-handling and preflight
+//! (`faucet doctor`) paths against a wiremock server. No live Snowflake.
+//!
+//! Covers:
+//! - a synchronous HTTP non-success → `FaucetError::Sink` with the status/body,
+//! - a non-`090001` code in a 200 body → `FaucetError::Sink`,
+//! - the async-poll HTTP-error and unparseable-body paths,
+//! - the `check()` probe (pass on `SELECT 1` success, fail on an error response).
+
+use faucet_core::check::{CheckContext, ProbeStatus};
+use faucet_core::{FaucetError, Sink};
+use faucet_sink_snowflake::{SnowflakeAuth, SnowflakeSink, SnowflakeSinkConfig};
+use serde_json::{Value, json};
+use wiremock::matchers::{body_partial_json, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn sample_config() -> SnowflakeSinkConfig {
+    SnowflakeSinkConfig::new(
+        "xy12345",
+        "WH",
+        "DB",
+        "PUBLIC",
+        "events",
+        SnowflakeAuth::OAuth {
+            token: "tok".into(),
+        },
+    )
+}
+
+fn endpoint(server: &MockServer) -> String {
+    format!("{}/api/v2/statements", server.uri())
+}
+
+fn record() -> Vec<Value> {
+    vec![json!({"id": 1, "name": "row"})]
+}
+
+#[tokio::test]
+async fn http_error_surfaces_as_sink_error_with_status_and_body() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/v2/statements"))
+        .respond_with(ResponseTemplate::new(400).set_body_string("bad request body"))
+        .mount(&server)
+        .await;
+
+    let sink = SnowflakeSink::new(sample_config())
+        .unwrap()
+        .with_endpoint(endpoint(&server));
+    let err = sink.write_batch(&record()).await.unwrap_err();
+    match err {
+        FaucetError::Sink(msg) => {
+            assert!(msg.contains("HTTP 400"), "msg: {msg}");
+            assert!(msg.contains("bad request body"), "msg: {msg}");
+        }
+        other => panic!("expected Sink error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn non_success_code_in_200_body_surfaces_as_sink_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/v2/statements"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "code": "002003",
+            "message": "SQL compilation error: Object does not exist"
+        })))
+        .mount(&server)
+        .await;
+
+    let sink = SnowflakeSink::new(sample_config())
+        .unwrap()
+        .with_endpoint(endpoint(&server));
+    let err = sink.write_batch(&record()).await.unwrap_err();
+    match err {
+        FaucetError::Sink(msg) => {
+            assert!(msg.contains("002003"), "msg: {msg}");
+            assert!(msg.contains("Object does not exist"), "msg: {msg}");
+        }
+        other => panic!("expected Sink error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn async_poll_http_error_surfaces_as_sink_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/v2/statements"))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+            "statementHandle": "poll-err"
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/api/v2/statements/poll-err"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("server exploded"))
+        .mount(&server)
+        .await;
+
+    let sink = SnowflakeSink::new(sample_config())
+        .unwrap()
+        .with_endpoint(endpoint(&server));
+    let err = sink.write_batch(&record()).await.unwrap_err();
+    match err {
+        FaucetError::Sink(msg) => {
+            assert!(msg.contains("poll returned HTTP 500"), "msg: {msg}");
+            assert!(msg.contains("server exploded"), "msg: {msg}");
+        }
+        other => panic!("expected Sink error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn async_poll_unparseable_body_surfaces_as_sink_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/v2/statements"))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+            "statementHandle": "poll-parse"
+        })))
+        .mount(&server)
+        .await;
+    // 200 but a non-JSON body → the poll-response parse fails.
+    Mock::given(method("GET"))
+        .and(path("/api/v2/statements/poll-parse"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("definitely not json"))
+        .mount(&server)
+        .await;
+
+    let sink = SnowflakeSink::new(sample_config())
+        .unwrap()
+        .with_endpoint(endpoint(&server));
+    let err = sink.write_batch(&record()).await.unwrap_err();
+    match err {
+        FaucetError::Sink(msg) => assert!(
+            msg.contains("failed to parse Snowflake poll response"),
+            "msg: {msg}"
+        ),
+        other => panic!("expected Sink error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn check_passes_on_select_1_success() {
+    let server = MockServer::start().await;
+    // The probe must run a read-only `SELECT 1`, not an INSERT.
+    Mock::given(method("POST"))
+        .and(path("/api/v2/statements"))
+        .and(body_partial_json(json!({"statement": "SELECT 1"})))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "code": "090001",
+            "message": "Statement executed successfully"
+        })))
+        .mount(&server)
+        .await;
+
+    let sink = SnowflakeSink::new(sample_config())
+        .unwrap()
+        .with_endpoint(endpoint(&server));
+    let report = sink.check(&CheckContext::default()).await.unwrap();
+    let probe = &report.probes[0];
+    assert_eq!(probe.name, "auth");
+    assert!(
+        matches!(probe.status, ProbeStatus::Pass),
+        "expected a passing probe, got {:?}",
+        probe.status
+    );
+}
+
+#[tokio::test]
+async fn check_fails_on_error_response() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/v2/statements"))
+        .respond_with(ResponseTemplate::new(401).set_body_string("invalid token"))
+        .mount(&server)
+        .await;
+
+    let sink = SnowflakeSink::new(sample_config())
+        .unwrap()
+        .with_endpoint(endpoint(&server));
+    let report = sink.check(&CheckContext::default()).await.unwrap();
+    let probe = &report.probes[0];
+    assert_eq!(probe.name, "auth");
+    match &probe.status {
+        ProbeStatus::Fail { reason } => {
+            assert!(reason.contains("SELECT 1 failed"), "reason: {reason}");
+            assert!(reason.contains("401"), "reason: {reason}");
+        }
+        other => panic!("expected a Fail probe, got {other:?}"),
+    }
+}

--- a/crates/source/bigquery/tests/bigquery_source.rs
+++ b/crates/source/bigquery/tests/bigquery_source.rs
@@ -298,3 +298,362 @@ async fn submits_positional_bindings_for_params_and_context() {
     assert_eq!(params[1]["parameterValue"]["value"], "100");
     assert_eq!(body["location"], "EU");
 }
+
+#[tokio::test]
+async fn fetch_all_decodes_all_bigquery_types_to_json() {
+    // Type-aware decoding end-to-end through `jobs.query`: INTEGER, FLOAT,
+    // BOOL, STRING, TIMESTAMP, a nested RECORD, and a REPEATED column all
+    // round-trip into the expected JSON shapes.
+    let server = MockServer::start().await;
+    mount_token(&server).await;
+
+    let schema = json!({
+        "fields": [
+            {"name": "id", "type": "INTEGER"},
+            {"name": "ratio", "type": "FLOAT"},
+            {"name": "active", "type": "BOOLEAN"},
+            {"name": "label", "type": "STRING"},
+            {"name": "ts", "type": "TIMESTAMP"},
+            {"name": "tags", "type": "STRING", "mode": "REPEATED"},
+            {
+                "name": "owner",
+                "type": "RECORD",
+                "fields": [
+                    {"name": "uid", "type": "INTEGER"},
+                    {"name": "email", "type": "STRING"}
+                ]
+            }
+        ]
+    });
+    // A single row exercising every cell shape BigQuery returns.
+    let row = json!({"f": [
+        {"v": "42"},
+        {"v": "2.5"},
+        {"v": "true"},
+        {"v": "hello"},
+        {"v": "1.7e9"},
+        {"v": [{"v": "a"}, {"v": "b"}]},
+        {"v": {"f": [{"v": "7"}, {"v": "x@y.z"}]}}
+    ]});
+
+    Mock::given(method("POST"))
+        .and(path(format!("/projects/{PROJECT_ID}/queries")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jobComplete": true,
+            "schema": schema,
+            "jobReference": {"projectId": PROJECT_ID, "jobId": "job-types"},
+            "rows": [row],
+        })))
+        .mount(&server)
+        .await;
+
+    let (src, _f) = build_source(&server, default_config()).await;
+    let rows = src.fetch_all().await.unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0],
+        json!({
+            "id": 42,
+            "ratio": 2.5,
+            "active": true,
+            "label": "hello",
+            "ts": "1.7e9",
+            "tags": ["a", "b"],
+            "owner": {"uid": 7, "email": "x@y.z"}
+        })
+    );
+}
+
+#[tokio::test]
+async fn fetch_all_paginates_across_three_pages_via_get_query_results() {
+    // jobs.query → page 1 (+tok-1); getQueryResults → page 2 (+tok-2);
+    // getQueryResults → page 3 (no token, final). All three pages flow
+    // through the getQueryResults polling/paging loop.
+    let server = MockServer::start().await;
+    mount_token(&server).await;
+
+    Mock::given(method("POST"))
+        .and(path(format!("/projects/{PROJECT_ID}/queries")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jobComplete": true,
+            "schema": schema_two_cols(),
+            "jobReference": {"projectId": PROJECT_ID, "jobId": "job-3pages"},
+            "rows": rows(0, 4),
+            "pageToken": "tok-1",
+        })))
+        .mount(&server)
+        .await;
+
+    // Second page carries a further pageToken so the loop iterates again.
+    Mock::given(method("GET"))
+        .and(path(format!("/projects/{PROJECT_ID}/queries/job-3pages")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jobComplete": true,
+            "schema": schema_two_cols(),
+            "rows": rows(4, 4),
+            "pageToken": "tok-2",
+        })))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    // Final page: no pageToken.
+    Mock::given(method("GET"))
+        .and(path(format!("/projects/{PROJECT_ID}/queries/job-3pages")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jobComplete": true,
+            "schema": schema_two_cols(),
+            "rows": rows(8, 2),
+        })))
+        .mount(&server)
+        .await;
+
+    let (src, _f) = build_source(&server, default_config()).await;
+    let rows = src.fetch_all().await.unwrap();
+    assert_eq!(rows.len(), 10);
+    assert_eq!(rows[0]["id"], 0);
+    assert_eq!(rows[4]["id"], 4);
+    assert_eq!(rows[9]["id"], 9);
+    assert_eq!(rows[9]["name"], "name-9");
+}
+
+#[tokio::test]
+async fn stream_pages_initial_response_without_rows_then_paginates() {
+    // jobs.query returns a complete-but-rowless first response carrying only a
+    // pageToken (exercises `rows_from_response_owned`'s None branch); the
+    // actual rows arrive via getQueryResults.
+    let server = MockServer::start().await;
+    mount_token(&server).await;
+
+    Mock::given(method("POST"))
+        .and(path(format!("/projects/{PROJECT_ID}/queries")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jobComplete": true,
+            "schema": schema_two_cols(),
+            "jobReference": {"projectId": PROJECT_ID, "jobId": "job-norows"},
+            "pageToken": "tok-1",
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("/projects/{PROJECT_ID}/queries/job-norows")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jobComplete": true,
+            "schema": schema_two_cols(),
+            "rows": rows(0, 3),
+        })))
+        .mount(&server)
+        .await;
+
+    let (src, _f) = build_source(&server, default_config().with_batch_size(0)).await;
+    let ctx = HashMap::new();
+    let pages: Vec<_> = src.stream_pages(&ctx, 0).collect().await;
+    assert_eq!(pages.len(), 1);
+    let page = pages[0].as_ref().unwrap();
+    assert_eq!(page.records.len(), 3);
+    assert_eq!(page.records[0], json!({"id": 0, "name": "name-0"}));
+}
+
+#[tokio::test]
+async fn fetch_all_errors_when_job_query_returns_non_2xx() {
+    let server = MockServer::start().await;
+    mount_token(&server).await;
+    Mock::given(method("POST"))
+        .and(path(format!("/projects/{PROJECT_ID}/queries")))
+        .respond_with(ResponseTemplate::new(403).set_body_json(json!({
+            "error": {"code": 403, "message": "Access Denied"}
+        })))
+        .mount(&server)
+        .await;
+
+    let (src, _f) = build_source(&server, default_config()).await;
+    match src.fetch_all().await {
+        Err(faucet_core::FaucetError::Source(m)) => {
+            assert!(m.contains("jobs.query failed"), "got: {m}");
+        }
+        other => panic!("expected Source error, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn fetch_all_errors_when_get_query_results_returns_non_2xx() {
+    let server = MockServer::start().await;
+    mount_token(&server).await;
+    // First page completes with a token, forcing a getQueryResults call.
+    Mock::given(method("POST"))
+        .and(path(format!("/projects/{PROJECT_ID}/queries")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jobComplete": true,
+            "schema": schema_two_cols(),
+            "jobReference": {"projectId": PROJECT_ID, "jobId": "job-getfail"},
+            "rows": rows(0, 1),
+            "pageToken": "tok-1",
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(format!("/projects/{PROJECT_ID}/queries/job-getfail")))
+        .respond_with(ResponseTemplate::new(500).set_body_string("boom"))
+        .mount(&server)
+        .await;
+
+    let (src, _f) = build_source(&server, default_config()).await;
+    match src.fetch_all().await {
+        Err(faucet_core::FaucetError::Source(m)) => {
+            assert!(m.contains("getQueryResults failed"), "got: {m}");
+        }
+        other => panic!("expected Source error, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn fetch_all_errors_when_job_reference_missing() {
+    // A complete 200 response with rows but no jobReference must surface a
+    // typed Source error rather than silently proceeding.
+    let server = MockServer::start().await;
+    mount_token(&server).await;
+    Mock::given(method("POST"))
+        .and(path(format!("/projects/{PROJECT_ID}/queries")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jobComplete": true,
+            "schema": schema_two_cols(),
+            "rows": rows(0, 1),
+        })))
+        .mount(&server)
+        .await;
+
+    let (src, _f) = build_source(&server, default_config()).await;
+    match src.fetch_all().await {
+        Err(faucet_core::FaucetError::Source(m)) => {
+            assert!(m.contains("missing jobReference"), "got: {m}");
+        }
+        other => panic!("expected Source error, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn submits_typed_bool_and_float_param_types() {
+    // `bq_param_type` infers BOOL / FLOAT64 / INT64 from the JSON value so a
+    // numeric/boolean bind isn't forced to STRING. A JSON null becomes a typed
+    // NULL with the value omitted.
+    let server = MockServer::start().await;
+    mount_token(&server).await;
+    Mock::given(method("POST"))
+        .and(path(format!("/projects/{PROJECT_ID}/queries")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jobComplete": true,
+            "schema": schema_two_cols(),
+            "jobReference": {"projectId": PROJECT_ID, "jobId": "job-typed"},
+            "rows": rows(0, 1),
+        })))
+        .mount(&server)
+        .await;
+
+    let cfg = default_config().with_params(vec![json!(true), json!(2.5), json!(7), json!(null)]);
+    let (src, _f) = build_source(&server, cfg).await;
+    src.fetch_all().await.unwrap();
+
+    let reqs = server.received_requests().await.unwrap();
+    let query_req = reqs
+        .iter()
+        .find(|r| r.url.path().ends_with("/queries"))
+        .expect("captured jobs.query request");
+    let body: Value = serde_json::from_slice(&query_req.body).unwrap();
+    let params = body["queryParameters"].as_array().unwrap();
+    assert_eq!(params.len(), 4);
+    assert_eq!(params[0]["parameterType"]["type"], "BOOL");
+    assert_eq!(params[0]["parameterValue"]["value"], "true");
+    assert_eq!(params[1]["parameterType"]["type"], "FLOAT64");
+    assert_eq!(params[1]["parameterValue"]["value"], "2.5");
+    assert_eq!(params[2]["parameterType"]["type"], "INT64");
+    assert_eq!(params[2]["parameterValue"]["value"], "7");
+    // JSON null → typed STRING NULL: value omitted from the value object.
+    assert_eq!(params[3]["parameterType"]["type"], "STRING");
+    assert!(
+        params[3]["parameterValue"]["value"].is_null(),
+        "null bind must omit the value: {:?}",
+        params[3]
+    );
+}
+
+#[tokio::test]
+async fn connector_name_schema_and_dataset_uri_are_exposed() {
+    let server = MockServer::start().await;
+    mount_token(&server).await;
+    let mut cfg = default_config();
+    cfg.query = "SELECT 1".into();
+    let (src, _f) = build_source(&server, cfg).await;
+
+    assert_eq!(src.connector_name(), "bigquery");
+    assert_eq!(src.dataset_uri(), "bigquery://test-project?query=SELECT 1");
+    let schema = src.config_schema();
+    // schema_for! emits an object schema describing the config struct.
+    assert!(
+        schema.get("properties").is_some() || schema.get("$ref").is_some(),
+        "config_schema should be a JSON Schema object: {schema}"
+    );
+}
+
+#[tokio::test]
+async fn check_probe_passes_on_successful_dry_run() {
+    use faucet_core::check::{CheckContext, ProbeStatus};
+    let server = MockServer::start().await;
+    mount_token(&server).await;
+    // The doctor probe submits the query with dryRun=true to the same
+    // jobs.query endpoint; a 200 → a passing probe.
+    Mock::given(method("POST"))
+        .and(path(format!("/projects/{PROJECT_ID}/queries")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jobComplete": true,
+            "jobReference": {"projectId": PROJECT_ID, "jobId": "dry"},
+        })))
+        .mount(&server)
+        .await;
+
+    let (src, _f) = build_source(&server, default_config()).await;
+    let report = src.check(&CheckContext::default()).await.unwrap();
+    assert_eq!(report.probes.len(), 1);
+    assert_eq!(report.probes[0].name, "query");
+    assert!(
+        matches!(report.probes[0].status, ProbeStatus::Pass),
+        "expected Pass, got: {:?}",
+        report.probes[0].status
+    );
+
+    // And the submitted body really did carry dryRun=true.
+    let reqs = server.received_requests().await.unwrap();
+    let query_req = reqs
+        .iter()
+        .find(|r| r.url.path().ends_with("/queries"))
+        .expect("captured dry-run request");
+    let body: Value = serde_json::from_slice(&query_req.body).unwrap();
+    assert_eq!(body["dryRun"], true);
+}
+
+#[tokio::test]
+async fn check_probe_fails_on_dry_run_error() {
+    use faucet_core::check::{CheckContext, ProbeStatus};
+    let server = MockServer::start().await;
+    mount_token(&server).await;
+    Mock::given(method("POST"))
+        .and(path(format!("/projects/{PROJECT_ID}/queries")))
+        .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+            "error": {"code": 400, "message": "Syntax error"}
+        })))
+        .mount(&server)
+        .await;
+
+    let (src, _f) = build_source(&server, default_config()).await;
+    let report = src.check(&CheckContext::default()).await.unwrap();
+    assert_eq!(report.probes.len(), 1);
+    match &report.probes[0].status {
+        ProbeStatus::Fail { reason } => {
+            assert!(reason.contains("dry-run failed"), "got: {reason}");
+        }
+        other => panic!("expected Fail, got: {other:?}"),
+    }
+    assert!(
+        report.probes[0].hint.is_some(),
+        "a failing probe should carry a remediation hint"
+    );
+}

--- a/crates/source/graphql/tests/coverage.rs
+++ b/crates/source/graphql/tests/coverage.rs
@@ -1,0 +1,463 @@
+//! Additional coverage tests for `GraphqlStream` driven against a wiremock
+//! GraphQL endpoint (no live services).
+//!
+//! These exercise paths the existing `streaming.rs` / `shared_auth_test.rs`
+//! suites leave uncovered:
+//!   * the buffered `fetch_all` / `fetch_with_context` pagination loop
+//!     (multi-page walk via `pageInfo.hasNextPage` / `endCursor`, the
+//!     `!has_next` and missing-cursor terminators, and the `max_pages` cap);
+//!   * parent-context variable injection into the GraphQL request body;
+//!   * the JSONPath records-extraction path;
+//!   * `Custom` header auth application;
+//!   * the `credential_to_auth` mapping for every shared-provider `Credential`
+//!     variant (Token / Header / Basic);
+//!   * GraphQL `errors` arrays in a 200 body surfaced as
+//!     `FaucetError::HttpStatus`;
+//!   * non-2xx HTTP surfaced as the expected `FaucetError`.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use faucet_core::{AuthProvider, Credential, FaucetError, Source};
+use faucet_source_graphql::config::{GraphqlAuth, GraphqlPagination};
+use faucet_source_graphql::{GraphqlStream, GraphqlStreamConfig};
+use serde_json::{Value, json};
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, Request, ResponseTemplate};
+
+/// Parse a wiremock request body as JSON and return the `variables` object.
+fn request_variables(req: &Request) -> Value {
+    let body: Value = serde_json::from_slice(&req.body).expect("request body is JSON");
+    body.get("variables").cloned().unwrap_or(Value::Null)
+}
+
+/// Read the `after` cursor variable from a GraphQL request body.
+fn request_cursor(req: &Request) -> Option<String> {
+    request_variables(req)
+        .get("after")
+        .and_then(|v| v.as_str().map(|s| s.to_string()))
+}
+
+/// Relay-style page payload with records `start..start+n` under
+/// `data.users.edges[*].node`, advertising `next_cursor` when present.
+fn make_page(start: u64, n: u64, next_cursor: Option<&str>) -> Value {
+    let edges: Vec<Value> = (start..start + n)
+        .map(|i| json!({ "node": { "id": i } }))
+        .collect();
+    json!({
+        "data": {
+            "users": {
+                "edges": edges,
+                "pageInfo": {
+                    "hasNextPage": next_cursor.is_some(),
+                    "endCursor": next_cursor,
+                }
+            }
+        }
+    })
+}
+
+/// Mount a two-page Relay endpoint: cursor `None` → page 0 (next `"c1"`),
+/// cursor `"c1"` → page 1 (final, `hasNextPage: false`).
+async fn mount_two_pages(server: &MockServer) {
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .respond_with(move |req: &Request| match request_cursor(req).as_deref() {
+            None => ResponseTemplate::new(200).set_body_json(make_page(0, 2, Some("c1"))),
+            Some("c1") => ResponseTemplate::new(200).set_body_json(make_page(2, 2, None)),
+            other => panic!("unexpected cursor {other:?}"),
+        })
+        .mount(server)
+        .await;
+}
+
+fn relay_config(server: &MockServer) -> GraphqlStreamConfig {
+    GraphqlStreamConfig::new(
+        format!("{}/graphql", server.uri()),
+        "query($first: Int, $after: String) { users(first: $first, after: $after) { \
+         edges { node { id } } pageInfo { hasNextPage endCursor } } }",
+    )
+    .records_path("$.data.users.edges[*].node")
+    .pagination(GraphqlPagination {
+        has_next_page_path: "$.data.users.pageInfo.hasNextPage".into(),
+        cursor_path: "$.data.users.pageInfo.endCursor".into(),
+        cursor_variable: "after".into(),
+        page_size_variable: "first".into(),
+    })
+    .with_batch_size(2)
+}
+
+/// `fetch_all` must walk every page until `hasNextPage: false`, advancing the
+/// `after` cursor with `endCursor`, and concatenate the extracted records.
+#[tokio::test(flavor = "multi_thread")]
+async fn fetch_all_walks_cursor_pages_until_has_next_page_false() {
+    let server = MockServer::start().await;
+    mount_two_pages(&server).await;
+
+    let source = GraphqlStream::new(relay_config(&server));
+    let records = source.fetch_all().await.expect("fetch_all ok");
+
+    let ids: Vec<u64> = records
+        .iter()
+        .map(|r| r["id"].as_u64().expect("id is a number"))
+        .collect();
+    assert_eq!(
+        ids,
+        vec![0, 1, 2, 3],
+        "both pages must be walked and concatenated in order"
+    );
+
+    // Exactly two requests: page 0 (after=None) then page 1 (after=c1).
+    let requests = server.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 2, "exactly two upstream pages fetched");
+    assert_eq!(request_cursor(&requests[0]), None);
+    assert_eq!(request_cursor(&requests[1]), Some("c1".to_string()));
+    // The page-size variable carries `batch_size`.
+    assert_eq!(request_variables(&requests[0])["first"].as_u64(), Some(2));
+}
+
+/// `max_pages` caps the buffered `fetch_all` walk at the configured number of
+/// upstream pages even when more pages are available.
+#[tokio::test(flavor = "multi_thread")]
+async fn fetch_all_respects_max_pages_cap() {
+    let server = MockServer::start().await;
+    mount_two_pages(&server).await;
+
+    let source = GraphqlStream::new(relay_config(&server).max_pages(1));
+    let records = source.fetch_all().await.expect("fetch_all ok");
+
+    let ids: Vec<u64> = records.iter().map(|r| r["id"].as_u64().unwrap()).collect();
+    assert_eq!(ids, vec![0, 1], "max_pages=1 stops after the first page");
+
+    let requests = server.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1, "max_pages=1 issues exactly one request");
+}
+
+/// `fetch_all` stops when the server reports `hasNextPage: false` even on the
+/// very first page (single-page result set).
+#[tokio::test(flavor = "multi_thread")]
+async fn fetch_all_single_page_stops_immediately() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(make_page(0, 3, None)))
+        .mount(&server)
+        .await;
+
+    let source = GraphqlStream::new(relay_config(&server));
+    let records = source.fetch_all().await.expect("fetch_all ok");
+    assert_eq!(records.len(), 3);
+
+    let requests = server.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1, "a single non-next page ends pagination");
+}
+
+/// `fetch_all` stops when the server claims `hasNextPage: true` but provides no
+/// `endCursor` — advancing is impossible, so the walk terminates without
+/// re-fetching (the missing-cursor terminator).
+#[tokio::test(flavor = "multi_thread")]
+async fn fetch_all_stops_when_next_cursor_is_absent() {
+    let server = MockServer::start().await;
+    // hasNextPage=true but endCursor=null.
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": {
+                "users": {
+                    "edges": [{ "node": { "id": 0 } }],
+                    "pageInfo": { "hasNextPage": true, "endCursor": null }
+                }
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let source = GraphqlStream::new(relay_config(&server));
+    let records = source.fetch_all().await.expect("fetch_all ok");
+    assert_eq!(records.len(), 1);
+
+    let requests = server.received_requests().await.unwrap();
+    assert_eq!(
+        requests.len(),
+        1,
+        "a null endCursor must stop the walk after one request"
+    );
+}
+
+/// Parent context values are merged into the GraphQL request `variables` via
+/// `fetch_with_context`, alongside the injected cursor / page-size variables.
+#[tokio::test(flavor = "multi_thread")]
+async fn fetch_with_context_injects_parent_variables() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .respond_with(move |req: &Request| {
+            let vars = request_variables(req);
+            // Parent context value merged into variables verbatim.
+            assert_eq!(vars["org"], json!("acme"), "parent context var injected");
+            assert_eq!(vars["region"], json!("us-east-1"));
+            ResponseTemplate::new(200).set_body_json(make_page(0, 1, None))
+        })
+        .mount(&server)
+        .await;
+
+    let source = GraphqlStream::new(relay_config(&server));
+    let mut ctx: HashMap<String, Value> = HashMap::new();
+    ctx.insert("org".to_string(), json!("acme"));
+    ctx.insert("region".to_string(), json!("us-east-1"));
+
+    let records = source.fetch_with_context(&ctx).await.expect("fetch ok");
+    assert_eq!(records.len(), 1);
+
+    let requests = server.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1);
+}
+
+/// `Custom` header auth applies each configured header to the request.
+#[tokio::test(flavor = "multi_thread")]
+async fn custom_header_auth_is_applied() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .and(header("x-api-key", "secret-key"))
+        .and(header("x-tenant", "acme"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(make_page(0, 1, None)))
+        .mount(&server)
+        .await;
+
+    let mut headers = HashMap::new();
+    headers.insert("X-API-Key".to_string(), "secret-key".to_string());
+    headers.insert("X-Tenant".to_string(), "acme".to_string());
+
+    let config = GraphqlStreamConfig::new(
+        format!("{}/graphql", server.uri()),
+        "query { users { edges { node { id } } } }",
+    )
+    .records_path("$.data.users.edges[*].node")
+    .auth(GraphqlAuth::Custom { headers });
+
+    let source = GraphqlStream::new(config);
+    let records = source.fetch_all().await.expect("custom-auth fetch ok");
+    assert_eq!(
+        records.len(),
+        1,
+        "request matched only with both custom headers"
+    );
+}
+
+/// A `Custom` header with an invalid header *name* surfaces as
+/// `FaucetError::Auth` rather than silently sending an unauthenticated request.
+#[tokio::test(flavor = "multi_thread")]
+async fn custom_header_auth_invalid_name_errors() {
+    let server = MockServer::start().await;
+    // No mock mounted — request must never be sent.
+
+    let mut headers = HashMap::new();
+    // A space is not a legal HTTP header-name character.
+    headers.insert("Bad Header".to_string(), "value".to_string());
+
+    let config = GraphqlStreamConfig::new(
+        format!("{}/graphql", server.uri()),
+        "query { users { edges { node { id } } } }",
+    )
+    .records_path("$.data.users.edges[*].node")
+    .auth(GraphqlAuth::Custom { headers });
+
+    let source = GraphqlStream::new(config);
+    let err = source
+        .fetch_all()
+        .await
+        .expect_err("invalid header name must error");
+    assert!(matches!(err, FaucetError::Auth(_)), "got {err:?}");
+
+    let requests = server.received_requests().await.unwrap();
+    assert!(
+        requests.is_empty(),
+        "no request leaks on invalid header name"
+    );
+}
+
+// ─── credential_to_auth mapping for every shared-provider variant ────────────
+
+/// A provider returning an arbitrary [`Credential`] for `credential_to_auth`.
+#[derive(Debug)]
+struct FixedCredential(Credential);
+
+#[async_trait::async_trait]
+impl AuthProvider for FixedCredential {
+    async fn credential(&self) -> Result<Credential, FaucetError> {
+        Ok(self.0.clone())
+    }
+    fn provider_name(&self) -> &'static str {
+        "fixed-credential"
+    }
+}
+
+async fn run_with_provider_expecting_header(
+    cred: Credential,
+    header_name: &str,
+    header_value: &str,
+) {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .and(header(header_name, header_value))
+        .respond_with(ResponseTemplate::new(200).set_body_json(make_page(0, 1, None)))
+        .mount(&server)
+        .await;
+
+    let provider = Arc::new(FixedCredential(cred));
+    let source = GraphqlStream::new(
+        GraphqlStreamConfig::new(
+            format!("{}/graphql", server.uri()),
+            "query { users { edges { node { id } } } }",
+        )
+        .records_path("$.data.users.edges[*].node"),
+    )
+    .with_auth_provider(provider);
+
+    let records = source.fetch_all().await.expect("provider-auth fetch ok");
+    assert_eq!(
+        records.len(),
+        1,
+        "request matched only with the expected auth header"
+    );
+}
+
+/// `Credential::Token` maps to a raw `Authorization` header value.
+#[tokio::test(flavor = "multi_thread")]
+async fn provider_token_credential_sets_authorization_header() {
+    run_with_provider_expecting_header(
+        Credential::Token("raw-token-123".to_string()),
+        "authorization",
+        "raw-token-123",
+    )
+    .await;
+}
+
+/// `Credential::Header` maps to a custom header with the given name/value.
+#[tokio::test(flavor = "multi_thread")]
+async fn provider_header_credential_sets_named_header() {
+    run_with_provider_expecting_header(
+        Credential::Header {
+            name: "X-Api-Token".to_string(),
+            value: "hv-456".to_string(),
+        },
+        "x-api-token",
+        "hv-456",
+    )
+    .await;
+}
+
+/// `Credential::Basic` maps to a base64-encoded `Authorization: Basic` header.
+#[tokio::test(flavor = "multi_thread")]
+async fn provider_basic_credential_sets_basic_authorization_header() {
+    // base64("alice:s3cr3t") == "YWxpY2U6czNjcjN0"
+    run_with_provider_expecting_header(
+        Credential::Basic {
+            username: "alice".to_string(),
+            password: "s3cr3t".to_string(),
+        },
+        "authorization",
+        "Basic YWxpY2U6czNjcjN0",
+    )
+    .await;
+}
+
+// ─── error surfacing ─────────────────────────────────────────────────────────
+
+/// A GraphQL `errors` array in a 200 body is surfaced as
+/// `FaucetError::HttpStatus { status: 200, .. }` with the joined messages.
+#[tokio::test(flavor = "multi_thread")]
+async fn graphql_errors_array_surfaces_as_http_status_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": null,
+            "errors": [
+                { "message": "Field 'bogus' doesn't exist" },
+                { "message": "Cannot query nonsense" }
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let config = GraphqlStreamConfig::new(
+        format!("{}/graphql", server.uri()),
+        "query { users { edges { node { id } } } }",
+    )
+    .records_path("$.data.users.edges[*].node");
+    let source = GraphqlStream::new(config);
+
+    let err = source
+        .fetch_all()
+        .await
+        .expect_err("errors array must fail the fetch");
+    match err {
+        FaucetError::HttpStatus { status, body, .. } => {
+            assert_eq!(status, 200, "GraphQL errors arrive in a 200 response");
+            assert!(
+                body.contains("Field 'bogus' doesn't exist")
+                    && body.contains("Cannot query nonsense"),
+                "all error messages must be joined into the body; got {body:?}"
+            );
+        }
+        other => panic!("expected HttpStatus, got {other:?}"),
+    }
+}
+
+/// A non-2xx HTTP status (non-retriable 4xx) surfaces as
+/// `FaucetError::HttpStatus` carrying that status code.
+#[tokio::test(flavor = "multi_thread")]
+async fn non_2xx_http_status_surfaces_as_http_status_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .respond_with(ResponseTemplate::new(404).set_body_string("not found"))
+        .mount(&server)
+        .await;
+
+    let config = GraphqlStreamConfig::new(
+        format!("{}/graphql", server.uri()),
+        "query { users { edges { node { id } } } }",
+    )
+    .records_path("$.data.users.edges[*].node");
+    let source = GraphqlStream::new(config);
+
+    let err = source
+        .fetch_all()
+        .await
+        .expect_err("404 must fail the fetch");
+    match err {
+        FaucetError::HttpStatus { status, .. } => {
+            assert_eq!(status, 404, "the upstream 404 status must be surfaced");
+        }
+        other => panic!("expected HttpStatus(404), got {other:?}"),
+    }
+}
+
+// ─── config schema introspection ─────────────────────────────────────────────
+
+/// `config_schema()` returns a JSON object describing `GraphqlStreamConfig`.
+#[tokio::test(flavor = "multi_thread")]
+async fn config_schema_describes_the_config_struct() {
+    let source = GraphqlStream::new(GraphqlStreamConfig::new(
+        "https://api.example.com/graphql",
+        "query { id }",
+    ));
+    let schema = source.config_schema();
+    let props = schema
+        .get("properties")
+        .and_then(|p| p.as_object())
+        .expect("schema has a properties object");
+    assert!(
+        props.contains_key("endpoint"),
+        "schema documents `endpoint`"
+    );
+    assert!(props.contains_key("query"), "schema documents `query`");
+    assert!(
+        props.contains_key("pagination"),
+        "schema documents `pagination`"
+    );
+}

--- a/crates/source/kafka/src/decode.rs
+++ b/crates/source/kafka/src/decode.rs
@@ -149,4 +149,62 @@ mod tests {
         let m = format!("{err}").to_lowercase();
         assert!(m.contains("utf-8") || m.contains("utf"));
     }
+
+    #[cfg(feature = "schema-registry")]
+    #[tokio::test]
+    async fn decode_confluent_avro_without_client_is_config_error() {
+        use faucet_common_kafka::SchemaRegistryConfig;
+        let format = KafkaValueFormat::ConfluentAvro {
+            schema_registry: SchemaRegistryConfig::new("http://localhost:8081"),
+        };
+        let err = decode(Some(b"\x00\x00\x00\x00\x01"), &format, None)
+            .await
+            .unwrap_err();
+        match err {
+            FaucetError::Config(msg) => assert!(
+                msg.contains("ConfluentAvro") && msg.contains("no SchemaRegistryClient"),
+                "unexpected message: {msg}"
+            ),
+            other => panic!("expected Config error, got {other:?}"),
+        }
+    }
+
+    #[cfg(feature = "schema-registry")]
+    #[tokio::test]
+    async fn decode_confluent_protobuf_without_client_is_config_error() {
+        use faucet_common_kafka::SchemaRegistryConfig;
+        let format = KafkaValueFormat::ConfluentProtobuf {
+            schema_registry: SchemaRegistryConfig::new("http://localhost:8081"),
+        };
+        let err = decode(Some(b"\x00\x00\x00\x00\x01"), &format, None)
+            .await
+            .unwrap_err();
+        match err {
+            FaucetError::Config(msg) => assert!(
+                msg.contains("ConfluentProtobuf") && msg.contains("no SchemaRegistryClient"),
+                "unexpected message: {msg}"
+            ),
+            other => panic!("expected Config error, got {other:?}"),
+        }
+    }
+
+    #[cfg(feature = "schema-registry")]
+    #[tokio::test]
+    async fn decode_confluent_json_schema_without_client_is_config_error() {
+        use faucet_common_kafka::SchemaRegistryConfig;
+        let format = KafkaValueFormat::ConfluentJsonSchema {
+            schema_registry: SchemaRegistryConfig::new("http://localhost:8081"),
+            validate: false,
+        };
+        let err = decode(Some(b"\x00\x00\x00\x00\x01"), &format, None)
+            .await
+            .unwrap_err();
+        match err {
+            FaucetError::Config(msg) => assert!(
+                msg.contains("ConfluentJsonSchema") && msg.contains("no SchemaRegistryClient"),
+                "unexpected message: {msg}"
+            ),
+            other => panic!("expected Config error, got {other:?}"),
+        }
+    }
 }

--- a/crates/source/kafka/src/stream.rs
+++ b/crates/source/kafka/src/stream.rs
@@ -665,4 +665,69 @@ mod tests {
         let uri = format!("kafka://{}?topic={}", broker, topics.join(","));
         assert_eq!(uri, "kafka://b1:9092?topic=events,logs");
     }
+
+    #[cfg(feature = "schema-registry")]
+    mod sr_client {
+        use crate::stream::build_sr_client;
+        use faucet_common_kafka::{KafkaValueFormat, SchemaRegistryConfig};
+
+        #[test]
+        fn build_sr_client_none_for_plain_formats() {
+            assert!(
+                build_sr_client(&KafkaValueFormat::Json, None)
+                    .unwrap()
+                    .is_none()
+            );
+            assert!(
+                build_sr_client(&KafkaValueFormat::RawString, Some(&KafkaValueFormat::Bytes))
+                    .unwrap()
+                    .is_none()
+            );
+        }
+
+        #[test]
+        fn build_sr_client_some_for_confluent_avro_value() {
+            let format = KafkaValueFormat::ConfluentAvro {
+                schema_registry: SchemaRegistryConfig::new("http://localhost:8081"),
+            };
+            assert!(build_sr_client(&format, None).unwrap().is_some());
+        }
+
+        #[test]
+        fn build_sr_client_some_for_confluent_protobuf_value() {
+            let format = KafkaValueFormat::ConfluentProtobuf {
+                schema_registry: SchemaRegistryConfig::new("http://localhost:8081"),
+            };
+            assert!(build_sr_client(&format, None).unwrap().is_some());
+        }
+
+        #[test]
+        fn build_sr_client_some_for_confluent_json_schema_value() {
+            let format = KafkaValueFormat::ConfluentJsonSchema {
+                schema_registry: SchemaRegistryConfig::new("http://localhost:8081"),
+                validate: true,
+            };
+            assert!(build_sr_client(&format, None).unwrap().is_some());
+        }
+
+        #[test]
+        fn build_sr_client_falls_back_to_key_format() {
+            let key = KafkaValueFormat::ConfluentAvro {
+                schema_registry: SchemaRegistryConfig::new("http://localhost:8081"),
+            };
+            assert!(
+                build_sr_client(&KafkaValueFormat::Json, Some(&key))
+                    .unwrap()
+                    .is_some()
+            );
+        }
+
+        #[test]
+        fn build_sr_client_propagates_invalid_url() {
+            let format = KafkaValueFormat::ConfluentAvro {
+                schema_registry: SchemaRegistryConfig::new("not-a-url"),
+            };
+            assert!(build_sr_client(&format, None).is_err());
+        }
+    }
 }

--- a/crates/source/kafka/tests/coverage.rs
+++ b/crates/source/kafka/tests/coverage.rs
@@ -1,0 +1,291 @@
+//! Additional `KafkaSource` integration tests targeting branches that the
+//! existing `integration.rs` / `streaming.rs` suites do not exercise: keyed
+//! JSON decoding, message headers, `OnDecodeError::Skip`, `extra_client_config`
+//! propagation, the `check()` metadata probe, and the trait accessor methods
+//! (`connector_name`, `dataset_uri`, `config_schema`).
+//!
+//! Each test boots its own container so they are isolated and parallel-safe.
+//! Import notes match the sibling suites (testcontainers-modules 0.15).
+
+use faucet_common_kafka::{KafkaAuth, KafkaValueFormat, OnDecodeError};
+use faucet_core::check::{CheckContext, ProbeStatus};
+use faucet_core::{DEFAULT_BATCH_SIZE, Source};
+use faucet_source_kafka::{KafkaSource, KafkaSourceConfig, OffsetReset};
+use rdkafka::ClientConfig;
+use rdkafka::message::{Header, OwnedHeaders};
+use rdkafka::producer::{FutureProducer, FutureRecord, Producer};
+use std::collections::BTreeMap;
+use std::time::Duration;
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::kafka::apache::{KAFKA_PORT, Kafka};
+
+async fn start_kafka() -> (testcontainers::ContainerAsync<Kafka>, String) {
+    let container = Kafka::default()
+        .start()
+        .await
+        .expect("kafka container start");
+    let port = container
+        .get_host_port_ipv4(KAFKA_PORT)
+        .await
+        .expect("kafka port");
+    (container, format!("127.0.0.1:{port}"))
+}
+
+async fn produce(brokers: &str, topic: &str, messages: &[(Option<&str>, &str)]) {
+    let producer: FutureProducer = ClientConfig::new()
+        .set("bootstrap.servers", brokers)
+        .set("message.timeout.ms", "5000")
+        .create()
+        .expect("producer init");
+
+    for (key, value) in messages {
+        let mut record: FutureRecord<'_, str, str> = FutureRecord::to(topic).payload(*value);
+        if let Some(k) = key {
+            record = record.key(*k);
+        }
+        producer
+            .send(record, Duration::from_secs(5))
+            .await
+            .expect("producer send");
+    }
+    producer
+        .flush(Duration::from_secs(5))
+        .expect("producer flush");
+}
+
+/// Produce a single message carrying both a UTF-8 header and a binary
+/// (non-UTF-8) header so both `message_to_value` header branches are hit.
+async fn produce_with_headers(brokers: &str, topic: &str, value: &str) {
+    let producer: FutureProducer = ClientConfig::new()
+        .set("bootstrap.servers", brokers)
+        .set("message.timeout.ms", "5000")
+        .create()
+        .expect("producer init");
+
+    let headers = OwnedHeaders::new()
+        .insert(Header {
+            key: "trace-id",
+            value: Some("abc-123".as_bytes()),
+        })
+        .insert(Header {
+            key: "blob",
+            value: Some(&[0xFFu8, 0x00, 0xFE][..]),
+        });
+    let record: FutureRecord<'_, str, str> =
+        FutureRecord::to(topic).payload(value).headers(headers);
+    producer
+        .send(record, Duration::from_secs(5))
+        .await
+        .expect("producer send");
+    producer
+        .flush(Duration::from_secs(5))
+        .expect("producer flush");
+}
+
+fn source_config(
+    brokers: &str,
+    topic: &str,
+    group: &str,
+    max_messages: usize,
+) -> KafkaSourceConfig {
+    KafkaSourceConfig {
+        brokers: brokers.into(),
+        topics: vec![topic.into()],
+        group_id: group.into(),
+        auth: KafkaAuth::None,
+        value_format: KafkaValueFormat::Json,
+        key_format: None,
+        auto_offset_reset: OffsetReset::Earliest,
+        max_messages: Some(max_messages),
+        idle_timeout: Some(Duration::from_secs(30)),
+        poll_timeout: Duration::from_secs(1),
+        session_timeout: Duration::from_secs(30),
+        on_decode_error: OnDecodeError::Fail,
+        extra_client_config: BTreeMap::new(),
+        batch_size: DEFAULT_BATCH_SIZE,
+    }
+}
+
+/// `key_format = Some(Json)` routes the message key through the JSON decoder
+/// (the `Some(fmt)` arm of `message_to_value`) rather than treating it as a
+/// raw UTF-8 string.
+#[tokio::test(flavor = "multi_thread")]
+async fn key_format_json_decodes_key_as_json() {
+    let (_c, brokers) = start_kafka().await;
+    let topic = "cov-key-json";
+    produce(&brokers, topic, &[(Some(r#"{"k":1}"#), r#"{"id":1}"#)]).await;
+
+    let mut cfg = source_config(&brokers, topic, "g-cov-key-json", 1);
+    cfg.key_format = Some(KafkaValueFormat::Json);
+    let source = KafkaSource::new(cfg).await.unwrap();
+    let records = source.fetch_all().await.unwrap();
+    assert_eq!(records.len(), 1);
+    // Decoded as a JSON object, not the raw string `{"k":1}`.
+    assert_eq!(records[0]["key"]["k"], 1);
+    assert_eq!(records[0]["value"]["id"], 1);
+}
+
+/// A message with no key under `key_format = None` yields a JSON `null` key
+/// (the `None => Value::Null` arm of `message_to_value`).
+#[tokio::test(flavor = "multi_thread")]
+async fn missing_key_is_json_null() {
+    let (_c, brokers) = start_kafka().await;
+    let topic = "cov-no-key";
+    produce(&brokers, topic, &[(None, r#"{"id":9}"#)]).await;
+
+    let source = KafkaSource::new(source_config(&brokers, topic, "g-cov-no-key", 1))
+        .await
+        .unwrap();
+    let records = source.fetch_all().await.unwrap();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0]["key"], serde_json::Value::Null);
+}
+
+/// Message headers are surfaced under `headers`: a UTF-8 header passes through
+/// as a string, a non-UTF-8 header is base64-encoded.
+#[tokio::test(flavor = "multi_thread")]
+async fn message_headers_are_surfaced_utf8_and_base64() {
+    let (_c, brokers) = start_kafka().await;
+    let topic = "cov-headers";
+    produce_with_headers(&brokers, topic, r#"{"id":1}"#).await;
+
+    let source = KafkaSource::new(source_config(&brokers, topic, "g-cov-headers", 1))
+        .await
+        .unwrap();
+    let records = source.fetch_all().await.unwrap();
+    assert_eq!(records.len(), 1);
+    let headers = &records[0]["headers"];
+    assert_eq!(headers["trace-id"], "abc-123");
+    // [0xFF, 0x00, 0xFE] base64-encodes to "/wD+".
+    assert_eq!(headers["blob"], "/wD+");
+}
+
+/// `OnDecodeError::Skip` drops a record whose payload is not valid JSON and
+/// keeps the surrounding valid records.
+#[tokio::test(flavor = "multi_thread")]
+async fn on_decode_error_skip_drops_invalid_records() {
+    let (_c, brokers) = start_kafka().await;
+    let topic = "cov-skip";
+    produce(
+        &brokers,
+        topic,
+        &[
+            (None, r#"{"id":1}"#),
+            (None, "{not json"),
+            (None, r#"{"id":3}"#),
+        ],
+    )
+    .await;
+
+    let mut cfg = source_config(&brokers, topic, "g-cov-skip", 100);
+    cfg.on_decode_error = OnDecodeError::Skip;
+    // Short idle so the loop terminates after the 2 valid records are consumed
+    // (max_messages can't be hit because one record is dropped).
+    cfg.idle_timeout = Some(Duration::from_secs(10));
+    let source = KafkaSource::new(cfg).await.unwrap();
+    let records = source.fetch_all().await.unwrap();
+    assert_eq!(records.len(), 2, "the invalid record must be skipped");
+    assert_eq!(records[0]["value"]["id"], 1);
+    assert_eq!(records[1]["value"]["id"], 3);
+}
+
+/// `OnDecodeError::Fail` (the default) surfaces a decode error as a `Source`
+/// error rather than skipping.
+#[tokio::test(flavor = "multi_thread")]
+async fn on_decode_error_fail_surfaces_error() {
+    let (_c, brokers) = start_kafka().await;
+    let topic = "cov-fail";
+    produce(&brokers, topic, &[(None, "{still not json")]).await;
+
+    let cfg = source_config(&brokers, topic, "g-cov-fail", 1);
+    let source = KafkaSource::new(cfg).await.unwrap();
+    let err = source.fetch_all().await.unwrap_err();
+    let msg = format!("{err}").to_lowercase();
+    assert!(
+        msg.contains("json"),
+        "expected json decode error, got {msg}"
+    );
+}
+
+/// `extra_client_config` entries are applied to the underlying consumer's
+/// `ClientConfig` (the `for (k, v) in &config.extra_client_config` loop). A
+/// benign override keeps the consumer functional and a round-trip still works.
+#[tokio::test(flavor = "multi_thread")]
+async fn extra_client_config_is_applied() {
+    let (_c, brokers) = start_kafka().await;
+    let topic = "cov-extra-config";
+    produce(&brokers, topic, &[(None, r#"{"id":1}"#)]).await;
+
+    let mut cfg = source_config(&brokers, topic, "g-cov-extra", 1);
+    cfg.extra_client_config
+        .insert("fetch.min.bytes".into(), "1".into());
+    let source = KafkaSource::new(cfg).await.unwrap();
+    let records = source.fetch_all().await.unwrap();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0]["value"]["id"], 1);
+}
+
+/// `check()` returns a single passing `metadata` probe against a reachable
+/// broker (the `Probe::pass` arm of the metadata fetch).
+#[tokio::test(flavor = "multi_thread")]
+async fn check_passes_against_reachable_broker() {
+    let (_c, brokers) = start_kafka().await;
+    let source = KafkaSource::new(source_config(&brokers, "cov-check", "g-cov-check", 1))
+        .await
+        .unwrap();
+    let report = source.check(&CheckContext::default()).await.unwrap();
+    assert_eq!(report.probes.len(), 1);
+    assert_eq!(report.probes[0].name, "metadata");
+    assert!(
+        matches!(report.probes[0].status, ProbeStatus::Pass),
+        "expected a passing metadata probe, got {:?}",
+        report.probes[0].status
+    );
+}
+
+/// `check()` fails (rather than hanging) when the broker is unreachable: the
+/// metadata fetch times out / errors and returns a single failing probe.
+#[tokio::test(flavor = "multi_thread")]
+async fn check_fails_against_unreachable_broker() {
+    // 127.0.0.1:1 is a closed port — connection refused / metadata timeout.
+    let mut cfg = source_config("127.0.0.1:1", "cov-check-bad", "g-cov-check-bad", 1);
+    cfg.session_timeout = Duration::from_secs(6);
+    let source = KafkaSource::new(cfg).await.unwrap();
+    let ctx = CheckContext {
+        timeout: Duration::from_secs(3),
+    };
+    let report = source.check(&ctx).await.unwrap();
+    assert_eq!(report.probes.len(), 1);
+    assert_eq!(report.probes[0].name, "metadata");
+    assert!(
+        matches!(report.probes[0].status, ProbeStatus::Fail { .. }),
+        "expected a failing metadata probe, got {:?}",
+        report.probes[0].status
+    );
+}
+
+/// The trait accessor methods (`connector_name`, `dataset_uri`,
+/// `config_schema`) return the expected values on a constructed source.
+#[tokio::test(flavor = "multi_thread")]
+async fn accessor_methods_on_constructed_source() {
+    let (_c, brokers) = start_kafka().await;
+    let source = KafkaSource::new(source_config(&brokers, "cov-accessors", "g-cov-acc", 1))
+        .await
+        .unwrap();
+
+    assert_eq!(source.connector_name(), "kafka");
+
+    let uri = source.dataset_uri();
+    assert!(
+        uri.starts_with("kafka://") && uri.ends_with("?topic=cov-accessors"),
+        "unexpected dataset_uri: {uri}"
+    );
+
+    let schema = source.config_schema();
+    // The schema is a JSON object describing KafkaSourceConfig's properties.
+    assert!(schema.is_object());
+    assert!(
+        schema["properties"]["topics"].is_object(),
+        "config_schema must describe the topics field"
+    );
+}

--- a/crates/source/mongodb-cdc/src/stream.rs
+++ b/crates/source/mongodb-cdc/src/stream.rs
@@ -468,6 +468,31 @@ mod tests {
     }
 
     #[test]
+    fn explicit_resume_token_overrides_bookmark() {
+        // An explicit ResumeToken in config must win over any persisted
+        // bookmark and resolve to ResumeAfter(token).
+        let pending = Bookmark {
+            resume_token: json!({ "_data": "PENDING" }),
+        };
+        let pos = resolve_start(
+            &StartFrom::ResumeToken {
+                token: json!({ "_data": "8264AB00" }),
+            },
+            Some(&pending),
+        )
+        .unwrap();
+        // The resolved position must round-trip back to the configured token,
+        // not the pending bookmark's token.
+        match pos {
+            StartPosition::ResumeAfter(tok) => {
+                let b = Bookmark::from_token(&tok).unwrap();
+                assert_eq!(b.resume_token["_data"], json!("8264AB00"));
+            }
+            other => panic!("expected ResumeAfter, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn now_yields_to_bookmark() {
         let pending = Bookmark {
             resume_token: json!({ "_data": "8264AB00" }),
@@ -524,6 +549,79 @@ mod tests {
         }))
         .unwrap();
         assert!(matches!(build_pipeline(&c), Err(FaucetError::Config(_))));
+    }
+
+    #[test]
+    fn pipeline_appends_object_stages_after_match() {
+        // operation_types prepends a $match; each aggregation_pipeline object
+        // stage is appended in order.
+        let c: MongoCdcSourceConfig = serde_json::from_value(json!({
+            "connection_uri": "mongodb://h/?replicaSet=rs0",
+            "scope": { "type": "cluster" },
+            "operation_types": ["insert"],
+            "aggregation_pipeline": [
+                { "$match": { "fullDocument.tier": "gold" } },
+                { "$project": { "fullDocument._id": 1 } }
+            ]
+        }))
+        .unwrap();
+        let p = build_pipeline(&c).unwrap();
+        assert_eq!(p.len(), 3, "operation $match + two user stages");
+        // First is the operation-type $match.
+        assert!(
+            p[0].get_document("$match")
+                .unwrap()
+                .contains_key("operationType")
+        );
+        // User object stages preserved verbatim, in order.
+        assert!(p[1].contains_key("$match"));
+        assert!(p[2].contains_key("$project"));
+    }
+
+    #[test]
+    fn pipeline_object_stages_without_operation_match() {
+        // No operation_types → no leading $match; only the user object stage.
+        let c: MongoCdcSourceConfig = serde_json::from_value(json!({
+            "connection_uri": "mongodb://h/?replicaSet=rs0",
+            "scope": { "type": "cluster" },
+            "aggregation_pipeline": [ { "$project": { "_id": 1 } } ]
+        }))
+        .unwrap();
+        let p = build_pipeline(&c).unwrap();
+        assert_eq!(p.len(), 1);
+        assert!(p[0].contains_key("$project"));
+    }
+
+    #[test]
+    fn full_document_type_mapping() {
+        use crate::config::FullDocument as F;
+        assert!(full_document_type(F::Off).is_none());
+        assert!(matches!(
+            full_document_type(F::WhenAvailable),
+            Some(FullDocumentType::WhenAvailable)
+        ));
+        assert!(matches!(
+            full_document_type(F::Required),
+            Some(FullDocumentType::Required)
+        ));
+        assert!(matches!(
+            full_document_type(F::UpdateLookup),
+            Some(FullDocumentType::UpdateLookup)
+        ));
+    }
+
+    #[test]
+    fn full_document_before_type_mapping() {
+        use crate::config::FullDocumentBeforeChange as F;
+        assert!(full_document_before_type(F::Off).is_none());
+        assert!(matches!(
+            full_document_before_type(F::WhenAvailable),
+            Some(FullDocumentBeforeChangeType::WhenAvailable)
+        ));
+        assert!(matches!(
+            full_document_before_type(F::Required),
+            Some(FullDocumentBeforeChangeType::Required)
+        ));
     }
 
     // dataset_uri is a pure-config method; MongoCdcSource requires a live

--- a/crates/source/mongodb-cdc/tests/integration.rs
+++ b/crates/source/mongodb-cdc/tests/integration.rs
@@ -14,6 +14,7 @@
 //! subsequent write — and only that write — is delivered (no replay).
 
 use faucet_core::Source;
+use faucet_core::check::{CheckContext, ProbeStatus};
 use faucet_source_mongodb_cdc::{MongoCdcSource, MongoCdcSourceConfig};
 use futures::StreamExt;
 use mongodb::Client;
@@ -170,4 +171,197 @@ async fn cdc_captures_crud_then_resumes_without_replay() {
         );
     }
     assert!(records2.iter().any(|r| r["op"] == "c"));
+}
+
+// --- instance trait methods (require a live replica set via new()) ---
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn instance_metadata_methods() {
+    let (_container, uri) = start_repl_set().await;
+    let source = MongoCdcSource::new(config(&uri)).await.expect("source");
+
+    // state_key is derived from the (collection) scope.
+    assert_eq!(
+        source.state_key().as_deref(),
+        Some("mongodb-cdc:coll:app.users"),
+        "collection-scope state key"
+    );
+
+    // CDC supports exactly-once delivery (durable resume token).
+    assert!(source.supports_exactly_once());
+
+    // Stable connector label used for metrics/logging.
+    assert_eq!(source.connector_name(), "mongodb-cdc");
+
+    // dataset_uri for a collection scope appends db/coll after the redacted URI.
+    let ds = source.dataset_uri();
+    assert!(
+        ds.ends_with(&format!("/{DB}/{COLL}")),
+        "collection dataset_uri: {ds}"
+    );
+
+    // config_schema is the JSON Schema for the config struct.
+    let schema = source.config_schema();
+    let props = schema
+        .get("properties")
+        .and_then(|p| p.as_object())
+        .expect("config_schema must be a JSON object schema");
+    assert!(props.contains_key("connection_uri"), "schema: {schema}");
+    assert!(props.contains_key("scope"));
+    assert!(props.contains_key("start_from"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn dataset_uri_database_and_cluster_scopes() {
+    let (_container, uri) = start_repl_set().await;
+    let base = faucet_core::redact_uri_credentials(&uri);
+
+    // Database scope → base/<db>; state key is mongodb-cdc:db:<db>.
+    let db_cfg: MongoCdcSourceConfig = serde_json::from_value(json!({
+        "connection_uri": &uri,
+        "scope": { "type": "database", "database": DB },
+        "idle_timeout": 5,
+        "max_await_time_ms": 500,
+        "batch_size": 0
+    }))
+    .expect("db config");
+    let db_source = MongoCdcSource::new(db_cfg).await.expect("db source");
+    assert_eq!(db_source.dataset_uri(), format!("{base}/{DB}"));
+    assert_eq!(
+        db_source.state_key().as_deref(),
+        Some(format!("mongodb-cdc:db:{DB}").as_str())
+    );
+
+    // Cluster scope → just the redacted base; state key is mongodb-cdc:cluster.
+    let cluster_cfg: MongoCdcSourceConfig = serde_json::from_value(json!({
+        "connection_uri": &uri,
+        "scope": { "type": "cluster" },
+        "idle_timeout": 5,
+        "max_await_time_ms": 500,
+        "batch_size": 0
+    }))
+    .expect("cluster config");
+    let cluster_source = MongoCdcSource::new(cluster_cfg)
+        .await
+        .expect("cluster source");
+    assert_eq!(cluster_source.dataset_uri(), base);
+    assert_eq!(
+        cluster_source.state_key().as_deref(),
+        Some("mongodb-cdc:cluster")
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn check_passes_on_replica_set() {
+    let (_container, uri) = start_repl_set().await;
+    let source = MongoCdcSource::new(config(&uri)).await.expect("source");
+
+    let report = source
+        .check(&CheckContext::default())
+        .await
+        .expect("check report");
+    // Replica set → both connection and topology probes pass.
+    let names: Vec<&str> = report.probes.iter().map(|p| p.name).collect();
+    assert!(names.contains(&"connection"), "probes: {names:?}");
+    assert!(names.contains(&"topology"), "probes: {names:?}");
+    for p in &report.probes {
+        assert!(
+            matches!(p.status, ProbeStatus::Pass),
+            "probe {} must pass on a replica set, got {:?}",
+            p.name,
+            p.status
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fetch_with_context_drains_into_flat_vec() {
+    let (_container, uri) = start_repl_set().await;
+    {
+        let client = Client::with_uri_str(&uri).await.expect("seed client");
+        client
+            .database(DB)
+            .collection::<Document>(COLL)
+            .insert_one(doc! { "_id": 0, "seed": true })
+            .await
+            .expect("seed insert");
+    }
+    let source = MongoCdcSource::new(config(&uri)).await.expect("source");
+
+    let writer_uri = uri.clone();
+    let writer = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        let client = Client::with_uri_str(&writer_uri)
+            .await
+            .expect("writer client");
+        client
+            .database(DB)
+            .collection::<Document>(COLL)
+            .insert_one(doc! { "_id": 7, "name": "eve" })
+            .await
+            .expect("insert");
+    });
+
+    // fetch_with_context drains every page of one cycle into a flat Vec.
+    let ctx: HashMap<String, Value> = HashMap::new();
+    let records = source.fetch_with_context(&ctx).await.expect("fetch");
+    writer.await.expect("writer task");
+
+    assert!(
+        records
+            .iter()
+            .any(|r| r["op"] == "c" && r["after"]["name"] == "eve"),
+        "expected the eve insert in the flattened result, got {records:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn new_warns_but_succeeds_with_pre_image_request() {
+    // full_document_before_change != Off triggers the warn branch in new();
+    // construction must still succeed against a replica set (the server only
+    // errors at stream open if pre-images are unavailable, not at connect).
+    let (_container, uri) = start_repl_set().await;
+    let cfg: MongoCdcSourceConfig = serde_json::from_value(json!({
+        "connection_uri": uri,
+        "scope": { "type": "collection", "database": DB, "collection": COLL },
+        "full_document_before_change": "when_available",
+        "idle_timeout": 5,
+        "max_await_time_ms": 500,
+        "batch_size": 0
+    }))
+    .expect("config");
+    let source = MongoCdcSource::new(cfg).await.expect("source new");
+    assert_eq!(source.connector_name(), "mongodb-cdc");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn new_rejects_standalone_topology() {
+    // A standalone mongod (not a replica set) does not support change streams;
+    // new() must fail via ensure_changestream_capable with a Source error.
+    let container = Mongo::default()
+        .start()
+        .await
+        .expect("standalone mongo start");
+    let port = container.get_host_port_ipv4(27017).await.expect("port");
+    let uri = format!("mongodb://127.0.0.1:{port}/?directConnection=true");
+
+    let cfg: MongoCdcSourceConfig = serde_json::from_value(json!({
+        "connection_uri": uri,
+        "scope": { "type": "collection", "database": DB, "collection": COLL },
+        "idle_timeout": 5,
+        "max_await_time_ms": 500,
+        "batch_size": 0
+    }))
+    .expect("config");
+
+    match MongoCdcSource::new(cfg).await {
+        Err(faucet_core::FaucetError::Source(m)) => {
+            assert!(
+                m.contains("replica set") || m.contains("standalone"),
+                "expected a topology rejection, got: {m}"
+            );
+        }
+        Err(other) => panic!("expected a Source topology error, got {other:?}"),
+        Ok(_) => panic!("standalone mongod must be rejected for change streams"),
+    }
 }

--- a/crates/source/mongodb/src/stream.rs
+++ b/crates/source/mongodb/src/stream.rs
@@ -397,4 +397,102 @@ mod tests {
         );
         assert_eq!(uri, "mongodb://h:27017/mydb/events");
     }
+
+    // --- substitute_optional_value (the private context-interpolation helper) ---
+
+    #[test]
+    fn substitute_optional_value_none_passthrough() {
+        let ctx: std::collections::HashMap<String, Value> = std::collections::HashMap::new();
+        let out = substitute_optional_value(&None, &ctx, "filter").unwrap();
+        assert!(out.is_none(), "None input must yield None output");
+    }
+
+    #[test]
+    fn substitute_optional_value_replaces_string_placeholder() {
+        let mut ctx: std::collections::HashMap<String, Value> = std::collections::HashMap::new();
+        // Placeholders use the flat `{key}` syntax over top-level context keys.
+        ctx.insert("user_id".into(), json!("abc-123"));
+        // The placeholder lives inside a JSON string value; substitution must
+        // preserve JSON validity (string stays a string).
+        let filter = Some(json!({"owner": "{user_id}"}));
+        let out = substitute_optional_value(&filter, &ctx, "filter")
+            .unwrap()
+            .expect("Some input yields Some output");
+        assert_eq!(out, json!({"owner": "abc-123"}));
+    }
+
+    #[test]
+    fn substitute_optional_value_no_placeholder_is_identity() {
+        let ctx: std::collections::HashMap<String, Value> = std::collections::HashMap::new();
+        let proj = Some(json!({"_id": 0, "name": 1}));
+        let out = substitute_optional_value(&proj, &ctx, "projection")
+            .unwrap()
+            .unwrap();
+        assert_eq!(out, json!({"_id": 0, "name": 1}));
+    }
+
+    #[test]
+    fn substitute_optional_value_escapes_value_for_json_safety() {
+        // A context value containing a double-quote must be escaped so the
+        // re-parsed JSON is valid and the literal characters survive.
+        let mut ctx: std::collections::HashMap<String, Value> = std::collections::HashMap::new();
+        ctx.insert("name".into(), json!("a\"b"));
+        let filter = Some(json!({"n": "{name}"}));
+        let out = substitute_optional_value(&filter, &ctx, "filter")
+            .unwrap()
+            .unwrap();
+        assert_eq!(out, json!({"n": "a\"b"}));
+    }
+
+    // --- bson_document_to_json_value: relaxed extended-JSON shapes ---
+
+    #[test]
+    fn bson_object_id_converts_to_oid_extjson() {
+        use mongodb::bson::oid::ObjectId;
+        let mut doc = Document::new();
+        let oid = ObjectId::parse_str("64ab00112233445566778899").unwrap();
+        doc.insert("_id", oid);
+        let value = bson_document_to_json_value(&doc).unwrap();
+        // Relaxed extended JSON renders an ObjectId as {"$oid": "<hex>"}.
+        assert_eq!(value["_id"]["$oid"], "64ab00112233445566778899");
+    }
+
+    #[test]
+    fn bson_datetime_converts_to_date_extjson() {
+        use mongodb::bson::DateTime;
+        let mut doc = Document::new();
+        // 1_000_000 ms past the epoch.
+        doc.insert("created_at", DateTime::from_millis(1_000_000));
+        let value = bson_document_to_json_value(&doc).unwrap();
+        // Relaxed extended JSON renders a post-1970 datetime as
+        // {"$date": "<RFC3339>"}.
+        assert!(
+            value["created_at"]["$date"].is_string(),
+            "expected $date string, got {value:?}"
+        );
+    }
+
+    #[test]
+    fn bson_null_and_array_and_nested_convert() {
+        use mongodb::bson::Bson;
+        let mut doc = Document::new();
+        doc.insert("missing", Bson::Null);
+        doc.insert("tags", vec!["a", "b"]);
+        let mut nested = Document::new();
+        nested.insert("k", 7i32);
+        doc.insert("nested", nested);
+        let value = bson_document_to_json_value(&doc).unwrap();
+        assert_eq!(value["missing"], Value::Null);
+        assert_eq!(value["tags"], json!(["a", "b"]));
+        assert_eq!(value["nested"]["k"], 7);
+    }
+
+    #[test]
+    fn bson_int64_converts_to_number() {
+        let mut doc = Document::new();
+        doc.insert("big", 9_000_000_000i64);
+        let value = bson_document_to_json_value(&doc).unwrap();
+        // Relaxed extended JSON renders an i64 as a bare JSON number.
+        assert_eq!(value["big"], json!(9_000_000_000i64));
+    }
 }

--- a/crates/source/mongodb/tests/streaming.rs
+++ b/crates/source/mongodb/tests/streaming.rs
@@ -209,3 +209,207 @@ async fn stream_pages_first_page_completes_without_parsing_full_result() {
          first page took {first_elapsed:?}, full drain took {full_elapsed:?}"
     );
 }
+
+// --- fetch_all(): the convenience buffering path (distinct from stream_pages) ---
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fetch_all_returns_all_matching_documents() {
+    let (_container, uri) = start_mongo().await;
+    seed_docs(&uri, "testdb", "events", 1_234).await;
+
+    let config = MongoSourceConfig::new(uri, "testdb", "events");
+    let source = MongoSource::new(config).await.expect("source new");
+
+    let records = source.fetch_all().await.expect("fetch_all");
+    assert_eq!(records.len(), 1_234);
+    // Every record carries its `id` field and a server-assigned `_id`.
+    assert!(records.iter().all(|r| r.get("id").is_some()));
+    assert!(records.iter().all(|r| r["_id"]["$oid"].is_string()));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fetch_all_applies_filter_projection_sort_and_limit() {
+    let (_container, uri) = start_mongo().await;
+    let client = Client::with_uri_str(&uri).await.expect("client");
+    let coll = client.database("testdb").collection::<Document>("people");
+    coll.insert_many(vec![
+        doc! { "id": 1, "name": "alice", "active": true },
+        doc! { "id": 2, "name": "bob", "active": false },
+        doc! { "id": 3, "name": "carol", "active": true },
+        doc! { "id": 4, "name": "dave", "active": true },
+    ])
+    .await
+    .expect("insert_many");
+
+    let config = MongoSourceConfig::new(uri, "testdb", "people")
+        .filter(serde_json::json!({"active": true}))
+        .projection(serde_json::json!({"_id": 0, "name": 1, "id": 1}))
+        .sort(serde_json::json!({"id": -1}))
+        .limit(2);
+    let source = MongoSource::new(config).await.expect("source new");
+
+    let records = source.fetch_all().await.expect("fetch_all");
+    // filter: only active (alice, carol, dave); sort id desc → dave(4), carol(3);
+    // limit 2 → two records; projection drops _id.
+    assert_eq!(records.len(), 2);
+    assert_eq!(records[0]["name"], "dave");
+    assert_eq!(records[1]["name"], "carol");
+    assert!(
+        records[0].get("_id").is_none(),
+        "projection must exclude _id: {:?}",
+        records[0]
+    );
+    assert!(
+        records[0].get("active").is_none(),
+        "projection excludes active"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fetch_all_with_cursor_batch_size_and_empty_result() {
+    let (_container, uri) = start_mongo().await;
+    // Empty collection — exercises the zero-document branch of fetch_all.
+    let config = MongoSourceConfig::new(uri, "testdb", "nothing_here").cursor_batch_size(50);
+    let source = MongoSource::new(config).await.expect("source new");
+
+    let records = source.fetch_all().await.expect("fetch_all");
+    assert!(records.is_empty(), "empty collection yields no records");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fetch_all_preserves_bson_types_as_relaxed_extjson() {
+    use mongodb::bson::DateTime;
+    use mongodb::bson::oid::ObjectId;
+    let (_container, uri) = start_mongo().await;
+    let client = Client::with_uri_str(&uri).await.expect("client");
+    let coll = client.database("testdb").collection::<Document>("typed");
+    let oid = ObjectId::parse_str("64ab00112233445566778899").unwrap();
+    coll.insert_one(doc! {
+        "_id": oid,
+        "when": DateTime::from_millis(1_000_000),
+        "count": 9_000_000_000i64,
+        "nothing": mongodb::bson::Bson::Null,
+        "tags": ["x", "y"],
+        "nested": { "inner": 5 },
+    })
+    .await
+    .expect("insert_one");
+
+    let config = MongoSourceConfig::new(uri, "testdb", "typed");
+    let source = MongoSource::new(config).await.expect("source new");
+    let records = source.fetch_all().await.expect("fetch_all");
+    assert_eq!(records.len(), 1);
+    let r = &records[0];
+    assert_eq!(r["_id"]["$oid"], "64ab00112233445566778899");
+    assert!(r["when"]["$date"].is_string(), "datetime → $date: {r:?}");
+    assert_eq!(r["count"], serde_json::json!(9_000_000_000i64));
+    assert_eq!(r["nothing"], serde_json::Value::Null);
+    assert_eq!(r["tags"], serde_json::json!(["x", "y"]));
+    assert_eq!(r["nested"]["inner"], 5);
+}
+
+// --- fetch_with_context: empty ctx delegates to fetch_all; non-empty substitutes ---
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fetch_with_context_empty_delegates_to_fetch_all() {
+    let (_container, uri) = start_mongo().await;
+    seed_docs(&uri, "testdb", "events", 5).await;
+
+    let config = MongoSourceConfig::new(uri, "testdb", "events");
+    let source = MongoSource::new(config).await.expect("source new");
+
+    let ctx: HashMap<String, serde_json::Value> = HashMap::new();
+    let records = source
+        .fetch_with_context(&ctx)
+        .await
+        .expect("fetch_with_context");
+    assert_eq!(records.len(), 5);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fetch_with_context_substitutes_filter_placeholder() {
+    let (_container, uri) = start_mongo().await;
+    let client = Client::with_uri_str(&uri).await.expect("client");
+    let coll = client.database("testdb").collection::<Document>("orders");
+    coll.insert_many(vec![
+        doc! { "id": 1, "region": "us" },
+        doc! { "id": 2, "region": "eu" },
+        doc! { "id": 3, "region": "us" },
+    ])
+    .await
+    .expect("insert_many");
+
+    // Placeholders use the flat `{key}` syntax over top-level context keys.
+    let config = MongoSourceConfig::new(uri, "testdb", "orders")
+        .filter(serde_json::json!({"region": "{region}"}))
+        .sort(serde_json::json!({"id": 1}));
+    let source = MongoSource::new(config).await.expect("source new");
+
+    let mut ctx: HashMap<String, serde_json::Value> = HashMap::new();
+    ctx.insert("region".into(), serde_json::json!("us"));
+
+    let records = source
+        .fetch_with_context(&ctx)
+        .await
+        .expect("fetch_with_context");
+    // Only the two "us" docs match after substitution.
+    let ids: Vec<i64> = records.iter().map(|r| r["id"].as_i64().unwrap()).collect();
+    assert_eq!(ids, vec![1, 3]);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn stream_pages_substitutes_context_into_filter() {
+    use futures::StreamExt;
+    let (_container, uri) = start_mongo().await;
+    let client = Client::with_uri_str(&uri).await.expect("client");
+    let coll = client.database("testdb").collection::<Document>("logs");
+    coll.insert_many(vec![
+        doc! { "id": 1, "level": "info" },
+        doc! { "id": 2, "level": "error" },
+        doc! { "id": 3, "level": "error" },
+    ])
+    .await
+    .expect("insert_many");
+
+    let config = MongoSourceConfig::new(uri, "testdb", "logs")
+        .filter(serde_json::json!({"level": "{level}"}))
+        .with_batch_size(10);
+    let source = MongoSource::new(config).await.expect("source new");
+
+    let mut ctx: HashMap<String, serde_json::Value> = HashMap::new();
+    ctx.insert("level".into(), serde_json::json!("error"));
+
+    let mut pages = source.stream_pages(&ctx, 10);
+    let mut total = 0;
+    while let Some(page) = pages.next().await {
+        total += page.expect("page ok").records.len();
+    }
+    assert_eq!(
+        total, 2,
+        "only the two error docs match the substituted filter"
+    );
+}
+
+// --- instance trait methods (require a live server via new()) ---
+
+#[tokio::test(flavor = "multi_thread")]
+async fn config_schema_and_dataset_uri_via_instance() {
+    let (_container, uri) = start_mongo().await;
+    let config = MongoSourceConfig::new(uri.clone(), "shop", "carts");
+    let source = MongoSource::new(config).await.expect("source new");
+
+    let schema = source.config_schema();
+    let props = schema
+        .get("properties")
+        .and_then(|p| p.as_object())
+        .expect("config_schema must be a JSON object schema");
+    assert!(props.contains_key("connection_uri"), "schema: {schema}");
+    assert!(props.contains_key("filter"), "schema documents `filter`");
+    assert!(
+        props.contains_key("batch_size"),
+        "schema documents `batch_size`"
+    );
+
+    let ds = source.dataset_uri();
+    assert!(ds.ends_with("/shop/carts"), "dataset_uri: {ds}");
+}

--- a/crates/source/mysql-cdc/src/stream.rs
+++ b/crates/source/mysql-cdc/src/stream.rs
@@ -1097,4 +1097,92 @@ mod tests {
         };
         assert_eq!(uri, "mysql://h:3306/db?tables=db.orders,db.users");
     }
+
+    // ── build_request ─────────────────────────────────────────────────────────
+    //
+    // `BinlogStreamRequest` exposes no public getters and does not derive
+    // `Debug`, so the only observable outcome of `build_request` for the
+    // non-erroring arms is `Ok` vs `Err` (the builder is side-effect-free).
+    // The GtidSet arm additionally has an observable error path, which is
+    // asserted exactly below.
+
+    #[test]
+    fn build_request_current_arm_succeeds() {
+        // Defensive arm: `resolve_current` normally converts Current → FilePos
+        // before `build_request`, but a caller that skips it must still get a
+        // plain request rather than an error.
+        let resolved = ResolvedStart::Current {
+            file: String::new(),
+            pos: 0,
+        };
+        assert!(build_request(42, &resolved).is_ok());
+    }
+
+    #[test]
+    fn build_request_earliest_arm_succeeds() {
+        let resolved = ResolvedStart::Earliest;
+        assert!(build_request(7, &resolved).is_ok());
+    }
+
+    #[test]
+    fn build_request_file_pos_arm_succeeds() {
+        let resolved = ResolvedStart::FilePos {
+            file: "binlog.000007".into(),
+            pos: 8192,
+        };
+        assert!(build_request(1001, &resolved).is_ok());
+    }
+
+    #[test]
+    fn build_request_valid_gtid_set_succeeds() {
+        // A well-formed `uuid:interval` GTID parses into `Sid`s; multiple
+        // comma-separated entries are each trimmed and parsed.
+        let resolved = ResolvedStart::GtidSet {
+            value: "3E11FA47-71CA-11E1-9E33-C80AA9429562:1-5, \
+                    8a1d3a7c-71ca-11e1-9e33-c80aa9429562:1-10"
+                .into(),
+        };
+        assert!(build_request(1001, &resolved).is_ok());
+    }
+
+    #[test]
+    fn build_request_invalid_gtid_set_errors_with_source_variant() {
+        // A malformed GTID set surfaces as a typed `FaucetError::Source` whose
+        // message names the offending fragment.
+        let resolved = ResolvedStart::GtidSet {
+            value: "totally-not-a-gtid".into(),
+        };
+        // `BinlogStreamRequest` is not `Debug`, so match the `Result` directly
+        // rather than via `expect_err` (which would require `Ok: Debug`).
+        match build_request(1001, &resolved) {
+            Err(FaucetError::Source(msg)) => {
+                assert!(
+                    msg.contains("invalid GTID set 'totally-not-a-gtid'"),
+                    "message must name the bad fragment; got: {msg}"
+                );
+            }
+            Err(other) => panic!("expected FaucetError::Source, got {other:?}"),
+            Ok(_) => panic!("invalid GTID must error"),
+        }
+    }
+
+    // ── build_ddl_envelope ────────────────────────────────────────────────────
+
+    #[test]
+    fn ddl_envelope_shape() {
+        let env = build_ddl_envelope("ALTER TABLE t ADD c INT", 1_700, "binlog.000004", 512);
+        assert_eq!(env["op"], "ddl");
+        assert_eq!(env["ts_ms"], 1_700_u64);
+        assert_eq!(env["statement"], "ALTER TABLE t ADD c INT");
+        assert_eq!(
+            env["lsn"],
+            json!({ "file": "binlog.000004", "pos": 512_u64 })
+        );
+        // DDL envelopes carry no before/after/schema/table keys.
+        let obj = env.as_object().unwrap();
+        assert!(!obj.contains_key("before"));
+        assert!(!obj.contains_key("after"));
+        assert!(!obj.contains_key("schema"));
+        assert!(!obj.contains_key("table"));
+    }
 }

--- a/crates/source/mysql-cdc/tests/integration.rs
+++ b/crates/source/mysql-cdc/tests/integration.rs
@@ -15,6 +15,7 @@
 //! replay).
 
 use faucet_core::Source;
+use faucet_core::check::{CheckContext, ProbeStatus};
 use faucet_source_mysql_cdc::{MysqlCdcSource, MysqlCdcSourceConfig};
 use futures::StreamExt;
 use mysql_async::{Conn, Opts, prelude::Queryable};
@@ -210,5 +211,194 @@ async fn cdc_captures_crud_then_resumes_without_replay() {
     assert!(
         records2.iter().any(|r| r["op"] == "c"),
         "expected a create op in cycle 2, got: {records2:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn source_trait_metadata_and_check_against_live_server() {
+    // A live MySQL is required because `MysqlCdcSource::new()` opens a preflight
+    // connection. Once built, exercise the trait metadata accessors and the
+    // non-stream `check()` preflight (which runs the connection + binlog-config
+    // probes without opening the binlog stream).
+    let (_container, url) = start_mysql_cdc().await;
+
+    // include_tables makes `dataset_uri` append the `?tables=` suffix.
+    let config: MysqlCdcSourceConfig = serde_json::from_value(json!({
+        "connection_url": url,
+        "server_id": 2002,
+        "include_tables": ["test.orders"],
+        "start_position": { "type": "current" },
+        "idle_timeout": 5,
+        "batch_size": 0
+    }))
+    .expect("config");
+    let source = MysqlCdcSource::new(config).await.expect("source new");
+
+    // connector_name / supports_exactly_once are pure constants.
+    assert_eq!(source.connector_name(), "mysql-cdc");
+    assert!(
+        source.supports_exactly_once(),
+        "mysql-cdc bookmarks file/pos + per-page → exactly-once capable"
+    );
+
+    // state_key derives from server_id.
+    assert_eq!(source.state_key().as_deref(), Some("mysql-cdc:2002"));
+
+    // dataset_uri redacts credentials and appends the configured tables.
+    let uri = source.dataset_uri();
+    assert!(
+        !uri.contains("root@") && !uri.contains("@127.0.0.1"),
+        "credentials must be stripped from dataset_uri: {uri}"
+    );
+    assert!(
+        uri.ends_with("?tables=test.orders"),
+        "dataset_uri must append include_tables: {uri}"
+    );
+
+    // config_schema is the JSON Schema for the config struct.
+    let schema = source.config_schema();
+    assert!(
+        schema.get("properties").is_some(),
+        "config_schema must be a JSON object schema: {schema}"
+    );
+
+    // check(): the container is configured with ROW/FULL/FULL binlog settings
+    // and the root user has all privileges, so both probes must pass.
+    let report = source
+        .check(&CheckContext::default())
+        .await
+        .expect("check report");
+    assert_eq!(report.failed_count(), 0, "all probes must pass: {report:?}");
+    let names: Vec<&str> = report.probes.iter().map(|p| p.name).collect();
+    assert!(
+        names.contains(&"connection"),
+        "expected a connection probe, got {names:?}"
+    );
+    assert!(
+        names.contains(&"binlog-config"),
+        "expected a binlog-config probe, got {names:?}"
+    );
+    for probe in &report.probes {
+        assert!(
+            matches!(probe.status, ProbeStatus::Pass),
+            "probe {} must pass: {:?}",
+            probe.name,
+            probe.status
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn check_reports_binlog_config_failure_when_row_metadata_minimal() {
+    // Boot MySQL WITHOUT the binlog flags the CDC source requires: the default
+    // `binlog_row_metadata` is MINIMAL, so the binlog-config probe must fail
+    // while the connection probe still passes. (`MysqlCdcSource::new()`'s own
+    // preflight would reject this, so we build via `check()` only — which is the
+    // `faucet doctor` path.)
+    let _permit = startup_limit()
+        .acquire()
+        .await
+        .expect("startup semaphore closed");
+    let container = Mysql::default()
+        .with_cmd(["--server-id=1", "--log-bin=mysql-bin"]) // no row-metadata=FULL
+        .start()
+        .await
+        .expect("mysql start");
+    let port = container
+        .get_host_port_ipv4(3306)
+        .await
+        .expect("mysql port");
+    let url = format!("mysql://root@127.0.0.1:{port}/test");
+
+    // `MysqlCdcSource::new()` runs the same `run_preflight_probes` that the
+    // `check()` binlog-config probe uses, so a server with the default MINIMAL
+    // `binlog_row_metadata` exercises the failing-variable branch and surfaces a
+    // typed error naming the offending variable.
+    let config: MysqlCdcSourceConfig = serde_json::from_value(json!({
+        "connection_url": url,
+        "server_id": 3003,
+        "idle_timeout": 5,
+        "batch_size": 0
+    }))
+    .expect("config");
+    // `MysqlCdcSource` is not `Debug`, so match the `Result` directly rather
+    // than via `expect_err` (which would require `Ok: Debug`).
+    let msg = match MysqlCdcSource::new(config).await {
+        Ok(_) => panic!("new() must reject MINIMAL binlog_row_metadata"),
+        Err(e) => e.to_string(),
+    };
+    assert!(
+        msg.contains("binlog_row_metadata"),
+        "error must name the offending binlog variable; got: {msg}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fetch_with_context_aggregates_and_emit_schema_changes_yields_ddl() {
+    // Two paths in one container:
+    //  1. `fetch_with_context` drains the stream into a flat Vec (aggregate mode).
+    //  2. `emit_schema_changes = true` turns a DDL `QueryEvent` into an
+    //     `{op:"ddl"}` envelope in the captured stream.
+    let (_container, url) = start_mysql_cdc().await;
+    {
+        let mut conn = connect(&url).await;
+        conn.query_drop("CREATE TABLE test.t (id INT PRIMARY KEY, n VARCHAR(32))")
+            .await
+            .expect("create table");
+    }
+
+    let config: MysqlCdcSourceConfig = serde_json::from_value(json!({
+        "connection_url": url,
+        "server_id": 4004,
+        "start_position": { "type": "current" },
+        "emit_schema_changes": true,
+        "idle_timeout": 5,
+        "batch_size": 0
+    }))
+    .expect("config");
+    let source = MysqlCdcSource::new(config).await.expect("source new");
+
+    let writer_url = url.clone();
+    let writer = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        let mut conn = connect(&writer_url).await;
+        conn.query_drop("INSERT INTO test.t (id, n) VALUES (1, 'x')")
+            .await
+            .expect("insert");
+        // DDL — auto-commits, must surface as an op:"ddl" envelope.
+        conn.query_drop("ALTER TABLE test.t ADD COLUMN extra INT")
+            .await
+            .expect("alter");
+    });
+
+    // `fetch_with_context` returns every record across the fetch cycle as a
+    // single flat Vec (it drives stream_pages with the batch_size=0 sentinel).
+    let ctx: HashMap<String, Value> = HashMap::new();
+    let records = source.fetch_with_context(&ctx).await.expect("fetch");
+    writer.await.expect("writer");
+
+    let ops: Vec<&str> = records
+        .iter()
+        .map(|r| r["op"].as_str().unwrap_or(""))
+        .collect();
+    assert!(
+        ops.contains(&"c"),
+        "fetch_with_context must aggregate the insert, got {ops:?}"
+    );
+
+    let ddl = records
+        .iter()
+        .find(|r| r["op"] == "ddl")
+        .expect("emit_schema_changes must produce a ddl envelope");
+    assert!(
+        ddl["statement"]
+            .as_str()
+            .unwrap_or("")
+            .contains("ALTER TABLE"),
+        "ddl envelope must carry the statement text: {ddl:?}"
+    );
+    assert!(
+        ddl["lsn"]["file"].is_string() && ddl["lsn"]["pos"].is_number(),
+        "ddl envelope must carry a file/pos lsn: {ddl:?}"
     );
 }

--- a/crates/source/parquet/tests/coverage.rs
+++ b/crates/source/parquet/tests/coverage.rs
@@ -1,0 +1,277 @@
+//! Additional coverage tests for `faucet-source-parquet`.
+//!
+//! These exercise branches not covered by `round_trip.rs` / `streaming.rs`:
+//! the metadata-read error path on a non-Parquet file, `config_schema()`, the
+//! S3 `dataset_uri` prefix / bucket-only branches (pure config, no network),
+//! the streaming projection path on a single local file, and glob expansion
+//! that skips directory entries. Fixtures are written with the raw
+//! `parquet::arrow::ArrowWriter` (no dependency on `faucet-sink-parquet`),
+//! mirroring the existing test style.
+
+use std::sync::Arc;
+
+use arrow::array::{Int32Array, Int64Array, RecordBatch, StringArray};
+use arrow::datatypes::{DataType, Field, Schema};
+use faucet_core::{Source, StreamPage};
+use faucet_source_parquet::{ParquetS3Config, ParquetSource, ParquetSourceConfig};
+use futures::StreamExt;
+use parquet::arrow::ArrowWriter;
+use std::fs::File;
+use std::path::Path;
+use tempfile::TempDir;
+
+fn write_parquet(path: &Path, batch: &RecordBatch) {
+    let file = File::create(path).expect("create file");
+    let mut writer = ArrowWriter::try_new(file, batch.schema(), None).expect("arrow writer");
+    writer.write(batch).expect("write batch");
+    writer.close().expect("close writer");
+}
+
+async fn collect_pages(source: &ParquetSource) -> Vec<StreamPage> {
+    let ctx = std::collections::HashMap::new();
+    let mut stream = source.stream_pages(&ctx, 0);
+    let mut pages = Vec::new();
+    while let Some(page) = stream.next().await {
+        pages.push(page.expect("stream_pages must not error"));
+    }
+    pages
+}
+
+#[tokio::test]
+async fn non_parquet_file_surfaces_metadata_read_error() {
+    // A file that exists but is not valid Parquet must fail at metadata-read
+    // time with a `FaucetError::Source` naming the file — not panic.
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("garbage.parquet");
+    std::fs::write(&path, b"this is not a parquet file at all").unwrap();
+
+    let source = ParquetSource::new(ParquetSourceConfig::local(path.to_str().unwrap()))
+        .await
+        .unwrap();
+    let err = source.fetch_all().await.expect_err("should fail");
+    match err {
+        faucet_core::FaucetError::Source(msg) => {
+            assert!(
+                msg.contains("garbage.parquet"),
+                "error must name the file: {msg}"
+            );
+        }
+        other => panic!("expected Source error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn non_parquet_file_surfaces_error_in_stream_pages() {
+    // Same corrupt-file failure mode, but driven through the streaming path:
+    // `open_target_stream` fails during the up-front schema-validation pass.
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("garbage.parquet");
+    std::fs::write(&path, b"definitely not parquet").unwrap();
+
+    let source = ParquetSource::new(ParquetSourceConfig::local(path.to_str().unwrap()))
+        .await
+        .unwrap();
+    let ctx = std::collections::HashMap::new();
+    let mut stream = source.stream_pages(&ctx, 0);
+    let mut errored = false;
+    let mut pages = 0usize;
+    while let Some(item) = stream.next().await {
+        match item {
+            Ok(_) => pages += 1,
+            Err(faucet_core::FaucetError::Source(msg)) => {
+                assert!(msg.contains("garbage.parquet"), "names file: {msg}");
+                errored = true;
+                break;
+            }
+            Err(other) => panic!("unexpected error: {other:?}"),
+        }
+    }
+    assert!(errored, "corrupt file must surface as a streaming error");
+    assert_eq!(pages, 0, "no pages may be yielded before the error");
+}
+
+#[tokio::test]
+async fn config_schema_serializes_to_object() {
+    // `config_schema()` must serialise the JSON Schema without panicking.
+    let source = ParquetSource::new(ParquetSourceConfig::local("/tmp/x.parquet"))
+        .await
+        .unwrap();
+    let schema = source.config_schema();
+    assert!(schema.is_object(), "schema should be a JSON object");
+    // The schema describes the `source` discriminated union field.
+    assert!(
+        schema.get("properties").is_some() || schema.get("$ref").is_some(),
+        "schema should expose properties or a $ref: {schema}"
+    );
+}
+
+#[tokio::test]
+async fn dataset_uri_s3_prefix_and_bucket_only() {
+    // The S3 prefix branch of `dataset_uri`.
+    let s3 = ParquetS3Config::prefix("my-bucket", "events/2024/");
+    let source = ParquetSource::new(ParquetSourceConfig::s3(s3))
+        .await
+        .unwrap();
+    assert_eq!(source.dataset_uri(), "s3://my-bucket/events/2024/");
+
+    // The bucket-only branch (neither key nor prefix set). `new()` succeeds —
+    // the key/prefix requirement is enforced at resolve time, not construction.
+    let s3 = ParquetS3Config {
+        bucket: "only-bucket".into(),
+        key: None,
+        prefix: None,
+        region: None,
+        endpoint_url: None,
+    };
+    let source = ParquetSource::new(ParquetSourceConfig::s3(s3))
+        .await
+        .unwrap();
+    assert_eq!(source.dataset_uri(), "s3://only-bucket");
+}
+
+#[tokio::test]
+async fn stream_pages_applies_column_projection() {
+    // The projection (`ProjectionMask`) path is exercised on a single local
+    // file through the streaming reader: only the requested columns appear in
+    // the emitted pages.
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("a", DataType::Int32, false),
+        Field::new("b", DataType::Int32, false),
+        Field::new("c", DataType::Int32, false),
+    ]));
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3])),
+            Arc::new(Int32Array::from(vec![10, 20, 30])),
+            Arc::new(Int32Array::from(vec![100, 200, 300])),
+        ],
+    )
+    .unwrap();
+
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("proj.parquet");
+    write_parquet(&path, &batch);
+
+    let cfg = ParquetSourceConfig::local(path.to_str().unwrap())
+        .columns(["b"])
+        .with_batch_size(2);
+    let source = ParquetSource::new(cfg).await.unwrap();
+
+    let pages = collect_pages(&source).await;
+    let total: usize = pages.iter().map(|p| p.records.len()).sum();
+    assert_eq!(total, 3);
+    for page in &pages {
+        for rec in &page.records {
+            let obj = rec.as_object().expect("object");
+            assert_eq!(obj.len(), 1, "only the projected column should remain");
+            assert!(obj.contains_key("b"));
+            assert!(!obj.contains_key("a"));
+            assert!(!obj.contains_key("c"));
+        }
+    }
+    // First emitted value carries the projected column's data.
+    assert_eq!(pages[0].records[0]["b"], 10);
+}
+
+#[tokio::test]
+async fn stream_pages_projection_missing_column_errors() {
+    // Streaming path: a projected column absent from the file fails during the
+    // up-front schema-validation pass, naming the missing column.
+    let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
+    let batch = RecordBatch::try_new(schema, vec![Arc::new(Int32Array::from(vec![1]))]).unwrap();
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("only_a.parquet");
+    write_parquet(&path, &batch);
+
+    let cfg = ParquetSourceConfig::local(path.to_str().unwrap()).columns(["missing"]);
+    let source = ParquetSource::new(cfg).await.unwrap();
+
+    let ctx = std::collections::HashMap::new();
+    let mut stream = source.stream_pages(&ctx, 0);
+    let first = stream.next().await.expect("an item");
+    match first {
+        Err(faucet_core::FaucetError::Source(msg)) => {
+            assert!(msg.contains("missing"), "names the column: {msg}");
+        }
+        other => panic!("expected projection Source error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn glob_skips_directory_entries() {
+    // `expand_glob` keeps only entries where `is_file()` is true. A pattern
+    // that also matches a subdirectory must not try to read the directory as a
+    // parquet file — only the real `.parquet` file is read.
+    let dir = TempDir::new().unwrap();
+    // A subdirectory that matches `*` but is not a file.
+    std::fs::create_dir(dir.path().join("nested.parquet")).unwrap();
+
+    let schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int64, false)]));
+    let batch =
+        RecordBatch::try_new(schema, vec![Arc::new(Int64Array::from(vec![1_i64, 2, 3]))]).unwrap();
+    write_parquet(&dir.path().join("data.parquet"), &batch);
+
+    let pattern = format!("{}/*.parquet", dir.path().display());
+    let source = ParquetSource::new(ParquetSourceConfig::glob(pattern))
+        .await
+        .unwrap();
+    let rows = source.fetch_all().await.unwrap();
+    assert_eq!(
+        rows.len(),
+        3,
+        "directory entry must be skipped, only the file read"
+    );
+    let mut nums: Vec<i64> = rows.iter().map(|r| r["v"].as_i64().unwrap()).collect();
+    nums.sort();
+    assert_eq!(nums, vec![1, 2, 3]);
+}
+
+#[tokio::test]
+async fn invalid_glob_pattern_is_config_error() {
+    // A syntactically invalid glob pattern surfaces as `FaucetError::Config`
+    // from `expand_glob`'s `glob::glob` parse step.
+    let source = ParquetSource::new(ParquetSourceConfig::glob("/tmp/[invalid"))
+        .await
+        .unwrap();
+    let err = source
+        .fetch_all()
+        .await
+        .expect_err("invalid glob should fail");
+    assert!(
+        matches!(err, faucet_core::FaucetError::Config(_)),
+        "expected Config error, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn stream_pages_single_local_file_round_trips() {
+    // A straightforward single-file streaming round-trip with the default
+    // batch size: every written row is recovered in order across the pages.
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("name", DataType::Utf8, false),
+    ]));
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int64Array::from(vec![1_i64, 2, 3])),
+            Arc::new(StringArray::from(vec!["a", "b", "c"])),
+        ],
+    )
+    .unwrap();
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("single.parquet");
+    write_parquet(&path, &batch);
+
+    let source = ParquetSource::new(ParquetSourceConfig::local(path.to_str().unwrap()))
+        .await
+        .unwrap();
+    let pages = collect_pages(&source).await;
+    let rows: Vec<_> = pages.into_iter().flat_map(|p| p.records).collect();
+    assert_eq!(rows.len(), 3);
+    assert_eq!(rows[0]["id"], 1);
+    assert_eq!(rows[0]["name"], "a");
+    assert_eq!(rows[2]["id"], 3);
+    assert_eq!(rows[2]["name"], "c");
+}

--- a/crates/source/postgres-cdc/src/pgoutput/decoder.rs
+++ b/crates/source/postgres-cdc/src/pgoutput/decoder.rs
@@ -586,4 +586,170 @@ mod tests {
             other => panic!("expected Insert, got {other:?}"),
         }
     }
+
+    #[test]
+    fn xlogdata_header_truncated_errors() {
+        // Only 23 bytes — one short of the 24-byte header.
+        let bytes = vec![0u8; XLogDataHeader::SIZE - 1];
+        let Err(err) = XLogDataHeader::decode(&bytes) else {
+            panic!("a header shorter than SIZE must be rejected");
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("XLogData header truncated"), "{msg}");
+        assert!(msg.contains("23 < 24"), "{msg}");
+    }
+
+    #[test]
+    fn keepalive_truncated_errors() {
+        // Only 16 bytes — one short of the 17-byte keepalive.
+        let bytes = vec![0u8; PrimaryKeepAlive::SIZE - 1];
+        let Err(err) = PrimaryKeepAlive::decode(&bytes) else {
+            panic!("a keepalive shorter than SIZE must be rejected");
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("PrimaryKeepAlive truncated"), "{msg}");
+        assert!(msg.contains("16 < 17"), "{msg}");
+    }
+
+    #[test]
+    fn keepalive_no_reply_requested() {
+        // wal_end=0/16A4F88, ts=750000000000000, reply_requested=0
+        let bytes = hex("00 00 00 00 01 6A 4F 88 \
+             00 02 A4 A6 4A 1B 80 00 \
+             00");
+        let k = PrimaryKeepAlive::decode(&bytes).unwrap();
+        assert_eq!(k.wal_end, 0x0000_0000_016A_4F88);
+        assert_eq!(k.server_ts, 0x0002_A4A6_4A1B_8000);
+        assert!(!k.reply_requested);
+    }
+
+    #[test]
+    fn decode_origin_message_ignored() {
+        // 'O' (0x4F) origin message — accepted and mapped to Message::Origin,
+        // the trailing payload bytes are not parsed in v1.
+        let bytes = hex("4F 00 00 00 00 01 6A 4F A0");
+        assert_eq!(decode_message(&bytes).unwrap(), Message::Origin);
+    }
+
+    #[test]
+    fn decode_type_message_ignored() {
+        // 'Y' (0x59) type-registration message — accepted and ignored in v1.
+        let bytes = hex("59 00 00 40 00");
+        assert_eq!(decode_message(&bytes).unwrap(), Message::Type);
+    }
+
+    #[test]
+    fn decode_insert_rejects_non_n_tuple_tag() {
+        // 'I', relation=16384, but the tuple tag is 'K' (0x4B) instead of 'N'.
+        let bytes = hex("49 00 00 40 00 4B");
+        let Err(err) = decode_message(&bytes) else {
+            panic!("INSERT with a non-'N' tuple tag must be rejected");
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("INSERT"), "{msg}");
+        assert!(msg.contains("expected 'N' tuple tag"), "{msg}");
+        assert!(msg.contains("'K'"), "{msg}");
+    }
+
+    #[test]
+    fn decode_update_rejects_invalid_first_tag() {
+        // 'U', relation=16384, first tag 'Z' (0x5A) — not K/O/N.
+        let bytes = hex("55 00 00 40 00 5A");
+        let Err(err) = decode_message(&bytes) else {
+            panic!("UPDATE with an invalid first tag must be rejected");
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("UPDATE"), "{msg}");
+        assert!(msg.contains("invalid first tag byte"), "{msg}");
+        assert!(msg.contains("0x5A"), "{msg}");
+    }
+
+    #[test]
+    fn decode_update_rejects_missing_n_after_old_tuple() {
+        // 'U', relation=16384, 'K', old{1 cell, t,1,"1"}, then 'X' (0x58)
+        // instead of the required 'N' new-tuple tag.
+        let bytes = hex("55 \
+             00 00 40 00 \
+             4B \
+             00 01 74 00 00 00 01 31 \
+             58");
+        let Err(err) = decode_message(&bytes) else {
+            panic!("UPDATE missing the 'N' new-tuple tag must be rejected");
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("UPDATE"), "{msg}");
+        assert!(
+            msg.contains("expected 'N' new-tuple tag after old tuple"),
+            "{msg}"
+        );
+        assert!(msg.contains("'X'"), "{msg}");
+    }
+
+    #[test]
+    fn decode_delete_rejects_invalid_tag() {
+        // 'D', relation=16384, tag 'N' (0x4E) — DELETE only accepts 'K' or 'O'.
+        let bytes = hex("44 00 00 40 00 4E");
+        let Err(err) = decode_message(&bytes) else {
+            panic!("DELETE with a non-K/O tuple tag must be rejected");
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("DELETE"), "{msg}");
+        assert!(msg.contains("expected 'K' or 'O' tuple tag"), "{msg}");
+        assert!(msg.contains("'N'"), "{msg}");
+    }
+
+    #[test]
+    fn decode_delete_full_old_tuple() {
+        // 'D', relation=16384, 'O', old{2, t,1,"1", t,5,"alice"}
+        let bytes = hex("44 \
+             00 00 40 00 \
+             4F \
+             00 02 74 00 00 00 01 31 74 00 00 00 05 61 6C 69 63 65");
+        match decode_message(&bytes).unwrap() {
+            Message::Delete(d) => {
+                assert_eq!(d.old_kind, DeleteOldKind::Full);
+                assert_eq!(d.old.cells.len(), 2);
+                assert_eq!(d.old.cells[1], TupleCell::Text("alice".into()));
+            }
+            other => panic!("expected Delete, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_tuple_rejects_non_utf8_text() {
+        // n_cells=1, kind 't', len=2, bytes 0xFF 0xFE (an invalid UTF-8 pair).
+        let bytes = hex("00 01 74 00 00 00 02 FF FE");
+        let mut c = Cursor::new(bytes.as_slice());
+        let Err(err) = decode_tuple(&mut c) else {
+            panic!("a non-UTF-8 text cell must be rejected");
+        };
+        assert!(err.to_string().contains("not UTF-8"), "{err}");
+    }
+
+    #[test]
+    fn decode_tuple_rejects_binary_mode_cell() {
+        // n_cells=1, kind 'b' (0x62) — binary-mode cells are unsupported in v1.
+        let bytes = hex("00 01 62");
+        let mut c = Cursor::new(bytes.as_slice());
+        let Err(err) = decode_tuple(&mut c) else {
+            panic!("a binary-mode cell must be rejected");
+        };
+        assert!(
+            err.to_string().contains("binary-mode cells not supported"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn decode_tuple_rejects_unknown_cell_tag() {
+        // n_cells=1, kind 'x' (0x78) — not n/u/t/b.
+        let bytes = hex("00 01 78");
+        let mut c = Cursor::new(bytes.as_slice());
+        let Err(err) = decode_tuple(&mut c) else {
+            panic!("an unknown cell tag must be rejected");
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("unknown cell tag"), "{msg}");
+        assert!(msg.contains("'x'"), "{msg}");
+    }
 }

--- a/crates/source/postgres-cdc/src/pgoutput/registry.rs
+++ b/crates/source/postgres-cdc/src/pgoutput/registry.rs
@@ -90,4 +90,30 @@ mod tests {
         let err = r.get(99999).unwrap_err();
         assert!(format!("{err}").contains("99999"));
     }
+
+    #[test]
+    fn reinsert_with_changed_columns_warns_and_replaces() {
+        use crate::pgoutput::messages::ColumnDesc;
+        let col = |name: &str, oid: u32| ColumnDesc {
+            flags: 0,
+            name: name.into(),
+            type_oid: oid,
+            type_modifier: -1,
+        };
+        let mut rel_v1 = rel(16384, "users");
+        rel_v1.columns = vec![col("id", 23)];
+        let mut rel_v2 = rel(16384, "users");
+        // A different column set (added column) exercises the schema-change
+        // warning branch; subsequent lookups bind against the new descriptor.
+        rel_v2.columns = vec![col("id", 23), col("email", 25)];
+
+        let mut r = RelationRegistry::new();
+        r.insert(rel_v1);
+        r.insert(rel_v2);
+
+        let got = r.get(16384).unwrap();
+        assert_eq!(got.columns.len(), 2);
+        assert_eq!(got.columns[1].name, "email");
+        assert_eq!(got.columns[1].type_oid, 25);
+    }
 }

--- a/crates/source/postgres-cdc/src/pgoutput/values.rs
+++ b/crates/source/postgres-cdc/src/pgoutput/values.rs
@@ -326,4 +326,129 @@ mod tests {
             json!("2026-05-17 12:34:56+00")
         );
     }
+
+    #[test]
+    fn int2_and_int8_arrays_decode() {
+        // _int2 (1005) → int2 elements.
+        assert_eq!(text_to_json(1005, "{1,2,3}").unwrap(), json!([1, 2, 3]));
+        // _int8 (1016) is already covered elsewhere; assert _int2 negative too.
+        assert_eq!(text_to_json(1005, "{-7,7}").unwrap(), json!([-7, 7]));
+    }
+
+    #[test]
+    fn float_arrays_decode() {
+        // _float4 (1021) and _float8 (1022) → JSON numbers.
+        assert_eq!(text_to_json(1021, "{1.5,2.5}").unwrap(), json!([1.5, 2.5]));
+        assert_eq!(
+            text_to_json(1022, "{3.25,-4.75}").unwrap(),
+            json!([3.25, -4.75])
+        );
+    }
+
+    #[test]
+    fn numeric_array_keeps_elements_as_strings() {
+        // _numeric (1231) → each element stays a string (NUMERIC is OID_NUMERIC).
+        assert_eq!(
+            text_to_json(1231, "{1.10,2.20}").unwrap(),
+            json!(["1.10", "2.20"])
+        );
+    }
+
+    #[test]
+    fn bytea_array_decodes_to_base64_elements() {
+        // _bytea (1001) → element OID_BYTEA → base64. \xDEADBEEF → "3q2+7w==".
+        assert_eq!(
+            text_to_json(1001, "{\\xDEADBEEF}").unwrap(),
+            json!(["3q2+7w=="])
+        );
+    }
+
+    #[test]
+    fn json_and_jsonb_arrays_decode_elements() {
+        // _json (199) and _jsonb (3807) → element OID_JSON/JSONB → parsed JSON.
+        // The element values are quoted so the embedded braces are not treated
+        // as a nested array by the array parser.
+        assert_eq!(
+            text_to_json(199, r#"{"{\"a\":1}"}"#).unwrap(),
+            json!([{"a": 1}])
+        );
+        assert_eq!(text_to_json(3807, r#"{"[1,2]"}"#).unwrap(), json!([[1, 2]]));
+    }
+
+    #[test]
+    fn varchar_bpchar_uuid_arrays_decode_to_strings() {
+        // _varchar (1015), _bpchar (1014), _uuid (2951) all map to string
+        // element types and pass through verbatim.
+        assert_eq!(text_to_json(1015, "{a,b}").unwrap(), json!(["a", "b"]));
+        assert_eq!(text_to_json(1014, "{x,y}").unwrap(), json!(["x", "y"]));
+        assert_eq!(
+            text_to_json(2951, "{11111111-1111-1111-1111-111111111111}").unwrap(),
+            json!(["11111111-1111-1111-1111-111111111111"])
+        );
+    }
+
+    #[test]
+    fn datetime_arrays_decode_to_strings() {
+        // _timestamp (1115), _timestamptz (1185), _date (1182), _time (1183)
+        // all map to text-passthrough element types. Commas-free literals so
+        // the simple parser splits cleanly.
+        assert_eq!(
+            text_to_json(1115, r#"{"2026-05-17 12:34:56"}"#).unwrap(),
+            json!(["2026-05-17 12:34:56"])
+        );
+        assert_eq!(
+            text_to_json(1185, r#"{"2026-05-17 12:34:56+00"}"#).unwrap(),
+            json!(["2026-05-17 12:34:56+00"])
+        );
+        assert_eq!(
+            text_to_json(1182, "{2026-05-17}").unwrap(),
+            json!(["2026-05-17"])
+        );
+        assert_eq!(
+            text_to_json(1183, "{12:34:56}").unwrap(),
+            json!(["12:34:56"])
+        );
+    }
+
+    #[test]
+    fn float_array_element_parse_error_propagates() {
+        // A float array whose element is not parseable surfaces the float
+        // parse error (lines 90-92) rather than falling back to a string.
+        let err = text_to_json(1022, "{not_a_float}").unwrap_err();
+        assert!(err.to_string().contains("float parse"), "{err}");
+    }
+
+    #[test]
+    fn json_array_element_parse_error_propagates() {
+        // A _json array whose element is not valid JSON surfaces the json
+        // parse error (lines 108-110).
+        let err = text_to_json(199, "{notjson}").unwrap_err();
+        assert!(err.to_string().contains("json/jsonb parse"), "{err}");
+    }
+
+    #[test]
+    fn array_oid_with_non_brace_text_falls_back_to_string() {
+        // An array OID (1007 _int4) whose text is not `{...}`-delimited makes
+        // parse_pg_array return None (line 142), so text_to_json falls back to
+        // wrapping the raw text in a string.
+        assert_eq!(
+            text_to_json(1007, "not-an-array").unwrap(),
+            json!("not-an-array")
+        );
+    }
+
+    #[test]
+    fn array_with_unterminated_quote_falls_back_to_string() {
+        // An unterminated quote makes parse_pg_array return None (line 185),
+        // so the whole literal is kept as a raw string.
+        let raw = r#"{"unterminated}"#;
+        assert_eq!(text_to_json(1009, raw).unwrap(), json!(raw));
+    }
+
+    #[test]
+    fn bytea_odd_length_hex_errors() {
+        // \x followed by an odd number of hex digits is rejected (lines 202-205).
+        let err = text_to_json(OID_BYTEA, "\\xABC").unwrap_err();
+        assert!(err.to_string().contains("odd length"), "{err}");
+    }
 }

--- a/crates/source/redis/src/stream.rs
+++ b/crates/source/redis/src/stream.rs
@@ -675,6 +675,45 @@ mod tests {
     }
 
     #[test]
+    fn dataset_uri_keys_source() {
+        use faucet_core::Source;
+        let source = RedisSource::new(RedisSourceConfig::new(
+            "redis://u:p@localhost:6379/0",
+            RedisSourceType::Keys {
+                pattern: "user:*".into(),
+            },
+        ))
+        .unwrap();
+        assert_eq!(
+            source.dataset_uri(),
+            "redis://localhost:6379/0?key=user:*",
+            "keys variant renders the glob pattern as the key, with credentials redacted"
+        );
+    }
+
+    #[test]
+    fn config_schema_describes_redis_source_config() {
+        use faucet_core::Source;
+        let source = RedisSource::new(RedisSourceConfig::new(
+            "redis://localhost",
+            RedisSourceType::List { key: "k".into() },
+        ))
+        .unwrap();
+        let schema = source.config_schema();
+        // The schema must expose the user-facing config fields.
+        let props = &schema["properties"];
+        assert!(props.get("url").is_some(), "schema exposes 'url'");
+        assert!(
+            props.get("source_type").is_some(),
+            "schema exposes 'source_type'"
+        );
+        assert!(
+            props.get("batch_size").is_some(),
+            "schema exposes 'batch_size'"
+        );
+    }
+
+    #[test]
     fn new_rejects_out_of_range_batch_size() {
         let mut config = RedisSourceConfig::new(
             "redis://localhost",

--- a/crates/source/redis/tests/fetch.rs
+++ b/crates/source/redis/tests/fetch.rs
@@ -1,0 +1,447 @@
+//! Integration tests for the convenience `RedisSource::fetch_all` and the
+//! `Source::fetch_with_context` paths against a real Redis instance via
+//! testcontainers. These exercise the batch (non-streaming) read APIs for all
+//! three source modes — list `LRANGE`, stream `XREAD` / `XREADGROUP`, and
+//! key-pattern `SCAN` + `MGET` — plus `max_records` truncation, empty/missing
+//! results, and the `${ctx}` key substitution path.
+//!
+//! These tests require Docker. Each test boots its own container and seeds its
+//! own keyspace so they are fully isolated and safe to run in parallel.
+
+use faucet_core::Source;
+use faucet_source_redis::{RedisSource, RedisSourceConfig, RedisSourceType};
+use redis::AsyncCommands;
+use std::collections::HashMap;
+use testcontainers::{ContainerAsync, runners::AsyncRunner};
+use testcontainers_modules::redis::{REDIS_PORT, Redis};
+
+/// Start a Redis container and return both the container handle and a
+/// connection URL. The container is kept alive by the returned handle.
+async fn start_redis() -> (ContainerAsync<Redis>, String) {
+    let container: ContainerAsync<Redis> = Redis::default()
+        .start()
+        .await
+        .expect("redis container start");
+    let host = container.get_host().await.expect("redis host");
+    let port = container
+        .get_host_port_ipv4(REDIS_PORT)
+        .await
+        .expect("redis port");
+    let url = format!("redis://{host}:{port}");
+    // Drive a PING through the same retry path used by the source so the
+    // container is fully reachable from the host before any test code runs.
+    let _ = open_conn(&url).await;
+    (container, url)
+}
+
+/// Open a multiplexed async connection for seeding the test container. Retries
+/// briefly on the initial connect — the "Ready to accept connections" log line
+/// testcontainers waits on can race with the port binding on some Docker hosts.
+async fn open_conn(url: &str) -> redis::aio::MultiplexedConnection {
+    let client = redis::Client::open(url).expect("redis client open");
+    let mut last_err: Option<redis::RedisError> = None;
+    for _ in 0..30 {
+        match client.get_multiplexed_async_connection().await {
+            Ok(conn) => return conn,
+            Err(e) => {
+                last_err = Some(e);
+                tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            }
+        }
+    }
+    panic!("redis connect: {:?}", last_err);
+}
+
+// ── List mode (fetch_all) ─────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fetch_all_list_returns_all_elements_in_order() {
+    let (_container, url) = start_redis().await;
+    let mut conn = open_conn(&url).await;
+    // RPUSH preserves insertion order; LRANGE 0 -1 returns head→tail.
+    let _: i64 = conn.rpush("items", "alpha").await.unwrap();
+    let _: i64 = conn.rpush("items", "beta").await.unwrap();
+    let _: i64 = conn.rpush("items", "gamma").await.unwrap();
+
+    let source = RedisSource::new(RedisSourceConfig::new(
+        &url,
+        RedisSourceType::List {
+            key: "items".into(),
+        },
+    ))
+    .unwrap();
+
+    let records = source.fetch_all().await.expect("fetch_all ok");
+    assert_eq!(
+        records,
+        vec!["alpha", "beta", "gamma"],
+        "non-JSON list elements come back as bare JSON strings, in list order"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fetch_all_list_parses_json_elements_and_falls_back_to_string() {
+    let (_container, url) = start_redis().await;
+    let mut conn = open_conn(&url).await;
+    // First element is valid JSON (parsed into an object), second is not
+    // (kept as a bare string) — exercises both arms of the parse/fallback.
+    let _: i64 = conn.rpush("mixed", "{\"n\":7}").await.unwrap();
+    let _: i64 = conn.rpush("mixed", "not-json").await.unwrap();
+
+    let source = RedisSource::new(RedisSourceConfig::new(
+        &url,
+        RedisSourceType::List {
+            key: "mixed".into(),
+        },
+    ))
+    .unwrap();
+
+    let records = source.fetch_all().await.expect("fetch_all ok");
+    assert_eq!(records.len(), 2);
+    assert_eq!(records[0]["n"], 7, "valid JSON element is parsed");
+    assert_eq!(
+        records[1], "not-json",
+        "invalid JSON falls back to a string"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fetch_all_list_respects_max_records() {
+    let (_container, url) = start_redis().await;
+    let mut conn = open_conn(&url).await;
+    for i in 0..10 {
+        let _: i64 = conn.rpush("capped", format!("e-{i}")).await.unwrap();
+    }
+
+    let source = RedisSource::new(
+        RedisSourceConfig::new(
+            &url,
+            RedisSourceType::List {
+                key: "capped".into(),
+            },
+        )
+        .max_records(3),
+    )
+    .unwrap();
+
+    let records = source.fetch_all().await.expect("fetch_all ok");
+    assert_eq!(
+        records,
+        vec!["e-0", "e-1", "e-2"],
+        "truncated to max_records"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fetch_all_list_missing_key_returns_empty() {
+    let (_container, url) = start_redis().await;
+    // Don't seed — LRANGE on a missing key returns an empty list, not an error.
+    let source = RedisSource::new(RedisSourceConfig::new(
+        &url,
+        RedisSourceType::List {
+            key: "no-such-list".into(),
+        },
+    ))
+    .unwrap();
+
+    let records = source.fetch_all().await.expect("fetch_all ok");
+    assert!(records.is_empty());
+}
+
+// ── Stream mode (fetch_all, no consumer group → XREAD) ────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fetch_all_stream_no_group_reads_whole_stream() {
+    let (_container, url) = start_redis().await;
+    let mut conn = open_conn(&url).await;
+    let _: String = conn.xadd("evt", "*", &[("name", "first")]).await.unwrap();
+    let _: String = conn.xadd("evt", "*", &[("name", "second")]).await.unwrap();
+
+    let source = RedisSource::new(RedisSourceConfig::new(
+        &url,
+        RedisSourceType::Stream {
+            key: "evt".into(),
+            group: None,
+            consumer: None,
+            count: None,
+        },
+    ))
+    .unwrap();
+
+    let records = source.fetch_all().await.expect("fetch_all ok");
+    assert_eq!(records.len(), 2);
+    assert_eq!(records[0]["fields"]["name"], "first");
+    assert_eq!(records[1]["fields"]["name"], "second");
+    let id0 = records[0]["id"].as_str().expect("id string");
+    assert!(id0.contains('-'), "stream id must be 'ms-seq', got {id0}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fetch_all_stream_no_group_with_count_caps_read() {
+    let (_container, url) = start_redis().await;
+    let mut conn = open_conn(&url).await;
+    for i in 0..5 {
+        let _: String = conn
+            .xadd("capped-stream", "*", &[("i", i.to_string())])
+            .await
+            .unwrap();
+    }
+
+    // An explicit `count` is the caller's own XREAD cap (no consumer group).
+    let source = RedisSource::new(RedisSourceConfig::new(
+        &url,
+        RedisSourceType::Stream {
+            key: "capped-stream".into(),
+            group: None,
+            consumer: None,
+            count: Some(2),
+        },
+    ))
+    .unwrap();
+
+    let records = source.fetch_all().await.expect("fetch_all ok");
+    assert_eq!(records.len(), 2, "XREAD COUNT caps the single read");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fetch_all_stream_no_group_empty_stream_returns_empty() {
+    let (_container, url) = start_redis().await;
+    let source = RedisSource::new(RedisSourceConfig::new(
+        &url,
+        RedisSourceType::Stream {
+            key: "absent-stream".into(),
+            group: None,
+            consumer: None,
+            count: None,
+        },
+    ))
+    .unwrap();
+
+    let records = source.fetch_all().await.expect("fetch_all ok");
+    assert!(records.is_empty());
+}
+
+// ── Stream mode (fetch_all, consumer group → XREADGROUP) ──────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fetch_all_stream_group_respects_max_records() {
+    // The XREADGROUP drain loop should stop once `max_records` is reached even
+    // when more entries are pending in the group.
+    let (_container, url) = start_redis().await;
+    let mut conn = open_conn(&url).await;
+    let _: () = redis::cmd("XGROUP")
+        .arg("CREATE")
+        .arg("mstream")
+        .arg("grp")
+        .arg("0")
+        .arg("MKSTREAM")
+        .query_async(&mut conn)
+        .await
+        .expect("XGROUP CREATE");
+    for i in 0..250 {
+        let _: String = conn
+            .xadd("mstream", "*", &[("i", i.to_string())])
+            .await
+            .unwrap();
+    }
+
+    let source = RedisSource::new(
+        RedisSourceConfig::new(
+            &url,
+            RedisSourceType::Stream {
+                key: "mstream".into(),
+                group: Some("grp".into()),
+                consumer: Some("worker".into()),
+                count: Some(100),
+            },
+        )
+        .max_records(120),
+    )
+    .unwrap();
+
+    let records = source.fetch_all().await.expect("fetch_all ok");
+    assert_eq!(
+        records.len(),
+        120,
+        "consumer-group drain must stop at max_records"
+    );
+}
+
+// ── Keys mode (fetch_all → SCAN + MGET) ───────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fetch_all_keys_returns_key_value_pairs() {
+    let (_container, url) = start_redis().await;
+    let mut conn = open_conn(&url).await;
+    let _: () = conn.set("user:alice", "{\"age\":30}").await.unwrap();
+    let _: () = conn.set("user:bob", "{\"age\":25}").await.unwrap();
+    // A key outside the pattern must be excluded by SCAN MATCH.
+    let _: () = conn.set("other:zed", "{\"age\":99}").await.unwrap();
+
+    let source = RedisSource::new(RedisSourceConfig::new(
+        &url,
+        RedisSourceType::Keys {
+            pattern: "user:*".into(),
+        },
+    ))
+    .unwrap();
+
+    let mut records = source.fetch_all().await.expect("fetch_all ok");
+    assert_eq!(records.len(), 2, "SCAN MATCH must exclude 'other:zed'");
+    records.sort_by(|a, b| a["key"].as_str().cmp(&b["key"].as_str()));
+    assert_eq!(records[0]["key"], "user:alice");
+    assert_eq!(records[0]["value"]["age"], 30);
+    assert_eq!(records[1]["key"], "user:bob");
+    assert_eq!(records[1]["value"]["age"], 25);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fetch_all_keys_non_json_value_falls_back_to_string() {
+    let (_container, url) = start_redis().await;
+    let mut conn = open_conn(&url).await;
+    let _: () = conn.set("plain:k", "hello-world").await.unwrap();
+
+    let source = RedisSource::new(RedisSourceConfig::new(
+        &url,
+        RedisSourceType::Keys {
+            pattern: "plain:*".into(),
+        },
+    ))
+    .unwrap();
+
+    let records = source.fetch_all().await.expect("fetch_all ok");
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0]["key"], "plain:k");
+    assert_eq!(
+        records[0]["value"], "hello-world",
+        "non-JSON value is preserved as a bare string"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fetch_all_keys_no_match_returns_empty() {
+    let (_container, url) = start_redis().await;
+    // Empty keyspace — SCAN matches nothing, the early `keys.is_empty()` branch
+    // returns before any MGET round-trip.
+    let source = RedisSource::new(RedisSourceConfig::new(
+        &url,
+        RedisSourceType::Keys {
+            pattern: "ghost:*".into(),
+        },
+    ))
+    .unwrap();
+
+    let records = source.fetch_all().await.expect("fetch_all ok");
+    assert!(records.is_empty());
+}
+
+// ── fetch_with_context: empty ctx delegates, non-empty ctx substitutes ────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fetch_with_context_empty_delegates_to_fetch_all() {
+    let (_container, url) = start_redis().await;
+    let mut conn = open_conn(&url).await;
+    let _: i64 = conn.rpush("plain-list", "x").await.unwrap();
+    let _: i64 = conn.rpush("plain-list", "y").await.unwrap();
+
+    let source = RedisSource::new(RedisSourceConfig::new(
+        &url,
+        RedisSourceType::List {
+            key: "plain-list".into(),
+        },
+    ))
+    .unwrap();
+
+    let ctx: HashMap<String, serde_json::Value> = HashMap::new();
+    let records = source.fetch_with_context(&ctx).await.expect("ok");
+    assert_eq!(records, vec!["x", "y"]);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fetch_with_context_substitutes_list_key() {
+    let (_container, url) = start_redis().await;
+    let mut conn = open_conn(&url).await;
+    let _: i64 = conn.rpush("list:42", "only").await.unwrap();
+
+    let source = RedisSource::new(RedisSourceConfig::new(
+        &url,
+        RedisSourceType::List {
+            key: "list:{tenant}".into(),
+        },
+    ))
+    .unwrap();
+
+    let mut ctx: HashMap<String, serde_json::Value> = HashMap::new();
+    ctx.insert("tenant".into(), serde_json::json!("42"));
+    let records = source.fetch_with_context(&ctx).await.expect("ok");
+    assert_eq!(
+        records,
+        vec!["only"],
+        "key '{{tenant}}' resolved to 'list:42'"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fetch_with_context_substitutes_stream_key() {
+    let (_container, url) = start_redis().await;
+    let mut conn = open_conn(&url).await;
+    let _: String = conn
+        .xadd("stream:eu", "*", &[("region", "eu")])
+        .await
+        .unwrap();
+
+    let source = RedisSource::new(RedisSourceConfig::new(
+        &url,
+        RedisSourceType::Stream {
+            key: "stream:{region}".into(),
+            group: None,
+            consumer: None,
+            count: None,
+        },
+    ))
+    .unwrap();
+
+    let mut ctx: HashMap<String, serde_json::Value> = HashMap::new();
+    ctx.insert("region".into(), serde_json::json!("eu"));
+    let records = source.fetch_with_context(&ctx).await.expect("ok");
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0]["fields"]["region"], "eu");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fetch_with_context_substitutes_keys_pattern_and_respects_max_records() {
+    let (_container, url) = start_redis().await;
+    let mut conn = open_conn(&url).await;
+    for i in 0..6 {
+        let _: () = conn
+            .set(format!("acct:7:{i}"), format!("{{\"i\":{i}}}"))
+            .await
+            .unwrap();
+    }
+
+    let source = RedisSource::new(
+        RedisSourceConfig::new(
+            &url,
+            RedisSourceType::Keys {
+                pattern: "acct:{id}:*".into(),
+            },
+        )
+        .max_records(2),
+    )
+    .unwrap();
+
+    let mut ctx: HashMap<String, serde_json::Value> = HashMap::new();
+    ctx.insert("id".into(), serde_json::json!("7"));
+    let records = source.fetch_with_context(&ctx).await.expect("ok");
+    assert_eq!(
+        records.len(),
+        2,
+        "pattern 'acct:{{id}}:*' resolved to 'acct:7:*' and truncated to max_records"
+    );
+    for r in &records {
+        assert!(
+            r["key"].as_str().unwrap().starts_with("acct:7:"),
+            "every key matches the resolved pattern"
+        );
+    }
+}

--- a/crates/source/rest/src/auth/oauth2.rs
+++ b/crates/source/rest/src/auth/oauth2.rs
@@ -146,3 +146,178 @@ async fn fetch_oauth2_token_inner_with_client(
     let token_resp: TokenResponse = resp.json().await?;
     Ok((token_resp.access_token, token_resp.expires_in))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{body_string_contains, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[tokio::test]
+    async fn fetch_oauth2_token_returns_access_token_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            // The client-credentials grant must POST the form fields.
+            .and(body_string_contains("grant_type=client_credentials"))
+            .and(body_string_contains("scope=read+write"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "abc123",
+                "expires_in": 3600,
+                "token_type": "Bearer"
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let url = format!("{}/token", server.uri());
+        let token = fetch_oauth2_token(&url, "id", "secret", &["read".into(), "write".into()])
+            .await
+            .expect("token fetch should succeed");
+        assert_eq!(token, "abc123");
+    }
+
+    #[tokio::test]
+    async fn fetch_oauth2_token_maps_error_status_to_auth_error_with_body() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(401).set_body_string("invalid_client"))
+            .mount(&server)
+            .await;
+        let url = format!("{}/token", server.uri());
+        let err = fetch_oauth2_token(&url, "id", "bad", &[])
+            .await
+            .expect_err("401 must surface as an error");
+        match err {
+            FaucetError::Auth(msg) => {
+                assert!(msg.contains("HTTP 401"), "status must be in message: {msg}");
+                assert!(
+                    msg.contains("invalid_client"),
+                    "error body must be included: {msg}"
+                );
+            }
+            other => panic!("expected FaucetError::Auth, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn get_or_refresh_caches_token_across_calls() {
+        let server = MockServer::start().await;
+        // `.expect(1)` asserts the network is hit exactly once even though
+        // get_or_refresh is called twice — proving the cache-hit branch.
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "cached-token",
+                "expires_in": 3600
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let url = format!("{}/token", server.uri());
+        let client = Client::new();
+        let cache = TokenCache::new();
+        let t1 = cache
+            .get_or_refresh(&client, &url, "id", "secret", &[], DEFAULT_EXPIRY_RATIO)
+            .await
+            .unwrap();
+        let t2 = cache
+            .get_or_refresh(&client, &url, "id", "secret", &[], DEFAULT_EXPIRY_RATIO)
+            .await
+            .unwrap();
+        assert_eq!(t1, "cached-token");
+        assert_eq!(t2, "cached-token");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn get_or_refresh_refetches_after_proactive_expiry() {
+        let server = MockServer::start().await;
+        // expires_in=100, ratio=0.9 → token considered expired after 90s.
+        // Two fetches expected: initial, then after the clock advances past 90s.
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "rotating",
+                "expires_in": 100
+            })))
+            .expect(2)
+            .mount(&server)
+            .await;
+        let url = format!("{}/token", server.uri());
+        let client = Client::new();
+        let cache = TokenCache::new();
+        cache
+            .get_or_refresh(&client, &url, "id", "s", &[], 0.9)
+            .await
+            .unwrap();
+        tokio::time::advance(std::time::Duration::from_secs(91)).await;
+        cache
+            .get_or_refresh(&client, &url, "id", "s", &[], 0.9)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn get_or_refresh_treats_missing_expiry_as_valid_indefinitely() {
+        let server = MockServer::start().await;
+        // No `expires_in` → expires_at = None → is_valid()'s None arm keeps the
+        // token forever, so the second call must not re-hit the network.
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "no-expiry"
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let url = format!("{}/token", server.uri());
+        let client = Client::new();
+        let cache = TokenCache::new();
+        let t1 = cache
+            .get_or_refresh(&client, &url, "i", "s", &[], 0.9)
+            .await
+            .unwrap();
+        let t2 = cache
+            .get_or_refresh(&client, &url, "i", "s", &[], 0.9)
+            .await
+            .unwrap();
+        assert_eq!(t1, "no-expiry");
+        assert_eq!(t2, "no-expiry");
+    }
+
+    #[tokio::test]
+    async fn get_or_refresh_propagates_server_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("boom"))
+            .mount(&server)
+            .await;
+        let url = format!("{}/token", server.uri());
+        let client = Client::new();
+        let cache = TokenCache::new();
+        let err = cache
+            .get_or_refresh(&client, &url, "i", "s", &[], 0.9)
+            .await
+            .expect_err("5xx must propagate");
+        assert!(matches!(err, FaucetError::Auth(_)));
+    }
+
+    #[test]
+    fn cached_token_without_expiry_is_always_valid() {
+        let token = CachedToken {
+            access_token: "x".into(),
+            expires_at: None,
+        };
+        assert!(token.is_valid());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn cached_token_with_future_expiry_is_valid_until_it_passes() {
+        let token = CachedToken {
+            access_token: "x".into(),
+            expires_at: Some(tokio::time::Instant::now() + std::time::Duration::from_secs(60)),
+        };
+        assert!(token.is_valid(), "still inside the window");
+        tokio::time::advance(std::time::Duration::from_secs(61)).await;
+        assert!(
+            !token.is_valid(),
+            "expired once the clock passes expires_at"
+        );
+    }
+}

--- a/crates/source/snowflake/src/stream.rs
+++ b/crates/source/snowflake/src/stream.rs
@@ -751,6 +751,39 @@ mod tests {
     }
 
     #[test]
+    fn build_request_body_array_and_object_bindings_fall_back_to_text() {
+        // The catch-all arm (`other => ("TEXT", ...)`) stringifies array/object
+        // JSON values into a TEXT bind so they keep their positional slot.
+        let src = SnowflakeSource::new(cfg()).unwrap();
+        let body = src.build_request_body(&[json!([1, 2, 3]), json!({"k": "v"})]);
+        let b = &body["bindings"];
+        assert_eq!(b["1"]["type"], "TEXT");
+        assert_eq!(b["1"]["value"], "[1,2,3]");
+        assert_eq!(b["2"]["type"], "TEXT");
+        assert_eq!(b["2"]["value"], r#"{"k":"v"}"#);
+    }
+
+    #[test]
+    fn connector_name_is_snowflake() {
+        use faucet_core::Source;
+        let src = SnowflakeSource::new(cfg()).unwrap();
+        assert_eq!(src.connector_name(), "snowflake");
+    }
+
+    #[test]
+    fn config_schema_reports_required_fields() {
+        use faucet_core::Source;
+        let src = SnowflakeSource::new(cfg()).unwrap();
+        let schema = src.config_schema();
+        // The generated JSON Schema should describe the config's properties.
+        assert!(schema["properties"]["account"].is_object());
+        assert!(schema["properties"]["query"].is_object());
+        let required = schema["required"].as_array().expect("required array");
+        assert!(required.iter().any(|v| v == "account"));
+        assert!(required.iter().any(|v| v == "query"));
+    }
+
+    #[test]
     fn build_request_body_null_binding_preserves_positional_alignment() {
         // Regression for #78/#18: a NULL must occupy its positional slot as an
         // explicit null-valued binding, not be skipped (which would shift "42"

--- a/crates/source/snowflake/tests/snowflake_source_errors.rs
+++ b/crates/source/snowflake/tests/snowflake_source_errors.rs
@@ -1,0 +1,441 @@
+//! Integration tests for the Snowflake source's less-travelled HTTP paths:
+//!
+//! - the asynchronous (HTTP 202) submit → poll-until-ready flow,
+//! - the 202-without-handle error and the poll-timeout error,
+//! - partition-fetch failures (HTTP non-success and a missing handle),
+//! - the key-pair JWT auth header shape,
+//! - `faucet doctor` probe failures (auth-resolution, request, and HTTP).
+//!
+//! All scenarios run against a wiremock server; no live Snowflake is touched.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use faucet_core::check::{CheckContext, ProbeStatus};
+use faucet_core::{AuthSpec, FaucetError, Source};
+use faucet_source_snowflake::{SnowflakeAuth, SnowflakeSource, SnowflakeSourceConfig};
+use serde_json::{Value, json};
+use wiremock::matchers::{body_partial_json, header, header_exists, method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn cfg() -> SnowflakeSourceConfig {
+    SnowflakeSourceConfig::new(
+        "xy12345",
+        "WH",
+        "DB",
+        "PUBLIC",
+        SnowflakeAuth::OAuth { token: "t".into() },
+        "SELECT id FROM events",
+    )
+    .with_batch_size(10)
+}
+
+fn build_source(cfg: SnowflakeSourceConfig, server: &MockServer) -> SnowflakeSource {
+    SnowflakeSource::new(cfg)
+        .unwrap()
+        .with_endpoint_base(server.uri())
+}
+
+fn metadata(num_partitions: usize) -> Value {
+    let partition_info: Vec<Value> = (0..num_partitions)
+        .map(|_| json!({"rowCount": 1}))
+        .collect();
+    json!({
+        "rowType": [{"name": "ID", "type": "fixed"}],
+        "partitionInfo": partition_info,
+    })
+}
+
+// --- Async submit (HTTP 202) → poll-until-ready -----------------------------
+
+#[tokio::test]
+async fn async_202_submit_is_polled_until_ready_then_rows_decode() {
+    let server = MockServer::start().await;
+
+    // The initial POST is accepted asynchronously: 202 + a handle to poll.
+    Mock::given(method("POST"))
+        .and(path("/api/v2/statements"))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+            "statementHandle": "async-h",
+            "message": "Asynchronous execution in progress"
+        })))
+        .mount(&server)
+        .await;
+
+    // Polling the handle (no `partition` query param) returns the finished
+    // result set with schema + a single row.
+    Mock::given(method("GET"))
+        .and(path("/api/v2/statements/async-h"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "code": "090001",
+            "statementHandle": "async-h",
+            "resultSetMetaData": metadata(1),
+            "data": [["7"]],
+        })))
+        .mount(&server)
+        .await;
+
+    let src = build_source(cfg(), &server);
+    let rows = src.fetch_all().await.unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["ID"], 7);
+
+    // One POST (submit) followed by at least one GET (poll).
+    let reqs = server.received_requests().await.unwrap();
+    assert_eq!(reqs[0].method.as_str(), "POST");
+    assert!(reqs.iter().skip(1).all(|r| r.method.as_str() == "GET"));
+}
+
+#[tokio::test]
+async fn async_202_submit_without_handle_is_an_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/v2/statements"))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+            "message": "accepted but no handle"
+        })))
+        .mount(&server)
+        .await;
+
+    let src = build_source(cfg(), &server);
+    let err = src.fetch_all().await.unwrap_err();
+    match err {
+        FaucetError::Source(msg) => {
+            assert!(
+                msg.contains("without a statementHandle"),
+                "unexpected: {msg}"
+            );
+        }
+        other => panic!("expected Source error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn poll_gives_up_after_poll_timeout() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/v2/statements"))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+            "statementHandle": "stuck-h"
+        })))
+        .mount(&server)
+        .await;
+    // The statement never finishes — every poll stays 202.
+    Mock::given(method("GET"))
+        .and(path("/api/v2/statements/stuck-h"))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+            "statementHandle": "stuck-h"
+        })))
+        .mount(&server)
+        .await;
+
+    let src = build_source(cfg().with_poll_timeout(Duration::from_millis(1)), &server);
+    let err = src.fetch_all().await.unwrap_err();
+    match err {
+        FaucetError::Source(msg) => {
+            assert!(msg.contains("poll_timeout"), "unexpected: {msg}");
+            assert!(msg.contains("stuck-h"), "should name the handle: {msg}");
+        }
+        other => panic!("expected Source error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn poll_http_error_surfaces_as_source_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/v2/statements"))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+            "statementHandle": "err-h"
+        })))
+        .mount(&server)
+        .await;
+    // The poll itself returns a hard 500.
+    Mock::given(method("GET"))
+        .and(path("/api/v2/statements/err-h"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("boom"))
+        .mount(&server)
+        .await;
+
+    let src = build_source(cfg(), &server);
+    let err = src.fetch_all().await.unwrap_err();
+    match err {
+        FaucetError::Source(msg) => {
+            assert!(msg.contains("poll returned HTTP 500"), "unexpected: {msg}");
+            assert!(msg.contains("boom"), "should carry the body: {msg}");
+        }
+        other => panic!("expected Source error, got {other:?}"),
+    }
+}
+
+// --- Partition-fetch failures ----------------------------------------------
+
+#[tokio::test]
+async fn partition_fetch_http_error_surfaces_with_status_and_index() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/v2/statements"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "code": "090001",
+            "statementHandle": "ph",
+            "resultSetMetaData": metadata(2),
+            "data": [["0"]],
+        })))
+        .mount(&server)
+        .await;
+    // The second partition fetch fails with 503.
+    Mock::given(method("GET"))
+        .and(path("/api/v2/statements/ph"))
+        .and(query_param("partition", "1"))
+        .respond_with(ResponseTemplate::new(503).set_body_string("unavailable"))
+        .mount(&server)
+        .await;
+
+    let src = build_source(cfg(), &server);
+    let err = src.fetch_all().await.unwrap_err();
+    match err {
+        FaucetError::Source(msg) => {
+            assert!(msg.contains("partition fetch"), "unexpected: {msg}");
+            assert!(msg.contains("503"), "should carry status: {msg}");
+            assert!(msg.contains("partition 1"), "should name index: {msg}");
+        }
+        other => panic!("expected Source error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn partition_fetch_parse_error_surfaces_as_source_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/v2/statements"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "code": "090001",
+            "statementHandle": "ph2",
+            "resultSetMetaData": metadata(2),
+            "data": [["0"]],
+        })))
+        .mount(&server)
+        .await;
+    // Second partition returns 200 but a non-JSON body → parse failure.
+    Mock::given(method("GET"))
+        .and(path("/api/v2/statements/ph2"))
+        .and(query_param("partition", "1"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("not-json-at-all"))
+        .mount(&server)
+        .await;
+
+    let src = build_source(cfg(), &server);
+    let err = src.fetch_all().await.unwrap_err();
+    match err {
+        FaucetError::Source(msg) => {
+            assert!(
+                msg.contains("failed to parse Snowflake partition response"),
+                "unexpected: {msg}"
+            );
+            assert!(msg.contains("partition 1"), "should name index: {msg}");
+        }
+        other => panic!("expected Source error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn fetch_all_missing_handle_with_multiple_partitions_errors() {
+    let server = MockServer::start().await;
+    // metadata claims 2 partitions but the response omits `statementHandle`,
+    // so the source has no way to fetch partition 1.
+    Mock::given(method("POST"))
+        .and(path("/api/v2/statements"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "code": "090001",
+            "resultSetMetaData": metadata(2),
+            "data": [["0"]],
+        })))
+        .mount(&server)
+        .await;
+
+    let src = build_source(cfg(), &server);
+    let err = src.fetch_all().await.unwrap_err();
+    match err {
+        FaucetError::Source(msg) => assert!(
+            msg.contains("without a statementHandle"),
+            "unexpected: {msg}"
+        ),
+        other => panic!("expected Source error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn stream_pages_missing_handle_with_multiple_partitions_errors() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/v2/statements"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "code": "090001",
+            "resultSetMetaData": metadata(2),
+            "data": [["0"]],
+        })))
+        .mount(&server)
+        .await;
+
+    use futures::StreamExt;
+    let src = build_source(cfg(), &server);
+    let ctx = HashMap::new();
+    let pages: Vec<_> = src.stream_pages(&ctx, 0).collect().await;
+    // The first partition's row yields a page; the missing handle then errors.
+    let err = pages
+        .into_iter()
+        .find_map(|p| p.err())
+        .expect("expected a partition-fetch error in the stream");
+    match err {
+        FaucetError::Source(msg) => assert!(
+            msg.contains("without a statementHandle"),
+            "unexpected: {msg}"
+        ),
+        other => panic!("expected Source error, got {other:?}"),
+    }
+}
+
+// --- Key-pair JWT auth header ----------------------------------------------
+
+// Throwaway 2048-bit RSA test key (PKCS#8). Not used anywhere real.
+const TEST_RSA_PKCS8_PEM: &str = "-----BEGIN PRIVATE KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDDmeSF5jD5LMGw
+INB1hExU2Ux9qEQ9DXNUeWxrDv7K3QHA+UkCbdUpHDZdFSbIr/bvwlNn16Hqhqi9
+b8WywAzjagZNg0cReXuQ7nKIr5c9zYl2EJe+RZTo2z2LE21HrSKRhTAmlOk3XJ1N
+xc7ahYcKyw8lchuTcZaYWaNTYvronOpHUAGS0XpT0y8Oggzp1DvZNYOeZbJCPZwf
+mpGGCSilnODNYnwT02Pc4aXXBzJP7TP57+ve/ZzqvsKCBiNJUMLsjUZcGWnqQHnR
+A+8B87ug7CyhhEiYnskp0d1ZlWT/kU7rIZv58KMbMJidAdizA47jRjelsWeoedRf
+JmiA99ZhAgMBAAECggEAAOrybwxm82xZ1k05HSwLPaStXrOQ6mZrQZy2PQRbfrEt
+xm2FAa1pQCGhQauNPIjS1EopoQWafWK3XPguyclr5g9Dy05P4Y2b3lC4GdsVDxWt
+TPAD/kEOU09gCQyEyT7PODaTRMMTGw7ksA47C7xvp0XPouHXrkfsqHdXNFd1DO1Z
+dBCzkX4dg4Y4ffh5tt/ILeSsNlmqqpUQmHQZ/X3JHkP9/+NpAe6i4k9QKsqmLDGD
+7+br/snVYbECBgmN1QIofTSvnlmmRiKgoG9wbZLmGvCiW9xVjbY+ryJs/lsLoM7w
+W1TUuOlk3apoIzQ7OIGznyZzE5RumdQq11rNKB7aaQKBgQDowsceEQz2kLb93f8J
+QaBDcebqbbGTJE6+hq2k8D/GzvZAdBHGuEt7NiDAFKy/GItwzJSGGdjK24iRtZ7G
+2gIloZShu+7mmxX6Ojuxun8EMRZKZzTedMJWQJMwA1Hk1fwzsEM0+9+yZdTcylP9
+wYDMFKbvw+av7sDcySENNEhshQKBgQDXIVX+Zvlf2PoLkRx11mk1CBtPfjqPTMcs
+QVjISwvkgGSi8ihq+mwsIWLXhOZX38+L4iGfdIgqSSnwqB/fgTbjwQsa0Dqkygt6
+IBfb3QmWr7196c+xss5h8eUTFiCMWw/EAa9R+jkWH0cVpJVbyTK7cBJlaXxPcXx3
+xprI10qnLQKBgBl/NKajgYME6Ta3+bb+3FpnAL+PUpNmt8WBJUZbFvFlPG5lCIl3
+KLWPgVjpKt8oBiZOErr529ik4bnsZj8sJG4Q3CI3Xv0d4fNuK5nVbxJ7ehCea5ku
+uxcNrdHlmzPxCNZ0qXgFW0TEiOPCuh6i8sPoQz0ifYOqKLBGy/sRThmtAoGAGTd9
+Hv7vCD8kwCpYTa++UUsL+HtxXc7AIf3e7Etvr28lXLxJ5JBKEbowHdckMPS5HUp6
+anh8ZYiB9AWhBs/coUHFjXUPCrXsNnqAkXMNZq5e5d18TPYKnwx9r4kOc6VQ6cbQ
+yCkue9tat7y9DS8+VR5D6cM9oQpKbrfG+PfTdlkCgYBf/pUWO94VgZvpV5Ui7MHb
+6ZoH11q0gIhmT72FQ+2Erw977qghzs1+C7HO4Q7kNfC8sA9uVS4WiA1EzE6QeJWt
++FklEinW+AR2azgC/+gEUBvZSWU1v4meYdAQcNEek8L4VtBuGc4ZwbVbho3hiLmx
+68Y3qeoKxOyBKo6j2NiZzg==
+-----END PRIVATE KEY-----
+";
+
+#[tokio::test]
+async fn key_pair_auth_sends_bearer_jwt_and_keypair_token_type() {
+    let server = MockServer::start().await;
+    // Only respond when the Authorization header is a Bearer JWT and the token
+    // type is KEYPAIR_JWT. A mismatch ⇒ no match ⇒ 404 ⇒ test fails.
+    Mock::given(method("POST"))
+        .and(path("/api/v2/statements"))
+        .and(header(
+            "X-Snowflake-Authorization-Token-Type",
+            "KEYPAIR_JWT",
+        ))
+        .and(header_exists("Authorization"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "code": "090001",
+            "statementHandle": "h",
+            "resultSetMetaData": metadata(1),
+            "data": [["1"]],
+        })))
+        .mount(&server)
+        .await;
+
+    let cfg = SnowflakeSourceConfig::new(
+        "acct",
+        "WH",
+        "DB",
+        "PUBLIC",
+        SnowflakeAuth::KeyPair {
+            user: "u".into(),
+            private_key_pem: TEST_RSA_PKCS8_PEM.into(),
+        },
+        "SELECT 1",
+    );
+    let src = build_source(cfg, &server);
+    let rows = src.fetch_all().await.unwrap();
+    assert_eq!(rows.len(), 1);
+
+    // Confirm the actual Authorization value is a `Bearer <jwt>`.
+    let reqs = server.received_requests().await.unwrap();
+    let auth = reqs[0]
+        .headers
+        .get("Authorization")
+        .unwrap()
+        .to_str()
+        .unwrap();
+    assert!(auth.starts_with("Bearer "), "auth header: {auth}");
+}
+
+// --- `faucet doctor` probe failures ----------------------------------------
+
+#[tokio::test]
+async fn check_fails_on_unresolved_auth_reference() {
+    // No mock server interaction: auth resolution fails before any request.
+    let server = MockServer::start().await;
+    let mut config = cfg();
+    config.auth = AuthSpec::Reference(faucet_core::AuthReference {
+        name: "missing".into(),
+    });
+    let src = build_source(config, &server);
+
+    let report = src.check(&CheckContext::default()).await.unwrap();
+    let probe = &report.probes[0];
+    assert_eq!(probe.name, "auth");
+    match &probe.status {
+        ProbeStatus::Fail { reason } => assert!(reason.contains("missing"), "reason: {reason}"),
+        other => panic!("expected a Fail probe, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn check_fails_on_http_error_response() {
+    let server = MockServer::start().await;
+    // doctor submits `SELECT 1`; respond to it with a 403.
+    Mock::given(method("POST"))
+        .and(path("/api/v2/statements"))
+        .and(body_partial_json(json!({"statement": "SELECT 1"})))
+        .respond_with(ResponseTemplate::new(403).set_body_string("forbidden"))
+        .mount(&server)
+        .await;
+
+    let src = build_source(cfg(), &server);
+    let report = src.check(&CheckContext::default()).await.unwrap();
+    let probe = &report.probes[0];
+    assert_eq!(probe.name, "query");
+    match &probe.status {
+        ProbeStatus::Fail { reason } => {
+            assert!(reason.contains("403"), "reason: {reason}");
+            assert!(reason.contains("forbidden"), "reason: {reason}");
+        }
+        other => panic!("expected a Fail probe, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn check_fails_when_endpoint_unreachable() {
+    // Point at a closed port so the request layer (`reqwest::send`) fails.
+    let src = SnowflakeSource::new(cfg())
+        .unwrap()
+        .with_endpoint_base("http://127.0.0.1:1");
+    let report = src.check(&CheckContext::default()).await.unwrap();
+    let probe = &report.probes[0];
+    assert_eq!(probe.name, "query");
+    match &probe.status {
+        ProbeStatus::Fail { reason } => {
+            assert!(
+                reason.contains("Snowflake request failed"),
+                "reason: {reason}"
+            )
+        }
+        other => panic!("expected a Fail probe, got {other:?}"),
+    }
+}

--- a/crates/source/xml/src/convert.rs
+++ b/crates/source/xml/src/convert.rs
@@ -632,4 +632,192 @@ mod tests {
         assert_eq!(streamed.len(), 2);
         assert_eq!(streamed[1]["Name"], "Bob");
     }
+
+    #[test]
+    fn xml_to_json_mixed_text_and_children_keeps_both() {
+        // An element with both text and a child element is NOT flattened to a
+        // bare string (obj.len() != 1), so #text and the child coexist.
+        let xml = r#"<root><p>hello<b>bold</b></p></root>"#;
+        let json = xml_to_json(xml).unwrap();
+        assert_eq!(json["root"]["p"]["#text"], "hello");
+        assert_eq!(json["root"]["p"]["b"], "bold");
+    }
+
+    #[test]
+    fn xml_to_json_text_split_by_entity_is_concatenated() {
+        // An entity reference (&amp;) splits the character data into two
+        // Text events on the same element; the second event hits the
+        // "#text already a String" branch and appends with a space.
+        let xml = r#"<root><msg>foo &amp; bar</msg></root>"#;
+        let json = xml_to_json(xml).unwrap();
+        assert_eq!(json["root"]["msg"], "foo & bar");
+    }
+
+    #[test]
+    fn xml_to_json_text_then_cdata_concatenated() {
+        // Leading plain text followed by a CDATA block on the same element:
+        // the CDATA arm appends to the existing #text String.
+        let xml = r#"<root><note>before <![CDATA[<raw>]]></note></root>"#;
+        let json = xml_to_json(xml).unwrap();
+        assert_eq!(json["root"]["note"], "before <raw>");
+    }
+
+    #[test]
+    fn xml_to_json_repeated_empty_elements_become_array() {
+        // Two self-closing tags with the same name under one parent: the
+        // second Empty event converts the first scalar value into an array.
+        let xml = r#"<root><flag/><flag/></root>"#;
+        let json = xml_to_json(xml).unwrap();
+        let flags = json["root"]["flag"].as_array().expect("repeated empties");
+        assert_eq!(flags.len(), 2);
+        assert!(flags[0].is_null());
+        assert!(flags[1].is_null());
+    }
+
+    #[test]
+    fn xml_to_json_three_repeated_empty_elements_push_onto_array() {
+        // A third same-named empty element pushes onto the already-array
+        // value (the `Some(Value::Array(arr)) => arr.push(value)` arm).
+        let xml = r#"<root><flag a="1"/><flag a="2"/><flag a="3"/></root>"#;
+        let json = xml_to_json(xml).unwrap();
+        let flags = json["root"]["flag"].as_array().expect("repeated empties");
+        assert_eq!(flags.len(), 3);
+        assert_eq!(flags[2]["@a"], "3");
+    }
+
+    #[test]
+    fn xml_to_json_skips_comments_and_processing_instructions() {
+        // Comments and PIs hit the `Ok(_) => {}` skip arm; the surrounding
+        // data must still parse correctly.
+        let xml = r#"<?xml version="1.0"?><root><!-- a comment --><name>X</name></root>"#;
+        let json = xml_to_json(xml).unwrap();
+        assert_eq!(json["root"]["name"], "X");
+    }
+
+    #[test]
+    fn xml_to_json_malformed_returns_parse_error() {
+        // A mismatched end tag is rejected by quick_xml's end-name check,
+        // surfacing as FaucetError::Transform via the `Err(e)` arm.
+        let xml = r#"<root><a></b></root>"#;
+        let err = xml_to_json(xml).unwrap_err();
+        assert!(
+            matches!(&err, FaucetError::Transform(m) if m.contains("XML parse error")),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn extract_at_path_descending_into_scalar_returns_empty() {
+        // The path tries to descend past a scalar leaf, hitting the
+        // `_ => return vec![]` non-object arm.
+        let val = json!({"root": {"name": "Alice"}});
+        let records = extract_at_path(&val, "root.name.first");
+        assert!(records.is_empty());
+    }
+
+    #[test]
+    fn extract_at_path_scalar_root_returns_empty() {
+        // The very first segment lookup is against a non-object value.
+        let val = json!("just a string");
+        let records = extract_at_path(&val, "anything");
+        assert!(records.is_empty());
+    }
+
+    #[test]
+    fn stream_extract_full_doc_mode_self_closing_and_repeats() {
+        // No path => full_doc mode. Exercises the Empty arm under full_doc
+        // (append_child into doc.last_mut), including repetition → array.
+        let xml = r#"<root><flag/><flag/><name>Z</name></root>"#;
+        let streamed = collect_stream_extract(xml, None);
+        let eager = xml_to_json(xml).unwrap();
+        assert_eq!(streamed.len(), 1);
+        assert_eq!(streamed[0], eager);
+        let flags = streamed[0]["root"]["flag"]
+            .as_array()
+            .expect("repeated empties in full-doc mode");
+        assert_eq!(flags.len(), 2);
+        assert_eq!(streamed[0]["root"]["name"], "Z");
+    }
+
+    #[test]
+    fn stream_extract_full_doc_mode_mixed_text_and_cdata() {
+        // full_doc mode: text then CDATA on the same element appends to the
+        // existing #text String (the full_doc Text + CData arms).
+        let xml = r#"<root><note>hi &amp; <![CDATA[<x>]]></note></root>"#;
+        let streamed = collect_stream_extract(xml, None);
+        let eager = xml_to_json(xml).unwrap();
+        assert_eq!(streamed.len(), 1);
+        assert_eq!(streamed[0], eager);
+        assert_eq!(streamed[0]["root"]["note"], "hi & <x>");
+    }
+
+    #[test]
+    fn stream_extract_subtree_self_closing_child_appends() {
+        // A self-closing child inside a matched subtree exercises the
+        // `start_depth.is_some()` Empty append_child branch.
+        let xml = r#"<root>
+            <user id="1"><active/><name>Alice</name></user>
+            <user id="2"><active/><name>Bob</name></user>
+        </root>"#;
+        let streamed = collect_stream_extract(xml, Some("root.user"));
+        let eager = extract_at_path(&xml_to_json(xml).unwrap(), "root.user");
+        assert_eq!(streamed, eager);
+        assert_eq!(streamed.len(), 2);
+        assert!(streamed[0]["active"].is_null());
+        assert_eq!(streamed[0]["name"], "Alice");
+    }
+
+    #[test]
+    fn stream_extract_subtree_text_split_by_entity_concatenated() {
+        // Entity-split text inside a matched subtree hits the subtree
+        // "#text already a String" append branch.
+        let xml = r#"<root><item><msg>a &amp; b</msg></item></root>"#;
+        let streamed = collect_stream_extract(xml, Some("root.item"));
+        assert_eq!(streamed.len(), 1);
+        assert_eq!(streamed[0]["msg"], "a & b");
+    }
+
+    #[test]
+    fn stream_extract_subtree_text_then_cdata_concatenated() {
+        // Text then CDATA inside a matched subtree appends CDATA onto the
+        // existing #text String (subtree CData "already a String" branch).
+        let xml = r#"<root><item><note>start <![CDATA[<end>]]></note></item></root>"#;
+        let streamed = collect_stream_extract(xml, Some("root.item"));
+        assert_eq!(streamed.len(), 1);
+        assert_eq!(streamed[0]["note"], "start <end>");
+    }
+
+    #[test]
+    fn stream_extract_repeated_children_push_onto_existing_array() {
+        // Three same-named children inside a matched element exercise the
+        // append_child `Some(Value::Array(arr)) => arr.push` arm.
+        let xml = r#"<root><order><line>a</line><line>b</line><line>c</line></order></root>"#;
+        let streamed = collect_stream_extract(xml, Some("root.order"));
+        assert_eq!(streamed.len(), 1);
+        let lines = streamed[0]["line"].as_array().expect("repeated children");
+        assert_eq!(lines.len(), 3);
+        assert_eq!(lines[2], "c");
+    }
+
+    #[test]
+    fn stream_extract_malformed_returns_parse_error() {
+        // A mismatched end tag surfaces via the streaming parser's Err arm.
+        let xml = r#"<root><a></b></root>"#;
+        let mut out = Vec::new();
+        let err = stream_extract(xml, Some("root.a"), |v| out.push(v)).unwrap_err();
+        assert!(
+            matches!(&err, FaucetError::Transform(m) if m.contains("XML parse error")),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn stream_extract_skips_comments_outside_match() {
+        // Comments hit the `Ok(_) => {}` arm; surrounding records still emit.
+        let xml = r#"<root><!-- c --><item><v>1</v></item><!-- d --><item><v>2</v></item></root>"#;
+        let streamed = collect_stream_extract(xml, Some("root.item"));
+        assert_eq!(streamed.len(), 2);
+        assert_eq!(streamed[0]["v"], "1");
+        assert_eq!(streamed[1]["v"], "2");
+    }
 }

--- a/crates/source/xml/tests/fetch_http.rs
+++ b/crates/source/xml/tests/fetch_http.rs
@@ -1,0 +1,412 @@
+//! Integration tests for `XmlStream`'s HTTP fetch path against a wiremock
+//! server: auth header application, pagination (page-number / offset),
+//! `max_pages` capping, the identical-page loop guard, SOAP POST bodies,
+//! and error paths (non-2xx status, malformed XML).
+
+use faucet_core::FaucetError;
+use faucet_source_xml::{XmlAuth, XmlPagination, XmlStream, XmlStreamConfig};
+use reqwest::Method;
+use std::collections::HashMap;
+use wiremock::matchers::{body_string_contains, header, method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// `<root><item><id>i</id></item>...</root>` with `n` items.
+fn items_doc(start: usize, n: usize) -> String {
+    let mut s = String::from("<root>");
+    for i in start..start + n {
+        s.push_str(&format!("<item><id>{i}</id></item>"));
+    }
+    s.push_str("</root>");
+    s
+}
+
+#[tokio::test]
+async fn basic_auth_header_is_sent() {
+    let server = MockServer::start().await;
+    // Basic dXNlcjpwYXNz == base64("user:pass").
+    Mock::given(method("GET"))
+        .and(path("/feed.xml"))
+        .and(header("authorization", "Basic dXNlcjpwYXNz"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Content-Type", "application/xml")
+                .set_body_string(items_doc(0, 2)),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let config = XmlStreamConfig::new(server.uri(), "/feed.xml")
+        .records_element_path("root.item")
+        .auth(XmlAuth::Basic {
+            username: "user".into(),
+            password: "pass".into(),
+        });
+    let records = XmlStream::new(config).fetch_all().await.unwrap();
+    assert_eq!(records.len(), 2);
+    assert_eq!(records[0]["id"], "0");
+}
+
+#[tokio::test]
+async fn custom_auth_headers_are_sent() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/soap"))
+        .and(header("soapaction", "urn:GetUsers"))
+        .and(header("x-api-key", "secret-key"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Content-Type", "text/xml")
+                .set_body_string(items_doc(0, 1)),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let mut headers = HashMap::new();
+    headers.insert("SOAPAction".to_string(), "urn:GetUsers".to_string());
+    headers.insert("X-API-Key".to_string(), "secret-key".to_string());
+
+    let config = XmlStreamConfig::new(server.uri(), "/soap")
+        .method(Method::POST)
+        .records_element_path("root.item")
+        .auth(XmlAuth::Custom { headers });
+    let records = XmlStream::new(config).fetch_all().await.unwrap();
+    assert_eq!(records.len(), 1);
+}
+
+#[tokio::test]
+async fn custom_auth_invalid_header_name_errors() {
+    // An illegal HTTP header name must surface as FaucetError::Auth before
+    // any request is sent.
+    let server = MockServer::start().await;
+    let mut headers = HashMap::new();
+    headers.insert("Invalid Header Name".to_string(), "v".to_string());
+    let config = XmlStreamConfig::new(server.uri(), "/feed.xml")
+        .records_element_path("root.item")
+        .auth(XmlAuth::Custom { headers });
+    let err = XmlStream::new(config).fetch_all().await.unwrap_err();
+    assert!(matches!(err, FaucetError::Auth(_)), "got {err:?}");
+}
+
+#[tokio::test]
+async fn soap_post_body_is_sent_and_response_extracted() {
+    let server = MockServer::start().await;
+    let soap_response = r#"<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+        <soap:Body>
+            <GetUsersResponse>
+                <User><Name>Alice</Name></User>
+                <User><Name>Bob</Name></User>
+            </GetUsersResponse>
+        </soap:Body>
+    </soap:Envelope>"#;
+    Mock::given(method("POST"))
+        .and(path("/soap"))
+        .and(body_string_contains("GetUsers"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Content-Type", "text/xml")
+                .set_body_string(soap_response),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let config = XmlStreamConfig::new(server.uri(), "/soap")
+        .method(Method::POST)
+        .body("<soap:Envelope><soap:Body><GetUsers/></soap:Body></soap:Envelope>")
+        .records_element_path("soap:Envelope.soap:Body.GetUsersResponse.User");
+    let records = XmlStream::new(config).fetch_all().await.unwrap();
+    assert_eq!(records.len(), 2);
+    assert_eq!(records[0]["Name"], "Alice");
+    assert_eq!(records[1]["Name"], "Bob");
+}
+
+#[tokio::test]
+async fn query_params_are_sent() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/feed.xml"))
+        .and(query_param("format", "xml"))
+        .and(query_param("v", "2"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Content-Type", "application/xml")
+                .set_body_string(items_doc(0, 1)),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let config = XmlStreamConfig::new(server.uri(), "/feed.xml")
+        .records_element_path("root.item")
+        .query_param("format", "xml")
+        .query_param("v", "2");
+    let records = XmlStream::new(config).fetch_all().await.unwrap();
+    assert_eq!(records.len(), 1);
+}
+
+#[tokio::test]
+async fn page_number_pagination_walks_pages_until_empty() {
+    let server = MockServer::start().await;
+    // page=1 -> 2 items, page=2 -> 2 items, page=3 -> empty (stops).
+    Mock::given(method("GET"))
+        .and(path("/feed.xml"))
+        .and(query_param("page", "1"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Content-Type", "application/xml")
+                .set_body_string(items_doc(0, 2)),
+        )
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/feed.xml"))
+        .and(query_param("page", "2"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Content-Type", "application/xml")
+                .set_body_string(items_doc(2, 2)),
+        )
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/feed.xml"))
+        .and(query_param("page", "3"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Content-Type", "application/xml")
+                .set_body_string("<root></root>"),
+        )
+        .mount(&server)
+        .await;
+
+    let config = XmlStreamConfig::new(server.uri(), "/feed.xml")
+        .records_element_path("root.item")
+        .pagination(XmlPagination::PageNumber {
+            param_name: "page".into(),
+            start_page: 1,
+            page_size: None,
+            page_size_param: None,
+        });
+    let records = XmlStream::new(config).fetch_all().await.unwrap();
+    assert_eq!(records.len(), 4);
+    assert_eq!(records[0]["id"], "0");
+    assert_eq!(records[3]["id"], "3");
+}
+
+#[tokio::test]
+async fn page_number_pagination_stops_on_short_page() {
+    let server = MockServer::start().await;
+    // page_size=3: first page full (3), second page short (1) -> stop.
+    Mock::given(method("GET"))
+        .and(path("/feed.xml"))
+        .and(query_param("page", "1"))
+        .and(query_param("size", "3"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Content-Type", "application/xml")
+                .set_body_string(items_doc(0, 3)),
+        )
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/feed.xml"))
+        .and(query_param("page", "2"))
+        .and(query_param("size", "3"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Content-Type", "application/xml")
+                .set_body_string(items_doc(3, 1)),
+        )
+        .mount(&server)
+        .await;
+
+    let config = XmlStreamConfig::new(server.uri(), "/feed.xml")
+        .records_element_path("root.item")
+        .pagination(XmlPagination::PageNumber {
+            param_name: "page".into(),
+            start_page: 1,
+            page_size: Some(3),
+            page_size_param: Some("size".into()),
+        });
+    let records = XmlStream::new(config).fetch_all().await.unwrap();
+    assert_eq!(records.len(), 4, "3 full + 1 short page, then stop");
+}
+
+#[tokio::test]
+async fn offset_pagination_walks_until_short_page() {
+    let server = MockServer::start().await;
+    // limit=2: offset 0 -> 2, offset 2 -> 2, offset 4 -> 1 (short) -> stop.
+    Mock::given(method("GET"))
+        .and(path("/feed.xml"))
+        .and(query_param("offset", "0"))
+        .and(query_param("limit", "2"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Content-Type", "application/xml")
+                .set_body_string(items_doc(0, 2)),
+        )
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/feed.xml"))
+        .and(query_param("offset", "2"))
+        .and(query_param("limit", "2"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Content-Type", "application/xml")
+                .set_body_string(items_doc(2, 2)),
+        )
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/feed.xml"))
+        .and(query_param("offset", "4"))
+        .and(query_param("limit", "2"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Content-Type", "application/xml")
+                .set_body_string(items_doc(4, 1)),
+        )
+        .mount(&server)
+        .await;
+
+    let config = XmlStreamConfig::new(server.uri(), "/feed.xml")
+        .records_element_path("root.item")
+        .pagination(XmlPagination::Offset {
+            offset_param: "offset".into(),
+            limit_param: "limit".into(),
+            limit: 2,
+        });
+    let records = XmlStream::new(config).fetch_all().await.unwrap();
+    assert_eq!(records.len(), 5);
+    assert_eq!(records[4]["id"], "4");
+}
+
+#[tokio::test]
+async fn max_pages_caps_fetch() {
+    let server = MockServer::start().await;
+    // Every page is full (2 items), but max_pages=2 caps it at 4 records.
+    // Use distinct page bodies so the loop guard does not trip first.
+    Mock::given(method("GET"))
+        .and(path("/feed.xml"))
+        .and(query_param("page", "1"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Content-Type", "application/xml")
+                .set_body_string(items_doc(0, 2)),
+        )
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/feed.xml"))
+        .and(query_param("page", "2"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Content-Type", "application/xml")
+                .set_body_string(items_doc(2, 2)),
+        )
+        .mount(&server)
+        .await;
+
+    let config = XmlStreamConfig::new(server.uri(), "/feed.xml")
+        .records_element_path("root.item")
+        .max_pages(2)
+        .pagination(XmlPagination::PageNumber {
+            param_name: "page".into(),
+            start_page: 1,
+            page_size: None,
+            page_size_param: None,
+        });
+    let records = XmlStream::new(config).fetch_all().await.unwrap();
+    assert_eq!(records.len(), 4, "max_pages=2 -> at most 4 records");
+}
+
+#[tokio::test]
+async fn identical_page_loop_guard_stops_fetch() {
+    // A server that ignores the page param and returns the same non-empty
+    // body forever must stop after two identical pages (audit #146 H4/H5).
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/feed.xml"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Content-Type", "application/xml")
+                .set_body_string(items_doc(0, 2)),
+        )
+        .mount(&server)
+        .await;
+
+    let config = XmlStreamConfig::new(server.uri(), "/feed.xml")
+        .records_element_path("root.item")
+        .pagination(XmlPagination::PageNumber {
+            param_name: "page".into(),
+            start_page: 1,
+            page_size: None,
+            page_size_param: None,
+        });
+    let records = XmlStream::new(config).fetch_all().await.unwrap();
+    // Page 1 + identical page 2 (which trips the guard) = 4 records, no loop.
+    assert_eq!(records.len(), 4);
+}
+
+#[tokio::test]
+async fn non_2xx_status_returns_error() {
+    // A persistent 404 is non-retriable and must surface as an error.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/feed.xml"))
+        .respond_with(ResponseTemplate::new(404).set_body_string("not found"))
+        .mount(&server)
+        .await;
+
+    let config = XmlStreamConfig::new(server.uri(), "/feed.xml").records_element_path("root.item");
+    let err = XmlStream::new(config).fetch_all().await.unwrap_err();
+    assert!(
+        matches!(err, FaucetError::HttpStatus { status, .. } if status == 404),
+        "got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn malformed_xml_response_returns_transform_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/feed.xml"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Content-Type", "application/xml")
+                .set_body_string("<root><a></b></root>"),
+        )
+        .mount(&server)
+        .await;
+
+    let config = XmlStreamConfig::new(server.uri(), "/feed.xml").records_element_path("root.a");
+    let err = XmlStream::new(config).fetch_all().await.unwrap_err();
+    assert!(
+        matches!(&err, FaucetError::Transform(m) if m.contains("XML parse error")),
+        "got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn no_records_path_returns_whole_document() {
+    // With records_element_path = None, fetch_all returns the full doc as a
+    // single record.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/feed.xml"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Content-Type", "application/xml")
+                .set_body_string("<root><name>Z</name></root>"),
+        )
+        .mount(&server)
+        .await;
+
+    let config = XmlStreamConfig::new(server.uri(), "/feed.xml");
+    let records = XmlStream::new(config).fetch_all().await.unwrap();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0]["root"]["name"], "Z");
+}

--- a/crates/transform-sql/src/shovel.rs
+++ b/crates/transform-sql/src/shovel.rs
@@ -143,4 +143,69 @@ mod tests {
         let b = infer_schema(&[json!({"a": 1, "b": "x"})]).unwrap();
         assert_ne!(a.fields().len(), b.fields().len());
     }
+
+    #[test]
+    fn round_trip_all_json_value_types() {
+        // null, bool, int, float, string, nested object, nested array.
+        let recs = vec![json!({
+            "n": null,
+            "flag": true,
+            "count": 7,
+            "ratio": 2.5,
+            "label": "hello",
+            "nested": {"inner": 1, "deep": {"x": "y"}},
+            "list": [1, 2, 3]
+        })];
+        let schema = infer_schema(&recs).unwrap();
+        let batch = json_to_record_batch(&recs, schema).unwrap();
+        assert_eq!(batch.num_rows(), 1);
+        let back = record_batches_to_json(&[batch]).unwrap();
+        assert_eq!(back[0]["flag"], json!(true));
+        assert_eq!(back[0]["count"], json!(7));
+        assert_eq!(back[0]["ratio"], json!(2.5));
+        assert_eq!(back[0]["label"], json!("hello"));
+        assert_eq!(back[0]["nested"], json!({"inner": 1, "deep": {"x": "y"}}));
+        assert_eq!(back[0]["list"], json!([1, 2, 3]));
+        // A null-valued field is dropped by the arrow-json writer (sparse output).
+        assert!(back[0].get("n").is_none() || back[0]["n"] == json!(null));
+    }
+
+    #[test]
+    fn json_to_record_batch_empty_records_yields_empty_batch() {
+        // No records → the decoder flushes nothing → empty batch built from schema.
+        let schema = infer_schema(&[json!({"a": 1})]).unwrap();
+        let batch = json_to_record_batch(&[], schema).unwrap();
+        assert_eq!(batch.num_rows(), 0);
+        assert_eq!(batch.num_columns(), 1);
+    }
+
+    #[test]
+    fn record_batches_to_json_empty_input_is_empty_vec() {
+        let rows = record_batches_to_json(&[]).unwrap();
+        assert!(rows.is_empty());
+    }
+
+    #[test]
+    fn values_relation_row_arity_mismatch_is_config_error() {
+        // Two columns declared, second row has only one cell → Config error naming
+        // the offending row index and the expected/actual counts.
+        let err = values_to_record_batch(
+            &["id".to_string(), "label".to_string()],
+            &[vec![json!(1), json!("ok")], vec![json!(2)]],
+        )
+        .unwrap_err();
+        assert!(matches!(err, FaucetError::Config(_)), "got: {err:?}");
+        let msg = format!("{err}");
+        assert!(msg.contains("row 1"), "got: {msg}");
+        assert!(msg.contains("1 cells, expected 2"), "got: {msg}");
+    }
+
+    #[test]
+    fn infer_schema_on_non_object_is_transform_error() {
+        // A bare scalar is not a JSON object; arrow-json schema inference rejects
+        // it and the `te` helper wraps it as a Transform error.
+        let err = infer_schema(&[json!(42)]).unwrap_err();
+        assert!(matches!(err, FaucetError::Transform(_)), "got: {err:?}");
+        assert!(format!("{err}").contains("sql transform"), "got: {err}");
+    }
 }

--- a/crates/transform-sql/tests/data/regions.jsonl
+++ b/crates/transform-sql/tests/data/regions.jsonl
@@ -1,0 +1,2 @@
+{"code":"US","region":"NA"}
+{"code":"IN","region":"APAC"}

--- a/crates/transform-sql/tests/runtime.rs
+++ b/crates/transform-sql/tests/runtime.rs
@@ -224,3 +224,264 @@ fn aggregation_is_per_page_over_two_pages() {
     assert_eq!(p1[0]["total"], json!(3)); // per-page, not global
     assert_eq!(p2[0]["total"], json!(10));
 }
+
+/// `batch_size: 0` (single-page) gives global aggregation: the whole result set
+/// arrives in one page, so the SUM is computed across every record at once.
+#[test]
+fn global_aggregation_single_page() {
+    let out = run(
+        "SELECT SUM(v) AS total FROM batch",
+        vec![json!({"v": 1}), json!({"v": 2}), json!({"v": 10})],
+    );
+    assert_eq!(out, vec![json!({"total": 13})]);
+}
+
+#[test]
+fn memory_limit_and_threads_pragmas_apply() {
+    // Both pragmas must be accepted by DuckDB and the query still runs.
+    let s = stage(SqlTransformConfig {
+        query: "SELECT count(*) AS n FROM batch".into(),
+        relations: vec![],
+        memory_limit: Some("256MB".into()),
+        threads: Some(2),
+    });
+    let out = apply_stages_to_page(vec![json!({"x": 1}), json!({"x": 2})], &[s]).unwrap();
+    assert_eq!(out[0]["n"], json!(2));
+}
+
+#[test]
+fn duplicate_relation_name_rejected() {
+    let err = SqlTransform::compile(&SqlTransformConfig {
+        query: "SELECT * FROM batch".into(),
+        relations: vec![
+            RelationSpec {
+                name: "dup".into(),
+                source: RelationSource::Values {
+                    columns: vec!["a".into()],
+                    rows: vec![vec![json!(1)]],
+                },
+                reload_on_change: false,
+            },
+            RelationSpec {
+                name: "dup".into(),
+                source: RelationSource::Values {
+                    columns: vec!["b".into()],
+                    rows: vec![vec![json!(2)]],
+                },
+                reload_on_change: false,
+            },
+        ],
+        memory_limit: None,
+        threads: None,
+    })
+    .unwrap_err();
+    let msg = format!("{err}");
+    assert!(msg.contains("duplicate relation name 'dup'"), "got: {msg}");
+}
+
+#[test]
+fn invalid_relation_name_rejected() {
+    let err = SqlTransform::compile(&SqlTransformConfig {
+        query: "SELECT * FROM batch".into(),
+        relations: vec![RelationSpec {
+            name: "1bad name".into(), // starts with a digit + has a space
+            source: RelationSource::Values {
+                columns: vec!["a".into()],
+                rows: vec![vec![json!(1)]],
+            },
+            reload_on_change: false,
+        }],
+        memory_limit: None,
+        threads: None,
+    })
+    .unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("invalid relation name '1bad name'"),
+        "got: {msg}"
+    );
+}
+
+#[test]
+fn values_relation_with_no_columns_rejected() {
+    let err = SqlTransform::compile(&SqlTransformConfig {
+        query: "SELECT * FROM batch".into(),
+        relations: vec![RelationSpec {
+            name: "empty".into(),
+            source: RelationSource::Values {
+                columns: vec![],
+                rows: vec![],
+            },
+            reload_on_change: false,
+        }],
+        memory_limit: None,
+        threads: None,
+    })
+    .unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("values relation 'empty' has no columns"),
+        "got: {msg}"
+    );
+}
+
+#[test]
+fn jsonl_reference_relation_join() {
+    let path = format!("{}/tests/data/regions.jsonl", env!("CARGO_MANIFEST_DIR"));
+    let s = stage(SqlTransformConfig {
+        query: "SELECT b.id, r.region FROM batch b LEFT JOIN regions r ON b.code = r.code ORDER BY b.id".into(),
+        relations: vec![RelationSpec {
+            name: "regions".into(),
+            source: RelationSource::Jsonl { path },
+            reload_on_change: false,
+        }],
+        memory_limit: None,
+        threads: None,
+    });
+    let out = apply_stages_to_page(
+        vec![
+            json!({"id": 1, "code": "US"}),
+            json!({"id": 2, "code": "IN"}),
+        ],
+        &[s],
+    )
+    .unwrap();
+    assert_eq!(out[0]["region"], json!("NA"));
+    assert_eq!(out[1]["region"], json!("APAC"));
+}
+
+/// A query that fully validates at compile time (no `batch` reference at all)
+/// takes the `Ok` arm of `validate_query` rather than the missing-`batch`
+/// tolerance arm.
+#[test]
+fn query_without_batch_reference_compiles_and_runs() {
+    let out = run("SELECT 1 AS one, 'hi' AS greeting", vec![json!({"x": 1})]);
+    assert_eq!(out, vec![json!({"one": 1, "greeting": "hi"})]);
+}
+
+#[test]
+fn debug_impl_exposes_query() {
+    let t = SqlTransform::compile(&SqlTransformConfig {
+        query: "SELECT * FROM batch".into(),
+        relations: vec![],
+        memory_limit: None,
+        threads: None,
+    })
+    .unwrap();
+    let dbg = format!("{t:?}");
+    assert!(dbg.contains("SqlTransform"), "got: {dbg}");
+    assert!(dbg.contains("SELECT * FROM batch"), "got: {dbg}");
+}
+
+/// A CSV reference relation with `reload_on_change: true` must pick up edits to
+/// the file between pages (re-stat mtime → rebuild + swap the table).
+#[test]
+fn reload_on_change_csv_picks_up_edits_between_pages() {
+    use std::io::Write;
+    let dir = std::env::temp_dir();
+    let path = dir.join(format!(
+        "faucet_sql_reload_{}_{}.csv",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    let path_str = path.to_string_lossy().to_string();
+
+    std::fs::write(&path, "code,country\nUS,United States\n").unwrap();
+
+    let s = stage(SqlTransformConfig {
+        query: "SELECT b.id, c.country FROM batch b LEFT JOIN refs c ON b.code = c.code".into(),
+        relations: vec![RelationSpec {
+            name: "refs".into(),
+            source: RelationSource::Csv {
+                path: path_str.clone(),
+                has_header: true,
+            },
+            reload_on_change: true,
+        }],
+        memory_limit: None,
+        threads: None,
+    });
+
+    let p1 = apply_stages_to_page(
+        vec![json!({"id": 1, "code": "US"})],
+        std::slice::from_ref(&s),
+    )
+    .unwrap();
+    assert_eq!(p1[0]["country"], json!("United States"));
+
+    // Rewrite the file with a different value for US; sleep guards against the
+    // filesystem mtime resolution coalescing the two writes.
+    std::thread::sleep(std::time::Duration::from_millis(1100));
+    {
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(b"code,country\nUS,Reloaded\n").unwrap();
+        f.flush().unwrap();
+    }
+
+    let p2 = apply_stages_to_page(
+        vec![json!({"id": 2, "code": "US"})],
+        std::slice::from_ref(&s),
+    )
+    .unwrap();
+    assert_eq!(p2[0]["country"], json!("Reloaded"));
+
+    let _ = std::fs::remove_file(&path);
+}
+
+/// Same as above for a JSONL relation — exercises the non-CSV reload branch.
+#[test]
+fn reload_on_change_jsonl_picks_up_edits_between_pages() {
+    use std::io::Write;
+    let dir = std::env::temp_dir();
+    let path = dir.join(format!(
+        "faucet_sql_reload_{}_{}.jsonl",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    let path_str = path.to_string_lossy().to_string();
+
+    std::fs::write(&path, "{\"code\":\"US\",\"region\":\"NA\"}\n").unwrap();
+
+    let s = stage(SqlTransformConfig {
+        query: "SELECT b.id, r.region FROM batch b LEFT JOIN refs r ON b.code = r.code".into(),
+        relations: vec![RelationSpec {
+            name: "refs".into(),
+            source: RelationSource::Jsonl {
+                path: path_str.clone(),
+            },
+            reload_on_change: true,
+        }],
+        memory_limit: None,
+        threads: None,
+    });
+
+    let p1 = apply_stages_to_page(
+        vec![json!({"id": 1, "code": "US"})],
+        std::slice::from_ref(&s),
+    )
+    .unwrap();
+    assert_eq!(p1[0]["region"], json!("NA"));
+
+    std::thread::sleep(std::time::Duration::from_millis(1100));
+    {
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(b"{\"code\":\"US\",\"region\":\"EMEA\"}\n")
+            .unwrap();
+        f.flush().unwrap();
+    }
+
+    let p2 = apply_stages_to_page(
+        vec![json!({"id": 2, "code": "US"})],
+        std::slice::from_ref(&s),
+    )
+    .unwrap();
+    assert_eq!(p2[0]["region"], json!("EMEA"));
+
+    let _ = std::fs::remove_file(&path);
+}


### PR DESCRIPTION
## Summary

Targeted unit + integration tests across 30+ crates to lift Codecov **project coverage** comfortably past the 90% line. Local `cargo-llvm-cov` line coverage went **86.5% → 90.4%** (mssql excluded locally; it runs natively on CI), which maps to **Codecov ~89.5% → ~94%** (Codecov counts lines slightly more leniently than llvm-cov — a stable ~+3pt offset measured against the current `main` number).

**Tests only — no production code changed, and no existing tests were modified.**

## What's newly covered (uncovered branches, not padding)

- **rest**: OAuth2 client-credentials flow (was **3%**) — token fetch, caching, proactive expiry refresh, 4xx/5xx error mapping (wiremock + `tokio` paused clock).
- **core**: transform built-ins (every cast / key-case / value-case / redact / spell arm), pipeline stages + the hand-rolled JSONPath subset, `run_stream` cancel / DLQ / quality / exactly-once paths, `Memory`/`File` state stores, config loaders, observability decorators + `install`.
- **cli**: registry dispatch + schemas, `init`/`preview` commands, `executor` (`on_error` continue vs stop, parent→child fan-out, duplicate-state-key), scheduler, offline secrets parsing/request-building.
- **HTTP connectors (wiremock)**: snowflake (src+sink), bigquery (src+sink), graphql, xml (convert + fetch), http sink.
- **parquet**: sink/source round-trip, row/byte rollover, column projection, multi-file schema-mismatch (local files, no cloud).
- **testcontainer connectors**: redis, mongodb, mongodb-cdc, kafka (src+sink + pure encode/decode/context), mysql-cdc, postgres + mysql sinks (incl. idempotent/exactly-once writes).
- **postgres-cdc**: pgoutput byte decoder + value/OID conversions.
- **transform-sql**: compile-time validation, runtime per-page + global aggregation, JSON↔Arrow shovel.
- **lineage**: emitter event types + facets, column-lineage derivation, file + http transports, and the "emission never fails a run" guarantee.

Also adds `*.profraw` to `.gitignore` (cargo-llvm-cov artifacts).

## Remaining low-coverage areas (infra-bound, out of scope here)

GCS gRPC object I/O (no emulator — tracked in #220), plus S3 / Iceberg catalog / gRPC server paths that need a live backend unavailable in CI.

## Verification (local)

- `cargo llvm-cov --workspace --all-features --no-fail-fast` (mssql excluded locally): **2,950 tests pass, 0 failed**; line coverage **90.44%**.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean.
- `cargo fmt --all --check`: clean.

Continues the coverage work from #219 and #221.