### PR TITLE
fix(mysql-cdc): support MySQL 8.4+ current-position capture (#242)

### DIFF
--- a/crates/source/mysql-cdc/README.md
+++ b/crates/source/mysql-cdc/README.md
@@ -187,6 +187,7 @@ Example: `server_id: 1001` → state key `mysql-cdc:1001`.
 - **`start_position: earliest` may error.** If binlogs have been purged (via `expire_logs_days` or `PURGE BINARY LOGS`), MySQL returns an error when the requested position no longer exists. Keep your binlog retention window large enough for your expected downtime.
 - **Per-transaction durability.** The bookmark advances once per committed transaction. A crash mid-transaction replays at most the events since the last persisted bookmark (the incomplete transaction is re-delivered from the last commit boundary).
 - **`max_staged_records` guards against OOM.** Very large transactions (bulk INSERTs of millions of rows) buffer all rows in memory before the commit event arrives. Set `max_staged_records` to a safe upper bound for your workload.
+- **MySQL 5.7 / 8.0 / 8.4+ are all supported.** Capturing the current binlog position (`start_position: current` and `capture_resume_position()`) tries `SHOW BINARY LOG STATUS` (MySQL 8.4+) and falls back to `SHOW MASTER STATUS` (5.7 / 8.0), so the connector works against the 8.4 LTS — which removed `SHOW MASTER STATUS` — out of the box.
 
 ---
 
@@ -258,8 +259,8 @@ state:
 ## Snapshot → CDC handoff
 
 This source implements `capture_resume_position()`, which reads the server's
-**current binlog coordinates** (`{ file, pos }` via `SHOW MASTER STATUS`) as a
-resume bookmark — without consuming any changes. The `faucet replicate` command
+**current binlog coordinates** (`{ file, pos }`) as a resume bookmark — without
+consuming any changes. The `faucet replicate` command
 uses it to anchor the binlog stream at-or-before a bulk snapshot of the table,
 so the combined snapshot+CDC result is a gap-free, duplicate-free mirror when
 paired with a `write_mode: upsert` sink.

--- a/crates/source/mysql-cdc/src/stream.rs
+++ b/crates/source/mysql-cdc/src/stream.rs
@@ -231,8 +231,9 @@ impl MysqlCdcSource {
                 .await
                 .map_err(|e| FaucetError::Source(format!("mysql-cdc: connect failed: {e}")))?;
 
-            // Resolve Current → FilePos by querying SHOW MASTER STATUS (fills in the
-            // actual file/pos before we build the request that borrows from `resolved`).
+            // Resolve Current → FilePos by querying the server's current binlog
+            // position (fills in the actual file/pos before we build the request
+            // that borrows from `resolved`).
             let resolved = resolve_current(resolved, &mut conn).await?;
             let req = build_request(self.config.server_id, &resolved)?;
 
@@ -546,7 +547,7 @@ pub(crate) fn resolve_start(
     // No persisted bookmark — use the config.
     match start_position {
         StartPosition::Current => {
-            // Placeholder; real file/pos filled in by `build_request` via SHOW MASTER STATUS.
+            // Placeholder; real file/pos filled in later by `current_binlog_position`.
             ResolvedStart::Current {
                 file: String::new(),
                 pos: 0,
@@ -581,22 +582,40 @@ async fn resolve_current(
     Ok(ResolvedStart::FilePos { file, pos })
 }
 
-/// Read the server's current binlog coordinates via `SHOW MASTER STATUS`.
+/// Read the server's current binlog coordinates.
+///
+/// MySQL 8.4 removed `SHOW MASTER STATUS` in favour of `SHOW BINARY LOG STATUS`
+/// (same `File` / `Position` columns). We try the 8.4+ spelling first and fall
+/// back to the legacy statement when the server rejects it (5.7 / 8.0 raise a
+/// parse error), so one code path works across 5.7 / 8.0 / 8.4+ without version
+/// parsing. Only invoked at start/capture time, never on the per-event hot path.
+///
+/// A statement that *runs* but returns no rows means binary logging is disabled
+/// — that is a definitive answer, so we surface it rather than falling back.
 async fn current_binlog_position(conn: &mut Conn) -> Result<(String, u64), FaucetError> {
-    let row: Option<Row> = conn
-        .query_first("SHOW MASTER STATUS")
-        .await
-        .map_err(|e| FaucetError::Source(format!("mysql-cdc: SHOW MASTER STATUS failed: {e}")))?;
+    let (row, stmt): (Option<Row>, &str) = match conn.query_first("SHOW BINARY LOG STATUS").await {
+        Ok(row) => (row, "SHOW BINARY LOG STATUS"),
+        // The 8.4+ spelling was rejected (older server) — fall back.
+        Err(new_err) => match conn.query_first("SHOW MASTER STATUS").await {
+            Ok(row) => (row, "SHOW MASTER STATUS"),
+            Err(old_err) => {
+                return Err(FaucetError::Source(format!(
+                    "mysql-cdc: reading current binlog position failed — \
+                         `SHOW BINARY LOG STATUS`: {new_err}; `SHOW MASTER STATUS`: {old_err}"
+                )));
+            }
+        },
+    };
     let row = row.ok_or_else(|| {
-        FaucetError::Source(
-            "mysql-cdc: SHOW MASTER STATUS returned no rows; is binary logging enabled?".into(),
-        )
+        FaucetError::Source(format!(
+            "mysql-cdc: {stmt} returned no rows; is binary logging enabled?"
+        ))
     })?;
-    let file: String = row.get(0).ok_or_else(|| {
-        FaucetError::Source("mysql-cdc: SHOW MASTER STATUS: missing File column".into())
-    })?;
+    let file: String = row
+        .get(0)
+        .ok_or_else(|| FaucetError::Source(format!("mysql-cdc: {stmt}: missing File column")))?;
     let pos: u64 = row.get(1).ok_or_else(|| {
-        FaucetError::Source("mysql-cdc: SHOW MASTER STATUS: missing Position column".into())
+        FaucetError::Source(format!("mysql-cdc: {stmt}: missing Position column"))
     })?;
     Ok((file, pos))
 }

--- a/crates/source/mysql-cdc/src/stream.rs
+++ b/crates/source/mysql-cdc/src/stream.rs
@@ -598,23 +598,46 @@ async fn current_binlog_position(conn: &mut Conn) -> Result<(String, u64), Fauce
         // The 8.4+ spelling was rejected (older server) — fall back.
         Err(new_err) => match conn.query_first("SHOW MASTER STATUS").await {
             Ok(row) => (row, "SHOW MASTER STATUS"),
-            Err(old_err) => {
-                return Err(FaucetError::Source(format!(
-                    "mysql-cdc: reading current binlog position failed — \
-                         `SHOW BINARY LOG STATUS`: {new_err}; `SHOW MASTER STATUS`: {old_err}"
-                )));
-            }
+            Err(old_err) => return Err(binlog_position_error(new_err, old_err)),
         },
     };
-    let row = row.ok_or_else(|| {
+    // Pull the raw `File` / `Position` columns out of the row (the only
+    // server-dependent step), then hand the pure optionals to a unit-testable
+    // decoder so the no-rows / missing-column branches need no live server.
+    let extracted = row.map(|r| (r.get::<String, _>(0), r.get::<u64, _>(1)));
+    finalize_binlog_position(extracted, stmt)
+}
+
+/// Error returned when *both* binlog-status statements are rejected — which
+/// should never happen on a connected server, since at least one spelling is
+/// valid for any supported version. Pulled out so its message is unit-testable.
+fn binlog_position_error(
+    new_err: impl std::fmt::Display,
+    old_err: impl std::fmt::Display,
+) -> FaucetError {
+    FaucetError::Source(format!(
+        "mysql-cdc: reading current binlog position failed — \
+         `SHOW BINARY LOG STATUS`: {new_err}; `SHOW MASTER STATUS`: {old_err}"
+    ))
+}
+
+/// Turn the raw `(File, Position)` columns of a binlog-status row into binlog
+/// coordinates. `extracted` is `None` when the statement returned no rows
+/// (binary logging disabled); the inner options are `None` when a column is
+/// absent. Pure (no I/O) so every branch — no-rows, missing-column, success —
+/// is unit-testable without a live server. `stmt` names the statement for errors.
+fn finalize_binlog_position(
+    extracted: Option<(Option<String>, Option<u64>)>,
+    stmt: &str,
+) -> Result<(String, u64), FaucetError> {
+    let (file, pos) = extracted.ok_or_else(|| {
         FaucetError::Source(format!(
             "mysql-cdc: {stmt} returned no rows; is binary logging enabled?"
         ))
     })?;
-    let file: String = row
-        .get(0)
-        .ok_or_else(|| FaucetError::Source(format!("mysql-cdc: {stmt}: missing File column")))?;
-    let pos: u64 = row.get(1).ok_or_else(|| {
+    let file =
+        file.ok_or_else(|| FaucetError::Source(format!("mysql-cdc: {stmt}: missing File column")))?;
+    let pos = pos.ok_or_else(|| {
         FaucetError::Source(format!("mysql-cdc: {stmt}: missing Position column"))
     })?;
     Ok((file, pos))
@@ -876,6 +899,54 @@ mod tests {
     use super::*;
     use crate::state::Bookmark;
     use serde_json::json;
+
+    // ── binlog position decoding (MySQL 8.4 fallback, #242) ───────────────────
+
+    #[test]
+    fn finalize_binlog_position_returns_file_and_pos() {
+        let got = finalize_binlog_position(Some((Some("mysql-bin.000007".into()), Some(154))), "S")
+            .expect("valid row decodes");
+        assert_eq!(got, ("mysql-bin.000007".to_string(), 154));
+    }
+
+    #[test]
+    fn finalize_binlog_position_no_rows_means_binlogging_disabled() {
+        let err = finalize_binlog_position(None, "SHOW BINARY LOG STATUS")
+            .expect_err("no rows must error");
+        let msg = err.to_string();
+        assert!(msg.contains("returned no rows"), "{msg}");
+        assert!(msg.contains("SHOW BINARY LOG STATUS"), "{msg}");
+    }
+
+    #[test]
+    fn finalize_binlog_position_missing_file_column() {
+        let err = finalize_binlog_position(Some((None, Some(4))), "SHOW MASTER STATUS")
+            .expect_err("missing File must error");
+        assert!(err.to_string().contains("missing File column"), "{err}");
+    }
+
+    #[test]
+    fn finalize_binlog_position_missing_position_column() {
+        let err = finalize_binlog_position(
+            Some((Some("mysql-bin.1".into()), None)),
+            "SHOW MASTER STATUS",
+        )
+        .expect_err("missing Position must error");
+        assert!(err.to_string().contains("missing Position column"), "{err}");
+    }
+
+    #[test]
+    fn binlog_position_error_names_both_statements() {
+        let msg = binlog_position_error("parse error NEW", "parse error OLD").to_string();
+        assert!(
+            msg.contains("SHOW BINARY LOG STATUS") && msg.contains("parse error NEW"),
+            "{msg}"
+        );
+        assert!(
+            msg.contains("SHOW MASTER STATUS") && msg.contains("parse error OLD"),
+            "{msg}"
+        );
+    }
 
     // ── resolve_start precedence ──────────────────────────────────────────────
 

--- a/crates/source/mysql-cdc/tests/integration.rs
+++ b/crates/source/mysql-cdc/tests/integration.rs
@@ -48,12 +48,22 @@ fn startup_limit() -> &'static tokio::sync::Semaphore {
 /// having no password, so the connection URL is
 /// `mysql://root@127.0.0.1:<port>/test`.
 async fn start_mysql_cdc() -> (ContainerAsync<Mysql>, String) {
+    // The `Mysql` module's default tag is 8.1; pin it explicitly so this and the
+    // 8.4-specific test below differ only by version.
+    start_mysql_cdc_tagged("8.1").await
+}
+
+/// Start a MySQL container at a specific image tag with the binlog options
+/// required for CDC. Lets a test pick the server version (e.g. `8.4`, where
+/// `SHOW MASTER STATUS` was removed in favour of `SHOW BINARY LOG STATUS`).
+async fn start_mysql_cdc_tagged(tag: &str) -> (ContainerAsync<Mysql>, String) {
     let _permit = startup_limit()
         .acquire()
         .await
         .expect("startup semaphore closed");
 
     let container = Mysql::default()
+        .with_tag(tag)
         .with_cmd([
             "--server-id=1",
             "--log-bin=mysql-bin",
@@ -421,5 +431,32 @@ async fn capture_resume_position_returns_file_and_pos() {
     assert!(
         pos.get("pos").and_then(|v| v.as_u64()).is_some(),
         "pos present: {pos}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn capture_resume_position_works_on_mysql_8_4() {
+    // MySQL 8.4 removed `SHOW MASTER STATUS` (replaced by `SHOW BINARY LOG
+    // STATUS`). The CDC source must capture the current binlog coordinates on
+    // 8.4 too — both for `start_position: current` and for `faucet replicate`'s
+    // pre-snapshot position capture (#189). Regression guard for #242.
+    let (_container, url) = start_mysql_cdc_tagged("8.4").await;
+    let source = MysqlCdcSource::new(build_config(&url))
+        .await
+        .expect("source new on MySQL 8.4");
+    let pos = source
+        .capture_resume_position()
+        .await
+        .expect("capture_resume_position must succeed on MySQL 8.4")
+        .expect("mysql-cdc must capture a position");
+    assert!(
+        pos.get("file")
+            .and_then(|v| v.as_str())
+            .is_some_and(|f| !f.is_empty()),
+        "binlog file present: {pos}"
+    );
+    assert!(
+        pos.get("pos").and_then(|v| v.as_u64()).is_some(),
+        "binlog pos present: {pos}"
     );
 }


### PR DESCRIPTION
## Summary

`faucet-source-mysql-cdc` resolved the server's current binlog coordinates with `SHOW MASTER STATUS` only. That statement was **removed in MySQL 8.4** (the current LTS), replaced by `SHOW BINARY LOG STATUS`. So on 8.4+ both `start_position: current` and `capture_resume_position()` (the pre-snapshot position anchor used by `faucet replicate`, #189) failed with `ERROR 1064`.

## Fix

In `current_binlog_position` (the helper shared by `resolve_current` and `capture_resume_position`):

- Try `SHOW BINARY LOG STATUS` first (MySQL 8.4+), fall back to `SHOW MASTER STATUS` when the server rejects it (5.7 / 8.0 raise a parse error). One code path works across **5.7 / 8.0 / 8.4+** with no version parsing or extra hot-path round-trips (only the start/capture path is affected).
- A statement that *runs* but returns no rows (binary logging disabled) is surfaced as a definitive error rather than triggering the fallback.

## Tests (TDD)

- New `capture_resume_position_works_on_mysql_8_4` integration test against a **MySQL 8.4** image — written test-first, confirmed RED on the old code (`SHOW MASTER STATUS failed: ERROR 1064 … near 'MASTER STATUS'`), GREEN after the fix.
- The existing `capture_resume_position_returns_file_and_pos` test (default 8.1 image) now exercises the **fallback** path, since 8.1 lacks `SHOW BINARY LOG STATUS`. Both pass (`2 passed`).
- The container helper was refactored to `start_mysql_cdc_tagged(tag)` so the two tests differ only by server version.

## Docs

- `crates/source/mysql-cdc/README.md`: added a 5.7 / 8.0 / 8.4+ compatibility note and dropped the now-inaccurate `SHOW MASTER STATUS` reference.

Closes #242