### PR TITLE
feat(sink-kafka): exactly-once delivery via transactional producer (#216)

### DIFF
--- a/cli/examples/postgres_cdc_to_kafka_exactly_once.yaml
+++ b/cli/examples/postgres_cdc_to_kafka_exactly_once.yaml
@@ -21,8 +21,9 @@
 #
 # Then:
 #   export SOURCE_PG_URL=postgres://faucet:faucet@localhost:5432/appdb
-#   export KAFKA_BROKERS=localhost:9092
 #   faucet run cli/examples/postgres_cdc_to_kafka_exactly_once.yaml
+#
+# (Point `brokers` below at your cluster; it is a literal here for the example.)
 
 version: 1
 name: pg_cdc_to_kafka_eo
@@ -46,7 +47,7 @@ pipeline:
   sink:
     type: kafka
     config:
-      brokers: ${env:KAFKA_BROKERS}
+      brokers: "localhost:9092"
       topic:
         type: fixed
         name: orders_cdc

--- a/cli/examples/postgres_cdc_to_kafka_exactly_once.yaml
+++ b/cli/examples/postgres_cdc_to_kafka_exactly_once.yaml
@@ -1,0 +1,63 @@
+# End-to-end Postgres CDC -> Kafka, exactly-once.
+#
+# Streams logical-replication change events from a source database and produces
+# them onto a Kafka topic with end-to-end exactly-once delivery. The Kafka sink
+# uses a transactional producer: each page's records PLUS a commit-token record
+# are written into a compacted side-topic (`commit_token_topic`) inside ONE
+# Kafka transaction, so the data and the watermark commit atomically. On resume
+# the sink reads the latest token for its scope back from the side-topic and the
+# pipeline skips already-committed pages -> zero duplicates.
+#
+# The `transactional.id` is auto-derived from the pipeline scope (stable across
+# restarts, unique per matrix row) so a restart fences any prior producer.
+# Downstream consumers of `orders_cdc` should set
+# `isolation.level=read_committed` so they only ever see committed transactions.
+#
+# Setup on the SOURCE database (logical replication must be enabled):
+#   psql "$SOURCE_PG_URL" <<SQL
+#     CREATE TABLE IF NOT EXISTS orders (id int4 PRIMARY KEY, total numeric);
+#     CREATE PUBLICATION faucet_pub FOR TABLE orders;
+#   SQL
+#
+# Then:
+#   export SOURCE_PG_URL=postgres://faucet:faucet@localhost:5432/appdb
+#   export KAFKA_BROKERS=localhost:9092
+#   faucet run cli/examples/postgres_cdc_to_kafka_exactly_once.yaml
+
+version: 1
+name: pg_cdc_to_kafka_eo
+
+# Exactly-once delivery composes a CDC source + an idempotent (transactional)
+# sink + a state store with no DLQ. Each committed page and its monotonic commit
+# token land in one Kafka transaction, so a crash/resume never re-applies or
+# skips a page.
+delivery: exactly_once
+
+pipeline:
+  source:
+    type: postgres-cdc
+    config:
+      connection_url: ${env:SOURCE_PG_URL}
+      slot_name: faucet_kafka_eo
+      publication_name: faucet_pub
+      create_slot_if_missing: true
+      idle_timeout: 30
+
+  sink:
+    type: kafka
+    config:
+      brokers: ${env:KAFKA_BROKERS}
+      topic:
+        type: fixed
+        name: orders_cdc
+      value_format:
+        type: json
+      # exactly-once: transactional producer + compacted watermark side-topic
+      # (auto-created with cleanup.policy=compact). transactional.id is
+      # auto-derived from the pipeline scope.
+      commit_token_topic: __faucet_commit_token
+
+  state:
+    type: file
+    config:
+      path: ./.faucet-state/pg_cdc_to_kafka_eo

--- a/cli/src/registry.rs
+++ b/cli/src/registry.rs
@@ -363,7 +363,7 @@ pub fn source_supports_exactly_once(kind: &str) -> bool {
 pub fn sink_supports_idempotent_writes(kind: &str) -> bool {
     matches!(
         kind,
-        "sqlite" | "postgres" | "mysql" | "mssql" | "iceberg" | "bigquery"
+        "sqlite" | "postgres" | "mysql" | "mssql" | "iceberg" | "bigquery" | "kafka"
     )
 }
 
@@ -998,6 +998,7 @@ mod tests {
         assert!(sink_supports_idempotent_writes("postgres"));
         assert!(sink_supports_idempotent_writes("iceberg"));
         assert!(sink_supports_idempotent_writes("bigquery"));
+        assert!(sink_supports_idempotent_writes("kafka"));
         assert!(!sink_supports_idempotent_writes("jsonl"));
     }
 

--- a/crates/sink/kafka/README.md
+++ b/crates/sink/kafka/README.md
@@ -113,6 +113,17 @@ All fields are keys under `sink.config`.
 | `compression` | `"none" \| "gzip" \| "snappy" \| "lz4" \| "zstd"` | `"none"` | Producer-side compression codec. See [Compression](#compression). |
 | `extra_client_config` | object (string→string) | `{}` | Raw librdkafka client properties. **Overrides** anything set by `auth` or the typed fields above. |
 
+### Exactly-once
+
+These fields apply only under `delivery: exactly_once` (ignored otherwise). See [Exactly-once delivery](#exactly-once-delivery).
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `transactional_id_prefix` | string | `"faucet"` | Namespace prefix for the producer's auto-derived `transactional.id` (`"{prefix}.{sanitized_scope}"`). Set it to isolate transactional ids across clusters/environments that share a pipeline-scope namespace. |
+| `commit_token_topic` | string | `"__faucet_commit_token"` | Compacted side-topic that holds one commit-token record per pipeline scope. Auto-created with `cleanup.policy=compact` if absent. |
+| `commit_token_topic_partitions` | int | `1` | Partition count used when auto-creating `commit_token_topic`. Must be ≥ 1. |
+| `commit_token_topic_replication` | int | `-1` | Replication factor used when auto-creating `commit_token_topic`. `-1` means "use the broker default". |
+
 ## Topic routing
 
 `topic` is a `{ type, … }` discriminated value with two strategies:
@@ -294,7 +305,47 @@ When `batch_size > 0`, `KafkaSink::new` also sets librdkafka's `queue.buffering.
 
 Reach for `batch_size: 0` when a source emits its whole result set as a single page (small lookup tables, one-shot drains) and you want the entire write to fire in parallel without the extra cap.
 
-> **Not exactly-once.** This sink provides idempotent-producer de-duplication *within a producer session* (`idempotent: true`), not faucet-stream's cross-run exactly-once delivery — it does not implement `write_batch_idempotent` / `last_committed_token`. It is also **append-only**: there is no `write_mode` / upsert / delete (Kafka has no row identity to update). For end-to-end exactly-once, target a transactional sink (BigQuery, the SQL sinks, or Iceberg).
+> **Two delivery tiers.** `idempotent: true` (the default) de-duplicates retried produce calls *within a producer session* — fast, but it does not survive a faucet-stream crash/resume. For faucet-stream's cross-run **exactly-once** delivery (`delivery: exactly_once`), the sink runs a *transactional* producer that writes each page's records and a commit-token record into a compacted side-topic in one Kafka transaction — see [Exactly-once delivery](#exactly-once-delivery) below. The sink is **append-only** either way: there is no `write_mode` / upsert / delete (Kafka has no row identity to update).
+
+## Exactly-once delivery
+
+`KafkaSink` implements `Sink::supports_idempotent_writes` (returns `true`) and the two companion hooks:
+
+- `write_batch_idempotent(records, scope, token)` — a **transactional** producer writes the page's records **and** a commit-token record for `scope` into the compacted side-topic (`commit_token_topic`) inside a single Kafka transaction, so the data and the watermark commit atomically or not at all.
+- `last_committed_token(scope)` — reads the latest token for `scope` back from the side-topic so the pipeline skips already-committed pages on resume.
+
+The producer's `transactional.id` is auto-derived from the pipeline scope — stable across restarts and unique per matrix row — so a restart fences any prior producer. The side-topic is **auto-created** with `cleanup.policy=compact` if it does not exist (so only the latest token per scope is retained). Downstream consumers of the destination topic should set `isolation.level=read_committed` so they only ever observe committed transactions.
+
+To use exactly-once delivery, set `delivery: exactly_once` and pair this sink with a CDC source (`postgres-cdc`, `mysql-cdc`, `mongodb-cdc`) plus a `state:` block. A DLQ is not permitted in exactly-once mode. All four requirements are validated at config-load time (`faucet validate`) before any run starts.
+
+```yaml
+version: 1
+name: pg_cdc_to_kafka_eo
+delivery: exactly_once
+pipeline:
+  source:
+    type: postgres-cdc
+    config:
+      connection_url: ${env:SOURCE_PG_URL}
+      slot_name: faucet_kafka_eo
+      publication_name: faucet_pub
+      create_slot_if_missing: true
+  sink:
+    type: kafka
+    config:
+      brokers: ${env:KAFKA_BROKERS}
+      topic: { type: fixed, name: orders_cdc }
+      value_format: { type: json }
+      # exactly-once: transactional producer + compacted watermark side-topic
+      # (auto-created). transactional.id is auto-derived from the pipeline scope.
+      commit_token_topic: __faucet_commit_token
+  state:
+    type: file
+    config:
+      path: ./.faucet-state/pg_cdc_to_kafka_eo
+```
+
+The four new config fields ([`transactional_id_prefix`](#exactly-once), `commit_token_topic`, `commit_token_topic_partitions`, `commit_token_topic_replication`) tune the transactional id namespace and the side-topic. See the [exactly-once delivery cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/state.html#exactly-once-delivery) for the cross-connector picture, and the runnable [`cli/examples/postgres_cdc_to_kafka_exactly_once.yaml`](https://github.com/PawanSikawat/faucet-stream/blob/main/cli/examples/postgres_cdc_to_kafka_exactly_once.yaml).
 
 ## Config loading & schema
 

--- a/crates/sink/kafka/README.md
+++ b/crates/sink/kafka/README.md
@@ -333,7 +333,7 @@ pipeline:
   sink:
     type: kafka
     config:
-      brokers: ${env:KAFKA_BROKERS}
+      brokers: localhost:9092
       topic: { type: fixed, name: orders_cdc }
       value_format: { type: json }
       # exactly-once: transactional producer + compacted watermark side-topic

--- a/crates/sink/kafka/src/config.rs
+++ b/crates/sink/kafka/src/config.rs
@@ -86,6 +86,25 @@ pub struct KafkaSinkConfig {
     pub queue_full_backoff: Duration,
     #[serde(default = "default_queue_full_max_retries")]
     pub queue_full_max_retries: u32,
+    /// Optional namespace prefix for the producer's auto-derived
+    /// `transactional.id` (exactly-once mode only). The id is
+    /// `"{prefix}.{sanitized_scope}"`; `prefix` defaults to `"faucet"` when
+    /// unset. Set this to isolate transactional ids across clusters or
+    /// environments that share a pipeline scope namespace.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transactional_id_prefix: Option<String>,
+    /// Compacted side-topic that holds one commit-token record per pipeline
+    /// scope (exactly-once mode only). Auto-created with
+    /// `cleanup.policy=compact` if absent.
+    #[serde(default = "default_commit_token_topic")]
+    pub commit_token_topic: String,
+    /// Partition count used when auto-creating [`Self::commit_token_topic`].
+    #[serde(default = "default_commit_token_topic_partitions")]
+    pub commit_token_topic_partitions: i32,
+    /// Replication factor used when auto-creating
+    /// [`Self::commit_token_topic`]. `-1` means "use the broker default".
+    #[serde(default = "default_commit_token_topic_replication")]
+    pub commit_token_topic_replication: i32,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub extra_client_config: BTreeMap<String, String>,
 }
@@ -150,6 +169,15 @@ fn default_queue_full_backoff() -> Duration {
 fn default_queue_full_max_retries() -> u32 {
     3
 }
+fn default_commit_token_topic() -> String {
+    "__faucet_commit_token".to_string()
+}
+fn default_commit_token_topic_partitions() -> i32 {
+    1
+}
+fn default_commit_token_topic_replication() -> i32 {
+    -1
+}
 
 impl KafkaSinkConfig {
     pub fn validate(&self) -> Result<(), FaucetError> {
@@ -203,6 +231,16 @@ impl KafkaSinkConfig {
                     .into(),
             ));
         }
+        if self.commit_token_topic.trim().is_empty() {
+            return Err(FaucetError::Config(
+                "kafka sink: commit_token_topic must not be empty".into(),
+            ));
+        }
+        if self.commit_token_topic_partitions < 1 {
+            return Err(FaucetError::Config(
+                "kafka sink: commit_token_topic_partitions must be at least 1".into(),
+            ));
+        }
         faucet_core::validate_batch_size(self.batch_size)?;
         Ok(())
     }
@@ -246,6 +284,10 @@ mod tests {
             max_in_flight: 100,
             queue_full_backoff: Duration::from_millis(100),
             queue_full_max_retries: 3,
+            transactional_id_prefix: None,
+            commit_token_topic: "__faucet_commit_token".into(),
+            commit_token_topic_partitions: 1,
+            commit_token_topic_replication: -1,
             extra_client_config: BTreeMap::new(),
         }
     }
@@ -371,6 +413,34 @@ mod tests {
     #[test]
     fn validate_rejects_batch_size_above_max() {
         let c = minimal().with_batch_size(faucet_core::MAX_BATCH_SIZE + 1);
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn commit_token_defaults_are_set() {
+        let raw = r#"{
+            "brokers": "b:9092",
+            "topic": { "type": "fixed", "name": "out" }
+        }"#;
+        let c: KafkaSinkConfig = serde_json::from_str(raw).unwrap();
+        assert_eq!(c.commit_token_topic, "__faucet_commit_token");
+        assert_eq!(c.commit_token_topic_partitions, 1);
+        assert_eq!(c.commit_token_topic_replication, -1);
+        assert!(c.transactional_id_prefix.is_none());
+    }
+
+    #[test]
+    fn validate_rejects_empty_commit_token_topic() {
+        let mut c = minimal();
+        c.commit_token_topic = "  ".into();
+        let err = c.validate().unwrap_err();
+        assert!(format!("{err}").contains("commit_token_topic"), "{err}");
+    }
+
+    #[test]
+    fn validate_rejects_zero_commit_token_partitions() {
+        let mut c = minimal();
+        c.commit_token_topic_partitions = 0;
         assert!(c.validate().is_err());
     }
 

--- a/crates/sink/kafka/src/config.rs
+++ b/crates/sink/kafka/src/config.rs
@@ -169,6 +169,9 @@ fn default_queue_full_backoff() -> Duration {
 fn default_queue_full_max_retries() -> u32 {
     3
 }
+// Double leading underscore mirrors Kafka's own internal-topic convention
+// (__consumer_offsets / __transaction_state); intentionally distinct from the
+// SQL sinks' `_faucet_commit_token` table constant in faucet_core::idempotency.
 fn default_commit_token_topic() -> String {
     "__faucet_commit_token".to_string()
 }
@@ -239,6 +242,12 @@ impl KafkaSinkConfig {
         if self.commit_token_topic_partitions < 1 {
             return Err(FaucetError::Config(
                 "kafka sink: commit_token_topic_partitions must be at least 1".into(),
+            ));
+        }
+        if self.commit_token_topic_replication < 1 && self.commit_token_topic_replication != -1 {
+            return Err(FaucetError::Config(
+                "kafka sink: commit_token_topic_replication must be -1 (broker default) or at least 1"
+                    .into(),
             ));
         }
         faucet_core::validate_batch_size(self.batch_size)?;
@@ -442,6 +451,35 @@ mod tests {
         let mut c = minimal();
         c.commit_token_topic_partitions = 0;
         assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn commit_token_explicit_values_round_trip() {
+        let raw = r#"{
+            "brokers": "b:9092",
+            "topic": { "type": "fixed", "name": "out" },
+            "transactional_id_prefix": "acme",
+            "commit_token_topic": "wm",
+            "commit_token_topic_partitions": 3,
+            "commit_token_topic_replication": 2
+        }"#;
+        let c: KafkaSinkConfig = serde_json::from_str(raw).unwrap();
+        assert_eq!(c.transactional_id_prefix.as_deref(), Some("acme"));
+        assert_eq!(c.commit_token_topic, "wm");
+        assert_eq!(c.commit_token_topic_partitions, 3);
+        assert_eq!(c.commit_token_topic_replication, 2);
+        assert!(c.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_invalid_commit_token_replication() {
+        let mut c = minimal();
+        c.commit_token_topic_replication = 0;
+        assert!(c.validate().is_err());
+        c.commit_token_topic_replication = -2;
+        assert!(c.validate().is_err());
+        c.commit_token_topic_replication = -1; // broker default — allowed
+        assert!(c.validate().is_ok());
     }
 
     #[test]

--- a/crates/sink/kafka/src/idempotent.rs
+++ b/crates/sink/kafka/src/idempotent.rs
@@ -79,6 +79,12 @@ pub(crate) async fn read_last_token(
     cfg.set("group.id", "faucet-commit-token-reader");
     cfg.set("enable.auto.commit", "false");
     cfg.set("auto.offset.reset", "earliest");
+    // The side-topic is written by a transactional producer, so we must only
+    // read committed records — `read_committed` also makes `fetch_watermarks`
+    // return the Last Stable Offset, keeping the drain target consistent with
+    // what `poll` delivers. librdkafka defaults to this, but it is load-bearing
+    // for exactly-once correctness, so pin it explicitly.
+    cfg.set("isolation.level", "read_committed");
     let topic = config.commit_token_topic.clone();
     let scope = scope.to_string();
     let timeout = config.message_timeout;
@@ -107,17 +113,22 @@ fn read_last_token_blocking(
     };
 
     let mut tpl = TopicPartitionList::new();
-    // (partition_id, high_watermark)
+    // (partition_id, target_count) where target_count = high - low is the number
+    // of readable messages between the (committed) low and high watermarks.
+    // Subtracting `low` keeps the drain target correct on a compacted topic whose
+    // log-start offset has advanced past 0 (tombstone removal / `compact,delete`);
+    // assuming 0 there would make `consumed` never reach the target and stall the
+    // loop for a full `timeout` waiting on the empty-poll fallback.
     let mut ends: Vec<(i32, i64)> = Vec::new();
     for p in topic_meta.partitions() {
-        let (_low, high) = consumer
+        let (low, high) = consumer
             .fetch_watermarks(topic, p.id(), timeout)
             .map_err(|e| FaucetError::Sink(format!("kafka token reader watermarks: {e}")))?;
-        ends.push((p.id(), high));
+        ends.push((p.id(), (high - low).max(0)));
         tpl.add_partition_offset(topic, p.id(), Offset::Beginning)
             .map_err(|e| FaucetError::Sink(format!("kafka token reader tpl: {e}")))?;
     }
-    if ends.iter().all(|(_, high)| *high == 0) {
+    if ends.iter().all(|(_, target)| *target == 0) {
         return Ok(None); // every partition empty
     }
     consumer
@@ -126,11 +137,12 @@ fn read_last_token_blocking(
 
     let mut records: Vec<(Vec<u8>, Option<Vec<u8>>)> = Vec::new();
     let mut consumed: HashMap<i32, i64> = HashMap::new();
+    let done = |consumed: &HashMap<i32, i64>| {
+        ends.iter()
+            .all(|(pid, target)| consumed.get(pid).copied().unwrap_or(0) >= *target)
+    };
     loop {
-        let done = ends
-            .iter()
-            .all(|(pid, high)| *high == 0 || consumed.get(pid).copied().unwrap_or(0) >= *high);
-        if done {
+        if done(&consumed) {
             break;
         }
         match consumer.poll(timeout) {
@@ -143,7 +155,24 @@ fn read_last_token_blocking(
             Some(Err(e)) => {
                 return Err(FaucetError::Sink(format!("kafka token reader poll: {e}")));
             }
-            None => break, // no message within the timeout — stop draining
+            // An empty poll before every partition reached its high watermark means
+            // the broker did not deliver the remaining committed records within
+            // `timeout`. Returning the max found so far could yield a token *below*
+            // the true committed value, which would make the pipeline re-write
+            // already-committed pages and produce duplicates — defeating exactly-once.
+            // Fail loudly instead so the run aborts rather than silently degrading.
+            None => {
+                if done(&consumed) {
+                    break;
+                }
+                return Err(FaucetError::Sink(format!(
+                    "kafka token reader: drained {} record(s) but did not reach the high \
+                     watermark on every partition within the {:?} poll timeout — refusing to \
+                     return a possibly-stale commit token",
+                    records.len(),
+                    timeout
+                )));
+            }
         }
     }
 

--- a/crates/sink/kafka/src/idempotent.rs
+++ b/crates/sink/kafka/src/idempotent.rs
@@ -8,7 +8,13 @@
 
 use crate::config::KafkaSinkConfig;
 use faucet_core::FaucetError;
-use rdkafka::ClientConfig;
+use rdkafka::admin::{AdminClient, AdminOptions, NewTopic, TopicReplication};
+use rdkafka::client::DefaultClientContext;
+use rdkafka::consumer::{BaseConsumer, Consumer};
+use rdkafka::error::RDKafkaErrorCode;
+use rdkafka::{ClientConfig, Message, Offset, TopicPartitionList};
+use std::collections::HashMap;
+use std::time::Duration;
 
 /// Build the shared connection `ClientConfig` (brokers + auth) reused by the
 /// producer, the transactional producer, the admin client, and the
@@ -23,6 +29,125 @@ pub(crate) fn client_config_base(config: &KafkaSinkConfig) -> Result<ClientConfi
     cfg.set("bootstrap.servers", &config.brokers);
     config.auth.apply(&mut cfg)?;
     Ok(cfg)
+}
+
+/// Auto-create the compacted commit-token side-topic if it does not exist.
+/// Idempotent: an "already exists" result is treated as success.
+pub(crate) async fn ensure_commit_topic(
+    config: &KafkaSinkConfig,
+    base: &ClientConfig,
+) -> Result<(), FaucetError> {
+    let admin: AdminClient<DefaultClientContext> = base
+        .create()
+        .map_err(|e| FaucetError::Sink(format!("kafka admin client init: {e}")))?;
+    let topic = NewTopic::new(
+        &config.commit_token_topic,
+        config.commit_token_topic_partitions,
+        TopicReplication::Fixed(config.commit_token_topic_replication),
+    )
+    .set("cleanup.policy", "compact");
+    let results = admin
+        .create_topics([&topic], &AdminOptions::new())
+        .await
+        .map_err(|e| FaucetError::Sink(format!("kafka create_topics request: {e}")))?;
+    for r in results {
+        match r {
+            Ok(_) => {}
+            Err((_t, RDKafkaErrorCode::TopicAlreadyExists)) => {}
+            Err((t, code)) => {
+                return Err(FaucetError::Sink(format!(
+                    "kafka create commit-token topic '{t}': {code:?}"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Read the latest committed token for `scope` from the compacted side-topic.
+/// Returns `None` when the topic is empty or has no token for the scope.
+///
+/// Builds a short-lived, non-committing consumer, assigns every side-topic
+/// partition from the beginning, and drains up to each partition's high
+/// watermark. Called once per run (at startup), so a full read is cheap.
+pub(crate) async fn read_last_token(
+    config: &KafkaSinkConfig,
+    base: &ClientConfig,
+    scope: &str,
+) -> Result<Option<String>, FaucetError> {
+    let mut cfg = base.clone();
+    cfg.set("group.id", "faucet-commit-token-reader");
+    cfg.set("enable.auto.commit", "false");
+    cfg.set("auto.offset.reset", "earliest");
+    let topic = config.commit_token_topic.clone();
+    let scope = scope.to_string();
+    let timeout = config.message_timeout;
+
+    tokio::task::spawn_blocking(move || read_last_token_blocking(&cfg, &topic, &scope, timeout))
+        .await
+        .map_err(|e| FaucetError::Sink(format!("kafka token read task: {e}")))?
+}
+
+fn read_last_token_blocking(
+    cfg: &ClientConfig,
+    topic: &str,
+    scope: &str,
+    timeout: Duration,
+) -> Result<Option<String>, FaucetError> {
+    let consumer: BaseConsumer = cfg
+        .create()
+        .map_err(|e| FaucetError::Sink(format!("kafka token reader init: {e}")))?;
+
+    let metadata = consumer
+        .fetch_metadata(Some(topic), timeout)
+        .map_err(|e| FaucetError::Sink(format!("kafka token reader metadata: {e}")))?;
+    let topic_meta = match metadata.topics().iter().find(|t| t.name() == topic) {
+        Some(t) if !t.partitions().is_empty() => t,
+        _ => return Ok(None),
+    };
+
+    let mut tpl = TopicPartitionList::new();
+    // (partition_id, high_watermark)
+    let mut ends: Vec<(i32, i64)> = Vec::new();
+    for p in topic_meta.partitions() {
+        let (_low, high) = consumer
+            .fetch_watermarks(topic, p.id(), timeout)
+            .map_err(|e| FaucetError::Sink(format!("kafka token reader watermarks: {e}")))?;
+        ends.push((p.id(), high));
+        tpl.add_partition_offset(topic, p.id(), Offset::Beginning)
+            .map_err(|e| FaucetError::Sink(format!("kafka token reader tpl: {e}")))?;
+    }
+    if ends.iter().all(|(_, high)| *high == 0) {
+        return Ok(None); // every partition empty
+    }
+    consumer
+        .assign(&tpl)
+        .map_err(|e| FaucetError::Sink(format!("kafka token reader assign: {e}")))?;
+
+    let mut records: Vec<(Vec<u8>, Option<Vec<u8>>)> = Vec::new();
+    let mut consumed: HashMap<i32, i64> = HashMap::new();
+    loop {
+        let done = ends
+            .iter()
+            .all(|(pid, high)| *high == 0 || consumed.get(pid).copied().unwrap_or(0) >= *high);
+        if done {
+            break;
+        }
+        match consumer.poll(timeout) {
+            Some(Ok(msg)) => {
+                let key = msg.key().map(|k| k.to_vec()).unwrap_or_default();
+                let val = msg.payload().map(|v| v.to_vec());
+                *consumed.entry(msg.partition()).or_insert(0) += 1;
+                records.push((key, val));
+            }
+            Some(Err(e)) => {
+                return Err(FaucetError::Sink(format!("kafka token reader poll: {e}")));
+            }
+            None => break, // no message within the timeout — stop draining
+        }
+    }
+
+    Ok(max_token_for_scope(&records, scope).map(faucet_core::idempotency::format_token))
 }
 
 /// Derive the producer `transactional.id` from a stable pipeline scope.

--- a/crates/sink/kafka/src/idempotent.rs
+++ b/crates/sink/kafka/src/idempotent.rs
@@ -14,7 +14,6 @@ use rdkafka::consumer::{BaseConsumer, Consumer};
 use rdkafka::error::{KafkaError, RDKafkaErrorCode};
 use rdkafka::producer::{FutureProducer, FutureRecord, Producer};
 use rdkafka::{ClientConfig, Message, Offset, TopicPartitionList};
-use std::collections::HashMap;
 use std::time::Duration;
 
 /// Build the shared connection `ClientConfig` (brokers + auth) reused by the
@@ -53,7 +52,10 @@ pub(crate) fn producer_client_config(
         config.message_timeout.as_millis().to_string(),
     );
     if config.batch_size > 0 {
-        cfg.set("queue.buffering.max.messages", config.batch_size.to_string());
+        cfg.set(
+            "queue.buffering.max.messages",
+            config.batch_size.to_string(),
+        );
     }
     for (k, v) in &config.extra_client_config {
         cfg.set(k, v);
@@ -143,56 +145,89 @@ fn read_last_token_blocking(
     };
 
     let mut tpl = TopicPartitionList::new();
-    // (partition_id, target_count) where target_count = high - low is the number
-    // of readable messages between the (committed) low and high watermarks.
-    // Subtracting `low` keeps the drain target correct on a compacted topic whose
-    // log-start offset has advanced past 0 (tombstone removal / `compact,delete`);
-    // assuming 0 there would make `consumed` never reach the target and stall the
-    // loop for a full `timeout` waiting on the empty-poll fallback.
-    let mut ends: Vec<(i32, i64)> = Vec::new();
+    // (partition_id, high_watermark). Under `read_committed`, `high` is the Last
+    // Stable Offset — the offset *after* the last committed batch, including any
+    // transaction commit/abort control markers. The drain target is therefore the
+    // consumer's fetch *position* reaching `high`, NOT a count of delivered
+    // records: a transaction commit marker advances the log offset (and the LSO)
+    // but is never delivered to a consumer via `poll`. Counting delivered records
+    // against `high - low` would over-count by one per transaction commit and the
+    // loop could never reach the target, stalling for a full `timeout`.
+    // (partition_id, high_watermark, is_empty). `is_empty` (low == high) means the
+    // partition has no readable records — true on a fresh topic AND on a fully
+    // compacted partition whose log-start offset advanced past 0; either way it is
+    // already drained and must never block the loop while we wait on a position
+    // that will never be reported (nothing is ever fetched there).
+    let mut ends: Vec<(i32, i64, bool)> = Vec::new();
     for p in topic_meta.partitions() {
         let (low, high) = consumer
             .fetch_watermarks(topic, p.id(), timeout)
             .map_err(|e| FaucetError::Sink(format!("kafka token reader watermarks: {e}")))?;
-        ends.push((p.id(), (high - low).max(0)));
+        ends.push((p.id(), high, low >= high));
         tpl.add_partition_offset(topic, p.id(), Offset::Beginning)
             .map_err(|e| FaucetError::Sink(format!("kafka token reader tpl: {e}")))?;
-    }
-    if ends.iter().all(|(_, target)| *target == 0) {
-        return Ok(None); // every partition empty
     }
     consumer
         .assign(&tpl)
         .map_err(|e| FaucetError::Sink(format!("kafka token reader assign: {e}")))?;
 
-    let mut records: Vec<(Vec<u8>, Option<Vec<u8>>)> = Vec::new();
-    let mut consumed: HashMap<i32, i64> = HashMap::new();
-    let done = |consumed: &HashMap<i32, i64>| {
-        ends.iter()
-            .all(|(pid, target)| consumed.get(pid).copied().unwrap_or(0) >= *target)
+    // Per-partition next-fetch position. A partition is drained once its position
+    // reaches its high watermark (LSO). The consumer advances its position past a
+    // control marker even though no record is delivered, so position — unlike a
+    // delivered-record count — converges to `high` exactly. An empty partition has
+    // nothing to fetch (no position is ever reported), so it counts as drained
+    // outright.
+    let position_reached = |consumer: &BaseConsumer, ends: &[(i32, i64, bool)]| -> bool {
+        let Ok(pos) = consumer.position() else {
+            return false;
+        };
+        ends.iter().all(|(pid, high, is_empty)| {
+            if *is_empty {
+                return true;
+            }
+            match pos
+                .find_partition(topic, *pid)
+                .and_then(|p| match p.offset() {
+                    Offset::Offset(o) => Some(o),
+                    _ => None,
+                }) {
+                Some(o) => o >= *high,
+                // Non-empty partition with no fetched position yet ⇒ not drained.
+                None => false,
+            }
+        })
     };
+
+    let mut records: Vec<(Vec<u8>, Option<Vec<u8>>)> = Vec::new();
+    if position_reached(&consumer, &ends) {
+        // Every partition empty (or already at its watermark) — nothing to read.
+        return Ok(None);
+    }
     loop {
-        if done(&consumed) {
-            break;
-        }
         match consumer.poll(timeout) {
             Some(Ok(msg)) => {
                 let key = msg.key().map(|k| k.to_vec()).unwrap_or_default();
                 let val = msg.payload().map(|v| v.to_vec());
-                *consumed.entry(msg.partition()).or_insert(0) += 1;
                 records.push((key, val));
+                if position_reached(&consumer, &ends) {
+                    break;
+                }
             }
             Some(Err(e)) => {
                 return Err(FaucetError::Sink(format!("kafka token reader poll: {e}")));
             }
-            // An empty poll before every partition reached its high watermark means
-            // the broker did not deliver the remaining committed records within
-            // `timeout`. Returning the max found so far could yield a token *below*
-            // the true committed value, which would make the pipeline re-write
-            // already-committed pages and produce duplicates — defeating exactly-once.
-            // Fail loudly instead so the run aborts rather than silently degrading.
+            // An empty poll means the broker delivered no record within `timeout`.
+            // The consumer's fetch position still advances past control markers on
+            // an empty fetch, so re-check it: if every partition has reached its
+            // high watermark we are genuinely done (the remaining gap to `high` was
+            // a transaction commit marker, which is never delivered). Only if the
+            // position has NOT reached the watermark did the broker fail to deliver
+            // committed data records in time — returning the max found so far could
+            // yield a token *below* the true committed value, making the pipeline
+            // re-write already-committed pages and produce duplicates. Fail loudly
+            // there rather than silently degrading exactly-once.
             None => {
-                if done(&consumed) {
+                if position_reached(&consumer, &ends) {
                     break;
                 }
                 return Err(FaucetError::Sink(format!(

--- a/crates/sink/kafka/src/idempotent.rs
+++ b/crates/sink/kafka/src/idempotent.rs
@@ -10,17 +10,18 @@ use crate::config::KafkaSinkConfig;
 use faucet_core::FaucetError;
 use rdkafka::ClientConfig;
 
-/// Build the shared `ClientConfig` (brokers, auth, compression, user overrides)
-/// reused by the producer, the transactional producer, the admin client, and
-/// the token-reader consumer. Callers add role-specific keys on top.
+/// Build the shared connection `ClientConfig` (brokers + auth) reused by the
+/// producer, the transactional producer, the admin client, and the
+/// token-reader consumer. Only keys valid for every client type live here.
+///
+/// Producer-only keys (compression, buffering, idempotence) and the
+/// `extra_client_config` overrides are layered on by the producer builders —
+/// applying them here would let a producer-only property reach a consumer or
+/// admin client and be rejected at create time.
 pub(crate) fn client_config_base(config: &KafkaSinkConfig) -> Result<ClientConfig, FaucetError> {
     let mut cfg = ClientConfig::new();
     cfg.set("bootstrap.servers", &config.brokers);
-    cfg.set("compression.type", config.compression.as_str());
     config.auth.apply(&mut cfg)?;
-    for (k, v) in &config.extra_client_config {
-        cfg.set(k, v);
-    }
     Ok(cfg)
 }
 
@@ -74,7 +75,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn base_config_sets_brokers_and_compression() {
+    fn base_config_sets_brokers_only() {
         use crate::config::{Acks, KafkaSinkConfig, KafkaSinkTopic};
         use faucet_common_kafka::{CompressionType, KafkaAuth, KafkaValueFormat, OnKeyError};
         use std::collections::BTreeMap;
@@ -109,7 +110,8 @@ mod tests {
         };
         let cfg = client_config_base(&config).unwrap();
         assert_eq!(cfg.get("bootstrap.servers"), Some("host:9092"));
-        assert_eq!(cfg.get("compression.type"), Some("none"));
+        // compression is producer-only — layered by new(), not by the base.
+        assert_eq!(cfg.get("compression.type"), None);
     }
 
     #[test]

--- a/crates/sink/kafka/src/idempotent.rs
+++ b/crates/sink/kafka/src/idempotent.rs
@@ -32,6 +32,35 @@ pub(crate) fn client_config_base(config: &KafkaSinkConfig) -> Result<ClientConfi
     Ok(cfg)
 }
 
+/// Full producer `ClientConfig`: the connection base plus producer tuning
+/// (`acks`, idempotence, compression, linger, message timeout, buffer cap) and
+/// the user's `extra_client_config` overrides (applied last so they win). Used
+/// by both the at-least-once producer and the transactional producer; the
+/// latter then force-sets the transactional invariants on top.
+pub(crate) fn producer_client_config(
+    config: &KafkaSinkConfig,
+) -> Result<ClientConfig, FaucetError> {
+    let mut cfg = client_config_base(config)?;
+    cfg.set("acks", config.acks.as_str());
+    cfg.set(
+        "enable.idempotence",
+        if config.idempotent { "true" } else { "false" },
+    );
+    cfg.set("compression.type", config.compression.as_str());
+    cfg.set("linger.ms", config.linger.as_millis().to_string());
+    cfg.set(
+        "message.timeout.ms",
+        config.message_timeout.as_millis().to_string(),
+    );
+    if config.batch_size > 0 {
+        cfg.set("queue.buffering.max.messages", config.batch_size.to_string());
+    }
+    for (k, v) in &config.extra_client_config {
+        cfg.set(k, v);
+    }
+    Ok(cfg)
+}
+
 /// Auto-create the compacted commit-token side-topic if it does not exist.
 /// Idempotent: an "already exists" result is treated as success.
 pub(crate) async fn ensure_commit_topic(

--- a/crates/sink/kafka/src/idempotent.rs
+++ b/crates/sink/kafka/src/idempotent.rs
@@ -11,7 +11,8 @@ use faucet_core::FaucetError;
 use rdkafka::admin::{AdminClient, AdminOptions, NewTopic, TopicReplication};
 use rdkafka::client::DefaultClientContext;
 use rdkafka::consumer::{BaseConsumer, Consumer};
-use rdkafka::error::RDKafkaErrorCode;
+use rdkafka::error::{KafkaError, RDKafkaErrorCode};
+use rdkafka::producer::{FutureProducer, FutureRecord, Producer};
 use rdkafka::{ClientConfig, Message, Offset, TopicPartitionList};
 use std::collections::HashMap;
 use std::time::Duration;
@@ -222,6 +223,59 @@ pub(crate) fn max_token_for_scope(
         .filter_map(|v| std::str::from_utf8(v).ok())
         .filter_map(faucet_core::idempotency::parse_token)
         .max()
+}
+
+/// Enqueue one record into the current transaction, retrying on `QueueFull`.
+///
+/// Unlike the at-least-once `send_with_queue_full_retry`, this does NOT await
+/// the delivery future: inside a transaction, delivery only completes at
+/// `commit_transaction`, so awaiting here would deadlock. Errors surface at
+/// commit time.
+pub(crate) async fn enqueue_in_txn(
+    producer: &FutureProducer,
+    topic: &str,
+    value_bytes: Vec<u8>,
+    key_bytes: Option<Vec<u8>>,
+    partition: Option<i32>,
+    max_retries: u32,
+    backoff: Duration,
+) -> Result<(), FaucetError> {
+    let mut attempts: u32 = 0;
+    loop {
+        let mut record: FutureRecord<'_, [u8], [u8]> =
+            FutureRecord::to(topic).payload(value_bytes.as_slice());
+        if let Some(k) = key_bytes.as_deref() {
+            record = record.key(k);
+        }
+        if let Some(p) = partition {
+            record = record.partition(p);
+        }
+        match producer.send_result(record) {
+            Ok(_delivery_future) => return Ok(()),
+            Err((KafkaError::MessageProduction(RDKafkaErrorCode::QueueFull), _)) => {
+                if attempts >= max_retries {
+                    return Err(FaucetError::Sink(format!(
+                        "kafka send: QueueFull after {max_retries} retries"
+                    )));
+                }
+                tracing::warn!(attempts, "kafka send: QueueFull, backing off");
+                tokio::time::sleep(backoff).await;
+                attempts += 1;
+            }
+            Err((e, _)) => return Err(FaucetError::Sink(format!("kafka send: {e}"))),
+        }
+    }
+}
+
+/// Abort the current transaction (best-effort, on the blocking pool).
+pub(crate) async fn abort_txn(
+    producer: std::sync::Arc<FutureProducer>,
+    timeout: Duration,
+) -> Result<(), FaucetError> {
+    tokio::task::spawn_blocking(move || producer.abort_transaction(timeout))
+        .await
+        .map_err(|e| FaucetError::Sink(format!("kafka abort task: {e}")))?
+        .map_err(|e| FaucetError::Sink(format!("kafka abort_transaction: {e}")))
 }
 
 #[cfg(test)]

--- a/crates/sink/kafka/src/idempotent.rs
+++ b/crates/sink/kafka/src/idempotent.rs
@@ -1,0 +1,105 @@
+//! Exactly-once delivery support for the Kafka sink.
+//!
+//! Implements the watermark mechanics behind the `Sink` idempotency hooks: a
+//! transactional producer commits each page's records plus a commit-token
+//! record into a compacted side-topic in one Kafka transaction, and the token
+//! is read back on resume. See
+//! `docs/superpowers/specs/2026-06-18-kafka-sink-exactly-once-design.md`.
+
+/// Derive the producer `transactional.id` from a stable pipeline scope.
+///
+/// The result is `"{prefix}.{sanitized}"`, where `sanitized` replaces any
+/// character outside `[A-Za-z0-9._-]` with `_`. This keeps the id stable across
+/// restarts of the same pipeline-row (so a restart fences its own zombie) and
+/// unique across rows/pipelines whose scopes differ after sanitization (so
+/// distinct pipelines never fence each other). Sanitization is many-to-one, so
+/// callers must keep their scopes distinct under it; faucet derives scopes from
+/// the pipeline/row identity (`{name}::{row_id}`), which stay distinct. `prefix`
+/// is interpolated verbatim — validating it as a legal `transactional.id`
+/// fragment is the caller's responsibility.
+pub(crate) fn derive_transactional_id(prefix: &str, scope: &str) -> String {
+    let sanitized: String = scope
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-') {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    format!("{prefix}.{sanitized}")
+}
+
+/// The maximum commit-token value recorded for `scope` among consumed
+/// side-topic records.
+///
+/// Records are `(key_bytes, value_bytes)`. Only records whose key equals
+/// `scope` are considered; their values are parsed as commit tokens and the
+/// maximum is returned (robust to pre-compaction duplicates / out-of-order
+/// delivery). Returns `None` when no valid token exists for the scope.
+pub(crate) fn max_token_for_scope(
+    records: &[(Vec<u8>, Option<Vec<u8>>)],
+    scope: &str,
+) -> Option<u64> {
+    records
+        .iter()
+        .filter(|(k, _)| k.as_slice() == scope.as_bytes())
+        .filter_map(|(_, v)| v.as_ref())
+        .filter_map(|v| std::str::from_utf8(v).ok())
+        .filter_map(faucet_core::idempotency::parse_token)
+        .max()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn derive_sanitizes_scope_separators() {
+        assert_eq!(
+            derive_transactional_id("faucet", "pipe::row0"),
+            "faucet.pipe__row0"
+        );
+    }
+
+    #[test]
+    fn derive_keeps_allowed_chars_and_prefix() {
+        assert_eq!(derive_transactional_id("acme", "a.b-c_1"), "acme.a.b-c_1");
+        assert_eq!(derive_transactional_id("faucet", "x/y z"), "faucet.x_y_z");
+    }
+
+    #[test]
+    fn max_token_picks_highest_for_scope_only() {
+        let recs = vec![
+            (
+                b"s1".to_vec(),
+                Some(faucet_core::idempotency::format_token(3).into_bytes()),
+            ),
+            (
+                b"s1".to_vec(),
+                Some(faucet_core::idempotency::format_token(7).into_bytes()),
+            ),
+            (
+                b"s2".to_vec(),
+                Some(faucet_core::idempotency::format_token(99).into_bytes()),
+            ),
+        ];
+        assert_eq!(max_token_for_scope(&recs, "s1"), Some(7));
+        assert_eq!(max_token_for_scope(&recs, "s2"), Some(99));
+        assert_eq!(max_token_for_scope(&recs, "absent"), None);
+    }
+
+    #[test]
+    fn max_token_ignores_garbage_and_tombstones() {
+        let recs = vec![
+            (b"s1".to_vec(), None),
+            (b"s1".to_vec(), Some(b"not-a-token".to_vec())),
+            (
+                b"s1".to_vec(),
+                Some(faucet_core::idempotency::format_token(4).into_bytes()),
+            ),
+        ];
+        assert_eq!(max_token_for_scope(&recs, "s1"), Some(4));
+    }
+}

--- a/crates/sink/kafka/src/idempotent.rs
+++ b/crates/sink/kafka/src/idempotent.rs
@@ -6,6 +6,24 @@
 //! is read back on resume. See
 //! `docs/superpowers/specs/2026-06-18-kafka-sink-exactly-once-design.md`.
 
+use crate::config::KafkaSinkConfig;
+use faucet_core::FaucetError;
+use rdkafka::ClientConfig;
+
+/// Build the shared `ClientConfig` (brokers, auth, compression, user overrides)
+/// reused by the producer, the transactional producer, the admin client, and
+/// the token-reader consumer. Callers add role-specific keys on top.
+pub(crate) fn client_config_base(config: &KafkaSinkConfig) -> Result<ClientConfig, FaucetError> {
+    let mut cfg = ClientConfig::new();
+    cfg.set("bootstrap.servers", &config.brokers);
+    cfg.set("compression.type", config.compression.as_str());
+    config.auth.apply(&mut cfg)?;
+    for (k, v) in &config.extra_client_config {
+        cfg.set(k, v);
+    }
+    Ok(cfg)
+}
+
 /// Derive the producer `transactional.id` from a stable pipeline scope.
 ///
 /// The result is `"{prefix}.{sanitized}"`, where `sanitized` replaces any
@@ -54,6 +72,45 @@ pub(crate) fn max_token_for_scope(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn base_config_sets_brokers_and_compression() {
+        use crate::config::{Acks, KafkaSinkConfig, KafkaSinkTopic};
+        use faucet_common_kafka::{CompressionType, KafkaAuth, KafkaValueFormat, OnKeyError};
+        use std::collections::BTreeMap;
+        use std::time::Duration;
+
+        let config = KafkaSinkConfig {
+            brokers: "host:9092".into(),
+            topic: KafkaSinkTopic::Fixed { name: "out".into() },
+            auth: KafkaAuth::None,
+            value_format: KafkaValueFormat::Json,
+            key_format: None,
+            value_schema: None,
+            key_schema: None,
+            key_path: None,
+            partition_path: None,
+            headers_path: None,
+            on_key_error: OnKeyError::Fail,
+            compression: CompressionType::None,
+            acks: Acks::All,
+            idempotent: true,
+            linger: Duration::from_millis(5),
+            batch_size: faucet_core::DEFAULT_BATCH_SIZE,
+            message_timeout: Duration::from_secs(30),
+            max_in_flight: 100,
+            queue_full_backoff: Duration::from_millis(100),
+            queue_full_max_retries: 3,
+            transactional_id_prefix: None,
+            commit_token_topic: "__faucet_commit_token".into(),
+            commit_token_topic_partitions: 1,
+            commit_token_topic_replication: -1,
+            extra_client_config: BTreeMap::new(),
+        };
+        let cfg = client_config_base(&config).unwrap();
+        assert_eq!(cfg.get("bootstrap.servers"), Some("host:9092"));
+        assert_eq!(cfg.get("compression.type"), Some("none"));
+    }
 
     #[test]
     fn derive_sanitizes_scope_separators() {

--- a/crates/sink/kafka/src/idempotent.rs
+++ b/crates/sink/kafka/src/idempotent.rs
@@ -145,15 +145,12 @@ fn read_last_token_blocking(
     };
 
     let mut tpl = TopicPartitionList::new();
-    // (partition_id, high_watermark). Under `read_committed`, `high` is the Last
-    // Stable Offset — the offset *after* the last committed batch, including any
-    // transaction commit/abort control markers. The drain target is therefore the
-    // consumer's fetch *position* reaching `high`, NOT a count of delivered
-    // records: a transaction commit marker advances the log offset (and the LSO)
-    // but is never delivered to a consumer via `poll`. Counting delivered records
-    // against `high - low` would over-count by one per transaction commit and the
-    // loop could never reach the target, stalling for a full `timeout`.
-    // (partition_id, high_watermark, is_empty). `is_empty` (low == high) means the
+    // (partition_id, high_watermark, is_empty). Under `read_committed`, `high` is
+    // the Last Stable Offset — the offset *after* the last committed batch, including
+    // any transaction commit/abort control markers — so the drain target is the
+    // consumer's fetch *position* reaching `high`, NOT a count of delivered records
+    // (a commit marker advances the log offset but is never delivered via `poll`).
+    // `is_empty` (low == high) means the
     // partition has no readable records — true on a fresh topic AND on a fully
     // compacted partition whose log-start offset advanced past 0; either way it is
     // already drained and must never block the loop while we wait on a position

--- a/crates/sink/kafka/src/lib.rs
+++ b/crates/sink/kafka/src/lib.rs
@@ -9,6 +9,7 @@
 pub mod config;
 pub mod encode;
 pub mod extract;
+mod idempotent;
 pub mod sink;
 
 #[cfg(feature = "schema-registry")]

--- a/crates/sink/kafka/src/sink.rs
+++ b/crates/sink/kafka/src/sink.rs
@@ -339,22 +339,18 @@ impl Sink for KafkaSink {
             let topic = match self.resolve_topic(record) {
                 Ok(t) => t,
                 Err(e) => {
-                    let _ = crate::idempotent::abort_txn(
-                        producer.clone(),
-                        self.config.message_timeout,
-                    )
-                    .await;
+                    let _ =
+                        crate::idempotent::abort_txn(producer.clone(), self.config.message_timeout)
+                            .await;
                     return Err(e);
                 }
             };
             let (value_bytes, key_bytes) = match self.build_record_bytes(record, &topic).await {
                 Ok(v) => v,
                 Err(e) => {
-                    let _ = crate::idempotent::abort_txn(
-                        producer.clone(),
-                        self.config.message_timeout,
-                    )
-                    .await;
+                    let _ =
+                        crate::idempotent::abort_txn(producer.clone(), self.config.message_timeout)
+                            .await;
                     return Err(e);
                 }
             };
@@ -412,8 +408,8 @@ impl Sink for KafkaSink {
         )
         .await
         {
-            let _ = crate::idempotent::abort_txn(producer.clone(), self.config.message_timeout)
-                .await;
+            let _ =
+                crate::idempotent::abort_txn(producer.clone(), self.config.message_timeout).await;
             return Err(e);
         }
 
@@ -424,13 +420,16 @@ impl Sink for KafkaSink {
             .await
             .map_err(|e| FaucetError::Sink(format!("kafka commit task: {e}")))?;
         if let Err(e) = commit {
-            let _ = crate::idempotent::abort_txn(producer.clone(), self.config.message_timeout)
-                .await;
+            let _ =
+                crate::idempotent::abort_txn(producer.clone(), self.config.message_timeout).await;
             return Err(FaucetError::Sink(format!("kafka commit_transaction: {e}")));
         }
 
         if skipped > 0 {
-            tracing::warn!(skipped, "kafka sink: dropped records due to OnKeyError::Skip");
+            tracing::warn!(
+                skipped,
+                "kafka sink: dropped records due to OnKeyError::Skip"
+            );
         }
         Ok(produced)
     }

--- a/crates/sink/kafka/src/sink.rs
+++ b/crates/sink/kafka/src/sink.rs
@@ -9,7 +9,6 @@ use faucet_common_kafka::KafkaValueFormat;
 use faucet_common_kafka::OnKeyError;
 use faucet_core::{FaucetError, Sink};
 use futures::stream::{FuturesUnordered, StreamExt};
-use rdkafka::ClientConfig;
 use rdkafka::error::{KafkaError, RDKafkaErrorCode};
 use rdkafka::producer::{FutureProducer, FutureRecord, Producer};
 use serde_json::Value;
@@ -30,36 +29,23 @@ impl KafkaSink {
     pub async fn new(config: KafkaSinkConfig) -> Result<Self, FaucetError> {
         config.validate()?;
 
-        let mut client_config = ClientConfig::new();
-        client_config.set("bootstrap.servers", &config.brokers);
+        let mut client_config = crate::idempotent::client_config_base(&config)?;
         client_config.set("acks", config.acks.as_str());
         client_config.set(
             "enable.idempotence",
             if config.idempotent { "true" } else { "false" },
         );
-        client_config.set("compression.type", config.compression.as_str());
         client_config.set("linger.ms", config.linger.as_millis().to_string());
         client_config.set(
             "message.timeout.ms",
             config.message_timeout.as_millis().to_string(),
         );
-        // Tie the librdkafka producer buffer cap to the streaming-pipeline
-        // batch_size so the broker-side buffer can hold one full
-        // FuturesUnordered send window. The `batch_size = 0` sentinel keeps
-        // librdkafka's default (100,000) so the "no batching" path stays
-        // identical to pre-streaming behaviour. `extra_client_config`
-        // overrides this so tests (and ops) can force a tighter cap to
-        // exercise QueueFull backpressure.
+        // Tie the librdkafka producer buffer cap to batch_size (see config docs).
         if config.batch_size > 0 {
             client_config.set(
                 "queue.buffering.max.messages",
                 config.batch_size.to_string(),
             );
-        }
-
-        config.auth.apply(&mut client_config)?;
-        for (k, v) in &config.extra_client_config {
-            client_config.set(k, v);
         }
 
         let producer: FutureProducer = client_config

--- a/crates/sink/kafka/src/sink.rs
+++ b/crates/sink/kafka/src/sink.rs
@@ -35,6 +35,7 @@ impl KafkaSink {
             "enable.idempotence",
             if config.idempotent { "true" } else { "false" },
         );
+        client_config.set("compression.type", config.compression.as_str());
         client_config.set("linger.ms", config.linger.as_millis().to_string());
         client_config.set(
             "message.timeout.ms",
@@ -46,6 +47,11 @@ impl KafkaSink {
                 "queue.buffering.max.messages",
                 config.batch_size.to_string(),
             );
+        }
+        // extra_client_config is applied last so it overrides any of the above —
+        // matching the pre-refactor escape-hatch precedence.
+        for (k, v) in &config.extra_client_config {
+            client_config.set(k, v);
         }
 
         let producer: FutureProducer = client_config

--- a/crates/sink/kafka/src/sink.rs
+++ b/crates/sink/kafka/src/sink.rs
@@ -21,6 +21,10 @@ use faucet_common_kafka::schema_registry::client::SchemaRegistryClient;
 pub struct KafkaSink {
     config: KafkaSinkConfig,
     producer: Arc<FutureProducer>,
+    /// Lazily-built transactional producer for exactly-once writes. Built on
+    /// the first `write_batch_idempotent` call (needs the scope-derived
+    /// `transactional.id`, unknown at `new()`).
+    txn: tokio::sync::OnceCell<Arc<FutureProducer>>,
     #[cfg(feature = "schema-registry")]
     sr_client: Option<SchemaRegistryClient>,
 }
@@ -29,30 +33,7 @@ impl KafkaSink {
     pub async fn new(config: KafkaSinkConfig) -> Result<Self, FaucetError> {
         config.validate()?;
 
-        let mut client_config = crate::idempotent::client_config_base(&config)?;
-        client_config.set("acks", config.acks.as_str());
-        client_config.set(
-            "enable.idempotence",
-            if config.idempotent { "true" } else { "false" },
-        );
-        client_config.set("compression.type", config.compression.as_str());
-        client_config.set("linger.ms", config.linger.as_millis().to_string());
-        client_config.set(
-            "message.timeout.ms",
-            config.message_timeout.as_millis().to_string(),
-        );
-        // Tie the librdkafka producer buffer cap to batch_size (see config docs).
-        if config.batch_size > 0 {
-            client_config.set(
-                "queue.buffering.max.messages",
-                config.batch_size.to_string(),
-            );
-        }
-        // extra_client_config is applied last so it overrides any of the above —
-        // matching the pre-refactor escape-hatch precedence.
-        for (k, v) in &config.extra_client_config {
-            client_config.set(k, v);
-        }
+        let client_config = crate::idempotent::producer_client_config(&config)?;
 
         let producer: FutureProducer = client_config
             .create()
@@ -64,6 +45,7 @@ impl KafkaSink {
         Ok(Self {
             config,
             producer: Arc::new(producer),
+            txn: tokio::sync::OnceCell::new(),
             #[cfg(feature = "schema-registry")]
             sr_client,
         })
@@ -159,6 +141,52 @@ impl KafkaSink {
                 OnKeyError::Skip | OnKeyError::RoundRobin => Ok(None),
             },
         }
+    }
+
+    /// Build (once) the transactional producer for `scope` and run
+    /// `init_transactions` — which also fences any zombie producer sharing this
+    /// `transactional.id`. Cached for the run; a fatal producer error fails the
+    /// run and the whole sink is rebuilt on the next run.
+    async fn txn_producer(&self, scope: &str) -> Result<Arc<FutureProducer>, FaucetError> {
+        self.txn
+            .get_or_try_init(|| async {
+                let prefix = self
+                    .config
+                    .transactional_id_prefix
+                    .as_deref()
+                    .unwrap_or("faucet");
+                let txn_id = crate::idempotent::derive_transactional_id(prefix, scope);
+
+                let mut cfg = crate::idempotent::producer_client_config(&self.config)?;
+                // Force the transactional invariants AFTER extra_client_config so
+                // a user override cannot disable them and break EOS.
+                cfg.set("transactional.id", &txn_id);
+                cfg.set("enable.idempotence", "true");
+                cfg.set("acks", "all");
+                // message.timeout.ms must be <= transaction.timeout.ms; raise the
+                // transaction timeout floor so a large message_timeout config does
+                // not make init_transactions reject the producer.
+                let msg_timeout_ms = self.config.message_timeout.as_millis();
+                let txn_timeout_ms = msg_timeout_ms.max(60_000);
+                cfg.set("transaction.timeout.ms", txn_timeout_ms.to_string());
+
+                let producer: FutureProducer = cfg
+                    .create()
+                    .map_err(|e| FaucetError::Sink(format!("kafka txn producer init: {e}")))?;
+                let producer = Arc::new(producer);
+
+                // init_transactions is a blocking FFI call.
+                let p = producer.clone();
+                let timeout = self.config.message_timeout;
+                tokio::task::spawn_blocking(move || p.init_transactions(timeout))
+                    .await
+                    .map_err(|e| FaucetError::Sink(format!("kafka init_transactions task: {e}")))?
+                    .map_err(|e| FaucetError::Sink(format!("kafka init_transactions: {e}")))?;
+
+                Ok::<_, FaucetError>(producer)
+            })
+            .await
+            .cloned()
     }
 }
 
@@ -279,6 +307,132 @@ impl Sink for KafkaSink {
             .flush(self.config.message_timeout)
             .map_err(|e| FaucetError::Sink(format!("kafka producer flush: {e}")))?;
         Ok(())
+    }
+
+    fn supports_idempotent_writes(&self) -> bool {
+        true
+    }
+
+    async fn last_committed_token(&self, scope: &str) -> Result<Option<String>, FaucetError> {
+        let base = crate::idempotent::client_config_base(&self.config)?;
+        crate::idempotent::ensure_commit_topic(&self.config, &base).await?;
+        crate::idempotent::read_last_token(&self.config, &base, scope).await
+    }
+
+    async fn write_batch_idempotent(
+        &self,
+        records: &[Value],
+        scope: &str,
+        token: &str,
+    ) -> Result<usize, FaucetError> {
+        let producer = self.txn_producer(scope).await?;
+
+        producer
+            .begin_transaction()
+            .map_err(|e| FaucetError::Sink(format!("kafka begin_transaction: {e}")))?;
+
+        let mut produced = 0usize;
+        let mut skipped = 0usize;
+
+        // Enqueue all data records (non-awaiting — delivery completes at commit).
+        for record in records {
+            let topic = match self.resolve_topic(record) {
+                Ok(t) => t,
+                Err(e) => {
+                    let _ = crate::idempotent::abort_txn(
+                        producer.clone(),
+                        self.config.message_timeout,
+                    )
+                    .await;
+                    return Err(e);
+                }
+            };
+            let (value_bytes, key_bytes) = match self.build_record_bytes(record, &topic).await {
+                Ok(v) => v,
+                Err(e) => {
+                    let _ = crate::idempotent::abort_txn(
+                        producer.clone(),
+                        self.config.message_timeout,
+                    )
+                    .await;
+                    return Err(e);
+                }
+            };
+
+            if self.config.key_path.is_some()
+                && key_bytes.is_none()
+                && matches!(self.config.on_key_error, OnKeyError::Skip)
+            {
+                skipped += 1;
+                continue;
+            }
+
+            let partition = match &self.config.partition_path {
+                Some(p) => match extract::partition_at(record, p) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        let _ = crate::idempotent::abort_txn(
+                            producer.clone(),
+                            self.config.message_timeout,
+                        )
+                        .await;
+                        return Err(e);
+                    }
+                },
+                None => None,
+            };
+
+            if let Err(e) = crate::idempotent::enqueue_in_txn(
+                &producer,
+                &topic,
+                value_bytes,
+                key_bytes,
+                partition,
+                self.config.queue_full_max_retries,
+                self.config.queue_full_backoff,
+            )
+            .await
+            {
+                let _ = crate::idempotent::abort_txn(producer.clone(), self.config.message_timeout)
+                    .await;
+                return Err(e);
+            }
+            produced += 1;
+        }
+
+        // Enqueue the commit-token record (key = scope, value = token).
+        if let Err(e) = crate::idempotent::enqueue_in_txn(
+            &producer,
+            &self.config.commit_token_topic,
+            token.as_bytes().to_vec(),
+            Some(scope.as_bytes().to_vec()),
+            None,
+            self.config.queue_full_max_retries,
+            self.config.queue_full_backoff,
+        )
+        .await
+        {
+            let _ = crate::idempotent::abort_txn(producer.clone(), self.config.message_timeout)
+                .await;
+            return Err(e);
+        }
+
+        // Commit atomically (blocking FFI). Errors → abort + propagate.
+        let p = producer.clone();
+        let timeout = self.config.message_timeout;
+        let commit = tokio::task::spawn_blocking(move || p.commit_transaction(timeout))
+            .await
+            .map_err(|e| FaucetError::Sink(format!("kafka commit task: {e}")))?;
+        if let Err(e) = commit {
+            let _ = crate::idempotent::abort_txn(producer.clone(), self.config.message_timeout)
+                .await;
+            return Err(FaucetError::Sink(format!("kafka commit_transaction: {e}")));
+        }
+
+        if skipped > 0 {
+            tracing::warn!(skipped, "kafka sink: dropped records due to OnKeyError::Skip");
+        }
+        Ok(produced)
     }
 
     fn config_schema(&self) -> Value {

--- a/crates/sink/kafka/tests/coverage.rs
+++ b/crates/sink/kafka/tests/coverage.rs
@@ -53,6 +53,10 @@ fn sink_config(brokers: &str, topic: KafkaSinkTopic) -> KafkaSinkConfig {
         max_in_flight: 50,
         queue_full_backoff: Duration::from_millis(100),
         queue_full_max_retries: 3,
+        transactional_id_prefix: None,
+        commit_token_topic: "__faucet_commit_token".into(),
+        commit_token_topic_partitions: 1,
+        commit_token_topic_replication: -1,
         extra_client_config: BTreeMap::new(),
     }
 }

--- a/crates/sink/kafka/tests/exactly_once.rs
+++ b/crates/sink/kafka/tests/exactly_once.rs
@@ -1,0 +1,142 @@
+//! Exactly-once delivery integration tests for `KafkaSink` (#216).
+//!
+//! Covers the transactional write path and the commit-token round-trip:
+//! `write_batch_idempotent` commits records + a token atomically; on a
+//! simulated crash (sink dropped before any state persist) a rebuilt sink
+//! reports the committed token via `last_committed_token`, so the pipeline
+//! skips the replayed page — zero duplicates.
+//!
+//! Requires Docker. A single-broker container must enable transactions, so we
+//! force the transaction-state-log replication/ISR + offsets replication to 1.
+
+use faucet_common_kafka::{CompressionType, KafkaAuth, KafkaValueFormat, OnKeyError};
+use faucet_core::idempotency::format_token;
+use faucet_core::{DEFAULT_BATCH_SIZE, Sink};
+use faucet_sink_kafka::{Acks, KafkaSink, KafkaSinkConfig, KafkaSinkTopic};
+use rdkafka::ClientConfig;
+use rdkafka::consumer::{Consumer, StreamConsumer};
+use serde_json::json;
+use std::collections::BTreeMap;
+use std::time::Duration;
+use testcontainers::ImageExt;
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::kafka::apache::{KAFKA_PORT, Kafka};
+
+async fn start_kafka() -> (testcontainers::ContainerAsync<Kafka>, String) {
+    // Single-broker transactions need these replication/ISR settings at 1.
+    let container = Kafka::default()
+        .with_env_var("KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", "1")
+        .with_env_var("KAFKA_TRANSACTION_STATE_LOG_MIN_ISR", "1")
+        .with_env_var("KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", "1")
+        .start()
+        .await
+        .expect("kafka container start");
+    let port = container
+        .get_host_port_ipv4(KAFKA_PORT)
+        .await
+        .expect("kafka port");
+    (container, format!("127.0.0.1:{port}"))
+}
+
+fn eo_config(brokers: &str, topic: &str) -> KafkaSinkConfig {
+    KafkaSinkConfig {
+        brokers: brokers.into(),
+        topic: KafkaSinkTopic::Fixed { name: topic.into() },
+        auth: KafkaAuth::None,
+        value_format: KafkaValueFormat::Json,
+        key_format: None,
+        value_schema: None,
+        key_schema: None,
+        key_path: None,
+        partition_path: None,
+        headers_path: None,
+        on_key_error: OnKeyError::Fail,
+        compression: CompressionType::None,
+        acks: Acks::All,
+        idempotent: true,
+        linger: Duration::from_millis(5),
+        batch_size: DEFAULT_BATCH_SIZE,
+        message_timeout: Duration::from_secs(15),
+        max_in_flight: 50,
+        queue_full_backoff: Duration::from_millis(100),
+        queue_full_max_retries: 3,
+        transactional_id_prefix: None,
+        commit_token_topic: "__faucet_commit_token".into(),
+        commit_token_topic_partitions: 1,
+        commit_token_topic_replication: 1,
+        extra_client_config: BTreeMap::new(),
+    }
+}
+
+/// Count messages on `topic` by draining from the beginning until idle.
+async fn count_messages(brokers: &str, topic: &str) -> usize {
+    let consumer: StreamConsumer = ClientConfig::new()
+        .set("bootstrap.servers", brokers)
+        .set("group.id", "verifier")
+        .set("auto.offset.reset", "earliest")
+        .set("enable.auto.commit", "false")
+        .set("isolation.level", "read_committed")
+        .create()
+        .expect("verifier consumer");
+    consumer.subscribe(&[topic]).expect("subscribe");
+    let mut count = 0usize;
+    loop {
+        match tokio::time::timeout(Duration::from_secs(5), consumer.recv()).await {
+            Ok(Ok(_msg)) => count += 1,
+            Ok(Err(e)) => panic!("verifier recv error: {e}"),
+            Err(_) => break, // idle timeout — done
+        }
+    }
+    count
+}
+
+#[tokio::test]
+async fn exactly_once_round_trip_and_no_duplicates_on_resume() {
+    let (_container, brokers) = start_kafka().await;
+    let topic = "eo_dest";
+    let scope = "pipe::row0";
+
+    // ---- Run 1: write page seq=1, then "crash" (drop sink, no state persist).
+    {
+        let sink = KafkaSink::new(eo_config(&brokers, topic)).await.unwrap();
+        assert!(sink.supports_idempotent_writes());
+        // Fresh topic → no committed token yet.
+        assert_eq!(sink.last_committed_token(scope).await.unwrap(), None);
+
+        let page1 = vec![json!({"id": 1}), json!({"id": 2})];
+        let n = sink
+            .write_batch_idempotent(&page1, scope, &format_token(1))
+            .await
+            .unwrap();
+        assert_eq!(n, 2);
+        sink.flush().await.unwrap();
+        // sink dropped here — simulating a crash BEFORE the pipeline persists state.
+    }
+
+    // ---- Run 2: rebuilt sink reports page 1 committed, so the pipeline would skip it.
+    let sink2 = KafkaSink::new(eo_config(&brokers, topic)).await.unwrap();
+    let committed = sink2.last_committed_token(scope).await.unwrap();
+    assert_eq!(
+        committed,
+        Some(format_token(1)),
+        "page 1 must read back as committed"
+    );
+
+    // Pipeline logic skips seq<=committed, then writes the genuinely-new page 2.
+    let page2 = vec![json!({"id": 3})];
+    sink2
+        .write_batch_idempotent(&page2, scope, &format_token(2))
+        .await
+        .unwrap();
+    sink2.flush().await.unwrap();
+
+    // Destination must hold exactly 3 records (2 + 1), no duplicate of page 1.
+    let total = count_messages(&brokers, topic).await;
+    assert_eq!(total, 3, "expected zero duplicates on resume");
+
+    // And the latest committed token is now seq=2.
+    assert_eq!(
+        sink2.last_committed_token(scope).await.unwrap(),
+        Some(format_token(2))
+    );
+}

--- a/crates/sink/kafka/tests/integration.rs
+++ b/crates/sink/kafka/tests/integration.rs
@@ -55,6 +55,10 @@ fn sink_config(brokers: &str, topic: KafkaSinkTopic) -> KafkaSinkConfig {
         max_in_flight: 50,
         queue_full_backoff: Duration::from_millis(100),
         queue_full_max_retries: 3,
+        transactional_id_prefix: None,
+        commit_token_topic: "__faucet_commit_token".into(),
+        commit_token_topic_partitions: 1,
+        commit_token_topic_replication: -1,
         extra_client_config: BTreeMap::new(),
     }
 }

--- a/docs/book/src/cookbook/state.md
+++ b/docs/book/src/cookbook/state.md
@@ -100,6 +100,12 @@ records and the token atomically inside its own transaction:
   UNNEST(JSON_QUERY_ARRAY(@payload))` plus a `MERGE` into the
   `_faucet_commit_token` watermark table in the target dataset), so both land
   atomically.
+- **Kafka sink** — a transactional producer writes each page's records plus a
+  commit-token record into a compacted side-topic (default
+  `__faucet_commit_token`, auto-created with `cleanup.policy=compact`) inside one
+  Kafka transaction, so the data and the watermark commit atomically. The
+  `transactional.id` is auto-derived from the pipeline scope. Downstream
+  consumers should read the destination with `isolation.level=read_committed`.
 
 On the *next run*, before writing each page, the pipeline reads the sink's
 `last_committed_token` for the current scope. If the stored token is greater
@@ -114,7 +120,7 @@ Only certain connectors are allowed in an exactly-once pipeline:
 | Role | Allowed connectors | Why others are excluded |
 |------|--------------------|------------------------|
 | Source | `postgres-cdc`, `mysql-cdc`, `mongodb-cdc` | The source must deterministically replay the same pages from a given bookmark. Non-CDC / batch sources (REST, SQL query, etc.) do not replay deterministically — a different page on resume would cause the pipeline to silently skip records it never wrote. |
-| Sink | `sqlite`, `postgres`, `mysql`, `mssql`, `iceberg`, `bigquery` | The sink must be able to commit data and a watermark token atomically in a single transaction or snapshot. Sinks without transaction support cannot provide this guarantee. |
+| Sink | `sqlite`, `postgres`, `mysql`, `mssql`, `iceberg`, `bigquery`, `kafka` | The sink must be able to commit data and a watermark token atomically in a single transaction or snapshot. Sinks without transaction support cannot provide this guarantee. The Kafka sink uses a transactional producer that commits records plus a commit-token record into a compacted side-topic in one Kafka transaction. |
 
 A DLQ (`dlq:` block) is incompatible with `exactly_once` in this version.
 

--- a/docs/book/src/reference/connectors.md
+++ b/docs/book/src/reference/connectors.md
@@ -73,7 +73,7 @@ file/append sinks (`jsonl`, `csv`, `stdout`) it's a no-op — they write per rec
 | Elasticsearch | `sink-elasticsearch` | ✓ | ✗ | **✓** | ✗ | `_bulk` NDJSON (per-row DLQ) |
 | HTTP | `sink-http` | ✓ | ✗ | ✗ | ✗ | POST, concurrent under a semaphore |
 | Stdout | `sink-stdout` | no-op | ✗ | ✗ | ✗ | JSON Lines / pretty JSON / TSV |
-| Apache Kafka | `sink-kafka` | ✓ | ✗ | ✗ | ✗ | producer, batched sends, multi-topic routing |
+| Apache Kafka | `sink-kafka` | ✓ | ✗ | ✗ | **✓** | producer, batched sends, multi-topic routing; transactional producer + compacted watermark side-topic for exactly-once |
 | Apache Parquet | `sink-parquet` | ✓ | ✗⁶ | ✗ | ✗ | local/S3, schema inference, row/byte rollover |
 | Apache Iceberg | `sink-iceberg` | ✓ | ✗⁶ | ✗ | **✓** | REST/Glue/SQL/HMS catalog, local + cloud (S3/GCS) warehouses, `fast_append` snapshot, Parquet data files |
 
@@ -81,8 +81,9 @@ file/append sinks (`jsonl`, `csv`, `stdout`) it's a no-op — they write per rec
 level, so the file-level `compression` feature doesn't apply to either.
 ⁷ **Exactly-once** = commits data and a watermark token atomically; required for
 `delivery: exactly_once`. The BigQuery sink does this via a multi-statement
-`MERGE` transaction (distinct from its default streaming `insertAll` path);
-Kafka is at-least-once only in this version. See
+`MERGE` transaction (distinct from its default streaming `insertAll` path); the
+Kafka sink uses a transactional producer that writes each page's records plus a
+commit-token record into a compacted side-topic in one Kafka transaction. See
 [Exactly-once delivery](../cookbook/state.md#exactly-once-delivery).
 ⁸ **Upsert** = supports `write_mode: upsert` / `delete` (insert-or-update and
 delete by `key`) in addition to plain `append`. The SQL sinks require


### PR DESCRIPTION
Implements exactly-once delivery for the Kafka sink (#216), completing the exactly-once feature surface (#188) for the most common streaming sink.

## Mechanism
A transactional Kafka producer writes each page's records **plus** a per-page commit-token record into a compacted side-topic (`__faucet_commit_token`, auto-created) in **one Kafka transaction** — data + watermark commit atomically. On resume, `last_committed_token` reads the latest token for the pipeline scope back from the side-topic (`isolation.level=read_committed`, draining to the Last-Stable-Offset high watermark) and the pipeline skips already-committed pages → **zero duplicates**. The `transactional.id` is auto-derived from the pipeline scope (stable across restarts for zombie fencing, unique per row), with an optional `transactional_id_prefix`.

## Changes
- **`faucet-sink-kafka`**: 4 new config fields (`transactional_id_prefix`, `commit_token_topic`, `commit_token_topic_partitions`, `commit_token_topic_replication`); new `idempotent.rs` (txn.id derive, token selection, connection-only `client_config_base` + full `producer_client_config`, compacted side-topic auto-create, watermark read, in-txn enqueue/abort); the three `Sink` idempotency hooks via a lazily-built transactional producer (forces `enable.idempotence`/`acks=all`/`transactional.id`, `transaction.timeout.ms` floor, `init_transactions` fencing). Every error path aborts the transaction.
- **`faucet-cli`**: `kafka` added to `sink_supports_idempotent_writes` (the existing CDC-source + state + no-DLQ hard gate now admits it).
- **Tests**: unit (pure helpers + config validation) + a Docker integration test proving no-duplicate-on-resume (verified against a live broker).
- **Docs**: sink README exactly-once section, capability matrix, cookbook/state.md, runnable `cli/examples/postgres_cdc_to_kafka_exactly_once.yaml`.

## Notable correctness work
Two real bugs were caught during review/integration testing and fixed: (1) a stale-token read that could re-deliver committed pages (now fails loud rather than returning a low watermark); (2) a drain-loop stall under `read_committed` where `fetch_watermarks` counts transaction control markers never delivered by `poll` (now tracks consumer fetch position vs. the high watermark).

## Out of scope
`write_mode: upsert` for Kafka (stays append-only); `send_offsets_to_transaction` read-process-write EOS (no Kafka-source exactly-once path exists).

Closes #216.

🤖 Generated with [Claude Code](https://claude.com/claude-code)