### PR TITLE
feat(observability): OpenTelemetry (OTLP) trace + metric export (#201)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,6 +267,7 @@ jobs:
           - "full"
           - "source-rest,sink-jsonl,sink-stdout,transforms"
           - "observability,source-rest,sink-jsonl,sink-stdout,transforms"
+          - "otel,source-rest,sink-jsonl,sink-stdout,transforms"
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3277,8 +3277,12 @@ dependencies = [
  "jsonpath-rust",
  "jsonschema",
  "metrics",
+ "metrics-exporter-opentelemetry",
  "metrics-exporter-prometheus",
  "metrics-util",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "regex",
  "reqwest 0.13.3",
  "schemars 1.2.1",
@@ -3289,7 +3293,9 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
+ "url",
  "uuid",
  "zstd",
 ]
@@ -6263,6 +6269,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics-exporter-opentelemetry"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "500e1fa58894a8c140ee0a9282e1d9e765fc7c7853bd310d1357d2808ad8f0b0"
+dependencies = [
+ "derive_more",
+ "metrics",
+ "opentelemetry",
+ "opentelemetry_sdk",
+]
+
+[[package]]
 name = "metrics-exporter-prometheus"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6942,6 +6960,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry-http"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 1.4.0",
+ "opentelemetry",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+dependencies = [
+ "http 1.4.0",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost 0.14.3",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic 0.14.6",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost 0.14.3",
+ "tonic 0.14.6",
+ "tonic-prost",
+]
+
+[[package]]
 name = "opentelemetry-semantic-conventions"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6960,6 +7020,8 @@ dependencies = [
  "percent-encoding",
  "rand 0.9.4",
  "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -10436,8 +10498,10 @@ checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
 dependencies = [
  "js-sys",
  "opentelemetry",
+ "smallvec",
  "tracing",
  "tracing-core",
+ "tracing-log",
  "tracing-subscriber",
  "web-time",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3267,6 +3267,7 @@ dependencies = [
  "async-compression",
  "async-stream",
  "async-trait",
+ "axum",
  "chrono",
  "criterion",
  "dotenvy",
@@ -6969,6 +6970,7 @@ dependencies = [
  "bytes",
  "http 1.4.0",
  "opentelemetry",
+ "reqwest 0.12.28",
 ]
 
 [[package]]
@@ -6983,6 +6985,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost 0.14.3",
+ "reqwest 0.12.28",
  "thiserror 2.0.18",
  "tokio",
  "tonic 0.14.6",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,6 +202,16 @@ lru = "0.18"
 metrics = "0.24"
 metrics-exporter-prometheus = { version = "0.18", default-features = false, features = ["http-listener"] }
 metrics-util = "0.20"
+# OpenTelemetry (OTLP) export — issue #201. PINNED TO THE 0.31 LINE: the metrics
+# bridge `metrics-exporter-opentelemetry` 0.2.1 requires `opentelemetry`/`opentelemetry_sdk`
+# ^0.31, so the whole stack is locked to 0.31 (tracing-opentelemetry 0.32.1 is the
+# 0.31-compatible release — 0.33 targets opentelemetry 0.32). Before bumping any of
+# these, confirm metrics-exporter-opentelemetry supports the newer line first.
+opentelemetry = "0.31"
+opentelemetry_sdk = { version = "0.31", features = ["rt-tokio"] }
+opentelemetry-otlp = { version = "0.31", default-features = false, features = ["trace", "metrics", "grpc-tonic", "http-proto"] }
+tracing-opentelemetry = "0.32.1"
+metrics-exporter-opentelemetry = "0.2.1"
 bytes = "1"
 url = "2"
 percent-encoding = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -209,7 +209,7 @@ metrics-util = "0.20"
 # these, confirm metrics-exporter-opentelemetry supports the newer line first.
 opentelemetry = "0.31"
 opentelemetry_sdk = { version = "0.31", features = ["rt-tokio"] }
-opentelemetry-otlp = { version = "0.31", default-features = false, features = ["trace", "metrics", "grpc-tonic", "http-proto"] }
+opentelemetry-otlp = { version = "0.31", default-features = false, features = ["trace", "metrics", "grpc-tonic", "http-proto", "reqwest-blocking-client"] }
 tracing-opentelemetry = "0.32.1"
 metrics-exporter-opentelemetry = "0.2.1"
 bytes = "1"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -26,7 +26,7 @@ default = ["observability", "source", "sink", "state", "transforms", "compressio
 
 # Everything the default build ships, plus the long-running runtime modes:
 # `schedule` (cron scheduler) and `serve` (HTTP control plane).
-full = ["default", "schedule", "serve", "serve-ui", "serve-history-postgres", "serve-history-sqlite", "lineage", "lineage-kafka", "transform-sql", "triggers", "triggers-object-store", "triggers-redis", "triggers-kafka"]
+full = ["default", "otel", "schedule", "serve", "serve-ui", "serve-history-postgres", "serve-history-sqlite", "lineage", "lineage-kafka", "transform-sql", "triggers", "triggers-object-store", "triggers-redis", "triggers-kafka"]
 
 # Data-quality checks (`quality:` config block). `quality-jsonschema` adds the
 # `json_schema` record check via a JSON Schema validator. Forwarded to
@@ -186,6 +186,9 @@ observability = [
     "dep:metrics-exporter-prometheus",
     "dep:tracing-subscriber",
 ]
+
+# OTLP (OpenTelemetry) export of traces + metrics (#201). Forwards to faucet-core.
+otel = ["observability", "faucet-core/otel"]
 
 # Built-in cron scheduler (`faucet schedule` + the `schedule:` config block).
 # Pulls a cron parser + IANA timezone db; opt out of it for slim builds.

--- a/cli/src/commands/replicate.rs
+++ b/cli/src/commands/replicate.rs
@@ -58,6 +58,9 @@ pub async fn run(args: ReplicateArgs) -> CliResult<()> {
     )
     .await?;
 
+    // Flush any buffered OTLP telemetry before exiting (no-op without `otel`).
+    faucet_core::shutdown_otel();
+
     println!("replication finished");
     Ok(())
 }

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -136,6 +136,10 @@ pub async fn run(args: RunArgs) -> CliResult<()> {
         if total_written == 1 { "" } else { "s" }
     );
 
+    // Flush any buffered OTLP telemetry before the process exits (no-op without
+    // the `otel` feature). Done on both the success and failure exit paths.
+    faucet_core::shutdown_otel();
+
     if summary.had_failures() {
         return Err(CliError::PipelineHadFailures { count: failed });
     }

--- a/cli/src/commands/schedule.rs
+++ b/cli/src/commands/schedule.rs
@@ -465,6 +465,9 @@ async fn run_loop(
             _ = shutdown.recv() => {
                 tracing::info!(pipeline = %pipeline_name, "shutdown signal received; draining in-flight run");
                 graceful_shutdown(running.take(), compiled.shutdown_grace, &pipeline_name).await;
+                // Flush any buffered OTLP telemetry after the final run drains
+                // (no-op without the `otel` feature).
+                faucet_core::shutdown_otel();
                 return Ok(());
             }
 

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -748,10 +748,10 @@ impl PipelineConfig {
             });
         }
         crate::interpolate::resolve_config_refs(&mut cfg)?;
-        if let Some(obs) = cfg.observability.as_ref() {
-            if let Some(otel) = obs.otel.as_ref() {
-                otel.to_core().map_err(CliError::Config)?;
-            }
+        if let Some(obs) = cfg.observability.as_ref()
+            && let Some(otel) = obs.otel.as_ref()
+        {
+            otel.to_core().map_err(CliError::Config)?;
         }
         Ok(cfg)
     }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -382,7 +382,10 @@ fn default_otel_ratio() -> f64 {
     1.0
 }
 fn default_otel_export() -> Vec<faucet_core::OtelSignal> {
-    vec![faucet_core::OtelSignal::Traces, faucet_core::OtelSignal::Metrics]
+    vec![
+        faucet_core::OtelSignal::Traces,
+        faucet_core::OtelSignal::Metrics,
+    ]
 }
 fn default_otel_service() -> String {
     "faucet".to_string()

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -321,6 +321,10 @@ pub struct ObservabilitySpec {
     /// Tracing / logging configuration.
     #[serde(default)]
     pub tracing: Option<TracingSpec>,
+
+    /// OTLP (OpenTelemetry) export configuration (#201).
+    #[serde(default)]
+    pub otel: Option<OtelSpec>,
 }
 
 /// Configuration for the Prometheus metrics HTTP endpoint.
@@ -342,6 +346,70 @@ pub struct TracingSpec {
     /// `"faucet=trace"`). Defaults to the value of `RUST_LOG` when `None`.
     #[serde(default)]
     pub level: Option<String>,
+}
+
+/// OTLP export block under `observability.otel:`.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct OtelSpec {
+    /// Collector endpoint URL. When empty, defaults to the protocol-specific
+    /// localhost address (`http://localhost:4317` for gRPC, `:4318` for HTTP).
+    #[serde(default)]
+    pub endpoint: String,
+    /// OTLP transport protocol (`grpc` or `http`). Default: `grpc`.
+    #[serde(default)]
+    pub protocol: faucet_core::OtelProtocol,
+    /// Extra headers sent on every export request (e.g. backend auth tokens).
+    #[serde(default)]
+    pub headers: std::collections::HashMap<String, String>,
+    /// Head-based trace sampling ratio, 0.0..=1.0. Default: 1.0 (sample all).
+    #[serde(default = "default_otel_ratio")]
+    pub sample_ratio: f64,
+    /// Which signals to export. Default: `[traces, metrics]`.
+    #[serde(default = "default_otel_export")]
+    pub export: Vec<faucet_core::OtelSignal>,
+    /// OTel resource `service.name`. Default: `"faucet"`.
+    #[serde(default = "default_otel_service")]
+    pub service_name: String,
+    /// Per-export timeout in seconds. Default: 10.
+    #[serde(default = "default_otel_timeout")]
+    pub timeout_secs: u64,
+    /// Metric push interval in seconds. Default: 60.
+    #[serde(default = "default_otel_interval")]
+    pub metric_interval_secs: u64,
+}
+
+fn default_otel_ratio() -> f64 {
+    1.0
+}
+fn default_otel_export() -> Vec<faucet_core::OtelSignal> {
+    vec![faucet_core::OtelSignal::Traces, faucet_core::OtelSignal::Metrics]
+}
+fn default_otel_service() -> String {
+    "faucet".to_string()
+}
+fn default_otel_timeout() -> u64 {
+    10
+}
+fn default_otel_interval() -> u64 {
+    60
+}
+
+impl OtelSpec {
+    /// Convert to the core config and validate ranges/URL.
+    pub fn to_core(&self) -> Result<faucet_core::OtelConfig, String> {
+        let cfg = faucet_core::OtelConfig {
+            endpoint: self.endpoint.clone(),
+            protocol: self.protocol,
+            headers: self.headers.clone(),
+            sample_ratio: self.sample_ratio,
+            export: self.export.clone(),
+            service_name: self.service_name.clone(),
+            timeout_secs: self.timeout_secs,
+            metric_interval_secs: self.metric_interval_secs,
+        };
+        cfg.validate()?;
+        Ok(cfg)
+    }
 }
 
 /// Mirrors `faucet_core::OnBatchError` but with `JsonSchema` derived and
@@ -677,6 +745,11 @@ impl PipelineConfig {
             });
         }
         crate::interpolate::resolve_config_refs(&mut cfg)?;
+        if let Some(obs) = cfg.observability.as_ref() {
+            if let Some(otel) = obs.otel.as_ref() {
+                otel.to_core().map_err(CliError::Config)?;
+            }
+        }
         Ok(cfg)
     }
 }
@@ -1463,5 +1536,38 @@ resilience: { retry: { max_attempts: 0 } }
         let cfg = parse_with_extension(yaml, "yaml").unwrap();
         let err = cfg.resilience.unwrap().to_policy().unwrap_err();
         assert!(err.to_string().contains("max_attempts"));
+    }
+
+    #[test]
+    fn observability_parses_otel_block() {
+        let yaml = r#"
+version: 1
+pipeline:
+  source: { type: rest, config: { base_url: "http://x" } }
+  sink: { type: stdout, config: {} }
+observability:
+  otel:
+    endpoint: http://collector:4317
+    protocol: grpc
+    export: [traces, metrics]
+"#;
+        let cfg = parse_with_extension(yaml, "yaml").unwrap();
+        let otel = cfg.observability.unwrap().otel.unwrap();
+        assert_eq!(otel.endpoint, "http://collector:4317");
+    }
+
+    #[test]
+    fn otel_validation_rejects_bad_ratio() {
+        let yaml = r#"
+version: 1
+pipeline:
+  source: { type: rest, config: { base_url: "http://x" } }
+  sink: { type: stdout, config: {} }
+observability:
+  otel:
+    sample_ratio: 9.0
+"#;
+        let err = parse_with_extension(yaml, "yaml").unwrap_err();
+        assert!(format!("{err}").contains("sample_ratio"));
     }
 }

--- a/cli/src/obs.rs
+++ b/cli/src/obs.rs
@@ -46,6 +46,8 @@ pub fn install(cfg: &PipelineConfig) -> CliResult<()> {
                 buckets: p.buckets.clone(),
             }),
         tracing: level.map(|l| TracingConfig { level: l }),
+        // OTLP export is wired from the config in a follow-up task; default off.
+        otel: None,
     };
     let report = install_observability(&obs_cfg)?;
     if let Some(addr) = report.prometheus_listen.as_deref() {

--- a/cli/src/obs.rs
+++ b/cli/src/obs.rs
@@ -26,9 +26,10 @@ pub fn resolve_tracing_level(cli_flag: Option<&str>, yaml_level: Option<&str>) -
     yaml_level.map(|s| s.to_string())
 }
 
-/// Install Prometheus + tracing from the config's `observability:` block. Logs
-/// (does not fail) when a recorder/subscriber is already installed.
-pub fn install(cfg: &PipelineConfig) -> CliResult<()> {
+/// Build the core `ObservabilityConfig` from the CLI config, including OTLP when
+/// the `otel` feature is compiled in. Logs a one-shot warning if an `otel:` block
+/// is present but the binary was built without `--features otel`.
+pub fn build_observability_config(cfg: &PipelineConfig) -> ObservabilityConfig {
     let level = resolve_tracing_level(
         None,
         cfg.observability
@@ -36,7 +37,9 @@ pub fn install(cfg: &PipelineConfig) -> CliResult<()> {
             .and_then(|o| o.tracing.as_ref())
             .and_then(|t| t.level.as_deref()),
     );
-    let obs_cfg = ObservabilityConfig {
+    // `mut` is only needed when the `otel` feature populates `obs.otel` below.
+    #[cfg_attr(not(feature = "otel"), allow(unused_mut))]
+    let mut obs = ObservabilityConfig {
         prometheus: cfg
             .observability
             .as_ref()
@@ -46,9 +49,39 @@ pub fn install(cfg: &PipelineConfig) -> CliResult<()> {
                 buckets: p.buckets.clone(),
             }),
         tracing: level.map(|l| TracingConfig { level: l }),
-        // OTLP export is wired from the config in a follow-up task; default off.
-        otel: None,
+        ..Default::default()
     };
+
+    let otel_present = cfg
+        .observability
+        .as_ref()
+        .and_then(|o| o.otel.as_ref())
+        .is_some();
+    #[cfg(feature = "otel")]
+    {
+        if let Some(spec) = cfg.observability.as_ref().and_then(|o| o.otel.as_ref()) {
+            match spec.to_core() {
+                Ok(c) => obs.otel = Some(c),
+                Err(e) => tracing::warn!("ignoring invalid otel config: {e}"),
+            }
+        }
+    }
+    #[cfg(not(feature = "otel"))]
+    {
+        if otel_present {
+            tracing::warn!(
+                "observability.otel is configured but this binary was built without --features otel; OTLP export is disabled"
+            );
+        }
+    }
+    let _ = otel_present;
+    obs
+}
+
+/// Install Prometheus + tracing from the config's `observability:` block. Logs
+/// (does not fail) when a recorder/subscriber is already installed.
+pub fn install(cfg: &PipelineConfig) -> CliResult<()> {
+    let obs_cfg = build_observability_config(cfg);
     let report = install_observability(&obs_cfg)?;
     if let Some(addr) = report.prometheus_listen.as_deref() {
         tracing::info!("Prometheus /metrics listening on {addr}");
@@ -62,6 +95,9 @@ pub fn install(cfg: &PipelineConfig) -> CliResult<()> {
         tracing::warn!(
             "tracing subscriber already installed; logs route through the existing subscriber"
         );
+    }
+    if report.otel_installed {
+        tracing::info!("OTLP export enabled: {}", report.otel_signals.join(", "));
     }
     Ok(())
 }
@@ -137,5 +173,22 @@ mod tests {
         with_clean_env(|| {
             assert_eq!(resolve_tracing_level(None, None), None);
         });
+    }
+
+    #[test]
+    fn maps_otel_spec_into_observability_config() {
+        let yaml = r#"
+version: 1
+pipeline:
+  source: { type: rest, config: { base_url: "http://x" } }
+  sink: { type: stdout, config: {} }
+observability:
+  otel: { endpoint: "http://c:4317" }
+"#;
+        let cfg = crate::config::parse_with_extension(yaml, "yaml").unwrap();
+        let obs = build_observability_config(&cfg);
+        #[cfg(feature = "otel")]
+        assert!(obs.otel.is_some());
+        let _ = obs;
     }
 }

--- a/cli/src/serve/server.rs
+++ b/cli/src/serve/server.rs
@@ -404,6 +404,9 @@ pub async fn serve(config: ServeConfig) -> CliResult<()> {
     for h in trigger_handles {
         h.abort();
     }
+    // Flush any buffered OTLP telemetry after in-flight runs drain (no-op without
+    // the `otel` feature).
+    faucet_core::shutdown_otel();
     tracing::info!("faucet serve stopped");
     Ok(())
 }

--- a/cli/tests/observability_end_to_end.rs
+++ b/cli/tests/observability_end_to_end.rs
@@ -228,6 +228,7 @@ fn install_observability_returns_typed_error_on_garbage_listen() {
             buckets: None,
         }),
         tracing: None,
+        otel: None,
     };
     match install_observability(&cfg) {
         Err(InstallError::PrometheusBind { .. }) => {}

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -108,6 +108,7 @@ futures.workspace = true
 tempfile = "3"
 metrics-util.workspace = true
 criterion = { workspace = true, features = ["async_tokio"] }
+axum = { workspace = true }
 
 [[bench]]
 name = "observability"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -53,7 +53,9 @@ otel = [
     "dep:opentelemetry-otlp",
     "dep:tracing-opentelemetry",
     "dep:metrics-exporter-opentelemetry",
+    "dep:metrics-util",
     "dep:tracing-subscriber",
+    "tokio/rt",
 ]
 compression = ["dep:async-compression", "dep:flate2", "dep:zstd"]
 quality = ["dep:regex"]
@@ -84,6 +86,9 @@ metrics.workspace = true
 schemars.workspace = true
 uuid.workspace = true
 metrics-exporter-prometheus = { workspace = true, optional = true }
+# `FanoutBuilder` for the Prometheus + OTLP fanout recorder (#201); optional,
+# pulled in only by the `otel` feature.
+metrics-util = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }
 opentelemetry = { workspace = true, optional = true }
 opentelemetry_sdk = { workspace = true, optional = true }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -43,6 +43,18 @@ transforms = [
     "transform-cdc-unwrap",
 ]
 observability-install = ["dep:metrics-exporter-prometheus", "dep:tracing-subscriber"]
+# OTLP (OpenTelemetry) export of traces + metrics (#201). Opt-in; pulls the
+# 0.31-line OTel stack. The wiring inside `install_observability` is additionally
+# gated on `observability-install` (see otel.rs); enabling `otel` alone just makes
+# the provider builders available to library callers.
+otel = [
+    "dep:opentelemetry",
+    "dep:opentelemetry_sdk",
+    "dep:opentelemetry-otlp",
+    "dep:tracing-opentelemetry",
+    "dep:metrics-exporter-opentelemetry",
+    "dep:tracing-subscriber",
+]
 compression = ["dep:async-compression", "dep:flate2", "dep:zstd"]
 quality = ["dep:regex"]
 quality-jsonschema = ["quality", "dep:jsonschema"]
@@ -72,6 +84,11 @@ schemars.workspace = true
 uuid.workspace = true
 metrics-exporter-prometheus = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }
+opentelemetry = { workspace = true, optional = true }
+opentelemetry_sdk = { workspace = true, optional = true }
+opentelemetry-otlp = { workspace = true, optional = true }
+tracing-opentelemetry = { workspace = true, optional = true }
+metrics-exporter-opentelemetry = { workspace = true, optional = true }
 async-compression = { workspace = true, optional = true }
 flate2 = { workspace = true, optional = true }
 zstd = { workspace = true, optional = true }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -63,6 +63,7 @@ quality-jsonschema = ["quality", "dep:jsonschema"]
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
+url.workspace = true
 tracing.workspace = true
 async-trait.workspace = true
 reqwest.workspace = true

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -55,6 +55,7 @@ pub use error::FaucetError;
 pub use idempotency::{DeliveryMode, format_token, parse_token, unwrap_state, wrap_state};
 #[cfg(feature = "quality")]
 pub use observability::instrumented_apply_quality;
+pub use observability::otel::{OtelConfig, OtelProtocol, OtelSignal, shutdown_otel};
 pub use observability::{
     DurationGuard, InstallError, InstallReport, InstrumentedSink, InstrumentedSource,
     InstrumentedStateStore, Labels, ObservabilityConfig, PrometheusConfig, RunStreamOptions,

--- a/crates/core/src/observability/install.rs
+++ b/crates/core/src/observability/install.rs
@@ -14,6 +14,9 @@ pub struct ObservabilityConfig {
 }
 
 /// Which metrics recorder to install given which exporters are requested.
+/// Only consulted by `install_observability`, which itself requires the recorder
+/// machinery, so it's gated on the same feature.
+#[cfg(feature = "observability-install")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum MetricsMode {
     None,
@@ -22,6 +25,7 @@ pub(crate) enum MetricsMode {
     Fanout,
 }
 
+#[cfg(feature = "observability-install")]
 impl MetricsMode {
     pub(crate) fn select(prometheus: bool, otel_metrics: bool) -> Self {
         match (prometheus, otel_metrics) {

--- a/crates/core/src/observability/install.rs
+++ b/crates/core/src/observability/install.rs
@@ -181,10 +181,12 @@ pub fn install_observability(cfg: &ObservabilityConfig) -> Result<InstallReport,
                         if reg.try_init().is_err() {
                             tracing::warn!("tracing subscriber already installed; continuing");
                             report.tracing_already_installed = true;
+                            // try_init failed: no otel layer was installed, so DON'T store the
+                            // provider — let `tp` drop here to shut its exporter down.
                         } else {
                             report.otel_signals.push("traces");
+                            otel_tracer = Some(tp);
                         }
-                        otel_tracer = Some(tp);
                         installed = true;
                     }
                     Err(e) => tracing::warn!("OTLP trace exporter init failed; logs-only: {e}"),

--- a/crates/core/src/observability/install.rs
+++ b/crates/core/src/observability/install.rs
@@ -10,6 +10,27 @@ use thiserror::Error;
 pub struct ObservabilityConfig {
     pub prometheus: Option<PrometheusConfig>,
     pub tracing: Option<TracingConfig>,
+    pub otel: Option<crate::observability::otel::OtelConfig>,
+}
+
+/// Which metrics recorder to install given which exporters are requested.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MetricsMode {
+    None,
+    PrometheusOnly,
+    OtelOnly,
+    Fanout,
+}
+
+impl MetricsMode {
+    pub(crate) fn select(prometheus: bool, otel_metrics: bool) -> Self {
+        match (prometheus, otel_metrics) {
+            (true, true) => MetricsMode::Fanout,
+            (true, false) => MetricsMode::PrometheusOnly,
+            (false, true) => MetricsMode::OtelOnly,
+            (false, false) => MetricsMode::None,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -35,6 +56,8 @@ pub struct InstallReport {
     pub prometheus_listen: Option<String>,
     pub prometheus_already_installed: bool,
     pub tracing_already_installed: bool,
+    pub otel_installed: bool,
+    pub otel_signals: Vec<&'static str>,
 }
 
 #[derive(Debug, Error)]
@@ -65,70 +88,134 @@ pub enum InstallError {
 pub fn install_observability(cfg: &ObservabilityConfig) -> Result<InstallReport, InstallError> {
     let mut report = InstallReport::default();
 
-    if let Some(p) = cfg.prometheus.as_ref() {
-        use metrics_exporter_prometheus::{BuildError, PrometheusBuilder};
+    // Provider holders moved into the guard after both arms run; only populated
+    // (and only referenced) when the `otel` feature is enabled.
+    #[cfg(feature = "otel")]
+    let mut otel_tracer: Option<opentelemetry_sdk::trace::SdkTracerProvider> = None;
 
-        let listen: std::net::SocketAddr =
-            p.listen.parse().map_err(|e: std::net::AddrParseError| {
-                InstallError::PrometheusBind {
-                    listen: p.listen.clone(),
-                    source: std::io::Error::new(std::io::ErrorKind::InvalidInput, e.to_string()),
+    // --- Metrics ---
+    #[cfg(feature = "otel")]
+    let otel_metrics = cfg
+        .otel
+        .as_ref()
+        .map(|o| o.exports(crate::observability::otel::OtelSignal::Metrics))
+        .unwrap_or(false);
+    #[cfg(not(feature = "otel"))]
+    let otel_metrics = false;
+
+    let mode = MetricsMode::select(cfg.prometheus.is_some(), otel_metrics);
+
+    // Declared so the trace arm + guard step can move them; only used under otel.
+    #[cfg(feature = "otel")]
+    let mut otel_meter: Option<opentelemetry_sdk::metrics::SdkMeterProvider> = None;
+
+    match mode {
+        MetricsMode::None => {}
+        MetricsMode::PrometheusOnly => {
+            install_prometheus_only(cfg.prometheus.as_ref().unwrap(), &mut report)?;
+        }
+        #[cfg(feature = "otel")]
+        MetricsMode::OtelOnly => {
+            if let Some(otel) = cfg.otel.as_ref() {
+                match crate::observability::otel::build_meter_provider(otel) {
+                    Ok((mp, recorder)) => {
+                        if metrics::set_global_recorder(recorder).is_err() {
+                            tracing::warn!("metrics recorder already installed; continuing");
+                            report.prometheus_already_installed = true;
+                        } else {
+                            otel_meter = Some(mp);
+                            report.otel_signals.push("metrics");
+                        }
+                    }
+                    Err(e) => tracing::warn!("OTLP metrics exporter init failed; skipping: {e}"),
                 }
-            })?;
-
-        const DEFAULT_BUCKETS: &[f64] = &[
-            0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 30.0, 60.0, 300.0,
-        ];
-        let buckets = p.buckets.as_deref().unwrap_or(DEFAULT_BUCKETS);
-
-        let builder = PrometheusBuilder::new()
-            .with_http_listener(listen)
-            .set_buckets(buckets)
-            .map_err(|e| InstallError::PrometheusInstall(e.to_string()))?;
-
-        match builder.install() {
-            Ok(()) => report.prometheus_listen = Some(p.listen.clone()),
-            // Match the TYPED `BuildError` variant rather than scraping its
-            // Display string — the latter breaks silently if the upstream
-            // wording changes.
-            Err(e) => match e {
-                // Recorder already installed (e.g. a prior `install` call or a
-                // test harness). Idempotent: warn and continue.
-                BuildError::FailedToSetGlobalRecorder(_) => {
-                    tracing::warn!("Prometheus recorder already installed; continuing");
-                    report.prometheus_already_installed = true;
-                }
-                // The HTTP `/metrics` listener could not bind. This is where a
-                // genuine bind failure (e.g. EADDRINUSE / port-in-use) lands,
-                // since the real `TcpListener::bind` happens inside `install()`,
-                // not in the address parse above. Surface it as the dedicated
-                // bind error so port-in-use is reported correctly.
-                BuildError::FailedToCreateHTTPListener(msg) => {
-                    return Err(InstallError::PrometheusBind {
-                        listen: p.listen.clone(),
-                        source: std::io::Error::other(msg),
-                    });
-                }
-                other => return Err(InstallError::PrometheusInstall(other.to_string())),
-            },
+            }
+        }
+        #[cfg(feature = "otel")]
+        MetricsMode::Fanout => {
+            install_fanout(
+                cfg.prometheus.as_ref().unwrap(),
+                cfg.otel.as_ref().unwrap(),
+                &mut report,
+                &mut otel_meter,
+            )?;
+        }
+        #[cfg(not(feature = "otel"))]
+        MetricsMode::OtelOnly | MetricsMode::Fanout => {
+            unreachable!("otel metrics mode selected without the otel feature")
         }
     }
 
+    // --- Traces ---
     if let Some(t) = cfg.tracing.as_ref() {
         use tracing_subscriber::EnvFilter;
         use tracing_subscriber::layer::SubscriberExt;
         use tracing_subscriber::util::SubscriberInitExt;
 
-        let filter = EnvFilter::try_new(&t.level).unwrap_or_else(|_| EnvFilter::new("info"));
-        let registry = tracing_subscriber::registry()
-            .with(filter)
-            .with(tracing_subscriber::fmt::layer());
-        if registry.try_init().is_err() {
-            // Some other code path has already set a global default. Log and
-            // continue — observability still works through the previously-
-            // installed subscriber.
-            tracing::warn!("tracing subscriber already installed; continuing");
-            report.tracing_already_installed = true;
+        let make_filter =
+            || EnvFilter::try_new(&t.level).unwrap_or_else(|_| EnvFilter::new("info"));
+
+        // Reassigned only in the `otel` branch below; without that feature the
+        // `mut` is genuinely unused.
+        #[cfg_attr(not(feature = "otel"), allow(unused_mut))]
+        let mut installed = false;
+
+        #[cfg(feature = "otel")]
+        {
+            let otel_traces = cfg
+                .otel
+                .as_ref()
+                .map(|o| o.exports(crate::observability::otel::OtelSignal::Traces))
+                .unwrap_or(false);
+            if let (true, Some(otel)) = (otel_traces, cfg.otel.as_ref()) {
+                match crate::observability::otel::build_trace_provider(otel) {
+                    Ok(tp) => {
+                        use opentelemetry::trace::TracerProvider as _;
+                        let tracer = tp.tracer("faucet");
+                        crate::observability::otel::install_propagator();
+                        let reg = tracing_subscriber::registry()
+                            .with(make_filter())
+                            .with(tracing_subscriber::fmt::layer())
+                            .with(tracing_opentelemetry::layer().with_tracer(tracer))
+                            .with(crate::observability::otel::OtelErrorCountLayer);
+                        if reg.try_init().is_err() {
+                            tracing::warn!("tracing subscriber already installed; continuing");
+                            report.tracing_already_installed = true;
+                        } else {
+                            report.otel_signals.push("traces");
+                        }
+                        otel_tracer = Some(tp);
+                        installed = true;
+                    }
+                    Err(e) => tracing::warn!("OTLP trace exporter init failed; logs-only: {e}"),
+                }
+            }
+        }
+
+        if !installed {
+            let reg = tracing_subscriber::registry()
+                .with(make_filter())
+                .with(tracing_subscriber::fmt::layer());
+            if reg.try_init().is_err() {
+                // Some other code path has already set a global default. Log and
+                // continue — observability still works through the previously-
+                // installed subscriber.
+                tracing::warn!("tracing subscriber already installed; continuing");
+                report.tracing_already_installed = true;
+            }
+        }
+    }
+
+    // --- OTel guard + describe ---
+    #[cfg(feature = "otel")]
+    {
+        if otel_tracer.is_some() || otel_meter.is_some() {
+            crate::observability::otel::describe();
+            let _ = crate::observability::otel::set_guard(crate::observability::otel::OtelGuard {
+                tracer: otel_tracer,
+                meter: otel_meter,
+            });
+            report.otel_installed = true;
         }
     }
 
@@ -142,11 +229,142 @@ pub fn install_observability(cfg: &ObservabilityConfig) -> Result<InstallReport,
     Ok(report)
 }
 
+/// Install the Prometheus recorder + `/metrics` HTTP endpoint as the sole
+/// global recorder. Extracted verbatim from the original metrics arm so the
+/// fanout / otel-only paths can choose a different recorder.
+#[cfg(feature = "observability-install")]
+fn install_prometheus_only(
+    p: &PrometheusConfig,
+    report: &mut InstallReport,
+) -> Result<(), InstallError> {
+    use metrics_exporter_prometheus::{BuildError, PrometheusBuilder};
+
+    let listen: std::net::SocketAddr =
+        p.listen
+            .parse()
+            .map_err(|e: std::net::AddrParseError| InstallError::PrometheusBind {
+                listen: p.listen.clone(),
+                source: std::io::Error::new(std::io::ErrorKind::InvalidInput, e.to_string()),
+            })?;
+
+    const DEFAULT_BUCKETS: &[f64] = &[
+        0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 30.0, 60.0, 300.0,
+    ];
+    let buckets = p.buckets.as_deref().unwrap_or(DEFAULT_BUCKETS);
+
+    let builder = PrometheusBuilder::new()
+        .with_http_listener(listen)
+        .set_buckets(buckets)
+        .map_err(|e| InstallError::PrometheusInstall(e.to_string()))?;
+
+    match builder.install() {
+        Ok(()) => report.prometheus_listen = Some(p.listen.clone()),
+        // Match the TYPED `BuildError` variant rather than scraping its
+        // Display string — the latter breaks silently if the upstream
+        // wording changes.
+        Err(e) => match e {
+            // Recorder already installed (e.g. a prior `install` call or a
+            // test harness). Idempotent: warn and continue.
+            BuildError::FailedToSetGlobalRecorder(_) => {
+                tracing::warn!("Prometheus recorder already installed; continuing");
+                report.prometheus_already_installed = true;
+            }
+            // The HTTP `/metrics` listener could not bind. This is where a
+            // genuine bind failure (e.g. EADDRINUSE / port-in-use) lands,
+            // since the real `TcpListener::bind` happens inside `install()`,
+            // not in the address parse above. Surface it as the dedicated
+            // bind error so port-in-use is reported correctly.
+            BuildError::FailedToCreateHTTPListener(msg) => {
+                return Err(InstallError::PrometheusBind {
+                    listen: p.listen.clone(),
+                    source: std::io::Error::other(msg),
+                });
+            }
+            other => return Err(InstallError::PrometheusInstall(other.to_string())),
+        },
+    }
+    Ok(())
+}
+
+/// Install a `metrics-util` fanout recorder dispatching to BOTH a Prometheus
+/// recorder (with its `/metrics` HTTP endpoint) and an OTLP metrics recorder,
+/// so both coexist. If the OTLP exporter fails to build, falls back to a
+/// Prometheus-only recorder so `/metrics` still works — export never fails the
+/// process.
+#[cfg(all(feature = "observability-install", feature = "otel"))]
+fn install_fanout(
+    p: &PrometheusConfig,
+    otel: &crate::observability::otel::OtelConfig,
+    report: &mut InstallReport,
+    otel_meter: &mut Option<opentelemetry_sdk::metrics::SdkMeterProvider>,
+) -> Result<(), InstallError> {
+    use metrics_exporter_prometheus::{BuildError, PrometheusBuilder};
+    use metrics_util::layers::FanoutBuilder;
+
+    let listen: std::net::SocketAddr =
+        p.listen
+            .parse()
+            .map_err(|e: std::net::AddrParseError| InstallError::PrometheusBind {
+                listen: p.listen.clone(),
+                source: std::io::Error::new(std::io::ErrorKind::InvalidInput, e.to_string()),
+            })?;
+    const DEFAULT_BUCKETS: &[f64] = &[
+        0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 30.0, 60.0, 300.0,
+    ];
+    let buckets = p.buckets.as_deref().unwrap_or(DEFAULT_BUCKETS);
+
+    // build() returns (recorder, /metrics exporter future) WITHOUT setting the
+    // global recorder, so we can fan it out.
+    let (prom_recorder, prom_exporter) = PrometheusBuilder::new()
+        .with_http_listener(listen)
+        .set_buckets(buckets)
+        .map_err(|e| InstallError::PrometheusInstall(e.to_string()))?
+        .build()
+        .map_err(|e| match e {
+            BuildError::FailedToCreateHTTPListener(msg) => InstallError::PrometheusBind {
+                listen: p.listen.clone(),
+                source: std::io::Error::other(msg),
+            },
+            other => InstallError::PrometheusInstall(other.to_string()),
+        })?;
+
+    match crate::observability::otel::build_meter_provider(otel) {
+        Ok((mp, otel_recorder)) => {
+            let fanout = FanoutBuilder::default()
+                .add_recorder(prom_recorder)
+                .add_recorder(otel_recorder)
+                .build();
+            if metrics::set_global_recorder(fanout).is_err() {
+                tracing::warn!("metrics recorder already installed; continuing");
+                report.prometheus_already_installed = true;
+            } else {
+                report.prometheus_listen = Some(p.listen.clone());
+                report.otel_signals.push("metrics");
+                *otel_meter = Some(mp);
+                tokio::spawn(prom_exporter);
+            }
+        }
+        Err(e) => {
+            // OTLP metrics init failed — fall back to Prometheus-only so /metrics
+            // still works; export never fails the process.
+            tracing::warn!("OTLP metrics exporter init failed; Prometheus-only: {e}");
+            if metrics::set_global_recorder(prom_recorder).is_err() {
+                report.prometheus_already_installed = true;
+            } else {
+                report.prometheus_listen = Some(p.listen.clone());
+                tokio::spawn(prom_exporter);
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Non-`observability-install` stub. Returns an empty report, never panics.
 #[cfg(not(feature = "observability-install"))]
 pub fn install_observability(_cfg: &ObservabilityConfig) -> Result<InstallReport, InstallError> {
     crate::observability::resilience::describe();
     crate::observability::drift::describe();
+    crate::observability::otel::describe();
     register_build_info();
     Ok(InstallReport::default())
 }
@@ -176,6 +394,18 @@ mod tests {
     static LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
+    fn metrics_mode_selection() {
+        use super::MetricsMode;
+        assert_eq!(MetricsMode::select(true, true), MetricsMode::Fanout);
+        assert_eq!(
+            MetricsMode::select(true, false),
+            MetricsMode::PrometheusOnly
+        );
+        assert_eq!(MetricsMode::select(false, true), MetricsMode::OtelOnly);
+        assert_eq!(MetricsMode::select(false, false), MetricsMode::None);
+    }
+
+    #[test]
     fn no_config_returns_empty_report() {
         let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let r = install_observability(&ObservabilityConfig::default()).unwrap();
@@ -193,6 +423,7 @@ mod tests {
                 buckets: None,
             }),
             tracing: None,
+            otel: None,
         };
         match install_observability(&cfg) {
             Err(InstallError::PrometheusBind { .. }) => {}
@@ -226,6 +457,7 @@ mod tests {
             tracing: Some(TracingConfig {
                 level: "info".into(),
             }),
+            otel: None,
         };
         let report = install_observability(&cfg).expect("install must return Ok");
         // Exactly one of: recorder installed (listen set) OR already installed.
@@ -246,6 +478,7 @@ mod tests {
                 // Garbage directive → try_new errors → fallback to info.
                 level: "this is !!! not a valid filter".into(),
             }),
+            otel: None,
         };
         install_observability(&cfg).expect("invalid tracing directive must not fail install");
     }

--- a/crates/core/src/observability/mod.rs
+++ b/crates/core/src/observability/mod.rs
@@ -11,6 +11,7 @@ mod labels;
 mod options;
 #[cfg(feature = "quality")]
 mod quality;
+pub mod otel;
 pub mod resilience;
 mod state;
 mod strip;

--- a/crates/core/src/observability/mod.rs
+++ b/crates/core/src/observability/mod.rs
@@ -9,9 +9,9 @@ mod drift;
 mod install;
 mod labels;
 mod options;
+pub mod otel;
 #[cfg(feature = "quality")]
 mod quality;
-pub mod otel;
 pub mod resilience;
 mod state;
 mod strip;

--- a/crates/core/src/observability/otel.rs
+++ b/crates/core/src/observability/otel.rs
@@ -94,6 +94,39 @@ impl OtelConfig {
     pub fn exports(&self, signal: OtelSignal) -> bool {
         self.export.contains(&signal)
     }
+
+    /// The collector endpoint, filling in the protocol-specific default when
+    /// `endpoint` is empty.
+    pub fn resolve_endpoint(&self) -> String {
+        if !self.endpoint.is_empty() {
+            return self.endpoint.clone();
+        }
+        match self.protocol {
+            OtelProtocol::Grpc => "http://localhost:4317".to_string(),
+            OtelProtocol::Http => "http://localhost:4318".to_string(),
+        }
+    }
+
+    /// Validate ranges + endpoint URL at config-load time. Returns a message on
+    /// the first problem.
+    pub fn validate(&self) -> Result<(), String> {
+        if !(0.0..=1.0).contains(&self.sample_ratio) {
+            return Err(format!(
+                "otel.sample_ratio must be in 0.0..=1.0, got {}",
+                self.sample_ratio
+            ));
+        }
+        if self.timeout_secs == 0 {
+            return Err("otel.timeout_secs must be > 0".to_string());
+        }
+        if self.metric_interval_secs == 0 {
+            return Err("otel.metric_interval_secs must be > 0".to_string());
+        }
+        // resolve_endpoint() always yields a value; validate the effective URL.
+        let ep = self.resolve_endpoint();
+        url::Url::parse(&ep).map_err(|e| format!("otel.endpoint is not a valid URL ({ep}): {e}"))?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -111,5 +144,39 @@ mod tests {
         assert_eq!(cfg.metric_interval_secs, 60);
         assert!(cfg.exports(OtelSignal::Traces));
         assert!(cfg.exports(OtelSignal::Metrics));
+    }
+
+    #[test]
+    fn resolve_endpoint_defaults_per_protocol() {
+        let mut cfg = OtelConfig::default();
+        assert_eq!(cfg.resolve_endpoint(), "http://localhost:4317");
+        cfg.protocol = OtelProtocol::Http;
+        assert_eq!(cfg.resolve_endpoint(), "http://localhost:4318");
+        cfg.endpoint = "http://collector:4317".into();
+        assert_eq!(cfg.resolve_endpoint(), "http://collector:4317");
+    }
+
+    #[test]
+    fn validate_rejects_bad_values() {
+        let mut cfg = OtelConfig::default();
+        assert!(cfg.validate().is_ok());
+
+        cfg.sample_ratio = 1.5;
+        assert!(cfg.validate().is_err());
+        cfg.sample_ratio = -0.1;
+        assert!(cfg.validate().is_err());
+        cfg.sample_ratio = 0.5;
+        assert!(cfg.validate().is_ok());
+
+        cfg.timeout_secs = 0;
+        assert!(cfg.validate().is_err());
+        cfg.timeout_secs = 10;
+
+        cfg.metric_interval_secs = 0;
+        assert!(cfg.validate().is_err());
+        cfg.metric_interval_secs = 60;
+
+        cfg.endpoint = "not a url".into();
+        assert!(cfg.validate().is_err());
     }
 }

--- a/crates/core/src/observability/otel.rs
+++ b/crates/core/src/observability/otel.rs
@@ -1,0 +1,115 @@
+//! OpenTelemetry (OTLP) export of traces + metrics (#201).
+//!
+//! `OtelConfig` and its enums are pure data (no opentelemetry types) so they
+//! compile unconditionally. Everything that touches the OTel SDK is gated on
+//! `#[cfg(feature = "otel")]` further down this file.
+
+use serde::{Deserialize, Serialize};
+
+/// OTLP transport protocol.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum OtelProtocol {
+    /// gRPC over tonic (default OTLP port 4317). Must be initialised inside a
+    /// tokio runtime.
+    #[default]
+    Grpc,
+    /// HTTP/protobuf (default OTLP port 4318).
+    Http,
+}
+
+/// A telemetry signal that can be exported over OTLP.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum OtelSignal {
+    Traces,
+    Metrics,
+}
+
+fn default_protocol() -> OtelProtocol {
+    OtelProtocol::Grpc
+}
+fn default_sample_ratio() -> f64 {
+    1.0
+}
+fn default_export() -> Vec<OtelSignal> {
+    vec![OtelSignal::Traces, OtelSignal::Metrics]
+}
+fn default_service_name() -> String {
+    "faucet".to_string()
+}
+fn default_timeout_secs() -> u64 {
+    10
+}
+fn default_metric_interval_secs() -> u64 {
+    60
+}
+
+/// Pure-data OTLP export configuration. Contains no opentelemetry types.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct OtelConfig {
+    /// Collector endpoint. When empty, resolved per protocol
+    /// (`http://localhost:4317` grpc / `:4318` http) by [`OtelConfig::resolve_endpoint`].
+    #[serde(default)]
+    pub endpoint: String,
+    #[serde(default = "default_protocol")]
+    pub protocol: OtelProtocol,
+    /// Extra headers sent on every export (e.g. backend auth tokens).
+    #[serde(default)]
+    pub headers: std::collections::HashMap<String, String>,
+    /// Head-based trace sampling ratio, 0.0..=1.0.
+    #[serde(default = "default_sample_ratio")]
+    pub sample_ratio: f64,
+    /// Which signals to export.
+    #[serde(default = "default_export")]
+    pub export: Vec<OtelSignal>,
+    /// OTel resource `service.name`.
+    #[serde(default = "default_service_name")]
+    pub service_name: String,
+    /// Per-export timeout (seconds).
+    #[serde(default = "default_timeout_secs")]
+    pub timeout_secs: u64,
+    /// Metric push interval (seconds).
+    #[serde(default = "default_metric_interval_secs")]
+    pub metric_interval_secs: u64,
+}
+
+impl Default for OtelConfig {
+    fn default() -> Self {
+        Self {
+            endpoint: String::new(),
+            protocol: default_protocol(),
+            headers: std::collections::HashMap::new(),
+            sample_ratio: default_sample_ratio(),
+            export: default_export(),
+            service_name: default_service_name(),
+            timeout_secs: default_timeout_secs(),
+            metric_interval_secs: default_metric_interval_secs(),
+        }
+    }
+}
+
+impl OtelConfig {
+    /// Whether the given signal is in the export list.
+    pub fn exports(&self, signal: OtelSignal) -> bool {
+        self.export.contains(&signal)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_defaults_are_applied_from_empty_yaml() {
+        let cfg: OtelConfig = serde_json::from_str("{}").unwrap();
+        assert_eq!(cfg.protocol, OtelProtocol::Grpc);
+        assert_eq!(cfg.sample_ratio, 1.0);
+        assert_eq!(cfg.export, vec![OtelSignal::Traces, OtelSignal::Metrics]);
+        assert_eq!(cfg.service_name, "faucet");
+        assert_eq!(cfg.timeout_secs, 10);
+        assert_eq!(cfg.metric_interval_secs, 60);
+        assert!(cfg.exports(OtelSignal::Traces));
+        assert!(cfg.exports(OtelSignal::Metrics));
+    }
+}

--- a/crates/core/src/observability/otel.rs
+++ b/crates/core/src/observability/otel.rs
@@ -125,7 +125,8 @@ impl OtelConfig {
         }
         // resolve_endpoint() always yields a value; validate the effective URL.
         let ep = self.resolve_endpoint();
-        url::Url::parse(&ep).map_err(|e| format!("otel.endpoint is not a valid URL ({ep}): {e}"))?;
+        url::Url::parse(&ep)
+            .map_err(|e| format!("otel.endpoint is not a valid URL ({ep}): {e}"))?;
         Ok(())
     }
 }
@@ -134,6 +135,9 @@ impl OtelConfig {
 /// appends the per-signal path for the `OTEL_EXPORTER_OTLP_ENDPOINT` env-var
 /// form). Users naturally configure the base endpoint, so for HTTP we append the
 /// conventional per-signal path ourselves when it is not already present.
+// Always compiled (unit-testable without the feature); only *called* from the
+// otel-gated `mod sdk`, so it reads as dead code in a no-otel non-test build.
+#[cfg_attr(not(feature = "otel"), allow(dead_code))]
 pub(crate) fn http_signal_endpoint(base: &str, signal_path: &str) -> String {
     let trimmed = base.trim_end_matches('/');
     if trimmed.ends_with(signal_path) {
@@ -146,6 +150,9 @@ pub(crate) fn http_signal_endpoint(base: &str, signal_path: &str) -> String {
 /// Map an `opentelemetry*` tracing event target to a `signal` label for the
 /// `faucet_otel_export_failures_total` counter. Pure — unit-testable without a
 /// tracing `Context`.
+// Always compiled (unit-testable without the feature); only *called* from the
+// otel-gated `mod layer`, so it reads as dead code in a no-otel non-test build.
+#[cfg_attr(not(feature = "otel"), allow(dead_code))]
 pub(crate) fn otel_signal_label(target: &str) -> &'static str {
     if target.contains("metric") {
         "metrics"
@@ -343,17 +350,35 @@ mod tests {
 
     #[test]
     fn http_signal_endpoint_appends_path_when_absent() {
-        assert_eq!(http_signal_endpoint("http://c:4318", "/v1/traces"), "http://c:4318/v1/traces");
-        assert_eq!(http_signal_endpoint("http://c:4318/", "/v1/traces"), "http://c:4318/v1/traces");
+        assert_eq!(
+            http_signal_endpoint("http://c:4318", "/v1/traces"),
+            "http://c:4318/v1/traces"
+        );
+        assert_eq!(
+            http_signal_endpoint("http://c:4318/", "/v1/traces"),
+            "http://c:4318/v1/traces"
+        );
         // idempotent: already has the path
-        assert_eq!(http_signal_endpoint("http://c:4318/v1/traces", "/v1/traces"), "http://c:4318/v1/traces");
-        assert_eq!(http_signal_endpoint("http://c:4318", "/v1/metrics"), "http://c:4318/v1/metrics");
+        assert_eq!(
+            http_signal_endpoint("http://c:4318/v1/traces", "/v1/traces"),
+            "http://c:4318/v1/traces"
+        );
+        assert_eq!(
+            http_signal_endpoint("http://c:4318", "/v1/metrics"),
+            "http://c:4318/v1/metrics"
+        );
     }
 
     #[test]
     fn record_otel_error_classifies_signal_by_target() {
-        assert_eq!(otel_signal_label("opentelemetry_sdk::metrics::periodic_reader"), "metrics");
-        assert_eq!(otel_signal_label("opentelemetry_sdk::trace::span_processor"), "traces");
+        assert_eq!(
+            otel_signal_label("opentelemetry_sdk::metrics::periodic_reader"),
+            "metrics"
+        );
+        assert_eq!(
+            otel_signal_label("opentelemetry_sdk::trace::span_processor"),
+            "traces"
+        );
         assert_eq!(otel_signal_label("opentelemetry_otlp::exporter"), "export");
         assert_eq!(otel_signal_label("opentelemetry"), "export");
     }

--- a/crates/core/src/observability/otel.rs
+++ b/crates/core/src/observability/otel.rs
@@ -129,9 +129,72 @@ impl OtelConfig {
     }
 }
 
+/// Map an `opentelemetry*` tracing event target to a `signal` label for the
+/// `faucet_otel_export_failures_total` counter. Pure — unit-testable without a
+/// tracing `Context`.
+pub(crate) fn otel_signal_label(target: &str) -> &'static str {
+    if target.contains("metric") {
+        "metrics"
+    } else if target.contains("trace") || target.contains("span") {
+        "traces"
+    } else {
+        "export"
+    }
+}
+
+/// Register HELP text for the OTLP export metric. Called from
+/// `install_observability` (a `describe!` into a not-yet-installed recorder is a
+/// no-op, so ordering is forgiving).
+pub fn describe() {
+    metrics::describe_counter!(
+        "faucet_otel_export_failures_total",
+        "OTLP export attempts that failed (collector unreachable, serialization error, etc.)."
+    );
+}
+
+#[cfg(feature = "otel")]
+mod layer {
+    use super::otel_signal_label;
+    use tracing::{Event, Level, Subscriber};
+    use tracing_subscriber::layer::{Context, Layer};
+
+    /// A `tracing` layer that counts ERROR/WARN events emitted by the
+    /// opentelemetry SDK (its only error channel in the 0.31 line, since
+    /// `global::set_error_handler` was removed) into
+    /// `faucet_otel_export_failures_total{signal}`.
+    pub struct OtelErrorCountLayer;
+
+    impl<S: Subscriber> Layer<S> for OtelErrorCountLayer {
+        fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+            let meta = event.metadata();
+            let target = meta.target();
+            if target.starts_with("opentelemetry")
+                && matches!(*meta.level(), Level::ERROR | Level::WARN)
+            {
+                metrics::counter!(
+                    "faucet_otel_export_failures_total",
+                    "signal" => otel_signal_label(target),
+                )
+                .increment(1);
+            }
+        }
+    }
+}
+
+#[cfg(feature = "otel")]
+pub use layer::OtelErrorCountLayer;
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn record_otel_error_classifies_signal_by_target() {
+        assert_eq!(otel_signal_label("opentelemetry_sdk::metrics::periodic_reader"), "metrics");
+        assert_eq!(otel_signal_label("opentelemetry_sdk::trace::span_processor"), "traces");
+        assert_eq!(otel_signal_label("opentelemetry_otlp::exporter"), "export");
+        assert_eq!(otel_signal_label("opentelemetry"), "export");
+    }
 
     #[test]
     fn config_defaults_are_applied_from_empty_yaml() {

--- a/crates/core/src/observability/otel.rs
+++ b/crates/core/src/observability/otel.rs
@@ -333,6 +333,45 @@ mod tests {
     use super::*;
 
     #[cfg(feature = "otel")]
+    #[test]
+    fn error_layer_increments_export_failures_counter() {
+        // Validates the failure-isolation acceptance criterion end-to-end: an
+        // ERROR event from an `opentelemetry*` target, routed through
+        // `OtelErrorCountLayer`, bumps `faucet_otel_export_failures_total` with
+        // the classified `signal` label. Reuses the crate-wide shared debugging
+        // recorder + LOCK (same pattern as the decorator metric tests).
+        use crate::observability::decorator::source_tests::{LOCK, snapshotter};
+        use metrics_util::debugging::DebugValue;
+        use tracing_subscriber::layer::SubscriberExt;
+
+        let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let snap = snapshotter();
+
+        let subscriber = tracing_subscriber::registry().with(OtelErrorCountLayer);
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::error!(
+                target: "opentelemetry_sdk::metrics::periodic_reader",
+                "simulated export failure"
+            );
+        });
+
+        let found = snap.snapshot().into_vec().into_iter().any(
+            |(key, _u, _d, v): (metrics_util::CompositeKey, _, _, _)| {
+                key.key().name() == "faucet_otel_export_failures_total"
+                    && key
+                        .key()
+                        .labels()
+                        .any(|l: &metrics::Label| l.key() == "signal" && l.value() == "metrics")
+                    && matches!(v, DebugValue::Counter(c) if c >= 1)
+            },
+        );
+        assert!(
+            found,
+            "OtelErrorCountLayer must increment faucet_otel_export_failures_total{{signal=metrics}}"
+        );
+    }
+
+    #[cfg(feature = "otel")]
     #[tokio::test]
     async fn build_providers_construct_without_a_live_collector() {
         let cfg = OtelConfig {

--- a/crates/core/src/observability/otel.rs
+++ b/crates/core/src/observability/otel.rs
@@ -184,9 +184,148 @@ mod layer {
 #[cfg(feature = "otel")]
 pub use layer::OtelErrorCountLayer;
 
+#[cfg(feature = "otel")]
+mod sdk {
+    use super::{OtelConfig, OtelProtocol};
+    use opentelemetry_otlp::{WithExportConfig, WithHttpConfig};
+    use opentelemetry_sdk::Resource;
+    use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
+    use opentelemetry_sdk::trace::{Sampler, SdkTracerProvider};
+    use std::sync::OnceLock;
+    use std::time::Duration;
+
+    pub type OtelError = Box<dyn std::error::Error + Send + Sync>;
+
+    fn resource(cfg: &OtelConfig) -> Resource {
+        Resource::builder()
+            .with_service_name(cfg.service_name.clone())
+            .build()
+    }
+
+    fn header_map(cfg: &OtelConfig) -> std::collections::HashMap<String, String> {
+        cfg.headers.clone()
+    }
+
+    /// Build a batch-exporting tracer provider. NOTE: with grpc-tonic this MUST
+    /// be called inside a tokio runtime (the CLI is `#[tokio::main]`).
+    pub fn build_trace_provider(cfg: &OtelConfig) -> Result<SdkTracerProvider, OtelError> {
+        let endpoint = cfg.resolve_endpoint();
+        let timeout = Duration::from_secs(cfg.timeout_secs);
+        let exporter = match cfg.protocol {
+            OtelProtocol::Grpc => opentelemetry_otlp::SpanExporter::builder()
+                .with_tonic()
+                .with_endpoint(&endpoint)
+                .with_timeout(timeout)
+                .build()?,
+            OtelProtocol::Http => opentelemetry_otlp::SpanExporter::builder()
+                .with_http()
+                .with_endpoint(&endpoint)
+                .with_headers(header_map(cfg))
+                .with_timeout(timeout)
+                .build()?,
+        };
+        let provider = SdkTracerProvider::builder()
+            .with_batch_exporter(exporter)
+            .with_sampler(Sampler::TraceIdRatioBased(cfg.sample_ratio))
+            .with_resource(resource(cfg))
+            .build();
+        Ok(provider)
+    }
+
+    /// Build a NON-global metrics recorder bridging the `metrics` facade to an
+    /// OTLP PeriodicReader, plus its meter provider (kept alive by the caller).
+    pub fn build_meter_provider(
+        cfg: &OtelConfig,
+    ) -> Result<(SdkMeterProvider, metrics_exporter_opentelemetry::Recorder), OtelError> {
+        let endpoint = cfg.resolve_endpoint();
+        let timeout = Duration::from_secs(cfg.timeout_secs);
+        let exporter = match cfg.protocol {
+            OtelProtocol::Grpc => opentelemetry_otlp::MetricExporter::builder()
+                .with_tonic()
+                .with_endpoint(&endpoint)
+                .with_timeout(timeout)
+                .build()?,
+            OtelProtocol::Http => opentelemetry_otlp::MetricExporter::builder()
+                .with_http()
+                .with_endpoint(&endpoint)
+                .with_headers(header_map(cfg))
+                .with_timeout(timeout)
+                .build()?,
+        };
+        let reader = PeriodicReader::builder(exporter)
+            .with_interval(Duration::from_secs(cfg.metric_interval_secs))
+            .build();
+        let res = resource(cfg);
+        let (provider, recorder) =
+            metrics_exporter_opentelemetry::Recorder::builder(cfg.service_name.clone())
+                .with_meter_provider(move |mb| mb.with_reader(reader).with_resource(res))
+                .build();
+        Ok((provider, recorder))
+    }
+
+    pub struct OtelGuard {
+        pub tracer: Option<SdkTracerProvider>,
+        pub meter: Option<SdkMeterProvider>,
+    }
+
+    static GUARD: OnceLock<OtelGuard> = OnceLock::new();
+
+    /// Store providers for the process lifetime. Returns false if already set.
+    pub fn set_guard(guard: OtelGuard) -> bool {
+        GUARD.set(guard).is_ok()
+    }
+
+    /// Flush + shut down installed providers. Idempotent.
+    pub fn shutdown_otel() {
+        if let Some(g) = GUARD.get() {
+            if let Some(t) = g.tracer.as_ref() {
+                let _ = t.force_flush();
+                let _ = t.shutdown();
+            }
+            if let Some(m) = g.meter.as_ref() {
+                let _ = m.force_flush();
+                let _ = m.shutdown();
+            }
+        }
+    }
+
+    /// Install the W3C trace-context propagator globally (#230 groundwork).
+    pub fn install_propagator() {
+        use opentelemetry_sdk::propagation::TraceContextPropagator;
+        opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
+    }
+}
+
+#[cfg(feature = "otel")]
+pub use sdk::{
+    OtelError, OtelGuard, build_meter_provider, build_trace_provider, install_propagator,
+    set_guard, shutdown_otel,
+};
+
+/// No-op `shutdown_otel` when the `otel` feature is disabled, so CLI call sites
+/// compile in every build.
+#[cfg(not(feature = "otel"))]
+pub fn shutdown_otel() {}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(feature = "otel")]
+    #[tokio::test]
+    async fn build_providers_construct_without_a_live_collector() {
+        let cfg = OtelConfig {
+            endpoint: "http://localhost:4317".into(),
+            protocol: OtelProtocol::Grpc,
+            ..Default::default()
+        };
+        let tp = build_trace_provider(&cfg).expect("trace provider builds");
+        let (mp, _recorder) = build_meter_provider(&cfg).expect("meter provider builds");
+        let _ = tp.force_flush();
+        let _ = mp.force_flush();
+        let _ = tp.shutdown();
+        let _ = mp.shutdown();
+    }
 
     #[test]
     fn record_otel_error_classifies_signal_by_target() {

--- a/crates/core/src/observability/otel.rs
+++ b/crates/core/src/observability/otel.rs
@@ -4,10 +4,11 @@
 //! compile unconditionally. Everything that touches the OTel SDK is gated on
 //! `#[cfg(feature = "otel")]` further down this file.
 
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// OTLP transport protocol.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum OtelProtocol {
     /// gRPC over tonic (default OTLP port 4317). Must be initialised inside a
@@ -19,7 +20,7 @@ pub enum OtelProtocol {
 }
 
 /// A telemetry signal that can be exported over OTLP.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum OtelSignal {
     Traces,

--- a/crates/core/src/observability/otel.rs
+++ b/crates/core/src/observability/otel.rs
@@ -129,6 +129,19 @@ impl OtelConfig {
     }
 }
 
+/// opentelemetry-otlp uses a programmatic HTTP endpoint verbatim (it only
+/// appends the per-signal path for the `OTEL_EXPORTER_OTLP_ENDPOINT` env-var
+/// form). Users naturally configure the base endpoint, so for HTTP we append the
+/// conventional per-signal path ourselves when it is not already present.
+pub(crate) fn http_signal_endpoint(base: &str, signal_path: &str) -> String {
+    let trimmed = base.trim_end_matches('/');
+    if trimmed.ends_with(signal_path) {
+        trimmed.to_string()
+    } else {
+        format!("{trimmed}{signal_path}")
+    }
+}
+
 /// Map an `opentelemetry*` tracing event target to a `signal` label for the
 /// `faucet_otel_export_failures_total` counter. Pure — unit-testable without a
 /// tracing `Context`.
@@ -219,7 +232,7 @@ mod sdk {
                 .build()?,
             OtelProtocol::Http => opentelemetry_otlp::SpanExporter::builder()
                 .with_http()
-                .with_endpoint(&endpoint)
+                .with_endpoint(super::http_signal_endpoint(&endpoint, "/v1/traces"))
                 .with_headers(header_map(cfg))
                 .with_timeout(timeout)
                 .build()?,
@@ -247,7 +260,7 @@ mod sdk {
                 .build()?,
             OtelProtocol::Http => opentelemetry_otlp::MetricExporter::builder()
                 .with_http()
-                .with_endpoint(&endpoint)
+                .with_endpoint(super::http_signal_endpoint(&endpoint, "/v1/metrics"))
                 .with_headers(header_map(cfg))
                 .with_timeout(timeout)
                 .build()?,
@@ -325,6 +338,15 @@ mod tests {
         let _ = mp.force_flush();
         let _ = tp.shutdown();
         let _ = mp.shutdown();
+    }
+
+    #[test]
+    fn http_signal_endpoint_appends_path_when_absent() {
+        assert_eq!(http_signal_endpoint("http://c:4318", "/v1/traces"), "http://c:4318/v1/traces");
+        assert_eq!(http_signal_endpoint("http://c:4318/", "/v1/traces"), "http://c:4318/v1/traces");
+        // idempotent: already has the path
+        assert_eq!(http_signal_endpoint("http://c:4318/v1/traces", "/v1/traces"), "http://c:4318/v1/traces");
+        assert_eq!(http_signal_endpoint("http://c:4318", "/v1/metrics"), "http://c:4318/v1/metrics");
     }
 
     #[test]

--- a/crates/core/tests/otel.rs
+++ b/crates/core/tests/otel.rs
@@ -6,9 +6,10 @@
 //! Note on endpoint handling: opentelemetry-otlp 0.31's HTTP exporter uses a
 //! programmatically supplied `.with_endpoint(...)` value **verbatim** — unlike
 //! the `OTEL_EXPORTER_OTLP_ENDPOINT` env var, it does NOT append the standard
-//! `/v1/traces` / `/v1/metrics` signal path. So we point each provider's config
-//! at its full per-signal URL (a valid real-world OTLP/HTTP configuration) and
-//! register the mock at exactly those paths.
+//! `/v1/traces` / `/v1/metrics` signal path. `http_signal_endpoint` in `otel.rs`
+//! corrects this by appending the per-signal path when it is absent, so a
+//! conventional bare base endpoint (e.g. `http://collector:4318`) reaches the
+//! right route on the collector. This test uses the bare base to prove that.
 
 use axum::{Router, body::Bytes, extract::State, routing::post};
 use faucet_core::observability::otel::{
@@ -50,28 +51,24 @@ async fn spans_and_metrics_reach_collector() {
         axum::serve(listener, app).await.unwrap();
     });
 
-    // Traces: emit a span, force-flush.
-    let trace_cfg = OtelConfig {
-        endpoint: format!("http://{addr}/v1/traces"),
+    // Both providers use the bare base endpoint — the fix appends /v1/traces and
+    // /v1/metrics respectively so requests reach the correct mock routes.
+    let cfg = OtelConfig {
+        endpoint: format!("http://{addr}"),
         protocol: OtelProtocol::Http,
         export: vec![OtelSignal::Traces, OtelSignal::Metrics],
         metric_interval_secs: 1,
         ..Default::default()
     };
-    let tp = build_trace_provider(&trace_cfg).unwrap();
+
+    // Traces: emit a span, force-flush.
+    let tp = build_trace_provider(&cfg).unwrap();
     let tracer = tp.tracer("test");
     tracer.in_span("unit-span", |_cx| {});
     let _ = tp.force_flush();
 
     // Metrics: record through the bridged recorder locally (not global), flush.
-    let metric_cfg = OtelConfig {
-        endpoint: format!("http://{addr}/v1/metrics"),
-        protocol: OtelProtocol::Http,
-        export: vec![OtelSignal::Traces, OtelSignal::Metrics],
-        metric_interval_secs: 1,
-        ..Default::default()
-    };
-    let (mp, recorder) = build_meter_provider(&metric_cfg).unwrap();
+    let (mp, recorder) = build_meter_provider(&cfg).unwrap();
     metrics::with_local_recorder(&recorder, || {
         metrics::counter!("faucet_test_counter").increment(1);
     });

--- a/crates/core/tests/otel.rs
+++ b/crates/core/tests/otel.rs
@@ -1,0 +1,99 @@
+#![cfg(feature = "otel")]
+//! Integration test: drive the isolated OTLP provider builders against an
+//! in-process axum mock OTLP/HTTP collector and assert both signals arrive —
+//! WITHOUT touching the global recorder/subscriber.
+//!
+//! Note on endpoint handling: opentelemetry-otlp 0.31's HTTP exporter uses a
+//! programmatically supplied `.with_endpoint(...)` value **verbatim** — unlike
+//! the `OTEL_EXPORTER_OTLP_ENDPOINT` env var, it does NOT append the standard
+//! `/v1/traces` / `/v1/metrics` signal path. So we point each provider's config
+//! at its full per-signal URL (a valid real-world OTLP/HTTP configuration) and
+//! register the mock at exactly those paths.
+
+use axum::{Router, body::Bytes, extract::State, routing::post};
+use faucet_core::observability::otel::{
+    OtelConfig, OtelProtocol, OtelSignal, build_meter_provider, build_trace_provider,
+};
+use opentelemetry::trace::{Tracer, TracerProvider as _};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+#[derive(Clone, Default)]
+struct Hits {
+    traces: Arc<AtomicUsize>,
+    metrics: Arc<AtomicUsize>,
+}
+
+async fn traces_handler(State(h): State<Hits>, body: Bytes) {
+    if !body.is_empty() {
+        h.traces.fetch_add(1, Ordering::SeqCst);
+    }
+}
+async fn metrics_handler(State(h): State<Hits>, body: Bytes) {
+    if !body.is_empty() {
+        h.metrics.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn spans_and_metrics_reach_collector() {
+    let hits = Hits::default();
+    let app = Router::new()
+        .route("/v1/traces", post(traces_handler))
+        .route("/v1/metrics", post(metrics_handler))
+        .with_state(hits.clone());
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    // Traces: emit a span, force-flush.
+    let trace_cfg = OtelConfig {
+        endpoint: format!("http://{addr}/v1/traces"),
+        protocol: OtelProtocol::Http,
+        export: vec![OtelSignal::Traces, OtelSignal::Metrics],
+        metric_interval_secs: 1,
+        ..Default::default()
+    };
+    let tp = build_trace_provider(&trace_cfg).unwrap();
+    let tracer = tp.tracer("test");
+    tracer.in_span("unit-span", |_cx| {});
+    let _ = tp.force_flush();
+
+    // Metrics: record through the bridged recorder locally (not global), flush.
+    let metric_cfg = OtelConfig {
+        endpoint: format!("http://{addr}/v1/metrics"),
+        protocol: OtelProtocol::Http,
+        export: vec![OtelSignal::Traces, OtelSignal::Metrics],
+        metric_interval_secs: 1,
+        ..Default::default()
+    };
+    let (mp, recorder) = build_meter_provider(&metric_cfg).unwrap();
+    metrics::with_local_recorder(&recorder, || {
+        metrics::counter!("faucet_test_counter").increment(1);
+    });
+    let _ = mp.force_flush();
+
+    // Allow the async HTTP exports to land.
+    for _ in 0..50 {
+        if hits.traces.load(Ordering::SeqCst) > 0 && hits.metrics.load(Ordering::SeqCst) > 0 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    assert!(
+        hits.traces.load(Ordering::SeqCst) > 0,
+        "no trace export received"
+    );
+    assert!(
+        hits.metrics.load(Ordering::SeqCst) > 0,
+        "no metric export received"
+    );
+
+    let _ = tp.shutdown();
+    let _ = mp.shutdown();
+}

--- a/docs/book/src/operations/observability.md
+++ b/docs/book/src/operations/observability.md
@@ -59,3 +59,55 @@ Spans carry `run_id`, `pipeline`, `row`, and per-operation timing. Point a
 `--log-level` or `FAUCET_LOG`.
 
 > Full design: `docs/superpowers/specs/2026-05-23-observability-otel-prometheus-design.md`.
+
+## OTLP / OpenTelemetry export
+
+The `otel` feature pushes traces **and** metrics to any OTLP-compatible
+collector (Jaeger, Grafana Tempo, Honeycomb, Datadog, the OpenTelemetry
+Collector, etc.) alongside — not instead of — the Prometheus endpoint. Build
+the CLI with `cargo install faucet-cli --features otel`; the feature is
+included in the `full` aggregate. Enable it in your pipeline config with an
+`otel:` sub-block under the existing `observability:` key:
+
+```yaml
+observability:
+  prometheus:
+    listen: "0.0.0.0:9090"
+  otel:
+    endpoint: "https://api.honeycomb.io"
+    protocol: grpc                        # grpc (default) | http
+    headers:
+      x-honeycomb-team: "${env:HONEYCOMB_KEY}"
+    sample_ratio: 0.1                     # head-based; 1.0 = keep all traces
+    export: [traces, metrics]             # which signals to push
+    service_name: faucet                  # OTel resource service.name
+    timeout_secs: 10
+    metric_interval_secs: 60
+```
+
+The `observability.prometheus:` and `observability.otel:` blocks coexist
+independently — both can be active in the same run and metrics are fanned out
+to both exporters.
+
+**Protocol notes:**
+
+- `grpc` uses `tonic` (the default). The `faucet` CLI always runs inside a
+  tokio runtime, so gRPC works without any extra setup.
+- `http` uses HTTP/Protobuf. When `endpoint` does not already end in a
+  per-signal path (`/v1/traces`, `/v1/metrics`), faucet appends it
+  automatically — point `endpoint` at the base URL of the collector (e.g.
+  `http://localhost:4318`) and the right path is added per signal.
+
+**Reliability:** export is best-effort. An unreachable or slow collector
+**never** fails or delays a pipeline run. Export failures increment
+`faucet_otel_export_failures_total{signal}` so you can alert on a broken
+pipeline to your observability backend.
+
+See `examples/infra/otel-collector.yaml` for a minimal local collector config
+you can run with `otelcol --config examples/infra/otel-collector.yaml`.
+
+### OTLP metrics
+
+| Metric | Labels | Description |
+|--------|--------|-------------|
+| `faucet_otel_export_failures_total` | `signal` (`traces`/`metrics`/`export`) | OTLP export attempts that failed. Failures are non-fatal; the pipeline continues. |

--- a/docs/book/src/reference/config.md
+++ b/docs/book/src/reference/config.md
@@ -534,6 +534,46 @@ See the [Lineage cookbook](../cookbook/lineage.md) for the full field reference,
 transports (HTTP, file, Kafka), the column-lineage support matrix, schema-facet behavior, and
 the Prometheus metrics (`faucet_lineage_events_total`, etc.).
 
+## `observability`
+
+Optional top-level block that enables runtime observability backends. All
+sub-blocks are independently optional; omitting the entire `observability:` key
+leaves the defaults (no Prometheus server, no OTLP export).
+
+### `otel:`
+
+Pushes traces and metrics to any OTLP-compatible collector. Requires building
+the CLI with `--features otel` (included in `full`).
+
+```yaml
+observability:
+  otel:
+    endpoint: "http://localhost:4317"
+    protocol: grpc
+    headers: {}
+    sample_ratio: 1.0
+    export: [traces, metrics]
+    service_name: faucet
+    timeout_secs: 10
+    metric_interval_secs: 60
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `endpoint` | string | `http://localhost:4317` (grpc) / `http://localhost:4318` (http) | OTLP collector URL. For `http`, if the URL does not already contain a per-signal path (`/v1/traces`, `/v1/metrics`), faucet appends it automatically. |
+| `protocol` | `grpc` \| `http` | `grpc` | Transport protocol. `grpc` uses tonic; `http` uses HTTP/Protobuf. The `faucet` CLI always runs inside a tokio runtime, so both work without extra setup. |
+| `headers` | map&lt;string, string&gt; | `{}` | Extra headers sent on every export request — auth tokens, team keys, etc. Values are secret-interpolated the same as any config value (e.g. `"${env:HONEYCOMB_KEY}"`). |
+| `sample_ratio` | float | `1.0` | Head-based trace sampling probability, `0.0`–`1.0`. `1.0` exports every trace; `0.1` keeps ~10%. Does not affect metric export. |
+| `export` | list | `[traces, metrics]` | Which signals to push. Each element is `traces` or `metrics`. Omit a signal to disable it entirely. |
+| `service_name` | string | `faucet` | Value of the OpenTelemetry resource attribute `service.name` attached to every span and metric point. |
+| `timeout_secs` | integer | `10` | Per-export timeout in seconds. Timed-out exports are counted in `faucet_otel_export_failures_total` but do not fail the run. |
+| `metric_interval_secs` | integer | `60` | How often (in seconds) accumulated metric points are pushed to the collector. |
+
+**Coexistence:** `observability.otel:` and `observability.prometheus:` are
+fully independent; both can be active at the same time and metrics fan out to
+both exporters. Export failures are never propagated to the pipeline — they
+increment `faucet_otel_export_failures_total{signal}` and are logged.
+
 ## Discovery & env files
 
 `run` / `validate` / `preview` / `schedule` auto-discover `faucet.yaml` → `.yml` → `.json` in

--- a/examples/README.md
+++ b/examples/README.md
@@ -84,6 +84,12 @@ files as each config shows:
 `postgres_to_bigquery.yaml`, `rest_to_bigquery.yaml`, `s3_to_bigquery.yaml`,
 `mysql_to_snowflake.yaml`, `postgres_to_snowflake.yaml`, `s3_to_snowflake.yaml`.
 
+## OTLP / OpenTelemetry export
+
+| File | Notes |
+|------|-------|
+| `examples/infra/otel-collector.yaml` | OTLP collector for testing `observability.otel` export (build the CLI with `--features otel`). Run with `otelcol --config examples/infra/otel-collector.yaml` to receive traces and metrics on gRPC `:4317` and HTTP `:4318`. |
+
 ## OpenLineage emission
 
 | Example | Notes |

--- a/examples/infra/otel-collector.yaml
+++ b/examples/infra/otel-collector.yaml
@@ -1,0 +1,22 @@
+# Minimal OpenTelemetry Collector config for local testing of `faucet`'s OTLP
+# export. Run: otelcol --config examples/infra/otel-collector.yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+exporters:
+  debug:
+    verbosity: detailed
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [debug]
+    metrics:
+      receivers: [otlp]
+      exporters: [debug]


### PR DESCRIPTION
Adds opt-in **OTLP export** of faucet's existing `tracing` spans and `metrics`, pushed to any OTLP collector (Tempo, Jaeger, Honeycomb, Datadog, Grafana Cloud) **alongside** the Prometheus scrape endpoint — neither replaces the other.

Closes #201. Closes #258. Roadmap epic #38.

## What's added
- **`faucet-core` `otel` feature** pulling the OpenTelemetry **0.31-line** stack (compatibility-locked by `metrics-exporter-opentelemetry =0.2.1`, which pins `opentelemetry`/`opentelemetry_sdk ^0.31`; `tracing-opentelemetry 0.32.1`). **CLI `otel` feature** forwards to it — opt-in, in `full`, not `default`.
- **`observability.otel:` config block**: `endpoint`, `protocol` (`grpc`|`http`), `headers`, `sample_ratio`, `export` (`[traces, metrics]`), `service_name`, `timeout_secs`, `metric_interval_secs` — validated at config-load (`faucet validate`).
- **Metrics** install a `metrics-util` fanout recorder so **Prometheus and OTLP coexist**; **traces** via a `tracing-opentelemetry` layer. Both wired into the single idempotent `install_observability`.
- **Export never fails a run** — the SDK's async exporters swallow collector outages; failures are counted in `faucet_otel_export_failures_total{signal}` (captured via a tracing layer, since `global::set_error_handler` was removed in 0.31).
- **W3C `TraceContextPropagator`** installed for future clustered tracing (#230).
- **Graceful flush** (`shutdown_otel()`) on the `run` / `replicate` / `schedule` / `serve` exit paths.

## Why #258 is closed here
opentelemetry-otlp 0.31 uses a programmatic HTTP endpoint **verbatim** (no `/v1/traces` append), so a user setting the conventional base `endpoint: http://collector:4318` would silently drop telemetry. Per the project's "complete a picked feature" rule this is the unfinished tail of #201, not a follow-up — fixed by auto-appending the per-signal path for HTTP.

## Testing
- Unit: config defaults, endpoint resolution, validation, the metrics-mode decision fn, the export-failure classifier, the HTTP path-append.
- Integration (`crates/core/tests/otel.rs`): drives the isolated provider builders against an in-process **axum mock OTLP/HTTP collector** with a **bare base endpoint** and asserts both spans and metrics arrive — without touching the global recorder/subscriber.

## Docs
`operations/observability.md` (OTLP section + new metric), `reference/config.md` (field table), `examples/infra/otel-collector.yaml`, plus the 0.31 dependency-lock note.