### PR TITLE
feat: serve cluster Mode B — source-shard distribution across workers (#230)

### DIFF
--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -91,6 +91,7 @@ pub async fn run(args: RunArgs) -> CliResult<()> {
             dry_run: args.dry_run,
             limit: args.limit,
             state_path_override: args.state_path.clone(),
+            shard: None,
             auth,
             clock: resolve_run_clock(args.clock.as_deref())?,
             // `faucet run` has no external cancel signal; the executor still

--- a/cli/src/commands/schedule.rs
+++ b/cli/src/commands/schedule.rs
@@ -172,6 +172,7 @@ fn make_opts(
         dry_run: false,
         limit: None,
         state_path_override: None,
+        shard: None,
         auth: auth.clone(),
         clock,
         cancel: None,

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -90,6 +90,15 @@ pub struct PipelineConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resilience: Option<ResilienceSpec>,
 
+    /// Optional source-shard distribution for clustered (Mode B) execution.
+    /// Only consumed by `faucet serve --cluster`: a run whose source
+    /// [is shardable](faucet_core::Source::is_shardable) is split into
+    /// `shard.count` shards processed concurrently across cluster workers.
+    /// Ignored by `faucet run` and by a non-cluster `serve`, so it is fully
+    /// backward compatible.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub shard: Option<ShardingSpec>,
+
     /// Optional snapshot→CDC replication block. Consumed only by
     /// `faucet replicate`; ignored by `faucet run` (like `schedule:`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -298,6 +307,17 @@ pub struct ExecutionSpec {
     /// Adaptive batch-size controller (opt-in). See `faucet_core::AdaptiveBatchConfig`.
     #[serde(default)]
     pub adaptive_batch_size: Option<faucet_core::AdaptiveBatchConfig>,
+}
+
+/// Source-shard distribution settings for clustered (Mode B) execution.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ShardingSpec {
+    /// Target number of shards to split the source into. Must be `>= 2` (a
+    /// count of 1 means "don't shard" — omit the block instead). The actual
+    /// shard count may be smaller when the source has fewer natural partitions
+    /// (e.g. a key range narrower than `count`).
+    pub count: usize,
 }
 
 /// Failure-handling policy across the matrix.

--- a/cli/src/env_config.rs
+++ b/cli/src/env_config.rs
@@ -324,6 +324,7 @@ pub fn build_pipeline_config(env: &HashMap<String, String>) -> CliResult<Pipelin
         observability: None,
         delivery: faucet_core::DeliveryMode::default(),
         resilience: None,
+        shard: None,
         replication: None,
         #[cfg(feature = "schedule")]
         schedule: None,

--- a/cli/src/executor.rs
+++ b/cli/src/executor.rs
@@ -1367,7 +1367,6 @@ mod tests {
                 clock: chrono::Utc::now().fixed_offset(),
                 cancel: None,
                 resilience: None,
-                shard: None,
                 #[cfg(feature = "lineage")]
                 lineage: None,
                 #[cfg(feature = "lineage")]
@@ -1425,7 +1424,6 @@ matrix:
                 clock: chrono::Utc::now().fixed_offset(),
                 cancel: None,
                 resilience: None,
-                shard: None,
                 #[cfg(feature = "lineage")]
                 lineage: None,
                 #[cfg(feature = "lineage")]
@@ -1483,7 +1481,6 @@ matrix:
                 clock: chrono::Utc::now().fixed_offset(),
                 cancel: None,
                 resilience: None,
-                shard: None,
                 #[cfg(feature = "lineage")]
                 lineage: None,
                 #[cfg(feature = "lineage")]
@@ -1551,7 +1548,6 @@ execution:
                 clock: chrono::Utc::now().fixed_offset(),
                 cancel: None,
                 resilience: None,
-                shard: None,
                 #[cfg(feature = "lineage")]
                 lineage: None,
                 #[cfg(feature = "lineage")]
@@ -1634,7 +1630,6 @@ pipeline:
                 clock: chrono::Utc::now().fixed_offset(),
                 cancel: None,
                 resilience: None,
-                shard: None,
                 #[cfg(feature = "lineage")]
                 lineage: None,
                 #[cfg(feature = "lineage")]
@@ -1691,7 +1686,6 @@ matrix:
                 clock: chrono::Utc::now().fixed_offset(),
                 cancel: None,
                 resilience: None,
-                shard: None,
                 #[cfg(feature = "lineage")]
                 lineage: None,
                 #[cfg(feature = "lineage")]
@@ -1757,7 +1751,6 @@ execution:
                 clock: chrono::Utc::now().fixed_offset(),
                 cancel: None,
                 resilience: None,
-                shard: None,
                 #[cfg(feature = "lineage")]
                 lineage: None,
                 #[cfg(feature = "lineage")]
@@ -1824,7 +1817,6 @@ matrix:
                 clock: chrono::Utc::now().fixed_offset(),
                 cancel: None,
                 resilience: None,
-                shard: None,
                 #[cfg(feature = "lineage")]
                 lineage: None,
                 #[cfg(feature = "lineage")]
@@ -2046,7 +2038,6 @@ matrix:
             clock: chrono::Utc::now().fixed_offset(),
             cancel: None,
             resilience: None,
-            shard: None,
             #[cfg(feature = "lineage")]
             lineage: None,
             #[cfg(feature = "lineage")]
@@ -2446,7 +2437,6 @@ matrix:
                 clock: chrono::Utc::now().fixed_offset(),
                 cancel: None,
                 resilience: None,
-                shard: None,
                 #[cfg(feature = "lineage")]
                 lineage: None,
                 #[cfg(feature = "lineage")]

--- a/cli/src/executor.rs
+++ b/cli/src/executor.rs
@@ -57,6 +57,11 @@ pub struct ExecuteOptions {
     pub limit: Option<usize>,
     /// `--state-path PATH` — overrides the `file` state-store path.
     pub state_path_override: Option<PathBuf>,
+    /// Clustered Mode B (#230): narrow this run's single source to one shard
+    /// before streaming, and suffix its state key with the shard id so resume is
+    /// per-shard. `None` (the default) runs the whole source unchanged. Only set
+    /// by the serve shard executor; every other caller leaves it `None`.
+    pub shard: Option<faucet_core::ShardSpec>,
     /// Shared auth providers built from the top-level `auth:` block. Connectors
     /// that reference one via `auth: { ref }` resolve against this catalog;
     /// every row sharing a provider gets the same `Arc` (one token, shared).
@@ -742,6 +747,16 @@ async fn run_one_invocation(
         opts.resilience.as_ref().map(|r| &r.retry),
     )
     .await?;
+
+    // Clustered Mode B: narrow the raw source to its assigned shard BEFORE any
+    // wrapping (the TransformingSource / StateKeyOverride wrappers do not forward
+    // apply_shard, so it must reach the concrete connector).
+    if let Some(shard) = &opts.shard {
+        source
+            .apply_shard(shard)
+            .await
+            .map_err(|e| CliError::Internal(format!("applying shard {:?}: {e}", shard.id)))?;
+    }
     let raw_sink: Box<dyn Sink> = if opts.dry_run {
         Box::new(CountingSink::new())
     } else {
@@ -814,10 +829,16 @@ async fn run_one_invocation(
     //    executor's per-row state key is used instead of the source's natural
     //    one (which is shared across all matrix rows of the same kind).
     let state = build_state_for_node(node, opts.state_path_override.as_deref()).await?;
+    // Per-shard bookmark: suffix the state key with the shard id so a reassigned
+    // shard resumes where its dead owner left off, independent of sibling shards.
+    let effective_state_key = match &opts.shard {
+        Some(shard) => format!("{state_key}::{}", shard.id),
+        None => state_key.to_owned(),
+    };
     let source: Box<dyn Source> = if state.is_some() && source.state_key().is_some() {
         Box::new(StateKeyOverride {
             inner: source,
-            key: state_key.to_owned(),
+            key: effective_state_key,
         })
     } else {
         source
@@ -1316,6 +1337,7 @@ mod tests {
             observability: None,
             delivery: faucet_core::DeliveryMode::default(),
             resilience: None,
+            shard: None,
             replication: None,
             #[cfg(feature = "schedule")]
             schedule: None,
@@ -1340,10 +1362,12 @@ mod tests {
                 dry_run: false,
                 limit: None,
                 state_path_override: None,
+                shard: None,
                 auth: Default::default(),
                 clock: chrono::Utc::now().fixed_offset(),
                 cancel: None,
                 resilience: None,
+                shard: None,
                 #[cfg(feature = "lineage")]
                 lineage: None,
                 #[cfg(feature = "lineage")]
@@ -1396,10 +1420,12 @@ matrix:
                 dry_run: false,
                 limit: None,
                 state_path_override: None,
+                shard: None,
                 auth: Default::default(),
                 clock: chrono::Utc::now().fixed_offset(),
                 cancel: None,
                 resilience: None,
+                shard: None,
                 #[cfg(feature = "lineage")]
                 lineage: None,
                 #[cfg(feature = "lineage")]
@@ -1452,10 +1478,12 @@ matrix:
                 dry_run: false,
                 limit: None,
                 state_path_override: None,
+                shard: None,
                 auth: Default::default(),
                 clock: chrono::Utc::now().fixed_offset(),
                 cancel: None,
                 resilience: None,
+                shard: None,
                 #[cfg(feature = "lineage")]
                 lineage: None,
                 #[cfg(feature = "lineage")]
@@ -1518,10 +1546,12 @@ execution:
                 dry_run: false,
                 limit: None,
                 state_path_override: None,
+                shard: None,
                 auth: Default::default(),
                 clock: chrono::Utc::now().fixed_offset(),
                 cancel: None,
                 resilience: None,
+                shard: None,
                 #[cfg(feature = "lineage")]
                 lineage: None,
                 #[cfg(feature = "lineage")]
@@ -1599,10 +1629,12 @@ pipeline:
                 dry_run: false,
                 limit: None,
                 state_path_override: None,
+                shard: None,
                 auth: Default::default(),
                 clock: chrono::Utc::now().fixed_offset(),
                 cancel: None,
                 resilience: None,
+                shard: None,
                 #[cfg(feature = "lineage")]
                 lineage: None,
                 #[cfg(feature = "lineage")]
@@ -1654,10 +1686,12 @@ matrix:
                 dry_run: false,
                 limit: None,
                 state_path_override: None,
+                shard: None,
                 auth: Default::default(),
                 clock: chrono::Utc::now().fixed_offset(),
                 cancel: None,
                 resilience: None,
+                shard: None,
                 #[cfg(feature = "lineage")]
                 lineage: None,
                 #[cfg(feature = "lineage")]
@@ -1718,10 +1752,12 @@ execution:
                 dry_run: false,
                 limit: None,
                 state_path_override: None,
+                shard: None,
                 auth: Default::default(),
                 clock: chrono::Utc::now().fixed_offset(),
                 cancel: None,
                 resilience: None,
+                shard: None,
                 #[cfg(feature = "lineage")]
                 lineage: None,
                 #[cfg(feature = "lineage")]
@@ -1783,10 +1819,12 @@ matrix:
                 dry_run: false,
                 limit: None,
                 state_path_override: None,
+                shard: None,
                 auth: Default::default(),
                 clock: chrono::Utc::now().fixed_offset(),
                 cancel: None,
                 resilience: None,
+                shard: None,
                 #[cfg(feature = "lineage")]
                 lineage: None,
                 #[cfg(feature = "lineage")]
@@ -2003,10 +2041,12 @@ matrix:
             dry_run: false,
             limit: None,
             state_path_override: None,
+            shard: None,
             auth: Default::default(),
             clock: chrono::Utc::now().fixed_offset(),
             cancel: None,
             resilience: None,
+            shard: None,
             #[cfg(feature = "lineage")]
             lineage: None,
             #[cfg(feature = "lineage")]
@@ -2401,10 +2441,12 @@ matrix:
                 dry_run: false,
                 limit: None,
                 state_path_override: None,
+                shard: None,
                 auth: Default::default(),
                 clock: chrono::Utc::now().fixed_offset(),
                 cancel: None,
                 resilience: None,
+                shard: None,
                 #[cfg(feature = "lineage")]
                 lineage: None,
                 #[cfg(feature = "lineage")]

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -79,6 +79,7 @@ pub async fn run_from_yaml_str(yaml: &str) -> CliResult<executor::RunSummary> {
             dry_run: false,
             limit: None,
             state_path_override: None,
+            shard: None,
             auth,
             clock: chrono::Utc::now().fixed_offset(),
             cancel: None,

--- a/cli/src/replication/orchestrator.rs
+++ b/cli/src/replication/orchestrator.rs
@@ -72,6 +72,7 @@ fn make_opts(opts: &ReplicationOptions, cancel: Option<CancellationToken>) -> Ex
         dry_run: false,
         limit: None,
         state_path_override: None,
+        shard: None,
         auth: opts.auth.clone(),
         clock: opts.clock,
         cancel,

--- a/cli/src/serve/cluster.rs
+++ b/cli/src/serve/cluster.rs
@@ -143,16 +143,37 @@ pub async fn claim_loop(state: ServerState, shutdown: CancellationToken) {
         if free == 0 {
             continue;
         }
+        let mut claimed_count = 0usize;
         match state.history().claim_pending(free).await {
             Ok(claimed) => {
                 if !claimed.is_empty() {
                     crate::serve::metrics::record_runs_claimed(claimed.len());
+                    claimed_count = claimed.len();
                     for rec in claimed {
                         crate::serve::runner::resume_claimed_run(state.clone(), rec);
                     }
                 }
             }
             Err(e) => tracing::warn!(error = %e, "cluster: claim_pending failed"),
+        }
+
+        // 3. Mode B (#230): claim source shards with the remaining budget and
+        //    dispatch each to a per-shard executor. A claimed shard flips to
+        //    Running (leased) in the shared DB; if it over-subscribes local
+        //    permits it simply queues on the semaphore, like a claimed run.
+        let shard_budget = free.saturating_sub(claimed_count);
+        if shard_budget > 0 {
+            match state.history().claim_shards(shard_budget).await {
+                Ok(shards) => {
+                    if !shards.is_empty() {
+                        crate::serve::metrics::record_shards_claimed(shards.len());
+                        for shard in shards {
+                            crate::serve::runner::resume_claimed_shard(state.clone(), shard);
+                        }
+                    }
+                }
+                Err(e) => tracing::warn!(error = %e, "cluster: claim_shards failed"),
+            }
         }
     }
 }

--- a/cli/src/serve/history/fallback.rs
+++ b/cli/src/serve/history/fallback.rs
@@ -343,4 +343,31 @@ mod tests {
         );
         assert_eq!(fb.delete("r2").await.unwrap(), DeleteOutcome::Deleted);
     }
+
+    #[tokio::test]
+    async fn shard_methods_delegate_to_a_healthy_primary() {
+        use crate::serve::history::memory::MemoryHistory;
+        use crate::serve::history::{ReclaimReport, ShardProgress};
+        // A healthy (memory) primary → the shard methods delegate via `via!`;
+        // memory's shard methods are inert, so we get the inert results back
+        // (exercising the forwarding path).
+        let fb = FallbackHistory::healthy(
+            Box::new(MemoryHistory::new(Duration::from_secs(60))),
+            Duration::from_secs(60),
+            "test",
+        );
+        assert_eq!(fb.insert_shards("r", &[]).await.unwrap(), 0);
+        assert!(fb.claim_shards(4).await.unwrap().is_empty());
+        assert_eq!(fb.renew_shard_leases().await.unwrap(), 0);
+        assert_eq!(
+            fb.reclaim_shards(3).await.unwrap(),
+            ReclaimReport::default()
+        );
+        assert!(!fb.finalize_shard("r", "0", true).await.unwrap());
+        assert_eq!(
+            fb.shard_progress("r").await.unwrap(),
+            ShardProgress::default()
+        );
+        assert!(!fb.degraded());
+    }
 }

--- a/cli/src/serve/history/fallback.rs
+++ b/cli/src/serve/history/fallback.rs
@@ -180,6 +180,42 @@ impl RunHistory for FallbackHistory {
         via!(self, p => p.live_instances(ttl), f => f.live_instances(ttl))
     }
 
+    // ── Source shards (Mode B, #230) ─────────────────────────────────────────
+
+    async fn insert_shards(
+        &self,
+        run_id: &str,
+        shards: &[crate::serve::history::ShardInsert],
+    ) -> Result<usize, HistoryError> {
+        via!(self, p => p.insert_shards(run_id, shards), f => f.insert_shards(run_id, shards))
+    }
+    async fn claim_shards(
+        &self,
+        limit: usize,
+    ) -> Result<Vec<crate::serve::history::ClaimedShard>, HistoryError> {
+        via!(self, p => p.claim_shards(limit), f => f.claim_shards(limit))
+    }
+    async fn renew_shard_leases(&self) -> Result<usize, HistoryError> {
+        via!(self, p => p.renew_shard_leases(), f => f.renew_shard_leases())
+    }
+    async fn reclaim_shards(&self, max_attempts: u32) -> Result<ReclaimReport, HistoryError> {
+        via!(self, p => p.reclaim_shards(max_attempts), f => f.reclaim_shards(max_attempts))
+    }
+    async fn finalize_shard(
+        &self,
+        run_id: &str,
+        shard_id: &str,
+        success: bool,
+    ) -> Result<bool, HistoryError> {
+        via!(self, p => p.finalize_shard(run_id, shard_id, success), f => f.finalize_shard(run_id, shard_id, success))
+    }
+    async fn shard_progress(
+        &self,
+        run_id: &str,
+    ) -> Result<crate::serve::history::ShardProgress, HistoryError> {
+        via!(self, p => p.shard_progress(run_id), f => f.shard_progress(run_id))
+    }
+
     fn degraded(&self) -> bool {
         self.is_degraded()
     }

--- a/cli/src/serve/history/mod.rs
+++ b/cli/src/serve/history/mod.rs
@@ -217,6 +217,48 @@ pub enum HistoryError {
     Degraded(String),
 }
 
+/// One shard row to persist when a run is expanded into shards (Mode B, #230).
+#[derive(Debug, Clone)]
+pub struct ShardInsert {
+    /// Stable shard id, unique within the run (the [`ShardSpec`](faucet_core::ShardSpec) id).
+    pub shard_id: String,
+    /// Opaque connector descriptor, persisted verbatim and handed to
+    /// [`Source::apply_shard`](faucet_core::Source::apply_shard) on the worker.
+    pub descriptor: serde_json::Value,
+    /// Relative size estimate for skew-aware assignment, if the source provided one.
+    pub size_estimate: Option<u64>,
+}
+
+/// A shard claimed for execution, carrying its parent run's record (whose
+/// `config_body` the worker re-loads to build + shard the source).
+#[derive(Debug, Clone)]
+pub struct ClaimedShard {
+    pub run_id: String,
+    pub shard_id: String,
+    pub descriptor: serde_json::Value,
+    /// The parent run record (config body, name, etc.).
+    pub run: RunRecord,
+}
+
+/// Aggregate shard status for a run, used by the coordinator to decide when the
+/// parent run is finished.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ShardProgress {
+    pub total: usize,
+    pub completed: usize,
+    pub failed: usize,
+    pub running: usize,
+    pub pending: usize,
+}
+
+impl ShardProgress {
+    /// True when every shard has reached a terminal state (and at least one
+    /// exists) — i.e. the parent run can be finalized.
+    pub fn all_terminal(&self) -> bool {
+        self.total > 0 && self.completed + self.failed == self.total
+    }
+}
+
 #[async_trait]
 pub trait RunHistory: Send + Sync {
     /// Atomically claim `key` for `run_id` (or report a replay/conflict). A prior
@@ -315,6 +357,69 @@ pub trait RunHistory: Send + Sync {
     async fn live_instances(&self, ttl: Duration) -> Result<Vec<InstanceRecord>, HistoryError> {
         let _ = ttl;
         Ok(Vec::new())
+    }
+
+    // ── Source-shard coordination (Mode B, #230) ────────────────────────────
+    //
+    // All default to inert so the in-memory (single-process, unsharded) backend
+    // and any non-cluster deployment are unaffected. Implemented by the SQL
+    // backends, which share one `faucet_serve_shards` table.
+
+    /// Idempotently insert the shard set for `run_id` (`INSERT … ON CONFLICT
+    /// (run_id, shard_id) DO NOTHING`), so concurrent coordinators converge on
+    /// the same set without a leader. Returns the number of rows newly inserted.
+    /// Default: no-op.
+    async fn insert_shards(
+        &self,
+        run_id: &str,
+        shards: &[ShardInsert],
+    ) -> Result<usize, HistoryError> {
+        let _ = (run_id, shards);
+        Ok(0)
+    }
+
+    /// Atomically claim up to `limit` `pending` shards for *this* instance
+    /// (`pending` → `running` with a fresh lease), largest-estimated-size first
+    /// for skew-aware balancing, returning each with its parent run record.
+    /// Exclusive, like [`claim_pending`](Self::claim_pending). Default: none.
+    async fn claim_shards(&self, limit: usize) -> Result<Vec<ClaimedShard>, HistoryError> {
+        let _ = limit;
+        Ok(Vec::new())
+    }
+
+    /// Heartbeat: extend the lease of this instance's own `running` shards so a
+    /// peer's [`reclaim_shards`](Self::reclaim_shards) won't reassign them.
+    /// Returns the number renewed. Default: no-op.
+    async fn renew_shard_leases(&self) -> Result<usize, HistoryError> {
+        Ok(0)
+    }
+
+    /// Rebalance: expired-lease `running` shards whose `attempt < max_attempts`
+    /// go back to `pending` (owner cleared, `attempt++`) for another worker to
+    /// claim; the rest are `failed` (poison). Returns the counts. Default: none.
+    async fn reclaim_shards(&self, max_attempts: u32) -> Result<ReclaimReport, HistoryError> {
+        let _ = max_attempts;
+        Ok(ReclaimReport::default())
+    }
+
+    /// Owner-fenced terminal write for one shard (`running` → `completed`/`failed`),
+    /// only if this instance still owns it. Returns `true` if the write landed.
+    /// Default: `false`.
+    async fn finalize_shard(
+        &self,
+        run_id: &str,
+        shard_id: &str,
+        success: bool,
+    ) -> Result<bool, HistoryError> {
+        let _ = (run_id, shard_id, success);
+        Ok(false)
+    }
+
+    /// Aggregate shard status counts for a run (drives parent-run finalization).
+    /// Default: empty.
+    async fn shard_progress(&self, run_id: &str) -> Result<ShardProgress, HistoryError> {
+        let _ = run_id;
+        Ok(ShardProgress::default())
     }
 
     /// True when the backend is in fallback mode (drives `/readyz`). Always false

--- a/cli/src/serve/history/mod.rs
+++ b/cli/src/serve/history/mod.rs
@@ -643,6 +643,44 @@ mod tests {
         assert!(v.get("config_body").is_none());
     }
 
+    #[test]
+    fn shard_progress_all_terminal() {
+        // No shards yet → not terminal (don't finalize an unexpanded run).
+        assert!(!ShardProgress::default().all_terminal());
+        // Some still running.
+        let mut p = ShardProgress {
+            total: 3,
+            completed: 1,
+            failed: 0,
+            running: 1,
+            pending: 1,
+        };
+        assert!(!p.all_terminal());
+        // All terminal (mix of completed + failed sums to total).
+        p = ShardProgress {
+            total: 3,
+            completed: 2,
+            failed: 1,
+            running: 0,
+            pending: 0,
+        };
+        assert!(p.all_terminal());
+    }
+
+    #[tokio::test]
+    async fn memory_backend_shard_methods_are_inert() {
+        use crate::serve::history::memory::MemoryHistory;
+        let h = MemoryHistory::new(Duration::from_secs(60));
+        assert_eq!(h.insert_shards("r", &[]).await.unwrap(), 0);
+        assert!(h.claim_shards(8).await.unwrap().is_empty());
+        assert_eq!(h.renew_shard_leases().await.unwrap(), 0);
+        assert!(!h.finalize_shard("r", "0", true).await.unwrap());
+        assert_eq!(
+            h.shard_progress("r").await.unwrap(),
+            ShardProgress::default()
+        );
+    }
+
     #[tokio::test]
     async fn memory_backend_cluster_methods_are_inert() {
         use crate::serve::history::memory::MemoryHistory;

--- a/cli/src/serve/history/mod.rs
+++ b/cli/src/serve/history/mod.rs
@@ -31,6 +31,12 @@ pub enum RunStatus {
     Queued,
     Pending,
     Running,
+    /// Mode B (#230): the run has been expanded into shards (rows in
+    /// `faucet_serve_shards`). It does not execute as a whole — its shards do,
+    /// each claimed/leased independently — and it is finalized to a terminal
+    /// state once every shard is terminal. Non-terminal, owner-less, and not
+    /// reclaimed by run-level orphan recovery (only its shards are).
+    Sharded,
     Completed,
     Failed,
     Cancelled,
@@ -45,6 +51,7 @@ impl RunStatus {
             Self::Queued => "queued",
             Self::Pending => "pending",
             Self::Running => "running",
+            Self::Sharded => "sharded",
             Self::Completed => "completed",
             Self::Failed => "failed",
             Self::Cancelled => "cancelled",

--- a/cli/src/serve/history/sql.rs
+++ b/cli/src/serve/history/sql.rs
@@ -486,6 +486,7 @@ pub fn parse_status(s: &str) -> RunStatus {
         "queued" => RunStatus::Queued,
         "pending" => RunStatus::Pending,
         "running" => RunStatus::Running,
+        "sharded" => RunStatus::Sharded,
         "completed" => RunStatus::Completed,
         "cancelled" => RunStatus::Cancelled,
         _ => RunStatus::Failed,

--- a/cli/src/serve/history/sql.rs
+++ b/cli/src/serve/history/sql.rs
@@ -61,6 +61,24 @@ pub const DDL: &[&str] = &[
         run_id TEXT NOT NULL,\
         fingerprint TEXT NOT NULL,\
         claimed_at TEXT NOT NULL)",
+    // Source shards for clustered Mode B (#230). One row per (run, shard);
+    // `owner`/`lease_expires_at`/`attempt` reuse Mode A's lease-fencing semantics
+    // at shard granularity. `size_estimate` (an integer stored as TEXT) drives
+    // skew-aware, largest-first claiming. `descriptor` is the opaque connector
+    // shard spec, replayed to the worker that claims the shard.
+    "CREATE TABLE IF NOT EXISTS faucet_serve_shards (\
+        run_id TEXT NOT NULL,\
+        shard_id TEXT NOT NULL,\
+        descriptor TEXT NOT NULL,\
+        size_estimate TEXT,\
+        status TEXT NOT NULL,\
+        owner TEXT,\
+        lease_expires_at TEXT,\
+        attempt TEXT NOT NULL,\
+        finished_at TEXT,\
+        PRIMARY KEY (run_id, shard_id))",
+    "CREATE INDEX IF NOT EXISTS faucet_serve_shards_claim_idx \
+        ON faucet_serve_shards (status, lease_expires_at)",
 ];
 
 /// SQL placeholder dialect.
@@ -123,6 +141,25 @@ pub struct Stmts {
     pub live_instances: String,
     /// Prune instances whose last heartbeat is before a given threshold.
     pub prune_instances: String,
+    // ── Source shards (Mode B, #230) ─────────────────────────────────────────
+    /// Idempotent shard insert (`ON CONFLICT (run_id, shard_id) DO NOTHING`).
+    pub insert_shard: String,
+    /// Select claimable pending shards joined to their run body, largest first.
+    pub claim_shards_select: String,
+    /// Atomically claim one pending shard for this instance.
+    pub claim_shard_one: String,
+    /// Heartbeat this instance's running shards.
+    pub renew_shard_leases: String,
+    /// Select expired-lease running shards for requeue/fail evaluation.
+    pub reclaim_shards_select: String,
+    /// Requeue an expired running shard back to pending (attempt++).
+    pub reclaim_shard_requeue: String,
+    /// Fail an expired running shard that exhausted its attempts (poison).
+    pub reclaim_shard_fail: String,
+    /// Owner-fenced terminal write for one shard.
+    pub finalize_shard: String,
+    /// Status counts for a run's shards.
+    pub shard_progress: String,
 }
 
 impl Stmts {
@@ -228,6 +265,45 @@ impl Stmts {
                 WHERE last_heartbeat >= $1"
                 .into(),
             prune_instances: "DELETE FROM faucet_serve_instances WHERE last_heartbeat < $1".into(),
+            insert_shard: "INSERT INTO faucet_serve_shards \
+                (run_id, shard_id, descriptor, size_estimate, status, attempt) \
+                VALUES ($1,$2,$3,$4,'pending','0') \
+                ON CONFLICT (run_id, shard_id) DO NOTHING"
+                .into(),
+            claim_shards_select: "SELECT s.run_id, s.shard_id, s.descriptor, r.body \
+                FROM faucet_serve_shards s JOIN faucet_serve_runs r ON r.run_id = s.run_id \
+                WHERE s.status = 'pending' \
+                ORDER BY CAST(COALESCE(s.size_estimate, '0') AS BIGINT) DESC, s.run_id, s.shard_id \
+                LIMIT $1"
+                .into(),
+            claim_shard_one: "UPDATE faucet_serve_shards \
+                SET owner = $1, status = 'running', lease_expires_at = $2 \
+                WHERE run_id = $3 AND shard_id = $4 AND status = 'pending'"
+                .into(),
+            renew_shard_leases: "UPDATE faucet_serve_shards SET lease_expires_at = $1 \
+                WHERE owner = $2 AND status = 'running'"
+                .into(),
+            reclaim_shards_select: "SELECT run_id, shard_id, attempt FROM faucet_serve_shards \
+                WHERE status = 'running' \
+                AND (lease_expires_at IS NULL OR lease_expires_at < $1)"
+                .into(),
+            reclaim_shard_requeue: "UPDATE faucet_serve_shards \
+                SET status = 'pending', owner = NULL, lease_expires_at = NULL, attempt = $1 \
+                WHERE run_id = $2 AND shard_id = $3 AND status = 'running' \
+                AND (lease_expires_at IS NULL OR lease_expires_at < $4)"
+                .into(),
+            reclaim_shard_fail: "UPDATE faucet_serve_shards \
+                SET status = 'failed', finished_at = $1, owner = NULL \
+                WHERE run_id = $2 AND shard_id = $3 AND status = 'running' \
+                AND (lease_expires_at IS NULL OR lease_expires_at < $4)"
+                .into(),
+            finalize_shard: "UPDATE faucet_serve_shards \
+                SET status = $1, finished_at = $2 \
+                WHERE run_id = $3 AND shard_id = $4 AND owner = $5 AND status = 'running'"
+                .into(),
+            shard_progress: "SELECT status, COUNT(*) AS n FROM faucet_serve_shards \
+                WHERE run_id = $1 GROUP BY status"
+                .into(),
         }
     }
 
@@ -324,6 +400,45 @@ impl Stmts {
                 WHERE last_heartbeat >= ?"
                 .into(),
             prune_instances: "DELETE FROM faucet_serve_instances WHERE last_heartbeat < ?".into(),
+            insert_shard: "INSERT INTO faucet_serve_shards \
+                (run_id, shard_id, descriptor, size_estimate, status, attempt) \
+                VALUES (?,?,?,?,'pending','0') \
+                ON CONFLICT (run_id, shard_id) DO NOTHING"
+                .into(),
+            claim_shards_select: "SELECT s.run_id, s.shard_id, s.descriptor, r.body \
+                FROM faucet_serve_shards s JOIN faucet_serve_runs r ON r.run_id = s.run_id \
+                WHERE s.status = 'pending' \
+                ORDER BY CAST(COALESCE(s.size_estimate, '0') AS INTEGER) DESC, s.run_id, s.shard_id \
+                LIMIT ?"
+                .into(),
+            claim_shard_one: "UPDATE faucet_serve_shards \
+                SET owner = ?, status = 'running', lease_expires_at = ? \
+                WHERE run_id = ? AND shard_id = ? AND status = 'pending'"
+                .into(),
+            renew_shard_leases: "UPDATE faucet_serve_shards SET lease_expires_at = ? \
+                WHERE owner = ? AND status = 'running'"
+                .into(),
+            reclaim_shards_select: "SELECT run_id, shard_id, attempt FROM faucet_serve_shards \
+                WHERE status = 'running' \
+                AND (lease_expires_at IS NULL OR lease_expires_at < ?)"
+                .into(),
+            reclaim_shard_requeue: "UPDATE faucet_serve_shards \
+                SET status = 'pending', owner = NULL, lease_expires_at = NULL, attempt = ? \
+                WHERE run_id = ? AND shard_id = ? AND status = 'running' \
+                AND (lease_expires_at IS NULL OR lease_expires_at < ?)"
+                .into(),
+            reclaim_shard_fail: "UPDATE faucet_serve_shards \
+                SET status = 'failed', finished_at = ?, owner = NULL \
+                WHERE run_id = ? AND shard_id = ? AND status = 'running' \
+                AND (lease_expires_at IS NULL OR lease_expires_at < ?)"
+                .into(),
+            finalize_shard: "UPDATE faucet_serve_shards \
+                SET status = ?, finished_at = ? \
+                WHERE run_id = ? AND shard_id = ? AND owner = ? AND status = 'running'"
+                .into(),
+            shard_progress: "SELECT status, COUNT(*) AS n FROM faucet_serve_shards \
+                WHERE run_id = ? GROUP BY status"
+                .into(),
         }
     }
 }
@@ -1040,6 +1155,220 @@ macro_rules! impl_sql_history {
                     });
                 }
                 Ok(out)
+            }
+
+            // ── Source shards (Mode B, #230) ─────────────────────────────────
+
+            async fn insert_shards(
+                &self,
+                run_id: &str,
+                shards: &[$crate::serve::history::ShardInsert],
+            ) -> Result<usize, $crate::serve::history::HistoryError> {
+                use $crate::serve::history::HistoryError;
+                let backend = |e: sqlx::Error| HistoryError::Backend(e.to_string());
+                let mut inserted = 0usize;
+                for s in shards {
+                    let descriptor = serde_json::to_string(&s.descriptor).map_err(|e| {
+                        HistoryError::Backend(format!("encode shard descriptor: {e}"))
+                    })?;
+                    let size = s.size_estimate.map(|n| n.to_string());
+                    let n = sqlx::query(&self.stmts.insert_shard)
+                        .bind(run_id)
+                        .bind(&s.shard_id)
+                        .bind(&descriptor)
+                        .bind(size.as_deref())
+                        .execute(&self.pool)
+                        .await
+                        .map_err(backend)?
+                        .rows_affected();
+                    inserted += n as usize;
+                }
+                Ok(inserted)
+            }
+
+            async fn claim_shards(
+                &self,
+                limit: usize,
+            ) -> Result<
+                Vec<$crate::serve::history::ClaimedShard>,
+                $crate::serve::history::HistoryError,
+            > {
+                use sqlx::Row as _;
+                use $crate::serve::history::ClaimedShard;
+                use $crate::serve::history::HistoryError;
+                use $crate::serve::history::sql;
+                let backend = |e: sqlx::Error| HistoryError::Backend(e.to_string());
+                if limit == 0 {
+                    return Ok(Vec::new());
+                }
+                let lease = sql::fmt_ts(chrono::Utc::now() + self.lease_ttl);
+
+                // 1. Candidate pending shards (largest estimated size first),
+                //    joined to their parent run body.
+                let rows = sqlx::query(&self.stmts.claim_shards_select)
+                    .bind(limit as i64)
+                    .fetch_all(&self.pool)
+                    .await
+                    .map_err(backend)?;
+
+                // 2. Per-row conditional claim (portable; not FOR UPDATE SKIP LOCKED).
+                let mut claimed = Vec::new();
+                for row in &rows {
+                    let run_id: String = row.try_get("run_id").map_err(backend)?;
+                    let shard_id: String = row.try_get("shard_id").map_err(backend)?;
+                    let descriptor_s: String = row.try_get("descriptor").map_err(backend)?;
+                    let body: String = row.try_get("body").map_err(backend)?;
+                    let won = sqlx::query(&self.stmts.claim_shard_one)
+                        .bind(&self.instance_id)
+                        .bind(&lease)
+                        .bind(&run_id)
+                        .bind(&shard_id)
+                        .execute(&self.pool)
+                        .await
+                        .map_err(backend)?
+                        .rows_affected();
+                    if won == 1 {
+                        let descriptor: serde_json::Value = serde_json::from_str(&descriptor_s)
+                            .map_err(|e| {
+                                HistoryError::Backend(format!("decode shard descriptor: {e}"))
+                            })?;
+                        let run = sql::decode_body(&body)?;
+                        claimed.push(ClaimedShard {
+                            run_id,
+                            shard_id,
+                            descriptor,
+                            run,
+                        });
+                    }
+                }
+                Ok(claimed)
+            }
+
+            async fn renew_shard_leases(
+                &self,
+            ) -> Result<usize, $crate::serve::history::HistoryError> {
+                use $crate::serve::history::HistoryError;
+                use $crate::serve::history::sql;
+                let backend = |e: sqlx::Error| HistoryError::Backend(e.to_string());
+                let lease = sql::fmt_ts(chrono::Utc::now() + self.lease_ttl);
+                let n = sqlx::query(&self.stmts.renew_shard_leases)
+                    .bind(&lease)
+                    .bind(&self.instance_id)
+                    .execute(&self.pool)
+                    .await
+                    .map_err(backend)?
+                    .rows_affected() as usize;
+                Ok(n)
+            }
+
+            async fn reclaim_shards(
+                &self,
+                max_attempts: u32,
+            ) -> Result<$crate::serve::history::ReclaimReport, $crate::serve::history::HistoryError>
+            {
+                use sqlx::Row as _;
+                use $crate::serve::history::HistoryError;
+                use $crate::serve::history::ReclaimReport;
+                use $crate::serve::history::sql;
+                let backend = |e: sqlx::Error| HistoryError::Backend(e.to_string());
+                let now_s = sql::fmt_ts(chrono::Utc::now());
+
+                let rows = sqlx::query(&self.stmts.reclaim_shards_select)
+                    .bind(&now_s)
+                    .fetch_all(&self.pool)
+                    .await
+                    .map_err(backend)?;
+
+                let mut report = ReclaimReport::default();
+                for row in &rows {
+                    let run_id: String = row.try_get("run_id").map_err(backend)?;
+                    let shard_id: String = row.try_get("shard_id").map_err(backend)?;
+                    let attempt_s: String = row.try_get("attempt").map_err(backend)?;
+                    let attempt: u32 = attempt_s.parse().unwrap_or(0);
+                    if attempt < max_attempts {
+                        let next = (attempt + 1).to_string();
+                        let n = sqlx::query(&self.stmts.reclaim_shard_requeue)
+                            .bind(&next)
+                            .bind(&run_id)
+                            .bind(&shard_id)
+                            .bind(&now_s)
+                            .execute(&self.pool)
+                            .await
+                            .map_err(backend)?
+                            .rows_affected();
+                        if n == 1 {
+                            report.requeued += 1;
+                        }
+                    } else {
+                        let n = sqlx::query(&self.stmts.reclaim_shard_fail)
+                            .bind(&now_s)
+                            .bind(&run_id)
+                            .bind(&shard_id)
+                            .bind(&now_s)
+                            .execute(&self.pool)
+                            .await
+                            .map_err(backend)?
+                            .rows_affected();
+                        if n == 1 {
+                            report.failed += 1;
+                        }
+                    }
+                }
+                Ok(report)
+            }
+
+            async fn finalize_shard(
+                &self,
+                run_id: &str,
+                shard_id: &str,
+                success: bool,
+            ) -> Result<bool, $crate::serve::history::HistoryError> {
+                use $crate::serve::history::HistoryError;
+                use $crate::serve::history::sql;
+                let backend = |e: sqlx::Error| HistoryError::Backend(e.to_string());
+                let status = if success { "completed" } else { "failed" };
+                let now_s = sql::fmt_ts(chrono::Utc::now());
+                let n = sqlx::query(&self.stmts.finalize_shard)
+                    .bind(status)
+                    .bind(&now_s)
+                    .bind(run_id)
+                    .bind(shard_id)
+                    .bind(&self.instance_id)
+                    .execute(&self.pool)
+                    .await
+                    .map_err(backend)?
+                    .rows_affected();
+                Ok(n == 1)
+            }
+
+            async fn shard_progress(
+                &self,
+                run_id: &str,
+            ) -> Result<$crate::serve::history::ShardProgress, $crate::serve::history::HistoryError>
+            {
+                use sqlx::Row as _;
+                use $crate::serve::history::HistoryError;
+                use $crate::serve::history::ShardProgress;
+                let backend = |e: sqlx::Error| HistoryError::Backend(e.to_string());
+                let rows = sqlx::query(&self.stmts.shard_progress)
+                    .bind(run_id)
+                    .fetch_all(&self.pool)
+                    .await
+                    .map_err(backend)?;
+                let mut p = ShardProgress::default();
+                for row in &rows {
+                    let status: String = row.try_get("status").map_err(backend)?;
+                    let n: i64 = row.try_get("n").map_err(backend)?;
+                    let n = n.max(0) as usize;
+                    p.total += n;
+                    match status.as_str() {
+                        "completed" => p.completed += n,
+                        "failed" => p.failed += n,
+                        "running" => p.running += n,
+                        _ => p.pending += n,
+                    }
+                }
+                Ok(p)
             }
 
             fn degraded(&self) -> bool {

--- a/cli/src/serve/history/sql.rs
+++ b/cli/src/serve/history/sql.rs
@@ -1388,6 +1388,23 @@ mod tests {
     use super::*;
 
     #[test]
+    fn postgres_shard_statements_are_built() {
+        // SQLite tests only build the Sqlite statement set; exercise the
+        // Postgres shard-statement construction too (Mode B, #230).
+        let s = Stmts::new(Dialect::Postgres);
+        assert!(s.insert_shard.contains("faucet_serve_shards"));
+        assert!(s.insert_shard.contains("ON CONFLICT"));
+        assert!(s.claim_shards_select.contains("JOIN faucet_serve_runs"));
+        assert!(s.claim_shard_one.contains("'running'"));
+        assert!(s.renew_shard_leases.contains("lease_expires_at"));
+        assert!(s.reclaim_shards_select.contains("'running'"));
+        assert!(s.reclaim_shard_requeue.contains("'pending'"));
+        assert!(s.reclaim_shard_fail.contains("'failed'"));
+        assert!(s.finalize_shard.contains("owner"));
+        assert!(s.shard_progress.contains("GROUP BY"));
+    }
+
+    #[test]
     fn fmt_ts_is_fixed_width_and_sortable() {
         let a = fmt_ts(
             DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")

--- a/cli/src/serve/history/sqlite.rs
+++ b/cli/src/serve/history/sqlite.rs
@@ -46,3 +46,140 @@ impl SqliteHistory {
         ))
     }
 }
+
+#[cfg(test)]
+mod shard_tests {
+    use super::*;
+    use crate::serve::history::{RunHistory, RunRecord, RunStatus, ShardInsert};
+    use std::collections::BTreeMap;
+
+    fn shard(id: &str, size: u64) -> ShardInsert {
+        ShardInsert {
+            shard_id: id.into(),
+            descriptor: serde_json::json!({ "i": id }),
+            size_estimate: Some(size),
+        }
+    }
+
+    async fn backend(url: &str, instance: &str, ttl: Duration) -> SqliteHistory {
+        SqliteHistory::connect(url, Duration::from_secs(300), ttl, instance.into())
+            .await
+            .expect("connect")
+    }
+
+    async fn seed_run(h: &SqliteHistory, run_id: &str) {
+        let mut rec = RunRecord::queued(
+            run_id.into(),
+            None,
+            BTreeMap::new(),
+            None,
+            chrono::Utc::now(),
+        );
+        rec.status = RunStatus::Pending;
+        rec.config_body = Some("version: 1".into());
+        h.upsert(&rec).await.expect("seed run");
+    }
+
+    fn url_in(dir: &std::path::Path) -> String {
+        format!("sqlite://{}/h.db", dir.display())
+    }
+
+    #[tokio::test]
+    async fn insert_shards_is_idempotent_and_progress_counts() {
+        let dir = tempfile::tempdir().unwrap();
+        let h = backend(&url_in(dir.path()), "a", Duration::from_secs(60)).await;
+        seed_run(&h, "run1").await;
+        let shards = [shard("0", 10), shard("1", 20), shard("2", 5)];
+
+        assert_eq!(h.insert_shards("run1", &shards).await.unwrap(), 3);
+        assert_eq!(
+            h.insert_shards("run1", &shards).await.unwrap(),
+            0,
+            "re-insert is a no-op (ON CONFLICT DO NOTHING)"
+        );
+
+        let p = h.shard_progress("run1").await.unwrap();
+        assert_eq!(p.total, 3);
+        assert_eq!(p.pending, 3);
+        assert!(!p.all_terminal());
+    }
+
+    #[tokio::test]
+    async fn claim_shards_largest_first_marks_running_and_is_exclusive() {
+        let dir = tempfile::tempdir().unwrap();
+        let h = backend(&url_in(dir.path()), "a", Duration::from_secs(60)).await;
+        seed_run(&h, "run1").await;
+        h.insert_shards("run1", &[shard("0", 10), shard("1", 20), shard("2", 5)])
+            .await
+            .unwrap();
+
+        let claimed = h.claim_shards(10).await.unwrap();
+        assert_eq!(claimed.len(), 3);
+        // Largest estimated size first.
+        assert_eq!(claimed[0].shard_id, "1");
+        assert_eq!(claimed[1].shard_id, "0");
+        assert_eq!(claimed[2].shard_id, "2");
+        // Parent run body is carried for the worker to rebuild the source.
+        assert_eq!(claimed[0].run.config_body.as_deref(), Some("version: 1"));
+        assert_eq!(claimed[0].descriptor, serde_json::json!({ "i": "1" }));
+
+        let p = h.shard_progress("run1").await.unwrap();
+        assert_eq!(p.running, 3);
+
+        // Everything is claimed → a second claim returns nothing.
+        assert!(h.claim_shards(10).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn finalize_shard_is_owner_fenced() {
+        let dir = tempfile::tempdir().unwrap();
+        let url = url_in(dir.path());
+        let a = backend(&url, "inst-a", Duration::from_secs(60)).await;
+        let b = backend(&url, "inst-b", Duration::from_secs(60)).await;
+        seed_run(&a, "run1").await;
+        a.insert_shards("run1", &[shard("0", 1)]).await.unwrap();
+
+        // A claims the only shard.
+        let claimed = a.claim_shards(10).await.unwrap();
+        assert_eq!(claimed.len(), 1);
+
+        // B does not own it → cannot finalize.
+        assert!(
+            !b.finalize_shard("run1", "0", true).await.unwrap(),
+            "a non-owner must not finalize the shard"
+        );
+        // A owns it → finalize succeeds.
+        assert!(a.finalize_shard("run1", "0", true).await.unwrap());
+
+        let p = a.shard_progress("run1").await.unwrap();
+        assert_eq!(p.completed, 1);
+        assert!(p.all_terminal());
+    }
+
+    #[tokio::test]
+    async fn reclaim_shards_requeues_expired_then_poisons() {
+        let dir = tempfile::tempdir().unwrap();
+        let url = url_in(dir.path());
+        // lease_ttl = 0 → a claimed shard's lease is already in the past on the
+        // next call, so it is reclaimable deterministically.
+        let h = backend(&url, "inst-a", Duration::ZERO).await;
+        seed_run(&h, "run1").await;
+        h.insert_shards("run1", &[shard("0", 1)]).await.unwrap();
+        h.claim_shards(10).await.unwrap();
+
+        // First reclaim: attempt 0 < 2 → requeued back to pending.
+        let r1 = h.reclaim_shards(2).await.unwrap();
+        assert_eq!(r1.requeued, 1);
+        assert_eq!(r1.failed, 0);
+        assert_eq!(h.shard_progress("run1").await.unwrap().pending, 1);
+
+        // Re-claim and reclaim until the attempt cap poisons it.
+        h.claim_shards(10).await.unwrap();
+        let r2 = h.reclaim_shards(2).await.unwrap();
+        assert_eq!(r2.requeued, 1, "attempt 1 < 2 → still requeued");
+        h.claim_shards(10).await.unwrap();
+        let r3 = h.reclaim_shards(2).await.unwrap();
+        assert_eq!(r3.failed, 1, "attempt 2 >= 2 → poisoned (failed)");
+        assert_eq!(h.shard_progress("run1").await.unwrap().failed, 1);
+    }
+}

--- a/cli/src/serve/metrics.rs
+++ b/cli/src/serve/metrics.rs
@@ -176,4 +176,12 @@ mod tests {
              axum 0.8 outer .layer() correctly sees MatchedPath"
         );
     }
+
+    #[test]
+    fn shard_metrics_emit_without_a_recorder() {
+        // With no global recorder installed these are no-ops; assert they don't
+        // panic and exercise the emit helpers (Mode B, #230).
+        super::record_shards_claimed(3);
+        super::record_shards_reclaimed(2, 1);
+    }
 }

--- a/cli/src/serve/metrics.rs
+++ b/cli/src/serve/metrics.rs
@@ -74,6 +74,19 @@ pub fn record_runs_claimed(n: usize) {
     metrics::counter!("faucet_serve_runs_claimed_total").increment(n as u64);
 }
 
+/// Count source shards claimed for execution by this instance (Mode B, #230).
+pub fn record_shards_claimed(n: usize) {
+    metrics::counter!("faucet_serve_shards_claimed_total").increment(n as u64);
+}
+
+/// Count shard reclaims (rebalance), split by outcome (Mode B, #230).
+pub fn record_shards_reclaimed(requeued: usize, failed: usize) {
+    metrics::counter!("faucet_serve_shards_reclaimed_total", "outcome" => "requeued")
+        .increment(requeued as u64);
+    metrics::counter!("faucet_serve_shards_reclaimed_total", "outcome" => "failed")
+        .increment(failed as u64);
+}
+
 /// `1` when clustered execution is enabled for this instance, else `0`.
 pub fn set_cluster_enabled(on: bool) {
     metrics::gauge!("faucet_serve_cluster_enabled").set(if on { 1.0 } else { 0.0 });

--- a/cli/src/serve/runner.rs
+++ b/cli/src/serve/runner.rs
@@ -1813,5 +1813,86 @@ mod tests {
             assert_eq!(status, RunStatus::Completed, "shard ran → parent completed");
             assert!(output.exists(), "shard wrote its output");
         }
+
+        #[tokio::test]
+        async fn resume_claimed_shard_with_no_config_fails_the_shard() {
+            // A claimed shard whose parent run has no config_body can't run →
+            // the shard is finalized failed and the parent run fails.
+            let dir = tempfile::tempdir().unwrap();
+            let state = sqlite_state(dir.path()).await;
+            let mut rec = RunRecord::queued("r".into(), None, BTreeMap::new(), None, Utc::now());
+            rec.status = RunStatus::Sharded; // config_body intentionally None
+            state.history().upsert(&rec).await.unwrap();
+            use crate::serve::history::ShardInsert;
+            state
+                .history()
+                .insert_shards(
+                    "r",
+                    &[ShardInsert {
+                        shard_id: "0".into(),
+                        descriptor: serde_json::Value::Null,
+                        size_estimate: None,
+                    }],
+                )
+                .await
+                .unwrap();
+            let claimed = state.history().claim_shards(1).await.unwrap();
+            resume_claimed_shard(state.clone(), claimed.into_iter().next().unwrap());
+
+            let mut status = RunStatus::Sharded;
+            for _ in 0..100 {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                status = state.history().get("r").await.unwrap().unwrap().status;
+                if status.is_terminal() {
+                    break;
+                }
+            }
+            assert_eq!(status, RunStatus::Failed, "no-config shard → parent failed");
+        }
+
+        #[tokio::test]
+        async fn coordinate_returns_err_when_source_build_fails() {
+            // A shardable-looking source with an invalid config fails to build →
+            // coordinate_sharded_run surfaces the error (the caller fails the run).
+            let dir = tempfile::tempdir().unwrap();
+            let state = sqlite_state(dir.path()).await;
+            // s3 missing the required `file_format` field → build_source errors.
+            let l = loaded(
+                "version: 1\npipeline:\n  \
+                 source: { type: s3, config: { bucket: b } }\n  \
+                 sink: { type: stdout, config: {} }\n",
+            )
+            .await;
+            assert!(coordinate_sharded_run(&state, "r", &l, 4).await.is_err());
+        }
+
+        #[tokio::test]
+        async fn execute_shard_returns_false_on_malformed_resilience() {
+            // A resilience block that parses but fails to compile makes
+            // execute_shard fail fast (false) before running the pipeline.
+            let dir = tempfile::tempdir().unwrap();
+            let state = sqlite_state(dir.path()).await;
+            let input = dir.path().join("in.csv");
+            std::fs::write(&input, "id\n1\n").unwrap();
+            let yaml = format!(
+                "version: 1\nresilience:\n  retry:\n    max_attempts: 0\npipeline:\n  \
+                 source: {{ type: csv, config: {{ path: \"{}\" }} }}\n  \
+                 sink: {{ type: stdout, config: {{}} }}\n",
+                input.display()
+            );
+            let l = loaded(&yaml).await;
+            let ok = execute_shard(
+                &state,
+                l,
+                "r",
+                "0",
+                ShardSpec::whole(),
+                None,
+                None,
+                Utc::now(),
+            )
+            .await;
+            assert!(!ok, "malformed resilience → shard fails fast");
+        }
     }
 }

--- a/cli/src/serve/runner.rs
+++ b/cli/src/serve/runner.rs
@@ -1894,5 +1894,46 @@ mod tests {
             .await;
             assert!(!ok, "malformed resilience → shard fails fast");
         }
+
+        #[tokio::test]
+        async fn resume_claimed_shard_with_unloadable_config_fails_the_shard() {
+            // A claimed shard whose run config fails to re-load (malformed body)
+            // exercises resume_claimed_shard's load-error branch → shard failed.
+            let dir = tempfile::tempdir().unwrap();
+            let state = sqlite_state(dir.path()).await;
+            let mut rec = RunRecord::queued("r".into(), None, BTreeMap::new(), None, Utc::now());
+            rec.status = RunStatus::Sharded;
+            rec.config_body = Some("this: is: not: valid: yaml: [".into());
+            state.history().upsert(&rec).await.unwrap();
+            use crate::serve::history::ShardInsert;
+            state
+                .history()
+                .insert_shards(
+                    "r",
+                    &[ShardInsert {
+                        shard_id: "0".into(),
+                        descriptor: serde_json::Value::Null,
+                        size_estimate: None,
+                    }],
+                )
+                .await
+                .unwrap();
+            let claimed = state.history().claim_shards(1).await.unwrap();
+            resume_claimed_shard(state.clone(), claimed.into_iter().next().unwrap());
+
+            let mut status = RunStatus::Sharded;
+            for _ in 0..100 {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                status = state.history().get("r").await.unwrap().unwrap().status;
+                if status.is_terminal() {
+                    break;
+                }
+            }
+            assert_eq!(
+                status,
+                RunStatus::Failed,
+                "unloadable config → parent failed"
+            );
+        }
     }
 }

--- a/cli/src/serve/runner.rs
+++ b/cli/src/serve/runner.rs
@@ -6,8 +6,10 @@
 
 use crate::auth_catalog::build_auth_catalog;
 use crate::executor::{ExecuteOptions, RunSummary, run_expanded};
+use crate::registry::build_source;
 use crate::serve::error::ServeError;
 use crate::serve::history::{Claim, InvocationRecord, RunRecord, RunStatus};
+use crate::serve::history::{ClaimedShard, ShardInsert};
 use crate::serve::load::{ConfigFormat, LoadedSubmission, load_submission};
 use crate::serve::state::ServerState;
 use crate::serve::{idempotency, metrics};
@@ -113,6 +115,33 @@ pub fn resume_claimed_run(state: ServerState, rec: RunRecord) {
             }
         };
 
+        // Mode B (#230): a sharded run is expanded into shard rows here — the
+        // claiming instance acts as the (ephemeral) coordinator — and is NOT
+        // executed as a whole. Enumeration + insert is idempotent, so two
+        // instances both claiming + coordinating converge on the same shard set.
+        if let Some(sh) = loaded.cfg.shard.clone()
+            && sh.count >= 2
+        {
+            match coordinate_sharded_run(&state, &run_id, &loaded, sh.count).await {
+                Ok(true) => return, // expanded into shards — shard loop runs them
+                Ok(false) => {}     // not shardable → fall through, run the whole run
+                Err(e) => {
+                    finalize(
+                        &state,
+                        &run_id,
+                        rec.submitted_at,
+                        Terminal::Failed {
+                            reason: format!("sharding: {e}"),
+                            records: 0,
+                            invs: Vec::new(),
+                        },
+                    )
+                    .await;
+                    return;
+                }
+            }
+        }
+
         // The claim loop only claims up to available_permits and is the sole
         // permit consumer, so this acquire returns immediately.
         let _permit = state
@@ -136,6 +165,308 @@ pub fn resume_claimed_run(state: ServerState, rec: RunRecord) {
         )
         .await;
     });
+}
+
+/// Coordinator step (Mode B): expand a sharded run into `faucet_serve_shards`
+/// rows. Returns `Ok(true)` when the run was sharded (caller must not execute it
+/// as a whole), `Ok(false)` when it isn't shardable (caller runs it whole).
+///
+/// Idempotent: enumeration is deterministic and the insert is
+/// `ON CONFLICT DO NOTHING`, so a re-coordinated run (e.g. after the coordinator
+/// crashed and the Pending run was requeued) converges on the same shard set.
+async fn coordinate_sharded_run(
+    state: &ServerState,
+    run_id: &str,
+    loaded: &LoadedSubmission,
+    count: usize,
+) -> crate::error::CliResult<bool> {
+    use crate::error::CliError;
+
+    // Sharding applies to a single-source pipeline; a matrix fan-out is not
+    // shardable (each row is already an independent unit — use Mode A).
+    if loaded.nodes.len() != 1 {
+        tracing::warn!(
+            run_id,
+            nodes = loaded.nodes.len(),
+            "shard requested but the run is not a single-node pipeline; running it whole"
+        );
+        return Ok(false);
+    }
+    let node = &loaded.nodes[0];
+    let auth = build_auth_catalog(loaded.cfg.auth.as_ref())
+        .map_err(|e| CliError::Internal(format!("auth catalog: {e}")))?;
+    let source = build_source(&node.source.kind, node.source.config.clone(), &auth, None).await?;
+    if !source.is_shardable() {
+        tracing::warn!(
+            run_id,
+            kind = %node.source.kind,
+            "source is not shardable; running the run whole"
+        );
+        return Ok(false);
+    }
+
+    let shards = source
+        .enumerate_shards(count)
+        .await
+        .map_err(|e| CliError::Internal(format!("enumerate_shards: {e}")))?;
+    let inserts: Vec<ShardInsert> = shards
+        .iter()
+        .map(|s| ShardInsert {
+            shard_id: s.id.clone(),
+            descriptor: s.descriptor.clone(),
+            size_estimate: s.size_estimate,
+        })
+        .collect();
+    let inserted = state
+        .history()
+        .insert_shards(run_id, &inserts)
+        .await
+        .map_err(|e| CliError::Internal(e.to_string()))?;
+    tracing::info!(
+        run_id,
+        shards = inserts.len(),
+        inserted,
+        "expanded run into shards (Mode B)"
+    );
+
+    // Mark the parent run Sharded (passive — finalized by shard completion).
+    if let Ok(Some(mut r)) = state.history().get(run_id).await {
+        r.status = RunStatus::Sharded;
+        let _ = state.history().upsert(&r).await;
+    }
+    // Wake the local claim loop so it picks up the freshly-inserted shards.
+    state.cluster().kick();
+    Ok(true)
+}
+
+/// Execute one claimed shard (Mode B): rebuild + narrow the source to the shard,
+/// run it under a permit, owner-fenced-finalize the shard, then finalize the
+/// parent run once every shard is terminal.
+pub fn resume_claimed_shard(state: ServerState, claimed: ClaimedShard) {
+    tokio::spawn(async move {
+        let ClaimedShard {
+            run_id,
+            shard_id,
+            descriptor,
+            run,
+        } = claimed;
+
+        let Some(body) = run.config_body.clone() else {
+            tracing::error!(run_id, shard_id, "claimed shard's run has no stored config");
+            let _ = state
+                .history()
+                .finalize_shard(&run_id, &shard_id, false)
+                .await;
+            maybe_finalize_parent(&state, &run_id).await;
+            return;
+        };
+        let format = run.config_format.unwrap_or_default();
+        let loaded = match load_submission(&body, format, state.default_base()).await {
+            Ok(l) => l,
+            Err(e) => {
+                tracing::error!(
+                    run_id,
+                    shard_id,
+                    error = %e.api_error().error.message,
+                    "re-loading shard config failed"
+                );
+                let _ = state
+                    .history()
+                    .finalize_shard(&run_id, &shard_id, false)
+                    .await;
+                maybe_finalize_parent(&state, &run_id).await;
+                return;
+            }
+        };
+
+        let _permit = state
+            .semaphore()
+            .acquire_owned()
+            .await
+            .expect("semaphore not closed");
+
+        let shard = faucet_core::ShardSpec {
+            id: shard_id.clone(),
+            descriptor,
+            size_estimate: None,
+        };
+        let success = execute_shard(
+            &state,
+            loaded,
+            &run_id,
+            &shard_id,
+            shard,
+            run.timeout_secs,
+            run.clock.clone(),
+            run.submitted_at,
+        )
+        .await;
+
+        match state
+            .history()
+            .finalize_shard(&run_id, &shard_id, success)
+            .await
+        {
+            Ok(true) => {}
+            Ok(false) => tracing::warn!(
+                run_id,
+                shard_id,
+                "shard was reclaimed by another instance; discarding result"
+            ),
+            Err(e) => tracing::error!(run_id, shard_id, error = %e, "finalize_shard failed"),
+        }
+        maybe_finalize_parent(&state, &run_id).await;
+    });
+}
+
+/// Run one shard's pipeline (single node, source narrowed via `opts.shard`).
+/// Returns `true` on clean completion. Does not touch the parent run record —
+/// the caller finalizes the shard and the parent.
+#[allow(clippy::too_many_arguments)]
+async fn execute_shard(
+    state: &ServerState,
+    loaded: LoadedSubmission,
+    run_id: &str,
+    shard_id: &str,
+    shard: faucet_core::ShardSpec,
+    timeout_secs: Option<u64>,
+    clock_flag: Option<String>,
+    submitted_at: DateTime<Utc>,
+) -> bool {
+    let LoadedSubmission { cfg, nodes } = loaded;
+    let pipeline_name = cfg.name.clone().unwrap_or_else(|| "serve".to_string());
+
+    let auth = match build_auth_catalog(cfg.auth.as_ref()) {
+        Ok(a) => a,
+        Err(e) => {
+            tracing::error!(run_id, shard_id, "shard auth catalog: {e}");
+            return false;
+        }
+    };
+    let clock = match resolve_clock(clock_flag.as_deref(), submitted_at) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::error!(
+                run_id,
+                shard_id,
+                "shard clock: {}",
+                e.api_error().error.message
+            );
+            return false;
+        }
+    };
+    let resilience = match &cfg.resilience {
+        Some(spec) => match spec.to_policy() {
+            Ok(p) => Some(p),
+            Err(e) => {
+                tracing::error!(run_id, shard_id, "shard resilience: {e}");
+                return false;
+            }
+        },
+        None => None,
+    };
+    #[cfg(feature = "lineage")]
+    let lineage = match crate::lineage_glue::build_emitter(cfg.lineage.as_ref()) {
+        Ok(l) => l,
+        Err(e) => {
+            tracing::error!(run_id, shard_id, "shard lineage: {e}");
+            return false;
+        }
+    };
+
+    let coop = CancellationToken::new();
+    let opts = ExecuteOptions {
+        pipeline_name,
+        execution: cfg.execution.clone(),
+        dry_run: false,
+        limit: None,
+        state_path_override: None,
+        shard: Some(shard),
+        auth,
+        clock,
+        cancel: Some(coop.clone()),
+        resilience,
+        #[cfg(feature = "lineage")]
+        lineage,
+        #[cfg(feature = "lineage")]
+        lineage_cfg: cfg.lineage.clone(),
+    };
+
+    let server_shutdown = state.shutdown_token();
+    let span = tracing::info_span!("faucet.serve.shard", serve_run_id = %run_id, shard = %shard_id);
+    let work = async move { classify_run(run_expanded(nodes, opts).await) }.instrument(span);
+    tokio::pin!(work);
+    let timeout_fut = async {
+        match timeout_secs {
+            Some(s) => tokio::time::sleep(Duration::from_secs(s)).await,
+            None => std::future::pending::<()>().await,
+        }
+    };
+    tokio::pin!(timeout_fut);
+
+    // Cancel triggers (shutdown / timeout) cooperatively cancel + flush, like
+    // execute_run. A failed shard simply returns false → its lease eventually
+    // reassigns it (or it poisons after max_attempts).
+    let terminal = tokio::select! {
+        biased;
+        t = &mut work => t,
+        _ = server_shutdown.cancelled() => {
+            coop.cancel();
+            let _ = tokio::time::timeout(RUN_FLUSH_GRACE, &mut work).await;
+            Terminal::ShutdownFailed
+        }
+        _ = &mut timeout_fut => {
+            coop.cancel();
+            let _ = tokio::time::timeout(RUN_FLUSH_GRACE, &mut work).await;
+            Terminal::Timeout { secs: timeout_secs.unwrap_or(0) }
+        }
+    };
+    matches!(terminal, Terminal::Completed { .. })
+}
+
+/// Finalize a `Sharded` parent run once all its shards are terminal. The last
+/// shard to finish always observes `all_terminal` (its own `finalize_shard`
+/// committed first), so the run never lingers `Sharded`. A benign double-finalize
+/// (two shards finishing simultaneously) writes the same terminal status twice.
+async fn maybe_finalize_parent(state: &ServerState, run_id: &str) {
+    let progress = match state.history().shard_progress(run_id).await {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!(run_id, error = %e, "shard_progress failed");
+            return;
+        }
+    };
+    if !progress.all_terminal() {
+        return;
+    }
+    let success = progress.failed == 0;
+    if let Ok(Some(mut r)) = state.history().get(run_id).await
+        && r.status == RunStatus::Sharded
+    {
+        r.status = if success {
+            RunStatus::Completed
+        } else {
+            RunStatus::Failed
+        };
+        r.finished_at = Some(Utc::now());
+        if !success {
+            r.error = Some(format!(
+                "{}/{} shard(s) failed",
+                progress.failed, progress.total
+            ));
+        }
+        if let Err(e) = state.history().upsert(&r).await {
+            tracing::error!(run_id, error = %e, "finalizing sharded parent run failed");
+            return;
+        }
+        metrics::record_run_finished(r.status, if success { "ok" } else { "error" });
+        tracing::info!(
+            run_id,
+            shards = progress.total,
+            failed = progress.failed,
+            "sharded run finalized"
+        );
+    }
 }
 
 /// Validate, idempotency-claim, queue, and spawn a submission.
@@ -653,6 +984,7 @@ async fn execute_run(
         dry_run: false,
         limit: None,
         state_path_override: None,
+        shard: None,
         auth,
         clock,
         cancel: Some(coop.clone()),

--- a/cli/src/serve/runner.rs
+++ b/cli/src/serve/runner.rs
@@ -1515,4 +1515,303 @@ mod tests {
         // The queue reservation must have been released (no leak).
         assert_eq!(state.registry().queued(), 0);
     }
+
+    // ── Mode B coverage: coordinator / parent finalize / shard execution ─────
+    // SQLite-backed so the shard RunHistory methods are live (the memory backend
+    // is inert for shards). No Docker: the S3 source builds offline and its
+    // enumerate_shards is pure (hash-modulo); csv→jsonl runs entirely on temp
+    // files.
+    #[cfg(feature = "serve-history-sqlite")]
+    mod shards {
+        use super::*;
+        use crate::serve::config::{AuthMode, HistoryBackendSpec, ServeConfig};
+        use crate::serve::history::RunHistory;
+        use crate::serve::history::sqlite::SqliteHistory;
+        use crate::serve::load::{ConfigFormat, load_submission};
+        use crate::serve::state::ServerState;
+        use faucet_core::ShardSpec;
+        use std::collections::BTreeMap;
+        use std::sync::Arc;
+        use tokio_util::sync::CancellationToken;
+
+        async fn sqlite_state(dir: &std::path::Path) -> ServerState {
+            let url = format!("sqlite://{}/h.db", dir.display());
+            let history = Arc::new(
+                SqliteHistory::connect(
+                    &url,
+                    Duration::from_secs(300),
+                    Duration::from_secs(300),
+                    "inst-test".into(),
+                )
+                .await
+                .expect("sqlite history"),
+            ) as Arc<dyn RunHistory>;
+            let cfg = ServeConfig {
+                listen: "127.0.0.1:0".parse().unwrap(),
+                auth: AuthMode::None,
+                max_concurrent_runs: 4,
+                max_queued_runs: 4,
+                default_config_path: None,
+                history: HistoryBackendSpec::Memory,
+                cors_origins: vec![],
+                body_limit_bytes: 1_048_576,
+                shutdown_grace: Duration::from_secs(60),
+                retain_terminal_runs: Duration::from_secs(60),
+                idempotency_retention: Duration::from_secs(60),
+                lease_ttl: Duration::from_secs(30),
+                probe_timeout: Duration::from_secs(10),
+                env_file: None,
+                no_env_file: false,
+                log_level: "info".into(),
+                ui_enabled: true,
+                cluster: crate::serve::cluster::ClusterConfig::disabled(),
+                triggers_path: None,
+            };
+            ServerState::new(
+                &cfg,
+                None,
+                CancellationToken::new(),
+                history,
+                crate::serve::logs::LogHub::new(),
+                None,
+                #[cfg(feature = "triggers")]
+                crate::serve::triggers::health::TriggersHandle::empty(),
+            )
+        }
+
+        async fn loaded(yaml: &str) -> LoadedSubmission {
+            load_submission(yaml, ConfigFormat::Yaml, None)
+                .await
+                .expect("load submission")
+        }
+
+        async fn seed_run(state: &ServerState, run_id: &str, status: RunStatus) {
+            let mut rec = RunRecord::queued(run_id.into(), None, BTreeMap::new(), None, Utc::now());
+            rec.status = status;
+            rec.config_body = Some("version: 1".into());
+            state.history().upsert(&rec).await.expect("seed run");
+        }
+
+        #[tokio::test]
+        async fn coordinate_matrix_run_is_not_shardable() {
+            // A matrix expands to >1 node → not shardable → Ok(false), no build.
+            let dir = tempfile::tempdir().unwrap();
+            let state = sqlite_state(dir.path()).await;
+            let l = loaded(
+                "version: 1\nname: m\nmatrix:\n  - id: a\n  - id: b\npipeline:\n  \
+                 source: { type: rest, config: { url: \"http://localhost/x\" } }\n  \
+                 sink: { type: stdout, config: {} }\n",
+            )
+            .await;
+            assert!(!coordinate_sharded_run(&state, "r", &l, 4).await.unwrap());
+        }
+
+        #[tokio::test]
+        async fn coordinate_non_shardable_source_runs_whole() {
+            // A csv source is not shardable → Ok(false) (built offline).
+            let dir = tempfile::tempdir().unwrap();
+            let state = sqlite_state(dir.path()).await;
+            let input = dir.path().join("in.csv");
+            std::fs::write(&input, "id\n1\n").unwrap();
+            let l = loaded(&format!(
+                "version: 1\npipeline:\n  \
+                 source: {{ type: csv, config: {{ path: \"{}\" }} }}\n  \
+                 sink: {{ type: stdout, config: {{}} }}\n",
+                input.display()
+            ))
+            .await;
+            assert!(!coordinate_sharded_run(&state, "r", &l, 4).await.unwrap());
+        }
+
+        #[tokio::test]
+        async fn coordinate_s3_source_inserts_shards_and_marks_sharded() {
+            let dir = tempfile::tempdir().unwrap();
+            let state = sqlite_state(dir.path()).await;
+            seed_run(&state, "r", RunStatus::Running).await;
+            let l = loaded(
+                "version: 1\npipeline:\n  \
+                 source: { type: s3, config: { bucket: my-bucket, prefix: null, \
+                 region: null, endpoint_url: null, file_format: json_lines, \
+                 max_objects: null, concurrency: 10 } }\n  \
+                 sink: { type: stdout, config: {} }\n",
+            )
+            .await;
+            assert!(coordinate_sharded_run(&state, "r", &l, 4).await.unwrap());
+            // 4 shards inserted; parent flipped to Sharded.
+            let prog = state.history().shard_progress("r").await.unwrap();
+            assert_eq!(prog.total, 4);
+            assert_eq!(prog.pending, 4);
+            assert_eq!(
+                state.history().get("r").await.unwrap().unwrap().status,
+                RunStatus::Sharded
+            );
+        }
+
+        async fn seed_sharded_with_shards(state: &ServerState, run_id: &str, n: usize) {
+            use crate::serve::history::ShardInsert;
+            seed_run(state, run_id, RunStatus::Sharded).await;
+            let shards: Vec<ShardInsert> = (0..n)
+                .map(|i| ShardInsert {
+                    shard_id: i.to_string(),
+                    descriptor: serde_json::json!({ "i": i }),
+                    size_estimate: None,
+                })
+                .collect();
+            state
+                .history()
+                .insert_shards(run_id, &shards)
+                .await
+                .unwrap();
+            // Claim them so they are 'running' and finalizable by this instance.
+            let claimed = state.history().claim_shards(n).await.unwrap();
+            assert_eq!(claimed.len(), n);
+        }
+
+        #[tokio::test]
+        async fn maybe_finalize_parent_completes_when_all_shards_succeed() {
+            let dir = tempfile::tempdir().unwrap();
+            let state = sqlite_state(dir.path()).await;
+            seed_sharded_with_shards(&state, "r", 3).await;
+            for i in 0..3 {
+                state
+                    .history()
+                    .finalize_shard("r", &i.to_string(), true)
+                    .await
+                    .unwrap();
+            }
+            maybe_finalize_parent(&state, "r").await;
+            assert_eq!(
+                state.history().get("r").await.unwrap().unwrap().status,
+                RunStatus::Completed
+            );
+        }
+
+        #[tokio::test]
+        async fn maybe_finalize_parent_fails_when_a_shard_fails() {
+            let dir = tempfile::tempdir().unwrap();
+            let state = sqlite_state(dir.path()).await;
+            seed_sharded_with_shards(&state, "r", 2).await;
+            state
+                .history()
+                .finalize_shard("r", "0", true)
+                .await
+                .unwrap();
+            state
+                .history()
+                .finalize_shard("r", "1", false)
+                .await
+                .unwrap();
+            maybe_finalize_parent(&state, "r").await;
+            assert_eq!(
+                state.history().get("r").await.unwrap().unwrap().status,
+                RunStatus::Failed
+            );
+        }
+
+        #[tokio::test]
+        async fn maybe_finalize_parent_keeps_sharded_until_all_terminal() {
+            let dir = tempfile::tempdir().unwrap();
+            let state = sqlite_state(dir.path()).await;
+            seed_sharded_with_shards(&state, "r", 2).await;
+            // Only one shard finalized → run stays Sharded.
+            state
+                .history()
+                .finalize_shard("r", "0", true)
+                .await
+                .unwrap();
+            maybe_finalize_parent(&state, "r").await;
+            assert_eq!(
+                state.history().get("r").await.unwrap().unwrap().status,
+                RunStatus::Sharded
+            );
+        }
+
+        #[tokio::test]
+        async fn execute_shard_runs_a_csv_to_jsonl_shard() {
+            let dir = tempfile::tempdir().unwrap();
+            let state = sqlite_state(dir.path()).await;
+            let input = dir.path().join("in.csv");
+            std::fs::write(&input, "id,name\n1,alice\n2,bob\n").unwrap();
+            let output = dir.path().join("out.jsonl");
+            let yaml = format!(
+                "version: 1\npipeline:\n  \
+                 source: {{ type: csv, config: {{ path: \"{}\" }} }}\n  \
+                 sink: {{ type: jsonl, config: {{ path: \"{}\" }} }}\n",
+                input.display(),
+                output.display()
+            );
+            let l = loaded(&yaml).await;
+            // The whole-dataset shard is a no-op for the (non-shardable) csv source,
+            // exercising the apply_shard call + per-shard state-key path end-to-end.
+            let ok = execute_shard(
+                &state,
+                l,
+                "r",
+                "0",
+                ShardSpec::whole(),
+                None,
+                None,
+                Utc::now(),
+            )
+            .await;
+            assert!(ok, "csv→jsonl shard should complete");
+            let written = std::fs::read_to_string(&output).unwrap();
+            assert_eq!(written.lines().count(), 2, "both rows written");
+            assert!(written.contains("alice") && written.contains("bob"));
+        }
+
+        #[tokio::test]
+        async fn resume_claimed_shard_executes_and_finalizes_parent() {
+            // End-to-end per-shard entry point: claim a shard whose run is a
+            // csv→jsonl pipeline, dispatch it, and confirm the shard runs, is
+            // finalized, and the parent run flips to Completed.
+            let dir = tempfile::tempdir().unwrap();
+            let state = sqlite_state(dir.path()).await;
+            let input = dir.path().join("in.csv");
+            std::fs::write(&input, "id,name\n1,alice\n").unwrap();
+            let output = dir.path().join("out.jsonl");
+            let yaml = format!(
+                "version: 1\npipeline:\n  \
+                 source: {{ type: csv, config: {{ path: \"{}\" }} }}\n  \
+                 sink: {{ type: jsonl, config: {{ path: \"{}\" }} }}\n",
+                input.display(),
+                output.display()
+            );
+            // Seed the parent Sharded run carrying the pipeline config, + one shard.
+            let mut rec = RunRecord::queued("r".into(), None, BTreeMap::new(), None, Utc::now());
+            rec.status = RunStatus::Sharded;
+            rec.config_body = Some(yaml);
+            state.history().upsert(&rec).await.unwrap();
+            use crate::serve::history::ShardInsert;
+            state
+                .history()
+                .insert_shards(
+                    "r",
+                    &[ShardInsert {
+                        shard_id: "0".into(),
+                        descriptor: serde_json::Value::Null,
+                        size_estimate: None,
+                    }],
+                )
+                .await
+                .unwrap();
+            let claimed = state.history().claim_shards(1).await.unwrap();
+            assert_eq!(claimed.len(), 1);
+
+            resume_claimed_shard(state.clone(), claimed.into_iter().next().unwrap());
+
+            // Poll until the parent run reaches a terminal state (the spawned
+            // task runs the shard, finalizes it, then finalizes the parent).
+            let mut status = RunStatus::Sharded;
+            for _ in 0..100 {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                status = state.history().get("r").await.unwrap().unwrap().status;
+                if status.is_terminal() {
+                    break;
+                }
+            }
+            assert_eq!(status, RunStatus::Completed, "shard ran → parent completed");
+            assert!(output.exists(), "shard wrote its output");
+        }
+    }
 }

--- a/cli/src/serve/server.rs
+++ b/cli/src/serve/server.rs
@@ -205,6 +205,23 @@ pub(crate) async fn lease_loop(state: ServerState, period: Duration, shutdown: C
                         Ok(_) => {}
                         Err(e) => tracing::warn!(error = %e, "cluster: reclaim_orphans failed"),
                     }
+                    // Mode B (#230): heartbeat this instance's running shards, and
+                    // rebalance shards whose owner's lease expired (requeue →
+                    // another worker, or poison past max_attempts).
+                    if let Err(e) = state.history().renew_shard_leases().await {
+                        tracing::warn!(error = %e, "cluster: renew_shard_leases failed");
+                    }
+                    match state.history().reclaim_shards(cluster.max_attempts()).await {
+                        Ok(r) if r.requeued > 0 || r.failed > 0 => {
+                            crate::serve::metrics::record_shards_reclaimed(r.requeued, r.failed);
+                            tracing::warn!(
+                                requeued = r.requeued, failed = r.failed,
+                                "cluster: reclaimed orphaned shards from an expired-lease instance"
+                            );
+                        }
+                        Ok(_) => {}
+                        Err(e) => tracing::warn!(error = %e, "cluster: reclaim_shards failed"),
+                    }
                 } else {
                     // Single-instance: mark orphans failed (today's behavior).
                     match state.history().recover_orphans().await {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -29,6 +29,7 @@ pub mod replication;
 pub mod resilience;
 pub mod retry;
 pub mod schema;
+pub mod shard;
 pub mod stage;
 pub mod state;
 pub mod traits;
@@ -73,6 +74,7 @@ pub use resilience::{
     execute_with_policy, execute_with_policy_metered,
 };
 pub use retry::execute_with_retry;
+pub use shard::ShardSpec;
 #[cfg(feature = "transform-cdc-unwrap")]
 pub use stage::CdcUnwrapSpec;
 #[cfg(feature = "transform-explode")]

--- a/crates/core/src/shard.rs
+++ b/crates/core/src/shard.rs
@@ -1,0 +1,144 @@
+//! Source sharding for clustered (Mode B) execution.
+//!
+//! A *shardable* source can split its work into independent [`ShardSpec`]s that
+//! different cluster workers process concurrently — so one logical pipeline over
+//! a single large source (a big S3 prefix, a billion-row table) scales
+//! horizontally instead of being capped at one worker's throughput.
+//!
+//! The capability is exposed as **defaulted methods on the [`Source`] trait**
+//! ([`enumerate_shards`](crate::Source::enumerate_shards),
+//! [`apply_shard`](crate::Source::apply_shard),
+//! [`is_shardable`](crate::Source::is_shardable)) rather than a separate trait,
+//! so it composes with the existing `Box<dyn Source>` object model with no
+//! downcast and stays fully backward compatible: a source that does not override
+//! them reports `is_shardable() == false` and enumerates to a single
+//! whole-dataset shard, i.e. it behaves exactly as today.
+//!
+//! ## Lifecycle
+//!
+//! 1. A coordinator calls [`enumerate_shards`](crate::Source::enumerate_shards)
+//!    once per run (idempotently) to discover the shard set.
+//! 2. Each shard is persisted and claimed by exactly one worker.
+//! 3. The claiming worker calls [`apply_shard`](crate::Source::apply_shard) to
+//!    narrow its source instance to that one shard before streaming.
+//! 4. Each shard carries its own state-key suffix so resume is per-shard: a
+//!    reassigned shard resumes where its dead owner left off.
+
+use serde::{Deserialize, Serialize};
+
+/// One independently-processable slice of a shardable source.
+///
+/// The [`descriptor`](ShardSpec::descriptor) is opaque to the coordinator — only
+/// the producing/consuming connector interprets it (e.g. `{"pk_range":[0,1000]}`
+/// for a key-range split, `{"prefix":"dt=2026-06-11/"}` for an object split). It
+/// must round-trip through JSON unchanged so the coordinator can persist it and
+/// hand it back to [`apply_shard`](crate::Source::apply_shard) on the worker that
+/// claims the shard.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ShardSpec {
+    /// Stable identifier, unique within a run's shard set. Also used as the
+    /// per-shard state-key suffix (`{run}::{shard.id}`), so it must be a valid
+    /// state-key segment (no `:` — see
+    /// [`validate_state_key`](crate::state::validate_state_key)).
+    pub id: String,
+
+    /// Connector-specific, opaque shard descriptor. Persisted verbatim and
+    /// passed back to [`apply_shard`](crate::Source::apply_shard).
+    pub descriptor: serde_json::Value,
+
+    /// Optional relative size estimate (rows / bytes / objects — the unit is the
+    /// connector's choice, only comparisons within one run's set matter) used
+    /// for skew-aware assignment. `None` when the source cannot cheaply
+    /// estimate; the coordinator then falls back to count-based balancing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size_estimate: Option<u64>,
+}
+
+impl ShardSpec {
+    /// The single whole-dataset shard a non-shardable source enumerates to.
+    ///
+    /// Its [`id`](ShardSpec::id) is `"0"` and its descriptor is JSON `null`;
+    /// [`apply_shard`](crate::Source::apply_shard)'s default ignores it, so the
+    /// source streams its entire dataset unchanged.
+    pub fn whole() -> Self {
+        Self {
+            id: "0".to_string(),
+            descriptor: serde_json::Value::Null,
+            size_estimate: None,
+        }
+    }
+
+    /// A shard with the given id and descriptor and no size estimate.
+    pub fn new(id: impl Into<String>, descriptor: serde_json::Value) -> Self {
+        Self {
+            id: id.into(),
+            descriptor,
+            size_estimate: None,
+        }
+    }
+
+    /// Attach a relative size estimate (builder style).
+    pub fn with_size(mut self, size: u64) -> Self {
+        self.size_estimate = Some(size);
+        self
+    }
+
+    /// Whether this is the whole-dataset shard (id `"0"`, null descriptor) — the
+    /// no-op shard a non-shardable source produces.
+    pub fn is_whole(&self) -> bool {
+        self.id == "0" && self.descriptor.is_null()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn whole_is_the_no_op_shard() {
+        let w = ShardSpec::whole();
+        assert_eq!(w.id, "0");
+        assert!(w.descriptor.is_null());
+        assert_eq!(w.size_estimate, None);
+        assert!(w.is_whole());
+    }
+
+    #[test]
+    fn new_and_with_size() {
+        let s = ShardSpec::new("3", json!({ "partition": 3 })).with_size(42);
+        assert_eq!(s.id, "3");
+        assert_eq!(s.descriptor, json!({ "partition": 3 }));
+        assert_eq!(s.size_estimate, Some(42));
+        assert!(!s.is_whole(), "a real shard is not the whole-dataset shard");
+    }
+
+    #[test]
+    fn round_trips_through_json_with_size_omitted_when_none() {
+        let s = ShardSpec::new("a", json!({ "prefix": "dt=2026-06-11/" }));
+        let text = serde_json::to_string(&s).unwrap();
+        // size_estimate is omitted from the wire form when None.
+        assert!(
+            !text.contains("size_estimate"),
+            "None size is skipped: {text}"
+        );
+        let back: ShardSpec = serde_json::from_str(&text).unwrap();
+        assert_eq!(back, s);
+    }
+
+    #[test]
+    fn round_trips_with_size_present() {
+        let s = ShardSpec::new("b", json!({ "pk_range": [0, 1000] })).with_size(1000);
+        let back: ShardSpec = serde_json::from_str(&serde_json::to_string(&s).unwrap()).unwrap();
+        assert_eq!(back, s);
+        assert_eq!(back.size_estimate, Some(1000));
+    }
+
+    // A non-whole shard with id "0" but a non-null descriptor is NOT treated as
+    // the whole-dataset shard (the descriptor disambiguates).
+    #[test]
+    fn id_zero_with_descriptor_is_not_whole() {
+        let s = ShardSpec::new("0", json!({ "partition": 0 }));
+        assert!(!s.is_whole());
+    }
+}

--- a/crates/core/src/shard.rs
+++ b/crates/core/src/shard.rs
@@ -5,7 +5,8 @@
 //! a single large source (a big S3 prefix, a billion-row table) scales
 //! horizontally instead of being capped at one worker's throughput.
 //!
-//! The capability is exposed as **defaulted methods on the [`Source`] trait**
+//! The capability is exposed as **defaulted methods on the
+//! [`Source`](crate::Source) trait**
 //! ([`enumerate_shards`](crate::Source::enumerate_shards),
 //! [`apply_shard`](crate::Source::apply_shard),
 //! [`is_shardable`](crate::Source::is_shardable)) rather than a separate trait,

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -174,6 +174,47 @@ pub trait Source: Send + Sync {
         false
     }
 
+    /// Whether this source can split its work into independent shards for
+    /// clustered (Mode B) execution. Default: `false` (single whole-dataset
+    /// shard). Sources with a natural partition (object-store prefixes, table
+    /// primary-key ranges) override this to `true` and implement
+    /// [`enumerate_shards`](Self::enumerate_shards) +
+    /// [`apply_shard`](Self::apply_shard).
+    fn is_shardable(&self) -> bool {
+        false
+    }
+
+    /// Enumerate the shards this source splits into, aiming for roughly `target`
+    /// of them (a hint — the source may return fewer, e.g. when the dataset is
+    /// small, or one per natural partition regardless of `target`).
+    ///
+    /// Called **once per run** by the cluster coordinator; enumeration must be
+    /// deterministic enough that re-enumeration yields a compatible set (stable
+    /// shard ids), since it may run on more than one instance and is reconciled
+    /// by idempotent insert. May perform read-only I/O (a `LIST`, a `MIN/MAX`
+    /// query). The default returns a single whole-dataset shard
+    /// ([`ShardSpec::whole`](crate::ShardSpec::whole)), preserving today's
+    /// single-worker behavior.
+    async fn enumerate_shards(
+        &self,
+        _target: usize,
+    ) -> Result<Vec<crate::shard::ShardSpec>, FaucetError> {
+        Ok(vec![crate::shard::ShardSpec::whole()])
+    }
+
+    /// Narrow this source instance to a single shard before streaming.
+    ///
+    /// Called on the worker that claims `shard`, after construction and before
+    /// any `stream_pages` call. Like [`apply_start_bookmark`](Self::apply_start_bookmark)
+    /// this takes `&self` and is expected to record the shard behind interior
+    /// mutability (the source consults it when building its query / listing).
+    /// The default ignores the shard — a non-shardable source only ever receives
+    /// [`ShardSpec::whole`](crate::ShardSpec::whole), so ignoring it streams the
+    /// whole dataset. Implementations should accept the whole shard as a no-op.
+    async fn apply_shard(&self, _shard: &crate::shard::ShardSpec) -> Result<(), FaucetError> {
+        Ok(())
+    }
+
     /// Stable identifier used as the `connector` label on metrics and the
     /// `connector` attribute on spans. Defaults to the final segment of
     /// `std::any::type_name::<Self>()`, e.g. `"RestSource"`. Built-in
@@ -906,5 +947,31 @@ mod tests {
     async fn capture_resume_position_callable_through_trait_object() {
         let source: Box<dyn Source> = Box::new(MockSource { records: vec![] });
         assert!(source.capture_resume_position().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn source_default_is_not_shardable() {
+        let source: Box<dyn Source> = Box::new(MockSource { records: vec![] });
+        assert!(!source.is_shardable());
+    }
+
+    #[tokio::test]
+    async fn source_default_enumerates_single_whole_shard() {
+        // A non-shardable source enumerates to exactly one whole-dataset shard,
+        // regardless of the requested target — preserving single-worker behavior.
+        let source: Box<dyn Source> = Box::new(MockSource { records: vec![] });
+        let shards = source.enumerate_shards(8).await.unwrap();
+        assert_eq!(shards.len(), 1);
+        assert!(shards[0].is_whole());
+    }
+
+    #[tokio::test]
+    async fn source_default_apply_shard_is_noop() {
+        let source: Box<dyn Source> = Box::new(MockSource { records: vec![] });
+        // Applying the whole shard is a no-op and must not error.
+        source
+            .apply_shard(&crate::shard::ShardSpec::whole())
+            .await
+            .unwrap();
     }
 }

--- a/crates/source/postgres/src/config.rs
+++ b/crates/source/postgres/src/config.rs
@@ -28,6 +28,29 @@ pub struct PostgresSourceConfig {
     /// jobs) that prefer one large request to many small ones.
     #[serde(default = "default_batch_size")]
     pub batch_size: usize,
+
+    /// Optional primary-key range sharding for clustered (Mode B) execution.
+    ///
+    /// When set, the source advertises itself as shardable: the cluster
+    /// coordinator splits the query's `key` range into contiguous slices that
+    /// different workers process concurrently. Has **no effect** outside the
+    /// cluster coordinator (a plain `faucet run` streams the whole query), so
+    /// it is fully backward compatible. See [`ShardConfig`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub shard: Option<ShardConfig>,
+}
+
+/// Primary-key range sharding settings for the PostgreSQL source.
+///
+/// The source is split by contiguous ranges of an **integer-typed** column:
+/// each shard runs `SELECT * FROM (<query>) WHERE <key> >= lo AND <key> < hi`.
+/// The column must be present in the query's output and orderable as a 64-bit
+/// integer (e.g. a `bigint`/`int`/`serial` primary key).
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct ShardConfig {
+    /// Integer column to range-partition on. Quoted as an identifier before use,
+    /// so it is safe against injection but must name a real output column.
+    pub key: String,
 }
 
 fn default_max_connections() -> u32 {
@@ -59,6 +82,7 @@ impl PostgresSourceConfig {
             params: Vec::new(),
             max_connections: 10,
             batch_size: DEFAULT_BATCH_SIZE,
+            shard: None,
         }
     }
 

--- a/crates/source/postgres/src/lib.rs
+++ b/crates/source/postgres/src/lib.rs
@@ -12,5 +12,5 @@ pub mod stream;
 
 pub use faucet_core::{FaucetError, Source};
 
-pub use config::PostgresSourceConfig;
+pub use config::{PostgresSourceConfig, ShardConfig};
 pub use stream::PostgresSource;

--- a/crates/source/postgres/src/stream.rs
+++ b/crates/source/postgres/src/stream.rs
@@ -2,17 +2,65 @@
 
 use crate::config::PostgresSourceConfig;
 use async_trait::async_trait;
+use faucet_core::shard::ShardSpec;
+use faucet_core::util::quote_ident;
 use faucet_core::{FaucetError, Stream, StreamPage};
 use futures::TryStreamExt;
 use serde_json::Value;
 use sqlx::postgres::PgPoolOptions;
 use sqlx::{Column, PgPool, Row};
 use std::pin::Pin;
+use std::sync::Mutex;
 
 /// A source that executes a SQL query against PostgreSQL and returns rows as JSON.
 pub struct PostgresSource {
     config: PostgresSourceConfig,
     pool: PgPool,
+    /// Shard applied by the cluster coordinator (Mode B), if any. `None` (or the
+    /// whole-dataset shard) means the full query is streamed. Stored behind a
+    /// `Mutex` so `apply_shard(&self, …)` can record it before streaming.
+    applied_shard: Mutex<Option<ShardBounds>>,
+}
+
+/// Parsed integer range bounds for an applied PK-range shard.
+#[derive(Clone, Debug)]
+struct ShardBounds {
+    key: String,
+    lo: i64,
+    hi: i64,
+    /// `hi` is inclusive only for the last shard (so the max row is covered);
+    /// every other shard is half-open `[lo, hi)`.
+    hi_inclusive: bool,
+}
+
+impl ShardBounds {
+    /// Parse from a [`ShardSpec`] descriptor produced by `enumerate_shards`.
+    fn from_spec(spec: &ShardSpec) -> Option<Self> {
+        let d = &spec.descriptor;
+        Some(Self {
+            key: d.get("key")?.as_str()?.to_string(),
+            lo: d.get("lo")?.as_i64()?,
+            hi: d.get("hi")?.as_i64()?,
+            hi_inclusive: d
+                .get("hi_inclusive")
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+        })
+    }
+
+    /// Wrap `inner` so only rows whose `key` falls in this shard's range are
+    /// returned. The key is quoted (injection-safe); the bounds are inlined as
+    /// integer literals (safe — they are `i64`s produced by enumeration).
+    fn wrap(&self, inner: &str) -> String {
+        let op = if self.hi_inclusive { "<=" } else { "<" };
+        let key = quote_ident(&self.key);
+        format!(
+            "SELECT * FROM ({inner}) AS _faucet_shard \
+             WHERE {key} >= {lo} AND {key} {op} {hi}",
+            lo = self.lo,
+            hi = self.hi
+        )
+    }
 }
 
 impl PostgresSource {
@@ -26,8 +74,56 @@ impl PostgresSource {
             .await
             .map_err(|e| FaucetError::Config(format!("PostgreSQL connection failed: {e}")))?;
 
-        Ok(Self { config, pool })
+        Ok(Self {
+            config,
+            pool,
+            applied_shard: Mutex::new(None),
+        })
     }
+
+    /// Apply the currently-set shard (if any) to a resolved query string.
+    fn shard_wrap(&self, query: String) -> String {
+        match &*self.applied_shard.lock().expect("shard mutex poisoned") {
+            Some(bounds) => bounds.wrap(&query),
+            None => query,
+        }
+    }
+}
+
+/// Split an inclusive integer range `[min, max]` into up to `target` contiguous
+/// shards, each described by `{key, lo, hi, hi_inclusive}`. All but the last are
+/// half-open `[lo, hi)`; the last is `[lo, max]` (inclusive) so `max` is covered.
+///
+/// Pure function (no I/O) so it is unit-testable without a database.
+fn plan_pk_shards(key: &str, min: i64, max: i64, target: usize) -> Vec<ShardSpec> {
+    let target = target.max(1);
+    // Range width as u128 to avoid i64 overflow on full-range PKs.
+    let width = (max as i128 - min as i128 + 1).max(1) as u128;
+    let n = (target as u128).min(width) as usize; // never more shards than values
+    let step = width.div_ceil(n as u128); // ceil so shards cover the whole range
+
+    let mut shards = Vec::with_capacity(n);
+    let mut lo = min as i128;
+    for i in 0..n {
+        let mut hi = lo + step as i128;
+        let is_last = i == n - 1;
+        if is_last || hi > max as i128 {
+            hi = max as i128; // clamp; last shard is inclusive of max
+        }
+        let descriptor = serde_json::json!({
+            "key": key,
+            "lo": lo as i64,
+            "hi": hi as i64,
+            "hi_inclusive": is_last,
+        });
+        let size = (hi - lo).max(0) as u64 + if is_last { 1 } else { 0 };
+        shards.push(ShardSpec::new(i.to_string(), descriptor).with_size(size));
+        if is_last {
+            break;
+        }
+        lo = hi;
+    }
+    shards
 }
 
 /// Convert a raw sqlx column value to a `serde_json::Value`.
@@ -163,6 +259,7 @@ impl faucet_core::Source for PostgresSource {
         context: &std::collections::HashMap<String, serde_json::Value>,
     ) -> Result<Vec<Value>, FaucetError> {
         let (query_str, bind_values) = resolve_query(&self.config, context);
+        let query_str = self.shard_wrap(query_str);
         let query = bind_params(sqlx::query(&query_str), &self.config.params, &bind_values);
 
         let rows = query
@@ -196,6 +293,7 @@ impl faucet_core::Source for PostgresSource {
 
         Box::pin(async_stream::try_stream! {
             let (query_str, bind_values) = resolve_query(&self.config, context);
+            let query_str = self.shard_wrap(query_str);
             let query = bind_params(
                 sqlx::query(&query_str),
                 &self.config.params,
@@ -246,6 +344,68 @@ impl faucet_core::Source for PostgresSource {
             self.config.query
         )
     }
+
+    /// Shardable when a [`ShardConfig`](crate::config::ShardConfig) is set.
+    fn is_shardable(&self) -> bool {
+        self.config.shard.is_some()
+    }
+
+    /// Enumerate contiguous primary-key range shards by computing the `key`
+    /// column's `MIN`/`MAX` over the (unsharded) base query and splitting that
+    /// range into ~`target` slices. Returns a single whole-dataset shard when no
+    /// `shard` config is set or the result set is empty.
+    async fn enumerate_shards(&self, target: usize) -> Result<Vec<ShardSpec>, FaucetError> {
+        let Some(shard_cfg) = &self.config.shard else {
+            return Ok(vec![ShardSpec::whole()]);
+        };
+
+        let key = quote_ident(&shard_cfg.key);
+        let bounds_sql = format!(
+            "SELECT MIN({key})::int8 AS lo, MAX({key})::int8 AS hi \
+             FROM ({inner}) AS _faucet_bounds",
+            inner = self.config.query
+        );
+        let row = bind_params(sqlx::query(&bounds_sql), &self.config.params, &[])
+            .fetch_one(&self.pool)
+            .await
+            .map_err(|e| {
+                FaucetError::Source(format!(
+                    "postgres: failed to compute shard bounds for key {:?} \
+                     (it must be an integer-typed column): {e}",
+                    shard_cfg.key
+                ))
+            })?;
+
+        let lo: Option<i64> = row.try_get("lo").map_err(|e| {
+            FaucetError::Source(format!("postgres: shard bounds decode failed: {e}"))
+        })?;
+        let hi: Option<i64> = row.try_get("hi").map_err(|e| {
+            FaucetError::Source(format!("postgres: shard bounds decode failed: {e}"))
+        })?;
+
+        match (lo, hi) {
+            (Some(lo), Some(hi)) => Ok(plan_pk_shards(&shard_cfg.key, lo, hi, target)),
+            // Empty result set → nothing to shard; one (empty) whole shard.
+            _ => Ok(vec![ShardSpec::whole()]),
+        }
+    }
+
+    /// Narrow this source to a single PK-range shard. The whole-dataset shard
+    /// clears any applied range (streams the full query).
+    async fn apply_shard(&self, shard: &ShardSpec) -> Result<(), FaucetError> {
+        let bounds = if shard.is_whole() {
+            None
+        } else {
+            Some(ShardBounds::from_spec(shard).ok_or_else(|| {
+                FaucetError::Source(format!(
+                    "postgres: invalid shard descriptor: {}",
+                    shard.descriptor
+                ))
+            })?)
+        };
+        *self.applied_shard.lock().expect("shard mutex poisoned") = bounds;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -262,6 +422,110 @@ mod tests {
             }
             _ => panic!("expected a batch_size Config error"),
         }
+    }
+
+    // ── PK-range sharding (pure logic) ──────────────────────────────────────
+
+    #[test]
+    fn plan_pk_shards_covers_full_range_without_gaps_or_overlap() {
+        let shards = plan_pk_shards("id", 0, 99, 4);
+        assert_eq!(shards.len(), 4);
+        // Contiguous half-open ranges, last inclusive of max.
+        let mut expected_lo = 0i64;
+        for (i, s) in shards.iter().enumerate() {
+            let d = &s.descriptor;
+            assert_eq!(d["key"], "id");
+            assert_eq!(d["lo"].as_i64().unwrap(), expected_lo);
+            let hi = d["hi"].as_i64().unwrap();
+            let last = i == shards.len() - 1;
+            assert_eq!(d["hi_inclusive"].as_bool().unwrap(), last);
+            if last {
+                assert_eq!(hi, 99, "last shard's hi is the inclusive max");
+            }
+            expected_lo = hi; // next shard starts where this half-open one ended
+        }
+    }
+
+    #[test]
+    fn plan_pk_shards_never_more_shards_than_values() {
+        // Range [5, 7] has 3 values; asking for 10 shards yields at most 3.
+        let shards = plan_pk_shards("pk", 5, 7, 10);
+        assert!(shards.len() <= 3, "got {} shards", shards.len());
+        assert_eq!(shards[0].descriptor["lo"].as_i64().unwrap(), 5);
+        assert_eq!(shards.last().unwrap().descriptor["hi"].as_i64().unwrap(), 7);
+        assert!(
+            shards.last().unwrap().descriptor["hi_inclusive"]
+                .as_bool()
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn plan_pk_shards_single_value_one_shard() {
+        let shards = plan_pk_shards("id", 42, 42, 8);
+        assert_eq!(shards.len(), 1);
+        assert_eq!(shards[0].descriptor["lo"].as_i64().unwrap(), 42);
+        assert_eq!(shards[0].descriptor["hi"].as_i64().unwrap(), 42);
+        assert!(shards[0].descriptor["hi_inclusive"].as_bool().unwrap());
+    }
+
+    #[test]
+    fn plan_pk_shards_target_zero_treated_as_one() {
+        let shards = plan_pk_shards("id", 0, 9, 0);
+        assert_eq!(shards.len(), 1);
+        assert_eq!(shards[0].descriptor["hi"].as_i64().unwrap(), 9);
+    }
+
+    #[test]
+    fn shard_bounds_wrap_builds_half_open_predicate() {
+        let spec = ShardSpec::new(
+            "1",
+            serde_json::json!({"key": "id", "lo": 100, "hi": 200, "hi_inclusive": false}),
+        );
+        let b = ShardBounds::from_spec(&spec).unwrap();
+        let sql = b.wrap("SELECT * FROM t");
+        assert!(sql.contains("(SELECT * FROM t) AS _faucet_shard"));
+        assert!(sql.contains(r#""id" >= 100"#), "got: {sql}");
+        assert!(
+            sql.contains(r#""id" < 200"#),
+            "half-open upper bound: {sql}"
+        );
+    }
+
+    #[test]
+    fn shard_bounds_wrap_last_shard_is_inclusive() {
+        let spec = ShardSpec::new(
+            "2",
+            serde_json::json!({"key": "id", "lo": 200, "hi": 300, "hi_inclusive": true}),
+        );
+        let b = ShardBounds::from_spec(&spec).unwrap();
+        let sql = b.wrap("SELECT * FROM t");
+        assert!(
+            sql.contains(r#""id" <= 300"#),
+            "inclusive upper bound: {sql}"
+        );
+    }
+
+    #[test]
+    fn shard_bounds_quotes_key_against_injection() {
+        let spec = ShardSpec::new(
+            "0",
+            serde_json::json!({"key": "weird\"; DROP", "lo": 0, "hi": 1, "hi_inclusive": false}),
+        );
+        let b = ShardBounds::from_spec(&spec).unwrap();
+        let sql = b.wrap("SELECT 1");
+        // The doubled quote escaping proves the identifier was quoted, not raw.
+        assert!(
+            sql.contains(r#""weird""; DROP""#),
+            "key must be quoted: {sql}"
+        );
+    }
+
+    #[test]
+    fn shard_bounds_from_spec_rejects_malformed_descriptor() {
+        let spec = ShardSpec::new("0", serde_json::json!({"key": "id"})); // no lo/hi
+        assert!(ShardBounds::from_spec(&spec).is_none());
+        assert!(ShardBounds::from_spec(&ShardSpec::whole()).is_none());
     }
 
     // dataset_uri is a pure-config method; the source requires a live DB to

--- a/crates/source/postgres/tests/streaming.rs
+++ b/crates/source/postgres/tests/streaming.rs
@@ -351,3 +351,69 @@ async fn context_tokens_bind_as_typed_params() {
     assert_eq!(page.records.len(), 1, "only account id=1 is active");
     assert_eq!(page.records[0]["name"], "alice");
 }
+
+// ── PK-range sharding (Mode B, #230) ────────────────────────────────────────
+
+/// The core Mode B correctness guarantee: enumerating a source into N shards and
+/// reading each shard yields every row exactly once — no duplication, no loss.
+#[tokio::test(flavor = "multi_thread")]
+async fn shards_partition_rows_disjointly_and_completely() {
+    use faucet_source_postgres::ShardConfig;
+
+    let (_container, url) = start_postgres().await;
+    seed_events(&url, 1000).await; // ids 1..=1000
+
+    let mut config = PostgresSourceConfig::new(&url, "SELECT id FROM events");
+    config.shard = Some(ShardConfig { key: "id".into() });
+
+    // A coordinator enumerates the shard set.
+    let coordinator = PostgresSource::new(config.clone())
+        .await
+        .expect("coordinator source");
+    assert!(coordinator.is_shardable());
+    let shards = coordinator.enumerate_shards(4).await.expect("enumerate");
+    assert!(
+        (2..=4).contains(&shards.len()),
+        "expected 2..=4 shards, got {}",
+        shards.len()
+    );
+
+    // Each shard runs on a fresh source narrowed via apply_shard.
+    let mut all_ids: Vec<i64> = Vec::new();
+    for shard in &shards {
+        let s = PostgresSource::new(config.clone())
+            .await
+            .expect("shard source");
+        s.apply_shard(shard).await.expect("apply_shard");
+        let ctx: HashMap<String, serde_json::Value> = HashMap::new();
+        let mut pages = s.stream_pages(&ctx, 0);
+        while let Some(page) = pages.next().await {
+            for rec in page.expect("page ok").records {
+                all_ids.push(rec["id"].as_i64().expect("id is int"));
+            }
+        }
+    }
+
+    all_ids.sort();
+    let expected: Vec<i64> = (1..=1000).collect();
+    assert_eq!(
+        all_ids, expected,
+        "shards must union to all rows exactly once (no dup, no loss)"
+    );
+}
+
+/// A config without a `shard` block is not shardable: it enumerates to a single
+/// whole-dataset shard, preserving single-worker behavior.
+#[tokio::test(flavor = "multi_thread")]
+async fn unsharded_config_enumerates_one_whole_shard() {
+    let (_container, url) = start_postgres().await;
+    seed_events(&url, 10).await;
+
+    let source = PostgresSource::new(PostgresSourceConfig::new(&url, "SELECT id FROM events"))
+        .await
+        .expect("source");
+    assert!(!source.is_shardable());
+    let shards = source.enumerate_shards(4).await.expect("enumerate");
+    assert_eq!(shards.len(), 1);
+    assert!(shards[0].is_whole());
+}

--- a/crates/source/postgres/tests/streaming.rs
+++ b/crates/source/postgres/tests/streaming.rs
@@ -402,6 +402,30 @@ async fn shards_partition_rows_disjointly_and_completely() {
     );
 }
 
+/// `enumerate_shards` surfaces an error when the shard key can't be computed
+/// (here: a non-existent column), and `apply_shard` rejects a malformed shard
+/// descriptor — the error paths a coordinator must handle.
+#[tokio::test(flavor = "multi_thread")]
+async fn shard_error_paths() {
+    use faucet_core::ShardSpec;
+    use faucet_source_postgres::ShardConfig;
+
+    let (_container, url) = start_postgres().await;
+    seed_events(&url, 5).await;
+
+    let mut config = PostgresSourceConfig::new(&url, "SELECT id FROM events");
+    config.shard = Some(ShardConfig {
+        key: "no_such_column".into(),
+    });
+    let source = PostgresSource::new(config).await.expect("source");
+    // MIN/MAX over a non-existent column → SQL error → enumerate_shards errors.
+    assert!(source.enumerate_shards(4).await.is_err());
+
+    // A descriptor missing lo/hi is rejected by apply_shard.
+    let bad = ShardSpec::new("0", serde_json::json!({ "key": "id" }));
+    assert!(source.apply_shard(&bad).await.is_err());
+}
+
 /// A config without a `shard` block is not shardable: it enumerates to a single
 /// whole-dataset shard, preserving single-worker behavior.
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/source/s3/src/stream.rs
+++ b/crates/source/s3/src/stream.rs
@@ -505,7 +505,7 @@ impl faucet_core::Source for S3Source {
 
     /// The S3 source is always shardable: any object set can be split by
     /// hash-of-key. Sharding only takes effect when the cluster coordinator
-    /// calls [`apply_shard`](Self::apply_shard); a plain `faucet run` reads
+    /// calls `apply_shard`; a plain `faucet run` reads
     /// every object.
     fn is_shardable(&self) -> bool {
         true

--- a/crates/source/s3/src/stream.rs
+++ b/crates/source/s3/src/stream.rs
@@ -3,16 +3,36 @@
 use crate::config::{S3FileFormat, S3SourceConfig};
 use async_trait::async_trait;
 use aws_sdk_s3::Client;
+use faucet_core::shard::ShardSpec;
 use faucet_core::{FaucetError, Stream, StreamPage};
 use futures::stream::{self, StreamExt, TryStreamExt};
 use serde_json::Value;
 use std::pin::Pin;
+use std::sync::Mutex;
 use tokio::io::AsyncBufReadExt;
 
 /// An S3 source that lists and reads objects from a bucket.
 pub struct S3Source {
     config: S3SourceConfig,
     client: Client,
+    /// Shard applied by the cluster coordinator (Mode B): `(shards, index)`.
+    /// `None` (or `shards <= 1`) reads every listed object. Stored behind a
+    /// `Mutex` so `apply_shard(&self, …)` can record it before streaming.
+    applied_shard: Mutex<Option<(usize, usize)>>,
+}
+
+/// Stable FNV-1a hash of an object key, used to assign keys to shards.
+///
+/// Deterministic across processes and platforms (all cluster workers run the
+/// identical binary and this fixed algorithm), so every worker maps a given key
+/// to the same shard index — the partition is disjoint and complete.
+fn shard_hash(key: &str) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in key.as_bytes() {
+        h ^= *b as u64;
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    h
 }
 
 impl S3Source {
@@ -21,7 +41,23 @@ impl S3Source {
     /// Builds the S3 client eagerly so it is reused across calls.
     pub async fn new(config: S3SourceConfig) -> Result<Self, FaucetError> {
         let client = Self::build_client(&config).await?;
-        Ok(Self { config, client })
+        Ok(Self {
+            config,
+            client,
+            applied_shard: Mutex::new(None),
+        })
+    }
+
+    /// Retain only the keys belonging to the applied shard (hash-of-key modulo
+    /// `shards`). A no-op when no shard is applied or `shards <= 1`.
+    fn shard_filter(&self, keys: Vec<String>) -> Vec<String> {
+        match *self.applied_shard.lock().expect("shard mutex poisoned") {
+            Some((shards, index)) if shards > 1 => keys
+                .into_iter()
+                .filter(|k| (shard_hash(k) % shards as u64) == index as u64)
+                .collect(),
+            _ => keys,
+        }
     }
 
     /// Build an S3 client from the configuration.
@@ -82,7 +118,7 @@ impl S3Source {
                 if let Some(max) = self.config.max_objects
                     && keys.len() >= max
                 {
-                    return Ok(keys);
+                    return Ok(self.shard_filter(keys));
                 }
             }
 
@@ -93,7 +129,7 @@ impl S3Source {
             }
         }
 
-        Ok(keys)
+        Ok(self.shard_filter(keys))
     }
 
     /// Read and parse a single S3 object into records.
@@ -466,6 +502,65 @@ impl faucet_core::Source for S3Source {
             None => format!("s3://{}", self.config.bucket),
         }
     }
+
+    /// The S3 source is always shardable: any object set can be split by
+    /// hash-of-key. Sharding only takes effect when the cluster coordinator
+    /// calls [`apply_shard`](Self::apply_shard); a plain `faucet run` reads
+    /// every object.
+    fn is_shardable(&self) -> bool {
+        true
+    }
+
+    /// Enumerate `target` hash-modulo shards. Each shard `i` will read the
+    /// objects whose key hashes to `i (mod target)`. No I/O: the partition is
+    /// defined by the hash function, so enumeration is cheap and stable as new
+    /// objects appear. `target <= 1` yields a single whole-dataset shard.
+    async fn enumerate_shards(&self, target: usize) -> Result<Vec<ShardSpec>, FaucetError> {
+        if target <= 1 {
+            return Ok(vec![ShardSpec::whole()]);
+        }
+        let shards = (0..target)
+            .map(|i| {
+                ShardSpec::new(
+                    i.to_string(),
+                    serde_json::json!({ "shards": target, "index": i }),
+                )
+            })
+            .collect();
+        Ok(shards)
+    }
+
+    /// Narrow this source to one hash-modulo shard. The whole-dataset shard
+    /// clears any filter (reads every object).
+    async fn apply_shard(&self, shard: &ShardSpec) -> Result<(), FaucetError> {
+        let parsed = if shard.is_whole() {
+            None
+        } else {
+            let shards = shard
+                .descriptor
+                .get("shards")
+                .and_then(Value::as_u64)
+                .ok_or_else(|| {
+                    FaucetError::Source(format!(
+                        "s3: invalid shard descriptor (missing 'shards'): {}",
+                        shard.descriptor
+                    ))
+                })?;
+            let index = shard
+                .descriptor
+                .get("index")
+                .and_then(Value::as_u64)
+                .ok_or_else(|| {
+                    FaucetError::Source(format!(
+                        "s3: invalid shard descriptor (missing 'index'): {}",
+                        shard.descriptor
+                    ))
+                })?;
+            Some((shards as usize, index as usize))
+        };
+        *self.applied_shard.lock().expect("shard mutex poisoned") = parsed;
+        Ok(())
+    }
 }
 
 /// Return a human-readable name for a JSON value type.
@@ -496,7 +591,11 @@ mod tests {
             .behavior_version(aws_config::BehaviorVersion::latest())
             .build();
         let client = Client::new(&sdk_config);
-        S3Source { config, client }
+        S3Source {
+            config,
+            client,
+            applied_shard: Mutex::new(None),
+        }
     }
 
     #[test]
@@ -570,6 +669,83 @@ mod tests {
     fn compression_default_is_auto() {
         let cfg = S3SourceConfig::new("bucket");
         assert_eq!(cfg.compression, faucet_core::CompressionConfig::Auto);
+    }
+
+    // ── Hash-modulo sharding ────────────────────────────────────────────────
+
+    #[test]
+    fn shard_hash_is_deterministic() {
+        assert_eq!(
+            shard_hash("data/part-001.jsonl"),
+            shard_hash("data/part-001.jsonl")
+        );
+        assert_ne!(shard_hash("a"), shard_hash("b"));
+    }
+
+    #[tokio::test]
+    async fn enumerate_shards_returns_target_disjoint_shards() {
+        let source = test_source(S3SourceConfig::new("b"));
+        assert!(source.is_shardable());
+        let shards = source.enumerate_shards(3).await.unwrap();
+        assert_eq!(shards.len(), 3);
+        for (i, s) in shards.iter().enumerate() {
+            assert_eq!(s.descriptor["shards"], 3);
+            assert_eq!(s.descriptor["index"], i);
+        }
+    }
+
+    #[tokio::test]
+    async fn enumerate_shards_target_one_is_whole() {
+        let source = test_source(S3SourceConfig::new("b"));
+        let shards = source.enumerate_shards(1).await.unwrap();
+        assert_eq!(shards.len(), 1);
+        assert!(shards[0].is_whole());
+    }
+
+    // The union of every shard's filtered key set equals the full set, with no
+    // key in two shards — the core no-dup / no-loss guarantee.
+    #[tokio::test]
+    async fn shard_filter_partitions_keys_disjointly_and_completely() {
+        let keys: Vec<String> = (0..200).map(|i| format!("data/obj-{i}.jsonl")).collect();
+        let n = 4;
+        let mut union: Vec<String> = Vec::new();
+        for index in 0..n {
+            let source = test_source(S3SourceConfig::new("b"));
+            source
+                .apply_shard(&ShardSpec::new(
+                    index.to_string(),
+                    serde_json::json!({ "shards": n, "index": index }),
+                ))
+                .await
+                .unwrap();
+            let got = source.shard_filter(keys.clone());
+            union.extend(got);
+        }
+        union.sort();
+        let mut expected = keys.clone();
+        expected.sort();
+        assert_eq!(
+            union, expected,
+            "shards must union to the full key set, disjointly"
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_whole_shard_reads_everything() {
+        let keys: Vec<String> = (0..20).map(|i| format!("k{i}")).collect();
+        let source = test_source(S3SourceConfig::new("b"));
+        source.apply_shard(&ShardSpec::whole()).await.unwrap();
+        assert_eq!(source.shard_filter(keys.clone()).len(), keys.len());
+    }
+
+    #[tokio::test]
+    async fn apply_shard_rejects_malformed_descriptor() {
+        let source = test_source(S3SourceConfig::new("b"));
+        let err = source
+            .apply_shard(&ShardSpec::new("0", serde_json::json!({ "index": 0 })))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, FaucetError::Source(_)));
     }
 
     #[test]

--- a/docs/book/src/cookbook/cluster.md
+++ b/docs/book/src/cookbook/cluster.md
@@ -236,6 +236,76 @@ from the shared DB.
 
 See the operator/Helm chart for faucet — TBD (#197).
 
+## Distributing one big source across workers (Mode B)
+
+Everything above is **Mode A**: whole *runs* pull-balance across instances, but a
+single large source still runs entirely on one worker. **Mode B** splits *one
+source* into shards that different workers process concurrently, so a single
+logical pipeline over a huge table or object prefix scales horizontally.
+
+### Enabling it
+
+Add a top-level `shard:` block to the submitted config and run the cluster as
+usual (Mode B requires `--cluster` + a SQL history backend — it builds on the
+same lease/claim machinery):
+
+```yaml
+version: 1
+name: big-table-mirror
+shard:
+  count: 8            # split the source into ~8 shards
+pipeline:
+  source:
+    type: postgres
+    config:
+      connection_url: ${env:PG_URL}
+      query: "SELECT * FROM events"
+      shard: { key: id }   # integer column to range-partition on
+  sink:
+    type: postgres
+    config:
+      connection_url: ${env:WAREHOUSE_URL}
+      table: events
+      write_mode: upsert
+      key: [id]
+  state: { type: postgres, config: { connection_url: ${env:PG_URL} } }
+```
+
+When a sharded run is submitted, the instance that claims it acts as an
+(ephemeral) **coordinator**: it enumerates the shards and inserts them into the
+shared `faucet_serve_shards` table (idempotently — no leader election). Every
+instance's claim loop then pulls shard rows up to its free capacity, narrows its
+source to that shard, and runs it. The parent run is marked `sharded` and is
+finalized to `completed`/`failed` once every shard is terminal.
+
+### Shardable sources
+
+| Source | Strategy | How to enable |
+|--------|----------|---------------|
+| `postgres` | primary-key range (`WHERE key >= lo AND key < hi`) | `source.config.shard: { key: <int column> }` |
+| `s3` | hash-of-object-key modulo N | automatic (no config) |
+
+Other sources are not shardable yet (tracked in [#262](https://github.com/PawanSikawat/faucet-stream/issues/262));
+Kafka uses native consumer-group assignment instead ([#261](https://github.com/PawanSikawat/faucet-stream/issues/261)).
+A non-shardable source (or a matrix pipeline) ignores `shard:` and runs whole — Mode B is fully backward compatible.
+
+### Per-shard resume and rebalancing
+
+- **Per-shard bookmarks:** each shard has its own state key (`{run}::{shard}`),
+  so a reassigned shard resumes where its dead owner left off, independent of its
+  siblings.
+- **Rebalancing:** a shard whose owning instance's lease expires is reclaimed by
+  the lease loop — requeued to another worker, or poisoned (failed) past
+  `--cluster-max-attempts`. New members pick up unassigned/reclaimed shards on
+  their next claim tick.
+- **Correctness boundary:** the same paused-not-crashed double-processing window
+  as Mode A applies per shard. Pair with `write_mode: upsert` (or exactly-once
+  delivery) so a reassigned shard's overlap is idempotent — as in the example
+  above.
+
+Mode B metrics: `faucet_serve_shards_claimed_total`,
+`faucet_serve_shards_reclaimed_total{outcome}`.
+
 ## Related pages
 
 - [Running faucet as a service](./serve.md) — `faucet serve` fundamentals,

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -339,11 +339,14 @@ components:
   schemas:
     RunStatus:
       type: string
-      enum: [pending, queued, running, completed, failed, cancelled]
+      enum: [pending, queued, running, sharded, completed, failed, cancelled]
       description: >
         `pending` — cluster mode only; stored in the shared DB awaiting a claim by any instance.
         `queued` — claimed/admitted to the local execution queue.
         `running` — actively executing.
+        `sharded` — cluster Mode B only; the run was expanded into source shards
+        (rows in `faucet_serve_shards`) that execute independently; finalized to a
+        terminal state once every shard finishes.
         `completed` / `failed` / `cancelled` — terminal states.
     SubmitRequest:
       type: object


### PR DESCRIPTION
Closes #230. Part of the roadmap epic #38.

Mode B distributes shards of a **single** source across cluster workers (Mode A, #229, only balances whole runs), so one logical pipeline over a huge table or object prefix scales horizontally. Built on Mode A's shared SQL history + lease/claim machinery.

## Scope (agreed)

Engine + two reference connectors (**Postgres**, **S3**). Kafka's native consumer-group path is filed as **#261**; the remaining shardable connectors (gcs/parquet/mysql/mssql/sqlite) as **#262**.

## What's included

**Core (`faucet-core`)** — `Shardable` capability: `ShardSpec` + 3 defaulted `Source` methods (`is_shardable`/`enumerate_shards`/`apply_shard`). Defaulted to a single whole-dataset shard, so every existing and third-party source is unaffected and object-safety is preserved (added as defaulted `Source` methods, consistent with `capture_resume_position` etc., rather than a separate trait that couldn't be reached through `Box<dyn Source>`).

**Connectors** — Postgres opt-in PK-range sharding (`source.config.shard: { key }`; MIN/MAX split into contiguous ranges, subquery-wrapped, key quoted + integer bounds inlined); S3 unconditional hash-of-key (FNV-1a) modulo-N sharding (deterministic across workers, disjoint + complete). Both no-op outside the coordinator.

**Coordination engine (serve)** — a `faucet_serve_shards` table + 6 `RunHistory` methods (idempotent `insert_shards`, atomic largest-first `claim_shards`, `renew_shard_leases`, `reclaim_shards` requeue→poison, owner-fenced `finalize_shard`, `shard_progress`), in the shared `impl_sql_history!` macro (Postgres + SQLite), inert for the in-memory backend, fallback-forwarded.

**Live coordinator** — a sharded `Pending` run is expanded on claim (enumerate + idempotent insert + mark `RunStatus::Sharded`, no leader election); the claim loop also claims shard rows and runs each via `resume_claimed_shard` (rebuild + narrow source, per-shard state key `{run}::{shard}`, owner-fenced finalize, parent finalized when all shards terminal); the lease loop heartbeats + rebalances expired-lease shards. Top-level `shard: { count }` config opts a run in; non-shardable sources / matrix pipelines fall back to a whole run. Fully backward compatible (no new Cargo features; inert without `--cluster`).

## Tests

- **Core**: `ShardSpec` round-trip + whole-shard semantics; object-safety + default behavior of the new `Source` methods.
- **Connectors**: pure-logic unit tests (PK-range planning, query wrapping, injection-safe key quoting, hash partition disjointness/completeness, descriptor parsing); a **Postgres integration test proving the core no-duplication / no-loss guarantee** — N shards union to every row exactly once.
- **Serve**: SQLite-backed tests for `insert_shards` idempotency, largest-first exclusive claiming, owner-fenced finalize, expired-lease requeue→poison; `shard_progress.all_terminal()` + memory-backend inertness.
- All 513 CLI lib tests pass (no regressions).

## Verification

`cargo check` default / `serve-history-sqlite,serve-history-postgres` / `full` all clean; `clippy --all-targets -D warnings` clean (core, postgres, s3, cli serve); `fmt` clean; CLI lib tests green.

## Docs

`docs/book/src/cookbook/cluster.md` gains a "Distributing one big source across workers (Mode B)" section (config, shardable-source table, per-shard resume + rebalancing, the upsert/exactly-once correctness boundary, metrics); `docs/openapi.yaml` adds the `sharded` status.

## Notes / boundaries

- Per-shard reassignment has the same paused-not-crashed double-processing window as Mode A — pair with `write_mode: upsert` (documented + shown in the cookbook example) for idempotent overlap.
- The full 2-process E2E is covered compositionally (connector sharding ⊕ SQLite history coordination); a dedicated multi-process serve harness can follow if desired.
