### PR TITLE
feat(core): data contracts — versioned output schema/constraints, enforced (#204)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,8 @@ jobs:
           # Quality checks
           - quality
           - quality-jsonschema
+          # Data contracts
+          - contract
           # OpenLineage emission
           - lineage
           - lineage-kafka

--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ cargo add faucet-stream           # the library
 - **🧩 Config-driven _or_ embeddable** — run `faucet run pipeline.yaml`, or call
   `Pipeline::new(&source, &sink).run().await?` from Rust. Same orchestration either way.
 - **⚙️ A runtime, not just connectors** — incremental + resumable replication, change-data-capture,
-  exactly-once delivery, upsert/delete write modes, data-quality checks, dead-letter queues,
-  automatic retries, adaptive batch sizing, secrets-manager interpolation, cron scheduling,
-  an HTTP control plane with event-driven triggers, OpenLineage emission, and built-in
-  Prometheus metrics + `tracing` spans — all with zero per-connector code.
+  exactly-once delivery, upsert/delete write modes, data-quality checks, data contracts,
+  dead-letter queues, automatic retries, adaptive batch sizing, secrets-manager interpolation,
+  cron scheduling, an HTTP control plane with event-driven triggers, OpenLineage emission, and
+  built-in Prometheus metrics + `tracing` spans — all with zero per-connector code.
 - **📦 Pay only for what you use** — every connector is a Cargo feature, so a slim build can
   be just REST + JSONL, or pull in all 41 connectors with `--features full`.
 
@@ -171,6 +171,7 @@ one-block addition to your YAML:
 | **Exactly-once delivery** | Monotonic per-page commit tokens committed atomically with the data (SQL sinks, Iceberg, BigQuery) — no duplicates on resume. | [state](https://pawansikawat.github.io/faucet-stream/cookbook/state.html) |
 | **Upsert / delete write modes** | `write_mode: upsert \| delete` with a `key` + `delete_marker` — merge by key on Postgres / MySQL / SQL Server / SQLite / Mongo / Elasticsearch. | [upsert](https://pawansikawat.github.io/faucet-stream/cookbook/upsert.html) |
 | **Data-quality checks** | 13 per-record and per-batch assertions (not-null, regex, ranges, uniqueness, row-count, JSON Schema, …) with quarantine routing or abort policies. | [quality](https://pawansikawat.github.io/faucet-stream/cookbook/quality.html) |
+| **Data contracts** | A versioned promise about the output shape (types, nullability, enums, patterns, bounds) enforced per page — breaches fail, quarantine, or warn; export as JSON Schema / OpenLineage via `faucet contract`. | [contracts](https://pawansikawat.github.io/faucet-stream/cookbook/contracts.html) |
 | **Dead-letter queue** | Route failed rows to any sink instead of aborting the run, with a fixed envelope and reason. | [DLQ](https://pawansikawat.github.io/faucet-stream/cookbook/dlq.html) |
 | **Adaptive batch sizing** | Opt-in AIMD controller that tunes write batch size from observed sink latency and error rate. | [tuning](https://pawansikawat.github.io/faucet-stream/) |
 | **Secrets-manager interpolation** | `${vault:…}`, `${aws-sm:…}`, `${gcp-sm:…}`, `${azure-kv:…}` resolved at load time, redacted from logs. | [secrets](https://pawansikawat.github.io/faucet-stream/cookbook/secrets.html) |
@@ -459,7 +460,8 @@ Default features: `source-rest`, `transform-flatten`, `transform-rename-keys`,
 
 `RecordTransform::Custom` is always available regardless of feature flags. CLI-only features
 (`schedule`, `serve`, `serve-ui`, `serve-history-*`, `triggers*`, `lineage`, `quality`,
-`secrets-*`) live in `faucet-cli`, not the umbrella crate — see [`cli/README.md`](cli/README.md).
+`contract`, `secrets-*`) live in `faucet-cli`, not the umbrella crate — see
+[`cli/README.md`](cli/README.md).
 
 </details>
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/main.rs"
 # `serve` (HTTP control plane; links a web-server dependency tree and opens a
 # network listener). Opt in with `--features schedule` / `--features serve`, or
 # take everything with `--features full`.
-default = ["observability", "source", "sink", "state", "transforms", "compression", "quality"]
+default = ["observability", "source", "sink", "state", "transforms", "compression", "quality", "contract"]
 
 # Everything the default build ships, plus the long-running runtime modes:
 # `schedule` (cron scheduler) and `serve` (HTTP control plane).
@@ -33,6 +33,11 @@ full = ["default", "otel", "schedule", "serve", "serve-ui", "serve-history-postg
 # `faucet-core`.
 quality = ["faucet-core/quality"]
 quality-jsonschema = ["quality", "faucet-core/quality-jsonschema"]
+
+# Data contracts (`contract:` config block + `faucet contract` verb, #204):
+# a versioned output schema/constraint promise enforced per page. Forwarded
+# to `faucet-core`.
+contract = ["faucet-core/contract"]
 
 source = [
     "source-rest",

--- a/cli/README.md
+++ b/cli/README.md
@@ -34,6 +34,7 @@ cargo install faucet-cli --no-default-features \
 | `faucet preview <config> --limit N` | Run only the source side and emit the first N records to stdout as JSONL. |
 | `faucet init [name] [--source X] [--sink Y]` | Scaffold a pipeline.yaml from each connector's JSON Schema. |
 | `faucet doctor <config> [--timeout-secs N] [--json]` | Probe every connector (auth/network/permissions/reachability) and print a checklist. Exits with the failed-probe count. |
+| `faucet contract <config> [--export contract\|json-schema\|openlineage]` | Validate the `pipeline.contract:` block and print a summary, or export the data contract as canonical JSON / JSON Schema / an OpenLineage schema facet. `faucet schema contract` prints the block's own JSON Schema. |
 | `faucet schedule <config> [--once]` | Run a pipeline on a cron schedule (long-running foreground process). Requires a `schedule:` block. |
 
 Pass `--log-level debug` (or set `FAUCET_LOG=debug`) for verbose tracing. Logs are written to stderr; pipeline records and command output go to stdout.
@@ -720,6 +721,32 @@ pipeline:
     max_failures_per_page: 100
     max_failures_total: 10000
 ```
+
+### `contract:` (optional)
+
+Sibling of `source`, `sink`, `transforms`, `state` under `pipeline:` — a
+versioned **data contract** for the pipeline's output (required fields, types,
+nullability, enum sets, patterns, numeric/length bounds), enforced per page
+after transforms and quality checks. `on_breach: fail` (default) aborts the
+run on the first breach; `quarantine` routes breaching records to the DLQ
+(requires a `dlq:` block, validated at load time); `warn` logs + counts but
+writes everything. Requires the `contract` feature (in the default build).
+
+```yaml
+pipeline:
+  contract:
+    version: "1.0.0"
+    on_breach: quarantine
+    fields:
+      - { name: order_id, type: string, min_length: 1 }
+      - { name: status, type: string, enum: [open, shipped, cancelled] }
+      - { name: amount, type: number, min: 0, required: false, nullable: true }
+```
+
+Inspect or publish it with `faucet contract <config> [--export
+contract|json-schema|openlineage]`; `faucet schema contract` prints the
+block's JSON Schema. Full model:
+[Data contracts](https://pawansikawat.github.io/faucet-stream/cookbook/contracts.html).
 
 ### Transforms
 

--- a/cli/examples/csv_to_jsonl_with_contract.yaml
+++ b/cli/examples/csv_to_jsonl_with_contract.yaml
@@ -1,0 +1,56 @@
+# CSV → JSONL guarded by a data contract (issue #204).
+#
+# The `contract:` block is a versioned promise about the pipeline's *output*
+# shape: required fields, types, nullability, enum sets, regex patterns, and
+# numeric/length bounds. It is enforced per page after transforms and quality
+# checks and before the sink write. `on_breach` picks the enforcement policy:
+#
+#   fail       — abort the run on the first breach (default; nothing from the
+#                breaching page is written)
+#   quarantine — route breaching records to the DLQ, write the rest
+#   warn       — log + count breaches, write everything unchanged
+#
+# Inspect or publish the contract with the CLI:
+#   faucet contract cli/examples/csv_to_jsonl_with_contract.yaml
+#   faucet contract cli/examples/csv_to_jsonl_with_contract.yaml --export json-schema
+#   faucet contract cli/examples/csv_to_jsonl_with_contract.yaml --export openlineage
+version: 1
+name: orders_csv_with_contract
+
+pipeline:
+  source:
+    type: csv
+    config:
+      path: ./orders.csv
+
+  contract:
+    version: "1.0.0"
+    description: Orders exported for the analytics team.
+    owner: data-platform
+    on_breach: quarantine
+    allow_extra_fields: true
+    fields:
+      - name: order_id
+        type: string
+        min_length: 1
+        description: Unique order identifier.
+      - name: status
+        type: string
+        enum: [open, shipped, cancelled]
+        description: Order lifecycle state.
+      - name: customer_email
+        type: string
+        pattern: '^[^@\s]+@[^@\s]+\.[^@\s]+$'
+        required: false
+        nullable: true
+
+  dlq:
+    sink:
+      type: jsonl
+      config:
+        path: ./dlq/contract_breaches.jsonl
+
+  sink:
+    type: jsonl
+    config:
+      path: ./orders_out.jsonl

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -37,6 +37,10 @@ pub enum Command {
     /// Probe every connector in a config (auth / network / permissions) and
     /// print a green/red checklist. Exits non-zero if any probe fails.
     Doctor(DoctorArgs),
+    /// Validate a config's `contract:` block and print a summary, or export
+    /// it in a machine-readable format (`--export`).
+    #[cfg(feature = "contract")]
+    Contract(ContractArgs),
     /// Run a pipeline on a cron schedule (long-running; Ctrl-C / SIGTERM to stop).
     #[cfg(feature = "schedule")]
     Schedule(ScheduleArgs),
@@ -68,6 +72,44 @@ pub struct DoctorArgs {
     /// it over the composed base. Overrides the `FAUCET_PROFILE` env var.
     #[arg(long, env = "FAUCET_PROFILE")]
     pub profile: Option<String>,
+}
+
+/// `faucet contract` arguments.
+#[cfg(feature = "contract")]
+#[derive(Debug, Parser)]
+pub struct ContractArgs {
+    /// Path to a `.yaml`, `.yml`, or `.json` pipeline config with a
+    /// `pipeline.contract:` block. If omitted, auto-discover
+    /// `faucet.yaml` / `faucet.yml` / `faucet.json` in cwd.
+    pub config: Option<PathBuf>,
+    /// Path to a `.env` file to load for `${env:VAR}` interpolation.
+    /// Defaults to `.env` in cwd if present.
+    #[arg(long, conflicts_with = "no_env_file")]
+    pub env_file: Option<PathBuf>,
+    /// Skip auto-loading `.env` from cwd.
+    #[arg(long)]
+    pub no_env_file: bool,
+    /// Select a named overlay from the config's `profiles:` block and deep-merge
+    /// it over the composed base. Overrides the `FAUCET_PROFILE` env var.
+    #[arg(long, env = "FAUCET_PROFILE")]
+    pub profile: Option<String>,
+    /// Export the contract in a machine-readable format instead of the
+    /// human summary: the canonical contract JSON, a standalone JSON Schema,
+    /// or an OpenLineage schema facet.
+    #[arg(long, value_enum)]
+    pub export: Option<ContractExportFormat>,
+}
+
+/// Export format for `faucet contract --export`.
+#[cfg(feature = "contract")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum ContractExportFormat {
+    /// The canonical contract document as JSON.
+    Contract,
+    /// A standalone JSON Schema (draft 2020-12) for the promised records.
+    JsonSchema,
+    /// An OpenLineage `SchemaDatasetFacet` JSON document.
+    Openlineage,
 }
 
 /// `faucet schedule` arguments.
@@ -305,6 +347,9 @@ pub enum SchemaTarget {
     /// JSON Schema for the `quality:` block.
     #[cfg(feature = "quality")]
     Quality,
+    /// JSON Schema for the `contract:` block.
+    #[cfg(feature = "contract")]
+    Contract,
     /// Grammar reference for secrets-manager interpolation directives.
     Secrets,
     /// JSON Schema for the `schedule:` block.

--- a/cli/src/commands/contract.rs
+++ b/cli/src/commands/contract.rs
@@ -1,0 +1,191 @@
+//! `faucet contract` — validate a config's `contract:` block and print a
+//! human summary, or export it in a machine-readable format (`--export
+//! contract | json-schema | openlineage`). Offline-safe: secrets are never
+//! fetched (a contract holds no credentials).
+
+use crate::cli::{ContractArgs, ContractExportFormat};
+use crate::config::PipelineConfig;
+use crate::error::{CliError, CliResult};
+use faucet_core::contract::{CompiledContract, ContractSpec, to_json_schema, to_openlineage_facet};
+
+/// Producer identifier embedded in the OpenLineage export.
+const PRODUCER: &str = concat!(
+    "https://github.com/PawanSikawat/faucet-stream/tree/v",
+    env!("CARGO_PKG_VERSION")
+);
+
+/// Execute the `contract` subcommand.
+pub async fn run(args: ContractArgs) -> CliResult<()> {
+    let cwd = std::env::current_dir()?;
+    let env_path =
+        crate::env_loader::resolve_env_file(args.env_file.as_deref(), args.no_env_file, &cwd)?;
+    crate::env_loader::load_env_file_if_present(env_path.as_deref())?;
+
+    let path = match args.config {
+        Some(p) => p,
+        None => crate::env_loader::discover_config_path(&cwd).ok_or(CliError::NoConfigOrFromEnv)?,
+    };
+    let cfg = PipelineConfig::from_path_tolerating_secrets(&path, args.profile.as_deref())?;
+    let spec = cfg.pipeline.contract.as_ref().ok_or_else(|| {
+        CliError::Config(
+            "no `pipeline.contract:` block in this config — add one, or run \
+             `faucet schema contract` to see the block's JSON Schema"
+                .to_string(),
+        )
+    })?;
+    // Compile first so a malformed contract fails before anything is printed.
+    let compiled =
+        CompiledContract::compile(spec).map_err(|e| CliError::Config(format!("contract: {e}")))?;
+
+    match args.export {
+        None => print!("{}", render_summary(spec, &compiled)),
+        Some(format) => {
+            let doc = export(spec, format);
+            let body = serde_json::to_string_pretty(&doc).unwrap_or_else(|_| doc.to_string());
+            println!("{body}");
+        }
+    }
+    Ok(())
+}
+
+/// Render the exported document for the requested format. Pure.
+pub fn export(spec: &ContractSpec, format: ContractExportFormat) -> serde_json::Value {
+    match format {
+        ContractExportFormat::Contract => {
+            serde_json::to_value(spec).unwrap_or_else(|_| serde_json::json!({}))
+        }
+        ContractExportFormat::JsonSchema => to_json_schema(spec),
+        ContractExportFormat::Openlineage => to_openlineage_facet(spec, PRODUCER),
+    }
+}
+
+/// Render the human summary. Pure — returned as a string for testability.
+fn render_summary(spec: &ContractSpec, compiled: &CompiledContract) -> String {
+    use std::fmt::Write;
+    let mut out = String::new();
+    let _ = writeln!(
+        out,
+        "contract v{} — valid ({} field{})",
+        spec.version,
+        spec.fields.len(),
+        if spec.fields.len() == 1 { "" } else { "s" }
+    );
+    if let Some(d) = &spec.description {
+        let _ = writeln!(out, "  description: {d}");
+    }
+    if let Some(o) = &spec.owner {
+        let _ = writeln!(out, "  owner: {o}");
+    }
+    let _ = writeln!(out, "  on_breach: {}", spec.on_breach);
+    let _ = writeln!(out, "  allow_extra_fields: {}", spec.allow_extra_fields);
+    let _ = writeln!(out, "  fields:");
+    for f in &spec.fields {
+        let mut flags: Vec<String> = Vec::new();
+        if !f.required {
+            flags.push("optional".into());
+        }
+        if f.nullable {
+            flags.push("nullable".into());
+        }
+        if let Some(values) = &f.allowed_values {
+            flags.push(format!("enum[{}]", values.len()));
+        }
+        if f.pattern.is_some() {
+            flags.push("pattern".into());
+        }
+        if f.min.is_some() || f.max.is_some() {
+            flags.push("range".into());
+        }
+        if f.min_length.is_some() || f.max_length.is_some() {
+            flags.push("length".into());
+        }
+        let suffix = if flags.is_empty() {
+            String::new()
+        } else {
+            format!(" ({})", flags.join(", "))
+        };
+        let _ = writeln!(out, "    - {}: {}{}", f.name, f.field_type, suffix);
+    }
+    if compiled.requires_dlq() {
+        let _ = writeln!(
+            out,
+            "  note: on_breach=quarantine requires a `dlq:` block at run time"
+        );
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn spec() -> ContractSpec {
+        serde_json::from_value(json!({
+            "version": "1.2.0",
+            "owner": "data-platform",
+            "on_breach": "quarantine",
+            "allow_extra_fields": false,
+            "fields": [
+                { "name": "id", "type": "integer", "min": 0 },
+                { "name": "status", "type": "string", "enum": ["a", "b"],
+                  "required": false, "nullable": true }
+            ]
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn summary_lists_fields_policy_and_dlq_note() {
+        let s = spec();
+        let compiled = CompiledContract::compile(&s).unwrap();
+        let out = render_summary(&s, &compiled);
+        assert!(out.contains("contract v1.2.0 — valid (2 fields)"), "{out}");
+        assert!(out.contains("owner: data-platform"), "{out}");
+        assert!(out.contains("on_breach: quarantine"), "{out}");
+        assert!(out.contains("allow_extra_fields: false"), "{out}");
+        assert!(out.contains("- id: integer (range)"), "{out}");
+        assert!(
+            out.contains("- status: string (optional, nullable, enum[2])"),
+            "{out}"
+        );
+        assert!(out.contains("requires a `dlq:` block"), "{out}");
+    }
+
+    #[test]
+    fn summary_omits_dlq_note_for_fail() {
+        let s: ContractSpec = serde_json::from_value(json!({
+            "version": "1",
+            "fields": [{ "name": "id", "type": "string" }]
+        }))
+        .unwrap();
+        let compiled = CompiledContract::compile(&s).unwrap();
+        let out = render_summary(&s, &compiled);
+        assert!(out.contains("(1 field)"), "{out}");
+        assert!(!out.contains("dlq"), "{out}");
+    }
+
+    #[test]
+    fn export_contract_round_trips_the_spec() {
+        let doc = export(&spec(), ContractExportFormat::Contract);
+        let back: ContractSpec = serde_json::from_value(doc).unwrap();
+        assert_eq!(back.version, "1.2.0");
+        assert_eq!(back.fields.len(), 2);
+    }
+
+    #[test]
+    fn export_json_schema_is_a_schema_document() {
+        let doc = export(&spec(), ContractExportFormat::JsonSchema);
+        assert_eq!(doc["x-faucet-contract-version"], "1.2.0");
+        assert_eq!(doc["type"], "object");
+        assert_eq!(doc["additionalProperties"], false);
+        assert!(doc["properties"]["id"].is_object());
+    }
+
+    #[test]
+    fn export_openlineage_is_a_schema_facet() {
+        let doc = export(&spec(), ContractExportFormat::Openlineage);
+        assert!(doc["_producer"].as_str().unwrap().contains("faucet-stream"));
+        assert_eq!(doc["fields"].as_array().unwrap().len(), 2);
+    }
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,6 +1,8 @@
 //! Subcommand implementations. Each module owns its `run(...)` entry point
 //! and stays free of clap so the integration tests can drive it directly.
 
+#[cfg(feature = "contract")]
+pub mod contract;
 pub mod doctor;
 pub mod init;
 pub mod list;

--- a/cli/src/commands/schema.rs
+++ b/cli/src/commands/schema.rs
@@ -34,6 +34,12 @@ pub async fn run(args: SchemaArgs) -> CliResult<()> {
             serde_json::to_value(quality_schema)
                 .unwrap_or_else(|_| serde_json::json!({"type": "object"}))
         }
+        #[cfg(feature = "contract")]
+        SchemaTarget::Contract => {
+            let contract_schema = faucet_core::schema_for!(faucet_core::ContractSpec);
+            serde_json::to_value(contract_schema)
+                .unwrap_or_else(|_| serde_json::json!({"type": "object"}))
+        }
         #[cfg(feature = "schedule")]
         SchemaTarget::Schedule => {
             let s = faucet_core::schema_for!(crate::schedule::spec::ScheduleSpec);

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -150,6 +150,13 @@ pub struct PipelineSpec {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub quality: Option<faucet_core::QualitySpec>,
 
+    /// Data contract (pipeline-level; no matrix-row override in v1): a
+    /// versioned output schema/constraint promise enforced per page after
+    /// transforms and quality checks (#204). See `faucet schema contract`.
+    #[cfg(feature = "contract")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub contract: Option<faucet_core::ContractSpec>,
+
     /// Schema-drift handling policy (pipeline-level; no matrix-row override in v1).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub schema: Option<faucet_core::SchemaDriftSpec>,
@@ -1213,6 +1220,28 @@ pipeline:
         let cfg = parse_with_extension(yaml, "yaml").unwrap();
         let q = cfg.pipeline.quality.expect("quality parsed");
         assert_eq!(q.record.len(), 1);
+    }
+
+    #[cfg(feature = "contract")]
+    #[test]
+    fn parses_contract_block() {
+        let yaml = r#"
+version: 1
+pipeline:
+  source: { type: rest, config: { url: "https://x" } }
+  contract:
+    version: "1.0.0"
+    on_breach: warn
+    fields:
+      - { name: id, type: integer }
+      - { name: status, type: string, enum: [open, closed] }
+  sink: { type: stdout, config: {} }
+"#;
+        let cfg = parse_with_extension(yaml, "yaml").unwrap();
+        let c = cfg.pipeline.contract.expect("contract parsed");
+        assert_eq!(c.version, "1.0.0");
+        assert_eq!(c.on_breach, faucet_core::OnBreach::Warn);
+        assert_eq!(c.fields.len(), 2);
     }
 
     #[test]

--- a/cli/src/env_config.rs
+++ b/cli/src/env_config.rs
@@ -317,6 +317,8 @@ pub fn build_pipeline_config(env: &HashMap<String, String>) -> CliResult<Pipelin
             dlq: None,
             #[cfg(feature = "quality")]
             quality: None,
+            #[cfg(feature = "contract")]
+            contract: None,
             schema: None,
         },
         matrix: Vec::new(),

--- a/cli/src/executor.rs
+++ b/cli/src/executor.rs
@@ -911,6 +911,19 @@ async fn run_one_invocation(
     } else {
         pipeline
     };
+    // Pipeline-level data contract (v1: no matrix-row override). `expand`
+    // already validated the spec; compile again here to obtain the runtime
+    // `CompiledContract`.
+    #[cfg(feature = "contract")]
+    let pipeline = if let Some(ref contract_spec) = node.contract {
+        let compiled = Arc::new(
+            faucet_core::CompiledContract::compile(contract_spec)
+                .map_err(|e| CliError::Config(format!("contract: {e}")))?,
+        );
+        pipeline.with_contract(compiled)
+    } else {
+        pipeline
+    };
     // Schema-drift policy (pipeline-level in v1; same for every invocation).
     let pipeline = if let Some(ref sd) = node.schema {
         pipeline.with_schema_drift(faucet_core::SchemaDriftPolicy::compile(sd))
@@ -1341,6 +1354,8 @@ mod tests {
                 dlq: None,
                 #[cfg(feature = "quality")]
                 quality: None,
+                #[cfg(feature = "contract")]
+                contract: None,
                 schema: None,
             },
             matrix: Vec::new(),
@@ -1960,6 +1975,8 @@ matrix:
                 delivery: faucet_core::DeliveryMode::AtLeastOnce,
                 #[cfg(feature = "quality")]
                 quality: None,
+                #[cfg(feature = "contract")]
+                contract: None,
                 schema: None,
                 deferred_refs: refs
                     .iter()
@@ -2023,6 +2040,8 @@ matrix:
             delivery: faucet_core::DeliveryMode::AtLeastOnce,
             #[cfg(feature = "quality")]
             quality: None,
+            #[cfg(feature = "contract")]
+            contract: None,
             schema: None,
             deferred_refs: vec![DeferredRef {
                 referenced_id: "p".into(),
@@ -2269,6 +2288,8 @@ matrix:
             delivery: faucet_core::DeliveryMode::AtLeastOnce,
             #[cfg(feature = "quality")]
             quality: None,
+            #[cfg(feature = "contract")]
+            contract: None,
             schema: None,
             deferred_refs: Vec::new(),
         }
@@ -2335,6 +2356,8 @@ matrix:
             delivery: faucet_core::DeliveryMode::AtLeastOnce,
             #[cfg(feature = "quality")]
             quality: None,
+            #[cfg(feature = "contract")]
+            contract: None,
             schema: None,
             deferred_refs: Vec::new(),
         };

--- a/cli/src/expand.rs
+++ b/cli/src/expand.rs
@@ -42,6 +42,10 @@ pub struct ExpandedNode {
     /// matrix-row override in v1, so this is `cfg.pipeline.quality` verbatim.
     #[cfg(feature = "quality")]
     pub quality: Option<faucet_core::QualitySpec>,
+    /// Pipeline-level data contract, shared by every node (`contract:` has no
+    /// matrix-row override in v1) — `cfg.pipeline.contract` verbatim.
+    #[cfg(feature = "contract")]
+    pub contract: Option<faucet_core::ContractSpec>,
     /// Compiled schema-drift policy spec (pipeline-level; same for every node).
     pub schema: Option<faucet_core::SchemaDriftSpec>,
     /// Delivery guarantee for this row. Resolved from the row's override or
@@ -421,6 +425,25 @@ pub fn expand(cfg: &PipelineConfig) -> CliResult<Vec<ExpandedNode>> {
             }
         }
 
+        // `contract:` is pipeline-level only in v1 (like `quality:`). Compile
+        // it once per node so a malformed contract (bad regex, duplicate
+        // fields, misplaced constraints) surfaces at expand time, and fail
+        // fast when `on_breach: quarantine` has no DLQ to route to.
+        #[cfg(feature = "contract")]
+        let contract = cfg.pipeline.contract.clone();
+        #[cfg(feature = "contract")]
+        if let Some(ref spec) = contract {
+            let compiled = faucet_core::CompiledContract::compile(spec)
+                .map_err(|e| CliError::Config(format!("contract (row `{row_id}`): {e}")))?;
+            if compiled.requires_dlq() && dlq.is_none() {
+                return Err(CliError::Config(format!(
+                    "row `{row_id}`: the contract uses `on_breach: quarantine` \
+                     but no DLQ is configured — add a `dlq:` block (or change \
+                     `on_breach` to `fail` or `warn`)"
+                )));
+            }
+        }
+
         // Exactly-once delivery gate: enforce source, sink, state, and DLQ
         // compatibility at config-load time so `faucet validate` catches
         // unsupported combinations before any run starts.
@@ -579,6 +602,8 @@ pub fn expand(cfg: &PipelineConfig) -> CliResult<Vec<ExpandedNode>> {
             delivery,
             #[cfg(feature = "quality")]
             quality,
+            #[cfg(feature = "contract")]
+            contract,
             schema: cfg.pipeline.schema.clone(),
             deferred_refs: deferred,
         });
@@ -1113,6 +1138,99 @@ pipeline:
         let cfg = parse_with_extension(yaml, "yaml").unwrap();
         let nodes = expand(&cfg).unwrap();
         assert!(nodes[0].quality.is_some());
+    }
+
+    #[cfg(feature = "contract")]
+    #[test]
+    fn expand_rejects_contract_quarantine_without_dlq() {
+        let yaml = r#"
+version: 1
+pipeline:
+  source: { type: rest, config: {} }
+  sink:   { type: jsonl, config: { path: ./o.jsonl } }
+  contract:
+    version: "1.0.0"
+    on_breach: quarantine
+    fields:
+      - { name: id, type: integer }
+"#;
+        let cfg = parse_with_extension(yaml, "yaml").unwrap();
+        let err = expand(&cfg).unwrap_err();
+        match err {
+            CliError::Config(msg) => {
+                assert!(msg.contains("on_breach: quarantine"), "{msg}");
+                assert!(msg.contains("dlq"), "{msg}");
+            }
+            other => panic!("expected Config error, got {other:?}"),
+        }
+    }
+
+    #[cfg(feature = "contract")]
+    #[test]
+    fn expand_accepts_contract_quarantine_with_dlq() {
+        let yaml = r#"
+version: 1
+pipeline:
+  source: { type: rest, config: {} }
+  sink:   { type: jsonl, config: { path: ./o.jsonl } }
+  dlq:
+    sink: { type: jsonl, config: { path: ./dlq.jsonl } }
+  contract:
+    version: "1.0.0"
+    on_breach: quarantine
+    fields:
+      - { name: id, type: integer }
+"#;
+        let cfg = parse_with_extension(yaml, "yaml").unwrap();
+        let nodes = expand(&cfg).unwrap();
+        assert_eq!(nodes.len(), 1);
+        let c = nodes[0]
+            .contract
+            .as_ref()
+            .expect("contract threaded onto node");
+        assert_eq!(c.version, "1.0.0");
+        assert_eq!(c.fields.len(), 1);
+    }
+
+    #[cfg(feature = "contract")]
+    #[test]
+    fn expand_accepts_contract_fail_without_dlq() {
+        // `on_breach: fail` (the default) does not route to a DLQ.
+        let yaml = r#"
+version: 1
+pipeline:
+  source: { type: rest, config: {} }
+  sink:   { type: jsonl, config: { path: ./o.jsonl } }
+  contract:
+    version: "1.0.0"
+    fields:
+      - { name: id, type: integer }
+"#;
+        let cfg = parse_with_extension(yaml, "yaml").unwrap();
+        let nodes = expand(&cfg).unwrap();
+        assert!(nodes[0].contract.is_some());
+    }
+
+    #[cfg(feature = "contract")]
+    #[test]
+    fn expand_rejects_malformed_contract() {
+        // A bad regex must surface at expand time (load-time), not mid-run.
+        let yaml = r#"
+version: 1
+pipeline:
+  source: { type: rest, config: {} }
+  sink:   { type: jsonl, config: { path: ./o.jsonl } }
+  contract:
+    version: "1.0.0"
+    fields:
+      - { name: email, type: string, pattern: "[invalid" }
+"#;
+        let cfg = parse_with_extension(yaml, "yaml").unwrap();
+        let err = expand(&cfg).unwrap_err();
+        match err {
+            CliError::Config(msg) => assert!(msg.contains("invalid pattern"), "{msg}"),
+            other => panic!("expected Config error, got {other:?}"),
+        }
     }
 
     #[test]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -29,6 +29,8 @@ async fn main() {
         Command::Preview(args) => commands::preview::run(args).await,
         Command::Init(args) => commands::init::run(args).await,
         Command::Doctor(args) => commands::doctor::run(args).await,
+        #[cfg(feature = "contract")]
+        Command::Contract(args) => commands::contract::run(args).await,
         #[cfg(feature = "schedule")]
         Command::Schedule(args) => commands::schedule::run(args).await,
         #[cfg(feature = "serve")]

--- a/cli/tests/cli_end_to_end.rs
+++ b/cli/tests/cli_end_to_end.rs
@@ -980,3 +980,225 @@ fn init_output_loads_and_expands() {
         nodes[0].source.config
     );
 }
+
+/// Helper: a csv→jsonl config with a `contract:` block and (optionally) a DLQ.
+#[cfg(feature = "contract")]
+fn contract_yaml(csv: &Path, out: &Path, dlq: Option<&Path>, on_breach: &str) -> String {
+    let dlq_block = match dlq {
+        Some(p) => format!(
+            "  dlq:\n    sink: {{ type: jsonl, config: {{ path: {} }} }}\n",
+            p.display()
+        ),
+        None => String::new(),
+    };
+    format!(
+        r#"version: 1
+name: csv_contract
+pipeline:
+  source:
+    type: csv
+    config:
+      path: {csv}
+  sink:
+    type: jsonl
+    config:
+      path: {out}
+{dlq_block}  contract:
+    version: "1.0.0"
+    on_breach: {on_breach}
+    fields:
+      - {{ name: name, type: string }}
+      - {{ name: status, type: string, enum: [open, closed] }}
+"#,
+        csv = csv.display(),
+        out = out.display(),
+    )
+}
+
+#[cfg(feature = "contract")]
+#[test]
+fn run_with_contract_quarantine_routes_breaches_to_dlq() {
+    let dir = TempDir::new().unwrap();
+    let csv = dir.path().join("in.csv");
+    let out = dir.path().join("out.jsonl");
+    let dlq = dir.path().join("dlq.jsonl");
+    fs::write(&csv, "name,status\nalice,open\nbob,bogus\n").unwrap();
+
+    let cfg = dir.path().join("pipeline.yaml");
+    fs::write(&cfg, contract_yaml(&csv, &out, Some(&dlq), "quarantine")).unwrap();
+
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["run"])
+        .arg(&cfg)
+        .assert()
+        .success()
+        .stdout(contains("wrote 1 record"));
+
+    let out_body = fs::read_to_string(&out).unwrap();
+    assert!(out_body.contains("\"alice\""), "{out_body}");
+    assert!(!out_body.contains("\"bob\""), "{out_body}");
+    let dlq_body = fs::read_to_string(&dlq).unwrap();
+    assert!(dlq_body.contains("ContractViolation"), "{dlq_body}");
+    assert!(dlq_body.contains("\"bob\""), "{dlq_body}");
+    assert!(dlq_body.contains("1.0.0"), "{dlq_body}");
+}
+
+#[cfg(feature = "contract")]
+#[test]
+fn run_with_contract_fail_aborts_run() {
+    let dir = TempDir::new().unwrap();
+    let csv = dir.path().join("in.csv");
+    let out = dir.path().join("out.jsonl");
+    fs::write(&csv, "name,status\nalice,open\nbob,bogus\n").unwrap();
+
+    let cfg = dir.path().join("pipeline.yaml");
+    fs::write(&cfg, contract_yaml(&csv, &out, None, "fail")).unwrap();
+
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["run"])
+        .arg(&cfg)
+        .assert()
+        .failure()
+        .stderr(contains("Contract v1.0.0 violated"))
+        .stderr(contains("status"));
+}
+
+#[cfg(feature = "contract")]
+#[test]
+fn run_with_contract_warn_writes_everything() {
+    let dir = TempDir::new().unwrap();
+    let csv = dir.path().join("in.csv");
+    let out = dir.path().join("out.jsonl");
+    fs::write(&csv, "name,status\nalice,open\nbob,bogus\n").unwrap();
+
+    let cfg = dir.path().join("pipeline.yaml");
+    fs::write(&cfg, contract_yaml(&csv, &out, None, "warn")).unwrap();
+
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["run"])
+        .arg(&cfg)
+        .assert()
+        .success()
+        .stdout(contains("wrote 2 records"));
+
+    let out_body = fs::read_to_string(&out).unwrap();
+    assert!(
+        out_body.contains("\"bob\""),
+        "warn must write breaching records"
+    );
+}
+
+#[cfg(feature = "contract")]
+#[test]
+fn validate_rejects_contract_quarantine_without_dlq() {
+    let dir = TempDir::new().unwrap();
+    let csv = dir.path().join("in.csv");
+    let out = dir.path().join("out.jsonl");
+    let cfg = dir.path().join("pipeline.yaml");
+    fs::write(&cfg, contract_yaml(&csv, &out, None, "quarantine")).unwrap();
+
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["validate"])
+        .arg(&cfg)
+        .assert()
+        .failure()
+        .stderr(contains("on_breach: quarantine"))
+        .stderr(contains("dlq"));
+}
+
+#[cfg(feature = "contract")]
+#[test]
+fn contract_command_prints_summary() {
+    let dir = TempDir::new().unwrap();
+    let csv = dir.path().join("in.csv");
+    let out = dir.path().join("out.jsonl");
+    let cfg = dir.path().join("pipeline.yaml");
+    fs::write(&cfg, contract_yaml(&csv, &out, None, "warn")).unwrap();
+
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["contract"])
+        .arg(&cfg)
+        .assert()
+        .success()
+        .stdout(contains("contract v1.0.0 — valid (2 fields)"))
+        .stdout(contains("on_breach: warn"))
+        .stdout(contains("- status: string (enum[2])"));
+}
+
+#[cfg(feature = "contract")]
+#[test]
+fn contract_command_exports_json_schema_and_openlineage() {
+    let dir = TempDir::new().unwrap();
+    let csv = dir.path().join("in.csv");
+    let out = dir.path().join("out.jsonl");
+    let cfg = dir.path().join("pipeline.yaml");
+    fs::write(&cfg, contract_yaml(&csv, &out, None, "warn")).unwrap();
+
+    let assert = Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["contract"])
+        .arg(&cfg)
+        .args(["--export", "json-schema"])
+        .assert()
+        .success();
+    let schema: serde_json::Value =
+        serde_json::from_slice(&assert.get_output().stdout).expect("valid JSON schema output");
+    assert_eq!(schema["x-faucet-contract-version"], "1.0.0");
+    assert_eq!(schema["type"], "object");
+    assert_eq!(schema["required"], serde_json::json!(["name", "status"]));
+
+    let assert = Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["contract"])
+        .arg(&cfg)
+        .args(["--export", "openlineage"])
+        .assert()
+        .success();
+    let facet: serde_json::Value =
+        serde_json::from_slice(&assert.get_output().stdout).expect("valid OL facet output");
+    assert!(
+        facet["_schemaURL"]
+            .as_str()
+            .unwrap()
+            .contains("SchemaDatasetFacet")
+    );
+    assert_eq!(facet["fields"].as_array().unwrap().len(), 2);
+}
+
+#[cfg(feature = "contract")]
+#[test]
+fn contract_command_errors_without_contract_block() {
+    let dir = TempDir::new().unwrap();
+    let csv = dir.path().join("in.csv");
+    let out = dir.path().join("out.jsonl");
+    let cfg = dir.path().join("pipeline.yaml");
+    fs::write(&cfg, csv_to_jsonl_yaml(&csv, &out)).unwrap();
+
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["contract"])
+        .arg(&cfg)
+        .assert()
+        .failure()
+        .stderr(contains("no `pipeline.contract:` block"));
+}
+
+#[cfg(feature = "contract")]
+#[test]
+fn schema_contract_prints_contract_spec_schema() {
+    let assert = Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["schema", "contract"])
+        .assert()
+        .success();
+    let schema: serde_json::Value =
+        serde_json::from_slice(&assert.get_output().stdout).expect("valid JSON output");
+    assert!(schema["properties"].get("version").is_some());
+    assert!(schema["properties"].get("fields").is_some());
+    assert!(schema["properties"].get("on_breach").is_some());
+}

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -60,6 +60,9 @@ otel = [
 compression = ["dep:async-compression", "dep:flate2", "dep:zstd"]
 quality = ["dep:regex"]
 quality-jsonschema = ["quality", "dep:jsonschema"]
+# Data contracts (`contract:` config block, issue #204): a versioned output
+# schema/constraint promise enforced per page with fail/quarantine/warn.
+contract = ["dep:regex"]
 
 [dependencies]
 serde.workspace = true

--- a/crates/core/README.md
+++ b/crates/core/README.md
@@ -15,7 +15,7 @@ The foundation crate for the [faucet-stream](https://github.com/PawanSikawat/fau
 - **Batch and streaming orchestration** — `Pipeline::run` (fetch-all) and `run_stream` (page-by-page, O(batch_size) memory) connect any source to any sink.
 - **Pluggable transforms** — `RecordTransform` (flatten, key/value casing, regex rename, cast, redact, …) plus stage-level `Filter` / `Explode` / `CdcUnwrap`, attachable to any source via `TransformingSource`.
 - **Durable bookmarks** — the `StateStore` trait with in-process `MemoryStateStore` and crash-safe `FileStateStore` built in; Redis / Postgres backends live in their own crates.
-- **Reliability primitives** — dead-letter queue routing, exactly-once delivery (`DeliveryMode`), key-based upsert/delete write modes, and per-page / per-record data-quality checks.
+- **Reliability primitives** — dead-letter queue routing, exactly-once delivery (`DeliveryMode`), key-based upsert/delete write modes, per-page / per-record data-quality checks, and versioned data contracts.
 - **Shared authentication** — the `AuthProvider` trait and `AuthSpec` config field give N connectors one token with single-flight refresh.
 - **Typed errors** — one `FaucetError` enum covers every failure path, with a `Custom` variant for third-party connector errors.
 - **Built-in observability** — pipelines emit `tracing` spans and `metrics` counters/histograms automatically; connectors only override `connector_name()` for a friendly label.
@@ -163,6 +163,7 @@ let result = Pipeline::new(&source, &sink)
     .with_state_store(state_store)   // durable bookmarks
     .with_dlq(dlq_config)            // dead-letter routing
     .with_quality(compiled_quality)  // per-page data-quality checks
+    .with_contract(compiled_contract) // versioned data contract (contract feature)
     .with_cancel(CancellationToken::new()) // flush-completing cooperative cancel
     .run()
     .await?;
@@ -231,6 +232,7 @@ let wrapped = TransformingSource::new(source, stages);
 | `Source(String)` | Source-specific errors |
 | `Sink(String)` | Sink-specific errors |
 | `QualityFailure { check, message }` | A quality check failed under `abort` |
+| `ContractViolation { version, message }` | A record breached the data contract under `on_breach: fail` |
 | `State(String)` | State-store read/write/delete failures |
 | `Custom(Box<dyn Error + Send + Sync>)` | Wrap any third-party connector error |
 
@@ -381,6 +383,49 @@ let result = Pipeline::new(&source, &sink)
     .await?;
 ```
 
+## Data contracts
+
+A `contract:` block (the `contract` Cargo feature) declares a **versioned
+promise** about the pipeline's output — required fields, types, nullability,
+enum sets, regex patterns, numeric/length bounds — enforced per page after the
+quality pass and before the sink write. The contract-level `on_breach` policy
+picks the enforcement: `fail` (default — abort on the first breach, writing
+nothing from the page), `quarantine` (route breaching records to the DLQ,
+write the rest), or `warn` (log + count, write everything). Compilation is
+fail-fast: a malformed contract (bad regex, duplicate fields, constraints on
+the wrong type) is a `Config` error at load time.
+
+```yaml
+contract:
+  version: "1.0.0"
+  on_breach: quarantine        # fail (default) | quarantine | warn
+  allow_extra_fields: true
+  fields:
+    - { name: order_id, type: string, min_length: 1 }
+    - { name: status, type: string, enum: [open, shipped, cancelled] }
+    - { name: amount, type: number, min: 0, required: false, nullable: true }
+```
+
+### Contracts — Rust API
+
+```rust
+use faucet_core::{CompiledContract, ContractSpec, Pipeline};
+use std::sync::Arc;
+
+let spec: ContractSpec = serde_json::from_value(/* ... */)?;
+let compiled = Arc::new(CompiledContract::compile(&spec)?);
+let result = Pipeline::new(&source, &sink)
+    .with_dlq(dlq_config)      // required when on_breach = quarantine
+    .with_contract(compiled)
+    .run()
+    .await?;
+```
+
+Machine-readable exports for downstream consumers are plain functions:
+`contract::to_json_schema(&spec)` (a standalone JSON Schema document) and
+`contract::to_openlineage_facet(&spec, producer)` (an OpenLineage
+`SchemaDatasetFacet`). The CLI surfaces them as `faucet contract --export`.
+
 ## Config loading & schema
 
 Load any `Deserialize`-able config from JSON files or environment variables:
@@ -447,6 +492,7 @@ let schema = serde_json::to_value(schema_for!(MyConfig))?;
 | `idempotency` | `DeliveryMode`, `format_token`, `parse_token`, `wrap_state`, `unwrap_state` |
 | `write_mode` | `WriteMode`, `WriteSpec`, `DeleteMarker`, `plan_writes`, `WritePlan` |
 | `quality` | Per-record / per-batch checks (`quality` / `quality-jsonschema` features) |
+| `contract` | Versioned data contracts — `ContractSpec`, `CompiledContract`, `apply_contract`, JSON-Schema / OpenLineage exports (the `contract` feature) |
 | `replication` | `ReplicationMethod`, `filter_incremental`, `max_replication_value` |
 | `retry` | `execute_with_retry` (exponential backoff + jitter) |
 | `schema` | `infer_schema` from record samples |
@@ -465,6 +511,7 @@ Defaults: `transform-flatten`, `transform-rename-keys`, `transform-keys-case`.
 | `transforms` | All built-in transforms |
 | `quality` | The 12 base per-record / per-batch quality checks |
 | `quality-jsonschema` | Adds the `json_schema` record check (pulls `jsonschema`) |
+| `contract` | Versioned data contracts (the `contract:` config block + enforcement pass) |
 | `compression` | `CompressionConfig` + gzip/zstd helpers |
 | `observability-install` | `install_observability` (Prometheus exporter + tracing subscriber) |
 

--- a/crates/core/src/contract/compile.rs
+++ b/crates/core/src/contract/compile.rs
@@ -1,0 +1,397 @@
+//! Compile a `ContractSpec` into a `CompiledContract`: validate the version,
+//! field-name uniqueness, per-type constraint compatibility, and bounds, and
+//! compile regexes/enum sets once so the per-record pass is cheap. Failures
+//! surface as `FaucetError::Config` at config-load time, never mid-run.
+
+use crate::contract::config::{ContractFieldType, ContractSpec, FieldContract, OnBreach};
+use crate::error::FaucetError;
+use serde_json::Value;
+use std::collections::HashSet;
+
+/// A fully compiled contract. Built once via [`CompiledContract::compile`].
+#[derive(Debug)]
+pub struct CompiledContract {
+    /// Contract version (carried into breach errors and DLQ envelopes).
+    pub version: String,
+    /// Breach policy.
+    pub on_breach: OnBreach,
+    /// When `false`, undeclared top-level keys breach the contract.
+    pub allow_extra_fields: bool,
+    /// Compiled per-field rules, in declared order (first breach wins).
+    pub fields: Vec<CompiledField>,
+    /// Declared field names, for the O(1) extra-field membership test.
+    pub declared: HashSet<String>,
+}
+
+/// One compiled field rule.
+#[derive(Debug)]
+pub struct CompiledField {
+    pub name: String,
+    pub field_type: ContractFieldType,
+    pub required: bool,
+    pub nullable: bool,
+    pub allowed_values: Option<Vec<Value>>,
+    pub pattern: Option<regex::Regex>,
+    pub min: Option<f64>,
+    pub max: Option<f64>,
+    pub min_length: Option<usize>,
+    pub max_length: Option<usize>,
+}
+
+fn config_err(msg: impl Into<String>) -> FaucetError {
+    FaucetError::Config(format!("contract: {}", msg.into()))
+}
+
+/// Does `value` conform to the declared contract type? `integer` means a JSON
+/// number with no fractional part (fits `i64`/`u64` as parsed).
+pub(crate) fn type_matches(value: &Value, ty: ContractFieldType) -> bool {
+    match ty {
+        ContractFieldType::String => value.is_string(),
+        ContractFieldType::Integer => value.is_i64() || value.is_u64(),
+        ContractFieldType::Number => value.is_number(),
+        ContractFieldType::Boolean => value.is_boolean(),
+        ContractFieldType::Object => value.is_object(),
+        ContractFieldType::Array => value.is_array(),
+    }
+}
+
+impl CompiledContract {
+    /// Compile and validate a [`ContractSpec`]. Returns [`FaucetError::Config`]
+    /// on a malformed contract: empty version, no fields, duplicate/empty
+    /// field names, an invalid regex, an empty or type-mismatched `enum`,
+    /// constraints that don't apply to the declared type, or `min > max`.
+    pub fn compile(spec: &ContractSpec) -> Result<Self, FaucetError> {
+        if spec.version.trim().is_empty() {
+            return Err(config_err("`version` must be non-empty"));
+        }
+        if spec.fields.is_empty() {
+            return Err(config_err("`fields` must be non-empty"));
+        }
+        let mut declared: HashSet<String> = HashSet::with_capacity(spec.fields.len());
+        let mut fields = Vec::with_capacity(spec.fields.len());
+        for f in &spec.fields {
+            if f.name.trim().is_empty() {
+                return Err(config_err("field names must be non-empty"));
+            }
+            if !declared.insert(f.name.clone()) {
+                return Err(config_err(format!("duplicate field '{}'", f.name)));
+            }
+            fields.push(compile_field(f)?);
+        }
+        Ok(Self {
+            version: spec.version.clone(),
+            on_breach: spec.on_breach,
+            allow_extra_fields: spec.allow_extra_fields,
+            fields,
+            declared,
+        })
+    }
+
+    /// True when breaches route records to the DLQ (so a DLQ sink is
+    /// required). Checked by the pipeline at run start and by the CLI at
+    /// config-load time.
+    pub fn requires_dlq(&self) -> bool {
+        self.on_breach == OnBreach::Quarantine
+    }
+}
+
+fn compile_field(f: &FieldContract) -> Result<CompiledField, FaucetError> {
+    let is_string = f.field_type == ContractFieldType::String;
+    let is_numeric = matches!(
+        f.field_type,
+        ContractFieldType::Integer | ContractFieldType::Number
+    );
+
+    let pattern = match &f.pattern {
+        Some(p) => {
+            if !is_string {
+                return Err(config_err(format!(
+                    "field '{}': `pattern` applies only to string fields, not {}",
+                    f.name, f.field_type
+                )));
+            }
+            Some(regex::Regex::new(p).map_err(|e| {
+                config_err(format!("field '{}': invalid pattern '{p}': {e}", f.name))
+            })?)
+        }
+        None => None,
+    };
+
+    if (f.min.is_some() || f.max.is_some()) && !is_numeric {
+        return Err(config_err(format!(
+            "field '{}': `min`/`max` apply only to integer/number fields, not {}",
+            f.name, f.field_type
+        )));
+    }
+    if let (Some(lo), Some(hi)) = (f.min, f.max)
+        && lo > hi
+    {
+        return Err(config_err(format!(
+            "field '{}': `min` must be <= `max`",
+            f.name
+        )));
+    }
+
+    if (f.min_length.is_some() || f.max_length.is_some()) && !is_string {
+        return Err(config_err(format!(
+            "field '{}': `min_length`/`max_length` apply only to string fields, not {}",
+            f.name, f.field_type
+        )));
+    }
+    if let (Some(lo), Some(hi)) = (f.min_length, f.max_length)
+        && lo > hi
+    {
+        return Err(config_err(format!(
+            "field '{}': `min_length` must be <= `max_length`",
+            f.name
+        )));
+    }
+
+    if let Some(values) = &f.allowed_values {
+        if values.is_empty() {
+            return Err(config_err(format!(
+                "field '{}': `enum` must be non-empty",
+                f.name
+            )));
+        }
+        for v in values {
+            if v.is_null() {
+                return Err(config_err(format!(
+                    "field '{}': `enum` must not contain null — use `nullable: true`",
+                    f.name
+                )));
+            }
+            if !type_matches(v, f.field_type) {
+                return Err(config_err(format!(
+                    "field '{}': enum value {v} does not match declared type {}",
+                    f.name, f.field_type
+                )));
+            }
+        }
+    }
+
+    Ok(CompiledField {
+        name: f.name.clone(),
+        field_type: f.field_type,
+        required: f.required,
+        nullable: f.nullable,
+        allowed_values: f.allowed_values.clone(),
+        pattern,
+        min: f.min,
+        max: f.max,
+        min_length: f.min_length,
+        max_length: f.max_length,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn spec(v: Value) -> ContractSpec {
+        serde_json::from_value(v).unwrap()
+    }
+
+    fn compile(v: Value) -> Result<CompiledContract, FaucetError> {
+        CompiledContract::compile(&spec(v))
+    }
+
+    fn assert_config_err(r: Result<CompiledContract, FaucetError>, needle: &str) {
+        match r {
+            Err(FaucetError::Config(msg)) => {
+                assert!(msg.contains(needle), "expected '{needle}' in: {msg}")
+            }
+            other => panic!("expected Config error containing '{needle}', got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn compiles_valid_contract() {
+        let c = compile(json!({
+            "version": "1.0.0",
+            "on_breach": "quarantine",
+            "fields": [
+                { "name": "id", "type": "integer", "min": 0 },
+                { "name": "status", "type": "string", "enum": ["a", "b"] }
+            ]
+        }))
+        .unwrap();
+        assert_eq!(c.version, "1.0.0");
+        assert_eq!(c.fields.len(), 2);
+        assert!(c.requires_dlq());
+        assert!(c.declared.contains("status"));
+    }
+
+    #[test]
+    fn requires_dlq_only_for_quarantine() {
+        for (policy, expected) in [("fail", false), ("warn", false), ("quarantine", true)] {
+            let c = compile(json!({
+                "version": "1", "on_breach": policy,
+                "fields": [{ "name": "id", "type": "string" }]
+            }))
+            .unwrap();
+            assert_eq!(c.requires_dlq(), expected, "policy {policy}");
+        }
+    }
+
+    #[test]
+    fn rejects_empty_version() {
+        assert_config_err(
+            compile(json!({"version": "  ", "fields": [{"name": "x", "type": "string"}]})),
+            "`version` must be non-empty",
+        );
+    }
+
+    #[test]
+    fn rejects_empty_fields() {
+        assert_config_err(
+            compile(json!({"version": "1", "fields": []})),
+            "`fields` must be non-empty",
+        );
+    }
+
+    #[test]
+    fn rejects_duplicate_field_names() {
+        assert_config_err(
+            compile(json!({"version": "1", "fields": [
+                {"name": "id", "type": "string"},
+                {"name": "id", "type": "integer"}
+            ]})),
+            "duplicate field 'id'",
+        );
+    }
+
+    #[test]
+    fn rejects_empty_field_name() {
+        assert_config_err(
+            compile(json!({"version": "1", "fields": [{"name": " ", "type": "string"}]})),
+            "field names must be non-empty",
+        );
+    }
+
+    #[test]
+    fn rejects_bad_regex() {
+        assert_config_err(
+            compile(json!({"version": "1", "fields": [
+                {"name": "email", "type": "string", "pattern": "[invalid"}
+            ]})),
+            "invalid pattern",
+        );
+    }
+
+    #[test]
+    fn rejects_pattern_on_non_string() {
+        assert_config_err(
+            compile(json!({"version": "1", "fields": [
+                {"name": "n", "type": "integer", "pattern": "^\\d+$"}
+            ]})),
+            "`pattern` applies only to string fields",
+        );
+    }
+
+    #[test]
+    fn rejects_min_max_on_non_numeric() {
+        assert_config_err(
+            compile(json!({"version": "1", "fields": [
+                {"name": "s", "type": "string", "min": 1.0}
+            ]})),
+            "`min`/`max` apply only to integer/number fields",
+        );
+    }
+
+    #[test]
+    fn rejects_min_gt_max() {
+        assert_config_err(
+            compile(json!({"version": "1", "fields": [
+                {"name": "n", "type": "number", "min": 5.0, "max": 1.0}
+            ]})),
+            "`min` must be <= `max`",
+        );
+    }
+
+    #[test]
+    fn rejects_length_on_non_string() {
+        assert_config_err(
+            compile(json!({"version": "1", "fields": [
+                {"name": "n", "type": "number", "min_length": 1}
+            ]})),
+            "`min_length`/`max_length` apply only to string fields",
+        );
+    }
+
+    #[test]
+    fn rejects_min_length_gt_max_length() {
+        assert_config_err(
+            compile(json!({"version": "1", "fields": [
+                {"name": "s", "type": "string", "min_length": 9, "max_length": 3}
+            ]})),
+            "`min_length` must be <= `max_length`",
+        );
+    }
+
+    #[test]
+    fn rejects_empty_enum() {
+        assert_config_err(
+            compile(json!({"version": "1", "fields": [
+                {"name": "s", "type": "string", "enum": []}
+            ]})),
+            "`enum` must be non-empty",
+        );
+    }
+
+    #[test]
+    fn rejects_null_in_enum() {
+        assert_config_err(
+            compile(json!({"version": "1", "fields": [
+                {"name": "s", "type": "string", "enum": ["a", null]}
+            ]})),
+            "must not contain null",
+        );
+    }
+
+    #[test]
+    fn rejects_enum_value_type_mismatch() {
+        assert_config_err(
+            compile(json!({"version": "1", "fields": [
+                {"name": "n", "type": "integer", "enum": [1, "two"]}
+            ]})),
+            "does not match declared type",
+        );
+    }
+
+    #[test]
+    fn integer_type_rejects_float_enum_value() {
+        assert_config_err(
+            compile(json!({"version": "1", "fields": [
+                {"name": "n", "type": "integer", "enum": [1.5]}
+            ]})),
+            "does not match declared type",
+        );
+    }
+
+    #[test]
+    fn number_type_accepts_integer_enum_value() {
+        assert!(
+            compile(json!({"version": "1", "fields": [
+                {"name": "n", "type": "number", "enum": [1, 2.5]}
+            ]}))
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn type_matches_covers_all_types() {
+        use ContractFieldType::*;
+        assert!(type_matches(&json!("s"), String));
+        assert!(!type_matches(&json!(1), String));
+        assert!(type_matches(&json!(1), Integer));
+        assert!(!type_matches(&json!(1.5), Integer));
+        assert!(type_matches(&json!(1.5), Number));
+        assert!(type_matches(&json!(1), Number));
+        assert!(type_matches(&json!(true), Boolean));
+        assert!(type_matches(&json!({}), Object));
+        assert!(type_matches(&json!([]), Array));
+        assert!(!type_matches(&json!(null), Boolean));
+    }
+}

--- a/crates/core/src/contract/config.rs
+++ b/crates/core/src/contract/config.rs
@@ -1,0 +1,242 @@
+//! Config-shaped types for the data-contract layer (issue #204). Pure
+//! declarations — validation and compilation live in `compile.rs`, evaluation
+//! in the module root.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+fn default_true() -> bool {
+    true
+}
+
+/// What to do when a record breaches the contract. Contract-level (not
+/// per-field): a contract is a single versioned promise, so one policy
+/// governs every rule in it.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum OnBreach {
+    /// Surface [`FaucetError::ContractViolation`](crate::FaucetError::ContractViolation)
+    /// on the first breach and fail the run (default — a contract is a
+    /// promise, so silent divergence is the worst outcome).
+    #[default]
+    Fail,
+    /// Route breaching records to the DLQ; write the rest. Requires a DLQ.
+    Quarantine,
+    /// Log + count breaches, but write every record unchanged.
+    Warn,
+}
+
+impl std::fmt::Display for OnBreach {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            OnBreach::Fail => "fail",
+            OnBreach::Quarantine => "quarantine",
+            OnBreach::Warn => "warn",
+        })
+    }
+}
+
+/// Declared type of a contract field.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ContractFieldType {
+    /// JSON string.
+    String,
+    /// JSON number with no fractional part (fits `i64`/`u64` as parsed).
+    Integer,
+    /// Any JSON number (integer or float).
+    Number,
+    /// JSON boolean.
+    Boolean,
+    /// JSON object. Nested shapes are treated as one opaque column — a
+    /// contract describes the top-level output shape, matching the
+    /// schema-drift convention.
+    Object,
+    /// JSON array.
+    Array,
+}
+
+impl std::fmt::Display for ContractFieldType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            ContractFieldType::String => "string",
+            ContractFieldType::Integer => "integer",
+            ContractFieldType::Number => "number",
+            ContractFieldType::Boolean => "boolean",
+            ContractFieldType::Object => "object",
+            ContractFieldType::Array => "array",
+        })
+    }
+}
+
+/// The `contract:` config block: a declarative, versioned schema + semantic
+/// contract for a pipeline's output, enforced per page after transforms and
+/// quality checks and before the sink write.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ContractSpec {
+    /// Contract version, e.g. `"1.0.0"`. Required and non-empty. Carried
+    /// into breach errors, DLQ envelopes, and every export format so
+    /// producers and consumers can pin the promise they agreed on.
+    /// Recommendation: bump the major version on breaking changes (removing
+    /// a field, narrowing a type) and the minor version on additive ones.
+    pub version: String,
+
+    /// Human-readable description of the dataset this contract covers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// Owning team or person (documentation metadata; carried into exports).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner: Option<String>,
+
+    /// Breach policy: `fail` (default) aborts the run, `quarantine` routes
+    /// breaching records to the DLQ (a `dlq:` block is required), `warn`
+    /// logs + counts but writes everything.
+    #[serde(default)]
+    pub on_breach: OnBreach,
+
+    /// When `false`, a top-level key not declared in `fields` is a breach
+    /// (`extra_field`). Default `true` — additive fields are allowed.
+    #[serde(default = "default_true")]
+    pub allow_extra_fields: bool,
+
+    /// The promised top-level fields. Must be non-empty; names must be unique.
+    pub fields: Vec<FieldContract>,
+}
+
+/// One promised top-level field: its type plus optional semantic constraints.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct FieldContract {
+    /// Top-level field name (contracts describe the output's top-level shape;
+    /// nested objects are typed as `object`).
+    pub name: String,
+
+    /// Declared type. `integer` means a JSON number with no fractional part;
+    /// `number` accepts any JSON number.
+    #[serde(rename = "type")]
+    pub field_type: ContractFieldType,
+
+    /// When `true` (default) the field must be present in every record.
+    /// A non-required field that is absent skips all other checks.
+    #[serde(default = "default_true")]
+    pub required: bool,
+
+    /// When `true`, an explicit JSON `null` is allowed (and skips the
+    /// type/constraint checks). Default `false`.
+    #[serde(default)]
+    pub nullable: bool,
+
+    /// Allowed values (exact JSON equality). Must be non-empty when present,
+    /// and every value must match the declared `type`. Use `nullable` for
+    /// null — `null` is not allowed inside `enum`.
+    #[serde(rename = "enum", default, skip_serializing_if = "Option::is_none")]
+    pub allowed_values: Option<Vec<Value>>,
+
+    /// Regex the value must match. `string` fields only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pattern: Option<String>,
+
+    /// Minimum numeric value (inclusive). `integer`/`number` fields only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub min: Option<f64>,
+
+    /// Maximum numeric value (inclusive). `integer`/`number` fields only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max: Option<f64>,
+
+    /// Minimum string length in characters (inclusive). `string` fields only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub min_length: Option<usize>,
+
+    /// Maximum string length in characters (inclusive). `string` fields only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_length: Option<usize>,
+
+    /// Column description (documentation metadata; carried into exports).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn on_breach_defaults_to_fail() {
+        assert_eq!(OnBreach::default(), OnBreach::Fail);
+    }
+
+    #[test]
+    fn on_breach_serializes_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&OnBreach::Quarantine).unwrap(),
+            "\"quarantine\""
+        );
+        let w: OnBreach = serde_json::from_str("\"warn\"").unwrap();
+        assert_eq!(w, OnBreach::Warn);
+    }
+
+    #[test]
+    fn field_type_round_trips() {
+        let t: ContractFieldType = serde_json::from_str("\"integer\"").unwrap();
+        assert_eq!(t, ContractFieldType::Integer);
+        assert_eq!(t.to_string(), "integer");
+    }
+
+    #[test]
+    fn parses_full_contract_block() {
+        let spec: ContractSpec = serde_json::from_value(json!({
+            "version": "1.2.0",
+            "description": "orders output",
+            "owner": "data-platform",
+            "on_breach": "quarantine",
+            "allow_extra_fields": false,
+            "fields": [
+                { "name": "id", "type": "integer", "min": 1 },
+                { "name": "status", "type": "string",
+                  "enum": ["open", "closed"], "description": "lifecycle state" },
+                { "name": "email", "type": "string", "pattern": "^.+@.+$",
+                  "required": false, "nullable": true,
+                  "min_length": 3, "max_length": 254 }
+            ]
+        }))
+        .unwrap();
+        assert_eq!(spec.version, "1.2.0");
+        assert_eq!(spec.on_breach, OnBreach::Quarantine);
+        assert!(!spec.allow_extra_fields);
+        assert_eq!(spec.fields.len(), 3);
+        assert!(spec.fields[0].required, "required defaults to true");
+        assert!(!spec.fields[0].nullable, "nullable defaults to false");
+        assert!(!spec.fields[2].required);
+        assert!(spec.fields[2].nullable);
+        assert_eq!(
+            spec.fields[1].allowed_values.as_ref().unwrap(),
+            &vec![json!("open"), json!("closed")]
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_keys() {
+        let err = serde_json::from_value::<ContractSpec>(json!({
+            "version": "1", "fields": [], "nope": true
+        }));
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn defaults_when_optional_fields_absent() {
+        let spec: ContractSpec = serde_json::from_value(json!({
+            "version": "1.0.0",
+            "fields": [{ "name": "id", "type": "string" }]
+        }))
+        .unwrap();
+        assert_eq!(spec.on_breach, OnBreach::Fail);
+        assert!(spec.allow_extra_fields);
+        assert!(spec.description.is_none());
+        assert!(spec.owner.is_none());
+    }
+}

--- a/crates/core/src/contract/export.rs
+++ b/crates/core/src/contract/export.rs
@@ -1,0 +1,199 @@
+//! Machine-readable contract exports: JSON Schema and an OpenLineage
+//! `SchemaDatasetFacet`. Pure functions over a [`ContractSpec`] — no I/O.
+//! Used by `faucet contract --export …`; available to library callers too.
+
+use crate::contract::config::{ContractFieldType, ContractSpec, FieldContract};
+use serde_json::{Map, Value, json};
+
+/// Pinned OpenLineage `SchemaDatasetFacet` schema URL used by
+/// [`to_openlineage_facet`].
+pub const OPENLINEAGE_SCHEMA_FACET_URL: &str =
+    "https://openlineage.io/spec/facets/1-1-1/SchemaDatasetFacet.json";
+
+/// Render the contract as a standalone JSON Schema (draft 2020-12) document.
+///
+/// Mapping: each field becomes a property; `required: true` fields land in
+/// the top-level `required` array; `nullable` widens the property `type` to
+/// `[…, "null"]` (and appends `null` to `enum` when both are set);
+/// `allow_extra_fields: false` maps to `additionalProperties: false`. The
+/// contract version travels as `x-faucet-contract-version`.
+pub fn to_json_schema(spec: &ContractSpec) -> Value {
+    let mut properties = Map::new();
+    let mut required: Vec<Value> = Vec::new();
+    for f in &spec.fields {
+        if f.required {
+            required.push(Value::String(f.name.clone()));
+        }
+        properties.insert(f.name.clone(), field_schema(f));
+    }
+    let mut root = Map::new();
+    root.insert(
+        "$schema".into(),
+        json!("https://json-schema.org/draft/2020-12/schema"),
+    );
+    root.insert(
+        "title".into(),
+        json!(format!("faucet data contract v{}", spec.version)),
+    );
+    if let Some(d) = &spec.description {
+        root.insert("description".into(), json!(d));
+    }
+    root.insert("x-faucet-contract-version".into(), json!(spec.version));
+    if let Some(o) = &spec.owner {
+        root.insert("x-faucet-contract-owner".into(), json!(o));
+    }
+    root.insert("type".into(), json!("object"));
+    root.insert("properties".into(), Value::Object(properties));
+    root.insert("required".into(), Value::Array(required));
+    root.insert(
+        "additionalProperties".into(),
+        json!(spec.allow_extra_fields),
+    );
+    Value::Object(root)
+}
+
+fn json_schema_type(ty: ContractFieldType) -> &'static str {
+    match ty {
+        ContractFieldType::String => "string",
+        ContractFieldType::Integer => "integer",
+        ContractFieldType::Number => "number",
+        ContractFieldType::Boolean => "boolean",
+        ContractFieldType::Object => "object",
+        ContractFieldType::Array => "array",
+    }
+}
+
+fn field_schema(f: &FieldContract) -> Value {
+    let mut prop = Map::new();
+    let base = json_schema_type(f.field_type);
+    if f.nullable {
+        prop.insert("type".into(), json!([base, "null"]));
+    } else {
+        prop.insert("type".into(), json!(base));
+    }
+    if let Some(values) = &f.allowed_values {
+        let mut e = values.clone();
+        if f.nullable {
+            e.push(Value::Null);
+        }
+        prop.insert("enum".into(), Value::Array(e));
+    }
+    if let Some(p) = &f.pattern {
+        prop.insert("pattern".into(), json!(p));
+    }
+    if let Some(min) = f.min {
+        prop.insert("minimum".into(), json!(min));
+    }
+    if let Some(max) = f.max {
+        prop.insert("maximum".into(), json!(max));
+    }
+    if let Some(min) = f.min_length {
+        prop.insert("minLength".into(), json!(min));
+    }
+    if let Some(max) = f.max_length {
+        prop.insert("maxLength".into(), json!(max));
+    }
+    if let Some(d) = &f.description {
+        prop.insert("description".into(), json!(d));
+    }
+    Value::Object(prop)
+}
+
+/// Render the contract as an OpenLineage `SchemaDatasetFacet` — the same
+/// facet shape `faucet-lineage` attaches to dataset events, so downstream
+/// OpenLineage consumers can ingest the contract as a schema promise.
+///
+/// `producer` identifies the emitting tool (e.g. the faucet repo URL + version).
+pub fn to_openlineage_facet(spec: &ContractSpec, producer: &str) -> Value {
+    let fields: Vec<Value> = spec
+        .fields
+        .iter()
+        .map(|f| {
+            let mut entry = Map::new();
+            entry.insert("name".into(), json!(f.name));
+            entry.insert("type".into(), json!(json_schema_type(f.field_type)));
+            if let Some(d) = &f.description {
+                entry.insert("description".into(), json!(d));
+            }
+            Value::Object(entry)
+        })
+        .collect();
+    json!({
+        "_producer": producer,
+        "_schemaURL": OPENLINEAGE_SCHEMA_FACET_URL,
+        "x-faucet-contract-version": spec.version,
+        "fields": fields,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn spec() -> ContractSpec {
+        serde_json::from_value(json!({
+            "version": "2.1.0",
+            "description": "orders",
+            "owner": "data-platform",
+            "allow_extra_fields": false,
+            "fields": [
+                { "name": "id", "type": "integer", "min": 1.0, "max": 100.0 },
+                { "name": "status", "type": "string", "enum": ["open", "closed"],
+                  "nullable": true, "description": "lifecycle" },
+                { "name": "email", "type": "string", "pattern": "^.+@.+$",
+                  "required": false, "min_length": 3, "max_length": 254 }
+            ]
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn json_schema_maps_types_required_and_constraints() {
+        let s = to_json_schema(&spec());
+        assert_eq!(s["x-faucet-contract-version"], "2.1.0");
+        assert_eq!(s["x-faucet-contract-owner"], "data-platform");
+        assert_eq!(s["description"], "orders");
+        assert_eq!(s["type"], "object");
+        assert_eq!(s["additionalProperties"], false);
+        assert_eq!(s["required"], json!(["id", "status"]));
+        assert_eq!(s["properties"]["id"]["type"], "integer");
+        assert_eq!(s["properties"]["id"]["minimum"], 1.0);
+        assert_eq!(s["properties"]["id"]["maximum"], 100.0);
+        // nullable widens type and appends null to enum
+        assert_eq!(s["properties"]["status"]["type"], json!(["string", "null"]));
+        assert_eq!(
+            s["properties"]["status"]["enum"],
+            json!(["open", "closed", null])
+        );
+        assert_eq!(s["properties"]["status"]["description"], "lifecycle");
+        assert_eq!(s["properties"]["email"]["pattern"], "^.+@.+$");
+        assert_eq!(s["properties"]["email"]["minLength"], 3);
+        assert_eq!(s["properties"]["email"]["maxLength"], 254);
+    }
+
+    #[test]
+    fn json_schema_allows_extra_fields_by_default() {
+        let spec: ContractSpec = serde_json::from_value(json!({
+            "version": "1", "fields": [{ "name": "id", "type": "string" }]
+        }))
+        .unwrap();
+        let s = to_json_schema(&spec);
+        assert_eq!(s["additionalProperties"], true);
+        assert!(s.get("x-faucet-contract-owner").is_none());
+    }
+
+    #[test]
+    fn openlineage_facet_shape() {
+        let f = to_openlineage_facet(&spec(), "https://example.com/faucet/v1");
+        assert_eq!(f["_producer"], "https://example.com/faucet/v1");
+        assert_eq!(f["_schemaURL"], OPENLINEAGE_SCHEMA_FACET_URL);
+        assert_eq!(f["x-faucet-contract-version"], "2.1.0");
+        let fields = f["fields"].as_array().unwrap();
+        assert_eq!(fields.len(), 3);
+        assert_eq!(fields[0]["name"], "id");
+        assert_eq!(fields[0]["type"], "integer");
+        assert!(fields[0].get("description").is_none());
+        assert_eq!(fields[1]["description"], "lifecycle");
+    }
+}

--- a/crates/core/src/contract/mod.rs
+++ b/crates/core/src/contract/mod.rs
@@ -1,0 +1,458 @@
+//! Data contracts (issue #204): a declarative, versioned schema + semantic
+//! contract for a pipeline's output — required fields, types, nullability,
+//! enum sets, regex patterns, numeric/length bounds — enforced per page after
+//! transforms and quality checks and before the sink write. Breaches `fail`,
+//! `quarantine` (via the DLQ), or `warn` per the contract-level policy.
+//!
+//! Pure evaluation; the pipeline wires DLQ routing and metrics in
+//! `run_stream` / `instrumented_apply_contract`.
+
+pub mod compile;
+pub mod config;
+pub mod export;
+
+pub use compile::{CompiledContract, CompiledField};
+pub use config::{ContractFieldType, ContractSpec, FieldContract, OnBreach};
+pub use export::{OPENLINEAGE_SCHEMA_FACET_URL, to_json_schema, to_openlineage_facet};
+
+use crate::contract::compile::type_matches;
+use crate::error::FaucetError;
+use serde_json::Value;
+
+/// One observed contract breach.
+#[derive(Debug, Clone)]
+pub struct ContractViolation {
+    /// Stable rule label (closed set, safe as a metric label): `not_object`,
+    /// `missing`, `null`, `type`, `enum`, `pattern`, `range`, `length`,
+    /// `extra_field`.
+    pub rule: &'static str,
+    /// Breaching field name; `None` for whole-record rules (`not_object`).
+    pub field: Option<String>,
+    /// Human-readable breach message (goes into errors / DLQ envelopes).
+    pub message: String,
+    /// 0-based position within the original page — the DLQ envelope's
+    /// `record_index` contract (position within the page that failed).
+    pub page_index: usize,
+}
+
+impl ContractViolation {
+    /// One-line human description: `field 'x': <message> (<rule>)`.
+    pub fn describe(&self) -> String {
+        match &self.field {
+            Some(f) => format!("field '{f}': {} ({})", self.message, self.rule),
+            None => format!("{} ({})", self.message, self.rule),
+        }
+    }
+}
+
+/// A record removed from the page by a `quarantine` breach, destined for the
+/// DLQ.
+#[derive(Debug, Clone)]
+pub struct ViolatingRecord {
+    pub record: Value,
+    pub violation: ContractViolation,
+}
+
+/// Result of applying the contract pass to one page.
+#[derive(Debug, Clone, Default)]
+pub struct ContractOutcome {
+    /// Records that conform (plus, under `warn`, records that breached).
+    pub survivors: Vec<Value>,
+    /// Breaching records routed to the DLQ (`quarantine` only).
+    pub quarantined: Vec<ViolatingRecord>,
+    /// Breaches observed under `warn` (their records stay in `survivors`).
+    pub warned: Vec<ContractViolation>,
+}
+
+/// Apply the contract to one page. Pure: no metrics, no DLQ I/O.
+///
+/// Records are evaluated in order; per record, the first breach wins (fields
+/// in declared order, then the extra-field check). Policy:
+/// - `fail` — return [`FaucetError::ContractViolation`] on the first breach.
+/// - `quarantine` — move breaching records to `quarantined`.
+/// - `warn` — record the breach in `warned`, keep the record in `survivors`.
+pub fn apply_contract(
+    records: Vec<Value>,
+    contract: &CompiledContract,
+) -> Result<ContractOutcome, FaucetError> {
+    let mut out = ContractOutcome::default();
+    for (page_index, rec) in records.into_iter().enumerate() {
+        match evaluate_record(&rec, contract, page_index) {
+            None => out.survivors.push(rec),
+            Some(violation) => match contract.on_breach {
+                OnBreach::Fail => {
+                    return Err(FaucetError::ContractViolation {
+                        version: contract.version.clone(),
+                        message: violation.describe(),
+                    });
+                }
+                OnBreach::Quarantine => out.quarantined.push(ViolatingRecord {
+                    record: rec,
+                    violation,
+                }),
+                OnBreach::Warn => {
+                    out.warned.push(violation);
+                    out.survivors.push(rec);
+                }
+            },
+        }
+    }
+    Ok(out)
+}
+
+/// Evaluate one record against the contract. Returns the first breach, or
+/// `None` when the record conforms.
+fn evaluate_record(
+    rec: &Value,
+    contract: &CompiledContract,
+    page_index: usize,
+) -> Option<ContractViolation> {
+    let violation = |rule: &'static str, field: Option<&str>, message: String| ContractViolation {
+        rule,
+        field: field.map(str::to_string),
+        message,
+        page_index,
+    };
+
+    let Some(obj) = rec.as_object() else {
+        return Some(violation(
+            "not_object",
+            None,
+            format!("record is not a JSON object (got {})", json_type_name(rec)),
+        ));
+    };
+
+    for f in &contract.fields {
+        let value = match obj.get(&f.name) {
+            None => {
+                if f.required {
+                    return Some(violation(
+                        "missing",
+                        Some(&f.name),
+                        "required field is missing".into(),
+                    ));
+                }
+                continue; // absent optional field: nothing else to check
+            }
+            Some(v) => v,
+        };
+        if value.is_null() {
+            if f.nullable {
+                continue; // explicit null allowed: skip the value checks
+            }
+            return Some(violation(
+                "null",
+                Some(&f.name),
+                "field is null but not nullable".into(),
+            ));
+        }
+        if !type_matches(value, f.field_type) {
+            return Some(violation(
+                "type",
+                Some(&f.name),
+                format!("expected {}, got {}", f.field_type, json_type_name(value)),
+            ));
+        }
+        if let Some(values) = &f.allowed_values
+            && !values.iter().any(|v| v == value)
+        {
+            return Some(violation(
+                "enum",
+                Some(&f.name),
+                format!("value {value} is not in the allowed set"),
+            ));
+        }
+        if let Some(re) = &f.pattern {
+            // compile() guarantees pattern ⇒ string type, checked above.
+            let s = value.as_str().unwrap_or_default();
+            if !re.is_match(s) {
+                return Some(violation(
+                    "pattern",
+                    Some(&f.name),
+                    format!("value {value} does not match pattern '{re}'"),
+                ));
+            }
+        }
+        if (f.min.is_some() || f.max.is_some())
+            && let Some(n) = value.as_f64()
+        {
+            if let Some(min) = f.min
+                && n < min
+            {
+                return Some(violation(
+                    "range",
+                    Some(&f.name),
+                    format!("value {n} is below the minimum {min}"),
+                ));
+            }
+            if let Some(max) = f.max
+                && n > max
+            {
+                return Some(violation(
+                    "range",
+                    Some(&f.name),
+                    format!("value {n} is above the maximum {max}"),
+                ));
+            }
+        }
+        if f.min_length.is_some() || f.max_length.is_some() {
+            let len = value.as_str().map(|s| s.chars().count()).unwrap_or(0);
+            if let Some(min) = f.min_length
+                && len < min
+            {
+                return Some(violation(
+                    "length",
+                    Some(&f.name),
+                    format!("string length {len} is below the minimum {min}"),
+                ));
+            }
+            if let Some(max) = f.max_length
+                && len > max
+            {
+                return Some(violation(
+                    "length",
+                    Some(&f.name),
+                    format!("string length {len} is above the maximum {max}"),
+                ));
+            }
+        }
+    }
+
+    if !contract.allow_extra_fields {
+        for key in obj.keys() {
+            if !contract.declared.contains(key) {
+                return Some(violation(
+                    "extra_field",
+                    Some(key),
+                    "field is not declared in the contract and allow_extra_fields is false".into(),
+                ));
+            }
+        }
+    }
+
+    None
+}
+
+fn json_type_name(v: &Value) -> &'static str {
+    match v {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn compiled(v: Value) -> CompiledContract {
+        let spec: ContractSpec = serde_json::from_value(v).unwrap();
+        CompiledContract::compile(&spec).unwrap()
+    }
+
+    fn basic(on_breach: &str) -> CompiledContract {
+        compiled(json!({
+            "version": "1.0.0",
+            "on_breach": on_breach,
+            "fields": [
+                { "name": "id", "type": "integer", "min": 0 },
+                { "name": "status", "type": "string", "enum": ["open", "closed"] },
+                { "name": "email", "type": "string", "required": false,
+                  "nullable": true, "pattern": "^.+@.+$", "min_length": 3 }
+            ]
+        }))
+    }
+
+    #[test]
+    fn conforming_page_passes_untouched() {
+        let page = vec![
+            json!({"id": 1, "status": "open", "email": "a@b.c"}),
+            json!({"id": 2, "status": "closed"}), // optional email absent
+            json!({"id": 3, "status": "open", "email": null}), // nullable
+        ];
+        let out = apply_contract(page.clone(), &basic("fail")).unwrap();
+        assert_eq!(out.survivors, page);
+        assert!(out.quarantined.is_empty());
+        assert!(out.warned.is_empty());
+    }
+
+    #[test]
+    fn fail_raises_typed_error_with_version_and_field() {
+        let page = vec![
+            json!({"id": 1, "status": "open"}),
+            json!({"id": 2, "status": "bogus"}),
+        ];
+        let err = apply_contract(page, &basic("fail")).unwrap_err();
+        match err {
+            FaucetError::ContractViolation { version, message } => {
+                assert_eq!(version, "1.0.0");
+                assert!(message.contains("status"), "message: {message}");
+                assert!(message.contains("enum"), "message: {message}");
+            }
+            other => panic!("expected ContractViolation, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn quarantine_partitions_page_and_keeps_page_index() {
+        let page = vec![
+            json!({"id": 1, "status": "open"}),
+            json!({"id": -5, "status": "open"}), // range breach at index 1
+            json!({"id": 3, "status": "open"}),
+            json!({"id": 4, "status": "nope"}), // enum breach at index 3
+        ];
+        let out = apply_contract(page, &basic("quarantine")).unwrap();
+        assert_eq!(out.survivors.len(), 2);
+        let idx: Vec<usize> = out
+            .quarantined
+            .iter()
+            .map(|q| q.violation.page_index)
+            .collect();
+        assert_eq!(idx, vec![1, 3], "page_index must be the original position");
+        assert_eq!(out.quarantined[0].violation.rule, "range");
+        assert_eq!(out.quarantined[1].violation.rule, "enum");
+    }
+
+    #[test]
+    fn warn_keeps_all_records_and_reports_breaches() {
+        let page = vec![
+            json!({"id": 1, "status": "open"}),
+            json!({"id": "not-an-int", "status": "open"}),
+        ];
+        let out = apply_contract(page.clone(), &basic("warn")).unwrap();
+        assert_eq!(out.survivors, page, "warn must not remove records");
+        assert!(out.quarantined.is_empty());
+        assert_eq!(out.warned.len(), 1);
+        assert_eq!(out.warned[0].rule, "type");
+        assert_eq!(out.warned[0].field.as_deref(), Some("id"));
+        assert_eq!(out.warned[0].page_index, 1);
+    }
+
+    #[test]
+    fn missing_required_field_breaches() {
+        let out = apply_contract(vec![json!({"status": "open"})], &basic("warn")).unwrap();
+        assert_eq!(out.warned[0].rule, "missing");
+        assert_eq!(out.warned[0].field.as_deref(), Some("id"));
+    }
+
+    #[test]
+    fn null_on_non_nullable_breaches() {
+        let out =
+            apply_contract(vec![json!({"id": null, "status": "open"})], &basic("warn")).unwrap();
+        assert_eq!(out.warned[0].rule, "null");
+    }
+
+    #[test]
+    fn pattern_and_length_breaches() {
+        let c = basic("warn");
+        let out = apply_contract(
+            vec![json!({"id": 1, "status": "open", "email": "nope"})],
+            &c,
+        )
+        .unwrap();
+        assert_eq!(out.warned[0].rule, "pattern");
+        let out =
+            apply_contract(vec![json!({"id": 1, "status": "open", "email": "@b"})], &c).unwrap();
+        // "@b" fails min_length 3? len 2 < 3 → but pattern checked first: "@b"
+        // does not match ^.+@.+$ either. Pattern wins (declared order of rules).
+        assert_eq!(out.warned[0].rule, "pattern");
+        let out =
+            apply_contract(vec![json!({"id": 1, "status": "open", "email": "a@c"})], &c).unwrap();
+        assert!(out.warned.is_empty(), "a@c matches pattern and min_length");
+    }
+
+    #[test]
+    fn min_length_breach_reported() {
+        let c = compiled(json!({
+            "version": "1", "on_breach": "warn",
+            "fields": [{ "name": "s", "type": "string", "min_length": 3, "max_length": 5 }]
+        }));
+        let out = apply_contract(vec![json!({"s": "ab"})], &c).unwrap();
+        assert_eq!(out.warned[0].rule, "length");
+        let out = apply_contract(vec![json!({"s": "abcdef"})], &c).unwrap();
+        assert_eq!(out.warned[0].rule, "length");
+        // char count, not byte count
+        let out = apply_contract(vec![json!({"s": "héllo"})], &c).unwrap();
+        assert!(out.warned.is_empty());
+    }
+
+    #[test]
+    fn integer_type_rejects_float_value() {
+        let out =
+            apply_contract(vec![json!({"id": 1.5, "status": "open"})], &basic("warn")).unwrap();
+        assert_eq!(out.warned[0].rule, "type");
+    }
+
+    #[test]
+    fn extra_field_breach_when_disallowed() {
+        let c = compiled(json!({
+            "version": "1", "on_breach": "warn", "allow_extra_fields": false,
+            "fields": [{ "name": "id", "type": "integer" }]
+        }));
+        let out = apply_contract(vec![json!({"id": 1, "surprise": true})], &c).unwrap();
+        assert_eq!(out.warned[0].rule, "extra_field");
+        assert_eq!(out.warned[0].field.as_deref(), Some("surprise"));
+    }
+
+    #[test]
+    fn extra_field_allowed_by_default() {
+        let c = compiled(json!({
+            "version": "1", "on_breach": "warn",
+            "fields": [{ "name": "id", "type": "integer" }]
+        }));
+        let out = apply_contract(vec![json!({"id": 1, "surprise": true})], &c).unwrap();
+        assert!(out.warned.is_empty());
+    }
+
+    #[test]
+    fn non_object_record_breaches() {
+        let out = apply_contract(vec![json!([1, 2, 3])], &basic("warn")).unwrap();
+        assert_eq!(out.warned[0].rule, "not_object");
+        assert!(out.warned[0].field.is_none());
+    }
+
+    #[test]
+    fn first_breach_wins_in_declared_field_order() {
+        // Both `id` (type) and `status` (enum) breach; `id` is declared first.
+        let out =
+            apply_contract(vec![json!({"id": "x", "status": "nope"})], &basic("warn")).unwrap();
+        assert_eq!(out.warned.len(), 1, "one breach per record");
+        assert_eq!(out.warned[0].field.as_deref(), Some("id"));
+    }
+
+    #[test]
+    fn range_bounds_inclusive() {
+        let c = compiled(json!({
+            "version": "1", "on_breach": "warn",
+            "fields": [{ "name": "n", "type": "number", "min": 0.0, "max": 10.0 }]
+        }));
+        let out = apply_contract(vec![json!({"n": 0.0}), json!({"n": 10.0})], &c).unwrap();
+        assert!(out.warned.is_empty(), "bounds are inclusive");
+        let out = apply_contract(vec![json!({"n": 10.001})], &c).unwrap();
+        assert_eq!(out.warned[0].rule, "range");
+    }
+
+    #[test]
+    fn violation_describe_includes_field_and_rule() {
+        let v = ContractViolation {
+            rule: "enum",
+            field: Some("status".into()),
+            message: "value \"x\" is not in the allowed set".into(),
+            page_index: 0,
+        };
+        let d = v.describe();
+        assert!(d.contains("field 'status'"));
+        assert!(d.contains("(enum)"));
+        let v2 = ContractViolation {
+            rule: "not_object",
+            field: None,
+            message: "record is not a JSON object (got array)".into(),
+            page_index: 0,
+        };
+        assert!(!v2.describe().contains("field"));
+    }
+}

--- a/crates/core/src/dlq.rs
+++ b/crates/core/src/dlq.rs
@@ -106,6 +106,9 @@ pub enum DlqReason {
     /// A record was routed to the DLQ by an `on_drift`/`on_incompatible`
     /// quarantine policy.
     SchemaDrift,
+    /// A record was routed to the DLQ by a data-contract `on_breach:
+    /// quarantine` policy.
+    Contract,
 }
 
 impl DlqReason {
@@ -117,6 +120,7 @@ impl DlqReason {
             DlqReason::DlqAll => "dlq_all",
             DlqReason::Quality => "quality",
             DlqReason::SchemaDrift => "schema_drift",
+            DlqReason::Contract => "contract",
         }
     }
 }
@@ -232,5 +236,10 @@ mod tests {
     #[test]
     fn dlq_reason_schema_drift_string() {
         assert_eq!(DlqReason::SchemaDrift.as_str(), "schema_drift");
+    }
+
+    #[test]
+    fn dlq_reason_contract_string() {
+        assert_eq!(DlqReason::Contract.as_str(), "contract");
     }
 }

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -68,6 +68,12 @@ pub enum FaucetError {
         message: String,
     },
 
+    /// A record breached the pipeline's data contract under an
+    /// `on_breach: fail` policy. `version` is the contract version the
+    /// record was validated against.
+    #[error("Contract v{version} violated: {message}")]
+    ContractViolation { version: String, message: String },
+
     /// A state-store operation failed (read/write/delete of a replication
     /// bookmark, checkpoint, or other persisted pipeline state).
     #[error("State error: {0}")]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -17,6 +17,8 @@ pub mod adaptive;
 pub mod auth;
 pub mod check;
 pub mod config;
+#[cfg(feature = "contract")]
+pub mod contract;
 pub mod dlq;
 pub mod drift;
 pub mod error;
@@ -54,6 +56,8 @@ pub use drift::{
 };
 pub use error::FaucetError;
 pub use idempotency::{DeliveryMode, format_token, parse_token, unwrap_state, wrap_state};
+#[cfg(feature = "contract")]
+pub use observability::instrumented_apply_contract;
 #[cfg(feature = "quality")]
 pub use observability::instrumented_apply_quality;
 pub use observability::otel::{OtelConfig, OtelProtocol, OtelSignal, shutdown_otel};
@@ -118,4 +122,10 @@ pub use compression::{Compression, CompressionConfig, compress_buf, warn_mismatc
 pub use quality::{
     BatchCheck, CheckTally, CompareOp, CompiledQuality, JsonType, OnFailure, QualityOutcome,
     QualitySpec, QuarantinedRecord, RecordCheck, apply_quality,
+};
+
+#[cfg(feature = "contract")]
+pub use contract::{
+    CompiledContract, ContractFieldType, ContractOutcome, ContractSpec, ContractViolation,
+    FieldContract, OnBreach, ViolatingRecord, apply_contract, to_json_schema, to_openlineage_facet,
 };

--- a/crates/core/src/observability/contract.rs
+++ b/crates/core/src/observability/contract.rs
@@ -1,0 +1,158 @@
+//! Observability wrapper around `contract::apply_contract`. Emits the
+//! `faucet_contract_*` metrics from the returned outcome. The pure logic
+//! lives in `crate::contract`.
+
+use crate::contract::{CompiledContract, ContractOutcome, ContractViolation, apply_contract};
+use crate::error::FaucetError;
+use crate::observability::Labels;
+use metrics::{Label, SharedString, counter};
+use serde_json::Value;
+
+/// Apply the contract pass and emit metrics. Returns the same outcome as
+/// [`apply_contract`]; on a `fail`-policy breach, increments
+/// `faucet_contract_aborts_total` before propagating the error.
+pub fn instrumented_apply_contract(
+    records: Vec<Value>,
+    contract: &CompiledContract,
+    labels: &Labels,
+) -> Result<ContractOutcome, FaucetError> {
+    let records_in = records.len();
+    let span = tracing::info_span!(
+        "faucet.contract.apply",
+        pipeline = %labels.pipeline,
+        row = %labels.row,
+        run_id = %labels.run_id,
+        version = %contract.version,
+        records_in,
+    );
+    let _enter = span.enter();
+
+    let base = || -> Vec<Label> {
+        vec![
+            Label::new("pipeline", SharedString::from(labels.pipeline.to_string())),
+            Label::new("row", SharedString::from(labels.row.to_string())),
+        ]
+    };
+    let violation_labels = |v: &ContractViolation, mode: &'static str| -> Vec<Label> {
+        let mut l = base();
+        l.push(Label::new(
+            "field",
+            SharedString::from(v.field.clone().unwrap_or_default()),
+        ));
+        l.push(Label::new("rule", SharedString::const_str(v.rule)));
+        l.push(Label::new("mode", SharedString::const_str(mode)));
+        l
+    };
+
+    let result = apply_contract(records, contract);
+
+    match &result {
+        Ok(outcome) => {
+            for q in &outcome.quarantined {
+                counter!(
+                    "faucet_contract_violations_total",
+                    violation_labels(&q.violation, "quarantine")
+                )
+                .increment(1);
+            }
+            for v in &outcome.warned {
+                counter!(
+                    "faucet_contract_violations_total",
+                    violation_labels(v, "warn")
+                )
+                .increment(1);
+            }
+        }
+        Err(FaucetError::ContractViolation { .. }) => {
+            counter!("faucet_contract_aborts_total", base()).increment(1);
+        }
+        Err(_) => {}
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::contract::ContractSpec;
+    use crate::observability::decorator::source_tests::{LOCK, snapshotter};
+    use metrics_util::debugging::DebugValue;
+    use serde_json::json;
+
+    fn compiled(on_breach: &str) -> CompiledContract {
+        let spec: ContractSpec = serde_json::from_value(json!({
+            "version": "1.0.0",
+            "on_breach": on_breach,
+            "fields": [{ "name": "id", "type": "integer" }]
+        }))
+        .unwrap();
+        CompiledContract::compile(&spec).unwrap()
+    }
+
+    #[test]
+    fn instrumented_returns_same_outcome() {
+        let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _snap = snapshotter();
+        let out = instrumented_apply_contract(
+            vec![json!({"id": 1}), json!({"id": "x"})],
+            &compiled("quarantine"),
+            &Labels::for_named("test"),
+        )
+        .unwrap();
+        assert_eq!(out.survivors.len(), 1);
+        assert_eq!(out.quarantined.len(), 1);
+    }
+
+    #[test]
+    fn emits_violation_counter_with_rule_and_mode() {
+        let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let snap = snapshotter();
+        instrumented_apply_contract(
+            vec![json!({"id": "x"})],
+            &compiled("warn"),
+            &Labels::for_named("test_contract_warn"),
+        )
+        .unwrap();
+        let snapshot = snap.snapshot().into_vec();
+        let found = snapshot.iter().any(|(key, _, _, v)| {
+            key.key().name() == "faucet_contract_violations_total"
+                && key
+                    .key()
+                    .labels()
+                    .any(|l| l.key() == "rule" && l.value() == "type")
+                && key
+                    .key()
+                    .labels()
+                    .any(|l| l.key() == "mode" && l.value() == "warn")
+                && key
+                    .key()
+                    .labels()
+                    .any(|l| l.key() == "field" && l.value() == "id")
+                && matches!(v, DebugValue::Counter(c) if *c >= 1)
+        });
+        assert!(
+            found,
+            "expected faucet_contract_violations_total{{rule=type,mode=warn,field=id}}"
+        );
+    }
+
+    #[test]
+    fn emits_aborts_total_on_fail_breach() {
+        let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let snap = snapshotter();
+        let err = instrumented_apply_contract(
+            vec![json!({"id": "x"})],
+            &compiled("fail"),
+            &Labels::for_named("test_contract_abort"),
+        )
+        .unwrap_err();
+        assert!(matches!(err, FaucetError::ContractViolation { .. }));
+        let snapshot = snap.snapshot().into_vec();
+        let found = snapshot.iter().any(|(key, _, _, v)| {
+            key.key().name() == "faucet_contract_aborts_total"
+                && matches!(v, DebugValue::Counter(c) if *c >= 1)
+        });
+        assert!(found, "expected faucet_contract_aborts_total >= 1");
+    }
+}

--- a/crates/core/src/observability/decorator.rs
+++ b/crates/core/src/observability/decorator.rs
@@ -216,6 +216,7 @@ pub(crate) fn error_kind(e: &FaucetError) -> &'static str {
         FaucetError::Sink(_) => "Sink",
         FaucetError::QualityFailure { .. } => "QualityFailure",
         FaucetError::SchemaDrift { .. } => "SchemaDrift",
+        FaucetError::ContractViolation { .. } => "ContractViolation",
         FaucetError::State(_) => "State",
         FaucetError::CircuitOpen { .. } => "CircuitOpen",
         FaucetError::Custom(_) => "Custom",

--- a/crates/core/src/observability/mod.rs
+++ b/crates/core/src/observability/mod.rs
@@ -4,6 +4,8 @@
 //! `docs/superpowers/specs/2026-05-23-observability-otel-prometheus-design.md`.
 
 mod bookmark;
+#[cfg(feature = "contract")]
+mod contract;
 pub(crate) mod decorator;
 mod drift;
 mod install;
@@ -19,6 +21,8 @@ mod timer;
 mod transform;
 
 pub use bookmark::update_bookmark_lag;
+#[cfg(feature = "contract")]
+pub use contract::instrumented_apply_contract;
 pub use decorator::{InstrumentedSink, InstrumentedSource};
 pub use drift::schema_drift;
 pub use install::{

--- a/crates/core/src/observability/options.rs
+++ b/crates/core/src/observability/options.rs
@@ -17,6 +17,10 @@ pub struct RunStreamOptions {
     pub dlq: Option<DlqConfig>,
     #[cfg(feature = "quality")]
     pub quality: Option<std::sync::Arc<crate::quality::CompiledQuality>>,
+    /// Compiled data contract (issue #204). The pass runs per page after the
+    /// quality pass and before the schema-drift pass.
+    #[cfg(feature = "contract")]
+    pub contract: Option<std::sync::Arc<crate::contract::CompiledContract>>,
     /// Adaptive batch-size controller config; `None` (or `enabled = false`)
     /// leaves the per-page write path unchanged.
     pub adaptive: Option<crate::adaptive::AdaptiveBatchConfig>,
@@ -87,6 +91,17 @@ impl RunStreamOptions {
         quality: std::sync::Arc<crate::quality::CompiledQuality>,
     ) -> Self {
         self.quality = Some(quality);
+        self
+    }
+
+    /// Attach a compiled data contract. The pass runs per page after the
+    /// quality pass and before the schema-drift pass.
+    #[cfg(feature = "contract")]
+    pub fn with_contract(
+        mut self,
+        contract: std::sync::Arc<crate::contract::CompiledContract>,
+    ) -> Self {
+        self.contract = Some(contract);
         self
     }
 

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -131,6 +131,8 @@ pub struct Pipeline<'a, So: Source + ?Sized, Si: Sink + ?Sized> {
     dlq: Option<DlqConfig>,
     #[cfg(feature = "quality")]
     quality: Option<Arc<crate::quality::CompiledQuality>>,
+    #[cfg(feature = "contract")]
+    contract: Option<Arc<crate::contract::CompiledContract>>,
     adaptive: Option<crate::adaptive::AdaptiveBatchConfig>,
     cancel: Option<tokio_util::sync::CancellationToken>,
     delivery: crate::idempotency::DeliveryMode,
@@ -151,6 +153,8 @@ impl<'a, So: Source + ?Sized, Si: Sink + ?Sized> Pipeline<'a, So, Si> {
             dlq: None,
             #[cfg(feature = "quality")]
             quality: None,
+            #[cfg(feature = "contract")]
+            contract: None,
             adaptive: None,
             cancel: None,
             delivery: crate::idempotency::DeliveryMode::AtLeastOnce,
@@ -210,6 +214,14 @@ impl<'a, So: Source + ?Sized, Si: Sink + ?Sized> Pipeline<'a, So, Si> {
     #[cfg(feature = "quality")]
     pub fn with_quality(mut self, quality: Arc<crate::quality::CompiledQuality>) -> Self {
         self.quality = Some(quality);
+        self
+    }
+
+    /// Attach a compiled data contract (issue #204). The pass runs after the
+    /// quality pass and before the schema-drift pass, per page.
+    #[cfg(feature = "contract")]
+    pub fn with_contract(mut self, contract: Arc<crate::contract::CompiledContract>) -> Self {
+        self.contract = Some(contract);
         self
     }
 
@@ -384,6 +396,10 @@ impl<'a, So: Source + ?Sized, Si: Sink + ?Sized> Pipeline<'a, So, Si> {
             if let Some(q) = self.quality.clone() {
                 opts = opts.with_quality(q);
             }
+            #[cfg(feature = "contract")]
+            if let Some(c) = self.contract.clone() {
+                opts = opts.with_contract(c);
+            }
             if let Some(ad) = self.adaptive.clone() {
                 opts = opts.with_adaptive(ad);
             }
@@ -470,6 +486,22 @@ where
             "quality: on_failure 'quarantine'/'quarantine_batch' requires a DLQ sink".into(),
         ));
     }
+
+    #[cfg(feature = "contract")]
+    let contract = options.contract.clone();
+    // Fail fast: contract quarantine requires a DLQ (mirrors the quality guard).
+    #[cfg(feature = "contract")]
+    if let Some(c) = contract.as_ref()
+        && c.requires_dlq()
+        && dlq.is_none()
+    {
+        return Err(FaucetError::Config(
+            "contract: on_breach 'quarantine' requires a DLQ sink".into(),
+        ));
+    }
+    // One-shot warn guard for contract `on_breach: warn` breaches.
+    #[cfg(feature = "contract")]
+    let mut warned_contract_breach = false;
 
     // ── Schema-drift policy + lazy destination-schema cache (#194) ───────────
     let schema_drift = options.schema_drift;
@@ -686,6 +718,55 @@ where
                     let (records, quality_envelopes): (Vec<Value>, Vec<Value>) =
                         (page.records, Vec::new());
 
+                    // ── Contract pass (after quality, before schema drift) ───
+                    // `fail` mirrors a quality `abort`: the breach error
+                    // propagates immediately and nothing from this page is
+                    // written — a contract must never commit breaching data
+                    // (unlike drift `fail`, which defers because its records
+                    // are individually fine).
+                    #[cfg(feature = "contract")]
+                    let (records, contract_envelopes): (Vec<Value>, Vec<Value>) =
+                        if let Some(c) = contract.as_ref() {
+                            let labels =
+                                crate::observability::Labels::new(&*pipeline_name, &*row, &*run_id);
+                            let outcome = crate::observability::instrumented_apply_contract(
+                                records, c, &labels,
+                            )?;
+                            if !outcome.warned.is_empty() && !warned_contract_breach {
+                                tracing::warn!(
+                                    version = %c.version,
+                                    breaches = outcome.warned.len(),
+                                    first = %outcome.warned[0].describe(),
+                                    "contract: breaching records written unchanged \
+                                     (on_breach=warn); this warning fires once per run"
+                                );
+                                warned_contract_breach = true;
+                            }
+                            let envelopes: Vec<Value> = outcome
+                                .quarantined
+                                .iter()
+                                .map(|vr| {
+                                    let err = FaucetError::ContractViolation {
+                                        version: c.version.clone(),
+                                        message: vr.violation.describe(),
+                                    };
+                                    // `record_index` is the position within the PAGE
+                                    // (the frozen envelope contract).
+                                    build_envelope(
+                                        &vr.record,
+                                        &err,
+                                        sink_name,
+                                        &pipeline_name,
+                                        &row,
+                                        vr.violation.page_index,
+                                    )
+                                })
+                                .collect();
+                            (outcome.survivors, envelopes)
+                        } else {
+                            (records, Vec::new())
+                        };
+
                     // ── Schema-drift pass (after quality, before sink) ───────
                     let mut drift_envelopes: Vec<Value> = Vec::new();
                     let (records, drift_abort): (Vec<Value>, Option<FaucetError>) =
@@ -740,10 +821,13 @@ where
                         } else {
                             (records, None)
                         };
-                    // Merge drift quarantine envelopes into the quality envelopes
-                    // so the existing DLQ path writes them together.
+                    // Merge contract + drift quarantine envelopes into the
+                    // quality envelopes so the existing DLQ path writes them
+                    // together.
                     let quality_envelopes = {
                         let mut q = quality_envelopes;
+                        #[cfg(feature = "contract")]
+                        q.extend(contract_envelopes);
                         q.append(&mut drift_envelopes);
                         q
                     };
@@ -3331,6 +3415,144 @@ mod tests {
         let opts = RunStreamOptions::new().with_quality(quality);
         let result = run_stream(futures::stream::iter(pages), &main, opts).await;
         assert!(matches!(result, Err(FaucetError::Config(_))));
+    }
+
+    #[cfg(feature = "contract")]
+    fn compiled_contract(on_breach: &str) -> Arc<crate::contract::CompiledContract> {
+        let spec: crate::contract::ContractSpec = serde_json::from_value(json!({
+            "version": "1.0.0",
+            "on_breach": on_breach,
+            "fields": [{ "name": "id", "type": "integer" }]
+        }))
+        .unwrap();
+        Arc::new(crate::contract::CompiledContract::compile(&spec).unwrap())
+    }
+
+    #[cfg(feature = "contract")]
+    #[tokio::test]
+    async fn contract_quarantines_to_dlq_and_writes_survivors() {
+        use crate::dlq::DlqConfig;
+        let main = Arc::new(MockSink::new());
+        let dlq_sink = Arc::new(MockSink::new());
+        let pages: Vec<Result<StreamPage, FaucetError>> = vec![Ok(StreamPage {
+            records: vec![json!({"id": 1}), json!({"id": "bad"}), json!({"id": 3})],
+            bookmark: None,
+        })];
+        let opts = RunStreamOptions::new()
+            .with_dlq(DlqConfig::new(dlq_sink.clone()))
+            .with_contract(compiled_contract("quarantine"));
+        let result = run_stream(futures::stream::iter(pages), main.as_ref(), opts)
+            .await
+            .unwrap();
+
+        assert_eq!(result.records_written, 2);
+        assert_eq!(main.written(), vec![json!({"id": 1}), json!({"id": 3})]);
+        let dlq = dlq_sink.written();
+        assert_eq!(dlq.len(), 1);
+        assert_eq!(dlq[0]["error"]["kind"], "ContractViolation");
+        assert_eq!(dlq[0]["payload"], json!({"id": "bad"}));
+        // record_index is the position within the page (frozen contract).
+        assert_eq!(dlq[0]["record_index"], 1);
+        assert_eq!(result.dlq.unwrap().records_dlq, 1);
+    }
+
+    #[cfg(feature = "contract")]
+    #[tokio::test]
+    async fn contract_fail_aborts_run_and_writes_nothing() {
+        let main = MockSink::new();
+        let pages: Vec<Result<StreamPage, FaucetError>> = vec![Ok(StreamPage {
+            records: vec![json!({"id": 1}), json!({"id": "bad"})],
+            bookmark: None,
+        })];
+        let opts = RunStreamOptions::new().with_contract(compiled_contract("fail"));
+        let result = run_stream(futures::stream::iter(pages), &main, opts).await;
+        match result {
+            Err(FaucetError::ContractViolation { version, message }) => {
+                assert_eq!(version, "1.0.0");
+                assert!(message.contains("id"), "message: {message}");
+            }
+            other => panic!("expected ContractViolation, got {other:?}"),
+        }
+        assert!(
+            main.written().is_empty(),
+            "a contract fail must not commit any of the page's records"
+        );
+    }
+
+    #[cfg(feature = "contract")]
+    #[tokio::test]
+    async fn contract_warn_writes_everything() {
+        let main = MockSink::new();
+        let pages: Vec<Result<StreamPage, FaucetError>> = vec![Ok(StreamPage {
+            records: vec![json!({"id": 1}), json!({"id": "bad"})],
+            bookmark: None,
+        })];
+        let opts = RunStreamOptions::new().with_contract(compiled_contract("warn"));
+        let result = run_stream(futures::stream::iter(pages), &main, opts)
+            .await
+            .unwrap();
+        assert_eq!(result.records_written, 2);
+        assert_eq!(main.written(), vec![json!({"id": 1}), json!({"id": "bad"})]);
+    }
+
+    #[cfg(feature = "contract")]
+    #[tokio::test]
+    async fn contract_quarantine_without_dlq_is_rejected() {
+        let main = MockSink::new();
+        let pages: Vec<Result<StreamPage, FaucetError>> = vec![Ok(StreamPage {
+            records: vec![json!({"id": 1})],
+            bookmark: None,
+        })];
+        // No .with_dlq(...) — must be rejected up front.
+        let opts = RunStreamOptions::new().with_contract(compiled_contract("quarantine"));
+        let result = run_stream(futures::stream::iter(pages), &main, opts).await;
+        assert!(matches!(result, Err(FaucetError::Config(_))));
+    }
+
+    #[cfg(all(feature = "contract", feature = "quality"))]
+    #[tokio::test]
+    async fn contract_runs_after_quality_and_shares_dlq() {
+        // Quality quarantines the null id; the contract then quarantines the
+        // string id from the quality survivors. Both envelopes land in the
+        // same DLQ write, each with its own error kind.
+        use crate::dlq::DlqConfig;
+        use crate::quality::{CompiledQuality, OnFailure, QualitySpec, RecordCheck};
+        let main = Arc::new(MockSink::new());
+        let dlq_sink = Arc::new(MockSink::new());
+        let quality = Arc::new(
+            CompiledQuality::compile(&QualitySpec {
+                record: vec![RecordCheck::NotNull {
+                    field: "id".into(),
+                    treat_missing_as_null: true,
+                    on_failure: OnFailure::Quarantine,
+                }],
+                batch: vec![],
+            })
+            .unwrap(),
+        );
+        let pages: Vec<Result<StreamPage, FaucetError>> = vec![Ok(StreamPage {
+            records: vec![json!({"id": null}), json!({"id": "bad"}), json!({"id": 3})],
+            bookmark: None,
+        })];
+        let opts = RunStreamOptions::new()
+            .with_dlq(DlqConfig::new(dlq_sink.clone()))
+            .with_quality(quality)
+            .with_contract(compiled_contract("quarantine"));
+        let result = run_stream(futures::stream::iter(pages), main.as_ref(), opts)
+            .await
+            .unwrap();
+
+        assert_eq!(result.records_written, 1);
+        assert_eq!(main.written(), vec![json!({"id": 3})]);
+        let dlq = dlq_sink.written();
+        assert_eq!(dlq.len(), 2);
+        let kinds: Vec<&str> = dlq
+            .iter()
+            .map(|e| e["error"]["kind"].as_str().unwrap())
+            .collect();
+        assert!(kinds.contains(&"QualityFailure"), "kinds: {kinds:?}");
+        assert!(kinds.contains(&"ContractViolation"), "kinds: {kinds:?}");
+        assert_eq!(result.dlq.unwrap().records_dlq, 2);
     }
 
     /// Sink whose write_batch_partial fails every Nth record; drives the

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -26,6 +26,7 @@
 - [Dead-letter queues](./cookbook/dlq.md)
 - [Resilience (retry / circuit breaker / poison-pill)](./cookbook/resilience.md)
 - [Data-quality checks](./cookbook/quality.md)
+- [Data contracts](./cookbook/contracts.md)
 - [Compression](./cookbook/compression.md)
 - [Record transforms](./cookbook/transforms.md)
 - [SQL transform](./cookbook/sql-transform.md)

--- a/docs/book/src/cookbook/contracts.md
+++ b/docs/book/src/cookbook/contracts.md
@@ -1,0 +1,171 @@
+# Data contracts
+
+A **data contract** is a declarative, versioned promise about a pipeline's
+*output*: which fields exist, their types, whether they may be null, which
+values are allowed, and what patterns/bounds they must satisfy. Producers and
+consumers agree on the contract; faucet enforces it at runtime.
+
+Contracts complement the other governance layers:
+
+- [Quality checks](./quality.md) validate records against *ad-hoc rules*
+  (per-record and per-batch). A contract is a stronger, first-class, versioned
+  promise about the dataset's whole shape.
+- [Schema drift](./schema-drift.md) decides *how the destination table
+  evolves* when the shape changes. A contract decides *what is allowed to
+  change at all*.
+
+## Declaring a contract
+
+The `contract:` block is pipeline-level (a sibling of `source` / `sink` /
+`transforms` inside `pipeline:`; no matrix-row override in v1):
+
+```yaml
+version: 1
+name: orders
+
+pipeline:
+  source: { type: csv, config: { path: ./orders.csv } }
+
+  contract:
+    version: "1.0.0"                  # required, non-empty
+    description: Orders exported for the analytics team.
+    owner: data-platform
+    on_breach: quarantine             # fail (default) | quarantine | warn
+    allow_extra_fields: true          # default true
+    fields:
+      - name: order_id
+        type: string                  # string | integer | number | boolean | object | array
+        min_length: 1
+      - name: status
+        type: string
+        enum: [open, shipped, cancelled]
+      - name: amount
+        type: number
+        min: 0
+      - name: customer_email
+        type: string
+        pattern: '^[^@\s]+@[^@\s]+\.[^@\s]+$'
+        required: false               # default true
+        nullable: true                # default false
+
+  dlq:
+    sink: { type: jsonl, config: { path: ./dlq/contract_breaches.jsonl } }
+
+  sink: { type: jsonl, config: { path: ./orders_out.jsonl } }
+```
+
+Runnable example: `cli/examples/csv_to_jsonl_with_contract.yaml`.
+
+### Field rules
+
+| Field | Default | Purpose |
+|-------|---------|---------|
+| `name` | — | Top-level field name. Contracts describe the output's **top-level** shape; a nested object is typed as one `object` column (matching the schema-drift convention). |
+| `type` | — | `string`, `integer` (a JSON number with no fractional part), `number` (any JSON number), `boolean`, `object`, `array`. |
+| `required` | `true` | The field must be present in every record. An absent *optional* field skips all other checks. |
+| `nullable` | `false` | An explicit JSON `null` is allowed (and skips the value checks). |
+| `enum` | — | Allowed values (exact JSON equality). Values must match the declared `type`; use `nullable` for null (null inside `enum` is rejected). |
+| `pattern` | — | Regex the value must match. String fields only. |
+| `min` / `max` | — | Inclusive numeric bounds. Integer/number fields only. |
+| `min_length` / `max_length` | — | Inclusive string length bounds (characters). String fields only. |
+| `description` | — | Documentation; carried into every export format. |
+
+Contract-level: `version` (required), `description`, `owner`, `on_breach`,
+and `allow_extra_fields` (when `false`, an undeclared top-level key is a
+breach).
+
+Per record, the **first breach wins** — fields are checked in declared order
+(presence → null → type → enum → pattern → range → length), then the
+extra-field check. Each breach carries a stable `rule` label: `missing`,
+`null`, `type`, `enum`, `pattern`, `range`, `length`, `extra_field`,
+`not_object`.
+
+## Enforcement policies (`on_breach`)
+
+The pass runs per page **after** transforms and quality checks and **before**
+the sink write (and before the schema-drift pass):
+
+- **`fail`** (default) — the run aborts with a typed
+  `ContractViolation` error on the first breach. Nothing from the breaching
+  page is written: a contract must never commit breaching data.
+- **`quarantine`** — breaching records are routed to the
+  [DLQ](./dlq.md) wrapped in the standard envelope (`error.kind:
+  "ContractViolation"`, the message names the field, rule, and contract
+  version); conforming records are written. Requires a `dlq:` block —
+  validated at config-load time. DLQ failure budgets
+  (`max_failures_per_page` / `max_failures_total`) count contract breaches
+  alongside quality quarantines and sink-side row failures.
+- **`warn`** — breaches are logged (once per run) and counted in metrics, but
+  every record is written unchanged. Use this to trial a contract against
+  live traffic before turning on enforcement.
+
+A malformed contract — empty version, duplicate/empty field names, an invalid
+regex, an empty or type-mismatched `enum`, constraints on the wrong type,
+`min > max` — is rejected at config-load time (`faucet validate` catches it),
+never mid-run.
+
+**Exactly-once:** `fail` and `warn` compose with `delivery: exactly_once`;
+`quarantine` does not (exactly-once forbids a DLQ).
+
+## Validating, printing, and publishing (`faucet contract`)
+
+```console
+$ faucet contract pipeline.yaml
+contract v1.0.0 — valid (4 fields)
+  owner: data-platform
+  on_breach: quarantine
+  allow_extra_fields: true
+  fields:
+    - order_id: string (length)
+    - status: string (enum[3])
+    ...
+```
+
+`--export` emits a machine-readable artifact for downstream consumers:
+
+| Format | Output |
+|--------|--------|
+| `--export contract` | The canonical contract document as JSON. |
+| `--export json-schema` | A standalone JSON Schema (draft 2020-12): `required` from the required fields, `additionalProperties` from `allow_extra_fields`, `nullable` widening `type` to `[..., "null"]`, and the contract version as `x-faucet-contract-version`. |
+| `--export openlineage` | An OpenLineage `SchemaDatasetFacet` document — the same facet shape `faucet-lineage` emits, so OpenLineage consumers can ingest the contract as a schema promise. |
+
+`faucet schema contract` prints the JSON Schema of the `contract:` block
+itself (for editor autocompletion / config linting).
+
+### Versioning
+
+The `version` string travels into every breach error, DLQ envelope, and
+export, so consumers can pin the exact promise they built against.
+Recommendation: treat it like semver — bump the **major** version for
+breaking changes (removing a field, narrowing a type, tightening a
+constraint) and the **minor** version for additive ones (a new optional
+field). Enforcement is always against the version in the running config; a
+central contract registry is out of scope for v1.
+
+## Observability
+
+- `faucet_contract_violations_total{pipeline,row,field,rule,mode}` — one
+  increment per breach under `warn` / `quarantine`.
+- `faucet_contract_aborts_total{pipeline,row}` — a `fail`-policy abort.
+- The pass runs inside a `faucet.contract.apply` tracing span carrying the
+  contract version.
+- Quarantined pages surface through the standard DLQ metrics
+  (`faucet_sink_dlq_records_total`, …).
+
+## Library usage
+
+```rust,ignore
+use faucet_core::{CompiledContract, ContractSpec, Pipeline};
+use std::sync::Arc;
+
+let spec: ContractSpec = serde_yaml::from_str(yaml)?;   // or serde_json
+let compiled = Arc::new(CompiledContract::compile(&spec)?);
+
+let result = Pipeline::new(&source, &sink)
+    .with_contract(compiled)        // requires the `contract` feature
+    .run()
+    .await?;
+```
+
+Exports are plain functions: `faucet_core::contract::to_json_schema(&spec)`
+and `to_openlineage_facet(&spec, producer)`.

--- a/docs/book/src/cookbook/quality.md
+++ b/docs/book/src/cookbook/quality.md
@@ -15,6 +15,11 @@ Quality checks require the `quality` Cargo feature (included in `full` and in
 `faucet-cli`'s default build). The `json_schema` check additionally requires
 `quality-jsonschema`.
 
+> Quality checks are *ad-hoc rules*. For a first-class, **versioned promise**
+> about the dataset's whole output shape — enforced at runtime and exportable
+> as JSON Schema / an OpenLineage facet — see
+> [Data contracts](./contracts.md).
+
 ## Full example
 
 The following config fetches users from a REST API, normalises keys to snake_case,

--- a/docs/book/src/reference/cli.md
+++ b/docs/book/src/reference/cli.md
@@ -106,6 +106,7 @@ faucet schema sink bigquery
 faucet schema transform keys_case
 faucet schema dlq
 faucet schema execution
+faucet schema contract
 faucet schema secrets
 faucet schema triggers
 ```
@@ -167,6 +168,22 @@ probing (same semantics as `run` and `validate`).
 
 See the [Troubleshooting](../cookbook/troubleshooting.md) cookbook page for
 reading the output and common failures.
+
+## `contract`
+
+```bash
+faucet contract pipeline.yaml                       # validate + human summary
+faucet contract pipeline.yaml --export contract     # canonical contract JSON
+faucet contract pipeline.yaml --export json-schema  # standalone JSON Schema
+faucet contract pipeline.yaml --export openlineage  # OpenLineage schema facet
+```
+
+Validates the config's `pipeline.contract:` block (a malformed contract exits
+non-zero with the compile error) and prints a summary of the promised fields,
+constraints, and breach policy — or, with `--export`, a machine-readable
+artifact for downstream consumers. Offline-safe: secrets are never fetched.
+Requires the `contract` Cargo feature (in the default build). See the
+[Data contracts](../cookbook/contracts.md) cookbook page.
 
 ## `replicate`
 

--- a/docs/book/src/reference/config.md
+++ b/docs/book/src/reference/config.md
@@ -332,6 +332,51 @@ Against a **schemaless** sink (jsonl, csv, stdout, mongodb, redis, http, kafka,
 s3, gcs, snowflake, parquet) any non-`evolve` policy is inert — the sink reports
 no schema to diverge from.
 
+## `contract`
+
+Optional **pipeline-level** block (a sibling of `source` / `sink` /
+`transforms` inside `pipeline:`; no matrix-row override in v1) declaring a
+**data contract**: a versioned promise about the pipeline's output shape,
+enforced per page after transforms and quality checks and before the sink
+write. Requires the `contract` Cargo feature (in the default build). See the
+[Data contracts cookbook](../cookbook/contracts.md) for the full model and
+`faucet schema contract` for the block's JSON Schema.
+
+```yaml
+pipeline:
+  contract:
+    version: "1.0.0"            # required, non-empty
+    description: Orders feed.   # optional metadata
+    owner: data-platform        # optional metadata
+    on_breach: fail             # fail (default) | quarantine | warn
+    allow_extra_fields: true    # default true
+    fields:                     # required, non-empty; names unique
+      - name: order_id
+        type: string            # string | integer | number | boolean | object | array
+        required: true          # default true
+        nullable: false         # default false
+        min_length: 1           # string-only (with max_length)
+      - name: status
+        type: string
+        enum: [open, shipped, cancelled]
+      - name: amount
+        type: number
+        min: 0                  # numeric-only (with max)
+```
+
+| Field | Default | Purpose |
+|-------|---------|---------|
+| `version` | — | Carried into breach errors, DLQ envelopes, and exports. Semver recommended (major = breaking, minor = additive). |
+| `on_breach` | `fail` | `fail` aborts on the first breach (nothing from the page is written); `quarantine` routes breaching records to the DLQ and writes the rest (requires a `dlq:` block — validated at load time); `warn` logs + counts but writes everything. |
+| `allow_extra_fields` | `true` | When `false`, an undeclared top-level key is a breach (`extra_field`). |
+| `fields[]` | — | Per-field type + constraints: `required`, `nullable`, `enum`, `pattern` (string), `min`/`max` (numeric, inclusive), `min_length`/`max_length` (string, inclusive), `description`. |
+
+A malformed contract (empty version, duplicate fields, invalid regex, empty or
+type-mismatched `enum`, constraints on the wrong type, `min > max`) is a
+config-load error — `faucet validate` catches it. `fail`/`warn` compose with
+`delivery: exactly_once`; `quarantine` does not (exactly-once forbids a DLQ).
+Inspect or export the contract with [`faucet contract`](./cli.md#contract).
+
 ## `execution`
 
 - `max_concurrent` — one shared concurrency budget across roots and child

--- a/examples/README.md
+++ b/examples/README.md
@@ -32,6 +32,7 @@ These run immediately after installing the CLI — great for a first smoke test:
 | Example | Notes |
 |---------|-------|
 | `csv_to_jsonl.yaml` | the canonical smoke test (`make demo` runs this) |
+| `csv_to_jsonl_with_contract.yaml` | a versioned data contract (`contract:` block) quarantining breaching records to a DLQ; inspect with `faucet contract` |
 | `csv_to_jsonl_sql.yaml` | CSV → SQL GROUP BY + LEFT JOIN (embedded DuckDB) → JSONL; requires `--features transform-sql` |
 | `csv_to_sqlite.yaml` | CSV → local SQLite file |
 | `sqlite_to_jsonl.yaml`, `sqlite_to_csv.yaml` | local SQLite → file |

--- a/faucet-stream/Cargo.toml
+++ b/faucet-stream/Cargo.toml
@@ -87,6 +87,9 @@ auth = ["dep:faucet-auth"]
 ## `faucet-core`.
 quality = ["faucet-core/quality"]
 quality-jsonschema = ["quality", "faucet-core/quality-jsonschema"]
+## Data contracts (`contract:` config block, #204): a versioned output
+## schema/constraint promise enforced per page. Forwarded to `faucet-core`.
+contract = ["faucet-core/contract"]
 ## OpenLineage emission (`lineage:` config block). `lineage-kafka` adds the
 ## Kafka transport. Forwarded to `faucet-lineage`.
 lineage = ["dep:faucet-lineage"]
@@ -94,7 +97,7 @@ lineage-kafka = ["lineage", "faucet-lineage/transport-kafka"]
 ## SQL-as-transform via embedded DuckDB.
 transform-sql = ["dep:faucet-transform-sql"]
 ## Every connector and state backend.
-full = ["source", "sink", "state", "auth", "kafka-schema-registry", "compression", "quality", "quality-jsonschema", "lineage", "lineage-kafka", "transform-sql", "transform-cdc-unwrap"]
+full = ["source", "sink", "state", "auth", "kafka-schema-registry", "compression", "quality", "quality-jsonschema", "contract", "lineage", "lineage-kafka", "transform-sql", "transform-cdc-unwrap"]
 
 ## Individual source connectors.
 source-rest = ["dep:faucet-source-rest"]

--- a/faucet-stream/README.md
+++ b/faucet-stream/README.md
@@ -113,6 +113,7 @@ The `memory` and `file` state stores are always available via `faucet-core`. The
 | `auth` | Shared single-flight auth providers (`faucet-auth`) — OAuth2 client-credentials / refresh, token-endpoint — reusable across connectors |
 | `quality` | Data-quality checks (the `quality:` config block) — per-record and per-batch |
 | `quality-jsonschema` | Adds the `json_schema` record check (implies `quality`) |
+| `contract` | Data contracts (the `contract:` config block) — a versioned output schema/constraint promise enforced per page (fail / quarantine / warn) |
 | `lineage` | OpenLineage emission (the `lineage:` block) — HTTP + file transports |
 | `lineage-kafka` | Adds the Kafka lineage transport (implies `lineage`) |
 | `transform-sql` | SQL-as-transform via embedded DuckDB — each page is a `batch` relation |


### PR DESCRIPTION
## Summary

Adds **data contracts** (#204): a declarative, versioned schema + semantic contract for a pipeline's output — required fields, types, nullability, enum sets, regex patterns, numeric/length bounds — **enforced at runtime** per page with a contract-level `on_breach: fail | quarantine | warn` policy, and **publishable as an artifact** (canonical JSON / JSON Schema / OpenLineage `SchemaDatasetFacet`) via a new `faucet contract` verb.

Closes #204. Roadmap: #38.

## Core (`faucet-core`, new `contract` feature = `dep:regex`)

- `contract/config.rs` — `ContractSpec` (`version` required, `description`/`owner` metadata, `on_breach` default **fail**, `allow_extra_fields` default true) + `FieldContract` (type `string|integer|number|boolean|object|array`, `required`/`nullable`, `enum`, `pattern`, `min`/`max`, `min_length`/`max_length`, `description`). Top-level fields only, matching the schema-drift convention.
- `contract/compile.rs` — fail-fast `CompiledContract::compile`: empty version/fields, duplicate/empty names, invalid regex, empty/null-containing/type-mismatched `enum`, constraints on the wrong type, `min > max` → `FaucetError::Config` at load time, never mid-run. Regexes/enum sets compiled once (cheap per-page evaluation).
- `contract/mod.rs` — `apply_contract`: per record, first breach wins (fields in declared order, then the extra-field check); closed `rule` set (`missing|null|type|enum|pattern|range|length|extra_field|not_object`).
- `contract/export.rs` — pure `to_json_schema` (draft 2020-12; `required`/`additionalProperties`/nullable-widening; version as `x-faucet-contract-version`) and `to_openlineage_facet` (same facet shape `faucet-lineage` emits).
- New `FaucetError::ContractViolation { version, message }`; `DlqReason::Contract`.

## Pipeline pass

Runs per page **after quality, before schema drift** (`Pipeline::with_contract` / `RunStreamOptions::with_contract`):

- **`fail`** mirrors a quality `abort`: the typed error propagates immediately and **nothing from the page is written** — a contract never commits breaching data (deliberately unlike drift-`fail`, which defers because its records are individually fine).
- **`quarantine`** routes breaching records into the same DLQ write as quality/drift envelopes (error kind `ContractViolation`, `record_index` = page position, shared failure budgets). Requires a `dlq:` block — gated at expand time *and* at run start. Transitively incompatible with exactly-once (DLQ ban), no extra gate needed.
- **`warn`** writes everything, warns once per run, counts every breach.
- Metrics: `faucet_contract_violations_total{pipeline,row,field,rule,mode}` + `faucet_contract_aborts_total{pipeline,row}` (from `instrumented_apply_contract`, inside a `faucet.contract.apply` span). Bounded cardinality: fields come from the contract, `rule`/`mode` are closed sets.

## CLI

- `pipeline.contract:` block (pipeline-level, like `quality:`); expand-time compile surfaces malformed contracts in `faucet validate`.
- **`faucet contract [CONFIG]`** — validates + prints a human summary; `--export contract|json-schema|openlineage` emits the machine-readable artifact. Offline-safe (no secret fetch).
- **`faucet schema contract`** — JSON Schema of the block itself.
- `contract` feature in the CLI **default** build; forwarded by the umbrella crate; in `full`; CI feature-isolation matrix entry.

## Tests

- Core: 51 unit tests (compile validation, all nine breach rules, all three policies, page-index preservation, exports) + `run_stream` integration tests (quarantine→DLQ envelope, fail-writes-nothing, warn-writes-all, no-DLQ rejection, quality+contract sharing one DLQ write).
- CLI: expand-gate tests, config parse test, command unit tests, and 8 `assert_cmd` end-to-end tests (run under each policy, validate rejection, summary, both exports, missing-block error, schema verb).

## Docs

- New cookbook page `docs/book/src/cookbook/contracts.md` (+ SUMMARY); `## contract` in `reference/config.md`; `## contract` verb in `reference/cli.md`; `cli/README.md` + crate READMEs + root README; runnable `cli/examples/csv_to_jsonl_with_contract.yaml` (validates in the shipped-examples test).

## Out of scope (per issue)

- Central contract registry/marketplace; cross-pipeline contract negotiation. Version *comparison* across runs needs a registry, so `version` is enforced-as-declared and carried into every error/envelope/export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)