### PR TITLE
feat(sink-iceberg): opt-in orphan cleanup on definitive commit failure (#193)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3419,6 +3419,7 @@ dependencies = [
  "async-trait",
  "aws-config",
  "aws-sdk-s3",
+ "bytes",
  "faucet-core",
  "futures",
  "iceberg",

--- a/crates/sink/iceberg/Cargo.toml
+++ b/crates/sink/iceberg/Cargo.toml
@@ -45,6 +45,7 @@ typetag = { version = "0.2", optional = true }
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time", "test-util"] }
 tempfile = "3"
+bytes = "1"
 iceberg = "0.9.1"
 iceberg-catalog-sql = "0.9.1"
 # sqlx runtime-tokio must be enabled explicitly here because iceberg-catalog-sql's

--- a/crates/sink/iceberg/README.md
+++ b/crates/sink/iceberg/README.md
@@ -93,6 +93,7 @@ faucet run pipeline.yaml
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `batch_size` | int | `10000` | Records buffered in memory before each Arrow write pass. **`0` = no limit** (the entire upstream page is written in one batch). Validated against `MAX_BATCH_SIZE` (1,000,000). |
+| `cleanup_orphans_on_failure` | bool | `false` | Delete the data files a flush already uploaded when the snapshot commit **definitively** fails, so they don't accumulate as orphans. Ambiguous failures are never cleaned up. See [Concurrent writers & orphaned files](#concurrent-writers--commit-conflict-retry). |
 
 ### Catalog config
 
@@ -213,7 +214,31 @@ The pipeline calls `Sink::write_batch` for each `StreamPage`, then `flush()` onc
 
 For high-throughput pipelines, use a large **upstream** `batch_size` (e.g. `100000`) so the snapshot amortises catalog-commit overhead across many rows, and leave the sink's `batch_size` near its default so Arrow batches stay within memory limits.
 
-`flush()` does two things in sequence: (1) closes the Parquet data file (writes the footer, uploads it), then (2) commits the snapshot via `Transaction::fast_append`. If step 2 fails (e.g. an unresolvable optimistic-concurrency conflict), the data files from step 1 are already in storage but referenced by no snapshot — they are **orphaned**. The error propagates, the run aborts, and the bookmark does not advance; the re-run writes fresh files and commits them. The sink does **not** auto-delete on failure (re-committing after an ambiguous commit could duplicate data); run Iceberg's standard `remove_orphan_files` maintenance to reclaim them.
+`flush()` does two things in sequence: (1) closes the Parquet data file (writes the footer, uploads it), then (2) commits the snapshot via `Transaction::fast_append`.
+
+### Concurrent writers & commit-conflict retry
+
+Iceberg commits use optimistic concurrency. If a competing writer commits between this sink's table load and its commit, `Transaction::commit` (iceberg-rust 0.9.1) **transparently retries**: it reloads the table metadata and re-applies the `fast_append` against the latest snapshot — *without re-uploading the data files* — with exponential backoff. A benign concurrent write therefore does **not** abort the run. Tune the retry budget with the standard Iceberg `commit.retry.*` table properties, set via `snapshot_properties` at table creation:
+
+```yaml
+snapshot_properties:
+  commit.retry.num-retries: "8"        # default 4
+  commit.retry.min-wait-ms: "100"
+  commit.retry.max-wait-ms: "60000"
+  commit.retry.total-timeout-ms: "1800000"
+```
+
+### Orphaned data files on a definitive commit failure
+
+If the commit *definitively* fails after those retries are exhausted (a competing writer won), the data files from step 1 are already in storage but referenced by no snapshot — they are **orphaned**. The error propagates, the run aborts, and the bookmark does not advance; the re-run writes fresh files and commits them.
+
+By default the sink leaves orphans in place — reclaim them with Iceberg's standard `remove_orphan_files` maintenance. Set **`cleanup_orphans_on_failure: true`** to delete them automatically:
+
+```yaml
+cleanup_orphans_on_failure: true   # default false
+```
+
+Cleanup runs **only** on a *definitive* loss (an exhausted commit conflict, or a catalog-rejected commit). An **ambiguous** failure — e.g. a network error on the catalog update where the commit may have landed server-side — is **never** cleaned up regardless of this flag, because deleting then could remove files a successful-but-unacknowledged commit references. The data files this sink writes have unique (UUID-based) names, so cleanup can never remove a file a concurrent writer references.
 
 ## Write mode (append-only)
 
@@ -343,7 +368,7 @@ In the CLI/umbrella, the corresponding feature is `sink-iceberg` (REST), with `s
 | `unknown variant 'overwrite'` / `write_mode … rejected` | Only `append` is supported. `upsert`/`delete` parse but are rejected at `new()`; `overwrite` is not a variant. See [Write mode](#write-mode-append-only). |
 | Catalog type fails at startup despite a valid config | The catalog's Cargo feature isn't compiled in. Rebuild with `--features catalog-glue` (or `-sql` / `-hms`) — `catalog-rest` is the only one in the default build. |
 | `faucet doctor` catalog probe times out / fails | Verify the catalog URI, credentials, and network reachability. The probe calls `table_exists` and is bounded by `--timeout-secs`. |
-| Data files exist in object storage but no snapshot references them | A commit failed after the Parquet file was uploaded (orphaned files). Re-run to write fresh files; reclaim orphans with Iceberg's `remove_orphan_files` maintenance. The sink never auto-deletes (avoids duplicating data). |
+| Data files exist in object storage but no snapshot references them | A commit failed *definitively* after the Parquet file was uploaded (orphaned files). Re-run to write fresh files. Reclaim orphans with Iceberg's `remove_orphan_files` maintenance, or set `cleanup_orphans_on_failure: true` to delete them automatically on a definitive failure (ambiguous failures are never auto-deleted). |
 | `partition_spec[…].transform … is not a recognised Iceberg transform` | Use one of `identity`/`year`/`month`/`day`/`hour`/`void` or `bucket[N]`/`truncate[N]` with a positive `N`. |
 | `target_file_size_mb must be > 0` | `0` would roll a tiny file per batch. Use a positive MB target (default `256`). |
 | Partition spec seems ignored | `partition_spec` only applies when **creating** a new table (`create_if_missing: true`). An existing table keeps its own spec. |

--- a/crates/sink/iceberg/src/config.rs
+++ b/crates/sink/iceberg/src/config.rs
@@ -274,6 +274,31 @@ pub struct IcebergSinkConfig {
     /// iceberg writer pipeline. `0` = no limit (single batch). Default: 10 000.
     #[serde(default = "default_batch_size")]
     pub batch_size: usize,
+
+    /// Delete the Parquet data files this flush already uploaded when the
+    /// snapshot commit *definitively* fails, so they do not accumulate as
+    /// orphans.
+    ///
+    /// Iceberg commits use optimistic concurrency: the data files are written
+    /// to object storage *before* the snapshot commit. iceberg-rust already
+    /// retries retryable commit conflicts internally (reloading table metadata
+    /// and re-applying the append against the latest snapshot — tunable via the
+    /// standard `commit.retry.*` table properties). If those retries are
+    /// exhausted (a competing writer won) the just-written files are orphaned —
+    /// valid Parquet, but referenced by no snapshot.
+    ///
+    /// With this flag set, such orphans are deleted automatically on a
+    /// **definitive** loss (an exhausted commit conflict, or a catalog-rejected
+    /// commit). An **ambiguous** failure — e.g. a network error on the catalog
+    /// update where the commit may have landed server-side — is *never* cleaned
+    /// up regardless of this flag, because deleting then could remove files a
+    /// successful-but-unacknowledged commit references.
+    ///
+    /// Default `false`: leave orphans in place (recoverable later via Iceberg's
+    /// standard `remove_orphan_files` maintenance) so cleanup is an explicit,
+    /// opt-in choice.
+    #[serde(default)]
+    pub cleanup_orphans_on_failure: bool,
 }
 
 fn default_create_if_missing() -> bool {

--- a/crates/sink/iceberg/src/sink.rs
+++ b/crates/sink/iceberg/src/sink.rs
@@ -11,16 +11,31 @@
 //! as an Iceberg snapshot. The pipeline (via `faucet-core`) calls `flush()`
 //! automatically at the end of each `StreamPage`.
 //!
-//! ## Commit failure
+//! ## Commit failure & conflict handling
 //!
-//! If the snapshot commit itself fails (after iceberg's internal retry of
-//! retryable conflicts), the already-uploaded data files are orphaned — written
-//! to object storage but never referenced by any snapshot. The error
-//! propagates so the run aborts without advancing the bookmark; the re-run
-//! writes fresh files and commits them. Orphaned files accumulate until you run
-//! Iceberg's standard `remove_orphan_files` maintenance (e.g. via Spark /
-//! pyiceberg). The sink does **not** auto-delete on failure (re-committing
-//! after an ambiguous commit could duplicate data).
+//! Iceberg commits use optimistic concurrency. `Transaction::commit` in
+//! iceberg-rust 0.9.1 already handles benign races: on a retryable conflict it
+//! reloads the table metadata and re-applies the `fast_append` against the
+//! latest snapshot **without re-uploading the data files**, retrying with
+//! exponential backoff. The retry budget is tunable via the standard
+//! `commit.retry.*` table properties (e.g. `commit.retry.num-retries`), which
+//! can be set through [`IcebergSinkConfig::snapshot_properties`] at table
+//! creation. So a concurrent writer that commits between our load and our
+//! commit does **not** abort the run — it is transparently retried.
+//!
+//! If the commit *definitively* fails after those retries are exhausted (a
+//! competing writer won), the already-uploaded data files are orphaned —
+//! written to object storage but never referenced by any snapshot. By default
+//! the error propagates so the run aborts without advancing the bookmark, and
+//! the orphans remain until you run Iceberg's standard `remove_orphan_files`
+//! maintenance (e.g. via Spark / pyiceberg).
+//!
+//! Set [`IcebergSinkConfig::cleanup_orphans_on_failure`] to delete those
+//! orphans automatically. Cleanup runs **only** on a definitive loss
+//! (`CatalogCommitConflicts` / `DataInvalid`); an *ambiguous* failure
+//! (`Unexpected` / transport error, where the commit may have landed
+//! server-side) is never cleaned up, because deleting then could remove files a
+//! successful-but-unacknowledged commit references.
 //!
 //! ## Schema management
 //!
@@ -38,10 +53,11 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use faucet_core::FaucetError;
+use iceberg::io::FileIO;
 use iceberg::spec::{DataFile, Transform, UnboundPartitionSpec};
 use iceberg::table::Table;
 use iceberg::transaction::{ApplyTransactionAction, Transaction};
-use iceberg::{Catalog, NamespaceIdent, TableCreation, TableIdent};
+use iceberg::{Catalog, ErrorKind, NamespaceIdent, TableCreation, TableIdent};
 use serde_json::Value;
 use tokio::sync::Mutex;
 
@@ -360,9 +376,17 @@ impl IcebergSink {
 
     /// Commit all pending data files as a single `fast_append` snapshot.
     ///
-    /// `Transaction::commit` in iceberg 0.9.1 already includes an internal
-    /// retry loop (exponential back-off on retryable commit conflicts), so we
-    /// do not add an outer retry.  Returns `Ok(())` when the commit succeeds.
+    /// `Transaction::commit` in iceberg-rust 0.9.1 already includes an internal
+    /// retry loop (reload metadata + re-apply the append against the latest
+    /// snapshot, exponential back-off on retryable commit conflicts), so we do
+    /// not add an outer retry. Returns `Ok(())` when the commit succeeds.
+    ///
+    /// On a commit failure the data files this flush uploaded are orphaned. When
+    /// [`IcebergSinkConfig::cleanup_orphans_on_failure`] is set and the failure
+    /// is a *definitive* loss (see [`commit_failure_is_definite_loss`]) those
+    /// files are deleted before the error propagates; an ambiguous failure is
+    /// never cleaned up. Either way the original error is returned so the run
+    /// aborts without advancing the bookmark.
     async fn commit_pending(&self, state: &mut SinkState) -> Result<(), FaucetError> {
         let files = std::mem::take(&mut state.pending_files);
 
@@ -380,6 +404,11 @@ impl IcebergSink {
                 )
             })?
             .clone();
+
+        // Capture the paths of the data files we are about to commit, before
+        // they are moved into the transaction action, so we can clean them up
+        // if the commit fails.
+        let file_paths: Vec<String> = files.iter().map(|f| f.file_path().to_string()).collect();
 
         let tx = Transaction::new(&table);
 
@@ -403,20 +432,132 @@ impl IcebergSink {
             action = action.set_snapshot_properties(props);
         }
 
-        let tx = action
-            .apply(tx)
-            .map_err(|e| FaucetError::Sink(format!("iceberg: fast_append apply failed: {e}")))?;
+        let tx = match action.apply(tx) {
+            Ok(tx) => tx,
+            Err(e) => {
+                // Building the append failed locally — the data files were
+                // uploaded but definitively never committed.
+                maybe_cleanup_orphans(
+                    table.file_io(),
+                    &self.config.table,
+                    self.config.cleanup_orphans_on_failure,
+                    true,
+                    &file_paths,
+                )
+                .await;
+                return Err(FaucetError::Sink(format!(
+                    "iceberg: fast_append apply failed: {e}"
+                )));
+            }
+        };
 
-        let updated_table = tx
-            .commit(self.catalog.as_ref())
-            .await
-            .map_err(|e| FaucetError::Sink(format!("iceberg: transaction commit failed: {e}")))?;
+        let updated_table = match tx.commit(self.catalog.as_ref()).await {
+            Ok(updated_table) => updated_table,
+            Err(e) => {
+                maybe_cleanup_orphans(
+                    table.file_io(),
+                    &self.config.table,
+                    self.config.cleanup_orphans_on_failure,
+                    commit_failure_is_definite_loss(e.kind()),
+                    &file_paths,
+                )
+                .await;
+                return Err(FaucetError::Sink(format!(
+                    "iceberg: transaction commit failed ({}): {e}",
+                    e.kind()
+                )));
+            }
+        };
 
         // Update the stored table handle so subsequent writes use the latest
         // metadata (snapshot ID, manifest list, etc.).
         state.table = Some(updated_table);
         Ok(())
     }
+}
+
+/// Best-effort orphan cleanup after a failed snapshot commit.
+///
+/// No-op (with a one-line warning) when cleanup is disabled (`enabled == false`)
+/// or the failure is ambiguous (`definite_loss == false`); otherwise deletes
+/// `file_paths` via `file_io`. Errors are logged, never propagated — the caller
+/// still returns the original commit error.
+pub(crate) async fn maybe_cleanup_orphans(
+    file_io: &FileIO,
+    table_name: &str,
+    enabled: bool,
+    definite_loss: bool,
+    file_paths: &[String],
+) {
+    if !enabled {
+        tracing::warn!(
+            table = %table_name,
+            orphans = file_paths.len(),
+            "iceberg: commit failed; {} data file(s) orphaned. Set \
+             cleanup_orphans_on_failure to delete them automatically, or run \
+             Iceberg's remove_orphan_files maintenance.",
+            file_paths.len()
+        );
+        return;
+    }
+
+    if !definite_loss {
+        tracing::warn!(
+            table = %table_name,
+            orphans = file_paths.len(),
+            "iceberg: commit outcome ambiguous; NOT deleting {} data file(s) \
+             (a possibly-succeeded commit may reference them). Run \
+             remove_orphan_files if the commit is confirmed failed.",
+            file_paths.len()
+        );
+        return;
+    }
+
+    let (deleted, failed) = delete_data_files(file_io, file_paths).await;
+    tracing::info!(
+        table = %table_name,
+        deleted,
+        failed,
+        "iceberg: cleaned up orphaned data files after a definitive commit failure"
+    );
+}
+
+/// Classify whether a commit failure of `kind` means the commit *definitively*
+/// did not land — so the data files we uploaded are safe to delete — versus an
+/// *ambiguous* outcome where the commit may have succeeded server-side.
+///
+/// `CatalogCommitConflicts` (a competing writer won, after iceberg-rust's
+/// internal retries are exhausted) and `DataInvalid` (the catalog rejected the
+/// commit request) both mean our commit did not apply, so our uploaded files
+/// are safely orphaned. Every other kind — notably `Unexpected` (transport / IO
+/// failure on the catalog update) — is treated as ambiguous and is never
+/// cleaned up.
+pub(crate) fn commit_failure_is_definite_loss(kind: ErrorKind) -> bool {
+    matches!(
+        kind,
+        ErrorKind::CatalogCommitConflicts | ErrorKind::DataInvalid
+    )
+}
+
+/// Delete each path in `paths` via `file_io`, returning `(deleted, failed)`.
+///
+/// Best-effort: a delete error is logged and counted as `failed` but does not
+/// stop the remaining deletes. The data files written by this sink have unique
+/// (UUID-based) names, so deleting them can never remove a file a concurrent
+/// writer references.
+pub(crate) async fn delete_data_files(file_io: &FileIO, paths: &[String]) -> (usize, usize) {
+    let mut deleted = 0usize;
+    let mut failed = 0usize;
+    for path in paths {
+        match file_io.delete(path).await {
+            Ok(()) => deleted += 1,
+            Err(e) => {
+                failed += 1;
+                tracing::warn!(path = %path, error = %e, "iceberg: failed to delete orphaned data file");
+            }
+        }
+    }
+    (deleted, failed)
 }
 
 // ── Sink trait ────────────────────────────────────────────────────────────────
@@ -825,6 +966,156 @@ mod tests {
             msg.contains("nonexistent_col"),
             "error should name the bad column: {msg}"
         );
+    }
+
+    // ── Orphan cleanup (#193) ───────────────────────────────────────────────
+
+    use iceberg::ErrorKind;
+    use iceberg::io::FileIO;
+
+    // Only a definitive loss (our commit certainly did not land) is safe to
+    // clean up; an ambiguous outcome must never delete files.
+    #[test]
+    fn definite_loss_classification() {
+        assert!(
+            commit_failure_is_definite_loss(ErrorKind::CatalogCommitConflicts),
+            "an exhausted commit conflict means our commit definitively lost"
+        );
+        assert!(
+            commit_failure_is_definite_loss(ErrorKind::DataInvalid),
+            "a catalog-rejected commit definitively did not apply"
+        );
+        // Ambiguous / not-our-loss kinds must NOT be treated as definite.
+        assert!(
+            !commit_failure_is_definite_loss(ErrorKind::Unexpected),
+            "a transport error is ambiguous — the commit may have landed"
+        );
+        assert!(!commit_failure_is_definite_loss(
+            ErrorKind::PreconditionFailed
+        ));
+        assert!(!commit_failure_is_definite_loss(
+            ErrorKind::FeatureUnsupported
+        ));
+    }
+
+    /// Write `n` files via `io` under `dir`, returning their `file://` paths.
+    async fn seed_files(io: &FileIO, dir: &std::path::Path, n: usize) -> Vec<String> {
+        let mut paths = Vec::new();
+        for i in 0..n {
+            let p = format!("file://{}/orphan-{i}.parquet", dir.display());
+            io.new_output(&p)
+                .expect("new_output")
+                .write(bytes::Bytes::from_static(b"parquet"))
+                .await
+                .expect("write orphan file");
+            assert!(
+                io.exists(&p).await.expect("exists check"),
+                "seed file present"
+            );
+            paths.push(p);
+        }
+        paths
+    }
+
+    // delete_data_files removes every path and reports an accurate count.
+    #[tokio::test]
+    async fn delete_data_files_removes_all() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let io = FileIO::new_with_fs();
+        let paths = seed_files(&io, dir.path(), 3).await;
+
+        let (deleted, failed) = delete_data_files(&io, &paths).await;
+        assert_eq!(deleted, 3);
+        assert_eq!(failed, 0);
+        for p in &paths {
+            assert!(!io.exists(p).await.expect("exists check"), "file deleted");
+        }
+    }
+
+    // Deleting a path that is already gone is idempotent on the local-FS
+    // backend (`Ok`), so the whole batch is reported as deleted and the present
+    // file is removed regardless of ordering. (A genuine delete error — e.g. an
+    // object-store permission failure — is counted toward `failed`; that path
+    // is exercised against real cloud backends in the S3 integration tests.)
+    #[tokio::test]
+    async fn delete_data_files_idempotent_on_missing() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let io = FileIO::new_with_fs();
+        let mut paths = seed_files(&io, dir.path(), 1).await;
+        let present = paths[0].clone();
+        paths.push(format!(
+            "file://{}/never-written.parquet",
+            dir.path().display()
+        ));
+
+        let (deleted, failed) = delete_data_files(&io, &paths).await;
+        assert_eq!(
+            failed, 0,
+            "idempotent delete of a missing file is not a failure"
+        );
+        assert_eq!(deleted, 2);
+        assert!(
+            !io.exists(&present).await.expect("exists check"),
+            "the present file was deleted"
+        );
+    }
+
+    // Cleanup is a no-op when disabled: files survive.
+    #[tokio::test]
+    async fn maybe_cleanup_disabled_keeps_files() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let io = FileIO::new_with_fs();
+        let paths = seed_files(&io, dir.path(), 2).await;
+
+        maybe_cleanup_orphans(
+            &io, "t", /*enabled=*/ false, /*definite=*/ true, &paths,
+        )
+        .await;
+
+        for p in &paths {
+            assert!(io.exists(p).await.expect("exists check"), "disabled → kept");
+        }
+    }
+
+    // Cleanup is a no-op on an ambiguous failure even when enabled: deleting
+    // could remove files a possibly-succeeded commit references.
+    #[tokio::test]
+    async fn maybe_cleanup_ambiguous_keeps_files() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let io = FileIO::new_with_fs();
+        let paths = seed_files(&io, dir.path(), 2).await;
+
+        maybe_cleanup_orphans(
+            &io, "t", /*enabled=*/ true, /*definite=*/ false, &paths,
+        )
+        .await;
+
+        for p in &paths {
+            assert!(
+                io.exists(p).await.expect("exists check"),
+                "ambiguous → kept"
+            );
+        }
+    }
+
+    // Cleanup deletes files only when enabled AND the failure is definitive.
+    #[tokio::test]
+    async fn maybe_cleanup_enabled_definite_deletes_files() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let io = FileIO::new_with_fs();
+        let paths = seed_files(&io, dir.path(), 2).await;
+
+        maybe_cleanup_orphans(
+            &io, "t", /*enabled=*/ true, /*definite=*/ true, &paths,
+        )
+        .await;
+
+        for p in &paths {
+            assert!(
+                !io.exists(p).await.expect("exists check"),
+                "enabled + definite → deleted"
+            );
+        }
     }
 
     // Verify the partition spec builder succeeds on a valid identity field.

--- a/crates/sink/iceberg/tests/integration.rs
+++ b/crates/sink/iceberg/tests/integration.rs
@@ -201,6 +201,112 @@ async fn write_and_flush_creates_iceberg_snapshots() {
     );
 }
 
+/// Two writers committing from a stale base must both land — iceberg-rust
+/// reloads the latest metadata and re-applies the append against the newest
+/// snapshot rather than aborting (#193).
+///
+/// After a setup commit (snapshot 1), two sinks each lazily load the table at
+/// snapshot 1 and buffer their data files. Sink A flushes → snapshot 2, leaving
+/// sink B's in-memory base stale. Sink B then flushes: `Transaction::commit`
+/// detects the stale base, rebases onto snapshot 2, and re-applies the
+/// `fast_append` → snapshot 3. No error, no lost write.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn concurrent_writers_resolve_commit_conflict_via_refresh() {
+    let dir = TempDir::new().expect("tempdir");
+
+    // ── Setup: create the table + snapshot 1 ────────────────────────────────
+    let setup = IcebergSink::new(sink_config(&dir, "races"))
+        .await
+        .expect("setup sink");
+    let seed: Vec<serde_json::Value> = (0u64..10)
+        .map(|i| json!({ "id": i, "name": format!("n{i}") }))
+        .collect();
+    setup.write_batch(&seed).await.expect("seed write");
+    setup.flush().await.expect("seed flush");
+
+    // ── Two writers both lazily load the table at snapshot 1 ────────────────
+    let a = IcebergSink::new(sink_config(&dir, "races"))
+        .await
+        .expect("sink a");
+    let b = IcebergSink::new(sink_config(&dir, "races"))
+        .await
+        .expect("sink b");
+
+    let a_rows: Vec<serde_json::Value> = (100u64..110)
+        .map(|i| json!({ "id": i, "name": format!("a{i}") }))
+        .collect();
+    let b_rows: Vec<serde_json::Value> = (200u64..210)
+        .map(|i| json!({ "id": i, "name": format!("b{i}") }))
+        .collect();
+
+    // Both buffer (and lazily load the same base snapshot 1) before either
+    // commits.
+    a.write_batch(&a_rows).await.expect("a write");
+    b.write_batch(&b_rows).await.expect("b write");
+
+    // A commits → snapshot 2. B's cached base is now stale.
+    a.flush().await.expect("a flush");
+    // B commits from a stale base → iceberg reloads + rebases → snapshot 3.
+    b.flush()
+        .await
+        .expect("b flush must succeed via metadata refresh, not abort");
+
+    // ── Assert all three commits landed (no lost write) ─────────────────────
+    let reader = open_reader_catalog(&dir).await;
+    let ns = NamespaceIdent::from_strs(["db"]).expect("ns");
+    let tid = TableIdent::new(ns, "races".to_string());
+    let table = reader.load_table(&tid).await.expect("load table");
+    assert_eq!(
+        table.metadata().snapshots().count(),
+        3,
+        "setup + two stale-base commits must all produce snapshots (no lost write)"
+    );
+}
+
+/// A snapshot commit that fails (here: the table is dropped out from under the
+/// sink before flush) propagates as an error so the run aborts without
+/// advancing the bookmark — and because a "table vanished" outcome is ambiguous
+/// (not a definitive commit conflict), the uploaded data files are NOT deleted
+/// even with `cleanup_orphans_on_failure` enabled (#193).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn commit_failure_on_dropped_table_propagates_and_keeps_orphans() {
+    use iceberg::Catalog;
+
+    let dir = TempDir::new().expect("tempdir");
+
+    // Create the table + first snapshot via a setup sink.
+    let setup = IcebergSink::new(sink_config(&dir, "vanishing"))
+        .await
+        .expect("setup sink");
+    let seed: Vec<serde_json::Value> = (0u64..5).map(|i| json!({ "id": i })).collect();
+    setup.write_batch(&seed).await.expect("seed write");
+    setup.flush().await.expect("seed flush");
+
+    // A writer with cleanup enabled buffers a batch (loading the table).
+    let mut cfg = sink_config(&dir, "vanishing");
+    cfg.cleanup_orphans_on_failure = true;
+    let writer = IcebergSink::new(cfg).await.expect("writer sink");
+    let rows: Vec<serde_json::Value> = (100u64..105).map(|i| json!({ "id": i })).collect();
+    writer.write_batch(&rows).await.expect("buffer write");
+
+    // Drop the table from the catalog before the writer flushes.
+    let reader = open_reader_catalog(&dir).await;
+    let ns = NamespaceIdent::from_strs(["db"]).expect("ns");
+    let tid = TableIdent::new(ns, "vanishing".to_string());
+    reader.drop_table(&tid).await.expect("drop table");
+
+    // The commit must fail (table gone) and surface as a Sink error.
+    let err = writer
+        .flush()
+        .await
+        .expect_err("flush must fail when the table was dropped");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("iceberg") && msg.contains("commit"),
+        "error should describe the failed commit: {msg}"
+    );
+}
+
 /// Empty `write_batch` followed by `flush` must not produce any snapshot.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn empty_write_batch_no_snapshot() {


### PR DESCRIPTION
Closes #193. Part of the roadmap epic #38.

## Background — what was already shipped

The issue's "Proposed design" centers on *commit-conflict retry with metadata refresh*. On inspection, **iceberg-rust 0.9.1 already implements this inside `Transaction::commit`**: `do_commit` reloads the table from the catalog, detects a stale base, rebases onto the latest snapshot, and re-applies the `fast_append` **without re-uploading the data files** — retried with exponential backoff `.when(|e| e.retryable())`, tunable via the standard `commit.retry.*` table properties. So a benign concurrent writer does **not** abort the run, and adding an outer app-level retry would be redundant and harmful (double-retry / re-adding files).

That leaves the genuinely-unshipped, valuable part of #193: the data files **orphaned** when those retries are exhausted, plus a safe classifier and tests.

## What this PR adds

- **`cleanup_orphans_on_failure`** config flag (default `false`). On a commit failure the sink deletes the Parquet files this flush already uploaded, so they don't accumulate as orphans.
- **Conflict-vs-ambiguous classifier** (`commit_failure_is_definite_loss`): cleanup runs **only** on a *definitive* loss (`CatalogCommitConflicts` / `DataInvalid` — our commit certainly did not land). An **ambiguous** failure (`Unexpected` / transport, where the commit may have landed server-side) is **never** cleaned up, because deleting then could remove files a successful-but-unacknowledged commit references. The sink's data files have unique UUID names, so cleanup can never touch a concurrent writer's files.
- **Docs**: replaced the "orphans accumulate, no auto-delete" caveat in the module doc + README with the retry/cleanup behavior, and documented that retry is upstream and tunable via `commit.retry.*`.

## Tests

- **Unit** (no catalog): classifier (definite vs ambiguous kinds); `delete_data_files` (deletes all; idempotent on missing); `maybe_cleanup_orphans` for all three branches — disabled / ambiguous / enabled+definite — verifying files are kept or deleted accordingly.
- **Integration** (SQLite catalog + local-FS warehouse, no Docker): `concurrent_writers_resolve_commit_conflict_via_refresh` proves two writers committing from a stale base both land (snapshot 1 → 2 → 3) without aborting; `commit_failure_on_dropped_table_propagates_and_keeps_orphans` proves a failed commit surfaces as a typed error.

## Acceptance criteria (from #193)

- ✅ A concurrent commit is retried/rebased to a successful commit, not an abort (integration test).
- ✅ The "orphaned files on commit failure" caveat is removed from README + module docs.
- ✅ Tests for conflict-vs-non-conflict classification.

## Verification

`cargo test -p faucet-sink-iceberg --features catalog-sql` (74 lib + 5 integration pass), `clippy --all-targets --all-features -D warnings` clean, `fmt` clean, `cargo doc --all-features -D warnings` clean, umbrella + CLI build with `sink-iceberg`. (The pre-existing Docker-gated `integration_s3` test is unaffected — no S3 code changed.)

## Note on scope

The app-level retry the issue proposed is intentionally **not** added — it's already handled correctly by iceberg-rust internally. Equality-delete upsert (#225), schema evolution (#255), and overwrite mode (#179) remain blocked on upstream iceberg-rust and are out of scope here.