### PR TITLE
feat: unified resilience policy (retry / circuit-breaker / poison-pill)

### DIFF
--- a/cli/examples/rest_to_jsonl_resilient.yaml
+++ b/cli/examples/rest_to_jsonl_resilient.yaml
@@ -9,17 +9,17 @@ version: 1
 name: resilient_rest_to_jsonl
 pipeline:
   source:
-    kind: rest
+    type: rest
     config:
       endpoint: "https://api.example.com/v1/items"
   sink:
-    kind: jsonl
+    type: jsonl
     config:
       path: "./out/items.jsonl"
   # Poison-pill `action: dlq` (below) requires a DLQ to be configured.
   dlq:
     sink:
-      kind: jsonl
+      type: jsonl
       config:
         path: "./out/items.dlq.jsonl"
 resilience:

--- a/cli/examples/rest_to_jsonl_resilient.yaml
+++ b/cli/examples/rest_to_jsonl_resilient.yaml
@@ -1,0 +1,39 @@
+# Resilient REST -> JSONL pipeline.
+#
+# Demonstrates the top-level `resilience:` policy: transient-failure retry with
+# exponential backoff, a circuit breaker that fails the run fast when the sink is
+# wedged, and poison-pill row handling that routes persistently-failing rows to
+# the DLQ instead of looping. The block is fully opt-in: remove it and the
+# pipeline behaves exactly as before (no sink-write retry).
+version: 1
+name: resilient_rest_to_jsonl
+pipeline:
+  source:
+    kind: rest
+    config:
+      endpoint: "https://api.example.com/v1/items"
+  sink:
+    kind: jsonl
+    config:
+      path: "./out/items.jsonl"
+  # Poison-pill `action: dlq` (below) requires a DLQ to be configured.
+  dlq:
+    sink:
+      kind: jsonl
+      config:
+        path: "./out/items.dlq.jsonl"
+resilience:
+  retry:
+    max_attempts: 5            # total tries including the first (1 = no retry)
+    backoff: exponential       # none | fixed | exponential
+    base_ms: 200
+    max_ms: 30000              # per-sleep cap, before jitter
+    jitter: true
+  # Which transient error classes are retried. Default = all four.
+  retry_on: [http_5xx, rate_limited, connection, timeout]
+  circuit_breaker:
+    consecutive_failures: 5    # consecutive fully-failed pages before the circuit opens
+    cooldown_secs: 60          # advisory: `faucet schedule` waits this long before the next tick
+  poison:
+    max_row_attempts: 3        # per-row write attempts before applying `action`
+    action: dlq                # dlq | drop | fail

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -300,6 +300,8 @@ pub enum SchemaTarget {
     Replication,
     /// JSON Schema for the top-level `execution:` block.
     Execution,
+    /// JSON Schema for the top-level `resilience:` block.
+    Resilience,
     /// JSON Schema for the `quality:` block.
     #[cfg(feature = "quality")]
     Quality,

--- a/cli/src/commands/doctor.rs
+++ b/cli/src/commands/doctor.rs
@@ -137,7 +137,7 @@ pub async fn probe_invocation(
 ) -> InvocationOut {
     let mut probes = Vec::new();
 
-    match build_source(&source.kind, source.config.clone(), auth).await {
+    match build_source(&source.kind, source.config.clone(), auth, None).await {
         Ok(src) => {
             probes.extend(collect_probes("source", src.connector_name(), ctx, src.check(ctx)).await)
         }

--- a/cli/src/commands/preview.rs
+++ b/cli/src/commands/preview.rs
@@ -44,6 +44,7 @@ pub async fn run(args: PreviewArgs) -> CliResult<()> {
         &first_root.source.kind,
         first_root.source.config.clone(),
         &auth,
+        None,
     )
     .await?;
     let stages = compile_transforms(&first_root.transforms)?;

--- a/cli/src/commands/replicate.rs
+++ b/cli/src/commands/replicate.rs
@@ -40,6 +40,10 @@ pub async fn run(args: ReplicateArgs) -> CliResult<()> {
             .to_owned()
     });
     let auth = crate::auth_catalog::build_auth_catalog(cfg.auth.as_ref())?;
+    let resilience = match &cfg.resilience {
+        Some(spec) => Some(spec.to_policy()?),
+        None => None,
+    };
 
     run_replication(
         &cfg,
@@ -49,6 +53,7 @@ pub async fn run(args: ReplicateArgs) -> CliResult<()> {
             execution: cfg.execution.clone(),
             auth,
             clock: chrono::Utc::now().fixed_offset(),
+            resilience,
         },
     )
     .await?;

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -78,6 +78,10 @@ pub async fn run(args: RunArgs) -> CliResult<()> {
     #[cfg(feature = "lineage")]
     let lineage = crate::lineage_glue::build_emitter(cfg.lineage.as_ref())
         .map_err(|e| CliError::Config(format!("lineage: {e}")))?;
+    let resilience = match &cfg.resilience {
+        Some(spec) => Some(spec.to_policy()?),
+        None => None,
+    };
     let nodes = expand(&cfg)?;
     let summary = run_expanded(
         nodes,
@@ -92,6 +96,7 @@ pub async fn run(args: RunArgs) -> CliResult<()> {
             // `faucet run` has no external cancel signal; the executor still
             // cooperatively cancels in-flight rows on `on_error: stop`.
             cancel: None,
+            resilience,
             #[cfg(feature = "lineage")]
             lineage,
             #[cfg(feature = "lineage")]

--- a/cli/src/commands/schedule.rs
+++ b/cli/src/commands/schedule.rs
@@ -29,6 +29,8 @@ struct RunFinished {
     outcome: RunOutcome,
     duration: Duration,
     detail: Option<String>,
+    /// Circuit-breaker re-entry cooldown when the run tripped the breaker.
+    cooldown: Option<Duration>,
 }
 
 /// Cross-platform shutdown-signal source, registered once.
@@ -218,8 +220,43 @@ fn spawn_run(
     )
 }
 
-/// Classify a joined run task into a scheduler outcome + a log detail.
-fn classify(joined: Result<CliResult<RunSummary>, tokio::task::JoinError>) -> RunFinished {
+/// Display prefix of [`faucet_core::FaucetError::CircuitOpen`]. The per-invocation
+/// typed error is flattened to a string by the executor, so the scheduler matches
+/// on this stable prefix to detect a circuit-open run; the authoritative cooldown
+/// duration is recovered from the run's configured resilience policy (not parsed
+/// out of the message).
+const CIRCUIT_OPEN_PREFIX: &str = "Circuit open after";
+
+/// Classify a joined run task into a scheduler outcome + a log detail. When the
+/// run tripped the circuit breaker, `cooldown` is set to the policy's re-entry
+/// cooldown so the loop can delay the next tick.
+fn classify(
+    joined: Result<CliResult<RunSummary>, tokio::task::JoinError>,
+    breaker_cooldown: Option<Duration>,
+) -> RunFinished {
+    // Did any failure indicate a tripped circuit breaker?
+    let circuit_open = match &joined {
+        Ok(Ok(summary)) => summary
+            .invocations
+            .iter()
+            .filter_map(|i| i.error.as_deref())
+            .any(|e| e.starts_with(CIRCUIT_OPEN_PREFIX)),
+        Ok(Err(e)) => e.to_string().contains(CIRCUIT_OPEN_PREFIX),
+        Err(_) => false,
+    };
+    // Recover the typed cooldown through the pure decision helper, using the
+    // configured cooldown as the authoritative duration.
+    let cooldown = if circuit_open {
+        let reconstructed: Result<(), faucet_core::FaucetError> =
+            Err(faucet_core::FaucetError::CircuitOpen {
+                failures: 0,
+                cooldown: breaker_cooldown.unwrap_or(Duration::ZERO),
+            });
+        crate::schedule::state::cooldown_delay(&reconstructed).filter(|d| !d.is_zero())
+    } else {
+        None
+    };
+
     let (outcome, detail) = match joined {
         Ok(Ok(summary)) if summary.had_failures() => (
             RunOutcome::Failure,
@@ -236,6 +273,7 @@ fn classify(joined: Result<CliResult<RunSummary>, tokio::task::JoinError>) -> Ru
         outcome,
         duration: Duration::ZERO,
         detail,
+        cooldown,
     }
 }
 
@@ -298,6 +336,12 @@ async fn run_loop(
     #[cfg(feature = "lineage")] lineage_cfg: Option<faucet_lineage::LineageConfig>,
 ) -> CliResult<()> {
     let mut state = SchedulerState::new(&compiled);
+    // The circuit-breaker re-entry cooldown, if a breaker is configured. Used to
+    // delay the next tick after a run trips the breaker.
+    let breaker_cooldown = resilience
+        .as_ref()
+        .and_then(|r| r.circuit_breaker)
+        .map(|cb| cb.cooldown);
     let mut shutdown = Shutdown::new()?;
     let mut running: Option<RunningRun> = None;
     let mut pending_scheduled_for: Option<DateTime<Utc>> = None;
@@ -424,13 +468,35 @@ async fn run_loop(
                 return Ok(());
             }
 
-            finished = wait_for_run(&mut running) => {
+            finished = wait_for_run(&mut running, breaker_cooldown) => {
                 let mut finished = finished;
                 if let Some(rr) = running.take() {
                     finished.duration = rr.started.elapsed();
                 }
                 m::in_flight(&pipeline_name, 0);
                 let done_at = Utc::now();
+
+                // Circuit-breaker re-entry cooldown: if the run tripped the
+                // breaker, push the next tick out so AT LEAST `cooldown` elapses
+                // before re-entry. This composes with the cron schedule — it
+                // only delays `next_due` when the cooldown would land later than
+                // the next scheduled occurrence. The actual wait happens in the
+                // existing cancellation-aware `select!` below, so SIGTERM still
+                // interrupts it.
+                if let Some(d) = finished.cooldown
+                    && let Ok(delta) = chrono::Duration::from_std(d)
+                {
+                    let resume = done_at + delta;
+                    if resume > next_due {
+                        next_due = resume;
+                    }
+                    tracing::warn!(
+                        pipeline = %pipeline_name,
+                        cooldown_secs = d.as_secs(),
+                        next_due = %next_due,
+                        "circuit breaker opened; delaying re-entry by cooldown"
+                    );
+                }
                 m::last_run_completed(&pipeline_name, done_at);
                 m::last_run_duration(&pipeline_name, finished.duration);
                 m::run_outcome(&pipeline_name, match finished.outcome {
@@ -491,9 +557,12 @@ async fn run_loop(
 
 /// Await the in-flight run (or never resolve when idle). Returns the classified
 /// outcome; the caller fills in `duration` from the `RunningRun`.
-async fn wait_for_run(running: &mut Option<RunningRun>) -> RunFinished {
+async fn wait_for_run(
+    running: &mut Option<RunningRun>,
+    breaker_cooldown: Option<Duration>,
+) -> RunFinished {
     match running {
-        Some(rr) => classify((&mut rr.handle).await),
+        Some(rr) => classify((&mut rr.handle).await, breaker_cooldown),
         None => std::future::pending().await,
     }
 }
@@ -548,24 +617,26 @@ mod tests {
     #[test]
     fn classify_success_when_no_failures() {
         let joined = Ok(Ok(summary(0, 2)));
-        let f = classify(joined);
+        let f = classify(joined, None);
         assert_eq!(f.outcome, RunOutcome::Success);
         assert!(f.detail.is_none());
+        assert!(f.cooldown.is_none());
     }
 
     #[test]
     fn classify_failure_when_some_invocations_failed() {
         let joined = Ok(Ok(summary(2, 5)));
-        let f = classify(joined);
+        let f = classify(joined, None);
         assert_eq!(f.outcome, RunOutcome::Failure);
         assert_eq!(f.detail.as_deref(), Some("2 invocation(s) failed"));
+        assert!(f.cooldown.is_none());
     }
 
     #[test]
     fn classify_failure_when_run_errored() {
         let joined: Result<CliResult<RunSummary>, tokio::task::JoinError> =
             Ok(Err(CliError::Internal("disk full".into())));
-        let f = classify(joined);
+        let f = classify(joined, None);
         assert_eq!(f.outcome, RunOutcome::Failure);
         assert!(f.detail.as_deref().unwrap().contains("disk full"));
     }
@@ -575,13 +646,65 @@ mod tests {
         // Spawn a task that panics, then join it to obtain a real JoinError.
         let handle = tokio::spawn(async { panic!("kaboom") });
         let joined: Result<CliResult<RunSummary>, tokio::task::JoinError> = handle.await.map(Ok);
-        let f = classify(joined);
+        let f = classify(joined, None);
         assert_eq!(f.outcome, RunOutcome::Failure);
         assert!(
             f.detail.as_deref().unwrap().contains("panicked"),
             "{:?}",
             f.detail
         );
+    }
+
+    #[test]
+    fn classify_recovers_cooldown_from_circuit_open_invocation() {
+        // An invocation whose error is the flattened CircuitOpen Display string
+        // is detected; the cooldown is recovered from the configured policy.
+        let circuit_open_msg = faucet_core::FaucetError::CircuitOpen {
+            failures: 3,
+            cooldown: Duration::from_secs(60),
+        }
+        .to_string();
+        let invocations = vec![crate::executor::InvocationOutcome {
+            row_id: "r0".into(),
+            parent_record_key: None,
+            records_written: 0,
+            error: Some(circuit_open_msg),
+        }];
+        let joined = Ok(Ok(RunSummary { invocations }));
+        let f = classify(joined, Some(Duration::from_secs(45)));
+        assert_eq!(f.outcome, RunOutcome::Failure);
+        assert_eq!(f.cooldown, Some(Duration::from_secs(45)));
+    }
+
+    #[test]
+    fn classify_circuit_open_without_configured_cooldown_yields_none() {
+        // Defensive: a circuit-open run with no configured cooldown (zero)
+        // produces no delay rather than a spurious zero-length sleep.
+        let circuit_open_msg = faucet_core::FaucetError::CircuitOpen {
+            failures: 1,
+            cooldown: Duration::from_secs(10),
+        }
+        .to_string();
+        let invocations = vec![crate::executor::InvocationOutcome {
+            row_id: "r0".into(),
+            parent_record_key: None,
+            records_written: 0,
+            error: Some(circuit_open_msg),
+        }];
+        let joined = Ok(Ok(RunSummary { invocations }));
+        let f = classify(joined, None);
+        assert_eq!(f.outcome, RunOutcome::Failure);
+        assert!(f.cooldown.is_none());
+    }
+
+    #[test]
+    fn classify_no_cooldown_for_ordinary_failure() {
+        // A plain failing invocation must not trip the cooldown path even when a
+        // breaker cooldown is configured.
+        let joined = Ok(Ok(summary(1, 2)));
+        let f = classify(joined, Some(Duration::from_secs(30)));
+        assert_eq!(f.outcome, RunOutcome::Failure);
+        assert!(f.cooldown.is_none());
     }
 
     #[test]
@@ -601,7 +724,7 @@ mod tests {
             handle,
             started: Instant::now(),
         });
-        let finished = wait_for_run(&mut running).await;
+        let finished = wait_for_run(&mut running, None).await;
         assert_eq!(finished.outcome, RunOutcome::Success);
     }
 

--- a/cli/src/commands/schedule.rs
+++ b/cli/src/commands/schedule.rs
@@ -114,6 +114,10 @@ pub async fn run(args: ScheduleArgs) -> CliResult<()> {
     let lineage_cfg = cfg.lineage.clone();
     let nodes = expand(&cfg)?; // validate once; cloned per tick
     let execution = cfg.execution.clone();
+    let resilience = match &cfg.resilience {
+        Some(spec) => Some(spec.to_policy()?),
+        None => None,
+    };
 
     if args.once {
         return run_once(
@@ -122,6 +126,7 @@ pub async fn run(args: ScheduleArgs) -> CliResult<()> {
             &execution,
             &compiled,
             &pipeline_name,
+            &resilience,
             #[cfg(feature = "lineage")]
             &lineage,
             #[cfg(feature = "lineage")]
@@ -138,6 +143,7 @@ pub async fn run(args: ScheduleArgs) -> CliResult<()> {
         pipeline_name,
         cron,
         timezone,
+        resilience,
         #[cfg(feature = "lineage")]
         lineage,
         #[cfg(feature = "lineage")]
@@ -148,11 +154,13 @@ pub async fn run(args: ScheduleArgs) -> CliResult<()> {
 
 /// Build a fresh `ExecuteOptions` for one tick (connectors are rebuilt per run;
 /// the auth catalog is shared so cached tokens survive across ticks).
+#[allow(clippy::too_many_arguments)]
 fn make_opts(
     pipeline_name: &str,
     execution: &Option<crate::config::ExecutionSpec>,
     auth: &AuthCatalog,
     clock: chrono::DateTime<chrono::FixedOffset>,
+    resilience: &Option<faucet_core::ResiliencePolicy>,
     #[cfg(feature = "lineage")] lineage: &Option<std::sync::Arc<faucet_lineage::LineageEmitter>>,
     #[cfg(feature = "lineage")] lineage_cfg: &Option<faucet_lineage::LineageConfig>,
 ) -> ExecuteOptions {
@@ -165,6 +173,7 @@ fn make_opts(
         auth: auth.clone(),
         clock,
         cancel: None,
+        resilience: resilience.clone(),
         #[cfg(feature = "lineage")]
         lineage: lineage.clone(),
         #[cfg(feature = "lineage")]
@@ -238,6 +247,7 @@ async fn run_once(
     execution: &Option<crate::config::ExecutionSpec>,
     compiled: &CompiledSchedule,
     pipeline_name: &str,
+    resilience: &Option<faucet_core::ResiliencePolicy>,
     #[cfg(feature = "lineage")] lineage: &Option<std::sync::Arc<faucet_lineage::LineageEmitter>>,
     #[cfg(feature = "lineage")] lineage_cfg: &Option<faucet_lineage::LineageConfig>,
 ) -> CliResult<()> {
@@ -248,6 +258,7 @@ async fn run_once(
         execution,
         auth,
         compiled.clock_at(now),
+        resilience,
         #[cfg(feature = "lineage")]
         lineage,
         #[cfg(feature = "lineage")]
@@ -282,6 +293,7 @@ async fn run_loop(
     pipeline_name: String,
     cron: String,
     timezone: String,
+    resilience: Option<faucet_core::ResiliencePolicy>,
     #[cfg(feature = "lineage")] lineage: Option<std::sync::Arc<faucet_lineage::LineageEmitter>>,
     #[cfg(feature = "lineage")] lineage_cfg: Option<faucet_lineage::LineageConfig>,
 ) -> CliResult<()> {
@@ -344,6 +356,7 @@ async fn run_loop(
                         &execution,
                         &auth,
                         compiled.clock_at(next_due),
+                        &resilience,
                         #[cfg(feature = "lineage")]
                         &lineage,
                         #[cfg(feature = "lineage")]
@@ -453,6 +466,7 @@ async fn run_loop(
                                 &execution,
                                 &auth,
                                 compiled.clock_at(sched_for),
+                                &resilience,
                                 #[cfg(feature = "lineage")]
                                 &lineage,
                                 #[cfg(feature = "lineage")]
@@ -613,6 +627,7 @@ mod tests {
             &None,
             &auth,
             Utc::now().fixed_offset(),
+            &None,
             #[cfg(feature = "lineage")]
             &None,
             #[cfg(feature = "lineage")]
@@ -644,6 +659,7 @@ mod tests {
             &None,
             &auth,
             clock,
+            &None,
             #[cfg(feature = "lineage")]
             &None,
             #[cfg(feature = "lineage")]

--- a/cli/src/commands/schema.rs
+++ b/cli/src/commands/schema.rs
@@ -24,6 +24,10 @@ pub async fn run(args: SchemaArgs) -> CliResult<()> {
             let s = faucet_core::schema_for!(crate::config::ExecutionSpec);
             serde_json::to_value(s).unwrap_or_else(|_| serde_json::json!({"type": "object"}))
         }
+        SchemaTarget::Resilience => {
+            let s = faucet_core::schema_for!(crate::config::ResilienceSpec);
+            serde_json::to_value(s).unwrap_or_else(|_| serde_json::json!({"type": "object"}))
+        }
         #[cfg(feature = "quality")]
         SchemaTarget::Quality => {
             let quality_schema = faucet_core::schema_for!(faucet_core::QualitySpec);
@@ -107,5 +111,25 @@ mod tests {
         let schema = faucet_core::schema_for!(crate::config::ExecutionSpec);
         let value = serde_json::to_value(schema).expect("execution schema serializes");
         assert!(value["properties"].get("adaptive_batch_size").is_some());
+    }
+
+    #[tokio::test]
+    async fn schema_resilience_target_ok() {
+        let r = super::run(SchemaArgs {
+            target: SchemaTarget::Resilience,
+        })
+        .await;
+        assert!(r.is_ok(), "{r:?}");
+    }
+
+    #[test]
+    fn schema_resilience_emits_json_schema() {
+        // Mirrors `faucet schema resilience`: the serialized ResilienceSpec
+        // schema must expose the retry `max_attempts` knob and the
+        // `circuit_breaker` sub-block.
+        let schema = faucet_core::schema_for!(crate::config::ResilienceSpec);
+        let out = serde_json::to_string(&schema).expect("resilience schema serializes");
+        assert!(out.contains("max_attempts"), "{out}");
+        assert!(out.contains("circuit_breaker"), "{out}");
     }
 }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -84,6 +84,12 @@ pub struct PipelineConfig {
     #[serde(default)]
     pub delivery: faucet_core::DeliveryMode,
 
+    /// Optional resilience policy (retry / backoff / circuit-breaker /
+    /// poison-pill). Top-level in v1 (not per-matrix-row). Absent = no behaviour
+    /// change. Consumed by `faucet run`/`schedule`/`replicate`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resilience: Option<ResilienceSpec>,
+
     /// Optional snapshot→CDC replication block. Consumed only by
     /// `faucet replicate`; ignored by `faucet run` (like `schedule:`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -358,6 +364,187 @@ pub struct DlqSpec {
     pub max_failures_total: Option<usize>,
     #[serde(default = "default_true")]
     pub include_original_payload: bool,
+}
+
+/// User-facing `resilience:` config. Maps to `faucet_core::ResiliencePolicy`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ResilienceSpec {
+    /// Retry/backoff applied to sink-write, flush, and state-store I/O (and
+    /// injected into rest/xml/graphql sources).
+    #[serde(default)]
+    pub retry: RetrySpec,
+    /// Which error classes are retried. Omitted = all four transient classes.
+    #[serde(default)]
+    pub retry_on: Option<Vec<faucet_core::RetryClass>>,
+    /// Optional circuit breaker.
+    #[serde(default)]
+    pub circuit_breaker: Option<CircuitBreakerSpec>,
+    /// Optional poison-pill (per-row) handling (DLQ path only).
+    #[serde(default)]
+    pub poison: Option<PoisonSpec>,
+}
+
+/// Retry/backoff tuning.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct RetrySpec {
+    /// Total attempts including the first (1 = no retry).
+    #[serde(default = "default_max_attempts")]
+    pub max_attempts: u32,
+    /// Backoff growth shape.
+    #[serde(default)]
+    pub backoff: BackoffSpec,
+    /// Base delay in milliseconds.
+    #[serde(default = "default_base_ms")]
+    pub base_ms: u64,
+    /// Per-sleep cap in milliseconds (pre-jitter).
+    #[serde(default = "default_max_ms")]
+    pub max_ms: u64,
+    /// Whether to apply `[0.5, 1.5)` jitter.
+    #[serde(default = "default_true")]
+    pub jitter: bool,
+}
+
+impl Default for RetrySpec {
+    fn default() -> Self {
+        Self {
+            max_attempts: default_max_attempts(),
+            backoff: BackoffSpec::default(),
+            base_ms: default_base_ms(),
+            max_ms: default_max_ms(),
+            jitter: true,
+        }
+    }
+}
+
+/// Backoff growth shape (config spelling of `faucet_core::BackoffKind`).
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum BackoffSpec {
+    /// No delay between attempts.
+    None,
+    /// Constant `base_ms` delay.
+    Fixed,
+    /// `base_ms * 2^attempt`, capped at `max_ms`.
+    #[default]
+    Exponential,
+}
+
+/// Circuit-breaker tuning.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct CircuitBreakerSpec {
+    /// Consecutive exhausted-retry page failures before the circuit opens.
+    pub consecutive_failures: u32,
+    /// Re-entry cooldown in seconds (honored by the orchestration layer).
+    pub cooldown_secs: u64,
+}
+
+/// Poison-pill (per-row) policy.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct PoisonSpec {
+    /// Per-row write attempts before applying `action`.
+    pub max_row_attempts: u32,
+    /// Terminal action for a persistently failing row.
+    #[serde(default)]
+    pub action: PoisonActionSpec,
+}
+
+/// Terminal action for a poison row (config spelling of
+/// `faucet_core::PoisonAction`).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum PoisonActionSpec {
+    /// Route to the DLQ (requires a `dlq:` block).
+    #[default]
+    Dlq,
+    /// Discard the row.
+    Drop,
+    /// Propagate the row error and abort the run.
+    Fail,
+}
+
+fn default_max_attempts() -> u32 {
+    5
+}
+fn default_base_ms() -> u64 {
+    200
+}
+fn default_max_ms() -> u64 {
+    30_000
+}
+
+impl ResilienceSpec {
+    /// Validate and build the core policy. Fail-fast on bad config.
+    pub fn to_policy(&self) -> Result<faucet_core::ResiliencePolicy, crate::error::CliError> {
+        use crate::error::CliError;
+        if self.retry.max_attempts < 1 {
+            return Err(CliError::Config(
+                "resilience.retry.max_attempts must be >= 1".into(),
+            ));
+        }
+        if self.retry.base_ms > self.retry.max_ms {
+            return Err(CliError::Config(
+                "resilience.retry.base_ms must be <= max_ms".into(),
+            ));
+        }
+        let retry_on = match &self.retry_on {
+            Some(v) if v.is_empty() => {
+                return Err(CliError::Config(
+                    "resilience.retry_on must not be empty".into(),
+                ));
+            }
+            Some(v) => faucet_core::RetryClassSet::from_iter(v.iter().copied()),
+            None => faucet_core::RetryClassSet::default(),
+        };
+        let backoff = match self.retry.backoff {
+            BackoffSpec::None => faucet_core::BackoffKind::None,
+            BackoffSpec::Fixed => faucet_core::BackoffKind::Fixed,
+            BackoffSpec::Exponential => faucet_core::BackoffKind::Exponential,
+        };
+        let circuit_breaker = match self.circuit_breaker {
+            Some(cb) if cb.consecutive_failures < 1 => {
+                return Err(CliError::Config(
+                    "resilience.circuit_breaker.consecutive_failures must be >= 1".into(),
+                ));
+            }
+            Some(cb) => Some(faucet_core::CircuitBreakerConfig {
+                consecutive_failures: cb.consecutive_failures,
+                cooldown: std::time::Duration::from_secs(cb.cooldown_secs),
+            }),
+            None => None,
+        };
+        let poison = match self.poison {
+            Some(p) if p.max_row_attempts < 1 => {
+                return Err(CliError::Config(
+                    "resilience.poison.max_row_attempts must be >= 1".into(),
+                ));
+            }
+            Some(p) => Some(faucet_core::PoisonPolicy {
+                max_row_attempts: p.max_row_attempts,
+                action: match p.action {
+                    PoisonActionSpec::Dlq => faucet_core::PoisonAction::Dlq,
+                    PoisonActionSpec::Drop => faucet_core::PoisonAction::Drop,
+                    PoisonActionSpec::Fail => faucet_core::PoisonAction::Fail,
+                },
+            }),
+            None => None,
+        };
+        Ok(faucet_core::ResiliencePolicy {
+            retry: faucet_core::RetryPolicy {
+                max_attempts: self.retry.max_attempts,
+                backoff,
+                base: std::time::Duration::from_millis(self.retry.base_ms),
+                max: std::time::Duration::from_millis(self.retry.max_ms),
+                jitter: self.retry.jitter,
+                retry_on,
+            },
+            circuit_breaker,
+            poison,
+        })
+    }
 }
 
 fn default_true() -> bool {
@@ -1214,5 +1401,40 @@ matrix:
             cfg3.matrix[1].delivery,
             Some(faucet_core::DeliveryMode::ExactlyOnce)
         );
+    }
+
+    #[test]
+    fn resilience_spec_parses_and_builds_policy() {
+        let yaml = r#"
+version: 1
+pipeline:
+  source: { type: rest, config: { base_url: "https://x" } }
+  sink: { type: stdout, config: {} }
+resilience:
+  retry: { max_attempts: 4, backoff: exponential, base_ms: 100, max_ms: 5000, jitter: true }
+  retry_on: [http5xx, timeout]
+  circuit_breaker: { consecutive_failures: 3, cooldown_secs: 30 }
+  poison: { max_row_attempts: 2, action: dlq }
+"#;
+        let cfg = parse_with_extension(yaml, "yaml").unwrap();
+        let spec = cfg.resilience.unwrap();
+        let policy = spec.to_policy().unwrap();
+        assert_eq!(policy.retry.max_attempts, 4);
+        assert_eq!(policy.circuit_breaker.unwrap().consecutive_failures, 3);
+        assert_eq!(policy.poison.unwrap().max_row_attempts, 2);
+    }
+
+    #[test]
+    fn resilience_rejects_zero_max_attempts() {
+        let yaml = r#"
+version: 1
+pipeline:
+  source: { type: rest, config: { base_url: "https://x" } }
+  sink: { type: stdout, config: {} }
+resilience: { retry: { max_attempts: 0 } }
+"#;
+        let cfg = parse_with_extension(yaml, "yaml").unwrap();
+        let err = cfg.resilience.unwrap().to_policy().unwrap_err();
+        assert!(err.to_string().contains("max_attempts"));
     }
 }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1412,7 +1412,7 @@ pipeline:
   sink: { type: stdout, config: {} }
 resilience:
   retry: { max_attempts: 4, backoff: exponential, base_ms: 100, max_ms: 5000, jitter: true }
-  retry_on: [http5xx, timeout]
+  retry_on: [http_5xx, timeout]
   circuit_breaker: { consecutive_failures: 3, cooldown_secs: 30 }
   poison: { max_row_attempts: 2, action: dlq }
 "#;

--- a/cli/src/env_config.rs
+++ b/cli/src/env_config.rs
@@ -322,6 +322,7 @@ pub fn build_pipeline_config(env: &HashMap<String, String>) -> CliResult<Pipelin
         execution: None,
         observability: None,
         delivery: faucet_core::DeliveryMode::default(),
+        resilience: None,
         replication: None,
         #[cfg(feature = "schedule")]
         schedule: None,

--- a/cli/src/executor.rs
+++ b/cli/src/executor.rs
@@ -71,6 +71,11 @@ pub struct ExecuteOptions {
     /// hard-dropped (#146 H16). `faucet serve` wires this to run-cancel /
     /// timeout / shutdown; `faucet run` leaves it `None`.
     pub cancel: Option<CancellationToken>,
+    /// Optional resilience policy (retry/backoff/circuit-breaker/poison),
+    /// attached to every invocation's `RunStreamOptions` and injected into
+    /// rest/xml/graphql sources. Built once from the top-level `resilience:`
+    /// block; `None` preserves today's behaviour.
+    pub resilience: Option<faucet_core::ResiliencePolicy>,
     /// Shared OpenLineage emitter, built once from the `lineage:` block. `None`
     /// disables lineage (and adds zero overhead). Gated on the `lineage` feature.
     #[cfg(feature = "lineage")]
@@ -730,7 +735,13 @@ async fn run_one_invocation(
     }
 
     // 2) Build source + sink.
-    let source = build_source(&node.source.kind, source_cfg, &opts.auth).await?;
+    let source = build_source(
+        &node.source.kind,
+        source_cfg,
+        &opts.auth,
+        opts.resilience.as_ref().map(|r| &r.retry),
+    )
+    .await?;
     let raw_sink: Box<dyn Sink> = if opts.dry_run {
         Box::new(CountingSink::new())
     } else {
@@ -877,6 +888,13 @@ async fn run_one_invocation(
         ab.validate()
             .map_err(|e| CliError::Config(format!("adaptive_batch_size: {e}")))?;
         pipeline.with_adaptive(ab)
+    } else {
+        pipeline
+    };
+    // Resilience policy (retry/backoff/circuit-breaker/poison). Top-level in v1,
+    // so the same policy is attached to every invocation.
+    let pipeline = if let Some(policy) = opts.resilience.clone() {
+        pipeline.with_resilience(policy)
     } else {
         pipeline
     };
@@ -1318,6 +1336,7 @@ mod tests {
                 auth: Default::default(),
                 clock: chrono::Utc::now().fixed_offset(),
                 cancel: None,
+                resilience: None,
                 #[cfg(feature = "lineage")]
                 lineage: None,
                 #[cfg(feature = "lineage")]
@@ -1373,6 +1392,7 @@ matrix:
                 auth: Default::default(),
                 clock: chrono::Utc::now().fixed_offset(),
                 cancel: None,
+                resilience: None,
                 #[cfg(feature = "lineage")]
                 lineage: None,
                 #[cfg(feature = "lineage")]
@@ -1428,6 +1448,7 @@ matrix:
                 auth: Default::default(),
                 clock: chrono::Utc::now().fixed_offset(),
                 cancel: None,
+                resilience: None,
                 #[cfg(feature = "lineage")]
                 lineage: None,
                 #[cfg(feature = "lineage")]
@@ -1493,6 +1514,7 @@ execution:
                 auth: Default::default(),
                 clock: chrono::Utc::now().fixed_offset(),
                 cancel: None,
+                resilience: None,
                 #[cfg(feature = "lineage")]
                 lineage: None,
                 #[cfg(feature = "lineage")]
@@ -1573,6 +1595,7 @@ pipeline:
                 auth: Default::default(),
                 clock: chrono::Utc::now().fixed_offset(),
                 cancel: None,
+                resilience: None,
                 #[cfg(feature = "lineage")]
                 lineage: None,
                 #[cfg(feature = "lineage")]
@@ -1627,6 +1650,7 @@ matrix:
                 auth: Default::default(),
                 clock: chrono::Utc::now().fixed_offset(),
                 cancel: None,
+                resilience: None,
                 #[cfg(feature = "lineage")]
                 lineage: None,
                 #[cfg(feature = "lineage")]
@@ -1690,6 +1714,7 @@ execution:
                 auth: Default::default(),
                 clock: chrono::Utc::now().fixed_offset(),
                 cancel: None,
+                resilience: None,
                 #[cfg(feature = "lineage")]
                 lineage: None,
                 #[cfg(feature = "lineage")]
@@ -1754,6 +1779,7 @@ matrix:
                 auth: Default::default(),
                 clock: chrono::Utc::now().fixed_offset(),
                 cancel: None,
+                resilience: None,
                 #[cfg(feature = "lineage")]
                 lineage: None,
                 #[cfg(feature = "lineage")]
@@ -1971,6 +1997,7 @@ matrix:
             auth: Default::default(),
             clock: chrono::Utc::now().fixed_offset(),
             cancel: None,
+            resilience: None,
             #[cfg(feature = "lineage")]
             lineage: None,
             #[cfg(feature = "lineage")]
@@ -2205,6 +2232,7 @@ matrix:
             "csv",
             json!({"path": input.to_str().unwrap()}),
             &AuthCatalog::new(),
+            None,
         )
         .await
         .unwrap();
@@ -2365,6 +2393,7 @@ matrix:
                 auth: Default::default(),
                 clock: chrono::Utc::now().fixed_offset(),
                 cancel: None,
+                resilience: None,
                 #[cfg(feature = "lineage")]
                 lineage: None,
                 #[cfg(feature = "lineage")]

--- a/cli/src/executor.rs
+++ b/cli/src/executor.rs
@@ -1290,6 +1290,7 @@ mod tests {
             execution: None,
             observability: None,
             delivery: faucet_core::DeliveryMode::default(),
+            resilience: None,
             replication: None,
             #[cfg(feature = "schedule")]
             schedule: None,

--- a/cli/src/expand.rs
+++ b/cli/src/expand.rs
@@ -451,6 +451,21 @@ pub fn expand(cfg: &PipelineConfig) -> CliResult<Vec<ExpandedNode>> {
             }
         }
 
+        // Resilience poison-pill cross-check: `poison.action: dlq` routes
+        // persistently-failing rows to the DLQ, so a DLQ must be configured.
+        // Caught here so `faucet validate` reports it before any run starts.
+        if let Some(spec) = &cfg.resilience
+            && matches!(
+                spec.poison.as_ref().map(|p| p.action),
+                Some(crate::config::PoisonActionSpec::Dlq)
+            )
+            && dlq.is_none()
+        {
+            return Err(CliError::Config(format!(
+                "row '{row_id}': resilience.poison.action=dlq requires a dlq: block"
+            )));
+        }
+
         // write_mode × sink validation (load-time): reject an unsupported mode
         // for the sink kind, and upsert/delete without a key, before any run.
         // Runs for every row; append rows pass trivially.
@@ -1748,5 +1763,53 @@ pipeline:
             msg.contains("unknown write_mode") && msg.contains("replace"),
             "{msg}"
         );
+    }
+
+    #[test]
+    fn rejects_poison_dlq_action_without_dlq() {
+        let c = cfg(r#"
+version: 1
+pipeline:
+  source: { type: rest, config: { base_url: https://x } }
+  sink:   { type: jsonl, config: { path: ./o } }
+resilience:
+  poison: { max_row_attempts: 3, action: dlq }
+"#);
+        let err = expand(&c).unwrap_err();
+        assert!(
+            matches!(&err, CliError::Config(m) if m.contains("poison.action=dlq") && m.contains("dlq:")),
+            "got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn accepts_poison_dlq_action_with_dlq() {
+        let c = cfg(r#"
+version: 1
+pipeline:
+  source: { type: rest, config: { base_url: https://x } }
+  sink:   { type: jsonl, config: { path: ./o } }
+  dlq:
+    sink: { type: jsonl, config: { path: ./dead.jsonl } }
+resilience:
+  poison: { max_row_attempts: 3, action: dlq }
+"#);
+        let nodes = expand(&c).expect("poison.action=dlq with a dlq: block should validate");
+        assert_eq!(nodes.len(), 1);
+    }
+
+    #[test]
+    fn accepts_poison_drop_action_without_dlq() {
+        // action=drop discards rows in place, so no DLQ is required.
+        let c = cfg(r#"
+version: 1
+pipeline:
+  source: { type: rest, config: { base_url: https://x } }
+  sink:   { type: jsonl, config: { path: ./o } }
+resilience:
+  poison: { max_row_attempts: 3, action: drop }
+"#);
+        let nodes = expand(&c).expect("poison.action=drop needs no dlq");
+        assert_eq!(nodes.len(), 1);
     }
 }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -66,6 +66,10 @@ pub async fn run_from_yaml_str(yaml: &str) -> CliResult<executor::RunSummary> {
     crate::secrets::resolve_secrets(&mut cfg).await?;
     let pipeline_name = cfg.name.clone().unwrap_or_else(|| "unnamed".to_string());
     let auth = auth_catalog::build_auth_catalog(cfg.auth.as_ref())?;
+    let resilience = match &cfg.resilience {
+        Some(spec) => Some(spec.to_policy()?),
+        None => None,
+    };
     let nodes = expand::expand(&cfg)?;
     executor::run_expanded(
         nodes,
@@ -78,6 +82,7 @@ pub async fn run_from_yaml_str(yaml: &str) -> CliResult<executor::RunSummary> {
             auth,
             clock: chrono::Utc::now().fixed_offset(),
             cancel: None,
+            resilience,
             #[cfg(feature = "lineage")]
             lineage: None,
             #[cfg(feature = "lineage")]

--- a/cli/src/registry.rs
+++ b/cli/src/registry.rs
@@ -18,6 +18,7 @@ pub async fn build_source(
     kind: &str,
     config: Value,
     auth: &AuthCatalog,
+    retry_policy: Option<&faucet_core::RetryPolicy>,
 ) -> CliResult<Box<dyn Source>> {
     let auth_ref = auth_catalog::auth_ref(&config);
     match kind {
@@ -27,6 +28,9 @@ pub async fn build_source(
             let mut s = faucet_source_rest::RestStream::new(cfg)?;
             if let Some(name) = &auth_ref {
                 s = s.with_auth_provider(auth_catalog::resolve(auth, name)?);
+            }
+            if let Some(rp) = retry_policy {
+                s = s.with_retry_policy(rp.clone());
             }
             Ok(Box::new(s))
         }
@@ -38,6 +42,9 @@ pub async fn build_source(
             if let Some(name) = &auth_ref {
                 s = s.with_auth_provider(auth_catalog::resolve(auth, name)?);
             }
+            if let Some(rp) = retry_policy {
+                s = s.with_retry_policy(rp.clone());
+            }
             Ok(Box::new(s))
         }
         #[cfg(feature = "source-xml")]
@@ -46,6 +53,9 @@ pub async fn build_source(
             let mut s = faucet_source_xml::XmlStream::new(cfg);
             if let Some(name) = &auth_ref {
                 s = s.with_auth_provider(auth_catalog::resolve(auth, name)?);
+            }
+            if let Some(rp) = retry_policy {
+                s = s.with_retry_policy(rp.clone());
             }
             Ok(Box::new(s))
         }
@@ -679,7 +689,7 @@ mod tests {
 
     #[tokio::test]
     async fn unknown_source_kind_errors() {
-        let err = build_source("nope", serde_json::json!({}), &AuthCatalog::new())
+        let err = build_source("nope", serde_json::json!({}), &AuthCatalog::new(), None)
             .await
             .err()
             .expect("should fail");
@@ -754,6 +764,7 @@ mod tests {
             "csv",
             serde_json::json!({ "path": "/tmp/does-not-need-to-exist.csv" }),
             &AuthCatalog::new(),
+            None,
         )
         .await
         .expect("csv source should build without I/O");
@@ -801,6 +812,7 @@ mod tests {
             "csv",
             serde_json::json!({ "path": 42 }),
             &AuthCatalog::new(),
+            None,
         )
         .await;
         match res {
@@ -939,7 +951,7 @@ mod tests {
         );
         let catalog = auth_catalog::build_auth_catalog(Some(&specs)).expect("catalog");
 
-        let src = build_source("rest", rest_config_with_auth_ref("tok"), &catalog)
+        let src = build_source("rest", rest_config_with_auth_ref("tok"), &catalog, None)
             .await
             .expect("rest source with a resolvable auth ref should build");
         assert_eq!(src.connector_name(), "rest");
@@ -966,6 +978,7 @@ mod tests {
             "rest",
             rest_config_with_auth_ref("missing"),
             &AuthCatalog::new(),
+            None,
         )
         .await;
         match res {

--- a/cli/src/replication/orchestrator.rs
+++ b/cli/src/replication/orchestrator.rs
@@ -23,6 +23,8 @@ pub struct ReplicationOptions {
     pub execution: Option<ExecutionSpec>,
     pub auth: AuthCatalog,
     pub clock: DateTime<FixedOffset>,
+    /// Optional resilience policy, applied to both the snapshot and CDC phases.
+    pub resilience: Option<faucet_core::ResiliencePolicy>,
 }
 
 /// Build the snapshot-phase node by cloning the CDC node and swapping in the
@@ -73,6 +75,7 @@ fn make_opts(opts: &ReplicationOptions, cancel: Option<CancellationToken>) -> Ex
         auth: opts.auth.clone(),
         clock: opts.clock,
         cancel,
+        resilience: opts.resilience.clone(),
         #[cfg(feature = "lineage")]
         lineage: None,
         #[cfg(feature = "lineage")]
@@ -145,6 +148,7 @@ pub async fn run_replication(
             &cdc_node.source.kind,
             cdc_node.source.config.clone(),
             &opts.auth,
+            None,
         )
         .await?;
         let position = cdc_source.capture_resume_position().await?.ok_or_else(|| {

--- a/cli/src/schedule/state.rs
+++ b/cli/src/schedule/state.rs
@@ -35,6 +35,21 @@ pub enum AfterRun {
     ExitFailure { consecutive: u64 },
 }
 
+/// Extra delay before the next tick when a run tripped the circuit breaker.
+///
+/// Pure: maps a run result to the advisory cooldown carried by
+/// [`faucet_core::FaucetError::CircuitOpen`], or `None` for any other outcome.
+/// The scheduler loop uses this to push the next tick out by at least the
+/// cooldown after a fail-fast circuit-open run.
+pub fn cooldown_delay<T>(
+    result: &Result<T, faucet_core::FaucetError>,
+) -> Option<std::time::Duration> {
+    match result {
+        Err(faucet_core::FaucetError::CircuitOpen { cooldown, .. }) => Some(*cooldown),
+        _ => None,
+    }
+}
+
 /// Mutable scheduler counters + policy.
 pub struct SchedulerState {
     overlap: OverlapPolicy,
@@ -121,6 +136,24 @@ mod tests {
         let spec: ScheduleSpec = serde_yaml::from_str(yaml).unwrap();
         let compiled = CompiledSchedule::compile(&spec).unwrap();
         SchedulerState::new(&compiled)
+    }
+
+    #[test]
+    fn circuit_open_yields_cooldown_delay() {
+        use faucet_core::FaucetError;
+        let err: Result<(), FaucetError> = Err(FaucetError::CircuitOpen {
+            failures: 3,
+            cooldown: std::time::Duration::from_secs(45),
+        });
+        assert_eq!(
+            cooldown_delay(&err),
+            Some(std::time::Duration::from_secs(45))
+        );
+        let ok: Result<(), FaucetError> = Ok(());
+        assert_eq!(cooldown_delay(&ok), None);
+        // A non-circuit error carries no cooldown.
+        let other: Result<(), FaucetError> = Err(FaucetError::Sink("down".into()));
+        assert_eq!(cooldown_delay(&other), None);
     }
 
     #[test]

--- a/cli/src/serve/runner.rs
+++ b/cli/src/serve/runner.rs
@@ -603,6 +603,29 @@ async fn execute_run(
     // page boundary on cancel / timeout / shutdown — instead of having its
     // future hard-dropped, which flushes nothing (#146 H16).
     let coop = CancellationToken::new();
+    // Resilience policy from the (merged) submitted config. A malformed
+    // `resilience:` block finalizes the run as Failed, mirroring the
+    // auth/clock failure handling above.
+    let resilience = match &cfg.resilience {
+        Some(spec) => match spec.to_policy() {
+            Ok(p) => Some(p),
+            Err(e) => {
+                finalize(
+                    &state,
+                    &run_id,
+                    started,
+                    Terminal::Failed {
+                        reason: format!("resilience: {e}"),
+                        records: 0,
+                        invs: Vec::new(),
+                    },
+                )
+                .await;
+                return;
+            }
+        },
+        None => None,
+    };
     // Build the per-run OpenLineage emitter from the (merged) submitted
     // config. A malformed `lineage:` block finalizes the run as Failed,
     // mirroring the auth/clock failure handling above.
@@ -633,6 +656,7 @@ async fn execute_run(
         auth,
         clock,
         cancel: Some(coop.clone()),
+        resilience,
         #[cfg(feature = "lineage")]
         lineage,
         #[cfg(feature = "lineage")]

--- a/cli/tests/replication.rs
+++ b/cli/tests/replication.rs
@@ -112,6 +112,7 @@ async fn run_once(url: &str, state_dir: &str) {
             execution: None,
             auth: Default::default(),
             clock: chrono::Utc::now().fixed_offset(),
+            resilience: None,
         },
     )
     .await

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -65,6 +65,12 @@ pub enum FaucetError {
     #[error("State error: {0}")]
     State(String),
 
+    /// The resilience circuit breaker opened after repeated failures; the run
+    /// is aborted fast. `cooldown` is advisory for the orchestration layer
+    /// (e.g. `faucet schedule` delays re-entry by this duration).
+    #[error("Circuit open after {failures} consecutive failures; cooldown {cooldown:?}")]
+    CircuitOpen { failures: u32, cooldown: Duration },
+
     /// A custom error from a third-party connector.
     ///
     /// Use this to wrap your own error types without losing the error chain:
@@ -279,5 +285,17 @@ mod tests {
         let s = err.to_string();
         assert!(s.contains("not_null"));
         assert!(s.contains("user_id"));
+    }
+
+    #[test]
+    fn circuit_open_is_not_retriable_and_displays() {
+        let err = FaucetError::CircuitOpen {
+            failures: 5,
+            cooldown: std::time::Duration::from_secs(60),
+        };
+        assert!(!err.is_retriable());
+        let s = err.to_string();
+        assert!(s.contains("5"));
+        assert!(s.contains("Circuit open"));
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -60,6 +60,10 @@ pub use pipeline::{
     validate_batch_size,
 };
 pub use replication::ReplicationMethod;
+pub use resilience::{
+    BackoffKind, CircuitBreaker, CircuitBreakerConfig, PoisonAction, PoisonPolicy, ResiliencePolicy,
+    RetryClass, RetryClassSet, RetryPolicy, classify, execute_with_policy,
+};
 pub use retry::execute_with_retry;
 #[cfg(feature = "transform-cdc-unwrap")]
 pub use stage::CdcUnwrapSpec;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -61,8 +61,9 @@ pub use pipeline::{
 };
 pub use replication::ReplicationMethod;
 pub use resilience::{
-    BackoffKind, CircuitBreaker, CircuitBreakerConfig, PoisonAction, PoisonPolicy, ResiliencePolicy,
-    RetryClass, RetryClassSet, RetryPolicy, classify, execute_with_policy,
+    BackoffKind, CircuitBreaker, CircuitBreakerConfig, PoisonAction, PoisonPolicy,
+    ResiliencePolicy, RetryClass, RetryClassSet, RetryMetrics, RetryPolicy, classify,
+    execute_with_policy, execute_with_policy_metered,
 };
 pub use retry::execute_with_retry;
 #[cfg(feature = "transform-cdc-unwrap")]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -25,6 +25,7 @@ pub mod pipeline;
 #[cfg(feature = "quality")]
 pub mod quality;
 pub mod replication;
+pub mod resilience;
 pub mod retry;
 pub mod schema;
 pub mod stage;

--- a/crates/core/src/observability/decorator.rs
+++ b/crates/core/src/observability/decorator.rs
@@ -216,6 +216,7 @@ pub(crate) fn error_kind(e: &FaucetError) -> &'static str {
         FaucetError::Sink(_) => "Sink",
         FaucetError::QualityFailure { .. } => "QualityFailure",
         FaucetError::State(_) => "State",
+        FaucetError::CircuitOpen { .. } => "CircuitOpen",
         FaucetError::Custom(_) => "Custom",
     }
 }
@@ -667,6 +668,13 @@ pub(crate) mod source_tests {
                 "QualityFailure",
             ),
             (FaucetError::State("st".into()), "State"),
+            (
+                FaucetError::CircuitOpen {
+                    failures: 3,
+                    cooldown: Duration::from_secs(60),
+                },
+                "CircuitOpen",
+            ),
             (
                 FaucetError::Custom(Box::new(std::io::Error::other("boom"))),
                 "Custom",

--- a/crates/core/src/observability/install.rs
+++ b/crates/core/src/observability/install.rs
@@ -132,8 +132,10 @@ pub fn install_observability(cfg: &ObservabilityConfig) -> Result<InstallReport,
         }
     }
 
-    // Register build_info after any Prometheus install attempt — set!() into
-    // a not-yet-installed recorder is a no-op, so we order it last.
+    // Register metric HELP text + build_info after any Prometheus install
+    // attempt — describe!()/set!() into a not-yet-installed recorder is a no-op,
+    // so we order them last.
+    crate::observability::resilience::describe();
     register_build_info();
 
     Ok(report)
@@ -142,6 +144,7 @@ pub fn install_observability(cfg: &ObservabilityConfig) -> Result<InstallReport,
 /// Non-`observability-install` stub. Returns an empty report, never panics.
 #[cfg(not(feature = "observability-install"))]
 pub fn install_observability(_cfg: &ObservabilityConfig) -> Result<InstallReport, InstallError> {
+    crate::observability::resilience::describe();
     register_build_info();
     Ok(InstallReport::default())
 }

--- a/crates/core/src/observability/mod.rs
+++ b/crates/core/src/observability/mod.rs
@@ -10,6 +10,7 @@ mod labels;
 mod options;
 #[cfg(feature = "quality")]
 mod quality;
+pub mod resilience;
 mod state;
 mod strip;
 mod timer;

--- a/crates/core/src/observability/options.rs
+++ b/crates/core/src/observability/options.rs
@@ -32,6 +32,8 @@ pub struct RunStreamOptions {
     /// Resume sequence read from the (unwrapped) exactly-once state value.
     /// Ignored unless `delivery == ExactlyOnce`. Defaults to 0.
     pub start_seq: u64,
+    /// Optional resilience policy (retry/backoff/circuit-breaker/poison).
+    pub resilience: Option<crate::resilience::ResiliencePolicy>,
 }
 
 impl RunStreamOptions {
@@ -96,6 +98,12 @@ impl RunStreamOptions {
     /// `Pipeline::run` from the unwrapped state value.
     pub fn with_start_seq(mut self, seq: u64) -> Self {
         self.start_seq = seq;
+        self
+    }
+
+    /// Attach a resilience policy to the run.
+    pub fn with_resilience(mut self, policy: crate::resilience::ResiliencePolicy) -> Self {
+        self.resilience = Some(policy);
         self
     }
 }

--- a/crates/core/src/observability/resilience.rs
+++ b/crates/core/src/observability/resilience.rs
@@ -1,0 +1,135 @@
+//! Metric registration + emit helpers for the unified resilience policy
+//! (retry/backoff, circuit breaker, poison-pill). See
+//! `docs/superpowers/specs/2026-06-17-resilience-policy-design.md` (§Metrics).
+//!
+//! `retries_total` / `retry_sleep_seconds` / `giveup_total` carry per-op labels
+//! (`pipeline`, `row`, `op`, and `class` for retries) and are emitted from the
+//! metered runner [`crate::resilience::execute_with_policy_metered`] where those
+//! labels are in scope. The breaker and poison helpers live here because they
+//! are emitted from the pipeline loop.
+
+use metrics::{counter, describe_counter, describe_gauge, describe_histogram, gauge, histogram};
+
+/// Register HELP text for every resilience metric. Idempotent — safe to call
+/// more than once. Invoked from `install_observability` so the descriptions are
+/// present in `/metrics` from t=0, even before the first retry/open/poison
+/// event. No-op when no recorder is installed.
+pub fn describe() {
+    describe_counter!(
+        "faucet_resilience_retries_total",
+        "Retry attempts, by op (sink_write|flush|state_put|source) and error class."
+    );
+    describe_histogram!(
+        "faucet_resilience_retry_sleep_seconds",
+        "Backoff sleep duration before a retry attempt, by op."
+    );
+    describe_counter!(
+        "faucet_resilience_giveup_total",
+        "Operations that exhausted their retry budget and failed, by op."
+    );
+    describe_gauge!(
+        "faucet_resilience_circuit_state",
+        "Circuit breaker state (0 closed, 1 open)."
+    );
+    describe_counter!(
+        "faucet_resilience_circuit_opened_total",
+        "Circuit breaker open events."
+    );
+    describe_counter!(
+        "faucet_resilience_poison_rows_total",
+        "Poison-pill rows resolved by terminal action (dlq|drop|fail)."
+    );
+}
+
+/// Record a single retry attempt (`op` failed transiently and will be retried),
+/// labelled by `pipeline` / `row` / `op` / error `class`.
+pub fn retry(pipeline: &str, row: &str, op: &'static str, class: &'static str) {
+    counter!(
+        "faucet_resilience_retries_total",
+        "pipeline" => pipeline.to_string(),
+        "row" => row.to_string(),
+        "op" => op,
+        "class" => class,
+    )
+    .increment(1);
+}
+
+/// Record the backoff sleep (seconds) taken before a retry attempt.
+pub fn retry_sleep(pipeline: &str, row: &str, op: &'static str, seconds: f64) {
+    histogram!(
+        "faucet_resilience_retry_sleep_seconds",
+        "pipeline" => pipeline.to_string(),
+        "row" => row.to_string(),
+        "op" => op,
+    )
+    .record(seconds);
+}
+
+/// Record an op that exhausted its retry budget and ultimately failed.
+pub fn giveup(pipeline: &str, row: &str, op: &'static str) {
+    counter!(
+        "faucet_resilience_giveup_total",
+        "pipeline" => pipeline.to_string(),
+        "row" => row.to_string(),
+        "op" => op,
+    )
+    .increment(1);
+}
+
+/// Mark the circuit breaker open for a pipeline/row: bump the open-events
+/// counter and set the state gauge to 1.
+pub fn circuit_opened(pipeline: &str, row: &str) {
+    counter!(
+        "faucet_resilience_circuit_opened_total",
+        "pipeline" => pipeline.to_string(),
+        "row" => row.to_string(),
+    )
+    .increment(1);
+    gauge!(
+        "faucet_resilience_circuit_state",
+        "pipeline" => pipeline.to_string(),
+        "row" => row.to_string(),
+    )
+    .set(1.0);
+}
+
+/// Count `n` poison-pill rows resolved by a terminal `action` (`dlq` / `drop` /
+/// `fail`).
+pub fn poison_rows(pipeline: &str, row: &str, action: &'static str, n: u64) {
+    if n == 0 {
+        return;
+    }
+    counter!(
+        "faucet_resilience_poison_rows_total",
+        "pipeline" => pipeline.to_string(),
+        "row" => row.to_string(),
+        "action" => action,
+    )
+    .increment(n);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn describe_is_callable_and_idempotent() {
+        // No recorder installed in this test → describes are no-ops; the call
+        // must not panic regardless, and repeat calls are safe.
+        describe();
+        describe();
+    }
+
+    #[test]
+    fn emit_helpers_do_not_panic_without_recorder() {
+        // Metric emits are no-ops when no recorder is installed; assert the
+        // helpers stay panic-free across every label shape.
+        retry("p", "r", "sink_write", "http_5xx");
+        retry_sleep("p", "r", "flush", 0.25);
+        giveup("p", "r", "state_put");
+        circuit_opened("p", "r");
+        poison_rows("p", "r", "dlq", 3);
+        // n == 0 short-circuits without emitting; must also not panic.
+        poison_rows("p", "r", "drop", 0);
+    }
+}

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -522,6 +522,41 @@ where
     // flush below, so a buffered sink (Parquet footer, S3 multipart) is made
     // durable — the difference from a dropped future, which flushes nothing.
     let mut cancelled = false;
+
+    // ── Resilience policy (retry/backoff/circuit-breaker) ────────────────────
+    // When no policy is attached, `retry_policy` is `None` and the `with_retry!`
+    // macro falls through to a bare `$op.await`, leaving the write path
+    // byte-for-byte identical to today. The breaker is bound for later tasks
+    // (DLQ-path circuit breaking) and is unused by the default/exactly-once
+    // paths wrapped here.
+    let resilience = options.resilience.clone();
+    let retry_policy = resilience.as_ref().map(|r| r.retry.clone());
+    let mut breaker = resilience.as_ref().and_then(|r| r.circuit_breaker).map(|cb| {
+        (
+            crate::resilience::CircuitBreaker::new(cb.consecutive_failures),
+            cb.cooldown,
+        )
+    });
+    // `breaker` is consumed by the DLQ path (Task 9); silence the unused
+    // warning until then without disabling it for the whole function.
+    let _ = &mut breaker;
+
+    // Run a sink/state op under the retry policy, or bare if no policy is set.
+    // A macro (not a closure) so it works across the differently-typed call
+    // sites (`Result<usize, _>`, `Result<(), _>`) without boxing. `cancel` is
+    // the `Option<CancellationToken>` already in scope; a cancel during a
+    // backoff sleep returns the last error promptly so the caller can flush.
+    macro_rules! with_retry {
+        ($op:expr) => {
+            match &retry_policy {
+                Some(p) => {
+                    crate::resilience::execute_with_policy(p, cancel.as_ref(), || $op).await
+                }
+                None => $op.await,
+            }
+        };
+    }
+
     let loop_result: Result<(), FaucetError> = async {
         loop {
             // Poll the next page, but if a cancellation token is wired, race it
@@ -862,30 +897,29 @@ where
                                 counter!("faucet_pipeline_pages_skipped_total", skip_labels)
                                     .increment(1);
                             } else {
-                                records_written += sink
-                                    .write_batch_idempotent(&page.records, &scope, &token)
-                                    .await?;
+                                records_written += with_retry!(sink.write_batch_idempotent(
+                                    &page.records,
+                                    &scope,
+                                    &token
+                                ))?;
                             }
-                            sink.flush().await?;
+                            with_retry!(sink.flush())?;
                             let bm_labels =
                                 crate::observability::Labels::new(&*pipeline_name, &*row, &*run_id);
                             crate::observability::update_bookmark_lag(&bookmark, &bm_labels);
                             if let (Some(store), Some(key)) =
                                 (state_store.as_ref(), state_key.as_ref())
                             {
-                                store
-                                    .put(
-                                        key,
-                                        &crate::idempotency::wrap_state(Some(&bookmark), next_seq),
-                                    )
-                                    .await?;
+                                let wrapped =
+                                    crate::idempotency::wrap_state(Some(&bookmark), next_seq);
+                                with_retry!(store.put(key, &wrapped))?;
                             }
                             last_bookmark = Some(bookmark);
                         } else if !page.records.is_empty() {
                             // No bookmark → not individually checkpointed; write
                             // as-is (rare for EO sources, which bookmark every
                             // page). Stays at-least-once for this page.
-                            records_written += sink.write_batch(&page.records).await?;
+                            records_written += with_retry!(sink.write_batch(&page.records))?;
                         }
                     } else {
                         // ── DLQ-disabled path (today's behaviour) ──────────────
@@ -905,7 +939,7 @@ where
                                         ctrl.current().max(1).min(page.records.len() - offset);
                                     let chunk = &page.records[offset..offset + size];
                                     let t0 = std::time::Instant::now();
-                                    let n = sink.write_batch(chunk).await?;
+                                    let n = with_retry!(sink.write_batch(chunk))?;
                                     let latency = t0.elapsed();
                                     records_written += n;
                                     offset += size;
@@ -917,18 +951,18 @@ where
                                     emit_adaptive_metrics(ctrl, adj, &pipeline_name, &row);
                                 }
                             } else {
-                                records_written += sink.write_batch(&page.records).await?;
+                                records_written += with_retry!(sink.write_batch(&page.records))?;
                             }
                         }
                         if let Some(bookmark) = page.bookmark {
-                            sink.flush().await?;
+                            with_retry!(sink.flush())?;
                             let bm_labels =
                                 crate::observability::Labels::new(&*pipeline_name, &*row, &*run_id);
                             crate::observability::update_bookmark_lag(&bookmark, &bm_labels);
                             if let (Some(store), Some(key)) =
                                 (state_store.as_ref(), state_key.as_ref())
                             {
-                                store.put(key, &bookmark).await?;
+                                with_retry!(store.put(key, &bookmark))?;
                             }
                             last_bookmark = Some(bookmark);
                         }
@@ -3193,5 +3227,64 @@ mod tests {
             .unwrap();
         assert_eq!(result.records_written, 10);
         assert_eq!(*sink.0.lock().unwrap(), 10);
+    }
+
+    #[tokio::test]
+    async fn resilience_retries_transient_sink_write() {
+        use crate::resilience::{BackoffKind, ResiliencePolicy, RetryPolicy};
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicU32, Ordering};
+        use std::time::Duration;
+
+        struct TransientFlakySink {
+            attempts: Arc<AtomicU32>,
+            written: Arc<AtomicU32>,
+        }
+        #[async_trait::async_trait]
+        impl Sink for TransientFlakySink {
+            async fn write_batch(&self, records: &[serde_json::Value]) -> Result<usize, FaucetError> {
+                let n = self.attempts.fetch_add(1, Ordering::SeqCst);
+                if n < 2 {
+                    return Err(FaucetError::HttpStatus {
+                        status: 503,
+                        url: "u".into(),
+                        body: "".into(),
+                    });
+                }
+                self.written.fetch_add(records.len() as u32, Ordering::SeqCst);
+                Ok(records.len())
+            }
+            async fn flush(&self) -> Result<(), FaucetError> {
+                Ok(())
+            }
+        }
+
+        let attempts = Arc::new(AtomicU32::new(0));
+        let written = Arc::new(AtomicU32::new(0));
+        let sink = TransientFlakySink {
+            attempts: attempts.clone(),
+            written: written.clone(),
+        };
+        let pages = futures::stream::iter(vec![Ok(StreamPage {
+            records: vec![serde_json::json!({"a": 1})],
+            bookmark: None,
+        })]);
+        let policy = ResiliencePolicy {
+            retry: RetryPolicy {
+                max_attempts: 5,
+                backoff: BackoffKind::None,
+                base: Duration::ZERO,
+                max: Duration::ZERO,
+                jitter: false,
+                ..RetryPolicy::default()
+            },
+            ..ResiliencePolicy::default()
+        };
+        let res = run_stream(pages, &sink, RunStreamOptions::new().with_resilience(policy))
+            .await
+            .unwrap();
+        assert_eq!(written.load(Ordering::SeqCst), 1);
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+        assert_eq!(res.records_written, 1);
     }
 }

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -537,10 +537,6 @@ where
             cb.cooldown,
         )
     });
-    // `breaker` is consumed by the DLQ path (Task 9); silence the unused
-    // warning until then without disabling it for the whole function.
-    let _ = &mut breaker;
-
     // Run a sink/state op under the retry policy, or bare if no policy is set.
     // A macro (not a closure) so it works across the differently-typed call
     // sites (`Result<usize, _>`, `Result<(), _>`) without boxing. `cancel` is
@@ -675,7 +671,13 @@ where
                             }
                             let chunk = &page.records[offset..offset + size];
                             let t0 = std::time::Instant::now();
-                            let chunk_outcomes_result = sink.write_batch_partial(chunk).await;
+                            // Wrap the partial write with the retry policy so a
+                            // whole-batch transient `Err` (a 5xx / connection
+                            // drop the sink reports at the outer level) is
+                            // retried before the `on_batch_error` decision.
+                            // Inert when no policy is attached.
+                            let chunk_outcomes_result =
+                                with_retry!(sink.write_batch_partial(chunk));
                             let latency = t0.elapsed();
                             // `chunk_synthesized` is true only when this chunk's
                             // outcomes were fabricated from a single outer
@@ -756,6 +758,27 @@ where
                         // the threshold are still written to the DLQ — losing
                         // them would be strictly worse than the small overshoot.
                         let mut budget_error: Option<FaucetError> = None;
+                        // Circuit-breaker accounting: a page counts as a failure
+                        // for the breaker when it was non-empty and nothing
+                        // succeeded (everything went to the DLQ / dropped). Any
+                        // success resets the consecutive counter. When the breaker
+                        // opens, defer the abort to the same site as `budget_error`
+                        // so the page's failures still reach the DLQ and the
+                        // bookmark advances before the run stops. Inert when no
+                        // breaker is configured.
+                        let mut circuit_error: Option<FaucetError> = None;
+                        if let Some((b, cooldown)) = breaker.as_mut() {
+                            if records_len > 0 && page_success == 0 {
+                                if b.record_failure() {
+                                    circuit_error = Some(FaucetError::CircuitOpen {
+                                        failures: b.consecutive(),
+                                        cooldown: *cooldown,
+                                    });
+                                }
+                            } else if page_success > 0 {
+                                b.record_success();
+                            }
+                        }
                         if let Some(limit) = dlq_cfg.max_failures_per_page
                             && page_failures > limit
                         {
@@ -873,6 +896,10 @@ where
                         // as a circuit breaker but never re-delivers this
                         // already-committed page (#146 M4).
                         if let Some(e) = budget_error {
+                            return Err(e);
+                        }
+                        // Circuit breaker opened after the page was made durable.
+                        if let Some(e) = circuit_error {
                             return Err(e);
                         }
                     } else if exactly_once {
@@ -3287,4 +3314,72 @@ mod tests {
         assert_eq!(attempts.load(Ordering::SeqCst), 3);
         assert_eq!(res.records_written, 1);
     }
+
+    #[tokio::test]
+    async fn resilience_circuit_opens_after_consecutive_failed_pages() {
+        use crate::dlq::{DlqConfig, OnBatchError};
+        use crate::resilience::{
+            BackoffKind, CircuitBreakerConfig, ResiliencePolicy, RetryPolicy,
+        };
+        use std::sync::Arc;
+        use std::time::Duration;
+
+        // A sink whose write_batch_partial always fully fails (outer Err).
+        struct DeadSink;
+        #[async_trait]
+        impl Sink for DeadSink {
+            async fn write_batch(&self, _r: &[Value]) -> Result<usize, FaucetError> {
+                Err(FaucetError::Sink("down".into()))
+            }
+            async fn flush(&self) -> Result<(), FaucetError> {
+                Ok(())
+            }
+        }
+        // DLQ sink that accepts everything.
+        struct NullSink;
+        #[async_trait]
+        impl Sink for NullSink {
+            async fn write_batch(&self, r: &[Value]) -> Result<usize, FaucetError> {
+                Ok(r.len())
+            }
+            async fn flush(&self) -> Result<(), FaucetError> {
+                Ok(())
+            }
+        }
+
+        let pages = futures::stream::iter(
+            (0..10).map(|i| Ok(StreamPage { records: vec![json!({"i": i})], bookmark: None })),
+        );
+        let dlq = DlqConfig {
+            on_batch_error: OnBatchError::DlqAll,
+            ..DlqConfig::new(Arc::new(NullSink))
+        };
+        let policy = ResiliencePolicy {
+            retry: RetryPolicy {
+                max_attempts: 1,
+                backoff: BackoffKind::None,
+                base: Duration::ZERO,
+                max: Duration::ZERO,
+                jitter: false,
+                ..RetryPolicy::default()
+            },
+            circuit_breaker: Some(CircuitBreakerConfig {
+                consecutive_failures: 3,
+                cooldown: Duration::from_secs(60),
+            }),
+            poison: None,
+        };
+        let err = run_stream(
+            pages,
+            &DeadSink,
+            RunStreamOptions::new().with_dlq(dlq).with_resilience(policy),
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(err, FaucetError::CircuitOpen { failures: 3, .. }),
+            "got {err:?}"
+        );
+    }
+
 }

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -134,6 +134,7 @@ pub struct Pipeline<'a, So: Source + ?Sized, Si: Sink + ?Sized> {
     adaptive: Option<crate::adaptive::AdaptiveBatchConfig>,
     cancel: Option<tokio_util::sync::CancellationToken>,
     delivery: crate::idempotency::DeliveryMode,
+    resilience: Option<crate::resilience::ResiliencePolicy>,
 }
 
 impl<'a, So: Source + ?Sized, Si: Sink + ?Sized> Pipeline<'a, So, Si> {
@@ -152,6 +153,7 @@ impl<'a, So: Source + ?Sized, Si: Sink + ?Sized> Pipeline<'a, So, Si> {
             adaptive: None,
             cancel: None,
             delivery: crate::idempotency::DeliveryMode::AtLeastOnce,
+            resilience: None,
         }
     }
 
@@ -232,6 +234,12 @@ impl<'a, So: Source + ?Sized, Si: Sink + ?Sized> Pipeline<'a, So, Si> {
     /// `FaucetError::Config`.
     pub fn with_delivery(mut self, mode: crate::idempotency::DeliveryMode) -> Self {
         self.delivery = mode;
+        self
+    }
+
+    /// Attach a resilience policy (retry/backoff/circuit-breaker/poison-pill).
+    pub fn with_resilience(mut self, policy: crate::resilience::ResiliencePolicy) -> Self {
+        self.resilience = Some(policy);
         self
     }
 
@@ -372,6 +380,9 @@ impl<'a, So: Source + ?Sized, Si: Sink + ?Sized> Pipeline<'a, So, Si> {
             }
             if let Some(cancel) = self.cancel.clone() {
                 opts = opts.with_cancel(cancel);
+            }
+            if let Some(policy) = self.resilience.clone() {
+                opts = opts.with_resilience(policy);
             }
             opts = opts.with_delivery(self.delivery).with_start_seq(start_seq);
 

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -941,12 +941,17 @@ where
                         records_written += page_success;
 
                         if let Some(bookmark) = page.bookmark {
-                            sink.flush().await?;
+                            // Retry-wrap the main-sink flush, the DLQ-sink flush,
+                            // and the state write so a transient failure on any of
+                            // them is retried before aborting — same as the default
+                            // and exactly-once paths. Inert when no policy is set
+                            // (the macro's `None` arm is a bare `.await`).
+                            with_retry!(sink.flush())?;
                             let _dlq_flush_timer = crate::observability::DurationGuard::new(
                                 "faucet_sink_dlq_flush_duration_seconds",
                                 metric_labels.clone(),
                             );
-                            dlq_cfg.sink.flush().await.map_err(|e| {
+                            with_retry!(dlq_cfg.sink.flush()).map_err(|e| {
                                 let mut lbl = metric_labels.clone();
                                 lbl.push(Label::new(
                                     "kind",
@@ -963,7 +968,7 @@ where
                             if let (Some(store), Some(key)) =
                                 (state_store.as_ref(), state_key.as_ref())
                             {
-                                store.put(key, &bookmark).await?;
+                                with_retry!(store.put(key, &bookmark))?;
                             }
                             last_bookmark = Some(bookmark);
                         }
@@ -3559,5 +3564,146 @@ mod tests {
         let dlq = captured.lock().unwrap();
         assert_eq!(dlq.len(), 1, "one row to DLQ");
         assert_eq!(dlq[0]["payload"]["bad"], json!(true));
+    }
+
+    #[tokio::test]
+    async fn resilience_retries_transient_flush_and_state_on_dlq_path() {
+        // The DLQ path's `sink.flush()` and `store.put()` must be retry-wrapped
+        // like the default/exactly-once paths: a transient failure on either is
+        // retried before the run aborts. Drive a bookmark-carrying page through
+        // the DLQ path (one row routed to the DLQ via a partial-write failure),
+        // with both the main-sink flush and the state put failing twice then
+        // succeeding.
+        use crate::dlq::DlqConfig;
+        use crate::resilience::{BackoffKind, ResiliencePolicy, RetryPolicy};
+        use crate::state::StateStore;
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicU32, Ordering};
+        use std::time::Duration;
+
+        fn transient_503() -> FaucetError {
+            FaucetError::HttpStatus {
+                status: 503,
+                url: "u".into(),
+                body: "".into(),
+            }
+        }
+
+        // Main sink: one row fails per-row (→ DLQ), the rest succeed; flush()
+        // fails transiently the first two calls, then succeeds.
+        struct FlakyFlushSink {
+            flush_attempts: Arc<AtomicU32>,
+        }
+        #[async_trait]
+        impl Sink for FlakyFlushSink {
+            async fn write_batch(&self, r: &[Value]) -> Result<usize, FaucetError> {
+                Ok(r.len())
+            }
+            async fn write_batch_partial(
+                &self,
+                records: &[Value],
+            ) -> Result<Vec<crate::RowOutcome>, FaucetError> {
+                Ok(records
+                    .iter()
+                    .map(|rec| {
+                        if rec.get("bad").and_then(|v| v.as_bool()).unwrap_or(false) {
+                            Err(transient_503())
+                        } else {
+                            Ok(())
+                        }
+                    })
+                    .collect())
+            }
+            async fn flush(&self) -> Result<(), FaucetError> {
+                let n = self.flush_attempts.fetch_add(1, Ordering::SeqCst);
+                if n < 2 { Err(transient_503()) } else { Ok(()) }
+            }
+        }
+        struct NullSink;
+        #[async_trait]
+        impl Sink for NullSink {
+            async fn write_batch(&self, r: &[Value]) -> Result<usize, FaucetError> {
+                Ok(r.len())
+            }
+            async fn flush(&self) -> Result<(), FaucetError> {
+                Ok(())
+            }
+        }
+
+        // State store whose put() fails transiently the first two calls.
+        struct FlakyStore {
+            put_attempts: Arc<AtomicU32>,
+            value: Arc<std::sync::Mutex<Option<Value>>>,
+        }
+        #[async_trait]
+        impl StateStore for FlakyStore {
+            async fn get(&self, _key: &str) -> Result<Option<Value>, FaucetError> {
+                Ok(self.value.lock().unwrap().clone())
+            }
+            async fn put(&self, _key: &str, value: &Value) -> Result<(), FaucetError> {
+                let n = self.put_attempts.fetch_add(1, Ordering::SeqCst);
+                if n < 2 {
+                    return Err(transient_503());
+                }
+                *self.value.lock().unwrap() = Some(value.clone());
+                Ok(())
+            }
+            async fn delete(&self, _key: &str) -> Result<(), FaucetError> {
+                Ok(())
+            }
+        }
+
+        let flush_attempts = Arc::new(AtomicU32::new(0));
+        let put_attempts = Arc::new(AtomicU32::new(0));
+        let stored = Arc::new(std::sync::Mutex::new(None));
+        let sink = FlakyFlushSink {
+            flush_attempts: flush_attempts.clone(),
+        };
+        let store: Arc<dyn StateStore> = Arc::new(FlakyStore {
+            put_attempts: put_attempts.clone(),
+            value: stored.clone(),
+        });
+        let pages = futures::stream::iter(vec![Ok(StreamPage {
+            records: vec![json!({"ok": 1}), json!({"bad": true})],
+            bookmark: Some(json!({"cursor": 42})),
+        })]);
+        let policy = ResiliencePolicy {
+            retry: RetryPolicy {
+                max_attempts: 5,
+                backoff: BackoffKind::None,
+                base: Duration::ZERO,
+                max: Duration::ZERO,
+                jitter: false,
+                ..RetryPolicy::default()
+            },
+            ..ResiliencePolicy::default()
+        };
+        let res = run_stream(
+            pages,
+            &sink,
+            RunStreamOptions::new()
+                .with_dlq(DlqConfig::new(Arc::new(NullSink)))
+                .with_state(store, "k")
+                .with_resilience(policy),
+        )
+        .await
+        .unwrap();
+
+        // Page-gate flush: 2 transient failures retried, success on the 3rd
+        // call — proving the DLQ-path `sink.flush()` is retry-wrapped. A 4th
+        // call is the (already-succeeding) end-of-stream final flush.
+        assert_eq!(
+            flush_attempts.load(Ordering::SeqCst),
+            4,
+            "page-gate flush retried past two transient failures (3) + 1 final flush"
+        );
+        // State put succeeded on the 3rd call (2 transient failures retried).
+        assert_eq!(
+            put_attempts.load(Ordering::SeqCst),
+            3,
+            "state put retried past two transient failures"
+        );
+        assert_eq!(*stored.lock().unwrap(), Some(json!({"cursor": 42})));
+        assert_eq!(res.records_written, 1, "the ok row");
     }
 }

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -507,6 +507,8 @@ where
     }
     let mut controller: Option<crate::adaptive::AimdController> = None;
     let mut warned_noop_sink = false;
+    // One-shot warn guard for poison-pill `Drop` action (DLQ path).
+    let mut warned_poison_drop = false;
 
     let sink_name = sink.connector_name();
     let dlq_sink_name = dlq.as_ref().map(|d| d.sink.connector_name()).unwrap_or("");
@@ -537,6 +539,9 @@ where
             cb.cooldown,
         )
     });
+    // Poison-pill (per-row) policy, applied in the DLQ path only.
+    let poison = resilience.as_ref().and_then(|r| r.poison);
+
     // Run a sink/state op under the retry policy, or bare if no policy is set.
     // A macro (not a closure) so it works across the differently-typed call
     // sites (`Result<usize, _>`, `Result<(), _>`) without boxing. `cancel` is
@@ -687,7 +692,7 @@ where
                             // `reason` label accurate when adaptive reslicing
                             // mixes a synthesized chunk with partial-failure
                             // chunks on the same page.
-                            let (chunk_outcomes, chunk_synthesized): (
+                            let (mut chunk_outcomes, chunk_synthesized): (
                                 Vec<crate::RowOutcome>,
                                 bool,
                             ) = match chunk_outcomes_result {
@@ -704,23 +709,97 @@ where
                                     }
                                 },
                             };
+
+                            // ── Poison-pill: retry the still-failing,
+                            // retriable-row subset before enveloping. A row that
+                            // succeeds on retry becomes a success; one that keeps
+                            // failing falls through to the terminal `action`
+                            // applied in the per-row loop below. Only genuine
+                            // per-row failures are retried (not a synthesized
+                            // `DlqAll` chunk — there is no per-row sink to retry
+                            // against). Inert when `poison` is `None`.
+                            if let Some(pp) = poison
+                                && !chunk_synthesized
+                            {
+                                let mut attempt = 1u32; // first attempt already done
+                                while attempt < pp.max_row_attempts {
+                                    let failing: Vec<usize> = chunk_outcomes
+                                        .iter()
+                                        .enumerate()
+                                        .filter_map(|(j, o)| match o {
+                                            Err(e)
+                                                if retry_policy
+                                                    .as_ref()
+                                                    .map(|p| p.is_retriable(e))
+                                                    .unwrap_or(false) =>
+                                            {
+                                                Some(j)
+                                            }
+                                            _ => None,
+                                        })
+                                        .collect();
+                                    if failing.is_empty() {
+                                        break;
+                                    }
+                                    let subset: Vec<Value> =
+                                        failing.iter().map(|&j| chunk[j].clone()).collect();
+                                    let retried =
+                                        with_retry!(sink.write_batch_partial(&subset))?;
+                                    // `retried` aligns positionally with `failing`
+                                    // (the subset was built in `failing` order).
+                                    // Consume by value — `FaucetError` is not Clone.
+                                    let mut retried = retried.into_iter();
+                                    for &j in failing.iter() {
+                                        chunk_outcomes[j] = retried.next().unwrap_or(Ok(()));
+                                    }
+                                    attempt += 1;
+                                }
+                            }
+
                             let mut chunk_errors = 0usize;
                             for (j, outcome) in chunk_outcomes.iter().enumerate() {
                                 match outcome {
                                     Ok(()) => page_success += 1,
                                     Err(err) => {
-                                        chunk_errors += 1;
-                                        if !chunk_synthesized {
-                                            had_per_row_sink_failure = true;
+                                        // Terminal poison action for a row that
+                                        // remained failing after retries. With no
+                                        // poison policy this is always the default
+                                        // `Dlq` behavior (envelope).
+                                        let action = poison
+                                            .map(|pp| pp.action)
+                                            .unwrap_or(crate::resilience::PoisonAction::Dlq);
+                                        match action {
+                                            crate::resilience::PoisonAction::Fail => {
+                                                return Err(FaucetError::Sink(format!(
+                                                    "poison-pill row failed permanently: {err}"
+                                                )));
+                                            }
+                                            crate::resilience::PoisonAction::Drop => {
+                                                // Count + one-shot warn, discard the
+                                                // row (no envelope). Metric emission
+                                                // is wired in Task 11.
+                                                if !warned_poison_drop {
+                                                    tracing::warn!(
+                                                        "poison-pill: dropping permanently-failing row(s) (action=drop); this warning fires once per run"
+                                                    );
+                                                    warned_poison_drop = true;
+                                                }
+                                            }
+                                            crate::resilience::PoisonAction::Dlq => {
+                                                chunk_errors += 1;
+                                                if !chunk_synthesized {
+                                                    had_per_row_sink_failure = true;
+                                                }
+                                                envelopes.push(build_envelope(
+                                                    &chunk[j],
+                                                    err,
+                                                    sink_name,
+                                                    &pipeline_name,
+                                                    &row,
+                                                    offset + j,
+                                                ));
+                                            }
                                         }
-                                        envelopes.push(build_envelope(
-                                            &chunk[j],
-                                            err,
-                                            sink_name,
-                                            &pipeline_name,
-                                            &row,
-                                            offset + j,
-                                        ));
                                     }
                                 }
                             }
@@ -3382,4 +3461,103 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn resilience_poison_retries_then_dlqs_failing_row() {
+        use crate::dlq::DlqConfig;
+        use crate::resilience::{
+            BackoffKind, PoisonAction, PoisonPolicy, ResiliencePolicy, RetryPolicy,
+        };
+        use std::sync::{Arc, Mutex};
+        use std::time::Duration;
+
+        // Sink: row {"bad":true} always fails; others succeed. Counts attempts
+        // on the bad row.
+        struct PickySink {
+            bad_attempts: Arc<Mutex<u32>>,
+        }
+        #[async_trait]
+        impl Sink for PickySink {
+            async fn write_batch(&self, r: &[Value]) -> Result<usize, FaucetError> {
+                Ok(r.len())
+            }
+            async fn write_batch_partial(
+                &self,
+                records: &[Value],
+            ) -> Result<Vec<crate::RowOutcome>, FaucetError> {
+                Ok(records
+                    .iter()
+                    .map(|rec| {
+                        if rec.get("bad").and_then(|v| v.as_bool()).unwrap_or(false) {
+                            *self.bad_attempts.lock().unwrap() += 1;
+                            Err(FaucetError::HttpStatus {
+                                status: 503,
+                                url: "u".into(),
+                                body: "".into(),
+                            })
+                        } else {
+                            Ok(())
+                        }
+                    })
+                    .collect())
+            }
+            async fn flush(&self) -> Result<(), FaucetError> {
+                Ok(())
+            }
+        }
+        struct CaptureSink(Arc<Mutex<Vec<Value>>>);
+        #[async_trait]
+        impl Sink for CaptureSink {
+            async fn write_batch(&self, r: &[Value]) -> Result<usize, FaucetError> {
+                self.0.lock().unwrap().extend_from_slice(r);
+                Ok(r.len())
+            }
+            async fn flush(&self) -> Result<(), FaucetError> {
+                Ok(())
+            }
+        }
+
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let bad_attempts = Arc::new(Mutex::new(0u32));
+        let sink = PickySink {
+            bad_attempts: bad_attempts.clone(),
+        };
+        let pages = futures::stream::iter(vec![Ok(StreamPage {
+            records: vec![json!({"ok": 1}), json!({"bad": true})],
+            bookmark: None,
+        })]);
+        let policy = ResiliencePolicy {
+            retry: RetryPolicy {
+                max_attempts: 1,
+                backoff: BackoffKind::None,
+                base: Duration::ZERO,
+                max: Duration::ZERO,
+                jitter: false,
+                ..RetryPolicy::default()
+            },
+            circuit_breaker: None,
+            poison: Some(PoisonPolicy {
+                max_row_attempts: 3,
+                action: PoisonAction::Dlq,
+            }),
+        };
+        let res = run_stream(
+            pages,
+            &sink,
+            RunStreamOptions::new()
+                .with_dlq(DlqConfig::new(Arc::new(CaptureSink(captured.clone()))))
+                .with_resilience(policy),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            *bad_attempts.lock().unwrap(),
+            3,
+            "bad row tried max_row_attempts times"
+        );
+        assert_eq!(res.records_written, 1, "the ok row");
+        let dlq = captured.lock().unwrap();
+        assert_eq!(dlq.len(), 1, "one row to DLQ");
+        assert_eq!(dlq[0]["payload"]["bad"], json!(true));
+    }
 }

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -533,12 +533,15 @@ where
     // paths wrapped here.
     let resilience = options.resilience.clone();
     let retry_policy = resilience.as_ref().map(|r| r.retry.clone());
-    let mut breaker = resilience.as_ref().and_then(|r| r.circuit_breaker).map(|cb| {
-        (
-            crate::resilience::CircuitBreaker::new(cb.consecutive_failures),
-            cb.cooldown,
-        )
-    });
+    let mut breaker = resilience
+        .as_ref()
+        .and_then(|r| r.circuit_breaker)
+        .map(|cb| {
+            (
+                crate::resilience::CircuitBreaker::new(cb.consecutive_failures),
+                cb.cooldown,
+            )
+        });
     // Poison-pill (per-row) policy, applied in the DLQ path only.
     let poison = resilience.as_ref().and_then(|r| r.poison);
 
@@ -547,11 +550,24 @@ where
     // sites (`Result<usize, _>`, `Result<(), _>`) without boxing. `cancel` is
     // the `Option<CancellationToken>` already in scope; a cancel during a
     // backoff sleep returns the last error promptly so the caller can flush.
+    //
+    // Each call site tags its `op` (`"sink_write"` / `"flush"` / `"state_put"`)
+    // so the resilience metrics (`faucet_resilience_retries_total{op,class}`,
+    // `_retry_sleep_seconds{op}`, `_giveup_total{op}`) get the spec's labels via
+    // the metered runner. The `RetryMetrics` (which clones the pipeline/row
+    // strings) is built only when a policy is attached, so the no-policy path
+    // stays allocation-free and byte-for-byte identical to today.
     macro_rules! with_retry {
-        ($op:expr) => {
+        ($op_label:literal, $op:expr) => {
             match &retry_policy {
                 Some(p) => {
-                    crate::resilience::execute_with_policy(p, cancel.as_ref(), || $op).await
+                    let m = crate::resilience::RetryMetrics {
+                        pipeline: pipeline_name.to_string(),
+                        row: row.to_string(),
+                        op: $op_label,
+                    };
+                    crate::resilience::execute_with_policy_metered(p, cancel.as_ref(), &m, || $op)
+                        .await
                 }
                 None => $op.await,
             }
@@ -682,7 +698,7 @@ where
                             // retried before the `on_batch_error` decision.
                             // Inert when no policy is attached.
                             let chunk_outcomes_result =
-                                with_retry!(sink.write_batch_partial(chunk));
+                                with_retry!("sink_write", sink.write_batch_partial(chunk));
                             let latency = t0.elapsed();
                             // `chunk_synthesized` is true only when this chunk's
                             // outcomes were fabricated from a single outer
@@ -744,7 +760,7 @@ where
                                     let subset: Vec<Value> =
                                         failing.iter().map(|&j| chunk[j].clone()).collect();
                                     let retried =
-                                        with_retry!(sink.write_batch_partial(&subset))?;
+                                        with_retry!("sink_write", sink.write_batch_partial(&subset))?;
                                     // `retried` aligns positionally with `failing`
                                     // (the subset was built in `failing` order).
                                     // Consume by value — `FaucetError` is not Clone.
@@ -757,6 +773,13 @@ where
                             }
 
                             let mut chunk_errors = 0usize;
+                            // Per-action poison counts for this chunk. Emitted to
+                            // `faucet_resilience_poison_rows_total` only when a
+                            // `poison` policy is configured — the default `Dlq`
+                            // fallback (no policy) is ordinary DLQ traffic and must
+                            // not inflate the poison metric.
+                            let mut poison_dlq = 0u64;
+                            let mut poison_drop = 0u64;
                             for (j, outcome) in chunk_outcomes.iter().enumerate() {
                                 match outcome {
                                     Ok(()) => page_success += 1,
@@ -770,14 +793,20 @@ where
                                             .unwrap_or(crate::resilience::PoisonAction::Dlq);
                                         match action {
                                             crate::resilience::PoisonAction::Fail => {
+                                                crate::observability::resilience::poison_rows(
+                                                    &pipeline_name,
+                                                    &row,
+                                                    "fail",
+                                                    1,
+                                                );
                                                 return Err(FaucetError::Sink(format!(
                                                     "poison-pill row failed permanently: {err}"
                                                 )));
                                             }
                                             crate::resilience::PoisonAction::Drop => {
                                                 // Count + one-shot warn, discard the
-                                                // row (no envelope). Metric emission
-                                                // is wired in Task 11.
+                                                // row (no envelope).
+                                                poison_drop += 1;
                                                 if !warned_poison_drop {
                                                     tracing::warn!(
                                                         "poison-pill: dropping permanently-failing row(s) (action=drop); this warning fires once per run"
@@ -786,6 +815,7 @@ where
                                                 }
                                             }
                                             crate::resilience::PoisonAction::Dlq => {
+                                                poison_dlq += 1;
                                                 chunk_errors += 1;
                                                 if !chunk_synthesized {
                                                     had_per_row_sink_failure = true;
@@ -802,6 +832,23 @@ where
                                         }
                                     }
                                 }
+                            }
+                            // Only attribute these to the poison metric when the
+                            // policy is active (otherwise `Dlq` rows are plain DLQ
+                            // traffic, already counted elsewhere).
+                            if poison.is_some() {
+                                crate::observability::resilience::poison_rows(
+                                    &pipeline_name,
+                                    &row,
+                                    "dlq",
+                                    poison_dlq,
+                                );
+                                crate::observability::resilience::poison_rows(
+                                    &pipeline_name,
+                                    &row,
+                                    "drop",
+                                    poison_drop,
+                                );
                             }
                             if let Some(ctrl) = controller.as_mut() {
                                 let adj = ctrl.observe(crate::adaptive::Observation {
@@ -849,6 +896,10 @@ where
                         if let Some((b, cooldown)) = breaker.as_mut() {
                             if records_len > 0 && page_success == 0 {
                                 if b.record_failure() {
+                                    crate::observability::resilience::circuit_opened(
+                                        &pipeline_name,
+                                        &row,
+                                    );
                                     circuit_error = Some(FaucetError::CircuitOpen {
                                         failures: b.consecutive(),
                                         cooldown: *cooldown,
@@ -946,12 +997,12 @@ where
                             // them is retried before aborting — same as the default
                             // and exactly-once paths. Inert when no policy is set
                             // (the macro's `None` arm is a bare `.await`).
-                            with_retry!(sink.flush())?;
+                            with_retry!("flush", sink.flush())?;
                             let _dlq_flush_timer = crate::observability::DurationGuard::new(
                                 "faucet_sink_dlq_flush_duration_seconds",
                                 metric_labels.clone(),
                             );
-                            with_retry!(dlq_cfg.sink.flush()).map_err(|e| {
+                            with_retry!("flush", dlq_cfg.sink.flush()).map_err(|e| {
                                 let mut lbl = metric_labels.clone();
                                 lbl.push(Label::new(
                                     "kind",
@@ -968,7 +1019,7 @@ where
                             if let (Some(store), Some(key)) =
                                 (state_store.as_ref(), state_key.as_ref())
                             {
-                                with_retry!(store.put(key, &bookmark))?;
+                                with_retry!("state_put", store.put(key, &bookmark))?;
                             }
                             last_bookmark = Some(bookmark);
                         }
@@ -1008,13 +1059,12 @@ where
                                 counter!("faucet_pipeline_pages_skipped_total", skip_labels)
                                     .increment(1);
                             } else {
-                                records_written += with_retry!(sink.write_batch_idempotent(
-                                    &page.records,
-                                    &scope,
-                                    &token
-                                ))?;
+                                records_written += with_retry!(
+                                    "sink_write",
+                                    sink.write_batch_idempotent(&page.records, &scope, &token)
+                                )?;
                             }
-                            with_retry!(sink.flush())?;
+                            with_retry!("flush", sink.flush())?;
                             let bm_labels =
                                 crate::observability::Labels::new(&*pipeline_name, &*row, &*run_id);
                             crate::observability::update_bookmark_lag(&bookmark, &bm_labels);
@@ -1023,14 +1073,14 @@ where
                             {
                                 let wrapped =
                                     crate::idempotency::wrap_state(Some(&bookmark), next_seq);
-                                with_retry!(store.put(key, &wrapped))?;
+                                with_retry!("state_put", store.put(key, &wrapped))?;
                             }
                             last_bookmark = Some(bookmark);
                         } else if !page.records.is_empty() {
                             // No bookmark → not individually checkpointed; write
                             // as-is (rare for EO sources, which bookmark every
                             // page). Stays at-least-once for this page.
-                            records_written += with_retry!(sink.write_batch(&page.records))?;
+                            records_written += with_retry!("sink_write", sink.write_batch(&page.records))?;
                         }
                     } else {
                         // ── DLQ-disabled path (today's behaviour) ──────────────
@@ -1050,7 +1100,7 @@ where
                                         ctrl.current().max(1).min(page.records.len() - offset);
                                     let chunk = &page.records[offset..offset + size];
                                     let t0 = std::time::Instant::now();
-                                    let n = with_retry!(sink.write_batch(chunk))?;
+                                    let n = with_retry!("sink_write", sink.write_batch(chunk))?;
                                     let latency = t0.elapsed();
                                     records_written += n;
                                     offset += size;
@@ -1062,18 +1112,19 @@ where
                                     emit_adaptive_metrics(ctrl, adj, &pipeline_name, &row);
                                 }
                             } else {
-                                records_written += with_retry!(sink.write_batch(&page.records))?;
+                                records_written +=
+                                    with_retry!("sink_write", sink.write_batch(&page.records))?;
                             }
                         }
                         if let Some(bookmark) = page.bookmark {
-                            with_retry!(sink.flush())?;
+                            with_retry!("flush", sink.flush())?;
                             let bm_labels =
                                 crate::observability::Labels::new(&*pipeline_name, &*row, &*run_id);
                             crate::observability::update_bookmark_lag(&bookmark, &bm_labels);
                             if let (Some(store), Some(key)) =
                                 (state_store.as_ref(), state_key.as_ref())
                             {
-                                with_retry!(store.put(key, &bookmark))?;
+                                with_retry!("state_put", store.put(key, &bookmark))?;
                             }
                             last_bookmark = Some(bookmark);
                         }
@@ -3353,7 +3404,10 @@ mod tests {
         }
         #[async_trait::async_trait]
         impl Sink for TransientFlakySink {
-            async fn write_batch(&self, records: &[serde_json::Value]) -> Result<usize, FaucetError> {
+            async fn write_batch(
+                &self,
+                records: &[serde_json::Value],
+            ) -> Result<usize, FaucetError> {
                 let n = self.attempts.fetch_add(1, Ordering::SeqCst);
                 if n < 2 {
                     return Err(FaucetError::HttpStatus {
@@ -3362,7 +3416,8 @@ mod tests {
                         body: "".into(),
                     });
                 }
-                self.written.fetch_add(records.len() as u32, Ordering::SeqCst);
+                self.written
+                    .fetch_add(records.len() as u32, Ordering::SeqCst);
                 Ok(records.len())
             }
             async fn flush(&self) -> Result<(), FaucetError> {
@@ -3391,9 +3446,13 @@ mod tests {
             },
             ..ResiliencePolicy::default()
         };
-        let res = run_stream(pages, &sink, RunStreamOptions::new().with_resilience(policy))
-            .await
-            .unwrap();
+        let res = run_stream(
+            pages,
+            &sink,
+            RunStreamOptions::new().with_resilience(policy),
+        )
+        .await
+        .unwrap();
         assert_eq!(written.load(Ordering::SeqCst), 1);
         assert_eq!(attempts.load(Ordering::SeqCst), 3);
         assert_eq!(res.records_written, 1);
@@ -3402,9 +3461,7 @@ mod tests {
     #[tokio::test]
     async fn resilience_circuit_opens_after_consecutive_failed_pages() {
         use crate::dlq::{DlqConfig, OnBatchError};
-        use crate::resilience::{
-            BackoffKind, CircuitBreakerConfig, ResiliencePolicy, RetryPolicy,
-        };
+        use crate::resilience::{BackoffKind, CircuitBreakerConfig, ResiliencePolicy, RetryPolicy};
         use std::sync::Arc;
         use std::time::Duration;
 
@@ -3431,9 +3488,12 @@ mod tests {
             }
         }
 
-        let pages = futures::stream::iter(
-            (0..10).map(|i| Ok(StreamPage { records: vec![json!({"i": i})], bookmark: None })),
-        );
+        let pages = futures::stream::iter((0..10).map(|i| {
+            Ok(StreamPage {
+                records: vec![json!({"i": i})],
+                bookmark: None,
+            })
+        }));
         let dlq = DlqConfig {
             on_batch_error: OnBatchError::DlqAll,
             ..DlqConfig::new(Arc::new(NullSink))
@@ -3456,7 +3516,9 @@ mod tests {
         let err = run_stream(
             pages,
             &DeadSink,
-            RunStreamOptions::new().with_dlq(dlq).with_resilience(policy),
+            RunStreamOptions::new()
+                .with_dlq(dlq)
+                .with_resilience(policy),
         )
         .await
         .unwrap_err();
@@ -3705,5 +3767,108 @@ mod tests {
         );
         assert_eq!(*stored.lock().unwrap(), Some(json!({"cursor": 42})));
         assert_eq!(res.records_written, 1, "the ok row");
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn resilience_emits_retries_total_with_op_and_class_labels() {
+        // Drive the flaky-sink retry path under a recorder and assert the
+        // metered runner emitted `faucet_resilience_retries_total` with the
+        // spec's `{op, class}` labels.
+        use crate::observability::decorator::source_tests::{LOCK, snapshotter};
+        use crate::resilience::{BackoffKind, ResiliencePolicy, RetryPolicy};
+        use metrics_util::debugging::DebugValue;
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicU32, Ordering};
+        use std::time::Duration;
+
+        struct RetryProbeSink {
+            attempts: Arc<AtomicU32>,
+        }
+        #[async_trait]
+        impl Sink for RetryProbeSink {
+            async fn write_batch(&self, r: &[Value]) -> Result<usize, FaucetError> {
+                let n = self.attempts.fetch_add(1, Ordering::SeqCst);
+                if n < 2 {
+                    return Err(FaucetError::HttpStatus {
+                        status: 503,
+                        url: "u".into(),
+                        body: "".into(),
+                    });
+                }
+                Ok(r.len())
+            }
+            async fn flush(&self) -> Result<(), FaucetError> {
+                Ok(())
+            }
+            // Unique connector name unused for resilience metrics (they carry
+            // pipeline/row/op only) but keeps the debug_assert happy.
+            fn connector_name(&self) -> &'static str {
+                "retry-probe"
+            }
+        }
+
+        let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let snap = snapshotter();
+
+        let attempts = Arc::new(AtomicU32::new(0));
+        let sink = RetryProbeSink {
+            attempts: attempts.clone(),
+        };
+        let pages = futures::stream::iter(vec![Ok(StreamPage {
+            records: vec![json!({"a": 1})],
+            bookmark: None,
+        })]);
+        let policy = ResiliencePolicy {
+            retry: RetryPolicy {
+                max_attempts: 5,
+                backoff: BackoffKind::None,
+                base: Duration::ZERO,
+                max: Duration::ZERO,
+                jitter: false,
+                ..RetryPolicy::default()
+            },
+            ..ResiliencePolicy::default()
+        };
+        run_stream(
+            pages,
+            &sink,
+            RunStreamOptions::new()
+                .with_name("retry-metrics-pipeline")
+                .with_resilience(policy),
+        )
+        .await
+        .unwrap();
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+
+        let snapshot = snap.snapshot();
+        let retries: u64 = snapshot
+            .into_vec()
+            .into_iter()
+            .filter_map(|(key, _u, _d, v): (metrics_util::CompositeKey, _, _, _)| {
+                if key.key().name() == "faucet_resilience_retries_total"
+                    && key.key().labels().any(|l: &metrics::Label| {
+                        l.key() == "pipeline" && l.value() == "retry-metrics-pipeline"
+                    })
+                    && key
+                        .key()
+                        .labels()
+                        .any(|l: &metrics::Label| l.key() == "op" && l.value() == "sink_write")
+                    && key
+                        .key()
+                        .labels()
+                        .any(|l: &metrics::Label| l.key() == "class" && l.value() == "http_5xx")
+                    && let DebugValue::Counter(c) = v
+                {
+                    Some(c)
+                } else {
+                    None
+                }
+            })
+            .sum();
+        assert_eq!(
+            retries, 2,
+            "expected 2 retries (2 transient 503s) counted with op=sink_write, class=http_5xx"
+        );
     }
 }

--- a/crates/core/src/resilience/breaker.rs
+++ b/crates/core/src/resilience/breaker.rs
@@ -11,7 +11,10 @@ pub struct CircuitBreaker {
 impl CircuitBreaker {
     /// New breaker that opens after `threshold` consecutive failures.
     pub fn new(threshold: u32) -> Self {
-        Self { threshold: threshold.max(1), consecutive: 0 }
+        Self {
+            threshold: threshold.max(1),
+            consecutive: 0,
+        }
     }
 
     /// Record a success; resets the consecutive counter.

--- a/crates/core/src/resilience/breaker.rs
+++ b/crates/core/src/resilience/breaker.rs
@@ -1,0 +1,62 @@
+//! Consecutive-failure circuit breaker. Pure (no clock): counts consecutive
+//! page-level write failures and reports when the threshold is crossed.
+
+/// Tracks consecutive failures; opens when `threshold` is reached.
+#[derive(Debug)]
+pub struct CircuitBreaker {
+    threshold: u32,
+    consecutive: u32,
+}
+
+impl CircuitBreaker {
+    /// New breaker that opens after `threshold` consecutive failures.
+    pub fn new(threshold: u32) -> Self {
+        Self { threshold: threshold.max(1), consecutive: 0 }
+    }
+
+    /// Record a success; resets the consecutive counter.
+    pub fn record_success(&mut self) {
+        self.consecutive = 0;
+    }
+
+    /// Record a failure; returns `true` if the circuit is now open.
+    pub fn record_failure(&mut self) -> bool {
+        self.consecutive = self.consecutive.saturating_add(1);
+        self.consecutive >= self.threshold
+    }
+
+    /// Current consecutive-failure count.
+    pub fn consecutive(&self) -> u32 {
+        self.consecutive
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn opens_after_threshold_consecutive_failures() {
+        let mut b = CircuitBreaker::new(3);
+        assert!(!b.record_failure());
+        assert!(!b.record_failure());
+        assert!(b.record_failure(), "third consecutive failure should open");
+        assert_eq!(b.consecutive(), 3);
+    }
+
+    #[test]
+    fn success_resets_the_counter() {
+        let mut b = CircuitBreaker::new(3);
+        b.record_failure();
+        b.record_failure();
+        b.record_success();
+        assert_eq!(b.consecutive(), 0);
+        assert!(!b.record_failure());
+    }
+
+    #[test]
+    fn threshold_one_opens_immediately() {
+        let mut b = CircuitBreaker::new(1);
+        assert!(b.record_failure());
+    }
+}

--- a/crates/core/src/resilience/classify.rs
+++ b/crates/core/src/resilience/classify.rs
@@ -95,19 +95,21 @@ pub fn classify(err: &FaucetError) -> Option<RetryClass> {
     }
 }
 
-/// Pure classification of a reqwest transport error from its three discriminating
+/// Pure classification of a reqwest transport error from its discriminating
 /// predicates. Factored out of the [`FaucetError::Http`] arm so it is unit-testable
 /// without constructing a `reqwest::Error` (which has no public constructor).
 ///
 /// A timeout wins regardless of any attached status. A 5xx/429 status maps to the
 /// matching class; any other status is non-transient (`None`). With no status, a
 /// connect failure and every other transport error (body/decode mid-stream) are
-/// treated as connection-class transient — a strict superset of the legacy
-/// `FaucetError::is_retriable`, so behavior is preserved.
+/// treated as connection-class transient — so `is_connect` does not change the
+/// outcome and is accepted only to mirror the reqwest predicate at the call site.
+/// This is a strict superset of the legacy `FaucetError::is_retriable`, so behavior
+/// is preserved.
 fn classify_transport(
     is_timeout: bool,
     status: Option<u16>,
-    is_connect: bool,
+    _is_connect: bool,
 ) -> Option<RetryClass> {
     if is_timeout {
         Some(RetryClass::Timeout)
@@ -119,9 +121,9 @@ fn classify_transport(
         } else {
             None
         }
-    } else if is_connect {
-        Some(RetryClass::Connection)
     } else {
+        // Statusless, non-timeout transport error: a connect failure and every
+        // other transport error (body/decode mid-stream) are connection-class.
         Some(RetryClass::Connection)
     }
 }

--- a/crates/core/src/resilience/classify.rs
+++ b/crates/core/src/resilience/classify.rs
@@ -5,7 +5,17 @@ use crate::error::FaucetError;
 
 /// The transient-failure class an error belongs to. Closed set so it can be a
 /// bounded metric label and a `retry_on` config value.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
+    schemars::JsonSchema,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum RetryClass {
     /// HTTP 5xx server error.
@@ -76,9 +86,11 @@ pub fn classify(err: &FaucetError) -> Option<RetryClass> {
         FaucetError::HttpStatus { status, .. } if *status == 429 => Some(RetryClass::RateLimited),
         FaucetError::HttpStatus { status, .. } if *status >= 500 => Some(RetryClass::Http5xx),
         FaucetError::RateLimited(_) => Some(RetryClass::RateLimited),
-        FaucetError::Http(e) => {
-            classify_transport(e.is_timeout(), e.status().map(|s| s.as_u16()), e.is_connect())
-        }
+        FaucetError::Http(e) => classify_transport(
+            e.is_timeout(),
+            e.status().map(|s| s.as_u16()),
+            e.is_connect(),
+        ),
         _ => None,
     }
 }
@@ -122,11 +134,19 @@ mod tests {
     #[test]
     fn classifies_5xx_429_and_rate_limited() {
         assert_eq!(
-            classify(&FaucetError::HttpStatus { status: 503, url: "u".into(), body: "".into() }),
+            classify(&FaucetError::HttpStatus {
+                status: 503,
+                url: "u".into(),
+                body: "".into()
+            }),
             Some(RetryClass::Http5xx)
         );
         assert_eq!(
-            classify(&FaucetError::HttpStatus { status: 429, url: "u".into(), body: "".into() }),
+            classify(&FaucetError::HttpStatus {
+                status: 429,
+                url: "u".into(),
+                body: "".into()
+            }),
             Some(RetryClass::RateLimited)
         );
         assert_eq!(
@@ -138,16 +158,34 @@ mod tests {
     #[test]
     fn transport_classification_covers_every_arm() {
         // Timeout wins regardless of status.
-        assert_eq!(classify_transport(true, None, false), Some(RetryClass::Timeout));
-        assert_eq!(classify_transport(true, Some(500), true), Some(RetryClass::Timeout));
+        assert_eq!(
+            classify_transport(true, None, false),
+            Some(RetryClass::Timeout)
+        );
+        assert_eq!(
+            classify_transport(true, Some(500), true),
+            Some(RetryClass::Timeout)
+        );
         // Status-bearing transport errors.
-        assert_eq!(classify_transport(false, Some(503), false), Some(RetryClass::Http5xx));
-        assert_eq!(classify_transport(false, Some(429), false), Some(RetryClass::RateLimited));
+        assert_eq!(
+            classify_transport(false, Some(503), false),
+            Some(RetryClass::Http5xx)
+        );
+        assert_eq!(
+            classify_transport(false, Some(429), false),
+            Some(RetryClass::RateLimited)
+        );
         // A non-5xx/429 status is not transient.
         assert_eq!(classify_transport(false, Some(404), false), None);
         // Statusless: connect and other transport errors are connection-class.
-        assert_eq!(classify_transport(false, None, true), Some(RetryClass::Connection));
-        assert_eq!(classify_transport(false, None, false), Some(RetryClass::Connection));
+        assert_eq!(
+            classify_transport(false, None, true),
+            Some(RetryClass::Connection)
+        );
+        assert_eq!(
+            classify_transport(false, None, false),
+            Some(RetryClass::Connection)
+        );
     }
 
     #[test]

--- a/crates/core/src/resilience/classify.rs
+++ b/crates/core/src/resilience/classify.rs
@@ -19,6 +19,7 @@ use crate::error::FaucetError;
 #[serde(rename_all = "snake_case")]
 pub enum RetryClass {
     /// HTTP 5xx server error.
+    #[serde(rename = "http_5xx")]
     Http5xx,
     /// HTTP 429 / rate-limit signal.
     RateLimited,
@@ -195,6 +196,30 @@ mod tests {
         assert_eq!(classify(&FaucetError::Auth("x".into())), None);
         assert_eq!(classify(&FaucetError::Config("x".into())), None);
         assert_eq!(classify(&FaucetError::Sink("x".into())), None);
+    }
+
+    #[test]
+    fn retry_class_serde_round_trips() {
+        use serde_json::json;
+        // Http5xx serializes/deserializes as `http_5xx`, matching the metric
+        // label and the docs/example config value.
+        assert_eq!(
+            serde_json::from_value::<RetryClass>(json!("http_5xx")).unwrap(),
+            RetryClass::Http5xx
+        );
+        assert_eq!(
+            serde_json::to_value(RetryClass::Http5xx).unwrap(),
+            json!("http_5xx")
+        );
+        // The other three round-trip via their snake_case names.
+        for (s, c) in [
+            ("rate_limited", RetryClass::RateLimited),
+            ("connection", RetryClass::Connection),
+            ("timeout", RetryClass::Timeout),
+        ] {
+            assert_eq!(serde_json::from_value::<RetryClass>(json!(s)).unwrap(), c);
+            assert_eq!(serde_json::to_value(c).unwrap(), json!(s));
+        }
     }
 
     #[test]

--- a/crates/core/src/resilience/classify.rs
+++ b/crates/core/src/resilience/classify.rs
@@ -1,0 +1,145 @@
+//! Classify a [`FaucetError`] into a retry class, and a small set of classes
+//! the user opts into via `retry_on: [...]`.
+
+use crate::error::FaucetError;
+
+/// The transient-failure class an error belongs to. Closed set so it can be a
+/// bounded metric label and a `retry_on` config value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum RetryClass {
+    /// HTTP 5xx server error.
+    Http5xx,
+    /// HTTP 429 / rate-limit signal.
+    RateLimited,
+    /// Connection-level failure (DNS, refused, reset) with no HTTP status.
+    Connection,
+    /// Request timeout.
+    Timeout,
+}
+
+impl RetryClass {
+    /// Stable Prometheus label value.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            RetryClass::Http5xx => "http_5xx",
+            RetryClass::RateLimited => "rate_limited",
+            RetryClass::Connection => "connection",
+            RetryClass::Timeout => "timeout",
+        }
+    }
+}
+
+/// The set of classes the user has opted into retrying. Backed by a fixed-size
+/// bool array (only four variants), so it is `Copy` and allocation-free.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RetryClassSet([bool; 4]);
+
+impl RetryClassSet {
+    fn idx(c: RetryClass) -> usize {
+        match c {
+            RetryClass::Http5xx => 0,
+            RetryClass::RateLimited => 1,
+            RetryClass::Connection => 2,
+            RetryClass::Timeout => 3,
+        }
+    }
+
+    /// True when `c` is in the set.
+    pub fn contains(&self, c: RetryClass) -> bool {
+        self.0[Self::idx(c)]
+    }
+}
+
+impl Default for RetryClassSet {
+    /// All four classes — reproduces today's `FaucetError::is_retriable`.
+    fn default() -> Self {
+        RetryClassSet([true; 4])
+    }
+}
+
+impl FromIterator<RetryClass> for RetryClassSet {
+    fn from_iter<I: IntoIterator<Item = RetryClass>>(iter: I) -> Self {
+        let mut set = RetryClassSet([false; 4]);
+        for c in iter {
+            set.0[Self::idx(c)] = true;
+        }
+        set
+    }
+}
+
+/// Map a [`FaucetError`] to its [`RetryClass`], or `None` if it is not a
+/// transient failure. The single source of truth for retriability — both the
+/// policy runner and `FaucetError::is_retriable` defer to this.
+pub fn classify(err: &FaucetError) -> Option<RetryClass> {
+    match err {
+        FaucetError::HttpStatus { status, .. } if *status == 429 => Some(RetryClass::RateLimited),
+        FaucetError::HttpStatus { status, .. } if *status >= 500 => Some(RetryClass::Http5xx),
+        FaucetError::RateLimited(_) => Some(RetryClass::RateLimited),
+        FaucetError::Http(e) => {
+            if e.is_timeout() {
+                Some(RetryClass::Timeout)
+            } else if let Some(status) = e.status() {
+                if status.is_server_error() {
+                    Some(RetryClass::Http5xx)
+                } else if status.as_u16() == 429 {
+                    Some(RetryClass::RateLimited)
+                } else {
+                    None
+                }
+            } else if e.is_connect() {
+                Some(RetryClass::Connection)
+            } else {
+                // Other reqwest transport errors (body, decode mid-stream) —
+                // treat as connection-class transient.
+                Some(RetryClass::Connection)
+            }
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn classifies_5xx_429_and_rate_limited() {
+        assert_eq!(
+            classify(&FaucetError::HttpStatus { status: 503, url: "u".into(), body: "".into() }),
+            Some(RetryClass::Http5xx)
+        );
+        assert_eq!(
+            classify(&FaucetError::HttpStatus { status: 429, url: "u".into(), body: "".into() }),
+            Some(RetryClass::RateLimited)
+        );
+        assert_eq!(
+            classify(&FaucetError::RateLimited(Duration::from_secs(1))),
+            Some(RetryClass::RateLimited)
+        );
+    }
+
+    #[test]
+    fn non_retriable_errors_classify_none() {
+        assert_eq!(classify(&FaucetError::Auth("x".into())), None);
+        assert_eq!(classify(&FaucetError::Config("x".into())), None);
+        assert_eq!(classify(&FaucetError::Sink("x".into())), None);
+    }
+
+    #[test]
+    fn set_contains_and_default_covers_all_four() {
+        let set = RetryClassSet::default();
+        for c in [
+            RetryClass::Http5xx,
+            RetryClass::RateLimited,
+            RetryClass::Connection,
+            RetryClass::Timeout,
+        ] {
+            assert!(set.contains(c), "default set should contain {c:?}");
+        }
+        let only5xx = RetryClassSet::from_iter([RetryClass::Http5xx]);
+        assert!(only5xx.contains(RetryClass::Http5xx));
+        assert!(!only5xx.contains(RetryClass::RateLimited));
+    }
+}

--- a/crates/core/src/resilience/classify.rs
+++ b/crates/core/src/resilience/classify.rs
@@ -77,25 +77,40 @@ pub fn classify(err: &FaucetError) -> Option<RetryClass> {
         FaucetError::HttpStatus { status, .. } if *status >= 500 => Some(RetryClass::Http5xx),
         FaucetError::RateLimited(_) => Some(RetryClass::RateLimited),
         FaucetError::Http(e) => {
-            if e.is_timeout() {
-                Some(RetryClass::Timeout)
-            } else if let Some(status) = e.status() {
-                if status.is_server_error() {
-                    Some(RetryClass::Http5xx)
-                } else if status.as_u16() == 429 {
-                    Some(RetryClass::RateLimited)
-                } else {
-                    None
-                }
-            } else if e.is_connect() {
-                Some(RetryClass::Connection)
-            } else {
-                // Other reqwest transport errors (body, decode mid-stream) —
-                // treat as connection-class transient.
-                Some(RetryClass::Connection)
-            }
+            classify_transport(e.is_timeout(), e.status().map(|s| s.as_u16()), e.is_connect())
         }
         _ => None,
+    }
+}
+
+/// Pure classification of a reqwest transport error from its three discriminating
+/// predicates. Factored out of the [`FaucetError::Http`] arm so it is unit-testable
+/// without constructing a `reqwest::Error` (which has no public constructor).
+///
+/// A timeout wins regardless of any attached status. A 5xx/429 status maps to the
+/// matching class; any other status is non-transient (`None`). With no status, a
+/// connect failure and every other transport error (body/decode mid-stream) are
+/// treated as connection-class transient — a strict superset of the legacy
+/// `FaucetError::is_retriable`, so behavior is preserved.
+fn classify_transport(
+    is_timeout: bool,
+    status: Option<u16>,
+    is_connect: bool,
+) -> Option<RetryClass> {
+    if is_timeout {
+        Some(RetryClass::Timeout)
+    } else if let Some(status) = status {
+        if status >= 500 {
+            Some(RetryClass::Http5xx)
+        } else if status == 429 {
+            Some(RetryClass::RateLimited)
+        } else {
+            None
+        }
+    } else if is_connect {
+        Some(RetryClass::Connection)
+    } else {
+        Some(RetryClass::Connection)
     }
 }
 
@@ -118,6 +133,21 @@ mod tests {
             classify(&FaucetError::RateLimited(Duration::from_secs(1))),
             Some(RetryClass::RateLimited)
         );
+    }
+
+    #[test]
+    fn transport_classification_covers_every_arm() {
+        // Timeout wins regardless of status.
+        assert_eq!(classify_transport(true, None, false), Some(RetryClass::Timeout));
+        assert_eq!(classify_transport(true, Some(500), true), Some(RetryClass::Timeout));
+        // Status-bearing transport errors.
+        assert_eq!(classify_transport(false, Some(503), false), Some(RetryClass::Http5xx));
+        assert_eq!(classify_transport(false, Some(429), false), Some(RetryClass::RateLimited));
+        // A non-5xx/429 status is not transient.
+        assert_eq!(classify_transport(false, Some(404), false), None);
+        // Statusless: connect and other transport errors are connection-class.
+        assert_eq!(classify_transport(false, None, true), Some(RetryClass::Connection));
+        assert_eq!(classify_transport(false, None, false), Some(RetryClass::Connection));
     }
 
     #[test]

--- a/crates/core/src/resilience/execute.rs
+++ b/crates/core/src/resilience/execute.rs
@@ -2,18 +2,74 @@
 //! honoring backoff, jitter, retry classification, and a cancellation token.
 
 use crate::error::FaucetError;
+use crate::resilience::classify::classify;
 use crate::resilience::policy::RetryPolicy;
 use std::future::Future;
 use tokio_util::sync::CancellationToken;
+
+/// Per-op labels for the metered runner. Identifies which pipeline / matrix row
+/// / I/O operation a retry belongs to so the resilience metrics
+/// (`faucet_resilience_retries_total` / `_retry_sleep_seconds` / `_giveup_total`)
+/// carry the spec's `{pipeline, row, op}` label set. `op` is a closed set
+/// (`sink_write` / `flush` / `state_put` / `source`).
+#[derive(Debug, Clone)]
+pub struct RetryMetrics {
+    /// Pipeline name label.
+    pub pipeline: String,
+    /// Matrix row id label (`""` for non-matrix runs).
+    pub row: String,
+    /// Operation label — a `&'static str` from the closed op set.
+    pub op: &'static str,
+}
 
 /// Execute `op` under `policy`. Retries retriable errors (per
 /// [`RetryPolicy::is_retriable`]) up to `max_attempts` total attempts, sleeping
 /// the backoff delay between attempts. If `cancel` is provided, a cancellation
 /// during a backoff sleep stops waiting and returns the last error immediately
 /// (the caller observes the token and flushes). `Ok` returns at once.
+///
+/// This is the connector-facing, label-free runner used by source connectors;
+/// the pipeline loop uses [`execute_with_policy_metered`] so the resilience
+/// metrics get their `{pipeline, row, op}` labels.
 pub async fn execute_with_policy<F, Fut, T>(
     policy: &RetryPolicy,
     cancel: Option<&CancellationToken>,
+    op: F,
+) -> Result<T, FaucetError>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T, FaucetError>>,
+{
+    run_with_policy(policy, cancel, None, op).await
+}
+
+/// Like [`execute_with_policy`], but emits the resilience metrics
+/// (`faucet_resilience_retries_total{op,class}`,
+/// `faucet_resilience_retry_sleep_seconds{op}`, and
+/// `faucet_resilience_giveup_total{op}` when retries are exhausted) using the
+/// labels in `metrics`. Behavior (retry/give-up/cancel outcomes) is identical to
+/// `execute_with_policy` — only the metric emission differs.
+pub async fn execute_with_policy_metered<F, Fut, T>(
+    policy: &RetryPolicy,
+    cancel: Option<&CancellationToken>,
+    metrics: &RetryMetrics,
+    op: F,
+) -> Result<T, FaucetError>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T, FaucetError>>,
+{
+    run_with_policy(policy, cancel, Some(metrics), op).await
+}
+
+/// Shared retry loop backing both the bare and metered public runners. When
+/// `metrics` is `Some`, emits per-attempt retry / sleep / give-up metrics; when
+/// `None`, the metric calls are skipped entirely (zero overhead on the
+/// connector-facing path).
+async fn run_with_policy<F, Fut, T>(
+    policy: &RetryPolicy,
+    cancel: Option<&CancellationToken>,
+    metrics: Option<&RetryMetrics>,
     mut op: F,
 ) -> Result<T, FaucetError>
 where
@@ -36,12 +92,32 @@ where
                     attempt + 1,
                     policy.max_attempts
                 );
+                if let Some(m) = metrics {
+                    // `is_retriable` above guarantees a class; fall back defensively.
+                    let class = classify(&e).map(|c| c.as_str()).unwrap_or("unknown");
+                    crate::observability::resilience::retry(&m.pipeline, &m.row, m.op, class);
+                    crate::observability::resilience::retry_sleep(
+                        &m.pipeline,
+                        &m.row,
+                        m.op,
+                        wait.as_secs_f64(),
+                    );
+                }
                 if !wait.is_zero() {
                     match cancel {
                         Some(token) => {
                             tokio::select! {
                                 biased;
-                                _ = token.cancelled() => return Err(e),
+                                _ = token.cancelled() => {
+                                    // Cancelled mid-backoff: the op was retriable but
+                                    // we are abandoning it — count as a give-up.
+                                    if let Some(m) = metrics {
+                                        crate::observability::resilience::giveup(
+                                            &m.pipeline, &m.row, m.op,
+                                        );
+                                    }
+                                    return Err(e);
+                                }
                                 _ = tokio::time::sleep(wait) => {}
                             }
                         }
@@ -50,7 +126,17 @@ where
                 }
                 attempt += 1;
             }
-            Err(e) => return Err(e),
+            Err(e) => {
+                // Retries exhausted (or a non-retriable error). Only count a
+                // give-up when at least one retry was attempted — a first-attempt
+                // non-retriable failure is not an exhausted budget.
+                if attempt > 0
+                    && let Some(m) = metrics
+                {
+                    crate::observability::resilience::giveup(&m.pipeline, &m.row, m.op);
+                }
+                return Err(e);
+            }
         }
     }
 }
@@ -176,6 +262,100 @@ mod tests {
         let token = CancellationToken::new();
         token.cancel(); // already cancelled → backoff sleep returns at once
         let r = execute_with_policy(&policy, Some(&token), || async {
+            Err::<i32, _>(FaucetError::HttpStatus {
+                status: 503,
+                url: "u".into(),
+                body: "".into(),
+            })
+        })
+        .await;
+        assert!(r.is_err());
+    }
+
+    fn metrics() -> RetryMetrics {
+        RetryMetrics {
+            pipeline: "p".into(),
+            row: "r".into(),
+            op: "sink_write",
+        }
+    }
+
+    // The metered runner must produce byte-for-byte identical retry / give-up /
+    // cancel outcomes to the bare runner — only the metric emission differs (the
+    // emits are no-ops without a recorder, so these assert behavior).
+
+    #[tokio::test]
+    async fn metered_retries_then_succeeds_same_as_bare() {
+        let calls = Arc::new(AtomicU32::new(0));
+        let c = calls.clone();
+        let m = metrics();
+        let r = execute_with_policy_metered(&fast_policy(5), None, &m, move || {
+            let n = c.fetch_add(1, Ordering::SeqCst);
+            async move {
+                if n < 2 {
+                    Err::<i32, _>(FaucetError::HttpStatus {
+                        status: 503,
+                        url: "u".into(),
+                        body: "".into(),
+                    })
+                } else {
+                    Ok(42)
+                }
+            }
+        })
+        .await;
+        assert_eq!(r.unwrap(), 42);
+        assert_eq!(calls.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn metered_gives_up_after_max_attempts_same_as_bare() {
+        let calls = Arc::new(AtomicU32::new(0));
+        let c = calls.clone();
+        let m = metrics();
+        let r = execute_with_policy_metered(&fast_policy(3), None, &m, move || {
+            c.fetch_add(1, Ordering::SeqCst);
+            async {
+                Err::<i32, _>(FaucetError::HttpStatus {
+                    status: 503,
+                    url: "u".into(),
+                    body: "".into(),
+                })
+            }
+        })
+        .await;
+        assert!(r.is_err());
+        assert_eq!(calls.load(Ordering::SeqCst), 3, "1 initial + 2 retries");
+    }
+
+    #[tokio::test]
+    async fn metered_non_retriable_fails_immediately_same_as_bare() {
+        let calls = Arc::new(AtomicU32::new(0));
+        let c = calls.clone();
+        let m = metrics();
+        let r = execute_with_policy_metered(&fast_policy(5), None, &m, move || {
+            c.fetch_add(1, Ordering::SeqCst);
+            async { Err::<i32, _>(FaucetError::Auth("nope".into())) }
+        })
+        .await;
+        assert!(r.is_err());
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn metered_cancel_during_backoff_returns_promptly() {
+        let policy = RetryPolicy {
+            max_attempts: 10,
+            backoff: BackoffKind::Fixed,
+            base: Duration::from_secs(30),
+            max: Duration::from_secs(30),
+            jitter: false,
+            ..RetryPolicy::default()
+        };
+        let token = CancellationToken::new();
+        token.cancel();
+        let m = metrics();
+        let r = execute_with_policy_metered(&policy, Some(&token), &m, || async {
             Err::<i32, _>(FaucetError::HttpStatus {
                 status: 503,
                 url: "u".into(),

--- a/crates/core/src/resilience/execute.rs
+++ b/crates/core/src/resilience/execute.rs
@@ -1,0 +1,153 @@
+//! The retry runner: executes a fallible async op under a [`RetryPolicy`],
+//! honoring backoff, jitter, retry classification, and a cancellation token.
+
+use crate::error::FaucetError;
+use crate::resilience::policy::{BackoffKind, RetryPolicy};
+use std::future::Future;
+use tokio_util::sync::CancellationToken;
+
+/// Execute `op` under `policy`. Retries retriable errors (per
+/// [`RetryPolicy::is_retriable`]) up to `max_attempts` total attempts, sleeping
+/// the backoff delay between attempts. If `cancel` is provided, a cancellation
+/// during a backoff sleep stops waiting and returns the last error immediately
+/// (the caller observes the token and flushes). `Ok` returns at once.
+pub async fn execute_with_policy<F, Fut, T>(
+    policy: &RetryPolicy,
+    cancel: Option<&CancellationToken>,
+    mut op: F,
+) -> Result<T, FaucetError>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T, FaucetError>>,
+{
+    let mut attempt = 0u32;
+    loop {
+        match op().await {
+            Ok(val) => return Ok(val),
+            Err(e) if policy.is_retriable(&e) && attempt + 1 < policy.max_attempts => {
+                let base = policy.backoff.delay(policy.base, policy.max, attempt);
+                let wait = if policy.jitter {
+                    crate::retry::apply_jitter(base)
+                } else {
+                    base
+                };
+                tracing::warn!(
+                    "operation failed (attempt {}/{}), retrying in {wait:?}: {e}",
+                    attempt + 1,
+                    policy.max_attempts
+                );
+                if !wait.is_zero() {
+                    match cancel {
+                        Some(token) => {
+                            tokio::select! {
+                                biased;
+                                _ = token.cancelled() => return Err(e),
+                                _ = tokio::time::sleep(wait) => {}
+                            }
+                        }
+                        None => tokio::time::sleep(wait).await,
+                    }
+                }
+                attempt += 1;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::time::Duration;
+
+    fn fast_policy(max_attempts: u32) -> RetryPolicy {
+        RetryPolicy {
+            max_attempts,
+            backoff: BackoffKind::None,
+            base: Duration::from_millis(0),
+            max: Duration::from_millis(0),
+            jitter: false,
+            ..RetryPolicy::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn retries_then_succeeds() {
+        let calls = Arc::new(AtomicU32::new(0));
+        let c = calls.clone();
+        let r = execute_with_policy(&fast_policy(5), None, move || {
+            let n = c.fetch_add(1, Ordering::SeqCst);
+            async move {
+                if n < 2 {
+                    Err::<i32, _>(FaucetError::HttpStatus {
+                        status: 503,
+                        url: "u".into(),
+                        body: "".into(),
+                    })
+                } else {
+                    Ok(42)
+                }
+            }
+        })
+        .await;
+        assert_eq!(r.unwrap(), 42);
+        assert_eq!(calls.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn gives_up_after_max_attempts() {
+        let calls = Arc::new(AtomicU32::new(0));
+        let c = calls.clone();
+        let r = execute_with_policy(&fast_policy(3), None, move || {
+            c.fetch_add(1, Ordering::SeqCst);
+            async {
+                Err::<i32, _>(FaucetError::HttpStatus {
+                    status: 503,
+                    url: "u".into(),
+                    body: "".into(),
+                })
+            }
+        })
+        .await;
+        assert!(r.is_err());
+        assert_eq!(calls.load(Ordering::SeqCst), 3, "1 initial + 2 retries");
+    }
+
+    #[tokio::test]
+    async fn non_retriable_fails_immediately() {
+        let calls = Arc::new(AtomicU32::new(0));
+        let c = calls.clone();
+        let r = execute_with_policy(&fast_policy(5), None, move || {
+            c.fetch_add(1, Ordering::SeqCst);
+            async { Err::<i32, _>(FaucetError::Auth("nope".into())) }
+        })
+        .await;
+        assert!(r.is_err());
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn cancel_during_backoff_returns_last_error_promptly() {
+        let policy = RetryPolicy {
+            max_attempts: 10,
+            backoff: BackoffKind::Fixed,
+            base: Duration::from_secs(30),
+            max: Duration::from_secs(30),
+            jitter: false,
+            ..RetryPolicy::default()
+        };
+        let token = CancellationToken::new();
+        token.cancel(); // already cancelled → backoff sleep returns at once
+        let r = execute_with_policy(&policy, Some(&token), || async {
+            Err::<i32, _>(FaucetError::HttpStatus {
+                status: 503,
+                url: "u".into(),
+                body: "".into(),
+            })
+        })
+        .await;
+        assert!(r.is_err());
+    }
+}

--- a/crates/core/src/resilience/execute.rs
+++ b/crates/core/src/resilience/execute.rs
@@ -130,6 +130,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn jittered_nonzero_backoff_with_no_cancel_retries() {
+        // Exercises the `jitter: true` + non-zero `Fixed` backoff + `None` cancel
+        // arms directly (the zero-backoff `fast_policy` skips both). Backoff is a
+        // few ms so the test stays fast while still sleeping a real interval.
+        let policy = RetryPolicy {
+            max_attempts: 3,
+            backoff: BackoffKind::Fixed,
+            base: Duration::from_millis(2),
+            max: Duration::from_millis(2),
+            jitter: true,
+            ..RetryPolicy::default()
+        };
+        let calls = Arc::new(AtomicU32::new(0));
+        let c = calls.clone();
+        let r = execute_with_policy(&policy, None, move || {
+            let n = c.fetch_add(1, Ordering::SeqCst);
+            async move {
+                if n < 1 {
+                    Err::<i32, _>(FaucetError::HttpStatus {
+                        status: 503,
+                        url: "u".into(),
+                        body: "".into(),
+                    })
+                } else {
+                    Ok(9)
+                }
+            }
+        })
+        .await;
+        assert_eq!(r.unwrap(), 9);
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
     async fn cancel_during_backoff_returns_last_error_promptly() {
         let policy = RetryPolicy {
             max_attempts: 10,

--- a/crates/core/src/resilience/execute.rs
+++ b/crates/core/src/resilience/execute.rs
@@ -2,7 +2,7 @@
 //! honoring backoff, jitter, retry classification, and a cancellation token.
 
 use crate::error::FaucetError;
-use crate::resilience::policy::{BackoffKind, RetryPolicy};
+use crate::resilience::policy::RetryPolicy;
 use std::future::Future;
 use tokio_util::sync::CancellationToken;
 
@@ -58,6 +58,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::resilience::policy::BackoffKind;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicU32, Ordering};
     use std::time::Duration;

--- a/crates/core/src/resilience/mod.rs
+++ b/crates/core/src/resilience/mod.rs
@@ -3,5 +3,9 @@
 //! `docs/superpowers/specs/2026-06-17-resilience-policy-design.md`.
 
 mod classify;
+mod policy;
 
 pub use classify::{RetryClass, RetryClassSet, classify};
+pub use policy::{
+    BackoffKind, CircuitBreakerConfig, PoisonAction, PoisonPolicy, ResiliencePolicy, RetryPolicy,
+};

--- a/crates/core/src/resilience/mod.rs
+++ b/crates/core/src/resilience/mod.rs
@@ -4,9 +4,11 @@
 
 mod breaker;
 mod classify;
+mod execute;
 mod policy;
 
 pub use breaker::CircuitBreaker;
+pub use execute::execute_with_policy;
 pub use classify::{RetryClass, RetryClassSet, classify};
 pub use policy::{
     BackoffKind, CircuitBreakerConfig, PoisonAction, PoisonPolicy, ResiliencePolicy, RetryPolicy,

--- a/crates/core/src/resilience/mod.rs
+++ b/crates/core/src/resilience/mod.rs
@@ -1,0 +1,7 @@
+//! Unified resilience policy: retry, backoff classification, circuit breaker,
+//! and poison-pill row handling. See
+//! `docs/superpowers/specs/2026-06-17-resilience-policy-design.md`.
+
+mod classify;
+
+pub use classify::{RetryClass, RetryClassSet, classify};

--- a/crates/core/src/resilience/mod.rs
+++ b/crates/core/src/resilience/mod.rs
@@ -8,8 +8,8 @@ mod execute;
 mod policy;
 
 pub use breaker::CircuitBreaker;
-pub use execute::execute_with_policy;
 pub use classify::{RetryClass, RetryClassSet, classify};
+pub use execute::execute_with_policy;
 pub use policy::{
     BackoffKind, CircuitBreakerConfig, PoisonAction, PoisonPolicy, ResiliencePolicy, RetryPolicy,
 };

--- a/crates/core/src/resilience/mod.rs
+++ b/crates/core/src/resilience/mod.rs
@@ -2,9 +2,11 @@
 //! and poison-pill row handling. See
 //! `docs/superpowers/specs/2026-06-17-resilience-policy-design.md`.
 
+mod breaker;
 mod classify;
 mod policy;
 
+pub use breaker::CircuitBreaker;
 pub use classify::{RetryClass, RetryClassSet, classify};
 pub use policy::{
     BackoffKind, CircuitBreakerConfig, PoisonAction, PoisonPolicy, ResiliencePolicy, RetryPolicy,

--- a/crates/core/src/resilience/mod.rs
+++ b/crates/core/src/resilience/mod.rs
@@ -9,7 +9,7 @@ mod policy;
 
 pub use breaker::CircuitBreaker;
 pub use classify::{RetryClass, RetryClassSet, classify};
-pub use execute::execute_with_policy;
+pub use execute::{RetryMetrics, execute_with_policy, execute_with_policy_metered};
 pub use policy::{
     BackoffKind, CircuitBreakerConfig, PoisonAction, PoisonPolicy, ResiliencePolicy, RetryPolicy,
 };

--- a/crates/core/src/resilience/policy.rs
+++ b/crates/core/src/resilience/policy.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 pub enum BackoffKind {
     /// No delay between attempts.
     None,
-    /// Constant `base` delay.
+    /// Constant `base` delay, capped at `max`.
     Fixed,
     /// `base * 2^attempt`, capped at `max`.
     #[default]
@@ -144,6 +144,11 @@ mod tests {
         let max = Duration::from_secs(10);
         assert_eq!(BackoffKind::None.delay(base, max, 0), Duration::ZERO);
         assert_eq!(BackoffKind::Fixed.delay(base, max, 3), base);
+        // Fixed is capped at max when base exceeds it.
+        assert_eq!(
+            BackoffKind::Fixed.delay(Duration::from_secs(20), Duration::from_secs(10), 0),
+            Duration::from_secs(10)
+        );
         assert_eq!(BackoffKind::Exponential.delay(base, max, 0), base);
         assert_eq!(BackoffKind::Exponential.delay(base, max, 2), base * 4);
         // capped at max

--- a/crates/core/src/resilience/policy.rs
+++ b/crates/core/src/resilience/policy.rs
@@ -1,0 +1,151 @@
+//! Configuration value types for the resilience policy.
+
+use crate::error::FaucetError;
+use crate::resilience::classify::{RetryClass, RetryClassSet, classify};
+use std::time::Duration;
+
+/// How the inter-attempt delay grows.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum BackoffKind {
+    /// No delay between attempts.
+    None,
+    /// Constant `base` delay.
+    Fixed,
+    /// `base * 2^attempt`, capped at `max`.
+    #[default]
+    Exponential,
+}
+
+impl BackoffKind {
+    /// Pre-jitter delay for a zero-based `attempt` index.
+    pub fn delay(self, base: Duration, max: Duration, attempt: u32) -> Duration {
+        match self {
+            BackoffKind::None => Duration::ZERO,
+            BackoffKind::Fixed => base.min(max),
+            BackoffKind::Exponential => base
+                .saturating_mul(2u32.saturating_pow(attempt))
+                .min(max),
+        }
+    }
+}
+
+/// Retry configuration shared by the pipeline loop and source connectors.
+#[derive(Debug, Clone)]
+pub struct RetryPolicy {
+    /// Total attempts including the first (1 = no retry).
+    pub max_attempts: u32,
+    /// Backoff growth shape.
+    pub backoff: BackoffKind,
+    /// Base delay.
+    pub base: Duration,
+    /// Per-sleep cap (pre-jitter).
+    pub max: Duration,
+    /// Whether to apply `[0.5, 1.5)` jitter.
+    pub jitter: bool,
+    /// Which error classes are retried.
+    pub retry_on: RetryClassSet,
+}
+
+impl Default for RetryPolicy {
+    fn default() -> Self {
+        Self {
+            max_attempts: 5,
+            backoff: BackoffKind::Exponential,
+            base: Duration::from_millis(200),
+            max: Duration::from_secs(30),
+            jitter: true,
+            retry_on: RetryClassSet::default(),
+        }
+    }
+}
+
+impl RetryPolicy {
+    /// Whether `err` should be retried under this policy: it must classify into
+    /// a class that is in `retry_on`.
+    pub fn is_retriable(&self, err: &FaucetError) -> bool {
+        classify(err).is_some_and(|c| self.retry_on.contains(c))
+    }
+}
+
+/// Circuit-breaker tuning. Counts consecutive page-level write failures.
+#[derive(Debug, Clone, Copy)]
+pub struct CircuitBreakerConfig {
+    /// Consecutive exhausted-retry failures before the circuit opens.
+    pub consecutive_failures: u32,
+    /// Re-entry cooldown (honored by the orchestration layer, e.g. `schedule`).
+    pub cooldown: Duration,
+}
+
+/// What to do with a row that keeps failing after `max_row_attempts`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PoisonAction {
+    /// Route to the DLQ (requires a DLQ to be configured).
+    #[default]
+    Dlq,
+    /// Discard the row (counts + warns).
+    Drop,
+    /// Propagate the row error and abort the run.
+    Fail,
+}
+
+/// Poison-pill (per-row) policy.
+#[derive(Debug, Clone, Copy)]
+pub struct PoisonPolicy {
+    /// Per-row write attempts before applying `action`.
+    pub max_row_attempts: u32,
+    /// Terminal action for a persistently failing row.
+    pub action: PoisonAction,
+}
+
+/// The umbrella policy attached to a run.
+#[derive(Debug, Clone, Default)]
+pub struct ResiliencePolicy {
+    /// Retry/backoff applied to sink-write, flush, and state-store I/O.
+    pub retry: RetryPolicy,
+    /// Optional circuit breaker.
+    pub circuit_breaker: Option<CircuitBreakerConfig>,
+    /// Optional poison-pill row handling (DLQ path only).
+    pub poison: Option<PoisonPolicy>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_policy_retries_all_classes() {
+        let p = RetryPolicy::default();
+        assert_eq!(p.max_attempts, 5);
+        assert!(p.is_retriable(&FaucetError::HttpStatus {
+            status: 500, url: "u".into(), body: "".into()
+        }));
+        assert!(!p.is_retriable(&FaucetError::Auth("x".into())));
+    }
+
+    #[test]
+    fn restricted_retry_on_excludes_unlisted_classes() {
+        let p = RetryPolicy {
+            retry_on: RetryClassSet::from_iter([RetryClass::Http5xx]),
+            ..RetryPolicy::default()
+        };
+        assert!(p.is_retriable(&FaucetError::HttpStatus {
+            status: 500, url: "u".into(), body: "".into()
+        }));
+        // 429 classifies RateLimited, which is not opted in.
+        assert!(!p.is_retriable(&FaucetError::HttpStatus {
+            status: 429, url: "u".into(), body: "".into()
+        }));
+    }
+
+    #[test]
+    fn backoff_none_is_zero_fixed_is_constant_exp_grows() {
+        let base = Duration::from_millis(100);
+        let max = Duration::from_secs(10);
+        assert_eq!(BackoffKind::None.delay(base, max, 0), Duration::ZERO);
+        assert_eq!(BackoffKind::Fixed.delay(base, max, 3), base);
+        assert_eq!(BackoffKind::Exponential.delay(base, max, 0), base);
+        assert_eq!(BackoffKind::Exponential.delay(base, max, 2), base * 4);
+        // capped at max
+        assert_eq!(BackoffKind::Exponential.delay(base, max, 30), max);
+    }
+}

--- a/crates/core/src/resilience/policy.rs
+++ b/crates/core/src/resilience/policy.rs
@@ -22,9 +22,7 @@ impl BackoffKind {
         match self {
             BackoffKind::None => Duration::ZERO,
             BackoffKind::Fixed => base.min(max),
-            BackoffKind::Exponential => base
-                .saturating_mul(2u32.saturating_pow(attempt))
-                .min(max),
+            BackoffKind::Exponential => base.saturating_mul(2u32.saturating_pow(attempt)).min(max),
         }
     }
 }
@@ -118,7 +116,9 @@ mod tests {
         let p = RetryPolicy::default();
         assert_eq!(p.max_attempts, 5);
         assert!(p.is_retriable(&FaucetError::HttpStatus {
-            status: 500, url: "u".into(), body: "".into()
+            status: 500,
+            url: "u".into(),
+            body: "".into()
         }));
         assert!(!p.is_retriable(&FaucetError::Auth("x".into())));
     }
@@ -130,11 +130,15 @@ mod tests {
             ..RetryPolicy::default()
         };
         assert!(p.is_retriable(&FaucetError::HttpStatus {
-            status: 500, url: "u".into(), body: "".into()
+            status: 500,
+            url: "u".into(),
+            body: "".into()
         }));
         // 429 classifies RateLimited, which is not opted in.
         assert!(!p.is_retriable(&FaucetError::HttpStatus {
-            status: 429, url: "u".into(), body: "".into()
+            status: 429,
+            url: "u".into(),
+            body: "".into()
         }));
     }
 

--- a/crates/core/src/resilience/policy.rs
+++ b/crates/core/src/resilience/policy.rs
@@ -1,7 +1,7 @@
 //! Configuration value types for the resilience policy.
 
 use crate::error::FaucetError;
-use crate::resilience::classify::{RetryClass, RetryClassSet, classify};
+use crate::resilience::classify::{RetryClassSet, classify};
 use std::time::Duration;
 
 /// How the inter-attempt delay grows.
@@ -111,6 +111,7 @@ pub struct ResiliencePolicy {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::resilience::classify::RetryClass;
 
     #[test]
     fn default_policy_retries_all_classes() {

--- a/crates/core/src/retry.rs
+++ b/crates/core/src/retry.rs
@@ -99,6 +99,14 @@ fn jitter_factor(nanos: u32) -> f64 {
     0.5 + (nanos as f64 / 1_000_000_000.0)
 }
 
+/// Apply the same `[0.5, 1.5)` decorrelated jitter used by [`backoff_with_jitter`]
+/// to an already-computed delay. Used by the resilience runner, which computes
+/// the base delay from its own [`BackoffKind`](crate::resilience::BackoffKind).
+pub(crate) fn apply_jitter(delay: std::time::Duration) -> std::time::Duration {
+    let nanos = delay.as_nanos() as u64;
+    std::time::Duration::from_nanos((nanos as f64 * pseudo_random_factor()) as u64)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/core/src/retry.rs
+++ b/crates/core/src/retry.rs
@@ -24,29 +24,22 @@ const MAX_BACKOFF: Duration = Duration::from_secs(60);
 pub async fn execute_with_retry<F, Fut, T>(
     max_retries: u32,
     base_backoff: Duration,
-    mut operation: F,
+    operation: F,
 ) -> Result<T, FaucetError>
 where
     F: FnMut() -> Fut,
     Fut: Future<Output = Result<T, FaucetError>>,
 {
-    let mut attempt = 0u32;
-    loop {
-        match operation().await {
-            Ok(val) => return Ok(val),
-            Err(e) if e.is_retriable() && attempt < max_retries => {
-                let wait = backoff_with_jitter(base_backoff, attempt);
-                tracing::warn!(
-                    "request failed (attempt {}/{}), retrying in {wait:?}: {e}",
-                    attempt + 1,
-                    max_retries + 1
-                );
-                tokio::time::sleep(wait).await;
-                attempt += 1;
-            }
-            Err(e) => return Err(e),
-        }
-    }
+    let policy = crate::resilience::RetryPolicy {
+        // max_attempts is total tries; legacy `max_retries` is retries-after-first.
+        max_attempts: max_retries.saturating_add(1),
+        backoff: crate::resilience::BackoffKind::Exponential,
+        base: base_backoff,
+        max: MAX_BACKOFF,
+        jitter: true,
+        retry_on: crate::resilience::RetryClassSet::default(),
+    };
+    crate::resilience::execute_with_policy(&policy, None, operation).await
 }
 
 /// `base * 2^attempt`, capped at `MAX_BACKOFF` (60s), scaled by a random factor

--- a/crates/source/graphql/README.md
+++ b/crates/source/graphql/README.md
@@ -298,7 +298,7 @@ To share one token across many sources, build a provider and inject it with `Gra
 
 1. `new()` builds the `reqwest::Client` **once** and reuses it for every request.
 2. Each request merges static `variables`, the current cursor (into `cursor_variable`), the page-size value (into `page_size_variable`, unless `batch_size = 0`), and any parent-record context values into the GraphQL variables map.
-3. The POST is retried up to 3 times with exponential backoff + jitter (500 ms base) on retriable HTTP failures.
+3. The POST is retried up to 3 times with exponential backoff + jitter (500 ms base) on retriable HTTP failures. When driven by the CLI, a pipeline-level [`resilience:`](https://pawansikawat.github.io/faucet-stream/cookbook/resilience.html) block replaces these built-in retry defaults with one shared policy — GraphQL honors the policy's `max_attempts`, `base`, `max`, `jitter`, and `retry_on` in full.
 4. `records_path` extracts the record array via JSONPath; the page is yielded immediately.
 5. Pagination advances by reading `hasNextPage` / `endCursor`, stopping on a false flag, an absent or repeated cursor (loop guard), or `max_pages`.
 

--- a/crates/source/graphql/src/stream.rs
+++ b/crates/source/graphql/src/stream.rs
@@ -248,19 +248,18 @@ impl GraphqlStream {
         // backoff, matching the REST source's reliability layer (#78/#16).
         // GraphQL-level `errors` in a 200 body are application errors and are
         // handled below — they are not retried here.
-        let body: Value =
-            faucet_core::execute_with_policy(&self.retry_policy, None, || {
-                let attempt = req.try_clone();
-                async move {
-                    let req = attempt.ok_or_else(|| {
-                        FaucetError::Source("graphql: request is not cloneable for retry".into())
-                    })?;
-                    let resp = req.send().await.map_err(FaucetError::Http)?;
-                    let resp = util::check_http_response(resp, DEFAULT_ERROR_BODY_MAX_LEN).await?;
-                    resp.json().await.map_err(FaucetError::Http)
-                }
-            })
-            .await?;
+        let body: Value = faucet_core::execute_with_policy(&self.retry_policy, None, || {
+            let attempt = req.try_clone();
+            async move {
+                let req = attempt.ok_or_else(|| {
+                    FaucetError::Source("graphql: request is not cloneable for retry".into())
+                })?;
+                let resp = req.send().await.map_err(FaucetError::Http)?;
+                let resp = util::check_http_response(resp, DEFAULT_ERROR_BODY_MAX_LEN).await?;
+                resp.json().await.map_err(FaucetError::Http)
+            }
+        })
+        .await?;
 
         // Check for GraphQL-level errors.
         if let Some(errors) = body.get("errors")

--- a/crates/source/graphql/src/stream.rs
+++ b/crates/source/graphql/src/stream.rs
@@ -25,6 +25,10 @@ pub struct GraphqlStream {
     /// auth. Used by the CLI to resolve `auth: { ref }`, and by library callers
     /// who construct one provider and inject it into many sources.
     auth_provider: Option<SharedAuthProvider>,
+    /// Retry policy for transient request failures. Defaulted in `new()` to
+    /// reproduce the legacy `RETRY_MAX_ATTEMPTS` / `RETRY_BASE_BACKOFF`
+    /// constants; overridable via [`with_retry_policy`](Self::with_retry_policy).
+    retry_policy: faucet_core::RetryPolicy,
 }
 
 /// Map a [`Credential`] from a shared provider onto the GraphQL [`GraphqlAuth`]
@@ -58,7 +62,27 @@ impl GraphqlStream {
             config,
             client: Client::new(),
             auth_provider: None,
+            // Reproduce the legacy `execute_with_retry(RETRY_MAX_ATTEMPTS,
+            // RETRY_BASE_BACKOFF, …)` behavior exactly: `max_retries` is
+            // retries-after-first, so `max_attempts = RETRY_MAX_ATTEMPTS + 1`.
+            retry_policy: faucet_core::RetryPolicy {
+                max_attempts: RETRY_MAX_ATTEMPTS + 1,
+                backoff: faucet_core::BackoffKind::Exponential,
+                base: RETRY_BASE_BACKOFF,
+                max: Duration::from_secs(60),
+                jitter: true,
+                retry_on: faucet_core::RetryClassSet::default(),
+            },
         }
+    }
+
+    /// Attach a custom [`RetryPolicy`](faucet_core::RetryPolicy) for transient
+    /// request failures, replacing the default derived from
+    /// `RETRY_MAX_ATTEMPTS` / `RETRY_BASE_BACKOFF`. Used by the CLI to inject a
+    /// pipeline-level `resilience:` policy into the source.
+    pub fn with_retry_policy(mut self, policy: faucet_core::RetryPolicy) -> Self {
+        self.retry_policy = policy;
+        self
     }
 
     /// Attach a shared [`AuthProvider`](faucet_core::AuthProvider). When set, the
@@ -225,7 +249,7 @@ impl GraphqlStream {
         // GraphQL-level `errors` in a 200 body are application errors and are
         // handled below — they are not retried here.
         let body: Value =
-            faucet_core::execute_with_retry(RETRY_MAX_ATTEMPTS, RETRY_BASE_BACKOFF, || {
+            faucet_core::execute_with_policy(&self.retry_policy, None, || {
                 let attempt = req.try_clone();
                 async move {
                     let req = attempt.ok_or_else(|| {
@@ -550,5 +574,31 @@ mod tests {
             "query { id }",
         ));
         assert_eq!(stream.dataset_uri(), "https://api.example.com/graphql");
+    }
+
+    #[test]
+    fn default_retry_policy_reproduces_legacy_constants() {
+        let stream = GraphqlStream::new(GraphqlStreamConfig::new(
+            "https://api.example.com/graphql",
+            "query { id }",
+        ));
+        assert_eq!(stream.retry_policy.max_attempts, RETRY_MAX_ATTEMPTS + 1);
+        assert_eq!(stream.retry_policy.base, RETRY_BASE_BACKOFF);
+    }
+
+    #[test]
+    fn with_retry_policy_overrides_the_default() {
+        let policy = faucet_core::RetryPolicy {
+            max_attempts: 9,
+            base: Duration::from_secs(7),
+            ..faucet_core::RetryPolicy::default()
+        };
+        let stream = GraphqlStream::new(GraphqlStreamConfig::new(
+            "https://api.example.com/graphql",
+            "query { id }",
+        ))
+        .with_retry_policy(policy);
+        assert_eq!(stream.retry_policy.max_attempts, 9);
+        assert_eq!(stream.retry_policy.base, Duration::from_secs(7));
     }
 }

--- a/crates/source/rest/README.md
+++ b/crates/source/rest/README.md
@@ -104,6 +104,12 @@ faucet run pipeline.yaml
 
 A **`204 No Content`** response — or any `2xx` with an empty/whitespace-only body — is treated as an empty page ("no data"), not a parse error. A non-empty body that isn't valid JSON still fails loudly with `FaucetError::Json`.
 
+#### Unified `resilience:` policy
+
+When driven by the CLI, a pipeline-level [`resilience:`](https://pawansikawat.github.io/faucet-stream/cookbook/resilience.html) block can inject one shared retry policy into this source. **Legacy fields win when set explicitly:** if you set `max_retries` or `retry_backoff` to anything other than their defaults (`3` / `1`), the per-connector value is used and the injected policy is ignored for that field — an explicit setting is never silently overridden. Otherwise the injected policy applies.
+
+Because the REST source keeps its own `429`/`Retry-After`-aware retry runner, it honors **only** the injected policy's `max_attempts` (→ `max_retries`) and `base` (→ `retry_backoff`). The policy's `retry_on`, `max` (per-sleep cap), and `jitter` fields are **inert on REST** — they are honored on the `xml`/`graphql` sources and on every sink-side write.
+
 ### Replication & state
 
 | Field | Type | Default | Description |

--- a/crates/source/rest/src/config.rs
+++ b/crates/source/rest/src/config.rs
@@ -45,7 +45,20 @@ pub struct RestStreamConfig {
     #[serde(with = "faucet_core::config::duration_secs_option", default)]
     #[schemars(with = "Option<u64>")]
     pub timeout: Option<Duration>,
+    /// Number of retries (after the first attempt) for transient request
+    /// failures. Default `3`.
+    ///
+    /// **Precedence note:** the REST source predates the unified pipeline
+    /// `resilience:` policy. When this field (or [`retry_backoff`](Self::retry_backoff))
+    /// is left at its default, an injected `RetryPolicy` (e.g. from a
+    /// pipeline-level `resilience:` block, via
+    /// [`RestStream::with_retry_policy`](crate::RestStream::with_retry_policy))
+    /// governs the retry budget. Setting this field away from its default makes
+    /// it win — an explicit per-connector value is never silently overridden by
+    /// a pipeline-wide default.
     pub max_retries: u32,
+    /// Base exponential-backoff delay between retries. Default `1s`. Shares the
+    /// legacy-field precedence rule documented on [`max_retries`](Self::max_retries).
     #[serde(with = "faucet_core::config::duration_secs")]
     #[schemars(with = "u64")]
     pub retry_backoff: Duration,

--- a/crates/source/rest/src/stream.rs
+++ b/crates/source/rest/src/stream.rs
@@ -42,7 +42,23 @@ pub struct RestStream {
     /// [`Source::apply_start_bookmark`](faucet_core::Source::apply_start_bookmark).
     /// Takes precedence over `config.start_replication_value` when set.
     runtime_start: Arc<AsyncMutex<Option<Value>>>,
+    /// Retry policy for transient request failures. Built in `new()` from the
+    /// REST source's own `config.max_retries` / `config.retry_backoff`. Fed into
+    /// the REST `retry::execute_with_retry` runner (which keeps its 429 /
+    /// `Retry-After` handling). Overridable via
+    /// [`with_retry_policy`](Self::with_retry_policy) — but the REST connector's
+    /// own legacy `max_retries` / `retry_backoff` fields take precedence when the
+    /// user has set them away from their defaults.
+    retry_policy: faucet_core::RetryPolicy,
 }
+
+/// Default value of [`RestStreamConfig::max_retries`]. When the user leaves this
+/// untouched, an injected [`RetryPolicy`](faucet_core::RetryPolicy) is allowed to
+/// override it (see [`RestStream::with_retry_policy`]).
+const DEFAULT_MAX_RETRIES: u32 = 3;
+/// Default value of [`RestStreamConfig::retry_backoff`]. Same precedence rule as
+/// [`DEFAULT_MAX_RETRIES`].
+const DEFAULT_RETRY_BACKOFF: Duration = Duration::from_secs(1);
 
 /// Map a [`Credential`] from a shared provider onto the REST [`Auth`]
 /// representation so the existing header-application path can be reused.
@@ -80,6 +96,16 @@ impl RestStream {
         if let Some(t) = config.timeout {
             builder = builder.timeout(t);
         }
+        // Build the default retry policy from REST's own legacy reliability
+        // fields so behavior is unchanged when no policy is injected. The REST
+        // `retry::execute_with_retry` runner is driven by `max_retries`
+        // (retries-after-first) + `base`, so `max_attempts = max_retries + 1`.
+        let retry_policy = faucet_core::RetryPolicy {
+            max_attempts: config.max_retries.saturating_add(1),
+            backoff: faucet_core::BackoffKind::Exponential,
+            base: config.retry_backoff,
+            ..faucet_core::RetryPolicy::default()
+        };
         Ok(Self {
             config,
             client: builder.build()?,
@@ -87,6 +113,7 @@ impl RestStream {
             token_endpoint_cache: TokenEndpointCache::new(),
             auth_provider: None,
             runtime_start: Arc::new(AsyncMutex::new(None)),
+            retry_policy,
         })
     }
 
@@ -98,6 +125,26 @@ impl RestStream {
     /// sources.
     pub fn with_auth_provider(mut self, provider: SharedAuthProvider) -> Self {
         self.auth_provider = Some(provider);
+        self
+    }
+
+    /// Attach a custom [`RetryPolicy`](faucet_core::RetryPolicy) for transient
+    /// request failures, used by the CLI to inject a pipeline-level
+    /// `resilience:` policy.
+    ///
+    /// **Legacy-field precedence:** the REST connector predates the unified
+    /// resilience policy and exposes its own `max_retries` / `retry_backoff`
+    /// config fields. If the user has set either of those away from its default
+    /// (`max_retries: 3`, `retry_backoff: 1s`), those explicit values win and the
+    /// injected `policy` is ignored — an explicit per-connector setting is never
+    /// silently overridden by a pipeline-wide default. When both fields are at
+    /// their defaults, the injected policy takes effect.
+    pub fn with_retry_policy(mut self, policy: faucet_core::RetryPolicy) -> Self {
+        let user_changed_legacy_fields = self.config.max_retries != DEFAULT_MAX_RETRIES
+            || self.config.retry_backoff != DEFAULT_RETRY_BACKOFF;
+        if !user_changed_legacy_fields {
+            self.retry_policy = policy;
+        }
         self
     }
 
@@ -311,8 +358,13 @@ impl RestStream {
                 let ctx_ref = owned_context.as_ref();
                 let is_first_page = pages_fetched == 0;
                 let (body, resp_headers) = retry::execute_with_retry(
-                    self.config.max_retries,
-                    self.config.retry_backoff,
+                    // The REST runner takes retries-after-first; the policy holds
+                    // total attempts. Feed both knobs from the resolved policy so
+                    // an injected `resilience:` policy (when legacy fields are
+                    // untouched) governs the retry budget + base backoff while the
+                    // runner keeps its 429 / `Retry-After` handling.
+                    self.retry_policy.max_attempts.saturating_sub(1),
+                    self.retry_policy.base,
                     || {
                         self.execute_request(
                             &params_clone,
@@ -757,6 +809,40 @@ impl faucet_core::Source for RestStream {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn injected_policy_applies_when_legacy_fields_at_defaults() {
+        // Config left at the default max_retries/retry_backoff → injection wins.
+        let stream =
+            RestStream::new(RestStreamConfig::new("https://api.example.com", "/items")).unwrap();
+        let injected = faucet_core::RetryPolicy {
+            max_attempts: 9,
+            base: Duration::from_secs(7),
+            ..faucet_core::RetryPolicy::default()
+        };
+        let stream = stream.with_retry_policy(injected);
+        assert_eq!(stream.retry_policy.max_attempts, 9);
+        assert_eq!(stream.retry_policy.base, Duration::from_secs(7));
+    }
+
+    #[test]
+    fn legacy_fields_take_precedence_over_injected_policy() {
+        // User set max_retries explicitly → the injected policy is ignored and
+        // the connector's own legacy fields keep governing retries.
+        let config = RestStreamConfig::new("https://api.example.com", "/items").max_retries(7);
+        let stream = RestStream::new(config).unwrap();
+        // Default policy derived from legacy fields: max_attempts = 7 + 1.
+        assert_eq!(stream.retry_policy.max_attempts, 8);
+        let injected = faucet_core::RetryPolicy {
+            max_attempts: 99,
+            base: Duration::from_secs(42),
+            ..faucet_core::RetryPolicy::default()
+        };
+        let stream = stream.with_retry_policy(injected);
+        // Unchanged: the legacy max_retries(7) still wins.
+        assert_eq!(stream.retry_policy.max_attempts, 8);
+        assert_eq!(stream.retry_policy.base, DEFAULT_RETRY_BACKOFF);
+    }
 
     #[test]
     fn test_substitute_context_substitutes_placeholders() {

--- a/crates/source/rest/src/stream.rs
+++ b/crates/source/rest/src/stream.rs
@@ -139,6 +139,13 @@ impl RestStream {
     /// injected `policy` is ignored — an explicit per-connector setting is never
     /// silently overridden by a pipeline-wide default. When both fields are at
     /// their defaults, the injected policy takes effect.
+    ///
+    /// **Inert fields on REST:** because the REST source keeps its own
+    /// `429`/`Retry-After`-aware retry runner, it honors only the injected
+    /// policy's `max_attempts` (→ `max_retries`) and `base` (→ `retry_backoff`).
+    /// The policy's `max` (per-sleep cap), `jitter`, and `retry_on` fields are
+    /// **not** honored here — they apply on the `xml`/`graphql` sources and on
+    /// every sink-side write.
     pub fn with_retry_policy(mut self, policy: faucet_core::RetryPolicy) -> Self {
         let user_changed_legacy_fields = self.config.max_retries != DEFAULT_MAX_RETRIES
             || self.config.retry_backoff != DEFAULT_RETRY_BACKOFF;

--- a/crates/source/xml/README.md
+++ b/crates/source/xml/README.md
@@ -292,7 +292,7 @@ To wire it into a pipeline, hand the `XmlStream` to `faucet_core::Pipeline` (bat
 ## How it works
 
 1. `new()` builds the `reqwest` client **once** and stores it on the struct.
-2. Each page issues one request (`base_url + path` with `query_params` + the pagination param), retried up to **3 times** with exponential backoff (base 500 ms) on transient failures via `faucet_core::execute_with_retry`. Non-cloneable request bodies are not retried (surfaced as `FaucetError::Source`).
+2. Each page issues one request (`base_url + path` with `query_params` + the pagination param), retried up to **3 times** with exponential backoff (base 500 ms) on transient failures via `faucet_core::execute_with_retry`. Non-cloneable request bodies are not retried (surfaced as `FaucetError::Source`). When driven by the CLI, a pipeline-level [`resilience:`](https://pawansikawat.github.io/faucet-stream/cookbook/resilience.html) block replaces these built-in retry defaults with one shared policy — XML honors the policy's `max_attempts`, `base`, `max`, `jitter`, and `retry_on` in full.
 3. The response is converted XML → JSON and `records_element_path` is walked to find the repeating element.
 4. Records are buffered and yielded as `StreamPage`s of `batch_size`; pagination advances until the stop condition or `max_pages`.
 

--- a/crates/source/xml/src/stream.rs
+++ b/crates/source/xml/src/stream.rs
@@ -42,6 +42,10 @@ pub struct XmlStream {
     /// refresh. Used by the CLI to resolve `auth: { ref }`, and by library
     /// callers who construct one provider and inject it into many sources.
     auth_provider: Option<SharedAuthProvider>,
+    /// Retry policy for transient request failures. Defaulted in `new()` to
+    /// reproduce the legacy `RETRY_MAX_ATTEMPTS` / `RETRY_BASE_BACKOFF`
+    /// constants; overridable via [`with_retry_policy`](Self::with_retry_policy).
+    retry_policy: faucet_core::RetryPolicy,
 }
 
 /// Map a [`Credential`] from a shared provider onto the XML [`XmlAuth`]
@@ -66,7 +70,27 @@ impl XmlStream {
             config,
             client: Client::new(),
             auth_provider: None,
+            // Reproduce the legacy `execute_with_retry(RETRY_MAX_ATTEMPTS,
+            // RETRY_BASE_BACKOFF, …)` behavior exactly: `max_retries` is
+            // retries-after-first, so `max_attempts = RETRY_MAX_ATTEMPTS + 1`.
+            retry_policy: faucet_core::RetryPolicy {
+                max_attempts: RETRY_MAX_ATTEMPTS + 1,
+                backoff: faucet_core::BackoffKind::Exponential,
+                base: RETRY_BASE_BACKOFF,
+                max: Duration::from_secs(60),
+                jitter: true,
+                retry_on: faucet_core::RetryClassSet::default(),
+            },
         }
+    }
+
+    /// Attach a custom [`RetryPolicy`](faucet_core::RetryPolicy) for transient
+    /// request failures, replacing the default derived from
+    /// `RETRY_MAX_ATTEMPTS` / `RETRY_BASE_BACKOFF`. Used by the CLI to inject a
+    /// pipeline-level `resilience:` policy into the source.
+    pub fn with_retry_policy(mut self, policy: faucet_core::RetryPolicy) -> Self {
+        self.retry_policy = policy;
+        self
     }
 
     /// Attach a shared [`AuthProvider`](faucet_core::AuthProvider). When set,
@@ -287,7 +311,7 @@ impl XmlStream {
         // Retry transient failures (5xx / connection resets) with jittered
         // backoff, matching the REST source's reliability layer (#78/#16).
         // The request body is a String, so `try_clone` always succeeds.
-        faucet_core::execute_with_retry(RETRY_MAX_ATTEMPTS, RETRY_BASE_BACKOFF, || {
+        faucet_core::execute_with_policy(&self.retry_policy, None, || {
             let attempt = req.try_clone();
             async move {
                 let req = attempt.ok_or_else(|| {
@@ -483,5 +507,25 @@ mod tests {
             "/svc",
         ));
         assert_eq!(source.dataset_uri(), "https://soap.example.com/svc");
+    }
+
+    #[test]
+    fn default_retry_policy_reproduces_legacy_constants() {
+        let source = XmlStream::new(XmlStreamConfig::new("https://soap.example.com", "/svc"));
+        assert_eq!(source.retry_policy.max_attempts, RETRY_MAX_ATTEMPTS + 1);
+        assert_eq!(source.retry_policy.base, RETRY_BASE_BACKOFF);
+    }
+
+    #[test]
+    fn with_retry_policy_overrides_the_default() {
+        let policy = faucet_core::RetryPolicy {
+            max_attempts: 9,
+            base: Duration::from_secs(7),
+            ..faucet_core::RetryPolicy::default()
+        };
+        let source = XmlStream::new(XmlStreamConfig::new("https://soap.example.com", "/svc"))
+            .with_retry_policy(policy);
+        assert_eq!(source.retry_policy.max_attempts, 9);
+        assert_eq!(source.retry_policy.base, Duration::from_secs(7));
     }
 }

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -23,6 +23,7 @@
 - [Upsert / mirror tables](./cookbook/upsert.md)
 - [Replication (snapshot → CDC)](./cookbook/replication.md)
 - [Dead-letter queues](./cookbook/dlq.md)
+- [Resilience (retry / circuit breaker / poison-pill)](./cookbook/resilience.md)
 - [Data-quality checks](./cookbook/quality.md)
 - [Compression](./cookbook/compression.md)
 - [Record transforms](./cookbook/transforms.md)

--- a/docs/book/src/cookbook/resilience.md
+++ b/docs/book/src/cookbook/resilience.md
@@ -1,0 +1,137 @@
+# Resilience: retry, circuit breaker, and poison-pill
+
+The top-level `resilience:` block gives a pipeline one declarative place to say
+how it should behave under transient and persistent failure. It is **fully
+opt-in**: with no `resilience:` block a pipeline behaves exactly as before — no
+sink-write retry, and source connectors keep their built-in retry defaults.
+
+```yaml
+resilience:
+  retry:
+    max_attempts: 5            # total tries including the first (1 = no retry)
+    backoff: exponential       # none | fixed | exponential
+    base_ms: 200
+    max_ms: 30000              # per-sleep cap, before jitter
+    jitter: true
+  retry_on: [http_5xx, rate_limited, connection, timeout]
+  circuit_breaker:
+    consecutive_failures: 5
+    cooldown_secs: 60
+  poison:
+    max_row_attempts: 3
+    action: dlq                # dlq | drop | fail
+```
+
+A runnable example lives at `cli/examples/rest_to_jsonl_resilient.yaml`.
+
+## What the policy wraps
+
+The policy is applied at two layers:
+
+- **Sink side (the pipeline loop):** every sink write (`write_batch` /
+  `write_batch_partial` / `write_batch_idempotent`), `flush`, and state-store
+  `put` is wrapped with retry + the circuit breaker. This covers the default,
+  exactly-once, and DLQ write paths.
+- **Source side (the connector):** the `retry` policy is injected into the
+  connectors that retry their own requests (`rest`, `xml`, `graphql`), replacing
+  their ad-hoc retry settings with one shared configuration.
+
+> The pipeline cannot retry a *source page-poll* itself — once a streaming
+> source yields an error mid-stream, the page cannot be replayed by re-polling.
+> Source-side retry therefore lives inside the connector, governed by the same
+> `retry` policy.
+
+## `retry`
+
+| Field | Default | Meaning |
+|-------|---------|---------|
+| `max_attempts` | `5` | Total attempts including the first. `1` disables retry. |
+| `backoff` | `exponential` | `none` (no delay), `fixed` (constant `base_ms`), or `exponential` (`base_ms * 2^attempt`). |
+| `base_ms` | `200` | Base delay. |
+| `max_ms` | `30000` | Per-sleep cap (before jitter). |
+| `jitter` | `true` | Apply `[0.5, 1.5)` decorrelated jitter to each sleep. |
+
+### `retry_on`
+
+The set of transient error classes that are retried. Anything not in the set
+(and anything that doesn't classify as transient — auth errors, config errors,
+JSON parse errors, 4xx other than 429) fails fast and is **never** retried.
+
+| Class | Matches |
+|-------|---------|
+| `http_5xx` | HTTP 5xx server errors |
+| `rate_limited` | HTTP 429 / rate-limit signals |
+| `connection` | connection-level failures (DNS, refused, reset) |
+| `timeout` | request timeouts |
+
+Default (omit `retry_on`) = all four. An empty list is rejected at config load.
+
+## `circuit_breaker`
+
+Counts **consecutive fully-failed pages** (a page whose write ultimately failed
+after retries). A page with any success resets the counter. When the count
+reaches `consecutive_failures`, the run **fails fast** with a `CircuitOpen`
+error rather than continuing.
+
+This only changes behavior on the DLQ / poison path — without a DLQ the first
+exhausted-retry write already aborts the run. Its real job is to stop a wedged
+destination from silently draining the entire source into the dead-letter queue.
+
+`cooldown_secs` is **advisory for the orchestration layer**: when a
+[`faucet schedule`](../reference/cli.md) run fails with `CircuitOpen`, the
+scheduler waits at least `cooldown_secs` before the next tick. A one-shot
+`faucet run` simply exits non-zero; `faucet serve` records the run as failed
+(no automatic re-run).
+
+## `poison`
+
+Per-row handling for the DLQ path. When `write_batch_partial` reports individual
+row failures, the still-failing, retriable rows are re-submitted up to
+`max_row_attempts` times before the terminal `action` is applied:
+
+| `action` | Effect |
+|----------|--------|
+| `dlq` | Route the row to the DLQ (the default). **Requires a `dlq:` block** — validated at config load. |
+| `drop` | Discard the row (counted; logged once per run). |
+| `fail` | Propagate the row error and abort the run. |
+
+## Composition
+
+- **Exactly-once delivery** — retry wraps `write_batch_idempotent`; a retried
+  idempotent write is safe because the commit token makes it idempotent.
+- **Adaptive batch sizing** — retry wraps each adaptive chunk; the breaker
+  counts page-level failures.
+- **Cancellation** — a backoff sleep is abandoned immediately on a shutdown /
+  timeout cancel, so the policy never wedges a graceful drain.
+
+## REST precedence
+
+The `rest` source predates this unified policy and has its own `max_retries` /
+`retry_backoff` config fields. When you leave both at their defaults
+(`max_retries: 3`, `retry_backoff: 1s`), the pipeline `resilience.retry` policy
+governs the REST source. If you set either field explicitly, the per-connector
+value wins — an explicit setting is never silently overridden by a pipeline-wide
+default. (Because REST keeps its own 429/`Retry-After`-aware runner, only the
+policy's `max_attempts` and `base` apply to REST; `retry_on`/`max`/`jitter` are
+honored on the `xml`/`graphql` sources and on every sink-side write.)
+
+## Metrics
+
+| Metric | Type | Labels |
+|--------|------|--------|
+| `faucet_resilience_retries_total` | counter | `pipeline, row, op, class` |
+| `faucet_resilience_retry_sleep_seconds` | histogram | `pipeline, row, op` |
+| `faucet_resilience_giveup_total` | counter | `pipeline, row, op` |
+| `faucet_resilience_circuit_state` | gauge (0/1) | `pipeline, row` |
+| `faucet_resilience_circuit_opened_total` | counter | `pipeline, row` |
+| `faucet_resilience_poison_rows_total` | counter | `pipeline, row, action` |
+
+`op` is one of `sink_write`, `flush`, `state_put`. Source-connector retries are
+observable through the connector's existing `faucet_source_errors_total` and
+tracing output rather than these metrics.
+
+## Inspecting the schema
+
+```bash
+faucet schema resilience
+```

--- a/docs/book/src/cookbook/resilience.md
+++ b/docs/book/src/cookbook/resilience.md
@@ -83,6 +83,10 @@ scheduler waits at least `cooldown_secs` before the next tick. A one-shot
 `faucet run` simply exits non-zero; `faucet serve` records the run as failed
 (no automatic re-run).
 
+> The cooldown only delays the scheduler's next cron-tick re-entry. An overlap
+> run that is **already queued** (`overlap: queue`) starts immediately when the
+> active run finishes — it is not delayed by the cooldown.
+
 ## `poison`
 
 Per-row handling for the DLQ path. When `write_batch_partial` reports individual

--- a/docs/book/src/reference/config.md
+++ b/docs/book/src/reference/config.md
@@ -330,6 +330,52 @@ See the [Adaptive batching cookbook](../cookbook/adaptive-batching.md) for a
 full worked example, the AIMD trajectory, and the four Prometheus metrics
 (`faucet_pipeline_adaptive_batch_*`).
 
+## `resilience`
+
+Optional top-level block giving the pipeline one declarative place to configure
+retry, a circuit breaker, and per-row poison-pill handling. Fully opt-in: with
+no `resilience:` block, sink writes are not retried and source connectors keep
+their built-in retry defaults. See the
+[Resilience cookbook](../cookbook/resilience.md) for the full model, composition
+notes, and metrics.
+
+```yaml
+resilience:
+  retry:
+    max_attempts: 5            # total tries including the first (1 = no retry)
+    backoff: exponential       # none | fixed | exponential
+    base_ms: 200
+    max_ms: 30000              # per-sleep cap, before jitter
+    jitter: true
+  retry_on: [http_5xx, rate_limited, connection, timeout]
+  circuit_breaker:
+    consecutive_failures: 5
+    cooldown_secs: 60
+  poison:
+    max_row_attempts: 3
+    action: dlq                # dlq | drop | fail
+```
+
+- **`retry`** — `max_attempts` (default `5`; `1` disables retry), `backoff`
+  (`none` / `fixed` / `exponential`, default `exponential`), `base_ms` (default
+  `200`), `max_ms` (per-sleep cap, default `30000`), `jitter` (default `true`,
+  applies `[0.5, 1.5)` decorrelated jitter).
+- **`retry_on`** — the transient error classes that are retried:
+  `http_5xx` (HTTP 5xx), `rate_limited` (HTTP 429 / rate-limit signals),
+  `connection` (DNS / refused / reset), `timeout` (request timeouts). Omit for
+  all four; an empty list is rejected at config load.
+- **`circuit_breaker`** — `consecutive_failures` consecutive fully-failed pages
+  open the breaker and fail the run with a `CircuitOpen` error;
+  `cooldown_secs` is advisory for `faucet schedule` (delays the next cron tick).
+- **`poison`** — per-row DLQ-path handling: `max_row_attempts` re-submits a
+  still-failing retriable row before the terminal `action` — `dlq` (requires a
+  `dlq:` block), `drop`, or `fail`.
+
+The `rest` source's legacy `max_retries` / `retry_backoff` fields win when set
+explicitly; otherwise the injected policy's `max_attempts` + `base` apply (its
+`retry_on` / `max` / `jitter` are inert on REST, honored on `xml` / `graphql`
+and on every sink-side write).
+
 ## `replication`
 
 Present only when you run [`faucet replicate`](cli.md#replicate). It turns the


### PR DESCRIPTION
## Summary

Adds a unified, top-level **`resilience:` policy** — one declarative place to control how a pipeline behaves under transient and persistent failure. Reliability is faucet's stated #1 priority, but retry logic was previously fragmented (`core::retry`, the REST source's own 429 module, hardcoded constants in XML/GraphQL) with **no pipeline-level policy at all** — every sink/flush/state failure aborted the run on the first error.

The block is **fully opt-in**: with no `resilience:` block, behavior is byte-for-byte unchanged (no sink-write retry; sources keep their built-in defaults).

```yaml
resilience:
  retry:
    max_attempts: 5
    backoff: exponential       # none | fixed | exponential
    base_ms: 200
    max_ms: 30000
    jitter: true
  retry_on: [http_5xx, rate_limited, connection, timeout]
  circuit_breaker:
    consecutive_failures: 5
    cooldown_secs: 60
  poison:
    max_row_attempts: 3
    action: dlq                # dlq | drop | fail
```

## What's included

- **New `faucet-core::resilience` module** — `RetryPolicy`, `BackoffKind`, a `FaucetError → RetryClass` classifier (`http_5xx`/`rate_limited`/`connection`/`timeout`), `CircuitBreaker`, and `execute_with_policy` (+ a metered variant for the pipeline). `execute_with_retry` is reimplemented as a thin shim over it.
- **Pipeline integration** — `run_stream` retries every sink write / `flush` / state `put` across the default, exactly-once, and DLQ paths; the circuit breaker fails the run fast with `FaucetError::CircuitOpen` once a destination is wedged; poison-pill retries failing rows then routes them (`dlq`/`drop`/`fail`). Composes with exactly-once, adaptive batching, and cooperative cancellation.
- **Source unification** — `rest`, `xml`, `graphql` consume the shared `RetryPolicy` via an inherent `with_retry_policy(...)`. REST keeps its own `max_retries`/`retry_backoff` (legacy-field precedence) and its 429/`Retry-After` runner.
- **CLI** — `resilience:` config block with fail-fast validation; `faucet schema resilience`; `faucet schedule` honors the circuit-breaker `cooldown_secs` for re-entry.
- **Observability** — `faucet_resilience_{retries,retry_sleep_seconds,giveup,circuit_state,circuit_opened,poison_rows}_*` metrics.
- **Docs** — cookbook page, reference section, connector READMEs, and a runnable `cli/examples/rest_to_jsonl_resilient.yaml`.

## Key design decisions

- **Circuit open = fail fast** (`CircuitOpen`); `cooldown_secs` is advisory for the orchestration layer (`faucet schedule` delays re-entry).
- **Source retry is connector-internal.** The pipeline can't replay a failed source page-poll (streams are terminal after an error), so source-side retry lives inside `stream_pages`, governed by the same policy.
- **Resilience retry metrics are pipeline-side only** (`op ∈ {sink_write, flush, state_put}`); source retries surface via the existing `faucet_source_errors_total` + tracing.

## Testing

Per-slice TDD with spec + code-quality review on each of the 9 implementation groups. `cargo fmt --all --check` clean; the resilient example validates; full `clippy --all-features -D warnings` and `test --workspace --all-features` run in the final sweep.

Closes #191.

Part of the connector & runtime coverage roadmap (#38).
