### PR TITLE
chore(release): align faucet-lineage + faucet-transform-sql to 1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ categories = ["database", "asynchronous"]
 # Internal crates
 faucet-core = { path = "crates/core", version = "1.0.0" }
 faucet-auth = { path = "crates/auth", version = "1.0.0" }
-faucet-lineage = { path = "crates/lineage", version = "0.1.0" }
+faucet-lineage = { path = "crates/lineage", version = "1.0.0" }
 faucet-common-bigquery = { path = "crates/common/bigquery", version = "1.0.0" }
 faucet-common-elasticsearch = { path = "crates/common/elasticsearch", version = "1.0.0" }
 faucet-common-gcs = { path = "crates/common/gcs", version = "1.0.0" }
@@ -128,7 +128,7 @@ faucet-sink-iceberg = { path = "crates/sink/iceberg", version = "1.0.0" }
 faucet-state-redis = { path = "crates/state/redis", version = "1.0.0" }
 faucet-state-postgres = { path = "crates/state/postgres", version = "1.0.0" }
 faucet-cli = { path = "cli", version = "1.0.1" }
-faucet-transform-sql = { path = "crates/transform-sql", version = "0.1.0" }
+faucet-transform-sql = { path = "crates/transform-sql", version = "1.0.0" }
 
 # Shared external deps
 serde = { version = "1", features = ["derive"] }

--- a/crates/lineage/Cargo.toml
+++ b/crates/lineage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "faucet-lineage"
-version = "0.1.0"
+version = "1.0.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/transform-sql/Cargo.toml
+++ b/crates/transform-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "faucet-transform-sql"
-version = "0.1.0"
+version = "1.0.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/transform-sql/README.md
+++ b/crates/transform-sql/README.md
@@ -5,7 +5,7 @@ page's records are exposed as the relation `batch`; the result set replaces the 
 
 ```toml
 [dependencies]
-faucet-transform-sql = "0.1"
+faucet-transform-sql = "1.0"
 ```
 
 Enable in the umbrella crate or CLI:


### PR DESCRIPTION
## Summary
`faucet-lineage` and `faucet-transform-sql` — the two newest crates — sat at `0.1.0` while every other crate in the workspace is `1.0.x`. Both are **unpublished** (HTTP 404 on crates.io, no `*-v*` release tags), so this is a clean first-publish at `1.0.0`, not a semver jump. Aligning them avoids signalling pre-1.0 instability for crates held to the same quality bar as the rest.

## Changes
- `crates/lineage/Cargo.toml`: `version` 0.1.0 → 1.0.0
- `crates/transform-sql/Cargo.toml`: `version` 0.1.0 → 1.0.0
- `Cargo.toml` `[workspace.dependencies]`: bump the `version` requirement for both (the only place it's declared — dependents use `workspace = true`)
- `crates/transform-sql/README.md`: install example `"0.1"` → `"1.0"` (the only pinned-version doc ref; baked into the published crate per the publishing rules)

`cargo metadata` resolves cleanly with both at 1.0.0.

## Release impact
Once merged, release-plz regenerates the `chore: release` PR (#177) with both crates' first release at **1.0.0**. Worth a glance at that PR to confirm before publishing.
