### PR TITLE
feat(cli): faucet test — fixture-based offline pipeline testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ cargo install faucet-cli
 faucet init my_pipeline --source postgres --sink bigquery   # scaffold pipeline.yaml from schemas
 faucet validate pipeline.yaml                               # parse + resolve secrets, no run
 faucet doctor pipeline.yaml                                 # preflight: probe auth/network/permissions
+faucet test tests/*.yaml                                    # offline fixture tests for pipeline logic
 faucet run pipeline.yaml                                    # one-shot run to completion
 faucet schedule pipeline.yaml                               # run on a cron schedule (add a schedule: block)
 faucet serve --no-auth                                      # HTTP control plane: submit/poll/cancel runs over REST
@@ -259,7 +260,7 @@ for help picking between overlapping connectors (Postgres query vs CDC, S3 vs Pa
 | [`faucet-lineage`](crates/lineage) | OpenLineage event emission — HTTP/file/Kafka transports, schema facets, column-lineage analysis |
 | [`faucet-transform-sql`](crates/transform-sql) | Embedded DuckDB SQL transform — run DuckDB SQL over each page (`batch` relation) |
 | [`faucet-stream`](faucet-stream) | Umbrella crate — feature-gated re-exports of all connectors and state backends |
-| [`faucet-cli`](cli) | `faucet` binary — YAML/JSON config-driven pipeline runner (`run`, `validate`, `schema`, `list`, `preview`, `init`, `doctor`, `schedule`, `serve`) |
+| [`faucet-cli`](cli) | `faucet` binary — YAML/JSON config-driven pipeline runner (`run`, `validate`, `schema`, `list`, `preview`, `init`, `doctor`, `test`, `schedule`, `serve`) |
 
 </details>
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -34,6 +34,7 @@ cargo install faucet-cli --no-default-features \
 | `faucet preview <config> --limit N` | Run only the source side and emit the first N records to stdout as JSONL. |
 | `faucet init [name] [--source X] [--sink Y]` | Scaffold a pipeline.yaml from each connector's JSON Schema. |
 | `faucet doctor <config> [--timeout-secs N] [--json]` | Probe every connector (auth/network/permissions/reachability) and print a checklist. Exits with the failed-probe count. |
+| `faucet test <specs…> [--filter S] [--json] [--clock C]` | Run fixture-based **offline** pipeline tests: stream sample records through a config's transforms/quality/contract with in-memory source/sink/DLQ and assert the output. Exits with the failed-case count. `faucet schema test` prints the spec-file JSON Schema. |
 | `faucet contract <config> [--export contract\|json-schema\|openlineage]` | Validate the `pipeline.contract:` block and print a summary, or export the data contract as canonical JSON / JSON Schema / an OpenLineage schema facet. `faucet schema contract` prints the block's own JSON Schema. |
 | `faucet schedule <config> [--once]` | Run a pipeline on a cron schedule (long-running foreground process). Requires a `schedule:` block. |
 
@@ -80,6 +81,53 @@ Flags:
 **Exit code** = the number of failed probes, clamped to 255 (so `0` means all probes passed). **Child invocations** (parent/child matrix rows) are listed but not probed — their configs depend on parent records that only exist at run time. Probe `reason`/`hint` text is scrubbed for resolved secrets before printing, but third-party connectors should never place credentials in a probe message.
 
 **Probe contract for connector authors:** `Source::check` / `Sink::check` / `StateStore::check` (in `faucet-core`) default to a generic probe (source) or "not implemented" skip (sink / state). Override them with a probe that is **idempotent and side-effect-free** and never echoes credentials. Return probe-level failures as `ProbeStatus::Fail` inside an `Ok(CheckReport)`; reserve `Err` for "couldn't run any probe".
+
+### `faucet test`
+
+`faucet test <specs…>` runs fixture-based, **fully-offline** pipeline tests. A spec file declares sample input records, the pipeline logic under test (a config file's transforms/quality/contract — or the same declared inline), and the expected outcome; the runner streams the fixtures through the real per-page pipeline path with an in-memory source, sink, and DLQ. No configured source or sink is ever built or contacted, so pipeline logic is assertable in CI with nothing but the `faucet` binary.
+
+```bash
+faucet test tests/*.yaml                       # run every case in every spec
+faucet test tests/orders.yaml --filter null    # only cases whose name contains "null"
+faucet test tests/*.yaml --json                # machine-readable report
+faucet test tests/*.yaml --clock 2026-03-01    # default ${now.*} clock for cases without clock:
+```
+
+Spec grammar (see `faucet schema test` for the full JSON Schema):
+
+```yaml
+version: 1
+tests:
+  - name: null order ids quarantined   # unique per spec file
+    config: ../pipeline.yaml           # config under test (relative to the spec file)…
+    # pipeline: { transforms: […], quality: …, contract: … }   # …or inline logic instead
+    # row: shaped                      # matrix row id when the config expands to several
+    # page_size: 100                   # chunk fixtures into pages (0 = one page, default)
+    # clock: 2026-02-01T00:00:00Z      # pin ${now.*} for deterministic inline transforms
+    input:                             # inline records, or a .jsonl/.json/.yaml file path
+      - { OrderId: 1, Amount: 9.5 }
+      - { OrderId: null, Amount: 3.0 }
+    expect:                            # every set field is asserted; at least one required
+      records: [ { order_id: 1, amount: 9.5 } ]   # exact sink output, in order
+      dlq: [ { order_id: null, amount: 3.0 } ]    # quarantined payloads (envelope metadata ignored)
+      # records_written: 1 / dlq_count: 1         # count-only alternatives
+      # error: "Contract v1.0.0 violated"         # the run must FAIL with this substring
+      # unordered: true                           # compare records/dlq as multisets
+      # match: subset                             # expected records name only the fields they assert
+```
+
+Failures print a structured path diff (`records[0].amount: expected 9.5, got 3.0`); the **exit code** is the failed-case count clamped to 255. The `schema:` (drift) block is inert offline; referenced configs load without contacting secrets managers (pass `--resolve-secrets` to opt in). A runnable example lives in [`examples/tests/`](examples/tests/); the [testing cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/testing.html) has the full walkthrough and CI recipe.
+
+Flags:
+
+| Flag | Purpose |
+|------|---------|
+| `--filter <substring>` | Run only cases whose name contains the substring. |
+| `--json` | Emit a `{ total, passed, failed, tests }` JSON report. |
+| `--clock <value>` | Default `${now.*}` clock for cases without their own `clock:` (RFC 3339 or `YYYY-MM-DD`). |
+| `--profile <name>` | Profile overlay applied to referenced configs (as in `run`). |
+| `--resolve-secrets` | Resolve `${vault:…}`-style directives in referenced configs (network). Default: offline. |
+| `--env-file <path>` / `--no-env-file` | Same `.env` handling as `run` / `validate`. |
 
 ### `faucet schedule`
 

--- a/cli/examples/tests/fixtures/orders.jsonl
+++ b/cli/examples/tests/fixtures/orders.jsonl
@@ -1,0 +1,2 @@
+{"OrderId": 42, "Amount": 100.0}
+{"OrderId": 43, "Amount": 250.25}

--- a/cli/examples/tests/pipeline.yaml
+++ b/cli/examples/tests/pipeline.yaml
@@ -1,0 +1,30 @@
+# A small pipeline used by `pipeline_tests.yaml` to demonstrate `faucet test`.
+# The csv source and jsonl sink are never touched by tests — only the
+# transforms, quality checks, and contract run against fixture records.
+version: 1
+name: orders
+pipeline:
+  source:
+    type: csv
+    config:
+      path: ./orders.csv
+  sink:
+    type: jsonl
+    config:
+      path: ./orders.jsonl
+  transforms:
+    - type: keys_case
+      config: { mode: snake }
+  quality:
+    record:
+      - { type: not_null, field: order_id, on_failure: quarantine }
+  contract:
+    version: "1.0.0"
+    fields:
+      - { name: order_id, type: integer, required: true }
+      - { name: amount, type: number, required: true }
+  dlq:
+    sink:
+      type: jsonl
+      config:
+        path: ./orders_dlq.jsonl

--- a/cli/examples/tests/pipeline_tests.yaml
+++ b/cli/examples/tests/pipeline_tests.yaml
@@ -1,0 +1,69 @@
+# Fixture-based offline tests for pipeline.yaml — run with:
+#
+#   faucet test cli/examples/tests/pipeline_tests.yaml
+#
+# No source or sink is touched: fixture records stream through the real
+# transform → quality → contract path with an in-memory sink + DLQ.
+version: 1
+tests:
+  # Happy path: keys are snake_cased and clean rows pass the contract.
+  - name: clean orders pass through
+    config: pipeline.yaml
+    input:
+      - { OrderId: 1, Amount: 9.5 }
+      - { OrderId: 2, Amount: 12.0 }
+    expect:
+      records:
+        - { order_id: 1, amount: 9.5 }
+        - { order_id: 2, amount: 12.0 }
+
+  # Quality: a null order_id is quarantined to the DLQ; the rest still land.
+  - name: null order ids quarantined
+    config: pipeline.yaml
+    input:
+      - { OrderId: 1, Amount: 9.5 }
+      - { OrderId: null, Amount: 3.0 }
+    expect:
+      records: [ { order_id: 1, amount: 9.5 } ]
+      dlq: [ { order_id: null, amount: 3.0 } ]
+      dlq_count: 1
+
+  # Contract: a string amount breaches `type: number` and (on_breach: fail,
+  # the default) aborts the run — assertable via `expect.error`.
+  - name: string amount breaches the contract
+    config: pipeline.yaml
+    input:
+      - { OrderId: 1, Amount: not-a-number }
+    expect:
+      error: "Contract v1.0.0 violated"
+      records_written: 0
+
+  # Fixture records can live in a file (.jsonl / .json / .yaml) next to the
+  # spec. `match: subset` asserts only the named fields; `unordered` compares
+  # as a multiset.
+  - name: fixture file input
+    config: pipeline.yaml
+    input: fixtures/orders.jsonl
+    expect:
+      match: subset
+      unordered: true
+      records:
+        - { order_id: 43 }
+        - { order_id: 42 }
+
+  # Inline pipelines skip the config file entirely — handy for testing a
+  # transform chain in isolation. `${now.*}` in inline transforms resolves
+  # against the case `clock:` (or `--clock`), keeping the case deterministic.
+  - name: inline transform chain with a pinned clock
+    pipeline:
+      transforms:
+        - type: flatten
+          config: { separator: "_" }
+        - type: set
+          config: { values: { day: "${now.date}" } }
+    clock: 2026-02-01T00:00:00Z
+    input:
+      - { user: { name: Ada } }
+    expect:
+      records:
+        - { user_name: Ada, day: "2026-02-01" }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -37,6 +37,9 @@ pub enum Command {
     /// Probe every connector in a config (auth / network / permissions) and
     /// print a green/red checklist. Exits non-zero if any probe fails.
     Doctor(DoctorArgs),
+    /// Run fixture-based offline pipeline tests from one or more spec files.
+    /// No real source or sink is touched. Exits non-zero if any case fails.
+    Test(TestArgs),
     /// Validate a config's `contract:` block and print a summary, or export
     /// it in a machine-readable format (`--export`).
     #[cfg(feature = "contract")]
@@ -47,6 +50,43 @@ pub enum Command {
     /// Run a long-running HTTP control plane (submit / poll / cancel pipeline runs).
     #[cfg(feature = "serve")]
     Serve(ServeArgs),
+}
+
+/// `faucet test` arguments.
+#[derive(Debug, Parser)]
+pub struct TestArgs {
+    /// One or more test-spec files (`.yaml`, `.yml`, or `.json`), e.g.
+    /// `faucet test tests/*.yaml`.
+    #[arg(required = true)]
+    pub specs: Vec<PathBuf>,
+    /// Run only cases whose name contains this substring.
+    #[arg(long)]
+    pub filter: Option<String>,
+    /// Emit a machine-readable JSON report instead of the human checklist.
+    #[arg(long)]
+    pub json: bool,
+    /// Default `${now.*}` clock for cases without their own `clock:` field
+    /// (RFC3339 like `2026-01-31T00:00:00Z`, or a date `2026-01-31`).
+    /// Defaults to process start (UTC).
+    #[arg(long)]
+    pub clock: Option<String>,
+    /// Path to a `.env` file to load for `${env:VAR}` interpolation in
+    /// referenced pipeline configs. Defaults to `.env` in cwd if present.
+    #[arg(long, conflicts_with = "no_env_file")]
+    pub env_file: Option<PathBuf>,
+    /// Skip auto-loading `.env` from cwd.
+    #[arg(long)]
+    pub no_env_file: bool,
+    /// Select a named overlay from each referenced config's `profiles:` block.
+    /// Overrides the `FAUCET_PROFILE` env var.
+    #[arg(long, env = "FAUCET_PROFILE")]
+    pub profile: Option<String>,
+    /// Resolve `${vault:…}` / `${aws-sm:…}` / … secret directives in
+    /// referenced configs (requires network + credentials). By default tests
+    /// load configs offline and leave secret directives unresolved — safe
+    /// because the real source/sink configs holding them are never used.
+    #[arg(long)]
+    pub resolve_secrets: bool,
 }
 
 /// `faucet doctor` arguments.
@@ -350,6 +390,8 @@ pub enum SchemaTarget {
     /// JSON Schema for the `contract:` block.
     #[cfg(feature = "contract")]
     Contract,
+    /// JSON Schema for the `faucet test` spec file.
+    Test,
     /// Grammar reference for secrets-manager interpolation directives.
     Secrets,
     /// JSON Schema for the `schedule:` block.

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -14,6 +14,7 @@ pub mod schedule;
 pub mod schema;
 #[cfg(feature = "serve")]
 pub mod serve;
+pub mod test;
 pub mod validate;
 
 use crate::error::CliError;

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -9,7 +9,10 @@ use crate::expand::expand;
 
 /// Parse the optional `--clock` override (RFC3339 or `YYYY-MM-DD`), or default
 /// to process start. Returned as a UTC fixed-offset clock for `${now.*}`.
-fn resolve_run_clock(flag: Option<&str>) -> CliResult<chrono::DateTime<chrono::FixedOffset>> {
+/// Shared with `faucet test` (the `--clock` flag and per-case `clock:` field).
+pub(crate) fn resolve_run_clock(
+    flag: Option<&str>,
+) -> CliResult<chrono::DateTime<chrono::FixedOffset>> {
     use chrono::{DateTime, NaiveDate, TimeZone, Utc};
     match flag {
         None => Ok(Utc::now().fixed_offset()),

--- a/cli/src/commands/schema.rs
+++ b/cli/src/commands/schema.rs
@@ -52,6 +52,10 @@ pub async fn run(args: SchemaArgs) -> CliResult<()> {
             let s = faucet_core::schema_for!(crate::serve::triggers::spec::TriggersFile);
             serde_json::to_value(s).unwrap_or_else(|_| serde_json::json!({"type": "object"}))
         }
+        SchemaTarget::Test => {
+            let s = faucet_core::schema_for!(crate::pipeline_test::spec::TestSpecFile);
+            serde_json::to_value(s).unwrap_or_else(|_| serde_json::json!({"type": "object"}))
+        }
         SchemaTarget::Secrets => serde_json::json!({
             "title": "Secrets-manager interpolation grammar",
             "schemes": {

--- a/cli/src/commands/test.rs
+++ b/cli/src/commands/test.rs
@@ -1,0 +1,167 @@
+//! `faucet test` — run fixture-based offline pipeline tests (#210).
+//!
+//! Loads one or more spec files, resolves each case's pipeline logic (from a
+//! referenced config file or the inline `pipeline:` block), streams the
+//! fixture records through the real pipeline pass chain with in-memory
+//! source/sink/DLQ, and reports pass/fail per case. Exits non-zero (the
+//! failed-case count) when any case fails, so CI can gate on it.
+
+use crate::cli::TestArgs;
+use crate::config::PipelineConfig;
+use crate::error::{CliError, CliResult};
+use crate::expand::expand;
+use crate::pipeline_test::report::{CaseOutcome, TestReport};
+use crate::pipeline_test::runner::{ResolvedCase, run_case};
+use crate::pipeline_test::spec::{TestCase, load_spec};
+use crate::pipeline_test::{diff, fixtures};
+use chrono::{DateTime, FixedOffset};
+use std::path::Path;
+
+/// Execute the `test` subcommand.
+pub async fn run(args: TestArgs) -> CliResult<()> {
+    let cwd = std::env::current_dir()?;
+    let env_path =
+        crate::env_loader::resolve_env_file(args.env_file.as_deref(), args.no_env_file, &cwd)?;
+    crate::env_loader::load_env_file_if_present(env_path.as_deref())?;
+
+    let default_clock = crate::commands::run::resolve_run_clock(args.clock.as_deref())?;
+
+    let mut outcomes: Vec<CaseOutcome> = Vec::new();
+    for spec_path in &args.specs {
+        let spec = load_spec(spec_path)?;
+        let spec_dir = spec_path.parent().unwrap_or(Path::new("."));
+        for case in &spec.tests {
+            if let Some(f) = &args.filter
+                && !case.name.contains(f.as_str())
+            {
+                continue;
+            }
+            let resolved = resolve_case(case, spec_path, spec_dir, default_clock, &args).await?;
+            let run = run_case(&resolved).await?;
+            let failures = diff::evaluate(&case.expect, &run);
+            outcomes.push(CaseOutcome::new(
+                case.name.clone(),
+                spec_path.display().to_string(),
+                failures,
+            ));
+        }
+    }
+
+    if outcomes.is_empty() {
+        return Err(CliError::Config(match &args.filter {
+            Some(f) => format!("no test cases match --filter '{f}'"),
+            None => "no test cases found in the given spec file(s)".to_string(),
+        }));
+    }
+
+    let report = TestReport::new(outcomes);
+    if args.json {
+        println!("{}", report.render_json());
+    } else {
+        print!("{}", report.render_human());
+    }
+    if report.failed > 0 {
+        return Err(CliError::TestsFailed {
+            failed: report.failed,
+        });
+    }
+    Ok(())
+}
+
+/// Resolve a case's pipeline logic + fixtures into the runner's input.
+async fn resolve_case(
+    case: &TestCase,
+    spec_path: &Path,
+    spec_dir: &Path,
+    default_clock: DateTime<FixedOffset>,
+    args: &TestArgs,
+) -> CliResult<ResolvedCase> {
+    let at = |msg: String| {
+        CliError::Config(format!(
+            "{}: test '{}': {msg}",
+            spec_path.display(),
+            case.name
+        ))
+    };
+    let clock = match &case.clock {
+        Some(s) => crate::commands::run::resolve_run_clock(Some(s))
+            .map_err(|e| at(format!("clock: {e}")))?,
+        None => default_clock,
+    };
+    let input = fixtures::load_input(spec_dir, &case.input)?;
+
+    let resolved = match (&case.config, &case.pipeline) {
+        (Some(config_rel), None) => {
+            let config_path = spec_dir.join(config_rel);
+            // Offline by default: leave `${vault:…}`-style directives
+            // unresolved — the source/sink configs that hold them are
+            // replaced by fixtures anyway. `--resolve-secrets` opts into the
+            // real (network) resolution for the rare secret inside a
+            // transform/quality/contract block.
+            let cfg = if args.resolve_secrets {
+                PipelineConfig::from_path_async(&config_path, args.profile.as_deref()).await?
+            } else {
+                PipelineConfig::from_path_tolerating_secrets(&config_path, args.profile.as_deref())?
+            };
+            let nodes = expand(&cfg)?;
+            let node = match &case.row {
+                Some(row) => nodes.iter().find(|n| &n.id == row).ok_or_else(|| {
+                    at(format!(
+                        "row '{row}' not found in '{}' — available rows: {}",
+                        config_path.display(),
+                        ids(&nodes)
+                    ))
+                })?,
+                None if nodes.len() == 1 => &nodes[0],
+                None => {
+                    return Err(at(format!(
+                        "'{}' expands to {} invocations — set `row` to one of: {}",
+                        config_path.display(),
+                        nodes.len(),
+                        ids(&nodes)
+                    )));
+                }
+            };
+            if node.schema.is_some() {
+                tracing::warn!(
+                    test = %case.name,
+                    "the config's `schema:` (drift) block is inert in `faucet test` — \
+                     there is no destination schema offline"
+                );
+            }
+            ResolvedCase {
+                name: case.name.clone(),
+                transforms: node.transforms.clone(),
+                #[cfg(feature = "quality")]
+                quality: node.quality.clone(),
+                #[cfg(feature = "contract")]
+                contract: node.contract.clone(),
+                input,
+                page_size: case.page_size,
+                clock,
+            }
+        }
+        (None, Some(inline)) => ResolvedCase {
+            name: case.name.clone(),
+            transforms: inline.transforms.clone(),
+            #[cfg(feature = "quality")]
+            quality: inline.quality.clone(),
+            #[cfg(feature = "contract")]
+            contract: inline.contract.clone(),
+            input,
+            page_size: case.page_size,
+            clock,
+        },
+        // Spec validation guarantees exactly one of config/pipeline is set.
+        _ => unreachable!("spec validation enforces config XOR pipeline"),
+    };
+    Ok(resolved)
+}
+
+fn ids(nodes: &[crate::expand::ExpandedNode]) -> String {
+    nodes
+        .iter()
+        .map(|n| n.id.as_str())
+        .collect::<Vec<_>>()
+        .join(", ")
+}

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -353,6 +353,12 @@ pub enum CliError {
     #[error("{failed} preflight probe(s) failed")]
     DoctorFailed { failed: usize },
 
+    /// One or more `faucet test` cases failed. The report is printed by the
+    /// command; `main` maps this to an exit code equal to the failed-case
+    /// count (clamped to 255).
+    #[error("{failed} test case(s) failed")]
+    TestsFailed { failed: usize },
+
     /// A `faucet serve` startup or runtime failure (bind, auth gate, etc.).
     #[error("serve error: {0}")]
     Serve(String),

--- a/cli/src/executor.rs
+++ b/cli/src/executor.rs
@@ -1137,7 +1137,12 @@ pub async fn build_dlq_config(spec: &crate::config::DlqSpec) -> CliResult<DlqCon
 
 /// In-place `${now.*}` resolution against the run clock. Walks every string
 /// leaf and rewrites `${now.<token>}`; all other `${...}` tokens are untouched.
-fn resolve_now_inplace(value: &mut Value, clock: DateTime<FixedOffset>) -> CliResult<()> {
+/// Shared with `faucet test`, which applies the same pre-pass to transform
+/// configs under the case clock.
+pub(crate) fn resolve_now_inplace(
+    value: &mut Value,
+    clock: DateTime<FixedOffset>,
+) -> CliResult<()> {
     match value {
         Value::String(s) => {
             *s = crate::interpolate::resolve_now(s, clock)?;

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -27,6 +27,7 @@ pub mod interpolate;
 pub mod lineage_glue;
 pub mod merge;
 pub mod obs;
+pub mod pipeline_test;
 pub mod registry;
 pub mod replication;
 #[cfg(feature = "schedule")]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -29,6 +29,7 @@ async fn main() {
         Command::Preview(args) => commands::preview::run(args).await,
         Command::Init(args) => commands::init::run(args).await,
         Command::Doctor(args) => commands::doctor::run(args).await,
+        Command::Test(args) => commands::test::run(args).await,
         #[cfg(feature = "contract")]
         Command::Contract(args) => commands::contract::run(args).await,
         #[cfg(feature = "schedule")]
@@ -41,6 +42,11 @@ async fn main() {
         // `doctor` already printed its checklist; surface the failure count as
         // the exit code (clamped to 255) rather than the generic exit-1 path.
         if let CliError::DoctorFailed { failed } = &err {
+            std::process::exit((*failed).min(255) as i32);
+        }
+        // Same shape for `test`: the report is already printed; the exit code
+        // is the failed-case count (clamped to 255).
+        if let CliError::TestsFailed { failed } = &err {
             std::process::exit((*failed).min(255) as i32);
         }
         commands::report(&err);

--- a/cli/src/pipeline_test/diff.rs
+++ b/cli/src/pipeline_test/diff.rs
@@ -1,0 +1,476 @@
+//! Expectation evaluation for `faucet test` — pure record matching + a
+//! structured, path-based diff for failure messages.
+
+use crate::pipeline_test::runner::CaseRun;
+use crate::pipeline_test::spec::{Expectation, MatchMode};
+use serde_json::Value;
+
+/// Max differing paths listed per record mismatch, so a wholly-different
+/// record doesn't flood the report.
+const MAX_DIFF_PATHS: usize = 8;
+
+/// Evaluate an expectation against a finished run. Returns one message per
+/// failed assertion; an empty vec means the case passed.
+pub fn evaluate(expect: &Expectation, run: &CaseRun) -> Vec<String> {
+    let mut failures = Vec::new();
+
+    match (&expect.error, &run.error) {
+        (Some(want), Some(got)) => {
+            if !got.contains(want.as_str()) {
+                failures.push(format!(
+                    "error: expected message containing '{want}', got: {got}"
+                ));
+            }
+        }
+        (Some(want), None) => {
+            failures.push(format!(
+                "error: expected the run to fail with '{want}', but it succeeded"
+            ));
+        }
+        (None, Some(got)) => {
+            failures.push(format!("run failed unexpectedly: {got}"));
+        }
+        (None, None) => {}
+    }
+
+    if let Some(expected) = &expect.records {
+        failures.extend(match_records(
+            "records",
+            expected,
+            &run.written,
+            expect.match_mode,
+            expect.unordered,
+        ));
+    }
+    if let Some(expected) = &expect.dlq {
+        failures.extend(match_records(
+            "dlq",
+            expected,
+            &run.dlq_payloads,
+            expect.match_mode,
+            expect.unordered,
+        ));
+    }
+    if let Some(want) = expect.records_written
+        && want != run.records_written
+    {
+        failures.push(format!(
+            "records_written: expected {want}, got {}",
+            run.records_written
+        ));
+    }
+    if let Some(want) = expect.dlq_count
+        && want != run.dlq_payloads.len()
+    {
+        failures.push(format!(
+            "dlq_count: expected {want}, got {}",
+            run.dlq_payloads.len()
+        ));
+    }
+    failures
+}
+
+/// True when `actual` satisfies `expected` under `mode`.
+///
+/// `Exact` is deep equality. `Subset` lets actual objects carry extra fields
+/// at any depth; arrays still require equal length with per-element matching.
+pub fn value_matches(expected: &Value, actual: &Value, mode: MatchMode) -> bool {
+    match mode {
+        MatchMode::Exact => expected == actual,
+        MatchMode::Subset => subset_matches(expected, actual),
+    }
+}
+
+fn subset_matches(expected: &Value, actual: &Value) -> bool {
+    match (expected, actual) {
+        (Value::Object(e), Value::Object(a)) => e
+            .iter()
+            .all(|(k, ev)| a.get(k).is_some_and(|av| subset_matches(ev, av))),
+        (Value::Array(e), Value::Array(a)) => {
+            e.len() == a.len() && e.iter().zip(a).all(|(ev, av)| subset_matches(ev, av))
+        }
+        _ => expected == actual,
+    }
+}
+
+/// Match an expected record list against the actual list, producing failure
+/// messages. Ordered mode compares index-by-index; unordered mode greedily
+/// pairs each expected record with the first unclaimed matching actual.
+fn match_records(
+    label: &str,
+    expected: &[Value],
+    actual: &[Value],
+    mode: MatchMode,
+    unordered: bool,
+) -> Vec<String> {
+    let mut failures = Vec::new();
+    if expected.len() != actual.len() {
+        failures.push(format!(
+            "{label}: expected {} record(s), got {}",
+            expected.len(),
+            actual.len()
+        ));
+    }
+    if unordered {
+        let mut claimed = vec![false; actual.len()];
+        for (i, exp) in expected.iter().enumerate() {
+            let hit = actual
+                .iter()
+                .enumerate()
+                .find(|(j, act)| !claimed[*j] && value_matches(exp, act, mode));
+            match hit {
+                Some((j, _)) => claimed[j] = true,
+                None => failures.push(format!(
+                    "{label}[{i}]: no unmatched actual record equals {}",
+                    compact(exp)
+                )),
+            }
+        }
+    } else {
+        for (i, (exp, act)) in expected.iter().zip(actual).enumerate() {
+            if !value_matches(exp, act, mode) {
+                let mut paths = Vec::new();
+                diff_paths(exp, act, mode, &format!("{label}[{i}]"), &mut paths);
+                if paths.is_empty() {
+                    // Shape mismatch with no leaf-level detail (shouldn't
+                    // happen, but never report a bare "mismatch").
+                    paths.push(format!(
+                        "{label}[{i}]: expected {}, got {}",
+                        compact(exp),
+                        compact(act)
+                    ));
+                }
+                failures.extend(paths);
+            }
+        }
+    }
+    failures
+}
+
+/// Collect up to [`MAX_DIFF_PATHS`] `path: expected X, got Y` lines for two
+/// mismatching values.
+fn diff_paths(
+    expected: &Value,
+    actual: &Value,
+    mode: MatchMode,
+    path: &str,
+    out: &mut Vec<String>,
+) {
+    if out.len() >= MAX_DIFF_PATHS {
+        return;
+    }
+    match (expected, actual) {
+        (Value::Object(e), Value::Object(a)) => {
+            for (k, ev) in e {
+                match a.get(k) {
+                    Some(av) => diff_paths(ev, av, mode, &format!("{path}.{k}"), out),
+                    None => {
+                        if out.len() < MAX_DIFF_PATHS {
+                            out.push(format!(
+                                "{path}.{k}: expected {}, field missing",
+                                compact(ev)
+                            ));
+                        }
+                    }
+                }
+            }
+            if mode == MatchMode::Exact {
+                for k in a.keys() {
+                    if !e.contains_key(k) && out.len() < MAX_DIFF_PATHS {
+                        out.push(format!("{path}.{k}: unexpected field {}", compact(&a[k])));
+                    }
+                }
+            }
+        }
+        (Value::Array(e), Value::Array(a)) => {
+            if e.len() != a.len() {
+                out.push(format!(
+                    "{path}: expected array of {}, got {}",
+                    e.len(),
+                    a.len()
+                ));
+                return;
+            }
+            for (i, (ev, av)) in e.iter().zip(a).enumerate() {
+                diff_paths(ev, av, mode, &format!("{path}[{i}]"), out);
+            }
+        }
+        (e, a) => {
+            if !value_matches(e, a, mode) {
+                out.push(format!(
+                    "{path}: expected {}, got {}",
+                    compact(e),
+                    compact(a)
+                ));
+            }
+        }
+    }
+}
+
+/// Compact single-line JSON, truncated so one huge record can't flood a line.
+fn compact(v: &Value) -> String {
+    const MAX: usize = 120;
+    let s = v.to_string();
+    if s.chars().count() > MAX {
+        let cut: String = s.chars().take(MAX).collect();
+        format!("{cut}…")
+    } else {
+        s
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn run(written: Vec<Value>, dlq: Vec<Value>, error: Option<&str>) -> CaseRun {
+        CaseRun {
+            records_written: written.len(),
+            written,
+            dlq_payloads: dlq,
+            error: error.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn passing_exact_records() {
+        let expect = Expectation {
+            records: Some(vec![json!({"a": 1})]),
+            ..Default::default()
+        };
+        assert!(evaluate(&expect, &run(vec![json!({"a": 1})], vec![], None)).is_empty());
+    }
+
+    #[test]
+    fn mismatch_reports_field_path() {
+        let expect = Expectation {
+            records: Some(vec![json!({"a": 1, "b": {"c": "x"}})]),
+            ..Default::default()
+        };
+        let failures = evaluate(
+            &expect,
+            &run(vec![json!({"a": 1, "b": {"c": "y"}})], vec![], None),
+        );
+        assert_eq!(failures.len(), 1);
+        assert!(failures[0].contains("records[0].b.c"), "{failures:?}");
+        assert!(failures[0].contains("\"x\""), "{failures:?}");
+        assert!(failures[0].contains("\"y\""), "{failures:?}");
+    }
+
+    #[test]
+    fn exact_mode_flags_unexpected_and_missing_fields() {
+        let expect = Expectation {
+            records: Some(vec![json!({"a": 1})]),
+            ..Default::default()
+        };
+        let failures = evaluate(
+            &expect,
+            &run(vec![json!({"a": 1, "extra": 2})], vec![], None),
+        );
+        assert!(
+            failures.iter().any(|f| f.contains("unexpected field")),
+            "{failures:?}"
+        );
+
+        let expect = Expectation {
+            records: Some(vec![json!({"a": 1, "missing": 3})]),
+            ..Default::default()
+        };
+        let failures = evaluate(&expect, &run(vec![json!({"a": 1})], vec![], None));
+        assert!(
+            failures.iter().any(|f| f.contains("field missing")),
+            "{failures:?}"
+        );
+    }
+
+    #[test]
+    fn subset_mode_allows_extra_actual_fields() {
+        let expect = Expectation {
+            records: Some(vec![json!({"a": 1, "n": {"x": true}})]),
+            match_mode: MatchMode::Subset,
+            ..Default::default()
+        };
+        let actual = vec![json!({"a": 1, "n": {"x": true, "y": 0}, "extra": "ok"})];
+        assert!(evaluate(&expect, &run(actual, vec![], None)).is_empty());
+        // …but a wrong value still fails.
+        let failures = evaluate(
+            &expect,
+            &run(vec![json!({"a": 2, "n": {"x": true}})], vec![], None),
+        );
+        assert!(
+            failures.iter().any(|f| f.contains("records[0].a")),
+            "{failures:?}"
+        );
+    }
+
+    #[test]
+    fn subset_arrays_require_same_length() {
+        assert!(value_matches(
+            &json!({"tags": [1, 2]}),
+            &json!({"tags": [1, 2], "e": 3}),
+            MatchMode::Subset
+        ));
+        assert!(!value_matches(
+            &json!({"tags": [1]}),
+            &json!({"tags": [1, 2]}),
+            MatchMode::Subset
+        ));
+    }
+
+    #[test]
+    fn unordered_matches_as_multiset() {
+        let expect = Expectation {
+            records: Some(vec![json!({"a": 2}), json!({"a": 1})]),
+            unordered: true,
+            ..Default::default()
+        };
+        assert!(
+            evaluate(
+                &expect,
+                &run(vec![json!({"a": 1}), json!({"a": 2})], vec![], None)
+            )
+            .is_empty()
+        );
+        // Duplicates are counted: two expected {a:1} need two actuals.
+        let expect = Expectation {
+            records: Some(vec![json!({"a": 1}), json!({"a": 1})]),
+            unordered: true,
+            ..Default::default()
+        };
+        let failures = evaluate(
+            &expect,
+            &run(vec![json!({"a": 1}), json!({"a": 2})], vec![], None),
+        );
+        assert!(
+            failures.iter().any(|f| f.contains("no unmatched actual")),
+            "{failures:?}"
+        );
+    }
+
+    #[test]
+    fn length_mismatch_reported_once_with_counts() {
+        let expect = Expectation {
+            records: Some(vec![json!({"a": 1})]),
+            ..Default::default()
+        };
+        let failures = evaluate(&expect, &run(vec![], vec![], None));
+        assert_eq!(failures, vec!["records: expected 1 record(s), got 0"]);
+    }
+
+    #[test]
+    fn counts_and_dlq_assertions() {
+        let expect = Expectation {
+            records_written: Some(2),
+            dlq_count: Some(1),
+            dlq: Some(vec![json!({"bad": true})]),
+            ..Default::default()
+        };
+        let ok = run(
+            vec![json!({"a": 1}), json!({"a": 2})],
+            vec![json!({"bad": true})],
+            None,
+        );
+        assert!(evaluate(&expect, &ok).is_empty());
+
+        let wrong = run(vec![json!({"a": 1})], vec![], None);
+        let failures = evaluate(&expect, &wrong);
+        assert!(
+            failures
+                .iter()
+                .any(|f| f.contains("records_written: expected 2, got 1"))
+        );
+        assert!(
+            failures
+                .iter()
+                .any(|f| f.contains("dlq_count: expected 1, got 0"))
+        );
+        assert!(
+            failures
+                .iter()
+                .any(|f| f.contains("dlq: expected 1 record(s), got 0"))
+        );
+    }
+
+    #[test]
+    fn error_expectations() {
+        let expect = Expectation {
+            error: Some("contract".into()),
+            ..Default::default()
+        };
+        // Expected failure present and matching → pass.
+        assert!(
+            evaluate(
+                &expect,
+                &run(vec![], vec![], Some("contract violation: v1"))
+            )
+            .is_empty()
+        );
+        // Failure with a different message → fail.
+        let failures = evaluate(&expect, &run(vec![], vec![], Some("boom")));
+        assert!(
+            failures[0].contains("expected message containing 'contract'"),
+            "{failures:?}"
+        );
+        // Success when a failure was demanded → fail.
+        let failures = evaluate(&expect, &run(vec![], vec![], None));
+        assert!(failures[0].contains("but it succeeded"), "{failures:?}");
+        // Unexpected failure without `error:` → fail.
+        let expect = Expectation {
+            records_written: Some(0),
+            ..Default::default()
+        };
+        let failures = evaluate(&expect, &run(vec![], vec![], Some("boom")));
+        assert!(
+            failures[0].contains("run failed unexpectedly"),
+            "{failures:?}"
+        );
+    }
+
+    #[test]
+    fn diff_path_cap_and_truncation() {
+        // 20 differing fields → capped at MAX_DIFF_PATHS messages.
+        let mut e = serde_json::Map::new();
+        let mut a = serde_json::Map::new();
+        for i in 0..20 {
+            e.insert(format!("k{i:02}"), json!(1));
+            a.insert(format!("k{i:02}"), json!(2));
+        }
+        let expect = Expectation {
+            records: Some(vec![Value::Object(e)]),
+            ..Default::default()
+        };
+        let failures = evaluate(&expect, &run(vec![Value::Object(a)], vec![], None));
+        assert_eq!(failures.len(), MAX_DIFF_PATHS);
+
+        // A giant string value is truncated with an ellipsis.
+        let long = "x".repeat(500);
+        let expect = Expectation {
+            records: Some(vec![json!({"v": long})]),
+            ..Default::default()
+        };
+        let failures = evaluate(&expect, &run(vec![json!({"v": "short"})], vec![], None));
+        assert!(failures[0].contains('…'), "{failures:?}");
+    }
+
+    #[test]
+    fn array_length_and_scalar_type_mismatches() {
+        let expect = Expectation {
+            records: Some(vec![json!({"t": [1, 2, 3]})]),
+            ..Default::default()
+        };
+        let failures = evaluate(&expect, &run(vec![json!({"t": [1]})], vec![], None));
+        assert!(
+            failures[0].contains("expected array of 3, got 1"),
+            "{failures:?}"
+        );
+
+        // Whole-record shape mismatch (object vs scalar) still yields a message.
+        let expect = Expectation {
+            records: Some(vec![json!("scalar")]),
+            ..Default::default()
+        };
+        let failures = evaluate(&expect, &run(vec![json!({"a": 1})], vec![], None));
+        assert!(!failures.is_empty());
+    }
+}

--- a/cli/src/pipeline_test/fixtures.rs
+++ b/cli/src/pipeline_test/fixtures.rs
@@ -1,0 +1,162 @@
+//! Fixture-input loading for `faucet test`.
+//!
+//! A case's `input` is either an inline array of records or a path to a
+//! fixture file. Files resolve relative to the spec file's directory and may
+//! be `.jsonl` (one JSON record per line, blank lines skipped) or `.json` /
+//! `.yaml` / `.yml` (a top-level array).
+
+use crate::error::{CliError, CliResult};
+use crate::pipeline_test::spec::InputSpec;
+use serde_json::Value;
+use std::path::Path;
+
+/// Materialize a case's fixture records.
+pub fn load_input(spec_dir: &Path, input: &InputSpec) -> CliResult<Vec<Value>> {
+    match input {
+        InputSpec::Inline(records) => Ok(records.clone()),
+        InputSpec::Path(rel) => load_fixture_file(&spec_dir.join(rel)),
+    }
+}
+
+fn load_fixture_file(path: &Path) -> CliResult<Vec<Value>> {
+    let text = std::fs::read_to_string(path).map_err(|source| CliError::ReadConfig {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(str::to_ascii_lowercase);
+    match ext.as_deref() {
+        Some("jsonl" | "ndjson") => text
+            .lines()
+            .enumerate()
+            .filter(|(_, line)| !line.trim().is_empty())
+            .map(|(i, line)| {
+                serde_json::from_str(line).map_err(|e| CliError::ParseConfig {
+                    path: path.to_path_buf(),
+                    message: format!("line {}: {e}", i + 1),
+                })
+            })
+            .collect(),
+        Some("json") => as_array(
+            serde_json::from_str(&text).map_err(|e| CliError::ParseConfig {
+                path: path.to_path_buf(),
+                message: e.to_string(),
+            })?,
+            path,
+        ),
+        Some("yaml" | "yml") => as_array(
+            serde_yaml::from_str(&text).map_err(|e| CliError::ParseConfig {
+                path: path.to_path_buf(),
+                message: e.to_string(),
+            })?,
+            path,
+        ),
+        _ => Err(CliError::Config(format!(
+            "fixture file '{}' must be .jsonl, .ndjson, .json, .yaml, or .yml",
+            path.display()
+        ))),
+    }
+}
+
+fn as_array(v: Value, path: &Path) -> CliResult<Vec<Value>> {
+    match v {
+        Value::Array(records) => Ok(records),
+        other => Err(CliError::Config(format!(
+            "fixture file '{}' must hold a top-level array of records, got {}",
+            path.display(),
+            type_name(&other)
+        ))),
+    }
+}
+
+fn type_name(v: &Value) -> &'static str {
+    match v {
+        Value::Null => "null",
+        Value::Bool(_) => "a boolean",
+        Value::Number(_) => "a number",
+        Value::String(_) => "a string",
+        Value::Array(_) => "an array",
+        Value::Object(_) => "an object",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn inline_records_pass_through() {
+        let dir = tempfile::tempdir().unwrap();
+        let records = load_input(
+            dir.path(),
+            &InputSpec::Inline(vec![json!({"a": 1}), json!({"a": 2})]),
+        )
+        .unwrap();
+        assert_eq!(records.len(), 2);
+    }
+
+    #[test]
+    fn jsonl_fixture_skips_blank_lines() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("f.jsonl"), "{\"a\":1}\n\n{\"a\":2}\n").unwrap();
+        let records = load_input(dir.path(), &InputSpec::Path("f.jsonl".into())).unwrap();
+        assert_eq!(records, vec![json!({"a": 1}), json!({"a": 2})]);
+    }
+
+    #[test]
+    fn jsonl_bad_line_reports_line_number() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("f.jsonl"), "{\"a\":1}\nnot-json\n").unwrap();
+        let err = load_input(dir.path(), &InputSpec::Path("f.jsonl".into()))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("line 2"), "{err}");
+    }
+
+    #[test]
+    fn json_and_yaml_arrays_load() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("f.json"), r#"[{"a":1}]"#).unwrap();
+        std::fs::write(dir.path().join("f.yaml"), "- a: 1\n- a: 2\n").unwrap();
+        assert_eq!(
+            load_input(dir.path(), &InputSpec::Path("f.json".into())).unwrap(),
+            vec![json!({"a": 1})]
+        );
+        assert_eq!(
+            load_input(dir.path(), &InputSpec::Path("f.yaml".into()))
+                .unwrap()
+                .len(),
+            2
+        );
+    }
+
+    #[test]
+    fn non_array_json_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("f.json"), r#"{"a":1}"#).unwrap();
+        let err = load_input(dir.path(), &InputSpec::Path("f.json".into()))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("top-level array"), "{err}");
+        assert!(err.contains("an object"), "{err}");
+    }
+
+    #[test]
+    fn unknown_extension_and_missing_file_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("f.csv"), "a\n1\n").unwrap();
+        assert!(
+            load_input(dir.path(), &InputSpec::Path("f.csv".into()))
+                .unwrap_err()
+                .to_string()
+                .contains("must be .jsonl")
+        );
+        assert!(matches!(
+            load_input(dir.path(), &InputSpec::Path("missing.jsonl".into())),
+            Err(CliError::ReadConfig { .. })
+        ));
+    }
+}

--- a/cli/src/pipeline_test/mod.rs
+++ b/cli/src/pipeline_test/mod.rs
@@ -1,0 +1,23 @@
+//! `faucet test` — fixture-based, fully-offline pipeline testing (#210).
+//!
+//! A spec file declares test cases: fixture input records, the pipeline logic
+//! under test (a config file's transforms/quality/contract, or the same
+//! declared inline), and the expected outcome (output records, DLQ routing,
+//! counts, or an expected failure). The runner streams the fixtures through
+//! the real `faucet_core::Pipeline` loop with in-memory source/sink/DLQ, so
+//! CI can assert pipeline logic without any external infrastructure.
+//!
+//! Module layout mirrors `schedule/` and `replication/`:
+//! - [`spec`] — serde types + validation for the spec file (`faucet schema test`).
+//! - [`fixtures`] — fixture-input loading (inline / `.jsonl` / `.json` / `.yaml`).
+//! - [`runner`] — the offline execution harness (fixture source, capturing
+//!   sink + DLQ, the real pipeline pass chain).
+//! - [`diff`] — tolerant matchers (`exact`/`subset`, ordered/unordered) and
+//!   the structured path diff behind failure messages.
+//! - [`report`] — human checklist + `--json` rendering.
+
+pub mod diff;
+pub mod fixtures;
+pub mod report;
+pub mod runner;
+pub mod spec;

--- a/cli/src/pipeline_test/report.rs
+++ b/cli/src/pipeline_test/report.rs
@@ -1,0 +1,152 @@
+//! Rendering for `faucet test` results — the human checklist and the
+//! machine-readable `--json` document.
+
+use serde::Serialize;
+
+/// One test case's final result.
+#[derive(Debug, Serialize)]
+pub struct CaseOutcome {
+    /// Case name from the spec file.
+    pub name: String,
+    /// Spec file the case came from.
+    pub spec: String,
+    /// `"pass"` or `"fail"`.
+    pub status: &'static str,
+    /// One message per failed assertion (empty on pass).
+    pub failures: Vec<String>,
+}
+
+impl CaseOutcome {
+    pub fn new(name: String, spec: String, failures: Vec<String>) -> Self {
+        Self {
+            name,
+            spec,
+            status: if failures.is_empty() { "pass" } else { "fail" },
+            failures,
+        }
+    }
+
+    pub fn passed(&self) -> bool {
+        self.failures.is_empty()
+    }
+}
+
+/// The full report across every spec file.
+#[derive(Debug, Serialize)]
+pub struct TestReport {
+    pub total: usize,
+    pub passed: usize,
+    pub failed: usize,
+    pub tests: Vec<CaseOutcome>,
+}
+
+impl TestReport {
+    pub fn new(tests: Vec<CaseOutcome>) -> Self {
+        let total = tests.len();
+        let passed = tests.iter().filter(|t| t.passed()).count();
+        Self {
+            total,
+            passed,
+            failed: total - passed,
+            tests,
+        }
+    }
+
+    /// Render the human checklist, grouped by spec file in declared order.
+    pub fn render_human(&self) -> String {
+        let mut out = String::new();
+        let mut current_spec: Option<&str> = None;
+        for case in &self.tests {
+            if current_spec != Some(case.spec.as_str()) {
+                if current_spec.is_some() {
+                    out.push('\n');
+                }
+                out.push_str(&case.spec);
+                out.push('\n');
+                current_spec = Some(case.spec.as_str());
+            }
+            if case.passed() {
+                out.push_str(&format!("  ✓ {}\n", case.name));
+            } else {
+                out.push_str(&format!("  ✗ {}\n", case.name));
+                for failure in &case.failures {
+                    out.push_str(&format!("      - {failure}\n"));
+                }
+            }
+        }
+        out.push_str(&format!(
+            "\n{} test{}, {} passed, {} failed\n",
+            self.total,
+            if self.total == 1 { "" } else { "s" },
+            self.passed,
+            self.failed
+        ));
+        out
+    }
+
+    /// Render the `--json` document.
+    pub fn render_json(&self) -> String {
+        serde_json::to_string_pretty(self).expect("report serialization is infallible")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn report() -> TestReport {
+        TestReport::new(vec![
+            CaseOutcome::new("ok case".into(), "a.yaml".into(), vec![]),
+            CaseOutcome::new(
+                "bad case".into(),
+                "a.yaml".into(),
+                vec!["records[0].x: expected 1, got 2".into()],
+            ),
+            CaseOutcome::new("other".into(), "b.yaml".into(), vec![]),
+        ])
+    }
+
+    #[test]
+    fn counts_and_status() {
+        let r = report();
+        assert_eq!((r.total, r.passed, r.failed), (3, 2, 1));
+        assert_eq!(r.tests[0].status, "pass");
+        assert_eq!(r.tests[1].status, "fail");
+    }
+
+    #[test]
+    fn human_rendering_groups_by_spec() {
+        let text = report().render_human();
+        assert!(
+            text.contains("a.yaml\n  ✓ ok case\n  ✗ bad case\n"),
+            "{text}"
+        );
+        assert!(
+            text.contains("      - records[0].x: expected 1, got 2"),
+            "{text}"
+        );
+        assert!(text.contains("b.yaml\n  ✓ other"), "{text}");
+        assert!(text.contains("3 tests, 2 passed, 1 failed"), "{text}");
+    }
+
+    #[test]
+    fn singular_summary_line() {
+        let r = TestReport::new(vec![CaseOutcome::new(
+            "one".into(),
+            "s.yaml".into(),
+            vec![],
+        )]);
+        assert!(r.render_human().contains("1 test, 1 passed, 0 failed"));
+    }
+
+    #[test]
+    fn json_rendering_is_machine_readable() {
+        let v: serde_json::Value = serde_json::from_str(&report().render_json()).unwrap();
+        assert_eq!(v["total"], 3);
+        assert_eq!(v["tests"][1]["status"], "fail");
+        assert_eq!(
+            v["tests"][1]["failures"][0],
+            "records[0].x: expected 1, got 2"
+        );
+    }
+}

--- a/cli/src/pipeline_test/runner.rs
+++ b/cli/src/pipeline_test/runner.rs
@@ -8,7 +8,9 @@
 //! for the same records.
 
 use crate::config::TransformSpec;
-use crate::error::{CliError, CliResult};
+// `CliError` is referenced only inside the `quality`/`contract` cfg blocks —
+// import it there-adjacent via full path so slim builds stay warning-free.
+use crate::error::CliResult;
 use crate::transforms::compile_transforms;
 use async_trait::async_trait;
 use chrono::{DateTime, FixedOffset};
@@ -112,8 +114,9 @@ pub async fn run_case(case: &ResolvedCase) -> CliResult<CaseRun> {
     #[cfg(feature = "quality")]
     let pipeline = match &case.quality {
         Some(spec) => {
-            let compiled = faucet_core::CompiledQuality::compile(spec)
-                .map_err(|e| CliError::Config(format!("test '{}': quality: {e}", case.name)))?;
+            let compiled = faucet_core::CompiledQuality::compile(spec).map_err(|e| {
+                crate::error::CliError::Config(format!("test '{}': quality: {e}", case.name))
+            })?;
             pipeline.with_quality(Arc::new(compiled))
         }
         None => pipeline,
@@ -121,8 +124,9 @@ pub async fn run_case(case: &ResolvedCase) -> CliResult<CaseRun> {
     #[cfg(feature = "contract")]
     let pipeline = match &case.contract {
         Some(spec) => {
-            let compiled = faucet_core::CompiledContract::compile(spec)
-                .map_err(|e| CliError::Config(format!("test '{}': contract: {e}", case.name)))?;
+            let compiled = faucet_core::CompiledContract::compile(spec).map_err(|e| {
+                crate::error::CliError::Config(format!("test '{}': contract: {e}", case.name))
+            })?;
             pipeline.with_contract(Arc::new(compiled))
         }
         None => pipeline,

--- a/cli/src/pipeline_test/runner.rs
+++ b/cli/src/pipeline_test/runner.rs
@@ -1,0 +1,392 @@
+//! Offline pipeline execution for `faucet test`.
+//!
+//! Runs the deterministic slice of a pipeline — transforms → quality →
+//! contract — through the *real* `faucet_core::Pipeline` streaming loop, with
+//! the configured source and sink replaced by in-memory fixtures/captures.
+//! Because the genuine per-page code path runs (including DLQ routing and
+//! abort semantics), what a test observes is exactly what production would do
+//! for the same records.
+
+use crate::config::TransformSpec;
+use crate::error::{CliError, CliResult};
+use crate::transforms::compile_transforms;
+use async_trait::async_trait;
+use chrono::{DateTime, FixedOffset};
+use faucet_core::observability::Labels;
+use faucet_core::{DlqConfig, FaucetError, Pipeline, Sink, Source, StreamPage};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+
+/// A test case with its pipeline logic and fixtures fully resolved — the
+/// runner's only input, shared by the config-file and inline paths.
+pub struct ResolvedCase {
+    /// Case name (used as the observability row label).
+    pub name: String,
+    /// Transform chain to apply (already layered for config-file cases).
+    pub transforms: Vec<TransformSpec>,
+    /// Quality checks to enforce per page.
+    #[cfg(feature = "quality")]
+    pub quality: Option<faucet_core::QualitySpec>,
+    /// Data contract to enforce per page.
+    #[cfg(feature = "contract")]
+    pub contract: Option<faucet_core::ContractSpec>,
+    /// Fixture records fed to the pipeline.
+    pub input: Vec<Value>,
+    /// Page size for the fixture source (`0` = single page).
+    pub page_size: usize,
+    /// `${now.*}` clock applied to transform configs.
+    pub clock: DateTime<FixedOffset>,
+}
+
+/// Everything a run produced, for the expectation pass.
+#[derive(Debug)]
+pub struct CaseRun {
+    /// Records the (capturing) sink received, in write order.
+    pub written: Vec<Value>,
+    /// Original payloads of DLQ envelopes, in routing order.
+    pub dlq_payloads: Vec<Value>,
+    /// Count reported by the pipeline (equals `written.len()`).
+    pub records_written: usize,
+    /// The run's error, when it failed (e.g. quality `abort`, contract
+    /// `on_breach: fail`, a transform error).
+    pub error: Option<String>,
+}
+
+/// Execute one resolved case fully offline. Only *setup* problems (an invalid
+/// transform config) surface as `Err`; a failing pipeline run is a legitimate,
+/// assertable outcome and lands in `CaseRun::error`.
+pub async fn run_case(case: &ResolvedCase) -> CliResult<CaseRun> {
+    // Resolve `${now.*}` in transform configs against the case clock — the
+    // same pre-pass `faucet run` applies (crate::executor) — so a `set`
+    // transform stamping `${now.date}` is deterministic under `clock:`.
+    let stages = if case.transforms.is_empty() {
+        Vec::new()
+    } else {
+        let mut transforms = case.transforms.clone();
+        for t in &mut transforms {
+            crate::executor::resolve_now_inplace(&mut t.config, case.clock)?;
+        }
+        compile_transforms(&transforms)?
+    };
+
+    let labels = Labels::new(
+        "faucet-test",
+        case.name.clone(),
+        uuid::Uuid::now_v7().to_string(),
+    );
+    let source: Box<dyn Source> = Box::new(FixtureSource {
+        records: case.input.clone(),
+        page_size: case.page_size,
+    });
+    let source: Box<dyn Source> = if stages.is_empty() {
+        source
+    } else {
+        Box::new(faucet_core::TransformingSource::new(
+            source,
+            stages,
+            labels.clone(),
+        )?)
+    };
+
+    let written = Arc::new(Mutex::new(Vec::new()));
+    let sink = CollectingSink {
+        buffer: Arc::clone(&written),
+        payload_key: None,
+    };
+    // The DLQ capture unwraps each envelope down to its original payload so
+    // expectations compare records, not timestamps/messages.
+    let dlq_payloads = Arc::new(Mutex::new(Vec::new()));
+    let dlq_sink = CollectingSink {
+        buffer: Arc::clone(&dlq_payloads),
+        payload_key: Some("payload"),
+    };
+
+    let pipeline = Pipeline::new(source.as_ref(), &sink)
+        .with_name("faucet-test")
+        .with_row(case.name.clone())
+        // Always attach a capturing DLQ so quality/contract `quarantine`
+        // policies are testable without a `dlq:` block in the config.
+        .with_dlq(DlqConfig::new(Arc::new(dlq_sink)));
+    #[cfg(feature = "quality")]
+    let pipeline = match &case.quality {
+        Some(spec) => {
+            let compiled = faucet_core::CompiledQuality::compile(spec)
+                .map_err(|e| CliError::Config(format!("test '{}': quality: {e}", case.name)))?;
+            pipeline.with_quality(Arc::new(compiled))
+        }
+        None => pipeline,
+    };
+    #[cfg(feature = "contract")]
+    let pipeline = match &case.contract {
+        Some(spec) => {
+            let compiled = faucet_core::CompiledContract::compile(spec)
+                .map_err(|e| CliError::Config(format!("test '{}': contract: {e}", case.name)))?;
+            pipeline.with_contract(Arc::new(compiled))
+        }
+        None => pipeline,
+    };
+
+    let (records_written, error) = match pipeline.run().await {
+        Ok(result) => (result.records_written, None),
+        Err(e) => (0, Some(e.to_string())),
+    };
+
+    // Take the buffers (the pipeline is done; the Arcs are only held here).
+    let written = std::mem::take(&mut *written.lock().expect("buffer lock"));
+    let dlq_payloads = std::mem::take(&mut *dlq_payloads.lock().expect("dlq lock"));
+    let records_written = if error.is_none() {
+        records_written
+    } else {
+        // On failure the pipeline reports no count; what the sink actually
+        // received before the abort is still the honest number.
+        written.len()
+    };
+    Ok(CaseRun {
+        written,
+        dlq_payloads,
+        records_written,
+        error,
+    })
+}
+
+/// In-memory source that streams fixture records, chunked by the case's own
+/// `page_size` (the pipeline's `batch_size` hint is ignored so a test's page
+/// boundaries are exactly what the spec declares).
+struct FixtureSource {
+    records: Vec<Value>,
+    page_size: usize,
+}
+
+#[async_trait]
+impl Source for FixtureSource {
+    async fn fetch_with_context(
+        &self,
+        _context: &HashMap<String, Value>,
+    ) -> Result<Vec<Value>, FaucetError> {
+        Ok(self.records.clone())
+    }
+
+    fn stream_pages<'a>(
+        &'a self,
+        _context: &'a HashMap<String, Value>,
+        _batch_size: usize,
+    ) -> Pin<Box<dyn faucet_core::Stream<Item = Result<StreamPage, FaucetError>> + Send + 'a>> {
+        let chunk = if self.page_size == 0 {
+            usize::MAX
+        } else {
+            self.page_size
+        };
+        Box::pin(faucet_core::async_stream::try_stream! {
+            let mut iter = self.records.iter().cloned();
+            loop {
+                let page: Vec<Value> = iter.by_ref().take(chunk).collect();
+                if page.is_empty() {
+                    break;
+                }
+                yield StreamPage { records: page, bookmark: None };
+            }
+        })
+    }
+
+    fn connector_name(&self) -> &'static str {
+        "fixture"
+    }
+}
+
+/// In-memory sink that appends every record to a shared buffer. With
+/// `payload_key` set, it stores only that field of each record — used to
+/// unwrap DLQ envelopes down to the quarantined payload.
+struct CollectingSink {
+    buffer: Arc<Mutex<Vec<Value>>>,
+    payload_key: Option<&'static str>,
+}
+
+#[async_trait]
+impl Sink for CollectingSink {
+    async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
+        let mut buf = self.buffer.lock().expect("buffer lock");
+        for r in records {
+            match self.payload_key {
+                Some(key) => buf.push(r.get(key).cloned().unwrap_or_else(|| r.clone())),
+                None => buf.push(r.clone()),
+            }
+        }
+        Ok(records.len())
+    }
+
+    fn connector_name(&self) -> &'static str {
+        "capture"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn case(input: Vec<Value>) -> ResolvedCase {
+        ResolvedCase {
+            name: "t".into(),
+            transforms: Vec::new(),
+            #[cfg(feature = "quality")]
+            quality: None,
+            #[cfg(feature = "contract")]
+            contract: None,
+            input,
+            page_size: 0,
+            clock: chrono::Utc::now().fixed_offset(),
+        }
+    }
+
+    #[tokio::test]
+    async fn passthrough_captures_all_records() {
+        let run = run_case(&case(vec![json!({"a": 1}), json!({"a": 2})]))
+            .await
+            .unwrap();
+        assert_eq!(run.records_written, 2);
+        assert_eq!(run.written, vec![json!({"a": 1}), json!({"a": 2})]);
+        assert!(run.dlq_payloads.is_empty());
+        assert!(run.error.is_none());
+    }
+
+    #[tokio::test]
+    async fn empty_input_yields_empty_run() {
+        let run = run_case(&case(vec![])).await.unwrap();
+        assert_eq!(run.records_written, 0);
+        assert!(run.written.is_empty());
+    }
+
+    #[tokio::test]
+    async fn transforms_apply_in_order() {
+        let mut c = case(vec![json!({"user": {"name": "Ada"}})]);
+        c.transforms = vec![
+            TransformSpec {
+                kind: "flatten".into(),
+                config: json!({"separator": "_"}),
+            },
+            TransformSpec {
+                kind: "set".into(),
+                config: json!({"values": {"src": "fixture"}}),
+            },
+        ];
+        let run = run_case(&c).await.unwrap();
+        assert_eq!(
+            run.written,
+            vec![json!({"user_name": "Ada", "src": "fixture"})]
+        );
+    }
+
+    #[tokio::test]
+    async fn now_tokens_resolve_against_case_clock() {
+        let mut c = case(vec![json!({"a": 1})]);
+        c.clock = chrono::DateTime::parse_from_rfc3339("2026-01-31T00:00:00Z").unwrap();
+        c.transforms = vec![TransformSpec {
+            kind: "set".into(),
+            config: json!({"values": {"day": "${now.date}"}}),
+        }];
+        let run = run_case(&c).await.unwrap();
+        assert_eq!(run.written, vec![json!({"a": 1, "day": "2026-01-31"})]);
+    }
+
+    #[tokio::test]
+    async fn invalid_transform_is_a_setup_error() {
+        let mut c = case(vec![json!({"a": 1})]);
+        c.transforms = vec![TransformSpec {
+            kind: "rename_keys".into(),
+            config: json!({"pattern": "(", "replacement": ""}),
+        }];
+        assert!(run_case(&c).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn page_size_chunks_fixture_pages() {
+        // A page-granular batch quality check observes the page boundary:
+        // with page_size 2 and a 3-record fixture, a `row_count` min of 2
+        // aborts on the second (1-record) page.
+        let mut c = case(vec![json!({"a": 1}), json!({"a": 2}), json!({"a": 3})]);
+        c.page_size = 2;
+        #[cfg(feature = "quality")]
+        {
+            c.quality = Some(
+                serde_json::from_value(json!({
+                    "batch": [ { "type": "row_count", "min": 2, "on_failure": "abort" } ]
+                }))
+                .unwrap(),
+            );
+            let run = run_case(&c).await.unwrap();
+            assert!(
+                run.error.is_some(),
+                "expected quality abort on the short page"
+            );
+            // The first (full) page was written before the abort.
+            assert_eq!(run.written.len(), 2);
+            assert_eq!(run.records_written, 2);
+        }
+    }
+
+    #[cfg(feature = "quality")]
+    #[tokio::test]
+    async fn quality_quarantine_routes_to_dlq_capture() {
+        let mut c = case(vec![json!({"id": 1}), json!({"id": null})]);
+        c.quality = Some(
+            serde_json::from_value(json!({
+                "record": [ { "type": "not_null", "field": "id", "on_failure": "quarantine" } ]
+            }))
+            .unwrap(),
+        );
+        let run = run_case(&c).await.unwrap();
+        assert!(run.error.is_none());
+        assert_eq!(run.written, vec![json!({"id": 1})]);
+        assert_eq!(run.dlq_payloads, vec![json!({"id": null})]);
+    }
+
+    #[cfg(feature = "quality")]
+    #[tokio::test]
+    async fn invalid_quality_spec_is_a_setup_error() {
+        let mut c = case(vec![json!({"a": 1})]);
+        c.quality = Some(
+            serde_json::from_value(json!({
+                "record": [ { "type": "regex_match", "field": "a", "pattern": "(", "on_failure": "abort" } ]
+            }))
+            .unwrap(),
+        );
+        assert!(run_case(&c).await.is_err());
+    }
+
+    #[cfg(feature = "contract")]
+    #[tokio::test]
+    async fn contract_fail_aborts_and_quarantine_routes() {
+        let contract = |on_breach: &str| -> faucet_core::ContractSpec {
+            serde_json::from_value(json!({
+                "version": "1.0.0",
+                "on_breach": on_breach,
+                "fields": [ { "name": "id", "type": "integer", "required": true } ]
+            }))
+            .unwrap()
+        };
+        // fail → run error, nothing written from the breaching page.
+        let mut c = case(vec![json!({"id": "not-an-int"})]);
+        c.contract = Some(contract("fail"));
+        let run = run_case(&c).await.unwrap();
+        assert!(
+            run.error
+                .as_deref()
+                .unwrap_or_default()
+                .contains("Contract v1.0.0 violated"),
+            "unexpected error: {:?}",
+            run.error
+        );
+        assert!(run.written.is_empty());
+        assert_eq!(run.records_written, 0);
+
+        // quarantine → breaching record lands in the DLQ capture.
+        let mut c = case(vec![json!({"id": 7}), json!({"id": "bad"})]);
+        c.contract = Some(contract("quarantine"));
+        let run = run_case(&c).await.unwrap();
+        assert!(run.error.is_none());
+        assert_eq!(run.written, vec![json!({"id": 7})]);
+        assert_eq!(run.dlq_payloads, vec![json!({"id": "bad"})]);
+    }
+}

--- a/cli/src/pipeline_test/spec.rs
+++ b/cli/src/pipeline_test/spec.rs
@@ -1,0 +1,469 @@
+//! Serde types for the `faucet test` spec file.
+//!
+//! A spec file declares fixture-based, fully-offline test cases for a
+//! pipeline's deterministic path (transforms → quality → contract). No real
+//! source or sink is ever built: fixture records are streamed through an
+//! in-memory source and captured by an in-memory sink + DLQ.
+
+use crate::config::TransformSpec;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Top-level shape of a `faucet test` spec file (YAML or JSON).
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct TestSpecFile {
+    /// Spec-format version. Must be `1`.
+    pub version: u32,
+    /// The test cases, run in declared order.
+    pub tests: Vec<TestCase>,
+}
+
+/// One fixture-based test case.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct TestCase {
+    /// Human-readable case name. Must be unique within the spec file.
+    pub name: String,
+
+    /// Path to a pipeline config file (relative paths resolve against the
+    /// spec file's directory). The case runs that config's transforms,
+    /// `quality:`, and `contract:` blocks against the fixture input.
+    /// Mutually exclusive with `pipeline`.
+    #[serde(default)]
+    pub config: Option<String>,
+
+    /// Inline pipeline logic (transforms / quality / contract) — no config
+    /// file needed. Mutually exclusive with `config`.
+    #[serde(default)]
+    pub pipeline: Option<InlinePipeline>,
+
+    /// Matrix row id to test when the referenced config expands to more than
+    /// one invocation. Defaults to the sole invocation; an error names the
+    /// available ids when the config has several and `row` is omitted.
+    #[serde(default)]
+    pub row: Option<String>,
+
+    /// Fixture input: an inline array of JSON records, or a path (string) to
+    /// a `.jsonl` / `.json` / `.yaml` fixture file (relative to the spec
+    /// file's directory).
+    pub input: InputSpec,
+
+    /// Chunk the fixture input into pages of this many records before feeding
+    /// the pipeline. `0` (default) feeds everything as a single page —
+    /// matching `batch_size: 0` semantics for per-page checks (batch quality
+    /// checks and aggregating SQL transforms see the whole input at once).
+    #[serde(default)]
+    pub page_size: usize,
+
+    /// Fixed `${now.*}` clock for this case (RFC3339 like
+    /// `2026-01-31T00:00:00Z`, or a date `2026-01-31`). Overrides the
+    /// command-level `--clock`; defaults to process start (UTC). Set this
+    /// whenever a transform stamps `${now.*}` so the case is deterministic.
+    #[serde(default)]
+    pub clock: Option<String>,
+
+    /// What the case asserts about the run's outcome.
+    pub expect: Expectation,
+}
+
+/// Inline pipeline logic for a test case that doesn't reference a config file.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct InlinePipeline {
+    /// Transform chain, identical to `pipeline.transforms` in a config file.
+    #[serde(default)]
+    pub transforms: Vec<TransformSpec>,
+
+    /// Quality checks, identical to `pipeline.quality` in a config file.
+    /// Quarantined records are capturable via `expect.dlq` / `dlq_count`.
+    #[cfg(feature = "quality")]
+    #[serde(default)]
+    pub quality: Option<faucet_core::QualitySpec>,
+
+    /// Data contract, identical to `pipeline.contract` in a config file.
+    #[cfg(feature = "contract")]
+    #[serde(default)]
+    pub contract: Option<faucet_core::ContractSpec>,
+}
+
+/// Fixture input — inline records or a fixture-file path.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+pub enum InputSpec {
+    /// Inline JSON records.
+    Inline(Vec<Value>),
+    /// Path to a `.jsonl` (one record per line) or `.json` / `.yaml` /
+    /// `.yml` (top-level array) fixture file, relative to the spec file.
+    Path(String),
+}
+
+/// Expected outcome of a test case. Every field is optional but at least one
+/// must be set; all set fields are asserted together.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct Expectation {
+    /// The exact records the sink must receive, in order (set
+    /// `unordered: true` to compare as a multiset). Compared per `match`.
+    #[serde(default)]
+    pub records: Option<Vec<Value>>,
+
+    /// The original record payloads that must land in the DLQ (quality /
+    /// contract quarantines), in order. Envelope metadata (timestamps, error
+    /// messages) is not compared — only the quarantined payload itself.
+    #[serde(default)]
+    pub dlq: Option<Vec<Value>>,
+
+    /// Total records the sink must receive (a count-only alternative to
+    /// `records`).
+    #[serde(default)]
+    pub records_written: Option<usize>,
+
+    /// Total DLQ envelopes (a count-only alternative to `dlq`).
+    #[serde(default)]
+    pub dlq_count: Option<usize>,
+
+    /// The run must FAIL, and the error message must contain this substring
+    /// (e.g. a quality `abort` or contract `on_breach: fail`). Without this
+    /// field, a failing run fails the case.
+    #[serde(default)]
+    pub error: Option<String>,
+
+    /// Compare `records` / `dlq` as multisets instead of ordered lists.
+    #[serde(default)]
+    pub unordered: bool,
+
+    /// How individual records are compared.
+    #[serde(default, rename = "match")]
+    pub match_mode: MatchMode,
+}
+
+/// Record-comparison mode for `expect.records` / `expect.dlq`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum MatchMode {
+    /// Expected and actual records must be deeply equal.
+    #[default]
+    Exact,
+    /// Each expected record must be a recursive subset of the actual record:
+    /// every expected object field must be present and match, but the actual
+    /// record may carry extra fields. Arrays still compare element-by-element
+    /// (same length), applying subset semantics to nested objects.
+    Subset,
+}
+
+impl Expectation {
+    /// True when at least one assertion field is set.
+    pub fn has_any(&self) -> bool {
+        self.records.is_some()
+            || self.dlq.is_some()
+            || self.records_written.is_some()
+            || self.dlq_count.is_some()
+            || self.error.is_some()
+    }
+}
+
+impl TestSpecFile {
+    /// Structural validation, run right after parsing. Fail-fast so a broken
+    /// spec never reaches the runner: version, unique non-empty names, the
+    /// config/pipeline exclusivity, a non-empty expectation, and page-size
+    /// bounds all surface here with the spec path in the message.
+    pub fn validate(&self, spec_path: &std::path::Path) -> crate::error::CliResult<()> {
+        let at =
+            |msg: String| crate::error::CliError::Config(format!("{}: {msg}", spec_path.display()));
+        if self.version != 1 {
+            return Err(at(format!(
+                "unsupported test-spec version {} (expected 1)",
+                self.version
+            )));
+        }
+        if self.tests.is_empty() {
+            return Err(at("spec declares no tests".to_string()));
+        }
+        let mut seen = std::collections::HashSet::new();
+        for case in &self.tests {
+            let name = case.name.trim();
+            if name.is_empty() {
+                return Err(at("test case with an empty name".to_string()));
+            }
+            if !seen.insert(name) {
+                return Err(at(format!("duplicate test name '{name}'")));
+            }
+            match (&case.config, &case.pipeline) {
+                (Some(_), Some(_)) => {
+                    return Err(at(format!(
+                        "test '{name}': `config` and `pipeline` are mutually exclusive — pick one"
+                    )));
+                }
+                (None, None) => {
+                    return Err(at(format!(
+                        "test '{name}': one of `config` (a pipeline config path) or `pipeline` \
+                         (inline transforms/quality/contract) is required"
+                    )));
+                }
+                _ => {}
+            }
+            if case.row.is_some() && case.config.is_none() {
+                return Err(at(format!(
+                    "test '{name}': `row` selects a matrix row and requires `config`"
+                )));
+            }
+            if !case.expect.has_any() {
+                return Err(at(format!(
+                    "test '{name}': `expect` must set at least one of records / dlq / \
+                     records_written / dlq_count / error"
+                )));
+            }
+            faucet_core::validate_batch_size(case.page_size)
+                .map_err(|e| at(format!("test '{name}': page_size: {e}")))?;
+        }
+        Ok(())
+    }
+}
+
+/// Parse a spec file (YAML or JSON by extension) and validate it.
+pub fn load_spec(path: &std::path::Path) -> crate::error::CliResult<TestSpecFile> {
+    use crate::error::CliError;
+    let text = std::fs::read_to_string(path).map_err(|source| CliError::ReadConfig {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(str::to_ascii_lowercase);
+    let spec: TestSpecFile = match ext.as_deref() {
+        Some("yaml" | "yml") => serde_yaml::from_str(&text).map_err(|e| CliError::ParseConfig {
+            path: path.to_path_buf(),
+            message: e.to_string(),
+        })?,
+        Some("json") => serde_json::from_str(&text).map_err(|e| CliError::ParseConfig {
+            path: path.to_path_buf(),
+            message: e.to_string(),
+        })?,
+        _ => {
+            return Err(CliError::UnknownExtension {
+                path: path.to_path_buf(),
+            });
+        }
+    };
+    spec.validate(path)?;
+    Ok(spec)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::path::Path;
+
+    fn write_spec(dir: &tempfile::TempDir, name: &str, body: &str) -> std::path::PathBuf {
+        let p = dir.path().join(name);
+        std::fs::write(&p, body).unwrap();
+        p
+    }
+
+    #[test]
+    fn parses_minimal_inline_spec() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_spec(
+            &dir,
+            "t.yaml",
+            r#"
+version: 1
+tests:
+  - name: passthrough
+    pipeline: {}
+    input: [ { a: 1 } ]
+    expect: { records: [ { a: 1 } ] }
+"#,
+        );
+        let spec = load_spec(&p).unwrap();
+        assert_eq!(spec.tests.len(), 1);
+        assert_eq!(spec.tests[0].name, "passthrough");
+        assert!(matches!(spec.tests[0].input, InputSpec::Inline(ref v) if v.len() == 1));
+        assert_eq!(spec.tests[0].expect.records, Some(vec![json!({"a": 1})]));
+        assert_eq!(spec.tests[0].expect.match_mode, MatchMode::Exact);
+        assert!(!spec.tests[0].expect.unordered);
+    }
+
+    #[test]
+    fn parses_json_spec() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_spec(
+            &dir,
+            "t.json",
+            r#"{ "version": 1, "tests": [ { "name": "n", "pipeline": {},
+                 "input": [], "expect": { "records_written": 0 } } ] }"#,
+        );
+        assert_eq!(load_spec(&p).unwrap().tests.len(), 1);
+    }
+
+    #[test]
+    fn rejects_unknown_extension_and_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_spec(&dir, "t.toml", "version = 1");
+        assert!(matches!(
+            load_spec(&p),
+            Err(crate::error::CliError::UnknownExtension { .. })
+        ));
+        assert!(matches!(
+            load_spec(Path::new("/nonexistent/spec.yaml")),
+            Err(crate::error::CliError::ReadConfig { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_bad_version_empty_tests_and_duplicates() {
+        let dir = tempfile::tempdir().unwrap();
+        let bad_version = write_spec(
+            &dir,
+            "v.yaml",
+            "version: 2\ntests: [ { name: x, pipeline: {}, input: [], expect: { records_written: 0 } } ]",
+        );
+        let err = load_spec(&bad_version).unwrap_err().to_string();
+        assert!(err.contains("version 2"), "{err}");
+
+        let empty = write_spec(&dir, "e.yaml", "version: 1\ntests: []");
+        assert!(
+            load_spec(&empty)
+                .unwrap_err()
+                .to_string()
+                .contains("no tests")
+        );
+
+        let dup = write_spec(
+            &dir,
+            "d.yaml",
+            r#"
+version: 1
+tests:
+  - { name: same, pipeline: {}, input: [], expect: { records_written: 0 } }
+  - { name: same, pipeline: {}, input: [], expect: { records_written: 0 } }
+"#,
+        );
+        assert!(
+            load_spec(&dup)
+                .unwrap_err()
+                .to_string()
+                .contains("duplicate")
+        );
+    }
+
+    #[test]
+    fn rejects_config_pipeline_conflicts() {
+        let dir = tempfile::tempdir().unwrap();
+        let both = write_spec(
+            &dir,
+            "b.yaml",
+            r#"
+version: 1
+tests:
+  - { name: x, config: p.yaml, pipeline: {}, input: [], expect: { records_written: 0 } }
+"#,
+        );
+        assert!(
+            load_spec(&both)
+                .unwrap_err()
+                .to_string()
+                .contains("mutually exclusive")
+        );
+
+        let neither = write_spec(
+            &dir,
+            "n.yaml",
+            "version: 1\ntests: [ { name: x, input: [], expect: { records_written: 0 } } ]",
+        );
+        assert!(
+            load_spec(&neither)
+                .unwrap_err()
+                .to_string()
+                .contains("is required")
+        );
+    }
+
+    #[test]
+    fn rejects_row_without_config_and_empty_expect() {
+        let dir = tempfile::tempdir().unwrap();
+        let row = write_spec(
+            &dir,
+            "r.yaml",
+            "version: 1\ntests: [ { name: x, pipeline: {}, row: a, input: [], expect: { records_written: 0 } } ]",
+        );
+        assert!(
+            load_spec(&row)
+                .unwrap_err()
+                .to_string()
+                .contains("requires `config`")
+        );
+
+        let empty_expect = write_spec(
+            &dir,
+            "x.yaml",
+            "version: 1\ntests: [ { name: x, pipeline: {}, input: [], expect: {} } ]",
+        );
+        assert!(
+            load_spec(&empty_expect)
+                .unwrap_err()
+                .to_string()
+                .contains("at least one")
+        );
+    }
+
+    #[test]
+    fn rejects_oversized_page_size_and_empty_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let big = write_spec(
+            &dir,
+            "p.yaml",
+            "version: 1\ntests: [ { name: x, pipeline: {}, input: [], page_size: 2000000, expect: { records_written: 0 } } ]",
+        );
+        assert!(
+            load_spec(&big)
+                .unwrap_err()
+                .to_string()
+                .contains("page_size")
+        );
+
+        let unnamed = write_spec(
+            &dir,
+            "u.yaml",
+            "version: 1\ntests: [ { name: '  ', pipeline: {}, input: [], expect: { records_written: 0 } } ]",
+        );
+        assert!(
+            load_spec(&unnamed)
+                .unwrap_err()
+                .to_string()
+                .contains("empty name")
+        );
+    }
+
+    #[test]
+    fn input_path_variant_parses() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_spec(
+            &dir,
+            "f.yaml",
+            r#"
+version: 1
+tests:
+  - name: from-file
+    pipeline: {}
+    input: fixtures/records.jsonl
+    expect: { records_written: 2 }
+"#,
+        );
+        let spec = load_spec(&p).unwrap();
+        assert!(
+            matches!(spec.tests[0].input, InputSpec::Path(ref s) if s == "fixtures/records.jsonl")
+        );
+    }
+
+    #[test]
+    fn schema_generates() {
+        let schema = schemars::schema_for!(TestSpecFile);
+        let v = serde_json::to_value(&schema).unwrap();
+        assert!(v["properties"]["tests"].is_object());
+    }
+}

--- a/cli/tests/pipeline_test_cmd.rs
+++ b/cli/tests/pipeline_test_cmd.rs
@@ -1,0 +1,447 @@
+//! `faucet test` end-to-end: passing and failing specs report correctly with
+//! proper exit codes, DLQ/quality/contract outcomes are assertable, `--json`
+//! emits a parseable report, and `faucet schema test` prints the spec schema.
+
+use assert_cmd::Command;
+use predicates::str::contains;
+use std::fs;
+use std::path::Path;
+use tempfile::TempDir;
+
+fn write(dir: &Path, name: &str, body: &str) -> std::path::PathBuf {
+    let p = dir.join(name);
+    fs::write(&p, body).unwrap();
+    p
+}
+
+fn faucet() -> Command {
+    let mut cmd = Command::cargo_bin("faucet").unwrap();
+    // Never pick up a developer's .env from the test cwd.
+    cmd.arg("test").arg("--no-env-file");
+    cmd
+}
+
+#[test]
+fn passing_inline_spec_exits_zero() {
+    let dir = TempDir::new().unwrap();
+    let spec = write(
+        dir.path(),
+        "spec.yaml",
+        r#"
+version: 1
+tests:
+  - name: flatten and stamp
+    pipeline:
+      transforms:
+        - type: flatten
+          config: { separator: "_" }
+        - type: set
+          config: { values: { day: "${now.date}" } }
+    clock: 2026-02-01T00:00:00Z
+    input:
+      - { user: { name: Ada } }
+    expect:
+      records:
+        - { user_name: Ada, day: "2026-02-01" }
+"#,
+    );
+    faucet()
+        .arg(&spec)
+        .assert()
+        .success()
+        .stdout(contains("✓ flatten and stamp"))
+        .stdout(contains("1 test, 1 passed, 0 failed"));
+}
+
+#[test]
+fn failing_case_exits_with_failure_count_and_diff() {
+    let dir = TempDir::new().unwrap();
+    let spec = write(
+        dir.path(),
+        "spec.yaml",
+        r#"
+version: 1
+tests:
+  - name: ok
+    pipeline: {}
+    input: [ { a: 1 } ]
+    expect: { records_written: 1 }
+  - name: wrong value
+    pipeline: {}
+    input: [ { a: 1 } ]
+    expect: { records: [ { a: 2 } ] }
+  - name: wrong count
+    pipeline: {}
+    input: [ { a: 1 } ]
+    expect: { records_written: 5 }
+"#,
+    );
+    faucet()
+        .arg(&spec)
+        .assert()
+        .code(2) // two failed cases → exit 2
+        .stdout(contains("✓ ok"))
+        .stdout(contains("✗ wrong value"))
+        .stdout(contains("records[0].a: expected 2, got 1"))
+        .stdout(contains("records_written: expected 5, got 1"))
+        .stdout(contains("3 tests, 1 passed, 2 failed"));
+}
+
+#[test]
+fn json_report_is_machine_readable() {
+    let dir = TempDir::new().unwrap();
+    let spec = write(
+        dir.path(),
+        "spec.yaml",
+        r#"
+version: 1
+tests:
+  - name: pass case
+    pipeline: {}
+    input: [ { a: 1 } ]
+    expect: { records_written: 1 }
+  - name: fail case
+    pipeline: {}
+    input: [ { a: 1 } ]
+    expect: { records_written: 0 }
+"#,
+    );
+    let output = faucet().arg(&spec).arg("--json").output().unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let v: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(v["total"], 2);
+    assert_eq!(v["passed"], 1);
+    assert_eq!(v["failed"], 1);
+    assert_eq!(v["tests"][0]["status"], "pass");
+    assert_eq!(v["tests"][1]["status"], "fail");
+    assert!(
+        v["tests"][1]["failures"][0]
+            .as_str()
+            .unwrap()
+            .contains("records_written")
+    );
+}
+
+#[test]
+fn config_file_quality_quarantine_routes_to_dlq() {
+    let dir = TempDir::new().unwrap();
+    // A realistic config: the csv source / jsonl sink are never touched by
+    // `faucet test` — only transforms + quality run against the fixtures.
+    write(
+        dir.path(),
+        "pipeline.yaml",
+        r#"
+version: 1
+name: orders
+pipeline:
+  source: { type: csv, config: { path: ./never-read.csv } }
+  sink:   { type: jsonl, config: { path: ./never-written.jsonl } }
+  transforms:
+    - type: keys_case
+      config: { mode: snake }
+  quality:
+    record:
+      - { type: not_null, field: order_id, on_failure: quarantine }
+  dlq:
+    sink: { type: stdout, config: {} }
+"#,
+    );
+    let spec = write(
+        dir.path(),
+        "spec.yaml",
+        r#"
+version: 1
+tests:
+  - name: null ids quarantined
+    config: pipeline.yaml
+    input:
+      - { OrderId: 1 }
+      - { OrderId: null }
+    expect:
+      records: [ { order_id: 1 } ]
+      dlq: [ { order_id: null } ]
+      dlq_count: 1
+"#,
+    );
+    faucet()
+        .arg(&spec)
+        .assert()
+        .success()
+        .stdout(contains("✓ null ids quarantined"));
+}
+
+#[test]
+fn contract_fail_is_assertable_via_expect_error() {
+    let dir = TempDir::new().unwrap();
+    let spec = write(
+        dir.path(),
+        "spec.yaml",
+        r#"
+version: 1
+tests:
+  - name: breach aborts
+    pipeline:
+      contract:
+        version: "2.0.0"
+        fields:
+          - { name: id, type: integer, required: true }
+    input: [ { id: not-an-int } ]
+    expect:
+      error: "Contract v2.0.0 violated"
+      records_written: 0
+"#,
+    );
+    faucet().arg(&spec).assert().success();
+}
+
+#[test]
+fn fixture_file_input_and_subset_unordered_matching() {
+    let dir = TempDir::new().unwrap();
+    fs::create_dir(dir.path().join("fixtures")).unwrap();
+    write(
+        &dir.path().join("fixtures"),
+        "records.jsonl",
+        "{\"id\":1,\"noise\":\"x\"}\n{\"id\":2,\"noise\":\"y\"}\n",
+    );
+    let spec = write(
+        dir.path(),
+        "spec.yaml",
+        r#"
+version: 1
+tests:
+  - name: subset unordered
+    pipeline: {}
+    input: fixtures/records.jsonl
+    expect:
+      match: subset
+      unordered: true
+      records:
+        - { id: 2 }
+        - { id: 1 }
+"#,
+    );
+    faucet().arg(&spec).assert().success();
+}
+
+#[test]
+fn matrix_config_requires_row_and_selects_it() {
+    let dir = TempDir::new().unwrap();
+    write(
+        dir.path(),
+        "pipeline.yaml",
+        r#"
+version: 1
+pipeline:
+  source: { type: csv, config: { path: ./in.csv } }
+  sink:   { type: jsonl, config: { path: ./out.jsonl } }
+matrix:
+  - id: plain
+  - id: shaped
+    transforms:
+      - type: set
+        config: { values: { shaped: true } }
+"#,
+    );
+    let no_row = write(
+        dir.path(),
+        "no_row.yaml",
+        r#"
+version: 1
+tests:
+  - name: ambiguous
+    config: pipeline.yaml
+    input: [ { a: 1 } ]
+    expect: { records_written: 1 }
+"#,
+    );
+    faucet()
+        .arg(&no_row)
+        .assert()
+        .code(1)
+        .stderr(contains("set `row` to one of"))
+        .stderr(contains("plain"))
+        .stderr(contains("shaped"));
+
+    let with_row = write(
+        dir.path(),
+        "with_row.yaml",
+        r#"
+version: 1
+tests:
+  - name: shaped row applies row transforms
+    config: pipeline.yaml
+    row: shaped
+    input: [ { a: 1 } ]
+    expect:
+      records: [ { a: 1, shaped: true } ]
+  - name: unknown row errors
+    config: pipeline.yaml
+    row: nope
+    input: [ { a: 1 } ]
+    expect: { records_written: 1 }
+"#,
+    );
+    // The unknown-row case is a setup error (not a test failure) — the whole
+    // command errors out before reporting.
+    faucet()
+        .arg(&with_row)
+        .assert()
+        .code(1)
+        .stderr(contains("row 'nope' not found"));
+
+    faucet()
+        .arg(&with_row)
+        .arg("--filter")
+        .arg("shaped row")
+        .assert()
+        .success()
+        .stdout(contains("✓ shaped row applies row transforms"));
+}
+
+#[test]
+fn filter_with_no_matches_errors() {
+    let dir = TempDir::new().unwrap();
+    let spec = write(
+        dir.path(),
+        "spec.yaml",
+        r#"
+version: 1
+tests:
+  - name: only case
+    pipeline: {}
+    input: []
+    expect: { records_written: 0 }
+"#,
+    );
+    faucet()
+        .arg(&spec)
+        .arg("--filter")
+        .arg("does-not-exist")
+        .assert()
+        .code(1)
+        .stderr(contains("no test cases match --filter"));
+}
+
+#[test]
+fn multiple_spec_files_aggregate_into_one_report() {
+    let dir = TempDir::new().unwrap();
+    let a = write(
+        dir.path(),
+        "a.yaml",
+        "version: 1\ntests: [ { name: a1, pipeline: {}, input: [], expect: { records_written: 0 } } ]\n",
+    );
+    let b = write(
+        dir.path(),
+        "b.yaml",
+        "version: 1\ntests: [ { name: b1, pipeline: {}, input: [], expect: { records_written: 0 } } ]\n",
+    );
+    faucet()
+        .arg(&a)
+        .arg(&b)
+        .assert()
+        .success()
+        .stdout(contains("a.yaml"))
+        .stdout(contains("b.yaml"))
+        .stdout(contains("2 tests, 2 passed, 0 failed"));
+}
+
+#[test]
+fn command_clock_applies_when_case_has_none() {
+    let dir = TempDir::new().unwrap();
+    let spec = write(
+        dir.path(),
+        "spec.yaml",
+        r#"
+version: 1
+tests:
+  - name: stamped by flag clock
+    pipeline:
+      transforms:
+        - type: set
+          config: { values: { day: "${now.date}" } }
+    input: [ {} ]
+    expect: { records: [ { day: "2026-03-01" } ] }
+"#,
+    );
+    faucet()
+        .arg(&spec)
+        .arg("--clock")
+        .arg("2026-03-01")
+        .assert()
+        .success();
+}
+
+#[test]
+fn invalid_spec_reports_config_error() {
+    let dir = TempDir::new().unwrap();
+    let spec = write(
+        dir.path(),
+        "spec.yaml",
+        "version: 1\ntests: [ { name: x, input: [], expect: { records_written: 0 } } ]\n",
+    );
+    faucet()
+        .arg(&spec)
+        .assert()
+        .code(1)
+        .stderr(contains("one of `config`"));
+}
+
+#[test]
+fn schema_test_target_prints_spec_schema() {
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["schema", "test"])
+        .assert()
+        .success()
+        .stdout(contains("\"tests\""))
+        .stdout(contains("TestCase"));
+}
+
+#[test]
+fn shipped_example_spec_passes() {
+    // Keeps cli/examples/tests/ (and the docs that quote it) grounded: the
+    // shipped example spec must always pass against its pipeline config.
+    let spec = Path::new(env!("CARGO_MANIFEST_DIR")).join("examples/tests/pipeline_tests.yaml");
+    faucet()
+        .arg(&spec)
+        .assert()
+        .success()
+        .stdout(contains("5 tests, 5 passed, 0 failed"));
+}
+
+#[test]
+fn resolve_secrets_flag_loads_plain_config() {
+    // --resolve-secrets on a config with no secret directives goes through the
+    // async load path and behaves identically.
+    let dir = TempDir::new().unwrap();
+    write(
+        dir.path(),
+        "pipeline.yaml",
+        r#"
+version: 1
+pipeline:
+  source: { type: csv, config: { path: ./in.csv } }
+  sink:   { type: jsonl, config: { path: ./out.jsonl } }
+  transforms:
+    - type: set
+      config: { values: { ok: true } }
+"#,
+    );
+    let spec = write(
+        dir.path(),
+        "spec.yaml",
+        r#"
+version: 1
+tests:
+  - name: async load path
+    config: pipeline.yaml
+    input: [ {} ]
+    expect: { records: [ { ok: true } ] }
+"#,
+    );
+    faucet()
+        .arg(&spec)
+        .arg("--resolve-secrets")
+        .assert()
+        .success();
+}

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -27,6 +27,7 @@
 - [Resilience (retry / circuit breaker / poison-pill)](./cookbook/resilience.md)
 - [Data-quality checks](./cookbook/quality.md)
 - [Data contracts](./cookbook/contracts.md)
+- [Testing pipelines](./cookbook/testing.md)
 - [Compression](./cookbook/compression.md)
 - [Record transforms](./cookbook/transforms.md)
 - [SQL transform](./cookbook/sql-transform.md)

--- a/docs/book/src/cookbook/testing.md
+++ b/docs/book/src/cookbook/testing.md
@@ -1,0 +1,171 @@
+# Testing pipelines (`faucet test`)
+
+`faucet test` runs **fixture-based, fully-offline tests** for your pipeline
+logic. A spec file declares sample input records, the pipeline under test, and
+the expected outcome; the runner streams the fixtures through the real
+transform → quality → contract path with an in-memory source, sink, and DLQ —
+no database, API, broker, or credentials required. That makes pipeline logic
+CI-testable: assert "this config + these records produce exactly this output"
+on every pull request.
+
+```bash
+faucet test tests/orders_tests.yaml       # one spec file
+faucet test tests/*.yaml                  # shell glob — any number of specs
+faucet test tests/*.yaml --json           # machine-readable report
+faucet test tests/*.yaml --filter orders  # run only matching case names
+```
+
+The exit code is the number of failed cases (0 = all passed), so CI gates on
+it directly.
+
+## Spec file format
+
+```yaml
+version: 1
+tests:
+  - name: null order ids quarantined      # unique per spec file
+    config: ../pipeline.yaml              # pipeline config to test (relative to the spec)
+    input:                                # fixture records (inline…)
+      - { OrderId: 1, Amount: 9.5 }
+      - { OrderId: null, Amount: 3.0 }
+    expect:
+      records: [ { order_id: 1, amount: 9.5 } ]   # what the sink must receive
+      dlq: [ { order_id: null, amount: 3.0 } ]    # what quarantine must route
+```
+
+Each case needs `name`, `input`, `expect`, and exactly one of:
+
+- **`config:`** — a pipeline config file path (resolved relative to the spec
+  file). The case runs that config's transform chain, `quality:` checks, and
+  `contract:` against the fixtures. The configured source and sink are **never
+  built or contacted** — fixtures replace the source and an in-memory capture
+  replaces the sink (a `dlq:` block's sink is likewise replaced by an
+  in-memory capture, and quarantine works in tests even without one).
+- **`pipeline:`** — the same logic inline, for testing a transform chain or
+  contract in isolation:
+
+  ```yaml
+  - name: flatten then stamp
+    pipeline:
+      transforms:
+        - type: flatten
+          config: { separator: "_" }
+        - type: set
+          config: { values: { day: "${now.date}" } }
+      quality: { … }        # optional, same shape as pipeline.quality
+      contract: { … }       # optional, same shape as pipeline.contract
+    clock: 2026-02-01T00:00:00Z
+    input: [ { user: { name: Ada } } ]
+    expect:
+      records: [ { user_name: Ada, day: "2026-02-01" } ]
+  ```
+
+### Case fields
+
+| Field | Purpose |
+|-------|---------|
+| `name` | Unique case name (also the `--filter` target). |
+| `config` / `pipeline` | What to test — a config file or inline logic (exactly one). |
+| `row` | Matrix row id to test when `config` expands to several invocations. The error lists available ids when omitted ambiguously. Row-level transform overrides apply, exactly as in `faucet run`. |
+| `input` | Inline record array, **or** a path (relative to the spec) to a `.jsonl` / `.ndjson` (one record per line), `.json`, `.yaml` / `.yml` (top-level array) fixture file. |
+| `page_size` | Chunk fixtures into pages of N records. Default `0` = one page (like `batch_size: 0`). Set it to exercise per-page semantics — batch quality checks and aggregating SQL transforms operate per page. |
+| `clock` | Fixed `${now.*}` clock for the case (RFC 3339 or `YYYY-MM-DD`). Overrides `--clock`; default is process start. Pin it whenever the pipeline stamps `${now.*}` so the case is deterministic. |
+| `expect` | The assertions — see below. |
+
+### Expectations
+
+All fields are optional, at least one is required; every set field is asserted:
+
+| Field | Asserts |
+|-------|---------|
+| `records` | The sink received exactly these records, in order. |
+| `dlq` | These record payloads were routed to the DLQ (quality / contract quarantine), in order. Envelope metadata (timestamp, error message) is not compared — only the quarantined payload. |
+| `records_written` | Count-only alternative to `records`. |
+| `dlq_count` | Count-only alternative to `dlq`. |
+| `error` | The run must **fail** and the error message must contain this substring — for quality `abort` and contract `on_breach: fail` paths. Without it, a failing run fails the case. |
+| `unordered: true` | Compare `records` / `dlq` as multisets instead of ordered lists. |
+| `match: subset` | Each expected record only names the fields it cares about; extra actual fields are allowed (recursively). Default `match: exact` also flags unexpected fields. Arrays always compare element-wise with equal length. |
+
+Failures print a structured, path-based diff:
+
+```
+spec.yaml
+  ✗ null order ids quarantined
+      - records[0].amount: expected 9.5, got 3.0
+      - dlq: expected 1 record(s), got 0
+
+2 tests, 1 passed, 1 failed
+```
+
+## What runs, what doesn't
+
+`faucet test` executes the genuine `faucet-core` pipeline loop per page, so
+what a test observes is what production does for the same records:
+
+- **Runs:** the full transform chain (including layered pipeline + source
+  template + matrix-row transforms, resolved exactly as `faucet run` does),
+  `quality:` record + batch checks with real quarantine/abort routing,
+  `contract:` enforcement with real quarantine/fail semantics, and DLQ
+  envelope routing (unwrapped to payloads for matching).
+- **Replaced:** the source (fixtures), the sink, and the DLQ sink (in-memory
+  captures). `state:` bookmarks and `delivery:` guarantees don't apply — every
+  case is a fresh, single run.
+- **Inert:** the `schema:` (drift) block — there is no destination schema
+  offline; a warning notes this when the config declares one.
+- **Offline config loading:** referenced configs load without contacting
+  secrets managers (`${vault:…}`-style directives stay unresolved — safe,
+  because the source/sink configs holding them are never used). Pass
+  `--resolve-secrets` for the rare secret inside a transform / quality /
+  contract block. `${env:VAR}` / `${file:…}` interpolation and `--profile`
+  overlays work as usual.
+
+Note: `${now.*}` tokens resolve in source/sink configs (untested here) and in
+**inline** test transforms; a config file's transform chain cannot contain
+them (`faucet run` rejects that too).
+
+## CI recipe
+
+Pipeline tests need only the `faucet` binary — no services, no Docker:
+
+```yaml
+# .github/workflows/pipelines.yml
+name: pipeline-tests
+on: [pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install faucet
+        run: cargo install faucet-cli
+      - name: Validate configs
+        run: faucet validate pipeline.yaml --no-secrets
+      - name: Run pipeline tests
+        run: faucet test tests/*.yaml
+```
+
+`--json` emits a report for tooling:
+
+```json
+{
+  "total": 5,
+  "passed": 5,
+  "failed": 0,
+  "tests": [
+    { "name": "clean orders pass through", "spec": "tests/orders.yaml", "status": "pass", "failures": [] }
+  ]
+}
+```
+
+## Complete example
+
+A runnable pipeline + spec pair ships in
+[`cli/examples/tests/`](https://github.com/PawanSikawat/faucet-stream/tree/main/cli/examples/tests)
+— quality quarantine, contract breach, fixture files, subset/unordered
+matching, and an inline case with a pinned clock:
+
+```bash
+faucet test cli/examples/tests/pipeline_tests.yaml
+```
+
+`faucet schema test` prints the spec file's JSON Schema for editor validation.

--- a/docs/book/src/reference/cli.md
+++ b/docs/book/src/reference/cli.md
@@ -12,6 +12,7 @@ The `faucet` binary exposes these commands. Pass `--log-level <level>` (or set
 | `faucet list` | List every compiled-in source, sink, and transform with a one-line description. |
 | `faucet init [name]` | Scaffold a commented config skeleton from connector schemas. |
 | `faucet doctor [config]` | Probe every connector (auth/network/permissions) and print a checklist. |
+| `faucet test <specs…>` | Run fixture-based offline pipeline tests from one or more spec files. |
 | `faucet replicate [config]` | Bulk-snapshot a table, then hand off to CDC for a gap-free mirror. |
 | `faucet schedule [config]` | Run a pipeline on a cron schedule (long-running foreground process). |
 | `faucet serve` | Run a long-running HTTP control plane: submit / poll / cancel pipeline runs over REST. |
@@ -168,6 +169,37 @@ probing (same semantics as `run` and `validate`).
 
 See the [Troubleshooting](../cookbook/troubleshooting.md) cookbook page for
 reading the output and common failures.
+
+## `test`
+
+```bash
+faucet test tests/*.yaml                    # run every case; exit code = # of failed cases
+faucet test tests/orders.yaml --filter null # only cases whose name contains "null"
+faucet test tests/*.yaml --json             # machine-readable { total, passed, failed, tests }
+faucet test tests/*.yaml --clock 2026-03-01 # default ${now.*} clock for cases without clock:
+```
+
+Runs fixture-based, **fully-offline** pipeline tests. Each case in a spec file
+feeds sample records through the real transform → quality → contract path with
+an in-memory source, sink, and DLQ — the configured source and sink are never
+built or contacted — and asserts the output records, DLQ routing, counts, or an
+expected failure. The **exit code equals the number of failed cases** (clamped
+to 255), so CI gates on it directly.
+
+Flags:
+
+| Flag | Purpose |
+|------|---------|
+| `--filter <substring>` | Run only cases whose name contains the substring. |
+| `--json` | Emit the JSON report instead of the human checklist. |
+| `--clock <value>` | Default `${now.*}` clock for cases without `clock:` (RFC 3339 or `YYYY-MM-DD`). |
+| `--profile <name>` | Profile overlay applied to referenced configs (same semantics as `run`). |
+| `--resolve-secrets` | Resolve secrets-manager directives in referenced configs. Default: offline, directives stay unresolved. |
+| `--env-file <path>` / `--no-env-file` | Same `.env` handling as `run` / `validate`. |
+
+`faucet schema test` prints the spec file's JSON Schema. See the
+[Testing pipelines](../cookbook/testing.md) cookbook page for the spec grammar,
+matching semantics, and a CI recipe.
 
 ## `contract`
 


### PR DESCRIPTION
Closes #210. Part of the roadmap epic #38.

## What

Adds **`faucet test`** — fixture-based, fully-offline pipeline testing. A spec file declares sample input records, the pipeline logic under test, and the expected outcome; the runner streams the fixtures through the **real** `faucet-core` per-page pipeline path (transforms → quality → contract, including DLQ routing and abort semantics) with an in-memory source, sink, and DLQ. No configured source or sink is ever built or contacted, so pipeline logic is CI-testable with nothing but the `faucet` binary.

```yaml
version: 1
tests:
  - name: null order ids quarantined
    config: ../pipeline.yaml          # or `pipeline:` inline (transforms/quality/contract)
    input:
      - { OrderId: 1, Amount: 9.5 }
      - { OrderId: null, Amount: 3.0 }
    expect:
      records: [ { order_id: 1, amount: 9.5 } ]
      dlq: [ { order_id: null, amount: 3.0 } ]
```

## Surface

- `faucet test <specs…> [--filter S] [--json] [--clock C] [--profile P] [--resolve-secrets] [--env-file/--no-env-file]` — exit code = failed-case count (clamped to 255), mirroring `doctor`.
- Spec grammar: `config:` (a pipeline config path; goes through the real compose/interpolate/expand pipeline — matrix `row:` selection, transforms layering, and config gates all apply) **or** inline `pipeline:`; `input:` inline records or a `.jsonl`/`.json`/`.yaml` fixture file; `page_size:` to exercise per-page semantics; `clock:` to pin `${now.*}`.
- Expectations: `records` / `dlq` (tolerant matchers — `match: exact|subset`, `unordered: true`), `records_written` / `dlq_count`, and `error:` (asserts the run fails, for quality `abort` / contract `on_breach: fail`). Failures render a structured path diff (`records[0].amount: expected 9.5, got 3.0`).
- `faucet schema test` prints the spec-file JSON Schema.
- Offline guarantees: referenced configs load without contacting secrets managers (opt back in with `--resolve-secrets`); the `schema:` drift block is inert (warned) — there is no destination schema offline.

## Implementation

- New `cli/src/pipeline_test/` module tree mirroring `schedule/` / `replication/`: `spec.rs` (serde types + fail-fast validation), `fixtures.rs`, `runner.rs` (FixtureSource + capturing sink/DLQ around the genuine `Pipeline::run`), `diff.rs` (pure matching + path diff), `report.rs` (human + `--json`).
- `commands/test.rs` entry point; `CliError::TestsFailed` exit-code mapping in `main.rs`; `SchemaTarget::Test`.
- Zero `faucet-core` changes.

## Tests & docs

- 39 unit tests across the module + 14 end-to-end tests (`cli/tests/pipeline_test_cmd.rs`) covering pass/fail exit codes, JSON report, quality quarantine → DLQ assertions, contract fail via `expect.error`, fixture files, subset/unordered matching, matrix row selection, `--filter`, `--clock`, and the shipped example.
- **Patch coverage 97.0%** (local `cargo llvm-cov` ∩ diff; every file ≥90%).
- Runnable example pair in `cli/examples/tests/` (kept honest by an integration test), new cookbook page `docs/book/src/cookbook/testing.md` with a CI recipe, CLI reference section, `cli/README.md` grammar, root README mention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)