### PR TITLE
fix(release-plz): per-package changelogs — fix broken release-PR changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (see the versioning policy in CONTRIBUTING.md — connector crates version
 independently).
+
+> [!NOTE]
+> **This file is a frozen historical archive.** As of #248, releases are
+> tracked in **per-package changelogs** — each crate has its own
+> `CHANGELOG.md` in its directory (e.g. `crates/core/CHANGELOG.md`,
+> `cli/CHANGELOG.md`, `faucet-stream/CHANGELOG.md`), maintained automatically
+> by release-plz. This root file preserves the consolidated history up to and
+> including the 1.1.0 release; new entries are **not** added here.
+
 ## [Unreleased]
 
 ## `faucet-cli` — [1.1.0](https://github.com/PawanSikawat/faucet-stream/compare/faucet-cli-v1.0.1...faucet-cli-v1.1.0) - 2026-06-12

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,13 +1,14 @@
 # git-cliff configuration — manual `git cliff` invocations only.
 #
-# As of #97, `CHANGELOG.md` is auto-maintained by release-plz on every
-# release PR (config: /release-plz.toml, [changelog] block). This file is
-# retained for one-off `git cliff` runs (e.g. regenerating the full history
-# from scratch, or previewing the unreleased section locally without going
-# through release-plz):
+# As of #97, changelogs are auto-maintained by release-plz on every release
+# PR (config: /release-plz.toml, [changelog] block). As of #248 they are
+# **per-package** — each crate has its own `CHANGELOG.md`; the root
+# `./CHANGELOG.md` is a frozen historical archive that release-plz no longer
+# touches. This file is retained for one-off `git cliff` runs (e.g. previewing
+# the unreleased section locally without going through release-plz):
 #
-#   git cliff -o CHANGELOG.md                       # regenerate the whole file
-#   git cliff --unreleased --prepend CHANGELOG.md   # preview unreleased section
+#   git cliff --unreleased                          # preview unreleased section
+#   git cliff -o CHANGELOG.md                       # regenerate a consolidated view
 #
 # See https://git-cliff.org
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -28,12 +28,19 @@ git_tag_name = "{{ package }}-v{{ version }}"
 # notes use the changelog body template below.
 git_release_enable = true
 
-# Aggregate every bumped crate's changelog entries into the single root
-# CHANGELOG.md (already managed by the project today). Per-crate
-# CHANGELOG.md files in 45 separate locations would be noisy for a
-# marketplace-style workspace; one repo-level file matches the existing
-# layout and CHANGELOG.md badge in the README.
-changelog_path = "./CHANGELOG.md"
+# Per-package changelogs (release-plz default): each crate's entries go to a
+# `CHANGELOG.md` in that crate's own directory (e.g. crates/core/CHANGELOG.md).
+# We do NOT set `changelog_path`, so release-plz uses this default.
+#
+# Why not one shared CHANGELOG.md? release-plz reads the existing changelog
+# with the `parse_changelog` crate, which requires every release heading to
+# LEAD with the version (`## [x.y.z] …`). A single shared file needs the
+# package name in the heading to disambiguate crates (`## `pkg` — [x.y.z]`),
+# which `parse_changelog` cannot parse — so it fell back to the oldest legacy
+# `## [0.2.0]` section and emitted wrong release notes for every release PR
+# (#248). Per-package files keep the version leading the heading, so the
+# parser is happy. The historical aggregated `./CHANGELOG.md` is preserved
+# in the repo as a frozen archive (release-plz no longer touches it).
 
 # Crates.io sparse-index propagation: release-plz publishes in dependency
 # order and polls between dependent publishes until each new version is
@@ -73,11 +80,13 @@ release_always = false
 # desired once the registry is stable.
 semver_check = false
 
-# Changelog body template — mirrors cliff.toml so rendered output looks the
-# same as past entries. release-plz uses git-cliff internally but no longer
-# honours the deprecated `changelog_config = "cliff.toml"` pointer, so the
-# template is inlined here. `cliff.toml` is retained for manual `git cliff`
-# invocations on demand.
+# Changelog body template. The H2 heading MUST lead with the version so
+# release-plz's `parse_changelog`-based reader can recognize each release
+# section (see #248). Because changelogs are now per-package, the file itself
+# is the package context — no package name in the heading is needed. release-plz
+# uses git-cliff internally but no longer honours the deprecated
+# `changelog_config = "cliff.toml"` pointer, so the template is inlined here.
+# `cliff.toml` is retained for manual `git cliff` invocations on demand.
 [changelog]
 header = """# Changelog
 
@@ -90,7 +99,7 @@ independently).
 """
 
 body = """
-## `{{ package }}` — [{{ version }}]{%- if release_link %}({{ release_link }}){% endif %} - {{ timestamp | date(format="%Y-%m-%d") }}
+## [{{ version }}]{%- if release_link %}({{ release_link }}){% endif %} - {{ timestamp | date(format="%Y-%m-%d") }}
 {% for group, commits in commits | group_by(attribute="group") %}
 ### {{ group | upper_first }}
 {% for commit in commits %}


### PR DESCRIPTION
## Problem

Every release-plz "chore: release" PR rendered an **incorrect changelog**. Each crate's release notes (PR description + per-crate GitHub release) showed the ancient `## [0.2.0] - 2026-04-03` section copied verbatim from the bottom of `CHANGELOG.md` — including the dead `- {{crate_name}} v{{version}}` template literal — instead of that crate's actual changes. On PR #243 the six crates with real changes (`faucet-core`, `faucet-cli`, `faucet-sink-bigquery`, the three CDC sources) also got **no entry at all**. Confirmed on #238 and #243.

## Root cause (source-confirmed)

The single shared `CHANGELOG.md` used package-name-prefixed headings:

```
## `faucet-core` — [1.2.0](…) - 2026-06-15
```

release-plz reads existing changelogs with the [`parse_changelog`](https://github.com/taiki-e/parse-changelog) crate. Its default config requires the heading to **lead with the version** (after an optional `v`/`Version `/`Release ` prefix):

- prefix `^(v|Version |Release )?`
- version `^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-…)?(\+…)?$|^Unreleased$`

Our headings lead with the package name, so **every** per-package section is rejected and the parser falls through to the first heading whose first token *is* a version — the legacy, pre-release-plz `## [0.2.0]` at the bottom. That drove the wrong release notes (every PR) and the dropped bodies (#243, worsening as the file grows).

The release-plz maintainers' own workspace uses **one changelog file per crate** with version-leading headings — which is why their parser is happy.

## Fix

Switch to release-plz's native **per-package changelog** model:

- **`release-plz.toml`**: removed `changelog_path = "./CHANGELOG.md"` so each crate gets its own `CHANGELOG.md` (release-plz default), and changed the `[changelog].body` heading to lead with the version (`## [{{ version }}]…`, package name dropped — the file is the package context now).
- **Root `CHANGELOG.md`**: preserved **byte-for-byte as a frozen historical archive** (all history through 1.1.0). release-plz no longer reads or writes it; added a one-line note pointing to the per-package files.
- Docs synced: `cliff.toml` comment (+ local `.claude/rules/publishing.md`).

Tags (`{{ package }}-v{{ version }}`, all 135), `git_release_enable`, `release_commits`, `semver_check`, and `publish_timeout` are unchanged.

## Validation

Reproduced with a live **release-plz 0.3.159** run using this exact `[changelog]` config on a synthetic workspace (network here can't download all 56 published crates for the real repo). Results:

- Wrote `crates/<crate>/CHANGELOG.md` in the crate's own directory; **did not create/modify a root `CHANGELOG.md`** → confirms the root file stays frozen.
- Heading rendered `## [0.1.0](…compare…) - 2026-06-15` — the version-leading format `parse_changelog` accepts.
- Real commit bodies rendered correctly (feat under `### Features`, scope shown); no `{{crate_name}}` literal, no `[0.2.0]` fallback.
- A dependency-only crate with no own `feat`/`fix`/`perf` was correctly skipped.

The broken behavior itself is already demonstrated in production by #243 and #238.

## Note on the open release PR

Once this lands on `main`, release-plz regenerates the release PR with per-package changelogs. The current broken release PR (#243) should be closed/superseded so a fresh, correct one is produced.

Closes #248
