### PR TITLE
feat(sink-bigquery): write_mode upsert/delete via in-place MERGE (#224)

### DIFF
--- a/cli/examples/postgres_cdc_to_bigquery_upsert.yaml
+++ b/cli/examples/postgres_cdc_to_bigquery_upsert.yaml
@@ -1,0 +1,63 @@
+# End-to-end Postgres CDC -> BigQuery upsert mirror, exactly-once.
+#
+# Streams logical-replication change events from a source database, normalizes
+# the CDC envelope with `cdc_unwrap`, and mirrors them into a BigQuery table
+# with `write_mode: upsert` — inserts/updates become MERGE UPSERTs and deletes
+# become row deletes, so the BigQuery table stays an exact replica of the
+# source. The whole page is merged in place (no staging table).
+#
+# Prerequisites:
+#   - Logical replication enabled on the SOURCE database + a publication:
+#       psql "$SOURCE_PG_URL" -c "CREATE PUBLICATION faucet_pub FOR TABLE users;"
+#   - A BigQuery table matching the source columns (key column(s) included):
+#       bq mk --table myproject:warehouse.users_mirror id:INTEGER,name:STRING
+#   - GOOGLE_APPLICATION_CREDENTIALS pointing at a service-account key with
+#     bigquery.dataEditor + bigquery.jobUser on the dataset.
+#
+# Then:
+#   export SOURCE_PG_URL=postgres://faucet:faucet@localhost:5432/appdb
+#   faucet run cli/examples/postgres_cdc_to_bigquery_upsert.yaml
+
+version: 1
+name: pg_cdc_to_bq_mirror
+
+# Exactly-once: CDC source + idempotent BigQuery sink + state store, no DLQ.
+# Each committed page's MERGE and its commit token land in one BigQuery
+# transaction, so a crash/resume never re-applies or skips a page.
+delivery: exactly_once
+
+pipeline:
+  source:
+    type: postgres-cdc
+    config:
+      connection_url: ${env:SOURCE_PG_URL}
+      slot_name: faucet_bq_mirror
+      publication_name: faucet_pub
+      create_slot_if_missing: true
+      idle_timeout: 30
+
+  # Normalize the CDC envelope ({op, before, after}) into a flat row plus a
+  # `__op` marker. Inserts/updates emit the post-image; deletes emit the key.
+  transforms:
+    - type: cdc_unwrap
+
+  sink:
+    type: bigquery
+    config:
+      project_id: myproject
+      dataset_id: warehouse
+      table_id: users_mirror
+      auth:
+        type: application_default
+      # Insert-or-update by `id` via in-place MERGE; rows whose `__op` is "d"
+      # are routed to a keyed DELETE instead. `key` must be real BigQuery
+      # column(s). The whole page is one MERGE request (~10MB jobs.query limit;
+      # lower batch_size for very large pages).
+      write_mode: upsert
+      key: [id]
+      delete_marker: { field: __op, values: [d] }
+
+  state:
+    type: file
+    config:
+      path: ./state

--- a/cli/src/expand.rs
+++ b/cli/src/expand.rs
@@ -1696,6 +1696,18 @@ pipeline:
     }
 
     #[test]
+    fn bigquery_upsert_passes_write_mode_gate() {
+        let c = cfg(r#"
+version: 1
+name: t
+pipeline:
+  source: { type: rest, config: { url: "http://x" } }
+  sink:   { type: bigquery, config: { project_id: p, dataset_id: d, table_id: t, auth: { type: application_default }, write_mode: upsert, key: [id] } }
+"#);
+        assert!(expand(&c).is_ok());
+    }
+
+    #[test]
     fn accepts_append_by_default_on_any_sink() {
         let c = cfg(r#"
 version: 1

--- a/cli/src/registry.rs
+++ b/cli/src/registry.rs
@@ -362,7 +362,7 @@ pub fn sink_supports_idempotent_writes(kind: &str) -> bool {
 pub fn sink_supported_write_modes(kind: &str) -> &'static [faucet_core::WriteMode] {
     use faucet_core::WriteMode;
     match kind {
-        "postgres" | "sqlite" | "mysql" | "mssql" | "mongodb" | "elasticsearch" => {
+        "postgres" | "sqlite" | "mysql" | "mssql" | "mongodb" | "elasticsearch" | "bigquery" => {
             &[WriteMode::Append, WriteMode::Upsert, WriteMode::Delete]
         }
         _ => &[WriteMode::Append],
@@ -993,6 +993,7 @@ mod tests {
         use faucet_core::WriteMode;
         assert!(sink_supported_write_modes("postgres").contains(&WriteMode::Upsert));
         assert!(sink_supported_write_modes("elasticsearch").contains(&WriteMode::Delete));
+        assert!(sink_supported_write_modes("bigquery").contains(&WriteMode::Upsert));
         // a sink without upsert support is append-only
         assert_eq!(sink_supported_write_modes("jsonl"), &[WriteMode::Append]);
         assert_eq!(sink_supported_write_modes("kafka"), &[WriteMode::Append]);

--- a/crates/sink/bigquery/README.md
+++ b/crates/sink/bigquery/README.md
@@ -96,6 +96,84 @@ reporting and the sink's "first row that failed" error message are
 unchanged. Per-call retry is delegated to `gcp_bigquery_client`'s built-in
 retry middleware.
 
+### Write modes (`upsert` / `delete`)
+
+In addition to the default `append` mode (streaming `insertAll`), the BigQuery
+sink supports `write_mode: upsert` and `write_mode: delete`. These use an
+in-place `MERGE … USING (SELECT … FROM UNNEST(JSON_QUERY_ARRAY(@payload)))` over
+the target table — **no staging table required**.
+
+Three flattened fields appear at the sink `config` top level:
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `write_mode` | `append` | `append`, `upsert`, or `delete` |
+| `key` | `[]` | Key column(s). **Required and non-empty** for `upsert`/`delete`; must be real columns of the target table |
+| `delete_marker` | (none) | `upsert` only — `{ field: <name>, values: [<str>, …] }`; rows whose `field` matches one of `values` become deletes instead of upserts |
+
+**`upsert`** — insert-or-update by `key` via an in-place `MERGE`. If
+`delete_marker` is set (the standard CDC pattern), rows whose marker field
+matches are routed to a keyed `DELETE` instead; the marker field is stripped from
+upserted rows.
+
+**`delete`** — delete by `key` for every record in the batch (direct keyed
+`DELETE`, no MERGE).
+
+The `key` columns must be real columns of the target BigQuery table (they are
+validated against the table schema via `tables.get` at write time). The target
+table must already exist with a defined schema.
+
+**Page-size limit.** The whole page is sent as one `jobs.query` request — BigQuery's
+~10 MB body limit applies. The default `batch_size: 1000` is appropriate for most
+schemas; lower it for very wide rows.
+
+**Exactly-once composition.** `delivery: exactly_once` composes with
+`write_mode: upsert`: the data `MERGE` and the watermark `MERGE` (into
+`_faucet_commit_token`) commit inside a single BigQuery transaction. See the
+[Exactly-once delivery cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/state.html#exactly-once-delivery)
+for the full requirements (CDC source + state + no DLQ).
+
+**Example (Postgres CDC → BigQuery upsert mirror, exactly-once):**
+
+```yaml
+version: 1
+name: pg_cdc_to_bq_mirror
+delivery: exactly_once
+
+pipeline:
+  source:
+    type: postgres-cdc
+    config:
+      connection_url: ${env:SOURCE_PG_URL}
+      slot_name: faucet_bq_mirror
+      publication_name: faucet_pub
+      create_slot_if_missing: true
+      idle_timeout: 30
+
+  transforms:
+    - type: cdc_unwrap
+
+  sink:
+    type: bigquery
+    config:
+      project_id: myproject
+      dataset_id: warehouse
+      table_id: users_mirror
+      auth:
+        type: application_default
+      write_mode: upsert
+      key: [id]
+      delete_marker: { field: __op, values: [d] }
+
+  state:
+    type: file
+    config:
+      path: ./state
+```
+
+See the full runnable config at
+[`cli/examples/postgres_cdc_to_bigquery_upsert.yaml`](../../../cli/examples/postgres_cdc_to_bigquery_upsert.yaml).
+
 ### Authentication (`BigQueryCredentials`)
 
 | Variant | Description |

--- a/crates/sink/bigquery/src/config.rs
+++ b/crates/sink/bigquery/src/config.rs
@@ -45,6 +45,14 @@ pub struct BigQuerySinkConfig {
     /// inserted without an `insertId` (no dedup for that row).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub insert_id_field: Option<String>,
+    /// Write mode (append / upsert / delete) plus the `key` columns and optional
+    /// `delete_marker`. Flattened, so `write_mode` / `key` / `delete_marker`
+    /// appear at the config top level. Defaults to append (every existing
+    /// config keeps working). Upsert/delete merge by `key` in place via a
+    /// BigQuery `MERGE` over the page (no staging table); `key` must be real
+    /// column(s) of the target table.
+    #[serde(flatten)]
+    pub write: faucet_core::WriteSpec,
 }
 
 fn default_batch_size() -> usize {
@@ -66,6 +74,7 @@ impl BigQuerySinkConfig {
             auth: credentials,
             batch_size: DEFAULT_BATCH_SIZE,
             insert_id_field: None,
+            write: faucet_core::WriteSpec::default(),
         }
     }
 
@@ -227,5 +236,32 @@ mod tests {
         }"#;
         let config: BigQuerySinkConfig = serde_json::from_str(json).unwrap();
         assert_eq!(config.batch_size, faucet_core::DEFAULT_BATCH_SIZE);
+    }
+
+    #[test]
+    fn write_mode_defaults_to_append() {
+        let config =
+            BigQuerySinkConfig::new("p", "d", "t", BigQueryCredentials::ApplicationDefault);
+        assert_eq!(config.write.write_mode, faucet_core::WriteMode::Append);
+        assert!(config.write.key.is_empty());
+    }
+
+    #[test]
+    fn write_spec_deserializes_flattened() {
+        let json = r#"{
+            "project_id": "p",
+            "dataset_id": "d",
+            "table_id": "t",
+            "auth": {"type": "application_default"},
+            "write_mode": "upsert",
+            "key": ["id"],
+            "delete_marker": {"field": "__op", "values": ["d"]}
+        }"#;
+        let config: BigQuerySinkConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.write.write_mode, faucet_core::WriteMode::Upsert);
+        assert_eq!(config.write.key, vec!["id".to_string()]);
+        let dm = config.write.delete_marker.expect("delete_marker");
+        assert_eq!(dm.field, "__op");
+        assert_eq!(dm.values, vec!["d".to_string()]);
     }
 }

--- a/crates/sink/bigquery/src/idempotent.rs
+++ b/crates/sink/bigquery/src/idempotent.rs
@@ -115,19 +115,19 @@ impl FieldSpec {
 
 /// SQL string literal for a path/value: single-quoted with `\` and `'` escaped
 /// (BigQuery accepts backslash escapes in quoted strings).
-fn sql_str(s: &str) -> String {
+pub(crate) fn sql_str(s: &str) -> String {
     format!("'{}'", s.replace('\\', "\\\\").replace('\'', "\\'"))
 }
 
 /// Backtick-quoted identifier. BigQuery identifiers never contain a backtick
 /// (the schema came from BigQuery), so a stray one is stripped defensively.
-fn quote_ident(name: &str) -> String {
+pub(crate) fn quote_ident(name: &str) -> String {
     format!("`{}`", name.replace('`', ""))
 }
 
 /// A single JSONPath member segment. Safe BigQuery identifiers use the `.name`
 /// form; anything else is bracket-quoted (`['weird.name']`).
-fn json_path_segment(name: &str) -> String {
+pub(crate) fn json_path_segment(name: &str) -> String {
     let safe = match name.chars().next() {
         Some(c) if c.is_ascii_alphabetic() || c == '_' => {
             name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
@@ -144,7 +144,7 @@ fn json_path_segment(name: &str) -> String {
 
 /// Wrap a STRING-typed SQL expression `var` into the column's target type.
 /// `Struct` is handled by [`column_expr`], never here.
-fn wrap_scalar(ty: &BqType, var: &str) -> String {
+pub(crate) fn wrap_scalar(ty: &BqType, var: &str) -> String {
     match ty {
         BqType::String => var.to_string(),
         BqType::Bytes => format!("FROM_BASE64({var})"),
@@ -179,7 +179,7 @@ fn struct_field_list(
 /// `path` is always a JSONPath relative to that variable's JSON root (e.g. `"$.field"`
 /// at top level, `"$.child"` inside a nested struct). `depth` keeps nested `UNNEST`
 /// aliases unique (`e{depth}` for struct elements, `x{depth}` for scalars).
-fn column_expr(field: &FieldSpec, json_var: &str, path: &str, depth: usize) -> String {
+pub(crate) fn column_expr(field: &FieldSpec, json_var: &str, path: &str, depth: usize) -> String {
     if field.repeated {
         if field.ty == BqType::Struct {
             let elem = format!("e{depth}");
@@ -216,7 +216,7 @@ fn column_expr(field: &FieldSpec, json_var: &str, path: &str, depth: usize) -> S
 /// Inputs are not backtick-stripped (unlike [`quote_ident`]): BigQuery
 /// project/dataset/table names cannot contain a backtick per BQ naming rules,
 /// and these come from admin-controlled config, never from row data.
-fn table_ref(project: &str, dataset: &str, table: &str) -> String {
+pub(crate) fn table_ref(project: &str, dataset: &str, table: &str) -> String {
     format!("`{project}.{dataset}.{table}`")
 }
 

--- a/crates/sink/bigquery/src/lib.rs
+++ b/crates/sink/bigquery/src/lib.rs
@@ -9,6 +9,7 @@
 
 pub mod config;
 mod idempotent;
+mod merge;
 pub mod sink;
 
 // Re-export core types.

--- a/crates/sink/bigquery/src/merge.rs
+++ b/crates/sink/bigquery/src/merge.rs
@@ -1,0 +1,273 @@
+//! Schema-driven SQL generation for the BigQuery upsert/delete write path (#224).
+//!
+//! All functions are **pure** (no I/O): given the target table's schema as
+//! [`crate::idempotent::FieldSpec`]s and the `key` columns, they generate the
+//! `MERGE` / `DELETE` / transaction SQL that merges a page in place via
+//! `MERGE … USING (SELECT … FROM UNNEST(JSON_QUERY_ARRAY(@payload)))`. No
+//! staging table. See `docs/superpowers/specs/2026-06-13-bigquery-upsert-design.md`.
+
+use crate::idempotent::{
+    FieldSpec, build_merge_token, column_expr, json_path_segment, quote_ident, table_ref,
+};
+use faucet_core::FaucetError;
+
+/// Find the `FieldSpec` for a key column by name.
+fn key_field<'a>(columns: &'a [FieldSpec], name: &str) -> Option<&'a FieldSpec> {
+    columns.iter().find(|f| f.name == name)
+}
+
+/// `SELECT <typed expr> AS `col`, … FROM UNNEST(JSON_QUERY_ARRAY(<payload_param>)) AS r`.
+///
+/// Each column is extracted with the same typed `column_expr` the exactly-once
+/// `INSERT … SELECT` uses, then aliased to its name so the MERGE `ON`/`SET`/
+/// `INSERT` clauses can reference `S.`col``.
+pub(crate) fn build_source_select(columns: &[FieldSpec], payload_param: &str) -> String {
+    let exprs = columns
+        .iter()
+        .map(|f| {
+            let path = format!("${}", json_path_segment(&f.name));
+            format!("{} AS {}", column_expr(f, "r", &path, 0), quote_ident(&f.name))
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("SELECT {exprs} FROM UNNEST(JSON_QUERY_ARRAY({payload_param})) AS r")
+}
+
+/// The in-place upsert `MERGE` over the `@payload` page.
+pub(crate) fn build_merge_upsert(
+    columns: &[FieldSpec],
+    key: &[String],
+    project: &str,
+    dataset: &str,
+    table: &str,
+) -> String {
+    let src = build_source_select(columns, "@payload");
+    let on = key
+        .iter()
+        .map(|k| format!("T.{q} = S.{q}", q = quote_ident(k)))
+        .collect::<Vec<_>>()
+        .join(" AND ");
+    let insert_cols = columns
+        .iter()
+        .map(|f| quote_ident(&f.name))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let insert_vals = columns
+        .iter()
+        .map(|f| format!("S.{}", quote_ident(&f.name)))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let non_key_sets = columns
+        .iter()
+        .filter(|f| !key.iter().any(|k| k == &f.name))
+        .map(|f| format!("{q} = S.{q}", q = quote_ident(&f.name)))
+        .collect::<Vec<_>>();
+    let matched = if non_key_sets.is_empty() {
+        String::new()
+    } else {
+        format!("WHEN MATCHED THEN UPDATE SET {} ", non_key_sets.join(", "))
+    };
+    format!(
+        "MERGE INTO {t} T USING ({src}) S ON {on} {matched}WHEN NOT MATCHED THEN INSERT ({insert_cols}) VALUES ({insert_vals})",
+        t = table_ref(project, dataset, table),
+    )
+}
+
+/// Keyed `DELETE` via a semi-join over the `@deletes` payload (an array of
+/// `{key_col: value, …}` objects). Key columns are typed via `column_expr` so
+/// an INT64 key compares as INT64, not STRING.
+pub(crate) fn build_delete_by_keys(
+    columns: &[FieldSpec],
+    key: &[String],
+    project: &str,
+    dataset: &str,
+    table: &str,
+) -> String {
+    let preds = key
+        .iter()
+        .map(|k| {
+            let path = format!("${}", json_path_segment(k));
+            // Callers run `validate_keys_present` before building any SQL, so
+            // every key is guaranteed to be a real column here.
+            let fs = key_field(columns, k)
+                .unwrap_or_else(|| unreachable!("validate_keys_present runs before build_delete_by_keys"));
+            let rhs = column_expr(fs, "d", &path, 0);
+            format!("T.{} = {}", quote_ident(k), rhs)
+        })
+        .collect::<Vec<_>>()
+        .join(" AND ");
+    format!(
+        "DELETE FROM {t} T WHERE EXISTS (SELECT 1 FROM UNNEST(JSON_QUERY_ARRAY(@deletes)) AS d WHERE {preds})",
+        t = table_ref(project, dataset, table),
+    )
+}
+
+fn wrap_transaction(stmts: &[String]) -> String {
+    format!("BEGIN TRANSACTION;\n{};\nCOMMIT TRANSACTION;", stmts.join(";\n"))
+}
+
+/// `BEGIN; [MERGE upsert]; [DELETE]; COMMIT;` — the at-least-once upsert/delete path.
+pub(crate) fn build_upsert_transaction_sql(
+    columns: &[FieldSpec],
+    key: &[String],
+    has_upserts: bool,
+    has_deletes: bool,
+    project: &str,
+    dataset: &str,
+    table: &str,
+) -> String {
+    let mut stmts = Vec::new();
+    if has_upserts {
+        stmts.push(build_merge_upsert(columns, key, project, dataset, table));
+    }
+    if has_deletes {
+        stmts.push(build_delete_by_keys(columns, key, project, dataset, table));
+    }
+    wrap_transaction(&stmts)
+}
+
+/// As [`build_upsert_transaction_sql`] but with the watermark `MERGE` appended
+/// inside the same transaction — the exactly-once + upsert composition.
+pub(crate) fn build_upsert_idempotent_sql(
+    columns: &[FieldSpec],
+    key: &[String],
+    has_upserts: bool,
+    has_deletes: bool,
+    project: &str,
+    dataset: &str,
+    table: &str,
+) -> String {
+    let mut stmts = Vec::new();
+    if has_upserts {
+        stmts.push(build_merge_upsert(columns, key, project, dataset, table));
+    }
+    if has_deletes {
+        stmts.push(build_delete_by_keys(columns, key, project, dataset, table));
+    }
+    stmts.push(build_merge_token(project, dataset));
+    wrap_transaction(&stmts)
+}
+
+/// Validate that every `key` column exists in the target table schema. Returns
+/// a `FaucetError::Sink` naming the missing column otherwise.
+pub(crate) fn validate_keys_present(
+    columns: &[FieldSpec],
+    key: &[String],
+) -> Result<(), FaucetError> {
+    for k in key {
+        if !columns.iter().any(|f| &f.name == k) {
+            return Err(FaucetError::Sink(format!(
+                "bigquery upsert: key column '{k}' is not a column of the target table"
+            )));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::idempotent::{BqType, FieldSpec};
+
+    fn scalar(name: &str, ty: BqType) -> FieldSpec {
+        FieldSpec { name: name.into(), ty, repeated: false, fields: vec![] }
+    }
+
+    fn id_name_cols() -> Vec<FieldSpec> {
+        vec![scalar("id", BqType::Int64), scalar("name", BqType::String)]
+    }
+
+    #[test]
+    fn source_select_aliases_each_typed_column() {
+        let sql = build_source_select(&id_name_cols(), "@payload");
+        assert_eq!(
+            sql,
+            "SELECT CAST(JSON_VALUE(r, '$.id') AS INT64) AS `id`, JSON_VALUE(r, '$.name') AS `name` FROM UNNEST(JSON_QUERY_ARRAY(@payload)) AS r"
+        );
+    }
+
+    #[test]
+    fn merge_upsert_single_key() {
+        let sql = build_merge_upsert(&id_name_cols(), &["id".into()], "p", "d", "t");
+        assert_eq!(
+            sql,
+            "MERGE INTO `p.d.t` T USING (SELECT CAST(JSON_VALUE(r, '$.id') AS INT64) AS `id`, JSON_VALUE(r, '$.name') AS `name` FROM UNNEST(JSON_QUERY_ARRAY(@payload)) AS r) S ON T.`id` = S.`id` WHEN MATCHED THEN UPDATE SET `name` = S.`name` WHEN NOT MATCHED THEN INSERT (`id`, `name`) VALUES (S.`id`, S.`name`)"
+        );
+    }
+
+    #[test]
+    fn merge_upsert_composite_key() {
+        let cols = vec![
+            scalar("tenant", BqType::String),
+            scalar("id", BqType::Int64),
+            scalar("name", BqType::String),
+        ];
+        let sql = build_merge_upsert(&cols, &["tenant".into(), "id".into()], "p", "d", "t");
+        assert!(sql.contains("ON T.`tenant` = S.`tenant` AND T.`id` = S.`id`"), "got: {sql}");
+        assert!(sql.contains("WHEN MATCHED THEN UPDATE SET `name` = S.`name`"), "got: {sql}");
+        assert!(sql.contains("INSERT (`tenant`, `id`, `name`) VALUES (S.`tenant`, S.`id`, S.`name`)"), "got: {sql}");
+    }
+
+    #[test]
+    fn merge_upsert_all_columns_are_key_omits_update() {
+        // Only a key column: no non-key columns to SET, so emit INSERT-only.
+        let sql = build_merge_upsert(&[scalar("id", BqType::Int64)], &["id".into()], "p", "d", "t");
+        assert!(!sql.contains("WHEN MATCHED"), "got: {sql}");
+        assert!(sql.contains("ON T.`id` = S.`id` WHEN NOT MATCHED THEN INSERT (`id`) VALUES (S.`id`)"), "got: {sql}");
+    }
+
+    #[test]
+    fn delete_by_keys_typed_single_key() {
+        let sql = build_delete_by_keys(&id_name_cols(), &["id".into()], "p", "d", "t");
+        assert_eq!(
+            sql,
+            "DELETE FROM `p.d.t` T WHERE EXISTS (SELECT 1 FROM UNNEST(JSON_QUERY_ARRAY(@deletes)) AS d WHERE T.`id` = CAST(JSON_VALUE(d, '$.id') AS INT64))"
+        );
+    }
+
+    #[test]
+    fn delete_by_keys_composite() {
+        let cols = vec![scalar("tenant", BqType::String), scalar("id", BqType::Int64)];
+        let sql = build_delete_by_keys(&cols, &["tenant".into(), "id".into()], "p", "d", "t");
+        assert!(
+            sql.contains("WHERE T.`tenant` = JSON_VALUE(d, '$.tenant') AND T.`id` = CAST(JSON_VALUE(d, '$.id') AS INT64)"),
+            "got: {sql}"
+        );
+    }
+
+    #[test]
+    fn transaction_upserts_and_deletes() {
+        let sql = build_upsert_transaction_sql(&id_name_cols(), &["id".into()], true, true, "p", "d", "t");
+        assert!(sql.starts_with("BEGIN TRANSACTION;\n"), "got: {sql}");
+        assert!(sql.trim_end().ends_with("COMMIT TRANSACTION;"), "got: {sql}");
+        let m = sql.find("MERGE INTO").unwrap();
+        let d = sql.find("DELETE FROM").unwrap();
+        let c = sql.find("COMMIT TRANSACTION").unwrap();
+        assert!(m < d && d < c, "order wrong: {sql}");
+        assert!(!sql.contains("_faucet_commit_token"), "no watermark in non-EO path: {sql}");
+    }
+
+    #[test]
+    fn transaction_upserts_only() {
+        let sql = build_upsert_transaction_sql(&id_name_cols(), &["id".into()], true, false, "p", "d", "t");
+        assert!(sql.contains("MERGE INTO"), "got: {sql}");
+        assert!(!sql.contains("DELETE FROM"), "got: {sql}");
+    }
+
+    #[test]
+    fn idempotent_transaction_appends_watermark_merge() {
+        let sql = build_upsert_idempotent_sql(&id_name_cols(), &["id".into()], true, true, "p", "d", "t");
+        let m = sql.find("MERGE INTO `p.d.t`").unwrap();
+        let d = sql.find("DELETE FROM").unwrap();
+        let w = sql.find("MERGE `p.d._faucet_commit_token`").unwrap();
+        let c = sql.find("COMMIT TRANSACTION").unwrap();
+        assert!(m < d && d < w && w < c, "order wrong: {sql}");
+    }
+
+    #[test]
+    fn validate_keys_present_ok_and_err() {
+        assert!(validate_keys_present(&id_name_cols(), &["id".into()]).is_ok());
+        let err = validate_keys_present(&id_name_cols(), &["missing".into()]).unwrap_err();
+        assert!(format!("{err}").contains("missing"), "got: {err}");
+    }
+}

--- a/crates/sink/bigquery/src/merge.rs
+++ b/crates/sink/bigquery/src/merge.rs
@@ -26,7 +26,11 @@ pub(crate) fn build_source_select(columns: &[FieldSpec], payload_param: &str) ->
         .iter()
         .map(|f| {
             let path = format!("${}", json_path_segment(&f.name));
-            format!("{} AS {}", column_expr(f, "r", &path, 0), quote_ident(&f.name))
+            format!(
+                "{} AS {}",
+                column_expr(f, "r", &path, 0),
+                quote_ident(&f.name)
+            )
         })
         .collect::<Vec<_>>()
         .join(", ");
@@ -89,8 +93,9 @@ pub(crate) fn build_delete_by_keys(
             let path = format!("${}", json_path_segment(k));
             // Callers run `validate_keys_present` before building any SQL, so
             // every key is guaranteed to be a real column here.
-            let fs = key_field(columns, k)
-                .unwrap_or_else(|| unreachable!("validate_keys_present runs before build_delete_by_keys"));
+            let fs = key_field(columns, k).unwrap_or_else(|| {
+                unreachable!("validate_keys_present runs before build_delete_by_keys")
+            });
             let rhs = column_expr(fs, "d", &path, 0);
             format!("T.{} = {}", quote_ident(k), rhs)
         })
@@ -103,7 +108,10 @@ pub(crate) fn build_delete_by_keys(
 }
 
 fn wrap_transaction(stmts: &[String]) -> String {
-    format!("BEGIN TRANSACTION;\n{};\nCOMMIT TRANSACTION;", stmts.join(";\n"))
+    format!(
+        "BEGIN TRANSACTION;\n{};\nCOMMIT TRANSACTION;",
+        stmts.join(";\n")
+    )
 }
 
 /// `BEGIN; [MERGE upsert]; [DELETE]; COMMIT;` — the at-least-once upsert/delete path.
@@ -170,7 +178,12 @@ mod tests {
     use crate::idempotent::{BqType, FieldSpec};
 
     fn scalar(name: &str, ty: BqType) -> FieldSpec {
-        FieldSpec { name: name.into(), ty, repeated: false, fields: vec![] }
+        FieldSpec {
+            name: name.into(),
+            ty,
+            repeated: false,
+            fields: vec![],
+        }
     }
 
     fn id_name_cols() -> Vec<FieldSpec> {
@@ -203,17 +216,35 @@ mod tests {
             scalar("name", BqType::String),
         ];
         let sql = build_merge_upsert(&cols, &["tenant".into(), "id".into()], "p", "d", "t");
-        assert!(sql.contains("ON T.`tenant` = S.`tenant` AND T.`id` = S.`id`"), "got: {sql}");
-        assert!(sql.contains("WHEN MATCHED THEN UPDATE SET `name` = S.`name`"), "got: {sql}");
-        assert!(sql.contains("INSERT (`tenant`, `id`, `name`) VALUES (S.`tenant`, S.`id`, S.`name`)"), "got: {sql}");
+        assert!(
+            sql.contains("ON T.`tenant` = S.`tenant` AND T.`id` = S.`id`"),
+            "got: {sql}"
+        );
+        assert!(
+            sql.contains("WHEN MATCHED THEN UPDATE SET `name` = S.`name`"),
+            "got: {sql}"
+        );
+        assert!(
+            sql.contains("INSERT (`tenant`, `id`, `name`) VALUES (S.`tenant`, S.`id`, S.`name`)"),
+            "got: {sql}"
+        );
     }
 
     #[test]
     fn merge_upsert_all_columns_are_key_omits_update() {
         // Only a key column: no non-key columns to SET, so emit INSERT-only.
-        let sql = build_merge_upsert(&[scalar("id", BqType::Int64)], &["id".into()], "p", "d", "t");
+        let sql = build_merge_upsert(
+            &[scalar("id", BqType::Int64)],
+            &["id".into()],
+            "p",
+            "d",
+            "t",
+        );
         assert!(!sql.contains("WHEN MATCHED"), "got: {sql}");
-        assert!(sql.contains("ON T.`id` = S.`id` WHEN NOT MATCHED THEN INSERT (`id`) VALUES (S.`id`)"), "got: {sql}");
+        assert!(
+            sql.contains("ON T.`id` = S.`id` WHEN NOT MATCHED THEN INSERT (`id`) VALUES (S.`id`)"),
+            "got: {sql}"
+        );
     }
 
     #[test]
@@ -227,7 +258,10 @@ mod tests {
 
     #[test]
     fn delete_by_keys_composite() {
-        let cols = vec![scalar("tenant", BqType::String), scalar("id", BqType::Int64)];
+        let cols = vec![
+            scalar("tenant", BqType::String),
+            scalar("id", BqType::Int64),
+        ];
         let sql = build_delete_by_keys(&cols, &["tenant".into(), "id".into()], "p", "d", "t");
         assert!(
             sql.contains("WHERE T.`tenant` = JSON_VALUE(d, '$.tenant') AND T.`id` = CAST(JSON_VALUE(d, '$.id') AS INT64)"),
@@ -237,26 +271,49 @@ mod tests {
 
     #[test]
     fn transaction_upserts_and_deletes() {
-        let sql = build_upsert_transaction_sql(&id_name_cols(), &["id".into()], true, true, "p", "d", "t");
+        let sql = build_upsert_transaction_sql(
+            &id_name_cols(),
+            &["id".into()],
+            true,
+            true,
+            "p",
+            "d",
+            "t",
+        );
         assert!(sql.starts_with("BEGIN TRANSACTION;\n"), "got: {sql}");
-        assert!(sql.trim_end().ends_with("COMMIT TRANSACTION;"), "got: {sql}");
+        assert!(
+            sql.trim_end().ends_with("COMMIT TRANSACTION;"),
+            "got: {sql}"
+        );
         let m = sql.find("MERGE INTO").unwrap();
         let d = sql.find("DELETE FROM").unwrap();
         let c = sql.find("COMMIT TRANSACTION").unwrap();
         assert!(m < d && d < c, "order wrong: {sql}");
-        assert!(!sql.contains("_faucet_commit_token"), "no watermark in non-EO path: {sql}");
+        assert!(
+            !sql.contains("_faucet_commit_token"),
+            "no watermark in non-EO path: {sql}"
+        );
     }
 
     #[test]
     fn transaction_upserts_only() {
-        let sql = build_upsert_transaction_sql(&id_name_cols(), &["id".into()], true, false, "p", "d", "t");
+        let sql = build_upsert_transaction_sql(
+            &id_name_cols(),
+            &["id".into()],
+            true,
+            false,
+            "p",
+            "d",
+            "t",
+        );
         assert!(sql.contains("MERGE INTO"), "got: {sql}");
         assert!(!sql.contains("DELETE FROM"), "got: {sql}");
     }
 
     #[test]
     fn idempotent_transaction_appends_watermark_merge() {
-        let sql = build_upsert_idempotent_sql(&id_name_cols(), &["id".into()], true, true, "p", "d", "t");
+        let sql =
+            build_upsert_idempotent_sql(&id_name_cols(), &["id".into()], true, true, "p", "d", "t");
         let m = sql.find("MERGE INTO `p.d.t`").unwrap();
         let d = sql.find("DELETE FROM").unwrap();
         let w = sql.find("MERGE `p.d._faucet_commit_token`").unwrap();

--- a/crates/sink/bigquery/src/sink.rs
+++ b/crates/sink/bigquery/src/sink.rs
@@ -711,6 +711,18 @@ impl faucet_core::Sink for BigQuerySink {
         token: &str,
     ) -> Result<usize, FaucetError> {
         self.ensure_commit_table().await?;
+
+        if !matches!(self.config.write.write_mode, faucet_core::WriteMode::Append) {
+            let plan = faucet_core::plan_writes(records, &self.config.write);
+            if let Some((idx, msg)) = plan.failed.first() {
+                return Err(FaucetError::Sink(format!(
+                    "bigquery {}: row {idx}: {msg}",
+                    self.config.write.write_mode.as_str()
+                )));
+            }
+            return self.run_upsert_script(&plan, Some((scope, token))).await;
+        }
+
         let columns = self.target_schema().await?;
 
         let payload = serde_json::to_string(records).map_err(|e| {

--- a/crates/sink/bigquery/src/sink.rs
+++ b/crates/sink/bigquery/src/sink.rs
@@ -573,6 +573,20 @@ impl faucet_core::Sink for BigQuerySink {
             return Ok(Vec::new());
         }
 
+        if !matches!(self.config.write.write_mode, faucet_core::WriteMode::Append) {
+            let plan = faucet_core::plan_writes(records, &self.config.write);
+            self.run_upsert_script(&plan, None).await?;
+            let mut outcomes: Vec<faucet_core::RowOutcome> =
+                records.iter().map(|_| Ok(())).collect();
+            for (idx, msg) in &plan.failed {
+                outcomes[*idx] = Err(FaucetError::Sink(format!(
+                    "bigquery {}: {msg}",
+                    self.config.write.write_mode.as_str()
+                )));
+            }
+            return Ok(outcomes);
+        }
+
         let chunks: Vec<&[Value]> = if self.config.batch_size == 0 {
             vec![records]
         } else {

--- a/crates/sink/bigquery/src/sink.rs
+++ b/crates/sink/bigquery/src/sink.rs
@@ -376,10 +376,22 @@ impl BigQuerySink {
         );
         let sql = match token {
             Some(_) => merge::build_upsert_idempotent_sql(
-                columns, key, has_upserts, has_deletes, project, dataset, table,
+                columns,
+                key,
+                has_upserts,
+                has_deletes,
+                project,
+                dataset,
+                table,
             ),
             None => merge::build_upsert_transaction_sql(
-                columns, key, has_upserts, has_deletes, project, dataset, table,
+                columns,
+                key,
+                has_upserts,
+                has_deletes,
+                project,
+                dataset,
+                table,
             ),
         };
 

--- a/crates/sink/bigquery/src/sink.rs
+++ b/crates/sink/bigquery/src/sink.rs
@@ -2,6 +2,7 @@
 
 use crate::config::BigQuerySinkConfig;
 use crate::idempotent;
+use crate::merge;
 use async_trait::async_trait;
 use faucet_common_bigquery::build_client;
 use faucet_core::FaucetError;
@@ -28,6 +29,22 @@ const IDEMPOTENT_JOB_TIMEOUT: Duration = Duration::from_secs(120);
 /// BigQuery holds the connection open up to this long, so we don't busy-wait.
 const JOB_POLL_LONG_POLL_MS: i32 = 10_000;
 
+/// Serialize planned delete key tuples into a JSON array of `{key_col: value}`
+/// objects for the `@deletes` parameter consumed by the semi-join `DELETE`.
+fn deletes_to_payload(deletes: &[faucet_core::KeyTuple]) -> String {
+    let arr: Vec<Value> = deletes
+        .iter()
+        .map(|kt| {
+            let mut obj = serde_json::Map::new();
+            for (k, v) in &kt.0 {
+                obj.insert(k.clone(), v.clone());
+            }
+            Value::Object(obj)
+        })
+        .collect();
+    Value::Array(arr).to_string()
+}
+
 /// A sink that writes JSON records to a BigQuery table using the streaming
 /// insert API (`tabledata.insertAll`).
 pub struct BigQuerySink {
@@ -45,6 +62,7 @@ impl BigQuerySink {
     /// Returns a [`FaucetError::Auth`] if authentication fails.
     pub async fn new(config: BigQuerySinkConfig) -> Result<Self, FaucetError> {
         faucet_core::validate_batch_size(config.batch_size)?;
+        config.write.validate()?;
         let client = build_client(&config.auth).await?;
         Ok(Self {
             config,
@@ -324,6 +342,84 @@ impl BigQuerySink {
             .ok_or_else(|| FaucetError::Sink("BigQuery jobReference missing jobId".to_string()))?;
         Ok((job_id, r.location.clone()))
     }
+
+    /// Run a planned upsert/delete page as one BigQuery multi-statement
+    /// transaction. When `token` is `Some((scope, tok))` the watermark `MERGE`
+    /// is appended inside the same transaction (exactly-once + upsert).
+    ///
+    /// The caller must have already validated `plan.failed` is empty (and, for
+    /// the exactly-once path, ensured the commit table exists). Returns the
+    /// number of rows applied (upserts + deletes).
+    async fn run_upsert_script(
+        &self,
+        plan: &faucet_core::WritePlan,
+        token: Option<(&str, &str)>,
+    ) -> Result<usize, FaucetError> {
+        let columns = self.target_schema().await?;
+        merge::validate_keys_present(columns, &self.config.write.key)?;
+
+        let has_upserts = !plan.upserts.is_empty();
+        let has_deletes = !plan.deletes.is_empty();
+        if !has_upserts && !has_deletes {
+            // Nothing planned; for the exactly-once path the bookmark still
+            // needs its token, so emit the watermark MERGE alone.
+            if token.is_none() {
+                return Ok(0);
+            }
+        }
+
+        let key = &self.config.write.key;
+        let (project, dataset, table) = (
+            &self.config.project_id,
+            &self.config.dataset_id,
+            &self.config.table_id,
+        );
+        let sql = match token {
+            Some(_) => merge::build_upsert_idempotent_sql(
+                columns, key, has_upserts, has_deletes, project, dataset, table,
+            ),
+            None => merge::build_upsert_transaction_sql(
+                columns, key, has_upserts, has_deletes, project, dataset, table,
+            ),
+        };
+
+        let mut params = Vec::new();
+        if has_upserts {
+            let payload = serde_json::to_string(&plan.upserts).map_err(|e| {
+                FaucetError::Sink(format!("bigquery upsert: serialize payload: {e}"))
+            })?;
+            params.push(Self::string_param("payload", &payload));
+        }
+        if has_deletes {
+            let deletes = deletes_to_payload(&plan.deletes);
+            params.push(Self::string_param("deletes", &deletes));
+        }
+        if let Some((scope, tok)) = token {
+            params.push(Self::string_param("scope", scope));
+            params.push(Self::string_param("token", tok));
+        }
+
+        let mut req = QueryRequest::new(sql);
+        req.use_legacy_sql = false;
+        req.parameter_mode = Some("NAMED".to_string());
+        // MERGE-by-key is idempotent, so a retried request is harmless; for the
+        // exactly-once path a deterministic request_id additionally suppresses
+        // duplicate jobs from a retried HTTP request within BigQuery's window.
+        if let Some((scope, tok)) = token {
+            req.request_id = Some(idempotent::build_request_id(scope, tok));
+        }
+        req.query_parameters = Some(params);
+
+        let resp = self
+            .client
+            .job()
+            .query(&self.config.project_id, req)
+            .await
+            .map_err(|e| FaucetError::Sink(format!("bigquery upsert write failed: {e}")))?;
+        self.await_query_complete(resp).await?;
+
+        Ok(plan.upserts.len() + plan.deletes.len())
+    }
 }
 
 #[async_trait]
@@ -413,6 +509,17 @@ impl faucet_core::Sink for BigQuerySink {
     async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
         if records.is_empty() {
             return Ok(0);
+        }
+
+        if !matches!(self.config.write.write_mode, faucet_core::WriteMode::Append) {
+            let plan = faucet_core::plan_writes(records, &self.config.write);
+            if let Some((idx, msg)) = plan.failed.first() {
+                return Err(FaucetError::Sink(format!(
+                    "bigquery {}: row {idx}: {msg}",
+                    self.config.write.write_mode.as_str()
+                )));
+            }
+            return self.run_upsert_script(&plan, None).await;
         }
 
         let chunks: Vec<&[Value]> = if self.config.batch_size == 0 {
@@ -511,6 +618,14 @@ impl faucet_core::Sink for BigQuerySink {
         }
 
         Ok(outcomes)
+    }
+
+    fn supported_write_modes(&self) -> &'static [faucet_core::WriteMode] {
+        &[
+            faucet_core::WriteMode::Append,
+            faucet_core::WriteMode::Upsert,
+            faucet_core::WriteMode::Delete,
+        ]
     }
 
     fn supports_idempotent_writes(&self) -> bool {

--- a/crates/sink/bigquery/src/sink.rs
+++ b/crates/sink/bigquery/src/sink.rs
@@ -770,7 +770,42 @@ impl faucet_core::Sink for BigQuerySink {
 
 #[cfg(test)]
 mod tests {
+    use super::deletes_to_payload;
+    use faucet_core::KeyTuple;
+    use serde_json::json;
+
     // dataset_uri test is skipped: BigQuerySink::new() requires GCP credentials
     // (build_client fetches auth in new()), and from_parts() requires a
     // gcp_bigquery_client::Client which cannot be constructed without auth.
+
+    #[test]
+    fn deletes_to_payload_preserves_number_type() {
+        // The delete payload must keep an integer key as a JSON number (not the
+        // string "2"), so the matching `CAST(JSON_VALUE(d, '$.id') AS INT64)`
+        // semi-join compares like-for-like.
+        let p = deletes_to_payload(&[KeyTuple(vec![("id".into(), json!(2))])]);
+        let v: serde_json::Value = serde_json::from_str(&p).expect("valid JSON");
+        assert_eq!(v, json!([{"id": 2}]));
+        assert!(v[0]["id"].is_number(), "id must serialize as a number: {p}");
+    }
+
+    #[test]
+    fn deletes_to_payload_composite_key_roundtrips() {
+        let p = deletes_to_payload(&[KeyTuple(vec![
+            ("tenant".into(), json!("acme")),
+            ("id".into(), json!(7)),
+        ])]);
+        let v: serde_json::Value = serde_json::from_str(&p).expect("valid JSON");
+        assert_eq!(v, json!([{"tenant": "acme", "id": 7}]));
+    }
+
+    #[test]
+    fn deletes_to_payload_multiple_rows() {
+        let p = deletes_to_payload(&[
+            KeyTuple(vec![("id".into(), json!(1))]),
+            KeyTuple(vec![("id".into(), json!(2))]),
+        ]);
+        let v: serde_json::Value = serde_json::from_str(&p).expect("valid JSON");
+        assert_eq!(v, json!([{"id": 1}, {"id": 2}]));
+    }
 }

--- a/crates/sink/bigquery/tests/upsert.rs
+++ b/crates/sink/bigquery/tests/upsert.rs
@@ -220,3 +220,26 @@ async fn write_batch_upsert_missing_key_errors() {
         .unwrap_err();
     assert!(format!("{err}").contains("bigquery upsert"), "got: {err}");
 }
+
+#[tokio::test]
+async fn write_batch_partial_upsert_routes_missing_key_to_dlq() {
+    let server = MockServer::start().await;
+    mount_token_endpoint(&server).await;
+    mount_table_schema(&server).await;
+    mount_query_done(&server, "job-p").await;
+    mount_job_done(&server, "job-p").await;
+
+    let cfg = config_with(|c| {
+        c.write.write_mode = faucet_core::WriteMode::Upsert;
+        c.write.key = vec!["id".into()];
+    });
+    let (sink, _sa) = build_sink(&server, cfg).await;
+    // Row 0 good, row 1 missing key → row 1 must come back Err, row 0 Ok.
+    let outcomes = sink
+        .write_batch_partial(&[json!({"id": 1, "name": "a"}), json!({"name": "no key"})])
+        .await
+        .expect("partial write");
+    assert_eq!(outcomes.len(), 2);
+    assert!(outcomes[0].is_ok(), "row 0 should be Ok");
+    assert!(outcomes[1].is_err(), "row 1 (missing key) should be Err");
+}

--- a/crates/sink/bigquery/tests/upsert.rs
+++ b/crates/sink/bigquery/tests/upsert.rs
@@ -222,6 +222,42 @@ async fn write_batch_upsert_missing_key_errors() {
 }
 
 #[tokio::test]
+async fn write_batch_idempotent_upsert_composes_merge_and_watermark() {
+    let server = MockServer::start().await;
+    mount_token_endpoint(&server).await;
+    mount_table_schema(&server).await;
+    // CREATE commit-table + the transaction both resolve to job-eo.
+    mount_query_done(&server, "job-eo").await;
+    mount_job_done(&server, "job-eo").await;
+
+    let cfg = config_with(|c| {
+        c.write.write_mode = faucet_core::WriteMode::Upsert;
+        c.write.key = vec!["id".into()];
+    });
+    let (sink, _sa) = build_sink(&server, cfg).await;
+    let n = sink
+        .write_batch_idempotent(&[json!({"id": 1, "name": "a"})], "pipe::row1", "00000000000000000005")
+        .await
+        .expect("eo upsert");
+    assert_eq!(n, 1);
+
+    let bodies = captured_query_bodies(&server).await;
+    let tx = bodies
+        .iter()
+        .find(|b| {
+            let q = b["query"].as_str().unwrap_or("");
+            q.contains("MERGE INTO `p.d.t`") && q.contains("MERGE `p.d._faucet_commit_token`")
+        })
+        .expect("transaction with data MERGE + watermark MERGE");
+    let q = tx["query"].as_str().unwrap();
+    let data = q.find("MERGE INTO `p.d.t`").unwrap();
+    let wm = q.find("MERGE `p.d._faucet_commit_token`").unwrap();
+    assert!(data < wm, "data merge must precede watermark: {q}");
+    let pnames: Vec<&str> = tx["queryParameters"].as_array().unwrap().iter().map(|p| p["name"].as_str().unwrap()).collect();
+    assert!(pnames.contains(&"payload") && pnames.contains(&"scope") && pnames.contains(&"token"), "got: {pnames:?}");
+}
+
+#[tokio::test]
 async fn write_batch_partial_upsert_routes_missing_key_to_dlq() {
     let server = MockServer::start().await;
     mount_token_endpoint(&server).await;

--- a/crates/sink/bigquery/tests/upsert.rs
+++ b/crates/sink/bigquery/tests/upsert.rs
@@ -279,3 +279,71 @@ async fn write_batch_partial_upsert_routes_missing_key_to_dlq() {
     assert!(outcomes[0].is_ok(), "row 0 should be Ok");
     assert!(outcomes[1].is_err(), "row 1 (missing key) should be Err");
 }
+
+#[tokio::test]
+async fn write_batch_delete_only_posts_delete_without_merge() {
+    let server = MockServer::start().await;
+    mount_token_endpoint(&server).await;
+    mount_table_schema(&server).await;
+    mount_query_done(&server, "job-del").await;
+    mount_job_done(&server, "job-del").await;
+
+    // write_mode: delete routes every keyed row to a DELETE — no upserts, so
+    // the transaction must bind only @deletes and emit no data MERGE.
+    let cfg = config_with(|c| {
+        c.write.write_mode = faucet_core::WriteMode::Delete;
+        c.write.key = vec!["id".into()];
+    });
+    let (sink, _sa) = build_sink(&server, cfg).await;
+    let n = sink
+        .write_batch(&[json!({"id": 1}), json!({"id": 2})])
+        .await
+        .expect("delete write");
+    assert_eq!(n, 2);
+
+    let bodies = captured_query_bodies(&server).await;
+    let tx = bodies
+        .iter()
+        .find(|b| b["query"].as_str().unwrap_or("").contains("DELETE FROM `p.d.t`"))
+        .expect("delete query");
+    let q = tx["query"].as_str().unwrap();
+    assert!(q.contains("DELETE FROM `p.d.t` T WHERE EXISTS"), "got: {q}");
+    assert!(!q.contains("MERGE INTO `p.d.t`"), "delete-only must not emit a data MERGE: {q}");
+    let pnames: Vec<&str> = tx["queryParameters"].as_array().unwrap().iter().map(|p| p["name"].as_str().unwrap()).collect();
+    assert!(pnames.contains(&"deletes"), "got: {pnames:?}");
+    assert!(!pnames.contains(&"payload"), "delete-only must not bind @payload: {pnames:?}");
+}
+
+#[tokio::test]
+async fn write_batch_idempotent_zero_rows_posts_watermark_only() {
+    let server = MockServer::start().await;
+    mount_token_endpoint(&server).await;
+    mount_table_schema(&server).await;
+    mount_query_done(&server, "job-wm").await;
+    mount_job_done(&server, "job-wm").await;
+
+    let cfg = config_with(|c| {
+        c.write.write_mode = faucet_core::WriteMode::Upsert;
+        c.write.key = vec!["id".into()];
+    });
+    let (sink, _sa) = build_sink(&server, cfg).await;
+    // An empty exactly-once page must still advance the watermark: the
+    // transaction posts the token MERGE alone, with no data MERGE/DELETE.
+    let n = sink
+        .write_batch_idempotent(&[], "pipe::row1", "00000000000000000009")
+        .await
+        .expect("zero-row eo upsert");
+    assert_eq!(n, 0);
+
+    let bodies = captured_query_bodies(&server).await;
+    let tx = bodies
+        .iter()
+        .find(|b| b["query"].as_str().unwrap_or("").contains("MERGE `p.d._faucet_commit_token`"))
+        .expect("watermark merge query");
+    let q = tx["query"].as_str().unwrap();
+    assert!(!q.contains("MERGE INTO `p.d.t`"), "zero-row page must not emit a data MERGE: {q}");
+    assert!(!q.contains("DELETE FROM `p.d.t`"), "zero-row page must not emit a DELETE: {q}");
+    let pnames: Vec<&str> = tx["queryParameters"].as_array().unwrap().iter().map(|p| p["name"].as_str().unwrap()).collect();
+    assert!(pnames.contains(&"scope") && pnames.contains(&"token"), "got: {pnames:?}");
+    assert!(!pnames.contains(&"payload") && !pnames.contains(&"deletes"), "no data params for a zero-row page: {pnames:?}");
+}

--- a/crates/sink/bigquery/tests/upsert.rs
+++ b/crates/sink/bigquery/tests/upsert.rs
@@ -1,0 +1,222 @@
+//! Integration tests for the BigQuery upsert/delete write path (#224): the
+//! in-place `MERGE … USING (SELECT … FROM UNNEST(@payload))` driven by
+//! `write_batch` / `write_batch_partial` / `write_batch_idempotent`.
+
+use faucet_core::Sink;
+use faucet_sink_bigquery::{BigQueryCredentials, BigQuerySink, BigQuerySinkConfig};
+use gcp_bigquery_client::client_builder::ClientBuilder;
+use serde::Serialize;
+use serde_json::json;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const PROJECT_ID: &str = "p";
+const DATASET_ID: &str = "d";
+const TABLE_ID: &str = "t";
+const AUTH_TOKEN_PATH: &str = "/:o/oauth2/token";
+const AUTH_SCOPE_BASE: &str = "/auth/bigquery";
+
+#[derive(Serialize)]
+struct FakeToken {
+    access_token: &'static str,
+    token_type: &'static str,
+    expires_in: u32,
+}
+
+fn fake_token() -> FakeToken {
+    FakeToken { access_token: "fake-token", token_type: "bearer", expires_in: 9_999_999 }
+}
+
+fn dummy_service_account_json(oauth_server: &str) -> serde_json::Value {
+    let token_uri = format!("{oauth_server}{AUTH_TOKEN_PATH}");
+    json!({
+        "type": "service_account",
+        "project_id": "dummy",
+        "private_key_id": "dummy",
+        "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQDNk6cKkWP/4NMu\nWb3s24YHfM639IXzPtTev06PUVVQnyHmT1bZgQ/XB6BvIRaReqAqnQd61PAGtX3e\n8XocTw+u/ZfiPJOf+jrXMkRBpiBh9mbyEIqBy8BC20OmsUc+O/YYh/qRccvRfPI7\n3XMabQ8eFWhI6z/t35oRpvEVFJnSIgyV4JR/L/cjtoKnxaFwjBzEnxPiwtdy4olU\nKO/1maklXexvlO7onC7CNmPAjuEZKzdMLzFszikCDnoKJC8k6+2GZh0/JDMAcAF4\nwxlKNQ89MpHVRXZ566uKZg0MqZqkq5RXPn6u7yvNHwZ0oahHT+8ixPPrAEjuPEKM\nUPzVRz71AgMBAAECggEAfdbVWLW5Befkvam3hea2+5xdmeN3n3elrJhkiXxbAhf3\nE1kbq9bCEHmdrokNnI34vz0SWBFCwIiWfUNJ4UxQKGkZcSZto270V8hwWdNMXUsM\npz6S2nMTxJkdp0s7dhAUS93o9uE2x4x5Z0XecJ2ztFGcXY6Lupu2XvnW93V9109h\nkY3uICLdbovJq7wS/fO/AL97QStfEVRWW2agIXGvoQG5jOwfPh86GZZRYP9b8VNw\ntkAUJe4qpzNbWs9AItXOzL+50/wsFkD/iWMGWFuU8DY5ZwsL434N+uzFlaD13wtZ\n63D+tNAxCSRBfZGQbd7WxJVFfZe/2vgjykKWsdyNAQKBgQDnEBgSI836HGSRk0Ub\nDwiEtdfh2TosV+z6xtyU7j/NwjugTOJEGj1VO/TMlZCEfpkYPLZt3ek2LdNL66n8\nDyxwzTT5Q3D/D0n5yE3mmxy13Qyya6qBYvqqyeWNwyotGM7hNNOix1v9lEMtH5Rd\nUT0gkThvJhtrV663bcAWCALmtQKBgQDjw2rYlMUp2TUIa2/E7904WOnSEG85d+nc\norhzthX8EWmPgw1Bbfo6NzH4HhebTw03j3NjZdW2a8TG/uEmZFWhK4eDvkx+rxAa\n6EwamS6cmQ4+vdep2Ac4QCSaTZj02YjHb06Be3gptvpFaFrotH2jnpXxggdiv8ul\n6x+ooCffQQKBgQCR3ykzGoOI6K/c75prELyR+7MEk/0TzZaAY1cSdq61GXBHLQKT\nd/VMgAN1vN51pu7DzGBnT/dRCvEgNvEjffjSZdqRmrAVdfN/y6LSeQ5RCfJgGXSV\nJoWVmMxhCNrxiX3h01Xgp/c9SYJ3VD54AzeR/dwg32/j/oEAsDraLciXGQKBgQDF\nMNc8k/DvfmJv27R06Ma6liA6AoiJVMxgfXD8nVUDW3/tBCVh1HmkFU1p54PArvxe\nchAQqoYQ3dUMBHeh6ZRJaYp2ATfxJlfnM99P1/eHFOxEXdBt996oUMBf53bZ5cyJ\n/lAVwnQSiZy8otCyUDHGivJ+mXkTgcIq8BoEwERFAQKBgQDmImBaFqoMSVihqHIf\nDa4WZqwM7ODqOx0JnBKrKO8UOc51J5e1vpwP/qRpNhUipoILvIWJzu4efZY7GN5C\nImF9sN3PP6Sy044fkVPyw4SYEisxbvp9tfw8Xmpj/pbmugkB2ut6lz5frmEBoJSN\n3osZlZTgx+pM3sO6ITV6U4ID2Q==\n-----END PRIVATE KEY-----\n",
+        "client_email": "dummy@developer.gserviceaccount.com",
+        "client_id": "dummy",
+        "auth_uri": format!("{oauth_server}/o/oauth2/auth"),
+        "token_uri": token_uri,
+        "auth_provider_x509_cert_url": format!("{oauth_server}/oauth2/v1/certs"),
+        "client_x509_cert_url": format!("{oauth_server}/robot/v1/metadata/x509/dummy"),
+    })
+}
+
+async fn mount_token_endpoint(server: &MockServer) {
+    Mock::given(method("POST"))
+        .and(path(AUTH_TOKEN_PATH))
+        .respond_with(ResponseTemplate::new(200).set_body_json(fake_token()))
+        .mount(server)
+        .await;
+}
+
+fn config_with<F: FnOnce(&mut BigQuerySinkConfig)>(f: F) -> BigQuerySinkConfig {
+    let mut c =
+        BigQuerySinkConfig::new(PROJECT_ID, DATASET_ID, TABLE_ID, BigQueryCredentials::ApplicationDefault);
+    f(&mut c);
+    c
+}
+
+async fn build_sink(server: &MockServer, config: BigQuerySinkConfig) -> (BigQuerySink, tempfile::NamedTempFile) {
+    let sa_json = dummy_service_account_json(&server.uri());
+    let sa_file = tempfile::NamedTempFile::new().expect("create sa tempfile");
+    std::fs::write(sa_file.path(), serde_json::to_string_pretty(&sa_json).unwrap()).expect("write sa");
+    let client = ClientBuilder::new()
+        .with_auth_base_url(format!("{}{AUTH_SCOPE_BASE}", server.uri()))
+        .with_v2_base_url(server.uri())
+        .build_from_service_account_key_file(sa_file.path().to_str().unwrap())
+        .await
+        .expect("build client");
+    (BigQuerySink::from_parts(config, client), sa_file)
+}
+
+fn tables_get_path() -> String {
+    format!("/projects/{PROJECT_ID}/datasets/{DATASET_ID}/tables/{TABLE_ID}")
+}
+fn queries_path() -> String {
+    format!("/projects/{PROJECT_ID}/queries")
+}
+
+async fn mount_table_schema(server: &MockServer) {
+    Mock::given(method("GET"))
+        .and(path(tables_get_path()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "tableReference": {"projectId": PROJECT_ID, "datasetId": DATASET_ID, "tableId": TABLE_ID},
+            "schema": {"fields": [
+                {"name": "id", "type": "INTEGER", "mode": "REQUIRED"},
+                {"name": "name", "type": "STRING", "mode": "NULLABLE"}
+            ]}
+        })))
+        .mount(server)
+        .await;
+}
+
+fn done_query(job_id: &str) -> serde_json::Value {
+    json!({
+        "kind": "bigquery#queryResponse",
+        "jobComplete": true,
+        "jobReference": {"projectId": PROJECT_ID, "jobId": job_id}
+    })
+}
+
+async fn mount_query_done(server: &MockServer, job_id: &str) {
+    Mock::given(method("POST"))
+        .and(path(queries_path()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(done_query(job_id)))
+        .mount(server)
+        .await;
+}
+
+async fn mount_job_done(server: &MockServer, job_id: &str) {
+    Mock::given(method("GET"))
+        .and(path(format!("/projects/{PROJECT_ID}/jobs/{job_id}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jobReference": {"projectId": PROJECT_ID, "jobId": job_id},
+            "status": {"state": "DONE"}
+        })))
+        .mount(server)
+        .await;
+}
+
+async fn captured_query_bodies(server: &MockServer) -> Vec<serde_json::Value> {
+    server
+        .received_requests()
+        .await
+        .expect("recording enabled")
+        .into_iter()
+        .filter(|r| r.url.path().ends_with("/queries"))
+        .map(|r| serde_json::from_slice(&r.body).expect("query body is JSON"))
+        .collect()
+}
+
+#[tokio::test]
+async fn sink_advertises_upsert_and_delete() {
+    let server = MockServer::start().await;
+    mount_token_endpoint(&server).await;
+    let (sink, _sa) = build_sink(&server, config_with(|_| {})).await;
+    let modes = sink.supported_write_modes();
+    assert!(modes.contains(&faucet_core::WriteMode::Upsert));
+    assert!(modes.contains(&faucet_core::WriteMode::Delete));
+}
+
+#[tokio::test]
+async fn write_batch_upsert_posts_merge() {
+    let server = MockServer::start().await;
+    mount_token_endpoint(&server).await;
+    mount_table_schema(&server).await;
+    mount_query_done(&server, "job-u").await;
+    mount_job_done(&server, "job-u").await;
+
+    let cfg = config_with(|c| {
+        c.write.write_mode = faucet_core::WriteMode::Upsert;
+        c.write.key = vec!["id".into()];
+    });
+    let (sink, _sa) = build_sink(&server, cfg).await;
+    let n = sink
+        .write_batch(&[json!({"id": 1, "name": "a"}), json!({"id": 2, "name": "b"})])
+        .await
+        .expect("upsert write");
+    assert_eq!(n, 2);
+
+    let bodies = captured_query_bodies(&server).await;
+    let tx = bodies.iter().find(|b| b["query"].as_str().unwrap_or("").contains("MERGE INTO `p.d.t`")).expect("merge query");
+    let q = tx["query"].as_str().unwrap();
+    assert!(q.contains("USING (SELECT CAST(JSON_VALUE(r, '$.id') AS INT64) AS `id`"), "got: {q}");
+    assert!(q.contains("ON T.`id` = S.`id`"), "got: {q}");
+    assert!(q.contains("WHEN MATCHED THEN UPDATE SET `name` = S.`name`"), "got: {q}");
+    assert_eq!(tx["parameterMode"], "NAMED");
+    let pnames: Vec<&str> = tx["queryParameters"].as_array().unwrap().iter().map(|p| p["name"].as_str().unwrap()).collect();
+    assert!(pnames.contains(&"payload"), "got: {pnames:?}");
+}
+
+#[tokio::test]
+async fn write_batch_delete_marker_routes_to_delete() {
+    let server = MockServer::start().await;
+    mount_token_endpoint(&server).await;
+    mount_table_schema(&server).await;
+    mount_query_done(&server, "job-d").await;
+    mount_job_done(&server, "job-d").await;
+
+    let cfg = config_with(|c| {
+        c.write.write_mode = faucet_core::WriteMode::Upsert;
+        c.write.key = vec!["id".into()];
+        c.write.delete_marker = Some(faucet_core::DeleteMarker { field: "__op".into(), values: vec!["d".into()] });
+    });
+    let (sink, _sa) = build_sink(&server, cfg).await;
+    // One upsert (id=1), one delete (id=2 marked __op=d).
+    let n = sink
+        .write_batch(&[json!({"id": 1, "name": "a", "__op": "u"}), json!({"id": 2, "__op": "d"})])
+        .await
+        .expect("upsert+delete write");
+    assert_eq!(n, 2);
+
+    let bodies = captured_query_bodies(&server).await;
+    let tx = bodies.iter().find(|b| b["query"].as_str().unwrap_or("").contains("BEGIN TRANSACTION")).expect("tx");
+    let q = tx["query"].as_str().unwrap();
+    assert!(q.contains("MERGE INTO `p.d.t`"), "got: {q}");
+    assert!(q.contains("DELETE FROM `p.d.t` T WHERE EXISTS"), "got: {q}");
+    let pnames: Vec<&str> = tx["queryParameters"].as_array().unwrap().iter().map(|p| p["name"].as_str().unwrap()).collect();
+    assert!(pnames.contains(&"payload") && pnames.contains(&"deletes"), "got: {pnames:?}");
+}
+
+#[tokio::test]
+async fn write_batch_upsert_missing_key_errors() {
+    let server = MockServer::start().await;
+    mount_token_endpoint(&server).await;
+    mount_table_schema(&server).await;
+    mount_query_done(&server, "job-x").await;
+    mount_job_done(&server, "job-x").await;
+
+    let cfg = config_with(|c| {
+        c.write.write_mode = faucet_core::WriteMode::Upsert;
+        c.write.key = vec!["id".into()];
+    });
+    let (sink, _sa) = build_sink(&server, cfg).await;
+    // Second row has no `id` → planner routes it to `failed` → write_batch errors.
+    let err = sink
+        .write_batch(&[json!({"id": 1, "name": "a"}), json!({"name": "no key"})])
+        .await
+        .unwrap_err();
+    assert!(format!("{err}").contains("bigquery upsert"), "got: {err}");
+}

--- a/crates/sink/bigquery/tests/upsert.rs
+++ b/crates/sink/bigquery/tests/upsert.rs
@@ -24,7 +24,11 @@ struct FakeToken {
 }
 
 fn fake_token() -> FakeToken {
-    FakeToken { access_token: "fake-token", token_type: "bearer", expires_in: 9_999_999 }
+    FakeToken {
+        access_token: "fake-token",
+        token_type: "bearer",
+        expires_in: 9_999_999,
+    }
 }
 
 fn dummy_service_account_json(oauth_server: &str) -> serde_json::Value {
@@ -52,16 +56,27 @@ async fn mount_token_endpoint(server: &MockServer) {
 }
 
 fn config_with<F: FnOnce(&mut BigQuerySinkConfig)>(f: F) -> BigQuerySinkConfig {
-    let mut c =
-        BigQuerySinkConfig::new(PROJECT_ID, DATASET_ID, TABLE_ID, BigQueryCredentials::ApplicationDefault);
+    let mut c = BigQuerySinkConfig::new(
+        PROJECT_ID,
+        DATASET_ID,
+        TABLE_ID,
+        BigQueryCredentials::ApplicationDefault,
+    );
     f(&mut c);
     c
 }
 
-async fn build_sink(server: &MockServer, config: BigQuerySinkConfig) -> (BigQuerySink, tempfile::NamedTempFile) {
+async fn build_sink(
+    server: &MockServer,
+    config: BigQuerySinkConfig,
+) -> (BigQuerySink, tempfile::NamedTempFile) {
     let sa_json = dummy_service_account_json(&server.uri());
     let sa_file = tempfile::NamedTempFile::new().expect("create sa tempfile");
-    std::fs::write(sa_file.path(), serde_json::to_string_pretty(&sa_json).unwrap()).expect("write sa");
+    std::fs::write(
+        sa_file.path(),
+        serde_json::to_string_pretty(&sa_json).unwrap(),
+    )
+    .expect("write sa");
     let client = ClientBuilder::new()
         .with_auth_base_url(format!("{}{AUTH_SCOPE_BASE}", server.uri()))
         .with_v2_base_url(server.uri())
@@ -160,13 +175,32 @@ async fn write_batch_upsert_posts_merge() {
     assert_eq!(n, 2);
 
     let bodies = captured_query_bodies(&server).await;
-    let tx = bodies.iter().find(|b| b["query"].as_str().unwrap_or("").contains("MERGE INTO `p.d.t`")).expect("merge query");
+    let tx = bodies
+        .iter()
+        .find(|b| {
+            b["query"]
+                .as_str()
+                .unwrap_or("")
+                .contains("MERGE INTO `p.d.t`")
+        })
+        .expect("merge query");
     let q = tx["query"].as_str().unwrap();
-    assert!(q.contains("USING (SELECT CAST(JSON_VALUE(r, '$.id') AS INT64) AS `id`"), "got: {q}");
+    assert!(
+        q.contains("USING (SELECT CAST(JSON_VALUE(r, '$.id') AS INT64) AS `id`"),
+        "got: {q}"
+    );
     assert!(q.contains("ON T.`id` = S.`id`"), "got: {q}");
-    assert!(q.contains("WHEN MATCHED THEN UPDATE SET `name` = S.`name`"), "got: {q}");
+    assert!(
+        q.contains("WHEN MATCHED THEN UPDATE SET `name` = S.`name`"),
+        "got: {q}"
+    );
     assert_eq!(tx["parameterMode"], "NAMED");
-    let pnames: Vec<&str> = tx["queryParameters"].as_array().unwrap().iter().map(|p| p["name"].as_str().unwrap()).collect();
+    let pnames: Vec<&str> = tx["queryParameters"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|p| p["name"].as_str().unwrap())
+        .collect();
     assert!(pnames.contains(&"payload"), "got: {pnames:?}");
 }
 
@@ -181,23 +215,45 @@ async fn write_batch_delete_marker_routes_to_delete() {
     let cfg = config_with(|c| {
         c.write.write_mode = faucet_core::WriteMode::Upsert;
         c.write.key = vec!["id".into()];
-        c.write.delete_marker = Some(faucet_core::DeleteMarker { field: "__op".into(), values: vec!["d".into()] });
+        c.write.delete_marker = Some(faucet_core::DeleteMarker {
+            field: "__op".into(),
+            values: vec!["d".into()],
+        });
     });
     let (sink, _sa) = build_sink(&server, cfg).await;
     // One upsert (id=1), one delete (id=2 marked __op=d).
     let n = sink
-        .write_batch(&[json!({"id": 1, "name": "a", "__op": "u"}), json!({"id": 2, "__op": "d"})])
+        .write_batch(&[
+            json!({"id": 1, "name": "a", "__op": "u"}),
+            json!({"id": 2, "__op": "d"}),
+        ])
         .await
         .expect("upsert+delete write");
     assert_eq!(n, 2);
 
     let bodies = captured_query_bodies(&server).await;
-    let tx = bodies.iter().find(|b| b["query"].as_str().unwrap_or("").contains("BEGIN TRANSACTION")).expect("tx");
+    let tx = bodies
+        .iter()
+        .find(|b| {
+            b["query"]
+                .as_str()
+                .unwrap_or("")
+                .contains("BEGIN TRANSACTION")
+        })
+        .expect("tx");
     let q = tx["query"].as_str().unwrap();
     assert!(q.contains("MERGE INTO `p.d.t`"), "got: {q}");
     assert!(q.contains("DELETE FROM `p.d.t` T WHERE EXISTS"), "got: {q}");
-    let pnames: Vec<&str> = tx["queryParameters"].as_array().unwrap().iter().map(|p| p["name"].as_str().unwrap()).collect();
-    assert!(pnames.contains(&"payload") && pnames.contains(&"deletes"), "got: {pnames:?}");
+    let pnames: Vec<&str> = tx["queryParameters"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|p| p["name"].as_str().unwrap())
+        .collect();
+    assert!(
+        pnames.contains(&"payload") && pnames.contains(&"deletes"),
+        "got: {pnames:?}"
+    );
 }
 
 #[tokio::test]
@@ -236,7 +292,11 @@ async fn write_batch_idempotent_upsert_composes_merge_and_watermark() {
     });
     let (sink, _sa) = build_sink(&server, cfg).await;
     let n = sink
-        .write_batch_idempotent(&[json!({"id": 1, "name": "a"})], "pipe::row1", "00000000000000000005")
+        .write_batch_idempotent(
+            &[json!({"id": 1, "name": "a"})],
+            "pipe::row1",
+            "00000000000000000005",
+        )
         .await
         .expect("eo upsert");
     assert_eq!(n, 1);
@@ -253,8 +313,16 @@ async fn write_batch_idempotent_upsert_composes_merge_and_watermark() {
     let data = q.find("MERGE INTO `p.d.t`").unwrap();
     let wm = q.find("MERGE `p.d._faucet_commit_token`").unwrap();
     assert!(data < wm, "data merge must precede watermark: {q}");
-    let pnames: Vec<&str> = tx["queryParameters"].as_array().unwrap().iter().map(|p| p["name"].as_str().unwrap()).collect();
-    assert!(pnames.contains(&"payload") && pnames.contains(&"scope") && pnames.contains(&"token"), "got: {pnames:?}");
+    let pnames: Vec<&str> = tx["queryParameters"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|p| p["name"].as_str().unwrap())
+        .collect();
+    assert!(
+        pnames.contains(&"payload") && pnames.contains(&"scope") && pnames.contains(&"token"),
+        "got: {pnames:?}"
+    );
 }
 
 #[tokio::test]
@@ -304,14 +372,30 @@ async fn write_batch_delete_only_posts_delete_without_merge() {
     let bodies = captured_query_bodies(&server).await;
     let tx = bodies
         .iter()
-        .find(|b| b["query"].as_str().unwrap_or("").contains("DELETE FROM `p.d.t`"))
+        .find(|b| {
+            b["query"]
+                .as_str()
+                .unwrap_or("")
+                .contains("DELETE FROM `p.d.t`")
+        })
         .expect("delete query");
     let q = tx["query"].as_str().unwrap();
     assert!(q.contains("DELETE FROM `p.d.t` T WHERE EXISTS"), "got: {q}");
-    assert!(!q.contains("MERGE INTO `p.d.t`"), "delete-only must not emit a data MERGE: {q}");
-    let pnames: Vec<&str> = tx["queryParameters"].as_array().unwrap().iter().map(|p| p["name"].as_str().unwrap()).collect();
+    assert!(
+        !q.contains("MERGE INTO `p.d.t`"),
+        "delete-only must not emit a data MERGE: {q}"
+    );
+    let pnames: Vec<&str> = tx["queryParameters"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|p| p["name"].as_str().unwrap())
+        .collect();
     assert!(pnames.contains(&"deletes"), "got: {pnames:?}");
-    assert!(!pnames.contains(&"payload"), "delete-only must not bind @payload: {pnames:?}");
+    assert!(
+        !pnames.contains(&"payload"),
+        "delete-only must not bind @payload: {pnames:?}"
+    );
 }
 
 #[tokio::test]
@@ -338,12 +422,34 @@ async fn write_batch_idempotent_zero_rows_posts_watermark_only() {
     let bodies = captured_query_bodies(&server).await;
     let tx = bodies
         .iter()
-        .find(|b| b["query"].as_str().unwrap_or("").contains("MERGE `p.d._faucet_commit_token`"))
+        .find(|b| {
+            b["query"]
+                .as_str()
+                .unwrap_or("")
+                .contains("MERGE `p.d._faucet_commit_token`")
+        })
         .expect("watermark merge query");
     let q = tx["query"].as_str().unwrap();
-    assert!(!q.contains("MERGE INTO `p.d.t`"), "zero-row page must not emit a data MERGE: {q}");
-    assert!(!q.contains("DELETE FROM `p.d.t`"), "zero-row page must not emit a DELETE: {q}");
-    let pnames: Vec<&str> = tx["queryParameters"].as_array().unwrap().iter().map(|p| p["name"].as_str().unwrap()).collect();
-    assert!(pnames.contains(&"scope") && pnames.contains(&"token"), "got: {pnames:?}");
-    assert!(!pnames.contains(&"payload") && !pnames.contains(&"deletes"), "no data params for a zero-row page: {pnames:?}");
+    assert!(
+        !q.contains("MERGE INTO `p.d.t`"),
+        "zero-row page must not emit a data MERGE: {q}"
+    );
+    assert!(
+        !q.contains("DELETE FROM `p.d.t`"),
+        "zero-row page must not emit a DELETE: {q}"
+    );
+    let pnames: Vec<&str> = tx["queryParameters"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|p| p["name"].as_str().unwrap())
+        .collect();
+    assert!(
+        pnames.contains(&"scope") && pnames.contains(&"token"),
+        "got: {pnames:?}"
+    );
+    assert!(
+        !pnames.contains(&"payload") && !pnames.contains(&"deletes"),
+        "no data params for a zero-row page: {pnames:?}"
+    );
 }

--- a/docs/book/src/cookbook/upsert.md
+++ b/docs/book/src/cookbook/upsert.md
@@ -29,7 +29,7 @@ the top level of the sink's `config`, alongside `table_name` etc.):
 
 ## Supported sinks and their native primitives
 
-Six sinks support `upsert`/`delete`; every other sink is append-only.
+Seven sinks support `upsert`/`delete`; every other sink is append-only.
 
 | Sink | Requires | Native primitive |
 |------|----------|------------------|
@@ -39,6 +39,7 @@ Six sinks support `upsert`/`delete`; every other sink is append-only.
 | `mssql` | `column_mapping: auto_columns` + UNIQUE/PK on `key` | `MERGE` |
 | `mongodb` | — (schemaless) | `replace_one(upsert)` / `delete_one`, `key` → match filter |
 | `elasticsearch` | — (schemaless) | `_bulk` `index` / `delete`, `key` → `_id` |
+| `bigquery` | a defined table schema + `key` columns | in-place `MERGE … USING UNNEST(@payload)` (no staging table) |
 
 The **SQL sinks require column-mapping mode** — `column_mapping: auto_map`
 (postgres/mysql/sqlite) or `auto_columns` (mssql). The single-JSONB-column blob
@@ -52,10 +53,8 @@ The **schemaless sinks** (MongoDB, Elasticsearch) have no such requirement: the
 `key` columns are joined into a document filter / `_id`, so the same record both
 inserts and replaces.
 
-> **Not yet supported:** BigQuery and Iceberg are append-only today. BigQuery
-> upsert needs a staging-table + `MERGE` design (and a quota/cost model), and
-> Iceberg upsert is blocked on equality-delete writer support in `iceberg-rust`.
-> Both are tracked as follow-ups.
+> **Not yet supported:** Iceberg is append-only today — Iceberg upsert is blocked
+> on equality-delete writer support in `iceberg-rust` (#225).
 
 ## Last-write-wins within a batch
 
@@ -139,11 +138,11 @@ faucet validate cli/examples/postgres_cdc_to_postgres_upsert.yaml
 ## Composing with exactly-once delivery
 
 `write_mode: upsert` composes with [`delivery: exactly_once`](./state.md#exactly-once-delivery)
-on the four SQL sinks (`postgres`, `mysql`, `mssql`, `sqlite`). The same four
-hard requirements apply, checked at config-load time:
+on the four SQL sinks (`postgres`, `mysql`, `mssql`, `sqlite`) and on **BigQuery**.
+The same four hard requirements apply, checked at config-load time:
 
 1. a CDC source (`postgres-cdc` / `mysql-cdc` / `mongodb-cdc`),
-2. an idempotent SQL sink (`postgres` / `mysql` / `mssql` / `sqlite`),
+2. an idempotent sink (`postgres` / `mysql` / `mssql` / `sqlite` / `bigquery`),
 3. a `state:` block, and
 4. **no** `dlq:` block (incompatible with exactly-once in this version).
 
@@ -152,6 +151,10 @@ monotonic commit token in a single transaction, so a crash-and-resume never
 re-applies or skips a batch — the mirror stays exactly consistent with the source
 even across restarts. (Because exactly-once forbids a DLQ, a missing/null-key row
 fails the batch rather than being routed aside.)
+
+For BigQuery, the whole page is merged as one `jobs.query` request (~10 MB limit);
+keep the CDC source's `batch_size` modest (the default 1 000 rows is fine for most
+schemas; lower it for very wide rows that approach the limit).
 
 MongoDB and Elasticsearch support upsert but **not** exactly-once (their bulk
 APIs cannot commit a watermark atomically), so an upsert mirror into those sinks

--- a/docs/book/src/reference/connectors.md
+++ b/docs/book/src/reference/connectors.md
@@ -58,7 +58,7 @@ file/append sinks (`jsonl`, `csv`, `stdout`) it's a no-op — they write per rec
 
 | Connector | Feature | `batch_size` | Compression | Upsert⁸ | Exactly-once⁷ | Write unit |
 |-----------|---------|:---:|:---:|:---:|:---:|------------|
-| BigQuery | `sink-bigquery` | ✓ | ✗ | ✗ | **✓** | `tabledata.insertAll` streaming; `MERGE`-transaction write for exactly-once |
+| BigQuery | `sink-bigquery` | ✓ | ✗ | **✓** | **✓** | `tabledata.insertAll` streaming; in-place `MERGE` for upsert + exactly-once |
 | PostgreSQL | `sink-postgres` | ✓ | ✗ | **✓** | **✓** | multi-row `INSERT` (JSONB or mapped cols) |
 | JSON Lines | `sink-jsonl` | no-op | ✓ | ✗ | ✗ | buffered file append |
 | Snowflake | `sink-snowflake` | ✓ | ✗ | ✗ | ✗ | SQL REST API |
@@ -89,7 +89,7 @@ delete by `key`) in addition to plain `append`. The SQL sinks require
 column-mapping mode (`auto_map`, or `auto_columns` for mssql) and a
 UNIQUE/PRIMARY KEY on `key`; the
 schemaless sinks (MongoDB, Elasticsearch) map `key` to a match filter / `_id`.
-BigQuery and Iceberg upsert are not yet supported (follow-ups). See
+Iceberg upsert is not yet supported (a follow-up, blocked on `iceberg-rust`). See
 [Upsert / mirror tables](../cookbook/upsert.md).
 
 ## Authentication at a glance

--- a/examples/README.md
+++ b/examples/README.md
@@ -56,6 +56,7 @@ The service column lists what each example touches; all are provided by
 |---------|----------|
 | `postgres_cdc_to_jsonl.yaml` | postgres (logical replication preconfigured) |
 | `postgres_cdc_to_postgres_upsert.yaml` | postgres (CDC source + an upsert mirror table; `cdc_unwrap` + `write_mode: upsert`, exactly-once) |
+| `postgres_cdc_to_bigquery_upsert.yaml` | postgres (CDC source) + BigQuery (`write_mode: upsert`, in-place MERGE, exactly-once; requires GCP credentials) |
 | `mongodb_cdc_to_jsonl.yaml` | mongodb (single-node replica set preconfigured; Change Streams) |
 | `mysql_cdc_to_jsonl.yaml` | mysql (binlog enabled; `repl` user with replication grants preconfigured) |
 | `rest_to_postgres.yaml`, `rest_to_postgres_with_quality.yaml`, `mongodb_to_postgres.yaml`, `graphql_to_postgres.yaml`, `webhook_to_postgres.yaml` | postgres (+ source) |


### PR DESCRIPTION
## Summary

Adds `write_mode: upsert | delete` (merge by key) to the **BigQuery sink**, so a CDC → BigQuery pipeline produces a **mirror table** (current state) instead of an append-only change log. This completes the BigQuery half of #190 and is the natural destination for the snapshot→CDC replication path (#189).

Implemented via an **in-place** `MERGE … USING (SELECT … FROM UNNEST(JSON_QUERY_ARRAY(@payload)))` — **no staging table** — reusing the #215 exactly-once typed-extraction machinery (`idempotent.rs`). Deletes use a keyed semi-join `DELETE`; both run in one multi-statement transaction. Mirrors the canonical Postgres-sink upsert/DLQ/exactly-once structure.

### Design notes (supersedes parts of the original issue)

The issue text predates the #215 exactly-once merge; two assumptions are deliberately superseded (see the design spec):

- **No staging table.** The `UNNEST(@payload)` trick makes the page the MERGE source inline — eliminating staging lifecycle, orphan cleanup, and the streaming-buffer-vs-DML window. Trade-off: one page must fit BigQuery's ~10 MB `jobs.query` limit (fine for the CDC tail; documented, size `batch_size` down for large pages).
- **No coalescing knob.** Modern BigQuery removed the per-table daily DML cap (mutating DML queues), the exactly-once path already does one DML job per page, and a cross-page buffer would break the per-page bookmark contract. → one MERGE-script per page.
- **Exactly-once + upsert composes** (data MERGE + watermark MERGE in one transaction), avoiding the footgun where `exactly_once` + `upsert` would silently append.

## Changes

- `faucet-sink-bigquery`: flattened `WriteSpec` config; `supported_write_modes()`; new pure `merge.rs` SQL generators; `write_batch` / `write_batch_partial` / `write_batch_idempotent` route through `plan_writes` → in-place MERGE/DELETE.
- `faucet-cli`: `bigquery` added to `sink_supported_write_modes` (the `write_mode × sink` gate).
- Docs: capability matrix, upsert cookbook, sink README, and a runnable `cli/examples/postgres_cdc_to_bigquery_upsert.yaml`.

## Test plan

- **bigquery (77 tests):** unit tests on the SQL generators + wiremock integration covering upsert-only, delete-only, upsert+delete, missing-key → error/DLQ, zero-row exactly-once (watermark-only), and exactly-once + upsert composition (request-body SQL + bound params asserted).
- **cli (389 unit tests):** incl. the `write_mode: upsert` × `sink: bigquery` gate test.
- `cargo clippy --all-features` clean; `cargo fmt`; builds with default **and** `--no-default-features`.

Closes #224.
