### PR TITLE
feat(bigquery-sink): exactly-once delivery via MERGE transaction (#215)

### DIFF
--- a/cli/examples/mongodb_cdc_to_bigquery_exactly_once.yaml
+++ b/cli/examples/mongodb_cdc_to_bigquery_exactly_once.yaml
@@ -10,15 +10,21 @@
 # idempotent sink (bigquery), a state store, and NO dlq block. These are
 # validated at config-load time — run `faucet validate` first.
 version: 1
-name: mongo-cdc-to-bigquery
-
+name: mongodb-cdc-to-bigquery
 pipeline:
   source:
     type: mongodb-cdc
     config:
-      connection_url: ${env:MONGODB_URI}
-      database: app
-      collection: orders
+      connection_uri: "mongodb://localhost:27017/?replicaSet=rs0"
+      scope:
+        type: collection
+        database: app
+        collection: orders
+      full_document: when_available
+      start_from:
+        type: now
+      idle_timeout: 30
+      batch_size: 1000
   sink:
     type: bigquery
     config:
@@ -33,6 +39,6 @@ pipeline:
   state:
     type: file
     config:
-      path: ./state
+      path: ./state/mongodb_cdc_bigquery.json
 
 delivery: exactly_once

--- a/cli/examples/mongodb_cdc_to_bigquery_exactly_once.yaml
+++ b/cli/examples/mongodb_cdc_to_bigquery_exactly_once.yaml
@@ -1,0 +1,38 @@
+# Exactly-once delivery: MongoDB CDC (Change Streams) → BigQuery.
+#
+# The BigQuery sink commits each page's rows and a per-page commit token in one
+# atomic multi-statement transaction (INSERT … SELECT FROM
+# UNNEST(JSON_QUERY_ARRAY(@payload)) + a MERGE into the `_faucet_commit_token`
+# watermark table). On crash/resume the pipeline reads the watermark and skips
+# already-committed pages, so the target table never sees duplicates.
+#
+# Exactly-once requires all four: a deterministic-replay CDC source, an
+# idempotent sink (bigquery), a state store, and NO dlq block. These are
+# validated at config-load time — run `faucet validate` first.
+version: 1
+name: mongo-cdc-to-bigquery
+
+pipeline:
+  source:
+    type: mongodb-cdc
+    config:
+      connection_url: ${env:MONGODB_URI}
+      database: app
+      collection: orders
+  sink:
+    type: bigquery
+    config:
+      project_id: my-gcp-project
+      dataset_id: analytics
+      # The target table must already exist with a defined schema — the sink
+      # reads it to generate the typed INSERT. Keep pages within BigQuery's
+      # ~10 MB jobs.query request limit.
+      table_id: orders
+      auth:
+        type: application_default
+  state:
+    type: file
+    config:
+      path: ./state
+
+delivery: exactly_once

--- a/cli/src/expand.rs
+++ b/cli/src/expand.rs
@@ -433,7 +433,7 @@ pub fn expand(cfg: &PipelineConfig) -> CliResult<Vec<ExpandedNode>> {
             if !crate::registry::sink_supports_idempotent_writes(&merged_sink.kind) {
                 return Err(CliError::Config(format!(
                     "row '{}': delivery: exactly_once is not supported by sink '{}' \
-                     (idempotent sinks only: sqlite, postgres, mysql, mssql, iceberg)",
+                     (idempotent sinks only: sqlite, postgres, mysql, mssql, iceberg, bigquery)",
                     ids[i], merged_sink.kind
                 )));
             }

--- a/cli/src/registry.rs
+++ b/cli/src/registry.rs
@@ -351,7 +351,10 @@ pub fn source_supports_exactly_once(kind: &str) -> bool {
 /// Mirrors `Sink::supports_idempotent_writes` overrides — keep in sync when a
 /// new sink opts in.
 pub fn sink_supports_idempotent_writes(kind: &str) -> bool {
-    matches!(kind, "sqlite" | "postgres" | "mysql" | "mssql" | "iceberg")
+    matches!(
+        kind,
+        "sqlite" | "postgres" | "mysql" | "mssql" | "iceberg" | "bigquery"
+    )
 }
 
 /// Write modes each sink kind supports. Kept in sync with each sink's
@@ -981,6 +984,7 @@ mod tests {
 
         assert!(sink_supports_idempotent_writes("postgres"));
         assert!(sink_supports_idempotent_writes("iceberg"));
+        assert!(sink_supports_idempotent_writes("bigquery"));
         assert!(!sink_supports_idempotent_writes("jsonl"));
     }
 

--- a/crates/sink/bigquery/Cargo.toml
+++ b/crates/sink/bigquery/Cargo.toml
@@ -17,7 +17,7 @@ gcp-bigquery-client = "0.28.0"
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-tokio = { workspace = true, features = ["sync"] }
+tokio = { workspace = true, features = ["sync", "time"] }
 tracing.workspace = true
 async-trait.workspace = true
 

--- a/crates/sink/bigquery/Cargo.toml
+++ b/crates/sink/bigquery/Cargo.toml
@@ -17,7 +17,7 @@ gcp-bigquery-client = "0.28.0"
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["sync"] }
 tracing.workspace = true
 async-trait.workspace = true
 

--- a/crates/sink/bigquery/README.md
+++ b/crates/sink/bigquery/README.md
@@ -262,6 +262,44 @@ let sink = BigQuerySink::new(config).await?;
 - Per-row errors in the BigQuery response are detected and reported. If any rows fail, the entire batch returns an error with details about the first failure.
 - The client is reused across all `write_batch()` calls -- no re-authentication per request.
 
+## Exactly-once delivery
+
+`BigQuerySink` implements `Sink::supports_idempotent_writes` (returns `true`) and the two companion hooks:
+
+- `write_batch_idempotent(records, scope, token)` — writes the page **and** records the `token` for `scope` in **one BigQuery multi-statement transaction**: a typed `INSERT INTO <target> SELECT … FROM UNNEST(JSON_QUERY_ARRAY(@payload))` (the page ships as a single bound JSON parameter; each column is cast per the target table's schema, fetched once via `tables.get`) followed by a `MERGE` into the `_faucet_commit_token` watermark table in the target dataset. Either both commit or neither does. Success is verified authoritatively via the job's `errorResult`, so a runtime failure (a bad `CAST`, a `NULL` into a `REQUIRED` column) aborts the page rather than advancing the bookmark over data that never landed.
+- `last_committed_token(scope)` — reads the watermark row for `scope` so the pipeline can skip already-committed pages on resume.
+
+On crash/resume the pipeline reads `last_committed_token` and skips any page whose token is already committed, so the target table never sees duplicates. This is **append-with-idempotency**, distinct from the default streaming `insertAll` path and from key-based upsert (`write_mode`), which BigQuery does not support.
+
+**Requirements & limits.** The target table must already exist with a defined schema (the sink reads it to build the typed INSERT — a schemaless table is rejected with a clear error). Because each page commits as one atomic transaction (one token per page, no `batch_size` re-chunking on this path), the page must serialize within BigQuery's ~10 MB `jobs.query` request limit — keep the CDC source's per-page size modest. A scalar column whose JSON value is an object/array is coerced to `NULL` (or, for a `REQUIRED` column, fails the INSERT). This path uses BigQuery DML, which has concurrency limits; it is intended for the opt-in exactly-once mode, not high-rate streaming (use the default streaming `insertAll` path for that).
+
+To use exactly-once delivery, set `delivery: exactly_once` in your pipeline config and pair this sink with one of the CDC sources (`postgres-cdc`, `mysql-cdc`, `mongodb-cdc`) plus a `state:` block. A DLQ is not permitted in exactly-once mode. All four requirements are validated at config-load time (`faucet validate`) before any run starts.
+
+```yaml
+pipeline:
+  source:
+    type: mongodb-cdc
+    config:
+      connection_url: mongodb://localhost:27017
+      database: app
+      collection: orders
+  sink:
+    type: bigquery
+    config:
+      project_id: my-gcp-project
+      dataset_id: analytics
+      table_id: orders
+      auth:
+        type: application_default
+  state:
+    type: file
+    config:
+      path: ./state
+delivery: exactly_once
+```
+
+See the [Exactly-once delivery cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/state.html#exactly-once-delivery) for full rationale and the supported source/sink set.
+
 ## Dead-letter queue support
 
 This sink overrides `Sink::write_batch_partial` to surface per-row

--- a/crates/sink/bigquery/README.md
+++ b/crates/sink/bigquery/README.md
@@ -280,9 +280,13 @@ pipeline:
   source:
     type: mongodb-cdc
     config:
-      connection_url: mongodb://localhost:27017
-      database: app
-      collection: orders
+      connection_uri: "mongodb://localhost:27017/?replicaSet=rs0"
+      scope:
+        type: collection
+        database: app
+        collection: orders
+      start_from:
+        type: now
   sink:
     type: bigquery
     config:

--- a/crates/sink/bigquery/src/idempotent.rs
+++ b/crates/sink/bigquery/src/idempotent.rs
@@ -1,0 +1,155 @@
+//! Schema-driven SQL generation for the BigQuery exactly-once write path (#215).
+//!
+//! All functions here are **pure** (no I/O): given the target table's schema as
+//! [`FieldSpec`]s, they generate the SQL for the atomic
+//! `INSERT … SELECT FROM UNNEST(JSON_QUERY_ARRAY(@payload))` + watermark `MERGE`
+//! transaction that makes a page's rows and its commit token land atomically.
+//! See `docs/superpowers/specs/2026-06-10-bigquery-exactly-once-design.md`.
+
+#[allow(unused_imports)]
+use faucet_core::idempotency::{
+    COMMIT_TOKEN_SCOPE_COL, COMMIT_TOKEN_TABLE, COMMIT_TOKEN_TOKEN_COL,
+};
+use gcp_bigquery_client::model::field_type::FieldType;
+use gcp_bigquery_client::model::table_field_schema::TableFieldSchema;
+
+/// A normalized BigQuery column spec — the sink's own mirror of the client's
+/// `TableFieldSchema`, so the SQL generator is independent of the client model
+/// and trivially constructible in unit tests.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FieldSpec {
+    /// Column / field name (a valid BigQuery identifier, since it came from
+    /// BigQuery's own schema).
+    pub name: String,
+    /// Normalized type.
+    pub ty: BqType,
+    /// `true` for a `REPEATED` (array) column.
+    pub repeated: bool,
+    /// Sub-fields for `STRUCT`/`RECORD` columns (empty otherwise).
+    pub fields: Vec<FieldSpec>,
+}
+
+/// Normalized BigQuery type, collapsing the client's alias variants
+/// (`INT64`=`INTEGER`, `FLOAT64`=`FLOAT`, `BOOL`=`BOOLEAN`, `STRUCT`=`RECORD`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BqType {
+    String,
+    Bytes,
+    Int64,
+    Float64,
+    Numeric,
+    BigNumeric,
+    Bool,
+    Timestamp,
+    Date,
+    Time,
+    Datetime,
+    Interval,
+    Geography,
+    Json,
+    Struct,
+}
+
+impl BqType {
+    /// Map the client's `FieldType` discriminant to a normalized [`BqType`].
+    pub fn from_field_type(ft: &FieldType) -> Self {
+        match ft {
+            FieldType::String => BqType::String,
+            FieldType::Bytes => BqType::Bytes,
+            FieldType::Integer | FieldType::Int64 => BqType::Int64,
+            FieldType::Float | FieldType::Float64 => BqType::Float64,
+            FieldType::Numeric => BqType::Numeric,
+            FieldType::Bignumeric => BqType::BigNumeric,
+            FieldType::Boolean | FieldType::Bool => BqType::Bool,
+            FieldType::Timestamp => BqType::Timestamp,
+            FieldType::Date => BqType::Date,
+            FieldType::Time => BqType::Time,
+            FieldType::Datetime => BqType::Datetime,
+            FieldType::Interval => BqType::Interval,
+            FieldType::Geography => BqType::Geography,
+            FieldType::Json => BqType::Json,
+            FieldType::Record | FieldType::Struct => BqType::Struct,
+        }
+    }
+
+    /// The BigQuery SQL type keyword used in a `CAST(... AS <kw>)` / array
+    /// element type.
+    #[allow(dead_code)]
+    fn sql_keyword(&self) -> &'static str {
+        match self {
+            BqType::String => "STRING",
+            BqType::Bytes => "BYTES",
+            BqType::Int64 => "INT64",
+            BqType::Float64 => "FLOAT64",
+            BqType::Numeric => "NUMERIC",
+            BqType::BigNumeric => "BIGNUMERIC",
+            BqType::Bool => "BOOL",
+            BqType::Timestamp => "TIMESTAMP",
+            BqType::Date => "DATE",
+            BqType::Time => "TIME",
+            BqType::Datetime => "DATETIME",
+            BqType::Interval => "INTERVAL",
+            BqType::Geography => "GEOGRAPHY",
+            BqType::Json => "JSON",
+            BqType::Struct => "STRUCT",
+        }
+    }
+}
+
+impl FieldSpec {
+    /// Convert a client `TableFieldSchema` (possibly nested) into a [`FieldSpec`].
+    pub fn from_table_field(f: &TableFieldSchema) -> Self {
+        let repeated = f.mode.as_deref() == Some("REPEATED");
+        let ty = BqType::from_field_type(&f.r#type);
+        let fields = f
+            .fields
+            .as_ref()
+            .map(|sub| sub.iter().map(FieldSpec::from_table_field).collect())
+            .unwrap_or_default();
+        FieldSpec {
+            name: f.name.clone(),
+            ty,
+            repeated,
+            fields,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scalar(name: &str, ty: BqType) -> FieldSpec {
+        FieldSpec { name: name.into(), ty, repeated: false, fields: vec![] }
+    }
+
+    #[test]
+    fn field_type_aliases_collapse() {
+        assert_eq!(BqType::from_field_type(&FieldType::Integer), BqType::Int64);
+        assert_eq!(BqType::from_field_type(&FieldType::Int64), BqType::Int64);
+        assert_eq!(BqType::from_field_type(&FieldType::Float), BqType::Float64);
+        assert_eq!(BqType::from_field_type(&FieldType::Boolean), BqType::Bool);
+        assert_eq!(BqType::from_field_type(&FieldType::Record), BqType::Struct);
+        assert_eq!(BqType::from_field_type(&FieldType::Struct), BqType::Struct);
+    }
+
+    #[test]
+    fn from_table_field_reads_mode_and_nested_fields() {
+        let tf = TableFieldSchema {
+            name: "addr".into(),
+            r#type: FieldType::Record,
+            mode: Some("REPEATED".into()),
+            fields: Some(vec![TableFieldSchema::string("city")]),
+            categories: None,
+            description: None,
+            policy_tags: None,
+        };
+        let fs = FieldSpec::from_table_field(&tf);
+        assert_eq!(fs, FieldSpec {
+            name: "addr".into(),
+            ty: BqType::Struct,
+            repeated: true,
+            fields: vec![scalar("city", BqType::String)],
+        });
+    }
+}

--- a/crates/sink/bigquery/src/idempotent.rs
+++ b/crates/sink/bigquery/src/idempotent.rs
@@ -5,8 +5,10 @@
 //! `INSERT … SELECT FROM UNNEST(JSON_QUERY_ARRAY(@payload))` + watermark `MERGE`
 //! transaction that makes a page's rows and its commit token land atomically.
 //! See `docs/superpowers/specs/2026-06-10-bigquery-exactly-once-design.md`.
+// Builder functions are wired into sink.rs in a later task; suppress dead_code
+// until they are called from the write path.
+#![allow(dead_code)]
 
-#[allow(unused_imports)]
 use faucet_core::idempotency::{
     COMMIT_TOKEN_SCOPE_COL, COMMIT_TOKEN_TABLE, COMMIT_TOKEN_TOKEN_COL,
 };
@@ -74,7 +76,6 @@ impl BqType {
 
     /// The BigQuery SQL type keyword used in a `CAST(... AS <kw>)` / array
     /// element type.
-    #[allow(dead_code)]
     fn sql_keyword(&self) -> &'static str {
         match self {
             BqType::String => "STRING",
@@ -123,7 +124,6 @@ fn sql_str(s: &str) -> String {
 
 /// Backtick-quoted identifier. BigQuery identifiers never contain a backtick
 /// (the schema came from BigQuery), so a stray one is stripped defensively.
-#[allow(dead_code)]
 fn quote_ident(name: &str) -> String {
     format!("`{}`", name.replace('`', ""))
 }
@@ -173,9 +173,9 @@ fn struct_field_list(fields: &[FieldSpec], json_var: &str, base_path: &str, dept
 
 /// Generate the SQL extraction expression for one column.
 ///
-/// `json_var` is the SQL expression naming the current JSON value (the row alias
-/// `r` at the top level, or an `UNNEST` element alias deeper down). `path` is
-/// the JSONPath into `json_var` for this field. `depth` keeps nested `UNNEST`
+/// `json_var` is always the UNNEST element alias or the top-level row variable;
+/// `path` is always a JSONPath relative to that variable's JSON root (e.g. `"$.field"`
+/// at top level, `"$.child"` inside a nested struct). `depth` keeps nested `UNNEST`
 /// aliases unique (`e{depth}` for struct elements, `x{depth}` for scalars).
 fn column_expr(field: &FieldSpec, json_var: &str, path: &str, depth: usize) -> String {
     if field.repeated {
@@ -207,6 +207,110 @@ fn column_expr(field: &FieldSpec, json_var: &str, path: &str, depth: usize) -> S
         };
         wrap_scalar(&field.ty, &raw)
     }
+}
+
+/// Backtick-quoted fully-qualified table reference (`` `project.dataset.table` ``).
+///
+/// Inputs are not backtick-stripped (unlike [`quote_ident`]): BigQuery
+/// project/dataset/table names cannot contain a backtick per BQ naming rules,
+/// and these come from admin-controlled config, never from row data.
+fn table_ref(project: &str, dataset: &str, table: &str) -> String {
+    format!("`{project}.{dataset}.{table}`")
+}
+
+/// Reference to the shared commit-token watermark table in the target dataset.
+fn commit_table_ref(project: &str, dataset: &str) -> String {
+    format!("`{project}.{dataset}.{COMMIT_TOKEN_TABLE}`")
+}
+
+/// `CREATE TABLE IF NOT EXISTS` for the watermark table. Run as its own query
+/// job (DDL is kept out of the data transaction, mirroring the SQL sinks).
+pub fn build_create_commit_table(project: &str, dataset: &str) -> String {
+    format!(
+        "CREATE TABLE IF NOT EXISTS {t} ({scope} STRING NOT NULL, {token} STRING NOT NULL, updated_at TIMESTAMP)",
+        t = commit_table_ref(project, dataset),
+        scope = COMMIT_TOKEN_SCOPE_COL,
+        token = COMMIT_TOKEN_TOKEN_COL,
+    )
+}
+
+/// Parameterized read of the last committed token for `@scope`.
+///
+/// `LIMIT 1` has no `ORDER BY`: the `MERGE` below maintains exactly one
+/// watermark row per scope, so there is never more than one row to choose from.
+pub fn build_select_token(project: &str, dataset: &str) -> String {
+    format!(
+        "SELECT {token} FROM {t} WHERE {scope} = @scope LIMIT 1",
+        token = COMMIT_TOKEN_TOKEN_COL,
+        t = commit_table_ref(project, dataset),
+        scope = COMMIT_TOKEN_SCOPE_COL,
+    )
+}
+
+/// Parameterized upsert of the watermark row (one row per `scope`).
+pub fn build_merge_token(project: &str, dataset: &str) -> String {
+    format!(
+        "MERGE {t} T USING (SELECT @scope AS {scope}, @token AS {token}) S ON T.{scope} = S.{scope} \
+WHEN MATCHED THEN UPDATE SET {token} = S.{token}, updated_at = CURRENT_TIMESTAMP() \
+WHEN NOT MATCHED THEN INSERT ({scope}, {token}, updated_at) VALUES (S.{scope}, S.{token}, CURRENT_TIMESTAMP())",
+        t = commit_table_ref(project, dataset),
+        scope = COMMIT_TOKEN_SCOPE_COL,
+        token = COMMIT_TOKEN_TOKEN_COL,
+    )
+}
+
+/// The typed `INSERT … SELECT FROM UNNEST(JSON_QUERY_ARRAY(@payload))` statement.
+fn build_insert_select(columns: &[FieldSpec], project: &str, dataset: &str, table: &str) -> String {
+    let col_list = columns
+        .iter()
+        .map(|f| quote_ident(&f.name))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let exprs = columns
+        .iter()
+        .map(|f| {
+            let path = format!("${}", json_path_segment(&f.name));
+            column_expr(f, "r", &path, 0)
+        })
+        .collect::<Vec<_>>()
+        .join(",\n    ");
+    format!(
+        "INSERT INTO {t} ({col_list})\nSELECT\n    {exprs}\nFROM UNNEST(JSON_QUERY_ARRAY(@payload)) AS r",
+        t = table_ref(project, dataset, table),
+    )
+}
+
+/// The full atomic transaction: typed INSERT of the page + watermark MERGE.
+pub fn build_transaction_sql(columns: &[FieldSpec], project: &str, dataset: &str, table: &str) -> String {
+    format!(
+        "BEGIN TRANSACTION;\n{insert};\n{merge};\nCOMMIT TRANSACTION;",
+        insert = build_insert_select(columns, project, dataset, table),
+        merge = build_merge_token(project, dataset),
+    )
+}
+
+/// Deterministic, sanitized `requestId` for transport-retry dedup. Correctness
+/// does not depend on it (the transaction + core skip logic are authoritative);
+/// it just suppresses duplicate jobs from a retried HTTP request within
+/// BigQuery's stateless-query window.
+///
+/// The scope hash uses FNV-1a rather than `std::hash::DefaultHasher` so the id
+/// is byte-stable across Rust toolchains (`DefaultHasher`'s algorithm is
+/// explicitly allowed to change between releases). The resulting id is bounded
+/// at ~112 chars — well under BigQuery's 1024-char `requestId` limit.
+pub fn build_request_id(scope: &str, token: &str) -> String {
+    // FNV-1a 64-bit over the scope bytes.
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in scope.as_bytes() {
+        h ^= u64::from(*b);
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    let safe_scope: String = scope
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() || c == '-' || c == '_' { c } else { '_' })
+        .take(64)
+        .collect();
+    format!("faucet_eo_{safe_scope}_{h:016x}_{token}")
 }
 
 #[cfg(test)]
@@ -323,5 +427,57 @@ mod tests {
         assert_eq!(json_path_segment("ok_name"), ".ok_name");
         assert_eq!(json_path_segment("_lead"), "._lead");
         assert_eq!(json_path_segment("1bad"), "['1bad']");
+    }
+
+    #[test]
+    fn create_commit_table_sql() {
+        assert_eq!(build_create_commit_table("p", "d"),
+            "CREATE TABLE IF NOT EXISTS `p.d._faucet_commit_token` (scope STRING NOT NULL, token STRING NOT NULL, updated_at TIMESTAMP)");
+    }
+
+    #[test]
+    fn select_token_sql() {
+        assert_eq!(build_select_token("p", "d"),
+            "SELECT token FROM `p.d._faucet_commit_token` WHERE scope = @scope LIMIT 1");
+    }
+
+    #[test]
+    fn merge_token_sql() {
+        assert_eq!(build_merge_token("p", "d"),
+            "MERGE `p.d._faucet_commit_token` T USING (SELECT @scope AS scope, @token AS token) S ON T.scope = S.scope WHEN MATCHED THEN UPDATE SET token = S.token, updated_at = CURRENT_TIMESTAMP() WHEN NOT MATCHED THEN INSERT (scope, token, updated_at) VALUES (S.scope, S.token, CURRENT_TIMESTAMP())");
+    }
+
+    #[test]
+    fn transaction_sql_wraps_insert_and_merge() {
+        let cols = vec![scalar("id", BqType::Int64), scalar("name", BqType::String)];
+        let sql = build_transaction_sql(&cols, "p", "d", "t");
+        assert!(sql.starts_with("BEGIN TRANSACTION;\n"), "got: {sql}");
+        assert!(sql.contains("INSERT INTO `p.d.t` (`id`, `name`)"), "got: {sql}");
+        assert!(sql.contains("FROM UNNEST(JSON_QUERY_ARRAY(@payload)) AS r"), "got: {sql}");
+        assert!(sql.contains("MERGE `p.d._faucet_commit_token` T"), "got: {sql}");
+        assert!(sql.trim_end().ends_with("COMMIT TRANSACTION;"), "got: {sql}");
+        let i = sql.find("INSERT INTO").unwrap();
+        let m = sql.find("MERGE").unwrap();
+        let c = sql.find("COMMIT TRANSACTION").unwrap();
+        assert!(i < m && m < c, "statement order wrong: {sql}");
+    }
+
+    #[test]
+    fn request_id_is_deterministic_and_sanitized() {
+        let a = build_request_id("pipe::row1", "00000000000000000007");
+        let b = build_request_id("pipe::row1", "00000000000000000007");
+        assert_eq!(a, b, "must be deterministic across calls/processes");
+        assert!(a.chars().all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-'),
+            "request_id must be sanitized: {a}");
+        assert!(a.ends_with("_00000000000000000007"), "got: {a}");
+        assert_ne!(a, build_request_id("pipe::row2", "00000000000000000007"));
+    }
+
+    #[test]
+    fn sql_str_escapes_backslash_then_quote() {
+        // The replace order is load-bearing: backslash first, then single-quote.
+        assert_eq!(sql_str("a'b"), "'a\\'b'");
+        assert_eq!(sql_str("a\\b"), "'a\\\\b'");
+        assert_eq!(sql_str("$.ok"), "'$.ok'");
     }
 }

--- a/crates/sink/bigquery/src/idempotent.rs
+++ b/crates/sink/bigquery/src/idempotent.rs
@@ -115,6 +115,100 @@ impl FieldSpec {
     }
 }
 
+/// SQL string literal for a path/value: single-quoted with `\` and `'` escaped
+/// (BigQuery accepts backslash escapes in quoted strings).
+fn sql_str(s: &str) -> String {
+    format!("'{}'", s.replace('\\', "\\\\").replace('\'', "\\'"))
+}
+
+/// Backtick-quoted identifier. BigQuery identifiers never contain a backtick
+/// (the schema came from BigQuery), so a stray one is stripped defensively.
+#[allow(dead_code)]
+fn quote_ident(name: &str) -> String {
+    format!("`{}`", name.replace('`', ""))
+}
+
+/// A single JSONPath member segment. Safe BigQuery identifiers use the `.name`
+/// form; anything else is bracket-quoted (`['weird.name']`).
+fn json_path_segment(name: &str) -> String {
+    let safe = match name.chars().next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {
+            name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+        }
+        _ => false,
+    };
+    if safe {
+        format!(".{name}")
+    } else {
+        let esc = name.replace('\\', "\\\\").replace('\'', "\\'");
+        format!("['{esc}']")
+    }
+}
+
+/// Wrap a STRING-typed SQL expression `var` into the column's target type.
+/// `Struct` is handled by [`column_expr`], never here.
+fn wrap_scalar(ty: &BqType, var: &str) -> String {
+    match ty {
+        BqType::String => var.to_string(),
+        BqType::Bytes => format!("FROM_BASE64({var})"),
+        BqType::Geography => format!("ST_GEOGFROMTEXT({var})"),
+        BqType::Json => format!("PARSE_JSON({var})"),
+        BqType::Struct => unreachable!("struct is handled by column_expr"),
+        other => format!("CAST({var} AS {})", other.sql_keyword()),
+    }
+}
+
+/// Build the `field AS name, …` list for a STRUCT, recursing into each child.
+fn struct_field_list(fields: &[FieldSpec], json_var: &str, base_path: &str, depth: usize) -> String {
+    fields
+        .iter()
+        .map(|f| {
+            let child_path = format!("{base_path}{}", json_path_segment(&f.name));
+            let expr = column_expr(f, json_var, &child_path, depth);
+            format!("{expr} AS {}", quote_ident(&f.name))
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Generate the SQL extraction expression for one column.
+///
+/// `json_var` is the SQL expression naming the current JSON value (the row alias
+/// `r` at the top level, or an `UNNEST` element alias deeper down). `path` is
+/// the JSONPath into `json_var` for this field. `depth` keeps nested `UNNEST`
+/// aliases unique (`e{depth}` for struct elements, `x{depth}` for scalars).
+fn column_expr(field: &FieldSpec, json_var: &str, path: &str, depth: usize) -> String {
+    if field.repeated {
+        if field.ty == BqType::Struct {
+            let elem = format!("e{depth}");
+            let fields = struct_field_list(&field.fields, &elem, "$", depth + 1);
+            format!(
+                "ARRAY(SELECT AS STRUCT {fields} FROM UNNEST(JSON_QUERY_ARRAY({json_var}, {p})) AS {elem})",
+                p = sql_str(path)
+            )
+        } else {
+            let x = format!("x{depth}");
+            let src = if field.ty == BqType::Json {
+                format!("JSON_QUERY_ARRAY({json_var}, {p})", p = sql_str(path))
+            } else {
+                format!("JSON_VALUE_ARRAY({json_var}, {p})", p = sql_str(path))
+            };
+            let elem = wrap_scalar(&field.ty, &x);
+            format!("ARRAY(SELECT {elem} FROM UNNEST({src}) AS {x})")
+        }
+    } else if field.ty == BqType::Struct {
+        let fields = struct_field_list(&field.fields, json_var, path, depth + 1);
+        format!("STRUCT({fields})")
+    } else {
+        let raw = if field.ty == BqType::Json {
+            format!("JSON_QUERY({json_var}, {p})", p = sql_str(path))
+        } else {
+            format!("JSON_VALUE({json_var}, {p})", p = sql_str(path))
+        };
+        wrap_scalar(&field.ty, &raw)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -151,5 +245,83 @@ mod tests {
             repeated: true,
             fields: vec![scalar("city", BqType::String)],
         });
+    }
+
+    fn repeated(name: &str, ty: BqType) -> FieldSpec {
+        FieldSpec { name: name.into(), ty, repeated: true, fields: vec![] }
+    }
+    fn record(name: &str, repeated: bool, fields: Vec<FieldSpec>) -> FieldSpec {
+        FieldSpec { name: name.into(), ty: BqType::Struct, repeated, fields }
+    }
+
+    #[test]
+    fn scalar_exprs_per_type() {
+        assert_eq!(column_expr(&scalar("s", BqType::String), "r", "$.s", 0),
+            "JSON_VALUE(r, '$.s')");
+        assert_eq!(column_expr(&scalar("n", BqType::Int64), "r", "$.n", 0),
+            "CAST(JSON_VALUE(r, '$.n') AS INT64)");
+        assert_eq!(column_expr(&scalar("f", BqType::Float64), "r", "$.f", 0),
+            "CAST(JSON_VALUE(r, '$.f') AS FLOAT64)");
+        assert_eq!(column_expr(&scalar("b", BqType::Bool), "r", "$.b", 0),
+            "CAST(JSON_VALUE(r, '$.b') AS BOOL)");
+        assert_eq!(column_expr(&scalar("ts", BqType::Timestamp), "r", "$.ts", 0),
+            "CAST(JSON_VALUE(r, '$.ts') AS TIMESTAMP)");
+        assert_eq!(column_expr(&scalar("by", BqType::Bytes), "r", "$.by", 0),
+            "FROM_BASE64(JSON_VALUE(r, '$.by'))");
+        assert_eq!(column_expr(&scalar("g", BqType::Geography), "r", "$.g", 0),
+            "ST_GEOGFROMTEXT(JSON_VALUE(r, '$.g'))");
+        assert_eq!(column_expr(&scalar("j", BqType::Json), "r", "$.j", 0),
+            "PARSE_JSON(JSON_QUERY(r, '$.j'))");
+    }
+
+    #[test]
+    fn repeated_scalar_exprs() {
+        assert_eq!(column_expr(&repeated("xs", BqType::String), "r", "$.xs", 0),
+            "ARRAY(SELECT x0 FROM UNNEST(JSON_VALUE_ARRAY(r, '$.xs')) AS x0)");
+        assert_eq!(column_expr(&repeated("ns", BqType::Int64), "r", "$.ns", 0),
+            "ARRAY(SELECT CAST(x0 AS INT64) FROM UNNEST(JSON_VALUE_ARRAY(r, '$.ns')) AS x0)");
+        assert_eq!(column_expr(&repeated("js", BqType::Json), "r", "$.js", 0),
+            "ARRAY(SELECT PARSE_JSON(x0) FROM UNNEST(JSON_QUERY_ARRAY(r, '$.js')) AS x0)");
+    }
+
+    #[test]
+    fn nested_struct_expr() {
+        let f = record("addr", false, vec![
+            scalar("city", BqType::String),
+            scalar("zip", BqType::Int64),
+        ]);
+        assert_eq!(column_expr(&f, "r", "$.addr", 0),
+            "STRUCT(JSON_VALUE(r, '$.addr.city') AS `city`, CAST(JSON_VALUE(r, '$.addr.zip') AS INT64) AS `zip`)");
+    }
+
+    #[test]
+    fn repeated_record_expr_uses_unnest_element() {
+        let f = record("items", true, vec![
+            scalar("sku", BqType::String),
+            scalar("qty", BqType::Int64),
+        ]);
+        assert_eq!(column_expr(&f, "r", "$.items", 0),
+            "ARRAY(SELECT AS STRUCT JSON_VALUE(e0, '$.sku') AS `sku`, CAST(JSON_VALUE(e0, '$.qty') AS INT64) AS `qty` FROM UNNEST(JSON_QUERY_ARRAY(r, '$.items')) AS e0)");
+    }
+
+    #[test]
+    fn nested_repeated_record_aliases_are_unique() {
+        // ARRAY<STRUCT<tags ARRAY<STRING>>> nested inside ARRAY<STRUCT<...>>
+        let inner = repeated("tags", BqType::String);
+        let f = record("groups", true, vec![inner]);
+        let sql = column_expr(&f, "r", "$.groups", 0);
+        // Outer element alias e0; the inner repeated scalar uses x1 (depth+1) —
+        // distinct from any outer alias.
+        assert_eq!(sql,
+            "ARRAY(SELECT AS STRUCT ARRAY(SELECT x1 FROM UNNEST(JSON_VALUE_ARRAY(e0, '$.tags')) AS x1) AS `tags` FROM UNNEST(JSON_QUERY_ARRAY(r, '$.groups')) AS e0)");
+    }
+
+    #[test]
+    fn unsafe_member_name_uses_bracket_path() {
+        // A name with a dot would be ambiguous in `$.a.b`; bracket-quote it.
+        assert_eq!(json_path_segment("a.b"), "['a.b']");
+        assert_eq!(json_path_segment("ok_name"), ".ok_name");
+        assert_eq!(json_path_segment("_lead"), "._lead");
+        assert_eq!(json_path_segment("1bad"), "['1bad']");
     }
 }

--- a/crates/sink/bigquery/src/idempotent.rs
+++ b/crates/sink/bigquery/src/idempotent.rs
@@ -156,7 +156,12 @@ fn wrap_scalar(ty: &BqType, var: &str) -> String {
 }
 
 /// Build the `field AS name, …` list for a STRUCT, recursing into each child.
-fn struct_field_list(fields: &[FieldSpec], json_var: &str, base_path: &str, depth: usize) -> String {
+fn struct_field_list(
+    fields: &[FieldSpec],
+    json_var: &str,
+    base_path: &str,
+    depth: usize,
+) -> String {
     fields
         .iter()
         .map(|f| {
@@ -278,7 +283,12 @@ fn build_insert_select(columns: &[FieldSpec], project: &str, dataset: &str, tabl
 }
 
 /// The full atomic transaction: typed INSERT of the page + watermark MERGE.
-pub fn build_transaction_sql(columns: &[FieldSpec], project: &str, dataset: &str, table: &str) -> String {
+pub fn build_transaction_sql(
+    columns: &[FieldSpec],
+    project: &str,
+    dataset: &str,
+    table: &str,
+) -> String {
     format!(
         "BEGIN TRANSACTION;\n{insert};\n{merge};\nCOMMIT TRANSACTION;",
         insert = build_insert_select(columns, project, dataset, table),
@@ -304,7 +314,13 @@ pub fn build_request_id(scope: &str, token: &str) -> String {
     }
     let safe_scope: String = scope
         .chars()
-        .map(|c| if c.is_ascii_alphanumeric() || c == '-' || c == '_' { c } else { '_' })
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
         .take(64)
         .collect();
     format!("faucet_eo_{safe_scope}_{h:016x}_{token}")
@@ -315,7 +331,12 @@ mod tests {
     use super::*;
 
     fn scalar(name: &str, ty: BqType) -> FieldSpec {
-        FieldSpec { name: name.into(), ty, repeated: false, fields: vec![] }
+        FieldSpec {
+            name: name.into(),
+            ty,
+            repeated: false,
+            fields: vec![],
+        }
     }
 
     #[test]
@@ -340,69 +361,110 @@ mod tests {
             policy_tags: None,
         };
         let fs = FieldSpec::from_table_field(&tf);
-        assert_eq!(fs, FieldSpec {
-            name: "addr".into(),
-            ty: BqType::Struct,
-            repeated: true,
-            fields: vec![scalar("city", BqType::String)],
-        });
+        assert_eq!(
+            fs,
+            FieldSpec {
+                name: "addr".into(),
+                ty: BqType::Struct,
+                repeated: true,
+                fields: vec![scalar("city", BqType::String)],
+            }
+        );
     }
 
     fn repeated(name: &str, ty: BqType) -> FieldSpec {
-        FieldSpec { name: name.into(), ty, repeated: true, fields: vec![] }
+        FieldSpec {
+            name: name.into(),
+            ty,
+            repeated: true,
+            fields: vec![],
+        }
     }
     fn record(name: &str, repeated: bool, fields: Vec<FieldSpec>) -> FieldSpec {
-        FieldSpec { name: name.into(), ty: BqType::Struct, repeated, fields }
+        FieldSpec {
+            name: name.into(),
+            ty: BqType::Struct,
+            repeated,
+            fields,
+        }
     }
 
     #[test]
     fn scalar_exprs_per_type() {
-        assert_eq!(column_expr(&scalar("s", BqType::String), "r", "$.s", 0),
-            "JSON_VALUE(r, '$.s')");
-        assert_eq!(column_expr(&scalar("n", BqType::Int64), "r", "$.n", 0),
-            "CAST(JSON_VALUE(r, '$.n') AS INT64)");
-        assert_eq!(column_expr(&scalar("f", BqType::Float64), "r", "$.f", 0),
-            "CAST(JSON_VALUE(r, '$.f') AS FLOAT64)");
-        assert_eq!(column_expr(&scalar("b", BqType::Bool), "r", "$.b", 0),
-            "CAST(JSON_VALUE(r, '$.b') AS BOOL)");
-        assert_eq!(column_expr(&scalar("ts", BqType::Timestamp), "r", "$.ts", 0),
-            "CAST(JSON_VALUE(r, '$.ts') AS TIMESTAMP)");
-        assert_eq!(column_expr(&scalar("by", BqType::Bytes), "r", "$.by", 0),
-            "FROM_BASE64(JSON_VALUE(r, '$.by'))");
-        assert_eq!(column_expr(&scalar("g", BqType::Geography), "r", "$.g", 0),
-            "ST_GEOGFROMTEXT(JSON_VALUE(r, '$.g'))");
-        assert_eq!(column_expr(&scalar("j", BqType::Json), "r", "$.j", 0),
-            "PARSE_JSON(JSON_QUERY(r, '$.j'))");
+        assert_eq!(
+            column_expr(&scalar("s", BqType::String), "r", "$.s", 0),
+            "JSON_VALUE(r, '$.s')"
+        );
+        assert_eq!(
+            column_expr(&scalar("n", BqType::Int64), "r", "$.n", 0),
+            "CAST(JSON_VALUE(r, '$.n') AS INT64)"
+        );
+        assert_eq!(
+            column_expr(&scalar("f", BqType::Float64), "r", "$.f", 0),
+            "CAST(JSON_VALUE(r, '$.f') AS FLOAT64)"
+        );
+        assert_eq!(
+            column_expr(&scalar("b", BqType::Bool), "r", "$.b", 0),
+            "CAST(JSON_VALUE(r, '$.b') AS BOOL)"
+        );
+        assert_eq!(
+            column_expr(&scalar("ts", BqType::Timestamp), "r", "$.ts", 0),
+            "CAST(JSON_VALUE(r, '$.ts') AS TIMESTAMP)"
+        );
+        assert_eq!(
+            column_expr(&scalar("by", BqType::Bytes), "r", "$.by", 0),
+            "FROM_BASE64(JSON_VALUE(r, '$.by'))"
+        );
+        assert_eq!(
+            column_expr(&scalar("g", BqType::Geography), "r", "$.g", 0),
+            "ST_GEOGFROMTEXT(JSON_VALUE(r, '$.g'))"
+        );
+        assert_eq!(
+            column_expr(&scalar("j", BqType::Json), "r", "$.j", 0),
+            "PARSE_JSON(JSON_QUERY(r, '$.j'))"
+        );
     }
 
     #[test]
     fn repeated_scalar_exprs() {
-        assert_eq!(column_expr(&repeated("xs", BqType::String), "r", "$.xs", 0),
-            "ARRAY(SELECT x0 FROM UNNEST(JSON_VALUE_ARRAY(r, '$.xs')) AS x0)");
-        assert_eq!(column_expr(&repeated("ns", BqType::Int64), "r", "$.ns", 0),
-            "ARRAY(SELECT CAST(x0 AS INT64) FROM UNNEST(JSON_VALUE_ARRAY(r, '$.ns')) AS x0)");
-        assert_eq!(column_expr(&repeated("js", BqType::Json), "r", "$.js", 0),
-            "ARRAY(SELECT PARSE_JSON(x0) FROM UNNEST(JSON_QUERY_ARRAY(r, '$.js')) AS x0)");
+        assert_eq!(
+            column_expr(&repeated("xs", BqType::String), "r", "$.xs", 0),
+            "ARRAY(SELECT x0 FROM UNNEST(JSON_VALUE_ARRAY(r, '$.xs')) AS x0)"
+        );
+        assert_eq!(
+            column_expr(&repeated("ns", BqType::Int64), "r", "$.ns", 0),
+            "ARRAY(SELECT CAST(x0 AS INT64) FROM UNNEST(JSON_VALUE_ARRAY(r, '$.ns')) AS x0)"
+        );
+        assert_eq!(
+            column_expr(&repeated("js", BqType::Json), "r", "$.js", 0),
+            "ARRAY(SELECT PARSE_JSON(x0) FROM UNNEST(JSON_QUERY_ARRAY(r, '$.js')) AS x0)"
+        );
     }
 
     #[test]
     fn nested_struct_expr() {
-        let f = record("addr", false, vec![
-            scalar("city", BqType::String),
-            scalar("zip", BqType::Int64),
-        ]);
-        assert_eq!(column_expr(&f, "r", "$.addr", 0),
-            "STRUCT(JSON_VALUE(r, '$.addr.city') AS `city`, CAST(JSON_VALUE(r, '$.addr.zip') AS INT64) AS `zip`)");
+        let f = record(
+            "addr",
+            false,
+            vec![scalar("city", BqType::String), scalar("zip", BqType::Int64)],
+        );
+        assert_eq!(
+            column_expr(&f, "r", "$.addr", 0),
+            "STRUCT(JSON_VALUE(r, '$.addr.city') AS `city`, CAST(JSON_VALUE(r, '$.addr.zip') AS INT64) AS `zip`)"
+        );
     }
 
     #[test]
     fn repeated_record_expr_uses_unnest_element() {
-        let f = record("items", true, vec![
-            scalar("sku", BqType::String),
-            scalar("qty", BqType::Int64),
-        ]);
-        assert_eq!(column_expr(&f, "r", "$.items", 0),
-            "ARRAY(SELECT AS STRUCT JSON_VALUE(e0, '$.sku') AS `sku`, CAST(JSON_VALUE(e0, '$.qty') AS INT64) AS `qty` FROM UNNEST(JSON_QUERY_ARRAY(r, '$.items')) AS e0)");
+        let f = record(
+            "items",
+            true,
+            vec![scalar("sku", BqType::String), scalar("qty", BqType::Int64)],
+        );
+        assert_eq!(
+            column_expr(&f, "r", "$.items", 0),
+            "ARRAY(SELECT AS STRUCT JSON_VALUE(e0, '$.sku') AS `sku`, CAST(JSON_VALUE(e0, '$.qty') AS INT64) AS `qty` FROM UNNEST(JSON_QUERY_ARRAY(r, '$.items')) AS e0)"
+        );
     }
 
     #[test]
@@ -413,8 +475,10 @@ mod tests {
         let sql = column_expr(&f, "r", "$.groups", 0);
         // Outer element alias e0; the inner repeated scalar uses x1 (depth+1) —
         // distinct from any outer alias.
-        assert_eq!(sql,
-            "ARRAY(SELECT AS STRUCT ARRAY(SELECT x1 FROM UNNEST(JSON_VALUE_ARRAY(e0, '$.tags')) AS x1) AS `tags` FROM UNNEST(JSON_QUERY_ARRAY(r, '$.groups')) AS e0)");
+        assert_eq!(
+            sql,
+            "ARRAY(SELECT AS STRUCT ARRAY(SELECT x1 FROM UNNEST(JSON_VALUE_ARRAY(e0, '$.tags')) AS x1) AS `tags` FROM UNNEST(JSON_QUERY_ARRAY(r, '$.groups')) AS e0)"
+        );
     }
 
     #[test]
@@ -428,20 +492,26 @@ mod tests {
 
     #[test]
     fn create_commit_table_sql() {
-        assert_eq!(build_create_commit_table("p", "d"),
-            "CREATE TABLE IF NOT EXISTS `p.d._faucet_commit_token` (scope STRING NOT NULL, token STRING NOT NULL, updated_at TIMESTAMP)");
+        assert_eq!(
+            build_create_commit_table("p", "d"),
+            "CREATE TABLE IF NOT EXISTS `p.d._faucet_commit_token` (scope STRING NOT NULL, token STRING NOT NULL, updated_at TIMESTAMP)"
+        );
     }
 
     #[test]
     fn select_token_sql() {
-        assert_eq!(build_select_token("p", "d"),
-            "SELECT token FROM `p.d._faucet_commit_token` WHERE scope = @scope LIMIT 1");
+        assert_eq!(
+            build_select_token("p", "d"),
+            "SELECT token FROM `p.d._faucet_commit_token` WHERE scope = @scope LIMIT 1"
+        );
     }
 
     #[test]
     fn merge_token_sql() {
-        assert_eq!(build_merge_token("p", "d"),
-            "MERGE `p.d._faucet_commit_token` T USING (SELECT @scope AS scope, @token AS token) S ON T.scope = S.scope WHEN MATCHED THEN UPDATE SET token = S.token, updated_at = CURRENT_TIMESTAMP() WHEN NOT MATCHED THEN INSERT (scope, token, updated_at) VALUES (S.scope, S.token, CURRENT_TIMESTAMP())");
+        assert_eq!(
+            build_merge_token("p", "d"),
+            "MERGE `p.d._faucet_commit_token` T USING (SELECT @scope AS scope, @token AS token) S ON T.scope = S.scope WHEN MATCHED THEN UPDATE SET token = S.token, updated_at = CURRENT_TIMESTAMP() WHEN NOT MATCHED THEN INSERT (scope, token, updated_at) VALUES (S.scope, S.token, CURRENT_TIMESTAMP())"
+        );
     }
 
     #[test]
@@ -449,10 +519,22 @@ mod tests {
         let cols = vec![scalar("id", BqType::Int64), scalar("name", BqType::String)];
         let sql = build_transaction_sql(&cols, "p", "d", "t");
         assert!(sql.starts_with("BEGIN TRANSACTION;\n"), "got: {sql}");
-        assert!(sql.contains("INSERT INTO `p.d.t` (`id`, `name`)"), "got: {sql}");
-        assert!(sql.contains("FROM UNNEST(JSON_QUERY_ARRAY(@payload)) AS r"), "got: {sql}");
-        assert!(sql.contains("MERGE `p.d._faucet_commit_token` T"), "got: {sql}");
-        assert!(sql.trim_end().ends_with("COMMIT TRANSACTION;"), "got: {sql}");
+        assert!(
+            sql.contains("INSERT INTO `p.d.t` (`id`, `name`)"),
+            "got: {sql}"
+        );
+        assert!(
+            sql.contains("FROM UNNEST(JSON_QUERY_ARRAY(@payload)) AS r"),
+            "got: {sql}"
+        );
+        assert!(
+            sql.contains("MERGE `p.d._faucet_commit_token` T"),
+            "got: {sql}"
+        );
+        assert!(
+            sql.trim_end().ends_with("COMMIT TRANSACTION;"),
+            "got: {sql}"
+        );
         let i = sql.find("INSERT INTO").unwrap();
         let m = sql.find("MERGE").unwrap();
         let c = sql.find("COMMIT TRANSACTION").unwrap();
@@ -464,8 +546,11 @@ mod tests {
         let a = build_request_id("pipe::row1", "00000000000000000007");
         let b = build_request_id("pipe::row1", "00000000000000000007");
         assert_eq!(a, b, "must be deterministic across calls/processes");
-        assert!(a.chars().all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-'),
-            "request_id must be sanitized: {a}");
+        assert!(
+            a.chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-'),
+            "request_id must be sanitized: {a}"
+        );
         assert!(a.ends_with("_00000000000000000007"), "got: {a}");
         assert_ne!(a, build_request_id("pipe::row2", "00000000000000000007"));
     }

--- a/crates/sink/bigquery/src/idempotent.rs
+++ b/crates/sink/bigquery/src/idempotent.rs
@@ -5,9 +5,6 @@
 //! `INSERT … SELECT FROM UNNEST(JSON_QUERY_ARRAY(@payload))` + watermark `MERGE`
 //! transaction that makes a page's rows and its commit token land atomically.
 //! See `docs/superpowers/specs/2026-06-10-bigquery-exactly-once-design.md`.
-// Builder functions are wired into sink.rs in a later task; suppress dead_code
-// until they are called from the write path.
-#![allow(dead_code)]
 
 use faucet_core::idempotency::{
     COMMIT_TOKEN_SCOPE_COL, COMMIT_TOKEN_TABLE, COMMIT_TOKEN_TOKEN_COL,

--- a/crates/sink/bigquery/src/lib.rs
+++ b/crates/sink/bigquery/src/lib.rs
@@ -8,6 +8,7 @@
 //! the BigQuery streaming insert API.
 
 pub mod config;
+mod idempotent;
 pub mod sink;
 
 // Re-export core types.

--- a/crates/sink/bigquery/src/sink.rs
+++ b/crates/sink/bigquery/src/sink.rs
@@ -1,19 +1,42 @@
 //! BigQuery streaming insert sink.
 
 use crate::config::BigQuerySinkConfig;
+use crate::idempotent;
 use async_trait::async_trait;
 use faucet_common_bigquery::build_client;
 use faucet_core::FaucetError;
 use gcp_bigquery_client::Client;
+use gcp_bigquery_client::model::get_query_results_parameters::GetQueryResultsParameters;
+use gcp_bigquery_client::model::query_parameter::QueryParameter;
+use gcp_bigquery_client::model::query_parameter_type::QueryParameterType;
+use gcp_bigquery_client::model::query_parameter_value::QueryParameterValue;
+use gcp_bigquery_client::model::query_request::QueryRequest;
+use gcp_bigquery_client::model::query_response::QueryResponse;
 use gcp_bigquery_client::model::table_data_insert_all_request::TableDataInsertAllRequest;
 use gcp_bigquery_client::model::table_data_insert_all_response::TableDataInsertAllResponse;
 use serde_json::Value;
+use std::time::Duration;
+use tokio::sync::OnceCell;
+
+/// Max wall-clock spent polling an idempotent-write / token-read job to
+/// completion before giving up. Exactly-once pages are small, so this is a
+/// generous safety cap, not a steady-state wait.
+#[allow(dead_code)]
+const IDEMPOTENT_JOB_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Server-side long-poll window per `getQueryResults` completion check —
+/// BigQuery holds the connection open up to this long, so we don't busy-wait.
+#[allow(dead_code)]
+const JOB_POLL_LONG_POLL_MS: i32 = 10_000;
 
 /// A sink that writes JSON records to a BigQuery table using the streaming
 /// insert API (`tabledata.insertAll`).
 pub struct BigQuerySink {
     config: BigQuerySinkConfig,
     client: Client,
+    /// Target table schema, fetched once on the first exactly-once call and
+    /// reused for every page in the run. Empty on the streaming path.
+    schema_cache: OnceCell<Vec<idempotent::FieldSpec>>,
 }
 
 impl BigQuerySink {
@@ -24,7 +47,11 @@ impl BigQuerySink {
     pub async fn new(config: BigQuerySinkConfig) -> Result<Self, FaucetError> {
         faucet_core::validate_batch_size(config.batch_size)?;
         let client = build_client(&config.auth).await?;
-        Ok(Self { config, client })
+        Ok(Self {
+            config,
+            client,
+            schema_cache: OnceCell::new(),
+        })
     }
 
     /// Construct a sink from a pre-built BigQuery client.
@@ -37,7 +64,11 @@ impl BigQuerySink {
     /// prefer [`BigQuerySink::new`], which handles credential loading.
     #[doc(hidden)]
     pub fn from_parts(config: BigQuerySinkConfig, client: Client) -> Self {
-        Self { config, client }
+        Self {
+            config,
+            client,
+            schema_cache: OnceCell::new(),
+        }
     }
 
     /// Issue a single `tabledata.insertAll` call and return the raw response.
@@ -127,6 +158,156 @@ impl BigQuerySink {
         }
 
         Ok(rows.len())
+    }
+
+    // -----------------------------------------------------------------------
+    // Exactly-once helpers (wired into trait hooks in a later task)
+    // -----------------------------------------------------------------------
+
+    /// Build a NAMED STRING query parameter.
+    #[allow(dead_code)]
+    fn string_param(name: &str, value: &str) -> QueryParameter {
+        QueryParameter {
+            name: Some(name.to_string()),
+            parameter_type: Some(QueryParameterType {
+                r#type: "STRING".to_string(),
+                array_type: None,
+                struct_types: None,
+            }),
+            parameter_value: Some(QueryParameterValue {
+                value: Some(value.to_string()),
+                array_values: None,
+                struct_values: None,
+            }),
+        }
+    }
+
+    /// Fetch (once) and cache the target table's schema as [`idempotent::FieldSpec`]s.
+    #[allow(dead_code)]
+    async fn target_schema(&self) -> Result<&Vec<idempotent::FieldSpec>, FaucetError> {
+        self.schema_cache
+            .get_or_try_init(|| async {
+                let table = self
+                    .client
+                    .table()
+                    .get(
+                        &self.config.project_id,
+                        &self.config.dataset_id,
+                        &self.config.table_id,
+                        Some(vec!["schema"]),
+                    )
+                    .await
+                    .map_err(|e| {
+                        FaucetError::Sink(format!("BigQuery tables.get (schema) failed: {e}"))
+                    })?;
+                // Table.schema is TableSchema (not Option); TableSchema.fields is Option<Vec<...>>.
+                let fields: Vec<idempotent::FieldSpec> = table
+                    .schema
+                    .fields
+                    .as_ref()
+                    .map(|fs| fs.iter().map(idempotent::FieldSpec::from_table_field).collect())
+                    .unwrap_or_default();
+                if fields.is_empty() {
+                    return Err(FaucetError::Sink(format!(
+                        "BigQuery target table {}.{}.{} has no schema fields; exactly-once \
+                         delivery requires a table with a defined schema",
+                        self.config.project_id, self.config.dataset_id, self.config.table_id
+                    )));
+                }
+                Ok(fields)
+            })
+            .await
+    }
+
+    /// Create the commit-token watermark table if it does not exist.
+    #[allow(dead_code)]
+    async fn ensure_commit_table(&self) -> Result<(), FaucetError> {
+        let sql = idempotent::build_create_commit_table(
+            &self.config.project_id,
+            &self.config.dataset_id,
+        );
+        let mut req = QueryRequest::new(sql);
+        req.use_legacy_sql = false;
+        let resp = self
+            .client
+            .job()
+            .query(&self.config.project_id, req)
+            .await
+            .map_err(|e| {
+                FaucetError::Sink(format!("BigQuery commit-table create failed: {e}"))
+            })?;
+        self.await_query_complete(resp).await
+    }
+
+    /// Wait for a query/script job to finish, then authoritatively verify it
+    /// succeeded. Returns `Ok(())` only once the job reaches a terminal state
+    /// with no `errorResult`.
+    ///
+    /// Why `get_job` rather than the response `errors` field: the client maps
+    /// only non-2xx HTTP to `Err`, so a job that fails at *runtime* (a CAST
+    /// failure, a NULL into a REQUIRED column, …) comes back as `Ok` with the
+    /// failure recorded in the job body. `Job.status.error_result` is the
+    /// authoritative terminal-failure signal; the `errors` array can also carry
+    /// non-fatal warnings, so it must not be treated as failure on its own.
+    #[allow(dead_code)]
+    async fn await_query_complete(&self, initial: QueryResponse) -> Result<(), FaucetError> {
+        let (job_id, location) = Self::job_reference(&initial)?;
+
+        // Phase 1 — wait for completion via server-side long-poll (not a busy wait).
+        if !initial.job_complete.unwrap_or(false) {
+            let started = std::time::Instant::now();
+            loop {
+                let params = GetQueryResultsParameters {
+                    location: location.clone(),
+                    timeout_ms: Some(JOB_POLL_LONG_POLL_MS),
+                    max_results: Some(0),
+                    ..Default::default()
+                };
+                let resp = self
+                    .client
+                    .job()
+                    .get_query_results(&self.config.project_id, &job_id, params)
+                    .await
+                    .map_err(|e| {
+                        FaucetError::Sink(format!("BigQuery jobs.getQueryResults failed: {e}"))
+                    })?;
+                if resp.job_complete.unwrap_or(false) {
+                    break;
+                }
+                if started.elapsed() >= IDEMPOTENT_JOB_TIMEOUT {
+                    return Err(FaucetError::Sink(format!(
+                        "BigQuery job '{job_id}' did not complete within {}s",
+                        IDEMPOTENT_JOB_TIMEOUT.as_secs()
+                    )));
+                }
+            }
+        }
+
+        // Phase 2 — authoritative success check via the job's errorResult.
+        let job = self
+            .client
+            .job()
+            .get_job(&self.config.project_id, &job_id, location.as_deref())
+            .await
+            .map_err(|e| FaucetError::Sink(format!("BigQuery jobs.get failed: {e}")))?;
+        match job.status.and_then(|s| s.error_result) {
+            Some(err) => Err(FaucetError::Sink(format!(
+                "BigQuery query job '{job_id}' failed: {err}"
+            ))),
+            None => Ok(()),
+        }
+    }
+
+    /// Extract `(job_id, location)` from a query response's job reference.
+    #[allow(dead_code)]
+    fn job_reference(qr: &QueryResponse) -> Result<(String, Option<String>), FaucetError> {
+        let r = qr.job_reference.as_ref().ok_or_else(|| {
+            FaucetError::Sink("BigQuery query response missing jobReference".to_string())
+        })?;
+        let job_id = r.job_id.clone().ok_or_else(|| {
+            FaucetError::Sink("BigQuery jobReference missing jobId".to_string())
+        })?;
+        Ok((job_id, r.location.clone()))
     }
 }
 

--- a/crates/sink/bigquery/src/sink.rs
+++ b/crates/sink/bigquery/src/sink.rs
@@ -275,6 +275,10 @@ impl BigQuerySink {
                         IDEMPOTENT_JOB_TIMEOUT.as_secs()
                     )));
                 }
+                // The server long-poll normally blocks until completion, but if
+                // it returns early, back off so a still-running job can't turn
+                // this into a tight request-hammering loop.
+                tokio::time::sleep(Duration::from_millis(250)).await;
             }
         }
 

--- a/crates/sink/bigquery/src/sink.rs
+++ b/crates/sink/bigquery/src/sink.rs
@@ -5,13 +5,13 @@ use crate::idempotent;
 use async_trait::async_trait;
 use faucet_common_bigquery::build_client;
 use faucet_core::FaucetError;
+use faucet_core::idempotency::COMMIT_TOKEN_TOKEN_COL;
 use gcp_bigquery_client::Client;
 use gcp_bigquery_client::model::get_query_results_parameters::GetQueryResultsParameters;
 use gcp_bigquery_client::model::query_parameter::QueryParameter;
 use gcp_bigquery_client::model::query_parameter_type::QueryParameterType;
 use gcp_bigquery_client::model::query_parameter_value::QueryParameterValue;
 use gcp_bigquery_client::model::query_request::QueryRequest;
-use faucet_core::idempotency::COMMIT_TOKEN_TOKEN_COL;
 use gcp_bigquery_client::model::query_response::{QueryResponse, ResultSet};
 use gcp_bigquery_client::model::table_data_insert_all_request::TableDataInsertAllRequest;
 use gcp_bigquery_client::model::table_data_insert_all_response::TableDataInsertAllResponse;
@@ -202,7 +202,11 @@ impl BigQuerySink {
                     .schema
                     .fields
                     .as_ref()
-                    .map(|fs| fs.iter().map(idempotent::FieldSpec::from_table_field).collect())
+                    .map(|fs| {
+                        fs.iter()
+                            .map(idempotent::FieldSpec::from_table_field)
+                            .collect()
+                    })
                     .unwrap_or_default();
                 if fields.is_empty() {
                     return Err(FaucetError::Sink(format!(
@@ -218,10 +222,8 @@ impl BigQuerySink {
 
     /// Create the commit-token watermark table if it does not exist.
     async fn ensure_commit_table(&self) -> Result<(), FaucetError> {
-        let sql = idempotent::build_create_commit_table(
-            &self.config.project_id,
-            &self.config.dataset_id,
-        );
+        let sql =
+            idempotent::build_create_commit_table(&self.config.project_id, &self.config.dataset_id);
         let mut req = QueryRequest::new(sql);
         req.use_legacy_sql = false;
         let resp = self
@@ -229,9 +231,7 @@ impl BigQuerySink {
             .job()
             .query(&self.config.project_id, req)
             .await
-            .map_err(|e| {
-                FaucetError::Sink(format!("BigQuery commit-table create failed: {e}"))
-            })?;
+            .map_err(|e| FaucetError::Sink(format!("BigQuery commit-table create failed: {e}")))?;
         self.await_query_complete(resp).await
     }
 
@@ -314,9 +314,10 @@ impl BigQuerySink {
         let r = qr.job_reference.as_ref().ok_or_else(|| {
             FaucetError::Sink("BigQuery query response missing jobReference".to_string())
         })?;
-        let job_id = r.job_id.clone().ok_or_else(|| {
-            FaucetError::Sink("BigQuery jobReference missing jobId".to_string())
-        })?;
+        let job_id = r
+            .job_id
+            .clone()
+            .ok_or_else(|| FaucetError::Sink("BigQuery jobReference missing jobId".to_string()))?;
         Ok((job_id, r.location.clone()))
     }
 }
@@ -580,7 +581,9 @@ impl faucet_core::Sink for BigQuerySink {
         let columns = self.target_schema().await?;
 
         let payload = serde_json::to_string(records).map_err(|e| {
-            FaucetError::Sink(format!("BigQuery exactly-once: serialize page payload: {e}"))
+            FaucetError::Sink(format!(
+                "BigQuery exactly-once: serialize page payload: {e}"
+            ))
         })?;
 
         let sql = idempotent::build_transaction_sql(

--- a/crates/sink/bigquery/src/sink.rs
+++ b/crates/sink/bigquery/src/sink.rs
@@ -11,7 +11,8 @@ use gcp_bigquery_client::model::query_parameter::QueryParameter;
 use gcp_bigquery_client::model::query_parameter_type::QueryParameterType;
 use gcp_bigquery_client::model::query_parameter_value::QueryParameterValue;
 use gcp_bigquery_client::model::query_request::QueryRequest;
-use gcp_bigquery_client::model::query_response::QueryResponse;
+use faucet_core::idempotency::COMMIT_TOKEN_TOKEN_COL;
+use gcp_bigquery_client::model::query_response::{QueryResponse, ResultSet};
 use gcp_bigquery_client::model::table_data_insert_all_request::TableDataInsertAllRequest;
 use gcp_bigquery_client::model::table_data_insert_all_response::TableDataInsertAllResponse;
 use serde_json::Value;
@@ -21,12 +22,10 @@ use tokio::sync::OnceCell;
 /// Max wall-clock spent polling an idempotent-write / token-read job to
 /// completion before giving up. Exactly-once pages are small, so this is a
 /// generous safety cap, not a steady-state wait.
-#[allow(dead_code)]
 const IDEMPOTENT_JOB_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// Server-side long-poll window per `getQueryResults` completion check —
 /// BigQuery holds the connection open up to this long, so we don't busy-wait.
-#[allow(dead_code)]
 const JOB_POLL_LONG_POLL_MS: i32 = 10_000;
 
 /// A sink that writes JSON records to a BigQuery table using the streaming
@@ -161,11 +160,10 @@ impl BigQuerySink {
     }
 
     // -----------------------------------------------------------------------
-    // Exactly-once helpers (wired into trait hooks in a later task)
+    // Exactly-once helpers
     // -----------------------------------------------------------------------
 
     /// Build a NAMED STRING query parameter.
-    #[allow(dead_code)]
     fn string_param(name: &str, value: &str) -> QueryParameter {
         QueryParameter {
             name: Some(name.to_string()),
@@ -183,7 +181,6 @@ impl BigQuerySink {
     }
 
     /// Fetch (once) and cache the target table's schema as [`idempotent::FieldSpec`]s.
-    #[allow(dead_code)]
     async fn target_schema(&self) -> Result<&Vec<idempotent::FieldSpec>, FaucetError> {
         self.schema_cache
             .get_or_try_init(|| async {
@@ -220,7 +217,6 @@ impl BigQuerySink {
     }
 
     /// Create the commit-token watermark table if it does not exist.
-    #[allow(dead_code)]
     async fn ensure_commit_table(&self) -> Result<(), FaucetError> {
         let sql = idempotent::build_create_commit_table(
             &self.config.project_id,
@@ -249,7 +245,6 @@ impl BigQuerySink {
     /// failure recorded in the job body. `Job.status.error_result` is the
     /// authoritative terminal-failure signal; the `errors` array can also carry
     /// non-fatal warnings, so it must not be treated as failure on its own.
-    #[allow(dead_code)]
     async fn await_query_complete(&self, initial: QueryResponse) -> Result<(), FaucetError> {
         let (job_id, location) = Self::job_reference(&initial)?;
 
@@ -284,22 +279,37 @@ impl BigQuerySink {
         }
 
         // Phase 2 — authoritative success check via the job's errorResult.
+        //
+        // We require an explicit terminal `DONE` state with no `errorResult`.
+        // A missing `status`, a non-`DONE` state, or a present `errorResult` all
+        // mean we cannot confirm the transaction durably committed — fail safe
+        // (returning `Ok` here would advance the bookmark over data that may
+        // never have landed, the silent-data-loss failure mode).
         let job = self
             .client
             .job()
             .get_job(&self.config.project_id, &job_id, location.as_deref())
             .await
             .map_err(|e| FaucetError::Sink(format!("BigQuery jobs.get failed: {e}")))?;
-        match job.status.and_then(|s| s.error_result) {
-            Some(err) => Err(FaucetError::Sink(format!(
+        let status = job.status.ok_or_else(|| {
+            FaucetError::Sink(format!(
+                "BigQuery job '{job_id}' returned no status; cannot confirm durable commit"
+            ))
+        })?;
+        if let Some(err) = status.error_result {
+            return Err(FaucetError::Sink(format!(
                 "BigQuery query job '{job_id}' failed: {err}"
+            )));
+        }
+        match status.state.as_deref() {
+            Some("DONE") => Ok(()),
+            other => Err(FaucetError::Sink(format!(
+                "BigQuery job '{job_id}' is in state {other:?}, not DONE; cannot confirm durable commit"
             ))),
-            None => Ok(()),
         }
     }
 
     /// Extract `(job_id, location)` from a query response's job reference.
-    #[allow(dead_code)]
     fn job_reference(qr: &QueryResponse) -> Result<(String, Option<String>), FaucetError> {
         let r = qr.job_reference.as_ref().ok_or_else(|| {
             FaucetError::Sink("BigQuery query response missing jobReference".to_string())
@@ -496,6 +506,117 @@ impl faucet_core::Sink for BigQuerySink {
         }
 
         Ok(outcomes)
+    }
+
+    fn supports_idempotent_writes(&self) -> bool {
+        true
+    }
+
+    /// Read the last durably-committed token for `scope` from the watermark
+    /// table, so the pipeline can skip already-committed pages on resume.
+    async fn last_committed_token(&self, scope: &str) -> Result<Option<String>, FaucetError> {
+        self.ensure_commit_table().await?;
+        let mut req = QueryRequest::new(idempotent::build_select_token(
+            &self.config.project_id,
+            &self.config.dataset_id,
+        ));
+        req.use_legacy_sql = false;
+        req.parameter_mode = Some("NAMED".to_string());
+        req.query_parameters = Some(vec![Self::string_param("scope", scope)]);
+
+        let resp = self
+            .client
+            .job()
+            .query(&self.config.project_id, req)
+            .await
+            .map_err(|e| FaucetError::Sink(format!("BigQuery token read failed: {e}")))?;
+
+        // The watermark is a single tiny row, so `jobs.query` returns it inline.
+        // If BigQuery did not complete the read synchronously, fail safe: a
+        // wrong `None` here would re-run an already-committed page and produce
+        // duplicates, defeating exactly-once.
+        if !resp.job_complete.unwrap_or(false) {
+            return Err(FaucetError::Sink(
+                "BigQuery watermark read did not complete synchronously".to_string(),
+            ));
+        }
+        // `ResultSet` only yields rows when the response carries a schema; a
+        // completed `SELECT` always returns one. If it is somehow absent we
+        // cannot tell "no committed token" from "row present but unreadable",
+        // and a wrong `None` would replay committed pages — fail safe instead.
+        if resp.schema.is_none() {
+            return Err(FaucetError::Sink(
+                "BigQuery watermark read returned no schema; cannot trust the token result"
+                    .to_string(),
+            ));
+        }
+
+        let mut rs = ResultSet::new_from_query_response(resp);
+        if rs.next_row() {
+            rs.get_string_by_name(COMMIT_TOKEN_TOKEN_COL)
+                .map_err(|e| FaucetError::Sink(format!("BigQuery token decode failed: {e}")))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Atomically write `records` and record `token` for `scope` in one BigQuery
+    /// multi-statement transaction: a typed `INSERT … SELECT FROM
+    /// UNNEST(JSON_QUERY_ARRAY(@payload))` plus a watermark `MERGE`. Either both
+    /// the rows and the token commit, or neither does — so a crash/resume skips
+    /// the already-committed page (zero duplicates) and a failed page replays
+    /// cleanly.
+    ///
+    /// The entire page is one atomic unit (no `batch_size` re-chunking — core
+    /// issues exactly one token per page), so the page must serialize within
+    /// BigQuery's ~10 MB `jobs.query` request limit.
+    async fn write_batch_idempotent(
+        &self,
+        records: &[Value],
+        scope: &str,
+        token: &str,
+    ) -> Result<usize, FaucetError> {
+        self.ensure_commit_table().await?;
+        let columns = self.target_schema().await?;
+
+        let payload = serde_json::to_string(records).map_err(|e| {
+            FaucetError::Sink(format!("BigQuery exactly-once: serialize page payload: {e}"))
+        })?;
+
+        let sql = idempotent::build_transaction_sql(
+            columns,
+            &self.config.project_id,
+            &self.config.dataset_id,
+            &self.config.table_id,
+        );
+        let mut req = QueryRequest::new(sql);
+        req.use_legacy_sql = false;
+        req.parameter_mode = Some("NAMED".to_string());
+        req.request_id = Some(idempotent::build_request_id(scope, token));
+        req.query_parameters = Some(vec![
+            Self::string_param("payload", &payload),
+            Self::string_param("scope", scope),
+            Self::string_param("token", token),
+        ]);
+
+        let resp = self
+            .client
+            .job()
+            .query(&self.config.project_id, req)
+            .await
+            .map_err(|e| FaucetError::Sink(format!("BigQuery idempotent write failed: {e}")))?;
+        self.await_query_complete(resp).await?;
+
+        tracing::info!(
+            table = %format!(
+                "{}.{}.{}",
+                self.config.project_id, self.config.dataset_id, self.config.table_id
+            ),
+            rows = records.len(),
+            token = %token,
+            "BigQuery exactly-once page committed"
+        );
+        Ok(records.len())
     }
 }
 

--- a/crates/sink/bigquery/tests/idempotent.rs
+++ b/crates/sink/bigquery/tests/idempotent.rs
@@ -25,7 +25,11 @@ struct FakeToken {
 }
 
 fn fake_token() -> FakeToken {
-    FakeToken { access_token: "fake-token", token_type: "bearer", expires_in: 9_999_999 }
+    FakeToken {
+        access_token: "fake-token",
+        token_type: "bearer",
+        expires_in: 9_999_999,
+    }
 }
 
 fn dummy_service_account_json(oauth_server: &str) -> serde_json::Value {
@@ -55,8 +59,11 @@ async fn mount_token_endpoint(server: &MockServer) {
 async fn build_sink(server: &MockServer) -> (BigQuerySink, tempfile::NamedTempFile) {
     let sa_json = dummy_service_account_json(&server.uri());
     let sa_file = tempfile::NamedTempFile::new().expect("create sa tempfile");
-    std::fs::write(sa_file.path(), serde_json::to_string_pretty(&sa_json).unwrap())
-        .expect("write sa tempfile");
+    std::fs::write(
+        sa_file.path(),
+        serde_json::to_string_pretty(&sa_json).unwrap(),
+    )
+    .expect("write sa tempfile");
     let client = ClientBuilder::new()
         .with_auth_base_url(format!("{}{AUTH_SCOPE_BASE}", server.uri()))
         .with_v2_base_url(server.uri())
@@ -64,7 +71,10 @@ async fn build_sink(server: &MockServer) -> (BigQuerySink, tempfile::NamedTempFi
         .await
         .expect("build bigquery client against mock");
     let config = BigQuerySinkConfig::new(
-        PROJECT_ID, DATASET_ID, TABLE_ID, BigQueryCredentials::ApplicationDefault,
+        PROJECT_ID,
+        DATASET_ID,
+        TABLE_ID,
+        BigQueryCredentials::ApplicationDefault,
     );
     (BigQuerySink::from_parts(config, client), sa_file)
 }
@@ -168,20 +178,43 @@ async fn write_batch_idempotent_posts_transaction_with_params() {
     let bodies = captured_query_bodies(&server).await;
     let tx = bodies
         .iter()
-        .find(|b| b["query"].as_str().unwrap_or("").contains("BEGIN TRANSACTION"))
+        .find(|b| {
+            b["query"]
+                .as_str()
+                .unwrap_or("")
+                .contains("BEGIN TRANSACTION")
+        })
         .expect("a transaction query was sent");
     let q = tx["query"].as_str().unwrap();
     assert!(q.contains("INSERT INTO `p.d.t` (`id`, `name`)"), "got: {q}");
-    assert!(q.contains("FROM UNNEST(JSON_QUERY_ARRAY(@payload)) AS r"), "got: {q}");
+    assert!(
+        q.contains("FROM UNNEST(JSON_QUERY_ARRAY(@payload)) AS r"),
+        "got: {q}"
+    );
     assert!(q.contains("MERGE `p.d._faucet_commit_token`"), "got: {q}");
     assert_eq!(tx["parameterMode"], "NAMED");
-    let names: Vec<&str> = tx["queryParameters"].as_array().unwrap()
-        .iter().map(|p| p["name"].as_str().unwrap()).collect();
-    assert!(names.contains(&"payload") && names.contains(&"scope") && names.contains(&"token"),
-        "params: {names:?}");
-    let payload = tx["queryParameters"].as_array().unwrap().iter()
-        .find(|p| p["name"] == "payload").unwrap()["parameterValue"]["value"].as_str().unwrap();
-    assert_eq!(serde_json::from_str::<serde_json::Value>(payload).unwrap(), json!(records));
+    let names: Vec<&str> = tx["queryParameters"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|p| p["name"].as_str().unwrap())
+        .collect();
+    assert!(
+        names.contains(&"payload") && names.contains(&"scope") && names.contains(&"token"),
+        "params: {names:?}"
+    );
+    let payload = tx["queryParameters"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|p| p["name"] == "payload")
+        .unwrap()["parameterValue"]["value"]
+        .as_str()
+        .unwrap();
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(payload).unwrap(),
+        json!(records)
+    );
     assert!(tx.get("requestId").is_some(), "requestId must be set");
 }
 
@@ -207,9 +240,13 @@ async fn ensure_commit_table_issues_create() {
     mount_job_done(&server, "job-t").await;
 
     let (sink, _sa) = build_sink(&server).await;
-    sink.write_batch_idempotent(&[json!({"id": 1, "name": "x"})], "s", "00000000000000000001")
-        .await
-        .expect("write");
+    sink.write_batch_idempotent(
+        &[json!({"id": 1, "name": "x"})],
+        "s",
+        "00000000000000000001",
+    )
+    .await
+    .expect("write");
     // The .expect(1..) on the CREATE mock asserts it was issued.
 }
 
@@ -239,7 +276,10 @@ async fn last_committed_token_reads_watermark_row() {
         .await;
 
     let (sink, _sa) = build_sink(&server).await;
-    let got = sink.last_committed_token("pipe::row1").await.expect("read token");
+    let got = sink
+        .last_committed_token("pipe::row1")
+        .await
+        .expect("read token");
     assert_eq!(got.as_deref(), Some("00000000000000000009"));
 }
 
@@ -271,7 +311,10 @@ async fn last_committed_token_none_when_no_row() {
         .await;
 
     let (sink, _sa) = build_sink(&server).await;
-    let got = sink.last_committed_token("never-seen").await.expect("read token");
+    let got = sink
+        .last_committed_token("never-seen")
+        .await
+        .expect("read token");
     assert_eq!(got, None);
 }
 
@@ -298,7 +341,11 @@ async fn write_batch_idempotent_bubbles_job_error() {
 
     let (sink, _sa) = build_sink(&server).await;
     match sink
-        .write_batch_idempotent(&[json!({"id": "notint", "name": "x"})], "s", "00000000000000000001")
+        .write_batch_idempotent(
+            &[json!({"id": "notint", "name": "x"})],
+            "s",
+            "00000000000000000001",
+        )
         .await
     {
         Err(faucet_core::FaucetError::Sink(m)) => assert!(m.contains("type mismatch"), "got: {m}"),
@@ -326,9 +373,23 @@ async fn empty_page_still_commits_token() {
     assert_eq!(written, 0);
 
     let bodies = captured_query_bodies(&server).await;
-    let tx = bodies.iter().find(|b| b["query"].as_str().unwrap_or("").contains("BEGIN TRANSACTION")).unwrap();
-    let payload = tx["queryParameters"].as_array().unwrap().iter()
-        .find(|p| p["name"] == "payload").unwrap()["parameterValue"]["value"].as_str().unwrap();
+    let tx = bodies
+        .iter()
+        .find(|b| {
+            b["query"]
+                .as_str()
+                .unwrap_or("")
+                .contains("BEGIN TRANSACTION")
+        })
+        .unwrap();
+    let payload = tx["queryParameters"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|p| p["name"] == "payload")
+        .unwrap()["parameterValue"]["value"]
+        .as_str()
+        .unwrap();
     assert_eq!(payload, "[]");
 }
 
@@ -362,7 +423,10 @@ async fn write_batch_idempotent_errors_on_schemaless_table() {
         .await
     {
         Err(faucet_core::FaucetError::Sink(m)) => {
-            assert!(m.contains("schema fields"), "expected a schema-fields error, got: {m}")
+            assert!(
+                m.contains("schema fields"),
+                "expected a schema-fields error, got: {m}"
+            )
         }
         other => panic!("expected Sink error for a schemaless table, got: {other:?}"),
     }

--- a/crates/sink/bigquery/tests/idempotent.rs
+++ b/crates/sink/bigquery/tests/idempotent.rs
@@ -1,0 +1,369 @@
+//! Integration tests for the BigQuery exactly-once write path (#215): the
+//! `write_batch_idempotent` / `last_committed_token` hooks driving `jobs.query`
+//! and verifying success via `get_job`.
+
+use faucet_core::Sink;
+use faucet_sink_bigquery::BigQuerySink;
+use faucet_sink_bigquery::{BigQueryCredentials, BigQuerySinkConfig};
+use gcp_bigquery_client::client_builder::ClientBuilder;
+use serde::Serialize;
+use serde_json::json;
+use wiremock::matchers::{body_string_contains, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const PROJECT_ID: &str = "p";
+const DATASET_ID: &str = "d";
+const TABLE_ID: &str = "t";
+const AUTH_TOKEN_PATH: &str = "/:o/oauth2/token";
+const AUTH_SCOPE_BASE: &str = "/auth/bigquery";
+
+#[derive(Serialize)]
+struct FakeToken {
+    access_token: &'static str,
+    token_type: &'static str,
+    expires_in: u32,
+}
+
+fn fake_token() -> FakeToken {
+    FakeToken { access_token: "fake-token", token_type: "bearer", expires_in: 9_999_999 }
+}
+
+fn dummy_service_account_json(oauth_server: &str) -> serde_json::Value {
+    let token_uri = format!("{oauth_server}{AUTH_TOKEN_PATH}");
+    json!({
+        "type": "service_account",
+        "project_id": "dummy",
+        "private_key_id": "dummy",
+        "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQDNk6cKkWP/4NMu\nWb3s24YHfM639IXzPtTev06PUVVQnyHmT1bZgQ/XB6BvIRaReqAqnQd61PAGtX3e\n8XocTw+u/ZfiPJOf+jrXMkRBpiBh9mbyEIqBy8BC20OmsUc+O/YYh/qRccvRfPI7\n3XMabQ8eFWhI6z/t35oRpvEVFJnSIgyV4JR/L/cjtoKnxaFwjBzEnxPiwtdy4olU\nKO/1maklXexvlO7onC7CNmPAjuEZKzdMLzFszikCDnoKJC8k6+2GZh0/JDMAcAF4\nwxlKNQ89MpHVRXZ566uKZg0MqZqkq5RXPn6u7yvNHwZ0oahHT+8ixPPrAEjuPEKM\nUPzVRz71AgMBAAECggEAfdbVWLW5Befkvam3hea2+5xdmeN3n3elrJhkiXxbAhf3\nE1kbq9bCEHmdrokNnI34vz0SWBFCwIiWfUNJ4UxQKGkZcSZto270V8hwWdNMXUsM\npz6S2nMTxJkdp0s7dhAUS93o9uE2x4x5Z0XecJ2ztFGcXY6Lupu2XvnW93V9109h\nkY3uICLdbovJq7wS/fO/AL97QStfEVRWW2agIXGvoQG5jOwfPh86GZZRYP9b8VNw\ntkAUJe4qpzNbWs9AItXOzL+50/wsFkD/iWMGWFuU8DY5ZwsL434N+uzFlaD13wtZ\n63D+tNAxCSRBfZGQbd7WxJVFfZe/2vgjykKWsdyNAQKBgQDnEBgSI836HGSRk0Ub\nDwiEtdfh2TosV+z6xtyU7j/NwjugTOJEGj1VO/TMlZCEfpkYPLZt3ek2LdNL66n8\nDyxwzTT5Q3D/D0n5yE3mmxy13Qyya6qBYvqqyeWNwyotGM7hNNOix1v9lEMtH5Rd\nUT0gkThvJhtrV663bcAWCALmtQKBgQDjw2rYlMUp2TUIa2/E7904WOnSEG85d+nc\norhzthX8EWmPgw1Bbfo6NzH4HhebTw03j3NjZdW2a8TG/uEmZFWhK4eDvkx+rxAa\n6EwamS6cmQ4+vdep2Ac4QCSaTZj02YjHb06Be3gptvpFaFrotH2jnpXxggdiv8ul\n6x+ooCffQQKBgQCR3ykzGoOI6K/c75prELyR+7MEk/0TzZaAY1cSdq61GXBHLQKT\nd/VMgAN1vN51pu7DzGBnT/dRCvEgNvEjffjSZdqRmrAVdfN/y6LSeQ5RCfJgGXSV\nJoWVmMxhCNrxiX3h01Xgp/c9SYJ3VD54AzeR/dwg32/j/oEAsDraLciXGQKBgQDF\nMNc8k/DvfmJv27R06Ma6liA6AoiJVMxgfXD8nVUDW3/tBCVh1HmkFU1p54PArvxe\nchAQqoYQ3dUMBHeh6ZRJaYp2ATfxJlfnM99P1/eHFOxEXdBt996oUMBf53bZ5cyJ\n/lAVwnQSiZy8otCyUDHGivJ+mXkTgcIq8BoEwERFAQKBgQDmImBaFqoMSVihqHIf\nDa4WZqwM7ODqOx0JnBKrKO8UOc51J5e1vpwP/qRpNhUipoILvIWJzu4efZY7GN5C\nImF9sN3PP6Sy044fkVPyw4SYEisxbvp9tfw8Xmpj/pbmugkB2ut6lz5frmEBoJSN\n3osZlZTgx+pM3sO6ITV6U4ID2Q==\n-----END PRIVATE KEY-----\n",
+        "client_email": "dummy@developer.gserviceaccount.com",
+        "client_id": "dummy",
+        "auth_uri": format!("{oauth_server}/o/oauth2/auth"),
+        "token_uri": token_uri,
+        "auth_provider_x509_cert_url": format!("{oauth_server}/oauth2/v1/certs"),
+        "client_x509_cert_url": format!("{oauth_server}/robot/v1/metadata/x509/dummy"),
+    })
+}
+
+async fn mount_token_endpoint(server: &MockServer) {
+    Mock::given(method("POST"))
+        .and(path(AUTH_TOKEN_PATH))
+        .respond_with(ResponseTemplate::new(200).set_body_json(fake_token()))
+        .mount(server)
+        .await;
+}
+
+async fn build_sink(server: &MockServer) -> (BigQuerySink, tempfile::NamedTempFile) {
+    let sa_json = dummy_service_account_json(&server.uri());
+    let sa_file = tempfile::NamedTempFile::new().expect("create sa tempfile");
+    std::fs::write(sa_file.path(), serde_json::to_string_pretty(&sa_json).unwrap())
+        .expect("write sa tempfile");
+    let client = ClientBuilder::new()
+        .with_auth_base_url(format!("{}{AUTH_SCOPE_BASE}", server.uri()))
+        .with_v2_base_url(server.uri())
+        .build_from_service_account_key_file(sa_file.path().to_str().unwrap())
+        .await
+        .expect("build bigquery client against mock");
+    let config = BigQuerySinkConfig::new(
+        PROJECT_ID, DATASET_ID, TABLE_ID, BigQueryCredentials::ApplicationDefault,
+    );
+    (BigQuerySink::from_parts(config, client), sa_file)
+}
+
+fn queries_path() -> String {
+    format!("/projects/{PROJECT_ID}/queries")
+}
+fn tables_get_path() -> String {
+    format!("/projects/{PROJECT_ID}/datasets/{DATASET_ID}/tables/{TABLE_ID}")
+}
+
+/// A completed `jobs.query` response with no rows, carrying the given jobId.
+fn done_query(job_id: &str) -> serde_json::Value {
+    json!({
+        "kind": "bigquery#queryResponse",
+        "jobComplete": true,
+        "jobReference": {"projectId": PROJECT_ID, "jobId": job_id}
+    })
+}
+
+/// Mount the target table's schema (id INTEGER REQUIRED, name STRING NULLABLE).
+async fn mount_table_schema(server: &MockServer) {
+    Mock::given(method("GET"))
+        .and(path(tables_get_path()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "tableReference": {"projectId": PROJECT_ID, "datasetId": DATASET_ID, "tableId": TABLE_ID},
+            "schema": {"fields": [
+                {"name": "id", "type": "INTEGER", "mode": "REQUIRED"},
+                {"name": "name", "type": "STRING", "mode": "NULLABLE"}
+            ]}
+        })))
+        .mount(server)
+        .await;
+}
+
+/// Mount a `get_job` that reports DONE with no error.
+async fn mount_job_done(server: &MockServer, job_id: &str) {
+    Mock::given(method("GET"))
+        .and(path(format!("/projects/{PROJECT_ID}/jobs/{job_id}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jobReference": {"projectId": PROJECT_ID, "jobId": job_id},
+            "status": {"state": "DONE"}
+        })))
+        .mount(server)
+        .await;
+}
+
+/// Mount a `get_job` that reports DONE with a terminal errorResult.
+async fn mount_job_failed(server: &MockServer, job_id: &str, message: &str) {
+    Mock::given(method("GET"))
+        .and(path(format!("/projects/{PROJECT_ID}/jobs/{job_id}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jobReference": {"projectId": PROJECT_ID, "jobId": job_id},
+            "status": {"state": "DONE", "errorResult": {"reason": "invalidQuery", "message": message}}
+        })))
+        .mount(server)
+        .await;
+}
+
+/// Capture all POST bodies sent to the queries endpoint as parsed JSON.
+async fn captured_query_bodies(server: &MockServer) -> Vec<serde_json::Value> {
+    server
+        .received_requests()
+        .await
+        .expect("recording enabled")
+        .into_iter()
+        .filter(|r| r.url.path().ends_with("/queries"))
+        .map(|r| serde_json::from_slice(&r.body).expect("query body is JSON"))
+        .collect()
+}
+
+#[tokio::test]
+async fn sink_advertises_idempotent_support() {
+    let server = MockServer::start().await;
+    mount_token_endpoint(&server).await;
+    let (sink, _sa) = build_sink(&server).await;
+    assert!(sink.supports_idempotent_writes());
+}
+
+#[tokio::test]
+async fn write_batch_idempotent_posts_transaction_with_params() {
+    let server = MockServer::start().await;
+    mount_token_endpoint(&server).await;
+    mount_table_schema(&server).await;
+    // CREATE and the transaction both resolve to job-x; one get_job(DONE) covers both.
+    Mock::given(method("POST"))
+        .and(path(queries_path()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(done_query("job-x")))
+        .mount(&server)
+        .await;
+    mount_job_done(&server, "job-x").await;
+
+    let (sink, _sa) = build_sink(&server).await;
+    let records = vec![json!({"id": 1, "name": "a"}), json!({"id": 2, "name": "b"})];
+    let written = sink
+        .write_batch_idempotent(&records, "pipe::row1", "00000000000000000003")
+        .await
+        .expect("idempotent write");
+    assert_eq!(written, 2);
+
+    let bodies = captured_query_bodies(&server).await;
+    let tx = bodies
+        .iter()
+        .find(|b| b["query"].as_str().unwrap_or("").contains("BEGIN TRANSACTION"))
+        .expect("a transaction query was sent");
+    let q = tx["query"].as_str().unwrap();
+    assert!(q.contains("INSERT INTO `p.d.t` (`id`, `name`)"), "got: {q}");
+    assert!(q.contains("FROM UNNEST(JSON_QUERY_ARRAY(@payload)) AS r"), "got: {q}");
+    assert!(q.contains("MERGE `p.d._faucet_commit_token`"), "got: {q}");
+    assert_eq!(tx["parameterMode"], "NAMED");
+    let names: Vec<&str> = tx["queryParameters"].as_array().unwrap()
+        .iter().map(|p| p["name"].as_str().unwrap()).collect();
+    assert!(names.contains(&"payload") && names.contains(&"scope") && names.contains(&"token"),
+        "params: {names:?}");
+    let payload = tx["queryParameters"].as_array().unwrap().iter()
+        .find(|p| p["name"] == "payload").unwrap()["parameterValue"]["value"].as_str().unwrap();
+    assert_eq!(serde_json::from_str::<serde_json::Value>(payload).unwrap(), json!(records));
+    assert!(tx.get("requestId").is_some(), "requestId must be set");
+}
+
+#[tokio::test]
+async fn ensure_commit_table_issues_create() {
+    let server = MockServer::start().await;
+    mount_token_endpoint(&server).await;
+    mount_table_schema(&server).await;
+    Mock::given(method("POST"))
+        .and(path(queries_path()))
+        .and(body_string_contains("CREATE TABLE IF NOT EXISTS"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(done_query("job-c")))
+        .expect(1..)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path(queries_path()))
+        .and(body_string_contains("BEGIN TRANSACTION"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(done_query("job-t")))
+        .mount(&server)
+        .await;
+    mount_job_done(&server, "job-c").await;
+    mount_job_done(&server, "job-t").await;
+
+    let (sink, _sa) = build_sink(&server).await;
+    sink.write_batch_idempotent(&[json!({"id": 1, "name": "x"})], "s", "00000000000000000001")
+        .await
+        .expect("write");
+    // The .expect(1..) on the CREATE mock asserts it was issued.
+}
+
+#[tokio::test]
+async fn last_committed_token_reads_watermark_row() {
+    let server = MockServer::start().await;
+    mount_token_endpoint(&server).await;
+    Mock::given(method("POST"))
+        .and(path(queries_path()))
+        .and(body_string_contains("CREATE TABLE IF NOT EXISTS"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(done_query("job-c")))
+        .mount(&server)
+        .await;
+    mount_job_done(&server, "job-c").await;
+    Mock::given(method("POST"))
+        .and(path(queries_path()))
+        .and(body_string_contains("SELECT token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "kind": "bigquery#queryResponse",
+            "jobComplete": true,
+            "jobReference": {"projectId": PROJECT_ID, "jobId": "job-sel"},
+            "schema": {"fields": [{"name": "token", "type": "STRING", "mode": "NULLABLE"}]},
+            "rows": [{"f": [{"v": "00000000000000000009"}]}],
+            "totalRows": "1"
+        })))
+        .mount(&server)
+        .await;
+
+    let (sink, _sa) = build_sink(&server).await;
+    let got = sink.last_committed_token("pipe::row1").await.expect("read token");
+    assert_eq!(got.as_deref(), Some("00000000000000000009"));
+}
+
+#[tokio::test]
+async fn last_committed_token_none_when_no_row() {
+    let server = MockServer::start().await;
+    mount_token_endpoint(&server).await;
+    Mock::given(method("POST"))
+        .and(path(queries_path()))
+        .and(body_string_contains("CREATE TABLE IF NOT EXISTS"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(done_query("job-c")))
+        .mount(&server)
+        .await;
+    mount_job_done(&server, "job-c").await;
+    // `.expect(1..)`: None must come from actually running the SELECT against an
+    // empty watermark, not from short-circuiting before issuing the query.
+    Mock::given(method("POST"))
+        .and(path(queries_path()))
+        .and(body_string_contains("SELECT token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "kind": "bigquery#queryResponse",
+            "jobComplete": true,
+            "jobReference": {"projectId": PROJECT_ID, "jobId": "job-sel"},
+            "schema": {"fields": [{"name": "token", "type": "STRING", "mode": "NULLABLE"}]},
+            "totalRows": "0"
+        })))
+        .expect(1..)
+        .mount(&server)
+        .await;
+
+    let (sink, _sa) = build_sink(&server).await;
+    let got = sink.last_committed_token("never-seen").await.expect("read token");
+    assert_eq!(got, None);
+}
+
+#[tokio::test]
+async fn write_batch_idempotent_bubbles_job_error() {
+    let server = MockServer::start().await;
+    mount_token_endpoint(&server).await;
+    mount_table_schema(&server).await;
+    // CREATE succeeds; the transaction's job reports a terminal errorResult.
+    Mock::given(method("POST"))
+        .and(path(queries_path()))
+        .and(body_string_contains("CREATE TABLE IF NOT EXISTS"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(done_query("job-c")))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path(queries_path()))
+        .and(body_string_contains("BEGIN TRANSACTION"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(done_query("job-t")))
+        .mount(&server)
+        .await;
+    mount_job_done(&server, "job-c").await;
+    mount_job_failed(&server, "job-t", "type mismatch on column id").await;
+
+    let (sink, _sa) = build_sink(&server).await;
+    match sink
+        .write_batch_idempotent(&[json!({"id": "notint", "name": "x"})], "s", "00000000000000000001")
+        .await
+    {
+        Err(faucet_core::FaucetError::Sink(m)) => assert!(m.contains("type mismatch"), "got: {m}"),
+        other => panic!("expected Sink error, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn empty_page_still_commits_token() {
+    let server = MockServer::start().await;
+    mount_token_endpoint(&server).await;
+    mount_table_schema(&server).await;
+    Mock::given(method("POST"))
+        .and(path(queries_path()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(done_query("job-x")))
+        .mount(&server)
+        .await;
+    mount_job_done(&server, "job-x").await;
+
+    let (sink, _sa) = build_sink(&server).await;
+    let written = sink
+        .write_batch_idempotent(&[], "pipe::row1", "00000000000000000004")
+        .await
+        .expect("empty idempotent write");
+    assert_eq!(written, 0);
+
+    let bodies = captured_query_bodies(&server).await;
+    let tx = bodies.iter().find(|b| b["query"].as_str().unwrap_or("").contains("BEGIN TRANSACTION")).unwrap();
+    let payload = tx["queryParameters"].as_array().unwrap().iter()
+        .find(|p| p["name"] == "payload").unwrap()["parameterValue"]["value"].as_str().unwrap();
+    assert_eq!(payload, "[]");
+}
+
+#[tokio::test]
+async fn write_batch_idempotent_errors_on_schemaless_table() {
+    // The typed INSERT is generated from the target schema; a table with no
+    // field definitions cannot be written idempotently, so the sink must fail
+    // with a clear error rather than emit an empty column list.
+    let server = MockServer::start().await;
+    mount_token_endpoint(&server).await;
+    // ensure_commit_table's CREATE succeeds first.
+    Mock::given(method("POST"))
+        .and(path(queries_path()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(done_query("job-x")))
+        .mount(&server)
+        .await;
+    mount_job_done(&server, "job-x").await;
+    // The target table reports an empty schema.
+    Mock::given(method("GET"))
+        .and(path(tables_get_path()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "tableReference": {"projectId": PROJECT_ID, "datasetId": DATASET_ID, "tableId": TABLE_ID},
+            "schema": {"fields": []}
+        })))
+        .mount(&server)
+        .await;
+
+    let (sink, _sa) = build_sink(&server).await;
+    match sink
+        .write_batch_idempotent(&[json!({"id": 1})], "s", "00000000000000000001")
+        .await
+    {
+        Err(faucet_core::FaucetError::Sink(m)) => {
+            assert!(m.contains("schema fields"), "expected a schema-fields error, got: {m}")
+        }
+        other => panic!("expected Sink error for a schemaless table, got: {other:?}"),
+    }
+}

--- a/crates/sink/bigquery/tests/idempotent.rs
+++ b/crates/sink/bigquery/tests/idempotent.rs
@@ -431,3 +431,71 @@ async fn write_batch_idempotent_errors_on_schemaless_table() {
         other => panic!("expected Sink error for a schemaless table, got: {other:?}"),
     }
 }
+
+#[tokio::test]
+async fn last_committed_token_errors_when_select_not_complete() {
+    // Fail-safe guard: a non-synchronous watermark read must NOT be read as
+    // `None` (which would replay committed pages → duplicates) — it must error.
+    let server = MockServer::start().await;
+    mount_token_endpoint(&server).await;
+    Mock::given(method("POST"))
+        .and(path(queries_path()))
+        .and(body_string_contains("CREATE TABLE IF NOT EXISTS"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(done_query("job-c")))
+        .mount(&server)
+        .await;
+    mount_job_done(&server, "job-c").await;
+    // The SELECT comes back still running.
+    Mock::given(method("POST"))
+        .and(path(queries_path()))
+        .and(body_string_contains("SELECT token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "kind": "bigquery#queryResponse",
+            "jobComplete": false,
+            "jobReference": {"projectId": PROJECT_ID, "jobId": "job-sel"}
+        })))
+        .mount(&server)
+        .await;
+
+    let (sink, _sa) = build_sink(&server).await;
+    match sink.last_committed_token("pipe::row1").await {
+        Err(faucet_core::FaucetError::Sink(m)) => {
+            assert!(m.contains("did not complete"), "got: {m}")
+        }
+        other => panic!("expected a fail-safe Sink error, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn last_committed_token_errors_when_select_has_no_schema() {
+    // Fail-safe guard: a completed read with no schema cannot be trusted to
+    // distinguish "no token" from "row present but unreadable" — it must error
+    // rather than return a wrong `None`.
+    let server = MockServer::start().await;
+    mount_token_endpoint(&server).await;
+    Mock::given(method("POST"))
+        .and(path(queries_path()))
+        .and(body_string_contains("CREATE TABLE IF NOT EXISTS"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(done_query("job-c")))
+        .mount(&server)
+        .await;
+    mount_job_done(&server, "job-c").await;
+    // Completed, but the response carries no schema.
+    Mock::given(method("POST"))
+        .and(path(queries_path()))
+        .and(body_string_contains("SELECT token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "kind": "bigquery#queryResponse",
+            "jobComplete": true,
+            "jobReference": {"projectId": PROJECT_ID, "jobId": "job-sel"},
+            "totalRows": "0"
+        })))
+        .mount(&server)
+        .await;
+
+    let (sink, _sa) = build_sink(&server).await;
+    match sink.last_committed_token("pipe::row1").await {
+        Err(faucet_core::FaucetError::Sink(m)) => assert!(m.contains("no schema"), "got: {m}"),
+        other => panic!("expected a fail-safe Sink error, got: {other:?}"),
+    }
+}

--- a/docs/book/src/cookbook/state.md
+++ b/docs/book/src/cookbook/state.md
@@ -95,6 +95,11 @@ records and the token atomically inside its own transaction:
   into a `_faucet_commit_token(scope TEXT, token TEXT)` watermark table.
 - **Iceberg sink** — the token is written as snapshot summary properties
   `faucet.commit-scope` and `faucet.commit-token` on the committed snapshot.
+- **BigQuery sink** — the rows and the token are written in one BigQuery
+  multi-statement transaction (a typed `INSERT … SELECT FROM
+  UNNEST(JSON_QUERY_ARRAY(@payload))` plus a `MERGE` into the
+  `_faucet_commit_token` watermark table in the target dataset), so both land
+  atomically.
 
 On the *next run*, before writing each page, the pipeline reads the sink's
 `last_committed_token` for the current scope. If the stored token is greater
@@ -109,7 +114,7 @@ Only certain connectors are allowed in an exactly-once pipeline:
 | Role | Allowed connectors | Why others are excluded |
 |------|--------------------|------------------------|
 | Source | `postgres-cdc`, `mysql-cdc`, `mongodb-cdc` | The source must deterministically replay the same pages from a given bookmark. Non-CDC / batch sources (REST, SQL query, etc.) do not replay deterministically — a different page on resume would cause the pipeline to silently skip records it never wrote. |
-| Sink | `sqlite`, `postgres`, `mysql`, `mssql`, `iceberg` | The sink must be able to commit data and a watermark token atomically in a single transaction or snapshot. Sinks without transaction support cannot provide this guarantee. |
+| Sink | `sqlite`, `postgres`, `mysql`, `mssql`, `iceberg`, `bigquery` | The sink must be able to commit data and a watermark token atomically in a single transaction or snapshot. Sinks without transaction support cannot provide this guarantee. |
 
 A DLQ (`dlq:` block) is incompatible with `exactly_once` in this version.
 

--- a/docs/book/src/reference/config.md
+++ b/docs/book/src/reference/config.md
@@ -210,7 +210,7 @@ matrix:
 All four conditions are validated at config-load time (`faucet validate` and `faucet run`). A violation is a hard `config error` naming the offending row — no run is started.
 
 1. **Deterministic-replay source** — the source must be one of: `postgres-cdc`, `mysql-cdc`, `mongodb-cdc`. Non-CDC sources are rejected because a different page content on replay would cause the pipeline to silently skip records it never wrote.
-2. **Idempotent sink** — the sink must be one of: `sqlite`, `postgres`, `mysql`, `mssql`, `iceberg`. These sinks atomically commit both the data and a watermark token inside the same transaction or snapshot.
+2. **Idempotent sink** — the sink must be one of: `sqlite`, `postgres`, `mysql`, `mssql`, `iceberg`, `bigquery`. These sinks atomically commit both the data and a watermark token inside the same transaction or snapshot.
 3. **State store** — a `state:` block is required. The pipeline stores the per-page sequence number alongside the bookmark so it can detect already-committed pages on resume.
 4. **No DLQ** — a `dlq:` block is incompatible with `exactly_once` in this version. Per-row error routing and the idempotency watermark interact in ways not yet resolved.
 

--- a/docs/book/src/reference/connectors.md
+++ b/docs/book/src/reference/connectors.md
@@ -58,7 +58,7 @@ file/append sinks (`jsonl`, `csv`, `stdout`) it's a no-op — they write per rec
 
 | Connector | Feature | `batch_size` | Compression | Upsert⁸ | Exactly-once⁷ | Write unit |
 |-----------|---------|:---:|:---:|:---:|:---:|------------|
-| BigQuery | `sink-bigquery` | ✓ | ✗ | ✗ | ✗ | `tabledata.insertAll` (per-row DLQ) |
+| BigQuery | `sink-bigquery` | ✓ | ✗ | ✗ | **✓** | `tabledata.insertAll` streaming; `MERGE`-transaction write for exactly-once |
 | PostgreSQL | `sink-postgres` | ✓ | ✗ | **✓** | **✓** | multi-row `INSERT` (JSONB or mapped cols) |
 | JSON Lines | `sink-jsonl` | no-op | ✓ | ✗ | ✗ | buffered file append |
 | Snowflake | `sink-snowflake` | ✓ | ✗ | ✗ | ✗ | SQL REST API |
@@ -80,8 +80,10 @@ file/append sinks (`jsonl`, `csv`, `stdout`) it's a no-op — they write per rec
 ⁶ Parquet and Iceberg both handle compression internally at the Parquet column
 level, so the file-level `compression` feature doesn't apply to either.
 ⁷ **Exactly-once** = commits data and a watermark token atomically; required for
-`delivery: exactly_once`. BigQuery and Kafka are at-least-once only in this
-version. See [Exactly-once delivery](../cookbook/state.md#exactly-once-delivery).
+`delivery: exactly_once`. The BigQuery sink does this via a multi-statement
+`MERGE` transaction (distinct from its default streaming `insertAll` path);
+Kafka is at-least-once only in this version. See
+[Exactly-once delivery](../cookbook/state.md#exactly-once-delivery).
 ⁸ **Upsert** = supports `write_mode: upsert` / `delete` (insert-or-update and
 delete by `key`) in addition to plain `append`. The SQL sinks require
 column-mapping mode (`auto_map`, or `auto_columns` for mssql) and a


### PR DESCRIPTION
Implements exactly-once delivery for the BigQuery sink. Closes #215.

## What
Each bookmark-carrying page's rows and its commit token are committed in **one BigQuery multi-statement transaction**: a schema-driven, parameterized `INSERT INTO <target> SELECT … FROM UNNEST(JSON_QUERY_ARRAY(@payload))` plus a `MERGE` into a `_faucet_commit_token` watermark table in the target dataset. Either both land or neither does. On resume the pipeline reads `last_committed_token` and skips already-committed pages → zero duplicates.

This is **append-with-idempotency**, distinct from the default streaming `insertAll` path (whose `insertId` dedup is best-effort/time-windowed) and from key-based upsert (`write_mode`), which BigQuery still does not support.

## How it works
- `supports_idempotent_writes() == true`; `write_batch_idempotent` + `last_committed_token` implemented (the hooks from #188).
- The page ships as a single bound `@payload` JSON-array STRING parameter (no SQL injection, no query-text blowup). Columns are cast per the target table schema, fetched once via `tables.get` and cached in a `OnceCell`.
- **Authoritative success check:** the `gcp-bigquery-client` maps only non-2xx HTTP to `Err`, so a runtime job failure returns `Ok`. Completion is awaited via a server-side long-poll, then success is verified via `get_job().status.error_result` — a missing status, non-`DONE` state, or any `errorResult` aborts the page rather than advancing the bookmark (silent-data-loss guard). `last_committed_token` likewise fails safe (errs, never a wrong `None`) on a non-synchronous or schema-less read.
- The pure SQL generator lives in `crates/sink/bigquery/src/idempotent.rs` and is exhaustively unit-tested (every BigQuery type, nested STRUCT, REPEATED scalar/record with unique nested-UNNEST aliases, path/identifier escaping).

## Surfaces updated
- CLI gate `cli/src/registry.rs::sink_supports_idempotent_writes` + `expand.rs` error message now include `bigquery`.
- BigQuery sink `README.md`, the connector capability matrix, the state cookbook, and `reference/config.md` (idempotent-sink list).
- A runnable example: `cli/examples/mongodb_cdc_to_bigquery_exactly_once.yaml` (validates with `delivery: exactly_once`).
- No `faucet-core` changes; the default streaming `write_batch` / `write_batch_partial` paths are untouched.

## Testing
- 10 wiremock integration tests asserting the transaction SQL shape, named params + `requestId`, the `get_job` success/failure verification, watermark read (present/absent), the two fail-safe guards, the empty-page case, and the schemaless-table guard.
- Unit tests for the full SQL generator and the watermark/transaction builders.
- `cargo test -p faucet-sink-bigquery` and `-p faucet-cli` green; `cargo clippy --all-targets --all-features -- -D warnings` clean; `cargo fmt --all --check` clean; mdBook builds.

## Out of scope
A live BigQuery / emulator kill-resume test (the wiremock suite asserts the exact wire shape that yields exactly-once; the no-Docker kill/resume harness from #188 covers sqlite at the core level). Key-based upsert for BigQuery remains a separate follow-up.

Part of #188 (exactly-once delivery); roadmap epic #38.