### PR TITLE
feat(cli): config composition — extends / profiles / !include (#212)

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -370,6 +370,43 @@ See [`examples/templates_dry_rest.yaml`](examples/templates_dry_rest.yaml) and
 [`examples/templates_users_posts.yaml`](examples/templates_users_posts.yaml) for
 end-to-end examples of this pattern.
 
+## Config composition
+
+Factor shared connection / sink / transform pieces out of each file and
+recombine them at load time. Three mechanisms, all resolved when the file is
+read (**before** any `${...}` interpolation):
+
+| Mechanism | Form | Effect |
+|-----------|------|--------|
+| `extends:` | `extends: ./base.yaml` (or a list) | Inherit one or more base files; the child deep-merges on top. |
+| `profiles:` | `profiles: { dev: {…}, prod: {…} }` | Named overlays, selected with `--profile NAME` / `FAUCET_PROFILE` (flag wins). |
+| `!include` | `key: !include ./frag.yaml` | Substitute a YAML fragment at any node (**YAML only**). |
+
+```yaml
+# app.yaml — inherits a base, then pulls in a reusable transform chain.
+extends: ./base.yaml
+pipeline:
+  transforms: !include ./transforms.yaml
+```
+
+```bash
+faucet run app.yaml --profile prod                 # select an overlay
+faucet validate app.yaml --show-composed --profile prod   # print the merged config
+```
+
+Precedence (last wins): `extended base → child document → profile → matrix row`,
+all via the same deep-merge as `matrix` rows. `faucet validate --show-composed`
+prints the fully composed document (bases merged, profile applied, fragments
+substituted, `extends:`/`profiles:` metadata stripped) before interpolation.
+
+**Composition is file-loads-only** — `extends`/`profiles`/`!include` apply to
+configs read from disk (`run`/`validate`/`preview`/`doctor`/`schedule`), **not**
+to configs submitted to `faucet serve` over HTTP (a submitted body is a single
+self-contained document with no filesystem access). See
+[`examples/compose/`](examples/compose/) for an end-to-end example, and the
+[docs-site composition cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/composition.html)
+for the full walkthrough.
+
 ## Config shape
 
 ```yaml

--- a/cli/examples/compose/app.yaml
+++ b/cli/examples/compose/app.yaml
@@ -1,0 +1,4 @@
+# Inherits the shared base, then pulls in a reusable transform chain.
+extends: ./base.yaml
+pipeline:
+  transforms: !include ./transforms.yaml

--- a/cli/examples/compose/base.yaml
+++ b/cli/examples/compose/base.yaml
@@ -1,0 +1,28 @@
+# Shared base — connection + sink target reused across pipelines.
+# Select an environment overlay at run time, e.g. (from the repo root):
+#   faucet run cli/examples/compose/app.yaml --profile prod
+version: 1
+name: composed-pipeline
+pipeline:
+  source:
+    type: csv
+    config:
+      path: ./data/input.csv
+  sink:
+    type: jsonl
+    config:
+      path: ./out/output.jsonl   # neutral default — overridden per-env by the profiles below
+
+# Named overlays selected at run time via --profile / FAUCET_PROFILE.
+# Each profile points the sink at an environment-specific file.
+profiles:
+  dev:
+    pipeline:
+      sink:
+        config:
+          path: ./out/dev.jsonl
+  prod:
+    pipeline:
+      sink:
+        config:
+          path: ./out/prod.jsonl

--- a/cli/examples/compose/transforms.yaml
+++ b/cli/examples/compose/transforms.yaml
@@ -1,0 +1,5 @@
+# A reusable transform chain, pulled into pipelines via `!include`.
+- type: flatten
+  config: { separator: "__" }
+- type: keys_case
+  config: { mode: snake }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -60,6 +60,10 @@ pub struct DoctorArgs {
     /// Emit machine-readable JSON instead of the human checklist.
     #[arg(long)]
     pub json: bool,
+    /// Select a named overlay from the config's `profiles:` block and deep-merge
+    /// it over the composed base. Overrides the `FAUCET_PROFILE` env var.
+    #[arg(long, env = "FAUCET_PROFILE")]
+    pub profile: Option<String>,
 }
 
 /// `faucet schedule` arguments.
@@ -80,6 +84,10 @@ pub struct ScheduleArgs {
     /// Useful for platform-driven invocation (k8s CronJob / systemd OnCalendar).
     #[arg(long)]
     pub once: bool,
+    /// Select a named overlay from the config's `profiles:` block and deep-merge
+    /// it over the composed base. Overrides the `FAUCET_PROFILE` env var.
+    #[arg(long, env = "FAUCET_PROFILE")]
+    pub profile: Option<String>,
 }
 
 /// `faucet serve` arguments.
@@ -196,6 +204,11 @@ pub struct RunArgs {
     /// Use for backfills.
     #[arg(long)]
     pub clock: Option<String>,
+    /// Select a named overlay from the config's `profiles:` block and deep-merge
+    /// it over the composed base. Overrides the `FAUCET_PROFILE` env var.
+    /// Not applicable in `--from-env` mode (no config file to compose).
+    #[arg(long, env = "FAUCET_PROFILE")]
+    pub profile: Option<String>,
 }
 
 /// `faucet validate` arguments.
@@ -215,6 +228,10 @@ pub struct ValidateArgs {
     /// managers (no network / credentials needed).
     #[arg(long)]
     pub no_secrets: bool,
+    /// Select a named overlay from the config's `profiles:` block and deep-merge
+    /// it over the composed base. Overrides the `FAUCET_PROFILE` env var.
+    #[arg(long, env = "FAUCET_PROFILE")]
+    pub profile: Option<String>,
 }
 
 /// `faucet schema` arguments.
@@ -274,6 +291,10 @@ pub struct PreviewArgs {
     /// Skip auto-loading `.env` from cwd.
     #[arg(long)]
     pub no_env_file: bool,
+    /// Select a named overlay from the config's `profiles:` block and deep-merge
+    /// it over the composed base. Overrides the `FAUCET_PROFILE` env var.
+    #[arg(long, env = "FAUCET_PROFILE")]
+    pub profile: Option<String>,
 }
 
 /// `faucet init` arguments.

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -232,6 +232,11 @@ pub struct ValidateArgs {
     /// it over the composed base. Overrides the `FAUCET_PROFILE` env var.
     #[arg(long, env = "FAUCET_PROFILE")]
     pub profile: Option<String>,
+    /// Print the fully-composed config (after extends/!include/profile, before
+    /// `${...}` interpolation) and exit. For debugging composition precedence.
+    /// `--no-secrets` is redundant here (no interpolation or secret fetch occurs).
+    #[arg(long)]
+    pub show_composed: bool,
 }
 
 /// `faucet schema` arguments.

--- a/cli/src/commands/doctor.rs
+++ b/cli/src/commands/doctor.rs
@@ -76,7 +76,8 @@ pub async fn run(args: DoctorArgs) -> CliResult<()> {
     };
 
     let t_cfg = Instant::now();
-    let cfg = PipelineConfig::from_path_async(&path).await?;
+    // TODO(Task 5): thread --profile
+    let cfg = PipelineConfig::from_path_async(&path, None).await?;
     let cfg_ms = t_cfg.elapsed().as_millis();
 
     let nodes = expand(&cfg)?;

--- a/cli/src/commands/doctor.rs
+++ b/cli/src/commands/doctor.rs
@@ -76,8 +76,7 @@ pub async fn run(args: DoctorArgs) -> CliResult<()> {
     };
 
     let t_cfg = Instant::now();
-    // TODO(Task 5): thread --profile
-    let cfg = PipelineConfig::from_path_async(&path, None).await?;
+    let cfg = PipelineConfig::from_path_async(&path, args.profile.as_deref()).await?;
     let cfg_ms = t_cfg.elapsed().as_millis();
 
     let nodes = expand(&cfg)?;

--- a/cli/src/commands/preview.rs
+++ b/cli/src/commands/preview.rs
@@ -28,7 +28,8 @@ pub async fn run(args: PreviewArgs) -> CliResult<()> {
         Some(p) => p,
         None => crate::env_loader::discover_config_path(&cwd).ok_or(CliError::NoConfigOrFromEnv)?,
     };
-    let cfg = PipelineConfig::from_path_async(&path).await?;
+    // TODO(Task 5): thread --profile
+    let cfg = PipelineConfig::from_path_async(&path, None).await?;
     let auth = crate::auth_catalog::build_auth_catalog(cfg.auth.as_ref())?;
     let nodes = expand(&cfg)?;
     let first_root = nodes

--- a/cli/src/commands/preview.rs
+++ b/cli/src/commands/preview.rs
@@ -28,8 +28,7 @@ pub async fn run(args: PreviewArgs) -> CliResult<()> {
         Some(p) => p,
         None => crate::env_loader::discover_config_path(&cwd).ok_or(CliError::NoConfigOrFromEnv)?,
     };
-    // TODO(Task 5): thread --profile
-    let cfg = PipelineConfig::from_path_async(&path, None).await?;
+    let cfg = PipelineConfig::from_path_async(&path, args.profile.as_deref()).await?;
     let auth = crate::auth_catalog::build_auth_catalog(cfg.auth.as_ref())?;
     let nodes = expand(&cfg)?;
     let first_root = nodes

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -47,14 +47,18 @@ pub async fn run(args: RunArgs) -> CliResult<()> {
     };
 
     let cfg = if args.from_env {
+        if args.profile.is_some() {
+            tracing::warn!(
+                "--profile / FAUCET_PROFILE has no effect in --from-env mode (no config file to compose); ignoring"
+            );
+        }
         crate::env_config::from_process_env()?
     } else {
-        // TODO(Task 5): thread --profile
         PipelineConfig::from_path_async(
             resolved_config_path
                 .as_ref()
                 .expect("YAML mode always resolves a path above"),
-            None,
+            args.profile.as_deref(),
         )
         .await?
     };

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -49,10 +49,12 @@ pub async fn run(args: RunArgs) -> CliResult<()> {
     let cfg = if args.from_env {
         crate::env_config::from_process_env()?
     } else {
+        // TODO(Task 5): thread --profile
         PipelineConfig::from_path_async(
             resolved_config_path
                 .as_ref()
                 .expect("YAML mode always resolves a path above"),
+            None,
         )
         .await?
     };

--- a/cli/src/commands/schedule.rs
+++ b/cli/src/commands/schedule.rs
@@ -84,8 +84,7 @@ pub async fn run(args: ScheduleArgs) -> CliResult<()> {
         None => crate::env_loader::discover_config_path(&cwd).ok_or(CliError::NoConfigOrFromEnv)?,
     };
 
-    // TODO(Task 5): thread --profile
-    let cfg = PipelineConfig::from_path_async(&path, None).await?;
+    let cfg = PipelineConfig::from_path_async(&path, args.profile.as_deref()).await?;
     let spec = cfg.schedule.as_ref().ok_or_else(|| {
         CliError::Config(
             "no `schedule:` block in config — use `faucet run` for a one-shot run, or add a `schedule:` block"

--- a/cli/src/commands/schedule.rs
+++ b/cli/src/commands/schedule.rs
@@ -84,7 +84,8 @@ pub async fn run(args: ScheduleArgs) -> CliResult<()> {
         None => crate::env_loader::discover_config_path(&cwd).ok_or(CliError::NoConfigOrFromEnv)?,
     };
 
-    let cfg = PipelineConfig::from_path_async(&path).await?;
+    // TODO(Task 5): thread --profile
+    let cfg = PipelineConfig::from_path_async(&path, None).await?;
     let spec = cfg.schedule.as_ref().ok_or_else(|| {
         CliError::Config(
             "no `schedule:` block in config — use `faucet run` for a one-shot run, or add a `schedule:` block"

--- a/cli/src/commands/validate.rs
+++ b/cli/src/commands/validate.rs
@@ -22,6 +22,17 @@ pub async fn run(args: ValidateArgs) -> CliResult<()> {
         Some(p) => p,
         None => crate::env_loader::discover_config_path(&cwd).ok_or(CliError::NoConfigOrFromEnv)?,
     };
+
+    if args.show_composed {
+        let composed = crate::compose::compose(&path, args.profile.as_deref())?;
+        // Normalize to exactly one trailing newline: the YAML serializer appends
+        // one but `serde_json::to_string_pretty` (JSON-format configs) does not,
+        // and the fast path echoes the file verbatim. A single `\n` keeps
+        // `faucet validate … --show-composed > out.{yaml,json}` well-formed.
+        println!("{}", composed.trim_end_matches('\n'));
+        return Ok(());
+    }
+
     let cfg = if args.no_secrets {
         // Grammar / structure only — never touch the network.
         PipelineConfig::from_path_tolerating_secrets(&path, args.profile.as_deref())?

--- a/cli/src/commands/validate.rs
+++ b/cli/src/commands/validate.rs
@@ -24,11 +24,14 @@ pub async fn run(args: ValidateArgs) -> CliResult<()> {
     };
     let cfg = if args.no_secrets {
         // Grammar / structure only — never touch the network.
-        PipelineConfig::from_path_tolerating_secrets(&path)?
+        // TODO(Task 5): thread --profile
+        PipelineConfig::from_path_tolerating_secrets(&path, None)?
     } else {
         // Real preflight: report each secret reference, then resolve.
-        let refs = crate::secrets::scan_path_refs(&path)?;
-        let cfg = PipelineConfig::from_path_async(&path).await?;
+        // TODO(Task 5): thread --profile
+        let refs = crate::secrets::scan_path_refs(&path, None)?;
+        // TODO(Task 5): thread --profile
+        let cfg = PipelineConfig::from_path_async(&path, None).await?;
         for (scheme, reference) in &refs {
             println!("secret: {scheme}:{reference} → resolved");
         }

--- a/cli/src/commands/validate.rs
+++ b/cli/src/commands/validate.rs
@@ -24,14 +24,11 @@ pub async fn run(args: ValidateArgs) -> CliResult<()> {
     };
     let cfg = if args.no_secrets {
         // Grammar / structure only — never touch the network.
-        // TODO(Task 5): thread --profile
-        PipelineConfig::from_path_tolerating_secrets(&path, None)?
+        PipelineConfig::from_path_tolerating_secrets(&path, args.profile.as_deref())?
     } else {
         // Real preflight: report each secret reference, then resolve.
-        // TODO(Task 5): thread --profile
-        let refs = crate::secrets::scan_path_refs(&path, None)?;
-        // TODO(Task 5): thread --profile
-        let cfg = PipelineConfig::from_path_async(&path, None).await?;
+        let refs = crate::secrets::scan_path_refs(&path, args.profile.as_deref())?;
+        let cfg = PipelineConfig::from_path_async(&path, args.profile.as_deref()).await?;
         for (scheme, reference) in &refs {
             println!("secret: {scheme}:{reference} → resolved");
         }

--- a/cli/src/compose.rs
+++ b/cli/src/compose.rs
@@ -128,8 +128,8 @@ fn compose_document(path: &Path, visited: &mut Vec<PathBuf>, depth: usize) -> Cl
     Ok(result)
 }
 
-/// Parse one file into a `serde_json::Value`. (No `!include` resolution yet —
-/// added in the next task.)
+/// Parse one file into a `serde_json::Value`, resolving any `!include` tags
+/// (YAML only) before conversion.
 fn load_value(path: &Path) -> CliResult<JsonValue> {
     let text = std::fs::read_to_string(path).map_err(|source| CliError::ReadConfig {
         path: path.to_path_buf(),
@@ -137,11 +137,13 @@ fn load_value(path: &Path) -> CliResult<JsonValue> {
     })?;
     match format_of(path)? {
         Format::Yaml => {
-            let yv: serde_yaml::Value =
+            let mut yv: serde_yaml::Value =
                 serde_yaml::from_str(&text).map_err(|e| CliError::ParseConfig {
                     path: path.to_path_buf(),
                     message: e.to_string(),
                 })?;
+            let mut visited: Vec<PathBuf> = Vec::new();
+            resolve_includes(&mut yv, path, &mut visited, 0)?;
             yaml_to_json(yv, path)
         }
         Format::Json => serde_json::from_str(&text).map_err(|e| CliError::ParseConfig {
@@ -222,6 +224,104 @@ fn serialize_for(entry: &Path, merged: &JsonValue) -> CliResult<String> {
         Format::Json => serde_json::to_string_pretty(merged)
             .map_err(|e| CliError::Internal(format!("re-serialize composed config to JSON: {e}"))),
     }
+}
+
+/// Resolve `!include <path>` tags throughout a YAML value in place. Each tag's
+/// payload must be a string path, resolved relative to `including`'s directory.
+/// Recurses into the included fragment (which may itself contain `!include`s).
+fn resolve_includes(
+    yv: &mut serde_yaml::Value,
+    including: &Path,
+    visited: &mut Vec<PathBuf>,
+    depth: usize,
+) -> CliResult<()> {
+    use serde_yaml::Value as Y;
+    match yv {
+        Y::Tagged(tagged) => {
+            if tagged.tag == "include" {
+                let Y::String(rel) = &tagged.value else {
+                    return Err(CliError::BadInclude {
+                        path: including.to_path_buf(),
+                        reason: "`!include` payload must be a string path".into(),
+                    });
+                };
+                let dir = including.parent().unwrap_or_else(|| Path::new("."));
+                let target = resolve_rel(dir, rel);
+                if !target.exists() {
+                    return Err(CliError::IncludeNotFound {
+                        path: target,
+                        referenced_by: including.to_path_buf(),
+                    });
+                }
+                *yv = load_fragment(&target, visited, depth + 1)?;
+            } else {
+                return Err(CliError::BadInclude {
+                    path: including.to_path_buf(),
+                    reason: format!(
+                        "unsupported YAML tag '{}' (only `!include` is supported)",
+                        tagged.tag
+                    ),
+                });
+            }
+        }
+        Y::Mapping(map) => {
+            for v in map.values_mut() {
+                resolve_includes(v, including, visited, depth)?;
+            }
+        }
+        Y::Sequence(seq) => {
+            for v in seq.iter_mut() {
+                resolve_includes(v, including, visited, depth)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+/// Load an `!include` target into a YAML value, resolving its own nested
+/// includes. Fragments are raw nodes — `extends`/`profiles` are NOT processed.
+/// A fragment's own top-level `extends`/`profiles` keys are therefore passed
+/// through as literal data (not stripped, not followed); if such a fragment is
+/// spliced where `PipelineConfig` is parsed, the leftover key surfaces as a
+/// `deny_unknown_fields` error downstream.
+fn load_fragment(path: &Path, visited: &mut Vec<PathBuf>, depth: usize) -> CliResult<serde_yaml::Value> {
+    if depth > MAX_COMPOSE_DEPTH {
+        return Err(CliError::CompositionDepthExceeded {
+            max: MAX_COMPOSE_DEPTH,
+        });
+    }
+    let key = cycle_key(path);
+    if visited.contains(&key) {
+        let mut chain: Vec<String> = visited.iter().map(|p| p.display().to_string()).collect();
+        chain.push(key.display().to_string());
+        return Err(CliError::CompositionCycle { chain });
+    }
+    visited.push(key);
+
+    let text = std::fs::read_to_string(path).map_err(|source| CliError::ReadConfig {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let mut yv: serde_yaml::Value = match format_of(path)? {
+        Format::Yaml => serde_yaml::from_str(&text).map_err(|e| CliError::ParseConfig {
+            path: path.to_path_buf(),
+            message: e.to_string(),
+        })?,
+        Format::Json => {
+            let jv: JsonValue = serde_json::from_str(&text).map_err(|e| CliError::ParseConfig {
+                path: path.to_path_buf(),
+                message: e.to_string(),
+            })?;
+            serde_yaml::to_value(jv).map_err(|e| CliError::ParseConfig {
+                path: path.to_path_buf(),
+                message: format!("could not convert JSON fragment to YAML: {e}"),
+            })?
+        }
+    };
+    resolve_includes(&mut yv, path, visited, depth)?;
+    visited.pop();
+    Ok(yv)
 }
 
 #[cfg(test)]
@@ -389,5 +489,80 @@ mod tests {
         let v: JsonValue = serde_yaml::from_str(&compose(&app, None).unwrap()).unwrap();
         assert_eq!(v["pipeline"]["sink"]["config"]["path"], "base.jsonl");
         assert_eq!(v["pipeline"]["source"]["config"]["path"], "a.csv");
+    }
+
+    #[test]
+    fn include_substitutes_at_nested_map_position() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "auth.yaml", "type: bearer\nconfig: { token: T }\n");
+        let app = write(
+            dir.path(),
+            "app.yaml",
+            "version: 1\npipeline:\n  source:\n    type: rest\n    config: { base_url: https://x }\n    auth: !include ./auth.yaml\n",
+        );
+        let v: JsonValue = serde_yaml::from_str(&compose(&app, None).unwrap()).unwrap();
+        assert_eq!(v["pipeline"]["source"]["auth"]["type"], "bearer");
+        assert_eq!(v["pipeline"]["source"]["auth"]["config"]["token"], "T");
+    }
+
+    #[test]
+    fn include_substitutes_a_sequence_fragment() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "tx.yaml", "- { type: flatten }\n- { type: redact, config: { fields: [ssn] } }\n");
+        let app = write(
+            dir.path(),
+            "app.yaml",
+            "version: 1\npipeline:\n  source: { type: csv, config: { path: x.csv } }\n  sink: { type: jsonl, config: { path: o.jsonl } }\n  transforms: !include ./tx.yaml\n",
+        );
+        let v: JsonValue = serde_yaml::from_str(&compose(&app, None).unwrap()).unwrap();
+        assert_eq!(v["pipeline"]["transforms"][0]["type"], "flatten");
+        assert_eq!(v["pipeline"]["transforms"][1]["type"], "redact");
+    }
+
+    #[test]
+    fn include_combined_with_extends() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "base.yaml", "version: 1\npipeline:\n  sink: { type: jsonl, config: { path: base.jsonl } }\n");
+        write(dir.path(), "src.yaml", "type: csv\nconfig: { path: from-include.csv }\n");
+        let app = write(
+            dir.path(),
+            "app.yaml",
+            "extends: ./base.yaml\npipeline:\n  source: !include ./src.yaml\n",
+        );
+        let v: JsonValue = serde_yaml::from_str(&compose(&app, None).unwrap()).unwrap();
+        assert_eq!(v["pipeline"]["source"]["config"]["path"], "from-include.csv");
+        assert_eq!(v["pipeline"]["sink"]["config"]["path"], "base.jsonl");
+    }
+
+    #[test]
+    fn include_non_string_payload_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let app = write(dir.path(), "app.yaml", "version: 1\nbad: !include { not: a-path }\n");
+        assert!(matches!(
+            compose(&app, None).unwrap_err(),
+            CliError::BadInclude { .. }
+        ));
+    }
+
+    #[test]
+    fn include_missing_file_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let app = write(dir.path(), "app.yaml", "version: 1\nx: !include ./nope.yaml\n");
+        assert!(matches!(
+            compose(&app, None).unwrap_err(),
+            CliError::IncludeNotFound { .. }
+        ));
+    }
+
+    #[test]
+    fn include_cycle_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "a.yaml", "x: !include ./b.yaml\n");
+        write(dir.path(), "b.yaml", "y: !include ./a.yaml\n");
+        let a = dir.path().join("a.yaml");
+        assert!(matches!(
+            compose(&a, None).unwrap_err(),
+            CliError::CompositionCycle { .. }
+        ));
     }
 }

--- a/cli/src/compose.rs
+++ b/cli/src/compose.rs
@@ -158,7 +158,9 @@ fn load_value(path: &Path) -> CliResult<JsonValue> {
 fn yaml_to_json(yv: serde_yaml::Value, path: &Path) -> CliResult<JsonValue> {
     serde_json::to_value(yv).map_err(|e| CliError::ParseConfig {
         path: path.to_path_buf(),
-        message: format!("could not convert YAML to JSON (non-string keys or unsupported tag?): {e}"),
+        message: format!(
+            "could not convert YAML to JSON (non-string keys or unsupported tag?): {e}"
+        ),
     })
 }
 
@@ -285,7 +287,11 @@ fn resolve_includes(
 /// through as literal data (not stripped, not followed); if such a fragment is
 /// spliced where `PipelineConfig` is parsed, the leftover key surfaces as a
 /// `deny_unknown_fields` error downstream.
-fn load_fragment(path: &Path, visited: &mut Vec<PathBuf>, depth: usize) -> CliResult<serde_yaml::Value> {
+fn load_fragment(
+    path: &Path,
+    visited: &mut Vec<PathBuf>,
+    depth: usize,
+) -> CliResult<serde_yaml::Value> {
     if depth > MAX_COMPOSE_DEPTH {
         return Err(CliError::CompositionDepthExceeded {
             max: MAX_COMPOSE_DEPTH,
@@ -342,7 +348,10 @@ mod tests {
         let body = "version: 1\npipeline:\n  source: { type: csv, config: { path: x.csv } }\n  sink: { type: jsonl, config: { path: o.jsonl } }\n";
         let p = write(dir.path(), "p.yaml", body);
         let out = compose(&p, None).unwrap();
-        assert_eq!(out, body, "no directives + no profile must be byte-identical");
+        assert_eq!(
+            out, body,
+            "no directives + no profile must be byte-identical"
+        );
     }
 
     #[test]
@@ -368,20 +377,35 @@ mod tests {
     #[test]
     fn extends_list_merges_left_to_right() {
         let dir = tempfile::tempdir().unwrap();
-        write(dir.path(), "a.yaml", "version: 1\npipeline: { transforms: [] }\nshared: { a: 1, both: \"from-a\" }\n");
+        write(
+            dir.path(),
+            "a.yaml",
+            "version: 1\npipeline: { transforms: [] }\nshared: { a: 1, both: \"from-a\" }\n",
+        );
         write(dir.path(), "b.yaml", "shared: { b: 2, both: \"from-b\" }\n");
-        let app = write(dir.path(), "app.yaml", "extends: [./a.yaml, ./b.yaml]\nshared: { c: 3 }\n");
+        let app = write(
+            dir.path(),
+            "app.yaml",
+            "extends: [./a.yaml, ./b.yaml]\nshared: { c: 3 }\n",
+        );
         let v: JsonValue = serde_yaml::from_str(&compose(&app, None).unwrap()).unwrap();
         assert_eq!(v["shared"]["a"], 1);
         assert_eq!(v["shared"]["b"], 2);
         assert_eq!(v["shared"]["c"], 3);
-        assert_eq!(v["shared"]["both"], "from-b", "later base wins over earlier");
+        assert_eq!(
+            v["shared"]["both"], "from-b",
+            "later base wins over earlier"
+        );
     }
 
     #[test]
     fn profile_overlay_beats_extended_base() {
         let dir = tempfile::tempdir().unwrap();
-        write(dir.path(), "base.yaml", "version: 1\npipeline:\n  sink: { type: jsonl, config: { path: base.jsonl } }\n");
+        write(
+            dir.path(),
+            "base.yaml",
+            "version: 1\npipeline:\n  sink: { type: jsonl, config: { path: base.jsonl } }\n",
+        );
         let app = write(
             dir.path(),
             "app.yaml",
@@ -408,7 +432,11 @@ mod tests {
     #[test]
     fn unknown_profile_errors_with_known_list() {
         let dir = tempfile::tempdir().unwrap();
-        let p = write(dir.path(), "p.yaml", "version: 1\nprofiles:\n  dev: {}\n  prod: {}\npipeline: {}\n");
+        let p = write(
+            dir.path(),
+            "p.yaml",
+            "version: 1\nprofiles:\n  dev: {}\n  prod: {}\npipeline: {}\n",
+        );
         match compose(&p, Some("staging")).unwrap_err() {
             CliError::UnknownProfile { name, known } => {
                 assert_eq!(name, "staging");
@@ -445,9 +473,21 @@ mod tests {
         // app extends [b, c]; both b and c extend d. d is reached twice on
         // different branches — that is NOT a cycle.
         let dir = tempfile::tempdir().unwrap();
-        write(dir.path(), "d.yaml", "version: 1\nshared: { from_d: true }\n");
-        write(dir.path(), "b.yaml", "extends: ./d.yaml\nshared: { from_b: true }\n");
-        write(dir.path(), "c.yaml", "extends: ./d.yaml\nshared: { from_c: true }\n");
+        write(
+            dir.path(),
+            "d.yaml",
+            "version: 1\nshared: { from_d: true }\n",
+        );
+        write(
+            dir.path(),
+            "b.yaml",
+            "extends: ./d.yaml\nshared: { from_b: true }\n",
+        );
+        write(
+            dir.path(),
+            "c.yaml",
+            "extends: ./d.yaml\nshared: { from_c: true }\n",
+        );
         let app = write(
             dir.path(),
             "app.yaml",
@@ -464,7 +504,11 @@ mod tests {
     fn missing_base_after_successful_base_errors() {
         let dir = tempfile::tempdir().unwrap();
         write(dir.path(), "good.yaml", "version: 1\n");
-        let app = write(dir.path(), "app.yaml", "extends: [./good.yaml, ./nope.yaml]\n");
+        let app = write(
+            dir.path(),
+            "app.yaml",
+            "extends: [./good.yaml, ./nope.yaml]\n",
+        );
         assert!(matches!(
             compose(&app, None).unwrap_err(),
             CliError::IncludeNotFound { .. }
@@ -484,8 +528,16 @@ mod tests {
     #[test]
     fn yaml_can_extend_json_base() {
         let dir = tempfile::tempdir().unwrap();
-        write(dir.path(), "base.json", "{ \"version\": 1, \"pipeline\": { \"sink\": { \"type\": \"jsonl\", \"config\": { \"path\": \"base.jsonl\" } } } }");
-        let app = write(dir.path(), "app.yaml", "extends: ./base.json\npipeline:\n  source: { type: csv, config: { path: a.csv } }\n");
+        write(
+            dir.path(),
+            "base.json",
+            "{ \"version\": 1, \"pipeline\": { \"sink\": { \"type\": \"jsonl\", \"config\": { \"path\": \"base.jsonl\" } } } }",
+        );
+        let app = write(
+            dir.path(),
+            "app.yaml",
+            "extends: ./base.json\npipeline:\n  source: { type: csv, config: { path: a.csv } }\n",
+        );
         let v: JsonValue = serde_yaml::from_str(&compose(&app, None).unwrap()).unwrap();
         assert_eq!(v["pipeline"]["sink"]["config"]["path"], "base.jsonl");
         assert_eq!(v["pipeline"]["source"]["config"]["path"], "a.csv");
@@ -494,7 +546,11 @@ mod tests {
     #[test]
     fn include_substitutes_at_nested_map_position() {
         let dir = tempfile::tempdir().unwrap();
-        write(dir.path(), "auth.yaml", "type: bearer\nconfig: { token: T }\n");
+        write(
+            dir.path(),
+            "auth.yaml",
+            "type: bearer\nconfig: { token: T }\n",
+        );
         let app = write(
             dir.path(),
             "app.yaml",
@@ -508,7 +564,11 @@ mod tests {
     #[test]
     fn include_substitutes_a_sequence_fragment() {
         let dir = tempfile::tempdir().unwrap();
-        write(dir.path(), "tx.yaml", "- { type: flatten }\n- { type: redact, config: { fields: [ssn] } }\n");
+        write(
+            dir.path(),
+            "tx.yaml",
+            "- { type: flatten }\n- { type: redact, config: { fields: [ssn] } }\n",
+        );
         let app = write(
             dir.path(),
             "app.yaml",
@@ -522,22 +582,37 @@ mod tests {
     #[test]
     fn include_combined_with_extends() {
         let dir = tempfile::tempdir().unwrap();
-        write(dir.path(), "base.yaml", "version: 1\npipeline:\n  sink: { type: jsonl, config: { path: base.jsonl } }\n");
-        write(dir.path(), "src.yaml", "type: csv\nconfig: { path: from-include.csv }\n");
+        write(
+            dir.path(),
+            "base.yaml",
+            "version: 1\npipeline:\n  sink: { type: jsonl, config: { path: base.jsonl } }\n",
+        );
+        write(
+            dir.path(),
+            "src.yaml",
+            "type: csv\nconfig: { path: from-include.csv }\n",
+        );
         let app = write(
             dir.path(),
             "app.yaml",
             "extends: ./base.yaml\npipeline:\n  source: !include ./src.yaml\n",
         );
         let v: JsonValue = serde_yaml::from_str(&compose(&app, None).unwrap()).unwrap();
-        assert_eq!(v["pipeline"]["source"]["config"]["path"], "from-include.csv");
+        assert_eq!(
+            v["pipeline"]["source"]["config"]["path"],
+            "from-include.csv"
+        );
         assert_eq!(v["pipeline"]["sink"]["config"]["path"], "base.jsonl");
     }
 
     #[test]
     fn include_non_string_payload_errors() {
         let dir = tempfile::tempdir().unwrap();
-        let app = write(dir.path(), "app.yaml", "version: 1\nbad: !include { not: a-path }\n");
+        let app = write(
+            dir.path(),
+            "app.yaml",
+            "version: 1\nbad: !include { not: a-path }\n",
+        );
         assert!(matches!(
             compose(&app, None).unwrap_err(),
             CliError::BadInclude { .. }
@@ -547,7 +622,11 @@ mod tests {
     #[test]
     fn include_missing_file_errors() {
         let dir = tempfile::tempdir().unwrap();
-        let app = write(dir.path(), "app.yaml", "version: 1\nx: !include ./nope.yaml\n");
+        let app = write(
+            dir.path(),
+            "app.yaml",
+            "version: 1\nx: !include ./nope.yaml\n",
+        );
         assert!(matches!(
             compose(&app, None).unwrap_err(),
             CliError::IncludeNotFound { .. }

--- a/cli/src/compose.rs
+++ b/cli/src/compose.rs
@@ -1,0 +1,393 @@
+//! Config composition front pre-pass: `extends` (base inheritance), `profiles`
+//! (named overlays selected via `--profile`/`FAUCET_PROFILE`), and `!include`
+//! (YAML fragment substitution). Runs BEFORE `${...}` interpolation and the
+//! secrets pass, reusing [`crate::merge::merge_value`].
+//!
+//! [`compose`] returns the merged document as **text** (in the entry file's
+//! format) so the unchanged `interpolate → from_text` pipeline runs verbatim.
+//! When no composition is in play it returns the raw file text byte-identical.
+
+use crate::error::{CliError, CliResult};
+use crate::merge::merge_value;
+use serde_json::Value as JsonValue;
+use std::path::{Path, PathBuf};
+
+/// Hard cap on extends/!include nesting depth (loop backstop).
+const MAX_COMPOSE_DEPTH: usize = 32;
+
+/// File format, chosen by extension.
+#[derive(Clone, Copy)]
+enum Format {
+    Yaml,
+    Json,
+}
+
+fn format_of(path: &Path) -> CliResult<Format> {
+    match path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(str::to_ascii_lowercase)
+        .as_deref()
+    {
+        Some("yaml" | "yml") => Ok(Format::Yaml),
+        Some("json") => Ok(Format::Json),
+        _ => Err(CliError::UnknownExtension {
+            path: path.to_path_buf(),
+        }),
+    }
+}
+
+/// Resolve a (possibly relative) `extends`/`!include` target against the
+/// directory of the file that referenced it.
+fn resolve_rel(dir: &Path, rel: &str) -> PathBuf {
+    let p = Path::new(rel);
+    if p.is_absolute() {
+        p.to_path_buf()
+    } else {
+        dir.join(p)
+    }
+}
+
+/// Canonicalize for cycle detection; fall back to the raw path if the file
+/// cannot be canonicalized (callers verify existence before recursing).
+fn cycle_key(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+/// Cheap substring pre-check: are there any composition markers in the text?
+/// A false positive only forces the (still-correct) merge path; never a false
+/// negative for real directives, so the fast path stays safe.
+fn has_composition_markers(raw: &str) -> bool {
+    raw.contains("extends") || raw.contains("profiles") || raw.contains("!include")
+}
+
+/// Public entry: returns text ready to feed into `interpolate` + `from_text`.
+pub fn compose(entry: &Path, profile: Option<&str>) -> CliResult<String> {
+    let raw = std::fs::read_to_string(entry).map_err(|source| CliError::ReadConfig {
+        path: entry.to_path_buf(),
+        source,
+    })?;
+    // Fast path: no directives + no profile selected → byte-identical passthrough.
+    if profile.is_none() && !has_composition_markers(&raw) {
+        return Ok(raw);
+    }
+    let mut visited: Vec<PathBuf> = Vec::new();
+    let mut merged = compose_document(entry, &mut visited, 0)?;
+    apply_profile(&mut merged, profile)?;
+    // Strip composition metadata so PipelineConfig (deny_unknown_fields) never sees it.
+    if let JsonValue::Object(map) = &mut merged {
+        map.remove("profiles");
+        map.remove("extends");
+    }
+    serialize_for(entry, &merged)
+}
+
+/// Load a document, then resolve its `extends` chain. Returns the deep-merged
+/// `serde_json::Value` (profiles preserved; extends stripped). Used for the
+/// entry file and every `extends` target.
+fn compose_document(path: &Path, visited: &mut Vec<PathBuf>, depth: usize) -> CliResult<JsonValue> {
+    if depth > MAX_COMPOSE_DEPTH {
+        return Err(CliError::CompositionDepthExceeded {
+            max: MAX_COMPOSE_DEPTH,
+        });
+    }
+    let key = cycle_key(path);
+    if visited.contains(&key) {
+        let mut chain: Vec<String> = visited.iter().map(|p| p.display().to_string()).collect();
+        chain.push(key.display().to_string());
+        return Err(CliError::CompositionCycle { chain });
+    }
+    visited.push(key);
+
+    let mut doc = load_value(path)?;
+    let bases = take_extends(&mut doc, path)?;
+    let result = if bases.is_empty() {
+        doc
+    } else {
+        let dir = path.parent().unwrap_or_else(|| Path::new("."));
+        let mut acc = JsonValue::Object(serde_json::Map::new());
+        for base_rel in bases {
+            let base_path = resolve_rel(dir, &base_rel);
+            if !base_path.exists() {
+                // No mid-fn pop: any Err aborts the whole traversal and `visited`
+                // (a `compose`-local) is discarded, so the stack is only meaningful
+                // on the Ok path.
+                return Err(CliError::IncludeNotFound {
+                    path: base_path,
+                    referenced_by: path.to_path_buf(),
+                });
+            }
+            let base_doc = compose_document(&base_path, visited, depth + 1)?;
+            merge_value(&mut acc, base_doc);
+        }
+        merge_value(&mut acc, doc); // child wins over its bases
+        acc
+    };
+
+    visited.pop();
+    Ok(result)
+}
+
+/// Parse one file into a `serde_json::Value`. (No `!include` resolution yet —
+/// added in the next task.)
+fn load_value(path: &Path) -> CliResult<JsonValue> {
+    let text = std::fs::read_to_string(path).map_err(|source| CliError::ReadConfig {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    match format_of(path)? {
+        Format::Yaml => {
+            let yv: serde_yaml::Value =
+                serde_yaml::from_str(&text).map_err(|e| CliError::ParseConfig {
+                    path: path.to_path_buf(),
+                    message: e.to_string(),
+                })?;
+            yaml_to_json(yv, path)
+        }
+        Format::Json => serde_json::from_str(&text).map_err(|e| CliError::ParseConfig {
+            path: path.to_path_buf(),
+            message: e.to_string(),
+        }),
+    }
+}
+
+/// Convert a (fully include-resolved) YAML value to JSON. Non-string map keys
+/// or leftover unsupported tags surface as a parse error against `path`.
+fn yaml_to_json(yv: serde_yaml::Value, path: &Path) -> CliResult<JsonValue> {
+    serde_json::to_value(yv).map_err(|e| CliError::ParseConfig {
+        path: path.to_path_buf(),
+        message: format!("could not convert YAML to JSON (non-string keys or unsupported tag?): {e}"),
+    })
+}
+
+/// Remove and return the top-level `extends` entry as a list of path strings.
+fn take_extends(doc: &mut JsonValue, path: &Path) -> CliResult<Vec<String>> {
+    let JsonValue::Object(map) = doc else {
+        return Ok(Vec::new());
+    };
+    let Some(ext) = map.remove("extends") else {
+        return Ok(Vec::new());
+    };
+    match ext {
+        JsonValue::String(s) => Ok(vec![s]),
+        JsonValue::Array(arr) => arr
+            .into_iter()
+            .map(|v| match v {
+                JsonValue::String(s) => Ok(s),
+                other => Err(CliError::Config(format!(
+                    "`extends` list entries must be strings, got {other} in '{}'",
+                    path.display()
+                ))),
+            })
+            .collect(),
+        other => Err(CliError::Config(format!(
+            "`extends` must be a string or list of strings, got {other} in '{}'",
+            path.display()
+        ))),
+    }
+}
+
+/// Deep-merge `profiles[name]` over `merged` when a profile is selected.
+fn apply_profile(merged: &mut JsonValue, profile: Option<&str>) -> CliResult<()> {
+    let Some(name) = profile else {
+        return Ok(());
+    };
+    let profiles = merged.get("profiles").and_then(|p| p.as_object());
+    let known: Vec<String> = profiles
+        .map(|m| m.keys().cloned().collect())
+        .unwrap_or_default();
+    let overlay = profiles.and_then(|m| m.get(name)).cloned();
+    match overlay {
+        Some(ov) => {
+            merge_value(merged, ov);
+            Ok(())
+        }
+        None => Err(CliError::UnknownProfile {
+            name: name.to_string(),
+            known,
+        }),
+    }
+}
+
+/// Serialize the merged document back to the entry file's format.
+///
+/// The output is canonicalized, not a faithful re-render: `serde_json`'s map is
+/// a `BTreeMap`, so keys come out sorted and comments/formatting are dropped.
+/// That's fine — the result is re-parsed by `from_text` downstream, and the fast
+/// path keeps non-composed configs byte-identical.
+fn serialize_for(entry: &Path, merged: &JsonValue) -> CliResult<String> {
+    match format_of(entry)? {
+        Format::Yaml => serde_yaml::to_string(merged)
+            .map_err(|e| CliError::Internal(format!("re-serialize composed config to YAML: {e}"))),
+        Format::Json => serde_json::to_string_pretty(merged)
+            .map_err(|e| CliError::Internal(format!("re-serialize composed config to JSON: {e}"))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write(dir: &Path, name: &str, body: &str) -> PathBuf {
+        let p = dir.join(name);
+        let mut f = std::fs::File::create(&p).unwrap();
+        f.write_all(body.as_bytes()).unwrap();
+        p
+    }
+
+    #[test]
+    fn fast_path_returns_raw_text_unchanged() {
+        let dir = tempfile::tempdir().unwrap();
+        let body = "version: 1\npipeline:\n  source: { type: csv, config: { path: x.csv } }\n  sink: { type: jsonl, config: { path: o.jsonl } }\n";
+        let p = write(dir.path(), "p.yaml", body);
+        let out = compose(&p, None).unwrap();
+        assert_eq!(out, body, "no directives + no profile must be byte-identical");
+    }
+
+    #[test]
+    fn single_extends_child_wins_and_base_keys_survive() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "base.yaml",
+            "version: 1\npipeline:\n  source: { type: csv, config: { path: BASE.csv } }\n  sink: { type: jsonl, config: { path: base.jsonl } }\n",
+        );
+        let app = write(
+            dir.path(),
+            "app.yaml",
+            "extends: ./base.yaml\npipeline:\n  source: { config: { path: APP.csv } }\n",
+        );
+        let text = compose(&app, None).unwrap();
+        let v: JsonValue = serde_yaml::from_str(&text).unwrap();
+        assert_eq!(v["pipeline"]["source"]["config"]["path"], "APP.csv"); // child wins
+        assert_eq!(v["pipeline"]["sink"]["config"]["path"], "base.jsonl"); // base survives
+        assert!(v.get("extends").is_none(), "extends must be stripped");
+    }
+
+    #[test]
+    fn extends_list_merges_left_to_right() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "a.yaml", "version: 1\npipeline: { transforms: [] }\nshared: { a: 1, both: \"from-a\" }\n");
+        write(dir.path(), "b.yaml", "shared: { b: 2, both: \"from-b\" }\n");
+        let app = write(dir.path(), "app.yaml", "extends: [./a.yaml, ./b.yaml]\nshared: { c: 3 }\n");
+        let v: JsonValue = serde_yaml::from_str(&compose(&app, None).unwrap()).unwrap();
+        assert_eq!(v["shared"]["a"], 1);
+        assert_eq!(v["shared"]["b"], 2);
+        assert_eq!(v["shared"]["c"], 3);
+        assert_eq!(v["shared"]["both"], "from-b", "later base wins over earlier");
+    }
+
+    #[test]
+    fn profile_overlay_beats_extended_base() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "base.yaml", "version: 1\npipeline:\n  sink: { type: jsonl, config: { path: base.jsonl } }\n");
+        let app = write(
+            dir.path(),
+            "app.yaml",
+            "extends: ./base.yaml\nprofiles:\n  prod:\n    pipeline:\n      sink: { config: { path: prod.jsonl } }\n",
+        );
+        let v: JsonValue = serde_yaml::from_str(&compose(&app, Some("prod")).unwrap()).unwrap();
+        assert_eq!(v["pipeline"]["sink"]["config"]["path"], "prod.jsonl");
+        assert!(v.get("profiles").is_none(), "profiles must be stripped");
+    }
+
+    #[test]
+    fn profiles_stripped_when_no_profile_selected() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = write(
+            dir.path(),
+            "p.yaml",
+            "version: 1\npipeline:\n  sink: { type: jsonl, config: { path: base.jsonl } }\nprofiles:\n  prod: { pipeline: { sink: { config: { path: prod.jsonl } } } }\n",
+        );
+        let v: JsonValue = serde_yaml::from_str(&compose(&p, None).unwrap()).unwrap();
+        assert_eq!(v["pipeline"]["sink"]["config"]["path"], "base.jsonl");
+        assert!(v.get("profiles").is_none());
+    }
+
+    #[test]
+    fn unknown_profile_errors_with_known_list() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = write(dir.path(), "p.yaml", "version: 1\nprofiles:\n  dev: {}\n  prod: {}\npipeline: {}\n");
+        match compose(&p, Some("staging")).unwrap_err() {
+            CliError::UnknownProfile { name, known } => {
+                assert_eq!(name, "staging");
+                assert!(known.contains(&"dev".to_string()) && known.contains(&"prod".to_string()));
+            }
+            other => panic!("expected UnknownProfile, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn missing_extends_base_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let app = write(dir.path(), "app.yaml", "extends: ./nope.yaml\nversion: 1\n");
+        assert!(matches!(
+            compose(&app, None).unwrap_err(),
+            CliError::IncludeNotFound { .. }
+        ));
+    }
+
+    #[test]
+    fn extends_cycle_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "a.yaml", "extends: ./b.yaml\nversion: 1\n");
+        write(dir.path(), "b.yaml", "extends: ./a.yaml\nversion: 1\n");
+        let a = dir.path().join("a.yaml");
+        assert!(matches!(
+            compose(&a, None).unwrap_err(),
+            CliError::CompositionCycle { .. }
+        ));
+    }
+
+    #[test]
+    fn diamond_extends_does_not_false_trigger_cycle() {
+        // app extends [b, c]; both b and c extend d. d is reached twice on
+        // different branches — that is NOT a cycle.
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "d.yaml", "version: 1\nshared: { from_d: true }\n");
+        write(dir.path(), "b.yaml", "extends: ./d.yaml\nshared: { from_b: true }\n");
+        write(dir.path(), "c.yaml", "extends: ./d.yaml\nshared: { from_c: true }\n");
+        let app = write(
+            dir.path(),
+            "app.yaml",
+            "extends: [./b.yaml, ./c.yaml]\nshared: { from_app: true }\n",
+        );
+        let v: JsonValue = serde_yaml::from_str(&compose(&app, None).unwrap()).unwrap();
+        assert_eq!(v["shared"]["from_d"], true);
+        assert_eq!(v["shared"]["from_b"], true);
+        assert_eq!(v["shared"]["from_c"], true);
+        assert_eq!(v["shared"]["from_app"], true);
+    }
+
+    #[test]
+    fn missing_base_after_successful_base_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "good.yaml", "version: 1\n");
+        let app = write(dir.path(), "app.yaml", "extends: [./good.yaml, ./nope.yaml]\n");
+        assert!(matches!(
+            compose(&app, None).unwrap_err(),
+            CliError::IncludeNotFound { .. }
+        ));
+    }
+
+    #[test]
+    fn self_extends_is_a_cycle() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = write(dir.path(), "a.yaml", "extends: ./a.yaml\nversion: 1\n");
+        assert!(matches!(
+            compose(&a, None).unwrap_err(),
+            CliError::CompositionCycle { .. }
+        ));
+    }
+
+    #[test]
+    fn yaml_can_extend_json_base() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "base.json", "{ \"version\": 1, \"pipeline\": { \"sink\": { \"type\": \"jsonl\", \"config\": { \"path\": \"base.jsonl\" } } } }");
+        let app = write(dir.path(), "app.yaml", "extends: ./base.json\npipeline:\n  source: { type: csv, config: { path: a.csv } }\n");
+        let v: JsonValue = serde_yaml::from_str(&compose(&app, None).unwrap()).unwrap();
+        assert_eq!(v["pipeline"]["sink"]["config"]["path"], "base.jsonl");
+        assert_eq!(v["pipeline"]["source"]["config"]["path"], "a.csv");
+    }
+}

--- a/cli/src/compose.rs
+++ b/cli/src/compose.rs
@@ -99,7 +99,7 @@ fn compose_document(path: &Path, visited: &mut Vec<PathBuf>, depth: usize) -> Cl
     }
     visited.push(key);
 
-    let mut doc = load_value(path)?;
+    let mut doc = load_value(path, visited, depth)?;
     let bases = take_extends(&mut doc, path)?;
     let result = if bases.is_empty() {
         doc
@@ -129,8 +129,10 @@ fn compose_document(path: &Path, visited: &mut Vec<PathBuf>, depth: usize) -> Cl
 }
 
 /// Parse one file into a `serde_json::Value`, resolving any `!include` tags
-/// (YAML only) before conversion.
-fn load_value(path: &Path) -> CliResult<JsonValue> {
+/// (YAML only) before conversion. Shares the caller's `visited`/`depth` cycle
+/// stack so a mixed `extends`+`!include` loop is caught as a `CompositionCycle`
+/// rather than terminating with a confusing leftover-key error.
+fn load_value(path: &Path, visited: &mut Vec<PathBuf>, depth: usize) -> CliResult<JsonValue> {
     let text = std::fs::read_to_string(path).map_err(|source| CliError::ReadConfig {
         path: path.to_path_buf(),
         source,
@@ -142,8 +144,7 @@ fn load_value(path: &Path) -> CliResult<JsonValue> {
                     path: path.to_path_buf(),
                     message: e.to_string(),
                 })?;
-            let mut visited: Vec<PathBuf> = Vec::new();
-            resolve_includes(&mut yv, path, &mut visited, 0)?;
+            resolve_includes(&mut yv, path, visited, depth)?;
             yaml_to_json(yv, path)
         }
         Format::Json => serde_json::from_str(&text).map_err(|e| CliError::ParseConfig {
@@ -638,6 +639,21 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         write(dir.path(), "a.yaml", "x: !include ./b.yaml\n");
         write(dir.path(), "b.yaml", "y: !include ./a.yaml\n");
+        let a = dir.path().join("a.yaml");
+        assert!(matches!(
+            compose(&a, None).unwrap_err(),
+            CliError::CompositionCycle { .. }
+        ));
+    }
+
+    #[test]
+    fn cross_mechanism_extends_include_cycle_errors() {
+        // `a extends b`, `b !includes a` — the extends and include stacks are
+        // shared, so the loop surfaces as a CompositionCycle (not a confusing
+        // leftover-key parse error or an infinite loop).
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "a.yaml", "extends: ./b.yaml\nversion: 1\n");
+        write(dir.path(), "b.yaml", "x: !include ./a.yaml\n");
         let a = dir.path().join("a.yaml");
         assert!(matches!(
             compose(&a, None).unwrap_err(),

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -416,10 +416,7 @@ impl PipelineConfig {
     /// Async load path: like [`Self::from_path`] but resolves secret-manager
     /// directives (`${vault:…}`, `${aws-sm:…}`, …) as a final stage. Composition
     /// (extends/profiles/`!include`) runs first via [`crate::compose::compose`].
-    pub async fn from_path_async(
-        path: impl AsRef<Path>,
-        profile: Option<&str>,
-    ) -> CliResult<Self> {
+    pub async fn from_path_async(path: impl AsRef<Path>, profile: Option<&str>) -> CliResult<Self> {
         let path = path.as_ref();
         let composed = crate::compose::compose(path, profile)?;
         let interpolated = interpolate(&composed)?;
@@ -1124,11 +1121,17 @@ pipeline:
 
         // No profile → base sink path.
         let cfg = PipelineConfig::from_path(&app, None).unwrap();
-        assert_eq!(cfg.pipeline.sink.as_ref().unwrap().config["path"], "base.jsonl");
+        assert_eq!(
+            cfg.pipeline.sink.as_ref().unwrap().config["path"],
+            "base.jsonl"
+        );
 
         // --profile prod → overridden sink path.
         let cfg = PipelineConfig::from_path(&app, Some("prod")).unwrap();
-        assert_eq!(cfg.pipeline.sink.as_ref().unwrap().config["path"], "prod.jsonl");
+        assert_eq!(
+            cfg.pipeline.sink.as_ref().unwrap().config["path"],
+            "prod.jsonl"
+        );
     }
 
     #[test]
@@ -1141,7 +1144,10 @@ pipeline:
         });
         let err = PipelineConfig::from_value(v).unwrap_err();
         let msg = err.to_string();
-        assert!(msg.contains("composition"), "expected composition hint, got: {msg}");
+        assert!(
+            msg.contains("composition"),
+            "expected composition hint, got: {msg}"
+        );
     }
 
     #[test]

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -381,16 +381,18 @@ impl PipelineConfig {
     /// parser: `.yaml` / `.yml` → YAML, `.json` → JSON. Other extensions are
     /// rejected.
     ///
+    /// Composition runs first via [`crate::compose::compose`]: `extends` (base
+    /// inheritance), `profiles` (the named overlay selected by `profile`), and
+    /// `!include` (YAML fragment substitution) are resolved into a single
+    /// merged document before `${...}` interpolation and parsing.
+    ///
     /// Secret directives (`${vault:…}`, `${aws-sm:…}`, etc.) are **not**
     /// resolved by this path. If any are present the call returns
     /// `CliError::SecretsRequireAsyncLoad` — use [`Self::from_path_async`] instead.
-    pub fn from_path(path: impl AsRef<Path>) -> CliResult<Self> {
+    pub fn from_path(path: impl AsRef<Path>, profile: Option<&str>) -> CliResult<Self> {
         let path = path.as_ref();
-        let raw = std::fs::read_to_string(path).map_err(|source| CliError::ReadConfig {
-            path: path.to_path_buf(),
-            source,
-        })?;
-        let interpolated = interpolate(&raw)?;
+        let composed = crate::compose::compose(path, profile)?;
+        let interpolated = interpolate(&composed)?;
         let cfg = Self::from_text(&interpolated, path)?;
         // Secret directives need the async resolver path; never let them survive
         // into a connector config as literal `${vault:…}` text.
@@ -399,26 +401,28 @@ impl PipelineConfig {
     }
 
     /// Like [`Self::from_path`] but does not reject secret directives — they are
-    /// left unresolved. Used by `validate --no-secrets`.
-    pub fn from_path_tolerating_secrets(path: impl AsRef<Path>) -> CliResult<Self> {
+    /// left unresolved. Used by `validate --no-secrets`. Composition
+    /// (extends/profiles/`!include`) runs first via [`crate::compose::compose`].
+    pub fn from_path_tolerating_secrets(
+        path: impl AsRef<Path>,
+        profile: Option<&str>,
+    ) -> CliResult<Self> {
         let path = path.as_ref();
-        let raw = std::fs::read_to_string(path).map_err(|source| CliError::ReadConfig {
-            path: path.to_path_buf(),
-            source,
-        })?;
-        let interpolated = interpolate(&raw)?;
+        let composed = crate::compose::compose(path, profile)?;
+        let interpolated = interpolate(&composed)?;
         Self::from_text(&interpolated, path)
     }
 
     /// Async load path: like [`Self::from_path`] but resolves secret-manager
-    /// directives (`${vault:…}`, `${aws-sm:…}`, …) as a final stage.
-    pub async fn from_path_async(path: impl AsRef<Path>) -> CliResult<Self> {
+    /// directives (`${vault:…}`, `${aws-sm:…}`, …) as a final stage. Composition
+    /// (extends/profiles/`!include`) runs first via [`crate::compose::compose`].
+    pub async fn from_path_async(
+        path: impl AsRef<Path>,
+        profile: Option<&str>,
+    ) -> CliResult<Self> {
         let path = path.as_ref();
-        let raw = std::fs::read_to_string(path).map_err(|source| CliError::ReadConfig {
-            path: path.to_path_buf(),
-            source,
-        })?;
-        let interpolated = interpolate(&raw)?;
+        let composed = crate::compose::compose(path, profile)?;
+        let interpolated = interpolate(&composed)?;
         let mut cfg = Self::from_text(&interpolated, path)?;
         crate::secrets::resolve_secrets(&mut cfg).await?;
         Ok(cfg)
@@ -706,7 +710,7 @@ pipeline:
 "#,
         )
         .unwrap();
-        let cfg = PipelineConfig::from_path(&path).unwrap();
+        let cfg = PipelineConfig::from_path(&path, None).unwrap();
         assert_eq!(
             cfg.pipeline.source.as_ref().unwrap().config["base_url"],
             "https://x.example"
@@ -760,7 +764,7 @@ pipeline:
 "#,
         )
         .unwrap();
-        let cfg = PipelineConfig::from_path(&path).unwrap();
+        let cfg = PipelineConfig::from_path(&path, None).unwrap();
         assert_eq!(
             cfg.pipeline.source.as_ref().unwrap().config["path"],
             "/v1/users/${users.id}/posts"
@@ -1013,7 +1017,7 @@ pipeline:
 "#,
         )
         .unwrap();
-        let cfg = PipelineConfig::from_path(&path).unwrap();
+        let cfg = PipelineConfig::from_path(&path, None).unwrap();
         assert_eq!(
             cfg.pipeline.source.as_ref().unwrap().config["url"],
             "https://api.example.com/v1"
@@ -1034,7 +1038,7 @@ pipeline:
 "#,
         )
         .unwrap();
-        match PipelineConfig::from_path(&path).unwrap_err() {
+        match PipelineConfig::from_path(&path, None).unwrap_err() {
             CliError::SecretsRequireAsyncLoad => {}
             other => panic!("expected SecretsRequireAsyncLoad, got {other:?}"),
         }
@@ -1081,7 +1085,7 @@ pipeline:
 "#,
         )
         .unwrap();
-        let cfg = PipelineConfig::from_path_async(&path).await.unwrap();
+        let cfg = PipelineConfig::from_path_async(&path, None).await.unwrap();
         assert_eq!(cfg.version, 1);
     }
 
@@ -1100,6 +1104,26 @@ pipeline:
         let cfg = parse_with_extension(yaml, "yaml").unwrap();
         let l = cfg.lineage.expect("lineage parsed");
         assert_eq!(l.namespace, "prod");
+    }
+
+    #[test]
+    fn from_path_resolves_extends_and_profile() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("base.yaml"),
+            "version: 1\npipeline:\n  source: { type: csv, config: { path: x.csv } }\n  sink: { type: jsonl, config: { path: base.jsonl } }\nprofiles:\n  prod:\n    pipeline:\n      sink: { config: { path: prod.jsonl } }\n",
+        )
+        .unwrap();
+        let app = dir.path().join("app.yaml");
+        std::fs::write(&app, "extends: ./base.yaml\n").unwrap();
+
+        // No profile → base sink path.
+        let cfg = PipelineConfig::from_path(&app, None).unwrap();
+        assert_eq!(cfg.pipeline.sink.as_ref().unwrap().config["path"], "base.jsonl");
+
+        // --profile prod → overridden sink path.
+        let cfg = PipelineConfig::from_path(&app, Some("prod")).unwrap();
+        assert_eq!(cfg.pipeline.sink.as_ref().unwrap().config["path"], "prod.jsonl");
     }
 
     #[test]

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -497,6 +497,11 @@ fn friendly_parse_error(raw: &str) -> String {
             "{raw}\n\nhint: top-level `source:` / `sink:` is no longer supported. Wrap them in a `pipeline:` block — see `faucet init` for the new shape."
         );
     }
+    if lower.contains("unknown field `extends`") || lower.contains("unknown field `profiles`") {
+        return format!(
+            "{raw}\n\nhint: config composition (`extends` / `profiles` / `!include`) is resolved only for file-based loads, not for configs submitted to `faucet serve` — resolve composition before submitting."
+        );
+    }
     raw.to_owned()
 }
 
@@ -1124,6 +1129,19 @@ pipeline:
         // --profile prod → overridden sink path.
         let cfg = PipelineConfig::from_path(&app, Some("prod")).unwrap();
         assert_eq!(cfg.pipeline.sink.as_ref().unwrap().config["path"], "prod.jsonl");
+    }
+
+    #[test]
+    fn from_value_rejects_extends_with_composition_hint() {
+        // A submitted body (serve path) must not silently accept `extends`.
+        let v = serde_json::json!({
+            "version": 1,
+            "extends": "base.yaml",
+            "pipeline": { "source": { "type": "csv", "config": {} }, "sink": { "type": "jsonl", "config": {} } }
+        });
+        let err = PipelineConfig::from_value(v).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("composition"), "expected composition hint, got: {msg}");
     }
 
     #[test]

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -230,10 +230,15 @@ pub enum CliError {
         path.display(),
         referenced_by.display()
     )]
-    IncludeNotFound { path: PathBuf, referenced_by: PathBuf },
+    IncludeNotFound {
+        path: PathBuf,
+        referenced_by: PathBuf,
+    },
 
     /// Composition nesting exceeded the safety cap (extends/!include loop guard).
-    #[error("config composition nested deeper than {max} levels — check for an extends/!include loop")]
+    #[error(
+        "config composition nested deeper than {max} levels — check for an extends/!include loop"
+    )]
     CompositionDepthExceeded { max: usize },
 
     /// An `!include` tag had a non-string payload, an unsupported tag, or its
@@ -535,7 +540,10 @@ mod tests {
         let msg = e.to_string();
         assert!(msg.contains("staging") && msg.contains("dev") && msg.contains("prod"));
 
-        let none = CliError::UnknownProfile { name: "x".into(), known: vec![] };
+        let none = CliError::UnknownProfile {
+            name: "x".into(),
+            known: vec![],
+        };
         assert!(none.to_string().contains("no `profiles:` block"));
     }
 
@@ -551,7 +559,11 @@ mod tests {
 
     #[test]
     fn composition_depth_exceeds_renders_max() {
-        assert!(CliError::CompositionDepthExceeded { max: 32 }.to_string().contains("32"));
+        assert!(
+            CliError::CompositionDepthExceeded { max: 32 }
+                .to_string()
+                .contains("32")
+        );
     }
 
     #[test]

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -220,6 +220,34 @@ pub enum CliError {
     #[error("interpolation cycle: {}", chain.join(" -> "))]
     InterpolationCycle { chain: Vec<String> },
 
+    /// A config-composition include/extends chain contains a cycle.
+    #[error("config composition cycle: {}", chain.join(" -> "))]
+    CompositionCycle { chain: Vec<String> },
+
+    /// An `extends`/`!include` target file does not exist.
+    #[error(
+        "config composition: file '{}' referenced by '{}' not found",
+        path.display(),
+        referenced_by.display()
+    )]
+    IncludeNotFound { path: PathBuf, referenced_by: PathBuf },
+
+    /// Composition nesting exceeded the safety cap (extends/!include loop guard).
+    #[error("config composition nested deeper than {max} levels — check for an extends/!include loop")]
+    CompositionDepthExceeded { max: usize },
+
+    /// An `!include` tag had a non-string payload, an unsupported tag, or its
+    /// target failed structural checks.
+    #[error("invalid `!include` in '{}': {reason}", path.display())]
+    BadInclude { path: PathBuf, reason: String },
+
+    /// `--profile NAME` (or FAUCET_PROFILE) named a profile not declared under `profiles:`.
+    #[error(
+        "unknown profile '{name}'. Declared profiles: {}",
+        if known.is_empty() { String::from("(none — no `profiles:` block)") } else { known.join(", ") }
+    )]
+    UnknownProfile { name: String, known: Vec<String> },
+
     /// A `${vars.X}` token referenced an undefined var.
     #[error(
         "interpolation '{token}' references unknown var '{name}' (define it under top-level `vars:`)"
@@ -486,5 +514,52 @@ mod tests {
         let msg = e.to_string();
         assert!(msg.contains("vars.a"));
         assert!(msg.contains("vars.b"));
+    }
+
+    #[test]
+    fn composition_cycle_renders_chain() {
+        let e = CliError::CompositionCycle {
+            chain: vec!["a.yaml".into(), "b.yaml".into(), "a.yaml".into()],
+        };
+        let msg = e.to_string();
+        assert!(msg.contains("a.yaml") && msg.contains("b.yaml"));
+        assert!(msg.contains(" -> "));
+    }
+
+    #[test]
+    fn unknown_profile_lists_known() {
+        let e = CliError::UnknownProfile {
+            name: "staging".into(),
+            known: vec!["dev".into(), "prod".into()],
+        };
+        let msg = e.to_string();
+        assert!(msg.contains("staging") && msg.contains("dev") && msg.contains("prod"));
+
+        let none = CliError::UnknownProfile { name: "x".into(), known: vec![] };
+        assert!(none.to_string().contains("no `profiles:` block"));
+    }
+
+    #[test]
+    fn include_not_found_names_both_paths() {
+        let e = CliError::IncludeNotFound {
+            path: std::path::PathBuf::from("base.yaml"),
+            referenced_by: std::path::PathBuf::from("app.yaml"),
+        };
+        let msg = e.to_string();
+        assert!(msg.contains("base.yaml") && msg.contains("app.yaml"));
+    }
+
+    #[test]
+    fn composition_depth_exceeds_renders_max() {
+        assert!(CliError::CompositionDepthExceeded { max: 32 }.to_string().contains("32"));
+    }
+
+    #[test]
+    fn bad_include_names_path_and_reason() {
+        let e = CliError::BadInclude {
+            path: std::path::PathBuf::from("f.yaml"),
+            reason: "!include payload must be a string path".into(),
+        };
+        assert!(e.to_string().contains("f.yaml") && e.to_string().contains("string path"));
     }
 }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -14,6 +14,7 @@
 pub mod auth_catalog;
 pub mod cli;
 pub mod commands;
+pub mod compose;
 pub mod config;
 pub mod env_config;
 pub mod env_loader;

--- a/cli/src/secrets/mod.rs
+++ b/cli/src/secrets/mod.rs
@@ -302,8 +302,11 @@ pub(crate) fn scan_config(cfg: &PipelineConfig) -> BTreeSet<SecretRef> {
 }
 
 /// Parse `path` (tolerating secret directives) and return its unique secret refs.
-pub fn scan_path_refs(path: &std::path::Path) -> CliResult<BTreeSet<SecretRef>> {
-    let cfg = PipelineConfig::from_path_tolerating_secrets(path)?;
+pub fn scan_path_refs(
+    path: &std::path::Path,
+    profile: Option<&str>,
+) -> CliResult<BTreeSet<SecretRef>> {
+    let cfg = PipelineConfig::from_path_tolerating_secrets(path, profile)?;
     Ok(scan_config(&cfg))
 }
 

--- a/cli/src/serve/load.rs
+++ b/cli/src/serve/load.rs
@@ -153,4 +153,26 @@ schedule:
             .unwrap_err();
         assert!(matches!(err, ServeError::BadConfig(_)));
     }
+
+    #[tokio::test]
+    async fn submitted_extends_is_rejected_with_composition_hint() {
+        // Composition must NOT run for HTTP-submitted bodies — otherwise a client
+        // could read arbitrary server files via `extends`. `deny_unknown_fields`
+        // rejects the key during `from_value` (no I/O), and `friendly_parse_error`
+        // attaches the composition hint.
+        let body = "version: 1\nextends: /etc/passwd\npipeline:\n  source: { type: csv, config: { path: x.csv } }\n  sink: { type: jsonl, config: { path: o.jsonl } }\n";
+        let err = load_submission(body, ConfigFormat::Yaml, None).await.unwrap_err();
+        // ServeError doesn't implement Display; pull the inner message directly.
+        let msg = match &err {
+            ServeError::Unprocessable { message, .. } => message.clone(),
+            ServeError::BadConfig(m) => m.clone(),
+            other => format!("{other:?}"),
+        };
+        // Assert the hint fired (not merely that serde named the field) so a
+        // regression in `friendly_parse_error` is caught.
+        assert!(
+            msg.contains("composition"),
+            "submitted extends must be rejected with the composition hint, got: {msg}"
+        );
+    }
 }

--- a/cli/src/serve/load.rs
+++ b/cli/src/serve/load.rs
@@ -161,7 +161,9 @@ schedule:
         // rejects the key during `from_value` (no I/O), and `friendly_parse_error`
         // attaches the composition hint.
         let body = "version: 1\nextends: /etc/passwd\npipeline:\n  source: { type: csv, config: { path: x.csv } }\n  sink: { type: jsonl, config: { path: o.jsonl } }\n";
-        let err = load_submission(body, ConfigFormat::Yaml, None).await.unwrap_err();
+        let err = load_submission(body, ConfigFormat::Yaml, None)
+            .await
+            .unwrap_err();
         // ServeError doesn't implement Display; pull the inner message directly.
         let msg = match &err {
             ServeError::Unprocessable { message, .. } => message.clone(),

--- a/cli/src/serve/server.rs
+++ b/cli/src/serve/server.rs
@@ -79,7 +79,8 @@ async fn load_default_base(config: &ServeConfig) -> CliResult<Option<Value>> {
     match &config.default_config_path {
         None => Ok(None),
         Some(path) => {
-            let cfg = crate::config::PipelineConfig::from_path_async(path).await?;
+            // TODO(Task 5): thread --profile
+            let cfg = crate::config::PipelineConfig::from_path_async(path, None).await?;
             Ok(Some(serde_json::to_value(&cfg).map_err(|e| {
                 CliError::Serve(format!("serializing --default-config: {e}"))
             })?))

--- a/cli/src/serve/server.rs
+++ b/cli/src/serve/server.rs
@@ -79,8 +79,10 @@ async fn load_default_base(config: &ServeConfig) -> CliResult<Option<Value>> {
     match &config.default_config_path {
         None => Ok(None),
         Some(path) => {
-            // TODO(Task 5): thread --profile
-            let cfg = crate::config::PipelineConfig::from_path_async(path, None).await?;
+            // `serve` has no --profile flag; honour FAUCET_PROFILE from the environment directly.
+            let profile = std::env::var("FAUCET_PROFILE").ok();
+            let cfg =
+                crate::config::PipelineConfig::from_path_async(path, profile.as_deref()).await?;
             Ok(Some(serde_json::to_value(&cfg).map_err(|e| {
                 CliError::Serve(format!("serializing --default-config: {e}"))
             })?))

--- a/cli/tests/cli_end_to_end.rs
+++ b/cli/tests/cli_end_to_end.rs
@@ -753,7 +753,7 @@ fn init_output_loads_and_expands() {
         .assert()
         .success();
 
-    let cfg = faucet_cli::config::PipelineConfig::from_path(&path)
+    let cfg = faucet_cli::config::PipelineConfig::from_path(&path, None)
         .expect("init output must load via PipelineConfig::from_path");
     let nodes = faucet_cli::expand::expand(&cfg).expect("init output must expand cleanly");
     assert_eq!(nodes.len(), 1, "expected exactly one expanded node");

--- a/cli/tests/config_composition.rs
+++ b/cli/tests/config_composition.rs
@@ -1,0 +1,89 @@
+//! End-to-end: a base + overlay + `--profile` composes correctly through the
+//! `faucet` binary.
+
+use assert_cmd::Command;
+use std::fs;
+
+fn faucet() -> Command {
+    Command::cargo_bin("faucet").expect("faucet binary builds")
+}
+
+#[test]
+fn run_with_profile_selects_overlay_sink() {
+    let dir = tempfile::tempdir().unwrap();
+    let data = dir.path().join("in.csv");
+    fs::write(&data, "id,name\n1,alice\n2,bob\n").unwrap();
+
+    fs::write(
+        dir.path().join("base.yaml"),
+        format!(
+            "version: 1\nname: composed\npipeline:\n  source: {{ type: csv, config: {{ path: {csv} }} }}\n  sink: {{ type: jsonl, config: {{ path: {dev} }} }}\nprofiles:\n  prod:\n    pipeline:\n      sink: {{ config: {{ path: {prod} }} }}\n",
+            csv = data.display(),
+            dev = dir.path().join("dev.jsonl").display(),
+            prod = dir.path().join("prod.jsonl").display(),
+        ),
+    )
+    .unwrap();
+    let app = dir.path().join("app.yaml");
+    fs::write(&app, "extends: ./base.yaml\n").unwrap();
+
+    faucet()
+        .args(["run", app.to_str().unwrap(), "--profile", "prod"])
+        .assert()
+        .success();
+
+    assert!(dir.path().join("prod.jsonl").exists(), "prod overlay sink must be written");
+    assert!(!dir.path().join("dev.jsonl").exists(), "base sink must NOT be written when prod selected");
+}
+
+#[test]
+fn env_profile_is_honored_and_flag_overrides_it() {
+    let dir = tempfile::tempdir().unwrap();
+    let data = dir.path().join("in.csv");
+    fs::write(&data, "id\n1\n").unwrap();
+    fs::write(
+        dir.path().join("p.yaml"),
+        format!(
+            "version: 1\npipeline:\n  source: {{ type: csv, config: {{ path: {csv} }} }}\n  sink: {{ type: jsonl, config: {{ path: {base} }} }}\nprofiles:\n  dev: {{ pipeline: {{ sink: {{ config: {{ path: {dev} }} }} }} }}\n  prod: {{ pipeline: {{ sink: {{ config: {{ path: {prod} }} }} }} }}\n",
+            csv = data.display(),
+            base = dir.path().join("base.jsonl").display(),
+            dev = dir.path().join("dev.jsonl").display(),
+            prod = dir.path().join("prod.jsonl").display(),
+        ),
+    )
+    .unwrap();
+    let p = dir.path().join("p.yaml");
+
+    // FAUCET_PROFILE=dev (no flag) → dev.jsonl
+    faucet().args(["run", p.to_str().unwrap()]).env("FAUCET_PROFILE", "dev").assert().success();
+    assert!(dir.path().join("dev.jsonl").exists());
+
+    // --profile prod overrides FAUCET_PROFILE=dev → prod.jsonl, NOT dev.jsonl.
+    // Remove dev.jsonl first so its non-recreation proves the env var was suppressed.
+    fs::remove_file(dir.path().join("dev.jsonl")).unwrap();
+    faucet()
+        .args(["run", p.to_str().unwrap(), "--profile", "prod"])
+        .env("FAUCET_PROFILE", "dev")
+        .assert()
+        .success();
+    assert!(dir.path().join("prod.jsonl").exists(), "prod overlay must be written");
+    assert!(
+        !dir.path().join("dev.jsonl").exists(),
+        "dev sink must NOT be written — --profile prod overrides FAUCET_PROFILE=dev"
+    );
+}
+
+#[test]
+fn unknown_profile_fails_clearly() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join("p.yaml"),
+        "version: 1\npipeline:\n  source: { type: csv, config: { path: x.csv } }\n  sink: { type: jsonl, config: { path: o.jsonl } }\nprofiles:\n  dev: {}\n",
+    )
+    .unwrap();
+    faucet()
+        .args(["validate", dir.path().join("p.yaml").to_str().unwrap(), "--profile", "staging", "--no-secrets"])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("unknown profile 'staging'"));
+}

--- a/cli/tests/config_composition.rs
+++ b/cli/tests/config_composition.rs
@@ -96,6 +96,17 @@ fn show_composed_prints_merged_config_with_profile_applied() {
 }
 
 #[test]
+fn shipped_compose_example_validates_under_each_profile() {
+    let app = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("examples/compose/app.yaml");
+    for profile in ["dev", "prod"] {
+        faucet()
+            .args(["validate", app.to_str().unwrap(), "--profile", profile, "--no-secrets"])
+            .assert()
+            .success();
+    }
+}
+
+#[test]
 fn unknown_profile_fails_clearly() {
     let dir = tempfile::tempdir().unwrap();
     fs::write(

--- a/cli/tests/config_composition.rs
+++ b/cli/tests/config_composition.rs
@@ -2,6 +2,7 @@
 //! `faucet` binary.
 
 use assert_cmd::Command;
+use predicates::prelude::*;
 use std::fs;
 
 fn faucet() -> Command {
@@ -71,6 +72,27 @@ fn env_profile_is_honored_and_flag_overrides_it() {
         !dir.path().join("dev.jsonl").exists(),
         "dev sink must NOT be written — --profile prod overrides FAUCET_PROFILE=dev"
     );
+}
+
+#[test]
+fn show_composed_prints_merged_config_with_profile_applied() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join("base.yaml"),
+        "version: 1\npipeline:\n  source: { type: csv, config: { path: x.csv } }\n  sink: { type: jsonl, config: { path: base.jsonl } }\nprofiles:\n  prod:\n    pipeline:\n      sink: { config: { path: prod.jsonl } }\n",
+    )
+    .unwrap();
+    let app = dir.path().join("app.yaml");
+    fs::write(&app, "extends: ./base.yaml\n").unwrap();
+
+    faucet()
+        .args(["validate", app.to_str().unwrap(), "--profile", "prod", "--show-composed", "--no-secrets"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("prod.jsonl"))      // profile applied
+        .stdout(predicates::str::contains("base.jsonl").not()) // base sink overridden
+        .stdout(predicates::str::contains("profiles:").not())  // metadata stripped
+        .stdout(predicates::str::contains("extends:").not());
 }
 
 #[test]

--- a/cli/tests/config_composition.rs
+++ b/cli/tests/config_composition.rs
@@ -33,8 +33,14 @@ fn run_with_profile_selects_overlay_sink() {
         .assert()
         .success();
 
-    assert!(dir.path().join("prod.jsonl").exists(), "prod overlay sink must be written");
-    assert!(!dir.path().join("dev.jsonl").exists(), "base sink must NOT be written when prod selected");
+    assert!(
+        dir.path().join("prod.jsonl").exists(),
+        "prod overlay sink must be written"
+    );
+    assert!(
+        !dir.path().join("dev.jsonl").exists(),
+        "base sink must NOT be written when prod selected"
+    );
 }
 
 #[test]
@@ -56,7 +62,11 @@ fn env_profile_is_honored_and_flag_overrides_it() {
     let p = dir.path().join("p.yaml");
 
     // FAUCET_PROFILE=dev (no flag) → dev.jsonl
-    faucet().args(["run", p.to_str().unwrap()]).env("FAUCET_PROFILE", "dev").assert().success();
+    faucet()
+        .args(["run", p.to_str().unwrap()])
+        .env("FAUCET_PROFILE", "dev")
+        .assert()
+        .success();
     assert!(dir.path().join("dev.jsonl").exists());
 
     // --profile prod overrides FAUCET_PROFILE=dev → prod.jsonl, NOT dev.jsonl.
@@ -67,7 +77,10 @@ fn env_profile_is_honored_and_flag_overrides_it() {
         .env("FAUCET_PROFILE", "dev")
         .assert()
         .success();
-    assert!(dir.path().join("prod.jsonl").exists(), "prod overlay must be written");
+    assert!(
+        dir.path().join("prod.jsonl").exists(),
+        "prod overlay must be written"
+    );
     assert!(
         !dir.path().join("dev.jsonl").exists(),
         "dev sink must NOT be written — --profile prod overrides FAUCET_PROFILE=dev"
@@ -86,12 +99,19 @@ fn show_composed_prints_merged_config_with_profile_applied() {
     fs::write(&app, "extends: ./base.yaml\n").unwrap();
 
     faucet()
-        .args(["validate", app.to_str().unwrap(), "--profile", "prod", "--show-composed", "--no-secrets"])
+        .args([
+            "validate",
+            app.to_str().unwrap(),
+            "--profile",
+            "prod",
+            "--show-composed",
+            "--no-secrets",
+        ])
         .assert()
         .success()
-        .stdout(predicates::str::contains("prod.jsonl"))      // profile applied
+        .stdout(predicates::str::contains("prod.jsonl")) // profile applied
         .stdout(predicates::str::contains("base.jsonl").not()) // base sink overridden
-        .stdout(predicates::str::contains("profiles:").not())  // metadata stripped
+        .stdout(predicates::str::contains("profiles:").not()) // metadata stripped
         .stdout(predicates::str::contains("extends:").not());
 }
 
@@ -100,7 +120,13 @@ fn shipped_compose_example_validates_under_each_profile() {
     let app = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("examples/compose/app.yaml");
     for profile in ["dev", "prod"] {
         faucet()
-            .args(["validate", app.to_str().unwrap(), "--profile", profile, "--no-secrets"])
+            .args([
+                "validate",
+                app.to_str().unwrap(),
+                "--profile",
+                profile,
+                "--no-secrets",
+            ])
             .assert()
             .success();
     }
@@ -115,7 +141,13 @@ fn unknown_profile_fails_clearly() {
     )
     .unwrap();
     faucet()
-        .args(["validate", dir.path().join("p.yaml").to_str().unwrap(), "--profile", "staging", "--no-secrets"])
+        .args([
+            "validate",
+            dir.path().join("p.yaml").to_str().unwrap(),
+            "--profile",
+            "staging",
+            "--no-secrets",
+        ])
         .assert()
         .failure()
         .stderr(predicates::str::contains("unknown profile 'staging'"));

--- a/cli/tests/examples_roundtrip.rs
+++ b/cli/tests/examples_roundtrip.rs
@@ -67,7 +67,7 @@ fn every_example_loads_and_expands() {
             }
         }
         count += 1;
-        let cfg = match PipelineConfig::from_path(&path) {
+        let cfg = match PipelineConfig::from_path(&path, None) {
             Ok(c) => c,
             Err(ref e) if is_credential_error(e) => {
                 // Credential not available in this environment — skip.
@@ -102,6 +102,6 @@ fn every_example_loads_and_expands() {
 #[test]
 fn serve_minimal_default_config_parses() {
     let path = examples_dir().join("serve_minimal.yaml");
-    PipelineConfig::from_path(&path)
+    PipelineConfig::from_path(&path, None)
         .expect("serve_minimal.yaml must parse as a valid PipelineConfig");
 }

--- a/cli/tests/init_preview.rs
+++ b/cli/tests/init_preview.rs
@@ -168,6 +168,7 @@ fn preview_args(config: Option<PathBuf>, limit: usize) -> PreviewArgs {
         limit,
         env_file: None,
         no_env_file: true,
+        profile: None,
     }
 }
 

--- a/cli/tests/lineage_run.rs
+++ b/cli/tests/lineage_run.rs
@@ -18,6 +18,7 @@ fn run_args(config: PathBuf) -> faucet_cli::cli::RunArgs {
         limit: None,
         state_path: None,
         clock: None,
+        profile: None,
     }
 }
 

--- a/cli/tests/secrets_aws_sm.rs
+++ b/cli/tests/secrets_aws_sm.rs
@@ -23,7 +23,7 @@ pipeline:
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("p.yaml");
     std::fs::write(&path, yaml).unwrap();
-    let cfg = PipelineConfig::from_path_async(&path).await.unwrap();
+    let cfg = PipelineConfig::from_path_async(&path, None).await.unwrap();
     let token = &cfg.pipeline.source.unwrap().config["auth"]["config"]["token"];
     assert_eq!(token, "aws-live-token");
 }

--- a/cli/tests/secrets_vault.rs
+++ b/cli/tests/secrets_vault.rs
@@ -22,7 +22,7 @@ pipeline:
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("p.yaml");
     std::fs::write(&path, yaml).unwrap();
-    let cfg = PipelineConfig::from_path_async(&path).await.unwrap();
+    let cfg = PipelineConfig::from_path_async(&path, None).await.unwrap();
     let token = &cfg.pipeline.source.unwrap().config["auth"]["config"]["token"];
     assert_eq!(token, "live-token-value");
 }

--- a/cli/tests/templates_end_to_end.rs
+++ b/cli/tests/templates_end_to_end.rs
@@ -57,7 +57,7 @@ matrix:
     )
     .unwrap();
 
-    let cfg = PipelineConfig::from_path(&path).unwrap();
+    let cfg = PipelineConfig::from_path(&path, None).unwrap();
     // Vars resolved.
     assert_eq!(
         cfg.pipeline.sources["users_api"].config["base_url"],

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -27,6 +27,7 @@
 - [Record transforms](./cookbook/transforms.md)
 - [SQL transform](./cookbook/sql-transform.md)
 - [Secrets-manager interpolation](./cookbook/secrets.md)
+- [Config composition](./cookbook/composition.md)
 - [Adaptive batching](./cookbook/adaptive-batching.md)
 - [Scheduling](./cookbook/scheduling.md)
 - [Running faucet as a service](./cookbook/serve.md)

--- a/docs/book/src/cookbook/composition.md
+++ b/docs/book/src/cookbook/composition.md
@@ -1,0 +1,227 @@
+# Config composition
+
+Real deployments rarely run a single pipeline file. The same connection,
+sink target, and transform chain are reused across dev / staging / prod, and
+across many similar pipelines. **Config composition** lets you factor those
+shared pieces out of each file and recombine them at load time — without
+copy-pasting or templating engines.
+
+Three mechanisms, all resolved when the file is read (before any `${...}`
+interpolation runs):
+
+| Mechanism | What it does |
+|-----------|--------------|
+| `extends:` | Inherit one or more **base** config files; the child deep-merges on top. |
+| `profiles:` | Declare named **overlays** in the file; select one at run time with `--profile NAME` / `FAUCET_PROFILE`. |
+| `!include path` | Substitute a **YAML fragment** at any node (YAML only). |
+
+This walkthrough uses the files shipped under
+[`cli/examples/compose/`](https://github.com/PawanSikawat/faucet-stream/tree/main/cli/examples/compose).
+
+## A worked dev / staging / prod setup
+
+### The shared base
+
+`base.yaml` holds everything common to every environment — the source
+connection and a neutral default sink — plus a `profiles:` block of
+per-environment overlays that each visibly override it:
+
+```yaml
+# cli/examples/compose/base.yaml
+version: 1
+name: composed-pipeline
+pipeline:
+  source:
+    type: csv
+    config:
+      path: ./data/input.csv
+  sink:
+    type: jsonl
+    config:
+      path: ./out/output.jsonl   # neutral default — overridden per-env by the profiles below
+
+# Named overlays selected at run time via --profile / FAUCET_PROFILE.
+# Each profile points the sink at an environment-specific file.
+profiles:
+  dev:
+    pipeline:
+      sink:
+        config:
+          path: ./out/dev.jsonl
+  prod:
+    pipeline:
+      sink:
+        config:
+          path: ./out/prod.jsonl
+```
+
+### A reusable fragment
+
+`transforms.yaml` is a bare YAML **sequence** — a transform chain you can pull
+into any pipeline:
+
+```yaml
+# cli/examples/compose/transforms.yaml
+- type: flatten
+  config: { separator: "__" }
+- type: keys_case
+  config: { mode: snake }
+```
+
+### The pipeline that ties it together
+
+`app.yaml` inherits the base and pulls in the transform chain with `!include`:
+
+```yaml
+# cli/examples/compose/app.yaml
+extends: ./base.yaml
+pipeline:
+  transforms: !include ./transforms.yaml
+```
+
+Run it against an environment by selecting a profile:
+
+```bash
+faucet run cli/examples/compose/app.yaml --profile prod
+```
+
+The composed pipeline reads `./data/input.csv` (from the base), applies the
+`flatten` → `keys_case` chain (from the include), and writes
+`./out/prod.jsonl` (from the `prod` profile overlay). Without `--profile`,
+the sink falls back to the neutral base default (`./out/output.jsonl`);
+`--profile dev` redirects it to `./out/dev.jsonl`.
+
+## `extends` — base inheritance
+
+`extends:` names one or more base files. Relative paths resolve against the
+**directory of the file that declares them**. The child document deep-merges on
+top of the base (child keys win on collision).
+
+```yaml
+# Single base
+extends: ./base.yaml
+
+# A list of bases — merged left-to-right, so later bases override earlier ones,
+# and the child document overrides them all.
+extends:
+  - ./connection.yaml
+  - ./sink-defaults.yaml
+```
+
+Bases may themselves `extends:` other files; the chain is followed to its root
+(a depth cap and cycle detection guard against runaway or circular includes).
+
+## `profiles` + `--profile` / `FAUCET_PROFILE`
+
+A top-level `profiles:` block maps a name to a partial config that is
+deep-merged **over** the composed document when that profile is selected.
+Nothing is applied unless a profile is chosen:
+
+```bash
+faucet run app.yaml --profile prod          # explicit flag
+FAUCET_PROFILE=prod faucet run app.yaml      # via environment
+```
+
+**The flag overrides the environment variable.** `--profile prod` with
+`FAUCET_PROFILE=dev` set selects `prod`. Selecting a name that isn't declared
+is a clear load-time error (`unknown profile '<name>'`).
+
+`profiles:` and `extends:` compose freely: a base can declare the profiles and
+the child can select one at run time, as in the worked example above.
+
+## `!include` — YAML fragment substitution
+
+`!include path` (a YAML tag) replaces the node it tags with the parsed contents
+of another YAML file. The fragment can be any YAML value — a sequence (as in
+`transforms.yaml`), a mapping, or a scalar — and is substituted **structurally**
+before the document is interpreted:
+
+```yaml
+pipeline:
+  transforms: !include ./transforms.yaml   # a sequence fragment
+  source: !include ./source.yaml           # a mapping fragment
+```
+
+`!include` is **YAML-only** — it is a YAML tag, so it has no equivalent in JSON
+configs. Paths resolve against the including file's directory, like `extends:`.
+
+## Precedence
+
+Everything is merged with the same deep-merge rule used by `matrix` rows:
+**objects merge recursively, arrays replace wholesale, scalars replace.** The
+layers, from lowest to highest priority (last wins):
+
+```
+extended base(s)  →  child document  →  selected profile  →  matrix row
+```
+
+- `extends:` bases are the foundation (a list merges left-to-right).
+- The child document (the file you ran) overrides its bases.
+- The selected `profile` overlays the composed document.
+- At expand time, each `matrix` row deep-merges on top — so a row can still
+  override a profile-supplied value.
+
+**Composition resolves before all `${...}` interpolation.** The full load order
+is:
+
+1. **Composition** — `extends` / `!include` are stitched, then the selected
+   `profile` is overlaid; `extends:` / `profiles:` metadata keys are stripped.
+2. **Interpolation** — `${env:…}` / `${file:…}` / `${secret:…}`, then
+   `${vars.X}` and `${sources.X}` / `${sinks.X}`.
+3. **Secrets-manager directives** — `${vault:…}` etc. (the final load-time
+   stage).
+4. **Expand** — `matrix` rows are deep-merged per invocation.
+
+This ordering means a `profile` can supply a value that a later
+`${env:…}`/`${vars.X}` reference is then resolved within, and that a base file
+can carry `${...}` tokens resolved only after the merge.
+
+## Inspecting the result: `validate --show-composed`
+
+`faucet validate --show-composed` prints the fully composed config — bases
+merged, the selected profile applied, fragments substituted, and the
+`extends:` / `profiles:` metadata stripped — *before* `${...}` interpolation.
+It's the fastest way to confirm a multi-file setup resolves to what you expect:
+
+```bash
+faucet validate cli/examples/compose/app.yaml --show-composed --profile prod
+```
+
+```yaml
+version: 1
+name: composed-pipeline
+pipeline:
+  source:
+    type: csv
+    config:
+      path: ./data/input.csv
+  sink:
+    type: jsonl
+    config:
+      path: ./out/prod.jsonl     # ← from the prod profile
+  transforms:                    # ← from the !include
+  - type: flatten
+    config:
+      separator: __
+  - type: keys_case
+    config:
+      mode: snake
+```
+
+## Security
+
+**Composition is file-loads-only.** `extends`, `profiles`, and `!include` are
+resolved only when `faucet` reads a config from disk (`run`, `validate`,
+`preview`, `doctor`, `schedule`). They are **not** honored for configs submitted
+to `faucet serve` over HTTP — a submitted body is parsed as a single,
+self-contained document with no filesystem access. This keeps a multi-tenant or
+internet-exposed `serve` process from being coerced into reading arbitrary local
+files via a crafted `extends:` / `!include` path. Compose your config locally and
+submit the result (`validate --show-composed` gives you exactly that document).
+
+## See also
+
+- [Config reference — composition](../reference/config.md#config-composition) — concise field grammar for `extends:`, `profiles:`, and `!include`.
+- [Transforms](./transforms.md) — the full set of built-in record transforms you can include or layer per profile.
+- [Secrets](./secrets.md) — interpolate secrets-manager references that survive composition unchanged until the final load stage.
+- [State & resumability](./state.md) — bookmark-based incremental runs that compose cleanly with profile overlays.

--- a/docs/book/src/reference/cli.md
+++ b/docs/book/src/reference/cli.md
@@ -35,6 +35,7 @@ Flags:
 | Flag | Purpose |
 |------|---------|
 | `--clock <value>` | Override the clock used by `${now.*}` tokens. Accepts an RFC 3339 timestamp (`2026-03-01T00:00:00Z`) or a bare date (`2026-03-01`, treated as midnight UTC). Default: process start time in UTC. Use this for backfills — run the same config with a different date without changing the file. |
+| `--profile <name>` | Select a named overlay from the config's `profiles:` block (see [Config composition](config.md#config-composition)). Overrides `FAUCET_PROFILE`. |
 | `--env-file <path>` / `--no-env-file` | Same `.env` handling as `validate` / `preview`. |
 | `--from-env` | Build the pipeline entirely from `FAUCET_*` environment variables; mutually exclusive with a positional config path. |
 
@@ -65,6 +66,23 @@ development before vault access is available:
 faucet validate --no-secrets pipeline.yaml
 ```
 
+### Composition flags
+
+When a config uses [composition](config.md#config-composition) (`extends:` /
+`profiles:` / `!include`), `validate` resolves it like `run` does:
+
+```bash
+faucet validate app.yaml --profile prod        # select a named overlay
+faucet validate app.yaml --show-composed       # print the fully merged config
+```
+
+- `--profile <name>` selects a named overlay from `profiles:` (also settable via
+  `FAUCET_PROFILE`; the flag wins). An undeclared name is a clear load-time error.
+- `--show-composed` prints the fully composed document — bases merged, the
+  selected profile applied, `!include` fragments substituted, and the
+  `extends:` / `profiles:` metadata stripped — *before* `${...}` interpolation.
+  It's the fastest way to confirm a multi-file setup resolves to what you expect.
+
 ## `preview`
 
 Runs the first root row's source and prints records (via the stdout sink).
@@ -73,7 +91,11 @@ Children aren't previewed because they need parent records to resolve
 
 ```bash
 faucet preview pipeline.yaml --limit 10
+faucet preview app.yaml --profile dev --limit 5   # preview with a named profile overlay
 ```
+
+`--profile <name>` / `FAUCET_PROFILE` selects a named overlay from `profiles:` before
+previewing. Same semantics as `run` and `validate`.
 
 ## `schema`
 
@@ -109,6 +131,7 @@ mode (`--interactive`) is gated behind the `cli-interactive` feature.
 faucet doctor pipeline.yaml                  # checklist; exit code = # of failed probes
 faucet doctor pipeline.yaml --timeout-secs 5 # per-probe timeout (default 10)
 faucet doctor pipeline.yaml --json           # machine-readable, for CI gating
+faucet doctor app.yaml --profile prod        # probe with a named profile overlay applied
 ```
 
 Runs a fast, **non-mutating** preflight against every connector in the config so
@@ -129,6 +152,9 @@ Child invocations (parent/child matrix rows) are listed but not probed — their
 configs depend on parent records that only exist at run time. Probe messages are
 scrubbed for resolved secrets before printing.
 
+`--profile <name>` / `FAUCET_PROFILE` selects a named overlay from `profiles:` before
+probing (same semantics as `run` and `validate`).
+
 See the [Troubleshooting](../cookbook/troubleshooting.md) cookbook page for
 reading the output and common failures.
 
@@ -139,6 +165,7 @@ faucet schedule pipeline.yaml                  # run on cron schedule, foregroun
 faucet schedule pipeline.yaml --once           # run exactly once now, then exit
 faucet schedule pipeline.yaml --env-file prod.env
 faucet schedule pipeline.yaml --no-env-file
+faucet schedule app.yaml --profile prod        # schedule with a named profile overlay applied
 ```
 
 Runs a pipeline on a recurring cron schedule in a **long-running foreground process**. The config
@@ -157,6 +184,7 @@ Flags:
 | Flag | Purpose |
 |------|---------|
 | `--once` | Run exactly once now, then exit. Ignores cron timing. |
+| `--profile <name>` | Select a named overlay from `profiles:` (also settable via `FAUCET_PROFILE`; the flag wins). Same semantics as `run` / `validate`. |
 | `--env-file <path>` / `--no-env-file` | Same `.env` handling as `run` / `validate`. |
 
 See the [scheduling cookbook](../cookbook/scheduling.md) for worked examples, the overlap-policy

--- a/docs/book/src/reference/config.md
+++ b/docs/book/src/reference/config.md
@@ -67,6 +67,74 @@ each. Highlights:
 - `filter` — keep records where a JSONPath predicate is true. See the cookbook for the operator set and path syntax.
 - `explode` — expand an array field into one record per element. See the cookbook for the merge rule and `on_missing` semantics.
 
+## Config composition
+
+Three top-level mechanisms let a config be assembled from reusable pieces.
+They are resolved when the file is read, **before** any `${...}` interpolation.
+
+| Mechanism | Form | Effect |
+|-----------|------|--------|
+| `extends:` | `extends: ./base.yaml` or a list | Inherit one or more base files; the child deep-merges on top. |
+| `profiles:` | `profiles: { dev: {…}, prod: {…} }` | Named overlays, selected at run time with `--profile NAME` / `FAUCET_PROFILE`. |
+| `!include` | `key: !include ./frag.yaml` | Substitute a YAML fragment at any node (**YAML only**). |
+
+```yaml
+# app.yaml — inherits a base and pulls in a transform fragment.
+extends: ./base.yaml          # single path, or a list (merged left-to-right)
+pipeline:
+  transforms: !include ./transforms.yaml
+```
+
+```yaml
+# base.yaml — shared connection + sink, with named per-environment overlays.
+version: 1
+name: composed-pipeline
+pipeline:
+  source: { type: csv,   config: { path: ./data/input.csv } }
+  sink:   { type: jsonl, config: { path: ./out/dev.jsonl } }
+profiles:
+  dev:  { pipeline: { sink: { config: { path: ./out/dev.jsonl } } } }
+  prod: { pipeline: { sink: { config: { path: ./out/prod.jsonl } } } }
+```
+
+- **`extends`** — relative paths resolve against the directory of the file that
+  declares them. A list of bases merges left-to-right; the child document
+  overrides them all. Bases may themselves `extends:` further files (depth-capped,
+  cycle-detected).
+- **`profiles`** — nothing is applied unless a profile is selected. Select with
+  `--profile prod` or `FAUCET_PROFILE=prod`; **the flag overrides the env var**.
+  An undeclared name is a load-time error.
+- **`!include`** — a YAML tag (no JSON equivalent) that replaces the tagged node
+  with the parsed contents of another YAML file (sequence, mapping, or scalar).
+  Paths resolve against the including file's directory.
+
+**Merge rule and precedence.** Everything composes with the same deep-merge used
+by `matrix` rows (objects merge recursively, arrays replace wholesale, scalars
+replace). Lowest-to-highest priority (last wins):
+
+```
+extended base(s)  →  child document  →  selected profile  →  matrix row
+```
+
+**Load-time ordering.** Composition runs first, then interpolation:
+
+1. **Composition** — `extends` / `!include` stitched, then the selected
+   `profile` overlaid; the `extends:` / `profiles:` metadata keys are stripped.
+2. `${env:…}` / `${file:…}` / `${secret:…}`, then `${vars.X}` and
+   `${sources.X}` / `${sinks.X}` (see [Interpolation](#interpolation)).
+3. Secrets-manager directives (`${vault:…}` etc.).
+4. `matrix` expansion.
+
+**Inspect the result** with `faucet validate --show-composed` — it prints the
+fully composed document (bases merged, profile applied, fragments substituted,
+metadata stripped) before interpolation.
+
+> **Composition is file-loads-only.** `extends` / `profiles` / `!include` apply
+> to configs faucet reads from disk (`run`, `validate`, `preview`, `doctor`,
+> `schedule`). They are **not** honored for configs submitted to `faucet serve`
+> over HTTP — a submitted body is a single self-contained document with no
+> filesystem access. See the [config-composition cookbook](../cookbook/composition.md).
+
 ## Interpolation
 
 Three stages resolve placeholders:


### PR DESCRIPTION
## Summary

Adds **config composition** to the `faucet` CLI so teams stop copy-pasting connection blocks, auth catalogs, transform chains, and resilience settings across pipeline files:

- **`extends:`** — base-config inheritance (single path or list; deep-merge via `merge.rs::merge_value`, child wins).
- **`profiles:`** — named overlays (`dev`/`staging`/`prod`/…) selected at run time via `--profile NAME` / `FAUCET_PROFILE` (the flag overrides the env var).
- **`!include path`** — YAML-only fragment substitution at any node (e.g. `transforms: !include ./transforms.yaml`).
- **`faucet validate --show-composed`** — print the fully-merged config (after extends/include/profile, before `${...}` interpolation) for debugging precedence.

CLI-layer only — **no `faucet-core` changes** (like secrets/interpolation/scheduling).

## Design

A new `cli/src/compose.rs` front pre-pass resolves `!include` → `extends` → profile overlay at the `serde_json::Value` level and re-emits merged **text** into the unchanged `interpolate → from_text → resolve_secrets → expand` pipeline. A **zero-impact fast path** returns the raw file text byte-identical when no composition is present, so every existing config behaves exactly as before (verified by the examples-roundtrip test).

**Precedence (last wins):** extended base → child document → selected profile → matrix row — all resolved **before** `${...}` interpolation. Safety: canonicalized-path cycle detection shared across `extends` + `!include`, a depth cap (32), and typed errors for missing files / bad `!include` payload / unknown profile.

**Security:** composition is **file-loads-only**. HTTP-submitted `faucet serve` bodies go through `from_value` (never `compose`), so a client cannot read arbitrary server files via `extends`/`!include`; such bodies are rejected with a clear hint.

## Test plan

- [x] `cargo test -p faucet-cli --all-features` — green (incl. 19 `compose` unit tests, integration tests for `--profile`/`FAUCET_PROFILE` precedence, `--show-composed`, the serve security boundary, and the shipped example validating under each profile).
- [x] `cargo clippy -p faucet-cli --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo fmt --all --check` — clean.
- [x] docs.rs-style nightly doc build — clean.
- [x] Runnable example `cli/examples/compose/` + docs (`reference/config.md`, `reference/cli.md`, cookbook `composition.md`, `cli/README.md`).

Closes #212