### PR TITLE
feat(cli): add execution schema output

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -298,6 +298,8 @@ pub enum SchemaTarget {
     Dlq,
     /// JSON Schema for the `replication:` (snapshot→CDC) block.
     Replication,
+    /// JSON Schema for the top-level `execution:` block.
+    Execution,
     /// JSON Schema for the `quality:` block.
     #[cfg(feature = "quality")]
     Quality,

--- a/cli/src/commands/schema.rs
+++ b/cli/src/commands/schema.rs
@@ -93,6 +93,15 @@ mod tests {
         assert!(r.is_ok(), "{r:?}");
     }
 
+    #[tokio::test]
+    async fn schema_execution_target_ok() {
+        let r = super::run(SchemaArgs {
+            target: SchemaTarget::Execution,
+        })
+        .await;
+        assert!(r.is_ok(), "{r:?}");
+    }
+
     #[test]
     fn execution_schema_includes_adaptive_batch_size() {
         let schema = faucet_core::schema_for!(crate::config::ExecutionSpec);

--- a/cli/src/commands/schema.rs
+++ b/cli/src/commands/schema.rs
@@ -20,6 +20,10 @@ pub async fn run(args: SchemaArgs) -> CliResult<()> {
             let s = faucet_core::schema_for!(crate::replication::spec::ReplicationSpec);
             serde_json::to_value(s).unwrap_or_else(|_| serde_json::json!({"type": "object"}))
         }
+        SchemaTarget::Execution => {
+            let s = faucet_core::schema_for!(crate::config::ExecutionSpec);
+            serde_json::to_value(s).unwrap_or_else(|_| serde_json::json!({"type": "object"}))
+        }
         #[cfg(feature = "quality")]
         SchemaTarget::Quality => {
             let quality_schema = faucet_core::schema_for!(faucet_core::QualitySpec);
@@ -87,5 +91,12 @@ mod tests {
         })
         .await;
         assert!(r.is_ok(), "{r:?}");
+    }
+
+    #[test]
+    fn execution_schema_includes_adaptive_batch_size() {
+        let schema = faucet_core::schema_for!(crate::config::ExecutionSpec);
+        let value = serde_json::to_value(schema).expect("execution schema serializes");
+        assert!(value["properties"].get("adaptive_batch_size").is_some());
     }
 }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -272,7 +272,7 @@ pub struct MatrixRow {
 }
 
 /// Execution-time controls.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct ExecutionSpec {
     /// Maximum concurrent pipeline invocations (root + per-parent-record
@@ -291,7 +291,7 @@ pub struct ExecutionSpec {
 }
 
 /// Failure-handling policy across the matrix.
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum OnError {
     /// Skip the failed invocation's subtree but keep running siblings (default).

--- a/docs/book/src/reference/cli.md
+++ b/docs/book/src/reference/cli.md
@@ -105,6 +105,7 @@ faucet schema source rest
 faucet schema sink bigquery
 faucet schema transform keys_case
 faucet schema dlq
+faucet schema execution
 faucet schema secrets
 faucet schema triggers
 ```
@@ -112,6 +113,9 @@ faucet schema triggers
 `faucet schema transform <name>` prints the inline config schema for a
 transform (e.g. `keys_case` lists the valid `mode:` values). Run
 `faucet list` to see which transforms are compiled into your binary.
+
+`faucet schema execution` prints the schema for the top-level `execution:`
+block, including concurrency, error handling, and adaptive batch sizing.
 
 `faucet schema secrets` prints the directive grammar and auth requirements for
 all four secrets-manager backends in machine-readable JSON — useful for tooling


### PR DESCRIPTION
## Summary
- add `execution` as a `faucet schema` target
- derive JSON Schema for execution and error handling configuration
- cover the adaptive batch size property and document the command

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`

A full local build was not completed because the dependency build exceeded the available Windows session time; CI should exercise the complete workspace matrix.

Closes #141