### PR TITLE
feat: extend cluster Mode B sharding to mysql, mssql, sqlite, gcs, and parquet sources

### DIFF
--- a/crates/core/src/shard.rs
+++ b/crates/core/src/shard.rs
@@ -262,7 +262,7 @@ impl PkShardBounds {
 /// Parse + validate an applied shard for a PK-range source.
 ///
 /// Returns `Ok(None)` for the whole-dataset shard (the source should clear any
-/// narrowing and stream everything) and a typed [`FaucetError::Source`] naming
+/// narrowing and stream everything) and a typed [`FaucetError::Source`](crate::FaucetError::Source) naming
 /// `connector` for a malformed descriptor. The one-line body every SQL
 /// source's [`apply_shard`](crate::Source::apply_shard) delegates to.
 pub fn parse_pk_shard(
@@ -380,7 +380,7 @@ impl HashShard {
 /// Parse + validate an applied shard for a hash-of-key source.
 ///
 /// Returns `Ok(None)` for the whole-dataset shard (the source should clear any
-/// filter and read everything) and a typed [`FaucetError::Source`] naming
+/// filter and read everything) and a typed [`FaucetError::Source`](crate::FaucetError::Source) naming
 /// `connector` for a malformed descriptor. The one-line body every
 /// object-store / file source's [`apply_shard`](crate::Source::apply_shard)
 /// delegates to.

--- a/crates/core/src/shard.rs
+++ b/crates/core/src/shard.rs
@@ -91,6 +91,314 @@ impl ShardSpec {
     }
 }
 
+// ── PK-range sharding (shared by the SQL query sources) ─────────────────────
+
+/// Split the integer range observed as `[min, max]` into up to `target`
+/// contiguous shards, each described by
+/// `{key, lo, hi, lo_unbounded, hi_unbounded, include_null}`. Interior cut
+/// points are half-open `[lo, hi)`, but the **boundary shards are open-ended**:
+/// the first shard has no lower bound and the last shard has no upper bound, so
+/// the union of all shards tiles `(-∞, +∞)`.
+///
+/// Open-ended boundaries match unsharded semantics: `min`/`max` are captured
+/// once at enumeration time, but rows can be inserted below `min` or above `max`
+/// (or backfilled) before the workers actually stream their shards. Clamping the
+/// boundary shards to the captured `[min, max]` would silently drop those rows
+/// (audit F54/F55); leaving them open captures everything.
+///
+/// The last shard also carries `include_null: true` so that NULL-key rows —
+/// invisible to the `MIN`/`MAX` enumeration that produced `[min, max]` — are
+/// read by exactly one shard (no loss, no duplication; audit F37). Picking the
+/// *last* shard means a single-shard plan still covers NULLs.
+///
+/// Coverage scheme (proven by `predicate_coverage_*` tests):
+/// - non-NULL keys: the first shard owns `key < cut₁`, interior shards own
+///   `[cutᵢ, cutᵢ₊₁)`, and the last shard owns `key >= cutₙ` — every value
+///   (including below `min` and above `max`) falls in exactly one shard;
+/// - NULL keys: matched only by the last shard's `OR key IS NULL` clause —
+///   exactly one shard.
+///
+/// Pure function (no I/O) so it is unit-testable without a database. Shared by
+/// every PK-range-sharded SQL source (postgres, mysql, mssql, sqlite) so the
+/// subtle boundary/NULL coverage logic lives in exactly one place.
+pub fn plan_pk_shards(key: &str, min: i64, max: i64, target: usize) -> Vec<ShardSpec> {
+    let target = target.max(1);
+    // Range width as u128 to avoid i64 overflow on full-range PKs.
+    let width = (max as i128 - min as i128 + 1).max(1) as u128;
+    let n = (target as u128).min(width) as usize; // never more shards than values
+    let step = width.div_ceil(n as u128); // ceil so shards cover the whole range
+
+    let mut shards = Vec::with_capacity(n);
+    let mut lo = min as i128;
+    for i in 0..n {
+        let mut hi = lo + step as i128;
+        let is_first = i == 0;
+        let is_last = i == n - 1;
+        if is_last || hi > max as i128 {
+            hi = max as i128; // last interior cut closes at max (the last shard
+            // is unbounded above, so `hi` is unused there)
+        }
+        let descriptor = serde_json::json!({
+            "key": key,
+            "lo": lo as i64,
+            "hi": hi as i64,
+            // Boundary shards are open-ended so the union tiles (-∞, +∞).
+            "lo_unbounded": is_first,
+            "hi_unbounded": is_last,
+            // Exactly one shard (the last) owns the NULL-key rows.
+            "include_null": is_last,
+        });
+        let size = (hi - lo).max(0) as u64 + if is_last { 1 } else { 0 };
+        shards.push(ShardSpec::new(i.to_string(), descriptor).with_size(size));
+        if is_last {
+            break;
+        }
+        lo = hi;
+    }
+    shards
+}
+
+/// Parsed integer range bounds for an applied PK-range shard, produced by
+/// [`plan_pk_shards`] and applied by a SQL source's
+/// [`apply_shard`](crate::Source::apply_shard).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PkShardBounds {
+    /// The shard-key column name, **unquoted** — the consuming dialect quotes
+    /// it via the closure handed to [`wrap`](Self::wrap).
+    pub key: String,
+    /// Inclusive lower cut point (unused when `lo_unbounded`).
+    pub lo: i64,
+    /// Exclusive upper cut point (unused when `hi_unbounded`).
+    pub hi: i64,
+    /// When `true` this shard has **no lower bound** — it is the *first* shard,
+    /// so it owns every key below `hi` including any below the enumerated `MIN`.
+    /// Rows backfilled or inserted with smaller ids during the run are read by
+    /// this shard instead of being silently dropped outside `[MIN, MAX]` (F54).
+    pub lo_unbounded: bool,
+    /// When `true` this shard has **no upper bound** — it is the *last* shard,
+    /// so it owns every key at/above `lo` including any above the enumerated
+    /// `MAX`. Rows appended above the captured `MAX` between coordination and
+    /// shard execution are read by this shard instead of being lost (F55).
+    pub hi_unbounded: bool,
+    /// When `true` this shard *additionally* matches rows whose `key` is NULL.
+    ///
+    /// SQL aggregates (`MIN`/`MAX`) ignore NULLs, so a nullable shard key never
+    /// produces a `[lo, hi]` range covering NULL-key rows — without this flag
+    /// every sharded run would silently drop them (audit F37). Exactly one
+    /// shard (the last) carries this flag, so NULL-key rows are read by
+    /// precisely one shard: no loss, no duplication.
+    pub include_null: bool,
+}
+
+impl PkShardBounds {
+    /// Parse from a [`ShardSpec`] descriptor produced by [`plan_pk_shards`].
+    /// Returns `None` for a malformed descriptor (missing/ill-typed
+    /// `key`/`lo`/`hi`) — including the whole-dataset shard's `null`
+    /// descriptor, so callers must check [`ShardSpec::is_whole`] first.
+    pub fn from_spec(spec: &ShardSpec) -> Option<Self> {
+        let d = &spec.descriptor;
+        Some(Self {
+            key: d.get("key")?.as_str()?.to_string(),
+            lo: d.get("lo")?.as_i64()?,
+            hi: d.get("hi")?.as_i64()?,
+            lo_unbounded: d
+                .get("lo_unbounded")
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(false),
+            hi_unbounded: d
+                .get("hi_unbounded")
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(false),
+            include_null: d
+                .get("include_null")
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(false),
+        })
+    }
+
+    /// Wrap `inner` so only rows whose `key` falls in this shard's range are
+    /// returned: `SELECT * FROM (<inner>) AS _faucet_shard WHERE <predicate>`.
+    ///
+    /// `quote_ident` is the consuming dialect's identifier quoting (ANSI
+    /// double quotes for postgres/sqlite, backticks for mysql, brackets for
+    /// mssql) — quoting the key makes it injection-safe. The bounds are
+    /// inlined as integer literals (safe — they are `i64`s produced by
+    /// enumeration).
+    ///
+    /// The boundary shards are **open-ended** (`lo_unbounded` / `hi_unbounded`)
+    /// so the union of all shards tiles `(-∞, +∞)`, matching unsharded
+    /// semantics — no row is dropped for sorting outside the `[MIN, MAX]`
+    /// captured at enumeration time (F54/F55). The single shard with
+    /// `include_null` also matches `key IS NULL` so NULL-key rows (invisible to
+    /// the `MIN`/`MAX` enumeration) are still read.
+    pub fn wrap(&self, inner: &str, quote_ident: impl Fn(&str) -> String) -> String {
+        let key = quote_ident(&self.key);
+        let mut parts: Vec<String> = Vec::with_capacity(2);
+        if !self.lo_unbounded {
+            parts.push(format!("{key} >= {lo}", lo = self.lo));
+        }
+        if !self.hi_unbounded {
+            parts.push(format!("{key} < {hi}", hi = self.hi));
+        }
+        let range = parts.join(" AND ");
+        let predicate = if self.include_null {
+            if range.is_empty() {
+                // A single fully-unbounded shard owns the whole dataset,
+                // NULL-key rows included.
+                "TRUE".to_string()
+            } else {
+                // Parenthesize so the OR binds correctly inside the WHERE clause.
+                format!("(({range}) OR {key} IS NULL)")
+            }
+        } else if range.is_empty() {
+            "TRUE".to_string()
+        } else {
+            range
+        };
+        format!("SELECT * FROM ({inner}) AS _faucet_shard WHERE {predicate}")
+    }
+}
+
+/// Parse + validate an applied shard for a PK-range source.
+///
+/// Returns `Ok(None)` for the whole-dataset shard (the source should clear any
+/// narrowing and stream everything) and a typed [`FaucetError::Source`] naming
+/// `connector` for a malformed descriptor. The one-line body every SQL
+/// source's [`apply_shard`](crate::Source::apply_shard) delegates to.
+pub fn parse_pk_shard(
+    shard: &ShardSpec,
+    connector: &str,
+) -> Result<Option<PkShardBounds>, crate::FaucetError> {
+    if shard.is_whole() {
+        return Ok(None);
+    }
+    PkShardBounds::from_spec(shard).map(Some).ok_or_else(|| {
+        crate::FaucetError::Source(format!(
+            "{connector}: invalid shard descriptor: {}",
+            shard.descriptor
+        ))
+    })
+}
+
+/// Build the `MIN`/`MAX` bounds probe a PK-range enumeration runs once:
+/// `SELECT CAST(MIN(<key>) AS <int_cast>) AS lo, CAST(MAX(<key>) AS <int_cast>) AS hi
+/// FROM (<inner>) AS _faucet_bounds`.
+///
+/// `quoted_key` must already be dialect-quoted; `int_cast` is the dialect's
+/// 64-bit integer cast target (`BIGINT` for postgres/mssql, `SIGNED` for
+/// mysql, `INTEGER` for sqlite).
+pub fn pk_bounds_query(inner: &str, quoted_key: &str, int_cast: &str) -> String {
+    format!(
+        "SELECT CAST(MIN({quoted_key}) AS {int_cast}) AS lo, \
+         CAST(MAX({quoted_key}) AS {int_cast}) AS hi \
+         FROM ({inner}) AS _faucet_bounds"
+    )
+}
+
+/// Turn the decoded output of a [`pk_bounds_query`] probe into a shard plan: a
+/// populated range plans PK-range shards via [`plan_pk_shards`]; an empty
+/// result set (`MIN`/`MAX` are NULL) degrades to one whole-dataset shard.
+pub fn pk_shards_from_bounds(
+    key: &str,
+    lo: Option<i64>,
+    hi: Option<i64>,
+    target: usize,
+) -> Vec<ShardSpec> {
+    match (lo, hi) {
+        (Some(lo), Some(hi)) => plan_pk_shards(key, lo, hi, target),
+        _ => vec![ShardSpec::whole()],
+    }
+}
+
+// ── Hash-of-key sharding (shared by the object-store / file sources) ────────
+
+/// Stable FNV-1a hash of an object key / file path, used to assign keys to
+/// shards.
+///
+/// Deterministic across processes and platforms (all cluster workers run the
+/// identical binary and this fixed algorithm), so every worker maps a given key
+/// to the same shard index — the partition is disjoint and complete.
+pub fn shard_hash(key: &str) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in key.as_bytes() {
+        h ^= *b as u64;
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    h
+}
+
+/// Enumerate `target` hash-modulo shards, each described by
+/// `{shards, index}`. Shard `i` owns the keys whose [`shard_hash`] is
+/// `i (mod target)`. No I/O: the partition is defined by the hash function,
+/// so enumeration is cheap and stays stable as new objects appear.
+/// `target <= 1` yields a single whole-dataset shard.
+pub fn plan_hash_shards(target: usize) -> Vec<ShardSpec> {
+    if target <= 1 {
+        return vec![ShardSpec::whole()];
+    }
+    (0..target)
+        .map(|i| {
+            ShardSpec::new(
+                i.to_string(),
+                serde_json::json!({ "shards": target, "index": i }),
+            )
+        })
+        .collect()
+}
+
+/// Parsed `{shards, index}` hash-modulo shard descriptor, produced by
+/// [`plan_hash_shards`] and applied by an object-store / file source's
+/// [`apply_shard`](crate::Source::apply_shard).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct HashShard {
+    /// Total shard count in this run's set.
+    pub shards: usize,
+    /// This shard's index in `0..shards`.
+    pub index: usize,
+}
+
+impl HashShard {
+    /// Parse from a [`ShardSpec`] descriptor produced by [`plan_hash_shards`].
+    /// Returns `None` for a malformed descriptor (missing/ill-typed `shards`
+    /// or `index`) — including the whole-dataset shard's `null` descriptor,
+    /// so callers must check [`ShardSpec::is_whole`] first.
+    pub fn from_spec(spec: &ShardSpec) -> Option<Self> {
+        let d = &spec.descriptor;
+        Some(Self {
+            shards: d.get("shards")?.as_u64()? as usize,
+            index: d.get("index")?.as_u64()? as usize,
+        })
+    }
+
+    /// Whether `key` belongs to this shard. A degenerate set of `<= 1` shards
+    /// owns every key.
+    pub fn contains(&self, key: &str) -> bool {
+        self.shards <= 1 || (shard_hash(key) % self.shards as u64) == self.index as u64
+    }
+}
+
+/// Parse + validate an applied shard for a hash-of-key source.
+///
+/// Returns `Ok(None)` for the whole-dataset shard (the source should clear any
+/// filter and read everything) and a typed [`FaucetError::Source`] naming
+/// `connector` for a malformed descriptor. The one-line body every
+/// object-store / file source's [`apply_shard`](crate::Source::apply_shard)
+/// delegates to.
+pub fn parse_hash_shard(
+    shard: &ShardSpec,
+    connector: &str,
+) -> Result<Option<HashShard>, crate::FaucetError> {
+    if shard.is_whole() {
+        return Ok(None);
+    }
+    HashShard::from_spec(shard).map(Some).ok_or_else(|| {
+        crate::FaucetError::Source(format!(
+            "{connector}: invalid shard descriptor: {}",
+            shard.descriptor
+        ))
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -141,5 +449,374 @@ mod tests {
     fn id_zero_with_descriptor_is_not_whole() {
         let s = ShardSpec::new("0", json!({ "partition": 0 }));
         assert!(!s.is_whole());
+    }
+
+    // ── PK-range planning ────────────────────────────────────────────────────
+
+    /// ANSI double-quote identifier quoting, matching
+    /// `faucet_core::util::quote_ident` (not imported to keep this module
+    /// self-contained).
+    fn ansi_quote(name: &str) -> String {
+        format!("\"{}\"", name.replace('"', "\"\""))
+    }
+
+    #[test]
+    fn plan_pk_shards_covers_full_range_without_gaps_or_overlap() {
+        let shards = plan_pk_shards("id", 0, 99, 4);
+        assert_eq!(shards.len(), 4);
+        // Contiguous half-open interior cuts; boundary shards are open-ended.
+        let mut expected_lo = 0i64;
+        for (i, s) in shards.iter().enumerate() {
+            let d = &s.descriptor;
+            assert_eq!(d["key"], "id");
+            assert_eq!(d["lo"].as_i64().unwrap(), expected_lo);
+            let hi = d["hi"].as_i64().unwrap();
+            let first = i == 0;
+            let last = i == shards.len() - 1;
+            assert_eq!(d["lo_unbounded"].as_bool().unwrap(), first);
+            assert_eq!(d["hi_unbounded"].as_bool().unwrap(), last);
+            expected_lo = hi; // next shard starts where this half-open one ended
+        }
+    }
+
+    #[test]
+    fn plan_pk_shards_never_more_shards_than_values() {
+        // Range [5, 7] has 3 values; asking for 10 shards yields at most 3.
+        let shards = plan_pk_shards("pk", 5, 7, 10);
+        assert!(shards.len() <= 3, "got {} shards", shards.len());
+        assert!(
+            shards[0].descriptor["lo_unbounded"].as_bool().unwrap(),
+            "first shard is unbounded below"
+        );
+        assert!(
+            shards.last().unwrap().descriptor["hi_unbounded"]
+                .as_bool()
+                .unwrap(),
+            "last shard is unbounded above"
+        );
+    }
+
+    #[test]
+    fn plan_pk_shards_single_value_one_shard() {
+        let shards = plan_pk_shards("id", 42, 42, 8);
+        assert_eq!(shards.len(), 1);
+        // A lone shard is open-ended on both sides → the whole dataset.
+        assert!(shards[0].descriptor["lo_unbounded"].as_bool().unwrap());
+        assert!(shards[0].descriptor["hi_unbounded"].as_bool().unwrap());
+    }
+
+    #[test]
+    fn plan_pk_shards_target_zero_treated_as_one() {
+        let shards = plan_pk_shards("id", 0, 9, 0);
+        assert_eq!(shards.len(), 1);
+        assert_eq!(shards[0].descriptor["hi"].as_i64().unwrap(), 9);
+    }
+
+    #[test]
+    fn plan_pk_shards_full_i64_range_does_not_overflow() {
+        // A full-range key must not overflow the i128 width computation.
+        let shards = plan_pk_shards("id", i64::MIN, i64::MAX, 4);
+        assert_eq!(shards.len(), 4);
+        assert!(shards[0].descriptor["lo_unbounded"].as_bool().unwrap());
+        assert!(
+            shards.last().unwrap().descriptor["hi_unbounded"]
+                .as_bool()
+                .unwrap()
+        );
+    }
+
+    // ── PK-range bounds / predicate generation ──────────────────────────────
+
+    #[test]
+    fn pk_bounds_wrap_builds_half_open_predicate() {
+        // An interior shard (bounded both sides) is half-open `[lo, hi)`.
+        let spec = ShardSpec::new(
+            "1",
+            json!({"key": "id", "lo": 100, "hi": 200, "lo_unbounded": false, "hi_unbounded": false}),
+        );
+        let b = PkShardBounds::from_spec(&spec).unwrap();
+        let sql = b.wrap("SELECT * FROM t", ansi_quote);
+        assert!(sql.contains("(SELECT * FROM t) AS _faucet_shard"));
+        assert!(sql.contains(r#""id" >= 100"#), "got: {sql}");
+        assert!(
+            sql.contains(r#""id" < 200"#),
+            "half-open upper bound: {sql}"
+        );
+    }
+
+    #[test]
+    fn pk_bounds_wrap_first_shard_has_no_lower_bound() {
+        // F54: the first shard omits the `>= lo` floor so keys below the
+        // enumerated MIN are still read.
+        let spec = ShardSpec::new(
+            "0",
+            json!({"key": "id", "lo": 0, "hi": 100, "lo_unbounded": true, "hi_unbounded": false}),
+        );
+        let b = PkShardBounds::from_spec(&spec).unwrap();
+        let sql = b.wrap("SELECT * FROM t", ansi_quote);
+        assert!(sql.contains(r#""id" < 100"#), "upper bound present: {sql}");
+        assert!(!sql.contains(">="), "first shard has no lower floor: {sql}");
+    }
+
+    #[test]
+    fn pk_bounds_wrap_last_shard_has_no_upper_bound() {
+        // F55: the last shard omits the upper bound so keys above the
+        // enumerated MAX are still read.
+        let spec = ShardSpec::new(
+            "2",
+            json!({"key": "id", "lo": 200, "hi": 300, "lo_unbounded": false, "hi_unbounded": true}),
+        );
+        let b = PkShardBounds::from_spec(&spec).unwrap();
+        let sql = b.wrap("SELECT * FROM t", ansi_quote);
+        assert!(sql.contains(r#""id" >= 200"#), "lower bound present: {sql}");
+        assert!(
+            !sql.contains(" < ") && !sql.contains("<="),
+            "last shard has no upper bound: {sql}"
+        );
+    }
+
+    #[test]
+    fn pk_bounds_wrap_uses_the_supplied_dialect_quoting() {
+        let spec = ShardSpec::new(
+            "0",
+            json!({"key": "id", "lo": 0, "hi": 1, "lo_unbounded": false, "hi_unbounded": false}),
+        );
+        let b = PkShardBounds::from_spec(&spec).unwrap();
+        let backtick = b.wrap("SELECT 1", |k| format!("`{k}`"));
+        assert!(backtick.contains("`id` >= 0"), "got: {backtick}");
+        let bracket = b.wrap("SELECT 1", |k| format!("[{k}]"));
+        assert!(bracket.contains("[id] >= 0"), "got: {bracket}");
+    }
+
+    #[test]
+    fn pk_bounds_from_spec_rejects_malformed_descriptor() {
+        let spec = ShardSpec::new("0", json!({"key": "id"})); // no lo/hi
+        assert!(PkShardBounds::from_spec(&spec).is_none());
+        assert!(PkShardBounds::from_spec(&ShardSpec::whole()).is_none());
+    }
+
+    // ── F37: NULL-key shard coverage ────────────────────────────────────────
+
+    #[test]
+    fn exactly_one_shard_includes_null() {
+        let shards = plan_pk_shards("id", 0, 99, 5);
+        let null_owners: Vec<usize> = shards
+            .iter()
+            .enumerate()
+            .filter(|(_, s)| s.descriptor["include_null"].as_bool().unwrap_or(false))
+            .map(|(i, _)| i)
+            .collect();
+        assert_eq!(
+            null_owners,
+            vec![shards.len() - 1],
+            "exactly the last shard owns NULL keys"
+        );
+    }
+
+    #[test]
+    fn single_shard_plan_still_owns_null() {
+        // A single value yields one shard; it must still cover NULL keys.
+        let shards = plan_pk_shards("id", 7, 7, 4);
+        assert_eq!(shards.len(), 1);
+        assert!(shards[0].descriptor["include_null"].as_bool().unwrap());
+    }
+
+    #[test]
+    fn last_shard_wrap_emits_is_null_clause() {
+        let shards = plan_pk_shards("id", 0, 99, 3);
+        let last = PkShardBounds::from_spec(shards.last().unwrap()).unwrap();
+        let sql = last.wrap("SELECT * FROM t", ansi_quote);
+        assert!(
+            sql.contains(r#""id" IS NULL"#),
+            "last shard must match NULL keys: {sql}"
+        );
+        assert!(sql.contains(" OR "), "NULL clause OR'd with range: {sql}");
+    }
+
+    #[test]
+    fn non_last_shard_wrap_omits_is_null_clause() {
+        let shards = plan_pk_shards("id", 0, 99, 3);
+        // First shard is not the last → no NULL clause.
+        let first = PkShardBounds::from_spec(&shards[0]).unwrap();
+        let sql = first.wrap("SELECT * FROM t", ansi_quote);
+        assert!(
+            !sql.contains("IS NULL"),
+            "non-last shard must not match NULL keys: {sql}"
+        );
+    }
+
+    /// Property check on the generated predicates: OR-ing every shard's WHERE
+    /// predicate must cover (a) every non-NULL key — including values *outside*
+    /// the enumerated `[min, max]` (F54/F55) — exactly once and (b) NULL keys
+    /// exactly once.
+    #[test]
+    fn predicate_coverage_complete_and_non_overlapping() {
+        let (min, max, target) = (0i64, 19i64, 4usize);
+        let bounds: Vec<PkShardBounds> = plan_pk_shards("k", min, max, target)
+            .iter()
+            .map(|s| PkShardBounds::from_spec(s).unwrap())
+            .collect();
+
+        // The boundary shards model SQL membership: open below for the first
+        // shard, open above for the last.
+        let matches_key = |b: &PkShardBounds, key: i64| -> bool {
+            let lower = b.lo_unbounded || key >= b.lo;
+            let upper = b.hi_unbounded || key < b.hi;
+            lower && upper
+        };
+
+        // (a) Every non-NULL key — well below min, in range, and well above max
+        // — matches exactly one shard. Keys outside [min, max] model rows
+        // inserted/backfilled during the coordinate→execute window.
+        for key in (min - 50)..=(max + 50) {
+            let matches = bounds.iter().filter(|b| matches_key(b, key)).count();
+            assert_eq!(matches, 1, "key {key} matched {matches} shards (want 1)");
+        }
+
+        // (b) NULL keys match exactly one shard (the one with include_null).
+        let null_matches = bounds.iter().filter(|b| b.include_null).count();
+        assert_eq!(null_matches, 1, "NULL keys must match exactly one shard");
+    }
+
+    #[test]
+    fn single_shard_wrap_selects_whole_dataset_including_null() {
+        // A lone open-ended shard must select every row, NULL keys included.
+        let shards = plan_pk_shards("id", 7, 7, 1);
+        assert_eq!(shards.len(), 1);
+        let b = PkShardBounds::from_spec(&shards[0]).unwrap();
+        let sql = b.wrap("SELECT * FROM t", ansi_quote);
+        assert!(sql.contains("WHERE TRUE"), "whole-dataset predicate: {sql}");
+        assert!(!sql.contains(">="), "no bounds on a lone shard: {sql}");
+    }
+
+    // ── Hash-of-key sharding ────────────────────────────────────────────────
+
+    #[test]
+    fn shard_hash_is_deterministic() {
+        assert_eq!(
+            shard_hash("data/part-001.jsonl"),
+            shard_hash("data/part-001.jsonl")
+        );
+        assert_ne!(shard_hash("a"), shard_hash("b"));
+    }
+
+    #[test]
+    fn plan_hash_shards_returns_target_disjoint_shards() {
+        let shards = plan_hash_shards(3);
+        assert_eq!(shards.len(), 3);
+        for (i, s) in shards.iter().enumerate() {
+            assert_eq!(s.descriptor["shards"], 3);
+            assert_eq!(s.descriptor["index"], i);
+            assert_eq!(s.id, i.to_string());
+        }
+    }
+
+    #[test]
+    fn plan_hash_shards_target_one_is_whole() {
+        let shards = plan_hash_shards(1);
+        assert_eq!(shards.len(), 1);
+        assert!(shards[0].is_whole());
+        let shards = plan_hash_shards(0);
+        assert_eq!(shards.len(), 1);
+        assert!(shards[0].is_whole());
+    }
+
+    // The union of every shard's owned key set equals the full set, with no
+    // key in two shards — the core no-dup / no-loss guarantee.
+    #[test]
+    fn hash_shards_partition_keys_disjointly_and_completely() {
+        let keys: Vec<String> = (0..200).map(|i| format!("data/obj-{i}.jsonl")).collect();
+        let n = 4;
+        let members: Vec<HashShard> = plan_hash_shards(n)
+            .iter()
+            .map(|s| HashShard::from_spec(s).unwrap())
+            .collect();
+        for key in &keys {
+            let owners = members.iter().filter(|m| m.contains(key)).count();
+            assert_eq!(owners, 1, "key {key} owned by {owners} shards (want 1)");
+        }
+    }
+
+    #[test]
+    fn hash_shard_degenerate_single_shard_owns_everything() {
+        let m = HashShard {
+            shards: 1,
+            index: 0,
+        };
+        assert!(m.contains("anything"));
+    }
+
+    #[test]
+    fn hash_shard_from_spec_rejects_malformed_descriptor() {
+        assert!(HashShard::from_spec(&ShardSpec::new("0", json!({ "index": 0 }))).is_none());
+        assert!(HashShard::from_spec(&ShardSpec::new("0", json!({ "shards": 4 }))).is_none());
+        assert!(HashShard::from_spec(&ShardSpec::whole()).is_none());
+    }
+
+    #[test]
+    fn hash_shard_round_trips_plan_descriptors() {
+        for spec in plan_hash_shards(5) {
+            let m = HashShard::from_spec(&spec).unwrap();
+            assert_eq!(m.shards, 5);
+            assert_eq!(m.index, spec.id.parse::<usize>().unwrap());
+        }
+    }
+
+    // ── Connector-glue helpers (parse / bounds probe / plan-from-bounds) ─────
+
+    #[test]
+    fn parse_pk_shard_whole_clears_and_real_parses() {
+        assert!(parse_pk_shard(&ShardSpec::whole(), "t").unwrap().is_none());
+        let spec = &plan_pk_shards("id", 0, 99, 3)[1];
+        let bounds = parse_pk_shard(spec, "t").unwrap().unwrap();
+        assert_eq!(bounds.key, "id");
+    }
+
+    #[test]
+    fn parse_pk_shard_malformed_names_connector() {
+        let bad = ShardSpec::new("0", json!({ "key": "id" }));
+        let err = parse_pk_shard(&bad, "mysql").unwrap_err();
+        assert!(err.to_string().contains("mysql"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_hash_shard_whole_clears_and_real_parses() {
+        assert!(
+            parse_hash_shard(&ShardSpec::whole(), "t")
+                .unwrap()
+                .is_none()
+        );
+        let spec = &plan_hash_shards(3)[2];
+        let m = parse_hash_shard(spec, "t").unwrap().unwrap();
+        assert_eq!((m.shards, m.index), (3, 2));
+    }
+
+    #[test]
+    fn parse_hash_shard_malformed_names_connector() {
+        let bad = ShardSpec::new("0", json!({ "index": 0 }));
+        let err = parse_hash_shard(&bad, "gcs").unwrap_err();
+        assert!(err.to_string().contains("gcs"), "got: {err}");
+    }
+
+    #[test]
+    fn pk_bounds_query_shapes_the_probe() {
+        let sql = pk_bounds_query("SELECT * FROM t", "\"id\"", "BIGINT");
+        assert_eq!(
+            sql,
+            "SELECT CAST(MIN(\"id\") AS BIGINT) AS lo, CAST(MAX(\"id\") AS BIGINT) AS hi \
+             FROM (SELECT * FROM t) AS _faucet_bounds"
+        );
+    }
+
+    #[test]
+    fn pk_shards_from_bounds_plans_or_degrades() {
+        let shards = pk_shards_from_bounds("id", Some(0), Some(99), 4);
+        assert_eq!(shards.len(), 4);
+        // NULL MIN/MAX (empty result set) → one whole shard.
+        for (lo, hi) in [(None, None), (Some(1), None), (None, Some(1))] {
+            let shards = pk_shards_from_bounds("id", lo, hi, 4);
+            assert_eq!(shards.len(), 1);
+            assert!(shards[0].is_whole());
+        }
     }
 }

--- a/crates/source/gcs/README.md
+++ b/crates/source/gcs/README.md
@@ -328,6 +328,20 @@ Enable the connector itself in the CLI/umbrella via the `source-gcs` feature.
 - [`faucet-source-s3`](https://crates.io/crates/faucet-source-s3) — the AWS S3 equivalent with the same format semantics.
 - [`faucet-common-gcs`](https://crates.io/crates/faucet-common-gcs) — the shared credentials enum and client builders.
 
+## Sharded execution (cluster Mode B)
+
+Under [`faucet serve --cluster`](https://pawansikawat.github.io/faucet-stream/cookbook/cluster.html),
+a top-level `shard: { count: N }` block splits this source across cluster
+workers **automatically — no connector config needed**. Each worker reads the
+objects whose key hashes to its shard index (stable FNV-1a modulo `count`),
+so the partition is disjoint and complete: every object is read by exactly one
+worker, and the partition stays stable as new objects appear. Outside the
+cluster coordinator a run reads every object, unchanged.
+
+> `max_objects` is applied before the shard filter, so it caps the run's
+> *total* object set (matching single-worker semantics) rather than
+> multiplying by the shard count.
+
 ## License
 
 Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/source/gcs/src/stream.rs
+++ b/crates/source/gcs/src/stream.rs
@@ -3,12 +3,14 @@
 use crate::config::{GcsFileFormat, GcsSourceConfig};
 use async_trait::async_trait;
 use faucet_common_gcs::{build_storage, build_storage_control};
+use faucet_core::shard::{HashShard, ShardSpec, parse_hash_shard, plan_hash_shards};
 use faucet_core::{FaucetError, Stream, StreamPage};
 use futures::stream::{self, StreamExt, TryStreamExt};
 use google_cloud_gax::paginator::ItemPaginator;
 use google_cloud_storage::client::{Storage, StorageControl};
 use serde_json::Value;
 use std::pin::Pin;
+use std::sync::Mutex;
 use tokio::io::AsyncBufReadExt;
 
 /// A GCS source that lists and reads objects from a bucket.
@@ -16,6 +18,10 @@ pub struct GcsSource {
     config: GcsSourceConfig,
     storage: Storage,
     control: StorageControl,
+    /// Shard applied by the cluster coordinator (Mode B). `None` (or a
+    /// degenerate single-shard set) reads every listed object. Stored behind a
+    /// `Mutex` so `apply_shard(&self, …)` can record it before streaming.
+    applied_shard: Mutex<Option<HashShard>>,
 }
 
 impl GcsSource {
@@ -28,7 +34,17 @@ impl GcsSource {
             config,
             storage,
             control,
+            applied_shard: Mutex::new(None),
         })
+    }
+
+    /// Retain only the keys belonging to the applied shard (hash-of-key modulo
+    /// `shards`). A no-op when no shard is applied.
+    fn shard_filter(&self, keys: Vec<String>) -> Vec<String> {
+        filter_shard_keys(
+            keys,
+            *self.applied_shard.lock().expect("shard mutex poisoned"),
+        )
     }
 
     /// Bucket as a GCS resource path: `projects/_/buckets/{bucket}`.
@@ -43,7 +59,7 @@ impl GcsSource {
         prefix_override: Option<&str>,
     ) -> Result<Vec<String>, FaucetError> {
         if let Some(ref keys) = self.config.object_keys {
-            return Ok(cap_keys(keys.clone(), self.config.max_objects));
+            return Ok(self.shard_filter(cap_keys(keys.clone(), self.config.max_objects)));
         }
 
         let effective_prefix = prefix_override.or(self.config.prefix.as_deref());
@@ -72,7 +88,10 @@ impl GcsSource {
                 break;
             }
         }
-        Ok(names)
+        // Shard-filter AFTER the max_objects cap so the cap bounds the run's
+        // total object set (matching single-worker semantics) rather than
+        // multiplying by the shard count.
+        Ok(self.shard_filter(names))
     }
 
     /// Read the full body of a single GCS object into a UTF-8 `String`.
@@ -417,6 +436,28 @@ impl faucet_core::Source for GcsSource {
             None => format!("gs://{}", self.config.bucket),
         }
     }
+
+    /// The GCS source is always shardable: any object set can be split by
+    /// hash-of-key. Sharding only takes effect when the cluster coordinator
+    /// calls `apply_shard`; a plain `faucet run` reads every object.
+    fn is_shardable(&self) -> bool {
+        true
+    }
+
+    /// Enumerate `target` hash-modulo shards. Each shard `i` will read the
+    /// objects whose key hashes to `i (mod target)`. No I/O: the partition is
+    /// defined by the hash function, so enumeration is cheap and stable as new
+    /// objects appear. `target <= 1` yields a single whole-dataset shard.
+    async fn enumerate_shards(&self, target: usize) -> Result<Vec<ShardSpec>, FaucetError> {
+        Ok(plan_hash_shards(target))
+    }
+
+    /// Narrow this source to one hash-modulo shard. The whole-dataset shard
+    /// clears any filter (reads every object).
+    async fn apply_shard(&self, shard: &ShardSpec) -> Result<(), FaucetError> {
+        *self.applied_shard.lock().expect("shard mutex poisoned") = parse_hash_shard(shard, "gcs")?;
+        Ok(())
+    }
 }
 
 /// Truncate an explicit object-key list to the `max_objects` cap.
@@ -430,6 +471,17 @@ fn cap_keys(mut keys: Vec<String>, max: Option<usize>) -> Vec<String> {
         keys.truncate(n);
     }
     keys
+}
+
+/// Retain only the keys owned by `shard` (hash-of-key modulo `shards`). Free
+/// function (vs. a `GcsSource` method) so the partitioning logic is
+/// unit-testable without a GCS client — constructing the source requires live
+/// credentials, and the gRPC integration tests are `#[ignore]`d (#220).
+fn filter_shard_keys(keys: Vec<String>, shard: Option<HashShard>) -> Vec<String> {
+    match shard {
+        Some(member) => keys.into_iter().filter(|k| member.contains(k)).collect(),
+        None => keys,
+    }
 }
 
 fn value_type_name(v: &Value) -> &'static str {
@@ -535,6 +587,36 @@ mod tests {
         let keys = vec!["a".to_string(), "b".to_string()];
         let capped = cap_keys(keys.clone(), Some(10));
         assert_eq!(capped, keys);
+    }
+
+    // ── Hash-modulo sharding (Mode B, #262) ──────────────────────────────────
+
+    // The union of every shard's filtered key set equals the full set, with no
+    // key in two shards — the core no-dup / no-loss guarantee.
+    #[test]
+    fn shard_filter_partitions_keys_disjointly_and_completely() {
+        let keys: Vec<String> = (0..200).map(|i| format!("data/obj-{i}.jsonl")).collect();
+        let members: Vec<HashShard> = plan_hash_shards(4)
+            .iter()
+            .map(|s| HashShard::from_spec(s).expect("descriptor parses"))
+            .collect();
+        let mut union: Vec<String> = Vec::new();
+        for member in members {
+            union.extend(filter_shard_keys(keys.clone(), Some(member)));
+        }
+        union.sort();
+        let mut expected = keys.clone();
+        expected.sort();
+        assert_eq!(
+            union, expected,
+            "shards must union to the full key set, disjointly"
+        );
+    }
+
+    #[test]
+    fn no_applied_shard_reads_everything() {
+        let keys: Vec<String> = (0..20).map(|i| format!("k{i}")).collect();
+        assert_eq!(filter_shard_keys(keys.clone(), None), keys);
     }
 
     // GcsSource requires an async constructor that tries to connect to GCS,

--- a/crates/source/mssql/README.md
+++ b/crates/source/mssql/README.md
@@ -72,6 +72,7 @@ faucet run pipeline.yaml
 |-------|------|---------|-------------|
 | `max_connections` | int | `10` | Maximum pooled connections. |
 | `batch_size` | int | `1000` | Records per emitted `StreamPage`. **`0` = no batching**: the entire result set is emitted as a single page (good for small lookup tables, or sinks that prefer one large request). |
+| `shard` | object | *(unset)* | Optional [Mode B sharding](#sharded-execution-cluster-mode-b): `{ key: <integer column> }`. Opts the source into primary-key range splitting under `faucet serve --cluster`; no effect on a plain `faucet run`. |
 | `statement_timeout_secs` | int (seconds) | `300` | Per-query timeout. **`0` disables** (wait indefinitely). |
 | `state_key` | string | *(derived)* | Explicit state-store key for the incremental bookmark. When unset, a stable key is derived from the connection host plus a fingerprint of the query. |
 
@@ -310,6 +311,42 @@ This crate has no optional features of its own; enable it in the CLI/umbrella vi
 - [Configuration grammar reference](https://pawansikawat.github.io/faucet-stream/reference/config.html)
 - [`faucet-common-mssql`](https://crates.io/crates/faucet-common-mssql) — shared connection/TLS/pool types.
 - [`faucet-sink-mssql`](https://crates.io/crates/faucet-sink-mssql) — the matching SQL Server sink.
+
+## Sharded execution (cluster Mode B)
+
+Under [`faucet serve --cluster`](https://pawansikawat.github.io/faucet-stream/cookbook/cluster.html),
+a top-level `shard: { count: N }` block splits this source into contiguous
+primary-key ranges that different cluster workers process concurrently. Opt in
+by naming an integer-typed key column:
+
+```yaml
+shard:
+  count: 8
+pipeline:
+  source:
+    type: mssql
+    config:
+      connection_url: ${env:MSSQL_URL}
+      query: "SELECT * FROM events"
+      shard: { key: id }   # integer column to range-partition on
+```
+
+The coordinator computes `MIN(key)` / `MAX(key)` once and splits that range
+into half-open slices (`[key]` in the generated predicate, injection-safe).
+The boundary shards stay open-ended so rows inserted outside the captured
+range during the run are still read, and exactly one shard additionally
+matches `key IS NULL` so nullable keys are never silently dropped. Each shard
+keeps its own state key (`{run}::{shard}`), so a reassigned shard resumes
+where its previous owner left off.
+
+Outside the cluster coordinator the `shard` config has **no effect** — a plain
+`faucet run` streams the whole query.
+
+> A sharded query must not end in a top-level `ORDER BY` — T-SQL forbids it
+> inside the derived table the shard predicate wraps (ordering across
+> concurrently-executing shards is meaningless anyway). With incremental
+> replication, shard bounds are computed over the not-yet-synced slice (the
+> `@bookmark` binding is honoured during enumeration).
 
 ## License
 

--- a/crates/source/mssql/src/config.rs
+++ b/crates/source/mssql/src/config.rs
@@ -70,6 +70,38 @@ pub struct MssqlSourceConfig {
     /// from the connection host and a query fingerprint.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub state_key: Option<String>,
+    /// Optional primary-key range sharding for clustered (Mode B) execution.
+    ///
+    /// When set, the source advertises itself as shardable: the cluster
+    /// coordinator splits the query's `key` range into contiguous slices that
+    /// different workers process concurrently. Has **no effect** outside the
+    /// cluster coordinator (a plain `faucet run` streams the whole query), so
+    /// it is fully backward compatible. See [`ShardConfig`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub shard: Option<ShardConfig>,
+}
+
+/// Primary-key range sharding settings for the MSSQL source.
+///
+/// The source is split by contiguous ranges of an **integer-typed** column:
+/// each shard runs `SELECT * FROM (<query>) WHERE [key] >= lo AND [key] < hi`.
+/// The column must be present in the query's output and orderable as a 64-bit
+/// integer (e.g. a `BIGINT`/`INT` `IDENTITY` primary key).
+///
+/// **`ORDER BY`:** T-SQL forbids `ORDER BY` inside a derived table (without
+/// `TOP`/`OFFSET`), so a sharded query must not end in a top-level `ORDER BY`
+/// — ordering across concurrently-executing shards is meaningless anyway.
+///
+/// **Nullable keys:** if the key column contains NULLs, those rows are not
+/// visible to the `MIN`/`MAX` range enumeration. They are still read — exactly
+/// one shard (the last) additionally matches `[key] IS NULL`, so NULL-key rows
+/// are covered by precisely one shard with no loss and no duplication.
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct ShardConfig {
+    /// Integer column to range-partition on. Quoted as an identifier (brackets)
+    /// before use, so it is safe against injection but must name a real output
+    /// column.
+    pub key: String,
 }
 
 impl std::fmt::Debug for MssqlSourceConfig {
@@ -102,6 +134,7 @@ impl MssqlSourceConfig {
             statement_timeout_secs: default_statement_timeout_secs(),
             replication: MssqlReplication::Full,
             state_key: None,
+            shard: None,
         }
     }
 

--- a/crates/source/mssql/src/lib.rs
+++ b/crates/source/mssql/src/lib.rs
@@ -29,7 +29,7 @@ mod config;
 mod convert;
 mod stream;
 
-pub use config::{MssqlReplication, MssqlSourceConfig};
+pub use config::{MssqlReplication, MssqlSourceConfig, ShardConfig};
 pub use stream::MssqlSource;
 
 // Re-export the shared connection/TLS types so users configure the source

--- a/crates/source/mssql/src/stream.rs
+++ b/crates/source/mssql/src/stream.rs
@@ -376,10 +376,10 @@ impl Source for MssqlSource {
     /// range into ~`target` slices. Returns a single whole-dataset shard when no
     /// `shard` config is set or the result set is empty.
     ///
-    /// The base query is resolved through [`build_query_and_params`] first so a
-    /// `@bookmark` token (incremental replication) is bound rather than left
-    /// dangling — bounds are then computed over the not-yet-synced slice, which
-    /// is exactly the data the shards will read.
+    /// The base query is resolved through the same query builder as a normal
+    /// fetch first, so a `@bookmark` token (incremental replication) is bound
+    /// rather than left dangling — bounds are then computed over the
+    /// not-yet-synced slice, which is exactly the data the shards will read.
     async fn enumerate_shards(&self, target: usize) -> Result<Vec<ShardSpec>, FaucetError> {
         let Some(shard_cfg) = &self.config.shard else {
             return Ok(vec![ShardSpec::whole()]);

--- a/crates/source/mssql/src/stream.rs
+++ b/crates/source/mssql/src/stream.rs
@@ -10,12 +10,15 @@ use std::time::Duration;
 use async_trait::async_trait;
 use faucet_core::check::{CheckContext, CheckReport, Probe};
 use faucet_core::replication::{filter_incremental, max_replication_value, max_value};
+use faucet_core::shard::{
+    PkShardBounds, ShardSpec, parse_pk_shard, pk_bounds_query, pk_shards_from_bounds,
+};
 use faucet_core::{FaucetError, Source, StreamPage};
 use futures::{Stream, TryStreamExt};
 use serde_json::Value;
 use tiberius::{QueryItem, ToSql};
 
-use faucet_common_mssql::{MssqlPool, build_pool, with_statement_timeout};
+use faucet_common_mssql::{MssqlPool, build_pool, quote_ident_mssql, with_statement_timeout};
 
 use crate::config::{MssqlReplication, MssqlSourceConfig};
 use crate::convert::row_to_json;
@@ -27,6 +30,10 @@ pub struct MssqlSource {
     /// Bookmark loaded via [`Source::apply_start_bookmark`]; overrides the
     /// configured `initial_value` for incremental runs.
     start_bookmark: Mutex<Option<Value>>,
+    /// Shard applied by the cluster coordinator (Mode B), if any. `None` (or the
+    /// whole-dataset shard) means the full query is streamed. Stored behind a
+    /// `Mutex` so `apply_shard(&self, …)` can record it before streaming.
+    applied_shard: Mutex<Option<PkShardBounds>>,
 }
 
 impl MssqlSource {
@@ -38,6 +45,7 @@ impl MssqlSource {
             config,
             pool,
             start_bookmark: Mutex::new(None),
+            applied_shard: Mutex::new(None),
         })
     }
 
@@ -54,6 +62,23 @@ impl MssqlSource {
             .expect("start_bookmark mutex poisoned")
             .clone()
     }
+
+    /// Apply the currently-set shard (if any) to a resolved query string. The
+    /// positional `@Pn` bind markers inside the wrapped subquery are unaffected
+    /// (they bind by name, not by position in the text).
+    fn shard_wrap(&self, query: String) -> String {
+        match &*self.applied_shard.lock().expect("shard mutex poisoned") {
+            Some(bounds) => bounds.wrap(&query, bracket_quote),
+            None => query,
+        }
+    }
+}
+
+/// Infallible bracket quoting for a shard key whose NUL-freeness was already
+/// validated (via [`quote_ident_mssql`]) when the shard was applied/enumerated.
+/// Interior `]` are doubled per T-SQL rules, preventing identifier injection.
+fn bracket_quote(name: &str) -> String {
+    format!("[{}]", name.replace(']', "]]"))
 }
 
 /// Incremental-replication context resolved for one run.
@@ -213,6 +238,7 @@ impl Source for MssqlSource {
         let cap = if batch_size == 0 { 1024 } else { batch_size };
         let start = self.current_start();
         let (query, values, incr) = build_query_and_params(&self.config, context, start.as_ref());
+        let query = self.shard_wrap(query);
 
         Box::pin(async_stream::try_stream! {
             let mut conn = self
@@ -339,6 +365,98 @@ impl Source for MssqlSource {
         };
         Ok(CheckReport::single(probe))
     }
+
+    /// Shardable when a [`ShardConfig`](crate::config::ShardConfig) is set.
+    fn is_shardable(&self) -> bool {
+        self.config.shard.is_some()
+    }
+
+    /// Enumerate contiguous primary-key range shards by computing the `key`
+    /// column's `MIN`/`MAX` over the (unsharded) base query and splitting that
+    /// range into ~`target` slices. Returns a single whole-dataset shard when no
+    /// `shard` config is set or the result set is empty.
+    ///
+    /// The base query is resolved through [`build_query_and_params`] first so a
+    /// `@bookmark` token (incremental replication) is bound rather than left
+    /// dangling — bounds are then computed over the not-yet-synced slice, which
+    /// is exactly the data the shards will read.
+    async fn enumerate_shards(&self, target: usize) -> Result<Vec<ShardSpec>, FaucetError> {
+        let Some(shard_cfg) = &self.config.shard else {
+            return Ok(vec![ShardSpec::whole()]);
+        };
+
+        let start = self.current_start();
+        let (inner, values, _incr) =
+            build_query_and_params(&self.config, &HashMap::new(), start.as_ref());
+        let key = quote_ident_mssql(&shard_cfg.key)?;
+        let bounds_sql = pk_bounds_query(&inner, &key, "BIGINT");
+
+        let mut conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| FaucetError::Source(format!("MSSQL pool checkout failed: {e}")))?;
+
+        let rows = {
+            let owned: Vec<OwnedParam> = values.iter().map(OwnedParam::from_value).collect();
+            let refs: Vec<&dyn ToSql> = owned.iter().map(OwnedParam::as_tosql).collect();
+            let run = async {
+                conn.query(&bounds_sql, &refs)
+                    .await
+                    .map_err(|e| {
+                        FaucetError::Source(format!(
+                            "mssql: failed to compute shard bounds for key {:?} \
+                             (it must be an integer-typed column, and the query must \
+                             not end in a top-level ORDER BY): {e}",
+                            shard_cfg.key
+                        ))
+                    })?
+                    .into_first_result()
+                    .await
+                    .map_err(|e| {
+                        FaucetError::Source(format!(
+                            "mssql: failed to compute shard bounds for key {:?} \
+                             (it must be an integer-typed column, and the query must \
+                             not end in a top-level ORDER BY): {e}",
+                            shard_cfg.key
+                        ))
+                    })
+            };
+            match self.timeout() {
+                Some(t) => {
+                    with_statement_timeout(t, run, || {
+                        FaucetError::Source("MSSQL shard-bounds query timed out".into())
+                    })
+                    .await?
+                }
+                None => run.await?,
+            }
+        };
+
+        let Some(row) = rows.first() else {
+            return Ok(vec![ShardSpec::whole()]);
+        };
+        let decoded = row_to_json(row)?;
+        Ok(pk_shards_from_bounds(
+            &shard_cfg.key,
+            decoded["lo"].as_i64(),
+            decoded["hi"].as_i64(),
+            target,
+        ))
+    }
+
+    /// Narrow this source to a single PK-range shard. The whole-dataset shard
+    /// clears any applied range (streams the full query).
+    async fn apply_shard(&self, shard: &ShardSpec) -> Result<(), FaucetError> {
+        let bounds = parse_pk_shard(shard, "mssql")?;
+        if let Some(b) = &bounds {
+            // Validate the key now (NUL check) so `bracket_quote` in the hot
+            // wrap path stays infallible.
+            quote_ident_mssql(&b.key)?;
+        }
+        *self.applied_shard.lock().expect("shard mutex poisoned") = bounds;
+        Ok(())
+    }
 }
 
 impl MssqlSource {
@@ -350,6 +468,7 @@ impl MssqlSource {
     ) -> Result<(Vec<Value>, Option<Value>), FaucetError> {
         let start = self.current_start();
         let (query, values, incr) = build_query_and_params(&self.config, context, start.as_ref());
+        let query = self.shard_wrap(query);
 
         let mut conn = self
             .pool
@@ -417,6 +536,7 @@ fn apply_incremental(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use faucet_core::shard::plan_pk_shards;
     use serde_json::json;
 
     fn full_cfg() -> MssqlSourceConfig {
@@ -592,5 +712,55 @@ mod tests {
             uri,
             "mssql://db.example.com:1433/sales?query=SELECT * FROM t"
         );
+    }
+
+    // ── PK-range sharding (Mode B, #262) ─────────────────────────────────────
+
+    #[test]
+    fn shard_wrap_uses_bracket_quoting() {
+        let spec = faucet_core::ShardSpec::new(
+            "1",
+            json!({"key": "id", "lo": 100, "hi": 200, "lo_unbounded": false, "hi_unbounded": false}),
+        );
+        let bounds = PkShardBounds::from_spec(&spec).unwrap();
+        let sql = bounds.wrap("SELECT * FROM t", bracket_quote);
+        assert!(sql.contains("(SELECT * FROM t) AS _faucet_shard"), "{sql}");
+        assert!(sql.contains("[id] >= 100"), "bracket-quoted key: {sql}");
+        assert!(sql.contains("[id] < 200"), "half-open upper bound: {sql}");
+    }
+
+    #[test]
+    fn last_shard_wrap_covers_null_keys() {
+        let shards = plan_pk_shards("id", 0, 99, 3);
+        let last = PkShardBounds::from_spec(shards.last().unwrap()).unwrap();
+        let sql = last.wrap("SELECT * FROM t", bracket_quote);
+        assert!(
+            sql.contains("[id] IS NULL"),
+            "last shard must match NULL keys: {sql}"
+        );
+    }
+
+    #[test]
+    fn shard_wrap_preserves_positional_bind_markers() {
+        // The @Pn markers of a resolved incremental query survive the wrap —
+        // tiberius binds them by name, not by textual position.
+        let cfg = MssqlSourceConfig {
+            query: "SELECT * FROM t WHERE c > @bookmark".into(),
+            replication: MssqlReplication::Incremental {
+                column: "c".into(),
+                initial_value: json!(0),
+            },
+            ..full_cfg()
+        };
+        let (q, v, _incr) = build_query_and_params(&cfg, &HashMap::new(), None);
+        let spec = faucet_core::ShardSpec::new(
+            "0",
+            json!({"key": "id", "lo": 0, "hi": 10, "lo_unbounded": false, "hi_unbounded": false}),
+        );
+        let wrapped = PkShardBounds::from_spec(&spec)
+            .unwrap()
+            .wrap(&q, bracket_quote);
+        assert!(wrapped.contains("@P1"), "bind marker survives: {wrapped}");
+        assert_eq!(v.len(), 1, "one bound value for the bookmark");
     }
 }

--- a/crates/source/mssql/tests/integration.rs
+++ b/crates/source/mssql/tests/integration.rs
@@ -193,3 +193,92 @@ async fn incremental_resumes_without_duplicates() {
     assert_eq!(ids2, vec![4], "run 2 resumes from bookmark, no duplicates");
     assert_eq!(bookmark2, Some(Value::from("2024-04-01")));
 }
+
+// ── PK-range sharding (Mode B, #262) ────────────────────────────────────────
+
+/// The core Mode B correctness guarantee: enumerating a source into N shards and
+/// reading each shard yields every row exactly once — no duplication, no loss.
+/// Includes a NULL-key row, which MIN/MAX enumeration cannot see but exactly one
+/// shard must still read (F37).
+#[tokio::test(flavor = "multi_thread")]
+async fn shards_partition_rows_disjointly_and_completely() {
+    use faucet_source_mssql::ShardConfig;
+
+    let _serial = SERIAL.lock().await;
+    let (_c, port) = start_mssql().await;
+    let cfg = conn_cfg(port);
+    let pool = build_pool(&cfg, 4).await.expect("pool");
+
+    exec(
+        &pool,
+        "CREATE TABLE dbo.items (k BIGINT, label NVARCHAR(20))",
+    )
+    .await;
+    // Multi-row VALUES keeps the seeding to a handful of round trips.
+    for chunk in (1..=200i64).collect::<Vec<_>>().chunks(50) {
+        let values: Vec<String> = chunk.iter().map(|i| format!("({i}, N'row-{i}')")).collect();
+        exec(
+            &pool,
+            &format!(
+                "INSERT INTO dbo.items (k, label) VALUES {}",
+                values.join(", ")
+            ),
+        )
+        .await;
+    }
+    exec(
+        &pool,
+        "INSERT INTO dbo.items (k, label) VALUES (NULL, N'null-row')",
+    )
+    .await;
+
+    let mut scfg = MssqlSourceConfig::new(
+        cfg.connection_url.clone().unwrap(),
+        "SELECT k, label FROM dbo.items",
+    );
+    scfg.connection.tls = cfg.tls.clone();
+    scfg.shard = Some(ShardConfig { key: "k".into() });
+
+    let source = MssqlSource::new(scfg).await.expect("source");
+    assert!(source.is_shardable());
+    let shards = source.enumerate_shards(4).await.expect("enumerate");
+    assert!(
+        (2..=4).contains(&shards.len()),
+        "expected 2..=4 shards, got {}",
+        shards.len()
+    );
+
+    // Each shard is applied on the same source sequentially (apply_shard
+    // replaces the previous narrowing), mirroring what a claiming worker does.
+    let mut labels: Vec<String> = Vec::new();
+    for shard in &shards {
+        source.apply_shard(shard).await.expect("apply_shard");
+        for rec in source.fetch_all().await.expect("fetch shard") {
+            labels.push(rec["label"].as_str().unwrap().to_string());
+        }
+    }
+
+    labels.sort();
+    let mut expected: Vec<String> = (1..=200i64).map(|i| format!("row-{i}")).collect();
+    expected.push("null-row".to_string());
+    expected.sort();
+    assert_eq!(
+        labels, expected,
+        "shards must union to all rows exactly once (no dup, no loss)"
+    );
+
+    // Error paths: a bad key errors at enumeration; a malformed descriptor is
+    // rejected by apply_shard. Reuses the running container to keep CI time down.
+    let mut bad_cfg = MssqlSourceConfig::new(
+        cfg.connection_url.clone().unwrap(),
+        "SELECT k FROM dbo.items",
+    );
+    bad_cfg.connection.tls = cfg.tls.clone();
+    bad_cfg.shard = Some(ShardConfig {
+        key: "no_such_column".into(),
+    });
+    let bad = MssqlSource::new(bad_cfg).await.expect("source");
+    assert!(bad.enumerate_shards(4).await.is_err());
+    let malformed = faucet_core::ShardSpec::new("0", serde_json::json!({ "key": "k" }));
+    assert!(bad.apply_shard(&malformed).await.is_err());
+}

--- a/crates/source/mysql/README.md
+++ b/crates/source/mysql/README.md
@@ -69,6 +69,7 @@ faucet run pipeline.yaml
 | `query` | string | — *(required)* | The SQL query to execute. May contain `${parent.field}` tokens that are bound as parameters in a matrix run (see [Per-record queries](#per-record-queries-matrix-pipelines)). |
 | `max_connections` | int | `10` | Maximum connections in the sqlx pool. |
 | `batch_size` | int | `1000` | Rows per emitted `StreamPage`. **`0` = no batching** (drain the whole result set into one page). Values above `MAX_BATCH_SIZE` (1,000,000) are rejected at construction by `faucet_core::validate_batch_size`. |
+| `shard` | object | *(unset)* | Optional [Mode B sharding](#sharded-execution-cluster-mode-b): `{ key: <integer column> }`. Opts the source into primary-key range splitting under `faucet serve --cluster`; no effect on a plain `faucet run`. |
 
 There is no separate `auth` block — credentials live in `connection_url` (and can be sourced from env or a secrets manager; see [Config loading](#config-loading)).
 
@@ -333,6 +334,36 @@ This crate has no optional Cargo features of its own. Enable it in the CLI / umb
 
 - [Connector reference](https://pawansikawat.github.io/faucet-stream/reference/connectors.html) · [Config grammar](https://pawansikawat.github.io/faucet-stream/reference/config.html) · [CLI reference](https://pawansikawat.github.io/faucet-stream/reference/cli.html)
 - Related crates: [faucet-source-mysql-cdc](https://crates.io/crates/faucet-source-mysql-cdc) · [faucet-sink-mysql](https://crates.io/crates/faucet-sink-mysql) · [faucet-source-postgres](https://crates.io/crates/faucet-source-postgres)
+
+## Sharded execution (cluster Mode B)
+
+Under [`faucet serve --cluster`](https://pawansikawat.github.io/faucet-stream/cookbook/cluster.html),
+a top-level `shard: { count: N }` block splits this source into contiguous
+primary-key ranges that different cluster workers process concurrently. Opt in
+by naming an integer-typed key column:
+
+```yaml
+shard:
+  count: 8
+pipeline:
+  source:
+    type: mysql
+    config:
+      connection_url: ${env:MYSQL_URL}
+      query: "SELECT * FROM events"
+      shard: { key: id }   # integer column to range-partition on
+```
+
+The coordinator computes `MIN(key)` / `MAX(key)` once and splits that range
+into half-open slices (`` `key` `` in the generated predicate, injection-safe).
+The boundary shards stay open-ended so rows inserted outside the captured
+range during the run are still read, and exactly one shard additionally
+matches `key IS NULL` so nullable keys are never silently dropped. Each shard
+keeps its own state key (`{run}::{shard}`), so a reassigned shard resumes
+where its previous owner left off.
+
+Outside the cluster coordinator the `shard` config has **no effect** — a plain
+`faucet run` streams the whole query.
 
 ## License
 

--- a/crates/source/mysql/src/config.rs
+++ b/crates/source/mysql/src/config.rs
@@ -24,6 +24,35 @@ pub struct MysqlSourceConfig {
     /// jobs) that prefer one large request to many small ones.
     #[serde(default = "default_batch_size")]
     pub batch_size: usize,
+
+    /// Optional primary-key range sharding for clustered (Mode B) execution.
+    ///
+    /// When set, the source advertises itself as shardable: the cluster
+    /// coordinator splits the query's `key` range into contiguous slices that
+    /// different workers process concurrently. Has **no effect** outside the
+    /// cluster coordinator (a plain `faucet run` streams the whole query), so
+    /// it is fully backward compatible. See [`ShardConfig`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub shard: Option<ShardConfig>,
+}
+
+/// Primary-key range sharding settings for the MySQL source.
+///
+/// The source is split by contiguous ranges of an **integer-typed** column:
+/// each shard runs ``SELECT * FROM (<query>) WHERE `key` >= lo AND `key` < hi``.
+/// The column must be present in the query's output and orderable as a 64-bit
+/// integer (e.g. a `BIGINT`/`INT` auto-increment primary key).
+///
+/// **Nullable keys:** if the key column contains NULLs, those rows are not
+/// visible to the `MIN`/`MAX` range enumeration. They are still read — exactly
+/// one shard (the last) additionally matches ``` `key` IS NULL ```, so NULL-key
+/// rows are covered by precisely one shard with no loss and no duplication.
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct ShardConfig {
+    /// Integer column to range-partition on. Quoted as an identifier (backticks)
+    /// before use, so it is safe against injection but must name a real output
+    /// column.
+    pub key: String,
 }
 
 fn default_max_connections() -> u32 {
@@ -53,6 +82,7 @@ impl MysqlSourceConfig {
             query: query.into(),
             max_connections: 10,
             batch_size: DEFAULT_BATCH_SIZE,
+            shard: None,
         }
     }
 

--- a/crates/source/mysql/src/lib.rs
+++ b/crates/source/mysql/src/lib.rs
@@ -12,5 +12,5 @@ pub mod stream;
 
 pub use faucet_core::{FaucetError, Source};
 
-pub use config::MysqlSourceConfig;
+pub use config::{MysqlSourceConfig, ShardConfig};
 pub use stream::MysqlSource;

--- a/crates/source/mysql/src/stream.rs
+++ b/crates/source/mysql/src/stream.rs
@@ -2,17 +2,32 @@
 
 use crate::config::MysqlSourceConfig;
 use async_trait::async_trait;
+use faucet_core::shard::{
+    PkShardBounds, ShardSpec, parse_pk_shard, pk_bounds_query, pk_shards_from_bounds,
+};
 use faucet_core::{FaucetError, Stream, StreamPage};
 use futures::TryStreamExt;
 use serde_json::Value;
 use sqlx::mysql::MySqlPoolOptions;
 use sqlx::{Column, MySqlPool, Row};
 use std::pin::Pin;
+use std::sync::Mutex;
 
 /// A source that executes a SQL query against MySQL and returns rows as JSON.
 pub struct MysqlSource {
     config: MysqlSourceConfig,
     pool: MySqlPool,
+    /// Shard applied by the cluster coordinator (Mode B), if any. `None` (or the
+    /// whole-dataset shard) means the full query is streamed. Stored behind a
+    /// `Mutex` so `apply_shard(&self, …)` can record it before streaming.
+    applied_shard: Mutex<Option<PkShardBounds>>,
+}
+
+/// Quote a MySQL identifier with backticks (MySQL's default identifier
+/// quoting — double quotes require the non-default `ANSI_QUOTES` sql_mode).
+/// Embedded backticks are doubled, preventing identifier injection.
+fn quote_ident_mysql(name: &str) -> String {
+    format!("`{}`", name.replace('`', "``"))
 }
 
 impl MysqlSource {
@@ -26,7 +41,19 @@ impl MysqlSource {
             .await
             .map_err(|e| FaucetError::Config(format!("MySQL connection failed: {e}")))?;
 
-        Ok(Self { config, pool })
+        Ok(Self {
+            config,
+            pool,
+            applied_shard: Mutex::new(None),
+        })
+    }
+
+    /// Apply the currently-set shard (if any) to a resolved query string.
+    fn shard_wrap(&self, query: String) -> String {
+        match &*self.applied_shard.lock().expect("shard mutex poisoned") {
+            Some(bounds) => bounds.wrap(&query, quote_ident_mysql),
+            None => query,
+        }
     }
 }
 
@@ -209,6 +236,7 @@ impl faucet_core::Source for MysqlSource {
         context: &std::collections::HashMap<String, serde_json::Value>,
     ) -> Result<Vec<Value>, FaucetError> {
         let (query_str, bind_values) = resolve_query(&self.config, context);
+        let query_str = self.shard_wrap(query_str);
         let query = bind_params(sqlx::query(&query_str), &bind_values);
 
         let rows = query
@@ -242,6 +270,7 @@ impl faucet_core::Source for MysqlSource {
 
         Box::pin(async_stream::try_stream! {
             let (query_str, bind_values) = resolve_query(&self.config, context);
+            let query_str = self.shard_wrap(query_str);
             let query = bind_params(sqlx::query(&query_str), &bind_values);
 
             let mut rows = query.fetch(&self.pool);
@@ -288,11 +317,58 @@ impl faucet_core::Source for MysqlSource {
             self.config.query
         )
     }
+
+    /// Shardable when a [`ShardConfig`](crate::config::ShardConfig) is set.
+    fn is_shardable(&self) -> bool {
+        self.config.shard.is_some()
+    }
+
+    /// Enumerate contiguous primary-key range shards by computing the `key`
+    /// column's `MIN`/`MAX` over the (unsharded) base query and splitting that
+    /// range into ~`target` slices. Returns a single whole-dataset shard when no
+    /// `shard` config is set or the result set is empty.
+    async fn enumerate_shards(&self, target: usize) -> Result<Vec<ShardSpec>, FaucetError> {
+        let Some(shard_cfg) = &self.config.shard else {
+            return Ok(vec![ShardSpec::whole()]);
+        };
+
+        let bounds_sql = pk_bounds_query(
+            &self.config.query,
+            &quote_ident_mysql(&shard_cfg.key),
+            "SIGNED",
+        );
+        let row = sqlx::query(&bounds_sql)
+            .fetch_one(&self.pool)
+            .await
+            .map_err(|e| {
+                FaucetError::Source(format!(
+                    "mysql: failed to compute shard bounds for key {:?} \
+                     (it must be an integer-typed column): {e}",
+                    shard_cfg.key
+                ))
+            })?;
+
+        let lo: Option<i64> = row
+            .try_get("lo")
+            .map_err(|e| FaucetError::Source(format!("mysql: shard bounds decode failed: {e}")))?;
+        let hi: Option<i64> = row
+            .try_get("hi")
+            .map_err(|e| FaucetError::Source(format!("mysql: shard bounds decode failed: {e}")))?;
+        Ok(pk_shards_from_bounds(&shard_cfg.key, lo, hi, target))
+    }
+
+    /// Narrow this source to a single PK-range shard. The whole-dataset shard
+    /// clears any applied range (streams the full query).
+    async fn apply_shard(&self, shard: &ShardSpec) -> Result<(), FaucetError> {
+        *self.applied_shard.lock().expect("shard mutex poisoned") = parse_pk_shard(shard, "mysql")?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use faucet_core::shard::plan_pk_shards;
 
     #[tokio::test]
     async fn new_rejects_out_of_range_batch_size() {
@@ -372,6 +448,108 @@ mod tests {
         assert_eq!(
             classify_number(&num(serde_json::json!(3.5))),
             NumberBind::F64
+        );
+    }
+
+    // ── PK-range sharding (Mode B, #262) ─────────────────────────────────────
+
+    #[test]
+    fn quote_ident_mysql_backticks_and_escapes() {
+        assert_eq!(quote_ident_mysql("id"), "`id`");
+        // Embedded backticks are doubled — identifier injection is inert.
+        assert_eq!(quote_ident_mysql("we`ird"), "`we``ird`");
+    }
+
+    #[test]
+    fn shard_wrap_uses_backtick_quoting() {
+        let spec = faucet_core::shard::ShardSpec::new(
+            "1",
+            serde_json::json!({"key": "id", "lo": 100, "hi": 200, "lo_unbounded": false, "hi_unbounded": false}),
+        );
+        let bounds = PkShardBounds::from_spec(&spec).unwrap();
+        let sql = bounds.wrap("SELECT * FROM t", quote_ident_mysql);
+        assert!(sql.contains("(SELECT * FROM t) AS _faucet_shard"), "{sql}");
+        assert!(sql.contains("`id` >= 100"), "backtick-quoted key: {sql}");
+        assert!(sql.contains("`id` < 200"), "half-open upper bound: {sql}");
+    }
+
+    #[test]
+    fn last_shard_wrap_covers_null_keys() {
+        let shards = plan_pk_shards("id", 0, 99, 3);
+        let last = PkShardBounds::from_spec(shards.last().unwrap()).unwrap();
+        let sql = last.wrap("SELECT * FROM t", quote_ident_mysql);
+        assert!(
+            sql.contains("`id` IS NULL"),
+            "last shard must match NULL keys: {sql}"
+        );
+    }
+
+    /// Build a source over a lazy pool (no server needed) so the shard glue —
+    /// `apply_shard`, `shard_wrap`, and `enumerate_shards`' non-I/O branches —
+    /// is testable without Docker.
+    fn lazy_source(config: MysqlSourceConfig) -> MysqlSource {
+        let pool = MySqlPoolOptions::new()
+            // Fail fast at first checkout — these tests never reach a server.
+            .acquire_timeout(std::time::Duration::from_millis(200))
+            .connect_lazy(&config.connection_url)
+            .expect("lazy pool");
+        MysqlSource {
+            config,
+            pool,
+            applied_shard: Mutex::new(None),
+        }
+    }
+
+    #[tokio::test]
+    async fn apply_shard_then_shard_wrap_narrows_query() {
+        use faucet_core::Source as _;
+        let mut config = MysqlSourceConfig::new("mysql://root@127.0.0.1:1/db", "SELECT * FROM t");
+        config.shard = Some(crate::config::ShardConfig { key: "id".into() });
+        let source = lazy_source(config);
+        assert!(source.is_shardable());
+
+        // No shard applied / whole shard applied → query passes through.
+        assert_eq!(source.shard_wrap("SELECT 1".into()), "SELECT 1");
+        source
+            .apply_shard(&faucet_core::ShardSpec::whole())
+            .await
+            .unwrap();
+        assert_eq!(source.shard_wrap("SELECT 1".into()), "SELECT 1");
+
+        // A real shard narrows with backtick quoting.
+        let spec = &plan_pk_shards("id", 0, 99, 2)[0];
+        source.apply_shard(spec).await.unwrap();
+        let wrapped = source.shard_wrap("SELECT * FROM t".into());
+        assert!(wrapped.contains("`id`"), "got: {wrapped}");
+        assert!(wrapped.contains("_faucet_shard"), "got: {wrapped}");
+
+        // Malformed descriptor is rejected.
+        let bad = faucet_core::ShardSpec::new("0", serde_json::json!({ "key": "id" }));
+        assert!(source.apply_shard(&bad).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn enumerate_shards_without_config_is_whole_and_with_config_needs_db() {
+        use faucet_core::Source as _;
+        // No `shard` config → single whole shard, no I/O.
+        let plain = lazy_source(MysqlSourceConfig::new(
+            "mysql://root@127.0.0.1:1/db",
+            "SELECT 1",
+        ));
+        assert!(!plain.is_shardable());
+        let shards = plain.enumerate_shards(4).await.unwrap();
+        assert_eq!(shards.len(), 1);
+        assert!(shards[0].is_whole());
+
+        // With config, enumeration must reach the (unreachable) server → the
+        // bounds-probe error path surfaces as FaucetError::Source.
+        let mut config = MysqlSourceConfig::new("mysql://root@127.0.0.1:1/db", "SELECT 1");
+        config.shard = Some(crate::config::ShardConfig { key: "id".into() });
+        let sharded = lazy_source(config);
+        let err = sharded.enumerate_shards(4).await.unwrap_err();
+        assert!(
+            err.to_string().contains("shard bounds"),
+            "expected bounds-probe error, got: {err}"
         );
     }
 }

--- a/crates/source/mysql/tests/streaming.rs
+++ b/crates/source/mysql/tests/streaming.rs
@@ -444,3 +444,93 @@ async fn context_tokens_bind_as_typed_params() {
     assert_eq!(page.records.len(), 1, "only account id=1 is active");
     assert_eq!(page.records[0]["name"], "alice");
 }
+
+// ── PK-range sharding (Mode B, #262) ────────────────────────────────────────
+
+/// The core Mode B correctness guarantee: enumerating a source into N shards and
+/// reading each shard yields every row exactly once — no duplication, no loss.
+#[tokio::test(flavor = "multi_thread")]
+async fn shards_partition_rows_disjointly_and_completely() {
+    use faucet_source_mysql::ShardConfig;
+
+    let (_container, url) = start_mysql().await;
+    seed_events(&url, 1000).await; // ids 1..=1000
+
+    let mut config = MysqlSourceConfig::new(&url, "SELECT id FROM events");
+    config.shard = Some(ShardConfig { key: "id".into() });
+
+    // A coordinator enumerates the shard set.
+    let coordinator = MysqlSource::new(config.clone())
+        .await
+        .expect("coordinator source");
+    assert!(coordinator.is_shardable());
+    let shards = coordinator.enumerate_shards(4).await.expect("enumerate");
+    assert!(
+        (2..=4).contains(&shards.len()),
+        "expected 2..=4 shards, got {}",
+        shards.len()
+    );
+
+    // Each shard runs on a fresh source narrowed via apply_shard.
+    let mut all_ids: Vec<i64> = Vec::new();
+    for shard in &shards {
+        let s = MysqlSource::new(config.clone())
+            .await
+            .expect("shard source");
+        s.apply_shard(shard).await.expect("apply_shard");
+        let ctx: HashMap<String, serde_json::Value> = HashMap::new();
+        let mut pages = s.stream_pages(&ctx, 0);
+        while let Some(page) = pages.next().await {
+            for rec in page.expect("page ok").records {
+                all_ids.push(rec["id"].as_i64().expect("id is int"));
+            }
+        }
+    }
+
+    all_ids.sort();
+    let expected: Vec<i64> = (1..=1000).collect();
+    assert_eq!(
+        all_ids, expected,
+        "shards must union to all rows exactly once (no dup, no loss)"
+    );
+}
+
+/// `enumerate_shards` surfaces an error when the shard key can't be computed
+/// (here: a non-existent column), and `apply_shard` rejects a malformed shard
+/// descriptor — the error paths a coordinator must handle.
+#[tokio::test(flavor = "multi_thread")]
+async fn shard_error_paths() {
+    use faucet_core::ShardSpec;
+    use faucet_source_mysql::ShardConfig;
+
+    let (_container, url) = start_mysql().await;
+    seed_events(&url, 5).await;
+
+    let mut config = MysqlSourceConfig::new(&url, "SELECT id FROM events");
+    config.shard = Some(ShardConfig {
+        key: "no_such_column".into(),
+    });
+    let source = MysqlSource::new(config).await.expect("source");
+    // MIN/MAX over a non-existent column → SQL error → enumerate_shards errors.
+    assert!(source.enumerate_shards(4).await.is_err());
+
+    // A descriptor missing lo/hi is rejected by apply_shard.
+    let bad = ShardSpec::new("0", serde_json::json!({ "key": "id" }));
+    assert!(source.apply_shard(&bad).await.is_err());
+}
+
+/// A config without a `shard` block is not shardable: it enumerates to a single
+/// whole-dataset shard, preserving single-worker behavior.
+#[tokio::test(flavor = "multi_thread")]
+async fn unsharded_config_enumerates_one_whole_shard() {
+    let (_container, url) = start_mysql().await;
+    seed_events(&url, 10).await;
+
+    let source = MysqlSource::new(MysqlSourceConfig::new(&url, "SELECT id FROM events"))
+        .await
+        .expect("source");
+    assert!(!source.is_shardable());
+    let shards = source.enumerate_shards(4).await.expect("enumerate");
+    assert_eq!(shards.len(), 1);
+    assert!(shards[0].is_whole());
+}

--- a/crates/source/parquet/README.md
+++ b/crates/source/parquet/README.md
@@ -192,6 +192,20 @@ No optional features of its own; enable it in the CLI/umbrella via the `source-p
 
 - [Connector reference](https://pawansikawat.github.io/faucet-stream/reference/connectors.html) · [faucet-sink-parquet](https://crates.io/crates/faucet-sink-parquet) · [faucet-source-s3](https://crates.io/crates/faucet-source-s3)
 
+## Sharded execution (cluster Mode B)
+
+Under [`faucet serve --cluster`](https://pawansikawat.github.io/faucet-stream/cookbook/cluster.html),
+a top-level `shard: { count: N }` block splits this source across cluster
+workers **automatically — no connector config needed**. Each worker reads the
+files whose path hashes to its shard index (stable FNV-1a modulo `count`),
+so the partition is disjoint and complete: every file is read by exactly one
+worker, and the partition stays stable as new files appear. Outside the
+cluster coordinator a run reads every file, unchanged.
+
+> Cross-file schema validation still covers the **full** resolved file set on
+> every worker, so a schema mismatch fails the run even when the mismatching
+> files hash into different shards.
+
 ## License
 
 Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/source/parquet/src/stream.rs
+++ b/crates/source/parquet/src/stream.rs
@@ -7,9 +7,10 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::pin::Pin;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
+use faucet_core::shard::{HashShard, ShardSpec, parse_hash_shard, plan_hash_shards};
 use faucet_core::{FaucetError, Stream, StreamPage};
 use futures::{StreamExt, TryStreamExt, stream};
 use object_store::ObjectStore;
@@ -28,6 +29,10 @@ pub struct ParquetSource {
     /// Eagerly-constructed object store used for S3 sources. `None` for
     /// local file / glob sources.
     s3_store: Option<Arc<dyn ObjectStore>>,
+    /// Shard applied by the cluster coordinator (Mode B). `None` (or a
+    /// degenerate single-shard set) reads every resolved file. Stored behind a
+    /// `Mutex` so `apply_shard(&self, …)` can record it before streaming.
+    applied_shard: Mutex<Option<HashShard>>,
 }
 
 impl ParquetSource {
@@ -51,14 +56,18 @@ impl ParquetSource {
             _ => None,
         };
 
-        Ok(Self { config, s3_store })
+        Ok(Self {
+            config,
+            s3_store,
+            applied_shard: Mutex::new(None),
+        })
     }
 
-    /// Resolve the configured `source` into the concrete list of files to read.
+    /// Resolve the configured `source` into the full (unsharded) list of files.
     ///
     /// For S3 prefix mode this issues a list-objects call. For glob mode this
     /// expands the pattern. The result is sorted for deterministic ordering.
-    async fn resolve_files(
+    async fn resolve_all_files(
         &self,
         context: &HashMap<String, Value>,
     ) -> Result<Vec<FileTarget>, FaucetError> {
@@ -72,6 +81,29 @@ impl ParquetSource {
                 expand_glob(&resolved)
             }
             ParquetLocation::S3(s3) => self.resolve_s3_files(s3, context).await,
+        }
+    }
+
+    /// Resolve the configured `source` into the concrete list of files to read,
+    /// narrowed to the applied shard (if any).
+    async fn resolve_files(
+        &self,
+        context: &HashMap<String, Value>,
+    ) -> Result<Vec<FileTarget>, FaucetError> {
+        Ok(self.shard_filter(self.resolve_all_files(context).await?))
+    }
+
+    /// Retain only the files belonging to the applied shard (hash of the
+    /// file's display path modulo `shards`). A no-op when no shard is applied.
+    /// Every worker resolves the same sorted file list and hashes the same
+    /// deterministic path strings, so the partition is disjoint and complete.
+    fn shard_filter(&self, targets: Vec<FileTarget>) -> Vec<FileTarget> {
+        match *self.applied_shard.lock().expect("shard mutex poisoned") {
+            Some(member) => targets
+                .into_iter()
+                .filter(|t| member.contains(&t.display()))
+                .collect(),
+            None => targets,
         }
     }
 
@@ -311,10 +343,21 @@ impl faucet_core::Source for ParquetSource {
         _batch_size: usize,
     ) -> Pin<Box<dyn Stream<Item = Result<StreamPage, FaucetError>> + Send + 'a>> {
         Box::pin(async_stream::try_stream! {
-            let targets = self.resolve_files(context).await?;
-            tracing::info!(files = targets.len(), "Parquet source resolved files");
+            // Resolve the FULL file set first: schema validation must cover
+            // every file even under Mode B sharding, then only this shard's
+            // subset is streamed. Validating just the shard's files would let
+            // a cross-shard schema mismatch slip through (each worker would
+            // see an internally-consistent subset) and silently mix shapes
+            // downstream — the exact failure the unsharded path rejects.
+            let all_targets = self.resolve_all_files(context).await?;
+            let targets = self.shard_filter(all_targets.clone());
+            tracing::info!(
+                files = targets.len(),
+                resolved = all_targets.len(),
+                "Parquet source resolved files",
+            );
 
-            if targets.is_empty() {
+            if all_targets.is_empty() {
                 return;
             }
 
@@ -327,7 +370,7 @@ impl faucet_core::Source for ParquetSource {
             // probe stream immediately. The cost is one extra footer read per
             // file, paid once before streaming begins.
             let mut reference: Option<(String, arrow::datatypes::SchemaRef)> = None;
-            for target in &targets {
+            for target in &all_targets {
                 let (_, arrow_schema, display) = self.open_target_stream(target).await?;
                 if let Some((first_path, first_schema)) = &reference {
                     if first_schema != &arrow_schema {
@@ -389,6 +432,31 @@ impl faucet_core::Source for ParquetSource {
                 _ => format!("s3://{}", s3.bucket),
             },
         }
+    }
+
+    /// The Parquet source is always shardable: any resolved file set (glob or
+    /// S3 prefix) can be split by hash-of-path. Sharding only takes effect when
+    /// the cluster coordinator calls `apply_shard`; a plain `faucet run` reads
+    /// every file. A single-file source still enumerates — the extra shards
+    /// simply resolve to zero files.
+    fn is_shardable(&self) -> bool {
+        true
+    }
+
+    /// Enumerate `target` hash-modulo shards. Each shard `i` will read the
+    /// files whose path hashes to `i (mod target)`. No I/O: the partition is
+    /// defined by the hash function, so enumeration is cheap and stable as new
+    /// files appear. `target <= 1` yields a single whole-dataset shard.
+    async fn enumerate_shards(&self, target: usize) -> Result<Vec<ShardSpec>, FaucetError> {
+        Ok(plan_hash_shards(target))
+    }
+
+    /// Narrow this source to one hash-modulo shard. The whole-dataset shard
+    /// clears any filter (reads every file).
+    async fn apply_shard(&self, shard: &ShardSpec) -> Result<(), FaucetError> {
+        *self.applied_shard.lock().expect("shard mutex poisoned") =
+            parse_hash_shard(shard, "parquet")?;
+        Ok(())
     }
 }
 
@@ -671,5 +739,90 @@ mod tests {
         let cfg = ParquetSourceConfig::s3(s3);
         let source = ParquetSource::new(cfg).await.unwrap();
         assert_eq!(source.dataset_uri(), "s3://my-bucket/path/to/file.parquet");
+    }
+
+    // ── Hash-modulo file sharding (Mode B, #262) ─────────────────────────────
+
+    /// Create `n` empty `part-XX.parquet` files in a temp dir and return the
+    /// dir. `resolve_files` only globs (no footer read), so empty files are
+    /// enough to exercise the shard partition logic.
+    fn glob_fixture(n: usize) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        for i in 0..n {
+            std::fs::write(dir.path().join(format!("part-{i:02}.parquet")), b"").expect("touch");
+        }
+        dir
+    }
+
+    /// The union of every shard's resolved file set equals the full set, with
+    /// no file in two shards — the core no-dup / no-loss guarantee.
+    #[tokio::test]
+    async fn shards_partition_resolved_files_disjointly_and_completely() {
+        let dir = glob_fixture(12);
+        let pattern = format!("{}/*.parquet", dir.path().display());
+        let source = ParquetSource::new(ParquetSourceConfig::glob(&pattern))
+            .await
+            .unwrap();
+
+        assert!(source.is_shardable());
+        let shards = source.enumerate_shards(3).await.unwrap();
+        assert_eq!(shards.len(), 3);
+
+        let ctx = HashMap::new();
+        let all: Vec<String> = source
+            .resolve_files(&ctx)
+            .await
+            .unwrap()
+            .iter()
+            .map(FileTarget::display)
+            .collect();
+        assert_eq!(all.len(), 12);
+
+        let mut union: Vec<String> = Vec::new();
+        for shard in &shards {
+            source.apply_shard(shard).await.unwrap();
+            union.extend(
+                source
+                    .resolve_files(&ctx)
+                    .await
+                    .unwrap()
+                    .iter()
+                    .map(FileTarget::display),
+            );
+        }
+        union.sort();
+        let mut expected = all.clone();
+        expected.sort();
+        assert_eq!(
+            union, expected,
+            "shards must union to the full file set, disjointly"
+        );
+    }
+
+    #[tokio::test]
+    async fn whole_shard_and_target_one_read_everything() {
+        let dir = glob_fixture(4);
+        let pattern = format!("{}/*.parquet", dir.path().display());
+        let source = ParquetSource::new(ParquetSourceConfig::glob(&pattern))
+            .await
+            .unwrap();
+
+        // target <= 1 enumerates to the single whole-dataset shard.
+        let shards = source.enumerate_shards(1).await.unwrap();
+        assert_eq!(shards.len(), 1);
+        assert!(shards[0].is_whole());
+
+        let ctx = HashMap::new();
+        source.apply_shard(&shards[0]).await.unwrap();
+        assert_eq!(source.resolve_files(&ctx).await.unwrap().len(), 4);
+    }
+
+    #[tokio::test]
+    async fn apply_shard_rejects_malformed_descriptor() {
+        let source = ParquetSource::new(ParquetSourceConfig::local("/tmp/x.parquet"))
+            .await
+            .unwrap();
+        let bad = faucet_core::ShardSpec::new("0", serde_json::json!({ "index": 0 }));
+        assert!(source.apply_shard(&bad).await.is_err());
     }
 }

--- a/crates/source/parquet/tests/streaming.rs
+++ b/crates/source/parquet/tests/streaming.rs
@@ -441,3 +441,93 @@ async fn stream_pages_first_page_arrives_before_full_drain() {
         full_elapsed
     );
 }
+
+// ── Hash-modulo file sharding (Mode B, #262) ────────────────────────────────
+
+/// End-to-end Mode B guarantee on real files: splitting a multi-file glob into
+/// N shards and streaming each shard yields every row exactly once.
+#[tokio::test]
+async fn shards_stream_all_rows_exactly_once() {
+    let dir = TempDir::new().expect("tempdir");
+    let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
+    // 6 files × 10 rows, globally-unique ids 0..60.
+    for f in 0..6i64 {
+        let ids: Vec<i64> = (f * 10..(f + 1) * 10).collect();
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(Int64Array::from(ids))])
+            .expect("batch");
+        write_single_row_group(&dir.path().join(format!("part-{f}.parquet")), &batch);
+    }
+
+    let pattern = format!("{}/*.parquet", dir.path().display());
+    let source = ParquetSource::new(ParquetSourceConfig::glob(&pattern))
+        .await
+        .expect("source");
+
+    assert!(source.is_shardable());
+    let shards = source.enumerate_shards(3).await.expect("enumerate");
+    assert_eq!(shards.len(), 3);
+
+    let ctx = std::collections::HashMap::new();
+    let mut all_ids: Vec<i64> = Vec::new();
+    for shard in &shards {
+        source.apply_shard(shard).await.expect("apply_shard");
+        let pages: Vec<StreamPage> = source
+            .stream_pages(&ctx, 0)
+            .map(|p| p.expect("page"))
+            .collect()
+            .await;
+        for page in pages {
+            for rec in page.records {
+                all_ids.push(rec["id"].as_i64().expect("id is int"));
+            }
+        }
+    }
+
+    all_ids.sort();
+    let expected: Vec<i64> = (0..60).collect();
+    assert_eq!(
+        all_ids, expected,
+        "shards must union to all rows exactly once (no dup, no loss)"
+    );
+}
+
+/// A cross-file schema mismatch must fail a sharded worker even when the
+/// mismatching file hashes into a DIFFERENT shard — schema validation covers
+/// the full resolved set, not just the shard's subset.
+#[tokio::test]
+async fn sharded_stream_rejects_cross_shard_schema_mismatch() {
+    let dir = TempDir::new().expect("tempdir");
+    let int_schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
+    let str_schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Utf8, false)]));
+    let int_batch = RecordBatch::try_new(
+        int_schema.clone(),
+        vec![Arc::new(Int64Array::from(vec![1i64, 2]))],
+    )
+    .expect("int batch");
+    let str_batch = RecordBatch::try_new(
+        str_schema.clone(),
+        vec![Arc::new(StringArray::from(vec!["a", "b"]))],
+    )
+    .expect("str batch");
+    write_single_row_group(&dir.path().join("part-0.parquet"), &int_batch);
+    write_single_row_group(&dir.path().join("part-1.parquet"), &str_batch);
+
+    let pattern = format!("{}/*.parquet", dir.path().display());
+    let source = ParquetSource::new(ParquetSourceConfig::glob(&pattern))
+        .await
+        .expect("source");
+
+    // Every shard must reject the mismatched file set — even a shard whose own
+    // subset is internally consistent (or empty).
+    let shards = source.enumerate_shards(2).await.expect("enumerate");
+    let ctx = std::collections::HashMap::new();
+    for shard in &shards {
+        source.apply_shard(shard).await.expect("apply_shard");
+        let results: Vec<_> = source.stream_pages(&ctx, 0).collect().await;
+        assert!(
+            results.iter().any(|r| r.is_err()),
+            "shard {} must surface the cross-file schema mismatch",
+            shard.id
+        );
+    }
+}

--- a/crates/source/postgres/README.md
+++ b/crates/source/postgres/README.md
@@ -69,6 +69,7 @@ All fields live under `pipeline.source.config`.
 |-------|------|---------|-------------|
 | `max_connections` | int | `10` | Maximum connections in the `sqlx` pool. |
 | `batch_size` | int | `1000` | Rows per `StreamPage`. **`0` = no batching** — the cursor is fully drained and the entire result set is emitted in a single page (see [Streaming & batching](#streaming--batching)). Values above `MAX_BATCH_SIZE` (1,000,000) are rejected at construction. |
+| `shard` | object | *(unset)* | Optional [Mode B sharding](#sharded-execution-cluster-mode-b): `{ key: <integer column> }`. Opts the source into primary-key range splitting under `faucet serve --cluster`; no effect on a plain `faucet run`. |
 
 ## Examples
 
@@ -305,6 +306,36 @@ This crate has no optional features of its own. Enable it in the CLI or umbrella
 - [`faucet-source-postgres-cdc`](https://crates.io/crates/faucet-source-postgres-cdc) — resumable change data capture via logical replication
 - [`faucet-sink-postgres`](https://crates.io/crates/faucet-sink-postgres) — the PostgreSQL sink (insert / upsert / delete)
 - [`faucet-source-mysql`](https://crates.io/crates/faucet-source-mysql) · [`faucet-source-sqlite`](https://crates.io/crates/faucet-source-sqlite) · [`faucet-source-mssql`](https://crates.io/crates/faucet-source-mssql)
+
+## Sharded execution (cluster Mode B)
+
+Under [`faucet serve --cluster`](https://pawansikawat.github.io/faucet-stream/cookbook/cluster.html),
+a top-level `shard: { count: N }` block splits this source into contiguous
+primary-key ranges that different cluster workers process concurrently. Opt in
+by naming an integer-typed key column:
+
+```yaml
+shard:
+  count: 8
+pipeline:
+  source:
+    type: postgres
+    config:
+      connection_url: ${env:PG_URL}
+      query: "SELECT * FROM events"
+      shard: { key: id }   # integer column to range-partition on
+```
+
+The coordinator computes `MIN(key)` / `MAX(key)` once and splits that range
+into half-open slices (`"key"` in the generated predicate, injection-safe).
+The boundary shards stay open-ended so rows inserted outside the captured
+range during the run are still read, and exactly one shard additionally
+matches `key IS NULL` so nullable keys are never silently dropped. Each shard
+keeps its own state key (`{run}::{shard}`), so a reassigned shard resumes
+where its previous owner left off.
+
+Outside the cluster coordinator the `shard` config has **no effect** — a plain
+`faucet run` streams the whole query.
 
 ## License
 

--- a/crates/source/postgres/src/stream.rs
+++ b/crates/source/postgres/src/stream.rs
@@ -2,7 +2,9 @@
 
 use crate::config::PostgresSourceConfig;
 use async_trait::async_trait;
-use faucet_core::shard::ShardSpec;
+use faucet_core::shard::{
+    PkShardBounds, ShardSpec, parse_pk_shard, pk_bounds_query, pk_shards_from_bounds,
+};
 use faucet_core::util::quote_ident;
 use faucet_core::{FaucetError, Stream, StreamPage};
 use futures::TryStreamExt;
@@ -19,94 +21,7 @@ pub struct PostgresSource {
     /// Shard applied by the cluster coordinator (Mode B), if any. `None` (or the
     /// whole-dataset shard) means the full query is streamed. Stored behind a
     /// `Mutex` so `apply_shard(&self, …)` can record it before streaming.
-    applied_shard: Mutex<Option<ShardBounds>>,
-}
-
-/// Parsed integer range bounds for an applied PK-range shard.
-#[derive(Clone, Debug)]
-struct ShardBounds {
-    key: String,
-    lo: i64,
-    hi: i64,
-    /// When `true` this shard has **no lower bound** — it is the *first* shard,
-    /// so it owns every key below `hi` including any below the enumerated `MIN`.
-    /// Rows backfilled or inserted with smaller ids during the run are read by
-    /// this shard instead of being silently dropped outside `[MIN, MAX]` (F54).
-    lo_unbounded: bool,
-    /// When `true` this shard has **no upper bound** — it is the *last* shard,
-    /// so it owns every key at/above `lo` including any above the enumerated
-    /// `MAX`. Rows appended above the captured `MAX` between coordination and
-    /// shard execution are read by this shard instead of being lost (F55).
-    hi_unbounded: bool,
-    /// When `true` this shard *additionally* matches rows whose `key` is NULL.
-    ///
-    /// SQL aggregates (`MIN`/`MAX`) ignore NULLs, so a nullable shard key never
-    /// produces a `[lo, hi]` range covering NULL-key rows — without this flag
-    /// every sharded run would silently drop them (audit F37). Exactly one
-    /// shard (the last) carries this flag, so NULL-key rows are read by
-    /// precisely one shard: no loss, no duplication.
-    include_null: bool,
-}
-
-impl ShardBounds {
-    /// Parse from a [`ShardSpec`] descriptor produced by `enumerate_shards`.
-    fn from_spec(spec: &ShardSpec) -> Option<Self> {
-        let d = &spec.descriptor;
-        Some(Self {
-            key: d.get("key")?.as_str()?.to_string(),
-            lo: d.get("lo")?.as_i64()?,
-            hi: d.get("hi")?.as_i64()?,
-            lo_unbounded: d
-                .get("lo_unbounded")
-                .and_then(Value::as_bool)
-                .unwrap_or(false),
-            hi_unbounded: d
-                .get("hi_unbounded")
-                .and_then(Value::as_bool)
-                .unwrap_or(false),
-            include_null: d
-                .get("include_null")
-                .and_then(Value::as_bool)
-                .unwrap_or(false),
-        })
-    }
-
-    /// Wrap `inner` so only rows whose `key` falls in this shard's range are
-    /// returned. The key is quoted (injection-safe); the bounds are inlined as
-    /// integer literals (safe — they are `i64`s produced by enumeration).
-    ///
-    /// The boundary shards are **open-ended** (`lo_unbounded` / `hi_unbounded`)
-    /// so the union of all shards tiles `(-∞, +∞)`, matching unsharded
-    /// semantics — no row is dropped for sorting outside the `[MIN, MAX]`
-    /// captured at enumeration time (F54/F55). The single shard with
-    /// `include_null` also matches `key IS NULL` so NULL-key rows (invisible to
-    /// the `MIN`/`MAX` enumeration) are still read.
-    fn wrap(&self, inner: &str) -> String {
-        let key = quote_ident(&self.key);
-        let mut parts: Vec<String> = Vec::with_capacity(2);
-        if !self.lo_unbounded {
-            parts.push(format!("{key} >= {lo}", lo = self.lo));
-        }
-        if !self.hi_unbounded {
-            parts.push(format!("{key} < {hi}", hi = self.hi));
-        }
-        let range = parts.join(" AND ");
-        let predicate = if self.include_null {
-            if range.is_empty() {
-                // A single fully-unbounded shard owns the whole dataset,
-                // NULL-key rows included.
-                "TRUE".to_string()
-            } else {
-                // Parenthesize so the OR binds correctly inside the WHERE clause.
-                format!("(({range}) OR {key} IS NULL)")
-            }
-        } else if range.is_empty() {
-            "TRUE".to_string()
-        } else {
-            range
-        };
-        format!("SELECT * FROM ({inner}) AS _faucet_shard WHERE {predicate}")
-    }
+    applied_shard: Mutex<Option<PkShardBounds>>,
 }
 
 impl PostgresSource {
@@ -130,73 +45,10 @@ impl PostgresSource {
     /// Apply the currently-set shard (if any) to a resolved query string.
     fn shard_wrap(&self, query: String) -> String {
         match &*self.applied_shard.lock().expect("shard mutex poisoned") {
-            Some(bounds) => bounds.wrap(&query),
+            Some(bounds) => bounds.wrap(&query, quote_ident),
             None => query,
         }
     }
-}
-
-/// Split the integer range observed as `[min, max]` into up to `target`
-/// contiguous shards, each described by
-/// `{key, lo, hi, lo_unbounded, hi_unbounded, include_null}`. Interior cut
-/// points are half-open `[lo, hi)`, but the **boundary shards are open-ended**:
-/// the first shard has no lower bound and the last shard has no upper bound, so
-/// the union of all shards tiles `(-∞, +∞)`.
-///
-/// Open-ended boundaries match unsharded semantics: `min`/`max` are captured
-/// once at enumeration time, but rows can be inserted below `min` or above `max`
-/// (or backfilled) before the workers actually stream their shards. Clamping the
-/// boundary shards to the captured `[min, max]` would silently drop those rows
-/// (audit F54/F55); leaving them open captures everything.
-///
-/// The last shard also carries `include_null: true` so that NULL-key rows —
-/// invisible to the `MIN`/`MAX` enumeration that produced `[min, max]` — are
-/// read by exactly one shard (no loss, no duplication; audit F37). Picking the
-/// *last* shard means a single-shard plan still covers NULLs.
-///
-/// Coverage scheme (proven by `predicate_coverage_*` tests):
-/// - non-NULL keys: the first shard owns `key < cut₁`, interior shards own
-///   `[cutᵢ, cutᵢ₊₁)`, and the last shard owns `key >= cutₙ` — every value
-///   (including below `min` and above `max`) falls in exactly one shard;
-/// - NULL keys: matched only by the last shard's `OR key IS NULL` clause —
-///   exactly one shard.
-///
-/// Pure function (no I/O) so it is unit-testable without a database.
-fn plan_pk_shards(key: &str, min: i64, max: i64, target: usize) -> Vec<ShardSpec> {
-    let target = target.max(1);
-    // Range width as u128 to avoid i64 overflow on full-range PKs.
-    let width = (max as i128 - min as i128 + 1).max(1) as u128;
-    let n = (target as u128).min(width) as usize; // never more shards than values
-    let step = width.div_ceil(n as u128); // ceil so shards cover the whole range
-
-    let mut shards = Vec::with_capacity(n);
-    let mut lo = min as i128;
-    for i in 0..n {
-        let mut hi = lo + step as i128;
-        let is_first = i == 0;
-        let is_last = i == n - 1;
-        if is_last || hi > max as i128 {
-            hi = max as i128; // last interior cut closes at max (the last shard
-            // is unbounded above, so `hi` is unused there)
-        }
-        let descriptor = serde_json::json!({
-            "key": key,
-            "lo": lo as i64,
-            "hi": hi as i64,
-            // Boundary shards are open-ended so the union tiles (-∞, +∞).
-            "lo_unbounded": is_first,
-            "hi_unbounded": is_last,
-            // Exactly one shard (the last) owns the NULL-key rows.
-            "include_null": is_last,
-        });
-        let size = (hi - lo).max(0) as u64 + if is_last { 1 } else { 0 };
-        shards.push(ShardSpec::new(i.to_string(), descriptor).with_size(size));
-        if is_last {
-            break;
-        }
-        lo = hi;
-    }
-    shards
 }
 
 /// Convert a raw sqlx column value to a `serde_json::Value`.
@@ -473,12 +325,8 @@ impl faucet_core::Source for PostgresSource {
             return Ok(vec![ShardSpec::whole()]);
         };
 
-        let key = quote_ident(&shard_cfg.key);
-        let bounds_sql = format!(
-            "SELECT MIN({key})::int8 AS lo, MAX({key})::int8 AS hi \
-             FROM ({inner}) AS _faucet_bounds",
-            inner = self.config.query
-        );
+        let bounds_sql =
+            pk_bounds_query(&self.config.query, &quote_ident(&shard_cfg.key), "BIGINT");
         let row = bind_params(sqlx::query(&bounds_sql), &self.config.params, &[])
             .fetch_one(&self.pool)
             .await
@@ -496,28 +344,14 @@ impl faucet_core::Source for PostgresSource {
         let hi: Option<i64> = row.try_get("hi").map_err(|e| {
             FaucetError::Source(format!("postgres: shard bounds decode failed: {e}"))
         })?;
-
-        match (lo, hi) {
-            (Some(lo), Some(hi)) => Ok(plan_pk_shards(&shard_cfg.key, lo, hi, target)),
-            // Empty result set → nothing to shard; one (empty) whole shard.
-            _ => Ok(vec![ShardSpec::whole()]),
-        }
+        Ok(pk_shards_from_bounds(&shard_cfg.key, lo, hi, target))
     }
 
     /// Narrow this source to a single PK-range shard. The whole-dataset shard
     /// clears any applied range (streams the full query).
     async fn apply_shard(&self, shard: &ShardSpec) -> Result<(), FaucetError> {
-        let bounds = if shard.is_whole() {
-            None
-        } else {
-            Some(ShardBounds::from_spec(shard).ok_or_else(|| {
-                FaucetError::Source(format!(
-                    "postgres: invalid shard descriptor: {}",
-                    shard.descriptor
-                ))
-            })?)
-        };
-        *self.applied_shard.lock().expect("shard mutex poisoned") = bounds;
+        *self.applied_shard.lock().expect("shard mutex poisoned") =
+            parse_pk_shard(shard, "postgres")?;
         Ok(())
     }
 }
@@ -525,6 +359,12 @@ impl faucet_core::Source for PostgresSource {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use faucet_core::shard::plan_pk_shards;
+
+    /// The shard-bounds type moved to `faucet_core::shard` (#262) so the
+    /// PK-range logic is shared across the SQL sources; alias it so the
+    /// long-standing tests below keep pinning postgres's behavior unchanged.
+    type ShardBounds = PkShardBounds;
 
     #[tokio::test]
     async fn new_rejects_out_of_range_batch_size() {
@@ -665,7 +505,7 @@ mod tests {
             serde_json::json!({"key": "id", "lo": 100, "hi": 200, "lo_unbounded": false, "hi_unbounded": false}),
         );
         let b = ShardBounds::from_spec(&spec).unwrap();
-        let sql = b.wrap("SELECT * FROM t");
+        let sql = b.wrap("SELECT * FROM t", quote_ident);
         assert!(sql.contains("(SELECT * FROM t) AS _faucet_shard"));
         assert!(sql.contains(r#""id" >= 100"#), "got: {sql}");
         assert!(
@@ -683,7 +523,7 @@ mod tests {
             serde_json::json!({"key": "id", "lo": 0, "hi": 100, "lo_unbounded": true, "hi_unbounded": false}),
         );
         let b = ShardBounds::from_spec(&spec).unwrap();
-        let sql = b.wrap("SELECT * FROM t");
+        let sql = b.wrap("SELECT * FROM t", quote_ident);
         assert!(sql.contains(r#""id" < 100"#), "upper bound present: {sql}");
         assert!(!sql.contains(">="), "first shard has no lower floor: {sql}");
     }
@@ -697,7 +537,7 @@ mod tests {
             serde_json::json!({"key": "id", "lo": 200, "hi": 300, "lo_unbounded": false, "hi_unbounded": true}),
         );
         let b = ShardBounds::from_spec(&spec).unwrap();
-        let sql = b.wrap("SELECT * FROM t");
+        let sql = b.wrap("SELECT * FROM t", quote_ident);
         assert!(sql.contains(r#""id" >= 200"#), "lower bound present: {sql}");
         assert!(
             !sql.contains(" < ") && !sql.contains("<="),
@@ -712,7 +552,7 @@ mod tests {
             serde_json::json!({"key": "weird\"; DROP", "lo": 0, "hi": 1, "lo_unbounded": false, "hi_unbounded": false}),
         );
         let b = ShardBounds::from_spec(&spec).unwrap();
-        let sql = b.wrap("SELECT 1");
+        let sql = b.wrap("SELECT 1", quote_ident);
         // The doubled quote escaping proves the identifier was quoted, not raw.
         assert!(
             sql.contains(r#""weird""; DROP""#),
@@ -757,7 +597,7 @@ mod tests {
     fn last_shard_wrap_emits_is_null_clause() {
         let shards = plan_pk_shards("id", 0, 99, 3);
         let last = ShardBounds::from_spec(shards.last().unwrap()).unwrap();
-        let sql = last.wrap("SELECT * FROM t");
+        let sql = last.wrap("SELECT * FROM t", quote_ident);
         assert!(
             sql.contains(r#""id" IS NULL"#),
             "last shard must match NULL keys: {sql}"
@@ -770,7 +610,7 @@ mod tests {
         let shards = plan_pk_shards("id", 0, 99, 3);
         // First shard is not the last → no NULL clause.
         let first = ShardBounds::from_spec(&shards[0]).unwrap();
-        let sql = first.wrap("SELECT * FROM t");
+        let sql = first.wrap("SELECT * FROM t", quote_ident);
         assert!(
             !sql.contains("IS NULL"),
             "non-last shard must not match NULL keys: {sql}"
@@ -816,7 +656,7 @@ mod tests {
         let shards = plan_pk_shards("id", 7, 7, 1);
         assert_eq!(shards.len(), 1);
         let b = ShardBounds::from_spec(&shards[0]).unwrap();
-        let sql = b.wrap("SELECT * FROM t");
+        let sql = b.wrap("SELECT * FROM t", quote_ident);
         assert!(sql.contains("WHERE TRUE"), "whole-dataset predicate: {sql}");
         assert!(!sql.contains(">="), "no bounds on a lone shard: {sql}");
     }
@@ -830,5 +670,54 @@ mod tests {
         let redacted = faucet_core::redact_uri_credentials("postgres://u:p@h:5432/db");
         let uri = format!("{}?query={}", redacted, "SELECT 1");
         assert_eq!(uri, "postgres://h:5432/db?query=SELECT 1");
+    }
+
+    /// Build a source over a lazy pool (no server needed) so the shard glue —
+    /// `apply_shard`, `shard_wrap`, and `enumerate_shards`' error path — is
+    /// testable without Docker.
+    fn lazy_source(config: PostgresSourceConfig) -> PostgresSource {
+        let pool = PgPoolOptions::new()
+            // Fail fast at first checkout — these tests never reach a server.
+            .acquire_timeout(std::time::Duration::from_millis(200))
+            .connect_lazy(&config.connection_url)
+            .expect("lazy pool");
+        PostgresSource {
+            config,
+            pool,
+            applied_shard: Mutex::new(None),
+        }
+    }
+
+    #[tokio::test]
+    async fn apply_shard_then_shard_wrap_narrows_query() {
+        use faucet_core::Source as _;
+        let mut config =
+            PostgresSourceConfig::new("postgres://u@127.0.0.1:1/db", "SELECT * FROM t");
+        config.shard = Some(crate::config::ShardConfig { key: "id".into() });
+        let source = lazy_source(config);
+        assert!(source.is_shardable());
+
+        // No shard applied / whole shard applied → query passes through.
+        assert_eq!(source.shard_wrap("SELECT 1".into()), "SELECT 1");
+        source
+            .apply_shard(&faucet_core::ShardSpec::whole())
+            .await
+            .unwrap();
+        assert_eq!(source.shard_wrap("SELECT 1".into()), "SELECT 1");
+
+        // A real shard narrows with ANSI double-quote quoting.
+        let spec = &plan_pk_shards("id", 0, 99, 2)[0];
+        source.apply_shard(spec).await.unwrap();
+        let wrapped = source.shard_wrap("SELECT * FROM t".into());
+        assert!(wrapped.contains(r#""id""#), "got: {wrapped}");
+        assert!(wrapped.contains("_faucet_shard"), "got: {wrapped}");
+
+        // Enumeration against the unreachable server surfaces the bounds-probe
+        // error path.
+        let err = source.enumerate_shards(4).await.unwrap_err();
+        assert!(
+            err.to_string().contains("shard bounds"),
+            "expected bounds-probe error, got: {err}"
+        );
     }
 }

--- a/crates/source/s3/README.md
+++ b/crates/source/s3/README.md
@@ -358,6 +358,16 @@ Enable the connector itself in the CLI/umbrella via the `source-s3` feature.
 - [Connector reference](https://pawansikawat.github.io/faucet-stream/reference/connectors.html) · [Compression cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/compression.html)
 - Related crates: [faucet-sink-s3](https://crates.io/crates/faucet-sink-s3) · [faucet-source-gcs](https://crates.io/crates/faucet-source-gcs) · [faucet-source-parquet](https://crates.io/crates/faucet-source-parquet)
 
+## Sharded execution (cluster Mode B)
+
+Under [`faucet serve --cluster`](https://pawansikawat.github.io/faucet-stream/cookbook/cluster.html),
+a top-level `shard: { count: N }` block splits this source across cluster
+workers **automatically — no connector config needed**. Each worker reads the
+objects whose key hashes to its shard index (stable FNV-1a modulo `count`),
+so the partition is disjoint and complete: every object is read by exactly one
+worker, and the partition stays stable as new objects appear. Outside the
+cluster coordinator a run reads every object, unchanged.
+
 ## License
 
 Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT license](https://opensource.org/licenses/MIT) at your option.

--- a/crates/source/s3/src/stream.rs
+++ b/crates/source/s3/src/stream.rs
@@ -3,7 +3,7 @@
 use crate::config::{S3FileFormat, S3SourceConfig};
 use async_trait::async_trait;
 use aws_sdk_s3::Client;
-use faucet_core::shard::ShardSpec;
+use faucet_core::shard::{HashShard, ShardSpec, parse_hash_shard, plan_hash_shards};
 use faucet_core::{FaucetError, Stream, StreamPage};
 use futures::stream::{self, StreamExt, TryStreamExt};
 use serde_json::Value;
@@ -15,24 +15,10 @@ use tokio::io::AsyncBufReadExt;
 pub struct S3Source {
     config: S3SourceConfig,
     client: Client,
-    /// Shard applied by the cluster coordinator (Mode B): `(shards, index)`.
-    /// `None` (or `shards <= 1`) reads every listed object. Stored behind a
+    /// Shard applied by the cluster coordinator (Mode B). `None` (or a
+    /// degenerate single-shard set) reads every listed object. Stored behind a
     /// `Mutex` so `apply_shard(&self, …)` can record it before streaming.
-    applied_shard: Mutex<Option<(usize, usize)>>,
-}
-
-/// Stable FNV-1a hash of an object key, used to assign keys to shards.
-///
-/// Deterministic across processes and platforms (all cluster workers run the
-/// identical binary and this fixed algorithm), so every worker maps a given key
-/// to the same shard index — the partition is disjoint and complete.
-fn shard_hash(key: &str) -> u64 {
-    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
-    for b in key.as_bytes() {
-        h ^= *b as u64;
-        h = h.wrapping_mul(0x0000_0100_0000_01b3);
-    }
-    h
+    applied_shard: Mutex<Option<HashShard>>,
 }
 
 impl S3Source {
@@ -52,11 +38,8 @@ impl S3Source {
     /// `shards`). A no-op when no shard is applied or `shards <= 1`.
     fn shard_filter(&self, keys: Vec<String>) -> Vec<String> {
         match *self.applied_shard.lock().expect("shard mutex poisoned") {
-            Some((shards, index)) if shards > 1 => keys
-                .into_iter()
-                .filter(|k| (shard_hash(k) % shards as u64) == index as u64)
-                .collect(),
-            _ => keys,
+            Some(member) => keys.into_iter().filter(|k| member.contains(k)).collect(),
+            None => keys,
         }
     }
 
@@ -516,49 +499,13 @@ impl faucet_core::Source for S3Source {
     /// defined by the hash function, so enumeration is cheap and stable as new
     /// objects appear. `target <= 1` yields a single whole-dataset shard.
     async fn enumerate_shards(&self, target: usize) -> Result<Vec<ShardSpec>, FaucetError> {
-        if target <= 1 {
-            return Ok(vec![ShardSpec::whole()]);
-        }
-        let shards = (0..target)
-            .map(|i| {
-                ShardSpec::new(
-                    i.to_string(),
-                    serde_json::json!({ "shards": target, "index": i }),
-                )
-            })
-            .collect();
-        Ok(shards)
+        Ok(plan_hash_shards(target))
     }
 
     /// Narrow this source to one hash-modulo shard. The whole-dataset shard
     /// clears any filter (reads every object).
     async fn apply_shard(&self, shard: &ShardSpec) -> Result<(), FaucetError> {
-        let parsed = if shard.is_whole() {
-            None
-        } else {
-            let shards = shard
-                .descriptor
-                .get("shards")
-                .and_then(Value::as_u64)
-                .ok_or_else(|| {
-                    FaucetError::Source(format!(
-                        "s3: invalid shard descriptor (missing 'shards'): {}",
-                        shard.descriptor
-                    ))
-                })?;
-            let index = shard
-                .descriptor
-                .get("index")
-                .and_then(Value::as_u64)
-                .ok_or_else(|| {
-                    FaucetError::Source(format!(
-                        "s3: invalid shard descriptor (missing 'index'): {}",
-                        shard.descriptor
-                    ))
-                })?;
-            Some((shards as usize, index as usize))
-        };
-        *self.applied_shard.lock().expect("shard mutex poisoned") = parsed;
+        *self.applied_shard.lock().expect("shard mutex poisoned") = parse_hash_shard(shard, "s3")?;
         Ok(())
     }
 }
@@ -675,6 +622,7 @@ mod tests {
 
     #[test]
     fn shard_hash_is_deterministic() {
+        use faucet_core::shard::shard_hash;
         assert_eq!(
             shard_hash("data/part-001.jsonl"),
             shard_hash("data/part-001.jsonl")

--- a/crates/source/sqlite/README.md
+++ b/crates/source/sqlite/README.md
@@ -67,6 +67,7 @@ All fields live under `pipeline.source.config`.
 | `query` | string | — *(required)* | SQL to execute. May contain `{field}` placeholders that are bound from the matrix / parent-record context as positional `?` parameters at runtime. |
 | `max_connections` | int (`u32`) | `10` | Maximum connections in the sqlx pool. SQLite is single-writer; a small pool (2–5) is usually plenty for a read-only source. |
 | `batch_size` | int (`usize`) | `1000` | Rows per emitted `StreamPage`. **`0` = no batching**: the cursor is fully drained and the entire result set is emitted in a single page. Values above `MAX_BATCH_SIZE` (1,000,000) are rejected at construction. |
+| `shard` | object | *(unset)* | Optional [Mode B sharding](#sharded-execution-cluster-mode-b): `{ key: <integer column> }`. Opts the source into primary-key range splitting under `faucet serve --cluster`; no effect on a plain `faucet run`. |
 
 There is **no auth, TLS, or credential configuration** — SQLite is a local in-process engine.
 
@@ -281,6 +282,39 @@ This crate has no optional features of its own. Enable it in the CLI / umbrella 
 - [State & resume cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/state.html)
 - [`faucet-sink-sqlite`](https://crates.io/crates/faucet-sink-sqlite) — the matching SQLite sink
 - [`faucet-source-postgres`](https://crates.io/crates/faucet-source-postgres) · [`faucet-source-mysql`](https://crates.io/crates/faucet-source-mysql) — server-based SQL sources
+
+## Sharded execution (cluster Mode B)
+
+Under [`faucet serve --cluster`](https://pawansikawat.github.io/faucet-stream/cookbook/cluster.html),
+a top-level `shard: { count: N }` block splits this source into contiguous
+primary-key ranges that different cluster workers process concurrently. Opt in
+by naming an integer-typed key column:
+
+```yaml
+shard:
+  count: 8
+pipeline:
+  source:
+    type: sqlite
+    config:
+      database_url: sqlite:/shared/data.db
+      query: "SELECT * FROM events"
+      shard: { key: id }   # integer column to range-partition on
+```
+
+The coordinator computes `MIN(key)` / `MAX(key)` once and splits that range
+into half-open slices (`` `key` `` in the generated predicate, injection-safe).
+The boundary shards stay open-ended so rows inserted outside the captured
+range during the run are still read, and exactly one shard additionally
+matches `key IS NULL` so nullable keys are never silently dropped. Each shard
+keeps its own state key (`{run}::{shard}`), so a reassigned shard resumes
+where its previous owner left off.
+
+Outside the cluster coordinator the `shard` config has **no effect** — a plain
+`faucet run` streams the whole query.
+
+> Sharding a SQLite source across cluster workers requires every worker to
+> reach the same database file (e.g. a shared volume).
 
 ## License
 

--- a/crates/source/sqlite/src/config.rs
+++ b/crates/source/sqlite/src/config.rs
@@ -24,6 +24,37 @@ pub struct SqliteSourceConfig {
     /// jobs) that prefer one large request to many small ones.
     #[serde(default = "default_batch_size")]
     pub batch_size: usize,
+
+    /// Optional primary-key range sharding for clustered (Mode B) execution.
+    ///
+    /// When set, the source advertises itself as shardable: the cluster
+    /// coordinator splits the query's `key` range into contiguous slices that
+    /// different workers process concurrently. Has **no effect** outside the
+    /// cluster coordinator (a plain `faucet run` streams the whole query), so
+    /// it is fully backward compatible. See [`ShardConfig`].
+    ///
+    /// Note: sharding a SQLite source across cluster workers requires every
+    /// worker to reach the same database file (e.g. a shared volume).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub shard: Option<ShardConfig>,
+}
+
+/// Primary-key range sharding settings for the SQLite source.
+///
+/// The source is split by contiguous ranges of an **integer-typed** column:
+/// each shard runs `SELECT * FROM (<query>) WHERE "key" >= lo AND "key" < hi`.
+/// The column must be present in the query's output and orderable as a 64-bit
+/// integer (e.g. an `INTEGER PRIMARY KEY` rowid alias).
+///
+/// **Nullable keys:** if the key column contains NULLs, those rows are not
+/// visible to the `MIN`/`MAX` range enumeration. They are still read — exactly
+/// one shard (the last) additionally matches `"key" IS NULL`, so NULL-key rows
+/// are covered by precisely one shard with no loss and no duplication.
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct ShardConfig {
+    /// Integer column to range-partition on. Quoted as an identifier before use,
+    /// so it is safe against injection but must name a real output column.
+    pub key: String,
 }
 
 fn default_max_connections() -> u32 {
@@ -42,6 +73,7 @@ impl SqliteSourceConfig {
             query: query.into(),
             max_connections: 10,
             batch_size: DEFAULT_BATCH_SIZE,
+            shard: None,
         }
     }
 

--- a/crates/source/sqlite/src/lib.rs
+++ b/crates/source/sqlite/src/lib.rs
@@ -12,5 +12,5 @@ pub mod stream;
 
 pub use faucet_core::{FaucetError, Source};
 
-pub use config::SqliteSourceConfig;
+pub use config::{ShardConfig, SqliteSourceConfig};
 pub use stream::SqliteSource;

--- a/crates/source/sqlite/src/stream.rs
+++ b/crates/source/sqlite/src/stream.rs
@@ -2,17 +2,38 @@
 
 use crate::config::SqliteSourceConfig;
 use async_trait::async_trait;
+use faucet_core::shard::{
+    PkShardBounds, ShardSpec, parse_pk_shard, pk_bounds_query, pk_shards_from_bounds,
+};
 use faucet_core::{FaucetError, Stream, StreamPage};
 use futures::TryStreamExt;
 use serde_json::Value;
 use sqlx::sqlite::SqlitePoolOptions;
 use sqlx::{Column, Row, SqlitePool};
 use std::pin::Pin;
+use std::sync::Mutex;
 
 /// A source that executes a SQL query against SQLite and returns rows as JSON.
 pub struct SqliteSource {
     config: SqliteSourceConfig,
     pool: SqlitePool,
+    /// Shard applied by the cluster coordinator (Mode B), if any. `None` (or the
+    /// whole-dataset shard) means the full query is streamed. Stored behind a
+    /// `Mutex` so `apply_shard(&self, …)` can record it before streaming.
+    applied_shard: Mutex<Option<PkShardBounds>>,
+}
+
+/// Quote a SQLite identifier with backticks.
+///
+/// Deliberately NOT ANSI double quotes: SQLite's double-quoted-string
+/// misfeature silently reinterprets a double-quoted identifier that does not
+/// resolve to a column as a **string literal**, so a typo'd shard key would
+/// make `MIN("typo")` return the literal string (→ bounds of 0) instead of
+/// erroring. Backtick-quoted identifiers are always identifiers — an unknown
+/// column surfaces as a proper "no such column" error. Embedded backticks are
+/// doubled, preventing identifier injection.
+fn quote_ident_sqlite(name: &str) -> String {
+    format!("`{}`", name.replace('`', "``"))
 }
 
 impl SqliteSource {
@@ -26,7 +47,19 @@ impl SqliteSource {
             .await
             .map_err(|e| FaucetError::Config(format!("SQLite connection failed: {e}")))?;
 
-        Ok(Self { config, pool })
+        Ok(Self {
+            config,
+            pool,
+            applied_shard: Mutex::new(None),
+        })
+    }
+
+    /// Apply the currently-set shard (if any) to a resolved query string.
+    fn shard_wrap(&self, query: String) -> String {
+        match &*self.applied_shard.lock().expect("shard mutex poisoned") {
+            Some(bounds) => bounds.wrap(&query, quote_ident_sqlite),
+            None => query,
+        }
     }
 }
 
@@ -164,6 +197,7 @@ impl faucet_core::Source for SqliteSource {
         context: &std::collections::HashMap<String, serde_json::Value>,
     ) -> Result<Vec<Value>, FaucetError> {
         let (query_str, bind_values) = resolve_query(&self.config, context);
+        let query_str = self.shard_wrap(query_str);
         let query = bind_params(sqlx::query(&query_str), &bind_values);
 
         let rows = query
@@ -203,6 +237,7 @@ impl faucet_core::Source for SqliteSource {
 
         Box::pin(async_stream::try_stream! {
             let (query_str, bind_values) = resolve_query(&self.config, context);
+            let query_str = self.shard_wrap(query_str);
             let query = bind_params(sqlx::query(&query_str), &bind_values);
 
             let mut rows = query.fetch(&self.pool);
@@ -249,6 +284,53 @@ impl faucet_core::Source for SqliteSource {
             .trim_start_matches("sqlite://")
             .trim_start_matches("sqlite:");
         format!("sqlite://{}?query={}", path, self.config.query)
+    }
+
+    /// Shardable when a [`ShardConfig`](crate::config::ShardConfig) is set.
+    fn is_shardable(&self) -> bool {
+        self.config.shard.is_some()
+    }
+
+    /// Enumerate contiguous primary-key range shards by computing the `key`
+    /// column's `MIN`/`MAX` over the (unsharded) base query and splitting that
+    /// range into ~`target` slices. Returns a single whole-dataset shard when no
+    /// `shard` config is set or the result set is empty.
+    async fn enumerate_shards(&self, target: usize) -> Result<Vec<ShardSpec>, FaucetError> {
+        let Some(shard_cfg) = &self.config.shard else {
+            return Ok(vec![ShardSpec::whole()]);
+        };
+
+        let bounds_sql = pk_bounds_query(
+            &self.config.query,
+            &quote_ident_sqlite(&shard_cfg.key),
+            "INTEGER",
+        );
+        let row = sqlx::query(&bounds_sql)
+            .fetch_one(&self.pool)
+            .await
+            .map_err(|e| {
+                FaucetError::Source(format!(
+                    "sqlite: failed to compute shard bounds for key {:?} \
+                     (it must be an integer-typed column): {e}",
+                    shard_cfg.key
+                ))
+            })?;
+
+        let lo: Option<i64> = row
+            .try_get("lo")
+            .map_err(|e| FaucetError::Source(format!("sqlite: shard bounds decode failed: {e}")))?;
+        let hi: Option<i64> = row
+            .try_get("hi")
+            .map_err(|e| FaucetError::Source(format!("sqlite: shard bounds decode failed: {e}")))?;
+        Ok(pk_shards_from_bounds(&shard_cfg.key, lo, hi, target))
+    }
+
+    /// Narrow this source to a single PK-range shard. The whole-dataset shard
+    /// clears any applied range (streams the full query).
+    async fn apply_shard(&self, shard: &ShardSpec) -> Result<(), FaucetError> {
+        *self.applied_shard.lock().expect("shard mutex poisoned") =
+            parse_pk_shard(shard, "sqlite")?;
+        Ok(())
     }
 }
 
@@ -492,5 +574,127 @@ mod tests {
         let uri = source.dataset_uri();
         assert!(uri.contains("SELECT 42 AS n"), "got: {uri}");
         assert!(uri.starts_with("sqlite://"), "got: {uri}");
+    }
+
+    // ── PK-range sharding (Mode B, #262) ─────────────────────────────────────
+
+    /// Build a single-connection in-memory source so every query sees the same
+    /// database (each pooled connection normally gets its own `:memory:` DB).
+    async fn sharded_memory_source(query: &str, key: &str) -> SqliteSource {
+        let mut config = SqliteSourceConfig::new("sqlite::memory:", query).with_max_connections(1);
+        config.shard = Some(crate::config::ShardConfig { key: key.into() });
+        SqliteSource::new(config).await.unwrap()
+    }
+
+    /// The core Mode B correctness guarantee, end-to-end on a real database:
+    /// enumerating into N shards and reading each shard yields every row —
+    /// including a NULL-key row invisible to MIN/MAX (F37) — exactly once.
+    #[tokio::test]
+    async fn shards_partition_rows_disjointly_and_completely() {
+        let source = sharded_memory_source("SELECT k, label FROM items", "k").await;
+        sqlx::query("CREATE TABLE items (k INTEGER, label TEXT)")
+            .execute(&source.pool)
+            .await
+            .unwrap();
+        for i in 1..=100i64 {
+            sqlx::query("INSERT INTO items (k, label) VALUES (?, ?)")
+                .bind(i)
+                .bind(format!("row-{i}"))
+                .execute(&source.pool)
+                .await
+                .unwrap();
+        }
+        // A NULL-key row: MIN/MAX can't see it, but exactly one shard must.
+        sqlx::query("INSERT INTO items (k, label) VALUES (NULL, 'null-row')")
+            .execute(&source.pool)
+            .await
+            .unwrap();
+
+        assert!(source.is_shardable());
+        let shards = source.enumerate_shards(4).await.expect("enumerate");
+        assert!(
+            (2..=4).contains(&shards.len()),
+            "expected 2..=4 shards, got {}",
+            shards.len()
+        );
+
+        let mut labels: Vec<String> = Vec::new();
+        for shard in &shards {
+            source.apply_shard(shard).await.expect("apply_shard");
+            for rec in source.fetch_all().await.expect("fetch shard") {
+                labels.push(rec["label"].as_str().unwrap().to_string());
+            }
+        }
+
+        labels.sort();
+        let mut expected: Vec<String> = (1..=100i64).map(|i| format!("row-{i}")).collect();
+        expected.push("null-row".to_string());
+        expected.sort();
+        assert_eq!(
+            labels, expected,
+            "shards must union to all rows exactly once (no dup, no loss)"
+        );
+    }
+
+    /// Applying the whole-dataset shard clears the range — full query again.
+    #[tokio::test]
+    async fn whole_shard_restores_full_query() {
+        let source = sharded_memory_source("SELECT k FROM items", "k").await;
+        sqlx::query("CREATE TABLE items (k INTEGER)")
+            .execute(&source.pool)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO items (k) VALUES (1), (2), (3)")
+            .execute(&source.pool)
+            .await
+            .unwrap();
+
+        let shards = source.enumerate_shards(2).await.unwrap();
+        source.apply_shard(&shards[0]).await.unwrap();
+        let narrowed = source.fetch_all().await.unwrap().len();
+        assert!(narrowed < 3, "a real shard narrows the result set");
+
+        source
+            .apply_shard(&faucet_core::ShardSpec::whole())
+            .await
+            .unwrap();
+        assert_eq!(source.fetch_all().await.unwrap().len(), 3);
+    }
+
+    /// Enumeration over an empty result set degrades to one whole shard, and a
+    /// config without `shard:` is not shardable.
+    #[tokio::test]
+    async fn empty_result_and_unsharded_config_yield_whole_shard() {
+        let source = sharded_memory_source("SELECT k FROM items", "k").await;
+        sqlx::query("CREATE TABLE items (k INTEGER)")
+            .execute(&source.pool)
+            .await
+            .unwrap();
+        let shards = source.enumerate_shards(4).await.unwrap();
+        assert_eq!(shards.len(), 1);
+        assert!(shards[0].is_whole());
+
+        let plain = SqliteSource::new(SqliteSourceConfig::new("sqlite::memory:", "SELECT 1"))
+            .await
+            .unwrap();
+        assert!(!plain.is_shardable());
+        let shards = plain.enumerate_shards(4).await.unwrap();
+        assert_eq!(shards.len(), 1);
+        assert!(shards[0].is_whole());
+    }
+
+    /// Error paths a coordinator must handle: a bad shard key errors at
+    /// enumeration; a malformed descriptor is rejected by apply_shard.
+    #[tokio::test]
+    async fn shard_error_paths() {
+        let source = sharded_memory_source("SELECT k FROM items", "no_such_column").await;
+        sqlx::query("CREATE TABLE items (k INTEGER)")
+            .execute(&source.pool)
+            .await
+            .unwrap();
+        assert!(source.enumerate_shards(4).await.is_err());
+
+        let bad = faucet_core::ShardSpec::new("0", serde_json::json!({ "key": "k" }));
+        assert!(source.apply_shard(&bad).await.is_err());
     }
 }

--- a/docs/book/src/cookbook/cluster.md
+++ b/docs/book/src/cookbook/cluster.md
@@ -290,14 +290,27 @@ finalized to `completed`/`failed` once every shard is terminal.
 | Source | Strategy | How to enable |
 |--------|----------|---------------|
 | `postgres` | primary-key range (`WHERE key >= lo AND key < hi`) | `source.config.shard: { key: <int column> }` |
+| `mysql` | primary-key range | `source.config.shard: { key: <int column> }` |
+| `mssql` | primary-key range | `source.config.shard: { key: <int column> }` |
+| `sqlite` | primary-key range | `source.config.shard: { key: <int column> }` |
 | `s3` | hash-of-object-key modulo N | automatic (no config) |
+| `gcs` | hash-of-object-key modulo N | automatic (no config) |
+| `parquet` | hash-of-file-path modulo N | automatic (no config) |
 
 > **NULL shard keys are not dropped.** Rows whose `shard` key column is `NULL`
-> fall outside every range predicate, so the postgres sharder assigns them to
+> fall outside every range predicate, so the SQL sharders assign them to
 > exactly one shard (alongside its range) — they are mirrored once, never
 > silently lost.
 
-Other sources are not shardable yet (tracked in [#262](https://github.com/PawanSikawat/faucet-stream/issues/262));
+PK-range notes: the shard `key` must be an integer-typed column present in the
+query's output. On `mssql`, a sharded query must not end in a top-level
+`ORDER BY` (T-SQL forbids it inside the derived table the shard predicate
+wraps — and ordering across concurrent shards is meaningless anyway). Sharding
+a `sqlite` source across workers requires every worker to reach the same
+database file (e.g. a shared volume). On `mssql` with incremental replication,
+shard bounds are computed over the not-yet-synced slice (the `@bookmark`
+binding is honoured during enumeration).
+
 Kafka uses native consumer-group assignment instead ([#261](https://github.com/PawanSikawat/faucet-stream/issues/261)).
 A non-shardable source (or a matrix pipeline) ignores `shard:` and runs whole — Mode B is fully backward compatible.
 


### PR DESCRIPTION
Closes #262

Part of the serve-cluster Mode B work (#230, roadmap epic #38).

## What

Every naturally-partitionable source now implements the `Shardable` capability, so a top-level `shard: { count: N }` distributes a single large source across cluster workers for **seven** sources instead of two:

| Source | Strategy | How to enable |
|--------|----------|---------------|
| `postgres` (existing) | PK range | `source.config.shard: { key }` |
| `mysql` **(new)** | PK range | `source.config.shard: { key }` |
| `mssql` **(new)** | PK range | `source.config.shard: { key }` |
| `sqlite` **(new)** | PK range | `source.config.shard: { key }` |
| `s3` (existing) | hash-of-key mod N | automatic |
| `gcs` **(new)** | hash-of-key mod N | automatic |
| `parquet` **(new)** | hash-of-file-path mod N | automatic |

## How

- **`faucet-core`**: the PK-range planning/predicate logic (`plan_pk_shards`, `PkShardBounds` — now taking a dialect-quoting closure) and the hash-modulo helpers (`shard_hash`, `plan_hash_shards`, `HashShard`) moved from the postgres/s3 reference implementations into `faucet_core::shard`, plus shared connector glue (`parse_pk_shard`, `parse_hash_shard`, `pk_bounds_query`, `pk_shards_from_bounds`). The subtle open-ended-boundary (F54/F55) and NULL-key-coverage (F37) logic now lives in exactly one tested place instead of being copied into five connectors. postgres/s3 were refactored onto the shared helpers with no behavior change (postgres's bounds probe now uses `CAST(… AS BIGINT)` instead of the equivalent `::int8`).
- **SQL sources**: identifier quoting is per-dialect — ANSI double quotes (postgres), backticks (mysql), brackets (mssql, NUL-validated at apply time so the hot path stays infallible), and **backticks for sqlite**: SQLite's double-quoted-string misfeature silently turns a typo'd key into a string literal (`MIN("typo")` → bounds of 0) instead of erroring; backtick-quoted identifiers surface a proper "no such column" error.
- **mssql**: shard bounds are computed over the `@bookmark`-bound query, so incremental replication composes (bounds cover the not-yet-synced slice). Documented: a sharded query must not end in a top-level `ORDER BY` (T-SQL forbids it inside a derived table).
- **gcs**: mirrors s3; `max_objects` caps the run's *total* object set before the shard filter so the cap keeps single-worker semantics.
- **parquet**: cross-file schema validation still runs over the **full** resolved file set on every worker, so a schema mismatch fails the run even when the mismatching files hash into different shards (otherwise each worker would see an internally-consistent subset and silently mix shapes downstream).

No serve/CLI changes needed — the coordinator and claim loop are already generic over `is_shardable` / `enumerate_shards` / `apply_shard`.

## Tests

- Core: pure-logic suites for planning, predicates (coverage property: every key incl. out-of-range and NULL matched by exactly one shard), hash partitioning, and the new glue helpers.
- **sqlite + parquet: end-to-end partition proofs without Docker** (union of shard outputs == whole dataset, incl. a NULL-key row / real parquet files).
- postgres + mysql + mssql: testcontainer partition tests (same guarantee against real servers; mssql's includes a NULL-key row). postgres + mysql verified locally via colima; the mssql container is amd64-only so its test runs in CI (the pre-existing mssql integration tests fail identically on local aarch64).
- Patch coverage (unit tests only, Docker excluded): **92.0%** by local `cargo llvm-cov` diff-intersection. Uncovered residue is GCS client construction glue and the mssql enumerate I/O shim, both exercised by the Docker integration tests.

## Docs

Cluster cookbook shardable-source table extended (the "not shardable yet, tracked in #262" note removed); `## Sharded execution (cluster Mode B)` sections added to all seven source crate READMEs (postgres/s3 had never documented it); `shard` config row added to the four SQL crates' config tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)