### PR TITLE
docs: extensive standardized READMEs for all crates + badge/category fixes

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -1,5 +1,10 @@
 # faucet-cli
 
+[![Crates.io](https://img.shields.io/crates/v/faucet-cli.svg)](https://crates.io/crates/faucet-cli)
+[![Docs.rs](https://docs.rs/faucet-cli/badge.svg)](https://docs.rs/faucet-cli)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-cli.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-cli.svg)](https://github.com/PawanSikawat/faucet-stream#license)
+
 `faucet` — config-driven runner for [`faucet-stream`](https://crates.io/crates/faucet-stream) pipelines.
 
 Write a YAML or JSON file describing a source, optional transforms, a sink, and (optionally) a state store. Run it with the `faucet` binary. No Rust code required.
@@ -955,6 +960,34 @@ tracing_subscriber::registry().with(otel_layer).init();
 
 Faucet does not bundle an OTel exporter — wire your own to keep dependencies minimal.
 
+## Troubleshooting / FAQ
+
+**"No config file found" / wrong file picked up.** With no path argument, `faucet` auto-discovers `faucet.yaml`, then `faucet.yml`, then `faucet.json` in the current directory. Pass the path explicitly (`faucet run path/to/pipeline.yaml`) when the file lives elsewhere or has a different name.
+
+**Environment variables / `.env` not applied.** `faucet` loads a `.env` from the current directory by default; point at another with `--env-file path/.env`, or disable loading entirely with `--no-env-file`. `${env:VAR}` / `${file:PATH}` placeholders resolve at config-load time, so the var must be set (or the `.env` loaded) before the command runs.
+
+**"unknown source/sink type" or a connector seems missing.** Connectors are feature-gated. A slim build (`--no-default-features --features …`) only includes the connectors you compiled in. Run `faucet list` to see exactly which sources, sinks, transforms, and state backends are present in your binary; reinstall with the needed `--features` (or the `full` feature) if one is absent.
+
+**`faucet validate` fails.** Validation parses the config, expands the matrix, and checks every connector/transform spec (plus exactly-once and write-mode gates) without running. The error names the offending matrix row and field. Use `faucet validate --show-composed` to print the fully merged document (after `extends:` / `!include` / profiles) and `faucet schema source|sink|transform <name>` to confirm the expected field shape.
+
+**Secrets not resolving (`${vault:…}` / `${aws-sm:…}` / `${gcp-sm:…}` / `${azure-kv:…}`).** Secrets resolution is feature-gated — install with the matching `secrets-*` feature (or the `secrets` aggregate). Run `faucet validate` (without `--no-secrets`) as a real preflight: it fetches each reference and prints `secret: <scheme>:<reference> → resolved`, surfacing missing credentials (e.g. `VAULT_ADDR`/`VAULT_TOKEN`, the AWS default chain, GCP ADC, Azure env/managed identity) before a run. Use `--no-secrets` to validate offline without contacting any secrets manager.
+
+**Pipeline runs but I see no records / no logs.** Pipeline records and command output go to **stdout**; logs go to **stderr**. Raise verbosity with `--log-level debug` or `FAUCET_LOG=debug`. Never enable debug logging on a pipeline whose connector configs hold resolved secrets — third-party connector debug output is outside faucet's redaction boundary.
+
+## See also
+
+- [`faucet-stream`](https://crates.io/crates/faucet-stream) — the umbrella library this CLI is built on.
+- [`faucet-core`](https://crates.io/crates/faucet-core) — shared traits, pipeline orchestration, and error types.
+- [Documentation site](https://pawansikawat.github.io/faucet-stream/) — guides, the connector capability matrix, and the config-file grammar reference.
+- [GitHub repository](https://github.com/PawanSikawat/faucet-stream) — source, examples (`cli/examples/`), and issue tracker.
+
 ## License
 
-MIT OR Apache-2.0
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](../LICENSE-APACHE) or <https://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](../LICENSE-MIT) or <https://opensource.org/licenses/MIT>)
+
+at your option.
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.

--- a/cli/README.md
+++ b/cli/README.md
@@ -759,12 +759,12 @@ File-shaped connectors (JSONL/CSV/S3/GCS source and sink) accept a `compression`
 version: 1
 pipeline:
   source:
-    kind: csv
+    type: csv
     config:
       path: data.csv.gz
       compression: auto      # or 'gzip', 'zstd', 'none'
   sink:
-    kind: jsonl
+    type: jsonl
     config:
       path: out.jsonl.zst
       compression: auto

--- a/crates/auth/README.md
+++ b/crates/auth/README.md
@@ -1,43 +1,105 @@
 # faucet-auth
 
-Shared, single-flight authentication providers for
-[`faucet-stream`](https://github.com/PawanSikawat/faucet-stream).
+[![Crates.io](https://img.shields.io/crates/v/faucet-auth.svg)](https://crates.io/crates/faucet-auth)
+[![Docs.rs](https://docs.rs/faucet-auth/badge.svg)](https://docs.rs/faucet-auth)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-auth.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-auth.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-These implement [`faucet_core::AuthProvider`] — a live entity that owns a token
-cache and refresh lifecycle. One instance, wrapped in an `Arc`, is shared across
-every connector that references it, so **N connectors hitting one identity
-provider share a single token with single-flight refresh** instead of each
-racing to refresh a single-active / rotating token.
+Shared, single-flight authentication providers for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem. Each provider implements [`faucet_core::AuthProvider`](https://docs.rs/faucet-core/latest/faucet_core/trait.AuthProvider.html) — a live entity that owns a token cache and refresh lifecycle.
 
-## Providers
+The point of this crate is **token sharing**: one provider instance, wrapped in an `Arc`, is handed to every connector that authenticates against the same identity provider. So N connectors (or N matrix rows) hitting one IdP share a **single** token with **single-flight** refresh, instead of each racing to mint or rotate its own. That is the difference between one token request per run and one per connector per refresh window — and, for rotating refresh tokens, the difference between working and invalidating each other.
 
-| `type`           | Provider                          | Notes |
-|------------------|-----------------------------------|-------|
-| `static`         | `StaticProvider`                  | Fixed pre-minted credential (bearer / header / basic). |
-| `oauth2`         | `OAuth2ClientCredentialsProvider` | OAuth2 `client_credentials` grant. |
-| `oauth2_refresh` | `OAuth2RefreshProvider`           | OAuth2 `refresh_token` grant with refresh-token **rotation capture**. |
-| `token_endpoint` | `TokenEndpointProvider`           | Fetch a token from any HTTP endpoint, extract via JSONPath. |
+## Feature highlights
 
-### Token caching & refresh
+- **Four provider types** — a fixed static credential, OAuth2 `client_credentials`, OAuth2 `refresh_token` with **rotation capture**, and a generic JSONPath-extracting token endpoint.
+- **Single-flight refresh** — concurrent callers during a refresh await the one in-flight fetch; they don't stampede the token endpoint.
+- **Force-refresh on rejection** — a connector that gets a `401` calls `invalidate(stale)` and receives a freshly-fetched token. Concurrent invalidations of the same token collapse into one refresh via compare-and-swap.
+- **Refresh-token rotation capture** — `oauth2_refresh` captures a rotated `refresh_token` from each response in place, so a single active access token plus a rotating refresh token can be shared safely across many connectors.
+- **Secret-safe `Debug`** — every provider's `Debug` impl renders secrets (`client_secret`, refresh token, request body, cached access token) as `***`; only non-secret identifiers stay visible.
+- **Bounded fetch timeout** — providers hold a single-flight mutex across the network call, so the internal HTTP client has a 30 s request timeout: a hung IdP fails and releases the lock instead of wedging every connector that shares the provider.
+- **Validated config at load time** — `expiry_ratio` is checked to be a finite number in `(0, 1]`; unknown provider `type`s and missing required fields surface as `FaucetError::Config` before any run starts.
 
-The three fetching providers (`oauth2`, `oauth2_refresh`, `token_endpoint`)
-cache the token until `expires_in × expiry_ratio` has elapsed, then refresh
-single-flight. All three also support **force-refresh on rejection**: a
-connector that gets a `401` calls `invalidate(stale)` and receives a
-freshly-fetched token (concurrent invalidations of the same token collapse into
-one refresh).
+## Installation
 
-`expiry_ratio` (default `0.9`) must be a finite number in `(0, 1]` — it is
-validated at construction. A value `≤ 0` would expire every token immediately
-(defeating the cache); a value `> 1` would use a token past its real expiry
-(causing `401`s mid-use).
+```bash
+# As a library:
+cargo add faucet-auth
 
-## CLI usage
+# In the CLI, the shared `auth:` catalog is always available — no feature flag needed.
+# Library callers who want the umbrella crate to build providers enable the `auth` feature:
+cargo add faucet-stream --features auth
+```
 
-Define a provider once in the top-level `auth:` catalog and reference it from any
-connector via `auth: { ref: <name> }`:
+The `faucet-cli` binary always links `faucet-auth` to power the top-level `auth:` catalog, so config-driven users get every provider type out of the box.
+
+## What it provides
+
+| `type` (config) | Rust type | What it does |
+|-----------------|-----------|--------------|
+| `static` | [`StaticProvider`] | Returns a fixed, pre-minted credential forever — bearer token, custom header, or HTTP Basic. No network calls. |
+| `oauth2` | [`OAuth2ClientCredentialsProvider`] | OAuth2 `client_credentials` grant. Fetches a token from the token endpoint, caches it, refreshes single-flight. |
+| `oauth2_refresh` | [`OAuth2RefreshProvider`] | OAuth2 `refresh_token` grant with refresh-token **rotation capture** (a single active access token + a rotating refresh token, shared safely). |
+| `token_endpoint` | [`TokenEndpointProvider`] | Fetches a token from any HTTP endpoint and extracts it from the JSON response via JSONPath. The escape hatch for non-standard token APIs. |
+
+`build_provider(&Value)` is the entry point: it reads a `{ type, config }` spec and returns a `SharedAuthProvider` (`Arc<dyn AuthProvider>`).
+
+[`StaticProvider`]: https://docs.rs/faucet-auth/latest/faucet_auth/struct.StaticProvider.html
+[`OAuth2ClientCredentialsProvider`]: https://docs.rs/faucet-auth/latest/faucet_auth/struct.OAuth2ClientCredentialsProvider.html
+[`OAuth2RefreshProvider`]: https://docs.rs/faucet-auth/latest/faucet_auth/struct.OAuth2RefreshProvider.html
+[`TokenEndpointProvider`]: https://docs.rs/faucet-auth/latest/faucet_auth/struct.TokenEndpointProvider.html
+
+## Provider configuration reference
+
+Every provider is built from a `{ type, config }` object — the project-wide adjacently-tagged auth shape. The fields below are the keys inside each provider's `config`.
+
+### `static`
+
+A fixed credential. Exactly one of the three shapes below must be present.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `token` | string | — | Bearer token → `Authorization: Bearer <token>`. |
+| `header` + `value` | string + string | — | A custom header credential (e.g. `X-Api-Key`). Both keys required together. |
+| `username` + `password` | string + string | — | HTTP Basic credentials. Both keys required together. |
+
+### `oauth2` (client-credentials)
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `token_url` | string | — *(required)* | OAuth2 token endpoint. |
+| `client_id` | string | — *(required)* | OAuth2 client ID. |
+| `client_secret` | string | — *(required)* | OAuth2 client secret. |
+| `scopes` | array of string | `[]` | Scopes, sent space-joined as the `scope` form field. |
+| `expiry_ratio` | number | `0.9` | Refresh after `expires_in × expiry_ratio` seconds. Must be a finite number in `(0, 1]`. |
+
+### `oauth2_refresh`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `token_url` | string | — *(required)* | OAuth2 token endpoint. |
+| `client_id` | string | — *(required)* | OAuth2 client ID. |
+| `client_secret` | string | — *(required)* | OAuth2 client secret. |
+| `refresh_token` | string | — *(required)* | Initial refresh token. A rotated token in the response is captured in place for the next refresh. |
+| `expiry_ratio` | number | `0.9` | Refresh after `expires_in × expiry_ratio` seconds. Must be a finite number in `(0, 1]`. |
+
+### `token_endpoint`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `url` | string | — *(required)* | HTTP endpoint to fetch the token from. |
+| `method` | string | `POST` | HTTP method. |
+| `body` | object | *(none)* | JSON request body (e.g. carrying `client_id` / `client_secret`). Omit for a GET. |
+| `token_path` | string | — *(required)* | JSONPath selecting the token from the response (e.g. `$.auth.access_token`). String and numeric matches are accepted. |
+| `expiry_path` | string | *(none)* | JSONPath selecting `expires_in` (seconds) from the response. When absent, the token is cached without an expiry. |
+| `expiry_ratio` | number | `0.9` | Refresh after `expires_in × expiry_ratio` seconds. Must be a finite number in `(0, 1]`. |
+
+## CLI usage — the top-level `auth:` catalog
+
+Define a provider **once** in the top-level `auth:` catalog, then reference it from any connector via `auth: { ref: <name> }`. The CLI builds each named provider a single time and injects the same `Arc` into every connector that references it, so all the rows that share a `ref` share one token.
 
 ```yaml
+# faucet run pipeline.yaml
+version: 1
 auth:
   sf:
     type: oauth2_refresh
@@ -52,22 +114,114 @@ pipeline:
       kind: snowflake
       config:
         account: ${vars.account}
-        auth: { ref: sf }     # every row sharing this template shares ONE token
+        auth: { ref: sf }      # every row using this template shares ONE token
+  sink:
+    type: jsonl
+    config:
+      path: ./out.jsonl
 ```
+
+Eight connectors consume shared providers via `auth: { ref }`: `rest`, `graphql`, `xml`, `grpc`, `websocket`, `sink-http`, `elasticsearch`, and `snowflake`. (Kafka / BigQuery / GCS keep the same `{ type, config }` wire shape but are not bearer/token-based, so they don't take `auth: { ref }`.)
+
+Provider configs can hold `${env:…}` / `${file:…}` / `${secret:…}` / `${vault:…}` / `${aws-sm:…}` indirection — the secrets pass walks the `auth:` catalog, so a single shared provider can hold a secret-manager reference and be reused across every row.
+
+### Inline auth vs shared provider
+
+A connector's `auth` field accepts **either** an inline `{ type, config }` block **or** a `{ ref: <name> }` pointer. Use a `ref` (and the `auth:` catalog) whenever more than one connector / matrix row authenticates against the same IdP — that's when token sharing and single-flight refresh actually pay off. A one-off connector can keep its auth inline.
 
 ## Library usage
 
+Build a provider, wrap it in an `Arc`, and clone it into every source/sink that should share the token via `with_auth_provider`:
+
 ```rust
 use std::sync::Arc;
-use faucet_auth::OAuth2RefreshProvider;
+use faucet_auth::{build_provider, OAuth2RefreshProvider};
 use faucet_core::SharedAuthProvider;
+use serde_json::json;
 
-let provider: SharedAuthProvider = Arc::new(OAuth2RefreshProvider::from_config(&cfg)?);
-// Clone the Arc into every connector that should share the token:
-let source_a = MySource::new(cfg_a, Some(provider.clone()));
-let source_b = MySource::new(cfg_b, Some(provider.clone()));
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+// Build directly from a typed config object…
+let provider: SharedAuthProvider = Arc::new(OAuth2RefreshProvider::from_config(&json!({
+    "token_url": "https://idp.example/token",
+    "client_id": "my-client",
+    "client_secret": "s3cr3t",
+    "refresh_token": "initial-rt",
+}))?);
+
+// …or from a `{ type, config }` spec, the same shape the CLI catalog uses:
+let provider2: SharedAuthProvider = build_provider(&json!({
+    "type": "oauth2",
+    "config": {
+        "token_url": "https://idp.example/token",
+        "client_id": "my-client",
+        "client_secret": "s3cr3t",
+        "scopes": ["read"]
+    }
+}))?;
+# let _ = (provider2,);
+
+// Clone the Arc into every connector that should share the one token:
+// let source_a = RestStreamSource::new(cfg_a)?.with_auth_provider(provider.clone());
+// let source_b = RestStreamSource::new(cfg_b)?.with_auth_provider(provider.clone());
+# let _ = provider;
+# Ok(())
+# }
 ```
+
+Asking the provider for a credential is then a one-liner; the cache, refresh, and single-flight coordination are internal:
+
+```rust,no_run
+use faucet_core::{AuthProvider, Credential};
+# async fn use_provider(provider: &dyn AuthProvider) -> Result<(), Box<dyn std::error::Error>> {
+let cred: Credential = provider.credential().await?;     // cached or freshly refreshed
+// On a 401, force a single-flight refresh of exactly this stale token:
+let fresh = provider.invalidate(&cred).await?;
+# let _ = fresh;
+# Ok(())
+# }
+```
+
+## How single-flight refresh works
+
+Each fetching provider (`oauth2`, `oauth2_refresh`, `token_endpoint`) holds a `Mutex`-guarded token cache and performs the token-endpoint call **with the lock held**:
+
+1. **Cache hit** — `credential()` returns the cached token until `expires_in × expiry_ratio` has elapsed.
+2. **Cache miss / expiry** — the first caller takes the lock and fetches; concurrent callers block on the same lock and, when it's released, observe the freshly-cached token. Result: **one** network fetch serves an arbitrary number of concurrent callers.
+3. **Force-refresh on `401`** — a connector whose request was rejected calls `invalidate(stale)`. This is a compare-and-swap: it refetches **only** if the cache still holds the `stale` token. If a concurrent caller already refreshed (the cache now holds a *different* token), the stale caller gets that new token back without a second fetch.
+4. **Rotation capture** (`oauth2_refresh` only) — each refresh response may carry a rotated `refresh_token`; the provider stores it in place, so the next refresh uses the latest rotated token. This is exactly the case that breaks when each connector keeps its own copy of a rotating refresh token.
+
+The internal HTTP client has a bounded 30 s request timeout so a hung or unreachable IdP fails the fetch and releases the single-flight lock, rather than wedging every connector that shares the provider.
+
+`expiry_ratio` (default `0.9`) must be a finite number in `(0, 1]`, validated at construction. A value `≤ 0` (or `NaN`) would expire every token immediately, defeating the cache and single-flight refresh; a value `> 1` would treat the token as valid past its real expiry, causing `401`s mid-use. Both are rejected at config-load time.
+
+## Feature flags
+
+This crate has no optional Cargo features of its own. It is pulled in by:
+
+- the **`faucet-cli`** binary (always — for the top-level `auth:` catalog);
+- the **`faucet-stream`** umbrella crate's `auth` feature, for library callers who want `build_provider` available alongside the connectors.
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause & fix |
+|---------|--------------------|
+| `Config: auth provider: unknown type ...` | The `type` isn't one of `static` / `oauth2` / `oauth2_refresh` / `token_endpoint`. Check the spelling. |
+| `Config: ... missing 'type'` | The provider spec has no `type` key. Each `auth:` catalog entry needs `{ type, config }`. |
+| `Config: oauth2 auth provider: missing 'client_id'` (or `token_url` / `client_secret` / `refresh_token`) | A required OAuth2 field is absent. All of `token_url`, `client_id`, `client_secret` are required; `oauth2_refresh` also requires `refresh_token`. |
+| `Config: static auth provider: config must contain ...` | The `static` config didn't match `token`, `header`+`value`, or `username`+`password`. Provide exactly one of those shapes. |
+| `Config: ... 'expiry_ratio' must be a finite number in (0, 1]` | `expiry_ratio` is out of range or non-numeric. Use a value like `0.9`; remove the field to take the default. |
+| `Auth: OAuth2 token request failed (HTTP 401): ...` | The IdP rejected the client credentials / refresh token. Verify `client_id` / `client_secret`, and that the `refresh_token` hasn't already been rotated/revoked by a stale copy elsewhere — share **one** `oauth2_refresh` provider via `auth: { ref }`. |
+| `Auth: token endpoint request failed (HTTP ...)` | The `token_endpoint` `url` returned a non-2xx. Check the URL, `method`, and `body`. |
+| `Auth: token_path '...' did not match a string value` | The `token_path` JSONPath didn't select a string/number in the response. Inspect the real response body and fix the path (e.g. `$.auth.access_token`). |
+| Token endpoint hangs the whole pipeline | A single-flight fetch is blocked. Providers cap each fetch at 30 s, after which the lock is released and the call fails with `FaucetError`; check IdP reachability and the `token_url`. |
+| Every request re-fetches a token | An `expiry_ratio` near 0 (or a missing `expiry_path` on `token_endpoint` combined with no caching expectation) shortens the cache window. Set a sensible `expiry_ratio` and an `expiry_path` that selects the response's TTL. |
+
+## See also
+
+- [Authentication cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/auth.html) — the full `{ type, config }` vs `{ ref }` model, per-connector auth methods, and the shared `auth:` catalog.
+- [Secrets cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/secrets.html) — feeding `${secret:…}` / `${vault:…}` references into provider configs.
+- [`faucet-core`](https://crates.io/crates/faucet-core) — defines the [`AuthProvider`](https://docs.rs/faucet-core/latest/faucet_core/trait.AuthProvider.html) trait, [`Credential`](https://docs.rs/faucet-core/latest/faucet_core/enum.Credential.html) enum, and `SharedAuthProvider` / `AuthSpec` types this crate implements against.
 
 ## License
 
-MIT OR Apache-2.0
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/auth/README.md
+++ b/crates/auth/README.md
@@ -111,7 +111,7 @@ auth:
 pipeline:
   sources:
     sf_table:
-      kind: snowflake
+      type: snowflake
       config:
         account: ${vars.account}
         auth: { ref: sf }      # every row using this template shares ONE token

--- a/crates/common/bigquery/README.md
+++ b/crates/common/bigquery/README.md
@@ -1,21 +1,121 @@
 # faucet-common-bigquery
 
-Shared credential configuration and client construction for the BigQuery source and sink connectors in the [`faucet-stream`](https://crates.io/crates/faucet-stream) ecosystem.
+[![Crates.io](https://img.shields.io/crates/v/faucet-common-bigquery.svg)](https://crates.io/crates/faucet-common-bigquery)
+[![Docs.rs](https://docs.rs/faucet-common-bigquery/badge.svg)](https://docs.rs/faucet-common-bigquery)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-common-bigquery.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-common-bigquery.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-## Contents
+Shared Google BigQuery credentials and client construction for the BigQuery source and sink connectors. Part of the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
 
-- `BigQueryCredentials` — credential source: `ServiceAccountKeyPath(String)`, `ServiceAccountKey(String)` (inline JSON), or `ApplicationDefault`. Derives `Serialize`, `Deserialize`, `JsonSchema`. Its `Debug` impl masks inline JSON as `"***"`.
-- `build_client(&BigQueryCredentials)` — async helper that turns a `BigQueryCredentials` into a ready-to-use `gcp_bigquery_client::Client`.
+This is a small **internal/shared** crate: it holds the one credential enum and the one async client builder that both [`faucet-source-bigquery`](https://crates.io/crates/faucet-source-bigquery) and [`faucet-sink-bigquery`](https://crates.io/crates/faucet-sink-bigquery) need, so the two crates accept exactly the same auth shape and build their `gcp_bigquery_client::Client` the same way.
+
+## What it provides
+
+| Item | Kind | Description |
+|---|---|---|
+| `BigQueryCredentials` | `enum` | How to authenticate with BigQuery. Derives `Serialize`, `Deserialize`, `JsonSchema` so it round-trips through YAML/JSON configs and CLI schema introspection. Its `Debug` impl masks inline service-account JSON as `***` while leaving the key path visible. |
+| `build_client(&BigQueryCredentials)` | `async fn` | Turns a `BigQueryCredentials` into a ready-to-use [`gcp_bigquery_client::Client`]. Returns `FaucetError::Auth` on authentication failure or unparseable inline JSON. |
+
+### `BigQueryCredentials` variants
+
+Credentials serialize as `{ type: <method>, config: { … } }` (adjacent tagging, `snake_case` discriminators) — the consistent auth wire shape shared by every faucet connector.
+
+| `type` | `config` fields | Description |
+|---|---|---|
+| `service_account_key_path` | `path: String` | Path to a service-account JSON key file on disk. |
+| `service_account_key` | `json: String` | Inline service-account JSON key content (e.g. injected from a secrets manager). |
+| `application_default` | *(none)* | Use Application Default Credentials — workload identity, `gcloud auth application-default login`, or the `GOOGLE_APPLICATION_CREDENTIALS` env var. |
+
+Example YAML, as it appears inside a source/sink `credentials:` block:
+
+```yaml
+# Key file on disk
+credentials:
+  type: service_account_key_path
+  config:
+    path: /etc/faucet/bq-key.json
+
+# Inline JSON (often via a secret reference)
+credentials:
+  type: service_account_key
+  config:
+    json: ${secret:BQ_SA_JSON}
+
+# Application Default Credentials — no config
+credentials:
+  type: application_default
+```
+
+## Who should depend on this
+
+- **End users / pipeline authors** — you almost certainly **do not** depend on this crate directly. Install [`faucet-source-bigquery`](https://crates.io/crates/faucet-source-bigquery) or [`faucet-sink-bigquery`](https://crates.io/crates/faucet-sink-bigquery) (or the `faucet` CLI with the `source-bigquery` / `sink-bigquery` features); both re-export `BigQueryCredentials`, so your imports don't change.
+- **Connector authors** — depend on this crate if you are building a third-party `faucet-source-*` / `faucet-sink-*` crate that talks to BigQuery and want to accept the same credentials shape and reuse the same client builder.
+
+## Installation
+
+```bash
+cargo add faucet-common-bigquery
+```
+
+The only required faucet dependency is `faucet-core` (pulled in transitively); see the [Third-Party Connector Friendliness](https://github.com/PawanSikawat/faucet-stream#readme) guidance.
 
 ## Usage
 
-Most users do not depend on this crate directly. It is re-exported by:
+```rust
+use faucet_common_bigquery::{build_client, BigQueryCredentials};
 
-- [`faucet-source-bigquery`](https://crates.io/crates/faucet-source-bigquery)
-- [`faucet-sink-bigquery`](https://crates.io/crates/faucet-sink-bigquery)
+#[tokio::main]
+async fn main() -> Result<(), faucet_core::FaucetError> {
+    // Built from your connector's deserialized config.
+    let creds = BigQueryCredentials::ServiceAccountKeyPath {
+        path: "/etc/faucet/bq-key.json".to_string(),
+    };
 
-Depend on this crate directly only if you are building a third-party connector that needs to accept the same credentials shape in its config.
+    let client = build_client(&creds).await?;
+    // `client` is a `gcp_bigquery_client::Client` — drive jobs / streaming inserts with it.
+    let _ = client;
+    Ok(())
+}
+```
+
+Embed `BigQueryCredentials` in your own connector config so it deserializes from the standard wire shape:
+
+```rust
+use faucet_common_bigquery::BigQueryCredentials;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, JsonSchema)]
+pub struct MyBigQueryConfig {
+    pub project_id: String,
+    pub credentials: BigQueryCredentials,
+}
+```
+
+## Feature flags
+
+None. The crate has no optional features; all functionality is always compiled.
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| `FaucetError::Auth("invalid service account JSON: …")` | The `service_account_key` `json` string is not valid service-account JSON. Verify the value (and that any secret reference resolved to the full key body, not a path). |
+| `FaucetError::Auth("BigQuery auth failed: …")` | The key file path is wrong/unreadable, the service account lacks BigQuery permissions, or ADC could not be resolved. Check the `path`, the SA's IAM roles, and run `gcloud auth application-default login` for the `application_default` variant. |
+| Inline key shows as `ServiceAccountKey(***)` in logs | Intended — the `Debug` impl masks inline JSON so it never leaks into tracing output. Key paths are not masked. |
+| `application_default` can't find credentials | Set `GOOGLE_APPLICATION_CREDENTIALS`, run `gcloud auth application-default login`, or run on a GCP runtime with an attached service account / workload identity. |
+
+## See also
+
+- [faucet-source-bigquery](https://crates.io/crates/faucet-source-bigquery) — BigQuery query source.
+- [faucet-sink-bigquery](https://crates.io/crates/faucet-sink-bigquery) — BigQuery streaming-insert / `MERGE` upsert sink.
+- [faucet-stream documentation](https://pawansikawat.github.io/faucet-stream/) — full project docs.
 
 ## License
 
-MIT OR Apache-2.0
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+
+at your option.

--- a/crates/common/elasticsearch/README.md
+++ b/crates/common/elasticsearch/README.md
@@ -1,20 +1,102 @@
 # faucet-common-elasticsearch
 
-Shared configuration types for the Elasticsearch source and sink connectors in the [`faucet-stream`](https://crates.io/crates/faucet-stream) ecosystem.
+[![Crates.io](https://img.shields.io/crates/v/faucet-common-elasticsearch.svg)](https://crates.io/crates/faucet-common-elasticsearch)
+[![Docs.rs](https://docs.rs/faucet-common-elasticsearch/badge.svg)](https://docs.rs/faucet-common-elasticsearch)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-common-elasticsearch.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-common-elasticsearch.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-## Types
+Shared configuration types for the Elasticsearch source and sink connectors. Part of the
+[faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
 
-- `ElasticsearchAuth` — authentication mode: `None`, `Basic`, `Bearer`, or `ApiKey`. Derives `Serialize`, `Deserialize`, `JsonSchema`. Its `Debug` impl masks credentials as `"***"`.
+This crate exists so that `faucet-source-elasticsearch` and `faucet-sink-elasticsearch` describe
+authentication exactly the same way — one `ElasticsearchAuth` enum, one wire shape, one
+secret-masking `Debug` impl — instead of each duplicating its own copy. If you only run pipelines,
+you never touch this crate directly; it's pulled in (and re-exported) by the connectors.
+
+## What it provides
+
+- **`ElasticsearchAuth`** — the authentication mode for an Elasticsearch endpoint. Derives
+  `Serialize`, `Deserialize`, and `JsonSchema` so it round-trips through YAML/JSON configs and
+  shows up in `faucet schema`. Its `Debug` impl masks credentials as `"***"`, so accidentally
+  logging a config value never leaks a password, token, or key.
+- **`credential_to_auth`** — maps a [`Credential`](https://docs.rs/faucet-core) yielded by a shared
+  `faucet_core::AuthProvider` onto an `ElasticsearchAuth` variant (used when a connector references a
+  provider from the top-level `auth:` catalog).
+
+### `ElasticsearchAuth` variants
+
+Serializes as `{ type: <method>, config: { … } }` (adjacent tagging, snake_case discriminators) —
+the consistent auth wire shape shared by every faucet connector.
+
+| `type`     | `config` fields        | Description                                                            |
+|------------|------------------------|------------------------------------------------------------------------|
+| `none`     | *(none)*               | No authentication.                                                     |
+| `basic`    | `username`, `password` | HTTP Basic authentication.                                             |
+| `bearer`   | `token`                | Bearer token in the `Authorization` header.                            |
+| `api_key`  | `key`                  | API key sent as `ApiKey <key>` in the `Authorization` header.          |
+
+Example config snippets (as they appear inside a connector's `auth:` block):
+
+```yaml
+auth: { type: none }
+auth: { type: basic, config: { username: elastic, password: changeme } }
+auth: { type: bearer, config: { token: my-token } }
+auth: { type: api_key, config: { key: base64-encoded-id-and-key } }
+```
+
+## Who should depend on this
+
+- **End users:** you don't. Use the connectors directly —
+  [`faucet-source-elasticsearch`](https://crates.io/crates/faucet-source-elasticsearch) and
+  [`faucet-sink-elasticsearch`](https://crates.io/crates/faucet-sink-elasticsearch) re-export
+  `ElasticsearchAuth`, so the type is already in scope from those crates.
+- **Third-party connector authors:** depend on this crate if you're building another Elasticsearch
+  connector and want to accept the identical auth shape in your config (so users get one consistent
+  experience across the ecosystem).
+
+## Installation
+
+```bash
+cargo add faucet-common-elasticsearch
+```
 
 ## Usage
 
-Most users do not depend on this crate directly. It is re-exported by:
+```rust
+use faucet_common_elasticsearch::{ElasticsearchAuth, credential_to_auth};
+use faucet_core::Credential;
 
-- [`faucet-source-elasticsearch`](https://crates.io/crates/faucet-source-elasticsearch)
-- [`faucet-sink-elasticsearch`](https://crates.io/crates/faucet-sink-elasticsearch)
+// Embed the auth enum in your connector's config struct.
+#[derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+struct MyConfig {
+    url: String,
+    auth: ElasticsearchAuth,
+}
 
-Depend on this crate directly only if you are building a third-party connector that needs to accept the same auth shape in its config.
+// Parse the `{ type, config }` wire shape straight from JSON/YAML.
+let cfg: MyConfig = serde_json::from_str(
+    r#"{ "url": "https://es:9200", "auth": { "type": "bearer", "config": { "token": "t" } } }"#,
+)?;
+
+// Map a shared AuthProvider credential onto an ElasticsearchAuth variant.
+let auth = credential_to_auth(Credential::Bearer("token".into()))?;
+assert!(matches!(auth, ElasticsearchAuth::Bearer { .. }));
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+## Troubleshooting / FAQ
+
+| Question / symptom | Answer |
+|---|---|
+| `credential_to_auth` returns `FaucetError::Auth`. | The shared provider yielded a `Header` or `Token` credential, which has no Elasticsearch equivalent. Elasticsearch accepts only `Bearer` and `Basic` credentials from a shared `auth:` provider — use a `bearer`/`basic`-yielding provider, or set the connector's `auth:` inline instead. |
+| My password / token showed up in a log line. | It shouldn't — `ElasticsearchAuth`'s `Debug` impl masks `password`, `token`, and `key` as `"***"`. If you see a raw secret, it came from somewhere other than this type's `Debug` output. |
+| `unknown variant` / `missing field` when parsing config. | The auth block must use the `{ type, config }` shape (e.g. `{ type: basic, config: { username, password } }`), not flat fields. `type: none` takes no `config`. |
 
 ## License
 
-MIT OR Apache-2.0
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](../../../LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](../../../LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+
+at your option.

--- a/crates/common/gcs/README.md
+++ b/crates/common/gcs/README.md
@@ -1,32 +1,30 @@
 # faucet-common-gcs
 
-Shared credential and client-construction types for `faucet-source-gcs` and
-`faucet-sink-gcs`. Both crates re-export `GcsCredentials`, so end-users
-typically don't depend on this crate directly.
+[![Crates.io](https://img.shields.io/crates/v/faucet-common-gcs.svg)](https://crates.io/crates/faucet-common-gcs)
+[![Docs.rs](https://docs.rs/faucet-common-gcs/badge.svg)](https://docs.rs/faucet-common-gcs)
+[![MSRV](https://img.shields.io/badge/MSRV-1.85-blue.svg)](https://github.com/PawanSikawat/faucet-stream)
+[![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](#license)
 
-Built on the official [`google-cloud-storage`](https://crates.io/crates/google-cloud-storage)
-SDK (1.12) and [`google-cloud-auth`](https://crates.io/crates/google-cloud-auth) (1.10).
+Shared Google Cloud Storage credentials and client construction for the GCS source and sink connectors. Part of the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
 
-## `GcsCredentials`
+This is a small **internal/shared** crate: it holds the one credential enum and the async client builders that both [`faucet-source-gcs`](https://crates.io/crates/faucet-source-gcs) and [`faucet-sink-gcs`](https://crates.io/crates/faucet-sink-gcs) need, so the two crates accept exactly the same `credentials:` shape and build their GCS clients the same way. It is built on the official [`google-cloud-storage`](https://crates.io/crates/google-cloud-storage) SDK and [`google-cloud-auth`](https://crates.io/crates/google-cloud-auth).
 
-Tagged enum (`#[serde(tag = "type")]`) so YAML/JSON configs read naturally.
-The discriminator is `snake_case`.
+## What it provides
 
-| Variant | YAML example |
-|---|---|
-| `application_default` *(default)* | `{ type: application_default }` |
-| `service_account_json_file` | `{ type: service_account_json_file, config: { path: /run/secrets/sa.json } }` |
-| `service_account_json_inline` | `{ type: service_account_json_inline, config: { json: "${env:GCP_SA_JSON}" } }` |
-| `anonymous` | `{ type: anonymous }` |
+### `GcsCredentials`
 
-`application_default` (ADC) honours `GOOGLE_APPLICATION_CREDENTIALS`,
-`gcloud auth application-default login` creds, and the GCE/GKE metadata
-server in that order.
+A tagged enum that serializes as the project-wide `{ type, config }` auth wire shape — adjacent tagging (`#[serde(tag = "type", content = "config")]`) with `snake_case` discriminators — so YAML/JSON configs read consistently across every faucet connector. Derives `Serialize + Deserialize + JsonSchema + Clone + Default`.
 
-`anonymous` is for emulators (e.g. `fake-gcs-server`) that don't validate
-bearer tokens. Production deployments should never use it.
+| Variant | YAML | Notes |
+|---|---|---|
+| `application_default` *(default)* | `{ type: application_default }` | Application Default Credentials — honours `GOOGLE_APPLICATION_CREDENTIALS`, `gcloud auth application-default login` user creds, and the GCE/GKE metadata server, in that order. |
+| `service_account_json_file` | `{ type: service_account_json_file, config: { path: /run/secrets/sa.json } }` | Reads a service-account JSON key file from disk. |
+| `service_account_json_inline` | `{ type: service_account_json_inline, config: { json: "${env:GCP_SA_JSON}" } }` | Service-account JSON key as an inline string. Pairs with `${env:…}` / `${secret:…}` interpolation in CLI configs. |
+| `anonymous` | `{ type: anonymous }` | Unauthenticated. Use **only** with emulators (e.g. `fake-gcs-server`) that don't validate bearer tokens — never in production. |
 
-## Client builders
+### Client builders
+
+All three are `async` and map every failure to [`FaucetError::Auth`](https://docs.rs/faucet-core/latest/faucet_core/enum.FaucetError.html) with a message that includes the underlying SDK / I/O error.
 
 ```rust
 pub async fn build_credentials(
@@ -44,17 +42,73 @@ pub async fn build_storage_control(
 ) -> Result<google_cloud_storage::client::StorageControl, FaucetError>;
 ```
 
-- `build_storage` returns the data-plane client used by source reads and
-  sink writes (`read_object`, `write_object`).
-- `build_storage_control` returns the control-plane client used by source
-  listings (`list_objects`).
-- `storage_host` is an integration-test escape hatch — leave it `None` in
-  production. Tests target `fake-gcs-server` via
-  `Some("http://127.0.0.1:4443")`.
+- `build_credentials` resolves a `GcsCredentials` spec into a `google-cloud-auth` credential handle (the shared step both client builders call first).
+- `build_storage` returns the **data-plane** `Storage` client used by source reads and sink writes (`read_object`, `write_object`).
+- `build_storage_control` returns the **control-plane** `StorageControl` client used by source object listings (`list_objects`).
+- `storage_host` is an integration-test escape hatch — pass `None` in production. Tests target `fake-gcs-server` with `Some("http://127.0.0.1:4443")`, which sets the client endpoint.
 
-All failures map to `FaucetError::Auth` with a message that includes the
-underlying SDK / I/O error.
+## Who depends on this
+
+You usually **don't** depend on this crate directly. End users configure GCS through `faucet-source-gcs` / `faucet-sink-gcs` (both re-export `GcsCredentials`), or through the `faucet` CLI via the `source-gcs` / `sink-gcs` features. Depend on `faucet-common-gcs` only if you are a **third-party connector author** building your own GCS source/sink for the faucet ecosystem and want to stay interchangeable with the first-party connectors' credential shape and client construction.
+
+## Installation
+
+```bash
+cargo add faucet-common-gcs
+```
+
+## Usage
+
+```rust
+use faucet_common_gcs::{build_storage, build_storage_control, GcsCredentials};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let creds = GcsCredentials::ServiceAccountJsonFile {
+        path: "/run/secrets/sa.json".into(),
+    };
+
+    // Data-plane client for read/write object operations.
+    let storage = build_storage(&creds, None).await?;
+
+    // Control-plane client for listing objects.
+    let control = build_storage_control(&creds, None).await?;
+
+    let _ = (storage, control);
+    Ok(())
+}
+```
+
+In a faucet config, the same enum is what the GCS source/sink accept under `credentials:`:
+
+```yaml
+credentials:
+  type: service_account_json_inline
+  config:
+    json: "${env:GCP_SA_JSON}"
+```
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause / fix |
+|---|---|
+| `FaucetError::Auth: GCS auth (ADC): …` | Application Default Credentials could not be resolved. Set `GOOGLE_APPLICATION_CREDENTIALS`, run `gcloud auth application-default login`, or run on a GCE/GKE node with a metadata server. |
+| `GCS auth: could not read service-account key from '…'` | The `path` for `service_account_json_file` is wrong or unreadable by the process. Check the path and file permissions. |
+| `GCS auth: … is not valid JSON` | The service-account key (file or inline) isn't valid JSON. For `service_account_json_inline`, confirm the env var / secret holds the full JSON, not a path. |
+| Requests fail against an emulator | The SDK tries to fetch ADC tokens by default. Use `type: anonymous` with emulators like `fake-gcs-server`, and pass the emulator endpoint via `storage_host`. |
+
+**Why two clients?** GCS splits object I/O (`Storage`, data plane) from bucket/object metadata operations like listing (`StorageControl`, control plane). The source needs both; the sink needs only `Storage`.
+
+## See also
+
+- [`faucet-source-gcs`](https://crates.io/crates/faucet-source-gcs) and [`faucet-sink-gcs`](https://crates.io/crates/faucet-sink-gcs) — the connectors that consume these types.
+- [faucet-stream documentation](https://pawansikawat.github.io/faucet-stream/) — connector reference and cookbook.
 
 ## License
 
-Dual-licensed under MIT and Apache-2.0, per the workspace `license` field.
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](../../../LICENSE-APACHE) or <https://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](../../../LICENSE-MIT) or <https://opensource.org/licenses/MIT>)
+
+at your option.

--- a/crates/common/gcs/README.md
+++ b/crates/common/gcs/README.md
@@ -2,8 +2,8 @@
 
 [![Crates.io](https://img.shields.io/crates/v/faucet-common-gcs.svg)](https://crates.io/crates/faucet-common-gcs)
 [![Docs.rs](https://docs.rs/faucet-common-gcs/badge.svg)](https://docs.rs/faucet-common-gcs)
-[![MSRV](https://img.shields.io/badge/MSRV-1.85-blue.svg)](https://github.com/PawanSikawat/faucet-stream)
-[![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](#license)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-common-gcs.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-common-gcs.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
 Shared Google Cloud Storage credentials and client construction for the GCS source and sink connectors. Part of the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
 

--- a/crates/common/kafka/README.md
+++ b/crates/common/kafka/README.md
@@ -1,276 +1,163 @@
 # faucet-common-kafka
 
-Shared configuration types for `faucet-source-kafka` and `faucet-sink-kafka`.
+[![Crates.io](https://img.shields.io/crates/v/faucet-common-kafka.svg)](https://crates.io/crates/faucet-common-kafka)
+[![Docs.rs](https://docs.rs/faucet-common-kafka/badge.svg)](https://docs.rs/faucet-common-kafka)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-common-kafka.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-common-kafka.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-Most users don't depend on this crate directly — they import from
-`faucet-source-kafka` or `faucet-sink-kafka`, which re-export everything. Third-party
-connector authors building their own Kafka source/sink for the faucet ecosystem should
-depend on this crate to stay interchangeable with the first-party connectors.
+Shared configuration types for the Kafka source and sink connectors. Part of the
+[faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
 
----
-
-## Features
-
-### `default`
-
-No features enabled. Provides:
-
-- `KafkaAuth` — all authentication modes
-- `KafkaValueFormat::{Json, RawString, Bytes}` — the three wire-independent formats
-- `CompressionType` — producer-side compression enum
-- `OnDecodeError` — per-message decode failure policy
-- `OnKeyError` — per-record key/partition failure policy
-
-### `schema-registry`
-
-Enables Confluent Schema Registry integration:
-
-- `KafkaValueFormat::{ConfluentAvro, ConfluentProtobuf, ConfluentJsonSchema}` variants
-- `SchemaRegistryConfig` — connection settings for the registry client
-- `schema_registry::client::SchemaRegistryClient` — HTTP client with LRU schema cache
-- Per-format codec modules: `schema_registry::avro`, `schema_registry::protobuf`,
-  `schema_registry::json_schema`, `schema_registry::envelope`
-
-Additional dependencies pulled in: `reqwest`, `lru`, `bytes`, `apache-avro`,
-`prost-reflect`, `prost`, `jsonschema`, `tokio`, `url`, `urlencoding`.
+This crate holds the wire-format config that `faucet-source-kafka` and `faucet-sink-kafka`
+have in common — authentication, value formats, compression, and the Confluent Schema
+Registry client — so the two connectors stay byte-for-byte interchangeable. All types derive
+`Serialize`, `Deserialize`, and `JsonSchema`, so they round-trip through YAML/JSON configs
+and `faucet schema` introspection.
 
 ---
 
-## Auth modes
+## Who should depend on this
 
-Authentication is configured via `KafkaAuth` (`crates/common/kafka/src/auth.rs`).
-The `type` discriminator uses `snake_case` matching the enum variant names.
+- **End users:** you almost never depend on this crate directly. `faucet-source-kafka` and
+  `faucet-sink-kafka` re-export every type below, so importing from those connectors is enough.
+- **Third-party connector authors:** if you build your own Kafka source/sink for the faucet
+  ecosystem, depend on `faucet-common-kafka` and reuse these types so your connector accepts
+  the same `auth:` / `value_format:` config as the first-party ones.
 
-### `none` (default)
+---
 
-```yaml
-auth:
-  type: none
-```
+## Types it provides
 
-Plaintext brokers only. Sets `security.protocol = PLAINTEXT`.
+| Type | Module | Purpose |
+|------|--------|---------|
+| `KafkaAuth` | `auth` | Broker authentication mode (adjacently-tagged enum) |
+| `ScramMechanism` | `auth` | `sha256` / `sha512` selector for SASL/SCRAM |
+| `BasicAuth` | `auth` | Optional username/password for the Schema Registry HTTP client |
+| `KafkaValueFormat` | `format` | Message value serialization format (adjacently-tagged enum) |
+| `OnDecodeError` | `format` | Source policy when a message fails to decode (`fail` / `skip`) |
+| `OnKeyError` | `format` | Sink policy when key/partition extraction fails (`fail` / `skip` / `round_robin`) |
+| `CompressionType` | `format` | Producer-side compression (`none` / `gzip` / `snappy` / `lz4` / `zstd`) |
+| `SchemaRegistryConfig` | `schema_registry` | Confluent Schema Registry client settings (feature `schema-registry`) |
 
-### `sasl_plain`
+The `schema_registry` module also exposes `SchemaRegistryClient` (an `Arc`-cloneable HTTP
+client with an LRU schema cache) and per-format codecs (`avro`, `protobuf`, `json_schema`,
+`envelope`) — all behind the `schema-registry` feature.
 
-```yaml
-auth:
-  type: sasl_plain
-  username: my-user
-  password: my-secret
-```
+### `KafkaAuth` modes
 
-Sets `security.protocol = SASL_PLAINTEXT`, `sasl.mechanism = PLAIN`. Both
-`username` and `password` must be non-empty or the config is rejected.
+Configured as a `{ type, config }`-style **adjacently-tagged** enum — the `type`
+discriminator (`snake_case`) selects the variant and its fields sit alongside it, matching the
+project-wide auth convention (not a flat shape).
 
-### `sasl_scram`
+| `type` | Fields | Effect |
+|--------|--------|--------|
+| `none` (default) | — | `security.protocol = PLAINTEXT` |
+| `sasl_plain` | `username`, `password` | `SASL_PLAINTEXT` + `sasl.mechanism = PLAIN`; both fields must be non-empty |
+| `sasl_scram` | `mechanism` (`sha256`/`sha512`), `username`, `password` | `SASL_PLAINTEXT` + `SCRAM-SHA-256`/`SCRAM-SHA-512` |
+| `ssl` | `ca_path`, `cert_path`, `key_path`, `key_password?` | `SSL`; all three paths validated to exist at config time |
+| `sasl_ssl` | `sasl` (a `sasl_plain`/`sasl_scram`), `ssl` (an `ssl`) | applies `ssl` then `sasl`, then forces `security.protocol = SASL_SSL` |
 
 ```yaml
 auth:
   type: sasl_scram
-  mechanism: sha256   # or sha512
+  mechanism: sha512
   username: my-user
   password: my-secret
 ```
 
-`mechanism` is a `ScramMechanism` enum: `sha256` maps to `SCRAM-SHA-256`,
-`sha512` maps to `SCRAM-SHA-512`. Sets `security.protocol = SASL_PLAINTEXT`.
+### `KafkaValueFormat` formats
 
-### `ssl`
+Same adjacently-tagged shape. The first three are always available; the Confluent variants
+require the `schema-registry` feature.
 
-```yaml
-auth:
-  type: ssl
-  ca_path: /etc/kafka/certs/ca.pem
-  cert_path: /etc/kafka/certs/client.pem
-  key_path: /etc/kafka/certs/client.key
-  key_password: optional-passphrase   # omit if key is unencrypted
-```
-
-All three path fields are validated to exist on the filesystem at config time.
-`key_password` is optional and omitted from serialization when absent.
-Sets `security.protocol = SSL`.
-
-### `sasl_ssl`
-
-```yaml
-auth:
-  type: sasl_ssl
-  sasl:
-    type: sasl_plain
-    username: my-user
-    password: my-secret
-  ssl:
-    type: ssl
-    ca_path: /etc/kafka/certs/ca.pem
-    cert_path: /etc/kafka/certs/client.pem
-    key_path: /etc/kafka/certs/client.key
-```
-
-Combines a SASL mechanism with TLS transport. The `sasl` field must be either
-`sasl_plain` or `sasl_scram`; the `ssl` field must be `ssl`. The inner configs
-are applied in order (`ssl` first, then `sasl`), then `security.protocol` is
-overridden to `SASL_SSL`.
-
----
-
-## Value formats
-
-Configured via `KafkaValueFormat` (`crates/common/kafka/src/format.rs`).
-The `type` discriminator uses `snake_case`.
-
-### `json` (default)
-
-```yaml
-value_format:
-  type: json
-```
-
-Parses message bytes as a JSON document. Invalid JSON fails per `on_decode_error`.
-
-### `raw_string`
-
-```yaml
-value_format:
-  type: raw_string
-```
-
-Treats message bytes as a UTF-8 string. The string becomes the `value` field
-in the JSON record. Invalid UTF-8 fails per `on_decode_error`.
-
-### `bytes`
-
-```yaml
-value_format:
-  type: bytes
-```
-
-Passes message bytes through as a base64-encoded string in the JSON record.
-On the sink side, expects a base64 string in the source record.
-
-### `confluent_avro` (feature: `schema-registry`)
+| `type` | Feature | Behaviour |
+|--------|---------|-----------|
+| `json` (default) | — | Parse bytes as a JSON document |
+| `raw_string` | — | UTF-8 string → `value` field |
+| `bytes` | — | Raw bytes passed through as a base64 string |
+| `confluent_avro` | `schema-registry` | Confluent wire envelope; writer schema fetched by id and cached |
+| `confluent_protobuf` | `schema-registry` | Type present for symmetry; v1 returns `FaucetError::Config` (full descriptor support tracked in #44) |
+| `confluent_json_schema` | `schema-registry` | Confluent wire envelope; optional `validate: true` checks decoded JSON against the schema |
 
 ```yaml
 value_format:
   type: confluent_avro
   schema_registry:
     url: http://localhost:8081
-    auth:                         # optional
+    auth:                  # optional BasicAuth
       username: sr-user
       password: sr-secret
-    cache_capacity: 1024          # default 1024
-    request_timeout: 10           # seconds, default 10
+    cache_capacity: 1024   # default 1024
+    request_timeout: 10    # seconds, default 10
 ```
 
-Decodes messages using the Confluent wire envelope: `[0x00][be u32 schema_id][Avro binary]`.
-The writer schema is fetched from the registry by `schema_id` and cached. On the sink side,
-the subject name is `{topic}-value` (Confluent TopicNameStrategy).
-
-### `confluent_protobuf` (feature: `schema-registry`)
-
-```yaml
-value_format:
-  type: confluent_protobuf
-  schema_registry:
-    url: http://localhost:8081
-```
-
-**Note:** `ConfluentProtobuf` is present in the type system for API symmetry with Avro
-and JSON Schema, but v1 returns a `FaucetError::Config` on both encode and decode.
-Full descriptor support (pre-built `FileDescriptorSet` or `protoc`-based compilation)
-is tracked in issue #44. The wire format expected is:
-`[0x00][be u32 schema_id][message_indexes][protobuf bytes]`, where v1 only supports
-the single-message case (`message_indexes = [0x00]`).
-
-### `confluent_json_schema` (feature: `schema-registry`)
-
-```yaml
-value_format:
-  type: confluent_json_schema
-  schema_registry:
-    url: http://localhost:8081
-    auth:
-      username: sr-user
-      password: sr-secret
-  validate: false   # default false; set true to validate decoded JSON against the schema
-```
-
-Decodes using `[0x00][be u32 schema_id][JSON bytes]`. When `validate: true`, the
-decoded JSON object is validated against the registered JSON Schema; validation
-errors fail per `on_decode_error`.
+The Confluent wire envelope is `[0x00][schema_id: 4-byte big-endian][payload bytes…]`. The
+client caches schema fetches (keyed by id) and registrations (keyed by subject/type/text) in
+two LRUs of `cache_capacity`, so a stream sharing one schema issues a single registry call.
+On the sink side the subject is `{topic}-value` (Confluent TopicNameStrategy).
 
 ---
 
-## Schema Registry
+## Usage
 
-Configuration struct: `SchemaRegistryConfig` (`crates/common/kafka/src/schema_registry/mod.rs`).
+Library callers normally pull these in transitively. To depend on them directly:
 
-**Wire envelope** (`crates/common/kafka/src/schema_registry/envelope.rs`):
-
+```bash
+cargo add faucet-common-kafka
+cargo add faucet-common-kafka --features schema-registry   # for the Confluent variants
 ```
-[0x00] [schema_id: 4 bytes big-endian] [payload bytes...]
+
+```rust
+use faucet_common_kafka::{KafkaAuth, KafkaValueFormat, CompressionType};
+
+// Built straight from a YAML/JSON config, or constructed in code:
+let auth: KafkaAuth = serde_yaml::from_str(
+    "type: sasl_plain\nusername: u\npassword: p",
+)?;
+let format = KafkaValueFormat::default();      // KafkaValueFormat::Json
+let compression = CompressionType::default();  // CompressionType::None
+# Ok::<(), Box<dyn std::error::Error>>(())
 ```
 
-The magic byte `0x00` identifies the Confluent wire format. `envelope::decode` strips
-the header and returns `(schema_id, payload_bytes)`. `envelope::encode` prepends the
-header to a serialized payload.
-
-**Client** (`crates/common/kafka/src/schema_registry/client.rs`):
-
-`SchemaRegistryClient` is `Arc`-cloneable and safe to share across tasks. Schema
-fetches are cached in an LRU bounded by `cache_capacity` (default 1024), keyed by
-the integer schema ID; misses hit `GET /schemas/ids/{id}`. Schema *registrations*
-are cached in a second LRU of the same capacity, keyed by `(subject, schema_type,
-schema_text)` — so encoding a stream of records that share one schema issues a
-single `POST /subjects/{subject}/versions` instead of one per record. Registry auth
-is `BasicAuth` (optional); `request_timeout` applies per HTTP call (default 10 s).
-
-**Subject naming on the sink side**: `{topic}-value` (Confluent TopicNameStrategy).
-The sink registers or looks up the schema under this subject before the first produce call.
-
-**Decoder flow**: read `schema_id` from wire envelope → cache lookup or HTTP fetch →
-parse writer schema → decode payload bytes into `serde_json::Value`.
+End users configure these through the Kafka connectors rather than this crate; see the
+connector READMEs for full pipeline examples.
 
 ---
 
-## Policy enums
+## Feature flags
 
-All three enums are in `crates/common/kafka/src/format.rs` and derive `Serialize`,
-`Deserialize`, `JsonSchema`.
+| Feature | Default | Adds |
+|---------|---------|------|
+| `schema-registry` | off | The Confluent `KafkaValueFormat` variants, `SchemaRegistryConfig`, `SchemaRegistryClient`, and the `avro`/`protobuf`/`json_schema`/`envelope` codec modules. Pulls in `reqwest`, `lru`, `bytes`, `apache-avro`, `prost-reflect`, `prost`, `jsonschema`, `tokio`, `url`, `urlencoding`. |
 
-### `OnDecodeError`
+> In the umbrella `faucet-stream` crate and the `faucet-cli`, this is enabled via the
+> `kafka-schema-registry` feature, which forwards to this crate's `schema-registry` feature.
 
-What the source does when a single message fails to decode. Serializes as `snake_case`.
+---
 
-| Value | Behaviour | Default |
-|-------|-----------|---------|
-| `fail` | Surface `FaucetError::Source` and abort the batch | yes |
-| `skip` | Drop the message and continue (logs a `WARN`) | |
+## Troubleshooting / FAQ
 
-### `OnKeyError`
+| Symptom | Cause & fix |
+|---------|-------------|
+| `confluent_avro` / `confluent_json_schema` rejected as an unknown variant | The `schema-registry` feature is off. Enable it on this crate (or `kafka-schema-registry` on the umbrella / CLI). |
+| `sasl_plain` config rejected at load | `username` and `password` must both be non-empty. |
+| `ssl` config errors on a path | `ca_path`, `cert_path`, and `key_path` are validated to exist on the filesystem at config time. Check the paths and the process's read permissions. |
+| `confluent_protobuf` returns `FaucetError::Config` | Protobuf decode/encode is not yet implemented in v1 (#44). Use `confluent_avro` or `confluent_json_schema`, or decode protobuf upstream. |
+| Schema Registry calls time out | Raise `request_timeout` (seconds, default 10) and verify `url` / `auth` reachability. |
+| Encrypted SSL key fails to load | Supply `key_password`; omit it only for unencrypted keys. |
 
-What the sink does when key or partition extraction fails for a record. Serializes as
-`snake_case`.
+---
 
-| Value | Behaviour | Default |
-|-------|-----------|---------|
-| `fail` | Surface `FaucetError::Sink` and abort the batch | yes |
-| `skip` | Drop the record and continue (logs a `WARN`) | |
-| `round_robin` | Send the record with no key; librdkafka chooses the partition | |
+## See also
 
-### `CompressionType`
-
-Producer-side compression applied to outbound batches. Serializes as `lowercase`.
-
-| Value | librdkafka string | Default |
-|-------|-------------------|---------|
-| `none` | `none` | yes |
-| `gzip` | `gzip` | |
-| `snappy` | `snappy` | |
-| `lz4` | `lz4` | |
-| `zstd` | `zstd` | |
+- [faucet-source-kafka](https://crates.io/crates/faucet-source-kafka) — Kafka consumer source
+- [faucet-sink-kafka](https://crates.io/crates/faucet-sink-kafka) — Kafka producer sink
+- [Connectors reference](https://pawansikawat.github.io/faucet-stream/reference/connectors.html)
+- [Authentication cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/auth.html)
 
 ---
 
 ## License
 
-Dual-licensed under MIT and Apache-2.0, per the workspace `license` field.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/common/mssql/README.md
+++ b/crates/common/mssql/README.md
@@ -1,34 +1,69 @@
 # faucet-common-mssql
 
-Shared configuration, TLS, and connection-pool types for the
-[`faucet-stream`](https://crates.io/crates/faucet-stream) Microsoft SQL Server
-**source** ([`faucet-source-mssql`](https://crates.io/crates/faucet-source-mssql))
-and **sink** ([`faucet-sink-mssql`](https://crates.io/crates/faucet-sink-mssql))
-connectors. Built on [`tiberius`](https://crates.io/crates/tiberius) +
-[`bb8-tiberius`](https://crates.io/crates/bb8-tiberius).
+[![Crates.io](https://img.shields.io/crates/v/faucet-common-mssql.svg)](https://crates.io/crates/faucet-common-mssql)
+[![Docs.rs](https://docs.rs/faucet-common-mssql/badge.svg)](https://docs.rs/faucet-common-mssql)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-common-mssql.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-common-mssql.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-You normally don't depend on this crate directly — both connectors re-export the
-types you configure. It exists so the source and sink share one connection /
-TLS / pooling implementation (per the faucet "source/sink pair shares a
-`faucet-common-<name>` crate" convention).
+Shared connection, TLS, and pooling types for the Microsoft SQL Server **source** and **sink** connectors. Part of the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
 
-## What's here
+This is an internal building block. It holds the configuration the MSSQL [source](https://crates.io/crates/faucet-source-mssql) and [sink](https://crates.io/crates/faucet-sink-mssql) must agree on — how to parse a connection target, apply TLS, and build a [`tiberius`](https://crates.io/crates/tiberius) + [`bb8`](https://crates.io/crates/bb8) connection pool — so both connectors behave identically instead of duplicating the logic. End users configure MSSQL through the source/sink crates, which re-export these types; you only depend on this crate directly if you are building your own MSSQL connector.
 
-| Item | Purpose |
-|------|---------|
-| `MssqlConnectionConfig` | `connection_url` **or** `connection_string` (exactly one) + a `tls` block. Flattened into both end configs. |
-| `MssqlTls` / `MssqlTlsMode` | Encryption mode (`prefer` / `require` / `trust_server_certificate` / `disable`) + optional `ca_cert_path`. |
-| `build_config` | `MssqlConnectionConfig` → `tiberius::Config` (URL parse, ADO passthrough, TLS). |
-| `build_pool` | Builds a `bb8` pool and eagerly validates one connection (fail-fast). |
-| `with_statement_timeout` | Wraps a query future in a timeout. |
-| `quote_ident_mssql` | `[bracket]` identifier quoting (doubles interior `]`). |
-| `PARAM_LIMIT` | `2100` — MSSQL's per-request bind-parameter ceiling. |
+## What it provides
 
-## Connection
+| Item | Kind | Purpose |
+|------|------|---------|
+| `MssqlConnectionConfig` | struct | `connection_url` **or** `connection_string` (exactly one) plus a `tls` block. `#[serde(flatten)]`'d into both end configs. |
+| `MssqlTls` / `MssqlTlsMode` | struct / enum | Encryption mode + optional `ca_cert_path`. |
+| `build_config` | fn | `MssqlConnectionConfig` → `tiberius::Config` (URL parse / ADO passthrough + TLS). |
+| `build_pool` | async fn | Builds a `bb8` pool and eagerly validates one connection (fail-fast). |
+| `with_statement_timeout` | async fn | Wraps a query future in a `tokio::time::timeout`. |
+| `quote_ident_mssql` | fn | `[bracket]` identifier quoting (doubles interior `]`). |
+| `PARAM_LIMIT` | const | `2100` — MSSQL's per-request bind-parameter ceiling. |
+| `MssqlPool` / `MssqlPooledConnection<'a>` | type alias | The `bb8` pool and a checked-out connection (derefs to `tiberius::Client`). |
+
+### `MssqlConnectionConfig` fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `connection_url` | `Option<String>` | `None` | `mssql://user:pass@host:1433/database` URL form. Mutually exclusive with `connection_string`. |
+| `connection_string` | `Option<String>` | `None` | ADO.NET-style string handed straight to `tiberius` (`Server=tcp:host,1433;Database=db;User Id=sa;Password=...;`). Mutually exclusive with `connection_url`. |
+| `tls` | `MssqlTls` | `{ type: prefer }` | TLS / encryption settings (see below). |
+
+`validate()` enforces that exactly one of `connection_url` / `connection_string` is set. `max_connections` and `statement_timeout_secs` are deliberately **not** here — they default differently per end (source 10 / 300s, sink 5 / 300s), so each connector owns them and passes them to `build_pool` / `with_statement_timeout`.
+
+### `MssqlTls` modes
+
+`MssqlTls { type: <mode>, ca_cert_path: <path?> }`. `ca_cert_path` trusts a specific CA for server validation and is ignored when `mode` is `disable`.
+
+| Mode | `tiberius` encryption | Notes |
+|------|-----------------------|-------|
+| `prefer` (default) | `On` | Encrypt the connection — the safe modern default. |
+| `require` | `Required` | Fail if the server does not offer TLS. |
+| `trust_server_certificate` | `On` + `trust_cert()` | Accepts self-signed certs. **Insecure against MITM — dev only.** |
+| `disable` | `NotSupported` | No transport encryption. |
+
+### Authentication
+
+SQL Server authentication (username + password) only in v1. Windows / Integrated authentication and Azure AD / Managed Identity are out of scope.
+
+## Who should depend on this
+
+- **Connector authors** building an alternative MSSQL source/sink who want the same connection/TLS/pool behaviour.
+- The first-party `faucet-source-mssql` and `faucet-sink-mssql` crates (they re-export everything here).
+
+If you are running pipelines, install the connectors instead — you never add this crate to a YAML config:
+
+```bash
+cargo install faucet-cli --features "source-mssql,sink-mssql"
+```
+
+## Usage
+
+The connection block in a pipeline config flattens straight onto each end config:
 
 ```yaml
-# URL form — faucet parses host/port/database/credentials; the tls block
-# governs encryption.
+# URL form — faucet parses host/port/database/credentials; tls governs encryption.
 connection_url: "mssql://sa:Str0ng%40Pass@localhost:1433/sales"
 tls:
   type: prefer          # prefer | require | trust_server_certificate | disable
@@ -38,26 +73,67 @@ tls:
 connection_string: "Server=tcp:localhost,1433;Database=sales;User Id=sa;Password=...;"
 ```
 
-Special characters in URL credentials must be percent-encoded
-(`@` → `%40`, `:` → `%3A`, `/` → `%2F`).
+In Rust, build a pool and run a quoted query:
 
-### TLS modes
+```rust,no_run
+use faucet_common_mssql::{MssqlConnectionConfig, build_pool, quote_ident_mssql, with_statement_timeout};
+use std::time::Duration;
+use faucet_core::FaucetError;
 
-| Mode | `tiberius` encryption | Notes |
-|------|-----------------------|-------|
-| `prefer` (default) | `On` | Encrypt the connection (safe modern default). |
-| `require` | `Required` | Fail if the server doesn't offer TLS. |
-| `trust_server_certificate` | `On` + `trust_cert()` | Accepts self-signed certs. **Insecure against MITM — dev only.** |
-| `disable` | `NotSupported` | No transport encryption. |
+# async fn demo() -> Result<(), FaucetError> {
+let cfg = MssqlConnectionConfig {
+    connection_url: Some("mssql://sa:pw@localhost:1433/sales".into()),
+    ..Default::default()
+};
 
-`ca_cert_path` trusts a specific CA certificate for server validation (ignored
-when `disable`).
+// Eagerly validates one connection — bad creds / unreachable host fail here.
+let pool = build_pool(&cfg, 10).await?;
 
-## Auth
+let table = quote_ident_mssql("orders")?; // -> "[orders]"
+let mut conn = pool.get().await.map_err(|e| FaucetError::Source(e.to_string()))?;
 
-SQL Server authentication (username + password) only. Windows / Integrated
-authentication and Azure AD / Managed Identity are out of scope for v1.
+let query = conn.simple_query(format!("SELECT TOP 100 * FROM {table}"));
+let _stream = with_statement_timeout(
+    Duration::from_secs(300),
+    async { query.await.map_err(|e| FaucetError::Source(e.to_string())) },
+    || FaucetError::Source("query timed out".into()),
+)
+.await?;
+# Ok(())
+# }
+```
+
+`pool.rs` is the only place in the workspace that constructs a `tiberius::Config` or an MSSQL pool, so TLS, auth, and pooling stay consistent across the source and sink.
+
+## Feature flags
+
+None. This crate has no optional features — it is pure config + pool plumbing always compiled into the MSSQL source/sink.
+
+## Troubleshooting / FAQ
+
+| Symptom | Cause / fix |
+|---------|-------------|
+| `MSSQL config requires either connection_url or connection_string` | Neither field set. Provide exactly one. |
+| `MSSQL config sets both ... set exactly one` | Both fields set. Keep only one. |
+| `MSSQL connection_url scheme must be mssql://` | Use the `mssql://` (or `sqlserver://`) scheme, not `postgres://` etc. |
+| `MSSQL connection_url is missing a host` | The URL has no host segment — check for a stray `@` or empty authority. |
+| Password / username rejected, special chars mangled | Percent-encode special characters in URL credentials: `@` → `%40`, `:` → `%3A`, `/` → `%2F`. |
+| `MSSQL connection failed` at startup | `build_pool` validates one connection eagerly. Verify host/port reachability, credentials, and that the TLS mode matches the server (try `require` vs `prefer`). |
+| Self-signed cert handshake fails | Use `tls.type: trust_server_certificate` (dev only) or point `ca_cert_path` at the server's CA. |
+| `... binds more than 2100 parameters` style errors | That is `PARAM_LIMIT`; the sink auto-splits batches, so this should not surface — if it does, reduce `batch_size`. |
+
+## See also
+
+- [`faucet-source-mssql`](https://crates.io/crates/faucet-source-mssql) — the MSSQL query source.
+- [`faucet-sink-mssql`](https://crates.io/crates/faucet-sink-mssql) — the MSSQL sink.
+- [`faucet-core`](https://crates.io/crates/faucet-core) — traits, `FaucetError`, and the pipeline runtime.
+- [faucet-stream documentation](https://pawansikawat.github.io/faucet-stream/) — connector reference and cookbook.
 
 ## License
 
-MIT OR Apache-2.0.
+Licensed under either of:
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](../../../LICENSE-APACHE) or <https://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](../../../LICENSE-MIT) or <https://opensource.org/licenses/MIT>)
+
+at your option.

--- a/crates/common/snowflake/README.md
+++ b/crates/common/snowflake/README.md
@@ -1,22 +1,108 @@
 # faucet-common-snowflake
 
-Shared configuration types and helpers for the Snowflake source and sink connectors in the [`faucet-stream`](https://crates.io/crates/faucet-stream) ecosystem.
+[![Crates.io](https://img.shields.io/crates/v/faucet-common-snowflake.svg)](https://crates.io/crates/faucet-common-snowflake)
+[![Docs.rs](https://docs.rs/faucet-common-snowflake/badge.svg)](https://docs.rs/faucet-common-snowflake)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-common-snowflake.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-common-snowflake.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-## Contents
+Shared Snowflake authentication types and SQL REST API header helpers. Part of the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
 
-- `SnowflakeAuth` — JWT key-pair (`KeyPair { user, private_key_pem }`) or OAuth bearer (`OAuth { token }`). Derives `Serialize`, `Deserialize`, `JsonSchema`. Its `Debug` impl masks credentials as `"***"`.
-- `authorization_header(&SnowflakeAuth, account)` — produces the `Authorization` header value for a Snowflake SQL REST API request (`Bearer {jwt}` for `KeyPair`, `Snowflake Token="{token}"` for `OAuth`).
-- `snowflake_token_type(&SnowflakeAuth)` — matching `X-Snowflake-Authorization-Token-Type` header value (`KEYPAIR_JWT` / `OAUTH`).
+This is an internal building block: it holds the one piece of configuration the Snowflake **source** and **sink** must agree on — how a request authenticates against the Snowflake SQL REST API — so both connectors mint identical `Authorization` / `X-Snowflake-Authorization-Token-Type` headers from one place instead of duplicating the JWT logic.
 
-## Usage
+## What it provides
 
-Most users do not depend on this crate directly. It is re-exported by:
+### `SnowflakeAuth`
+
+The authentication method for a Snowflake connector. It serializes as the project-wide adjacently-tagged shape — `{ type: <method>, config: { … } }`, snake_case discriminators — and derives `Serialize`, `Deserialize`, and `JsonSchema` so it round-trips through YAML/JSON configs and CLI schema introspection. Its `Debug` impl masks every credential as `"***"`.
+
+| `type` | `config` fields | Notes |
+|---|---|---|
+| `key_pair` | `user: String`, `private_key_pem: String` | RSA key-pair JWT auth. A fresh RS256 JWT is minted locally per request (1-hour expiry); the issuer carries the SHA-256 fingerprint of the derived public key, which Snowflake requires. Accepts PKCS#8 (`BEGIN PRIVATE KEY`) or PKCS#1 (`BEGIN RSA PRIVATE KEY`) PEM. Stateless — cannot be sourced from a shared `auth: { ref }` provider. |
+| `oauth` | `token: String` | OAuth2 bearer token from an external IdP. Can be supplied via a shared `auth: { ref }` provider. |
+
+### Helper functions
+
+| Function | Returns | Purpose |
+|---|---|---|
+| `authorization_header(auth, account) -> Result<String, FaucetError>` | `Bearer {jwt}` for `KeyPair`; `Snowflake Token="{token}"` for `OAuth` | Builds the `Authorization` header value for a SQL REST API request. `account` (e.g. `"xy12345.us-east-1"`) is uppercased into the JWT `iss`/`sub` claims. |
+| `snowflake_token_type(auth) -> &'static str` | `KEYPAIR_JWT` or `OAUTH` | The matching `X-Snowflake-Authorization-Token-Type` header value. |
+| `credential_to_auth(cred) -> Result<SnowflakeAuth, FaucetError>` | `SnowflakeAuth::OAuth { token }` | Maps a `faucet_core::Credential` from a shared `AuthProvider` onto `SnowflakeAuth`. `Bearer`/`Token` → OAuth; `Basic`/`Header` → `FaucetError::Auth` (key-pair JWT can't come from a provider). |
+
+## Who should depend on this
+
+Most users **don't** — it is re-exported by the connectors:
 
 - [`faucet-source-snowflake`](https://crates.io/crates/faucet-source-snowflake)
 - [`faucet-sink-snowflake`](https://crates.io/crates/faucet-sink-snowflake)
 
-Depend on this crate directly only if you are building a third-party connector that needs to accept the same auth shape in its config.
+Depend on it directly only if you are building a third-party Snowflake connector and want to accept the same `auth` config shape and produce correct request headers.
+
+## Installation
+
+```bash
+cargo add faucet-common-snowflake
+```
+
+## Usage
+
+In a config (the wire shape `SnowflakeAuth` deserializes from):
+
+```yaml
+# Key-pair JWT
+auth:
+  type: key_pair
+  config:
+    user: SVC_FAUCET
+    private_key_pem: ${file:./rsa_key.p8}
+
+# OAuth bearer
+auth:
+  type: oauth
+  config:
+    token: ${env:SNOWFLAKE_OAUTH_TOKEN}
+```
+
+In Rust, build the two headers a SQL REST API call needs:
+
+```rust
+use faucet_common_snowflake::{SnowflakeAuth, authorization_header, snowflake_token_type};
+
+let auth = SnowflakeAuth::OAuth { token: "ey...".into() };
+let account = "xy12345.us-east-1";
+
+let authorization = authorization_header(&auth, account)?;      // Snowflake Token="ey..."
+let token_type = snowflake_token_type(&auth);                   // "OAUTH"
+
+let resp = client
+    .post(format!("https://{account}.snowflakecomputing.com/api/v2/statements"))
+    .header("Authorization", authorization)
+    .header("X-Snowflake-Authorization-Token-Type", token_type)
+    .json(&body)
+    .send()
+    .await?;
+# Ok::<(), faucet_core::FaucetError>(())
+```
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause / fix |
+|---|---|
+| `401` from Snowflake with a key-pair JWT | The registered public key must match the private key in `private_key_pem`. The `iss` claim is `{ACCOUNT}.{USER}.SHA256:<fingerprint>`; verify the fingerprint matches `openssl rsa -pubout … \| openssl dgst -sha256 -binary \| base64`. |
+| `FaucetError::Auth("invalid RSA private key: …")` | `private_key_pem` isn't valid PKCS#8 or PKCS#1 PEM. Generate an RSA key in PEM form (encrypted keys are not supported — decrypt first). |
+| `FaucetError::Auth("Snowflake auth provider must yield a bearer/token credential")` | A shared `auth: { ref }` provider returned a `Basic`/`Header` credential. Only OAuth bearer/token credentials work; use inline `key_pair` for JWT auth. |
+| A private key showed up in logs | It shouldn't — `SnowflakeAuth`'s `Debug` masks all credentials as `"***"`. File an issue if you see one leak. |
+
+## See also
+
+- [Snowflake source crate](https://crates.io/crates/faucet-source-snowflake) · [Snowflake sink crate](https://crates.io/crates/faucet-sink-snowflake)
+- [Authentication cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/auth.html)
+- [Configuration reference](https://pawansikawat.github.io/faucet-stream/reference/config.html)
 
 ## License
 
-MIT OR Apache-2.0
+Licensed under either of:
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](../../../LICENSE-APACHE) or <https://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](../../../LICENSE-MIT) or <https://opensource.org/licenses/MIT>)
+
+at your option.

--- a/crates/core/README.md
+++ b/crates/core/README.md
@@ -2,6 +2,8 @@
 
 [![Crates.io](https://img.shields.io/crates/v/faucet-core.svg)](https://crates.io/crates/faucet-core)
 [![Docs.rs](https://docs.rs/faucet-core/badge.svg)](https://docs.rs/faucet-core)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-core.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-core.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
 Shared types, traits, and utilities for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
 

--- a/crates/core/README.md
+++ b/crates/core/README.md
@@ -5,233 +5,284 @@
 [![MSRV](https://img.shields.io/crates/msrv/faucet-core.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
 [![License](https://img.shields.io/crates/l/faucet-core.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-Shared types, traits, and utilities for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
+The foundation crate for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem — the shared traits, pipeline orchestration, error type, transforms, state stores, and reliability machinery that every source and sink connector builds on.
 
-This is the foundation crate that all faucet source and sink connectors depend on. If you're building a custom connector, this is the only dependency you need.
+**If you are building a custom connector, this is the only dependency you need.** `faucet-core` re-exports `async-trait`, `serde_json`, `schemars`, and `CancellationToken`, so a third-party `faucet-source-*` / `faucet-sink-*` crate can implement the `Source` / `Sink` traits without pulling those in directly. The traits are object-safe (`Box<dyn Source>` / `Box<dyn Sink>` work), and `Pipeline` is generic over any source + sink combination — so anything you write here drops straight into the `faucet` CLI and the umbrella crate.
+
+## Feature highlights
+
+- **Two object-safe traits** — [`Source`](https://docs.rs/faucet-core/latest/faucet_core/trait.Source.html) and [`Sink`](https://docs.rs/faucet-core/latest/faucet_core/trait.Sink.html), with rich defaults so a minimal connector needs only one method.
+- **Batch and streaming orchestration** — `Pipeline::run` (fetch-all) and `run_stream` (page-by-page, O(batch_size) memory) connect any source to any sink.
+- **Pluggable transforms** — `RecordTransform` (flatten, key/value casing, regex rename, cast, redact, …) plus stage-level `Filter` / `Explode` / `CdcUnwrap`, attachable to any source via `TransformingSource`.
+- **Durable bookmarks** — the `StateStore` trait with in-process `MemoryStateStore` and crash-safe `FileStateStore` built in; Redis / Postgres backends live in their own crates.
+- **Reliability primitives** — dead-letter queue routing, exactly-once delivery (`DeliveryMode`), key-based upsert/delete write modes, and per-page / per-record data-quality checks.
+- **Shared authentication** — the `AuthProvider` trait and `AuthSpec` config field give N connectors one token with single-flight refresh.
+- **Typed errors** — one `FaucetError` enum covers every failure path, with a `Custom` variant for third-party connector errors.
+- **Built-in observability** — pipelines emit `tracing` spans and `metrics` counters/histograms automatically; connectors only override `connector_name()` for a friendly label.
 
 ## Installation
 
 ```bash
+# As a connector author (the only dependency you need):
 cargo add faucet-core
-cargo add tokio --features rt
+cargo add tokio --features rt   # plus a runtime to drive the async traits
 ```
 
-## What's Inside
+`faucet-core` is always linked by the [`faucet-stream`](https://crates.io/crates/faucet-stream) umbrella crate and the [`faucet-cli`](https://crates.io/crates/faucet-cli) binary — you only depend on it directly when writing a connector or driving a pipeline from Rust.
 
-### Traits
+## Quick start — a minimal connector
 
-- **`Source`** — async trait for fetching records from external systems
-- **`Sink`** — async trait for writing records to external systems
-
-Both traits include a `config_schema()` method that returns a JSON Schema describing the connector's configuration.
-
-### Decorators
-
-- **`TransformingSource`** — wraps any `Source` with a fixed `Vec<TransformStage>` (covering 1→1 `Map(RecordTransform)`, 1→0|1 `Filter`, 1→0..N `Explode`, and arbitrary `Custom` closures) applied per page via `instrumented_apply_stages`. The canonical way library callers attach transforms — including filter and explode — to any source. See [`docs.rs`](https://docs.rs/faucet-core/latest/faucet_core/struct.TransformingSource.html).
-
-### `Source::stream_pages` (recommended for large sources)
-
-`stream_pages(ctx, batch_size)` returns a `Stream<Item = Result<StreamPage, FaucetError>>` where each `StreamPage` contains a chunk of records plus an optional bookmark. The default implementation wraps `fetch_with_context_incremental` and chunks the result in memory; sources that can stream natively (REST, CDC, query DBs with cursor pagination) override this method directly to bound source-side memory at O(batch_size). `Pipeline::run` drives this stream internally; library users do not normally call it themselves.
-
-`DEFAULT_BATCH_SIZE` is `1000`, `MAX_BATCH_SIZE` is `1_000_000`, and `validate_batch_size(n)` enforces the range with `FaucetError::Config` errors for connector authors to use at config-load time. **`batch_size = 0` is the "no batching" sentinel** — sources emit the entire result set in a single `StreamPage` (and sinks that expose their own `batch_size` accept whatever upstream hands them without re-chunking). Use it for small lookup tables or for bulk-load-style sinks (SQL `COPY`, BigQuery load jobs) that prefer one large request to many small ones.
+A source needs just one method; everything else has a default.
 
 ```rust
-use faucet_core::{async_trait, FaucetError, Source, Sink, Value};
+use faucet_core::{async_trait, FaucetError, Source, Sink, Value, json};
+
+struct MySource;
 
 #[async_trait]
 impl Source for MySource {
-    async fn fetch_all(&self) -> Result<Vec<Value>, FaucetError> {
-        // Fetch records
-        todo!()
+    async fn fetch_with_context(
+        &self,
+        _ctx: &std::collections::HashMap<String, Value>,
+    ) -> Result<Vec<Value>, FaucetError> {
+        Ok(vec![json!({ "id": 1 }), json!({ "id": 2 })])
     }
 
-    // Optional: incremental replication with bookmark
-    // async fn fetch_all_incremental(&self) -> Result<(Vec<Value>, Option<Value>), FaucetError>
-
-    // Optional: return JSON Schema of config
-    // fn config_schema(&self) -> Value
+    // Optional overrides: fetch_with_context_incremental (bookmarks),
+    // stream_pages (native streaming), config_schema, connector_name, …
 }
+
+struct MySink;
 
 #[async_trait]
 impl Sink for MySink {
     async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
-        // Write records, return count written
-        todo!()
+        for r in records {
+            println!("{r}");
+        }
+        Ok(records.len())
     }
-
-    // Optional: flush buffered data
-    // async fn flush(&self) -> Result<(), FaucetError>
-
-    // Optional: return JSON Schema of config
-    // fn config_schema(&self) -> Value
+    // Optional: flush(), config_schema(), supported_write_modes(), …
 }
 ```
 
-### Pipeline
+Then connect them with a `Pipeline`:
 
-Connect any source to any sink:
+```rust
+use faucet_core::Pipeline;
+
+# async fn run(source: MySource, sink: MySink) -> Result<(), faucet_core::FaucetError> {
+let result = Pipeline::new(&source, &sink).run().await?;
+println!("Wrote {} records", result.records_written);
+# Ok(())
+# }
+```
+
+## The `Source` trait
+
+`Source: Send + Sync`. Implement at least `fetch_with_context`; the rest have defaults.
+
+| Method | Purpose | Default |
+|--------|---------|---------|
+| `fetch_with_context(ctx)` | **Required.** Fetch all records, resolving `{placeholder}` tokens from a parent-record `ctx`. | — |
+| `fetch_all()` | Convenience: fetch with an empty context. | delegates to `fetch_with_context` |
+| `fetch_with_context_incremental(ctx)` | Fetch records + an optional bookmark `Value` for incremental replication. | `(records, None)` |
+| `fetch_all_incremental()` | Convenience: incremental fetch, empty context. | delegates above |
+| `stream_pages(ctx, batch_size)` | Stream `StreamPage`s so the pipeline writes per page (bounded memory). | chunks `fetch_*_incremental` in memory |
+| `config_schema()` | JSON Schema of the config struct (via `schema_for!`). | empty object |
+| `state_key()` | `Some(key)` opts into resumable runs (read before fetch, persist after sink confirms). | `None` |
+| `apply_start_bookmark(value)` | Apply a bookmark from the state store as the run's start point. | no-op |
+| `capture_resume_position()` | Capture the current replication position without consuming changes (used by `faucet replicate`). | `None` |
+| `supports_exactly_once()` | `true` only for sources that deterministically replay from a bookmark (CDC). | `false` |
+| `connector_name()` | Stable `&'static str` label for metrics/spans. | stripped `type_name` |
+| `dataset_uri()` | Credential-free OpenLineage dataset URI. | `"<connector_name>://unknown"` |
+| `check(ctx)` | Non-mutating preflight probe for `faucet doctor`. | pulls one page via `stream_pages` |
+
+## The `Sink` trait
+
+`Sink: Send + Sync`. Implement at least `write_batch`.
+
+| Method | Purpose | Default |
+|--------|---------|---------|
+| `write_batch(records)` | **Required.** Write a batch; return count written. | — |
+| `flush()` | Flush buffered data (Parquet footer, S3 multipart, …). | no-op |
+| `write_batch_partial(records)` | Per-row `RowOutcome`s so failed rows can be routed to a DLQ. | maps a single success → all-`Ok` |
+| `supports_idempotent_writes()` | `true` for sinks that commit rows + a commit token atomically. | `false` |
+| `write_batch_idempotent(records, scope, token)` | Atomic exactly-once write + watermark. | delegates to `write_batch` (not idempotent) |
+| `last_committed_token(scope)` | Highest committed token for resume-skip. | `None` |
+| `supported_write_modes()` | The `WriteMode`s this sink accepts (`Append` / `Upsert` / `Delete`). | `[Append]` |
+| `config_schema()` | JSON Schema of the config struct. | empty object |
+| `connector_name()` / `dataset_uri()` | Metrics label / lineage URI. | as for `Source` |
+| `check(ctx)` | Non-mutating preflight probe. | `not_implemented` (sinks override with a connect/auth probe) |
+
+## The `AuthProvider` trait
+
+A live, shareable source of credentials. Multiple connectors hitting the **same** identity provider hold an `Arc<dyn AuthProvider>` ([`SharedAuthProvider`]) and ask for the current `Credential` per request — so N connectors share one token with **single-flight refresh** instead of racing.
+
+```rust
+use faucet_core::{async_trait, AuthProvider, Credential, FaucetError};
+
+#[derive(Debug)]
+struct StaticToken(String);
+
+#[async_trait]
+impl AuthProvider for StaticToken {
+    async fn credential(&self) -> Result<Credential, FaucetError> {
+        Ok(Credential::Bearer(self.0.clone()))
+    }
+    fn provider_name(&self) -> &'static str { "static" }
+}
+```
+
+- `Credential` variants: `Bearer(token)`, `Header { name, value }`, `Basic { username, password }`, `Token(raw)`. Its `Debug` impl redacts secrets as `"***"` — part of the frozen 1.0 contract.
+- `invalidate(stale)` is a compare-and-swap refresh: connectors that all hit a `401` with the same token collapse into one refresh.
+- `AuthSpec<A>` is the connector config field: it accepts **either** inline `{ type, config }` auth **or** a `{ ref: <name> }` pointer to a provider in the top-level `auth:` catalog. `ref` and inline fields are mutually exclusive (enforced at deserialize time).
+
+Concrete HTTP-based providers (OAuth2 client-credentials / refresh, token-endpoint) live in the separate [`faucet-auth`](https://crates.io/crates/faucet-auth) crate so `faucet-core` stays free of an HTTP-client dependency.
+
+## Pipeline & streaming
 
 ```rust
 use faucet_core::{Pipeline, run_stream};
 
-// Batch mode: fetch all, then write
+// Batch mode: fetch all, then write.
 let result = Pipeline::new(&source, &sink).run().await?;
 println!("Wrote {} records", result.records_written);
 
-// Streaming mode: write page-by-page (bounded memory)
-let result = run_stream(source.stream_pages(), &sink).await?;
+// Streaming mode: write page-by-page (bounded memory).
+let ctx = std::collections::HashMap::new();
+let result = run_stream(source.stream_pages(&ctx, 1000), &sink).await?;
 ```
 
-### Error Types
+`Pipeline` builders compose the reliability features below:
 
-`FaucetError` covers all failure modes:
+```rust
+use faucet_core::{Pipeline, CancellationToken};
 
-| Variant | Use Case |
+let result = Pipeline::new(&source, &sink)
+    .with_state_store(state_store)   // durable bookmarks
+    .with_dlq(dlq_config)            // dead-letter routing
+    .with_quality(compiled_quality)  // per-page data-quality checks
+    .with_cancel(CancellationToken::new()) // flush-completing cooperative cancel
+    .run()
+    .await?;
+```
+
+### `stream_pages` and `batch_size`
+
+`stream_pages(ctx, batch_size)` returns a `Stream<Item = Result<StreamPage, FaucetError>>`; each `StreamPage` is a chunk of records plus an optional bookmark. The default implementation chunks `fetch_*_incremental` in memory; sources that can stream natively (REST, CDC, query DBs with cursor pagination) override it to bound source-side memory at O(batch_size). `Pipeline::run` drives this internally — library users rarely call it directly.
+
+- `DEFAULT_BATCH_SIZE` = `1000`, `MAX_BATCH_SIZE` = `1_000_000`.
+- `validate_batch_size(n)` enforces the range with `FaucetError::Config` for config-load-time validation.
+- **`batch_size = 0` is the "no batching" sentinel** — sources emit the entire result set in a single `StreamPage` (and sinks that expose their own `batch_size` accept whatever upstream hands them without re-chunking). Use it for small lookup tables or bulk-load sinks (SQL `COPY`, BigQuery load jobs).
+
+### Cooperative cancellation
+
+`Pipeline::with_cancel(CancellationToken)` (and `RunStreamOptions::with_cancel`) attach a cancel token. When cancelled mid-run, the page loop stops at the next page boundary, **flushes the sinks** (so a buffered Parquet/S3 sink writes its footer instead of orphaning the file), and returns `Ok` with the partial result. `CancellationToken` is re-exported from `faucet-core`, so callers need not add `tokio-util`.
+
+## Transforms
+
+Transform records as they flow through the pipeline. `RecordTransform` covers per-record (1→1) operations; stage-level variants add filter, explode, and CDC-unwrap.
+
+```rust
+use faucet_core::{RecordTransform, KeyCaseMode};
+
+// Flatten nested objects: {"user": {"id": 1}} -> {"user__id": 1}
+RecordTransform::Flatten { separator: "__".into() };
+
+// Convert keys to snake_case (or camel / pascal / kebab / screaming_snake)
+RecordTransform::KeysCase { mode: KeyCaseMode::Snake };
+
+// Regex key renaming
+RecordTransform::RenameKeys { pattern: r"^_sdc_".into(), replacement: "".into() };
+
+// Custom closure
+RecordTransform::custom(|record| record);
+```
+
+Built-in `RecordTransform` variants (each feature-gated `transform-<name>`; the `transforms` aggregate enables all): `flatten`, `rename_keys` (regex), `keys_case`, `select`, `drop`, `set`, `rename_field`, `cast` (`CastType` + `CastOnError`), `redact`, `value_case` (`ValueCaseMode`), `spell_symbols`, plus `Custom` closures.
+
+Stage-level transforms (`TransformStage`, in the `stage` module): `Map(RecordTransform)` (1→1), `Filter` (1→0|1), `Explode` (1→0..N), `CdcUnwrap` (normalize a CDC envelope into a flat row + `__op` marker — the standard pairing for an upsert sink), and `PageFn` (whole-page closure). Attach any set of stages to any source with `TransformingSource` — the canonical way library callers add transforms:
+
+```rust
+use faucet_core::{TransformingSource, TransformStage, RecordTransform};
+
+let stages = vec![TransformStage::Map(
+    RecordTransform::Flatten { separator: "__".into() }.compile()?,
+)];
+let wrapped = TransformingSource::new(source, stages);
+```
+
+## Error types
+
+`FaucetError` covers every failure mode:
+
+| Variant | Use case |
 |---------|----------|
 | `Http(reqwest::Error)` | HTTP transport errors |
-| `HttpStatus { status, url, body }` | Non-success HTTP responses |
+| `HttpStatus { status, url, body }` | Non-success HTTP responses (truncated body) |
 | `Json(serde_json::Error)` | JSON parse/serialize errors |
 | `JsonPath(String)` | JSONPath extraction failures |
 | `Auth(String)` | Authentication errors |
-| `RateLimited { retry_after }` | 429 rate limit responses |
-| `Url(String)` | URL construction errors |
-| `Transform(String)` | Record transform errors |
-| `Config(String)` | Configuration/validation errors |
+| `RateLimited(Duration)` | 429 responses (wait duration from `Retry-After`) |
+| `Url(String)` | URL construction/parse errors |
+| `Transform(String)` | Record-transform compile/apply errors |
+| `Config(String)` | Configuration / validation errors |
 | `Source(String)` | Source-specific errors |
 | `Sink(String)` | Sink-specific errors |
-| `Custom(Box<dyn Error>)` | Wrap any third-party error |
+| `QualityFailure { check, message }` | A quality check failed under `abort` |
+| `State(String)` | State-store read/write/delete failures |
+| `Custom(Box<dyn Error + Send + Sync>)` | Wrap any third-party connector error |
 
-### Config Loading
+`FaucetError::is_retriable()` classifies transient failures (network errors, 5xx, 429) so connectors can drive `execute_with_retry` (exponential backoff + jitter, also re-exported). The `Custom` variant is intentionally permanent in the public API so connector authors can wrap their own error types without losing the chain.
 
-Load any `Deserialize`-able config struct from JSON files or environment variables:
+## State stores (resume & bookmarks)
 
-```rust
-use faucet_core::config::{load_json, load_env, load_env_file};
+The `StateStore` trait is a minimal async key/value store over `Value` (`get` / `put` / `delete`). Sources that override `state_key()` opt into resumable runs: the pipeline reads the bookmark before fetching and persists the new one **only after the sink confirms** the batch.
 
-// From a JSON file
-let config: MyConfig = load_json("config.json")?;
-
-// From environment variables (reads MYAPP_URL, MYAPP_BATCH_SIZE, etc.)
-let config: MyConfig = load_env("MYAPP")?;
-
-// From a .env file + environment variables
-let config: MyConfig = load_env_file(".env", "MYAPP")?;
-```
-
-#### Duration Serde Helpers
-
-For `Duration` fields in configs, use the provided serde modules:
+| Backend | Crate | Use when |
+|---------|-------|----------|
+| `MemoryStateStore` | `faucet-core` | Tests, or runs that start fresh each time. |
+| `FileStateStore` | `faucet-core` | One JSON file per key, written via atomic rename (crash-safe). |
+| `RedisStateStore` | [`faucet-state-redis`](https://crates.io/crates/faucet-state-redis) | Shared bookmarks across hosts. |
+| `PostgresStateStore` | [`faucet-state-postgres`](https://crates.io/crates/faucet-state-postgres) | Durable bookmarks in an existing Postgres. |
 
 ```rust
-use std::time::Duration;
-use serde::{Serialize, Deserialize};
+use faucet_core::{Pipeline, FileStateStore};
+use std::sync::Arc;
 
-#[derive(Serialize, Deserialize)]
-struct MyConfig {
-    #[serde(with = "faucet_core::config::duration_secs")]
-    timeout: Duration,                    // serializes as u64 seconds
-
-    #[serde(with = "faucet_core::config::duration_secs_option", default)]
-    retry_delay: Option<Duration>,        // serializes as Option<u64>
-}
+let store = Arc::new(FileStateStore::new("./state"));
+let result = Pipeline::new(&source, &sink)
+    .with_state_store(store)
+    .run()
+    .await?;
 ```
 
-### Record Transforms
+State keys are validated via `state::validate_state_key`.
 
-Transform records as they flow through the pipeline:
+## Dead-letter queue (DLQ)
 
-```rust
-use faucet_core::RecordTransform;
+`Pipeline::with_dlq(DlqConfig)` attaches an optional DLQ sink. The streaming loop calls `Sink::write_batch_partial` per page; rows that come back `Err` are wrapped in a fixed-shape envelope (`build_envelope`) and routed to the DLQ before the page bookmark advances. `OnBatchError` controls the policy when a sink can't report per-row results: `propagate` aborts the run; `dlq_all` routes the whole failed page. Sinks override `write_batch_partial` to expose per-row results (BigQuery `insertAll`, Elasticsearch `_bulk`).
 
-// Flatten nested objects: {"user": {"id": 1}} -> {"user__id": 1}
-RecordTransform::Flatten { separator: "__".into() }
+## Exactly-once delivery
 
-// Convert keys to snake_case (or camel / pascal / kebab / screaming_snake)
-RecordTransform::KeysCase { mode: KeyCaseMode::Snake }
+`DeliveryMode` (`AtLeastOnce` default, or `ExactlyOnce`) controls run semantics. Under `ExactlyOnce` the pipeline assigns a monotonic fixed-width commit token (`format_token(seq)`) to each bookmark-carrying page and calls `write_batch_idempotent(records, scope, token)`; the sink commits records **and** token atomically. On resume, `last_committed_token(scope)` is consulted to skip already-committed pages.
 
-// Regex key renaming
-RecordTransform::RenameKeys {
-    pattern: r"^_sdc_".into(),
-    replacement: "".into(),
-}
+Exactly-once requires a **deterministic-replay source** (`supports_exactly_once() == true` — CDC sources) and an **idempotent sink** (`supports_idempotent_writes() == true`). The bookmark + sequence persist together via `wrap_state(bookmark, seq)` / `unwrap_state(value)`.
 
-// Custom closure
-RecordTransform::custom(|mut record| {
-    // modify record
-    record
-})
-```
+## Write modes (upsert / delete)
 
-### Replication
+`faucet_core::write_mode` is the unified upsert layer. `WriteSpec` (`write_mode` + `key` + `delete_marker`) flattens into a capable sink's config; `plan_writes(page, &spec) -> WritePlan { upserts, deletes, failed }` is the single partitioning routine (last-write-wins dedup by `key`; missing/null-key rows → `failed` for DLQ/abort). Sinks advertise support via `supported_write_modes()`. Helpers: `key_to_doc_id`, `key_to_filter`, `KeyTuple`.
 
-Incremental replication support:
+## Data-quality checks
 
-```rust
-use faucet_core::ReplicationMethod;
-use faucet_core::replication::{filter_incremental, max_replication_value};
+Add a `quality:` block (sibling of `transforms:` and `dlq:` under `pipeline:`) to assert invariants on every page before records reach the sink. The quality pass runs **after** transforms and **before** `write_batch`: per-record checks partition the page into survivors and quarantined rows, then per-batch checks run over the survivors. Quarantined rows are routed to the DLQ.
 
-// Filter records newer than a bookmark
-let filtered = filter_incremental(&records, "updated_at", &bookmark_value);
+Enable with the `quality` Cargo feature (base) or `quality-jsonschema` (adds the `json_schema` record check).
 
-// Compute new bookmark from records
-let new_bookmark = max_replication_value(&records, "updated_at");
-```
+### Check catalog
 
-### Schema Inference
-
-Infer JSON Schema from record samples:
-
-```rust
-use faucet_core::schema::infer_schema;
-
-let schema = infer_schema(&records);
-// Returns a JSON Schema with inferred types, nullable fields, nested objects
-```
-
-### JSON Schema Generation
-
-All config structs derive `schemars::JsonSchema`. Use `schema_for!` to generate schemas:
-
-```rust
-use faucet_core::{schema_for, JsonSchema};
-use serde::{Serialize, Deserialize};
-
-#[derive(Serialize, Deserialize, JsonSchema)]
-struct MyConfig {
-    url: String,
-    batch_size: usize,
-}
-
-let schema = schema_for!(MyConfig);
-let json = serde_json::to_value(schema)?;
-```
-
-## Re-exports
-
-`faucet-core` re-exports common dependencies so connector authors only need one dependency:
-
-| Re-export | From |
-|-----------|------|
-| `async_trait` | `async-trait` |
-| `serde_json`, `Value`, `json!` | `serde_json` |
-| `schemars`, `JsonSchema`, `schema_for!` | `schemars` |
-
-### Quality checks
-
-Add a `quality:` block (sibling of `transforms:` and `dlq:` under `pipeline:`) to
-assert invariants on every page of records before they reach the sink. The quality
-pass runs **after** transforms and **before** `write_batch`; per-record checks
-partition the page into survivors and quarantined rows, then per-batch checks run
-over the survivors. Quarantined rows are routed to the DLQ sink.
-
-Enable with the `quality` Cargo feature (base) or `quality-jsonschema` to add the
-`json_schema` record check.
-
-#### Check catalog
-
-**Per-record checks** — each record is evaluated in declared order; first failure
-wins. `on_failure` may be `quarantine` (route the row to the DLQ) or `abort` (fail
-the run immediately with `FaucetError::QualityFailure`).
+**Per-record checks** — each record is evaluated in declared order; first failure wins. `on_failure` may be `quarantine` (route the row to the DLQ) or `abort` (fail the run with `FaucetError::QualityFailure`).
 
 | Check | Key config fields | Passes when | Missing field |
 |---|---|---|---|
@@ -245,15 +296,9 @@ the run immediately with `FaucetError::QualityFailure`).
 | `string_length` | `field`, `min?`, `max?` (at least one required) | char count in `[min, max]` | fail |
 | `json_schema` *(quality-jsonschema feature)* | `schema` (JSON Schema doc) | record validates against `schema` | (whole-record check; always evaluated) |
 
-`json_schema` is the most expressive check; its cost scales with schema
-complexity — for very large or deeply nested schemas on hot paths, prefer the
-granular checks above and benchmark your case.
+`json_schema` is the most expressive check; its cost scales with schema complexity — for very large or deeply nested schemas on hot paths, prefer the granular checks above and benchmark your case.
 
-**Per-batch checks** — evaluated per page over the survivors (records that passed
-the per-record pass). `on_failure` for aggregate checks (`row_count`, `null_rate`,
-`distinct_count`) may be `abort` or `quarantine_batch` (route all current survivors
-to the DLQ, write nothing this page). `unique` is row-attributable and accepts
-`quarantine` (route the duplicate rows) or `abort`.
+**Per-batch checks** — evaluated per page over the survivors. `on_failure` for aggregate checks (`row_count`, `null_rate`, `distinct_count`) may be `abort` or `quarantine_batch` (route all current survivors to the DLQ, write nothing this page). `unique` is row-attributable and accepts `quarantine` or `abort`.
 
 | Check | Key config fields | Passes when |
 |---|---|---|
@@ -262,7 +307,7 @@ to the DLQ, write nothing this page). `unique` is row-attributable and accepts
 | `unique` | `fields: [...]` (composite key, ≥1) | every survivor's key is unique within the page |
 | `distinct_count` | `field`, `min?`, `max?` | distinct values of `field` in `[min, max]` |
 
-#### `on_failure` policies
+### `on_failure` policies
 
 | Policy | Meaning | Allowed on |
 |---|---|---|
@@ -270,10 +315,9 @@ to the DLQ, write nothing this page). `unique` is row-attributable and accepts
 | `quarantine_batch` | Route all survivors of the page to the DLQ; write nothing this page | aggregate batch checks |
 | `abort` | Surface `FaucetError::QualityFailure` and fail the run | every check |
 
-**`quarantine` and `quarantine_batch` require a DLQ sink.** Configuring either
-without a `dlq:` block is rejected at config-load time with `FaucetError::Config`.
+**`quarantine` and `quarantine_batch` require a DLQ sink.** Configuring either without a `dlq:` block is rejected at config-load time with `FaucetError::Config`.
 
-#### Example
+### Example (YAML, via the CLI)
 
 ```yaml
 pipeline:
@@ -285,14 +329,6 @@ pipeline:
       method: GET
       auth: { type: bearer, config: { token: "${env:API_TOKEN}" } }
       pagination: { type: Cursor, next_token_path: $.meta.next_cursor, param_name: cursor }
-      max_retries: 3
-      retry_backoff: 2
-      tolerated_http_errors: []
-      replication_method: { type: Incremental }
-      replication_key: updated_at
-      primary_keys: ["id"]
-      partitions: []
-      schema_sample_size: 100
 
   transforms:
     - type: keys_case
@@ -303,16 +339,9 @@ pipeline:
       - type: not_null
         field: id
         on_failure: abort
-      - type: not_null
-        field: email
-        on_failure: quarantine
       - type: regex_match
         field: email
         pattern: '^[^@\s]+@[^@\s]+\.[^@\s]+$'
-        on_failure: quarantine
-      - type: value_in_set
-        field: status
-        values: ["active", "inactive", "pending", "suspended"]
         on_failure: quarantine
     batch:
       - type: row_count
@@ -338,7 +367,7 @@ pipeline:
       batch_size: 500
 ```
 
-#### Rust API
+### Quality — Rust API
 
 ```rust
 use faucet_core::{Pipeline, CompiledQuality, QualitySpec};
@@ -352,21 +381,118 @@ let result = Pipeline::new(&source, &sink)
     .await?;
 ```
 
+## Config loading & schema
+
+Load any `Deserialize`-able config from JSON files or environment variables:
+
+```rust
+use faucet_core::config::{load_json, load_env, load_env_file};
+
+let config: MyConfig = load_json("config.json")?;          // from a JSON file
+let config: MyConfig = load_env("MYAPP")?;                 // from MYAPP_* env vars
+let config: MyConfig = load_env_file(".env", "MYAPP")?;    // .env file + env vars
+```
+
+For `Duration` config fields, use the provided serde modules:
+
+```rust
+#[derive(serde::Serialize, serde::Deserialize)]
+struct MyConfig {
+    #[serde(with = "faucet_core::config::duration_secs")]
+    timeout: std::time::Duration,                         // u64 seconds
+    #[serde(with = "faucet_core::config::duration_secs_option", default)]
+    retry_delay: Option<std::time::Duration>,             // Option<u64>
+}
+```
+
+All config structs derive `schemars::JsonSchema`; implement `config_schema()` with `schema_for!` so the CLI's `faucet schema source|sink <name>` and `faucet init` can introspect them:
+
+```rust
+use faucet_core::{schema_for, JsonSchema};
+
+#[derive(serde::Serialize, serde::Deserialize, JsonSchema)]
+struct MyConfig { url: String, batch_size: usize }
+
+let schema = serde_json::to_value(schema_for!(MyConfig))?;
+```
+
+## Re-exports for connector authors
+
+`faucet-core` re-exports the dependencies a connector needs, so a third-party crate depends only on `faucet-core`:
+
+| Re-export | From | Why |
+|-----------|------|-----|
+| `async_trait` | `async-trait` | Implement the `Source` / `Sink` async traits |
+| `serde_json`, `Value`, `json!` | `serde_json` | The record type and JSON literals |
+| `schemars`, `JsonSchema`, `schema_for!` | `schemars` | Config-schema introspection |
+| `Stream`, `async_stream`, `futures_core` | `futures-core` / `async-stream` | Implement `stream_pages` |
+| `CancellationToken` | `tokio-util` | Name the token for `with_cancel` without adding `tokio-util` |
+
+> **Keep `faucet-core` the only required dependency.** If your connector needs a new common dependency, propose re-exporting it from `faucet-core` rather than requiring every connector author to add it. Keep the `Source` / `Sink` traits object-safe (no connector-specific types or generics on methods) and `FaucetError::Custom` intact for third-party error wrapping.
+
 ## Modules
 
 | Module | Contents |
 |--------|----------|
-| `traits` | `Source` and `Sink` async traits |
-| `error` | `FaucetError` enum |
-| `pipeline` | `Pipeline`, `PipelineResult`, `run_stream` |
+| `traits` | `Source` and `Sink` async traits; `RowOutcome` |
+| `auth` | `AuthProvider`, `Credential`, `AuthSpec`, `SharedAuthProvider` |
+| `pipeline` | `Pipeline`, `PipelineResult`, `StreamPage`, `run_stream`, batch-size constants |
+| `error` | `FaucetError` enum + `is_retriable` |
 | `config` | `load_json`, `load_env`, `load_env_file`, duration serde helpers |
-| `transform` | `RecordTransform`, `CompiledTransform`, plus support enums (`CastType`, `CastOnError`, `ValueCaseMode`) |
+| `transform` | `RecordTransform`, `CompiledTransform`, support enums (`CastType`, `CastOnError`, `KeyCaseMode`, `ValueCaseMode`) |
+| `transforming_source` | `TransformingSource` — attach stages to any source |
+| `stage` | `TransformStage`, `FilterSpec`, `ExplodeSpec`, `CdcUnwrapSpec`, `compile_stage` |
+| `state` | `StateStore` trait, `MemoryStateStore`, `FileStateStore`, `validate_state_key` |
+| `dlq` | `DlqConfig`, `OnBatchError`, `DlqReason`, `DlqStats`, `build_envelope` |
+| `idempotency` | `DeliveryMode`, `format_token`, `parse_token`, `wrap_state`, `unwrap_state` |
+| `write_mode` | `WriteMode`, `WriteSpec`, `DeleteMarker`, `plan_writes`, `WritePlan` |
+| `quality` | Per-record / per-batch checks (`quality` / `quality-jsonschema` features) |
 | `replication` | `ReplicationMethod`, `filter_incremental`, `max_replication_value` |
-| `schema` | `infer_schema` |
-| `stage` | `TransformStage`, `FilterSpec`, `ExplodeSpec`, `OnMissing`. The pipeline-level stage type that wraps `RecordTransform` (1→1) and adds filter (1→0\|1) and explode (1→0..N). See `docs/book/src/cookbook/transforms.md` for the merge rule and JSONPath subset. |
-| `quality` | Per-record and per-batch data-quality checks: `QualitySpec` config, `CompiledQuality`, `apply_quality`, `QualityOutcome`. Gated on the `quality` / `quality-jsonschema` features. |
-| `util` | `quote_ident`, `extract_records`, `check_http_response` |
+| `retry` | `execute_with_retry` (exponential backoff + jitter) |
+| `schema` | `infer_schema` from record samples |
+| `check` | `CheckContext`, `Probe`, `CheckReport` for `faucet doctor` |
+| `observability` | Pipeline-internal `tracing`/`metrics` decorators; `install_observability` |
+| `compression` | `CompressionConfig`, `compress_buf` (the `compression` feature) |
+| `util` | `quote_ident`, `extract_records`, `check_http_response`, `redact_uri_credentials` |
+
+## Feature flags
+
+Defaults: `transform-flatten`, `transform-rename-keys`, `transform-keys-case`.
+
+| Feature | Enables |
+|---------|---------|
+| `transform-<name>` | One built-in transform (`flatten`, `rename-keys`, `keys-case`, `select`, `drop`, `set`, `rename-field`, `cast`, `redact`, `value-case`, `spell-symbols`, `filter`, `explode`, `cdc-unwrap`) |
+| `transforms` | All built-in transforms |
+| `quality` | The 12 base per-record / per-batch quality checks |
+| `quality-jsonschema` | Adds the `json_schema` record check (pulls `jsonschema`) |
+| `compression` | `CompressionConfig` + gzip/zstd helpers |
+| `observability-install` | `install_observability` (Prometheus exporter + tracing subscriber) |
+
+> Connector authors: enable in your **own** `Cargo.toml` every feature your crate uses — the feature-isolation CI matrix builds each connector alone, so relying on workspace feature unification compiles locally but fails CI.
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause & fix |
+|---------|--------------------|
+| `the trait Source is not object-safe` / can't `Box<dyn Source>` | You added a method with a generic or an associated type. Keep trait methods concrete; give new methods a default impl so existing connectors don't break. |
+| Records aren't being transformed when driving a source from Rust | Transforms aren't part of the `Source` trait. Wrap the source with `TransformingSource::new(source, stages)` — there is no per-connector `add_transform`. |
+| `FaucetError::Config: batch_size out of range` | `batch_size` exceeded `MAX_BATCH_SIZE` (1,000,000). Use `validate_batch_size` at load time; `0` is the valid "no batching" sentinel. |
+| Bookmark never persists across runs | Your source returns `None` from `state_key()`, or no `with_state_store` was set. Override `state_key()` and read the bookmark via `apply_start_bookmark`. |
+| `DeliveryMode::ExactlyOnce` rejected | The source isn't deterministic-replay (`supports_exactly_once()` is `false`) or the sink isn't idempotent (`supports_idempotent_writes()` is `false`). Exactly-once needs a CDC source + an idempotent sink + a state store + no DLQ. |
+| Quality config rejected at load time | A `quarantine` / `quarantine_batch` policy was set without a `dlq:` block, or a regex / JSON Schema / bound is invalid — `CompiledQuality::compile` is fail-fast. Add a DLQ or fix the spec. |
+| `Custom` errors lose their cause | Wrap with `FaucetError::Custom(Box::new(your_error))` — it implements `From<Box<dyn Error + Send + Sync>>` and preserves the chain. |
+| Secret printed in logs | `Credential`'s `Debug` redacts secrets, but connector-specific debug logging is outside that boundary. Never run a secret-bearing pipeline at `FAUCET_LOG=debug`. |
+| Buffered sink output lost on cancel | Use `Pipeline::with_cancel` (not a dropped future): cancellation flushes at the next page boundary so Parquet/S3 sinks finalize their output. |
+
+## See also
+
+- **Concepts & library guide:** <https://pawansikawat.github.io/faucet-stream/getting-started/concepts.html> · <https://pawansikawat.github.io/faucet-stream/tutorials/library.html>
+- **Transforms cookbook:** <https://pawansikawat.github.io/faucet-stream/cookbook/transforms.html>
+- **State & exactly-once:** <https://pawansikawat.github.io/faucet-stream/cookbook/state.html>
+- **Upsert / write modes:** <https://pawansikawat.github.io/faucet-stream/cookbook/upsert.html>
+- **Quality checks & DLQ:** <https://pawansikawat.github.io/faucet-stream/reference/config.html>
+- **Related crates:** [`faucet-auth`](https://crates.io/crates/faucet-auth) (shared auth providers) · [`faucet-state-redis`](https://crates.io/crates/faucet-state-redis) / [`faucet-state-postgres`](https://crates.io/crates/faucet-state-postgres) (state backends) · [`faucet-stream`](https://crates.io/crates/faucet-stream) (umbrella) · [`faucet-cli`](https://crates.io/crates/faucet-cli) (the `faucet` binary)
 
 ## License
 
-Licensed under either of [MIT](../../LICENSE-MIT) or [Apache-2.0](../../LICENSE-APACHE) at your option.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/lineage/README.md
+++ b/crates/lineage/README.md
@@ -1,104 +1,345 @@
 # faucet-lineage
 
-OpenLineage event emission for
-[`faucet-stream`](https://github.com/PawanSikawat/faucet-stream).
+[![Crates.io](https://img.shields.io/crates/v/faucet-lineage.svg)](https://crates.io/crates/faucet-lineage)
+[![Docs.rs](https://docs.rs/faucet-lineage/badge.svg)](https://docs.rs/faucet-lineage)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-lineage.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-lineage.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-Every pipeline run emits OpenLineage `RunEvent`s
-(`START` / `RUNNING` / `COMPLETE` / `ABORT` / `FAIL`) describing the job, run,
-input/output datasets, inferred schemas, and column-level lineage to a
-configured HTTP, file, or Kafka backend. Wired automatically by the `faucet`
-CLI via a top-level `lineage:` block; the types here are also usable directly by
-library callers.
+[OpenLineage](https://openlineage.io/) event emission for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem. Every pipeline run emits OpenLineage `RunEvent`s describing the job, the run, its input/output datasets, their inferred schemas, and column-level lineage — to an HTTP endpoint (e.g. [Marquez](https://marquezproject.ai/)), a local JSON Lines file, or a Kafka topic.
 
-**OpenLineage spec version: 2.0.2.** Every event carries the pinned schema URL
-[`event::OL_SCHEMA_URL`]
-(`https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/RunEvent`).
+Reach for it when you want your faucet-stream pipelines to show up in a lineage / data-catalog tool automatically — no per-connector instrumentation, no code in your data path. The `faucet` CLI wires it from a single top-level `lineage:` block; the types here are also usable directly by library callers via [`LineageEmitter`].
 
-## Emission never fails a run
+**OpenLineage spec version: 2.0.2.** Every event carries the pinned schema URL `https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/RunEvent`.
 
-Lineage is observability, not a data path. The [`LineageEmitter::emit`] method
-returns no error: a transport failure (HTTP non-2xx, unreachable file, Kafka
-send error), a serialization failure, or a disabled event is logged and counted,
-then dropped. A broken lineage backend can never abort or stall a pipeline.
+## Feature highlights
 
-## Configuration
+- **Automatic lifecycle events** — `START` / `RUNNING` / `COMPLETE` / `ABORT` / `FAIL` emitted around every pipeline run, with per-event toggles.
+- **Three transports** — HTTP (with optional bearer auth), local JSON Lines file, or Kafka — all using the project-wide `{ type, config }` shape.
+- **Schema facets** — inferred `(field, type)` dataset schemas attached to inputs/outputs on terminal events, derived from a bounded record sample.
+- **Deterministic column-level lineage** — per-output-field input edges folded over the declared transform chain, emitted only when the whole chain is mappable (never fabricated).
+- **Parent-job linkage** — tie runs to an orchestrator job (Airflow, Dagster, …) via `parent_job`.
+- **Emission never fails a run** — a broken lineage backend is logged and counted, then dropped; it can never abort or stall a pipeline.
+- **Cheap to enable** — emission work happens in the CLI layer; the hot `run_stream` loop is untouched.
 
-The `lineage:` block deserializes into [`LineageConfig`]:
+## Installation
+
+```bash
+# As a library:
+cargo add faucet-lineage
+
+# In the CLI (opt-in feature — enables the top-level `lineage:` block):
+cargo install faucet-cli --features lineage
+
+# Add the Kafka transport:
+cargo install faucet-cli --features lineage-kafka
+```
+
+`lineage` is a **CLI-only** feature and is **not** in the CLI `default` build — it is included in `full`. The `lineage` CLI feature enables HTTP + file transports; `lineage-kafka` additionally enables the Kafka transport (pulls in `rdkafka`).
+
+## Quick start
+
+Add a top-level `lineage:` block to any pipeline config. The pipeline below pulls from PostgreSQL, shapes records, and lands them in BigQuery, emitting OpenLineage events to a Marquez endpoint on the way:
+
+```yaml
+# pipeline.yaml — faucet run pipeline.yaml
+version: 1
+name: orders_load
+
+lineage:
+  namespace: prod.warehouse
+  transport:
+    type: http
+    config:
+      url: ${env:MARQUEZ_URL}   # e.g. http://localhost:5000/api/v1/lineage
+  include_schema_facet: true
+  include_column_lineage: true
+
+pipeline:
+  source:
+    type: postgres
+    config:
+      connection_url: postgres://user:pass@localhost/app
+      query: SELECT id, created_at, customer_email FROM orders
+  transforms:
+    - type: rename_field
+      config:
+        fields:
+          customer_email: contact_email
+  sink:
+    type: jsonl
+    config:
+      path: ./orders.jsonl
+```
+
+```bash
+faucet run pipeline.yaml
+```
+
+A full end-to-end example lives at [`cli/examples/postgres_to_bigquery_with_lineage.yaml`](https://github.com/PawanSikawat/faucet-stream/blob/main/cli/examples/postgres_to_bigquery_with_lineage.yaml).
+
+## OpenLineage event types
+
+faucet-lineage emits standard OpenLineage `RunEvent`s. The pipeline's lifecycle maps to event types as follows; each can be toggled independently via `emit_on`:
+
+| Event | When | Default | Carries terminal facets? |
+|-------|------|---------|--------------------------|
+| `START` | Just before the run begins. | on | no |
+| `RUNNING` | Periodic heartbeat while the run is in flight (every `heartbeat_interval`). | **off** | no |
+| `COMPLETE` | The run finished successfully. | on | yes |
+| `ABORT` | The run was cancelled. | on | yes |
+| `FAIL` | The run errored. | on | yes |
+
+"Terminal facets" (schema + column-lineage) are attached only to the terminal events (`COMPLETE` / `ABORT` / `FAIL`), because they depend on the record sample observed during the run.
+
+## Configuration reference
+
+The `lineage:` block deserializes into [`LineageConfig`]. Unknown top-level fields are rejected.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `type` | enum | `openlineage` | Lineage format. Only `openlineage` exists in v1. |
+| `namespace` | string | — *(required)* | OpenLineage namespace for the emitted job and datasets. |
+| `transport` | `Transport` | — *(required)* | Where events are sent — see [Transports](#transports). |
+| `job_name` | string | `"${name}::${row_id}"` | Job-name template; `${name}` / `${row_id}` / `${now.*}` resolve per matrix row at run time. |
+| `parent_job` | `ParentJob` | *(unset)* | Optional orchestrator linkage — see [Parent job](#parent-job). |
+| `include_schema_facet` | bool | `false` | Emit inferred `(field, type)` dataset schema facets on input/output datasets. |
+| `include_column_lineage` | bool | `false` | Emit column-level lineage facets when the transform chain is mappable. |
+| `include_source_code_facet` | bool | `false` | Emit the resolved config body as a `SourceCode` job facet. **Off by default — the resolved config may contain secrets; enabling logs a warning.** |
+| `emit_on` | `EmitOn` | see below | Which lifecycle events to emit — see [Emit toggles](#emit-toggles-emit_on). |
+| `sample_records` | int | `100` | Max records sampled for schema / column-lineage facets. |
+| `heartbeat_interval` | int (seconds) | `30` | Interval between `RUNNING` heartbeat events; only used when `emit_on.running` is `true`. |
+
+### Transports
+
+`transport` uses the project-wide `{ type, config: { … } }` shape (adjacently tagged):
+
+| `type`  | Backend                                  | `config` fields |
+|---------|------------------------------------------|-----------------|
+| `http`  | OpenLineage HTTP endpoint (e.g. Marquez) | `url` *(required)*, `timeout_secs` (default `10`), `auth` (optional — see below). `POST`s one event per call; a non-2xx response is logged and dropped. |
+| `file`  | Local JSON Lines file                    | `path` *(required)*. Appends one JSON object per line; parent directories are created. |
+| `kafka` | Kafka topic                              | `brokers` *(required)*, `topic` *(required)*. One JSON message per event. **Requires the `transport-kafka` feature.** |
+
+```yaml
+# HTTP — POST to an OpenLineage endpoint
+transport:
+  type: http
+  config:
+    url: https://marquez/api/v1/lineage
+    timeout_secs: 10
+    auth:
+      type: bearer
+      config:
+        token: ${env:MARQUEZ_TOKEN}
+```
+
+```yaml
+# File — append JSON Lines locally (great for testing)
+transport:
+  type: file
+  config:
+    path: ./out/lineage.jsonl
+```
+
+```yaml
+# Kafka — requires the transport-kafka feature
+transport:
+  type: kafka
+  config:
+    brokers: localhost:9092
+    topic: openlineage.events
+```
+
+#### HTTP transport auth
+
+The nested `auth` uses the same `{ type, config }` shape as connector auth. Only bearer is supported:
+
+| `type`  | `config`          | Effect |
+|---------|-------------------|--------|
+| `bearer`| `{ token: <str> }`| Sends `Authorization: Bearer <token>` on each POST. |
+
+### Parent job
+
+`parent_job` links each run to an upstream orchestrator job, populating OpenLineage's `parent` run facet:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `namespace` | string | — *(required)* | Orchestrator namespace (e.g. `airflow`). |
+| `name` | string | — *(required)* | Parent job name (e.g. `warehouse_dag.load_orders`). |
+| `run_id` | string | *(unset)* | Parent run id. When omitted, the pipeline's own run id is used as the parent run reference. |
+
+```yaml
+parent_job:
+  namespace: airflow
+  name: warehouse_dag.load_orders
+  run_id: 0190-abc...   # optional
+```
+
+### Emit toggles (`emit_on`)
+
+Per-event booleans. Defaults: `start`, `complete`, `fail`, `abort` are `true`; `running` is `false`.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `start` | bool | `true` | Emit a `START` event. |
+| `running` | bool | `false` | Emit periodic `RUNNING` heartbeats every `heartbeat_interval`. |
+| `complete` | bool | `true` | Emit a `COMPLETE` event on success. |
+| `fail` | bool | `true` | Emit a `FAIL` event on error. |
+| `abort` | bool | `true` | Emit an `ABORT` event on cancellation. |
+
+```yaml
+emit_on:
+  start: true
+  running: true        # opt into heartbeats
+  complete: true
+  fail: true
+  abort: true
+heartbeat_interval: 15
+```
+
+## Schema facets
+
+When `include_schema_facet: true`, the run wraps its source and sink in sampling wrappers ([`SamplingSource`] / [`SamplingSink`]) that clone up to `sample_records` records, infer an ordered `(field, type)` schema, and attach it to the input/output datasets on the terminal event.
+
+Inferred OpenLineage types: `null`, `boolean`, `integer`, `number`, `string`, `array`, `object`.
+
+## Column-level lineage
+
+When `include_column_lineage: true`, the declared transform chain is folded over the input field set ([`derive_column_lineage`]) to produce per-output-field input edges. Lineage is **only** emitted when *every* transform in the chain is mappable; if any transform is opaque, no column-lineage facet is attached for that run — it is never fabricated.
+
+| Transform | Column lineage |
+|-----------|----------------|
+| `rename_field`, `select`, `drop`, `set` | **Mapped** — explicit key relationships. |
+| `cast`, `redact`, `value_case`, `spell_symbols`, `filter` | **Mapped** — identity (keys unchanged). |
+| `flatten`, `explode`, `keys_case`, `rename_keys`, custom Rust closures | **Opaque** — facet suppressed for the whole run. |
+
+A `set` field with no upstream column produces a literal output field with no input edge.
+
+## Examples
+
+### File transport for local development
 
 ```yaml
 lineage:
-  type: openlineage              # only "openlineage" in v1 (default)
-  namespace: prod.warehouse      # OpenLineage namespace for job + datasets
+  namespace: dev.local
   transport:
-    type: http                   # http | file | kafka
+    type: file
     config:
-      url: https://marquez/api/v1/lineage
-      timeout_secs: 10           # default 10s
+      path: ./out/lineage.jsonl
+  include_schema_facet: true
+```
+
+### HTTP with bearer auth and an orchestrator parent
+
+```yaml
+lineage:
+  namespace: prod.warehouse
+  job_name: ${name}::${row_id}
+  transport:
+    type: http
+    config:
+      url: ${env:MARQUEZ_URL}
+      timeout_secs: 15
       auth:
         type: bearer
         config:
           token: ${env:MARQUEZ_TOKEN}
-  job_name: "${name}::${row_id}" # template; resolved per matrix row (default)
-  parent_job:                    # optional orchestrator linkage
+  parent_job:
     namespace: airflow
     name: warehouse_dag.load_orders
-    run_id: 0190-abc...          # optional
-  include_schema_facet: true     # emit inferred dataset schemas (default false)
-  include_column_lineage: true   # emit column-lineage facets (default false)
-  include_source_code_facet: false  # emit resolved config (default false; warns)
-  emit_on:                       # which lifecycle events to send
-    start: true                  # default true
-    running: false               # default false (RUNNING heartbeat)
-    complete: true               # default true
-    fail: true                   # default true
-    abort: true                  # default true
-  sample_records: 100            # records sampled for schema/column facets
-  heartbeat_interval: 30         # RUNNING heartbeat seconds (when running:true)
+  include_schema_facet: true
+  include_column_lineage: true
 ```
 
-## Transports
+### Heartbeats for long-running pipelines
 
-| `type`  | Backend                                   | Notes                                            |
-|---------|-------------------------------------------|--------------------------------------------------|
-| `http`  | OpenLineage HTTP endpoint (e.g. Marquez)  | `POST` per event; optional `bearer` auth; `timeout_secs`. |
-| `file`  | Local JSON Lines file                     | One JSON object per line; parent dirs created.   |
-| `kafka` | Kafka topic                               | One JSON message per event. Requires the `transport-kafka` feature. |
-
-The Kafka transport is gated behind the **`transport-kafka`** Cargo feature
-(pulls in `rdkafka`); `http` and `file` are always available.
-
-## Schema facets
-
-When `include_schema_facet` is set, the source/sink wrappers
-([`SamplingSource`] / [`SamplingSink`]) clone up to `sample_records` records and
-infer an ordered `(field, type)` schema attached to the input/output datasets on
-terminal events. Inferred OpenLineage types: `null`, `boolean`, `integer`,
-`number`, `string`, `array`, `object`.
-
-## Column-level lineage
-
-When `include_column_lineage` is set, the declared transform chain is folded
-over the input field set ([`derive_column_lineage`]) to produce per-output-field
-input edges. Lineage is **only** emitted when every transform in the chain is
-mappable — it is never fabricated.
-
-| Transform                                                | Column lineage |
-|----------------------------------------------------------|----------------|
-| `rename_field`, `select`, `drop`, `set`                  | Mapped (explicit key relationships). |
-| `cast`, `redact`, `value_case`, `spell_symbols`, `filter`| Mapped (identity — keys unchanged).  |
-| `flatten`, `explode`, `keys_case`, `rename_keys`, custom | Opaque — no facet emitted for the run. |
-
-If any transform in the chain is opaque, [`derive_column_lineage`] returns
-`None` and **no** column-lineage facet is attached.
+```yaml
+lineage:
+  namespace: prod.warehouse
+  transport:
+    type: http
+    config:
+      url: ${env:MARQUEZ_URL}
+  emit_on:
+    running: true
+  heartbeat_interval: 30
+```
 
 ## Metrics
 
-Emitted via the [`metrics`](https://docs.rs/metrics) facade:
+Emitted via the [`metrics`](https://docs.rs/metrics) facade (scraped through the standard faucet-stream observability exporter):
 
-- `faucet_lineage_events_total{event_type, outcome}` — events sent, `outcome` ∈ `ok|err`.
-- `faucet_lineage_dropped_total{reason}` — dropped events, `reason` ∈ `disabled|transport_error`.
-- `faucet_lineage_emit_duration_seconds{event_type}` — per-event send latency histogram.
+- `faucet_lineage_events_total{event_type, outcome}` — events sent; `outcome` ∈ `ok | err`.
+- `faucet_lineage_dropped_total{reason}` — dropped events; `reason` ∈ `disabled | transport_error`.
+- `faucet_lineage_emit_duration_seconds{event_type}` — per-event send-latency histogram.
+
+## Emission never fails a run
+
+Lineage is observability, not a data path. [`LineageEmitter::emit`] returns no error: a transport failure (HTTP non-2xx, unreachable file, Kafka send error), a serialization failure, or a disabled event is logged and counted (`faucet_lineage_dropped_total`), then dropped. A broken lineage backend can never abort or stall a pipeline.
+
+## Library usage
+
+Build a [`LineageEmitter`] from a [`LineageConfig`] and emit lifecycle events around your own run loop:
+
+```rust
+use faucet_lineage::{LineageConfig, LineageEmitter};
+use faucet_lineage::event::EventType;
+
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let cfg: LineageConfig = serde_json::from_value(serde_json::json!({
+    "namespace": "prod.warehouse",
+    "transport": {
+        "type": "file",
+        "config": { "path": "./out/lineage.jsonl" }
+    }
+}))?;
+
+let emitter = LineageEmitter::new(cfg)?;   // Arc<LineageEmitter>
+
+// Build a RunLifecycle for the run (job/run ids, input/output datasets, …),
+// then emit around the run — emit() never returns an error.
+// emitter.emit(EventType::Start, &lifecycle).await;
+// emitter.emit(EventType::Complete, &lifecycle).await;
+# Ok(())
+# }
+```
+
+The CLI bridge (`cli/src/lineage_glue.rs`) does exactly this: it builds the emitter, wraps the source/sink in the sampling wrappers, maps resolved transform specs onto `ColumnOp`s, and emits around `run_stream`.
+
+## How it works
+
+- The only `faucet-core` touch-points are `dataset_uri()` on the `Source` / `Sink` traits (so each connector names its dataset) and `redact_uri_credentials` in `faucet_core::util` (so credentials never leak into a dataset URI). The hot `run_stream` loop is untouched.
+- `event.rs` is a serde-faithful subset of the OpenLineage 2.0.2 `RunEvent` object model; `emitter.rs` builds events from a `RunLifecycle` and dispatches them through the configured transport.
+- Each transport (`transport/{http,file,kafka}.rs`) implements a single `send(Vec<u8>)` method that serializes and ships one event; errors are returned to the emitter, which logs and drops them.
+- Column lineage (`column.rs`) is a pure, deterministic fold over `ColumnOp`s with no I/O — fully unit-tested.
+
+## Feature flags
+
+| Feature | Default | Effect |
+|---------|---------|--------|
+| *(none)* | — | HTTP and file transports are always available. |
+| `transport-kafka` | off | Adds the Kafka transport (pulls in `rdkafka`). |
+
+In the CLI these surface as the `lineage` (HTTP + file) and `lineage-kafka` (adds Kafka) features.
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause & fix |
+|---------|--------------------|
+| No events appear in Marquez | Confirm `transport.url` points at the `/api/v1/lineage` endpoint and is reachable. Emission failures are silent by design — set `FAUCET_LOG=warn` to see drop warnings, or check `faucet_lineage_dropped_total{reason="transport_error"}`. |
+| 401 / 403 from the HTTP endpoint | The endpoint needs auth. Add `auth: { type: bearer, config: { token: ${env:MARQUEZ_TOKEN} } }`. |
+| No column-lineage facet emitted | The transform chain contains an opaque transform (`flatten`, `explode`, `keys_case`, `rename_keys`, or a custom closure). Lineage is suppressed for the whole run rather than fabricated — see the [matrix](#column-level-lineage). Also ensure `include_column_lineage: true`. |
+| No schema facet emitted | Set `include_schema_facet: true`. Schemas attach only to terminal events (`COMPLETE` / `ABORT` / `FAIL`), not `START`. |
+| `RUNNING` heartbeats never fire | `emit_on.running` defaults to `false`. Set it `true` (and tune `heartbeat_interval`). |
+| `transport: kafka` rejected as an unknown variant | The Kafka transport is gated behind the `transport-kafka` feature (`lineage-kafka` in the CLI). Rebuild with it enabled. |
+| Config rejected with an unknown-field error | `LineageConfig` is `deny_unknown_fields`. Check spelling against the [configuration reference](#configuration-reference). |
+| Worried about secrets in lineage events | Keep `include_source_code_facet: false` (the default). Enabling it emits the resolved config — which may contain resolved secrets — and logs a warning. |
+
+## See also
+
+- [Lineage cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/lineage.html) — end-to-end walkthrough.
+- [Config reference](https://pawansikawat.github.io/faucet-stream/reference/config.html) — the full `lineage:` grammar.
+- [OpenLineage](https://openlineage.io/) · [Marquez](https://marquezproject.ai/) — the spec and a reference backend.
 
 ## License
 
-MIT OR Apache-2.0.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/sink/bigquery/README.md
+++ b/crates/sink/bigquery/README.md
@@ -2,6 +2,8 @@
 
 [![Crates.io](https://img.shields.io/crates/v/faucet-sink-bigquery.svg)](https://crates.io/crates/faucet-sink-bigquery)
 [![Docs.rs](https://docs.rs/faucet-sink-bigquery/badge.svg)](https://docs.rs/faucet-sink-bigquery)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-sink-bigquery.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-sink-bigquery.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
 Google BigQuery streaming insert sink for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
 

--- a/crates/sink/bigquery/README.md
+++ b/crates/sink/bigquery/README.md
@@ -5,137 +5,155 @@
 [![MSRV](https://img.shields.io/crates/msrv/faucet-sink-bigquery.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
 [![License](https://img.shields.io/crates/l/faucet-sink-bigquery.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-Google BigQuery streaming insert sink for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
+Google **BigQuery** streaming-insert sink for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem. Writes JSON records to a BigQuery table via the [`tabledata.insertAll`](https://cloud.google.com/bigquery/docs/reference/rest/v2/tabledata/insertAll) streaming API, automatically re-chunking each batch to stay within BigQuery's per-request limits.
 
-Writes JSON records to a BigQuery table using the `tabledata.insertAll` streaming API. Records are automatically split into configurable batch sizes to stay within BigQuery API limits. The BigQuery client is authenticated once at construction and reused across all writes.
+Reach for it when you want to land events, CDC streams, or query results into a BigQuery table from any faucet-stream source with one declarative config — and, when you need it, full **upsert/delete** mirroring and **exactly-once** delivery on top of the same connector.
 
-`write_batch` accepts whatever slice the pipeline hands it. When `batch_size > 0` and the slice is larger than `batch_size`, the sink re-chunks internally and issues one `insertAll` call per chunk; when `batch_size = 0`, the entire slice is sent in a single request — see [Streaming and batching](#streaming-and-batching) for the tradeoffs.
+## Feature highlights
+
+- **Streaming inserts** — high-throughput `tabledata.insertAll`; each batch is re-chunked to BigQuery's ~10 MB / ~500-row sweet spot.
+- **Three credential modes** — Application Default Credentials, a service-account key file, or inline service-account JSON. The shared `BigQueryCredentials` enum is re-exported from [`faucet-common-bigquery`](https://crates.io/crates/faucet-common-bigquery) so it matches the BigQuery **source** byte-for-byte.
+- **Write modes** — `append` (default), `upsert`, and `delete` via an in-place `MERGE` over the target table; no staging table required.
+- **Exactly-once delivery** — pair with a CDC source for a multi-statement `MERGE`/`INSERT` transaction that commits records and a `_faucet_commit_token` watermark atomically.
+- **Retry de-duplication** — set `insert_id_field` to a stable per-row key so BigQuery best-effort de-dupes the at-least-once streaming path.
+- **Dead-letter queue** — surfaces per-row `insertErrors` so only the rows BigQuery actually rejected are routed to the DLQ; committed rows are never duplicated.
+- **Client built once** — the authenticated BigQuery client is constructed (and credentials validated) in `new()` and reused for every write.
 
 ## Installation
 
 ```bash
+# As a library:
 cargo add faucet-sink-bigquery
 cargo add tokio --features full
+
+# Or via the umbrella crate:
+cargo add faucet-stream --features sink-bigquery
+
+# In the CLI (opt-in connector feature):
+cargo install faucet-cli --features sink-bigquery
 ```
 
-Or via the umbrella crate:
+## Quick start
+
+```yaml
+# pipeline.yaml — faucet run pipeline.yaml
+version: 1
+pipeline:
+  source:
+    type: rest
+    config:
+      base_url: https://api.example.com
+      path: /v1/events
+  sink:
+    type: bigquery
+    config:
+      project_id: my-gcp-project
+      dataset_id: analytics
+      table_id: events
+      auth:
+        type: service_account_key_path
+        config:
+          path: /etc/secrets/bigquery-sa.json
+      batch_size: 500
+```
 
 ```bash
-cargo add faucet-stream --features sink-bigquery
+faucet run pipeline.yaml
 ```
 
-## Quick Start
+## Configuration reference
 
-```rust
-use faucet_sink_bigquery::{BigQuerySink, BigQuerySinkConfig, BigQueryCredentials};
-use faucet_core::Sink;
-use serde_json::json;
-
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let config = BigQuerySinkConfig::new(
-        "my-gcp-project",
-        "analytics",
-        "events",
-        BigQueryCredentials::ServiceAccountKeyPath("/path/to/service-account.json".into()),
-    )
-    .with_batch_size(500);
-
-    let sink = BigQuerySink::new(config).await?;
-
-    let records = vec![
-        json!({"user_id": "u123", "event": "page_view", "timestamp": "2026-04-02T10:00:00Z"}),
-        json!({"user_id": "u456", "event": "click", "timestamp": "2026-04-02T10:01:00Z"}),
-    ];
-
-    let rows_written = sink.write_batch(&records).await?;
-    println!("Wrote {rows_written} rows to BigQuery");
-
-    Ok(())
-}
-```
-
-## Configuration
+### Core
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `project_id` | `String` | *(required)* | GCP project ID |
-| `dataset_id` | `String` | *(required)* | BigQuery dataset ID |
-| `table_id` | `String` | *(required)* | BigQuery table ID |
-| `credentials` | `BigQueryCredentials` | *(required)* | Authentication credentials (see below) |
-| `batch_size` | `usize` | `1000` | Maximum rows per `insertAll` request. See [Streaming and batching](#streaming-and-batching) below |
-| `insert_id_field` | `Option<String>` | `None` | Record field whose value is sent as the per-row streaming `insertId`. See [Retry de-duplication](#retry-de-duplication) below |
+| `project_id` | string | — *(required)* | GCP project ID that owns the dataset and is billed for the inserts. |
+| `dataset_id` | string | — *(required)* | BigQuery dataset ID. |
+| `table_id` | string | — *(required)* | BigQuery table ID. The table must already exist with a defined schema. |
+| `auth` | `BigQueryCredentials` | — *(required)* | Authentication — see [Authentication](#authentication). |
 
-### Retry de-duplication
+### Reliability & batching
 
-BigQuery streaming inserts are **at-least-once** — a transport retry can
-insert the same row twice. Setting `insert_id_field` to a stable per-row
-key (e.g. a primary key or event id) makes the sink send that value as the
-row's `insertId`, which BigQuery uses for best-effort de-duplication over a
-short window. When `insert_id_field` is unset, or a given row lacks the
-field, that row is inserted without an `insertId` (no dedup for it).
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `batch_size` | int | `1000` | Maximum rows per `insertAll` request. **`0` = no batching**: the whole upstream page is sent in one call (use when the source already chunks to BigQuery's preferred size). See [Streaming & batching](#streaming--batching). |
+| `insert_id_field` | string | *(unset)* | Record field whose value is sent as the per-row streaming `insertId` for best-effort de-duplication on retry. See [Retry de-duplication](#retry-de-duplication). |
 
-### Streaming and batching
+### Write mode
 
-The BigQuery sink re-chunks each incoming `StreamPage` to keep individual
-`tabledata.insertAll` calls under BigQuery's limits.
+These fields are flattened, so they appear at the sink `config` top level.
 
-- **`batch_size > 0`** (default `1000`) — the sink slices the incoming slice
-  into `batch_size`-row chunks and issues one `insertAll` HTTP call per
-  chunk. **Recommended value is `500`**: that's the documented sweet spot
-  for BigQuery streaming inserts (small enough to stay well under the
-  ~10MB request limit even for wide rows, large enough to amortise per-call
-  overhead). Bump it higher when rows are narrow; drop it when rows are
-  wide enough to push individual chunks past 10MB.
-- **`batch_size = 0`** — the "no batching" sentinel. The entire upstream
-  `StreamPage` is forwarded in a single `insertAll` call. Use this when the
-  source already emits page sizes tuned for BigQuery — for example a
-  Postgres source configured with `batch_size: 500`. Larger pages risk
-  HTTP-413 from BigQuery's ~10MB body limit.
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `write_mode` | enum | `append` | `append` (streaming `insertAll`), `upsert`, or `delete` (in-place `MERGE` / keyed `DELETE`). |
+| `key` | array | `[]` | Key column(s). **Required and non-empty** for `upsert`/`delete`; must be real columns of the target table. |
+| `delete_marker` | object | *(none)* | `upsert` only — `{ field: <name>, values: [<str>, …] }`; rows whose `field` matches one of `values` become deletes instead of upserts. |
 
-`batch_size` is purely a chunk-size knob — BigQuery's per-row error
-reporting and the sink's "first row that failed" error message are
-unchanged. Per-call retry is delegated to `gcp_bigquery_client`'s built-in
-retry middleware.
+## Authentication
 
-### Write modes (`upsert` / `delete`)
+`auth` uses the shared `BigQueryCredentials` enum (the project-wide `{ type, config }` shape). Its `Debug` impl masks inline key JSON as `***` to prevent accidental credential leakage in logs.
 
-In addition to the default `append` mode (streaming `insertAll`), the BigQuery
-sink supports `write_mode: upsert` and `write_mode: delete`. These use an
-in-place `MERGE … USING (SELECT … FROM UNNEST(JSON_QUERY_ARRAY(@payload)))` over
-the target table — **no staging table required**.
+| `type` | `config` | Use when |
+|--------|----------|----------|
+| `application_default` | *(none)* | Running on GCP (workload identity / metadata server) or after `gcloud auth application-default login`. |
+| `service_account_key_path` | `{ path: <file> }` | You have a service-account key file on disk. |
+| `service_account_key` | `{ json: <string> }` | You want to inject the key JSON inline, typically via `${env:VAR}` / `${secret:…}` indirection (e.g. Kubernetes secrets, CI/CD). |
 
-Three flattened fields appear at the sink `config` top level:
+```yaml
+# Application Default Credentials (workload identity, gcloud)
+auth:
+  type: application_default
+```
 
-| Field | Default | Description |
-|-------|---------|-------------|
-| `write_mode` | `append` | `append`, `upsert`, or `delete` |
-| `key` | `[]` | Key column(s). **Required and non-empty** for `upsert`/`delete`; must be real columns of the target table |
-| `delete_marker` | (none) | `upsert` only — `{ field: <name>, values: [<str>, …] }`; rows whose `field` matches one of `values` become deletes instead of upserts |
+```yaml
+# Service-account key file
+auth:
+  type: service_account_key_path
+  config:
+    path: /etc/secrets/bigquery-sa.json
+```
 
-**`upsert`** — insert-or-update by `key` via an in-place `MERGE`. If
-`delete_marker` is set (the standard CDC pattern), rows whose marker field
-matches are routed to a keyed `DELETE` instead; the marker field is stripped from
-upserted rows.
+```yaml
+# Inline service-account JSON via env indirection
+auth:
+  type: service_account_key
+  config:
+    json: ${env:GCP_SERVICE_ACCOUNT_JSON}
+```
 
-**`delete`** — delete by `key` for every record in the batch (direct keyed
-`DELETE`, no MERGE).
+## Examples
 
-The `key` columns must be real columns of the target BigQuery table (they are
-validated against the table schema via `tables.get` at write time). The target
-table must already exist with a defined schema.
+### Streaming inserts with retry de-duplication
 
-**Page-size limit.** The whole page is sent as one `jobs.query` request — BigQuery's
-~10 MB body limit applies. The default `batch_size: 1000` is appropriate for most
-schemas; lower it for very wide rows.
+```yaml
+sink:
+  type: bigquery
+  config:
+    project_id: production-project
+    dataset_id: warehouse
+    table_id: user_events
+    auth:
+      type: service_account_key_path
+      config: { path: /etc/secrets/bigquery-writer.json }
+    batch_size: 500
+    insert_id_field: event_id   # stable per-row key → best-effort dedup
+```
 
-**Exactly-once composition.** `delivery: exactly_once` composes with
-`write_mode: upsert`: the data `MERGE` and the watermark `MERGE` (into
-`_faucet_commit_token`) commit inside a single BigQuery transaction. See the
-[Exactly-once delivery cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/state.html#exactly-once-delivery)
-for the full requirements (CDC source + state + no DLQ).
+### Local development with Application Default Credentials
 
-**Example (Postgres CDC → BigQuery upsert mirror, exactly-once):**
+```yaml
+sink:
+  type: bigquery
+  config:
+    project_id: dev-project
+    dataset_id: scratch
+    table_id: test_table
+    auth:
+      type: application_default
+    batch_size: 100
+```
+
+### Postgres CDC → BigQuery upsert mirror (exactly-once)
 
 ```yaml
 version: 1
@@ -173,173 +191,33 @@ pipeline:
       path: ./state
 ```
 
-See the full runnable config at
-[`cli/examples/postgres_cdc_to_bigquery_upsert.yaml`](../../../cli/examples/postgres_cdc_to_bigquery_upsert.yaml).
+See the full runnable config at [`cli/examples/postgres_cdc_to_bigquery_upsert.yaml`](../../../cli/examples/postgres_cdc_to_bigquery_upsert.yaml).
 
-### Authentication (`BigQueryCredentials`)
+## Streaming & batching
 
-| Variant | Description |
-|---------|-------------|
-| `ServiceAccountKeyPath(String)` | Path to a service account JSON key file on disk |
-| `ServiceAccountKey(String)` | Inline service account JSON key content as a string |
-| `ApplicationDefault` | Use application default credentials (workload identity, `gcloud auth application-default login`, etc.) |
+The BigQuery sink re-chunks each incoming `StreamPage` to keep individual `tabledata.insertAll` calls under BigQuery's limits. `write_batch` accepts whatever slice the pipeline hands it:
 
-The `ServiceAccountKey` variant is useful in environments where the key is injected as an environment variable rather than stored on disk (e.g. Kubernetes secrets, CI/CD).
+- **`batch_size > 0`** (default `1000`) — the sink slices the incoming slice into `batch_size`-row chunks and issues one `insertAll` HTTP call per chunk. **Recommended value is `500`**: the documented sweet spot for BigQuery streaming inserts — small enough to stay well under the ~10 MB request limit even for wide rows, large enough to amortise per-call overhead. Bump it higher when rows are narrow; drop it when rows are wide enough to push individual chunks past 10 MB.
+- **`batch_size = 0`** — the "no batching" sentinel. The entire upstream `StreamPage` is forwarded in a single `insertAll` call. Use this when the source already emits page sizes tuned for BigQuery (e.g. a Postgres source configured with `batch_size: 500`). Larger pages risk HTTP-413 from BigQuery's ~10 MB body limit.
 
-The `Debug` implementation masks the inline key content with `***` to prevent accidental credential leakage in logs.
+`batch_size` is purely a chunk-size knob — BigQuery's per-row error reporting and the sink's "first row that failed" error message are unchanged. Per-call retry is delegated to `gcp_bigquery_client`'s built-in retry middleware.
 
-### Builder Methods
+### Retry de-duplication
 
-```rust
-use faucet_sink_bigquery::{BigQuerySinkConfig, BigQueryCredentials};
+BigQuery streaming inserts are **at-least-once** — a transport retry can insert the same row twice. Setting `insert_id_field` to a stable per-row key (e.g. a primary key or event id) makes the sink send that value as the row's `insertId`, which BigQuery uses for best-effort de-duplication over a short window. When `insert_id_field` is unset, or a given row lacks the field, that row is inserted without an `insertId` (no dedup for it).
 
-let config = BigQuerySinkConfig::new(
-    "my-project",
-    "my_dataset",
-    "my_table",
-    BigQueryCredentials::ApplicationDefault,
-)
-.with_batch_size(500);
-```
+## Write modes (`upsert` / `delete`)
 
-## Config Loading
+In addition to the default `append` mode (streaming `insertAll`), the BigQuery sink supports `write_mode: upsert` and `write_mode: delete`. These use an in-place `MERGE … USING (SELECT … FROM UNNEST(JSON_QUERY_ARRAY(@payload)))` over the target table — **no staging table required**.
 
-```rust
-use faucet_core::config::{load_json, load_env_file};
-use faucet_sink_bigquery::BigQuerySinkConfig;
+- **`upsert`** — insert-or-update by `key` via an in-place `MERGE`. If `delete_marker` is set (the standard CDC pattern), rows whose marker field matches are routed to a keyed `DELETE` instead, and the marker field is stripped from upserted rows.
+- **`delete`** — delete by `key` for every record in the batch (direct keyed `DELETE`, no MERGE).
 
-// From a JSON file
-let config: BigQuerySinkConfig = load_json("config.json")?;
+The `key` columns must be real columns of the target BigQuery table (validated against the table schema via `tables.get` at write time). The target table must already exist with a defined schema.
 
-// From an .env file with a prefix
-let config: BigQuerySinkConfig = load_env_file(".env", "BIGQUERY")?;
-```
+**Page-size limit.** The whole page is sent as one `jobs.query` request — BigQuery's ~10 MB body limit applies. The default `batch_size: 1000` suits most schemas; lower it for very wide rows.
 
-### Example JSON config
-
-```json
-{
-  "project_id": "my-gcp-project",
-  "dataset_id": "analytics",
-  "table_id": "events",
-  "auth": {
-    "type": "service_account_key_path",
-    "config": { "path": "/etc/secrets/bigquery-sa.json" }
-  },
-  "batch_size": 1000
-}
-```
-
-Using application default credentials:
-
-```json
-{
-  "project_id": "my-gcp-project",
-  "dataset_id": "analytics",
-  "table_id": "events",
-  "auth": {
-    "type": "application_default"
-  },
-  "batch_size": 1000
-}
-```
-
-### Example .env file
-
-```env
-BIGQUERY_PROJECT_ID=my-gcp-project
-BIGQUERY_DATASET_ID=analytics
-BIGQUERY_TABLE_ID=events
-BIGQUERY_CREDENTIALS='{"type":"service_account_key_path","config":{"path":"/etc/secrets/bigquery-sa.json"}}'
-BIGQUERY_BATCH_SIZE=1000
-```
-
-## Config Schema Introspection
-
-```rust
-use faucet_core::Sink;
-
-let sink = BigQuerySink::new(config).await?;
-let schema = sink.config_schema();
-println!("{}", serde_json::to_string_pretty(&schema)?);
-```
-
-## Pipeline Usage
-
-```rust
-use faucet_core::Pipeline;
-use faucet_source_rest::{RestStream, RestStreamConfig};
-use faucet_sink_bigquery::{BigQuerySink, BigQuerySinkConfig, BigQueryCredentials};
-
-let source_config = RestStreamConfig::new("https://api.example.com", "/v1/events");
-let source = RestStream::new(source_config);
-
-let sink_config = BigQuerySinkConfig::new(
-    "my-project",
-    "analytics",
-    "events",
-    BigQueryCredentials::ApplicationDefault,
-);
-let sink = BigQuerySink::new(sink_config).await?;
-
-let result = Pipeline::new(source, sink).run().await?;
-println!("Transferred {} records", result.records_written);
-```
-
-## Examples
-
-### Streaming inserts with a service account key file
-
-```rust
-let config = BigQuerySinkConfig::new(
-    "production-project",
-    "warehouse",
-    "user_events",
-    BigQueryCredentials::ServiceAccountKeyPath(
-        "/etc/secrets/bigquery-writer.json".into()
-    ),
-)
-.with_batch_size(500);
-
-let sink = BigQuerySink::new(config).await?;
-let written = sink.write_batch(&records).await?;
-```
-
-### Using inline service account JSON
-
-```rust
-let sa_json = std::env::var("BIGQUERY_SA_KEY")?;
-
-let config = BigQuerySinkConfig::new(
-    "my-project",
-    "analytics",
-    "events",
-    BigQueryCredentials::ServiceAccountKey(sa_json),
-);
-
-let sink = BigQuerySink::new(config).await?;
-```
-
-### Using application default credentials (local development)
-
-```rust
-let config = BigQuerySinkConfig::new(
-    "dev-project",
-    "scratch",
-    "test_table",
-    BigQueryCredentials::ApplicationDefault,
-)
-.with_batch_size(100);
-
-let sink = BigQuerySink::new(config).await?;
-```
-
-## How It Works
-
-- The BigQuery client is created and authenticated in `BigQuerySink::new()`. This validates credentials eagerly so failures surface immediately.
-- `write_batch()` slices the input into `batch_size`-row chunks (or forwards the whole slice when `batch_size = 0`) and sends each chunk as a separate `insertAll` request.
-- Per-row errors in the BigQuery response are detected and reported. If any rows fail, the entire batch returns an error with details about the first failure.
-- The client is reused across all `write_batch()` calls -- no re-authentication per request.
+**Exactly-once composition.** `delivery: exactly_once` composes with `write_mode: upsert`: the data `MERGE` and the watermark `MERGE` (into `_faucet_commit_token`) commit inside a single BigQuery transaction. See [Exactly-once delivery](#exactly-once-delivery) below.
 
 ## Exactly-once delivery
 
@@ -348,7 +226,7 @@ let sink = BigQuerySink::new(config).await?;
 - `write_batch_idempotent(records, scope, token)` — writes the page **and** records the `token` for `scope` in **one BigQuery multi-statement transaction**: a typed `INSERT INTO <target> SELECT … FROM UNNEST(JSON_QUERY_ARRAY(@payload))` (the page ships as a single bound JSON parameter; each column is cast per the target table's schema, fetched once via `tables.get`) followed by a `MERGE` into the `_faucet_commit_token` watermark table in the target dataset. Either both commit or neither does. Success is verified authoritatively via the job's `errorResult`, so a runtime failure (a bad `CAST`, a `NULL` into a `REQUIRED` column) aborts the page rather than advancing the bookmark over data that never landed.
 - `last_committed_token(scope)` — reads the watermark row for `scope` so the pipeline can skip already-committed pages on resume.
 
-On crash/resume the pipeline reads `last_committed_token` and skips any page whose token is already committed, so the target table never sees duplicates. This is **append-with-idempotency**, distinct from the default streaming `insertAll` path and from key-based upsert (`write_mode`), which BigQuery does not support.
+On crash/resume the pipeline reads `last_committed_token` and skips any page whose token is already committed, so the target table never sees duplicates. This is **append-with-idempotency**, distinct from the default streaming `insertAll` path and from key-based upsert (`write_mode`).
 
 **Requirements & limits.** The target table must already exist with a defined schema (the sink reads it to build the typed INSERT — a schemaless table is rejected with a clear error). Because each page commits as one atomic transaction (one token per page, no `batch_size` re-chunking on this path), the page must serialize within BigQuery's ~10 MB `jobs.query` request limit — keep the CDC source's per-page size modest. A scalar column whose JSON value is an object/array is coerced to `NULL` (or, for a `REQUIRED` column, fails the INSERT). This path uses BigQuery DML, which has concurrency limits; it is intended for the opt-in exactly-once mode, not high-rate streaming (use the default streaming `insertAll` path for that).
 
@@ -383,18 +261,138 @@ delivery: exactly_once
 
 See the [Exactly-once delivery cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/state.html#exactly-once-delivery) for full rationale and the supported source/sink set.
 
-## Dead-letter queue support
+## Dead-letter queue
 
-This sink overrides `Sink::write_batch_partial` to surface per-row
-failures from BigQuery `tabledata.insertAll`'s `insertErrors` response.
-Configure a DLQ at the pipeline level (see [cli/README.md — dlq:](../../../cli/README.md))
-and only the rows BigQuery actually rejected will be routed there —
-already-committed rows stay in the main sink with no duplicates.
+This sink overrides `Sink::write_batch_partial` to surface per-row failures from BigQuery `tabledata.insertAll`'s `insertErrors` response. Configure a DLQ at the pipeline level (see [cli/README.md — `dlq:`](../../../cli/README.md)) and only the rows BigQuery actually rejected are routed there — already-committed rows stay in the main sink with no duplicates. (DLQ is not permitted in exactly-once mode.)
+
+## Config loading & schema introspection
+
+Load from YAML/JSON files or environment variables via the `faucet_core::config` helpers, and inspect the full JSON Schema with `faucet schema sink bigquery`.
+
+```rust
+use faucet_core::config::{load_json, load_env_file};
+use faucet_sink_bigquery::BigQuerySinkConfig;
+
+// From a JSON file
+let config: BigQuerySinkConfig = load_json("config.json")?;
+
+// From an .env file with a prefix
+let config: BigQuerySinkConfig = load_env_file(".env", "BIGQUERY")?;
+```
+
+### Example JSON config
+
+```json
+{
+  "project_id": "my-gcp-project",
+  "dataset_id": "analytics",
+  "table_id": "events",
+  "auth": {
+    "type": "service_account_key_path",
+    "config": { "path": "/etc/secrets/bigquery-sa.json" }
+  },
+  "batch_size": 1000
+}
+```
+
+### Example `.env` file
+
+```env
+BIGQUERY_PROJECT_ID=my-gcp-project
+BIGQUERY_DATASET_ID=analytics
+BIGQUERY_TABLE_ID=events
+BIGQUERY_AUTH='{"type":"service_account_key_path","config":{"path":"/etc/secrets/bigquery-sa.json"}}'
+BIGQUERY_BATCH_SIZE=1000
+```
+
+## Library usage
+
+```rust
+use faucet_core::{Pipeline, Sink};
+use faucet_sink_bigquery::{BigQuerySink, BigQuerySinkConfig, BigQueryCredentials};
+use serde_json::json;
+
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let config = BigQuerySinkConfig::new(
+    "my-gcp-project",
+    "analytics",
+    "events",
+    BigQueryCredentials::ServiceAccountKeyPath { path: "/path/to/service-account.json".into() },
+)
+.with_batch_size(500)
+.with_insert_id_field("event_id");
+
+let sink = BigQuerySink::new(config).await?;
+
+let records = vec![
+    json!({"user_id": "u123", "event": "page_view", "timestamp": "2026-04-02T10:00:00Z"}),
+    json!({"user_id": "u456", "event": "click",     "timestamp": "2026-04-02T10:01:00Z"}),
+];
+
+let rows_written = sink.write_batch(&records).await?;
+println!("Wrote {rows_written} rows to BigQuery");
+# Ok(())
+# }
+```
+
+Drive it from a full pipeline with any source:
+
+```rust
+use faucet_core::Pipeline;
+use faucet_source_rest::{RestStream, RestStreamConfig};
+use faucet_sink_bigquery::{BigQuerySink, BigQuerySinkConfig, BigQueryCredentials};
+
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let source = RestStream::new(RestStreamConfig::new("https://api.example.com", "/v1/events"));
+let sink = BigQuerySink::new(BigQuerySinkConfig::new(
+    "my-project", "analytics", "events", BigQueryCredentials::ApplicationDefault,
+)).await?;
+
+let result = Pipeline::new(source, sink).run().await?;
+println!("Transferred {} records", result.records_written);
+# Ok(())
+# }
+```
+
+## How it works
+
+1. `new()` resolves `BigQueryCredentials` and builds an authenticated client **once**, validating credentials eagerly so failures surface immediately.
+2. `write_batch()` slices the input into `batch_size`-row chunks (or forwards the whole slice when `batch_size = 0`) and sends each chunk as a separate `insertAll` request.
+3. Per-row errors in the BigQuery response are detected and reported. If any rows fail, the batch returns an error with details about the first failure; `write_batch_partial` exposes them per-row for DLQ routing.
+4. `write_mode: upsert`/`delete` and the exactly-once path build pure-SQL `MERGE` / `INSERT` statements and execute them via `jobs.query`, verifying success against the job's `errorResult`.
+5. The client is reused across all calls — no re-authentication per request.
 
 ## Lineage dataset URI
 
 `bigquery://<project_id>.<dataset_id>.<table_id>` — e.g. `bigquery://my-project.warehouse.orders`.
 
+## Feature flags
+
+This crate has no optional features of its own; enable it in the CLI/umbrella via the `sink-bigquery` feature.
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause & fix |
+|---------|--------------------|
+| `Auth` error / 401 / 403 | Credentials invalid or missing scope. Confirm the service account has **BigQuery Data Editor** + **BigQuery Job User** on the project, or that ADC is initialized (`gcloud auth application-default login`). |
+| `403 ... billing` | The `project_id` has no billing enabled, or the SA lacks `bigquery.jobs.create`. Use a project with billing and the Job User role. |
+| HTTP 413 / request too large | A chunk exceeded BigQuery's ~10 MB body limit. Lower `batch_size` (or set a non-zero `batch_size` if you were using `0` with wide rows). |
+| Duplicate rows after a retry | Streaming inserts are at-least-once. Set `insert_id_field` to a stable per-row key for best-effort de-dup, or use `delivery: exactly_once`. |
+| `write_mode: upsert` / `key` rejected | `key` must be non-empty and name real columns of the target table; the table must already exist with a defined schema. |
+| Exactly-once run rejected at validate | Exactly-once requires a CDC source (`postgres-cdc`/`mysql-cdc`/`mongodb-cdc`), this sink, a `state:` block, and **no** `dlq:`. `faucet validate` reports the missing requirement. |
+| Idempotent INSERT fails on a `REQUIRED` column | A scalar column received a JSON object/array (coerced to `NULL`) or a missing value. Shape the records (e.g. `cdc_unwrap` + a transform) so every `REQUIRED` column is populated with a scalar. |
+| Inline key JSON appears as `***` in logs | Intentional — `BigQueryCredentials`'s `Debug` masks inline JSON to prevent credential leakage. |
+
+## See also
+
+- [Connector reference](https://pawansikawat.github.io/faucet-stream/reference/connectors.html) — capability matrix.
+- [Exactly-once delivery cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/state.html#exactly-once-delivery).
+- [Upsert / write-modes cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/upsert.html).
+- [`faucet-source-bigquery`](https://crates.io/crates/faucet-source-bigquery) — the matching BigQuery query source.
+- [`faucet-common-bigquery`](https://crates.io/crates/faucet-common-bigquery) — shared `BigQueryCredentials` + client builder.
+
 ## License
 
-Licensed under MIT or Apache-2.0.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.
+</content>
+</invoke>

--- a/crates/sink/csv/README.md
+++ b/crates/sink/csv/README.md
@@ -5,263 +5,306 @@
 [![MSRV](https://img.shields.io/crates/msrv/faucet-sink-csv.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
 [![License](https://img.shields.io/crates/l/faucet-sink-csv.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-CSV file sink connector for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
+CSV / TSV file sink for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem. Writes JSON records to a delimited text file — comma, tab, semicolon, pipe, or any other single-byte delimiter — with an optional header row and RFC 4180 quoting handled automatically.
 
-Writes JSON records to a CSV file. Column order is the union of keys across the records of the first `write_batch()` call. Supports configurable delimiters, optional header rows, and append mode. Uses `spawn_blocking` to avoid blocking the async runtime during file I/O.
+Reach for it whenever the destination is a spreadsheet, a BI import, a data-exchange handoff, or anything that consumes plain delimited text. All file I/O runs inside `tokio::task::spawn_blocking` and flows through a buffered `csv::Writer`, so it stays off the async runtime and doesn't bottleneck on per-record syscalls.
+
+## Feature highlights
+
+- **Any single-byte delimiter** — comma (CSV), tab (TSV), semicolon, pipe (`|`), or any other byte. One field controls the whole dialect.
+- **RFC 4180 quoting, automatic** — the underlying `csv` crate quotes fields that contain the delimiter, quotes, or newlines, so values never break the layout. No quoting knobs to misconfigure.
+- **Optional header row** — emit a header of column names (default) or write headerless data for append-style logs.
+- **Stable, union-derived columns** — column order is the union of keys across every record in the first batch (first-seen order), so a field present only in a later record of that batch is still captured.
+- **Append or truncate** — append to an existing file for incremental exports, or truncate-on-open for a clean rewrite each run.
+- **Creates missing parent dirs** — dated-subdirectory paths like `./data/dt=2026-03-08/part.csv` work with no `mkdir -p` step.
+- **Buffered, off-runtime I/O** — every write runs in `spawn_blocking` behind a buffered writer; the async runtime is never blocked on disk.
+- **Optional compression** — gzip / zstd output behind the `compression` feature, with auto-detection from the `.gz` / `.zst` suffix and an explicitly-finalised trailer (no silent corruption).
 
 ## Installation
 
 ```bash
+# As a library:
 cargo add faucet-sink-csv
-cargo add tokio --features full
+
+# In the CLI (opt-in connector feature):
+cargo install faucet-cli --features sink-csv
+
+# With gzip / zstd output:
+cargo install faucet-cli --features "sink-csv,compression"
 ```
 
-Or via the umbrella crate:
+The `sink-csv` feature is **not** in the CLI default build — enable it explicitly (or use a `full` build). Or pull it through the umbrella crate with `cargo add faucet-stream --features sink-csv`.
+
+## Quick start
+
+```yaml
+# pipeline.yaml — faucet run pipeline.yaml
+version: 1
+pipeline:
+  source:
+    type: sqlite
+    config:
+      database_url: sqlite://./data/app.db
+      query: SELECT id, email, created_at FROM users ORDER BY id
+  sink:
+    type: csv
+    config:
+      path: ./out/users.csv
+```
 
 ```bash
-cargo add faucet-stream --features sink-csv
+faucet run pipeline.yaml
 ```
 
-## Quick Start
+Every row of the query result is written to `./out/users.csv` with a header row, comma-delimited, RFC 4180-quoted. The `out/` directory is created if it doesn't exist.
 
-```rust
-use faucet_sink_csv::{CsvSink, CsvSinkConfig};
-use faucet_core::Sink;
-use serde_json::json;
-
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let config = CsvSinkConfig::new("/tmp/output.csv");
-    let sink = CsvSink::new(config);
-
-    let records = vec![
-        json!({"id": 1, "name": "Alice", "email": "alice@example.com"}),
-        json!({"id": 2, "name": "Bob", "email": "bob@example.com"}),
-    ];
-
-    let written = sink.write_batch(&records).await?;
-    sink.flush().await?;
-
-    println!("Wrote {written} rows to CSV");
-    Ok(())
-}
-```
-
-## Configuration
+## Configuration reference
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `path` | `String` | *(required)* | Path to the output CSV file |
-| `delimiter` | `u8` | `b','` (comma) | Field delimiter byte |
-| `write_headers` | `bool` | `true` | Whether to write a header row with column names |
-| `append` | `bool` | `false` | Whether to append to an existing file. When `false`, the file is truncated on open. |
-| `batch_size` | `usize` | `1000` | Records per upstream `StreamPage`. **No behavioural impact** at this sink — present for symmetry. See [Streaming and batching](#streaming-and-batching). |
+| `path` | string | *(required)* | Path to the output file. Missing parent directories are created automatically (`mkdir -p`). |
+| `delimiter` | byte (int) | `44` (`,`) | Single-byte field delimiter. Common values: `44` comma, `9` tab, `59` semicolon, `124` pipe. |
+| `write_headers` | bool | `true` | Write a header row of column names on the first open. Skipped automatically on append-mode re-opens. |
+| `append` | bool | `false` | Append to an existing file instead of truncating it on open. When `false`, the file is truncated on the first open. |
+| `batch_size` | int | `1000` | Records per upstream `StreamPage`. **No behavioural impact at this sink** — present only for config parity. See [Streaming & batching](#streaming--batching). |
+| `compression` | `none` \| `gzip` \| `zstd` \| `auto` | `auto` | Output compression. Requires the `compression` feature. `auto` infers from the `.gz` / `.zst` path suffix. See [Compression](#compression). |
 
-## Streaming and batching
+In YAML/JSON `delimiter` is the **byte value** of the character, not the character itself — e.g. `9` for tab, `59` for semicolon. The library builder takes a `u8` (`b'\t'`).
 
-This sink writes rows to the output CSV file one at a time via a buffered `csv::Writer` running inside `tokio::task::spawn_blocking`. The per-page memory bound for the pipeline is set by the **source's** `batch_size` (the size of each `StreamPage` that `Pipeline::run` hands to `Sink::write_batch`); how that page is then iterated record-by-record on the sink side is what determines on-disk output, and that path does not depend on `batch_size` at all.
+## Examples
 
-`batch_size` is exposed on this config purely for symmetry across every sink in the workspace — sinks like `faucet-sink-postgres` or `faucet-sink-bigquery` use the field to size their multi-row inserts / streaming-insert requests, but a per-record file sink has nothing to tune. `batch_size = 0` (the "no batching" sentinel) and any positive value are observably identical for this sink: both produce byte-for-byte the same `.csv` file.
+### Comma-separated export with headers
 
-### Builder Methods
-
-```rust
-use faucet_sink_csv::CsvSinkConfig;
-
-let config = CsvSinkConfig::new("/data/output.tsv")
-    .delimiter(b'\t')
-    .write_headers(true)
-    .append(false);
+```yaml
+version: 1
+name: sqlite_to_csv
+pipeline:
+  source:
+    type: sqlite
+    config:
+      database_url: sqlite://./data/app.db
+      query: SELECT id, email, created_at FROM users ORDER BY id
+  sink:
+    type: csv
+    config:
+      path: ./out/users.csv
+      delimiter: 44       # ','
+      write_headers: true
+      append: false
 ```
 
-### Column Order and Missing Fields
+### Tab-separated values (TSV)
 
-- Column order is the **union of keys across all records in the first** `write_batch()` call, in first-seen order — so a field present only in a later record of that batch is still captured (audit #146 H2).
-- All subsequent records use the same column order, regardless of their key order.
-- If a record is missing a field that exists in the column list, an empty string is written for that cell.
-- Keys that appear only in a **later** `write_batch()` call (after the header is written) are still ignored — the header is fixed once on the first call.
+```yaml
+version: 1
+pipeline:
+  source:
+    type: rest
+    config:
+      url: https://api.example.com/v1/orders
+  sink:
+    type: csv
+    config:
+      path: ./out/orders.tsv
+      delimiter: 9        # tab
+```
 
-### Value Conversion
+### Append mode for incremental / streaming exports
 
-| JSON Type | CSV Output |
-|-----------|-----------|
+A webhook receiver appending every batch to one growing file — header written once, subsequent runs append:
+
+```yaml
+version: 1
+name: webhook_to_csv
+pipeline:
+  source:
+    type: webhook
+    config:
+      listen_addr: 127.0.0.1:9090
+      path: /inbox
+      max_payloads: 5000
+      timeout_secs: 120
+  sink:
+    type: csv
+    config:
+      path: webhooks.csv
+      delimiter: 59       # ';'
+      write_headers: true
+      append: true
+```
+
+### Dated partition path with gzip compression
+
+```yaml
+version: 1
+pipeline:
+  source:
+    type: postgres
+    config:
+      connection_url: ${env:DATABASE_URL}
+      query: SELECT * FROM events WHERE created_at::date = current_date
+  sink:
+    type: csv
+    config:
+      path: ./data/dt=${now.date}/events.csv.gz   # parent dir auto-created
+      compression: auto                           # .gz suffix → gzip
+```
+
+## Streaming & batching
+
+`Pipeline::run` drives the source's `stream_pages` and hands each emitted `StreamPage` to `Sink::write_batch`. This sink then iterates the page **record by record**, serializing and writing each row through a buffered `csv::Writer` inside `spawn_blocking`.
+
+Because the write path is inherently per-record, the `batch_size` config field has **no observable effect** here. `batch_size = 0` (the "no batching" sentinel) and any positive value produce byte-for-byte identical output. The field exists only so every sink in the workspace shares one config shape — sinks like `faucet-sink-postgres` (multi-row INSERTs) or `faucet-sink-bigquery` (streaming-insert request sizing) genuinely use it; a per-record file sink has nothing to tune.
+
+The per-run memory bound is set by the **source's** `batch_size` (the size of each `StreamPage`), not by this field.
+
+### Column order & missing fields
+
+- **Column order** is the union of keys across **all records in the first** `write_batch` call, in first-seen order — a field present only in a later record of that batch is still captured.
+- All subsequent records use that same column order, regardless of their own key order.
+- A record **missing** a column writes an empty string for that cell.
+- Keys appearing only in a **later** `write_batch` call (after the header is fixed) are ignored — the header is set once, on the first call. Normalize the record shape upstream (e.g. `select` / `set` transforms) if every column must be present.
+- A non-object record (bare scalar or array) is rejected with `FaucetError::Sink` — every record must be a JSON object.
+
+### Value conversion
+
+| JSON type | CSV cell |
+|-----------|----------|
 | `null` | empty string |
 | `string` | the string value |
 | `number` | string representation |
-| `boolean` | `"true"` or `"false"` |
-| `object` / `array` | JSON serialization (e.g. `{"nested":true}`) |
+| `boolean` | `true` / `false` |
+| `object` / `array` | compact JSON (e.g. `{"nested":true}`) |
 
-## Config Loading
+## Compression
+
+Behind the crate-local `compression` Cargo feature. Adds the `compression` config field with values `none`, `gzip`, `zstd`, or `auto` (the default — selects gzip / zstd from the `.gz` / `.zst` path suffix).
+
+```yaml
+type: csv
+config:
+  path: ./out/users.csv.gz
+  compression: auto    # or 'gzip' | 'zstd' | 'none'
+```
+
+`flush()` explicitly finalises the compression encoder (writing the gzip / zstd trailer) and propagates any trailer-write I/O error rather than swallowing it on drop — so a pipeline bookmark never advances over a truncated or corrupt file. Each mid-stream flush finalises one member; the next write starts a fresh member appended after it, which gzip / zstd decoders read back transparently.
+
+S3 / GCS-style `Content-Encoding` headers don't apply here — this is a local-file sink; consumers decompress by file suffix.
+
+## Config loading & schema
+
+Configs load from YAML/JSON files, environment variables, or `.env` files via the CLI's normal loading path.
 
 ```rust
 use faucet_core::config::{load_json, load_env_file};
 use faucet_sink_csv::CsvSinkConfig;
 
+# fn run() -> Result<(), faucet_core::FaucetError> {
 // From a JSON file
 let config: CsvSinkConfig = load_json("config.json")?;
 
-// From an .env file with a prefix
+// From an .env file with a prefix (CSV_SINK_PATH, CSV_SINK_DELIMITER, …)
 let config: CsvSinkConfig = load_env_file(".env", "CSV_SINK")?;
+# Ok(())
+# }
 ```
 
-### Example JSON config
+Inspect the full JSON Schema with:
 
-```json
-{
-  "path": "/data/exports/users.csv",
-  "delimiter": 44,
-  "write_headers": true,
-  "append": false,
-  "batch_size": 1000
-}
+```bash
+faucet schema sink csv
 ```
 
-Note: The `delimiter` is a byte value (44 = comma, 9 = tab, 124 = pipe `|`).
-
-### Example JSON config (TSV)
-
-```json
-{
-  "path": "/data/exports/users.tsv",
-  "delimiter": 9,
-  "write_headers": true,
-  "append": false,
-  "batch_size": 1000
-}
-```
-
-### Example .env file
-
-```env
-CSV_SINK_PATH=/data/exports/users.csv
-CSV_SINK_DELIMITER=44
-CSV_SINK_WRITE_HEADERS=true
-CSV_SINK_APPEND=false
-```
-
-## Config Schema Introspection
+## Library usage
 
 ```rust
-use faucet_core::Sink;
+use faucet_core::{Pipeline, Sink};
+use faucet_sink_csv::{CsvSink, CsvSinkConfig};
+use serde_json::json;
+
+# async fn run() -> Result<(), faucet_core::FaucetError> {
+let config = CsvSinkConfig::new("./out/users.csv")
+    .delimiter(b'\t')        // TSV
+    .write_headers(true)
+    .append(false);
 
 let sink = CsvSink::new(config);
-let schema = sink.config_schema();
-println!("{}", serde_json::to_string_pretty(&schema)?);
+
+sink.write_batch(&[
+    json!({ "id": 1, "name": "Alice", "email": "alice@example.com" }),
+    json!({ "id": 2, "name": "Bob",   "email": "bob@example.com" }),
+])
+.await?;
+sink.flush().await?;       // always flush before dropping the sink
+# Ok(())
+# }
 ```
 
-## Pipeline Usage
+Wired into a `Pipeline` with any source:
 
 ```rust
 use faucet_core::Pipeline;
 use faucet_source_rest::{RestStream, RestStreamConfig};
 use faucet_sink_csv::{CsvSink, CsvSinkConfig};
 
-let source = RestStream::new(
-    RestStreamConfig::new("https://api.example.com", "/v1/users")
-);
-
-let sink = CsvSink::new(CsvSinkConfig::new("/data/users.csv"));
+# async fn run() -> Result<(), faucet_core::FaucetError> {
+let source = RestStream::new(RestStreamConfig::new("https://api.example.com", "/v1/users"));
+let sink = CsvSink::new(CsvSinkConfig::new("./out/users.csv"));
 
 let result = Pipeline::new(source, sink).run().await?;
 println!("Exported {} records to CSV", result.records_written);
+# Ok(())
+# }
 ```
 
-## Examples
+The builder methods are `delimiter(u8)`, `write_headers(bool)`, `append(bool)`, `with_batch_size(usize)`, and `compression(CompressionConfig)` (the last only with the `compression` feature).
 
-### Basic CSV export
+## How it works
 
-```rust
-let config = CsvSinkConfig::new("/tmp/users.csv");
-let sink = CsvSink::new(config);
-
-let records = vec![
-    json!({"id": 1, "name": "Alice", "email": "alice@example.com"}),
-    json!({"id": 2, "name": "Bob", "email": "bob@example.com"}),
-];
-
-sink.write_batch(&records).await?;
-sink.flush().await?;
-```
-
-Output (`/tmp/users.csv`):
-```csv
-id,name,email
-1,Alice,alice@example.com
-2,Bob,bob@example.com
-```
-
-### Tab-separated output (TSV)
-
-```rust
-let config = CsvSinkConfig::new("/tmp/data.tsv")
-    .delimiter(b'\t');
-
-let sink = CsvSink::new(config);
-sink.write_batch(&records).await?;
-sink.flush().await?;
-```
-
-### Append mode for incremental exports
-
-```rust
-// First run: creates the file with headers
-let sink = CsvSink::new(CsvSinkConfig::new("/data/events.csv"));
-sink.write_batch(&batch_1).await?;
-sink.flush().await?;
-drop(sink);
-
-// Second run: appends without headers
-let sink = CsvSink::new(
-    CsvSinkConfig::new("/data/events.csv")
-        .append(true)
-        .write_headers(false)
-);
-sink.write_batch(&batch_2).await?;
-sink.flush().await?;
-```
-
-### Without header row
-
-```rust
-let config = CsvSinkConfig::new("/tmp/data.csv")
-    .write_headers(false);
-
-let sink = CsvSink::new(config);
-sink.write_batch(&records).await?;
-sink.flush().await?;
-```
-
-## How It Works
-
-- The file is opened lazily on the first `write_batch()` call. Column order is the union of keys across the records of the first `write_batch()` call.
-- Missing parent directories of `path` are created automatically (equivalent to `mkdir -p`) before the file is opened, matching the behaviour of the parquet sink. Dated-subdirectory paths such as `./data/dt=2026-03-08/part.csv` work without any pre-creation step.
-- All CSV I/O runs inside `tokio::task::spawn_blocking` to avoid blocking the async runtime.
-- A `Mutex` protects the writer state (column order + csv::Writer) for thread-safe access.
-- Headers are written only on file creation (not in append mode) when `write_headers` is `true`.
-- Multiple `write_batch()` calls accumulate rows in the same file using the same column order.
-- Call `flush()` to ensure all buffered data is written to disk before dropping the sink or reading the file.
-
-## Compression
-
-Behind the crate-local `compression` Cargo feature. Adds a `compression` config
-field with values `none`, `gzip`, `zstd`, or `auto` (the default — detects
-`.gz` / `.zst` from the file path / object key).
-
-YAML example:
-
-```yaml
-kind: csv
-config:
-  # ... existing fields ...
-  compression: auto  # or 'gzip' | 'zstd' | 'none'
-```
-
-`flush()` explicitly finalises the compression encoder (writing the gzip/zstd trailer) and propagates any trailer-write I/O error, rather than swallowing it on drop — so a bookmark never advances over a truncated/corrupt file. Subsequent writes append a fresh member. Headers are emitted only on the first open.
+1. The file is opened **lazily** on the first `write_batch` call. Column order is computed from the union of keys across that first batch's records.
+2. The first open obeys `config.append` (truncate when `false`). A `Mutex` guards the writer state (column order + `csv::Writer`) for thread-safe access.
+3. Each record's cells are written in column order; missing fields become empty strings, and the `csv` crate applies RFC 4180 quoting automatically.
+4. All CSV I/O runs inside `tokio::task::spawn_blocking` so the async runtime is never blocked; the writer state is moved in and out of the `Mutex` across the blocking boundary (never held across an await).
+5. `flush()` finalises the writer (and the compression encoder, with its error surfaced) and **clears the writer slot**. A subsequent `write_batch` reopens the file in **append mode regardless of `config.append`**, so the pipeline's per-bookmark flush is safe for CDC-style sources — every transaction appends rather than truncates. The header is written only on the very first open.
+6. The default `Sink` impl does **not** flush on `Drop` — always call `flush()` before dropping the sink or reading the file.
+7. `check()` (for `faucet doctor`) verifies the parent directory exists and is writable by creating then removing a temp file there; it never touches your actual output file.
 
 ## Lineage dataset URI
 
 `file://<path>` — e.g. `file:///tmp/output.csv`.
 
+## Feature flags
+
+| Feature | Default | Description |
+|---------|---------|-------------|
+| `compression` | off | Adds the `compression` config field (gzip / zstd) via `faucet-core/compression`. |
+
+Enable the connector itself in the CLI / umbrella via the `sink-csv` feature.
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause & fix |
+|---------|--------------------|
+| `CSV sink expects JSON objects, got non-object record` | The source emits bare scalars or arrays. CSV needs columnar objects — shape records into objects upstream (e.g. a `set` / `select` transform) before this sink. |
+| A column present in some rows is missing from the file | The header is fixed from the **first** batch. A key that first appears in a *later* batch is dropped. Normalize the record shape upstream so every expected column is present in the first batch (e.g. `select`/`set`), or sort the source so a fully-populated record comes first. |
+| Output file is empty or truncated | The sink buffers; you must `flush()` before reading or exiting. With compression, an un-flushed file is missing its trailer and won't decode. |
+| Delimiter setting seems ignored | `delimiter` is the **byte value** (e.g. `9` for tab, `59` for semicolon), not the literal character. Setting `delimiter: ","` in YAML is wrong; use `delimiter: 44`. |
+| Header keeps repeating across runs | You're truncating each run but expected append, or vice versa. Set `append: true` + `write_headers: false` for incremental log-style files; the header is written only on the first (truncating) open. |
+| `failed to open CSV file …` / `failed to create parent directory …` | The path isn't writable. The sink creates parent dirs but can't fix permissions — check directory ownership/mode, or run `faucet doctor` to probe writability. |
+| Setting `batch_size` changes nothing | Expected — `batch_size` is a no-op for this per-record sink (present only for config parity). To bound per-page memory, set the **source's** `batch_size`. |
+| Fields with commas/newlines look fine but a downstream parser chokes | Output is RFC 4180-quoted. Ensure the consumer uses a real CSV parser (and the same delimiter), not a naive split-on-comma. |
+| `.gz` / `.zst` output isn't compressed | The `compression` feature isn't enabled, so the `compression` field is absent and ignored. Rebuild with `--features "sink-csv,compression"`. |
+
+## See also
+
+- [Connectors reference](https://pawansikawat.github.io/faucet-stream/reference/connectors.html) — the full connector capability matrix.
+- [Compression cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/compression.html) — gzip / zstd across file sinks.
+- [CLI reference](https://pawansikawat.github.io/faucet-stream/reference/cli.html) — `faucet run`, `faucet schema`, `faucet doctor`.
+- [`faucet-sink-jsonl`](https://crates.io/crates/faucet-sink-jsonl) — write JSON Lines to a file instead of delimited text.
+- [`faucet-sink-stdout`](https://crates.io/crates/faucet-sink-stdout) — TSV/JSON to a standard stream for debugging and piping.
+- [`faucet-source-csv`](https://crates.io/crates/faucet-source-csv) — read CSV files as a pipeline source.
+- [`faucet-core`](https://crates.io/crates/faucet-core) — the `Sink` trait this connector implements.
+
 ## License
 
-Licensed under MIT or Apache-2.0.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/sink/csv/README.md
+++ b/crates/sink/csv/README.md
@@ -2,6 +2,8 @@
 
 [![Crates.io](https://img.shields.io/crates/v/faucet-sink-csv.svg)](https://crates.io/crates/faucet-sink-csv)
 [![Docs.rs](https://docs.rs/faucet-sink-csv/badge.svg)](https://docs.rs/faucet-sink-csv)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-sink-csv.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-sink-csv.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
 CSV file sink connector for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
 

--- a/crates/sink/elasticsearch/README.md
+++ b/crates/sink/elasticsearch/README.md
@@ -2,6 +2,8 @@
 
 [![Crates.io](https://img.shields.io/crates/v/faucet-sink-elasticsearch.svg)](https://crates.io/crates/faucet-sink-elasticsearch)
 [![Docs.rs](https://docs.rs/faucet-sink-elasticsearch/badge.svg)](https://docs.rs/faucet-sink-elasticsearch)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-sink-elasticsearch.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-sink-elasticsearch.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
 Elasticsearch sink connector for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
 

--- a/crates/sink/elasticsearch/README.md
+++ b/crates/sink/elasticsearch/README.md
@@ -5,150 +5,152 @@
 [![MSRV](https://img.shields.io/crates/msrv/faucet-sink-elasticsearch.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
 [![License](https://img.shields.io/crates/l/faucet-sink-elasticsearch.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-Elasticsearch sink connector for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
+**Elasticsearch** sink for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem. Indexes JSON records into an Elasticsearch index via the bulk API (`POST /_bulk`, NDJSON body), re-chunking each page into payloads that land in Elasticsearch's per-request sweet spot.
 
-Indexes JSON records into an Elasticsearch index using the bulk API (`_bulk` endpoint) with NDJSON format. Supports optional document ID extraction from record fields, multiple authentication methods, and configurable batch sizes for bulk requests.
+Reach for it when you want to land any faucet-stream source — a database, a queue, a file, a REST API — into Elasticsearch for search and analytics, with one declarative config and no glue code. The `_bulk` `index` action is an idempotent overwrite by `_id`, so the same sink does append, upsert, and delete just by switching `write_mode`.
 
-`write_batch` accepts whatever slice the pipeline hands it. When `batch_size > 0` and the slice is larger than `batch_size`, the sink re-chunks internally and issues one `_bulk` HTTP call per chunk; when `batch_size = 0`, the entire slice is sent in a single bulk request — see [Streaming and batching](#streaming-and-batching) for the tradeoffs.
+## Feature highlights
+
+- **Bulk indexing** — every chunk is a single `POST /_bulk` NDJSON request; the HTTP client is built once in `new()` and reused for every call.
+- **Write modes** — `append` (default), `upsert`, and `delete`. Upsert/delete derive a stable `_id` from `key` columns, so they're idempotent overwrites and keyed removals with no staging.
+- **Four auth methods** — none, HTTP Basic, Bearer token, or API key. The shared `ElasticsearchAuth` enum is re-exported from [`faucet-common-elasticsearch`](https://crates.io/crates/faucet-common-elasticsearch) so it matches the Elasticsearch **source** byte-for-byte, and credentials are masked in `Debug` output.
+- **Shared auth providers** — `auth: { ref: <name> }` points at a provider in the CLI's top-level `auth:` catalog, so many sinks can share one token.
+- **Per-row DLQ** — overrides `write_batch_partial` to read per-item errors from the `_bulk` response, so only the documents Elasticsearch actually rejected go to the dead-letter queue (no duplicates of already-indexed rows).
+- **Tunable batching** — `batch_size` controls documents per `_bulk` call, with a `0` sentinel that forwards each page untouched.
 
 ## Installation
 
 ```bash
+# As a library:
 cargo add faucet-sink-elasticsearch
-cargo add tokio --features full
+
+# In the CLI (opt-in connector feature):
+cargo install faucet-cli --features sink-elasticsearch
 ```
 
-Or via the umbrella crate:
+Or via the umbrella crate: `cargo add faucet-stream --features sink-elasticsearch`.
+
+## Quick start
+
+```yaml
+# pipeline.yaml — faucet run pipeline.yaml
+version: 1
+pipeline:
+  source:
+    type: rest
+    config:
+      base_url: https://api.example.com
+      endpoint: /v1/logs
+  sink:
+    type: elasticsearch
+    config:
+      base_url: http://localhost:9200
+      index: events
+      auth:
+        type: none
+      batch_size: 1000
+      id_field: event_id
+```
 
 ```bash
-cargo add faucet-stream --features sink-elasticsearch
+faucet run pipeline.yaml
 ```
 
-## Quick Start
+## Configuration reference
 
-```rust
-use faucet_sink_elasticsearch::{ElasticsearchSink, ElasticsearchSinkConfig};
-use faucet_core::Sink;
-use serde_json::json;
-
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let config = ElasticsearchSinkConfig::new(
-        "http://localhost:9200",
-        "events",
-    )
-    .with_batch_size(1000);
-
-    let sink = ElasticsearchSink::new(config)?;
-
-    let records = vec![
-        json!({"user_id": "u123", "event": "page_view", "url": "/home"}),
-        json!({"user_id": "u456", "event": "click", "url": "/pricing"}),
-    ];
-
-    let written = sink.write_batch(&records).await?;
-    println!("Indexed {written} documents");
-
-    Ok(())
-}
-```
-
-## Configuration
+### Core
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `base_url` | `String` | *(required)* | Base URL of the Elasticsearch cluster (e.g. `"http://localhost:9200"`). Trailing slashes are stripped automatically. |
-| `index` | `String` | *(required)* | Target index name |
-| `auth` | `ElasticsearchAuth` | `None` | Authentication method (see below) |
-| `batch_size` | `usize` | `1000` | Maximum documents per `_bulk` request. See [Streaming and batching](#streaming-and-batching) below |
-| `id_field` | `Option<String>` | `None` | JSON field name to use as the document `_id`. If `None`, Elasticsearch auto-generates IDs. **Superseded by `key` in `upsert`/`delete` modes.** |
-| `write_mode` | `"append" \| "upsert" \| "delete"` | `"append"` | Write semantics. See [Write modes](#write-modes-upsert--delete) below |
-| `key` | `[String]` | `[]` | Key columns whose values form the document `_id` (joined with `:`). Required and non-empty for `upsert`/`delete` |
-| `delete_marker` | `{ field, values }` | *(none)* | Upsert only: rows whose `field` matches one of `values` are routed to deletes instead of upserts; the marker field is stripped from upserted docs |
+| `base_url` | string | — *(required)* | Base URL of the Elasticsearch cluster (e.g. `"http://localhost:9200"`). Trailing slashes are stripped automatically. |
+| `index` | string | — *(required)* | Target index name. |
+| `auth` | `AuthSpec<ElasticsearchAuth>` | `{ type: none }` | Authentication — inline `{ type, config }` or `{ ref: <name> }`. See [Authentication](#authentication). |
+| `id_field` | string | *(unset)* | JSON field name used as the document `_id` in `append` mode. If unset, Elasticsearch auto-generates IDs. **Superseded by `key` in `upsert`/`delete` modes.** |
 
-### Streaming and batching
+### Batching
 
-The Elasticsearch sink re-chunks each incoming `StreamPage` to keep
-individual `POST /_bulk` calls under Elasticsearch's recommended payload
-size.
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `batch_size` | int | `1000` | Maximum documents per `_bulk` request. The sink slices larger pages into `batch_size`-document chunks. **`0` = no batching**: the whole upstream page is sent in one `_bulk` call. See [Streaming & batching](#streaming--batching). |
 
-- **`batch_size > 0`** (default `1000`) — the sink slices the incoming
-  slice into `batch_size`-document chunks and issues one `_bulk` HTTP
-  call per chunk. Elasticsearch's documented sweet spot for `_bulk`
-  payloads is **5–15 MB of NDJSON per request**, so the right document
-  count depends on the average document size:
+### Write mode
 
-  | Avg doc size | Recommended `batch_size` |
-  |--------------|--------------------------|
-  | ~1 KB (log lines, simple events) | 5000 |
-  | ~5 KB (typical app events, denormalised rows) | 1000–2000 |
-  | ~25 KB (analytics aggregates, large nested objects) | 200–500 |
-  | ~100 KB+ (huge nested docs) | 50–100 |
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `write_mode` | `append \| upsert \| delete` | `append` | Write semantics. See [Write modes](#write-modes-upsert--delete). |
+| `key` | array of string | `[]` | Key columns whose values form the document `_id` (joined with `:`). Required and non-empty for `upsert`/`delete`; ignored for `append`. |
+| `delete_marker` | `{ field, values }` | *(none)* | Upsert only: rows whose `field` matches one of `values` become deletes; the marker field is stripped from upserted docs. |
 
-  Start with the default of `1000`, watch the [`_bulk` response size in
-  ES logs](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-bulk),
-  and adjust until each call lands in the 5–15 MB band. Larger calls
-  risk HTTP-413, slow GC, or rejected-execution exceptions on the
-  Elasticsearch side; smaller calls amortise less per-request overhead.
+## Authentication
 
-- **`batch_size = 0`** — the "no batching" sentinel. The entire upstream
-  `StreamPage` is forwarded in a single `_bulk` call. Use this when the
-  source already emits page sizes tuned for Elasticsearch — for example
-  a Postgres source configured with `batch_size: 2000`. Larger pages
-  risk HTTP-413 from Elasticsearch's `http.max_content_length` (default
-  100 MB but typically lowered to 10–20 MB in production).
+`auth` uses the shared `ElasticsearchAuth` enum (the project-wide `{ type, config }` shape). It also accepts `auth: { ref: <name> }` to use a shared provider from the CLI's top-level `auth:` catalog (`bearer` / `basic` credentials map onto the matching variant).
 
-`batch_size` is purely a chunk-size knob — the sink's per-item error
-inspection of the `_bulk` response and the "first item that failed"
-error message are unchanged.
+| `type` | `config` | Use when |
+|--------|----------|----------|
+| `none` | *(none)* | No authentication (local / unsecured cluster). |
+| `basic` | `{ username, password }` | HTTP Basic — the classic `elastic` / password setup. |
+| `bearer` | `{ token }` | Bearer token in the `Authorization` header. |
+| `api_key` | `{ key }` | API key sent as `ApiKey <key>` in the `Authorization` header (Elastic Cloud). |
 
-### Authentication (`ElasticsearchAuth`)
+```yaml
+# No authentication
+auth:
+  type: none
+```
 
-| Variant | Fields | Description |
-|---------|--------|-------------|
-| `None` | -- | No authentication |
-| `Basic { username, password }` | `String`, `String` | HTTP Basic authentication |
-| `Bearer { token }` | `String` | Bearer token in the Authorization header |
-| `ApiKey { key }` | `String` | API key sent as `ApiKey <key>` in the Authorization header |
+```yaml
+# HTTP Basic
+auth:
+  type: basic
+  config:
+    username: elastic
+    password: ${env:ES_PASSWORD}
+```
 
-The `Debug` implementation masks passwords, tokens, and API keys with `***` to prevent credential leakage in logs.
+```yaml
+# API key (Elastic Cloud)
+auth:
+  type: api_key
+  config:
+    key: ${env:ES_API_KEY}
+```
 
-### Document ID Extraction
+The `Debug` impl masks passwords, tokens, and keys with `***` to prevent credential leakage in logs.
 
-When `id_field` is set, the sink extracts the document `_id` from each record:
+## Examples
 
-- If the field value is a string, it is used directly.
-- If the field value is a number or other type, it is converted to its string representation.
-- If a record is missing the `id_field`, Elasticsearch auto-generates an ID for that document.
+### Postgres → Elasticsearch with API key and a stable `_id`
 
-### Write modes (upsert / delete)
+```yaml
+version: 1
+name: postgres_to_elasticsearch
+pipeline:
+  source:
+    type: postgres
+    config:
+      connection_url: postgres://user:pass@localhost/app
+      query: SELECT id, title, body, tags FROM articles WHERE published = $1
+      params: [true]
+      max_connections: 8
+  sink:
+    type: elasticsearch
+    config:
+      base_url: https://es.example.com:9200
+      index: articles
+      auth:
+        type: api_key
+        config:
+          key: ${env:ES_API_KEY}
+      batch_size: 500
+      id_field: id
+```
 
-Elasticsearch is schemaless and `_id`-addressable, so the sink supports all
-three write modes. The `_bulk` `index` action is already an idempotent
-overwrite by `_id`, so an **upsert is just an `index` keyed on a stable
-document `_id`**, and a **delete is a `delete` action by `_id`**.
-
-- **`append`** (default) — every record is indexed; `_id` comes from `id_field`
-  if set, otherwise Elasticsearch auto-generates one. Unchanged behaviour.
-- **`upsert`** — each record's `_id` is derived from its `key` columns and the
-  document is re-indexed (an idempotent overwrite). This **supersedes
-  `id_field`** — `key` is authoritative for the `_id` in this mode.
-- **`delete`** — each record's `key` columns derive an `_id` and a `delete`
-  action removes that document (no doc body is sent).
-
-Composite keys are joined with `:` — e.g. `key: [tenant, id]` over
-`{tenant: "acme", id: 7}` produces `_id` `"acme:7"`. Within a single batch,
-**duplicate keys collapse last-write-wins** before the bulk request is built.
-
-In `upsert` mode, `delete_marker` lets a single stream carry both writes and
-tombstones: rows whose `field` value matches one of `values` become `delete`
-actions; all other rows are upserted with the marker field stripped from the
-indexed document.
+### CDC → upsert mirror with tombstones
 
 ```yaml
 pipeline:
   sink:
-    kind: elasticsearch
+    type: elasticsearch
     config:
       base_url: http://localhost:9200
       index: products
@@ -159,25 +161,71 @@ pipeline:
         values: [d, delete]   # rows with __op in (d, delete) are removed by _id
 ```
 
-Missing or null `key` values are per-row failures: `write_batch` aborts the
-page, and the DLQ-aware `write_batch_partial` path routes exactly those rows to
-the dead-letter queue while the rest are written.
+### One `_bulk` call per upstream page
 
-### Builder Methods
-
-```rust
-use faucet_sink_elasticsearch::{ElasticsearchSinkConfig, ElasticsearchAuth};
-
-let config = ElasticsearchSinkConfig::new("http://localhost:9200", "events")
-    .auth(ElasticsearchAuth::Basic {
-        username: "elastic".into(),
-        password: "changeme".into(),
-    })
-    .with_batch_size(1000)
-    .id_field("doc_id");
+```yaml
+pipeline:
+  sink:
+    type: elasticsearch
+    config:
+      base_url: http://localhost:9200
+      index: events
+      auth: { type: none }
+      batch_size: 0          # forward each upstream page as a single bulk request
 ```
 
-## Config Loading
+## Streaming & batching
+
+The sink re-chunks each incoming `StreamPage` to keep individual `POST /_bulk` calls within Elasticsearch's recommended payload size.
+
+- **`batch_size > 0`** (default `1000`) — the page is sliced into `batch_size`-document chunks; one `_bulk` HTTP call per chunk. Elasticsearch's documented sweet spot is **5–15 MB of NDJSON per request**, so the right document count depends on average document size:
+
+  | Avg doc size | Recommended `batch_size` |
+  |--------------|--------------------------|
+  | ~1 KB (log lines, simple events) | 5000 |
+  | ~5 KB (typical app events, denormalised rows) | 1000–2000 |
+  | ~25 KB (analytics aggregates, large nested objects) | 200–500 |
+  | ~100 KB+ (huge nested docs) | 50–100 |
+
+  Start with the default `1000`, watch the [`_bulk` response size in ES logs](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-bulk), and adjust until each call lands in the 5–15 MB band. Larger calls risk HTTP 413, slow GC, or rejected-execution exceptions; smaller calls amortise less per-request overhead.
+
+- **`batch_size = 0`** — the "no batching" sentinel. The entire upstream `StreamPage` is forwarded in a single `_bulk` call. Use this when the source already emits page sizes tuned for Elasticsearch (e.g. a Postgres source with `batch_size: 2000`). Larger pages risk HTTP 413 from `http.max_content_length` (default 100 MB but typically lowered to 10–20 MB in production).
+
+`batch_size` is purely a chunk-size knob — per-item error inspection of the `_bulk` response is unchanged.
+
+## Write modes (upsert / delete)
+
+Elasticsearch is schemaless and `_id`-addressable, so the sink supports all three write modes (`Sink::supported_write_modes()` returns `[Append, Upsert, Delete]`). The `_bulk` `index` action is an idempotent overwrite by `_id`, so an **upsert is just an `index` keyed on a stable `_id`**, and a **delete is a `delete` action by `_id`**.
+
+- **`append`** (default) — every record is indexed; `_id` comes from `id_field` if set, otherwise Elasticsearch auto-generates one.
+- **`upsert`** — each record's `_id` is derived from its `key` columns and the document is re-indexed (idempotent overwrite). This **supersedes `id_field`** — `key` is authoritative for `_id` here.
+- **`delete`** — each record's `key` columns derive an `_id` and a `delete` action removes that document (no doc body is sent).
+
+Composite keys are joined with `:` — e.g. `key: [tenant, id]` over `{tenant: "acme", id: 7}` produces `_id` `"acme:7"`. Within a single batch, **duplicate keys collapse last-write-wins** before the bulk request is built.
+
+In `upsert` mode, `delete_marker` lets a single stream carry both writes and tombstones: rows whose `field` value matches one of `values` become `delete` actions; all other rows are upserted with the marker field stripped from the indexed document. This is the standard pairing with the `cdc_unwrap` transform for a CDC → mirror pipeline.
+
+Missing or null `key` values are per-row failures: `write_batch` aborts the page, while the DLQ-aware `write_batch_partial` path routes exactly those rows to the dead-letter queue and writes the rest.
+
+## Document ID extraction
+
+In `append` mode, when `id_field` is set the sink extracts the document `_id` from each record:
+
+- A string field value is used directly.
+- A number or other type is converted to its string representation.
+- A record missing `id_field` gets an Elasticsearch auto-generated ID.
+
+Setting `id_field` to a stable business key makes resumed/retried runs **idempotent overwrites** rather than duplicates — the recommended setting for resumable append pipelines (or configure a DLQ, whose per-row path avoids the whole-page re-send).
+
+## Dead-letter queue
+
+This sink overrides `Sink::write_batch_partial` to surface per-row failures from Elasticsearch's `_bulk` response items. Configure a DLQ at the pipeline level (see [cli/README.md — `dlq:`](https://github.com/PawanSikawat/faucet-stream/blob/main/cli/README.md)) and only the documents Elasticsearch actually rejected are routed there — already-indexed items stay in the main sink with no duplicates. This is why the bulk API's best-effort, partial-success behaviour doesn't double-write rows into the DLQ.
+
+> **Not exactly-once.** Elasticsearch does not commit a faucet commit token transactionally, so this sink does not support `delivery: exactly_once`. For idempotent re-sends use `write_mode: upsert` (or a stable `id_field` in append mode).
+
+## Config loading & schema
+
+Load from YAML/JSON or environment via the helpers in `faucet_core::config`:
 
 ```rust
 use faucet_core::config::{load_json, load_env_file};
@@ -190,54 +238,7 @@ let config: ElasticsearchSinkConfig = load_json("config.json")?;
 let config: ElasticsearchSinkConfig = load_env_file(".env", "ES_SINK")?;
 ```
 
-### Example JSON config
-
-```json
-{
-  "base_url": "http://localhost:9200",
-  "index": "events",
-  "auth": {
-    "type": "basic",
-    "config": {
-      "username": "elastic",
-      "password": "changeme"
-    }
-  },
-  "batch_size": 1000,
-  "id_field": "event_id"
-}
-```
-
-### Example JSON config (no auth, auto-generated IDs)
-
-```json
-{
-  "base_url": "http://localhost:9200",
-  "index": "logs",
-  "auth": {
-    "type": "none"
-  },
-  "batch_size": 1000
-}
-```
-
-### Example JSON config (API key)
-
-```json
-{
-  "base_url": "https://my-cluster.es.cloud:9243",
-  "index": "metrics",
-  "auth": {
-    "type": "api_key",
-    "config": {
-      "key": "VnVhQ2ZHY0JDZGJrU..."
-    }
-  },
-  "batch_size": 500
-}
-```
-
-### Example .env file
+Example `.env`:
 
 ```env
 ES_SINK_BASE_URL=http://localhost:9200
@@ -247,118 +248,83 @@ ES_SINK_BATCH_SIZE=1000
 ES_SINK_ID_FIELD=event_id
 ```
 
-## Config Schema Introspection
+Inspect the full JSON Schema with:
 
-```rust
-use faucet_core::Sink;
-
-let sink = ElasticsearchSink::new(config)?;
-let schema = sink.config_schema();
-println!("{}", serde_json::to_string_pretty(&schema)?);
+```bash
+faucet schema sink elasticsearch
 ```
 
-## Pipeline Usage
+## Library usage
 
 ```rust
-use faucet_core::Pipeline;
+use faucet_core::{Pipeline, Sink};
+use faucet_sink_elasticsearch::{ElasticsearchAuth, ElasticsearchSink, ElasticsearchSinkConfig};
 use faucet_source_rest::{RestStream, RestStreamConfig};
-use faucet_sink_elasticsearch::{ElasticsearchSink, ElasticsearchSinkConfig};
 
-let source = RestStream::new(
-    RestStreamConfig::new("https://api.example.com", "/v1/logs")
-);
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let source = RestStream::new(RestStreamConfig::new("https://api.example.com", "/v1/logs"));
 
-let sink = ElasticsearchSink::new(
-    ElasticsearchSinkConfig::new("http://localhost:9200", "api_logs")
-        .id_field("log_id")
-        .with_batch_size(1000)
-)?;
+let config = ElasticsearchSinkConfig::new("http://localhost:9200", "api_logs")
+    .auth(ElasticsearchAuth::ApiKey { key: std::env::var("ES_API_KEY")? })
+    .with_batch_size(1000)
+    .id_field("log_id");
+let sink = ElasticsearchSink::new(config)?;
 
 let result = Pipeline::new(source, sink).run().await?;
 println!("Indexed {} documents", result.records_written);
+# Ok(())
+# }
 ```
 
-## Examples
+## How it works
 
-### Basic indexing with auto-generated IDs
-
-```rust
-let config = ElasticsearchSinkConfig::new("http://localhost:9200", "logs");
-let sink = ElasticsearchSink::new(config)?;
-
-let records = vec![
-    json!({"level": "info", "message": "Server started", "timestamp": "2026-04-02T10:00:00Z"}),
-    json!({"level": "error", "message": "Connection timeout", "timestamp": "2026-04-02T10:01:00Z"}),
-];
-
-sink.write_batch(&records).await?;
-```
-
-### Custom document IDs from a record field
-
-```rust
-let config = ElasticsearchSinkConfig::new("http://localhost:9200", "products")
-    .id_field("product_id");
-
-let sink = ElasticsearchSink::new(config)?;
-
-let records = vec![
-    json!({"product_id": "SKU-001", "name": "Widget", "price": 9.99}),
-    json!({"product_id": "SKU-002", "name": "Gadget", "price": 24.99}),
-];
-
-sink.write_batch(&records).await?;
-// Documents are indexed with _id = "SKU-001" and _id = "SKU-002"
-```
-
-### Elasticsearch Cloud with API key authentication
-
-```rust
-let config = ElasticsearchSinkConfig::new(
-    "https://my-deployment.es.us-east-1.aws.found.io:9243",
-    "application-events",
-)
-.auth(ElasticsearchAuth::ApiKey {
-    key: std::env::var("ES_API_KEY")?,
-})
-.with_batch_size(2000);
-
-let sink = ElasticsearchSink::new(config)?;
-sink.write_batch(&records).await?;
-```
-
-## How It Works
-
-- The HTTP client is created in `ElasticsearchSink::new()` and reused across all requests.
-- `write_batch()` slices the input into `batch_size`-document chunks (or forwards the whole slice when `batch_size = 0`). For each chunk, it builds an NDJSON body with alternating action/data lines:
-  ```
-  {"index":{"_index":"events","_id":"optional-id"}}
-  {"user_id":"u123","event":"page_view"}
-  {"index":{"_index":"events"}}
-  {"user_id":"u456","event":"click"}
-  ```
-- The NDJSON body is sent as a POST to `{base_url}/_bulk` with `Content-Type: application/x-ndjson`.
-- The bulk response is inspected for per-item errors. If any items report errors, the sink returns a `FaucetError::Sink` with details about the first error.
-- Authentication headers are applied to every request based on the configured auth method.
-
-## Dead-letter queue support
-
-This sink overrides `Sink::write_batch_partial` to surface per-row
-failures from Elasticsearch's `_bulk` response items. Configure a DLQ
-at the pipeline level (see [cli/README.md — dlq:](../../../cli/README.md))
-and only the documents Elasticsearch actually rejected will be routed
-there — already-indexed items stay in the main sink with no duplicates.
-
-## Shared types
-
-`ElasticsearchAuth` lives in [`faucet-common-elasticsearch`](../../common/elasticsearch) and is shared with `faucet-source-elasticsearch`. The sink re-exports it as `faucet_sink_elasticsearch::ElasticsearchAuth`.
-
-> **Deprecation:** the previous name `ElasticsearchSinkAuth` is retained as a deprecated type alias in `0.3.x` and removed in `0.4.0`. Migrate imports to `ElasticsearchAuth` at your convenience.
+1. `new()` validates `batch_size` (≤ `MAX_BATCH_SIZE`) and the write spec, then builds the HTTP client **once**.
+2. `write_batch()` slices the input into `batch_size`-document chunks (or forwards the whole slice when `batch_size = 0`). For each chunk it builds an NDJSON body of alternating action/data lines:
+   ```
+   {"index":{"_index":"events","_id":"optional-id"}}
+   {"user_id":"u123","event":"page_view"}
+   {"index":{"_index":"events"}}
+   {"user_id":"u456","event":"click"}
+   ```
+3. The NDJSON body is `POST`ed to `{base_url}/_bulk` with `Content-Type: application/x-ndjson`; auth headers are applied per request.
+4. The bulk response is inspected for per-item errors — `write_batch` fails with a `FaucetError::Sink` naming the first failed item; `write_batch_partial` returns per-row outcomes for the DLQ router.
 
 ## Lineage dataset URI
 
 `http://<host>:<port>/<index>` (credentials stripped) — e.g. `http://localhost:9200/my-index`.
 
+## Feature flags
+
+This crate has no optional features of its own; enable it in the CLI/umbrella via the `sink-elasticsearch` feature.
+
+## Shared types
+
+`ElasticsearchAuth` lives in [`faucet-common-elasticsearch`](https://crates.io/crates/faucet-common-elasticsearch) and is shared with [`faucet-source-elasticsearch`](https://crates.io/crates/faucet-source-elasticsearch). The sink re-exports it as `faucet_sink_elasticsearch::ElasticsearchAuth`.
+
+> **Deprecation:** the previous name `ElasticsearchSinkAuth` is retained as a deprecated type alias and removed in `0.4.0`. Migrate imports to `ElasticsearchAuth` at your convenience.
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause & fix |
+|---------|--------------------|
+| `401 Unauthorized` / `403 Forbidden` | Missing or wrong credentials. Set `auth` (`basic` / `bearer` / `api_key`) and confirm the role can write to the index. |
+| `FaucetError::Auth` on a shared provider | The `auth: { ref }` provider yielded a non-bearer/basic credential. Elasticsearch only accepts `bearer` or `basic` from a shared provider. |
+| HTTP 413 / request-too-large | A `_bulk` body exceeded `http.max_content_length`. Lower `batch_size` (or set a non-zero value if you were using `0`) until each call lands in the 5–15 MB band. |
+| `rejected_execution_exception` in ES logs | Bulk queue saturated — calls too large or too frequent. Lower `batch_size`; back-pressure with a smaller upstream page. |
+| Resumed run creates duplicate documents | Append mode with auto-generated IDs re-sends a partially-committed page. Set `id_field` to a stable business key (idempotent overwrite) or configure a DLQ. |
+| `write_mode: upsert/delete` rejected at validate | `key` is empty. Provide a non-empty `key: [...]` — it's required for upsert/delete. |
+| Rows land in the DLQ before any HTTP call | Those rows are missing/null `key` values (upsert/delete) — they're per-row failures routed to the DLQ. Fix the upstream data or the `key` columns. |
+| `index_not_found_exception` | The target `index` doesn't exist and the cluster has auto-create disabled. Create the index/template first, or enable `action.auto_create_index`. |
+| Mapping / `mapper_parsing_exception` | A field's type conflicts with the existing index mapping. Reshape with a transform, or use a fresh index/template with the right mapping. |
+
+## See also
+
+- [Sinks reference](https://pawansikawat.github.io/faucet-stream/reference/connectors.html) — capability matrix.
+- [Upsert & write modes cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/upsert.html).
+- [Dead-letter queue cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/dlq.html).
+- [Authentication cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/auth.html).
+- [`faucet-source-elasticsearch`](https://crates.io/crates/faucet-source-elasticsearch) — the Elasticsearch source (search/scroll API).
+
 ## License
 
-Licensed under MIT or Apache-2.0.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/sink/gcs/README.md
+++ b/crates/sink/gcs/README.md
@@ -1,137 +1,285 @@
 # faucet-sink-gcs
 
-Google Cloud Storage sink connector for the
-[faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
+[![Crates.io](https://img.shields.io/crates/v/faucet-sink-gcs.svg)](https://crates.io/crates/faucet-sink-gcs)
+[![Docs.rs](https://docs.rs/faucet-sink-gcs/badge.svg)](https://docs.rs/faucet-sink-gcs)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-sink-gcs.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-sink-gcs.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-Serializes batches of `serde_json::Value` records as JSON Lines files and
-uploads them concurrently to a GCS bucket, with time-sortable UUIDv7 object
-keys. Mirrors `faucet-sink-s3` structurally with two improvements:
-UUIDv7 keys (vs UUIDv4) for natural sort order, and explicit
-`application/x-ndjson` content type.
+Google **Cloud Storage** sink for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem. Serializes batches of `serde_json::Value` records as [JSON Lines](https://jsonlines.org/) (NDJSON) and uploads them concurrently to a GCS bucket with time-sortable UUIDv7 object keys.
 
-Built on the official [`google-cloud-storage`](https://crates.io/crates/google-cloud-storage)
-SDK (1.12).
+Reach for it when you want to land data from any faucet-stream source — a database, an API, a queue, a CDC stream — into GCS as newline-delimited JSON, ready for BigQuery external tables, Dataflow, or any downstream reader. It is built on the official [`google-cloud-storage`](https://crates.io/crates/google-cloud-storage) SDK and uses `buffer_unordered` to fan uploads out across the wire.
 
-## Config
+## Feature highlights
 
-```rust
-pub struct GcsSinkConfig {
-    pub bucket: String,
-    pub prefix: String,
-    pub credentials: GcsCredentials,
-    pub file_extension: String,          // default ".jsonl"
-    pub max_records_per_file: Option<usize>,
-    pub concurrency: usize,              // default 10
-    pub batch_size: usize,               // default DEFAULT_BATCH_SIZE
-    pub storage_host: Option<String>,
-}
+- **Concurrent uploads** — each batch is chunked and the chunks upload in parallel via `buffer_unordered(concurrency)` (default 10), so throughput scales with your network rather than serializing one PUT at a time.
+- **Time-sortable keys** — every object is named `{prefix}{uuidv7}{file_extension}`. UUIDv7 embeds a timestamp, so a bucket listing returns objects in write order without any extra index.
+- **Explicit NDJSON content type** — uploads are tagged `application/x-ndjson` so consumers and tooling recognize the format.
+- **Flexible object sizing** — combine `batch_size` (pipeline-level chunking) and `max_records_per_file` (a hard per-object cap); the sink uploads at whichever limit is smaller.
+- **Optional compression** — gzip or zstd per object behind the `compression` feature, with auto-detection from the file extension.
+- **Four credential modes** — Application Default Credentials, a service-account key file, inline service-account JSON, or anonymous (emulators). The shared `GcsCredentials` enum is re-exported from [`faucet-common-gcs`](https://crates.io/crates/faucet-common-gcs), so it matches the GCS **source** byte-for-byte.
+- **Client built once** — the authenticated `Storage` client is constructed in `new()` and reused for every upload.
+
+## Installation
+
+```bash
+# As a library:
+cargo add faucet-sink-gcs
+
+# In the CLI (opt-in connector feature):
+cargo install faucet-cli --features sink-gcs
+
+# With compression support:
+cargo install faucet-cli --features "sink-gcs,compression"
 ```
 
-| Field | Description |
-|---|---|
-| `bucket` | GCS bucket name. |
-| `prefix` | Object-name prefix; concatenated with the UUIDv7 key and file extension. |
-| `credentials` | See [`GcsCredentials`](../../common/gcs/README.md). Defaults to `application_default`. |
-| `file_extension` | Suffix appended to every object name (default `.jsonl`). |
-| `max_records_per_file` | Hard cap on records per uploaded object. `None` means a single object per `write_batch` call (still subject to `batch_size`). |
-| `concurrency` | Maximum concurrent uploads. |
-| `batch_size` | Pipeline-level chunk size. See [Streaming](#streaming-and-batching). |
-| `storage_host` | Endpoint override (integration tests only). |
+`sink-gcs` is opt-in — it is not part of the CLI's default feature set.
 
-YAML example:
+## Quick start
+
+```yaml
+# pipeline.yaml — faucet run pipeline.yaml
+version: 1
+pipeline:
+  source:
+    type: rest
+    config:
+      url: https://api.example.com/events
+  sink:
+    type: gcs
+    config:
+      bucket: my-bucket
+      prefix: events/
+      auth:
+        type: application_default
+```
+
+```bash
+faucet run pipeline.yaml
+```
+
+This uploads each batch of records as one or more `events/{uuidv7}.jsonl` objects in `gs://my-bucket`.
+
+## Configuration reference
+
+### Core
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `bucket` | string | — *(required)* | GCS bucket name (without the `gs://` scheme). |
+| `prefix` | string | — *(required)* | Object-name prefix; concatenated with the UUIDv7 key and `file_extension` to form each object name. Use a trailing `/` for a folder-like layout (e.g. `events/2026/`). |
+| `auth` | `GcsCredentials` | `application_default` | Authentication — see [Authentication](#authentication). |
+| `file_extension` | string | `.jsonl` | Suffix appended to every object name. Also drives compression auto-detection (`.jsonl.gz` → gzip). |
+
+### Batching & throughput
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `batch_size` | int | `1000` | Records per uploaded object from a single `write_batch` call. **`0` = no batching** — the sink writes whatever upstream hands it as one object. Recommended value for GCS (see [Streaming & batching](#streaming--batching)). Validated at construction (`0` ≤ value ≤ `1_000_000`). |
+| `max_records_per_file` | int | *(unset)* | Hard cap on records per uploaded object. `None` means no file-rollover cap (a single object per `write_batch` call, still subject to `batch_size`). When both are set, the **smaller** of `batch_size` and `max_records_per_file` wins. |
+| `concurrency` | int | `10` | Maximum number of object uploads in flight at once. Higher = more throughput but more peak memory (see the memory note below). Clamped to a minimum of 1. |
+
+### Compression *(feature `compression`)*
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `compression` | `none` \| `gzip` \| `zstd` \| `auto` | `auto` | Codec applied to each object body. `auto` resolves from `file_extension` (`.gz` → gzip, `.zst` → zstd, otherwise none). This sink does **not** set the GCS `Content-Encoding` metadata — consumers must decompress explicitly. |
+
+### Advanced
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `storage_host` | string | *(unset)* | Endpoint override for the storage host. Integration-test escape hatch (e.g. `http://localhost:4443` for an emulator) — leave unset in production. |
+
+## Authentication
+
+`auth` uses the shared `GcsCredentials` enum (the project-wide `{ type, config }` shape, snake_case discriminators). It defaults to `application_default` when omitted.
+
+| `type` | `config` | Use when |
+|--------|----------|----------|
+| `application_default` *(default)* | *(none)* | Running on GCP (workload identity / GCE/GKE metadata server), with `GOOGLE_APPLICATION_CREDENTIALS` set, or after `gcloud auth application-default login`. |
+| `service_account_json_file` | `{ path: <file> }` | You have a service-account key file on disk. |
+| `service_account_json_inline` | `{ json: <string> }` | You want to inject the key JSON inline, typically via `${env:VAR}` / `${secret:…}` indirection. |
+| `anonymous` | *(none)* | Talking to an emulator (e.g. `fake-gcs-server`) that does not validate bearer tokens. **Never use in production.** |
+
+```yaml
+# Application Default Credentials (workload identity, gcloud)
+auth:
+  type: application_default
+```
+
+```yaml
+# Service-account key file
+auth:
+  type: service_account_json_file
+  config:
+    path: /run/secrets/sa.json
+```
+
+```yaml
+# Inline service-account JSON via env indirection
+auth:
+  type: service_account_json_inline
+  config:
+    json: ${env:GCP_SA_JSON}
+```
+
+## Examples
+
+### Large export with no re-chunking (recommended)
+
+Let the source size its own pages and write one object per page — the standard, cost-efficient layout for GCS.
 
 ```yaml
 sink:
   type: gcs
-  bucket: my-bucket
-  prefix: events/2026/
-  auth:
-    type: application_default
-  file_extension: .jsonl
-  max_records_per_file: 50000
-  concurrency: 16
-  batch_size: 0   # let the source's batch_size drive object sizing
+  config:
+    bucket: my-bucket
+    prefix: warehouse/daily/
+    auth: { type: application_default }
+    batch_size: 0   # accept upstream pages as-is, one object per page
 ```
 
-## Streaming and batching
+### Hard cap per object with high concurrency
 
-`write_batch` chunks the incoming records by `min(batch_size, max_records_per_file)`
-(treating `None` as "no limit" and `batch_size = 0` as "no limit"). Each
-chunk becomes a single GCS object with a UUIDv7 key:
-`{prefix}{uuidv7}{file_extension}`.
+Bound each object at 50k records and fan 16 uploads out at once.
 
-**Recommended: `batch_size = 0`** for GCS. Writing many small objects is a
-well-known anti-pattern — per-request overhead, slower downstream reads,
-inflated LIST/GET costs. Let the source's `batch_size` drive object sizing,
-or set an explicit `max_records_per_file` if you need a hard cap.
-
-Uploads dispatch via `buffer_unordered(concurrency)` and `try_collect()`,
-so the first upload error aborts the batch. **Partial-failure caveat:** a
-batch that errors mid-flight may leave already-uploaded chunks in the
-bucket. Same semantics as `faucet-sink-s3`. v1 does not use resumable
-uploads.
-
-> **Memory ceiling.** Each chunk is buffered fully in memory (and, with
-> compression enabled, briefly held as both the raw and compressed body)
-> before a single-shot upload. Because up to `concurrency` chunks upload
-> at once, peak memory is roughly **`concurrency` × (chunk size) × ~2**.
-> A `batch_size = 0` (or `max_records_per_file = None`) fed by a
-> `fetch_all`-style source produces one chunk per `write_batch` call that
-> can be very large — pair `batch_size = 0` with a streaming source that
-> already sizes its pages, or set `max_records_per_file` / lower
-> `concurrency` to cap peak memory. Streaming multipart upload for very
-> large chunks is a future enhancement.
-
-## Errors
-
-| Failure | `FaucetError` variant | Message shape |
-|---|---|---|
-| Bad / missing credentials | `Auth` | `"GCS auth: ..."` |
-| Upload API error | `Sink` | `"GCS put object error for key '{key}': {e}"` |
-| JSON serialization error | `Sink` | `"JSON serialization failed: {e}"` |
-
-## Running the tests
-
-```bash
-cargo test -p faucet-sink-gcs                # unit tests (no network)
-cargo test -p faucet-sink-gcs --test integration -- --ignored
+```yaml
+sink:
+  type: gcs
+  config:
+    bucket: my-bucket
+    prefix: events/2026/
+    auth:
+      type: service_account_json_file
+      config: { path: /run/secrets/sa.json }
+    max_records_per_file: 50000
+    concurrency: 16
 ```
 
-Integration tests are marked `#[ignore]` because they require a real
-GCS-compatible **gRPC** backend. The `google-cloud-storage` SDK's
-control-plane calls (used during round-trip readback) need gRPC, and
-`fake-gcs-server` only speaks REST — so the test fails with
-`h2 protocol error / GoAway`. Run with `--ignored` against a real GCS
-bucket or a gRPC-capable emulator when validating changes.
+### Date-partitioned, gzip-compressed output
+
+Uses a `${now.*}` token for a dated prefix and gzip via the file extension (requires the `compression` feature).
+
+```yaml
+sink:
+  type: gcs
+  config:
+    bucket: my-bucket
+    prefix: events/dt=${now.date}/
+    auth: { type: application_default }
+    file_extension: .jsonl.gz
+    compression: auto   # resolves to gzip from the .gz suffix
+    batch_size: 0
+```
+
+## Streaming & batching
+
+The sink implements `Sink::write_batch`: the pipeline streams pages from the source, and each page is handed to the sink as it arrives, so peak memory is bounded by the page size rather than the total record volume.
+
+Within a `write_batch` call the records are chunked by the **effective chunk size** — `min(batch_size, max_records_per_file)`, where `batch_size = 0` and `max_records_per_file = None` each mean "no limit" (`usize::MAX`). Each chunk becomes a single GCS object with a fresh UUIDv7 key. Chunks upload concurrently via `buffer_unordered(concurrency)` and `try_collect`, so the first upload error aborts the batch.
+
+**Recommended: `batch_size = 0`.** Writing many small objects is a well-known cloud-storage anti-pattern — per-request overhead, slower downstream reads, and inflated LIST/GET costs. Let the source's `batch_size` drive object sizing, or set an explicit `max_records_per_file` if you need a hard cap.
+
+> **Memory ceiling.** Each chunk is buffered fully in memory (and, with compression enabled, briefly held as both the raw and compressed body) before a single-shot upload. Because up to `concurrency` chunks upload at once, peak memory is roughly **`concurrency` × (chunk size) × ~2**. A `batch_size = 0` (or `max_records_per_file = None`) fed by a `fetch_all`-style source produces one very large chunk per `write_batch` call — pair `batch_size = 0` with a streaming source that already sizes its pages, or set `max_records_per_file` / lower `concurrency` to cap peak memory.
+
+**Partial-failure caveat:** because uploads abort on the first error, a batch that fails mid-flight may leave already-uploaded chunks in the bucket. The pipeline bookmark only advances after the whole batch confirms, so a resumed run re-uploads the batch (yielding new UUIDv7 keys for the chunks that already landed). This sink does not use resumable uploads.
 
 ## Compression
 
-Behind the crate-local `compression` Cargo feature. Adds a `compression` config
-field with values `none`, `gzip`, `zstd`, or `auto` (the default — detects
-`.gz` / `.zst` from the file path / object key).
-
-YAML example:
+Gated behind the crate-local `compression` Cargo feature. It adds the `compression` config field (`none` / `gzip` / `zstd` / `auto`, default `auto`). With `auto`, the codec is resolved from `file_extension` per upload, so `.jsonl.gz` triggers gzip and `.jsonl.zst` triggers zstd; an explicit codec that disagrees with the suffix logs a one-time warning.
 
 ```yaml
-kind: gcs
-config:
-  # ... existing fields ...
-  compression: auto  # or 'gzip' | 'zstd' | 'none'
+sink:
+  type: gcs
+  config:
+    bucket: my-bucket
+    prefix: events/
+    auth: { type: application_default }
+    file_extension: .jsonl.zst
+    compression: zstd
 ```
 
-Same as S3: codec resolves from `file_extension`, no `Content-Encoding` metadata set.
+> **Content-Encoding is NOT set.** Unlike a gzip object served with `Content-Encoding: gzip`, this sink uploads the compressed bytes with the `application/x-ndjson` content type and no encoding metadata. Downstream consumers must decompress the object explicitly (the `.gz` / `.zst` suffix is the signal).
 
-## Out of scope (v1)
+Enable it with `cargo add faucet-sink-gcs --features compression` (library) or `cargo install faucet-cli --features "sink-gcs,compression"` (CLI).
 
-- Resumable uploads.
-- Signed URLs.
-- Custom object metadata or user headers.
-- KMS CMEK encryption configuration.
+## Config loading & schema
+
+Load config from YAML/JSON or environment. Inspect the full JSON Schema with:
+
+```bash
+faucet schema sink gcs
+```
+
+## Library usage
+
+```rust
+use faucet_core::Sink;
+use faucet_sink_gcs::{GcsCredentials, GcsSink, GcsSinkConfig};
+use serde_json::json;
+
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let cfg = GcsSinkConfig::new("my-bucket")
+    .prefix("events/")
+    .auth(GcsCredentials::ApplicationDefault)
+    .with_batch_size(0)
+    .concurrency(16);
+
+let sink = GcsSink::new(cfg).await?;
+let written = sink
+    .write_batch(&[json!({ "id": 1 }), json!({ "id": 2 })])
+    .await?;
+println!("uploaded {written} records");
+# Ok(())
+# }
+```
+
+Most users drive the sink through a `Pipeline` rather than calling `write_batch` directly — see the [library tutorial](https://pawansikawat.github.io/faucet-stream/tutorials/library.html).
+
+## How it works
+
+1. `new()` validates `batch_size`, resolves `GcsCredentials`, and builds an authenticated data-plane `Storage` client **once**.
+2. `write_batch` chunks the page by the effective chunk size and serializes each chunk to a JSON Lines byte buffer (one `serde_json` line + `\n` per record).
+3. With the `compression` feature, each buffer is compressed in-memory before upload.
+4. Each chunk gets a fresh UUIDv7 key (`{prefix}{uuidv7}{file_extension}`) and is uploaded single-shot via `write_object(...).set_content_type("application/x-ndjson").send_unbuffered()`.
+5. Chunk uploads run concurrently through `buffer_unordered(concurrency)`; the first error aborts the batch.
+
+The `faucet doctor` preflight probe (`Sink::check`) builds a control-plane `StorageControl` client and issues a non-mutating `list_objects` call capped at one result, so it verifies bucket reachability and credentials without writing anything.
 
 ## Lineage dataset URI
 
-`gs://<bucket>/<prefix>` — e.g. `gs://my-bucket/data/events/`.
+`gs://<bucket>/<prefix>` — e.g. `gs://my-bucket/events/`.
+
+## Feature flags
+
+| Feature | Default | Enables |
+|---------|---------|---------|
+| `compression` | off | The `compression` config field (gzip / zstd / auto); pulls in `faucet-core/compression`. |
+
+Enable the connector itself in the CLI/umbrella via the `sink-gcs` feature.
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause & fix |
+|---------|--------------------|
+| `Auth` error / `GCS auth: ...` | Credentials invalid, missing, or unreadable. Confirm ADC is initialized (`gcloud auth application-default login`) or that the service-account `path` exists and is valid JSON. On GCP, confirm the workload identity / metadata server is reachable. |
+| `403` on upload | The principal lacks write permission. Grant the service account **Storage Object Creator** (or **Storage Object Admin**) on the bucket. |
+| `404` / bucket-not-found | The `bucket` name is wrong or the project's credentials can't see it. Verify the bucket exists and `faucet doctor` passes. |
+| `Sink: GCS put object error ...` | A transient API/network failure or a quota limit. Retry; if persistent, lower `concurrency` to reduce request burst, and check GCS quotas. |
+| Many tiny objects in the bucket | `batch_size` is too small for the source's page size. Set `batch_size: 0` and let the source size pages, or raise `max_records_per_file`. |
+| High memory / OOM during writes | Large chunks × high `concurrency`. Lower `concurrency`, set `max_records_per_file`, or feed the sink from a streaming source rather than a `fetch_all`-style one (see the memory note above). |
+| Downstream reader sees garbled bytes | The object is compressed but the reader didn't decompress. This sink sets no `Content-Encoding`; consumers must decompress explicitly based on the `.gz` / `.zst` suffix. |
+| Duplicate-looking data after a failed run resumed | A partial batch left some chunks behind, then the retry re-uploaded with new UUIDv7 keys. De-duplicate downstream, or size batches so a single object is the unit of retry. |
+| Integration tests fail with `h2 protocol error / GoAway` | The integration tests need a real gRPC-capable GCS backend; `fake-gcs-server` only speaks REST. Run unit tests with `cargo test -p faucet-sink-gcs`; run integration tests `--ignored` against real GCS or a gRPC emulator. |
+
+## See also
+
+- [Connector reference & capability matrix](https://pawansikawat.github.io/faucet-stream/reference/connectors.html)
+- [Compression cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/compression.html)
+- [`faucet-source-gcs`](https://crates.io/crates/faucet-source-gcs) — the matching GCS source.
+- [`faucet-common-gcs`](https://crates.io/crates/faucet-common-gcs) — shared `GcsCredentials` enum and client builders.
+- [`faucet-sink-s3`](https://crates.io/crates/faucet-sink-s3) — the structurally equivalent AWS S3 sink.
 
 ## License
 
-Dual-licensed under MIT and Apache-2.0, per the workspace `license` field.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/sink/http/README.md
+++ b/crates/sink/http/README.md
@@ -2,6 +2,8 @@
 
 [![Crates.io](https://img.shields.io/crates/v/faucet-sink-http.svg)](https://crates.io/crates/faucet-sink-http)
 [![Docs.rs](https://docs.rs/faucet-sink-http/badge.svg)](https://docs.rs/faucet-sink-http)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-sink-http.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-sink-http.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
 HTTP POST sink connector for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
 

--- a/crates/sink/http/README.md
+++ b/crates/sink/http/README.md
@@ -5,280 +5,269 @@
 [![MSRV](https://img.shields.io/crates/msrv/faucet-sink-http.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
 [![License](https://img.shields.io/crates/l/faucet-sink-http.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-HTTP POST sink connector for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
+HTTP POST sink connector for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem. Sends JSON records to any HTTP(S) endpoint — a webhook, an ingest API, a serverless function, another faucet pipeline's webhook source.
 
-Sends JSON records to an HTTP endpoint. Supports two batch modes: Individual (one request per record with concurrent execution) and Array (all records in a single request as a JSON array). Includes configurable authentication, retry logic for transient failures, and concurrency control via semaphores.
+Reach for it when the destination speaks HTTP but isn't one of the first-class warehouse/database/queue sinks: a SaaS ingest endpoint, an internal microservice, a Lambda/Cloud Function URL, or a fan-out webhook. It reuses a single `reqwest::Client`, sends records concurrently, and retries transient failures so it stays fast and resilient under load.
+
+## Feature highlights
+
+- **Two batch modes** — `Individual` (one POST per record, sent concurrently up to a `concurrency` cap) and `Array` (records packed into a JSON-array body, re-chunked by `batch_size`).
+- **Concurrent sends** — `Individual` mode drives a `FuturesUnordered` with at most `concurrency` requests in flight, refilling as each completes (no up-front permit acquisition, no deadlock).
+- **Four auth methods** — `none`, `bearer`, `basic`, and `custom` headers — all on the project-wide `{ type, config }` wire shape. Tokens/passwords are masked (`***`) in `Debug` output.
+- **Shared auth providers** — point `auth` at a `{ ref: <name> }` in the CLI's top-level `auth:` catalog to share one OAuth2 token (with single-flight refresh) across many sinks.
+- **Configurable retry** — retriable failures (network errors, 5xx, 429) are retried up to `max_retries`; 4xx client errors fail fast.
+- **Per-row DLQ in Individual mode** — `write_batch_partial` attempts every record and dead-letters only the ones that actually failed, so already-delivered rows are never duplicated against a non-idempotent endpoint.
+- **Client built once** — the `reqwest::Client` is created in `new()` and reused for every request, with connection pooling and keep-alive.
 
 ## Installation
 
 ```bash
+# As a library:
 cargo add faucet-sink-http
-cargo add tokio --features full
+
+# In the CLI (opt-in connector feature):
+cargo install faucet-cli --features sink-http
 ```
 
-Or via the umbrella crate:
+Or via the umbrella crate: `cargo add faucet-stream --features sink-http`.
+
+## Quick start
+
+```yaml
+# pipeline.yaml — faucet run pipeline.yaml
+version: 1
+pipeline:
+  source:
+    type: webhook
+    config:
+      listen_addr: 0.0.0.0:8080
+      path: /webhook
+  sink:
+    type: http
+    config:
+      url: https://downstream.example.com/ingest
+      method: POST
+      auth:
+        type: bearer
+        config:
+          token: ${env:INGEST_TOKEN}
+      batch_mode:
+        type: Individual
+      max_retries: 3
+      concurrency: 16
+```
 
 ```bash
-cargo add faucet-stream --features sink-http
+faucet run pipeline.yaml
 ```
 
-## Quick Start
+## Configuration reference
 
-```rust
-use faucet_sink_http::{HttpSink, HttpSinkConfig};
-use faucet_core::Sink;
-use serde_json::json;
-
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let config = HttpSinkConfig::new("https://api.example.com/ingest")
-        .max_retries(3)
-        .concurrency(10);
-
-    let sink = HttpSink::new(config);
-
-    let records = vec![
-        json!({"user_id": "u123", "event": "signup"}),
-        json!({"user_id": "u456", "event": "login"}),
-    ];
-
-    let written = sink.write_batch(&records).await?;
-    println!("Sent {written} records");
-
-    Ok(())
-}
-```
-
-## Configuration
+### Core
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `url` | `String` | *(required)* | Target endpoint URL |
-| `method` | `reqwest::Method` | `POST` | HTTP method to use |
-| `headers` | `HeaderMap` | empty | Additional request headers (not serializable; set via builder only) |
-| `auth` | `HttpSinkAuth` | `None` | Authentication method (see below) |
-| `batch_mode` | `HttpBatchMode` | `Individual` | How to batch records in requests (see below) |
-| `max_retries` | `usize` | `0` | Number of retries on transient failures |
-| `concurrency` | `usize` | `10` | Maximum number of concurrent requests in Individual mode |
-| `batch_size` | `usize` | `1000` (`faucet_core::DEFAULT_BATCH_SIZE`) | Maximum records per outbound HTTP request. Re-chunks the upstream `StreamPage` in `Array` mode; no-op in `Individual` mode. `0` = "no batching" sentinel (one POST per `StreamPage`). |
+| `url` | string | — *(required)* | Target endpoint URL. |
+| `method` | string | `POST` | HTTP method (`POST`, `PUT`, `PATCH`, …). |
+| `headers` | header map | empty | Additional request headers. **Library-only** — `#[serde(skip)]`, set via the `headers()` builder; not settable from YAML/JSON. |
+| `auth` | `HttpSinkAuth` | `{ type: none }` | Authentication — inline `{ type, config }` or `{ ref: <name> }`. See [Authentication](#authentication). |
 
-### Authentication (`HttpSinkAuth`)
+### Batching & concurrency
 
-| Variant | Fields | Description |
-|---------|--------|-------------|
-| `None` | -- | No authentication |
-| `Bearer { token }` | `String` | Bearer token in the Authorization header |
-| `Basic { username, password }` | `String`, `String` | HTTP Basic authentication |
-| `Custom { headers }` | `HashMap<String, String>` | Header name → value map attached to every request |
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `batch_mode` | `HttpBatchMode` | `Individual` | `Individual` = one POST per record; `Array` = records sent as one JSON-array body. See [Batch modes](#batch-modes). |
+| `concurrency` | int | `10` | Max concurrent in-flight requests in `Individual` mode. No effect in `Array` mode (one POST per chunk, issued sequentially). Clamped to a floor of `1`. |
+| `batch_size` | int | `1000` | Max records per outbound HTTP request in `Array` mode (re-chunks the upstream page). **`0` = "no batching" sentinel** — forwards the whole page as one JSON array. **No effect in `Individual` mode** (each record is already its own request); kept for config-shape parity and validated via `faucet_core::validate_batch_size`. |
 
-The `Debug` implementation masks tokens and passwords with `***` to prevent credential leakage in logs.
+### Reliability
 
-### Batch Modes (`HttpBatchMode`)
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `max_retries` | int | `0` | Number of retries on retriable failures (network errors, 5xx, 429). Each retry is immediate (no backoff). 4xx client errors fail fast. After exhausting retries the last error is returned. |
 
-| Mode | Description |
-|------|-------------|
-| `Individual` | Send one HTTP request per record. Requests are executed concurrently up to the `concurrency` limit using a semaphore. |
-| `Array` | Send all records as a JSON array in a single HTTP request. |
+## Authentication
 
-### Streaming and batching
+`auth` accepts the project-wide `{ type, config }` shape — either inline, or `{ ref: <name> }` pointing at a shared provider in the CLI's top-level `auth:` catalog.
 
-The HTTP sink honours the workspace-wide `batch_size` contract. The exact effect on the wire depends on the configured `batch_mode`:
+| `type` | `config` | Description |
+|--------|----------|-------------|
+| `none` | *(none)* | No authentication. |
+| `bearer` | `{ token }` | Sent as `Authorization: Bearer <token>`. |
+| `basic` | `{ username, password }` | HTTP Basic authentication. |
+| `custom` | `{ headers: { <name>: <value>, … } }` | Arbitrary header map applied to every request (e.g. an API key header). |
 
-- **`Individual` mode** — one HTTP request per record, executed concurrently up to `concurrency` via a semaphore. `batch_size` has **no effect on wire framing** in this mode (each record is already its own request); the field is accepted only for config-shape parity with other sinks and validated via `faucet_core::validate_batch_size` at load time. Use `concurrency` to tune throughput.
-- **`Array` mode** — the sink re-chunks the upstream `StreamPage` into `batch_size`-row slices and issues one POST request per chunk, with each request body a JSON array of up to `batch_size` records. With the default `batch_size = 1000`, a 2 500-record `write_batch` produces 3 POSTs (1000 + 1000 + 500). When `batch_size = 0` (the **"no batching" sentinel**), the entire records slice is forwarded as a single JSON array — useful when the upstream source already chunks the stream to a size the destination endpoint accepts (e.g. a Postgres source with its own `batch_size`).
-
-Recommended value for HTTP POST endpoints that accept arrays: match the destination's documented batch limit (commonly 100–1000 records per request). For per-record send semantics, prefer `batch_mode: Individual` over `batch_size: 1` — the former is the more direct expression of intent and the only one that drives concurrent in-flight requests.
-
-### Retry Behavior
-
-When `max_retries > 0`, the sink retries requests that fail with retriable errors (network errors, 5xx status codes, etc.). Each retry is immediate (no backoff). After exhausting all retries, the last error is returned.
-
-### Builder Methods
-
-```rust
-use faucet_sink_http::{HttpSinkConfig, HttpSinkAuth, HttpBatchMode};
-
-let config = HttpSinkConfig::new("https://api.example.com/ingest")
-    .method(reqwest::Method::PUT)
-    .auth(HttpSinkAuth::Bearer { token: "my-token".into() })
-    .batch_mode(HttpBatchMode::Array)
-    .max_retries(3)
-    .concurrency(20)
-    .with_batch_size(500);
+```yaml
+# Bearer token (typically via env / secret indirection)
+auth:
+  type: bearer
+  config:
+    token: ${env:INGEST_TOKEN}
 ```
 
-## Config Loading
-
-```rust
-use faucet_core::config::{load_json, load_env_file};
-use faucet_sink_http::HttpSinkConfig;
-
-// From a JSON file
-let config: HttpSinkConfig = load_json("config.json")?;
-
-// From an .env file with a prefix
-let config: HttpSinkConfig = load_env_file(".env", "HTTP_SINK")?;
+```yaml
+# HTTP Basic
+auth:
+  type: basic
+  config:
+    username: ingest-user
+    password: ${secret:vault:secret/ingest#password}
 ```
 
-Note: The `headers` field on `HttpSinkConfig` is `HeaderMap` and remains `#[serde(skip)]` — set it programmatically. The `Custom` auth variant uses a `HashMap<String, String>` and round-trips through JSON/YAML.
-
-### Example JSON config (Individual mode with Bearer auth)
-
-```json
-{
-  "url": "https://api.example.com/ingest",
-  "method": "POST",
-  "auth": {
-    "type": "bearer",
-    "config": {
-      "token": "my-api-token"
-    }
-  },
-  "batch_mode": {
-    "type": "Individual"
-  },
-  "max_retries": 3,
-  "concurrency": 10
-}
+```yaml
+# Custom API-key header
+auth:
+  type: custom
+  config:
+    headers:
+      X-Api-Key: ${env:API_KEY}
 ```
 
-### Example JSON config (Array mode with Basic auth)
-
-```json
-{
-  "url": "https://api.example.com/bulk",
-  "method": "POST",
-  "auth": {
-    "type": "basic",
-    "config": {
-      "username": "ingest-user",
-      "password": "s3cret"
-    }
-  },
-  "batch_mode": {
-    "type": "Array"
-  },
-  "max_retries": 2,
-  "concurrency": 1,
-  "batch_size": 500
-}
+```yaml
+# Shared provider from the top-level `auth:` catalog (OAuth2 with single-flight refresh)
+auth: { ref: my_idp }
 ```
 
-### Example .env file
-
-```env
-HTTP_SINK_URL=https://api.example.com/ingest
-HTTP_SINK_METHOD=POST
-HTTP_SINK_AUTH='{"type":"bearer","config":{"token":"my-api-token"}}'
-HTTP_SINK_BATCH_MODE='{"type":"Individual"}'
-HTTP_SINK_MAX_RETRIES=3
-HTTP_SINK_CONCURRENCY=10
-```
-
-## Config Schema Introspection
-
-```rust
-use faucet_core::Sink;
-
-let sink = HttpSink::new(config);
-let schema = sink.config_schema();
-println!("{}", serde_json::to_string_pretty(&schema)?);
-```
-
-## Pipeline Usage
-
-```rust
-use faucet_core::Pipeline;
-use faucet_source_rest::{RestStream, RestStreamConfig};
-use faucet_sink_http::{HttpSink, HttpSinkConfig, HttpBatchMode};
-
-let source = RestStream::new(
-    RestStreamConfig::new("https://source-api.example.com", "/v1/events")
-);
-
-let sink = HttpSink::new(
-    HttpSinkConfig::new("https://dest-api.example.com/ingest")
-        .batch_mode(HttpBatchMode::Array)
-        .max_retries(3)
-);
-
-let result = Pipeline::new(source, sink).run().await?;
-println!("Forwarded {} records", result.records_written);
-```
+When a shared provider is attached it **takes precedence** over inline `auth`; a bare `{ ref: <name> }` with no provider wired up is a config error.
 
 ## Examples
 
-### Individual mode -- one request per record with concurrency
+### Individual mode — one POST per record, sent concurrently
 
-```rust
-let config = HttpSinkConfig::new("https://webhooks.example.com/event")
-    .auth(HttpSinkAuth::Bearer { token: "webhook-token".into() })
-    .batch_mode(HttpBatchMode::Individual)
-    .concurrency(20)
-    .max_retries(2);
-
-let sink = HttpSink::new(config);
-
-let records = vec![
-    json!({"event": "user.created", "user_id": "u1"}),
-    json!({"event": "user.updated", "user_id": "u2"}),
-    json!({"event": "order.placed", "order_id": "o1"}),
-];
-
-// All 3 records are sent concurrently (up to 20 at a time)
-sink.write_batch(&records).await?;
+```yaml
+sink:
+  type: http
+  config:
+    url: https://webhooks.example.com/event
+    auth:
+      type: bearer
+      config: { token: ${env:WEBHOOK_TOKEN} }
+    batch_mode:
+      type: Individual
+    concurrency: 20
+    max_retries: 2
 ```
 
-### Array mode -- bulk send as JSON array
+### Array mode — bulk POST as a JSON array
+
+```yaml
+sink:
+  type: http
+  config:
+    url: https://api.example.com/bulk-ingest
+    batch_mode:
+      type: Array
+    batch_size: 500     # one POST per 500-record chunk
+    max_retries: 3
+```
+
+### Custom method + API-key header
+
+```yaml
+sink:
+  type: http
+  config:
+    url: https://api.example.com/data
+    method: PUT
+    auth:
+      type: custom
+      config:
+        headers:
+          X-Api-Key: ${env:API_KEY}
+    batch_mode:
+      type: Array
+    batch_size: 0       # forward the whole upstream page as one array
+```
+
+## Streaming & batching
+
+The pipeline calls `Sink::write_batch` once per upstream `StreamPage`. The on-the-wire effect depends on `batch_mode`:
+
+- **`Individual`** — one HTTP request per record, executed concurrently up to `concurrency` via a refilling `FuturesUnordered`. `batch_size` has **no effect** on framing here (each record is already its own request); tune throughput with `concurrency`. For per-record send semantics, prefer `batch_mode: Individual` over `batch_size: 1` — it's the direct expression of intent and the only one that drives concurrent in-flight requests.
+- **`Array`** — the page is re-chunked into `batch_size`-row slices and one POST is issued per chunk, each body a JSON array. With the default `batch_size: 1000`, a 2 500-record page produces 3 POSTs (1000 + 1000 + 500). With **`batch_size: 0`** the whole page is forwarded as a single JSON array — useful when the upstream source already chunks the stream to a size the destination accepts (e.g. a Postgres source with its own `batch_size`).
+
+Recommended `batch_size` for array-accepting endpoints: match the destination's documented batch limit (commonly 100–1000 records per request).
+
+## Dead-letter queue
+
+The sink overrides `write_batch_partial` so a configured [DLQ](https://pawansikawat.github.io/faucet-stream/cookbook/dlq.html) gets accurate per-row outcomes:
+
+- **`Individual` mode** — every record is an independent POST, so each success/failure is attributable. The sink attempts **all** records (failures don't short-circuit siblings) and returns one outcome per record; only the genuinely-failed rows are dead-lettered. This avoids duplicating already-delivered rows against a non-idempotent endpoint under `on_batch_error: dlq_all`.
+- **`Array` mode** — a single array POST cannot attribute a failure to specific rows, so it stays all-or-nothing: the whole array surfaces as an error and the DLQ `on_batch_error` policy decides whether to abort or dead-letter the batch.
+
+This sink does **not** support exactly-once delivery or upsert/delete write modes — HTTP endpoints are opaque to faucet, so it can only append (POST). For idempotent delivery, make the destination endpoint idempotent (e.g. key on a record field) and use `Individual` mode + a DLQ.
+
+## Config loading & schema
+
+Load config from YAML/JSON, environment variables, or a `.env` file. Inspect the full JSON Schema with:
+
+```bash
+faucet schema sink http
+```
+
+Note: `headers` is `#[serde(skip)]` (library-only, set via the `headers()` builder). The `custom` auth variant's header map round-trips through JSON/YAML.
+
+## Library usage
 
 ```rust
-let config = HttpSinkConfig::new("https://api.example.com/bulk-ingest")
+use faucet_core::Pipeline;
+use faucet_sink_http::{HttpBatchMode, HttpSink, HttpSinkAuth, HttpSinkConfig};
+
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let cfg = HttpSinkConfig::new("https://api.example.com/ingest")
+    .auth(HttpSinkAuth::Bearer { token: "my-token".into() })
     .batch_mode(HttpBatchMode::Array)
-    .max_retries(3);
+    .with_batch_size(500)
+    .max_retries(3)
+    .concurrency(20);
 
-let sink = HttpSink::new(config);
+let sink = HttpSink::new(cfg);
 
-let records = vec![
-    json!({"metric": "cpu_usage", "value": 0.85}),
-    json!({"metric": "memory_usage", "value": 0.72}),
-];
-
-// Sends: POST with body [{"metric":"cpu_usage","value":0.85},{"metric":"memory_usage","value":0.72}]
-sink.write_batch(&records).await?;
+// let result = Pipeline::new(source, sink).run().await?;
+# let _ = sink;
+# Ok(())
+# }
 ```
 
-### Custom HTTP method and headers
+Attach a shared `AuthProvider` (so several sinks share one token with single-flight refresh) via `HttpSink::new(cfg).with_auth_provider(provider)`.
 
-```rust
-use reqwest::header::{HeaderMap, HeaderValue};
+## How it works
 
-let mut headers = HeaderMap::new();
-headers.insert("X-Custom-Header", HeaderValue::from_static("my-value"));
-
-let config = HttpSinkConfig::new("https://api.example.com/data")
-    .method(reqwest::Method::PUT)
-    .headers(headers)
-    .auth(HttpSinkAuth::Basic {
-        username: "api-user".into(),
-        password: "api-pass".into(),
-    });
-
-let sink = HttpSink::new(config);
-```
-
-## How It Works
-
-- The HTTP client is created in `HttpSink::new()` and reused across all requests.
-- In **Individual** mode, each record is sent as a separate HTTP request. Requests are executed concurrently (bounded by `concurrency`). In `write_batch` the first error aborts the batch; when a [DLQ](https://pawansikawat.github.io/faucet-stream/cookbook/dlq.html) is configured the sink instead reports **per-row** outcomes (`write_batch_partial`), attempting every record and dead-lettering only the ones that actually failed — so already-delivered rows are never duplicated against a non-idempotent endpoint.
-- In **Array** mode, all records are collected into a JSON array and sent as a single request body. A failure can't be attributed to specific rows, so the whole array surfaces as an error (the DLQ `on_batch_error` policy decides whether to abort or dead-letter the batch).
-- Retry logic: on transient failures (network errors, retriable HTTP status codes), the request is retried up to `max_retries` times. Non-retriable errors (4xx client errors) are returned immediately.
-- Authentication and custom headers are applied to every request.
-- HTTP responses are validated using `check_http_response()` from `faucet-core`, which checks status codes and returns structured errors.
+- `new()` builds the `reqwest::Client` **once** and reuses it for every request (connection pooling + keep-alive).
+- Auth is resolved **once per batch** — the shared provider (if attached) wins, otherwise inline `auth` is used.
+- `Individual` mode drives a `FuturesUnordered`, seeding it with up to `concurrency` futures and refilling as each completes — so exactly `concurrency` requests are in flight without acquiring permits up-front.
+- `Array` mode collects each `batch_size` chunk into a `Value::Array` and POSTs it as one request body.
+- Every response runs through `faucet_core::util::check_http_response`, which maps non-2xx statuses to typed `FaucetError`s; retriable ones (network, 5xx, 429) are retried up to `max_retries`.
 
 ## Lineage dataset URI
 
-`https://<host><path>` (credentials stripped) — e.g. `https://api.example.com/ingest`.
+`https://<host><path>` with credentials stripped — e.g. `https://api.example.com/ingest` (a `user:pass@` prefix in the URL is redacted).
+
+## Feature flags
+
+This crate has no optional features of its own; enable it in the CLI/umbrella via the `sink-http` feature.
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause & fix |
+|---------|--------------------|
+| `Auth` error: "references provider … but no provider was supplied" | `auth: { ref: <name> }` points at a provider not in the top-level `auth:` catalog (or no provider was injected via `with_auth_provider`). Add the named provider, or use inline `auth`. |
+| `401` / `403` from the endpoint | Wrong or expired credentials. Verify the `bearer` token / `basic` credentials, or that the shared provider's scopes are correct. |
+| `Auth` error: "invalid custom header name/value" | A `custom` header name or value isn't a valid HTTP header. Remove non-ASCII / control characters. |
+| Requests not parallel / slow in `Individual` mode | `concurrency` defaults to `10`. Raise it for high-fan-out endpoints; it's clamped to a floor of `1`. |
+| `batch_size` seems ignored | You're in `Individual` mode, where each record is its own request — `batch_size` only affects `Array` mode. Switch to `batch_mode: Array` to pack records, or use `concurrency` to tune `Individual`. |
+| Endpoint rejects large array bodies (`413` / timeout) | The `Array` body exceeds the destination's limit. Lower `batch_size` to its documented per-request cap. |
+| Duplicate rows after a partial failure | The destination isn't idempotent. Use `batch_mode: Individual` + a DLQ so only failed rows are retried/dead-lettered, and make the endpoint idempotent (key on a record field). |
+| `4xx` errors not retried | Intentional — only retriable failures (network, 5xx, 429) are retried. Fix the request shape (`url`, `method`, body) for 4xx. |
+
+## See also
+
+- [Sinks reference](https://pawansikawat.github.io/faucet-stream/reference/connectors.html) — capability matrix across all connectors.
+- [Authentication cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/auth.html) — shared `auth:` providers and the `{ type, config }` shape.
+- [Dead-letter queue cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/dlq.html) — `on_batch_error` policies and per-row dead-lettering.
+- [`faucet-source-webhook`](https://crates.io/crates/faucet-source-webhook) — the natural upstream for HTTP fan-out pipelines.
+- [`faucet-source-rest`](https://crates.io/crates/faucet-source-rest) — pull from a REST API and forward it over HTTP.
 
 ## License
 
-Licensed under MIT or Apache-2.0.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/sink/iceberg/README.md
+++ b/crates/sink/iceberg/README.md
@@ -5,216 +5,43 @@
 [![MSRV](https://img.shields.io/crates/msrv/faucet-sink-iceberg.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
 [![License](https://img.shields.io/crates/l/faucet-sink-iceberg.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-Apache Iceberg sink connector for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
+Apache **Iceberg** sink for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem. Buffers JSON records into Arrow batches, writes them as Parquet data files, and commits each batch as a new Iceberg snapshot via `Transaction::fast_append` — so any faucet-stream source can land directly in an Iceberg lakehouse.
 
-Writes JSON records as Parquet data files and commits them as Iceberg snapshots
-via `Transaction::fast_append`. Catalog connectivity is pluggable — REST
-(default), AWS Glue, SQL-backed, or Hive Metastore — selected by Cargo feature.
+Reach for it when you want a database query, a CDC stream, a CSV dump, or an API feed to become append-only Iceberg snapshots in your lake — with a pluggable catalog (REST, AWS Glue, SQL-backed, or Hive Metastore) and a local **or** cloud (S3/GCS) warehouse, all from one declarative config and no glue code.
 
-## Append-only (v1)
+## Feature highlights
 
-Only `write_mode: append` is supported. Each `flush()` call commits the
-buffered data files as a new snapshot; existing data is never modified.
-Overwrite / replace support is tracked in
-[#179](https://github.com/PawanSikawat/faucet-stream/issues/179) and is blocked
-on upstream `iceberg-rust` 0.9.x, which does not yet expose an overwrite
-transaction action.
+- **Four catalog backends, one config shape** — REST (Polaris, Nessie, Tabular, …), AWS Glue, SQL-backed (Postgres/SQLite/…), and Hive Metastore, each selected by a Cargo feature and a single `catalog.type` discriminator.
+- **Local & cloud warehouses** — REST resolves FileIO server-side; the SQL/Glue/HMS catalogs pick an OpenDAL-backed storage factory from the `warehouse` URI scheme (`file://`, `s3://`/`s3a://`, `gs://`).
+- **Atomic snapshot commits** — each `flush()` writes the Parquet footer and registers the new data files in a single `fast_append` transaction. One `StreamPage` becomes exactly one snapshot.
+- **Schema inference on create** — when `create_if_missing` is set and the table is new, the Iceberg schema is inferred from the first Arrow batch (every field becomes a nullable column typed by its first non-null value).
+- **Partitioning on create** — `identity`, `year`, `month`, `day`, `hour`, `void`, plus parameterized `bucket[N]` / `truncate[N]`.
+- **Parquet codec choice** — `snappy` (default), `zstd`, `gzip`, `lz4`, or `none`, with a soft `target_file_size_mb` rollover.
+- **Exactly-once delivery** — pairs with the CDC sources; the commit token is durably recorded as Iceberg snapshot summary properties (`faucet.commit-scope` / `faucet.commit-token`) inside the same atomic commit.
+- **`faucet doctor` preflight** — probes catalog connectivity and table existence without writing any data.
+- **Secrets-safe `Debug`** — the catalog `credential` and `uri` are redacted, never logged.
 
-## Catalog support
-
-| Catalog | `catalog.type` | Cargo feature | Included by default? |
-|---------|---------------|--------------|----------------------|
-| REST (Polaris, Nessie, Tabular, …) | `rest` | `catalog-rest` | **yes** |
-| AWS Glue | `glue` | `catalog-glue` | no |
-| SQL-backed (Postgres, SQLite, …) | `sql` | `catalog-sql` | no |
-| Hive Metastore | `hms` | `catalog-hms` | no |
-
-**Warehouse storage:** all catalogs support both cloud object stores and local
-filesystems. The **REST** catalog resolves FileIO server-side from the catalog
-config + `s3.*` properties. The **SQL / Glue / HMS** catalogs select an
-OpenDAL-backed storage factory from the `warehouse` URI scheme:
-
-| Warehouse scheme | Storage |
-|---|---|
-| `file://…` / bare path | local filesystem |
-| `s3://…` / `s3a://…` | Amazon S3 / S3-compatible (MinIO, …) |
-| `gs://…` | Google Cloud Storage |
-
-Cloud storage is enabled automatically when you enable a non-REST catalog
-feature (each of `catalog-glue` / `catalog-sql` / `catalog-hms` also enables the
-`storage-opendal` feature). Pass storage credentials and options through
-`catalog.properties`:
-
-- **S3:** `s3.region`, `s3.endpoint` (for S3-compatible stores), `s3.access-key-id`,
-  `s3.secret-access-key`, `s3.path-style-access`, `s3.disable-config-load`.
-- **GCS:** `gcs.credentials-json`, `gcs.no-auth`, `gcs.service.path`.
-
-Schemes without a built-in factory (e.g. `oss://`, `abfss://`) are rejected at
-config-load time; use the REST catalog for those object stores.
-
-Install only what you need:
+## Installation
 
 ```bash
-# REST catalog (default):
+# As a library (REST catalog, the default):
 cargo add faucet-sink-iceberg
 
-# Glue catalog:
+# Add other catalogs by feature:
 cargo add faucet-sink-iceberg --features catalog-glue
-
-# All catalogs:
 cargo add faucet-sink-iceberg --features catalog-glue,catalog-sql,catalog-hms
+
+# In the CLI (opt-in connector feature):
+cargo install faucet-cli --features sink-iceberg                    # REST only
+cargo install faucet-cli --features sink-iceberg,sink-iceberg-glue  # REST + Glue
 ```
 
-Via the umbrella crate, catalog forwarding features are available:
-
-```bash
-cargo add faucet-stream --features sink-iceberg                    # REST only
-cargo add faucet-stream --features sink-iceberg,sink-iceberg-glue  # REST + Glue
-```
+The umbrella crate mirrors the same shape — `sink-iceberg` enables the REST catalog; `sink-iceberg-glue` / `sink-iceberg-sql` / `sink-iceberg-hms` forward the catalog features onto the sink. Enabling any non-REST catalog automatically pulls in `storage-opendal` (S3/GCS/local warehouse support).
 
 ## Quick start
 
-```rust
-use faucet_sink_iceberg::{IcebergSink, IcebergSinkConfig};
-use faucet_core::Sink;
-use serde_json::json;
-
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Configs are normally loaded from YAML/JSON; deserialize one here.
-    let config: IcebergSinkConfig = serde_json::from_value(json!({
-        "catalog": {
-            "type": "rest",
-            "uri": "http://localhost:8181",
-            "warehouse": "s3://warehouse/"
-        },
-        "namespace": ["analytics"],
-        "table": "events",
-        "create_if_missing": true,
-        "batch_size": 10000
-    }))?;
-
-    let sink = IcebergSink::new(config).await?;
-
-    sink.write_batch(&[
-        json!({"user_id": "u123", "event": "page_view", "ts": "2026-01-02T10:00:00Z"}),
-        json!({"user_id": "u456", "event": "click",     "ts": "2026-01-02T10:01:00Z"}),
-    ]).await?;
-
-    // Required: writes the Parquet footer and commits the Iceberg snapshot.
-    sink.flush().await?;
-    Ok(())
-}
-```
-
-## Configuration
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `catalog` | `CatalogConfig` | *(required)* | Catalog type and connection settings |
-| `namespace` | `Vec<String>` | *(required)* | Multi-part namespace, e.g. `["analytics", "events"]`. Must be non-empty; no segment may be empty |
-| `table` | `String` | *(required)* | Table name within the namespace |
-| `create_if_missing` | `bool` | `true` | Create the table (inferring schema from the first batch) if it does not exist. When `false`, `new()` fails immediately if the table is absent |
-| `partition_spec` | `Vec<PartitionField>` | `[]` | Partition fields used **only when creating** the table. Ignored for existing tables |
-| `write_mode` | `WriteMode` | `append` | Write semantics. Only `append` is supported in v1 |
-| `target_file_size_mb` | `u64` | `256` | Soft target for Parquet data-file size (MB). The sink rolls over to a new file when the estimated in-memory size exceeds this threshold |
-| `parquet.compression` | `String` | `"snappy"` | Parquet compression codec: `snappy`, `zstd`, `gzip`, `lz4`, `none` |
-| `snapshot_properties` | `HashMap<String,String>` | `{}` | Key-value pairs written into the Iceberg snapshot summary |
-| `batch_size` | `usize` | `10000` | Records buffered before each Arrow writer flush. `0` = no limit (entire page in one batch) |
-
-### Catalog config
-
-Every catalog variant shares the same inner fields:
-
-| Field | Description |
-|-------|-------------|
-| `uri` | Catalog endpoint. Required for `rest`, `sql`, `hms`; resolved from AWS config for `glue` |
-| `warehouse` | Object-storage warehouse root, e.g. `s3://lake/warehouse/` |
-| `credential` | REST bearer token or other catalog-specific credential. Redacted in `Debug` output |
-| `properties` | Arbitrary key-value pairs forwarded to the catalog builder (e.g. `s3.region`, `s3.endpoint`) |
-
-Example — SQL catalog (Postgres metadata) writing to an S3 warehouse:
-
 ```yaml
-sink:
-  type: iceberg
-  config:
-    catalog:
-      type: sql
-      uri: "postgres://meta:meta@localhost:5432/iceberg"
-      warehouse: "s3://lake/warehouse"
-      properties:
-        s3.region: "us-east-1"
-        s3.access-key-id: "${env:AWS_ACCESS_KEY_ID}"
-        s3.secret-access-key: "${env:AWS_SECRET_ACCESS_KEY}"
-    namespace: ["analytics"]
-    table: "events"
-    create_if_missing: true
-```
-
-### Partition transforms
-
-Supported transforms for `partition_spec[*].transform`:
-
-`identity`, `year`, `month`, `day`, `hour`, `void`, `bucket[N]`, `truncate[N]`
-(where `N` is a positive integer, e.g. `bucket[16]`, `truncate[8]`).
-
-## Schema inference
-
-When `create_if_missing: true` and the table is new, the Iceberg schema is
-inferred from the first Arrow batch: every JSON field becomes a nullable
-column, typed by its first non-null value. Subsequent batches use the
-table's existing schema so the writer and the table schema stay in sync.
-
-Iceberg assigns **field IDs** sequentially starting from `1`. IDs are
-stable once the table is created; renaming or reordering JSON keys in later
-runs does not change them.
-
-## Arrow / Parquet version note
-
-`faucet-sink-iceberg` links Arrow 57 to match `iceberg-rust` 0.9.x, which
-pins the same major. This version does not affect the workspace's other
-connectors — the Parquet source/sink use Arrow 58 (workspace) and Cargo
-resolves both majors simultaneously.
-
-## Flush semantics and commit-failure caveat
-
-`flush()` does two things in sequence:
-
-1. **Closes the Parquet data file** — writes the Parquet footer and uploads
-   it to object storage.
-2. **Commits the Iceberg snapshot** — calls `Transaction::fast_append` to
-   atomically register the new data files as a snapshot.
-
-If step 2 fails (e.g. a concurrent writer caused an optimistic-concurrency
-conflict that iceberg's internal retry could not resolve), the data files
-from step 1 are already in object storage but never referenced by any
-snapshot — they are **orphaned**. The error propagates, the run aborts, the
-bookmark is not advanced, and the re-run writes fresh files and commits
-them.
-
-Orphaned files accumulate over time. Run Iceberg's standard
-`remove_orphan_files` maintenance (e.g. via Spark, pyiceberg, or your
-catalog's UI) to clean them up. The sink does **not** auto-delete on
-failure, because re-committing after an ambiguous commit could duplicate
-data.
-
-## Streaming and batching
-
-| Config | Default | Meaning |
-|--------|---------|---------|
-| `batch_size` | `10000` | Records buffered per Arrow write pass |
-| `batch_size = 0` | n/a | "No batching" — pass the entire upstream page in one go |
-
-The pipeline calls `flush()` once per `StreamPage`, so each page becomes
-exactly one Iceberg snapshot. For high-throughput pipelines, use a large
-upstream `batch_size` (e.g. `100000`) and leave the sink's `batch_size` at
-its default so Arrow batches stay within memory limits while the snapshot
-amortises catalog-commit overhead across many rows.
-
-## YAML config example
-
-```yaml
+# pipeline.yaml — faucet run pipeline.yaml
 version: 1
 name: postgres-to-iceberg
 pipeline:
@@ -233,20 +60,173 @@ pipeline:
       namespace: ["analytics"]
       table: "users"
       create_if_missing: true
-      partition_spec:
-        - source: created_at
-          transform: day
       batch_size: 10000
 ```
 
+```bash
+faucet run pipeline.yaml
+```
+
+## Configuration reference
+
+### Core
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `catalog` | `CatalogConfig` | — *(required)* | Catalog type + connection settings — see [Catalog config](#catalog-config). |
+| `namespace` | `[string]` | — *(required)* | Multi-part namespace containing the target table, e.g. `["analytics", "events"]`. Must be non-empty; no segment may be empty. |
+| `table` | string | — *(required)* | Table name within the namespace (no namespace prefix). |
+| `create_if_missing` | bool | `true` | Create the table (inferring schema from the first batch) if it doesn't exist. When `false`, `new()` fails immediately if the table is absent. |
+| `partition_spec` | `[PartitionField]` | `[]` | Partition fields used **only when creating** the table; ignored for existing tables — the table's own spec is used. See [Partitioning](#partitioning). |
+| `write_mode` | `WriteMode` | `append` | Write semantics. **Only `append` is supported** — see [Write mode](#write-mode-append-only). |
+
+### Format & files
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `target_file_size_mb` | int | `256` | Soft target for Parquet data-file size (MB). The rolling writer rolls a new file when the estimated in-memory size (uncompressed Arrow bytes × 0.4) exceeds this. Must be `> 0`. |
+| `parquet.compression` | string | `"snappy"` | Parquet codec: `snappy`, `zstd`, `gzip`, `lz4`, or `none`. |
+| `snapshot_properties` | map | `{}` | Key-value pairs written into the Iceberg snapshot summary on every commit. |
+
+### Batching
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `batch_size` | int | `10000` | Records buffered in memory before each Arrow write pass. **`0` = no limit** (the entire upstream page is written in one batch). Validated against `MAX_BATCH_SIZE` (1,000,000). |
+
+### Catalog config
+
+The `catalog` block is an internally-tagged enum selected by `type`. Every variant carries the same inner fields; the relevant set differs per catalog:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | `rest` \| `glue` \| `sql` \| `hms` | Catalog backend (each gated by its own Cargo feature — see [Feature flags](#feature-flags)). |
+| `uri` | string | Catalog endpoint. **Required** for `rest` (`https://catalog.example.com`), `sql` (the SQLx/JDBC connection string, e.g. `postgres://…`), and `hms` (`thrift://hms:9083`). For `glue` the endpoint is resolved from AWS config, so `uri` is **not** required. |
+| `warehouse` | string | Object-storage warehouse root, e.g. `s3://lake/warehouse`. Required by the non-REST catalogs (its scheme selects the storage factory). |
+| `credential` | string | REST bearer token (or other catalog-specific credential). **Redacted in `Debug`.** |
+| `properties` | map | Arbitrary key-value pairs forwarded to the catalog/storage builder (S3/GCS options — see [Warehouse storage](#warehouse-storage)). |
+
+#### `PartitionField`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `source` | string | Source column name in the table schema. Must not be empty. |
+| `transform` | string | One of: `identity`, `year`, `month`, `day`, `hour`, `void`, `bucket[N]`, `truncate[N]` (`N` a positive integer, e.g. `bucket[16]`). |
+
+## Catalog support
+
+| Catalog | `catalog.type` | Cargo feature | In default build? |
+|---------|----------------|---------------|-------------------|
+| REST (Polaris, Nessie, Tabular, …) | `rest` | `catalog-rest` | **yes** |
+| AWS Glue | `glue` | `catalog-glue` | no |
+| SQL-backed (Postgres, SQLite, …) | `sql` | `catalog-sql` | no |
+| Hive Metastore | `hms` | `catalog-hms` | no |
+
+Configuring a catalog type whose feature is not compiled in returns `FaucetError::Config` at startup.
+
+### Warehouse storage
+
+All catalogs support both cloud object stores and local filesystems. The **REST** catalog resolves FileIO server-side from the catalog config + `s3.*` properties. The **SQL / Glue / HMS** catalogs select an OpenDAL-backed storage factory from the `warehouse` URI scheme:
+
+| Warehouse scheme | Storage |
+|---|---|
+| `file://…` / bare path | local filesystem |
+| `s3://…` / `s3a://…` | Amazon S3 / S3-compatible (MinIO, …) |
+| `gs://…` | Google Cloud Storage |
+
+Cloud storage is enabled automatically when you enable a non-REST catalog feature (each of `catalog-glue` / `catalog-sql` / `catalog-hms` also enables `storage-opendal`). Pass storage credentials/options through `catalog.properties`:
+
+- **S3:** `s3.region`, `s3.endpoint` (for S3-compatible stores), `s3.access-key-id`, `s3.secret-access-key`, `s3.path-style-access`, `s3.disable-config-load`.
+- **GCS:** `gcs.credentials-json`, `gcs.no-auth`, `gcs.service.path`.
+
+Schemes without a built-in factory (e.g. `oss://`, `abfss://`) are rejected at config-load time for the non-REST catalogs; use the REST catalog for those object stores.
+
+## Examples
+
+### SQL catalog (Postgres metadata) writing to an S3 warehouse
+
+```yaml
+sink:
+  type: iceberg
+  config:
+    catalog:
+      type: sql
+      uri: "postgres://meta:meta@localhost:5432/iceberg"
+      warehouse: "s3://lake/warehouse"
+      properties:
+        s3.region: "us-east-1"
+        s3.access-key-id: "${env:AWS_ACCESS_KEY_ID}"
+        s3.secret-access-key: "${env:AWS_SECRET_ACCESS_KEY}"
+    namespace: ["analytics"]
+    table: "events"
+    create_if_missing: true
+```
+
+### Partitioned table with zstd Parquet
+
+```yaml
+sink:
+  type: iceberg
+  config:
+    catalog:
+      type: rest
+      uri: "http://localhost:8181"
+      warehouse: "s3://warehouse/"
+    namespace: ["analytics"]
+    table: "events"
+    create_if_missing: true
+    partition_spec:
+      - source: created_at
+        transform: day
+      - source: tenant_id
+        transform: bucket[16]
+    parquet:
+      compression: zstd
+    target_file_size_mb: 512
+    batch_size: 50000
+```
+
+### AWS Glue catalog (endpoint resolved from AWS config)
+
+```yaml
+sink:
+  type: iceberg
+  config:
+    catalog:
+      type: glue
+      warehouse: "s3://lake/warehouse"   # no uri — Glue uses the AWS default chain
+      properties:
+        s3.region: "eu-west-1"
+    namespace: ["lake", "raw"]
+    table: "page_views"
+    create_if_missing: true
+```
+
+## Streaming and batching
+
+The pipeline calls `Sink::write_batch` for each `StreamPage`, then `flush()` once the page carries a bookmark — so **each page becomes exactly one Iceberg snapshot**. `batch_size` controls the Arrow write granularity, not the snapshot granularity:
+
+| `batch_size` | Meaning |
+|--------------|---------|
+| `10000` (default) | records buffered per Arrow write pass |
+| `0` | "no batching" — write the entire upstream page in one Arrow batch |
+
+For high-throughput pipelines, use a large **upstream** `batch_size` (e.g. `100000`) so the snapshot amortises catalog-commit overhead across many rows, and leave the sink's `batch_size` near its default so Arrow batches stay within memory limits.
+
+`flush()` does two things in sequence: (1) closes the Parquet data file (writes the footer, uploads it), then (2) commits the snapshot via `Transaction::fast_append`. If step 2 fails (e.g. an unresolvable optimistic-concurrency conflict), the data files from step 1 are already in storage but referenced by no snapshot — they are **orphaned**. The error propagates, the run aborts, and the bookmark does not advance; the re-run writes fresh files and commits them. The sink does **not** auto-delete on failure (re-committing after an ambiguous commit could duplicate data); run Iceberg's standard `remove_orphan_files` maintenance to reclaim them.
+
+## Write mode (append-only)
+
+`write_mode` accepts the shared `faucet_core::WriteMode` enum, but **only `append` is supported at runtime**. `upsert` / `delete` deserialise successfully (so configs round-trip) but are rejected by `IcebergSink::new` with a typed `FaucetError::Config`; `overwrite` is not a recognised variant and fails to deserialise. `Sink::supported_write_modes()` therefore returns `[Append]`. Equality-delete upsert is tracked in [#179](https://github.com/PawanSikawat/faucet-stream/issues/179), blocked on upstream `iceberg-rust` exposing a replace/overwrite transaction action.
+
 ## Exactly-once delivery
 
-`IcebergSink` implements `Sink::supports_idempotent_writes` (returns `true`) and the two companion hooks:
+`IcebergSink` implements `Sink::supports_idempotent_writes()` (returns `true`) and the two companion hooks:
 
-- `write_batch_idempotent(records, scope, token)` — writes `records` and records the `token` as Iceberg **snapshot summary properties** (`faucet.commit-scope` and `faucet.commit-token`) on the committed snapshot, so both are durable in the same atomic catalog operation.
-- `last_committed_token(scope)` — scans recent snapshots for a matching `faucet.commit-scope` entry to let the pipeline skip already-committed pages on resume.
+- `write_batch_idempotent(records, scope, token)` — writes `records` and stashes the `(scope, token)` so it lands in the snapshot summary as `faucet.commit-scope` / `faucet.commit-token` inside the same atomic `fast_append`. Records and token commit together or not at all.
+- `last_committed_token(scope)` — scans snapshot history newest-first for a matching `faucet.commit-scope`, letting the pipeline skip already-committed pages on resume.
 
-To use exactly-once delivery, set `delivery: exactly_once` in your pipeline config and pair this sink with one of the CDC sources (`postgres-cdc`, `mysql-cdc`, `mongodb-cdc`) plus a `state:` block. A DLQ is not permitted in exactly-once mode. All four requirements are validated at config-load time (`faucet validate`) before any run starts.
+To enable it, set `delivery: exactly_once` and pair this sink with a CDC source (`postgres-cdc`, `mysql-cdc`, `mongodb-cdc`) plus a `state:` block. A DLQ is **not** permitted in exactly-once mode. All four requirements are validated at config-load time (`faucet validate`) before any run starts.
 
 ```yaml
 pipeline:
@@ -273,12 +253,103 @@ pipeline:
 delivery: exactly_once
 ```
 
-See the [Exactly-once delivery cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/state.html#exactly-once-delivery) for full rationale and the supported source/sink set.
+See the [Exactly-once delivery cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/state.html#exactly-once-delivery) for the full rationale and supported source/sink set.
+
+## Schema inference
+
+When `create_if_missing: true` and the table is new, the Iceberg schema is inferred from the first Arrow batch: every JSON field becomes a nullable column, typed by its first non-null value. Subsequent batches use the table's existing schema so the writer and table stay in sync. Iceberg assigns **field IDs** sequentially from `1`; IDs are stable once the table exists, so renaming or reordering JSON keys in later runs does not change them.
+
+## Config loading & schema
+
+Configs load from YAML/JSON (or env). Inspect the full JSON Schema with:
+
+```bash
+faucet schema sink iceberg
+```
+
+`faucet doctor` runs the sink's preflight `check()` — it builds the namespace/table ident and probes catalog connectivity + table existence (bounded by the probe timeout) **without writing any data**; a catalog connection failure or timeout surfaces as a red probe.
+
+## Library usage
+
+```rust
+use faucet_core::Sink;
+use faucet_sink_iceberg::{IcebergSink, IcebergSinkConfig};
+use serde_json::json;
+
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+// Configs are normally loaded from YAML/JSON; deserialize one here.
+let config: IcebergSinkConfig = serde_json::from_value(json!({
+    "catalog": {
+        "type": "rest",
+        "uri": "http://localhost:8181",
+        "warehouse": "s3://warehouse/"
+    },
+    "namespace": ["analytics"],
+    "table": "events",
+    "create_if_missing": true,
+    "batch_size": 10000
+}))?;
+
+let sink = IcebergSink::new(config).await?;
+
+sink.write_batch(&[
+    json!({"user_id": "u123", "event": "page_view", "ts": "2026-01-02T10:00:00Z"}),
+    json!({"user_id": "u456", "event": "click",     "ts": "2026-01-02T10:01:00Z"}),
+]).await?;
+
+// Required: writes the Parquet footer and commits the Iceberg snapshot.
+sink.flush().await?;
+# Ok(())
+# }
+```
+
+## How it works
+
+1. `new()` validates the config, builds the configured catalog client, and either creates the table (inferring schema from the first batch) or loads an existing one.
+2. `write_batch` shovels JSON → Arrow, buffers into the iceberg-rust rolling writer, and rolls a new Parquet data file when the estimated size crosses `target_file_size_mb`.
+3. `flush()` closes the open data file and commits all buffered files as one snapshot via `Transaction::fast_append`; the catalog client is reused across all calls.
+4. In exactly-once mode the pending `(scope, token)` is merged into that snapshot's summary properties so it commits atomically with the data.
+
+**Arrow / Parquet version note:** this crate links Arrow / Parquet **57** to match `iceberg-rust` 0.9.x, which pins the same major. This does not affect the workspace's other connectors — the Parquet source/sink use Arrow 58, and Cargo resolves both majors simultaneously.
 
 ## Lineage dataset URI
 
-`iceberg://<catalog_type>/<namespace>.<table>` — e.g. `iceberg://rest/prod.events` (catalog type is `rest`, `glue`, `sql`, or `hms`).
+`iceberg://<catalog_type>/<namespace>.<table>` — e.g. `iceberg://rest/analytics.events` (catalog type is `rest`, `glue`, `sql`, or `hms`).
+
+## Feature flags
+
+| Feature | Default? | Enables |
+|---------|----------|---------|
+| `catalog-rest` | **yes** | REST catalog (`iceberg-catalog-rest`). |
+| `catalog-glue` | no | AWS Glue catalog (also enables `storage-opendal`). |
+| `catalog-sql` | no | SQL-backed catalog (also enables `storage-opendal`). |
+| `catalog-hms` | no | Hive Metastore catalog (also enables `storage-opendal`). |
+| `storage-opendal` | no (auto) | OpenDAL S3/GCS/local warehouse storage factory for the non-REST catalogs. Auto-enabled by each non-REST catalog feature. |
+
+In the CLI/umbrella, the corresponding feature is `sink-iceberg` (REST), with `sink-iceberg-glue` / `sink-iceberg-sql` / `sink-iceberg-hms` forwarding the catalog features.
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause & fix |
+|---------|--------------------|
+| `FaucetError::Config: catalog '…' requires a non-empty uri` | `rest` / `sql` / `hms` catalogs need a `uri`. Set it (Glue is the only catalog that resolves its endpoint from AWS config). |
+| `FaucetError::Config: warehouse scheme '…://' is not supported` | A non-REST catalog got an unsupported warehouse scheme. Use `file://`, `s3://`, `s3a://`, or `gs://` — or switch to the REST catalog, which accepts any scheme (it resolves FileIO server-side). |
+| `unknown variant 'overwrite'` / `write_mode … rejected` | Only `append` is supported. `upsert`/`delete` parse but are rejected at `new()`; `overwrite` is not a variant. See [Write mode](#write-mode-append-only). |
+| Catalog type fails at startup despite a valid config | The catalog's Cargo feature isn't compiled in. Rebuild with `--features catalog-glue` (or `-sql` / `-hms`) — `catalog-rest` is the only one in the default build. |
+| `faucet doctor` catalog probe times out / fails | Verify the catalog URI, credentials, and network reachability. The probe calls `table_exists` and is bounded by `--timeout-secs`. |
+| Data files exist in object storage but no snapshot references them | A commit failed after the Parquet file was uploaded (orphaned files). Re-run to write fresh files; reclaim orphans with Iceberg's `remove_orphan_files` maintenance. The sink never auto-deletes (avoids duplicating data). |
+| `partition_spec[…].transform … is not a recognised Iceberg transform` | Use one of `identity`/`year`/`month`/`day`/`hour`/`void` or `bucket[N]`/`truncate[N]` with a positive `N`. |
+| `target_file_size_mb must be > 0` | `0` would roll a tiny file per batch. Use a positive MB target (default `256`). |
+| Partition spec seems ignored | `partition_spec` only applies when **creating** a new table (`create_if_missing: true`). An existing table keeps its own spec. |
+| Exactly-once config rejected by `faucet validate` | `delivery: exactly_once` requires a CDC source + a `state:` block + **no** DLQ. Fix whichever requirement the error names. |
+
+## See also
+
+- [Connector reference & capability matrix](https://pawansikawat.github.io/faucet-stream/reference/connectors.html)
+- [Exactly-once delivery cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/state.html#exactly-once-delivery)
+- [Configuration grammar](https://pawansikawat.github.io/faucet-stream/reference/config.html)
+- Related crates: [`faucet-sink-parquet`](https://crates.io/crates/faucet-sink-parquet), [`faucet-sink-s3`](https://crates.io/crates/faucet-sink-s3), [`faucet-sink-bigquery`](https://crates.io/crates/faucet-sink-bigquery), [`faucet-source-postgres-cdc`](https://crates.io/crates/faucet-source-postgres-cdc)
 
 ## License
 
-Licensed under MIT or Apache-2.0.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/sink/iceberg/README.md
+++ b/crates/sink/iceberg/README.md
@@ -2,6 +2,8 @@
 
 [![Crates.io](https://img.shields.io/crates/v/faucet-sink-iceberg.svg)](https://crates.io/crates/faucet-sink-iceberg)
 [![Docs.rs](https://docs.rs/faucet-sink-iceberg/badge.svg)](https://docs.rs/faucet-sink-iceberg)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-sink-iceberg.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-sink-iceberg.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
 Apache Iceberg sink connector for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
 

--- a/crates/sink/jsonl/README.md
+++ b/crates/sink/jsonl/README.md
@@ -2,6 +2,8 @@
 
 [![Crates.io](https://img.shields.io/crates/v/faucet-sink-jsonl.svg)](https://crates.io/crates/faucet-sink-jsonl)
 [![Docs.rs](https://docs.rs/faucet-sink-jsonl/badge.svg)](https://docs.rs/faucet-sink-jsonl)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-sink-jsonl.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-sink-jsonl.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
 JSON Lines file sink connector for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
 

--- a/crates/sink/jsonl/README.md
+++ b/crates/sink/jsonl/README.md
@@ -5,15 +5,31 @@
 [![MSRV](https://img.shields.io/crates/msrv/faucet-sink-jsonl.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
 [![License](https://img.shields.io/crates/l/faucet-sink-jsonl.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-JSON Lines file sink connector for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
+JSON Lines (**`.jsonl`**) file sink for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem. Writes each record as one JSON object per line in [JSON Lines](https://jsonlines.org/) format.
 
-Writes JSON records to a file in [JSON Lines](https://jsonlines.org/) format (one JSON object per line). The file is opened lazily on the first write. Uses buffered async I/O via `tokio::io::BufWriter` for high throughput. Supports append mode, pretty-printing, and explicit flush control.
+It's the workhorse local-file destination: zero credentials, zero connection setup, and a streaming-friendly format that everything downstream understands (`jq`, `pandas`, DuckDB, BigQuery / Snowflake / Spark loaders). Records stream through a buffered async writer so even multi-million-row exports stay fast and bounded in memory, and dated output paths like `./data/dt=2026-03-08/part.jsonl` work without pre-creating the directory tree.
+
+## Feature highlights
+
+- **Buffered async writes** — records go through a `tokio::io::BufWriter`, so high-volume runs aren't bottlenecked on per-record syscalls.
+- **Append or truncate** — `append: true` adds to an existing file; the default truncates on open for a clean export.
+- **Auto-creates parent directories** — missing parents of `path` are created (`mkdir -p` semantics) before the file opens, so dated/partitioned subdirectory paths just work.
+- **Optional compression** — behind the `compression` feature, gzip / zstd are selected automatically from the `.gz` / `.zst` suffix (or set explicitly). Multi-member output stays decoder-compatible across mid-stream flushes.
+- **Pretty-print mode** — `pretty: true` indents each record for human reading (no longer strict JSONL — records span multiple lines).
+- **Flush-safe for CDC** — `flush()` finalises the writer and the next write reopens in append mode regardless of `append`, so a CDC source's per-transaction flush appends rather than truncates — no data loss mid-stream.
+- **`faucet doctor` preflight** — `check()` verifies the parent directory is writable (via a throwaway temp file) without ever touching your real output file.
 
 ## Installation
 
 ```bash
+# As a library:
 cargo add faucet-sink-jsonl
-cargo add tokio --features full
+
+# In the CLI (connector feature; in the CLI default build):
+cargo install faucet-cli --features sink-jsonl
+
+# With gzip / zstd compression:
+cargo install faucet-cli --features "sink-jsonl,compression"
 ```
 
 Or via the umbrella crate:
@@ -22,200 +38,232 @@ Or via the umbrella crate:
 cargo add faucet-stream --features sink-jsonl
 ```
 
-## Quick Start
+`sink-jsonl` is one of the most common destinations and ships in the CLI's default build. The crate-local `compression` feature is opt-in.
 
-```rust
-use faucet_sink_jsonl::{JsonlSink, JsonlSinkConfig};
-use faucet_core::Sink;
-use serde_json::json;
+## Quick start
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let config = JsonlSinkConfig::new("/tmp/output.jsonl");
-    let sink = JsonlSink::new(config);
-
-    let records = vec![
-        json!({"id": 1, "name": "Alice", "email": "alice@example.com"}),
-        json!({"id": 2, "name": "Bob", "email": "bob@example.com"}),
-    ];
-
-    let written = sink.write_batch(&records).await?;
-    sink.flush().await?;
-
-    println!("Wrote {written} records");
-    Ok(())
-}
+```yaml
+# pipeline.yaml — faucet run pipeline.yaml
+version: 1
+name: csv_to_jsonl
+pipeline:
+  source:
+    type: csv
+    config:
+      path: ./data/input.csv
+  sink:
+    type: jsonl
+    config:
+      path: ./out/records.jsonl
 ```
 
-## Configuration
+```bash
+faucet run pipeline.yaml
+```
+
+Every row of `input.csv` is written to `./out/records.jsonl` as one compact JSON object per line. The `./out/` directory is created automatically if it doesn't exist.
+
+## Configuration reference
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `path` | `PathBuf` | *(required)* | Path to the output file |
-| `append` | `bool` | `false` | Whether to append to an existing file. When `false`, the file is truncated on open. |
-| `pretty` | `bool` | `false` | Whether to pretty-print each JSON record with indentation. Note: this breaks strict JSONL format since records span multiple lines. |
-| `batch_size` | `usize` | `1000` | Records per upstream `StreamPage`. **No behavioural impact** at this sink — present for symmetry. See [Streaming and batching](#streaming-and-batching). |
+| `path` | string (path) | *(required)* | Path to the output file. Missing parent directories are created automatically. |
+| `append` | bool | `false` | Append to an existing file. When `false`, the file is **truncated** on first open. |
+| `pretty` | bool | `false` | Pretty-print (indent) each record. This breaks strict JSONL — records span multiple lines. |
+| `batch_size` | int | `1000` | Records per upstream `StreamPage`. **No behavioural effect** at this per-record sink; present only for config parity. See [Streaming & batching](#streaming--batching). |
+| `compression` | `none` \| `gzip` \| `zstd` \| `auto` | `auto` | *(requires the `compression` feature)* Output codec. `auto` picks gzip/zstd from the file suffix; anything else writes uncompressed. See [Compression](#compression). |
 
-## Streaming and batching
+## Examples
 
-This sink writes records to the output file one at a time via `tokio::io::BufWriter`. The per-page memory bound for the pipeline is set by the **source's** `batch_size` (the size of each `StreamPage` that `Pipeline::run` hands to `Sink::write_batch`); how that page is then iterated record-by-record on the sink side is what determines on-disk output, and that path does not depend on `batch_size` at all.
+### Basic export (truncate mode)
 
-`batch_size` is exposed on this config purely for symmetry across every sink in the workspace — sinks like `faucet-sink-postgres` or `faucet-sink-bigquery` use the field to size their multi-row inserts / streaming-insert requests, but a per-record file sink has nothing to tune. `batch_size = 0` (the "no batching" sentinel) and any positive value are observably identical for this sink: both produce byte-for-byte the same `.jsonl` file.
-
-### Builder Methods
-
-```rust
-use faucet_sink_jsonl::JsonlSinkConfig;
-
-let config = JsonlSinkConfig::new("/data/output.jsonl")
-    .append(true)
-    .pretty(false);
+```yaml
+version: 1
+pipeline:
+  source:
+    type: rest
+    config:
+      base_url: https://api.example.com
+      path: /v1/events
+  sink:
+    type: jsonl
+    config:
+      path: ./out/events.jsonl
 ```
 
-## Config Loading
+### Append for incremental / repeated runs
+
+```yaml
+version: 1
+pipeline:
+  source:
+    type: postgres
+    config:
+      connection_url: ${env:DATABASE_URL}
+      query: SELECT id, name, signup_date FROM users
+  sink:
+    type: jsonl
+    config:
+      path: ./out/users.jsonl
+      append: true   # each run adds to the file rather than overwriting it
+```
+
+### Partitioned, dated output path
+
+```yaml
+version: 1
+pipeline:
+  source:
+    type: csv
+    config:
+      path: ./data/input.csv
+  sink:
+    type: jsonl
+    config:
+      # ${now.date} resolves to YYYY-MM-DD per run; the dt=... directory
+      # is created automatically.
+      path: ./data/dt=${now.date}/part.jsonl
+```
+
+### Gzip-compressed export (requires the `compression` feature)
+
+```yaml
+version: 1
+pipeline:
+  source:
+    type: postgres
+    config:
+      connection_url: ${env:DATABASE_URL}
+      query: SELECT * FROM events
+  sink:
+    type: jsonl
+    config:
+      path: ./out/events.jsonl.gz   # .gz suffix → gzip via compression: auto
+```
+
+## Streaming & batching
+
+`Pipeline::run` drives the source's `stream_pages` and hands each emitted `StreamPage` to `Sink::write_batch`. This sink iterates the page **record by record**, serializing and appending each one through the buffered writer.
+
+Because the write path is inherently per-record, `batch_size` has **no observable effect** here — `batch_size = 0` (the "no batching" sentinel) and any positive value produce byte-for-byte identical files. The field exists only so every sink shares one config shape; sinks like `faucet-sink-postgres` (multi-row INSERTs) or `faucet-sink-bigquery` (streaming-insert request sizing) genuinely use it. The per-run memory bound is set by the **source's** `batch_size` (the size of each `StreamPage`), not by this field.
+
+When a bookmark-carrying page arrives (e.g. from a CDC source), the pipeline calls `flush()` after the page. This sink finalises the writer and the next `write_batch` reopens the file in **append mode regardless of `append`**, so per-transaction durability never truncates previously-written records.
+
+## Compression
+
+Behind the crate-local `compression` Cargo feature. Adds a `compression` config field with values `none`, `gzip`, `zstd`, or `auto` (the default — detects `.gz` / `.zst` from the file path):
+
+```yaml
+type: jsonl
+config:
+  path: ./out/events.jsonl.zst
+  compression: auto   # or 'gzip' | 'zstd' | 'none'
+```
+
+`flush()` finalises the encoder (writes the trailer); a subsequent write appends a fresh gzip/zstd member, producing a multi-member compressed file that standard decoders read back transparently. The sink does not set any HTTP `Content-Encoding` — the file is a plain compressed file on disk.
+
+## Config loading & schema
+
+Configs load from YAML/JSON files, environment variables, or `.env` files via the CLI's normal loading path. From a library, use the `faucet_core::config` helpers:
 
 ```rust
 use faucet_core::config::{load_json, load_env_file};
 use faucet_sink_jsonl::JsonlSinkConfig;
 
-// From a JSON file
 let config: JsonlSinkConfig = load_json("config.json")?;
-
-// From an .env file with a prefix
 let config: JsonlSinkConfig = load_env_file(".env", "JSONL_SINK")?;
 ```
 
-### Example JSON config
+Inspect the full JSON Schema with:
 
-```json
-{
-  "path": "/data/exports/events.jsonl",
-  "append": false,
-  "pretty": false,
-  "batch_size": 1000
-}
+```bash
+faucet schema sink jsonl
 ```
 
-### Example .env file
-
-```env
-JSONL_SINK_PATH=/data/exports/events.jsonl
-JSONL_SINK_APPEND=false
-JSONL_SINK_PRETTY=false
-```
-
-## Config Schema Introspection
+## Library usage
 
 ```rust
-use faucet_core::Sink;
+use faucet_core::{Pipeline, Sink};
+use faucet_sink_jsonl::{JsonlSink, JsonlSinkConfig};
+use serde_json::json;
 
+# async fn run() -> Result<(), faucet_core::FaucetError> {
+let config = JsonlSinkConfig::new("./out/output.jsonl")
+    .append(true)
+    .pretty(false);
 let sink = JsonlSink::new(config);
-let schema = sink.config_schema();
-println!("{}", serde_json::to_string_pretty(&schema)?);
+
+sink.write_batch(&[
+    json!({"id": 1, "name": "Alice"}),
+    json!({"id": 2, "name": "Bob"}),
+])
+.await?;
+sink.flush().await?; // always flush before dropping the sink
+# Ok(())
+# }
 ```
 
-## Pipeline Usage
+Wire it to any source through a `Pipeline`:
 
 ```rust
 use faucet_core::Pipeline;
 use faucet_source_rest::{RestStream, RestStreamConfig};
 use faucet_sink_jsonl::{JsonlSink, JsonlSinkConfig};
 
-let source_config = RestStreamConfig::new("https://api.example.com", "/v1/events");
-let source = RestStream::new(source_config);
-
-let sink_config = JsonlSinkConfig::new("/data/events.jsonl");
-let sink = JsonlSink::new(sink_config);
+# async fn run() -> Result<(), faucet_core::FaucetError> {
+let source = RestStream::new(RestStreamConfig::new("https://api.example.com", "/v1/events"));
+let sink = JsonlSink::new(JsonlSinkConfig::new("./out/events.jsonl"));
 
 let result = Pipeline::new(source, sink).run().await?;
-println!("Exported {} records to JSONL", result.records_written);
+println!("Exported {} records", result.records_written);
+# Ok(())
+# }
 ```
 
-## Examples
+## How it works
 
-### Basic file export (truncate mode)
-
-```rust
-let config = JsonlSinkConfig::new("/tmp/users.jsonl");
-let sink = JsonlSink::new(config);
-
-sink.write_batch(&records).await?;
-sink.flush().await?;
-```
-
-Output (`/tmp/users.jsonl`):
-```
-{"id":1,"name":"Alice","email":"alice@example.com"}
-{"id":2,"name":"Bob","email":"bob@example.com"}
-```
-
-### Append mode for incremental exports
-
-```rust
-// First run: creates the file
-let sink = JsonlSink::new(JsonlSinkConfig::new("/data/events.jsonl"));
-sink.write_batch(&batch_1).await?;
-sink.flush().await?;
-drop(sink);
-
-// Second run: appends to existing file
-let sink = JsonlSink::new(JsonlSinkConfig::new("/data/events.jsonl").append(true));
-sink.write_batch(&batch_2).await?;
-sink.flush().await?;
-```
-
-### Pretty-printed output for debugging
-
-```rust
-let config = JsonlSinkConfig::new("/tmp/debug.json").pretty(true);
-let sink = JsonlSink::new(config);
-sink.write_batch(&records).await?;
-sink.flush().await?;
-```
-
-Output:
-```json
-{
-  "id": 1,
-  "name": "Alice"
-}
-{
-  "id": 2,
-  "name": "Bob"
-}
-```
-
-## How It Works
-
-- The file is opened lazily on the first `write_batch()` call and wrapped in a `tokio::io::BufWriter` for efficient buffered writes.
-- Missing parent directories of `path` are created automatically (equivalent to `mkdir -p`) before the file is opened, matching the behaviour of the parquet sink. Dated-subdirectory paths such as `./data/dt=2026-03-08/part.jsonl` work without any pre-creation step.
-- A `Mutex` protects the writer for thread-safe concurrent access.
-- Each record is serialized to a single JSON line (or pretty-printed if configured) followed by a newline character.
-- Multiple `write_batch()` calls accumulate data in the same file without re-opening it.
-- Call `flush()` to ensure all buffered data is written to disk. This is important before dropping the sink or reading the file.
-- In truncate mode (default), the file is emptied on first write. In append mode, new records are added after existing content.
-
-## Compression
-
-Behind the crate-local `compression` Cargo feature. Adds a `compression` config
-field with values `none`, `gzip`, `zstd`, or `auto` (the default — detects
-`.gz` / `.zst` from the file path / object key).
-
-YAML example:
-
-```yaml
-kind: jsonl
-config:
-  # ... existing fields ...
-  compression: auto  # or 'gzip' | 'zstd' | 'none'
-```
-
-`flush()` finalises the encoder; subsequent writes append a fresh gzip / zstd member (multi-member-decoder compatible).
+1. The file is opened **lazily** on the first `write_batch` call and wrapped in a `tokio::io::BufWriter`. An empty batch is a no-op (no file is created).
+2. Missing parent directories of `path` are created (`mkdir -p`) before the file opens.
+3. The first open obeys `append`; **re-opens after a `flush()` always append**, so a flush-then-write sequence never truncates earlier data — important for CDC's per-transaction flush.
+4. Each record is serialized to a single JSON line (or pretty-printed) followed by a newline; a `Mutex` guards the writer for thread-safe writes.
+5. With the `compression` feature, the buffered file is wrapped in a gzip/zstd encoder chosen by `compression.resolve(path)`; a one-shot warning fires if an explicit codec disagrees with the file suffix.
+6. `flush()` finalises and shuts down the writer (flushing the buffer and writing any compression trailer). The default `Sink` impl does **not** flush on `Drop` — call `flush()` explicitly before the program exits or the tail of the buffer is lost.
 
 ## Lineage dataset URI
 
 `file://<path>` — e.g. `file:///tmp/output.jsonl`.
 
+## Feature flags
+
+| Feature | Default | Effect |
+|---------|---------|--------|
+| `compression` | off | Adds the `compression` config field and gzip/zstd encoding via `faucet-core/compression`. |
+
+This sink does **not** support exactly-once delivery or upsert/delete write modes — it is an append-only file writer. For exactly-once or upsert semantics, use a transactional sink (`faucet-sink-postgres`, `faucet-sink-bigquery`, etc.).
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause & fix |
+|---------|--------------------|
+| `failed to create parent directory '...'` | The parent path isn't creatable (permissions, or a path component is a file). Check write permissions on the closest existing ancestor; run `faucet doctor` to probe writability up front. |
+| `failed to open <path>` | The file path is unwritable (read-only filesystem, no permission, or path is a directory). Verify the path and permissions. |
+| File is empty / truncated after the run | You didn't `flush()`. The buffered/compressed writer only finalises on `flush()` — call it before dropping the sink (the CLI does this automatically). |
+| Previous data disappeared on the next run | Default mode **truncates** on open. Set `append: true` to keep prior content across runs. |
+| Output isn't valid line-delimited JSON | `pretty: true` indents records across multiple lines, which breaks strict JSONL. Use `pretty: false` (the default) for tooling that expects one object per line. |
+| `.gz` / `.zst` file isn't compressed | The `compression` feature isn't enabled. Rebuild with `--features "sink-jsonl,compression"` (CLI) or `--features compression` (library); without it the suffix is treated as a plain filename. |
+| Setting `batch_size` changes nothing | Expected — it's a no-op for this per-record sink. To bound per-page memory, set the **source's** `batch_size`. |
+| Records lost mid-stream from a CDC source | Should not happen — re-opens after a per-page flush always append. If you see truncation, confirm nothing else is rewriting the file out-of-band. |
+
+## See also
+
+- [Sinks reference](https://pawansikawat.github.io/faucet-stream/reference/connectors.html) — the full connector capability matrix.
+- [Compression cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/compression.html) — gzip/zstd across file sinks.
+- [CLI reference](https://pawansikawat.github.io/faucet-stream/reference/cli.html) — `faucet run`, `faucet validate`, `faucet schema`, `faucet doctor`.
+- [`faucet-sink-stdout`](https://crates.io/crates/faucet-sink-stdout) — the same JSON Lines to a standard stream instead of a file.
+- [`faucet-sink-csv`](https://crates.io/crates/faucet-sink-csv) — CSV/TSV file output with full quoting.
+- [`faucet-sink-s3`](https://crates.io/crates/faucet-sink-s3) / [`faucet-sink-gcs`](https://crates.io/crates/faucet-sink-gcs) — the same JSONL records to object storage.
+- [`faucet-core`](https://crates.io/crates/faucet-core) — the `Sink` trait this connector implements.
+
 ## License
 
-Licensed under MIT or Apache-2.0.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/sink/kafka/README.md
+++ b/crates/sink/kafka/README.md
@@ -1,112 +1,152 @@
 # faucet-sink-kafka
 
-Apache Kafka producer sink for `faucet-stream`. Publishes records to one or more Kafka topics. Built on [`rdkafka`](https://crates.io/crates/rdkafka) (`FutureProducer`). Supports idempotent producer, fixed or per-record topic routing, JSONPath-driven key/partition/headers extraction, configurable compression, and `QueueFull` retry.
+[![Crates.io](https://img.shields.io/crates/v/faucet-sink-kafka.svg)](https://crates.io/crates/faucet-sink-kafka)
+[![Docs.rs](https://docs.rs/faucet-sink-kafka/badge.svg)](https://docs.rs/faucet-sink-kafka)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-sink-kafka.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-sink-kafka.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
----
+Apache **Kafka** producer sink for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem. Publishes each record to one or more Kafka topics over [`rdkafka`](https://crates.io/crates/rdkafka)'s `FutureProducer`, with an idempotent producer, configurable compression, per-record topic/key/partition/header routing, and `QueueFull` retry.
+
+Reach for it when you want to land any faucet-stream source — a REST API, a database, a CDC stream, a file — onto Kafka with one declarative config and no glue code. Sends inside each batch fly concurrently through a `FuturesUnordered` window, so a single pipeline saturates the producer instead of round-tripping one message at a time.
+
+## Feature highlights
+
+- **Concurrent batched sends** — each `write_batch` enqueues its records into a `FuturesUnordered` of `send_result` futures so multiple produce requests are in flight at once, bounded by `min(max_in_flight, batch_size)`.
+- **Idempotent producer by default** — `idempotent: true` sets `enable.idempotence`, so retried produce calls within a session never duplicate. Combined with `acks: all`, that's no-loss, no-duplicate delivery per produce call.
+- **`QueueFull` retry** — when librdkafka's send queue is full, the sink backs off (`queue_full_backoff`) and retries up to `queue_full_max_retries` before surfacing the error.
+- **Multi-topic routing** — send everything to one `fixed` topic, or extract the destination topic from each record with a JSONPath (`from_path`).
+- **Per-record key / partition / headers** — JSONPath-driven `key_path`, `partition_path`, and `headers_path`, with a configurable `on_key_error` policy (`fail` / `skip` / `round_robin`).
+- **Producer compression** — `none` / `gzip` / `snappy` / `lz4` / `zstd`.
+- **Value & key encoding** — JSON, raw UTF-8 string, or base64 bytes out of the box; Confluent **Avro / Protobuf / JSON Schema** behind the `schema-registry` feature.
+- **SASL / SSL auth** — `none`, `sasl_plain`, `sasl_scram` (SHA-256/512), `ssl` (mTLS), and `sasl_ssl`, shared verbatim with the Kafka **source** via [`faucet-common-kafka`](https://crates.io/crates/faucet-common-kafka).
+- **Producer built once** — the authenticated `FutureProducer` is constructed in `new()` and reused for every batch.
+
+## Installation
+
+```bash
+# As a library:
+cargo add faucet-sink-kafka
+
+# In the CLI (opt-in connector feature):
+cargo install faucet-cli --features sink-kafka
+
+# With Confluent Schema Registry encoding (Avro / JSON Schema):
+cargo install faucet-cli --features sink-kafka,kafka-schema-registry
+```
 
 ## Quick start
 
 ```yaml
-# pipeline.yaml
+# pipeline.yaml — faucet run pipeline.yaml
 version: 1
-
-source:
-  kind: rest
-  config:
-    base_url: "https://api.example.com"
-    path: "/orders"
-    records_path: "$.orders"
-
-sink:
-  kind: kafka
-  config:
-    brokers: "broker1:9092,broker2:9092"
-    topic:
-      type: fixed
-      name: orders
-    value_format:
-      type: json
-    compression: lz4
-    idempotent: true
-    acks: all
+pipeline:
+  source:
+    type: rest
+    config:
+      base_url: https://jsonplaceholder.typicode.com
+      path: /users
+      pagination: { type: none }
+  sink:
+    type: kafka
+    config:
+      brokers: localhost:9092
+      topic: { type: fixed, name: users }
+      value_format: { type: json }
+      key_path: $.id          # use the record's "id" field as the message key
+      on_key_error: round_robin
+      compression: zstd
+      acks: all
+      idempotent: true
 ```
-
-Run it:
 
 ```bash
 faucet run pipeline.yaml
 ```
 
----
+## Configuration reference
 
-## Full config reference
+All fields are keys under `sink.config`.
 
-All fields are top-level keys under `sink.config` in the pipeline YAML.
+### Core
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `brokers` | `string` | **required** | Comma-separated bootstrap broker addresses, e.g. `"broker1:9092,broker2:9092"`. |
-| `topic` | `KafkaSinkTopic` | **required** | Topic routing strategy. See [Topic resolution](#topic-resolution). |
-| `auth` | `KafkaAuth` | `{type: none}` | Authentication mode. See [SASL/SSL setup](#saslssl-setup). |
-| `value_format` | `KafkaValueFormat` | `{type: json}` | How each record is encoded as message bytes. See [Value + key encoding](#value--key-encoding). |
-| `key_format` | `KafkaValueFormat \| null` | `null` | Encoding applied to the extracted key value. When absent, key bytes are serialized as UTF-8. |
-| `key_path` | `string \| null` | `null` | JSONPath into each record to extract the message key. |
-| `partition_path` | `string \| null` | `null` | JSONPath into each record to extract the target partition number (integer). |
-| `headers_path` | `string \| null` | `null` | JSONPath into each record to extract a flat object of header key → string value pairs. |
-| `on_key_error` | `"fail" \| "skip" \| "round_robin"` | `"fail"` | What to do when key or partition extraction fails. See [OnKeyError policy](#onkeyerror-policy). |
-| `compression` | `"none" \| "gzip" \| "snappy" \| "lz4" \| "zstd"` | `"none"` | Producer-side compression codec. See [Compression](#compression). |
+| `brokers` | string | — *(required)* | Comma-separated bootstrap broker addresses, e.g. `"broker1:9092,broker2:9092"`. |
+| `topic` | `KafkaSinkTopic` | — *(required)* | Topic routing strategy. See [Topic routing](#topic-routing). |
+| `auth` | `KafkaAuth` | `{ type: none }` | Authentication / transport security. See [Authentication](#authentication). |
+
+### Value & key encoding
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `value_format` | `KafkaValueFormat` | `{ type: json }` | How each record is encoded into the message value bytes. See [Encoding](#encoding). |
+| `key_format` | `KafkaValueFormat` | *(unset)* | Encoding applied to the extracted key value. When unset, the key is written as UTF-8 bytes. |
+| `value_schema` | string | *(unset)* | Schema text (Avro `.avsc` JSON / `.proto` / JSON Schema) for the value, **required** when `value_format` is a Confluent format. Registered under the `{topic}-value` subject on first use; ignored otherwise. |
+| `key_schema` | string | *(unset)* | Schema text for the key, **required** when `key_format` is a Confluent format. Registered under `{topic}-key`; ignored otherwise. |
+
+### Routing
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `key_path` | string | *(unset)* | JSONPath into each record to extract the message key. Absent → no key (round-robin partitioning). |
+| `partition_path` | string | *(unset)* | JSONPath to extract the target partition number (integer). Absent → librdkafka chooses. |
+| `headers_path` | string | *(unset)* | JSONPath to a flat object of `header → string` pairs written as Kafka headers. |
+| `on_key_error` | `"fail" \| "skip" \| "round_robin"` | `"fail"` | What to do when `key_path` / `partition_path` extraction fails. See [Key error policy](#key-error-policy). |
+
+### Reliability
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
 | `acks` | `"none" \| "leader" \| "all"` | `"all"` | Broker acknowledgment level. Must be `"all"` when `idempotent: true`. |
-| `idempotent` | `bool` | `true` | Enable the idempotent producer (`enable.idempotence = true`). Requires `acks: all`. |
-| `linger` | `integer` (seconds) | `0` | Time the producer waits before flushing a partial batch. Use `extra_client_config: {linger.ms: "5"}` for millisecond precision. |
-| `batch_size` | `integer` | `1000` (`DEFAULT_BATCH_SIZE`) | Maximum number of in-flight `FuturesUnordered` send futures per `write_batch` call. Also seeds librdkafka's `queue.buffering.max.messages` so the broker-side buffer matches the send window. `0` disables the explicit cap (bounded only by `max_in_flight`) and leaves `queue.buffering.max.messages` at its librdkafka default. See [Streaming and batching](#streaming-and-batching). |
-| `message_timeout` | `integer` (seconds) | `30` | Delivery timeout per message. |
-| `max_in_flight` | `integer` | `100` | Maximum concurrent produce requests. Must be ≥ 1. |
-| `queue_full_backoff` | `integer` (seconds) | `0` | Pause between retries on `QueueFull` error. |
-| `queue_full_max_retries` | `integer` | `3` | Maximum `QueueFull` retries before the error surfaces. |
-| `extra_client_config` | `object` | `{}` | Raw librdkafka client properties. Overrides anything set by `auth` or the typed fields above. |
+| `idempotent` | bool | `true` | Enable the idempotent producer (`enable.idempotence = true`). Requires `acks: all`. |
+| `message_timeout` | int (seconds) | `30` | Per-message delivery timeout. Raise for high-latency brokers. |
+| `max_in_flight` | int | `100` | Max concurrent produce requests. Must be ≥ 1. Set to `1` (with `idempotent: true`) for strict per-partition ordering. |
+| `queue_full_backoff` | int (seconds) | `0` *(0.1s)* | Pause between retries on `QueueFull`. The default is **100 ms** (sub-second); the config field is whole-seconds, so use `extra_client_config` only if you need finer control elsewhere. |
+| `queue_full_max_retries` | int | `3` | Max `QueueFull` retries before the error surfaces. |
 
----
+### Batching & throughput
 
-## Topic resolution
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `batch_size` | int | `1000` | In-flight `FuturesUnordered` send-window cap per `write_batch`, and the seed for librdkafka's `queue.buffering.max.messages`. **`0` = no cap** (bounded only by `max_in_flight`). See [Streaming & batching](#streaming--batching). |
+| `linger` | int (seconds) | `0` *(5ms)* | Time the producer waits to accumulate a batch before flushing. The default is **5 ms**; for other sub-second values set `linger.ms` via `extra_client_config`. |
+| `compression` | `"none" \| "gzip" \| "snappy" \| "lz4" \| "zstd"` | `"none"` | Producer-side compression codec. See [Compression](#compression). |
+| `extra_client_config` | object (string→string) | `{}` | Raw librdkafka client properties. **Overrides** anything set by `auth` or the typed fields above. |
 
-Two strategies are available, selected by the `type` discriminator.
+## Topic routing
 
-### `fixed` — all records go to the same topic
+`topic` is a `{ type, … }` discriminated value with two strategies:
 
 ```yaml
+# fixed — every record goes to the same topic
 topic:
   type: fixed
   name: orders
 ```
 
-### `from_path` — topic extracted per record via JSONPath
-
 ```yaml
+# from_path — topic extracted per record via JSONPath
 topic:
   type: from_path
-  path: "$.dest"   # JSONPath extracted from each record
+  path: $.dest
 ```
 
-The path must resolve to a non-empty string for every record. A missing or non-string value is always fatal — there is no `on_key_error` equivalent for topic routing.
+For `from_path`, the path must resolve to a non-empty string for **every** record — a missing or non-string value is always fatal. `on_key_error` does **not** apply to topic routing.
 
----
+## Encoding
 
-## Value + key encoding
+`value_format` (and the optional `key_format`) is a `{ type, … }` value:
 
-Configured via `value_format` (and optionally `key_format`). All formats use a `type` discriminator.
+| `type` | Feature | Description |
+|--------|---------|-------------|
+| `json` | — | Serialize the record as a JSON document. **Default.** |
+| `raw_string` | — | Write the record's string representation as UTF-8 bytes. |
+| `bytes` | — | Expect a base64-encoded string; decode and write the raw bytes. |
+| `confluent_avro` | `schema-registry` | Confluent wire-format Avro (`[0x00][be u32 schema_id][Avro]`). Subject `{topic}-value`. |
+| `confluent_protobuf` | `schema-registry` | Present for API symmetry; v1 returns `FaucetError::Config` on encode (full descriptor support tracked in [#44](https://github.com/PawanSikawat/faucet-stream/issues/44)). |
+| `confluent_json_schema` | `schema-registry` | Confluent wire-format JSON (`[0x00][be u32 schema_id][JSON]`). |
 
-| Format | `type` | Description |
-|--------|--------|-------------|
-| JSON | `json` | Serialize the record as a JSON document. Default. |
-| Raw string | `raw_string` | Write the string representation as UTF-8 bytes. |
-| Bytes | `bytes` | Expect a base64-encoded string; decode and write raw bytes. |
-| Confluent Avro | `confluent_avro` | Confluent wire-format Avro. Subject is `{topic}-value`. Requires `schema-registry` feature. |
-| Confluent Protobuf | `confluent_protobuf` | v1 returns an error — tracked in issue #44. Requires `schema-registry` feature. |
-| Confluent JSON Schema | `confluent_json_schema` | Confluent wire-format JSON. Requires `schema-registry` feature. |
-
-The three Confluent formats require the `schema-registry` feature flag. Each takes a `schema_registry` block — see the [`faucet-common-kafka` README](../../common/kafka/README.md#value-formats) for `SchemaRegistryConfig` options.
-
-When a Confluent format is used on the **sink** side you must also supply the schema text to register and encode against: set `value_schema` (for `value_format`) and/or `key_schema` (for `key_format`) to the Avro `.avsc` JSON, `.proto`, or JSON Schema document. They are registered under the `{topic}-value` / `{topic}-key` subjects on first use. The config is rejected at load time if a Confluent format is selected without its schema.
+The three Confluent formats need the `schema-registry` feature (CLI: `kafka-schema-registry`) and a `schema_registry` block. On the **sink** side you must also supply the schema text to register and encode against — `value_schema` for the value, `key_schema` for the key — or the config is rejected at load time. See the [`faucet-common-kafka` README](https://crates.io/crates/faucet-common-kafka) for `SchemaRegistryConfig` options.
 
 ```yaml
 sink:
@@ -120,111 +160,24 @@ sink:
     value_schema: '{"type":"record","name":"Event","fields":[{"name":"id","type":"long"}]}'
 ```
 
----
+## Authentication
 
-## Key / partition / headers
+`auth` uses the shared `KafkaAuth` enum (the project-wide `{ type, config }` discriminated shape; SASL/SSL fields sit alongside `type`):
 
-`key_path`, `partition_path`, and `headers_path` are JSONPath expressions evaluated against each record.
-
-```yaml
-key_path: "$.order_id"          # string → Kafka message key
-partition_path: "$.shard"       # integer → target partition
-headers_path: "$.meta"          # flat object → Kafka headers
-```
-
-When any path is absent, the corresponding attribute is not set and librdkafka applies its default (round-robin for partition, no key, no headers).
-
----
-
-## OnKeyError policy
-
-Controls what happens when `key_path` or `partition_path` extraction fails (path absent, type mismatch, or invalid partition).
-
-| Value | Behaviour |
-|-------|-----------|
-| `fail` (default) | Abort the batch with `FaucetError::Sink`. |
-| `skip` | Drop the record, log `WARN`, and continue. |
-| `round_robin` | Send the record with no key; librdkafka assigns the partition. Record is not dropped. |
-
-`on_key_error` does not apply to `from_path` topic failures — those are always fatal.
-
----
-
-## Idempotence + acks
-
-`idempotent: true` (the default) sets `enable.idempotence = true` in librdkafka. This prevents duplicate messages from retried produce calls within a single producer session. Combined with `acks: all`, this is the no-duplicate, no-loss guarantee for individual produce calls.
-
-The config is rejected at construction time if `idempotent: true` and `acks != all`:
-
-```
-kafka sink: idempotent=true requires acks=all
-```
-
-To trade durability for throughput:
+| `type` | Required fields | Use when |
+|--------|-----------------|----------|
+| `none` | — | Plaintext brokers (default; `security.protocol = PLAINTEXT`). |
+| `sasl_plain` | `username`, `password` | SASL/PLAIN over plaintext (e.g. dev clusters). |
+| `sasl_scram` | `mechanism` (`sha256`/`sha512`), `username`, `password` | SASL/SCRAM over plaintext. |
+| `ssl` | `ca_path`, `cert_path`, `key_path` (+ optional `key_password`) | Mutual TLS. Paths are validated to exist at config time. |
+| `sasl_ssl` | `sasl` (a `sasl_plain`/`sasl_scram` block), `ssl` (an `ssl` block) | SASL over TLS — Confluent Cloud, Amazon MSK. |
 
 ```yaml
-idempotent: false
-acks: leader   # or "none" for fire-and-forget
-```
-
----
-
-## Compression
-
-| Value | Description |
-|-------|-------------|
-| `none` (default) | No compression. |
-| `gzip` | Good ratio; higher CPU cost. |
-| `snappy` | Balanced speed and ratio. |
-| `lz4` | Fast encode/decode; recommended for throughput-sensitive pipelines. |
-| `zstd` | Best ratio at moderate CPU cost. Requires Kafka broker ≥ 2.1. |
-
----
-
-## Throughput knobs
-
-| Field | Default | Effect |
-|-------|---------|--------|
-| `linger` | `0` s | Time the producer waits to accumulate records. Increase for larger batches. Use `linger.ms` in `extra_client_config` for sub-second precision. |
-| `batch_size` | `1000` | In-flight `FuturesUnordered` send-window cap and seed for librdkafka's `queue.buffering.max.messages`. See [Streaming and batching](#streaming-and-batching). |
-| `max_in_flight` | `100` | Concurrent produce requests. Set to 1 with `idempotent: true` for strict ordering. |
-| `message_timeout` | `30` s | Delivery timeout. Increase for high-latency brokers. |
-| `queue_full_backoff` | `0` s | Backoff on `QueueFull`. Set to e.g. `1` to avoid tight-looping. |
-| `queue_full_max_retries` | `3` | Maximum `QueueFull` retries before the error surfaces. |
-
-Tune the librdkafka byte-size batch knob — historically exposed as `batch_size` (bytes) — via `extra_client_config: {batch.size: "16384"}`. The default (16 KiB) is rarely worth changing unless you have very small or very large records.
-
----
-
-## Streaming and batching
-
-The sink is driven from the streaming pipeline via `Sink::write_batch`. Within a single `write_batch` call, records are produced to the broker through a `FuturesUnordered` of `send_result` futures so multiple sends can fly concurrently. The `batch_size` field bounds how many of those futures are in flight at any moment:
-
-- **Effective in-flight cap = `min(max_in_flight, batch_size)`** when `batch_size > 0`.
-- **Effective in-flight cap = `max_in_flight`** when `batch_size = 0` (the "no batching" sentinel — pre-streaming behaviour).
-
-When `batch_size > 0`, `KafkaSink::new` also sets librdkafka's `queue.buffering.max.messages` to `batch_size` so the producer's broker-side message buffer can hold one full send window. This avoids the asymmetry where the FuturesUnordered cap permits N concurrent sends but the producer queue rejects them with `QueueFull` immediately. `extra_client_config` takes precedence — pass a smaller `queue.buffering.max.messages` there if you want to force backpressure (e.g. to exercise the `QueueFull` retry path in tests).
-
-`QueueFull` retry semantics are unaffected by `batch_size`. Whenever librdkafka rejects an enqueue with `QueueFull`, the existing loop (`queue_full_backoff` / `queue_full_max_retries`) still applies; the in-flight cap simply makes those rejections less likely in the common case.
-
-**When to tune away from the default:**
-
-- **Throughput-bound, large records.** If `DEFAULT_BATCH_SIZE = 1000` is leaving the producer thread starved, raise `batch_size` (and consequently `max_in_flight`) to push more concurrent requests in flight. The librdkafka `queue.buffering.max.messages` rises with it automatically.
-- **Strict ordering.** Combine `batch_size = 1` with `max_in_flight = 1` and `idempotent: true` so at most one send is on the wire at a time. Lower throughput, but per-partition order is preserved.
-- **One-shot drain.** Use `batch_size = 0` for a small lookup-table source that emits a single page per run, so the entire write_batch fires in parallel up to `max_in_flight` without the extra cap.
-
----
-
-## SASL/SSL setup
-
-Authentication is configured via the `auth` field using `KafkaAuth` from `faucet-common-kafka`. The full auth reference is in the [`faucet-common-kafka` README](../../common/kafka/README.md#auth-modes).
-
-```yaml
-# SASL/PLAIN (Confluent Cloud, Amazon MSK)
+# SASL/PLAIN
 auth:
   type: sasl_plain
-  username: "${env:KAFKA_USERNAME}"
-  password: "${env:KAFKA_PASSWORD}"
+  username: ${env:KAFKA_USERNAME}
+  password: ${env:KAFKA_PASSWORD}
 ```
 
 ```yaml
@@ -234,8 +187,8 @@ auth:
   sasl:
     type: sasl_scram
     mechanism: sha512
-    username: "${env:KAFKA_USERNAME}"
-    password: "${env:KAFKA_PASSWORD}"
+    username: ${env:KAFKA_USERNAME}
+    password: ${env:KAFKA_PASSWORD}
   ssl:
     type: ssl
     ca_path: /etc/kafka/certs/ca.pem
@@ -243,34 +196,192 @@ auth:
     key_path: /etc/kafka/certs/client.key
 ```
 
-Use `${env:VAR}` interpolation so credentials never land in the YAML file.
+Use `${env:VAR}` / `${secret:…}` interpolation so credentials never land in the YAML file. The full auth reference lives in the [`faucet-common-kafka` README](https://crates.io/crates/faucet-common-kafka).
 
----
+## Key error policy
 
-## CLI integration
+`on_key_error` controls what happens when `key_path` or `partition_path` extraction fails (path absent, type mismatch, or invalid partition):
+
+| Value | Behaviour |
+|-------|-----------|
+| `fail` *(default)* | Abort the batch with `FaucetError::Sink`. |
+| `skip` | Drop the record, log a `WARN`, continue. |
+| `round_robin` | Send the record with no key; librdkafka assigns the partition. Record is kept. |
+
+It does **not** apply to `from_path` topic failures — those are always fatal.
+
+## Compression
+
+| Value | Notes |
+|-------|-------|
+| `none` *(default)* | No compression. |
+| `gzip` | Good ratio, higher CPU. |
+| `snappy` | Balanced speed and ratio. |
+| `lz4` | Fast encode/decode — recommended for throughput-sensitive pipelines. |
+| `zstd` | Best ratio at moderate CPU. Requires broker ≥ 2.1. |
+
+## Examples
+
+### Fan out to many topics by a record field
+
+```yaml
+sink:
+  type: kafka
+  config:
+    brokers: broker1:9092,broker2:9092
+    topic:
+      type: from_path
+      path: $.event_type      # each record routed to its own topic
+    value_format: { type: json }
+    key_path: $.entity_id
+    compression: lz4
+```
+
+### Strict per-partition ordering
+
+```yaml
+sink:
+  type: kafka
+  config:
+    brokers: localhost:9092
+    topic: { type: fixed, name: ledger }
+    key_path: $.account_id
+    idempotent: true
+    acks: all
+    max_in_flight: 1          # at most one send on the wire
+    batch_size: 1
+```
+
+### Throughput over durability (fire-and-forget)
+
+```yaml
+sink:
+  type: kafka
+  config:
+    brokers: localhost:9092
+    topic: { type: fixed, name: telemetry }
+    value_format: { type: json }
+    idempotent: false
+    acks: leader              # or "none" for no broker ack
+    compression: zstd
+    batch_size: 5000          # wider send window
+    max_in_flight: 200
+    linger: 0                 # 0s field → 5ms default; raise linger.ms via extra_client_config
+```
+
+### Key, partition, and headers from the record
+
+```yaml
+sink:
+  type: kafka
+  config:
+    brokers: localhost:9092
+    topic: { type: fixed, name: orders }
+    key_path: $.order_id        # string → message key
+    partition_path: $.shard     # integer → target partition
+    headers_path: $.meta        # flat object → Kafka headers
+    on_key_error: skip
+```
+
+## Streaming & batching
+
+The sink is driven from the streaming pipeline via `Sink::write_batch`, once per `StreamPage` the source emits. Within a single call, records are produced through a `FuturesUnordered` of `send_result` futures so multiple sends fly concurrently. `batch_size` bounds how many futures are in flight at any moment:
+
+- **Effective in-flight cap = `min(max_in_flight, batch_size)`** when `batch_size > 0`.
+- **Effective in-flight cap = `max_in_flight`** when `batch_size = 0` (the "no batching" sentinel — every record is enqueued immediately).
+
+When `batch_size > 0`, `KafkaSink::new` also sets librdkafka's `queue.buffering.max.messages` to `batch_size` so the broker-side buffer can hold one full send window (avoiding spurious `QueueFull` rejections). `extra_client_config` takes precedence — set a smaller `queue.buffering.max.messages` there to force backpressure. `QueueFull` retry semantics (`queue_full_backoff` / `queue_full_max_retries`) are independent of `batch_size`.
+
+Reach for `batch_size: 0` when a source emits its whole result set as a single page (small lookup tables, one-shot drains) and you want the entire write to fire in parallel without the extra cap.
+
+> **Not exactly-once.** This sink provides idempotent-producer de-duplication *within a producer session* (`idempotent: true`), not faucet-stream's cross-run exactly-once delivery — it does not implement `write_batch_idempotent` / `last_committed_token`. It is also **append-only**: there is no `write_mode` / upsert / delete (Kafka has no row identity to update). For end-to-end exactly-once, target a transactional sink (BigQuery, the SQL sinks, or Iceberg).
+
+## Config loading & schema
+
+Load from YAML/JSON or environment. Inspect the full JSON Schema with:
 
 ```bash
-faucet run cli/examples/rest_to_kafka.yaml
-faucet validate cli/examples/rest_to_kafka.yaml
-faucet preview cli/examples/rest_to_kafka.yaml --limit 5
 faucet schema sink kafka
 ```
 
-A complete working example is in [`cli/examples/rest_to_kafka.yaml`](../../cli/examples/rest_to_kafka.yaml).
+Validate and dry-run a config before sending anything:
 
----
+```bash
+faucet validate pipeline.yaml
+faucet preview pipeline.yaml --limit 5
+```
 
-## See also
+## Library usage
 
-- [`faucet-source-kafka`](../../crates/source/kafka/README.md) — consume records from Kafka topics.
-- [`faucet-common-kafka`](../../common/kafka/README.md) — shared auth modes, value formats, schema registry client, and policy enums.
+```rust
+use faucet_core::Sink;
+use faucet_sink_kafka::{KafkaSink, KafkaSinkConfig, KafkaSinkTopic};
+use faucet_common_kafka::{KafkaAuth, KafkaValueFormat};
 
----
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let cfg = KafkaSinkConfig {
+    brokers: "localhost:9092".into(),
+    topic: KafkaSinkTopic::Fixed { name: "orders".into() },
+    auth: KafkaAuth::None,
+    value_format: KafkaValueFormat::Json,
+    key_path: Some("$.order_id".into()),
+    ..serde_json::from_value(serde_json::json!({
+        "brokers": "localhost:9092",
+        "topic": { "type": "fixed", "name": "orders" }
+    }))?
+};
+cfg.validate()?;
+
+let sink = KafkaSink::new(cfg).await?;
+let n = sink.write_batch(&[serde_json::json!({ "order_id": "A1", "total": 42 })]).await?;
+sink.flush().await?;
+println!("produced {n} records");
+# Ok(())
+# }
+```
+
+In a full pipeline, wire the sink into `faucet_core::Pipeline` (or `run_stream`) with any `Source`.
+
+## How it works
+
+1. `new()` resolves `KafkaAuth`, applies compression / acks / idempotence / timeout / `extra_client_config`, and builds the `FutureProducer` **once**.
+2. Each `write_batch` resolves the topic, key, partition, and headers per record (JSONPath), encoding the value via `value_format`.
+3. Records are enqueued into a `FuturesUnordered` up to the effective in-flight cap; `QueueFull` rejections back off and retry.
+4. `flush()` blocks until all in-flight deliveries are acknowledged (or `message_timeout` elapses) before the pipeline advances the bookmark.
 
 ## Lineage dataset URI
 
-`kafka://<brokers>?topic=<topic>` or `kafka://<brokers>?topic=(from_path:<path>)` for dynamic routing — e.g. `kafka://kafka.example.com:9092?topic=orders`.
+`kafka://<brokers>?topic=<topic>` for a fixed topic, or `kafka://<brokers>?topic=(from_path:<path>)` for dynamic routing — e.g. `kafka://kafka.example.com:9092?topic=orders`.
+
+## Feature flags
+
+| Feature | Default | Enables |
+|---------|---------|---------|
+| `schema-registry` | off | Confluent Avro / Protobuf / JSON Schema value/key formats + `SchemaRegistryConfig` (via `faucet-common-kafka/schema-registry`). In the CLI / umbrella this is the `kafka-schema-registry` feature. |
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause & fix |
+|---------|--------------------|
+| `kafka sink: idempotent=true requires acks=all` | `idempotent` defaults to `true`, which forces `acks: all`. Either keep `acks: all` or set `idempotent: false` to use `acks: leader` / `none`. |
+| `kafka sink: max_in_flight must be at least 1` | `max_in_flight` is `0`. Set it to ≥ 1. |
+| `kafka sink: value_schema is not set` | A Confluent `value_format` was selected without `value_schema`. Supply the schema text (and likewise `key_schema` for a Confluent `key_format`). |
+| Confluent format compiles but won't build | The `schema-registry` feature isn't enabled. Install with `--features sink-kafka,kafka-schema-registry`. |
+| `confluent_protobuf` returns a `Config` error | Protobuf encode is not implemented in v1 (issue #44). Use `confluent_avro` or `confluent_json_schema`. |
+| `QueueFull` errors surface despite retries | The producer queue is saturating faster than the broker drains. Raise `queue_full_max_retries` / `queue_full_backoff`, lower `batch_size`/`max_in_flight`, or enable `compression`. |
+| `from_path` routing aborts mid-batch | A record's topic path was missing or non-string. `from_path` is always fatal — ensure every record carries the field, or use a `fixed` topic. |
+| Records dropped unexpectedly | `on_key_error: skip` silently drops records whose key/partition extraction fails. Use `fail` to surface the error or `round_robin` to keep them keyless. |
+| Auth handshake fails / `SSL` errors | Verify `brokers` matches the listener's advertised name and that `ca_path`/`cert_path`/`key_path` exist and match the cluster. For managed clusters use `sasl_ssl`. |
+| Messages produced out of order | Concurrent sends reorder under retries. For strict order set `max_in_flight: 1`, `batch_size: 1`, `idempotent: true`. |
+
+## See also
+
+- [`faucet-source-kafka`](https://crates.io/crates/faucet-source-kafka) — consume records from Kafka topics.
+- [`faucet-common-kafka`](https://crates.io/crates/faucet-common-kafka) — shared auth modes, value formats, schema-registry client, and policy enums.
+- [Connectors reference](https://pawansikawat.github.io/faucet-stream/reference/connectors.html) — capability matrix.
+- [Configuration reference](https://pawansikawat.github.io/faucet-stream/reference/config.html) — the full pipeline-config grammar.
+- A complete working example: [`cli/examples/rest_to_kafka.yaml`](https://github.com/PawanSikawat/faucet-stream/blob/main/cli/examples/rest_to_kafka.yaml).
 
 ## License
 
-Dual-licensed under MIT and Apache-2.0, matching the workspace `license` field.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/sink/mongodb/README.md
+++ b/crates/sink/mongodb/README.md
@@ -5,130 +5,123 @@
 [![MSRV](https://img.shields.io/crates/msrv/faucet-sink-mongodb.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
 [![License](https://img.shields.io/crates/l/faucet-sink-mongodb.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-MongoDB sink connector for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
+**MongoDB** sink for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem. Writes JSON records into a MongoDB collection — appending with batched `insert_many`, or keeping a collection in sync with a changing source via `upsert` / `delete`.
 
-Inserts JSON records into a MongoDB collection using `insert_many` for efficient batch writes. Each JSON record is converted to a BSON document before insertion. The MongoDB client connection is established once and reused across all writes.
+Reach for it when you want to land any faucet-stream source — a REST API, a database, a CDC stream, a file — into MongoDB with one declarative config and no glue code. Each record is converted to a BSON document; the client connection is established once and reused across every write.
+
+## Feature highlights
+
+- **Batched inserts** — append mode issues `insert_many` per `batch_size`-sized chunk, the documented sweet spot for balancing round-trip overhead against MongoDB's ~48 MB per-request budget.
+- **Unordered by default** — `ordered: false` so a single poison document (duplicate `_id`, validation error) can't drop the rest of the batch.
+- **Write modes** — `append` (default), `upsert` (per-document `replace_one(upsert)`), and `delete` (`delete_one`); the `key` fields become the match filter (MongoDB is schemaless — no key columns).
+- **CDC mirroring** — a `delete_marker` mixes upserts and deletes in one stream, so a CDC source carrying an op flag (`__op: "u" | "d"`) keeps a collection in lock-step with its origin.
+- **Dead-letter queue aware** — overrides `write_batch_partial` so missing/null-key rows can be routed to a DLQ per-row while the good documents still commit.
+- **Nested documents preserved** — arbitrary nested objects, arrays, and all JSON scalar types convert to their BSON equivalents losslessly.
+- **Client built once** — the connection pool is created and validated in `new()` and reused for every write; the driver handles pooling and reconnection internally.
+- **Credential-safe logging** — the `Debug` impl masks `connection_uri` with `***`, and the lineage URI strips embedded credentials.
 
 ## Installation
 
 ```bash
+# As a library:
 cargo add faucet-sink-mongodb
-cargo add tokio --features full
+
+# In the CLI (opt-in connector feature):
+cargo install faucet-cli --features sink-mongodb
 ```
 
-Or via the umbrella crate:
+Or via the umbrella crate: `cargo add faucet-stream --features sink-mongodb`.
+
+## Quick start
+
+```yaml
+# pipeline.yaml — faucet run pipeline.yaml
+version: 1
+pipeline:
+  source:
+    type: rest
+    config:
+      base_url: https://api.example.com
+      endpoint: /v1/events
+  sink:
+    type: mongodb
+    config:
+      connection_uri: mongodb://localhost:27017
+      database: analytics
+      collection: events
+      batch_size: 1000
+```
 
 ```bash
-cargo add faucet-stream --features sink-mongodb
+faucet run pipeline.yaml
 ```
 
-## Quick Start
+## Configuration reference
 
-```rust
-use faucet_sink_mongodb::{MongoSink, MongoSinkConfig};
-use faucet_core::Sink;
-use serde_json::json;
-
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let config = MongoSinkConfig::new(
-        "mongodb://localhost:27017",
-        "analytics",
-        "events",
-    )
-    .with_batch_size(1000);
-
-    let sink = MongoSink::new(config).await?;
-
-    let records = vec![
-        json!({"user_id": "u123", "event": "signup", "source": "web"}),
-        json!({"user_id": "u456", "event": "login", "source": "mobile"}),
-    ];
-
-    let written = sink.write_batch(&records).await?;
-    println!("Inserted {written} documents");
-
-    Ok(())
-}
-```
-
-## Configuration
+### Core
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `connection_uri` | `String` | *(required)* | MongoDB connection URI (e.g. `mongodb://user:pass@host:27017`) |
-| `database` | `String` | *(required)* | Database name |
-| `collection` | `String` | *(required)* | Collection name |
-| `batch_size` | `usize` | `1000` | Maximum number of documents per `insert_many` call. See [Streaming and batching](#streaming-and-batching) below |
-| `ordered` | `bool` | `false` | Whether `insert_many` is ordered. Default `false` (unordered) so one bad document — duplicate `_id`, validation error — doesn't drop the rest of the batch. Set `true` only if you require strict insertion order and want the batch to abort at the first failure. |
-| `write_mode` | `string` | `append` | `append`, `upsert`, or `delete`. See [Write modes (upsert / delete)](#write-modes-upsert--delete) below |
-| `key` | `[string]` | `[]` | Match-filter fields for `upsert` / `delete`. **Required and non-empty** for those modes; ignored for `append`. Typically `["_id"]` |
-| `delete_marker` | `object` | *(none)* | Upsert only. `{ field, values }` — rows whose `field` matches one of `values` are routed to deletes instead of upserts. The marker field is stripped from upsert rows before writing |
+| `connection_uri` | string | — *(required)* | MongoDB connection URI (e.g. `mongodb://user:pass@host:27017`, or a replica-set URI). Masked as `***` in `Debug` output. |
+| `database` | string | — *(required)* | Target database name. |
+| `collection` | string | — *(required)* | Target collection name. |
 
-The `Debug` implementation masks the `connection_uri` with `***` to prevent credential leakage in logs.
+### Batching & reliability
 
-### Streaming and batching
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `batch_size` | int | `1000` | Maximum documents per `insert_many` call (append mode). **`0` = no batching**: the entire records slice is sent in one call. Values above `MAX_BATCH_SIZE` (1,000,000) are rejected. See [Streaming & batching](#streaming--batching). |
+| `ordered` | bool | `false` | Whether `insert_many` is ordered. Default `false` (unordered) so one bad document doesn't drop the rest of the batch. Set `true` only when you require strict insertion order and want the batch to abort at the first failure. |
 
-`MongoSink::write_batch` re-chunks the incoming records slice into
-`batch_size` slices and issues one `insert_many` call per chunk. The
-default of `1000` matches MongoDB's documented sweet spot for
-`insert_many` — roughly 1000 documents per call balances round-trip
-overhead against the per-request BSON size budget (the server caps a
-single request at 48 MB). Tune up for narrow documents where round-trip
-latency dominates, and down for very wide documents that bump up against
-the BSON size cap.
+### Write mode
 
-`batch_size = 0` is the **"no batching" sentinel** — `write_batch`
-forwards the entire records slice in a single `insert_many` call, no
-matter how large, so upstream `StreamPage` framing flows through
-untouched. Use it when the upstream source already emits pages sized for
-MongoDB's per-request limits. Values larger than `MAX_BATCH_SIZE`
-(1,000,000) are rejected by `faucet_core::validate_batch_size`.
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `write_mode` | string | `append` | `append`, `upsert`, or `delete`. See [Write modes (upsert / delete)](#write-modes-upsert--delete). |
+| `key` | `[string]` | `[]` | Match-filter fields for `upsert` / `delete`. **Required and non-empty** for those modes; ignored for `append`. Typically `["_id"]`. |
+| `delete_marker` | object | *(none)* | Upsert only. `{ field, values }` — rows whose `field` matches one of `values` are routed to deletes instead of upserts. The marker field is stripped from upsert rows before writing. |
 
-Note that this `batch_size` is a **write-side chunking knob** specific
-to the sink. It is unrelated to the MongoDB driver's internal
-`cursor_batch_size` (the wire-level read-side cursor tuning knob used by
-`faucet-source-mongodb`) — the two concerns don't share a value because
-`insert_many` and a query cursor are different operations.
+## Examples
 
-### Write modes (upsert / delete)
+### Append events from a REST API
 
-By default the sink runs in `append` mode and inserts every record via
-`insert_many`. Set `write_mode: upsert` or `write_mode: delete` to keep a
-collection in sync with a changing source instead of only appending.
+```yaml
+sink:
+  type: mongodb
+  config:
+    connection_uri: mongodb://localhost:27017
+    database: analytics
+    collection: events
+    batch_size: 1000
+```
 
-MongoDB is schemaless, so unlike the SQL sinks there are no key *columns* —
-the `key` fields become the **match filter** for each document. `key` is
-typically `["_id"]`, but any combination of top-level fields works
-(composite keys are matched on all of them). `key` must be non-empty for
-`upsert` / `delete`; an empty `key` is rejected at config-load time.
+### High-throughput load with large batches
 
-- **`upsert`** — each row is committed with a per-document
-  `replace_one(filter, replacement).upsert(true)`. The filter is built from
-  the row's `key` fields and the whole row is the replacement document, so an
-  existing document is **replaced in place** (not field-merged) and a missing
-  one is inserted.
-- **`delete`** — each row is removed with `delete_one(filter)`, where the
-  filter is built from the row's `key` fields.
-- **`delete_marker`** (upsert only) — mix upserts and deletes in one stream:
-  rows whose `delete_marker.field` matches one of `delete_marker.values` are
-  routed to `delete_one`; all others are upserted. The marker field is
-  stripped from the upsert replacement document so it never lands in the
-  collection — handy for CDC streams that carry an operation flag like
-  `__op: "u" | "d"`.
+```yaml
+sink:
+  type: mongodb
+  config:
+    connection_uri: mongodb://writer:s3cret@mongo-primary:27017
+    database: warehouse
+    collection: raw_events
+    batch_size: 5000        # narrow docs where round-trip latency dominates
+```
 
-Within a single batch, repeated keys are deduped **last-write-wins** before
-any write is issued, so a page that touches the same `_id` twice results in a
-single `replace_one` / `delete_one` carrying the final value.
+### Replica-set target, no client-side re-chunking
 
-A document missing or null in a key field fails. When a `dlq:` block is
-configured the good documents are still written and only the missing/null-key
-documents are routed to the DLQ per-row; without a DLQ the whole batch fails.
+```yaml
+sink:
+  type: mongodb
+  config:
+    connection_uri: mongodb://writer:s3cret@mongo1:27017,mongo2:27017,mongo3:27017/analytics?replicaSet=rs0
+    database: analytics
+    collection: events
+    batch_size: 0           # forward each upstream StreamPage as one insert_many
+```
 
-Each `replace_one` / `delete_one` is a per-document primitive (not the
-namespaced `Client::bulk_write`) for compatibility with all supported MongoDB
-server versions; the sink recovers throughput by issuing the deduped ops
-concurrently.
+### CDC mirror — upsert with a delete marker
+
+Pair a CDC source (e.g. `faucet-source-mongodb-cdc`) with a `delete_marker` to keep a collection in lock-step with its origin:
 
 ```yaml
 sink:
@@ -139,61 +132,50 @@ sink:
     collection: users
     write_mode: upsert
     key: ["_id"]
-    # Optional: route delete-flagged rows (e.g. from a CDC source) to deletes.
     delete_marker:
       field: __op
       values: ["d", "delete"]
 ```
 
-### Builder Methods
+## Streaming & batching
 
-```rust
-use faucet_sink_mongodb::MongoSinkConfig;
+`MongoSink::write_batch` re-chunks the incoming records slice into `batch_size` slices and issues one `insert_many` call per chunk. The default of `1000` matches MongoDB's documented sweet spot — roughly 1000 documents per call balances round-trip overhead against the per-request BSON size budget (the server caps a single request at ~48 MB). Tune **up** for narrow documents where round-trip latency dominates, and **down** for very wide documents that bump against the size cap.
 
-let config = MongoSinkConfig::new(
-    "mongodb://writer:s3cret@mongo.example.com:27017",
-    "my_database",
-    "my_collection",
-)
-.with_batch_size(2000);
-```
+`batch_size = 0` is the **"no batching" sentinel** — `write_batch` forwards the entire records slice in a single `insert_many` call, so upstream `StreamPage` framing flows through untouched. Use it when the source already emits pages sized for MongoDB's per-request limits. Values above `MAX_BATCH_SIZE` (1,000,000) are rejected by `faucet_core::validate_batch_size`.
 
-## Config Loading
+This `batch_size` is a **write-side chunking knob** specific to the sink. It is unrelated to the driver's internal `cursor_batch_size` (the read-side cursor tuning knob used by `faucet-source-mongodb`) — `insert_many` and a query cursor are different operations.
+
+## Write modes (upsert / delete)
+
+By default the sink runs in `append` mode and inserts every record via `insert_many`. Set `write_mode: upsert` or `write_mode: delete` to keep a collection in sync with a changing source instead of only appending.
+
+MongoDB is schemaless, so unlike the SQL sinks there are no key *columns* — the `key` fields become the **match filter** for each document. `key` is typically `["_id"]`, but any combination of top-level fields works (composite keys are matched on all of them). `key` must be non-empty for `upsert` / `delete`; an empty `key` is rejected at config-load time.
+
+- **`upsert`** — each row is committed with a per-document `replace_one(filter, replacement).upsert(true)`. The filter is built from the row's `key` fields and the whole row is the replacement document, so an existing document is **replaced in place** (not field-merged) and a missing one is inserted.
+- **`delete`** — each row is removed with `delete_one(filter)`, where the filter is built from the row's `key` fields.
+- **`delete_marker`** (upsert only) — mix upserts and deletes in one stream: rows whose `delete_marker.field` matches one of `delete_marker.values` are routed to `delete_one`; all others are upserted. The marker field is stripped from the upsert replacement so it never lands in the collection — ideal for CDC streams that carry an operation flag like `__op: "u" | "d"`.
+
+Within a single batch, repeated keys are deduped **last-write-wins** before any write is issued, so a page that touches the same `_id` twice results in a single `replace_one` / `delete_one` carrying the final value.
+
+A document missing or null in a key field fails. When a `dlq:` block is configured the good documents are still written and only the missing/null-key documents are routed to the DLQ per-row; without a DLQ the whole batch fails.
+
+Each `replace_one` / `delete_one` is a per-document primitive (not the namespaced `Client::bulk_write`) for compatibility with all supported MongoDB server versions; the sink recovers throughput by issuing the deduped ops concurrently.
+
+## Dead-letter queue
+
+The sink overrides `write_batch_partial`, so a `dlq:` block in the pipeline config catches per-row failures (missing/null-key rows in `upsert` / `delete` mode) and routes them to the dead-letter sink while the rest of the page commits. Without a DLQ, a row-level failure aborts the batch. See the [DLQ cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/dlq.html).
+
+## Config loading & schema
+
+Load config from YAML/JSON, environment variables, or a `.env` file:
 
 ```rust
 use faucet_core::config::{load_json, load_env_file};
 use faucet_sink_mongodb::MongoSinkConfig;
 
-// From a JSON file
-let config: MongoSinkConfig = load_json("config.json")?;
-
-// From an .env file with a prefix
-let config: MongoSinkConfig = load_env_file(".env", "MONGO_SINK")?;
+let from_file: MongoSinkConfig = load_json("config.json")?;
+let from_env: MongoSinkConfig = load_env_file(".env", "MONGO_SINK")?;
 ```
-
-### Example JSON config
-
-```json
-{
-  "connection_uri": "mongodb://writer:s3cret@mongo.example.com:27017",
-  "database": "analytics",
-  "collection": "events",
-  "batch_size": 1000
-}
-```
-
-### Example JSON config (replica set)
-
-```json
-{
-  "connection_uri": "mongodb://writer:s3cret@mongo1:27017,mongo2:27017,mongo3:27017/analytics?replicaSet=rs0",
-  "database": "analytics",
-  "collection": "events",
-  "batch_size": 500
-}
-```
-
-### Example .env file
 
 ```env
 MONGO_SINK_CONNECTION_URI=mongodb://writer:s3cret@mongo.example.com:27017
@@ -202,92 +184,97 @@ MONGO_SINK_COLLECTION=events
 MONGO_SINK_BATCH_SIZE=1000
 ```
 
-## Config Schema Introspection
+Inspect the full JSON Schema with:
 
-```rust
-use faucet_core::Sink;
-
-let sink = MongoSink::new(config).await?;
-let schema = sink.config_schema();
-println!("{}", serde_json::to_string_pretty(&schema)?);
+```bash
+faucet schema sink mongodb
 ```
 
-## Pipeline Usage
+## Library usage
+
+```rust
+use faucet_core::{Pipeline, Sink};
+use faucet_sink_mongodb::{MongoSink, MongoSinkConfig};
+use serde_json::json;
+
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let config = MongoSinkConfig::new(
+    "mongodb://localhost:27017",
+    "analytics",
+    "events",
+)
+.with_batch_size(1000);
+
+let sink = MongoSink::new(config).await?;
+
+let records = vec![
+    json!({"user_id": "u123", "event": "signup", "source": "web"}),
+    json!({"user_id": "u456", "event": "login", "source": "mobile"}),
+];
+
+let written = sink.write_batch(&records).await?;
+println!("Inserted {written} documents");
+# Ok(())
+# }
+```
+
+Drive it from a `Pipeline` with any source:
 
 ```rust
 use faucet_core::Pipeline;
 use faucet_source_rest::{RestStream, RestStreamConfig};
 use faucet_sink_mongodb::{MongoSink, MongoSinkConfig};
 
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
 let source = RestStream::new(
-    RestStreamConfig::new("https://api.example.com", "/v1/events")
+    RestStreamConfig::new("https://api.example.com", "/v1/events"),
 );
-
 let sink = MongoSink::new(
-    MongoSinkConfig::new("mongodb://localhost:27017", "analytics", "events")
+    MongoSinkConfig::new("mongodb://localhost:27017", "analytics", "events"),
 ).await?;
 
 let result = Pipeline::new(source, sink).run().await?;
 println!("Transferred {} records", result.records_written);
+# Ok(())
+# }
 ```
 
-## Examples
+## How it works
 
-### Basic insert with default batch size
-
-```rust
-let config = MongoSinkConfig::new(
-    "mongodb://localhost:27017",
-    "mydb",
-    "users",
-);
-
-let sink = MongoSink::new(config).await?;
-sink.write_batch(&records).await?;
-```
-
-### High-throughput loading with large batches
-
-```rust
-let config = MongoSinkConfig::new(
-    "mongodb://writer:pass@mongo-primary:27017",
-    "warehouse",
-    "raw_events",
-)
-.with_batch_size(5000);
-
-let sink = MongoSink::new(config).await?;
-sink.write_batch(&large_dataset).await?;
-```
-
-### Inserting nested documents
-
-MongoDB natively supports nested documents, so complex JSON structures are preserved:
-
-```rust
-let records = vec![
-    json!({
-        "user": {"name": "Alice", "email": "alice@example.com"},
-        "tags": ["premium", "active"],
-        "metadata": {"source": "api", "version": 2}
-    }),
-];
-
-sink.write_batch(&records).await?;
-```
-
-## How It Works
-
-- The MongoDB client is created in `MongoSink::new()` using `Client::with_uri_str()`. The connection is established and validated at this point.
-- `write_batch()` splits records into chunks of `batch_size`. Each chunk is converted from `serde_json::Value` to `bson::Document` and inserted using `collection.insert_many()`. When `batch_size = 0`, the entire slice is sent in a single `insert_many` call — see [Streaming and batching](#streaming-and-batching).
-- Every record must be a JSON object. Non-object values (arrays, strings, numbers, null) produce an error during BSON conversion.
-- Nested JSON objects, arrays, and all JSON types are correctly converted to their BSON equivalents.
-- The MongoDB driver handles connection pooling and automatic reconnection internally.
+1. `MongoSink::new()` builds the client via `Client::with_uri_str()` — the connection is established and validated **once** and the pool is reused for every write.
+2. **Append:** `write_batch` splits records into `batch_size` chunks; each chunk is converted from `serde_json::Value` to `bson::Document` and inserted with `collection.insert_many()` (unordered unless `ordered: true`). With `batch_size = 0`, the whole slice goes in one call.
+3. **Upsert / delete:** `faucet_core::plan_writes` dedups the page last-write-wins, strips the delete marker, and partitions into upserts / deletes / failed rows; the sink issues per-document `replace_one(upsert)` / `delete_one` ops **concurrently**.
+4. Every record must be a JSON object — non-object values produce an error during BSON conversion.
+5. The driver handles connection pooling and automatic reconnection internally.
 
 ## Lineage dataset URI
 
-`mongodb://<host>:<port>/<database>/<collection>` (credentials stripped) — e.g. `mongodb://host:27017/mydb/events`.
+`mongodb://<host>:<port>/<database>/<collection>` (credentials stripped) — e.g. `mongodb://host:27017/analytics/events`.
+
+## Feature flags
+
+This crate has no optional features of its own; enable it in the CLI / umbrella via the `sink-mongodb` feature.
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause & fix |
+|---------|--------------------|
+| Connection fails in `new()` / `check` ping fails | `connection_uri`, credentials, or network are wrong. Run `faucet doctor` — the sink's preflight runs a `ping` admin command. Verify the URI, that the server is reachable, and (for a replica set) that the `replicaSet=` name matches. |
+| Duplicate `_id` errors drop part of an append batch | You set `ordered: true`. Leave the default `ordered: false` so only the genuinely-bad documents fail and the rest of the batch still commits. |
+| `mongodb upsert: row N: ...` error | A row is missing or null in a `key` field. Ensure every record carries the `key` field(s), or configure a `dlq:` block to quarantine the bad rows per-row while the good ones commit. |
+| Upsert replaces the whole document instead of merging fields | Expected — `upsert` uses `replace_one`, which replaces the matched document in place. Shape the record upstream (e.g. with transforms) to carry every field you want retained. |
+| Delete-flagged CDC rows are inserted instead of removed | The `delete_marker.field` / `values` don't match the source's op flag. Confirm the field name and values (commonly `__op` with `["d", "delete"]`); pair with the `cdc_unwrap` transform to normalize the envelope to `__op`. |
+| "expected a JSON object" / BSON conversion error | A record is an array, string, number, or null. Every record must be a JSON object; reshape upstream with a transform. |
+| Documents rejected at ~48 MB | A batch exceeds MongoDB's per-request limit. Lower `batch_size` for wide documents, or split very large nested documents upstream. |
+
+## See also
+
+- [Sinks reference](https://pawansikawat.github.io/faucet-stream/reference/connectors.html) — capability matrix across all connectors.
+- [Write modes / upsert cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/upsert.html) — the shared upsert layer.
+- [Dead-letter queue cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/dlq.html) — routing failed rows.
+- [`faucet-source-mongodb`](https://crates.io/crates/faucet-source-mongodb) — the MongoDB source (`find()` with filter / projection / sort).
+- [`faucet-source-mongodb-cdc`](https://crates.io/crates/faucet-source-mongodb-cdc) — MongoDB Change Streams CDC source; the natural upstream for an upsert mirror.
 
 ## License
 
-Licensed under MIT or Apache-2.0.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/sink/mongodb/README.md
+++ b/crates/sink/mongodb/README.md
@@ -2,6 +2,8 @@
 
 [![Crates.io](https://img.shields.io/crates/v/faucet-sink-mongodb.svg)](https://crates.io/crates/faucet-sink-mongodb)
 [![Docs.rs](https://docs.rs/faucet-sink-mongodb/badge.svg)](https://docs.rs/faucet-sink-mongodb)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-sink-mongodb.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-sink-mongodb.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
 MongoDB sink connector for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
 

--- a/crates/sink/mssql/README.md
+++ b/crates/sink/mssql/README.md
@@ -1,64 +1,170 @@
 # faucet-sink-mssql
 
-Microsoft SQL Server sink for the
-[`faucet-stream`](https://crates.io/crates/faucet-stream) ecosystem. Inserts
-records via parameterized multi-row `INSERT`s with auto-mapped columns or a
-single JSON column. Built on [`tiberius`](https://crates.io/crates/tiberius) +
-[`bb8-tiberius`](https://crates.io/crates/bb8-tiberius).
+[![Crates.io](https://img.shields.io/crates/v/faucet-sink-mssql.svg)](https://crates.io/crates/faucet-sink-mssql)
+[![Docs.rs](https://docs.rs/faucet-sink-mssql/badge.svg)](https://docs.rs/faucet-sink-mssql)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-sink-mssql.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-sink-mssql.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-## Config
+Microsoft **SQL Server** sink for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem. Writes records via parameterized multi-row `INSERT`s — either auto-mapped to same-named table columns or serialized into a single JSON column — built on [`tiberius`](https://crates.io/crates/tiberius) + [`bb8-tiberius`](https://crates.io/crates/bb8-tiberius) with a pooled, statement-timeout-aware connection.
+
+Reach for it when you want to land records from any faucet-stream source into SQL Server or Azure SQL with one declarative config: multi-row INSERTs auto-split to stay under SQL Server's 2100-parameter ceiling, batches commit atomically inside a transaction, per-row failures are isolated for dead-letter routing, and `upsert`/`delete` write modes plus exactly-once delivery are available for keyed mirrors.
+
+## Feature highlights
+
+- **Two write shapes** — `auto_columns` maps top-level JSON keys to same-named table columns (the column set is the union across the batch); `json_column` serializes each record into a single `NVARCHAR(MAX)` / native `JSON` column. Schema-agnostic vs. typed-column landing.
+- **2100-parameter auto-split** — a multi-row `INSERT` binds `rows × columns` parameters. SQL Server caps a request at 2100 parameters (and `tiberius` spends 2 on its `sp_executesql` wrapper, leaving 2098) and at 1000 row expressions in a `VALUES` clause. The sink splits each batch into `min(2098 / columns, 1000)`-row statements automatically, all inside one transaction.
+- **Write modes (upsert / delete)** — beyond the default append, merge-by-key (`upsert`) or delete-by-key (`delete`) via a single T-SQL `MERGE`, including composite keys and a `delete_marker` for CDC-style streams. Requires `auto_columns`.
+- **Exactly-once delivery** — atomic record + commit-token write into a `_faucet_commit_token` watermark table, so a CDC mirror never double-applies a page on resume.
+- **Row-isolation DLQ** — on a batch failure the sink rolls back and replays the batch one row at a time so good rows still land and only the offender is dead-lettered. Transient errors (deadlock, lock-timeout, dropped connection) retry with backoff.
+- **Connection pooling** — a `bb8` pool (default 5 connections) created once and reused; each statement runs under a configurable server-side timeout.
+- **Flexible connection** — a `mssql://` URL parsed by faucet, or an ADO.NET-style connection string handed straight to `tiberius`, with TLS/encryption governed by a `tls` block in either case.
+
+## Installation
+
+```bash
+# As a library:
+cargo add faucet-sink-mssql
+
+# In the CLI (opt-in connector feature):
+cargo install faucet-cli --features sink-mssql
+```
+
+`sink-mssql` is opt-in — it is not in the CLI/umbrella default build.
+
+## Quick start
+
+```yaml
+# pipeline.yaml — faucet run pipeline.yaml
+version: 1
+pipeline:
+  source:
+    type: csv
+    config:
+      path: ./events.csv
+  sink:
+    type: mssql
+    config:
+      connection_url: "mssql://sa:Str0ng%40Pass@localhost:1433/sales"
+      table: "dbo.events"
+      column_mapping:
+        type: auto_columns
+```
+
+```bash
+faucet run pipeline.yaml
+```
+
+> The password in `connection_url` is percent-encoded (`@` → `%40`). Prefer secrets-manager / env indirection over inline credentials — see [Security](#security).
+
+## Configuration reference
+
+### Core
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `connection_url` | string | — | `mssql://user:pass@host:1433/database` URL (parsed by faucet; credentials percent-decoded). Mutually exclusive with `connection_string`; exactly one is required. |
+| `connection_string` | string | — | ADO.NET-style string handed straight to `tiberius`, e.g. `Server=tcp:host,1433;Database=db;User Id=sa;Password=...;`. Mutually exclusive with `connection_url`. |
+| `table` | string | — *(required)* | Target table, optionally schema-qualified (e.g. `dbo.events`). |
+| `column_mapping` | `MssqlColumnMapping` | `{ type: json_column, column: "data" }` | How records map onto columns — see [Column mapping](#column-mapping). |
+
+### Batching & reliability
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `batch_size` | int | `500` | Rows per multi-row `INSERT`. Auto-split further so `rows × columns` stays within the 2100-parameter limit. **`0` = send the whole page** in one logical write (still param-split internally). |
+| `max_connections` | int | `5` | Maximum pooled connections (`bb8`). |
+| `transaction_per_batch` | bool | `true` | Wrap each batch's `INSERT`s in `BEGIN TRAN` / `COMMIT TRAN`. Upsert/delete are always transaction-wrapped regardless. |
+| `isolate_row_failures` | bool | `true` | On a batch failure, roll back and replay row-by-row so good rows land and only the bad row is DLQ-routed. `false` fails the whole batch on the first bad row (fewer round-trips). |
+| `statement_timeout_secs` | int (seconds) | `300` | Per-statement server-side timeout. `0` disables. |
+| `create_table` | bool | `false` | **`json_column` mode only** — create the table if absent as `(id BIGINT IDENTITY PRIMARY KEY, <column> NVARCHAR(MAX))`. Rejected with `auto_columns` (schema inference for MSSQL types is unsafe). |
+
+### Write mode
+
+These fields come from the shared `WriteSpec` (flattened into the sink config), so they sit at the config top level:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `write_mode` | `append` \| `upsert` \| `delete` | `append` | Append (plain INSERT), merge-by-key, or delete-by-key. `upsert`/`delete` require `column_mapping: auto_columns`. |
+| `key` | array of string | `[]` | Key column(s) for upsert/delete. Required & non-empty for those modes; composite keys supported. Ignored for append. |
+| `delete_marker` | object | *(unset)* | **Upsert only.** `{ field: <name>, values: [<str>, …] }` — rows whose `field` matches a value become deletes; the marker field is stripped from upserted rows. |
+
+### TLS
+
+The `tls` block governs encryption for both connection forms:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `tls.type` | `prefer` \| `require` \| `trust_server_certificate` \| `disable` | `prefer` | Encryption mode — see [TLS modes](#tls-modes). |
+| `tls.ca_cert_path` | path | *(unset)* | CA certificate (PEM/DER) to trust for server validation. Ignored when `tls.type` is `disable`. |
+
+## Column mapping
+
+`column_mapping` is the project-wide `{ type, … }` tagged shape:
+
+| `type` | Fields | Behavior |
+|--------|--------|----------|
+| `auto_columns` | `on_unknown_field: warn \| drop \| error` | Top-level JSON keys map to same-named table columns. The column set is the **union** of keys across the batch (a field present only in a later record is still written; rows missing a column → SQL `NULL`). `IDENTITY` columns are skipped automatically. Keys with no matching column are handled by `on_unknown_field` (default `warn`). |
+| `json_column` | `column: <name>` | Each record is serialized to a JSON string inserted into a single `NVARCHAR(MAX)` (or native Azure SQL `JSON`) column. Schema-agnostic. Pair with `create_table: true` to create the table if absent. |
+
+```yaml
+# Typed columns
+column_mapping:
+  type: auto_columns
+  on_unknown_field: warn      # warn | drop | error
+```
+
+```yaml
+# Single JSON column
+column_mapping:
+  type: json_column
+  column: payload
+```
+
+> `IDENTITY` columns are server-generated — do **not** put identity values in your records unless you've run `SET IDENTITY_INSERT <table> ON` yourself. `auto_columns` + `create_table` is rejected at construction: create the table yourself first so its types are correct.
+
+## TLS modes
+
+| `tls.type` | Encryption | Use when |
+|-----------|------------|----------|
+| `prefer` | Encrypt if the server supports it (the safe modern default). | General use — the recommended default. |
+| `require` | Require encryption; fail if the server doesn't offer it. | Production where encryption is mandatory. |
+| `trust_server_certificate` | Encrypt but accept the server certificate without validating its chain. | **Dev/test only** — insecure against MITM. |
+| `disable` | No transport encryption. | Trusted local networks only. |
+
+## Examples
+
+### Append into typed columns
 
 ```yaml
 sink:
   type: mssql
   config:
     connection_url: "mssql://sa:Str0ng%40Pass@localhost:1433/sales"
-    # connection_string: "Server=tcp:localhost,1433;Database=sales;User Id=sa;Password=...;"
-
     table: "dbo.events"
-
     column_mapping:
-      type: auto_columns          # auto_columns | json_column
-      on_unknown_field: warn      # warn | drop | error  (auto_columns only)
-    # column_mapping: { type: json_column, column: "payload" }
-
-    batch_size: 500               # rows per multi-row INSERT (auto-split at the 2100-param limit)
-    max_connections: 5
-    transaction_per_batch: true   # wrap each batch in BEGIN/COMMIT TRAN
-    isolate_row_failures: true    # retry row-by-row on batch failure so only the bad row is DLQ'd
-    statement_timeout_secs: 300   # 0 disables
-    create_table: false           # json_column only: create (id IDENTITY, <column> NVARCHAR(MAX)) if absent
-
-    tls:
-      type: prefer                # prefer | require | trust_server_certificate | disable
-      ca_cert_path: null
+      type: auto_columns
+      on_unknown_field: drop
+    batch_size: 1000
+    max_connections: 8
 ```
 
-See [`faucet-common-mssql`](https://crates.io/crates/faucet-common-mssql) for the
-full connection / TLS reference.
+### JSON-column landing with auto-created table
 
-## Write modes
+```yaml
+sink:
+  type: mssql
+  config:
+    connection_string: "Server=tcp:db.example.com,1433;Database=lake;User Id=ingest;Password=${env:MSSQL_PASSWORD};"
+    table: "dbo.raw_payloads"
+    column_mapping:
+      type: json_column
+      column: payload
+    create_table: true
+    tls:
+      type: require
+```
 
-- **`auto_columns`** — top-level JSON keys map to same-named table columns. The
-  column set is the **union** of keys across the batch (a field present only in
-  a later record is still written; rows missing a column → SQL `NULL`).
-  `IDENTITY` columns are skipped automatically (the server generates them) — do
-  **not** put identity values in your records unless you've set
-  `SET IDENTITY_INSERT <table> ON` yourself. Keys with no matching column are
-  handled by `on_unknown_field` (`warn` / `drop` / `error`).
-- **`json_column`** — each record is serialized to JSON and inserted into a
-  single `NVARCHAR(MAX)` (or native Azure SQL `JSON`) column. Schema-agnostic.
-  `create_table: true` will create the table if absent.
-
-`auto_columns` + `create_table` is rejected — schema inference for MSSQL types is
-unsafe, so create the table yourself first.
-
-## Write modes (upsert / delete)
-
-In addition to the default append, the sink can **upsert** (insert-or-update by a
-key) or **delete** by key. Both require `column_mapping: auto_columns` — the key
-columns must be real table columns, not buried inside a JSON column (using
-`json_column` with `upsert`/`delete` is rejected at construction).
+### Upsert by key (keyed mirror)
 
 ```yaml
 sink:
@@ -69,82 +175,55 @@ sink:
     column_mapping:
       type: auto_columns
     write_mode: upsert            # append (default) | upsert | delete
-    key: [id]                     # one or more key columns (composite keys supported)
-    # delete_marker:              # upsert only: route marked rows to deletes
-    #   field: __op
-    #   values: [d, delete]
+    key: [id]                     # composite keys: [tenant_id, id]
+    delete_marker:                # upsert only: route flagged rows to deletes
+      field: __op
+      values: [d, delete]
 ```
 
-- **`upsert`** — each record is merged into the table via a single T-SQL
-  [`MERGE`](https://learn.microsoft.com/sql/t-sql/statements/merge-transact-sql):
-  matching rows (by `key`) have their non-key columns updated; non-matching rows
-  are inserted. When every column is a key column there is nothing to update, so
-  the `WHEN MATCHED` clause is omitted. Within a single batch, records with the
-  same key are deduplicated **last-write-wins** before the `MERGE` runs (MERGE
-  rejects a source that targets the same key twice).
-- **`delete`** — every record's `key` is collected and deleted. Composite keys
-  use a `MERGE … WHEN MATCHED THEN DELETE` (T-SQL has no row-constructor
-  `IN ((a,b), …)`), so single- and multi-column keys share one code path.
-- **`delete_marker`** (upsert mode only) — rows whose `field` equals one of
-  `values` are routed to a delete instead of an upsert; the marker field is
-  stripped from the upserted record. This lets a CDC stream carrying an
-  operation flag drive inserts, updates, and deletes from one pipeline.
+### Azure SQL with self-signed dev certificate
 
-A row missing or null in a key column fails with a clear `mssql upsert: …`
-error. When a `dlq:` block is configured the good rows are still applied
-(upserts + deletes) and only the missing/null-key rows are routed to the DLQ
-per-row; without a DLQ the whole batch fails. Upserts and deletes for a batch
-run inside a single `BEGIN TRAN` / `COMMIT TRAN` so they commit atomically.
+```yaml
+sink:
+  type: mssql
+  config:
+    connection_url: "mssql://sa:Str0ng%40Pass@localhost:1433/sales"
+    table: "dbo.events"
+    column_mapping: { type: json_column, column: data }
+    tls:
+      type: trust_server_certificate   # dev only — never in production
+```
 
-## Batching, transactions, and MSSQL's statement limits
+## Streaming & batching
 
-MSSQL enforces two caps on a multi-row statement: at most **2100 parameters** per
-request (and `tiberius` spends 2 of them on its `sp_executesql` wrapper, so the
-usable budget is 2098), and at most **1000 row expressions** in a `VALUES`
-clause. Both the append `INSERT` and the `MERGE` upsert/delete paths auto-split a
-batch into multiple statements that stay within *both* limits —
-`min(2098 / columns, 1000)` rows each — all within one transaction when
-`transaction_per_batch` (upsert/delete are always transaction-wrapped). Bulk-copy
-(`BCP`) is out of scope.
+The pipeline streams pages from the source and calls `Sink::write_batch` once per page. `batch_size` re-chunks each page into multi-row `INSERT` statements; every statement is then auto-split so `rows × columns ≤ 2098` and `rows ≤ 1000`, keeping a single request within SQL Server's caps. With `transaction_per_batch: true` (the default) all statements for a page commit atomically inside one `BEGIN TRAN` / `COMMIT TRAN`.
 
-## Partial failures (DLQ)
+`batch_size: 0` is the "no batching" sentinel: the whole upstream page is handed to the sink as one logical write (still param-split internally into compliant statements). Bulk-copy (`BCP`) is out of scope.
 
-With `isolate_row_failures: true` (default) a batch that fails is rolled back and
-retried one row at a time: the good rows land and only the offending row is
-returned as an error for dead-letter routing. Transient errors (deadlock,
-lock-timeout, connection drops) are retried with backoff and otherwise
-propagated so the pipeline's `on_batch_error` policy decides. Set
-`isolate_row_failures: false` to fail the whole batch on the first bad row
-(fewer round-trips).
+## Write modes (upsert / delete)
 
-## Security
+In addition to the default append, the sink can **upsert** (insert-or-update by key) or **delete** by key. Both require `column_mapping: auto_columns` — the key columns must be real table columns, not buried inside a JSON column (using `json_column` with `upsert`/`delete` is rejected at construction). The key columns should have a `UNIQUE` / `PRIMARY KEY` constraint.
 
-`tls.type: trust_server_certificate` and `TrustServerCertificate=true` in a
-connection string disable certificate-chain validation — they accept **any**
-server certificate, which is vulnerable to man-in-the-middle attacks. Use them
-only against trusted dev servers. In production use `prefer`/`require` with a
-proper certificate, or pin a CA via `tls.ca_cert_path`. Never hard-code
-credentials — supply `connection_url` / `connection_string` via secrets-manager
-interpolation or environment variables.
+- **`upsert`** — each record is merged via a single T-SQL [`MERGE`](https://learn.microsoft.com/sql/t-sql/statements/merge-transact-sql): matching rows (by `key`) have their non-key columns updated; non-matching rows are inserted. When every column is a key column there's nothing to update, so the `WHEN MATCHED` clause is omitted. Within a batch, records sharing a key are deduplicated **last-write-wins** before the `MERGE` runs (MERGE rejects a source targeting the same key twice).
+- **`delete`** — every record's `key` is collected and deleted via `MERGE … WHEN MATCHED THEN DELETE` (T-SQL has no row-constructor `IN ((a,b), …)`), so single- and multi-column keys share one code path.
+- **`delete_marker`** (upsert mode only) — rows whose `field` equals one of `values` are routed to a delete instead of an upsert; the marker field is stripped from the upserted record. This lets a CDC stream carrying an operation flag drive inserts, updates, and deletes from one pipeline.
 
-## Auth
+A row missing or null in a key column fails with a clear `mssql upsert: …` error. With a `dlq:` block configured, the good rows still apply (upserts + deletes) and only the missing/null-key rows are routed to the DLQ per-row; without a DLQ the whole batch fails. Upserts and deletes for a batch always run inside a single `BEGIN TRAN` / `COMMIT TRAN`.
 
-SQL Server authentication (username + password) only in v1. Windows / Integrated
-authentication and Azure AD / Managed Identity are out of scope.
+See the [upsert cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/upsert.html) for the full write-mode model.
 
-## Testing
+## Dead-letter queue (partial failures)
 
-Unit tests run with `cargo test -p faucet-sink-mssql --lib`. The integration
-tests (`--test integration`) require Docker.
+With `isolate_row_failures: true` (default), a batch that fails is rolled back and retried one row at a time: the good rows land and only the offending row is returned as an error for dead-letter routing under the pipeline's `dlq:` block. Transient errors (deadlock, lock-timeout, connection drops) are retried with backoff and otherwise propagated so the pipeline's `on_batch_error` policy decides. Set `isolate_row_failures: false` to fail the whole batch on the first bad row (fewer round-trips, no row isolation).
 
 ## Exactly-once delivery
 
 `MssqlSink` implements `Sink::supports_idempotent_writes` (returns `true`) and the two companion hooks:
 
-- `write_batch_idempotent(records, scope, token)` — writes `records` and UPSERTs the `token` into a `_faucet_commit_token(scope NVARCHAR, token NVARCHAR)` watermark table inside the **same transaction** (respecting `transaction_per_batch`), so both either commit together or neither does.
-- `last_committed_token(scope)` — reads the current watermark to let the pipeline skip already-committed pages on resume.
+- `write_batch_idempotent(records, scope, token)` — writes `records` and UPSERTs the `token` into a `_faucet_commit_token(scope NVARCHAR, token NVARCHAR)` watermark table inside the **same transaction** (respecting `transaction_per_batch`), so both commit together or neither does.
+- `last_committed_token(scope)` — reads the current watermark so the pipeline can skip already-committed pages on resume.
 
-To use exactly-once delivery, set `delivery: exactly_once` in your pipeline config and pair this sink with one of the CDC sources (`postgres-cdc`, `mysql-cdc`, `mongodb-cdc`) plus a `state:` block. A DLQ is not permitted in exactly-once mode. All four requirements are validated at config-load time (`faucet validate`) before any run starts.
+To use exactly-once delivery, set `delivery: exactly_once` in the pipeline config and pair this sink with one of the CDC sources (`postgres-cdc`, `mysql-cdc`, `mongodb-cdc`) plus a `state:` block. A DLQ is not permitted in exactly-once mode. All four requirements are validated at config-load time (`faucet validate`) before any run starts. Exactly-once composes with `write_mode: upsert`.
 
 ```yaml
 pipeline:
@@ -170,12 +249,92 @@ pipeline:
 delivery: exactly_once
 ```
 
-See the [Exactly-once delivery cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/state.html#exactly-once-delivery) for full rationale and the supported source/sink set.
+See the [exactly-once delivery cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/state.html#exactly-once-delivery) for the full rationale and supported source/sink set.
+
+## Config loading & schema
+
+Load from YAML/JSON or environment. Inspect the full JSON Schema with:
+
+```bash
+faucet schema sink mssql
+```
+
+## Library usage
+
+```rust
+use faucet_core::{Pipeline, Sink};
+use faucet_sink_mssql::{MssqlColumnMapping, MssqlSink, MssqlSinkConfig, OnUnknownField};
+
+# async fn run() -> Result<(), faucet_core::FaucetError> {
+let mut cfg = MssqlSinkConfig::new(
+    "mssql://sa:Str0ng%40Pass@localhost:1433/sales",
+    "dbo.events",
+);
+cfg.column_mapping = MssqlColumnMapping::AutoColumns {
+    on_unknown_field: OnUnknownField::Warn,
+};
+cfg.batch_size = 1000;
+
+let sink = MssqlSink::new(cfg).await?;
+// Drive it from any source via `Pipeline` / `run_stream`.
+# let _ = sink;
+# Ok(())
+# }
+```
+
+The shared connection/TLS types (`MssqlConnectionConfig`, `MssqlTls`, `MssqlTlsMode`) are re-exported from this crate, so you configure the sink without depending on [`faucet-common-mssql`](https://crates.io/crates/faucet-common-mssql) directly.
+
+## How it works
+
+1. `new()` validates the config, builds a `bb8`+`tiberius` connection pool **once**, and reuses it for every write.
+2. Each page is re-chunked to `batch_size` rows, then each chunk is split so `rows × columns ≤ 2098` and `rows ≤ 1000` — one or more multi-row `INSERT` (or `MERGE`) statements per chunk.
+3. With `transaction_per_batch`, all statements for a page run inside one `BEGIN TRAN` / `COMMIT TRAN`; upsert/delete are always transaction-wrapped.
+4. Identifiers are bracket-quoted (`[name]`, doubling interior `]`) via `quote_ident_mssql`; values are bound as parameters (never string-interpolated), so SQL injection isn't possible.
+5. On a batch failure with `isolate_row_failures`, the transaction rolls back and the batch is replayed one row at a time to surface the single offending row.
 
 ## Lineage dataset URI
 
 `<connection_url_or_string>?table=<table>` (password redacted) — e.g. `Server=tcp:host,1433;Database=db;User Id=sa;Password=***;?table=orders`.
 
+## Authentication
+
+SQL Server authentication (username + password) only in v1, via the `connection_url` / `connection_string`. Windows / Integrated authentication and Azure AD / Managed Identity are out of scope. See [`faucet-common-mssql`](https://crates.io/crates/faucet-common-mssql) for the full connection/TLS reference.
+
+## Security
+
+`tls.type: trust_server_certificate` (and `TrustServerCertificate=true` in a connection string) disable certificate-chain validation — they accept **any** server certificate and are vulnerable to man-in-the-middle attacks. Use them only against trusted dev servers. In production use `prefer` / `require` with a proper certificate, or pin a CA via `tls.ca_cert_path`. Never hard-code credentials — supply `connection_url` / `connection_string` via secrets-manager interpolation (`${vault:…}`, `${aws-sm:…}`, …) or environment variables (`${env:…}`).
+
+## Feature flags
+
+This crate has no optional Cargo features of its own; enable it in the CLI / umbrella via the `sink-mssql` feature.
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause & fix |
+|---------|--------------------|
+| `MSSQL config requires either connection_url or connection_string` | Neither connection form set. Provide exactly one. |
+| `MSSQL config sets both connection_url and connection_string` | Both forms set. Keep exactly one. |
+| `MSSQL connection_url scheme must be mssql://` | Wrong scheme. Use `mssql://` (or `sqlserver://`). |
+| Login fails with a parsed password | Special characters in the password aren't percent-encoded in the URL. Encode them (`@` → `%40`, `:` → `%3A`, `/` → `%2F`), or use `connection_string`. |
+| TLS handshake fails against a self-signed dev server | Set `tls.type: trust_server_certificate` (dev only) or pin the CA with `tls.ca_cert_path`. |
+| `create_table` rejected | `create_table` only works with `json_column`. For `auto_columns`, create the table yourself first (type inference is unsafe). |
+| Unknown-key rows error out | `on_unknown_field` is `error`. Switch to `warn` / `drop`, or add the column to the table. |
+| `IDENTITY` insert error | You included an identity column's value in a record. Drop it (the server generates identities) or run `SET IDENTITY_INSERT <table> ON`. |
+| `mssql upsert: …` missing/null key | An upsert/delete row has a null or absent `key` column. Configure a `dlq:` to isolate those rows, or fix the data. |
+| `json_column` with `upsert`/`delete` rejected | Key columns must be real table columns. Use `column_mapping: auto_columns` for keyed modes. |
+| Frequent deadlock / lock-timeout retries | Reduce `batch_size`, lower write concurrency, or ensure the upsert `key` matches an index so `MERGE` doesn't escalate locks. |
+| Exactly-once config rejected at `faucet validate` | All four gates must hold: a CDC source, this sink, a `state:` block, and **no** `dlq:`. The error names the offending row. |
+
+## See also
+
+- [Sinks reference & capability matrix](https://pawansikawat.github.io/faucet-stream/reference/connectors.html)
+- [Upsert / write modes cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/upsert.html)
+- [State & exactly-once cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/state.html)
+- [Dead-letter queue cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/dlq.html)
+- [`faucet-common-mssql`](https://crates.io/crates/faucet-common-mssql) — shared connection/TLS config
+- [`faucet-source-mssql`](https://crates.io/crates/faucet-source-mssql) — the matching SQL Server source
+- [`faucet-sink-postgres`](https://crates.io/crates/faucet-sink-postgres) · [`faucet-sink-mysql`](https://crates.io/crates/faucet-sink-mysql) · [`faucet-sink-sqlite`](https://crates.io/crates/faucet-sink-sqlite) — sibling SQL sinks
+
 ## License
 
-MIT OR Apache-2.0.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/sink/mysql/README.md
+++ b/crates/sink/mysql/README.md
@@ -2,6 +2,8 @@
 
 [![Crates.io](https://img.shields.io/crates/v/faucet-sink-mysql.svg)](https://crates.io/crates/faucet-sink-mysql)
 [![Docs.rs](https://docs.rs/faucet-sink-mysql/badge.svg)](https://docs.rs/faucet-sink-mysql)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-sink-mysql.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-sink-mysql.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
 MySQL sink connector for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
 

--- a/crates/sink/mysql/README.md
+++ b/crates/sink/mysql/README.md
@@ -5,204 +5,102 @@
 [![MSRV](https://img.shields.io/crates/msrv/faucet-sink-mysql.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
 [![License](https://img.shields.io/crates/l/faucet-sink-mysql.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-MySQL sink connector for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
+**MySQL** sink for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem. Writes JSON records to a MySQL (or MariaDB) table using a pooled `sqlx` connection and efficient multi-row `INSERT` statements with backtick-quoted identifiers.
 
-Writes JSON records to a MySQL table using either JSON column mode (storing each record as a serialized JSON string) or AutoMap mode (mapping top-level JSON keys directly to table columns). Uses connection pooling via `sqlx` and efficient multi-row `INSERT` statements with backtick-quoted identifiers.
+Reach for it when you want to land any faucet-stream source — a REST API, a CSV file, a CDC stream, a queue — into MySQL with one declarative config and no glue code. Store records as opaque JSON blobs, or map their keys straight onto real table columns; mirror a source table with `write_mode: upsert`; or run end-to-end exactly-once from a CDC source.
 
-`write_batch` accepts whatever slice the pipeline hands it. When `batch_size > 0` and the slice is larger than `batch_size`, the sink re-chunks internally and issues one multi-row `INSERT` per chunk; when `batch_size = 0`, the entire slice is sent in a single `INSERT` — see [Streaming and batching](#streaming-and-batching) for the tradeoffs.
+## Feature highlights
+
+- **Two column-mapping modes** — `json` packs each record into a single JSON column; `auto_map` maps top-level JSON keys directly onto table columns discovered from `INFORMATION_SCHEMA`.
+- **Multi-row `INSERT`** — every batch becomes a single `INSERT INTO t VALUES (...), (...), ...`, sub-chunked so `rows × columns` never exceeds MySQL's 65,535-placeholder limit.
+- **Connection pooling** — a `sqlx::MySqlPool` built once in `new()` and reused for every write; pool size is configurable.
+- **Write modes** — `append` (default), `upsert` (`INSERT … ON DUPLICATE KEY UPDATE`), and `delete` (delete by key), with last-write-wins de-duplication within a page and atomic per-page transactions.
+- **Exactly-once delivery** — pairs with a CDC source for at-most-once-effective writes; records and the commit-token watermark commit in one transaction.
+- **Dead-letter queue** — in upsert/delete mode, rows with a missing/null key are routed per-row to a configured DLQ instead of failing the whole batch.
+- **Native-typed binding** — in `auto_map` mode, values bind as native MySQL types (text, integer/double, `TINYINT` booleans, JSON for nested values).
+- **Credential-safe** — the `Debug` impl masks `connection_url` so credentials never leak into logs.
 
 ## Installation
 
 ```bash
+# As a library:
 cargo add faucet-sink-mysql
 cargo add tokio --features full
-```
 
-Or via the umbrella crate:
+# In the CLI (opt-in connector feature):
+cargo install faucet-cli --features sink-mysql
 
-```bash
+# Or via the umbrella crate:
 cargo add faucet-stream --features sink-mysql
 ```
 
-## Quick Start
+## Quick start
 
-```rust
-use faucet_sink_mysql::{MysqlSink, MysqlSinkConfig};
-use faucet_core::Sink;
-use serde_json::json;
-
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let config = MysqlSinkConfig::new(
-        "mysql://user:password@localhost:3306/mydb",
-        "events",
-    );
-
-    let sink = MysqlSink::new(config).await?;
-
-    let records = vec![
-        json!({"user_id": "u123", "event": "signup"}),
-        json!({"user_id": "u456", "event": "login"}),
-    ];
-
-    let rows_written = sink.write_batch(&records).await?;
-    println!("Wrote {rows_written} rows");
-
-    Ok(())
-}
+```yaml
+# pipeline.yaml — faucet run pipeline.yaml
+version: 1
+name: csv_to_mysql
+pipeline:
+  source:
+    type: csv
+    config:
+      path: customers.csv
+      has_headers: true
+  sink:
+    type: mysql
+    config:
+      connection_url: mysql://user:pass@localhost:3306/crm
+      table_name: customers
+      column_mapping: auto_map
+      batch_size: 1000
+      max_connections: 10
 ```
 
-## Configuration
+```bash
+faucet run pipeline.yaml
+```
+
+> Note YAML configs use `type:` (not `kind:`) for the connector discriminator.
+
+## Configuration reference
+
+### Core
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `connection_url` | `String` | *(required)* | MySQL connection URL (e.g. `mysql://user:pass@host:3306/db`) |
-| `table_name` | `String` | *(required)* | Target table name |
-| `column_mapping` | `MysqlColumnMapping` | `Json { column: "data" }` | How to map JSON records to table columns (see below) |
-| `batch_size` | `usize` | `1000` | Maximum rows per multi-row `INSERT`. See [Streaming and batching](#streaming-and-batching) below |
-| `max_connections` | `u32` | `5` | Maximum number of connections in the connection pool |
+| `connection_url` | string | — *(required)* | MySQL connection URL, e.g. `mysql://user:pass@host:3306/db`. Masked as `***` in `Debug` output. |
+| `table_name` | string | — *(required)* | Target table. Quoted with backticks (embedded backticks doubled). |
+| `column_mapping` | `MysqlColumnMapping` | `{ json: { column: "data" } }` | How JSON records map to columns — see [Column mapping](#column-mapping). |
+| `max_connections` | int | `5` | Maximum connections in the `sqlx` pool. |
+
+### Batching
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `batch_size` | int | `1000` | Rows per multi-row `INSERT`. **`0` = no re-chunking**: the whole upstream page is sent in one `INSERT` (bounded by `max_allowed_packet`). See [Streaming & batching](#streaming--batching). |
+
+### Write mode (flattened — top-level fields)
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
 | `write_mode` | `"append"` \| `"upsert"` \| `"delete"` | `"append"` | Write semantics. `upsert`/`delete` require `column_mapping: auto_map` and a non-empty `key`. See [Write modes](#write-modes-upsert--delete). |
-| `key` | `[String]` | `[]` | Key columns for `upsert`/`delete`. The table must have a PRIMARY or UNIQUE index on these columns. |
-| `delete_marker` | `{ field, values }` | *(none)* | Upsert-only: rows whose `field` matches one of `values` are treated as deletes; all others are upserts. The marker field is stripped before writing. |
+| `key` | array of string | `[]` | Key columns for `upsert`/`delete`. The table must have a PRIMARY or UNIQUE index on these columns. Ignored for `append`. |
+| `delete_marker` | `{ field, values }` | *(none)* | Upsert-only: rows whose `field` matches one of `values` become deletes; all others are upserts. The marker field is stripped from upsert rows before writing. |
 
-The `Debug` implementation masks the `connection_url` with `***` to prevent credential leakage in logs.
+### Column mapping
 
-### Streaming and batching
+`column_mapping` is a tagged enum (`snake_case` discriminators):
 
-The MySQL sink re-chunks each incoming `StreamPage` to keep individual
-multi-row `INSERT` statements under MySQL's `max_allowed_packet` limit.
-
-- **`batch_size > 0`** (default `1000`) — the sink slices the incoming slice
-  into `batch_size`-row chunks and issues one multi-row `INSERT INTO ...
-  VALUES (...), (...), ...` per chunk. **Recommended value is `1000`**:
-  that's the multi-row INSERT sweet spot for MySQL (small enough to stay
-  well under the default 64MB `max_allowed_packet` even for wide rows,
-  large enough to amortise per-statement overhead). Bump it higher when
-  rows are narrow; drop it when rows are wide enough to push individual
-  chunks past `max_allowed_packet`.
-- **`batch_size = 0`** — the "no batching" sentinel. The entire upstream
-  `StreamPage` is forwarded in a single multi-row `INSERT`. Use this when
-  the source already emits page sizes tuned for MySQL — for example a
-  Postgres source configured with `batch_size: 1000`. Larger pages risk a
-  `Packet too large` error from MySQL's `max_allowed_packet` limit.
-
-`batch_size` is purely a chunk-size knob — the SQL semantics, identifier
-quoting, and column-mapping behaviour are unchanged.
-
-### Column Mapping (`MysqlColumnMapping`)
-
-| Variant | Description |
-|---------|-------------|
-| `Json { column }` | Insert each record as a serialized JSON string in a single column. The column name defaults to `"data"` but can be overridden. Uses a multi-row `INSERT INTO t (col) VALUES (?), (?), ...` for efficiency. |
-| `AutoMap` | Map top-level JSON keys directly to table columns. Column names are discovered from `INFORMATION_SCHEMA.COLUMNS`. Values are bound as **native MySQL types** (strings as text, JSON numbers as integer/double, booleans as `TINYINT` 0/1, arrays/objects as JSON text). The INSERT column set is the **union** of record keys across the batch, so a field present only in a later record is still written; a row missing a column binds SQL `NULL`. Only keys that match existing columns are inserted; extra keys are silently ignored. Records with no matching keys are skipped with a warning. |
-
-### Builder Methods
-
-```rust
-use faucet_sink_mysql::{MysqlSinkConfig, MysqlColumnMapping};
-
-// JSON mode with custom column name
-let config = MysqlSinkConfig::new("mysql://localhost/mydb", "events")
-    .column_mapping(MysqlColumnMapping::Json { column: "payload".into() })
-    .with_batch_size(1000)
-    .max_connections(10);
-
-// AutoMap mode
-let config = MysqlSinkConfig::new("mysql://localhost/mydb", "events")
-    .column_mapping(MysqlColumnMapping::AutoMap)
-    .with_batch_size(250);
-```
-
-## Config Loading
-
-```rust
-use faucet_core::config::{load_json, load_env_file};
-use faucet_sink_mysql::MysqlSinkConfig;
-
-// From a JSON file
-let config: MysqlSinkConfig = load_json("config.json")?;
-
-// From an .env file with a prefix
-let config: MysqlSinkConfig = load_env_file(".env", "MYSQL_SINK")?;
-```
-
-### Example JSON config (JSON mode)
-
-```json
-{
-  "connection_url": "mysql://writer:s3cret@db.example.com:3306/analytics",
-  "table_name": "raw_events",
-  "column_mapping": {
-    "json": {
-      "column": "data"
-    }
-  },
-  "batch_size": 1000,
-  "max_connections": 5
-}
-```
-
-### Example JSON config (AutoMap mode)
-
-```json
-{
-  "connection_url": "mysql://writer:s3cret@db.example.com:3306/analytics",
-  "table_name": "events",
-  "column_mapping": "auto_map",
-  "batch_size": 1000,
-  "max_connections": 10
-}
-```
-
-### Example .env file
-
-```env
-MYSQL_SINK_CONNECTION_URL=mysql://writer:s3cret@db.example.com:3306/analytics
-MYSQL_SINK_TABLE_NAME=raw_events
-MYSQL_SINK_COLUMN_MAPPING='{"json":{"column":"data"}}'
-MYSQL_SINK_BATCH_SIZE=1000
-MYSQL_SINK_MAX_CONNECTIONS=5
-```
-
-## Config Schema Introspection
-
-```rust
-use faucet_core::Sink;
-
-let sink = MysqlSink::new(config).await?;
-let schema = sink.config_schema();
-println!("{}", serde_json::to_string_pretty(&schema)?);
-```
-
-## Pipeline Usage
-
-```rust
-use faucet_core::Pipeline;
-use faucet_source_rest::{RestStream, RestStreamConfig};
-use faucet_sink_mysql::{MysqlSink, MysqlSinkConfig, MysqlColumnMapping};
-
-let source = RestStream::new(
-    RestStreamConfig::new("https://api.example.com", "/v1/orders")
-);
-
-let sink_config = MysqlSinkConfig::new(
-    "mysql://writer:pass@localhost:3306/app",
-    "orders",
-)
-.column_mapping(MysqlColumnMapping::AutoMap);
-
-let sink = MysqlSink::new(sink_config).await?;
-
-let result = Pipeline::new(source, sink).run().await?;
-println!("Transferred {} records", result.records_written);
-```
+| Variant | YAML | Description |
+|---------|------|-------------|
+| `Json { column }` | `column_mapping: { json: { column: data } }` | Insert each record as a serialized JSON string in one column (defaults to `data`). Uses `INSERT INTO t (col) VALUES (?), (?), ...`. |
+| `AutoMap` | `column_mapping: auto_map` | Map top-level JSON keys directly to table columns discovered from `INFORMATION_SCHEMA.COLUMNS`. The INSERT column set is the **union** of record keys across the batch (a field present only in a later record is still written; a row missing a column binds SQL `NULL`). Extra keys with no matching column are silently ignored; records with no matching keys are skipped with a warning. |
 
 ## Examples
 
-### JSON mode -- store records as serialized JSON
+### JSON column mode — store records as serialized JSON
 
 ```sql
--- Table schema
 CREATE TABLE raw_events (
     id INT AUTO_INCREMENT PRIMARY KEY,
     data JSON NOT NULL,
@@ -210,80 +108,78 @@ CREATE TABLE raw_events (
 );
 ```
 
-```rust
-let config = MysqlSinkConfig::new(
-    "mysql://localhost/analytics",
-    "raw_events",
-)
-.column_mapping(MysqlColumnMapping::Json { column: "data".into() })
-.with_batch_size(1000);
-
-let sink = MysqlSink::new(config).await?;
-sink.write_batch(&records).await?;
+```yaml
+pipeline:
+  source: { type: rest, config: { base_url: https://api.example.com, path: /v1/events } }
+  sink:
+    type: mysql
+    config:
+      connection_url: ${env:MYSQL_URL}
+      table_name: raw_events
+      column_mapping:
+        json:
+          column: data
+      batch_size: 1000
 ```
 
-### AutoMap mode -- map JSON keys to table columns
+### AutoMap mode — map JSON keys onto columns
 
 ```sql
--- Table schema
 CREATE TABLE events (
     user_id VARCHAR(255),
-    event VARCHAR(255),
-    amount DECIMAL(10, 2),
+    event   VARCHAR(255),
+    amount  DECIMAL(10, 2),
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 ```
 
-```rust
-let config = MysqlSinkConfig::new(
-    "mysql://localhost/analytics",
-    "events",
-)
-.column_mapping(MysqlColumnMapping::AutoMap)
-.with_batch_size(1000)
-.max_connections(10);
-
-let sink = MysqlSink::new(config).await?;
-
-let records = vec![
-    json!({"user_id": "u1", "event": "purchase", "amount": 29.99}),
-    json!({"user_id": "u2", "event": "signup"}),
-];
-sink.write_batch(&records).await?;
+```yaml
+pipeline:
+  source: { type: csv, config: { path: events.csv, has_headers: true } }
+  sink:
+    type: mysql
+    config:
+      connection_url: mysql://writer:pass@db.internal:3306/analytics
+      table_name: events
+      column_mapping: auto_map
+      batch_size: 1000
+      max_connections: 10
 ```
 
-### High-throughput connection pooling
+### High-throughput pooling
 
-```rust
-let config = MysqlSinkConfig::new(
-    "mysql://writer:pass@db-primary.internal:3306/warehouse",
-    "metrics",
-)
-.max_connections(20)
-.with_batch_size(1000);
-
-let sink = MysqlSink::new(config).await?;
+```yaml
+sink:
+  type: mysql
+  config:
+    connection_url: mysql://writer:pass@db-primary.internal:3306/warehouse
+    table_name: metrics
+    column_mapping: auto_map
+    max_connections: 20
+    batch_size: 1000
 ```
 
-## How It Works
+## Streaming & batching
 
-- A connection pool is created in `MysqlSink::new()` using `sqlx::MySqlPool` with the configured `max_connections`.
-- `write_batch()` slices the input into `batch_size`-row chunks (or forwards the whole slice when `batch_size = 0`) and inserts each chunk using a single multi-row INSERT statement.
-- In JSON mode, each record is serialized to a JSON string and inserted as `INSERT INTO t (col) VALUES (?), (?), ...`.
-- In AutoMap mode, column names are queried from `INFORMATION_SCHEMA.COLUMNS` for the current database. A multi-row INSERT is built dynamically with `?` placeholders. Column values are bound as **native MySQL types** (#78/#4). The column set is the **union** of record keys across the batch, so a field present only in a later record is still written; a row missing a column binds SQL `NULL`. The INSERT is sub-chunked so `rows × columns` never exceeds MySQL's 65,535-placeholder limit.
-- All identifiers (table names, column names) are quoted with backticks using MySQL-safe escaping (embedded backticks are doubled).
+The sink re-chunks each incoming `StreamPage` to keep individual multi-row `INSERT` statements under MySQL's `max_allowed_packet` limit.
+
+- **`batch_size > 0`** (default `1000`) — the incoming slice is sliced into `batch_size`-row chunks; one multi-row `INSERT INTO ... VALUES (...), (...), ...` per chunk. **`1000` is the sweet spot**: small enough to stay well under the default 64 MB `max_allowed_packet` even for wide rows, large enough to amortise per-statement overhead. Bump it higher for narrow rows; drop it for very wide rows.
+- **`batch_size = 0`** — the "no batching" sentinel. The entire upstream `StreamPage` is forwarded in a single multi-row `INSERT`. Use this when the source already emits page sizes tuned for MySQL (e.g. a Postgres source configured with `batch_size: 1000`). Larger pages risk a `Packet too large` error.
+
+In `auto_map` mode the INSERT is sub-chunked further so `rows × columns` never exceeds MySQL's 65,535-placeholder limit. `batch_size` is purely a chunk-size knob — SQL semantics, identifier quoting, and column-mapping behaviour are unchanged.
 
 ## Write modes (upsert / delete)
 
-`MysqlSink` supports `write_mode: upsert` and `write_mode: delete` in addition to the default `write_mode: append`.
+`MysqlSink` advertises `[Append, Upsert, Delete]` via `Sink::supported_write_modes()`.
 
-**Requirements:**
+**Requirements for `upsert` / `delete`:**
+
 - `column_mapping` must be `auto_map` — key columns must be real table columns, not packed inside a JSON blob.
 - `key` must be a non-empty list of column names.
-- The target table must have a **PRIMARY or UNIQUE key** on those columns. MySQL's `ON DUPLICATE KEY UPDATE` detects conflicts via that index — the `key` config field drives which columns are updated, not which index is used. All non-key columns in the INSERT are set from `VALUES(col)`.
-- A row missing or null in a key column fails. When a `dlq:` block is configured the good rows are still written and only the missing/null-key rows are routed to the DLQ per-row; without a DLQ the whole batch fails.
+- The target table must have a **PRIMARY or UNIQUE index** on those columns. MySQL's `ON DUPLICATE KEY UPDATE` detects conflicts via that index; the `key` config drives which columns are matched, and all non-key columns are set from `VALUES(col)`.
+- A row missing/null in a key column fails. With a `dlq:` block configured, good rows are still written and only the bad rows are routed to the DLQ per-row; without a DLQ the whole batch fails.
 
-**`write_mode: upsert`** — each record is INSERT … ON DUPLICATE KEY UPDATE (last-write-wins). Optionally, a `delete_marker` field routes certain records to deletes instead:
+**`write_mode: upsert`** — each record is `INSERT … ON DUPLICATE KEY UPDATE` (last-write-wins). An optional `delete_marker` routes flagged records to deletes instead:
 
 ```yaml
 pipeline:
@@ -315,18 +211,21 @@ pipeline:
 ```
 
 **Behaviour:**
-- The planner (`plan_writes`) deduplicates within each page (last-write-wins), so a page that contains the same key twice produces exactly one MySQL statement touching that row.
-- Upserts and deletes within a page are applied inside **one transaction**, so they commit atomically or not at all.
+
+- The planner (`plan_writes`) de-duplicates within each page (last-write-wins), so a page containing the same key twice produces exactly one statement touching that row.
+- Upserts and deletes within a page are applied inside **one transaction** — they commit atomically or not at all.
 - The `delete_marker` field is stripped from upsert records before writing.
+
+Pair `write_mode: upsert` with the [`cdc_unwrap`](https://pawansikawat.github.io/faucet-stream/cookbook/upsert.html) transform to mirror a CDC source into MySQL. See the [upsert cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/upsert.html).
 
 ## Exactly-once delivery
 
-`MysqlSink` implements `Sink::supports_idempotent_writes` (returns `true`) and the two companion hooks:
+`MysqlSink` implements `Sink::supports_idempotent_writes` (`true`) and the two companion hooks:
 
-- `write_batch_idempotent(records, scope, token)` — writes `records` and UPSERTs the `token` into a `_faucet_commit_token(scope VARCHAR, token VARCHAR)` watermark table inside the **same transaction**, so both either commit together or neither does.
-- `last_committed_token(scope)` — reads the current watermark to let the pipeline skip already-committed pages on resume.
+- `write_batch_idempotent(records, scope, token)` — writes `records` and UPSERTs the `token` into a `_faucet_commit_token(scope VARCHAR, token VARCHAR)` watermark table inside the **same transaction**, so both commit together or neither does.
+- `last_committed_token(scope)` — reads the current watermark so the pipeline can skip already-committed pages on resume.
 
-To use exactly-once delivery, set `delivery: exactly_once` in your pipeline config and pair this sink with one of the CDC sources (`postgres-cdc`, `mysql-cdc`, `mongodb-cdc`) plus a `state:` block. A DLQ is not permitted in exactly-once mode. All four requirements are validated at config-load time (`faucet validate`) before any run starts.
+Set `delivery: exactly_once` and pair this sink with a CDC source (`postgres-cdc`, `mysql-cdc`, `mongodb-cdc`) plus a `state:` block. A DLQ is **not** permitted in exactly-once mode. All four requirements are validated at config-load time (`faucet validate`) before any run starts.
 
 ```yaml
 pipeline:
@@ -343,17 +242,121 @@ pipeline:
       column_mapping: auto_map
   state:
     type: file
-    config:
-      path: ./state
+    config: { path: ./state }
 delivery: exactly_once
 ```
 
-See the [Exactly-once delivery cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/state.html#exactly-once-delivery) for full rationale and the supported source/sink set.
+See the [exactly-once cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/state.html#exactly-once-delivery) for the full rationale and the supported source/sink set.
+
+## Dead-letter queue
+
+In `upsert`/`delete` mode the sink overrides `Sink::write_batch_partial`: good rows are applied and only the rows whose key could not be extracted (missing/null key) are reported as `Err`, so the pipeline routes them to the configured DLQ per-row rather than failing the whole page. In `append` mode it delegates to `write_batch`. Add a `dlq:` block to your pipeline to capture those rows; without one, a bad key fails the batch.
+
+```yaml
+pipeline:
+  sink:
+    type: mysql
+    config:
+      connection_url: ${env:MYSQL_URL}
+      table_name: products
+      column_mapping: auto_map
+      write_mode: upsert
+      key: [id]
+  dlq:
+    type: jsonl
+    config: { path: ./dlq/mysql.jsonl }
+```
+
+## Config loading & schema
+
+Load from YAML/JSON or environment, and inspect the full JSON Schema:
+
+```rust
+use faucet_core::config::{load_json, load_env_file};
+use faucet_sink_mysql::MysqlSinkConfig;
+
+// From a JSON file
+let config: MysqlSinkConfig = load_json("config.json")?;
+// From an .env file with a prefix
+let config: MysqlSinkConfig = load_env_file(".env", "MYSQL_SINK")?;
+```
+
+```env
+MYSQL_SINK_CONNECTION_URL=mysql://writer:s3cret@db.example.com:3306/analytics
+MYSQL_SINK_TABLE_NAME=raw_events
+MYSQL_SINK_COLUMN_MAPPING='{"json":{"column":"data"}}'
+MYSQL_SINK_BATCH_SIZE=1000
+MYSQL_SINK_MAX_CONNECTIONS=5
+```
+
+```bash
+faucet schema sink mysql
+```
+
+## Library usage
+
+```rust
+use faucet_core::{Pipeline, Sink};
+use faucet_sink_mysql::{MysqlColumnMapping, MysqlSink, MysqlSinkConfig};
+use serde_json::json;
+
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let config = MysqlSinkConfig::new("mysql://writer:pass@localhost:3306/app", "orders")
+    .column_mapping(MysqlColumnMapping::AutoMap)
+    .with_batch_size(1000)
+    .max_connections(10);
+
+let sink = MysqlSink::new(config).await?;
+
+let records = vec![
+    json!({"id": "o1", "status": "paid", "amount": 29.99}),
+    json!({"id": "o2", "status": "pending"}),
+];
+let rows = sink.write_batch(&records).await?;
+println!("wrote {rows} rows");
+# Ok(())
+# }
+```
+
+Drive it end-to-end via `Pipeline::new(source, sink).run()`.
+
+## How it works
+
+1. `MysqlSink::new()` builds a `sqlx::MySqlPool` **once** with the configured `max_connections`.
+2. `write_batch()` slices the input into `batch_size`-row chunks (or forwards the whole slice when `batch_size = 0`) and inserts each chunk with a single multi-row `INSERT`.
+3. **JSON mode** — each record is serialized to a JSON string: `INSERT INTO t (col) VALUES (?), (?), ...`.
+4. **AutoMap mode** — column names are read from `INFORMATION_SCHEMA.COLUMNS` for the current database; a multi-row INSERT is built dynamically with `?` placeholders, bound as native MySQL types. The column set is the union of record keys across the batch; the INSERT is sub-chunked so `rows × columns` stays under the 65,535-placeholder limit.
+5. **Upsert/delete** — `plan_writes` partitions the page (last-write-wins) and the resulting upserts/deletes are applied in one transaction.
+6. All identifiers are backtick-quoted with MySQL-safe escaping (embedded backticks doubled).
 
 ## Lineage dataset URI
 
 `mysql://<host>:<port>/<db>?table=<table>` (credentials stripped) — e.g. `mysql://host:3306/app?table=orders`.
 
+## Feature flags
+
+This crate has no optional features of its own; enable it in the CLI/umbrella via the `sink-mysql` feature.
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause & fix |
+|---------|--------------------|
+| `MySQL pool acquire failed` / connection refused | Wrong `connection_url`, DB unreachable, or credentials rejected. Run `faucet doctor` — the sink's `SELECT 1` probe pinpoints connectivity vs auth. |
+| `Packet too large` / `max_allowed_packet` error | A single `INSERT` exceeded the server limit. Lower `batch_size` (or set a smaller upstream page size when using `batch_size: 0`), or raise the server's `max_allowed_packet`. |
+| Records silently not written in AutoMap mode | The record's keys don't match any existing column (extra keys are ignored; a record with **no** matching keys is skipped with a warning). Confirm the table columns match the JSON keys, or switch to JSON column mode. |
+| `upsert`/`delete` rejected at validate time | `write_mode: upsert`/`delete` requires `column_mapping: auto_map` and a non-empty `key`. Fix the config; `faucet validate` catches this before any run. |
+| Upsert updates nothing / inserts duplicates | The table has no PRIMARY/UNIQUE index on the `key` columns, so `ON DUPLICATE KEY UPDATE` never detects a conflict. Add the index. |
+| `mysql upsert: row N: ...` (missing/null key) | A record had a null/absent key column. Add a `dlq:` block to route those rows per-row, or fix upstream. |
+| Exactly-once config rejected | `delivery: exactly_once` requires a CDC source, an idempotent sink (this one), a `state:` block, and **no** DLQ. All four are validated at load time. |
+| Numbers stored as text in AutoMap mode | Values bind by JSON type. A numeric column receiving a JSON string stores text. Cast upstream with a transform, or send JSON numbers. |
+
+## See also
+
+- [Sinks reference](https://pawansikawat.github.io/faucet-stream/reference/connectors.html) — capability matrix.
+- [Upsert cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/upsert.html) — write modes & `cdc_unwrap`.
+- [State & exactly-once cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/state.html) — resumable and exactly-once runs.
+- [`faucet-source-mysql`](https://crates.io/crates/faucet-source-mysql) · [`faucet-source-mysql-cdc`](https://crates.io/crates/faucet-source-mysql-cdc) — the MySQL query and CDC sources.
+
 ## License
 
-Licensed under MIT or Apache-2.0.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/sink/parquet/README.md
+++ b/crates/sink/parquet/README.md
@@ -1,197 +1,308 @@
 # faucet-sink-parquet
 
-Apache Parquet file sink connector for [faucet-stream](https://github.com/PawanSikawat/faucet-stream).
+[![Crates.io](https://img.shields.io/crates/v/faucet-sink-parquet.svg)](https://crates.io/crates/faucet-sink-parquet)
+[![Docs.rs](https://docs.rs/faucet-sink-parquet/badge.svg)](https://docs.rs/faucet-sink-parquet)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-sink-parquet.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-sink-parquet.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-Writes JSON records as columnar Parquet files to a local filesystem path or
-an S3 bucket. Schema is inferred from the first batch (or supplied
-explicitly), every field is nullable so missing keys round-trip as `NULL`,
-and large outputs can be rolled over to multiple files by row count or byte
-budget.
+Apache **Parquet** file sink for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem. Writes JSON records as columnar Parquet files to a **local filesystem path** or an **Amazon S3** bucket (or any S3-compatible service).
+
+Built on the `parquet` + `arrow` crates wired through `object_store`, so local and S3 share one streaming code path — records are decoded into Arrow `RecordBatch`es and paged through an `AsyncArrowWriter` with bounded buffering, never staging a whole file in memory. Reach for it to land pipeline output as a columnar data lake, partition large exports across many files, or feed downstream analytics engines (DuckDB, Spark, BigQuery external tables).
+
+## Feature highlights
+
+- **Local or S3** — write to a local file/directory or to S3 (and S3-compatible services like MinIO / LocalStack via `endpoint_url`).
+- **Schema inference on first batch** — the Arrow schema is learned from the opening batch; every field is forced nullable, so missing keys round-trip as `NULL`.
+- **Columnar compression** — `snappy` (default), `gzip`, `zstd`, `lz4`, or `uncompressed` — applied internally by the Parquet writer.
+- **Row & byte rollover** — split large outputs across multiple `<uuid>.parquet` files by row count (`max_rows_per_file`) or byte budget (`max_bytes_per_file`).
+- **Streaming writer** — one reused `object_store` client, bounded buffering, configurable `row_group_size` for read-back performance.
+- **Drops unknown fields** — fields not in the inferred schema are silently skipped with a one-shot `tracing::warn!` per field name.
+- **Flush-safe** — files become valid only when the footer is written; `flush()` (called automatically by the pipeline on success, error-unwind, and cooperative cancellation) commits the footer.
+
+## Installation
+
+```bash
+# As a library:
+cargo add faucet-sink-parquet
+
+# In the CLI (opt-in connector feature):
+cargo install faucet-cli --features sink-parquet
+```
+
+The `sink-parquet` feature is opt-in (not part of the CLI/umbrella defaults).
 
 ## Quick start
 
-```rust
-use faucet_core::Sink;
-use faucet_sink_parquet::{
-    ParquetCompression, ParquetSink, ParquetSinkConfig,
-};
-use serde_json::json;
-
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let cfg = ParquetSinkConfig::local("/tmp/events")
-        .compression(ParquetCompression::Snappy)
-        .max_rows_per_file(100_000);
-
-    let sink = ParquetSink::new(cfg).await?;
-    sink.write_batch(&[
-        json!({"id": 1, "name": "alice"}),
-        json!({"id": 2, "name": "bob"}),
-    ])
-    .await?;
-    // `flush()` writes the Parquet footer. Skipping it leaves no visible file.
-    sink.flush().await?;
-    Ok(())
-}
+```yaml
+# pipeline.yaml — faucet run pipeline.yaml
+version: 1
+pipeline:
+  source:
+    type: csv
+    config:
+      path: ./events.csv
+  sink:
+    type: parquet
+    config:
+      destination:
+        type: local_path
+        path: /var/lib/exports/events
+      compression: snappy
 ```
+
+```bash
+faucet run pipeline.yaml
+```
+
+Pointing `path` at a directory writes UUID-named files into it; pointing it at a `*.parquet` file writes a single file (only valid when no rollover thresholds are set — see [Rollover](#rollover)).
+
+## Configuration reference
+
+### Core
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `destination` | `ParquetDestination` | — *(required)* | Where to write — `local_path` or `s3` (see [Destinations](#destinations)). |
+| `schema` | `SchemaSource` | infer | How the Arrow schema is determined. Omit to infer from the first batch. `explicit` is reserved and currently errors. |
+| `compression` | enum | `snappy` | Column-data codec: `uncompressed` · `snappy` · `gzip` · `zstd` · `lz4`. See [Compression](#compression). |
+| `row_group_size` | int | `1048576` | Max rows per Parquet **row group**. Must be `> 0`. Larger groups favour read scan throughput. |
+
+### Rollover
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `max_rows_per_file` | int | *(none)* | Roll to a new file once the current writer has accepted this many rows. Must be `> 0` when set. |
+| `max_bytes_per_file` | int | *(none)* | Roll to a new file once the writer's estimated in-memory size exceeds this. Checked per batch (approximate — see below). Must be `> 0` when set. |
+
+### Batching
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `batch_size` | int | `1000` (`DEFAULT_BATCH_SIZE`) | Re-chunk incoming pages into this many records per internal write. **`0` = no batching** — pages pass through as-is. For Parquet, leaving this at the default (or `0`) is recommended. Capped at `MAX_BATCH_SIZE`. |
+
+### `schema` (`SchemaSource`)
+
+```yaml
+# Infer from the first batch, sampling up to N records (default 100):
+schema: { type: inferred, sample_size: 200 }
+```
+
+`type: explicit` is reserved for a future revision and currently returns a `Config` error.
 
 ## Destinations
 
+### Local filesystem — directory mode (UUID-suffixed files)
+
 ```yaml
-# Local filesystem — directory mode (UUID-suffixed files):
 destination:
   type: local_path
   path: /var/lib/exports/events
 ```
 
+### Local filesystem — single-file mode (no rollover thresholds)
+
 ```yaml
-# Local filesystem — single-file mode (no rollover thresholds set):
 destination:
   type: local_path
   path: /var/lib/exports/events.parquet
 ```
 
+### S3 (or any S3-compatible service)
+
 ```yaml
-# S3 (or any S3-compatible service via endpoint_url, e.g. MinIO/LocalStack):
 destination:
   type: s3
   bucket: my-bucket
-  prefix: events/
-  region: us-east-1
-  endpoint_url: http://localhost:4566   # optional
+  prefix: events/                       # each object is <prefix><uuid>.parquet
+  region: us-east-1                     # optional; defaults to the AWS chain
+  endpoint_url: http://localhost:4566   # optional; MinIO / LocalStack
   allow_http: true                      # required for http:// endpoints
 ```
 
-AWS credentials follow the standard `aws_config` chain (env vars, profile,
-instance metadata).
+| `ParquetS3Destination` field | Type | Default | Description |
+|------------------------------|------|---------|-------------|
+| `bucket` | string | — *(required)* | S3 bucket name. |
+| `prefix` | string | `""` | Key prefix for written objects. Empty writes to the bucket root. |
+| `region` | string | *(SDK default)* | AWS region. |
+| `endpoint_url` | string | *(none)* | Custom endpoint for S3-compatible services. |
+| `allow_http` | bool | `false` | Allow non-HTTPS endpoints. Required when `endpoint_url` is `http://`. |
+
+S3 credentials follow the standard `aws_config` / `object_store` AWS chain (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`, profile, instance metadata).
+
+## Examples
+
+### Roll over every million rows, zstd-compressed
+
+```yaml
+sink:
+  type: parquet
+  config:
+    destination: { type: local_path, path: /data/exports }
+    compression: zstd
+    max_rows_per_file: 1000000
+    row_group_size: 262144
+```
+
+### S3 export with a byte budget per file
+
+```yaml
+sink:
+  type: parquet
+  config:
+    destination:
+      type: s3
+      bucket: analytics-lake
+      prefix: events/dt=2026-06-16/
+      region: us-east-1
+    compression: snappy
+    max_bytes_per_file: 134217728   # ~128 MiB (approximate)
+```
+
+### Dated subdirectory via `${now.*}` interpolation
+
+```yaml
+sink:
+  type: parquet
+  config:
+    destination:
+      type: local_path
+      path: ./data/dt=${now.date}/events    # parent dirs auto-created
+    compression: gzip
+```
+
+The `${now.*}` tokens resolve to the run's clock (`faucet run` uses process-start UTC or `--clock`; `faucet schedule` uses the tick time). Missing parent directories are created automatically, so dated partition trees like `dt=2026-06-16/` work without pre-creating the path.
+
+### S3-compatible service (MinIO / LocalStack), one large file
+
+```yaml
+sink:
+  type: parquet
+  config:
+    destination:
+      type: s3
+      bucket: dev-bucket
+      prefix: out/
+      endpoint_url: http://localhost:9000
+      allow_http: true
+    batch_size: 0          # write upstream pages through as-is
+```
 
 ## Schema handling
 
-- **Inferred (default)** — the first batch is used to learn an Arrow schema
-  via `arrow_json::reader::infer_json_schema_from_iterator`. Up to 100
-  records by default (`SchemaSource::Inferred { sample_size }` overrides
-  this). All inferred fields are forced nullable.
-- **Explicit** — reserved (`SchemaSource::Explicit { }`); currently returns a
-  `Config` error.
-- **Missing fields** — recorded as Arrow `NULL` columns.
-- **Unknown fields** — silently dropped, with a one-shot `tracing::warn!` per
-  field name per batch.
-- **Type drift** — if a later batch sends a value whose JSON type disagrees
-  with the locked-in schema (e.g. int → string), `write_batch` returns
-  `FaucetError::Sink` naming the field, the schema's declared type, and the
-  drifting record's type.
+- **Inferred (default)** — the first batch is used to learn an Arrow schema via `arrow_json::reader::infer_json_schema_from_iterator`, sampling up to `sample_size` records (default `DEFAULT_SAMPLE_SIZE` = 100). All inferred fields are forced nullable.
+- **Missing fields** — absent keys are written as Arrow `NULL` columns.
+- **Unknown fields** — fields not present in the locked-in schema are silently dropped, with a one-shot `tracing::warn!` per field name.
+- **Type drift** — if a later batch sends a value whose JSON type disagrees with the locked-in schema (e.g. int → string), `write_batch` returns `FaucetError::Sink` naming the field, the schema's declared type, and the drifting record's type.
+- **Explicit schema** — reserved; currently returns a `Config` error.
 
 ## Rollover
 
-| Threshold              | Trigger                                              |
-|------------------------|------------------------------------------------------|
-| `max_rows_per_file`    | row count of the current writer >= limit             |
-| `max_bytes_per_file`   | `bytes_written + in_progress_size` >= limit          |
+| Threshold | Trigger |
+|-----------|---------|
+| `max_rows_per_file` | row count of the current writer ≥ limit |
+| `max_bytes_per_file` | estimated in-memory size ≥ limit |
 
-When either limit fires, the current Parquet writer is `close()`-d (writing
-the footer) and the next `write_batch` opens a fresh `<uuid>.parquet`. Both
-thresholds are checked after each batch, so the actual file size may
-slightly exceed the limit by one batch worth of data.
+When either limit fires, the current Parquet writer is closed (writing the footer) and the next `write_batch` opens a fresh `<uuid>.parquet`. Both thresholds are checked after each batch, so the actual file may exceed the limit by up to one batch.
 
-Setting neither produces a single file per sink instance (until `flush()`).
+> **`max_bytes_per_file` is approximate.** The threshold compares against an estimate of the *in-memory Arrow* size, not the on-disk Parquet size. Column encoding + compression usually make the actual file substantially smaller. Treat it as a soft target, not a hard byte cap.
 
-> **`max_bytes_per_file` is approximate.** The threshold compares against an
-> estimate of the *in-memory Arrow* size of what's been written, not the
-> on-disk Parquet size. Column encoding + compression (see [Compression](#compression))
-> usually make the actual file substantially smaller, and rollover happens at
-> batch granularity. Treat it as a soft target, not a hard byte cap.
-
-> **A fixed `*.parquet` local path + a rollover threshold can't coexist.**
-> Single-file mode (a `foo.parquet` destination) requires *no* rollover
-> thresholds. If you set `max_rows_per_file` / `max_bytes_per_file` alongside
-> a fixed `.parquet` path, the sink logs a warning and falls back to writing
-> UUID-named files into the parent directory (the fixed filename is ignored).
-> Use a directory destination when you want rollover.
-
-## Streaming and batching
-
-The sink accepts whatever the upstream pipeline hands it — the streaming
-runtime in `faucet-core` already caps per-call memory at the upstream
-source's `batch_size`. On top of that, the sink exposes its own `batch_size`
-knob that re-chunks every incoming page before it reaches the Arrow writer:
-
-| Config              | Default                          | Meaning                                              |
-|---------------------|----------------------------------|------------------------------------------------------|
-| `batch_size`        | `faucet_core::DEFAULT_BATCH_SIZE` | Re-chunk pages into this many records per write.    |
-| `batch_size = 0`    | n/a                              | "No batching" sentinel — pass pages through as-is.   |
-
-For Parquet (local or S3) the source-defined page size is usually optimal
-because the writer streams into the destination as one multipart upload and
-benefits from larger row groups. **Recommended: leave `batch_size` at `0` (or
-at its default) and let the upstream `batch_size` drive sizing.** Set a
-smaller value only if you have a specific reason to slice incoming pages
-finer than the upstream provides.
-
-The row/byte rollover thresholds (`max_rows_per_file`, `max_bytes_per_file`)
-are **independent of `batch_size`** and continue to work unchanged: when a
-chunk pushes the writer past either threshold, the current file is closed
-and the next chunk opens a fresh `<uuid>.parquet`.
+> **A fixed `*.parquet` local path + a rollover threshold can't coexist.** Single-file mode (a `foo.parquet` destination) requires *no* rollover thresholds. If you set `max_rows_per_file` / `max_bytes_per_file` alongside a fixed `.parquet` path, the sink logs a warning and falls back to writing UUID-named files into the parent directory. Use a directory destination when you want rollover.
 
 ## Compression
 
-| Codec          | Notes                                          |
-|----------------|------------------------------------------------|
-| `uncompressed` | Largest output, fastest writes.                |
-| `snappy`       | Default. Best balance of speed and size.       |
-| `gzip`         | Smaller than snappy, ~3-5x slower.             |
-| `zstd`         | Strong compression; default level.             |
-| `lz4`          | Maps to `LZ4_RAW` (the Parquet-spec variant).  |
+| Codec | Notes |
+|-------|-------|
+| `uncompressed` | Largest output, fastest writes. |
+| `snappy` | **Default.** Best balance of speed and size. |
+| `gzip` | Smaller than snappy, ~3–5× slower. |
+| `zstd` | Strong compression; default level. |
+| `lz4` | Maps to `LZ4_RAW` (the Parquet-spec variant). |
+
+Conservative (default) compression levels are used — every percent of CPU spent compressing is a percent the pipeline loses on throughput; post-process if you need maximum compression. This is **internal Parquet column compression** and is unrelated to the workspace-wide `compression` feature (file-level gzip/zstd wrappers), which this sink does not use.
+
+## Streaming and batching
+
+The sink accepts whatever the upstream pipeline hands it — the streaming runtime in `faucet-core` already caps per-call memory at the upstream source's `batch_size`. On top of that, the sink's own `batch_size` knob re-chunks every incoming page before it reaches the Arrow writer:
+
+- `batch_size` (default `1000`) — slice pages into this many records per internal write.
+- `batch_size: 0` — the "no batching" sentinel; pages pass through as-is.
+
+For Parquet (local or S3) the source-defined page size is usually optimal because the writer streams into the destination as one multipart upload and benefits from larger row groups. **Recommended: leave `batch_size` at its default (or `0`) and let the upstream `batch_size` drive sizing.** The row/byte rollover thresholds are **independent of `batch_size`** and continue to work unchanged.
 
 ## Flush semantics
 
-Parquet files are only valid once the trailing footer is written. The sink
-streams data into the destination as an `object_store` multipart upload, and
-the footer is emitted only when `flush()` is called (or when a row/byte
-threshold triggers automatic rollover). **If you drop the sink without
-calling `flush()`, no visible file is produced** — the upload is aborted by
-`object_store` so you never end up with a corrupt half-written object on
-disk or in S3.
+Parquet files are only valid once the trailing footer is written. The sink streams data into the destination as an `object_store` multipart upload, and the footer is emitted only when `flush()` is called (or when a row/byte threshold triggers automatic rollover). **If you drop the sink without calling `flush()`, no visible file is produced** — the upload is aborted by `object_store`, so you never end up with a corrupt half-written object on disk or in S3.
 
-Pipelines must therefore always call `flush()` at the end of their run.
-`faucet-core`'s streaming pipeline does this on the success path **and** on the
-error-unwind path. It also flushes on **cooperative cancellation**: when a run
-is cancelled via a `CancellationToken` (the `faucet serve` run-timeout / `POST
-/cancel` / shutdown, or the CLI's `on_error: stop`), the pipeline stops at the
-next page boundary and flushes, so the footer is written and the rows committed
-so far survive — rather than the whole file being orphaned by a dropped future
-(#146 H16). A sink stuck *mid-write* past the flush-grace window is still
-hard-dropped (and its file lost), so size pages so a single `write_batch` stays
-well within the grace.
+Pipelines must therefore always call `flush()` at the end of a run. `faucet-core`'s streaming pipeline does this on the success path **and** the error-unwind path. It also flushes on **cooperative cancellation**: when a run is cancelled via a `CancellationToken` (the `faucet serve` run-timeout / `POST /cancel` / shutdown, or the CLI's `on_error: stop`), the pipeline stops at the next page boundary and flushes, so the footer is written and the rows committed so far survive — rather than the whole file being orphaned by a dropped future (#146 H16). A sink stuck *mid-write* past the flush-grace window is still hard-dropped (and its file lost), so size pages so a single `write_batch` stays well within the grace.
 
-## Round-tripping with `faucet-source-parquet`
+## Config loading & schema introspection
 
-The companion source crate (issue #28) reads files produced by this sink
-back into JSON records using the same Arrow schema. Until both crates are
-released, the round-trip is validated against the raw `parquet` and `arrow`
-crates in this crate's own test suite.
+Config can be loaded from a YAML/JSON pipeline file (the 80% path), env vars, or a `.env` file via the helpers in `faucet_core::config`. Inspect the full JSON Schema with:
 
-## Performance
+```bash
+faucet schema sink parquet
+```
 
-On a recent MacBook Air (M-series, local SSD) writing 1,000,000 records of
-shape `{"id": i64, "name": utf8}` to a single Parquet file with Snappy
-compression takes well under 5 seconds. CI does not gate on this number,
-since runner hardware varies, but the goal informs every design decision:
-the writer reuses a single `object_store` client, batches records into
-`RecordBatch` via `arrow_json::Decoder`, and pages data through
-`AsyncArrowWriter` with bounded buffering.
+## Library usage
 
-## LocalStack / MinIO testing (future work)
+```rust,no_run
+use faucet_core::Sink;
+use faucet_sink_parquet::{ParquetCompression, ParquetSink, ParquetSinkConfig};
+use serde_json::json;
 
-The sink works against any S3-compatible service by setting `endpoint_url`
-and `allow_http: true`. We exercise the S3 code path in the test suite
-against `object_store::memory::InMemory` to avoid a network dependency on
-CI; running against a real LocalStack instance is straightforward and
-documented here for callers who want to verify the wire-level behavior.
+# async fn example() -> Result<(), Box<dyn std::error::Error>> {
+let cfg = ParquetSinkConfig::local("/tmp/events")
+    .compression(ParquetCompression::Snappy)
+    .max_rows_per_file(100_000);
+
+let sink = ParquetSink::new(cfg).await?;
+sink.write_batch(&[
+    json!({"id": 1, "name": "alice"}),
+    json!({"id": 2, "name": "bob"}),
+])
+.await?;
+// `flush()` writes the Parquet footer. Skipping it leaves no visible file.
+sink.flush().await?;
+# Ok(()) }
+```
+
+The builder methods (`compression`, `row_group_size`, `max_rows_per_file`, `max_bytes_per_file`, `schema`, `with_batch_size`) and the `ParquetSinkConfig::local(path)` / `ParquetSinkConfig::new(destination)` constructors all chain. Call `cfg.validate()` to fail fast on bad values before building the sink.
+
+## How it works
+
+The S3 (or local) `object_store` client is built once in `new()` and reused for the lifetime of the sink. Incoming JSON records are decoded into Arrow `RecordBatch`es via `arrow_json::Decoder` and paged through an `AsyncArrowWriter` with bounded buffering — the writer is opened lazily on the first batch so the schema is inferred from real data. Column data is written with the configured codec and `row_group_size`. Writing 1,000,000 rows of `{"id": i64, "name": utf8}` to a single Snappy file completes in well under 5 seconds on a recent laptop; throughput depends on row width, codec, and storage medium — benchmark with your own data.
+
+## Reading the output back
+
+Files produced by this sink are standard Apache Parquet and read back with any Parquet engine — DuckDB, Spark, pandas/pyarrow, BigQuery/Athena external tables — or with the companion [`faucet-source-parquet`](https://crates.io/crates/faucet-source-parquet) crate, which decodes them back to JSON records using the same Arrow schema. Because every inferred field is nullable, columns absent from some records read back as `NULL`.
 
 ## Lineage dataset URI
 
 `file://<path>` (local) or `s3://<bucket>/<prefix>` (S3) — e.g. `file:///tmp/output/` or `s3://my-bucket/data/`.
 
+## Feature flags
+
+This crate has no optional features of its own; enable it in the CLI/umbrella via the `sink-parquet` feature.
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause & fix |
+|---------|--------------------|
+| No file appears after a run | `flush()` was never called (the multipart upload was aborted on drop). Run via the faucet pipeline, which flushes on success/error/cancel; in library code call `sink.flush().await?`. |
+| `FaucetError::Config: row_group_size` | `row_group_size` is `0`. Set it to `≥ 1` (or omit to use the default). |
+| `FaucetError::Config` on `max_rows_per_file` / `max_bytes_per_file` | The threshold is `0`. Use `> 0`, or omit for single-file mode. |
+| `FaucetError::Config` on `destination` | Empty `path` (local) or empty `bucket` (S3). Provide a non-empty value. |
+| `FaucetError::Config` on `schema` | `type: explicit` is reserved/unsupported, or `inferred` `sample_size` is `0`. Use `inferred` with `sample_size ≥ 1`, or omit `schema`. |
+| `FaucetError::Sink` naming a field + two types | Type drift — a later batch's value type disagrees with the inferred schema. Cast the field upstream (e.g. a `cast` transform) so every record agrees. |
+| A field is missing from the output | It wasn't in the first batch (so not in the inferred schema) and was dropped — check the one-shot warn log. Ensure the schema-bearing fields appear in the opening records, or widen `sample_size`. |
+| Single-file `.parquet` path ignored; UUID files appear | You set a rollover threshold on a fixed `.parquet` path. Drop the threshold for single-file mode, or use a directory destination. |
+| S3 `403`/credential errors | Credentials missing from the AWS chain, or wrong region. Set `region` and the AWS env vars/profile. |
+| Connecting to MinIO/LocalStack fails | Set `endpoint_url` and `allow_http: true` (required for `http://` endpoints). |
+
+## See also
+
+- [Connector reference](https://pawansikawat.github.io/faucet-stream/reference/connectors.html) · [faucet-source-parquet](https://crates.io/crates/faucet-source-parquet) · [faucet-sink-s3](https://crates.io/crates/faucet-sink-s3)
+
 ## License
 
-MIT
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/sink/postgres/README.md
+++ b/crates/sink/postgres/README.md
@@ -5,151 +5,147 @@
 [![MSRV](https://img.shields.io/crates/msrv/faucet-sink-postgres.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
 [![License](https://img.shields.io/crates/l/faucet-sink-postgres.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-PostgreSQL sink connector for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
+PostgreSQL **sink** connector for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem. Writes JSON records to a Postgres table over a pooled `sqlx` connection, batching them into multi-row `INSERT` statements for high throughput.
 
-Writes JSON records to a PostgreSQL table using either JSONB column mode (storing each record as a single `jsonb` value) or AutoMap mode (mapping top-level JSON keys directly to table columns). Uses connection pooling via `sqlx` and efficient multi-row `INSERT` statements.
+Reach for it whenever you want to land a faucet-stream source — a REST API, a CDC stream, a file, a queue — into Postgres with one declarative config and no glue code. Store records verbatim as a single `jsonb` column for schemaless ingestion, or map JSON keys straight onto typed table columns. With `write_mode: upsert` and a CDC source it becomes a live mirror; with `delivery: exactly_once` it commits records and a watermark in one transaction.
 
-`write_batch` accepts whatever slice the pipeline hands it. When `batch_size > 0` and the slice is larger than `batch_size`, the sink re-chunks internally and issues one multi-row `INSERT` per chunk; when `batch_size = 0`, the entire slice is sent in a single `INSERT` — see [Streaming and batching](#streaming-and-batching) for the tradeoffs.
+## Feature highlights
+
+- **Two column-mapping modes** — **JSONB** stores each record as a single `jsonb` value (schemaless ingestion, query later with JSON operators); **AutoMap** maps top-level JSON keys directly onto typed table columns discovered from the Postgres catalog.
+- **Multi-row `INSERT` batching** — each page is written with one multi-row `INSERT` per chunk; JSONB mode uses `unnest($1::jsonb[])`, AutoMap binds per-column casts. Auto-splits to stay under Postgres' 65 535 bind-parameter ceiling.
+- **Write modes: upsert & delete** — merge or remove rows by key via `INSERT … ON CONFLICT (key) DO UPDATE` (AutoMap + a `UNIQUE`/`PRIMARY KEY` on the key columns required). Last-write-wins de-dup within a batch.
+- **Exactly-once delivery** — records and a monotonic commit token UPSERT into a `_faucet_commit_token` watermark table inside the **same transaction**; resume skips already-committed pages.
+- **Dead-letter queue** — per-row partial writes route missing/null-key rows to a configured DLQ while good rows still commit.
+- **Connection pooling** — one `sqlx::PgPool` built once in `new()` and reused for every batch; `max_connections` is configurable.
+- **Schema-qualified targets** — optional `schema` scopes both column discovery and the `INSERT` target, so a same-named table in another schema can't pollute the AutoMap column set.
+- **Credential-safe logging** — the `Debug` impl masks `connection_url` with `***`.
 
 ## Installation
 
 ```bash
+# As a library:
 cargo add faucet-sink-postgres
 cargo add tokio --features full
+
+# Or via the umbrella crate:
+cargo add faucet-stream --features sink-postgres
+
+# In the CLI (opt-in connector feature):
+cargo install faucet-cli --features sink-postgres
 ```
 
-Or via the umbrella crate:
+## Quick start
+
+```yaml
+# pipeline.yaml — faucet run pipeline.yaml
+version: 1
+pipeline:
+  source:
+    type: rest
+    config:
+      base_url: https://api.example.com
+      endpoint: /v1/users
+  sink:
+    type: postgres
+    config:
+      connection_url: postgres://writer:pass@localhost:5432/app
+      table_name: users
+      column_mapping: auto_map
+```
 
 ```bash
-cargo add faucet-stream --features sink-postgres
+faucet run pipeline.yaml
 ```
 
-## Quick Start
+## Configuration reference
 
-```rust
-use faucet_sink_postgres::{PostgresSink, PostgresSinkConfig};
-use faucet_core::Sink;
-use serde_json::json;
-
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let config = PostgresSinkConfig::new(
-        "postgres://user:password@localhost:5432/mydb",
-        "events",
-    );
-
-    let sink = PostgresSink::new(config).await?;
-
-    let records = vec![
-        json!({"user_id": "u123", "event": "signup", "metadata": {"source": "web"}}),
-        json!({"user_id": "u456", "event": "login", "metadata": {"source": "mobile"}}),
-    ];
-
-    let rows_written = sink.write_batch(&records).await?;
-    println!("Wrote {rows_written} rows");
-
-    Ok(())
-}
-```
-
-## Configuration
+### Core
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `connection_url` | `String` | *(required)* | PostgreSQL connection URL (e.g. `postgres://user:pass@host:5432/db`) |
-| `table_name` | `String` | *(required)* | Target table name |
-| `schema` | `Option<String>` | `null` | Schema (namespace) qualifying `table_name`. When set, both AutoMap column discovery and the `INSERT` target `schema.table_name` explicitly. When unset, the table resolves against the connection's `search_path` |
-| `column_mapping` | `PostgresColumnMapping` | `Jsonb { column: "data" }` | How to map JSON records to table columns (see below) |
-| `batch_size` | `usize` | `1000` | Maximum rows per multi-row `INSERT`. See [Streaming and batching](#streaming-and-batching) below |
-| `max_connections` | `u32` | `5` | Maximum number of connections in the connection pool |
+| `connection_url` | string | — *(required)* | PostgreSQL connection URL, e.g. `postgres://user:pass@host:5432/db`. Masked in logs. |
+| `table_name` | string | — *(required)* | Target table name. |
+| `schema` | string | *(unset)* | Schema (namespace) qualifying `table_name`. When set, both AutoMap column discovery and the `INSERT` target `schema.table_name` explicitly. When unset, the table resolves against the connection's `search_path`. |
+| `column_mapping` | `PostgresColumnMapping` | `{ jsonb: { column: "data" } }` | How to map JSON records to columns — see [Column mapping](#column-mapping). |
 
-The `Debug` implementation masks the `connection_url` with `***` to prevent credential leakage in logs.
-
-### Streaming and batching
-
-The PostgreSQL sink re-chunks each incoming `StreamPage` so individual
-multi-row `INSERT` statements stay well under Postgres' per-statement
-bind-parameter limit.
-
-- **`batch_size > 0`** (default `1000`) — the sink slices the incoming
-  slice into `batch_size`-row chunks and issues one multi-row `INSERT`
-  per chunk. **Recommended value is `1000`**: Postgres' multi-row
-  `INSERT` sweet spot. Larger chunks rarely add throughput. AutoMap mode
-  binds one parameter per column per row; the sink now splits each chunk
-  further so `rows × columns` never exceeds Postgres' 65 535 bind-parameter
-  ceiling, so a wide table no longer causes the server to reject the
-  statement regardless of `batch_size`. JSONB mode binds a single `jsonb[]`
-  array regardless of row count.
-- **`batch_size = 0`** — the "no batching" sentinel. The entire upstream
-  `StreamPage` is forwarded in a single logical write. Use this when the
-  source already emits page sizes tuned for Postgres — for example a
-  REST source with `batch_size: 1000` feeding a JSONB table. AutoMap still
-  sub-splits internally to respect the 65 535-parameter ceiling.
-
-`batch_size` is purely a chunk-size knob — connection pooling, identifier
-quoting, and JSONB vs AutoMap behaviour are unchanged.
-
-### Column Mapping (`PostgresColumnMapping`)
-
-| Variant | Description |
-|---------|-------------|
-| `Jsonb { column }` | Insert each record as a single `jsonb` column. The column name defaults to `"data"` but can be overridden. Uses PostgreSQL's `unnest($1::jsonb[])` for efficient batch inserts. |
-| `AutoMap` | Map top-level JSON keys directly to table columns. Column names are discovered from the PostgreSQL catalog, scoped (via `to_regclass`) to exactly the relation the `INSERT` targets — the configured `schema` if set, otherwise the `search_path`-resolved table. Only keys that match existing columns are inserted; extra keys are silently ignored. Records with no matching keys are skipped with a warning. |
-
-### Builder Methods
-
-```rust
-use faucet_sink_postgres::{PostgresSinkConfig, PostgresColumnMapping};
-
-// JSONB mode with custom column name
-let config = PostgresSinkConfig::new("postgres://localhost/mydb", "events")
-    .column_mapping(PostgresColumnMapping::Jsonb { column: "payload".into() })
-    .with_batch_size(1000)
-    .max_connections(10);
-
-// AutoMap mode
-let config = PostgresSinkConfig::new("postgres://localhost/mydb", "events")
-    .column_mapping(PostgresColumnMapping::AutoMap)
-    .with_batch_size(250);
-```
-
-## Write modes (upsert / delete)
-
-By default the sink **appends** every record. Set `write_mode` to `upsert` or
-`delete` to merge or remove rows by a key instead.
+### Batching
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `write_mode` | `"append" \| "upsert" \| "delete"` | `"append"` | How records are applied. |
-| `key` | `[String]` | `[]` | Key columns identifying a row. **Required and non-empty** for `upsert`/`delete`. Composite keys are supported. |
-| `delete_marker` | `{ field, values: [String] }` | *(none)* | **Upsert only.** Records whose `field` equals one of `values` are deleted by key; all others are upserts. The marker field is stripped from upserted rows before writing. |
+| `batch_size` | int | `1000` | Maximum rows per multi-row `INSERT`. **`0` = no batching** — the whole page is sent in one statement. See [Streaming & batching](#streaming--batching). |
+| `max_connections` | int | `5` | Maximum connections in the `sqlx` pool. |
 
-Requirements (validated in `PostgresSink::new`, before any connection is made):
+### Write mode
 
-- **`column_mapping: auto_map` is required.** Upsert/delete match on real
-  columns, so the key columns must be table columns — not fields buried inside
-  a JSONB blob.
-- **The `key` columns must carry a `UNIQUE` or `PRIMARY KEY` constraint**, since
-  upsert is implemented with `INSERT … ON CONFLICT (key) DO UPDATE SET …`
-  (non-key columns are set from `EXCLUDED`; if every column is a key column the
-  clause degrades to `DO NOTHING`). Without the constraint Postgres rejects the
-  `ON CONFLICT` target.
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `write_mode` | `"append" \| "upsert" \| "delete"` | `"append"` | How records are applied. See [Write modes](#write-modes-upsert--delete). |
+| `key` | `[string]` | `[]` | Key columns identifying a row. **Required and non-empty** for `upsert`/`delete`. Composite keys are supported. |
+| `delete_marker` | `{ field, values: [string] }` | *(none)* | **Upsert only.** Records whose `field` equals one of `values` are deleted by key; all others are upserts. The marker field is stripped from upserted rows before writing. |
 
-Semantics:
+### Column mapping
 
-- **Last-write-wins within a batch.** When the same key appears multiple times
-  in one `write_batch` call, the records are de-duplicated to a single
-  effective action (the final one), so a single statement never hits the same
-  `ON CONFLICT` target twice. A delete after an upsert (or vice-versa) for the
-  same key resolves to whichever came last.
-- **`write_mode: delete`** routes every record to a delete by key.
-- A record missing a key column (or with a `null` key value) fails with a typed
-  `Sink` error. When a `dlq:` block is configured the good rows are still
-  written (upserts + deletes applied) and only the missing/null-key rows are
-  routed to the DLQ per-row; without a DLQ the whole batch fails. Keys should be
-  present and non-null.
+`column_mapping` is the adjacently-tagged `PostgresColumnMapping` enum:
 
-### Example YAML config
+| Variant | YAML | Description |
+|---------|------|-------------|
+| `Jsonb { column }` | `{ jsonb: { column: data } }` | Insert each record as a single `jsonb` column (default name `"data"`). Uses `unnest($1::jsonb[])` for efficient batch inserts. |
+| `AutoMap` | `auto_map` | Map top-level JSON keys directly to table columns. Column names + types are discovered from the catalog, scoped (via `to_regclass`) to exactly the relation the `INSERT` targets. Only keys matching existing columns are inserted; extra keys are silently ignored. Records with no matching keys are skipped with a warning. |
+
+## Examples
+
+### JSONB mode — store entire records in one column
+
+Ideal for schemaless ingestion: store raw JSON and query it later with Postgres' JSONB operators.
+
+```sql
+CREATE TABLE raw_events (
+    id         SERIAL PRIMARY KEY,
+    data       JSONB NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+```
+
+```yaml
+sink:
+  type: postgres
+  config:
+    connection_url: postgres://writer:s3cret@db.example.com:5432/analytics
+    table_name: raw_events
+    column_mapping:
+      jsonb:
+        column: data
+    batch_size: 1000
+    max_connections: 5
+```
+
+### AutoMap mode — map JSON keys to typed columns
+
+Discovers column names and types from the table schema and maps matching JSON keys. A field present only in some records is still written; rows missing a column bind SQL `NULL`.
+
+```sql
+CREATE TABLE events (
+    user_id   TEXT,
+    event     TEXT,
+    timestamp TIMESTAMPTZ,
+    amount    NUMERIC
+);
+```
+
+```yaml
+sink:
+  type: postgres
+  config:
+    connection_url: postgres://writer:s3cret@db.example.com:5432/analytics
+    table_name: events
+    column_mapping: auto_map
+    batch_size: 1000
+    max_connections: 10
+```
+
+### CDC mirror — upsert with a delete marker
+
+Pair a CDC source (run through the `cdc_unwrap` transform) with `write_mode: upsert` to keep a destination table in lock-step with the source.
 
 ```yaml
 pipeline:
@@ -172,183 +168,58 @@ pipeline:
         values: [d]
 ```
 
-The destination table must define the key as a constraint, e.g.
-`CREATE TABLE users (id INT PRIMARY KEY, name TEXT, email TEXT)`.
+The destination must define the key as a constraint, e.g. `CREATE TABLE users (id INT PRIMARY KEY, name TEXT, email TEXT)`.
 
-## Config Loading
+### High-throughput pool
 
-```rust
-use faucet_core::config::{load_json, load_env_file};
-use faucet_sink_postgres::PostgresSinkConfig;
-
-// From a JSON file
-let config: PostgresSinkConfig = load_json("config.json")?;
-
-// From an .env file with a prefix
-let config: PostgresSinkConfig = load_env_file(".env", "PG_SINK")?;
+```yaml
+sink:
+  type: postgres
+  config:
+    connection_url: postgres://writer:pass@db-primary.internal:5432/warehouse
+    table_name: metrics
+    column_mapping: auto_map
+    max_connections: 20
+    batch_size: 1000
 ```
 
-### Example JSON config (JSONB mode)
+## Streaming & batching
 
-```json
-{
-  "connection_url": "postgres://writer:s3cret@db.example.com:5432/analytics",
-  "table_name": "raw_events",
-  "column_mapping": {
-    "jsonb": {
-      "column": "data"
-    }
-  },
-  "batch_size": 1000,
-  "max_connections": 5
-}
-```
+The sink re-chunks each incoming `StreamPage` so individual multi-row `INSERT` statements stay well under Postgres' per-statement bind-parameter limit.
 
-### Example JSON config (AutoMap mode)
+- **`batch_size > 0`** (default `1000`) — slice the incoming page into `batch_size`-row chunks, one multi-row `INSERT` per chunk. **`1000` is the recommended value** — Postgres' multi-row `INSERT` sweet spot. AutoMap binds one parameter per column per row; the sink sub-splits each chunk further so `rows × columns` never exceeds Postgres' 65 535 bind-parameter ceiling, so a wide table never causes a rejected statement. JSONB mode binds a single `jsonb[]` array regardless of row count.
+- **`batch_size = 0`** — the "no batching" sentinel: the entire upstream page is forwarded in a single logical write. Use it when the source already emits Postgres-tuned page sizes. AutoMap still sub-splits internally to respect the 65 535-parameter ceiling.
 
-```json
-{
-  "connection_url": "postgres://writer:s3cret@db.example.com:5432/analytics",
-  "table_name": "events",
-  "column_mapping": "auto_map",
-  "batch_size": 1000,
-  "max_connections": 10
-}
-```
+`batch_size` is purely a chunk-size knob — connection pooling, identifier quoting, and JSONB vs AutoMap behaviour are unchanged.
 
-### Example .env file
+## Write modes (upsert / delete)
 
-```env
-PG_SINK_CONNECTION_URL=postgres://writer:s3cret@db.example.com:5432/analytics
-PG_SINK_TABLE_NAME=raw_events
-PG_SINK_COLUMN_MAPPING='{"jsonb":{"column":"data"}}'
-PG_SINK_BATCH_SIZE=1000
-PG_SINK_MAX_CONNECTIONS=5
-```
+By default the sink **appends** every record. Set `write_mode` to `upsert` or `delete` to merge or remove rows by a key instead.
 
-## Config Schema Introspection
+Requirements (validated in `PostgresSink::new`, before any connection is made):
 
-```rust
-use faucet_core::Sink;
+- **`column_mapping: auto_map` is required.** Upsert/delete match on real columns, so the key columns must be table columns — not fields buried inside a JSONB blob.
+- **The `key` columns must carry a `UNIQUE` or `PRIMARY KEY` constraint**, since upsert is implemented with `INSERT … ON CONFLICT (key) DO UPDATE SET …` (non-key columns set from `EXCLUDED`; if every column is a key column the clause degrades to `DO NOTHING`). Without the constraint Postgres rejects the `ON CONFLICT` target.
 
-let sink = PostgresSink::new(config).await?;
-let schema = sink.config_schema();
-println!("{}", serde_json::to_string_pretty(&schema)?);
-```
+Semantics:
 
-## Pipeline Usage
+- **Last-write-wins within a batch.** When the same key appears multiple times in one `write_batch` call, the records are de-duplicated to a single effective action (the final one), so a single statement never hits the same `ON CONFLICT` target twice. A delete after an upsert (or vice-versa) for the same key resolves to whichever came last.
+- **`write_mode: delete`** routes every record to a delete by key.
+- A record missing a key column (or with a `null` key value) fails with a typed `Sink` error. When a `dlq:` block is configured the good rows are still written (upserts + deletes applied) and only the missing/null-key rows are routed to the DLQ per-row; without a DLQ the whole batch fails.
 
-```rust
-use faucet_core::Pipeline;
-use faucet_source_rest::{RestStream, RestStreamConfig};
-use faucet_sink_postgres::{PostgresSink, PostgresSinkConfig, PostgresColumnMapping};
-
-let source_config = RestStreamConfig::new("https://api.example.com", "/v1/users");
-let source = RestStream::new(source_config);
-
-let sink_config = PostgresSinkConfig::new(
-    "postgres://writer:pass@localhost:5432/app",
-    "users",
-)
-.column_mapping(PostgresColumnMapping::AutoMap);
-
-let sink = PostgresSink::new(sink_config).await?;
-
-let result = Pipeline::new(source, sink).run().await?;
-println!("Transferred {} records", result.records_written);
-```
-
-## Examples
-
-### JSONB mode -- store entire records in a single column
-
-This mode is ideal for schemaless ingestion where you want to store raw JSON and query it later with PostgreSQL's JSONB operators.
-
-```sql
--- Table schema
-CREATE TABLE raw_events (
-    id SERIAL PRIMARY KEY,
-    data JSONB NOT NULL,
-    created_at TIMESTAMPTZ DEFAULT NOW()
-);
-```
-
-```rust
-let config = PostgresSinkConfig::new(
-    "postgres://localhost/analytics",
-    "raw_events",
-)
-.column_mapping(PostgresColumnMapping::Jsonb { column: "data".into() })
-.with_batch_size(1000)
-.max_connections(5);
-
-let sink = PostgresSink::new(config).await?;
-sink.write_batch(&records).await?;
-```
-
-### AutoMap mode -- map JSON keys to table columns
-
-This mode automatically discovers column names from the table schema and maps matching JSON keys. Columns use SQL-injection-safe quoted identifiers.
-
-```sql
--- Table schema
-CREATE TABLE events (
-    user_id TEXT,
-    event TEXT,
-    timestamp TIMESTAMPTZ,
-    amount NUMERIC
-);
-```
-
-```rust
-let config = PostgresSinkConfig::new(
-    "postgres://localhost/analytics",
-    "events",
-)
-.column_mapping(PostgresColumnMapping::AutoMap)
-.with_batch_size(1000)
-.max_connections(10);
-
-let sink = PostgresSink::new(config).await?;
-
-let records = vec![
-    json!({"user_id": "u1", "event": "purchase", "amount": 29.99}),
-    json!({"user_id": "u2", "event": "signup"}),  // missing "amount" will be null
-];
-sink.write_batch(&records).await?;
-```
-
-### Connection pooling for high-throughput workloads
-
-```rust
-let config = PostgresSinkConfig::new(
-    "postgres://writer:pass@db-primary.internal:5432/warehouse",
-    "metrics",
-)
-.max_connections(20)
-.with_batch_size(1000);
-
-let sink = PostgresSink::new(config).await?;
-```
-
-## How It Works
-
-- A connection pool is created in `PostgresSink::new()` using `sqlx::PgPool` with the configured `max_connections`.
-- `write_batch()` slices records into chunks of `batch_size` (or forwards the whole slice when `batch_size = 0`) and inserts each chunk using a single multi-row INSERT statement.
-- In JSONB mode, inserts use `INSERT INTO table (col) SELECT * FROM unnest($1::jsonb[])` for maximum efficiency.
-- In AutoMap mode, each column's name **and underlying type** (`udt_name`) are queried from the PostgreSQL catalog, scoped via `to_regclass` to exactly the relation the `INSERT` targets (the configured `schema`, else the `search_path`-resolved table) — so a same-named table in another schema can't pollute the column set. A multi-row `INSERT INTO ... VALUES ($1::int4, $2::timestamptz), ...` is built dynamically with a per-column cast, and each value is bound as text so the destination column's input function parses it — numbers, booleans, timestamps, uuids land in their native column types, and `json`/`jsonb` columns receive JSON text. (Values are **not** bound as `jsonb` regardless of column type — doing so previously made the typed-column example above fail at runtime.) The column set is the **union** of record keys across the batch (in declared table order), so a field present only in a later record is still written; a row missing a column binds SQL `NULL`.
-- All identifiers (table names, column names) are quoted using `quote_ident()` to prevent SQL injection.
+The `cdc_unwrap` transform pairs naturally with upsert — it normalizes a CDC envelope into a flat row plus a `__op` marker (`"u"`/`"d"`) that the `delete_marker` matches. See the [upsert cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/upsert.html).
 
 ## Exactly-once delivery
 
 `PostgresSink` implements `Sink::supports_idempotent_writes` (returns `true`) and the two companion hooks:
 
 - `write_batch_idempotent(records, scope, token)` — writes `records` and UPSERTs the `token` into a `_faucet_commit_token(scope TEXT, token TEXT)` watermark table inside the **same transaction**, so both either commit together or neither does.
-- `last_committed_token(scope)` — reads the current watermark to let the pipeline skip already-committed pages on resume.
+- `last_committed_token(scope)` — reads the current watermark so the pipeline skips already-committed pages on resume.
 
-To use exactly-once delivery, set `delivery: exactly_once` in your pipeline config and pair this sink with one of the CDC sources (`postgres-cdc`, `mysql-cdc`, `mongodb-cdc`) plus a `state:` block. A DLQ is not permitted in exactly-once mode. All four requirements are validated at config-load time (`faucet validate`) before any run starts.
+To use exactly-once delivery, set `delivery: exactly_once` and pair this sink with a CDC source (`postgres-cdc`, `mysql-cdc`, `mongodb-cdc`) plus a `state:` block. A DLQ is not permitted in exactly-once mode. All four requirements are validated at config-load time (`faucet validate`) before any run starts.
 
 ```yaml
+version: 1
 pipeline:
   source:
     type: postgres-cdc
@@ -369,12 +240,124 @@ pipeline:
 delivery: exactly_once
 ```
 
-See the [Exactly-once delivery cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/state.html#exactly-once-delivery) for full rationale and the supported source/sink set.
+`delivery: exactly_once` and `write_mode: upsert` compose — the upsert and the commit-token UPSERT commit in the same transaction. See the [exactly-once delivery cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/state.html#exactly-once-delivery).
+
+## Dead-letter queue
+
+The sink overrides `Sink::write_batch_partial`, so when a `dlq:` block is configured the router gets per-row outcomes: good rows commit and only the failing rows (e.g. missing/null key columns under `write_mode: upsert`/`delete`) are wrapped in a DLQ envelope and routed to the DLQ sink — the batch is not aborted. Without a DLQ, a row failure fails the whole batch. See the [DLQ cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/dlq.html).
+
+## Config loading & schema introspection
+
+Load from YAML/JSON, environment variables, or a `.env` file via `faucet_core::config`:
+
+```rust
+use faucet_core::config::{load_json, load_env_file};
+use faucet_sink_postgres::PostgresSinkConfig;
+
+let config: PostgresSinkConfig = load_json("config.json")?;
+let config: PostgresSinkConfig = load_env_file(".env", "PG_SINK")?;
+```
+
+```env
+# .env (prefix PG_SINK)
+PG_SINK_CONNECTION_URL=postgres://writer:s3cret@db.example.com:5432/analytics
+PG_SINK_TABLE_NAME=raw_events
+PG_SINK_COLUMN_MAPPING='{"jsonb":{"column":"data"}}'
+PG_SINK_BATCH_SIZE=1000
+PG_SINK_MAX_CONNECTIONS=5
+```
+
+Inspect the full JSON Schema with:
+
+```bash
+faucet schema sink postgres
+```
+
+## Library usage
+
+```rust
+use faucet_core::{Pipeline, Sink};
+use faucet_sink_postgres::{PostgresColumnMapping, PostgresSink, PostgresSinkConfig};
+use serde_json::json;
+
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let config = PostgresSinkConfig::new("postgres://writer:pass@localhost:5432/app", "events")
+    .column_mapping(PostgresColumnMapping::AutoMap)
+    .with_batch_size(1000)
+    .max_connections(10);
+
+let sink = PostgresSink::new(config).await?;
+
+let records = vec![
+    json!({"user_id": "u1", "event": "purchase", "amount": 29.99}),
+    json!({"user_id": "u2", "event": "signup"}), // missing "amount" → NULL
+];
+let rows = sink.write_batch(&records).await?;
+println!("wrote {rows} rows");
+# Ok(())
+# }
+```
+
+Drive it from a full pipeline:
+
+```rust
+use faucet_core::Pipeline;
+use faucet_source_rest::{RestStream, RestStreamConfig};
+use faucet_sink_postgres::{PostgresColumnMapping, PostgresSink, PostgresSinkConfig};
+
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let source = RestStream::new(RestStreamConfig::new("https://api.example.com", "/v1/users"));
+let sink = PostgresSink::new(
+    PostgresSinkConfig::new("postgres://writer:pass@localhost:5432/app", "users")
+        .column_mapping(PostgresColumnMapping::AutoMap),
+)
+.await?;
+
+let result = Pipeline::new(source, sink).run().await?;
+println!("transferred {} records", result.records_written);
+# Ok(())
+# }
+```
+
+## How it works
+
+- A `sqlx::PgPool` is created once in `PostgresSink::new()` with the configured `max_connections` and reused for every batch.
+- `write_batch()` slices records into `batch_size` chunks (or forwards the whole slice when `batch_size = 0`) and inserts each chunk with a single multi-row `INSERT`.
+- **JSONB mode** inserts via `INSERT INTO table (col) SELECT * FROM unnest($1::jsonb[])` — one bound array, no per-row parameters.
+- **AutoMap mode** queries each column's name **and underlying type** (`udt_name`) from the catalog, scoped via `to_regclass` to exactly the relation the `INSERT` targets (the configured `schema`, else the `search_path`-resolved table). A multi-row `INSERT INTO ... VALUES ($1::int4, $2::timestamptz), ...` is built dynamically with a per-column cast; each value is bound as text so the destination column's input function parses it — numbers, booleans, timestamps, uuids, and `json`/`jsonb` columns all land in their native types. The column set is the **union** of record keys across the batch (in declared table order); a row missing a column binds SQL `NULL`.
+- All identifiers (table + column names) are quoted with `quote_ident()` to prevent SQL injection.
 
 ## Lineage dataset URI
 
 `postgres://<host>:<port>/<db>?table=<schema.table>` (credentials stripped) — e.g. `postgres://host:5432/app?table=public.orders`.
 
+## Feature flags
+
+This crate has no optional features of its own; enable it in the CLI/umbrella via the `sink-postgres` feature.
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause & fix |
+|---------|--------------------|
+| Connection refused / auth failed | Check the `connection_url` host/port/credentials and that the role can connect to the target database. The URL is masked in logs, so verify it in the config. |
+| `Sink` error: upsert/delete requires `auto_map` | `write_mode: upsert`/`delete` only works in AutoMap mode. Set `column_mapping: auto_map`. |
+| `ON CONFLICT` rejected / no unique constraint | The `key` columns need a `UNIQUE` or `PRIMARY KEY` constraint on the table. Add one, e.g. `ALTER TABLE t ADD PRIMARY KEY (id)`. |
+| `key` empty for upsert/delete | `key` must be non-empty for `upsert`/`delete`. List the key column(s), e.g. `key: [id]`. |
+| Rows silently dropped (AutoMap) | A record had no keys matching existing columns — logged as a warning. Verify the JSON keys match column names (case-sensitive). Extra keys are ignored by design. |
+| Wrong table picked up | A same-named table exists in another schema on the `search_path`. Set `schema:` explicitly to disambiguate. |
+| Statement rejected with too many parameters | Hit the 65 535 bind-parameter ceiling. AutoMap auto-splits to stay under it; if you still see this, lower `batch_size` (very wide tables). |
+| Missing/null key rows fail the whole batch | Without a `dlq:` block, a row missing a key column aborts the batch. Configure a DLQ to route just the bad rows, or ensure keys are present and non-null. |
+| Exactly-once config rejected at validate | Exactly-once requires a CDC source + idempotent sink + `state:` block + no `dlq:`. `faucet validate` names the missing requirement. |
+
+## See also
+
+- [Sinks reference](https://pawansikawat.github.io/faucet-stream/reference/connectors.html) — capability matrix across all connectors.
+- [Upsert cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/upsert.html) — write modes and CDC mirroring.
+- [Exactly-once delivery](https://pawansikawat.github.io/faucet-stream/cookbook/state.html#exactly-once-delivery) — state, watermarks, supported source/sink set.
+- [Dead-letter queue cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/dlq.html) — routing bad rows.
+- [`faucet-source-postgres`](https://crates.io/crates/faucet-source-postgres) — the matching query source.
+- [`faucet-source-postgres-cdc`](https://crates.io/crates/faucet-source-postgres-cdc) — the CDC source that pairs with upsert/exactly-once.
+
 ## License
 
-Licensed under MIT or Apache-2.0.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/sink/postgres/README.md
+++ b/crates/sink/postgres/README.md
@@ -2,6 +2,8 @@
 
 [![Crates.io](https://img.shields.io/crates/v/faucet-sink-postgres.svg)](https://crates.io/crates/faucet-sink-postgres)
 [![Docs.rs](https://docs.rs/faucet-sink-postgres/badge.svg)](https://docs.rs/faucet-sink-postgres)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-sink-postgres.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-sink-postgres.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
 PostgreSQL sink connector for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
 

--- a/crates/sink/redis/README.md
+++ b/crates/sink/redis/README.md
@@ -2,6 +2,8 @@
 
 [![Crates.io](https://img.shields.io/crates/v/faucet-sink-redis.svg)](https://crates.io/crates/faucet-sink-redis)
 [![Docs.rs](https://docs.rs/faucet-sink-redis/badge.svg)](https://docs.rs/faucet-sink-redis)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-sink-redis.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-sink-redis.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
 Redis sink connector for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
 

--- a/crates/sink/redis/README.md
+++ b/crates/sink/redis/README.md
@@ -5,15 +5,28 @@
 [![MSRV](https://img.shields.io/crates/msrv/faucet-sink-redis.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
 [![License](https://img.shields.io/crates/l/faucet-sink-redis.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-Redis sink connector for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
+**Redis** sink for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem. Writes JSON records into Redis lists (`RPUSH`), streams (`XADD`), or individual keys (`SET`), batching each page of records into a single pipelined round-trip.
 
-Writes JSON records to Redis data structures: lists (`RPUSH`), streams (`XADD`), or key-value pairs (`SET`). Uses Redis pipelines for efficient batched writes and a multiplexed async connection that is reused across all calls.
+Reach for it when you want to land pipeline output in Redis as a work queue, an event stream for consumers, or a cache/lookup table — with one declarative config and no glue code. Redis pipelining keeps the write path fast: every chunk of records ships as one network round-trip over a connection that's opened once and reused.
+
+## Feature highlights
+
+- **Three write targets** — `List` (append via `RPUSH`), `Stream` (append via `XADD` with auto-generated IDs), and `KeyValue` (one key per record via `SET`).
+- **Pipelined batching** — every chunk of records is packed into a single Redis pipeline, so a batch of N writes costs one round-trip instead of N.
+- **Stream field mapping** — for `Stream` mode, each record's top-level JSON object fields become native stream entry fields; non-object records land in a single `_data` field.
+- **Connection reuse** — a multiplexed async connection is opened once in `new()` and shared (cheaply cloned) across every `write_batch` call.
+- **Tunable batch window** — `batch_size` controls how many commands go in one pipeline, with a `0` sentinel that passes the upstream page straight through.
+- **Preflight probe** — `faucet doctor` issues a non-mutating `PING` over the live connection.
+- **Credential-safe logging** — the config's `Debug` impl masks the connection URL, and the lineage dataset URI strips credentials.
 
 ## Installation
 
 ```bash
+# As a library:
 cargo add faucet-sink-redis
-cargo add tokio --features full
+
+# In the CLI (opt-in connector feature):
+cargo install faucet-cli --features sink-redis
 ```
 
 Or via the umbrella crate:
@@ -22,84 +35,161 @@ Or via the umbrella crate:
 cargo add faucet-stream --features sink-redis
 ```
 
-## Quick Start
+## Quick start
 
-```rust
-use faucet_sink_redis::{RedisSink, RedisSinkConfig, RedisSinkType};
-use faucet_core::Sink;
-use serde_json::json;
-
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let config = RedisSinkConfig::new(
-        "redis://127.0.0.1:6379",
-        RedisSinkType::List { key: "events".into() },
-    );
-
-    let sink = RedisSink::new(config).await?;
-
-    let records = vec![
-        json!({"user_id": "u123", "event": "signup"}),
-        json!({"user_id": "u456", "event": "login"}),
-    ];
-
-    let written = sink.write_batch(&records).await?;
-    println!("Wrote {written} records to Redis");
-
-    Ok(())
-}
+```yaml
+# pipeline.yaml — faucet run pipeline.yaml
+version: 1
+pipeline:
+  source:
+    type: rest
+    config:
+      base_url: https://api.example.com
+      endpoint: /v1/events
+  sink:
+    type: redis
+    config:
+      url: redis://127.0.0.1:6379
+      sink_type:
+        type: Stream
+        key: events
 ```
 
-## Configuration
+```bash
+faucet run pipeline.yaml
+```
+
+## Configuration reference
+
+### Core
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `url` | `String` | *(required)* | Redis connection URL (e.g. `redis://127.0.0.1:6379`) |
-| `sink_type` | `RedisSinkType` | *(required)* | The type of Redis data structure to write to (see below) |
-| `batch_size` | `usize` | `DEFAULT_BATCH_SIZE` (1000) | Maximum number of commands packed into a single Redis pipeline. Pass `0` to opt out of re-chunking — see [Streaming and batching](#streaming-and-batching) below. |
+| `url` | string | — *(required)* | Redis connection URL, e.g. `redis://127.0.0.1:6379` or `rediss://host:6380` (TLS). Masked as `***` in `Debug` / log output. |
+| `sink_type` | `RedisSinkType` | — *(required)* | The Redis data structure to write to — see [Sink types](#sink-types). |
 
-The `Debug` implementation masks the `url` with `***` to prevent credential leakage in logs.
+### Batching
 
-### Sink Types (`RedisSinkType`)
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `batch_size` | int | `1000` | Maximum commands packed into one Redis pipeline. When `write_batch` receives a slice larger than this, the sink re-chunks it and issues one pipeline per chunk. **`0` = no batching**: the entire upstream slice is packed into a single pipeline, preserving the source's `StreamPage` framing. Validated against `MAX_BATCH_SIZE` (1,000,000) at construction. |
 
-| Variant | Fields | Description |
-|---------|--------|-------------|
-| `List` | `key: String` | Append each record as a serialized JSON string to a Redis list using `RPUSH`. |
-| `Stream` | `key: String` | Add each record as an entry to a Redis stream using `XADD` with auto-generated IDs (`*`). Top-level JSON fields become stream entry fields. Non-object records are stored as a single `_data` field. |
-| `KeyValue` | `key_field: String` | Store each record as a separate key using `SET`. The Redis key is extracted from the specified field in each record. The entire record is stored as a serialized JSON string value. |
+### Sink types
 
-### Stream Entry Field Mapping
+`sink_type` is an adjacently-tagged enum keyed by `type`:
 
-When using the `Stream` sink type, top-level JSON object fields are flattened into Redis stream entry fields:
+| `type` | Fields | Redis command | Behaviour |
+|--------|--------|---------------|-----------|
+| `List` | `key: string` | `RPUSH` | Append each record, serialized to a JSON string, to the list at `key`. |
+| `Stream` | `key: string` | `XADD` | Append each record as a stream entry at `key` with an auto-generated ID (`*`). Top-level object fields become entry fields; a non-object record is stored as a single `_data` field. |
+| `KeyValue` | `key_field: string` | `SET` | Store each record under a key read from its `key_field`. The full record (serialized JSON) is the value. A record missing `key_field` raises an error. |
 
-- String values are stored as-is
-- Numbers, booleans, and null are converted to their string representation
-- Nested objects and arrays are serialized as JSON strings
+#### Stream entry field mapping
 
-If a record is not a JSON object (e.g. a plain string), it is stored as a single `_data` field containing the serialized record.
+For `Stream` mode, each record's top-level JSON object fields are flattened into Redis stream entry fields:
 
-### Builder Methods
+- String values are stored as-is.
+- Numbers, booleans, and null are converted to their string representation.
+- Nested objects and arrays are serialized as JSON strings.
 
-```rust
-use faucet_sink_redis::{RedisSinkConfig, RedisSinkType};
+If a record is not a JSON object (e.g. a bare string), it is stored as a single `_data` field containing the serialized record. A record that flattens to zero fields also falls back to `_data`, because `XADD` requires at least one field.
 
-let config = RedisSinkConfig::new(
-    "redis://localhost:6379",
-    RedisSinkType::Stream { key: "events".into() },
-)
-.with_batch_size(1000);
+## Examples
+
+### Work queue (List)
+
+Fan records out to consumers reading from one end of a Redis list:
+
+```yaml
+version: 1
+pipeline:
+  source:
+    type: csv
+    config:
+      path: ./jobs.csv
+  sink:
+    type: redis
+    config:
+      url: redis://127.0.0.1:6379
+      sink_type:
+        type: List
+        key: job_queue
+      batch_size: 500
+```
+
+### Event stream (Stream)
+
+Each record becomes a stream entry with native fields, ready for `XREAD` / consumer groups:
+
+```yaml
+version: 1
+pipeline:
+  source:
+    type: rest
+    config:
+      base_url: https://api.example.com
+      endpoint: /v1/user-events
+  sink:
+    type: redis
+    config:
+      url: redis://127.0.0.1:6379
+      sink_type:
+        type: Stream
+        key: user_events
+```
+
+### Cache / lookup table (KeyValue)
+
+Materialize records into individual keys for point lookups:
+
+```yaml
+version: 1
+pipeline:
+  source:
+    type: postgres
+    config:
+      connection_url: ${env:DATABASE_URL}
+      query: SELECT user_id, name, plan FROM users
+  sink:
+    type: redis
+    config:
+      url: ${env:REDIS_URL}
+      sink_type:
+        type: KeyValue
+        key_field: user_id
+```
+
+This writes keys named after each row's `user_id`, with the full JSON record as the value.
+
+### One pipeline per source page (`batch_size: 0`)
+
+When the source already chooses a sensible page size, pass it straight through so each page maps to exactly one Redis pipeline:
+
+```yaml
+sink:
+  type: redis
+  config:
+    url: redis://127.0.0.1:6379
+    sink_type:
+      type: List
+      key: events
+    batch_size: 0
 ```
 
 ## Streaming and batching
 
-The sink fits the workspace's streaming pipeline contract: `Pipeline::run` drives `Source::stream_pages` and writes each `StreamPage` via `Sink::write_batch` as it arrives. `batch_size` controls how those records get packed into Redis pipelines on the way out:
+The sink follows the workspace streaming contract: `Pipeline::run` drives the source's `stream_pages` and writes each emitted `StreamPage` via `Sink::write_batch` as it arrives, so memory stays bounded at one page. `batch_size` controls how those records are packed into Redis pipelines on the way out:
 
 | `batch_size` | Behaviour |
 |--------------|-----------|
-| `1`..`MAX_BATCH_SIZE` (default `1000`) | When `write_batch` receives a slice larger than `batch_size`, the sink re-chunks it into `batch_size` slices and issues one Redis pipeline per chunk. Recommended for high-throughput writes — Redis pipelined commands are cheap, and a 1000-command window comfortably amortises the round-trip without starving other clients. |
-| `0` | "No batching" sentinel — the entire records slice is packed into a single Redis pipeline regardless of size, preserving upstream `StreamPage` framing. Use this when the source has already chosen a sensible page size (e.g. `RedisSourceConfig::batch_size`, or any other source's per-page knob) and you want one pipeline per page. |
+| `1`..`MAX_BATCH_SIZE` (default `1000`) | A slice larger than `batch_size` is re-chunked into `batch_size` slices; one Redis pipeline is issued per chunk. Recommended for high-throughput writes — pipelined commands are cheap, and a 1000-command window amortises the round-trip without starving other clients. |
+| `0` | "No batching" sentinel — the entire records slice is packed into a single pipeline regardless of size, preserving the upstream `StreamPage` framing. Use it when the source has already chosen the page size and you want one pipeline per page. |
 
-## Config Loading
+This sink writes **append/insert-only** (`RPUSH` / `XADD` / `SET`) and does not implement upsert/delete write modes or exactly-once delivery — see [Limitations](#limitations).
+
+## Config loading & schema
+
+Load from YAML/JSON files or environment variables via the helpers in `faucet_core::config`:
 
 ```rust
 use faucet_core::config::{load_json, load_env_file};
@@ -112,46 +202,7 @@ let config: RedisSinkConfig = load_json("config.json")?;
 let config: RedisSinkConfig = load_env_file(".env", "REDIS_SINK")?;
 ```
 
-### Example JSON config (List)
-
-```json
-{
-  "url": "redis://127.0.0.1:6379",
-  "sink_type": {
-    "type": "List",
-    "key": "event_queue"
-  },
-  "batch_size": 1000
-}
-```
-
-### Example JSON config (Stream)
-
-```json
-{
-  "url": "redis://127.0.0.1:6379",
-  "sink_type": {
-    "type": "Stream",
-    "key": "event_stream"
-  },
-  "batch_size": 1000
-}
-```
-
-### Example JSON config (KeyValue)
-
-```json
-{
-  "url": "redis://127.0.0.1:6379",
-  "sink_type": {
-    "type": "KeyValue",
-    "key_field": "id"
-  },
-  "batch_size": 1000
-}
-```
-
-### Example .env file
+Example `.env`:
 
 ```env
 REDIS_SINK_URL=redis://127.0.0.1:6379
@@ -159,102 +210,104 @@ REDIS_SINK_SINK_TYPE='{"type":"List","key":"events"}'
 REDIS_SINK_BATCH_SIZE=1000
 ```
 
-## Config Schema Introspection
+Inspect the full JSON Schema with:
 
-```rust
-use faucet_core::Sink;
-
-let sink = RedisSink::new(config).await?;
-let schema = sink.config_schema();
-println!("{}", serde_json::to_string_pretty(&schema)?);
+```bash
+faucet schema sink redis
 ```
 
-## Pipeline Usage
+## Library usage
+
+```rust
+use faucet_core::{Pipeline, Sink};
+use faucet_sink_redis::{RedisSink, RedisSinkConfig, RedisSinkType};
+use serde_json::json;
+
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let config = RedisSinkConfig::new(
+    "redis://127.0.0.1:6379",
+    RedisSinkType::Stream { key: "events".into() },
+)
+.with_batch_size(1000);
+
+let sink = RedisSink::new(config).await?;
+
+let records = vec![
+    json!({"user_id": "u123", "event": "signup"}),
+    json!({"user_id": "u456", "event": "login"}),
+];
+
+let written = sink.write_batch(&records).await?;
+println!("wrote {written} records to Redis");
+# Ok(())
+# }
+```
+
+Drive it from a full pipeline by pairing it with any source:
 
 ```rust
 use faucet_core::Pipeline;
 use faucet_source_rest::{RestStream, RestStreamConfig};
 use faucet_sink_redis::{RedisSink, RedisSinkConfig, RedisSinkType};
 
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
 let source = RestStream::new(
-    RestStreamConfig::new("https://api.example.com", "/v1/events")
+    RestStreamConfig::new("https://api.example.com", "/v1/events"),
 );
-
 let sink = RedisSink::new(RedisSinkConfig::new(
-    "redis://localhost:6379",
+    "redis://127.0.0.1:6379",
     RedisSinkType::Stream { key: "api_events".into() },
-)).await?;
+))
+.await?;
 
 let result = Pipeline::new(source, sink).run().await?;
-println!("Transferred {} records", result.records_written);
+println!("transferred {} records", result.records_written);
+# Ok(())
+# }
 ```
 
-## Examples
+## How it works
 
-### Writing to a Redis list (queue pattern)
-
-```rust
-let config = RedisSinkConfig::new(
-    "redis://localhost:6379",
-    RedisSinkType::List { key: "job_queue".into() },
-)
-.with_batch_size(500);
-
-let sink = RedisSink::new(config).await?;
-sink.write_batch(&records).await?;
-// Records are appended to the "job_queue" list via RPUSH
-```
-
-### Writing to a Redis stream (event sourcing)
-
-```rust
-let config = RedisSinkConfig::new(
-    "redis://localhost:6379",
-    RedisSinkType::Stream { key: "user_events".into() },
-);
-
-let sink = RedisSink::new(config).await?;
-
-let records = vec![
-    json!({"user_id": "u1", "action": "login", "ip": "10.0.0.1"}),
-    json!({"user_id": "u2", "action": "purchase", "amount": 99.99}),
-];
-
-sink.write_batch(&records).await?;
-// Each record becomes a stream entry with fields: user_id, action, ip/amount
-```
-
-### Writing to individual keys (cache/lookup pattern)
-
-```rust
-let config = RedisSinkConfig::new(
-    "redis://localhost:6379",
-    RedisSinkType::KeyValue { key_field: "user_id".into() },
-);
-
-let sink = RedisSink::new(config).await?;
-
-let records = vec![
-    json!({"user_id": "u123", "name": "Alice", "plan": "pro"}),
-    json!({"user_id": "u456", "name": "Bob", "plan": "free"}),
-];
-
-sink.write_batch(&records).await?;
-// Creates keys "u123" and "u456" with the full JSON as values
-```
-
-## How It Works
-
-- A multiplexed async connection is opened in `RedisSink::new()` and reused across all `write_batch()` calls. The multiplexed connection is cheaply cloneable.
-- `write_batch()` processes records in chunks of `batch_size`. Each chunk is sent as a Redis pipeline (multiple commands batched in a single round-trip) for maximum throughput. When `batch_size = 0`, the entire records slice is packed into a single pipeline — see [Streaming and batching](#streaming-and-batching).
-- For `List` mode: each record is serialized to JSON and appended with `RPUSH`.
-- For `Stream` mode: each record's top-level fields are flattened into stream entry fields for `XADD`. Auto-generated stream IDs (`*`) are used.
-- For `KeyValue` mode: the specified `key_field` is extracted from each record to use as the Redis key. The entire record (serialized as JSON) is the value for `SET`. Records missing the key field produce an error.
+1. `new()` validates `batch_size`, opens a `redis::Client` from `url`, and establishes a **multiplexed async connection** — once. The connection is cheaply cloneable and shared across every `write_batch` call (it multiplexes commands over a single socket).
+2. `write_batch` chunks the incoming slice by the effective window (`batch_size`, or the whole slice when `batch_size: 0`).
+3. Each chunk is assembled into one `redis::pipe()` — `RPUSH` for `List`, `XADD` for `Stream`, `SET` for `KeyValue` — and executed in a single round-trip via `query_async`.
+4. A failed pipeline surfaces as `FaucetError::Sink`; a record missing its `key_field` (KeyValue) or a JSON-serialization failure does the same.
 
 ## Lineage dataset URI
 
-`redis://<host>:<port>?key=<key>` or `?key_field=<field>` (credentials stripped) — e.g. `redis://localhost:6379?key=events`.
+`redis://<host>:<port>?key=<key>` (List/Stream) or `redis://<host>:<port>?key_field=<field>` (KeyValue), with credentials stripped — e.g. `redis://localhost:6379?key=events`.
+
+## Limitations
+
+- **Append/insert-only.** The sink writes via `RPUSH` / `XADD` / `SET`; it does not implement `write_mode: upsert | delete`. (`SET` on an existing key in `KeyValue` mode overwrites by nature, but there is no keyed upsert/delete planner.)
+- **No exactly-once delivery.** Redis writes are at-least-once; the sink does not implement idempotent commit tokens. On retry after a partial failure, already-written records may be re-applied (a re-pushed list entry / re-added stream entry; a `SET` is naturally idempotent for the same key+value).
+- **No compression.** Not applicable to a Redis protocol sink.
+
+## Feature flags
+
+This crate has no optional features of its own; enable it in the CLI/umbrella via the `sink-redis` feature.
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause & fix |
+|---------|--------------------|
+| `Config: invalid Redis URL` | `url` is malformed. Use the `redis://[:password@]host:port[/db]` form (or `rediss://` for TLS). |
+| `Sink: Redis connection failed` | The server is unreachable, refused the connection, or rejected auth. Check the host/port, that Redis is running, and that any password in the URL is correct. `faucet doctor` runs a `PING` probe that surfaces the same error early. |
+| `Config: batch_size ... exceeds maximum` | `batch_size` is above `MAX_BATCH_SIZE` (1,000,000). Lower it; `0` is valid (no batching). |
+| `Sink: record missing key field '<field>'` (KeyValue) | A record has no `key_field`. Ensure every record carries the field, or add a transform to populate/rename it before the sink. |
+| `Sink: Redis pipeline execution failed` | The server rejected a command mid-pipeline (e.g. `WRONGTYPE` — the key already holds a different data type, or `OOM` under `maxmemory`). Use a fresh key per `sink_type`, or free memory / raise `maxmemory`. |
+| Stream entry has only a `_data` field | The record wasn't a JSON object, or flattened to zero fields. `XADD` requires at least one field, so the whole record is stored under `_data`. Emit object records to get native stream fields. |
+| Numbers/booleans arrive as strings in a stream | Intentional — non-string scalars are stringified for `XADD`, and nested objects/arrays are serialized as JSON strings. Parse them on the consumer side. |
+| TLS connection rejected | Use a `rediss://` URL (double `s`) to negotiate TLS against a server configured for it. |
+
+## See also
+
+- [Sinks reference](https://pawansikawat.github.io/faucet-stream/reference/connectors.html) — capability matrix across all connectors.
+- [Configuration grammar](https://pawansikawat.github.io/faucet-stream/reference/config.html) — the full pipeline config shape.
+- [State & resumability cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/state.html).
+- [`faucet-source-redis`](https://crates.io/crates/faucet-source-redis) — the Redis **source** (streams, lists, key patterns).
+- [`faucet-core`](https://crates.io/crates/faucet-core) — traits, pipeline, and error types.
 
 ## License
 
-Licensed under MIT or Apache-2.0.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/sink/s3/README.md
+++ b/crates/sink/s3/README.md
@@ -2,6 +2,8 @@
 
 [![Crates.io](https://img.shields.io/crates/v/faucet-sink-s3.svg)](https://crates.io/crates/faucet-sink-s3)
 [![Docs.rs](https://docs.rs/faucet-sink-s3/badge.svg)](https://docs.rs/faucet-sink-s3)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-sink-s3.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-sink-s3.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
 AWS S3 sink connector for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
 

--- a/crates/sink/s3/README.md
+++ b/crates/sink/s3/README.md
@@ -5,15 +5,30 @@
 [![MSRV](https://img.shields.io/crates/msrv/faucet-sink-s3.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
 [![License](https://img.shields.io/crates/l/faucet-sink-s3.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-AWS S3 sink connector for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
+AWS **S3** sink for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem. Writes JSON records to S3 (or any S3-compatible store) as JSON Lines (NDJSON) objects, one UUID-keyed object per chunk, uploaded concurrently via `buffer_unordered`.
 
-Writes JSON records to S3 as JSON Lines (NDJSON) files. Each file is keyed with a UUID for uniqueness. Supports file splitting by record count, configurable key prefixes and file extensions, concurrent uploads via `buffer_unordered`, and custom S3-compatible endpoints (MinIO, LocalStack, etc.).
+Reach for it to land any faucet-stream source — a REST API, a database, a Kafka topic, a CDC stream — into an S3 data lake as newline-delimited JSON with one declarative config and no glue code. It's tuned to write a small number of large objects rather than a flood of tiny ones, which keeps downstream scans and PUT/LIST costs low.
+
+## Feature highlights
+
+- **JSON Lines (NDJSON) output** — each object is newline-delimited JSON, uploaded with `Content-Type: application/x-ndjson`. Reads back cleanly in Spark, Athena, DuckDB, `jq`, and the [`faucet-source-s3`](https://crates.io/crates/faucet-source-s3) JSONL reader.
+- **Concurrent uploads** — chunks are serialized up front and uploaded in parallel via `futures::stream::buffer_unordered`, bounded by `concurrency` (default 10).
+- **File splitting** — `max_records_per_file` caps records per object; `batch_size` re-chunks each `write_batch` call. The effective per-object cap is the smaller of the two.
+- **S3-compatible endpoints** — point `endpoint_url` at MinIO, LocalStack, Cloudflare R2, Backblaze B2, or any S3 API.
+- **AWS credential chain** — credentials resolve through the standard AWS SDK chain (env vars, shared credentials file, IAM instance/task roles, SSO) — no secrets in the config.
+- **Optional compression** — gzip / zstd / auto behind the crate-local `compression` feature; the codec auto-resolves from the file extension.
+- **Client built once** — the S3 client is constructed eagerly in `new()` and reused for every upload.
+- **Preflight `check()`** — `faucet doctor` issues a non-mutating `HeadBucket` to confirm the bucket is reachable and credentials work, uploading nothing.
 
 ## Installation
 
 ```bash
+# As a library:
 cargo add faucet-sink-s3
 cargo add tokio --features full
+
+# In the CLI (opt-in connector feature):
+cargo install faucet-cli --features sink-s3
 ```
 
 Or via the umbrella crate:
@@ -22,104 +37,169 @@ Or via the umbrella crate:
 cargo add faucet-stream --features sink-s3
 ```
 
-## Quick Start
+## Quick start
 
-```rust
-use faucet_sink_s3::{S3Sink, S3SinkConfig};
-use faucet_core::Sink;
-use serde_json::json;
-
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let config = S3SinkConfig::new("my-data-bucket")
-        .prefix("events/2026/04/02/")
-        .region("us-east-1");
-
-    let sink = S3Sink::new(config).await?;
-
-    let records = vec![
-        json!({"id": 1, "event": "page_view", "user": "alice"}),
-        json!({"id": 2, "event": "click", "user": "bob"}),
-    ];
-
-    let written = sink.write_batch(&records).await?;
-    println!("Wrote {written} records to S3");
-
-    Ok(())
-}
+```yaml
+# pipeline.yaml — faucet run pipeline.yaml
+version: 1
+pipeline:
+  source:
+    type: rest
+    config:
+      base_url: https://api.example.com
+      path: /v1/events
+      records_path: $.events[*]
+  sink:
+    type: s3
+    config:
+      bucket: my-data-lake
+      prefix: events/raw/
+      region: us-east-1
+      max_records_per_file: 10000
 ```
 
-## Configuration
+```bash
+faucet run pipeline.yaml
+```
+
+This writes `s3://my-data-lake/events/raw/<uuid>.jsonl` objects, each holding up to 10,000 records.
+
+## Configuration reference
+
+### Core
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `bucket` | `String` | *(required)* | S3 bucket name |
-| `prefix` | `String` | `""` (empty) | Key prefix for written objects (e.g. `"data/events/"`) |
-| `region` | `Option<String>` | `None` (SDK default) | AWS region |
-| `endpoint_url` | `Option<String>` | `None` | Custom endpoint URL for S3-compatible services (MinIO, LocalStack, etc.) |
-| `file_extension` | `String` | `".jsonl"` | File extension appended to each object key |
-| `max_records_per_file` | `Option<usize>` | `None` (all in one file) | Maximum records per file. When set, records are split across multiple files. |
-| `concurrency` | `usize` | `10` | Maximum number of concurrent file uploads |
-| `batch_size` | `usize` | `1000` ([`DEFAULT_BATCH_SIZE`]) | Records per S3 object written by a single `write_batch` call. `0` opts out of write-side re-chunking — see *Streaming and batching* below. |
+| `bucket` | string | — *(required)* | S3 bucket name. |
+| `prefix` | string | `""` | Key prefix for written objects (e.g. `"data/events/"`). Combined as `{prefix}{uuid}{file_extension}`. |
+| `region` | string | *(SDK default)* | AWS region. When unset, the AWS SDK resolves it from the environment / config. |
+| `endpoint_url` | string | *(unset)* | Custom endpoint for S3-compatible services (MinIO, LocalStack, R2, …). |
+| `file_extension` | string | `".jsonl"` | Extension appended to each object key. Append `.gz` / `.zst` here when using compression so consumers can detect the codec. |
 
-[`DEFAULT_BATCH_SIZE`]: https://docs.rs/faucet-core/latest/faucet_core/constant.DEFAULT_BATCH_SIZE.html
+### Batching & file splitting
 
-### Streaming and batching
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `max_records_per_file` | int | *(unset)* | Maximum records per object. When unset, all records in a `write_batch` call go to one object. |
+| `concurrency` | int | `10` | Maximum number of concurrent object uploads. Bounds peak memory together with object size. |
+| `batch_size` | int | `1000` | Records per object written by a single `write_batch` call (write-side re-chunking). `0` = no re-chunking — see [Streaming & batching](#streaming--batching). **`0` is the recommended value for S3.** |
 
-`batch_size` controls write-side re-chunking inside a single `write_batch`
-call. When the pipeline hands the sink `N` records and `batch_size = M > 0`,
-the sink writes `ceil(N / M)` separate S3 objects (each containing at most
-`M` records, with the final object holding the remainder). When
-`batch_size = 0`, the sink writes whatever upstream hands it as a single
-object — no re-chunking.
+### Format (compression feature)
 
-**Recommended value: `0`.** S3 is the canonical case where one large object
-beats many small ones — per-request overhead, slower downstream scans, and
-LIST/PUT cost all compound when a pipeline produces a flood of tiny objects.
-The source's `batch_size` already sizes each `write_batch` call, and most
-sources expose a `batch_size` field tuned to their native paging primitive
-(REST page, sqlx cursor chunk, Kafka poll, etc.). Leave this at `0` unless
-you explicitly want the sink to subdivide each upstream page further.
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `compression` | `none` \| `gzip` \| `zstd` \| `auto` | `auto` | Object-body codec. `auto` resolves from `file_extension`. Requires the crate-local `compression` feature. See [Compression](#compression). |
 
-When both `batch_size > 0` and `max_records_per_file` are set, the effective
-per-object cap is `min(batch_size, max_records_per_file)`. When both are `0`
-/ unset, the sink writes one object per `write_batch` call.
+## Examples
 
-> **Memory ceiling.** Each object's body is buffered fully in memory (and,
-> with compression enabled, briefly held as both the raw and compressed
-> body) before a single-shot `PutObject`. Up to `concurrency` objects
-> upload at once, so peak memory is roughly **`concurrency` × (object
-> size) × ~2**. A `batch_size = 0` / `max_records_per_file = None` fed by
-> a `fetch_all`-style source produces one potentially huge object per
-> `write_batch` — pair `batch_size = 0` with a streaming source that
-> already sizes its pages, or set `max_records_per_file` / lower
-> `concurrency` to cap peak memory. Streaming multipart upload for very
-> large objects is a future enhancement.
+### Sharded JSONL from a REST API
 
-### Builder Methods
-
-```rust
-use faucet_sink_s3::S3SinkConfig;
-
-let config = S3SinkConfig::new("my-bucket")
-    .prefix("output/events/")
-    .region("eu-west-1")
-    .endpoint_url("http://localhost:9000")
-    .file_extension(".ndjson")
-    .max_records_per_file(10000)
-    .concurrency(20);
+```yaml
+# Adapted from cli/examples/rest_to_s3.yaml
+version: 1
+name: rest_to_s3
+pipeline:
+  source:
+    type: rest
+    config:
+      base_url: https://api.example.com
+      path: /v1/events
+      records_path: $.events[*]
+      pagination:
+        type: Offset
+        offset_param: offset
+        limit_param: limit
+        limit: 500
+        total_path: $.meta.total
+  sink:
+    type: s3
+    config:
+      bucket: my-data-lake
+      prefix: events/raw/
+      region: us-east-1
+      file_extension: .jsonl
+      max_records_per_file: 10000
+      concurrency: 8
 ```
 
-### Object Key Format
+### Dated prefix driven by `${now.*}`
 
-Each file is written with the key: `{prefix}{uuid}{file_extension}`
-
-For example, with `prefix = "events/"` and `file_extension = ".jsonl"`:
+```yaml
+pipeline:
+  sink:
+    type: s3
+    config:
+      bucket: my-data-lake
+      prefix: events/dt=${now.date}/    # e.g. events/dt=2026-06-17/
+      region: us-east-1
+      batch_size: 0                      # let the source size each object
 ```
-events/a1b2c3d4-e5f6-7890-abcd-ef1234567890.jsonl
+
+### Compressed objects (gzip)
+
+```yaml
+pipeline:
+  sink:
+    type: s3
+    config:
+      bucket: my-data-lake
+      prefix: events/raw/
+      file_extension: .jsonl.gz   # auto-resolves to gzip
+      region: us-east-1
 ```
 
-## Config Loading
+### MinIO / LocalStack for local development
+
+```yaml
+pipeline:
+  sink:
+    type: s3
+    config:
+      bucket: test-bucket
+      prefix: dev/
+      endpoint_url: http://localhost:9000
+      region: us-east-1
+```
+
+## Streaming & batching
+
+The pipeline calls `Sink::write_batch` once per upstream page. Inside a call, `batch_size` and `max_records_per_file` together decide how many objects that page becomes:
+
+- The effective per-object cap is `min(batch_size, max_records_per_file)` when both are set, whichever single one is set, or **unbounded** when both are `0` / unset (the whole page becomes one object).
+- With a cap of `M`, a page of `N` records is written as `ceil(N / M)` objects, each holding at most `M` records (the last holds the remainder).
+- **`batch_size = 0` is the "no batching" sentinel:** the sink writes whatever upstream hands it without re-chunking (still honouring `max_records_per_file` if set).
+
+**Recommended: `batch_size: 0`.** S3 is the canonical case where one large object beats many small ones — per-request overhead, slower downstream scans, and LIST/PUT cost all compound with tiny objects. Most sources already size each page via their own `batch_size` (REST page, sqlx cursor chunk, Kafka poll, …), so let that drive object sizing.
+
+> **Memory ceiling.** Each object's body is buffered fully in memory before a single-shot `PutObject` (and, with compression on, briefly held as both raw and compressed). Up to `concurrency` objects upload at once, so peak memory is roughly **`concurrency` × object-size × ~2**. Pair `batch_size: 0` with a *streaming* source that sizes its own pages, or cap memory via `max_records_per_file` / lower `concurrency`. Streaming multipart upload for very large objects is a future enhancement.
+
+## Compression
+
+Behind the crate-local `compression` Cargo feature (`cargo add faucet-sink-s3 --features compression`, or `cargo install faucet-cli --features compression`). Adds the `compression` config field with values `none` / `gzip` / `zstd` / `auto`.
+
+- `auto` (the default) resolves the codec from `file_extension`: `.gz` → gzip, `.zst` → zstd, anything else → none.
+- Append `.gz` / `.zst` to `file_extension` so consumers can detect the codec from the object key.
+- The S3 **`Content-Encoding` header is deliberately unset** — consumers must decompress explicitly (the codec lives in the key suffix, not the HTTP metadata).
+- Resolution runs per-object, so a `${now.*}`- or matrix-driven extension can vary across a run.
+
+```yaml
+pipeline:
+  sink:
+    type: s3
+    config:
+      bucket: my-data-lake
+      prefix: events/raw/
+      file_extension: .jsonl.zst
+      compression: auto    # or 'gzip' | 'zstd' | 'none'
+```
+
+## Config loading & schema
+
+Load from YAML/JSON files or environment variables, and inspect the full JSON Schema:
+
+```bash
+faucet schema sink s3
+```
 
 ```rust
 use faucet_core::config::{load_json, load_env_file};
@@ -132,33 +212,7 @@ let config: S3SinkConfig = load_json("config.json")?;
 let config: S3SinkConfig = load_env_file(".env", "S3_SINK")?;
 ```
 
-### Example JSON config
-
-```json
-{
-  "bucket": "my-data-lake",
-  "prefix": "raw/events/2026/04/",
-  "region": "us-east-1",
-  "file_extension": ".jsonl",
-  "max_records_per_file": 50000,
-  "concurrency": 10
-}
-```
-
-### Example JSON config (S3-compatible endpoint)
-
-```json
-{
-  "bucket": "local-bucket",
-  "prefix": "test/",
-  "endpoint_url": "http://localhost:9000",
-  "region": "us-east-1",
-  "file_extension": ".jsonl",
-  "concurrency": 5
-}
-```
-
-### Example .env file
+Example `.env`:
 
 ```env
 S3_SINK_BUCKET=my-data-lake
@@ -169,109 +223,107 @@ S3_SINK_MAX_RECORDS_PER_FILE=50000
 S3_SINK_CONCURRENCY=10
 ```
 
-## Config Schema Introspection
+## Library usage
 
 ```rust
-use faucet_core::Sink;
+use faucet_core::{Pipeline, Sink};
+use faucet_sink_s3::{S3Sink, S3SinkConfig};
+use serde_json::json;
+
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let config = S3SinkConfig::new("my-data-bucket")
+    .prefix("events/2026/06/")
+    .region("us-east-1")
+    .max_records_per_file(10_000)
+    .concurrency(20);
 
 let sink = S3Sink::new(config).await?;
-let schema = sink.config_schema();
-println!("{}", serde_json::to_string_pretty(&schema)?);
+
+let records = vec![
+    json!({"id": 1, "event": "page_view", "user": "alice"}),
+    json!({"id": 2, "event": "click", "user": "bob"}),
+];
+let written = sink.write_batch(&records).await?;
+println!("Wrote {written} records to S3");
+# Ok(())
+# }
 ```
 
-## Pipeline Usage
+Driven by a `Pipeline`:
 
 ```rust
 use faucet_core::Pipeline;
 use faucet_source_rest::{RestStream, RestStreamConfig};
 use faucet_sink_s3::{S3Sink, S3SinkConfig};
 
-let source = RestStream::new(
-    RestStreamConfig::new("https://api.example.com", "/v1/events")
-);
-
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let source = RestStream::new(RestStreamConfig::new("https://api.example.com", "/v1/events"));
 let sink = S3Sink::new(
     S3SinkConfig::new("my-data-lake")
         .prefix("ingest/events/")
         .region("us-east-1")
-        .max_records_per_file(100000)
-).await?;
+        .max_records_per_file(100_000),
+)
+.await?;
 
 let result = Pipeline::new(source, sink).run().await?;
 println!("Transferred {} records to S3", result.records_written);
+# Ok(())
+# }
 ```
 
-## Examples
+## How it works
 
-### Basic upload to S3
+1. `new()` validates `batch_size` and builds an S3 client **once** via the AWS SDK default credential chain, applying `region` / `endpoint_url` overrides if set.
+2. `write_batch()` computes the effective per-object cap (`min(batch_size, max_records_per_file)`) and splits the page into chunks.
+3. Each chunk is serialized to a JSON Lines body and assigned a UUID-based key (`{prefix}{uuid}{file_extension}`) *before* any upload begins.
+4. Chunks upload concurrently via `buffer_unordered(concurrency)` as single-shot `PutObject` calls with `Content-Type: application/x-ndjson`.
+5. With the `compression` feature, each body is compressed in memory just before upload using the codec resolved from `file_extension`.
 
-```rust
-let config = S3SinkConfig::new("my-bucket")
-    .prefix("data/")
-    .region("us-west-2");
+## Object key format
 
-let sink = S3Sink::new(config).await?;
-sink.write_batch(&records).await?;
-// Writes: s3://my-bucket/data/<uuid>.jsonl
+Each object is keyed `{prefix}{uuid}{file_extension}`. With `prefix = "events/"` and `file_extension = ".jsonl"`:
+
+```
+events/a1b2c3d4-e5f6-7890-abcd-ef1234567890.jsonl
 ```
 
-### Splitting large datasets across multiple files
-
-```rust
-let config = S3SinkConfig::new("data-lake")
-    .prefix("events/daily/")
-    .max_records_per_file(100000)
-    .concurrency(20);
-
-let sink = S3Sink::new(config).await?;
-
-// 500,000 records will be split into 5 files of 100,000 each,
-// uploaded concurrently (up to 20 at a time).
-sink.write_batch(&large_record_set).await?;
-```
-
-### Using MinIO or LocalStack for local development
-
-```rust
-let config = S3SinkConfig::new("test-bucket")
-    .endpoint_url("http://localhost:9000")
-    .region("us-east-1")
-    .prefix("dev/");
-
-let sink = S3Sink::new(config).await?;
-sink.write_batch(&records).await?;
-```
-
-## How It Works
-
-- The S3 client is created eagerly in `S3Sink::new()` using the AWS SDK default credential chain. Custom regions and endpoints are applied if configured.
-- `write_batch()` splits records into chunks based on `max_records_per_file` (or writes all records to a single file if unset).
-- Each chunk is serialized to a JSON Lines string, assigned a UUID-based key, and uploaded to S3.
-- Uploads are performed concurrently using `futures::stream::buffer_unordered` with the configured `concurrency` limit.
-- Objects are uploaded with `Content-Type: application/x-ndjson`.
-- AWS credentials are resolved via the standard AWS SDK credential chain (environment variables, shared credentials file, instance profiles, etc.).
-
-## Compression
-
-Behind the crate-local `compression` Cargo feature. Adds a `compression` config
-field with values `none`, `gzip`, `zstd`, or `auto` (the default — detects
-`.gz` / `.zst` from the file path / object key).
-
-YAML example:
-
-```yaml
-kind: s3
-config:
-  # ... existing fields ...
-  compression: auto  # or 'gzip' | 'zstd' | 'none'
-```
-
-The codec resolves from `file_extension`. Append `.gz` / `.zst` to `file_extension` so consumers can detect the codec from the object key. The S3 `Content-Encoding` header is deliberately unset — consumers must decompress explicitly.
+UUID keys make writes idempotent-safe against collisions but mean re-runs append new objects rather than overwriting — downstream consumers should treat the prefix as append-only.
 
 ## Lineage dataset URI
 
-`s3://<bucket>/<prefix>` — e.g. `s3://my-bucket/data/events/`.
+`s3://<bucket>/<prefix>` — e.g. `s3://my-data-lake/events/raw/`.
+
+## Feature flags
+
+| Feature | Default | Effect |
+|---------|---------|--------|
+| `compression` | off | Adds the `compression` config field (gzip / zstd / auto) and compresses each object body before upload. Pulls in `faucet-core/compression`. |
+
+This is a write-only file sink: it does **not** support exactly-once delivery, upsert/delete write modes, or resumable bookmarks (UUID keys make every run append new objects).
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause & fix |
+|---------|--------------------|
+| `S3 put object error … AccessDenied` | The resolved credentials lack `s3:PutObject` on the bucket/prefix. Grant the IAM principal `s3:PutObject` (and `s3:ListBucket` if `faucet doctor` is used) on `arn:aws:s3:::<bucket>/<prefix>*`. |
+| `dispatch failure` / no credentials | The AWS SDK chain found no credentials. Set `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`, configure `~/.aws/credentials`, or run on a host with an instance/task role. |
+| `NoSuchBucket` / `PermanentRedirect` | Bucket doesn't exist, or `region` doesn't match the bucket's region. Set `region` to the bucket's actual region. |
+| Works against AWS but not MinIO/LocalStack | Set `endpoint_url` to the service URL and a non-empty `region` (e.g. `us-east-1`); S3-compatible stores still require a region string. |
+| `Config: batch_size …` at startup | `batch_size` exceeds `MAX_BATCH_SIZE` (1,000,000). Lower it, or set `0` for no re-chunking. |
+| Flood of tiny objects, slow downstream scans | `batch_size`/`max_records_per_file` are too small. Set `batch_size: 0` and let the source size each page, or raise `max_records_per_file`. |
+| OOM / high memory under load | Large pages × `concurrency` are buffered in memory. Lower `concurrency`, set `max_records_per_file`, or feed from a streaming source that sizes its pages. |
+| Compressed objects won't auto-decompress in a consumer | The `Content-Encoding` header is intentionally unset. Decompress by the key suffix (`.gz` / `.zst`), or use [`faucet-source-s3`](https://crates.io/crates/faucet-source-s3) with its `compression` feature. |
+
+## See also
+
+- [Compression cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/compression.html) — codecs, auto-detection, and the `Content-Encoding` note.
+- [Connector reference & capability matrix](https://pawansikawat.github.io/faucet-stream/reference/connectors.html)
+- [CLI & config-file reference](https://pawansikawat.github.io/faucet-stream/reference/cli.html)
+- [`faucet-source-s3`](https://crates.io/crates/faucet-source-s3) — read JSONL / JSON-array / raw-text objects back out of S3.
+- [`faucet-sink-gcs`](https://crates.io/crates/faucet-sink-gcs) — the equivalent sink for Google Cloud Storage.
+- [`faucet-sink-parquet`](https://crates.io/crates/faucet-sink-parquet) — columnar output to local or S3 with internal compression.
 
 ## License
 
-Licensed under MIT or Apache-2.0.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/sink/snowflake/README.md
+++ b/crates/sink/snowflake/README.md
@@ -5,126 +5,206 @@
 [![MSRV](https://img.shields.io/crates/msrv/faucet-sink-snowflake.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
 [![License](https://img.shields.io/crates/l/faucet-sink-snowflake.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-Snowflake sink connector for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
+**Snowflake** sink for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem. Writes JSON records to a Snowflake table over the [Snowflake SQL REST API](https://docs.snowflake.com/en/developer-guide/sql-api/index) — no driver, no ODBC, no client library, just HTTPS.
 
-Writes JSON records to a Snowflake table using the Snowflake SQL REST API. Supports JWT key-pair authentication and OAuth. Records are inserted using `PARSE_JSON` with `FLATTEN` for efficient batch loading; the JSON array is passed as a bound `TEXT` parameter (`PARSE_JSON(?)`) rather than interpolated into the SQL, so apostrophes and other quote characters in the data are safe and cannot inject SQL. All table and schema identifiers are quoted as well.
+Reach for it when you want to land records from any faucet-stream source — a REST API, a database, a file, a queue — into Snowflake with one declarative config. Each batch is parsed and inserted in a single `PARSE_JSON` + `FLATTEN` statement, and the JSON array travels as a bound `TEXT` parameter (`PARSE_JSON(?)`) rather than interpolated into SQL, so quote characters in your data are safe and cannot inject SQL.
+
+## Feature highlights
+
+- **Driverless SQL REST API** — pure HTTPS against `https://{account}.snowflakecomputing.com/api/v2/statements`. The HTTP client is built once in `new()` and reused for every request.
+- **Two auth methods** — JWT **key-pair** (RS256, minted locally from your RSA private key with the public-key SHA-256 fingerprint in the `iss` claim) or **OAuth** bearer tokens from an external identity provider.
+- **Shared auth providers** — the `auth` field also accepts `{ ref: <name> }`, pointing at a provider in the CLI's top-level `auth:` catalog (OAuth/bearer tokens only; key-pair JWT is always inline). N matrix rows hitting one IdP then share a single token.
+- **Set-based batch inserts** — one `INSERT … SELECT … FROM TABLE(FLATTEN(input => PARSE_JSON(?)))` per chunk parses and inserts the whole batch in a single statement.
+- **Configurable batching** — `batch_size` controls rows per request (default `1000`, the documented sweet spot); `batch_size: 0` forwards each upstream page untouched.
+- **Async-execution aware** — when Snowflake answers an `INSERT` with HTTP 202 (queued, not yet run), the sink polls the statement handle until it succeeds before counting rows as written, bounded by `poll_timeout`.
+- **SQL-injection-safe** — data is bound, never interpolated; all table/schema/database identifiers are quoted.
+- **Preflight probe** — `faucet doctor` runs a read-only `SELECT 1` to confirm credentials and warehouse access without writing rows.
 
 ## Installation
 
 ```bash
+# As a library:
 cargo add faucet-sink-snowflake
-cargo add tokio --features full
+
+# Via the umbrella crate:
+cargo add faucet-stream --features sink-snowflake
+
+# In the CLI (opt-in connector feature):
+cargo install faucet-cli --features sink-snowflake
 ```
 
-Or via the umbrella crate:
+## Quick start
+
+```yaml
+# pipeline.yaml — faucet run pipeline.yaml
+version: 1
+pipeline:
+  source:
+    type: s3
+    config:
+      bucket: my-data-lake
+      prefix: raw/events/
+      region: us-east-1
+      file_format: json_lines
+  sink:
+    type: snowflake
+    config:
+      account: xy12345.us-east-1
+      warehouse: LOAD_WH
+      database: ANALYTICS
+      schema: RAW
+      table: EVENTS
+      auth:
+        type: key_pair
+        config:
+          user: LOADER
+          private_key_pem: ${file:./snowflake_key.pem}
+      batch_size: 1000
+```
 
 ```bash
-cargo add faucet-stream --features sink-snowflake
+faucet run pipeline.yaml
 ```
 
-## Quick Start
+## Configuration reference
 
-```rust
-use faucet_sink_snowflake::{SnowflakeSink, SnowflakeSinkConfig, SnowflakeAuth};
-use faucet_core::Sink;
-use serde_json::json;
-
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let config = SnowflakeSinkConfig::new(
-        "xy12345.us-east-1",
-        "COMPUTE_WH",
-        "ANALYTICS_DB",
-        "PUBLIC",
-        "events",
-        SnowflakeAuth::OAuth { token: std::env::var("SNOWFLAKE_TOKEN")? },
-    )
-    .with_batch_size(1000);
-
-    let sink = SnowflakeSink::new(config)?;
-
-    let records = vec![
-        json!({"user_id": "u123", "event": "page_view", "ts": "2026-04-02T10:00:00Z"}),
-        json!({"user_id": "u456", "event": "click", "ts": "2026-04-02T10:01:00Z"}),
-    ];
-
-    let rows_written = sink.write_batch(&records).await?;
-    println!("Wrote {rows_written} rows to Snowflake");
-
-    Ok(())
-}
-```
-
-## Configuration
+### Core
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `account` | `String` | *(required)* | Snowflake account identifier (e.g. `"xy12345.us-east-1"`) |
-| `warehouse` | `String` | *(required)* | Warehouse to use for the session |
-| `database` | `String` | *(required)* | Database name |
-| `schema` | `String` | *(required)* | Schema name |
-| `table` | `String` | *(required)* | Target table name |
-| `auth` | `SnowflakeAuth` | *(required)* | Authentication credentials (see below) |
-| `batch_size` | `usize` | `1000` | Maximum number of records per Snowflake SQL REST API request. See [Streaming and batching](#streaming-and-batching) below |
-| `poll_timeout` | `Duration` (seconds) | `300` | Maximum wall-clock time to wait for an asynchronously-executed INSERT to finish. See [Asynchronous execution](#asynchronous-execution) below. `0` = poll forever |
+| `account` | string | — *(required)* | Snowflake account identifier (e.g. `"xy12345.us-east-1"`). Used to build the API host `https://{account}.snowflakecomputing.com`. |
+| `warehouse` | string | — *(required)* | Warehouse used for the session executing the inserts. |
+| `database` | string | — *(required)* | Target database name. |
+| `schema` | string | — *(required)* | Target schema name. |
+| `table` | string | — *(required)* | Target table name. |
+| `auth` | `AuthSpec<SnowflakeAuth>` | — *(required)* | Authentication — inline `{ type, config }` or `{ ref: <name> }`. See [Authentication](#authentication). |
 
-### Streaming and batching
+### Batching & reliability
 
-`SnowflakeSink::write_batch` re-chunks the incoming records slice into
-`batch_size` slices and issues one Snowflake SQL REST API request per
-chunk. The default of `1000` matches the documented sweet spot for the
-SQL REST API — Snowflake recommends roughly that many rows per request
-to balance round-trip overhead against request-body size and statement
-parse cost. Tune up for wide rows (lower per-row byte budget) or down
-for narrow rows where round-trip latency dominates.
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `batch_size` | int | `1000` | Maximum records per SQL REST API request. The sink re-chunks each incoming slice into `batch_size` slices and issues one `INSERT` per chunk. **`0` = no batching**: the whole slice is sent in one `INSERT`, no matter how large. Values above `MAX_BATCH_SIZE` (1,000,000) are rejected by `faucet_core::validate_batch_size`. |
+| `poll_timeout` | int (seconds) | `300` | Max wall-clock time to wait for an asynchronously-executed `INSERT` (HTTP 202) to finish before failing with `FaucetError::Sink`. **`0` = poll forever.** See [Asynchronous execution](#asynchronous-execution). |
 
-`batch_size = 0` is the **"no batching" sentinel** — `write_batch`
-forwards the entire records slice in a single INSERT request, no matter
-how large, so upstream `StreamPage` framing flows through untouched.
-Use it when the upstream source already emits pages sized for the
-ultimate target (e.g. a custom matrix that pairs Snowflake with a source
-configured for one large page per write). Values larger than
-`MAX_BATCH_SIZE` (1,000,000) are rejected by
-`faucet_core::validate_batch_size`.
+## Authentication
+
+`auth` uses the shared `SnowflakeAuth` enum (re-exported from [`faucet-common-snowflake`](https://crates.io/crates/faucet-common-snowflake), so it matches the Snowflake **source** byte-for-byte) in the project-wide `{ type, config }` shape. The `Debug` impl masks `private_key_pem` and `token` as `***`.
+
+| `type` | `config` | Use when |
+|--------|----------|----------|
+| `key_pair` | `{ user: <string>, private_key_pem: <PEM string> }` | You have an RSA key pair registered on the Snowflake user. The sink mints an RS256 JWT locally (1-hour expiry, public-key SHA-256 fingerprint in the `iss` claim). |
+| `oauth` | `{ token: <string> }` | You have an OAuth2 bearer token from an external IdP. Sent as `Snowflake Token="…"`. |
+
+```yaml
+# Key-pair JWT (PEM inlined from disk via the file: directive)
+auth:
+  type: key_pair
+  config:
+    user: INGEST_USER
+    private_key_pem: ${file:./snowflake_key.pem}
+```
+
+```yaml
+# OAuth bearer token via env indirection
+auth:
+  type: oauth
+  config:
+    token: ${env:SNOWFLAKE_TOKEN}
+```
+
+```yaml
+# Shared provider from the top-level auth: catalog (OAuth/bearer only)
+auth:
+  ref: snowflake_idp
+```
+
+> **Note:** a shared `auth: { ref }` provider must yield a `Bearer` or `Token` credential, which maps onto `SnowflakeAuth::OAuth`. Key-pair JWT is stateless (minted locally from the RSA key) and therefore must always be supplied inline.
+
+## Examples
+
+### Postgres → Snowflake with key-pair auth
+
+```yaml
+version: 1
+name: postgres_to_snowflake
+pipeline:
+  source:
+    type: postgres
+    config:
+      connection_url: postgres://user:pass@localhost/app
+      query: SELECT id, email, created_at FROM users WHERE tenant_id = $1
+      params:
+        - acme
+  sink:
+    type: snowflake
+    config:
+      account: xy12345.us-east-1
+      warehouse: INGEST_WH
+      database: ANALYTICS
+      schema: RAW
+      table: USERS
+      auth:
+        type: key_pair
+        config:
+          user: INGEST_USER
+          private_key_pem: ${file:./snowflake_key.pem}
+      batch_size: 500
+```
+
+### Latency-sensitive stream with small batches
+
+```yaml
+sink:
+  type: snowflake
+  config:
+    account: xy12345.us-east-1
+    warehouse: COMPUTE_WH
+    database: MY_DB
+    schema: PUBLIC
+    table: realtime_events
+    auth:
+      type: oauth
+      config: { token: ${env:SNOWFLAKE_TOKEN} }
+    batch_size: 50      # smaller chunks → lower per-row latency
+```
+
+### Large load with no re-chunking
+
+```yaml
+sink:
+  type: snowflake
+  config:
+    account: xy12345.us-east-1
+    warehouse: LOAD_WH
+    database: ANALYTICS
+    schema: RAW
+    table: EVENTS
+    auth:
+      type: key_pair
+      config:
+        user: LOADER
+        private_key_pem: ${file:./snowflake_key.pem}
+    batch_size: 0          # forward each upstream page as one INSERT
+    poll_timeout: 900      # allow up to 15 min for a queued statement to run
+```
+
+## Streaming & batching
+
+`SnowflakeSink::write_batch` re-chunks the incoming records slice into `batch_size` slices and issues one SQL REST API `INSERT` per chunk. The default of `1000` matches Snowflake's documented sweet spot for the SQL API — enough rows to amortize the round-trip and statement-parse cost without bloating the request body. Tune **up** for narrow rows where round-trip latency dominates, **down** for wide rows where request-body size dominates.
+
+`batch_size = 0` is the **"no batching" sentinel**: `write_batch` forwards the entire slice as a single `INSERT`, so the upstream source's `StreamPage` framing flows through untouched. Use it when the source already emits pages sized for the target (e.g. one large page per write).
 
 ### Asynchronous execution
 
-Snowflake's SQL REST API may answer a submitted INSERT with **HTTP 202
-Accepted** — the statement was queued but has not yet executed. The sink
-does **not** count those rows as written at that point; doing so would
-report success before the data is durable. Instead it polls
-`GET /api/v2/statements/{handle}` until the statement reports success
-(`code 090001`), then returns. The poll loop is bounded by `poll_timeout`
-(default 300 s): if the statement is still running after that budget, the
-write fails with a `FaucetError::Sink` rather than hanging forever. Set
-`poll_timeout = 0` to poll indefinitely.
+Snowflake's SQL REST API may answer a submitted `INSERT` with **HTTP 202 Accepted** — the statement was queued but has not yet executed. The sink does **not** count those rows as written at that point (that would report success before the data is durable). Instead it polls `GET /api/v2/statements/{handle}` until the statement reports success (code `090001`), then returns. The poll loop is bounded by `poll_timeout` (default 300 s): if the statement is still running after that budget, the write fails with `FaucetError::Sink` rather than hanging forever. Set `poll_timeout: 0` to poll indefinitely.
 
-### Authentication (`SnowflakeAuth`)
+## Config loading & schema
 
-| Variant | Fields | Description |
-|---------|--------|-------------|
-| `KeyPair` | `user: String`, `private_key_pem: String` | JWT key-pair authentication using an RSA private key (PEM-encoded). Generates RS256 JWT tokens with the Snowflake `ACCOUNT.USER` as the issuer and subject. Tokens are valid for 1 hour. |
-| `OAuth` | `token: String` | OAuth2 bearer token from an external identity provider. Sent as `Snowflake Token="..."` in the Authorization header. |
+Load from YAML/JSON or environment, and inspect the full JSON Schema:
 
-The `Debug` implementation masks `private_key_pem` and `token` with `***` to prevent credential leakage in logs.
-
-### Builder Methods
-
-```rust
-use faucet_sink_snowflake::{SnowflakeSinkConfig, SnowflakeAuth};
-
-let config = SnowflakeSinkConfig::new(
-    "xy12345.us-east-1",
-    "COMPUTE_WH",
-    "MY_DB",
-    "PUBLIC",
-    "events",
-    SnowflakeAuth::OAuth { token: "my-oauth-token".into() },
-)
-.with_batch_size(1000);
+```bash
+faucet schema sink snowflake
 ```
-
-## Config Loading
 
 ```rust
 use faucet_core::config::{load_json, load_env_file};
@@ -132,46 +212,9 @@ use faucet_sink_snowflake::SnowflakeSinkConfig;
 
 // From a JSON file
 let config: SnowflakeSinkConfig = load_json("config.json")?;
-
 // From an .env file with a prefix
 let config: SnowflakeSinkConfig = load_env_file(".env", "SNOWFLAKE")?;
 ```
-
-### Example JSON config (OAuth)
-
-```json
-{
-  "account": "xy12345.us-east-1",
-  "warehouse": "COMPUTE_WH",
-  "database": "ANALYTICS_DB",
-  "schema": "PUBLIC",
-  "table": "events",
-  "auth": {
-    "type": "oauth",
-    "config": { "token": "eyJhbGciOiJSUzI1NiIs..." }
-  },
-  "batch_size": 1000
-}
-```
-
-### Example JSON config (KeyPair JWT)
-
-```json
-{
-  "account": "xy12345.us-east-1",
-  "warehouse": "COMPUTE_WH",
-  "database": "ANALYTICS_DB",
-  "schema": "RAW",
-  "table": "ingest_events",
-  "auth": {
-    "type": "key_pair",
-    "config": { "user": "DATA_LOADER", "private_key_pem": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBAD..." }
-  },
-  "batch_size": 250
-}
-```
-
-### Example .env file
 
 ```env
 SNOWFLAKE_ACCOUNT=xy12345.us-east-1
@@ -183,112 +226,76 @@ SNOWFLAKE_AUTH='{"type":"oauth","config":{"token":"eyJhbGciOiJSUzI1NiIs..."}}'
 SNOWFLAKE_BATCH_SIZE=1000
 ```
 
-## Config Schema Introspection
+## Library usage
 
 ```rust
-use faucet_core::Sink;
+use faucet_core::{Pipeline, Sink};
+use faucet_sink_snowflake::{SnowflakeAuth, SnowflakeSink, SnowflakeSinkConfig};
+use serde_json::json;
 
-let sink = SnowflakeSink::new(config)?;
-let schema = sink.config_schema();
-println!("{}", serde_json::to_string_pretty(&schema)?);
-```
-
-## Pipeline Usage
-
-```rust
-use faucet_core::Pipeline;
-use faucet_source_rest::{RestStream, RestStreamConfig};
-use faucet_sink_snowflake::{SnowflakeSink, SnowflakeSinkConfig, SnowflakeAuth};
-
-let source = RestStream::new(
-    RestStreamConfig::new("https://api.example.com", "/v1/events")
-);
-
-let sink = SnowflakeSink::new(SnowflakeSinkConfig::new(
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let config = SnowflakeSinkConfig::new(
     "xy12345.us-east-1",
     "COMPUTE_WH",
     "ANALYTICS_DB",
     "PUBLIC",
     "events",
-    SnowflakeAuth::OAuth { token: "my-token".into() },
-))?;
-
-let result = Pipeline::new(source, sink).run().await?;
-println!("Transferred {} records", result.records_written);
-```
-
-## Examples
-
-### JWT key-pair authentication
-
-```rust
-let private_key = std::fs::read_to_string("/path/to/rsa_key.pem")?;
-
-let config = SnowflakeSinkConfig::new(
-    "xy12345.us-east-1",
-    "ETL_WH",
-    "RAW_DB",
-    "INGEST",
-    "api_events",
-    SnowflakeAuth::KeyPair {
-        user: "ETL_SERVICE_USER".into(),
-        private_key_pem: private_key,
-    },
+    SnowflakeAuth::OAuth { token: std::env::var("SNOWFLAKE_TOKEN")? },
 )
-.with_batch_size(500);
+.with_batch_size(1000);
 
 let sink = SnowflakeSink::new(config)?;
-sink.write_batch(&records).await?;
+
+let records = vec![
+    json!({"user_id": "u123", "event": "page_view", "ts": "2026-04-02T10:00:00Z"}),
+    json!({"user_id": "u456", "event": "click",     "ts": "2026-04-02T10:01:00Z"}),
+];
+let rows_written = sink.write_batch(&records).await?;
+println!("Wrote {rows_written} rows to Snowflake");
+# Ok(())
+# }
 ```
 
-### OAuth authentication
+To drive it end-to-end, pair it with any source via `Pipeline::new(source, sink).run().await?`.
 
-```rust
-let token = std::env::var("SNOWFLAKE_OAUTH_TOKEN")?;
+## How it works
 
-let config = SnowflakeSinkConfig::new(
-    "xy12345.us-east-1",
-    "COMPUTE_WH",
-    "ANALYTICS",
-    "PUBLIC",
-    "metrics",
-    SnowflakeAuth::OAuth { token },
-);
-
-let sink = SnowflakeSink::new(config)?;
-sink.write_batch(&records).await?;
-```
-
-### Small batch sizes for latency-sensitive workloads
-
-```rust
-let config = SnowflakeSinkConfig::new(
-    "xy12345.us-east-1",
-    "COMPUTE_WH",
-    "MY_DB",
-    "PUBLIC",
-    "realtime_events",
-    SnowflakeAuth::OAuth { token: "...".into() },
-)
-.with_batch_size(50);
-
-let sink = SnowflakeSink::new(config)?;
-```
-
-## How It Works
-
-- `SnowflakeSink::new()` creates an HTTP client (reused across all requests) but does not make any network calls.
-- `write_batch()` splits records into chunks of `batch_size` (or forwards the entire slice in one request when `batch_size = 0`). For each chunk, it builds an INSERT statement using `PARSE_JSON(?)` with `FLATTEN` and sends the chunk's JSON array as a bound `TEXT` parameter, parsing and inserting all rows in a single SQL statement without interpolating data into the SQL text.
-- **Field-to-column mapping:** each record's top-level keys are projected into matching table columns — `INSERT INTO "db"."schema"."tbl" ("col1", "col2") SELECT value:"col1"::string, value:"col2"::string FROM TABLE(FLATTEN(input => PARSE_JSON(?)))`. The `::string` cast strips the VARIANT's JSON quotes and lets Snowflake coerce each scalar into the destination column's type on `INSERT` (text → number / boolean / timestamp, etc.). The column set is taken from the **first record**; a key absent from a later record is inserted as `NULL`. Both column identifiers and JSON path keys are quote-escaped, so record keys cannot inject SQL. (This replaces an earlier `SELECT *` over `FLATTEN`, which inserted FLATTEN's `SEQ/KEY/PATH/INDEX/VALUE/THIS` metadata columns instead of the record's fields.) The target table's columns should be **scalar**; a key targeting a semi-structured (`VARIANT`/`OBJECT`/`ARRAY`) column is stringified rather than stored as structured JSON.
-- The SQL statement targets the fully qualified table name `"database"."schema"."table"` with quoted identifiers.
-- Authentication headers are generated per request: JWT tokens for KeyPair auth (with 1-hour expiry), or the `Snowflake Token="..."` header for OAuth.
-- The Snowflake SQL REST API endpoint is `https://{account}.snowflakecomputing.com/api/v2/statements`.
-- Successful execution is validated by checking for the `090001` response code ("Statement executed successfully").
+1. `SnowflakeSink::new()` builds an HTTP client (reused across all requests). No network call happens at construction.
+2. `write_batch()` splits records into `batch_size` chunks (or one chunk when `batch_size = 0`). For each chunk it builds an `INSERT` using `PARSE_JSON(?)` + `FLATTEN` and sends the chunk's JSON array as a **bound `TEXT` parameter**, parsing and inserting every row in one statement without interpolating data into the SQL text.
+3. **Field-to-column mapping:** each record's top-level keys project into matching table columns — `INSERT INTO "db"."schema"."tbl" ("col1","col2") SELECT value:"col1"::string, value:"col2"::string FROM TABLE(FLATTEN(input => PARSE_JSON(?)))`. The `::string` cast strips the VARIANT's JSON quotes so Snowflake coerces each scalar into the destination column's type on insert (text → number / boolean / timestamp, etc.). The column set comes from the **first record**; a key absent from a later record is inserted as `NULL`. Target columns should be **scalar** — a key targeting a `VARIANT`/`OBJECT`/`ARRAY` column is stringified, not stored as structured JSON. Both column identifiers and JSON path keys are quote-escaped, so record keys cannot inject SQL.
+4. The statement targets the fully-qualified `"database"."schema"."table"` with quoted identifiers.
+5. Auth headers are generated per request: an RS256 JWT (1-hour expiry, public-key fingerprint in `iss`) for `key_pair`, or `Snowflake Token="…"` for `oauth`.
+6. Success is confirmed by the `090001` response code; an HTTP 202 enters the [async-execution poll loop](#asynchronous-execution).
 
 ## Lineage dataset URI
 
-`snowflake://<account>/<database>/<schema>?table=<table>` — e.g. `snowflake://myacct.us-east-1/mydb/PUBLIC?table=events`.
+`snowflake://<account>/<database>/<schema>?table=<table>` — e.g. `snowflake://xy12345.us-east-1/ANALYTICS_DB/PUBLIC?table=events`.
+
+## Feature flags
+
+This crate has no optional features of its own; enable it in the CLI/umbrella via the `sink-snowflake` feature.
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause & fix |
+|---------|--------------------|
+| `Auth` error / 401 | Credentials rejected. For `key_pair`, confirm the **public** key is registered on the Snowflake user (`ALTER USER … SET RSA_PUBLIC_KEY=…`) and the PEM is a valid RSA private key (PKCS#8 `BEGIN PRIVATE KEY` or PKCS#1 `BEGIN RSA PRIVATE KEY`). For `oauth`, check the token isn't expired and matches the account's configured OAuth integration. Run `faucet doctor` for a one-shot `SELECT 1` probe. |
+| `invalid RSA private key` | The `private_key_pem` body isn't a parseable RSA key — check the `${file:…}` path resolved and the PEM wasn't truncated/escaped. |
+| `Snowflake auth provider must yield a bearer/token credential` | You pointed `auth: { ref }` at a non-bearer shared provider, or tried key-pair via a provider. Key-pair JWT must be inline; shared providers only supply OAuth/bearer tokens. |
+| Rows silently land as `NULL` | A record key doesn't match a table column name (case-sensitive — Snowflake folds unquoted identifiers to uppercase). Ensure record keys match the **quoted** column names exactly. |
+| Structured field stored as a JSON string | The target column isn't scalar. The `::string` cast stringifies `VARIANT`/`OBJECT`/`ARRAY` targets — land those into a `VARIANT` column with a transform, or split the field. |
+| Write fails with `FaucetError::Sink: … timed out` | The queued statement didn't finish within `poll_timeout`. Raise `poll_timeout` (or set `0`), and make sure the `warehouse` is not suspended / can resume. |
+| `batch_size` rejected | Values above `MAX_BATCH_SIZE` (1,000,000) are invalid. Use `0` for "no batching", or a value ≤ 1,000,000. |
+| First record's columns don't cover all rows | The column set is taken from the first record. Put a record with the full key set first, or normalize keys with an upstream transform so every row shares the same shape. |
+
+## See also
+
+- [Snowflake source](https://crates.io/crates/faucet-source-snowflake) — query Snowflake via the same SQL REST API.
+- [faucet-common-snowflake](https://crates.io/crates/faucet-common-snowflake) — the shared `SnowflakeAuth` enum and auth helpers.
+- [Sinks reference](https://pawansikawat.github.io/faucet-stream/reference/connectors.html) — capability matrix across all connectors.
+- [Authentication cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/auth.html) — the shared `auth:` provider catalog.
+- [Secrets cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/secrets.html) — injecting the PEM / token from a secrets manager.
 
 ## License
 
-Licensed under MIT or Apache-2.0.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/sink/snowflake/README.md
+++ b/crates/sink/snowflake/README.md
@@ -2,6 +2,8 @@
 
 [![Crates.io](https://img.shields.io/crates/v/faucet-sink-snowflake.svg)](https://crates.io/crates/faucet-sink-snowflake)
 [![Docs.rs](https://docs.rs/faucet-sink-snowflake/badge.svg)](https://docs.rs/faucet-sink-snowflake)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-sink-snowflake.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-sink-snowflake.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
 Snowflake sink connector for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
 

--- a/crates/sink/sqlite/README.md
+++ b/crates/sink/sqlite/README.md
@@ -2,6 +2,8 @@
 
 [![Crates.io](https://img.shields.io/crates/v/faucet-sink-sqlite.svg)](https://crates.io/crates/faucet-sink-sqlite)
 [![Docs.rs](https://docs.rs/faucet-sink-sqlite/badge.svg)](https://docs.rs/faucet-sink-sqlite)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-sink-sqlite.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-sink-sqlite.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
 SQLite sink connector for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
 

--- a/crates/sink/sqlite/README.md
+++ b/crates/sink/sqlite/README.md
@@ -5,199 +5,95 @@
 [![MSRV](https://img.shields.io/crates/msrv/faucet-sink-sqlite.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
 [![License](https://img.shields.io/crates/l/faucet-sink-sqlite.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-SQLite sink connector for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
+**SQLite** sink for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem. Writes JSON records into a SQLite table — either as serialized JSON text in a single column, or with top-level JSON keys auto-mapped to real table columns.
 
-Writes JSON records to a SQLite table using either JSON column mode (storing each record as a serialized JSON text value) or AutoMap mode (mapping top-level JSON keys directly to table columns). Uses connection pooling via `sqlx`, multi-row `INSERT` statements, and wraps each batch in a transaction (`BEGIN`/`COMMIT`) for maximum write throughput. Column discovery uses `PRAGMA table_info`.
+Reach for it when you want a zero-dependency, embedded landing table on local disk (or in memory) — a fast, transactional destination for events, change-data-capture mirrors, dev/test fixtures, or any pipeline that just needs a queryable file. The whole batch commits atomically inside a `BEGIN`/`COMMIT` transaction, so a partial write never leaves the table half-populated.
 
-`write_batch` accepts whatever slice the pipeline hands it. When `batch_size > 0` and the slice is larger than `batch_size`, the sink re-chunks internally and issues one multi-row INSERT (in its own transaction) per chunk; when `batch_size = 0`, the entire slice is written in a single transaction — see [Streaming and batching](#streaming-and-batching) for the tradeoffs.
+## Feature highlights
+
+- **Two write strategies** — store each record as a serialized JSON text value (`json` mode), or auto-map top-level JSON keys directly onto table columns (`auto_map` mode) discovered via `PRAGMA table_info`.
+- **Transactional batches** — every chunk is one multi-row `INSERT` wrapped in a `BEGIN`/`COMMIT`, so a batch commits all-or-nothing.
+- **High write throughput** — multi-row INSERTs, WAL journal mode, and a 5-second `busy_timeout` keep the single writer fast and lock-tolerant.
+- **Parameter-limit aware** — in `auto_map` mode the sink splits each chunk so `rows × columns` never exceeds SQLite's `SQLITE_MAX_VARIABLE_NUMBER`, so wide tables never fail with "too many SQL variables".
+- **Native-typed binds** — in `auto_map` mode strings bind as `TEXT`, JSON numbers as `INTEGER`/`REAL`, booleans as `INTEGER` 0/1; arrays/objects bind as JSON text — so column affinity round-trips correctly.
+- **Write modes** — `append` (default), `upsert` (`INSERT … ON CONFLICT … DO UPDATE`), and `delete`, all keyed on a UNIQUE/PRIMARY KEY column set.
+- **Exactly-once delivery** — pairs with a CDC source to commit records and a watermark token in one transaction.
+- **Dead-letter queue** — per-row error reporting routes failing rows to a DLQ instead of failing the whole batch.
 
 ## Installation
 
 ```bash
+# As a library:
 cargo add faucet-sink-sqlite
 cargo add tokio --features full
-```
 
-Or via the umbrella crate:
+# In the CLI (opt-in connector feature):
+cargo install faucet-cli --features sink-sqlite
 
-```bash
+# Or via the umbrella crate:
 cargo add faucet-stream --features sink-sqlite
 ```
 
-## Quick Start
+## Quick start
 
-```rust
-use faucet_sink_sqlite::{SqliteSink, SqliteSinkConfig};
-use faucet_core::Sink;
-use serde_json::json;
-
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let config = SqliteSinkConfig::new("sqlite:///tmp/app.db", "events");
-    let sink = SqliteSink::new(config).await?;
-
-    let records = vec![
-        json!({"user_id": "u123", "event": "signup"}),
-        json!({"user_id": "u456", "event": "login"}),
-    ];
-
-    let rows_written = sink.write_batch(&records).await?;
-    println!("Wrote {rows_written} rows");
-
-    Ok(())
-}
+```yaml
+# pipeline.yaml — faucet run pipeline.yaml
+version: 1
+pipeline:
+  source:
+    type: rest
+    config:
+      base_url: https://api.example.com
+      endpoint: /v1/events
+  sink:
+    type: sqlite
+    config:
+      database_url: /data/app.db
+      table_name: events
+      column_mapping: auto_map
 ```
 
-## Configuration
+```bash
+faucet run pipeline.yaml
+```
+
+## Configuration reference
+
+### Core
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `database_url` | `String` | *(required)* | SQLite database URL. Can be a file path (e.g. `/tmp/app.db`), a `sqlite:` URL, or `sqlite::memory:` for an in-memory database. |
-| `table_name` | `String` | *(required)* | Target table name |
-| `column_mapping` | `SqliteColumnMapping` | `Json { column: "data" }` | How to map JSON records to table columns (see below) |
-| `batch_size` | `usize` | `1000` | Maximum number of rows per multi-row INSERT. See [Streaming and batching](#streaming-and-batching) below |
-| `max_connections` | `u32` | `1` | Maximum number of connections in the connection pool. SQLite serializes writers at the file level, so one writer is the safe default — a multi-connection pool against a single file races for the write lock and risks `SQLITE_BUSY`. The pool opens connections in WAL mode with a 5s `busy_timeout`, so raising this lets extra connections read concurrently with the single writer. |
-| `write_mode` | `"append"` \| `"upsert"` \| `"delete"` | `"append"` | Write semantics. Upsert/delete require `column_mapping: auto_map` and a UNIQUE/PRIMARY KEY on `key`. |
-| `key` | `[String]` | `[]` | Key column(s) for upsert/delete. Must be non-empty when `write_mode` is not `append`. |
-| `delete_marker` | object | absent | `upsert` only: identifies delete-flagged rows by field name + value list. |
+| `database_url` | string | — *(required)* | SQLite database URL. A file path (`/tmp/app.db`), a `sqlite:` URL, or `sqlite::memory:` for an in-memory database. The file (and parent dirs) is created if missing. |
+| `table_name` | string | — *(required)* | Target table name. Must already exist with the appropriate columns. |
+| `column_mapping` | `SqliteColumnMapping` | `{ json: { column: "data" } }` | How JSON records map to columns — see [Column mapping](#column-mapping). |
 
-### Streaming and batching
+### Batching & pooling
 
-The SQLite sink re-chunks each incoming `StreamPage` to keep individual
-multi-row INSERT statements within SQLite's per-statement parameter limits
-and to amortise per-transaction overhead.
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `batch_size` | int | `1000` | Maximum rows per multi-row INSERT. **`0` = no batching** (write the whole page in one transaction). See [Streaming & batching](#streaming--batching). |
+| `max_connections` | int | `1` | Connections in the pool. SQLite serializes writers at the file level, so one writer is the safe default — a multi-connection pool against one file races for the write lock and risks `SQLITE_BUSY`. Connections open in WAL mode with a 5s `busy_timeout`, so raising this lets extra connections read concurrently with the single writer. |
 
-- **`batch_size > 0`** (default `1000`) — the sink slices the incoming
-  slice into `batch_size`-row chunks and issues one multi-row INSERT per
-  chunk, each wrapped in its own `BEGIN`/`COMMIT` transaction.
-  **Recommended value is `1000`**: large enough to amortise transaction
-  overhead, small enough to stay well under SQLite's default
-  `SQLITE_MAX_VARIABLE_NUMBER` (32766 since 3.32.0). In AutoMap mode the
-  sink also splits each chunk further so `rows × columns` never exceeds that
-  limit, so a wide table no longer fails with "too many SQL variables"
-  regardless of `batch_size`.
-- **`batch_size = 0`** — the "no batching" sentinel. The entire upstream
-  `StreamPage` is written in a single multi-row INSERT inside one
-  transaction. Use this when the source already emits page sizes tuned for
-  SQLite — for example a Postgres source with `batch_size: 1000`. Pages
-  large enough to push the parameter count past SQLite's per-statement
-  limit will fail at the prepare step.
+### Write mode
 
-`batch_size` is purely a chunk-size knob — transaction wrapping (one
-`BEGIN`/`COMMIT` per chunk), identifier quoting, and per-record error
-reporting are unchanged.
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `write_mode` | `"append"` \| `"upsert"` \| `"delete"` | `"append"` | Write semantics. Upsert/delete require `column_mapping: auto_map` and a UNIQUE/PRIMARY KEY on `key`. See [Write modes](#write-modes-upsert--delete). |
+| `key` | `[string]` | `[]` | Key column(s) for upsert/delete. Required and non-empty when `write_mode` is not `append`. |
+| `delete_marker` | `{ field: string, values: [string] }` | absent | `upsert` only: rows whose `field` matches one of `values` are routed to `DELETE`; the marker field is stripped from upsert rows. |
 
-### Column Mapping (`SqliteColumnMapping`)
+### Column mapping (`SqliteColumnMapping`)
 
-| Variant | Description |
-|---------|-------------|
-| `Json { column }` | Insert each record as a serialized JSON text string in a single column. The column name defaults to `"data"` but can be overridden. Uses a multi-row INSERT wrapped in a transaction. |
-| `AutoMap` | Map top-level JSON keys directly to table columns. Column names are discovered using `PRAGMA table_info(table_name)`. Only keys that match existing columns are inserted; extra keys are silently ignored. Records with no matching keys are skipped with a warning. |
-
-### Builder Methods
-
-```rust
-use faucet_sink_sqlite::{SqliteSinkConfig, SqliteColumnMapping};
-
-// JSON mode with custom column
-let config = SqliteSinkConfig::new("sqlite:///data/app.db", "events")
-    .column_mapping(SqliteColumnMapping::Json { column: "payload".into() })
-    .with_batch_size(1000)
-    .max_connections(3);
-
-// AutoMap mode
-let config = SqliteSinkConfig::new("sqlite:///data/app.db", "events")
-    .column_mapping(SqliteColumnMapping::AutoMap)
-    .with_batch_size(250);
-```
-
-## Config Loading
-
-```rust
-use faucet_core::config::{load_json, load_env_file};
-use faucet_sink_sqlite::SqliteSinkConfig;
-
-// From a JSON file
-let config: SqliteSinkConfig = load_json("config.json")?;
-
-// From an .env file with a prefix
-let config: SqliteSinkConfig = load_env_file(".env", "SQLITE_SINK")?;
-```
-
-### Example JSON config (JSON mode)
-
-```json
-{
-  "database_url": "/data/analytics.db",
-  "table_name": "raw_events",
-  "column_mapping": {
-    "json": {
-      "column": "data"
-    }
-  },
-  "batch_size": 1000,
-  "max_connections": 5
-}
-```
-
-### Example JSON config (AutoMap mode)
-
-```json
-{
-  "database_url": "/data/analytics.db",
-  "table_name": "events",
-  "column_mapping": "auto_map",
-  "batch_size": 1000,
-  "max_connections": 3
-}
-```
-
-### Example .env file
-
-```env
-SQLITE_SINK_DATABASE_URL=/data/analytics.db
-SQLITE_SINK_TABLE_NAME=raw_events
-SQLITE_SINK_COLUMN_MAPPING='{"json":{"column":"data"}}'
-SQLITE_SINK_BATCH_SIZE=1000
-SQLITE_SINK_MAX_CONNECTIONS=5
-```
-
-## Config Schema Introspection
-
-```rust
-use faucet_core::Sink;
-
-let sink = SqliteSink::new(config).await?;
-let schema = sink.config_schema();
-println!("{}", serde_json::to_string_pretty(&schema)?);
-```
-
-## Pipeline Usage
-
-```rust
-use faucet_core::Pipeline;
-use faucet_source_rest::{RestStream, RestStreamConfig};
-use faucet_sink_sqlite::{SqliteSink, SqliteSinkConfig, SqliteColumnMapping};
-
-let source = RestStream::new(
-    RestStreamConfig::new("https://api.example.com", "/v1/events")
-);
-
-let sink_config = SqliteSinkConfig::new("/data/events.db", "events")
-    .column_mapping(SqliteColumnMapping::AutoMap);
-
-let sink = SqliteSink::new(sink_config).await?;
-
-let result = Pipeline::new(source, sink).run().await?;
-println!("Transferred {} records", result.records_written);
-```
+| Variant | YAML | Description |
+|---------|------|-------------|
+| `Json { column }` | `{ json: { column: "data" } }` | Insert each record as a serialized JSON text string in a single column. The column name defaults to `"data"`. |
+| `AutoMap` | `auto_map` | Map top-level JSON keys directly to table columns, discovered via `PRAGMA table_info(table_name)`. Only keys matching existing columns are inserted; extra keys are silently ignored. Records with no matching keys are skipped with a warning. |
 
 ## Examples
 
-### JSON mode -- store records as serialized JSON text
+### JSON-column mode — store records as serialized JSON text
 
 ```sql
--- Table schema
 CREATE TABLE raw_events (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     data TEXT NOT NULL,
@@ -205,19 +101,21 @@ CREATE TABLE raw_events (
 );
 ```
 
-```rust
-let config = SqliteSinkConfig::new("/tmp/app.db", "raw_events")
-    .column_mapping(SqliteColumnMapping::Json { column: "data".into() })
-    .with_batch_size(1000);
-
-let sink = SqliteSink::new(config).await?;
-sink.write_batch(&records).await?;
+```yaml
+sink:
+  type: sqlite
+  config:
+    database_url: /data/analytics.db
+    table_name: raw_events
+    column_mapping:
+      json:
+        column: data
+    batch_size: 1000
 ```
 
-### AutoMap mode -- map JSON keys to table columns
+### AutoMap mode — map JSON keys to table columns
 
 ```sql
--- Table schema
 CREATE TABLE events (
     user_id TEXT,
     event TEXT,
@@ -226,37 +124,37 @@ CREATE TABLE events (
 );
 ```
 
-```rust
-let config = SqliteSinkConfig::new("/tmp/app.db", "events")
-    .column_mapping(SqliteColumnMapping::AutoMap)
-    .with_batch_size(1000);
-
-let sink = SqliteSink::new(config).await?;
-
-let records = vec![
-    json!({"user_id": "u1", "event": "purchase", "amount": 29.99}),
-    json!({"user_id": "u2", "event": "signup"}),  // missing "amount" will be null
-];
-sink.write_batch(&records).await?;
+```yaml
+sink:
+  type: sqlite
+  config:
+    database_url: /data/analytics.db
+    table_name: events
+    column_mapping: auto_map
+    batch_size: 1000
 ```
+
+A record missing a column (e.g. `{"user_id": "u2", "event": "signup"}` with no `amount`) binds SQL `NULL` for that column.
 
 ### In-memory database for testing
 
-```rust
-let config = SqliteSinkConfig::new("sqlite::memory:", "test_table")
-    .column_mapping(SqliteColumnMapping::AutoMap);
-
-let sink = SqliteSink::new(config).await?;
+```yaml
+sink:
+  type: sqlite
+  config:
+    database_url: "sqlite::memory:"
+    table_name: test_table
+    column_mapping: auto_map
 ```
 
-## How It Works
+## Streaming & batching
 
-- A connection pool is created in `SqliteSink::new()` using `sqlx::SqlitePool` with the configured `max_connections` (default `1`). Each connection is opened in WAL journal mode (`journal_mode = WAL`) with a 5-second `busy_timeout` and `create_if_missing`, so a writer and readers can proceed concurrently and lock contention waits-and-retries instead of failing immediately with `SQLITE_BUSY`. WAL on a `sqlite::memory:` database is a harmless no-op.
-- `write_batch()` slices the input into `batch_size`-row chunks (or forwards the whole slice when `batch_size = 0`). Each chunk is inserted using a single multi-row INSERT statement wrapped in a `BEGIN`/`COMMIT` transaction for write performance.
-- In JSON mode, each record is serialized to a JSON string and inserted as `INSERT INTO t (col) VALUES (?), (?), ...`.
-- In AutoMap mode, column names are discovered using `PRAGMA table_info(table_name)`. A multi-row INSERT is built dynamically. Column values are bound as **native SQLite types** — strings as `TEXT`, JSON numbers as `INTEGER`/`REAL`, booleans as `INTEGER` 0/1 — so column affinity and typed reads round-trip correctly. Arrays and objects (which have no scalar SQL representation) are bound as their JSON text. The INSERT column set is the **union** of record keys across the batch (in table order), so a field present only in a later record is still written; a row missing a column binds SQL `NULL`.
-- All identifiers (table names, column names) are quoted using `quote_ident()` (double-quote escaping) to prevent SQL injection.
-- Transaction wrapping ensures that either all rows in a batch are committed or none are, providing atomicity per batch.
+The SQLite sink re-chunks each incoming `StreamPage` to keep individual multi-row INSERT statements within SQLite's per-statement parameter limits and to amortise per-transaction overhead.
+
+- **`batch_size > 0`** (default `1000`) — the sink slices the incoming records into `batch_size`-row chunks and issues one multi-row INSERT per chunk, each wrapped in its own `BEGIN`/`COMMIT` transaction. **`1000` is the recommended value**: large enough to amortise transaction overhead, small enough to stay well under SQLite's default `SQLITE_MAX_VARIABLE_NUMBER` (32766 since 3.32.0). In `auto_map` mode the sink also splits each chunk further so `rows × columns` never exceeds that limit, so a wide table never fails with "too many SQL variables" regardless of `batch_size`.
+- **`batch_size = 0`** — the "no batching" sentinel. The entire upstream `StreamPage` is written in a single multi-row INSERT inside one transaction. Use this when the source already emits page sizes tuned for SQLite (e.g. a Postgres source with `batch_size: 1000`). Pages large enough to push the parameter count past SQLite's per-statement limit will fail at the prepare step.
+
+`batch_size` is purely a chunk-size knob — transaction wrapping, identifier quoting, and per-record error reporting are unchanged.
 
 ## Write modes (upsert / delete)
 
@@ -268,21 +166,16 @@ By default the sink uses `write_mode: append` — every record is inserted as a 
 | `upsert` | Insert-or-update by `key` (last-write-wins via `ON CONFLICT … DO UPDATE`). Optionally route delete-marked rows to `DELETE` via `delete_marker`. |
 | `delete` | Delete every record by `key`. |
 
-### Required fields
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `write_mode` | `"append"` \| `"upsert"` \| `"delete"` | `"append"` | Write semantics. |
-| `key` | `[String]` | `[]` | Key column(s). Required and non-empty for `upsert` / `delete`. |
-| `delete_marker` | `{ field: String, values: [String] }` | absent | `upsert` only: rows whose `field` matches one of `values` are routed to `DELETE`; all others are upserted. The marker field is stripped from upsert rows before writing. |
-
 **Requirements:**
+
 - `column_mapping` must be `auto_map` — key columns must be real table columns, not embedded inside a JSON blob.
 - The table must have a `UNIQUE` or `PRIMARY KEY` constraint on the `key` column(s) so SQLite's `ON CONFLICT` clause can enforce uniqueness.
-- Upsert/delete rows within a single batch are deduped by key (last-write-wins) before writing, so a single batch never conflicts with itself.
-- A row missing or null in a key column fails. When a `dlq:` block is configured the good rows are still written and only the missing/null-key rows are routed to the DLQ per-row; without a DLQ the whole batch fails.
+- Rows within a single batch are deduped by key (last-write-wins) before writing, so a batch never conflicts with itself.
+- A row missing or null in a key column fails. With a `dlq:` block configured, the good rows are still written and only the missing/null-key rows are routed to the DLQ per-row; without a DLQ the whole batch fails.
 
-### YAML example
+### CDC mirror with upsert + delete marker
+
+The standard CDC → mirror shape: a CDC source feeds change events, the `cdc_unwrap` transform normalizes them to a flat row plus a `__op` marker, and the sink upserts (or deletes flagged rows).
 
 ```yaml
 pipeline:
@@ -309,35 +202,14 @@ pipeline:
       path: ./state
 ```
 
-### Rust example
-
-```rust
-use faucet_sink_sqlite::{SqliteColumnMapping, SqliteSink, SqliteSinkConfig};
-use faucet_core::{WriteMode, WriteSpec};
-
-let config = SqliteSinkConfig {
-    database_url: "sqlite:///data/warehouse.db".into(),
-    table_name: "users".into(),
-    column_mapping: SqliteColumnMapping::AutoMap,
-    batch_size: 1000,
-    max_connections: 1,
-    write: WriteSpec {
-        write_mode: WriteMode::Upsert,
-        key: vec!["id".to_string()],
-        delete_marker: None,
-    },
-};
-let sink = SqliteSink::new(config).await?;
-```
-
 ## Exactly-once delivery
 
 `SqliteSink` implements `Sink::supports_idempotent_writes` (returns `true`) and the two companion hooks:
 
 - `write_batch_idempotent(records, scope, token)` — writes `records` and UPSERTs the `token` into a `_faucet_commit_token(scope TEXT, token TEXT)` watermark table inside the **same `BEGIN`/`COMMIT` transaction**, so both either commit together or neither does.
-- `last_committed_token(scope)` — reads the current watermark to let the pipeline skip already-committed pages on resume.
+- `last_committed_token(scope)` — reads the current watermark so the pipeline skips already-committed pages on resume.
 
-To use exactly-once delivery, set `delivery: exactly_once` in your pipeline config and pair this sink with one of the CDC sources (`postgres-cdc`, `mysql-cdc`, `mongodb-cdc`) plus a `state:` block. A DLQ is not permitted in exactly-once mode. All four requirements are validated at config-load time (`faucet validate`) before any run starts.
+To use exactly-once delivery, set `delivery: exactly_once` and pair this sink with a CDC source (`postgres-cdc`, `mysql-cdc`, `mongodb-cdc`) plus a `state:` block. A DLQ is not permitted in exactly-once mode. All four requirements are validated at config-load time (`faucet validate`) before any run starts.
 
 ```yaml
 pipeline:
@@ -362,10 +234,127 @@ delivery: exactly_once
 
 See the [Exactly-once delivery cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/state.html#exactly-once-delivery) for full rationale and the supported source/sink set.
 
+## Dead-letter queue
+
+The sink reports per-row outcomes via `write_batch_partial`, so when a `dlq:` block is configured, rows that fail (e.g. a missing/null key column in upsert/delete mode) are wrapped in a DLQ envelope and routed to the configured DLQ sink while the rest of the batch still commits. Without a DLQ, a failing row fails the whole batch. See the [DLQ cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/dlq.html).
+
+## Config loading & schema introspection
+
+Load from YAML/JSON or environment:
+
+```rust
+use faucet_core::config::{load_json, load_env_file};
+use faucet_sink_sqlite::SqliteSinkConfig;
+
+// From a JSON file
+let config: SqliteSinkConfig = load_json("config.json")?;
+
+// From an .env file with a prefix
+let config: SqliteSinkConfig = load_env_file(".env", "SQLITE_SINK")?;
+```
+
+```env
+SQLITE_SINK_DATABASE_URL=/data/analytics.db
+SQLITE_SINK_TABLE_NAME=raw_events
+SQLITE_SINK_COLUMN_MAPPING='{"json":{"column":"data"}}'
+SQLITE_SINK_BATCH_SIZE=1000
+SQLITE_SINK_MAX_CONNECTIONS=1
+```
+
+Inspect the full JSON Schema with:
+
+```bash
+faucet schema sink sqlite
+```
+
+## Library usage
+
+```rust
+use faucet_core::{Pipeline, Sink};
+use faucet_sink_sqlite::{SqliteColumnMapping, SqliteSink, SqliteSinkConfig};
+use serde_json::json;
+
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let config = SqliteSinkConfig::new("/data/app.db", "events")
+    .column_mapping(SqliteColumnMapping::AutoMap)
+    .with_batch_size(1000)
+    .max_connections(1);
+
+let sink = SqliteSink::new(config).await?;
+
+let records = vec![
+    json!({"user_id": "u1", "event": "purchase", "amount": 29.99}),
+    json!({"user_id": "u2", "event": "signup"}),
+];
+let rows_written = sink.write_batch(&records).await?;
+println!("Wrote {rows_written} rows");
+# Ok(())
+# }
+```
+
+Building the upsert `WriteSpec` directly:
+
+```rust
+use faucet_core::{WriteMode, WriteSpec};
+use faucet_sink_sqlite::{SqliteColumnMapping, SqliteSink, SqliteSinkConfig};
+
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let config = SqliteSinkConfig {
+    database_url: "sqlite:///data/warehouse.db".into(),
+    table_name: "users".into(),
+    column_mapping: SqliteColumnMapping::AutoMap,
+    batch_size: 1000,
+    max_connections: 1,
+    write: WriteSpec {
+        write_mode: WriteMode::Upsert,
+        key: vec!["id".to_string()],
+        delete_marker: None,
+    },
+};
+let sink = SqliteSink::new(config).await?;
+# Ok(())
+# }
+```
+
+## How it works
+
+- A connection pool is created in `SqliteSink::new()` using `sqlx::SqlitePool` with the configured `max_connections` (default `1`). Each connection opens in WAL journal mode with a 5-second `busy_timeout` and `create_if_missing`, so a writer and readers proceed concurrently and lock contention waits-and-retries instead of failing immediately with `SQLITE_BUSY`. WAL on a `sqlite::memory:` database is a harmless no-op.
+- `write_batch()` slices the input into `batch_size`-row chunks (or forwards the whole slice when `batch_size = 0`). Each chunk is inserted with a single multi-row INSERT wrapped in a `BEGIN`/`COMMIT` transaction.
+- In **JSON mode**, each record is serialized to a JSON string and inserted as `INSERT INTO t (col) VALUES (?), (?), …`.
+- In **AutoMap mode**, column names are discovered via `PRAGMA table_info(table_name)`. The INSERT column set is the **union** of record keys across the batch (in table order), so a field present only in a later record is still written; a row missing a column binds SQL `NULL`. Values bind as native SQLite types (`TEXT`/`INTEGER`/`REAL`; booleans as `0`/`1`; arrays/objects as JSON text).
+- All identifiers (table and column names) are quoted via `quote_ident()` (double-quote escaping) to prevent SQL injection.
+- Transaction wrapping guarantees per-batch atomicity: either all rows in a chunk commit, or none do.
+
 ## Lineage dataset URI
 
 `sqlite://<path>?table=<table>` — e.g. `sqlite:///tmp/test.db?table=events`.
 
+## Feature flags
+
+This crate has no optional features of its own; enable it in the CLI/umbrella via the `sink-sqlite` feature.
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause & fix |
+|---------|--------------------|
+| `SQLITE_BUSY` / "database is locked" | Multiple writers contending for the file. Keep `max_connections: 1` (the default); only raise it for read-heavy WAL workloads. Ensure no external process holds a long write lock. |
+| "too many SQL variables" | In JSON/`batch_size: 0` mode a single page exceeds SQLite's per-statement parameter limit (32766). Lower `batch_size` (e.g. `1000`). AutoMap mode auto-splits, so this is JSON-mode/large-page-specific. |
+| AutoMap inserts nothing / "skipped with no matching keys" warning | Record keys don't match any column. Confirm the table exists and column names match the JSON top-level keys (AutoMap silently drops unmatched keys). |
+| Upsert fails with `ON CONFLICT` error | The table has no `UNIQUE`/`PRIMARY KEY` on the `key` column(s). Add a constraint, e.g. `CREATE UNIQUE INDEX ON users(id)`. |
+| Upsert/delete rejected at config load | `column_mapping` is not `auto_map`, or `key` is empty. Upsert/delete require `auto_map` and a non-empty `key`. |
+| Exactly-once rejected by `faucet validate` | One of the four requirements is unmet: a CDC source, this sink, a `state:` block, and **no** `dlq:` block. |
+| A row with a missing/null key column fails the whole batch | Add a `dlq:` block to route only the offending rows to the DLQ while the rest commit. |
+| Numbers stored as text in AutoMap | Pass JSON numbers (`29.99`), not strings (`"29.99"`); strings bind as `TEXT`. |
+
+## See also
+
+- [Choosing a connector](https://pawansikawat.github.io/faucet-stream/reference/choosing.html)
+- [Connector capability matrix](https://pawansikawat.github.io/faucet-stream/reference/connectors.html)
+- [Upsert cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/upsert.html)
+- [State & exactly-once cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/state.html)
+- [`faucet-source-sqlite`](https://crates.io/crates/faucet-source-sqlite) — the matching SQLite query source.
+- [`faucet-sink-postgres`](https://crates.io/crates/faucet-sink-postgres) / [`faucet-sink-mysql`](https://crates.io/crates/faucet-sink-mysql) — server-database sinks with the same write-mode surface.
+
 ## License
 
-Licensed under MIT or Apache-2.0.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/sink/stdout/README.md
+++ b/crates/sink/stdout/README.md
@@ -1,73 +1,226 @@
 # faucet-sink-stdout
 
-Stdout/stderr sink for the [faucet-stream](https://crates.io/crates/faucet-stream) ecosystem. Writes each record to a standard stream in one of three formats — useful for debugging pipelines, building demos, and powering the `faucet preview` CLI workflow.
+[![Crates.io](https://img.shields.io/crates/v/faucet-sink-stdout.svg)](https://crates.io/crates/faucet-sink-stdout)
+[![Docs.rs](https://docs.rs/faucet-sink-stdout/badge.svg)](https://docs.rs/faucet-sink-stdout)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-sink-stdout.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-sink-stdout.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-## Install
+Standard-stream (**stdout / stderr**) sink for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem. Writes each record to a standard stream in one of three formats — compact JSON Lines, pretty-printed JSON, or tab-separated values.
+
+Reach for it whenever you want to *see* what a pipeline produces: debugging a new source, eyeballing the shape of records before wiring up a real destination, building a quick demo, sampling the first few rows with `faucet preview`, or piping records into another shell tool (`jq`, `head`, `grep`, `column`). It's the zero-setup sink — no credentials, no connection, no files — so it's almost always the first sink you point a new source at.
+
+## Feature highlights
+
+- **Three output formats** — `json_lines` (one compact object per line, the de-facto debug format), `pretty_json` (indented and readable), and `tsv` (tab-separated, spreadsheet-friendly).
+- **Pick the stream** — write to `stdout` (default, honors shell redirection) or `stderr` (when stdout is reserved for piping the pipeline's own output).
+- **Buffered, async writes** — records go through a buffered `tokio` async writer, so high-volume runs aren't bottlenecked on per-record syscalls.
+- **Live-preview flushing** — `flush_per_record` flushes after every record for low-latency, line-at-a-time output (e.g. tailing a streaming source).
+- **Record cap** — `max_records` stops after *N* records, which is exactly what powers `faucet preview --limit N`.
+- **Pipe-friendly** — a `BrokenPipe` from the consumer (e.g. `… | head`) is treated as a clean stop, not an error, so piping into truncating commands Just Works.
+- **Writer override** — `StdoutSink::with_writer` accepts any `Box<dyn AsyncWrite + Unpin + Send>`, handy for tests, in-memory capture, or redirecting into a log file.
+
+## Installation
 
 ```bash
-cargo add faucet-core
+# As a library:
 cargo add faucet-sink-stdout
+
+# In the CLI (opt-in connector feature):
+cargo install faucet-cli --features sink-stdout
 ```
 
-Or via the umbrella crate with the `sink-stdout` feature:
+The `sink-stdout` feature is **not** in the CLI default build — enable it explicitly (or use a `full` build).
+
+## Quick start
+
+```yaml
+# pipeline.yaml — faucet run pipeline.yaml
+version: 1
+pipeline:
+  source:
+    type: csv
+    config:
+      path: ./users.csv
+  sink:
+    type: stdout
+    config:
+      format: json_lines
+```
 
 ```bash
-cargo add faucet-stream --features sink-stdout
+faucet run pipeline.yaml
 ```
 
-## Usage
+Every row of `users.csv` is printed to stdout as one compact JSON object per line — ready to pipe into `jq`, redirect to a file, or just read.
 
-```rust,no_run
+## Configuration reference
+
+All fields are optional; an empty `config: {}` writes JSON Lines to stdout with no limit.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `destination` | `stdout` \| `stderr` | `stdout` | Which standard stream to write to. `stderr` is useful when stdout is reserved for the pipeline's own structured output. |
+| `format` | `json_lines` \| `pretty_json` \| `tsv` | `json_lines` | How each record is serialized — see [Formats](#formats). |
+| `flush_per_record` | bool | `false` | Flush the underlying writer after every record instead of at batch boundaries. Lower latency for live preview, slightly lower throughput. |
+| `max_records` | int | *(unset → unlimited)* | Stop after this many records. Once reached, subsequent `write_batch` calls become no-ops. Powers `faucet preview --limit N`. |
+| `batch_size` | int | `1000` | Records per upstream `StreamPage`. **No behavioural impact at this sink** — present only for config parity across the workspace. See [Streaming & batching](#streaming--batching). |
+
+### Formats
+
+| `format` | Output |
+|----------|--------|
+| `json_lines` | One compact JSON object per line (newline-delimited). The standard debug / pipe-into-`jq` format. |
+| `pretty_json` | Indented (pretty-printed) JSON, each record separated by a newline. Easier to read by eye; not a single-line format. |
+| `tsv` | Tab-separated values. Each record's keys are sorted alphabetically; scalar values are emitted raw (control characters in strings replaced by spaces), and nested objects/arrays are emitted as compact JSON. **Requires every record to be a JSON object.** |
+
+## Examples
+
+### Tail a streaming source live, line by line
+
+```yaml
+version: 1
+pipeline:
+  source:
+    type: websocket
+    config:
+      url: wss://stream.example.com/ticks
+  sink:
+    type: stdout
+    config:
+      format: json_lines
+      flush_per_record: true   # emit each record the instant it arrives
+```
+
+### Preview just the first few rows on stderr
+
+```yaml
+version: 1
+pipeline:
+  source:
+    type: rest
+    config:
+      url: https://api.example.com/v1/orders
+  sink:
+    type: stdout
+    config:
+      destination: stderr      # keep stdout free for other tooling
+      format: pretty_json
+      max_records: 5           # sample the shape, then stop
+```
+
+### Emit TSV to pipe into spreadsheet-style tools
+
+```yaml
+version: 1
+pipeline:
+  source:
+    type: postgres
+    config:
+      connection_url: ${env:DATABASE_URL}
+      query: SELECT id, name, signup_date FROM users ORDER BY id
+  sink:
+    type: stdout
+    config:
+      format: tsv
+```
+
+```bash
+faucet run pipeline.yaml | column -t -s $'\t'
+```
+
+## Streaming & batching
+
+`Pipeline::run` drives the source's `stream_pages` and hands each emitted `StreamPage` to `Sink::write_batch`. This sink then iterates the page **record by record**, serializing and writing each one through a buffered async writer.
+
+Because the write path is inherently per-record, the `batch_size` config field has **no observable effect** here. `batch_size = 0` (the "no batching" sentinel) and any positive value produce byte-for-byte identical output. The field exists only so every sink in the workspace shares one config shape — sinks like `faucet-sink-postgres` (multi-row INSERTs) or `faucet-sink-bigquery` (streaming-insert request sizing) genuinely use it; a per-record stream sink has nothing to tune.
+
+The per-run memory bound is set by the **source's** `batch_size` (the size of each `StreamPage`), not by this field. To control flush cadence for live preview, use `flush_per_record` — `batch_size` does not influence flushing.
+
+## Config loading & schema
+
+Configs load from YAML/JSON files, environment variables, or `.env` files via the CLI's normal loading path. Inspect the full JSON Schema with:
+
+```bash
+faucet schema sink stdout
+```
+
+## Library usage
+
+```rust
 use faucet_core::Sink;
-use faucet_sink_stdout::{StdoutFormat, StdStream, StdoutSink, StdoutSinkConfig};
+use faucet_sink_stdout::{StdStream, StdoutFormat, StdoutSink, StdoutSinkConfig};
 use serde_json::json;
 
 # async fn run() -> Result<(), faucet_core::FaucetError> {
 let sink = StdoutSink::new(
     StdoutSinkConfig::new()
         .destination(StdStream::Stdout)
-        .format(StdoutFormat::JsonLines),
+        .format(StdoutFormat::JsonLines)
+        .max_records(100),
 );
 
-sink.write_batch(&[json!({"id": 1, "name": "Alice"})]).await?;
+sink.write_batch(&[
+    json!({"id": 1, "name": "Alice"}),
+    json!({"id": 2, "name": "Bob"}),
+])
+.await?;
 sink.flush().await?;
 # Ok(())
 # }
 ```
 
-## Configuration
+Capture output into an in-memory buffer (e.g. in tests) with the writer override:
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `destination` | `stdout` \| `stderr` | `stdout` | Which standard stream to write to. |
-| `format` | `json_lines` \| `pretty_json` \| `tsv` | `json_lines` | Output format. |
-| `flush_per_record` | `bool` | `false` | Flush after every record (lower latency, slightly lower throughput). |
-| `max_records` | `usize?` | `None` | Stop after `n` records. Useful for `faucet preview --limit=N`. |
-| `batch_size` | `usize` | `1000` | Records per upstream `StreamPage`. **No behavioural impact** at this sink — present for symmetry. See [Streaming and batching](#streaming-and-batching). |
+```rust
+use faucet_core::Sink;
+use faucet_sink_stdout::{StdoutSink, StdoutSinkConfig};
+use serde_json::json;
 
-## Streaming and batching
+# async fn run() -> Result<(), faucet_core::FaucetError> {
+let buf: Vec<u8> = Vec::new();
+let sink = StdoutSink::with_writer(StdoutSinkConfig::new(), Box::new(buf));
+sink.write_batch(&[json!({"hello": "world"})]).await?;
+sink.flush().await?;
+# Ok(())
+# }
+```
 
-This sink writes each record to the chosen standard stream one at a time via a buffered async writer. The per-page memory bound for the pipeline is set by the **source's** `batch_size` (the size of each `StreamPage` that `Pipeline::run` hands to `Sink::write_batch`); how that page is then iterated record-by-record on the sink side is what determines the bytes written to stdout/stderr, and that path does not depend on `batch_size` at all.
+## How it works
 
-`batch_size` is exposed on this config purely for symmetry across every sink in the workspace — sinks like `faucet-sink-postgres` or `faucet-sink-bigquery` use the field to size their multi-row inserts / streaming-insert requests, but a per-record stream sink has nothing to tune. `batch_size = 0` (the "no batching" sentinel) and any positive value are observably identical for this sink: both produce byte-for-byte the same output. To get per-record flushing for live preview, use `flush_per_record` — `batch_size` does not influence flush cadence.
-
-### Formats
-
-- **`json_lines`** — one compact JSON object per line. The de facto debug format.
-- **`pretty_json`** — indented JSON, each record separated by a newline. Easier on the eyes.
-- **`tsv`** — tab-separated values. Each record's keys are sorted alphabetically; scalar values are emitted raw (with control characters replaced by spaces in strings), and nested objects/arrays are emitted as compact JSON. Requires every record to be a JSON object.
-
-## Behavior notes
-
-- The underlying writer is opened eagerly in `new()`.
-- A `BrokenPipe` from the consumer (e.g. piping into `head`) is treated as a clean termination — subsequent `write_batch` calls return `Ok(0)` rather than erroring.
-- `flush()` flushes the underlying writer; the default `Sink` impl does not flush on `Drop`, so call it explicitly if you need durability of buffered output.
-- `StdoutSink::with_writer(config, writer)` accepts any `Box<dyn AsyncWrite + Unpin + Send>`. Useful in tests and when redirecting into log files or in-memory buffers.
+1. `new()` opens the buffered async writer for the configured `destination` **eagerly** (at construction, not on first write).
+2. `write_batch` iterates the page, serializing each record per the chosen `format` and writing it through the buffer. When `max_records` is set, it stops once the cap is hit and turns further writes into no-ops.
+3. With `flush_per_record`, the buffer is flushed after every record; otherwise it flushes at batch boundaries and on `flush()`.
+4. A `BrokenPipe` error from the consumer is caught and treated as a clean termination — subsequent `write_batch` calls return `Ok(0)` rather than erroring.
+5. The default `Sink` impl does **not** flush on `Drop`, so call `flush()` explicitly if you need buffered output durably written before the program exits.
 
 ## Lineage dataset URI
 
-`stdout://` or `stderr://` depending on the configured destination.
+`stdout://` or `stderr://`, depending on the configured destination.
+
+## Feature flags
+
+This crate has no optional features of its own; enable it in the CLI/umbrella via the `sink-stdout` feature.
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause & fix |
+|---------|--------------------|
+| `tsv` format errors on some records | TSV requires every record to be a JSON **object**. A source emitting bare scalars or arrays can't be flattened to columns — switch to `json_lines`, or shape records into objects with a transform first. |
+| Output looks buffered / nothing prints until the run ends | The writer buffers by default. For line-at-a-time output (e.g. tailing a live source), set `flush_per_record: true`. |
+| Setting `batch_size` changes nothing | Expected — `batch_size` is a no-op for this per-record sink (present only for config parity). To bound per-page memory, set the **source's** `batch_size`; to control flush cadence, use `flush_per_record`. |
+| Pipeline stops early when piping into `head` / `sed` | Not an error — the consumer closed the pipe (`BrokenPipe`), which this sink treats as a clean stop. Remove the truncating command, or raise its limit, to see all records. |
+| TSV column order changes between records | Keys are sorted **alphabetically** per record for stable columns. If different records have different key sets, their columns won't line up — normalize the shape upstream (e.g. `select` / `set` transforms). |
+| Want only the first N records | Set `max_records: N` (this is what `faucet preview --limit N` uses), rather than relying on a downstream `head`. |
+| Pretty JSON is hard to pipe into `jq` | Use `format: json_lines` for tooling that expects newline-delimited JSON; reserve `pretty_json` for human reading. |
+
+## See also
+
+- [Sinks reference](https://pawansikawat.github.io/faucet-stream/reference/connectors.html) — the full connector capability matrix.
+- [CLI reference](https://pawansikawat.github.io/faucet-stream/reference/cli.html) — `faucet run`, `faucet preview`, `faucet schema`.
+- [`faucet-sink-jsonl`](https://crates.io/crates/faucet-sink-jsonl) — write the same JSON Lines to a file instead of a stream.
+- [`faucet-sink-csv`](https://crates.io/crates/faucet-sink-csv) — TSV/CSV to a file with full quoting.
+- [`faucet-core`](https://crates.io/crates/faucet-core) — the `Sink` trait this connector implements.
 
 ## License
 
-Licensed under either of MIT or Apache-2.0 at your option.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/source/bigquery/README.md
+++ b/crates/source/bigquery/README.md
@@ -1,57 +1,176 @@
 # faucet-source-bigquery
 
-BigQuery query source connector for the [`faucet-stream`](https://crates.io/crates/faucet-stream) ecosystem. Runs a SQL statement against [BigQuery](https://cloud.google.com/bigquery/docs/reference/rest) via `jobs.query` + `jobs.getQueryResults` and streams the rows back as `serde_json::Value` records.
+[![Crates.io](https://img.shields.io/crates/v/faucet-source-bigquery.svg)](https://crates.io/crates/faucet-source-bigquery)
+[![Docs.rs](https://docs.rs/faucet-source-bigquery/badge.svg)](https://docs.rs/faucet-source-bigquery)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-source-bigquery.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-source-bigquery.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-## Features
+Google **BigQuery** query source for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem. Runs a SQL statement against BigQuery's [REST API](https://cloud.google.com/bigquery/docs/reference/rest) (`jobs.query` + `jobs.getQueryResults`), decodes each row into a typed `serde_json::Value`, and streams the result set back page-by-page so memory stays bounded no matter how large the query result is.
 
-- **Three credential modes** — `ApplicationDefault`, `ServiceAccountKeyPath`, or inline `ServiceAccountKey`; the shared `BigQueryCredentials` enum is re-exported from [`faucet-common-bigquery`](https://crates.io/crates/faucet-common-bigquery) so it matches the BigQuery sink byte-for-byte.
-- **Sync + async result handling** — when BigQuery returns `jobComplete=false` (statement timeout exceeded), the source polls `getQueryResults` until the job finishes, bounded by `poll_timeout` (default 300 s; `0` = poll forever) so a job that never completes fails instead of hanging.
-- **Server-side pagination** — pages via `pageToken` for arbitrarily-large result sets; rows are re-framed into pages of `batch_size` for `Source::stream_pages`.
-- **Type-aware row decoding** — `INTEGER`/`INT64` → JSON number, `FLOAT`/`FLOAT64` → number, `BOOLEAN`/`BOOL` → bool, `NUMERIC`/`BIGNUMERIC` → string (full precision), `RECORD`/`STRUCT` → nested object, `REPEATED` → array, `JSON` → parsed value, everything else → string.
-- **Positional bind parameters** — `params` from config and `${parent.path}` matrix-context values are sent as `POSITIONAL` parameters whose type is inferred from the JSON value (`INT64` / `FLOAT64` / `BOOL` / `STRING`), so a numeric or boolean bind compares correctly against a typed column.
+Reach for it when you want to pull analytics tables, aggregates, or ad-hoc query results out of BigQuery and land them in any faucet-stream sink — a file, a database, a warehouse, a queue — with one declarative config and no glue code.
+
+## Feature highlights
+
+- **Three credential modes** — Application Default Credentials, a service-account key file, or inline service-account JSON. The shared `BigQueryCredentials` enum is re-exported from [`faucet-common-bigquery`](https://crates.io/crates/faucet-common-bigquery) so it matches the BigQuery **sink** byte-for-byte.
+- **Server-side pagination** — pages through arbitrarily large result sets via `pageToken`; rows are re-framed into pages of `batch_size` for streaming, so peak memory is `O(batch_size)`.
+- **Async-job aware** — when BigQuery returns `jobComplete=false` (the statement ran past `statement_timeout`), the source polls `jobs.getQueryResults` until the job finishes, bounded by `poll_timeout` so a job that never completes fails cleanly instead of hanging forever.
+- **Type-aware row decoding** — `INTEGER`/`INT64` → JSON number, `FLOAT`/`FLOAT64` → number, `BOOLEAN`/`BOOL` → bool, `NUMERIC`/`BIGNUMERIC` → string (full precision preserved), `RECORD`/`STRUCT` → nested object, `REPEATED` → array, `JSON` → parsed value, everything else → string.
+- **Positional bind parameters** — `params` from config plus any `${parent.path}` matrix-context values are sent as BigQuery `POSITIONAL` parameters, typed from the JSON value (`INT64` / `FLOAT64` / `BOOL` / `STRING`) so a numeric or boolean bind compares correctly against a typed column.
 - **Standard or legacy SQL** — `use_legacy_sql` toggle; defaults to Standard SQL.
+- **Client built once** — the authenticated BigQuery client is constructed in `new()` and reused for every request.
 
-## Configuration
+## Installation
 
-```yaml
-type: bigquery
-config:
-  project_id: my-project
-  auth:
-    type: service_account_key_path
-    config:
-      path: /etc/secrets/bigquery-sa.json
-  query: |
-    SELECT user_id, event_name, occurred_at
-    FROM `my-project.analytics.events`
-    WHERE occurred_at >= ?
-  params:
-    - "2026-01-01"
-  use_legacy_sql: false            # default
-  location: EU                     # optional; matches BigQuery dataset region
-  max_results_per_page: 1000       # default
-  statement_timeout: 60            # seconds, defaults to 60
-  poll_timeout: 300                # seconds, defaults to 300; 0 = poll forever
-  batch_size: 1000                 # default, or 0 to disable re-chunking
+```bash
+# As a library:
+cargo add faucet-source-bigquery
+
+# In the CLI (opt-in connector feature):
+cargo install faucet-cli --features source-bigquery
 ```
 
-### Other credential variants
+## Quick start
 
 ```yaml
-# Application Default Credentials (workload identity, gcloud auth).
+# pipeline.yaml — faucet run pipeline.yaml
+version: 1
+pipeline:
+  source:
+    type: bigquery
+    config:
+      project_id: my-project
+      auth:
+        type: service_account_key_path
+        config:
+          path: /etc/secrets/bigquery-sa.json
+      query: |
+        SELECT user_id, event_name, occurred_at
+        FROM `my-project.analytics.events`
+        WHERE occurred_at >= ?
+      params:
+        - "2026-01-01"
+  sink:
+    type: jsonl
+    config:
+      path: ./events.jsonl
+```
+
+```bash
+faucet run pipeline.yaml
+```
+
+## Configuration reference
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `project_id` | string | — *(required)* | GCP project ID the query is billed to and run against. |
+| `auth` | `BigQueryCredentials` | — *(required)* | Authentication — see [Authentication](#authentication). |
+| `query` | string | — *(required)* | SQL to execute. May contain positional `?` markers (bound from `params` + matrix context) and `${field.path}` placeholders resolved against the parent-record context at runtime. |
+| `use_legacy_sql` | bool | `false` | Use BigQuery's legacy SQL dialect. Leave `false` (Standard SQL) unless the query uses legacy `[project:dataset.table]` references. |
+| `location` | string | *(unset)* | Location override for non-`US` jobs (`"EU"`, `"asia-east1"`, …). When unset, BigQuery uses the queried tables' default location. |
+| `max_results_per_page` | int | `1000` | Rows per `jobs.getQueryResults` page. Smaller = more HTTP round-trips, less memory; larger = fewer requests, more memory. |
+| `params` | array | `[]` | Positional bind parameters, sent in declaration order **before** any context-derived values. Typed from each JSON value. |
+| `statement_timeout` | int (seconds) | `60` | Per-statement server-side timeout (`timeoutMs` on `jobs.query`). If the query isn't done within this window, BigQuery returns `jobComplete=false` and the source begins polling. |
+| `poll_timeout` | int (seconds) | `300` | Max wall-clock time spent polling `jobs.getQueryResults` for a job still reporting `jobComplete=false`, before failing with `FaucetError::Source`. **`0` disables the cap** (poll forever). Only the completion wait is bounded; `pageToken` paging afterward is unaffected. |
+| `batch_size` | int | `1000` | Records per emitted `StreamPage`. **`0` = no batching**: the entire result set is emitted in a single page (good for small lookup tables or sinks that prefer one large request). |
+
+### Authentication
+
+`auth` uses the shared `BigQueryCredentials` enum (the project-wide `{ type, config }` shape):
+
+| `type` | `config` | Use when |
+|--------|----------|----------|
+| `application_default` | *(none)* | Running on GCP (workload identity / metadata server) or after `gcloud auth application-default login`. |
+| `service_account_key_path` | `{ path: <file> }` | You have a service-account key file on disk. |
+| `service_account_key` | `{ json: <string> }` | You want to inject the key JSON inline, typically via `${env:VAR}` / `${secret:…}` indirection. |
+
+```yaml
+# Application Default Credentials (workload identity, gcloud)
 auth:
   type: application_default
 ```
 
 ```yaml
-# Inline service-account JSON — handy with env-var indirection.
+# Service-account key file
+auth:
+  type: service_account_key_path
+  config:
+    path: /etc/secrets/bigquery-sa.json
+```
+
+```yaml
+# Inline service-account JSON via env indirection
 auth:
   type: service_account_key
   config:
     json: ${env:GCP_SERVICE_ACCOUNT_JSON}
 ```
 
-## Library use
+## Examples
+
+### Incremental pull with a typed bind parameter
+
+```yaml
+source:
+  type: bigquery
+  config:
+    project_id: my-project
+    auth: { type: application_default }
+    query: |
+      SELECT id, name, score
+      FROM `my-project.app.users`
+      WHERE score > ?
+    params:
+      - 0.75          # bound as FLOAT64, compares correctly against a numeric column
+```
+
+### Large export with no re-chunking
+
+```yaml
+source:
+  type: bigquery
+  config:
+    project_id: my-project
+    auth:
+      type: service_account_key_path
+      config: { path: /etc/secrets/bigquery-sa.json }
+    query: SELECT * FROM `my-project.warehouse.daily_snapshot`
+    location: EU
+    max_results_per_page: 10000
+    batch_size: 0      # emit the whole result set as one page
+```
+
+### Long-running aggregate that may exceed the statement timeout
+
+```yaml
+source:
+  type: bigquery
+  config:
+    project_id: my-project
+    auth: { type: application_default }
+    query: |
+      SELECT country, COUNT(*) AS n
+      FROM `my-project.analytics.events`
+      GROUP BY country
+    statement_timeout: 30     # return fast; if not done, poll…
+    poll_timeout: 600         # …for up to 10 minutes before failing
+```
+
+## Streaming & batching
+
+The source overrides `Source::stream_pages`: it runs the job, then walks `jobs.getQueryResults` by `pageToken`, buffering decoded rows and yielding a `StreamPage` every time the buffer reaches `batch_size`. Memory is bounded at one page. With `batch_size: 0` the entire result set is buffered and emitted in a single page. `max_results_per_page` controls the *HTTP* page size independently of the *emitted* page size.
+
+This is a one-shot query source — it has no incremental bookmark / resume support (each run re-executes the query). For incremental loads, encode the watermark in the query (e.g. `WHERE occurred_at >= ?`) and drive it from a matrix context or `${now.*}` token.
+
+## Config loading & schema
+
+Load from YAML/JSON or environment. Inspect the full JSON Schema with:
+
+```bash
+faucet schema source bigquery
+```
+
+## Library usage
 
 ```rust
 use faucet_core::Source;
@@ -62,17 +181,44 @@ let cfg = BigQuerySourceConfig::new(
     "my-project",
     BigQueryCredentials::ApplicationDefault,
     "SELECT COUNT(*) AS n FROM analytics.events",
-);
+)
+.with_location("EU")
+.with_batch_size(0);
+
 let rows = BigQuerySource::new(cfg).await?.fetch_all().await?;
 println!("rows: {rows:?}");
 # Ok(())
 # }
 ```
 
+## How it works
+
+1. `new()` resolves `BigQueryCredentials` and builds an authenticated client **once**.
+2. `jobs.query` submits the SQL with `statement_timeout` as `timeoutMs` and any positional parameters.
+3. If `jobComplete=false`, the source polls `jobs.getQueryResults` until the job finishes or `poll_timeout` elapses.
+4. Result pages are walked via `pageToken`; each cell is decoded by its schema type into a typed JSON value.
+5. Rows are re-framed into `batch_size` pages and streamed to the pipeline.
+
 ## Lineage dataset URI
 
 `bigquery://<project_id>?query=<sql>` — e.g. `bigquery://my-project?query=SELECT id FROM events`.
 
+## Feature flags
+
+This crate has no optional features of its own; enable it in the CLI/umbrella via the `source-bigquery` feature.
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause & fix |
+|---------|--------------------|
+| `Auth` error / 401 / 403 | Credentials invalid or missing scope. Confirm the service account has **BigQuery Data Viewer** + **BigQuery Job User** on the project, or that ADC is initialized (`gcloud auth application-default login`). |
+| `403 ... billing` | The `project_id` has no billing enabled, or the SA lacks `bigquery.jobs.create`. Use a project with billing and the Job User role. |
+| Job fails with a location error | The queried dataset isn't in the default (`US`) location. Set `location` to the dataset's region (e.g. `EU`). |
+| `FaucetError::Source: poll timeout` | The job ran longer than `poll_timeout`. Raise `poll_timeout` (or set `0` to wait indefinitely), and/or raise `statement_timeout`. |
+| A `NUMERIC` column arrives as a string | Intentional — `NUMERIC`/`BIGNUMERIC` are decoded as strings to preserve full precision. Cast in a downstream transform if you need a JSON number. |
+| Bind parameter compared as text unexpectedly | Each `params` entry is typed from its JSON value. Pass `0.75` (number) not `"0.75"` (string) to bind a `FLOAT64`. |
+| Legacy table reference fails to parse | Set `use_legacy_sql: true` for `[project:dataset.table]` syntax. |
+
 ## License
 
-MIT OR Apache-2.0
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/source/csv/README.md
+++ b/crates/source/csv/README.md
@@ -2,6 +2,8 @@
 
 [![Crates.io](https://img.shields.io/crates/v/faucet-source-csv.svg)](https://crates.io/crates/faucet-source-csv)
 [![Docs.rs](https://docs.rs/faucet-source-csv/badge.svg)](https://docs.rs/faucet-source-csv)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-source-csv.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-source-csv.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
 A CSV file source that reads rows from CSV files and returns them as JSON objects, with configurable delimiters, headers, and quote characters.
 

--- a/crates/source/csv/README.md
+++ b/crates/source/csv/README.md
@@ -5,110 +5,188 @@
 [![MSRV](https://img.shields.io/crates/msrv/faucet-source-csv.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
 [![License](https://img.shields.io/crates/l/faucet-source-csv.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-A CSV file source that reads rows from CSV files and returns them as JSON objects, with configurable delimiters, headers, and quote characters.
+A **CSV file source** that reads delimited text files and yields each row as a `serde_json::Value` object. Part of the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
 
-Part of the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
+Built on the streaming RFC-4180 `csv-async` reader so the file is consumed lazily, line by line, instead of being slurped into memory — a multi-gigabyte export streams through with memory bounded by `batch_size`, not file size. Reach for it to load CSV/TSV/pipe-delimited exports, spreadsheet dumps, or legacy flat files into any faucet-stream sink.
+
+## Feature highlights
+
+- **True streaming reader** — `Source::stream_pages` reads from a `tokio` async reader and emits fixed-size pages; client-side memory is O(`batch_size`), not O(file size).
+- **Configurable dialect** — set the field `delimiter` and `quote` characters (byte values) for CSV, TSV, pipe-delimited, or any single-char-delimited format.
+- **Header or headerless** — with headers, columns are keyed by the header row; without, keys are generated as `column_0`, `column_1`, ….
+- **RFC-4180 correct** — quoted fields containing embedded delimiters *and* embedded newlines parse as a single record, so files written by `faucet-sink-csv` round-trip losslessly.
+- **Transparent compression** — opt-in `compression` feature reads `.gz` / `.zst` files, with auto-detection from the path suffix.
+- **No type inference** — every field is returned as a JSON string; cast downstream with the `cast` transform if you need typed values.
 
 ## Installation
 
 ```bash
+# As a library:
 cargo add faucet-source-csv
 cargo add tokio --features full
-```
 
-Or via the umbrella crate:
-```bash
+# In the CLI (opt-in connector feature):
+cargo install faucet-cli --features source-csv
+
+# Via the umbrella crate:
 cargo add faucet-stream --features source-csv
 ```
 
-## Quick Start
+`source-csv` is not in the CLI default build — enable it explicitly (or use the `source` / `full` aggregate features).
 
-```rust
-use faucet_source_csv::{CsvSource, CsvSourceConfig};
-use faucet_core::Source;
+## Quick start
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let config = CsvSourceConfig::new("/path/to/data.csv");
+```yaml
+# pipeline.yaml — faucet run pipeline.yaml
+version: 1
+name: csv_to_jsonl
 
-    let source = CsvSource::new(config);
-    let records = source.fetch_all().await?;
+pipeline:
+  source:
+    type: csv
+    config:
+      path: ./data/input.csv
 
-    for record in &records {
-        println!("{}", record);
-    }
-    Ok(())
-}
+  sink:
+    type: jsonl
+    config:
+      path: ./out/records.jsonl
 ```
 
-## How It Works
+```bash
+faucet run pipeline.yaml
+```
 
-- If the file has headers, each row becomes a JSON object with header names as keys
-- If the file has no headers, keys are generated as `column_0`, `column_1`, etc.
-- All field values are returned as JSON strings (no type inference)
-- `fetch_all` / `fetch_with_context` read the file via blocking I/O on a `spawn_blocking` task to avoid starving the async runtime
-- `Source::stream_pages` reads the file via async line-streaming on a tokio `BufReader` and parses each line through a single-record `csv::ReaderBuilder` parse
+With a header row of `id,name,email`, the file produces records like
+`{"id": "1", "name": "Alice", "email": "alice@example.com"}`.
 
-## Configuration
+## Configuration reference
 
-### CsvSourceConfig
+### Core
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `path` | `String` | *(required)* | Path to the CSV file |
-| `has_headers` | `bool` | `true` | Whether the file has a header row |
-| `delimiter` | `u8` | `b','` (comma) | Field delimiter byte |
-| `quote` | `u8` | `b'"'` (double quote) | Quote character byte |
-| `batch_size` | `usize` | `DEFAULT_BATCH_SIZE` (1000) | Rows per emitted `StreamPage` in `Source::stream_pages`. `0` is the "no batching" sentinel — emits all rows in a single page |
+| `path` | string | — *(required)* | Path to the CSV file on the local filesystem. |
+| `has_headers` | bool | `true` | Whether the first row is a header. `true` → header names become object keys. `false` → keys are generated `column_0`, `column_1`, …. |
+| `delimiter` | int (byte) | `44` (`,`) | Field delimiter, as a byte value. `9` = tab, `124` = pipe (`\|`), `59` = semicolon. |
+| `quote` | int (byte) | `34` (`"`) | Quote character, as a byte value. `39` = single quote (`'`). |
 
-### Streaming and batching
+### Batching
 
-`CsvSource::stream_pages` is a true client-side stream: it opens the file via
-`tokio::fs::File` + `tokio::io::BufReader`, reads the header line first (if
-`has_headers`), then iterates the remaining lines via
-`AsyncBufReadExt::lines`. Each line is parsed through a single-record
-`csv::ReaderBuilder` so quoted fields containing the delimiter
-(e.g. `"hello, world"`) parse correctly. There is no server-side concern —
-the file is consumed lazily from the local filesystem, so client-side memory
-is bounded at O(`batch_size`) regardless of file size.
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `batch_size` | int | `1000` | Rows per emitted `StreamPage` in `Source::stream_pages`. **`0` = no batching**: the entire file is drained into a single page (handy for small lookup tables or load-job sinks that prefer one large request). Capped at `MAX_BATCH_SIZE` (1,000,000); validated at config-load time. |
 
-`batch_size = 0` is the "no batching" sentinel: the file is fully drained
-and emitted as one page. Useful for small lookup tables or for sinks (SQL
-`COPY`, BigQuery load jobs) that prefer one large request to many small
-ones.
+### Format
 
-#### Multi-line quoted records
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `compression` | enum | `auto` | `none` \| `gzip` \| `zstd` \| `auto`. **Requires the `compression` feature.** `auto` selects the codec from the path suffix (`.gz` → gzip, `.zst` → zstd, otherwise none). |
 
-Parsing uses `csv-async`, a streaming RFC-4180 reader that tracks quote
-state across physical lines. Quoted fields containing embedded newlines
-(and embedded delimiters) are parsed correctly as a single record, so a
-file produced by `faucet-sink-csv` round-trips back losslessly through
-both `fetch_all` and the `stream_pages` streaming path.
+> Byte fields (`delimiter`, `quote`) are integers in JSON/YAML. Common values: `44` comma, `9` tab, `124` pipe, `59` semicolon, `34` double-quote, `39` single-quote.
 
-## Config Loading
+## Examples
+
+### TSV (tab-separated) file
+
+```yaml
+source:
+  type: csv
+  config:
+    path: /data/export.tsv
+    delimiter: 9          # tab
+```
+
+### Headerless, pipe-delimited legacy export
+
+```yaml
+source:
+  type: csv
+  config:
+    path: /data/legacy_export.csv
+    has_headers: false
+    delimiter: 124        # pipe |
+    quote: 39             # single quote '
+```
+
+Rows become `{"column_0": "...", "column_1": "...", ...}`.
+
+### Cast string fields to typed values en route to SQLite
+
+```yaml
+version: 1
+name: csv_to_sqlite
+
+pipeline:
+  source:
+    type: csv
+    config:
+      path: ./data/customers.csv
+
+  transforms:
+    - type: cast
+      config:
+        field: age
+        to: integer
+
+  sink:
+    type: sqlite
+    config:
+      connection_url: sqlite://./customers.db
+      table: customers
+      auto_map: true
+```
+
+### Compressed file (gzip), one page per file
+
+```yaml
+source:
+  type: csv
+  config:
+    path: /data/events.csv.gz
+    compression: auto      # detects .gz; explicit `gzip` also works
+    batch_size: 0          # emit the whole file as one page
+```
+
+## Streaming & batching
+
+`CsvSource` implements `Source::stream_pages` as a real client-side stream. It opens the file through `tokio::fs::File`, wraps it in a `csv_async::AsyncReaderBuilder` configured with the dialect (`delimiter` / `quote` / `has_headers`), and reads records incrementally — buffering up to `batch_size` rows before yielding a page. Because `csv-async` is a streaming RFC-4180 reader, it tracks quote state across physical lines, so quoted fields with embedded newlines and delimiters (e.g. `"hello, world"` or a multi-line cell) parse correctly as a single record.
+
+`batch_size = 0` is the **no-batching sentinel**: the file is fully drained and emitted in one `StreamPage`. Use it for small lookup tables, or for sinks (SQL `COPY`, BigQuery load jobs) that prefer one large request over many small ones.
+
+`fetch_all` / `fetch_with_context` are convenience methods that collect every page into a single `Vec<serde_json::Value>` by draining `stream_pages`.
+
+Every page carries `bookmark: None` — there is no incremental-replication mode for a flat file (the whole file is read on each run).
+
+## Compression
+
+Behind the crate-local `compression` Cargo feature, the source gains a `compression` config field (`none` / `gzip` / `zstd` / `auto`, default `auto`). Auto-detection consults the path suffix at I/O time — `.gz` selects gzip, `.zst` selects zstd, anything else is treated as uncompressed. The streaming reader decompresses on the fly, so memory stays bounded and multi-line quoted records still parse correctly. Enable it with `cargo install faucet-cli --features "source-csv compression"` or `cargo add faucet-source-csv --features compression`.
+
+## Config loading
 
 ```rust
 use faucet_core::config::{load_json, load_env_file};
 use faucet_source_csv::CsvSourceConfig;
 
+# fn example() -> Result<(), Box<dyn std::error::Error>> {
 let config: CsvSourceConfig = load_json("config.json")?;
 let config: CsvSourceConfig = load_env_file(".env", "CSV_SOURCE")?;
+# Ok(()) }
 ```
 
-### Example JSON config
+JSON config:
 
 ```json
 {
   "path": "/data/exports/customers.csv",
   "has_headers": true,
   "delimiter": 44,
-  "quote": 34
+  "quote": 34,
+  "batch_size": 1000
 }
 ```
 
-Note: `delimiter` and `quote` are specified as byte values (44 = comma, 34 = double quote, 9 = tab).
-
-### Example .env file
+`.env` file:
 
 ```env
 CSV_SOURCE_PATH=/data/exports/customers.csv
@@ -117,98 +195,77 @@ CSV_SOURCE_DELIMITER=44
 CSV_SOURCE_QUOTE=34
 ```
 
-## Config Schema Introspection
+## Schema introspection
 
-```rust
-use faucet_core::Source;
-
-let source = CsvSource::new(config);
-let schema = source.config_schema();
-println!("{}", serde_json::to_string_pretty(&schema)?);
+```bash
+faucet schema source csv
 ```
 
-## Examples
+Prints the JSON Schema for `CsvSourceConfig` — the authoritative field list, types, and defaults.
 
-### Reading a standard CSV file
+## Library usage
 
-```rust
+```rust,no_run
 use faucet_source_csv::{CsvSource, CsvSourceConfig};
 use faucet_core::Source;
 
-let config = CsvSourceConfig::new("/data/users.csv");
-let source = CsvSource::new(config);
-let records = source.fetch_all().await?;
-
-// Example record: {"id": "1", "name": "Alice", "email": "alice@example.com"}
-for record in &records {
-    println!("User: {}", record["name"]);
-}
-```
-
-### Reading a TSV (tab-separated) file
-
-```rust
-use faucet_source_csv::{CsvSource, CsvSourceConfig};
-use faucet_core::Source;
-
+# async fn example() -> Result<(), Box<dyn std::error::Error>> {
+// TSV without a header row
 let config = CsvSourceConfig::new("/data/export.tsv")
-    .delimiter(b'\t');
-
-let source = CsvSource::new(config);
-let records = source.fetch_all().await?;
-```
-
-### Reading a file without headers
-
-```rust
-use faucet_source_csv::{CsvSource, CsvSourceConfig};
-use faucet_core::Source;
-
-let config = CsvSourceConfig::new("/data/raw_data.csv")
-    .has_headers(false);
+    .has_headers(false)
+    .delimiter(b'\t')
+    .with_batch_size(5000);
 
 let source = CsvSource::new(config);
 let records = source.fetch_all().await?;
 
-// Keys are generated: column_0, column_1, column_2, ...
-println!("First field: {}", records[0]["column_0"]);
+for record in &records {
+    println!("{record}");
+}
+# Ok(()) }
 ```
 
-### Pipe-delimited file with single-quote quoting
+To run it through a pipeline, pair the source with any sink and drive it via
+`faucet_core::Pipeline` or `faucet_core::run_stream`.
 
-```rust
-use faucet_source_csv::{CsvSource, CsvSourceConfig};
-use faucet_core::Source;
+## How it works
 
-let config = CsvSourceConfig::new("/data/legacy_export.csv")
-    .delimiter(b'|')
-    .quote(b'\'');
-
-let source = CsvSource::new(config);
-let records = source.fetch_all().await?;
-```
-
-## Compression
-
-Behind the crate-local `compression` Cargo feature. Adds a `compression` config
-field with values `none`, `gzip`, `zstd`, or `auto` (the default — detects
-`.gz` / `.zst` from the file path / object key).
-
-YAML example:
-
-```yaml
-kind: csv
-config:
-  # ... existing fields ...
-  compression: auto  # or 'gzip' | 'zstd' | 'none'
-```
-
-Compression is detected from the file path. Multi-line quoted fields (records with embedded newlines inside quotes) are parsed correctly on both the streaming and `fetch_all` paths, regardless of compression.
+- The source holds only the parsed `CsvSourceConfig`; there is no client or pool to reuse, since reads are local-filesystem I/O.
+- `stream_pages` builds one `csv_async::AsyncReader` per run and pulls records through it incrementally, so the whole file is never resident in memory.
+- All values are emitted as JSON strings — the reader does no type inference. Use the `cast` transform to coerce numbers/booleans downstream.
+- Empty rows and the trailing newline are handled by the underlying RFC-4180 reader; an empty file yields zero records (not an error).
 
 ## Lineage dataset URI
 
 `file://<path>` — e.g. `file:///data/input.csv`.
 
+## Feature flags
+
+| Feature | Default | Effect |
+|---------|---------|--------|
+| `compression` | off | Adds the `compression` config field and `.gz` / `.zst` read support (pulls `faucet-core/compression`). |
+
+The connector itself is enabled in the CLI/umbrella via the `source-csv` feature.
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause & fix |
+|---------|--------------------|
+| `FaucetError::Source`: file not found / permission denied | `path` is wrong or unreadable. Check the path (relative paths resolve against the process working directory) and file permissions. |
+| Every value is a string, including numbers | Intentional — the CSV reader does no type inference. Add a `cast` transform (`to: integer` / `float` / `boolean`) for fields you need typed. |
+| Columns named `column_0`, `column_1`, … unexpectedly | `has_headers` is `false` (or defaulted off in an env config). Set `has_headers: true` so the first row supplies keys. |
+| Fields split in the wrong place | Wrong `delimiter`. Set the byte value for your format — `9` (tab), `124` (pipe), `59` (semicolon). |
+| Quoted text with commas is being split | The `quote` byte doesn't match the file. Set `quote` to the file's quote character (`34` double, `39` single). |
+| Multi-line cell breaks into several records | The cell isn't actually quoted, so the reader can't tell the embedded newline from a record boundary. Ensure the producer quotes fields containing newlines (faucet-sink-csv does). |
+| `FaucetError::Config` on `batch_size` | `batch_size` exceeds `MAX_BATCH_SIZE` (1,000,000). Lower it, or use `0` for no batching. |
+| `.gz` / `.zst` file read as raw bytes / garbage | The `compression` feature isn't enabled. Rebuild with `--features compression` (or set `compression: gzip` explicitly). |
+| A header name appears as a key but with surrounding whitespace | Header cells are taken verbatim. Trim upstream or rename with the `rename_keys` transform. |
+
+## See also
+
+- [Connector reference](https://pawansikawat.github.io/faucet-stream/reference/connectors.html) · [Compression cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/compression.html) · [Transforms cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/transforms.html)
+- Related crates: [faucet-sink-csv](https://crates.io/crates/faucet-sink-csv) · [faucet-source-parquet](https://crates.io/crates/faucet-source-parquet) · [faucet-source-s3](https://crates.io/crates/faucet-source-s3)
+
 ## License
 
-Licensed under MIT or Apache-2.0.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/source/elasticsearch/README.md
+++ b/crates/source/elasticsearch/README.md
@@ -2,6 +2,8 @@
 
 [![Crates.io](https://img.shields.io/crates/v/faucet-source-elasticsearch.svg)](https://crates.io/crates/faucet-source-elasticsearch)
 [![Docs.rs](https://docs.rs/faucet-source-elasticsearch/badge.svg)](https://docs.rs/faucet-source-elasticsearch)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-source-elasticsearch.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-source-elasticsearch.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
 An Elasticsearch source that reads documents using the search/scroll API with query DSL support, automatic scroll context management, and pluggable authentication.
 

--- a/crates/source/elasticsearch/README.md
+++ b/crates/source/elasticsearch/README.md
@@ -5,88 +5,233 @@
 [![MSRV](https://img.shields.io/crates/msrv/faucet-source-elasticsearch.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
 [![License](https://img.shields.io/crates/l/faucet-source-elasticsearch.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-An Elasticsearch source that reads documents using the search/scroll API with query DSL support, automatic scroll context management, and pluggable authentication.
+An **Elasticsearch** search source for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem. Runs a query-DSL search against an index, walks the result set page-by-page via the [scroll API](https://www.elastic.co/guide/en/elasticsearch/reference/current/scroll-api.html), emits each hit's `_source` as a `serde_json::Value`, and streams pages straight into any faucet-stream sink so memory stays bounded no matter how many documents match.
 
-Part of the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
+Reach for it when you need to export logs, metrics, orders, or any indexed documents out of Elasticsearch — for backup, reindexing, analytics offload, or feeding a database/warehouse/queue — with one declarative config and no glue code.
+
+## Feature highlights
+
+- **Scroll-based streaming** — the source uses the scroll API so an index of any size is drained at `O(batch_size)` client memory; each scroll response becomes exactly one `StreamPage` written to the sink as it lands.
+- **Full query-DSL support** — pass any Elasticsearch query object verbatim (`bool`, `range`, `term`, `match`, …); defaults to `match_all`.
+- **Four auth modes** — none, HTTP Basic, Bearer token, or API key. The shared `ElasticsearchAuth` enum is re-exported from [`faucet-common-elasticsearch`](https://crates.io/crates/faucet-common-elasticsearch) so it matches the Elasticsearch **sink** byte-for-byte; credentials are masked in debug output.
+- **Shared auth providers** — `auth: { ref: <name> }` points at a provider in the CLI's top-level `auth:` catalog, so many sources share one token with single-flight refresh.
+- **Unconditional scroll cleanup** — the open `_scroll_id` is always sent to `DELETE _search/scroll` on every exit path (clean drain, `max_pages` truncation, mid-stream error, or the consumer dropping the stream) via an RAII guard, so the cluster never leaks server-side scroll state.
+- **Matrix-context interpolation** — `${field.path}` placeholders in `index` and `query` resolve against the parent-record context at runtime, so one config can fan out across indices or query values.
+- **`max_pages` cap** — bound the number of scroll responses for previews or partial exports.
+- **No-batching sentinel** — `batch_size: 0` issues a single non-scroll `_search?size=10000` for small lookup indices or sinks that prefer one large request.
+- **Client built once** — the `reqwest` client is constructed in `new()` and reused for every request.
 
 ## Installation
 
 ```bash
+# As a library:
 cargo add faucet-source-elasticsearch
-cargo add tokio --features full
-```
 
-Or via the umbrella crate:
-```bash
+# Or via the umbrella crate:
 cargo add faucet-stream --features source-elasticsearch
+
+# In the CLI (opt-in connector feature):
+cargo install faucet-cli --features source-elasticsearch
 ```
 
-## Quick Start
+`source-elasticsearch` is an opt-in feature — it is not part of the CLI/umbrella default build.
 
-```rust
-use faucet_source_elasticsearch::{ElasticsearchSource, ElasticsearchSourceConfig};
-use faucet_core::Source;
+## Quick start
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let config = ElasticsearchSourceConfig::new(
-        "http://localhost:9200",
-        "my_index",
-    );
-
-    let source = ElasticsearchSource::new(config);
-    let records = source.fetch_all().await?;
-
-    println!("Read {} documents", records.len());
-    Ok(())
-}
+```yaml
+# pipeline.yaml — faucet run pipeline.yaml
+version: 1
+pipeline:
+  source:
+    type: elasticsearch
+    config:
+      base_url: http://localhost:9200
+      index: my_index
+      # query defaults to { match_all: {} }
+  sink:
+    type: jsonl
+    config:
+      path: ./docs.jsonl
 ```
 
-## How It Works
+```bash
+faucet run pipeline.yaml
+```
 
-The source uses the Elasticsearch scroll API for efficient retrieval of large result sets:
-
-1. Sends an initial `POST /{index}/_search?scroll={timeout}&size={batch_size}` with the query
-2. Extracts `_source` from each hit in `hits.hits[*]._source`
-3. Continues scrolling with `POST /_search/scroll` using the `_scroll_id`
-4. Stops when a scroll page returns zero hits, or `max_pages` is reached
-5. Clears the scroll context (best-effort) to free server resources
-
-## Configuration
-
-### ElasticsearchSourceConfig
+## Configuration reference
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `base_url` | `String` | *(required)* | Base URL of the Elasticsearch cluster (e.g. `"http://localhost:9200"`). Trailing slash is trimmed |
-| `index` | `String` | *(required)* | Index name to search |
-| `query` | `Value` | `{"match_all": {}}` | Elasticsearch query DSL |
-| `scroll_timeout` | `String` | `"1m"` | Scroll context timeout (e.g. `"1m"`, `"5m"`) |
-| `auth` | `ElasticsearchAuth` | `ElasticsearchAuth::None` | Authentication method |
-| `max_pages` | `Option<usize>` | `None` | Maximum number of scroll pages to fetch. `None` means no limit |
-| `batch_size` | `usize` | `DEFAULT_BATCH_SIZE` (1000) | Docs per emitted `StreamPage`; also the scroll API `size` parameter. `0` is the "no batching" sentinel — see below |
+| `base_url` | string | — *(required)* | Base URL of the Elasticsearch cluster (e.g. `http://localhost:9200`). A trailing slash is trimmed. |
+| `index` | string | — *(required)* | Index (or pattern, e.g. `metrics-*`) to search. Supports `${field.path}` matrix-context placeholders. |
+| `query` | object | `{ "match_all": {} }` | Elasticsearch query DSL, sent verbatim as the `query` of the search body. Supports `${field.path}` placeholders resolved against the parent-record context. |
+| `scroll_timeout` | string | `"1m"` | Scroll-context keep-alive sent on the initial and every follow-up scroll request (e.g. `"1m"`, `"5m"`). Must exceed the time taken to process one page downstream. |
+| `auth` | `ElasticsearchAuth` | `{ type: none }` | Authentication — inline `{ type, config }` or `{ ref: <name> }`. See [Authentication](#authentication). |
+| `max_pages` | int | *(unset = no limit)* | Maximum number of scroll responses to emit. The cap applies *after* a page is yielded. |
+| `batch_size` | int | `1000` | Docs per emitted `StreamPage`, also the scroll API `size` parameter. **`0` = no batching**: a single non-scroll `_search?size=10000` is issued instead. Validated against `MAX_BATCH_SIZE` (1,000,000) at construction. |
 
-### Authentication (ElasticsearchAuth)
+### Authentication
 
-| Variant | Fields | Description |
-|---------|--------|-------------|
-| `None` | -- | No authentication |
-| `Basic { username, password }` | `String`, `String` | HTTP Basic authentication. Password is masked in debug output |
-| `Bearer { token }` | `String` | Bearer token in the `Authorization` header. Masked in debug output |
-| `ApiKey { key }` | `String` | API key sent as `ApiKey <key>` in the `Authorization` header. Masked in debug output |
+`auth` uses the shared `ElasticsearchAuth` enum (the project-wide `{ type, config }` shape):
 
-## Streaming and batching
+| `type` | `config` | Sent as |
+|--------|----------|---------|
+| `none` | *(none)* | No `Authorization` header. |
+| `basic` | `{ username, password }` | HTTP Basic `Authorization: Basic <base64>`. |
+| `bearer` | `{ token }` | `Authorization: Bearer <token>`. |
+| `api_key` | `{ key }` | `Authorization: ApiKey <key>` (the base64 `id:api_key` value). |
 
-The source overrides [`Source::stream_pages`](https://docs.rs/faucet-core/latest/faucet_core/trait.Source.html#method.stream_pages) so the pipeline writes documents to the sink as each scroll page lands instead of buffering the full result. Client-side memory stays O(batch_size) regardless of the index's total document count.
+```yaml
+# No auth (local dev)
+auth:
+  type: none
+```
 
-- `batch_size` (default `1000`) is passed straight to the scroll API as the `size` parameter on the initial `POST /{index}/_search?scroll={timeout}&size={batch_size}`. Each scroll response — initial and follow-up — becomes exactly one `StreamPage`. The trailing empty scroll page is consumed but not emitted.
-- `batch_size = 0` is the **"no batching" sentinel**: the source skips scroll entirely and issues a single `POST /{index}/_search?size=10000`, then emits one `StreamPage`. Useful for small lookup indices, or for sinks like SQL `COPY` / BigQuery load jobs that prefer one large request to many small ones. The `10000` cap matches Elasticsearch's default `index.max_result_window`; indices with a larger `max_result_window` still receive only `10000` hits — switch back to scroll if you need more.
-- `batch_size = 0` is also honoured by the buffered `fetch_all` / `fetch_with_context` path: it maps to the same `size=10000` initial search (rather than the literal `size=0`, which would return zero hits).
-- `max_pages`, when set, caps the total number of scroll responses emitted. The cap applies *after* the page is yielded.
-- The Elasticsearch search source has no incremental-replication mode today, so every emitted page carries `bookmark: None`.
-- **Scroll-context cleanup is unconditional.** On every exit path — clean drain, `max_pages` truncation, mid-stream HTTP error, or the consumer dropping the stream — the open `_scroll_id` is sent to `DELETE _search/scroll` so the cluster does not leak server-side state.
+```yaml
+# HTTP Basic
+auth:
+  type: basic
+  config:
+    username: elastic
+    password: ${env:ES_PASSWORD}
+```
 
-## Config Loading
+```yaml
+# Bearer token
+auth:
+  type: bearer
+  config:
+    token: ${env:ES_BEARER_TOKEN}
+```
+
+```yaml
+# API key (recommended for Elastic Cloud)
+auth:
+  type: api_key
+  config:
+    key: ${env:ES_API_KEY}
+```
+
+Shared provider via the top-level `auth:` catalog (single token shared across sources):
+
+```yaml
+auth:
+  es_token:
+    type: static
+    config: { token: ${env:ES_BEARER_TOKEN} }
+
+pipeline:
+  source:
+    type: elasticsearch
+    config:
+      base_url: https://es.example.com:9200
+      index: orders
+      auth: { ref: es_token }
+```
+
+A shared provider may only yield a `bearer` or `basic` credential — header- and token-style credentials have no Elasticsearch equivalent and surface as an auth error.
+
+## Examples
+
+### Filtered error-log export to S3
+
+```yaml
+# Elasticsearch (API-key auth) → S3 with sharded parallel uploads.
+version: 1
+name: elasticsearch_to_s3
+pipeline:
+  source:
+    type: elasticsearch
+    config:
+      base_url: https://es.example.com:9200
+      index: logs-2026-05
+      query:
+        match:
+          level: error
+      scroll_timeout: 2m
+      batch_size: 2000
+      auth:
+        type: api_key
+        config:
+          key: ${env:ES_API_KEY}
+  sink:
+    type: s3
+    config:
+      bucket: my-es-backups
+      prefix: logs/2026-05/
+      region: us-east-1
+      file_extension: .jsonl
+      max_records_per_file: 50000
+      concurrency: 16
+```
+
+### Bool query with a time range and Basic auth
+
+```yaml
+source:
+  type: elasticsearch
+  config:
+    base_url: https://elasticsearch.example.com:9200
+    index: application-logs-2026.03
+    query:
+      bool:
+        must:
+          - match: { level: error }
+          - range:
+              "@timestamp": { gte: "2026-03-01", lt: "2026-04-01" }
+    scroll_timeout: 5m
+    batch_size: 5000
+    max_pages: 100
+    auth:
+      type: basic
+      config:
+        username: elastic
+        password: ${env:ES_PASSWORD}
+```
+
+### Small lookup index — one request, no scroll
+
+```yaml
+source:
+  type: elasticsearch
+  config:
+    base_url: http://localhost:9200
+    index: country_codes
+    batch_size: 0      # single _search?size=10000, no scroll context
+```
+
+### Daily metrics window driven by a matrix context
+
+```yaml
+source:
+  type: elasticsearch
+  config:
+    base_url: https://es.example.com:9200
+    index: "metrics-${region.name}"
+    query:
+      range:
+        "@timestamp": { gte: now-1h, lt: now }
+    auth: { ref: es_token }
+```
+
+## Streaming & batching
+
+The source overrides [`Source::stream_pages`](https://docs.rs/faucet-core/latest/faucet_core/trait.Source.html#tymethod.stream_pages): the pipeline writes documents to the sink as each scroll page lands, so client-side memory stays `O(batch_size)` regardless of the index's total document count.
+
+- `batch_size` (default `1000`) is passed straight to the scroll API as the `size` parameter on the initial `POST /{index}/_search?scroll={timeout}&size={batch_size}`. Each scroll response — initial and follow-up — becomes exactly one `StreamPage`. The trailing empty scroll page is the end-of-scroll sentinel and is consumed but not emitted.
+- **`batch_size: 0` is the "no batching" sentinel**: the source skips scroll entirely and issues a single `POST /{index}/_search?size=10000`, emitting one page. The `10000` cap mirrors Elasticsearch's default `index.max_result_window`; indices with a larger window still receive only `10000` hits — switch back to scroll if you need more.
+- `batch_size: 0` is also honoured on the buffered `fetch_all` / `fetch_with_context` path — it maps to the same `size=10000` initial search (not the literal `size=0`, which would return zero hits).
+- `max_pages`, when set, caps the total number of scroll responses emitted; the cap applies *after* the page is yielded.
+- The trait-level `batch_size` argument to `stream_pages` is **ignored** in favour of the config field, so a pipeline-supplied hint never silently overrides an explicit config value.
+- This source has no incremental-replication / resume mode today, so every emitted page carries `bookmark: None` (see [Resume & state](#resume--state)). For incremental loads, encode the watermark in the query (e.g. a `range` on `@timestamp`) and drive it from a matrix context or `${now.*}` token.
+
+## Resume & state
+
+The Elasticsearch search source is **stateless** — it does not implement `state_key()` / `apply_start_bookmark()`, so each run re-executes the full query and there is no durable bookmark. Make runs incremental at the query level: filter on a monotonic field (`@timestamp`, a sequence id) and supply the lower bound via a `${now.*}` token, a matrix-context value, or relative date math (`now-1h`).
+
+## Config loading & schema
+
+Load from YAML/JSON files, environment variables, or a `.env` file via the helpers in `faucet_core::config`:
 
 ```rust
 use faucet_core::config::{load_json, load_env_file};
@@ -96,36 +241,8 @@ let config: ElasticsearchSourceConfig = load_json("config.json")?;
 let config: ElasticsearchSourceConfig = load_env_file(".env", "ES_SOURCE")?;
 ```
 
-### Example JSON config
-
-```json
-{
-  "base_url": "https://elasticsearch.example.com:9200",
-  "index": "application-logs-2025.03",
-  "query": {
-    "bool": {
-      "must": [
-        { "match": { "level": "error" } },
-        { "range": { "@timestamp": { "gte": "2025-03-01", "lt": "2025-04-01" } } }
-      ]
-    }
-  },
-  "scroll_timeout": "2m",
-  "batch_size": 5000,
-  "auth": {
-    "type": "basic",
-    "config": {
-      "username": "elastic",
-      "password": "changeme"
-    }
-  },
-  "max_pages": 100
-}
-```
-
-### Example .env file
-
 ```env
+# .env
 ES_SOURCE_BASE_URL=http://localhost:9200
 ES_SOURCE_INDEX=my_index
 ES_SOURCE_SCROLL_TIMEOUT=1m
@@ -133,100 +250,80 @@ ES_SOURCE_BATCH_SIZE=1000
 ES_SOURCE_MAX_PAGES=50
 ```
 
-## Config Schema Introspection
+Inspect the full JSON Schema with:
+
+```bash
+faucet schema source elasticsearch
+```
+
+## Library usage
 
 ```rust
 use faucet_core::Source;
-
-let source = ElasticsearchSource::new(config);
-let schema = source.config_schema();
-println!("{}", serde_json::to_string_pretty(&schema)?);
-```
-
-## Examples
-
-### Match-all query with defaults
-
-```rust
-use faucet_source_elasticsearch::{ElasticsearchSource, ElasticsearchSourceConfig};
-use faucet_core::Source;
-
-let config = ElasticsearchSourceConfig::new("http://localhost:9200", "products");
-let source = ElasticsearchSource::new(config);
-let products = source.fetch_all().await?;
-```
-
-### Filtered query with bearer auth
-
-```rust
 use faucet_source_elasticsearch::{
     ElasticsearchSource, ElasticsearchSourceConfig, ElasticsearchAuth,
 };
-use faucet_core::Source;
 use serde_json::json;
 
-let config = ElasticsearchSourceConfig::new(
-    "https://es.production.example.com:9200",
-    "orders-2025",
-)
-.query(json!({
-    "bool": {
-        "filter": [
-            { "term": { "status": "completed" } },
-            { "range": { "amount": { "gte": 100 } } }
-        ]
-    }
-}))
-.auth(ElasticsearchAuth::Bearer {
-    token: "your-token".into(),
-})
-.with_batch_size(2000)
-.scroll_timeout("5m")
-.max_pages(50);
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let config = ElasticsearchSourceConfig::new("https://es.example.com:9200", "orders-2026")
+    .query(json!({
+        "bool": { "filter": [ { "term": { "status": "completed" } } ] }
+    }))
+    .auth(ElasticsearchAuth::Bearer { token: "your-token".into() })
+    .scroll_timeout("5m")
+    .with_batch_size(2000)
+    .max_pages(50);
 
-let source = ElasticsearchSource::new(config);
+// `new` validates batch_size and does no I/O.
+let source = ElasticsearchSource::new(config)?;
 let orders = source.fetch_all().await?;
 println!("Found {} matching orders", orders.len());
+# Ok(())
+# }
 ```
 
-### Using API key authentication
+For streaming into a sink, build a `Pipeline` (or call `faucet_core::run_stream`) with this source — it drives `stream_pages` automatically so memory stays bounded.
 
-```rust
-use faucet_source_elasticsearch::{
-    ElasticsearchSource, ElasticsearchSourceConfig, ElasticsearchAuth,
-};
-use faucet_core::Source;
-use serde_json::json;
+## How it works
 
-let config = ElasticsearchSourceConfig::new(
-    "https://my-cluster.es.cloud.example.com:9243",
-    "metrics-*",
-)
-.query(json!({
-    "range": {
-        "@timestamp": {
-            "gte": "now-1h",
-            "lt": "now"
-        }
-    }
-}))
-.auth(ElasticsearchAuth::ApiKey {
-    key: "base64-encoded-api-key".into(),
-})
-.with_batch_size(5000);
-
-let source = ElasticsearchSource::new(config);
-let metrics = source.fetch_all().await?;
-```
-
-## Shared types
-
-`ElasticsearchAuth` lives in [`faucet-common-elasticsearch`](../../common/elasticsearch) and is shared with `faucet-sink-elasticsearch`. The source re-exports it for convenience, so `faucet_source_elasticsearch::ElasticsearchAuth` continues to work unchanged.
+1. `new()` validates `batch_size` and builds a `reqwest::Client` **once** (no I/O on construction).
+2. The effective `index` and `query` are resolved against the matrix context (placeholder substitution), and auth is resolved once per run and reused across every scroll request.
+3. An initial `POST /{index}/_search?scroll={timeout}&size={batch_size}` returns the first page of hits plus a `_scroll_id`.
+4. Each scroll response's `hits.hits[*]._source` is extracted into a `StreamPage` and handed to the sink; the source then `POST /_search/scroll`s the `_scroll_id` for the next page.
+5. The loop stops on an empty hits array (the end-of-scroll sentinel) or when `max_pages` is reached.
+6. An RAII `ScrollGuard` owns the live `_scroll_id` and `DELETE`s the scroll context on **every** exit — clean drain, truncation, error, or drop — by spawning the cleanup so it survives the stream future being cancelled mid-await.
 
 ## Lineage dataset URI
 
-`http://<host>:<port>/<index>` (credentials stripped) — e.g. `http://localhost:9200/my_index`.
+`http://<host>:<port>/<index>` with credentials stripped — e.g. `http://localhost:9200/my_index`.
+
+## Feature flags
+
+This crate has no optional features of its own; enable it in the CLI/umbrella via the `source-elasticsearch` feature. `ElasticsearchAuth` is re-exported from [`faucet-common-elasticsearch`](https://crates.io/crates/faucet-common-elasticsearch), shared with `faucet-sink-elasticsearch` — `faucet_source_elasticsearch::ElasticsearchAuth` continues to work unchanged.
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause & fix |
+|---------|--------------------|
+| `401 Unauthorized` / `403` | Missing or wrong credentials. Set `auth` to `basic` / `bearer` / `api_key` with valid values; confirm the user/key has `read` privilege on the index. |
+| `auth references provider '<name>' but no provider was supplied` | The config uses `auth: { ref: <name> }` but no matching entry exists in the top-level `auth:` catalog. Add the provider, or switch to inline `{ type, config }`. |
+| Auth provider error: *"must yield a bearer or basic credential"* | A shared provider returned a `Header`/`Token` credential, which Elasticsearch can't use. Use a provider type that yields a bearer or basic credential, or inline `api_key` auth. |
+| Empty result / `0 documents` with `batch_size: 0` | The index's `max_result_window` is below the matched-doc count, or more than 10,000 docs match. The no-batching path caps at 10,000 hits — switch to scroll (`batch_size: 1000`) to drain everything. |
+| `Search context not found` / scroll expired mid-run | `scroll_timeout` is shorter than the time to process one page downstream. Raise it (e.g. `5m`) so the context outlives each page's sink write. |
+| `index_not_found_exception` | The `index` doesn't exist (after any `${...}` substitution). Verify the index/pattern name; patterns like `metrics-*` need `allow_no_indices` semantics on the cluster. |
+| `parsing_exception` / `400` on the query | The `query` object isn't a valid query-DSL clause. It is sent verbatim as the body's `query` — wrap a single clause directly (e.g. `{ "match": { … } }`), not inside another `query:` key. |
+| Connection refused / TLS error | Wrong `base_url` scheme/port, or a self-signed cert. Use the correct `https://host:9200` and ensure the cert chain is trusted by the host. |
+| Resumes re-read everything | This source is stateless by design — encode an incremental watermark in the `query` (see [Resume & state](#resume--state)). |
+
+## See also
+
+- [Connector reference](https://pawansikawat.github.io/faucet-stream/reference/connectors.html) — the full capability matrix.
+- [Authentication cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/auth.html) — inline vs shared providers.
+- [Configuration grammar](https://pawansikawat.github.io/faucet-stream/reference/config.html) — the YAML/JSON config shape.
+- [`faucet-sink-elasticsearch`](https://crates.io/crates/faucet-sink-elasticsearch) — the matching bulk-index sink.
+- [`faucet-common-elasticsearch`](https://crates.io/crates/faucet-common-elasticsearch) — the shared `ElasticsearchAuth` enum.
 
 ## License
 
-Licensed under MIT or Apache-2.0.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/source/gcs/README.md
+++ b/crates/source/gcs/README.md
@@ -1,168 +1,300 @@
 # faucet-source-gcs
 
-Google Cloud Storage source connector for the
-[faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
+[![Crates.io](https://img.shields.io/crates/v/faucet-source-gcs.svg)](https://crates.io/crates/faucet-source-gcs)
+[![Docs.rs](https://docs.rs/faucet-source-gcs/badge.svg)](https://docs.rs/faucet-source-gcs)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-source-gcs.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-source-gcs.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-Lists objects in a bucket (with optional prefix) or accepts an explicit list
-of object keys, then fetches and parses each object as one of three formats
-— **JSON Lines**, **JSON Array**, or **raw text** — yielding records as
-`serde_json::Value`. Mirrors the existing `faucet-source-s3` crate
-structurally and shares its semantics.
+Google **Cloud Storage** source connector for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem. Lists objects in a bucket (with an optional prefix) or reads an explicit list of object keys, fetches each one over the official [`google-cloud-storage`](https://crates.io/crates/google-cloud-storage) SDK, and parses it as **JSON Lines**, **JSON Array**, or **raw text** — yielding records as `serde_json::Value`.
 
-Built on the official [`google-cloud-storage`](https://crates.io/crates/google-cloud-storage)
-SDK (1.12).
+Reach for it when your data already lives in GCS — event exports, log dumps, analytics extracts, daily snapshots — and you want to move it into any faucet-stream sink (a database, a warehouse, a queue, a file) with one declarative config and no glue code. Objects are read concurrently and JSONL/raw-text bodies stream line-by-line, so a multi-gigabyte export lands without buffering the whole bucket in memory.
 
-## Config
+## Feature highlights
 
-```rust
-pub struct GcsSourceConfig {
-    pub bucket: String,
-    pub prefix: Option<String>,
-    pub object_keys: Option<Vec<String>>,
-    pub credentials: GcsCredentials,
-    pub file_format: GcsFileFormat,
-    pub max_objects: Option<usize>,
-    pub concurrency: usize,        // default 10
-    pub batch_size: usize,         // default DEFAULT_BATCH_SIZE; 0 = one page per object
-    pub storage_host: Option<String>,
-}
+- **Three file formats** — `json_lines` (one record per line), `json_array` (one array per object), and `raw_text` (each object becomes a `{key, content}` record).
+- **List or explicit keys** — scan a bucket by `prefix`, or skip listing entirely by passing an exact `object_keys` list.
+- **Concurrent reads** — objects are fetched in parallel via `buffer_unordered(concurrency)` (default 10), so wall-clock time is bounded by your slowest objects, not their sum.
+- **Bounded-memory streaming** — `json_lines` and `raw_text` decode straight off the GCS body reader, so peak memory is `O(batch_size)` regardless of total file size.
+- **Compression auto-detect** — behind the `compression` feature, `.gz` / `.zst` objects are transparently decompressed; the codec resolves *per object key*, so one run can mix compressed and uncompressed objects.
+- **Four credential modes** — Application Default Credentials, a service-account key file, inline service-account JSON, or anonymous (for emulators). The shared `GcsCredentials` enum is re-exported from [`faucet-common-gcs`](https://crates.io/crates/faucet-common-gcs) so it matches the GCS **sink** byte-for-byte.
+- **Clients built once** — the data-plane and control-plane clients are constructed in `new()` and reused for every list and read.
+- **Matrix-aware prefixes** — `${parent.path}` placeholders in `prefix` are resolved per-record at runtime, so a parent matrix row can fan out into many per-record bucket scans.
+
+## Installation
+
+```bash
+# As a library:
+cargo add faucet-source-gcs
+
+# In the CLI (opt-in connector feature):
+cargo install faucet-cli --features source-gcs
+
+# With transparent gzip/zstd decompression:
+cargo install faucet-cli --features "source-gcs,compression"
 ```
 
-| Field | Description |
-|---|---|
-| `bucket` | GCS bucket name (no `gs://` prefix, no path). |
-| `prefix` | Object-name prefix filter for listing. Ignored when `object_keys` is set. |
-| `object_keys` | Explicit list of object names. When set, listing is skipped. |
-| `credentials` | See [`GcsCredentials`](#authentication) below. Defaults to `application_default`. |
-| `file_format` | `json_lines` *(default)*, `json_array`, or `raw_text`. |
-| `max_objects` | Hard cap on the number of objects scanned. |
-| `concurrency` | Maximum concurrent object reads. |
-| `batch_size` | Records per emitted `StreamPage`. See [Streaming](#streaming-and-batching). |
-| `storage_host` | Endpoint override (integration tests only — production users leave unset). |
+## Quick start
 
-YAML example:
+```yaml
+# pipeline.yaml — faucet run pipeline.yaml
+version: 1
+pipeline:
+  source:
+    type: gcs
+    config:
+      bucket: my-bucket
+      prefix: events/2026/
+      auth:
+        type: service_account_json_file
+        config:
+          path: /run/secrets/gcp-sa.json
+      file_format: json_lines
+  sink:
+    type: jsonl
+    config:
+      path: ./events.jsonl
+```
+
+```bash
+faucet run pipeline.yaml
+```
+
+## Configuration reference
+
+### Core
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `bucket` | string | — *(required)* | GCS bucket name. No `gs://` prefix, no path. |
+| `prefix` | string | *(unset)* | Object-name prefix filter for listing. Ignored when `object_keys` is set. Supports `${field.path}` placeholders resolved against the parent-record context at runtime. |
+| `object_keys` | array of string | *(unset)* | Explicit object names to read. When set, listing is skipped and `prefix` is ignored. |
+| `auth` | `GcsCredentials` | `application_default` | Authentication — see [Authentication](#authentication). |
+| `file_format` | enum | `json_lines` | `json_lines`, `json_array`, or `raw_text` — see [File formats](#file-formats). |
+| `max_objects` | int | *(unset)* | Hard cap on the number of objects read (applied after listing, and to an explicit `object_keys` list). |
+
+### Performance
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `concurrency` | int | `10` | Maximum concurrent object reads. Higher = faster on many small objects; lower caps peak memory for large `raw_text` / `json_array` objects. |
+| `batch_size` | int | `1000` | Records per emitted `StreamPage`. **`0` = no batching** (one page per object). See [Streaming & batching](#streaming--batching). |
+
+### Format & testing
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `compression` | enum | `auto` | *(requires the `compression` feature)* Decompression codec — `none`, `gzip`, `zstd`, or `auto`. `auto` detects `.gz` / `.zst` from the object key. |
+| `storage_host` | string | *(unset)* | Endpoint override (integration tests / emulators only, e.g. `http://localhost:4443`). Production users leave this unset. |
+
+## Authentication
+
+`auth` uses the shared `GcsCredentials` enum from [`faucet-common-gcs`](https://crates.io/crates/faucet-common-gcs) (the project-wide `{ type, config }` shape):
+
+| `type` | `config` | Use when |
+|--------|----------|----------|
+| `application_default` | *(none)* | Running on GCE/GKE (metadata server / workload identity) or after `gcloud auth application-default login`. Also honours `GOOGLE_APPLICATION_CREDENTIALS`. **Default.** |
+| `service_account_json_file` | `{ path: <file> }` | You have a service-account key file on disk. |
+| `service_account_json_inline` | `{ json: <string> }` | You want to inject the key JSON inline, typically via `${env:VAR}` / `${secret:…}` indirection. |
+| `anonymous` | *(none)* | Talking to an emulator (e.g. `fake-gcs-server`) that does not validate bearer tokens. |
+
+```yaml
+# Application Default Credentials (workload identity, gcloud, GOOGLE_APPLICATION_CREDENTIALS)
+auth:
+  type: application_default
+```
+
+```yaml
+# Service-account key file
+auth:
+  type: service_account_json_file
+  config:
+    path: /run/secrets/gcp-sa.json
+```
+
+```yaml
+# Inline service-account JSON via env indirection
+auth:
+  type: service_account_json_inline
+  config:
+    json: ${env:GCP_SA_JSON}
+```
+
+HMAC-key auth, signed-URL generation, and KMS/CMEK encryption configuration are out of scope.
+
+## File formats
+
+| `file_format` | Behaviour | Streaming |
+|---------------|-----------|-----------|
+| `json_lines` *(default)* | One JSON record per line; blank lines are skipped. | Streams line-by-line — `O(batch_size)` memory. |
+| `json_array` | The entire object is a single JSON array of records. | Buffered fully per object (the closing `]` is required to parse), then chunked. |
+| `raw_text` | The whole object becomes one record `{"key": <name>, "content": <utf-8>}`. | Streamed into one `String` per object. |
+
+Parse errors are precise: a JSONL failure carries the object key **and** the 1-based line number; a JSON-array failure carries the key. A `json_array` object whose top-level value isn't an array fails with an `"expected JSON array"` message. Non-UTF-8 bodies surface as `FaucetError::Source` with a `"not valid UTF-8"` hint.
+
+## Examples
+
+### Scan a prefix as JSON Lines (the 80% path)
 
 ```yaml
 source:
   type: gcs
-  bucket: my-bucket
-  prefix: events/2026/
-  auth:
-    type: service_account_json_file
-    config:
-      path: /run/secrets/gcp.json
-  file_format: json_lines
-  concurrency: 20
-  batch_size: 5000
+  config:
+    bucket: analytics-exports
+    prefix: events/dt=2026-06-16/
+    auth: { type: application_default }
+    file_format: json_lines
+    concurrency: 20
+    batch_size: 5000
 ```
 
-## Authentication
+### Read an explicit set of objects, no listing
 
-See [`faucet-common-gcs`](../../common/gcs/README.md) for the full
-`GcsCredentials` reference. v1 supports:
-
-- `application_default` (ADC — recommended on GCE/GKE).
-- `service_account_json_file` (path to a key file).
-- `service_account_json_inline` (key as an inline string, env-injectable
-  via `${env:GCP_SA_JSON}` in CLI configs).
-
-HMAC-key auth and signed-URL generation are out of scope for v1.
-
-## File formats
-
-| Format | Behaviour |
-|---|---|
-| `json_lines` | One JSON record per line. Blank lines skipped. Streams line-by-line. |
-| `json_array` | The entire object is a JSON array of records. Buffered fully per object. |
-| `raw_text` | The whole object becomes one record `{"key": <name>, "content": <utf-8>}`. |
-
-JSONL parse errors carry the object key + 1-based line number. JSON-array
-parse errors include the object key. Non-UTF-8 bodies surface as
-`FaucetError::Source` with a `"not valid UTF-8"` hint.
-
-## Streaming and batching
-
-`Source::stream_pages` decodes `JsonLines` line-by-line so client-side
-memory stays bounded at O(`batch_size`) regardless of file size.
-`RawText` emits one record per object (`{"key": ..., "content": ...}`):
-the whole file is inherently its record, but it is streamed straight into
-one `String` via the same decoding reader `JsonLines` uses — no separate
-raw + decompressed copies for compressed objects. `JsonArray` buffers
-each object fully (the closing `]` is required to parse the structure)
-and then chunks; very large arrays hold the full object in memory once.
-
-`batch_size = 0` is the **no-batching sentinel**: every page contains one
-complete object, with no within-object chunking and no cross-object
-accumulation. Useful for small lookup tables.
-
-For non-zero `batch_size`, lines from multiple objects can share a page
-(cross-object flattening). The S3 source documents the same caveat — this
-is intentional.
-
-> **Memory ceiling — `RawText` / `JsonArray`.** Both hold one whole
-> decoded object in memory at a time (inherent: `RawText`'s record *is*
-> the whole file, and a JSON array isn't valid until its closing `]`).
-> Objects are fetched concurrently, so peak memory is bounded by roughly
-> **`concurrency` × (largest object's decoded size)**, not by
-> `batch_size`. For large `RawText` / `JsonArray` objects, lower
-> `concurrency` to cap peak memory, or re-emit the data as `JsonLines`
-> upstream so it streams at `O(batch_size)`.
-
-## Errors
-
-| Failure | `FaucetError` variant | Message shape |
-|---|---|---|
-| Bad / missing credentials | `Auth` | `"GCS auth: ..."` |
-| List API error | `Source` | `"GCS list error for bucket '{bucket}': {e}"` |
-| Get object API error | `Source` | `"GCS get error for bucket '{bucket}' key '{key}': {e}"` |
-| Body read error | `Source` | `"GCS read body error for key '{key}': {e}"` |
-| Read / decode / non-UTF-8 body (`RawText` / `JsonArray`) | `Source` | `"GCS read/decode error for key '{key}' (not valid UTF-8?): {e}"` |
-| JSON parse error | `Source` | `"GCS JSON parse error in '{key}' at line N: ..."` |
-
-## Running the tests
-
-```bash
-cargo test -p faucet-source-gcs              # unit tests (no network)
-cargo test -p faucet-source-gcs --test integration -- --ignored
+```yaml
+source:
+  type: gcs
+  config:
+    bucket: my-bucket
+    object_keys:
+      - lookups/countries.json
+      - lookups/currencies.json
+    auth:
+      type: service_account_json_file
+      config: { path: /run/secrets/gcp-sa.json }
+    file_format: json_array
+    batch_size: 0      # emit one page per object — ideal for small lookup tables
 ```
 
-Integration tests are marked `#[ignore]` because they require a real
-GCS-compatible **gRPC** backend. The `google-cloud-storage` SDK uses
-gRPC for control-plane operations (listing, metadata), and
-`fake-gcs-server` only speaks the REST API — so `cargo test` against
-the emulator fails with `h2 protocol error / GoAway`. Run the
-`--ignored` suite against a real GCS bucket or a gRPC-capable
-emulator when validating changes.
+### Raw text files, compressed, with a cap
+
+```yaml
+source:
+  type: gcs
+  config:
+    bucket: log-archive
+    prefix: app/2026/06/
+    auth: { type: application_default }
+    file_format: raw_text
+    compression: auto    # requires the `compression` feature; decompresses .gz / .zst objects
+    max_objects: 100     # read at most the first 100 objects
+    concurrency: 4       # raw_text holds a whole object in memory — keep concurrency low
+```
+
+### Date-templated prefix driven by the run clock
+
+```yaml
+source:
+  type: gcs
+  config:
+    bucket: analytics-exports
+    prefix: events/dt=${now.date}/   # resolves to e.g. events/dt=2026-06-16/ at run time
+    auth: { type: application_default }
+    file_format: json_lines
+```
+
+## Streaming & batching
+
+The source overrides `Source::stream_pages`. It lists object keys once, then walks them in order:
+
+- **`json_lines`** decodes the (optionally decompressed) body line-by-line off an async buffered reader, emitting a `StreamPage` every `batch_size` records. Memory stays at `O(batch_size)` no matter how large the file is.
+- **`raw_text`** emits one `{key, content}` record per object, streamed straight into a single `String` (no separate raw + decompressed copies for compressed objects).
+- **`json_array`** buffers each object fully (a JSON array isn't parseable until its closing `]`), then chunks its records into pages.
+
+For a non-zero `batch_size`, records from multiple objects can share a page (cross-object flattening) — the page boundary follows the record count, not the object boundary. This matches the `faucet-source-s3` source and is intentional.
+
+**`batch_size: 0`** is the no-batching sentinel: every page contains exactly one complete object's records, with no within-object chunking and no cross-object accumulation. Useful for small lookup tables or when a downstream sink prefers one large request per object.
+
+> **Memory ceiling — `raw_text` / `json_array`.** Both hold one whole decoded object in memory at a time (inherent: a raw-text record *is* the whole file, and a JSON array isn't valid until its closing `]`). Because objects are fetched concurrently, peak memory is bounded by roughly **`concurrency` × (largest object's decoded size)**, not by `batch_size`. For large `raw_text` / `json_array` objects, lower `concurrency` to cap peak memory, or re-emit the data as `json_lines` upstream so it streams at `O(batch_size)`.
+
+This is a one-shot scan source — it has no incremental bookmark / resume support, so each run re-lists and re-reads the matching objects. For incremental loads, advance the `prefix` between runs (e.g. a dated `events/dt=${now.date}/` prefix) so each run reads only fresh objects.
 
 ## Compression
 
-Behind the crate-local `compression` Cargo feature. Adds a `compression` config
-field with values `none`, `gzip`, `zstd`, or `auto` (the default — detects
-`.gz` / `.zst` from the file path / object key).
-
-YAML example:
+Behind the crate-local `compression` Cargo feature. Adds the `compression` config field with values `none`, `gzip`, `zstd`, or `auto` (the default). `auto` detects `.gz` / `.zst` from the object key; explicit codecs apply to every object.
 
 ```yaml
-kind: gcs
-config:
-  # ... existing fields ...
-  compression: auto  # or 'gzip' | 'zstd' | 'none'
+source:
+  type: gcs
+  config:
+    bucket: log-archive
+    prefix: app/
+    auth: { type: application_default }
+    compression: auto     # or 'gzip' | 'zstd' | 'none'
 ```
 
-The codec resolves per object key, so a single source can read a mix of compressed and uncompressed objects in one run.
+The codec resolves per object key, so a single source can read a mix of compressed and uncompressed objects in one run. A one-shot warning fires when an explicit codec disagrees with the object's filename suffix.
 
-## Out of scope (v1)
+## Config loading & schema
 
-- HMAC-key auth.
-- Signed URL generation.
-- Mid-scan resumable bookmarks (matches `faucet-source-s3` behaviour).
-- KMS CMEK encryption configuration.
-- Server-streaming gRPC reads.
+Config loads from YAML/JSON or environment. Inspect the full JSON Schema with:
+
+```bash
+faucet schema source gcs
+```
+
+## Library usage
+
+```rust
+use faucet_core::Source;
+use faucet_source_gcs::{GcsCredentials, GcsFileFormat, GcsSource, GcsSourceConfig};
+
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let cfg = GcsSourceConfig::new("analytics-exports")
+    .prefix("events/dt=2026-06-16/")
+    .auth(GcsCredentials::ApplicationDefault)
+    .file_format(GcsFileFormat::JsonLines)
+    .concurrency(20)
+    .with_batch_size(5000);
+
+let records = GcsSource::new(cfg).await?.fetch_all().await?;
+println!("records: {}", records.len());
+# Ok(())
+# }
+```
+
+## How it works
+
+1. `new()` resolves `GcsCredentials` and builds both a data-plane `Storage` client and a control-plane `StorageControl` client **once**, reusing them across calls.
+2. Listing uses the control-plane `list_objects` paginator (page size 1000), filtered by `prefix` and capped at `max_objects`. An explicit `object_keys` list skips listing entirely.
+3. Each object's body is opened as an async buffered reader; with the `compression` feature it is wrapped in a per-key decompressor.
+4. Objects are read concurrently via `buffer_unordered(concurrency)` and parsed per `file_format`.
+5. `stream_pages` re-frames the decoded records into `batch_size` pages and yields them to the pipeline, keeping peak memory bounded for the streaming formats.
 
 ## Lineage dataset URI
 
-`gs://<bucket>` or `gs://<bucket>/<prefix>` — e.g. `gs://my-bucket/data/2026/`.
+`gs://<bucket>` or `gs://<bucket>/<prefix>` — e.g. `gs://my-bucket/events/2026/`.
+
+## Feature flags
+
+| Feature | Default | Effect |
+|---------|---------|--------|
+| `compression` | off | Adds the `compression` config field and transparent gzip/zstd decompression (pulls in `faucet-core/compression`). |
+
+Enable the connector itself in the CLI/umbrella via the `source-gcs` feature.
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause & fix |
+|---------|--------------------|
+| `Auth` error / 401 / 403 | Credentials invalid or missing scope. Confirm the service account has **Storage Object Viewer** (`roles/storage.objectViewer`) on the bucket, or that ADC is initialized (`gcloud auth application-default login`). |
+| `GCS list error for bucket '…'` | The bucket name is wrong, doesn't exist, or the principal lacks `storage.objects.list`. Pass the bare bucket name (no `gs://`, no path) and grant the Viewer role. |
+| No objects read / empty output | The `prefix` matched nothing. Prefixes are literal (not globs) and case-sensitive; verify the exact object-name prefix, and remember `prefix` is ignored when `object_keys` is set. |
+| `GCS JSON parse error in '…' at line N` | A line in a `json_lines` object isn't valid JSON. The message pins the object key and 1-based line; fix the source data or switch `file_format`. |
+| `GCS expected JSON array in '…'` | `file_format: json_array` but the object's top-level value isn't an array. Use `json_lines` for newline-delimited data or `raw_text` for opaque blobs. |
+| `not valid UTF-8` | A `raw_text` / `json_array` object has a non-UTF-8 body. These formats require UTF-8; binary objects aren't supported. |
+| Compressed objects come through as garbled text | The `compression` feature isn't enabled, or `compression: none` is set. Build with `--features compression` and leave `compression: auto` (the default) so `.gz` / `.zst` keys are decompressed. |
+| Out-of-memory on large `raw_text` / `json_array` objects | These formats hold a whole object in memory and peak at ~`concurrency × largest-object size`. Lower `concurrency`, cap with `max_objects`, or re-emit the data as `json_lines`. |
+| Each run re-reads everything | This source has no resume bookmark. Advance the `prefix` between runs (e.g. a dated `events/dt=${now.date}/`) so each run reads only new objects. |
+| `h2 protocol error / GoAway` against `fake-gcs-server` | The SDK uses gRPC for control-plane operations; `fake-gcs-server` only speaks REST. Use a real GCS bucket or a gRPC-capable emulator, with `auth: { type: anonymous }` and a `storage_host` override. |
+
+## See also
+
+- [Connector reference](https://pawansikawat.github.io/faucet-stream/reference/connectors.html) — the full source/sink capability matrix.
+- [Authentication cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/auth.html) — shared auth providers and the `{type, config}` shape.
+- [Compression cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/compression.html) — gzip/zstd across file connectors.
+- [`faucet-sink-gcs`](https://crates.io/crates/faucet-sink-gcs) — the matching GCS sink.
+- [`faucet-source-s3`](https://crates.io/crates/faucet-source-s3) — the AWS S3 equivalent with the same format semantics.
+- [`faucet-common-gcs`](https://crates.io/crates/faucet-common-gcs) — the shared credentials enum and client builders.
 
 ## License
 
-Dual-licensed under MIT and Apache-2.0, per the workspace `license` field.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/source/graphql/README.md
+++ b/crates/source/graphql/README.md
@@ -5,91 +5,247 @@
 [![MSRV](https://img.shields.io/crates/msrv/faucet-source-graphql.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
 [![License](https://img.shields.io/crates/l/faucet-source-graphql.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-A config-driven GraphQL API source with cursor-based pagination, JSONPath record extraction, and pluggable authentication. Transient HTTP failures (5xx / connection resets) are retried with exponential backoff.
+Config-driven **GraphQL API** source for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem. Executes a GraphQL query against any endpoint, follows Relay-style cursor pagination, extracts records with a JSONPath expression, and streams them page-by-page into any faucet-stream sink — a file, a database, a warehouse, a queue — with one declarative config and no glue code.
 
-Part of the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
+Reach for it when you want to pull a paginated GraphQL collection (users, repositories, orders, issues…) out of a SaaS API or your own service. Pages are emitted as they arrive, so peak memory stays bounded no matter how many pages the query walks, and transient HTTP failures are retried automatically.
+
+## Feature highlights
+
+- **Native streaming** — overrides `Source::stream_pages`: every upstream GraphQL response is emitted as one `StreamPage` and written to the sink immediately, so a million-row collection never buffers client-side.
+- **Relay cursor pagination** — follows `pageInfo { hasNextPage, endCursor }`, injecting the `endCursor` back into the query's `after:` variable on each request. Stops cleanly when `hasNextPage` is false, the cursor is absent, the same cursor repeats (loop guard), or `max_pages` is reached.
+- **Variable injection** — static `variables` from config, plus per-request cursor / page-size variables, plus parent-record context values (`${parent.path}` matrix fan-out) merged into the GraphQL variables map at runtime.
+- **JSONPath record extraction** — `records_path` plucks the record array out of any response shape (`$.data.users.edges[*].node`). When unset, the whole `data` object is returned as a single record.
+- **Pluggable authentication** — inline Bearer or custom-header auth, or a `{ ref: <name> }` pointer to a shared `auth:` provider so many sources share one token with single-flight refresh.
+- **Automatic retries** — transient HTTP failures (5xx, connection resets) are retried up to 3 times with exponential backoff + jitter (500 ms base).
+- **Client built once** — the `reqwest` client is constructed in `new()` and reused for every request.
 
 ## Installation
 
 ```bash
+# As a library:
 cargo add faucet-source-graphql
-cargo add tokio --features full
+
+# In the CLI (opt-in connector feature):
+cargo install faucet-cli --features source-graphql
 ```
 
-Or via the umbrella crate:
+`source-graphql` is **not** in the CLI default build — enable it explicitly (or use the `full` / `source` aggregate features). Via the umbrella crate: `cargo add faucet-stream --features source-graphql`.
+
+## Quick start
+
+```yaml
+# pipeline.yaml — faucet run pipeline.yaml
+version: 1
+pipeline:
+  source:
+    type: graphql
+    config:
+      endpoint: https://api.example.com/graphql
+      query: |
+        query Users($after: String, $first: Int!) {
+          users(first: $first, after: $after) {
+            edges { node { id name email createdAt } }
+            pageInfo { endCursor hasNextPage }
+          }
+        }
+      auth:
+        type: bearer
+        config:
+          token: ${env:API_TOKEN}
+      records_path: $.data.users.edges[*].node
+      pagination:
+        has_next_page_path: $.data.users.pageInfo.hasNextPage
+        cursor_path: $.data.users.pageInfo.endCursor
+        cursor_variable: after
+        page_size_variable: first
+      batch_size: 100
+  sink:
+    type: jsonl
+    config:
+      path: ./users.jsonl
+```
+
 ```bash
-cargo add faucet-stream --features source-graphql
+faucet run pipeline.yaml
 ```
 
-## Quick Start
+## Configuration reference
 
-```rust
-use faucet_source_graphql::{GraphqlStream, GraphqlStreamConfig};
-
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let config = GraphqlStreamConfig::new(
-        "https://api.example.com/graphql",
-        "query { users { id name email } }",
-    )
-    .records_path("$.data.users[*]");
-
-    let stream = GraphqlStream::new(config);
-    let records = stream.fetch_all().await?;
-
-    for record in &records {
-        println!("{}", record);
-    }
-    Ok(())
-}
-```
-
-## Configuration
-
-### GraphqlStreamConfig
+### Core
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `endpoint` | `String` | *(required)* | GraphQL endpoint URL |
-| `query` | `String` | *(required)* | The GraphQL query string |
-| `variables` | `Value` | `{}` | Variables to pass with the query |
-| `auth` | `GraphqlAuth` | `GraphqlAuth::None` | Authentication method |
-| `headers` | `HeaderMap` | empty | Additional request headers |
-| `records_path` | `Option<String>` | `None` | JSONPath expression to extract records from the response. When `None`, the `data` field of the response is returned as a single record |
-| `pagination` | `Option<GraphqlPagination>` | `None` | Pagination configuration. `None` for single-page queries |
-| `max_pages` | `Option<usize>` | `None` | Maximum number of pages to fetch |
-| `batch_size` | `usize` | `1000` (`DEFAULT_BATCH_SIZE`) | Records per emitted `StreamPage` **and** the value injected as the GraphQL `first:` cursor argument. See *Streaming and batching* below |
+| `endpoint` | string | — *(required)* | GraphQL endpoint URL. |
+| `query` | string | — *(required)* | The GraphQL query string. Declare cursor/page-size variables (`$after`, `$first`) to enable pagination. |
+| `variables` | object | `{}` | Static variables merged into every request. Cursor, page-size, and parent-context values are layered on top per request. |
+| `records_path` | string | *(unset)* | JSONPath plucking the record array out of the response (e.g. `$.data.users.edges[*].node`). When unset, the whole `data` object is emitted as one record. |
+| `auth` | `GraphqlAuth` \| `{ ref }` | `none` | Authentication — inline `{ type, config }` or a shared-provider reference. See [Authentication](#authentication). |
 
-### Authentication (GraphqlAuth)
-
-| Variant | Description |
-|---------|-------------|
-| `None` | No authentication |
-| `Bearer { token }` | Bearer token in the `Authorization` header |
-| `Custom { headers }` | Custom headers map (`HashMap<String, String>`) attached to every request |
-
-### Pagination (GraphqlPagination)
-
-Cursor-based pagination following the Relay specification with `pageInfo { hasNextPage, endCursor }`.
+### Pagination
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `has_next_page_path` | `String` | `"$.data.*.pageInfo.hasNextPage"` | JSONPath to the `hasNextPage` boolean in the response |
-| `cursor_path` | `String` | `"$.data.*.pageInfo.endCursor"` | JSONPath to the `endCursor` string in the response |
-| `cursor_variable` | `String` | `"after"` | Name of the cursor variable in the GraphQL query |
-| `page_size_variable` | `String` | `"first"` | Name of the page-size variable that [`GraphqlStreamConfig::batch_size`](#graphqlstreamconfig) is injected into |
+| `pagination` | `GraphqlPagination` | *(unset)* | Cursor-pagination config. Omit for a single-page query. |
+| `pagination.has_next_page_path` | string | `$.data.*.pageInfo.hasNextPage` | JSONPath to the `hasNextPage` boolean. |
+| `pagination.cursor_path` | string | `$.data.*.pageInfo.endCursor` | JSONPath to the `endCursor` string. |
+| `pagination.cursor_variable` | string | `after` | GraphQL variable the `endCursor` is injected into on the next request. |
+| `pagination.page_size_variable` | string | `first` | GraphQL variable the `batch_size` value is injected into. |
+| `max_pages` | int | *(unbounded)* | Hard cap on pages fetched per run. |
 
-Pagination includes loop detection -- if the same cursor is returned twice in a row, pagination stops.
+### Batching
 
-## Streaming and batching
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `batch_size` | int | `1000` | Records per emitted `StreamPage` **and** the value injected as the page-size variable (`first:`). Max `1_000_000`. **`0` = no batching**: the page-size variable is omitted so the upstream uses its own default page size, and the whole response is emitted as a single page. See [Streaming & batching](#streaming--batching). |
 
-`GraphqlStream` implements `Source::stream_pages`: each upstream GraphQL response is emitted as one [`StreamPage`](https://docs.rs/faucet-core/latest/faucet_core/struct.StreamPage.html), so a pipeline writes to the sink as each page arrives instead of buffering the full result set client-side.
+## Authentication
 
-- `batch_size` (default `1000`, max `1_000_000`) maps directly to the GraphQL `first:` cursor argument (or whatever variable [`page_size_variable`](#pagination-graphqlpagination) names). Each emitted `StreamPage` carries up to `batch_size` records — the upstream is what actually decides how many records to return per request, so a server that caps `first:` will produce smaller pages than requested.
-- **`batch_size = 0` is the "no batching" sentinel**: the page-size variable is omitted from the request entirely so the upstream uses its own default page size, and the whole response is emitted as a single page. Use it for tiny lookup queries, or when the upstream's default page size already matches what the sink wants. **If the upstream schema declares the page-size variable as non-null (`first: Int!`), the server will respond with a GraphQL validation error and the stream will surface a `FaucetError::Config` explaining the contract — pick a non-zero `batch_size` in that case.**
-- Bookmarks are always `None` today — the GraphQL source has no incremental-replication mode yet. The `max_pages` truncation guard is wired structurally so a future incremental mode inherits the same trailing-checkpoint behaviour the REST source uses.
+`auth` accepts either an inline `{ type, config }` block or a `{ ref: <name> }` pointer to a provider in the CLI's top-level `auth:` catalog.
 
-## Config Loading
+| `type` | `config` | Behaviour |
+|--------|----------|-----------|
+| `none` | *(none)* | No authentication (the default). |
+| `bearer` | `{ token: <string> }` | Adds `Authorization: Bearer <token>`. |
+| `custom` | `{ headers: { <name>: <value>, … } }` | Attaches arbitrary headers (API keys, cookies, tenant headers) to every request. |
+
+```yaml
+# Bearer token (resolved from the environment at load time)
+auth:
+  type: bearer
+  config:
+    token: ${env:API_TOKEN}
+```
+
+```yaml
+# Custom headers — API key + tenant
+auth:
+  type: custom
+  config:
+    headers:
+      X-Api-Key: ${env:API_KEY}
+      X-Tenant: acme
+```
+
+```yaml
+# Shared provider from the top-level auth: catalog
+auth: { ref: my_idp }
+```
+
+When an `auth: { ref }` is resolved (or a shared provider is attached via `with_auth_provider`), the provider's credential takes precedence over any inline auth and is shared across every source referencing it, with single-flight token refresh.
+
+## Examples
+
+### GraphQL → PostgreSQL with cursor pagination
+
+```yaml
+version: 1
+name: graphql_to_postgres
+pipeline:
+  source:
+    type: graphql
+    config:
+      endpoint: https://api.example.com/graphql
+      query: |
+        query Users($after: String, $first: Int!) {
+          users(first: $first, after: $after) {
+            edges { node { id name email createdAt } }
+            pageInfo { endCursor hasNextPage }
+          }
+        }
+      variables:
+        first: 100
+      auth:
+        type: bearer
+        config:
+          token: ${env:API_TOKEN}
+      records_path: $.data.users.edges[*].node
+      pagination:
+        has_next_page_path: $.data.users.pageInfo.hasNextPage
+        cursor_path: $.data.users.pageInfo.endCursor
+        cursor_variable: after
+        page_size_variable: first
+      batch_size: 100
+  sink:
+    type: postgres
+    config:
+      connection_url: postgres://user:pass@localhost/app
+      table_name: users_imported
+      column_mapping:
+        type: auto_map
+      batch_size: 1000
+      max_connections: 8
+```
+
+### GraphQL → BigQuery with custom-header auth and a page cap
+
+```yaml
+version: 1
+name: graphql_to_bigquery
+pipeline:
+  source:
+    type: graphql
+    config:
+      endpoint: https://api.example.com/graphql
+      query: |
+        query Orders($after: String, $first: Int!) {
+          orders(first: $first, after: $after) {
+            edges { node { id total status createdAt } }
+            pageInfo { endCursor hasNextPage }
+          }
+        }
+      variables:
+        first: 200
+      auth:
+        type: custom
+        config:
+          headers:
+            X-Api-Key: ${env:API_KEY}
+            X-Tenant: acme
+      records_path: $.data.orders.edges[*].node
+      pagination:
+        has_next_page_path: $.data.orders.pageInfo.hasNextPage
+        cursor_path: $.data.orders.pageInfo.endCursor
+        cursor_variable: after
+        page_size_variable: first
+      max_pages: 500
+      batch_size: 200
+  sink:
+    type: bigquery
+    config:
+      project_id: my-gcp-project
+      dataset_id: raw
+      table_id: orders
+      auth:
+        type: application_default
+      batch_size: 1000
+```
+
+### Single-page query (no pagination)
+
+```yaml
+source:
+  type: graphql
+  config:
+    endpoint: https://api.example.com/graphql
+    query: "query($id: ID!) { user(id: $id) { name email } }"
+    variables:
+      id: user-123
+    records_path: $.data.user
+    # no `pagination:` block → one request, one page
+```
+
+## Streaming & batching
+
+`GraphqlStream` overrides `Source::stream_pages`: each upstream GraphQL response becomes one `StreamPage`, written to the sink as it arrives rather than buffering the entire result set.
+
+- `batch_size` (default `1000`, max `1_000_000`) maps directly to the page-size variable named by `pagination.page_size_variable` (`first:` by default). The upstream ultimately decides how many records to return per request — a server that caps `first:` produces smaller pages than requested.
+- **`batch_size = 0` is the "no batching" sentinel**: the page-size variable is omitted from the request so the upstream uses its own default page size, and the whole response is emitted as a single page. Use it for tiny lookup queries or when the upstream default already matches what the sink wants. **If the upstream schema declares the page-size variable as non-null (`first: Int!`), the server returns a GraphQL validation error and the stream surfaces a `FaucetError::Config` — pick a non-zero `batch_size` in that case.**
+
+This is a one-shot query source — page bookmarks are always `None`, so it has **no incremental-replication / resume support** (each run re-walks the query from page one). For incremental loads, encode a watermark in the query and drive it from a matrix context value or a `${now.*}` token.
+
+## Config loading & schema
+
+Load from YAML/JSON or environment:
 
 ```rust
 use faucet_core::config::{load_json, load_env_file};
@@ -99,127 +255,82 @@ let config: GraphqlStreamConfig = load_json("config.json")?;
 let config: GraphqlStreamConfig = load_env_file(".env", "GRAPHQL")?;
 ```
 
-### Example JSON config
+Inspect the full JSON Schema with:
 
-```json
-{
-  "endpoint": "https://api.github.com/graphql",
-  "query": "query($org: String!, $first: Int!, $after: String) { organization(login: $org) { repositories(first: $first, after: $after) { edges { node { name stargazerCount } } pageInfo { hasNextPage endCursor } } } }",
-  "variables": {
-    "org": "PawanSikawat"
-  },
-  "auth": {
-    "type": "bearer",
-    "config": {
-      "token": "ghp_xxxxxxxxxxxx"
-    }
-  },
-  "records_path": "$.data.organization.repositories.edges[*].node",
-  "pagination": {
-    "has_next_page_path": "$.data.organization.repositories.pageInfo.hasNextPage",
-    "cursor_path": "$.data.organization.repositories.pageInfo.endCursor",
-    "cursor_variable": "after",
-    "page_size_variable": "first"
-  },
-  "max_pages": 10,
-  "batch_size": 50
-}
+```bash
+faucet schema source graphql
 ```
 
-### Example .env file
-
-```env
-GRAPHQL_ENDPOINT=https://api.github.com/graphql
-GRAPHQL_QUERY=query { viewer { login } }
-GRAPHQL_MAX_PAGES=10
-```
-
-## Config Schema Introspection
+## Library usage
 
 ```rust
-use faucet_core::Source;
-
-let stream = GraphqlStream::new(config);
-let schema = stream.config_schema();
-println!("{}", serde_json::to_string_pretty(&schema)?);
-```
-
-## Examples
-
-### Simple single-page query
-
-```rust
-use faucet_source_graphql::{GraphqlStream, GraphqlStreamConfig};
-use faucet_source_graphql::config::GraphqlAuth;
-use serde_json::json;
-
-let config = GraphqlStreamConfig::new(
-    "https://api.example.com/graphql",
-    "query($id: ID!) { user(id: $id) { name email } }",
-)
-.variables(json!({"id": "user-123"}))
-.auth(GraphqlAuth::Bearer {
-    token: "your-token".into(),
-});
-
-let stream = GraphqlStream::new(config);
-let records = stream.fetch_all().await?;
-```
-
-### Relay cursor pagination with record extraction
-
-```rust
+use faucet_core::{Pipeline, Source};
 use faucet_source_graphql::{GraphqlStream, GraphqlStreamConfig};
 use faucet_source_graphql::config::{GraphqlAuth, GraphqlPagination};
-use serde_json::json;
 
+# async fn run(my_sink: Box<dyn faucet_core::Sink>) -> Result<(), Box<dyn std::error::Error>> {
 let config = GraphqlStreamConfig::new(
     "https://api.example.com/graphql",
-    r#"
-    query($first: Int!, $after: String) {
+    r#"query($first: Int!, $after: String) {
         users(first: $first, after: $after) {
-            edges {
-                node { id name email createdAt }
-            }
+            edges { node { id name email } }
             pageInfo { hasNextPage endCursor }
         }
-    }
-    "#,
+    }"#,
 )
-.auth(GraphqlAuth::Bearer {
-    token: "your-token".into(),
-})
+.auth(GraphqlAuth::Bearer { token: "your-token".into() })
 .records_path("$.data.users.edges[*].node")
-.pagination(GraphqlPagination {
-    has_next_page_path: "$.data.users.pageInfo.hasNextPage".into(),
-    cursor_path: "$.data.users.pageInfo.endCursor".into(),
-    cursor_variable: "after".into(),
-    page_size_variable: "first".into(),
-})
+.pagination(GraphqlPagination::default())
 .with_batch_size(100)
 .max_pages(20);
 
-let stream = GraphqlStream::new(config);
-let users = stream.fetch_all().await?;
-println!("Fetched {} users", users.len());
-```
-
-### Using with a Pipeline
-
-```rust
-use faucet_source_graphql::{GraphqlStream, GraphqlStreamConfig};
-use faucet_core::{Pipeline, Source, Sink};
-
 let source = GraphqlStream::new(config);
-let pipeline = Pipeline::new(Box::new(source), Box::new(my_sink));
+let pipeline = Pipeline::new(Box::new(source), my_sink);
 let result = pipeline.run().await?;
 println!("Transferred {} records", result.records_written);
+# Ok(())
+# }
 ```
+
+To share one token across many sources, build a provider and inject it with `GraphqlStream::new(config).with_auth_provider(provider)`.
+
+## How it works
+
+1. `new()` builds the `reqwest::Client` **once** and reuses it for every request.
+2. Each request merges static `variables`, the current cursor (into `cursor_variable`), the page-size value (into `page_size_variable`, unless `batch_size = 0`), and any parent-record context values into the GraphQL variables map.
+3. The POST is retried up to 3 times with exponential backoff + jitter (500 ms base) on retriable HTTP failures.
+4. `records_path` extracts the record array via JSONPath; the page is yielded immediately.
+5. Pagination advances by reading `hasNextPage` / `endCursor`, stopping on a false flag, an absent or repeated cursor (loop guard), or `max_pages`.
 
 ## Lineage dataset URI
 
-`https://<endpoint>` (credentials stripped) — e.g. `https://api.example.com/graphql`.
+`https://<endpoint>` with credentials stripped — e.g. `https://api.example.com/graphql`.
+
+## Feature flags
+
+This crate has no optional features of its own; enable it in the CLI/umbrella via the `source-graphql` feature.
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause & fix |
+|---------|--------------------|
+| `401` / `403` from the endpoint | Missing or invalid auth. Set `auth: { type: bearer, config: { token: … } }` (or `custom` headers), and confirm the token has scope for the queried fields. |
+| Response has `errors` but no `data` | A GraphQL-level error (bad field, unauthorized field, malformed query). The body's `errors[]` carries the reason — fix the query or permissions. |
+| `FaucetError::Config` mentioning a non-null `first:` | You used `batch_size: 0` against a schema that declares `first: Int!`. Set a concrete `batch_size`. |
+| Zero records returned despite a valid response | `records_path` doesn't match the response shape. Verify the JSONPath against the actual `data` envelope (e.g. `$.data.<field>.edges[*].node`). |
+| Pagination fetches only one page | No `pagination:` block, or `has_next_page_path` / `cursor_path` don't resolve. Point them at the real `pageInfo` location in your response. |
+| Pagination never stops / loops | The server returns the same `endCursor` repeatedly — the loop guard stops this automatically; also set `max_pages` as a hard cap. |
+| Run re-fetches everything each time | Expected — this source has no resume/bookmark. Encode a watermark in `query` + `variables` and drive it from a matrix context or `${now.*}` token. |
+| Transient 5xx still fails the run | Retries are capped at 3 attempts. Persistent 5xx indicates a server-side problem; check the upstream's status. |
+
+## See also
+
+- [Pagination guide](https://pawansikawat.github.io/faucet-stream/cookbook/pagination.html) — cursor pagination across connectors.
+- [Authentication guide](https://pawansikawat.github.io/faucet-stream/cookbook/auth.html) — inline auth and the shared `auth:` catalog.
+- [Connector reference](https://pawansikawat.github.io/faucet-stream/reference/connectors.html) — capability matrix.
+- [`faucet-source-rest`](https://crates.io/crates/faucet-source-rest) — the REST sibling source with broader pagination styles.
+- [`faucet-auth`](https://crates.io/crates/faucet-auth) — shared OAuth2 / token-endpoint providers.
 
 ## License
 
-Licensed under MIT or Apache-2.0.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/source/graphql/README.md
+++ b/crates/source/graphql/README.md
@@ -2,6 +2,8 @@
 
 [![Crates.io](https://img.shields.io/crates/v/faucet-source-graphql.svg)](https://crates.io/crates/faucet-source-graphql)
 [![Docs.rs](https://docs.rs/faucet-source-graphql/badge.svg)](https://docs.rs/faucet-source-graphql)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-source-graphql.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-source-graphql.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
 A config-driven GraphQL API source with cursor-based pagination, JSONPath record extraction, and pluggable authentication. Transient HTTP failures (5xx / connection resets) are retried with exponential backoff.
 

--- a/crates/source/grpc/README.md
+++ b/crates/source/grpc/README.md
@@ -5,116 +5,269 @@
 [![MSRV](https://img.shields.io/crates/msrv/faucet-source-grpc.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
 [![License](https://img.shields.io/crates/l/faucet-source-grpc.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-A config-driven gRPC source that uses protobuf reflection to call any gRPC service dynamically and return records as JSON.
+Config-driven **gRPC** source for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem. It calls any gRPC service **dynamically** via protobuf reflection (`prost-reflect`) — no generated client code, no per-service Rust — using a compiled `FileDescriptorSet` to encode the request and decode each response into a typed `serde_json::Value`.
 
-Part of the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
+Reach for it when you need to pull data out of an internal gRPC API — a list/get RPC for a one-shot snapshot, or a server-streaming RPC for a long-lived event/change/log feed — and land it in any faucet-stream sink with one declarative config.
+
+## Feature highlights
+
+- **Dynamic protobuf, zero codegen** — point the source at a `FileDescriptorSet` (`.bin`) produced by `protoc`; it resolves the service/method, maps your JSON `request` onto the protobuf message, and decodes responses back to JSON. No `.proto` compilation into your binary.
+- **Two RPC kinds** — `unary` (one request → one response) and `server_streaming` (one request → a stream of responses). Server-streaming is consumed message-by-message and emitted as records arrive.
+- **Native streaming for server-streaming RPCs** — `stream_pages` flushes a `StreamPage` each time `batch_size` messages accumulate, bounding **both** source-side and sink-side memory for unbounded feeds.
+- **Resilient reconnect** — server-streaming reconnects on transient transport errors with exponential backoff (`reconnect_initial_backoff` → `reconnect_max_backoff`), an optional attempt cap, and replay-prefix skipping so each message is delivered downstream once.
+- **JSONPath record extraction** — `records_path` (e.g. `$.users[*]`) pulls a repeated field out of each response message; unset returns the whole response as a single record.
+- **Three auth modes** — none, bearer token (`authorization` metadata), or arbitrary ordered metadata key/value pairs (duplicate keys allowed). Bearer/metadata auth also resolves from the CLI's shared `auth:` catalog via `auth: { ref: <name> }`.
+- **TLS auto-detection** — inferred from an `https://` endpoint, or forced on/off with `tls`.
+- **Tunable message-size limits** — raise `max_decoding_message_size` / `max_encoding_message_size` above tonic's 4 MiB default for large messages.
+- **Connection reuse** — the tonic channel is built once and reused for the run.
 
 ## Installation
 
 ```bash
+# As a library:
 cargo add faucet-source-grpc
-cargo add tokio --features full
+
+# In the CLI (opt-in connector feature):
+cargo install faucet-cli --features source-grpc
 ```
 
-Or via the umbrella crate:
+Via the umbrella crate:
+
 ```bash
 cargo add faucet-stream --features source-grpc
 ```
 
 ## Prerequisites
 
-This source requires a compiled `FileDescriptorSet` file. Generate it from your `.proto` files using `protoc`:
+This source needs a compiled `FileDescriptorSet` — the binary schema of your protobuf services. Generate it from your `.proto` files with `protoc`:
 
 ```bash
 protoc --descriptor_set_out=descriptor.bin --include_imports \
     -I proto/ proto/my_service.proto
 ```
 
-The descriptor file contains the full schema of your protobuf messages and services, enabling dynamic encoding and decoding without code generation.
+`--include_imports` is required so transitively-imported message types resolve. The descriptor file drives both request encoding and response decoding at runtime.
 
-## Quick Start
+## Quick start
 
-```rust
-use faucet_source_grpc::{GrpcStream, GrpcStreamConfig};
-use serde_json::json;
-
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let config = GrpcStreamConfig::new(
-        "http://localhost:50051",
-        "users.UserService",
-        "ListUsers",
-        "proto/descriptor.bin",
-    )
-    .request(json!({"page_size": 100}))
-    .records_path("$.users[*]");
-
-    let stream = GrpcStream::new(config)?;
-    let records = stream.fetch_all().await?;
-
-    for record in &records {
-        println!("{}", record);
-    }
-    Ok(())
-}
+```yaml
+# pipeline.yaml — faucet run pipeline.yaml
+version: 1
+pipeline:
+  source:
+    type: grpc
+    config:
+      endpoint: http://localhost:50051
+      service_name: users.UserService
+      method_name: ListUsers
+      descriptor_set_path: proto/descriptor.bin
+      request:
+        page_size: 100
+      records_path: $.users[*]
+  sink:
+    type: jsonl
+    config:
+      path: ./users.jsonl
 ```
 
-## Configuration
+```bash
+faucet run pipeline.yaml
+```
 
-### GrpcStreamConfig
+## Configuration reference
+
+### Core
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `endpoint` | `String` | *(required)* | gRPC endpoint URL (e.g. `"http://localhost:50051"`) |
-| `service_name` | `String` | *(required)* | Fully qualified service name (e.g. `"mypackage.MyService"`) |
-| `method_name` | `String` | *(required)* | Method name (e.g. `"ListUsers"`) |
-| `descriptor_set_path` | `PathBuf` | *(required)* | Path to the compiled `FileDescriptorSet` file |
-| `request` | `Value` | `{}` | Request message as JSON. Fields are mapped to protobuf fields using the descriptor |
-| `auth` | `GrpcAuth` | `GrpcAuth::None` | Authentication method |
-| `tls` | `Option<bool>` | `None` | Whether to use TLS. When `None`, auto-detected from `https://` in the endpoint URL |
-| `records_path` | `Option<String>` | `None` | JSONPath to extract records from the response. If not set, the entire response is returned as a single record |
-| `batch_size` | `usize` | `1000` | Records per emitted `StreamPage` for `Source::stream_pages`. `0` is the "no batching" sentinel — the entire result set is emitted in a single page. See [Streaming and batching](#streaming-and-batching) below — for unary RPCs `0` and any positive value behave identically |
-| `rpc_kind` | `RpcKind` | `Unary` | RPC kind: `Unary` (one request → one response) or `ServerStreaming` (one request → stream of responses). See [Server-streaming RPCs](#server-streaming-rpcs) below |
-| `max_messages` | `Option<usize>` | `None` | Server-streaming only. Cap on the number of streamed messages to consume before terminating. `None` means consume until the server closes the stream |
-| `terminate_on_error` | `bool` | `false` | Server-streaming only. If `true`, transient stream errors terminate the run. If `false`, the source reconnects with exponential backoff |
-| `reconnect_initial_backoff` | `Duration` (secs) | `1` | Server-streaming only. Initial backoff before the first reconnect attempt; doubles after each failure up to `reconnect_max_backoff`. Must be `> 0` (a zero backoff would busy-spin reconnects and is rejected at construction) |
-| `reconnect_max_backoff` | `Duration` (secs) | `30` | Server-streaming only. Upper bound on reconnect backoff |
-| `reconnect_max_attempts` | `Option<u32>` | `None` | Server-streaming only. Maximum reconnect attempts before surfacing the error. `None` means unlimited |
-| `reconnect_replay_from_start` | `bool` | `true` | Server-streaming only. Whether the server replays the stream from message 0 when the same request is re-issued on reconnect. `true` (default) skips already-emitted messages so each is delivered once; `false` emits every received message (at-least-once). See [Reconnect on transient errors](#reconnect-on-transient-errors) |
-| `max_decoding_message_size` | `Option<usize>` | `None` | Maximum size in bytes of a single inbound (decoded) message. `None` keeps tonic's built-in 4 MiB limit. Raise for sources that return large messages |
-| `max_encoding_message_size` | `Option<usize>` | `None` | Maximum size in bytes of a single outbound (encoded) request message. `None` keeps tonic's built-in limit |
+| `endpoint` | string | — *(required)* | gRPC endpoint URL (e.g. `http://localhost:50051`, `https://grpc.example.com:443`). |
+| `service_name` | string | — *(required)* | Fully qualified service name (e.g. `users.UserService`). Must exist in the descriptor set. |
+| `method_name` | string | — *(required)* | Method (RPC) name on that service (e.g. `ListUsers`). |
+| `descriptor_set_path` | path | — *(required)* | Path to the compiled `FileDescriptorSet` `.bin` file. |
+| `request` | object | `{}` | Request message as JSON; fields are mapped onto the protobuf request message via the descriptor. Unknown fields fail encoding. |
+| `records_path` | string | *(unset)* | JSONPath extracting records from each response (e.g. `$.users[*]`). When unset, the whole response is returned as a single record. For server-streaming it is applied to **each** message individually. |
+| `tls` | bool | *(auto)* | Force TLS on/off. When unset, auto-detected from an `https://` endpoint. |
 
-### Authentication (GrpcAuth)
+### Auth
 
-| Variant | Fields | Description |
-|---------|--------|-------------|
-| `None` | -- | No authentication |
-| `Bearer { token }` | `String` | Bearer token sent as `authorization` metadata |
-| `Metadata { entries }` | `Vec<MetadataEntry { key, value }>` | Custom metadata pairs attached to the gRPC request — `Vec` preserves order and allows duplicate keys (gRPC permits both) |
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `auth` | `GrpcAuth` / `{ ref }` | `none` | Inline `{ type, config }` (see [Authentication](#authentication)) or `{ ref: <name> }` pointing at a shared provider in the CLI's top-level `auth:` catalog. |
 
-## Streaming and batching
+### RPC kind & server-streaming
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `rpc_kind` | enum | `unary` | `unary` (one request → one response) or `server_streaming` (one request → stream of responses). |
+| `max_messages` | int | *(unset)* | Server-streaming only. Cap on streamed messages to consume before terminating. Unset = consume until the server closes the stream. |
+| `terminate_on_error` | bool | `false` | Server-streaming only. `true` propagates a transient stream error on first failure; `false` reconnects with backoff. |
+| `reconnect_initial_backoff` | int (seconds) | `1` | Server-streaming only. Initial reconnect backoff; doubles each failure up to `reconnect_max_backoff`. Must be `> 0`. |
+| `reconnect_max_backoff` | int (seconds) | `30` | Server-streaming only. Upper bound on reconnect backoff. |
+| `reconnect_max_attempts` | int | *(unset)* | Server-streaming only. Max reconnect attempts before surfacing the error. Unset = unlimited. |
+| `reconnect_replay_from_start` | bool | `true` | Server-streaming only. `true` skips the already-emitted prefix when a stateless server replays from message 0 (exactly-once downstream); `false` emits every received message (at-least-once). See [Reconnect](#reconnect-on-transient-errors). |
+
+### Batching & limits
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `batch_size` | int | `1000` | Records per emitted `StreamPage`. **`0` = no batching** (whole result set in one page). For unary RPCs any value behaves identically (full response is buffered first); for server-streaming it bounds memory. Max `1_000_000`. |
+| `max_decoding_message_size` | int (bytes) | *(tonic 4 MiB)* | Max size of a single inbound (decoded) message. Raise for large responses; a too-low limit surfaces as a decode error. |
+| `max_encoding_message_size` | int (bytes) | *(tonic default)* | Max size of a single outbound (encoded) request message. Rarely needs tuning for a data source. |
+
+## Authentication
+
+`auth` uses the project-wide `{ type, config }` shape (`GrpcAuth`):
+
+| `type` | `config` | Description |
+|--------|----------|-------------|
+| `none` | *(none)* | No authentication (default). |
+| `bearer` | `{ token: <string> }` | Token sent as `authorization` request metadata. |
+| `metadata` | `{ entries: [{ key, value }, …] }` | Arbitrary metadata pairs attached to every request. Order is preserved and duplicate keys are allowed (gRPC permits both). |
+
+```yaml
+# Bearer token (via env indirection)
+auth:
+  type: bearer
+  config:
+    token: ${env:GRPC_TOKEN}
+```
+
+```yaml
+# Custom metadata (e.g. API key + tenant)
+auth:
+  type: metadata
+  config:
+    entries:
+      - { key: x-api-key, value: ${env:API_KEY} }
+      - { key: x-tenant-id, value: tenant-123 }
+```
+
+```yaml
+# Shared provider from the top-level auth: catalog
+auth:
+  ref: my_idp
+```
+
+## Examples
+
+### Authenticated unary list with TLS and record extraction
+
+```yaml
+source:
+  type: grpc
+  config:
+    endpoint: https://grpc.production.example.com:443
+    service_name: analytics.EventService
+    method_name: QueryEvents
+    descriptor_set_path: proto/descriptor.bin
+    request:
+      start_time: "2026-01-01T00:00:00Z"
+      end_time: "2026-02-01T00:00:00Z"
+      limit: 1000
+    auth:
+      type: bearer
+      config: { token: ${env:GRPC_TOKEN} }
+    tls: true
+    records_path: $.events[*]
+```
+
+### gRPC → HTTP (matches `cli/examples/grpc_to_http.yaml`)
+
+```yaml
+version: 1
+name: grpc_to_http
+pipeline:
+  source:
+    type: grpc
+    config:
+      endpoint: https://grpc.example.com:443
+      service_name: metrics.MetricsService
+      method_name: ListMetrics
+      descriptor_set_path: proto/metrics.bin
+      request: { window: 1h }
+      auth:
+        type: bearer
+        config: { token: ${env:GRPC_TOKEN} }
+      tls: true
+      records_path: $.metrics[*]
+  sink:
+    type: http
+    config:
+      url: https://ingest.example.com/v1/events?tenant=acme
+      method: POST
+      auth:
+        type: bearer
+        config: { token: ${env:INGEST_TOKEN} }
+      batch_mode: { type: Array }
+      max_retries: 3
+      concurrency: 8
+```
+
+### Server-streaming event feed with reconnect
+
+```yaml
+source:
+  type: grpc
+  config:
+    endpoint: https://grpc.example.com:443
+    service_name: events.EventService
+    method_name: Tail
+    descriptor_set_path: proto/descriptor.bin
+    request: { topic: audit-log }
+    auth:
+      type: bearer
+      config: { token: ${env:GRPC_TOKEN} }
+    tls: true
+    rpc_kind: server_streaming
+    max_messages: 100000
+    batch_size: 500
+    reconnect_initial_backoff: 1
+    reconnect_max_backoff: 30
+    reconnect_replay_from_start: true
+    max_decoding_message_size: 16777216   # 16 MiB
+```
+
+### Custom-metadata auth, large messages
+
+```yaml
+source:
+  type: grpc
+  config:
+    endpoint: http://localhost:50051
+    service_name: inventory.InventoryService
+    method_name: ListProducts
+    descriptor_set_path: proto/descriptor.bin
+    request: { category: electronics, page_size: 100 }
+    auth:
+      type: metadata
+      config:
+        entries:
+          - { key: x-api-key, value: ${env:API_KEY} }
+    records_path: $.products[*]
+    max_decoding_message_size: 33554432   # 32 MiB
+```
+
+## Streaming & batching
 
 ### Unary RPCs
 
-Unary gRPC returns one response containing all records; `stream_pages` falls back to the default trait impl, which buffers the full response and then chunks it in memory into `batch_size` pages. This bounds **sink-side** memory only — source-side memory is still O(full response).
-
-`batch_size = 0` and any positive `batch_size` are observably identical for unary gRPC — both buffer the full result before yielding, since the unary RPC has no native paging primitive the source could honour. Treat the field as a sink-side chunk size, not a wire-protocol hint.
+A unary RPC returns one response containing all records. `stream_pages` falls back to the default trait impl, which buffers the full response and chunks it in memory into `batch_size` pages. This bounds **sink-side** memory only — source-side memory is `O(full response)`. `batch_size = 0` and any positive value are observably identical here, since there is no native wire paging primitive to honour. Treat `batch_size` as a sink-side chunk size for unary.
 
 ### Server-streaming RPCs
 
-When `rpc_kind = "server_streaming"`, the source calls `tonic::client::Grpc::server_streaming` and consumes the response stream message-by-message. Each streamed `DynamicMessage` is decoded via `prost-reflect` and converted to JSON; if `records_path` is set it is applied to each message individually (so `$.events[*]` flattens an array nested inside each message into the page record set).
-
-`stream_pages` flushes a page each time the buffer accumulates `batch_size` records, bounding both **source-side and sink-side** memory. `batch_size = 0` drains the entire stream into a single page (useful for short streams or sinks that prefer one large write). Pages carry `bookmark: None` — server-streaming has no native cursor, so resumption is driven by user-supplied request fields (e.g. an event id), not a faucet-managed bookmark.
+When `rpc_kind: server_streaming`, the source calls `tonic::client::Grpc::server_streaming` and consumes the response stream message-by-message. Each streamed `DynamicMessage` is decoded via `prost-reflect`, converted to JSON, and (if `records_path` is set) flattened per message. `stream_pages` flushes a page every `batch_size` records, bounding **both** source-side and sink-side memory — the right mode for unbounded feeds. `batch_size = 0` drains the whole stream into a single page (good for short streams). Pages carry `bookmark: None`.
 
 #### Reconnect on transient errors
 
-By default, transient stream errors (server disconnects, transport failures, etc.) trigger a reconnect with exponential backoff starting at `reconnect_initial_backoff`, doubling each attempt up to `reconnect_max_backoff`. After `reconnect_max_attempts` (when set), the error is surfaced. Set `terminate_on_error = true` to skip the reconnect path entirely and propagate the error on first failure.
+By default, transient stream errors (server disconnects, transport failures) trigger a reconnect with exponential backoff from `reconnect_initial_backoff`, doubling up to `reconnect_max_backoff`; after `reconnect_max_attempts` (when set) the error is surfaced. Set `terminate_on_error: true` to propagate on first failure instead.
 
-Reconnect re-sends the *same* request from scratch (the request is resolved once per run), so a stateless server begins emitting from the start of the stream again. By default (`reconnect_replay_from_start = true`) the source tracks how many messages it has already emitted and **skips that replayed prefix** on the reconnected attempt, so each message is delivered downstream exactly once.
+Reconnect re-sends the *same* request (resolved once per run), so a stateless server re-streams from message 0. With `reconnect_replay_from_start: true` (default) the source tracks how many messages it already emitted and **skips that replayed prefix**, delivering each message once. Set it `false` only for servers that resume mid-stream on an identical request (rare — most resumable feeds need a resume token *in the request*, e.g. an `after_event_id` field you maintain): there, every received message is emitted (at-least-once), so duplicates are possible on replay.
 
-Set `reconnect_replay_from_start = false` only for servers that resume mid-stream on an identical request (rare — most resumable feeds require a resume token *in the request*, e.g. an `after_event_id` field the user maintains). With it `false`, every received message is emitted (at-least-once), so a replayed prefix produces duplicates downstream; conversely, leaving it `true` against a genuinely-resuming server would skip legitimate new messages. Match the setting to the server's replay semantics.
+> **Resume/state:** this source has no faucet-managed bookmark or `state:` resume. For a resumable feed, drive the cursor through the `request` (e.g. an `after_event_id` your config advances), not via a faucet state store.
 
-## Config Loading
+## Config loading & schema introspection
+
+Load config from YAML/JSON, environment, or a `.env` file:
 
 ```rust
 use faucet_core::config::{load_json, load_env_file};
@@ -124,56 +277,6 @@ let config: GrpcStreamConfig = load_json("config.json")?;
 let config: GrpcStreamConfig = load_env_file(".env", "GRPC")?;
 ```
 
-### Example JSON config (unary)
-
-```json
-{
-  "endpoint": "https://grpc.example.com:443",
-  "service_name": "inventory.InventoryService",
-  "method_name": "ListProducts",
-  "descriptor_set_path": "proto/descriptor.bin",
-  "request": {
-    "category": "electronics",
-    "page_size": 100
-  },
-  "auth": {
-    "type": "bearer",
-    "config": {
-      "token": "your-api-token"
-    }
-  },
-  "tls": true,
-  "records_path": "$.products[*]",
-  "batch_size": 1000
-}
-```
-
-### Example JSON config (server-streaming)
-
-```json
-{
-  "endpoint": "https://grpc.example.com:443",
-  "service_name": "events.EventService",
-  "method_name": "Tail",
-  "descriptor_set_path": "proto/descriptor.bin",
-  "request": { "topic": "audit-log" },
-  "auth": { "type": "bearer", "config": { "token": "your-api-token" } },
-  "tls": true,
-  "records_path": null,
-  "rpc_kind": "server_streaming",
-  "max_messages": 100000,
-  "terminate_on_error": false,
-  "reconnect_initial_backoff": 1,
-  "reconnect_max_backoff": 30,
-  "reconnect_max_attempts": null,
-  "reconnect_replay_from_start": true,
-  "max_decoding_message_size": 16777216,
-  "batch_size": 500
-}
-```
-
-### Example .env file
-
 ```env
 GRPC_ENDPOINT=http://localhost:50051
 GRPC_SERVICE_NAME=users.UserService
@@ -181,71 +284,45 @@ GRPC_METHOD_NAME=ListUsers
 GRPC_DESCRIPTOR_SET_PATH=proto/descriptor.bin
 ```
 
-## Config Schema Introspection
+Inspect the full JSON Schema with:
 
-```rust
-use faucet_core::Source;
-
-let stream = GrpcStream::new(config)?;
-let schema = stream.config_schema();
-println!("{}", serde_json::to_string_pretty(&schema)?);
+```bash
+faucet schema source grpc
 ```
 
-## Examples
-
-### Basic unary RPC call
+## Library usage
 
 ```rust
-use faucet_source_grpc::{GrpcStream, GrpcStreamConfig};
-use serde_json::json;
-
-let config = GrpcStreamConfig::new(
-    "http://localhost:50051",
-    "orders.OrderService",
-    "GetOrder",
-    "proto/descriptor.bin",
-)
-.request(json!({"order_id": "ord-12345"}));
-
-let stream = GrpcStream::new(config)?;
-let records = stream.fetch_all().await?;
-// Returns the full response as a single JSON record
-```
-
-### Authenticated gRPC with TLS and record extraction
-
-```rust
-use faucet_source_grpc::{GrpcStream, GrpcStreamConfig, GrpcAuth};
-use serde_json::json;
-
-let config = GrpcStreamConfig::new(
-    "https://grpc.production.example.com",
-    "analytics.EventService",
-    "QueryEvents",
-    "proto/descriptor.bin",
-)
-.request(json!({
-    "start_time": "2025-01-01T00:00:00Z",
-    "end_time": "2025-02-01T00:00:00Z",
-    "limit": 1000
-}))
-.auth(GrpcAuth::Bearer {
-    token: "your-bearer-token".into(),
-})
-.tls(true)
-.records_path("$.events[*]");
-
-let stream = GrpcStream::new(config)?;
-let events = stream.fetch_all().await?;
-println!("Fetched {} events", events.len());
-```
-
-### Server-streaming RPC
-
-```rust
+use faucet_core::{Pipeline, Source};
 use faucet_source_grpc::{GrpcStream, GrpcStreamConfig, RpcKind};
 use serde_json::json;
 
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let config = GrpcStreamConfig::new(
+    "http://localhost:50051",
+    "users.UserService",
+    "ListUsers",
+    "proto/descriptor.bin",
+)
+.request(json!({ "page_size": 100 }))
+.records_path("$.users[*]");
+
+// One-shot collect:
+let stream = GrpcStream::new(config)?;
+let records = stream.fetch_all().await?;
+println!("fetched {} records", records.len());
+# Ok(())
+# }
+```
+
+For a long-lived server-streaming feed, drive the pipeline so pages flush to the sink as they arrive instead of buffering everything:
+
+```rust
+use faucet_core::Pipeline;
+use faucet_source_grpc::{GrpcStream, GrpcStreamConfig, RpcKind};
+use serde_json::json;
+
+# async fn run(my_sink: impl faucet_core::Sink) -> Result<(), Box<dyn std::error::Error>> {
 let config = GrpcStreamConfig::new(
     "http://localhost:50051",
     "events.EventService",
@@ -254,50 +331,52 @@ let config = GrpcStreamConfig::new(
 )
 .request(json!({ "topic": "audit-log" }))
 .rpc_kind(RpcKind::ServerStreaming)
-.max_messages(10_000)
 .with_batch_size(500);
 
 let stream = GrpcStream::new(config)?;
-let events = stream.fetch_all().await?;
-println!("Collected {} events", events.len());
+Pipeline::new(&stream, &my_sink).run().await?;
+# Ok(())
+# }
 ```
 
-For long-lived streams, drive the pipeline directly so pages flush to the
-sink as they arrive instead of buffering everything in memory:
+## How it works
 
-```rust
-use faucet_core::Pipeline;
-
-let pipeline = Pipeline::new(&stream, &my_sink);
-pipeline.run().await?;
-```
-
-### Custom metadata authentication
-
-```rust
-use faucet_source_grpc::{GrpcAuth, GrpcStream, GrpcStreamConfig, MetadataEntry};
-
-let config = GrpcStreamConfig::new(
-    "http://localhost:50051",
-    "mypackage.MyService",
-    "ListItems",
-    "proto/descriptor.bin",
-)
-.auth(GrpcAuth::Metadata {
-    entries: vec![
-        MetadataEntry { key: "x-api-key".into(), value: "my-secret-key".into() },
-        MetadataEntry { key: "x-tenant-id".into(), value: "tenant-123".into() },
-    ],
-});
-
-let stream = GrpcStream::new(config)?;
-let items = stream.fetch_all().await?;
-```
+1. `new()` loads and parses the `FileDescriptorSet`, resolves the service/method, and builds the tonic channel **once** (TLS auto-detected from the scheme unless `tls` overrides it).
+2. The JSON `request` is mapped onto the protobuf request message via reflection; any configured `max_encoding_message_size` is applied.
+3. **Unary:** a single response is decoded to JSON; `records_path` (if set) extracts records, otherwise the whole response is one record.
+4. **Server-streaming:** the response stream is consumed message-by-message; each `DynamicMessage` is decoded, JSON-converted, and `records_path`-flattened, with reconnect/backoff and replay-prefix skipping wrapping the consume loop.
+5. Records are framed into `batch_size` pages and streamed to the pipeline; `max_decoding_message_size` bounds each inbound message.
 
 ## Lineage dataset URI
 
-`<endpoint>/<service_name>/<method_name>` (credentials stripped) — e.g. `http://grpc.example.com:50051/example.Service/ListItems`.
+`<endpoint>/<service_name>/<method_name>` with credentials stripped — e.g. `http://grpc.example.com:50051/example.Service/ListItems`.
+
+## Feature flags
+
+This crate has no optional features of its own. Enable it in the CLI/umbrella via the `source-grpc` feature.
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause & fix |
+|---------|--------------------|
+| Service or method not found | `service_name` / `method_name` don't match the descriptor. Use the **fully qualified** service name (`package.Service`) exactly as in the `.proto`, and confirm the method exists. |
+| Descriptor fails to load | Regenerate with `--include_imports` so transitively-imported types resolve; pass the correct `descriptor_set_path`. |
+| Request field rejected during encoding | A `request` key isn't a field of the protobuf request message. Match field names (proto field names, not JSON aliases) against the descriptor. |
+| TLS handshake fails / plaintext on a TLS endpoint | Set `tls` explicitly. An `http://` endpoint defaults to plaintext, `https://` to TLS; override when the scheme and the server disagree. |
+| `Unauthenticated` / 401-equivalent | Wrong or missing credentials. For `bearer`, the token is sent as `authorization` metadata; for `metadata`, confirm the server expects those exact keys. |
+| Decode error on a large response | The message exceeds tonic's 4 MiB inbound limit. Raise `max_decoding_message_size`. |
+| `records_path` returns nothing | The JSONPath doesn't match the decoded response shape. Drop `records_path` to inspect the raw response, then target the actual array field (e.g. `$.users[*]`). |
+| Server-streaming run never ends | Expected for an open-ended feed. Bound it with `max_messages`, or cancel the run (the page loop stops at the next boundary). |
+| Reconnect busy-spins / errors immediately | `reconnect_initial_backoff` must be `> 0`. For non-transient failures set `terminate_on_error: true` to fail fast. |
+| Duplicate or missing messages after a reconnect | Match `reconnect_replay_from_start` to the server: `true` for a stateless server that replays from 0, `false` for one that resumes mid-stream on the same request. |
+
+## See also
+
+- [Choosing a connector](https://pawansikawat.github.io/faucet-stream/reference/choosing.html)
+- [Connector capability matrix](https://pawansikawat.github.io/faucet-stream/reference/connectors.html)
+- [Authentication cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/auth.html)
+- [`faucet-sink-http`](https://crates.io/crates/faucet-sink-http) · [`faucet-source-rest`](https://crates.io/crates/faucet-source-rest) · [`faucet-source-graphql`](https://crates.io/crates/faucet-source-graphql)
 
 ## License
 
-Licensed under MIT or Apache-2.0.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/source/grpc/README.md
+++ b/crates/source/grpc/README.md
@@ -2,6 +2,8 @@
 
 [![Crates.io](https://img.shields.io/crates/v/faucet-source-grpc.svg)](https://crates.io/crates/faucet-source-grpc)
 [![Docs.rs](https://docs.rs/faucet-source-grpc/badge.svg)](https://docs.rs/faucet-source-grpc)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-source-grpc.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-source-grpc.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
 A config-driven gRPC source that uses protobuf reflection to call any gRPC service dynamically and return records as JSON.
 

--- a/crates/source/kafka/README.md
+++ b/crates/source/kafka/README.md
@@ -1,35 +1,61 @@
 # faucet-source-kafka
 
-Apache Kafka consumer source for `faucet-stream`. Subscribes to one or more topics, drains messages until a `max_messages` count or `idle_timeout` is reached, and emits each Kafka message as a structured JSON record. Built on [`rdkafka`](https://crates.io/crates/rdkafka) (librdkafka bindings). Supports durable offset tracking via any `faucet-core` `StateStore` so pipelines can resume exactly where they left off.
+[![Crates.io](https://img.shields.io/crates/v/faucet-source-kafka.svg)](https://crates.io/crates/faucet-source-kafka)
+[![Docs.rs](https://docs.rs/faucet-source-kafka/badge.svg)](https://docs.rs/faucet-source-kafka)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-source-kafka.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-source-kafka.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
----
+Apache **Kafka** consumer source for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem. Subscribes to one or more topics, drains messages until a `max_messages` count or an `idle_timeout` window fires, and emits each Kafka message as a structured JSON record. Built on [`rdkafka`](https://crates.io/crates/rdkafka) (librdkafka bindings) — one of the fastest Kafka clients available.
+
+Reach for it when you want to land a Kafka topic into any faucet-stream sink — a file, a database, a warehouse, object storage — with one declarative config, durable offset resume, and no glue code. Offsets are tracked through any `faucet-core` `StateStore`, so a pipeline resumes exactly where the last run stopped, without re-reading or skipping records.
+
+## Feature highlights
+
+- **Native streaming** — overrides `Source::stream_pages`, draining the consumer into `batch_size`-sized pages so memory stays `O(batch_size)` no matter the topic volume; the sink writes (and the bookmark advances) incrementally rather than once at the end of the run.
+- **Durable offset resume** — persists a per-partition offset bookmark through any `StateStore` (file, memory, Redis, Postgres). On restart the bookmark seeds the partition assignment *before* the first poll, so a resume never produces a duplicate or skips a record.
+- **Two stop conditions** — `max_messages` and/or `idle_timeout`; the loop exits on whichever fires first (at least one is required). `Ctrl+C` exits cleanly, persisting everything consumed so far.
+- **Five authentication modes** — plaintext, SASL/PLAIN, SASL/SCRAM (SHA-256 / SHA-512), SSL client certificates, and SASL+SSL — via the shared `KafkaAuth` enum from [`faucet-common-kafka`](https://crates.io/crates/faucet-common-kafka).
+- **Six value formats** — JSON, raw string, raw bytes (base64), plus Confluent Avro / Protobuf / JSON Schema behind the `schema-registry` feature.
+- **Structured records** — each message becomes a JSON object with `key`, `value`, `topic`, `partition`, `offset`, `timestamp`, and `headers`.
+- **Per-message decode policy** — `on_decode_error: fail | skip` chooses between aborting the batch and dropping a bad message with a warning.
+- **Escape hatch** — `extra_client_config` passes any raw librdkafka property straight through to the consumer.
+
+## Installation
+
+```bash
+# As a library:
+cargo add faucet-source-kafka
+
+# With Confluent Schema Registry support:
+cargo add faucet-source-kafka --features schema-registry
+
+# In the CLI (opt-in connector feature):
+cargo install faucet-cli --features source-kafka
+```
+
+The Kafka source is **not** in the CLI default build — enable `source-kafka` (or `full`). Schema-Registry-backed formats additionally require `kafka-schema-registry` on the CLI / umbrella.
 
 ## Quick start
 
 ```yaml
-# pipeline.yaml
+# pipeline.yaml — faucet run pipeline.yaml
 version: 1
-
-source:
-  kind: kafka
-  config:
-    brokers: "broker1:9092,broker2:9092"
-    topics:
-      - orders
-    group_id: faucet-orders-consumer
-    value_format:
-      type: json
-    auto_offset_reset: earliest
-    idle_timeout: 30      # stop after 30 s of no new messages
-    max_messages: 10000   # or stop after 10 000 messages, whichever comes first
-
-sink:
-  kind: jsonl
-  config:
-    path: orders.jsonl
+pipeline:
+  source:
+    type: kafka
+    config:
+      brokers: "localhost:9092"
+      topics: ["orders"]
+      group_id: faucet-orders-consumer
+      value_format: { type: json }
+      auto_offset_reset: earliest
+      idle_timeout: 30      # stop after 30 s of no new messages
+      max_messages: 10000   # or after 10 000 messages, whichever comes first
+  sink:
+    type: jsonl
+    config:
+      path: ./orders.jsonl
 ```
-
-Run it:
 
 ```bash
 faucet run pipeline.yaml
@@ -38,40 +64,121 @@ faucet run pipeline.yaml
 To resume from where the last run stopped, add a state store:
 
 ```yaml
-state:
-  kind: file
-  config:
-    directory: .faucet-state
+  state:
+    type: file
+    config:
+      path: ./.faucet-state
 ```
 
----
+## Configuration reference
 
-## Full config reference
+All fields are keys under `source.config`.
 
-All fields are top-level keys under `source.config` in the pipeline YAML.
+### Core
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `brokers` | `string` | **required** | Comma-separated list of bootstrap broker addresses, e.g. `"broker1:9092,broker2:9092"`. |
-| `topics` | `string[]` | **required** | One or more topic names to subscribe to. |
-| `group_id` | `string` | **required** | Kafka consumer group ID. Used for partition assignment and is part of the state-store key. |
-| `auth` | `KafkaAuth` | `{type: none}` | Authentication mode. See [Auth](#auth) below. Full details in the `faucet-common-kafka` README. |
-| `value_format` | `KafkaValueFormat` | `{type: json}` | How message value bytes are decoded. See [Value formats](#value-formats). |
-| `key_format` | `KafkaValueFormat \| null` | `null` | How message key bytes are decoded. When absent or `null`, key bytes are decoded as UTF-8 (or `null` if no key was set on the message). |
-| `auto_offset_reset` | `"earliest" \| "latest"` | `"latest"` | Where to start consuming a partition that has **no** bookmarked offset. On a resume, every partition assigned in a prior run carries a bookmarked offset (see [Resume and state store](#resume-and-state-store)), so this only governs first-ever encounters — a fresh run or a newly-added partition. |
-| `max_messages` | `integer \| null` | `null` | Stop after this many messages have been consumed. At least one of `max_messages` and `idle_timeout` must be set. |
-| `idle_timeout` | `integer \| null` | `null` | Stop after this many **seconds** with no new messages. At least one of `max_messages` and `idle_timeout` must be set. |
-| `poll_timeout` | `integer` | `1` | Maximum seconds to wait on a single `consumer.recv()` call before checking termination conditions. Rarely needs tuning. |
-| `session_timeout` | `integer` | `30` | Kafka `session.timeout.ms` in **seconds**. Increase for slow brokers or long GC pauses. |
-| `on_decode_error` | `"fail" \| "skip"` | `"fail"` | What to do when a single message fails to decode. `fail` aborts the batch; `skip` drops the message and logs a warning. |
-| `extra_client_config` | `object` | `{}` | Raw librdkafka client properties passed directly to the consumer. These can override anything set by `auth` or the typed fields above — use with care. |
-| `batch_size` | `integer` | `1000` | Messages per emitted `StreamPage` when the source is driven through `Source::stream_pages` (i.e. `Pipeline::run` / `run_stream`). See [Streaming and batching](#streaming-and-batching) below. |
+| `brokers` | string | — *(required)* | Comma-separated bootstrap broker list, e.g. `"broker1:9092,broker2:9092"`. |
+| `topics` | string[] | — *(required)* | One or more topic names to subscribe to. Must contain at least one entry. |
+| `group_id` | string | — *(required)* | Kafka consumer group ID. Drives partition assignment and forms part of the state-store key. |
+| `auth` | `KafkaAuth` | `{ type: none }` | Authentication mode — see [Authentication](#authentication). |
+| `value_format` | `KafkaValueFormat` | `{ type: json }` | How message **value** bytes are decoded — see [Value formats](#value-formats). |
+| `key_format` | `KafkaValueFormat` \| null | `null` | How message **key** bytes are decoded. When unset, key bytes are decoded as UTF-8 (or `null` if the message carried no key). |
 
----
+### Termination & polling
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `max_messages` | int \| null | `null` | Stop after this many messages. At least one of `max_messages` / `idle_timeout` is required. |
+| `idle_timeout` | int (seconds) \| null | `null` | Stop after this many seconds with no new message. At least one of `max_messages` / `idle_timeout` is required. |
+| `poll_timeout` | int (seconds) | `1` | Max time to block on a single `consumer.recv()` before re-checking termination. Advisory — rarely needs tuning. |
+| `session_timeout` | int (seconds) | `30` | Kafka `session.timeout.ms` (in seconds). Increase for slow brokers or long GC pauses. |
+
+### Offsets & reliability
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `auto_offset_reset` | `earliest` \| `latest` | `latest` | Where to start a partition that has **no** bookmarked offset — i.e. a first-ever run or a newly-added partition. Resumed partitions always start from their bookmark. |
+| `on_decode_error` | `fail` \| `skip` | `fail` | What to do when one message fails to decode. `fail` aborts the batch; `skip` drops the message and logs a `WARN`. |
+| `extra_client_config` | object | `{}` | Raw librdkafka client properties passed straight to the consumer. These can override anything set by `auth` or the typed fields above — use with care. |
+
+### Batching
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `batch_size` | int | `1000` | Messages per emitted `StreamPage`. **`0` = drain the entire run window** into one page (tests / one-shot drains only — see [Streaming & batching](#streaming--batching)). Capped at `MAX_BATCH_SIZE` (1,000,000). |
+
+## Authentication
+
+`auth` uses the shared `KafkaAuth` enum (the project-wide `{ type, config }` shape). The full reference — all fields and edge cases — lives in the [`faucet-common-kafka`](https://crates.io/crates/faucet-common-kafka) README.
+
+| `type` | `config` | Use when |
+|--------|----------|----------|
+| `none` | *(none)* | Plaintext brokers (default). |
+| `sasl_plain` | `{ username, password }` | Confluent Cloud, MSK with SASL/PLAIN. |
+| `sasl_scram` | `{ mechanism: sha256\|sha512, username, password }` | Brokers configured for SCRAM. |
+| `ssl` | `{ ca_path, cert_path, key_path, key_password? }` | Mutual-TLS client certificates. |
+| `sasl_ssl` | `{ sasl: {…}, ssl: {…} }` | SASL over a TLS transport. |
+
+```yaml
+# SASL/PLAIN — env indirection keeps secrets out of the YAML
+auth:
+  type: sasl_plain
+  config:
+    username: ${env:KAFKA_USERNAME}
+    password: ${env:KAFKA_PASSWORD}
+```
+
+```yaml
+# SASL/SCRAM-SHA-512
+auth:
+  type: sasl_scram
+  config:
+    mechanism: sha512
+    username: ${env:KAFKA_USERNAME}
+    password: ${env:KAFKA_PASSWORD}
+```
+
+```yaml
+# Mutual TLS
+auth:
+  type: ssl
+  config:
+    ca_path: /etc/kafka/certs/ca.pem
+    cert_path: /etc/kafka/certs/client.pem
+    key_path: /etc/kafka/certs/client.key
+```
+
+## Value formats
+
+Configured via `value_format` (and optionally `key_format`); all use a `type` discriminator.
+
+| `type` | Description | Feature |
+|--------|-------------|---------|
+| `json` | Parse value bytes as a JSON document. **Default.** | base |
+| `raw_string` | Decode value bytes as a UTF-8 string into `value`. | base |
+| `bytes` | Pass bytes through as a **base64-encoded string** in `value`; no parsing. | base |
+| `confluent_avro` | Confluent wire-format Avro: `[0x00][schema_id 4B][Avro binary]`. | `schema-registry` |
+| `confluent_protobuf` | Confluent wire-format Protobuf. v1 returns an error — descriptor support tracked in [#44](https://github.com/PawanSikawat/faucet-stream/issues/44). | `schema-registry` |
+| `confluent_json_schema` | Confluent wire-format JSON: `[0x00][schema_id 4B][JSON bytes]`; optional validation. | `schema-registry` |
+
+The three Confluent formats take a `schema_registry` block (URL, optional basic auth, cache capacity, request timeout) — see the [`faucet-common-kafka`](https://crates.io/crates/faucet-common-kafka) README for the full `SchemaRegistryConfig`.
+
+```yaml
+value_format:
+  type: confluent_avro
+  schema_registry:
+    url: http://localhost:8081
+    auth:                  # optional basic auth (flat username/password)
+      username: ${env:SR_USERNAME}
+      password: ${env:SR_PASSWORD}
+    cache_capacity: 1024   # default 1024
+    request_timeout: 10    # seconds, default 10
+```
 
 ## Record shape
 
-Each Kafka message becomes one JSON object in the output stream:
+Each Kafka message becomes one JSON object:
 
 ```json
 {
@@ -81,78 +188,115 @@ Each Kafka message becomes one JSON object in the output stream:
   "partition": 2,
   "offset": 10483,
   "timestamp": 1747483200000,
-  "headers": {
-    "content-type": "application/json",
-    "trace-id": "abc123"
-  }
+  "headers": { "content-type": "application/json", "trace-id": "abc123" }
 }
 ```
 
-**Field notes:**
+- `key` — the key decoded as UTF-8, or per `key_format` if set. `null` when the message carried no key.
+- `value` — the decoded payload; shape depends on `value_format`.
+- `topic` / `partition` / `offset` — provenance for the message within its partition.
+- `timestamp` — milliseconds since the Unix epoch; `0` when the message had no timestamp.
+- `headers` — a flat string→string object; non-UTF-8 values are base64-encoded; `{}` when none were set.
 
-- `key` — the message key decoded as UTF-8, or decoded according to `key_format` if set. `null` when the Kafka message carried no key.
-- `value` — the decoded message payload. Shape depends on `value_format` (see below).
-- `topic` — the topic name the message was consumed from.
-- `partition` — the partition number (integer).
-- `offset` — the offset of this message within its partition.
-- `timestamp` — milliseconds since the Unix epoch, from the Kafka message timestamp. `0` when no timestamp is present in the message.
-- `headers` — a flat object of string key → string value. Values that are not valid UTF-8 are base64-encoded. Empty object `{}` when no headers were set on the message.
+## Examples
 
----
-
-## Value formats
-
-Configured via `value_format` (and optionally `key_format`). All formats use a `type` discriminator field.
-
-| Format | `type` | Description |
-|--------|--------|-------------|
-| JSON | `json` | Parse value bytes as a JSON document. Default. |
-| Raw string | `raw_string` | Treat value bytes as a UTF-8 string. The string becomes the `value` field. |
-| Bytes | `bytes` | Pass bytes through as a **base64-encoded string** inside `value`. No parsing is attempted. |
-| Confluent Avro | `confluent_avro` | Confluent wire-format Avro: `[0x00][schema_id 4B][Avro binary]`. Requires `schema-registry` feature. |
-| Confluent Protobuf | `confluent_protobuf` | Confluent wire-format Protobuf. Requires `schema-registry` feature. v1 returns an error — full descriptor support tracked in issue #44. |
-| Confluent JSON Schema | `confluent_json_schema` | Confluent wire-format JSON: `[0x00][schema_id 4B][JSON bytes]`. Optional schema validation. Requires `schema-registry` feature. |
-
-The three Confluent formats require building with the `schema-registry` feature flag:
-
-```bash
-cargo add faucet-source-kafka --features schema-registry
-```
-
-Each Confluent format takes a `schema_registry` block — see the `faucet-common-kafka` README for the full `SchemaRegistryConfig` options (URL, basic auth, cache capacity, request timeout).
-
----
-
-## Auth
-
-Authentication is configured via the `auth` field using `KafkaAuth` from `faucet-common-kafka`. The full auth reference — SASL/PLAIN, SASL/SCRAM, SSL client certificates, and SASL+SSL — is in the [`faucet-common-kafka` README](../../common/kafka/README.md#auth-modes).
-
-Quick example for SASL/PLAIN (Confluent Cloud, MSK with SASL):
+### Confluent Cloud (SASL/PLAIN + JSON)
 
 ```yaml
-auth:
-  type: sasl_plain
-  username: "${env:KAFKA_USERNAME}"
-  password: "${env:KAFKA_PASSWORD}"
+source:
+  type: kafka
+  config:
+    brokers: "pkc-xxxx.us-east-1.aws.confluent.cloud:9092"
+    topics: ["payments"]
+    group_id: faucet-payments
+    auth:
+      type: sasl_plain
+      config:
+        username: ${env:CC_API_KEY}
+        password: ${env:CC_API_SECRET}
+    value_format: { type: json }
+    auto_offset_reset: earliest
+    idle_timeout: 60
 ```
 
-Use `${env:VAR}` interpolation so credentials never land in the YAML file.
+### Confluent Avro via Schema Registry
 
----
+```yaml
+source:
+  type: kafka
+  config:
+    brokers: "localhost:9092"
+    topics: ["users-avro"]
+    group_id: faucet-users
+    value_format:
+      type: confluent_avro
+      schema_registry:
+        url: http://localhost:8081
+    max_messages: 5000
+    idle_timeout: 15
+```
 
-## Resume and state store
+### Resumable continuous drain into Postgres
 
-When a `StateStore` is wired into the pipeline (via `state:` in the YAML, or `Pipeline::with_state_store` in Rust), the source participates in durable offset tracking:
+```yaml
+pipeline:
+  source:
+    type: kafka
+    config:
+      brokers: "localhost:9092"
+      topics: ["events", "audit"]   # joined into one stable state key
+      group_id: faucet-warehouse
+      value_format: { type: json }
+      auto_offset_reset: earliest
+      idle_timeout: 30
+      batch_size: 5000
+  sink:
+    type: postgres
+    config:
+      connection_url: ${env:DATABASE_URL}
+      table: kafka_events
+  state:
+    type: file
+    config:
+      path: ./.faucet-state
+```
 
-1. **Before each run**, the pipeline reads the stored bookmark from the `StateStore` using the source's state key and calls `apply_start_bookmark`. The bookmark is buffered in memory; no seeking happens yet.
+### Raw-bytes passthrough, skip undecodable messages
 
-2. **On partition assignment** (the consumer's rebalance callback, which fires before any message is fetched), the bookmarked offset for each assigned `(topic, partition)` is injected into the assignment so the consumer starts there. Setting the offset *as part of* the assignment — rather than seeking after the first poll — means no message from before the bookmark is ever delivered, so a resume never produces a duplicate.
+```yaml
+source:
+  type: kafka
+  config:
+    brokers: "localhost:9092"
+    topics: ["raw-feed"]
+    group_id: faucet-raw
+    value_format: { type: bytes }   # base64 string in `value`
+    on_decode_error: skip
+    max_messages: 100000
+    idle_timeout: 10
+```
 
-3. **After the sink confirms the batch**, the pipeline persists the new bookmark — a list of `{topic, partition, offset}` entries recording one past the highest offset written.
+## Streaming & batching
 
-   The persisted bookmark records an offset for **every assigned partition**, not only the partitions that delivered a message in this run. A partition that was assigned but produced nothing is recorded at the consumer's current position (and a partition known from a prior run is carried forward). This is deliberate: if an empty-this-run partition were omitted, the next resume would have no offset for it and would fall back to `auto_offset_reset` (default `latest`) — silently **skipping** any records that arrived in the meantime. Recording its position closes that gap. The bookmark is only written on successful sink completion, so a crashed run never marks data as consumed.
+The source overrides `Source::stream_pages`. Messages drained from the `StreamConsumer` are accumulated into an in-memory buffer and emitted as a `StreamPage` whenever:
 
-   A partition that has *never* been assigned in any run (e.g. one added to the topic after the last run) has no recorded offset and so honours `auto_offset_reset` on first encounter — `earliest` reads it from the start, `latest` from the tail.
+1. **The buffer reaches `batch_size`** — yield a full page, reset the buffer, keep polling.
+2. **The idle window flushes a partial buffer** — when the `idle_timeout` deadline fires with a non-empty buffer, emit it as a trailing page and continue.
+3. **`max_messages` is reached or `Ctrl+C` is received** — emit the final partial page (if any) and exit.
+
+Each emitted page carries a snapshot of the cumulative `(topic, partition) → next_offset` bookmark. The pipeline persists it through the configured `StateStore` **after** the sink confirms the write, so memory is bounded at one page and a crash between pages re-reads only the uncommitted page on resume.
+
+**`batch_size = 0` — drain the entire run window.** The source accumulates **every** message produced by the run (until `max_messages` / `idle_timeout` fires) into a single page before yielding. This negates the streaming benefit and is intended only for tests or one-shot drains; production pipelines should use a finite `batch_size` so the state store advances with each successful sink write.
+
+## Resume & state store
+
+When a `StateStore` is wired in (via `state:` in YAML, or `Pipeline::with_state_store` in Rust) the source tracks durable offsets:
+
+1. **Before the run**, the pipeline reads the stored bookmark and calls `apply_start_bookmark`. It is buffered in memory — no seeking happens yet.
+2. **On partition assignment** (the rebalance callback, before any fetch), each assigned `(topic, partition)`'s bookmarked offset is injected *into* the assignment. Setting the offset as part of the assignment — rather than seeking after the first poll — means no pre-bookmark message is ever delivered, so a resume never duplicates.
+3. **After the sink confirms a batch**, the pipeline persists the new bookmark — one `{topic, partition, offset}` entry per assigned partition, recording one past the highest committed offset.
+
+The bookmark records an offset for **every assigned partition**, not just those that produced a message this run. An empty-this-run partition is recorded at the consumer's current position; if it were omitted, the next resume would fall back to `auto_offset_reset` (default `latest`) and silently **skip** records that arrived meanwhile. A partition that has *never* been assigned (e.g. added to the topic after the last run) honours `auto_offset_reset` on first encounter.
 
 **State key format:**
 
@@ -160,96 +304,98 @@ When a `StateStore` is wired into the pipeline (via `state:` in the YAML, or `Pi
 kafka:{group_id}:{topic1}:{topic2}...
 ```
 
-Topics are sorted alphabetically before joining, so the key is stable regardless of the order you list topics in the config. They are joined with `:` (not `.`) because a Kafka topic name may legally contain `.`, which would otherwise let `["a.b", "c"]` and `["a", "b.c"]` collide on the same `group_id`. For example, `group_id = "my-group"` and `topics = ["beta", "alpha"]` produces:
+Topics are sorted alphabetically before joining, so the key is stable regardless of config order. They are joined with `:` (not `.`) because a topic name may legally contain `.`. So `group_id = "my-group"`, `topics = ["beta", "alpha"]` yields `kafka:my-group:alpha:beta`.
 
-```
-kafka:my-group:alpha:beta
-```
+**Delivery semantics:** offsets are persisted only after the sink confirms, and on restart the consumer seeds the assignment with the bookmark before the first fetch. End-to-end this is **at-least-once** if the sink can fail mid-batch; pair with an idempotent sink for stricter guarantees. (The Kafka source does *not* advertise faucet-stream's exactly-once `delivery` mode — that gate requires a CDC source.)
 
-**Delivery semantics:** Offsets are persisted via faucet-stream's state store only after the sink confirms a batch, and on restart the consumer seeds the partition assignment with the bookmarked offset *before* any message is fetched. End-to-end this is at-least-once if the sink can fail mid-batch; pair with idempotent sinks if you need stricter guarantees.
+## Config loading & schema introspection
 
----
-
-## Streaming and batching
-
-When the source is driven through `Source::stream_pages` (which is what `Pipeline::run` and `run_stream` use internally), messages are accumulated into a `batch_size`-sized in-memory buffer and emitted as a `StreamPage` whenever:
-
-1. **The buffer reaches `batch_size`** — yield a full page, reset the buffer, and keep polling for more messages.
-2. **The `idle_timeout` window flushes a partial buffer** — when the idle deadline fires with a non-empty buffer, the buffer is emitted as a trailing page and the loop continues.
-3. **`max_messages` is reached or `Ctrl+C` is received** — emit the final partial page (if any) and exit.
-
-Each emitted page carries a snapshot of the cumulative `(topic, partition) -> next_offset` bookmark. The pipeline persists this via the configured `StateStore` **after** the sink confirms the write, giving at-least-once delivery with per-page durability — a crash between pages re-reads only the uncommitted page on resume.
-
-**Why this matters:** the batch-mode `fetch_all_incremental` waits for the entire run to complete before returning, which means the sink sees nothing until termination *and* the state store is only updated once. With streaming, the sink writes (and the state store advances) every `batch_size` messages.
-
-**`batch_size = 0` — drain entire run window.** Passes the special "no batching" sentinel: the source accumulates **every** message produced by the run (until `max_messages` or `idle_timeout` fires) into a single page before yielding. This negates the streaming benefit and is intended only for tests or one-shot drain scenarios. For production pipelines, prefer a finite `batch_size` so the state store advances with each successful sink write.
-
----
-
-## Termination
-
-The consume loop exits when any of the following is true:
-
-- **`max_messages`** — the configured number of messages has been collected.
-- **`idle_timeout`** — no new message has arrived within the configured number of seconds.
-- **`Ctrl+C` (SIGINT)** — the source catches the signal and exits the loop cleanly. The bookmark for everything consumed up to that point is returned to the pipeline, which persists it before exiting.
-
-At least one of `max_messages` and `idle_timeout` must be set; the config is rejected at construction time otherwise.
-
-Both conditions can be combined — the loop stops as soon as either threshold is hit:
-
-```yaml
-max_messages: 50000
-idle_timeout: 60
-```
-
----
-
-## Throughput notes
-
-librdkafka is one of the fastest Kafka client implementations available, benchmarked at millions of messages per second on well-provisioned hardware. For most pipelines the bottleneck is the downstream sink (BigQuery inserts, Postgres writes, S3 uploads), not the consume loop itself.
-
-The v1 consume loop is single-threaded — one goroutine polls one `StreamConsumer`. For higher throughput, partition your topic and run multiple `faucet` pipeline instances with the same `group_id`. Kafka assigns disjoint partition sets to each instance, and they scale linearly.
-
-Tuning tips:
-
-- Increase `max_messages` for larger batch sizes — fewer pipeline runs per unit of data.
-- Reduce `idle_timeout` for latency-sensitive pipelines where you want frequent small batches.
-- Use `extra_client_config` to pass `fetch.max.bytes`, `max.partition.fetch.bytes`, or `queued.max.messages.kbytes` if you need to push beyond librdkafka's defaults.
-
----
-
-## CLI integration
-
-Run with the `faucet` binary:
-
-```bash
-faucet run pipeline.yaml
-faucet validate pipeline.yaml
-faucet preview pipeline.yaml --limit 5   # consume 5 messages and print to stdout
-```
-
-Inspect the full JSON Schema for every config field:
+Load from YAML/JSON or environment. Inspect the full JSON Schema with:
 
 ```bash
 faucet schema source kafka
+faucet validate pipeline.yaml
+faucet preview pipeline.yaml --limit 5   # consume a few messages and print to stdout
 ```
 
-A complete working example is in [`cli/examples/kafka_to_jsonl.yaml`](../../cli/examples/kafka_to_jsonl.yaml).
+A complete working example ships at [`cli/examples/kafka_to_jsonl.yaml`](https://github.com/PawanSikawat/faucet-stream/blob/main/cli/examples/kafka_to_jsonl.yaml).
 
----
+## Library usage
 
-## See also
+```rust
+use faucet_core::Source;
+use faucet_source_kafka::{KafkaSource, KafkaSourceConfig, KafkaValueFormat, OffsetReset};
 
-- [`faucet-sink-kafka`](../../crates/sink/kafka/README.md) — produce records to Kafka topics.
-- [`faucet-common-kafka`](../../common/kafka/README.md) — shared auth modes, value formats, schema registry client, and policy enums used by both connectors.
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let cfg = KafkaSourceConfig {
+    brokers: "localhost:9092".into(),
+    topics: vec!["orders".into()],
+    group_id: "faucet-orders".into(),
+    auth: Default::default(),                 // KafkaAuth::None
+    value_format: KafkaValueFormat::Json,
+    key_format: None,
+    auto_offset_reset: OffsetReset::Earliest,
+    max_messages: Some(10_000),
+    idle_timeout: Some(std::time::Duration::from_secs(30)),
+    poll_timeout: std::time::Duration::from_secs(1),
+    session_timeout: std::time::Duration::from_secs(30),
+    on_decode_error: Default::default(),      // fail
+    extra_client_config: Default::default(),
+    batch_size: 1000,
+};
+cfg.validate()?;
 
----
+let records = KafkaSource::new(cfg).await?.fetch_all().await?;
+println!("consumed {} messages", records.len());
+# Ok(())
+# }
+```
+
+For durable resume and incremental sink writes, drive it through `faucet_core::Pipeline` (or `run_stream`) with a `StateStore` rather than `fetch_all`.
+
+## How it works
+
+1. `new()` validates the config, builds the state key, and constructs the `StreamConsumer` **once** with the resolved librdkafka client config (auth + typed fields + `extra_client_config` overrides).
+2. A rebalance callback seeds the partition assignment with bookmarked offsets before the first poll.
+3. The consume loop polls with `poll_timeout`, decodes each message per `value_format` / `key_format`, and buffers it; it exits on `max_messages`, `idle_timeout`, or SIGINT.
+4. Decoded messages are framed into `batch_size` pages and streamed to the pipeline, each page carrying the cumulative offset bookmark.
+
+The v1 consume loop is single-threaded — one task polls one `StreamConsumer`. For higher throughput, partition the topic and run multiple `faucet` instances with the same `group_id`; Kafka assigns disjoint partition sets and they scale linearly. The downstream sink (database writes, object-store uploads) is usually the bottleneck, not the consume loop.
 
 ## Lineage dataset URI
 
-`kafka://<first_broker>?topic=<topic1>,<topic2>` — e.g. `kafka://kafka.example.com:9092?topic=orders`.
+`kafka://<first_broker>?topic=<topic1>,<topic2>` — e.g. `kafka://kafka.example.com:9092?topic=orders` (the first broker in `brokers`, all topics comma-joined).
+
+## Feature flags
+
+| Feature | Default | Effect |
+|---------|---------|--------|
+| `schema-registry` | off | Enables the Confluent Avro / Protobuf / JSON Schema value formats and `SchemaRegistryConfig` (pulls `reqwest`, `apache-avro`, `prost-reflect`, `jsonschema`, …). |
+
+In the CLI / umbrella, enable the connector with `source-kafka`, and the registry formats with `kafka-schema-registry`.
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause & fix |
+|---------|--------------------|
+| `Config: at least one of max_messages or idle_timeout must be set` | A Kafka source has no stop condition. Set `max_messages`, `idle_timeout`, or both. |
+| Run consumes nothing and exits immediately | `auto_offset_reset` defaults to `latest`, so a fresh group skips existing messages. Set `auto_offset_reset: earliest` to read from the start. |
+| Run hangs until `idle_timeout` on an empty topic | Expected — the consumer waits `idle_timeout` seconds for new messages before exiting. Lower `idle_timeout` for faster turnaround. |
+| Resume re-reads or skips records | Ensure a non-`memory` `state:` block is configured and the `group_id` + `topics` are unchanged (the state key is derived from both). A changed `group_id` is a new bookmark. |
+| `Source` error / connection refused / timeout | Broker unreachable or wrong `brokers`. `faucet doctor` runs a non-consuming metadata probe to validate connectivity + auth without reading messages. |
+| SASL / SSL handshake failure | Wrong `auth` type or credentials, or a `key_path` / `cert_path` / `ca_path` that doesn't exist (paths are validated at config time). Confirm the broker's `security.protocol` matches. |
+| Messages fail to decode | The `value_format` doesn't match the wire data (e.g. `json` against Avro). Match the producer's format; use `on_decode_error: skip` to drop bad messages instead of aborting. |
+| `confluent_protobuf` returns an error | Protobuf decoding is not yet implemented (issue [#44](https://github.com/PawanSikawat/faucet-stream/issues/44)). Use `confluent_avro` / `confluent_json_schema`, or decode raw `bytes` and parse downstream. |
+| Confluent format rejected as unknown `type` | Build with the `schema-registry` feature (CLI: `kafka-schema-registry`). |
+| Throughput lower than expected | Partition the topic and run multiple instances with the same `group_id`, and/or tune `fetch.max.bytes` / `max.partition.fetch.bytes` via `extra_client_config`. |
+
+## See also
+
+- [Kafka source reference](https://pawansikawat.github.io/faucet-stream/reference/connectors.html) — capability matrix.
+- [State & resume cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/state.html) — bookmarks and delivery semantics.
+- [`faucet-sink-kafka`](https://crates.io/crates/faucet-sink-kafka) — produce records to Kafka topics.
+- [`faucet-common-kafka`](https://crates.io/crates/faucet-common-kafka) — shared auth modes, value formats, Schema Registry client, and policy enums.
 
 ## License
 
-Dual-licensed under MIT and Apache-2.0, matching the workspace `license` field.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/source/mongodb-cdc/README.md
+++ b/crates/source/mongodb-cdc/README.md
@@ -1,10 +1,54 @@
 # faucet-source-mongodb-cdc
 
-MongoDB CDC (Change Data Capture) source for [`faucet-stream`](https://github.com/PawanSikawat/faucet-stream). Tails a MongoDB [Change Stream](https://www.mongodb.com/docs/manual/changeStreams/) and emits each per-document change event (insert, update, replace, delete, DDL) as a JSON record. The opaque `resumeToken` is persisted via any `faucet-core` `StateStore`, so pipelines resume exactly where they left off after a restart — no duplicates, no gap.
+[![Crates.io](https://img.shields.io/crates/v/faucet-source-mongodb-cdc.svg)](https://crates.io/crates/faucet-source-mongodb-cdc)
+[![Docs.rs](https://docs.rs/faucet-source-mongodb-cdc/badge.svg)](https://docs.rs/faucet-source-mongodb-cdc)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-source-mongodb-cdc.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-source-mongodb-cdc.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-**Requires a replica set or sharded cluster.** Standalone `mongod` instances do not support Change Streams; the connector fails fast in `new()` with a clear error if a standalone is detected.
+MongoDB **Change Data Capture (CDC)** source for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem. Tails a MongoDB [Change Stream](https://www.mongodb.com/docs/manual/changeStreams/) — at collection, database, or whole-cluster scope — and emits each per-document change event (insert, update, replace, delete, DDL) as a flat JSON CDC envelope.
 
----
+Reach for it when you want to stream live mutations out of MongoDB into any faucet-stream sink — a warehouse, a queue, another database — with no polling and no missed changes. The opaque `resumeToken` is persisted to any `faucet-core` `StateStore` after every page, so a restarted pipeline resumes from exactly where it stopped: no duplicates, no gap. Paired with a CDC-aware sink, it is also an **exactly-once** delivery source.
+
+## Feature highlights
+
+- **Native Change Streams** — tails MongoDB's oplog-backed change stream directly via the official `mongodb` driver. No polling loop, no last-modified timestamp column, no `_changed_at` bookkeeping on your documents.
+- **Three watch scopes** — one collection, one whole database, or the entire deployment (`cluster`). Pick the narrowest scope that covers what you need.
+- **Resumable by design** — the server-assigned `resumeToken` of the last event in each page becomes the pipeline bookmark; on restart the stream re-opens with `resumeAfter: <token>` for a duplicate-free, gap-free resume.
+- **Exactly-once delivery** — `supports_exactly_once()` is `true`. Combined with an idempotent sink (sqlite / postgres / mysql / mssql / iceberg / bigquery) and a state store, the pipeline commits records and a monotonic commit token in one atomic unit.
+- **Snapshot → CDC handoff** — implements `capture_resume_position()`, so `faucet replicate` can anchor the change stream *before* a bulk snapshot of the collection and stitch the two into a true mirror.
+- **Server-side filtering** — push an `operationType` allowlist and arbitrary aggregation stages into the change stream so unwanted events never cross the wire.
+- **Pre-image / post-image control** — request the full document `before` and/or `after` each change (MongoDB 6.0+ for pre-images), with explicit `off` / `when_available` / `required` / `update_lookup` modes.
+- **Bounded memory** — events are emitted in pages of `batch_size`; peak memory is `O(batch_size)` no matter how busy the collection is.
+- **Client built once** — the authenticated `mongodb::Client` is constructed in `new()` and reused for the lifetime of the source.
+
+## Installation
+
+```bash
+# As a library:
+cargo add faucet-source-mongodb-cdc
+
+# In the CLI (opt-in connector feature):
+cargo install faucet-cli --features source-mongodb-cdc
+```
+
+This connector is **not** in the CLI default build — enable the `source-mongodb-cdc` feature (or the `source` / `full` aggregates).
+
+## Prerequisites
+
+Change Streams are only available on a **replica set** or a **sharded cluster** — they read from the oplog, which a standalone `mongod` does not maintain. The connector validates this at startup: if the connection URI points at a standalone instance, `new()` fails fast with a typed `FaucetError::Source` rather than silently producing no events.
+
+For local development, run a single-node replica set:
+
+```bash
+mongod --replSet rs0 --bind_ip localhost
+# then, in the shell, once:
+mongosh --eval 'rs.initiate()'
+```
+
+Connect with `?replicaSet=rs0` in the URI. Some additional requirements depending on the features you use:
+
+- **Pre-images** (`full_document_before_change`) require MongoDB **6.0+** and per-collection `changeStreamPreAndPostImages: { enabled: true }`.
+- The connecting user needs `find` and `changeStream` privileges on the watched namespace (the built-in `read` role covers a single database; cluster scope needs read across all databases).
 
 ## Quick start
 
@@ -34,11 +78,11 @@ state:
 faucet run pipeline.yaml
 ```
 
----
+Every change to `appdb.orders` lands as one JSON line in `changes.jsonl`; the resumeToken is checkpointed to `./state` after each page so a re-run picks up exactly where it left off.
 
 ## Output record schema
 
-Every change event is one JSON object:
+Every change event is one JSON object — a flat CDC envelope:
 
 ```json
 {
@@ -63,86 +107,85 @@ Every change event is one JSON object:
 |-------|------|-------------|
 | `op` | string | Operation type: `c` (insert), `u` (update), `r` (replace), `d` (delete), `ddl` (drop / rename / dropDatabase / invalidate) |
 | `ts_ms` | number | Wall-clock time of the change in Unix-epoch milliseconds (from `clusterTime`) |
-| `namespace` | object \| null | `{ "db": "…", "coll": "…" }`. `null` for cluster-scope events that carry no namespace (e.g. cluster-level invalidate) |
+| `namespace` | object \| null | `{ "db": "…", "coll": "…" }`. `null` for cluster-scope events that carry no namespace (e.g. a cluster-level invalidate) |
 | `document_key` | object \| null | Document identity key (typically `{ "_id": … }`) |
 | `before` | object \| null | Pre-image of the document. Populated only when `full_document_before_change` is enabled and the collection has `changeStreamPreAndPostImages` turned on (MongoDB 6.0+). |
 | `after` | object \| null | Post-image of the document. Populated on inserts, replaces, and updates when `full_document` is `update_lookup`, `when_available`, or `required`. `null` on deletes. |
 | `update_description` | object \| null | Present on `u` events: `{ "updated_fields": {…}, "removed_fields": ["…"], "truncated_arrays": [{…}] }`. `null` for all other op types. |
 | `resume_token` | object | Opaque server-assigned token. The pipeline persists this as the page bookmark and passes it to `resumeAfter` on the next run. |
 
-### op mapping
+### Operation-type mapping
 
 | MongoDB `operationType` | `op` value |
-|------------------------|-----------|
+|-------------------------|-----------|
 | `insert` | `c` |
 | `update` | `u` |
 | `replace` | `r` |
 | `delete` | `d` |
 | `drop`, `rename`, `dropDatabase`, `invalidate` | `ddl` |
 
----
+## Configuration reference
 
-## Configuration
+### Connection & scope
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `connection_uri` | string | — | MongoDB connection URI. Must point at a replica set (`?replicaSet=rs0`) or sharded cluster. A standalone `mongod` URI causes a hard error at startup. |
-| `scope` | enum | `{ type: cluster }` | Change Stream scope: `{ type: cluster }` (all databases), `{ type: database, database: "mydb" }` (one database), or `{ type: collection, database: "mydb", collection: "mycoll" }` (one collection). |
-| `operation_types` | string[] | `[]` (all) | Server-side `$match` on `operationType`. Empty = all. Example: `["insert", "update", "delete"]`. |
-| `full_document` | enum | `off` | Post-image delivery: `off` (no full doc), `when_available` (include when available), `required` (fail if unavailable), `update_lookup` (re-read from server at event time — at-least-once / read-skew caveat, see below). |
-| `full_document_before_change` | enum | `off` | Pre-image delivery: `off`, `when_available`, or `required`. Requires MongoDB 6.0+ and `changeStreamPreAndPostImages` enabled on the collection. |
-| `start_from` | enum | `{ type: now }` | Where to start if no persisted bookmark exists: `{ type: now }` (new events only), `{ type: earliest }` (from the oldest available oplog entry — errors if the oplog has rolled past), `{ type: resume_token, token: {…} }` (explicit token, always used regardless of any persisted bookmark), or `{ type: timestamp, timestamp_secs: N }` (cluster time in seconds, always used regardless of any persisted bookmark). |
-| `aggregation_pipeline` | object[] | `[]` | Extra aggregation stages appended **after** the internal `$match` on `operation_types`. Use for server-side field projection, filtering, or transformation. |
-| `idle_timeout` | seconds | `30` | Terminate the current fetch cycle after this long with no new events. The page accumulated so far is flushed and the bookmark is saved. |
-| `max_await_time_ms` | u64 | `1000` | Server-side `maxAwaitTimeMS` on `getMore` requests. Controls how long the server blocks before returning an empty batch. Must be less than `idle_timeout` (in milliseconds). |
-| `batch_size` | usize | `1000` | Records per emitted `StreamPage`. `0` = no batching — drain until idle and emit one page. |
+| `connection_uri` | string | — (required) | MongoDB connection URI. Must point at a replica set (`?replicaSet=rs0`) or sharded cluster. A standalone `mongod` URI causes a hard error at startup. Credentials in the URI are redacted from `Debug` output. |
+| `scope` | enum | `{ type: cluster }` | Which change stream to open. See the scope variants below. |
 
----
+`scope` variants:
 
-## Resumability and state key
+```yaml
+# Whole deployment (default)
+scope: { type: cluster }
 
-The connector is fully resumable. After each emitted page the pipeline writes the `resume_token` of the last event in that page to the configured `StateStore` (per-batch durability). On the next run, `apply_start_bookmark` restores the token and the Change Stream opens with `resumeAfter: <token>` — MongoDB delivers events from exactly that point onwards with no duplicates and no gap.
+# One database (all collections)
+scope: { type: database, database: appdb }
 
-**`start_from` precedence:**
+# One collection
+scope: { type: collection, database: appdb, collection: orders }
+```
 
-- `resume_token` and `timestamp` variants **always** override a persisted bookmark — they force an explicit start position regardless of what the state store holds.
-- `now` and `earliest` variants **yield** to a persisted bookmark: if one exists the connector resumes from it; if none exists the specified variant is used as the initial position.
+### Filtering
 
-State keys used (one per scope):
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `operation_types` | string[] | `[]` (all) | Server-side `$match` allowlist on `operationType`. Empty = every operation. Example: `["insert", "update", "delete"]`. |
+| `aggregation_pipeline` | object[] | `[]` | Extra aggregation stages appended **after** the internal `operation_types` `$match`. Use for server-side field projection, redaction, or further filtering of the change-event documents. |
 
-| Scope | State key |
-|-------|-----------|
-| Cluster | `mongodb-cdc:cluster` |
-| Database `mydb` | `mongodb-cdc:db:mydb` |
-| Collection `mydb.mycoll` | `mongodb-cdc:coll:mydb.mycoll` |
+### Document images
 
----
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `full_document` | enum | `off` | Post-image (`after`) delivery: `off` (no full doc), `when_available` (include when the server can supply it), `required` (error if unavailable), `update_lookup` (re-read the current document at event time — read-skew caveat, see [Caveats](#caveats)). |
+| `full_document_before_change` | enum | `off` | Pre-image (`before`) delivery: `off`, `when_available`, or `required`. Requires MongoDB 6.0+ and `changeStreamPreAndPostImages` enabled on the collection. |
 
-## invalidate events
+### Start position
 
-An `invalidate` event (emitted when a watched collection or database is dropped while the stream is open) is delivered as a `ddl` record and then **terminates the stream**. The connector closes the stream and returns; a fresh `faucet run` is needed to start a new Change Stream. Persisted bookmarks from before the invalidate are discarded by MongoDB — use `start_from: { type: now }` or `{ type: earliest }` on the next run.
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `start_from` | enum | `{ type: now }` | Where to start when **no persisted bookmark exists**. See the variants and precedence rules below. |
 
----
+`start_from` variants:
 
-## Caveats
+```yaml
+start_from: { type: now }                        # only events from now on (default)
+start_from: { type: earliest }                   # from the oldest retained oplog entry
+start_from: { type: resume_token, token: {...} } # an explicit opaque token
+start_from: { type: timestamp, timestamp_secs: 1779019200 }  # a cluster time, in epoch seconds
+```
 
-- **Replica set or sharded cluster required.** Standalone `mongod` instances do not support Change Streams. The connector validates this at startup and returns a typed `FaucetError::Source` immediately.
-- **`full_document: update_lookup` has at-least-once / read-skew semantics.** The document is re-read from the primary at event delivery time, not at the time of the original change. If the document has been further modified or deleted between the change and the lookup, the `after` image will reflect the later state (or be absent). Do not rely on `after` for exactly-once semantics when using `update_lookup`.
-- **`start_from: earliest` may error.** If the oplog has rolled past the earliest available timestamp (common on busy clusters with a short oplog window), MongoDB returns an error. Use `{ type: now }` for new deployments and keep your oplog window large enough for your expected downtime.
-- **`full_document_before_change` requires MongoDB 6.0+ and per-collection configuration.** Enable pre-images on the collection before starting the stream:
-  ```js
-  db.runCommand({
-    collMod: "mycoll",
-    changeStreamPreAndPostImages: { enabled: true }
-  });
-  ```
-  Without this, `required` will error; `when_available` will produce `before: null`.
-- **DDL events are best-effort.** Schema changes (collection drops, renames) arrive as `ddl` records, but the Change Stream does not replicate index operations or user-visible `collMod` changes that don't appear in the oplog.
-- **Per-batch durability, not per-event.** The bookmark is saved once per emitted page (every `batch_size` events), not after every individual event. A crash mid-page replays at most `batch_size` events.
+### Batching & timing
 
----
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `idle_timeout` | seconds | `30` | Terminate the current fetch cycle after this long with no new events. The page accumulated so far is flushed and the bookmark is saved. Must be `> 0`. |
+| `max_await_time_ms` | u64 | `1000` | Server-side `maxAwaitTimeMS` on `getMore` requests — how long the server blocks waiting for new events before returning an empty batch. Must be **strictly less than** `idle_timeout` (in milliseconds), else config validation fails. |
+| `batch_size` | usize | `1000` | Records per emitted `StreamPage`. `0` = no batching: drain until idle and emit one page. Max `1,000,000`. |
 
-## Example: capture all changes to a collection
+## Examples
+
+### Capture all changes to a collection, land in BigQuery
 
 ```yaml
 version: 1
@@ -176,9 +219,7 @@ state:
     namespace: faucet-cdc
 ```
 
----
-
-## Example: cluster-wide CDC with operation filtering
+### Cluster-wide CDC with operation filtering, printed to stdout
 
 ```yaml
 version: 1
@@ -199,37 +240,203 @@ state:
   config: { path: ./state/mongodb-cdc }
 ```
 
----
+### Server-side projection via an aggregation pipeline
+
+Strip large fields and redact a secret before events ever leave the server:
+
+```yaml
+version: 1
+source:
+  type: mongodb-cdc
+  config:
+    connection_uri: mongodb://localhost:27017/?replicaSet=rs0
+    scope:
+      type: collection
+      database: appdb
+      collection: users
+    full_document: update_lookup
+    aggregation_pipeline:
+      - { $unset: ["fullDocument.password_hash", "fullDocument.blob"] }
+state:
+  type: file
+  config: { path: ./state }
+sink:
+  type: jsonl
+  config:
+    path: ./users-changes.jsonl
+```
+
+## Streaming & batching
+
+The source overrides `stream_pages` to tail the change stream natively. It accumulates change events into a `StreamPage` and yields a page when **either** `batch_size` events have accumulated **or** `idle_timeout` elapses with no new event. The bookmark carried on each page is the `resume_token` of the last event in that page, so the pipeline persists durable progress every page.
+
+- The `batch_size` config field is authoritative — a pipeline-supplied hint never overrides it.
+- `batch_size: 0` is the "no batching" sentinel: drain events until idle and emit a single page. Use it for low-traffic collections where you'd rather get one consolidated page per quiet period.
+- `max_await_time_ms` is the inner blocking-wait knob; `idle_timeout` is the outer cycle terminator. The validation `max_await_time_ms < idle_timeout` guarantees the server returns control to the connector before the idle timer fires.
+
+## Resume & state
+
+The connector is fully resumable. After each emitted page the pipeline writes the `resume_token` of the last event to the configured `StateStore`. On the next run, `apply_start_bookmark` restores the token and the change stream opens with `resumeAfter: <token>` — MongoDB delivers events from exactly that point onwards.
+
+**`start_from` precedence (only consulted when no persisted bookmark exists, except as noted):**
+
+- `resume_token` and `timestamp` variants **always** override a persisted bookmark — they force an explicit start position regardless of what the state store holds.
+- `now` and `earliest` variants **yield** to a persisted bookmark: if one exists the connector resumes from it; if none exists, the variant chooses the initial position.
+
+State keys (one per scope) so that two pipelines on different scopes never collide:
+
+| Scope | State key |
+|-------|-----------|
+| Cluster | `mongodb-cdc:cluster` |
+| Database `mydb` | `mongodb-cdc:db:mydb` |
+| Collection `mydb.mycoll` | `mongodb-cdc:coll:mydb.mycoll` |
+
+Durability is **per-page, not per-event**: the bookmark is saved once per emitted page (every `batch_size` events). A crash mid-page replays at most `batch_size` events on the next run — at-least-once unless you also enable exactly-once delivery.
+
+## Exactly-once delivery
+
+`supports_exactly_once()` returns `true`. Set `delivery: exactly_once` on the pipeline and the source becomes eligible for end-to-end exactly-once semantics. The pipeline assigns a monotonic, fixed-width commit token to each bookmark-carrying page and calls the sink's `write_batch_idempotent`, which commits the records **and** the token atomically; on resume the sink's `last_committed_token` lets the pipeline skip any page already committed.
+
+The CLI enforces a hard gate at config-load time (caught by `faucet validate` before any run):
+
+1. **Source** must support exactly-once — `mongodb-cdc` qualifies.
+2. **Sink** must support idempotent writes — one of `sqlite`, `postgres`, `mysql`, `mssql`, `iceberg`, `bigquery`.
+3. A `state:` block must be configured.
+4. No `dlq:` block (DLQ and exactly-once are mutually exclusive in this version).
+
+```yaml
+version: 1
+delivery: exactly_once
+source:
+  type: mongodb-cdc
+  config:
+    connection_uri: mongodb://localhost:27017/?replicaSet=rs0
+    scope: { type: collection, database: appdb, collection: orders }
+    full_document: update_lookup
+sink:
+  type: postgres
+  config:
+    connection_url: postgres://user:pass@localhost/warehouse
+    table: orders_cdc
+state:
+  type: postgres
+  config:
+    connection_url: postgres://user:pass@localhost/warehouse
+```
+
+> **Note:** `full_document: update_lookup` re-reads the document at lookup time, not change time (see [Caveats](#caveats)). For a strict mirror, prefer the change-event payload itself plus an idempotent sink, and pair with the `cdc_unwrap` transform + `write_mode: upsert` — see the [upsert cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/upsert.html).
 
 ## Snapshot → CDC handoff
 
-This source implements `capture_resume_position()`, which opens a change stream
-against the configured scope and reads its `postBatchResumeToken` (present after
-the first server round-trip even with no events) as a resume bookmark — without
-consuming any changes. The `faucet replicate` command uses it to anchor the
-change stream at-or-before a bulk snapshot of the collection, so the combined
-snapshot+CDC result is a gap-free, duplicate-free mirror when paired with a
-`write_mode: upsert` sink.
+This source implements `capture_resume_position()`, which opens a change stream against the configured scope and reads its `postBatchResumeToken` (present after the first server round-trip even with no events) as a resume bookmark — **without consuming any changes**. The `faucet replicate` command uses it to anchor the change stream at-or-before a bulk snapshot of the collection, so the combined snapshot + CDC result is a gap-free, duplicate-free mirror when paired with a `write_mode: upsert` sink.
 
-There is no slot to pin; the **oplog window** is the retention risk — keep it
-comfortably larger than the expected snapshot duration, or the captured token may
-roll off before CDC starts and the stream will error. See the [replication
-cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/replication.html)
-for the full handoff model.
+There is no replication slot to pin — the **oplog window** is the retention risk. Keep it comfortably larger than the expected snapshot duration, or the captured token may roll off the oplog before CDC starts and the stream will error. See the [replication cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/replication.html) for the full handoff model.
 
----
+## `invalidate` events
 
-## See also
+An `invalidate` event (emitted when a watched collection or database is dropped while the stream is open) is delivered as a `ddl` record and then **terminates the stream**. The connector closes the stream and returns; a fresh `faucet run` is needed to start a new change stream. Persisted bookmarks from before the invalidate are no longer resumable by MongoDB — use `start_from: { type: now }` or `{ type: earliest }` on the next run.
 
-- `crates/source/mongodb/` — query-mode MongoDB source (snapshots via `find()`).
-- `crates/state/redis/` — Redis-backed `StateStore` for durable resumeToken bookmarks.
-- `crates/state/postgres/` — PostgreSQL-backed `StateStore` alternative.
-- `crates/source/postgres-cdc/` — PostgreSQL CDC for comparison (LSN bookmarks, pgoutput).
+## Config loading
+
+Configs load from YAML/JSON files, environment variables, or `.env` files. With the CLI, point `faucet run` at any YAML or JSON file. Programmatically, deserialize `MongoCdcSourceConfig` with `serde` from any supported format, or use the helpers in `faucet_core::config` (`load_json`, `load_env`, `load_env_file`).
+
+## Schema introspection
+
+Print the full JSON Schema for this source's config — every field, type, default, and enum variant — with:
+
+```bash
+faucet schema source mongodb-cdc
+```
+
+This is generated from the config struct via `schemars`, so it never drifts from the code.
+
+## Library usage
+
+```rust,no_run
+use faucet_core::{Pipeline, state::FileStateStore};
+use faucet_source_mongodb_cdc::{MongoCdcSource, MongoCdcSourceConfig, Scope};
+use std::sync::Arc;
+
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let config: MongoCdcSourceConfig = serde_json::from_value(serde_json::json!({
+    "connection_uri": "mongodb://localhost:27017/?replicaSet=rs0",
+    "scope": { "type": "collection", "database": "appdb", "collection": "orders" },
+    "full_document": "update_lookup",
+    "idle_timeout": 30
+}))?;
+
+// `new()` validates config, builds the client, and verifies the deployment
+// supports change streams (fails fast on a standalone).
+let source = MongoCdcSource::new(config).await?;
+
+// Build your sink (any faucet-stream sink) and a durable state store so the
+// resumeToken survives restarts.
+let state = Arc::new(FileStateStore::new("./state"));
+# let sink = todo!();
+let pipeline = Pipeline::new(source, sink).with_state_store(state);
+pipeline.run().await?;
+# Ok(())
+# }
+```
+
+## How it works
+
+- **One client, reused.** `MongoCdcSource::new()` builds the `mongodb::Client`, validates the config's fail-fast invariants, and confirms the deployment is a replica set / sharded cluster. The same client backs every fetch cycle.
+- **Native change stream.** Each fetch cycle opens (or resumes) a change stream with the configured scope, `$match` on `operation_types`, any extra `aggregation_pipeline` stages, the chosen full-document / pre-image modes, and `resumeAfter` (or `startAtOperationTime`) derived from the bookmark or `start_from`.
+- **Page assembly.** Events are decoded into the flat CDC envelope and buffered. A page flushes on `batch_size` events or `idle_timeout` quiet; `max_await_time_ms` controls the server's blocking `getMore` wait so the idle timer can fire promptly.
+- **Bookmark tracking.** The `resume_token` of the last event in a page becomes the page bookmark, which the pipeline persists after the sink confirms the write — so a token is only durable once its events are.
 
 ## Lineage dataset URI
 
-`mongodb://<host>:<port>/<database>/<collection>` or `/<database>` or just the host (depending on scope), credentials stripped — e.g. `mongodb://host:27017/mydb/orders`.
+`dataset_uri()` emits `mongodb://<host>:<port>/<database>/<collection>`, `/<database>`, or just the host (depending on scope), with credentials stripped — e.g. `mongodb://host:27017/appdb/orders` for collection scope, `mongodb://host:27017/appdb` for database scope, and the bare host for cluster scope.
+
+## Feature flags
+
+This crate has no optional features of its own. From the umbrella / CLI it is gated behind:
+
+| Feature | Enables |
+|---------|---------|
+| `source-mongodb-cdc` | this connector |
+| `source` | all sources, including this one |
+| `full` | everything |
+
+## Troubleshooting / FAQ
+
+| Symptom | Cause & fix |
+|---------|-------------|
+| `The $changeStream stage is only supported on replica sets` or a startup `FaucetError::Source` about standalone | The URI points at a standalone `mongod`. Change Streams need a replica set or sharded cluster. Run `mongod --replSet rs0` and `rs.initiate()`, then add `?replicaSet=rs0` to the URI. |
+| Config error: `max_await_time_ms must be strictly less than idle_timeout` | `max_await_time_ms` is in **milliseconds** and must be `< idle_timeout` (which is in **seconds**). E.g. `idle_timeout: 30` (30 000 ms) with `max_await_time_ms: 1000` is valid. |
+| `start_from: earliest` errors with an oplog/`resume of change stream was not possible` message | The oldest available oplog entry has rolled past. Use `{ type: now }` for fresh deployments, and size the oplog (and your tolerated downtime) so the window outlasts any gap between runs. |
+| Resume fails after restart with a "resume point may no longer be in the oplog" error | The persisted `resumeToken` rolled off the oplog while the pipeline was down. Increase the oplog size, or restart with `start_from: { type: now }` (accepting the gap). |
+| `before` is always `null` despite `full_document_before_change` set | Pre-images need MongoDB 6.0+ **and** `changeStreamPreAndPostImages: { enabled: true }` on the collection: `db.runCommand({ collMod: "mycoll", changeStreamPreAndPostImages: { enabled: true } })`. With `required` and pre-images off, the stream errors; with `when_available` you get `before: null`. |
+| `after` reflects a newer state than the change | You're using `full_document: update_lookup`, which re-reads the document at lookup time. If the doc was further modified or deleted in between, `after` shows the later state (or is absent). Don't rely on it for a strict point-in-time image. |
+| Pipeline exits cleanly but the source dropped a collection | An `invalidate` (collection/db dropped) arrives as a `ddl` event and **terminates the stream**. Re-run `faucet run`; the prior bookmark is no longer resumable, so set `start_from`. |
+| Authorization errors opening the stream | The user needs `find` + `changeStream` on the namespace (cluster scope needs read across all databases). Check `authSource` in the URI matches where the user is defined. |
+| No events appear even though documents are changing | Check `operation_types` isn't filtering them out, and that `scope` targets the right database/collection. A too-short `idle_timeout` ends the cycle before events arrive on a quiet collection — that's expected; the next run resumes. |
+
+## Caveats
+
+- **Replica set or sharded cluster required.** Standalone `mongod` instances do not support Change Streams; the connector validates this at startup and returns a typed `FaucetError::Source` immediately.
+- **`full_document: update_lookup` has at-least-once / read-skew semantics.** The document is re-read from the primary at delivery time, not at change time. If the document was further modified or deleted in between, the `after` image reflects the later state (or is absent).
+- **`start_from: earliest` may error** if the oplog has rolled past the earliest timestamp. Keep the oplog window large enough for your expected downtime.
+- **DDL events are best-effort.** Collection drops/renames arrive as `ddl` records, but the change stream does not replicate index operations or `collMod` changes that don't appear in the oplog.
+- **Per-batch durability, not per-event.** A crash mid-page replays at most `batch_size` events (unless exactly-once delivery is enabled).
+
+## See also
+
+- [State & resumability cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/state.html) — bookmarks, durable state stores, exactly-once.
+- [Replication cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/replication.html) — the snapshot → CDC handoff with `faucet replicate`.
+- [Upsert cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/upsert.html) — `cdc_unwrap` + `write_mode: upsert` for a true CDC mirror.
+- [Connector reference](https://pawansikawat.github.io/faucet-stream/reference/connectors.html) — the full capability matrix.
+- [`faucet-source-mongodb`](https://crates.io/crates/faucet-source-mongodb) — query-mode MongoDB source (`find()` snapshots).
+- [`faucet-state-redis`](https://crates.io/crates/faucet-state-redis) / [`faucet-state-postgres`](https://crates.io/crates/faucet-state-postgres) — durable `StateStore` backends for resumeToken bookmarks.
+- [`faucet-source-postgres-cdc`](https://crates.io/crates/faucet-source-postgres-cdc) / [`faucet-source-mysql-cdc`](https://crates.io/crates/faucet-source-mysql-cdc) — CDC sources for other databases.
 
 ## License
 
-Licensed under MIT or Apache-2.0.
+Licensed under either of:
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](https://github.com/PawanSikawat/faucet-stream/blob/main/LICENSE-APACHE))
+- MIT license ([LICENSE-MIT](https://github.com/PawanSikawat/faucet-stream/blob/main/LICENSE-MIT))
+
+at your option.

--- a/crates/source/mongodb/README.md
+++ b/crates/source/mongodb/README.md
@@ -5,128 +5,260 @@
 [![MSRV](https://img.shields.io/crates/msrv/faucet-source-mongodb.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
 [![License](https://img.shields.io/crates/l/faucet-source-mongodb.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-A MongoDB source that executes `find()` queries with filter, projection, sort, and limit, returning documents as JSON records.
+A **MongoDB** source for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem. Runs a single `find()` query against a collection — with optional filter, projection, sort, and limit — and yields each matching document as a `serde_json::Value` object.
 
-Part of the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
+Built on the official `mongodb` driver, which maintains an internal connection pool created once at construction and reused for every query. The source streams documents straight off the driver cursor (no full-result buffering), so memory stays bounded by `batch_size` regardless of how large the collection or result set is. Reach for it to drain collections into any faucet-stream sink — SQL warehouses, object stores, search indexes, or another database.
+
+## Feature highlights
+
+- **`find()` with the full query surface** — JSON `filter`, `projection`, `sort`, and `limit`, all converted to BSON at query time.
+- **Native cursor streaming** — `stream_pages` pulls documents off the driver cursor incrementally and yields a `StreamPage` once the buffer fills; the full result set is never materialized in memory.
+- **Two independent batching knobs** — `batch_size` (records per emitted page) and `cursor_batch_size` (the driver's per-round-trip fetch size), tunable separately to trade network round-trips against buffering.
+- **Pooled connections** — the driver's internal connection pool is created once in `new()` and reused across every query.
+- **Relaxed extended JSON** — BSON types (`ObjectId`, `DateTime`, `Int64`, …) are rendered as MongoDB relaxed extended JSON, so round-trips stay lossless and self-describing.
+- **Matrix-row context interpolation** — `{key}` placeholders inside `filter`/`projection`/`sort` are resolved per parent record (JSON-safe escaping) for parent/child fan-out pipelines.
+- **Credential safety** — the connection URI is masked in `Debug` output and stripped from the lineage dataset URI.
 
 ## Installation
 
 ```bash
+# As a library:
 cargo add faucet-source-mongodb
 cargo add tokio --features full
+
+# In the CLI (opt-in connector feature):
+cargo install faucet-cli --features source-mongodb
 ```
 
 Or via the umbrella crate:
+
 ```bash
 cargo add faucet-stream --features source-mongodb
 ```
 
-## Quick Start
+`source-mongodb` is an opt-in feature — it is not part of the CLI or umbrella default build.
 
-```rust
-use faucet_source_mongodb::{MongoSource, MongoSourceConfig};
-use faucet_core::Source;
+## Quick start
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let config = MongoSourceConfig::new(
-        "mongodb://localhost:27017",
-        "my_database",
-        "users",
-    );
-
-    let source = MongoSource::new(config).await?;
-    let records = source.fetch_all().await?;
-
-    for record in &records {
-        println!("{}", record);
-    }
-    Ok(())
-}
+```yaml
+# pipeline.yaml — faucet run pipeline.yaml
+version: 1
+pipeline:
+  source:
+    type: mongodb
+    config:
+      connection_uri: mongodb://localhost:27017
+      database: shop
+      collection: orders
+      filter:
+        status: completed
+      sort:
+        created_at: 1
+      limit: 100000
+  sink:
+    type: jsonl
+    config:
+      path: ./orders.jsonl
 ```
 
-## Configuration
+```bash
+faucet run pipeline.yaml
+```
 
-### MongoSourceConfig
+## Configuration reference
+
+All fields live directly under the source `config:` block.
+
+### Core
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `connection_uri` | `String` | *(required)* | MongoDB connection URI (e.g. `mongodb://localhost:27017`). Masked in debug output for security |
-| `database` | `String` | *(required)* | Database name |
-| `collection` | `String` | *(required)* | Collection name |
-| `filter` | `Option<Value>` | `None` | Query filter as a JSON object, converted to a BSON `Document` at query time |
-| `projection` | `Option<Value>` | `None` | Field projection as a JSON object (e.g. `{"_id": 0, "name": 1}`) |
-| `sort` | `Option<Value>` | `None` | Sort specification as a JSON object (e.g. `{"created_at": -1}`) |
-| `limit` | `Option<i64>` | `None` | Maximum number of documents to return |
-| `cursor_batch_size` | `Option<u32>` | `None` | MongoDB driver cursor batch size (documents per server round-trip). Wire-level tuning knob — see [Streaming and batching](#streaming-and-batching) for how this differs from `batch_size` |
-| `batch_size` | `usize` | `1000` | Records per `StreamPage` emitted by `Source::stream_pages`. See [Streaming and batching](#streaming-and-batching) below |
+| `connection_uri` | string | — *(required)* | MongoDB connection URI (e.g. `mongodb://localhost:27017` or `mongodb+srv://…`). Credentials, options, and replica-set config all go here. Masked in `Debug` output. |
+| `database` | string | — *(required)* | Database name. |
+| `collection` | string | — *(required)* | Collection name. |
 
-> ⚠️ **Breaking rename**: the previous `batch_size: Option<u32>` field has been renamed to `cursor_batch_size` so that the new standardised `batch_size: usize` (records per `StreamPage`) can live alongside it. Existing JSON/YAML configs using `batch_size: <n>` now configure the *pipeline* page size — if you relied on it as the driver cursor knob, rename it to `cursor_batch_size`.
+### Query
 
-### Streaming and batching
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `filter` | object | *(none)* | Query filter as a JSON object, converted to a BSON `Document` at query time. Must be a JSON object — arrays/scalars error. Empty/unset matches all documents. |
+| `projection` | object | *(none)* | Field projection as a JSON object, e.g. `{"_id": 0, "name": 1}`. |
+| `sort` | object | *(none)* | Sort specification as a JSON object, e.g. `{"created_at": -1}`. |
+| `limit` | int (i64) | *(none)* | Maximum number of documents to return. Unset = no limit. |
 
-`MongoSource::stream_pages` drives the MongoDB driver cursor (`Collection::find`)
-without buffering the full result. Documents are accumulated into a
-`batch_size` buffer and yielded as a `StreamPage` once the buffer fills;
-the trailing partial page (if any) is yielded after the cursor drains.
+### Batching
 
-`batch_size = 0` is the **"no batching" sentinel** — the cursor is drained
-completely and the entire result set is emitted in a single `StreamPage`.
-Use it for small lookup tables, or for downstream sinks (SQL `COPY`,
-BigQuery load jobs, Snowflake stage uploads) that prefer one large request
-to many small ones. Values larger than `MAX_BATCH_SIZE` (1,000,000) are
-rejected by `faucet_core::validate_batch_size`.
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `batch_size` | int (usize) | `1000` | Records per emitted `StreamPage`. `0` is the **no-batching sentinel** — the cursor is fully drained and the entire result set is emitted in a single page. Values above `MAX_BATCH_SIZE` (1,000,000) are rejected at construction by `faucet_core::validate_batch_size`. |
+| `cursor_batch_size` | int (u32) | *(driver default, 101)* | The MongoDB driver's per-round-trip batch size (`find().batch_size(N)`). Independent of `batch_size` — see [Streaming & batching](#streaming--batching). |
 
-`cursor_batch_size` is the **MongoDB driver's per-round-trip batch size**
-(`find().batch_size(N)`). It is independent of the pipeline-level
-`batch_size`: you can have the driver fetch 100 docs per round-trip and
-still yield `StreamPage`s of 1000 docs (or vice versa), trading network
-round-trips for buffering. Leave it unset to use the MongoDB driver's
-default (101 documents).
+> **Note on the rename:** an earlier release used a single `batch_size: Option<u32>` that mapped to the driver cursor knob. That field is now `cursor_batch_size`, and the standardized `batch_size: usize` (records per `StreamPage`) lives alongside it. A config that previously used `batch_size: <n>` as the driver knob should rename it to `cursor_batch_size`.
 
-The MongoDB source has no incremental-replication mode, so every emitted
-page carries `bookmark: None`.
+## Authentication
 
-### BSON Conversion
+MongoDB authentication is configured **inside the connection URI** — this connector does not take a separate `auth:` block or participate in the shared `auth:` catalog. Put credentials, auth source, and TLS options in the URI:
 
-All JSON filter, projection, and sort values are automatically converted to BSON documents at query time. The JSON values must be objects -- arrays and scalars will produce an error. Documents returned from MongoDB are converted back to relaxed extended JSON format.
+```yaml
+# Username / password (SCRAM)
+connection_uri: mongodb://appuser:s3cret@db1.example.com:27017/?authSource=admin
 
-## Config Loading
+# Atlas / SRV with TLS
+connection_uri: mongodb+srv://appuser:s3cret@cluster0.abcde.mongodb.net/?retryWrites=true&w=majority
+```
 
-```rust
+To keep the password out of the config file, use a secrets directive (`${env:…}`, `${vault:…}`, `${aws-sm:…}`, …) on the URI:
+
+```yaml
+config:
+  connection_uri: ${env:MONGO_URI}
+```
+
+## Examples
+
+### Filtered query with projection and sort
+
+```yaml
+# MongoDB → PostgreSQL JSONB
+version: 1
+name: mongodb_to_postgres
+pipeline:
+  source:
+    type: mongodb
+    config:
+      connection_uri: mongodb://localhost:27017
+      database: shop
+      collection: orders
+      filter:
+        status: completed
+      projection:
+        _id: 1
+        customer_id: 1
+        total: 1
+        items: 1
+      sort:
+        created_at: 1
+      limit: 500000
+      cursor_batch_size: 1000
+  sink:
+    type: postgres
+    config:
+      connection_url: postgres://user:pass@localhost/warehouse
+      table_name: orders_mirror
+      column_mapping:
+        type: jsonb
+        column: payload
+      batch_size: 1000
+      max_connections: 10
+```
+
+### Operator-rich filter, large pages
+
+```yaml
+version: 1
+pipeline:
+  source:
+    type: mongodb
+    config:
+      connection_uri: ${env:MONGO_URI}
+      database: analytics
+      collection: events
+      filter:
+        event_type: purchase
+        amount: { $gt: 100 }
+      projection:
+        _id: 0
+        user_id: 1
+        amount: 1
+      sort:
+        amount: -1
+      batch_size: 5000          # 5k docs per StreamPage
+      cursor_batch_size: 500    # 500 docs per server round-trip
+  sink:
+    type: elasticsearch
+    config:
+      url: http://localhost:9200
+      index: events
+```
+
+### Small lookup table — one page, no batching
+
+```yaml
+version: 1
+pipeline:
+  source:
+    type: mongodb
+    config:
+      connection_uri: mongodb://localhost:27017
+      database: ref
+      collection: countries
+      batch_size: 0             # drain the whole cursor into a single page
+  sink:
+    type: stdout
+    config:
+      format: jsonl
+```
+
+### Per-parent context interpolation (matrix fan-out)
+
+`{key}` placeholders inside `filter`/`projection`/`sort` are resolved per parent record at runtime (JSON-safe), so a child row can scope its query to each parent:
+
+```yaml
+filter:
+  tenant_id: "{tenant_id}"      # resolved from the parent record's `tenant_id`
+```
+
+## Streaming & batching
+
+`MongoSource::stream_pages` drives the driver cursor (`Collection::find`) without buffering the full result. Documents are accumulated into a `batch_size` buffer and yielded as a `StreamPage` once the buffer fills; the trailing partial page (if any) is yielded after the cursor drains. The pipeline writes each page to the sink as it arrives, so memory is bounded by `batch_size × document_width`, not by the size of the collection or result set.
+
+- **`batch_size = 0`** is the no-batching sentinel — the cursor is drained completely and the entire result set is emitted in one `StreamPage`. Use it for small lookup tables, or for sinks (SQL `COPY`, BigQuery load jobs, Snowflake stage uploads) that prefer one large request to many small ones.
+- The trait-level `batch_size` argument passed to `stream_pages` is **ignored** in favour of the config field — the config is the authoritative knob, so a pipeline-supplied hint can never silently override an explicit config value.
+
+`cursor_batch_size` is a **different, lower-level knob**: it sets the MongoDB driver's per-round-trip batch size (`find().batch_size(N)`). It is independent of the pipeline-level `batch_size` — you can have the driver fetch 100 docs per round-trip and still yield `StreamPage`s of 1000 docs (or vice versa), trading network round-trips against buffering. Leave it unset to use the driver default (101 documents).
+
+Every emitted page carries `bookmark: None` — the MongoDB source has no incremental-replication mode (see [Resume & state](#resume--state)).
+
+## Resume & state
+
+This source is **not resumable** and does not support exactly-once delivery. It runs a single `find()` per invocation and emits `bookmark: None` on every page, so no durable position is written and a re-run replays the full query. For change-data-capture with resumable resume tokens and exactly-once semantics, use [faucet-source-mongodb-cdc](https://crates.io/crates/faucet-source-mongodb-cdc) instead.
+
+To approximate incremental loads with this query source, add a high-watermark clause to `filter` and parameterize it (e.g. `created_at: { $gt: "${env:SINCE}" }`) at the orchestration layer.
+
+## BSON ↔ JSON conversion
+
+- **Inputs** (`filter`, `projection`, `sort`) are converted from JSON to BSON `Document`s at query time. Each must be a JSON **object** — passing an array or scalar produces a `FaucetError::Config`.
+- **Outputs** — documents returned from MongoDB are rendered as **relaxed extended JSON**:
+
+| BSON type | JSON shape |
+|---|---|
+| `ObjectId` | `{"$oid": "<hex>"}` |
+| `DateTime` (post-1970) | `{"$date": "<RFC3339>"}` |
+| `Int32` / `Int64` | bare number |
+| `Double` | bare number |
+| `Boolean` | `true` / `false` |
+| `String` | string |
+| `Null` | JSON `null` |
+| `Array` | array |
+| embedded `Document` | nested object |
+
+If a sink needs flat scalar columns instead of the `{"$oid": …}` / `{"$date": …}` wrappers, add a transform (e.g. `set` / `rename_field` / `cast`) between the source and sink.
+
+## Config loading & schema
+
+Load config from a JSON file or environment in library code:
+
+```rust,no_run
 use faucet_core::config::{load_json, load_env_file};
 use faucet_source_mongodb::MongoSourceConfig;
 
-let config: MongoSourceConfig = load_json("config.json")?;
-let config: MongoSourceConfig = load_env_file(".env", "MONGO_SOURCE")?;
+# fn example() -> Result<(), Box<dyn std::error::Error>> {
+let from_file: MongoSourceConfig = load_json("config.json")?;
+let from_env: MongoSourceConfig = load_env_file(".env", "MONGO_SOURCE")?;
+# Ok(()) }
 ```
 
-### Example JSON config
-
-```json
-{
-  "connection_uri": "mongodb://admin:password@mongo.example.com:27017",
-  "database": "analytics",
-  "collection": "events",
-  "filter": {
-    "event_type": "purchase",
-    "timestamp": { "$gte": "2025-01-01T00:00:00Z" }
-  },
-  "projection": {
-    "_id": 0,
-    "user_id": 1,
-    "event_type": 1,
-    "amount": 1,
-    "timestamp": 1
-  },
-  "sort": { "timestamp": -1 },
-  "limit": 10000,
-  "cursor_batch_size": 500,
-  "batch_size": 5000
-}
-```
-
-### Example .env file
+Example `.env`:
 
 ```env
 MONGO_SOURCE_CONNECTION_URI=mongodb://localhost:27017
@@ -137,90 +269,95 @@ MONGO_SOURCE_CURSOR_BATCH_SIZE=200
 MONGO_SOURCE_BATCH_SIZE=1000
 ```
 
-## Config Schema Introspection
+Inspect the full JSON Schema from the CLI:
 
-```rust
-use faucet_core::Source;
-
-let source = MongoSource::new(config).await?;
-let schema = source.config_schema();
-println!("{}", serde_json::to_string_pretty(&schema)?);
+```bash
+faucet schema source mongodb
 ```
 
-## Examples
+## Library usage
 
-### Simple collection read
-
-```rust
-use faucet_source_mongodb::{MongoSource, MongoSourceConfig};
-use faucet_core::Source;
-
-let config = MongoSourceConfig::new(
-    "mongodb://localhost:27017",
-    "mydb",
-    "customers",
-);
-let source = MongoSource::new(config).await?;
-let customers = source.fetch_all().await?;
-```
-
-### Filtered query with projection and sort
-
-```rust
+```rust,no_run
 use faucet_source_mongodb::{MongoSource, MongoSourceConfig};
 use faucet_core::Source;
 use serde_json::json;
 
+# async fn example() -> Result<(), Box<dyn std::error::Error>> {
 let config = MongoSourceConfig::new(
     "mongodb://localhost:27017",
     "ecommerce",
     "orders",
 )
-.filter(json!({
-    "status": "completed",
-    "total": { "$gt": 100 }
-}))
-.projection(json!({
-    "_id": 0,
-    "order_id": 1,
-    "customer": 1,
-    "total": 1,
-    "items": 1
-}))
-.sort(json!({"total": -1}))
+.filter(json!({ "status": "completed", "total": { "$gt": 100 } }))
+.projection(json!({ "_id": 0, "order_id": 1, "total": 1 }))
+.sort(json!({ "total": -1 }))
 .limit(500)
-.cursor_batch_size(100);
+.cursor_batch_size(100)
+.with_batch_size(2000);
 
 let source = MongoSource::new(config).await?;
+
+// One-shot collect:
 let orders = source.fetch_all().await?;
-println!("Found {} high-value orders", orders.len());
+println!("found {} high-value orders", orders.len());
+# Ok(()) }
 ```
 
-### Using with a Pipeline
+Drive it through a `Pipeline` to stream into a sink:
 
-```rust
+```rust,no_run
 use faucet_source_mongodb::{MongoSource, MongoSourceConfig};
-use faucet_core::{Pipeline, Source, Sink};
+use faucet_core::{Pipeline, Source};
 use serde_json::json;
 
-let config = MongoSourceConfig::new(
-    "mongodb://mongo.production.com:27017",
-    "logs",
-    "app_events",
-)
-.filter(json!({"level": "error"}))
-.sort(json!({"timestamp": -1}))
-.limit(10000);
+# async fn example(my_sink: Box<dyn faucet_core::Sink>) -> Result<(), Box<dyn std::error::Error>> {
+let source = MongoSource::new(
+    MongoSourceConfig::new("mongodb://localhost:27017", "logs", "app_events")
+        .filter(json!({ "level": "error" }))
+        .sort(json!({ "timestamp": -1 }))
+        .limit(10_000),
+).await?;
 
-let source = MongoSource::new(config).await?;
-let pipeline = Pipeline::new(Box::new(source), Box::new(my_sink));
+let pipeline = Pipeline::new(Box::new(source), my_sink);
 let result = pipeline.run().await?;
+# let _ = result;
+# Ok(()) }
 ```
+
+## How it works
+
+- The MongoDB `Client` (and its internal connection pool) is created **once** in `MongoSource::new()` from the connection URI and reused for every `fetch_all()` / `stream_pages()` call — never recreated per query.
+- `stream_pages` opens a single cursor with `FindOptions` (`projection` / `sort` / `limit` / `cursor_batch_size`) and pulls documents with `cursor.advance()`; each is deserialized to a BSON `Document` and converted to relaxed extended JSON, then pushed into the page buffer. A page is yielded when the buffer reaches `batch_size` (or at end-of-cursor for the trailing partial page).
+- `batch_size` is validated against `MAX_BATCH_SIZE` at construction, so an out-of-range value fails fast with `FaucetError::Config` rather than mid-run.
+- Context interpolation serializes the JSON `filter`/`projection`/`sort`, runs JSON-safe placeholder substitution, then re-parses — so a `{key}` value containing quotes can't break JSON validity.
 
 ## Lineage dataset URI
 
-`mongodb://<host>:<port>/<database>/<collection>` (credentials stripped) — e.g. `mongodb://host:27017/mydb/events`.
+`mongodb://<host>:<port>/<database>/<collection>` with credentials stripped — e.g. `mongodb://host:27017/mydb/events`.
+
+## Feature flags
+
+This crate has no optional features of its own. Enable it in the CLI / umbrella crate via the `source-mongodb` feature.
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause & fix |
+|---------|--------------------|
+| `FaucetError::Source: MongoDB connection failed` | Bad URI, unreachable host, wrong port, or auth rejected. Verify `connection_uri`, network reachability, and `authSource`. For Atlas, ensure your IP is allowlisted. |
+| `FaucetError::Source: MongoDB find failed` | Invalid filter/sort against the collection (e.g. sorting on an unindexed field past the in-memory sort limit), or insufficient read privileges. Check the query and the user's role. |
+| `FaucetError::Config: expected a JSON object, got BSON type …` | `filter`, `projection`, or `sort` was a JSON array or scalar. Each must be a JSON **object** (`{}`). |
+| `FaucetError::Config` mentioning `batch_size` | `batch_size` exceeds `MAX_BATCH_SIZE` (1,000,000). Lower it, or use `0` for a single page. |
+| Results come back with `{"$oid": …}` / `{"$date": …}` wrappers | Intentional — relaxed extended JSON preserves BSON types. Add a transform to flatten them if the sink needs plain scalars. |
+| Query is much slower than expected | High-cardinality `sort` without a supporting index forces an in-memory sort (capped server-side). Add an index, or lower `limit`. Tune `cursor_batch_size` to cut round-trips. |
+| `mongodb+srv://` URI fails to resolve | SRV requires DNS SRV/TXT records (Atlas provides them). Confirm DNS resolution from the host, or use the standard `mongodb://` seed-list form. |
+| Re-running reprocesses everything | Expected — this query source is not resumable. Use [faucet-source-mongodb-cdc](https://crates.io/crates/faucet-source-mongodb-cdc) for resumable change capture, or add a watermark to `filter`. |
+
+## See also
+
+- [Connector reference](https://pawansikawat.github.io/faucet-stream/reference/connectors.html) · [Choosing a connector](https://pawansikawat.github.io/faucet-stream/reference/choosing.html)
+- [faucet-source-mongodb-cdc](https://crates.io/crates/faucet-source-mongodb-cdc) — resumable, exactly-once change capture from MongoDB.
+- [faucet-sink-mongodb](https://crates.io/crates/faucet-sink-mongodb) — write into MongoDB (with upsert/delete write modes).
 
 ## License
 
-Licensed under MIT or Apache-2.0.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/source/mongodb/README.md
+++ b/crates/source/mongodb/README.md
@@ -2,6 +2,8 @@
 
 [![Crates.io](https://img.shields.io/crates/v/faucet-source-mongodb.svg)](https://crates.io/crates/faucet-source-mongodb)
 [![Docs.rs](https://docs.rs/faucet-source-mongodb/badge.svg)](https://docs.rs/faucet-source-mongodb)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-source-mongodb.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-source-mongodb.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
 A MongoDB source that executes `find()` queries with filter, projection, sort, and limit, returning documents as JSON records.
 

--- a/crates/source/mssql/README.md
+++ b/crates/source/mssql/README.md
@@ -1,59 +1,229 @@
 # faucet-source-mssql
 
-Microsoft SQL Server query source for the
-[`faucet-stream`](https://crates.io/crates/faucet-stream) ecosystem. Runs
-parameterized SQL, streams rows as JSON, and supports incremental replication
-via a tracking column. Built on [`tiberius`](https://crates.io/crates/tiberius)
-+ [`bb8-tiberius`](https://crates.io/crates/bb8-tiberius).
+[![Crates.io](https://img.shields.io/crates/v/faucet-source-mssql.svg)](https://crates.io/crates/faucet-source-mssql)
+[![Docs.rs](https://docs.rs/faucet-source-mssql/badge.svg)](https://docs.rs/faucet-source-mssql)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-source-mssql.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-source-mssql.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-## Config
+Microsoft **SQL Server** query source for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem. Runs a parameterized T-SQL statement over a pooled [`tiberius`](https://crates.io/crates/tiberius) connection, decodes each row into a typed `serde_json::Value`, and streams the result set back page-by-page so memory stays bounded regardless of how many rows the query returns.
 
-```yaml
-source:
-  type: mssql
-  config:
-    # connection_url OR connection_string (exactly one)
-    connection_url: "mssql://sa:Str0ng%40Pass@localhost:1433/sales"
-    # connection_string: "Server=tcp:localhost,1433;Database=sales;User Id=sa;Password=...;"
+Reach for it when you want to pull tables, views, or ad-hoc query results out of SQL Server (or Azure SQL) and land them in any faucet-stream sink — a file, another database, a warehouse, a queue — with one declarative config and no glue code. Built-in incremental replication lets repeat runs pick up only the rows that changed since last time.
 
-    query: "SELECT id, email, updated_at FROM dbo.users WHERE updated_at > @bookmark"
+## Feature highlights
 
-    params: []                 # positional @P1, @P2, … bind params
-    max_connections: 10
-    batch_size: 1000           # rows per emitted page; 0 = whole result set in one page
-    statement_timeout_secs: 300  # 0 disables
+- **Native row streaming** — overrides `Source::stream_pages` to walk `tiberius`'s `QueryStream` row-by-row, buffering into pages of `batch_size` and yielding each page as it fills. Peak memory is `O(batch_size)`, never the full result set.
+- **Connection pooling** — a [`bb8`](https://crates.io/crates/bb8) + [`bb8-tiberius`](https://crates.io/crates/bb8-tiberius) pool is built once in `new()` and reused for every query; size it with `max_connections` (default 10).
+- **Incremental / bookmark replication** — track a monotonic column (e.g. `updated_at`) and emit only rows strictly greater than the stored bookmark on each run. The cursor pushes down to the server via the `@bookmark` token *and* is enforced client-side as a correctness backstop.
+- **Positional bind parameters** — `params` are sent as `@P1`, `@P2`, … bind values, and `${parent.path}` matrix-context placeholders resolve to additional bind markers at runtime — no string interpolation into SQL.
+- **Type-aware row decoding** — integers, floats, `BIT`, decimals (precision-preserving strings), dates/times, `DATETIMEOFFSET`, `UNIQUEIDENTIFIER`, and binary (base64) all map to sensible JSON.
+- **Four TLS modes** — `prefer` (default), `require`, `trust_server_certificate`, `disable` — with an optional CA cert path, shared with the MSSQL sink via [`faucet-common-mssql`](https://crates.io/crates/faucet-common-mssql).
+- **Per-query timeout** — `statement_timeout_secs` bounds each query (default 300s; `0` disables).
+- **Credentials never logged** — the `Debug` impl masks the connection config, and the lineage URI strips credentials.
 
-    tls:
-      type: prefer             # prefer | require | trust_server_certificate | disable
-      ca_cert_path: null
+## Installation
 
-    replication:
-      type: incremental        # full | incremental
-      column: updated_at
-      initial_value: "1970-01-01T00:00:00Z"
+```bash
+# As a library:
+cargo add faucet-source-mssql
+
+# In the CLI (opt-in connector feature):
+cargo install faucet-cli --features source-mssql
 ```
 
-URL credentials with special characters must be percent-encoded
-(`@`→`%40`, `:`→`%3A`, `/`→`%2F`). See
-[`faucet-common-mssql`](https://crates.io/crates/faucet-common-mssql) for the
-full connection / TLS reference.
+This is an opt-in connector — it is not in the CLI default build. Enable it with the `source-mssql` feature (or the `source` / `full` aggregates).
 
-## Incremental replication
+## Quick start
 
-Set `replication.type: incremental` with a `column` (the cursor) and an
-`initial_value` (the lower bound on the first run). Across runs the source emits
-only rows whose `column` is strictly greater than the stored bookmark, and
-persists the new maximum on the final page.
+```yaml
+# pipeline.yaml — faucet run pipeline.yaml
+version: 1
+pipeline:
+  source:
+    type: mssql
+    config:
+      connection_url: "mssql://sa:Str0ng%40Pass@localhost:1433/sales"
+      query: "SELECT id, email, updated_at FROM dbo.users"
+  sink:
+    type: jsonl
+    config:
+      path: ./users.jsonl
+```
 
-- **Server-side pushdown:** put the literal token `@bookmark` in your `WHERE`
-  clause (e.g. `WHERE updated_at > @bookmark`). The source binds the cursor
-  there so SQL Server does the filtering.
-- **Backstop:** whether or not you use `@bookmark`, the source *also* filters
-  client-side, so correctness never depends on the query text. (Without
-  `@bookmark` the full result set is fetched and filtered in memory — fine for
-  small tables, but prefer `@bookmark` for large ones.)
+```bash
+faucet run pipeline.yaml
+```
 
-`@bookmark` is a reserved token; don't use it as an identifier.
+> URL credentials with special characters must be percent-encoded (`@` → `%40`, `:` → `%3A`, `/` → `%2F`).
+
+## Configuration reference
+
+### Core
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `connection_url` | string | — | `mssql://user:pass@host:1433/database` URL form. **Mutually exclusive** with `connection_string`; set exactly one. Host required; port defaults to `1433`; database optional. Credentials are percent-decoded. |
+| `connection_string` | string | — | ADO.NET-style string handed straight to `tiberius`, e.g. `Server=tcp:host,1433;Database=db;User Id=sa;Password=...;`. **Mutually exclusive** with `connection_url`. The `tls` block is applied on top. |
+| `query` | string | — *(required)* | T-SQL to run. Use `@P1`, `@P2`, … for `params`, and the literal `@bookmark` token to bind the incremental cursor server-side. |
+| `params` | array | `[]` | Positional bind parameters (`@P1`…`@Pn`), typed from each JSON value. Sent in declaration order, before any matrix-context values. |
+
+### Batching & reliability
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `max_connections` | int | `10` | Maximum pooled connections. |
+| `batch_size` | int | `1000` | Records per emitted `StreamPage`. **`0` = no batching**: the entire result set is emitted as a single page (good for small lookup tables, or sinks that prefer one large request). |
+| `statement_timeout_secs` | int (seconds) | `300` | Per-query timeout. **`0` disables** (wait indefinitely). |
+| `state_key` | string | *(derived)* | Explicit state-store key for the incremental bookmark. When unset, a stable key is derived from the connection host plus a fingerprint of the query. |
+
+### Replication
+
+`replication` is a tagged enum (`{ type: full | incremental, … }`):
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `replication.type` | `full` \| `incremental` | `full` | `full` re-fetches the whole result set every run; `incremental` emits only rows past the bookmark. |
+| `replication.column` | string | — *(required for `incremental`)* | The column whose value is the replication cursor (e.g. `updated_at`). Must be non-empty. |
+| `replication.initial_value` | any JSON | — *(required for `incremental`)* | Lower bound used on the first run, before any bookmark is stored. |
+
+### TLS
+
+`tls` matches the YAML shape `tls: { type: <mode>, ca_cert_path: <path> }`:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `tls.type` | enum | `prefer` | Encryption mode — see the table below. |
+| `tls.ca_cert_path` | path | *(unset)* | Optional CA certificate (PEM/DER) to trust for server validation. Ignored when `tls.type` is `disable`. |
+
+| `tls.type` | Behavior |
+|------------|----------|
+| `prefer` | Encrypt if the server supports it — the safe modern default. |
+| `require` | Require encryption; fail if the server does not offer it. |
+| `trust_server_certificate` | Encrypt and accept the server certificate **without validating its chain** (self-signed dev servers). **Insecure against MITM — never use in production.** |
+| `disable` | No transport encryption. |
+
+## Authentication
+
+SQL Server authentication (username + password) only, supplied inline in the `connection_url` or `connection_string`. Windows / Integrated authentication and Azure AD / Managed Identity are out of scope in v1.
+
+```yaml
+# URL form — percent-encode special characters in the password
+config:
+  connection_url: "mssql://sa:Str0ng%40Pass@localhost:1433/sales"
+```
+
+```yaml
+# ADO.NET connection-string form
+config:
+  connection_string: "Server=tcp:db.example.com,1433;Database=sales;User Id=sa;Password=${env:MSSQL_PASSWORD};"
+```
+
+Keep secrets out of the YAML by referencing the environment or a secrets manager — e.g. `Password=${env:MSSQL_PASSWORD}` or `${vault:secret/mssql#password}`.
+
+## Examples
+
+### Full table export to JSONL
+
+```yaml
+version: 1
+pipeline:
+  source:
+    type: mssql
+    config:
+      connection_url: "mssql://sa:Str0ng%40Pass@localhost:1433/sales"
+      query: "SELECT id, email, created_at FROM dbo.users"
+      batch_size: 5000
+  sink:
+    type: jsonl
+    config:
+      path: ./users.jsonl
+```
+
+### Incremental replication with a bookmark
+
+```yaml
+version: 1
+name: mssql_to_jsonl
+pipeline:
+  source:
+    type: mssql
+    config:
+      connection_url: "mssql://sa:Str0ng%40Pass@localhost:1433/sales"
+      query: "SELECT id, email, updated_at FROM dbo.users WHERE updated_at > @bookmark ORDER BY updated_at"
+      batch_size: 1000
+      tls:
+        type: trust_server_certificate   # self-signed dev cert; use prefer/require in prod
+      replication:
+        type: incremental
+        column: updated_at
+        initial_value: "1970-01-01T00:00:00Z"
+  sink:
+    type: jsonl
+    config:
+      path: ./out/users.jsonl
+      append: true
+  state:
+    type: file
+    config:
+      path: ./.faucet-state
+```
+
+### Parameterized query with bind values
+
+```yaml
+version: 1
+pipeline:
+  source:
+    type: mssql
+    config:
+      connection_url: "mssql://sa:Str0ng%40Pass@localhost:1433/sales"
+      query: "SELECT id, total FROM dbo.orders WHERE region = @P1 AND total > @P2"
+      params:
+        - "EMEA"
+        - 100
+  sink:
+    type: stdout
+    config:
+      format: jsonl
+```
+
+### Hardened production connection
+
+```yaml
+version: 1
+pipeline:
+  source:
+    type: mssql
+    config:
+      connection_url: "mssql://etl_user:${env:MSSQL_PASSWORD}@sql.internal:1433/warehouse"
+      query: "SELECT * FROM dbo.fact_sales"
+      max_connections: 20
+      statement_timeout_secs: 120
+      tls:
+        type: require
+        ca_cert_path: /etc/ssl/certs/corp-ca.pem
+  sink:
+    type: parquet
+    config:
+      path: ./fact_sales.parquet
+```
+
+## Streaming & batching
+
+The source overrides `Source::stream_pages`: it checks out a pooled connection, runs the query, and walks `tiberius`'s row stream. Rows are decoded and buffered until the buffer reaches `batch_size`, at which point a `StreamPage` is yielded; the final page carries the incremental bookmark (when replication is enabled) so the pipeline persists state only after every prior page has been written by the sink. With `batch_size: 0` the whole result set is buffered and emitted as one page.
+
+The `batch_size` argument the pipeline passes to `stream_pages` is informational — the config field is authoritative, so a pipeline-supplied hint never overrides an explicit value.
+
+## Resume & state
+
+When `replication.type: incremental`, the source is resumable:
+
+- `state_key()` returns the configured `state_key`, or a key derived from the connection host plus a query fingerprint (e.g. `mssql:db.example.com:<hex>`).
+- Before fetching, the pipeline loads the stored bookmark and hands it to `apply_start_bookmark()`, which overrides the configured `initial_value` for that run.
+- Each page is filtered to rows strictly greater than the bookmark on `replication.column`, and the running maximum is persisted on the final page **after** the sink confirms the batch — so a crash mid-run never advances the bookmark past unwritten rows.
+
+**Server-side pushdown:** put the literal `@bookmark` token in your `WHERE` clause (e.g. `WHERE updated_at > @bookmark ORDER BY updated_at`). The source binds the cursor there as a parameter so SQL Server does the filtering. **Backstop:** whether or not `@bookmark` appears, the source *also* filters client-side, so correctness never depends on the query text — though without `@bookmark` the full result set is fetched and filtered in memory (fine for small tables, prefer `@bookmark` for large ones). `@bookmark` is a reserved token; don't use it as an identifier.
+
+To use resume from the CLI, add a `state:` block (`file`, `memory`, `redis`, or `postgres`) to the pipeline as shown in the incremental example above.
 
 ## Type mapping
 
@@ -72,21 +242,75 @@ persists the new maximum on the final page.
 | BINARY / VARBINARY / IMAGE | base64 string |
 | SQL NULL | `null` |
 
-## Auth
+## Config loading & schema
 
-SQL Server authentication (username + password) only in v1. Windows / Integrated
-authentication and Azure AD / Managed Identity are out of scope.
+Load from YAML/JSON or environment. Inspect the full JSON Schema with:
 
-## Testing
+```bash
+faucet schema source mssql
+```
 
-Unit tests run with `cargo test -p faucet-source-mssql --lib`. The integration
-tests (`--test integration`) require Docker (the `mcr.microsoft.com/mssql/server`
-image).
+## Library usage
+
+```rust
+use faucet_core::Source;
+use faucet_source_mssql::{MssqlSource, MssqlSourceConfig};
+
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let cfg = MssqlSourceConfig::new(
+    "mssql://sa:Str0ng%40Pass@localhost:1433/sales",
+    "SELECT id, email, updated_at FROM dbo.users",
+);
+
+let source = MssqlSource::new(cfg).await?;
+let rows = source.fetch_all().await?;
+println!("rows: {rows:?}");
+# Ok(())
+# }
+```
+
+For incremental replication, set `cfg.replication` to `MssqlReplication::Incremental { column, initial_value }` and drive the source through a `Pipeline` with a `StateStore` so the bookmark persists across runs. The shared connection/TLS types (`MssqlConnectionConfig`, `MssqlTls`, `MssqlTlsMode`) are re-exported from this crate, so you don't need to depend on `faucet-common-mssql` directly.
+
+## How it works
+
+1. `new()` validates the config, then builds the `bb8` + `bb8-tiberius` connection pool **once** via `faucet-common-mssql::build_pool` (TLS mode applied).
+2. Each query checks out a pooled connection, binds `params` (and the bookmark, when `@bookmark` is present) as typed `@Pn` parameters, and runs under `statement_timeout_secs`.
+3. `tiberius`'s `QueryStream` is walked row-by-row; each row is decoded by its column type into JSON and buffered into `batch_size` pages.
+4. For incremental runs, each page is filtered against the bookmark and the running maximum is tracked; the bookmark is emitted on the final page so the pipeline persists it only after the sink confirms.
+5. `connector_name()` reports `"mssql"` for metrics labels; `check()` probes a pooled connection for `faucet doctor`.
 
 ## Lineage dataset URI
 
-`mssql://<host>,<port>/<db>?query=<sql>` (credentials/password stripped from connection string) — e.g. `Server=tcp:host,1433;Database=db;User Id=sa;Password=***;?query=SELECT id FROM orders`.
+`<connection>?query=<sql>` with credentials stripped — e.g. `mssql://db.example.com:1433/sales?query=SELECT id FROM orders`. Emitted automatically when lineage is enabled in the CLI.
+
+## Feature flags
+
+This crate has no optional features of its own; enable it in the CLI/umbrella via the `source-mssql` feature (included in the `source` and `full` aggregates, but not in the CLI default build).
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause & fix |
+|---------|--------------------|
+| `Config: MSSQL config requires either connection_url or connection_string` | Neither was set. Provide exactly one. |
+| `Config: MSSQL config sets both connection_url and connection_string` | Both were set. Remove one — they are mutually exclusive. |
+| `Config: invalid MSSQL connection_url` / scheme error | The URL is malformed or uses the wrong scheme. Use `mssql://` (or `sqlserver://`) and percent-encode special characters in the password (`@` → `%40`, `:` → `%3A`, `/` → `%2F`). |
+| `Source: MSSQL pool checkout failed` / connect timeout | Server unreachable, wrong host/port, bad credentials, or a TLS mismatch. Verify the server is listening on `1433`, the login works, and the `tls` mode matches what the server offers. |
+| TLS handshake fails against a self-signed dev server | Set `tls.type: trust_server_certificate` for local dev (never in production), or point `tls.ca_cert_path` at the server's CA. |
+| `Source: MSSQL query timed out` | The query ran longer than `statement_timeout_secs`. Raise the timeout (or set `0` to disable), and add the right indexes / `WHERE` clause. |
+| Incremental run re-emits old rows | No bookmark is being persisted — add a `state:` block, and make sure `replication.column` is the same monotonic column you filter on. |
+| Incremental run is slow on a large table | Add `@bookmark` to the `WHERE` clause so filtering pushes down to the server instead of fetching every row and filtering in memory. |
+| `Config: MSSQL incremental replication requires a non-empty column` | `replication.type` is `incremental` but `column` is empty. Set it to the cursor column. |
+| A `DECIMAL`/`MONEY` column arrives as a string | Intentional — decimals are decoded as strings to preserve full precision. Cast in a downstream transform if you need a JSON number. |
+| Windows / Azure AD login required | Not supported in v1 — only SQL Server username/password authentication. |
+
+## See also
+
+- [SQL Server connector docs](https://pawansikawat.github.io/faucet-stream/reference/connectors.html)
+- [State & incremental replication cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/state.html)
+- [Configuration grammar reference](https://pawansikawat.github.io/faucet-stream/reference/config.html)
+- [`faucet-common-mssql`](https://crates.io/crates/faucet-common-mssql) — shared connection/TLS/pool types.
+- [`faucet-sink-mssql`](https://crates.io/crates/faucet-sink-mssql) — the matching SQL Server sink.
 
 ## License
 
-MIT OR Apache-2.0.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/source/mysql-cdc/README.md
+++ b/crates/source/mysql-cdc/README.md
@@ -1,14 +1,39 @@
 # faucet-source-mysql-cdc
 
-MySQL CDC (Change Data Capture) source for [`faucet-stream`](https://github.com/PawanSikawat/faucet-stream). Tails the MySQL binary log via row-based replication and emits per-row change events (insert, update, delete, and optionally DDL) as JSON records. Bookmarks are persisted as binlog file/position coordinates, so pipelines resume exactly where they left off after a restart — no duplicates, no gap.
+[![Crates.io](https://img.shields.io/crates/v/faucet-source-mysql-cdc.svg)](https://crates.io/crates/faucet-source-mysql-cdc)
+[![Docs.rs](https://docs.rs/faucet-source-mysql-cdc/badge.svg)](https://docs.rs/faucet-source-mysql-cdc)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-source-mysql-cdc.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-source-mysql-cdc.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-**Targets transactional InnoDB tables.** Commits arrive as `XidEvent`; explicit `COMMIT` statements from non-transactional or mixed-engine workloads are also handled with identical durability semantics. Each committed transaction is emitted as its own `StreamPage` with a bookmark attached — uncommitted partial transactions are discarded at idle timeout and re-delivered from the last persisted bookmark on the next run.
+MySQL **Change Data Capture (CDC)** source for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem. Tails the MySQL binary log via row-based replication and emits every `INSERT` / `UPDATE` / `DELETE` (and optionally DDL) as a structured JSON change event.
 
----
+Reach for it when you want to mirror a MySQL database into a warehouse, lake, queue, or search index in near-real-time — without polling, without modifying the source schema, and without dropping a single committed row. Bookmarks are persisted as binlog `{ file, pos }` coordinates, so a restarted pipeline resumes from the exact position it left off: no gap, no duplicate.
+
+## Feature highlights
+
+- **Row-level change events** — each committed transaction is decoded from the binlog into a Debezium-style envelope (`op` / `before` / `after` / `lsn` / `txid`) and emitted as JSON.
+- **Per-transaction durability** — every committed transaction is its own `StreamPage` with a `{ file, pos }` bookmark attached, so the pipeline persists progress per commit. Uncommitted partial transactions never leak: they're buffered in memory and discarded at idle timeout, then re-delivered from the last persisted bookmark on the next run.
+- **Resumable** — overrides `state_key()` / `apply_start_bookmark()`; on resume the binlog stream reopens from the persisted file/position.
+- **Exactly-once delivery** — `supports_exactly_once()` is `true`. Pair with an idempotent sink (postgres / mysql / mssql / sqlite / iceberg / bigquery) + a state store for end-to-end exactly-once semantics, gated and validated by the CLI.
+- **Snapshot → CDC handoff** — implements `capture_resume_position()` (anchor the binlog *before* a bulk snapshot); `faucet replicate` uses it to build a gap-free, duplicate-free mirror. Works against MySQL **5.7 / 8.0 / 8.4+** — current-position capture tries `SHOW BINARY LOG STATUS` (8.4) and falls back to `SHOW MASTER STATUS` (5.7 / 8.0).
+- **Client-side table filtering** — `include_tables` / `exclude_tables` allowlist/blocklist by fully-qualified `database.table`.
+- **Flexible start positions** — `current`, `earliest`, explicit `file_pos`, or `gtid_set`.
+- **TLS** — `disable` / `require` / `verify_ca` / `verify_full` for the replication connection.
+- **OOM guard** — `max_staged_records` caps a single in-progress transaction's in-memory buffer and aborts cleanly rather than risking OOM on an unexpectedly huge transaction.
+
+## Installation
+
+```bash
+# As a library:
+cargo add faucet-source-mysql-cdc
+
+# In the CLI (opt-in connector feature):
+cargo install faucet-cli --features source-mysql-cdc
+```
 
 ## Server prerequisites
 
-Before connecting, the MySQL server must have binary logging configured for row-based replication. All four settings are verified at startup; the connector fails with a clear error if any are missing.
+The MySQL server must have binary logging configured for **row-based** replication. All four settings are verified at startup; the connector fails fast with a clear error if any are missing.
 
 ### Required server variables
 
@@ -16,18 +41,18 @@ Set these in `my.cnf` (or pass as `--option` flags to `mysqld`):
 
 ```ini
 [mysqld]
-server-id          = 1          # any non-zero value, unique per server
-log_bin            = mysql-bin  # enable binary logging
-binlog_format      = ROW        # required: row-level events
-binlog_row_image   = FULL       # required: full before/after images
-binlog_row_metadata = FULL      # REQUIRED for column names in the envelope
+server-id           = 1          # any non-zero value, unique per server
+log_bin             = mysql-bin  # enable binary logging
+binlog_format       = ROW        # required: row-level events (not STATEMENT/MIXED)
+binlog_row_image    = FULL       # required: full before/after images
+binlog_row_metadata = FULL       # REQUIRED for column names in the envelope
 ```
 
-**`binlog_row_metadata=FULL` is critical.** Without it, column names are absent from row events; the connector cannot decode column names and will fail. This setting is `MINIMAL` by default in MySQL 8.0 and must be explicitly changed.
+> **`binlog_row_metadata=FULL` is critical.** It is `MINIMAL` by default in MySQL 8.0. Without `FULL`, column names are absent from row events and the connector cannot decode them — startup fails.
 
 ### Required user grants
 
-The replication user must have `REPLICATION SLAVE` and `REPLICATION CLIENT` on `*.*`:
+The replication user needs `REPLICATION SLAVE` and `REPLICATION CLIENT` on `*.*`:
 
 ```sql
 CREATE USER 'repl'@'%' IDENTIFIED BY 'repl';
@@ -40,45 +65,44 @@ FLUSH PRIVILEGES;
 If you use `start_position: { type: gtid_set, value: "…" }`, the server must also have GTID mode enabled:
 
 ```ini
-gtid_mode               = ON
+gtid_mode                = ON
 enforce_gtid_consistency = ON
 ```
 
-File/pos and other start positions work with or without GTID mode.
-
----
+`current`, `earliest`, and `file_pos` start positions work with or without GTID mode.
 
 ## Quick start
 
 ```yaml
-# pipeline.yaml
+# pipeline.yaml — faucet run pipeline.yaml
 version: 1
-source:
-  type: mysql-cdc
-  config:
-    # No default database: the binlog is global; mysql-cdc reads all databases
-    # and filters client-side via include_tables/exclude_tables.
-    connection_url: mysql://repl:repl@localhost:3306
-    server_id: 1001
-    start_position:
-      type: current
-    include_columns: true
-    idle_timeout: 30
-sink:
-  type: jsonl
-  config:
-    path: ./changes.jsonl
-state:
-  type: file
-  config:
-    path: ./state/mysql_cdc.json
+pipeline:
+  source:
+    type: mysql-cdc
+    config:
+      # The binlog is global: mysql-cdc reads all databases and filters
+      # client-side via include_tables / exclude_tables. No default DB needed.
+      connection_url: mysql://repl:repl@localhost:3306
+      server_id: 1001
+      start_position:
+        type: current
+      include_columns: true
+      idle_timeout: 30
+  sink:
+    type: jsonl
+    config:
+      path: ./changes.jsonl
+  state:
+    type: file
+    config:
+      path: ./state/mysql_cdc.json
 ```
 
 ```bash
 faucet run pipeline.yaml
 ```
 
----
+A `state:` block is what makes the pipeline resumable — without it, each run restarts from `start_position`.
 
 ## Output record schema (CDC envelope)
 
@@ -101,16 +125,16 @@ Every change event is one JSON object:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `op` | string | Operation type: `c` (insert), `u` (update), `d` (delete). DDL events use `ddl` when `emit_schema_changes: true`. |
+| `op` | string | Operation: `c` (insert), `u` (update), `d` (delete), `ddl` (schema change, when `emit_schema_changes: true`). |
 | `ts_ms` | number | Wall-clock time of the binlog event in Unix-epoch milliseconds (from the event header timestamp). |
-| `schema` | string | The source database (schema) name. |
-| `table` | string | The source table name. |
+| `schema` | string | Source database (schema) name. |
+| `table` | string | Source table name. |
 | `before` | object \| null | Pre-image of the row. Populated on updates and deletes when `include_columns: true`. `null` on inserts, or when `include_columns: false`. |
 | `after` | object \| null | Post-image of the row. Populated on inserts and updates. `null` on deletes. |
 | `lsn` | object | Binlog coordinates of the commit event: `{ "file": "mysql-bin.000003", "pos": 4567 }`. Used as the persisted bookmark. |
 | `txid` | number | Monotonically increasing per-session transaction counter (resets to 0 on each `faucet run`). Useful for grouping rows from the same transaction. |
 
-### op mapping
+### `op` mapping
 
 | Binlog event | `op` value |
 |---|---|
@@ -119,55 +143,173 @@ Every change event is one JSON object:
 | `DeleteRowsEvent` (DELETE) | `d` |
 | DDL (`QueryEvent` other than BEGIN/COMMIT), when `emit_schema_changes: true` | `ddl` |
 
----
+## Configuration reference
 
-## Configuration
+### Core
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `connection_url` | string | — | MySQL connection URL, e.g. `mysql://repl:pass@host:3306/db`. Required. |
-| `server_id` | u32 | — | Replica server ID. **Required** and must be unique across all replication clients connecting to this server. |
-| `include_tables` | string[] | `[]` (all) | Client-side allowlist of `database.table` names. Empty = all tables. Must be fully qualified (e.g. `appdb.users`). |
-| `exclude_tables` | string[] | `[]` | Client-side blocklist of `database.table` names. Allowlist takes precedence when both are set. Must be fully qualified. |
-| `start_position` | enum | `{ type: current }` | Where to start on a fresh run (no persisted bookmark). See [Start positions](#start-positions) below. |
-| `include_columns` | bool | `true` | Emit the pre-image (`before`) on updates and deletes. Set to `false` to suppress the before-image and reduce payload size. |
+| `connection_url` | string | — *(required)* | MySQL connection URL, e.g. `mysql://repl:pass@host:3306/db`. The path component is optional — the binlog is global. |
+| `server_id` | u32 | — *(required)* | Replica server ID. Must be non-zero and **unique** across every replication client connected to this server. |
+| `start_position` | enum | `{ type: current }` | Where to start on a fresh run (no persisted bookmark). See [Start positions](#start-positions). |
+
+### Filtering
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `include_tables` | string[] | `[]` (all) | Client-side allowlist of fully-qualified `database.table` names. Empty = all tables. Takes precedence over `exclude_tables`. |
+| `exclude_tables` | string[] | `[]` | Client-side blocklist of fully-qualified `database.table` names. Ignored when `include_tables` is non-empty. |
+
+Both lists must use fully-qualified names (e.g. `appdb.users`); an unqualified entry fails validation.
+
+### Payload
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `include_columns` | bool | `true` | Emit the pre-image (`before`) on updates and deletes. Set `false` to suppress before-images and shrink payloads. |
 | `emit_schema_changes` | bool | `false` | Emit DDL statements (CREATE/ALTER/DROP TABLE etc.) as `{ op: "ddl" }` records. Each DDL auto-commits and advances the bookmark. |
-| `tls` | enum | `{ mode: disable }` | TLS for the replication connection. See [TLS](#tls) below. |
-| `idle_timeout` | seconds | `30` | Terminate the fetch cycle after this long with no new events. The accumulated page is flushed and the bookmark saved. |
-| `max_staged_records` | usize \| null | `null` | Abort if a single in-progress transaction buffers more than this many rows. `null` = unbounded. Set this to avoid OOM on unexpectedly large transactions. |
-| `batch_size` | usize | `1000` | Advisory page size. `0` = accumulate all committed transactions into one trailing page (useful for small lookup tables). Per-transaction streaming always emits one page per commit regardless of batch size when the pipeline drives `stream_pages`. |
+
+### Reliability & batching
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `idle_timeout` | int (seconds) | `30` | End the fetch cycle after this long with no new events. The accumulated page is flushed and the bookmark saved. Must be `> 0`. |
+| `max_staged_records` | int \| null | `null` | Abort if a single in-progress transaction buffers more than this many rows. `null` = unbounded. Set it to guard against OOM on bulk transactions. |
+| `batch_size` | int | `1000` | Advisory page-size hint. `0` = accumulate all committed transactions into one trailing page (useful for tiny lookup tables). Per-transaction streaming still emits one page per commit when the pipeline drives `stream_pages`. |
+
+### TLS
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `tls` | enum | `{ mode: disable }` | TLS for the replication connection. See [TLS modes](#tls-modes). |
 
 ### Start positions
 
 | Variant | Description |
 |---------|-------------|
-| `{ type: current }` | Start at the server's current binlog position — skip history. Default. |
+| `{ type: current }` | Start at the server's current binlog position — skip history. **Default.** |
 | `{ type: earliest }` | Start from the oldest available binlog file. Errors if binlogs have been purged past the earliest available point. |
 | `{ type: file_pos, file: "mysql-bin.000003", pos: 4567 }` | Resume from an explicit file/position. |
 | `{ type: gtid_set, value: "uuid:1-1000" }` | Start after an executed GTID set. Requires `gtid_mode=ON` on the server. |
 
-### TLS
+A persisted bookmark always wins over `start_position` — the latter only applies on a fresh run.
+
+### TLS modes
 
 | Mode | Description |
 |------|-------------|
 | `{ mode: disable }` | No TLS (default). Credentials and row data travel cleartext. |
 | `{ mode: require }` | Require TLS but do not verify the server certificate. |
-| `{ mode: verify_ca, ca_path: "/path/to/ca.pem" }` | Require TLS and verify the certificate chain. `ca_path` is optional (uses system roots if omitted). |
+| `{ mode: verify_ca, ca_path: "/path/to/ca.pem" }` | Require TLS and verify the certificate chain. `ca_path` optional (uses system roots if omitted). |
 | `{ mode: verify_full, ca_path: "/path/to/ca.pem" }` | Require TLS and verify both the chain and the hostname. `ca_path` optional. |
 
----
+## Examples
 
-## Resumability and state key
+### Capture two tables and land them in BigQuery
 
-The connector is fully resumable. After each committed transaction the pipeline writes the binlog file/position of that commit's end event to the configured `StateStore`. On the next run, `apply_start_bookmark` restores the coordinates and the binlog stream opens from that exact position — MySQL redelivers events from that point with no duplicates and no gap.
+```yaml
+version: 1
+pipeline:
+  source:
+    type: mysql-cdc
+    config:
+      connection_url: mysql://repl:${env:REPL_PASSWORD}@db.prod.internal:3306/myapp
+      server_id: 2001
+      start_position:
+        type: current
+      include_tables:
+        - myapp.orders
+        - myapp.order_items
+      include_columns: true
+      idle_timeout: 60
+      max_staged_records: 100000
+      batch_size: 500
+  sink:
+    type: bigquery
+    config:
+      project_id: my-gcp-project
+      dataset_id: cdc
+      table_id: mysql_changes
+      credentials:
+        type: service_account_file
+        config:
+          path: /secrets/bq-sa.json
+  state:
+    type: redis
+    config:
+      url: redis://localhost:6379
+      namespace: faucet-cdc
+```
 
-**Bookmark strategy:** all persisted bookmarks use `{ file, pos }` (the end-position of the commit event), even when `start_position` is `gtid_set`. This avoids the complexity of accumulating executed-GTID intervals across multiple sessions while still guaranteeing exactly-once resume semantics: `{ file, pos }` is always available, unambiguous, and honoured by the server regardless of whether GTID mode is on.
+### GTID-based start with full TLS verification
 
-**Persisted bookmark shape:**
+```yaml
+version: 1
+pipeline:
+  source:
+    type: mysql-cdc
+    config:
+      connection_url: mysql://repl:secret@db.internal:3306/events
+      server_id: 3001
+      start_position:
+        type: gtid_set
+        value: "3E11FA47-71CA-11E1-9E33-C80AA9429562:1-23"
+      tls:
+        mode: verify_full
+        ca_path: /etc/ssl/certs/mysql-ca.pem
+      idle_timeout: 30
+  sink:
+    type: stdout
+    config:
+      format: pretty
+  state:
+    type: file
+    config:
+      path: ./state/mysql_cdc.json
+```
+
+### Exclude noisy tables, suppress before-images
+
+```yaml
+version: 1
+pipeline:
+  source:
+    type: mysql-cdc
+    config:
+      connection_url: mysql://repl:repl@localhost:3306
+      server_id: 4001
+      exclude_tables:
+        - appdb.audit_log
+        - appdb.sessions
+      include_columns: false   # smaller payloads — no before-image on update/delete
+      emit_schema_changes: true
+  sink:
+    type: jsonl
+    config:
+      path: ./changes.jsonl
+  state:
+    type: file
+    config:
+      path: ./state/mysql_cdc.json
+```
+
+## Streaming & batching
+
+The source overrides `Source::stream_pages`. Binlog events are decoded and buffered per transaction; on a commit boundary (`XidEvent` for InnoDB, or an explicit `COMMIT` `QueryEvent`) the accumulated rows are emitted as a single `StreamPage` carrying the commit's `{ file, pos }` as its bookmark. The pipeline writes the page, flushes the sink, and persists the bookmark — giving you **per-transaction durability** out of the box.
+
+`batch_size` is advisory: per-transaction streaming naturally emits one page per commit. With `batch_size: 0` all committed transactions seen before the idle timeout are accumulated into one trailing page (handy for tiny tables). `idle_timeout` bounds how long a fetch cycle waits for new events before flushing and returning.
+
+## Resume & state
+
+The connector is fully resumable. After each committed transaction the pipeline writes the binlog `{ file, pos }` of that commit's end event to the configured `StateStore`. On the next run, `apply_start_bookmark()` restores the coordinates and the binlog stream opens from that exact position — MySQL redelivers events from there with no duplicates and no gap.
+
+**Bookmark shape** (the end-position of the commit event):
 
 ```json
 { "file": "mysql-bin.000003", "pos": 4567 }
 ```
+
+All persisted bookmarks use `{ file, pos }` — even when `start_position` is `gtid_set`. This avoids accumulating executed-GTID intervals across sessions while still guaranteeing unambiguous resume: `{ file, pos }` is always available and honoured by the server regardless of whether GTID mode is on.
 
 **State key** (one per `server_id`):
 
@@ -177,115 +319,122 @@ mysql-cdc:<server_id>
 
 Example: `server_id: 1001` → state key `mysql-cdc:1001`.
 
----
+Any [`StateStore`](https://crates.io/crates/faucet-core) works — `file` and `memory` ship in `faucet-core`; [`faucet-state-redis`](https://crates.io/crates/faucet-state-redis) and [`faucet-state-postgres`](https://crates.io/crates/faucet-state-postgres) provide durable shared backends.
 
-## Caveats
+## Exactly-once delivery
 
-- **InnoDB / transactional tables are the primary target.** InnoDB commits arrive as `XidEvent`. Explicit `COMMIT` statements from non-transactional engines (MyISAM, CSV, etc.) are also handled as commit boundaries. Mixed-engine transactions are supported but the commit boundary is detected from whichever event arrives first.
-- **`binlog_row_metadata=FULL` is required for column names.** Without it, column names are absent from row events. The connector verifies this at startup and fails fast if the variable is not `FULL`. Setting `binlog_row_metadata=MINIMAL` (the default in MySQL 8.0) will cause startup failure.
-- **JSON columns emit opaque nested scalars.** MySQL's binlog does not include full JSON diff metadata in ROW format; complex JSON column values may decode as `null` with a one-shot `tracing::warn!`. Use `{ type: update_lookup }` from a separate query source if you need full JSON-column fidelity.
-- **`start_position: earliest` may error.** If binlogs have been purged (via `expire_logs_days` or `PURGE BINARY LOGS`), MySQL returns an error when the requested position no longer exists. Keep your binlog retention window large enough for your expected downtime.
-- **Per-transaction durability.** The bookmark advances once per committed transaction. A crash mid-transaction replays at most the events since the last persisted bookmark (the incomplete transaction is re-delivered from the last commit boundary).
-- **`max_staged_records` guards against OOM.** Very large transactions (bulk INSERTs of millions of rows) buffer all rows in memory before the commit event arrives. Set `max_staged_records` to a safe upper bound for your workload.
-- **MySQL 5.7 / 8.0 / 8.4+ are all supported.** Capturing the current binlog position (`start_position: current` and `capture_resume_position()`) tries `SHOW BINARY LOG STATUS` (MySQL 8.4+) and falls back to `SHOW MASTER STATUS` (5.7 / 8.0), so the connector works against the 8.4 LTS — which removed `SHOW MASTER STATUS` — out of the box.
+`MysqlCdcSource::supports_exactly_once()` returns `true`. Combined with an idempotent sink and a state store, a pipeline can run with `delivery: exactly_once` for end-to-end exactly-once semantics — the pipeline assigns a monotonic commit token per bookmark-carrying page, the sink commits records and token atomically, and on resume already-committed pages are skipped.
 
----
+The CLI enforces all four requirements at config-load time (`faucet validate` catches them before any run starts):
 
-## Example: capture all changes and write to BigQuery
+1. **Source** must support exactly-once — `mysql-cdc` qualifies.
+2. **Sink** must support idempotent writes — `postgres`, `mysql`, `mssql`, `sqlite`, `iceberg`, or `bigquery`.
+3. A **`state:`** block must be configured.
+4. **No `dlq:`** block (DLQ and exactly-once are mutually exclusive in this version).
 
 ```yaml
 version: 1
-source:
-  type: mysql-cdc
-  config:
-    connection_url: mysql://repl:${env:REPL_PASSWORD}@db.prod.internal:3306/myapp
-    server_id: 2001
-    start_position:
-      type: current
-    include_tables:
-      - myapp.orders
-      - myapp.order_items
-    include_columns: true
-    idle_timeout: 60
-    max_staged_records: 100000
-    batch_size: 500
-sink:
-  type: bigquery
-  config:
-    project_id: my-gcp-project
-    dataset_id: cdc
-    table_id: mysql_changes
-    credentials:
-      type: service_account_file
-      config:
-        path: /secrets/bq-sa.json
-state:
-  type: redis
-  config:
-    url: redis://localhost:6379
-    namespace: faucet-cdc
+delivery: exactly_once
+pipeline:
+  source:
+    type: mysql-cdc
+    config:
+      connection_url: mysql://repl:repl@localhost:3306
+      server_id: 5001
+  sink:
+    type: postgres
+    config:
+      connection_url: postgres://app:app@localhost:5432/mirror
+      table: mysql_changes
+      auto_map: true
+  state:
+    type: postgres
+    config:
+      connection_url: postgres://app:app@localhost:5432/mirror
 ```
 
----
-
-## Example: GTID-based start with TLS
-
-```yaml
-version: 1
-source:
-  type: mysql-cdc
-  config:
-    connection_url: mysql://repl:secret@db.internal:3306/events
-    server_id: 3001
-    start_position:
-      type: gtid_set
-      value: "3E11FA47-71CA-11E1-9E33-C80AA9429562:1-23"
-    tls:
-      mode: verify_full
-      ca_path: /etc/ssl/certs/mysql-ca.pem
-    idle_timeout: 30
-sink:
-  type: stdout
-  config:
-    format: pretty
-state:
-  type: file
-  config:
-    path: ./state/mysql_cdc.json
-```
-
----
+To build a true table mirror (rather than an append-only change log), pair the `cdc_unwrap` transform with a `write_mode: upsert` sink — see the [upsert cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/upsert.html).
 
 ## Snapshot → CDC handoff
 
-This source implements `capture_resume_position()`, which reads the server's
-**current binlog coordinates** (`{ file, pos }`) as a resume bookmark — without
-consuming any changes. The `faucet replicate` command
-uses it to anchor the binlog stream at-or-before a bulk snapshot of the table,
-so the combined snapshot+CDC result is a gap-free, duplicate-free mirror when
-paired with a `write_mode: upsert` sink.
+This source implements `capture_resume_position()`, which reads the server's **current binlog coordinates** (`{ file, pos }`) as a resume bookmark — without consuming any changes. The `faucet replicate` command uses it to anchor the binlog stream at-or-before a bulk snapshot of the table, so the combined snapshot + CDC result is a gap-free, duplicate-free mirror when paired with a `write_mode: upsert` sink.
 
-There is no slot to pin; binlog retention is **time-based**, so keep your binlog
-retention window comfortably larger than the expected snapshot duration — if the
-captured position is purged before CDC starts, the stream errors that its start
-position is unavailable. See the [replication
-cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/replication.html)
-for the full handoff model.
+There is no slot to pin; binlog retention is **time-based**, so keep your binlog retention window comfortably larger than the expected snapshot duration. If the captured position is purged before CDC starts, the stream errors that its start position is unavailable. See the [replication cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/replication.html) for the full handoff model.
 
----
+## Config loading & schema
 
-## See also
+Load from YAML/JSON or environment. Inspect the full JSON Schema with:
 
-- `crates/source/mysql/` — query-mode MySQL source (snapshots via SQL queries).
-- `crates/state/redis/` — Redis-backed `StateStore` for durable file/pos bookmarks.
-- `crates/state/postgres/` — PostgreSQL-backed `StateStore` alternative.
-- `crates/source/postgres-cdc/` — PostgreSQL CDC for comparison (LSN bookmarks, pgoutput).
-- `crates/source/mongodb-cdc/` — MongoDB CDC (Change Streams, resumeToken bookmarks).
+```bash
+faucet schema source mysql-cdc
+```
+
+## Library usage
+
+```rust,no_run
+use faucet_core::Source;
+use faucet_source_mysql_cdc::{MysqlCdcSource, MysqlCdcSourceConfig, StartPosition};
+
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let cfg: MysqlCdcSourceConfig = serde_json::from_value(serde_json::json!({
+    "connection_url": "mysql://repl:repl@localhost:3306",
+    "server_id": 1001,
+    "start_position": { "type": "current" },
+    "include_tables": ["appdb.users", "appdb.orders"],
+    "idle_timeout": 30
+}))?;
+
+let source = MysqlCdcSource::new(cfg).await?;
+
+// Drive it via a Pipeline / run_stream, attaching a StateStore for resumable bookmarks.
+// (Direct fetch_all() is also available for a single fetch cycle.)
+let _ = source;
+# Ok(())
+# }
+```
+
+For resumable / exactly-once runs, drive the source through `faucet_core::Pipeline` (or `run_stream`) with `Pipeline::with_state_store(...)` so bookmarks are read before each fetch and persisted only after the sink confirms each transaction.
+
+## How it works
+
+1. `new()` validates the config, opens a replication connection (honouring `tls`), and verifies the four server variables (`log_bin`, `binlog_format=ROW`, `binlog_row_image=FULL`, `binlog_row_metadata=FULL`).
+2. The start position is resolved: a persisted bookmark wins; otherwise `start_position` (`current` capture tries `SHOW BINARY LOG STATUS` then falls back to `SHOW MASTER STATUS`).
+3. Binlog events stream in; row events are decoded against the relation metadata (column names come from `binlog_row_metadata=FULL`) and buffered per transaction.
+4. On each commit boundary, the buffered rows are emitted as one `StreamPage` with the commit's `{ file, pos }` bookmark; uncommitted buffers are bounded by `max_staged_records`.
+5. The cycle ends after `idle_timeout` of quiet, flushing the final page and saving the bookmark.
 
 ## Lineage dataset URI
 
 `mysql://<host>:<port>/<db>` or `mysql://<host>:<port>/<db>?tables=<t1>,<t2>` (credentials stripped) — e.g. `mysql://host:3306/app?tables=db.orders,db.users`.
 
+## Feature flags
+
+This crate has no optional features of its own; enable it in the CLI/umbrella via the `source-mysql-cdc` feature.
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause & fix |
+|---------|--------------------|
+| Startup fails: `binlog_row_metadata` not `FULL` | The server has the MySQL-8.0 default of `MINIMAL`. Set `binlog_row_metadata=FULL` in `my.cnf` and restart — required for column names. |
+| Startup fails: binary logging / `binlog_format` | `log_bin` is off or `binlog_format` is `STATEMENT`/`MIXED`. Enable `log_bin` and set `binlog_format=ROW` + `binlog_row_image=FULL`. |
+| `Access denied` / replication error | The user lacks `REPLICATION SLAVE` / `REPLICATION CLIENT`. Grant both on `*.*` and `FLUSH PRIVILEGES`. |
+| Another replica disconnects when this one connects | Two clients share a `server_id`. Pick a unique non-zero `server_id` per replication client. |
+| `start_position: earliest` errors | Binlogs were purged (`expire_logs_days` / `PURGE BINARY LOGS`) past the earliest point. Use `current`, or widen binlog retention. |
+| `gtid_set` start rejected by the server | `gtid_mode` is `OFF`. Set `gtid_mode=ON` + `enforce_gtid_consistency=ON`, or use a `file_pos` / `current` start instead. |
+| Resume errors that the start position is unavailable | The persisted/captured `{ file, pos }` was purged before resume. Widen binlog retention so it exceeds expected downtime / snapshot duration. |
+| A JSON column arrives as `null` (with a `warn!`) | MySQL's ROW binlog omits full JSON diff metadata; complex JSON values can't always be reconstructed. Use a query-mode lookup ([`faucet-source-mysql`](https://crates.io/crates/faucet-source-mysql)) if you need full JSON-column fidelity. |
+| Pipeline never returns / hangs | It's waiting for events. Lower `idle_timeout` so the fetch cycle ends sooner on a quiet binlog. |
+| OOM during a bulk load | A huge single transaction buffered entirely in memory before its commit. Set `max_staged_records` to a safe upper bound. |
+| `Config` error on a table filter | An `include_tables` / `exclude_tables` entry isn't fully qualified. Use `database.table` (e.g. `appdb.users`). |
+| TLS handshake fails | Wrong `tls` mode or CA. For self-signed servers use `require`; for verified chains set `verify_ca`/`verify_full` with a correct `ca_path`. |
+
+## See also
+
+- [Connector reference](https://pawansikawat.github.io/faucet-stream/reference/connectors.html) · [CDC / state cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/state.html) · [Upsert cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/upsert.html) · [Replication cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/replication.html)
+- [faucet-source-mysql](https://crates.io/crates/faucet-source-mysql) — query-mode MySQL source (snapshots via SQL)
+- [faucet-source-postgres-cdc](https://crates.io/crates/faucet-source-postgres-cdc) · [faucet-source-mongodb-cdc](https://crates.io/crates/faucet-source-mongodb-cdc) — sibling CDC sources
+- [faucet-state-redis](https://crates.io/crates/faucet-state-redis) · [faucet-state-postgres](https://crates.io/crates/faucet-state-postgres) — durable bookmark stores
+
 ## License
 
-Licensed under MIT or Apache-2.0.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/source/mysql/README.md
+++ b/crates/source/mysql/README.md
@@ -5,110 +5,228 @@
 [![MSRV](https://img.shields.io/crates/msrv/faucet-source-mysql.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
 [![License](https://img.shields.io/crates/l/faucet-source-mysql.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-A MySQL query source that executes SQL queries and returns rows as JSON records, with connection pooling via sqlx.
+A **MySQL query source** that runs a SQL query and streams the rows out as `serde_json::Value` records.
 
 Part of the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
+
+Built on `sqlx` with a pooled, async connection and a true row cursor (`Query::fetch`) — rows are decoded and handed to the sink as they arrive off the wire, so client-side memory stays bounded by `batch_size` no matter how large the result set is. Reach for it to pull tables, filtered extracts, or analytics queries out of MySQL / MariaDB into any faucet-stream sink, or to fan a query out per parent record in a matrix pipeline.
+
+## Feature highlights
+
+- **Streaming row cursor** — `Source::stream_pages` drives a sqlx cursor and yields one `StreamPage` per `batch_size` rows; the sink starts writing before the query finishes draining.
+- **Connection pooling** — a single `MySqlPool` is built once in `new()` and reused for every fetch; size it with `max_connections` (default `10`).
+- **Rich type decoding** — JSON, integers, floats, booleans, `DATETIME`/`TIMESTAMP`/`DATE`/`TIME`, `DECIMAL` (exact precision), and `BLOB`/`BINARY` (base64) all map to sensible JSON.
+- **Parameterised per-record queries** — in a parent/child matrix run, `${parent.field}` tokens in the query are substituted as **safe bind parameters** (`?` placeholders), never string-interpolated.
+- **TLS by default** — built with `tls-rustls`; encrypted connections need no extra dependency.
+- **Credential-safe** — the connection URL is masked in `Debug` output and stripped from the lineage dataset URI.
+- **`batch_size: 0` sentinel** — drain the whole result set into a single page for small lookup tables or load-job-style sinks.
 
 ## Installation
 
 ```bash
+# As a library:
 cargo add faucet-source-mysql
 cargo add tokio --features full
+
+# In the CLI (opt-in connector feature):
+cargo install faucet-cli --features source-mysql
 ```
 
 Or via the umbrella crate:
+
 ```bash
 cargo add faucet-stream --features source-mysql
 ```
 
-## Quick Start
+The MySQL source is **not** in the CLI/umbrella default build — enable the `source-mysql` feature explicitly.
 
-```rust
-use faucet_source_mysql::{MysqlSource, MysqlSourceConfig};
-use faucet_core::Source;
+## Quick start
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let config = MysqlSourceConfig::new(
-        "mysql://user:password@localhost:3306/mydb",
-        "SELECT id, name, email FROM users WHERE active = 1",
-    );
-
-    let source = MysqlSource::new(config).await?;
-    let records = source.fetch_all().await?;
-
-    for record in &records {
-        println!("{}", record);
-    }
-    Ok(())
-}
+```yaml
+# pipeline.yaml — faucet run pipeline.yaml
+version: 1
+pipeline:
+  source:
+    type: mysql
+    config:
+      connection_url: mysql://user:pass@localhost:3306/mydb
+      query: SELECT id, name, email FROM users WHERE active = 1 ORDER BY id
+  sink:
+    type: jsonl
+    config:
+      path: ./users.jsonl
 ```
 
-## Configuration
+```bash
+faucet run pipeline.yaml
+```
 
-### MysqlSourceConfig
+## Configuration reference
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `connection_url` | `String` | *(required)* | MySQL connection URL (e.g. `mysql://user:pass@host:3306/db`). Masked in debug output for security |
-| `query` | `String` | *(required)* | SQL query to execute |
-| `max_connections` | `u32` | `10` | Maximum number of connections in the pool |
-| `batch_size` | `usize` | `1000` | Rows per `StreamPage` emitted by `Source::stream_pages`. See [Streaming and batching](#streaming-and-batching) below |
+| `connection_url` | string | — *(required)* | MySQL connection URL, e.g. `mysql://user:pass@host:3306/db`. Masked in `Debug` output and stripped from the lineage URI. |
+| `query` | string | — *(required)* | The SQL query to execute. May contain `${parent.field}` tokens that are bound as parameters in a matrix run (see [Per-record queries](#per-record-queries-matrix-pipelines)). |
+| `max_connections` | int | `10` | Maximum connections in the sqlx pool. |
+| `batch_size` | int | `1000` | Rows per emitted `StreamPage`. **`0` = no batching** (drain the whole result set into one page). Values above `MAX_BATCH_SIZE` (1,000,000) are rejected at construction by `faucet_core::validate_batch_size`. |
 
-### Streaming and batching
+There is no separate `auth` block — credentials live in `connection_url` (and can be sourced from env or a secrets manager; see [Config loading](#config-loading)).
 
-`MysqlSource::stream_pages` drives a sqlx row cursor (`Query::fetch`)
-without buffering the full result. Rows are accumulated into a `batch_size`
-buffer and yielded as a `StreamPage` once the buffer fills; the trailing
-partial page (if any) is yielded after the cursor drains.
+## Examples
 
-`batch_size = 0` is the **"no batching" sentinel** — the cursor is drained
-completely and the entire result set is emitted in a single `StreamPage`.
-Use it for small lookup tables, or for downstream sinks (SQL `COPY`,
-BigQuery load jobs, Snowflake stage uploads) that prefer one large request
-to many small ones. Values larger than `MAX_BATCH_SIZE` (1,000,000) are
-rejected by `faucet_core::validate_batch_size`.
+### Filtered extract into Postgres
 
-The mysql query source has no incremental-replication mode, so every
-emitted page carries `bookmark: None`.
+Reuses [`cli/examples/mysql_to_postgres.yaml`](https://github.com/PawanSikawat/faucet-stream/blob/main/cli/examples/mysql_to_postgres.yaml):
 
-> **Note** — MySQL's wire protocol sends rows from a simple `SELECT` in a
-> single response (no server-side cursor). The streaming implementation
-> bounds *client-side* memory at `O(batch_size)` and lets the sink begin
-> writing as soon as the first batch is parsed off the wire. True
-> server-side cursor streaming (via stored procedures or `STREAM`-style
-> options) is tracked separately as a follow-up.
+```yaml
+version: 1
+name: mysql_to_postgres
+pipeline:
+  source:
+    type: mysql
+    config:
+      connection_url: mysql://user:pass@localhost/legacy
+      query: SELECT id, name, address, created_at FROM customers ORDER BY id
+      max_connections: 16
+  sink:
+    type: postgres
+    config:
+      connection_url: postgres://user:pass@localhost/modern
+      table_name: customers_imported
+      column_mapping:
+        type: auto_map
+      batch_size: 1000
+      max_connections: 10
+```
 
-### Supported Column Types
+### Rolling time window into stdout
 
-Columns are automatically converted to JSON values:
+```yaml
+version: 1
+pipeline:
+  source:
+    type: mysql
+    config:
+      connection_url: ${env:MYSQL_URL}
+      query: >
+        SELECT id, type, payload, created_at
+        FROM events
+        WHERE created_at >= CURDATE() - INTERVAL 7 DAY
+        ORDER BY created_at
+      batch_size: 5000
+  sink:
+    type: stdout
+    config:
+      format: jsonl
+```
 
-| MySQL Type | JSON Type |
-|------------|-----------|
-| `json` | Native JSON value |
-| `varchar`, `text`, `char` | `string` |
-| `bigint` | `number` (i64) |
-| `int`, `mediumint` | `number` (i32) |
-| `smallint`, `tinyint` | `number` (i16) |
-| `double` | `number` (f64) |
-| `float` | `number` (f32) |
-| `tinyint(1)`, `boolean` | `boolean` |
-| `datetime`, `timestamp`, `date`, `time` | `string` (RFC 3339 / ISO-8601) |
-| `decimal`, `numeric` | `string` (exact precision preserved) |
-| `blob`, `binary`, `varbinary` | `string` (base64) |
-| Other / `NULL` | `null` |
+### Small lookup table — one large page
 
-## Config Loading
+```yaml
+version: 1
+pipeline:
+  source:
+    type: mysql
+    config:
+      connection_url: ${env:MYSQL_URL}
+      query: SELECT code, label FROM country_codes
+      batch_size: 0          # drain the whole result set into a single page
+  sink:
+    type: bigquery
+    config:
+      project_id: my-project
+      dataset_id: ref
+      table_id: country_codes
+```
 
-```rust
+### Per-record queries (matrix pipelines)
+
+When a row runs once per record emitted by a `parent`, `${parent.field}` tokens in the `query` are resolved per record as **bind parameters** — the value is never spliced into the SQL text:
+
+```yaml
+version: 1
+name: orders_per_customer
+pipeline:
+  sources:
+    customers:
+      type: mysql
+      config:
+        connection_url: ${env:MYSQL_URL}
+        query: SELECT id FROM customers WHERE region = 'EU'
+    orders:
+      type: mysql
+      config:
+        connection_url: ${env:MYSQL_URL}
+        query: SELECT id, total FROM orders WHERE customer_id = ${customers.id}
+  sink:
+    type: jsonl
+    config:
+      path: ./orders.jsonl
+matrix:
+  - id: customers
+    source: { ref: customers }
+  - id: orders
+    parent: customers
+    source: { ref: orders }
+```
+
+## Streaming & batching
+
+`MysqlSource::stream_pages` drives a sqlx row cursor (`Query::fetch`) without buffering the full result. Rows are accumulated into a `batch_size` buffer and yielded as a `StreamPage` once the buffer fills; the trailing partial page (if any) is yielded after the cursor drains. This bounds *client-side* memory at `O(batch_size)` and lets the sink begin writing as soon as the first batch is parsed off the wire.
+
+`batch_size = 0` is the **"no batching" sentinel** — the cursor is drained completely and the entire result set is emitted in a single `StreamPage`. Use it for small lookup tables, or for downstream sinks (SQL `COPY`, BigQuery load jobs, Snowflake stage uploads) that prefer one large request to many small ones.
+
+The trait-level `batch_size` argument to `stream_pages` is ignored in favour of the config field — the config is the authoritative, user-facing knob, so a pipeline-supplied hint can never silently override an explicit config value.
+
+> **Note** — MySQL's wire protocol sends rows from a simple `SELECT` in a single response (no server-side cursor), so the streaming here bounds memory on the client side rather than asking the server to page. True server-side cursor streaming is tracked separately as a follow-up.
+
+The MySQL query source has **no incremental-replication mode**, so every emitted page carries `bookmark: None` (there is no resume or exactly-once support — see [Capabilities](#capabilities)). For change-data-capture against MySQL binlogs, use [`faucet-source-mysql-cdc`](https://crates.io/crates/faucet-source-mysql-cdc) instead.
+
+## Column types
+
+Columns are converted to JSON in order of likelihood; an unsupported or `NULL` column becomes `null`:
+
+| MySQL type | JSON shape |
+|------------|------------|
+| `json` | native JSON value |
+| `varchar`, `text`, `char` | string |
+| `bigint` | number (i64) |
+| `int`, `mediumint` | number (i32) |
+| `smallint`, `tinyint` | number (i16) |
+| `double` | number (f64) |
+| `float` | number (f32) |
+| `tinyint(1)`, `boolean` | `true`/`false` |
+| `datetime`, `timestamp` | string (RFC 3339 / ISO-8601) |
+| `date`, `time` | string (ISO-8601) |
+| `decimal`, `numeric` | string (exact precision preserved) |
+| `blob`, `binary`, `varbinary` | string (base64) |
+| other / `NULL` | `null` |
+
+## Capabilities
+
+| Capability | Supported | Notes |
+|------------|-----------|-------|
+| Native streaming | ✅ | sqlx row cursor; one page per `batch_size` rows. |
+| Connection pooling | ✅ | `max_connections`, reused across fetches. |
+| Resume / bookmark state | ❌ | Stateless query source; every page is `bookmark: None`. |
+| Exactly-once delivery | ❌ | Source does not implement `supports_exactly_once`. |
+| Write modes / upsert | — | Not applicable (this is a source). |
+| Compression | ❌ | No `compression` feature. |
+| Per-record (matrix) queries | ✅ | `${parent.field}` → SQL bind parameters. |
+
+## Config loading
+
+Load a config from a JSON file, environment variables, or a `.env` file via the helpers in `faucet_core::config`:
+
+```rust,no_run
 use faucet_core::config::{load_json, load_env_file};
 use faucet_source_mysql::MysqlSourceConfig;
 
+# fn example() -> Result<(), Box<dyn std::error::Error>> {
 let config: MysqlSourceConfig = load_json("config.json")?;
 let config: MysqlSourceConfig = load_env_file(".env", "MYSQL_SOURCE")?;
+# Ok(()) }
 ```
-
-### Example JSON config
 
 ```json
 {
@@ -119,74 +237,103 @@ let config: MysqlSourceConfig = load_env_file(".env", "MYSQL_SOURCE")?;
 }
 ```
 
-### Example .env file
-
 ```env
 MYSQL_SOURCE_CONNECTION_URL=mysql://user:password@localhost:3306/mydb
 MYSQL_SOURCE_QUERY=SELECT * FROM users
 MYSQL_SOURCE_MAX_CONNECTIONS=10
 ```
 
-## Config Schema Introspection
+In CLI configs the `connection_url` can also be drawn from env, files, or a secrets manager via `${env:VAR}` / `${file:PATH}` / `${vault:...}` directives.
 
-```rust
+## Schema introspection
+
+Print the JSON Schema for this connector's config:
+
+```bash
+faucet schema source mysql
+```
+
+Or from Rust:
+
+```rust,no_run
 use faucet_core::Source;
+use faucet_source_mysql::{MysqlSource, MysqlSourceConfig};
 
-let source = MysqlSource::new(config).await?;
+# async fn example() -> Result<(), Box<dyn std::error::Error>> {
+let source = MysqlSource::new(MysqlSourceConfig::new("mysql://localhost/db", "SELECT 1")).await?;
 let schema = source.config_schema();
 println!("{}", serde_json::to_string_pretty(&schema)?);
+# Ok(()) }
 ```
 
-## Examples
+## Library usage
 
-### Simple query
-
-```rust
+```rust,no_run
 use faucet_source_mysql::{MysqlSource, MysqlSourceConfig};
 use faucet_core::Source;
 
+# async fn example() -> Result<(), Box<dyn std::error::Error>> {
 let config = MysqlSourceConfig::new(
-    "mysql://localhost/mydb",
-    "SELECT id, name, email FROM customers ORDER BY id",
-);
-let source = MysqlSource::new(config).await?;
-let customers = source.fetch_all().await?;
-```
-
-### Custom connection pool size
-
-```rust
-use faucet_source_mysql::{MysqlSource, MysqlSourceConfig};
-
-let config = MysqlSourceConfig::new(
-    "mysql://localhost/mydb",
-    "SELECT * FROM large_table LIMIT 50000",
+    "mysql://user:password@localhost:3306/mydb",
+    "SELECT id, name, email FROM users WHERE active = 1",
 )
-.with_max_connections(20);
+.with_max_connections(20)
+.with_batch_size(5000);
 
 let source = MysqlSource::new(config).await?;
+
+// One-shot collect:
 let records = source.fetch_all().await?;
+for record in &records {
+    println!("{record}");
+}
+# Ok(()) }
 ```
 
-### Using with a Pipeline
+Wire it into a pipeline to stream straight to any sink:
 
-```rust
+```rust,ignore
 use faucet_source_mysql::{MysqlSource, MysqlSourceConfig};
-use faucet_core::{Pipeline, Source, Sink};
+use faucet_core::Pipeline;
 
-let config = MysqlSourceConfig::new(
-    "mysql://localhost/production",
-    "SELECT * FROM events WHERE date >= CURDATE() - INTERVAL 7 DAY",
-);
-let source = MysqlSource::new(config).await?;
+let source = MysqlSource::new(
+    MysqlSourceConfig::new("mysql://localhost/production", "SELECT * FROM events"),
+).await?;
 let pipeline = Pipeline::new(Box::new(source), Box::new(my_sink));
 let result = pipeline.run().await?;
 ```
+
+## How it works
+
+`MysqlSource::new` validates `batch_size`, then builds one `MySqlPool` (`MySqlPoolOptions::max_connections`) and stores it on the struct — every subsequent fetch reuses the pool rather than reconnecting. `stream_pages` opens a sqlx cursor with `Query::fetch` and pulls rows incrementally via `TryStreamExt::try_next`, flushing a `StreamPage` each time the buffer reaches `batch_size`. Each row is turned into a JSON object keyed by column name (`row_to_json`), and per-column decoding (`mysql_value_to_json`) probes the likely sqlx types in order, falling back to `Null`. Connection and query failures surface as `FaucetError::Config` with the underlying sqlx error attached. Throughput is dominated by row width and network round-trips; benchmark with your own schema and `batch_size`.
 
 ## Lineage dataset URI
 
 `mysql://<host>:<port>/<db>?query=<sql>` (credentials stripped) — e.g. `mysql://host:3306/app?query=SELECT id FROM orders`.
 
+## Feature flags
+
+This crate has no optional Cargo features of its own. Enable it in the CLI / umbrella via the `source-mysql` feature. TLS (`tls-rustls`), `chrono`, `bigdecimal`, and `json` sqlx features are always compiled in.
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause & fix |
+|---------|--------------------|
+| `FaucetError::Config: MySQL connection failed: ...` | Wrong host/port/credentials, the database is unreachable, or the URL scheme isn't `mysql://`. Verify the `connection_url` and that the server accepts the connection. |
+| `FaucetError::Config: batch_size ...` at startup | `batch_size` exceeds `MAX_BATCH_SIZE` (1,000,000). Lower it, or use `0` to disable batching. |
+| `FaucetError::Config: MySQL query failed: ...` | SQL syntax error, missing table/column, or insufficient privileges. Run the query directly against MySQL to confirm. |
+| TLS handshake / certificate error | The server requires TLS the client can't negotiate. Adjust the server's TLS settings or supply the right host; `tls-rustls` is built in, so no extra dependency is needed. |
+| A `DECIMAL` or `DATETIME` column arrives as a string | Intentional — `DECIMAL` is stringified to preserve exact precision and temporal types use ISO-8601. Cast downstream if you need a number. |
+| A column comes back as `null` unexpectedly | The column type isn't in the decode list, or the value is genuinely `NULL`. Wrap the column in `CAST(... AS CHAR)` in the query to force a string. |
+| Run holds many connections open | `max_connections` is high relative to the workload. Lower it; the default of `10` is plenty for a single streaming query. |
+| `${parent.field}` shows up literally in the SQL | The row isn't a matrix child of that parent (no `parent:` set), so the token was never resolved. Check the matrix wiring. |
+| Need change-data-capture, not a snapshot | This source only runs point-in-time queries. Use [`faucet-source-mysql-cdc`](https://crates.io/crates/faucet-source-mysql-cdc) for binlog replication. |
+
+## See also
+
+- [Connector reference](https://pawansikawat.github.io/faucet-stream/reference/connectors.html) · [Config grammar](https://pawansikawat.github.io/faucet-stream/reference/config.html) · [CLI reference](https://pawansikawat.github.io/faucet-stream/reference/cli.html)
+- Related crates: [faucet-source-mysql-cdc](https://crates.io/crates/faucet-source-mysql-cdc) · [faucet-sink-mysql](https://crates.io/crates/faucet-sink-mysql) · [faucet-source-postgres](https://crates.io/crates/faucet-source-postgres)
+
 ## License
 
-Licensed under MIT or Apache-2.0.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/source/mysql/README.md
+++ b/crates/source/mysql/README.md
@@ -2,6 +2,8 @@
 
 [![Crates.io](https://img.shields.io/crates/v/faucet-source-mysql.svg)](https://crates.io/crates/faucet-source-mysql)
 [![Docs.rs](https://docs.rs/faucet-source-mysql/badge.svg)](https://docs.rs/faucet-source-mysql)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-source-mysql.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-source-mysql.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
 A MySQL query source that executes SQL queries and returns rows as JSON records, with connection pooling via sqlx.
 

--- a/crates/source/parquet/README.md
+++ b/crates/source/parquet/README.md
@@ -1,40 +1,152 @@
 # faucet-source-parquet
 
-Apache Parquet file source connector for
-[faucet-stream](https://github.com/PawanSikawat/faucet-stream).
+[![Crates.io](https://img.shields.io/crates/v/faucet-source-parquet.svg)](https://crates.io/crates/faucet-source-parquet)
+[![Docs.rs](https://docs.rs/faucet-source-parquet/badge.svg)](https://docs.rs/faucet-source-parquet)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-source-parquet.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-source-parquet.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-Reads one or more Parquet files from a **local path**, a **local glob
-pattern**, or **Amazon S3** (single object or prefix) and yields each row as a
-`serde_json::Value` object. Built on the `parquet` + `arrow` crates for
-vectorised, streaming reads — `RecordBatch`es are decoded and converted to JSON
-incrementally, so the source never buffers a whole file in memory.
+Apache **Parquet** file source for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem. Reads one or more Parquet files from a **local path**, a **local glob pattern**, or **Amazon S3** (single object or prefix) and yields each row as a `serde_json::Value` object.
 
-## At a glance
+Built on the `parquet` + `arrow` crates wired through `object_store`, so local and S3 share one vectorized, streaming code path — `RecordBatch`es are decoded and converted to JSON incrementally and the source never buffers a whole file in memory. Reach for it to load columnar data lakes, S3 exports, or partitioned `year=/month=/` trees into any faucet-stream sink.
 
-| Feature | Notes |
+## Feature highlights
+
+- **Three location modes** — single local file, local glob (sorted for determinism), or S3 (single key **or** prefix listing).
+- **Column projection** — `columns: [a, b]` prunes at the Parquet level via `ProjectionMask`, so unread columns are skipped at the I/O layer, not just in JSON.
+- **Parallel multi-file reads** — Glob / S3-prefix modes read up to `concurrency` files at once via `buffer_unordered`.
+- **Vectorized streaming** — one Arrow `RecordBatch` per row-group; memory is bounded by `batch_size`, not file size.
+- **Fail-fast schema validation** — multi-file scans validate every file's Arrow schema up front (cheap footer probe) and surface a mismatch naming both files and the first diverging field, *before* any rows are committed downstream.
+- **S3-compatible** — custom `endpoint_url` for MinIO / LocalStack; credentials from the standard AWS chain.
+
+## Installation
+
+```bash
+# As a library:
+cargo add faucet-source-parquet
+
+# In the CLI (opt-in connector feature):
+cargo install faucet-cli --features source-parquet
+```
+
+## Quick start
+
+```yaml
+# pipeline.yaml — faucet run pipeline.yaml
+version: 1
+pipeline:
+  source:
+    type: parquet
+    config:
+      source:
+        type: local_path
+        path: /data/events.parquet
+  sink:
+    type: jsonl
+    config:
+      path: ./events.jsonl
+```
+
+```bash
+faucet run pipeline.yaml
+```
+
+## Configuration reference
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `source` | `ParquetLocation` | — *(required)* | Where to read from — `local_path`, `glob`, or `s3` (see below). |
+| `batch_size` | int | `1000` | Per-page row-count hint forwarded to `ParquetRecordBatchStreamBuilder::with_batch_size`. Arrow treats it as a max — a page may hold fewer rows at a row-group boundary. **`0` = no batching**: the file's native row-group size drives the page cadence (one page per row-group). |
+| `columns` | array | *(all)* | Top-level columns to decode. Unknown names error out. Prunes I/O at the Parquet layer. |
+| `concurrency` | int | `4` | Files read in parallel for Glob / S3-prefix modes. Ignored for single-file modes. Must be `> 0`. |
+
+### `source` location (`ParquetLocation`)
+
+```yaml
+# Single local file
+source: { type: local_path, path: /data/events.parquet }
+
+# Local glob — all matched files must share one Arrow schema
+source: { type: glob, pattern: "/data/year=2024/*.parquet" }
+
+# S3 — set EXACTLY ONE of key / prefix
+source:
+  type: s3
+  bucket: my-bucket
+  prefix: "events/2024/"      # or:  key: events/2024/data.parquet
+  region: us-east-1           # optional; defaults to the AWS resolution chain
+  endpoint_url: http://localhost:9000   # optional; MinIO / LocalStack
+```
+
+| `ParquetS3Config` field | Type | Description |
+|-------------------------|------|-------------|
+| `bucket` | string | S3 bucket (required). |
+| `key` | string | Single object key. Mutually exclusive with `prefix`. |
+| `prefix` | string | Object-key prefix to list and read. Mutually exclusive with `key`. |
+| `region` | string | AWS region. Defaults to the standard resolution chain. |
+| `endpoint_url` | string | Custom endpoint for S3-compatible services. HTTP endpoints automatically allow plain HTTP. |
+
+S3 credentials come from the standard `object_store` AWS chain (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`, IMDS, profile, …).
+
+## Examples
+
+### Projected columns from a partitioned tree, 8 files in parallel
+
+```yaml
+source:
+  type: parquet
+  config:
+    source: { type: glob, pattern: "/data/year=2024/*.parquet" }
+    columns: [id, amount]
+    concurrency: 8
+    batch_size: 4096
+```
+
+### S3 prefix, one page per row-group (load-job friendly)
+
+```yaml
+source:
+  type: parquet
+  config:
+    source: { type: s3, bucket: my-bucket, prefix: "events/2024/", region: us-east-1 }
+    batch_size: 0          # emit one page per native row-group
+```
+
+## JSON representation
+
+Each row becomes a `serde_json::Value::Object`. Field encoding is delegated to `arrow_json::ArrayWriter`, following Arrow's standard rules:
+
+| Arrow type | JSON shape |
 |---|---|
-| Local file | `ParquetLocation::LocalPath { path }` |
-| Local glob | `ParquetLocation::Glob { pattern }`, sorted for determinism |
-| S3 single object | `ParquetS3Config::object(bucket, key)` |
-| S3 prefix listing | `ParquetS3Config::prefix(bucket, prefix)` |
-| Column projection | `columns: ["a", "b"]` — column pruned at the Parquet level |
-| Concurrency | `concurrency: N` — `buffer_unordered` across files |
-| Batch size | `batch_size: N` — Arrow `RecordBatch` rows per chunk |
-| Schema validation | Cross-file Arrow schema mismatches fail fast |
-| Object safety | `Box<dyn Source>` compatible — no generics |
+| `Int32`/`Int64`/`Float32`/`Float64` | number |
+| `Utf8`/`LargeUtf8` | string |
+| `Boolean` | `true`/`false` |
+| `Date32`/`Date64` | ISO-8601 date string |
+| `Time32`/`Time64` | ISO-8601 time string |
+| `Timestamp(unit, tz)` | ISO-8601 timestamp string |
+| `Decimal128`/`Decimal256` | string (precision/scale preserved) |
+| `Binary`/`LargeBinary`/`FixedSizeBinary` | base64 string |
+| `Struct(...)` | nested object |
+| `List`/`LargeList`/`FixedSizeList` | array |
+| `Map(K, V)` | object keyed by `K` |
+| Null values | field omitted |
 
-## Configuration
+## Streaming & batching
+
+`ParquetSource` implements `Source::stream_pages`, writing each Arrow `RecordBatch` to the sink as it's decoded — memory is bounded by `batch_size × row_width`, not file size. `batch_size` is a hint (Arrow may emit smaller batches at row-group boundaries); `batch_size: 0` skips the override so the reader emits one batch per row-group. Multi-file scans flatten in sorted-path order, and **all files' schemas are validated up front** so a later mismatch fails before earlier rows are committed. Every page carries `bookmark: None` — there is no incremental-replication mode for Parquet.
+
+## Config loading & schema
+
+```bash
+faucet schema source parquet
+```
+
+## Library usage
 
 ```rust,no_run
 use faucet_source_parquet::{ParquetSource, ParquetSourceConfig, ParquetS3Config};
 
 # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-// Local file
-let source = ParquetSource::new(
-    ParquetSourceConfig::local("/data/events.parquet"),
-).await?;
-
-// Local glob, only two columns, eight files in parallel
+// Local glob, two columns, eight files in parallel
 let source = ParquetSource::new(
     ParquetSourceConfig::glob("/data/year=2024/*.parquet")
         .columns(["id", "amount"])
@@ -45,151 +157,41 @@ let source = ParquetSource::new(
 // S3 prefix
 let source = ParquetSource::new(
     ParquetSourceConfig::s3(
-        ParquetS3Config::prefix("my-bucket", "events/2024/")
-            .region("us-east-1"),
+        ParquetS3Config::prefix("my-bucket", "events/2024/").region("us-east-1"),
     ),
 ).await?;
 # Ok(()) }
 ```
 
-### YAML example for the `faucet` CLI
+## How it works
 
-```yaml
-version: 1
-source:
-  kind: parquet
-  config:
-    source:
-      type: glob
-      pattern: "/data/year=2024/*.parquet"
-    batch_size: 4096
-    columns: [id, amount]
-    concurrency: 8
-sink:
-  kind: jsonl
-  config:
-    path: out.jsonl
-```
-
-For S3:
-
-```yaml
-source:
-  kind: parquet
-  config:
-    source:
-      type: s3
-      bucket: my-bucket
-      prefix: "events/2024/"
-      region: us-east-1
-```
-
-## JSON representation
-
-Row → `serde_json::Value::Object`. Field encoding is delegated to
-`arrow_json::ArrayWriter`, so the conversion follows Arrow's standard rules:
-
-| Arrow type | JSON shape |
-|---|---|
-| `Int32`, `Int64`, `Float32`, `Float64` | JSON number |
-| `Utf8` / `LargeUtf8` | JSON string |
-| `Boolean` | JSON `true` / `false` |
-| `Date32` / `Date64` | ISO-8601 date string (`"2024-01-15"`) |
-| `Time32` / `Time64` | ISO-8601 time string |
-| `Timestamp(unit, tz)` | ISO-8601 timestamp string (`"2024-01-15T12:34:56Z"`) |
-| `Decimal128` / `Decimal256` | JSON string preserving precision/scale |
-| `Binary` / `LargeBinary` / `FixedSizeBinary` | base64-encoded string |
-| `Struct(...)` | nested JSON object |
-| `List(...)` / `LargeList(...)` / `FixedSizeList(...)` | JSON array |
-| `Map(K, V)` | JSON object keyed by `K` |
-| Null values | field is omitted (Arrow `ArrayWriter` default) |
-
-## Configuration fields
-
-| Field | Type | Default | Description |
-|---|---|---|---|
-| `source` | enum | required | One of `LocalPath`, `Glob`, `S3`. See below. |
-| `batch_size` | `usize` | `1000` (`faucet_core::DEFAULT_BATCH_SIZE`) | Per-page row-count hint passed to `ParquetRecordBatchStreamBuilder::with_batch_size`. Arrow may emit smaller batches at row-group boundaries. `0` disables the override — the file's native row-group size drives page cadence. |
-| `columns` | `Vec<String>?` | `None` | Top-level columns to read. Unknown names error out. |
-| `concurrency` | `usize` | `4` | Files read in parallel for Glob / S3-prefix modes (used by the eager `fetch_with_context` path; the streaming `stream_pages` path iterates files sequentially). |
-
-### `ParquetS3Config`
-
-| Field | Type | Description |
-|---|---|---|
-| `bucket` | `String` | S3 bucket. |
-| `key` | `Option<String>` | Single object key. Mutually exclusive with `prefix`. |
-| `prefix` | `Option<String>` | Object key prefix to list. Mutually exclusive with `key`. |
-| `region` | `Option<String>` | AWS region. Defaults to standard resolution chain. |
-| `endpoint_url` | `Option<String>` | Custom endpoint for MinIO / LocalStack / etc. HTTP endpoints automatically allow plain HTTP. |
-
-S3 credentials are loaded from the standard `object_store` AWS chain
-(`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`, IMDS, profile, etc.).
-
-## Streaming and batching
-
-`ParquetSource` implements
-[`Source::stream_pages`](https://docs.rs/faucet-core) so the pipeline can
-write each Arrow `RecordBatch` to the sink as it is decoded — client-side
-memory is bounded by `batch_size * row_width` rather than the file size.
-
-- `batch_size` is forwarded to
-  `ParquetRecordBatchStreamBuilder::with_batch_size`. The Arrow reader
-  treats it as a **hint**: a batch is *at most* `batch_size` rows, but a
-  smaller batch may be emitted at a row-group boundary. Consequently an
-  emitted `StreamPage` can hold fewer than `batch_size` rows.
-- `batch_size = 0` is the "no batching" sentinel. The call to
-  `with_batch_size` is skipped, so the Arrow reader emits one batch per
-  Parquet row-group. Useful for sinks (SQL `COPY`, BigQuery load jobs)
-  that prefer one large request per natural file boundary.
-- Multi-file scans (Glob / S3 prefix) flatten through the streaming
-  pipeline in sorted-path order. **All files' Arrow schemas are validated
-  up front** — by a cheap footer-only metadata probe — before any rows are
-  yielded, so a schema mismatch on a later file fails *before* earlier
-  files' rows are committed downstream rather than after a partial write
-  (#146 M11). The first file's schema is the reference; any divergent file
-  surfaces as `FaucetError::Source` naming both paths and the first
-  diverging field — matching the eager `fetch_with_context` behaviour.
-- Every page carries `bookmark: None` — the Parquet source has no
-  incremental-replication mode.
-- The trait-level `batch_size` argument that `Pipeline::run` passes is
-  intentionally ignored; the config field is the user-facing knob.
-
-## Performance notes
-
-- Decoding is **streaming**: each row group is read as an Arrow `RecordBatch`
-  and converted to JSON on the fly. Memory is bounded by `batch_size` rather
-  than the file size.
-- The S3 client is built once in `new()` and reused across every per-file read.
-- Glob / S3-prefix mode reads up to `concurrency` files in parallel via
-  `futures::buffer_unordered`.
-- Column projection is applied via `ProjectionMask::columns` so unread columns
-  are skipped at the Parquet I/O layer — not just at the JSON layer.
-
-A 100k-row, all-primitive file reads in well under 500 ms on a recent laptop in
-release mode. Throughput depends heavily on row width, projection, and storage
-medium; benchmark with your own data.
-
-## Failure modes
-
-| Condition | Error |
-|---|---|
-| `concurrency == 0` | `FaucetError::Config` |
-| S3 config with both `key` **and** `prefix`, or neither | `FaucetError::Config` |
-| Empty bucket name | `FaucetError::Config` |
-| Local file missing / unreadable | `FaucetError::Source` |
-| Projected column not found in file | `FaucetError::Source` (names file + column) |
-| Different Arrow schema across globbed / prefixed files | `FaucetError::Source` (names both paths + first diverging field) |
-| Parquet decode error | `FaucetError::Source` |
+Each row group is read as an Arrow `RecordBatch` and converted to JSON on the fly. The S3 client is built once in `new()` and reused across every per-file read. Glob / S3-prefix mode reads up to `concurrency` files in parallel via `futures::buffer_unordered`. Column projection is applied with `ProjectionMask::columns` so unread columns are skipped at the Parquet I/O layer. A 100k-row, all-primitive file reads in well under 500 ms on a recent laptop in release mode; throughput depends on row width, projection, and storage medium — benchmark with your own data.
 
 ## Lineage dataset URI
 
-`file://<path>` (local/glob), `s3://<bucket>/<key>` or `s3://<bucket>/<prefix>` — e.g. `file:///tmp/data.parquet` or `s3://my-bucket/path/to/file.parquet`.
+`file://<path>` (local/glob), `s3://<bucket>/<key>` or `s3://<bucket>/<prefix>` — e.g. `file:///tmp/data.parquet` or `s3://my-bucket/events/2024/`.
 
-## Status
+## Feature flags
 
-Issue [#28](https://github.com/PawanSikawat/faucet-stream/issues/28).
+No optional features of its own; enable it in the CLI/umbrella via the `source-parquet` feature.
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause & fix |
+|---------|--------------------|
+| `FaucetError::Config: concurrency` | `concurrency` is `0`. Set it to `≥ 1`. |
+| `FaucetError::Config` on S3 | Both `key` **and** `prefix` set, or neither, or an empty `bucket`. Set exactly one of `key`/`prefix`. |
+| Local read fails with `FaucetError::Source` | File missing/unreadable, or not valid Parquet. Check the path and permissions. |
+| `Source` error naming a column | A name in `columns` doesn't exist in the file schema. Match the Parquet column names exactly. |
+| `Source` error naming two files + a field | Globbed/prefixed files have divergent Arrow schemas. Ensure all files share one schema, or narrow the glob. |
+| S3 `403`/credential errors | Credentials missing from the AWS chain, or wrong region. Set `region` and the AWS env vars/profile. |
+| Connecting to MinIO/LocalStack fails | Set `endpoint_url` to the service URL (plain HTTP is auto-allowed for HTTP endpoints). |
+| A `Decimal`/`Timestamp` arrives as a string | Intentional — Arrow encodes these as strings to preserve precision. Cast downstream if you need a number. |
+
+## See also
+
+- [Connector reference](https://pawansikawat.github.io/faucet-stream/reference/connectors.html) · [faucet-sink-parquet](https://crates.io/crates/faucet-sink-parquet) · [faucet-source-s3](https://crates.io/crates/faucet-source-s3)
 
 ## License
 
-Licensed under MIT or Apache-2.0.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/source/postgres-cdc/README.md
+++ b/crates/source/postgres-cdc/README.md
@@ -1,61 +1,140 @@
 # faucet-source-postgres-cdc
 
-PostgreSQL CDC (Change Data Capture) source for [`faucet-stream`](https://github.com/PawanSikawat/faucet-stream). Subscribes to a Postgres logical replication slot using the `pgoutput` plugin and emits each row-level change (INSERT / UPDATE / DELETE / TRUNCATE) as a JSON record. Replication position is persisted via any `faucet-core` `StateStore`, so pipelines resume exactly where they left off — no duplicates, no gap.
+[![Crates.io](https://img.shields.io/crates/v/faucet-source-postgres-cdc.svg)](https://crates.io/crates/faucet-source-postgres-cdc)
+[![Docs.rs](https://docs.rs/faucet-source-postgres-cdc/badge.svg)](https://docs.rs/faucet-source-postgres-cdc)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-source-postgres-cdc.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-source-postgres-cdc.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
----
+PostgreSQL **change-data-capture (CDC)** source for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem. Subscribes to a Postgres logical-replication slot via the built-in `pgoutput` plugin and emits each row-level change — `INSERT` / `UPDATE` / `DELETE` / `TRUNCATE` — as a JSON change event, in transaction order.
+
+Reach for it when you want to stream live mutations out of an operational Postgres database into any faucet-stream sink — a warehouse, a queue, a search index, a file — without polling, triggers, or touching the application. Replication position is persisted to any `faucet-core` `StateStore`, so pipelines resume exactly where they left off across restarts: no gap, no loss.
+
+## Feature highlights
+
+- **Real CDC, not polling** — reads the write-ahead log directly through logical replication; no `updated_at` columns, triggers, or query load on the source tables.
+- **Transactionally consistent** — each transaction is buffered in memory and flushed to the sink only on `COMMIT`, so a sink never sees half a transaction.
+- **Resumable across restarts** — the connector overrides `state_key()` / `apply_start_bookmark()`; the durable LSN bookmark survives process crashes and restarts.
+- **Exactly-once delivery** — `supports_exactly_once()` is `true`; pair with an idempotent sink (`postgres`, `mysql`, `mssql`, `sqlite`, `iceberg`, `bigquery`) under `delivery: exactly_once`.
+- **Snapshot → CDC handoff** — implements `capture_resume_position()` so `faucet replicate` can bulk-snapshot a table and hand off to CDC with no gap and no duplicate.
+- **Crash-safe WAL feedback** — the advertised `confirmed_flush_lsn` advances *only* from a durably-persisted bookmark, so Postgres never recycles WAL for changes the consumer hasn't committed.
+- **TLS-capable** — `require` / `verify_ca` / `verify_full` modes for the replication connection (plaintext `disable` is the default for back-compat).
+- **Type-aware decoding** — booleans, integers, floats (incl. `NaN`/`Infinity`), `numeric` (exact precision), `bytea` (base64), `json`/`jsonb`, and 1-D scalar arrays decode to native JSON; everything else is preserved as raw Postgres text.
+- **OOM safety valves** — `max_staged_records` bounds a single in-progress transaction; `idle_timeout` and `max_messages` bound a fetch cycle.
+
+## Installation
+
+```bash
+# As a library:
+cargo add faucet-source-postgres-cdc
+
+# In the CLI (opt-in connector feature):
+cargo install faucet-cli --features source-postgres-cdc
+```
+
+## Postgres setup (one-time)
+
+Logical replication is off by default and requires a server restart to enable. Run this once as a superuser before pointing faucet at the database:
+
+```sql
+-- 1. Enable logical decoding (requires a Postgres restart afterwards).
+ALTER SYSTEM SET wal_level = 'logical';
+ALTER SYSTEM SET max_replication_slots = 4;   -- ≥ number of concurrent slots
+ALTER SYSTEM SET max_wal_senders     = 4;     -- ≥ number of concurrent streams
+-- → restart Postgres now
+
+-- 2. The connecting role must have the REPLICATION attribute.
+ALTER ROLE faucet WITH REPLICATION;
+
+-- 3. Create a publication selecting the tables you want to capture.
+--    (faucet does NOT create publications — that is a DBA concern.)
+CREATE PUBLICATION faucet_pub FOR TABLE public.users, public.orders;
+-- or:  CREATE PUBLICATION faucet_pub FOR ALL TABLES;
+
+-- 4. RECOMMENDED: capture a full row pre-image on UPDATE/DELETE.
+--    Without this, `before` is null on UPDATE and a DELETE carries only
+--    the primary-key columns.
+ALTER TABLE public.users  REPLICA IDENTITY FULL;
+ALTER TABLE public.orders REPLICA IDENTITY FULL;
+```
+
+The **replication slot** is created automatically on first run when `create_slot_if_missing: true` (the default). The **publication** must already exist — faucet never creates one.
+
+> `REPLICA IDENTITY FULL` writes the whole old row into the WAL on every update/delete, increasing WAL volume. The default (`DEFAULT` = primary key only) is fine if you don't need the `before` image of changed columns.
 
 ## Quick start
 
 ```yaml
-# pipeline.yaml
+# pipeline.yaml — faucet run pipeline.yaml
 version: 1
-source:
-  type: postgres-cdc
-  config:
-    connection_url: postgres://user:pass@localhost:5432/appdb
-    slot_name: faucet_slot
-    publication_name: faucet_pub
-    create_slot_if_missing: true
-    idle_timeout: 30
-sink:
-  type: jsonl
-  config:
-    path: ./changes.jsonl
-state:
-  type: file
-  config: { path: ./state }
+pipeline:
+  source:
+    type: postgres-cdc
+    config:
+      connection_url: postgres://faucet:faucet@localhost:5432/appdb
+      slot_name: faucet_slot
+      publication_name: faucet_pub
+      create_slot_if_missing: true
+      idle_timeout: 30
+  sink:
+    type: jsonl
+    config:
+      path: ./changes.jsonl
+      append: true
+  state:
+    type: file
+    config:
+      path: ./state
 ```
 
 ```bash
 faucet run pipeline.yaml
 ```
 
----
+Each fetch cycle drains all pending changes, then stops once the stream has been idle for `idle_timeout` seconds. Re-running resumes from the persisted bookmark. For a continuously-running mirror, drive this under `faucet schedule` or `faucet replicate`.
 
-## Postgres setup (one-time)
+## Configuration reference
 
-```sql
--- 1. Database needs logical replication enabled.
-ALTER SYSTEM SET wal_level = 'logical';
-ALTER SYSTEM SET max_replication_slots = 4;
-ALTER SYSTEM SET max_wal_senders = 4;
--- restart Postgres after this
+### Core
 
--- 2. The role that connects must have REPLICATION.
-ALTER ROLE faucet_user WITH REPLICATION;
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `connection_url` | string | — *(required)* | Postgres connection URL. The crate internally upgrades it to `replication=database` — you do **not** add that yourself. Redacted in logs/`Debug`. |
+| `slot_name` | string | — *(required)* | Logical replication slot. Must match `[a-z0-9_]{1,63}` (lowercase letters, digits, underscores; ≤ 63 chars). |
+| `publication_name` | string | — *(required)* | Existing publication that selects which tables are replicated. |
+| `create_slot_if_missing` | bool | `true` | Create the slot as a logical/`pgoutput` slot on first connect if it doesn't exist. |
+| `slot_type` | enum | `permanent` | `permanent` (survives disconnect, pins WAL until consumed or dropped) or `temporary` (auto-dropped when the replication connection closes). See [Slot lifecycle](#slot-lifecycle). |
+| `start_lsn` | string? | `null` | One-time starting-LSN override (e.g. `"0/16A4F88"`). Ignored when a state-store bookmark exists — the bookmark wins. With neither set, replication starts from the slot's `confirmed_flush_lsn`. |
+| `proto_version` | u32 | `1` | pgoutput protocol version. Only `1` is supported in this release (`validate` rejects anything else). |
 
--- 3. Create a publication for the tables you want to capture.
-CREATE PUBLICATION faucet_pub FOR TABLE public.users, public.orders;
--- or FOR ALL TABLES if you really want everything.
+### Reliability & flow control
 
--- 4. (Optional but recommended) get a full pre-image on UPDATE/DELETE.
-ALTER TABLE public.users REPLICA IDENTITY FULL;
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `idle_timeout` | seconds | `30` | Stop the current fetch cycle after this long with no new replication message. Must be `> 0`. |
+| `max_messages` | usize? | `null` | Optional cap on change events drained per fetch call. Checked **after each COMMIT**, never mid-transaction — a transaction larger than the cap still emits atomically. `idle_timeout` is the primary terminator. |
+| `max_staged_records` | usize? | `null` | Max change records buffered for a **single in-progress transaction** before the run aborts with a typed `FaucetError::Source`. `null` = unbounded. The OOM safety valve for huge bulk transactions — see [Transactional consistency](#transactional-consistency). |
+| `status_update_interval` | seconds | `10` | Standby Status Update (keepalive) cadence. Must be **strictly less than** `idle_timeout` and well under the server's `wal_sender_timeout` (default 60 s). |
+| `tcp_keepalive` | seconds | `60` | TCP keepalive on the replication connection. |
+| `slot_acquire_retries` | u32 | `10` | Retries when the slot is still **active** (held by a not-yet-released prior connection) on a rapid restart. Both the pre-stream slot advance and `START_REPLICATION` retry with exponential backoff (250 ms, doubling, capped at 4 s). `0` = fail fast. |
+| `batch_size` | usize | `1000` | Advisory page size. The source emits **one `StreamPage` per committed transaction** for per-transaction durability; transactions are never split, so a transaction larger than `batch_size` still emits as one page. **`0` = no batching**: accumulate every transaction in the run window into a single trailing page (negates per-transaction durability; for tests/snapshot-style runs only). |
+
+### TLS (`tls`)
+
+| `mode` | Extra config | Description |
+|--------|--------------|-------------|
+| `disable` | *(none)* | Plaintext — **default**, back-compatible. Credentials and WAL travel unencrypted. |
+| `require` | *(none)* | Require TLS, but do not verify the server certificate. |
+| `verify_ca` | `ca_path?` | Require TLS and verify the certificate chain against `ca_path` (or the system roots when omitted). |
+| `verify_full` | `ca_path?` | Require TLS and verify both the certificate chain **and** the hostname. |
+
+```yaml
+# Verify the full chain + hostname against a custom CA bundle
+tls:
+  mode: verify_full
+  ca_path: /etc/ssl/certs/rds-ca.pem
 ```
 
-The replication slot is created automatically on first run when
-`create_slot_if_missing = true` (the default).
-
----
+> Use `require` or a `verify_*` mode in any production / cross-network deployment — `disable` sends database credentials and all WAL data in the clear.
 
 ## Output record schema
 
@@ -63,28 +142,28 @@ Every change event is one JSON object:
 
 ```json
 {
-  "op":     "insert | update | delete | truncate",
+  "op":     "insert",
   "schema": "public",
   "table":  "users",
   "lsn":    "0/16A4F88",
   "ts_ms":  1779019200000,
-  "before": null | { ...row... },
-  "after":  null | { ...row..., "__unchanged_toast__": ["col1", "col2"] }
+  "before": null,
+  "after":  { "id": 42, "name": "Ada", "email": "ada@example.com" }
 }
 ```
 
-- `lsn` is the `commit_lsn` of the enclosing transaction.
-- `ts_ms` is Unix-epoch milliseconds, derived from the COMMIT's timestamp.
-- `before` is populated on `delete` always, and on `update` only when the
-  table is `REPLICA IDENTITY FULL`. Otherwise it is `null`.
-- `after` is populated on `insert` and `update`, and `null` on `delete` /
-  `truncate`.
-- If any column arrived as "unchanged TOAST" (Postgres elides large
-  out-of-line values whose stored copy was not rewritten), the column is
-  dropped from `before` / `after` and its name is recorded in
-  `before.__unchanged_toast__` / `after.__unchanged_toast__`.
+| Field | Description |
+|-------|-------------|
+| `op` | One of `insert` / `update` / `delete` / `truncate`. |
+| `schema` | Source schema name (e.g. `public`). |
+| `table` | Source table name. |
+| `lsn` | The `commit_lsn` of the enclosing transaction. |
+| `ts_ms` | Unix-epoch milliseconds, derived from the COMMIT timestamp. |
+| `before` | Row image **before** the change. Always present on `delete`; present on `update` only when the table is `REPLICA IDENTITY FULL`; otherwise `null`. |
+| `after` | Row image **after** the change. Present on `insert` and `update`; `null` on `delete` and `truncate`. |
 
-`truncate` emits one record per truncated relation with `before = after = null`.
+- A `truncate` emits one record per truncated relation with `before = after = null`.
+- **Unchanged TOAST:** Postgres elides large out-of-line values whose stored copy wasn't rewritten. Such columns are dropped from `before`/`after` and their names are recorded in `before.__unchanged_toast__` / `after.__unchanged_toast__` (a JSON array of column names).
 
 ### Column type mapping
 
@@ -99,148 +178,202 @@ Values arrive in Postgres text form and are decoded by column type OID:
 | `numeric` | string (exact precision) |
 | `bytea` | base64 string |
 | `json` / `jsonb` | parsed JSON value |
-| one-dimensional arrays of the above scalar types (`int4[]`, `text[]`, `uuid[]`, …) | JSON array, decoded element-by-element (`NULL` elements → `null`) |
+| 1-D arrays of the above scalar types (`int4[]`, `text[]`, `uuid[]`, …) | JSON array, decoded element-by-element (`NULL` elements → `null`) |
 | `uuid`, `date`, `time`, `timestamp`, `timestamptz`, and anything else | string (raw Postgres text — stable under the default `DateStyle ISO`) |
 
 Multi-dimensional arrays, ranges, composites, and enums fall back to the raw Postgres array/text string.
 
-### Stream robustness
+## Examples
 
-The decoder fails fast (`FaucetError::Source`, which the pipeline restarts from the durable bookmark) rather than silently dropping data on a protocol desync: a `COMMIT` without a `BEGIN`, a second `BEGIN` while a transaction is still staged, or a `ReplicationEvent` variant the decoder doesn't recognise. A relation whose column set changes mid-stream (an `ALTER TABLE`) is logged at `warn` — subsequent rows decode against the new descriptor.
+### CDC → Postgres mirror, exactly-once + upsert
 
----
+Stream changes into a target table with idempotent upserts. Pair with the `cdc_unwrap` transform so the envelope's `op` becomes a normalized `__op` marker the upsert sink can act on.
 
-## Configuration
+```yaml
+version: 1
+delivery: exactly_once          # CDC source + idempotent sink + state, no DLQ
+pipeline:
+  source:
+    type: postgres-cdc
+    config:
+      connection_url: ${env:SOURCE_PG_URL}
+      slot_name: mirror_slot
+      publication_name: mirror_pub
+      tls: { mode: require }
+  transforms:
+    - type: cdc_unwrap          # flatten {op,before,after} → row + __op
+  sink:
+    type: postgres
+    config:
+      connection_url: ${env:TARGET_PG_URL}
+      table: users
+      auto_map: true
+      write_mode: upsert
+      key: [id]
+      delete_marker: { field: __op, values: ["d"] }
+  state:
+    type: postgres
+    config:
+      connection_url: ${env:STATE_PG_URL}
+```
 
-| Field                       | Type     | Default | Description |
-|-----------------------------|----------|---------|-------------|
-| `connection_url`            | string   | —       | Postgres connection URL. |
-| `slot_name`                 | string   | —       | Logical replication slot. Must match `[a-z0-9_]{1,63}`. |
-| `publication_name`          | string   | —       | Publication that selects which tables are replicated. |
-| `create_slot_if_missing`    | bool     | `true`  | Create the slot on first run if it does not exist. |
-| `slot_type`                 | enum     | `permanent` | `permanent` (survives disconnect, pins WAL until consumed/dropped) or `temporary` (auto-dropped on disconnect; resets resume position, so not for cross-run bookmark resume). Permanent-slot creation logs a loud warning. Drop an unused permanent slot via `PostgresCdcSource::drop_slot()`. |
-| `tls`                       | object   | `{mode: disable}` | Replication-connection TLS: `{mode: disable}` (plaintext, default), `{mode: require}`, `{mode: verify_ca, ca_path?}`, or `{mode: verify_full, ca_path?}`. Use `require`/`verify_*` in production — `disable` sends credentials and WAL in plaintext. |
-| `start_lsn`                 | string?  | `null`  | One-time override (e.g. `"0/16A4F88"`); ignored if a state-store bookmark exists. |
-| `proto_version`             | u32      | `1`     | pgoutput protocol version. Only `1` is supported in this release. |
-| `idle_timeout`              | seconds  | `30`    | Stop the current fetch cycle after this long without a new replication message. |
-| `max_messages`              | usize?   | `null`  | Optional cap on change events per fetch call. The cap is checked **after each COMMIT**; a transaction larger than `max_messages` still emits atomically. |
-| `max_staged_records`        | usize?   | `null`  | Max change records buffered for a **single in-progress transaction** before the run aborts with a typed error. `null` = unbounded. A safety valve against OOM on huge bulk transactions — see [Transactional consistency](#transactional-consistency). |
-| `status_update_interval`    | seconds  | `10`    | Standby Status Update cadence. Must be `< idle_timeout` and well under the server's `wal_sender_timeout`. |
-| `tcp_keepalive`             | seconds  | `60`    | TCP keepalive on the replication connection. |
-| `slot_acquire_retries`      | u32      | `10`    | Retries when the slot is still **active** (held by a not-yet-released prior connection) on a rapid restart. Both the pre-stream slot advance and `START_REPLICATION` are retried with exponential backoff (250 ms, doubling, capped at 4 s). `0` = fail fast. |
+### Bound a large bulk transaction
 
----
+Protect the process from an OOM when a single `UPDATE`/`COPY` touches millions of rows.
+
+```yaml
+source:
+  type: postgres-cdc
+  config:
+    connection_url: postgres://faucet:faucet@db:5432/appdb
+    slot_name: faucet_slot
+    publication_name: faucet_pub
+    max_staged_records: 500000   # abort cleanly instead of OOM-killing
+    idle_timeout: 60
+```
+
+### Ephemeral / test run with a self-cleaning slot
+
+A temporary slot is dropped automatically when the connection closes, so it won't pin WAL after the run. (Note: temporary slots reset on reconnect — not for cross-run resume.)
+
+```yaml
+source:
+  type: postgres-cdc
+  config:
+    connection_url: postgres://faucet:faucet@localhost:5432/appdb
+    slot_name: ephemeral_slot
+    publication_name: faucet_pub
+    slot_type: temporary
+    idle_timeout: 10
+```
+
+## Streaming & batching
+
+The source overrides `Source::stream_pages` and emits **one `StreamPage` per committed transaction**, carrying `bookmark = commit_lsn`. The pipeline persists that bookmark to the state store after the sink flushes, giving per-transaction durability for free. Because transactions are atomic units, they are never split across pages — a transaction whose record count exceeds `batch_size` still emits as a single page.
+
+`batch_size: 0` is the "no batching" sentinel: every committed transaction in the run window is accumulated into a single trailing page emitted at the end with `bookmark = max(commit_lsn)`. This negates per-transaction durability and is only useful for tests or snapshot-style runs.
+
+## Resume & state
+
+The connector overrides `state_key()` and `apply_start_bookmark()` for durable, resumable replication:
+
+- **State key:** `postgres-cdc:<slot_name>` (e.g. `postgres-cdc:faucet_slot`). One bookmark per slot.
+- **Bookmark:** the most-recently-committed `commit_lsn`, persisted by the pipeline only **after the sink confirms** the batch flushed.
+- **On resume:** `apply_start_bookmark` receives that LSN and advances the slot's `confirmed_flush_lsn` to it before streaming continues.
+
+Configure any `faucet-core` `StateStore` — `file`, `memory`, [`faucet-state-postgres`](https://crates.io/crates/faucet-state-postgres), or [`faucet-state-redis`](https://crates.io/crates/faucet-state-redis). **Always configure a durable (non-`memory`) state store in production** — without one the slot's `confirmed_flush_lsn` never advances and WAL is retained indefinitely.
+
+## Exactly-once delivery
+
+`supports_exactly_once()` returns `true`, so this source qualifies for `delivery: exactly_once`. With that mode the pipeline assigns a monotonic per-transaction commit token; the sink commits the records and the token in one atomic unit, and on resume skips any transaction whose token is already committed — so a crash between sink-flush and bookmark-write can never double-apply.
+
+The CLI enforces the full exactly-once gate at config-load time (`faucet validate` catches all four):
+
+1. **Source** supports exactly-once — `postgres-cdc` does. ✅
+2. **Sink** supports idempotent writes — one of `postgres` / `mysql` / `mssql` / `sqlite` / `iceberg` / `bigquery`.
+3. A **`state:`** block is configured.
+4. **No `dlq:`** block (DLQ and exactly-once are mutually exclusive in this version).
+
+Without `delivery: exactly_once` the source still delivers **at-least-once**: Postgres redelivers everything after the most recent durably-persisted `confirmed_flush_lsn` on the next `START_REPLICATION`, so a crash replays the most recent transaction rather than losing it. Make sinks idempotent or tolerant of duplicates at transaction boundaries.
 
 ## Transactional consistency
 
-The connector buffers each transaction in memory and only flushes its records
-to the sink on `COMMIT`. Partial transactions (BEGIN seen, no COMMIT yet
-within `idle_timeout` / `max_messages`) are dropped and redelivered after the
-next `START_REPLICATION`. This makes the output transactionally consistent —
-sinks never see half a transaction — at the cost of needing each
-transaction to fit within one fetch cycle.
+The connector buffers each transaction in full and flushes to the sink only on `COMMIT`. Partial transactions (a `BEGIN` with no `COMMIT` before `idle_timeout` / `max_messages`) are dropped and redelivered after the next `START_REPLICATION`. This keeps the output transactionally consistent — at the cost of needing each transaction to fit in one fetch cycle and in memory.
 
-Because a transaction is buffered in full until its `COMMIT`, a single bulk
-`UPDATE`/`DELETE`/`COPY` of millions of rows holds every decoded row in
-memory at once. Set `max_staged_records` to bound that: when an in-progress
-transaction exceeds it the run aborts with a typed `FaucetError::Source`
-instead of risking an OOM-kill. Leave it `null` only if you are sure your
-source transactions fit comfortably in memory.
+A single bulk `UPDATE`/`DELETE`/`COPY` of millions of rows therefore holds every decoded row as a `serde_json::Value` in RAM at once. Set `max_staged_records` to a value sized to your available memory: when an in-progress transaction exceeds it, the run aborts with a typed `FaucetError::Source` instead of being OOM-killed.
 
----
+The decoder **fails fast** (`FaucetError::Source`, which the pipeline restarts from the durable bookmark) rather than silently dropping data on a protocol desync — a `COMMIT` without a `BEGIN`, a second `BEGIN` while a transaction is still staged, or an unrecognised replication event. A relation whose column set changes mid-stream (an `ALTER TABLE`) is logged at `warn`; subsequent rows decode against the new descriptor.
 
-## At-least-once semantics
+## Slot lifecycle
 
-- Postgres redelivers everything after the most recent `confirmed_flush_lsn`
-  on every `START_REPLICATION`, with no duplicates and no gap.
-- `faucet-stream`'s pipeline only writes the new bookmark to the state store
-  **after the sink confirms** the batch was flushed.
-- On the next run, `apply_start_bookmark` is called with that bookmark and
-  the connector advances `confirmed_flush_lsn` accordingly.
-- **The advertised `confirmed_flush_lsn` is advanced _only_ from a durable
-  bookmark** (via `apply_start_bookmark`) — never from decoded WAL at
-  commit-decode time, and never from a keepalive's `wal_end`. This guarantees
-  Postgres is never told to recycle WAL for changes the consumer has not
-  durably persisted, so a crash can never lose committed data (it replays
-  instead).
-- If the process crashes between sink flush and state-store write, the next
-  run will replay the most recent transaction. Sinks should be idempotent or
-  accept duplicates at transaction boundaries.
+| `slot_type` | Survives disconnect? | WAL retention | Cross-run resume? | Use for |
+|-------------|----------------------|---------------|-------------------|---------|
+| `permanent` *(default)* | Yes | Pins WAL until consumed or dropped | Yes | Production pipelines, snapshot→CDC handoff. |
+| `temporary` | No (auto-dropped) | Released on disconnect | No (resets on reconnect) | Ephemeral / test runs that should self-clean. |
 
----
-
-## Operational caveats
-
-- **Slot bloat / WAL retention:** the connector advances
-  `confirmed_flush_lsn` only at the *start* of a run, from the durable
-  bookmark. Within a single long-running fetch cycle it does not advance it,
-  so Postgres retains all WAL produced during that cycle until the next run
-  resumes from the persisted bookmark. Without a state store it never
-  advances at all and WAL is retained indefinitely. Always configure a state
-  store in production, and run frequently enough (or keep fetch cycles short
-  enough) that WAL retention stays within your disk budget. A **permanent**
-  slot (the default) keeps pinning WAL even when no consumer is connected, so
-  decommission an unused pipeline by calling `PostgresCdcSource::drop_slot()`
-  (or set `slot_type: temporary` for ephemeral runs that should self-clean on
-  disconnect).
-- **Encryption:** the replication connection is plaintext unless you set
-  `tls` to `require` / `verify_ca` / `verify_full` — credentials and WAL data
-  travel unencrypted under the default `disable`.
-- **Heartbeats:** if the network is silent for longer than the server's
-  `wal_sender_timeout` (default 60 s), Postgres kills the replication
-  connection. The default `status_update_interval` of 10 s leaves ample
-  margin.
-- **DDL is invisible.** Logical replication does not replicate schema
-  changes. After an `ALTER TABLE`, the next change event from that table
-  will arrive with a new `Relation` message — the connector picks it up
-  automatically.
-- **Reconnection on drop:** v1 surfaces a connection drop as
-  `FaucetError::Source`. Re-run the pipeline to reconnect; the persisted
-  LSN bookmark ensures no data loss.
-- **Slot creation timing:** the slot is created on the first fetch call.
-  Changes applied **before** the slot exists are not replicated. To avoid
-  losing initial changes, either create the slot before applying writes
-  (e.g. via `psql`) or do a warm-up fetch and then begin writes.
-
----
-
-## Implementation notes
-
-Built on top of the [`pgwire-replication`](https://crates.io/crates/pgwire-replication)
-crate for the Postgres logical-replication wire protocol; the `pgoutput`
-payload bytes are decoded by a hand-rolled decoder in this crate so that the
-output record shape stays under our control.
-
----
+A **permanent** slot keeps pinning WAL even when no consumer is connected — an abandoned slot fills `pg_wal` and can take the whole instance down. Decommission an unused pipeline by calling `PostgresCdcSource::drop_slot()` (or dropping it via `SELECT pg_drop_replication_slot('faucet_slot');` in `psql`). Permanent-slot creation logs a loud warning so the WAL-retention obligation is hard to miss.
 
 ## Snapshot → CDC handoff
 
-This source implements `capture_resume_position()`, which ensures the
-replication slot exists and then reads the server's **current WAL LSN**
-(`pg_current_wal_lsn`) as a resume bookmark — without consuming any changes. The
-`faucet replicate` command uses it to anchor the CDC stream at-or-before a bulk
-snapshot of the table, so the combined snapshot+CDC result is a gap-free,
-duplicate-free mirror when paired with a `write_mode: upsert` sink.
+This source implements `capture_resume_position()`: it ensures the slot exists, reads the server's **current WAL LSN** (`pg_current_wal_lsn`) as a resume bookmark, and consumes no changes. The `faucet replicate` command uses it to anchor the CDC stream at-or-before a bulk snapshot of the table, so the combined snapshot + CDC result is a gap-free, duplicate-free mirror when paired with a `write_mode: upsert` sink.
 
-Capture **requires a permanent slot** (`slot_type: permanent`, the default): a
-temporary slot is dropped when the short-lived capture connection closes, so it
-cannot retain WAL across the snapshot. Capture rejects a temporary slot with a
-typed error. See the [replication
-cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/replication.html)
-for the full handoff model.
+Capture **requires a permanent slot** (`slot_type: permanent`, the default): a temporary slot is dropped when the short-lived capture connection closes and so cannot retain WAL across the snapshot. Capture rejects a temporary slot with a typed error. See the [replication cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/replication.html) for the full handoff model.
 
----
+## Crash-safe WAL feedback (durability)
 
-## See also
+The advertised `confirmed_flush_lsn` is advanced **only** from a durably-persisted bookmark (via `apply_start_bookmark`) — never from decoded WAL at commit-decode time, and never from a keepalive's `wal_end`. This guarantees Postgres is never told to recycle WAL for changes the consumer hasn't durably persisted, so a crash can never lose committed data (it replays instead).
 
-- `crates/source/postgres/` — query-mode Postgres source (snapshots, not CDC).
-- `crates/state/postgres/` — Postgres-backed `StateStore` you can pair with this source.
-- `cli/examples/postgres_cdc_to_jsonl.yaml` — end-to-end demo configuration.
+The tradeoff: within a single long-running fetch cycle the flush LSN does not advance, so Postgres retains all WAL produced during the cycle until the next run resumes from the persisted bookmark. Run frequently enough (or keep fetch cycles short) that WAL retention stays within your disk budget.
+
+## Config loading & schema
+
+Load config from YAML/JSON or environment. Inspect the full JSON Schema with:
+
+```bash
+faucet schema source postgres-cdc
+```
+
+## Library usage
+
+```rust,no_run
+use std::sync::Arc;
+use faucet_core::{Pipeline, state::FileStateStore};
+use faucet_source_postgres_cdc::{PostgresCdcSource, PostgresCdcSourceConfig};
+
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let cfg: PostgresCdcSourceConfig = serde_json::from_value(serde_json::json!({
+    "connection_url": "postgres://faucet:faucet@localhost:5432/appdb",
+    "slot_name": "faucet_slot",
+    "publication_name": "faucet_pub",
+    "idle_timeout": 30,
+}))?;
+
+let source = PostgresCdcSource::new(cfg).await?;
+
+// Pair with any Sink + a durable StateStore for resumable runs.
+let state = Arc::new(FileStateStore::new("./state"));
+// let pipeline = Pipeline::new(source, my_sink).with_state_store(state);
+// pipeline.run().await?;
+# let _ = (source, state);
+# Ok(())
+# }
+```
+
+## How it works
+
+Built on the [`pgwire-replication`](https://crates.io/crates/pgwire-replication) crate for the logical-replication wire protocol; the `pgoutput` payload bytes are decoded by a hand-rolled decoder in this crate so the output record shape stays under our control. The `sqlx` Postgres driver handles slot lifecycle (create / advance / drop) and the `pg_current_wal_lsn` probe. Standby Status Updates are sent every `status_update_interval` to keep the connection alive and report the flush position. The replication connection is created once and held for the lifetime of the source.
 
 ## Lineage dataset URI
 
-`postgres://<host>:<port>/<db>?publication=<publication_name>` (credentials stripped) — e.g. `postgres://host:5432/app?publication=my_publication`.
+`postgres://<host>:<port>/<db>?publication=<publication_name>` (credentials stripped) — e.g. `postgres://host:5432/app?publication=faucet_pub`.
+
+## Feature flags
+
+This crate has no optional features of its own; enable it in the CLI/umbrella via the `source-postgres-cdc` feature.
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause & fix |
+|---------|--------------------|
+| `FaucetError::Config: slot_name … must contain only [a-z0-9_]` | Slot names allow only lowercase letters, digits, and underscores, ≤ 63 chars. Rename the slot. |
+| `wal_level` / "logical decoding requires wal_level >= logical" | Run `ALTER SYSTEM SET wal_level = 'logical';` and **restart Postgres**. |
+| `must be superuser or replication role` | The connecting role lacks `REPLICATION`. Run `ALTER ROLE <user> WITH REPLICATION;`. |
+| `publication "…" does not exist` | faucet doesn't create publications. `CREATE PUBLICATION … FOR TABLE …;` first. |
+| `replication slot … is active for PID …` on restart | A prior connection hasn't released the slot yet. The source retries (`slot_acquire_retries`, default 10, exp. backoff). Raise it, or wait for the old backend to exit. |
+| `before` is `null` on UPDATE / DELETE carries only the key | The table isn't `REPLICA IDENTITY FULL`. Run `ALTER TABLE … REPLICA IDENTITY FULL;` to capture the full pre-image. |
+| Replication connection dropped after ~60 s of silence | `status_update_interval` ≥ the server's `wal_sender_timeout`. Keep it well below (default 10 s vs 60 s). |
+| Process OOM-killed during a bulk load | A giant single transaction is buffered in full. Set `max_staged_records` sized to your RAM. |
+| `pg_wal` keeps growing / disk fills | A permanent slot is pinning WAL (no consumer, or fetch cycles too long). Run the pipeline more often, shorten cycles, or drop the slot via `PostgresCdcSource::drop_slot()` / `pg_drop_replication_slot(...)`. |
+| Pipeline doesn't resume / replays everything | No durable state store, or a `temporary` slot (resets on reconnect). Use `slot_type: permanent` + `file`/`postgres`/`redis` state. |
+| `proto_version must be 1` | Only pgoutput protocol v1 is supported. Remove the `proto_version` override or set it to `1`. |
+| Initial changes missing | The slot is created on first fetch — changes made **before** it exists aren't replicated. Create the slot (or do a warm-up fetch) before applying writes. |
+| `exactly_once` rejected by `faucet validate` | The sink isn't idempotent, no `state:` block, or a `dlq:` block is present. See [Exactly-once delivery](#exactly-once-delivery). |
+
+## See also
+
+- [Connector reference](https://pawansikawat.github.io/faucet-stream/reference/connectors.html) · [Replication cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/replication.html) · [State & resume cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/state.html) · [Upsert cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/upsert.html)
+- [faucet-source-postgres](https://crates.io/crates/faucet-source-postgres) (query-mode snapshots, not CDC) · [faucet-state-postgres](https://crates.io/crates/faucet-state-postgres) (pair as a `StateStore`) · `cli/examples/postgres_cdc_to_jsonl.yaml`
 
 ## License
 
-Licensed under MIT or Apache-2.0.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/source/postgres/README.md
+++ b/crates/source/postgres/README.md
@@ -5,113 +5,218 @@
 [![MSRV](https://img.shields.io/crates/msrv/faucet-source-postgres.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
 [![License](https://img.shields.io/crates/l/faucet-source-postgres.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-A PostgreSQL query source that executes SQL queries and returns rows as JSON records, with connection pooling via sqlx.
+A **PostgreSQL query source** for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem. Runs any SQL `SELECT` against a PostgreSQL database and streams the result set back row-by-row as `serde_json::Value` records.
 
-Part of the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
+Built on [`sqlx`](https://crates.io/crates/sqlx) with a reusable connection pool and a true row cursor (`Query::fetch`), so the source never buffers the whole result set in memory and the downstream sink starts writing as soon as the first batch is parsed off the wire. Reach for it to extract tables, joins, aggregates, or ad-hoc query results out of Postgres and land them in any faucet-stream sink — a file, an object store, a warehouse, a queue — with one declarative config and no glue code.
+
+## Feature highlights
+
+- **Streaming row cursor** — `stream_pages` drives a `sqlx` cursor and yields `batch_size`-sized pages; peak client memory is `O(batch_size)`, independent of total row count.
+- **Connection pooling** — a `PgPoolOptions` pool sized by `max_connections` is built once in `new()` and reused for every fetch.
+- **Type-aware row decoding** — integers, floats, booleans, `text`, `json`/`jsonb`, `timestamp(tz)`, `date`/`time`, `uuid`, `numeric`/`decimal`, and `bytea` are each converted to the right JSON shape (full numeric precision preserved as strings; binary base64-encoded).
+- **Positional bind parameters** — `params` from config are bound as native scalar types (`$1`, `$2`, …), so a numeric or boolean bind compares correctly against a typed column instead of being coerced to `jsonb`.
+- **Matrix-context binding** — `${parent.path}` tokens in the query are rewritten to additional positional bind markers and filled per parent record, so the same query template runs once per row produced by a parent in a [matrix](https://pawansikawat.github.io/faucet-stream/reference/config.html) pipeline.
+- **Credential redaction** — the connection URL is masked in `Debug` output and stripped from the emitted lineage dataset URI.
 
 ## Installation
 
 ```bash
+# As a library:
 cargo add faucet-source-postgres
-cargo add tokio --features full
+
+# In the CLI (opt-in connector feature):
+cargo install faucet-cli --features source-postgres
 ```
 
-Or via the umbrella crate:
+`source-postgres` is an opt-in feature — it is not in the CLI default build. Enable it (or the umbrella `source` aggregate) when you need this connector.
+
+## Quick start
+
+```yaml
+# pipeline.yaml — faucet run pipeline.yaml
+version: 1
+pipeline:
+  source:
+    type: postgres
+    config:
+      connection_url: postgres://user:pass@localhost:5432/app
+      query: SELECT id, name, email FROM users WHERE active = true
+  sink:
+    type: jsonl
+    config:
+      path: ./users.jsonl
+```
+
 ```bash
-cargo add faucet-stream --features source-postgres
+faucet run pipeline.yaml
 ```
 
-## Quick Start
+## Configuration reference
 
-```rust
-use faucet_source_postgres::{PostgresSource, PostgresSourceConfig};
-use faucet_core::Source;
+All fields live under `pipeline.source.config`.
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let config = PostgresSourceConfig::new(
-        "postgres://user:password@localhost:5432/mydb",
-        "SELECT id, name, email FROM users WHERE active = true",
-    );
-
-    let source = PostgresSource::new(config).await?;
-    let records = source.fetch_all().await?;
-
-    for record in &records {
-        println!("{}", record);
-    }
-    Ok(())
-}
-```
-
-## Configuration
-
-### PostgresSourceConfig
+### Core
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `connection_url` | `String` | *(required)* | PostgreSQL connection URL (e.g. `postgres://user:pass@host:5432/db`). Masked in debug output for security |
-| `query` | `String` | *(required)* | SQL query to execute |
-| `params` | `Vec<Value>` | `[]` | Bind parameters for the query (positional: `$1`, `$2`, etc.) |
-| `max_connections` | `u32` | `10` | Maximum number of connections in the pool |
-| `batch_size` | `usize` | `1000` | Rows per `StreamPage` emitted by `Source::stream_pages`. See [Streaming and batching](#streaming-and-batching) below |
+| `connection_url` | string | — *(required)* | PostgreSQL connection URL (`postgres://user:pass@host:5432/db`). Masked in `Debug` output and stripped from the lineage URI. |
+| `query` | string | — *(required)* | SQL query to execute. May contain positional placeholders `$1`, `$2`, … and `${parent.path}` matrix-context tokens. |
+| `params` | array | `[]` | Bind parameters for the query, in positional order. Each value is bound as its native scalar type (string / i64 / f64 / bool / null). |
 
-### Streaming and batching
+### Reliability & batching
 
-`PostgresSource::stream_pages` drives a sqlx row cursor (`Query::fetch`)
-without buffering the full result. Rows are accumulated into a `batch_size`
-buffer and yielded as a `StreamPage` once the buffer fills; the trailing
-partial page (if any) is yielded after the cursor drains.
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `max_connections` | int | `10` | Maximum connections in the `sqlx` pool. |
+| `batch_size` | int | `1000` | Rows per `StreamPage`. **`0` = no batching** — the cursor is fully drained and the entire result set is emitted in a single page (see [Streaming & batching](#streaming--batching)). Values above `MAX_BATCH_SIZE` (1,000,000) are rejected at construction. |
 
-`batch_size = 0` is the **"no batching" sentinel** — the cursor is drained
-completely and the entire result set is emitted in a single `StreamPage`.
-Use it for small lookup tables, or for downstream sinks (SQL `COPY`,
-BigQuery load jobs, Snowflake stage uploads) that prefer one large request
-to many small ones. Values larger than `MAX_BATCH_SIZE` (1,000,000) are
-rejected by `faucet_core::validate_batch_size`.
+## Examples
 
-The postgres query source has no incremental-replication mode, so every
-emitted page carries `bookmark: None`.
+### Parameterized query
 
-> **Note** — Postgres' wire protocol sends rows from a simple `SELECT` in a
-> single response (no server-side cursor). The streaming implementation
-> bounds *client-side* memory at `O(batch_size)` and lets the sink begin
-> writing as soon as the first batch is parsed off the wire. True
-> server-side cursor streaming (`DECLARE ... CURSOR FOR ...`) is tracked
-> separately as a follow-up.
+Bind a literal value into the query. Parameters are positional (`$1` maps to `params[0]`):
 
-### Supported Column Types
+```yaml
+version: 1
+name: shipped_orders
+pipeline:
+  source:
+    type: postgres
+    config:
+      connection_url: postgres://user:pass@localhost:5432/app
+      query: SELECT * FROM orders WHERE status = $1 AND total > $2
+      params:
+        - shipped
+        - 100.0
+  sink:
+    type: jsonl
+    config:
+      path: ./shipped_orders.jsonl
+```
 
-Columns are automatically converted to JSON values:
+### Archive a large table to S3, tuned pool and page size
 
-| PostgreSQL Type | JSON Type |
-|-----------------|-----------|
-| `json`, `jsonb` | Native JSON value |
-| `text`, `varchar`, `char` | `string` |
-| `int8`, `bigint` | `number` (i64) |
-| `int4`, `integer` | `number` (i32) |
-| `int2`, `smallint` | `number` (i16) |
-| `float8`, `double precision` | `number` (f64) |
-| `float4`, `real` | `number` (f32) |
-| `bool`, `boolean` | `boolean` |
-| `timestamptz` | `string` (RFC 3339) |
-| `timestamp`, `date`, `time` | `string` (ISO-8601) |
-| `uuid` | `string` |
-| `numeric`, `decimal` | `string` (exact precision preserved) |
-| `bytea` | `string` (base64) |
-| Other / `NULL` | `null` |
+```yaml
+version: 1
+name: postgres_to_s3
+pipeline:
+  source:
+    type: postgres
+    config:
+      connection_url: postgres://user:pass@localhost:5432/app
+      query: SELECT * FROM events WHERE created_at < $1
+      params:
+        - "2026-01-01T00:00:00Z"
+      max_connections: 12
+      batch_size: 5000
+  sink:
+    type: s3
+    config:
+      bucket: my-archive-bucket
+      prefix: events/2025/
+      region: us-east-1
+      file_extension: .jsonl
+      max_records_per_file: 50000
+      concurrency: 16
+```
 
-## Config Loading
+### Small lookup table, single page (load-job friendly)
 
-```rust
+Set `batch_size: 0` to emit the whole result set as one page — ideal feeding a sink that prefers one large request (SQL `COPY`, a BigQuery load job, a Snowflake stage upload):
+
+```yaml
+version: 1
+pipeline:
+  source:
+    type: postgres
+    config:
+      connection_url: postgres://user:pass@localhost:5432/app
+      query: SELECT code, label FROM country_codes
+      batch_size: 0
+  sink:
+    type: bigquery
+    config:
+      project_id: my-project
+      dataset_id: ref
+      table_id: country_codes
+```
+
+### Secrets-manager interpolation
+
+Keep the credentials out of the config file — the CLI resolves `${vault:…}` / `${aws-sm:…}` / `${gcp-sm:…}` / `${azure-kv:…}` at load time when built with the matching `secrets-*` feature:
+
+```yaml
+pipeline:
+  source:
+    type: postgres
+    config:
+      connection_url: ${vault:secret/data/warehouse#dsn}
+      query: SELECT * FROM customers
+```
+
+## Streaming & batching
+
+`PostgresSource::stream_pages` drives a `sqlx` row cursor (`Query::fetch`) without buffering the full result. Rows are accumulated into a `batch_size` buffer and yielded as a `StreamPage` once the buffer fills; the trailing partial page (if any) is yielded after the cursor drains. The pipeline writes each page to the sink as it arrives, so memory is bounded by `O(batch_size)` on both ends.
+
+`batch_size = 0` is the **"no batching" sentinel** — the cursor is drained completely and the entire result set is emitted in a single `StreamPage`. Use it for small lookup tables, or for downstream sinks (SQL `COPY`, BigQuery load jobs, Snowflake stage uploads) that prefer one large request to many small ones.
+
+The trait-level `batch_size` argument to `stream_pages` is informational; the source always uses its own config field as the authoritative knob, so a pipeline-supplied hint cannot silently override an explicit config value.
+
+This is a **query source with no incremental-replication mode** — it runs the configured query once and streams the result. Every emitted page therefore carries `bookmark: None`; there is no resume/state bookmark, no exactly-once delivery, and no upsert/write modes (those are sink concerns). For change data capture, see [`faucet-source-postgres-cdc`](https://crates.io/crates/faucet-source-postgres-cdc), which captures logical-replication changes and is resumable via a state store.
+
+> **Note** — Postgres' wire protocol sends rows from a simple `SELECT` in a single response (no server-side cursor by default). The streaming implementation bounds *client-side* memory at `O(batch_size)` and lets the sink begin writing as soon as the first batch is parsed off the wire.
+
+## Supported column types
+
+Columns are converted to JSON values by probing the row's value with each candidate Rust type in turn:
+
+| PostgreSQL type | JSON shape |
+|-----------------|------------|
+| `json`, `jsonb` | native JSON value |
+| `text`, `varchar`, `char` | string |
+| `int8` / `bigint` | number (i64) |
+| `int4` / `integer` | number (i32) |
+| `int2` / `smallint` | number (i16) |
+| `float8` / `double precision` | number (f64) |
+| `float4` / `real` | number (f32) |
+| `bool` / `boolean` | boolean |
+| `timestamptz` | string (RFC 3339) |
+| `timestamp`, `date`, `time` | string (ISO-8601) |
+| `uuid` | string (canonical hyphenated) |
+| `numeric`, `decimal` | string (exact precision preserved) |
+| `bytea` | string (base64) |
+| other / `NULL` | `null` |
+
+## Matrix-context binding
+
+In a parent/child [matrix](https://pawansikawat.github.io/faucet-stream/reference/config.html) pipeline, the query may reference fields from each parent record with `${parent_id.dotted.path}` tokens. At runtime these are rewritten to additional positional bind markers (appended after the static `params`) and filled per parent record, so a single query template fans out into one parameterized execution per parent row — never string-interpolated, so it is SQL-injection safe.
+
+```yaml
+matrix:
+  - id: parent
+    source: { ref: tenants }              # produces rows with a `tenant_id`
+  - id: child
+    parent: parent
+    source:
+      type: postgres
+      config:
+        connection_url: postgres://user:pass@localhost:5432/app
+        query: SELECT * FROM orders WHERE tenant_id = ${parent.tenant_id}
+```
+
+## Config loading
+
+Load a config from JSON, env vars, or a `.env` file via the helpers in `faucet_core::config`:
+
+```rust,no_run
 use faucet_core::config::{load_json, load_env_file};
 use faucet_source_postgres::PostgresSourceConfig;
 
+# fn example() -> Result<(), Box<dyn std::error::Error>> {
 let config: PostgresSourceConfig = load_json("config.json")?;
 let config: PostgresSourceConfig = load_env_file(".env", "PG_SOURCE")?;
+# Ok(()) }
 ```
-
-### Example JSON config
 
 ```json
 {
@@ -123,76 +228,84 @@ let config: PostgresSourceConfig = load_env_file(".env", "PG_SOURCE")?;
 }
 ```
 
-### Example .env file
-
 ```env
 PG_SOURCE_CONNECTION_URL=postgres://user:password@localhost:5432/mydb
 PG_SOURCE_QUERY=SELECT * FROM users
 PG_SOURCE_MAX_CONNECTIONS=10
 ```
 
-## Config Schema Introspection
+## Schema introspection
 
-```rust
-use faucet_core::Source;
+Print the JSON Schema for this source's config (drives `faucet validate` and `faucet init`):
 
-let source = PostgresSource::new(config).await?;
-let schema = source.config_schema();
-println!("{}", serde_json::to_string_pretty(&schema)?);
+```bash
+faucet schema source postgres
 ```
 
-## Examples
+## Library usage
 
-### Simple query
-
-```rust
-use faucet_source_postgres::{PostgresSource, PostgresSourceConfig};
-use faucet_core::Source;
-
-let config = PostgresSourceConfig::new(
-    "postgres://localhost/mydb",
-    "SELECT id, name, email FROM customers ORDER BY id",
-);
-let source = PostgresSource::new(config).await?;
-let customers = source.fetch_all().await?;
-```
-
-### Parameterized query
-
-```rust
+```rust,no_run
 use faucet_source_postgres::{PostgresSource, PostgresSourceConfig};
 use faucet_core::Source;
 use serde_json::json;
 
+# async fn example() -> Result<(), Box<dyn std::error::Error>> {
 let config = PostgresSourceConfig::new(
-    "postgres://localhost/mydb",
+    "postgres://user:pass@localhost:5432/app",
     "SELECT * FROM orders WHERE status = $1 AND total > $2",
 )
-.params(vec![json!("shipped"), json!(100.0)]);
+.params(vec![json!("shipped"), json!(100.0)])
+.with_max_connections(20)
+.with_batch_size(5000);
 
 let source = PostgresSource::new(config).await?;
+
+// Drain the whole result set:
 let orders = source.fetch_all().await?;
+for order in &orders {
+    println!("{order}");
+}
+# Ok(()) }
 ```
 
-### Custom connection pool size
+To wire it into a streaming pipeline, hand the source to `faucet_core::Pipeline` (or `run_stream`) together with any sink — each `StreamPage` is written as it arrives.
 
-```rust
-use faucet_source_postgres::{PostgresSource, PostgresSourceConfig};
+## How it works
 
-let config = PostgresSourceConfig::new(
-    "postgres://localhost/mydb",
-    "SELECT * FROM large_table",
-)
-.with_max_connections(20);
-
-let source = PostgresSource::new(config).await?;
-let records = source.fetch_all().await?;
-```
+- **Pool reuse** — `PostgresSource::new` validates `batch_size`, then builds one `PgPool` (`PgPoolOptions::max_connections(...)`) and stores it on the struct. Every fetch borrows a connection from the pool; nothing is reconnected per call.
+- **True cursor streaming** — `stream_pages` calls `Query::fetch` (a `sqlx` cursor) and pulls rows with `try_next()`, converting each `PgRow` to a JSON object keyed by column name. Rows are batched into a reusable buffer and the buffer is swapped (`mem::replace`) on each yield to avoid reallocation churn.
+- **Typed binding** — config and context parameters are bound as native scalars (string / i64 / f64 / bool / null), never as raw `jsonb`. Binding a `serde_json::Value` directly would encode it as `jsonb` and break comparisons against typed columns (e.g. `WHERE id = $1` against an integer column).
+- **Errors** — connection and query failures surface as `FaucetError::Config` with the underlying `sqlx` message; an out-of-range `batch_size` is rejected at construction.
 
 ## Lineage dataset URI
 
 `postgres://<host>:<port>/<db>?query=<sql>` (credentials stripped) — e.g. `postgres://host:5432/app?query=SELECT id FROM orders`.
 
+## Feature flags
+
+This crate has no optional features of its own. Enable it in the CLI or umbrella crate via the `source-postgres` feature.
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause & fix |
+|---------|--------------------|
+| `FaucetError::Config: PostgreSQL connection failed: …` | Bad host/port/db, wrong credentials, or the server is unreachable / not accepting TCP. Verify the `connection_url` and that the DB is up and reachable from the runner. |
+| `FaucetError::Config: PostgreSQL query failed: …` | Invalid SQL, a missing table/column, or insufficient privileges. Run the query directly with `psql` to confirm it works for that role. |
+| `operator does not exist: integer = text` (or similar) | A `params` value's JSON type doesn't match the column type. Use the matching JSON scalar — e.g. `42` (number) for an integer column, not `"42"` (string). |
+| `FaucetError::Config: batch_size must be …` | `batch_size` exceeds `MAX_BATCH_SIZE` (1,000,000). Lower it, or use `0` for a single un-chunked page. |
+| Run uses too much memory on a huge table | Lower `batch_size` so each page is smaller, and ensure the sink flushes per page. Avoid `batch_size: 0` for very large result sets — it materializes everything in one page. |
+| A `numeric`/`timestamp`/`uuid` arrives as a string | Intentional — these are encoded as strings to preserve exact precision / format. Cast downstream (e.g. a `cast` transform) if you need a JSON number. |
+| A column comes back as `null` unexpectedly | The column's Postgres type isn't in the supported-type table above and falls through to `null`. Cast it in SQL (e.g. `SELECT my_col::text`) so it decodes as a string. |
+| Connection-pool exhaustion under high matrix fan-out | Many matrix children share the pool. Raise `max_connections`, or lower the pipeline's `execution.max_concurrent`. |
+| Credentials appear in logs | The DSN is masked in `Debug` and stripped from the lineage URI, but never run a connector config holding a resolved secret with `FAUCET_LOG=debug` — third-party `sqlx` logging is outside faucet's redaction boundary. |
+
+## See also
+
+- [Connector reference](https://pawansikawat.github.io/faucet-stream/reference/connectors.html) · [Choosing a connector](https://pawansikawat.github.io/faucet-stream/reference/choosing.html)
+- [`faucet-source-postgres-cdc`](https://crates.io/crates/faucet-source-postgres-cdc) — resumable change data capture via logical replication
+- [`faucet-sink-postgres`](https://crates.io/crates/faucet-sink-postgres) — the PostgreSQL sink (insert / upsert / delete)
+- [`faucet-source-mysql`](https://crates.io/crates/faucet-source-mysql) · [`faucet-source-sqlite`](https://crates.io/crates/faucet-source-sqlite) · [`faucet-source-mssql`](https://crates.io/crates/faucet-source-mssql)
+
 ## License
 
-Licensed under MIT or Apache-2.0.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/source/postgres/README.md
+++ b/crates/source/postgres/README.md
@@ -2,6 +2,8 @@
 
 [![Crates.io](https://img.shields.io/crates/v/faucet-source-postgres.svg)](https://crates.io/crates/faucet-source-postgres)
 [![Docs.rs](https://docs.rs/faucet-source-postgres/badge.svg)](https://docs.rs/faucet-source-postgres)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-source-postgres.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-source-postgres.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
 A PostgreSQL query source that executes SQL queries and returns rows as JSON records, with connection pooling via sqlx.
 

--- a/crates/source/redis/README.md
+++ b/crates/source/redis/README.md
@@ -2,6 +2,8 @@
 
 [![Crates.io](https://img.shields.io/crates/v/faucet-source-redis.svg)](https://crates.io/crates/faucet-source-redis)
 [![Docs.rs](https://docs.rs/faucet-source-redis/badge.svg)](https://docs.rs/faucet-source-redis)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-source-redis.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-source-redis.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
 A Redis source that reads records from lists, streams, or key patterns, returning them as JSON.
 

--- a/crates/source/redis/README.md
+++ b/crates/source/redis/README.md
@@ -5,143 +5,222 @@
 [![MSRV](https://img.shields.io/crates/msrv/faucet-source-redis.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
 [![License](https://img.shields.io/crates/l/faucet-source-redis.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-A Redis source that reads records from lists, streams, or key patterns, returning them as JSON.
+A **Redis** source for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem. Reads records from a Redis **list**, **stream**, or a set of keys matched by a **glob pattern**, yielding each record as a `serde_json::Value`.
 
-Part of the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
+Built on a lazily-opened, reused `MultiplexedConnection` and each mode's native paging primitive (`LRANGE`, `XRANGE`, `SCAN` + `MGET`), so it streams page-by-page without buffering the whole dataset in memory. Reach for it to drain a work queue, replay a stream's history, or load a keyspace into any faucet-stream sink.
+
+## Feature highlights
+
+- **Three source modes** — `List` (FIFO list elements), `Stream` (entries with IDs + fields), and `Keys` (glob-matched keys with their values).
+- **Native streaming in all three modes** — `stream_pages` walks the list, stream, or keyspace in pages so the sink writes as data arrives.
+- **Server-side cursoring** — `Keys` drives the `SCAN` cursor manually and `MGET`s a page at a time, so a million-key namespace never materializes in memory at once.
+- **Consumer-group reads** — `Stream` + `group`/`consumer` uses `XREADGROUP` on the `fetch_all` path, draining all currently-pending new messages (not just one batch).
+- **JSON-aware values** — list elements, stream field values, and key values are parsed as JSON when they parse, and returned as strings otherwise.
+- **Connection reuse** — one multiplexed connection is opened on first use and cheaply cloned across every call (no per-call TCP/AUTH handshake).
+- **Secrets-safe** — the connection URL is masked in `Debug` output and credentials are stripped from the lineage dataset URI.
 
 ## Installation
 
 ```bash
+# As a library:
 cargo add faucet-source-redis
 cargo add tokio --features full
-```
 
-Or via the umbrella crate:
-```bash
+# Or via the umbrella crate:
 cargo add faucet-stream --features source-redis
+
+# In the CLI (opt-in connector feature):
+cargo install faucet-cli --features source-redis
 ```
 
-## Quick Start
+The Redis source is opt-in — it is not in the CLI's default feature set.
 
-```rust
-use faucet_source_redis::{RedisSource, RedisSourceConfig, RedisSourceType};
+## Quick start
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let config = RedisSourceConfig::new(
-        "redis://127.0.0.1:6379",
-        RedisSourceType::List { key: "my_queue".into() },
-    );
-
-    let source = RedisSource::new(config);
-    let records = source.fetch_all().await?;
-
-    for record in &records {
-        println!("{}", record);
-    }
-    Ok(())
-}
+```yaml
+# pipeline.yaml — faucet run pipeline.yaml
+version: 1
+pipeline:
+  source:
+    type: redis
+    config:
+      url: redis://127.0.0.1:6379
+      source_type:
+        type: List
+        key: jobs:pending
+  sink:
+    type: jsonl
+    config:
+      path: ./jobs.jsonl
 ```
 
-## Configuration
+```bash
+faucet run pipeline.yaml
+```
 
-### RedisSourceConfig
+## Configuration reference
+
+### `RedisSourceConfig`
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `url` | `String` | *(required)* | Redis connection URL (e.g. `"redis://127.0.0.1:6379"`). Masked in debug output for security |
-| `source_type` | `RedisSourceType` | *(required)* | The type of Redis data structure to read from |
-| `max_records` | `Option<usize>` | `None` | Optional maximum number of records to return (truncates after fetching) |
-| `batch_size` | `usize` | `DEFAULT_BATCH_SIZE` (1000) | Records per emitted `StreamPage` when driven via `Source::stream_pages`. `0` is the "no batching" sentinel — drains the underlying primitive and emits a single page. See [Streaming and batching](#streaming-and-batching). |
+| `url` | string | — *(required)* | Redis connection URL, e.g. `redis://127.0.0.1:6379` or `redis://user:pass@host:6379/0`. Masked in `Debug` output. |
+| `source_type` | `RedisSourceType` | — *(required)* | The Redis data structure to read from — `List`, `Stream`, or `Keys` (see below). |
+| `max_records` | int | *(unbounded)* | Optional cap on the total number of records returned. Honored by both `fetch_all` and streaming. |
+| `batch_size` | int | `1000` | Records per emitted `StreamPage`, mapped onto each mode's native paging primitive. **`0` = no batching** (drain into one page). See [Streaming & batching](#streaming--batching). |
 
-### Source Types (RedisSourceType)
+### `source_type` — `RedisSourceType`
 
-#### List
+A tagged enum (`type` discriminator). Pick exactly one variant.
 
-Read all elements from a Redis list via `LRANGE 0 -1`.
+#### `List`
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `key` | `String` | The list key |
-
-Each list element is parsed as JSON. If an element is not valid JSON, it is returned as a JSON string.
-
-#### Stream
-
-Read entries from a Redis stream via `XREAD` or `XREADGROUP`.
+Reads list elements via `LRANGE`. Each element is parsed as JSON, falling back to a JSON string.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `key` | `String` | *(required)* | The stream key |
-| `group` | `Option<String>` | `None` | Consumer group name. When set, uses `XREADGROUP` |
-| `consumer` | `Option<String>` | `None` | Consumer name within the group (required when `group` is set) |
-| `count` | `Option<usize>` | `None` (100 for `XREADGROUP`) | Maximum number of entries to read per call |
+| `type` | string | — | Literal `List`. |
+| `key` | string | — *(required)* | The list key. |
 
-Each stream entry is returned as:
+#### `Stream`
+
+Reads stream entries via `XRANGE` (streaming) or `XREAD` / `XREADGROUP` (the `fetch_all` consumer-group convenience path).
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `type` | string | — | Literal `Stream`. |
+| `key` | string | — *(required)* | The stream key. |
+| `group` | string | *(none)* | Consumer group name. When set, `fetch_all` uses `XREADGROUP`. |
+| `consumer` | string | *(none)* | Consumer name within the group (required when `group` is set). |
+| `count` | int | `100` (for `XREADGROUP`) | Max entries read per `XREAD`/`XREADGROUP` call on the `fetch_all` path. Ignored by streaming, which uses `batch_size`. |
+
+Each entry is returned as:
+
 ```json
-{
-  "id": "1234567890-0",
-  "fields": { "field1": "value1", "field2": "value2" }
-}
+{ "id": "1234567890-0", "fields": { "field1": "value1", "field2": "value2" } }
 ```
 
-Stream field values are parsed as JSON where possible; otherwise they are returned as strings.
+#### `Keys`
 
-#### Keys
+Scans keys matching a glob `pattern` via `SCAN`, then `MGET`s each batch.
 
-Scan for keys matching a glob pattern, then `MGET` all matched keys in a single round-trip.
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `pattern` | `String` | Glob pattern for `SCAN` (e.g. `"user:*"`) |
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `type` | string | — | Literal `Keys`. |
+| `pattern` | string | — *(required)* | Glob pattern for `SCAN MATCH`, e.g. `user:*`. |
 
 Each key-value pair is returned as:
+
 ```json
-{
-  "key": "user:123",
-  "value": { "name": "Alice", "email": "alice@example.com" }
-}
+{ "key": "user:123", "value": { "name": "Alice", "email": "alice@example.com" } }
 ```
 
-Values are parsed as JSON where possible; otherwise they are returned as strings.
+Stream field values and key values are parsed as JSON when possible; otherwise returned as strings.
 
-## Streaming and batching
+## Examples
 
-`RedisSource` overrides
-[`Source::stream_pages`](https://docs.rs/faucet-core/latest/faucet_core/trait.Source.html#method.stream_pages)
-so the pipeline can write pages to the sink as they arrive instead of
-buffering the full result set. Each mode maps `batch_size` onto its native
-paging primitive:
+### Drain a list into SQLite
+
+```yaml
+version: 1
+name: redis_to_sqlite
+pipeline:
+  source:
+    type: redis
+    config:
+      url: redis://localhost:6379
+      source_type:
+        type: List
+        key: jobs:pending
+      max_records: 10000
+  sink:
+    type: sqlite
+    config:
+      database_url: sqlite:./cache.db
+      table_name: jobs
+      column_mapping:
+        type: auto_map
+      batch_size: 500
+```
+
+### Replay a stream's history
+
+```yaml
+version: 1
+pipeline:
+  source:
+    type: redis
+    config:
+      url: redis://localhost:6379
+      source_type:
+        type: Stream
+        key: order-events
+      batch_size: 2000
+  sink:
+    type: jsonl
+    config:
+      path: ./order-events.jsonl
+```
+
+### Consumer-group read
+
+```yaml
+version: 1
+pipeline:
+  source:
+    type: redis
+    config:
+      url: redis://localhost:6379
+      source_type:
+        type: Stream
+        key: events
+        group: analytics-group
+        consumer: worker-1
+        count: 200
+  sink:
+    type: stdout
+    config:
+      format: jsonl
+```
+
+> Consumer-group fields (`group` / `consumer`) apply only to the `XREADGROUP` path used by `fetch_all`. Streaming via `stream_pages` always uses `XRANGE`.
+
+### Scan a keyspace by pattern
+
+```yaml
+version: 1
+pipeline:
+  source:
+    type: redis
+    config:
+      url: redis://localhost:6379
+      source_type:
+        type: Keys
+        pattern: "session:*"
+      max_records: 500
+  sink:
+    type: jsonl
+    config:
+      path: ./sessions.jsonl
+```
+
+## Streaming & batching
+
+`RedisSource` overrides [`Source::stream_pages`](https://docs.rs/faucet-core/latest/faucet_core/trait.Source.html#method.stream_pages) so the pipeline writes pages to the sink as they arrive instead of buffering the full result set. Each mode maps `batch_size` onto its native paging primitive:
 
 | Mode | Native primitive | Per-page command |
 |------|------------------|------------------|
-| `Keys` | `SCAN COUNT batch_size` cursor → `MGET` per batch | `SCAN MATCH <pattern> COUNT <batch_size>` then `MGET key1 ... keyN` |
-| `Stream` | `XRANGE - + COUNT batch_size`, advancing start ID | `XRANGE <key> <start> + COUNT <batch_size>` |
 | `List` | `LRANGE start stop`, sliding the window | `LRANGE <key> <start> <start + batch_size - 1>` |
+| `Stream` | `XRANGE start + COUNT batch_size`, advancing the start ID | `XRANGE <key> <start> + COUNT <batch_size>` |
+| `Keys` | `SCAN MATCH pattern COUNT batch_size` cursor → `MGET` per page | `SCAN <cursor> MATCH <pattern> COUNT <batch_size>` then `MGET key1 … keyN` |
 
-`batch_size = 0` is the "no batching" sentinel:
+**`batch_size = 0`** is the "no batching" sentinel — every mode drains its primitive into a single page: `LRANGE 0 -1` for `List`, `XRANGE - +` for `Stream`, and the full `SCAN` cursor followed by one `MGET` for `Keys`. Useful for small lookup tables or for sinks (SQL `COPY`, BigQuery load jobs) that prefer one large request.
 
-- `Keys`: the `SCAN` cursor is drained to completion and a single `MGET`
-  retrieves all matched keys; one `StreamPage` is yielded.
-- `Stream`: a single `XRANGE - +` drains the stream; one `StreamPage` is
-  yielded.
-- `List`: a single `LRANGE 0 -1` drains the list; one `StreamPage` is
-  yielded.
+The trait-level `batch_size` argument passed to `stream_pages` is **ignored** in favour of `RedisSourceConfig::batch_size` — the config is the authoritative, user-facing knob, so a pipeline-supplied hint can never silently override an explicit config value.
 
-Bookmarks are `None` on every page — the Redis source has no
-incremental-replication mode today.
+Every emitted page carries `bookmark: None` — the Redis source has no incremental-replication / resume mode today, so it is **not resumable** and does not support exactly-once delivery.
 
-When the consumer-group fields (`group` / `consumer`) are set, they apply only
-to the `XREADGROUP` path used by `fetch_all`. Streaming via `stream_pages`
-always uses `XRANGE` because the page-then-write contract is incompatible
-with `XREADGROUP`'s deferred-acknowledgement semantics.
-
-The trait-level `batch_size` argument that `stream_pages` receives is ignored
-in favour of `RedisSourceConfig::batch_size` — the config is the user-facing
-knob, and routing the pipeline hint through it would silently override an
-explicit config value.
-
-## Config Loading
+## Config loading
 
 ```rust
 use faucet_core::config::{load_json, load_env_file};
@@ -151,88 +230,46 @@ let config: RedisSourceConfig = load_json("config.json")?;
 let config: RedisSourceConfig = load_env_file(".env", "REDIS_SOURCE")?;
 ```
 
-### Example JSON config (List)
-
-```json
-{
-  "url": "redis://127.0.0.1:6379",
-  "source_type": {
-    "type": "List",
-    "key": "task_queue"
-  },
-  "max_records": 1000
-}
-```
-
-### Example JSON config (Stream with consumer group)
-
-```json
-{
-  "url": "redis://127.0.0.1:6379",
-  "source_type": {
-    "type": "Stream",
-    "key": "events",
-    "group": "my-consumer-group",
-    "consumer": "worker-1",
-    "count": 100
-  }
-}
-```
-
-### Example JSON config (Keys)
-
-```json
-{
-  "url": "redis://127.0.0.1:6379",
-  "source_type": {
-    "type": "Keys",
-    "pattern": "session:*"
-  },
-  "max_records": 500
-}
-```
-
-### Example .env file
-
 ```env
+# .env
 REDIS_SOURCE_URL=redis://127.0.0.1:6379
 REDIS_SOURCE_MAX_RECORDS=1000
 ```
 
-## Config Schema Introspection
+## Schema introspection
+
+```bash
+faucet schema source redis
+```
 
 ```rust
 use faucet_core::Source;
-
-let source = RedisSource::new(config);
-let schema = source.config_schema();
-println!("{}", serde_json::to_string_pretty(&schema)?);
+let source = faucet_source_redis::RedisSource::new(config)?;
+println!("{}", serde_json::to_string_pretty(&source.config_schema())?);
 ```
 
-## Examples
+## Library usage
 
-### Reading from a list
-
-```rust
+```rust,no_run
 use faucet_source_redis::{RedisSource, RedisSourceConfig, RedisSourceType};
 use faucet_core::Source;
 
+# async fn example() -> Result<(), Box<dyn std::error::Error>> {
+// List mode, capped at 100 records.
 let config = RedisSourceConfig::new(
     "redis://127.0.0.1:6379",
     RedisSourceType::List { key: "notifications".into() },
 )
-.max_records(100);
+.max_records(100)
+.with_batch_size(500);
 
-let source = RedisSource::new(config);
-let notifications = source.fetch_all().await?;
-```
+let source = RedisSource::new(config)?;
+let records = source.fetch_all().await?;
+for record in &records {
+    println!("{record}");
+}
 
-### Reading from a stream with consumer group
-
-```rust
-use faucet_source_redis::{RedisSource, RedisSourceConfig, RedisSourceType};
-use faucet_core::Source;
-
+// Stream mode with a consumer group.
 let config = RedisSourceConfig::new(
     "redis://127.0.0.1:6379",
     RedisSourceType::Stream {
@@ -242,38 +279,48 @@ let config = RedisSourceConfig::new(
         count: Some(200),
     },
 );
-
-let source = RedisSource::new(config);
+let source = RedisSource::new(config)?;
 let events = source.fetch_all().await?;
-
 for event in &events {
-    println!("Event {}: {:?}", event["id"], event["fields"]);
+    println!("event {}: {:?}", event["id"], event["fields"]);
 }
+# Ok(()) }
 ```
 
-### Scanning keys by pattern
+`RedisSource::new` is synchronous and does no I/O — the connection is opened lazily on first use. It returns `Err(FaucetError::Config)` only on an out-of-range `batch_size`. To drive it through the streaming pipeline, hand the source to `faucet_core::run_stream` or `Pipeline`.
 
-```rust
-use faucet_source_redis::{RedisSource, RedisSourceConfig, RedisSourceType};
-use faucet_core::Source;
+## How it works
 
-let config = RedisSourceConfig::new(
-    "redis://127.0.0.1:6379",
-    RedisSourceType::Keys { pattern: "user:*".into() },
-);
+The multiplexed connection is opened **once** on first use (`OnceCell`) and cloned per call — `MultiplexedConnection` shares a single underlying socket, so there is no repeated TCP/AUTH handshake. List and stream pages advance a server-side cursor (a sliding `LRANGE` window; the immediate-successor stream ID via `next_stream_id`) so no entry is re-emitted across page boundaries. `Keys` drives the `SCAN` cursor manually and `MGET`s a page as soon as `batch_size` keys accumulate, rather than materializing the whole matched keyset first; keys deleted between `SCAN` and `MGET` are dropped.
 
-let source = RedisSource::new(config);
-let users = source.fetch_all().await?;
-
-for user in &users {
-    println!("Key: {}, Value: {}", user["key"], user["value"]);
-}
-```
+**List paging consistency caveat:** index-based `LRANGE` paging is only stable if the list is not mutated mid-scan. A concurrent `LPUSH`/`LPOP` shifts every element's index, so a writer pushing/popping while the source drains can skip or duplicate elements across page boundaries. For a queue being consumed concurrently, prefer a Redis Stream (`XRANGE` / consumer groups) over a list.
 
 ## Lineage dataset URI
 
-`redis://<host>:<port>/<db>?key=<key>` or `?stream=<stream>` (credentials stripped) — e.g. `redis://localhost:6379/0?key=my-list`.
+`redis://<host>:<port>/<db>?key=<key>` (List / Keys) or `?stream=<stream>` (Stream), with credentials stripped — e.g. `redis://localhost:6379/0?key=jobs:pending`.
+
+## Feature flags
+
+This crate has no optional features of its own. Enable it in the CLI / umbrella crate via the `source-redis` feature.
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause & fix |
+|---------|--------------------|
+| `FaucetError::Config: invalid Redis URL` | The `url` is malformed. Use the `redis://[user:pass@]host:port[/db]` form (or `rediss://` for TLS). |
+| `FaucetError::Config: batch_size` | `batch_size` exceeds `MAX_BATCH_SIZE` (1,000,000). Lower it, or use `0` for a single page. |
+| `FaucetError::Source: Redis connection failed` | The server is unreachable or auth failed. Check host/port, credentials in the URL, and that Redis is running. |
+| `XREADGROUP failed: NOGROUP` | The consumer group doesn't exist. Create it with `XGROUP CREATE <key> <group> $ MKSTREAM` before running. |
+| Consumer-group read returns nothing | `XREADGROUP` with `>` only delivers **new** (never-delivered) messages. Already-pending entries for this consumer are not re-read here. |
+| Streaming ignores `group` / `consumer` | Intentional — `stream_pages` always uses `XRANGE`; consumer-group semantics only apply to `fetch_all`. |
+| List read skips/duplicates rows | The list is being mutated mid-scan (`LPUSH`/`LPOP`). Use a Redis Stream for a concurrently-consumed queue. |
+| Fewer key records than `SCAN` matched | Keys were deleted between `SCAN` and `MGET`; missing values are dropped. Expected for a live keyspace. |
+| Values arrive as strings, not objects | The stored value isn't valid JSON, so it's returned verbatim as a string. Store JSON to get parsed objects. |
+
+## See also
+
+- [Connector reference](https://pawansikawat.github.io/faucet-stream/reference/connectors.html) · [faucet-sink-redis](https://crates.io/crates/faucet-sink-redis) · [faucet-source-kafka](https://crates.io/crates/faucet-source-kafka)
 
 ## License
 
-Licensed under MIT or Apache-2.0.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/source/rest/README.md
+++ b/crates/source/rest/README.md
@@ -2,6 +2,8 @@
 
 [![Crates.io](https://img.shields.io/crates/v/faucet-source-rest.svg)](https://crates.io/crates/faucet-source-rest)
 [![Docs.rs](https://docs.rs/faucet-source-rest/badge.svg)](https://docs.rs/faucet-source-rest)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-source-rest.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-source-rest.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
 A declarative, config-driven REST API client with pluggable authentication, pagination, schema inference, and incremental replication. Attach transforms by wrapping the source with [`faucet_core::TransformingSource`](https://docs.rs/faucet-core/latest/faucet_core/struct.TransformingSource.html).
 

--- a/crates/source/rest/README.md
+++ b/crates/source/rest/README.md
@@ -5,195 +5,331 @@
 [![MSRV](https://img.shields.io/crates/msrv/faucet-source-rest.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
 [![License](https://img.shields.io/crates/l/faucet-source-rest.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-A declarative, config-driven REST API client with pluggable authentication, pagination, schema inference, and incremental replication. Attach transforms by wrapping the source with [`faucet_core::TransformingSource`](https://docs.rs/faucet-core/latest/faucet_core/struct.TransformingSource.html).
+A declarative, config-driven **REST API source** with pluggable authentication, six pagination styles, schema inference, and incremental replication. Part of the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
 
-Part of the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
+This is the flagship faucet-stream source: point it at any JSON-over-HTTP API, describe how to authenticate and paginate, and it streams every record page-by-page into any faucet-stream sink — with retries, `Retry-After` honouring, loop detection, and resumable bookmarks — all from one YAML config and no glue code.
+
+## Feature highlights
+
+- **Six pagination styles** — `Cursor`, `LinkHeader`, `NextLinkInBody`, `PageNumber`, `Offset`, and `None`, each with its own termination/loop guard so a misbehaving API can't loop forever.
+- **Eight auth methods** — `bearer`, `basic`, `api_key` (header), `api_key_query`, `oauth2` (client credentials with token caching), `token_endpoint` (fetch a token from an arbitrary endpoint), `custom` headers, and `none` — plus shared `auth: { ref }` providers via the CLI's top-level `auth:` catalog.
+- **Memory-bounded streaming** — overrides `Source::stream_pages`, so `Pipeline::run` writes each page to the sink as it arrives; peak memory stays `O(page)` regardless of total record count.
+- **Resilient by default** — exponential backoff with jitter (capped at 60 s), `429` `Retry-After` (delta-seconds or HTTP-date) honouring, and a `tolerated_http_errors` allowlist for legitimately-absent resources.
+- **Incremental replication** — bookmark by any record field, persist it across runs with a state store, and resume from the last value.
+- **Concurrent partitions** — fan a single config across many path substitutions (`/orgs/{org_id}/users`) and fetch them concurrently.
+- **Schema inference** — sample records to produce a JSON Schema, or supply your own; Singer/Meltano `primary_keys` / `name` metadata is carried through.
+- **Client built once** — the `reqwest` client is constructed in `new()` and reused for every request and partition.
 
 ## Installation
 
 ```bash
+# As a library:
 cargo add faucet-source-rest
 cargo add tokio --features full
+
+# In the CLI (source-rest is a DEFAULT feature — already enabled):
+cargo install faucet-cli
 ```
 
-Or via the umbrella crate:
+The umbrella crate enables it by default too:
+
 ```bash
 cargo add faucet-stream --features source-rest
 ```
 
-## Quick Start
+## Quick start
 
-```rust
-use faucet_source_rest::{RestStream, RestStreamConfig};
+```yaml
+# pipeline.yaml — faucet run pipeline.yaml
+version: 1
+name: github_issues_to_jsonl
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let config = RestStreamConfig::new("https://api.example.com", "/users")
-        .max_pages(5);
-
-    let stream = RestStream::new(config)?;
-    let records = stream.fetch_all().await?;
-
-    for record in &records {
-        println!("{}", record);
-    }
-    Ok(())
-}
+pipeline:
+  source:
+    type: rest
+    config:
+      base_url: https://api.github.com
+      path: /repos/PawanSikawat/faucet-stream/issues
+      method: GET
+      auth:
+        type: bearer
+        config:
+          token: ${env:GITHUB_TOKEN}
+      query_params:
+        state: open
+        per_page: "100"
+      pagination:
+        type: LinkHeader
+  sink:
+    type: jsonl
+    config:
+      path: ./out/issues.jsonl
 ```
 
-## Configuration
+```bash
+faucet run pipeline.yaml
+```
 
-### Core Request Fields
+## Configuration reference
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `base_url` | `String` | `""` | Base URL of the API (trailing slash is trimmed) |
-| `path` | `String` | `""` | URL path relative to `base_url`. Supports `{key}` placeholders for partition substitution (e.g. `"/orgs/{org_id}/users"`) |
-| `method` | `Method` | `GET` | HTTP method for the request |
-| `auth` | `Auth` | `Auth::None` | Authentication method (see Authentication section) |
-| `headers` | `HeaderMap` | empty | Additional HTTP headers to include in every request |
-| `query_params` | `HashMap<String, String>` | empty | Query parameters to include in every request |
-| `body` | `Option<Value>` | `None` | JSON request body (sent with `Content-Type: application/json`) |
-
-### Pagination Fields
+### Core request
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `pagination` | `PaginationStyle` | `PaginationStyle::None` | Pagination strategy (see Pagination section) |
-| `records_path` | `Option<String>` | `None` | JSONPath expression to extract records from the response body |
-| `max_pages` | `Option<usize>` | `Some(100)` | Maximum number of pages to fetch. Acts as a hard cap across all pagination styles |
-| `request_delay` | `Option<Duration>` | `None` | Delay between consecutive page requests |
-
-### Reliability Fields
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `timeout` | `Option<Duration>` | `Some(30s)` | HTTP request timeout per individual request |
-| `max_retries` | `u32` | `3` | Maximum number of retries on transient failures |
-| `retry_backoff` | `Duration` | `1s` | Base duration for exponential backoff between retries. The per-attempt sleep is `retry_backoff × 2^attempt`, **capped at 60s** and scaled by random jitter in `[0.5, 1.5)` (decorrelated across concurrent retries) to avoid a thundering herd. On `429`, the server's `Retry-After` (delta-seconds **or** an RFC 7231 HTTP-date) is honored instead. |
-| `tolerated_http_errors` | `Vec<u16>` | `[]` | HTTP status codes treated as an empty page **on the first request only** (i.e. a legitimately absent/empty resource). Mid-pagination a tolerated status is surfaced as an error instead of silently ending the stream — otherwise a transient failure on page _N_ would drop every later page as a "successful" run. Only safe for genuinely-empty resources. |
-
-A **`204 No Content`** response — or any `2xx` with an empty / whitespace-only
-body — is treated as an empty page ("no data"), not a parse error. A non-empty
-body that isn't valid JSON still fails loudly with `FaucetError::Json`.
-
-### Replication Fields
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `replication_method` | `ReplicationMethod` | `FullTable` | `FullTable` fetches all records; `Incremental` filters by bookmark |
-| `replication_key` | `Option<String>` | `None` | Field name used for incremental replication bookmarking |
-| `start_replication_value` | `Option<Value>` | `None` | Bookmark value; records at or before this value are filtered out in incremental mode |
-
-### Singer / Meltano Metadata Fields
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `name` | `Option<String>` | `None` | Human-readable stream name (used in logging and Singer SCHEMA messages) |
-| `primary_keys` | `Vec<String>` | `[]` | Field names that uniquely identify a record (Singer `key_properties`) |
-| `schema` | `Option<Value>` | `None` | JSON Schema describing the structure of each record |
-| `schema_sample_size` | `usize` | `100` | Maximum number of records to sample when inferring schema. `0` means sample all available records |
-
-### Partition Fields
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `partitions` | `Vec<HashMap<String, Value>>` | `[]` | Each entry is a context map substituted into `path` placeholders. The stream executes once per partition and concatenates results. Empty means run once with no substitution |
-| `partition_concurrency` | `Option<usize>` | `None` | Maximum number of partitions to fetch concurrently. `None` means sequential processing |
-
-### Authentication
-
-The `Auth` enum supports the following strategies:
-
-| Variant | Fields | Description |
-|---------|--------|-------------|
-| `None` | -- | No authentication |
-| `Bearer { token }` | `String` | Bearer token in the `Authorization` header |
-| `Basic { username, password }` | `String`, `String` | HTTP Basic authentication |
-| `ApiKey { header, value }` | `String`, `String` | API key sent in a custom request header |
-| `ApiKeyQuery { param, value }` | `String`, `String` | API key sent as a query parameter (e.g. `?api_key=secret`) |
-| `OAuth2 { token_url, client_id, client_secret, scopes, expiry_ratio }` | see below | Client credentials OAuth2 flow with token caching |
-| `TokenEndpoint { url, method, headers, body, token_path, expiry_path, expiry_ratio, response_validator }` | see below | Fetch token from an arbitrary HTTP endpoint |
-| `Custom { headers }` | `HashMap<String, String>` | Arbitrary custom headers attached to every request |
-
-**OAuth2 fields:**
-- `token_url` (`String`): Token endpoint URL
-- `client_id` (`String`): OAuth2 client ID
-- `client_secret` (`String`): OAuth2 client secret
-- `scopes` (`Vec<String>`): Requested scopes
-- `expiry_ratio` (`f64`): Fraction of `expires_in` after which the token is refreshed. Must be in `(0.0, 1.0]`. Defaults to `0.9`
-
-**TokenEndpoint fields:**
-- `url` (`String`): Token endpoint URL
-- `method` (`Method`): HTTP method (e.g. POST, GET)
-- `headers` (`HeaderMap`): Headers for the token request
-- `body` (`Option<Value>`): Optional JSON body for the token request
-- `token_path` (`String`): JSONPath expression to extract the token from the response
-- `expiry_path` (`Option<String>`): JSONPath to extract expiry (seconds) from the response
-- `expiry_ratio` (`f64`): Proactive refresh ratio. Defaults to `0.9`
-- `response_validator` (`Option<ResponseValidator>`): Custom success check for the token response
+| `base_url` | string | `""` | Base URL of the API (trailing slash trimmed). |
+| `path` | string | `""` | URL path relative to `base_url`. Supports `{key}` placeholders for partition substitution (e.g. `/orgs/{org_id}/users`). |
+| `method` | string | `GET` | HTTP method for the request. |
+| `auth` | `Auth` / `{ ref }` | `none` | Inline `{ type, config }` auth, or a `{ ref: <name> }` pointer to a shared provider. See [Authentication](#authentication). |
+| `headers` | map | empty | Extra HTTP headers sent on every request (library/`header()` only; not serialized in YAML/JSON). |
+| `query_params` | map<string,string> | empty | Query parameters added to every request. |
+| `body` | JSON / null | `null` | JSON request body (sent with `Content-Type: application/json`). |
 
 ### Pagination
 
-The `PaginationStyle` enum supports:
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `pagination` | `PaginationStyle` | `None` | Pagination strategy. See [Pagination](#pagination). |
+| `records_path` | string / null | `null` | JSONPath expression to extract the record array from each response body (e.g. `$.data[*]`). When unset, the whole body is treated as the record set. |
+| `max_pages` | int / null | `100` | Hard cap on pages fetched, across **all** pagination styles. `null` removes the cap (rely on the style's own termination). |
+| `request_delay` | int (seconds) / null | `null` | Delay between consecutive page requests. |
 
-| Style | Fields | Stops When |
-|-------|--------|------------|
-| `None` | -- | After first page |
-| `Cursor { next_token_path, param_name }` | JSONPath to next token, query param name | Next token is null or absent, or loop detected |
-| `LinkHeader` | -- | No `rel="next"` in the `Link` response header |
-| `NextLinkInBody { next_link_path }` | JSONPath to next page URL | URL is absent, null, or empty |
-| `PageNumber { param_name, start_page, page_size, page_size_param }` | Query param name, starting page number, optional page size and its param name | Response returns zero records, or the same page body is returned twice in a row |
-| `Offset { offset_param, limit_param, limit, total_path }` | Offset param, limit param, records per page, optional JSONPath to total count | A zero-record page, offset reaches total (via JSONPath), or fewer records than limit |
+### Reliability
 
-`Cursor`, `LinkHeader`, and `NextLinkInBody` include loop detection -- if the same cursor/link is returned twice in a row, pagination stops. `Offset` stops on a zero-record page (so a stalled offset cannot loop forever). `PageNumber` stops when a page returns zero records, and additionally detects content stagnation -- if an API clamps an out-of-range page to the last page and re-returns the identical body, pagination stops rather than looping to `max_pages`. For all styles, `max_pages` is a hard cap.
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `timeout` | int (seconds) / null | `30` | Per-request HTTP timeout. |
+| `max_retries` | int | `3` | Max retries on transient failures. |
+| `retry_backoff` | int (seconds) | `1` | Base for exponential backoff. Per-attempt sleep is `retry_backoff × 2^attempt`, **capped at 60 s** and scaled by random jitter in `[0.5, 1.5)` (decorrelated across concurrent retries). On `429`, the server's `Retry-After` (delta-seconds **or** an RFC 7231 HTTP-date) is honoured instead. |
+| `tolerated_http_errors` | array<int> | `[]` | HTTP status codes treated as an empty page **on the first request only**. Mid-pagination, a tolerated status surfaces as an error instead of silently ending the stream (otherwise a transient failure on page _N_ would drop every later page as a "successful" run). Only safe for genuinely-empty resources. |
 
-## Config Loading
+A **`204 No Content`** response — or any `2xx` with an empty/whitespace-only body — is treated as an empty page ("no data"), not a parse error. A non-empty body that isn't valid JSON still fails loudly with `FaucetError::Json`.
+
+### Replication & state
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `replication_method` | `{ type: FullTable \| Incremental }` | `FullTable` | `FullTable` fetches all records; `Incremental` filters by bookmark. |
+| `replication_key` | string / null | `null` | Record **field name** (not a JSONPath) used for incremental bookmarking. |
+| `start_replication_value` | JSON / null | `null` | Bookmark value; records where `record[replication_key] <= start_replication_value` are filtered out in `Incremental` mode. |
+| `state_key` | string / null | `null` | Stable key used by `Pipeline::with_state_store` to persist this stream's bookmark across runs. See [Resume & state](#resume--state). |
+
+### Singer / Meltano metadata
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | string / null | `null` | Human-readable stream name (logging, Singer SCHEMA messages). |
+| `primary_keys` | array<string> | `[]` | Fields that uniquely identify a record (Singer `key_properties`). |
+| `schema` | JSON / null | `null` | JSON Schema describing each record. When set, it's returned by `infer_schema()` instead of sampling. |
+| `schema_sample_size` | int | `100` | Max records sampled when inferring the schema. `0` = sample all available records. |
+
+### Partitions
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `partitions` | array<map> | `[]` | Each entry is a context map substituted into `path` placeholders. The stream runs once per partition and concatenates results. Empty = run once with no substitution. |
+| `partition_concurrency` | int / null | `null` | Max partitions fetched concurrently. `null` = sequential. |
+
+## Authentication
+
+The `auth` field accepts the project-wide adjacently-tagged `{ type, config }` shape (snake_case discriminators), or a `{ ref: <name> }` pointer into the CLI's top-level shared `auth:` catalog.
+
+| `type` | `config` fields | Description |
+|--------|-----------------|-------------|
+| `none` | *(none)* | No authentication. |
+| `bearer` | `token` | Bearer token in the `Authorization` header. |
+| `basic` | `username`, `password` | HTTP Basic authentication. |
+| `api_key` | `header`, `value` | API key sent in a custom request header. |
+| `api_key_query` | `param`, `value` | API key sent as a query parameter (e.g. `?api_key=secret`). |
+| `oauth2` | `token_url`, `client_id`, `client_secret`, `scopes`, `expiry_ratio` | OAuth2 client-credentials flow with token caching. |
+| `token_endpoint` | `url`, `method`, `body`, `token_path`, `expiry_path`, `expiry_ratio` | Fetch a token from an arbitrary HTTP endpoint (JSONPath-extracted). |
+| `custom` | `headers` (map<string,string>) | Arbitrary headers attached to every request. |
+
+**`oauth2` / `token_endpoint` notes:** `expiry_ratio` is the fraction of the token lifetime after which the cached token is proactively refreshed — must be in `(0.0, 1.0]`, defaults to `0.9`. For `token_endpoint`, `token_path` is the JSONPath to the token string and `expiry_path` (optional) is the JSONPath to the expiry in seconds; when absent the token is cached indefinitely.
+
+```yaml
+# Bearer
+auth:
+  type: bearer
+  config:
+    token: ${env:GITHUB_TOKEN}
+```
+
+```yaml
+# API key header
+auth:
+  type: api_key
+  config:
+    header: X-API-Key
+    value: ${env:API_KEY}
+```
+
+```yaml
+# OAuth2 client credentials
+auth:
+  type: oauth2
+  config:
+    token_url: https://auth.example.com/oauth/token
+    client_id: ${env:CLIENT_ID}
+    client_secret: ${env:CLIENT_SECRET}
+    scopes: ["read:events"]
+    expiry_ratio: 0.9
+```
+
+```yaml
+# Shared provider from the top-level auth: catalog
+auth: { ref: my_idp }
+```
+
+## Examples
+
+### Cursor-paginated API with bearer auth
+
+```yaml
+source:
+  type: rest
+  config:
+    base_url: https://api.example.com
+    path: /v2/contacts
+    auth:
+      type: bearer
+      config:
+        token: ${env:API_TOKEN}
+    pagination:
+      type: Cursor
+      next_token_path: $.meta.next_cursor
+      param_name: cursor
+    records_path: $.data[*]
+    max_pages: 50
+```
+
+### OAuth2 + incremental replication with a persisted bookmark
+
+```yaml
+version: 1
+name: events_incremental
+pipeline:
+  source:
+    type: rest
+    config:
+      base_url: https://api.example.com
+      path: /v1/events
+      auth:
+        type: oauth2
+        config:
+          token_url: https://auth.example.com/oauth/token
+          client_id: ${env:CLIENT_ID}
+          client_secret: ${env:CLIENT_SECRET}
+          scopes: ["read:events"]
+          expiry_ratio: 0.9
+      pagination:
+        type: Offset
+        offset_param: offset
+        limit_param: limit
+        limit: 100
+        total_path: $.total
+      records_path: $.events[*]
+      replication_method:
+        type: Incremental
+      replication_key: updated_at
+      start_replication_value: "2026-01-01T00:00:00Z"
+      state_key: events_stream
+  sink:
+    type: jsonl
+    config:
+      path: ./out/events.jsonl
+  state:
+    type: file
+    config:
+      path: ./state.json
+```
+
+### Multi-partition concurrent fetch
+
+```yaml
+source:
+  type: rest
+  config:
+    base_url: https://api.example.com
+    path: /orgs/{org_id}/members
+    auth:
+      type: bearer
+      config:
+        token: ${env:API_TOKEN}
+    records_path: $.members[*]
+    partitions:
+      - { org_id: acme }
+      - { org_id: globex }
+      - { org_id: initech }
+    partition_concurrency: 3
+```
+
+### Tolerating a `429` and capping retries
+
+```yaml
+source:
+  type: rest
+  config:
+    base_url: https://api.example.com
+    path: /v1/comments
+    auth:
+      type: api_key
+      config:
+        header: X-API-Key
+        value: ${env:API_KEY}
+    pagination:
+      type: LinkHeader
+    records_path: $.items[*]
+    timeout: 60
+    max_retries: 5
+    retry_backoff: 2
+    tolerated_http_errors: [429]
+```
+
+## Pagination
+
+The `pagination` field selects a `PaginationStyle` (tagged by `type`). `max_pages` is a hard cap across all styles.
+
+| Style (`type`) | Fields | Stops when |
+|----------------|--------|------------|
+| `None` | — | After the first page. |
+| `Cursor` | `next_token_path`, `param_name` | Next-token JSONPath is null/absent, or the same cursor repeats (loop detection). |
+| `LinkHeader` | — | No `rel="next"` in the `Link` response header, or the same link repeats. |
+| `NextLinkInBody` | `next_link_path` | Next-page URL is absent, null, empty, or repeats. |
+| `PageNumber` | `param_name`, `start_page`, `page_size`, `page_size_param` | A zero-record page, or the same body returned twice in a row (content-stagnation detection for APIs that clamp out-of-range pages). |
+| `Offset` | `offset_param`, `limit_param`, `limit`, `total_path` | A zero-record page, offset reaches `total` (via `total_path`), or a page returns fewer records than `limit`. |
+
+## Streaming & batching
+
+`RestStream` overrides `Source::stream_pages`, fetching the next HTTP page on demand and yielding it as a `StreamPage`. `Pipeline::run` writes each page to the sink as it arrives, so peak memory is bounded at one page no matter how large the feed. The bookmark is carried on the final page (incremental mode) so the state store advances only after the sink confirms the full run.
+
+The inherent `stream_pages()` method (yielding `Vec<Value>` pages, no per-page bookmark) remains for direct callers, alongside the eager `fetch_all()` / `fetch_all_incremental()` helpers.
+
+## Resume & state
+
+This source supports resumable runs. Set `state_key` and configure a `state:` block (or call `Pipeline::with_state_store` from Rust). On each run the pipeline:
+
+1. loads the previously persisted bookmark and applies it via `apply_start_bookmark` (overriding `start_replication_value`);
+2. fetches only records newer than the bookmark (`replication_method: Incremental` + `replication_key`);
+3. persists the new bookmark **only after the sink confirms** the batch — so a crash mid-run re-fetches rather than skips.
+
+`state_key` must satisfy `faucet_core::state::validate_state_key`. See the second [example](#oauth2--incremental-replication-with-a-persisted-bookmark) above.
+
+## Config loading & schema introspection
+
+Configs load from YAML/JSON files or environment variables:
 
 ```rust
 use faucet_core::config::{load_json, load_env_file};
 use faucet_source_rest::RestStreamConfig;
 
-// From JSON file
+// From a JSON file:
 let config: RestStreamConfig = load_json("config.json")?;
 
-// From .env file + environment variables
+// From a .env file + environment (REST_ prefix):
 let config: RestStreamConfig = load_env_file(".env", "REST")?;
 ```
 
-### Example JSON config
-
-```json
-{
-  "base_url": "https://api.github.com",
-  "path": "/repos/PawanSikawat/faucet-stream/issues",
-  "method": "GET",
-  "auth": {
-    "type": "bearer",
-    "config": {
-      "token": "ghp_xxxxxxxxxxxx"
-    }
-  },
-  "query_params": {
-    "state": "open",
-    "per_page": "100"
-  },
-  "pagination": {
-    "type": "LinkHeader"
-  },
-  "records_path": "$[*]",
-  "max_pages": 10,
-  "timeout": 30,
-  "max_retries": 3,
-  "retry_backoff": 1,
-  "tolerated_http_errors": [],
-  "replication_method": "FullTable",
-  "primary_keys": ["id"],
-  "schema_sample_size": 100
-}
-```
-
-### Example .env file
+Example `.env`:
 
 ```env
 REST_BASE_URL=https://api.github.com
@@ -206,123 +342,99 @@ REST_RETRY_BACKOFF=1
 REST_SCHEMA_SAMPLE_SIZE=100
 ```
 
-## Config Schema Introspection
+Inspect the full JSON Schema with:
 
-```rust
-use faucet_core::Source;
-
-let stream = RestStream::new(config)?;
-let schema = stream.config_schema();
-println!("{}", serde_json::to_string_pretty(&schema)?);
+```bash
+faucet schema source rest
 ```
 
-## Methods
-
-| Method | Return Type | Description |
-|--------|------------|-------------|
-| `RestStream::new(config)` | `Result<Self, FaucetError>` | Create a new stream. Validates auth at construction time |
-| `fetch_all()` | `Result<Vec<Value>, FaucetError>` | Fetch all records across all pages and partitions |
-| `fetch_all_as::<T>()` | `Result<Vec<T>, FaucetError>` | Fetch all records and deserialize into typed structs |
-| `fetch_all_incremental()` | `Result<(Vec<Value>, Option<Value>), FaucetError>` | Fetch records with incremental replication, returning records and bookmark |
-| `infer_schema()` | `Result<Value, FaucetError>` | Infer a JSON Schema from sampled records (or return the configured schema) |
-| `stream_pages()` | `Pin<Box<dyn Stream<Item = Result<Vec<Value>, FaucetError>>>>` | Stream records page-by-page without waiting for all pages |
-
-`RestStream` also implements the `faucet_core::Source::stream_pages` trait method, which is what `Pipeline::run` drives internally for memory-bounded streaming. The inherent `stream_pages()` method (which yields `Vec<Value>` pages) remains for direct callers who do not need per-page bookmarks.
-
-## Examples
-
-### Cursor-paginated API with bearer auth
+## Library usage
 
 ```rust
 use faucet_source_rest::{RestStream, RestStreamConfig, Auth, PaginationStyle};
 
-let config = RestStreamConfig::new("https://api.example.com", "/v2/contacts")
-    .auth(Auth::Bearer {
-        token: "your-api-token".into(),
-    })
-    .pagination(PaginationStyle::Cursor {
-        next_token_path: "$.meta.next_cursor".into(),
-        param_name: "cursor".into(),
-    })
-    .records_path("$.data[*]")
-    .max_pages(50);
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let config = RestStreamConfig::new("https://api.example.com", "/v2/contacts")
+        .auth(Auth::Bearer { token: "your-api-token".into() })
+        .pagination(PaginationStyle::Cursor {
+            next_token_path: "$.meta.next_cursor".into(),
+            param_name: "cursor".into(),
+        })
+        .records_path("$.data[*]")
+        .max_pages(50);
 
-let stream = RestStream::new(config)?;
-let contacts = stream.fetch_all().await?;
+    let stream = RestStream::new(config)?;          // validates auth at construction
+    let contacts = stream.fetch_all().await?;
+    println!("fetched {} records", contacts.len());
+    Ok(())
+}
 ```
 
-### OAuth2 client credentials with incremental replication
+Inherent helper methods on `RestStream`:
 
-```rust
-use faucet_source_rest::*;
-use serde_json::json;
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `RestStream::new(config)` | `Result<Self, FaucetError>` | Build the stream; validates auth at construction time. |
+| `fetch_all()` | `Result<Vec<Value>, _>` | Fetch all records across all pages and partitions. |
+| `fetch_all_as::<T>()` | `Result<Vec<T>, _>` | Fetch and deserialize into typed structs. |
+| `fetch_all_incremental()` | `Result<(Vec<Value>, Option<Value>), _>` | Fetch with incremental replication; returns records + new bookmark. |
+| `infer_schema()` | `Result<Value, _>` | Infer a JSON Schema from sampled records (or return the configured `schema`). |
 
-let config = RestStreamConfig::new("https://api.example.com", "/v1/events")
-    .auth(Auth::OAuth2 {
-        token_url: "https://auth.example.com/oauth/token".into(),
-        client_id: "my-client-id".into(),
-        client_secret: "my-client-secret".into(),
-        scopes: vec!["read:events".into()],
-        expiry_ratio: 0.9,
-    })
-    .pagination(PaginationStyle::Offset {
-        offset_param: "offset".into(),
-        limit_param: "limit".into(),
-        limit: 100,
-        total_path: Some("$.total".into()),
-    })
-    .records_path("$.events[*]")
-    .replication_method(ReplicationMethod::Incremental)
-    .replication_key("updated_at")
-    .start_replication_value(json!("2025-01-01T00:00:00Z"));
+Attach transforms by wrapping the source with [`faucet_core::TransformingSource`](https://docs.rs/faucet-core/latest/faucet_core/struct.TransformingSource.html).
 
-let stream = RestStream::new(config)?;
-let (records, bookmark) = stream.fetch_all_incremental().await?;
-println!("Fetched {} records, new bookmark: {:?}", records.len(), bookmark);
-```
+## How it works
 
-### Multi-partition concurrent fetch
-
-```rust
-use faucet_source_rest::{RestStream, RestStreamConfig, Auth};
-use std::collections::HashMap;
-use serde_json::json;
-
-let config = RestStreamConfig::new("https://api.example.com", "/orgs/{org_id}/members")
-    .auth(Auth::Bearer {
-        token: "token".into(),
-    })
-    .add_partition(HashMap::from([("org_id".into(), json!("acme"))]))
-    .add_partition(HashMap::from([("org_id".into(), json!("globex"))]))
-    .add_partition(HashMap::from([("org_id".into(), json!("initech"))]))
-    .partition_concurrency(Some(3))
-    .records_path("$.members[*]");
-
-let stream = RestStream::new(config)?;
-let all_members = stream.fetch_all().await?;
-```
-
-## Feature Flags
-
-| Feature | Default | Description |
-|---------|---------|-------------|
-| `transform-flatten` | yes | Enable the `Flatten` record transform |
-| `transform-rename-keys` | yes | Enable the `RenameKeys` regex-based transform |
-| `transform-keys-case` | yes | Enable the `KeysCase` transform (snake / camel / pascal / kebab / screaming_snake) |
-| `transform-select` | no | Enable the `Select` transform (keep listed top-level fields) |
-| `transform-drop` | no | Enable the `Drop` transform (remove listed top-level fields) |
-| `transform-set` | no | Enable the `Set` transform (insert/overwrite constants) |
-| `transform-rename-field` | no | Enable the `RenameField` transform (exact-name rename) |
-| `transform-cast` | no | Enable the `Cast` transform (per-field type coercion with `on_error` policy) |
-| `transform-redact` | no | Enable the `Redact` transform (mask listed field values) |
-| `transform-value-case` | no | Enable the `ValueCase` transform (lower / upper / trim string values) |
-| `transform-spell-symbols` | no | Enable the `SpellSymbols` transform (spell out `%`, `#`, `$`, … in keys) |
-| `transforms` | no | Enable every transform feature |
+1. `new()` resolves the auth method and builds the `reqwest` client **once**, reusing it for every request and partition.
+2. For each partition, `{key}` placeholders in `path` are substituted from the context map; with `partition_concurrency` set, partitions run concurrently.
+3. Each page request is wrapped in the retry layer: transient failures back off exponentially with jitter (capped at 60 s); `429` honours `Retry-After`.
+4. Records are extracted from the response body via `records_path` (JSONPath); the pagination style decides the next request and when to stop.
+5. In `Incremental` mode, records at or before the bookmark are filtered out and the max replication-key value becomes the new bookmark, carried on the final page.
 
 ## Lineage dataset URI
 
 `https://<base_url><path>` (credentials stripped) — e.g. `https://api.example.com/v1/users`.
 
+## Feature flags
+
+| Feature | Default | Description |
+|---------|---------|-------------|
+| `transform-flatten` | yes | `Flatten` record transform. |
+| `transform-rename-keys` | yes | `RenameKeys` regex-based transform. |
+| `transform-keys-case` | yes | `KeysCase` transform (snake / camel / pascal / kebab / screaming_snake). |
+| `transform-select` | no | `Select` transform (keep listed top-level fields). |
+| `transform-drop` | no | `Drop` transform (remove listed top-level fields). |
+| `transform-set` | no | `Set` transform (insert/overwrite constants). |
+| `transform-rename-field` | no | `RenameField` transform (exact-name rename). |
+| `transform-cast` | no | `Cast` transform (per-field type coercion with `on_error` policy). |
+| `transform-redact` | no | `Redact` transform (mask listed field values). |
+| `transform-value-case` | no | `ValueCase` transform (lower / upper / trim string values). |
+| `transform-spell-symbols` | no | `SpellSymbols` transform (spell out `%`, `#`, `$`, … in keys). |
+| `transforms` | no | Enable every transform feature. |
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause & fix |
+|---------|--------------------|
+| `401` / `403` on every page | Wrong or missing credentials. Verify the `auth` block; for `bearer`/`api_key`, confirm the token/header value is set (e.g. `${env:GITHUB_TOKEN}` is exported). |
+| Auth validation fails at `RestStream::new` | An auth field is malformed — e.g. `expiry_ratio` outside `(0.0, 1.0]`, or an empty required field. Fix the value; auth is validated at construction, not first request. |
+| Pagination stops after one page | `pagination` left as the default `None`. Set the style your API uses (`LinkHeader`, `Cursor`, `Offset`, …). |
+| Pagination stalls / never advances | The cursor/link token repeated, or the response body was identical twice — loop detection halted it. Check `next_token_path` / `next_link_path` points at the *next* token, not the current one. |
+| Records come back empty but the API has data | `records_path` doesn't match the response shape. Test your JSONPath against a real body (e.g. `$.data[*]` vs `$.items[*]`); when unset, the whole body is treated as the record set. |
+| Run ends early after a transient `5xx`/`429` mid-pagination | A `tolerated_http_errors` code only short-circuits the **first** request. Mid-stream it errors instead of silently truncating — raise `max_retries` / `retry_backoff` rather than tolerating the code. |
+| `FaucetError::Json` on a non-empty body | The response wasn't valid JSON (HTML error page, gateway response). Empty/`204` bodies are fine; a non-empty non-JSON body fails loudly by design. |
+| Incremental run re-fetches everything | No `state_key` + `state:` block, so the bookmark isn't persisted; or `replication_method` is still `FullTable`. Set both, plus `replication_key`. |
+| Rate-limited despite retries | The API returns `429` without `Retry-After`, or limits are stricter than backoff. Add `request_delay` to space requests, and/or lower `partition_concurrency`. |
+
+## See also
+
+- [Connector catalog & capability matrix](https://pawansikawat.github.io/faucet-stream/reference/connectors.html)
+- [Authentication cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/auth.html)
+- [Pagination cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/pagination.html)
+- [Resumable state & bookmarks](https://pawansikawat.github.io/faucet-stream/cookbook/state.html)
+- [Config-file grammar](https://pawansikawat.github.io/faucet-stream/reference/config.html)
+- Related crates: [`faucet-source-graphql`](https://crates.io/crates/faucet-source-graphql), [`faucet-source-xml`](https://crates.io/crates/faucet-source-xml), [`faucet-sink-http`](https://crates.io/crates/faucet-sink-http), [`faucet-auth`](https://crates.io/crates/faucet-auth).
+
 ## License
 
-Licensed under MIT or Apache-2.0.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/source/s3/README.md
+++ b/crates/source/s3/README.md
@@ -5,141 +5,234 @@
 [![MSRV](https://img.shields.io/crates/msrv/faucet-source-s3.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
 [![License](https://img.shields.io/crates/l/faucet-source-s3.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-An AWS S3 source that reads objects from a bucket and parses them as JSON Lines, JSON arrays, or raw text, with concurrent object reads via `buffer_unordered`.
+An **AWS S3** source that lists objects under a prefix and parses them as JSON Lines, a JSON array, or raw text. Part of the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
 
-Part of the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
+Built on the official `aws-sdk-s3` client (built once, reused across every read) with concurrent object fetches via `buffer_unordered`, it pulls a whole bucket prefix into any faucet-stream sink as fast as the storage and your parallelism allow. Point it at MinIO / LocalStack / Cloudflare R2 with a custom `endpoint_url`, and let the standard AWS credential chain handle auth.
+
+## Feature highlights
+
+- **Three file formats** — `json_lines` (one record per line), `json_array` (one record per array element), and `raw_text` (one `{key, content}` record per object).
+- **Parallel object reads** — up to `concurrency` objects fetched at once via `futures::buffer_unordered` (default 10).
+- **True line-level streaming** — for `json_lines` / `raw_text`, object bodies are decoded line-by-line via `tokio::io::AsyncBufReadExt`, so client memory is bounded at `O(batch_size)` regardless of file or scan size.
+- **Prefix listing with pagination** — handles truncated `ListObjectsV2` responses transparently and honours an optional `max_objects` cap.
+- **S3-compatible** — custom `endpoint_url` for MinIO, LocalStack, R2, and other S3-API services.
+- **Optional compression** — behind the `compression` feature: `gzip` / `zstd` / `auto` (suffix-detected per object key), so a single run can mix compressed and uncompressed objects.
+- **Matrix-friendly** — `${parent.field}` tokens in `prefix` are substituted per parent record in parent/child pipelines.
 
 ## Installation
 
 ```bash
+# As a library:
 cargo add faucet-source-s3
 cargo add tokio --features full
+
+# In the CLI (opt-in connector feature):
+cargo install faucet-cli --features source-s3
+
+# With compression support:
+cargo install faucet-cli --features "source-s3,compression"
 ```
 
 Or via the umbrella crate:
+
 ```bash
 cargo add faucet-stream --features source-s3
 ```
 
-## Quick Start
+`source-s3` is opt-in — it is not part of the CLI/umbrella default feature set.
 
-```rust
-use faucet_source_s3::{S3Source, S3SourceConfig};
-use faucet_core::Source;
+## Quick start
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let config = S3SourceConfig::new("my-data-bucket")
-        .prefix("exports/2025/")
-        .region("us-west-2");
-
-    let source = S3Source::new(config).await?;
-    let records = source.fetch_all().await?;
-
-    println!("Read {} records from S3", records.len());
-    Ok(())
-}
+```yaml
+# pipeline.yaml — faucet run pipeline.yaml
+version: 1
+name: s3_to_postgres
+pipeline:
+  source:
+    type: s3
+    config:
+      bucket: my-data-lake
+      prefix: events/2026/
+      region: us-east-1
+      file_format: json_lines
+      concurrency: 16
+  sink:
+    type: postgres
+    config:
+      connection_url: postgres://user:pass@localhost/warehouse
+      table_name: events_raw
+      column_mapping:
+        type: jsonb
+        column: payload
 ```
 
-## Configuration
+```bash
+export AWS_ACCESS_KEY_ID=...    # standard AWS credential chain
+export AWS_SECRET_ACCESS_KEY=...
+faucet run pipeline.yaml
+```
 
-### S3SourceConfig
+## Configuration reference
+
+### Core
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `bucket` | `String` | *(required)* | S3 bucket name |
-| `prefix` | `Option<String>` | `None` | Object key prefix filter. Only objects whose key starts with this prefix are read |
-| `region` | `Option<String>` | `None` | AWS region. `None` uses the SDK default (from env vars or instance metadata) |
-| `endpoint_url` | `Option<String>` | `None` | Custom endpoint URL for S3-compatible services (e.g. MinIO, LocalStack) |
-| `file_format` | `S3FileFormat` | `JsonLines` | Format of the files to read |
-| `max_objects` | `Option<usize>` | `None` | Maximum number of objects to read. `None` means read all matching objects |
-| `concurrency` | `usize` | `10` | Maximum number of concurrent object reads |
-| `batch_size` | `usize` | `1000` | Records per `StreamPage` emitted by `Source::stream_pages`. See [Streaming and batching](#streaming-and-batching) below |
+| `bucket` | string | *(required)* | S3 bucket name. |
+| `prefix` | string | *(none)* | Object-key prefix filter. Only objects whose key starts with this prefix are read. |
+| `region` | string | *(SDK chain)* | AWS region. `None` defers to the SDK default (env vars, profile, or instance metadata). |
+| `endpoint_url` | string | *(none)* | Custom endpoint URL for S3-compatible services (MinIO, LocalStack, R2). |
+| `file_format` | enum | `json_lines` | How object bodies are parsed — `json_lines`, `json_array`, or `raw_text`. See below. |
+| `max_objects` | int | *(all)* | Cap on the number of objects read. `None` reads every matching object. |
+| `concurrency` | int | `10` | Maximum number of objects fetched concurrently. Clamped to `≥ 1` at runtime. |
+| `batch_size` | int | `1000` | Records per emitted `StreamPage`. See [Streaming & batching](#streaming--batching). Rejected above `MAX_BATCH_SIZE` (1,000,000) by `faucet_core::validate_batch_size`. |
+| `compression` | enum | `auto` | *(requires the `compression` feature)* Per-object decompression codec — `none` / `gzip` / `zstd` / `auto`. |
 
-### Streaming and batching
+### File formats (`S3FileFormat`)
 
-`S3Source::stream_pages` lists objects matching the configured prefix and
-streams their records into `StreamPage`s without buffering the full scan.
-The exact behaviour depends on `file_format`:
+| Variant | Wire value | Record output |
+|---------|-----------|---------------|
+| JSON Lines (default) | `json_lines` | One record per non-empty line. Blank lines are skipped. |
+| JSON array | `json_array` | One record per array element. The object must be a top-level JSON array. |
+| Raw text | `raw_text` | One record per object: `{"key": "<object-key>", "content": "<file-text>"}`. |
 
-- **`JsonLines`** — the object body is decoded line-by-line via
-  `tokio::io::AsyncBufReadExt::lines`, so client-side memory is bounded at
-  `O(batch_size)` lines regardless of file or scan size. Records flow
-  across object boundaries — a single page may carry lines drawn from
-  multiple objects.
-- **`RawText`** — each object contributes exactly one record
-  (`{"key": ..., "content": ...}`). The contract requires the whole file
-  as a single string, so the object is necessarily held in memory once,
-  but it is streamed straight into that one `String` via the same
-  decoding reader `JsonLines` uses (no separate raw + decompressed copies
-  for compressed objects). Records are then accumulated into the same
-  `batch_size` buffer JsonLines uses.
-- **`JsonArray`** — the array can only be validated once the closing `]`
-  is observed, so each object is buffered fully and then its records are
-  chunked into pages of `batch_size`. This bounds *page* size at
-  `batch_size` but not *peak per-object* memory — sources that must
-  stream arbitrarily large array files should be re-emitted as `JsonLines`
-  upstream. The default `batch_size = 1000` keeps allocation reasonable
-  for typical sizes.
+## Authentication
 
-> **Memory ceiling — `RawText` / `JsonArray`.** Both formats hold one
-> whole decoded object in memory at a time (this is inherent: `RawText`'s
-> record *is* the whole file, and a JSON array isn't valid until its
-> closing `]`). Because objects are fetched concurrently, peak memory is
-> bounded by roughly **`concurrency` × (largest object's decoded size)**,
-> not by `batch_size`. If you read large `RawText` / `JsonArray` objects,
-> lower `concurrency` to cap peak memory, or re-emit the data as
-> `JsonLines` upstream so it streams line-by-line at `O(batch_size)`.
+This source uses the **standard AWS SDK credential chain** — there are no credential fields in the config. Credentials resolve automatically, in order:
 
-`batch_size = 0` is the **"no batching" sentinel**: every emitted
-`StreamPage` corresponds to exactly one S3 object — no within-object
-chunking and no cross-object accumulation. Use it for small lookup files,
-or for downstream sinks (SQL `COPY`, BigQuery load jobs, Snowflake stage
-uploads) that prefer one large request per file to many small ones.
-Values larger than `MAX_BATCH_SIZE` (1,000,000) are rejected by
-`faucet_core::validate_batch_size`.
+1. Environment variables — `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`.
+2. Shared AWS config files — `~/.aws/credentials`, `~/.aws/config` (honours `AWS_PROFILE`).
+3. IAM roles — EC2 instance metadata, ECS task roles, or Lambda execution roles.
 
-The S3 source has no incremental-replication mode today, so every emitted
-page carries `bookmark: None`.
+For MinIO / LocalStack, set `endpoint_url` and supply the service's access/secret keys via the same environment variables.
 
-> **Note** — `JsonArray` streaming is bounded at one full object in memory
-> at a time. True incremental JSON-array parsing (e.g. via
-> `serde_json::StreamDeserializer` over an `AsyncRead`) is a separate
-> follow-up; today the parse happens after the body is fully buffered.
+## Examples
 
-### File Formats (S3FileFormat)
+### JSON array files from MinIO (S3-compatible)
 
-| Variant | Description | Record Output |
-|---------|-------------|---------------|
-| `JsonLines` (default) | Each line in the file is a separate JSON record | One record per non-empty line |
-| `JsonArray` | The entire file is a JSON array of records | One record per array element |
-| `RawText` | Each file becomes a single record | `{"key": "<object-key>", "content": "<file-text>"}` |
+```yaml
+version: 1
+pipeline:
+  source:
+    type: s3
+    config:
+      bucket: local-bucket
+      prefix: exports/
+      region: us-east-1
+      endpoint_url: http://localhost:9000
+      file_format: json_array
+  sink:
+    type: jsonl
+    config:
+      path: ./exports.jsonl
+```
 
-## Config Loading
+### Raw text files into a document store
 
-```rust
+```yaml
+version: 1
+pipeline:
+  source:
+    type: s3
+    config:
+      bucket: documents-bucket
+      prefix: reports/
+      file_format: raw_text
+      max_objects: 50
+  sink:
+    type: mongodb
+    config:
+      connection_url: mongodb://localhost:27017
+      database: lake
+      collection: reports
+```
+
+Each record is `{"key": "reports/q1.txt", "content": "…"}`.
+
+### Compressed JSONL with auto codec detection
+
+```yaml
+version: 1
+pipeline:
+  source:
+    type: s3
+    config:
+      bucket: my-data-lake
+      prefix: logs/2026/
+      file_format: json_lines
+      concurrency: 32
+      compression: auto    # .gz → gzip, .zst → zstd, otherwise none
+  sink:
+    type: stdout
+    config:
+      format: jsonl
+```
+
+`auto` resolves the codec per object key, so a prefix holding a mix of `.jsonl`, `.jsonl.gz`, and `.jsonl.zst` objects all read correctly in one run. Requires building with the `compression` feature.
+
+### One page per object for a load-job sink
+
+```yaml
+version: 1
+pipeline:
+  source:
+    type: s3
+    config:
+      bucket: my-data-lake
+      prefix: staging/
+      file_format: json_lines
+      batch_size: 0      # one StreamPage per S3 object
+  sink:
+    type: bigquery
+    config:
+      project_id: my-project
+      dataset_id: analytics
+      table_id: events
+```
+
+## Streaming & batching
+
+`S3Source` implements `Source::stream_pages`: it lists matching objects, then streams their records into `StreamPage`s without buffering the whole scan. The per-page record count comes from the config `batch_size` field (the trait-level `batch_size` argument is ignored so a pipeline hint can't silently override an explicit config value).
+
+Behaviour by format:
+
+- **`json_lines`** — the object body is decoded line-by-line via `tokio::io::AsyncBufReadExt::lines`, so client-side memory stays bounded at `O(batch_size)` lines regardless of file or scan size. Records flow across object boundaries — a single page may carry lines drawn from multiple objects.
+- **`raw_text`** — each object contributes exactly one `{key, content}` record. The whole body is held in one `String` (the record *is* the file), then accumulated into the same `batch_size` buffer.
+- **`json_array`** — the array can only be validated once the closing `]` is observed, so each object is buffered fully, then its elements are chunked into pages of `batch_size`. This bounds *page* size but not *peak per-object* memory.
+
+`batch_size = 0` is the **"no batching" sentinel**: every emitted `StreamPage` corresponds to exactly one S3 object — no within-object chunking and no cross-object accumulation. Use it for small lookup files, or for downstream sinks (SQL `COPY`, BigQuery load jobs, Snowflake stage uploads) that prefer one large request per file to many small ones.
+
+> **Memory ceiling — `raw_text` / `json_array`.** Both formats hold one whole decoded object in memory at a time (inherent: `raw_text`'s record *is* the file, and a JSON array isn't valid until its closing `]`). Because objects are fetched concurrently, peak memory is roughly **`concurrency` × (largest object's decoded size)**, not `batch_size`. For large `raw_text` / `json_array` objects, lower `concurrency` to cap peak memory, or re-emit the data as `json_lines` upstream so it streams line-by-line.
+
+The S3 source has **no incremental-replication mode** today, so every emitted page carries `bookmark: None`. It does not implement resume/state, exactly-once, write modes, or a dead-letter queue (those are sink- or CDC-source-specific capabilities).
+
+## Compression
+
+Behind the crate-local `compression` Cargo feature. Adds the `compression` config field with values `none`, `gzip`, `zstd`, or `auto` (the default — detects `.gz` / `.zst` from the object key).
+
+```yaml
+type: s3
+config:
+  bucket: my-data-lake
+  prefix: logs/
+  compression: auto    # or 'gzip' | 'zstd' | 'none'
+```
+
+The codec resolves per object key at read time, so a single source can read a mix of compressed and uncompressed objects in one run. When an explicit codec disagrees with the key suffix, a one-time warning is logged. Decompression is streamed straight into the line reader — there is no separate raw + decompressed copy held at once.
+
+## Config loading
+
+```rust,no_run
 use faucet_core::config::{load_json, load_env_file};
 use faucet_source_s3::S3SourceConfig;
 
+# fn example() -> Result<(), Box<dyn std::error::Error>> {
 let config: S3SourceConfig = load_json("config.json")?;
 let config: S3SourceConfig = load_env_file(".env", "S3_SOURCE")?;
+# Ok(()) }
 ```
 
-### Example JSON config
-
-```json
-{
-  "bucket": "my-data-lake",
-  "prefix": "raw/events/2025-03/",
-  "region": "us-east-1",
-  "file_format": "json_lines",
-  "max_objects": 100,
-  "concurrency": 20,
-  "batch_size": 5000
-}
-```
-
-### Example .env file
+Example `.env`:
 
 ```env
 S3_SOURCE_BUCKET=my-data-lake
@@ -148,104 +241,87 @@ S3_SOURCE_REGION=us-east-1
 S3_SOURCE_CONCURRENCY=10
 ```
 
-## Config Schema Introspection
+## Schema introspection
 
-```rust
+```bash
+faucet schema source s3
+```
+
+Programmatically:
+
+```rust,no_run
 use faucet_core::Source;
-
-let source = S3Source::new(config).await?;
+# async fn example(source: faucet_source_s3::S3Source) -> Result<(), Box<dyn std::error::Error>> {
 let schema = source.config_schema();
 println!("{}", serde_json::to_string_pretty(&schema)?);
+# Ok(()) }
 ```
 
-## Examples
+## Library usage
 
-### Reading JSON Lines files from S3
-
-```rust
-use faucet_source_s3::{S3Source, S3SourceConfig};
-use faucet_core::Source;
-
-let config = S3SourceConfig::new("analytics-bucket")
-    .prefix("logs/2025/03/")
-    .region("us-west-2")
-    .concurrency(20);
-
-let source = S3Source::new(config).await?;
-let records = source.fetch_all().await?;
-println!("Read {} log records", records.len());
-```
-
-### Reading JSON array files from MinIO
-
-```rust
+```rust,no_run
 use faucet_source_s3::{S3Source, S3SourceConfig, S3FileFormat};
 use faucet_core::Source;
 
-let config = S3SourceConfig::new("local-bucket")
-    .endpoint_url("http://localhost:9000")
-    .region("us-east-1")
-    .file_format(S3FileFormat::JsonArray)
-    .prefix("exports/");
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let config = S3SourceConfig::new("my-data-bucket")
+        .prefix("exports/2026/")
+        .region("us-west-2")
+        .file_format(S3FileFormat::JsonLines)
+        .concurrency(20)
+        .with_batch_size(5000);
 
-let source = S3Source::new(config).await?;
-let records = source.fetch_all().await?;
-```
-
-### Reading raw text files
-
-```rust
-use faucet_source_s3::{S3Source, S3SourceConfig, S3FileFormat};
-use faucet_core::Source;
-
-let config = S3SourceConfig::new("documents-bucket")
-    .prefix("reports/")
-    .file_format(S3FileFormat::RawText)
-    .max_objects(50);
-
-let source = S3Source::new(config).await?;
-let records = source.fetch_all().await?;
-
-// Each record has "key" and "content" fields
-for record in &records {
-    println!("File: {}, Size: {} bytes",
-        record["key"].as_str().unwrap(),
-        record["content"].as_str().unwrap().len()
-    );
+    let source = S3Source::new(config).await?;
+    let records = source.fetch_all().await?;
+    println!("Read {} records from S3", records.len());
+    Ok(())
 }
 ```
 
-## AWS Authentication
+To run a full pipeline, wrap the source with any sink in `faucet_core::Pipeline` or drive `faucet_core::run_stream` for bounded-memory streaming.
 
-This source uses the standard AWS SDK credential chain. Credentials are resolved automatically from (in order):
+## How it works
 
-1. Environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`)
-2. AWS config files (`~/.aws/credentials`, `~/.aws/config`)
-3. IAM instance roles (on EC2/ECS/Lambda)
+- **Client reuse** — the `aws-sdk-s3` `Client` is built once in `S3Source::new()` (resolving region and `endpoint_url`) and reused for every list and get. No per-object client construction.
+- **Paginated listing** — `list_objects_v2` follows `next_continuation_token` until the response is no longer truncated, stopping early once `max_objects` is reached.
+- **Parallel reads** — listed keys are read through `futures::stream::buffer_unordered(concurrency)`, so up to `concurrency` `GetObject` calls are in flight at once.
+- **Streaming decode** — `json_lines` / `raw_text` open each body as an `AsyncBufRead` and decode line-by-line; only `json_array` buffers a full object before parsing.
 
-No credential fields are included in the config -- use the standard AWS environment instead.
-
-## Compression
-
-Behind the crate-local `compression` Cargo feature. Adds a `compression` config
-field with values `none`, `gzip`, `zstd`, or `auto` (the default — detects
-`.gz` / `.zst` from the file path / object key).
-
-YAML example:
-
-```yaml
-kind: s3
-config:
-  # ... existing fields ...
-  compression: auto  # or 'gzip' | 'zstd' | 'none'
-```
-
-The codec resolves per object key, so a single source can read a mix of compressed and uncompressed objects in one run.
+Throughput scales with `concurrency` and is ultimately bounded by S3 / network bandwidth — benchmark with your own object sizes and parallelism.
 
 ## Lineage dataset URI
 
 `s3://<bucket>` or `s3://<bucket>/<prefix>` — e.g. `s3://my-bucket/data/2026/`.
 
+## Feature flags
+
+| Feature | Default | Effect |
+|---------|---------|--------|
+| `compression` | off | Adds the `compression` config field (`none`/`gzip`/`zstd`/`auto`); pulls in `faucet-core/compression`. |
+
+Enable the connector itself in the CLI/umbrella via the `source-s3` feature.
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause & fix |
+|---------|--------------------|
+| `S3 list objects error … 403` / credential errors | Credentials missing from the AWS chain, or wrong region. Set `region` and the AWS env vars / profile (or an IAM role). |
+| `S3 get object error … NoSuchBucket` | `bucket` is wrong, or the region doesn't match the bucket's region. Verify both. |
+| `S3 JSON parse error in '<key>' at line N` | A line in a `json_lines` object isn't valid JSON. Fix the source data, or switch to the format that matches the file. |
+| `S3 expected JSON array in '<key>', got object` | `file_format: json_array` but the object isn't a top-level array. Use `json_lines` or `raw_text` instead. |
+| `S3 read/decode error … not valid UTF-8?` | The object isn't UTF-8 text. This source reads text formats only; binary blobs aren't supported. |
+| No records and no error | The `prefix` matched no objects (note S3 prefixes are case-sensitive and don't imply a trailing `/`), or `max_objects` is `0`. Check the prefix. |
+| `compression` field rejected as unknown | The crate was built without the `compression` feature. Rebuild with `--features compression`. |
+| Connecting to MinIO / LocalStack fails | Set `endpoint_url` to the service URL (e.g. `http://localhost:9000`) and supply the service's keys via the AWS env vars. |
+| Out-of-memory on large `raw_text` / `json_array` objects | These formats buffer a whole object; peak memory ≈ `concurrency` × largest object. Lower `concurrency`, or re-emit as `json_lines`. |
+| `batch_size` rejected at load | Value exceeds `MAX_BATCH_SIZE` (1,000,000). Use a smaller value, or `0` for the no-batching sentinel. |
+
+## See also
+
+- [Connector reference](https://pawansikawat.github.io/faucet-stream/reference/connectors.html) · [Compression cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/compression.html)
+- Related crates: [faucet-sink-s3](https://crates.io/crates/faucet-sink-s3) · [faucet-source-gcs](https://crates.io/crates/faucet-source-gcs) · [faucet-source-parquet](https://crates.io/crates/faucet-source-parquet)
+
 ## License
 
-Licensed under MIT or Apache-2.0.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/source/s3/README.md
+++ b/crates/source/s3/README.md
@@ -2,6 +2,8 @@
 
 [![Crates.io](https://img.shields.io/crates/v/faucet-source-s3.svg)](https://crates.io/crates/faucet-source-s3)
 [![Docs.rs](https://docs.rs/faucet-source-s3/badge.svg)](https://docs.rs/faucet-source-s3)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-source-s3.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-source-s3.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
 An AWS S3 source that reads objects from a bucket and parses them as JSON Lines, JSON arrays, or raw text, with concurrent object reads via `buffer_unordered`.
 

--- a/crates/source/snowflake/README.md
+++ b/crates/source/snowflake/README.md
@@ -1,42 +1,116 @@
 # faucet-source-snowflake
 
-Snowflake query source connector for the [`faucet-stream`](https://crates.io/crates/faucet-stream) ecosystem. Executes a SQL statement against Snowflake via the [SQL REST API](https://docs.snowflake.com/en/developer-guide/sql-api/intro) and streams rows back as `serde_json::Value` records.
+[![Crates.io](https://img.shields.io/crates/v/faucet-source-snowflake.svg)](https://crates.io/crates/faucet-source-snowflake)
+[![Docs.rs](https://docs.rs/faucet-source-snowflake/badge.svg)](https://docs.rs/faucet-source-snowflake)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-source-snowflake.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-source-snowflake.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-## Features
+**Snowflake** query source for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem. Executes a SQL statement against Snowflake's [SQL REST API](https://docs.snowflake.com/en/developer-guide/sql-api/intro) (`POST /api/v2/statements`), decodes each row into a typed `serde_json::Value`, and streams the result set back partition-by-partition so peak memory stays bounded no matter how large the result is.
 
-- **JWT key-pair and OAuth bearer authentication** — `SnowflakeAuth` re-exported from [`faucet-common-snowflake`](https://crates.io/crates/faucet-common-snowflake); credentials are masked in `Debug` output.
-- **Server-side partitioning** — large result sets are paged via `GET /api/v2/statements/{handle}?partition=N`; one HTTP round-trip per partition, no client-side buffering of unrelated partitions.
-- **Configurable batching** — `batch_size` re-frames partitions into pages for `Source::stream_pages`; `batch_size = 0` opts out of re-chunking and emits the full result set as one page.
-- **Async / sync handling** — if Snowflake returns `202 Accepted` (statement still running), the source polls the handle until the result is ready, bounded by `poll_timeout` (default 300 s; `0` = poll forever) so a stuck statement fails instead of hanging.
-- **Bind parameters** — positional `params` from config are merged with `${parent.path}` tokens resolved from the matrix-row context. Each bind's Snowflake type is inferred from the JSON value (`FIXED` for integers, `REAL` for floats, `BOOLEAN` for bools, `TEXT` otherwise), so numeric/boolean binds compare against typed columns instead of being forced to `TEXT`.
-- **Type-aware row conversion** — `FIXED`, `REAL`, `BOOLEAN`, and `VARIANT`/`OBJECT`/`ARRAY` columns are parsed into native JSON shapes; everything else (timestamps, dates, binary) passes through as strings. A scale-0 `FIXED`/`NUMBER` value beyond `u64` (e.g. `NUMBER(38,0)`) is kept as a **string** rather than a lossy `f64`, preserving full precision (the same approach as BigQuery NUMERIC).
+Reach for it when you want to pull tables, aggregates, or ad-hoc query results out of Snowflake and land them in any faucet-stream sink — a file, a database, a warehouse, a queue — with one declarative config and no glue code. It talks to Snowflake over HTTPS only, so there is no driver, no ODBC, and no native dependency to build.
 
-## Configuration
+## Feature highlights
 
-```yaml
-type: snowflake
-config:
-  account: xy12345.us-east-1
-  warehouse: COMPUTE_WH
-  database: ANALYTICS
-  schema: PUBLIC
-  role: ANALYST                     # optional
-  auth:
-    type: oauth
-    config:
-      token: ${env:SNOWFLAKE_OAUTH_TOKEN}
-  query: |
-    SELECT id, name, created_at
-    FROM events
-    WHERE created_at >= ?
-  params:
-    - "2026-01-01"
-  statement_timeout: 60             # seconds, defaults to 60
-  poll_timeout: 300                 # seconds, defaults to 300; 0 = poll forever
-  batch_size: 1000                  # default, or 0 to disable re-chunking
+- **JWT key-pair and OAuth bearer authentication** — sign requests with an RSA key pair (RS256 JWT minted per request) or hand Snowflake an OAuth bearer token from an external IdP. The shared `SnowflakeAuth` enum is re-exported from [`faucet-common-snowflake`](https://crates.io/crates/faucet-common-snowflake) so it matches the Snowflake **sink** byte-for-byte, and credentials are masked in `Debug` output.
+- **Server-side partition pagination** — large result sets are paged via `GET /api/v2/statements/{handle}?partition=N`; one HTTP round-trip per partition, with no client-side buffering of partitions you haven't reached yet.
+- **Native streaming** — overrides `Source::stream_pages`: partitions are re-framed into `batch_size`-sized pages on the fly, so peak memory is `O(batch_size)` regardless of total row count.
+- **Async-statement aware** — when the initial `POST` returns `202 Accepted` (the statement is still running), the source polls the statement handle until the result is ready, bounded by `poll_timeout` so a stuck statement fails cleanly instead of hanging forever.
+- **Typed positional bind parameters** — `params` from config plus any `${parent.path}` matrix-context values are sent as Snowflake bind variables, typed from the JSON value (`FIXED` for integers, `REAL` for floats, `BOOLEAN` for bools, `TEXT` otherwise) so a numeric or boolean bind compares correctly against a typed column.
+- **Type-aware row decoding** — `FIXED`, `REAL`, `BOOLEAN`, and `VARIANT`/`OBJECT`/`ARRAY` columns are parsed into native JSON shapes; everything else (timestamps, dates, binary) passes through as strings. A scale-0 `NUMBER(38,0)` value beyond `u64` is kept as a **string** to preserve full precision rather than losing it to `f64`.
+- **Shared auth catalog** — OAuth tokens can come from the CLI's top-level `auth:` catalog via `auth: { ref: <name> }`, so many matrix rows hitting one IdP share a single token with single-flight refresh.
+
+## Installation
+
+```bash
+# As a library:
+cargo add faucet-source-snowflake
+
+# In the CLI (opt-in connector feature):
+cargo install faucet-cli --features source-snowflake
 ```
 
-### Key-pair authentication
+The connector is opt-in — it is not in the CLI's default feature set. Enable `source-snowflake` (or the `source` / `full` aggregates) to compile it in.
+
+## Quick start
+
+```yaml
+# pipeline.yaml — faucet run pipeline.yaml
+version: 1
+pipeline:
+  source:
+    type: snowflake
+    config:
+      account: xy12345.us-east-1
+      warehouse: COMPUTE_WH
+      database: ANALYTICS
+      schema: PUBLIC
+      auth:
+        type: oauth
+        config:
+          token: ${env:SNOWFLAKE_OAUTH_TOKEN}
+      query: |
+        SELECT id, name, created_at
+        FROM events
+        WHERE created_at >= ?
+      params:
+        - "2026-01-01"
+  sink:
+    type: jsonl
+    config:
+      path: ./events.jsonl
+```
+
+```bash
+faucet run pipeline.yaml
+```
+
+## Configuration reference
+
+### Core
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `account` | string | — *(required)* | Snowflake account identifier (e.g. `"xy12345.us-east-1"`). Used to build the API hostname and to sign the key-pair JWT. |
+| `warehouse` | string | — *(required)* | Virtual warehouse to run the statement on. |
+| `database` | string | — *(required)* | Database for the session. |
+| `schema` | string | — *(required)* | Schema for the session. |
+| `role` | string | *(unset)* | Optional role to assume for the session. When unset, the user's default role is used. |
+| `auth` | `AuthSpec<SnowflakeAuth>` | — *(required)* | Authentication — see [Authentication](#authentication). Accepts an inline `{ type, config }` block or `{ ref: <name> }` pointing at a shared provider. |
+| `query` | string | — *(required)* | SQL to execute. May contain positional `?` bind markers (bound from `params` + matrix context) and `${field.path}` placeholders resolved against the parent-record context at runtime. |
+| `params` | array | `[]` | Positional bind parameters, applied in order **before** any context-derived values. Each entry is typed from its JSON value. |
+
+### Reliability & timeouts
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `statement_timeout` | int (seconds) | `60` | Per-statement server-side timeout, passed as the `timeout` field on the `POST /api/v2/statements` body. Independent of the HTTP-level request timeout. |
+| `poll_timeout` | int (seconds) | `300` | Max wall-clock time the source spends polling an asynchronous statement (one whose initial `POST` returned HTTP 202) before failing with `FaucetError::Source`. **`0` disables the cap** (poll forever). |
+
+### Batching
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `batch_size` | int | `1000` | Records per emitted `StreamPage`. Snowflake returns the result in *partitions*; the source re-frames them into `batch_size`-sized pages. **`0` = no batching**: the entire result set is buffered and emitted in a single page (good for small lookup tables or sinks that prefer one large request). Capped at `MAX_BATCH_SIZE` (1,000,000); validated at config-load time. |
+
+## Authentication
+
+`auth` uses the shared `SnowflakeAuth` enum (the project-wide `{ type, config }` shape):
+
+| `type` | `config` | Use when |
+|--------|----------|----------|
+| `oauth` | `{ token: <string> }` | You have an OAuth bearer token from Snowflake or an external IdP. Sent as `Authorization: Snowflake Token="..."` with `X-Snowflake-Authorization-Token-Type: OAUTH`. |
+| `key_pair` | `{ user: <string>, private_key_pem: <pem> }` | You authenticate with an RSA key pair registered on the Snowflake user. A fresh RS256 JWT (1-hour expiry) is minted per request and sent as `Authorization: Bearer <jwt>` with `X-Snowflake-Authorization-Token-Type: KEYPAIR_JWT`. |
+
+### OAuth bearer token
+
+```yaml
+auth:
+  type: oauth
+  config:
+    token: ${env:SNOWFLAKE_OAUTH_TOKEN}
+```
+
+### Key-pair JWT
 
 ```yaml
 auth:
@@ -46,9 +120,112 @@ auth:
     private_key_pem: ${file:/etc/secrets/snowflake.pem}
 ```
 
-The source generates an RS256 JWT per request (1-hour expiry) signed with the configured PEM key and sends it in the `Authorization: Bearer ...` header along with `X-Snowflake-Authorization-Token-Type: KEYPAIR_JWT`.
+### Shared provider (CLI `auth:` catalog)
 
-## Library use
+A shared provider must yield a `Bearer` or `Token` credential, which maps onto `SnowflakeAuth::OAuth`. Key-pair JWT is always inline (it cannot be shared via the catalog).
+
+```yaml
+auth:
+  my_snowflake_idp:
+    type: oauth2
+    config:
+      token_url: https://idp.example.com/oauth/token
+      client_id: ${env:SF_CLIENT_ID}
+      client_secret: ${secret:SF_CLIENT_SECRET}
+pipeline:
+  source:
+    type: snowflake
+    config:
+      account: xy12345.us-east-1
+      warehouse: COMPUTE_WH
+      database: ANALYTICS
+      schema: PUBLIC
+      auth: { ref: my_snowflake_idp }
+      query: SELECT 1
+```
+
+## Examples
+
+### Incremental pull with a typed bind parameter
+
+```yaml
+source:
+  type: snowflake
+  config:
+    account: xy12345.us-east-1
+    warehouse: COMPUTE_WH
+    database: ANALYTICS
+    schema: PUBLIC
+    auth:
+      type: oauth
+      config: { token: ${env:SNOWFLAKE_OAUTH_TOKEN} }
+    query: |
+      SELECT id, name, score
+      FROM users
+      WHERE score > ?
+    params:
+      - 0.75          # bound as REAL, compares correctly against a numeric column
+```
+
+### Large export with no re-chunking
+
+```yaml
+source:
+  type: snowflake
+  config:
+    account: xy12345.us-east-1
+    warehouse: COMPUTE_WH
+    database: WAREHOUSE
+    schema: PUBLIC
+    auth:
+      type: key_pair
+      config:
+        user: SVC_LOAD
+        private_key_pem: ${file:/etc/secrets/snowflake.pem}
+    query: SELECT * FROM daily_snapshot
+    batch_size: 0      # emit the whole result set as one page
+```
+
+### Daily window driven by a `${now.*}` token
+
+```yaml
+source:
+  type: snowflake
+  config:
+    account: xy12345.us-east-1
+    warehouse: COMPUTE_WH
+    database: ANALYTICS
+    schema: PUBLIC
+    role: ANALYST
+    auth:
+      type: oauth
+      config: { token: ${env:SNOWFLAKE_OAUTH_TOKEN} }
+    query: |
+      SELECT country, COUNT(*) AS n
+      FROM events
+      WHERE event_date = ?
+      GROUP BY country
+    params:
+      - "${now.date}"           # resolved per run, e.g. 2026-06-17
+    statement_timeout: 30       # return fast; if not done, poll…
+    poll_timeout: 600           # …for up to 10 minutes before failing
+```
+
+## Streaming & batching
+
+The source overrides `Source::stream_pages`. It submits the statement, then walks the result partitions reported by Snowflake (the first partition arrives inline in the `POST` response; subsequent partitions are fetched via `GET /api/v2/statements/{handle}?partition=N`). Decoded rows accumulate in a buffer and are yielded as a `StreamPage` every time the buffer reaches `batch_size`, so peak memory is one page. With `batch_size: 0` the entire result set is buffered and emitted in a single page.
+
+This is a one-shot query source — it has no incremental bookmark / resume support, so each run re-executes the query. For incremental loads, encode the watermark in the query (e.g. `WHERE created_at >= ?`) and drive it from a `params` entry, a matrix context, or a `${now.*}` token.
+
+## Config loading & schema introspection
+
+Configs load from YAML/JSON files, environment variables, or `.env` files via the helpers in `faucet_core::config`. Inspect the full JSON Schema with:
+
+```bash
+faucet schema source snowflake
+```
+
+## Library usage
 
 ```rust
 use faucet_core::Source;
@@ -62,17 +239,53 @@ let cfg = SnowflakeSourceConfig::new(
     "PUBLIC",
     SnowflakeAuth::OAuth { token: std::env::var("SNOWFLAKE_OAUTH_TOKEN")? },
     "SELECT id, name FROM events LIMIT 10",
-);
+)
+.with_role("ANALYST")
+.with_batch_size(0);
+
 let rows = SnowflakeSource::new(cfg).fetch_all().await?;
 println!("got {} rows", rows.len());
 # Ok(())
 # }
 ```
 
+## How it works
+
+1. `new()` builds the reusable HTTPS client and derives the API base URL from `account`.
+2. `POST /api/v2/statements` submits the SQL with `statement_timeout` as the body `timeout`, the session `warehouse` / `database` / `schema` / `role`, and any positional bindings (typed from their JSON values). The `Authorization` header is minted per request — a fresh RS256 JWT for key-pair auth, or the OAuth bearer token wrapped as `Snowflake Token="..."`.
+3. If the statement is still running, Snowflake returns `202 Accepted` with a handle; the source polls the handle until the result is ready or `poll_timeout` elapses.
+4. Result partitions are walked via `?partition=N`; each cell is decoded by its column metadata into a typed JSON value (full precision preserved for large `NUMBER`s).
+5. Rows are re-framed into `batch_size` pages and streamed to the pipeline.
+
 ## Lineage dataset URI
 
 `snowflake://<account>/<database>/<schema>?query=<sql>` — e.g. `snowflake://xy12345.us-east-1/DB/PUBLIC?query=SELECT id FROM orders`.
 
+## Feature flags
+
+This crate has no optional features of its own; enable it in the CLI/umbrella via the `source-snowflake` feature (included in the `source` and `full` aggregates).
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause & fix |
+|---------|--------------------|
+| `Auth` error / 401 | OAuth token expired or invalid, or the key-pair public key isn't registered on the Snowflake user. Refresh the token, or confirm `ALTER USER … SET RSA_PUBLIC_KEY` matches your `private_key_pem`. |
+| `403` / "insufficient privileges" | The session role can't read the queried objects, or `warehouse` access is denied. Set `role` to one with `USAGE` on the warehouse and `SELECT` on the objects. |
+| Statement hangs, then fails with `FaucetError::Source: poll timeout` | The statement ran longer than `poll_timeout` (default 300 s). Raise `poll_timeout` (or set `0` to poll indefinitely), and/or resize the warehouse so the query finishes sooner. |
+| `390201` / "no active warehouse" | `warehouse` is misspelled, suspended, or the role lacks `USAGE` on it. Verify the warehouse name and grants. |
+| Account / host not found (DNS or 404) | `account` is wrong. Use the full account identifier including region/cloud (e.g. `xy12345.us-east-1`, or `orgname-accountname`), not the login URL. |
+| A `NUMBER(38,0)` column arrives as a string | Intentional — scale-0 `FIXED`/`NUMBER` values beyond `u64` are decoded as strings to preserve full precision. Cast in a downstream transform if you need a JSON number. |
+| Bind parameter compared as text unexpectedly | Each `params` entry is typed from its JSON value. Pass `0.75` (number) not `"0.75"` (string) to bind a `REAL`. |
+| `auth: { ref }` rejected for key-pair | Key-pair JWT can't come from the shared `auth:` catalog — only OAuth (`Bearer`/`Token`) credentials map to a shared provider. Inline the `key_pair` block instead. |
+
+## See also
+
+- [Connector reference & capability matrix](https://pawansikawat.github.io/faucet-stream/reference/connectors.html)
+- [Authentication cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/auth.html) — shared `auth:` catalog and the `{ type, config }` shape
+- [Secrets interpolation](https://pawansikawat.github.io/faucet-stream/cookbook/secrets.html) — `${env:…}` / `${file:…}` / `${secret:…}`
+- [`faucet-common-snowflake`](https://crates.io/crates/faucet-common-snowflake) — the shared `SnowflakeAuth` enum and header helpers
+- [`faucet-sink-snowflake`](https://crates.io/crates/faucet-sink-snowflake) — write rows back to Snowflake
+
 ## License
 
-MIT OR Apache-2.0
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/source/sqlite/README.md
+++ b/crates/source/sqlite/README.md
@@ -5,96 +5,172 @@
 [![MSRV](https://img.shields.io/crates/msrv/faucet-source-sqlite.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
 [![License](https://img.shields.io/crates/l/faucet-source-sqlite.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-A SQLite query source that executes SQL queries and returns rows as JSON records, with connection pooling and dynamic type probing via sqlx.
+A **SQLite** query source for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem. Executes a SQL statement against a SQLite database (a file or an in-memory database), decodes each row into a typed `serde_json::Value`, and streams the result set back page-by-page via a sqlx row cursor so memory stays bounded no matter how large the table is.
 
-Part of the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
+SQLite is an in-process, file-based engine — there is no server, no network wire, and no auth. That makes this connector the simplest, lowest-overhead way to pull rows out of a local database and land them in any faucet-stream sink (a file, another database, a warehouse, a queue) with one declarative config and no glue code. It's also ideal for CI and locked-down environments where you don't want to stand up a server.
+
+## Feature highlights
+
+- **Native cursor streaming** — overrides `Source::stream_pages` to drive a sqlx row cursor (`Query::fetch`) without buffering the whole result. Rows are accumulated into a `batch_size` buffer and yielded as a `StreamPage` as soon as it fills, so peak client-side memory is `O(batch_size)` and the sink can start writing while the rest of the table is still being read off disk.
+- **`batch_size: 0` "no batching" sentinel** — drain the entire cursor into one page for small lookup tables or for sinks that prefer one large request to many small ones.
+- **Dynamic-type aware decoding** — SQLite's storage classes (INTEGER, REAL, TEXT, BLOB, NULL) are probed in order of specificity; TEXT that parses as JSON is returned as a native JSON value, BLOBs are base64-encoded so binary survives the round-trip.
+- **Connection pooling** — a `sqlx::SqlitePool` is built once in `new()` and reused for every query; pool size is configurable.
+- **Safe parameter binding** — `{field}` placeholders in the query are bound from the matrix / parent-record context as positional `?` parameters, so values are never string-interpolated into SQL (no injection).
+- **File or in-memory** — point at `sqlite:data.db`, an absolute path, or `sqlite::memory:`.
 
 ## Installation
 
 ```bash
+# As a library:
 cargo add faucet-source-sqlite
 cargo add tokio --features full
+
+# In the CLI (opt-in connector feature):
+cargo install faucet-cli --features source-sqlite
 ```
 
 Or via the umbrella crate:
+
 ```bash
 cargo add faucet-stream --features source-sqlite
 ```
 
-## Quick Start
+## Quick start
 
-```rust
-use faucet_source_sqlite::{SqliteSource, SqliteSourceConfig};
-use faucet_core::Source;
-
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let config = SqliteSourceConfig::new(
-        "sqlite:data.db",
-        "SELECT id, name, score FROM students ORDER BY score DESC",
-    );
-
-    let source = SqliteSource::new(config).await?;
-    let records = source.fetch_all().await?;
-
-    for record in &records {
-        println!("{}", record);
-    }
-    Ok(())
-}
+```yaml
+# pipeline.yaml — faucet run pipeline.yaml
+version: 1
+name: sqlite_to_jsonl
+pipeline:
+  source:
+    type: sqlite
+    config:
+      database_url: sqlite:./app.db
+      query: SELECT * FROM events ORDER BY ts
+  sink:
+    type: jsonl
+    config:
+      path: events.jsonl
 ```
 
-## Configuration
+```bash
+faucet run pipeline.yaml
+```
 
-### SqliteSourceConfig
+## Configuration reference
+
+All fields live under `pipeline.source.config`.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `database_url` | `String` | *(required)* | SQLite database URL. Can be a file path (e.g. `"sqlite:data.db"`, `"sqlite:/path/to/db"`) or in-memory (`"sqlite::memory:"`) |
-| `query` | `String` | *(required)* | SQL query to execute |
-| `max_connections` | `u32` | `10` | Maximum number of connections in the pool |
-| `batch_size` | `usize` | `1000` | Rows per `StreamPage` emitted by `Source::stream_pages`. See [Streaming and batching](#streaming-and-batching) below |
+| `database_url` | string | — *(required)* | SQLite database URL. A file path (`"sqlite:data.db"`, `"sqlite://./data/app.db"`, `"sqlite:/abs/path.db"`) or in-memory (`"sqlite::memory:"`). |
+| `query` | string | — *(required)* | SQL to execute. May contain `{field}` placeholders that are bound from the matrix / parent-record context as positional `?` parameters at runtime. |
+| `max_connections` | int (`u32`) | `10` | Maximum connections in the sqlx pool. SQLite is single-writer; a small pool (2–5) is usually plenty for a read-only source. |
+| `batch_size` | int (`usize`) | `1000` | Rows per emitted `StreamPage`. **`0` = no batching**: the cursor is fully drained and the entire result set is emitted in a single page. Values above `MAX_BATCH_SIZE` (1,000,000) are rejected at construction. |
 
-### Streaming and batching
+There is **no auth, TLS, or credential configuration** — SQLite is a local in-process engine.
 
-`SqliteSource::stream_pages` drives a sqlx row cursor (`Query::fetch`)
-without buffering the full result. Rows are accumulated into a `batch_size`
-buffer and yielded as a `StreamPage` once the buffer fills; the trailing
-partial page (if any) is yielded after the cursor drains.
+## Examples
 
-`batch_size = 0` is the **"no batching" sentinel** — the cursor is drained
-completely and the entire result set is emitted in a single `StreamPage`.
-Use it for small lookup tables, or for downstream sinks (SQL `COPY`,
-BigQuery load jobs, Snowflake stage uploads) that prefer one large request
-to many small ones. Values larger than `MAX_BATCH_SIZE` (1,000,000) are
-rejected by `faucet_core::validate_batch_size`.
+### Read a table into CSV (no network required)
 
-The sqlite query source has no incremental-replication mode, so every
-emitted page carries `bookmark: None`.
+```yaml
+version: 1
+name: sqlite_to_csv
+pipeline:
+  source:
+    type: sqlite
+    config:
+      database_url: sqlite://./data/app.db
+      query: SELECT id, email, created_at FROM users ORDER BY id
+  sink:
+    type: csv
+    config:
+      path: ./out/users.csv
+      delimiter: 44        # ','
+      write_headers: true
+```
 
-> **Note** — SQLite is an in-process, file-based engine: there is no
-> server-side cursor concept and no network wire to worry about. The
-> streaming implementation bounds *client-side* memory at `O(batch_size)`
-> and lets the sink begin writing as soon as the first batch is parsed
-> off disk, rather than waiting for the whole result set to materialise
-> in a `Vec`.
+### Project a JSON column out of a row
 
-### Supported Column Types
+`json_extract` is a SQLite built-in; the extracted TEXT is returned as a native JSON value when it parses.
 
-SQLite has dynamic typing -- values are stored as INTEGER, REAL, TEXT, BLOB, or NULL. The source probes each column value in order of specificity:
+```yaml
+source:
+  type: sqlite
+  config:
+    database_url: sqlite:/var/data/app.db
+    query: |
+      SELECT id, name, created_at,
+             json_extract(metadata, '$.tags') AS tags
+      FROM items
+      WHERE active = 1
+    batch_size: 5000
+```
 
-| SQLite Storage Class | JSON Type |
-|---------------------|-----------|
-| TEXT (valid JSON) | Native JSON value |
+### Whole-table export with no re-chunking
+
+```yaml
+source:
+  type: sqlite
+  config:
+    database_url: sqlite:analytics.db
+    query: SELECT * FROM daily_snapshot
+    batch_size: 0          # emit the entire result set as one page
+```
+
+### Per-parent query in a matrix fan-out
+
+A child matrix row can substitute values from each parent record into the query with `{field}` placeholders. Each value is bound as a positional parameter, so injection is impossible.
+
+```yaml
+matrix:
+  - id: tenants
+    source:
+      ref: tenant_list
+  - id: rows
+    parent: tenants
+    source:
+      type: sqlite
+      config:
+        database_url: sqlite:tenants.db
+        query: SELECT * FROM records WHERE tenant_id = {tenants.id}
+```
+
+## Streaming & batching
+
+`SqliteSource::stream_pages` drives a sqlx row cursor (`Query::fetch`) without buffering the full result. Rows are accumulated into a `batch_size` buffer and yielded as a `StreamPage` once the buffer fills; the trailing partial page (if any) is yielded after the cursor drains. The pipeline writes each page to the sink as it arrives, so memory is bounded at `O(batch_size)` on both sides.
+
+`batch_size = 0` is the **"no batching" sentinel** — the cursor is drained completely and the entire result set is emitted in a single `StreamPage`. Use it for small lookup tables, or for downstream sinks (SQL `COPY`, BigQuery load jobs, Snowflake stage uploads) that prefer one large request to many small ones. Values larger than `MAX_BATCH_SIZE` (1,000,000) are rejected by `faucet_core::validate_batch_size` at construction time.
+
+> **Note** — SQLite is an in-process, file-based engine: there is no server-side cursor concept and no network wire to worry about. The streaming implementation bounds *client-side* memory and lets the sink begin writing as soon as the first batch is parsed off disk, rather than waiting for the whole result set to materialise in a `Vec`.
+
+The `batch_size` argument passed to `stream_pages` by the pipeline is informational — the source always uses its own `config.batch_size` so a pipeline-supplied hint cannot silently override an explicit config value.
+
+### No incremental / resume support
+
+This is a one-shot query source. It does **not** implement bookmark-based resume, incremental replication, or exactly-once delivery: every emitted page carries `bookmark: None`, and each run re-executes the full query. For incremental loads, encode the watermark directly in the query (e.g. `WHERE updated_at > '2026-01-01'`) and drive it from a matrix context or a `${now.*}` token. If you need change-data-capture, use a CDC source (postgres-cdc / mysql-cdc / mongodb-cdc) instead.
+
+## Supported column types
+
+SQLite has dynamic typing — values are stored as INTEGER, REAL, TEXT, BLOB, or NULL. The source probes each column value in order of specificity:
+
+| SQLite storage class | JSON type |
+|----------------------|-----------|
+| TEXT (valid JSON) | native JSON value |
 | TEXT | `string` |
-| INTEGER (i64) | `number` |
-| INTEGER (i32) | `number` |
-| REAL (f64) | `number` |
+| INTEGER (`i64`) | `number` |
+| INTEGER (`i32`) | `number` |
+| REAL (`f64`) | `number` |
 | BOOLEAN | `boolean` |
 | BLOB | `string` (base64) |
 | NULL / unsupported | `null` |
 
-## Config Loading
+SQLite has no native datetime / UUID / decimal types — those are stored as TEXT/INTEGER/REAL and surface accordingly. A non-finite `f64` (NaN / infinity) cannot be represented in JSON and decodes to `null`.
+
+## Config loading
+
+Load from YAML/JSON, environment variables, or a `.env` file via the helpers in `faucet_core::config`:
 
 ```rust
 use faucet_core::config::{load_json, load_env_file};
@@ -109,13 +185,13 @@ let config: SqliteSourceConfig = load_env_file(".env", "SQLITE_SOURCE")?;
 ```json
 {
   "database_url": "sqlite:/var/data/app.db",
-  "query": "SELECT id, name, created_at, json_extract(metadata, '$.tags') AS tags FROM items WHERE active = 1",
+  "query": "SELECT id, name, created_at FROM items WHERE active = 1",
   "max_connections": 5,
   "batch_size": 5000
 }
 ```
 
-### Example .env file
+### Example `.env` file
 
 ```env
 SQLITE_SOURCE_DATABASE_URL=sqlite:data.db
@@ -124,7 +200,15 @@ SQLITE_SOURCE_MAX_CONNECTIONS=10
 SQLITE_SOURCE_BATCH_SIZE=1000
 ```
 
-## Config Schema Introspection
+## Schema introspection
+
+Inspect the full JSON Schema for this connector's config with:
+
+```bash
+faucet schema source sqlite
+```
+
+Programmatically, every `Source` exposes `config_schema()`:
 
 ```rust
 use faucet_core::Source;
@@ -134,57 +218,70 @@ let schema = source.config_schema();
 println!("{}", serde_json::to_string_pretty(&schema)?);
 ```
 
-## Examples
-
-### File-based database
+## Library usage
 
 ```rust
-use faucet_source_sqlite::{SqliteSource, SqliteSourceConfig};
 use faucet_core::Source;
-
-let config = SqliteSourceConfig::new(
-    "sqlite:analytics.db",
-    "SELECT date, event_type, COUNT(*) as count FROM events GROUP BY date, event_type",
-);
-let source = SqliteSource::new(config).await?;
-let records = source.fetch_all().await?;
-```
-
-### In-memory database
-
-```rust
-use faucet_source_sqlite::{SqliteSource, SqliteSourceConfig};
-use faucet_core::Source;
-
-let config = SqliteSourceConfig::new(
-    "sqlite::memory:",
-    "SELECT 1 AS id, 'hello' AS message",
-);
-let source = SqliteSource::new(config).await?;
-let records = source.fetch_all().await?;
-assert_eq!(records[0]["id"], 1);
-assert_eq!(records[0]["message"], "hello");
-```
-
-### Custom pool size for concurrent access
-
-```rust
 use faucet_source_sqlite::{SqliteSource, SqliteSourceConfig};
 
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
 let config = SqliteSourceConfig::new(
-    "sqlite:shared.db",
-    "SELECT * FROM large_table",
+    "sqlite:data.db",
+    "SELECT id, name, score FROM students ORDER BY score DESC",
 )
-.with_max_connections(5);
+.with_max_connections(5)
+.with_batch_size(2000);
 
 let source = SqliteSource::new(config).await?;
+
+// Convenience: buffer the whole result set.
 let records = source.fetch_all().await?;
+for record in &records {
+    println!("{record}");
+}
+# Ok(())
+# }
 ```
+
+To wire it into a pipeline with a sink, build a `faucet_core::Pipeline` (or call `run_stream`) over this source and any `Sink` — the pipeline drives `stream_pages` and writes each page as it arrives.
+
+## How it works
+
+1. `new()` validates `batch_size` and builds a `sqlx::SqlitePool` (`SqlitePoolOptions::max_connections`) **once**, reusing it for every query. A connection failure surfaces as `FaucetError::Config`.
+2. `stream_pages` resolves any `{field}` context placeholders into positional `?` bind markers, binds the values by JSON type (string / i64 / f64 / bool / null), and opens a streaming cursor with `Query::fetch`.
+3. Rows are decoded one at a time (`row_to_json`), buffered to `batch_size`, and yielded as `StreamPage`s; the final partial buffer is flushed at the end.
+4. Each column value is decoded by probing storage classes in specificity order (see [Supported column types](#supported-column-types)).
 
 ## Lineage dataset URI
 
-`sqlite://<path>?query=<sql>` — e.g. `sqlite:///var/db/app.db?query=SELECT id FROM events`.
+`sqlite://<path>?query=<sql>` — e.g. `sqlite:///var/db/app.db?query=SELECT id FROM events`. The `sqlite://` / `sqlite:` scheme prefix is stripped from `database_url` before the path is rendered.
+
+## Feature flags
+
+This crate has no optional features of its own. Enable it in the CLI / umbrella crate via the `source-sqlite` feature. It is **not** in the CLI default build — opt in with `cargo install faucet-cli --features source-sqlite`.
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause & fix |
+|---------|--------------------|
+| `FaucetError::Config: SQLite connection failed` at startup | The database file doesn't exist or the path is wrong. sqlx does **not** create the file for a read-only URL — point at an existing `.db`, or use `sqlite:data.db?mode=rwc` to create it. Check the path is relative to the process working directory. |
+| `unable to open database file` | The directory doesn't exist or the process lacks read permission on the file. Verify the path and file permissions. |
+| `FaucetError::Config: SQLite query failed` | A SQL syntax error or a reference to a missing table/column. Run the query directly with the `sqlite3` CLI to confirm it's valid. |
+| In-memory DB looks empty / each query sees a fresh database | `sqlite::memory:` databases are per-connection. With a pool of more than one connection, different queries may hit different empty databases — use `max_connections: 1` for `:memory:`, or a real file. |
+| A `{placeholder}` in the query wasn't substituted | `{field}` substitution only happens when a matrix / parent-record context is present. For a non-matrix run there is no context, so the literal query is used as-is. Encode static filters as literals or bind via a matrix parent. |
+| `database is locked` errors under concurrent writes | Another process holds a write lock. SQLite is single-writer; lower `max_connections`, or enable WAL mode on the database (`PRAGMA journal_mode=WAL;`) out of band. |
+| A BLOB column arrives as a base64 string | Intentional — binary data is base64-encoded so it survives the JSON round-trip. Decode it in a downstream transform if you need the raw bytes. |
+| `batch_size` rejected at startup | `batch_size` exceeds `MAX_BATCH_SIZE` (1,000,000). Lower it, or use `0` for the no-batching sentinel. |
+| Need only changed rows, not the whole table | This source has no incremental/CDC mode. Add a `WHERE` watermark to the query (driven by `${now.*}` or a matrix context), or use a CDC source. |
+
+## See also
+
+- [Connector reference & capability matrix](https://pawansikawat.github.io/faucet-stream/reference/connectors.html)
+- [CLI & config-file grammar](https://pawansikawat.github.io/faucet-stream/reference/cli.html)
+- [State & resume cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/state.html)
+- [`faucet-sink-sqlite`](https://crates.io/crates/faucet-sink-sqlite) — the matching SQLite sink
+- [`faucet-source-postgres`](https://crates.io/crates/faucet-source-postgres) · [`faucet-source-mysql`](https://crates.io/crates/faucet-source-mysql) — server-based SQL sources
 
 ## License
 
-Licensed under MIT or Apache-2.0.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/source/sqlite/README.md
+++ b/crates/source/sqlite/README.md
@@ -2,6 +2,8 @@
 
 [![Crates.io](https://img.shields.io/crates/v/faucet-source-sqlite.svg)](https://crates.io/crates/faucet-source-sqlite)
 [![Docs.rs](https://docs.rs/faucet-source-sqlite/badge.svg)](https://docs.rs/faucet-source-sqlite)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-source-sqlite.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-source-sqlite.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
 A SQLite query source that executes SQL queries and returns rows as JSON records, with connection pooling and dynamic type probing via sqlx.
 

--- a/crates/source/webhook/README.md
+++ b/crates/source/webhook/README.md
@@ -2,6 +2,8 @@
 
 [![Crates.io](https://img.shields.io/crates/v/faucet-source-webhook.svg)](https://crates.io/crates/faucet-source-webhook)
 [![Docs.rs](https://docs.rs/faucet-source-webhook/badge.svg)](https://docs.rs/faucet-source-webhook)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-source-webhook.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-source-webhook.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
 A webhook receiver source that starts a temporary HTTP server and collects incoming POST payloads as JSON records.
 

--- a/crates/source/webhook/README.md
+++ b/crates/source/webhook/README.md
@@ -5,87 +5,211 @@
 [![MSRV](https://img.shields.io/crates/msrv/faucet-source-webhook.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
 [![License](https://img.shields.io/crates/l/faucet-source-webhook.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-A webhook receiver source that starts a temporary HTTP server and collects incoming POST payloads as JSON records.
+A **webhook receiver** source that starts a temporary HTTP server, collects incoming `POST` payloads as JSON records, and then hands them to the pipeline. Part of the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
 
-Part of the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
+Reach for it to capture push-style events — GitHub/GitLab hooks, Stripe events, SaaS callbacks, IoT pushes — without standing up a separate ingestion service. The server is short-lived: it runs for a bounded receive window (a timeout and/or a payload cap), drains everything it collected, and shuts down. Built on [`axum`](https://crates.io/crates/axum) + [`tokio`](https://crates.io/crates/tokio), with a constant-time shared-secret check and a hard request-body cap so a single huge POST can't exhaust memory.
+
+## Feature highlights
+
+- **Zero-infrastructure receiver** — one `axum` route, bound on demand; no broker or queue to operate.
+- **Bounded receive window** — terminates on `timeout_secs`, on `max_payloads`, or both (whichever comes first), so a run always completes.
+- **Lenient body parsing** — JSON bodies become native JSON values; non-JSON-but-UTF-8 bodies become JSON strings; non-UTF-8 bodies are rejected with `400`.
+- **Request-size guard** — `max_body_bytes` (default 1 MiB) rejects oversized POSTs with `413` before buffering them.
+- **Optional shared secret** — `auth_token` requires a token in the `Authorization` header (raw or `Bearer <token>`); the comparison is **constant-time** (no timing side-channel).
+- **Exact payload cap** — under concurrent arrivals the in-memory buffer never exceeds `max_payloads`; surplus in-flight POSTs are dropped, not stored.
+- **Fast preflight** — `faucet doctor` verifies the listen address is bindable without booting the receive loop.
 
 ## Installation
 
 ```bash
+# As a library:
 cargo add faucet-source-webhook
 cargo add tokio --features full
+
+# In the CLI (opt-in connector feature):
+cargo install faucet-cli --features source-webhook
 ```
 
 Or via the umbrella crate:
+
 ```bash
 cargo add faucet-stream --features source-webhook
 ```
 
-## Quick Start
+`source-webhook` is **not** in the default feature set — opt in explicitly.
 
-```rust
-use faucet_source_webhook::{WebhookSource, WebhookSourceConfig};
-use faucet_core::Source;
+## Quick start
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let config = WebhookSourceConfig::new()
-        .listen_addr("0.0.0.0:8080")
-        .path("/webhook")
-        .max_payloads(10)
-        .timeout_secs(60);
-
-    let source = WebhookSource::new(config);
-    // Blocks until timeout or max_payloads is reached
-    let records = source.fetch_all().await?;
-
-    println!("Received {} webhook payloads", records.len());
-    Ok(())
-}
+```yaml
+# pipeline.yaml — faucet run pipeline.yaml
+version: 1
+pipeline:
+  source:
+    type: webhook
+    config:
+      listen_addr: "127.0.0.1:8080"
+      path: /webhook
+      max_payloads: 100
+      timeout_secs: 60
+  sink:
+    type: jsonl
+    config:
+      path: ./events.jsonl
 ```
 
-## How It Works
+```bash
+faucet run pipeline.yaml
+```
 
-When `fetch_all()` is called, the source:
+The server listens on `127.0.0.1:8080/webhook`, collects up to 100 POSTed payloads (or until 60 s elapse), writes them to `events.jsonl`, and exits.
 
-1. Starts an HTTP server on the configured address using axum
-2. Listens for incoming POST requests on the configured path
-3. Parses each request body as JSON (falls back to a plain string if not valid JSON)
-4. Collects payloads until either the timeout expires or `max_payloads` is reached
-5. Shuts down the server and returns all collected payloads as records
+## Configuration reference
 
-The server responds with `200 OK` to valid requests and `400 Bad Request` for non-UTF-8 bodies.
-
-## Configuration
-
-### WebhookSourceConfig
+### Core
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `listen_addr` | `String` | `"127.0.0.1:8080"` | Address to bind the HTTP server to. Defaults to loopback; bind `0.0.0.0` only behind a trusted gateway. |
-| `path` | `String` | `"/webhook"` | Endpoint path for receiving webhooks |
-| `max_payloads` | `Option<usize>` | `None` | Stop after receiving this many payloads. `None` means collect until timeout |
-| `timeout_secs` | `u64` | `30` | How long to listen before returning, in seconds |
-| `max_body_bytes` | `usize` | `1048576` | Max accepted request body size (1 MiB). Larger POSTs are rejected with `413` so one huge request can't exhaust memory. |
-| `auth_token` | `Option<String>` | `None` | Optional shared secret. When set, requests must send it in the `Authorization` header (raw or `Bearer <token>`); others get `401`. The comparison is constant-time (no timing side-channel). Strongly recommended whenever `listen_addr` isn't loopback. |
-| `batch_size` | `usize` | `1000` | Records per emitted `StreamPage`. `0` is the "no batching" sentinel — emit the full flush window in one page. See [Streaming and batching](#streaming-and-batching) |
+| `listen_addr` | string | `"127.0.0.1:8080"` | Address to bind the HTTP server to. Defaults to **loopback only**; bind `0.0.0.0` only behind a trusted gateway (and set `auth_token`). |
+| `path` | string | `"/webhook"` | Endpoint path that accepts `POST` requests. Supports matrix-context substitution — e.g. `path: /hooks/${row.id}` resolves per row at runtime. |
 
-## Streaming and batching
+### Termination
 
-The webhook source collects POST requests into a per-flush in-memory buffer during its receive window (bounded by `timeout_secs` and, optionally, `max_payloads`). It has no native streaming primitive — `Source::stream_pages` falls back to the default trait implementation, which buffers the full flush window and then chunks it into pages of `batch_size` records.
+The receive window ends as soon as **any** configured condition is met; the server then drains its buffer and returns.
 
-- `batch_size` is honoured for **chunking the flush** that is handed downstream, but does not change how POSTs are buffered server-side: the HTTP handler always pushes into the in-process `Vec` until the receive window closes.
-- `batch_size = 0` is functionally equivalent to any positive value larger than the received payload count for this source — both emit one page containing every collected record.
-- Flushes are bounded by the receive-window timer (`timeout_secs`) and `max_payloads`, configured separately on the source. Tune those if you need to bound memory at request-receive time; `batch_size` only shapes the downstream page size.
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `timeout_secs` | int | `30` | How long to listen before returning, in seconds. Always applies. |
+| `max_payloads` | int \| null | `null` | Stop once this many payloads have been received. `null` means collect until `timeout_secs` expires. The cap is **exact** under concurrent load. |
 
-## Config Loading
+### Reliability & security
 
-```rust
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `max_body_bytes` | int | `1048576` | Max accepted request body size (1 MiB). Larger POSTs are rejected with `413 Payload Too Large` before buffering, so one huge request can't exhaust memory. |
+| `auth_token` | string \| null | `null` | Optional shared secret. When set, requests must carry it in the `Authorization` header (raw value or `Bearer <token>`); others get `401`. Comparison is constant-time. Strongly recommended whenever `listen_addr` isn't loopback. |
+
+### Batching
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `batch_size` | int | `1000` | Records per emitted `StreamPage` when chunking the collected buffer downstream. `0` is the "no batching" sentinel — emit the whole flush window in one page. See [Streaming & batching](#streaming--batching). Validated against `MAX_BATCH_SIZE` (1,000,000) at load time. |
+
+## Authentication
+
+The webhook source is a **server**, not a client, so it does not use the shared `auth: { ref }` provider catalog or the `{ type, config }` auth wire shape. Instead it accepts a single inbound shared secret via the top-level `auth_token` field. Callers must send it in the `Authorization` header, either raw or `Bearer`-prefixed:
+
+```yaml
+source:
+  type: webhook
+  config:
+    listen_addr: "0.0.0.0:9090"
+    path: /github-webhooks
+    auth_token: "${env:WEBHOOK_SECRET}"   # never hard-code secrets
+```
+
+```bash
+# Both of these are accepted:
+curl -X POST http://host:9090/github-webhooks -H "Authorization: s3cr3t"        -d '{"event":"push"}'
+curl -X POST http://host:9090/github-webhooks -H "Authorization: Bearer s3cr3t" -d '{"event":"push"}'
+```
+
+Requests missing or mismatching the token receive `401 Unauthorized`. When `auth_token` is unset, the endpoint is **unauthenticated** — only acceptable on a loopback bind or behind a gateway that authenticates for you.
+
+## Examples
+
+### Collect a fixed number of events, then exit
+
+```yaml
+version: 1
+pipeline:
+  source:
+    type: webhook
+    config:
+      listen_addr: "127.0.0.1:8080"
+      path: /events
+      max_payloads: 5
+      timeout_secs: 300        # safety cap — return after 5 min even if < 5 arrive
+  sink:
+    type: stdout
+    config:
+      format: jsonl
+```
+
+### Authenticated public receiver behind a gateway
+
+```yaml
+version: 1
+pipeline:
+  source:
+    type: webhook
+    config:
+      listen_addr: "0.0.0.0:9090"
+      path: /hooks/incoming
+      auth_token: "${env:WEBHOOK_SECRET}"
+      max_body_bytes: 4194304   # accept up to 4 MiB bodies
+      timeout_secs: 3600
+  sink:
+    type: postgres
+    config:
+      connection_url: "${env:DATABASE_URL}"
+      table: webhook_events
+```
+
+### Time-limited capture into Parquet
+
+```yaml
+version: 1
+pipeline:
+  source:
+    type: webhook
+    config:
+      listen_addr: "127.0.0.1:8080"
+      path: /telemetry
+      timeout_secs: 30          # collect everything received in 30 s
+      batch_size: 0             # emit a single page (load-job friendly)
+  sink:
+    type: parquet
+    config:
+      path: ./telemetry.parquet
+```
+
+## Streaming & batching
+
+The webhook source is **buffer-shaped**: it has no native streaming primitive, so it keeps the default chunk-the-buffer `Source::stream_pages` implementation. During the receive window the `axum` handler accumulates every accepted POST into an in-process `Vec`; once the window closes (timeout or `max_payloads`), the default trait impl chunks that buffer into pages of `batch_size` records.
+
+- `batch_size` shapes only the **downstream** page size handed to the sink — it does not change server-side buffering, which always pushes into the in-memory `Vec` until the receive window ends.
+- `batch_size = 0` emits the entire flush window in one page. For this source it is functionally equivalent to any positive value larger than the received payload count.
+- To bound memory at **receive** time, tune `timeout_secs` and `max_payloads` (which cap how much is collected), not `batch_size`.
+
+Every page carries `bookmark: None` — there is no incremental-replication or resume mode for a webhook receiver (see [Resume & state](#resume--state)).
+
+## Payload handling
+
+| Request body | Stored as | HTTP response |
+|--------------|-----------|---------------|
+| Valid JSON (object/array/scalar) | the parsed JSON value | `200 OK` |
+| UTF-8 but not JSON | a JSON string of the raw text | `200 OK` |
+| Non-UTF-8 bytes | *(not stored)* | `400 Bad Request` |
+| Larger than `max_body_bytes` | *(not stored)* | `413 Payload Too Large` |
+| Missing/wrong `auth_token` (when set) | *(not stored)* | `401 Unauthorized` |
+| Accepted after `max_payloads` reached | *(dropped, cap is exact)* | `200 OK` |
+
+Only `POST` is routed; other methods on the path return `405 Method Not Allowed` from `axum`.
+
+## Resume & state
+
+**Not supported.** A webhook receiver has no replayable position to bookmark — events are pushed to it, not pulled from an offset — so the source does not override `state_key()` / `apply_start_bookmark()` and emits `bookmark: None`. For at-most-once delivery to the sink within a single run, rely on `max_payloads` + `timeout_secs` to bound the window. If you need durable, replayable ingestion, push the events into a broker (e.g. Kafka or Redis Streams) and consume from there with a resumable source.
+
+## Config loading
+
+```rust,no_run
 use faucet_core::config::{load_json, load_env_file};
 use faucet_source_webhook::WebhookSourceConfig;
 
+# fn example() -> Result<(), Box<dyn std::error::Error>> {
 let config: WebhookSourceConfig = load_json("config.json")?;
 let config: WebhookSourceConfig = load_env_file(".env", "WEBHOOK")?;
+# Ok(()) }
 ```
 
 ### Example JSON config
@@ -96,6 +220,7 @@ let config: WebhookSourceConfig = load_env_file(".env", "WEBHOOK")?;
   "path": "/hooks/incoming",
   "max_payloads": 100,
   "timeout_secs": 120,
+  "max_body_bytes": 1048576,
   "batch_size": 1000
 }
 ```
@@ -109,78 +234,95 @@ WEBHOOK_MAX_PAYLOADS=50
 WEBHOOK_TIMEOUT_SECS=60
 ```
 
-## Config Schema Introspection
+## Schema introspection
 
-```rust
-use faucet_core::Source;
-
-let source = WebhookSource::new(config);
-let schema = source.config_schema();
-println!("{}", serde_json::to_string_pretty(&schema)?);
+```bash
+faucet schema source webhook
 ```
 
-## Examples
+Prints the full JSON Schema for `WebhookSourceConfig` (field names, types, defaults).
 
-### Collect a fixed number of webhooks
+## Library usage
 
-```rust
+```rust,no_run
 use faucet_source_webhook::{WebhookSource, WebhookSourceConfig};
 use faucet_core::Source;
 
-let config = WebhookSourceConfig::new()
-    .listen_addr("127.0.0.1:8080")
-    .path("/events")
-    .max_payloads(5)
-    .timeout_secs(300);
-
-let source = WebhookSource::new(config);
-// Server runs until 5 payloads are received or 5 minutes elapse
-let events = source.fetch_all().await?;
-```
-
-### Time-limited webhook collection
-
-```rust
-use faucet_source_webhook::{WebhookSource, WebhookSourceConfig};
-use faucet_core::Source;
-
-// Collect all webhooks received within 30 seconds
-let config = WebhookSourceConfig::new()
-    .timeout_secs(30);
-
-let source = WebhookSource::new(config);
-let payloads = source.fetch_all().await?;
-println!("Collected {} payloads in 30 seconds", payloads.len());
-```
-
-### Using with a Pipeline
-
-```rust
-use faucet_source_webhook::{WebhookSource, WebhookSourceConfig};
-use faucet_core::{Pipeline, Source, Sink};
-
+# async fn example() -> Result<(), Box<dyn std::error::Error>> {
 let config = WebhookSourceConfig::new()
     .listen_addr("0.0.0.0:9090")
     .path("/github-webhooks")
+    .auth_token("s3cr3t")
     .max_payloads(100)
-    .timeout_secs(3600);
+    .timeout_secs(3600)
+    .with_batch_size(500);
 
 let source = WebhookSource::new(config);
-let pipeline = Pipeline::new(Box::new(source), Box::new(my_sink));
-let result = pipeline.run().await?;
-println!("Processed {} webhook events", result.records_written);
+
+// Blocks until the receive window closes (timeout or max_payloads),
+// then returns every collected payload.
+let records = source.fetch_all().await?;
+println!("Received {} webhook payloads", records.len());
+# Ok(()) }
 ```
 
-## Payload Handling
+Or drive it through a `Pipeline` to stream collected payloads straight into any sink:
 
-- **JSON bodies** are parsed and stored as native JSON values
-- **Plain text bodies** (non-JSON) are stored as JSON strings
-- **Non-UTF-8 bodies** receive a `400 Bad Request` response and are not stored
+```rust,no_run
+use faucet_source_webhook::{WebhookSource, WebhookSourceConfig};
+use faucet_core::{Pipeline, Source, Sink};
+
+# async fn example(my_sink: Box<dyn Sink>) -> Result<(), Box<dyn std::error::Error>> {
+let source = WebhookSource::new(
+    WebhookSourceConfig::new()
+        .listen_addr("0.0.0.0:9090")
+        .path("/github-webhooks")
+        .max_payloads(100)
+        .timeout_secs(3600),
+);
+
+let pipeline = Pipeline::new(Box::new(source), my_sink);
+let result = pipeline.run().await?;
+println!("Processed {} webhook events", result.records_written);
+# Ok(()) }
+```
+
+## How it works
+
+`fetch_with_context` (and the convenience `fetch_all`) build a single-route `axum::Router` with a `DefaultBodyLimit` set to `max_body_bytes`, bind a `tokio::net::TcpListener` to `listen_addr`, and then `tokio::select!` three futures: the running server, a `timeout_secs` sleep, and a `Notify` that fires when `max_payloads` is reached. Whichever resolves first ends the window; the collected `Vec` is cloned out and returned.
+
+- **Exact cap under concurrency** — each accepted POST decides under the shared records lock whether there's room and whether the cap is now satisfied, so concurrently in-flight requests can never push the buffer past `max_payloads` (surplus is dropped while still notifying `done`).
+- **Constant-time auth** — the shared-secret check uses `subtle::ConstantTimeEq` with a non-short-circuiting compare across both the raw and `Bearer` forms, so neither which form matched nor where the first differing byte is can be inferred from response timing.
+- **Matrix context** — when invoked with a non-empty context map, `path` is interpolated (`${row.id}` etc.) before the route is registered, so one config can fan out to per-row paths.
+- **Preflight** — `check()` (used by `faucet doctor`) just binds and immediately drops a listener on `listen_addr` to confirm the port is free, rather than the default probe that would boot the receive loop and block for the whole window.
 
 ## Lineage dataset URI
 
 `webhook://<listen_addr><path>` — e.g. `webhook://0.0.0.0:8080/hooks/incoming`.
 
+## Feature flags
+
+This crate has no optional features of its own. Enable it in the CLI / umbrella crate via the `source-webhook` feature (opt-in; not in the default set).
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause & fix |
+|---------|--------------------|
+| `FaucetError::Config: failed to bind to <addr>` | The port is already in use, the address is malformed, or you lack permission to bind it (e.g. a privileged `:80`). Pick a free, high port; check with `faucet doctor`. |
+| The run finishes with **zero** records | No POSTs arrived before `timeout_secs` expired — or they hit the wrong `path`/port. Confirm the sender's URL matches `listen_addr` + `path`, and raise `timeout_secs`. |
+| Senders get `401 Unauthorized` | `auth_token` is set but the request lacks a matching `Authorization` header. Send the token raw or as `Bearer <token>`; verify the value matches exactly. |
+| Senders get `413 Payload Too Large` | The body exceeds `max_body_bytes` (default 1 MiB). Raise `max_body_bytes` if large payloads are expected. |
+| Senders get `400 Bad Request` | The body is not valid UTF-8 (binary uploads aren't supported). Have the sender post UTF-8 JSON or text. |
+| Senders get `405 Method Not Allowed` | Only `POST` is routed. Ensure the client uses `POST` on the configured `path`. |
+| The run blocks indefinitely | `max_payloads` is unset and `timeout_secs` is very large, so the server waits the full window. The window always ends at `timeout_secs`; lower it or set `max_payloads`. |
+| Remote senders can't reach the server | The default `listen_addr` is loopback (`127.0.0.1`). Bind `0.0.0.0` to accept external traffic — and set `auth_token` (and/or front it with a gateway) when you do. |
+| Received more than `max_payloads`? | Won't happen — the cap is exact; surplus concurrent POSTs are accepted with `200` but dropped, never stored. |
+
+## See also
+
+- [Connector reference](https://pawansikawat.github.io/faucet-stream/reference/connectors.html) · [Choosing a connector](https://pawansikawat.github.io/faucet-stream/reference/choosing.html)
+- Related crates: [faucet-source-websocket](https://crates.io/crates/faucet-source-websocket) · [faucet-source-kafka](https://crates.io/crates/faucet-source-kafka) · [faucet-sink-http](https://crates.io/crates/faucet-sink-http)
+
 ## License
 
-Licensed under MIT or Apache-2.0.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/source/websocket/README.md
+++ b/crates/source/websocket/README.md
@@ -5,80 +5,327 @@
 [![MSRV](https://img.shields.io/crates/msrv/faucet-source-websocket.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
 [![License](https://img.shields.io/crates/l/faucet-source-websocket.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-A WebSocket streaming source: connects to a `ws://`/`wss://` endpoint,
-optionally sends subscription frames, and streams each incoming message as a
-record until `max_messages`, `idle_timeout`, or Ctrl-C ends the run.
+**WebSocket** streaming source for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem. Connects to a `ws://` / `wss://` endpoint, optionally sends subscription frames, and streams every incoming message into the pipeline as a record — continuously, page-by-page — until a configured stop condition (`max_messages`, `idle_timeout`) or Ctrl-C ends the run.
 
-Part of the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
+Reach for it when you want to tap a live feed — market-data tickers, chat/event streams, IoT telemetry, real-time APIs — and land it in any faucet-stream sink with one declarative config and no glue code. The connection is built once and the receive loop is fully async, so records flow to the sink the moment they arrive rather than waiting for the run to finish.
+
+## Feature highlights
+
+- **Native streaming** — `stream_pages` yields a `StreamPage` every `batch_size` records, so the sink receives data continuously throughout the run. Peak memory is `O(batch_size)` no matter how long the feed runs.
+- **Subscription frames** — send any number of `subscribe_messages` (in order) immediately after every connect *and* every reconnect, so subscribe-on-open APIs work without manual steps.
+- **Automatic reconnect** — opt-in `reconnect` with a fixed `reconnect_backoff` and an optional cap on *consecutive* failures (`max_reconnect_attempts`). The idle clock spans reconnect gaps, so a long outage still trips `idle_timeout`.
+- **Three message formats** — `json` (parse each frame into a JSON value), `raw_string` (UTF-8 string), or `binary` (base64-encoded string) — covering text and binary frames alike.
+- **Lenient or strict JSON parsing** — `on_parse_error: fail` aborts on a non-JSON frame; `skip` logs and drops it (handy for feeds that interleave protocol noise with data).
+- **Optional envelope** — wrap each record as `{ data, received_at, url }` to keep provenance and an arrival timestamp.
+- **Keepalive pings** — send a WebSocket Ping on `ping_interval` to keep the connection alive through proxies and load balancers.
+- **Shared auth providers** — bearer / custom-header auth on the HTTP upgrade request, inline or via a `{ ref }` to the CLI's top-level `auth:` catalog; a shared provider's token is re-resolved on every (re)connect so a rotated token is picked up automatically.
+- **Memory safety knobs** — `max_message_bytes` caps frame/message size to prevent a runaway server from exhausting memory.
 
 ## Installation
 
 ```bash
+# As a library:
 cargo add faucet-source-websocket
 cargo add tokio --features full
+
+# In the CLI (opt-in connector feature):
+cargo install faucet-cli --features source-websocket
 ```
 
 Or via the umbrella crate:
+
 ```bash
 cargo add faucet-stream --features source-websocket
 ```
 
-## Quick Start — Binance trade stream
+The connector is opt-in — it is not part of any default feature set.
 
-```rust
-use faucet_source_websocket::{WebsocketSource, WebsocketSourceConfig, WsMessageFormat};
-use faucet_core::Source;
+## Quick start
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let config = WebsocketSourceConfig {
-        url: "wss://stream.binance.com:9443/ws/btcusdt@trade".into(),
-        message_format: WsMessageFormat::Json,
-        max_messages: Some(100),
-        idle_timeout: Some(std::time::Duration::from_secs(30)),
-        ..serde_json::from_value(serde_json::json!({
-            "url": "wss://stream.binance.com:9443/ws/btcusdt@trade"
-        }))?
-    };
-    let source = WebsocketSource::new(config)?;
-    let records = source.fetch_all().await?;
-    println!("got {} trades", records.len());
-    Ok(())
-}
+```yaml
+# pipeline.yaml — faucet run pipeline.yaml
+version: 1
+pipeline:
+  source:
+    type: websocket
+    config:
+      url: wss://stream.binance.com:9443/ws/btcusdt@trade
+      message_format: json
+      max_messages: 100
+      idle_timeout: 30
+  sink:
+    type: jsonl
+    config:
+      path: ./trades.jsonl
 ```
 
-## Config
+```bash
+faucet run pipeline.yaml
+```
 
-| Field | Type | Default | Notes |
-|-------|------|---------|-------|
-| `url` | string | — | `ws://` or `wss://`; supports `{ctx}` substitution |
-| `auth` | enum | `none` | `none` / `bearer{token}` / `custom{headers}` |
-| `subscribe_messages` | string[] | `[]` | Sent in order on every (re)connect |
-| `message_format` | enum | `json` | `json` / `raw_string` / `binary` (base64) |
-| `on_parse_error` | enum | `fail` | `fail` / `skip` (json mode) |
-| `envelope` | bool | `false` | `true` → `{data,received_at,url}` |
-| `ping_interval` | secs | — | Client keepalive ping |
-| `max_messages` | int | — | At least one of `max_messages`/`idle_timeout` required |
-| `idle_timeout` | secs | — | Stop after this long with no frame received. Reset by **any** inbound frame — data, ping/pong, or a frame dropped by `on_parse_error=skip` — so a live server streaming skippable frames does not trip it. Also caps outages |
-| `reconnect` | bool | `false` | Reconnect on drop / non-1000 close |
-| `reconnect_backoff` | secs | `1` | Fixed wait between attempts |
-| `max_reconnect_attempts` | int | — | Cap consecutive failures (`None` = unlimited) |
-| `max_message_bytes` | int | — | Bound frame/message size |
-| `batch_size` | int | `1000` | Records per `StreamPage`; `0` = one page |
+This connects to the Binance trade stream, captures the first 100 trade messages (or stops after 30 s of silence, whichever comes first), and writes each as a JSON line.
 
-## Behavior
+## Configuration reference
 
-- **Streaming:** `stream_pages` yields a page each `batch_size` records; the
-  sink receives data continuously throughout the run.
-- **Not resumable:** a live feed has no replayable offset, so there is no
-  state/bookmark — on reconnect the source resubscribes to the live stream.
-- **Termination:** `max_messages`, `idle_timeout`, Ctrl-C, or a clean `1000`
-  close with `reconnect=false`.
+### Core
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `url` | string | — *(required)* | WebSocket endpoint. Must start with `ws://` or `wss://`. Supports `{placeholder}` parent-matrix context substitution. |
+| `auth` | `WebsocketAuth` / `{ ref }` | `none` | Authentication on the HTTP upgrade request — see [Authentication](#authentication). |
+| `subscribe_messages` | string[] | `[]` | Frames sent (in order) immediately after every connect and reconnect. Empty = send nothing. |
+| `message_format` | enum | `json` | How each incoming frame is converted to a record — `json` / `raw_string` / `binary`. See [Message formats](#message-formats). |
+| `on_parse_error` | enum | `fail` | In `json` mode, what to do with a non-JSON frame — `fail` (abort) or `skip` (log + drop). |
+| `envelope` | bool | `false` | `false` emits the record as-is; `true` wraps it as `{ data, received_at, url }`. |
+
+### Reliability
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `ping_interval` | int (seconds) | *(unset)* | If set, send a WebSocket Ping frame on this interval to keep the connection alive through proxies / load balancers. |
+| `reconnect` | bool | `false` | Reconnect on transport error or a non-`1000` close. |
+| `reconnect_backoff` | int (seconds) | `1` | Fixed wait between reconnect attempts. |
+| `max_reconnect_attempts` | int | *(unlimited)* | Cap on *consecutive* failed reconnects (resets on any received message). Unset = unlimited (then `idle_timeout` is the natural cap). |
+| `max_message_bytes` | int | *(tungstenite default)* | Bound the max message/frame size (bytes) to prevent runaway memory. Unset = tungstenite default (64 MiB message / 16 MiB frame). |
+
+### Termination
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `max_messages` | int | *(unset)* | Stop after this many messages. |
+| `idle_timeout` | int (seconds) | *(unset)* | Stop after this long with no inbound frame. The idle clock keeps ticking across reconnect gaps, so it also caps a connection outage. Reset by **any** inbound frame — data, ping/pong, or a frame dropped by `on_parse_error: skip` — so a live server streaming skippable frames does not trip it. |
+
+> **At least one of `max_messages` / `idle_timeout` must be set** — a source with neither would never stop on its own and is rejected at config-load time. Ctrl-C (SIGINT) always ends the run regardless.
+
+### Batching
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `batch_size` | int | `1000` | Records per emitted `StreamPage`. **`0` = no batching**: the entire run window is drained into a single page (same sentinel as the Kafka source). |
+
+## Authentication
+
+`auth` accepts either the inline `{ type, config }` shape or a `{ ref: <name> }` pointer to a shared provider in the CLI's top-level `auth:` catalog. The credential is applied to the HTTP upgrade request:
+
+| `type` | `config` | Effect |
+|--------|----------|--------|
+| `none` | *(none)* | No authentication (default). |
+| `bearer` | `{ token: <string> }` | Adds `Authorization: Bearer <token>`. |
+| `custom` | `{ headers: { <name>: <value>, … } }` | Adds arbitrary request headers. |
+
+```yaml
+# No auth (default) — can be omitted entirely
+auth:
+  type: none
+```
+
+```yaml
+# Bearer token (e.g. injected from the environment)
+auth:
+  type: bearer
+  config:
+    token: ${env:WS_TOKEN}
+```
+
+```yaml
+# Arbitrary custom headers
+auth:
+  type: custom
+  config:
+    headers:
+      X-API-Key: ${env:API_KEY}
+      X-Client-Id: faucet-stream
+```
+
+### Shared auth providers
+
+Point `auth` at a named provider in the top-level `auth:` catalog with `{ ref }`. The provider is built once and shared across every connector that references it, and its credential is **re-resolved on every (re)connect** — so a rotated OAuth2 token is used automatically after a reconnect.
+
+```yaml
+version: 1
+auth:
+  feed-idp:
+    type: oauth2
+    config:
+      token_url: https://idp.example.com/oauth/token
+      client_id: ${env:CLIENT_ID}
+      client_secret: ${env:CLIENT_SECRET}
+pipeline:
+  source:
+    type: websocket
+    config:
+      url: wss://feed.example.com/stream
+      auth: { ref: feed-idp }
+      idle_timeout: 60
+  sink:
+    type: stdout
+    config: {}
+```
+
+## Message formats
+
+| `message_format` | Record produced |
+|------------------|-----------------|
+| `json` | Each frame payload is parsed as JSON. Invalid JSON is handled by `on_parse_error`. |
+| `raw_string` | The frame payload as a UTF-8 string (lossy for invalid UTF-8). |
+| `binary` | The frame payload base64-encoded as a string — use for binary protocols. |
+
+With `message_format: json` and `on_parse_error: skip`, non-JSON frames are logged at `warn` and dropped (and, importantly, still reset the idle clock) — so heartbeat/control frames interleaved with data don't fail the run.
+
+## Examples
+
+### Subscribe-on-open feed with the envelope
+
+Many APIs require a subscribe message after connecting and don't echo provenance. Send the subscription frame and wrap each record with its source URL and arrival time:
+
+```yaml
+source:
+  type: websocket
+  config:
+    url: wss://ws-feed.exchange.example.com
+    subscribe_messages:
+      - '{"type":"subscribe","channels":["ticker"],"product_ids":["BTC-USD"]}'
+    message_format: json
+    envelope: true            # → { data, received_at, url }
+    idle_timeout: 120
+    ping_interval: 30         # keep the socket alive through the LB
+```
+
+### Resilient long-running tap with reconnect
+
+Run indefinitely (until Ctrl-C or a long outage), reconnecting on drops and re-sending the subscription each time:
+
+```yaml
+source:
+  type: websocket
+  config:
+    url: wss://feed.example.com/events
+    subscribe_messages:
+      - '{"action":"subscribe","topic":"events"}'
+    reconnect: true
+    reconnect_backoff: 5         # wait 5s between attempts
+    max_reconnect_attempts: 10   # give up after 10 consecutive failures
+    idle_timeout: 300            # also caps a total outage at 5 min
+    batch_size: 500
+```
+
+### Binary protocol with size limits
+
+Capture raw binary frames as base64, bounding memory against an oversized frame:
+
+```yaml
+source:
+  type: websocket
+  config:
+    url: wss://telemetry.example.com/raw
+    message_format: binary
+    max_message_bytes: 1048576   # 1 MiB cap per frame/message
+    max_messages: 10000
+    idle_timeout: 60
+```
+
+### Lenient JSON feed
+
+Drop interleaved non-JSON control frames instead of aborting:
+
+```yaml
+source:
+  type: websocket
+  config:
+    url: wss://chat.example.com/ws
+    message_format: json
+    on_parse_error: skip       # log + drop non-JSON frames
+    idle_timeout: 45
+```
+
+## Streaming & batching
+
+The source overrides `Source::stream_pages`: it connects, sends the subscribe frames, then reads frames in a loop, decoding each into a record and buffering until the buffer reaches `batch_size` — at which point it yields a `StreamPage` to the pipeline. Memory is bounded at one page regardless of total volume or run length.
+
+`batch_size: 0` is the **no-batching sentinel**: the entire run window is buffered and emitted as a single page. Because a live feed has no natural end, only use `0` together with `max_messages` (a bounded window) — otherwise the run never emits.
+
+There is **no resumable bookmark / state**: a live feed has no replayable offset, so on reconnect the source simply re-subscribes to the live stream from the current moment. The run is a tap on "now," not a replay of history.
+
+### Termination
+
+A run ends on the first of:
+
+- `max_messages` reached,
+- `idle_timeout` elapsed with no inbound frame,
+- Ctrl-C (SIGINT),
+- a clean `1000` close from the server while `reconnect: false`.
+
+## Config loading & schema
+
+Load config from a YAML/JSON file (the CLI), from a struct (the library), or from environment variables. Inspect the full JSON Schema with:
+
+```bash
+faucet schema source websocket
+```
+
+## Library usage
+
+```rust
+use faucet_core::Source;
+use faucet_source_websocket::{WebsocketSource, WebsocketSourceConfig, WsMessageFormat};
+
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+// Build the config from a JSON value, then override fields:
+let mut config: WebsocketSourceConfig = serde_json::from_value(serde_json::json!({
+    "url": "wss://stream.binance.com:9443/ws/btcusdt@trade",
+}))?;
+config.message_format = WsMessageFormat::Json;
+config.max_messages = Some(100);
+config.idle_timeout = Some(std::time::Duration::from_secs(30));
+
+let source = WebsocketSource::new(config)?;
+let records = source.fetch_all().await?;
+println!("got {} trades", records.len());
+# Ok(())
+# }
+```
+
+To attach a shared auth provider (re-resolved on every reconnect), build the source and call `with_auth_provider(provider)` before running it.
+
+## How it works
+
+1. `new()` validates the config (URL scheme, termination condition, batch size) and stores it; the connection is *not* opened yet.
+2. `stream_pages` calls `connect()`, which builds the upgrade request, resolves the effective auth (shared provider first, then inline), applies any `max_message_bytes` limit, opens the socket, and sends every `subscribe_messages` frame.
+3. The receive loop decodes each data frame per `message_format`, optionally wraps it in the envelope, and buffers it; a page is flushed every `batch_size` records.
+4. Auth is resolved **per connect**, not once at construction — so reconnects pick up a freshly rotated token from a shared provider.
+5. On a transport error or non-`1000` close with `reconnect: true`, the loop waits `reconnect_backoff`, reconnects, re-subscribes, and continues — counting consecutive failures against `max_reconnect_attempts`.
 
 ## Lineage dataset URI
 
-`wss://<host><path>` or `ws://<host><path>` (credentials stripped) — e.g. `wss://stream.example.com/feed`.
+`wss://<host><path>` or `ws://<host><path>`, with any credentials in the URL stripped — e.g. `wss://stream.example.com/feed`.
+
+## Feature flags
+
+This crate has no optional features of its own; enable it in the CLI / umbrella via the `source-websocket` feature.
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause & fix |
+|---------|--------------------|
+| `Config: at least one of max_messages or idle_timeout must be set` | A live feed has no natural end. Set `max_messages`, `idle_timeout`, or both. |
+| `Config: url must start with ws:// or wss://` | Use the WebSocket scheme, not `http(s)://`. Use `wss://` for TLS. |
+| `Source: websocket connect …` error | The server is unreachable, rejected the upgrade, or TLS failed. Run `faucet doctor` — the preflight check verifies TCP reachability of the endpoint without opening the stream. |
+| `Auth: auth references provider '…' but no provider was supplied` | The config uses `auth: { ref: <name> }` but no matching entry exists in the top-level `auth:` catalog (CLI) / no provider was passed to `with_auth_provider` (library). Define the provider or switch to inline auth. |
+| Connect succeeds but no records arrive | The server expects a subscription before it sends data. Add the required frame(s) to `subscribe_messages`. |
+| Run stops early with no data | `idle_timeout` fired before the first frame. Raise it, or confirm the subscription frame is correct. |
+| `Source: websocket json parse: …` | A frame wasn't valid JSON in `json` mode. Set `on_parse_error: skip` to drop such frames, or use `message_format: raw_string`. |
+| Connection drops periodically through a proxy / LB | Set `ping_interval` to send keepalive pings, and enable `reconnect` for resilience. |
+| Run aborts on a huge frame / memory spikes | Set `max_message_bytes` to cap frame size. |
+| Reconnect loops forever after the server goes away | Set `max_reconnect_attempts` (consecutive cap) and/or `idle_timeout` to bound the outage. |
+
+## See also
+
+- [Connectors reference](https://pawansikawat.github.io/faucet-stream/reference/connectors.html) — capability matrix.
+- [Authentication cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/auth.html) — inline auth and shared `auth:` providers.
+- [Configuration reference](https://pawansikawat.github.io/faucet-stream/reference/config.html) — the full config-file grammar.
+- [`faucet-source-webhook`](https://crates.io/crates/faucet-source-webhook) — the inbound (server) counterpart for push delivery over HTTP.
+- [`faucet-source-kafka`](https://crates.io/crates/faucet-source-kafka) — durable, resumable streaming for a different transport.
 
 ## License
 
-MIT OR Apache-2.0
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/source/websocket/README.md
+++ b/crates/source/websocket/README.md
@@ -2,6 +2,8 @@
 
 [![Crates.io](https://img.shields.io/crates/v/faucet-source-websocket.svg)](https://crates.io/crates/faucet-source-websocket)
 [![Docs.rs](https://docs.rs/faucet-source-websocket/badge.svg)](https://docs.rs/faucet-source-websocket)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-source-websocket.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-source-websocket.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
 A WebSocket streaming source: connects to a `ws://`/`wss://` endpoint,
 optionally sends subscription frames, and streams each incoming message as a

--- a/crates/source/xml/README.md
+++ b/crates/source/xml/README.md
@@ -5,76 +5,249 @@
 [![MSRV](https://img.shields.io/crates/msrv/faucet-source-xml.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
 [![License](https://img.shields.io/crates/l/faucet-source-xml.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-A config-driven XML/SOAP API source with automatic XML-to-JSON conversion, dot-path record extraction, and pluggable authentication. Transient HTTP failures (5xx / connection resets) are retried with exponential backoff.
+A config-driven **XML / SOAP API source** for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem. It fetches an XML (or SOAP) HTTP endpoint, converts the response to JSON, pulls the repeating record element out by a dot-separated element path, and streams the records page-by-page into any faucet-stream sink — a file, a database, a warehouse, a queue — with one declarative config and no glue code.
 
-Part of the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
+Reach for it when the upstream system only speaks XML or SOAP: legacy enterprise web services, RSS/Atom-style feeds, government data portals, or any HTTP endpoint that returns `application/xml`. The parser is event-driven (streaming `quick-xml`), so peak memory stays bounded by `batch_size` even for large documents.
+
+## Feature highlights
+
+- **Automatic XML → JSON conversion** — every response is parsed into a `serde_json::Value` tree; attributes, text nodes, and repeated elements all map to predictable JSON shapes.
+- **Element-path record extraction** — `records_element_path` walks a dot-separated path (e.g. `Envelope.Body.GetUsersResponse.Users.User`) to the repeating element and emits one record per match. A single element collapses to one record; a repeated element fans out to many.
+- **SOAP friendly** — set `method: POST` and supply a raw SOAP envelope as `body`; attach SOAP-action and content-type headers via `Custom` auth or `query_params`.
+- **Two pagination styles** — page-number and offset/limit, each with a built-in loop guard so a misbehaving endpoint can't spin forever; `max_pages` is a hard cap across both.
+- **Pluggable authentication** — `none`, `bearer`, `basic`, or fully custom headers — inline or via a shared provider from the CLI `auth:` catalog (OAuth2 token reuse across matrix rows).
+- **Retry with backoff** — transient HTTP failures (5xx / connection resets) are retried up to **3 attempts** with exponential backoff (base 500 ms) via the shared `faucet_core::execute_with_retry`.
+- **Bounded-memory streaming** — `Source::stream_pages` accumulates matched subtrees and yields a `StreamPage` every `batch_size` records; `batch_size: 0` drains the whole document into one page.
+- **Client built once** — the `reqwest` client is constructed in `new()` and reused for every request and every page.
 
 ## Installation
 
 ```bash
+# As a library:
 cargo add faucet-source-xml
-cargo add tokio --features full
+
+# In the CLI (opt-in connector feature):
+cargo install faucet-cli --features source-xml
 ```
 
-Or via the umbrella crate:
+Or pull it in through the umbrella crate:
+
 ```bash
 cargo add faucet-stream --features source-xml
 ```
 
-## Quick Start
+`source-xml` is **not** in the CLI default build — enable it explicitly via the feature flag above.
 
-```rust
-use faucet_source_xml::{XmlStream, XmlStreamConfig};
+## Quick start
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let config = XmlStreamConfig::new("https://api.example.com", "/users.xml")
-        .records_element_path("Response.Users.User");
-
-    let stream = XmlStream::new(config);
-    let records = stream.fetch_all().await?;
-
-    for record in &records {
-        println!("{}", record);
-    }
-    Ok(())
-}
+```yaml
+# pipeline.yaml — faucet run pipeline.yaml
+version: 1
+pipeline:
+  source:
+    type: xml
+    config:
+      base_url: https://api.example.com
+      path: /users.xml
+      method: GET
+      records_element_path: Response.Users.User
+  sink:
+    type: jsonl
+    config:
+      path: ./users.jsonl
 ```
 
-## Configuration
+```bash
+faucet run pipeline.yaml
+```
 
-### XmlStreamConfig
+## Configuration reference
+
+### Core
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `base_url` | `String` | *(required)* | Base URL of the API |
-| `path` | `String` | *(required)* | Request path appended to `base_url` |
-| `method` | `Method` | `GET` | HTTP method (`GET` or `POST` for SOAP) |
-| `auth` | `XmlAuth` | `XmlAuth::None` | Authentication method |
-| `headers` | `HeaderMap` | empty | Additional request headers |
-| `body` | `Option<String>` | `None` | Optional request body (e.g. SOAP envelope as raw XML string) |
-| `records_element_path` | `Option<String>` | `None` | Dot-separated path to the repeating element in the XML response (e.g. `"Envelope.Body.GetUsersResponse.Users.User"`) |
-| `pagination` | `Option<XmlPagination>` | `None` | Pagination configuration |
-| `max_pages` | `Option<usize>` | `None` | Maximum number of pages to fetch |
-| `query_params` | `HashMap<String, String>` | empty | Query parameters to include in every request |
+| `base_url` | string | — *(required)* | Base URL of the API. |
+| `path` | string | — *(required)* | Request path appended to `base_url`. |
+| `method` | string | `GET` | HTTP method. Use `POST` for SOAP. |
+| `body` | string | *(unset)* | Optional request body — typically a raw SOAP envelope for `POST`. |
+| `records_element_path` | string | *(unset)* | Dot-separated path to the repeating element in the converted JSON (e.g. `Envelope.Body.GetUsersResponse.Users.User`). When unset, the whole converted document is emitted as one record. |
+| `query_params` | map<string,string> | `{}` | Query parameters added to every request (in addition to pagination params). |
 
-### Authentication (XmlAuth)
+### Authentication
 
-| Variant | Fields | Description |
-|---------|--------|-------------|
-| `None` | -- | No authentication |
-| `Bearer { token }` | `String` | Bearer token in the `Authorization` header |
-| `Basic { username, password }` | `String`, `String` | HTTP Basic authentication |
-| `Custom { headers }` | `HashMap<String, String>` | Custom headers (e.g. SOAP action headers, API keys) attached to every request |
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `auth` | `XmlAuth` *(inline `{type,config}`)* or `{ ref: <name> }` | `{ type: none }` | Authentication — see [Authentication](#authentication). |
 
-### Pagination (XmlPagination)
+### Pagination
 
-| Variant | Fields | Stops When |
-|---------|--------|------------|
-| `PageNumber` | `param_name`, `start_page`, `page_size` (optional), `page_size_param` (optional) | Response returns zero records, or fewer records than `page_size` |
-| `Offset` | `offset_param`, `limit_param`, `limit` | Fewer records returned than `limit`, or loop detected |
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `pagination` | `XmlPagination` | *(unset)* | Pagination strategy — see [Pagination](#pagination). When unset, exactly one request is made. |
+| `max_pages` | int | *(unset)* | Hard cap on pages fetched, across either pagination style. |
 
-## Config Loading
+### Batching
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `batch_size` | int | `1000` | Records per emitted `StreamPage`. The event-driven parser buffers matched subtrees and yields whenever the buffer reaches this size. **`0` = no batching**: the document is drained end-to-end and the entire result set is emitted in a single page. Validated against `MAX_BATCH_SIZE` (1,000,000). |
+
+> `headers` exists on the Rust config struct for programmatic use but is `#[serde(skip)]` — it is **not** settable from YAML/JSON. Use `Custom` auth (or `query_params`) to attach request headers from config.
+
+## Authentication
+
+`auth` accepts either an **inline** `{ type, config }` block or a `{ ref: <name> }` pointer to a shared provider declared in the CLI's top-level `auth:` catalog. Inline variants:
+
+| `type` | `config` | Description |
+|--------|----------|-------------|
+| `none` | *(none)* | No authentication (default). |
+| `bearer` | `{ token: <string> }` | `Authorization: Bearer <token>`. |
+| `basic` | `{ username, password }` | HTTP Basic authentication. |
+| `custom` | `{ headers: { <name>: <value>, … } }` | Arbitrary headers attached to every request — SOAPAction, API keys, content-type overrides, etc. |
+
+```yaml
+# Bearer token (read from the environment)
+auth:
+  type: bearer
+  config:
+    token: ${env:FEED_TOKEN}
+```
+
+```yaml
+# HTTP Basic
+auth:
+  type: basic
+  config:
+    username: admin
+    password: ${env:XML_PASSWORD}
+```
+
+```yaml
+# Custom headers — e.g. SOAPAction + an API key
+auth:
+  type: custom
+  config:
+    headers:
+      SOAPAction: "http://example.com/orders/GetOrders"
+      X-API-Key: ${env:API_KEY}
+```
+
+```yaml
+# Shared provider from the top-level auth: catalog (OAuth2 token reused across rows)
+auth: { ref: my_idp }
+```
+
+## Examples
+
+### REST XML API with page-number pagination
+
+```yaml
+version: 1
+pipeline:
+  source:
+    type: xml
+    config:
+      base_url: https://api.example.com
+      path: /api/products.xml
+      records_element_path: Products.Product
+      pagination:
+        type: PageNumber
+        param_name: page
+        start_page: 1
+        page_size: 50
+        page_size_param: per_page
+      max_pages: 20
+  sink:
+    type: jsonl
+    config:
+      path: ./products.jsonl
+```
+
+### SOAP service with Basic auth (POST envelope)
+
+```yaml
+version: 1
+pipeline:
+  source:
+    type: xml
+    config:
+      base_url: https://soap.example.com
+      path: /ws
+      method: POST
+      auth:
+        type: basic
+        config:
+          username: admin
+          password: ${env:SOAP_PASSWORD}
+      body: |
+        <?xml version="1.0"?>
+        <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+          <soapenv:Body>
+            <GetOrders xmlns="http://example.com/orders"/>
+          </soapenv:Body>
+        </soapenv:Envelope>
+      records_element_path: Envelope.Body.GetOrdersResponse.Orders.Order
+  sink:
+    type: postgres
+    config:
+      connection_url: ${env:DATABASE_URL}
+      table: orders
+```
+
+### Offset-paginated feed → MongoDB (Bearer auth)
+
+```yaml
+version: 1
+name: xml_to_mongodb
+pipeline:
+  source:
+    type: xml
+    config:
+      base_url: https://feeds.example.com
+      path: /catalog
+      method: GET
+      auth:
+        type: bearer
+        config:
+          token: ${env:FEED_TOKEN}
+      query_params:
+        format: xml
+      records_element_path: catalog.products.product
+      pagination:
+        type: Offset
+        offset_param: offset
+        limit_param: limit
+        limit: 250
+  sink:
+    type: mongodb
+    config:
+      connection_uri: mongodb://localhost:27017
+      database: warehouse
+      collection: catalog_items
+      batch_size: 1000
+```
+
+Runnable copies of the last two shapes live in [`cli/examples/xml_to_mongodb.yaml`](https://github.com/PawanSikawat/faucet-stream/blob/main/cli/examples/xml_to_mongodb.yaml) and [`cli/examples/xml_to_s3.yaml`](https://github.com/PawanSikawat/faucet-stream/blob/main/cli/examples/xml_to_s3.yaml).
+
+## Pagination
+
+| Style (`type`) | Fields | Stops when |
+|----------------|--------|------------|
+| `PageNumber` | `param_name`, `start_page`, `page_size` *(optional)*, `page_size_param` *(optional)* | A page returns zero records, or fewer records than `page_size`. |
+| `Offset` | `offset_param`, `limit_param`, `limit` | A page returns fewer records than `limit`, or a loop is detected. |
+
+`max_pages` caps the total number of pages for both styles. With no `pagination` block, exactly one request is made.
+
+## Streaming & batching
+
+The source overrides `Source::stream_pages`. The XML response is parsed with an event-driven `quick-xml` reader: only the subtree matching `records_element_path` is materialized, accumulated into a buffer, and yielded as a `StreamPage` whenever the buffer reaches `batch_size`. Memory is bounded at one page regardless of document size. With `batch_size: 0`, the whole document is drained and emitted in a single page — handy for small lookup payloads or for sinks (SQL `COPY`, BigQuery load jobs) that prefer one large request to many small ones.
+
+This is a one-shot fetch source: each run re-requests the endpoint and has no incremental bookmark / resume support. For incremental loads, encode a watermark in `query_params` or the request `body` (e.g. a `since=${now.date}` param) and drive it from a matrix context or `${now.*}` token.
+
+## Config loading & schema introspection
+
+Load from YAML/JSON files, environment variables, or a `.env` file via the helpers in `faucet_core::config`:
 
 ```rust
 use faucet_core::config::{load_json, load_env_file};
@@ -84,121 +257,74 @@ let config: XmlStreamConfig = load_json("config.json")?;
 let config: XmlStreamConfig = load_env_file(".env", "XML")?;
 ```
 
-### Example JSON config
+Inspect the full JSON Schema with:
 
-```json
-{
-  "base_url": "https://api.example.com",
-  "path": "/soap/service",
-  "method": "POST",
-  "auth": {
-    "type": "basic",
-    "config": {
-      "username": "admin",
-      "password": "secret"
-    }
-  },
-  "body": "<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:web=\"http://example.com/webservice\"><soapenv:Body><web:GetUsers/></soapenv:Body></soapenv:Envelope>",
-  "records_element_path": "Envelope.Body.GetUsersResponse.Users.User",
-  "pagination": {
-    "type": "PageNumber",
-    "param_name": "page",
-    "start_page": 1,
-    "page_size": 100,
-    "page_size_param": "pageSize"
-  },
-  "max_pages": 50,
-  "query_params": {}
-}
+```bash
+faucet schema source xml
 ```
 
-### Example .env file
-
-```env
-XML_BASE_URL=https://api.example.com
-XML_PATH=/users.xml
-XML_METHOD=GET
-XML_MAX_PAGES=50
-```
-
-## Config Schema Introspection
+## Library usage
 
 ```rust
 use faucet_core::Source;
+use faucet_source_xml::{XmlStream, XmlStreamConfig, XmlAuth, XmlPagination};
 
-let stream = XmlStream::new(config);
-let schema = stream.config_schema();
-println!("{}", serde_json::to_string_pretty(&schema)?);
-```
-
-## Examples
-
-### REST XML API with page-number pagination
-
-```rust
-use faucet_source_xml::{XmlStream, XmlStreamConfig, XmlPagination};
-
-let config = XmlStreamConfig::new("https://api.example.com", "/api/products.xml")
-    .records_element_path("Products.Product")
-    .pagination(XmlPagination::PageNumber {
-        param_name: "page".into(),
-        start_page: 1,
-        page_size: Some(50),
-        page_size_param: Some("per_page".into()),
-    })
-    .max_pages(20);
-
-let stream = XmlStream::new(config);
-let products = stream.fetch_all().await?;
-println!("Fetched {} products", products.len());
-```
-
-### SOAP API with custom headers
-
-```rust
-use faucet_source_xml::{XmlStream, XmlStreamConfig, XmlAuth};
-use reqwest::Method;
-
-let config = XmlStreamConfig::new("https://soap.example.com", "/ws")
-    .method(Method::POST)
-    .auth(XmlAuth::Basic {
-        username: "admin".into(),
-        password: "password".into(),
-    })
-    .body(r#"<?xml version="1.0"?>
-<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
-  <soapenv:Body>
-    <GetOrders xmlns="http://example.com/orders"/>
-  </soapenv:Body>
-</soapenv:Envelope>"#)
-    .records_element_path("Envelope.Body.GetOrdersResponse.Orders.Order");
-
-let stream = XmlStream::new(config);
-let orders = stream.fetch_all().await?;
-```
-
-### Offset-paginated XML feed
-
-```rust
-use faucet_source_xml::{XmlStream, XmlStreamConfig, XmlPagination};
-
-let config = XmlStreamConfig::new("https://feeds.example.com", "/articles.xml")
-    .records_element_path("Feed.Articles.Article")
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let config = XmlStreamConfig::new("https://feeds.example.com", "/catalog")
+    .auth(XmlAuth::Bearer { token: std::env::var("FEED_TOKEN")? })
+    .query_param("format", "xml")
+    .records_element_path("catalog.products.product")
     .pagination(XmlPagination::Offset {
-        offset_param: "start".into(),
-        limit_param: "count".into(),
-        limit: 100,
+        offset_param: "offset".into(),
+        limit_param: "limit".into(),
+        limit: 250,
     })
-    .query_param("format", "xml");
+    .with_batch_size(500);
 
-let stream = XmlStream::new(config);
-let articles = stream.fetch_all().await?;
+let records = XmlStream::new(config).fetch_all().await?;
+println!("fetched {} records", records.len());
+# Ok(())
+# }
 ```
+
+To wire it into a pipeline, hand the `XmlStream` to `faucet_core::Pipeline` (batch) or `faucet_core::run_stream` (streaming) alongside any `Sink`. For shared-token reuse across many sources, build a `faucet_core::AuthProvider` once and inject it with `XmlStream::with_auth_provider(provider)`.
+
+## How it works
+
+1. `new()` builds the `reqwest` client **once** and stores it on the struct.
+2. Each page issues one request (`base_url + path` with `query_params` + the pagination param), retried up to **3 times** with exponential backoff (base 500 ms) on transient failures via `faucet_core::execute_with_retry`. Non-cloneable request bodies are not retried (surfaced as `FaucetError::Source`).
+3. The response is converted XML → JSON and `records_element_path` is walked to find the repeating element.
+4. Records are buffered and yielded as `StreamPage`s of `batch_size`; pagination advances until the stop condition or `max_pages`.
 
 ## Lineage dataset URI
 
-`https://<base_url><path>` (credentials stripped) — e.g. `https://soap.example.com/api/v1/service`.
+`<base_url><path>` with any embedded credentials stripped — e.g. `https://soap.example.com/svc`.
+
+## Feature flags
+
+This crate has no optional features of its own. Enable it in the CLI / umbrella crate via the `source-xml` feature.
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause & fix |
+|---------|--------------------|
+| Zero records returned, no error | `records_element_path` doesn't match the converted JSON. Inspect the response (the converter maps attributes and text nodes); fix the dot-path to the *repeating* element, or drop it to emit the whole document as one record. |
+| Only one record when you expected many | The path points at a single element rather than the repeated parent's child. Point at the repeating element itself (e.g. `…Users.User`, not `…Users`). |
+| `401` / `403` | Auth missing or wrong. Set the right `auth` variant; for SOAP endpoints that gate on `SOAPAction`, add it via `custom` headers. |
+| `FaucetError::Source: request is not cloneable for retry` | A streaming/non-cloneable request body can't be retried. Pass the SOAP envelope as a plain `body` string (the default), which is cloneable. |
+| Persistent `5xx` after retries | The source retries transient failures **3 times** with backoff before failing. A persistent 5xx is upstream — check the service; raising your own request timeout won't help. |
+| Pagination never stops / fetches too much | Set `max_pages` as a hard cap. Confirm `page_size` (PageNumber) or `limit` (Offset) matches what the API actually returns per page so the "fewer than expected" stop condition fires. |
+| Headers set in code aren't sent from YAML | `headers` is `#[serde(skip)]` and not configurable from YAML/JSON. Use `custom` auth (or `query_params`) to attach headers from config. |
+| Malformed XML / parse error | The body isn't well-formed XML (often an HTML error page returned with a 200). Verify the endpoint and that auth/headers select the XML representation (e.g. `Accept: application/xml`). |
+
+## See also
+
+- [Connector reference](https://pawansikawat.github.io/faucet-stream/reference/connectors.html) — capability matrix.
+- [Authentication cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/auth.html) — inline vs shared `auth:` providers.
+- [Pagination cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/pagination.html).
+- [`faucet-source-rest`](https://crates.io/crates/faucet-source-rest) — the JSON/REST sibling source.
+- [`faucet-source-graphql`](https://crates.io/crates/faucet-source-graphql) — GraphQL source.
 
 ## License
 
-Licensed under MIT or Apache-2.0.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/source/xml/README.md
+++ b/crates/source/xml/README.md
@@ -2,6 +2,8 @@
 
 [![Crates.io](https://img.shields.io/crates/v/faucet-source-xml.svg)](https://crates.io/crates/faucet-source-xml)
 [![Docs.rs](https://docs.rs/faucet-source-xml/badge.svg)](https://docs.rs/faucet-source-xml)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-source-xml.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-source-xml.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
 A config-driven XML/SOAP API source with automatic XML-to-JSON conversion, dot-path record extraction, and pluggable authentication. Transient HTTP failures (5xx / connection resets) are retried with exponential backoff.
 

--- a/crates/state/postgres/README.md
+++ b/crates/state/postgres/README.md
@@ -1,24 +1,100 @@
 # faucet-state-postgres
 
-PostgreSQL-backed [`StateStore`](https://docs.rs/faucet-core/latest/faucet_core/state/trait.StateStore.html) for the [faucet-stream](https://crates.io/crates/faucet-stream) ecosystem. Persists incremental-replication bookmarks across pipeline runs in a single JSONB-backed table, so sources can resume exactly where they left off after a crash, restart, or scheduled invocation.
+[![Crates.io](https://img.shields.io/crates/v/faucet-state-postgres.svg)](https://crates.io/crates/faucet-state-postgres)
+[![Docs.rs](https://docs.rs/faucet-state-postgres/badge.svg)](https://docs.rs/faucet-state-postgres)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-state-postgres.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-state-postgres.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-## Install
+PostgreSQL-backed [`StateStore`](https://docs.rs/faucet-core/latest/faucet_core/state/trait.StateStore.html) for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem. Persists incremental-replication bookmarks in a single JSONB-backed table so sources can resume exactly where they left off after a crash, restart, or scheduled invocation.
+
+Reach for it when you run faucet pipelines across multiple machines (or in Kubernetes) and want durable, shared resume state in a database you already operate — instead of a local `file` store that lives on one node's disk.
+
+## Why durable state?
+
+faucet-stream sources that support incremental replication (CDC sources like `postgres-cdc` / `mysql-cdc` / `mongodb-cdc`, and query sources with a watermark column) emit a **bookmark** after each committed batch — the replication position they reached. A `StateStore` persists that bookmark; on the next run the pipeline reads it back and resumes from there, so a restart never re-emits already-delivered rows or skips data.
+
+The built-in `memory` store forgets everything on exit, and the built-in `file` store ties state to one node's filesystem. A Postgres-backed store gives you:
+
+- **Durability across restarts and crashes** — state survives the process and the host.
+- **A shared source of truth** — every replica of a `faucet serve` cluster, every scheduled tick, and every operator running `faucet replicate` reads and writes the same row, keyed by pipeline + matrix row.
+- **One less moving part** — if you already run Postgres for the pipeline's source or sink, state lives in the same database you back up and monitor.
+
+## Who should use this crate
+
+- **End users** reference it indirectly: add the CLI's `state-postgres` feature and point a pipeline's `state:` block at `type: postgres` (see below). You never import this crate directly.
+- **Library authors** building their own pipeline runner construct [`PostgresStateStore`] and hand it to [`Pipeline::with_state_store`](https://docs.rs/faucet-core/latest/faucet_core/pipeline/struct.Pipeline.html) / `RunStreamOptions`.
+
+It implements the [`faucet_core::state::StateStore`] trait — nothing more — so it slots in anywhere a `StateStore` is accepted.
+
+## Installation
 
 ```bash
-cargo add faucet-core
-cargo add faucet-state-postgres
+# As a library (you also need faucet-core for the StateStore trait + Pipeline):
+cargo add faucet-core faucet-state-postgres
+
+# In the CLI (opt-in state backend):
+cargo install faucet-cli --features state-postgres
 ```
 
-## Usage
+The `postgres` state backend is **not** in the CLI default build — enable the `state-postgres` feature explicitly (it is included in the `full` aggregate). The built-in `memory` and `file` backends ship in `faucet-core` and need no feature.
+
+## CLI configuration
+
+Point a pipeline's top-level `state:` block at the `postgres` backend:
+
+```yaml
+# pipeline.yaml — faucet run pipeline.yaml
+version: 1
+pipeline:
+  source:
+    type: postgres-cdc
+    config:
+      connection_url: ${env:SOURCE_PG_URL}
+      slot_name: faucet_slot
+      publication: faucet_pub
+      tables: [public.orders]
+  sink:
+    type: jsonl
+    config:
+      path: ./orders.jsonl
+  state:
+    type: postgres
+    config:
+      url: ${env:STATE_PG_URL}      # e.g. postgres://user:pass@localhost:5432/faucet
+      table: faucet_state
+      ensure_table: true
+```
+
+```bash
+faucet run pipeline.yaml
+```
+
+### `state.config` fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `url` | string | — *(required)* | PostgreSQL connection URL (`postgres://user:pass@host:port/db`). Resolve secrets via `${env:VAR}` / `${secret:…}` indirection — never hard-code credentials. |
+| `table` | string | `faucet_state` | Table that holds state rows. Validated as a Postgres identifier (ASCII letters/digits/underscore, ≤ 63 chars). |
+| `ensure_table` | bool | `false` | When `true`, run `CREATE TABLE IF NOT EXISTS` on startup. Leave `false` if you provision the table via migrations or want to grant the runtime role no DDL. |
+
+The CLI uses a fixed pool size of 5 connections for the state store. Library callers can size the pool themselves via [`PostgresStateStore::connect_with`].
+
+> **Tip:** the state database can be the *same* Postgres instance as your source or sink — just give it its own `url`/`table`. It does not have to be a separate server.
+
+## Library usage
+
+### Build it and hand it to a `Pipeline`
 
 ```rust,no_run
 use std::sync::Arc;
 use faucet_core::{Pipeline, state::StateStore};
 use faucet_state_postgres::PostgresStateStore;
 
-# async fn run(source: impl faucet_core::Source, sink: impl faucet_core::Sink) -> Result<(), faucet_core::FaucetError> {
+# async fn run(source: impl faucet_core::Source, sink: impl faucet_core::Sink)
+#     -> Result<(), faucet_core::FaucetError> {
+// Default: 5 connections, `faucet_state` table.
 let store = PostgresStateStore::connect("postgres://user:pass@localhost/faucet").await?;
-store.ensure_table().await?;
+store.ensure_table().await?;            // optional — skip if you manage schema yourself
 let store: Arc<dyn StateStore> = Arc::new(store);
 
 Pipeline::new(&source, &sink)
@@ -29,7 +105,52 @@ Pipeline::new(&source, &sink)
 # }
 ```
 
-## Storage layout
+### Custom pool size, table name, or a shared pool
+
+```rust,no_run
+use faucet_state_postgres::PostgresStateStore;
+use sqlx::PgPool;
+
+# async fn build() -> Result<(), faucet_core::FaucetError> {
+// Explicit pool size + table name.
+let store = PostgresStateStore::connect_with(
+    "postgres://user:pass@localhost/faucet",
+    10,                 // max_connections
+    "pipeline_state",   // table
+).await?;
+
+// Or reuse a PgPool you already manage.
+# let existing_pool: PgPool = unimplemented!();
+let store = PostgresStateStore::from_pool(existing_pool, "faucet_state")?;
+# let _ = store;
+# Ok(())
+# }
+```
+
+### Use the store directly
+
+`PostgresStateStore` implements `StateStore`, so you can read and write bookmarks yourself:
+
+```rust,no_run
+use faucet_core::state::StateStore;
+use faucet_core::serde_json::json;
+use faucet_state_postgres::PostgresStateStore;
+
+# async fn demo() -> Result<(), faucet_core::FaucetError> {
+let store = PostgresStateStore::connect("postgres://user:pass@localhost/faucet").await?;
+store.put("postgres-cdc:faucet_slot", &json!({ "lsn": "0/16B3748" })).await?;
+let bookmark = store.get("postgres-cdc:faucet_slot").await?;   // Some(Value) or None
+store.delete("postgres-cdc:faucet_slot").await?;               // missing key is not an error
+# let _ = bookmark;
+# Ok(())
+# }
+```
+
+## How it works
+
+### Storage layout
+
+Every entry is one row in a single table:
 
 ```sql
 CREATE TABLE faucet_state (
@@ -39,28 +160,52 @@ CREATE TABLE faucet_state (
 );
 ```
 
-`ensure_table()` runs the `CREATE TABLE IF NOT EXISTS` for you. If you manage schema separately, skip it.
+`ensure_table()` runs the `CREATE TABLE IF NOT EXISTS` form (the identifier is double-quoted via `faucet_core::util::quote_ident`). If you manage schema with migrations, skip it.
 
-## Operations
+### Operations
 
-- `get(key)` — `SELECT value FROM <table> WHERE key = $1`. Returns `None` when no row exists.
-- `put(key, value)` — `INSERT ... ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = NOW()`.
-- `delete(key)` — `DELETE FROM <table> WHERE key = $1`. A missing row is not an error.
+| Trait method | SQL | Notes |
+|--------------|-----|-------|
+| `get(key)` | `SELECT value FROM <table> WHERE key = $1` | Returns `None` when no row exists. |
+| `put(key, value)` | `INSERT … VALUES ($1, $2, NOW()) ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = NOW()` | Atomic upsert — the bookmark and its `updated_at` advance together. |
+| `delete(key)` | `DELETE FROM <table> WHERE key = $1` | A missing row is not an error. |
 
-The pool is configured via `connect_with(url, max_connections, table)`; the default `connect(url)` uses 5 connections and the `faucet_state` table.
+The pipeline reads the bookmark **before** fetching and writes it **only after the sink confirms** the batch, so a crash mid-write never advances state past delivered data.
 
-## Configuration
+### Performance & safety
 
-| Option | Default | Description |
-|--------|---------|-------------|
-| `max_connections` | `5` | Size of the `sqlx::PgPool`. State writes are cheap; the default is intentionally small. |
-| `table` | `faucet_state` | Override the table name. Validated as a Postgres identifier (letters/digits/underscore, ≤ 63 chars). |
+- **Pooled connections** — the `sqlx::PgPool` is built once in `connect`/`connect_with` and reused for every operation. State writes are cheap and infrequent (one per committed batch), so the default pool of 5 is intentionally small.
+- **Single-row upsert** — `put` is one round-trip with no read-modify-write race; concurrent writers to the same key resolve via `ON CONFLICT`.
+- **Validated identifiers** — table names are checked against Postgres identifier rules (non-empty, ≤ 63 chars, `[A-Za-z0-9_]`) at construction and double-quoted in every statement, so a misconfigured table name fails fast instead of risking SQL injection.
+- **Validated keys** — state keys are checked by [`faucet_core::state::validate_state_key`] (ASCII alphanumerics plus `_ - : .`, ≤ 256 chars).
 
-## Validation
+### Health check
 
-- State keys are validated by [`faucet_core::state::validate_state_key`] — ASCII alphanumerics plus `_ - : .`, max 256 characters.
-- Table identifiers are validated against the Postgres rules to keep error messages clear and avoid SQL injection through misconfiguration. Identifiers are also double-quoted via `faucet_core::util::quote_ident`.
+`check()` runs a real upsert → select → delete round-trip on a sentinel key (`__faucet_doctor__`), so `faucet doctor` verifies connectivity, credentials, table existence, and read/write permissions through the actual code path — and leaves no residue.
+
+## Feature flags
+
+This crate has **no optional features of its own**. Enable the backend in the CLI / umbrella via the `state-postgres` feature.
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause & fix |
+|---------|--------------------|
+| `State: PostgreSQL state-store connection failed` | The `url` is wrong, the server is unreachable, or auth failed. Verify the URL, that Postgres is listening, and that the role can log in. |
+| `State: … relation "faucet_state" does not exist` | The table was never created. Set `ensure_table: true` (CLI) or call `ensure_table()` (library), or create it via your migrations. |
+| `Config: state-store table name '…' contains illegal character` | `table` must be a bare Postgres identifier — letters, digits, underscores only, ≤ 63 chars. No dots, dashes, spaces, or schema-qualified names. |
+| `State: Postgres UPSERT … failed: permission denied` | The runtime role lacks `INSERT`/`UPDATE` (or `SELECT`/`DELETE`) on the table. Grant the needed privileges, or use a role that has them. |
+| `ensure_table` fails with `permission denied for schema` | The role can't run DDL. Provision the table out-of-band (migrations / a privileged role) and set `ensure_table: false`. |
+| Pipeline re-processes data after a restart | State isn't being persisted — confirm a `state:` block is present and points at this backend (not `memory`), and that the source actually emits bookmarks (incremental/CDC sources do; one-shot query sources without a watermark don't). |
+| `faucet doctor` reports the sentinel probe failing | The round-trip couldn't complete — follow the hint it prints: check reachability, credentials, and that the table exists. |
+
+## See also
+
+- [State & resumability cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/state.html) — how bookmarks, resume, and exactly-once work end to end.
+- [Configuration reference](https://pawansikawat.github.io/faucet-stream/reference/config.html) — the full `state:` block grammar.
+- [`faucet-core`](https://crates.io/crates/faucet-core) — the `StateStore` trait, `Pipeline`, and the built-in `MemoryStateStore` / `FileStateStore`.
+- [`faucet-state-redis`](https://crates.io/crates/faucet-state-redis) — the Redis-backed alternative for the same role.
 
 ## License
 
-Licensed under either of MIT or Apache-2.0 at your option.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/state/redis/README.md
+++ b/crates/state/redis/README.md
@@ -1,22 +1,77 @@
 # faucet-state-redis
 
-Redis-backed [`StateStore`](https://docs.rs/faucet-core/latest/faucet_core/state/trait.StateStore.html) for the [faucet-stream](https://crates.io/crates/faucet-stream) ecosystem. Persists incremental-replication bookmarks across pipeline runs so a source can resume exactly where it left off after a crash, restart, or scheduled invocation.
+[![Crates.io](https://img.shields.io/crates/v/faucet-state-redis.svg)](https://crates.io/crates/faucet-state-redis)
+[![Docs.rs](https://docs.rs/faucet-state-redis/badge.svg)](https://docs.rs/faucet-state-redis)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-state-redis.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-state-redis.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-## Install
+Redis-backed [`StateStore`](https://docs.rs/faucet-core/latest/faucet_core/state/trait.StateStore.html) for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem. Persists incremental-replication bookmarks in Redis so a pipeline can resume exactly where it left off after a crash, restart, or scheduled invocation.
+
+## Why durable state
+
+A faucet-stream pipeline records a **bookmark** — the source's resume position (a CDC LSN, a `WHERE id > ?` watermark, a Kafka offset) — every time the sink confirms a batch. Where that bookmark lives decides what happens after a restart:
+
+- **`memory`** (built into `faucet-core`) — fast, but the bookmark dies with the process. Every run starts from scratch.
+- **`file`** (built into `faucet-core`) — survives restarts on a single host, but isn't shared and doesn't fit ephemeral or multi-replica deployments.
+- **`redis`** (this crate) — a network-accessible, shared store. Ideal when the runner is containerized, scheduled, or horizontally placed, and you want resume state to outlive any one process or host.
+
+The bookmark is read **before** each fetch and persisted **only after** the sink confirms the batch — so a crash mid-write replays the last batch rather than losing it (at-least-once). This crate is the storage layer behind that guarantee; you wire it in once and the pipeline handles the rest.
+
+## Who depends on this
+
+You only depend on `faucet-state-redis` directly if you are **building a pipeline in Rust** and want Redis-backed resume state. If you drive faucet-stream through the **`faucet` CLI**, you don't add this crate by hand — it's compiled in via the `state-redis` feature and selected with a `state:` block in your YAML config (see below).
+
+## Installation
 
 ```bash
+# Library — add alongside faucet-core:
 cargo add faucet-core
 cargo add faucet-state-redis
+
+# CLI — enable the Redis state backend (opt-in feature):
+cargo install faucet-cli --features state-redis
 ```
 
-## Usage
+The `state-redis` feature is **not** in the CLI's default build — enable it explicitly (or use `--features full`).
+
+## Configuration (CLI `state:` block)
+
+In a `faucet` YAML/JSON config, select this backend with `type: redis`:
+
+```yaml
+version: 1
+pipeline:
+  source:
+    type: postgres-cdc
+    config:
+      # ... your CDC source ...
+  sink:
+    type: postgres
+    config:
+      # ... your sink ...
+  state:
+    type: redis
+    config:
+      url: redis://127.0.0.1:6379
+      namespace: faucet
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `url` | string | — *(required)* | Standard Redis URL: `redis://[:password@]host:port[/db]`. Use `rediss://` for TLS. |
+| `namespace` | string | `faucet` | Prefix applied to every key (`{namespace}:{key}`). Use it to isolate pipelines that share one Redis instance — e.g. `prod`, `staging`, `team-a`. Must be non-empty and contain only ASCII alphanumerics plus `_ - .` (no `:`). |
+
+Point `url` at a secret directive to keep credentials out of the file, e.g. `url: ${env:REDIS_URL}` or `url: ${secret:redis-url}`.
+
+## Library usage
 
 ```rust,no_run
 use std::sync::Arc;
 use faucet_core::{Pipeline, state::StateStore};
 use faucet_state_redis::RedisStateStore;
 
-# async fn run(source: impl faucet_core::Source, sink: impl faucet_core::Sink) -> Result<(), faucet_core::FaucetError> {
+# async fn run(source: impl faucet_core::Source, sink: impl faucet_core::Sink)
+#     -> Result<(), faucet_core::FaucetError> {
 let store: Arc<dyn StateStore> = Arc::new(
     RedisStateStore::connect("redis://127.0.0.1:6379", "faucet").await?,
 );
@@ -29,28 +84,74 @@ Pipeline::new(&source, &sink)
 # }
 ```
 
-## Storage layout
+To share one Redis connection across several stores (e.g. one per pipeline, each with its own namespace), open the connection yourself and use `from_connection`:
 
-Each entry is a single Redis string:
+```rust,no_run
+use faucet_state_redis::RedisStateStore;
+
+# async fn run() -> Result<(), faucet_core::FaucetError> {
+let client = redis::Client::open("redis://127.0.0.1:6379")
+    .map_err(|e| faucet_core::FaucetError::Config(e.to_string()))?;
+let conn = client.get_multiplexed_async_connection().await
+    .map_err(|e| faucet_core::FaucetError::State(e.to_string()))?;
+
+let prod = RedisStateStore::from_connection(conn.clone(), "prod")?;
+let staging = RedisStateStore::from_connection(conn, "staging")?;
+# let _ = (prod, staging);
+# Ok(())
+# }
+```
+
+## How it works
+
+### Storage layout
+
+Each bookmark is a single Redis string keyed by namespace plus state key:
 
 | Redis key | Value |
 |-----------|-------|
-| `{namespace}:{state_key}` | UTF-8 JSON serialization of the bookmark value. |
+| `{namespace}:{state_key}` | UTF-8 JSON serialization of the bookmark `Value`. |
 
-The namespace is configured once in `connect()` and prefixed onto every key. Use it to keep multiple pipelines isolated within a shared Redis instance (e.g. `prod:`, `staging:`, `team-a:`).
+The namespace is fixed once in `connect()` / `from_connection()` and prefixed onto every key. The `state_key` is supplied by the pipeline (e.g. `postgres-cdc:<slot>` for a CDC source, or the CLI's `{name}::{row_id}` composite for matrix runs), so multiple sources sharing one namespace never collide.
 
-## Operations
+### Operations
 
-- `get(key)` — `GET {namespace}:{key}` → parse JSON, return `None` if the key is missing.
-- `put(key, value)` — `SET {namespace}:{key} <serialized>`.
-- `delete(key)` — `DEL {namespace}:{key}` (a missing key is not an error).
+The three `StateStore` methods map directly onto Redis commands on a namespaced key:
 
-Connections use `redis::aio::MultiplexedConnection`, which is cheaply cloneable and safe to share across tasks.
+- `get(key)` → `GET {namespace}:{key}`, then parse the JSON; a missing key returns `None`.
+- `put(key, value)` → `SET {namespace}:{key} <serialized JSON>`.
+- `delete(key)` → `DEL {namespace}:{key}`; deleting a missing key is not an error.
 
-## Key validation
+Connections use `redis::aio::MultiplexedConnection`, which is cheaply cloneable and safe to share across concurrent tasks — the store clones it per call, so no locking or pooling is needed on the caller's side. The connection is opened once in `connect()` and reused for the lifetime of the store.
 
-State keys are validated by [`faucet_core::state::validate_state_key`] — ASCII alphanumerics plus `_ - : .`, max 256 characters, no leading dot. Namespaces additionally disallow `:` (since the namespace itself becomes a key prefix).
+### Validation & preflight
+
+- **State keys** are validated by [`faucet_core::state::validate_state_key`] — ASCII alphanumerics plus `_ - : .`, max 256 characters, no leading dot.
+- **Namespaces** are validated at construction: non-empty, and the same character set minus `:` (since the namespace itself becomes a key prefix). An invalid namespace or URL fails fast as `FaucetError::Config`.
+- **`faucet doctor`** exercises a real put → get → delete round-trip on a sentinel key, so the preflight validates connectivity, auth, and read/write permissions through the actual code path and leaves no residue.
+
+## Feature flags
+
+This crate has no optional features of its own. Enable it in the CLI or the `faucet-stream` umbrella crate via the `state-redis` feature.
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause & fix |
+|---------|--------------------|
+| `Config: invalid Redis URL` | The `url` isn't a valid Redis URL. Use the `redis://[:password@]host:port[/db]` form (`rediss://` for TLS). |
+| `State: Redis connection failed` | The server is unreachable, the port is wrong, or auth was rejected. Check the host/port, that Redis is running, and that any password in the URL is correct. |
+| `Config: ... namespace contains illegal character` / `must not be empty` | The `namespace` is empty or contains a disallowed character (only `[A-Za-z0-9_.-]` allowed — no `:`, `/`, or spaces). |
+| Pipeline always restarts from scratch | The `state:` block is missing, set to `type: memory`, or a different `namespace`/source `state_key` is used each run. Resume needs a stable, durable backend and a stable key. |
+| `State: stored value ... is not valid JSON` | The namespaced key holds a non-JSON string written by something other than faucet. Use a dedicated `namespace` (or db) for faucet state so it doesn't collide with other Redis users. |
+| Multiple pipelines clobber each other's bookmarks | Two pipelines share both a namespace and a source `state_key`. Give each pipeline its own `namespace`. |
+
+## See also
+
+- [State & resume cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/state.html) — bookmarks, resume semantics, and choosing a backend.
+- [`faucet-core`](https://crates.io/crates/faucet-core) — the `StateStore` trait this crate implements, plus the built-in `memory` and `file` backends.
+- [`faucet-state-postgres`](https://crates.io/crates/faucet-state-postgres) — the PostgreSQL-backed sibling backend.
+- [faucet-stream on GitHub](https://github.com/PawanSikawat/faucet-stream) — the full ecosystem.
 
 ## License
 
-Licensed under either of MIT or Apache-2.0 at your option.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/transform-sql/README.md
+++ b/crates/transform-sql/README.md
@@ -1,53 +1,97 @@
 # faucet-transform-sql
 
-SQL-as-transform for faucet-stream — run DuckDB SQL over each pipeline page. The
-page's records are exposed as the relation `batch`; the result set replaces the page.
+[![Crates.io](https://img.shields.io/crates/v/faucet-transform-sql.svg)](https://crates.io/crates/faucet-transform-sql)
+[![Docs.rs](https://docs.rs/faucet-transform-sql/badge.svg)](https://docs.rs/faucet-transform-sql)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-transform-sql.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-transform-sql.svg)](https://github.com/PawanSikawat/faucet-stream#license)
+
+SQL-as-transform for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem — run [DuckDB](https://duckdb.org/) SQL over each pipeline page. The page's records are exposed as the relation `batch`; the query's result set replaces the page.
+
+Reach for it when you need to filter, reshape, aggregate, or join your in-flight data with the full power of an analytical SQL engine, inline in the pipeline, without standing up a separate warehouse step. DuckDB is embedded (bundled at build time) and vectorized, so the transform is fast and self-contained — no external database, no network hop.
+
+## Feature highlights
+
+- **Full DuckDB SQL** — `SELECT`, `WHERE`, `GROUP BY`, window functions, CTEs, `json_extract`, casts, string/date functions — the page is just a table named `batch`.
+- **Reference relations** — pre-load static lookup data from CSV, JSONL, or inline `values` and `JOIN` against it by name. Optional `reload_on_change` re-reads a file when its mtime changes.
+- **Vectorized JSON ↔ Arrow shovel** — records are moved into and out of DuckDB through Arrow batches (`arrow` / `arrow-json`), not row-by-row, so throughput stays high.
+- **Compile-time query validation** — the query is parse/bind-checked inside DuckDB and missing relation files are caught at `faucet validate` / start of `faucet run`, never mid-stream.
+- **Embedded engine** — DuckDB is bundled (`bundled` feature), so there are no system dependencies and the connection is built once per transform and reused for every page.
+- **Tunable** — optional `memory_limit` and `threads` DuckDB pragmas keep resource use predictable in high-fan-out matrix runs.
+
+## Installation
 
 ```bash
+# As a library:
 cargo add faucet-transform-sql
-```
 
-Enable in the umbrella crate or CLI:
-
-```bash
+# In the umbrella crate (opt-in transform feature):
 cargo add faucet-stream --features transform-sql
+
+# In the CLI:
+cargo install faucet-cli --features transform-sql
 ```
 
-## What it does
+The `transform-sql` feature is **not** in the default build; it is included in `full`.
 
-Every pipeline page passes through the SQL query as a temporary in-memory DuckDB
-table named `batch`. The result set of the query becomes the new page — each result
-row becomes one output JSON record. Column name → JSON key; `NULL` → JSON `null`;
-`STRUCT`/`LIST`/`MAP` → nested JSON.
+## Quick start
 
-This makes it straightforward to filter, reshape, aggregate, and join inline data
-without a separate warehouse step.
-
-## Config
+The `sql` transform is a pipeline-level (or matrix-row-level) transform — it goes under `transforms:`, between a source and a sink:
 
 ```yaml
-- type: sql
-  config:
-    query: "SELECT id, upper(name) AS name FROM batch WHERE active"
+# pipeline.yaml — faucet run pipeline.yaml
+version: 1
+pipeline:
+  source:
+    type: csv
+    config:
+      path: data/users.csv
+      has_header: true
+  transforms:
+    - type: sql
+      config:
+        query: "SELECT id, upper(name) AS name FROM batch WHERE active"
+  sink:
+    type: jsonl
+    config:
+      path: ./active_users.jsonl
 ```
+
+```bash
+faucet run pipeline.yaml
+```
+
+Each result row becomes one output JSON record: column name → JSON key; `NULL` → JSON `null`; DuckDB `STRUCT` / `LIST` / `MAP` → nested JSON.
+
+## Configuration reference
 
 Wire shape: `{ type: sql, config: { query, relations?, memory_limit?, threads? } }`.
 
-### Field reference
-
-| Field | Type | Required | Description |
+| Field | Type | Default | Description |
 |---|---|---|---|
-| `query` | string | yes | The SQL statement. `batch` is the page's records as a table. |
-| `relations` | list | no | Reference relations loaded at compile time and joinable by name. |
-| `memory_limit` | string | no | DuckDB `memory_limit` pragma (e.g. `"1GB"`). Default: DuckDB's own. |
-| `threads` | integer | no | DuckDB `threads` pragma. Default: DuckDB's own. Set to 1–2 in high-fan-out matrices to avoid CPU over-subscription. |
+| `query` | string | — *(required)* | The SQL statement. The page's records are the relation `batch`. Must produce a result set; each result row becomes one output record. |
+| `relations` | list of [`RelationSpec`](#reference-relations) | `[]` | Reference relations loaded once at compile time and joinable by name. |
+| `memory_limit` | string | *(DuckDB's own)* | DuckDB `memory_limit` pragma (e.g. `"1GB"`). |
+| `threads` | integer | *(DuckDB's own)* | DuckDB `threads` pragma. Set to `1`–`2` in high-fan-out matrices to avoid CPU over-subscription across rows. |
+
+### Reference-relation fields (`RelationSpec`)
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `name` | string | — *(required)* | Relation name as referenced in the query. Must be a safe SQL identifier and must not be `batch` (reserved for the page). |
+| `source` | [`RelationSource`](#relation-source-types) | — *(required)* | Where the relation's data comes from. |
+| `reload_on_change` | bool | `false` | Re-stat the file's mtime before each page; rebuild and atomically swap the relation if it changed. Ignored for `values`. |
+
+### Relation source types (`source.type`)
+
+| `type` | Fields | Description |
+|---|---|---|
+| `csv` | `path` (string, required), `has_header` (bool, default `true`) | Delimited file loaded via DuckDB `read_csv_auto`. |
+| `jsonl` | `path` (string, required) | Newline-delimited JSON loaded via DuckDB `read_json_auto`. |
+| `values` | `columns` (list of strings, required), `rows` (list of lists, required) | Inline rows materialized into a table; no file I/O. Each inner row must have the same length as `columns`. |
 
 ## Reference relations
 
-Pre-load static lookup data (CSV, JSONL, or inline values) that your query can `JOIN`
-against. Relations are loaded **once at compile time** (when `faucet validate` /
-`faucet run` first reads the config) and remain resident for the lifetime of the
-transform.
+Pre-load static lookup data (CSV, JSONL, or inline `values`) that your query can `JOIN` against. Relations are loaded **once at compile time** (when `faucet validate` / `faucet run` first reads the config) and remain resident for the lifetime of the transform.
 
 ```yaml
 - type: sql
@@ -64,15 +108,7 @@ transform.
           has_header: true        # default true
 ```
 
-### Relation source types
-
-| `type` | Fields | Description |
-|---|---|---|
-| `csv` | `path` (string, required), `has_header` (bool, default `true`) | Loaded via DuckDB `read_csv_auto`. |
-| `jsonl` | `path` (string, required) | Loaded via DuckDB `read_json_auto`. |
-| `values` | `columns` (list of strings), `rows` (list of lists) | Inline data; no file I/O. |
-
-Inline `values` example:
+Inline `values` need no file I/O:
 
 ```yaml
 relations:
@@ -97,21 +133,15 @@ relations:
     reload_on_change: true   # re-read when the file's mtime changes
 ```
 
-When `true`, faucet stats the file before each page and rebuilds the relation
-atomically if the mtime changed. Defaults to `false`. Ignored for `values`.
+When `true`, faucet stats the file before each page and rebuilds the relation atomically if the mtime changed. Defaults to `false`. Ignored for `values`.
 
-### Reserved name
-
-The name `batch` is reserved for the page relation. Using it as a relation name
-is a compile-time error.
+The name `batch` is reserved for the page relation. Using it as a relation name is a compile-time error.
 
 ## Per-page semantics and `batch_size: 0`
 
 **This is the most important thing to understand about the SQL transform.**
 
-The transform runs once **per page**, not once across the whole stream. With the
-default `batch_size` of 1000, `GROUP BY` and window functions aggregate within a
-single 1000-row page — not across all pages.
+The transform runs once **per page**, not once across the whole stream. With the default `batch_size` of 1000, `GROUP BY` and window functions aggregate within a single 1000-row page — not across all pages.
 
 ```yaml
 # BAD: GROUP BY runs per-page, giving partial aggregates.
@@ -126,8 +156,7 @@ pipeline:
         query: "SELECT country, SUM(amount) AS total FROM batch GROUP BY country"
 ```
 
-**To aggregate across the whole dataset**, set the source's `batch_size: 0` so the
-entire result set arrives as one page:
+**To aggregate across the whole dataset**, set the source's `batch_size: 0` so the entire result set arrives as one page:
 
 ```yaml
 # CORRECT: batch_size: 0 loads the whole file as one page → global GROUP BY.
@@ -143,12 +172,9 @@ pipeline:
         query: "SELECT country, SUM(amount) AS total FROM batch GROUP BY country"
 ```
 
-`batch_size: 0` means "no batching" — the source emits the entire result set as a
-single `StreamPage`. All sources support it; it is appropriate for small lookup
-tables and for aggregating transforms like this one.
+`batch_size: 0` means "no batching" — the source emits the entire result set as a single `StreamPage`. All sources support it; it is appropriate for small lookup tables and for aggregating transforms like this one. Be mindful of memory: `batch_size: 0` buffers the whole result set in RAM, so use it for datasets that comfortably fit in memory.
 
-When an aggregating query receives a second page (i.e. `batch_size` was not set to
-`0`), faucet emits a one-time warning:
+When an aggregating query receives a second page (i.e. `batch_size` was not set to `0`), faucet emits a one-time warning:
 
 ```
 WARN faucet::transform::sql: sql transform with aggregation received multiple pages;
@@ -159,25 +185,36 @@ aggregation is per-page — set batch_size: 0 for global aggregation
 
 **At config load time** (`faucet validate` / start of `faucet run`):
 
-- The query is parse/bind-checked inside DuckDB. Syntax errors report line and
-  column number.
-- Reference-relation files that do not exist cause an immediate error (before any
-  page is processed).
+- The query is parse/bind-checked inside DuckDB. Syntax errors report line and column number.
+- Reference-relation files that do not exist cause an immediate error (before any page is processed).
 - A relation named `batch` is rejected.
 
 **At runtime** (per page):
 
-- A query that fails mid-run aborts the pipeline immediately (`FaucetError::Transform`).
-- Runtime query errors are **not** routed to the dead-letter queue — they follow the
-  same fail-fast policy as every other built-in transform.
+- A query that fails mid-run aborts the pipeline immediately with `FaucetError::Transform`.
+- Runtime query errors are **not** routed to the dead-letter queue — they follow the same fail-fast policy as every other built-in transform.
 
-Empty result sets are valid: a query that matches zero rows produces zero output
-records for that page.
+Empty result sets are valid: a query that matches zero rows produces zero output records for that page.
 
-## Runnable example
+## Examples
 
-The file `cli/examples/csv_to_jsonl_sql.yaml` groups order CSV data by country and
-joins to a reference countries CSV, writing JSONL output:
+### Filter and reshape (per-page, no aggregation)
+
+```yaml
+transforms:
+  - type: sql
+    config:
+      query: |
+        SELECT id,
+               lower(email)        AS email,
+               coalesce(plan, 'free') AS plan
+        FROM batch
+        WHERE deleted_at IS NULL
+```
+
+### Global aggregation joined to a reference CSV
+
+This mirrors `cli/examples/csv_to_jsonl_sql.yaml` — group order data by country and join to a reference countries CSV:
 
 ```yaml
 version: 1
@@ -196,7 +233,7 @@ pipeline:
       config:
         query: |
           SELECT c.country,
-                 COUNT(*)                     AS order_count,
+                 COUNT(*)                      AS order_count,
                  SUM(CAST(o.amount AS DOUBLE)) AS total_amount
           FROM   batch o
           LEFT JOIN countries c ON o.country_code = c.code
@@ -229,31 +266,30 @@ Output rows look like:
 {"country":"United States","order_count":2,"total_amount":15.5}
 ```
 
-## Feature flag
+### Enrich with an inline lookup table
 
-`transform-sql` — not in the default build; included in `full`.
-
-```bash
-# Enable only the SQL transform
-cargo add faucet-stream --features transform-sql
-
-# Enable together with specific connectors
-cargo add faucet-stream --features source-csv,sink-jsonl,transform-sql
-
-# Enable everything
-cargo add faucet-stream --features full
+```yaml
+transforms:
+  - type: sql
+    config:
+      query: |
+        SELECT b.id, b.tier_id, t.label AS tier
+        FROM batch b
+        LEFT JOIN tiers t ON b.tier_id = t.id
+      relations:
+        - name: tiers
+          source:
+            type: values
+            columns: [id, label]
+            rows:
+              - [1, gold]
+              - [2, silver]
+              - [3, bronze]
 ```
 
-CLI:
+## Working with JSON columns
 
-```bash
-cargo install faucet-cli --features transform-sql
-```
-
-## JSON columns
-
-DuckDB's `json_extract` works on string or JSON columns. If a field is a JSON
-string, use it directly:
+DuckDB's `json_extract` works on string or JSON columns. If a field is a JSON string, use it directly:
 
 ```sql
 SELECT json_extract(payload, '$.user.id') AS user_id FROM batch
@@ -267,8 +303,7 @@ SELECT json_extract(payload::JSON, '$.user.id') AS user_id FROM batch
 
 ## Timestamp / timezone note
 
-DuckDB's `TIMESTAMP` type is timezone-naive. faucet JSON timestamps are RFC 3339
-strings (e.g. `"2026-01-01T12:00:00Z"`). To compare or cast them:
+DuckDB's `TIMESTAMP` type is timezone-naive. faucet JSON timestamps are RFC 3339 strings (e.g. `"2026-01-01T12:00:00Z"`). To compare or cast them:
 
 ```sql
 -- Parse an RFC 3339 string into a DuckDB TIMESTAMP (drops the offset)
@@ -279,15 +314,25 @@ WHERE CAST(created_at AS TIMESTAMP) > '2026-01-01'::TIMESTAMP
 SELECT * FROM batch WHERE created_at > '2026-01-01T00:00:00Z'
 ```
 
-If your timestamps include non-UTC offsets, normalise them to UTC with `cast` before
-passing to the SQL transform, or parse with `strptime`.
+If your timestamps include non-UTC offsets, normalise them to UTC with `cast` before passing to the SQL transform, or parse with `strptime`.
+
+## Config loading & schema
+
+Configs load from YAML/JSON. Inspect the full JSON Schema for the transform with:
+
+```bash
+faucet schema transform sql
+```
 
 ## Library usage
+
+Library callers build the compiled transform and attach it to any `Source` via a page stage and `faucet_core::TransformingSource`:
 
 ```rust
 use faucet_transform_sql::{SqlTransform, SqlTransformConfig};
 use faucet_core::stage::{compile_stage, apply_stages_to_page};
 
+# fn run(records: Vec<serde_json::Value>) -> Result<(), faucet_core::FaucetError> {
 let cfg = SqlTransformConfig {
     query: "SELECT id, upper(name) AS name FROM batch".into(),
     relations: vec![],
@@ -295,12 +340,68 @@ let cfg = SqlTransformConfig {
     threads: None,
 };
 
-let t = SqlTransform::compile(&cfg)?;
+let t = SqlTransform::compile(&cfg)?;          // parse/bind-checks the query now
 let stage = compile_stage(&t.into_page_stage())?;
 
 let output = apply_stages_to_page(records, &[stage])?;
+# let _ = output;
+# Ok(())
+# }
 ```
+
+To wrap a whole source, hand the same stage to `faucet_core::TransformingSource::new(source, vec![stage])` and run it through `Pipeline` / `run_stream` like any other source. `SqlTransform::compile` is the canonical entry point; `into_page_stage()` produces a `TransformStage::PageFn` (a page-level, whole-batch stage).
+
+## How it works
+
+1. `SqlTransform::compile(&cfg)` opens an in-memory DuckDB connection, applies the `memory_limit` / `threads` pragmas, materializes every reference relation, and parse/bind-checks the query — all once.
+2. For each page, the records are converted to an Arrow batch and registered as the `batch` relation (a vectorized JSON ↔ Arrow shovel, not row-by-row).
+3. The query runs; the result set is converted back from Arrow to JSON records, which replace the page.
+4. With `reload_on_change`, a relation's file mtime is checked before each page and the relation is rebuilt and atomically swapped if it changed.
+
+The DuckDB connection and all relations are owned by the compiled `SqlTransform` and reused for every page — there is no per-page connection setup.
+
+## Feature flags
+
+| Feature | Enables |
+|---|---|
+| `transform-sql` (CLI / umbrella) | The `sql` transform type. Pulls in this crate (`duckdb` with `bundled` + `vtab-arrow`, `arrow`, `arrow-json`). Not in `default`; included in `full`. |
+
+This crate itself has no optional features of its own; the `bundled` and `vtab-arrow` DuckDB features are always on.
+
+```bash
+# Enable only the SQL transform
+cargo add faucet-stream --features transform-sql
+
+# Enable together with specific connectors
+cargo add faucet-stream --features source-csv,sink-jsonl,transform-sql
+
+# Enable everything
+cargo add faucet-stream --features full
+```
+
+## Troubleshooting / FAQ
+
+| Symptom | Likely cause & fix |
+|---------|--------------------|
+| `GROUP BY` / window results look partial or per-chunk | The transform runs **per page**. Set the source's `batch_size: 0` so the whole dataset arrives as one page (see [Per-page semantics](#per-page-semantics-and-batch_size-0)). |
+| `WARN ... aggregation is per-page` | An aggregating query saw a second page. Set the source's `batch_size: 0` for global aggregation, or accept per-page aggregates. |
+| Out-of-memory with `batch_size: 0` | The whole result set is buffered in RAM. Cap DuckDB with `memory_limit`, or aggregate in stages, or keep `batch_size` bounded if global aggregation isn't required. |
+| `FaucetError::Config` at validate time, "syntax error" | The query failed DuckDB parse/bind. The error reports line/column — fix the SQL. |
+| Validate fails: relation file not found | A `csv` / `jsonl` relation `path` doesn't exist. Paths are relative to the working directory; use an absolute path or run from the right directory. |
+| Compile error: relation named `batch` | `batch` is reserved for the page relation. Rename the reference relation. |
+| `FaucetError::Transform` aborts the run mid-stream | A runtime query error (e.g. a cast that fails on real data). These are **not** sent to the DLQ — fix the query or pre-clean the data with an earlier transform. |
+| A JSON column won't parse | Cast it: `json_extract(payload::JSON, '$.path')` (see [Working with JSON columns](#working-with-json-columns)). |
+| Timestamp comparisons behave oddly | DuckDB `TIMESTAMP` is timezone-naive; RFC 3339 strings carry offsets. Normalise to UTC first (see [Timestamp / timezone note](#timestamp--timezone-note)). |
+| High CPU in a large matrix run | Each row's transform spins up DuckDB threads. Set `threads: 1` or `2` on the SQL config to avoid over-subscription. |
+
+## See also
+
+- [SQL transform cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/transforms.html) — the transforms model and worked examples.
+- [Transforms reference](https://pawansikawat.github.io/faucet-stream/reference/config.html) — the full `transforms:` grammar and layering rules.
+- [`faucet-core`](https://crates.io/crates/faucet-core) — the `TransformStage` / `TransformingSource` types this transform plugs into.
+- [`faucet-stream`](https://crates.io/crates/faucet-stream) — the umbrella crate that exposes the `transform-sql` feature.
+- [DuckDB SQL documentation](https://duckdb.org/docs/sql/introduction) — the dialect available inside the `query`.
 
 ## License
 
-Licensed under either of Apache License 2.0 or MIT license at your option.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/docs/book/src/cookbook/state.md
+++ b/docs/book/src/cookbook/state.md
@@ -46,14 +46,14 @@ Available backends:
 state:
   type: redis
   config:
-    connection_url: redis://localhost:6379
+    url: redis://localhost:6379
     namespace: faucet
 
 # Postgres
 state:
   type: postgres
   config:
-    connection_url: postgres://user:pass@localhost/faucet
+    url: postgres://user:pass@localhost/faucet
 ```
 
 ## How bookmarks advance

--- a/faucet-stream/Cargo.toml
+++ b/faucet-stream/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 description = "A declarative, config-driven data pipeline with pluggable source and sink connectors"
 readme = "../README.md"
 keywords = ["rest", "api", "meltano", "bigquery", "streaming"]
-categories = ["web-programming::http-client"]
+categories = ["database", "asynchronous", "encoding"]
 exclude = [".trunk/"]
 
 [features]

--- a/faucet-stream/README.md
+++ b/faucet-stream/README.md
@@ -5,105 +5,193 @@
 [![MSRV](https://img.shields.io/crates/msrv/faucet-stream.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
 [![License](https://img.shields.io/crates/l/faucet-stream.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
-Umbrella crate for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem. Provides feature-gated access to all source and sink connectors through a single dependency.
+The umbrella crate for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem — a modular, config-driven Rust data-pipeline toolkit. One dependency gives you feature-gated access to every source and sink connector, the state-store backends, shared auth providers, data-quality checks, OpenLineage emission, and the embedded SQL transform — all built on the lightweight `faucet-core` traits.
+
+This crate is for **Rust library users** who want to build pipelines in code. If you'd rather drive pipelines declaratively from YAML/JSON with zero Rust, install the [`faucet-cli`](https://crates.io/crates/faucet-cli) binary instead — it wraps these same connectors behind a `faucet run pipeline.yaml` command.
+
+## Why the umbrella vs. individual crates?
+
+- **One dependency, one version line.** `faucet-stream` pins every connector to a compatible version so you never hand-align `faucet-source-rest`, `faucet-sink-postgres`, etc. Add the features you want and the right crates come along.
+- **Pay only for what you enable.** Every connector is behind an opt-in Cargo feature. The default build pulls in just the REST source, so an unused connector never touches your compile time or binary size.
+- **Uniform re-exports.** Connector types surface under one `faucet_stream::*` namespace, alongside the full `faucet-core` API (`Source`, `Sink`, `Pipeline`, `run_stream`, `FaucetError`, transforms).
+
+Prefer depending on the individual crates (`faucet-core` + `faucet-source-rest` + `faucet-sink-postgres`, …) when you want the absolute minimum dependency closure or are publishing your own connector crate — see [Using individual crates](#using-individual-crates) below.
 
 ## Installation
 
 ```bash
-# Default: REST source only
+# Default: REST source only (smallest build)
 cargo add faucet-stream
 
-# All sources
-cargo add faucet-stream --features source
+# Pick exactly the connectors you need
+cargo add faucet-stream --features source-rest,source-s3,sink-postgres,sink-jsonl
 
-# All sinks
+# All sources / all sinks
+cargo add faucet-stream --features source
 cargo add faucet-stream --features sink
 
-# Everything
+# Everything — every connector, state backend, auth, quality, lineage, SQL transform
 cargo add faucet-stream --features full
-
-# Pick what you need
-cargo add faucet-stream --features source-rest,source-s3,sink-postgres,sink-jsonl
 ```
 
-## Feature Flags
+> The default feature set is `["source-rest"]`. Every other connector and capability below is **opt-in**.
 
-### Source Connectors
+## Feature-flag matrix
 
-| Feature | Default | Crate |
-|---------|---------|-------|
-| `source-rest` | yes | REST API — auth, pagination, extraction, transforms |
-| `source-graphql` | no | GraphQL API — cursor pagination, variable injection |
-| `source-xml` | no | XML/SOAP API — XML-to-JSON conversion |
-| `source-grpc` | no | gRPC — dynamic protobuf via prost-reflect (unary + server-streaming) |
-| `source-postgres` | no | PostgreSQL — SQL queries as JSON |
-| `source-mysql` | no | MySQL — SQL queries as JSON |
-| `source-sqlite` | no | SQLite — SQL queries as JSON |
-| `source-s3` | no | AWS S3 — read JSONL, JSON array, or raw text |
-| `source-mongodb` | no | MongoDB — find() with filter/projection/sort |
-| `source-redis` | no | Redis — streams, lists, or key patterns |
-| `source-webhook` | no | Webhook — HTTP server collecting POST payloads |
-| `source-csv` | no | CSV — read CSV files as JSON objects |
-| `source-elasticsearch` | no | Elasticsearch — search/scroll API |
-
-### Sink Connectors
-
-| Feature | Default | Crate |
-|---------|---------|-------|
-| `sink-bigquery` | no | Google BigQuery — streaming inserts |
-| `sink-postgres` | no | PostgreSQL — JSONB or auto-mapped columns |
-| `sink-jsonl` | no | JSON Lines — file output |
-| `sink-snowflake` | no | Snowflake — SQL REST API with JWT/OAuth |
-| `sink-mysql` | no | MySQL — JSON or auto-mapped columns |
-| `sink-sqlite` | no | SQLite — JSON or auto-mapped columns |
-| `sink-s3` | no | AWS S3 — write JSONL files |
-| `sink-mongodb` | no | MongoDB — insert_many |
-| `sink-redis` | no | Redis — streams, lists, key-value |
-| `sink-csv` | no | CSV — write JSON as CSV rows |
-| `sink-elasticsearch` | no | Elasticsearch — bulk index API |
-| `sink-http` | no | HTTP — POST records to any endpoint |
-
-### Aggregate Features
-
-| Feature | Description |
-|---------|-------------|
-| `source` | All source connectors |
-| `sink` | All sink connectors |
-| `full` | Every connector |
-
-### Transform Features
+### Source connectors
 
 | Feature | Default | Description |
 |---------|---------|-------------|
-| `transform-flatten` | yes (via source-rest) | Flatten nested objects |
-| `transform-rename-keys` | yes (via source-rest) | Regex key renaming |
-| `transform-keys-case` | yes (via source-rest) | Re-case every key (snake / camel / pascal / kebab / screaming_snake) |
-| `transform-select` | no | Keep only listed top-level fields |
-| `transform-drop` | no | Remove listed top-level fields |
-| `transform-set` | no | Add/overwrite top-level fields with constants |
-| `transform-rename-field` | no | Exact-name field rename (single or batch) |
-| `transform-cast` | no | Per-field type coercion with configurable `on_error` |
-| `transform-redact` | no | Replace listed field values with a mask |
-| `transform-value-case` | no | Lowercase / uppercase / trim string field values |
-| `transform-spell-symbols` | no | Spell out symbols in keys (`%` → `percent`, `#` → `number`, …) |
-| `transforms` | no | All built-in transforms |
+| `source-rest` | **yes** | REST API — auth, pagination, JSONPath extraction, transforms |
+| `source-graphql` | no | GraphQL API — cursor pagination, variable injection |
+| `source-xml` | no | XML/SOAP API — XML-to-JSON conversion, dot-path extraction |
+| `source-grpc` | no | gRPC — dynamic protobuf via prost-reflect (unary + server-streaming) |
+| `source-postgres` | no | PostgreSQL — run SQL, return rows as JSON |
+| `source-postgres-cdc` | no | PostgreSQL CDC — logical replication (pgoutput), resumable |
+| `source-mysql` | no | MySQL — SQL queries as JSON |
+| `source-mysql-cdc` | no | MySQL CDC — binlog replication, resumable |
+| `source-mssql` | no | Microsoft SQL Server — streaming, incremental replication |
+| `source-sqlite` | no | SQLite — SQL queries as JSON |
+| `source-s3` | no | AWS S3 — JSONL, JSON array, or raw text |
+| `source-gcs` | no | Google Cloud Storage — JSONL, JSON array, or raw text |
+| `source-mongodb` | no | MongoDB — `find()` with filter / projection / sort |
+| `source-mongodb-cdc` | no | MongoDB CDC — Change Streams, resumable via resumeToken |
+| `source-redis` | no | Redis — streams, lists, or key patterns |
+| `source-webhook` | no | Webhook — temporary HTTP server collecting POSTs |
+| `source-websocket` | no | WebSocket — live streaming, subscription frames, reconnect |
+| `source-csv` | no | CSV — read CSV files as JSON objects |
+| `source-elasticsearch` | no | Elasticsearch — search / scroll API |
+| `source-parquet` | no | Parquet — local, glob, or S3; vectorized Arrow reader |
+| `source-kafka` | no | Kafka consumer — subscribe, drain with idle / max-message termination |
+| `source-bigquery` | no | BigQuery query source — `jobs.query` + pagination |
+| `source-snowflake` | no | Snowflake query source — SQL REST API, JWT / OAuth |
 
-## Quick Start
+### Sink connectors
+
+| Feature | Default | Description |
+|---------|---------|-------------|
+| `sink-bigquery` | no | Google BigQuery — streaming inserts; upsert/delete via MERGE |
+| `sink-iceberg` | no | Apache Iceberg — append snapshots (REST / Glue / SQL / HMS catalogs) |
+| `sink-postgres` | no | PostgreSQL — JSONB or auto-mapped columns |
+| `sink-mysql` | no | MySQL — JSON column or auto-mapped columns |
+| `sink-mssql` | no | Microsoft SQL Server — JSON or auto-mapped columns |
+| `sink-sqlite` | no | SQLite — JSON or auto-mapped columns |
+| `sink-snowflake` | no | Snowflake — SQL REST API |
+| `sink-mongodb` | no | MongoDB — `insert_many` / upsert |
+| `sink-redis` | no | Redis — streams, lists, key-value |
+| `sink-elasticsearch` | no | Elasticsearch — bulk index API |
+| `sink-s3` | no | AWS S3 — JSONL files |
+| `sink-gcs` | no | Google Cloud Storage — JSONL files |
+| `sink-parquet` | no | Parquet — local or S3; schema inference, row/byte rollover |
+| `sink-kafka` | no | Kafka producer — batched sends, multi-topic routing |
+| `sink-csv` | no | CSV — write JSON as CSV rows |
+| `sink-jsonl` | no | JSON Lines — file output |
+| `sink-http` | no | HTTP — POST records to any endpoint |
+| `sink-stdout` | no | Stdout/stderr — JSON Lines, pretty JSON, or TSV |
+
+### Iceberg catalog add-ons
+
+| Feature | Description |
+|---------|-------------|
+| `sink-iceberg-glue` | Enables the AWS Glue catalog on the Iceberg sink |
+| `sink-iceberg-sql` | Enables the SQL catalog on the Iceberg sink |
+| `sink-iceberg-hms` | Enables the Hive Metastore catalog on the Iceberg sink |
+
+### State-store backends
+
+The `memory` and `file` state stores are always available via `faucet-core`. These add durable backends for replication bookmarks / exactly-once tokens:
+
+| Feature | Description |
+|---------|-------------|
+| `state-redis` | Redis-backed `StateStore` |
+| `state-postgres` | PostgreSQL-backed `StateStore` |
+
+### Capabilities
+
+| Feature | Description |
+|---------|-------------|
+| `auth` | Shared single-flight auth providers (`faucet-auth`) — OAuth2 client-credentials / refresh, token-endpoint — reusable across connectors |
+| `quality` | Data-quality checks (the `quality:` config block) — per-record and per-batch |
+| `quality-jsonschema` | Adds the `json_schema` record check (implies `quality`) |
+| `lineage` | OpenLineage emission (the `lineage:` block) — HTTP + file transports |
+| `lineage-kafka` | Adds the Kafka lineage transport (implies `lineage`) |
+| `transform-sql` | SQL-as-transform via embedded DuckDB — each page is a `batch` relation |
+| `compression` | gzip/zstd on every opted-in file-shaped connector (see below) |
+| `kafka-schema-registry` | Confluent Schema Registry support (Avro / Protobuf / JSON Schema) for the Kafka pair |
+
+> `compression` uses optional-dependency forwarding (`faucet-source-csv?/compression`, …): it turns on gzip/zstd **only** for the file-shaped connectors you have already enabled (`source-csv`, `source-s3`, `source-gcs`, `sink-jsonl`, `sink-csv`, `sink-s3`, `sink-gcs`). It does not pull connectors you haven't requested.
+
+### Transforms
+
+Transforms reshape records mid-pipeline. Enabling `source-rest` (the default) already turns on `transform-flatten`, `transform-rename-keys`, and `transform-keys-case`.
+
+| Feature | Description |
+|---------|-------------|
+| `transform-flatten` | Flatten nested objects |
+| `transform-rename-keys` | Regex key renaming |
+| `transform-keys-case` | Re-case every key (snake / camel / pascal / kebab / screaming_snake) |
+| `transform-select` | Keep only listed top-level fields |
+| `transform-drop` | Remove listed top-level fields |
+| `transform-set` | Add/overwrite top-level fields with constants |
+| `transform-rename-field` | Exact-name field rename (single or batch) |
+| `transform-cast` | Per-field type coercion with configurable `on_error` |
+| `transform-redact` | Replace listed field values with a mask |
+| `transform-value-case` | Lowercase / uppercase / trim string field values |
+| `transform-spell-symbols` | Spell out symbols in keys (`%` → `percent`, `#` → `number`, …) |
+| `transform-filter` | Drop records that don't match a predicate (1→0\|1) |
+| `transform-explode` | Fan one record into N from an array field (1→0..N) |
+| `transform-cdc-unwrap` | Normalize a CDC envelope into a flat row + `__op` marker (the standard pairing for upsert sinks) |
+| `transforms` | All built-in transforms (includes `transform-cdc-unwrap`) |
+
+### Aggregate features
+
+| Feature | Pulls in |
+|---------|----------|
+| `source` | Every source connector |
+| `sink` | Every sink connector |
+| `state` | Every state-store backend (`state-redis`, `state-postgres`) |
+| `auth` | Shared auth providers |
+| `full` | Everything — all sources, sinks, state backends, `auth`, `kafka-schema-registry`, `compression`, `quality`, `quality-jsonschema`, `lineage`, `lineage-kafka`, `transform-sql`, `transform-cdc-unwrap` |
+
+## Pick your connectors
+
+Common combinations — enable only what your pipeline touches:
+
+```bash
+# REST API → PostgreSQL ELT
+cargo add faucet-stream --features source-rest,sink-postgres
+
+# Data-lake landing: REST → S3 with gzip
+cargo add faucet-stream --features source-rest,sink-s3,compression
+
+# S3 → BigQuery warehouse load
+cargo add faucet-stream --features source-s3,sink-bigquery
+
+# Postgres CDC → Postgres mirror with exactly-once + durable state
+cargo add faucet-stream --features source-postgres-cdc,sink-postgres,state-postgres,transform-cdc-unwrap
+
+# Kafka with Schema Registry → Parquet on S3
+cargo add faucet-stream --features source-kafka,sink-parquet,kafka-schema-registry
+
+# Everything, for prototyping
+cargo add faucet-stream --features full
+```
+
+## Library usage
+
+The whole `faucet-core` API is re-exported unconditionally; connector types appear when their feature is enabled.
 
 ```rust
-use faucet_stream::{
-    RestStream, RestStreamConfig, Auth, PaginationStyle,
-    Pipeline,
-};
+use faucet_stream::{Pipeline, run_stream};
+use faucet_source_rest::{RestStream, RestStreamConfig, Auth, PaginationStyle};
+use faucet_sink_jsonl::{JsonlSink, JsonlSinkConfig};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Configure a source
+    // Build a source: paginated REST API with bearer auth
     let source = RestStream::new(
         RestStreamConfig::new("https://api.example.com", "/v1/users")
-            .auth(Auth::Bearer {
-                token: "my-token".into(),
-            })
+            .auth(Auth::Bearer { token: "my-token".into() })
             .records_path("$.data[*]")
             .pagination(PaginationStyle::Cursor {
                 next_token_path: "$.meta.next_cursor".into(),
@@ -111,101 +199,42 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }),
     )?;
 
-    let records = source.fetch_all().await?;
-    println!("Fetched {} records", records.len());
+    // Build a sink
+    let sink = JsonlSink::new(JsonlSinkConfig::new("users.jsonl"))?;
+
+    // Batch mode: fetch all, then write
+    let result = Pipeline::new(&source, &sink).run().await?;
+    println!("Wrote {} records", result.records_written);
+
+    // Streaming mode: write each page as it arrives (memory bounded at O(batch_size))
+    let _ = run_stream(source.stream_pages(), &sink).await?;
     Ok(())
 }
 ```
 
-### Pipeline: Source to Sink
+### What's re-exported
 
-```rust
-use faucet_stream::{Pipeline, run_stream};
+Always available (from `faucet-core`):
 
-// Batch mode: fetch all, then write
-let result = Pipeline::new(&source, &sink).run().await?;
-println!("Wrote {} records", result.records_written);
+- `Source`, `Sink` traits; `Pipeline`, `PipelineResult`, `run_stream`
+- `FaucetError`; `RecordTransform`, `ReplicationMethod`
+- `config::load_json`, `config::load_env`, `config::load_env_file`
+- the connector-author re-exports — `async_trait`, `serde_json`, `Value`, `json!`, `JsonSchema`, `schema_for!`
 
-// Streaming mode: write page-by-page (bounded memory)
-let result = run_stream(source.stream_pages(), &sink).await?;
-```
+Plus the config + connector types from each enabled feature (e.g. `RestStream` / `RestStreamConfig` / `Auth` / `PaginationStyle` under `source-rest`). For connector-specific config fields, auth variants, and capability details, see each connector crate's own README and the docs site.
 
 ## Examples
 
-Runnable examples live in [`examples/`](examples/). Each one declares its required Cargo features so `cargo check --all-targets` skips examples whose connectors aren't enabled.
-
-### Pipeline shape (these run end-to-end against `jsonplaceholder.typicode.com`)
-
-| Example | What it shows |
-|---------|---------------|
-| `rest_to_jsonl` | Minimum-viable pipeline: REST source → JSONL sink |
-| `rest_streaming` | `run_stream` mode — write each page as it arrives, bounded memory |
-
-### Connector matrix (compile-only without external infra)
-
-The remaining examples illustrate popular source→sink pairings. They compile under their feature gates, but actually running them needs the listed infrastructure (DB, S3 bucket, GCP credentials, etc.).
-
-| Example | Source → Sink |
-|---------|---------------|
-| `rest_to_postgres` | REST → PostgreSQL — canonical API → operational-DB ELT |
-| `rest_to_bigquery` | REST → BigQuery |
-| `rest_to_s3` | REST → S3 — data-lake landing zone |
-| `graphql_to_postgres` | GraphQL → PostgreSQL |
-| `graphql_to_bigquery` | GraphQL → BigQuery |
-| `xml_to_s3` | XML/SOAP → S3 |
-| `xml_to_mongodb` | XML/SOAP → MongoDB |
-| `grpc_to_elasticsearch` | gRPC → Elasticsearch |
-| `grpc_to_http` | gRPC → HTTP — also demonstrates the full HTTP sink builder (auth, headers, method, batch mode) |
-| `postgres_to_bigquery` | PostgreSQL → BigQuery |
-| `postgres_to_snowflake` | PostgreSQL → Snowflake (key-pair auth) |
-| `postgres_to_s3` | PostgreSQL → S3 archive |
-| `postgres_to_elasticsearch` | PostgreSQL → Elasticsearch search index |
-| `mysql_to_postgres` | MySQL → PostgreSQL |
-| `mysql_to_snowflake` | MySQL → Snowflake (OAuth) |
-| `mysql_to_bigquery` | MySQL → BigQuery |
-| `sqlite_to_csv` | SQLite → CSV |
-| `sqlite_to_jsonl` | SQLite → JSONL |
-| `s3_to_postgres` | S3 → PostgreSQL |
-| `s3_to_mongodb` | S3 → MongoDB |
-| `s3_to_bigquery` | S3 → BigQuery — classic data-lake → DW |
-| `s3_to_snowflake` | S3 → Snowflake — data-lake → DW (alt) |
-| `mongodb_to_elasticsearch` | MongoDB → Elasticsearch |
-| `mongodb_to_redis` | MongoDB → Redis stream |
-| `mongodb_to_postgres` | MongoDB → PostgreSQL — document → relational mirror |
-| `redis_to_mysql` | Redis stream → MySQL |
-| `redis_to_sqlite` | Redis list → SQLite |
-| `webhook_to_http` | Webhook → HTTP forwarder |
-| `webhook_to_csv` | Webhook → CSV |
-| `webhook_to_postgres` | Webhook → PostgreSQL — durable webhook capture |
-| `csv_to_mysql` | CSV → MySQL |
-| `csv_to_sqlite` | CSV → SQLite |
-| `csv_to_bigquery` | CSV → BigQuery |
-| `elasticsearch_to_s3` | Elasticsearch → S3 backup |
-| `elasticsearch_to_redis` | Elasticsearch → Redis cache |
-
-Run any example with the feature flags it documents at the top of the file, e.g.:
+Runnable examples live in [`examples/`](examples/); each declares its required features at the top of the file. The `rest_to_jsonl` and `rest_streaming` examples run end-to-end against a public test API; the rest are compile-only source→sink pairings that need real infrastructure to run.
 
 ```bash
-cargo run -p faucet-stream --example postgres_to_bigquery \
-    --features "source-postgres sink-bigquery"
+cargo run -p faucet-stream --example rest_to_jsonl --features "source-rest sink-jsonl"
+cargo run -p faucet-stream --example postgres_to_bigquery --features "source-postgres sink-bigquery"
 ```
 
-## What's Re-exported
+## Using individual crates
 
-This crate re-exports everything from `faucet-core` unconditionally:
-
-- `Source`, `Sink` traits
-- `Pipeline`, `PipelineResult`, `run_stream`
-- `FaucetError`
-- `RecordTransform`, `ReplicationMethod`
-- `config::load_json`, `config::load_env`, `config::load_env_file`
-- `async_trait`, `serde_json`, `Value`, `json!`, `JsonSchema`, `schema_for!`
-
-Plus all types from enabled connector features (e.g. `RestStream`, `RestStreamConfig`, `Auth`, `PaginationStyle` when `source-rest` is enabled).
-
-## Using Individual Crates
-
-You can also depend on connector crates directly instead of using the umbrella:
+You can depend on the connector crates directly instead of the umbrella for the tightest dependency closure or finer compile-time control:
 
 ```bash
 cargo add faucet-core
@@ -213,7 +242,28 @@ cargo add faucet-source-rest
 cargo add faucet-sink-postgres
 ```
 
-This gives finer control over dependencies and compile times.
+If you are **building your own connector**, depend only on `faucet-core` — it is the single required dependency and re-exports everything a `faucet-source-*` / `faucet-sink-*` crate needs.
+
+## Troubleshooting / FAQ
+
+| Symptom | Cause & fix |
+|---------|-------------|
+| `cannot find type RestStream` (or any connector type) | The connector's feature isn't enabled. Add it, e.g. `cargo add faucet-stream --features source-rest`. The default build only enables `source-rest`. |
+| `transform-select`/`transform-cast`/etc. has no effect | The built-in transforms are forwarded to the REST source. Enable the specific `transform-*` feature (or `transforms` for all). The default build includes only `transform-flatten`, `transform-rename-keys`, `transform-keys-case`. |
+| Compression flag enabled but files aren't compressed | `compression` only activates for file-shaped connectors you've **also** enabled (`source-csv`, `source-s3`, `source-gcs`, `sink-jsonl`, `sink-csv`, `sink-s3`, `sink-gcs`). Confirm both features are on, and the path suffix is `.gz`/`.zst` (under `Auto`). |
+| Kafka Avro/Protobuf decode fails | Schema-Registry formats need `kafka-schema-registry` in addition to `source-kafka`/`sink-kafka`. |
+| `auth: { ref }` errors / shared OAuth provider not found | The shared-auth catalog needs the `auth` feature (`faucet-auth`). Library callers build providers directly and pass them via `Source::with_auth_provider`. |
+| Iceberg catalog (Glue/SQL/HMS) not recognized | Enable the matching add-on: `sink-iceberg-glue`, `sink-iceberg-sql`, or `sink-iceberg-hms`. The bare `sink-iceberg` only ships the REST catalog. |
+| Exactly-once or CDC bookmarks lost across restarts | Configure a durable state backend (`state-postgres` / `state-redis`); the in-memory store does not survive a restart. Exactly-once also requires a CDC source + an idempotent sink (sqlite/postgres/mysql/mssql/iceberg/bigquery). |
+| Long compile times / huge binary | Don't use `full`. Enable only the connectors your pipeline uses. |
+
+## See also
+
+- [Getting started](https://pawansikawat.github.io/faucet-stream/getting-started/concepts.html) and the [library tutorial](https://pawansikawat.github.io/faucet-stream/tutorials/library.html)
+- [Connector reference & capability matrix](https://pawansikawat.github.io/faucet-stream/reference/connectors.html)
+- [Choosing connectors](https://pawansikawat.github.io/faucet-stream/reference/choosing.html)
+- [`faucet-core`](https://crates.io/crates/faucet-core) — the traits + pipeline engine (the only dependency connector authors need)
+- [`faucet-cli`](https://crates.io/crates/faucet-cli) — drive these connectors from YAML/JSON with no Rust code
 
 ## License
 

--- a/faucet-stream/README.md
+++ b/faucet-stream/README.md
@@ -2,6 +2,8 @@
 
 [![Crates.io](https://img.shields.io/crates/v/faucet-stream.svg)](https://crates.io/crates/faucet-stream)
 [![Docs.rs](https://docs.rs/faucet-stream/badge.svg)](https://docs.rs/faucet-stream)
+[![MSRV](https://img.shields.io/crates/msrv/faucet-stream.svg)](https://github.com/PawanSikawat/faucet-stream/blob/main/rust-toolchain.toml)
+[![License](https://img.shields.io/crates/l/faucet-stream.svg)](https://github.com/PawanSikawat/faucet-stream#license)
 
 Umbrella crate for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem. Provides feature-gated access to all source and sink connectors through a single dependency.
 


### PR DESCRIPTION
## What

Documentation pass across the whole workspace, in three parts.

### 1. `fix:` correct the `faucet-stream` crates.io category
The umbrella crate overrode the workspace categories with `web-programming::http-client` — what showed as the **"HTTP Client"** category on [crates.io](https://crates.io/crates/faucet-stream) for an ETL toolkit. Replaced with accurate, valid slugs: **`database`, `asynchronous`, `encoding`** (confirmed against the crates.io categories API). Takes effect on the next publish of `faucet-stream`.

### 2. `docs:` MSRV + License badges on every per-crate README
Added the dynamic shields.io **MSRV** and **License** badges (each referencing its own crate) to the per-crate READMEs that previously only had Crates.io + Docs.rs.

### 3. `docs:` extensive, standardized rewrites for **all 55 publishable crates**
Every source (23), sink (18), `faucet-core`, `faucet-auth`, `faucet-lineage`, `faucet-transform-sql`, the 6 `faucet-common-*` crates, the 2 state backends, the `faucet-stream` umbrella, and `faucet-cli` were rewritten onto one canonical template:

- Feature highlights · Installation (library + CLI feature) · Quick start · **full config-reference tables** (every field · type · default · description) · Authentication · Examples (grounded in real `cli/examples/`) · Streaming & batching · capability sections (Resume/state, Exactly-once, Write modes/upsert, DLQ, Compression — **only where the crate actually supports them**) · Config loading & schema · Library usage · How it works · Lineage URI · Feature flags · **Troubleshooting/FAQ** · See also · standardized dual MIT/Apache license.

Internal/shared crates (`faucet-common-*`, state backends) get a consistent lighter variant. `faucet-cli` (already ~960 lines) got a light touch only.

Every fact is grounded in the crate's own `config.rs`/`lib.rs`/`sink.rs` — no invented fields. Along the way the rewrites corrected several **stale docs bugs**: wrong auth field names (`credentials:` → `auth:` on GCS), a flat Kafka auth shape that should be `{type, config}`, stray `kind:` connector keys that should be `type:`, wrong Kafka defaults (`linger`/`queue_full_backoff`), and a `connection_url:` → `url:` error in the docs-book state page.

## Notes
- READMEs go **live on crates.io only on the next publish** of each crate; on GitHub they're already correct.
- Badges were kept **dynamic** per request; `version`/`downloads`/`MSRV`/`License` will briefly show "invalid" during a shields.io ↔ crates.io outage and self-heal.
