### PR TITLE
ci(release-plz): harden cargo publish against transient crates.io HTTP2 drops

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -22,6 +22,14 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  # Harden against transient crates.io connectivity drops on GitHub-hosted
+  # runners — "Error in the HTTP2 framing layer (Connection reset by peer)" /
+  # "curl failed" / "SSL_read: unexpected eof" — that abort `cargo publish`
+  # mid-release (hit during the 1.1.0 release: faucet-sink-parquet failed on an
+  # HTTP2 reset). Retry more, and disable HTTP/2 multiplexing to force HTTP/1.1
+  # against the registry. Mirrors the same guards in .github/workflows/ci.yml.
+  CARGO_NET_RETRY: "10"
+  CARGO_HTTP_MULTIPLEXING: "false"
 
 jobs:
   release-plz-pr:


### PR DESCRIPTION
## Summary
Add `CARGO_NET_RETRY=10` and `CARGO_HTTP_MULTIPLEXING=false` to the **workflow-level `env:`** of `release-plz.yml`, so they apply to the `cargo publish` runs in the publish job.

## Motivation
The 1.1.0 release publish failed mid-way on `faucet-sink-parquet`:
```
failed to prepare local package for uploading
  [16] Error in the HTTP2 framing layer (Send failure: Connection reset by peer)
```
That's the well-known transient crates.io-index connectivity flake on GitHub-hosted runners. `ci.yml` already guards against it with exactly these two env vars (forces HTTP/1.1 + more retries), but `release-plz.yml` was missing them — making the release publish unnecessarily prone to a network blip and requiring a manual re-run to finish.

## Change
- `release-plz.yml` `env:` block gains the two cargo-net guards (mirrors `ci.yml`), with a comment pointing back to the 1.1.0 incident.

No behavior change beyond network resilience; applies to both release-plz jobs.

## Out of scope
- The separate `RELEASE_PLZ_TOKEN` gap (release PRs don't auto-run CI because they're created by the default `GITHUB_TOKEN`) — that needs a repo secret, tracked separately.
