### PR TITLE
ci(coverage): raise Codecov project target to 90%

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,9 +4,9 @@ coverage:
   status:
     project:
       default:
-        target: 80%
+        target: 90%
         threshold: 1%        # tolerate a <=1% drop without flipping the status red
-        informational: true  # report-only for now; a follow-up flips this to false once stably >=80%
+        informational: true  # report-only; project coverage sits ~93%. Flip to false to enforce as a gate.
     patch:
       default:
         target: 80%


### PR DESCRIPTION
Project coverage is stably ~93% (89.49% → 93.24% after #222), so raise the project status target 80% → 90%. Kept `informational: true` (report-only) with the existing 1% drop threshold. Patch target left at 80% — a hard 90% on changed lines can block PRs that touch infra-bound (no-emulator) paths; easy to raise later if desired.