### PR TITLE
feat: unified write_mode upsert/delete (merge by key) across SQL/Mongo/ES sinks

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -170,6 +170,7 @@ transforms = [
     "faucet-source-rest?/transforms",
     "transform-filter",
     "transform-explode",
+    "transform-cdc-unwrap",
 ]
 
 # Per-transform feature flags forwarded to faucet-core. Lets the CLI's
@@ -177,6 +178,7 @@ transforms = [
 # asked for. The `transforms` aggregate above enables every transform at once.
 transform-filter = ["faucet-core/transform-filter"]
 transform-explode = ["faucet-core/transform-explode"]
+transform-cdc-unwrap = ["faucet-core/transform-cdc-unwrap"]
 transform-sql = ["dep:faucet-transform-sql"]
 
 observability = [

--- a/cli/examples/postgres_cdc_to_postgres_upsert.yaml
+++ b/cli/examples/postgres_cdc_to_postgres_upsert.yaml
@@ -1,0 +1,67 @@
+# End-to-end Postgres CDC -> Postgres upsert mirror, exactly-once.
+#
+# Streams logical-replication change events from a source database, normalizes
+# the CDC envelope with `cdc_unwrap`, and mirrors them into a destination table
+# with `write_mode: upsert` — inserts/updates become UPSERTs and deletes become
+# row deletes, so the mirror table stays an exact replica of the source table.
+#
+# Setup on the SOURCE database (logical replication must be enabled):
+#   psql "$SOURCE_PG_URL" <<SQL
+#     CREATE TABLE IF NOT EXISTS users (id int4 PRIMARY KEY, name text);
+#     CREATE PUBLICATION faucet_pub FOR TABLE users;
+#   SQL
+#
+# Setup on the DEST database (upsert/delete need a UNIQUE/PRIMARY KEY on `key`):
+#   psql "$DEST_PG_URL" <<SQL
+#     CREATE TABLE IF NOT EXISTS users_mirror (id int4 PRIMARY KEY, name text);
+#   SQL
+#
+# Then:
+#   export SOURCE_PG_URL=postgres://faucet:faucet@localhost:5432/appdb
+#   export DEST_PG_URL=postgres://faucet:faucet@localhost:5432/warehouse
+#   faucet run cli/examples/postgres_cdc_to_postgres_upsert.yaml
+#
+# INSERT/UPDATE/DELETE rows in the source `users` table from another psql
+# session — every change is mirrored into `users_mirror` each fetch cycle.
+
+version: 1
+name: pg_cdc_mirror
+
+# Exactly-once delivery composes a CDC source + an idempotent SQL sink + a state
+# store with no DLQ: each committed batch and its monotonic commit token land in
+# one transaction, so a crash/resume never re-applies or skips a batch.
+delivery: exactly_once
+
+pipeline:
+  source:
+    type: postgres-cdc
+    config:
+      connection_url: ${env:SOURCE_PG_URL}
+      slot_name: faucet_mirror
+      publication_name: faucet_pub
+      create_slot_if_missing: true
+      idle_timeout: 30
+
+  # Normalize the postgres-cdc envelope ({op, before, after}) into a flat row
+  # plus a `__op` marker. Inserts/updates emit the post-image; deletes emit the
+  # key from the pre-image. DDL/truncate events are dropped.
+  transforms:
+    - type: cdc_unwrap
+
+  sink:
+    type: postgres
+    config:
+      connection_url: ${env:DEST_PG_URL}
+      table_name: users_mirror
+      # Upsert/delete require column-mapping mode (not the JSONB blob mode).
+      column_mapping: auto_map
+      # Insert-or-update by `id` (the mirror table needs a UNIQUE/PRIMARY KEY on
+      # it); rows whose `__op` is "d" are routed to DELETE instead.
+      write_mode: upsert
+      key: [id]
+      delete_marker: { field: __op, values: [d] }
+
+  state:
+    type: file
+    config:
+      path: ./state

--- a/cli/src/expand.rs
+++ b/cli/src/expand.rs
@@ -451,6 +451,50 @@ pub fn expand(cfg: &PipelineConfig) -> CliResult<Vec<ExpandedNode>> {
             }
         }
 
+        // write_mode × sink validation (load-time): reject an unsupported mode
+        // for the sink kind, and upsert/delete without a key, before any run.
+        // Runs for every row; append rows pass trivially.
+        let requested_mode = merged_sink
+            .config
+            .get("write_mode")
+            .and_then(|v| v.as_str())
+            .unwrap_or("append");
+        let mode = match requested_mode {
+            "append" => faucet_core::WriteMode::Append,
+            "upsert" => faucet_core::WriteMode::Upsert,
+            "delete" => faucet_core::WriteMode::Delete,
+            other => {
+                return Err(CliError::Config(format!(
+                    "row '{}': unknown write_mode '{}' (expected append, upsert, or delete)",
+                    ids[i], other
+                )));
+            }
+        };
+        if !crate::registry::sink_supported_write_modes(&merged_sink.kind).contains(&mode) {
+            return Err(CliError::Config(format!(
+                "row '{}': write_mode '{}' is not supported by sink '{}' \
+                 (upsert/delete sinks: postgres, sqlite, mysql, mssql, mongodb, elasticsearch)",
+                ids[i], requested_mode, merged_sink.kind
+            )));
+        }
+        if matches!(
+            mode,
+            faucet_core::WriteMode::Upsert | faucet_core::WriteMode::Delete
+        ) {
+            let key_present = merged_sink
+                .config
+                .get("key")
+                .and_then(|v| v.as_array())
+                .map(|a| !a.is_empty())
+                .unwrap_or(false);
+            if !key_present {
+                return Err(CliError::Config(format!(
+                    "row '{}': write_mode '{}' requires a non-empty `key`",
+                    ids[i], requested_mode
+                )));
+            }
+        }
+
         out.push(ExpandedNode {
             id: ids[i].clone(),
             row_index: i,
@@ -1606,5 +1650,91 @@ pipeline:
             }
             other => panic!("expected Config error, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn rejects_upsert_on_unsupported_sink() {
+        let c = cfg(r#"
+version: 1
+name: t
+pipeline:
+  source: { type: rest, config: { url: "http://x" } }
+  sink:   { type: jsonl, config: { path: "out.jsonl", write_mode: upsert, key: [id] } }
+"#);
+        let err = expand(&c).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("write_mode") && msg.contains("upsert") && msg.contains("jsonl"),
+            "{msg}"
+        );
+    }
+
+    #[test]
+    fn rejects_upsert_without_key() {
+        let c = cfg(r#"
+version: 1
+name: t
+pipeline:
+  source: { type: rest, config: { url: "http://x" } }
+  sink:   { type: postgres, config: { connection_url: "postgres://x", table_name: t, column_mapping: auto_map, write_mode: upsert } }
+"#);
+        let err = expand(&c).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("key"), "{msg}");
+    }
+
+    #[test]
+    fn accepts_upsert_on_postgres_with_key() {
+        let c = cfg(r#"
+version: 1
+name: t
+pipeline:
+  source: { type: rest, config: { url: "http://x" } }
+  sink:   { type: postgres, config: { connection_url: "postgres://x", table_name: t, column_mapping: auto_map, write_mode: upsert, key: [id] } }
+"#);
+        assert!(expand(&c).is_ok());
+    }
+
+    #[test]
+    fn accepts_append_by_default_on_any_sink() {
+        let c = cfg(r#"
+version: 1
+name: t
+pipeline:
+  source: { type: rest, config: { url: "http://x" } }
+  sink:   { type: jsonl, config: { path: "out.jsonl" } }
+"#);
+        assert!(expand(&c).is_ok());
+    }
+
+    #[test]
+    fn rejects_delete_without_key() {
+        let c = cfg(r#"
+version: 1
+name: t
+pipeline:
+  source: { type: rest, config: { url: "http://x" } }
+  sink:   { type: mongodb, config: { connection_url: "mongodb://x", database: d, collection: c, write_mode: delete } }
+"#);
+        let err = expand(&c).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("delete") && msg.contains("key"), "{msg}");
+    }
+
+    #[test]
+    fn rejects_unknown_write_mode() {
+        let c = cfg(r#"
+version: 1
+name: t
+pipeline:
+  source: { type: rest, config: { url: "http://x" } }
+  sink:   { type: postgres, config: { connection_url: "postgres://x", table_name: t, column_mapping: auto_map, write_mode: replace } }
+"#);
+        let err = expand(&c).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("unknown write_mode") && msg.contains("replace"),
+            "{msg}"
+        );
     }
 }

--- a/cli/src/registry.rs
+++ b/cli/src/registry.rs
@@ -354,6 +354,18 @@ pub fn sink_supports_idempotent_writes(kind: &str) -> bool {
     matches!(kind, "sqlite" | "postgres" | "mysql" | "mssql" | "iceberg")
 }
 
+/// Write modes each sink kind supports. Kept in sync with each sink's
+/// `Sink::supported_write_modes()` override.
+pub fn sink_supported_write_modes(kind: &str) -> &'static [faucet_core::WriteMode] {
+    use faucet_core::WriteMode;
+    match kind {
+        "postgres" | "sqlite" | "mysql" | "mssql" | "mongodb" | "elasticsearch" => {
+            &[WriteMode::Append, WriteMode::Upsert, WriteMode::Delete]
+        }
+        _ => &[WriteMode::Append],
+    }
+}
+
 /// Return the JSON Schema for the named source's config struct.
 pub fn source_schema(kind: &str) -> CliResult<Value> {
     match kind {
@@ -970,5 +982,15 @@ mod tests {
         assert!(sink_supports_idempotent_writes("postgres"));
         assert!(sink_supports_idempotent_writes("iceberg"));
         assert!(!sink_supports_idempotent_writes("jsonl"));
+    }
+
+    #[test]
+    fn sink_supported_write_modes_allowlist() {
+        use faucet_core::WriteMode;
+        assert!(sink_supported_write_modes("postgres").contains(&WriteMode::Upsert));
+        assert!(sink_supported_write_modes("elasticsearch").contains(&WriteMode::Delete));
+        // a sink without upsert support is append-only
+        assert_eq!(sink_supported_write_modes("jsonl"), &[WriteMode::Append]);
+        assert_eq!(sink_supported_write_modes("kafka"), &[WriteMode::Append]);
     }
 }

--- a/cli/src/transforms.rs
+++ b/cli/src/transforms.rs
@@ -5,10 +5,12 @@
 
 use crate::config::TransformSpec;
 use crate::error::{CliError, CliResult};
+#[cfg(any(feature = "transforms", feature = "transform-cdc-unwrap"))]
+use faucet_core::{JsonSchema, schema_for};
 #[cfg(feature = "transforms")]
-use faucet_core::{CastOnError, CastType, JsonSchema, KeyCaseMode, ValueCaseMode, schema_for};
+use faucet_core::{CastOnError, CastType, KeyCaseMode, ValueCaseMode};
 use faucet_core::{RecordTransform, TransformStage};
-#[cfg(feature = "transforms")]
+#[cfg(any(feature = "transforms", feature = "transform-cdc-unwrap"))]
 use serde::Deserialize;
 use serde_json::Value;
 #[cfg(feature = "transforms")]
@@ -149,6 +151,61 @@ struct ExplodeConfig {
 #[cfg(feature = "transform-explode")]
 fn default_explode_separator_cli() -> String {
     "_".to_owned()
+}
+
+#[cfg(feature = "transform-cdc-unwrap")]
+#[derive(Debug, Deserialize, JsonSchema)]
+struct CdcUnwrapConfig {
+    /// Envelope field holding the operation code. Default `"op"`.
+    #[serde(default = "cdc_op_field")]
+    op_field: String,
+    /// Envelope field holding the post-image row. Default `"after"`.
+    #[serde(default = "cdc_after_field")]
+    after_field: String,
+    /// Envelope field holding the pre-image row. Default `"before"`.
+    #[serde(default = "cdc_before_field")]
+    before_field: String,
+    /// Fallback key field for deletes when `before` is absent. Default `"document_key"`.
+    #[serde(default = "cdc_key_field")]
+    key_field: String,
+    /// Field stamped onto every emitted row with the op value. Default `"__op"`.
+    #[serde(default = "cdc_marker_field")]
+    marker_field: String,
+    /// Op values that mean delete. Default `["d", "delete"]`.
+    #[serde(default = "cdc_delete_ops")]
+    delete_ops: Vec<String>,
+    /// Op values that cause the record to be dropped (1→0). Default `["ddl", "truncate"]`.
+    #[serde(default = "cdc_drop_ops")]
+    drop_ops: Vec<String>,
+}
+
+#[cfg(feature = "transform-cdc-unwrap")]
+fn cdc_op_field() -> String {
+    "op".into()
+}
+#[cfg(feature = "transform-cdc-unwrap")]
+fn cdc_after_field() -> String {
+    "after".into()
+}
+#[cfg(feature = "transform-cdc-unwrap")]
+fn cdc_before_field() -> String {
+    "before".into()
+}
+#[cfg(feature = "transform-cdc-unwrap")]
+fn cdc_key_field() -> String {
+    "document_key".into()
+}
+#[cfg(feature = "transform-cdc-unwrap")]
+fn cdc_marker_field() -> String {
+    "__op".into()
+}
+#[cfg(feature = "transform-cdc-unwrap")]
+fn cdc_delete_ops() -> Vec<String> {
+    vec!["d".into(), "delete".into()]
+}
+#[cfg(feature = "transform-cdc-unwrap")]
+fn cdc_drop_ops() -> Vec<String> {
+    vec!["ddl".into(), "truncate".into()]
 }
 
 /// One row in the transform registry — the single source of truth for every
@@ -378,6 +435,26 @@ fn registry() -> Vec<TransformDef> {
             },
         });
     }
+    #[cfg(feature = "transform-cdc-unwrap")]
+    {
+        defs.push(TransformDef {
+            kind: "cdc_unwrap",
+            description: "Normalize a CDC envelope into a flat row + delete marker (for upsert sinks).",
+            schema_fn: || schema::<CdcUnwrapConfig>(),
+            compile_fn: |kind, config| {
+                let cfg = decode::<CdcUnwrapConfig>(kind, config)?;
+                Ok(faucet_core::TransformStage::CdcUnwrap(faucet_core::CdcUnwrapSpec {
+                    op_field: cfg.op_field,
+                    after_field: cfg.after_field,
+                    before_field: cfg.before_field,
+                    key_field: cfg.key_field,
+                    marker_field: cfg.marker_field,
+                    delete_ops: cfg.delete_ops,
+                    drop_ops: cfg.drop_ops,
+                }))
+            },
+        });
+    }
     defs
 }
 
@@ -470,12 +547,12 @@ fn unknown_transform(name: &str) -> CliError {
     }
 }
 
-#[cfg(feature = "transforms")]
+#[cfg(any(feature = "transforms", feature = "transform-cdc-unwrap"))]
 fn schema<T: JsonSchema>() -> Value {
     serde_json::to_value(schema_for!(T)).unwrap_or_else(|_| serde_json::json!({"type": "object"}))
 }
 
-#[cfg(feature = "transforms")]
+#[cfg(any(feature = "transforms", feature = "transform-cdc-unwrap"))]
 fn decode<T: serde::de::DeserializeOwned>(name: &str, config: Value) -> CliResult<T> {
     serde_json::from_value(config).map_err(|e| CliError::InvalidTransform {
         name: name.to_owned(),
@@ -923,6 +1000,25 @@ mod tests {
     fn sql_schema_and_listing_present() {
         assert!(transform_schema("sql").is_ok());
         assert!(available_transforms().contains(&"sql"));
+    }
+
+    #[cfg(feature = "transform-cdc-unwrap")]
+    #[test]
+    fn compiles_cdc_unwrap_with_defaults() {
+        let specs = vec![TransformSpec {
+            kind: "cdc_unwrap".into(),
+            config: json!({}),
+        }];
+        let out = compile_transforms(&specs).unwrap();
+        assert_eq!(out.len(), 1);
+        assert!(matches!(out[0], faucet_core::TransformStage::CdcUnwrap(_)));
+    }
+
+    #[cfg(feature = "transform-cdc-unwrap")]
+    #[test]
+    fn cdc_unwrap_schema_and_listing_present() {
+        assert!(transform_schema("cdc_unwrap").is_ok());
+        assert!(available_transforms().contains(&"cdc_unwrap"));
     }
 
     #[cfg(feature = "quality")]

--- a/cli/src/transforms.rs
+++ b/cli/src/transforms.rs
@@ -5,10 +5,10 @@
 
 use crate::config::TransformSpec;
 use crate::error::{CliError, CliResult};
-#[cfg(any(feature = "transforms", feature = "transform-cdc-unwrap"))]
-use faucet_core::{JsonSchema, schema_for};
 #[cfg(feature = "transforms")]
 use faucet_core::{CastOnError, CastType, KeyCaseMode, ValueCaseMode};
+#[cfg(any(feature = "transforms", feature = "transform-cdc-unwrap"))]
+use faucet_core::{JsonSchema, schema_for};
 use faucet_core::{RecordTransform, TransformStage};
 #[cfg(any(feature = "transforms", feature = "transform-cdc-unwrap"))]
 use serde::Deserialize;

--- a/cli/tests/cli_end_to_end.rs
+++ b/cli/tests/cli_end_to_end.rs
@@ -292,6 +292,78 @@ fn validate_accepts_csv_to_jsonl_yaml() {
 }
 
 #[test]
+fn validate_accepts_upsert_on_postgres_with_key() {
+    // Upsert on a supported sink with a non-empty key passes load-time
+    // validation. `validate` only expands + reports — no DB connection.
+    let dir = TempDir::new().unwrap();
+    let cfg = dir.path().join("pipeline.yaml");
+    fs::write(
+        &cfg,
+        r#"version: 1
+name: upsert_ok
+pipeline:
+  source:
+    type: rest
+    config:
+      url: http://x
+  sink:
+    type: postgres
+    config:
+      connection_url: postgres://x
+      table_name: t
+      column_mapping: auto_map
+      write_mode: upsert
+      key: [id]
+"#,
+    )
+    .unwrap();
+
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["validate"])
+        .arg(&cfg)
+        .assert()
+        .success()
+        .stdout(contains("sink=postgres"));
+}
+
+#[test]
+fn validate_rejects_upsert_on_jsonl_sink() {
+    // Upsert on an append-only sink fails load-time validation with a clear
+    // message naming the mode and the sink.
+    let dir = TempDir::new().unwrap();
+    let cfg = dir.path().join("pipeline.yaml");
+    fs::write(
+        &cfg,
+        r#"version: 1
+name: upsert_bad
+pipeline:
+  source:
+    type: rest
+    config:
+      url: http://x
+  sink:
+    type: jsonl
+    config:
+      path: out.jsonl
+      write_mode: upsert
+      key: [id]
+"#,
+    )
+    .unwrap();
+
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["validate"])
+        .arg(&cfg)
+        .assert()
+        .failure()
+        .stderr(contains("write_mode"))
+        .stderr(contains("upsert"))
+        .stderr(contains("jsonl"));
+}
+
+#[test]
 fn run_executes_csv_to_jsonl_pipeline() {
     let dir = TempDir::new().unwrap();
     let csv = dir.path().join("in.csv");

--- a/cli/tests/cli_end_to_end.rs
+++ b/cli/tests/cli_end_to_end.rs
@@ -519,6 +519,9 @@ fn shipped_example_yamls_pass_validate() {
         // postgres_to_bigquery_with_lineage.yaml (OpenLineage HTTP transport).
         ("MARQUEZ_URL", "http://localhost:5000/api/v1/lineage"),
         ("PG_URL", "postgres://u:p@localhost/db"),
+        // postgres_cdc_to_postgres_upsert.yaml (CDC source + upsert mirror).
+        ("SOURCE_PG_URL", "postgres://u:p@localhost/src"),
+        ("DEST_PG_URL", "postgres://u:p@localhost/dst"),
         ("SNOWFLAKE_OAUTH_TOKEN", "x"),
         ("SOAP_USER", "x"),
         ("SOAP_PASS", "x"),

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -25,6 +25,7 @@ transform-spell-symbols = []
 transform-keys-case = []
 transform-filter = []
 transform-explode = []
+transform-cdc-unwrap = []
 transforms = [
     "transform-flatten",
     "transform-rename-keys",
@@ -39,6 +40,7 @@ transforms = [
     "transform-keys-case",
     "transform-filter",
     "transform-explode",
+    "transform-cdc-unwrap",
 ]
 observability-install = ["dep:metrics-exporter-prometheus", "dep:tracing-subscriber"]
 compression = ["dep:async-compression", "dep:flate2", "dep:zstd"]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -60,6 +60,8 @@ pub use pipeline::{
 };
 pub use replication::ReplicationMethod;
 pub use retry::execute_with_retry;
+#[cfg(feature = "transform-cdc-unwrap")]
+pub use stage::CdcUnwrapSpec;
 #[cfg(feature = "transform-explode")]
 pub use stage::{ExplodeSpec, OnMissing};
 #[cfg(feature = "transform-filter")]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -29,11 +29,11 @@ pub mod retry;
 pub mod schema;
 pub mod stage;
 pub mod state;
-pub mod write_mode;
 pub mod traits;
 pub mod transform;
 pub mod transforming_source;
 pub mod util;
+pub mod write_mode;
 
 #[cfg(feature = "compression")]
 pub mod compression;
@@ -75,11 +75,11 @@ pub use transform::ValueCaseMode;
 #[cfg(feature = "transform-cast")]
 pub use transform::{CastOnError, CastType};
 pub use transforming_source::TransformingSource;
+pub use util::redact_uri_credentials;
 pub use write_mode::{
     DeleteMarker, KeyTuple, WriteMode, WritePlan, WriteSpec, key_to_doc_id, key_to_filter,
     plan_writes,
 };
-pub use util::redact_uri_credentials;
 
 // Re-export dependencies that connector authors need, so they only depend on
 // `faucet-core` instead of adding `async-trait` and `serde_json` themselves.

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -29,6 +29,7 @@ pub mod retry;
 pub mod schema;
 pub mod stage;
 pub mod state;
+pub mod write_mode;
 pub mod traits;
 pub mod transform;
 pub mod transforming_source;
@@ -74,6 +75,10 @@ pub use transform::ValueCaseMode;
 #[cfg(feature = "transform-cast")]
 pub use transform::{CastOnError, CastType};
 pub use transforming_source::TransformingSource;
+pub use write_mode::{
+    DeleteMarker, KeyTuple, WriteMode, WritePlan, WriteSpec, key_to_doc_id, key_to_filter,
+    plan_writes,
+};
 pub use util::redact_uri_credentials;
 
 // Re-export dependencies that connector authors need, so they only depend on

--- a/crates/core/src/stage.rs
+++ b/crates/core/src/stage.rs
@@ -1,11 +1,13 @@
-//! Pipeline-level transform stages. A [`TransformStage`] wraps one of five
+//! Pipeline-level transform stages. A [`TransformStage`] wraps one of six
 //! shapes:
 //!
 //! - [`TransformStage::Map`] holds an unchanged 1→1 [`RecordTransform`].
-//! - [`TransformStage::Filter`] is a predicate-based 1→0|1 stage (added in
-//!   Task 4).
+//! - [`TransformStage::Filter`] is a predicate-based 1→0|1 stage.
 //! - [`TransformStage::Explode`] expands an array field into 1→0..N output
-//!   records (added in Task 5).
+//!   records.
+//! - [`TransformStage::CdcUnwrap`] normalizes a CDC change-event envelope
+//!   (`{op, before, after, …}`) into a flat row plus a marker field; DDL and
+//!   truncate events are dropped (1→0|1).
 //! - [`TransformStage::Custom`] is an `Fn(Value) -> Vec<Value>` closure
 //!   escape hatch for library callers.
 //! - [`TransformStage::PageFn`] is a `Fn(Vec<Value>) -> Result<Vec<Value>,
@@ -41,6 +43,12 @@ pub enum TransformStage {
     /// container with a prefix, scalars/arrays replace the leaf in place.
     #[cfg(feature = "transform-explode")]
     Explode(ExplodeSpec),
+    /// CDC envelope → flat row + marker. 1→0|1.
+    /// Normalizes `{op, before, after, …}` into a flat row stamped with
+    /// `__op: "u"` (upsert) or `__op: "d"` (delete). DDL/truncate events
+    /// are dropped entirely.
+    #[cfg(feature = "transform-cdc-unwrap")]
+    CdcUnwrap(CdcUnwrapSpec),
     /// Arbitrary 0..N closure for library callers (not addressable from YAML).
     Custom(Arc<dyn Fn(Value) -> Vec<Value> + Send + Sync>),
     /// Page-level closure: sees the whole page, returns a new page; fallible.
@@ -58,6 +66,8 @@ impl std::fmt::Debug for TransformStage {
             Self::Filter(s) => f.debug_tuple("Filter").field(s).finish(),
             #[cfg(feature = "transform-explode")]
             Self::Explode(s) => f.debug_tuple("Explode").field(s).finish(),
+            #[cfg(feature = "transform-cdc-unwrap")]
+            Self::CdcUnwrap(s) => f.debug_tuple("CdcUnwrap").field(s).finish(),
             Self::Custom(_) => write!(f, "Custom(<fn>)"),
             Self::PageFn(_) => write!(f, "PageFn(<fn>)"),
         }
@@ -72,6 +82,8 @@ impl Clone for TransformStage {
             Self::Filter(s) => Self::Filter(s.clone()),
             #[cfg(feature = "transform-explode")]
             Self::Explode(s) => Self::Explode(s.clone()),
+            #[cfg(feature = "transform-cdc-unwrap")]
+            Self::CdcUnwrap(s) => Self::CdcUnwrap(s.clone()),
             Self::Custom(f) => Self::Custom(Arc::clone(f)),
             Self::PageFn(f) => Self::PageFn(Arc::clone(f)),
         }
@@ -85,6 +97,8 @@ pub enum CompiledStage {
     Filter(CompiledFilter),
     #[cfg(feature = "transform-explode")]
     Explode(CompiledExplode),
+    #[cfg(feature = "transform-cdc-unwrap")]
+    CdcUnwrap(CompiledCdcUnwrap),
     Custom(Arc<dyn Fn(Value) -> Vec<Value> + Send + Sync>),
     PageFn(PageFnBox),
 }
@@ -97,6 +111,8 @@ impl std::fmt::Debug for CompiledStage {
             Self::Filter(cf) => f.debug_tuple("Filter").field(cf).finish(),
             #[cfg(feature = "transform-explode")]
             Self::Explode(e) => f.debug_tuple("Explode").field(e).finish(),
+            #[cfg(feature = "transform-cdc-unwrap")]
+            Self::CdcUnwrap(c) => f.debug_tuple("CdcUnwrap").field(c).finish(),
             Self::Custom(_) => write!(f, "Custom(<fn>)"),
             Self::PageFn(_) => write!(f, "PageFn(<fn>)"),
         }
@@ -120,6 +136,8 @@ impl Clone for CompiledStage {
                 separator: e.separator.clone(),
                 on_missing: e.on_missing,
             }),
+            #[cfg(feature = "transform-cdc-unwrap")]
+            Self::CdcUnwrap(c) => Self::CdcUnwrap(c.clone()),
             Self::Custom(f) => Self::Custom(Arc::clone(f)),
             Self::PageFn(f) => Self::PageFn(Arc::clone(f)),
         }
@@ -618,6 +636,130 @@ impl CompiledExplode {
     }
 }
 
+// ── CDC unwrap spec ──
+
+/// Spec for [`TransformStage::CdcUnwrap`]. Normalizes a CDC change-event
+/// envelope (`{op, before, after, …}`) into a flat row plus a marker field,
+/// so a downstream upsert sink never needs to understand CDC. A 1→0|1 stage:
+/// DDL/truncate events (and non-delete events with no `after` image) are
+/// dropped.
+#[cfg(feature = "transform-cdc-unwrap")]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+pub struct CdcUnwrapSpec {
+    /// Envelope field holding the operation. Default `"op"`.
+    #[serde(default = "cdc_default_op_field")]
+    pub op_field: String,
+    /// Envelope field holding the post-image. Default `"after"`.
+    #[serde(default = "cdc_default_after_field")]
+    pub after_field: String,
+    /// Envelope field holding the pre-image. Default `"before"`.
+    #[serde(default = "cdc_default_before_field")]
+    pub before_field: String,
+    /// Optional fallback for the delete key when `before` is null (Mongo
+    /// carries the key in `document_key`). Default `"document_key"`.
+    #[serde(default = "cdc_default_key_field")]
+    pub key_field: String,
+    /// Field stamped on every emitted row. Default `"__op"`.
+    #[serde(default = "cdc_default_marker_field")]
+    pub marker_field: String,
+    /// `op` values that mean delete. Default covers all three CDC vocabularies.
+    #[serde(default = "cdc_default_delete_ops")]
+    pub delete_ops: Vec<String>,
+    /// `op` values dropped entirely (1→0). Default `["ddl", "truncate"]`.
+    #[serde(default = "cdc_default_drop_ops")]
+    pub drop_ops: Vec<String>,
+}
+
+#[cfg(feature = "transform-cdc-unwrap")]
+fn cdc_default_op_field() -> String {
+    "op".into()
+}
+#[cfg(feature = "transform-cdc-unwrap")]
+fn cdc_default_after_field() -> String {
+    "after".into()
+}
+#[cfg(feature = "transform-cdc-unwrap")]
+fn cdc_default_before_field() -> String {
+    "before".into()
+}
+#[cfg(feature = "transform-cdc-unwrap")]
+fn cdc_default_key_field() -> String {
+    "document_key".into()
+}
+#[cfg(feature = "transform-cdc-unwrap")]
+fn cdc_default_marker_field() -> String {
+    "__op".into()
+}
+#[cfg(feature = "transform-cdc-unwrap")]
+fn cdc_default_delete_ops() -> Vec<String> {
+    vec!["d".into(), "delete".into()]
+}
+#[cfg(feature = "transform-cdc-unwrap")]
+fn cdc_default_drop_ops() -> Vec<String> {
+    vec!["ddl".into(), "truncate".into()]
+}
+
+#[cfg(feature = "transform-cdc-unwrap")]
+impl Default for CdcUnwrapSpec {
+    fn default() -> Self {
+        Self {
+            op_field: cdc_default_op_field(),
+            after_field: cdc_default_after_field(),
+            before_field: cdc_default_before_field(),
+            key_field: cdc_default_key_field(),
+            marker_field: cdc_default_marker_field(),
+            delete_ops: cdc_default_delete_ops(),
+            drop_ops: cdc_default_drop_ops(),
+        }
+    }
+}
+
+/// Pre-compiled cdc_unwrap. `pub` so it can sit inside the `pub`
+/// [`CompiledStage::CdcUnwrap`] variant without triggering the
+/// `private_interfaces` lint — same shape as the already-`pub`
+/// [`CompiledExplode`] sibling that backs [`CompiledStage::Explode`].
+#[cfg(feature = "transform-cdc-unwrap")]
+#[derive(Debug, Clone)]
+pub struct CompiledCdcUnwrap {
+    spec: CdcUnwrapSpec,
+}
+
+#[cfg(feature = "transform-cdc-unwrap")]
+impl CompiledCdcUnwrap {
+    fn compile(spec: &CdcUnwrapSpec) -> Result<Self, FaucetError> {
+        Ok(Self { spec: spec.clone() })
+    }
+
+    fn apply(&self, rec: Value) -> Result<Vec<Value>, FaucetError> {
+        let s = &self.spec;
+        let op = rec.get(&s.op_field).and_then(Value::as_str).unwrap_or("");
+        if s.drop_ops.iter().any(|d| d == op) {
+            return Ok(vec![]);
+        }
+        let is_delete = s.delete_ops.iter().any(|d| d == op);
+        let row = if is_delete {
+            match rec.get(&s.before_field) {
+                Some(Value::Object(m)) => Some(Value::Object(m.clone())),
+                _ => match rec.get(&s.key_field) {
+                    Some(Value::Object(m)) => Some(Value::Object(m.clone())),
+                    _ => None,
+                },
+            }
+        } else {
+            match rec.get(&s.after_field) {
+                Some(Value::Object(m)) => Some(Value::Object(m.clone())),
+                _ => None,
+            }
+        };
+        let Some(Value::Object(mut map)) = row else {
+            return Ok(vec![]);
+        };
+        let marker = if is_delete { "d" } else { "u" };
+        map.insert(s.marker_field.clone(), Value::String(marker.to_string()));
+        Ok(vec![Value::Object(map)])
+    }
+}
+
 /// Compile a [`TransformStage`] into its [`CompiledStage`] form.
 pub fn compile_stage(s: &TransformStage) -> Result<CompiledStage, FaucetError> {
     match s {
@@ -627,6 +769,10 @@ pub fn compile_stage(s: &TransformStage) -> Result<CompiledStage, FaucetError> {
         #[cfg(feature = "transform-explode")]
         TransformStage::Explode(spec) => {
             Ok(CompiledStage::Explode(CompiledExplode::compile(spec)?))
+        }
+        #[cfg(feature = "transform-cdc-unwrap")]
+        TransformStage::CdcUnwrap(spec) => {
+            Ok(CompiledStage::CdcUnwrap(CompiledCdcUnwrap::compile(spec)?))
         }
         TransformStage::Custom(f) => Ok(CompiledStage::Custom(Arc::clone(f))),
         TransformStage::PageFn(f) => Ok(CompiledStage::PageFn(Arc::clone(f))),
@@ -686,6 +832,8 @@ fn apply_one_stage(rec: Value, stage: &CompiledStage) -> Result<Vec<Value>, Fauc
         }
         #[cfg(feature = "transform-explode")]
         CompiledStage::Explode(e) => e.apply(rec),
+        #[cfg(feature = "transform-cdc-unwrap")]
+        CompiledStage::CdcUnwrap(c) => c.apply(rec),
         CompiledStage::Custom(f) => Ok(f(rec)),
         CompiledStage::PageFn(_) => Err(FaucetError::Transform(
             "PageFn is a page-level stage and cannot run in a per-record context; \
@@ -1638,5 +1786,76 @@ mod tests {
         let mut rec = json!({"name": "scalar"});
         let result = CompiledPath::resolve_segments_mut(&mut rec, p.segments()).unwrap();
         assert!(result.is_none(), "scalar leaf is not an object container");
+    }
+
+    // ── CdcUnwrap ──
+
+    #[cfg(feature = "transform-cdc-unwrap")]
+    fn cdc_unwrap_default() -> TransformStage {
+        TransformStage::CdcUnwrap(CdcUnwrapSpec::default())
+    }
+
+    #[cfg(feature = "transform-cdc-unwrap")]
+    #[test]
+    fn cdc_unwrap_postgres_insert_emits_after_with_marker() {
+        let stages = compile(&[cdc_unwrap_default()]);
+        let env = json!({"op": "insert", "before": null, "after": {"id": 1, "name": "a"}});
+        let out = apply_stages(env, &stages).unwrap();
+        assert_eq!(out, vec![json!({"id": 1, "name": "a", "__op": "u"})]);
+    }
+
+    #[cfg(feature = "transform-cdc-unwrap")]
+    #[test]
+    fn cdc_unwrap_mysql_short_ops() {
+        let stages = compile(&[cdc_unwrap_default()]);
+        let c = apply_stages(json!({"op": "c", "after": {"id": 1}}), &stages).unwrap();
+        assert_eq!(c, vec![json!({"id": 1, "__op": "u"})]);
+        let d = apply_stages(
+            json!({"op": "d", "before": {"id": 2, "name": "x"}, "after": null}),
+            &stages,
+        )
+        .unwrap();
+        assert_eq!(d, vec![json!({"id": 2, "name": "x", "__op": "d"})]);
+    }
+
+    #[cfg(feature = "transform-cdc-unwrap")]
+    #[test]
+    fn cdc_unwrap_mongo_delete_uses_document_key() {
+        let stages = compile(&[cdc_unwrap_default()]);
+        let env = json!({"op": "d", "before": null, "after": null, "document_key": {"_id": "abc"}});
+        let out = apply_stages(env, &stages).unwrap();
+        assert_eq!(out, vec![json!({"_id": "abc", "__op": "d"})]);
+    }
+
+    #[cfg(feature = "transform-cdc-unwrap")]
+    #[test]
+    fn cdc_unwrap_mongo_replace_op_is_upsert() {
+        let stages = compile(&[cdc_unwrap_default()]);
+        let out =
+            apply_stages(json!({"op": "r", "after": {"_id": "x", "v": 1}}), &stages).unwrap();
+        assert_eq!(out, vec![json!({"_id": "x", "v": 1, "__op": "u"})]);
+    }
+
+    #[cfg(feature = "transform-cdc-unwrap")]
+    #[test]
+    fn cdc_unwrap_drops_ddl_and_truncate() {
+        let stages = compile(&[cdc_unwrap_default()]);
+        assert!(
+            apply_stages(json!({"op": "ddl", "statement": "ALTER ..."}), &stages)
+                .unwrap()
+                .is_empty()
+        );
+        assert!(apply_stages(json!({"op": "truncate"}), &stages)
+            .unwrap()
+            .is_empty());
+    }
+
+    #[cfg(feature = "transform-cdc-unwrap")]
+    #[test]
+    fn cdc_unwrap_non_object_after_for_insert_is_dropped() {
+        let stages = compile(&[cdc_unwrap_default()]);
+        assert!(apply_stages(json!({"op": "insert", "after": null}), &stages)
+            .unwrap()
+            .is_empty());
     }
 }

--- a/crates/core/src/stage.rs
+++ b/crates/core/src/stage.rs
@@ -752,6 +752,20 @@ impl CompiledCdcUnwrap {
             }
         };
         let Some(Value::Object(mut map)) = row else {
+            if is_delete {
+                tracing::warn!(
+                    op,
+                    key_field = %s.key_field,
+                    before_field = %s.before_field,
+                    "cdc_unwrap: dropping delete event with no usable key (no `before` image and no key_field object)"
+                );
+            } else {
+                tracing::warn!(
+                    op,
+                    after_field = %s.after_field,
+                    "cdc_unwrap: dropping non-delete event with no row image"
+                );
+            }
             return Ok(vec![]);
         };
         let marker = if is_delete { "d" } else { "u" };
@@ -1857,5 +1871,20 @@ mod tests {
         assert!(apply_stages(json!({"op": "insert", "after": null}), &stages)
             .unwrap()
             .is_empty());
+    }
+
+    #[cfg(feature = "transform-cdc-unwrap")]
+    #[test]
+    fn cdc_unwrap_update_ops_emit_after_as_upsert() {
+        let stages = compile(&[cdc_unwrap_default()]);
+        // postgres-cdc long form: update uses the `after` image, not `before`.
+        let pg = apply_stages(
+            json!({"op": "update", "before": {"id": 1, "v": "old"}, "after": {"id": 1, "v": "new"}}),
+            &stages,
+        ).unwrap();
+        assert_eq!(pg, vec![json!({"id": 1, "v": "new", "__op": "u"})]);
+        // mysql/mongo short form.
+        let my = apply_stages(json!({"op": "u", "after": {"id": 2, "v": 9}}), &stages).unwrap();
+        assert_eq!(my, vec![json!({"id": 2, "v": 9, "__op": "u"})]);
     }
 }

--- a/crates/core/src/stage.rs
+++ b/crates/core/src/stage.rs
@@ -1845,8 +1845,7 @@ mod tests {
     #[test]
     fn cdc_unwrap_mongo_replace_op_is_upsert() {
         let stages = compile(&[cdc_unwrap_default()]);
-        let out =
-            apply_stages(json!({"op": "r", "after": {"_id": "x", "v": 1}}), &stages).unwrap();
+        let out = apply_stages(json!({"op": "r", "after": {"_id": "x", "v": 1}}), &stages).unwrap();
         assert_eq!(out, vec![json!({"_id": "x", "v": 1, "__op": "u"})]);
     }
 
@@ -1859,18 +1858,22 @@ mod tests {
                 .unwrap()
                 .is_empty()
         );
-        assert!(apply_stages(json!({"op": "truncate"}), &stages)
-            .unwrap()
-            .is_empty());
+        assert!(
+            apply_stages(json!({"op": "truncate"}), &stages)
+                .unwrap()
+                .is_empty()
+        );
     }
 
     #[cfg(feature = "transform-cdc-unwrap")]
     #[test]
     fn cdc_unwrap_non_object_after_for_insert_is_dropped() {
         let stages = compile(&[cdc_unwrap_default()]);
-        assert!(apply_stages(json!({"op": "insert", "after": null}), &stages)
-            .unwrap()
-            .is_empty());
+        assert!(
+            apply_stages(json!({"op": "insert", "after": null}), &stages)
+                .unwrap()
+                .is_empty()
+        );
     }
 
     #[cfg(feature = "transform-cdc-unwrap")]

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -258,6 +258,15 @@ pub trait Sink: Send + Sync {
         false
     }
 
+    /// Write modes this sink can apply. Default: append-only. Sinks that
+    /// implement key-based merge override this to include
+    /// [`WriteMode::Upsert`](crate::write_mode::WriteMode) /
+    /// [`WriteMode::Delete`](crate::write_mode::WriteMode). The CLI rejects a
+    /// configured mode that is not in this set at config-load time.
+    fn supported_write_modes(&self) -> &'static [crate::write_mode::WriteMode] {
+        &[crate::write_mode::WriteMode::Append]
+    }
+
     /// Write `records` AND durably record `token` for `scope`, atomically.
     ///
     /// `scope` namespaces the watermark (the pipeline passes the per-row state
@@ -800,5 +809,19 @@ mod tests {
     fn source_default_does_not_support_exactly_once() {
         let source = MockSource { records: vec![] };
         assert!(!source.supports_exactly_once());
+    }
+
+    #[test]
+    fn sink_default_supported_write_modes_is_append_only() {
+        use crate::write_mode::WriteMode;
+        let sink = MockSink::new();
+        assert_eq!(sink.supported_write_modes(), &[WriteMode::Append]);
+    }
+
+    #[test]
+    fn supported_write_modes_callable_through_trait_object() {
+        use crate::write_mode::WriteMode;
+        let sink: Box<dyn Sink> = Box::new(MockSink::new());
+        assert!(sink.supported_write_modes().contains(&WriteMode::Append));
     }
 }

--- a/crates/core/src/write_mode.rs
+++ b/crates/core/src/write_mode.rs
@@ -6,7 +6,9 @@ use serde_json::{Map, Value};
 use std::collections::HashMap;
 
 /// Write semantics for a sink. Serialized snake_case. Default `Append`.
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, schemars::JsonSchema, PartialEq, Eq)]
+#[derive(
+    Debug, Clone, Copy, Default, Serialize, Deserialize, schemars::JsonSchema, PartialEq, Eq,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum WriteMode {
     /// Insert every record (today's behaviour).
@@ -164,7 +166,9 @@ fn extract_key(rec: &Value, key: &[String]) -> Result<KeyTuple, String> {
 
 fn is_delete_marked(rec: &Value, marker: Option<&DeleteMarker>) -> bool {
     let Some(dm) = marker else { return false };
-    let Some(v) = rec.get(&dm.field) else { return false };
+    let Some(v) = rec.get(&dm.field) else {
+        return false;
+    };
     let Some(s) = v.as_str() else { return false };
     dm.values.iter().any(|m| m == s)
 }
@@ -311,7 +315,10 @@ mod tests {
         );
         assert_eq!(plan.upserts.len(), 1);
         let plan2 = plan_writes(
-            &[json!({"a": 1, "b": 2, "v": "x"}), json!({"a": 1, "b": 3, "v": "y"})],
+            &[
+                json!({"a": 1, "b": 2, "v": "x"}),
+                json!({"a": 1, "b": 3, "v": "y"}),
+            ],
             &upsert_spec(&["a", "b"]),
         );
         assert_eq!(plan2.upserts.len(), 2, "(1,2) and (1,3) are distinct keys");
@@ -319,7 +326,11 @@ mod tests {
 
     #[test]
     fn validate_rejects_upsert_without_key() {
-        let spec = WriteSpec { write_mode: WriteMode::Upsert, key: vec![], delete_marker: None };
+        let spec = WriteSpec {
+            write_mode: WriteMode::Upsert,
+            key: vec![],
+            delete_marker: None,
+        };
         assert!(spec.validate().is_err());
     }
 
@@ -340,7 +351,10 @@ mod tests {
             }),
         };
         let plan = plan_writes(
-            &[json!({"id": 1, "__op": "d"}), json!({"id": 1, "v": 9, "__op": "u"})],
+            &[
+                json!({"id": 1, "__op": "d"}),
+                json!({"id": 1, "v": 9, "__op": "u"}),
+            ],
             &spec,
         );
         assert!(plan.deletes.is_empty());

--- a/crates/core/src/write_mode.rs
+++ b/crates/core/src/write_mode.rs
@@ -97,6 +97,10 @@ enum Action {
 /// sinks share. `WriteMode::Append` should never reach here (callers route
 /// append separately); if it does, every row is treated as an upsert.
 pub fn plan_writes(page: &[Value], spec: &WriteSpec) -> WritePlan {
+    debug_assert!(
+        spec.write_mode != WriteMode::Append,
+        "plan_writes called with WriteMode::Append — callers must route append separately"
+    );
     let mut plan = WritePlan::default();
     let mut index: HashMap<String, usize> = HashMap::new();
     let mut order: Vec<Action> = Vec::new();
@@ -175,11 +179,15 @@ fn strip_marker(mut rec: Value, marker: Option<&DeleteMarker>) -> Value {
 /// Stable canonical string for a key tuple, for dedup.
 fn canonical(k: &KeyTuple) -> String {
     let arr: Vec<&Value> = k.0.iter().map(|(_, v)| v).collect();
-    serde_json::to_string(&arr).unwrap_or_default()
+    serde_json::to_string(&arr).expect("a Vec<&serde_json::Value> always serializes")
 }
 
 /// Join a key tuple's values into a single document id (Elasticsearch `_id`,
 /// composite keys). Each value rendered as its plain string / JSON form.
+///
+/// Assumes each key column has a consistent JSON type across records (the
+/// normal case for SQL and CDC sources); it does not disambiguate, e.g., the
+/// integer `7` from the string `"7"` in the same column.
 pub fn key_to_doc_id(k: &KeyTuple, separator: &str) -> String {
     k.0.iter()
         .map(|(_, v)| match v {
@@ -318,5 +326,44 @@ mod tests {
     #[test]
     fn validate_allows_append_without_key() {
         assert!(WriteSpec::default().validate().is_ok());
+    }
+
+    #[test]
+    fn last_write_wins_upsert_after_delete_is_an_upsert() {
+        // Inverse of the delete-after-upsert case: [delete, upsert] → upsert wins.
+        let spec = WriteSpec {
+            write_mode: WriteMode::Upsert,
+            key: vec!["id".into()],
+            delete_marker: Some(DeleteMarker {
+                field: "__op".into(),
+                values: vec!["d".into()],
+            }),
+        };
+        let plan = plan_writes(
+            &[json!({"id": 1, "__op": "d"}), json!({"id": 1, "v": 9, "__op": "u"})],
+            &spec,
+        );
+        assert!(plan.deletes.is_empty());
+        assert_eq!(plan.upserts, vec![json!({"id": 1, "v": 9})]);
+    }
+
+    #[test]
+    fn empty_page_produces_empty_plan() {
+        let plan = plan_writes(&[], &upsert_spec(&["id"]));
+        assert!(plan.upserts.is_empty());
+        assert!(plan.deletes.is_empty());
+        assert!(plan.failed.is_empty());
+    }
+
+    #[test]
+    fn delete_mode_dedups_repeated_key() {
+        // Same key deleted twice in one page collapses to a single delete.
+        let spec = WriteSpec {
+            write_mode: WriteMode::Delete,
+            key: vec!["id".into()],
+            delete_marker: None,
+        };
+        let plan = plan_writes(&[json!({"id": 1}), json!({"id": 1})], &spec);
+        assert_eq!(plan.deletes.len(), 1);
     }
 }

--- a/crates/core/src/write_mode.rs
+++ b/crates/core/src/write_mode.rs
@@ -1,0 +1,322 @@
+//! Unified write-mode types + planner shared by every upsert-capable sink.
+
+use crate::error::FaucetError;
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use std::collections::HashMap;
+
+/// Write semantics for a sink. Serialized snake_case. Default `Append`.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, schemars::JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WriteMode {
+    /// Insert every record (today's behaviour).
+    #[default]
+    Append,
+    /// Insert-or-update by `key`; optionally route delete-marked rows to deletes.
+    Upsert,
+    /// Delete by `key` for every record.
+    Delete,
+}
+
+impl WriteMode {
+    /// Lowercase wire name, for error messages.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            WriteMode::Append => "append",
+            WriteMode::Upsert => "upsert",
+            WriteMode::Delete => "delete",
+        }
+    }
+}
+
+/// Identifies a record as a delete (vs. an upsert) by a marker field's value.
+/// e.g. `{ field: "__op", values: ["d", "delete"] }`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, schemars::JsonSchema, PartialEq, Eq)]
+pub struct DeleteMarker {
+    /// Field name whose value flags a delete.
+    pub field: String,
+    /// Values of `field` that mean "this row is a delete".
+    pub values: Vec<String>,
+}
+
+/// Shared write-mode config, embedded in each upsert-capable sink config via
+/// `#[serde(flatten)]` so `write_mode` / `key` / `delete_marker` appear at the
+/// sink-config top level.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct WriteSpec {
+    /// Append (default), upsert, or delete.
+    #[serde(default)]
+    pub write_mode: WriteMode,
+    /// Key columns. Required and non-empty for upsert/delete; ignored for append.
+    #[serde(default)]
+    pub key: Vec<String>,
+    /// Optional. Upsert only: rows whose `field` matches one of `values` are
+    /// deletes; all others are upserts. The marker field is stripped from
+    /// upsert rows before writing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub delete_marker: Option<DeleteMarker>,
+}
+
+impl WriteSpec {
+    /// Validate internal consistency at config-load time.
+    pub fn validate(&self) -> Result<(), FaucetError> {
+        if matches!(self.write_mode, WriteMode::Upsert | WriteMode::Delete) && self.key.is_empty() {
+            return Err(FaucetError::Config(format!(
+                "write_mode: {} requires a non-empty `key`",
+                self.write_mode.as_str()
+            )));
+        }
+        Ok(())
+    }
+}
+
+/// Ordered key column → value pairs, in `key` declaration order.
+#[derive(Debug, Clone, PartialEq)]
+pub struct KeyTuple(pub Vec<(String, Value)>);
+
+/// The partition of a page by write mode. Infallible to build — per-row
+/// failures (missing/null key) land in `failed` with their original page index
+/// so the caller can route them to a DLQ or abort.
+#[derive(Debug, Default)]
+pub struct WritePlan {
+    /// Rows to insert-or-update, deduped (last-write-wins), marker stripped.
+    pub upserts: Vec<Value>,
+    /// Key tuples to delete, deduped.
+    pub deletes: Vec<KeyTuple>,
+    /// `(page_index, message)` for rows whose key could not be extracted.
+    pub failed: Vec<(usize, String)>,
+}
+
+#[derive(Clone)]
+enum Action {
+    Upsert(Value),
+    Delete(KeyTuple),
+}
+
+/// Partition `page` into upserts + deletes per `spec`. The single place all six
+/// sinks share. `WriteMode::Append` should never reach here (callers route
+/// append separately); if it does, every row is treated as an upsert.
+pub fn plan_writes(page: &[Value], spec: &WriteSpec) -> WritePlan {
+    let mut plan = WritePlan::default();
+    let mut index: HashMap<String, usize> = HashMap::new();
+    let mut order: Vec<Action> = Vec::new();
+
+    for (i, rec) in page.iter().enumerate() {
+        let key_tuple = match extract_key(rec, &spec.key) {
+            Ok(k) => k,
+            Err(msg) => {
+                plan.failed.push((i, msg));
+                continue;
+            }
+        };
+        let canon = canonical(&key_tuple);
+
+        let is_delete = match spec.write_mode {
+            WriteMode::Delete => true,
+            WriteMode::Upsert => is_delete_marked(rec, spec.delete_marker.as_ref()),
+            WriteMode::Append => false,
+        };
+
+        let action = if is_delete {
+            Action::Delete(key_tuple)
+        } else {
+            Action::Upsert(strip_marker(rec.clone(), spec.delete_marker.as_ref()))
+        };
+
+        match index.get(&canon) {
+            Some(&slot) => order[slot] = action,
+            None => {
+                index.insert(canon, order.len());
+                order.push(action);
+            }
+        }
+    }
+
+    for action in order {
+        match action {
+            Action::Upsert(v) => plan.upserts.push(v),
+            Action::Delete(k) => plan.deletes.push(k),
+        }
+    }
+    plan
+}
+
+/// Pull the key columns out of a record in `key` order. Missing key or null
+/// key value is an error.
+fn extract_key(rec: &Value, key: &[String]) -> Result<KeyTuple, String> {
+    let obj = rec
+        .as_object()
+        .ok_or_else(|| "record is not a JSON object".to_string())?;
+    let mut out = Vec::with_capacity(key.len());
+    for col in key {
+        match obj.get(col) {
+            None => return Err(format!("missing key column '{col}'")),
+            Some(Value::Null) => return Err(format!("null value for key column '{col}'")),
+            Some(v) => out.push((col.clone(), v.clone())),
+        }
+    }
+    Ok(KeyTuple(out))
+}
+
+fn is_delete_marked(rec: &Value, marker: Option<&DeleteMarker>) -> bool {
+    let Some(dm) = marker else { return false };
+    let Some(v) = rec.get(&dm.field) else { return false };
+    let Some(s) = v.as_str() else { return false };
+    dm.values.iter().any(|m| m == s)
+}
+
+fn strip_marker(mut rec: Value, marker: Option<&DeleteMarker>) -> Value {
+    if let (Some(dm), Value::Object(map)) = (marker, &mut rec) {
+        map.remove(&dm.field);
+    }
+    rec
+}
+
+/// Stable canonical string for a key tuple, for dedup.
+fn canonical(k: &KeyTuple) -> String {
+    let arr: Vec<&Value> = k.0.iter().map(|(_, v)| v).collect();
+    serde_json::to_string(&arr).unwrap_or_default()
+}
+
+/// Join a key tuple's values into a single document id (Elasticsearch `_id`,
+/// composite keys). Each value rendered as its plain string / JSON form.
+pub fn key_to_doc_id(k: &KeyTuple, separator: &str) -> String {
+    k.0.iter()
+        .map(|(_, v)| match v {
+            Value::String(s) => s.clone(),
+            other => other.to_string(),
+        })
+        .collect::<Vec<_>>()
+        .join(separator)
+}
+
+/// Build a Mongo/ES filter document `{ col: value, … }` from a key tuple.
+pub fn key_to_filter(k: &KeyTuple) -> Map<String, Value> {
+    k.0.iter().map(|(c, v)| (c.clone(), v.clone())).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn upsert_spec(keys: &[&str]) -> WriteSpec {
+        WriteSpec {
+            write_mode: WriteMode::Upsert,
+            key: keys.iter().map(|s| s.to_string()).collect(),
+            delete_marker: None,
+        }
+    }
+
+    #[test]
+    fn upsert_extracts_key_and_keeps_row() {
+        let plan = plan_writes(&[json!({"id": 1, "name": "a"})], &upsert_spec(&["id"]));
+        assert_eq!(plan.upserts, vec![json!({"id": 1, "name": "a"})]);
+        assert!(plan.deletes.is_empty());
+        assert!(plan.failed.is_empty());
+    }
+
+    #[test]
+    fn missing_key_goes_to_failed_with_original_index() {
+        let plan = plan_writes(
+            &[json!({"id": 1}), json!({"name": "no-key"})],
+            &upsert_spec(&["id"]),
+        );
+        assert_eq!(plan.upserts.len(), 1);
+        assert_eq!(plan.failed.len(), 1);
+        assert_eq!(plan.failed[0].0, 1, "failed row keeps its page index");
+    }
+
+    #[test]
+    fn null_key_value_is_a_failure() {
+        let plan = plan_writes(&[json!({"id": null})], &upsert_spec(&["id"]));
+        assert!(plan.upserts.is_empty());
+        assert_eq!(plan.failed.len(), 1);
+    }
+
+    #[test]
+    fn delete_marker_routes_to_deletes_and_strips_marker() {
+        let spec = WriteSpec {
+            write_mode: WriteMode::Upsert,
+            key: vec!["id".into()],
+            delete_marker: Some(DeleteMarker {
+                field: "__op".into(),
+                values: vec!["d".into()],
+            }),
+        };
+        let plan = plan_writes(
+            &[
+                json!({"id": 1, "name": "a", "__op": "u"}),
+                json!({"id": 2, "__op": "d"}),
+            ],
+            &spec,
+        );
+        assert_eq!(plan.upserts, vec![json!({"id": 1, "name": "a"})]);
+        assert_eq!(plan.deletes.len(), 1);
+        assert_eq!(plan.deletes[0].0, vec![("id".to_string(), json!(2))]);
+    }
+
+    #[test]
+    fn last_write_wins_dedup_keeps_final_upsert() {
+        let plan = plan_writes(
+            &[json!({"id": 1, "v": "old"}), json!({"id": 1, "v": "new"})],
+            &upsert_spec(&["id"]),
+        );
+        assert_eq!(plan.upserts, vec![json!({"id": 1, "v": "new"})]);
+    }
+
+    #[test]
+    fn last_write_wins_delete_after_upsert_is_a_delete() {
+        let spec = WriteSpec {
+            write_mode: WriteMode::Upsert,
+            key: vec!["id".into()],
+            delete_marker: Some(DeleteMarker {
+                field: "__op".into(),
+                values: vec!["d".into()],
+            }),
+        };
+        let plan = plan_writes(
+            &[json!({"id": 1, "__op": "u"}), json!({"id": 1, "__op": "d"})],
+            &spec,
+        );
+        assert!(plan.upserts.is_empty());
+        assert_eq!(plan.deletes.len(), 1);
+    }
+
+    #[test]
+    fn delete_mode_routes_every_row_to_deletes() {
+        let spec = WriteSpec {
+            write_mode: WriteMode::Delete,
+            key: vec!["id".into()],
+            delete_marker: None,
+        };
+        let plan = plan_writes(&[json!({"id": 1}), json!({"id": 2})], &spec);
+        assert!(plan.upserts.is_empty());
+        assert_eq!(plan.deletes.len(), 2);
+    }
+
+    #[test]
+    fn composite_key_tuple_is_ordered() {
+        let plan = plan_writes(
+            &[json!({"a": 1, "b": 2, "v": 9})],
+            &upsert_spec(&["a", "b"]),
+        );
+        assert_eq!(plan.upserts.len(), 1);
+        let plan2 = plan_writes(
+            &[json!({"a": 1, "b": 2, "v": "x"}), json!({"a": 1, "b": 3, "v": "y"})],
+            &upsert_spec(&["a", "b"]),
+        );
+        assert_eq!(plan2.upserts.len(), 2, "(1,2) and (1,3) are distinct keys");
+    }
+
+    #[test]
+    fn validate_rejects_upsert_without_key() {
+        let spec = WriteSpec { write_mode: WriteMode::Upsert, key: vec![], delete_marker: None };
+        assert!(spec.validate().is_err());
+    }
+
+    #[test]
+    fn validate_allows_append_without_key() {
+        assert!(WriteSpec::default().validate().is_ok());
+    }
+}

--- a/crates/sink/elasticsearch/README.md
+++ b/crates/sink/elasticsearch/README.md
@@ -60,7 +60,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 | `index` | `String` | *(required)* | Target index name |
 | `auth` | `ElasticsearchAuth` | `None` | Authentication method (see below) |
 | `batch_size` | `usize` | `1000` | Maximum documents per `_bulk` request. See [Streaming and batching](#streaming-and-batching) below |
-| `id_field` | `Option<String>` | `None` | JSON field name to use as the document `_id`. If `None`, Elasticsearch auto-generates IDs. |
+| `id_field` | `Option<String>` | `None` | JSON field name to use as the document `_id`. If `None`, Elasticsearch auto-generates IDs. **Superseded by `key` in `upsert`/`delete` modes.** |
+| `write_mode` | `"append" \| "upsert" \| "delete"` | `"append"` | Write semantics. See [Write modes](#write-modes-upsert--delete) below |
+| `key` | `[String]` | `[]` | Key columns whose values form the document `_id` (joined with `:`). Required and non-empty for `upsert`/`delete` |
+| `delete_marker` | `{ field, values }` | *(none)* | Upsert only: rows whose `field` matches one of `values` are routed to deletes instead of upserts; the marker field is stripped from upserted docs |
 
 ### Streaming and batching
 
@@ -116,6 +119,48 @@ When `id_field` is set, the sink extracts the document `_id` from each record:
 - If the field value is a string, it is used directly.
 - If the field value is a number or other type, it is converted to its string representation.
 - If a record is missing the `id_field`, Elasticsearch auto-generates an ID for that document.
+
+### Write modes (upsert / delete)
+
+Elasticsearch is schemaless and `_id`-addressable, so the sink supports all
+three write modes. The `_bulk` `index` action is already an idempotent
+overwrite by `_id`, so an **upsert is just an `index` keyed on a stable
+document `_id`**, and a **delete is a `delete` action by `_id`**.
+
+- **`append`** (default) — every record is indexed; `_id` comes from `id_field`
+  if set, otherwise Elasticsearch auto-generates one. Unchanged behaviour.
+- **`upsert`** — each record's `_id` is derived from its `key` columns and the
+  document is re-indexed (an idempotent overwrite). This **supersedes
+  `id_field`** — `key` is authoritative for the `_id` in this mode.
+- **`delete`** — each record's `key` columns derive an `_id` and a `delete`
+  action removes that document (no doc body is sent).
+
+Composite keys are joined with `:` — e.g. `key: [tenant, id]` over
+`{tenant: "acme", id: 7}` produces `_id` `"acme:7"`. Within a single batch,
+**duplicate keys collapse last-write-wins** before the bulk request is built.
+
+In `upsert` mode, `delete_marker` lets a single stream carry both writes and
+tombstones: rows whose `field` value matches one of `values` become `delete`
+actions; all other rows are upserted with the marker field stripped from the
+indexed document.
+
+```yaml
+pipeline:
+  sink:
+    kind: elasticsearch
+    config:
+      base_url: http://localhost:9200
+      index: products
+      write_mode: upsert
+      key: [product_id]
+      delete_marker:
+        field: __op
+        values: [d, delete]   # rows with __op in (d, delete) are removed by _id
+```
+
+Missing or null `key` values are per-row failures: `write_batch` aborts the
+page, and the DLQ-aware `write_batch_partial` path routes exactly those rows to
+the dead-letter queue while the rest are written.
 
 ### Builder Methods
 

--- a/crates/sink/elasticsearch/src/config.rs
+++ b/crates/sink/elasticsearch/src/config.rs
@@ -50,6 +50,16 @@ pub struct ElasticsearchSinkConfig {
     /// recommended setting for resumable pipelines); alternatively, configure a
     /// DLQ, whose per-row `write_batch_partial` path avoids the whole-page re-send.
     pub id_field: Option<String>,
+    /// Write semantics: `append` (default), `upsert`, or `delete`.
+    ///
+    /// In `upsert` / `delete` modes the document `_id` is derived from the
+    /// configured `key` columns (joined with `:` for composite keys) — this
+    /// **supersedes `id_field`**. An `upsert` issues a `_bulk` `index` action
+    /// (an idempotent overwrite by `_id`); a `delete` issues a `_bulk` `delete`
+    /// action by `_id`. Duplicate keys within a single batch collapse
+    /// last-write-wins.
+    #[serde(flatten)]
+    pub write: faucet_core::WriteSpec,
 }
 
 fn default_batch_size() -> usize {
@@ -65,6 +75,7 @@ impl ElasticsearchSinkConfig {
             auth: AuthSpec::Inline(ElasticsearchAuth::None),
             batch_size: DEFAULT_BATCH_SIZE,
             id_field: None,
+            write: faucet_core::WriteSpec::default(),
         }
     }
 

--- a/crates/sink/elasticsearch/src/sink.rs
+++ b/crates/sink/elasticsearch/src/sink.rs
@@ -40,6 +40,9 @@ impl ElasticsearchSink {
     /// `MAX_BATCH_SIZE` (#78/#44).
     pub fn new(config: ElasticsearchSinkConfig) -> Result<Self, FaucetError> {
         faucet_core::validate_batch_size(config.batch_size)?;
+        // Schemaless target: upsert/delete only need a non-empty `key` (no
+        // column-mapping guard like the SQL sinks).
+        config.write.validate()?;
         Ok(Self {
             config,
             client: Client::new(),
@@ -108,6 +111,18 @@ impl ElasticsearchSink {
         auth: &ElasticsearchAuth,
     ) -> Result<Value, FaucetError> {
         let body = self.build_bulk_body(chunk)?;
+        self.send_bulk_body(body, auth).await
+    }
+
+    /// Send a pre-built NDJSON `_bulk` body and return the parsed response.
+    ///
+    /// Shared by the append path ([`send_bulk_raw`](Self::send_bulk_raw)) and
+    /// the upsert/delete path ([`build_plan_body`](Self::build_plan_body)).
+    async fn send_bulk_body(
+        &self,
+        body: String,
+        auth: &ElasticsearchAuth,
+    ) -> Result<Value, FaucetError> {
         let url = format!("{}/_bulk", self.config.base_url);
         let req = self
             .client
@@ -121,7 +136,68 @@ impl ElasticsearchSink {
         Ok(resp_body)
     }
 
-    /// Build the NDJSON bulk request body for a slice of records.
+    /// Check a `_bulk` response body for item-level errors and return an outer
+    /// `Err` matching the append path's behaviour (#78/#32). `Ok(())` when the
+    /// bulk request reports no errors.
+    fn check_bulk_errors(resp_body: &Value) -> Result<(), FaucetError> {
+        if resp_body
+            .get("errors")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
+        {
+            let error_items = extract_bulk_error_messages(resp_body);
+            if let Some(first) = error_items.first() {
+                return Err(FaucetError::Sink(format!(
+                    "Elasticsearch bulk request had {} errors: {first}",
+                    error_items.len(),
+                )));
+            }
+            return Err(FaucetError::Sink(
+                "Elasticsearch bulk request reported errors:true but no per-item error \
+                 could be extracted from the response — treating as a hard failure to \
+                 avoid silently dropping records"
+                    .into(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Build the action-metadata map for a `_bulk` action line, seeded with the
+    /// configured `_index` and an optional explicit `_id`.
+    fn action_meta(&self, id: Option<String>) -> serde_json::Map<String, Value> {
+        let mut action_meta = serde_json::Map::new();
+        action_meta.insert(
+            "_index".to_string(),
+            Value::String(self.config.index.clone()),
+        );
+        if let Some(id) = id {
+            action_meta.insert("_id".to_string(), Value::String(id));
+        }
+        action_meta
+    }
+
+    /// Append an `{ "<action>": {...} }` line followed by an optional doc line
+    /// to the NDJSON `body`.
+    fn push_bulk_line(
+        body: &mut String,
+        action: &str,
+        meta: serde_json::Map<String, Value>,
+        doc: Option<&Value>,
+    ) -> Result<(), FaucetError> {
+        let action_line = serde_json::to_string(&serde_json::json!({ action: meta }))
+            .map_err(|e| FaucetError::Sink(format!("failed to serialize bulk action: {e}")))?;
+        body.push_str(&action_line);
+        body.push('\n');
+        if let Some(doc) = doc {
+            let doc_line = serde_json::to_string(doc)
+                .map_err(|e| FaucetError::Sink(format!("failed to serialize record: {e}")))?;
+            body.push_str(&doc_line);
+            body.push('\n');
+        }
+        Ok(())
+    }
+
+    /// Build the NDJSON bulk request body for a slice of records (append mode).
     ///
     /// Each record is preceded by an `{"index": {...}}` action line.
     /// If `id_field` is configured, the corresponding value from each record
@@ -130,36 +206,64 @@ impl ElasticsearchSink {
         let mut body = String::new();
 
         for record in records {
-            // Build the action metadata.
-            let mut action_meta = serde_json::Map::new();
-            action_meta.insert(
-                "_index".to_string(),
-                Value::String(self.config.index.clone()),
-            );
-
-            if let Some(ref id_field) = self.config.id_field
-                && let Some(id_val) = record.get(id_field)
-            {
-                let id_str = match id_val {
+            let id = self.config.id_field.as_ref().and_then(|id_field| {
+                record.get(id_field).map(|id_val| match id_val {
                     Value::String(s) => s.clone(),
                     other => other.to_string(),
-                };
-                action_meta.insert("_id".to_string(), Value::String(id_str));
-            }
-
-            let action_line = serde_json::to_string(&serde_json::json!({"index": action_meta}))
-                .map_err(|e| FaucetError::Sink(format!("failed to serialize bulk action: {e}")))?;
-            body.push_str(&action_line);
-            body.push('\n');
-
-            let record_line = serde_json::to_string(record)
-                .map_err(|e| FaucetError::Sink(format!("failed to serialize record: {e}")))?;
-            body.push_str(&record_line);
-            body.push('\n');
+                })
+            });
+            let meta = self.action_meta(id);
+            Self::push_bulk_line(&mut body, "index", meta, Some(record))?;
         }
 
         Ok(body)
     }
+
+    /// Build the NDJSON bulk body for an upsert/delete [`WritePlan`].
+    ///
+    /// Each `plan.upserts` row becomes an `{"index":{"_id":…}}` action (an
+    /// idempotent overwrite) whose `_id` is derived from the row's `key`
+    /// columns — this **overrides** any `id_field`. The row itself (already
+    /// marker-stripped by the planner) is the doc line.
+    ///
+    /// Each `plan.deletes` key tuple becomes a `{"delete":{"_id":…}}` action
+    /// with **no** doc line.
+    fn build_plan_body(&self, plan: &faucet_core::WritePlan) -> Result<String, FaucetError> {
+        let key = &self.config.write.key;
+        let mut body = String::new();
+
+        for row in &plan.upserts {
+            let id = doc_id_from_row(row, key);
+            let meta = self.action_meta(Some(id));
+            Self::push_bulk_line(&mut body, "index", meta, Some(row))?;
+        }
+        for kt in &plan.deletes {
+            let id = faucet_core::key_to_doc_id(kt, ":");
+            let meta = self.action_meta(Some(id));
+            Self::push_bulk_line(&mut body, "delete", meta, None)?;
+        }
+
+        Ok(body)
+    }
+}
+
+/// Build a document `_id` from an upsert row's `key` columns, in `key` order,
+/// using the same join (`:`) and rendering (string→as-is, else `to_string()`)
+/// as [`faucet_core::key_to_doc_id`].
+///
+/// Key columns are guaranteed present — [`faucet_core::plan_writes`] validated
+/// them before the row reached `plan.upserts`. A missing column would only
+/// occur on a planner contract violation, so it renders as an empty segment
+/// rather than panicking.
+fn doc_id_from_row(row: &Value, key: &[String]) -> String {
+    key.iter()
+        .map(|col| match row.get(col) {
+            Some(Value::String(s)) => s.clone(),
+            Some(other) => other.to_string(),
+            None => String::new(),
+        })
+        .collect::<Vec<_>>()
+        .join(":")
 }
 
 /// Extract per-item error messages from a `_bulk` response body.
@@ -199,6 +303,18 @@ impl faucet_core::Sink for ElasticsearchSink {
             faucet_core::redact_uri_credentials(&self.config.base_url),
             self.config.index
         )
+    }
+
+    /// Elasticsearch is schemaless and `_id`-addressable, so all three write
+    /// modes are supported: upsert and delete derive the document `_id` from
+    /// the configured `key`, and the `_bulk` `index` / `delete` actions are
+    /// idempotent overwrites / removals by `_id`.
+    fn supported_write_modes(&self) -> &'static [faucet_core::WriteMode] {
+        &[
+            faucet_core::WriteMode::Append,
+            faucet_core::WriteMode::Upsert,
+            faucet_core::WriteMode::Delete,
+        ]
     }
 
     /// Non-mutating preflight probe.
@@ -308,6 +424,34 @@ impl faucet_core::Sink for ElasticsearchSink {
 
         // Resolve auth once per write_batch call; reuse across chunks.
         let auth = self.resolve_auth().await?;
+
+        // Upsert / delete routing: plan the page (dedup last-write-wins, strip
+        // the delete marker) and emit `index` / `delete` bulk actions whose
+        // `_id` derives from `key`. Append falls through to the existing
+        // chunked `index` fast path below.
+        if !matches!(self.config.write.write_mode, faucet_core::WriteMode::Append) {
+            let plan = faucet_core::plan_writes(records, &self.config.write);
+            if let Some((idx, msg)) = plan.failed.first() {
+                return Err(FaucetError::Sink(format!(
+                    "elasticsearch {}: row {idx}: {msg}",
+                    self.config.write.write_mode.as_str()
+                )));
+            }
+            let body = self.build_plan_body(&plan)?;
+            let written = plan.upserts.len() + plan.deletes.len();
+            if written == 0 {
+                return Ok(0);
+            }
+            let resp_body = self.send_bulk_body(body, &auth).await?;
+            Self::check_bulk_errors(&resp_body)?;
+            tracing::debug!(
+                upserts = plan.upserts.len(),
+                deletes = plan.deletes.len(),
+                "Elasticsearch upsert/delete bulk written"
+            );
+            return Ok(written);
+        }
+
         let mut total_written = 0;
 
         let chunks: Vec<&[Value]> = if self.config.batch_size == 0 {
@@ -339,30 +483,10 @@ impl faucet_core::Sink for ElasticsearchSink {
         for chunk in chunks {
             let resp_body = self.send_bulk_raw(chunk, &auth).await?;
 
-            // Check for item-level errors in the bulk response.
-            if resp_body
-                .get("errors")
-                .and_then(|v| v.as_bool())
-                .unwrap_or(false)
-            {
-                let error_items = extract_bulk_error_messages(&resp_body);
-                if let Some(first) = error_items.first() {
-                    return Err(FaucetError::Sink(format!(
-                        "Elasticsearch bulk request had {} errors: {first}",
-                        error_items.len(),
-                    )));
-                }
-                // `errors: true` but no per-item error could be extracted (an
-                // items shape the parser doesn't recognise). Treat as a hard
-                // failure rather than counting the chunk as written — otherwise
-                // failed rows are silently dropped (#78/#32).
-                return Err(FaucetError::Sink(
-                    "Elasticsearch bulk request reported errors:true but no per-item error \
-                     could be extracted from the response — treating as a hard failure to \
-                     avoid silently dropping records"
-                        .into(),
-                ));
-            }
+            // Check for item-level errors in the bulk response. `errors: true`
+            // with no extractable per-item error is treated as a hard failure
+            // rather than silently dropping the chunk (#78/#32).
+            Self::check_bulk_errors(&resp_body)?;
 
             total_written += chunk.len();
             tracing::debug!(records = chunk.len(), "Elasticsearch bulk batch written");
@@ -399,6 +523,35 @@ impl faucet_core::Sink for ElasticsearchSink {
 
         // Resolve auth once per write_batch_partial call; reuse across chunks.
         let auth = self.resolve_auth().await?;
+
+        // Upsert / delete routing. Per-row DLQ in these modes covers the
+        // missing/null-key case: `plan_writes` reports those rows in
+        // `plan.failed` with their original page index, and we mark exactly
+        // those indices `Err`. The deduped index/delete bulk is then sent in
+        // one call. Because the planner dedups by key (last-write-wins), an
+        // item-level bulk error can't be mapped back to a specific original
+        // record index, so per-item rejections aren't routed per-row here — a
+        // transport/bulk failure surfaces as an outer batch `Err` instead. This
+        // is the realistic DLQ case for upsert/delete (the missing-key route).
+        if !matches!(self.config.write.write_mode, faucet_core::WriteMode::Append) {
+            let plan = faucet_core::plan_writes(records, &self.config.write);
+            let mut outcomes: Vec<faucet_core::RowOutcome> =
+                (0..records.len()).map(|_| Ok(())).collect();
+            for (idx, msg) in &plan.failed {
+                outcomes[*idx] = Err(FaucetError::Sink(format!(
+                    "elasticsearch {}: row {idx}: {msg}",
+                    self.config.write.write_mode.as_str()
+                )));
+            }
+            if !plan.upserts.is_empty() || !plan.deletes.is_empty() {
+                let body = self.build_plan_body(&plan)?;
+                // A transport/HTTP failure aborts the batch (outer Err); the
+                // non-failed indices otherwise stay Ok.
+                let resp_body = self.send_bulk_body(body, &auth).await?;
+                Self::check_bulk_errors(&resp_body)?;
+            }
+            return Ok(outcomes);
+        }
 
         let chunks: Vec<&[Value]> = if self.config.batch_size == 0 {
             vec![records]
@@ -567,5 +720,71 @@ mod tests {
         // Third record: no id field, so no _id in action.
         let action2: Value = serde_json::from_str(lines[4]).unwrap();
         assert!(action2["index"].get("_id").is_none());
+    }
+
+    #[test]
+    fn doc_id_joins_composite_key() {
+        let kt = faucet_core::KeyTuple(vec![
+            ("tenant".to_string(), serde_json::json!("acme")),
+            ("id".to_string(), serde_json::json!(7)),
+        ]);
+        assert_eq!(faucet_core::key_to_doc_id(&kt, ":"), "acme:7");
+    }
+
+    #[test]
+    fn doc_id_from_row_joins_key_columns_in_order() {
+        // Composite key: string rendered as-is, number via to_string(), joined
+        // with ":" in `key` declaration order.
+        let row = json!({"id": 7, "tenant": "acme", "v": "x"});
+        let key = vec!["tenant".to_string(), "id".to_string()];
+        assert_eq!(doc_id_from_row(&row, &key), "acme:7");
+
+        // Single string key column → rendered as-is.
+        let row = json!({"id": "abc-123"});
+        assert_eq!(doc_id_from_row(&row, &["id".to_string()]), "abc-123");
+    }
+
+    #[test]
+    fn plan_body_upsert_uses_key_id_and_strips_marker() {
+        use faucet_core::{DeleteMarker, WriteMode, WriteSpec};
+
+        let config = ElasticsearchSinkConfig {
+            id_field: Some("ignored".to_string()),
+            write: WriteSpec {
+                write_mode: WriteMode::Upsert,
+                key: vec!["id".to_string()],
+                delete_marker: Some(DeleteMarker {
+                    field: "__op".to_string(),
+                    values: vec!["d".to_string()],
+                }),
+            },
+            ..ElasticsearchSinkConfig::new("http://localhost:9200", "idx")
+        };
+        let sink = ElasticsearchSink::new(config).unwrap();
+
+        let records = vec![
+            json!({"id": 1, "v": "a"}),
+            json!({"id": 2, "v": "x", "__op": "d"}),
+        ];
+        let plan = faucet_core::plan_writes(&records, &sink.config.write);
+        let body = sink.build_plan_body(&plan).unwrap();
+        let lines: Vec<&str> = body.trim().split('\n').collect();
+
+        // 1 upsert (action + doc) + 1 delete (action only) = 3 lines.
+        assert_eq!(lines.len(), 3, "{lines:?}");
+
+        // Upsert action: `_id` derived from the key (overrides id_field).
+        let action0: Value = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(action0["index"]["_id"], "1");
+        assert_eq!(action0["index"]["_index"], "idx");
+        // Doc line: the marker field is stripped.
+        let doc0: Value = serde_json::from_str(lines[1]).unwrap();
+        assert_eq!(doc0["v"], "a");
+        assert!(doc0.get("__op").is_none());
+
+        // Delete action: key-derived `_id`, NO doc line follows.
+        let action1: Value = serde_json::from_str(lines[2]).unwrap();
+        assert_eq!(action1["delete"]["_id"], "2");
+        assert_eq!(action1["delete"]["_index"], "idx");
     }
 }

--- a/crates/sink/elasticsearch/src/sink.rs
+++ b/crates/sink/elasticsearch/src/sink.rs
@@ -219,7 +219,7 @@ impl ElasticsearchSink {
         Ok(body)
     }
 
-    /// Build the NDJSON bulk body for an upsert/delete [`WritePlan`].
+    /// Build the NDJSON bulk body for an upsert/delete [`WritePlan`](faucet_core::WritePlan).
     ///
     /// Each `plan.upserts` row becomes an `{"index":{"_id":…}}` action (an
     /// idempotent overwrite) whose `_id` is derived from the row's `key`

--- a/crates/sink/elasticsearch/tests/upsert.rs
+++ b/crates/sink/elasticsearch/tests/upsert.rs
@@ -123,7 +123,10 @@ async fn delete_mode_emits_delete_action_by_key() {
     };
     let sink = ElasticsearchSink::new(config).unwrap();
 
-    let written = sink.write_batch(&[json!({"id": 5, "v": "x"})]).await.unwrap();
+    let written = sink
+        .write_batch(&[json!({"id": 5, "v": "x"})])
+        .await
+        .unwrap();
     assert_eq!(written, 1);
 
     let requests = server.received_requests().await.unwrap();
@@ -182,7 +185,10 @@ async fn duplicate_keys_collapse_last_write_wins() {
 
     // Two records for id=1; last write wins.
     let written = sink
-        .write_batch(&[json!({"id": 1, "v": "first"}), json!({"id": 1, "v": "second"})])
+        .write_batch(&[
+            json!({"id": 1, "v": "first"}),
+            json!({"id": 1, "v": "second"}),
+        ])
         .await
         .unwrap();
     // Deduped to one document.

--- a/crates/sink/elasticsearch/tests/upsert.rs
+++ b/crates/sink/elasticsearch/tests/upsert.rs
@@ -1,0 +1,226 @@
+//! Integration tests for `write_mode: upsert` / `delete` on the Elasticsearch
+//! sink.
+//!
+//! Each test stands up a wiremock server, captures the `_bulk` NDJSON the sink
+//! emits, and asserts on the action lines (key-derived `_id`s) and doc lines.
+
+use faucet_core::{DeleteMarker, Sink, WriteMode, WriteSpec};
+use faucet_sink_elasticsearch::{ElasticsearchSink, ElasticsearchSinkConfig};
+use serde_json::{Value, json};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, Request, ResponseTemplate};
+
+/// Parse a captured NDJSON `_bulk` body into a Vec of JSON lines.
+fn ndjson_lines(body: &[u8]) -> Vec<Value> {
+    std::str::from_utf8(body)
+        .unwrap()
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str(l).unwrap())
+        .collect()
+}
+
+/// Build a `_bulk` response with N successful `result` items (errors:false).
+fn ok_bulk_response(n: usize) -> Value {
+    let items: Vec<Value> = (0..n).map(|_| json!({"index": {"status": 200}})).collect();
+    json!({"errors": false, "items": items})
+}
+
+#[tokio::test]
+async fn upsert_emits_index_action_with_key_id_and_no_marker() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/_bulk"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(ok_bulk_response(1)))
+        .mount(&server)
+        .await;
+
+    let config = ElasticsearchSinkConfig {
+        write: WriteSpec {
+            write_mode: WriteMode::Upsert,
+            key: vec!["id".to_string()],
+            delete_marker: Some(DeleteMarker {
+                field: "__op".to_string(),
+                values: vec!["d".to_string()],
+            }),
+        },
+        ..ElasticsearchSinkConfig::new(server.uri(), "idx")
+    };
+    let sink = ElasticsearchSink::new(config).unwrap();
+
+    let written = sink
+        .write_batch(&[json!({"id": 1, "v": "a", "__op": "u"})])
+        .await
+        .unwrap();
+    assert_eq!(written, 1);
+
+    let requests: Vec<Request> = server.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1);
+    let lines = ndjson_lines(&requests[0].body);
+    assert_eq!(lines.len(), 2, "index action + doc line: {lines:?}");
+
+    // Action line: `index` with key-derived `_id`.
+    assert_eq!(lines[0]["index"]["_id"], "1");
+    assert_eq!(lines[0]["index"]["_index"], "idx");
+    // Doc line: marker field stripped.
+    assert_eq!(lines[1]["v"], "a");
+    assert!(lines[1].get("__op").is_none());
+}
+
+#[tokio::test]
+async fn delete_marker_emits_delete_action_with_no_doc_line() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/_bulk"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(ok_bulk_response(1)))
+        .mount(&server)
+        .await;
+
+    let config = ElasticsearchSinkConfig {
+        write: WriteSpec {
+            write_mode: WriteMode::Upsert,
+            key: vec!["id".to_string()],
+            delete_marker: Some(DeleteMarker {
+                field: "__op".to_string(),
+                values: vec!["d".to_string()],
+            }),
+        },
+        ..ElasticsearchSinkConfig::new(server.uri(), "idx")
+    };
+    let sink = ElasticsearchSink::new(config).unwrap();
+
+    let written = sink
+        .write_batch(&[json!({"id": 9, "__op": "d"})])
+        .await
+        .unwrap();
+    assert_eq!(written, 1);
+
+    let requests = server.received_requests().await.unwrap();
+    let lines = ndjson_lines(&requests[0].body);
+    // A delete is a single action line with NO doc line.
+    assert_eq!(lines.len(), 1, "delete action only: {lines:?}");
+    assert_eq!(lines[0]["delete"]["_id"], "9");
+    assert_eq!(lines[0]["delete"]["_index"], "idx");
+    assert!(lines[0].get("index").is_none());
+}
+
+#[tokio::test]
+async fn delete_mode_emits_delete_action_by_key() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/_bulk"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(ok_bulk_response(1)))
+        .mount(&server)
+        .await;
+
+    let config = ElasticsearchSinkConfig {
+        write: WriteSpec {
+            write_mode: WriteMode::Delete,
+            key: vec!["id".to_string()],
+            delete_marker: None,
+        },
+        ..ElasticsearchSinkConfig::new(server.uri(), "idx")
+    };
+    let sink = ElasticsearchSink::new(config).unwrap();
+
+    let written = sink.write_batch(&[json!({"id": 5, "v": "x"})]).await.unwrap();
+    assert_eq!(written, 1);
+
+    let requests = server.received_requests().await.unwrap();
+    let lines = ndjson_lines(&requests[0].body);
+    assert_eq!(lines.len(), 1, "delete action only: {lines:?}");
+    assert_eq!(lines[0]["delete"]["_id"], "5");
+}
+
+#[tokio::test]
+async fn composite_key_id_joined_with_colon() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/_bulk"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(ok_bulk_response(1)))
+        .mount(&server)
+        .await;
+
+    let config = ElasticsearchSinkConfig {
+        write: WriteSpec {
+            write_mode: WriteMode::Upsert,
+            key: vec!["tenant".to_string(), "id".to_string()],
+            delete_marker: None,
+        },
+        ..ElasticsearchSinkConfig::new(server.uri(), "idx")
+    };
+    let sink = ElasticsearchSink::new(config).unwrap();
+
+    sink.write_batch(&[json!({"tenant": "acme", "id": 7, "v": "z"})])
+        .await
+        .unwrap();
+
+    let requests = server.received_requests().await.unwrap();
+    let lines = ndjson_lines(&requests[0].body);
+    assert_eq!(lines[0]["index"]["_id"], "acme:7");
+}
+
+#[tokio::test]
+async fn duplicate_keys_collapse_last_write_wins() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/_bulk"))
+        // The deduped page has a single upsert.
+        .respond_with(ResponseTemplate::new(200).set_body_json(ok_bulk_response(1)))
+        .mount(&server)
+        .await;
+
+    let config = ElasticsearchSinkConfig {
+        write: WriteSpec {
+            write_mode: WriteMode::Upsert,
+            key: vec!["id".to_string()],
+            delete_marker: None,
+        },
+        ..ElasticsearchSinkConfig::new(server.uri(), "idx")
+    };
+    let sink = ElasticsearchSink::new(config).unwrap();
+
+    // Two records for id=1; last write wins.
+    let written = sink
+        .write_batch(&[json!({"id": 1, "v": "first"}), json!({"id": 1, "v": "second"})])
+        .await
+        .unwrap();
+    // Deduped to one document.
+    assert_eq!(written, 1);
+
+    let requests = server.received_requests().await.unwrap();
+    let lines = ndjson_lines(&requests[0].body);
+    assert_eq!(lines.len(), 2, "one index action + one doc: {lines:?}");
+    assert_eq!(lines[0]["index"]["_id"], "1");
+    assert_eq!(lines[1]["v"], "second");
+}
+
+#[tokio::test]
+async fn write_batch_partial_routes_missing_key_to_failed() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/_bulk"))
+        // Only the one valid upsert reaches the bulk request.
+        .respond_with(ResponseTemplate::new(200).set_body_json(ok_bulk_response(1)))
+        .mount(&server)
+        .await;
+
+    let config = ElasticsearchSinkConfig {
+        write: WriteSpec {
+            write_mode: WriteMode::Upsert,
+            key: vec!["id".to_string()],
+            delete_marker: None,
+        },
+        ..ElasticsearchSinkConfig::new(server.uri(), "idx")
+    };
+    let sink = ElasticsearchSink::new(config).unwrap();
+
+    // Row 0 is valid; row 1 is missing the key column → routed to `failed`.
+    let outcomes = sink
+        .write_batch_partial(&[json!({"id": 1, "v": "a"}), json!({"v": "no-key"})])
+        .await
+        .unwrap();
+    assert_eq!(outcomes.len(), 2);
+    assert!(outcomes[0].is_ok());
+    assert!(outcomes[1].is_err());
+}

--- a/crates/sink/iceberg/src/config.rs
+++ b/crates/sink/iceberg/src/config.rs
@@ -217,7 +217,7 @@ impl Default for ParquetOpts {
 /// Only `write_mode: append` is supported at runtime. The `write_mode` field
 /// accepts the shared [`faucet_core::WriteMode`] enum, so `upsert` and
 /// `delete` deserialise without error but are rejected by
-/// [`IcebergSink::new`] with a `FaucetError::Config`. Configuring
+/// [`IcebergSink::new`](crate::sink::IcebergSink::new) with a `FaucetError::Config`. Configuring
 /// `write_mode: overwrite` still produces a deserialization error (it is not
 /// a recognised variant). Equality-delete upsert is tracked in #179.
 ///
@@ -252,7 +252,7 @@ pub struct IcebergSinkConfig {
 
     /// Write semantics. Uses the shared [`faucet_core::WriteMode`] enum
     /// (`append` | `upsert` | `delete`). Only `append` is supported at
-    /// runtime; non-append modes are rejected by [`IcebergSink::new`] with a
+    /// runtime; non-append modes are rejected by [`IcebergSink::new`](crate::sink::IcebergSink::new) with a
     /// `FaucetError::Config`. Upsert via equality-delete is tracked in #179.
     #[serde(default)]
     pub write_mode: WriteMode,

--- a/crates/sink/iceberg/src/config.rs
+++ b/crates/sink/iceberg/src/config.rs
@@ -2,14 +2,18 @@
 //!
 //! ## Write mode
 //!
-//! Only `append` is supported in v1. Overwrite support is tracked in
+//! The `write_mode` field accepts the shared [`faucet_core::WriteMode`] enum
+//! (`append` | `upsert` | `delete`). Only `append` is supported at runtime in
+//! v1; `upsert` and `delete` deserialise successfully but are rejected by
+//! [`IcebergSink::new`](crate::sink::IcebergSink::new) with a typed
+//! `FaucetError::Config`. Equality-delete upsert is tracked in
 //! [#179](https://github.com/PawanSikawat/faucet-stream/issues/179) and is
 //! blocked on upstream iceberg-rust adding a replace/overwrite transaction action.
 
 use std::collections::HashMap;
 use std::fmt;
 
-use faucet_core::FaucetError;
+use faucet_core::{FaucetError, WriteMode};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -177,22 +181,6 @@ pub struct PartitionField {
     pub transform: String,
 }
 
-// ── Write mode ────────────────────────────────────────────────────────────────
-
-/// Write semantics for the Iceberg sink.
-///
-/// Only `append` is available in v1. Overwrite is tracked in
-/// [#179](https://github.com/PawanSikawat/faucet-stream/issues/179) and is
-/// blocked on upstream iceberg-rust adding an overwrite/replace transaction
-/// action (not present in 0.9.1).
-#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum WriteMode {
-    /// Append records as a new snapshot. Existing data is never modified.
-    #[default]
-    Append,
-}
-
 // ── Parquet options ───────────────────────────────────────────────────────────
 
 /// Parquet-level compression and encoding options.
@@ -226,9 +214,12 @@ impl Default for ParquetOpts {
 ///
 /// ## Append-only (v1)
 ///
-/// Only `write_mode: append` is supported. Overwrite is tracked in #179 and
-/// is blocked on upstream iceberg-rust. Configuring `write_mode: overwrite`
-/// will produce a deserialization error.
+/// Only `write_mode: append` is supported at runtime. The `write_mode` field
+/// accepts the shared [`faucet_core::WriteMode`] enum, so `upsert` and
+/// `delete` deserialise without error but are rejected by
+/// [`IcebergSink::new`] with a `FaucetError::Config`. Configuring
+/// `write_mode: overwrite` still produces a deserialization error (it is not
+/// a recognised variant). Equality-delete upsert is tracked in #179.
 ///
 /// ## Catalog feature gates
 ///
@@ -259,8 +250,10 @@ pub struct IcebergSinkConfig {
     #[serde(default)]
     pub partition_spec: Vec<PartitionField>,
 
-    /// Write semantics. Only `append` is supported in v1; see crate-level docs
-    /// for the overwrite roadmap item (#179).
+    /// Write semantics. Uses the shared [`faucet_core::WriteMode`] enum
+    /// (`append` | `upsert` | `delete`). Only `append` is supported at
+    /// runtime; non-append modes are rejected by [`IcebergSink::new`] with a
+    /// `FaucetError::Config`. Upsert via equality-delete is tracked in #179.
     #[serde(default)]
     pub write_mode: WriteMode,
 
@@ -715,6 +708,23 @@ mod tests {
         }));
         cfg.validate()
             .expect("REST should accept any warehouse scheme");
+    }
+
+    // ── write_mode core-enum ──────────────────────────────────────────────────
+
+    #[test]
+    fn iceberg_config_parses_upsert_against_core_enum() {
+        // Once the local WriteMode is replaced by faucet_core::WriteMode,
+        // "upsert" must deserialise (the local enum only had Append, so this
+        // would fail with "unknown variant 'upsert'" before the change).
+        let cfg: IcebergSinkConfig = serde_json::from_value(serde_json::json!({
+            "catalog": { "type": "rest", "uri": "http://localhost:8181" },
+            "namespace": ["analytics"],
+            "table": "events",
+            "write_mode": "upsert"
+        }))
+        .expect("upsert parses against the core enum");
+        assert_eq!(cfg.write_mode, faucet_core::WriteMode::Upsert);
     }
 
     // ── batch_size bounds ─────────────────────────────────────────────────────

--- a/crates/sink/iceberg/src/lib.rs
+++ b/crates/sink/iceberg/src/lib.rs
@@ -12,5 +12,6 @@ pub mod sink;
 pub(crate) mod storage_factory;
 pub(crate) mod writer;
 
-pub use config::{CatalogConfig, IcebergSinkConfig, ParquetOpts, PartitionField, WriteMode};
+pub use config::{CatalogConfig, IcebergSinkConfig, ParquetOpts, PartitionField};
+pub use faucet_core::WriteMode;
 pub use sink::IcebergSink;

--- a/crates/sink/iceberg/src/sink.rs
+++ b/crates/sink/iceberg/src/sink.rs
@@ -113,6 +113,14 @@ impl IcebergSink {
     pub async fn new(config: IcebergSinkConfig) -> Result<Self, FaucetError> {
         config.validate()?;
 
+        if config.write_mode != faucet_core::WriteMode::Append {
+            return Err(FaucetError::Config(format!(
+                "iceberg sink: write_mode '{}' is not supported (append only; \
+                 upsert is a version-gated follow-up tracked in #179 / #190)",
+                config.write_mode.as_str()
+            )));
+        }
+
         let catalog = build_catalog(&config.catalog).await?;
 
         let preloaded: Option<Table> = if !config.create_if_missing {
@@ -488,6 +496,12 @@ impl faucet_core::Sink for IcebergSink {
         };
 
         Ok(CheckReport::single(probe))
+    }
+
+    fn supported_write_modes(&self) -> &'static [faucet_core::WriteMode] {
+        // Append only — equality-delete upsert is version-gated on iceberg-rust
+        // (tracked as a follow-up to #190 / #179).
+        &[faucet_core::WriteMode::Append]
     }
 
     fn supports_idempotent_writes(&self) -> bool {

--- a/crates/sink/mongodb/Cargo.toml
+++ b/crates/sink/mongodb/Cargo.toml
@@ -18,6 +18,7 @@ serde_json.workspace = true
 async-trait.workspace = true
 tracing.workspace = true
 mongodb = { workspace = true }
+futures = { workspace = true }
 tokio = { workspace = true, features = ["time"] }
 
 [dev-dependencies]

--- a/crates/sink/mongodb/README.md
+++ b/crates/sink/mongodb/README.md
@@ -60,6 +60,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 | `collection` | `String` | *(required)* | Collection name |
 | `batch_size` | `usize` | `1000` | Maximum number of documents per `insert_many` call. See [Streaming and batching](#streaming-and-batching) below |
 | `ordered` | `bool` | `false` | Whether `insert_many` is ordered. Default `false` (unordered) so one bad document — duplicate `_id`, validation error — doesn't drop the rest of the batch. Set `true` only if you require strict insertion order and want the batch to abort at the first failure. |
+| `write_mode` | `string` | `append` | `append`, `upsert`, or `delete`. See [Write modes (upsert / delete)](#write-modes-upsert--delete) below |
+| `key` | `[string]` | `[]` | Match-filter fields for `upsert` / `delete`. **Required and non-empty** for those modes; ignored for `append`. Typically `["_id"]` |
+| `delete_marker` | `object` | *(none)* | Upsert only. `{ field, values }` — rows whose `field` matches one of `values` are routed to deletes instead of upserts. The marker field is stripped from upsert rows before writing |
 
 The `Debug` implementation masks the `connection_uri` with `***` to prevent credential leakage in logs.
 
@@ -86,6 +89,56 @@ to the sink. It is unrelated to the MongoDB driver's internal
 `cursor_batch_size` (the wire-level read-side cursor tuning knob used by
 `faucet-source-mongodb`) — the two concerns don't share a value because
 `insert_many` and a query cursor are different operations.
+
+### Write modes (upsert / delete)
+
+By default the sink runs in `append` mode and inserts every record via
+`insert_many`. Set `write_mode: upsert` or `write_mode: delete` to keep a
+collection in sync with a changing source instead of only appending.
+
+MongoDB is schemaless, so unlike the SQL sinks there are no key *columns* —
+the `key` fields become the **match filter** for each document. `key` is
+typically `["_id"]`, but any combination of top-level fields works
+(composite keys are matched on all of them). `key` must be non-empty for
+`upsert` / `delete`; an empty `key` is rejected at config-load time.
+
+- **`upsert`** — each row is committed with a per-document
+  `replace_one(filter, replacement).upsert(true)`. The filter is built from
+  the row's `key` fields and the whole row is the replacement document, so an
+  existing document is **replaced in place** (not field-merged) and a missing
+  one is inserted.
+- **`delete`** — each row is removed with `delete_one(filter)`, where the
+  filter is built from the row's `key` fields.
+- **`delete_marker`** (upsert only) — mix upserts and deletes in one stream:
+  rows whose `delete_marker.field` matches one of `delete_marker.values` are
+  routed to `delete_one`; all others are upserted. The marker field is
+  stripped from the upsert replacement document so it never lands in the
+  collection — handy for CDC streams that carry an operation flag like
+  `__op: "u" | "d"`.
+
+Within a single batch, repeated keys are deduped **last-write-wins** before
+any write is issued, so a page that touches the same `_id` twice results in a
+single `replace_one` / `delete_one` carrying the final value.
+
+Each `replace_one` / `delete_one` is a per-document primitive (not the
+namespaced `Client::bulk_write`) for compatibility with all supported MongoDB
+server versions; the sink recovers throughput by issuing the deduped ops
+concurrently.
+
+```yaml
+sink:
+  type: mongodb
+  config:
+    connection_uri: mongodb://localhost:27017
+    database: analytics
+    collection: users
+    write_mode: upsert
+    key: ["_id"]
+    # Optional: route delete-flagged rows (e.g. from a CDC source) to deletes.
+    delete_marker:
+      field: __op
+      values: ["d", "delete"]
+```
 
 ### Builder Methods
 

--- a/crates/sink/mongodb/README.md
+++ b/crates/sink/mongodb/README.md
@@ -120,6 +120,10 @@ Within a single batch, repeated keys are deduped **last-write-wins** before
 any write is issued, so a page that touches the same `_id` twice results in a
 single `replace_one` / `delete_one` carrying the final value.
 
+A document missing or null in a key field fails. When a `dlq:` block is
+configured the good documents are still written and only the missing/null-key
+documents are routed to the DLQ per-row; without a DLQ the whole batch fails.
+
 Each `replace_one` / `delete_one` is a per-document primitive (not the
 namespaced `Client::bulk_write`) for compatibility with all supported MongoDB
 server versions; the sink recovers throughput by issuing the deduped ops

--- a/crates/sink/mongodb/src/config.rs
+++ b/crates/sink/mongodb/src/config.rs
@@ -49,6 +49,15 @@ pub struct MongoSinkConfig {
     /// rest of the batch (#78/#20).
     #[serde(default)]
     pub ordered: bool,
+    /// Write mode, key columns, and optional delete marker.
+    ///
+    /// `write_mode` defaults to `append` (the `insert_many` fast path). For
+    /// `upsert` / `delete`, `key` must be non-empty — MongoDB being schemaless,
+    /// the key columns become the **match filter** (typically `["_id"]`), not
+    /// table columns. Each upsert is committed with a per-document
+    /// `replace_one(upsert = true)`; each delete with a `delete_one`.
+    #[serde(flatten)]
+    pub write: faucet_core::WriteSpec,
 }
 
 fn default_batch_size() -> usize {
@@ -68,6 +77,7 @@ impl MongoSinkConfig {
             collection: collection.into(),
             batch_size: DEFAULT_BATCH_SIZE,
             ordered: false,
+            write: faucet_core::WriteSpec::default(),
         }
     }
 
@@ -96,6 +106,7 @@ impl fmt::Debug for MongoSinkConfig {
             .field("collection", &self.collection)
             .field("batch_size", &self.batch_size)
             .field("ordered", &self.ordered)
+            .field("write", &self.write)
             .finish()
     }
 }

--- a/crates/sink/mongodb/src/sink.rs
+++ b/crates/sink/mongodb/src/sink.rs
@@ -282,6 +282,36 @@ impl faucet_core::Sink for MongoSink {
 
         Ok(total_written)
     }
+
+    /// Write a batch and report per-row outcomes.
+    ///
+    /// In append mode this delegates to [`write_batch`](Self::write_batch) and
+    /// maps a single success onto an all-`Ok(())` vector (the trait default).
+    /// In upsert/delete mode the good rows are applied (upserts + deletes), and
+    /// only the rows whose key could not be extracted (missing / null key) are
+    /// reported as `Err` so the pipeline routes them to the DLQ per-row instead
+    /// of sending the whole page.
+    async fn write_batch_partial(
+        &self,
+        records: &[Value],
+    ) -> Result<Vec<faucet_core::RowOutcome>, FaucetError> {
+        if matches!(self.config.write.write_mode, faucet_core::WriteMode::Append) {
+            self.write_batch(records).await?;
+            return Ok(records.iter().map(|_| Ok(())).collect());
+        }
+
+        let plan = faucet_core::plan_writes(records, &self.config.write);
+        self.apply_plan(&plan).await?;
+
+        let mut outcomes: Vec<faucet_core::RowOutcome> = records.iter().map(|_| Ok(())).collect();
+        for (idx, msg) in &plan.failed {
+            outcomes[*idx] = Err(FaucetError::Sink(format!(
+                "mongodb {}: {msg}",
+                self.config.write.write_mode.as_str()
+            )));
+        }
+        Ok(outcomes)
+    }
 }
 
 #[cfg(test)]

--- a/crates/sink/mongodb/src/sink.rs
+++ b/crates/sink/mongodb/src/sink.rs
@@ -3,9 +3,25 @@
 use crate::config::MongoSinkConfig;
 use async_trait::async_trait;
 use faucet_core::FaucetError;
+use futures::StreamExt;
 use mongodb::Client;
 use mongodb::bson::{self, Bson, Document};
-use serde_json::Value;
+use serde_json::{Map, Value};
+
+/// Max in-flight `replace_one` / `delete_one` operations issued concurrently
+/// from a single planned page. The planner has already deduped by key, so
+/// every concurrent op targets a distinct key — there is no intra-batch
+/// ordering hazard. A modest bound keeps round-trips overlapping without
+/// flooding the connection pool.
+const APPLY_CONCURRENCY: usize = 50;
+
+/// Convert a JSON object map (a key filter from
+/// [`faucet_core::key_to_filter`]) into a BSON filter [`Document`].
+///
+/// Returns a `Sink` error if the map does not convert to a BSON document.
+fn json_map_to_bson_filter(map: &Map<String, Value>) -> Result<Document, FaucetError> {
+    MongoSink::value_to_document(&Value::Object(map.clone()))
+}
 
 /// A sink that inserts JSON records into a MongoDB collection.
 ///
@@ -20,11 +36,119 @@ impl MongoSink {
     /// Create a new MongoDB sink, establishing the client connection.
     pub async fn new(config: MongoSinkConfig) -> Result<Self, FaucetError> {
         faucet_core::validate_batch_size(config.batch_size)?;
+        // Validate write-mode config up front (config-only, so before connecting
+        // is fine): upsert/delete require a non-empty `key`. MongoDB is
+        // schemaless, so there is no column-mapping guard to apply.
+        config.write.validate()?;
         let client = Client::with_uri_str(&config.connection_uri)
             .await
             .map_err(|e| FaucetError::Config(format!("MongoDB connection failed: {e}")))?;
 
         Ok(Self { config, client })
+    }
+
+    /// Build the match-filter [`Document`] for an upsert row by pulling the
+    /// configured `key` columns out of the row. The planner
+    /// ([`faucet_core::plan_writes`]) has already validated that every key
+    /// column is present and non-null on each upsert row, so a missing column
+    /// here is an internal invariant violation rather than user data error.
+    fn filter_from_row(row: &Value, key: &[String]) -> Result<Document, FaucetError> {
+        let obj = row.as_object().ok_or_else(|| {
+            FaucetError::Sink("upsert row is not a JSON object".to_string())
+        })?;
+        let mut filter = Map::with_capacity(key.len());
+        for col in key {
+            match obj.get(col) {
+                Some(v) => {
+                    filter.insert(col.clone(), v.clone());
+                }
+                None => {
+                    return Err(FaucetError::Sink(format!(
+                        "upsert row missing key column '{col}' after planning"
+                    )));
+                }
+            }
+        }
+        json_map_to_bson_filter(&filter)
+    }
+
+    /// Apply a planned page of upserts and deletes to the collection.
+    ///
+    /// Each upsert row is committed with `replace_one(filter, replacement)
+    /// .upsert(true)` and each delete with `delete_one(filter)`. We use the
+    /// per-document `replace_one(upsert)` / `delete_one` primitives (not the
+    /// namespaced `Client::bulk_write`) for compatibility with all supported
+    /// MongoDB server versions; throughput is recovered by issuing the ops
+    /// concurrently via `buffer_unordered`. The planner already deduped keys
+    /// (last-write-wins), so concurrent ops target distinct keys and there is
+    /// no intra-batch ordering hazard.
+    ///
+    /// Returns the number of upserts + deletes applied.
+    async fn apply_plan(&self, plan: &faucet_core::WritePlan) -> Result<usize, FaucetError> {
+        let collection = self
+            .client
+            .database(&self.config.database)
+            .collection::<Document>(&self.config.collection);
+        let key = &self.config.write.key;
+
+        // Build a single homogeneous op stream of (filter, replacement?) so
+        // upserts and deletes run through one bounded `buffer_unordered`.
+        enum Op {
+            Upsert(Document, Document),
+            Delete(Document),
+        }
+
+        let mut ops: Vec<Op> = Vec::with_capacity(plan.upserts.len() + plan.deletes.len());
+        for row in &plan.upserts {
+            let filter = Self::filter_from_row(row, key)?;
+            let replacement = Self::value_to_document(row)?;
+            ops.push(Op::Upsert(filter, replacement));
+        }
+        for kt in &plan.deletes {
+            let filter = json_map_to_bson_filter(&faucet_core::key_to_filter(kt))?;
+            ops.push(Op::Delete(filter));
+        }
+
+        let applied = ops.len();
+
+        futures::stream::iter(ops.into_iter().map(|op| {
+            let collection = collection.clone();
+            async move {
+                match op {
+                    Op::Upsert(filter, replacement) => collection
+                        .replace_one(filter, replacement)
+                        .upsert(true)
+                        .await
+                        .map(|_| ())
+                        .map_err(|e| {
+                            FaucetError::Sink(format!("MongoDB replace_one (upsert) failed: {e}"))
+                        }),
+                    Op::Delete(filter) => collection
+                        .delete_one(filter)
+                        .await
+                        .map(|_| ())
+                        .map_err(|e| {
+                            FaucetError::Sink(format!("MongoDB delete_one failed: {e}"))
+                        }),
+                }
+            }
+        }))
+        .buffer_unordered(APPLY_CONCURRENCY)
+        .collect::<Vec<Result<(), FaucetError>>>()
+        .await
+        .into_iter()
+        .collect::<Result<Vec<()>, FaucetError>>()?;
+
+        tracing::info!(
+            applied,
+            upserts = plan.upserts.len(),
+            deletes = plan.deletes.len(),
+            database = %self.config.database,
+            collection = %self.config.collection,
+            "MongoDB upsert/delete write complete"
+        );
+
+        Ok(applied)
     }
 
     /// Convert a `serde_json::Value` to a `bson::Document`.
@@ -47,6 +171,14 @@ impl faucet_core::Sink for MongoSink {
     fn config_schema(&self) -> serde_json::Value {
         serde_json::to_value(faucet_core::schema_for!(MongoSinkConfig))
             .expect("schema serialization")
+    }
+
+    fn supported_write_modes(&self) -> &'static [faucet_core::WriteMode] {
+        &[
+            faucet_core::WriteMode::Append,
+            faucet_core::WriteMode::Upsert,
+            faucet_core::WriteMode::Delete,
+        ]
     }
 
     fn dataset_uri(&self) -> String {
@@ -90,6 +222,20 @@ impl faucet_core::Sink for MongoSink {
     async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
         if records.is_empty() {
             return Ok(0);
+        }
+
+        // Upsert / delete routing: plan the page (dedup last-write-wins, strip
+        // the delete marker) and apply per-document `replace_one(upsert)` /
+        // `delete_one` ops. Append falls through to the `insert_many` fast path.
+        if !matches!(self.config.write.write_mode, faucet_core::WriteMode::Append) {
+            let plan = faucet_core::plan_writes(records, &self.config.write);
+            if let Some((idx, msg)) = plan.failed.first() {
+                return Err(FaucetError::Sink(format!(
+                    "mongodb {}: row {idx}: {msg}",
+                    self.config.write.write_mode.as_str()
+                )));
+            }
+            return self.apply_plan(&plan).await;
         }
 
         let collection = self
@@ -146,6 +292,30 @@ mod tests {
     // dataset_uri test is skipped: MongoSink::new() requires a live MongoDB
     // connection (Client::with_uri_str connects in new()), and no offline
     // constructor exists.
+
+    #[test]
+    fn filter_doc_from_key_tuple() {
+        let kt = faucet_core::KeyTuple(vec![
+            ("tenant".to_string(), serde_json::json!("acme")),
+            ("id".to_string(), serde_json::json!(7)),
+        ]);
+        let m = faucet_core::key_to_filter(&kt);
+        assert_eq!(m.get("tenant"), Some(&serde_json::json!("acme")));
+        assert_eq!(m.get("id"), Some(&serde_json::json!(7)));
+        // and it converts to a bson filter Document via the sink's converter:
+        let doc = super::json_map_to_bson_filter(&m).expect("filter converts to bson");
+        assert_eq!(doc.get_str("tenant").unwrap(), "acme");
+        assert_eq!(doc.get_i64("id").unwrap(), 7);
+    }
+
+    #[test]
+    fn filter_from_row_pulls_only_key_columns() {
+        let row = json!({"_id": 5, "name": "a", "extra": true});
+        let doc = MongoSink::filter_from_row(&row, &["_id".to_string()]).expect("filter");
+        assert_eq!(doc.get_i64("_id").unwrap(), 5);
+        assert!(!doc.contains_key("name"), "filter must contain only key columns");
+        assert!(!doc.contains_key("extra"));
+    }
 
     #[test]
     fn value_to_document_object() {

--- a/crates/sink/mongodb/src/sink.rs
+++ b/crates/sink/mongodb/src/sink.rs
@@ -53,9 +53,9 @@ impl MongoSink {
     /// column is present and non-null on each upsert row, so a missing column
     /// here is an internal invariant violation rather than user data error.
     fn filter_from_row(row: &Value, key: &[String]) -> Result<Document, FaucetError> {
-        let obj = row.as_object().ok_or_else(|| {
-            FaucetError::Sink("upsert row is not a JSON object".to_string())
-        })?;
+        let obj = row
+            .as_object()
+            .ok_or_else(|| FaucetError::Sink("upsert row is not a JSON object".to_string()))?;
         let mut filter = Map::with_capacity(key.len());
         for col in key {
             match obj.get(col) {
@@ -127,9 +127,7 @@ impl MongoSink {
                         .delete_one(filter)
                         .await
                         .map(|_| ())
-                        .map_err(|e| {
-                            FaucetError::Sink(format!("MongoDB delete_one failed: {e}"))
-                        }),
+                        .map_err(|e| FaucetError::Sink(format!("MongoDB delete_one failed: {e}"))),
                 }
             }
         }))
@@ -343,7 +341,10 @@ mod tests {
         let row = json!({"_id": 5, "name": "a", "extra": true});
         let doc = MongoSink::filter_from_row(&row, &["_id".to_string()]).expect("filter");
         assert_eq!(doc.get_i64("_id").unwrap(), 5);
-        assert!(!doc.contains_key("name"), "filter must contain only key columns");
+        assert!(
+            !doc.contains_key("name"),
+            "filter must contain only key columns"
+        );
         assert!(!doc.contains_key("extra"));
     }
 

--- a/crates/sink/mongodb/src/sink.rs
+++ b/crates/sink/mongodb/src/sink.rs
@@ -283,7 +283,7 @@ impl faucet_core::Sink for MongoSink {
 
     /// Write a batch and report per-row outcomes.
     ///
-    /// In append mode this delegates to [`write_batch`](Self::write_batch) and
+    /// In append mode this delegates to [`write_batch`](faucet_core::Sink::write_batch) and
     /// maps a single success onto an all-`Ok(())` vector (the trait default).
     /// In upsert/delete mode the good rows are applied (upserts + deletes), and
     /// only the rows whose key could not be extracted (missing / null key) are

--- a/crates/sink/mongodb/tests/upsert.rs
+++ b/crates/sink/mongodb/tests/upsert.rs
@@ -172,3 +172,45 @@ async fn intra_batch_last_write_wins() {
         "the last write in the batch must win"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Test 4: write_batch_partial routes missing-key rows to the DLQ per-row.
+// The good row is upserted; only the missing-`_id` row comes back as Err.
+// ---------------------------------------------------------------------------
+#[tokio::test(flavor = "multi_thread")]
+async fn write_batch_partial_routes_missing_key_per_row() {
+    let (_container, uri) = start_mongo().await;
+    let sink = MongoSink::new(upsert_config(&uri, None))
+        .await
+        .expect("sink new");
+
+    let records = [
+        serde_json::json!({"_id": 1, "name": "ok"}),
+        serde_json::json!({"name": "missing-id"}),
+    ];
+    let outcomes = sink
+        .write_batch_partial(&records)
+        .await
+        .expect("partial write");
+
+    assert_eq!(outcomes.len(), 2, "one outcome per input row");
+    assert!(outcomes[0].is_ok(), "the good row must be Ok");
+    assert!(
+        outcomes[1].is_err(),
+        "the missing-key row must be Err (routed to the DLQ)"
+    );
+
+    assert_eq!(
+        count_docs(&uri, "testdb", "docs").await,
+        1,
+        "only the good row should be written"
+    );
+    let doc = find_one_by_id(&uri, "testdb", "docs", 1)
+        .await
+        .expect("doc present");
+    assert_eq!(
+        doc.get_str("name").unwrap(),
+        "ok",
+        "_id=1 must be present with name 'ok'"
+    );
+}

--- a/crates/sink/mongodb/tests/upsert.rs
+++ b/crates/sink/mongodb/tests/upsert.rs
@@ -1,0 +1,174 @@
+//! Integration tests for the MongoDB sink's `upsert` / `delete` write modes.
+//!
+//! Each test boots a fresh MongoDB container via testcontainers, drives one or
+//! more `write_batch` calls in upsert/delete mode (with `key: ["_id"]`), and
+//! reads the collection back to assert on the post-condition. Upserts are
+//! committed via per-document `replace_one(upsert = true)` and deletes via
+//! `delete_one`, so the observable invariants are the document count and the
+//! contents of the surviving documents.
+
+use faucet_core::{DeleteMarker, Sink, WriteMode, WriteSpec};
+use faucet_sink_mongodb::{MongoSink, MongoSinkConfig};
+use mongodb::Client;
+use mongodb::bson::{Document, doc};
+use testcontainers::{ContainerAsync, runners::AsyncRunner};
+use testcontainers_modules::mongo::Mongo;
+
+/// Start a MongoDB container and return both the container handle and a
+/// connection URI. The container is kept alive by the returned handle.
+async fn start_mongo() -> (ContainerAsync<Mongo>, String) {
+    let container: ContainerAsync<Mongo> = Mongo::default()
+        .start()
+        .await
+        .expect("mongo container start");
+    let port = container
+        .get_host_port_ipv4(27017)
+        .await
+        .expect("mongo port");
+    let uri = format!("mongodb://127.0.0.1:{port}");
+    (container, uri)
+}
+
+/// Build an upsert-mode config keyed on `_id`, with an optional delete marker.
+fn upsert_config(uri: &str, delete_marker: Option<DeleteMarker>) -> MongoSinkConfig {
+    let mut config = MongoSinkConfig::new(uri, "testdb", "docs");
+    config.write = WriteSpec {
+        write_mode: WriteMode::Upsert,
+        key: vec!["_id".to_string()],
+        delete_marker,
+    };
+    config
+}
+
+async fn count_docs(uri: &str, db: &str, collection: &str) -> u64 {
+    let client = Client::with_uri_str(uri).await.expect("client");
+    client
+        .database(db)
+        .collection::<Document>(collection)
+        .count_documents(doc! {})
+        .await
+        .expect("count_documents")
+}
+
+async fn find_one_by_id(uri: &str, db: &str, collection: &str, id: i64) -> Option<Document> {
+    let client = Client::with_uri_str(uri).await.expect("client");
+    client
+        .database(db)
+        .collection::<Document>(collection)
+        .find_one(doc! { "_id": id })
+        .await
+        .expect("find_one")
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: upsert replaces an existing document in place (last-write-wins).
+// ---------------------------------------------------------------------------
+#[tokio::test(flavor = "multi_thread")]
+async fn upsert_replaces_existing_document() {
+    let (_container, uri) = start_mongo().await;
+    let sink = MongoSink::new(upsert_config(&uri, None))
+        .await
+        .expect("sink new");
+
+    // Insert the initial document.
+    sink.write_batch(&[serde_json::json!({"_id": 1, "name": "a"})])
+        .await
+        .expect("first write");
+    assert_eq!(count_docs(&uri, "testdb", "docs").await, 1);
+    let doc = find_one_by_id(&uri, "testdb", "docs", 1)
+        .await
+        .expect("doc present");
+    assert_eq!(doc.get_str("name").unwrap(), "a");
+
+    // Upsert the same _id with a new name — must replace in place, not duplicate.
+    sink.write_batch(&[serde_json::json!({"_id": 1, "name": "b"})])
+        .await
+        .expect("second write");
+    assert_eq!(
+        count_docs(&uri, "testdb", "docs").await,
+        1,
+        "upsert must not create a second document for the same _id"
+    );
+    let doc = find_one_by_id(&uri, "testdb", "docs", 1)
+        .await
+        .expect("doc still present");
+    assert_eq!(
+        doc.get_str("name").unwrap(),
+        "b",
+        "the replacement document's name must win"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: delete_marker routes a delete-flagged row to delete_one; the upsert
+// replacement that precedes it does NOT carry the marker field (plan_writes
+// strips it).
+// ---------------------------------------------------------------------------
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_marker_removes_document_and_strips_marker_from_upsert() {
+    let (_container, uri) = start_mongo().await;
+    let marker = DeleteMarker {
+        field: "__op".to_string(),
+        values: vec!["d".to_string()],
+    };
+    let sink = MongoSink::new(upsert_config(&uri, Some(marker)))
+        .await
+        .expect("sink new");
+
+    // Upsert a document carrying the marker field with a non-delete value.
+    sink.write_batch(&[serde_json::json!({"_id": 1, "name": "x", "__op": "u"})])
+        .await
+        .expect("upsert write");
+    assert_eq!(count_docs(&uri, "testdb", "docs").await, 1);
+    let doc = find_one_by_id(&uri, "testdb", "docs", 1)
+        .await
+        .expect("doc present");
+    assert_eq!(doc.get_str("name").unwrap(), "x");
+    assert!(
+        !doc.contains_key("__op"),
+        "the upsert replacement must not contain the stripped delete-marker field"
+    );
+
+    // Now write a delete-flagged row for the same _id — must remove it.
+    sink.write_batch(&[serde_json::json!({"_id": 1, "__op": "d"})])
+        .await
+        .expect("delete write");
+    assert_eq!(
+        count_docs(&uri, "testdb", "docs").await,
+        0,
+        "the delete-marked row must remove the document"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: within a single batch, last-write-wins dedup collapses repeated keys
+// to one document carrying the final value.
+// ---------------------------------------------------------------------------
+#[tokio::test(flavor = "multi_thread")]
+async fn intra_batch_last_write_wins() {
+    let (_container, uri) = start_mongo().await;
+    let sink = MongoSink::new(upsert_config(&uri, None))
+        .await
+        .expect("sink new");
+
+    sink.write_batch(&[
+        serde_json::json!({"_id": 1, "name": "old"}),
+        serde_json::json!({"_id": 1, "name": "new"}),
+    ])
+    .await
+    .expect("write");
+
+    assert_eq!(
+        count_docs(&uri, "testdb", "docs").await,
+        1,
+        "two rows with the same _id collapse to one document"
+    );
+    let doc = find_one_by_id(&uri, "testdb", "docs", 1)
+        .await
+        .expect("doc present");
+    assert_eq!(
+        doc.get_str("name").unwrap(),
+        "new",
+        "the last write in the batch must win"
+    );
+}

--- a/crates/sink/mssql/README.md
+++ b/crates/sink/mssql/README.md
@@ -53,15 +53,57 @@ full connection / TLS reference.
 `auto_columns` + `create_table` is rejected — schema inference for MSSQL types is
 unsafe, so create the table yourself first.
 
+## Write modes (upsert / delete)
+
+In addition to the default append, the sink can **upsert** (insert-or-update by a
+key) or **delete** by key. Both require `column_mapping: auto_columns` — the key
+columns must be real table columns, not buried inside a JSON column (using
+`json_column` with `upsert`/`delete` is rejected at construction).
+
+```yaml
+sink:
+  type: mssql
+  config:
+    connection_url: "mssql://sa:Str0ng%40Pass@localhost:1433/sales"
+    table: "dbo.users"
+    column_mapping:
+      type: auto_columns
+    write_mode: upsert            # append (default) | upsert | delete
+    key: [id]                     # one or more key columns (composite keys supported)
+    # delete_marker:              # upsert only: route marked rows to deletes
+    #   field: __op
+    #   values: [d, delete]
+```
+
+- **`upsert`** — each record is merged into the table via a single T-SQL
+  [`MERGE`](https://learn.microsoft.com/sql/t-sql/statements/merge-transact-sql):
+  matching rows (by `key`) have their non-key columns updated; non-matching rows
+  are inserted. When every column is a key column there is nothing to update, so
+  the `WHEN MATCHED` clause is omitted. Within a single batch, records with the
+  same key are deduplicated **last-write-wins** before the `MERGE` runs (MERGE
+  rejects a source that targets the same key twice).
+- **`delete`** — every record's `key` is collected and deleted. Composite keys
+  use a `MERGE … WHEN MATCHED THEN DELETE` (T-SQL has no row-constructor
+  `IN ((a,b), …)`), so single- and multi-column keys share one code path.
+- **`delete_marker`** (upsert mode only) — rows whose `field` equals one of
+  `values` are routed to a delete instead of an upsert; the marker field is
+  stripped from the upserted record. This lets a CDC stream carrying an
+  operation flag drive inserts, updates, and deletes from one pipeline.
+
+A row missing or null in a key column fails the whole batch with a clear
+`mssql upsert: row <i>: …` error. Upserts and deletes for a batch run inside a
+single `BEGIN TRAN` / `COMMIT TRAN` so they commit atomically.
+
 ## Batching, transactions, and MSSQL's statement limits
 
-MSSQL enforces two caps on a multi-row `INSERT`: at most **2100 parameters** per
+MSSQL enforces two caps on a multi-row statement: at most **2100 parameters** per
 request (and `tiberius` spends 2 of them on its `sp_executesql` wrapper, so the
 usable budget is 2098), and at most **1000 row expressions** in a `VALUES`
-clause. The sink auto-splits a batch into multiple `INSERT` statements that stay
-within *both* limits — `min(2098 / columns, 1000)` rows each — all within one
-transaction when `transaction_per_batch`. `MERGE`/`UPSERT` and bulk-copy (`BCP`)
-are out of scope for v1 — this is an append-only sink.
+clause. Both the append `INSERT` and the `MERGE` upsert/delete paths auto-split a
+batch into multiple statements that stay within *both* limits —
+`min(2098 / columns, 1000)` rows each — all within one transaction when
+`transaction_per_batch` (upsert/delete are always transaction-wrapped). Bulk-copy
+(`BCP`) is out of scope.
 
 ## Partial failures (DLQ)
 

--- a/crates/sink/mssql/README.md
+++ b/crates/sink/mssql/README.md
@@ -90,9 +90,11 @@ sink:
   stripped from the upserted record. This lets a CDC stream carrying an
   operation flag drive inserts, updates, and deletes from one pipeline.
 
-A row missing or null in a key column fails the whole batch with a clear
-`mssql upsert: row <i>: …` error. Upserts and deletes for a batch run inside a
-single `BEGIN TRAN` / `COMMIT TRAN` so they commit atomically.
+A row missing or null in a key column fails with a clear `mssql upsert: …`
+error. When a `dlq:` block is configured the good rows are still applied
+(upserts + deletes) and only the missing/null-key rows are routed to the DLQ
+per-row; without a DLQ the whole batch fails. Upserts and deletes for a batch
+run inside a single `BEGIN TRAN` / `COMMIT TRAN` so they commit atomically.
 
 ## Batching, transactions, and MSSQL's statement limits
 

--- a/crates/sink/mssql/src/config.rs
+++ b/crates/sink/mssql/src/config.rs
@@ -92,6 +92,11 @@ pub struct MssqlSinkConfig {
     /// `auto_columns` (schema inference is unsafe for MSSQL types). Defaults to false.
     #[serde(default)]
     pub create_table: bool,
+    /// Write mode (`append` / `upsert` / `delete`) + `key` / `delete_marker`.
+    /// `upsert` and `delete` require `column_mapping: auto_columns` (the key
+    /// columns must be real table columns, not buried inside a JSON column).
+    #[serde(flatten)]
+    pub write: faucet_core::WriteSpec,
 }
 
 impl std::fmt::Debug for MssqlSinkConfig {
@@ -106,6 +111,7 @@ impl std::fmt::Debug for MssqlSinkConfig {
             .field("isolate_row_failures", &self.isolate_row_failures)
             .field("statement_timeout_secs", &self.statement_timeout_secs)
             .field("create_table", &self.create_table)
+            .field("write", &self.write)
             .finish()
     }
 }
@@ -126,6 +132,7 @@ impl MssqlSinkConfig {
             isolate_row_failures: true,
             statement_timeout_secs: default_statement_timeout_secs(),
             create_table: false,
+            write: faucet_core::WriteSpec::default(),
         }
     }
 

--- a/crates/sink/mssql/src/encode.rs
+++ b/crates/sink/mssql/src/encode.rs
@@ -423,7 +423,9 @@ mod tests {
             "{sql}"
         );
         assert!(
-            sql.contains("WHEN NOT MATCHED THEN INSERT ([id], [name]) VALUES (src.[id], src.[name])"),
+            sql.contains(
+                "WHEN NOT MATCHED THEN INSERT ([id], [name]) VALUES (src.[id], src.[name])"
+            ),
             "{sql}"
         );
         assert!(

--- a/crates/sink/mssql/src/encode.rs
+++ b/crates/sink/mssql/src/encode.rs
@@ -1,7 +1,7 @@
 //! Pure helpers for turning JSON records into MSSQL `INSERT` statements and
 //! bound parameters. No I/O — all unit-testable.
 
-use faucet_common_mssql::PARAM_LIMIT;
+use faucet_common_mssql::{PARAM_LIMIT, quote_ident_mssql};
 use faucet_core::FaucetError;
 use serde_json::Value;
 use tiberius::ToSql;
@@ -158,6 +158,127 @@ pub(crate) fn resolve_insert_columns(
     Ok(columns)
 }
 
+/// Build a parameterized `MERGE` upsert. `table` must already be quoted; the
+/// `key` / `cols` entries are bare identifiers that this function quotes via
+/// [`quote_ident_mssql`].
+///
+/// Emits `n_rows` `VALUES` groups of `cols.len()` `@PN` params each, numbered
+/// row-major so the binding order matches `n_rows` calls of
+/// [`auto_row_params(record, cols)`](auto_row_params) concatenated in record
+/// order. Joins on every `key` column, `UPDATE`s the non-key columns, and
+/// `INSERT`s all columns. When every column is a key there is nothing to
+/// update, so the `WHEN MATCHED` clause is omitted entirely. T-SQL requires a
+/// terminating `;` on `MERGE`, so one is always appended.
+pub(crate) fn build_merge(
+    table: &str,
+    key: &[String],
+    cols: &[String],
+    n_rows: usize,
+) -> Result<String, FaucetError> {
+    let q = |s: &str| quote_ident_mssql(s);
+    let quoted_cols: Vec<String> = cols.iter().map(|c| q(c)).collect::<Result<_, _>>()?;
+    let quoted_keys: Vec<String> = key.iter().map(|k| q(k)).collect::<Result<_, _>>()?;
+    let col_list = quoted_cols.join(", ");
+
+    let mut ph = 1usize;
+    let groups: Vec<String> = (0..n_rows)
+        .map(|_| {
+            let g = cols
+                .iter()
+                .map(|_| {
+                    let p = format!("@P{ph}");
+                    ph += 1;
+                    p
+                })
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("({g})")
+        })
+        .collect();
+
+    let on = quoted_keys
+        .iter()
+        .map(|qk| format!("tgt.{qk} = src.{qk}"))
+        .collect::<Vec<_>>()
+        .join(" AND ");
+
+    // Non-key columns get UPDATE assignments; compare on the *bare* names so a
+    // column equal to a key column (after quoting) is correctly excluded.
+    let update_set = cols
+        .iter()
+        .zip(&quoted_cols)
+        .filter(|(c, _)| !key.iter().any(|k| k == *c))
+        .map(|(_, qc)| format!("tgt.{qc} = src.{qc}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    let insert_vals = quoted_cols
+        .iter()
+        .map(|qc| format!("src.{qc}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    let matched = if update_set.is_empty() {
+        String::new()
+    } else {
+        format!(" WHEN MATCHED THEN UPDATE SET {update_set}")
+    };
+
+    Ok(format!(
+        "MERGE {table} AS tgt USING (VALUES {}) AS src ({col_list}) ON {on}{matched} \
+         WHEN NOT MATCHED THEN INSERT ({col_list}) VALUES ({insert_vals});",
+        groups.join(", ")
+    ))
+}
+
+/// Build a parameterized `MERGE … WHEN MATCHED THEN DELETE` for composite-key
+/// deletes. `table` must already be quoted; `key` entries are bare identifiers
+/// quoted here.
+///
+/// T-SQL has no row-constructor `IN ((a,b), …)`, so a composite-key delete is
+/// expressed as a `MERGE` whose source is the `VALUES` list of key tuples.
+/// Params are numbered row-major over the key columns, matching how the caller
+/// binds each [`KeyTuple`](faucet_core::KeyTuple)'s values in `key` order.
+pub(crate) fn build_merge_delete(
+    table: &str,
+    key: &[String],
+    n_rows: usize,
+) -> Result<String, FaucetError> {
+    let quoted_keys: Vec<String> = key
+        .iter()
+        .map(|k| quote_ident_mssql(k))
+        .collect::<Result<_, _>>()?;
+    let key_list = quoted_keys.join(", ");
+
+    let mut ph = 1usize;
+    let groups: Vec<String> = (0..n_rows)
+        .map(|_| {
+            let g = key
+                .iter()
+                .map(|_| {
+                    let p = format!("@P{ph}");
+                    ph += 1;
+                    p
+                })
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("({g})")
+        })
+        .collect();
+
+    let on = quoted_keys
+        .iter()
+        .map(|qk| format!("tgt.{qk} = src.{qk}"))
+        .collect::<Vec<_>>()
+        .join(" AND ");
+
+    Ok(format!(
+        "MERGE {table} AS tgt USING (VALUES {}) AS src ({key_list}) ON {on} \
+         WHEN MATCHED THEN DELETE;",
+        groups.join(", ")
+    ))
+}
+
 /// Bind one record's values in `columns` order (SQL NULL for missing keys).
 pub(crate) fn auto_row_params(record: &Value, columns: &[String]) -> Vec<BoundParam> {
     let obj = record.as_object();
@@ -280,6 +401,109 @@ mod tests {
             BoundParam::from_value(&json!({"k":1})),
             BoundParam::Str(_)
         ));
+    }
+
+    #[test]
+    fn mssql_merge_statement_shape() {
+        let sql = build_merge(
+            "[dbo].[t]",
+            &["id".to_string()],
+            &["id".to_string(), "name".to_string()],
+            1,
+        )
+        .unwrap();
+        assert!(sql.contains("MERGE [dbo].[t] AS tgt"), "{sql}");
+        assert!(
+            sql.contains("USING (VALUES (@P1, @P2)) AS src ([id], [name])"),
+            "{sql}"
+        );
+        assert!(sql.contains("ON tgt.[id] = src.[id]"), "{sql}");
+        assert!(
+            sql.contains("WHEN MATCHED THEN UPDATE SET tgt.[name] = src.[name]"),
+            "{sql}"
+        );
+        assert!(
+            sql.contains("WHEN NOT MATCHED THEN INSERT ([id], [name]) VALUES (src.[id], src.[name])"),
+            "{sql}"
+        );
+        assert!(
+            sql.trim_end().ends_with(';'),
+            "MERGE needs a terminating semicolon: {sql}"
+        );
+    }
+
+    #[test]
+    fn mssql_merge_all_keys_has_no_update_clause() {
+        // When every column is a key, there is nothing to UPDATE — emit no WHEN
+        // MATCHED clause.
+        let sql = build_merge("[t]", &["id".to_string()], &["id".to_string()], 2).unwrap();
+        assert!(!sql.contains("WHEN MATCHED"), "{sql}");
+        assert!(sql.contains("WHEN NOT MATCHED THEN INSERT"), "{sql}");
+        assert!(sql.contains("(@P1), (@P2)"), "two single-col rows: {sql}");
+    }
+
+    #[test]
+    fn mssql_merge_numbers_params_row_major() {
+        // Two rows of two columns → @P1..@P4 in row-major order, matching how
+        // `auto_row_params` is concatenated per row.
+        let sql = build_merge(
+            "[t]",
+            &["id".to_string()],
+            &["id".to_string(), "name".to_string()],
+            2,
+        )
+        .unwrap();
+        assert!(
+            sql.contains("VALUES (@P1, @P2), (@P3, @P4)"),
+            "row-major param numbering: {sql}"
+        );
+    }
+
+    #[test]
+    fn mssql_merge_composite_key_joins_on_all_key_cols() {
+        let sql = build_merge(
+            "[t]",
+            &["a".to_string(), "b".to_string()],
+            &["a".to_string(), "b".to_string(), "v".to_string()],
+            1,
+        )
+        .unwrap();
+        assert!(
+            sql.contains("ON tgt.[a] = src.[a] AND tgt.[b] = src.[b]"),
+            "{sql}"
+        );
+        // Only the non-key column `v` is updated.
+        assert!(
+            sql.contains("WHEN MATCHED THEN UPDATE SET tgt.[v] = src.[v]"),
+            "{sql}"
+        );
+    }
+
+    #[test]
+    fn mssql_merge_delete_statement_shape() {
+        let sql = build_merge_delete("[dbo].[t]", &["id".to_string()], 2).unwrap();
+        assert!(sql.contains("MERGE [dbo].[t] AS tgt"), "{sql}");
+        assert!(
+            sql.contains("USING (VALUES (@P1), (@P2)) AS src ([id])"),
+            "{sql}"
+        );
+        assert!(sql.contains("ON tgt.[id] = src.[id]"), "{sql}");
+        assert!(sql.contains("WHEN MATCHED THEN DELETE"), "{sql}");
+        assert!(sql.trim_end().ends_with(';'), "{sql}");
+    }
+
+    #[test]
+    fn mssql_merge_delete_composite_key() {
+        let sql = build_merge_delete("[t]", &["a".to_string(), "b".to_string()], 1).unwrap();
+        assert!(
+            sql.contains("USING (VALUES (@P1, @P2)) AS src ([a], [b])"),
+            "{sql}"
+        );
+        assert!(
+            sql.contains("ON tgt.[a] = src.[a] AND tgt.[b] = src.[b]"),
+            "{sql}"
+        );
+        assert!(sql.contains("WHEN MATCHED THEN DELETE"), "{sql}");
     }
 
     #[test]

--- a/crates/sink/mssql/src/sink.rs
+++ b/crates/sink/mssql/src/sink.rs
@@ -15,7 +15,8 @@ use faucet_common_mssql::{MssqlPool, MssqlPooledConnection, build_pool, quote_id
 
 use crate::config::{MssqlColumnMapping, MssqlSinkConfig};
 use crate::encode::{
-    BoundParam, auto_row_params, build_insert_sql, max_rows_per_insert, resolve_insert_columns,
+    BoundParam, auto_row_params, build_insert_sql, build_merge, build_merge_delete,
+    max_rows_per_insert, resolve_insert_columns,
 };
 
 /// Microsoft SQL Server sink.
@@ -32,6 +33,16 @@ impl MssqlSink {
     /// mode) create the table if it doesn't exist.
     pub async fn new(config: MssqlSinkConfig) -> Result<Self, FaucetError> {
         config.validate()?;
+        config.write.validate()?;
+        if !matches!(config.write.write_mode, faucet_core::WriteMode::Append)
+            && !matches!(config.column_mapping, MssqlColumnMapping::AutoColumns { .. })
+        {
+            return Err(FaucetError::Config(
+                "mssql sink: write_mode upsert/delete requires column_mapping: auto_columns \
+                 (key columns must be real columns, not inside a JSON column)"
+                    .into(),
+            ));
+        }
         let table_quoted = quote_table(&config.table)?;
         let pool = build_pool(&config.connection, config.max_connections).await?;
 
@@ -305,6 +316,134 @@ impl MssqlSink {
         }
         Ok(rows.len())
     }
+
+    /// Run a single `MERGE`-upsert / `MERGE`-delete statement on an
+    /// already-open connection, honouring the per-statement timeout. Returns
+    /// `Err((error, timed_out))`; on timeout the connection is desynced and the
+    /// caller must NOT issue ROLLBACK on it (mirrors `insert_rows_no_txn`).
+    async fn exec_merge(
+        &self,
+        conn: &mut MssqlPooledConnection<'_>,
+        sql: &str,
+        refs: &[&dyn ToSql],
+    ) -> Result<(), (FaucetError, bool)> {
+        let exec = async {
+            conn.execute(sql, refs)
+                .await
+                .map(|_| ())
+                .map_err(|e| FaucetError::Sink(format!("MSSQL merge failed: {e}")))
+        };
+        match self.timeout() {
+            Some(t) => match tokio::time::timeout(t, exec).await {
+                Ok(Ok(())) => Ok(()),
+                Ok(Err(e)) => Err((e, false)),
+                Err(_) => Err((FaucetError::Sink("MSSQL merge timed out".into()), true)),
+            },
+            None => exec.await.map_err(|e| (e, false)),
+        }
+    }
+
+    /// Upsert `upserts` into the table via `MERGE`, on an already-open
+    /// connection (the caller owns the transaction). Resolves the column set
+    /// via `resolve_insert_columns`, chunks by `max_rows_per_insert`, and binds
+    /// each row's params row-major exactly as `build_merge` numbers them.
+    async fn upsert_rows_no_txn(
+        &self,
+        conn: &mut MssqlPooledConnection<'_>,
+        upserts: &[Value],
+    ) -> Result<usize, (FaucetError, bool)> {
+        if upserts.is_empty() {
+            return Ok(0);
+        }
+        let MssqlColumnMapping::AutoColumns { on_unknown_field } = &self.config.column_mapping
+        else {
+            // Validated in `new()` — upsert requires auto_columns.
+            return Err((
+                FaucetError::Sink(
+                    "MSSQL upsert requires column_mapping: auto_columns".into(),
+                ),
+                false,
+            ));
+        };
+        let insertable = self.insertable_columns().await.map_err(|e| (e, false))?;
+        let cols = resolve_insert_columns(&insertable, upserts, *on_unknown_field)
+            .map_err(|e| (e, false))?;
+        if cols.is_empty() {
+            return Ok(0);
+        }
+        let per_insert = max_rows_per_insert(cols.len());
+        for sub in upserts.chunks(per_insert) {
+            let sql = build_merge(&self.table_quoted, &self.config.write.key, &cols, sub.len())
+                .map_err(|e| (e, false))?;
+            // Bind every row's params concatenated row-major — matches the @PN
+            // numbering build_merge emits.
+            let owned: Vec<BoundParam> = sub
+                .iter()
+                .flat_map(|r| auto_row_params(r, &cols))
+                .collect();
+            let refs: Vec<&dyn ToSql> = owned.iter().map(|p| p.as_tosql()).collect();
+            self.exec_merge(conn, &sql, &refs).await?;
+        }
+        Ok(upserts.len())
+    }
+
+    /// Delete the `deletes` key tuples via `MERGE … WHEN MATCHED THEN DELETE`,
+    /// on an already-open connection. Chunks by `max_rows_per_insert(key.len())`
+    /// and binds each key tuple's values in `key` order, row-major.
+    async fn delete_keys_no_txn(
+        &self,
+        conn: &mut MssqlPooledConnection<'_>,
+        deletes: &[faucet_core::KeyTuple],
+    ) -> Result<usize, (FaucetError, bool)> {
+        if deletes.is_empty() {
+            return Ok(0);
+        }
+        let key = &self.config.write.key;
+        let per = max_rows_per_insert(key.len());
+        for chunk in deletes.chunks(per) {
+            let sql = build_merge_delete(&self.table_quoted, key, chunk.len())
+                .map_err(|e| (e, false))?;
+            // Bind each tuple's values in key order, row-major.
+            let owned: Vec<BoundParam> = chunk
+                .iter()
+                .flat_map(|kt| kt.0.iter().map(|(_, v)| BoundParam::from_value(v)))
+                .collect();
+            let refs: Vec<&dyn ToSql> = owned.iter().map(|p| p.as_tosql()).collect();
+            self.exec_merge(conn, &sql, &refs).await?;
+        }
+        Ok(deletes.len())
+    }
+
+    /// Apply a planned upsert/delete batch atomically: upserts then deletes,
+    /// wrapped in a single `BEGIN TRAN` / `COMMIT TRAN` so they commit together
+    /// (last-write-wins dedup already collapsed conflicting ops in the planner).
+    async fn apply_plan(&self, plan: &faucet_core::WritePlan) -> Result<usize, FaucetError> {
+        let mut conn = self.checkout().await?;
+        control(&mut conn, "BEGIN TRAN").await?;
+
+        let mut affected = 0usize;
+        match self.upsert_rows_no_txn(&mut conn, &plan.upserts).await {
+            Ok(n) => affected += n,
+            Err((e, timed_out)) => {
+                if !timed_out {
+                    let _ = control(&mut conn, "ROLLBACK TRAN").await;
+                }
+                return Err(e);
+            }
+        }
+        match self.delete_keys_no_txn(&mut conn, &plan.deletes).await {
+            Ok(n) => affected += n,
+            Err((e, timed_out)) => {
+                if !timed_out {
+                    let _ = control(&mut conn, "ROLLBACK TRAN").await;
+                }
+                return Err(e);
+            }
+        }
+
+        control(&mut conn, "COMMIT TRAN").await?;
+        Ok(affected)
+    }
 }
 
 /// Run a transaction-control statement and drain its (empty) result.
@@ -348,6 +487,28 @@ impl Sink for MssqlSink {
         if records.is_empty() {
             return Ok(0);
         }
+
+        // Non-append modes: plan the writes and apply upserts + deletes
+        // atomically. (NOTE: write_batch_partial upsert routing is handled in
+        // the DLQ task; write_batch_idempotent in the exactly-once task.)
+        if !matches!(self.config.write.write_mode, faucet_core::WriteMode::Append) {
+            let plan = faucet_core::plan_writes(records, &self.config.write);
+            if let Some((idx, msg)) = plan.failed.first() {
+                return Err(FaucetError::Sink(format!(
+                    "mssql {}: row {idx}: {msg}",
+                    self.config.write.write_mode.as_str()
+                )));
+            }
+            let total = self.apply_plan(&plan).await?;
+            tracing::info!(
+                table = %self.config.table,
+                mode = self.config.write.write_mode.as_str(),
+                rows = total,
+                "MSSQL write complete"
+            );
+            return Ok(total);
+        }
+
         let chunks: Vec<&[Value]> = if self.config.batch_size == 0 {
             vec![records]
         } else {
@@ -441,6 +602,14 @@ impl Sink for MssqlSink {
 
     fn supports_idempotent_writes(&self) -> bool {
         true
+    }
+
+    fn supported_write_modes(&self) -> &'static [faucet_core::WriteMode] {
+        &[
+            faucet_core::WriteMode::Append,
+            faucet_core::WriteMode::Upsert,
+            faucet_core::WriteMode::Delete,
+        ]
     }
 
     async fn last_committed_token(&self, scope: &str) -> Result<Option<String>, FaucetError> {

--- a/crates/sink/mssql/src/sink.rs
+++ b/crates/sink/mssql/src/sink.rs
@@ -641,29 +641,72 @@ impl Sink for MssqlSink {
         scope: &str,
         token: &str,
     ) -> Result<usize, FaucetError> {
+        // For upsert/delete modes, plan the page before opening the transaction
+        // so a key-extraction failure aborts without leaving an open tx.
+        let plan = if matches!(self.config.write.write_mode, faucet_core::WriteMode::Append) {
+            None
+        } else {
+            let plan = faucet_core::plan_writes(records, &self.config.write);
+            if let Some((idx, msg)) = plan.failed.first() {
+                return Err(FaucetError::Sink(format!(
+                    "mssql {}: row {idx}: {msg}",
+                    self.config.write.write_mode.as_str()
+                )));
+            }
+            Some(plan)
+        };
+
         let mut conn = self.checkout().await?;
         self.ensure_commit_table(&mut conn).await?;
         control(&mut conn, "BEGIN TRAN").await?;
 
-        let written = match self.prepare_chunk(records).await {
-            Ok(Some((cols, rows))) => {
-                match self.insert_rows_no_txn(&mut conn, &cols, &rows).await {
-                    Ok(n) => n,
+        // Data write and the commit-token MERGE share ONE transaction so the
+        // page is committed atomically with its watermark. For upsert/delete the
+        // planned upserts/deletes run via the same no-txn MERGE helpers used by
+        // the append path's INSERTs, inside this same BEGIN TRAN.
+        let written = match &plan {
+            Some(plan) => {
+                let mut affected = 0usize;
+                match self.upsert_rows_no_txn(&mut conn, &plan.upserts).await {
+                    Ok(n) => affected += n,
                     Err((e, timed_out)) => {
-                        // Desynced connection on timeout — ROLLBACK would run on a
-                        // corrupt stream (mirrors insert_chunk). Drop the conn instead.
                         if !timed_out {
                             let _ = control(&mut conn, "ROLLBACK TRAN").await;
                         }
                         return Err(e);
                     }
                 }
+                match self.delete_keys_no_txn(&mut conn, &plan.deletes).await {
+                    Ok(n) => affected += n,
+                    Err((e, timed_out)) => {
+                        if !timed_out {
+                            let _ = control(&mut conn, "ROLLBACK TRAN").await;
+                        }
+                        return Err(e);
+                    }
+                }
+                affected
             }
-            Ok(None) => 0,
-            Err(e) => {
-                let _ = control(&mut conn, "ROLLBACK TRAN").await;
-                return Err(e);
-            }
+            None => match self.prepare_chunk(records).await {
+                Ok(Some((cols, rows))) => {
+                    match self.insert_rows_no_txn(&mut conn, &cols, &rows).await {
+                        Ok(n) => n,
+                        Err((e, timed_out)) => {
+                            // Desynced connection on timeout — ROLLBACK would run on a
+                            // corrupt stream (mirrors insert_chunk). Drop the conn instead.
+                            if !timed_out {
+                                let _ = control(&mut conn, "ROLLBACK TRAN").await;
+                            }
+                            return Err(e);
+                        }
+                    }
+                }
+                Ok(None) => 0,
+                Err(e) => {
+                    let _ = control(&mut conn, "ROLLBACK TRAN").await;
+                    return Err(e);
+                }
+            },
         };
 
         // UPSERT the commit token atomically with the data rows.

--- a/crates/sink/mssql/src/sink.rs
+++ b/crates/sink/mssql/src/sink.rs
@@ -547,6 +547,24 @@ impl Sink for MssqlSink {
         if records.is_empty() {
             return Ok(Vec::new());
         }
+
+        // Upsert/delete: apply the good rows (upserts + deletes) and route only
+        // the rows whose key could not be extracted (missing / null key) to the
+        // DLQ per-row. The append path below keeps its row-isolation behaviour.
+        if !matches!(self.config.write.write_mode, faucet_core::WriteMode::Append) {
+            let plan = faucet_core::plan_writes(records, &self.config.write);
+            self.apply_plan(&plan).await?;
+
+            let mut outcomes: Vec<RowOutcome> = records.iter().map(|_| Ok(())).collect();
+            for (idx, msg) in &plan.failed {
+                outcomes[*idx] = Err(FaucetError::Sink(format!(
+                    "mssql {}: {msg}",
+                    self.config.write.write_mode.as_str()
+                )));
+            }
+            return Ok(outcomes);
+        }
+
         let chunks: Vec<&[Value]> = if self.config.batch_size == 0 {
             vec![records]
         } else {

--- a/crates/sink/mssql/src/sink.rs
+++ b/crates/sink/mssql/src/sink.rs
@@ -35,7 +35,10 @@ impl MssqlSink {
         config.validate()?;
         config.write.validate()?;
         if !matches!(config.write.write_mode, faucet_core::WriteMode::Append)
-            && !matches!(config.column_mapping, MssqlColumnMapping::AutoColumns { .. })
+            && !matches!(
+                config.column_mapping,
+                MssqlColumnMapping::AutoColumns { .. }
+            )
         {
             return Err(FaucetError::Config(
                 "mssql sink: write_mode upsert/delete requires column_mapping: auto_columns \
@@ -359,9 +362,7 @@ impl MssqlSink {
         else {
             // Validated in `new()` — upsert requires auto_columns.
             return Err((
-                FaucetError::Sink(
-                    "MSSQL upsert requires column_mapping: auto_columns".into(),
-                ),
+                FaucetError::Sink("MSSQL upsert requires column_mapping: auto_columns".into()),
                 false,
             ));
         };
@@ -377,10 +378,8 @@ impl MssqlSink {
                 .map_err(|e| (e, false))?;
             // Bind every row's params concatenated row-major — matches the @PN
             // numbering build_merge emits.
-            let owned: Vec<BoundParam> = sub
-                .iter()
-                .flat_map(|r| auto_row_params(r, &cols))
-                .collect();
+            let owned: Vec<BoundParam> =
+                sub.iter().flat_map(|r| auto_row_params(r, &cols)).collect();
             let refs: Vec<&dyn ToSql> = owned.iter().map(|p| p.as_tosql()).collect();
             self.exec_merge(conn, &sql, &refs).await?;
         }
@@ -401,8 +400,8 @@ impl MssqlSink {
         let key = &self.config.write.key;
         let per = max_rows_per_insert(key.len());
         for chunk in deletes.chunks(per) {
-            let sql = build_merge_delete(&self.table_quoted, key, chunk.len())
-                .map_err(|e| (e, false))?;
+            let sql =
+                build_merge_delete(&self.table_quoted, key, chunk.len()).map_err(|e| (e, false))?;
             // Bind each tuple's values in key order, row-major.
             let owned: Vec<BoundParam> = chunk
                 .iter()

--- a/crates/sink/mssql/tests/exactly_once_upsert.rs
+++ b/crates/sink/mssql/tests/exactly_once_upsert.rs
@@ -95,7 +95,11 @@ async fn idempotent_upsert_updates_in_place_and_advances_token() {
     let (_c, port) = start_mssql().await;
     let cfg = conn_cfg(port);
     let pool = build_pool(&cfg, 4).await.expect("pool");
-    exec(&pool, "CREATE TABLE dbo.t (id INT PRIMARY KEY, name NVARCHAR(255))").await;
+    exec(
+        &pool,
+        "CREATE TABLE dbo.t (id INT PRIMARY KEY, name NVARCHAR(255))",
+    )
+    .await;
 
     let scfg = upsert_sink_cfg(
         &cfg,

--- a/crates/sink/mssql/tests/exactly_once_upsert.rs
+++ b/crates/sink/mssql/tests/exactly_once_upsert.rs
@@ -1,0 +1,153 @@
+//! Composition test (#190): exactly-once delivery + `write_mode: upsert` for
+//! the Microsoft SQL Server sink, against a real SQL Server in Docker.
+//!
+//! Verifies that `write_batch_idempotent` routes through the upsert planner so
+//! the data write (MERGE) AND the commit-token watermark MERGE commit atomically
+//! in one `BEGIN TRAN`. Re-writing the same key in a later page (with a higher
+//! token) must UPDATE the row in place — not duplicate it — and advance the
+//! token.
+//!
+//! Requires Docker. The SQL Server image does not boot on Apple-Silicon hosts
+//! (QEMU); CI runs this test. Locally, `--no-run` confirms it compiles.
+
+use faucet_common_mssql::{MssqlConnectionConfig, MssqlPool, MssqlTls, MssqlTlsMode, build_pool};
+use faucet_core::{Sink, WriteMode, WriteSpec, format_token};
+use faucet_sink_mssql::{MssqlColumnMapping, MssqlSink, MssqlSinkConfig, OnUnknownField};
+use serde_json::json;
+use testcontainers_modules::mssql_server::MssqlServer;
+use testcontainers_modules::testcontainers::ContainerAsync;
+use testcontainers_modules::testcontainers::runners::AsyncRunner;
+
+const ENCODED_PW: &str = "yourStrong%28%21%29Password";
+
+// SQL Server containers need ~2 GB RAM each — serialize startups.
+static SERIAL: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+async fn start_mssql() -> (ContainerAsync<MssqlServer>, u16) {
+    let container = MssqlServer::default()
+        .with_accept_eula()
+        .start()
+        .await
+        .expect("start mssql container");
+    let port = container
+        .get_host_port_ipv4(1433)
+        .await
+        .expect("mssql host port");
+    (container, port)
+}
+
+fn conn_cfg(port: u16) -> MssqlConnectionConfig {
+    MssqlConnectionConfig {
+        connection_url: Some(format!("mssql://sa:{ENCODED_PW}@127.0.0.1:{port}/master")),
+        connection_string: None,
+        tls: MssqlTls {
+            mode: MssqlTlsMode::TrustServerCertificate,
+            ca_cert_path: None,
+        },
+    }
+}
+
+async fn exec(pool: &MssqlPool, sql: &str) {
+    let mut conn = pool.get().await.expect("checkout");
+    conn.execute(sql, &[]).await.expect("execute setup sql");
+}
+
+async fn count(pool: &MssqlPool, table: &str) -> i32 {
+    let mut conn = pool.get().await.expect("checkout");
+    let rows = conn
+        .query(format!("SELECT COUNT(*) AS c FROM {table}"), &[])
+        .await
+        .expect("count query")
+        .into_first_result()
+        .await
+        .expect("count result");
+    rows[0].get::<i32, _>("c").expect("count value")
+}
+
+async fn name_of(pool: &MssqlPool, table: &str, id: i32) -> String {
+    let mut conn = pool.get().await.expect("checkout");
+    let rows = conn
+        .query(format!("SELECT name FROM {table} WHERE id = @P1"), &[&id])
+        .await
+        .expect("name query")
+        .into_first_result()
+        .await
+        .expect("name result");
+    rows[0]
+        .get::<&str, _>("name")
+        .expect("name value")
+        .to_string()
+}
+
+fn upsert_sink_cfg(cfg: &MssqlConnectionConfig, write: WriteSpec) -> MssqlSinkConfig {
+    let mut s = MssqlSinkConfig::new(cfg.connection_url.clone().unwrap(), "dbo.t");
+    s.connection.tls = cfg.tls.clone();
+    s.column_mapping = MssqlColumnMapping::AutoColumns {
+        on_unknown_field: OnUnknownField::Warn,
+    };
+    s.write = write;
+    s
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn idempotent_upsert_updates_in_place_and_advances_token() {
+    let _serial = SERIAL.lock().await;
+    let (_c, port) = start_mssql().await;
+    let cfg = conn_cfg(port);
+    let pool = build_pool(&cfg, 4).await.expect("pool");
+    exec(&pool, "CREATE TABLE dbo.t (id INT PRIMARY KEY, name NVARCHAR(255))").await;
+
+    let scfg = upsert_sink_cfg(
+        &cfg,
+        WriteSpec {
+            write_mode: WriteMode::Upsert,
+            key: vec!["id".to_string()],
+            delete_marker: None,
+        },
+    );
+    let sink = MssqlSink::new(scfg).await.expect("sink");
+
+    let scope = "dbo.t::r1";
+    let t1 = format_token(1);
+    let t2 = format_token(2);
+
+    // Page 1, token ...0001: upsert id=1 -> "a" in the idempotent path.
+    let written = sink
+        .write_batch_idempotent(&[json!({"id": 1, "name": "a"})], scope, &t1)
+        .await
+        .expect("idempotent upsert 1");
+    assert_eq!(written, 1, "one upsert applied");
+    assert_eq!(
+        sink.last_committed_token(scope).await.expect("token read"),
+        Some(t1.clone()),
+        "token advanced to t1"
+    );
+    assert_eq!(count(&pool, "dbo.t").await, 1);
+    assert_eq!(name_of(&pool, "dbo.t", 1).await, "a");
+
+    // Page 2, token ...0002: upsert id=1 -> "b".
+    let written = sink
+        .write_batch_idempotent(&[json!({"id": 1, "name": "b"})], scope, &t2)
+        .await
+        .expect("idempotent upsert 2");
+    assert_eq!(written, 1, "one upsert applied (update in place)");
+
+    // Exactly ONE row id=1, now "b" — upserted in the idempotent path, not duplicated.
+    assert_eq!(
+        count(&pool, "dbo.t").await,
+        1,
+        "upsert in the idempotent path must update, not duplicate"
+    );
+    assert_eq!(
+        name_of(&pool, "dbo.t", 1).await,
+        "b",
+        "row must reflect the latest value 'b'"
+    );
+
+    // Token advanced to t2 — committed atomically with the upsert.
+    assert_eq!(
+        sink.last_committed_token(scope).await.expect("token read"),
+        Some(t2),
+        "token advanced to t2 alongside the upsert"
+    );
+}

--- a/crates/sink/mssql/tests/upsert.rs
+++ b/crates/sink/mssql/tests/upsert.rs
@@ -261,3 +261,43 @@ async fn new_rejects_upsert_with_json_column_mapping() {
         "error must mention auto_columns; got: {err}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Test 7: write_batch_partial routes missing-key rows to the DLQ per-row.
+// The good row is applied (upsert); only the missing-key row comes back Err.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn write_batch_partial_routes_missing_key_per_row() {
+    let _serial = SERIAL.lock().await;
+    let (_c, port) = start_mssql().await;
+    let cfg = conn_cfg(port);
+    let pool = build_pool(&cfg, 4).await.expect("pool");
+    exec(&pool, "CREATE TABLE dbo.t (id INT PRIMARY KEY, name NVARCHAR(255))").await;
+
+    let scfg = upsert_sink_cfg(
+        &cfg,
+        WriteSpec {
+            write_mode: WriteMode::Upsert,
+            key: vec!["id".to_string()],
+            delete_marker: None,
+        },
+    );
+    let sink = MssqlSink::new(scfg).await.expect("sink");
+
+    let records = [json!({"id": 1, "name": "ok"}), json!({"name": "missing-id"})];
+    let outcomes = sink
+        .write_batch_partial(&records)
+        .await
+        .expect("partial write");
+
+    assert_eq!(outcomes.len(), 2, "one outcome per input row");
+    assert!(outcomes[0].is_ok(), "the good row must be Ok");
+    assert!(
+        outcomes[1].is_err(),
+        "the missing-key row must be Err (routed to the DLQ)"
+    );
+
+    assert_eq!(count(&pool, "dbo.t").await, 1, "only the good row is written");
+    assert_eq!(name_of(&pool, "dbo.t", 1).await, "ok", "id=1 → name 'ok'");
+}

--- a/crates/sink/mssql/tests/upsert.rs
+++ b/crates/sink/mssql/tests/upsert.rs
@@ -97,7 +97,11 @@ async fn upsert_second_write_updates_existing_row() {
     let (_c, port) = start_mssql().await;
     let cfg = conn_cfg(port);
     let pool = build_pool(&cfg, 4).await.expect("pool");
-    exec(&pool, "CREATE TABLE dbo.t (id INT PRIMARY KEY, name NVARCHAR(255))").await;
+    exec(
+        &pool,
+        "CREATE TABLE dbo.t (id INT PRIMARY KEY, name NVARCHAR(255))",
+    )
+    .await;
 
     let scfg = upsert_sink_cfg(
         &cfg,
@@ -130,7 +134,11 @@ async fn upsert_with_delete_marker_removes_row() {
     let (_c, port) = start_mssql().await;
     let cfg = conn_cfg(port);
     let pool = build_pool(&cfg, 4).await.expect("pool");
-    exec(&pool, "CREATE TABLE dbo.t (id INT PRIMARY KEY, name NVARCHAR(255))").await;
+    exec(
+        &pool,
+        "CREATE TABLE dbo.t (id INT PRIMARY KEY, name NVARCHAR(255))",
+    )
+    .await;
 
     let scfg = upsert_sink_cfg(
         &cfg,
@@ -168,7 +176,11 @@ async fn upsert_same_key_twice_in_one_batch_last_write_wins() {
     let (_c, port) = start_mssql().await;
     let cfg = conn_cfg(port);
     let pool = build_pool(&cfg, 4).await.expect("pool");
-    exec(&pool, "CREATE TABLE dbo.t (id INT PRIMARY KEY, name NVARCHAR(255))").await;
+    exec(
+        &pool,
+        "CREATE TABLE dbo.t (id INT PRIMARY KEY, name NVARCHAR(255))",
+    )
+    .await;
 
     let scfg = upsert_sink_cfg(
         &cfg,
@@ -273,7 +285,11 @@ async fn write_batch_partial_routes_missing_key_per_row() {
     let (_c, port) = start_mssql().await;
     let cfg = conn_cfg(port);
     let pool = build_pool(&cfg, 4).await.expect("pool");
-    exec(&pool, "CREATE TABLE dbo.t (id INT PRIMARY KEY, name NVARCHAR(255))").await;
+    exec(
+        &pool,
+        "CREATE TABLE dbo.t (id INT PRIMARY KEY, name NVARCHAR(255))",
+    )
+    .await;
 
     let scfg = upsert_sink_cfg(
         &cfg,
@@ -285,7 +301,10 @@ async fn write_batch_partial_routes_missing_key_per_row() {
     );
     let sink = MssqlSink::new(scfg).await.expect("sink");
 
-    let records = [json!({"id": 1, "name": "ok"}), json!({"name": "missing-id"})];
+    let records = [
+        json!({"id": 1, "name": "ok"}),
+        json!({"name": "missing-id"}),
+    ];
     let outcomes = sink
         .write_batch_partial(&records)
         .await
@@ -298,6 +317,10 @@ async fn write_batch_partial_routes_missing_key_per_row() {
         "the missing-key row must be Err (routed to the DLQ)"
     );
 
-    assert_eq!(count(&pool, "dbo.t").await, 1, "only the good row is written");
+    assert_eq!(
+        count(&pool, "dbo.t").await,
+        1,
+        "only the good row is written"
+    );
     assert_eq!(name_of(&pool, "dbo.t", 1).await, "ok", "id=1 → name 'ok'");
 }

--- a/crates/sink/mssql/tests/upsert.rs
+++ b/crates/sink/mssql/tests/upsert.rs
@@ -1,0 +1,263 @@
+//! Integration tests for `MssqlSink` upsert / delete write modes against a real
+//! Microsoft SQL Server in Docker (`mcr.microsoft.com/mssql/server`).
+//!
+//! Run with `cargo test -p faucet-sink-mssql --test upsert`. Each test boots a
+//! container (serialized via `SERIAL` — SQL Server needs ~2 GB RAM each) and
+//! creates `CREATE TABLE dbo.t (id INT PRIMARY KEY, name NVARCHAR(255))`.
+
+use faucet_common_mssql::{MssqlConnectionConfig, MssqlPool, MssqlTls, MssqlTlsMode, build_pool};
+use faucet_core::{Sink, WriteMode, WriteSpec};
+use faucet_sink_mssql::{MssqlColumnMapping, MssqlSink, MssqlSinkConfig, OnUnknownField};
+use serde_json::json;
+use testcontainers_modules::mssql_server::MssqlServer;
+use testcontainers_modules::testcontainers::ContainerAsync;
+use testcontainers_modules::testcontainers::runners::AsyncRunner;
+
+const ENCODED_PW: &str = "yourStrong%28%21%29Password";
+
+// SQL Server containers need ~2 GB RAM each. `cargo test` runs a binary's tests
+// in parallel, so without this guard they would all start a container at once
+// and exhaust the runner. Serialize: at most one container at a time.
+static SERIAL: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+async fn start_mssql() -> (ContainerAsync<MssqlServer>, u16) {
+    let container = MssqlServer::default()
+        .with_accept_eula()
+        .start()
+        .await
+        .expect("start mssql container");
+    let port = container
+        .get_host_port_ipv4(1433)
+        .await
+        .expect("mssql host port");
+    (container, port)
+}
+
+fn conn_cfg(port: u16) -> MssqlConnectionConfig {
+    MssqlConnectionConfig {
+        connection_url: Some(format!("mssql://sa:{ENCODED_PW}@127.0.0.1:{port}/master")),
+        connection_string: None,
+        tls: MssqlTls {
+            mode: MssqlTlsMode::TrustServerCertificate,
+            ca_cert_path: None,
+        },
+    }
+}
+
+async fn exec(pool: &MssqlPool, sql: &str) {
+    let mut conn = pool.get().await.expect("checkout");
+    conn.execute(sql, &[]).await.expect("execute setup sql");
+}
+
+async fn count(pool: &MssqlPool, table: &str) -> i32 {
+    let mut conn = pool.get().await.expect("checkout");
+    let rows = conn
+        .query(format!("SELECT COUNT(*) AS c FROM {table}"), &[])
+        .await
+        .expect("count query")
+        .into_first_result()
+        .await
+        .expect("count result");
+    rows[0].get::<i32, _>("c").expect("count value")
+}
+
+async fn name_of(pool: &MssqlPool, table: &str, id: i32) -> String {
+    let mut conn = pool.get().await.expect("checkout");
+    let rows = conn
+        .query(format!("SELECT name FROM {table} WHERE id = @P1"), &[&id])
+        .await
+        .expect("name query")
+        .into_first_result()
+        .await
+        .expect("name result");
+    rows[0]
+        .get::<&str, _>("name")
+        .expect("name value")
+        .to_string()
+}
+
+/// Build an upsert sink targeting `dbo.t` with `auto_columns` mapping.
+fn upsert_sink_cfg(cfg: &MssqlConnectionConfig, write: WriteSpec) -> MssqlSinkConfig {
+    let mut s = MssqlSinkConfig::new(cfg.connection_url.clone().unwrap(), "dbo.t");
+    s.connection.tls = cfg.tls.clone();
+    s.column_mapping = MssqlColumnMapping::AutoColumns {
+        on_unknown_field: OnUnknownField::Warn,
+    };
+    s.write = write;
+    s
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: second upsert with the same key updates the row (last-write-wins)
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn upsert_second_write_updates_existing_row() {
+    let _serial = SERIAL.lock().await;
+    let (_c, port) = start_mssql().await;
+    let cfg = conn_cfg(port);
+    let pool = build_pool(&cfg, 4).await.expect("pool");
+    exec(&pool, "CREATE TABLE dbo.t (id INT PRIMARY KEY, name NVARCHAR(255))").await;
+
+    let scfg = upsert_sink_cfg(
+        &cfg,
+        WriteSpec {
+            write_mode: WriteMode::Upsert,
+            key: vec!["id".to_string()],
+            delete_marker: None,
+        },
+    );
+    let sink = MssqlSink::new(scfg).await.expect("sink");
+
+    sink.write_batch(&[json!({"id": 1, "name": "alice"})])
+        .await
+        .expect("first write");
+    sink.write_batch(&[json!({"id": 1, "name": "alice2"})])
+        .await
+        .expect("second write");
+
+    assert_eq!(count(&pool, "dbo.t").await, 1, "upsert must not duplicate");
+    assert_eq!(name_of(&pool, "dbo.t", 1).await, "alice2", "name updated");
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: delete_marker routes a row to delete; the table ends up empty
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn upsert_with_delete_marker_removes_row() {
+    let _serial = SERIAL.lock().await;
+    let (_c, port) = start_mssql().await;
+    let cfg = conn_cfg(port);
+    let pool = build_pool(&cfg, 4).await.expect("pool");
+    exec(&pool, "CREATE TABLE dbo.t (id INT PRIMARY KEY, name NVARCHAR(255))").await;
+
+    let scfg = upsert_sink_cfg(
+        &cfg,
+        WriteSpec {
+            write_mode: WriteMode::Upsert,
+            key: vec!["id".to_string()],
+            delete_marker: Some(faucet_core::DeleteMarker {
+                field: "__op".to_string(),
+                values: vec!["d".to_string()],
+            }),
+        },
+    );
+    let sink = MssqlSink::new(scfg).await.expect("sink");
+
+    // Insert the row first (marker field stripped from the upsert).
+    sink.write_batch(&[json!({"id": 1, "name": "x", "__op": "u"})])
+        .await
+        .expect("insert");
+    assert_eq!(count(&pool, "dbo.t").await, 1, "row present after upsert");
+
+    // Delete it via the marker.
+    sink.write_batch(&[json!({"id": 1, "__op": "d"})])
+        .await
+        .expect("delete");
+    assert_eq!(count(&pool, "dbo.t").await, 0, "row deleted via marker");
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: same key twice in one batch → last-write-wins (count 1, name "new")
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn upsert_same_key_twice_in_one_batch_last_write_wins() {
+    let _serial = SERIAL.lock().await;
+    let (_c, port) = start_mssql().await;
+    let cfg = conn_cfg(port);
+    let pool = build_pool(&cfg, 4).await.expect("pool");
+    exec(&pool, "CREATE TABLE dbo.t (id INT PRIMARY KEY, name NVARCHAR(255))").await;
+
+    let scfg = upsert_sink_cfg(
+        &cfg,
+        WriteSpec {
+            write_mode: WriteMode::Upsert,
+            key: vec!["id".to_string()],
+            delete_marker: None,
+        },
+    );
+    let sink = MssqlSink::new(scfg).await.expect("sink");
+
+    // Two records with the same id in one batch — the planner dedups so the
+    // MERGE source never double-hits the same key (MERGE rejects that).
+    sink.write_batch(&[
+        json!({"id": 1, "name": "old"}),
+        json!({"id": 1, "name": "new"}),
+    ])
+    .await
+    .expect("batch write");
+
+    assert_eq!(count(&pool, "dbo.t").await, 1, "dedup collapses to one row");
+    assert_eq!(name_of(&pool, "dbo.t", 1).await, "new", "last-write-wins");
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: supported_write_modes advertises Append, Upsert, Delete
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn supported_write_modes_includes_upsert_and_delete() {
+    let _serial = SERIAL.lock().await;
+    let (_c, port) = start_mssql().await;
+    let cfg = conn_cfg(port);
+
+    let mut scfg = MssqlSinkConfig::new(cfg.connection_url.clone().unwrap(), "dbo.t");
+    scfg.connection.tls = cfg.tls.clone();
+    let sink = MssqlSink::new(scfg).await.expect("sink");
+
+    let modes = sink.supported_write_modes();
+    assert!(modes.contains(&WriteMode::Append));
+    assert!(modes.contains(&WriteMode::Upsert));
+    assert!(modes.contains(&WriteMode::Delete));
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: config validation rejects upsert without a key (no container needed —
+//         the error fires before the connection attempt).
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn new_rejects_upsert_without_key() {
+    let mut config = MssqlSinkConfig::new("mssql://sa:pw@127.0.0.1:11433/master", "dbo.t");
+    config.column_mapping = MssqlColumnMapping::AutoColumns {
+        on_unknown_field: OnUnknownField::Warn,
+    };
+    config.write = WriteSpec {
+        write_mode: WriteMode::Upsert,
+        key: vec![], // missing key → rejected before any connection attempt
+        delete_marker: None,
+    };
+
+    let err = MssqlSink::new(config)
+        .await
+        .err()
+        .expect("must fail without key");
+    assert!(err.to_string().contains("non-empty `key`"), "got: {err}");
+}
+
+// ---------------------------------------------------------------------------
+// Test 6: config validation rejects upsert with json_column mapping (no
+//         container needed; fires before the connection attempt).
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn new_rejects_upsert_with_json_column_mapping() {
+    // Default column_mapping is json_column — upsert must be rejected.
+    let mut config = MssqlSinkConfig::new("mssql://sa:pw@127.0.0.1:11433/master", "dbo.t");
+    config.write = WriteSpec {
+        write_mode: WriteMode::Upsert,
+        key: vec!["id".to_string()],
+        delete_marker: None,
+    };
+
+    let err = MssqlSink::new(config)
+        .await
+        .err()
+        .expect("must fail with json_column mapping");
+    assert!(
+        err.to_string().contains("auto_columns"),
+        "error must mention auto_columns; got: {err}"
+    );
+}

--- a/crates/sink/mysql/README.md
+++ b/crates/sink/mysql/README.md
@@ -60,6 +60,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 | `column_mapping` | `MysqlColumnMapping` | `Json { column: "data" }` | How to map JSON records to table columns (see below) |
 | `batch_size` | `usize` | `1000` | Maximum rows per multi-row `INSERT`. See [Streaming and batching](#streaming-and-batching) below |
 | `max_connections` | `u32` | `5` | Maximum number of connections in the connection pool |
+| `write_mode` | `"append"` \| `"upsert"` \| `"delete"` | `"append"` | Write semantics. `upsert`/`delete` require `column_mapping: auto_map` and a non-empty `key`. See [Write modes](#write-modes-upsert--delete). |
+| `key` | `[String]` | `[]` | Key columns for `upsert`/`delete`. The table must have a PRIMARY or UNIQUE index on these columns. |
+| `delete_marker` | `{ field, values }` | *(none)* | Upsert-only: rows whose `field` matches one of `values` are treated as deletes; all others are upserts. The marker field is stripped before writing. |
 
 The `Debug` implementation masks the `connection_url` with `***` to prevent credential leakage in logs.
 
@@ -268,6 +271,51 @@ let sink = MysqlSink::new(config).await?;
 - In JSON mode, each record is serialized to a JSON string and inserted as `INSERT INTO t (col) VALUES (?), (?), ...`.
 - In AutoMap mode, column names are queried from `INFORMATION_SCHEMA.COLUMNS` for the current database. A multi-row INSERT is built dynamically with `?` placeholders. Column values are bound as **native MySQL types** (#78/#4). The column set is the **union** of record keys across the batch, so a field present only in a later record is still written; a row missing a column binds SQL `NULL`. The INSERT is sub-chunked so `rows × columns` never exceeds MySQL's 65,535-placeholder limit.
 - All identifiers (table names, column names) are quoted with backticks using MySQL-safe escaping (embedded backticks are doubled).
+
+## Write modes (upsert / delete)
+
+`MysqlSink` supports `write_mode: upsert` and `write_mode: delete` in addition to the default `write_mode: append`.
+
+**Requirements:**
+- `column_mapping` must be `auto_map` — key columns must be real table columns, not packed inside a JSON blob.
+- `key` must be a non-empty list of column names.
+- The target table must have a **PRIMARY or UNIQUE key** on those columns. MySQL's `ON DUPLICATE KEY UPDATE` detects conflicts via that index — the `key` config field drives which columns are updated, not which index is used. All non-key columns in the INSERT are set from `VALUES(col)`.
+
+**`write_mode: upsert`** — each record is INSERT … ON DUPLICATE KEY UPDATE (last-write-wins). Optionally, a `delete_marker` field routes certain records to deletes instead:
+
+```yaml
+pipeline:
+  sink:
+    type: mysql
+    config:
+      connection_url: mysql://writer:pass@localhost:3306/warehouse
+      table_name: products
+      column_mapping: auto_map
+      write_mode: upsert
+      key: [id]
+      delete_marker:
+        field: __op
+        values: [d, delete]
+```
+
+**`write_mode: delete`** — every record in the page is deleted by its key:
+
+```yaml
+pipeline:
+  sink:
+    type: mysql
+    config:
+      connection_url: mysql://writer:pass@localhost:3306/warehouse
+      table_name: products
+      column_mapping: auto_map
+      write_mode: delete
+      key: [id]
+```
+
+**Behaviour:**
+- The planner (`plan_writes`) deduplicates within each page (last-write-wins), so a page that contains the same key twice produces exactly one MySQL statement touching that row.
+- Upserts and deletes within a page are applied inside **one transaction**, so they commit atomically or not at all.
+- The `delete_marker` field is stripped from upsert records before writing.
 
 ## Exactly-once delivery
 

--- a/crates/sink/mysql/README.md
+++ b/crates/sink/mysql/README.md
@@ -280,6 +280,7 @@ let sink = MysqlSink::new(config).await?;
 - `column_mapping` must be `auto_map` — key columns must be real table columns, not packed inside a JSON blob.
 - `key` must be a non-empty list of column names.
 - The target table must have a **PRIMARY or UNIQUE key** on those columns. MySQL's `ON DUPLICATE KEY UPDATE` detects conflicts via that index — the `key` config field drives which columns are updated, not which index is used. All non-key columns in the INSERT are set from `VALUES(col)`.
+- A row missing or null in a key column fails. When a `dlq:` block is configured the good rows are still written and only the missing/null-key rows are routed to the DLQ per-row; without a DLQ the whole batch fails.
 
 **`write_mode: upsert`** — each record is INSERT … ON DUPLICATE KEY UPDATE (last-write-wins). Optionally, a `delete_marker` field routes certain records to deletes instead:
 

--- a/crates/sink/mysql/src/config.rs
+++ b/crates/sink/mysql/src/config.rs
@@ -1,6 +1,6 @@
 //! MySQL sink configuration.
 
-use faucet_core::DEFAULT_BATCH_SIZE;
+use faucet_core::{DEFAULT_BATCH_SIZE, WriteSpec};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -51,6 +51,15 @@ pub struct MysqlSinkConfig {
     pub batch_size: usize,
     /// Maximum number of connections in the pool. Defaults to 5.
     pub max_connections: u32,
+    /// Write mode: `append` (default), `upsert`, or `delete`.
+    ///
+    /// `upsert` and `delete` require `column_mapping: auto_map` (key columns
+    /// must be real table columns, not packed inside a JSON blob) and a
+    /// non-empty `key` list. The table must already have a PRIMARY or UNIQUE
+    /// index on the key columns; MySQL's `ON DUPLICATE KEY UPDATE` uses that
+    /// index to detect conflicts.
+    #[serde(flatten)]
+    pub write: WriteSpec,
 }
 
 fn default_batch_size() -> usize {
@@ -78,6 +87,7 @@ impl MysqlSinkConfig {
             column_mapping: MysqlColumnMapping::default(),
             batch_size: DEFAULT_BATCH_SIZE,
             max_connections: 5,
+            write: WriteSpec::default(),
         }
     }
 

--- a/crates/sink/mysql/src/sink.rs
+++ b/crates/sink/mysql/src/sink.rs
@@ -535,17 +535,55 @@ impl faucet_core::Sink for MysqlSink {
         token: &str,
     ) -> Result<usize, FaucetError> {
         self.ensure_commit_table().await?;
+
+        // For upsert/delete modes, plan the page before opening the transaction
+        // so a key-extraction failure aborts without leaving an open tx.
+        let plan = if matches!(self.config.write.write_mode, faucet_core::WriteMode::Append) {
+            None
+        } else {
+            let plan = faucet_core::plan_writes(records, &self.config.write);
+            if let Some((idx, msg)) = plan.failed.first() {
+                return Err(FaucetError::Sink(format!(
+                    "mysql {}: row {idx}: {msg}",
+                    self.config.write.write_mode.as_str()
+                )));
+            }
+            Some(plan)
+        };
+
         let mut tx = self
             .pool
             .begin()
             .await
             .map_err(|e| FaucetError::Sink(format!("MySQL transaction begin failed: {e}")))?;
 
-        let written = match &self.config.column_mapping {
-            MysqlColumnMapping::Json { column } => {
-                self.insert_json(&mut tx, records, column).await?
+        // Data write and the commit-token upsert share ONE transaction so the
+        // page is committed atomically with its watermark. For upsert/delete the
+        // planned upserts/deletes commit together with the watermark in this same
+        // tx (no nested tx — the helpers run on this transaction's connection).
+        let written = match &plan {
+            Some(plan) => {
+                let mut affected = 0usize;
+                if !plan.upserts.is_empty() {
+                    affected += self
+                        .insert_auto_map_with_conflict(
+                            &mut tx,
+                            &plan.upserts,
+                            Some(&self.config.write.key),
+                        )
+                        .await?;
+                }
+                if !plan.deletes.is_empty() {
+                    affected += self.delete_by_keys(&mut tx, &plan.deletes).await?;
+                }
+                affected
             }
-            MysqlColumnMapping::AutoMap => self.insert_auto_map(&mut tx, records).await?,
+            None => match &self.config.column_mapping {
+                MysqlColumnMapping::Json { column } => {
+                    self.insert_json(&mut tx, records, column).await?
+                }
+                MysqlColumnMapping::AutoMap => self.insert_auto_map(&mut tx, records).await?,
+            },
         };
 
         let upsert = format!(

--- a/crates/sink/mysql/src/sink.rs
+++ b/crates/sink/mysql/src/sink.rs
@@ -508,6 +508,36 @@ impl faucet_core::Sink for MysqlSink {
         Ok(total)
     }
 
+    /// Write a batch and report per-row outcomes.
+    ///
+    /// In append mode this delegates to [`write_batch`](Self::write_batch) and
+    /// maps a single success onto an all-`Ok(())` vector (the trait default).
+    /// In upsert/delete mode the good rows are applied (upserts + deletes), and
+    /// only the rows whose key could not be extracted (missing / null key) are
+    /// reported as `Err` so the pipeline routes them to the DLQ per-row instead
+    /// of sending the whole page.
+    async fn write_batch_partial(
+        &self,
+        records: &[Value],
+    ) -> Result<Vec<faucet_core::RowOutcome>, FaucetError> {
+        if matches!(self.config.write.write_mode, faucet_core::WriteMode::Append) {
+            self.write_batch(records).await?;
+            return Ok(records.iter().map(|_| Ok(())).collect());
+        }
+
+        let plan = faucet_core::plan_writes(records, &self.config.write);
+        self.apply_plan(&plan).await?;
+
+        let mut outcomes: Vec<faucet_core::RowOutcome> = records.iter().map(|_| Ok(())).collect();
+        for (idx, msg) in &plan.failed {
+            outcomes[*idx] = Err(FaucetError::Sink(format!(
+                "mysql {}: {msg}",
+                self.config.write.write_mode.as_str()
+            )));
+        }
+        Ok(outcomes)
+    }
+
     fn supports_idempotent_writes(&self) -> bool {
         true
     }

--- a/crates/sink/mysql/src/sink.rs
+++ b/crates/sink/mysql/src/sink.rs
@@ -220,10 +220,7 @@ impl MysqlSink {
                 value_tuples.join(", ")
             );
             let query = match conflict_key {
-                Some(key) => format!(
-                    "{base_query} {}",
-                    on_duplicate_clause(key, &insert_columns)
-                ),
+                Some(key) => format!("{base_query} {}", on_duplicate_clause(key, &insert_columns)),
                 None => base_query,
             };
 
@@ -353,11 +350,7 @@ impl MysqlSink {
         let mut affected = 0usize;
         if !plan.upserts.is_empty() {
             affected += self
-                .insert_auto_map_with_conflict(
-                    &mut tx,
-                    &plan.upserts,
-                    Some(&self.config.write.key),
-                )
+                .insert_auto_map_with_conflict(&mut tx, &plan.upserts, Some(&self.config.write.key))
                 .await?;
         }
         if !plan.deletes.is_empty() {
@@ -674,10 +667,8 @@ mod tests {
 
     #[test]
     fn mysql_on_duplicate_clause() {
-        let clause = on_duplicate_clause(
-            &["id".to_string()],
-            &["id".to_string(), "name".to_string()],
-        );
+        let clause =
+            on_duplicate_clause(&["id".to_string()], &["id".to_string(), "name".to_string()]);
         assert_eq!(clause, "ON DUPLICATE KEY UPDATE `name` = VALUES(`name`)");
     }
 

--- a/crates/sink/mysql/src/sink.rs
+++ b/crates/sink/mysql/src/sink.rs
@@ -503,7 +503,7 @@ impl faucet_core::Sink for MysqlSink {
 
     /// Write a batch and report per-row outcomes.
     ///
-    /// In append mode this delegates to [`write_batch`](Self::write_batch) and
+    /// In append mode this delegates to [`write_batch`](faucet_core::Sink::write_batch) and
     /// maps a single success onto an all-`Ok(())` vector (the trait default).
     /// In upsert/delete mode the good rows are applied (upserts + deletes), and
     /// only the rows whose key could not be extracted (missing / null key) are

--- a/crates/sink/mysql/src/sink.rs
+++ b/crates/sink/mysql/src/sink.rs
@@ -21,9 +21,44 @@ fn quote_ident_mysql(name: &str) -> String {
     format!("`{}`", name.replace('`', "``"))
 }
 
+/// Build the `ON DUPLICATE KEY UPDATE …` tail for an upsert INSERT.
+///
+/// MySQL's `ON DUPLICATE KEY UPDATE` does not name a conflict target — it
+/// relies on the table's existing PRIMARY or UNIQUE key. Non-key columns are
+/// set from `VALUES(col)`. If every column is a key column there is nothing to
+/// update, so a self-assignment no-op on the first key column is emitted to
+/// keep the statement syntactically valid.
+fn on_duplicate_clause(key: &[String], all_cols: &[String]) -> String {
+    let updates: Vec<String> = all_cols
+        .iter()
+        .filter(|c| !key.iter().any(|k| k == *c))
+        .map(|c| {
+            let q = quote_ident_mysql(c);
+            format!("{q} = VALUES({q})")
+        })
+        .collect();
+    if updates.is_empty() {
+        let q = quote_ident_mysql(&key[0]);
+        format!("ON DUPLICATE KEY UPDATE {q} = {q}")
+    } else {
+        format!("ON DUPLICATE KEY UPDATE {}", updates.join(", "))
+    }
+}
+
 impl MysqlSink {
     /// Create a new MySQL sink. Establishes a connection pool.
     pub async fn new(config: MysqlSinkConfig) -> Result<Self, FaucetError> {
+        config.write.validate()?;
+        if !matches!(config.write.write_mode, faucet_core::WriteMode::Append)
+            && !matches!(config.column_mapping, MysqlColumnMapping::AutoMap)
+        {
+            return Err(FaucetError::Config(
+                "mysql sink: write_mode upsert/delete requires column_mapping: auto_map \
+                 (key columns must be real columns, not inside a JSON blob)"
+                    .into(),
+            ));
+        }
+
         let pool = MySqlPoolOptions::new()
             .max_connections(config.max_connections)
             .connect(&config.connection_url)
@@ -71,16 +106,24 @@ impl MysqlSink {
         Ok(records.len())
     }
 
-    /// Insert a batch of records using auto-mapped columns.
+    /// Core auto-map insert logic, optionally appending an `ON DUPLICATE KEY
+    /// UPDATE …` clause when `conflict_key` is `Some`.
     ///
-    /// Discovers column names from INFORMATION_SCHEMA and maps top-level JSON
-    /// fields to columns. Executes on the provided connection (a bare pool
-    /// connection for `write_batch`, or a `&mut *tx` transaction for
-    /// `write_batch_idempotent`). Uses a single multi-row INSERT.
-    async fn insert_auto_map(
+    /// Discovers column names from `INFORMATION_SCHEMA.COLUMNS` and maps
+    /// top-level JSON fields to columns. Executes on the provided connection
+    /// (a bare pool connection for `write_batch`, or `&mut *tx` for
+    /// transactional paths). Uses sub-chunked multi-row INSERTs.
+    ///
+    /// When `conflict_key` is `Some(key)`, each sub-chunk's INSERT is given an
+    /// `ON DUPLICATE KEY UPDATE …` tail so it upserts by the existing PRIMARY
+    /// or UNIQUE key (last-write-wins within the batch is handled by the
+    /// planner's dedup, so a single sub-chunk never double-hits the same
+    /// conflict target).
+    async fn insert_auto_map_with_conflict(
         &self,
         conn: &mut MySqlConnection,
         records: &[Value],
+        conflict_key: Option<&[String]>,
     ) -> Result<usize, FaucetError> {
         if records.is_empty() {
             return Ok(0);
@@ -170,13 +213,19 @@ impl MysqlSink {
             let row_placeholder = format!("({})", vec!["?"; num_cols].join(", "));
             let value_tuples: Vec<&str> =
                 (0..sub.len()).map(|_| row_placeholder.as_str()).collect();
-
-            let query = format!(
+            let base_query = format!(
                 "INSERT INTO {} ({}) VALUES {}",
                 quote_ident_mysql(&self.config.table_name),
                 col_names.join(", "),
                 value_tuples.join(", ")
             );
+            let query = match conflict_key {
+                Some(key) => format!(
+                    "{base_query} {}",
+                    on_duplicate_clause(key, &insert_columns)
+                ),
+                None => base_query,
+            };
 
             let mut q = sqlx::query(&query);
             for matched in sub {
@@ -213,6 +262,112 @@ impl MysqlSink {
         }
 
         Ok(num_rows)
+    }
+
+    /// Auto-map insert with plain append semantics (no `ON DUPLICATE KEY`
+    /// clause). Thin wrapper over
+    /// [`insert_auto_map_with_conflict`](Self::insert_auto_map_with_conflict)
+    /// so the append path and `write_batch_idempotent` keep their original
+    /// signature.
+    async fn insert_auto_map(
+        &self,
+        conn: &mut MySqlConnection,
+        records: &[Value],
+    ) -> Result<usize, FaucetError> {
+        self.insert_auto_map_with_conflict(conn, records, None)
+            .await
+    }
+
+    /// Delete rows whose key columns match any of `deletes`, using
+    /// `DELETE FROM t WHERE (k1, …) IN ((?, …), …)`, chunked at MySQL's
+    /// 65535-placeholder limit. Runs inside the caller's transaction.
+    async fn delete_by_keys(
+        &self,
+        conn: &mut MySqlConnection,
+        deletes: &[faucet_core::KeyTuple],
+    ) -> Result<usize, FaucetError> {
+        if deletes.is_empty() {
+            return Ok(0);
+        }
+        let key = &self.config.write.key;
+        let table_ref = quote_ident_mysql(&self.config.table_name);
+        let col_list = key
+            .iter()
+            .map(|k| quote_ident_mysql(k))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        const MAX_MYSQL_PARAMS: usize = 65535;
+        let per = (MAX_MYSQL_PARAMS / key.len().max(1)).max(1);
+        let mut total = 0usize;
+
+        for chunk in deletes.chunks(per) {
+            let tuples: Vec<String> = chunk
+                .iter()
+                .map(|_| format!("({})", vec!["?"; key.len()].join(", ")))
+                .collect();
+            let sql = format!(
+                "DELETE FROM {table_ref} WHERE ({col_list}) IN ({})",
+                tuples.join(", ")
+            );
+            let mut q = sqlx::query(&sql);
+            for kt in chunk {
+                for (_, v) in &kt.0 {
+                    // Bind native MySQL types — same logic as in the INSERT path.
+                    q = match v {
+                        Value::Null => q.bind(None::<String>),
+                        Value::Bool(b) => q.bind(*b),
+                        Value::Number(n) => {
+                            if let Some(i) = n.as_i64() {
+                                q.bind(i)
+                            } else if let Some(f) = n.as_f64() {
+                                q.bind(f)
+                            } else {
+                                q.bind(n.to_string())
+                            }
+                        }
+                        Value::String(s) => q.bind(s.clone()),
+                        other => q.bind(other.to_string()),
+                    };
+                }
+            }
+            let res = q
+                .execute(&mut *conn)
+                .await
+                .map_err(|e| FaucetError::Sink(format!("MySQL delete failed: {e}")))?;
+            total += res.rows_affected() as usize;
+        }
+        Ok(total)
+    }
+
+    /// Apply a planned upsert/delete batch inside one `BEGIN`/`COMMIT`
+    /// transaction. Upserts and deletes are wrapped together so they commit
+    /// atomically.
+    async fn apply_plan(&self, plan: &faucet_core::WritePlan) -> Result<usize, FaucetError> {
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| FaucetError::Sink(format!("MySQL transaction begin failed: {e}")))?;
+
+        let mut affected = 0usize;
+        if !plan.upserts.is_empty() {
+            affected += self
+                .insert_auto_map_with_conflict(
+                    &mut tx,
+                    &plan.upserts,
+                    Some(&self.config.write.key),
+                )
+                .await?;
+        }
+        if !plan.deletes.is_empty() {
+            affected += self.delete_by_keys(&mut tx, &plan.deletes).await?;
+        }
+
+        tx.commit()
+            .await
+            .map_err(|e| FaucetError::Sink(format!("MySQL transaction commit failed: {e}")))?;
+        Ok(affected)
     }
 
     /// Create the commit-token watermark table if it does not yet exist.
@@ -283,6 +438,14 @@ impl faucet_core::Sink for MysqlSink {
         Ok(CheckReport::single(probe))
     }
 
+    fn supported_write_modes(&self) -> &'static [faucet_core::WriteMode] {
+        &[
+            faucet_core::WriteMode::Append,
+            faucet_core::WriteMode::Upsert,
+            faucet_core::WriteMode::Delete,
+        ]
+    }
+
     /// Write records to MySQL.
     ///
     /// When `config.batch_size > 0` and the input slice is larger than
@@ -298,6 +461,18 @@ impl faucet_core::Sink for MysqlSink {
     async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
         if records.is_empty() {
             return Ok(0);
+        }
+
+        // Non-append modes: plan the writes and apply atomically.
+        if !matches!(self.config.write.write_mode, faucet_core::WriteMode::Append) {
+            let plan = faucet_core::plan_writes(records, &self.config.write);
+            if let Some((idx, msg)) = plan.failed.first() {
+                return Err(FaucetError::Sink(format!(
+                    "mysql {}: row {idx}: {msg}",
+                    self.config.write.write_mode.as_str()
+                )));
+            }
+            return self.apply_plan(&plan).await;
         }
 
         let mut conn = self
@@ -427,5 +602,29 @@ mod tests {
     #[test]
     fn quote_ident_mysql_special_chars() {
         assert_eq!(quote_ident_mysql("table; DROP"), "`table; DROP`");
+    }
+
+    #[test]
+    fn mysql_on_duplicate_clause() {
+        let clause = on_duplicate_clause(
+            &["id".to_string()],
+            &["id".to_string(), "name".to_string()],
+        );
+        assert_eq!(clause, "ON DUPLICATE KEY UPDATE `name` = VALUES(`name`)");
+    }
+
+    #[test]
+    fn mysql_on_duplicate_all_keys_self_assign() {
+        let clause = on_duplicate_clause(&["id".to_string()], &["id".to_string()]);
+        assert_eq!(clause, "ON DUPLICATE KEY UPDATE `id` = `id`");
+    }
+
+    #[test]
+    fn mysql_on_duplicate_composite_key_partial_update() {
+        let clause = on_duplicate_clause(
+            &["a".to_string(), "b".to_string()],
+            &["a".to_string(), "b".to_string(), "v".to_string()],
+        );
+        assert_eq!(clause, "ON DUPLICATE KEY UPDATE `v` = VALUES(`v`)");
     }
 }

--- a/crates/sink/mysql/tests/exactly_once_upsert.rs
+++ b/crates/sink/mysql/tests/exactly_once_upsert.rs
@@ -1,0 +1,134 @@
+//! Composition test (#190): exactly-once delivery + `write_mode: upsert` for
+//! the MySQL sink, against a real MySQL instance via testcontainers.
+//!
+//! Verifies that `write_batch_idempotent` routes through the upsert planner so
+//! the data write AND the commit-token watermark commit atomically in one
+//! transaction. Re-writing the same key in a later page (with a higher token)
+//! must UPDATE the row in place — not duplicate it — and advance the token.
+//!
+//! Requires Docker. Boots its own container so it is isolated.
+
+use faucet_core::{Sink, WriteMode, WriteSpec, format_token};
+use faucet_sink_mysql::{MysqlColumnMapping, MysqlSink, MysqlSinkConfig};
+use serde_json::json;
+use sqlx::Row;
+use std::sync::OnceLock;
+use testcontainers::{ContainerAsync, runners::AsyncRunner};
+use testcontainers_modules::mysql::Mysql;
+use tokio::sync::Semaphore;
+
+/// Bounds concurrent MySQL container startups (see `upsert.rs` for rationale).
+fn startup_limit() -> &'static Semaphore {
+    static SEM: OnceLock<Semaphore> = OnceLock::new();
+    SEM.get_or_init(|| Semaphore::new(2))
+}
+
+async fn start_mysql() -> (ContainerAsync<Mysql>, String) {
+    let _permit = startup_limit()
+        .acquire()
+        .await
+        .expect("startup semaphore closed");
+    let image = Mysql::default();
+    let container: ContainerAsync<Mysql> = image.start().await.expect("mysql container start");
+    let port = container
+        .get_host_port_ipv4(3306)
+        .await
+        .expect("mysql port");
+    let url = format!("mysql://root@127.0.0.1:{port}/test");
+    (container, url)
+}
+
+async fn create_upsert_table(url: &str) {
+    let pool = sqlx::MySqlPool::connect(url).await.expect("pool connect");
+    sqlx::query("CREATE TABLE t (id INT PRIMARY KEY, name VARCHAR(255))")
+        .execute(&pool)
+        .await
+        .expect("create table");
+    pool.close().await;
+}
+
+async fn row_count(url: &str) -> i64 {
+    let pool = sqlx::MySqlPool::connect(url).await.expect("pool connect");
+    let row = sqlx::query("SELECT COUNT(*) AS n FROM t")
+        .fetch_one(&pool)
+        .await
+        .expect("count");
+    let n: i64 = row.get("n");
+    pool.close().await;
+    n
+}
+
+async fn name_for_id(url: &str, id: i32) -> Option<String> {
+    let pool = sqlx::MySqlPool::connect(url).await.expect("pool connect");
+    let row = sqlx::query("SELECT name FROM t WHERE id = ?")
+        .bind(id)
+        .fetch_optional(&pool)
+        .await
+        .expect("read back");
+    pool.close().await;
+    row.map(|r| r.get::<String, _>("name"))
+}
+
+fn upsert_sink_config(url: &str) -> MysqlSinkConfig {
+    let mut config = MysqlSinkConfig::new(url, "t").column_mapping(MysqlColumnMapping::AutoMap);
+    config.write = WriteSpec {
+        write_mode: WriteMode::Upsert,
+        key: vec!["id".to_string()],
+        delete_marker: None,
+    };
+    config
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn idempotent_upsert_updates_in_place_and_advances_token() {
+    let (_container, url) = start_mysql().await;
+    create_upsert_table(&url).await;
+
+    let sink = MysqlSink::new(upsert_sink_config(&url))
+        .await
+        .expect("sink new");
+
+    let scope = "t::r1";
+    let t1 = format_token(1);
+    let t2 = format_token(2);
+
+    // Page 1, token ...0001: upsert id=1 -> "a" in the idempotent path.
+    let written = sink
+        .write_batch_idempotent(&[json!({"id": 1, "name": "a"})], scope, &t1)
+        .await
+        .expect("idempotent upsert 1");
+    assert_eq!(written, 1, "one upsert applied");
+    assert_eq!(
+        sink.last_committed_token(scope).await.expect("token read"),
+        Some(t1.clone()),
+        "token advanced to t1"
+    );
+    assert_eq!(row_count(&url).await, 1);
+    assert_eq!(name_for_id(&url, 1).await.as_deref(), Some("a"));
+
+    // Page 2, token ...0002: upsert id=1 -> "b".
+    let written = sink
+        .write_batch_idempotent(&[json!({"id": 1, "name": "b"})], scope, &t2)
+        .await
+        .expect("idempotent upsert 2");
+    assert_eq!(written, 1, "one upsert applied (update in place)");
+
+    // Exactly ONE row id=1, now "b" — upserted in the idempotent path, not duplicated.
+    assert_eq!(
+        row_count(&url).await,
+        1,
+        "upsert in the idempotent path must update, not duplicate"
+    );
+    assert_eq!(
+        name_for_id(&url, 1).await.as_deref(),
+        Some("b"),
+        "row must reflect the latest value 'b'"
+    );
+
+    // Token advanced to t2 — committed atomically with the upsert.
+    assert_eq!(
+        sink.last_committed_token(scope).await.expect("token read"),
+        Some(t2),
+        "token advanced to t2 alongside the upsert"
+    );
+}

--- a/crates/sink/mysql/tests/upsert.rs
+++ b/crates/sink/mysql/tests/upsert.rs
@@ -1,0 +1,266 @@
+//! Integration tests for `MysqlSink` upsert / delete write modes,
+//! exercised against a real MySQL instance via testcontainers.
+//!
+//! These tests require Docker. Each test boots its own container and seeds
+//! its own table so they are fully isolated and safe to run in parallel.
+//!
+//! Each test creates `CREATE TABLE t (id INT PRIMARY KEY, name VARCHAR(255))`
+//! and exercises a write-mode scenario end-to-end via `write_batch`.
+
+use faucet_core::{Sink, WriteMode, WriteSpec};
+use faucet_sink_mysql::{MysqlColumnMapping, MysqlSink, MysqlSinkConfig};
+use serde_json::json;
+use sqlx::Row;
+use std::sync::OnceLock;
+use testcontainers::{ContainerAsync, runners::AsyncRunner};
+use testcontainers_modules::mysql::Mysql;
+use tokio::sync::Semaphore;
+
+/// Bounds concurrent MySQL container startups across all tests in this
+/// binary. MySQL 8.x init is heavy (~2-3 GB RSS per container during
+/// startup) and starting too many in parallel exhausts memory on
+/// Colima/Docker Desktop, surfacing as random "Failed to start mysqld
+/// daemon" errors. We allow at most two simultaneous startups; once a
+/// container is running it is steady-state cheap, so the cap only
+/// serialises the spin-up window.
+fn startup_limit() -> &'static Semaphore {
+    static SEM: OnceLock<Semaphore> = OnceLock::new();
+    SEM.get_or_init(|| Semaphore::new(2))
+}
+
+/// Start a MySQL container and return both the container handle and a
+/// connection URL. The container is kept alive by the returned handle; drop
+/// it to stop the container.
+async fn start_mysql() -> (ContainerAsync<Mysql>, String) {
+    let _permit = startup_limit()
+        .acquire()
+        .await
+        .expect("startup semaphore closed");
+    let image = Mysql::default();
+    let container: ContainerAsync<Mysql> = image.start().await.expect("mysql container start");
+    let port = container
+        .get_host_port_ipv4(3306)
+        .await
+        .expect("mysql port");
+    let url = format!("mysql://root@127.0.0.1:{port}/test");
+    (container, url)
+}
+
+/// Create `CREATE TABLE t (id INT PRIMARY KEY, name VARCHAR(255))`.
+async fn create_upsert_table(url: &str) {
+    let pool = sqlx::MySqlPool::connect(url).await.expect("pool connect");
+    sqlx::query("CREATE TABLE t (id INT PRIMARY KEY, name VARCHAR(255))")
+        .execute(&pool)
+        .await
+        .expect("create table");
+    pool.close().await;
+}
+
+/// Build an upsert sink for the given URL targeting table `t`.
+fn make_upsert_sink_config(url: &str, key: Vec<String>) -> MysqlSinkConfig {
+    let mut config = MysqlSinkConfig::new(url, "t").column_mapping(MysqlColumnMapping::AutoMap);
+    config.write = WriteSpec {
+        write_mode: WriteMode::Upsert,
+        key,
+        delete_marker: None,
+    };
+    config
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: second upsert with same key updates the row (last-write-wins)
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn upsert_second_write_updates_existing_row() {
+    let (_container, url) = start_mysql().await;
+    create_upsert_table(&url).await;
+
+    let config = make_upsert_sink_config(&url, vec!["id".to_string()]);
+    let sink = MysqlSink::new(config).await.expect("sink new");
+
+    // Insert {id:1, name:"alice"}.
+    sink.write_batch(&[json!({"id": 1, "name": "alice"})])
+        .await
+        .expect("first write");
+
+    // Upsert {id:1, name:"alice2"} — must update the row.
+    sink.write_batch(&[json!({"id": 1, "name": "alice2"})])
+        .await
+        .expect("second write");
+
+    let pool = sqlx::MySqlPool::connect(&url).await.expect("pool");
+    let count: i64 = sqlx::query("SELECT COUNT(*) FROM t")
+        .fetch_one(&pool)
+        .await
+        .expect("count")
+        .get(0);
+    let name: String = sqlx::query("SELECT name FROM t WHERE id = 1")
+        .fetch_one(&pool)
+        .await
+        .expect("row")
+        .get("name");
+    pool.close().await;
+
+    assert_eq!(count, 1, "upsert must not duplicate the row");
+    assert_eq!(name, "alice2", "upsert must update the name to 'alice2'");
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: delete_marker routes a row to delete; the table ends up empty
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn upsert_with_delete_marker_removes_row() {
+    let (_container, url) = start_mysql().await;
+    create_upsert_table(&url).await;
+
+    // Upsert sink with a delete_marker on __op = "d".
+    let mut config =
+        MysqlSinkConfig::new(&url, "t").column_mapping(MysqlColumnMapping::AutoMap);
+    config.write = WriteSpec {
+        write_mode: WriteMode::Upsert,
+        key: vec!["id".to_string()],
+        delete_marker: Some(faucet_core::DeleteMarker {
+            field: "__op".to_string(),
+            values: vec!["d".to_string()],
+        }),
+    };
+    let sink = MysqlSink::new(config).await.expect("sink new");
+
+    // Insert the row first (marker field stripped from upsert).
+    sink.write_batch(&[json!({"id": 1, "name": "x", "__op": "u"})])
+        .await
+        .expect("insert");
+
+    let pool = sqlx::MySqlPool::connect(&url).await.expect("pool");
+    let count_after_insert: i64 = sqlx::query("SELECT COUNT(*) FROM t")
+        .fetch_one(&pool)
+        .await
+        .expect("count")
+        .get(0);
+    pool.close().await;
+    assert_eq!(count_after_insert, 1, "row must be present after upsert");
+
+    // Delete via the marker.
+    sink.write_batch(&[json!({"id": 1, "__op": "d"})])
+        .await
+        .expect("delete");
+
+    let pool = sqlx::MySqlPool::connect(&url).await.expect("pool");
+    let count_after_delete: i64 = sqlx::query("SELECT COUNT(*) FROM t")
+        .fetch_one(&pool)
+        .await
+        .expect("count")
+        .get(0);
+    pool.close().await;
+
+    assert_eq!(count_after_delete, 0, "row must be deleted after delete-marker write");
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: same key twice in one batch → last-write-wins (count == 1, name == "new")
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn upsert_same_key_twice_in_one_batch_last_write_wins() {
+    let (_container, url) = start_mysql().await;
+    create_upsert_table(&url).await;
+
+    let config = make_upsert_sink_config(&url, vec!["id".to_string()]);
+    let sink = MysqlSink::new(config).await.expect("sink new");
+
+    // Two records with the same id in a single batch; the planner deduplicates
+    // them so MySQL sees only the last one.
+    sink.write_batch(&[
+        json!({"id": 1, "name": "old"}),
+        json!({"id": 1, "name": "new"}),
+    ])
+    .await
+    .expect("batch write");
+
+    let pool = sqlx::MySqlPool::connect(&url).await.expect("pool");
+    let count: i64 = sqlx::query("SELECT COUNT(*) FROM t")
+        .fetch_one(&pool)
+        .await
+        .expect("count")
+        .get(0);
+    let name: String = sqlx::query("SELECT name FROM t WHERE id = 1")
+        .fetch_one(&pool)
+        .await
+        .expect("row")
+        .get("name");
+    pool.close().await;
+
+    assert_eq!(count, 1, "dedup must collapse two records with the same key to one row");
+    assert_eq!(name, "new", "last-write-wins: name must be 'new'");
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: supported_write_modes includes Append, Upsert, Delete
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn supported_write_modes_includes_upsert_and_delete() {
+    let (_container, url) = start_mysql().await;
+    create_upsert_table(&url).await;
+
+    let config = MysqlSinkConfig::new(&url, "t");
+    let sink = MysqlSink::new(config).await.expect("sink new");
+
+    let modes = sink.supported_write_modes();
+    assert!(modes.contains(&WriteMode::Append));
+    assert!(modes.contains(&WriteMode::Upsert));
+    assert!(modes.contains(&WriteMode::Delete));
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: config validation rejects upsert without a key (no container needed;
+//         the error fires before the connection attempt).
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn new_rejects_upsert_without_key() {
+    let mut config =
+        MysqlSinkConfig::new("mysql://root@127.0.0.1:13306/test", "t")
+            .column_mapping(MysqlColumnMapping::AutoMap);
+    config.write = WriteSpec {
+        write_mode: WriteMode::Upsert,
+        key: vec![], // missing key → rejected before any connection attempt
+        delete_marker: None,
+    };
+
+    let err = MysqlSink::new(config)
+        .await
+        .err()
+        .expect("must fail without key");
+    assert!(
+        err.to_string().contains("non-empty `key`"),
+        "got: {err}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 6: config validation rejects upsert with json column_mapping (no
+//         container needed; the error fires before the connection attempt).
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn new_rejects_upsert_with_json_column_mapping() {
+    // Default column_mapping is Json — upsert must be rejected.
+    let mut config = MysqlSinkConfig::new("mysql://root@127.0.0.1:13306/test", "t");
+    config.write = WriteSpec {
+        write_mode: WriteMode::Upsert,
+        key: vec!["id".to_string()],
+        delete_marker: None,
+    };
+
+    let err = MysqlSink::new(config)
+        .await
+        .err()
+        .expect("must fail with json column_mapping");
+    assert!(
+        err.to_string().contains("auto_map"),
+        "error must mention auto_map; got: {err}"
+    );
+}

--- a/crates/sink/mysql/tests/upsert.rs
+++ b/crates/sink/mysql/tests/upsert.rs
@@ -264,3 +264,45 @@ async fn new_rejects_upsert_with_json_column_mapping() {
         "error must mention auto_map; got: {err}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Test 7: write_batch_partial routes missing-key rows to the DLQ per-row
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn write_batch_partial_routes_missing_key_per_row() {
+    let (_container, url) = start_mysql().await;
+    create_upsert_table(&url).await;
+
+    let config = make_upsert_sink_config(&url, vec!["id".to_string()]);
+    let sink = MysqlSink::new(config).await.expect("sink new");
+
+    let records = [json!({"id": 1, "name": "ok"}), json!({"name": "missing-id"})];
+    let outcomes = sink
+        .write_batch_partial(&records)
+        .await
+        .expect("partial write");
+
+    assert_eq!(outcomes.len(), 2, "one outcome per input row");
+    assert!(outcomes[0].is_ok(), "the good row must be Ok");
+    assert!(
+        outcomes[1].is_err(),
+        "the missing-key row must be Err (routed to the DLQ)"
+    );
+
+    let pool = sqlx::MySqlPool::connect(&url).await.expect("pool");
+    let count: i64 = sqlx::query("SELECT COUNT(*) FROM t")
+        .fetch_one(&pool)
+        .await
+        .expect("count")
+        .get(0);
+    let name: String = sqlx::query("SELECT name FROM t WHERE id = 1")
+        .fetch_one(&pool)
+        .await
+        .expect("row")
+        .get("name");
+    pool.close().await;
+
+    assert_eq!(count, 1, "only the good row should be written");
+    assert_eq!(name, "ok", "id=1 must be present with name 'ok'");
+}

--- a/crates/sink/mysql/tests/upsert.rs
+++ b/crates/sink/mysql/tests/upsert.rs
@@ -116,8 +116,7 @@ async fn upsert_with_delete_marker_removes_row() {
     create_upsert_table(&url).await;
 
     // Upsert sink with a delete_marker on __op = "d".
-    let mut config =
-        MysqlSinkConfig::new(&url, "t").column_mapping(MysqlColumnMapping::AutoMap);
+    let mut config = MysqlSinkConfig::new(&url, "t").column_mapping(MysqlColumnMapping::AutoMap);
     config.write = WriteSpec {
         write_mode: WriteMode::Upsert,
         key: vec!["id".to_string()],
@@ -155,7 +154,10 @@ async fn upsert_with_delete_marker_removes_row() {
         .get(0);
     pool.close().await;
 
-    assert_eq!(count_after_delete, 0, "row must be deleted after delete-marker write");
+    assert_eq!(
+        count_after_delete, 0,
+        "row must be deleted after delete-marker write"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -192,7 +194,10 @@ async fn upsert_same_key_twice_in_one_batch_last_write_wins() {
         .get("name");
     pool.close().await;
 
-    assert_eq!(count, 1, "dedup must collapse two records with the same key to one row");
+    assert_eq!(
+        count, 1,
+        "dedup must collapse two records with the same key to one row"
+    );
     assert_eq!(name, "new", "last-write-wins: name must be 'new'");
 }
 
@@ -221,9 +226,8 @@ async fn supported_write_modes_includes_upsert_and_delete() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn new_rejects_upsert_without_key() {
-    let mut config =
-        MysqlSinkConfig::new("mysql://root@127.0.0.1:13306/test", "t")
-            .column_mapping(MysqlColumnMapping::AutoMap);
+    let mut config = MysqlSinkConfig::new("mysql://root@127.0.0.1:13306/test", "t")
+        .column_mapping(MysqlColumnMapping::AutoMap);
     config.write = WriteSpec {
         write_mode: WriteMode::Upsert,
         key: vec![], // missing key → rejected before any connection attempt
@@ -234,10 +238,7 @@ async fn new_rejects_upsert_without_key() {
         .await
         .err()
         .expect("must fail without key");
-    assert!(
-        err.to_string().contains("non-empty `key`"),
-        "got: {err}"
-    );
+    assert!(err.to_string().contains("non-empty `key`"), "got: {err}");
 }
 
 // ---------------------------------------------------------------------------
@@ -277,7 +278,10 @@ async fn write_batch_partial_routes_missing_key_per_row() {
     let config = make_upsert_sink_config(&url, vec!["id".to_string()]);
     let sink = MysqlSink::new(config).await.expect("sink new");
 
-    let records = [json!({"id": 1, "name": "ok"}), json!({"name": "missing-id"})];
+    let records = [
+        json!({"id": 1, "name": "ok"}),
+        json!({"name": "missing-id"}),
+    ];
     let outcomes = sink
         .write_batch_partial(&records)
         .await

--- a/crates/sink/postgres/README.md
+++ b/crates/sink/postgres/README.md
@@ -142,9 +142,11 @@ Semantics:
   `ON CONFLICT` target twice. A delete after an upsert (or vice-versa) for the
   same key resolves to whichever came last.
 - **`write_mode: delete`** routes every record to a delete by key.
-- A record missing a key column (or with a `null` key value) fails the whole
-  batch with a typed `Sink` error naming the offending row index — keys must
-  be present and non-null.
+- A record missing a key column (or with a `null` key value) fails with a typed
+  `Sink` error. When a `dlq:` block is configured the good rows are still
+  written (upserts + deletes applied) and only the missing/null-key rows are
+  routed to the DLQ per-row; without a DLQ the whole batch fails. Keys should be
+  present and non-null.
 
 ### Example YAML config
 

--- a/crates/sink/postgres/README.md
+++ b/crates/sink/postgres/README.md
@@ -112,6 +112,66 @@ let config = PostgresSinkConfig::new("postgres://localhost/mydb", "events")
     .with_batch_size(250);
 ```
 
+## Write modes (upsert / delete)
+
+By default the sink **appends** every record. Set `write_mode` to `upsert` or
+`delete` to merge or remove rows by a key instead.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `write_mode` | `"append" \| "upsert" \| "delete"` | `"append"` | How records are applied. |
+| `key` | `[String]` | `[]` | Key columns identifying a row. **Required and non-empty** for `upsert`/`delete`. Composite keys are supported. |
+| `delete_marker` | `{ field, values: [String] }` | *(none)* | **Upsert only.** Records whose `field` equals one of `values` are deleted by key; all others are upserts. The marker field is stripped from upserted rows before writing. |
+
+Requirements (validated in `PostgresSink::new`, before any connection is made):
+
+- **`column_mapping: auto_map` is required.** Upsert/delete match on real
+  columns, so the key columns must be table columns — not fields buried inside
+  a JSONB blob.
+- **The `key` columns must carry a `UNIQUE` or `PRIMARY KEY` constraint**, since
+  upsert is implemented with `INSERT … ON CONFLICT (key) DO UPDATE SET …`
+  (non-key columns are set from `EXCLUDED`; if every column is a key column the
+  clause degrades to `DO NOTHING`). Without the constraint Postgres rejects the
+  `ON CONFLICT` target.
+
+Semantics:
+
+- **Last-write-wins within a batch.** When the same key appears multiple times
+  in one `write_batch` call, the records are de-duplicated to a single
+  effective action (the final one), so a single statement never hits the same
+  `ON CONFLICT` target twice. A delete after an upsert (or vice-versa) for the
+  same key resolves to whichever came last.
+- **`write_mode: delete`** routes every record to a delete by key.
+- A record missing a key column (or with a `null` key value) fails the whole
+  batch with a typed `Sink` error naming the offending row index — keys must
+  be present and non-null.
+
+### Example YAML config
+
+```yaml
+pipeline:
+  source:
+    type: postgres-cdc
+    config:
+      connection_url: postgres://faucet:faucet@localhost:5432/appdb
+      slot_name: faucet_slot
+      publication_name: faucet_pub
+  sink:
+    type: postgres
+    config:
+      connection_url: postgres://writer:pass@localhost:5432/warehouse
+      table_name: users
+      column_mapping: auto_map
+      write_mode: upsert
+      key: [id]
+      delete_marker:
+        field: __op
+        values: [d]
+```
+
+The destination table must define the key as a constraint, e.g.
+`CREATE TABLE users (id INT PRIMARY KEY, name TEXT, email TEXT)`.
+
 ## Config Loading
 
 ```rust

--- a/crates/sink/postgres/src/config.rs
+++ b/crates/sink/postgres/src/config.rs
@@ -67,6 +67,11 @@ pub struct PostgresSinkConfig {
     pub batch_size: usize,
     /// Maximum number of connections in the pool. Defaults to 5.
     pub max_connections: u32,
+    /// Write mode, key columns, and optional delete marker. `write_mode`
+    /// defaults to `append`. Upsert/delete require `column_mapping: auto_map`
+    /// and a UNIQUE/PRIMARY KEY constraint on `key`.
+    #[serde(flatten)]
+    pub write: faucet_core::WriteSpec,
 }
 
 fn default_batch_size() -> usize {
@@ -96,6 +101,7 @@ impl PostgresSinkConfig {
             column_mapping: PostgresColumnMapping::default(),
             batch_size: DEFAULT_BATCH_SIZE,
             max_connections: 5,
+            write: faucet_core::WriteSpec::default(),
         }
     }
 

--- a/crates/sink/postgres/src/sink.rs
+++ b/crates/sink/postgres/src/sink.rs
@@ -597,6 +597,41 @@ impl faucet_core::Sink for PostgresSink {
         Ok(total)
     }
 
+    /// Write a batch and report per-row outcomes.
+    ///
+    /// In append mode this delegates to [`write_batch`](Self::write_batch) and
+    /// maps a single success onto an all-`Ok(())` vector (the trait default).
+    /// In upsert/delete mode the good rows are applied (upserts + deletes), and
+    /// only the rows whose key could not be extracted (missing / null key) are
+    /// reported as `Err` so the pipeline routes them to the DLQ per-row instead
+    /// of sending the whole page.
+    async fn write_batch_partial(
+        &self,
+        records: &[Value],
+    ) -> Result<Vec<faucet_core::RowOutcome>, FaucetError> {
+        if matches!(self.config.write.write_mode, faucet_core::WriteMode::Append) {
+            self.write_batch(records).await?;
+            return Ok(records.iter().map(|_| Ok(())).collect());
+        }
+
+        let plan = faucet_core::plan_writes(records, &self.config.write);
+        let mut conn = self
+            .pool
+            .acquire()
+            .await
+            .map_err(|e| FaucetError::Sink(format!("PostgreSQL pool acquire failed: {e}")))?;
+        self.apply_plan(&mut conn, &plan).await?;
+
+        let mut outcomes: Vec<faucet_core::RowOutcome> = records.iter().map(|_| Ok(())).collect();
+        for (idx, msg) in &plan.failed {
+            outcomes[*idx] = Err(FaucetError::Sink(format!(
+                "postgres {}: {msg}",
+                self.config.write.write_mode.as_str()
+            )));
+        }
+        Ok(outcomes)
+    }
+
     fn supports_idempotent_writes(&self) -> bool {
         true
     }

--- a/crates/sink/postgres/src/sink.rs
+++ b/crates/sink/postgres/src/sink.rs
@@ -62,6 +62,30 @@ fn qualified_table_ref(schema: Option<&str>, table: &str) -> String {
     }
 }
 
+/// Build the `ON CONFLICT (key) DO UPDATE …` tail for an upsert INSERT.
+/// Non-key columns are SET from EXCLUDED. If every column is a key column,
+/// emit `DO NOTHING`.
+fn on_conflict_clause(key: &[String], all_cols: &[String]) -> String {
+    let key_list = key
+        .iter()
+        .map(|k| quote_ident(k))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let updates: Vec<String> = all_cols
+        .iter()
+        .filter(|c| !key.iter().any(|k| k == *c))
+        .map(|c| format!("{q} = EXCLUDED.{q}", q = quote_ident(c)))
+        .collect();
+    if updates.is_empty() {
+        format!("ON CONFLICT ({key_list}) DO NOTHING")
+    } else {
+        format!(
+            "ON CONFLICT ({key_list}) DO UPDATE SET {}",
+            updates.join(", ")
+        )
+    }
+}
+
 /// A sink that writes JSON records to a PostgreSQL table.
 pub struct PostgresSink {
     config: PostgresSinkConfig,
@@ -71,6 +95,17 @@ pub struct PostgresSink {
 impl PostgresSink {
     /// Create a new PostgreSQL sink. Establishes a connection pool.
     pub async fn new(config: PostgresSinkConfig) -> Result<Self, FaucetError> {
+        config.write.validate()?;
+        if !matches!(config.write.write_mode, faucet_core::WriteMode::Append)
+            && !matches!(config.column_mapping, PostgresColumnMapping::AutoMap)
+        {
+            return Err(FaucetError::Config(
+                "postgres sink: write_mode upsert/delete requires column_mapping: auto_map \
+                 (key columns must be real columns, not inside a JSONB blob)"
+                    .into(),
+            ));
+        }
+
         let pool = PgPoolOptions::new()
             .max_connections(config.max_connections)
             .connect(&config.connection_url)
@@ -130,10 +165,16 @@ impl PostgresSink {
     /// which sqlx encodes as `jsonb`, so an insert into any non-`jsonb` column
     /// failed at runtime — audit #146 C1.) Uses a single multi-row INSERT
     /// (sub-chunked at the 65535-parameter cap) for efficiency.
-    async fn insert_auto_map(
+    ///
+    /// When `conflict_key` is `Some(key)`, each sub-chunk's INSERT is given an
+    /// `ON CONFLICT (key) DO UPDATE …` tail so it upserts by the key columns
+    /// (last-write-wins within the batch is already handled by the planner's
+    /// dedup, so a single sub-chunk never double-hits the same conflict target).
+    async fn insert_auto_map_with_conflict(
         &self,
         conn: &mut sqlx::PgConnection,
         records: &[Value],
+        conflict_key: Option<&[String]>,
     ) -> Result<usize, FaucetError> {
         if records.is_empty() {
             return Ok(0);
@@ -258,6 +299,19 @@ impl PostgresSink {
                 col_names.join(", "),
                 value_tuples.join(", ")
             );
+            let query = match conflict_key {
+                Some(key) => format!(
+                    "{query} {}",
+                    on_conflict_clause(
+                        key,
+                        &insert_columns
+                            .iter()
+                            .map(|(c, _)| c.clone())
+                            .collect::<Vec<_>>()
+                    )
+                ),
+                None => query,
+            };
 
             let mut q = sqlx::query(&query);
             for matched in sub {
@@ -281,6 +335,122 @@ impl PostgresSink {
         Ok(num_rows)
     }
 
+    /// Insert a batch of records using auto-mapped columns, on the given
+    /// connection, with plain append semantics (no `ON CONFLICT` tail).
+    ///
+    /// Thin wrapper over [`insert_auto_map_with_conflict`](Self::insert_auto_map_with_conflict)
+    /// so the append path and the idempotent-write path keep their original
+    /// signature.
+    async fn insert_auto_map(
+        &self,
+        conn: &mut sqlx::PgConnection,
+        records: &[Value],
+    ) -> Result<usize, FaucetError> {
+        self.insert_auto_map_with_conflict(conn, records, None)
+            .await
+    }
+
+    /// Delete rows whose key columns match any of `deletes`, using
+    /// `DELETE FROM t WHERE (k1, …) IN ((v1, …), …)` with per-column `::udt`
+    /// casts (the key columns' underlying types), chunked at the param cap.
+    async fn delete_by_keys(
+        &self,
+        conn: &mut sqlx::PgConnection,
+        deletes: &[faucet_core::KeyTuple],
+    ) -> Result<usize, FaucetError> {
+        if deletes.is_empty() {
+            return Ok(0);
+        }
+        let key = &self.config.write.key;
+        let table_ref = qualified_table_ref(self.config.schema.as_deref(), &self.config.table_name);
+
+        // Underlying types for the key columns → drives the ::udt casts, same
+        // source the insert path uses.
+        let udts: std::collections::HashMap<String, String> = sqlx::query(
+            "SELECT a.attname::text AS column_name, t.typname::text AS udt_name \
+             FROM pg_catalog.pg_attribute a \
+             JOIN pg_catalog.pg_type t ON t.oid = a.atttypid \
+             WHERE a.attrelid = to_regclass($1)::oid AND a.attnum > 0 AND NOT a.attisdropped",
+        )
+        .bind(&table_ref)
+        .fetch_all(&mut *conn)
+        .await
+        .map_err(|e| FaucetError::Sink(format!("failed to query table columns: {e}")))?
+        .iter()
+        .map(|row| {
+            (
+                row.get::<String, _>("column_name"),
+                row.get::<String, _>("udt_name"),
+            )
+        })
+        .collect();
+        let key_udts: Vec<String> = key
+            .iter()
+            .map(|k| udts.get(k).cloned().unwrap_or_else(|| "text".to_string()))
+            .collect();
+        let col_list = key
+            .iter()
+            .map(|k| quote_ident(k))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        const MAX_PG_PARAMS: usize = 65535;
+        let per = (MAX_PG_PARAMS / key.len().max(1)).max(1);
+        let mut total = 0usize;
+        for chunk in deletes.chunks(per) {
+            let mut ph = 1usize;
+            let tuples: Vec<String> = chunk
+                .iter()
+                .map(|_| {
+                    let group = key_udts
+                        .iter()
+                        .map(|udt| {
+                            let p = format!("${ph}::{udt}");
+                            ph += 1;
+                            p
+                        })
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    format!("({group})")
+                })
+                .collect();
+            let sql = format!(
+                "DELETE FROM {table_ref} WHERE ({col_list}) IN ({})",
+                tuples.join(", ")
+            );
+            let mut q = sqlx::query(&sql);
+            for kt in chunk {
+                for ((_, v), udt) in kt.0.iter().zip(key_udts.iter()) {
+                    q = q.bind(pg_bind_text(Some(v), udt));
+                }
+            }
+            let res = q
+                .execute(&mut *conn)
+                .await
+                .map_err(|e| FaucetError::Sink(format!("PostgreSQL delete failed: {e}")))?;
+            total += res.rows_affected() as usize;
+        }
+        Ok(total)
+    }
+
+    /// Apply a planned upsert/delete batch on one connection.
+    async fn apply_plan(
+        &self,
+        conn: &mut sqlx::PgConnection,
+        plan: &faucet_core::WritePlan,
+    ) -> Result<usize, FaucetError> {
+        let mut affected = 0usize;
+        if !plan.upserts.is_empty() {
+            affected += self
+                .insert_auto_map_with_conflict(conn, &plan.upserts, Some(&self.config.write.key))
+                .await?;
+        }
+        if !plan.deletes.is_empty() {
+            affected += self.delete_by_keys(conn, &plan.deletes).await?;
+        }
+        Ok(affected)
+    }
+
     /// Ensure the commit-token watermark table exists.
     async fn ensure_commit_table(&self) -> Result<(), FaucetError> {
         let sql = format!(
@@ -301,6 +471,14 @@ impl faucet_core::Sink for PostgresSink {
     fn config_schema(&self) -> serde_json::Value {
         serde_json::to_value(faucet_core::schema_for!(PostgresSinkConfig))
             .expect("schema serialization")
+    }
+
+    fn supported_write_modes(&self) -> &'static [faucet_core::WriteMode] {
+        &[
+            faucet_core::WriteMode::Append,
+            faucet_core::WriteMode::Upsert,
+            faucet_core::WriteMode::Delete,
+        ]
     }
 
     fn dataset_uri(&self) -> String {
@@ -366,6 +544,22 @@ impl faucet_core::Sink for PostgresSink {
     async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
         if records.is_empty() {
             return Ok(0);
+        }
+
+        if !matches!(self.config.write.write_mode, faucet_core::WriteMode::Append) {
+            let plan = faucet_core::plan_writes(records, &self.config.write);
+            if let Some((idx, msg)) = plan.failed.first() {
+                return Err(FaucetError::Sink(format!(
+                    "postgres {}: row {idx}: {msg}",
+                    self.config.write.write_mode.as_str()
+                )));
+            }
+            let mut conn = self
+                .pool
+                .acquire()
+                .await
+                .map_err(|e| FaucetError::Sink(format!("PostgreSQL pool acquire failed: {e}")))?;
+            return self.apply_plan(&mut conn, &plan).await;
         }
 
         let chunks: Vec<&[Value]> = if self.config.batch_size == 0 {
@@ -468,8 +662,26 @@ impl faucet_core::Sink for PostgresSink {
 
 #[cfg(test)]
 mod tests {
-    use super::{pg_bind_text, qualified_table_ref};
+    use super::{on_conflict_clause, pg_bind_text, qualified_table_ref};
     use serde_json::json;
+
+    #[test]
+    fn upsert_on_conflict_clause_for_keys() {
+        let clause = on_conflict_clause(
+            &["id".to_string()],
+            &["id".to_string(), "name".to_string(), "email".to_string()],
+        );
+        assert_eq!(
+            clause,
+            r#"ON CONFLICT ("id") DO UPDATE SET "name" = EXCLUDED."name", "email" = EXCLUDED."email""#
+        );
+    }
+
+    #[test]
+    fn upsert_on_conflict_all_columns_are_key_does_nothing() {
+        let clause = on_conflict_clause(&["id".to_string()], &["id".to_string()]);
+        assert_eq!(clause, r#"ON CONFLICT ("id") DO NOTHING"#);
+    }
 
     #[test]
     fn commit_token_table_is_the_shared_constant() {

--- a/crates/sink/postgres/src/sink.rs
+++ b/crates/sink/postgres/src/sink.rs
@@ -598,7 +598,7 @@ impl faucet_core::Sink for PostgresSink {
 
     /// Write a batch and report per-row outcomes.
     ///
-    /// In append mode this delegates to [`write_batch`](Self::write_batch) and
+    /// In append mode this delegates to [`write_batch`](faucet_core::Sink::write_batch) and
     /// maps a single success onto an all-`Ok(())` vector (the trait default).
     /// In upsert/delete mode the good rows are applied (upserts + deletes), and
     /// only the rows whose key could not be extracted (missing / null key) are

--- a/crates/sink/postgres/src/sink.rs
+++ b/crates/sink/postgres/src/sink.rs
@@ -624,20 +624,40 @@ impl faucet_core::Sink for PostgresSink {
         token: &str,
     ) -> Result<usize, FaucetError> {
         self.ensure_commit_table().await?;
+
+        // For upsert/delete modes, plan the page before opening the transaction
+        // so a key-extraction failure aborts without leaving an open tx.
+        let plan = if matches!(self.config.write.write_mode, faucet_core::WriteMode::Append) {
+            None
+        } else {
+            let plan = faucet_core::plan_writes(records, &self.config.write);
+            if let Some((idx, msg)) = plan.failed.first() {
+                return Err(FaucetError::Sink(format!(
+                    "postgres {}: row {idx}: {msg}",
+                    self.config.write.write_mode.as_str()
+                )));
+            }
+            Some(plan)
+        };
+
         let mut tx =
             self.pool.begin().await.map_err(|e| {
                 FaucetError::Sink(format!("PostgreSQL transaction begin failed: {e}"))
             })?;
 
-        // Data insert(s) and the commit-token upsert share ONE transaction so
+        // Data write(s) and the commit-token upsert share ONE transaction so
         // the page is committed atomically with its watermark: on crash either
         // both land or neither does, which is what makes a replay skip-on-resume
-        // produce zero duplicates.
-        let written = match &self.config.column_mapping {
-            PostgresColumnMapping::Jsonb { column } => {
-                self.insert_jsonb(&mut tx, records, column).await?
-            }
-            PostgresColumnMapping::AutoMap => self.insert_auto_map(&mut tx, records).await?,
+        // produce zero duplicates. For upsert/delete this means the planned
+        // upserts/deletes commit together with the watermark in the same tx.
+        let written = match &plan {
+            Some(plan) => self.apply_plan(&mut tx, plan).await?,
+            None => match &self.config.column_mapping {
+                PostgresColumnMapping::Jsonb { column } => {
+                    self.insert_jsonb(&mut tx, records, column).await?
+                }
+                PostgresColumnMapping::AutoMap => self.insert_auto_map(&mut tx, records).await?,
+            },
         };
 
         let upsert = format!(

--- a/crates/sink/postgres/src/sink.rs
+++ b/crates/sink/postgres/src/sink.rs
@@ -554,11 +554,10 @@ impl faucet_core::Sink for PostgresSink {
                     self.config.write.write_mode.as_str()
                 )));
             }
-            let mut conn = self
-                .pool
-                .acquire()
-                .await
-                .map_err(|e| FaucetError::Sink(format!("PostgreSQL pool acquire failed: {e}")))?;
+            let mut conn =
+                self.pool.acquire().await.map_err(|e| {
+                    FaucetError::Sink(format!("PostgreSQL pool acquire failed: {e}"))
+                })?;
             return self.apply_plan(&mut conn, &plan).await;
         }
 

--- a/crates/sink/postgres/tests/exactly_once_upsert.rs
+++ b/crates/sink/postgres/tests/exactly_once_upsert.rs
@@ -1,0 +1,123 @@
+//! Composition test (#190): exactly-once delivery + `write_mode: upsert` for
+//! the PostgreSQL sink, against a real Postgres instance via testcontainers.
+//!
+//! Verifies that `write_batch_idempotent` routes through the upsert planner so
+//! the data write AND the commit-token watermark commit atomically in one
+//! transaction. Re-writing the same key in a later page (with a higher token)
+//! must UPDATE the row in place — not duplicate it — and advance the token.
+//!
+//! Requires Docker. Boots its own container so it is isolated.
+
+use faucet_core::{Sink, WriteMode, WriteSpec, format_token};
+use faucet_sink_postgres::{PostgresColumnMapping, PostgresSink, PostgresSinkConfig};
+use serde_json::json;
+use testcontainers::{ContainerAsync, ImageExt, runners::AsyncRunner};
+use testcontainers_modules::postgres::Postgres;
+
+async fn start_postgres() -> (ContainerAsync<Postgres>, String) {
+    let image = Postgres::default().with_tag("16-alpine");
+    let container: ContainerAsync<Postgres> =
+        image.start().await.expect("postgres container start");
+    let port = container
+        .get_host_port_ipv4(5432)
+        .await
+        .expect("postgres port");
+    let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
+    (container, url)
+}
+
+async fn create_kv_table(url: &str) {
+    let pool = sqlx::PgPool::connect(url).await.expect("pool connect");
+    sqlx::query("CREATE TABLE kv (id INT PRIMARY KEY, name TEXT)")
+        .execute(&pool)
+        .await
+        .expect("create table");
+    pool.close().await;
+}
+
+async fn row_count(url: &str) -> i64 {
+    let pool = sqlx::PgPool::connect(url).await.expect("pool connect");
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*)::BIGINT FROM kv")
+        .fetch_one(&pool)
+        .await
+        .expect("count");
+    pool.close().await;
+    count
+}
+
+async fn name_for_id(url: &str, id: i32) -> Option<String> {
+    let pool = sqlx::PgPool::connect(url).await.expect("pool connect");
+    let name: Option<String> = sqlx::query_scalar("SELECT name FROM kv WHERE id = $1")
+        .bind(id)
+        .fetch_optional(&pool)
+        .await
+        .expect("read back");
+    pool.close().await;
+    name
+}
+
+fn upsert_sink_config(url: &str) -> PostgresSinkConfig {
+    let mut config = PostgresSinkConfig::new(url, "kv")
+        .column_mapping(PostgresColumnMapping::AutoMap)
+        .with_batch_size(0);
+    config.write = WriteSpec {
+        write_mode: WriteMode::Upsert,
+        key: vec!["id".into()],
+        delete_marker: None,
+    };
+    config
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn idempotent_upsert_updates_in_place_and_advances_token() {
+    let (_container, url) = start_postgres().await;
+    create_kv_table(&url).await;
+
+    let sink = PostgresSink::new(upsert_sink_config(&url))
+        .await
+        .expect("sink new");
+
+    let scope = "kv::r1";
+    let t1 = format_token(1);
+    let t2 = format_token(2);
+
+    // Page 1, token ...0001: upsert id=1 -> "a" in the idempotent path.
+    let written = sink
+        .write_batch_idempotent(&[json!({"id": 1, "name": "a"})], scope, &t1)
+        .await
+        .expect("idempotent upsert 1");
+    assert_eq!(written, 1, "one upsert applied");
+    assert_eq!(
+        sink.last_committed_token(scope).await.expect("token read"),
+        Some(t1.clone()),
+        "token advanced to t1"
+    );
+    assert_eq!(row_count(&url).await, 1);
+    assert_eq!(name_for_id(&url, 1).await.as_deref(), Some("a"));
+
+    // Page 2, token ...0002: upsert id=1 -> "b".
+    let written = sink
+        .write_batch_idempotent(&[json!({"id": 1, "name": "b"})], scope, &t2)
+        .await
+        .expect("idempotent upsert 2");
+    assert_eq!(written, 1, "one upsert applied (update in place)");
+
+    // Exactly ONE row id=1, now "b" — upserted in the idempotent path, not duplicated.
+    assert_eq!(
+        row_count(&url).await,
+        1,
+        "upsert in the idempotent path must update, not duplicate"
+    );
+    assert_eq!(
+        name_for_id(&url, 1).await.as_deref(),
+        Some("b"),
+        "row must reflect the latest value 'b'"
+    );
+
+    // Token advanced to t2 — committed atomically with the upsert.
+    assert_eq!(
+        sink.last_committed_token(scope).await.expect("token read"),
+        Some(t2),
+        "token advanced to t2 alongside the upsert"
+    );
+}

--- a/crates/sink/postgres/tests/upsert.rs
+++ b/crates/sink/postgres/tests/upsert.rs
@@ -89,7 +89,11 @@ async fn upsert_insert_then_update_same_key_keeps_one_row_with_latest_value() {
     sink.write_batch(&[json!({"id": 1, "name": "alice2"})])
         .await
         .expect("second upsert");
-    assert_eq!(row_count(&url).await, 1, "same key must not create a new row");
+    assert_eq!(
+        row_count(&url).await,
+        1,
+        "same key must not create a new row"
+    );
     assert_eq!(
         name_for_id(&url, 1).await.as_deref(),
         Some("alice2"),
@@ -126,7 +130,11 @@ async fn upsert_with_delete_marker_removes_the_row() {
     sink.write_batch(&[json!({"id": 1, "__op": "d"})])
         .await
         .expect("delete via marker");
-    assert_eq!(row_count(&url).await, 0, "delete-marker must remove the row");
+    assert_eq!(
+        row_count(&url).await,
+        0,
+        "delete-marker must remove the row"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -169,7 +177,10 @@ async fn write_batch_partial_routes_missing_key_per_row() {
         .await
         .expect("sink new");
 
-    let records = [json!({"id": 1, "name": "ok"}), json!({"name": "missing-id"})];
+    let records = [
+        json!({"id": 1, "name": "ok"}),
+        json!({"name": "missing-id"}),
+    ];
     let outcomes = sink
         .write_batch_partial(&records)
         .await

--- a/crates/sink/postgres/tests/upsert.rs
+++ b/crates/sink/postgres/tests/upsert.rs
@@ -1,0 +1,158 @@
+//! Integration tests for [`PostgresSink`]'s write-mode upsert/delete path
+//! against a real Postgres instance via testcontainers.
+//!
+//! These tests require Docker. Each test boots its own container so they are
+//! fully isolated and safe to run in parallel.
+
+use faucet_core::{DeleteMarker, Sink, WriteMode, WriteSpec};
+use faucet_sink_postgres::{PostgresColumnMapping, PostgresSink, PostgresSinkConfig};
+use serde_json::json;
+use testcontainers::{ContainerAsync, ImageExt, runners::AsyncRunner};
+use testcontainers_modules::postgres::Postgres;
+
+/// Start a Postgres container and return both the container handle and a
+/// connection URL.
+async fn start_postgres() -> (ContainerAsync<Postgres>, String) {
+    let image = Postgres::default().with_tag("16-alpine");
+    let container: ContainerAsync<Postgres> =
+        image.start().await.expect("postgres container start");
+    let port = container
+        .get_host_port_ipv4(5432)
+        .await
+        .expect("postgres port");
+    let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
+    (container, url)
+}
+
+/// Create the keyed `kv` table with a PRIMARY KEY on `id`.
+async fn create_kv_table(url: &str) {
+    let pool = sqlx::PgPool::connect(url).await.expect("pool connect");
+    sqlx::query("CREATE TABLE kv (id INT PRIMARY KEY, name TEXT)")
+        .execute(&pool)
+        .await
+        .expect("create table");
+    pool.close().await;
+}
+
+async fn row_count(url: &str) -> i64 {
+    let pool = sqlx::PgPool::connect(url).await.expect("pool connect");
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*)::BIGINT FROM kv")
+        .fetch_one(&pool)
+        .await
+        .expect("count");
+    pool.close().await;
+    count
+}
+
+async fn name_for_id(url: &str, id: i32) -> Option<String> {
+    let pool = sqlx::PgPool::connect(url).await.expect("pool connect");
+    let name: Option<String> = sqlx::query_scalar("SELECT name FROM kv WHERE id = $1")
+        .bind(id)
+        .fetch_optional(&pool)
+        .await
+        .expect("read back");
+    pool.close().await;
+    name
+}
+
+fn upsert_sink_config(url: &str) -> PostgresSinkConfig {
+    let mut config = PostgresSinkConfig::new(url, "kv")
+        .column_mapping(PostgresColumnMapping::AutoMap)
+        .with_batch_size(0);
+    config.write = WriteSpec {
+        write_mode: WriteMode::Upsert,
+        key: vec!["id".into()],
+        delete_marker: None,
+    };
+    config
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn upsert_insert_then_update_same_key_keeps_one_row_with_latest_value() {
+    let (_container, url) = start_postgres().await;
+    create_kv_table(&url).await;
+
+    let sink = PostgresSink::new(upsert_sink_config(&url))
+        .await
+        .expect("sink new");
+
+    // First write inserts the row.
+    let n = sink
+        .write_batch(&[json!({"id": 1, "name": "alice"})])
+        .await
+        .expect("first upsert");
+    assert_eq!(n, 1);
+    assert_eq!(row_count(&url).await, 1);
+    assert_eq!(name_for_id(&url, 1).await.as_deref(), Some("alice"));
+
+    // Second write updates the same key in place.
+    sink.write_batch(&[json!({"id": 1, "name": "alice2"})])
+        .await
+        .expect("second upsert");
+    assert_eq!(row_count(&url).await, 1, "same key must not create a new row");
+    assert_eq!(
+        name_for_id(&url, 1).await.as_deref(),
+        Some("alice2"),
+        "upsert must overwrite with the latest value"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn upsert_with_delete_marker_removes_the_row() {
+    let (_container, url) = start_postgres().await;
+    create_kv_table(&url).await;
+
+    let mut config = PostgresSinkConfig::new(&url, "kv")
+        .column_mapping(PostgresColumnMapping::AutoMap)
+        .with_batch_size(0);
+    config.write = WriteSpec {
+        write_mode: WriteMode::Upsert,
+        key: vec!["id".into()],
+        delete_marker: Some(DeleteMarker {
+            field: "__op".into(),
+            values: vec!["d".into()],
+        }),
+    };
+    let sink = PostgresSink::new(config).await.expect("sink new");
+
+    // Upsert the row (marker value "u" → not a delete; marker field is stripped).
+    sink.write_batch(&[json!({"id": 1, "name": "x", "__op": "u"})])
+        .await
+        .expect("upsert with marker");
+    assert_eq!(row_count(&url).await, 1);
+    assert_eq!(name_for_id(&url, 1).await.as_deref(), Some("x"));
+
+    // Marker value "d" → delete the row by key.
+    sink.write_batch(&[json!({"id": 1, "__op": "d"})])
+        .await
+        .expect("delete via marker");
+    assert_eq!(row_count(&url).await, 0, "delete-marker must remove the row");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn upsert_duplicate_keys_in_one_batch_collapse_last_write_wins() {
+    // Two records with the same key in ONE batch must collapse to a single
+    // upsert (planner dedup), so the ON CONFLICT target is never hit twice in
+    // one statement — which Postgres would reject with "ON CONFLICT DO UPDATE
+    // command cannot affect row a second time".
+    let (_container, url) = start_postgres().await;
+    create_kv_table(&url).await;
+
+    let sink = PostgresSink::new(upsert_sink_config(&url))
+        .await
+        .expect("sink new");
+
+    sink.write_batch(&[
+        json!({"id": 1, "name": "old"}),
+        json!({"id": 1, "name": "new"}),
+    ])
+    .await
+    .expect("duplicate-key batch upsert");
+
+    assert_eq!(row_count(&url).await, 1);
+    assert_eq!(
+        name_for_id(&url, 1).await.as_deref(),
+        Some("new"),
+        "last write within the batch wins"
+    );
+}

--- a/crates/sink/postgres/tests/upsert.rs
+++ b/crates/sink/postgres/tests/upsert.rs
@@ -156,3 +156,40 @@ async fn upsert_duplicate_keys_in_one_batch_collapse_last_write_wins() {
         "last write within the batch wins"
     );
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn write_batch_partial_routes_missing_key_per_row() {
+    // A page with one good row and one missing-key row: the good row is written
+    // (upsert applied) and only the missing-key row comes back as Err so the
+    // pipeline routes it to the DLQ per-row instead of failing the whole page.
+    let (_container, url) = start_postgres().await;
+    create_kv_table(&url).await;
+
+    let sink = PostgresSink::new(upsert_sink_config(&url))
+        .await
+        .expect("sink new");
+
+    let records = [json!({"id": 1, "name": "ok"}), json!({"name": "missing-id"})];
+    let outcomes = sink
+        .write_batch_partial(&records)
+        .await
+        .expect("partial write");
+
+    assert_eq!(outcomes.len(), 2, "one outcome per input row");
+    assert!(outcomes[0].is_ok(), "the good row must be Ok");
+    assert!(
+        outcomes[1].is_err(),
+        "the missing-key row must be Err (routed to the DLQ)"
+    );
+
+    assert_eq!(
+        row_count(&url).await,
+        1,
+        "only the good row should be written"
+    );
+    assert_eq!(
+        name_for_id(&url, 1).await.as_deref(),
+        Some("ok"),
+        "id=1 must be present with name 'ok'"
+    );
+}

--- a/crates/sink/sqlite/README.md
+++ b/crates/sink/sqlite/README.md
@@ -56,6 +56,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 | `column_mapping` | `SqliteColumnMapping` | `Json { column: "data" }` | How to map JSON records to table columns (see below) |
 | `batch_size` | `usize` | `1000` | Maximum number of rows per multi-row INSERT. See [Streaming and batching](#streaming-and-batching) below |
 | `max_connections` | `u32` | `1` | Maximum number of connections in the connection pool. SQLite serializes writers at the file level, so one writer is the safe default — a multi-connection pool against a single file races for the write lock and risks `SQLITE_BUSY`. The pool opens connections in WAL mode with a 5s `busy_timeout`, so raising this lets extra connections read concurrently with the single writer. |
+| `write_mode` | `"append"` \| `"upsert"` \| `"delete"` | `"append"` | Write semantics. Upsert/delete require `column_mapping: auto_map` and a UNIQUE/PRIMARY KEY on `key`. |
+| `key` | `[String]` | `[]` | Key column(s) for upsert/delete. Must be non-empty when `write_mode` is not `append`. |
+| `delete_marker` | object | absent | `upsert` only: identifies delete-flagged rows by field name + value list. |
 
 ### Streaming and batching
 
@@ -253,6 +256,77 @@ let sink = SqliteSink::new(config).await?;
 - In AutoMap mode, column names are discovered using `PRAGMA table_info(table_name)`. A multi-row INSERT is built dynamically. Column values are bound as **native SQLite types** — strings as `TEXT`, JSON numbers as `INTEGER`/`REAL`, booleans as `INTEGER` 0/1 — so column affinity and typed reads round-trip correctly. Arrays and objects (which have no scalar SQL representation) are bound as their JSON text. The INSERT column set is the **union** of record keys across the batch (in table order), so a field present only in a later record is still written; a row missing a column binds SQL `NULL`.
 - All identifiers (table names, column names) are quoted using `quote_ident()` (double-quote escaping) to prevent SQL injection.
 - Transaction wrapping ensures that either all rows in a batch are committed or none are, providing atomicity per batch.
+
+## Write modes (upsert / delete)
+
+By default the sink uses `write_mode: append` — every record is inserted as a new row. Two additional modes are available when `column_mapping: auto_map` is set and the target table has a `UNIQUE` or `PRIMARY KEY` constraint on the key column(s):
+
+| Mode | Behaviour |
+|------|-----------|
+| `append` (default) | Insert every record unconditionally. |
+| `upsert` | Insert-or-update by `key` (last-write-wins via `ON CONFLICT … DO UPDATE`). Optionally route delete-marked rows to `DELETE` via `delete_marker`. |
+| `delete` | Delete every record by `key`. |
+
+### Required fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `write_mode` | `"append"` \| `"upsert"` \| `"delete"` | `"append"` | Write semantics. |
+| `key` | `[String]` | `[]` | Key column(s). Required and non-empty for `upsert` / `delete`. |
+| `delete_marker` | `{ field: String, values: [String] }` | absent | `upsert` only: rows whose `field` matches one of `values` are routed to `DELETE`; all others are upserted. The marker field is stripped from upsert rows before writing. |
+
+**Requirements:**
+- `column_mapping` must be `auto_map` — key columns must be real table columns, not embedded inside a JSON blob.
+- The table must have a `UNIQUE` or `PRIMARY KEY` constraint on the `key` column(s) so SQLite's `ON CONFLICT` clause can enforce uniqueness.
+- Upsert/delete rows within a single batch are deduped by key (last-write-wins) before writing, so a single batch never conflicts with itself.
+
+### YAML example
+
+```yaml
+pipeline:
+  source:
+    type: postgres-cdc
+    config:
+      connection_url: postgres://user:pass@localhost/db
+      slot_name: faucet_slot
+      publication_name: faucet_pub
+  sink:
+    type: sqlite
+    config:
+      database_url: /data/warehouse.db
+      table_name: users
+      column_mapping: auto_map
+      write_mode: upsert
+      key: [id]
+      delete_marker:
+        field: __op
+        values: [d, delete]
+  state:
+    type: file
+    config:
+      path: ./state
+```
+
+### Rust example
+
+```rust
+use faucet_sink_sqlite::{SqliteColumnMapping, SqliteSink, SqliteSinkConfig};
+use faucet_core::{WriteMode, WriteSpec};
+
+let config = SqliteSinkConfig {
+    database_url: "sqlite:///data/warehouse.db".into(),
+    table_name: "users".into(),
+    column_mapping: SqliteColumnMapping::AutoMap,
+    batch_size: 1000,
+    max_connections: 1,
+    write: WriteSpec {
+        write_mode: WriteMode::Upsert,
+        key: vec!["id".to_string()],
+        delete_marker: None,
+    },
+};
+let sink = SqliteSink::new(config).await?;
+```
 
 ## Exactly-once delivery
 

--- a/crates/sink/sqlite/README.md
+++ b/crates/sink/sqlite/README.md
@@ -279,6 +279,7 @@ By default the sink uses `write_mode: append` — every record is inserted as a 
 - `column_mapping` must be `auto_map` — key columns must be real table columns, not embedded inside a JSON blob.
 - The table must have a `UNIQUE` or `PRIMARY KEY` constraint on the `key` column(s) so SQLite's `ON CONFLICT` clause can enforce uniqueness.
 - Upsert/delete rows within a single batch are deduped by key (last-write-wins) before writing, so a single batch never conflicts with itself.
+- A row missing or null in a key column fails. When a `dlq:` block is configured the good rows are still written and only the missing/null-key rows are routed to the DLQ per-row; without a DLQ the whole batch fails.
 
 ### YAML example
 

--- a/crates/sink/sqlite/src/config.rs
+++ b/crates/sink/sqlite/src/config.rs
@@ -59,6 +59,11 @@ pub struct SqliteSinkConfig {
     /// read concurrently with the single writer).
     #[serde(default = "default_max_connections")]
     pub max_connections: u32,
+    /// Write mode, key columns, and optional delete marker. `write_mode`
+    /// defaults to `append`. Upsert/delete require `column_mapping: auto_map`
+    /// and a UNIQUE/PRIMARY KEY constraint on `key`.
+    #[serde(flatten)]
+    pub write: faucet_core::WriteSpec,
 }
 
 fn default_batch_size() -> usize {
@@ -78,6 +83,7 @@ impl SqliteSinkConfig {
             column_mapping: SqliteColumnMapping::default(),
             batch_size: DEFAULT_BATCH_SIZE,
             max_connections: default_max_connections(),
+            write: faucet_core::WriteSpec::default(),
         }
     }
 

--- a/crates/sink/sqlite/src/sink.rs
+++ b/crates/sink/sqlite/src/sink.rs
@@ -10,6 +10,30 @@ use sqlx::{Row, SqlitePool};
 use std::str::FromStr;
 use std::time::Duration;
 
+/// Build the `ON CONFLICT(key) DO UPDATE …` tail for an upsert INSERT.
+/// Non-key columns are SET from `excluded`. If every column is a key column,
+/// emit `DO NOTHING`.
+fn on_conflict_clause(key: &[String], all_cols: &[String]) -> String {
+    let key_list = key
+        .iter()
+        .map(|k| quote_ident(k))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let updates: Vec<String> = all_cols
+        .iter()
+        .filter(|c| !key.iter().any(|k| k == *c))
+        .map(|c| format!("{q} = excluded.{q}", q = quote_ident(c)))
+        .collect();
+    if updates.is_empty() {
+        format!("ON CONFLICT({key_list}) DO NOTHING")
+    } else {
+        format!(
+            "ON CONFLICT({key_list}) DO UPDATE SET {}",
+            updates.join(", ")
+        )
+    }
+}
+
 /// A sink that writes JSON records to a SQLite table.
 pub struct SqliteSink {
     config: SqliteSinkConfig,
@@ -27,6 +51,17 @@ impl SqliteSink {
     /// preserves the previous behaviour of creating the database file on first
     /// open. WAL on a `sqlite::memory:` database is a harmless no-op.
     pub async fn new(config: SqliteSinkConfig) -> Result<Self, FaucetError> {
+        config.write.validate()?;
+        if !matches!(config.write.write_mode, faucet_core::WriteMode::Append)
+            && !matches!(config.column_mapping, SqliteColumnMapping::AutoMap)
+        {
+            return Err(FaucetError::Config(
+                "sqlite sink: write_mode upsert/delete requires column_mapping: auto_map \
+                 (key columns must be real columns, not inside a JSON blob)"
+                    .into(),
+            ));
+        }
+
         let options = SqliteConnectOptions::from_str(&config.database_url)
             .map_err(|e| FaucetError::Sink(format!("invalid SQLite database_url: {e}")))?
             .create_if_missing(true)
@@ -130,10 +165,16 @@ impl SqliteSink {
     /// runs on the transaction's own connection (`&mut **tx`), not on
     /// `&self.pool` — otherwise, with the default single-connection pool, it
     /// would deadlock waiting for a connection the open transaction is holding.
-    async fn insert_auto_map_tx(
+    ///
+    /// When `conflict_key` is `Some(key)`, each sub-chunk's INSERT is given an
+    /// `ON CONFLICT(key) DO UPDATE …` tail so it upserts by the key columns
+    /// (last-write-wins within the batch is handled by the planner's dedup,
+    /// so a single sub-chunk never double-hits the same conflict target).
+    async fn insert_auto_map_with_conflict_tx(
         &self,
         tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
         records: &[Value],
+        conflict_key: Option<&[String]>,
     ) -> Result<usize, FaucetError> {
         if records.is_empty() {
             return Ok(0);
@@ -221,12 +262,19 @@ impl SqliteSink {
             let row_placeholder = format!("({})", vec!["?"; num_cols].join(", "));
             let value_tuples: Vec<&str> =
                 (0..sub.len()).map(|_| row_placeholder.as_str()).collect();
-            let query = format!(
+            let base_query = format!(
                 "INSERT INTO {} ({}) VALUES {}",
                 quote_ident(&self.config.table_name),
                 col_names.join(", "),
                 value_tuples.join(", ")
             );
+            let query = match conflict_key {
+                Some(key) => format!(
+                    "{base_query} {}",
+                    on_conflict_clause(key, &insert_columns)
+                ),
+                None => base_query,
+            };
 
             let mut q = sqlx::query(&query);
             for matched in sub {
@@ -264,6 +312,117 @@ impl SqliteSink {
         }
 
         Ok(num_rows)
+    }
+
+    /// Auto-map insert against an in-progress transaction with plain append
+    /// semantics (no `ON CONFLICT` tail).
+    ///
+    /// Thin wrapper over
+    /// [`insert_auto_map_with_conflict_tx`](Self::insert_auto_map_with_conflict_tx)
+    /// so the append path and the idempotent-write path keep their original
+    /// signature.
+    async fn insert_auto_map_tx(
+        &self,
+        tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+        records: &[Value],
+    ) -> Result<usize, FaucetError> {
+        self.insert_auto_map_with_conflict_tx(tx, records, None)
+            .await
+    }
+
+    /// Delete rows whose key columns match any of `deletes`, using
+    /// `DELETE FROM t WHERE (k1, …) IN ((?, …), …)`, chunked at
+    /// SQLite's bind-variable cap. Runs inside the caller's transaction.
+    async fn delete_by_keys(
+        &self,
+        tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+        deletes: &[faucet_core::KeyTuple],
+    ) -> Result<usize, FaucetError> {
+        if deletes.is_empty() {
+            return Ok(0);
+        }
+        let key = &self.config.write.key;
+        let table_ref = quote_ident(&self.config.table_name);
+        let col_list = key
+            .iter()
+            .map(|k| quote_ident(k))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        const MAX_SQLITE_VARS: usize = 32766;
+        let per = (MAX_SQLITE_VARS / key.len().max(1)).max(1);
+        let mut total = 0usize;
+
+        for chunk in deletes.chunks(per) {
+            let tuples: Vec<String> = chunk
+                .iter()
+                .map(|_| format!("({})", vec!["?"; key.len()].join(", ")))
+                .collect();
+            let sql = format!(
+                "DELETE FROM {table_ref} WHERE ({col_list}) IN ({})",
+                tuples.join(", ")
+            );
+            let mut q = sqlx::query(&sql);
+            for kt in chunk {
+                for (_, v) in &kt.0 {
+                    // Bind native SQLite types — same logic as in the INSERT path.
+                    q = match v {
+                        Value::Null => q.bind(None::<String>),
+                        Value::Bool(b) => q.bind(*b),
+                        Value::Number(n) => {
+                            if let Some(i) = n.as_i64() {
+                                q.bind(i)
+                            } else if let Some(f) = n.as_f64() {
+                                q.bind(f)
+                            } else {
+                                q.bind(n.to_string())
+                            }
+                        }
+                        Value::String(s) => q.bind(s.clone()),
+                        other => q.bind(other.to_string()),
+                    };
+                }
+            }
+            let res = q
+                .execute(&mut **tx)
+                .await
+                .map_err(|e| FaucetError::Sink(format!("SQLite delete failed: {e}")))?;
+            total += res.rows_affected() as usize;
+        }
+        Ok(total)
+    }
+
+    /// Apply a planned upsert/delete batch inside one `BEGIN`/`COMMIT`
+    /// transaction. Upserts and deletes are wrapped together so they commit
+    /// atomically.
+    async fn apply_plan(
+        &self,
+        plan: &faucet_core::WritePlan,
+    ) -> Result<usize, FaucetError> {
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| FaucetError::Sink(format!("SQLite transaction begin failed: {e}")))?;
+
+        let mut affected = 0usize;
+        if !plan.upserts.is_empty() {
+            affected += self
+                .insert_auto_map_with_conflict_tx(
+                    &mut tx,
+                    &plan.upserts,
+                    Some(&self.config.write.key),
+                )
+                .await?;
+        }
+        if !plan.deletes.is_empty() {
+            affected += self.delete_by_keys(&mut tx, &plan.deletes).await?;
+        }
+
+        tx.commit()
+            .await
+            .map_err(|e| FaucetError::Sink(format!("SQLite transaction commit failed: {e}")))?;
+        Ok(affected)
     }
 
     /// Ensure the commit-token watermark table exists.
@@ -331,9 +490,29 @@ impl faucet_core::Sink for SqliteSink {
         Ok(CheckReport::single(probe))
     }
 
+    fn supported_write_modes(&self) -> &'static [faucet_core::WriteMode] {
+        &[
+            faucet_core::WriteMode::Append,
+            faucet_core::WriteMode::Upsert,
+            faucet_core::WriteMode::Delete,
+        ]
+    }
+
     async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
         if records.is_empty() {
             return Ok(0);
+        }
+
+        // Non-append modes: plan the writes and apply atomically.
+        if !matches!(self.config.write.write_mode, faucet_core::WriteMode::Append) {
+            let plan = faucet_core::plan_writes(records, &self.config.write);
+            if let Some((idx, msg)) = plan.failed.first() {
+                return Err(FaucetError::Sink(format!(
+                    "sqlite {}: row {idx}: {msg}",
+                    self.config.write.write_mode.as_str()
+                )));
+            }
+            return self.apply_plan(&plan).await;
         }
 
         // `batch_size = 0` is the "no batching" sentinel: write the entire
@@ -445,5 +624,35 @@ mod tests {
         let config = SqliteSinkConfig::new("sqlite::memory:", "logs");
         let sink = SqliteSink::new(config).await.unwrap();
         assert_eq!(sink.dataset_uri(), "sqlite://:memory:?table=logs");
+    }
+
+    #[test]
+    fn sqlite_on_conflict_clause() {
+        let clause = on_conflict_clause(
+            &["id".to_string()],
+            &["id".to_string(), "name".to_string()],
+        );
+        assert_eq!(
+            clause,
+            r#"ON CONFLICT("id") DO UPDATE SET "name" = excluded."name""#
+        );
+    }
+
+    #[test]
+    fn sqlite_on_conflict_all_keys_does_nothing() {
+        let clause = on_conflict_clause(&["id".to_string()], &["id".to_string()]);
+        assert_eq!(clause, r#"ON CONFLICT("id") DO NOTHING"#);
+    }
+
+    #[test]
+    fn sqlite_on_conflict_composite_key() {
+        let clause = on_conflict_clause(
+            &["a".to_string(), "b".to_string()],
+            &["a".to_string(), "b".to_string(), "v".to_string()],
+        );
+        assert_eq!(
+            clause,
+            r#"ON CONFLICT("a", "b") DO UPDATE SET "v" = excluded."v""#
+        );
     }
 }

--- a/crates/sink/sqlite/src/sink.rs
+++ b/crates/sink/sqlite/src/sink.rs
@@ -538,7 +538,7 @@ impl faucet_core::Sink for SqliteSink {
 
     /// Write a batch and report per-row outcomes.
     ///
-    /// In append mode this delegates to [`write_batch`](Self::write_batch) and
+    /// In append mode this delegates to [`write_batch`](faucet_core::Sink::write_batch) and
     /// maps a single success onto an all-`Ok(())` vector (the trait default).
     /// In upsert/delete mode the good rows are applied (upserts + deletes), and
     /// only the rows whose key could not be extracted (missing / null key) are

--- a/crates/sink/sqlite/src/sink.rs
+++ b/crates/sink/sqlite/src/sink.rs
@@ -269,10 +269,7 @@ impl SqliteSink {
                 value_tuples.join(", ")
             );
             let query = match conflict_key {
-                Some(key) => format!(
-                    "{base_query} {}",
-                    on_conflict_clause(key, &insert_columns)
-                ),
+                Some(key) => format!("{base_query} {}", on_conflict_clause(key, &insert_columns)),
                 None => base_query,
             };
 
@@ -395,10 +392,7 @@ impl SqliteSink {
     /// Apply a planned upsert/delete batch inside one `BEGIN`/`COMMIT`
     /// transaction. Upserts and deletes are wrapped together so they commit
     /// atomically.
-    async fn apply_plan(
-        &self,
-        plan: &faucet_core::WritePlan,
-    ) -> Result<usize, FaucetError> {
+    async fn apply_plan(&self, plan: &faucet_core::WritePlan) -> Result<usize, FaucetError> {
         let mut tx = self
             .pool
             .begin()
@@ -694,10 +688,8 @@ mod tests {
 
     #[test]
     fn sqlite_on_conflict_clause() {
-        let clause = on_conflict_clause(
-            &["id".to_string()],
-            &["id".to_string(), "name".to_string()],
-        );
+        let clause =
+            on_conflict_clause(&["id".to_string()], &["id".to_string(), "name".to_string()]);
         assert_eq!(
             clause,
             r#"ON CONFLICT("id") DO UPDATE SET "name" = excluded."name""#

--- a/crates/sink/sqlite/src/sink.rs
+++ b/crates/sink/sqlite/src/sink.rs
@@ -542,6 +542,36 @@ impl faucet_core::Sink for SqliteSink {
         Ok(total)
     }
 
+    /// Write a batch and report per-row outcomes.
+    ///
+    /// In append mode this delegates to [`write_batch`](Self::write_batch) and
+    /// maps a single success onto an all-`Ok(())` vector (the trait default).
+    /// In upsert/delete mode the good rows are applied (upserts + deletes), and
+    /// only the rows whose key could not be extracted (missing / null key) are
+    /// reported as `Err` so the pipeline routes them to the DLQ per-row instead
+    /// of sending the whole page.
+    async fn write_batch_partial(
+        &self,
+        records: &[Value],
+    ) -> Result<Vec<faucet_core::RowOutcome>, FaucetError> {
+        if matches!(self.config.write.write_mode, faucet_core::WriteMode::Append) {
+            self.write_batch(records).await?;
+            return Ok(records.iter().map(|_| Ok(())).collect());
+        }
+
+        let plan = faucet_core::plan_writes(records, &self.config.write);
+        self.apply_plan(&plan).await?;
+
+        let mut outcomes: Vec<faucet_core::RowOutcome> = records.iter().map(|_| Ok(())).collect();
+        for (idx, msg) in &plan.failed {
+            outcomes[*idx] = Err(FaucetError::Sink(format!(
+                "sqlite {}: {msg}",
+                self.config.write.write_mode.as_str()
+            )));
+        }
+        Ok(outcomes)
+    }
+
     fn supports_idempotent_writes(&self) -> bool {
         true
     }

--- a/crates/sink/sqlite/src/sink.rs
+++ b/crates/sink/sqlite/src/sink.rs
@@ -569,21 +569,57 @@ impl faucet_core::Sink for SqliteSink {
         token: &str,
     ) -> Result<usize, FaucetError> {
         self.ensure_commit_table().await?;
+
+        // For upsert/delete modes, plan the page before opening the transaction
+        // so a key-extraction failure aborts without leaving an open tx.
+        let plan = if matches!(self.config.write.write_mode, faucet_core::WriteMode::Append) {
+            None
+        } else {
+            let plan = faucet_core::plan_writes(records, &self.config.write);
+            if let Some((idx, msg)) = plan.failed.first() {
+                return Err(FaucetError::Sink(format!(
+                    "sqlite {}: row {idx}: {msg}",
+                    self.config.write.write_mode.as_str()
+                )));
+            }
+            Some(plan)
+        };
+
         let mut tx = self
             .pool
             .begin()
             .await
             .map_err(|e| FaucetError::Sink(format!("SQLite transaction begin failed: {e}")))?;
 
-        // Data insert and the commit-token upsert share ONE transaction so the
+        // Data write and the commit-token upsert share ONE transaction so the
         // page is committed atomically with its watermark: on crash either both
         // land or neither does, which is what makes a replay skip-on-resume
-        // produce zero duplicates.
-        let written = match &self.config.column_mapping {
-            SqliteColumnMapping::Json { column } => {
-                self.insert_json_tx(&mut tx, records, column).await?
+        // produce zero duplicates. For upsert/delete the planned upserts/deletes
+        // commit together with the watermark in this same tx (no nested tx —
+        // we reuse `apply_plan`'s helpers directly on this transaction).
+        let written = match &plan {
+            Some(plan) => {
+                let mut affected = 0usize;
+                if !plan.upserts.is_empty() {
+                    affected += self
+                        .insert_auto_map_with_conflict_tx(
+                            &mut tx,
+                            &plan.upserts,
+                            Some(&self.config.write.key),
+                        )
+                        .await?;
+                }
+                if !plan.deletes.is_empty() {
+                    affected += self.delete_by_keys(&mut tx, &plan.deletes).await?;
+                }
+                affected
             }
-            SqliteColumnMapping::AutoMap => self.insert_auto_map_tx(&mut tx, records).await?,
+            None => match &self.config.column_mapping {
+                SqliteColumnMapping::Json { column } => {
+                    self.insert_json_tx(&mut tx, records, column).await?
+                }
+                SqliteColumnMapping::AutoMap => self.insert_auto_map_tx(&mut tx, records).await?,
+            },
         };
 
         let upsert = format!(

--- a/crates/sink/sqlite/tests/exactly_once_upsert.rs
+++ b/crates/sink/sqlite/tests/exactly_once_upsert.rs
@@ -1,0 +1,125 @@
+//! Composition test (#190): exactly-once delivery + `write_mode: upsert`.
+//!
+//! Verifies that `write_batch_idempotent` routes through the upsert planner so
+//! the data write AND the commit-token watermark commit atomically in one
+//! transaction. Re-writing the same key in a later page (with a higher token)
+//! must UPDATE the row in place — not duplicate it — and advance the token.
+//!
+//! Runs against a tempfile SQLite database — no Docker required.
+
+use faucet_core::{Sink, WriteMode, WriteSpec, format_token};
+use faucet_sink_sqlite::{SqliteColumnMapping, SqliteSink, SqliteSinkConfig};
+use serde_json::json;
+use sqlx::Row;
+use sqlx::sqlite::SqlitePoolOptions;
+use tempfile::TempDir;
+
+async fn fresh_db(create_sql: &str) -> (TempDir, String) {
+    let dir = TempDir::new().expect("tempdir");
+    let path = dir.path().join("test.db");
+    let url = format!("sqlite://{}?mode=rwc", path.display());
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect(&url)
+        .await
+        .expect("connect");
+    sqlx::query(create_sql)
+        .execute(&pool)
+        .await
+        .expect("create table");
+    pool.close().await;
+    (dir, url)
+}
+
+async fn count_rows(url: &str, table: &str) -> i64 {
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect(url)
+        .await
+        .expect("connect");
+    let row = sqlx::query(&format!("SELECT COUNT(*) AS n FROM \"{table}\""))
+        .fetch_one(&pool)
+        .await
+        .expect("count");
+    let n: i64 = row.get("n");
+    pool.close().await;
+    n
+}
+
+async fn fetch_name(url: &str, id: i64) -> Option<String> {
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect(url)
+        .await
+        .expect("connect");
+    let row = sqlx::query("SELECT name FROM users WHERE id = ?")
+        .bind(id)
+        .fetch_optional(&pool)
+        .await
+        .expect("fetch");
+    pool.close().await;
+    row.map(|r| r.get::<String, _>("name"))
+}
+
+#[tokio::test]
+async fn idempotent_upsert_updates_in_place_and_advances_token() {
+    let (_dir, url) = fresh_db("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)").await;
+
+    let cfg = SqliteSinkConfig {
+        database_url: url.clone(),
+        table_name: "users".to_string(),
+        column_mapping: SqliteColumnMapping::AutoMap,
+        batch_size: 1000,
+        max_connections: 1,
+        write: WriteSpec {
+            write_mode: WriteMode::Upsert,
+            key: vec!["id".to_string()],
+            delete_marker: None,
+        },
+    };
+    let sink = SqliteSink::new(cfg).await.unwrap();
+
+    let scope = "users::r1";
+    let t1 = format_token(1);
+    let t2 = format_token(2);
+
+    // Page 1, token ...0001: upsert id=1 -> "a".
+    let written = sink
+        .write_batch_idempotent(&[json!({"id": 1, "name": "a"})], scope, &t1)
+        .await
+        .unwrap();
+    assert_eq!(written, 1, "one upsert applied");
+    assert_eq!(
+        sink.last_committed_token(scope).await.unwrap(),
+        Some(t1.clone()),
+        "token advanced to t1"
+    );
+    assert_eq!(count_rows(&url, "users").await, 1);
+    assert_eq!(fetch_name(&url, 1).await.as_deref(), Some("a"));
+
+    // Page 2, token ...0002: upsert id=1 -> "b" in the idempotent path.
+    let written = sink
+        .write_batch_idempotent(&[json!({"id": 1, "name": "b"})], scope, &t2)
+        .await
+        .unwrap();
+    assert_eq!(written, 1, "one upsert applied (update in place)");
+
+    // Exactly ONE row id=1, now named "b" — upserted, not duplicated.
+    assert_eq!(
+        count_rows(&url, "users").await,
+        1,
+        "upsert in the idempotent path must update, not duplicate"
+    );
+    assert_eq!(
+        fetch_name(&url, 1).await.as_deref(),
+        Some("b"),
+        "row must reflect the latest value 'b'"
+    );
+
+    // Token advanced to t2 — committed atomically with the upsert.
+    assert_eq!(
+        sink.last_committed_token(scope).await.unwrap(),
+        Some(t2),
+        "token advanced to t2 alongside the upsert"
+    );
+}

--- a/crates/sink/sqlite/tests/upsert.rs
+++ b/crates/sink/sqlite/tests/upsert.rs
@@ -176,3 +176,35 @@ async fn single_batch_last_write_wins() {
         "last-write-wins: final value must be 'new'"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Test 4: write_batch_partial routes missing-key rows to the DLQ per-row
+// ---------------------------------------------------------------------------
+#[tokio::test]
+async fn write_batch_partial_routes_missing_key_per_row() {
+    let (_dir, url) = fresh_db("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)").await;
+
+    let sink = SqliteSink::new(upsert_config(&url)).await.unwrap();
+
+    let records: Vec<Value> = vec![json!({"id": 1, "name": "ok"}), json!({"name": "missing-id"})];
+    let outcomes = sink.write_batch_partial(&records).await.unwrap();
+
+    assert_eq!(outcomes.len(), 2, "one outcome per input row");
+    assert!(outcomes[0].is_ok(), "the good row must be Ok");
+    assert!(
+        outcomes[1].is_err(),
+        "the missing-key row must be Err (routed to the DLQ)"
+    );
+
+    // The good row must have been written even though the page had a bad row.
+    assert_eq!(
+        count_rows(&url, "users").await,
+        1,
+        "only the good row should be written"
+    );
+    assert_eq!(
+        fetch_name(&url, 1).await.as_deref(),
+        Some("ok"),
+        "id=1 must be present with name 'ok'"
+    );
+}

--- a/crates/sink/sqlite/tests/upsert.rs
+++ b/crates/sink/sqlite/tests/upsert.rs
@@ -78,8 +78,7 @@ fn upsert_config(url: &str) -> SqliteSinkConfig {
 // ---------------------------------------------------------------------------
 #[tokio::test]
 async fn upsert_updates_existing_row() {
-    let (_dir, url) =
-        fresh_db("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)").await;
+    let (_dir, url) = fresh_db("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)").await;
 
     let sink = SqliteSink::new(upsert_config(&url)).await.unwrap();
 
@@ -111,8 +110,7 @@ async fn upsert_updates_existing_row() {
 // ---------------------------------------------------------------------------
 #[tokio::test]
 async fn delete_marker_removes_row() {
-    let (_dir, url) =
-        fresh_db("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)").await;
+    let (_dir, url) = fresh_db("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)").await;
 
     let config = SqliteSinkConfig {
         database_url: url.clone(),
@@ -153,8 +151,7 @@ async fn delete_marker_removes_row() {
 // ---------------------------------------------------------------------------
 #[tokio::test]
 async fn single_batch_last_write_wins() {
-    let (_dir, url) =
-        fresh_db("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)").await;
+    let (_dir, url) = fresh_db("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)").await;
 
     let sink = SqliteSink::new(upsert_config(&url)).await.unwrap();
 
@@ -186,7 +183,10 @@ async fn write_batch_partial_routes_missing_key_per_row() {
 
     let sink = SqliteSink::new(upsert_config(&url)).await.unwrap();
 
-    let records: Vec<Value> = vec![json!({"id": 1, "name": "ok"}), json!({"name": "missing-id"})];
+    let records: Vec<Value> = vec![
+        json!({"id": 1, "name": "ok"}),
+        json!({"name": "missing-id"}),
+    ];
     let outcomes = sink.write_batch_partial(&records).await.unwrap();
 
     assert_eq!(outcomes.len(), 2, "one outcome per input row");

--- a/crates/sink/sqlite/tests/upsert.rs
+++ b/crates/sink/sqlite/tests/upsert.rs
@@ -1,0 +1,178 @@
+//! Integration tests for the SQLite sink's upsert / delete write modes.
+//!
+//! All tests use a tempfile-backed SQLite database — no Docker required.
+
+use faucet_core::{DeleteMarker, Sink, WriteMode, WriteSpec};
+use faucet_sink_sqlite::{SqliteColumnMapping, SqliteSink, SqliteSinkConfig};
+use serde_json::{Value, json};
+use sqlx::Row;
+use sqlx::sqlite::SqlitePoolOptions;
+use tempfile::TempDir;
+
+/// Create a fresh tempfile SQLite DB with the given CREATE TABLE SQL.
+/// Returns `(TempDir, url)` — keep `TempDir` alive for the test duration.
+async fn fresh_db(create_sql: &str) -> (TempDir, String) {
+    let dir = TempDir::new().expect("tempdir");
+    let path = dir.path().join("test.db");
+    let url = format!("sqlite://{}?mode=rwc", path.display());
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect(&url)
+        .await
+        .expect("connect");
+    sqlx::query(create_sql)
+        .execute(&pool)
+        .await
+        .expect("create table");
+    pool.close().await;
+    (dir, url)
+}
+
+async fn count_rows(url: &str, table: &str) -> i64 {
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect(url)
+        .await
+        .expect("connect");
+    let row = sqlx::query(&format!("SELECT COUNT(*) AS n FROM \"{table}\""))
+        .fetch_one(&pool)
+        .await
+        .expect("count");
+    let n: i64 = row.get("n");
+    pool.close().await;
+    n
+}
+
+async fn fetch_name(url: &str, id: i64) -> Option<String> {
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect(url)
+        .await
+        .expect("connect");
+    let row = sqlx::query("SELECT name FROM users WHERE id = ?")
+        .bind(id)
+        .fetch_optional(&pool)
+        .await
+        .expect("fetch");
+    pool.close().await;
+    row.map(|r| r.get::<String, _>("name"))
+}
+
+fn upsert_config(url: &str) -> SqliteSinkConfig {
+    SqliteSinkConfig {
+        database_url: url.to_string(),
+        table_name: "users".to_string(),
+        column_mapping: SqliteColumnMapping::AutoMap,
+        batch_size: 1000,
+        max_connections: 1,
+        write: WriteSpec {
+            write_mode: WriteMode::Upsert,
+            key: vec!["id".to_string()],
+            delete_marker: None,
+        },
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: upsert updates an existing row (last-write-wins)
+// ---------------------------------------------------------------------------
+#[tokio::test]
+async fn upsert_updates_existing_row() {
+    let (_dir, url) =
+        fresh_db("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)").await;
+
+    let sink = SqliteSink::new(upsert_config(&url)).await.unwrap();
+
+    // Insert initial row.
+    sink.write_batch(&[json!({"id": 1, "name": "alice"})])
+        .await
+        .unwrap();
+    assert_eq!(count_rows(&url, "users").await, 1);
+    assert_eq!(fetch_name(&url, 1).await.as_deref(), Some("alice"));
+
+    // Upsert same key with a different name — must update in place.
+    sink.write_batch(&[json!({"id": 1, "name": "alice2"})])
+        .await
+        .unwrap();
+    assert_eq!(
+        count_rows(&url, "users").await,
+        1,
+        "upsert must not create a duplicate row"
+    );
+    assert_eq!(
+        fetch_name(&url, 1).await.as_deref(),
+        Some("alice2"),
+        "name must be updated to 'alice2'"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: delete_marker routes delete-flagged rows to deletes
+// ---------------------------------------------------------------------------
+#[tokio::test]
+async fn delete_marker_removes_row() {
+    let (_dir, url) =
+        fresh_db("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)").await;
+
+    let config = SqliteSinkConfig {
+        database_url: url.clone(),
+        table_name: "users".to_string(),
+        column_mapping: SqliteColumnMapping::AutoMap,
+        batch_size: 1000,
+        max_connections: 1,
+        write: WriteSpec {
+            write_mode: WriteMode::Upsert,
+            key: vec!["id".to_string()],
+            delete_marker: Some(DeleteMarker {
+                field: "__op".to_string(),
+                values: vec!["d".to_string()],
+            }),
+        },
+    };
+    let sink = SqliteSink::new(config).await.unwrap();
+
+    // First write: upsert a row (marker present but not "d").
+    sink.write_batch(&[json!({"id": 1, "name": "x", "__op": "u"})])
+        .await
+        .unwrap();
+    assert_eq!(count_rows(&url, "users").await, 1);
+
+    // Second write: delete the row via marker.
+    sink.write_batch(&[json!({"id": 1, "__op": "d"})])
+        .await
+        .unwrap();
+    assert_eq!(
+        count_rows(&url, "users").await,
+        0,
+        "delete-marked row must be removed from the table"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: within a single batch, last-write-wins per key
+// ---------------------------------------------------------------------------
+#[tokio::test]
+async fn single_batch_last_write_wins() {
+    let (_dir, url) =
+        fresh_db("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)").await;
+
+    let sink = SqliteSink::new(upsert_config(&url)).await.unwrap();
+
+    // One batch containing two records with the same key; the last one wins.
+    let records: Vec<Value> = vec![
+        json!({"id": 1, "name": "old"}),
+        json!({"id": 1, "name": "new"}),
+    ];
+    sink.write_batch(&records).await.unwrap();
+
+    assert_eq!(
+        count_rows(&url, "users").await,
+        1,
+        "duplicate key within one batch must produce exactly one row"
+    );
+    assert_eq!(
+        fetch_name(&url, 1).await.as_deref(),
+        Some("new"),
+        "last-write-wins: final value must be 'new'"
+    );
+}

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -20,6 +20,7 @@
 - [Pagination styles](./cookbook/pagination.md)
 - [Authentication](./cookbook/auth.md)
 - [Incremental replication & state](./cookbook/state.md)
+- [Upsert / mirror tables](./cookbook/upsert.md)
 - [Dead-letter queues](./cookbook/dlq.md)
 - [Data-quality checks](./cookbook/quality.md)
 - [Compression](./cookbook/compression.md)

--- a/docs/book/src/cookbook/transforms.md
+++ b/docs/book/src/cookbook/transforms.md
@@ -438,3 +438,56 @@ transforms:
   - { type: filter, config: { path: item_status, op: in, value: [active, pending] } }
   - { type: keys_case, config: { mode: snake } }
 ```
+
+## `cdc_unwrap` — normalize CDC change events into flat rows
+
+The CDC sources (`postgres-cdc`, `mysql-cdc`, `mongodb-cdc`) emit change-event
+**envelopes** — a wrapper carrying an operation code and the row's before/after
+images — not the bare rows themselves. `cdc_unwrap` flattens that envelope into a
+single row plus an `__op` marker, so a downstream
+[upsert sink](./upsert.md) can mirror the change without understanding CDC at all.
+It's the standard first transform in a CDC → mirror pipeline:
+
+```yaml
+transforms:
+  - type: cdc_unwrap
+```
+
+For each change event it:
+
+- **drops** DDL / truncate events (`op` ∈ `drop_ops`) — they have no row to mirror;
+- for a **delete** (`op` ∈ `delete_ops`), emits the pre-image (`before`), falling
+  back to `key_field` (MongoDB carries the key in `document_key` when there is no
+  `before`); rows with no usable key are dropped with a `tracing::warn!`;
+- for an **insert / update**, emits the post-image (`after`); events with no row
+  image are dropped with a warning;
+- stamps every emitted row with a `marker_field` (`__op`) set to the normalized
+  value **`"d"`** (delete) or **`"u"`** (upsert) — *not* the raw op code. A
+  downstream sink's `delete_marker` should therefore match `"d"`.
+
+It is a 1→0|1 stage (every input row becomes zero or one output row) and runs in
+declaration order like any other transform.
+
+### Config fields and defaults
+
+| Field | Default | Purpose |
+|-------|---------|---------|
+| `op_field` | `op` | Envelope field holding the operation code |
+| `after_field` | `after` | Envelope field holding the post-image |
+| `before_field` | `before` | Envelope field holding the pre-image |
+| `key_field` | `document_key` | Fallback key for deletes with no `before` (MongoDB) |
+| `marker_field` | `__op` | Field stamped on every emitted row (`"d"` / `"u"`) |
+| `delete_ops` | `["d", "delete"]` | `op` values that mean delete |
+| `drop_ops` | `["ddl", "truncate"]` | `op` values dropped entirely |
+
+The defaults span all three CDC vocabularies seen in the wild — `insert` /
+`update` / `delete` / `truncate`, `c` / `u` / `d` / `ddl`, and `c` / `u` / `r` /
+`d` / `ddl` — so a bare `- type: cdc_unwrap` works for postgres-cdc, mysql-cdc,
+and mongodb-cdc without per-source tuning.
+
+`cdc_unwrap` is a built-in transform gated on the `transform-cdc-unwrap` feature
+(included in the `full` build). It is **opaque** for column-lineage analysis (it
+reshapes the whole envelope), so faucet emits no column-lineage edges for it.
+
+See the [Upsert / mirror tables](./upsert.md) cookbook for the full
+CDC → mirror pipeline.

--- a/docs/book/src/cookbook/upsert.md
+++ b/docs/book/src/cookbook/upsert.md
@@ -1,0 +1,158 @@
+# Upsert / mirror tables
+
+By default every sink **appends** — each record becomes a new row. That is the
+right behaviour for event logs and immutable history, but it is wrong for a
+*mirror*: a destination table that should stay an exact, up-to-date replica of a
+source table, where an updated source row updates the mirror in place and a
+deleted source row disappears from the mirror.
+
+Upsert-capable sinks add two more write modes — `upsert` and `delete` — keyed by
+a configurable `key`, so faucet can keep a destination in sync with a changing
+source instead of only ever growing it.
+
+## Write modes
+
+Each upsert-capable sink config carries three flattened fields (they appear at
+the top level of the sink's `config`, alongside `table_name` etc.):
+
+| Field | Default | Purpose |
+|-------|---------|---------|
+| `write_mode` | `append` | `append`, `upsert`, or `delete` |
+| `key` | `[]` | Key columns. **Required and non-empty** for `upsert`/`delete`; ignored for `append` |
+| `delete_marker` | (none) | `upsert` only — `{ field: <name>, values: [<str>, …] }`; rows whose `field` matches one of `values` become deletes instead of upserts |
+
+- **`append`** — insert every record (the default; today's behaviour).
+- **`upsert`** — insert-or-update by `key`. If `delete_marker` is set, rows whose
+  marker field matches are routed to deletes instead; the marker field is
+  stripped from the upserted row before writing.
+- **`delete`** — delete by `key` for every record in the batch.
+
+## Supported sinks and their native primitives
+
+Six sinks support `upsert`/`delete`; every other sink is append-only.
+
+| Sink | Requires | Native primitive |
+|------|----------|------------------|
+| `postgres` | `column_mapping: auto_map` + UNIQUE/PK on `key` | `INSERT … ON CONFLICT … DO UPDATE` |
+| `sqlite` | `column_mapping: auto_map` + UNIQUE/PK on `key` | `INSERT … ON CONFLICT … DO UPDATE` |
+| `mysql` | `column_mapping: auto_map` + UNIQUE/PK on `key` | `INSERT … ON DUPLICATE KEY UPDATE` |
+| `mssql` | `column_mapping: auto_columns` + UNIQUE/PK on `key` | `MERGE` |
+| `mongodb` | — (schemaless) | `replace_one(upsert)` / `delete_one`, `key` → match filter |
+| `elasticsearch` | — (schemaless) | `_bulk` `index` / `delete`, `key` → `_id` |
+
+The **SQL sinks require column-mapping mode** — `column_mapping: auto_map`
+(postgres/mysql/sqlite) or `auto_columns` (mssql). The single-JSONB-column blob
+mode cannot upsert because there is no per-column conflict target. They also require a
+**UNIQUE or PRIMARY KEY constraint on the `key` columns** — that constraint is
+what the database's `ON CONFLICT` / `ON DUPLICATE KEY` / `MERGE` matches against;
+without it the upsert silently degrades to plain inserts. faucet does not create
+the constraint for you; create it on the destination table first.
+
+The **schemaless sinks** (MongoDB, Elasticsearch) have no such requirement: the
+`key` columns are joined into a document filter / `_id`, so the same record both
+inserts and replaces.
+
+> **Not yet supported:** BigQuery and Iceberg are append-only today. BigQuery
+> upsert needs a staging-table + `MERGE` design (and a quota/cost model), and
+> Iceberg upsert is blocked on equality-delete writer support in `iceberg-rust`.
+> Both are tracked as follow-ups.
+
+## Last-write-wins within a batch
+
+A single batch may contain several changes to the same key (common with CDC — an
+insert and three updates of one row in one transaction). faucet **deduplicates by
+`key` within the batch, last-write-wins**: only the final action for each key is
+applied. If the last action is a delete, the row is deleted; if it is an upsert,
+the row is upserted — regardless of what came before it in the batch. This keeps
+the write minimal and the result deterministic.
+
+## Missing or null keys
+
+`upsert`/`delete` need a key value for every row. A record that is not a JSON
+object, is missing a `key` column, or has a `null` value in a `key` column cannot
+be keyed:
+
+- **With a DLQ configured**, the offending rows are routed to the dead-letter
+  queue per-row (the rest of the batch still writes).
+- **Without a DLQ**, the whole batch fails with a typed error so the bad data is
+  never silently dropped.
+
+## CDC → mirror with `cdc_unwrap`
+
+The most common use of upsert is mirroring a database table via change-data
+capture. CDC sources emit change-event **envelopes** (`{op, before, after, …}`),
+not bare rows, so a [`cdc_unwrap`](./transforms.md#cdc_unwrap--normalize-cdc-change-events-into-flat-rows)
+transform sits between the source and the sink: it flattens the envelope into a
+single row and stamps an `__op` marker (`"u"` for insert/update, `"d"` for
+delete). The sink's `delete_marker` then routes the `"d"` rows to deletes.
+
+This is the shipped example
+[`cli/examples/postgres_cdc_to_postgres_upsert.yaml`](https://github.com/PawanSikawat/faucet-stream/blob/main/cli/examples/postgres_cdc_to_postgres_upsert.yaml):
+
+```yaml
+version: 1
+name: pg_cdc_mirror
+delivery: exactly_once
+
+pipeline:
+  source:
+    type: postgres-cdc
+    config:
+      connection_url: ${env:SOURCE_PG_URL}
+      slot_name: faucet_mirror
+      publication_name: faucet_pub
+      create_slot_if_missing: true
+      idle_timeout: 30
+
+  transforms:
+    - type: cdc_unwrap
+
+  sink:
+    type: postgres
+    config:
+      connection_url: ${env:DEST_PG_URL}
+      table_name: users_mirror
+      column_mapping: auto_map
+      write_mode: upsert
+      key: [id]
+      delete_marker: { field: __op, values: [d] }
+
+  state:
+    type: file
+    config:
+      path: ./state
+```
+
+The destination table needs a UNIQUE/PRIMARY KEY on the `key` columns before the
+first run:
+
+```sql
+CREATE TABLE IF NOT EXISTS users_mirror (id int4 PRIMARY KEY, name text);
+```
+
+Validate it offline (no database connection required):
+
+```bash
+faucet validate cli/examples/postgres_cdc_to_postgres_upsert.yaml
+```
+
+## Composing with exactly-once delivery
+
+`write_mode: upsert` composes with [`delivery: exactly_once`](./state.md#exactly-once-delivery)
+on the four SQL sinks (`postgres`, `mysql`, `mssql`, `sqlite`). The same four
+hard requirements apply, checked at config-load time:
+
+1. a CDC source (`postgres-cdc` / `mysql-cdc` / `mongodb-cdc`),
+2. an idempotent SQL sink (`postgres` / `mysql` / `mssql` / `sqlite`),
+3. a `state:` block, and
+4. **no** `dlq:` block (incompatible with exactly-once in this version).
+
+Under exactly-once the sink commits the upserted/deleted rows **and** the
+monotonic commit token in a single transaction, so a crash-and-resume never
+re-applies or skips a batch — the mirror stays exactly consistent with the source
+even across restarts. (Because exactly-once forbids a DLQ, a missing/null-key row
+fails the batch rather than being routed aside.)
+
+MongoDB and Elasticsearch support upsert but **not** exactly-once (their bulk
+APIs cannot commit a watermark atomically), so an upsert mirror into those sinks
+runs at-least-once.

--- a/docs/book/src/reference/connectors.md
+++ b/docs/book/src/reference/connectors.md
@@ -56,32 +56,39 @@ persists a tracking-column bookmark); in `full` mode it is not.
 Every sink exposes a `batch_size` knob for write-side re-chunking. For the
 file/append sinks (`jsonl`, `csv`, `stdout`) it's a no-op — they write per record.
 
-| Connector | Feature | `batch_size` | Compression | Exactly-once⁷ | Write unit |
-|-----------|---------|:---:|:---:|:---:|------------|
-| BigQuery | `sink-bigquery` | ✓ | ✗ | ✗ | `tabledata.insertAll` (per-row DLQ) |
-| PostgreSQL | `sink-postgres` | ✓ | ✗ | **✓** | multi-row `INSERT` (JSONB or mapped cols) |
-| JSON Lines | `sink-jsonl` | no-op | ✓ | ✗ | buffered file append |
-| Snowflake | `sink-snowflake` | ✓ | ✗ | ✗ | SQL REST API |
-| MySQL | `sink-mysql` | ✓ | ✗ | **✓** | multi-row `INSERT` |
-| Microsoft SQL Server | `sink-mssql` | ✓ | ✗ | **✓** | multi-row `INSERT` (2100-param auto-split, per-row DLQ) |
-| SQLite | `sink-sqlite` | ✓ | ✗ | **✓** | transaction-wrapped batch |
-| AWS S3 | `sink-s3` | ✓ | ✓ | ✗ | JSONL objects, parallel uploads |
-| Google Cloud Storage | `sink-gcs` | ✓ | ✓ | ✗ | JSONL objects |
-| MongoDB | `sink-mongodb` | ✓ | ✗ | ✗ | `insert_many` |
-| Redis | `sink-redis` | ✓ | ✗ | ✗ | streams, lists, key-value (pipelined) |
-| CSV | `sink-csv` | no-op | ✓ | ✗ | buffered file rows |
-| Elasticsearch | `sink-elasticsearch` | ✓ | ✗ | ✗ | `_bulk` NDJSON (per-row DLQ) |
-| HTTP | `sink-http` | ✓ | ✗ | ✗ | POST, concurrent under a semaphore |
-| Stdout | `sink-stdout` | no-op | ✗ | ✗ | JSON Lines / pretty JSON / TSV |
-| Apache Kafka | `sink-kafka` | ✓ | ✗ | ✗ | producer, batched sends, multi-topic routing |
-| Apache Parquet | `sink-parquet` | ✓ | ✗⁶ | ✗ | local/S3, schema inference, row/byte rollover |
-| Apache Iceberg | `sink-iceberg` | ✓ | ✗⁶ | **✓** | REST/Glue/SQL/HMS catalog, local + cloud (S3/GCS) warehouses, `fast_append` snapshot, Parquet data files |
+| Connector | Feature | `batch_size` | Compression | Upsert⁸ | Exactly-once⁷ | Write unit |
+|-----------|---------|:---:|:---:|:---:|:---:|------------|
+| BigQuery | `sink-bigquery` | ✓ | ✗ | ✗ | ✗ | `tabledata.insertAll` (per-row DLQ) |
+| PostgreSQL | `sink-postgres` | ✓ | ✗ | **✓** | **✓** | multi-row `INSERT` (JSONB or mapped cols) |
+| JSON Lines | `sink-jsonl` | no-op | ✓ | ✗ | ✗ | buffered file append |
+| Snowflake | `sink-snowflake` | ✓ | ✗ | ✗ | ✗ | SQL REST API |
+| MySQL | `sink-mysql` | ✓ | ✗ | **✓** | **✓** | multi-row `INSERT` |
+| Microsoft SQL Server | `sink-mssql` | ✓ | ✗ | **✓** | **✓** | multi-row `INSERT` (2100-param auto-split, per-row DLQ) |
+| SQLite | `sink-sqlite` | ✓ | ✗ | **✓** | **✓** | transaction-wrapped batch |
+| AWS S3 | `sink-s3` | ✓ | ✓ | ✗ | ✗ | JSONL objects, parallel uploads |
+| Google Cloud Storage | `sink-gcs` | ✓ | ✓ | ✗ | ✗ | JSONL objects |
+| MongoDB | `sink-mongodb` | ✓ | ✗ | **✓** | ✗ | `insert_many` |
+| Redis | `sink-redis` | ✓ | ✗ | ✗ | ✗ | streams, lists, key-value (pipelined) |
+| CSV | `sink-csv` | no-op | ✓ | ✗ | ✗ | buffered file rows |
+| Elasticsearch | `sink-elasticsearch` | ✓ | ✗ | **✓** | ✗ | `_bulk` NDJSON (per-row DLQ) |
+| HTTP | `sink-http` | ✓ | ✗ | ✗ | ✗ | POST, concurrent under a semaphore |
+| Stdout | `sink-stdout` | no-op | ✗ | ✗ | ✗ | JSON Lines / pretty JSON / TSV |
+| Apache Kafka | `sink-kafka` | ✓ | ✗ | ✗ | ✗ | producer, batched sends, multi-topic routing |
+| Apache Parquet | `sink-parquet` | ✓ | ✗⁶ | ✗ | ✗ | local/S3, schema inference, row/byte rollover |
+| Apache Iceberg | `sink-iceberg` | ✓ | ✗⁶ | ✗ | **✓** | REST/Glue/SQL/HMS catalog, local + cloud (S3/GCS) warehouses, `fast_append` snapshot, Parquet data files |
 
 ⁶ Parquet and Iceberg both handle compression internally at the Parquet column
 level, so the file-level `compression` feature doesn't apply to either.
 ⁷ **Exactly-once** = commits data and a watermark token atomically; required for
 `delivery: exactly_once`. BigQuery and Kafka are at-least-once only in this
 version. See [Exactly-once delivery](../cookbook/state.md#exactly-once-delivery).
+⁸ **Upsert** = supports `write_mode: upsert` / `delete` (insert-or-update and
+delete by `key`) in addition to plain `append`. The SQL sinks require
+column-mapping mode (`auto_map`, or `auto_columns` for mssql) and a
+UNIQUE/PRIMARY KEY on `key`; the
+schemaless sinks (MongoDB, Elasticsearch) map `key` to a match filter / `_id`.
+BigQuery and Iceberg upsert are not yet supported (follow-ups). See
+[Upsert / mirror tables](../cookbook/upsert.md).
 
 ## Authentication at a glance
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -55,6 +55,7 @@ The service column lists what each example touches; all are provided by
 | Example | Services |
 |---------|----------|
 | `postgres_cdc_to_jsonl.yaml` | postgres (logical replication preconfigured) |
+| `postgres_cdc_to_postgres_upsert.yaml` | postgres (CDC source + an upsert mirror table; `cdc_unwrap` + `write_mode: upsert`, exactly-once) |
 | `mongodb_cdc_to_jsonl.yaml` | mongodb (single-node replica set preconfigured; Change Streams) |
 | `mysql_cdc_to_jsonl.yaml` | mysql (binlog enabled; `repl` user with replication grants preconfigured) |
 | `rest_to_postgres.yaml`, `rest_to_postgres_with_quality.yaml`, `mongodb_to_postgres.yaml`, `graphql_to_postgres.yaml`, `webhook_to_postgres.yaml` | postgres (+ source) |

--- a/faucet-stream/Cargo.toml
+++ b/faucet-stream/Cargo.toml
@@ -172,7 +172,7 @@ transform-keys-case = ["faucet-source-rest?/transform-keys-case"]
 transform-filter = ["faucet-source-rest?/transform-filter"]
 transform-explode = ["faucet-source-rest?/transform-explode"]
 transform-cdc-unwrap = ["faucet-core/transform-cdc-unwrap"]
-transforms = ["faucet-source-rest?/transforms"]
+transforms = ["faucet-source-rest?/transforms", "transform-cdc-unwrap"]
 
 [dependencies]
 faucet-core.workspace = true

--- a/faucet-stream/Cargo.toml
+++ b/faucet-stream/Cargo.toml
@@ -94,7 +94,7 @@ lineage-kafka = ["lineage", "faucet-lineage/transport-kafka"]
 ## SQL-as-transform via embedded DuckDB.
 transform-sql = ["dep:faucet-transform-sql"]
 ## Every connector and state backend.
-full = ["source", "sink", "state", "auth", "kafka-schema-registry", "compression", "quality", "quality-jsonschema", "lineage", "lineage-kafka", "transform-sql"]
+full = ["source", "sink", "state", "auth", "kafka-schema-registry", "compression", "quality", "quality-jsonschema", "lineage", "lineage-kafka", "transform-sql", "transform-cdc-unwrap"]
 
 ## Individual source connectors.
 source-rest = ["dep:faucet-source-rest"]
@@ -171,6 +171,7 @@ transform-spell-symbols = ["faucet-source-rest?/transform-spell-symbols"]
 transform-keys-case = ["faucet-source-rest?/transform-keys-case"]
 transform-filter = ["faucet-source-rest?/transform-filter"]
 transform-explode = ["faucet-source-rest?/transform-explode"]
+transform-cdc-unwrap = ["faucet-core/transform-cdc-unwrap"]
 transforms = ["faucet-source-rest?/transforms"]
 
 [dependencies]


### PR DESCRIPTION
## Summary

Adds a unified per-sink **`write_mode: append | upsert | delete`** (merge by key) so CDC and re-syncable batch pipelines produce a **mirror table** (current state) instead of an append-only change log.

- **Core** — new `faucet_core::write_mode` module: `WriteMode` / `WriteSpec` (`write_mode` + `key` + `delete_marker`) / `plan_writes()` — one shared planner doing key extraction, last-write-wins dedup (so a batch can't hit `ON CONFLICT` twice), delete-marker classification + stripping, and missing/null-key bucketing. New object-safe `Sink::supported_write_modes()` (default append-only).
- **`cdc_unwrap` transform** (`transform-cdc-unwrap` feature) — normalizes all three CDC envelope shapes (`insert/update/delete/truncate`, `c/u/d/ddl`, `c/u/r/d/ddl`) into a flat row + an `__op` marker, so sinks stay schema-agnostic. Mongo deletes fall back to `document_key`; DDL/truncate are dropped with a warn.
- **Sinks** (upsert + delete): postgres / sqlite / mysql (`INSERT … ON CONFLICT` / `ON DUPLICATE KEY UPDATE`), mssql (`MERGE`, reusing the 2100-param auto-split), mongodb (`replace_one(upsert)` / `delete_one`, concurrent), elasticsearch (`_bulk` `index` / `delete` by key-derived `_id`). SQL sinks require column-mapping mode + a UNIQUE/PK on `key`; this is rejected at config load otherwise.
- **Exactly-once composition** — the 4 SQL sinks apply the upsert/delete **and** the commit token atomically in one transaction (`write_batch_idempotent` routed through `plan_writes`), so a CDC → SQL mirror with `delivery: exactly_once` is duplicate-free on resume.
- **CLI** — `registry::sink_supported_write_modes` allowlist + `expand.rs` load-time gate rejecting unsupported `write_mode × sink` and upsert/delete without `key`. `cdc_unwrap` exposed via the transform registry; feature wired through cli + umbrella (incl. `transforms`/`full`).
- **DLQ** — missing/null-key rows route per-row via a mode-aware `write_batch_partial` (good rows still written), honoring `on_batch_error`.
- **Docs** — `cookbook/upsert.md`, an Upsert column in the connector capability matrix, `cdc_unwrap` in the transforms cookbook, each sink README, and a runnable `cli/examples/postgres_cdc_to_postgres_upsert.yaml` (CDC → cdc_unwrap → postgres upsert, exactly-once).

## Scope

**Part of #190.** Lands the sinks with a clean native per-batch upsert primitive (SQL + Mongo + ES). The two remaining destinations are filed as cross-linked follow-ups (both genuinely separate / blocked):

- #224 — BigQuery upsert via staging table + `MERGE` (streaming `insertAll` can't upsert; needs a DML-quota-conscious design).
- #225 — Iceberg upsert via equality deletes (blocked on `iceberg-rust` exposing an equality-delete writer; relates to #179). Iceberg stays append-only with a typed rejection until then.

#190 stays open as the umbrella until #224 + #225 land.

## Test plan

- [ ] CI green (full `--all-features` workspace suite + the MSSQL container, which can't boot on Apple-Silicon locally).
- [x] `plan_writes` unit tests: key extraction, last-write-wins (upsert/delete ordering), marker strip, composite/null keys, empty page.
- [x] `cdc_unwrap` unit tests across all three CDC vocabularies + Mongo `document_key` deletes + DDL/truncate drop.
- [x] Per-sink upsert integration tests (insert→update→one row latest; delete→gone; dup-keys-in-batch→last wins): postgres/mysql/mongo (live via colima), sqlite (local), elasticsearch (wiremock NDJSON asserts); mssql logic unit-tested + compiles (CI runs its container).
- [x] Exactly-once + upsert integration tests for the 4 SQL sinks (token1 then token2 same key → one row, latest, token advanced): sqlite/postgres/mysql passing live; mssql compiles.
- [x] CLI validation: unsupported `write_mode × sink`, upsert/delete without `key`, unknown mode — rejected at load (unit + `faucet validate` e2e).
- [x] DLQ per-row missing-key routing (good row written, bad row → `Err`).
- [x] `cargo fmt` clean; per-crate `clippy -D warnings` clean; the new example validates and the shipped-examples test passes under `--features full`; mdBook builds.
