### PR TITLE
feat: schema-drift handling policy (warn/evolve/ignore/quarantine/fail)

### DIFF
--- a/cli/examples/postgres_cdc_to_postgres_evolve.yaml
+++ b/cli/examples/postgres_cdc_to_postgres_evolve.yaml
@@ -1,0 +1,84 @@
+# End-to-end Postgres CDC -> Postgres upsert mirror with schema evolution.
+#
+# Streams logical-replication change events from a source database, normalizes
+# the CDC envelope with `cdc_unwrap`, and mirrors them into a destination table
+# with `write_mode: upsert`. The pipeline-level `schema:` block makes the mirror
+# resilient to source-schema drift: when the source table gains a column (or an
+# existing column widens losslessly), faucet applies the additive DDL to the
+# destination table in place and keeps streaming — no broken pipeline, no
+# manual `ALTER TABLE`.
+#
+# Setup on the SOURCE database (logical replication must be enabled):
+#   psql "$SOURCE_PG_URL" <<SQL
+#     CREATE TABLE IF NOT EXISTS users (id int4 PRIMARY KEY, name text);
+#     CREATE PUBLICATION faucet_pub FOR TABLE users;
+#   SQL
+#
+# Setup on the DEST database (upsert/delete need a UNIQUE/PRIMARY KEY on `key`):
+#   psql "$DEST_PG_URL" <<SQL
+#     CREATE TABLE IF NOT EXISTS users_mirror (id int4 PRIMARY KEY, name text);
+#   SQL
+#
+# Then:
+#   export SOURCE_PG_URL=postgres://faucet:faucet@localhost:5432/appdb
+#   export DEST_PG_URL=postgres://faucet:faucet@localhost:5432/warehouse
+#   faucet run cli/examples/postgres_cdc_to_postgres_evolve.yaml
+#
+# Now `ALTER TABLE users ADD COLUMN email text;` on the source and INSERT a row
+# with the new column — faucet adds `email` to `users_mirror` automatically on
+# the next fetch cycle, then writes the row.
+
+version: 1
+name: pg_cdc_mirror_evolve
+
+# Exactly-once delivery composes a CDC source + an idempotent SQL sink + a state
+# store with no DLQ. Schema `evolve` composes with exactly-once: the additive DDL
+# runs before the page write, then the records and the commit token land in one
+# transaction.
+delivery: exactly_once
+
+pipeline:
+  # Schema-drift policy (issue #194). `evolve` applies additive/widening DDL to
+  # the destination, then writes the page. `allow_type_widening` lets a lossless
+  # type change (e.g. integer -> number) be applied in place rather than treated
+  # as incompatible. `on_incompatible: fail` aborts on a narrowing / incompatible
+  # type swap that cannot be auto-applied.
+  schema:
+    on_drift: evolve
+    allow_type_widening: true
+    on_incompatible: fail
+
+  source:
+    type: postgres-cdc
+    config:
+      connection_url: ${env:SOURCE_PG_URL}
+      slot_name: faucet_mirror_evolve
+      publication_name: faucet_pub
+      create_slot_if_missing: true
+      idle_timeout: 30
+
+  # Normalize the postgres-cdc envelope ({op, before, after}) into a flat row
+  # plus a `__op` marker. Inserts/updates emit the post-image; deletes emit the
+  # key from the pre-image. DDL/truncate events are dropped.
+  transforms:
+    - type: cdc_unwrap
+
+  sink:
+    type: postgres
+    config:
+      connection_url: ${env:DEST_PG_URL}
+      table_name: users_mirror
+      # Upsert/delete and schema evolution both require column-mapping mode
+      # (not the single-JSONB-blob mode).
+      column_mapping: auto_map
+      max_connections: 5
+      # Insert-or-update by `id` (the mirror table needs a UNIQUE/PRIMARY KEY on
+      # it); rows whose `__op` is "d" are routed to DELETE instead.
+      write_mode: upsert
+      key: [id]
+      delete_marker: { field: __op, values: [d] }
+
+  state:
+    type: file
+    config:
+      path: ./state

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -141,6 +141,10 @@ pub struct PipelineSpec {
     #[cfg(feature = "quality")]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub quality: Option<faucet_core::QualitySpec>,
+
+    /// Schema-drift handling policy (pipeline-level; no matrix-row override in v1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub schema: Option<faucet_core::SchemaDriftSpec>,
 }
 
 /// A `{ type, config }` block, the universal shape for both sources and sinks.
@@ -745,6 +749,29 @@ replication:
         let cfg = parse_with_extension(yaml, "yaml").unwrap();
         let r = cfg.replication.expect("replication parsed");
         assert_eq!(r.snapshot.source.kind, "postgres");
+    }
+
+    #[test]
+    fn pipeline_spec_parses_schema_block() {
+        let yaml = r#"
+version: 1
+pipeline:
+  source:
+    type: rest
+    config:
+      base_url: https://api.example.com
+  sink:
+    type: jsonl
+    config:
+      path: ./out.jsonl
+  schema:
+    on_drift: evolve
+    allow_type_widening: false
+"#;
+        let cfg = parse_with_extension(yaml, "yaml").unwrap();
+        let schema = cfg.pipeline.schema.expect("schema block parsed");
+        assert_eq!(schema.on_drift, faucet_core::OnDrift::Evolve);
+        assert!(!schema.allow_type_widening);
     }
 
     #[test]

--- a/cli/src/env_config.rs
+++ b/cli/src/env_config.rs
@@ -317,6 +317,7 @@ pub fn build_pipeline_config(env: &HashMap<String, String>) -> CliResult<Pipelin
             dlq: None,
             #[cfg(feature = "quality")]
             quality: None,
+            schema: None,
         },
         matrix: Vec::new(),
         execution: None,

--- a/cli/src/executor.rs
+++ b/cli/src/executor.rs
@@ -879,6 +879,12 @@ async fn run_one_invocation(
     } else {
         pipeline
     };
+    // Schema-drift policy (pipeline-level in v1; same for every invocation).
+    let pipeline = if let Some(ref sd) = node.schema {
+        pipeline.with_schema_drift(faucet_core::SchemaDriftPolicy::compile(sd))
+    } else {
+        pipeline
+    };
     // Execution-level adaptive batch-size controller (shared by all rows).
     let pipeline = if let Some(ab) = opts
         .execution
@@ -1913,6 +1919,7 @@ matrix:
                 delivery: faucet_core::DeliveryMode::AtLeastOnce,
                 #[cfg(feature = "quality")]
                 quality: None,
+                schema: None,
                 deferred_refs: refs
                     .iter()
                     .map(|(rid, p)| DeferredRef {
@@ -1975,6 +1982,7 @@ matrix:
             delivery: faucet_core::DeliveryMode::AtLeastOnce,
             #[cfg(feature = "quality")]
             quality: None,
+            schema: None,
             deferred_refs: vec![DeferredRef {
                 referenced_id: "p".into(),
                 dotted_path: "".into(),
@@ -2219,6 +2227,7 @@ matrix:
             delivery: faucet_core::DeliveryMode::AtLeastOnce,
             #[cfg(feature = "quality")]
             quality: None,
+            schema: None,
             deferred_refs: Vec::new(),
         }
     }
@@ -2284,6 +2293,7 @@ matrix:
             delivery: faucet_core::DeliveryMode::AtLeastOnce,
             #[cfg(feature = "quality")]
             quality: None,
+            schema: None,
             deferred_refs: Vec::new(),
         };
         let err = run_expanded(vec![orphan], opts("deadlock"))

--- a/cli/src/executor.rs
+++ b/cli/src/executor.rs
@@ -1303,6 +1303,7 @@ mod tests {
                 dlq: None,
                 #[cfg(feature = "quality")]
                 quality: None,
+                schema: None,
             },
             matrix: Vec::new(),
             execution: None,

--- a/cli/src/expand.rs
+++ b/cli/src/expand.rs
@@ -1862,7 +1862,10 @@ pipeline:
         let err = expand(&c).unwrap_err();
         match &err {
             CliError::Config(msg) => {
-                assert!(msg.contains("evolve"), "expected evolve mention, got: {msg}");
+                assert!(
+                    msg.contains("evolve"),
+                    "expected evolve mention, got: {msg}"
+                );
                 assert!(msg.contains("jsonl"), "expected sink kind, got: {msg}");
             }
             other => panic!("expected Config error, got {other:?}"),

--- a/cli/src/expand.rs
+++ b/cli/src/expand.rs
@@ -510,6 +510,36 @@ pub fn expand(cfg: &PipelineConfig) -> CliResult<Vec<ExpandedNode>> {
             }
         }
 
+        // Schema-drift policy gates (load-time):
+        //  - `evolve` requires an evolution-capable sink.
+        //  - `quarantine` (drift or incompatible) requires a DLQ, and is
+        //    incompatible with exactly-once (which forbids a DLQ).
+        if let Some(ref sd) = cfg.pipeline.schema {
+            let policy = faucet_core::SchemaDriftPolicy::compile(sd);
+            if policy.on_drift == faucet_core::OnDrift::Evolve
+                && !crate::registry::sink_supports_schema_evolution(&merged_sink.kind)
+            {
+                return Err(CliError::Config(format!(
+                    "row '{}': schema.on_drift: evolve is not supported by sink '{}' \
+                     (evolvable sinks: postgres, mysql, mssql, sqlite, bigquery, elasticsearch)",
+                    ids[i], merged_sink.kind
+                )));
+            }
+            if policy.requires_dlq() && dlq.is_none() {
+                return Err(CliError::Config(format!(
+                    "row '{}': schema.on_drift/on_incompatible 'quarantine' requires a `dlq:` block",
+                    ids[i]
+                )));
+            }
+            if policy.requires_dlq() && delivery == faucet_core::DeliveryMode::ExactlyOnce {
+                return Err(CliError::Config(format!(
+                    "row '{}': schema quarantine is incompatible with delivery: exactly_once \
+                     (exactly_once forbids a DLQ)",
+                    ids[i]
+                )));
+            }
+        }
+
         out.push(ExpandedNode {
             id: ids[i].clone(),
             row_index: i,
@@ -1811,5 +1841,66 @@ resilience:
 "#);
         let nodes = expand(&c).expect("poison.action=drop needs no dlq");
         assert_eq!(nodes.len(), 1);
+    }
+
+    // --- schema-drift composition gate tests ---
+
+    #[test]
+    fn evolve_on_non_evolvable_sink_rejected() {
+        // jsonl is not evolution-capable; on_drift: evolve must fail.
+        let c = cfg(r#"
+version: 1
+pipeline:
+  source: { type: rest, config: { base_url: https://x } }
+  sink:   { type: jsonl, config: { path: ./o.jsonl } }
+  schema:
+    on_drift: evolve
+"#);
+        let err = expand(&c).unwrap_err();
+        match &err {
+            CliError::Config(msg) => {
+                assert!(msg.contains("evolve"), "expected evolve mention, got: {msg}");
+                assert!(msg.contains("jsonl"), "expected sink kind, got: {msg}");
+            }
+            other => panic!("expected Config error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn quarantine_drift_without_dlq_rejected() {
+        // on_drift: quarantine requires a dlq: block.
+        let c = cfg(r#"
+version: 1
+pipeline:
+  source: { type: rest, config: { base_url: https://x } }
+  sink:   { type: postgres, config: {} }
+  schema:
+    on_drift: quarantine
+"#);
+        let err = expand(&c).unwrap_err();
+        match &err {
+            CliError::Config(msg) => {
+                assert!(
+                    msg.contains("quarantine"),
+                    "expected quarantine mention, got: {msg}"
+                );
+                assert!(msg.contains("dlq") || msg.contains("DLQ"), "got: {msg}");
+            }
+            other => panic!("expected Config error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn evolve_on_postgres_passes() {
+        // postgres is evolution-capable; on_drift: evolve must expand.
+        let c = cfg(r#"
+version: 1
+pipeline:
+  source: { type: rest, config: { base_url: https://x } }
+  sink:   { type: postgres, config: {} }
+  schema:
+    on_drift: evolve
+"#);
+        assert!(expand(&c).is_ok());
     }
 }

--- a/cli/src/expand.rs
+++ b/cli/src/expand.rs
@@ -42,6 +42,8 @@ pub struct ExpandedNode {
     /// matrix-row override in v1, so this is `cfg.pipeline.quality` verbatim.
     #[cfg(feature = "quality")]
     pub quality: Option<faucet_core::QualitySpec>,
+    /// Compiled schema-drift policy spec (pipeline-level; same for every node).
+    pub schema: Option<faucet_core::SchemaDriftSpec>,
     /// Delivery guarantee for this row. Resolved from the row's override or
     /// falls back to the top-level `cfg.delivery`.
     pub delivery: faucet_core::DeliveryMode,
@@ -552,6 +554,7 @@ pub fn expand(cfg: &PipelineConfig) -> CliResult<Vec<ExpandedNode>> {
             delivery,
             #[cfg(feature = "quality")]
             quality,
+            schema: cfg.pipeline.schema.clone(),
             deferred_refs: deferred,
         });
     }

--- a/cli/src/registry.rs
+++ b/cli/src/registry.rs
@@ -367,6 +367,16 @@ pub fn sink_supports_idempotent_writes(kind: &str) -> bool {
     )
 }
 
+/// Sink kinds that can apply additive/widening DDL via `Sink::evolve_schema`.
+/// Mirrors each sink's `supports_schema_evolution()` override. Iceberg is
+/// intentionally excluded — iceberg-rust 0.9.1 exposes no schema-evolution API (#255).
+pub fn sink_supports_schema_evolution(kind: &str) -> bool {
+    matches!(
+        kind,
+        "postgres" | "mysql" | "mssql" | "sqlite" | "bigquery" | "elasticsearch"
+    )
+}
+
 /// Write modes each sink kind supports. Kept in sync with each sink's
 /// `Sink::supported_write_modes()` override.
 pub fn sink_supported_write_modes(kind: &str) -> &'static [faucet_core::WriteMode] {
@@ -1011,5 +1021,18 @@ mod tests {
         // a sink without upsert support is append-only
         assert_eq!(sink_supported_write_modes("jsonl"), &[WriteMode::Append]);
         assert_eq!(sink_supported_write_modes("kafka"), &[WriteMode::Append]);
+    }
+
+    #[test]
+    fn sink_supports_schema_evolution_allowlist() {
+        assert!(sink_supports_schema_evolution("postgres"));
+        assert!(sink_supports_schema_evolution("mysql"));
+        assert!(sink_supports_schema_evolution("mssql"));
+        assert!(sink_supports_schema_evolution("sqlite"));
+        assert!(sink_supports_schema_evolution("bigquery"));
+        assert!(sink_supports_schema_evolution("elasticsearch"));
+        assert!(!sink_supports_schema_evolution("iceberg"));
+        assert!(!sink_supports_schema_evolution("jsonl"));
+        assert!(!sink_supports_schema_evolution("kafka"));
     }
 }

--- a/cli/tests/cli_end_to_end.rs
+++ b/cli/tests/cli_end_to_end.rs
@@ -443,6 +443,169 @@ pipeline:
     assert!(lines[0].contains("\"alice\""));
 }
 
+/// Create a SQLite database file with `table_sql` using the system `sqlite3`
+/// CLI. Used to pre-seed a destination table whose shape is a strict subset of
+/// the incoming page so the drift pass has something to detect. Returns whether
+/// the `sqlite3` binary was available (tests skip themselves if not).
+fn sqlite_exec(db: &Path, sql: &str) -> bool {
+    match std::process::Command::new("sqlite3")
+        .arg(db)
+        .arg(sql)
+        .output()
+    {
+        Ok(out) => {
+            assert!(
+                out.status.success(),
+                "sqlite3 failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+            true
+        }
+        // `sqlite3` not installed on this host — caller skips the test.
+        Err(_) => false,
+    }
+}
+
+/// Read the output of a `sqlite3 <db> <query>` invocation as trimmed stdout.
+fn sqlite_query(db: &Path, sql: &str) -> String {
+    let out = std::process::Command::new("sqlite3")
+        .arg(db)
+        .arg(sql)
+        .output()
+        .expect("sqlite3 query");
+    assert!(
+        out.status.success(),
+        "sqlite3 query failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+/// End-to-end proof that the schema-drift policy actually *fires* through a
+/// schema-reporting sink — the real regression guard for the executor seam
+/// (`with_schema_drift`). Unlike the schemaless-jsonl test above (which is inert
+/// because jsonl reports no `current_schema`), this drives csv → **sqlite** with
+/// the destination table pre-created as a strict subset (`id` only) of the
+/// incoming rows (which also carry `name`). With `pipeline.schema.on_drift:
+/// fail` the run MUST abort.
+///
+/// This exercises the whole chain: config parses the `schema:` block →
+/// `expand` carries it onto the node → `executor` attaches the policy via
+/// `pipeline.with_schema_drift(...)` → `run_stream` runs the per-page drift pass
+/// → the sqlite `current_schema` PRAGMA returns `{id}` → `diff_schema` finds the
+/// `name` addition → the `fail` policy raises `FaucetError::SchemaDrift` →
+/// the run exits non-zero. If the wiring were broken (policy never attached),
+/// the drift pass would not run and the page would write successfully — so a
+/// SUCCESS here would catch a regression in the seam.
+#[test]
+fn run_schema_drift_fail_fires_through_a_schema_reporting_sink() {
+    let dir = TempDir::new().unwrap();
+    let csv = dir.path().join("in.csv");
+    let db = dir.path().join("dest.db");
+    // Rows carry both `id` and `name`; the destination table will have only `id`.
+    fs::write(&csv, "id,name\n1,alice\n2,bob\n").unwrap();
+
+    // Pre-create the destination table as a STRICT SUBSET of the source rows.
+    if !sqlite_exec(&db, "CREATE TABLE t (id INTEGER);") {
+        eprintln!("skipping: sqlite3 CLI not available");
+        return;
+    }
+
+    let yaml = format!(
+        r#"version: 1
+name: csv_to_sqlite_drift_fail
+pipeline:
+  source:
+    type: csv
+    config:
+      path: {csv}
+  sink:
+    type: sqlite
+    config:
+      database_url: sqlite:{db}
+      table_name: t
+      column_mapping: auto_map
+  schema:
+    on_drift: fail
+"#,
+        csv = csv.display(),
+        db = db.display(),
+    );
+    let cfg = dir.path().join("pipeline.yaml");
+    fs::write(&cfg, yaml).unwrap();
+
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["run"])
+        .arg(&cfg)
+        .assert()
+        .failure()
+        // The aborting FaucetError reaches stderr via the executor's
+        // `tracing::error!(error = %err, ...)`; it names the drifted column.
+        .stderr(contains("Schema drift"))
+        .stderr(contains("name"));
+
+    // The page never committed: the table is still empty.
+    assert_eq!(sqlite_query(&db, "SELECT count(*) FROM t;"), "0");
+}
+
+/// Positive counterpart: same csv → sqlite setup with the destination table a
+/// strict subset (`id` only), but `pipeline.schema.on_drift: ignore`. The run
+/// must SUCCEED and the unknown `name` column is stripped before the write, so
+/// the destination ends up with the two `id` values and nothing else. This
+/// proves the policy fires and takes the `ignore` branch (drop-unknown-fields),
+/// the complement of the `fail` test above.
+#[test]
+fn run_schema_drift_ignore_strips_unknown_columns_through_sqlite() {
+    let dir = TempDir::new().unwrap();
+    let csv = dir.path().join("in.csv");
+    let db = dir.path().join("dest.db");
+    fs::write(&csv, "id,name\n1,alice\n2,bob\n").unwrap();
+
+    if !sqlite_exec(&db, "CREATE TABLE t (id INTEGER);") {
+        eprintln!("skipping: sqlite3 CLI not available");
+        return;
+    }
+
+    let yaml = format!(
+        r#"version: 1
+name: csv_to_sqlite_drift_ignore
+pipeline:
+  source:
+    type: csv
+    config:
+      path: {csv}
+  sink:
+    type: sqlite
+    config:
+      database_url: sqlite:{db}
+      table_name: t
+      column_mapping: auto_map
+  schema:
+    on_drift: ignore
+"#,
+        csv = csv.display(),
+        db = db.display(),
+    );
+    let cfg = dir.path().join("pipeline.yaml");
+    fs::write(&cfg, yaml).unwrap();
+
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["run"])
+        .arg(&cfg)
+        .assert()
+        .success()
+        .stdout(contains("wrote 2 records"));
+
+    // Both rows landed with only the in-schema `id` column; `name` was stripped.
+    assert_eq!(sqlite_query(&db, "SELECT count(*) FROM t;"), "2");
+    assert_eq!(
+        sqlite_query(&db, "SELECT id FROM t ORDER BY id;"),
+        "1\n2"
+    );
+}
+
 #[test]
 fn run_with_dry_run_does_not_touch_the_sink_path() {
     let dir = TempDir::new().unwrap();

--- a/cli/tests/cli_end_to_end.rs
+++ b/cli/tests/cli_end_to_end.rs
@@ -600,10 +600,7 @@ pipeline:
 
     // Both rows landed with only the in-schema `id` column; `name` was stripped.
     assert_eq!(sqlite_query(&db, "SELECT count(*) FROM t;"), "2");
-    assert_eq!(
-        sqlite_query(&db, "SELECT id FROM t ORDER BY id;"),
-        "1\n2"
-    );
+    assert_eq!(sqlite_query(&db, "SELECT id FROM t ORDER BY id;"), "1\n2");
 }
 
 #[test]

--- a/cli/tests/cli_end_to_end.rs
+++ b/cli/tests/cli_end_to_end.rs
@@ -392,6 +392,57 @@ fn run_executes_csv_to_jsonl_pipeline() {
     assert!(lines[0].contains("\"alice\""));
 }
 
+/// A `schema:` drift block must not break a normal run when the sink reports
+/// no `current_schema` (jsonl is schemaless): the drift pass is inert. This
+/// proves the executor wiring (`with_schema_drift`) compiles and is harmless
+/// against a schemaless sink — same output as the plain csv→jsonl run.
+#[test]
+fn run_with_schema_drift_warn_against_schemaless_sink_is_inert() {
+    let dir = TempDir::new().unwrap();
+    let csv = dir.path().join("in.csv");
+    let out = dir.path().join("out.jsonl");
+    fs::write(&csv, "name,score\nalice,1\nbob,2\n").unwrap();
+
+    let yaml = format!(
+        r#"version: 1
+name: csv_to_jsonl_drift
+pipeline:
+  source:
+    type: csv
+    config:
+      path: {csv}
+  sink:
+    type: jsonl
+    config:
+      path: {out}
+  schema:
+    on_drift: warn
+"#,
+        csv = csv.display(),
+        out = out.display(),
+    );
+    let cfg = dir.path().join("pipeline.yaml");
+    fs::write(&cfg, yaml).unwrap();
+
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["run"])
+        .arg(&cfg)
+        .assert()
+        .success()
+        .stdout(contains("wrote 2 records"))
+        .stdout(contains("1 invocation"));
+
+    // Output is unchanged: the drift policy is present but harmless.
+    let lines: Vec<_> = fs::read_to_string(&out)
+        .unwrap()
+        .lines()
+        .map(str::to_owned)
+        .collect();
+    assert_eq!(lines.len(), 2);
+    assert!(lines[0].contains("\"alice\""));
+}
+
 #[test]
 fn run_with_dry_run_does_not_touch_the_sink_path() {
     let dir = TempDir::new().unwrap();

--- a/crates/core/src/dlq.rs
+++ b/crates/core/src/dlq.rs
@@ -103,6 +103,9 @@ pub enum DlqReason {
     DlqAll,
     /// A record was quarantined (or batch-quarantined) by a data-quality check.
     Quality,
+    /// A record was routed to the DLQ by an `on_drift`/`on_incompatible`
+    /// quarantine policy.
+    SchemaDrift,
 }
 
 impl DlqReason {
@@ -113,6 +116,7 @@ impl DlqReason {
             DlqReason::Partial => "partial",
             DlqReason::DlqAll => "dlq_all",
             DlqReason::Quality => "quality",
+            DlqReason::SchemaDrift => "schema_drift",
         }
     }
 }
@@ -223,5 +227,10 @@ mod tests {
     #[test]
     fn dlq_reason_quality_string() {
         assert_eq!(DlqReason::Quality.as_str(), "quality");
+    }
+
+    #[test]
+    fn dlq_reason_schema_drift_string() {
+        assert_eq!(DlqReason::SchemaDrift.as_str(), "schema_drift");
     }
 }

--- a/crates/core/src/drift.rs
+++ b/crates/core/src/drift.rs
@@ -105,29 +105,41 @@ fn type_set(fragment: &Value) -> (Vec<String>, bool) {
     (names, nullable)
 }
 
-/// Is moving from `from` to `to` a lossless widening?
-/// Top-level rules (issue #194): integer→number, and gaining nullability.
-fn is_widening(from: &Value, to: &Value) -> bool {
-    let (fnames, fnull) = type_set(from);
-    let (tnames, tnull) = type_set(to);
-    // Same non-null base types, but `to` adds nullability → widening.
-    if fnames == tnames && !fnull && tnull {
-        return true;
+/// Are the page's values already acceptable as-is by the destination?
+///
+/// True iff the page introduces no nulls a non-nullable destination would
+/// reject, AND every non-null base type the page carries is accepted by the
+/// destination (an exact base-type match, or `integer` landing in a `number`
+/// column). `fits` is never gated by `allow_widening` — a fitting page is not
+/// drift at all.
+fn fits(dest: &Value, page: &Value) -> bool {
+    let (dn, dnull) = type_set(dest);
+    let (pn, pnull) = type_set(page);
+    // The page must not introduce nulls a non-nullable destination rejects.
+    if pnull && !dnull {
+        return false;
     }
-    // integer → number (with or without matching nullability).
-    if fnames == vec!["integer".to_string()] && tnames == vec!["number".to_string()] && fnull == tnull
-    {
-        return true;
-    }
-    false
+    // Every page base type must be accepted by the destination.
+    pn.iter()
+        .all(|t| dn.contains(t) || (t == "integer" && dn.iter().any(|d| d == "number")))
 }
 
-/// Are the two fragments the same type (ignoring property/items detail —
-/// top-level only)?
-fn same_base_type(a: &Value, b: &Value) -> bool {
-    let (an, anull) = type_set(a);
-    let (bn, bnull) = type_set(b);
-    an == bn && anull == bnull
+/// Can the destination column losslessly evolve to accept the page?
+///
+/// The merged non-null base family must collapse to a single base type: take
+/// `dest ∪ page`, drop `integer` if `number` is present (int→number collapse),
+/// and require exactly one element. Nullability relaxation is always evolvable,
+/// so only the base-family check gates this.
+fn evolvable(dest: &Value, page: &Value) -> bool {
+    let (dn, _) = type_set(dest);
+    let (pn, _) = type_set(page);
+    let mut merged: Vec<String> = dn.into_iter().chain(pn).collect();
+    merged.sort();
+    merged.dedup();
+    if merged.iter().any(|t| t == "number") {
+        merged.retain(|t| t != "integer");
+    }
+    merged.len() == 1
 }
 
 /// Diff a page's inferred shape against the destination schema (top-level columns).
@@ -156,15 +168,15 @@ pub fn diff_schema(destination: &Value, page: &Value, allow_widening: bool) -> S
                 to: page_ty.clone(),
             }),
             Some(dest_ty) => {
-                if same_base_type(dest_ty, page_ty) {
-                    continue; // no change
+                if fits(dest_ty, page_ty) {
+                    continue; // page values already acceptable — no drift
                 }
                 let change = ColumnChange {
                     name: name.clone(),
                     from: Some(dest_ty.clone()),
                     to: page_ty.clone(),
                 };
-                if allow_widening && is_widening(dest_ty, page_ty) {
+                if allow_widening && evolvable(dest_ty, page_ty) {
                     diff.widenings.push(change);
                 } else {
                     diff.incompatible.push(change);
@@ -361,6 +373,112 @@ mod tests {
         let page = schema(json!({ "meta": {"type": "object", "properties": {"a": {"type": "integer"}, "b": {"type": "string"}}} }));
         let d = diff_schema(&dest, &page, true);
         assert!(d.is_empty(), "nested changes must not surface as drift; got {d:?}");
+    }
+
+    /// Which bucket a single-column diff landed in.
+    #[derive(Debug, PartialEq)]
+    enum Bucket {
+        None,
+        Widening,
+        Incompatible,
+    }
+
+    /// Diff a single column `col` (D vs P) and report which bucket it landed in.
+    fn classify_one(dest_ty: Value, page_ty: Value, allow_widening: bool) -> Bucket {
+        let dest = schema(json!({ "col": dest_ty }));
+        let page = schema(json!({ "col": page_ty }));
+        let d = diff_schema(&dest, &page, allow_widening);
+        assert!(d.additions.is_empty(), "unexpected addition: {d:?}");
+        assert!(d.droppable_required.is_empty(), "unexpected droppable: {d:?}");
+        match (d.widenings.len(), d.incompatible.len()) {
+            (0, 0) => Bucket::None,
+            (1, 0) => Bucket::Widening,
+            (0, 1) => Bucket::Incompatible,
+            _ => panic!("ambiguous classification: {d:?}"),
+        }
+    }
+
+    #[test]
+    fn truth_table_allow_widening() {
+        use Bucket::*;
+        // (dest, page, expected bucket) — allow_widening = true.
+        let cases: &[(Value, Value, Bucket)] = &[
+            (json!({"type": "integer"}), json!({"type": "integer"}), None),
+            (json!({"type": "string"}), json!({"type": "string"}), None),
+            (
+                json!({"type": ["string", "null"]}),
+                json!({"type": ["string", "null"]}),
+                None,
+            ),
+            // Regression guard: non-null page fits a nullable dest.
+            (
+                json!({"type": ["string", "null"]}),
+                json!({"type": "string"}),
+                None,
+            ),
+            // Regression guard: integer fits a number column.
+            (json!({"type": "number"}), json!({"type": "integer"}), None),
+            // integer → number widening.
+            (json!({"type": "integer"}), json!({"type": "number"}), Widening),
+            // string → nullable string (relax null).
+            (
+                json!({"type": "string"}),
+                json!({"type": ["string", "null"]}),
+                Widening,
+            ),
+            // integer → nullable number (int→number + null relax).
+            (
+                json!({"type": "integer"}),
+                json!({"type": ["number", "null"]}),
+                Widening,
+            ),
+            // nullable integer dest, number page → int→number, dest already nullable.
+            (
+                json!({"type": ["integer", "null"]}),
+                json!({"type": "number"}),
+                Widening,
+            ),
+            // Genuine incompatibilities.
+            (json!({"type": "string"}), json!({"type": "integer"}), Incompatible),
+            (json!({"type": "integer"}), json!({"type": "string"}), Incompatible),
+            (json!({"type": "boolean"}), json!({"type": "number"}), Incompatible),
+        ];
+        for (dest, page, want) in cases {
+            let got = classify_one(dest.clone(), page.clone(), true);
+            assert_eq!(
+                &got, want,
+                "allow_widening=true: D={dest} P={page} expected {want:?} got {got:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn truth_table_widening_disallowed() {
+        use Bucket::*;
+        // (dest, page, expected bucket) — allow_widening = false.
+        let cases: &[(Value, Value, Bucket)] = &[
+            // int→number is no longer a widening; with widening off it is incompatible.
+            (json!({"type": "integer"}), json!({"type": "number"}), Incompatible),
+            // `fits` still applies regardless of allow_widening.
+            (
+                json!({"type": ["string", "null"]}),
+                json!({"type": "string"}),
+                None,
+            ),
+            // null relaxation is a widening, not a fit → incompatible when disallowed.
+            (
+                json!({"type": "string"}),
+                json!({"type": ["string", "null"]}),
+                Incompatible,
+            ),
+        ];
+        for (dest, page, want) in cases {
+            let got = classify_one(dest.clone(), page.clone(), false);
+            assert_eq!(
+                &got, want,
+                "allow_widening=false: D={dest} P={page} expected {want:?} got {got:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/core/src/drift.rs
+++ b/crates/core/src/drift.rs
@@ -189,6 +189,82 @@ pub fn diff_schema(destination: &Value, page: &Value, allow_widening: bool) -> S
     diff
 }
 
+/// What to do when drift is detected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum OnDrift {
+    /// Detect + emit a metric and a one-shot log; write the page unchanged.
+    #[default]
+    Warn,
+    /// Apply additive/widening DDL to the destination, then write.
+    Evolve,
+    /// Drop unknown (non-destination) fields from every record; write the rest.
+    Ignore,
+    /// Route the records that exhibit the drift to the DLQ; write the rest.
+    Quarantine,
+    /// Raise `FaucetError::SchemaDrift` and abort.
+    Fail,
+}
+
+/// `evolve`-only: what to do with a narrowing/incompatible change that can't be
+/// auto-applied.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum OnIncompatible {
+    /// Abort the run (default).
+    #[default]
+    Fail,
+    /// Route the offending records to the DLQ.
+    Quarantine,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+/// User-facing `schema:` config block (pipeline level).
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct SchemaDriftSpec {
+    /// Policy applied when drift is detected.
+    #[serde(default)]
+    pub on_drift: OnDrift,
+    /// Whether a lossless widening counts as evolvable (vs incompatible).
+    /// Only consulted by `evolve`. Default: true.
+    #[serde(default = "default_true")]
+    pub allow_type_widening: bool,
+    /// `evolve` only: action for an incompatible residue. Default: fail.
+    #[serde(default)]
+    pub on_incompatible: OnIncompatible,
+}
+
+/// Compiled, ready-to-run drift policy. Cheap to clone.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SchemaDriftPolicy {
+    pub on_drift: OnDrift,
+    pub allow_widening: bool,
+    pub on_incompatible: OnIncompatible,
+}
+
+impl SchemaDriftPolicy {
+    /// Compile a spec into a runnable policy. Infallible — there is nothing to
+    /// validate that serde hasn't already (the DLQ requirement is enforced by
+    /// the pipeline at run start and by the CLI at config-load).
+    pub fn compile(spec: &SchemaDriftSpec) -> Self {
+        Self {
+            on_drift: spec.on_drift,
+            allow_widening: spec.allow_type_widening,
+            on_incompatible: spec.on_incompatible,
+        }
+    }
+
+    /// `true` when this policy can route records to a DLQ (so one must exist).
+    pub fn requires_dlq(&self) -> bool {
+        self.on_drift == OnDrift::Quarantine
+            || (self.on_drift == OnDrift::Evolve && self.on_incompatible == OnIncompatible::Quarantine)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -285,5 +361,40 @@ mod tests {
         let page = schema(json!({ "meta": {"type": "object", "properties": {"a": {"type": "integer"}, "b": {"type": "string"}}} }));
         let d = diff_schema(&dest, &page, true);
         assert!(d.is_empty(), "nested changes must not surface as drift; got {d:?}");
+    }
+
+    #[test]
+    fn spec_defaults() {
+        let spec: SchemaDriftSpec = serde_json::from_str("{}").unwrap();
+        assert_eq!(spec.on_drift, OnDrift::Warn);
+        assert!(spec.allow_type_widening);
+        assert_eq!(spec.on_incompatible, OnIncompatible::Fail);
+    }
+
+    #[test]
+    fn on_drift_serializes_snake_case() {
+        assert_eq!(serde_json::to_string(&OnDrift::Evolve).unwrap(), "\"evolve\"");
+        assert_eq!(serde_json::to_string(&OnDrift::Quarantine).unwrap(), "\"quarantine\"");
+    }
+
+    #[test]
+    fn policy_compile_carries_flags() {
+        let spec: SchemaDriftSpec =
+            serde_json::from_str(r#"{"on_drift":"evolve","allow_type_widening":false}"#).unwrap();
+        let policy = SchemaDriftPolicy::compile(&spec);
+        assert_eq!(policy.on_drift, OnDrift::Evolve);
+        assert!(!policy.allow_widening);
+        assert_eq!(policy.on_incompatible, OnIncompatible::Fail);
+    }
+
+    #[test]
+    fn policy_requires_dlq_only_for_quarantine_paths() {
+        let q: SchemaDriftSpec = serde_json::from_str(r#"{"on_drift":"quarantine"}"#).unwrap();
+        assert!(SchemaDriftPolicy::compile(&q).requires_dlq());
+        let evo_q: SchemaDriftSpec =
+            serde_json::from_str(r#"{"on_drift":"evolve","on_incompatible":"quarantine"}"#).unwrap();
+        assert!(SchemaDriftPolicy::compile(&evo_q).requires_dlq());
+        let warn: SchemaDriftSpec = serde_json::from_str(r#"{"on_drift":"warn"}"#).unwrap();
+        assert!(!SchemaDriftPolicy::compile(&warn).requires_dlq());
     }
 }

--- a/crates/core/src/drift.rs
+++ b/crates/core/src/drift.rs
@@ -307,7 +307,8 @@ impl SchemaDriftPolicy {
     /// `true` when this policy can route records to a DLQ (so one must exist).
     pub fn requires_dlq(&self) -> bool {
         self.on_drift == OnDrift::Quarantine
-            || (self.on_drift == OnDrift::Evolve && self.on_incompatible == OnIncompatible::Quarantine)
+            || (self.on_drift == OnDrift::Evolve
+                && self.on_incompatible == OnIncompatible::Quarantine)
     }
 }
 
@@ -359,11 +360,23 @@ mod tests {
     #[test]
     fn sql_type_mapping() {
         use super::SqlBaseType::*;
-        assert_eq!(json_schema_base_type(&json!({"type":"integer"})), Some(Integer));
-        assert_eq!(json_schema_base_type(&json!({"type":"number"})), Some(Double));
-        assert_eq!(json_schema_base_type(&json!({"type":"boolean"})), Some(Boolean));
+        assert_eq!(
+            json_schema_base_type(&json!({"type":"integer"})),
+            Some(Integer)
+        );
+        assert_eq!(
+            json_schema_base_type(&json!({"type":"number"})),
+            Some(Double)
+        );
+        assert_eq!(
+            json_schema_base_type(&json!({"type":"boolean"})),
+            Some(Boolean)
+        );
         assert_eq!(json_schema_base_type(&json!({"type":"string"})), Some(Text));
-        assert_eq!(json_schema_base_type(&json!({"type":["string","null"]})), Some(Text));
+        assert_eq!(
+            json_schema_base_type(&json!({"type":["string","null"]})),
+            Some(Text)
+        );
         assert_eq!(json_schema_base_type(&json!({"type":"object"})), Some(Json));
         assert_eq!(json_schema_base_type(&json!({"type":"array"})), Some(Json));
         assert_eq!(json_schema_base_type(&json!({"type":"null"})), None);
@@ -434,7 +447,11 @@ mod tests {
         }));
         let page = schema(json!({ "id": {"type": "integer"} }));
         let d = diff_schema(&dest, &page, true);
-        assert_eq!(d.droppable_required, vec!["created_at".to_string()], "got {d:?}");
+        assert_eq!(
+            d.droppable_required,
+            vec!["created_at".to_string()],
+            "got {d:?}"
+        );
     }
 
     #[test]
@@ -452,10 +469,16 @@ mod tests {
     #[test]
     fn nested_object_treated_as_single_column() {
         // A change *inside* a nested object is invisible — top-level only.
-        let dest = schema(json!({ "meta": {"type": "object", "properties": {"a": {"type": "integer"}}} }));
-        let page = schema(json!({ "meta": {"type": "object", "properties": {"a": {"type": "integer"}, "b": {"type": "string"}}} }));
+        let dest =
+            schema(json!({ "meta": {"type": "object", "properties": {"a": {"type": "integer"}}} }));
+        let page = schema(
+            json!({ "meta": {"type": "object", "properties": {"a": {"type": "integer"}, "b": {"type": "string"}}} }),
+        );
         let d = diff_schema(&dest, &page, true);
-        assert!(d.is_empty(), "nested changes must not surface as drift; got {d:?}");
+        assert!(
+            d.is_empty(),
+            "nested changes must not surface as drift; got {d:?}"
+        );
     }
 
     /// Which bucket a single-column diff landed in.
@@ -472,7 +495,10 @@ mod tests {
         let page = schema(json!({ "col": page_ty }));
         let d = diff_schema(&dest, &page, allow_widening);
         assert!(d.additions.is_empty(), "unexpected addition: {d:?}");
-        assert!(d.droppable_required.is_empty(), "unexpected droppable: {d:?}");
+        assert!(
+            d.droppable_required.is_empty(),
+            "unexpected droppable: {d:?}"
+        );
         match (d.widenings.len(), d.incompatible.len()) {
             (0, 0) => Bucket::None,
             (1, 0) => Bucket::Widening,
@@ -502,7 +528,11 @@ mod tests {
             // Regression guard: integer fits a number column.
             (json!({"type": "number"}), json!({"type": "integer"}), None),
             // integer → number widening.
-            (json!({"type": "integer"}), json!({"type": "number"}), Widening),
+            (
+                json!({"type": "integer"}),
+                json!({"type": "number"}),
+                Widening,
+            ),
             // string → nullable string (relax null).
             (
                 json!({"type": "string"}),
@@ -522,9 +552,21 @@ mod tests {
                 Widening,
             ),
             // Genuine incompatibilities.
-            (json!({"type": "string"}), json!({"type": "integer"}), Incompatible),
-            (json!({"type": "integer"}), json!({"type": "string"}), Incompatible),
-            (json!({"type": "boolean"}), json!({"type": "number"}), Incompatible),
+            (
+                json!({"type": "string"}),
+                json!({"type": "integer"}),
+                Incompatible,
+            ),
+            (
+                json!({"type": "integer"}),
+                json!({"type": "string"}),
+                Incompatible,
+            ),
+            (
+                json!({"type": "boolean"}),
+                json!({"type": "number"}),
+                Incompatible,
+            ),
         ];
         for (dest, page, want) in cases {
             let got = classify_one(dest.clone(), page.clone(), true);
@@ -541,7 +583,11 @@ mod tests {
         // (dest, page, expected bucket) — allow_widening = false.
         let cases: &[(Value, Value, Bucket)] = &[
             // int→number is no longer a widening; with widening off it is incompatible.
-            (json!({"type": "integer"}), json!({"type": "number"}), Incompatible),
+            (
+                json!({"type": "integer"}),
+                json!({"type": "number"}),
+                Incompatible,
+            ),
             // `fits` still applies regardless of allow_widening.
             (
                 json!({"type": ["string", "null"]}),
@@ -567,7 +613,10 @@ mod tests {
     #[test]
     fn base_widened_detects_base_type_change() {
         // integer → number is a base-type widening (needs ALTER TYPE).
-        assert!(base_widened(&json!({"type": "integer"}), &json!({"type": "number"})));
+        assert!(base_widened(
+            &json!({"type": "integer"}),
+            &json!({"type": "number"})
+        ));
         // nullability-only relaxation is NOT a base-type widening.
         assert!(!base_widened(
             &json!({"type": "string"}),
@@ -622,8 +671,14 @@ mod tests {
 
     #[test]
     fn on_drift_serializes_snake_case() {
-        assert_eq!(serde_json::to_string(&OnDrift::Evolve).unwrap(), "\"evolve\"");
-        assert_eq!(serde_json::to_string(&OnDrift::Quarantine).unwrap(), "\"quarantine\"");
+        assert_eq!(
+            serde_json::to_string(&OnDrift::Evolve).unwrap(),
+            "\"evolve\""
+        );
+        assert_eq!(
+            serde_json::to_string(&OnDrift::Quarantine).unwrap(),
+            "\"quarantine\""
+        );
     }
 
     #[test]
@@ -641,7 +696,8 @@ mod tests {
         let q: SchemaDriftSpec = serde_json::from_str(r#"{"on_drift":"quarantine"}"#).unwrap();
         assert!(SchemaDriftPolicy::compile(&q).requires_dlq());
         let evo_q: SchemaDriftSpec =
-            serde_json::from_str(r#"{"on_drift":"evolve","on_incompatible":"quarantine"}"#).unwrap();
+            serde_json::from_str(r#"{"on_drift":"evolve","on_incompatible":"quarantine"}"#)
+                .unwrap();
         assert!(SchemaDriftPolicy::compile(&evo_q).requires_dlq());
         let warn: SchemaDriftSpec = serde_json::from_str(r#"{"on_drift":"warn"}"#).unwrap();
         assert!(!SchemaDriftPolicy::compile(&warn).requires_dlq());

--- a/crates/core/src/drift.rs
+++ b/crates/core/src/drift.rs
@@ -74,3 +74,216 @@ impl SchemaEvolution {
         self.additions.is_empty() && self.widenings.is_empty() && self.relax_nullability.is_empty()
     }
 }
+
+/// The set of JSON-Schema primitive type names a fragment carries (excluding `null`),
+/// plus whether `null` is present.
+fn type_set(fragment: &Value) -> (Vec<String>, bool) {
+    let mut names = Vec::new();
+    let mut nullable = false;
+    match fragment.get("type") {
+        Some(Value::String(t)) => {
+            if t == "null" {
+                nullable = true
+            } else {
+                names.push(t.clone())
+            }
+        }
+        Some(Value::Array(arr)) => {
+            for v in arr {
+                if let Some(t) = v.as_str() {
+                    if t == "null" {
+                        nullable = true
+                    } else {
+                        names.push(t.to_string())
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+    names.sort();
+    (names, nullable)
+}
+
+/// Is moving from `from` to `to` a lossless widening?
+/// Top-level rules (issue #194): integer→number, and gaining nullability.
+fn is_widening(from: &Value, to: &Value) -> bool {
+    let (fnames, fnull) = type_set(from);
+    let (tnames, tnull) = type_set(to);
+    // Same non-null base types, but `to` adds nullability → widening.
+    if fnames == tnames && !fnull && tnull {
+        return true;
+    }
+    // integer → number (with or without matching nullability).
+    if fnames == vec!["integer".to_string()] && tnames == vec!["number".to_string()] && fnull == tnull
+    {
+        return true;
+    }
+    false
+}
+
+/// Are the two fragments the same type (ignoring property/items detail —
+/// top-level only)?
+fn same_base_type(a: &Value, b: &Value) -> bool {
+    let (an, anull) = type_set(a);
+    let (bn, bnull) = type_set(b);
+    an == bn && anull == bnull
+}
+
+/// Diff a page's inferred shape against the destination schema (top-level columns).
+///
+/// `destination` and `page` are both `infer_schema`-shaped object schemas
+/// (`{"type":"object","properties":{...}}`). `allow_widening` gates whether a
+/// lossless widening lands in `widenings` (true) or `incompatible` (false).
+pub fn diff_schema(destination: &Value, page: &Value, allow_widening: bool) -> SchemaDiff {
+    let empty = serde_json::Map::new();
+    let dest_props = destination
+        .get("properties")
+        .and_then(|p| p.as_object())
+        .unwrap_or(&empty);
+    let page_props = page
+        .get("properties")
+        .and_then(|p| p.as_object())
+        .unwrap_or(&empty);
+
+    let mut diff = SchemaDiff::default();
+
+    for (name, page_ty) in page_props {
+        match dest_props.get(name) {
+            None => diff.additions.push(ColumnChange {
+                name: name.clone(),
+                from: None,
+                to: page_ty.clone(),
+            }),
+            Some(dest_ty) => {
+                if same_base_type(dest_ty, page_ty) {
+                    continue; // no change
+                }
+                let change = ColumnChange {
+                    name: name.clone(),
+                    from: Some(dest_ty.clone()),
+                    to: page_ty.clone(),
+                };
+                if allow_widening && is_widening(dest_ty, page_ty) {
+                    diff.widenings.push(change);
+                } else {
+                    diff.incompatible.push(change);
+                }
+            }
+        }
+    }
+
+    // Destination columns absent from the page: drift only if NOT NULL.
+    for (name, dest_ty) in dest_props {
+        if !page_props.contains_key(name) {
+            let (_, nullable) = type_set(dest_ty);
+            if !nullable {
+                diff.droppable_required.push(name.clone());
+            }
+        }
+    }
+    diff.additions.sort_by(|a, b| a.name.cmp(&b.name));
+    diff.widenings.sort_by(|a, b| a.name.cmp(&b.name));
+    diff.incompatible.sort_by(|a, b| a.name.cmp(&b.name));
+    diff.droppable_required.sort();
+    diff
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn schema(props: Value) -> Value {
+        json!({ "type": "object", "properties": props })
+    }
+
+    #[test]
+    fn no_drift_when_shapes_match() {
+        let dest = schema(json!({ "id": {"type": "integer"}, "name": {"type": "string"} }));
+        let page = schema(json!({ "id": {"type": "integer"}, "name": {"type": "string"} }));
+        let d = diff_schema(&dest, &page, true);
+        assert!(d.is_empty(), "got {d:?}");
+    }
+
+    #[test]
+    fn detects_addition() {
+        let dest = schema(json!({ "id": {"type": "integer"} }));
+        let page = schema(json!({ "id": {"type": "integer"}, "email": {"type": "string"} }));
+        let d = diff_schema(&dest, &page, true);
+        assert_eq!(d.additions.len(), 1);
+        assert_eq!(d.additions[0].name, "email");
+        assert!(d.additions[0].from.is_none());
+        assert_eq!(d.additions[0].to, json!({"type": "string"}));
+        assert!(d.widenings.is_empty() && d.incompatible.is_empty());
+    }
+
+    #[test]
+    fn integer_to_number_is_widening_when_allowed() {
+        let dest = schema(json!({ "score": {"type": "integer"} }));
+        let page = schema(json!({ "score": {"type": "number"} }));
+        let d = diff_schema(&dest, &page, true);
+        assert_eq!(d.widenings.len(), 1, "got {d:?}");
+        assert_eq!(d.widenings[0].name, "score");
+        assert!(d.incompatible.is_empty());
+    }
+
+    #[test]
+    fn integer_to_number_is_incompatible_when_widening_disallowed() {
+        let dest = schema(json!({ "score": {"type": "integer"} }));
+        let page = schema(json!({ "score": {"type": "number"} }));
+        let d = diff_schema(&dest, &page, false);
+        assert_eq!(d.incompatible.len(), 1, "got {d:?}");
+        assert!(d.widenings.is_empty());
+    }
+
+    #[test]
+    fn gaining_nullability_is_widening() {
+        let dest = schema(json!({ "name": {"type": "string"} }));
+        let page = schema(json!({ "name": {"type": ["string", "null"]} }));
+        let d = diff_schema(&dest, &page, true);
+        assert_eq!(d.widenings.len(), 1, "got {d:?}");
+    }
+
+    #[test]
+    fn string_to_integer_is_incompatible() {
+        let dest = schema(json!({ "id": {"type": "string"} }));
+        let page = schema(json!({ "id": {"type": "integer"} }));
+        let d = diff_schema(&dest, &page, true);
+        assert_eq!(d.incompatible.len(), 1, "got {d:?}");
+        assert!(d.widenings.is_empty());
+    }
+
+    #[test]
+    fn required_destination_column_absent_from_page_is_droppable_required() {
+        // Destination has a non-nullable `created_at` the page never provides.
+        let dest = schema(json!({
+            "id": {"type": "integer"},
+            "created_at": {"type": "string"}
+        }));
+        let page = schema(json!({ "id": {"type": "integer"} }));
+        let d = diff_schema(&dest, &page, true);
+        assert_eq!(d.droppable_required, vec!["created_at".to_string()], "got {d:?}");
+    }
+
+    #[test]
+    fn nullable_destination_column_absent_from_page_is_not_drift() {
+        // A column the destination already allows to be null is fine to omit.
+        let dest = schema(json!({
+            "id": {"type": "integer"},
+            "note": {"type": ["string", "null"]}
+        }));
+        let page = schema(json!({ "id": {"type": "integer"} }));
+        let d = diff_schema(&dest, &page, true);
+        assert!(d.is_empty(), "got {d:?}");
+    }
+
+    #[test]
+    fn nested_object_treated_as_single_column() {
+        // A change *inside* a nested object is invisible — top-level only.
+        let dest = schema(json!({ "meta": {"type": "object", "properties": {"a": {"type": "integer"}}} }));
+        let page = schema(json!({ "meta": {"type": "object", "properties": {"a": {"type": "integer"}, "b": {"type": "string"}}} }));
+        let d = diff_schema(&dest, &page, true);
+        assert!(d.is_empty(), "nested changes must not surface as drift; got {d:?}");
+    }
+}

--- a/crates/core/src/drift.rs
+++ b/crates/core/src/drift.rs
@@ -312,6 +312,42 @@ impl SchemaDriftPolicy {
     }
 }
 
+/// Backend-neutral base column type inferred from a JSON-Schema fragment.
+/// Each SQL sink maps these to its concrete keyword.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SqlBaseType {
+    Integer,
+    Double,
+    Boolean,
+    Text,
+    /// Nested object / array → stored as JSON/JSONB/NVARCHAR(MAX) text.
+    Json,
+}
+
+/// Map a top-level JSON-Schema type fragment to a base SQL type, or `None` for
+/// a pure-null fragment (caller falls back to TEXT/NVARCHAR for an added column
+/// whose only observed value was null).
+pub fn json_schema_base_type(fragment: &Value) -> Option<SqlBaseType> {
+    let (names, _nullable) = type_set(fragment);
+    // Prefer the widest informative type among the union.
+    if names.iter().any(|t| t == "object" || t == "array") {
+        return Some(SqlBaseType::Json);
+    }
+    if names.iter().any(|t| t == "string") {
+        return Some(SqlBaseType::Text);
+    }
+    if names.iter().any(|t| t == "number") {
+        return Some(SqlBaseType::Double);
+    }
+    if names.iter().any(|t| t == "integer") {
+        return Some(SqlBaseType::Integer);
+    }
+    if names.iter().any(|t| t == "boolean") {
+        return Some(SqlBaseType::Boolean);
+    }
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -319,6 +355,19 @@ mod tests {
 
     fn schema(props: Value) -> Value {
         json!({ "type": "object", "properties": props })
+    }
+
+    #[test]
+    fn sql_type_mapping() {
+        use super::SqlBaseType::*;
+        assert_eq!(json_schema_base_type(&json!({"type":"integer"})), Some(Integer));
+        assert_eq!(json_schema_base_type(&json!({"type":"number"})), Some(Double));
+        assert_eq!(json_schema_base_type(&json!({"type":"boolean"})), Some(Boolean));
+        assert_eq!(json_schema_base_type(&json!({"type":"string"})), Some(Text));
+        assert_eq!(json_schema_base_type(&json!({"type":["string","null"]})), Some(Text));
+        assert_eq!(json_schema_base_type(&json!({"type":"object"})), Some(Json));
+        assert_eq!(json_schema_base_type(&json!({"type":"array"})), Some(Json));
+        assert_eq!(json_schema_base_type(&json!({"type":"null"})), None);
     }
 
     #[test]

--- a/crates/core/src/drift.rs
+++ b/crates/core/src/drift.rs
@@ -1,0 +1,76 @@
+//! Schema-drift detection + policy types (issue #194).
+//!
+//! Drift is the divergence between an incoming page's inferred top-level shape
+//! (via [`crate::schema::infer_schema`]) and the sink's live destination schema
+//! (via [`crate::Sink::current_schema`]). The pure [`diff_schema`] classifies
+//! each top-level column into one bucket; [`SchemaDriftPolicy`] decides what the
+//! pipeline does with the result. Nested objects are treated as a single column.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// One column's drift, expressed in JSON-Schema type-fragment terms
+/// (e.g. `{"type":"integer"}` or `{"type":["string","null"]}`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct ColumnChange {
+    /// Top-level column name.
+    pub name: String,
+    /// Destination type fragment; `None` for an addition (not in destination).
+    pub from: Option<Value>,
+    /// Inferred type fragment from the incoming page.
+    pub to: Value,
+}
+
+/// Result of diffing a page's inferred shape against the destination schema.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct SchemaDiff {
+    /// In the page, not in the destination.
+    pub additions: Vec<ColumnChange>,
+    /// Existing column whose type widened losslessly (e.g. integer→number,
+    /// or gained nullability).
+    pub widenings: Vec<ColumnChange>,
+    /// Existing column whose type changed in a way that cannot be auto-applied
+    /// (narrowing / incompatible type swap).
+    pub incompatible: Vec<ColumnChange>,
+    /// In the destination and NOT NULL, absent from the page — would fail an
+    /// insert unless relaxed to nullable.
+    pub droppable_required: Vec<String>,
+}
+
+impl SchemaDiff {
+    /// `true` when no drift of any kind was detected.
+    pub fn is_empty(&self) -> bool {
+        self.additions.is_empty()
+            && self.widenings.is_empty()
+            && self.incompatible.is_empty()
+            && self.droppable_required.is_empty()
+    }
+
+    /// Column names that drifted, for error messages / metrics.
+    pub fn changed_columns(&self) -> Vec<String> {
+        self.additions
+            .iter()
+            .chain(&self.widenings)
+            .chain(&self.incompatible)
+            .map(|c| c.name.clone())
+            .chain(self.droppable_required.iter().cloned())
+            .collect()
+    }
+}
+
+/// The applyable subset of a [`SchemaDiff`] handed to [`crate::Sink::evolve_schema`].
+/// Never carries `incompatible` columns — those are routed by the policy.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct SchemaEvolution {
+    pub additions: Vec<ColumnChange>,
+    pub widenings: Vec<ColumnChange>,
+    /// Columns to relax from NOT NULL to nullable.
+    pub relax_nullability: Vec<String>,
+}
+
+impl SchemaEvolution {
+    pub fn is_empty(&self) -> bool {
+        self.additions.is_empty() && self.widenings.is_empty() && self.relax_nullability.is_empty()
+    }
+}

--- a/crates/core/src/drift.rs
+++ b/crates/core/src/drift.rs
@@ -145,7 +145,7 @@ fn evolvable(dest: &Value, page: &Value) -> bool {
 /// True when the non-null base type family changes from `from` to `to`
 /// (after the integer→number collapse) — i.e. the column needs an `ALTER TYPE`.
 ///
-/// Mirrors the [`evolvable`] base-family collapse: take `from ∪ to`, drop
+/// Mirrors the `evolvable` base-family collapse: take `from ∪ to`, drop
 /// `integer` when `number` is present, and treat the change as a base-type
 /// widening only when the resulting family is no longer the destination's
 /// original family. Nullability changes alone never count here.

--- a/crates/core/src/drift.rs
+++ b/crates/core/src/drift.rs
@@ -142,6 +142,41 @@ fn evolvable(dest: &Value, page: &Value) -> bool {
     merged.len() == 1
 }
 
+/// True when the non-null base type family changes from `from` to `to`
+/// (after the integer→number collapse) — i.e. the column needs an `ALTER TYPE`.
+///
+/// Mirrors the [`evolvable`] base-family collapse: take `from ∪ to`, drop
+/// `integer` when `number` is present, and treat the change as a base-type
+/// widening only when the resulting family is no longer the destination's
+/// original family. Nullability changes alone never count here.
+pub fn base_widened(from: &Value, to: &Value) -> bool {
+    let (dn, _) = type_set(from);
+    let (pn, _) = type_set(to);
+    // Collapse the destination's own family the same way (so a nullable-only
+    // change yields an identical family and returns false).
+    let collapse = |names: Vec<String>| -> Vec<String> {
+        let mut m: Vec<String> = names;
+        m.sort();
+        m.dedup();
+        if m.iter().any(|t| t == "number") {
+            m.retain(|t| t != "integer");
+        }
+        m
+    };
+    let dest_family = collapse(dn.clone());
+    let mut merged: Vec<String> = dn.into_iter().chain(pn).collect();
+    let merged = collapse(merged.drain(..).collect());
+    merged != dest_family
+}
+
+/// True when `to` permits null but `from` does not — the column needs its
+/// `NOT NULL` constraint relaxed.
+pub fn adds_null(from: &Value, to: &Value) -> bool {
+    let (_, fnull) = type_set(from);
+    let (_, tnull) = type_set(to);
+    tnull && !fnull
+}
+
 /// Diff a page's inferred shape against the destination schema (top-level columns).
 ///
 /// `destination` and `page` are both `infer_schema`-shaped object schemas
@@ -479,6 +514,54 @@ mod tests {
                 "allow_widening=false: D={dest} P={page} expected {want:?} got {got:?}"
             );
         }
+    }
+
+    #[test]
+    fn base_widened_detects_base_type_change() {
+        // integer → number is a base-type widening (needs ALTER TYPE).
+        assert!(base_widened(&json!({"type": "integer"}), &json!({"type": "number"})));
+        // nullability-only relaxation is NOT a base-type widening.
+        assert!(!base_widened(
+            &json!({"type": "string"}),
+            &json!({"type": ["string", "null"]})
+        ));
+        // identical base type, no change.
+        assert!(!base_widened(
+            &json!({"type": "integer"}),
+            &json!({"type": "integer"})
+        ));
+        // integer dest, nullable number page → base family changed.
+        assert!(base_widened(
+            &json!({"type": "integer"}),
+            &json!({"type": ["number", "null"]})
+        ));
+        // number dest, integer page → integer collapses into number, no change.
+        assert!(!base_widened(
+            &json!({"type": "number"}),
+            &json!({"type": "integer"})
+        ));
+    }
+
+    #[test]
+    fn adds_null_detects_nullability_relaxation() {
+        assert!(adds_null(
+            &json!({"type": "string"}),
+            &json!({"type": ["string", "null"]})
+        ));
+        // already nullable destination → not adding null.
+        assert!(!adds_null(
+            &json!({"type": ["string", "null"]}),
+            &json!({"type": "string"})
+        ));
+        assert!(!adds_null(
+            &json!({"type": "string"}),
+            &json!({"type": "string"})
+        ));
+        // page nullable, dest not → adds null even with a base change.
+        assert!(adds_null(
+            &json!({"type": "integer"}),
+            &json!({"type": ["number", "null"]})
+        ));
     }
 
     #[test]

--- a/crates/core/src/drift.rs
+++ b/crates/core/src/drift.rs
@@ -164,8 +164,7 @@ pub fn base_widened(from: &Value, to: &Value) -> bool {
         m
     };
     let dest_family = collapse(dn.clone());
-    let mut merged: Vec<String> = dn.into_iter().chain(pn).collect();
-    let merged = collapse(merged.drain(..).collect());
+    let merged = collapse(dn.into_iter().chain(pn).collect());
     merged != dest_family
 }
 

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -63,7 +63,10 @@ pub enum FaucetError {
     /// An incoming page's shape diverged from the destination schema under an
     /// `on_drift: fail` (or `on_incompatible: fail`) policy.
     #[error("Schema drift on columns {columns:?}: {message}")]
-    SchemaDrift { columns: Vec<String>, message: String },
+    SchemaDrift {
+        columns: Vec<String>,
+        message: String,
+    },
 
     /// A state-store operation failed (read/write/delete of a replication
     /// bookmark, checkpoint, or other persisted pipeline state).

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -60,6 +60,11 @@ pub enum FaucetError {
     #[error("Quality check '{check}' failed: {message}")]
     QualityFailure { check: String, message: String },
 
+    /// An incoming page's shape diverged from the destination schema under an
+    /// `on_drift: fail` (or `on_incompatible: fail`) policy.
+    #[error("Schema drift on columns {columns:?}: {message}")]
+    SchemaDrift { columns: Vec<String>, message: String },
+
     /// A state-store operation failed (read/write/delete of a replication
     /// bookmark, checkpoint, or other persisted pipeline state).
     #[error("State error: {0}")]
@@ -285,6 +290,18 @@ mod tests {
         let s = err.to_string();
         assert!(s.contains("not_null"));
         assert!(s.contains("user_id"));
+    }
+
+    #[test]
+    fn schema_drift_is_not_retriable_and_displays() {
+        let err = FaucetError::SchemaDrift {
+            columns: vec!["email".into(), "score".into()],
+            message: "2 new columns".into(),
+        };
+        assert!(!err.is_retriable());
+        let s = err.to_string();
+        assert!(s.contains("email"));
+        assert!(s.contains("2 new columns"));
     }
 
     #[test]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -18,6 +18,7 @@ pub mod auth;
 pub mod check;
 pub mod config;
 pub mod dlq;
+pub mod drift;
 pub mod error;
 pub mod idempotency;
 pub mod observability;
@@ -45,6 +46,7 @@ pub use adaptive::{
 pub use auth::{AuthProvider, AuthReference, AuthSpec, Credential, SharedAuthProvider};
 pub use check::{CheckContext, CheckReport, Probe, ProbeStatus};
 pub use dlq::{DlqConfig, DlqReason, DlqStats, OnBatchError, build_envelope};
+pub use drift::{ColumnChange, SchemaDiff, SchemaEvolution};
 pub use error::FaucetError;
 pub use idempotency::{DeliveryMode, format_token, parse_token, unwrap_state, wrap_state};
 #[cfg(feature = "quality")]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -48,7 +48,7 @@ pub use check::{CheckContext, CheckReport, Probe, ProbeStatus};
 pub use dlq::{DlqConfig, DlqReason, DlqStats, OnBatchError, build_envelope};
 pub use drift::{
     ColumnChange, OnDrift, OnIncompatible, SchemaDiff, SchemaDriftPolicy, SchemaDriftSpec,
-    SchemaEvolution, adds_null, base_widened,
+    SchemaEvolution, SqlBaseType, adds_null, base_widened, json_schema_base_type,
 };
 pub use error::FaucetError;
 pub use idempotency::{DeliveryMode, format_token, parse_token, unwrap_state, wrap_state};

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -46,7 +46,10 @@ pub use adaptive::{
 pub use auth::{AuthProvider, AuthReference, AuthSpec, Credential, SharedAuthProvider};
 pub use check::{CheckContext, CheckReport, Probe, ProbeStatus};
 pub use dlq::{DlqConfig, DlqReason, DlqStats, OnBatchError, build_envelope};
-pub use drift::{ColumnChange, SchemaDiff, SchemaEvolution};
+pub use drift::{
+    ColumnChange, OnDrift, OnIncompatible, SchemaDiff, SchemaDriftPolicy, SchemaDriftSpec,
+    SchemaEvolution,
+};
 pub use error::FaucetError;
 pub use idempotency::{DeliveryMode, format_token, parse_token, unwrap_state, wrap_state};
 #[cfg(feature = "quality")]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -48,7 +48,7 @@ pub use check::{CheckContext, CheckReport, Probe, ProbeStatus};
 pub use dlq::{DlqConfig, DlqReason, DlqStats, OnBatchError, build_envelope};
 pub use drift::{
     ColumnChange, OnDrift, OnIncompatible, SchemaDiff, SchemaDriftPolicy, SchemaDriftSpec,
-    SchemaEvolution,
+    SchemaEvolution, adds_null, base_widened,
 };
 pub use error::FaucetError;
 pub use idempotency::{DeliveryMode, format_token, parse_token, unwrap_state, wrap_state};

--- a/crates/core/src/observability/decorator.rs
+++ b/crates/core/src/observability/decorator.rs
@@ -875,7 +875,9 @@ mod sink_tests {
             "capable-sink"
         }
         async fn current_schema(&self) -> Result<Option<Value>, FaucetError> {
-            Ok(Some(json!({"type": "object", "properties": {"id": {"type": "integer"}}})))
+            Ok(Some(
+                json!({"type": "object", "properties": {"id": {"type": "integer"}}}),
+            ))
         }
         fn supports_schema_evolution(&self) -> bool {
             true

--- a/crates/core/src/observability/decorator.rs
+++ b/crates/core/src/observability/decorator.rs
@@ -215,6 +215,7 @@ pub(crate) fn error_kind(e: &FaucetError) -> &'static str {
         FaucetError::Source(_) => "Source",
         FaucetError::Sink(_) => "Sink",
         FaucetError::QualityFailure { .. } => "QualityFailure",
+        FaucetError::SchemaDrift { .. } => "SchemaDrift",
         FaucetError::State(_) => "State",
         FaucetError::CircuitOpen { .. } => "CircuitOpen",
         FaucetError::Custom(_) => "Custom",

--- a/crates/core/src/observability/decorator.rs
+++ b/crates/core/src/observability/decorator.rs
@@ -424,6 +424,51 @@ impl<'a, S: Sink + ?Sized> Sink for InstrumentedSink<'a, S> {
             }
         }
     }
+
+    // ── Non-instrumented passthroughs ────────────────────────────────────────
+    // These carry no per-call metric/span of their own, but they MUST delegate
+    // to the inner sink — the `Sink` trait gives each a default that disables
+    // the corresponding feature (schema-drift, upsert, exactly-once). Because
+    // the pipeline drives the *wrapped* sink, failing to forward them silently
+    // makes those features inert through the entire CLI/observability path.
+
+    async fn current_schema(&self) -> Result<Option<Value>, FaucetError> {
+        self.inner.current_schema().await
+    }
+
+    fn supports_schema_evolution(&self) -> bool {
+        self.inner.supports_schema_evolution()
+    }
+
+    async fn evolve_schema(
+        &self,
+        evolution: &crate::drift::SchemaEvolution,
+    ) -> Result<(), FaucetError> {
+        self.inner.evolve_schema(evolution).await
+    }
+
+    fn supported_write_modes(&self) -> &'static [crate::write_mode::WriteMode] {
+        self.inner.supported_write_modes()
+    }
+
+    fn supports_idempotent_writes(&self) -> bool {
+        self.inner.supports_idempotent_writes()
+    }
+
+    async fn write_batch_idempotent(
+        &self,
+        records: &[Value],
+        scope: &str,
+        token: &str,
+    ) -> Result<usize, FaucetError> {
+        self.inner
+            .write_batch_idempotent(records, scope, token)
+            .await
+    }
+
+    async fn last_committed_token(&self, scope: &str) -> Result<Option<String>, FaucetError> {
+        self.inner.last_committed_token(scope).await
+    }
 }
 
 #[cfg(test)]
@@ -810,6 +855,76 @@ mod sink_tests {
             Sink::connector_name(&wrapped),
             "unknown",
             "instrumented sink must not leak an empty connector name"
+        );
+    }
+
+    /// Regression (#194): the pipeline drives the *wrapped* sink, so
+    /// `InstrumentedSink` MUST forward the capability methods to the inner sink.
+    /// Before this was fixed, the trait defaults (`current_schema -> None`,
+    /// `supports_schema_evolution -> false`, `supports_idempotent_writes ->
+    /// false`) silently disabled schema-drift, evolution, and exactly-once
+    /// detection through the entire observability/CLI path even when the real
+    /// sink supported them.
+    struct CapableSink;
+    #[async_trait]
+    impl Sink for CapableSink {
+        async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
+            Ok(records.len())
+        }
+        fn connector_name(&self) -> &'static str {
+            "capable-sink"
+        }
+        async fn current_schema(&self) -> Result<Option<Value>, FaucetError> {
+            Ok(Some(json!({"type": "object", "properties": {"id": {"type": "integer"}}})))
+        }
+        fn supports_schema_evolution(&self) -> bool {
+            true
+        }
+        fn supports_idempotent_writes(&self) -> bool {
+            true
+        }
+        fn supported_write_modes(&self) -> &'static [crate::write_mode::WriteMode] {
+            &[
+                crate::write_mode::WriteMode::Append,
+                crate::write_mode::WriteMode::Upsert,
+            ]
+        }
+        async fn last_committed_token(&self, _scope: &str) -> Result<Option<String>, FaucetError> {
+            Ok(Some("tok-1".into()))
+        }
+    }
+
+    #[tokio::test]
+    async fn instrumented_sink_forwards_capability_methods_to_inner() {
+        let inner = CapableSink;
+        let wrapped = InstrumentedSink::new(&inner, labels());
+
+        // Schema-drift (#194): the wrapper must surface the inner schema, not the
+        // `None` default — otherwise drift detection is inert through the pipeline.
+        assert_eq!(
+            wrapped.current_schema().await.unwrap(),
+            Some(json!({"type": "object", "properties": {"id": {"type": "integer"}}})),
+            "current_schema must delegate to the inner sink"
+        );
+        assert!(
+            wrapped.supports_schema_evolution(),
+            "supports_schema_evolution must delegate"
+        );
+        // Pre-existing capabilities the wrapper must also forward.
+        assert!(
+            wrapped.supports_idempotent_writes(),
+            "supports_idempotent_writes must delegate (exactly-once)"
+        );
+        assert!(
+            wrapped
+                .supported_write_modes()
+                .contains(&crate::write_mode::WriteMode::Upsert),
+            "supported_write_modes must delegate"
+        );
+        assert_eq!(
+            wrapped.last_committed_token("scope").await.unwrap(),
+            Some("tok-1".to_string()),
+            "last_committed_token must delegate"
         );
     }
 

--- a/crates/core/src/observability/drift.rs
+++ b/crates/core/src/observability/drift.rs
@@ -19,7 +19,14 @@ pub fn describe() {
 /// Emit `faucet_schema_drift_total{pipeline,row,connector,mode,kind}` for a
 /// detected drift: `count` columns of `kind` handled under policy `mode`.
 /// No-op when `count == 0`.
-pub fn schema_drift(pipeline: &str, row: &str, connector: &str, mode: &str, kind: &str, count: u64) {
+pub fn schema_drift(
+    pipeline: &str,
+    row: &str,
+    connector: &str,
+    mode: &str,
+    kind: &str,
+    count: u64,
+) {
     if count == 0 {
         return;
     }

--- a/crates/core/src/observability/drift.rs
+++ b/crates/core/src/observability/drift.rs
@@ -1,0 +1,57 @@
+//! Metric registration + emit helper for schema-drift handling (issue #194).
+//! `faucet_schema_drift_total` counts top-level columns detected as drifted on
+//! a page, labelled by the policy mode that handled the drift and the drift
+//! kind. Emitted from the pipeline loop where the per-page drift pass runs.
+
+use metrics::{counter, describe_counter};
+
+/// Register HELP text for the schema-drift metric. Idempotent — safe to call
+/// more than once. Invoked from `install_observability` so the description is
+/// present in `/metrics` from t=0, even before the first drift event. No-op
+/// when no recorder is installed.
+pub fn describe() {
+    describe_counter!(
+        "faucet_schema_drift_total",
+        "Top-level columns detected as drifted, by policy mode and drift kind."
+    );
+}
+
+/// Emit `faucet_schema_drift_total{pipeline,row,connector,mode,kind}` for a
+/// detected drift: `count` columns of `kind` handled under policy `mode`.
+/// No-op when `count == 0`.
+pub fn schema_drift(pipeline: &str, row: &str, connector: &str, mode: &str, kind: &str, count: u64) {
+    if count == 0 {
+        return;
+    }
+    counter!(
+        "faucet_schema_drift_total",
+        "pipeline" => pipeline.to_string(),
+        "row" => row.to_string(),
+        "connector" => connector.to_string(),
+        "mode" => mode.to_string(),
+        "kind" => kind.to_string(),
+    )
+    .increment(count);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn describe_is_callable_and_idempotent() {
+        // No recorder installed in this test → describe is a no-op; the call
+        // must not panic regardless, and repeat calls are safe.
+        describe();
+        describe();
+    }
+
+    #[test]
+    fn emit_does_not_panic_without_recorder() {
+        // Metric emits are no-ops when no recorder is installed; assert the
+        // helper stays panic-free.
+        schema_drift("p", "r", "postgres", "evolve", "added", 2);
+        // count == 0 short-circuits without emitting; must also not panic.
+        schema_drift("p", "r", "postgres", "ignore", "removed", 0);
+    }
+}

--- a/crates/core/src/observability/install.rs
+++ b/crates/core/src/observability/install.rs
@@ -136,6 +136,7 @@ pub fn install_observability(cfg: &ObservabilityConfig) -> Result<InstallReport,
     // attempt — describe!()/set!() into a not-yet-installed recorder is a no-op,
     // so we order them last.
     crate::observability::resilience::describe();
+    crate::observability::drift::describe();
     register_build_info();
 
     Ok(report)
@@ -145,6 +146,7 @@ pub fn install_observability(cfg: &ObservabilityConfig) -> Result<InstallReport,
 #[cfg(not(feature = "observability-install"))]
 pub fn install_observability(_cfg: &ObservabilityConfig) -> Result<InstallReport, InstallError> {
     crate::observability::resilience::describe();
+    crate::observability::drift::describe();
     register_build_info();
     Ok(InstallReport::default())
 }

--- a/crates/core/src/observability/mod.rs
+++ b/crates/core/src/observability/mod.rs
@@ -5,6 +5,7 @@
 
 mod bookmark;
 pub(crate) mod decorator;
+mod drift;
 mod install;
 mod labels;
 mod options;
@@ -18,6 +19,7 @@ mod transform;
 
 pub use bookmark::update_bookmark_lag;
 pub use decorator::{InstrumentedSink, InstrumentedSource};
+pub use drift::schema_drift;
 pub use install::{
     InstallError, InstallReport, ObservabilityConfig, PrometheusConfig, TracingConfig,
     install_observability, register_build_info,

--- a/crates/core/src/observability/options.rs
+++ b/crates/core/src/observability/options.rs
@@ -34,6 +34,8 @@ pub struct RunStreamOptions {
     pub start_seq: u64,
     /// Optional resilience policy (retry/backoff/circuit-breaker/poison).
     pub resilience: Option<crate::resilience::ResiliencePolicy>,
+    /// Compiled schema-drift policy (issue #194). `None` → no drift handling.
+    pub schema_drift: Option<crate::drift::SchemaDriftPolicy>,
 }
 
 impl RunStreamOptions {
@@ -104,6 +106,13 @@ impl RunStreamOptions {
     /// Attach a resilience policy to the run.
     pub fn with_resilience(mut self, policy: crate::resilience::ResiliencePolicy) -> Self {
         self.resilience = Some(policy);
+        self
+    }
+
+    /// Attach a compiled schema-drift policy. The pass runs per page after the
+    /// quality pass and before the sink write.
+    pub fn with_schema_drift(mut self, policy: crate::drift::SchemaDriftPolicy) -> Self {
+        self.schema_drift = Some(policy);
         self
     }
 }

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -1418,9 +1418,30 @@ async fn apply_drift_policy<Si: Sink + ?Sized>(
         OnDrift::Fail => "fail",
         OnDrift::Evolve => "evolve",
     };
-    emit_drift(pipeline_name, row, sink_name, mode, "added", diff.additions.len() as u64);
-    emit_drift(pipeline_name, row, sink_name, mode, "widened", diff.widenings.len() as u64);
-    emit_drift(pipeline_name, row, sink_name, mode, "narrowed", diff.incompatible.len() as u64);
+    emit_drift(
+        pipeline_name,
+        row,
+        sink_name,
+        mode,
+        "added",
+        diff.additions.len() as u64,
+    );
+    emit_drift(
+        pipeline_name,
+        row,
+        sink_name,
+        mode,
+        "widened",
+        diff.widenings.len() as u64,
+    );
+    emit_drift(
+        pipeline_name,
+        row,
+        sink_name,
+        mode,
+        "narrowed",
+        diff.incompatible.len() as u64,
+    );
     emit_drift(
         pipeline_name,
         row,
@@ -1456,17 +1477,18 @@ async fn apply_drift_policy<Si: Sink + ?Sized>(
             let trimmed = records
                 .into_iter()
                 .map(|r| match r {
-                    Value::Object(map) => {
-                        Value::Object(map.into_iter().filter(|(k, _)| allowed.contains(k)).collect())
-                    }
+                    Value::Object(map) => Value::Object(
+                        map.into_iter()
+                            .filter(|(k, _)| allowed.contains(k))
+                            .collect(),
+                    ),
                     other => other,
                 })
                 .collect();
             Ok((trimmed, None))
         }
         OnDrift::Quarantine => {
-            let (kept, env) =
-                quarantine_drift_rows(diff, records, sink_name, pipeline_name, row);
+            let (kept, env) = quarantine_drift_rows(diff, records, sink_name, pipeline_name, row);
             drift_envelopes.extend(env);
             Ok((kept, None))
         }
@@ -1572,7 +1594,14 @@ fn quarantine_drift_rows(
                 columns: diff.changed_columns(),
                 message: "row exhibits schema drift (on_drift=quarantine)".into(),
             };
-            envelopes.push(build_envelope(&rec, &err, sink_name, pipeline_name, row, idx));
+            envelopes.push(build_envelope(
+                &rec,
+                &err,
+                sink_name,
+                pipeline_name,
+                row,
+                idx,
+            ));
         } else {
             kept.push(rec);
         }
@@ -4269,7 +4298,11 @@ mod tests {
         let pages = one_page(vec![json!({"id": 1, "email": "a@x.com"})]);
         let res = run_stream(pages, &sink, drift_opts(policy)).await.unwrap();
         assert_eq!(res.records_written, 1);
-        assert_eq!(sink.written()[0], json!({"id": 1}), "email must be stripped");
+        assert_eq!(
+            sink.written()[0],
+            json!({"id": 1}),
+            "email must be stripped"
+        );
     }
 
     #[tokio::test]
@@ -4284,7 +4317,9 @@ mod tests {
             on_incompatible: crate::drift::OnIncompatible::Fail,
         };
         let pages = one_page(vec![json!({"id": 1, "email": "a@x.com"})]);
-        let err = run_stream(pages, &sink, drift_opts(policy)).await.unwrap_err();
+        let err = run_stream(pages, &sink, drift_opts(policy))
+            .await
+            .unwrap_err();
         assert!(matches!(err, FaucetError::SchemaDrift { .. }));
     }
 
@@ -4362,7 +4397,9 @@ mod tests {
             on_incompatible: crate::drift::OnIncompatible::Fail,
         };
         let pages = one_page(vec![json!({"id": 1})]);
-        let err = run_stream(pages, &sink, drift_opts(policy)).await.unwrap_err();
+        let err = run_stream(pages, &sink, drift_opts(policy))
+            .await
+            .unwrap_err();
         assert!(matches!(err, FaucetError::Config(_)));
     }
 
@@ -4408,13 +4445,23 @@ mod tests {
             .with_dlq(DlqConfig::new(dlq_sink.clone()));
         let err = run_stream(pages, &sink, opts).await.unwrap_err();
         // The run still aborts on drift.
-        assert!(matches!(err, FaucetError::SchemaDrift { .. }), "got {err:?}");
+        assert!(
+            matches!(err, FaucetError::SchemaDrift { .. }),
+            "got {err:?}"
+        );
         // …but the quality-quarantined row was written to the DLQ first, not lost.
         let dlq = dlq_sink.written();
-        assert_eq!(dlq.len(), 1, "quarantined row must reach the DLQ before abort");
+        assert_eq!(
+            dlq.len(),
+            1,
+            "quarantined row must reach the DLQ before abort"
+        );
         assert_eq!(dlq[0]["payload"], json!({"id": 2, "email": "b@x"}));
         assert_eq!(dlq[0]["error"]["kind"], "QualityFailure");
         // The surviving (drifting) row was committed to the main sink before the abort.
-        assert_eq!(sink.written(), vec![json!({"id": 1, "name": "ok", "email": "a@x"})]);
+        assert_eq!(
+            sink.written(),
+            vec![json!({"id": 1, "name": "ok", "email": "a@x"})]
+        );
     }
 }

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -471,6 +471,24 @@ where
         ));
     }
 
+    // ── Schema-drift policy + lazy destination-schema cache (#194) ───────────
+    let schema_drift = options.schema_drift;
+    // Fail fast: quarantine drift requires a DLQ (mirrors the quality guard).
+    if let Some(p) = schema_drift.as_ref()
+        && p.requires_dlq()
+        && dlq.is_none()
+    {
+        return Err(FaucetError::Config(
+            "schema: on_drift 'quarantine' (or on_incompatible 'quarantine') requires a DLQ sink"
+                .into(),
+        ));
+    }
+    // Destination schema cache: fetched lazily once, refreshed after evolve.
+    // The inner `None` means "fetched, sink is schemaless"; the outer `None`
+    // tracks "not yet fetched".
+    let mut dest_schema_cache: Option<Option<Value>> = None;
+    let mut warned_drift_inert = false;
+
     if let Some(key) = state_key.as_ref() {
         validate_state_key(key)?;
     }
@@ -647,6 +665,71 @@ where
                     #[cfg(not(feature = "quality"))]
                     let (records, quality_envelopes): (Vec<Value>, Vec<Value>) =
                         (page.records, Vec::new());
+
+                    // ── Schema-drift pass (after quality, before sink) ───────
+                    let mut drift_envelopes: Vec<Value> = Vec::new();
+                    let (records, drift_abort): (Vec<Value>, Option<FaucetError>) =
+                        if let Some(policy) = schema_drift.as_ref().filter(|_| !records.is_empty()) {
+                            // Lazily fetch + cache the destination schema.
+                            if dest_schema_cache.is_none() {
+                                dest_schema_cache = Some(sink.current_schema().await?);
+                            }
+                            let dest = dest_schema_cache.as_ref().and_then(|o| o.as_ref());
+                            match dest {
+                                None => {
+                                    if !warned_drift_inert {
+                                        tracing::info!(
+                                            connector = sink_name,
+                                            "schema-drift: sink reports no destination schema; \
+                                             drift handling is inert this run"
+                                        );
+                                        warned_drift_inert = true;
+                                    }
+                                    (records, None)
+                                }
+                                Some(dest) => {
+                                    let inferred = crate::schema::infer_schema(&records);
+                                    let diff = crate::drift::diff_schema(
+                                        dest,
+                                        &inferred,
+                                        policy.allow_widening,
+                                    );
+                                    if diff.is_empty() {
+                                        (records, None)
+                                    } else {
+                                        // The cache may be replaced inside the evolve
+                                        // arm; `dest` borrows it, so re-clone before the
+                                        // call to drop the borrow.
+                                        let dest_owned = dest.clone();
+                                        apply_drift_policy(
+                                            policy,
+                                            &diff,
+                                            &dest_owned,
+                                            records,
+                                            sink,
+                                            sink_name,
+                                            &pipeline_name,
+                                            &row,
+                                            &mut dest_schema_cache,
+                                            &mut drift_envelopes,
+                                        )
+                                        .await?
+                                    }
+                                }
+                            }
+                        } else {
+                            (records, None)
+                        };
+                    // Merge drift quarantine envelopes into the quality envelopes
+                    // so the existing DLQ path writes them together.
+                    let quality_envelopes = {
+                        let mut q = quality_envelopes;
+                        q.append(&mut drift_envelopes);
+                        q
+                    };
+                    if let Some(e) = drift_abort {
+                        return Err(e);
+                    }
 
                     let page = StreamPage {
                         records,
@@ -1284,6 +1367,194 @@ fn maybe_warn_noop_sink(sink_name: &str, warned: &mut bool) {
         );
         *warned = true;
     }
+}
+
+/// Apply the schema-drift policy to a page (#194). Returns the (possibly
+/// trimmed) records and an optional deferred abort error (raised by the caller
+/// after envelopes are staged). Appends quarantine envelopes to `drift_envelopes`.
+#[allow(clippy::too_many_arguments)]
+async fn apply_drift_policy<Si: Sink + ?Sized>(
+    policy: &crate::drift::SchemaDriftPolicy,
+    diff: &crate::drift::SchemaDiff,
+    dest: &Value,
+    records: Vec<Value>,
+    sink: &Si,
+    sink_name: &str,
+    pipeline_name: &str,
+    row: &str,
+    dest_schema_cache: &mut Option<Option<Value>>,
+    drift_envelopes: &mut Vec<Value>,
+) -> Result<(Vec<Value>, Option<FaucetError>), FaucetError> {
+    use crate::drift::{OnDrift, OnIncompatible};
+    use crate::observability::schema_drift as emit_drift;
+
+    let mode = match policy.on_drift {
+        OnDrift::Warn => "warn",
+        OnDrift::Ignore => "ignore",
+        OnDrift::Quarantine => "quarantine",
+        OnDrift::Fail => "fail",
+        OnDrift::Evolve => "evolve",
+    };
+    emit_drift(pipeline_name, row, sink_name, mode, "added", diff.additions.len() as u64);
+    emit_drift(pipeline_name, row, sink_name, mode, "widened", diff.widenings.len() as u64);
+    emit_drift(pipeline_name, row, sink_name, mode, "narrowed", diff.incompatible.len() as u64);
+    emit_drift(
+        pipeline_name,
+        row,
+        sink_name,
+        mode,
+        "dropped",
+        diff.droppable_required.len() as u64,
+    );
+
+    match policy.on_drift {
+        OnDrift::Warn => {
+            tracing::warn!(
+                connector = sink_name,
+                columns = ?diff.changed_columns(),
+                "schema-drift detected (on_drift=warn); writing page unchanged"
+            );
+            Ok((records, None))
+        }
+        OnDrift::Fail => Ok((
+            records,
+            Some(FaucetError::SchemaDrift {
+                columns: diff.changed_columns(),
+                message: "schema drift detected (on_drift=fail)".to_string(),
+            }),
+        )),
+        OnDrift::Ignore => {
+            // Drop fields not present in the destination schema.
+            let allowed: std::collections::HashSet<String> = dest
+                .get("properties")
+                .and_then(|p| p.as_object())
+                .map(|m| m.keys().cloned().collect())
+                .unwrap_or_default();
+            let trimmed = records
+                .into_iter()
+                .map(|r| match r {
+                    Value::Object(map) => {
+                        Value::Object(map.into_iter().filter(|(k, _)| allowed.contains(k)).collect())
+                    }
+                    other => other,
+                })
+                .collect();
+            Ok((trimmed, None))
+        }
+        OnDrift::Quarantine => {
+            let (kept, env) =
+                quarantine_drift_rows(diff, records, sink_name, pipeline_name, row);
+            drift_envelopes.extend(env);
+            Ok((kept, None))
+        }
+        OnDrift::Evolve => {
+            let evolution = crate::drift::SchemaEvolution {
+                additions: diff.additions.clone(),
+                widenings: diff
+                    .widenings
+                    .iter()
+                    .filter(|c| {
+                        c.from
+                            .as_ref()
+                            .map(|f| crate::drift::base_widened(f, &c.to))
+                            .unwrap_or(false)
+                    })
+                    .cloned()
+                    .collect(),
+                relax_nullability: diff
+                    .droppable_required
+                    .iter()
+                    .cloned()
+                    .chain(
+                        diff.widenings
+                            .iter()
+                            .filter(|c| {
+                                c.from
+                                    .as_ref()
+                                    .map(|f| crate::drift::adds_null(f, &c.to))
+                                    .unwrap_or(false)
+                            })
+                            .map(|c| c.name.clone()),
+                    )
+                    .collect(),
+            };
+            if !evolution.is_empty() {
+                sink.evolve_schema(&evolution).await?;
+                // Refresh the cached destination schema so later pages diff
+                // against the evolved shape (re-introspect authoritatively).
+                *dest_schema_cache = Some(sink.current_schema().await?);
+            }
+            // Handle the incompatible residue.
+            if diff.incompatible.is_empty() {
+                Ok((records, None))
+            } else {
+                match policy.on_incompatible {
+                    OnIncompatible::Fail => Ok((
+                        records,
+                        Some(FaucetError::SchemaDrift {
+                            columns: diff.incompatible.iter().map(|c| c.name.clone()).collect(),
+                            message: "incompatible type change cannot be auto-evolved \
+                                      (on_incompatible=fail)"
+                                .into(),
+                        }),
+                    )),
+                    OnIncompatible::Quarantine => {
+                        // Build a diff carrying only the incompatible columns.
+                        let incompat_only = crate::drift::SchemaDiff {
+                            incompatible: diff.incompatible.clone(),
+                            ..Default::default()
+                        };
+                        let (kept, env) = quarantine_drift_rows(
+                            &incompat_only,
+                            records,
+                            sink_name,
+                            pipeline_name,
+                            row,
+                        );
+                        drift_envelopes.extend(env);
+                        Ok((kept, None))
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Partition records: those exhibiting any drift column (an addition present in
+/// the record, or an incompatible column whose value type diverges) go to the
+/// DLQ; the rest are kept. Returns `(kept, envelopes)`.
+fn quarantine_drift_rows(
+    diff: &crate::drift::SchemaDiff,
+    records: Vec<Value>,
+    sink_name: &str,
+    pipeline_name: &str,
+    row: &str,
+) -> (Vec<Value>, Vec<Value>) {
+    use crate::dlq::build_envelope;
+    let drift_cols: std::collections::HashSet<&str> = diff
+        .additions
+        .iter()
+        .chain(&diff.incompatible)
+        .map(|c| c.name.as_str())
+        .collect();
+    let mut kept = Vec::new();
+    let mut envelopes = Vec::new();
+    for (idx, rec) in records.into_iter().enumerate() {
+        let exhibits = rec
+            .as_object()
+            .map(|m| m.keys().any(|k| drift_cols.contains(k.as_str())))
+            .unwrap_or(false);
+        if exhibits {
+            let err = FaucetError::SchemaDrift {
+                columns: diff.changed_columns(),
+                message: "row exhibits schema drift (on_drift=quarantine)".into(),
+            };
+            envelopes.push(build_envelope(&rec, &err, sink_name, pipeline_name, row, idx));
+        } else {
+            kept.push(rec);
+        }
+    }
+    (kept, envelopes)
 }
 
 #[cfg(test)]
@@ -3882,5 +4153,151 @@ mod tests {
             retries, 2,
             "expected 2 retries (2 transient 503s) counted with op=sink_write, class=http_5xx"
         );
+    }
+
+    // ── Schema-drift pass (#194) ─────────────────────────────────────────────
+
+    /// Sink that reports a fixed `current_schema` and records evolve calls.
+    struct SchemaSink {
+        schema: Value,
+        written: std::sync::Mutex<Vec<Value>>,
+        evolutions: std::sync::Mutex<Vec<crate::drift::SchemaEvolution>>,
+        evolvable: bool,
+    }
+    impl SchemaSink {
+        fn new(schema: Value, evolvable: bool) -> Self {
+            Self {
+                schema,
+                written: std::sync::Mutex::new(Vec::new()),
+                evolutions: std::sync::Mutex::new(Vec::new()),
+                evolvable,
+            }
+        }
+        fn written(&self) -> Vec<Value> {
+            self.written.lock().unwrap().clone()
+        }
+    }
+    #[async_trait]
+    impl Sink for SchemaSink {
+        async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
+            self.written.lock().unwrap().extend(records.iter().cloned());
+            Ok(records.len())
+        }
+        async fn current_schema(&self) -> Result<Option<Value>, FaucetError> {
+            Ok(Some(self.schema.clone()))
+        }
+        fn supports_schema_evolution(&self) -> bool {
+            self.evolvable
+        }
+        async fn evolve_schema(
+            &self,
+            evo: &crate::drift::SchemaEvolution,
+        ) -> Result<(), FaucetError> {
+            if !self.evolvable {
+                return Err(FaucetError::Sink("not evolvable".into()));
+            }
+            self.evolutions.lock().unwrap().push(evo.clone());
+            Ok(())
+        }
+    }
+
+    fn drift_opts(policy: crate::drift::SchemaDriftPolicy) -> RunStreamOptions {
+        RunStreamOptions::new().with_schema_drift(policy)
+    }
+
+    fn one_page(
+        records: Vec<Value>,
+    ) -> impl futures_core::Stream<Item = Result<StreamPage, FaucetError>> + Unpin {
+        Box::pin(futures::stream::iter(vec![Ok(StreamPage {
+            records,
+            bookmark: None,
+        })]))
+    }
+
+    #[tokio::test]
+    async fn drift_warn_writes_unchanged() {
+        let sink = SchemaSink::new(
+            json!({"type":"object","properties":{"id":{"type":"integer"}}}),
+            false,
+        );
+        let policy = crate::drift::SchemaDriftPolicy {
+            on_drift: crate::drift::OnDrift::Warn,
+            allow_widening: true,
+            on_incompatible: crate::drift::OnIncompatible::Fail,
+        };
+        let pages = one_page(vec![json!({"id": 1, "email": "a@x.com"})]);
+        let res = run_stream(pages, &sink, drift_opts(policy)).await.unwrap();
+        assert_eq!(res.records_written, 1);
+        // Unknown field is NOT stripped under warn.
+        assert_eq!(sink.written()[0], json!({"id": 1, "email": "a@x.com"}));
+    }
+
+    #[tokio::test]
+    async fn drift_ignore_strips_unknown_fields() {
+        let sink = SchemaSink::new(
+            json!({"type":"object","properties":{"id":{"type":"integer"}}}),
+            false,
+        );
+        let policy = crate::drift::SchemaDriftPolicy {
+            on_drift: crate::drift::OnDrift::Ignore,
+            allow_widening: true,
+            on_incompatible: crate::drift::OnIncompatible::Fail,
+        };
+        let pages = one_page(vec![json!({"id": 1, "email": "a@x.com"})]);
+        let res = run_stream(pages, &sink, drift_opts(policy)).await.unwrap();
+        assert_eq!(res.records_written, 1);
+        assert_eq!(sink.written()[0], json!({"id": 1}), "email must be stripped");
+    }
+
+    #[tokio::test]
+    async fn drift_fail_raises_schema_drift() {
+        let sink = SchemaSink::new(
+            json!({"type":"object","properties":{"id":{"type":"integer"}}}),
+            false,
+        );
+        let policy = crate::drift::SchemaDriftPolicy {
+            on_drift: crate::drift::OnDrift::Fail,
+            allow_widening: true,
+            on_incompatible: crate::drift::OnIncompatible::Fail,
+        };
+        let pages = one_page(vec![json!({"id": 1, "email": "a@x.com"})]);
+        let err = run_stream(pages, &sink, drift_opts(policy)).await.unwrap_err();
+        assert!(matches!(err, FaucetError::SchemaDrift { .. }));
+    }
+
+    #[tokio::test]
+    async fn drift_evolve_calls_sink_then_writes() {
+        let sink = SchemaSink::new(
+            json!({"type":"object","properties":{"id":{"type":"integer"}}}),
+            true,
+        );
+        let policy = crate::drift::SchemaDriftPolicy {
+            on_drift: crate::drift::OnDrift::Evolve,
+            allow_widening: true,
+            on_incompatible: crate::drift::OnIncompatible::Fail,
+        };
+        let pages = one_page(vec![json!({"id": 1, "email": "a@x.com"})]);
+        let res = run_stream(pages, &sink, drift_opts(policy)).await.unwrap();
+        assert_eq!(res.records_written, 1);
+        let evos = sink.evolutions.lock().unwrap();
+        assert_eq!(evos.len(), 1);
+        assert_eq!(evos[0].additions.len(), 1);
+        assert_eq!(evos[0].additions[0].name, "email");
+        // Page is written through (with the unknown field — destination now has it).
+        assert_eq!(sink.written()[0], json!({"id": 1, "email": "a@x.com"}));
+    }
+
+    #[tokio::test]
+    async fn drift_inert_when_sink_reports_no_schema() {
+        // MockSink::current_schema defaults to None → pass is inert.
+        let sink = MockSink::new();
+        let policy = crate::drift::SchemaDriftPolicy {
+            on_drift: crate::drift::OnDrift::Fail, // would fail IF a schema were known
+            allow_widening: true,
+            on_incompatible: crate::drift::OnIncompatible::Fail,
+        };
+        let pages = one_page(vec![json!({"id": 1, "anything": true})]);
+        let res = run_stream(pages, &sink, drift_opts(policy)).await.unwrap();
+        assert_eq!(res.records_written, 1);
     }
 }

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -4300,4 +4300,46 @@ mod tests {
         let res = run_stream(pages, &sink, drift_opts(policy)).await.unwrap();
         assert_eq!(res.records_written, 1);
     }
+
+    #[tokio::test]
+    async fn drift_quarantine_routes_drift_rows_to_dlq() {
+        let sink = SchemaSink::new(
+            json!({"type":"object","properties":{"id":{"type":"integer"}}}),
+            false,
+        );
+        let dlq_sink = std::sync::Arc::new(MockSink::new());
+        let policy = crate::drift::SchemaDriftPolicy {
+            on_drift: crate::drift::OnDrift::Quarantine,
+            allow_widening: true,
+            on_incompatible: crate::drift::OnIncompatible::Fail,
+        };
+        let pages = one_page(vec![
+            json!({"id": 1}),               // conforms → written
+            json!({"id": 2, "email": "x"}), // drift → DLQ
+        ]);
+        let opts = RunStreamOptions::new()
+            .with_schema_drift(policy)
+            .with_dlq(crate::dlq::DlqConfig::new(dlq_sink.clone()));
+        let res = run_stream(pages, &sink, opts).await.unwrap();
+        assert_eq!(res.records_written, 1, "only the conforming row is written");
+        assert_eq!(sink.written(), vec![json!({"id": 1})]);
+        // The drifting row is enveloped in the DLQ.
+        let dlq = dlq_sink.written();
+        assert_eq!(dlq.len(), 1);
+        assert_eq!(dlq[0]["payload"], json!({"id": 2, "email": "x"}));
+        assert_eq!(dlq[0]["error"]["kind"], "SchemaDrift");
+    }
+
+    #[tokio::test]
+    async fn drift_quarantine_without_dlq_is_rejected() {
+        let sink = SchemaSink::new(json!({"type":"object","properties":{}}), false);
+        let policy = crate::drift::SchemaDriftPolicy {
+            on_drift: crate::drift::OnDrift::Quarantine,
+            allow_widening: true,
+            on_incompatible: crate::drift::OnIncompatible::Fail,
+        };
+        let pages = one_page(vec![json!({"id": 1})]);
+        let err = run_stream(pages, &sink, drift_opts(policy)).await.unwrap_err();
+        assert!(matches!(err, FaucetError::Config(_)));
+    }
 }

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -135,6 +135,7 @@ pub struct Pipeline<'a, So: Source + ?Sized, Si: Sink + ?Sized> {
     cancel: Option<tokio_util::sync::CancellationToken>,
     delivery: crate::idempotency::DeliveryMode,
     resilience: Option<crate::resilience::ResiliencePolicy>,
+    schema_drift: Option<crate::drift::SchemaDriftPolicy>,
 }
 
 impl<'a, So: Source + ?Sized, Si: Sink + ?Sized> Pipeline<'a, So, Si> {
@@ -154,6 +155,7 @@ impl<'a, So: Source + ?Sized, Si: Sink + ?Sized> Pipeline<'a, So, Si> {
             cancel: None,
             delivery: crate::idempotency::DeliveryMode::AtLeastOnce,
             resilience: None,
+            schema_drift: None,
         }
     }
 
@@ -240,6 +242,13 @@ impl<'a, So: Source + ?Sized, Si: Sink + ?Sized> Pipeline<'a, So, Si> {
     /// Attach a resilience policy (retry/backoff/circuit-breaker/poison-pill).
     pub fn with_resilience(mut self, policy: crate::resilience::ResiliencePolicy) -> Self {
         self.resilience = Some(policy);
+        self
+    }
+
+    /// Attach a schema-drift policy. The drift pass runs after the quality pass
+    /// and before the sink write, per page.
+    pub fn with_schema_drift(mut self, policy: crate::drift::SchemaDriftPolicy) -> Self {
+        self.schema_drift = Some(policy);
         self
     }
 
@@ -383,6 +392,9 @@ impl<'a, So: Source + ?Sized, Si: Sink + ?Sized> Pipeline<'a, So, Si> {
             }
             if let Some(policy) = self.resilience.clone() {
                 opts = opts.with_resilience(policy);
+            }
+            if let Some(p) = self.schema_drift {
+                opts = opts.with_schema_drift(p);
             }
             opts = opts.with_delivery(self.delivery).with_start_seq(start_seq);
 

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -727,7 +727,19 @@ where
                         q.append(&mut drift_envelopes);
                         q
                     };
-                    if let Some(e) = drift_abort {
+                    // A drift `fail` / incompatible-`fail` abort is *deferred* the
+                    // same way the DLQ-budget and circuit-breaker aborts are: when a
+                    // DLQ is configured this page may carry quality- or drift-
+                    // quarantine envelopes that must still reach the DLQ before the
+                    // run stops (dropping them on an early `return` would silently
+                    // lose those rows — #146 M4). So with a DLQ we thread the error
+                    // into the post-commit raise site below; with no DLQ there are
+                    // no envelopes to strand (a no-DLQ quarantine config is rejected
+                    // at run start), so we abort immediately and write nothing.
+                    let mut drift_abort = drift_abort;
+                    if dlq.is_none()
+                        && let Some(e) = drift_abort.take()
+                    {
                         return Err(e);
                     }
 
@@ -1132,6 +1144,13 @@ where
                         if let Some(e) = circuit_error {
                             return Err(e);
                         }
+                        // Deferred schema-drift `fail` abort: this page's survivors
+                        // are committed and its quality/drift quarantine envelopes
+                        // are now in the DLQ, so the run stops without stranding
+                        // them (mirrors the budget/circuit deferral above).
+                        if let Some(e) = drift_abort {
+                            return Err(e);
+                        }
                     } else if exactly_once {
                         // ── Exactly-once path ──────────────────────────────────
                         // A token is issued only for bookmark-carrying pages, so
@@ -1370,8 +1389,12 @@ fn maybe_warn_noop_sink(sink_name: &str, warned: &mut bool) {
 }
 
 /// Apply the schema-drift policy to a page (#194). Returns the (possibly
-/// trimmed) records and an optional deferred abort error (raised by the caller
-/// after envelopes are staged). Appends quarantine envelopes to `drift_envelopes`.
+/// trimmed) records and an optional deferred abort error. The caller raises the
+/// error after this page is durable: with a DLQ it is threaded into the same
+/// post-commit raise site as the budget/circuit aborts (so the page's
+/// quality/drift quarantine envelopes reach the DLQ first); with no DLQ — where
+/// no envelopes can exist — it is raised immediately and the page is not written.
+/// Appends drift quarantine envelopes to `drift_envelopes`.
 #[allow(clippy::too_many_arguments)]
 async fn apply_drift_policy<Si: Sink + ?Sized>(
     policy: &crate::drift::SchemaDriftPolicy,
@@ -4341,5 +4364,57 @@ mod tests {
         let pages = one_page(vec![json!({"id": 1})]);
         let err = run_stream(pages, &sink, drift_opts(policy)).await.unwrap_err();
         assert!(matches!(err, FaucetError::Config(_)));
+    }
+
+    /// Regression: a drift `fail` abort must NOT discard a co-resident
+    /// quality-quarantine envelope. With a DLQ present the abort is deferred
+    /// (like the budget/circuit aborts) so the quarantined row reaches the DLQ
+    /// before the run stops — dropping it on an early `return` would silently
+    /// lose data.
+    #[cfg(feature = "quality")]
+    #[tokio::test]
+    async fn drift_fail_with_dlq_still_routes_quality_quarantine() {
+        use crate::dlq::DlqConfig;
+        use crate::quality::{CompiledQuality, OnFailure, QualitySpec, RecordCheck};
+
+        // Destination knows only `id`; the page carries an unknown `email`
+        // column → drift, and one record fails the `name` NotNull check.
+        let sink = SchemaSink::new(
+            json!({"type":"object","properties":{"id":{"type":"integer"}}}),
+            false,
+        );
+        let dlq_sink = std::sync::Arc::new(MockSink::new());
+        let policy = crate::drift::SchemaDriftPolicy {
+            on_drift: crate::drift::OnDrift::Fail,
+            allow_widening: true,
+            on_incompatible: crate::drift::OnIncompatible::Fail,
+        };
+        let spec = QualitySpec {
+            record: vec![RecordCheck::NotNull {
+                field: "name".into(),
+                treat_missing_as_null: true,
+                on_failure: OnFailure::Quarantine,
+            }],
+            batch: vec![],
+        };
+        let quality = std::sync::Arc::new(CompiledQuality::compile(&spec).unwrap());
+        let pages = one_page(vec![
+            json!({"id": 1, "name": "ok", "email": "a@x"}), // survives quality, drifts
+            json!({"id": 2, "email": "b@x"}),               // quarantined (no name)
+        ]);
+        let opts = RunStreamOptions::new()
+            .with_schema_drift(policy)
+            .with_quality(quality)
+            .with_dlq(DlqConfig::new(dlq_sink.clone()));
+        let err = run_stream(pages, &sink, opts).await.unwrap_err();
+        // The run still aborts on drift.
+        assert!(matches!(err, FaucetError::SchemaDrift { .. }), "got {err:?}");
+        // …but the quality-quarantined row was written to the DLQ first, not lost.
+        let dlq = dlq_sink.written();
+        assert_eq!(dlq.len(), 1, "quarantined row must reach the DLQ before abort");
+        assert_eq!(dlq[0]["payload"], json!({"id": 2, "email": "b@x"}));
+        assert_eq!(dlq[0]["error"]["kind"], "QualityFailure");
+        // The surviving (drifting) row was committed to the main sink before the abort.
+        assert_eq!(sink.written(), vec![json!({"id": 1, "name": "ok", "email": "a@x"})]);
     }
 }

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -282,6 +282,41 @@ pub trait Sink: Send + Sync {
         &[crate::write_mode::WriteMode::Append]
     }
 
+    /// The sink's live destination schema as an `infer_schema`-shaped object
+    /// (`{"type":"object","properties":{ <col>: <type-fragment>, … }}`), or
+    /// `None` for a schemaless sink or a target that does not exist yet.
+    ///
+    /// Used by the schema-drift policy to diff each page's shape against the
+    /// real destination. Default: `Ok(None)` (drift handling is inert).
+    async fn current_schema(&self) -> Result<Option<Value>, FaucetError> {
+        Ok(None)
+    }
+
+    /// Whether this sink can apply additive/widening DDL via
+    /// [`evolve_schema`](Self::evolve_schema). Default: `false`. The CLI rejects
+    /// `on_drift: evolve` against a sink that returns `false` at config-load.
+    fn supports_schema_evolution(&self) -> bool {
+        false
+    }
+
+    /// Apply an additive schema evolution (new columns, lossless widenings,
+    /// nullability relaxations) to the destination. MUST be idempotent
+    /// (`ADD COLUMN IF NOT EXISTS` semantics) so concurrent runs converge.
+    ///
+    /// Default: a typed "unsupported" error. Override only when the backend
+    /// supports in-place additive DDL (and return `true` from
+    /// `supports_schema_evolution`).
+    async fn evolve_schema(
+        &self,
+        evolution: &crate::drift::SchemaEvolution,
+    ) -> Result<(), FaucetError> {
+        let _ = evolution;
+        Err(FaucetError::Sink(format!(
+            "sink '{}' does not support schema evolution",
+            self.connector_name()
+        )))
+    }
+
     /// Write `records` AND durably record `token` for `scope`, atomically.
     ///
     /// `scope` namespaces the watermark (the pipeline passes the per-row state
@@ -838,6 +873,27 @@ mod tests {
         use crate::write_mode::WriteMode;
         let sink: Box<dyn Sink> = Box::new(MockSink::new());
         assert!(sink.supported_write_modes().contains(&WriteMode::Append));
+    }
+
+    #[tokio::test]
+    async fn sink_default_current_schema_is_none() {
+        let sink = MockSink::new();
+        assert_eq!(sink.current_schema().await.unwrap(), None);
+    }
+
+    #[test]
+    fn sink_default_does_not_support_schema_evolution() {
+        let sink = MockSink::new();
+        assert!(!sink.supports_schema_evolution());
+    }
+
+    #[tokio::test]
+    async fn sink_default_evolve_schema_is_unsupported_error() {
+        let sink = MockSink::new();
+        let evo = crate::drift::SchemaEvolution::default();
+        let err = sink.evolve_schema(&evo).await.unwrap_err();
+        assert!(matches!(err, FaucetError::Sink(_)));
+        assert!(err.to_string().contains("schema evolution"));
     }
 
     #[tokio::test]

--- a/crates/sink/bigquery/README.md
+++ b/crates/sink/bigquery/README.md
@@ -261,6 +261,18 @@ delivery: exactly_once
 
 See the [Exactly-once delivery cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/state.html#exactly-once-delivery) for full rationale and the supported source/sink set.
 
+## Schema evolution
+
+`BigQuerySink` reports its live destination schema via `current_schema()` (a schema-only `tables.get`; a missing table → `None`, so every page column reads as new), so the pipeline-level `schema:` policy can detect drift between an incoming page's top-level shape and the real table. All five `on_drift` modes (`warn` / `ignore` / `quarantine` / `fail` / `evolve`) work against this sink.
+
+Under `on_drift: evolve`, `BigQuerySink::evolve_schema()` applies `ALTER TABLE` DDL, each statement run as its own `jobs.query` job and verified to completion:
+
+- **New columns** → `ADD COLUMN IF NOT EXISTS <col> <type>` (idempotent).
+- **Lossless widenings** (e.g. integer → number) → `ALTER COLUMN <col> SET DATA TYPE <type>` — gated on `allow_type_widening`.
+- **Nullability relaxations** → `ALTER COLUMN <col> DROP NOT NULL`.
+
+The cached schema is invalidated afterwards so the next page (and the next exactly-once / upsert page) reads the evolved table. Incompatible changes (narrowing / type swaps) are never auto-applied — they are routed by `on_incompatible` (`fail` or `quarantine`). See the [schema-drift cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/schema-drift.html).
+
 ## Dead-letter queue
 
 This sink overrides `Sink::write_batch_partial` to surface per-row failures from BigQuery `tabledata.insertAll`'s `insertErrors` response. Configure a DLQ at the pipeline level (see [cli/README.md — `dlq:`](../../../cli/README.md)) and only the rows BigQuery actually rejected are routed there — already-committed rows stay in the main sink with no duplicates. (DLQ is not permitted in exactly-once mode.)

--- a/crates/sink/bigquery/src/idempotent.rs
+++ b/crates/sink/bigquery/src/idempotent.rs
@@ -326,6 +326,93 @@ pub fn build_request_id(scope: &str, token: &str) -> String {
     format!("faucet_eo_{safe_scope}_{h:016x}_{token}")
 }
 
+// ---------------------------------------------------------------------------
+// Schema introspection + evolution (issue #194)
+// ---------------------------------------------------------------------------
+
+use serde_json::{Map, Value, json};
+
+/// JSON-Schema base type keyword for a [`BqType`], used by
+/// [`fieldspecs_to_json_schema`] when reporting the sink's live schema for
+/// drift detection. Types without a JSON-native scalar (`BYTES`, `TIMESTAMP`,
+/// `DATE`, …) map to `"string"` — the shape they take in a JSON page.
+fn bq_to_json_base(ty: &BqType) -> &'static str {
+    match ty {
+        BqType::Int64 => "integer",
+        BqType::Float64 | BqType::Numeric | BqType::BigNumeric => "number",
+        BqType::Bool => "boolean",
+        BqType::Struct => "object",
+        _ => "string",
+    }
+}
+
+/// Convert the target table's [`FieldSpec`]s into an `infer_schema`-shaped JSON
+/// Schema object (`{"type":"object","properties":{<col>: <fragment>, …}}`) so
+/// the drift policy can diff a page against the live destination.
+///
+/// Every column is reported as nullable (`{"type":[base,"null"]}`): a
+/// schema-only `tables.get` carries `mode` per field, but treating columns as
+/// nullable is the safe default for drift — it never spuriously flags a page
+/// that omits an optional column. A `REPEATED` field is reported as an
+/// `array`.
+pub fn fieldspecs_to_json_schema(fields: &[FieldSpec]) -> Value {
+    let mut props = Map::new();
+    for f in fields {
+        let fragment = if f.repeated {
+            json!({ "type": ["array", "null"] })
+        } else {
+            json!({ "type": [bq_to_json_base(&f.ty), "null"] })
+        };
+        props.insert(f.name.clone(), fragment);
+    }
+    json!({ "type": "object", "properties": Value::Object(props) })
+}
+
+/// Map a [`faucet_core::SqlBaseType`] (the type inferred for a drifted column)
+/// to the BigQuery type keyword used in `ADD COLUMN` / `SET DATA TYPE` DDL.
+///
+/// Integers map to `INT64` and floats to `FLOAT64`; the drift engine only ever
+/// widens integer→number, and BigQuery permits `INT64 → FLOAT64`.
+pub fn base_to_bq(t: faucet_core::SqlBaseType) -> &'static str {
+    use faucet_core::SqlBaseType::*;
+    match t {
+        Integer => "INT64",
+        Double => "FLOAT64",
+        Boolean => "BOOL",
+        Text => "STRING",
+        Json => "JSON",
+    }
+}
+
+/// `ALTER TABLE <ref> ADD COLUMN IF NOT EXISTS `<col>` <bq_type>` — idempotent
+/// column addition. `table_ref` is already backtick-quoted (`` `p.d.t` ``).
+pub fn build_add_column_ddl(table_ref: &str, col: &str, bq_type: &str) -> String {
+    format!(
+        "ALTER TABLE {table_ref} ADD COLUMN IF NOT EXISTS {} {bq_type}",
+        quote_ident(col)
+    )
+}
+
+/// `ALTER TABLE <ref> ALTER COLUMN `<col>` SET DATA TYPE <bq_type>` — widen an
+/// existing column's type. Naturally idempotent (re-running the same widening
+/// is a no-op). BigQuery permits a lossless relaxation here (INT64→FLOAT64,
+/// NUMERIC→BIGNUMERIC/FLOAT64).
+pub fn build_alter_type_ddl(table_ref: &str, col: &str, bq_type: &str) -> String {
+    format!(
+        "ALTER TABLE {table_ref} ALTER COLUMN {} SET DATA TYPE {bq_type}",
+        quote_ident(col)
+    )
+}
+
+/// `ALTER TABLE <ref> ALTER COLUMN `<col>` DROP NOT NULL` — relax a REQUIRED
+/// column to NULLABLE. Naturally idempotent.
+pub fn build_drop_not_null_ddl(table_ref: &str, col: &str) -> String {
+    format!(
+        "ALTER TABLE {table_ref} ALTER COLUMN {} DROP NOT NULL",
+        quote_ident(col)
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -561,5 +648,75 @@ mod tests {
         assert_eq!(sql_str("a'b"), "'a\\'b'");
         assert_eq!(sql_str("a\\b"), "'a\\\\b'");
         assert_eq!(sql_str("$.ok"), "'$.ok'");
+    }
+
+    // --- schema introspection + evolution (issue #194) ---
+
+    #[test]
+    fn fieldspec_to_json_schema_maps_types_and_nullability() {
+        let fields = vec![
+            scalar("id", BqType::Int64),
+            scalar("score", BqType::Float64),
+            scalar("amount", BqType::Numeric),
+            scalar("flag", BqType::Bool),
+            scalar("name", BqType::String),
+            scalar("ts", BqType::Timestamp),
+            repeated("tags", BqType::String),
+            record("addr", false, vec![scalar("city", BqType::String)]),
+        ];
+        let js = fieldspecs_to_json_schema(&fields);
+        assert_eq!(js["type"], "object");
+        let p = &js["properties"];
+        // Numeric collapses to JSON `number`; non-JSON-native types → `string`.
+        assert_eq!(p["id"]["type"], json!(["integer", "null"]));
+        assert_eq!(p["score"]["type"], json!(["number", "null"]));
+        assert_eq!(p["amount"]["type"], json!(["number", "null"]));
+        assert_eq!(p["flag"]["type"], json!(["boolean", "null"]));
+        assert_eq!(p["name"]["type"], json!(["string", "null"]));
+        assert_eq!(p["ts"]["type"], json!(["string", "null"]));
+        // A repeated field is an array regardless of its element type.
+        assert_eq!(p["tags"]["type"], json!(["array", "null"]));
+        // A non-repeated struct is an object.
+        assert_eq!(p["addr"]["type"], json!(["object", "null"]));
+    }
+
+    #[test]
+    fn fieldspec_to_json_schema_empty_fields() {
+        let js = fieldspecs_to_json_schema(&[]);
+        assert_eq!(js, json!({ "type": "object", "properties": {} }));
+    }
+
+    #[test]
+    fn json_schema_to_bq_type_per_base() {
+        use faucet_core::SqlBaseType::*;
+        assert_eq!(base_to_bq(Integer), "INT64");
+        assert_eq!(base_to_bq(Double), "FLOAT64");
+        assert_eq!(base_to_bq(Boolean), "BOOL");
+        assert_eq!(base_to_bq(Text), "STRING");
+        assert_eq!(base_to_bq(Json), "JSON");
+    }
+
+    #[test]
+    fn add_column_ddl_is_idempotent_and_quoted() {
+        assert_eq!(
+            build_add_column_ddl("`p.d.t`", "email", "STRING"),
+            "ALTER TABLE `p.d.t` ADD COLUMN IF NOT EXISTS `email` STRING"
+        );
+    }
+
+    #[test]
+    fn alter_type_ddl_sets_data_type() {
+        assert_eq!(
+            build_alter_type_ddl("`p.d.t`", "score", "FLOAT64"),
+            "ALTER TABLE `p.d.t` ALTER COLUMN `score` SET DATA TYPE FLOAT64"
+        );
+    }
+
+    #[test]
+    fn drop_not_null_ddl() {
+        assert_eq!(
+            build_drop_not_null_ddl("`p.d.t`", "created_at"),
+            "ALTER TABLE `p.d.t` ALTER COLUMN `created_at` DROP NOT NULL"
+        );
     }
 }

--- a/crates/sink/bigquery/src/sink.rs
+++ b/crates/sink/bigquery/src/sink.rs
@@ -8,6 +8,7 @@ use faucet_common_bigquery::build_client;
 use faucet_core::FaucetError;
 use faucet_core::idempotency::COMMIT_TOKEN_TOKEN_COL;
 use gcp_bigquery_client::Client;
+use gcp_bigquery_client::error::BQError;
 use gcp_bigquery_client::model::get_query_results_parameters::GetQueryResultsParameters;
 use gcp_bigquery_client::model::query_parameter::QueryParameter;
 use gcp_bigquery_client::model::query_parameter_type::QueryParameterType;
@@ -18,7 +19,7 @@ use gcp_bigquery_client::model::table_data_insert_all_request::TableDataInsertAl
 use gcp_bigquery_client::model::table_data_insert_all_response::TableDataInsertAllResponse;
 use serde_json::Value;
 use std::time::Duration;
-use tokio::sync::OnceCell;
+use tokio::sync::RwLock;
 
 /// Max wall-clock spent polling an idempotent-write / token-read job to
 /// completion before giving up. Exactly-once pages are small, so this is a
@@ -28,6 +29,13 @@ const IDEMPOTENT_JOB_TIMEOUT: Duration = Duration::from_secs(120);
 /// Server-side long-poll window per `getQueryResults` completion check —
 /// BigQuery holds the connection open up to this long, so we don't busy-wait.
 const JOB_POLL_LONG_POLL_MS: i32 = 10_000;
+
+/// `true` when a `tables.get` error is a 404 (table does not exist) — used by
+/// `current_schema` to report a not-yet-created target as `Ok(None)` rather
+/// than a hard error.
+fn is_table_not_found(err: &BQError) -> bool {
+    matches!(err, BQError::ResponseError { error } if error.error.code == 404)
+}
 
 /// Serialize planned delete key tuples into a JSON array of `{key_col: value}`
 /// objects for the `@deletes` parameter consumed by the semi-join `DELETE`.
@@ -50,9 +58,12 @@ fn deletes_to_payload(deletes: &[faucet_core::KeyTuple]) -> String {
 pub struct BigQuerySink {
     config: BigQuerySinkConfig,
     client: Client,
-    /// Target table schema, fetched once on the first exactly-once call and
-    /// reused for every page in the run. Empty on the streaming path.
-    schema_cache: OnceCell<Vec<idempotent::FieldSpec>>,
+    /// Target table schema, fetched lazily on the first exactly-once / upsert
+    /// call and reused for every page in the run. `None` until first read, and
+    /// reset to `None` by [`evolve_schema`](faucet_core::Sink::evolve_schema) so
+    /// the next page diffs against the evolved table. Unused on the plain
+    /// streaming path.
+    schema_cache: RwLock<Option<Vec<idempotent::FieldSpec>>>,
 }
 
 impl BigQuerySink {
@@ -67,7 +78,7 @@ impl BigQuerySink {
         Ok(Self {
             config,
             client,
-            schema_cache: OnceCell::new(),
+            schema_cache: RwLock::new(None),
         })
     }
 
@@ -84,7 +95,7 @@ impl BigQuerySink {
         Self {
             config,
             client,
-            schema_cache: OnceCell::new(),
+            schema_cache: RwLock::new(None),
         }
     }
 
@@ -198,44 +209,87 @@ impl BigQuerySink {
         }
     }
 
-    /// Fetch (once) and cache the target table's schema as [`idempotent::FieldSpec`]s.
-    async fn target_schema(&self) -> Result<&Vec<idempotent::FieldSpec>, FaucetError> {
-        self.schema_cache
-            .get_or_try_init(|| async {
-                let table = self
-                    .client
-                    .table()
-                    .get(
-                        &self.config.project_id,
-                        &self.config.dataset_id,
-                        &self.config.table_id,
-                        Some(vec!["schema"]),
-                    )
-                    .await
-                    .map_err(|e| {
-                        FaucetError::Sink(format!("BigQuery tables.get (schema) failed: {e}"))
-                    })?;
-                // Table.schema is TableSchema (not Option); TableSchema.fields is Option<Vec<...>>.
-                let fields: Vec<idempotent::FieldSpec> = table
-                    .schema
-                    .fields
-                    .as_ref()
-                    .map(|fs| {
-                        fs.iter()
-                            .map(idempotent::FieldSpec::from_table_field)
-                            .collect()
-                    })
-                    .unwrap_or_default();
-                if fields.is_empty() {
-                    return Err(FaucetError::Sink(format!(
-                        "BigQuery target table {}.{}.{} has no schema fields; exactly-once \
-                         delivery requires a table with a defined schema",
-                        self.config.project_id, self.config.dataset_id, self.config.table_id
-                    )));
-                }
-                Ok(fields)
+    /// Fetch the target table's schema fields directly via `tables.get`, with no
+    /// caching. Returns the raw [`idempotent::FieldSpec`]s (possibly empty for a
+    /// schemaless table); a missing table surfaces as the client's `BQError`.
+    async fn fetch_schema_fields(&self) -> Result<Vec<idempotent::FieldSpec>, BQError> {
+        let table = self
+            .client
+            .table()
+            .get(
+                &self.config.project_id,
+                &self.config.dataset_id,
+                &self.config.table_id,
+                Some(vec!["schema"]),
+            )
+            .await?;
+        // Table.schema is TableSchema (not Option); TableSchema.fields is Option<Vec<...>>.
+        Ok(table
+            .schema
+            .fields
+            .as_ref()
+            .map(|fs| {
+                fs.iter()
+                    .map(idempotent::FieldSpec::from_table_field)
+                    .collect()
             })
+            .unwrap_or_default())
+    }
+
+    /// Fetch (once) and cache the target table's schema as
+    /// [`idempotent::FieldSpec`]s, returning an owned clone. Used by the
+    /// exactly-once / upsert write paths, which require a table with a defined
+    /// schema — a missing table or empty schema is a hard error here.
+    ///
+    /// The cache is reset by [`evolve_schema`](faucet_core::Sink::evolve_schema)
+    /// so a later page re-fetches the evolved schema.
+    async fn target_schema(&self) -> Result<Vec<idempotent::FieldSpec>, FaucetError> {
+        if let Some(fields) = self.schema_cache.read().await.as_ref() {
+            return Ok(fields.clone());
+        }
+        // Miss: fetch under the write lock so concurrent callers don't each
+        // issue a redundant tables.get. Re-check after acquiring in case a
+        // racing writer already filled it.
+        let mut guard = self.schema_cache.write().await;
+        if let Some(fields) = guard.as_ref() {
+            return Ok(fields.clone());
+        }
+        let fields = self.fetch_schema_fields().await.map_err(|e| {
+            FaucetError::Sink(format!("BigQuery tables.get (schema) failed: {e}"))
+        })?;
+        if fields.is_empty() {
+            return Err(FaucetError::Sink(format!(
+                "BigQuery target table {}.{}.{} has no schema fields; exactly-once \
+                 delivery requires a table with a defined schema",
+                self.config.project_id, self.config.dataset_id, self.config.table_id
+            )));
+        }
+        *guard = Some(fields.clone());
+        Ok(fields)
+    }
+
+    /// Backtick-quoted fully-qualified `` `project.dataset.table` `` reference.
+    fn table_ref(&self) -> String {
+        idempotent::table_ref(
+            &self.config.project_id,
+            &self.config.dataset_id,
+            &self.config.table_id,
+        )
+    }
+
+    /// Run one schema-evolution DDL statement through the same `jobs.query` +
+    /// authoritative job-status-verify path the data writes use, mapping any
+    /// failure to [`FaucetError::Sink`].
+    async fn run_ddl(&self, sql: String) -> Result<(), FaucetError> {
+        let mut req = QueryRequest::new(sql);
+        req.use_legacy_sql = false;
+        let resp = self
+            .client
+            .job()
+            .query(&self.config.project_id, req)
             .await
+            .map_err(|e| FaucetError::Sink(format!("BigQuery schema-evolution DDL failed: {e}")))?;
+        self.await_query_complete(resp).await
     }
 
     /// Create the commit-token watermark table if it does not exist.
@@ -356,7 +410,7 @@ impl BigQuerySink {
         token: Option<(&str, &str)>,
     ) -> Result<usize, FaucetError> {
         let columns = self.target_schema().await?;
-        merge::validate_keys_present(columns, &self.config.write.key)?;
+        merge::validate_keys_present(&columns, &self.config.write.key)?;
 
         let has_upserts = !plan.upserts.is_empty();
         let has_deletes = !plan.deletes.is_empty();
@@ -376,7 +430,7 @@ impl BigQuerySink {
         );
         let sql = match token {
             Some(_) => merge::build_upsert_idempotent_sql(
-                columns,
+                &columns,
                 key,
                 has_upserts,
                 has_deletes,
@@ -385,7 +439,7 @@ impl BigQuerySink {
                 table,
             ),
             None => merge::build_upsert_transaction_sql(
-                columns,
+                &columns,
                 key,
                 has_upserts,
                 has_deletes,
@@ -744,7 +798,7 @@ impl faucet_core::Sink for BigQuerySink {
         })?;
 
         let sql = idempotent::build_transaction_sql(
-            columns,
+            &columns,
             &self.config.project_id,
             &self.config.dataset_id,
             &self.config.table_id,
@@ -777,6 +831,76 @@ impl faucet_core::Sink for BigQuerySink {
             "BigQuery exactly-once page committed"
         );
         Ok(records.len())
+    }
+
+    // -----------------------------------------------------------------------
+    // Schema drift (issue #194)
+    // -----------------------------------------------------------------------
+
+    fn supports_schema_evolution(&self) -> bool {
+        true
+    }
+
+    /// Read the live destination schema via a schema-only `tables.get`, mapped
+    /// to an `infer_schema`-shaped object so the drift policy can diff a page
+    /// against the real table.
+    ///
+    /// Returns `Ok(None)` when the target table does not exist yet (404) or
+    /// carries no field definitions — both mean "no schema to diff against",
+    /// so the drift pass treats every page column as new.
+    async fn current_schema(&self) -> Result<Option<Value>, FaucetError> {
+        match self.fetch_schema_fields().await {
+            Ok(fields) if fields.is_empty() => Ok(None),
+            Ok(fields) => Ok(Some(idempotent::fieldspecs_to_json_schema(&fields))),
+            Err(e) if is_table_not_found(&e) => Ok(None),
+            Err(e) => Err(FaucetError::Sink(format!(
+                "BigQuery current_schema (tables.get) failed: {e}"
+            ))),
+        }
+    }
+
+    /// Apply an additive schema evolution to the target table via `ALTER TABLE`
+    /// DDL (issue #194):
+    ///
+    /// - additions → `ADD COLUMN IF NOT EXISTS <col> <type>`
+    /// - widenings → `ALTER COLUMN <col> SET DATA TYPE <type>`
+    /// - nullability relaxations → `ALTER COLUMN <col> DROP NOT NULL`
+    ///
+    /// Each statement runs as its own `jobs.query` job, verified to completion
+    /// via the authoritative job-status check. Every statement is idempotent so
+    /// concurrent runs converge. The cached schema is invalidated afterwards so
+    /// the next page re-fetches the evolved table.
+    async fn evolve_schema(
+        &self,
+        evolution: &faucet_core::SchemaEvolution,
+    ) -> Result<(), FaucetError> {
+        let table_ref = self.table_ref();
+
+        for c in &evolution.additions {
+            let bq = idempotent::base_to_bq(
+                faucet_core::json_schema_base_type(&c.to)
+                    .unwrap_or(faucet_core::SqlBaseType::Text),
+            );
+            self.run_ddl(idempotent::build_add_column_ddl(&table_ref, &c.name, bq))
+                .await?;
+        }
+        for c in &evolution.widenings {
+            let bq = idempotent::base_to_bq(
+                faucet_core::json_schema_base_type(&c.to)
+                    .unwrap_or(faucet_core::SqlBaseType::Text),
+            );
+            self.run_ddl(idempotent::build_alter_type_ddl(&table_ref, &c.name, bq))
+                .await?;
+        }
+        for col in &evolution.relax_nullability {
+            self.run_ddl(idempotent::build_drop_not_null_ddl(&table_ref, col))
+                .await?;
+        }
+
+        // Invalidate the cached schema so the next exactly-once / upsert page
+        // (and the next drift diff) reads the evolved table.
+        *self.schema_cache.write().await = None;
+        Ok(())
     }
 }
 

--- a/crates/sink/bigquery/src/sink.rs
+++ b/crates/sink/bigquery/src/sink.rs
@@ -254,9 +254,10 @@ impl BigQuerySink {
         if let Some(fields) = guard.as_ref() {
             return Ok(fields.clone());
         }
-        let fields = self.fetch_schema_fields().await.map_err(|e| {
-            FaucetError::Sink(format!("BigQuery tables.get (schema) failed: {e}"))
-        })?;
+        let fields = self
+            .fetch_schema_fields()
+            .await
+            .map_err(|e| FaucetError::Sink(format!("BigQuery tables.get (schema) failed: {e}")))?;
         if fields.is_empty() {
             return Err(FaucetError::Sink(format!(
                 "BigQuery target table {}.{}.{} has no schema fields; exactly-once \
@@ -878,16 +879,14 @@ impl faucet_core::Sink for BigQuerySink {
 
         for c in &evolution.additions {
             let bq = idempotent::base_to_bq(
-                faucet_core::json_schema_base_type(&c.to)
-                    .unwrap_or(faucet_core::SqlBaseType::Text),
+                faucet_core::json_schema_base_type(&c.to).unwrap_or(faucet_core::SqlBaseType::Text),
             );
             self.run_ddl(idempotent::build_add_column_ddl(&table_ref, &c.name, bq))
                 .await?;
         }
         for c in &evolution.widenings {
             let bq = idempotent::base_to_bq(
-                faucet_core::json_schema_base_type(&c.to)
-                    .unwrap_or(faucet_core::SqlBaseType::Text),
+                faucet_core::json_schema_base_type(&c.to).unwrap_or(faucet_core::SqlBaseType::Text),
             );
             self.run_ddl(idempotent::build_alter_type_ddl(&table_ref, &c.name, bq))
                 .await?;

--- a/crates/sink/bigquery/tests/schema_drift.rs
+++ b/crates/sink/bigquery/tests/schema_drift.rs
@@ -1,0 +1,295 @@
+//! Integration tests for the BigQuery sink's schema-drift hooks (#194):
+//! `current_schema` (via a schema-only `tables.get`) and `evolve_schema` (via
+//! `ALTER TABLE` DDL run through `jobs.query`).
+
+use faucet_core::Sink;
+use faucet_core::drift::{ColumnChange, SchemaEvolution};
+use faucet_sink_bigquery::BigQuerySink;
+use faucet_sink_bigquery::{BigQueryCredentials, BigQuerySinkConfig};
+use gcp_bigquery_client::client_builder::ClientBuilder;
+use serde::Serialize;
+use serde_json::json;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const PROJECT_ID: &str = "p";
+const DATASET_ID: &str = "d";
+const TABLE_ID: &str = "t";
+const AUTH_TOKEN_PATH: &str = "/:o/oauth2/token";
+const AUTH_SCOPE_BASE: &str = "/auth/bigquery";
+
+#[derive(Serialize)]
+struct FakeToken {
+    access_token: &'static str,
+    token_type: &'static str,
+    expires_in: u32,
+}
+
+fn fake_token() -> FakeToken {
+    FakeToken {
+        access_token: "fake-token",
+        token_type: "bearer",
+        expires_in: 9_999_999,
+    }
+}
+
+fn dummy_service_account_json(oauth_server: &str) -> serde_json::Value {
+    let token_uri = format!("{oauth_server}{AUTH_TOKEN_PATH}");
+    json!({
+        "type": "service_account",
+        "project_id": "dummy",
+        "private_key_id": "dummy",
+        "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQDNk6cKkWP/4NMu\nWb3s24YHfM639IXzPtTev06PUVVQnyHmT1bZgQ/XB6BvIRaReqAqnQd61PAGtX3e\n8XocTw+u/ZfiPJOf+jrXMkRBpiBh9mbyEIqBy8BC20OmsUc+O/YYh/qRccvRfPI7\n3XMabQ8eFWhI6z/t35oRpvEVFJnSIgyV4JR/L/cjtoKnxaFwjBzEnxPiwtdy4olU\nKO/1maklXexvlO7onC7CNmPAjuEZKzdMLzFszikCDnoKJC8k6+2GZh0/JDMAcAF4\nwxlKNQ89MpHVRXZ566uKZg0MqZqkq5RXPn6u7yvNHwZ0oahHT+8ixPPrAEjuPEKM\nUPzVRz71AgMBAAECggEAfdbVWLW5Befkvam3hea2+5xdmeN3n3elrJhkiXxbAhf3\nE1kbq9bCEHmdrokNnI34vz0SWBFCwIiWfUNJ4UxQKGkZcSZto270V8hwWdNMXUsM\npz6S2nMTxJkdp0s7dhAUS93o9uE2x4x5Z0XecJ2ztFGcXY6Lupu2XvnW93V9109h\nkY3uICLdbovJq7wS/fO/AL97QStfEVRWW2agIXGvoQG5jOwfPh86GZZRYP9b8VNw\ntkAUJe4qpzNbWs9AItXOzL+50/wsFkD/iWMGWFuU8DY5ZwsL434N+uzFlaD13wtZ\n63D+tNAxCSRBfZGQbd7WxJVFfZe/2vgjykKWsdyNAQKBgQDnEBgSI836HGSRk0Ub\nDwiEtdfh2TosV+z6xtyU7j/NwjugTOJEGj1VO/TMlZCEfpkYPLZt3ek2LdNL66n8\nDyxwzTT5Q3D/D0n5yE3mmxy13Qyya6qBYvqqyeWNwyotGM7hNNOix1v9lEMtH5Rd\nUT0gkThvJhtrV663bcAWCALmtQKBgQDjw2rYlMUp2TUIa2/E7904WOnSEG85d+nc\norhzthX8EWmPgw1Bbfo6NzH4HhebTw03j3NjZdW2a8TG/uEmZFWhK4eDvkx+rxAa\n6EwamS6cmQ4+vdep2Ac4QCSaTZj02YjHb06Be3gptvpFaFrotH2jnpXxggdiv8ul\n6x+ooCffQQKBgQCR3ykzGoOI6K/c75prELyR+7MEk/0TzZaAY1cSdq61GXBHLQKT\nd/VMgAN1vN51pu7DzGBnT/dRCvEgNvEjffjSZdqRmrAVdfN/y6LSeQ5RCfJgGXSV\nJoWVmMxhCNrxiX3h01Xgp/c9SYJ3VD54AzeR/dwg32/j/oEAsDraLciXGQKBgQDF\nMNc8k/DvfmJv27R06Ma6liA6AoiJVMxgfXD8nVUDW3/tBCVh1HmkFU1p54PArvxe\nchAQqoYQ3dUMBHeh6ZRJaYp2ATfxJlfnM99P1/eHFOxEXdBt996oUMBf53bZ5cyJ\n/lAVwnQSiZy8otCyUDHGivJ+mXkTgcIq8BoEwERFAQKBgQDmImBaFqoMSVihqHIf\nDa4WZqwM7ODqOx0JnBKrKO8UOc51J5e1vpwP/qRpNhUipoILvIWJzu4efZY7GN5C\nImF9sN3PP6Sy044fkVPyw4SYEisxbvp9tfw8Xmpj/pbmugkB2ut6lz5frmEBoJSN\n3osZlZTgx+pM3sO6ITV6U4ID2Q==\n-----END PRIVATE KEY-----\n",
+        "client_email": "dummy@developer.gserviceaccount.com",
+        "client_id": "dummy",
+        "auth_uri": format!("{oauth_server}/o/oauth2/auth"),
+        "token_uri": token_uri,
+        "auth_provider_x509_cert_url": format!("{oauth_server}/oauth2/v1/certs"),
+        "client_x509_cert_url": format!("{oauth_server}/robot/v1/metadata/x509/dummy"),
+    })
+}
+
+async fn mount_token_endpoint(server: &MockServer) {
+    Mock::given(method("POST"))
+        .and(path(AUTH_TOKEN_PATH))
+        .respond_with(ResponseTemplate::new(200).set_body_json(fake_token()))
+        .mount(server)
+        .await;
+}
+
+async fn build_sink(server: &MockServer) -> (BigQuerySink, tempfile::NamedTempFile) {
+    let sa_json = dummy_service_account_json(&server.uri());
+    let sa_file = tempfile::NamedTempFile::new().expect("create sa tempfile");
+    std::fs::write(
+        sa_file.path(),
+        serde_json::to_string_pretty(&sa_json).unwrap(),
+    )
+    .expect("write sa tempfile");
+    let client = ClientBuilder::new()
+        .with_auth_base_url(format!("{}{AUTH_SCOPE_BASE}", server.uri()))
+        .with_v2_base_url(server.uri())
+        .build_from_service_account_key_file(sa_file.path().to_str().unwrap())
+        .await
+        .expect("build bigquery client against mock");
+    let config = BigQuerySinkConfig::new(
+        PROJECT_ID,
+        DATASET_ID,
+        TABLE_ID,
+        BigQueryCredentials::ApplicationDefault,
+    );
+    (BigQuerySink::from_parts(config, client), sa_file)
+}
+
+fn queries_path() -> String {
+    format!("/projects/{PROJECT_ID}/queries")
+}
+fn tables_get_path() -> String {
+    format!("/projects/{PROJECT_ID}/datasets/{DATASET_ID}/tables/{TABLE_ID}")
+}
+
+/// Mount the target table's schema (id INTEGER REQUIRED, name STRING NULLABLE).
+async fn mount_table_schema(server: &MockServer) {
+    Mock::given(method("GET"))
+        .and(path(tables_get_path()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "tableReference": {"projectId": PROJECT_ID, "datasetId": DATASET_ID, "tableId": TABLE_ID},
+            "schema": {"fields": [
+                {"name": "id", "type": "INTEGER", "mode": "REQUIRED"},
+                {"name": "name", "type": "STRING", "mode": "NULLABLE"}
+            ]}
+        })))
+        .mount(server)
+        .await;
+}
+
+/// A completed `jobs.query` response carrying the given jobId.
+fn done_query(job_id: &str) -> serde_json::Value {
+    json!({
+        "kind": "bigquery#queryResponse",
+        "jobComplete": true,
+        "jobReference": {"projectId": PROJECT_ID, "jobId": job_id}
+    })
+}
+
+/// Mount a `get_job` that reports DONE with no error.
+async fn mount_job_done(server: &MockServer, job_id: &str) {
+    Mock::given(method("GET"))
+        .and(path(format!("/projects/{PROJECT_ID}/jobs/{job_id}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jobReference": {"projectId": PROJECT_ID, "jobId": job_id},
+            "status": {"state": "DONE"}
+        })))
+        .mount(server)
+        .await;
+}
+
+async fn captured_query_bodies(server: &MockServer) -> Vec<serde_json::Value> {
+    server
+        .received_requests()
+        .await
+        .expect("recording enabled")
+        .into_iter()
+        .filter(|r| r.url.path().ends_with("/queries"))
+        .map(|r| serde_json::from_slice(&r.body).expect("query body is JSON"))
+        .collect()
+}
+
+#[tokio::test]
+async fn advertises_schema_evolution_support() {
+    let server = MockServer::start().await;
+    mount_token_endpoint(&server).await;
+    let (sink, _sa) = build_sink(&server).await;
+    assert!(sink.supports_schema_evolution());
+}
+
+#[tokio::test]
+async fn current_schema_maps_table_fields() {
+    let server = MockServer::start().await;
+    mount_token_endpoint(&server).await;
+    mount_table_schema(&server).await;
+    let (sink, _sa) = build_sink(&server).await;
+
+    let schema = sink.current_schema().await.expect("current_schema").unwrap();
+    assert_eq!(schema["type"], "object");
+    // Every column reported nullable (safe default for drift).
+    assert_eq!(schema["properties"]["id"]["type"], json!(["integer", "null"]));
+    assert_eq!(
+        schema["properties"]["name"]["type"],
+        json!(["string", "null"])
+    );
+}
+
+#[tokio::test]
+async fn current_schema_none_for_missing_table() {
+    // A 404 on tables.get → Ok(None), so the drift pass treats the target as
+    // not-yet-created rather than erroring.
+    let server = MockServer::start().await;
+    mount_token_endpoint(&server).await;
+    Mock::given(method("GET"))
+        .and(path(tables_get_path()))
+        .respond_with(ResponseTemplate::new(404).set_body_json(json!({
+            "error": {"code": 404, "message": "Not found: Table p:d.t", "errors": []}
+        })))
+        .mount(&server)
+        .await;
+    let (sink, _sa) = build_sink(&server).await;
+    assert_eq!(sink.current_schema().await.expect("current_schema"), None);
+}
+
+#[tokio::test]
+async fn current_schema_none_for_schemaless_table() {
+    let server = MockServer::start().await;
+    mount_token_endpoint(&server).await;
+    Mock::given(method("GET"))
+        .and(path(tables_get_path()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "tableReference": {"projectId": PROJECT_ID, "datasetId": DATASET_ID, "tableId": TABLE_ID},
+            "schema": {"fields": []}
+        })))
+        .mount(&server)
+        .await;
+    let (sink, _sa) = build_sink(&server).await;
+    assert_eq!(sink.current_schema().await.expect("current_schema"), None);
+}
+
+#[tokio::test]
+async fn evolve_schema_issues_alter_table_ddl() {
+    let server = MockServer::start().await;
+    mount_token_endpoint(&server).await;
+    // Every DDL statement resolves to job-ddl; one get_job(DONE) covers all.
+    Mock::given(method("POST"))
+        .and(path(queries_path()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(done_query("job-ddl")))
+        .mount(&server)
+        .await;
+    mount_job_done(&server, "job-ddl").await;
+
+    let (sink, _sa) = build_sink(&server).await;
+    let evo = SchemaEvolution {
+        additions: vec![ColumnChange {
+            name: "email".into(),
+            from: None,
+            to: json!({"type": ["string", "null"]}),
+        }],
+        widenings: vec![ColumnChange {
+            name: "id".into(),
+            from: Some(json!({"type": "integer"})),
+            to: json!({"type": "number"}),
+        }],
+        relax_nullability: vec!["name".into()],
+    };
+    sink.evolve_schema(&evo).await.expect("evolve_schema");
+
+    let bodies = captured_query_bodies(&server).await;
+    let queries: Vec<&str> = bodies
+        .iter()
+        .filter_map(|b| b["query"].as_str())
+        .collect();
+    assert!(
+        queries.iter().any(|q| q.contains(
+            "ALTER TABLE `p.d.t` ADD COLUMN IF NOT EXISTS `email` STRING"
+        )),
+        "missing ADD COLUMN DDL; got {queries:?}"
+    );
+    assert!(
+        queries.iter().any(|q| q.contains(
+            "ALTER TABLE `p.d.t` ALTER COLUMN `id` SET DATA TYPE FLOAT64"
+        )),
+        "missing widening DDL; got {queries:?}"
+    );
+    assert!(
+        queries.iter().any(|q| q.contains(
+            "ALTER TABLE `p.d.t` ALTER COLUMN `name` DROP NOT NULL"
+        )),
+        "missing DROP NOT NULL DDL; got {queries:?}"
+    );
+}
+
+#[tokio::test]
+async fn evolve_schema_invalidates_cached_schema() {
+    // After evolve_schema, the next exactly-once write must re-fetch the table
+    // schema (the cache was reset). We assert a second tables.get is issued by
+    // demanding the schema mock fire at least twice.
+    let server = MockServer::start().await;
+    mount_token_endpoint(&server).await;
+
+    // tables.get must be hit more than once: once on the first idempotent write,
+    // again after evolve_schema invalidates the cache.
+    Mock::given(method("GET"))
+        .and(path(tables_get_path()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "tableReference": {"projectId": PROJECT_ID, "datasetId": DATASET_ID, "tableId": TABLE_ID},
+            "schema": {"fields": [
+                {"name": "id", "type": "INTEGER", "mode": "REQUIRED"}
+            ]}
+        })))
+        .expect(2..)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path(queries_path()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(done_query("job-x")))
+        .mount(&server)
+        .await;
+    mount_job_done(&server, "job-x").await;
+
+    let (sink, _sa) = build_sink(&server).await;
+    // 1st write fills the cache.
+    sink.write_batch_idempotent(&[json!({"id": 1})], "s", "00000000000000000001")
+        .await
+        .expect("first write");
+    // Evolve resets the cache.
+    let evo = SchemaEvolution {
+        additions: vec![ColumnChange {
+            name: "email".into(),
+            from: None,
+            to: json!({"type": ["string", "null"]}),
+        }],
+        ..Default::default()
+    };
+    sink.evolve_schema(&evo).await.expect("evolve");
+    // 2nd write must re-fetch (asserted by the .expect(2..) on the schema mock).
+    sink.write_batch_idempotent(&[json!({"id": 2})], "s", "00000000000000000002")
+        .await
+        .expect("second write");
+}

--- a/crates/sink/bigquery/tests/schema_drift.rs
+++ b/crates/sink/bigquery/tests/schema_drift.rs
@@ -149,10 +149,17 @@ async fn current_schema_maps_table_fields() {
     mount_table_schema(&server).await;
     let (sink, _sa) = build_sink(&server).await;
 
-    let schema = sink.current_schema().await.expect("current_schema").unwrap();
+    let schema = sink
+        .current_schema()
+        .await
+        .expect("current_schema")
+        .unwrap();
     assert_eq!(schema["type"], "object");
     // Every column reported nullable (safe default for drift).
-    assert_eq!(schema["properties"]["id"]["type"], json!(["integer", "null"]));
+    assert_eq!(
+        schema["properties"]["id"]["type"],
+        json!(["integer", "null"])
+    );
     assert_eq!(
         schema["properties"]["name"]["type"],
         json!(["string", "null"])
@@ -221,26 +228,23 @@ async fn evolve_schema_issues_alter_table_ddl() {
     sink.evolve_schema(&evo).await.expect("evolve_schema");
 
     let bodies = captured_query_bodies(&server).await;
-    let queries: Vec<&str> = bodies
-        .iter()
-        .filter_map(|b| b["query"].as_str())
-        .collect();
+    let queries: Vec<&str> = bodies.iter().filter_map(|b| b["query"].as_str()).collect();
     assert!(
-        queries.iter().any(|q| q.contains(
-            "ALTER TABLE `p.d.t` ADD COLUMN IF NOT EXISTS `email` STRING"
-        )),
+        queries
+            .iter()
+            .any(|q| q.contains("ALTER TABLE `p.d.t` ADD COLUMN IF NOT EXISTS `email` STRING")),
         "missing ADD COLUMN DDL; got {queries:?}"
     );
     assert!(
-        queries.iter().any(|q| q.contains(
-            "ALTER TABLE `p.d.t` ALTER COLUMN `id` SET DATA TYPE FLOAT64"
-        )),
+        queries
+            .iter()
+            .any(|q| q.contains("ALTER TABLE `p.d.t` ALTER COLUMN `id` SET DATA TYPE FLOAT64")),
         "missing widening DDL; got {queries:?}"
     );
     assert!(
-        queries.iter().any(|q| q.contains(
-            "ALTER TABLE `p.d.t` ALTER COLUMN `name` DROP NOT NULL"
-        )),
+        queries
+            .iter()
+            .any(|q| q.contains("ALTER TABLE `p.d.t` ALTER COLUMN `name` DROP NOT NULL")),
         "missing DROP NOT NULL DDL; got {queries:?}"
     );
 }

--- a/crates/sink/elasticsearch/README.md
+++ b/crates/sink/elasticsearch/README.md
@@ -217,6 +217,17 @@ In `append` mode, when `id_field` is set the sink extracts the document `_id` fr
 
 Setting `id_field` to a stable business key makes resumed/retried runs **idempotent overwrites** rather than duplicates — the recommended setting for resumable append pipelines (or configure a DLQ, whose per-row path avoids the whole-page re-send).
 
+## Schema evolution
+
+`ElasticsearchSink` reports its live index mappings via `current_schema()` (`GET /<index>/_mapping`, every field marked nullable since ES has no NOT NULL concept; a missing index → `None`), so the pipeline-level `schema:` policy can detect drift between an incoming page's top-level shape and the real index. All five `on_drift` modes (`warn` / `ignore` / `quarantine` / `fail` / `evolve`) work against this sink.
+
+Under `on_drift: evolve`, `ElasticsearchSink::evolve_schema()` is **add-fields only**:
+
+- **New fields** → `PUT /<index>/_mapping` adding the field mappings.
+- **Type widenings and nullability relaxations are no-ops** — Elasticsearch cannot change an existing field's mapping type or nullability in place (a one-shot `debug` log notes this).
+
+Because ES cannot retype an existing field, any change to an existing field's type is classified as **incompatible** and routed by `on_incompatible` (`fail` or `quarantine`) rather than applied. See the [schema-drift cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/schema-drift.html).
+
 ## Dead-letter queue
 
 This sink overrides `Sink::write_batch_partial` to surface per-row failures from Elasticsearch's `_bulk` response items. Configure a DLQ at the pipeline level (see [cli/README.md — `dlq:`](https://github.com/PawanSikawat/faucet-stream/blob/main/cli/README.md)) and only the documents Elasticsearch actually rejected are routed there — already-indexed items stay in the main sink with no duplicates. This is why the bulk API's best-effort, partial-success behaviour doesn't double-write rows into the DLQ.

--- a/crates/sink/elasticsearch/src/sink.rs
+++ b/crates/sink/elasticsearch/src/sink.rs
@@ -395,10 +395,7 @@ impl faucet_core::Sink for ElasticsearchSink {
                 let es_type = def.get("type").and_then(|t| t.as_str()).unwrap_or("object");
                 let base = es_type_to_json(es_type);
                 // ES has no NOT NULL → every field is nullable.
-                out_props.insert(
-                    field.clone(),
-                    serde_json::json!({ "type": [base, "null"] }),
-                );
+                out_props.insert(field.clone(), serde_json::json!({ "type": [base, "null"] }));
             }
         }
 

--- a/crates/sink/elasticsearch/src/sink.rs
+++ b/crates/sink/elasticsearch/src/sink.rs
@@ -354,7 +354,7 @@ impl faucet_core::Sink for ElasticsearchSink {
     /// Elasticsearch can add new fields to an existing index in place via
     /// `PUT /<index>/_mapping`, so additive schema evolution is supported.
     /// (Changing an existing field's mapping type is *not* possible — see
-    /// [`evolve_schema`](Self::evolve_schema).)
+    /// [`evolve_schema`](faucet_core::Sink::evolve_schema).)
     fn supports_schema_evolution(&self) -> bool {
         true
     }

--- a/crates/sink/elasticsearch/src/sink.rs
+++ b/crates/sink/elasticsearch/src/sink.rs
@@ -3,7 +3,9 @@
 use crate::config::{ElasticsearchAuth, ElasticsearchSinkConfig};
 use async_trait::async_trait;
 use faucet_core::util::{DEFAULT_ERROR_BODY_MAX_LEN, check_http_response};
-use faucet_core::{AuthSpec, FaucetError, SharedAuthProvider};
+use faucet_core::{
+    AuthSpec, FaucetError, SchemaEvolution, SharedAuthProvider, SqlBaseType, json_schema_base_type,
+};
 use reqwest::Client;
 use serde_json::Value;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -31,6 +33,10 @@ pub struct ElasticsearchSink {
     /// One-shot guard so the resume-duplication warning (see [`resume_dup_risk`])
     /// is logged at most once per sink instance, not per page.
     resume_dup_warned: AtomicBool,
+    /// One-shot guard for the "cannot change an existing field's mapping" debug
+    /// log emitted by [`evolve_schema`](faucet_core::Sink::evolve_schema) when an
+    /// evolution carries widenings / nullability relaxations (no-ops on ES).
+    evolve_noop_warned: AtomicBool,
 }
 
 impl ElasticsearchSink {
@@ -48,6 +54,7 @@ impl ElasticsearchSink {
             client: Client::new(),
             auth_provider: None,
             resume_dup_warned: AtomicBool::new(false),
+            evolve_noop_warned: AtomicBool::new(false),
         })
     }
 
@@ -266,6 +273,33 @@ fn doc_id_from_row(row: &Value, key: &[String]) -> String {
         .join(":")
 }
 
+/// Map an Elasticsearch field-mapping `type` to a JSON-Schema base type name.
+///
+/// Numeric families collapse to `integer`/`number`, `boolean` is its own base,
+/// `object`/`nested` are `object`, and everything else (`keyword`, `text`,
+/// `date`, `ip`, …) is treated as `string`.
+fn es_type_to_json(es_type: &str) -> &'static str {
+    match es_type {
+        "long" | "integer" | "short" | "byte" => "integer",
+        "double" | "float" | "half_float" | "scaled_float" => "number",
+        "boolean" => "boolean",
+        "object" | "nested" => "object",
+        _ => "string",
+    }
+}
+
+/// Map a backend-neutral [`SqlBaseType`] to the Elasticsearch field-mapping
+/// `type` used when adding a column via `PUT /<index>/_mapping`.
+fn base_to_es(base: SqlBaseType) -> &'static str {
+    match base {
+        SqlBaseType::Integer => "long",
+        SqlBaseType::Double => "double",
+        SqlBaseType::Boolean => "boolean",
+        SqlBaseType::Text => "keyword",
+        SqlBaseType::Json => "object",
+    }
+}
+
 /// Extract per-item error messages from a `_bulk` response body.
 ///
 /// Each `items` entry is `{ "<action>": { ..., "error": {...} } }` where
@@ -315,6 +349,118 @@ impl faucet_core::Sink for ElasticsearchSink {
             faucet_core::WriteMode::Upsert,
             faucet_core::WriteMode::Delete,
         ]
+    }
+
+    /// Elasticsearch can add new fields to an existing index in place via
+    /// `PUT /<index>/_mapping`, so additive schema evolution is supported.
+    /// (Changing an existing field's mapping type is *not* possible — see
+    /// [`evolve_schema`](Self::evolve_schema).)
+    fn supports_schema_evolution(&self) -> bool {
+        true
+    }
+
+    /// Read the index's live field mappings via `GET /<index>/_mapping`.
+    ///
+    /// Returns an `infer_schema`-shaped object schema with every field marked
+    /// nullable (Elasticsearch has no NOT NULL concept). A `404` (index does not
+    /// exist) yields `Ok(None)`; an index that exists with no explicit
+    /// `properties` yields an empty `{"type":"object","properties":{}}`.
+    async fn current_schema(&self) -> Result<Option<Value>, FaucetError> {
+        let auth = self.resolve_auth().await?;
+        let url = format!("{}/{}/_mapping", self.config.base_url, self.config.index);
+        let req = Self::apply_auth_value(self.client.get(&url), &auth);
+        let resp = req.send().await?;
+
+        // A missing index is reported as drift-inert (Ok(None)), not an error.
+        // Detect the 404 *before* check_http_response, which treats it as an error.
+        if resp.status().as_u16() == 404 {
+            return Ok(None);
+        }
+        let resp = check_http_response(resp, DEFAULT_ERROR_BODY_MAX_LEN).await?;
+        let body: Value = resp.json().await?;
+
+        // Shape: { "<index>": { "mappings": { "properties": { "<f>": {"type": …} } } } }.
+        // The top-level key is the concrete index name (exactly one entry).
+        let index_obj = body
+            .get(&self.config.index)
+            .or_else(|| body.as_object().and_then(|m| m.values().next()));
+        let mappings = index_obj.and_then(|v| v.get("mappings"));
+        let properties = mappings
+            .and_then(|m| m.get("properties"))
+            .and_then(|p| p.as_object());
+
+        let mut out_props = serde_json::Map::new();
+        if let Some(properties) = properties {
+            for (field, def) in properties {
+                let es_type = def.get("type").and_then(|t| t.as_str()).unwrap_or("object");
+                let base = es_type_to_json(es_type);
+                // ES has no NOT NULL → every field is nullable.
+                out_props.insert(
+                    field.clone(),
+                    serde_json::json!({ "type": [base, "null"] }),
+                );
+            }
+        }
+
+        Ok(Some(serde_json::json!({
+            "type": "object",
+            "properties": out_props,
+        })))
+    }
+
+    /// Apply an additive schema evolution to the index via
+    /// `PUT /<index>/_mapping`.
+    ///
+    /// Only [`additions`](faucet_core::SchemaEvolution::additions) are applied —
+    /// Elasticsearch cannot change an existing field's mapping type or
+    /// nullability in place, so
+    /// [`widenings`](faucet_core::SchemaEvolution::widenings) and
+    /// [`relax_nullability`](faucet_core::SchemaEvolution::relax_nullability) are
+    /// no-ops (a one-shot `debug` log notes the limitation). A `PUT` is only
+    /// issued when there is at least one addition.
+    async fn evolve_schema(&self, evolution: &SchemaEvolution) -> Result<(), FaucetError> {
+        if (!evolution.widenings.is_empty() || !evolution.relax_nullability.is_empty())
+            && !self.evolve_noop_warned.swap(true, Ordering::Relaxed)
+        {
+            tracing::debug!(
+                index = %self.config.index,
+                "elasticsearch cannot change an existing field's mapping type / nullability; \
+                 left as-is"
+            );
+        }
+
+        if evolution.additions.is_empty() {
+            return Ok(());
+        }
+
+        let mut properties = serde_json::Map::new();
+        for change in &evolution.additions {
+            let base = json_schema_base_type(&change.to).unwrap_or(SqlBaseType::Text);
+            properties.insert(
+                change.name.clone(),
+                serde_json::json!({ "type": base_to_es(base) }),
+            );
+        }
+        let body = serde_json::json!({ "properties": properties });
+
+        let auth = self.resolve_auth().await?;
+        let url = format!("{}/{}/_mapping", self.config.base_url, self.config.index);
+        let req = self
+            .client
+            .put(&url)
+            .header("Content-Type", "application/json")
+            .body(serde_json::to_string(&body).map_err(|e| {
+                FaucetError::Sink(format!("failed to serialize mapping update: {e}"))
+            })?);
+        let req = Self::apply_auth_value(req, &auth);
+        let resp = req.send().await?;
+        check_http_response(resp, DEFAULT_ERROR_BODY_MAX_LEN).await?;
+        tracing::debug!(
+            index = %self.config.index,
+            added = evolution.additions.len(),
+            "Elasticsearch mapping evolved (fields added)"
+        );
+        Ok(())
     }
 
     /// Non-mutating preflight probe.
@@ -720,6 +866,38 @@ mod tests {
         // Third record: no id field, so no _id in action.
         let action2: Value = serde_json::from_str(lines[4]).unwrap();
         assert!(action2["index"].get("_id").is_none());
+    }
+
+    #[test]
+    fn es_mapping_to_json_schema_types() {
+        // Numeric families collapse to integer / number.
+        assert_eq!(es_type_to_json("long"), "integer");
+        assert_eq!(es_type_to_json("integer"), "integer");
+        assert_eq!(es_type_to_json("short"), "integer");
+        assert_eq!(es_type_to_json("byte"), "integer");
+        assert_eq!(es_type_to_json("double"), "number");
+        assert_eq!(es_type_to_json("float"), "number");
+        assert_eq!(es_type_to_json("half_float"), "number");
+        assert_eq!(es_type_to_json("scaled_float"), "number");
+        // Boolean + object families.
+        assert_eq!(es_type_to_json("boolean"), "boolean");
+        assert_eq!(es_type_to_json("object"), "object");
+        assert_eq!(es_type_to_json("nested"), "object");
+        // Everything else → string.
+        assert_eq!(es_type_to_json("keyword"), "string");
+        assert_eq!(es_type_to_json("text"), "string");
+        assert_eq!(es_type_to_json("date"), "string");
+        assert_eq!(es_type_to_json("ip"), "string");
+        assert_eq!(es_type_to_json("geo_point"), "string");
+    }
+
+    #[test]
+    fn base_to_es_types() {
+        assert_eq!(base_to_es(SqlBaseType::Integer), "long");
+        assert_eq!(base_to_es(SqlBaseType::Double), "double");
+        assert_eq!(base_to_es(SqlBaseType::Boolean), "boolean");
+        assert_eq!(base_to_es(SqlBaseType::Text), "keyword");
+        assert_eq!(base_to_es(SqlBaseType::Json), "object");
     }
 
     #[test]

--- a/crates/sink/elasticsearch/tests/schema_evolution.rs
+++ b/crates/sink/elasticsearch/tests/schema_evolution.rs
@@ -66,7 +66,8 @@ async fn current_schema_missing_index_returns_none() {
         .mount(&server)
         .await;
 
-    let sink = ElasticsearchSink::new(ElasticsearchSinkConfig::new(server.uri(), "missing")).unwrap();
+    let sink =
+        ElasticsearchSink::new(ElasticsearchSinkConfig::new(server.uri(), "missing")).unwrap();
 
     assert_eq!(sink.current_schema().await.unwrap(), None);
 }
@@ -159,8 +160,7 @@ async fn evolve_schema_no_additions_issues_no_put() {
 
 #[tokio::test]
 async fn supports_schema_evolution_is_true() {
-    let sink =
-        ElasticsearchSink::new(ElasticsearchSinkConfig::new("http://localhost:9200", "idx"))
-            .unwrap();
+    let sink = ElasticsearchSink::new(ElasticsearchSinkConfig::new("http://localhost:9200", "idx"))
+        .unwrap();
     assert!(sink.supports_schema_evolution());
 }

--- a/crates/sink/elasticsearch/tests/schema_evolution.rs
+++ b/crates/sink/elasticsearch/tests/schema_evolution.rs
@@ -1,0 +1,166 @@
+//! Integration tests for schema introspection + evolution on the Elasticsearch
+//! sink (`current_schema` + `evolve_schema`, issue #194 Task 15).
+//!
+//! Each test stands up a wiremock server, mocks the `_mapping` endpoint, and
+//! asserts the sink maps ES field mappings to JSON-Schema fragments
+//! (`current_schema`) and issues an additive `PUT /<index>/_mapping`
+//! (`evolve_schema`).
+
+use faucet_core::{ColumnChange, SchemaEvolution, Sink};
+use faucet_sink_elasticsearch::{ElasticsearchSink, ElasticsearchSinkConfig};
+use serde_json::{Value, json};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, Request, ResponseTemplate};
+
+#[tokio::test]
+async fn current_schema_maps_es_field_types() {
+    let server = MockServer::start().await;
+
+    // GET /my_index/_mapping → a one-field-per-type mapping.
+    Mock::given(method("GET"))
+        .and(path("/my_index/_mapping"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "my_index": {
+                "mappings": {
+                    "properties": {
+                        "id": { "type": "long" },
+                        "score": { "type": "double" },
+                        "active": { "type": "boolean" },
+                        "name": { "type": "keyword" },
+                        "body": { "type": "text" },
+                        "meta": { "type": "object" },
+                    }
+                }
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let sink =
+        ElasticsearchSink::new(ElasticsearchSinkConfig::new(server.uri(), "my_index")).unwrap();
+
+    let schema = sink.current_schema().await.unwrap().expect("Some(schema)");
+    assert_eq!(schema["type"], "object");
+    let props = &schema["properties"];
+
+    // Every field is nullable (ES has no NOT NULL).
+    assert_eq!(props["id"], json!({ "type": ["integer", "null"] }));
+    assert_eq!(props["score"], json!({ "type": ["number", "null"] }));
+    assert_eq!(props["active"], json!({ "type": ["boolean", "null"] }));
+    assert_eq!(props["name"], json!({ "type": ["string", "null"] }));
+    assert_eq!(props["body"], json!({ "type": ["string", "null"] }));
+    assert_eq!(props["meta"], json!({ "type": ["object", "null"] }));
+}
+
+#[tokio::test]
+async fn current_schema_missing_index_returns_none() {
+    let server = MockServer::start().await;
+
+    // GET /missing/_mapping → 404 (index does not exist).
+    Mock::given(method("GET"))
+        .and(path("/missing/_mapping"))
+        .respond_with(ResponseTemplate::new(404).set_body_json(json!({
+            "error": { "type": "index_not_found_exception" },
+            "status": 404
+        })))
+        .mount(&server)
+        .await;
+
+    let sink = ElasticsearchSink::new(ElasticsearchSinkConfig::new(server.uri(), "missing")).unwrap();
+
+    assert_eq!(sink.current_schema().await.unwrap(), None);
+}
+
+#[tokio::test]
+async fn evolve_schema_puts_additions_via_mapping() {
+    let server = MockServer::start().await;
+
+    // PUT /my_index/_mapping → acknowledged.
+    Mock::given(method("PUT"))
+        .and(path("/my_index/_mapping"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "acknowledged": true })))
+        .mount(&server)
+        .await;
+
+    let sink =
+        ElasticsearchSink::new(ElasticsearchSinkConfig::new(server.uri(), "my_index")).unwrap();
+
+    let evolution = SchemaEvolution {
+        additions: vec![
+            ColumnChange {
+                name: "email".to_string(),
+                from: None,
+                to: json!({ "type": "string" }),
+            },
+            ColumnChange {
+                name: "age".to_string(),
+                from: None,
+                to: json!({ "type": "integer" }),
+            },
+        ],
+        // Widenings + nullability relaxations are no-ops on ES (left as-is).
+        widenings: vec![ColumnChange {
+            name: "score".to_string(),
+            from: Some(json!({ "type": "integer" })),
+            to: json!({ "type": "number" }),
+        }],
+        relax_nullability: vec!["created_at".to_string()],
+    };
+
+    sink.evolve_schema(&evolution).await.unwrap();
+
+    let requests: Vec<Request> = server.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1, "exactly one PUT _mapping call");
+
+    let body: Value = serde_json::from_slice(&requests[0].body).unwrap();
+    let props = &body["properties"];
+    // Additions only — mapped to ES field types.
+    assert_eq!(props["email"], json!({ "type": "keyword" }));
+    assert_eq!(props["age"], json!({ "type": "long" }));
+    // Widenings / relax_nullability never appear in the PUT body.
+    assert!(props.get("score").is_none(), "widenings are not applied");
+    assert!(
+        props.get("created_at").is_none(),
+        "nullability relaxations are not applied"
+    );
+}
+
+#[tokio::test]
+async fn evolve_schema_no_additions_issues_no_put() {
+    let server = MockServer::start().await;
+
+    // Mount a PUT mock so any stray call would still succeed; we assert it was
+    // never called.
+    Mock::given(method("PUT"))
+        .and(path("/my_index/_mapping"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "acknowledged": true })))
+        .mount(&server)
+        .await;
+
+    let sink =
+        ElasticsearchSink::new(ElasticsearchSinkConfig::new(server.uri(), "my_index")).unwrap();
+
+    // Only widenings → no PUT (ES cannot change an existing field type).
+    let evolution = SchemaEvolution {
+        additions: vec![],
+        widenings: vec![ColumnChange {
+            name: "score".to_string(),
+            from: Some(json!({ "type": "integer" })),
+            to: json!({ "type": "number" }),
+        }],
+        relax_nullability: vec![],
+    };
+
+    sink.evolve_schema(&evolution).await.unwrap();
+
+    let requests = server.received_requests().await.unwrap();
+    assert!(requests.is_empty(), "no PUT should be issued: {requests:?}");
+}
+
+#[tokio::test]
+async fn supports_schema_evolution_is_true() {
+    let sink =
+        ElasticsearchSink::new(ElasticsearchSinkConfig::new("http://localhost:9200", "idx"))
+            .unwrap();
+    assert!(sink.supports_schema_evolution());
+}

--- a/crates/sink/iceberg/README.md
+++ b/crates/sink/iceberg/README.md
@@ -255,6 +255,12 @@ delivery: exactly_once
 
 See the [Exactly-once delivery cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/state.html#exactly-once-delivery) for the full rationale and supported source/sink set.
 
+## Schema drift
+
+`IcebergSink` reports its live table schema via `current_schema()` (the table's current Iceberg schema converted through Arrow to the `infer_schema` JSON shape; a missing table → `None`), so the pipeline-level `schema:` policy can **detect** drift between an incoming page's top-level shape and the real table. The `warn` / `ignore` / `quarantine` / `fail` modes all work against this sink.
+
+**`on_drift: evolve` is NOT supported.** `supports_schema_evolution()` stays `false`: `iceberg-rust` 0.9.1 (pinned in this crate) exposes no schema-evolution transaction API (no `UpdateSchema` / `add_column` / type promotion — only `fast_append`), so additive DDL is blocked upstream. The CLI rejects `on_drift: evolve` against iceberg at config-load. This is tracked in [#255](https://github.com/PawanSikawat/faucet-stream/issues/255) (sibling to the equality-delete upsert gate, #179/#225). See the [schema-drift cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/schema-drift.html).
+
 ## Schema inference
 
 When `create_if_missing: true` and the table is new, the Iceberg schema is inferred from the first Arrow batch: every JSON field becomes a nullable column, typed by its first non-null value. Subsequent batches use the table's existing schema so the writer and table stay in sync. Iceberg assigns **field IDs** sequentially from `1`; IDs are stable once the table exists, so renaming or reordering JSON keys in later runs does not change them.

--- a/crates/sink/iceberg/src/schema.rs
+++ b/crates/sink/iceberg/src/schema.rs
@@ -383,7 +383,10 @@ mod tests {
         assert_eq!(props["i64"]["type"], serde_json::json!(["integer", "null"]));
         assert_eq!(props["u16"]["type"], serde_json::json!(["integer", "null"]));
         assert_eq!(props["f32"]["type"], serde_json::json!(["number", "null"]));
-        assert_eq!(props["flag"]["type"], serde_json::json!(["boolean", "null"]));
+        assert_eq!(
+            props["flag"]["type"],
+            serde_json::json!(["boolean", "null"])
+        );
         assert_eq!(props["name"]["type"], serde_json::json!(["string", "null"]));
         assert_eq!(props["meta"]["type"], serde_json::json!(["object", "null"]));
         assert_eq!(props["tags"]["type"], serde_json::json!(["array", "null"]));

--- a/crates/sink/iceberg/src/schema.rs
+++ b/crates/sink/iceberg/src/schema.rs
@@ -123,6 +123,48 @@ pub fn iceberg_to_arrow_schema(schema: &iceberg::spec::Schema) -> Result<SchemaR
         })
 }
 
+/// Convert an Arrow `Schema` to an `infer_schema`-shaped JSON object
+/// (`{"type":"object","properties":{ <col>: <type-fragment>, … }}`).
+///
+/// Used by the schema-drift policy (issue #194) to diff a page's shape against
+/// the live Iceberg table schema. Each top-level field maps to a JSON base type;
+/// nullable fields carry `{"type":[base,"null"]}`, non-nullable fields
+/// `{"type":base}`. Only the top level is described — nested struct/list fields
+/// collapse to `object` / `array`.
+pub fn arrow_to_json_schema(schema: &Schema) -> Value {
+    let mut props = serde_json::Map::new();
+    for field in schema.fields() {
+        let base = arrow_base_type(field.data_type());
+        let fragment = if field.is_nullable() {
+            serde_json::json!({ "type": [base, "null"] })
+        } else {
+            serde_json::json!({ "type": base })
+        };
+        props.insert(field.name().clone(), fragment);
+    }
+    serde_json::json!({ "type": "object", "properties": Value::Object(props) })
+}
+
+/// Map a top-level Arrow `DataType` to its `infer_schema` JSON base keyword.
+fn arrow_base_type(dt: &DataType) -> &'static str {
+    match dt {
+        DataType::Int8
+        | DataType::Int16
+        | DataType::Int32
+        | DataType::Int64
+        | DataType::UInt8
+        | DataType::UInt16
+        | DataType::UInt32
+        | DataType::UInt64 => "integer",
+        DataType::Float16 | DataType::Float32 | DataType::Float64 => "number",
+        DataType::Boolean => "boolean",
+        DataType::Utf8 | DataType::LargeUtf8 => "string",
+        DataType::Struct(_) => "object",
+        DataType::List(_) | DataType::LargeList(_) | DataType::FixedSizeList(_, _) => "array",
+        _ => "string",
+    }
+}
+
 // ── Internal helpers ──────────────────────────────────────────────────────────
 
 /// Recursively force every field in the schema to be nullable.
@@ -299,5 +341,53 @@ mod tests {
             back.fields().iter().map(|f| f.name().clone()).collect();
         assert!(names.contains("col_a"), "col_a must survive round-trip");
         assert!(names.contains("col_b"), "col_b must survive round-trip");
+    }
+
+    // ── arrow_to_json_schema ──────────────────────────────────────────────────
+
+    #[test]
+    fn arrow_schema_to_json_schema_top_level() {
+        let fields = vec![
+            Field::new("i32", DataType::Int32, false),
+            Field::new("i64", DataType::Int64, true),
+            Field::new("u16", DataType::UInt16, true),
+            Field::new("f32", DataType::Float32, true),
+            Field::new("f64", DataType::Float64, false),
+            Field::new("flag", DataType::Boolean, true),
+            Field::new("name", DataType::Utf8, true),
+            Field::new("big_name", DataType::LargeUtf8, false),
+            Field::new(
+                "meta",
+                DataType::Struct(vec![Field::new("a", DataType::Int64, true)].into()),
+                true,
+            ),
+            Field::new(
+                "tags",
+                DataType::List(Arc::new(Field::new("item", DataType::Utf8, true))),
+                true,
+            ),
+            // Unknown/unmapped type falls through to "string".
+            Field::new("ts", DataType::Date32, true),
+        ];
+        let schema = Schema::new(fields);
+        let json = arrow_to_json_schema(&schema);
+
+        assert_eq!(json["type"], "object");
+        let props = json["properties"].as_object().unwrap();
+
+        // Non-nullable → bare base type.
+        assert_eq!(props["i32"]["type"], "integer");
+        assert_eq!(props["f64"]["type"], "number");
+        assert_eq!(props["big_name"]["type"], "string");
+        // Nullable → [base, "null"].
+        assert_eq!(props["i64"]["type"], serde_json::json!(["integer", "null"]));
+        assert_eq!(props["u16"]["type"], serde_json::json!(["integer", "null"]));
+        assert_eq!(props["f32"]["type"], serde_json::json!(["number", "null"]));
+        assert_eq!(props["flag"]["type"], serde_json::json!(["boolean", "null"]));
+        assert_eq!(props["name"]["type"], serde_json::json!(["string", "null"]));
+        assert_eq!(props["meta"]["type"], serde_json::json!(["object", "null"]));
+        assert_eq!(props["tags"]["type"], serde_json::json!(["array", "null"]));
+        // Unmapped Arrow type → "string".
+        assert_eq!(props["ts"]["type"], serde_json::json!(["string", "null"]));
     }
 }

--- a/crates/sink/iceberg/src/sink.rs
+++ b/crates/sink/iceberg/src/sink.rs
@@ -48,7 +48,8 @@ use tokio::sync::Mutex;
 use crate::catalog::build_catalog;
 use crate::config::{IcebergSinkConfig, PartitionField};
 use crate::schema::{
-    arrow_to_iceberg_schema, iceberg_to_arrow_schema, infer_arrow_schema, json_to_record_batch,
+    arrow_to_iceberg_schema, arrow_to_json_schema, iceberg_to_arrow_schema, infer_arrow_schema,
+    json_to_record_batch,
 };
 use crate::writer::{TableWriter, compression_from_str};
 
@@ -502,6 +503,32 @@ impl faucet_core::Sink for IcebergSink {
         // Append only — equality-delete upsert is version-gated on iceberg-rust
         // (tracked as a follow-up to #190 / #179).
         &[faucet_core::WriteMode::Append]
+    }
+
+    /// Report the live table schema as an `infer_schema`-shaped JSON object so
+    /// the schema-drift policy (issue #194) can diff each page against the real
+    /// destination.
+    ///
+    /// Loads the table read-only via the catalog; a not-yet-created table (or
+    /// any "table absent" case) returns `Ok(None)` so drift handling stays inert
+    /// until the table exists — only a genuine catalog communication failure
+    /// surfaces as `Err`. On success the table's `current_schema()` is converted
+    /// to Arrow (via `iceberg_to_arrow_schema`) and then to the JSON shape.
+    ///
+    /// Schema *evolution* is intentionally NOT implemented for this sink:
+    /// `supports_schema_evolution` stays `false` (trait default) and
+    /// `evolve_schema` keeps the trait's typed "unsupported" error. iceberg-rust
+    /// 0.9.1 (pinned in this crate) exposes no schema-evolution transaction API
+    /// (no `UpdateSchema` / `add_column` / type-promotion — only `fast_append`),
+    /// so evolution is blocked upstream. Tracked in issue #255; the CLI rejects
+    /// `on_drift: evolve` against iceberg at config-load.
+    async fn current_schema(&self) -> Result<Option<Value>, FaucetError> {
+        let table = match self.load_table_readonly().await? {
+            Some(t) => t,
+            None => return Ok(None),
+        };
+        let arrow_schema = iceberg_to_arrow_schema(table.metadata().current_schema())?;
+        Ok(Some(arrow_to_json_schema(&arrow_schema)))
     }
 
     fn supports_idempotent_writes(&self) -> bool {

--- a/crates/sink/iceberg/tests/integration.rs
+++ b/crates/sink/iceberg/tests/integration.rs
@@ -250,9 +250,7 @@ async fn current_schema_reports_table_columns() {
         .expect("schema must be Some once the table exists");
 
     assert_eq!(schema["type"], "object");
-    let props = schema["properties"]
-        .as_object()
-        .expect("properties object");
+    let props = schema["properties"].as_object().expect("properties object");
     // Inferred Iceberg columns surface as nullable JSON base types.
     assert_eq!(props["id"]["type"], json!(["integer", "null"]));
     assert_eq!(props["name"]["type"], json!(["string", "null"]));

--- a/crates/sink/iceberg/tests/integration.rs
+++ b/crates/sink/iceberg/tests/integration.rs
@@ -223,3 +223,38 @@ async fn empty_write_batch_no_snapshot() {
     let exists = reader.table_exists(&tid).await.expect("table_exists check");
     assert!(!exists, "table must not exist after empty write+flush");
 }
+
+/// `current_schema` returns `Ok(None)` before the table exists and an
+/// `infer_schema`-shaped object once the table has been created (#194, #255).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn current_schema_reports_table_columns() {
+    let dir = TempDir::new().expect("tempdir");
+    let cfg = sink_config(&dir, "drift_table");
+    let sink = IcebergSink::new(cfg).await.expect("IcebergSink::new");
+
+    // Before any write the table does not exist → drift handling is inert.
+    let before = sink.current_schema().await.expect("current_schema (pre)");
+    assert_eq!(before, None, "missing table must report no schema");
+
+    // Write + flush so the table is created with an inferred schema.
+    let records: Vec<serde_json::Value> = (0u64..3)
+        .map(|i| json!({ "id": i, "name": format!("n{i}"), "active": true }))
+        .collect();
+    sink.write_batch(&records).await.expect("write_batch");
+    sink.flush().await.expect("flush");
+
+    let schema = sink
+        .current_schema()
+        .await
+        .expect("current_schema (post)")
+        .expect("schema must be Some once the table exists");
+
+    assert_eq!(schema["type"], "object");
+    let props = schema["properties"]
+        .as_object()
+        .expect("properties object");
+    // Inferred Iceberg columns surface as nullable JSON base types.
+    assert_eq!(props["id"]["type"], json!(["integer", "null"]));
+    assert_eq!(props["name"]["type"], json!(["string", "null"]));
+    assert_eq!(props["active"]["type"], json!(["boolean", "null"]));
+}

--- a/crates/sink/mssql/README.md
+++ b/crates/sink/mssql/README.md
@@ -251,6 +251,18 @@ delivery: exactly_once
 
 See the [exactly-once delivery cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/state.html#exactly-once-delivery) for the full rationale and supported source/sink set.
 
+## Schema evolution
+
+`MssqlSink` reports its live destination schema via `current_schema()` (read from `sys.columns`, including nullability), so the pipeline-level `schema:` policy can detect drift between an incoming page's top-level shape and the real table. All five `on_drift` modes (`warn` / `ignore` / `quarantine` / `fail` / `evolve`) work against this sink.
+
+Under `on_drift: evolve`, `MssqlSink::evolve_schema()` applies additive DDL:
+
+- **New columns** → `ALTER TABLE … ADD`, guarded with `IF NOT EXISTS (SELECT 1 FROM sys.columns …)` (idempotent).
+- **Lossless widenings** (e.g. integer → number) → `ALTER COLUMN` to the wider type — gated on `allow_type_widening`.
+- **Nullability relaxations** → `ALTER COLUMN … NULL`. MSSQL's `ALTER COLUMN` requires the full type spec, so the column is re-emitted at its widened base type keyword (e.g. `INT` → `BIGINT`). This is a minor, always-lossless type canonicalization — the column ends up nullable at the same or a wider type.
+
+After an evolution the cached AutoColumns set is dropped so the next write re-discovers any newly-added column. Incompatible changes (narrowing / type swaps) are never auto-applied — they are routed by `on_incompatible` (`fail` or `quarantine`). See the [schema-drift cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/schema-drift.html).
+
 ## Config loading & schema
 
 Load from YAML/JSON or environment. Inspect the full JSON Schema with:

--- a/crates/sink/mssql/src/sink.rs
+++ b/crates/sink/mssql/src/sink.rs
@@ -1030,9 +1030,13 @@ mod tests {
 
     #[test]
     fn mssql_add_column_ddl() {
-        let sql =
-            build_add_column_sql("[dbo].[events]", "dbo.events", "email", faucet_core::SqlBaseType::Text)
-                .unwrap();
+        let sql = build_add_column_sql(
+            "[dbo].[events]",
+            "dbo.events",
+            "email",
+            faucet_core::SqlBaseType::Text,
+        )
+        .unwrap();
         assert!(sql.starts_with("IF NOT EXISTS"), "{sql}");
         assert!(
             sql.contains("ALTER TABLE [dbo].[events] ADD [email] NVARCHAR(MAX)"),

--- a/crates/sink/mssql/src/sink.rs
+++ b/crates/sink/mssql/src/sink.rs
@@ -139,6 +139,40 @@ impl MssqlSink {
         Ok(cols)
     }
 
+    /// Discover each column's name, system type name, and nullability for the
+    /// target relation. Returns `(name, type_name, is_nullable)` in column order,
+    /// or an empty vec when the table does not exist / has no columns.
+    async fn discover_column_types(&self) -> Result<Vec<(String, String, bool)>, FaucetError> {
+        let mut conn = self.checkout().await?;
+        let table: &str = &self.config.table;
+        let rows = conn
+            .query(
+                "SELECT c.name AS name, ty.name AS type_name, c.is_nullable AS is_nullable \
+                 FROM sys.columns c \
+                 JOIN sys.types ty ON ty.user_type_id = c.user_type_id \
+                 WHERE c.object_id = OBJECT_ID(@P1) \
+                 ORDER BY c.column_id",
+                &[&table],
+            )
+            .await
+            .map_err(|e| FaucetError::Sink(format!("MSSQL schema query failed: {e}")))?
+            .into_first_result()
+            .await
+            .map_err(|e| FaucetError::Sink(format!("MSSQL schema query failed: {e}")))?;
+
+        let mut cols = Vec::with_capacity(rows.len());
+        for row in &rows {
+            let name = row.get::<&str, _>("name");
+            let type_name = row.get::<&str, _>("type_name");
+            // `is_nullable` is a SQL Server `bit` — tiberius decodes it as a bool.
+            let is_nullable = row.get::<bool, _>("is_nullable").unwrap_or(true);
+            if let (Some(name), Some(type_name)) = (name, type_name) {
+                cols.push((name.to_string(), type_name.to_string(), is_nullable));
+            }
+        }
+        Ok(cols)
+    }
+
     /// Resolve the column list + per-row owned params for one chunk.
     /// Returns `None` when there is nothing to insert (e.g. auto_columns with no
     /// matching keys).
@@ -456,6 +490,90 @@ async fn control(conn: &mut MssqlPooledConnection<'_>, stmt: &str) -> Result<(),
     Ok(())
 }
 
+/// Map a [`SqlBaseType`] to the MSSQL type keyword used when adding/widening a
+/// column during schema evolution (issue #194). Integers widen to `BIGINT` and
+/// floats to `FLOAT` so a later, wider value never overflows a narrower column;
+/// text/json land in `NVARCHAR(MAX)`.
+fn mssql_keyword(t: faucet_core::SqlBaseType) -> &'static str {
+    use faucet_core::SqlBaseType::*;
+    match t {
+        Integer => "BIGINT",
+        Double => "FLOAT",
+        Boolean => "BIT",
+        Text => "NVARCHAR(MAX)",
+        Json => "NVARCHAR(MAX)",
+    }
+}
+
+/// Build an idempotent `ADD COLUMN`. T-SQL has no `ADD COLUMN IF NOT EXISTS`, so
+/// guard with `IF NOT EXISTS (SELECT 1 FROM sys.columns …)`.
+///
+/// `table_quoted` is the already-bracket-quoted relation (`[dbo].[events]`).
+/// `table_literal` is the bare (un-quoted) table name used inside the
+/// `OBJECT_ID(N'…')` lookup — the caller passes `self.config.table` so it
+/// resolves the same relation the DDL targets. Both `table_literal` and `col`
+/// are single-quote-escaped for their `N'…'` string literals; `col` is also
+/// bracket-quoted for the `ADD` clause via [`quote_ident_mssql`].
+fn build_add_column_sql(
+    table_quoted: &str,
+    table_literal: &str,
+    col: &str,
+    t: faucet_core::SqlBaseType,
+) -> Result<String, FaucetError> {
+    let qcol = quote_ident_mssql(col)?;
+    Ok(format!(
+        "IF NOT EXISTS (SELECT 1 FROM sys.columns \
+         WHERE object_id = OBJECT_ID(N'{}') AND name = N'{}') \
+         ALTER TABLE {table_quoted} ADD {qcol} {}",
+        table_literal.replace('\'', "''"),
+        col.replace('\'', "''"),
+        mssql_keyword(t),
+    ))
+}
+
+/// `ALTER TABLE <ref> ALTER COLUMN <col> <kw>` — widen an existing column's
+/// type. Naturally idempotent (re-running the same type change is a no-op).
+fn build_alter_type_sql(
+    table_quoted: &str,
+    col: &str,
+    t: faucet_core::SqlBaseType,
+) -> Result<String, FaucetError> {
+    let qcol = quote_ident_mssql(col)?;
+    Ok(format!(
+        "ALTER TABLE {table_quoted} ALTER COLUMN {qcol} {}",
+        mssql_keyword(t),
+    ))
+}
+
+/// `ALTER TABLE <ref> ALTER COLUMN <col> <kw> NULL` — relax a NOT NULL
+/// constraint. MSSQL requires re-stating the column's current type when toggling
+/// nullability, so `kw` must be the column's existing type keyword. Naturally
+/// idempotent.
+fn build_alter_null_sql(table_quoted: &str, col: &str, kw: &str) -> Result<String, FaucetError> {
+    let qcol = quote_ident_mssql(col)?;
+    Ok(format!(
+        "ALTER TABLE {table_quoted} ALTER COLUMN {qcol} {kw} NULL",
+    ))
+}
+
+/// Map an MSSQL system type name (`sys.types.name`, e.g. `bigint`, `float`,
+/// `bit`, `nvarchar`) back to a JSON-Schema type fragment so
+/// [`MssqlSink::current_schema`] round-trips with [`faucet_core::diff_schema`].
+/// `nullable` reflects `sys.columns.is_nullable`.
+fn mssql_type_to_json_schema(type_name: &str, nullable: bool) -> Value {
+    let base = match type_name.to_ascii_lowercase().as_str() {
+        "bigint" | "int" | "smallint" | "tinyint" => "integer",
+        "float" | "real" | "decimal" | "numeric" | "money" | "smallmoney" => "number",
+        "bit" => "boolean",
+        _ => "string",
+    };
+    if nullable {
+        serde_json::json!({ "type": [base, "null"] })
+    } else {
+        serde_json::json!({ "type": base })
+    }
+}
+
 /// Quote a (possibly schema-qualified) table name: `dbo.events` → `[dbo].[events]`.
 fn quote_table(table: &str) -> Result<String, FaucetError> {
     let parts: Vec<String> = table
@@ -627,6 +745,86 @@ impl Sink for MssqlSink {
             faucet_core::WriteMode::Upsert,
             faucet_core::WriteMode::Delete,
         ]
+    }
+
+    fn supports_schema_evolution(&self) -> bool {
+        true
+    }
+
+    /// Read the live destination schema from `sys.columns` as an
+    /// `infer_schema`-shaped object (`{"type":"object","properties":{…}}`), or
+    /// `None` when the target table does not exist yet (issue #194).
+    async fn current_schema(&self) -> Result<Option<Value>, FaucetError> {
+        let cols = self.discover_column_types().await?;
+        if cols.is_empty() {
+            return Ok(None); // table does not exist yet
+        }
+        let mut props = serde_json::Map::new();
+        for (name, type_name, nullable) in cols {
+            props.insert(name, mssql_type_to_json_schema(&type_name, nullable));
+        }
+        Ok(Some(
+            serde_json::json!({ "type": "object", "properties": props }),
+        ))
+    }
+
+    /// Apply an additive schema evolution (new columns, lossless widenings,
+    /// nullability relaxations) to the destination table. Idempotent — the
+    /// `ADD` is guarded with `IF NOT EXISTS (SELECT 1 FROM sys.columns …)`, and
+    /// re-running the same `ALTER COLUMN` type / `… NULL` is a no-op (issue #194).
+    async fn evolve_schema(
+        &self,
+        evolution: &faucet_core::SchemaEvolution,
+    ) -> Result<(), FaucetError> {
+        let mut conn = self.checkout().await?;
+
+        for c in &evolution.additions {
+            let t =
+                faucet_core::json_schema_base_type(&c.to).unwrap_or(faucet_core::SqlBaseType::Text);
+            let sql = build_add_column_sql(&self.table_quoted, &self.config.table, &c.name, t)?;
+            control(&mut conn, &sql).await.map_err(|e| {
+                FaucetError::Sink(format!("MSSQL ADD COLUMN {} failed: {e}", c.name))
+            })?;
+        }
+        for c in &evolution.widenings {
+            let t =
+                faucet_core::json_schema_base_type(&c.to).unwrap_or(faucet_core::SqlBaseType::Text);
+            let sql = build_alter_type_sql(&self.table_quoted, &c.name, t)?;
+            control(&mut conn, &sql).await.map_err(|e| {
+                FaucetError::Sink(format!("MSSQL ALTER COLUMN {} failed: {e}", c.name))
+            })?;
+        }
+        if !evolution.relax_nullability.is_empty() {
+            // Re-emitting the column as NULL requires its CURRENT type keyword —
+            // derive it from the live schema.
+            let current: std::collections::HashMap<String, &'static str> = self
+                .discover_column_types()
+                .await?
+                .into_iter()
+                .map(|(name, type_name, _)| {
+                    let base = faucet_core::json_schema_base_type(&mssql_type_to_json_schema(
+                        &type_name, false,
+                    ))
+                    .unwrap_or(faucet_core::SqlBaseType::Text);
+                    (name, mssql_keyword(base))
+                })
+                .collect();
+            for col in &evolution.relax_nullability {
+                let Some(kw) = current.get(col) else {
+                    // Column not found in the live schema — nothing to relax.
+                    continue;
+                };
+                let sql = build_alter_null_sql(&self.table_quoted, col, kw)?;
+                control(&mut conn, &sql).await.map_err(|e| {
+                    FaucetError::Sink(format!("MSSQL relax NULL {col} failed: {e}"))
+                })?;
+            }
+        }
+
+        // Columns changed — drop the cached AutoColumns set so the next write
+        // re-discovers them (a newly-added column must be picked up).
+        *self.columns_cache.lock().expect("columns mutex") = None;
+        Ok(())
     }
 
     async fn last_committed_token(&self, scope: &str) -> Result<Option<String>, FaucetError> {
@@ -827,6 +1025,97 @@ mod tests {
             faucet_core::idempotency::COMMIT_TOKEN_TOKEN_COL,
             "token",
             "COMMIT_TOKEN_TOKEN_COL name changed — update DDL and queries"
+        );
+    }
+
+    #[test]
+    fn mssql_add_column_ddl() {
+        let sql =
+            build_add_column_sql("[dbo].[events]", "dbo.events", "email", faucet_core::SqlBaseType::Text)
+                .unwrap();
+        assert!(sql.starts_with("IF NOT EXISTS"), "{sql}");
+        assert!(
+            sql.contains("ALTER TABLE [dbo].[events] ADD [email] NVARCHAR(MAX)"),
+            "{sql}"
+        );
+        // The OBJECT_ID guard targets the bare table literal.
+        assert!(sql.contains("OBJECT_ID(N'dbo.events')"), "{sql}");
+        assert!(sql.contains("name = N'email'"), "{sql}");
+    }
+
+    #[test]
+    fn mssql_add_column_keyword_per_base_type() {
+        use faucet_core::SqlBaseType::*;
+        for (t, kw) in [
+            (Integer, "BIGINT"),
+            (Double, "FLOAT"),
+            (Boolean, "BIT"),
+            (Text, "NVARCHAR(MAX)"),
+            (Json, "NVARCHAR(MAX)"),
+        ] {
+            let sql = build_add_column_sql("[t]", "t", "c", t).unwrap();
+            assert!(sql.ends_with(&format!("ADD [c] {kw}")), "{t:?}: {sql}");
+        }
+    }
+
+    #[test]
+    fn mssql_add_column_escapes_literals() {
+        // Single quotes in the table/column literal are doubled for N'…';
+        // brackets in the identifier are doubled by quote_ident_mssql.
+        let sql = build_add_column_sql("[d].[t]", "d.o'x", "c'l", faucet_core::SqlBaseType::Text)
+            .unwrap();
+        assert!(sql.contains("OBJECT_ID(N'd.o''x')"), "{sql}");
+        assert!(sql.contains("name = N'c''l'"), "{sql}");
+        assert!(sql.contains("ADD [c'l] NVARCHAR(MAX)"), "{sql}");
+    }
+
+    #[test]
+    fn mssql_widen_column_ddl() {
+        let sql =
+            build_alter_type_sql("[dbo].[t]", "score", faucet_core::SqlBaseType::Double).unwrap();
+        assert_eq!(sql, "ALTER TABLE [dbo].[t] ALTER COLUMN [score] FLOAT");
+    }
+
+    #[test]
+    fn mssql_relax_null_ddl_re_emits_current_type() {
+        let sql = build_alter_null_sql("[t]", "created_at", "DATETIME2").unwrap();
+        assert_eq!(
+            sql,
+            "ALTER TABLE [t] ALTER COLUMN [created_at] DATETIME2 NULL"
+        );
+    }
+
+    #[test]
+    fn mssql_type_round_trips_to_json_schema() {
+        use serde_json::json;
+        assert_eq!(
+            mssql_type_to_json_schema("bigint", false),
+            json!({"type":"integer"})
+        );
+        assert_eq!(
+            mssql_type_to_json_schema("int", false),
+            json!({"type":"integer"})
+        );
+        assert_eq!(
+            mssql_type_to_json_schema("float", false),
+            json!({"type":"number"})
+        );
+        assert_eq!(
+            mssql_type_to_json_schema("decimal", false),
+            json!({"type":"number"})
+        );
+        assert_eq!(
+            mssql_type_to_json_schema("bit", false),
+            json!({"type":"boolean"})
+        );
+        assert_eq!(
+            mssql_type_to_json_schema("nvarchar", false),
+            json!({"type":"string"})
+        );
+        // Case-insensitive; nullable widens to a type array.
+        assert_eq!(
+            mssql_type_to_json_schema("NVARCHAR", true),
+            json!({"type":["string","null"]})
         );
     }
 

--- a/crates/sink/mssql/src/sink.rs
+++ b/crates/sink/mssql/src/sink.rs
@@ -490,7 +490,7 @@ async fn control(conn: &mut MssqlPooledConnection<'_>, stmt: &str) -> Result<(),
     Ok(())
 }
 
-/// Map a [`SqlBaseType`] to the MSSQL type keyword used when adding/widening a
+/// Map a [`SqlBaseType`](faucet_core::SqlBaseType) to the MSSQL type keyword used when adding/widening a
 /// column during schema evolution (issue #194). Integers widen to `BIGINT` and
 /// floats to `FLOAT` so a later, wider value never overflows a narrower column;
 /// text/json land in `NVARCHAR(MAX)`.

--- a/crates/sink/mssql/tests/schema_evolution.rs
+++ b/crates/sink/mssql/tests/schema_evolution.rs
@@ -1,0 +1,142 @@
+//! Integration tests for MSSQL sink schema introspection + evolution (#194).
+//!
+//! Requires Docker (the `mcr.microsoft.com/mssql/server` image). Run with:
+//! `cargo test -p faucet-sink-mssql --test schema_evolution`.
+
+use faucet_common_mssql::{MssqlConnectionConfig, MssqlPool, MssqlTls, MssqlTlsMode, build_pool};
+use faucet_core::{ColumnChange, SchemaEvolution, Sink};
+use serde_json::json;
+use testcontainers_modules::mssql_server::MssqlServer;
+use testcontainers_modules::testcontainers::ContainerAsync;
+use testcontainers_modules::testcontainers::runners::AsyncRunner;
+
+const ENCODED_PW: &str = "yourStrong%28%21%29Password";
+
+// SQL Server containers need ~2 GB RAM each; serialize so parallel tests don't
+// start several containers at once and exhaust the runner.
+static SERIAL: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+async fn start_mssql() -> (ContainerAsync<MssqlServer>, u16) {
+    let container = MssqlServer::default()
+        .with_accept_eula()
+        .start()
+        .await
+        .expect("start mssql container");
+    let port = container
+        .get_host_port_ipv4(1433)
+        .await
+        .expect("mssql host port");
+    (container, port)
+}
+
+fn conn_cfg(port: u16) -> MssqlConnectionConfig {
+    MssqlConnectionConfig {
+        connection_url: Some(format!("mssql://sa:{ENCODED_PW}@127.0.0.1:{port}/master")),
+        connection_string: None,
+        tls: MssqlTls {
+            mode: MssqlTlsMode::TrustServerCertificate,
+            ca_cert_path: None,
+        },
+    }
+}
+
+async fn exec(pool: &MssqlPool, sql: &str) {
+    let mut conn = pool.get().await.expect("checkout");
+    conn.execute(sql, &[]).await.expect("execute setup sql");
+}
+
+fn sink_cfg(cfg: &MssqlConnectionConfig, table: &str) -> MssqlSinkConfig {
+    let mut s = MssqlSinkConfig::new(cfg.connection_url.clone().unwrap(), table);
+    s.connection.tls = cfg.tls.clone();
+    s.column_mapping = MssqlColumnMapping::AutoColumns {
+        on_unknown_field: faucet_sink_mssql::OnUnknownField::Warn,
+    };
+    s
+}
+
+use faucet_sink_mssql::{MssqlColumnMapping, MssqlSink, MssqlSinkConfig};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn current_schema_and_evolve_add_and_widen() {
+    let _serial = SERIAL.lock().await;
+    let (_c, port) = start_mssql().await;
+    let cfg = conn_cfg(port);
+    let pool = build_pool(&cfg, 4).await.expect("pool");
+
+    exec(&pool, "CREATE TABLE dbo.t (id BIGINT)").await;
+
+    let sink = MssqlSink::new(sink_cfg(&cfg, "dbo.t")).await.expect("sink");
+
+    // current_schema: id is integer, nullable (no NOT NULL declared).
+    let schema = sink
+        .current_schema()
+        .await
+        .expect("current_schema")
+        .expect("table exists");
+    let id_ty = &schema["properties"]["id"]["type"];
+    // BIGINT → integer; the column allows NULL so the type widens to an array.
+    assert!(
+        id_ty == &json!("integer") || id_ty == &json!(["integer", "null"]),
+        "id should be integer (got {id_ty})"
+    );
+
+    // Evolve: add `email` (NVARCHAR(MAX) ← Text) and widen `id` → FLOAT (number).
+    let evolution = SchemaEvolution {
+        additions: vec![ColumnChange {
+            name: "email".into(),
+            from: None,
+            to: json!({"type": "string"}),
+        }],
+        widenings: vec![ColumnChange {
+            name: "id".into(),
+            from: Some(json!({"type": "integer"})),
+            to: json!({"type": "number"}),
+        }],
+        relax_nullability: vec![],
+    };
+    sink.evolve_schema(&evolution).await.expect("evolve");
+
+    // Re-query: email present (string), id now number.
+    let schema = sink
+        .current_schema()
+        .await
+        .expect("current_schema")
+        .expect("table exists");
+    let email_ty = &schema["properties"]["email"]["type"];
+    assert!(
+        email_ty == &json!("string") || email_ty == &json!(["string", "null"]),
+        "email should be string (got {email_ty})"
+    );
+    let id_ty = &schema["properties"]["id"]["type"];
+    assert!(
+        id_ty == &json!("number") || id_ty == &json!(["number", "null"]),
+        "id should be widened to number (got {id_ty})"
+    );
+
+    // Idempotent re-run: the guarded ADD + ALTER are no-ops and must not error.
+    sink.evolve_schema(&evolution)
+        .await
+        .expect("idempotent re-run");
+
+    // A write that uses the new column must succeed (cache was invalidated).
+    let written = sink
+        .write_batch(&[json!({"id": 1, "email": "a@b.c"})])
+        .await
+        .expect("write after evolve");
+    assert_eq!(written, 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn current_schema_returns_none_for_missing_table() {
+    let _serial = SERIAL.lock().await;
+    let (_c, port) = start_mssql().await;
+    let cfg = conn_cfg(port);
+
+    let sink = MssqlSink::new(sink_cfg(&cfg, "dbo.does_not_exist"))
+        .await
+        .expect("sink");
+    assert!(
+        sink.current_schema().await.expect("current_schema").is_none(),
+        "missing table → None"
+    );
+}

--- a/crates/sink/mssql/tests/schema_evolution.rs
+++ b/crates/sink/mssql/tests/schema_evolution.rs
@@ -136,7 +136,10 @@ async fn current_schema_returns_none_for_missing_table() {
         .await
         .expect("sink");
     assert!(
-        sink.current_schema().await.expect("current_schema").is_none(),
+        sink.current_schema()
+            .await
+            .expect("current_schema")
+            .is_none(),
         "missing table → None"
     );
 }

--- a/crates/sink/mysql/README.md
+++ b/crates/sink/mysql/README.md
@@ -248,6 +248,18 @@ delivery: exactly_once
 
 See the [exactly-once cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/state.html#exactly-once-delivery) for the full rationale and the supported source/sink set.
 
+## Schema evolution
+
+`MysqlSink` reports its live destination schema via `current_schema()` (read from `INFORMATION_SCHEMA.COLUMNS`, including `IS_NULLABLE`), so the pipeline-level `schema:` policy can detect drift between an incoming page's top-level shape and the real table. All five `on_drift` modes (`warn` / `ignore` / `quarantine` / `fail` / `evolve`) work against this sink.
+
+Under `on_drift: evolve`, `MysqlSink::evolve_schema()` applies additive DDL:
+
+- **New columns** → `ADD COLUMN`. MySQL has no `ADD COLUMN IF NOT EXISTS`, so the current column set is read first and an `ADD COLUMN` is emitted only for names not already present (idempotent by pre-check).
+- **Lossless widenings** (e.g. integer → number) → `MODIFY COLUMN` — gated on `allow_type_widening`; re-running the same `MODIFY` is a no-op.
+- **Nullability relaxations** → the column is re-emitted at its current mapped type with an explicit `NULL` (`MODIFY COLUMN`).
+
+Incompatible changes (narrowing / type swaps) are never auto-applied — they are routed by `on_incompatible` (`fail` or `quarantine`). See the [schema-drift cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/schema-drift.html).
+
 ## Dead-letter queue
 
 In `upsert`/`delete` mode the sink overrides `Sink::write_batch_partial`: good rows are applied and only the rows whose key could not be extracted (missing/null key) are reported as `Err`, so the pipeline routes them to the configured DLQ per-row rather than failing the whole page. In `append` mode it delegates to `write_batch`. Add a `dlq:` block to your pipeline to capture those rows; without one, a bad key fails the batch.

--- a/crates/sink/mysql/src/sink.rs
+++ b/crates/sink/mysql/src/sink.rs
@@ -550,7 +550,7 @@ impl faucet_core::Sink for MysqlSink {
     ///
     /// The MySQL database is implicit (`DATABASE()`), so there is no schema
     /// qualifier to thread. `DATA_TYPE` / `IS_NULLABLE` round-trip through
-    /// [`mysql_data_type_to_json_schema`].
+    /// `mysql_data_type_to_json_schema`.
     async fn current_schema(&self) -> Result<Option<serde_json::Value>, FaucetError> {
         let columns = self.read_columns().await?;
         if columns.is_empty() {

--- a/crates/sink/mysql/src/sink.rs
+++ b/crates/sink/mysql/src/sink.rs
@@ -457,7 +457,8 @@ impl MysqlSink {
                     // DATA_TYPE is already lowercase per the SQL standard, but
                     // normalize defensively.
                     row.get::<String, _>("DATA_TYPE").to_ascii_lowercase(),
-                    row.get::<String, _>("IS_NULLABLE").eq_ignore_ascii_case("YES"),
+                    row.get::<String, _>("IS_NULLABLE")
+                        .eq_ignore_ascii_case("YES"),
                 )
             })
             .collect())
@@ -600,7 +601,9 @@ impl faucet_core::Sink for MysqlSink {
             sqlx::query(&build_add_column_sql(&table_ref, &c.name, t))
                 .execute(&mut *conn)
                 .await
-                .map_err(|e| FaucetError::Sink(format!("MySQL ADD COLUMN {} failed: {e}", c.name)))?;
+                .map_err(|e| {
+                    FaucetError::Sink(format!("MySQL ADD COLUMN {} failed: {e}", c.name))
+                })?;
         }
 
         for c in &evolution.widenings {

--- a/crates/sink/mysql/src/sink.rs
+++ b/crates/sink/mysql/src/sink.rs
@@ -2,7 +2,7 @@
 
 use crate::config::{MysqlColumnMapping, MysqlSinkConfig};
 use async_trait::async_trait;
-use faucet_core::FaucetError;
+use faucet_core::{FaucetError, SchemaEvolution, SqlBaseType, json_schema_base_type};
 use serde_json::Value;
 use sqlx::mysql::MySqlPoolOptions;
 use sqlx::{MySqlConnection, MySqlPool, Row};
@@ -19,6 +19,68 @@ pub struct MysqlSink {
 /// them, per MySQL convention.
 fn quote_ident_mysql(name: &str) -> String {
     format!("`{}`", name.replace('`', "``"))
+}
+
+/// Map a [`SqlBaseType`] to the MySQL type keyword used when adding/widening a
+/// column during schema evolution (issue #194). Integers always widen to
+/// `BIGINT` and floats to `DOUBLE` so a later, wider value never overflows a
+/// narrower column. `Text` maps to `LONGTEXT` (the widest text type, so a long
+/// value never truncates) and `Json` to MySQL's native `JSON`.
+fn mysql_keyword(t: SqlBaseType) -> &'static str {
+    match t {
+        SqlBaseType::Integer => "BIGINT",
+        SqlBaseType::Double => "DOUBLE",
+        SqlBaseType::Boolean => "TINYINT(1)",
+        SqlBaseType::Text => "LONGTEXT",
+        SqlBaseType::Json => "JSON",
+    }
+}
+
+/// `ALTER TABLE <table> ADD COLUMN `col` <kw>` — column addition.
+///
+/// MySQL (pre-8.0.x) has no `ADD COLUMN IF NOT EXISTS`, so idempotency is
+/// achieved by the caller pre-checking the existing column set and only
+/// emitting this for columns not already present. `table` is the already-quoted
+/// table reference.
+fn build_add_column_sql(table: &str, col: &str, t: SqlBaseType) -> String {
+    format!(
+        "ALTER TABLE {table} ADD COLUMN {} {}",
+        quote_ident_mysql(col),
+        mysql_keyword(t)
+    )
+}
+
+/// `ALTER TABLE <table> MODIFY COLUMN `col` <kw>` — widen an existing column's
+/// type. Naturally idempotent (re-running the same MODIFY is a no-op). `table`
+/// is the already-quoted table reference.
+fn build_modify_column_sql(table: &str, col: &str, t: SqlBaseType) -> String {
+    format!(
+        "ALTER TABLE {table} MODIFY COLUMN {} {}",
+        quote_ident_mysql(col),
+        mysql_keyword(t)
+    )
+}
+
+/// Map a MySQL `INFORMATION_SCHEMA.COLUMNS.DATA_TYPE` value (lowercase, no
+/// precision — e.g. `bigint`, `double`, `json`, `varchar`) back to a JSON-Schema
+/// type fragment so [`MysqlSink::current_schema`] round-trips with
+/// [`faucet_core::diff_schema`]. `nullable` reflects `IS_NULLABLE = 'YES'`.
+///
+/// Note: `INFORMATION_SCHEMA.DATA_TYPE` returns bare `tinyint` without the
+/// `(1)` precision, so a `TINYINT(1)` (conventionally boolean) is
+/// indistinguishable from a real `TINYINT` — both map to `integer` for safety.
+fn mysql_data_type_to_json_schema(data_type: &str, nullable: bool) -> Value {
+    let base = match data_type {
+        "bigint" | "int" | "integer" | "smallint" | "mediumint" | "tinyint" => "integer",
+        "double" | "float" | "decimal" | "numeric" => "number",
+        "json" => "object",
+        _ => "string",
+    };
+    if nullable {
+        serde_json::json!({ "type": [base, "null"] })
+    } else {
+        serde_json::json!({ "type": base })
+    }
 }
 
 /// Build the `ON DUPLICATE KEY UPDATE …` tail for an upsert INSERT.
@@ -363,6 +425,44 @@ impl MysqlSink {
         Ok(affected)
     }
 
+    /// Read the live destination columns as `(name, data_type, nullable)`
+    /// tuples, in declared order, from `INFORMATION_SCHEMA.COLUMNS`. An empty
+    /// vector means the table does not exist (or has no columns).
+    ///
+    /// Shared by [`current_schema`](faucet_core::Sink::current_schema) and
+    /// [`evolve_schema`](faucet_core::Sink::evolve_schema) — the latter needs the
+    /// current set to make `ADD COLUMN` idempotent (MySQL lacks
+    /// `ADD COLUMN IF NOT EXISTS`).
+    async fn read_columns(&self) -> Result<Vec<(String, String, bool)>, FaucetError> {
+        // MySQL's INFORMATION_SCHEMA string columns are typed as a binary/blob
+        // collation, which sqlx decodes as `Vec<u8>` rather than `String`; cast
+        // each to CHAR so they decode as `String`.
+        let rows = sqlx::query(
+            "SELECT CAST(COLUMN_NAME AS CHAR) AS COLUMN_NAME, \
+                    CAST(DATA_TYPE AS CHAR) AS DATA_TYPE, \
+                    CAST(IS_NULLABLE AS CHAR) AS IS_NULLABLE \
+             FROM INFORMATION_SCHEMA.COLUMNS \
+             WHERE TABLE_NAME = ? AND TABLE_SCHEMA = DATABASE() ORDER BY ORDINAL_POSITION",
+        )
+        .bind(&self.config.table_name)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| FaucetError::Sink(format!("failed to query table columns: {e}")))?;
+
+        Ok(rows
+            .iter()
+            .map(|row| {
+                (
+                    row.get::<String, _>("COLUMN_NAME"),
+                    // DATA_TYPE is already lowercase per the SQL standard, but
+                    // normalize defensively.
+                    row.get::<String, _>("DATA_TYPE").to_ascii_lowercase(),
+                    row.get::<String, _>("IS_NULLABLE").eq_ignore_ascii_case("YES"),
+                )
+            })
+            .collect())
+    }
+
     /// Create the commit-token watermark table if it does not yet exist.
     ///
     /// The table holds one row per pipeline scope (state key). MySQL requires a
@@ -437,6 +537,106 @@ impl faucet_core::Sink for MysqlSink {
             faucet_core::WriteMode::Upsert,
             faucet_core::WriteMode::Delete,
         ]
+    }
+
+    fn supports_schema_evolution(&self) -> bool {
+        true
+    }
+
+    /// Read the live destination schema from `INFORMATION_SCHEMA.COLUMNS` as an
+    /// `infer_schema`-shaped object (`{"type":"object","properties":{…}}`), or
+    /// `None` when the target table does not exist yet (issue #194).
+    ///
+    /// The MySQL database is implicit (`DATABASE()`), so there is no schema
+    /// qualifier to thread. `DATA_TYPE` / `IS_NULLABLE` round-trip through
+    /// [`mysql_data_type_to_json_schema`].
+    async fn current_schema(&self) -> Result<Option<serde_json::Value>, FaucetError> {
+        let columns = self.read_columns().await?;
+        if columns.is_empty() {
+            return Ok(None); // table does not exist yet
+        }
+
+        let mut props = serde_json::Map::new();
+        for (name, data_type, nullable) in columns {
+            props.insert(name, mysql_data_type_to_json_schema(&data_type, nullable));
+        }
+        Ok(Some(
+            serde_json::json!({ "type": "object", "properties": props }),
+        ))
+    }
+
+    /// Apply an additive schema evolution (new columns, lossless widenings,
+    /// nullability relaxations) to the destination table (issue #194).
+    ///
+    /// MySQL has no `ADD COLUMN IF NOT EXISTS` (pre-8.0.x), so the current
+    /// column set is read first and an `ADD COLUMN` is emitted only for names
+    /// not already present — making re-runs idempotent. Widenings use
+    /// `MODIFY COLUMN` (re-running the same MODIFY is a no-op); nullability
+    /// relaxations re-emit the column as its current mapped type with an
+    /// explicit `NULL`.
+    async fn evolve_schema(&self, evolution: &SchemaEvolution) -> Result<(), FaucetError> {
+        let table_ref = quote_ident_mysql(&self.config.table_name);
+
+        // Read the current columns up front: needed for ADD-COLUMN idempotency
+        // (pre-check by name) and to derive a column's existing type when
+        // relaxing nullability.
+        let current = self.read_columns().await?;
+        let existing: std::collections::HashSet<&str> =
+            current.iter().map(|(n, _, _)| n.as_str()).collect();
+
+        let mut conn = self
+            .pool
+            .acquire()
+            .await
+            .map_err(|e| FaucetError::Sink(format!("MySQL evolve acquire failed: {e}")))?;
+
+        for c in &evolution.additions {
+            // Idempotency: MySQL lacks ADD COLUMN IF NOT EXISTS, so skip a
+            // column that already exists rather than erroring on a re-run.
+            if existing.contains(c.name.as_str()) {
+                continue;
+            }
+            let t = json_schema_base_type(&c.to).unwrap_or(SqlBaseType::Text);
+            sqlx::query(&build_add_column_sql(&table_ref, &c.name, t))
+                .execute(&mut *conn)
+                .await
+                .map_err(|e| FaucetError::Sink(format!("MySQL ADD COLUMN {} failed: {e}", c.name)))?;
+        }
+
+        for c in &evolution.widenings {
+            let t = json_schema_base_type(&c.to).unwrap_or(SqlBaseType::Text);
+            sqlx::query(&build_modify_column_sql(&table_ref, &c.name, t))
+                .execute(&mut *conn)
+                .await
+                .map_err(|e| {
+                    FaucetError::Sink(format!("MySQL MODIFY COLUMN {} failed: {e}", c.name))
+                })?;
+        }
+
+        for col in &evolution.relax_nullability {
+            // Re-emit the column as its CURRENT type but explicitly nullable.
+            // MySQL's MODIFY COLUMN requires the full type spec, so map the
+            // column's existing DATA_TYPE back to a base type and re-emit it.
+            let existing_type = current
+                .iter()
+                .find(|(n, _, _)| n == col)
+                .map(|(_, dt, nullable)| {
+                    let fragment = mysql_data_type_to_json_schema(dt, *nullable);
+                    json_schema_base_type(&fragment).unwrap_or(SqlBaseType::Text)
+                })
+                .unwrap_or(SqlBaseType::Text);
+            let sql = format!(
+                "ALTER TABLE {table_ref} MODIFY COLUMN {} {} NULL",
+                quote_ident_mysql(col),
+                mysql_keyword(existing_type)
+            );
+            sqlx::query(&sql)
+                .execute(&mut *conn)
+                .await
+                .map_err(|e| FaucetError::Sink(format!("MySQL DROP NOT NULL {col} failed: {e}")))?;
+        }
+
+        Ok(())
     }
 
     /// Write records to MySQL.
@@ -685,5 +885,73 @@ mod tests {
             &["a".to_string(), "b".to_string(), "v".to_string()],
         );
         assert_eq!(clause, "ON DUPLICATE KEY UPDATE `v` = VALUES(`v`)");
+    }
+
+    #[test]
+    fn mysql_add_column_ddl() {
+        let sql = build_add_column_sql("`t`", "email", SqlBaseType::Text);
+        assert_eq!(sql, "ALTER TABLE `t` ADD COLUMN `email` LONGTEXT");
+
+        // A backtick in the column name is doubled (SQL-injection safety).
+        let sql = build_add_column_sql("`t`", "ev`il", SqlBaseType::Integer);
+        assert_eq!(sql, "ALTER TABLE `t` ADD COLUMN `ev``il` BIGINT");
+    }
+
+    #[test]
+    fn mysql_modify_column_ddl() {
+        let sql = build_modify_column_sql("`t`", "score", SqlBaseType::Double);
+        assert_eq!(sql, "ALTER TABLE `t` MODIFY COLUMN `score` DOUBLE");
+
+        let sql = build_modify_column_sql("`t`", "flag", SqlBaseType::Boolean);
+        assert_eq!(sql, "ALTER TABLE `t` MODIFY COLUMN `flag` TINYINT(1)");
+    }
+
+    #[test]
+    fn mysql_keyword_mapping() {
+        assert_eq!(mysql_keyword(SqlBaseType::Integer), "BIGINT");
+        assert_eq!(mysql_keyword(SqlBaseType::Double), "DOUBLE");
+        assert_eq!(mysql_keyword(SqlBaseType::Boolean), "TINYINT(1)");
+        assert_eq!(mysql_keyword(SqlBaseType::Text), "LONGTEXT");
+        assert_eq!(mysql_keyword(SqlBaseType::Json), "JSON");
+    }
+
+    #[test]
+    fn mysql_data_type_round_trips_to_json_schema() {
+        use serde_json::json;
+        assert_eq!(
+            mysql_data_type_to_json_schema("bigint", false),
+            json!({"type":"integer"})
+        );
+        assert_eq!(
+            mysql_data_type_to_json_schema("int", false),
+            json!({"type":"integer"})
+        );
+        // tinyint maps to integer (precision is not exposed by DATA_TYPE, so we
+        // never guess boolean for safety).
+        assert_eq!(
+            mysql_data_type_to_json_schema("tinyint", false),
+            json!({"type":"integer"})
+        );
+        assert_eq!(
+            mysql_data_type_to_json_schema("double", false),
+            json!({"type":"number"})
+        );
+        assert_eq!(
+            mysql_data_type_to_json_schema("decimal", false),
+            json!({"type":"number"})
+        );
+        assert_eq!(
+            mysql_data_type_to_json_schema("json", false),
+            json!({"type":"object"})
+        );
+        assert_eq!(
+            mysql_data_type_to_json_schema("varchar", false),
+            json!({"type":"string"})
+        );
+        // Unknown types fall back to string; nullable widens the type array.
+        assert_eq!(
+            mysql_data_type_to_json_schema("datetime", true),
+            json!({"type":["string","null"]})
+        );
     }
 }

--- a/crates/sink/mysql/tests/schema_evolution.rs
+++ b/crates/sink/mysql/tests/schema_evolution.rs
@@ -1,0 +1,156 @@
+//! Integration tests for [`MysqlSink`]'s schema-drift introspection +
+//! evolution path (`current_schema` / `evolve_schema`, issue #194) against a
+//! real MySQL instance via testcontainers.
+//!
+//! These tests require Docker. Each test boots its own container so they are
+//! fully isolated and safe to run in parallel.
+
+use faucet_core::{ColumnChange, SchemaEvolution, Sink};
+use faucet_sink_mysql::{MysqlColumnMapping, MysqlSink, MysqlSinkConfig};
+use serde_json::json;
+use std::sync::OnceLock;
+use testcontainers::{ContainerAsync, runners::AsyncRunner};
+use testcontainers_modules::mysql::Mysql;
+use tokio::sync::Semaphore;
+
+/// Bounds concurrent MySQL container startups across all tests in this binary
+/// (MySQL 8.x init is memory-heavy — mirrors the cap in `upsert.rs`).
+fn startup_limit() -> &'static Semaphore {
+    static SEM: OnceLock<Semaphore> = OnceLock::new();
+    SEM.get_or_init(|| Semaphore::new(2))
+}
+
+/// Start a MySQL container and return both the container handle and a
+/// connection URL.
+async fn start_mysql() -> (ContainerAsync<Mysql>, String) {
+    let _permit = startup_limit()
+        .acquire()
+        .await
+        .expect("startup semaphore closed");
+    let image = Mysql::default();
+    let container: ContainerAsync<Mysql> = image.start().await.expect("mysql container start");
+    let port = container.get_host_port_ipv4(3306).await.expect("mysql port");
+    let url = format!("mysql://root@127.0.0.1:{port}/test");
+    (container, url)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn current_schema_then_evolve_add_and_widen_is_idempotent() {
+    let (_container, url) = start_mysql().await;
+
+    // 1. Create a one-column table: id BIGINT (nullable — no NOT NULL).
+    let pool = sqlx::MySqlPool::connect(&url).await.expect("pool connect");
+    sqlx::query("CREATE TABLE t (id BIGINT)")
+        .execute(&pool)
+        .await
+        .expect("create table");
+    pool.close().await;
+
+    // 2. Build the sink (AutoMap) and read the live schema.
+    let sink = MysqlSink::new(
+        MysqlSinkConfig::new(&url, "t").column_mapping(MysqlColumnMapping::AutoMap),
+    )
+    .await
+    .expect("sink new");
+
+    let schema = sink
+        .current_schema()
+        .await
+        .expect("current_schema")
+        .expect("table exists");
+    let props = schema
+        .get("properties")
+        .and_then(|p| p.as_object())
+        .expect("properties object");
+    assert_eq!(
+        props.get("id"),
+        Some(&json!({ "type": ["integer", "null"] })),
+        "id BIGINT must surface as a nullable integer; got {schema:?}"
+    );
+    assert!(!props.contains_key("email"), "email must not exist yet");
+
+    // 3. Evolve: add `email: text`, widen `id` integer→number (DOUBLE).
+    let evolution = SchemaEvolution {
+        additions: vec![ColumnChange {
+            name: "email".into(),
+            from: None,
+            to: json!({ "type": "string" }),
+        }],
+        widenings: vec![ColumnChange {
+            name: "id".into(),
+            from: Some(json!({ "type": ["integer", "null"] })),
+            to: json!({ "type": ["number", "null"] }),
+        }],
+        relax_nullability: vec![],
+    };
+    sink.evolve_schema(&evolution).await.expect("evolve_schema");
+
+    // 4. Re-query: email present, id widened to a numeric type.
+    let schema2 = sink
+        .current_schema()
+        .await
+        .expect("current_schema 2")
+        .expect("table still exists");
+    let props2 = schema2
+        .get("properties")
+        .and_then(|p| p.as_object())
+        .expect("properties object");
+    assert_eq!(
+        props2.get("email"),
+        Some(&json!({ "type": ["string", "null"] })),
+        "email must now exist as a nullable string; got {schema2:?}"
+    );
+    assert_eq!(
+        props2.get("id"),
+        Some(&json!({ "type": ["number", "null"] })),
+        "id must have widened to a numeric type (DOUBLE); got {schema2:?}"
+    );
+
+    // 5. Re-run the SAME evolution → idempotent, no error, no duplicate column.
+    sink.evolve_schema(&evolution)
+        .await
+        .expect("re-running the same evolution must be idempotent");
+
+    let schema3 = sink
+        .current_schema()
+        .await
+        .expect("current_schema 3")
+        .expect("table still exists");
+    let props3 = schema3
+        .get("properties")
+        .and_then(|p| p.as_object())
+        .expect("properties object");
+    assert_eq!(
+        props3.len(),
+        2,
+        "exactly two columns must exist (id, email) after a repeated evolution; got {props3:?}"
+    );
+    assert_eq!(
+        props3.get("id"),
+        Some(&json!({ "type": ["number", "null"] })),
+        "id type must be stable after a repeated evolution"
+    );
+    assert_eq!(
+        props3.get("email"),
+        Some(&json!({ "type": ["string", "null"] })),
+        "email must still exist after a repeated evolution"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn current_schema_is_none_for_missing_table() {
+    let (_container, url) = start_mysql().await;
+
+    let sink = MysqlSink::new(
+        MysqlSinkConfig::new(&url, "does_not_exist")
+            .column_mapping(MysqlColumnMapping::AutoMap),
+    )
+    .await
+    .expect("sink new");
+
+    assert_eq!(
+        sink.current_schema().await.expect("current_schema"),
+        None,
+        "a missing table must report no schema"
+    );
+}

--- a/crates/sink/mysql/tests/schema_evolution.rs
+++ b/crates/sink/mysql/tests/schema_evolution.rs
@@ -29,7 +29,10 @@ async fn start_mysql() -> (ContainerAsync<Mysql>, String) {
         .expect("startup semaphore closed");
     let image = Mysql::default();
     let container: ContainerAsync<Mysql> = image.start().await.expect("mysql container start");
-    let port = container.get_host_port_ipv4(3306).await.expect("mysql port");
+    let port = container
+        .get_host_port_ipv4(3306)
+        .await
+        .expect("mysql port");
     let url = format!("mysql://root@127.0.0.1:{port}/test");
     (container, url)
 }
@@ -47,11 +50,10 @@ async fn current_schema_then_evolve_add_and_widen_is_idempotent() {
     pool.close().await;
 
     // 2. Build the sink (AutoMap) and read the live schema.
-    let sink = MysqlSink::new(
-        MysqlSinkConfig::new(&url, "t").column_mapping(MysqlColumnMapping::AutoMap),
-    )
-    .await
-    .expect("sink new");
+    let sink =
+        MysqlSink::new(MysqlSinkConfig::new(&url, "t").column_mapping(MysqlColumnMapping::AutoMap))
+            .await
+            .expect("sink new");
 
     let schema = sink
         .current_schema()
@@ -142,8 +144,7 @@ async fn current_schema_is_none_for_missing_table() {
     let (_container, url) = start_mysql().await;
 
     let sink = MysqlSink::new(
-        MysqlSinkConfig::new(&url, "does_not_exist")
-            .column_mapping(MysqlColumnMapping::AutoMap),
+        MysqlSinkConfig::new(&url, "does_not_exist").column_mapping(MysqlColumnMapping::AutoMap),
     )
     .await
     .expect("sink new");

--- a/crates/sink/postgres/README.md
+++ b/crates/sink/postgres/README.md
@@ -242,6 +242,18 @@ delivery: exactly_once
 
 `delivery: exactly_once` and `write_mode: upsert` compose — the upsert and the commit-token UPSERT commit in the same transaction. See the [exactly-once delivery cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/state.html#exactly-once-delivery).
 
+## Schema evolution
+
+`PostgresSink` reports its live destination schema via `current_schema()` (read from `pg_catalog`, including `attnotnull` so nullability round-trips), so the pipeline-level `schema:` policy can detect drift between an incoming page's top-level shape and the real table. All five `on_drift` modes (`warn` / `ignore` / `quarantine` / `fail` / `evolve`) work against this sink.
+
+Under `on_drift: evolve`, `PostgresSink::evolve_schema()` applies additive DDL in one connection:
+
+- **New columns** → `ALTER TABLE … ADD COLUMN IF NOT EXISTS` (idempotent).
+- **Lossless widenings** (e.g. integer → number) → `ALTER COLUMN … TYPE` — gated on `allow_type_widening`.
+- **Nullability relaxations** (a previously `NOT NULL` column absent from the page) → `ALTER COLUMN … DROP NOT NULL`.
+
+Incompatible changes (narrowing / type swaps) are never auto-applied — they are routed by `on_incompatible` (`fail` or `quarantine`). See the [schema-drift cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/schema-drift.html).
+
 ## Dead-letter queue
 
 The sink overrides `Sink::write_batch_partial`, so when a `dlq:` block is configured the router gets per-row outcomes: good rows commit and only the failing rows (e.g. missing/null key columns under `write_mode: upsert`/`delete`) are wrapped in a DLQ envelope and routed to the DLQ sink — the batch is not aborted. Without a DLQ, a row failure fails the whole batch. See the [DLQ cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/dlq.html).

--- a/crates/sink/postgres/src/sink.rs
+++ b/crates/sink/postgres/src/sink.rs
@@ -553,7 +553,7 @@ impl faucet_core::Sink for PostgresSink {
     ///
     /// Reuses the AutoMap column-discovery query shape (scoped to the exact
     /// relation via `to_regclass`), additionally reading `a.attnotnull` so
-    /// nullability round-trips through [`pg_udt_to_json_schema`].
+    /// nullability round-trips through `pg_udt_to_json_schema`.
     async fn current_schema(&self) -> Result<Option<serde_json::Value>, FaucetError> {
         let table_ref = qualified_table_ref(self.config.schema.as_deref(), &self.config.table_name);
         let rows: Vec<(String, String, bool)> = sqlx::query(

--- a/crates/sink/postgres/src/sink.rs
+++ b/crates/sink/postgres/src/sink.rs
@@ -86,6 +86,68 @@ fn on_conflict_clause(key: &[String], all_cols: &[String]) -> String {
     }
 }
 
+/// Map a [`faucet_core::SqlBaseType`] to the PostgreSQL type keyword used when
+/// adding/widening a column during schema evolution (issue #194). Integers
+/// always widen to `bigint` and floats to `double precision` so a later, wider
+/// value never overflows a narrower column.
+fn pg_keyword(t: faucet_core::SqlBaseType) -> &'static str {
+    use faucet_core::SqlBaseType::*;
+    match t {
+        Integer => "bigint",
+        Double => "double precision",
+        Boolean => "boolean",
+        Text => "text",
+        Json => "jsonb",
+    }
+}
+
+/// `ALTER TABLE <ref> ADD COLUMN IF NOT EXISTS "<col>" <kw>` — idempotent column
+/// addition. `table_ref` is already quoted (`"schema"."table"`).
+fn build_add_column_sql(table_ref: &str, col: &str, t: faucet_core::SqlBaseType) -> String {
+    format!(
+        "ALTER TABLE {table_ref} ADD COLUMN IF NOT EXISTS {} {}",
+        quote_ident(col),
+        pg_keyword(t)
+    )
+}
+
+/// `ALTER TABLE <ref> ALTER COLUMN "<col>" TYPE <kw> USING "<col>"::<kw>` — widen
+/// an existing column's type. Naturally idempotent (re-running the same TYPE
+/// change is a no-op).
+fn build_alter_type_sql(table_ref: &str, col: &str, t: faucet_core::SqlBaseType) -> String {
+    let q = quote_ident(col);
+    let kw = pg_keyword(t);
+    format!("ALTER TABLE {table_ref} ALTER COLUMN {q} TYPE {kw} USING {q}::{kw}")
+}
+
+/// `ALTER TABLE <ref> ALTER COLUMN "<col>" DROP NOT NULL` — relax a NOT NULL
+/// constraint. Naturally idempotent.
+fn build_drop_not_null_sql(table_ref: &str, col: &str) -> String {
+    format!(
+        "ALTER TABLE {table_ref} ALTER COLUMN {} DROP NOT NULL",
+        quote_ident(col)
+    )
+}
+
+/// Map a PostgreSQL type name (`pg_type.typname`, e.g. `int4`, `float8`, `bool`,
+/// `jsonb`) back to a JSON-Schema type fragment so [`PostgresSink::current_schema`]
+/// round-trips with [`faucet_core::diff_schema`]. `nullable` reflects whether the
+/// column allows NULL (`NOT a.attnotnull`).
+fn pg_udt_to_json_schema(udt: &str, nullable: bool) -> serde_json::Value {
+    let base = match udt {
+        "int2" | "int4" | "int8" => "integer",
+        "float4" | "float8" | "numeric" => "number",
+        "bool" => "boolean",
+        "json" | "jsonb" => "object",
+        _ => "string",
+    };
+    if nullable {
+        serde_json::json!({ "type": [base, "null"] })
+    } else {
+        serde_json::json!({ "type": base })
+    }
+}
+
 /// A sink that writes JSON records to a PostgreSQL table.
 pub struct PostgresSink {
     config: PostgresSinkConfig,
@@ -481,6 +543,100 @@ impl faucet_core::Sink for PostgresSink {
         ]
     }
 
+    fn supports_schema_evolution(&self) -> bool {
+        true
+    }
+
+    /// Read the live destination schema from `pg_catalog` as an
+    /// `infer_schema`-shaped object (`{"type":"object","properties":{…}}`), or
+    /// `None` when the target table does not exist yet (issue #194).
+    ///
+    /// Reuses the AutoMap column-discovery query shape (scoped to the exact
+    /// relation via `to_regclass`), additionally reading `a.attnotnull` so
+    /// nullability round-trips through [`pg_udt_to_json_schema`].
+    async fn current_schema(&self) -> Result<Option<serde_json::Value>, FaucetError> {
+        let table_ref = qualified_table_ref(self.config.schema.as_deref(), &self.config.table_name);
+        let rows: Vec<(String, String, bool)> = sqlx::query(
+            "SELECT a.attname::text AS column_name, t.typname::text AS udt_name, a.attnotnull \
+             FROM pg_catalog.pg_attribute a \
+             JOIN pg_catalog.pg_type t ON t.oid = a.atttypid \
+             WHERE a.attrelid = to_regclass($1)::oid \
+               AND a.attnum > 0 AND NOT a.attisdropped \
+             ORDER BY a.attnum",
+        )
+        .bind(&table_ref)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| FaucetError::Sink(format!("postgres current_schema query failed: {e}")))?
+        .iter()
+        .map(|row| {
+            (
+                row.get::<String, _>("column_name"),
+                row.get::<String, _>("udt_name"),
+                row.get::<bool, _>("attnotnull"),
+            )
+        })
+        .collect();
+
+        if rows.is_empty() {
+            return Ok(None); // table does not exist yet
+        }
+
+        let mut props = serde_json::Map::new();
+        for (name, udt, notnull) in rows {
+            props.insert(name, pg_udt_to_json_schema(&udt, !notnull));
+        }
+        Ok(Some(
+            serde_json::json!({ "type": "object", "properties": props }),
+        ))
+    }
+
+    /// Apply an additive schema evolution (new columns, lossless widenings,
+    /// nullability relaxations) to the destination table. Idempotent —
+    /// `ADD COLUMN IF NOT EXISTS`, and re-running the same TYPE / DROP NOT NULL
+    /// is a no-op (issue #194).
+    async fn evolve_schema(
+        &self,
+        evolution: &faucet_core::SchemaEvolution,
+    ) -> Result<(), FaucetError> {
+        let table_ref = qualified_table_ref(self.config.schema.as_deref(), &self.config.table_name);
+        let mut conn = self
+            .pool
+            .acquire()
+            .await
+            .map_err(|e| FaucetError::Sink(format!("postgres evolve acquire failed: {e}")))?;
+
+        for c in &evolution.additions {
+            let t =
+                faucet_core::json_schema_base_type(&c.to).unwrap_or(faucet_core::SqlBaseType::Text);
+            sqlx::query(&build_add_column_sql(&table_ref, &c.name, t))
+                .execute(&mut *conn)
+                .await
+                .map_err(|e| {
+                    FaucetError::Sink(format!("postgres ADD COLUMN {} failed: {e}", c.name))
+                })?;
+        }
+        for c in &evolution.widenings {
+            let t =
+                faucet_core::json_schema_base_type(&c.to).unwrap_or(faucet_core::SqlBaseType::Text);
+            sqlx::query(&build_alter_type_sql(&table_ref, &c.name, t))
+                .execute(&mut *conn)
+                .await
+                .map_err(|e| {
+                    FaucetError::Sink(format!("postgres ALTER TYPE {} failed: {e}", c.name))
+                })?;
+        }
+        for col in &evolution.relax_nullability {
+            sqlx::query(&build_drop_not_null_sql(&table_ref, col))
+                .execute(&mut *conn)
+                .await
+                .map_err(|e| {
+                    FaucetError::Sink(format!("postgres DROP NOT NULL {col} failed: {e}"))
+                })?;
+        }
+        Ok(())
+    }
+
     fn dataset_uri(&self) -> String {
         let table = match &self.config.schema {
             Some(s) => format!("{}.{}", s, self.config.table_name),
@@ -716,8 +872,53 @@ impl faucet_core::Sink for PostgresSink {
 
 #[cfg(test)]
 mod tests {
-    use super::{on_conflict_clause, pg_bind_text, qualified_table_ref};
+    use super::{
+        build_add_column_sql, build_alter_type_sql, build_drop_not_null_sql, on_conflict_clause,
+        pg_bind_text, pg_udt_to_json_schema, qualified_table_ref,
+    };
     use serde_json::json;
+
+    #[test]
+    fn pg_add_column_ddl() {
+        let sql = build_add_column_sql("\"public\".\"t\"", "email", faucet_core::SqlBaseType::Text);
+        assert_eq!(
+            sql,
+            "ALTER TABLE \"public\".\"t\" ADD COLUMN IF NOT EXISTS \"email\" text"
+        );
+    }
+
+    #[test]
+    fn pg_widen_column_ddl() {
+        let sql =
+            build_alter_type_sql("\"public\".\"t\"", "score", faucet_core::SqlBaseType::Double);
+        assert_eq!(
+            sql,
+            "ALTER TABLE \"public\".\"t\" ALTER COLUMN \"score\" TYPE double precision USING \"score\"::double precision"
+        );
+    }
+
+    #[test]
+    fn pg_drop_not_null_ddl() {
+        let sql = build_drop_not_null_sql("\"t\"", "created_at");
+        assert_eq!(
+            sql,
+            "ALTER TABLE \"t\" ALTER COLUMN \"created_at\" DROP NOT NULL"
+        );
+    }
+
+    #[test]
+    fn pg_udt_round_trips_to_json_schema() {
+        assert_eq!(pg_udt_to_json_schema("int8", false), json!({"type":"integer"}));
+        assert_eq!(pg_udt_to_json_schema("float8", false), json!({"type":"number"}));
+        assert_eq!(pg_udt_to_json_schema("bool", false), json!({"type":"boolean"}));
+        assert_eq!(pg_udt_to_json_schema("jsonb", false), json!({"type":"object"}));
+        assert_eq!(pg_udt_to_json_schema("text", false), json!({"type":"string"}));
+        // Unknown types fall back to string; nullable widens the type array.
+        assert_eq!(
+            pg_udt_to_json_schema("timestamptz", true),
+            json!({"type":["string","null"]})
+        );
+    }
 
     #[test]
     fn upsert_on_conflict_clause_for_keys() {

--- a/crates/sink/postgres/src/sink.rs
+++ b/crates/sink/postgres/src/sink.rs
@@ -889,8 +889,11 @@ mod tests {
 
     #[test]
     fn pg_widen_column_ddl() {
-        let sql =
-            build_alter_type_sql("\"public\".\"t\"", "score", faucet_core::SqlBaseType::Double);
+        let sql = build_alter_type_sql(
+            "\"public\".\"t\"",
+            "score",
+            faucet_core::SqlBaseType::Double,
+        );
         assert_eq!(
             sql,
             "ALTER TABLE \"public\".\"t\" ALTER COLUMN \"score\" TYPE double precision USING \"score\"::double precision"
@@ -908,11 +911,26 @@ mod tests {
 
     #[test]
     fn pg_udt_round_trips_to_json_schema() {
-        assert_eq!(pg_udt_to_json_schema("int8", false), json!({"type":"integer"}));
-        assert_eq!(pg_udt_to_json_schema("float8", false), json!({"type":"number"}));
-        assert_eq!(pg_udt_to_json_schema("bool", false), json!({"type":"boolean"}));
-        assert_eq!(pg_udt_to_json_schema("jsonb", false), json!({"type":"object"}));
-        assert_eq!(pg_udt_to_json_schema("text", false), json!({"type":"string"}));
+        assert_eq!(
+            pg_udt_to_json_schema("int8", false),
+            json!({"type":"integer"})
+        );
+        assert_eq!(
+            pg_udt_to_json_schema("float8", false),
+            json!({"type":"number"})
+        );
+        assert_eq!(
+            pg_udt_to_json_schema("bool", false),
+            json!({"type":"boolean"})
+        );
+        assert_eq!(
+            pg_udt_to_json_schema("jsonb", false),
+            json!({"type":"object"})
+        );
+        assert_eq!(
+            pg_udt_to_json_schema("text", false),
+            json!({"type":"string"})
+        );
         // Unknown types fall back to string; nullable widens the type array.
         assert_eq!(
             pg_udt_to_json_schema("timestamptz", true),

--- a/crates/sink/postgres/tests/schema_evolution.rs
+++ b/crates/sink/postgres/tests/schema_evolution.rs
@@ -1,0 +1,143 @@
+//! Integration tests for [`PostgresSink`]'s schema-drift introspection +
+//! evolution path (`current_schema` / `evolve_schema`, issue #194) against a
+//! real Postgres instance via testcontainers.
+//!
+//! These tests require Docker. Each test boots its own container so they are
+//! fully isolated and safe to run in parallel.
+
+use faucet_core::{ColumnChange, SchemaEvolution, Sink};
+use faucet_sink_postgres::{PostgresColumnMapping, PostgresSink, PostgresSinkConfig};
+use serde_json::json;
+use testcontainers::{ContainerAsync, ImageExt, runners::AsyncRunner};
+use testcontainers_modules::postgres::Postgres;
+
+/// Start a Postgres container and return both the container handle and a
+/// connection URL.
+async fn start_postgres() -> (ContainerAsync<Postgres>, String) {
+    let image = Postgres::default().with_tag("16-alpine");
+    let container: ContainerAsync<Postgres> =
+        image.start().await.expect("postgres container start");
+    let port = container
+        .get_host_port_ipv4(5432)
+        .await
+        .expect("postgres port");
+    let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
+    (container, url)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn current_schema_then_evolve_add_and_widen_is_idempotent() {
+    let (_container, url) = start_postgres().await;
+
+    // 1. Create a one-column table: id bigint (int8, NOT NULL is not implied,
+    //    so it is nullable).
+    let pool = sqlx::PgPool::connect(&url).await.expect("pool connect");
+    sqlx::query("CREATE TABLE t (id bigint)")
+        .execute(&pool)
+        .await
+        .expect("create table");
+    pool.close().await;
+
+    // 2. Build the sink (AutoMap) and read the live schema.
+    let sink = PostgresSink::new(
+        PostgresSinkConfig::new(&url, "t").column_mapping(PostgresColumnMapping::AutoMap),
+    )
+    .await
+    .expect("sink new");
+
+    let schema = sink
+        .current_schema()
+        .await
+        .expect("current_schema")
+        .expect("table exists");
+    let props = schema
+        .get("properties")
+        .and_then(|p| p.as_object())
+        .expect("properties object");
+    assert_eq!(
+        props.get("id"),
+        Some(&json!({ "type": ["integer", "null"] })),
+        "id bigint must surface as a nullable integer; got {schema:?}"
+    );
+    assert!(!props.contains_key("email"), "email must not exist yet");
+
+    // 3. Evolve: add `email: text`, widen `id` integer→number.
+    let evolution = SchemaEvolution {
+        additions: vec![ColumnChange {
+            name: "email".into(),
+            from: None,
+            to: json!({ "type": "string" }),
+        }],
+        widenings: vec![ColumnChange {
+            name: "id".into(),
+            from: Some(json!({ "type": ["integer", "null"] })),
+            to: json!({ "type": ["number", "null"] }),
+        }],
+        relax_nullability: vec![],
+    };
+    sink.evolve_schema(&evolution).await.expect("evolve_schema");
+
+    // 4. Re-query: email present, id widened to a numeric type.
+    let schema2 = sink
+        .current_schema()
+        .await
+        .expect("current_schema 2")
+        .expect("table still exists");
+    let props2 = schema2
+        .get("properties")
+        .and_then(|p| p.as_object())
+        .expect("properties object");
+    assert_eq!(
+        props2.get("email"),
+        Some(&json!({ "type": ["string", "null"] })),
+        "email text must now exist as a nullable string; got {schema2:?}"
+    );
+    assert_eq!(
+        props2.get("id"),
+        Some(&json!({ "type": ["number", "null"] })),
+        "id must have widened to a numeric type (double precision); got {schema2:?}"
+    );
+
+    // 5. Re-run the SAME evolution → idempotent, no error.
+    sink.evolve_schema(&evolution)
+        .await
+        .expect("re-running the same evolution must be idempotent");
+
+    let schema3 = sink
+        .current_schema()
+        .await
+        .expect("current_schema 3")
+        .expect("table still exists");
+    let props3 = schema3
+        .get("properties")
+        .and_then(|p| p.as_object())
+        .expect("properties object");
+    assert_eq!(
+        props3.get("id"),
+        Some(&json!({ "type": ["number", "null"] })),
+        "id type must be stable after a repeated evolution"
+    );
+    assert_eq!(
+        props3.get("email"),
+        Some(&json!({ "type": ["string", "null"] })),
+        "email must still exist after a repeated evolution"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn current_schema_is_none_for_missing_table() {
+    let (_container, url) = start_postgres().await;
+
+    let sink = PostgresSink::new(
+        PostgresSinkConfig::new(&url, "does_not_exist")
+            .column_mapping(PostgresColumnMapping::AutoMap),
+    )
+    .await
+    .expect("sink new");
+
+    assert_eq!(
+        sink.current_schema().await.expect("current_schema"),
+        None,
+        "a missing table must report no schema"
+    );
+}

--- a/crates/sink/sqlite/README.md
+++ b/crates/sink/sqlite/README.md
@@ -234,6 +234,18 @@ delivery: exactly_once
 
 See the [Exactly-once delivery cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/state.html#exactly-once-delivery) for full rationale and the supported source/sink set.
 
+## Schema evolution
+
+`SqliteSink` reports its live destination schema via `current_schema()` (read from `PRAGMA table_info`, including the `notnull` flag), so the pipeline-level `schema:` policy can detect drift between an incoming page's top-level shape and the real table. All five `on_drift` modes (`warn` / `ignore` / `quarantine` / `fail` / `evolve`) work against this sink.
+
+Under `on_drift: evolve`, `SqliteSink::evolve_schema()` is **add-column only**, owing to SQLite's limited `ALTER TABLE` and dynamic typing:
+
+- **New columns** → `ALTER TABLE … ADD COLUMN`. SQLite has no `ADD COLUMN IF NOT EXISTS`, so the current columns are read first and any already present is skipped (idempotent by pre-check).
+- **Type widenings are a no-op** — under SQLite's dynamic typing a column already accepts a value of any type, so there is nothing to alter (logged once at `debug`).
+- **Nullability relaxations are a no-op** — SQLite cannot drop a `NOT NULL` constraint in place (it would require a full table rebuild, out of scope here); the column is left as-is (logged once at `debug`).
+
+Incompatible changes (narrowing / type swaps) are never auto-applied — they are routed by `on_incompatible` (`fail` or `quarantine`). See the [schema-drift cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/schema-drift.html).
+
 ## Dead-letter queue
 
 The sink reports per-row outcomes via `write_batch_partial`, so when a `dlq:` block is configured, rows that fail (e.g. a missing/null key column in upsert/delete mode) are wrapped in a DLQ envelope and routed to the configured DLQ sink while the rest of the batch still commits. Without a DLQ, a failing row fails the whole batch. See the [DLQ cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/dlq.html).

--- a/crates/sink/sqlite/src/sink.rs
+++ b/crates/sink/sqlite/src/sink.rs
@@ -2,13 +2,74 @@
 
 use crate::config::{SqliteColumnMapping, SqliteSinkConfig};
 use async_trait::async_trait;
-use faucet_core::FaucetError;
 use faucet_core::util::quote_ident;
+use faucet_core::{FaucetError, SchemaEvolution, SqlBaseType, json_schema_base_type};
 use serde_json::Value;
 use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions};
 use sqlx::{Row, SqlitePool};
 use std::str::FromStr;
 use std::time::Duration;
+
+/// Map a [`SqlBaseType`] to the SQLite column-type keyword used when adding a
+/// column during schema evolution (issue #194). SQLite uses dynamic typing
+/// (type affinity), so these are advisory affinities rather than strict types:
+/// `Boolean` maps to `INTEGER` (SQLite has no native boolean) and `Json` to
+/// `TEXT` (JSON is stored as text).
+fn sqlite_keyword(t: SqlBaseType) -> &'static str {
+    match t {
+        SqlBaseType::Integer => "INTEGER",
+        SqlBaseType::Double => "REAL",
+        SqlBaseType::Boolean => "INTEGER",
+        SqlBaseType::Text => "TEXT",
+        SqlBaseType::Json => "TEXT",
+    }
+}
+
+/// `ALTER TABLE <table> ADD COLUMN "<col>" <kw>` — SQLite has no
+/// `ADD COLUMN IF NOT EXISTS`, so [`SqliteSink::evolve_schema`] only emits this
+/// for columns it has already verified are absent (idempotency by pre-check).
+/// `table` is the unquoted table name; it is quoted here via [`quote_ident`].
+fn build_add_column_sql(table: &str, col: &str, t: SqlBaseType) -> String {
+    format!(
+        "ALTER TABLE {} ADD COLUMN {} {}",
+        quote_ident(table),
+        quote_ident(col),
+        sqlite_keyword(t)
+    )
+}
+
+/// Map a SQLite column affinity string (`PRAGMA table_info.type`, e.g. `INTEGER`,
+/// `REAL`, `VARCHAR(255)`, `TEXT`) to a JSON-Schema type fragment so
+/// [`SqliteSink::current_schema`] round-trips with [`faucet_core::diff_schema`].
+///
+/// SQLite determines affinity by a tolerant, case-insensitive substring match on
+/// the declared type (the rules in <https://www.sqlite.org/datatype3.html>), so
+/// this mirrors that: contains `INT` → integer; `CHAR`/`CLOB`/`TEXT` → string;
+/// `REAL`/`FLOA`/`DOUB` (and the loose `NUMERIC`/`DECIMAL`) → number; everything
+/// else falls back to string. `nullable` reflects `PRAGMA table_info.notnull == 0`.
+fn sqlite_affinity_to_json_schema(declared: &str, nullable: bool) -> serde_json::Value {
+    let up = declared.to_ascii_uppercase();
+    let contains = |needle: &str| up.contains(needle);
+    let base = if contains("INT") {
+        "integer"
+    } else if contains("CHAR") || contains("CLOB") || contains("TEXT") {
+        "string"
+    } else if contains("REAL")
+        || contains("FLOA")
+        || contains("DOUB")
+        || contains("NUMERIC")
+        || contains("DECIMAL")
+    {
+        "number"
+    } else {
+        "string"
+    };
+    if nullable {
+        serde_json::json!({ "type": [base, "null"] })
+    } else {
+        serde_json::json!({ "type": base })
+    }
+}
 
 /// Build the `ON CONFLICT(key) DO UPDATE …` tail for an upsert INSERT.
 /// Non-key columns are SET from `excluded`. If every column is a key column,
@@ -492,6 +553,94 @@ impl faucet_core::Sink for SqliteSink {
         ]
     }
 
+    fn supports_schema_evolution(&self) -> bool {
+        true
+    }
+
+    /// Read the live destination schema via `PRAGMA table_info`, shaped as an
+    /// `infer_schema`-compatible object (`{"type":"object","properties":{…}}`),
+    /// or `None` when the target table does not exist yet (issue #194).
+    ///
+    /// `PRAGMA table_info` returns one row per column with `name`, `type` (the
+    /// declared affinity string), and `notnull`. The affinity string is mapped
+    /// to a JSON-Schema base type via [`sqlite_affinity_to_json_schema`], and
+    /// `notnull == 0` surfaces the column as nullable. The PRAGMA runs on a
+    /// connection acquired from the pool (a standalone read — not inside an open
+    /// transaction).
+    async fn current_schema(&self) -> Result<Option<serde_json::Value>, FaucetError> {
+        let rows = sqlx::query(&format!(
+            "PRAGMA table_info({})",
+            quote_ident(&self.config.table_name)
+        ))
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| FaucetError::Sink(format!("sqlite current_schema query failed: {e}")))?;
+
+        if rows.is_empty() {
+            return Ok(None); // table does not exist yet (or has no columns)
+        }
+
+        let mut props = serde_json::Map::new();
+        for row in &rows {
+            let name: String = row.get("name");
+            let declared: String = row.get("type");
+            let notnull: i64 = row.get("notnull");
+            props.insert(
+                name,
+                sqlite_affinity_to_json_schema(&declared, notnull == 0),
+            );
+        }
+        Ok(Some(
+            serde_json::json!({ "type": "object", "properties": props }),
+        ))
+    }
+
+    /// Apply an additive schema evolution to the destination table (issue #194).
+    ///
+    /// - **Additions** — `ALTER TABLE … ADD COLUMN`. SQLite has no
+    ///   `ADD COLUMN IF NOT EXISTS`, so the current columns are read first and a
+    ///   column already present is silently skipped (idempotency by pre-check).
+    /// - **Widenings** — a no-op under SQLite's dynamic typing: a column already
+    ///   accepts a value of any type, so there is nothing to ALTER. Logged once
+    ///   at `debug`.
+    /// - **Nullability relaxations** — a no-op: SQLite cannot drop a `NOT NULL`
+    ///   constraint in place (it requires a full table rebuild, which is out of
+    ///   scope here). Logged once at `debug`; the column is left as-is.
+    async fn evolve_schema(&self, evolution: &SchemaEvolution) -> Result<(), FaucetError> {
+        // Read the current column set so additions are idempotent (no
+        // `ADD COLUMN IF NOT EXISTS` in SQLite).
+        let existing: std::collections::HashSet<String> = sqlx::query(&format!(
+            "PRAGMA table_info({})",
+            quote_ident(&self.config.table_name)
+        ))
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| FaucetError::Sink(format!("sqlite evolve table_info failed: {e}")))?
+        .iter()
+        .map(|row| row.get::<String, _>("name"))
+        .collect();
+
+        for c in &evolution.additions {
+            if existing.contains(&c.name) {
+                continue; // already present — ADD COLUMN would error
+            }
+            let t = json_schema_base_type(&c.to).unwrap_or(SqlBaseType::Text);
+            sqlx::query(&build_add_column_sql(&self.config.table_name, &c.name, t))
+                .execute(&self.pool)
+                .await
+                .map_err(|e| FaucetError::Sink(format!("sqlite ADD COLUMN {} failed: {e}", c.name)))?;
+        }
+
+        if !evolution.widenings.is_empty() {
+            tracing::debug!("sqlite: type widening is a no-op under dynamic typing");
+        }
+        for col in &evolution.relax_nullability {
+            tracing::debug!("sqlite cannot relax NOT NULL in place; column {col} left as-is");
+        }
+
+        Ok(())
+    }
+
     async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
         if records.is_empty() {
             return Ok(0);
@@ -711,6 +860,88 @@ mod tests {
         assert_eq!(
             clause,
             r#"ON CONFLICT("a", "b") DO UPDATE SET "v" = excluded."v""#
+        );
+    }
+
+    #[test]
+    fn sqlite_add_column_ddl() {
+        assert_eq!(
+            build_add_column_sql("t", "email", SqlBaseType::Text),
+            r#"ALTER TABLE "t" ADD COLUMN "email" TEXT"#
+        );
+        assert_eq!(
+            build_add_column_sql("t", "age", SqlBaseType::Integer),
+            r#"ALTER TABLE "t" ADD COLUMN "age" INTEGER"#
+        );
+        assert_eq!(
+            build_add_column_sql("t", "score", SqlBaseType::Double),
+            r#"ALTER TABLE "t" ADD COLUMN "score" REAL"#
+        );
+        // Boolean has no native SQLite type → INTEGER affinity; JSON → TEXT.
+        assert_eq!(
+            build_add_column_sql("t", "ok", SqlBaseType::Boolean),
+            r#"ALTER TABLE "t" ADD COLUMN "ok" INTEGER"#
+        );
+        assert_eq!(
+            build_add_column_sql("t", "meta", SqlBaseType::Json),
+            r#"ALTER TABLE "t" ADD COLUMN "meta" TEXT"#
+        );
+    }
+
+    #[test]
+    fn sqlite_keyword_mapping() {
+        assert_eq!(sqlite_keyword(SqlBaseType::Integer), "INTEGER");
+        assert_eq!(sqlite_keyword(SqlBaseType::Double), "REAL");
+        assert_eq!(sqlite_keyword(SqlBaseType::Boolean), "INTEGER");
+        assert_eq!(sqlite_keyword(SqlBaseType::Text), "TEXT");
+        assert_eq!(sqlite_keyword(SqlBaseType::Json), "TEXT");
+    }
+
+    #[test]
+    fn sqlite_affinity_round_trips_to_json_schema() {
+        use serde_json::json;
+        // Tolerant case-insensitive substring matching, SQLite affinity rules.
+        assert_eq!(
+            sqlite_affinity_to_json_schema("INTEGER", false),
+            json!({"type":"integer"})
+        );
+        assert_eq!(
+            sqlite_affinity_to_json_schema("BIGINT", false),
+            json!({"type":"integer"})
+        );
+        assert_eq!(
+            sqlite_affinity_to_json_schema("REAL", false),
+            json!({"type":"number"})
+        );
+        assert_eq!(
+            sqlite_affinity_to_json_schema("DOUBLE PRECISION", false),
+            json!({"type":"number"})
+        );
+        assert_eq!(
+            sqlite_affinity_to_json_schema("DECIMAL(10,2)", false),
+            json!({"type":"number"})
+        );
+        assert_eq!(
+            sqlite_affinity_to_json_schema("TEXT", false),
+            json!({"type":"string"})
+        );
+        assert_eq!(
+            sqlite_affinity_to_json_schema("VARCHAR(255)", false),
+            json!({"type":"string"})
+        );
+        // Unknown / empty affinity falls back to string.
+        assert_eq!(
+            sqlite_affinity_to_json_schema("BLOB", false),
+            json!({"type":"string"})
+        );
+        assert_eq!(
+            sqlite_affinity_to_json_schema("", false),
+            json!({"type":"string"})
+        );
+        // Nullable columns widen the type array.
+        assert_eq!(
+            sqlite_affinity_to_json_schema("integer", true),
+            json!({"type":["integer","null"]})
         );
     }
 }

--- a/crates/sink/sqlite/src/sink.rs
+++ b/crates/sink/sqlite/src/sink.rs
@@ -563,7 +563,7 @@ impl faucet_core::Sink for SqliteSink {
     ///
     /// `PRAGMA table_info` returns one row per column with `name`, `type` (the
     /// declared affinity string), and `notnull`. The affinity string is mapped
-    /// to a JSON-Schema base type via [`sqlite_affinity_to_json_schema`], and
+    /// to a JSON-Schema base type via `sqlite_affinity_to_json_schema`, and
     /// `notnull == 0` surfaces the column as nullable. The PRAGMA runs on a
     /// connection acquired from the pool (a standalone read — not inside an open
     /// transaction).

--- a/crates/sink/sqlite/src/sink.rs
+++ b/crates/sink/sqlite/src/sink.rs
@@ -628,7 +628,9 @@ impl faucet_core::Sink for SqliteSink {
             sqlx::query(&build_add_column_sql(&self.config.table_name, &c.name, t))
                 .execute(&self.pool)
                 .await
-                .map_err(|e| FaucetError::Sink(format!("sqlite ADD COLUMN {} failed: {e}", c.name)))?;
+                .map_err(|e| {
+                    FaucetError::Sink(format!("sqlite ADD COLUMN {} failed: {e}", c.name))
+                })?;
         }
 
         if !evolution.widenings.is_empty() {

--- a/crates/sink/sqlite/tests/schema_evolution.rs
+++ b/crates/sink/sqlite/tests/schema_evolution.rs
@@ -1,0 +1,166 @@
+//! Integration tests for the SQLite sink's schema-drift introspection +
+//! evolution path (`current_schema` / `evolve_schema`, issue #194).
+//!
+//! All tests run fully in-process against a tempfile-backed SQLite database —
+//! no Docker required. (`:memory:` is per-connection in SQLite, so a tempfile
+//! lets the test's own pool and the sink's pool see the same database.)
+
+use faucet_core::{ColumnChange, SchemaEvolution, Sink};
+use faucet_sink_sqlite::{SqliteColumnMapping, SqliteSink, SqliteSinkConfig};
+use serde_json::json;
+use sqlx::Row;
+use sqlx::sqlite::SqlitePoolOptions;
+use tempfile::TempDir;
+
+/// Create a fresh tempfile SQLite DB with the given CREATE TABLE SQL.
+/// Returns `(TempDir, url)` — keep `TempDir` alive for the test duration.
+async fn fresh_db(create_sql: &str) -> (TempDir, String) {
+    let dir = TempDir::new().expect("tempdir");
+    let path = dir.path().join("test.db");
+    let url = format!("sqlite://{}?mode=rwc", path.display());
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect(&url)
+        .await
+        .expect("connect");
+    sqlx::query(create_sql)
+        .execute(&pool)
+        .await
+        .expect("create table");
+    pool.close().await;
+    (dir, url)
+}
+
+/// Column names currently declared on the table, via `PRAGMA table_info`.
+async fn column_names(url: &str, table: &str) -> Vec<String> {
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect(url)
+        .await
+        .expect("connect");
+    let rows = sqlx::query(&format!("PRAGMA table_info(\"{table}\")"))
+        .fetch_all(&pool)
+        .await
+        .expect("pragma");
+    pool.close().await;
+    rows.iter().map(|r| r.get::<String, _>("name")).collect()
+}
+
+fn auto_map_config(url: &str, table: &str) -> SqliteSinkConfig {
+    SqliteSinkConfig::new(url, table).column_mapping(SqliteColumnMapping::AutoMap)
+}
+
+#[tokio::test]
+async fn current_schema_then_evolve_add_is_idempotent() {
+    let (_dir, url) = fresh_db("CREATE TABLE t (id INTEGER)").await;
+
+    let sink = SqliteSink::new(auto_map_config(&url, "t"))
+        .await
+        .expect("sink new");
+
+    // 1. Read the live schema: id integer (nullable — no NOT NULL on it).
+    let schema = sink
+        .current_schema()
+        .await
+        .expect("current_schema")
+        .expect("table exists");
+    let props = schema
+        .get("properties")
+        .and_then(|p| p.as_object())
+        .expect("properties object");
+    assert_eq!(
+        props.get("id"),
+        Some(&json!({ "type": ["integer", "null"] })),
+        "id INTEGER must surface as a nullable integer; got {schema:?}"
+    );
+    assert!(!props.contains_key("email"), "email must not exist yet");
+
+    // 2. Evolve: add `email: text`.
+    let evolution = SchemaEvolution {
+        additions: vec![ColumnChange {
+            name: "email".into(),
+            from: None,
+            to: json!({ "type": "string" }),
+        }],
+        widenings: vec![],
+        relax_nullability: vec![],
+    };
+    sink.evolve_schema(&evolution).await.expect("evolve_schema");
+
+    // 3. Re-query: email now present as a nullable string.
+    let schema2 = sink
+        .current_schema()
+        .await
+        .expect("current_schema 2")
+        .expect("table still exists");
+    let props2 = schema2
+        .get("properties")
+        .and_then(|p| p.as_object())
+        .expect("properties object");
+    assert_eq!(
+        props2.get("email"),
+        Some(&json!({ "type": ["string", "null"] })),
+        "email TEXT must now exist as a nullable string; got {schema2:?}"
+    );
+    assert_eq!(
+        column_names(&url, "t").await,
+        vec!["id".to_string(), "email".to_string()]
+    );
+
+    // 4. Re-run the SAME evolution → idempotent (SQLite has no
+    //    ADD COLUMN IF NOT EXISTS, so this exercises the pre-check skip).
+    sink.evolve_schema(&evolution)
+        .await
+        .expect("re-running the same evolution must be idempotent");
+    assert_eq!(
+        column_names(&url, "t").await,
+        vec!["id".to_string(), "email".to_string()],
+        "re-running the evolution must not add a duplicate column or error"
+    );
+}
+
+#[tokio::test]
+async fn evolve_widen_and_relax_nullability_are_no_ops() {
+    let (_dir, url) = fresh_db("CREATE TABLE t (id INTEGER, name TEXT NOT NULL)").await;
+
+    let sink = SqliteSink::new(auto_map_config(&url, "t"))
+        .await
+        .expect("sink new");
+
+    // A widening + a nullability relaxation: both are no-ops under SQLite's
+    // dynamic typing / in-place-NOT-NULL limitation. They must not error and
+    // must not change the column set.
+    let evolution = SchemaEvolution {
+        additions: vec![],
+        widenings: vec![ColumnChange {
+            name: "id".into(),
+            from: Some(json!({ "type": ["integer", "null"] })),
+            to: json!({ "type": ["number", "null"] }),
+        }],
+        relax_nullability: vec!["name".into()],
+    };
+    sink.evolve_schema(&evolution)
+        .await
+        .expect("widen/relax no-ops must succeed");
+
+    assert_eq!(
+        column_names(&url, "t").await,
+        vec!["id".to_string(), "name".to_string()],
+        "no-op evolution must leave the column set unchanged"
+    );
+}
+
+#[tokio::test]
+async fn current_schema_is_none_for_missing_table() {
+    let (_dir, url) = fresh_db("CREATE TABLE other (id INTEGER)").await;
+
+    let sink = SqliteSink::new(auto_map_config(&url, "does_not_exist"))
+        .await
+        .expect("sink new");
+
+    assert_eq!(
+        sink.current_schema().await.expect("current_schema"),
+        None,
+        "a missing table must report no schema"
+    );
+}

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -21,6 +21,7 @@
 - [Authentication](./cookbook/auth.md)
 - [Incremental replication & state](./cookbook/state.md)
 - [Upsert / mirror tables](./cookbook/upsert.md)
+- [Schema drift](./cookbook/schema-drift.md)
 - [Replication (snapshot → CDC)](./cookbook/replication.md)
 - [Dead-letter queues](./cookbook/dlq.md)
 - [Resilience (retry / circuit breaker / poison-pill)](./cookbook/resilience.md)

--- a/docs/book/src/cookbook/schema-drift.md
+++ b/docs/book/src/cookbook/schema-drift.md
@@ -1,0 +1,214 @@
+# Schema drift
+
+Source schemas change. A team adds a column to a table, an API starts returning
+a new field, an `integer` becomes a `bigint`. In a naive ELT pipeline those
+changes break the destination write — a new field has no column to land in, a
+widened type overflows — and the pipeline either errors out or silently drops
+data. faucet's `schema:` block turns that into one declarative policy: detect
+when an incoming page's shape diverges from the sink's live destination schema
+and apply a single, uniform action across every sink.
+
+## The `schema:` block
+
+`schema:` is a pipeline-level block (a sibling of `source`, `sink`,
+`transforms`, and `state`). It is fully opt-in — with no block, sinks keep their
+existing per-connector behaviour.
+
+```yaml
+pipeline:
+  schema:
+    on_drift: warn            # warn | evolve | ignore | quarantine | fail
+    allow_type_widening: true # default true; only consulted by `evolve`
+    on_incompatible: fail     # fail | quarantine — `evolve` only (default fail)
+  source: { ... }
+  sink: { ... }
+```
+
+| Field | Default | Purpose |
+|-------|---------|---------|
+| `on_drift` | `warn` | The policy applied when drift is detected. |
+| `allow_type_widening` | `true` | Whether a lossless type widening (e.g. `integer → number`, or gaining nullability) counts as evolvable rather than incompatible. Only consulted by `evolve`. |
+| `on_incompatible` | `fail` | `evolve` only — what to do with a residue that cannot be auto-applied (a narrowing / incompatible type swap): `fail` aborts, `quarantine` routes the offending rows to the DLQ. |
+
+### How detection works
+
+On each page, faucet infers the page's top-level shape and diffs it against the
+sink's **live** destination schema (read once per run, refreshed after an
+`evolve`). The diff is **top-level only**: a nested object counts as one column,
+so a change *inside* a nested object is invisible. Each top-level column is
+bucketed as an **addition** (in the page, not in the destination), a **widening**
+(an existing column whose type widened losslessly), an **incompatible** change (a
+narrowing or unrelated type swap), or a **droppable-required** column (a NOT NULL
+destination column the page never provides).
+
+## The five modes
+
+### `warn` (default)
+
+Detect, emit a metric and a one-shot log line, and write the page **unchanged**.
+The safest default — nothing about the destination or the data changes; you just
+get visibility that drift is happening.
+
+```yaml
+schema:
+  on_drift: warn
+```
+
+### `ignore`
+
+Drop every field that is not present in the destination schema, then write the
+trimmed records. Use this when the destination is the source of truth and new
+upstream fields should simply be discarded.
+
+```yaml
+schema:
+  on_drift: ignore
+```
+
+### `fail`
+
+Raise a `SchemaDrift` error and abort the run the moment drift is detected. Use
+this when any divergence is a real incident that a human must look at before more
+data flows.
+
+```yaml
+schema:
+  on_drift: fail
+```
+
+### `quarantine`
+
+Route the records that exhibit the drift to the [dead-letter
+queue](./dlq.md) and write the rest of the page normally. Requires a `dlq:`
+block. Quarantined rows carry a `schema_drift` reason in their DLQ envelope.
+
+```yaml
+schema:
+  on_drift: quarantine
+pipeline:
+  # ...
+  dlq:
+    sink: { type: jsonl, config: { path: ./drift.jsonl } }
+    on_batch_error: dlq_all
+```
+
+### `evolve`
+
+Apply additive/widening DDL to the destination — `ADD COLUMN` for additions,
+type widening for widenings, NOT NULL relaxation for droppable-required columns —
+then write the page through. Any incompatible residue is handled by
+`on_incompatible`. This is the mode that keeps a mirror in lockstep with a
+changing source without manual `ALTER TABLE`s.
+
+```yaml
+schema:
+  on_drift: evolve
+  allow_type_widening: true
+  on_incompatible: fail
+```
+
+## Sink support
+
+Not every sink can evolve, and a schemaless sink has no schema to diverge from.
+
+| Sink | Detection (`warn`/`ignore`/`fail`/`quarantine`) | `evolve` |
+|------|:---:|:---:|
+| `postgres`, `mysql`, `mssql`, `sqlite` | ✅ | ✅ |
+| `bigquery` | ✅ | ✅ |
+| `elasticsearch` | ✅ | ✅ (add fields only) |
+| `iceberg` | ✅ | ❌ detect-only |
+| `jsonl`, `csv`, `stdout`, `mongodb`, `redis`, `http`, `kafka`, `s3`, `gcs`, `snowflake`, `parquet` | — (inert) | — |
+
+- **Evolvable** (six sinks): postgres, mysql, mssql, sqlite, bigquery,
+  elasticsearch. They implement in-place additive DDL.
+- **Iceberg** reports its current schema so detection modes work, but **cannot
+  `evolve`** — schema evolution is blocked on upstream `iceberg-rust 0.9.1`
+  (issue #255). `on_drift: evolve` against iceberg is rejected at config-load
+  time with a "blocked on upstream" message.
+- **Schemaless sinks** report no destination schema, so *any* `schema:` policy is
+  **inert** against them (a one-shot log notes this). `on_drift: evolve` against
+  a schemaless sink is rejected at config-load (there is nothing to evolve).
+
+### Per-sink `evolve` nuances
+
+- **SQLite** — widening and NOT NULL relaxation are no-ops because SQLite is
+  dynamically typed; only `ADD COLUMN` does real work.
+- **MySQL / MSSQL** — relaxing a NOT NULL column re-emits the column at its
+  (lossless) widened base type to drop the constraint.
+- **Elasticsearch** — can only **add** fields. Changing the type of an existing
+  field is impossible in Elasticsearch mappings, so an existing-field type change
+  is always treated as incompatible (routed by `on_incompatible`).
+
+## Composition rules
+
+- **`quarantine` requires a `dlq:` block** (`on_drift: quarantine`, or `evolve`
+  with `on_incompatible: quarantine`). Validated at config-load.
+- **`quarantine` is incompatible with `delivery: exactly_once`** — exactly-once
+  forbids a DLQ, so a quarantine policy cannot run alongside it.
+- **`evolve` / `ignore` / `fail` / `warn` compose with everything** — including
+  [`delivery: exactly_once`](./state.md#exactly-once-delivery) and
+  [`write_mode: upsert`](./upsert.md). Under `evolve` + exactly-once the additive
+  DDL runs first, then the records and the commit token land in one transaction.
+
+## Worked example: CDC mirror that evolves with the source
+
+The shipped example
+[`cli/examples/postgres_cdc_to_postgres_evolve.yaml`](https://github.com/PawanSikawat/faucet-stream/blob/main/cli/examples/postgres_cdc_to_postgres_evolve.yaml)
+mirrors a Postgres table via CDC and evolves the destination as the source
+schema changes — exactly-once, upsert, drift-aware:
+
+```yaml
+version: 1
+name: pg_cdc_mirror_evolve
+delivery: exactly_once
+
+pipeline:
+  schema:
+    on_drift: evolve
+    allow_type_widening: true
+    on_incompatible: fail
+
+  source:
+    type: postgres-cdc
+    config:
+      connection_url: ${env:SOURCE_PG_URL}
+      slot_name: faucet_mirror_evolve
+      publication_name: faucet_pub
+      create_slot_if_missing: true
+      idle_timeout: 30
+
+  transforms:
+    - type: cdc_unwrap
+
+  sink:
+    type: postgres
+    config:
+      connection_url: ${env:DEST_PG_URL}
+      table_name: users_mirror
+      column_mapping: auto_map
+      write_mode: upsert
+      key: [id]
+      delete_marker: { field: __op, values: [d] }
+
+  state:
+    type: file
+    config:
+      path: ./state
+```
+
+`ALTER TABLE users ADD COLUMN email text;` on the source, then INSERT a row with
+`email` set — faucet adds `email` to `users_mirror` on the next fetch cycle and
+writes the row. Validate it offline (no database connection required):
+
+```bash
+faucet validate cli/examples/postgres_cdc_to_postgres_evolve.yaml
+```
+
+## Metric
+
+Every detected drift increments
+`faucet_schema_drift_total{pipeline,row,connector,mode,kind}`, where `mode` is
+the `on_drift` policy (`warn` / `ignore` / `quarantine` / `fail` / `evolve`) and
+`kind` is the drift bucket (`added` / `widened` / `narrowed` / `dropped`). Alert
+on it (or just chart it) to see drift before it surprises you — even under
+`warn`, where nothing else changes.

--- a/docs/book/src/reference/config.md
+++ b/docs/book/src/reference/config.md
@@ -284,6 +284,52 @@ All four conditions are validated at config-load time (`faucet validate` and `fa
 
 See the [Exactly-once delivery cookbook](../cookbook/state.md#exactly-once-delivery) for a worked example and the full rationale.
 
+## `schema`
+
+Optional **pipeline-level** block (a sibling of `source` / `sink` / `transforms`
+/ `state` inside `pipeline:`) that declares one uniform policy for **schema
+drift** — when an incoming page's top-level shape diverges from the sink's live
+destination schema. Fully opt-in: with no block, sinks keep their existing
+per-connector behaviour. See the [Schema drift cookbook](../cookbook/schema-drift.md)
+for the full model, sink-support matrix, and per-sink nuances.
+
+```yaml
+pipeline:
+  schema:
+    on_drift: warn            # warn | evolve | ignore | quarantine | fail
+    allow_type_widening: true # default true; only consulted by `evolve`
+    on_incompatible: fail     # fail | quarantine — `evolve` only (default fail)
+  source: { ... }
+  sink: { ... }
+```
+
+| Field | Default | Purpose |
+|-------|---------|---------|
+| `on_drift` | `warn` | Policy applied when drift is detected: `warn` (metric + log, write unchanged), `ignore` (drop unknown fields), `fail` (abort with a `SchemaDrift` error), `quarantine` (route drift-exhibiting rows to the DLQ, write the rest), `evolve` (apply additive/widening DDL, then write). |
+| `allow_type_widening` | `true` | Whether a lossless widening (`integer → number`, gaining nullability) counts as evolvable rather than incompatible. Only consulted by `evolve`. |
+| `on_incompatible` | `fail` | `evolve` only — action for an incompatible residue (narrowing / type swap): `fail` aborts, `quarantine` routes the offending rows to the DLQ. |
+
+Detection is **top-level only** — a nested object is one column, so changes
+inside it are invisible.
+
+### Gates (validated at config-load time)
+
+A violation is a hard `config error` naming the offending row; no run is started.
+
+1. **`evolve` needs an evolution-capable sink** — one of `postgres`, `mysql`,
+   `mssql`, `sqlite`, `bigquery`, `elasticsearch`. `iceberg` supports detection
+   but not `evolve` (blocked on upstream `iceberg-rust`, #255); schemaless sinks
+   have nothing to evolve. Both are rejected for `on_drift: evolve`.
+2. **`quarantine` needs a `dlq:` block** — `on_drift: quarantine`, or `evolve`
+   with `on_incompatible: quarantine`.
+3. **`quarantine` is incompatible with `delivery: exactly_once`** (exactly-once
+   forbids a DLQ). `evolve` / `ignore` / `fail` / `warn` all compose with
+   exactly-once and with `write_mode: upsert`.
+
+Against a **schemaless** sink (jsonl, csv, stdout, mongodb, redis, http, kafka,
+s3, gcs, snowflake, parquet) any non-`evolve` policy is inert — the sink reports
+no schema to diverge from.
+
 ## `execution`
 
 - `max_concurrent` — one shared concurrency budget across roots and child

--- a/docs/book/src/reference/connectors.md
+++ b/docs/book/src/reference/connectors.md
@@ -93,6 +93,24 @@ schemaless sinks (MongoDB, Elasticsearch) map `key` to a match filter / `_id`.
 Iceberg upsert is not yet supported (a follow-up, blocked on `iceberg-rust`). See
 [Upsert / mirror tables](../cookbook/upsert.md).
 
+## Schema evolution
+
+The pipeline-level [`schema:`](../cookbook/schema-drift.md) block detects when an
+incoming page's top-level shape diverges from the sink's destination schema and
+applies one policy (`warn` / `ignore` / `fail` / `quarantine` / `evolve`). Which
+sinks can actually *act* on it varies:
+
+| Sink | Schema evolution |
+|------|------------------|
+| `postgres`, `mysql`, `mssql`, `sqlite`, `bigquery` | **✓ evolve** — in-place additive/widening DDL |
+| `elasticsearch` | **✓ evolve** — can add fields only (existing-field type change is incompatible) |
+| `iceberg` | detect-only — `warn`/`ignore`/`fail`/`quarantine` work; `evolve` blocked on upstream `iceberg-rust` (#255) |
+| `jsonl`, `csv`, `stdout`, `mongodb`, `redis`, `http`, `kafka`, `s3`, `gcs`, `snowflake`, `parquet` | — (schemaless; the `schema:` policy is inert) |
+
+`on_drift: evolve` against a detect-only or schemaless sink is rejected at
+config-load. See [Schema drift](../cookbook/schema-drift.md) for the per-sink
+nuances (e.g. SQLite widening is a no-op; Elasticsearch can only add fields).
+
 ## Authentication at a glance
 
 | Family | Auth options |


### PR DESCRIPTION
## Summary

Adds a first-class, opt-in **schema-drift handling policy** (#194). A pipeline-level `schema:` block declares one action for when an incoming page's top-level shape diverges from the sink's live destination schema, instead of each sink's ad-hoc behavior:

```yaml
pipeline:
  schema:
    on_drift: warn        # warn | evolve | ignore | quarantine | fail   (default: warn)
    allow_type_widening: true
    on_incompatible: fail   # fail | quarantine  (evolve only)
```

- **warn** — detect, emit `faucet_schema_drift_total` + a one-shot log, write unchanged.
- **evolve** — apply additive/widening DDL to the destination, then write.
- **ignore** — drop unknown (non-destination) fields, write the rest.
- **quarantine** — route the drift-exhibiting rows to the DLQ, write the rest.
- **fail** — abort with `FaucetError::SchemaDrift`.

Detection diffs each page's inferred shape (`infer_schema`) against the sink-reported live schema (`Sink::current_schema`), cached per run and refreshed after an evolve. **Top-level columns only** (a nested object is one column).

## Sink support

| Capability | Sinks |
|---|---|
| Detect + **evolve** | postgres, mysql, mssql, sqlite, bigquery, elasticsearch* |
| Detect only (read schema; evolve blocked) | iceberg — no evolution API in iceberg-rust 0.9.1 (tracked in #255) |
| Inert (no schema reported) | jsonl, csv, stdout, mongodb, redis, http, kafka, s3, gcs, snowflake, parquet |

\* elasticsearch can only *add* fields; an existing-field type change is `incompatible`. sqlite widening / NOT-NULL-relax are no-ops under dynamic typing. mysql/mssql null-relaxation re-emits the column at its (lossless) widened base type.

## Composition & gates (config-load)

- `on_drift: evolve` against a non-evolvable sink → fails fast (incl. iceberg).
- `quarantine` requires a `dlq:` block and is incompatible with `delivery: exactly_once`.
- `evolve`/`ignore`/`fail`/`warn` compose with exactly-once **and** `write_mode: upsert`.
- No `schema:` block → behavior byte-for-byte unchanged.

## Notable fix surfaced during development

An end-to-end seam test caught a **pre-existing** bug: `InstrumentedSink` (which wraps every sink in `Pipeline::run`) did **not** forward the sink *capability* methods, so they fell through to the disabling trait defaults. This silently made schema-drift inert in real runs — and the same gap affected `supports_idempotent_writes`/`write_batch_idempotent`/`last_committed_token` (exactly-once) and `supported_write_modes`. The wrapper now delegates all of them, with regression tests at the core (`instrumented_sink_forwards_capability_methods_to_inner`) and CLI (`run_schema_drift_fail_fires_through_a_schema_reporting_sink`, csv→sqlite) levels.

## Tests / docs

- Pure `diff_schema` truth-table; per-sink unit (DDL/type round-trip) + integration tests (testcontainers / wiremock / in-process); pipeline tests for all 5 modes incl. quarantine→DLQ; CLI gate + end-to-end tests.
- Cookbook (`docs/book/src/cookbook/schema-drift.md`), config reference, capability matrix, per-sink READMEs, `cli/examples/postgres_cdc_to_postgres_evolve.yaml`.

Closes #194. Iceberg schema evolution follow-up: #255.
