### PR TITLE
docs(readme): use `cargo add` for install examples (no pinned versions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,10 +125,9 @@ every common source→sink combination.
 
 Embed the same engine in a Rust service:
 
-```toml
-[dependencies]
-faucet-stream = { version = "1.0", features = ["sink-jsonl"] }  # default already has the REST source
-tokio = { version = "1", features = ["full"] }
+```bash
+cargo add faucet-stream --features sink-jsonl   # default already has the REST source
+cargo add tokio --features full
 ```
 
 ```rust
@@ -265,21 +264,21 @@ for help picking between overlapping connectors (Postgres query vs CDC, S3 vs Pa
 
 ### Install
 
-```toml
+```bash
 # Everything (default includes the REST source)
-faucet-stream = "1.0"
+cargo add faucet-stream
 
 # All sources / all sinks / all connectors
-faucet-stream = { version = "1.0", features = ["source"] }
-faucet-stream = { version = "1.0", features = ["sink"] }
-faucet-stream = { version = "1.0", features = ["full"] }
+cargo add faucet-stream --features source
+cargo add faucet-stream --features sink
+cargo add faucet-stream --features full
 
 # Pick individual connectors
-faucet-stream = { version = "1.0", features = ["source-rest", "sink-postgres", "sink-s3"] }
+cargo add faucet-stream --features source-rest,sink-postgres,sink-s3
 
 # Or depend on individual connector crates directly
-faucet-source-rest = "1.0"
-faucet-source-mongodb = "1.0"
+cargo add faucet-source-rest
+cargo add faucet-source-mongodb
 ```
 
 ## How it compares

--- a/crates/core/README.md
+++ b/crates/core/README.md
@@ -9,10 +9,9 @@ This is the foundation crate that all faucet source and sink connectors depend o
 
 ## Installation
 
-```toml
-[dependencies]
-faucet-core = "1.0"
-tokio = { version = "1", features = ["rt"] }
+```bash
+cargo add faucet-core
+cargo add tokio --features rt
 ```
 
 ## What's Inside

--- a/crates/sink/bigquery/README.md
+++ b/crates/sink/bigquery/README.md
@@ -11,16 +11,15 @@ Writes JSON records to a BigQuery table using the `tabledata.insertAll` streamin
 
 ## Installation
 
-```toml
-[dependencies]
-faucet-sink-bigquery = "1.0"
-tokio = { version = "1", features = ["full"] }
+```bash
+cargo add faucet-sink-bigquery
+cargo add tokio --features full
 ```
 
 Or via the umbrella crate:
 
-```toml
-faucet-stream = { version = "1.0", features = ["sink-bigquery"] }
+```bash
+cargo add faucet-stream --features sink-bigquery
 ```
 
 ## Quick Start

--- a/crates/sink/csv/README.md
+++ b/crates/sink/csv/README.md
@@ -9,16 +9,15 @@ Writes JSON records to a CSV file. Column order is the union of keys across the 
 
 ## Installation
 
-```toml
-[dependencies]
-faucet-sink-csv = "1.0"
-tokio = { version = "1", features = ["full"] }
+```bash
+cargo add faucet-sink-csv
+cargo add tokio --features full
 ```
 
 Or via the umbrella crate:
 
-```toml
-faucet-stream = { version = "1.0", features = ["sink-csv"] }
+```bash
+cargo add faucet-stream --features sink-csv
 ```
 
 ## Quick Start

--- a/crates/sink/elasticsearch/README.md
+++ b/crates/sink/elasticsearch/README.md
@@ -11,16 +11,15 @@ Indexes JSON records into an Elasticsearch index using the bulk API (`_bulk` end
 
 ## Installation
 
-```toml
-[dependencies]
-faucet-sink-elasticsearch = "1.0"
-tokio = { version = "1", features = ["full"] }
+```bash
+cargo add faucet-sink-elasticsearch
+cargo add tokio --features full
 ```
 
 Or via the umbrella crate:
 
-```toml
-faucet-stream = { version = "1.0", features = ["sink-elasticsearch"] }
+```bash
+cargo add faucet-stream --features sink-elasticsearch
 ```
 
 ## Quick Start

--- a/crates/sink/http/README.md
+++ b/crates/sink/http/README.md
@@ -9,16 +9,15 @@ Sends JSON records to an HTTP endpoint. Supports two batch modes: Individual (on
 
 ## Installation
 
-```toml
-[dependencies]
-faucet-sink-http = "1.0"
-tokio = { version = "1", features = ["full"] }
+```bash
+cargo add faucet-sink-http
+cargo add tokio --features full
 ```
 
 Or via the umbrella crate:
 
-```toml
-faucet-stream = { version = "1.0", features = ["sink-http"] }
+```bash
+cargo add faucet-stream --features sink-http
 ```
 
 ## Quick Start

--- a/crates/sink/iceberg/README.md
+++ b/crates/sink/iceberg/README.md
@@ -52,22 +52,22 @@ config-load time; use the REST catalog for those object stores.
 
 Install only what you need:
 
-```toml
+```bash
 # REST catalog (default):
-faucet-sink-iceberg = "1.0"
+cargo add faucet-sink-iceberg
 
 # Glue catalog:
-faucet-sink-iceberg = { version = "1.0", features = ["catalog-glue"] }
+cargo add faucet-sink-iceberg --features catalog-glue
 
 # All catalogs:
-faucet-sink-iceberg = { version = "1.0", features = ["catalog-glue", "catalog-sql", "catalog-hms"] }
+cargo add faucet-sink-iceberg --features catalog-glue,catalog-sql,catalog-hms
 ```
 
 Via the umbrella crate, catalog forwarding features are available:
 
-```toml
-faucet-stream = { version = "1.0", features = ["sink-iceberg"] }                      # REST only
-faucet-stream = { version = "1.0", features = ["sink-iceberg", "sink-iceberg-glue"] } # REST + Glue
+```bash
+cargo add faucet-stream --features sink-iceberg                    # REST only
+cargo add faucet-stream --features sink-iceberg,sink-iceberg-glue  # REST + Glue
 ```
 
 ## Quick start

--- a/crates/sink/jsonl/README.md
+++ b/crates/sink/jsonl/README.md
@@ -9,16 +9,15 @@ Writes JSON records to a file in [JSON Lines](https://jsonlines.org/) format (on
 
 ## Installation
 
-```toml
-[dependencies]
-faucet-sink-jsonl = "1.0"
-tokio = { version = "1", features = ["full"] }
+```bash
+cargo add faucet-sink-jsonl
+cargo add tokio --features full
 ```
 
 Or via the umbrella crate:
 
-```toml
-faucet-stream = { version = "1.0", features = ["sink-jsonl"] }
+```bash
+cargo add faucet-stream --features sink-jsonl
 ```
 
 ## Quick Start

--- a/crates/sink/mongodb/README.md
+++ b/crates/sink/mongodb/README.md
@@ -9,16 +9,15 @@ Inserts JSON records into a MongoDB collection using `insert_many` for efficient
 
 ## Installation
 
-```toml
-[dependencies]
-faucet-sink-mongodb = "1.0"
-tokio = { version = "1", features = ["full"] }
+```bash
+cargo add faucet-sink-mongodb
+cargo add tokio --features full
 ```
 
 Or via the umbrella crate:
 
-```toml
-faucet-stream = { version = "1.0", features = ["sink-mongodb"] }
+```bash
+cargo add faucet-stream --features sink-mongodb
 ```
 
 ## Quick Start

--- a/crates/sink/mysql/README.md
+++ b/crates/sink/mysql/README.md
@@ -11,16 +11,15 @@ Writes JSON records to a MySQL table using either JSON column mode (storing each
 
 ## Installation
 
-```toml
-[dependencies]
-faucet-sink-mysql = "1.0"
-tokio = { version = "1", features = ["full"] }
+```bash
+cargo add faucet-sink-mysql
+cargo add tokio --features full
 ```
 
 Or via the umbrella crate:
 
-```toml
-faucet-stream = { version = "1.0", features = ["sink-mysql"] }
+```bash
+cargo add faucet-stream --features sink-mysql
 ```
 
 ## Quick Start

--- a/crates/sink/postgres/README.md
+++ b/crates/sink/postgres/README.md
@@ -11,16 +11,15 @@ Writes JSON records to a PostgreSQL table using either JSONB column mode (storin
 
 ## Installation
 
-```toml
-[dependencies]
-faucet-sink-postgres = "1.0"
-tokio = { version = "1", features = ["full"] }
+```bash
+cargo add faucet-sink-postgres
+cargo add tokio --features full
 ```
 
 Or via the umbrella crate:
 
-```toml
-faucet-stream = { version = "1.0", features = ["sink-postgres"] }
+```bash
+cargo add faucet-stream --features sink-postgres
 ```
 
 ## Quick Start

--- a/crates/sink/redis/README.md
+++ b/crates/sink/redis/README.md
@@ -9,16 +9,15 @@ Writes JSON records to Redis data structures: lists (`RPUSH`), streams (`XADD`),
 
 ## Installation
 
-```toml
-[dependencies]
-faucet-sink-redis = "1.0"
-tokio = { version = "1", features = ["full"] }
+```bash
+cargo add faucet-sink-redis
+cargo add tokio --features full
 ```
 
 Or via the umbrella crate:
 
-```toml
-faucet-stream = { version = "1.0", features = ["sink-redis"] }
+```bash
+cargo add faucet-stream --features sink-redis
 ```
 
 ## Quick Start

--- a/crates/sink/s3/README.md
+++ b/crates/sink/s3/README.md
@@ -9,16 +9,15 @@ Writes JSON records to S3 as JSON Lines (NDJSON) files. Each file is keyed with 
 
 ## Installation
 
-```toml
-[dependencies]
-faucet-sink-s3 = "1.0"
-tokio = { version = "1", features = ["full"] }
+```bash
+cargo add faucet-sink-s3
+cargo add tokio --features full
 ```
 
 Or via the umbrella crate:
 
-```toml
-faucet-stream = { version = "1.0", features = ["sink-s3"] }
+```bash
+cargo add faucet-stream --features sink-s3
 ```
 
 ## Quick Start

--- a/crates/sink/snowflake/README.md
+++ b/crates/sink/snowflake/README.md
@@ -9,16 +9,15 @@ Writes JSON records to a Snowflake table using the Snowflake SQL REST API. Suppo
 
 ## Installation
 
-```toml
-[dependencies]
-faucet-sink-snowflake = "1.0"
-tokio = { version = "1", features = ["full"] }
+```bash
+cargo add faucet-sink-snowflake
+cargo add tokio --features full
 ```
 
 Or via the umbrella crate:
 
-```toml
-faucet-stream = { version = "1.0", features = ["sink-snowflake"] }
+```bash
+cargo add faucet-stream --features sink-snowflake
 ```
 
 ## Quick Start

--- a/crates/sink/sqlite/README.md
+++ b/crates/sink/sqlite/README.md
@@ -11,16 +11,15 @@ Writes JSON records to a SQLite table using either JSON column mode (storing eac
 
 ## Installation
 
-```toml
-[dependencies]
-faucet-sink-sqlite = "1.0"
-tokio = { version = "1", features = ["full"] }
+```bash
+cargo add faucet-sink-sqlite
+cargo add tokio --features full
 ```
 
 Or via the umbrella crate:
 
-```toml
-faucet-stream = { version = "1.0", features = ["sink-sqlite"] }
+```bash
+cargo add faucet-stream --features sink-sqlite
 ```
 
 ## Quick Start

--- a/crates/sink/stdout/README.md
+++ b/crates/sink/stdout/README.md
@@ -4,17 +4,15 @@ Stdout/stderr sink for the [faucet-stream](https://crates.io/crates/faucet-strea
 
 ## Install
 
-```toml
-[dependencies]
-faucet-core = "1.0"
-faucet-sink-stdout = "1.0"
+```bash
+cargo add faucet-core
+cargo add faucet-sink-stdout
 ```
 
 Or via the umbrella crate with the `sink-stdout` feature:
 
-```toml
-[dependencies]
-faucet-stream = { version = "1.0", features = ["sink-stdout"] }
+```bash
+cargo add faucet-stream --features sink-stdout
 ```
 
 ## Usage

--- a/crates/source/csv/README.md
+++ b/crates/source/csv/README.md
@@ -9,15 +9,14 @@ Part of the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosy
 
 ## Installation
 
-```toml
-[dependencies]
-faucet-source-csv = "1.0"
-tokio = { version = "1", features = ["full"] }
+```bash
+cargo add faucet-source-csv
+cargo add tokio --features full
 ```
 
 Or via the umbrella crate:
-```toml
-faucet-stream = { version = "1.0", features = ["source-csv"] }
+```bash
+cargo add faucet-stream --features source-csv
 ```
 
 ## Quick Start

--- a/crates/source/elasticsearch/README.md
+++ b/crates/source/elasticsearch/README.md
@@ -9,15 +9,14 @@ Part of the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosy
 
 ## Installation
 
-```toml
-[dependencies]
-faucet-source-elasticsearch = "1.0"
-tokio = { version = "1", features = ["full"] }
+```bash
+cargo add faucet-source-elasticsearch
+cargo add tokio --features full
 ```
 
 Or via the umbrella crate:
-```toml
-faucet-stream = { version = "1.0", features = ["source-elasticsearch"] }
+```bash
+cargo add faucet-stream --features source-elasticsearch
 ```
 
 ## Quick Start

--- a/crates/source/graphql/README.md
+++ b/crates/source/graphql/README.md
@@ -9,15 +9,14 @@ Part of the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosy
 
 ## Installation
 
-```toml
-[dependencies]
-faucet-source-graphql = "1.0"
-tokio = { version = "1", features = ["full"] }
+```bash
+cargo add faucet-source-graphql
+cargo add tokio --features full
 ```
 
 Or via the umbrella crate:
-```toml
-faucet-stream = { version = "1.0", features = ["source-graphql"] }
+```bash
+cargo add faucet-stream --features source-graphql
 ```
 
 ## Quick Start

--- a/crates/source/grpc/README.md
+++ b/crates/source/grpc/README.md
@@ -9,15 +9,14 @@ Part of the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosy
 
 ## Installation
 
-```toml
-[dependencies]
-faucet-source-grpc = "1.0"
-tokio = { version = "1", features = ["full"] }
+```bash
+cargo add faucet-source-grpc
+cargo add tokio --features full
 ```
 
 Or via the umbrella crate:
-```toml
-faucet-stream = { version = "1.0", features = ["source-grpc"] }
+```bash
+cargo add faucet-stream --features source-grpc
 ```
 
 ## Prerequisites

--- a/crates/source/kafka/README.md
+++ b/crates/source/kafka/README.md
@@ -115,9 +115,8 @@ Configured via `value_format` (and optionally `key_format`). All formats use a `
 
 The three Confluent formats require building with the `schema-registry` feature flag:
 
-```toml
-[dependencies]
-faucet-source-kafka = { version = "...", features = ["schema-registry"] }
+```bash
+cargo add faucet-source-kafka --features schema-registry
 ```
 
 Each Confluent format takes a `schema_registry` block — see the `faucet-common-kafka` README for the full `SchemaRegistryConfig` options (URL, basic auth, cache capacity, request timeout).

--- a/crates/source/mongodb/README.md
+++ b/crates/source/mongodb/README.md
@@ -9,15 +9,14 @@ Part of the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosy
 
 ## Installation
 
-```toml
-[dependencies]
-faucet-source-mongodb = "1.0"
-tokio = { version = "1", features = ["full"] }
+```bash
+cargo add faucet-source-mongodb
+cargo add tokio --features full
 ```
 
 Or via the umbrella crate:
-```toml
-faucet-stream = { version = "1.0", features = ["source-mongodb"] }
+```bash
+cargo add faucet-stream --features source-mongodb
 ```
 
 ## Quick Start

--- a/crates/source/mysql/README.md
+++ b/crates/source/mysql/README.md
@@ -9,15 +9,14 @@ Part of the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosy
 
 ## Installation
 
-```toml
-[dependencies]
-faucet-source-mysql = "1.0"
-tokio = { version = "1", features = ["full"] }
+```bash
+cargo add faucet-source-mysql
+cargo add tokio --features full
 ```
 
 Or via the umbrella crate:
-```toml
-faucet-stream = { version = "1.0", features = ["source-mysql"] }
+```bash
+cargo add faucet-stream --features source-mysql
 ```
 
 ## Quick Start

--- a/crates/source/postgres/README.md
+++ b/crates/source/postgres/README.md
@@ -9,15 +9,14 @@ Part of the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosy
 
 ## Installation
 
-```toml
-[dependencies]
-faucet-source-postgres = "1.0"
-tokio = { version = "1", features = ["full"] }
+```bash
+cargo add faucet-source-postgres
+cargo add tokio --features full
 ```
 
 Or via the umbrella crate:
-```toml
-faucet-stream = { version = "1.0", features = ["source-postgres"] }
+```bash
+cargo add faucet-stream --features source-postgres
 ```
 
 ## Quick Start

--- a/crates/source/redis/README.md
+++ b/crates/source/redis/README.md
@@ -9,15 +9,14 @@ Part of the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosy
 
 ## Installation
 
-```toml
-[dependencies]
-faucet-source-redis = "1.0"
-tokio = { version = "1", features = ["full"] }
+```bash
+cargo add faucet-source-redis
+cargo add tokio --features full
 ```
 
 Or via the umbrella crate:
-```toml
-faucet-stream = { version = "1.0", features = ["source-redis"] }
+```bash
+cargo add faucet-stream --features source-redis
 ```
 
 ## Quick Start

--- a/crates/source/rest/README.md
+++ b/crates/source/rest/README.md
@@ -9,15 +9,14 @@ Part of the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosy
 
 ## Installation
 
-```toml
-[dependencies]
-faucet-source-rest = "1.0"
-tokio = { version = "1", features = ["full"] }
+```bash
+cargo add faucet-source-rest
+cargo add tokio --features full
 ```
 
 Or via the umbrella crate:
-```toml
-faucet-stream = { version = "1.0", features = ["source-rest"] }
+```bash
+cargo add faucet-stream --features source-rest
 ```
 
 ## Quick Start

--- a/crates/source/s3/README.md
+++ b/crates/source/s3/README.md
@@ -9,15 +9,14 @@ Part of the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosy
 
 ## Installation
 
-```toml
-[dependencies]
-faucet-source-s3 = "1.0"
-tokio = { version = "1", features = ["full"] }
+```bash
+cargo add faucet-source-s3
+cargo add tokio --features full
 ```
 
 Or via the umbrella crate:
-```toml
-faucet-stream = { version = "1.0", features = ["source-s3"] }
+```bash
+cargo add faucet-stream --features source-s3
 ```
 
 ## Quick Start

--- a/crates/source/sqlite/README.md
+++ b/crates/source/sqlite/README.md
@@ -9,15 +9,14 @@ Part of the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosy
 
 ## Installation
 
-```toml
-[dependencies]
-faucet-source-sqlite = "1.0"
-tokio = { version = "1", features = ["full"] }
+```bash
+cargo add faucet-source-sqlite
+cargo add tokio --features full
 ```
 
 Or via the umbrella crate:
-```toml
-faucet-stream = { version = "1.0", features = ["source-sqlite"] }
+```bash
+cargo add faucet-stream --features source-sqlite
 ```
 
 ## Quick Start

--- a/crates/source/webhook/README.md
+++ b/crates/source/webhook/README.md
@@ -9,15 +9,14 @@ Part of the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosy
 
 ## Installation
 
-```toml
-[dependencies]
-faucet-source-webhook = "1.0"
-tokio = { version = "1", features = ["full"] }
+```bash
+cargo add faucet-source-webhook
+cargo add tokio --features full
 ```
 
 Or via the umbrella crate:
-```toml
-faucet-stream = { version = "1.0", features = ["source-webhook"] }
+```bash
+cargo add faucet-stream --features source-webhook
 ```
 
 ## Quick Start

--- a/crates/source/websocket/README.md
+++ b/crates/source/websocket/README.md
@@ -11,15 +11,14 @@ Part of the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosy
 
 ## Installation
 
-```toml
-[dependencies]
-faucet-source-websocket = "1.0"
-tokio = { version = "1", features = ["full"] }
+```bash
+cargo add faucet-source-websocket
+cargo add tokio --features full
 ```
 
 Or via the umbrella crate:
-```toml
-faucet-stream = { version = "1.0", features = ["source-websocket"] }
+```bash
+cargo add faucet-stream --features source-websocket
 ```
 
 ## Quick Start — Binance trade stream

--- a/crates/source/xml/README.md
+++ b/crates/source/xml/README.md
@@ -9,15 +9,14 @@ Part of the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosy
 
 ## Installation
 
-```toml
-[dependencies]
-faucet-source-xml = "1.0"
-tokio = { version = "1", features = ["full"] }
+```bash
+cargo add faucet-source-xml
+cargo add tokio --features full
 ```
 
 Or via the umbrella crate:
-```toml
-faucet-stream = { version = "1.0", features = ["source-xml"] }
+```bash
+cargo add faucet-stream --features source-xml
 ```
 
 ## Quick Start

--- a/crates/state/postgres/README.md
+++ b/crates/state/postgres/README.md
@@ -4,10 +4,9 @@ PostgreSQL-backed [`StateStore`](https://docs.rs/faucet-core/latest/faucet_core/
 
 ## Install
 
-```toml
-[dependencies]
-faucet-core = "1.0"
-faucet-state-postgres = "1.0"
+```bash
+cargo add faucet-core
+cargo add faucet-state-postgres
 ```
 
 ## Usage

--- a/crates/state/redis/README.md
+++ b/crates/state/redis/README.md
@@ -4,10 +4,9 @@ Redis-backed [`StateStore`](https://docs.rs/faucet-core/latest/faucet_core/state
 
 ## Install
 
-```toml
-[dependencies]
-faucet-core = "1.0"
-faucet-state-redis = "1.0"
+```bash
+cargo add faucet-core
+cargo add faucet-state-redis
 ```
 
 ## Usage

--- a/crates/transform-sql/README.md
+++ b/crates/transform-sql/README.md
@@ -3,15 +3,14 @@
 SQL-as-transform for faucet-stream — run DuckDB SQL over each pipeline page. The
 page's records are exposed as the relation `batch`; the result set replaces the page.
 
-```toml
-[dependencies]
-faucet-transform-sql = "1.0"
+```bash
+cargo add faucet-transform-sql
 ```
 
 Enable in the umbrella crate or CLI:
 
-```toml
-faucet-stream = { version = "1.0", features = ["transform-sql"] }
+```bash
+cargo add faucet-stream --features transform-sql
 ```
 
 ## What it does
@@ -234,15 +233,15 @@ Output rows look like:
 
 `transform-sql` — not in the default build; included in `full`.
 
-```toml
+```bash
 # Enable only the SQL transform
-faucet-stream = { version = "1.0", features = ["transform-sql"] }
+cargo add faucet-stream --features transform-sql
 
 # Enable together with specific connectors
-faucet-stream = { version = "1.0", features = ["source-csv", "sink-jsonl", "transform-sql"] }
+cargo add faucet-stream --features source-csv,sink-jsonl,transform-sql
 
 # Enable everything
-faucet-stream = { version = "1.0", features = ["full"] }
+cargo add faucet-stream --features full
 ```
 
 CLI:

--- a/faucet-stream/README.md
+++ b/faucet-stream/README.md
@@ -7,22 +7,21 @@ Umbrella crate for the [faucet-stream](https://github.com/PawanSikawat/faucet-st
 
 ## Installation
 
-```toml
-[dependencies]
+```bash
 # Default: REST source only
-faucet-stream = "1.0"
+cargo add faucet-stream
 
 # All sources
-faucet-stream = { version = "1.0", features = ["source"] }
+cargo add faucet-stream --features source
 
 # All sinks
-faucet-stream = { version = "1.0", features = ["sink"] }
+cargo add faucet-stream --features sink
 
 # Everything
-faucet-stream = { version = "1.0", features = ["full"] }
+cargo add faucet-stream --features full
 
 # Pick what you need
-faucet-stream = { version = "1.0", features = ["source-rest", "source-s3", "sink-postgres", "sink-jsonl"] }
+cargo add faucet-stream --features source-rest,source-s3,sink-postgres,sink-jsonl
 ```
 
 ## Feature Flags
@@ -206,11 +205,10 @@ Plus all types from enabled connector features (e.g. `RestStream`, `RestStreamCo
 
 You can also depend on connector crates directly instead of using the umbrella:
 
-```toml
-[dependencies]
-faucet-core = "1.0"
-faucet-source-rest = "1.0"
-faucet-sink-postgres = "1.0"
+```bash
+cargo add faucet-core
+cargo add faucet-source-rest
+cargo add faucet-sink-postgres
 ```
 
 This gives finer control over dependencies and compile times.


### PR DESCRIPTION
## Summary
Replace pinned-version crate install examples (`faucet-core = "1.0"`, `faucet-stream = { version = "1.0", features = [...] }`) with version-less `cargo add` commands across all **35 READMEs**.

## Why
release-plz/cargo-release bump the `version` in `Cargo.toml`, but README install snippets are plain prose that no release tool touches — so they drift one release behind on every publish. That's why the `faucet-core` crates.io page still showed `faucet-core = "1.0"` after the 1.1.0 release. `cargo add` always installs the latest compatible version, so:
- the examples **can never go stale** (nothing to keep in sync — zero maintenance),
- no fragile release-time rewriting or CI drift-guard is needed,
- the concrete version stays visible on each crate's crates.io page header.

## Changes
- 35 README files: `toml` `[dependencies]` install blocks → `bash` `cargo add` blocks; features preserved (`--features full`, `--features source-rest,sink-postgres`, …); explanatory `#` comments kept.
- `cargo install faucet-cli` examples left as-is (already version-less).
- No non-install content touched (feature tables, prose, code/YAML examples, MSRV notes unchanged).

Verified: only README.md files changed, no `version =`/pinned-`faucet-* = "x"` install lines remain, all code fences balanced.
