### PR TITLE
feat(source-kafka): cluster Mode B sharding via native consumer-group assignment

### DIFF
--- a/crates/source/kafka/README.md
+++ b/crates/source/kafka/README.md
@@ -308,6 +308,17 @@ Topics are sorted alphabetically before joining, so the key is stable regardless
 
 **Delivery semantics:** offsets are persisted only after the sink confirms, and on restart the consumer seeds the assignment with the bookmark before the first fetch. End-to-end this is **at-least-once** if the sink can fail mid-batch; pair with an idempotent sink for stricter guarantees. (The Kafka source does *not* advertise faucet-stream's exactly-once `delivery` mode — that gate requires a CDC source.)
 
+## Clustered consumption (Mode B, native consumer groups)
+
+Under `faucet serve --cluster`, a top-level `shard: { count: N }` block distributes one Kafka pipeline across N cluster workers using **Kafka's native consumer-group assignment** ([#261](https://github.com/PawanSikawat/faucet-stream/issues/261)) — each shard is a *membership slot* (one more consumer sharing the config's `group_id`), not a data slice. The broker assigns the topic's partitions across the members and rebalances onto survivors when a worker dies; the requested member count is capped at the subscription's total partition count.
+
+In member mode (i.e. only when a cluster coordinator applies a shard — a plain `faucet run` is unchanged) the source additionally:
+
+- **commits offsets to the consumer group at durable page boundaries** — after the pipeline has written a page to the sink and persisted its bookmark, plus a synchronous commit at stream end — so a partition that migrates to another member resumes from the last durable position instead of `auto_offset_reset`;
+- **defers bookmark seeks to the group's committed offsets** whenever those are ahead (another member may have durably advanced a partition past this member's bookmark); a bookmark *ahead* of the committed offset — the durable-write→commit crash window — still wins.
+
+The boundary on membership change is **at-least-once**: a crash between a durable page and its commit makes the partition's next owner re-read that page. Pair with an upsert-mode or otherwise idempotent sink. Note `max_messages` applies per member (N members consume up to N × `max_messages` total); `idle_timeout` is the natural terminator for shared consumption. See the [cluster cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/cluster.html) for the full Mode B walkthrough.
+
 ## Config loading & schema introspection
 
 Load from YAML/JSON or environment. Inspect the full JSON Schema with:

--- a/crates/source/kafka/src/context.rs
+++ b/crates/source/kafka/src/context.rs
@@ -19,7 +19,14 @@ use rdkafka::consumer::{Consumer, ConsumerContext, Rebalance, RebalanceProtocol}
 use rdkafka::error::KafkaError;
 use rdkafka::types::RDKafkaRespErr;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+/// Broker-round-trip budget for the committed-offsets lookup performed inside
+/// the rebalance callback in group-member mode. Matches the watermark-lookup
+/// budget used elsewhere in this crate.
+const COMMITTED_LOOKUP_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Shared state between [`KafkaSource`](crate::stream::KafkaSource) and the
 /// rdkafka consumer background thread. Cloning a `BookmarkContext` clones the
@@ -40,6 +47,12 @@ pub(crate) struct BookmarkContext {
     /// The poll loop drains this between iterations and surfaces it to the
     /// caller.
     pub(crate) callback_error: Arc<Mutex<Option<FaucetError>>>,
+    /// Group-member (Mode B, #261) mode: this consumer is one of N cooperating
+    /// members of the group, so bookmark seeks must defer to the group's
+    /// committed offsets whenever those are ahead (another member may have
+    /// durably advanced a partition past our bookmark). Set by
+    /// [`KafkaSource::apply_shard`](crate::stream::KafkaSource).
+    pub(crate) member_mode: Arc<AtomicBool>,
 }
 
 impl BookmarkContext {
@@ -107,7 +120,7 @@ impl ConsumerContext for BookmarkContext {
 
                     // Collect (topic, partition, offset) triples first to avoid
                     // holding an immutable borrow on `tpl` while mutating it.
-                    let seeks: Vec<(String, i32, i64)> = tpl
+                    let mut seeks: Vec<(String, i32, i64)> = tpl
                         .elements()
                         .into_iter()
                         .filter_map(|elem| {
@@ -119,6 +132,22 @@ impl ConsumerContext for BookmarkContext {
                                 .map(|offset| (topic, partition, offset))
                         })
                         .collect();
+
+                    // Group-member mode (#261): the group's committed offsets
+                    // are the shared source of truth across members — another
+                    // member may have durably advanced a partition past this
+                    // member's bookmark, so an unconditional bookmark seek
+                    // would re-read its work. Keep a seek only when the
+                    // bookmark is AHEAD of the committed offset (the durable
+                    // write → commit crash window, where skipping the seek
+                    // under `auto.offset.reset: latest` would silently lose
+                    // records). The lookup is a bounded broker round-trip,
+                    // paid only at assign time; on failure fall back to
+                    // seeking every bookmarked partition — that can duplicate
+                    // (at-least-once) but never lose.
+                    if self.member_mode.load(Ordering::Acquire) && !seeks.is_empty() {
+                        seeks = filter_seeks_by_committed(base_consumer, seeks);
+                    }
 
                     // Partitions absent from the bookmark are left at their
                     // default offset (earliest/latest per `auto.offset.reset`).
@@ -197,6 +226,53 @@ impl ConsumerContext for BookmarkContext {
             }
         }
     }
+}
+
+/// Drop bookmark seeks that the group's committed offsets already cover
+/// (member mode only). Queries the committed offset for each seek candidate in
+/// one bounded broker round-trip; a lookup failure conservatively keeps every
+/// seek (duplicates are possible, loss is not). The per-partition decision is
+/// the pure [`member_seek_offset`](crate::shard::member_seek_offset).
+fn filter_seeks_by_committed(
+    consumer: &BaseConsumer<BookmarkContext>,
+    seeks: Vec<(String, i32, i64)>,
+) -> Vec<(String, i32, i64)> {
+    let mut query = TopicPartitionList::with_capacity(seeks.len());
+    for (topic, partition, _) in &seeks {
+        query.add_partition(topic, *partition);
+    }
+    let committed: HashMap<(String, i32), Option<i64>> =
+        match consumer.committed_offsets(query, COMMITTED_LOOKUP_TIMEOUT) {
+            Ok(tpl) => tpl
+                .elements()
+                .into_iter()
+                .map(|e| {
+                    let offset = match e.offset() {
+                        Offset::Offset(n) => Some(n),
+                        _ => None,
+                    };
+                    ((e.topic().to_string(), e.partition()), offset)
+                })
+                .collect(),
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "kafka member mode: committed-offsets lookup failed; \
+                     seeking every bookmarked partition (may re-read, never loses)"
+                );
+                return seeks;
+            }
+        };
+    seeks
+        .into_iter()
+        .filter(|(topic, partition, bookmark)| {
+            let c = committed
+                .get(&(topic.clone(), *partition))
+                .copied()
+                .flatten();
+            crate::shard::member_seek_offset(*bookmark, c).is_some()
+        })
+        .collect()
 }
 
 #[cfg(test)]

--- a/crates/source/kafka/src/lib.rs
+++ b/crates/source/kafka/src/lib.rs
@@ -10,6 +10,7 @@
 pub mod config;
 pub(crate) mod context;
 pub mod decode;
+pub mod shard;
 pub mod state;
 pub mod stream;
 

--- a/crates/source/kafka/src/shard.rs
+++ b/crates/source/kafka/src/shard.rs
@@ -1,0 +1,253 @@
+//! Group-member sharding for clustered (Mode B) execution — issue #261.
+//!
+//! Kafka already solves work distribution inside the broker: consumers that
+//! share a `group.id` have the topic's partitions assigned across them by the
+//! consumer-group protocol, and a member failure triggers a rebalance onto the
+//! survivors. So the Kafka source does **not** enumerate disjoint data slices
+//! the way the PK-range / hash-of-key sharders do — each "shard" is simply a
+//! *membership slot*: "run one more consumer in the shared group". N claimed
+//! member shards ⇒ N cooperating group members ⇒ the broker splits partitions
+//! among them with no duplication and rebalances on membership change.
+//!
+//! Offset continuity across members is delegated to the group's **committed
+//! offsets**: in member mode the source commits each page's offsets to the
+//! broker once that page is durable (see
+//! [`KafkaSource::stream_pages`](crate::stream::KafkaSource)), so a partition
+//! that migrates to another member (rebalance, worker death, shard reclaim)
+//! resumes from the last durably-written position. The state-store bookmark
+//! remains the per-member safety net for the crash window between a durable
+//! write and its commit — the rebalance callback seeks to the bookmark only
+//! when it is *ahead* of the committed offset (never behind, which would
+//! re-read work another member already completed).
+//!
+//! Everything in this module is pure (no I/O) so it is unit-testable without
+//! a broker.
+
+use faucet_core::{FaucetError, shard::ShardSpec};
+use std::collections::{HashMap, HashSet};
+
+/// One membership slot of the shared consumer group, parsed from a
+/// [`ShardSpec`] descriptor of the shape `{"members": N, "member": i}`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct MemberShard {
+    /// Total membership slots in this run's shard set.
+    pub members: usize,
+    /// This slot's index in `0..members`. Identification only — Kafka, not
+    /// faucet, decides which partitions this member consumes.
+    pub member: usize,
+}
+
+impl MemberShard {
+    /// Parse from a [`ShardSpec`] descriptor produced by
+    /// [`plan_member_shards`]. Returns `None` for a malformed descriptor —
+    /// including the whole-dataset shard's `null` descriptor, so callers must
+    /// check [`ShardSpec::is_whole`] first.
+    pub fn from_spec(spec: &ShardSpec) -> Option<Self> {
+        let d = &spec.descriptor;
+        Some(Self {
+            members: d.get("members")?.as_u64()? as usize,
+            member: d.get("member")?.as_u64()? as usize,
+        })
+    }
+}
+
+/// Enumerate `target` group-membership slots, optionally capped at the
+/// subscription's total partition count (a member beyond the partition count
+/// would sit idle — Kafka never assigns one partition to two members of a
+/// group). `partition_cap` is `None` when the partition count could not be
+/// resolved (broker unreachable at enumeration time); the plan then trusts
+/// `target`. `target <= 1` yields a single whole-dataset shard (run it as one
+/// plain consumer).
+pub fn plan_member_shards(target: usize, partition_cap: Option<usize>) -> Vec<ShardSpec> {
+    let n = match partition_cap {
+        Some(cap) => target.min(cap.max(1)),
+        None => target,
+    };
+    if n <= 1 {
+        return vec![ShardSpec::whole()];
+    }
+    (0..n)
+        .map(|i| {
+            ShardSpec::new(
+                i.to_string(),
+                serde_json::json!({ "members": n, "member": i }),
+            )
+        })
+        .collect()
+}
+
+/// Parse + validate an applied shard for the Kafka source.
+///
+/// Returns `Ok(None)` for the whole-dataset shard (plain single-consumer run)
+/// and a typed [`FaucetError::Source`] for a malformed descriptor.
+pub fn parse_member_shard(shard: &ShardSpec) -> Result<Option<MemberShard>, FaucetError> {
+    if shard.is_whole() {
+        return Ok(None);
+    }
+    MemberShard::from_spec(shard).map(Some).ok_or_else(|| {
+        FaucetError::Source(format!(
+            "kafka: invalid shard descriptor: {}",
+            shard.descriptor
+        ))
+    })
+}
+
+/// Decide whether a bookmarked partition needs an explicit seek, given the
+/// group's committed offset for it (`None` = no committed offset / lookup
+/// failed / invalid).
+///
+/// - Committed **at or ahead of** the bookmark → no seek: the consumer's
+///   default start (the committed offset) already covers everything the
+///   bookmark does, and seeking backwards would re-read messages another
+///   member durably wrote after this bookmark was taken.
+/// - Committed behind the bookmark, or absent → seek to the bookmark. This is
+///   the crash window between a durable page write (bookmark persisted) and
+///   its broker commit: the bookmark is the furthest durable position, so
+///   starting below it merely duplicates (at-least-once), while ignoring it
+///   under `auto.offset.reset: latest` would silently skip records.
+pub fn member_seek_offset(bookmark: i64, committed: Option<i64>) -> Option<i64> {
+    match committed {
+        Some(c) if c >= bookmark => None,
+        _ => Some(bookmark),
+    }
+}
+
+/// Filter a cumulative `(topic, partition) -> next_offset` map down to the
+/// partitions this member currently owns, as a deterministic list ready to be
+/// committed. Committing only owned partitions avoids regressing another
+/// member's committed offset after a partition migrated away mid-page.
+pub fn commit_list(
+    offsets: &HashMap<(String, i32), i64>,
+    assigned: &HashSet<(String, i32)>,
+) -> Vec<(String, i32, i64)> {
+    let mut out: Vec<(String, i32, i64)> = offsets
+        .iter()
+        .filter(|(tp, _)| assigned.contains(*tp))
+        .map(|((t, p), &o)| (t.clone(), *p, o))
+        .collect();
+    out.sort();
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn plan_member_shards_returns_target_slots() {
+        let shards = plan_member_shards(3, None);
+        assert_eq!(shards.len(), 3);
+        for (i, s) in shards.iter().enumerate() {
+            assert_eq!(s.id, i.to_string());
+            assert_eq!(s.descriptor["members"], 3);
+            assert_eq!(s.descriptor["member"], i);
+            assert_eq!(s.size_estimate, None, "member slots carry no size");
+        }
+    }
+
+    #[test]
+    fn plan_member_shards_caps_at_partition_count() {
+        // 8 requested members over a 3-partition subscription → 3 slots; the
+        // extra 5 would never be assigned a partition.
+        let shards = plan_member_shards(8, Some(3));
+        assert_eq!(shards.len(), 3);
+        assert_eq!(shards[0].descriptor["members"], 3);
+    }
+
+    #[test]
+    fn plan_member_shards_uncapped_when_partition_count_unknown() {
+        let shards = plan_member_shards(4, None);
+        assert_eq!(shards.len(), 4);
+    }
+
+    #[test]
+    fn plan_member_shards_target_one_is_whole() {
+        for (target, cap) in [(1, None), (0, None), (5, Some(1)), (5, Some(0))] {
+            let shards = plan_member_shards(target, cap);
+            assert_eq!(shards.len(), 1, "target={target} cap={cap:?}");
+            assert!(shards[0].is_whole());
+        }
+    }
+
+    #[test]
+    fn member_shard_round_trips_plan_descriptors() {
+        for spec in plan_member_shards(5, None) {
+            let m = MemberShard::from_spec(&spec).unwrap();
+            assert_eq!(m.members, 5);
+            assert_eq!(m.member, spec.id.parse::<usize>().unwrap());
+        }
+    }
+
+    #[test]
+    fn parse_member_shard_whole_clears_and_real_parses() {
+        assert!(
+            parse_member_shard(&ShardSpec::whole())
+                .expect("whole parses")
+                .is_none()
+        );
+        let spec = &plan_member_shards(3, None)[2];
+        let m = parse_member_shard(spec).unwrap().unwrap();
+        assert_eq!((m.members, m.member), (3, 2));
+    }
+
+    #[test]
+    fn parse_member_shard_rejects_malformed_descriptor() {
+        for bad in [
+            ShardSpec::new("0", json!({ "member": 0 })),
+            ShardSpec::new("0", json!({ "members": 4 })),
+            ShardSpec::new("0", json!({ "members": "four", "member": 0 })),
+        ] {
+            let err = parse_member_shard(&bad).unwrap_err();
+            assert!(err.to_string().contains("kafka"), "got: {err}");
+        }
+    }
+
+    // ── committed-aware seek decision ────────────────────────────────────────
+
+    #[test]
+    fn seek_when_committed_absent() {
+        assert_eq!(member_seek_offset(42, None), Some(42));
+    }
+
+    #[test]
+    fn seek_when_bookmark_ahead_of_committed() {
+        // The durable-write-before-commit crash window: bookmark is the
+        // furthest durable position, so it wins.
+        assert_eq!(member_seek_offset(100, Some(90)), Some(100));
+    }
+
+    #[test]
+    fn no_seek_when_committed_at_or_ahead() {
+        // A partition that migrated to another member and advanced: seeking
+        // back to our stale bookmark would duplicate that member's work.
+        assert_eq!(member_seek_offset(100, Some(100)), None);
+        assert_eq!(member_seek_offset(100, Some(250)), None);
+    }
+
+    // ── commit list ─────────────────────────────────────────────────────────
+
+    fn tp(t: &str, p: i32) -> (String, i32) {
+        (t.to_string(), p)
+    }
+
+    #[test]
+    fn commit_list_filters_to_assigned_and_sorts() {
+        let mut offsets = HashMap::new();
+        offsets.insert(tp("t", 1), 20);
+        offsets.insert(tp("t", 0), 10);
+        offsets.insert(tp("t", 2), 30); // migrated away — must not be committed
+        let assigned: HashSet<_> = [tp("t", 0), tp("t", 1)].into();
+        assert_eq!(
+            commit_list(&offsets, &assigned),
+            vec![("t".to_string(), 0, 10), ("t".to_string(), 1, 20)]
+        );
+    }
+
+    #[test]
+    fn commit_list_empty_when_nothing_assigned() {
+        let mut offsets = HashMap::new();
+        offsets.insert(tp("t", 0), 10);
+        assert!(commit_list(&offsets, &HashSet::new()).is_empty());
+    }
+}

--- a/crates/source/kafka/src/stream.rs
+++ b/crates/source/kafka/src/stream.rs
@@ -3,20 +3,22 @@
 use crate::config::KafkaSourceConfig;
 use crate::context::BookmarkContext;
 use crate::decode;
+use crate::shard::{MemberShard, commit_list, parse_member_shard, plan_member_shards};
 use crate::state::{Bookmark, PartitionOffset, state_key};
 use async_trait::async_trait;
 use base64::Engine;
 use faucet_common_kafka::OnDecodeError;
+use faucet_core::shard::ShardSpec;
 use faucet_core::{FaucetError, Source, Stream, StreamPage};
-use rdkafka::ClientConfig;
-use rdkafka::Message;
 use rdkafka::config::RDKafkaLogLevel;
-use rdkafka::consumer::{Consumer, StreamConsumer};
+use rdkafka::consumer::{CommitMode, Consumer, StreamConsumer};
 use rdkafka::message::Headers;
+use rdkafka::{ClientConfig, Message, Offset, TopicPartitionList};
 use serde_json::{Map, Value, json};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::pin::Pin;
 use std::sync::Arc;
+use std::sync::atomic::Ordering;
 use std::time::{Duration, Instant};
 
 #[cfg(feature = "schema-registry")]
@@ -34,6 +36,10 @@ pub struct KafkaSource {
     /// Resolved once per partition and reused so the streaming bookmark build
     /// doesn't issue a broker `fetch_watermarks` every page (#146 H9).
     assigned_floor: std::sync::Mutex<HashMap<(String, i32), i64>>,
+    /// The group-member shard applied by a cluster coordinator (Mode B, #261),
+    /// or `None` for a plain single-consumer run. `Mutex` so
+    /// `apply_shard(&self, …)` can record it before streaming.
+    member_shard: std::sync::Mutex<Option<MemberShard>>,
     #[cfg(feature = "schema-registry")]
     sr_client: Option<SchemaRegistryClient>,
 }
@@ -80,6 +86,7 @@ impl KafkaSource {
             context,
             state_key_value,
             assigned_floor: std::sync::Mutex::new(HashMap::new()),
+            member_shard: std::sync::Mutex::new(None),
             #[cfg(feature = "schema-registry")]
             sr_client,
         })
@@ -223,6 +230,134 @@ impl KafkaSource {
         } else {
             Ok(Some(merged.to_value()?))
         }
+    }
+
+    /// Whether a cluster coordinator applied a group-member shard (Mode B,
+    /// #261) — i.e. this consumer is one of N cooperating members of the group.
+    fn member_mode(&self) -> bool {
+        self.context.member_mode.load(Ordering::Acquire)
+    }
+
+    /// Group-member mode only: commit `offsets` (the cumulative
+    /// `(topic, partition) -> next_offset` map of pages that are already
+    /// durable — written to the sink and bookmark-persisted) to the consumer
+    /// group, so a partition that migrates to another member on rebalance
+    /// resumes from the last durable position instead of `auto.offset.reset`.
+    ///
+    /// Only currently-assigned partitions are committed — committing a stale
+    /// offset for a partition that migrated away mid-page would regress the
+    /// new owner's commit. Best-effort by design (warn on error): offsets are
+    /// cumulative, so a failed commit is retried at the next durable boundary
+    /// and the cost of a lost commit is a bounded re-read (at-least-once),
+    /// never data loss.
+    ///
+    /// Mid-run commits are `CommitMode::Async` (no broker round-trip on the
+    /// hot path). The `terminal` end-of-stream commit is synchronous (off the
+    /// async runtime) so the group's next member sees the final position even
+    /// when the process exits right after the run — the run-end handoff case.
+    async fn commit_durable(&self, offsets: &HashMap<(String, i32), i64>, terminal: bool) {
+        if !self.member_mode() || offsets.is_empty() {
+            return;
+        }
+        let assigned: HashSet<(String, i32)> = match self.consumer.assignment() {
+            Ok(tpl) => tpl
+                .elements()
+                .iter()
+                .map(|e| (e.topic().to_string(), e.partition()))
+                .collect(),
+            Err(e) => {
+                tracing::warn!(error = %e, "kafka member mode: assignment() failed; skipping offset commit");
+                return;
+            }
+        };
+        let list = commit_list(offsets, &assigned);
+        if list.is_empty() {
+            return;
+        }
+        let mut tpl = TopicPartitionList::with_capacity(list.len());
+        for (topic, partition, offset) in &list {
+            if let Err(e) = tpl.add_partition_offset(topic, *partition, Offset::Offset(*offset)) {
+                tracing::warn!(
+                    topic,
+                    partition,
+                    offset,
+                    error = %e,
+                    "kafka member mode: building commit list failed; skipping offset commit"
+                );
+                return;
+            }
+        }
+        if terminal {
+            // `commit(…, Sync)` is a blocking broker round-trip — run it off
+            // the async runtime.
+            let consumer = Arc::clone(&self.consumer);
+            match tokio::task::spawn_blocking(move || consumer.commit(&tpl, CommitMode::Sync)).await
+            {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => tracing::warn!(
+                    error = %e,
+                    "kafka member mode: terminal offset commit failed; \
+                     the group's next member may re-read the tail (at-least-once)"
+                ),
+                Err(join_err) => tracing::warn!(
+                    error = %join_err,
+                    "kafka member mode: terminal offset commit task failed"
+                ),
+            }
+        } else if let Err(e) = self.consumer.commit(&tpl, CommitMode::Async) {
+            tracing::warn!(
+                error = %e,
+                "kafka member mode: offset commit failed (retried at the next durable boundary)"
+            );
+        }
+    }
+
+    /// Total partition count across the subscribed topics, used to cap the
+    /// member-shard plan (a member beyond the partition count would sit idle).
+    /// `None` when any topic's metadata cannot be resolved — enumeration then
+    /// trusts the requested member count instead of failing the run.
+    async fn total_partitions(&self) -> Option<usize> {
+        let consumer = Arc::clone(&self.consumer);
+        let topics = self.config.topics.clone();
+        // `fetch_metadata` is a blocking librdkafka broker call — run it off
+        // the async runtime.
+        tokio::task::spawn_blocking(move || {
+            let mut total = 0usize;
+            for topic in &topics {
+                match consumer.fetch_metadata(Some(topic), Duration::from_secs(5)) {
+                    Ok(md) => {
+                        let n: usize = md
+                            .topics()
+                            .iter()
+                            .filter(|t| t.name() == topic)
+                            .map(|t| t.partitions().len())
+                            .sum();
+                        if n == 0 {
+                            tracing::warn!(
+                                topic,
+                                "kafka enumerate_shards: topic has no partitions in metadata; \
+                                 not capping the member count"
+                            );
+                            return None;
+                        }
+                        total += n;
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            topic,
+                            error = %e,
+                            "kafka enumerate_shards: metadata fetch failed; \
+                             not capping the member count"
+                        );
+                        return None;
+                    }
+                }
+            }
+            Some(total)
+        })
+        .await
+        .ok()
+        .flatten()
     }
 
     async fn message_to_value(
@@ -437,8 +572,19 @@ impl Source for KafkaSource {
             let mut pending_offsets: HashMap<(String, i32), i64> = HashMap::new();
             let mut last_message_at = Instant::now();
             let mut total: usize = 0;
+            // Group-member mode (#261): offsets of the last yielded page,
+            // committed to the consumer group once that page is DURABLE. The
+            // generator resumes after a `yield` only when the pipeline polls
+            // the next page — which happens after it has written the previous
+            // page to the sink and persisted its bookmark — so committing at
+            // resume time never advances the group past unwritten data.
+            let mut to_commit: Option<HashMap<(String, i32), i64>> = None;
 
             loop {
+                if let Some(durable) = to_commit.take() {
+                    self.commit_durable(&durable, false).await;
+                }
+
                 // Surface any error raised by the rebalance callback (e.g. a
                 // failed seek) before processing the next poll batch.
                 self.check_callback_error()?;
@@ -518,7 +664,11 @@ impl Source for KafkaSource {
                         Vec::with_capacity(initial_capacity),
                     );
                     let bookmark = self.build_bookmark(&pending_offsets).await?;
+                    let durable_snapshot = pending_offsets.clone();
                     yield StreamPage { records: page_records, bookmark };
+                    // Resumed ⇒ the page above is durable; commit its offsets
+                    // to the group at the top of the next iteration.
+                    to_commit = Some(durable_snapshot);
                 }
 
                 if stop {
@@ -533,6 +683,13 @@ impl Source for KafkaSource {
                 let bookmark = self.build_bookmark(&pending_offsets).await?;
                 yield StreamPage { records: buffer, bookmark };
             }
+
+            // This code runs only when the pipeline polls past the final page
+            // — i.e. after every yielded page has been written and its
+            // bookmark persisted — so the whole cumulative offset map is
+            // durable. Committing it hands the group's next member a clean
+            // starting position (covers the tail the mid-loop commit missed).
+            self.commit_durable(&pending_offsets, true).await;
 
             tracing::info!(
                 messages = total,
@@ -640,13 +797,196 @@ impl Source for KafkaSource {
         };
         Ok(CheckReport::single(probe))
     }
+
+    /// The Kafka source is always shardable via **native consumer-group
+    /// assignment** (#261): each shard is a membership slot in the shared
+    /// group, and the broker — not faucet — assigns partitions across the
+    /// members and rebalances on membership change. Sharding only takes
+    /// effect when the cluster coordinator calls `apply_shard`; a plain
+    /// `faucet run` consumes as a single group member, unchanged.
+    fn is_shardable(&self) -> bool {
+        true
+    }
+
+    /// Enumerate `target` group-membership slots, capped at the subscription's
+    /// total partition count (extra members would never be assigned a
+    /// partition). Falls back to the uncapped `target` when topic metadata
+    /// cannot be resolved.
+    async fn enumerate_shards(&self, target: usize) -> Result<Vec<ShardSpec>, FaucetError> {
+        if target <= 1 {
+            return Ok(vec![ShardSpec::whole()]);
+        }
+        let cap = self.total_partitions().await;
+        Ok(plan_member_shards(target, cap))
+    }
+
+    /// Enter group-member mode for one membership slot (or leave it, for the
+    /// whole-dataset shard). In member mode the source additionally:
+    ///
+    /// - **commits offsets to the consumer group at durable page boundaries**
+    ///   (see [`stream_pages`](Self::stream_pages)), so partitions that
+    ///   migrate between members resume from the last durably-written
+    ///   position;
+    /// - **defers bookmark seeks to the group's committed offsets** whenever
+    ///   those are ahead (another member may have advanced a partition past
+    ///   this member's bookmark).
+    ///
+    /// Only the streaming path (`stream_pages`, which every `Pipeline` run
+    /// drives) commits; the batch `fetch_all` path never commits because its
+    /// records are not durable until after the fetch returns.
+    async fn apply_shard(&self, shard: &ShardSpec) -> Result<(), FaucetError> {
+        let parsed = parse_member_shard(shard)?;
+        self.context
+            .member_mode
+            .store(parsed.is_some(), Ordering::Release);
+        *self
+            .member_shard
+            .lock()
+            .map_err(|e| FaucetError::State(format!("kafka member_shard mutex poisoned: {e}")))? =
+            parsed;
+        if let Some(m) = parsed {
+            tracing::info!(
+                member = m.member,
+                members = m.members,
+                group = %self.config.group_id,
+                "kafka source: joining the consumer group as one of N cooperating members (Mode B)"
+            );
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    /// `dataset_uri` logic tests — replicate the method's computation directly
-    /// using config field values, because `KafkaSource::new` requires a live
-    /// broker to construct an `rdkafka` consumer.
+    use super::*;
+    use crate::config::OffsetReset;
+    use std::collections::BTreeMap;
+
+    /// Build a source pointing at an unreachable broker. rdkafka client
+    /// construction and `subscribe()` are local operations (no broker
+    /// round-trip), so this constructs fine offline — only actual
+    /// polls/metadata fetches would fail.
+    async fn offline_source() -> KafkaSource {
+        let config = KafkaSourceConfig {
+            brokers: "127.0.0.1:1".into(),
+            topics: vec!["orders".into()],
+            group_id: "g".into(),
+            auth: faucet_common_kafka::KafkaAuth::None,
+            value_format: faucet_common_kafka::KafkaValueFormat::Json,
+            key_format: None,
+            auto_offset_reset: OffsetReset::Latest,
+            max_messages: Some(1),
+            idle_timeout: None,
+            poll_timeout: Duration::from_secs(1),
+            session_timeout: Duration::from_secs(30),
+            on_decode_error: OnDecodeError::Fail,
+            extra_client_config: BTreeMap::new(),
+            batch_size: 10,
+        };
+        KafkaSource::new(config)
+            .await
+            .expect("offline construction")
+    }
+
+    #[tokio::test]
+    async fn source_is_shardable() {
+        assert!(offline_source().await.is_shardable());
+    }
+
+    #[tokio::test]
+    async fn apply_shard_enters_and_leaves_member_mode() {
+        let source = offline_source().await;
+        assert!(!source.member_mode(), "plain run starts out of member mode");
+
+        let member = ShardSpec::new("1", serde_json::json!({ "members": 3, "member": 1 }));
+        source.apply_shard(&member).await.unwrap();
+        assert!(source.member_mode());
+        assert_eq!(
+            *source.member_shard.lock().unwrap(),
+            Some(MemberShard {
+                members: 3,
+                member: 1
+            })
+        );
+
+        // The whole-dataset shard clears member mode (plain single consumer).
+        source.apply_shard(&ShardSpec::whole()).await.unwrap();
+        assert!(!source.member_mode());
+        assert_eq!(*source.member_shard.lock().unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn apply_shard_rejects_malformed_descriptor() {
+        let source = offline_source().await;
+        let err = source
+            .apply_shard(&ShardSpec::new("0", serde_json::json!({ "member": 0 })))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("kafka"), "got: {err}");
+        assert!(
+            !source.member_mode(),
+            "a rejected shard must not flip modes"
+        );
+    }
+
+    #[tokio::test]
+    async fn enumerate_shards_target_one_is_whole() {
+        // target <= 1 short-circuits before any metadata fetch, so this is
+        // fast offline.
+        let source = offline_source().await;
+        let shards = source.enumerate_shards(1).await.unwrap();
+        assert_eq!(shards.len(), 1);
+        assert!(shards[0].is_whole());
+    }
+
+    #[tokio::test]
+    async fn enumerate_shards_uncapped_when_metadata_unreachable() {
+        // fetch_metadata against the unreachable broker fails within its
+        // bounded budget; enumeration falls back to the requested member
+        // count (uncapped) instead of failing the run.
+        let source = offline_source().await;
+        let shards = source.enumerate_shards(3).await.unwrap();
+        assert_eq!(shards.len(), 3);
+        assert_eq!(shards[0].descriptor["members"], 3);
+        assert_eq!(shards[2].descriptor["member"], 2);
+    }
+
+    #[tokio::test]
+    async fn commit_durable_with_no_assignment_commits_nothing() {
+        // Member mode + a non-empty offset map, but the consumer owns no
+        // partitions (it never polled): the assigned-partition filter drops
+        // everything and no commit is attempted — which would otherwise
+        // block against the unreachable broker.
+        let source = offline_source().await;
+        source
+            .apply_shard(&ShardSpec::new(
+                "0",
+                serde_json::json!({ "members": 2, "member": 0 }),
+            ))
+            .await
+            .unwrap();
+        let mut offsets = HashMap::new();
+        offsets.insert(("orders".to_string(), 0), 10i64);
+        source.commit_durable(&offsets, true).await;
+    }
+
+    #[tokio::test]
+    async fn commit_durable_is_a_noop_outside_member_mode() {
+        // Must not touch the (unreachable) broker: returns before any
+        // assignment/commit call when member mode is off or offsets are empty.
+        let source = offline_source().await;
+        let mut offsets = HashMap::new();
+        offsets.insert(("orders".to_string(), 0), 10i64);
+        source.commit_durable(&offsets, false).await; // member mode off
+        source
+            .apply_shard(&ShardSpec::new(
+                "0",
+                serde_json::json!({ "members": 2, "member": 0 }),
+            ))
+            .await
+            .unwrap();
+        source.commit_durable(&HashMap::new(), true).await; // empty offsets
+    }
 
     #[test]
     fn dataset_uri_single_broker_single_topic() {

--- a/crates/source/kafka/tests/cluster.rs
+++ b/crates/source/kafka/tests/cluster.rs
@@ -1,0 +1,419 @@
+//! Integration tests for clustered (Mode B, #261) group-member consumption
+//! against a real Kafka broker via testcontainers.
+//!
+//! These tests require Docker to be running.
+//!
+//! What is exercised end-to-end:
+//! - two member shards of the same group split a multi-partition topic with
+//!   no duplication and no loss (native consumer-group assignment);
+//! - a membership handoff (member gone, replacement joins) resumes from the
+//!   group's committed offsets — the offsets a member commits at durable page
+//!   boundaries — instead of `auto.offset.reset`;
+//! - a stale state-store bookmark on a new member defers to committed offsets
+//!   (no re-read of work another member already completed), while a bookmark
+//!   *ahead* of the committed offset still wins (the durable-write-before-
+//!   commit crash window).
+
+use faucet_core::shard::ShardSpec;
+use faucet_core::{Source, StreamPage};
+use faucet_source_kafka::{
+    KafkaAuth, KafkaSource, KafkaSourceConfig, KafkaValueFormat, OffsetReset, OnDecodeError,
+};
+use futures::StreamExt;
+use rdkafka::ClientConfig;
+use rdkafka::admin::{AdminClient, AdminOptions, NewTopic, TopicReplication};
+use rdkafka::client::DefaultClientContext;
+use rdkafka::producer::{FutureProducer, FutureRecord, Producer};
+use serde_json::Value;
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::time::Duration;
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::kafka::apache::{KAFKA_PORT, Kafka};
+
+async fn start_kafka() -> (testcontainers::ContainerAsync<Kafka>, String) {
+    let container = Kafka::default()
+        .start()
+        .await
+        .expect("kafka container start");
+    let port = container
+        .get_host_port_ipv4(KAFKA_PORT)
+        .await
+        .expect("kafka port");
+    (container, format!("127.0.0.1:{port}"))
+}
+
+async fn create_topic(brokers: &str, topic: &str, partitions: i32) {
+    let admin: AdminClient<DefaultClientContext> = ClientConfig::new()
+        .set("bootstrap.servers", brokers)
+        .create()
+        .expect("admin client init");
+    admin
+        .create_topics(
+            &[NewTopic::new(topic, partitions, TopicReplication::Fixed(1))],
+            &AdminOptions::new(),
+        )
+        .await
+        .expect("create_topics");
+}
+
+/// Produce `per_partition` JSON messages to each of the topic's partitions.
+async fn produce_across_partitions(
+    brokers: &str,
+    topic: &str,
+    partitions: i32,
+    per_partition: u32,
+) {
+    let producer: FutureProducer = ClientConfig::new()
+        .set("bootstrap.servers", brokers)
+        .set("message.timeout.ms", "5000")
+        .create()
+        .expect("producer init");
+    for p in 0..partitions {
+        for i in 0..per_partition {
+            let value = format!(r#"{{"p":{p},"i":{i}}}"#);
+            let record: FutureRecord<'_, str, String> =
+                FutureRecord::to(topic).partition(p).payload(&value);
+            producer
+                .send(record, Duration::from_secs(5))
+                .await
+                .expect("producer send");
+        }
+    }
+    producer
+        .flush(Duration::from_secs(5))
+        .expect("producer flush");
+}
+
+fn member_config(
+    brokers: &str,
+    topic: &str,
+    group: &str,
+    idle: Duration,
+    batch_size: usize,
+) -> KafkaSourceConfig {
+    KafkaSourceConfig {
+        brokers: brokers.into(),
+        topics: vec![topic.into()],
+        group_id: group.into(),
+        auth: KafkaAuth::None,
+        value_format: KafkaValueFormat::Json,
+        key_format: None,
+        auto_offset_reset: OffsetReset::Earliest,
+        max_messages: None,
+        idle_timeout: Some(idle),
+        poll_timeout: Duration::from_secs(1),
+        session_timeout: Duration::from_secs(10),
+        on_decode_error: OnDecodeError::Fail,
+        extra_client_config: BTreeMap::new(),
+        batch_size,
+    }
+}
+
+fn member_shard(members: usize, member: usize) -> ShardSpec {
+    ShardSpec::new(
+        member.to_string(),
+        serde_json::json!({ "members": members, "member": member }),
+    )
+}
+
+/// Drive `stream_pages` to completion (so the terminal offset commit runs)
+/// and return every record.
+async fn drain(source: &KafkaSource) -> Vec<Value> {
+    let ctx = HashMap::new();
+    let mut stream = source.stream_pages(&ctx, 0);
+    let mut records = Vec::new();
+    while let Some(page) = stream.next().await {
+        let StreamPage { records: r, .. } = page.expect("stream page");
+        records.extend(r);
+    }
+    records
+}
+
+/// Extract the `(partition, offset)` identity of each consumed record.
+fn identities(records: &[Value]) -> Vec<(i64, i64)> {
+    records
+        .iter()
+        .map(|r| {
+            (
+                r["partition"].as_i64().expect("partition"),
+                r["offset"].as_i64().expect("offset"),
+            )
+        })
+        .collect()
+}
+
+/// Two member shards of the same group, running concurrently, split a
+/// 4-partition topic: every message is consumed by exactly one member — no
+/// loss, no duplication — and (with messages on every partition) both members
+/// participate. This is the steady-state acceptance criterion of #261.
+#[tokio::test(flavor = "multi_thread")]
+async fn group_members_split_partitions_concurrently() {
+    let (_container, brokers) = start_kafka().await;
+    let topic = "cluster-split";
+    let group = "g-cluster-split";
+    let partitions = 4i32;
+    let per_partition = 5u32;
+    create_topic(&brokers, topic, partitions).await;
+
+    // Start both members BEFORE producing: the group forms and reaches its
+    // steady 2-member assignment while the topic is empty, so no message is
+    // in flight during the join rebalances (which is what makes the strict
+    // no-duplication assertion deterministic).
+    let a = KafkaSource::new(member_config(
+        &brokers,
+        topic,
+        group,
+        Duration::from_secs(25),
+        2,
+    ))
+    .await
+    .unwrap();
+    let b = KafkaSource::new(member_config(
+        &brokers,
+        topic,
+        group,
+        Duration::from_secs(25),
+        2,
+    ))
+    .await
+    .unwrap();
+    a.apply_shard(&member_shard(2, 0)).await.unwrap();
+    b.apply_shard(&member_shard(2, 1)).await.unwrap();
+
+    let fut_a = tokio::spawn(async move { (identities(&drain(&a).await), a) });
+    let fut_b = tokio::spawn(async move { (identities(&drain(&b).await), b) });
+
+    // Give the group time to form (both joins + rebalance), then produce.
+    tokio::time::sleep(Duration::from_secs(10)).await;
+    produce_across_partitions(&brokers, topic, partitions, per_partition).await;
+
+    let (got_a, _a) = fut_a.await.expect("member a task");
+    let (got_b, _b) = fut_b.await.expect("member b task");
+
+    let expected: HashSet<(i64, i64)> = (0..partitions as i64)
+        .flat_map(|p| (0..per_partition as i64).map(move |o| (p, o)))
+        .collect();
+    let union: Vec<(i64, i64)> = got_a.iter().chain(got_b.iter()).copied().collect();
+    let unique: HashSet<(i64, i64)> = union.iter().copied().collect();
+
+    assert_eq!(
+        unique, expected,
+        "every produced message consumed (no loss)"
+    );
+    assert_eq!(
+        union.len(),
+        expected.len(),
+        "each message consumed exactly once (no duplication): a={got_a:?} b={got_b:?}"
+    );
+    assert!(
+        !got_a.is_empty() && !got_b.is_empty(),
+        "both members participate in a 4-partition split: a={} b={}",
+        got_a.len(),
+        got_b.len()
+    );
+    // Kafka assigns a partition to exactly one member of a generation.
+    let parts_a: HashSet<i64> = got_a.iter().map(|(p, _)| *p).collect();
+    let parts_b: HashSet<i64> = got_b.iter().map(|(p, _)| *p).collect();
+    assert!(
+        parts_a.is_disjoint(&parts_b),
+        "partition sets are disjoint: a={parts_a:?} b={parts_b:?}"
+    );
+}
+
+/// Membership handoff: a member consumes + commits at durable page boundaries
+/// (terminal commit at stream end), then leaves. A replacement member of the
+/// same group must resume from the committed offsets — zero re-read of the
+/// first member's work, and exactly the newly-produced messages afterwards.
+/// This simulates the "killing one worker triggers a rebalance onto the
+/// survivor" criterion deterministically.
+#[tokio::test(flavor = "multi_thread")]
+async fn membership_handoff_resumes_from_committed_offsets() {
+    let (_container, brokers) = start_kafka().await;
+    let topic = "cluster-handoff";
+    let group = "g-cluster-handoff";
+    let partitions = 3i32;
+    create_topic(&brokers, topic, partitions).await;
+    produce_across_partitions(&brokers, topic, partitions, 3).await; // 9 messages
+
+    // Member 0 drains everything; page size 2 forces mid-stream commits and
+    // the stream end runs the synchronous terminal commit.
+    let m0 = KafkaSource::new(member_config(
+        &brokers,
+        topic,
+        group,
+        Duration::from_secs(8),
+        2,
+    ))
+    .await
+    .unwrap();
+    m0.apply_shard(&member_shard(2, 0)).await.unwrap();
+    let got0 = drain(&m0).await;
+    assert_eq!(got0.len(), 9, "member 0 drains the whole topic");
+    drop(m0); // member leaves the group
+
+    // A replacement member joins: the committed offsets cover everything, so
+    // it must consume nothing (no duplication across the handoff).
+    let m1 = KafkaSource::new(member_config(
+        &brokers,
+        topic,
+        group,
+        Duration::from_secs(8),
+        0,
+    ))
+    .await
+    .unwrap();
+    m1.apply_shard(&member_shard(2, 1)).await.unwrap();
+    let got1 = drain(&m1).await;
+    assert!(
+        got1.is_empty(),
+        "replacement member must not re-read committed work, got {got1:?}"
+    );
+    drop(m1);
+
+    // New messages after the handoff are consumed exactly once from the
+    // committed positions.
+    produce_across_partitions(&brokers, topic, partitions, 2).await; // 6 new
+    let m2 = KafkaSource::new(member_config(
+        &brokers,
+        topic,
+        group,
+        Duration::from_secs(8),
+        0,
+    ))
+    .await
+    .unwrap();
+    m2.apply_shard(&member_shard(2, 1)).await.unwrap();
+    let got2 = identities(&drain(&m2).await);
+    let expected: HashSet<(i64, i64)> = (0..partitions as i64)
+        .flat_map(|p| (3..5i64).map(move |o| (p, o)))
+        .collect();
+    assert_eq!(
+        got2.iter().copied().collect::<HashSet<_>>(),
+        expected,
+        "exactly the post-handoff messages, no old re-reads"
+    );
+    assert_eq!(got2.len(), expected.len(), "no duplicates");
+}
+
+/// A stale state-store bookmark on a new member (e.g. a reclaimed shard whose
+/// dead owner's bookmark predates work other members completed) must defer to
+/// the group's committed offsets instead of seeking backwards and re-reading.
+#[tokio::test(flavor = "multi_thread")]
+async fn stale_member_bookmark_defers_to_committed_offsets() {
+    let (_container, brokers) = start_kafka().await;
+    let topic = "cluster-stale-bookmark";
+    let group = "g-cluster-stale";
+    create_topic(&brokers, topic, 1).await;
+    produce_across_partitions(&brokers, topic, 1, 5).await;
+
+    // Member 0 consumes all 5 and commits (terminal sync commit).
+    let m0 = KafkaSource::new(member_config(
+        &brokers,
+        topic,
+        group,
+        Duration::from_secs(8),
+        0,
+    ))
+    .await
+    .unwrap();
+    m0.apply_shard(&member_shard(2, 0)).await.unwrap();
+    assert_eq!(drain(&m0).await.len(), 5);
+    drop(m0);
+
+    // New member with a STALE bookmark (offset 2 < committed 5): committed
+    // must win — nothing is re-read.
+    let m1 = KafkaSource::new(member_config(
+        &brokers,
+        topic,
+        group,
+        Duration::from_secs(8),
+        0,
+    ))
+    .await
+    .unwrap();
+    m1.apply_shard(&member_shard(2, 1)).await.unwrap();
+    m1.apply_start_bookmark(serde_json::json!({
+        "partition_offsets": [{"topic": topic, "partition": 0, "offset": 2}]
+    }))
+    .await
+    .unwrap();
+    let got = drain(&m1).await;
+    assert!(
+        got.is_empty(),
+        "stale bookmark must not re-read past-committed messages, got {got:?}"
+    );
+}
+
+/// A bookmark AHEAD of the committed offset (the durable-write-before-commit
+/// crash window) must still be seeked to in member mode: the bookmarked pages
+/// are durable, so starting below the bookmark would re-write them, and
+/// ignoring it entirely under `auto.offset.reset: latest` would lose data.
+#[tokio::test(flavor = "multi_thread")]
+async fn member_bookmark_ahead_of_committed_wins() {
+    let (_container, brokers) = start_kafka().await;
+    let topic = "cluster-ahead-bookmark";
+    let group = "g-cluster-ahead";
+    create_topic(&brokers, topic, 1).await;
+    produce_across_partitions(&brokers, topic, 1, 5).await;
+
+    // No committed offsets exist (fresh group); the member's bookmark says
+    // offsets 0..3 are already durable → only 3 and 4 may be consumed.
+    let m = KafkaSource::new(member_config(
+        &brokers,
+        topic,
+        group,
+        Duration::from_secs(8),
+        0,
+    ))
+    .await
+    .unwrap();
+    m.apply_shard(&member_shard(2, 0)).await.unwrap();
+    m.apply_start_bookmark(serde_json::json!({
+        "partition_offsets": [{"topic": topic, "partition": 0, "offset": 3}]
+    }))
+    .await
+    .unwrap();
+    let got = identities(&drain(&m).await);
+    assert_eq!(
+        got.iter().copied().collect::<HashSet<_>>(),
+        HashSet::from([(0i64, 3i64), (0, 4)]),
+        "bookmark ahead of committed is honoured"
+    );
+}
+
+/// `enumerate_shards` caps the member count at the subscription's partition
+/// count (a member beyond it would never be assigned a partition), and the
+/// resulting descriptors round-trip through `apply_shard`.
+#[tokio::test(flavor = "multi_thread")]
+async fn enumerate_shards_caps_at_partition_count() {
+    let (_container, brokers) = start_kafka().await;
+    let topic = "cluster-enumerate";
+    create_topic(&brokers, topic, 3).await;
+
+    let source = KafkaSource::new(member_config(
+        &brokers,
+        topic,
+        "g-enumerate",
+        Duration::from_secs(5),
+        0,
+    ))
+    .await
+    .unwrap();
+    assert!(source.is_shardable());
+
+    let shards = source.enumerate_shards(8).await.unwrap();
+    assert_eq!(
+        shards.len(),
+        3,
+        "8 requested members capped at 3 partitions"
+    );
+    for (i, s) in shards.iter().enumerate() {
+        assert_eq!(s.id, i.to_string());
+        assert_eq!(s.descriptor["members"], 3);
+        assert_eq!(s.descriptor["member"], i);
+        source.apply_shard(s).await.unwrap();
+    }
+
+    let two = source.enumerate_shards(2).await.unwrap();
+    assert_eq!(two.len(), 2, "a target below the partition count is kept");
+}

--- a/docs/book/src/cookbook/cluster.md
+++ b/docs/book/src/cookbook/cluster.md
@@ -296,6 +296,7 @@ finalized to `completed`/`failed` once every shard is terminal.
 | `s3` | hash-of-object-key modulo N | automatic (no config) |
 | `gcs` | hash-of-object-key modulo N | automatic (no config) |
 | `parquet` | hash-of-file-path modulo N | automatic (no config) |
+| `kafka` | native consumer-group membership | automatic (no config) |
 
 > **NULL shard keys are not dropped.** Rows whose `shard` key column is `NULL`
 > fall outside every range predicate, so the SQL sharders assign them to
@@ -311,8 +312,66 @@ database file (e.g. a shared volume). On `mssql` with incremental replication,
 shard bounds are computed over the not-yet-synced slice (the `@bookmark`
 binding is honoured during enumeration).
 
-Kafka uses native consumer-group assignment instead ([#261](https://github.com/PawanSikawat/faucet-stream/issues/261)).
 A non-shardable source (or a matrix pipeline) ignores `shard:` and runs whole — Mode B is fully backward compatible.
+
+### Kafka: native consumer-group sharding
+
+Kafka already solves work distribution inside the broker, so the `kafka`
+source does not enumerate data slices like the sharders above
+([#261](https://github.com/PawanSikawat/faucet-stream/issues/261)). Each shard
+is a **membership slot**: `shard.count: N` makes N workers each run one more
+consumer with the pipeline's `group_id`, and Kafka's consumer-group protocol
+assigns the topic's partitions across them — killing a worker triggers a
+broker-side rebalance onto the survivors immediately (well before the shard
+lease even expires), and the reclaimed membership slot simply rejoins the
+group on another worker.
+
+```yaml
+version: 1
+name: orders-fanin
+shard:
+  count: 4            # four cooperating members of the consumer group
+pipeline:
+  source:
+    type: kafka
+    config:
+      brokers: broker-1:9092,broker-2:9092
+      topics: [orders]
+      group_id: faucet-orders     # ALL members share this group
+      idle_timeout: 60
+  sink:
+    type: postgres
+    config:
+      connection_url: ${env:WAREHOUSE_URL}
+      table_name: orders
+      column_mapping: auto_map
+      write_mode: upsert
+      key: [id]
+  state: { type: postgres, config: { connection_url: ${env:STATE_URL} } }
+```
+
+How it differs from the other sharders:
+
+- **The broker decides the split.** Which member consumes which partition is
+  Kafka's choice, not faucet's; the member count is capped at the
+  subscription's total partition count (an extra member would sit idle).
+- **Offset continuity is Kafka-managed.** In member mode each consumer
+  *commits offsets to the group* at durable page boundaries (after the sink
+  confirmed the page and its bookmark persisted; plus a synchronous commit at
+  stream end). A partition that migrates to another member — rebalance,
+  worker death, shard reclaim — resumes from the last committed (= durable)
+  position instead of `auto.offset.reset`. The per-shard state-store bookmark
+  remains the safety net for the tiny durable-write→commit crash window: a
+  member seeks to its bookmark only when it is *ahead* of the committed
+  offset, never behind.
+- **The boundary is at-least-once on membership change.** A crash between a
+  durable page and its commit makes the partition's next owner re-read that
+  page. Pair with `write_mode: upsert` or an idempotent destination, as with
+  every clustered run.
+- **Termination:** each member stops on its own `idle_timeout` /
+  `max_messages` (`max_messages` is per member — N members consume up to N ×
+  `max_messages` in total). `idle_timeout` is the natural terminator for
+  shared consumption; a non-cluster Kafka run is completely unchanged.
 
 ### Per-shard resume and rebalancing
 


### PR DESCRIPTION
## Summary

Implements cluster Mode B sharding for the Kafka source via **native consumer-group assignment** — each shard is a *membership slot* in the shared consumer group rather than a data slice, so the broker (not faucet's shard coordinator) assigns partitions across the N cooperating members and rebalances onto survivors when a worker dies.

Closes #261. Parent: #230 (Mode B). Roadmap: #38.

## Design

**Membership slots, not data slices.** `KafkaSource` now overrides the three `Source` shard hooks:

- `is_shardable()` → `true`.
- `enumerate_shards(target)` → `target` member slots (`{"members": N, "member": i}` descriptors), **capped at the subscription's total partition count** (an extra member would never be assigned a partition; falls back to the uncapped target when metadata is unreachable).
- `apply_shard(...)` → enters *member mode*: this consumer is one of N cooperating members of the config's `group_id`.

The generic Mode B machinery (`coordinate_sharded_run` → `faucet_serve_shards` rows → claim loop → `resume_claimed_shard`) needed **zero changes**: each claimed member slot runs the pipeline with the shared `group_id`, and Kafka's group protocol does the actual work distribution. A worker death is handled twice over — the broker rebalances its partitions onto surviving members immediately, and the lease loop later requeues its membership slot so a replacement rejoins the group.

**Offset continuity is Kafka-managed in member mode.** Partitions migrate between members on rebalance, so per-member state-store bookmarks alone can't carry continuity. In member mode the source now:

- **commits offsets to the consumer group at durable page boundaries** — the generator resumes after a `yield` only once the pipeline has written that page and persisted its bookmark, so the commit never advances the group past unwritten data (async mid-run; a synchronous terminal commit at stream end covers the run-end handoff);
- commits **only currently-assigned partitions** (never regresses a new owner's commit after a mid-page migration);
- makes the rebalance callback **committed-aware**: a bookmarked partition is seeked only when the bookmark is *ahead* of the committed offset (`member_seek_offset`). Committed-ahead → no seek (seeking back would re-read another member's durable work); bookmark-ahead or committed-absent → seek (the durable-write→commit crash window, where honouring `auto.offset.reset: latest` would silently lose records). A failed committed-offsets lookup conservatively keeps every seek — may duplicate, never loses.

The boundary on membership change is **at-least-once** (documented): a crash between a durable page and its commit makes the partition's next owner re-read that page. The existing submit-time warning for at-least-once sharded runs with append-mode sinks applies unchanged.

**Backward compatible.** Member mode only activates when a cluster coordinator applies a member shard. A plain `faucet run` / non-cluster serve run never commits offsets and seeds bookmarks exactly as before (all existing integration tests pass unchanged).

## Changes

- `crates/source/kafka/src/shard.rs` (new) — pure member-slot planning/parsing (`plan_member_shards`, `MemberShard`, `parse_member_shard`), the committed-aware seek decision (`member_seek_offset`), and the assigned-partition commit filter (`commit_list`). No I/O; fully unit-tested.
- `crates/source/kafka/src/context.rs` — `member_mode` flag on `BookmarkContext`; `filter_seeks_by_committed` in the assign callback (one bounded broker round-trip, assign-time only).
- `crates/source/kafka/src/stream.rs` — the three `Source` shard overrides; `commit_durable` (durable-boundary group commits); `total_partitions` (partition-count cap probe); member-mode wiring in `stream_pages`.
- `docs/book/src/cookbook/cluster.md` — `kafka` row in the shardable-sources table + a "Kafka: native consumer-group sharding" section (semantics, offset continuity, at-least-once boundary, per-member termination).
- `crates/source/kafka/README.md` — "Clustered consumption (Mode B, native consumer groups)" section.

## Testing

- **Unit** (no broker): member-slot planning/capping/parsing round-trips, seek-decision truth table, commit-list filtering; `apply_shard` mode toggling + malformed-descriptor rejection; `enumerate_shards(1)` short-circuit; `commit_durable` no-op outside member mode.
- **Docker integration** (`crates/source/kafka/tests/cluster.rs`, testcontainers — all passing locally):
  - `group_members_split_partitions_concurrently` — two members of one group split a 4-partition topic: every message consumed exactly once (no loss, no duplication), partition sets disjoint — the steady-state acceptance criterion.
  - `membership_handoff_resumes_from_committed_offsets` — a member drains + commits, leaves; the replacement re-reads **nothing** and consumes exactly the post-handoff messages — the kill-one-worker → survivor criterion, deterministically.
  - `stale_member_bookmark_defers_to_committed_offsets` — a reclaimed slot's stale bookmark does not re-read past-committed work.
  - `member_bookmark_ahead_of_committed_wins` — the crash-window bookmark still seeks.
  - `enumerate_shards_caps_at_partition_count` — 8 requested members over 3 partitions → 3 slots.
- Existing kafka integration + streaming suites pass unchanged (non-cluster behaviour untouched).
- `cargo fmt` / `cargo clippy --all-targets --all-features -- -D warnings` clean.
- **Patch coverage 92.4%** (local `cargo llvm-cov` incl. the Docker suite ∩ diff, code lines): `shard.rs` 100%, `context.rs` 91.4%, `stream.rs` 87.4%. The residue is warn-and-degrade broker-fault branches (commit/assignment/metadata/committed-offsets lookup failures) that need a fault-injected broker to reach — each degrades to a bounded re-read (at-least-once), never loss.

## Out of scope

- The custom shard coordinator for non-Kafka sources (#230, already shipped).
- Batch-path (`fetch_all`) member commits — the pipeline always drives `stream_pages`; the batch path's records aren't durable until after the fetch returns, so committing there would risk at-most-once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
