### PR TITLE
feat(cli): data-freshness & volume SLA monitoring with anomaly alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ cargo add faucet-stream           # the library
   `Pipeline::new(&source, &sink).run().await?` from Rust. Same orchestration either way.
 - **⚙️ A runtime, not just connectors** — incremental + resumable replication, change-data-capture,
   exactly-once delivery, upsert/delete write modes, data-quality checks, data contracts,
-  dead-letter queues, automatic retries, adaptive batch sizing, secrets-manager interpolation,
+  freshness/volume SLA monitoring, dead-letter queues, automatic retries, adaptive batch sizing,
+  secrets-manager interpolation,
   cron scheduling, an HTTP control plane with event-driven triggers, OpenLineage emission, and
   built-in Prometheus metrics + `tracing` spans — all with zero per-connector code.
 - **📦 Pay only for what you use** — every connector is a Cargo feature, so a slim build can
@@ -173,6 +174,7 @@ one-block addition to your YAML:
 | **Upsert / delete write modes** | `write_mode: upsert \| delete` with a `key` + `delete_marker` — merge by key on Postgres / MySQL / SQL Server / SQLite / Mongo / Elasticsearch. | [upsert](https://pawansikawat.github.io/faucet-stream/cookbook/upsert.html) |
 | **Data-quality checks** | 13 per-record and per-batch assertions (not-null, regex, ranges, uniqueness, row-count, JSON Schema, …) with quarantine routing or abort policies. | [quality](https://pawansikawat.github.io/faucet-stream/cookbook/quality.html) |
 | **Data contracts** | A versioned promise about the output shape (types, nullability, enums, patterns, bounds) enforced per page — breaches fail, quarantine, or warn; export as JSON Schema / OpenLineage via `faucet contract`. | [contracts](https://pawansikawat.github.io/faucet-stream/cookbook/contracts.html) |
+| **SLA monitoring** | Declared freshness (`max_staleness_secs`) + volume floors and learned-baseline anomaly detection (z-score / IQR) per pipeline — violations emit metrics + warnings and surface in `faucet doctor`, never failing the run. | [SLA](https://pawansikawat.github.io/faucet-stream/cookbook/sla.html) |
 | **Dead-letter queue** | Route failed rows to any sink instead of aborting the run, with a fixed envelope and reason. | [DLQ](https://pawansikawat.github.io/faucet-stream/cookbook/dlq.html) |
 | **Adaptive batch sizing** | Opt-in AIMD controller that tunes write batch size from observed sink latency and error rate. | [tuning](https://pawansikawat.github.io/faucet-stream/) |
 | **Secrets-manager interpolation** | `${vault:…}`, `${aws-sm:…}`, `${gcp-sm:…}`, `${azure-kv:…}` resolved at load time, redacted from logs. | [secrets](https://pawansikawat.github.io/faucet-stream/cookbook/secrets.html) |

--- a/cli/README.md
+++ b/cli/README.md
@@ -49,6 +49,7 @@ For each root invocation it probes the source, sink, and state store:
 - **Sources** reuse the real read path — the probe pulls a *single page* (DNS + TLS + auth + the first request + first-record decode) and stops, never paginating the full dataset. A handful of sources whose first page would block or have side effects use a targeted probe instead: `webhook` checks the port is bindable, `websocket` does a TCP connect, `postgres-cdc` checks the replication slot is reachable, `kafka` fetches cluster metadata.
 - **Sinks** run a non-mutating connect/auth/metadata call (e.g. `SELECT 1`, `HeadBucket`, `PING`, `tables.get`, cluster health, `fetch_metadata`) — never a real write. File sinks check the target directory is writable; `stdout` always passes.
 - **State stores** do a sentinel `put`/`get`/`delete` round-trip that leaves no residue.
+- **SLA** (when an [`sla:` block](#sla-optional) is configured) probes the persisted run history read-only: staleness of the last successful run vs `max_staleness_secs`, and volume-baseline warm-up state.
 
 ```bash
 faucet doctor pipeline.yaml                      # checklist, exit code = # of failed probes
@@ -795,6 +796,27 @@ Inspect or publish it with `faucet contract <config> [--export
 contract|json-schema|openlineage]`; `faucet schema contract` prints the
 block's JSON Schema. Full model:
 [Data contracts](https://pawansikawat.github.io/faucet-stream/cookbook/contracts.html).
+
+### `sla:` (optional)
+
+**Top-level** block (sibling of `pipeline:`, like `resilience:`) declaring a
+freshness/volume SLA, evaluated after every root invocation by
+`run`/`schedule`/`serve`/`replicate`. Violations emit
+`faucet_pipeline_sla_violations_total{pipeline,row,kind}` + a WARN log and
+**never fail the run**; `faucet doctor` probes staleness/baseline health
+read-only.
+
+```yaml
+sla:
+  max_staleness_secs: 7200   # stale when no successful run within 2h (needs state:)
+  min_rows_per_run: 1        # a successful run writing fewer records violates
+  volume_anomaly:            # learned baseline over recent successful runs (needs state:)
+    method: zscore           # zscore | iqr
+    min_history: 5           # successful runs before detection starts
+```
+
+`faucet schema sla` prints the block's JSON Schema. Full model:
+[SLA monitoring](https://pawansikawat.github.io/faucet-stream/cookbook/sla.html).
 
 ### Transforms
 

--- a/cli/examples/csv_to_jsonl_with_sla.yaml
+++ b/cli/examples/csv_to_jsonl_with_sla.yaml
@@ -1,0 +1,52 @@
+# CSV → JSONL monitored by a freshness/volume SLA (issue #202).
+#
+# The top-level `sla:` block declares what "healthy" looks like for this
+# pipeline. It is evaluated automatically after every root invocation (by
+# `faucet run`, `schedule`, `serve`, and `replicate`) and NEVER fails the run —
+# a violation emits the `faucet_pipeline_sla_violations_total{kind}` counter
+# and a WARN log, and `faucet doctor` reports staleness/baseline health:
+#
+#   max_staleness_secs — stale when no *successful* run within the window
+#                        (fires on failing runs and in `faucet doctor`)
+#   min_rows_per_run   — a successful run writing fewer records violates
+#                        (catches a source silently returning nothing)
+#   volume_anomaly     — learned baseline over recent successful-run volumes;
+#                        zscore (default) or iqr detection, two-sided
+#
+# Staleness/volume need run history, so a `state:` block is required for them;
+# the history is stored next to the bookmarks under `{name}::{row}::__sla__`.
+#
+#   faucet run cli/examples/csv_to_jsonl_with_sla.yaml
+#   faucet doctor cli/examples/csv_to_jsonl_with_sla.yaml
+#   faucet schema sla
+version: 1
+name: orders_csv_with_sla
+
+pipeline:
+  source:
+    type: csv
+    config:
+      path: ./orders.csv
+
+  sink:
+    type: jsonl
+    config:
+      path: ./orders_out.jsonl
+
+  state:
+    type: file
+    config:
+      path: ./state
+
+sla:
+  # Alert when the pipeline hasn't completed successfully in 24 hours.
+  max_staleness_secs: 86400
+  # A successful run that writes zero records is a silent failure.
+  min_rows_per_run: 1
+  # Flag a run whose volume deviates more than 3σ from the recent baseline,
+  # once 5 successful runs of history exist.
+  volume_anomaly:
+    method: zscore
+    sensitivity: 3.0
+    min_history: 5
+    window: 20

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -384,6 +384,8 @@ pub enum SchemaTarget {
     Execution,
     /// JSON Schema for the top-level `resilience:` block.
     Resilience,
+    /// JSON Schema for the top-level `sla:` (freshness/volume SLA) block.
+    Sla,
     /// JSON Schema for the `quality:` block.
     #[cfg(feature = "quality")]
     Quality,

--- a/cli/src/commands/doctor.rs
+++ b/cli/src/commands/doctor.rs
@@ -84,6 +84,14 @@ pub async fn run(args: DoctorArgs) -> CliResult<()> {
     let ctx = CheckContext {
         timeout: Duration::from_secs(args.timeout_secs),
     };
+    // Same derivation as `faucet run`, so the SLA probes read the same
+    // state keys the executor writes.
+    let pipeline_name = cfg.name.clone().unwrap_or_else(|| {
+        path.file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("pipeline")
+            .to_owned()
+    });
 
     let roots: Vec<&ExpandedNode> = nodes
         .iter()
@@ -91,7 +99,7 @@ pub async fn run(args: DoctorArgs) -> CliResult<()> {
         .collect();
     let n_children = nodes.len() - roots.len();
 
-    let mut invocations = probe_roots(&nodes, &auth, &ctx).await;
+    let mut invocations = probe_roots(&nodes, &auth, &ctx, cfg.sla.as_ref(), &pipeline_name).await;
 
     // Lineage transport reachability — one pipeline-wide probe (the `lineage:`
     // block is top-level, not per-row), rendered as its own invocation entry so
@@ -126,7 +134,10 @@ pub async fn run(args: DoctorArgs) -> CliResult<()> {
     Ok(())
 }
 
-/// Build the three connectors for one invocation and run their probes.
+/// Build the three connectors for one invocation and run their probes. When an
+/// `sla:` block is configured, `sla` carries the spec plus the invocation's
+/// base state key so the persisted SLA history can be probed read-only
+/// (staleness vs `max_staleness_secs`, volume-baseline warm-up).
 pub async fn probe_invocation(
     id: String,
     source: ConnectorSpec,
@@ -134,6 +145,7 @@ pub async fn probe_invocation(
     state: Option<StateStoreSpec>,
     auth: &AuthCatalog,
     ctx: &CheckContext,
+    sla: Option<(crate::sla::SlaSpec, String)>,
 ) -> InvocationOut {
     let mut probes = Vec::new();
 
@@ -151,11 +163,36 @@ pub async fn probe_invocation(
         Err(e) => probes.push(construct_fail("sink", &sink.kind, &e)),
     }
 
+    let mut store = None;
     if let Some(spec) = state {
         match build_state_store(&spec).await {
-            Ok(st) => probes.extend(collect_probes("state", &spec.kind, ctx, st.check(ctx)).await),
+            Ok(st) => {
+                probes.extend(collect_probes("state", &spec.kind, ctx, st.check(ctx)).await);
+                store = Some(st);
+            }
             Err(e) => probes.push(construct_fail("state", &spec.kind, &e)),
         }
+    }
+
+    if let Some((spec, base_key)) = sla {
+        let now = chrono::Utc::now().timestamp();
+        let sla_probes = tokio::time::timeout(
+            ctx.timeout,
+            crate::sla::doctor_probes(&spec, store.as_ref(), &base_key, now),
+        )
+        .await
+        .unwrap_or_else(|_| {
+            vec![Probe::fail(
+                "history",
+                ctx.timeout,
+                "SLA state read timed out",
+            )]
+        });
+        probes.extend(
+            sla_probes
+                .into_iter()
+                .map(|p| ProbeOut::from_probe("sla", "sla".to_string(), p)),
+        );
     }
 
     InvocationOut {
@@ -193,11 +230,15 @@ pub async fn probe_lineage(
 
 /// Probe every *root* invocation's source/sink/state concurrently (bounded).
 /// Child invocations are skipped — their configs need parent records. Reused by
-/// `faucet doctor` and serve's `doctor_first` preflight.
+/// `faucet doctor` and serve's `doctor_first` preflight. `sla` /
+/// `pipeline_name` come from the top-level config; when set, each root also
+/// gets read-only SLA staleness/baseline probes against its state store.
 pub async fn probe_roots(
     nodes: &[ExpandedNode],
     auth: &AuthCatalog,
     ctx: &CheckContext,
+    sla: Option<&crate::sla::SlaSpec>,
+    pipeline_name: &str,
 ) -> Vec<InvocationOut> {
     let sem = Arc::new(Semaphore::new(8));
     let mut handles = Vec::new();
@@ -209,9 +250,15 @@ pub async fn probe_roots(
         let auth = auth.clone();
         let ctx = ctx.clone();
         let sem = sem.clone();
+        let sla = sla.map(|s| {
+            (
+                s.clone(),
+                crate::executor::build_state_key(pipeline_name, &node.id, None),
+            )
+        });
         handles.push(tokio::spawn(async move {
             let _permit = sem.acquire_owned().await.expect("semaphore not closed");
-            probe_invocation(id, source, sink, state, &auth, &ctx).await
+            probe_invocation(id, source, sink, state, &auth, &ctx, sla).await
         }));
     }
     let mut out = Vec::with_capacity(handles.len());

--- a/cli/src/commands/replicate.rs
+++ b/cli/src/commands/replicate.rs
@@ -54,6 +54,7 @@ pub async fn run(args: ReplicateArgs) -> CliResult<()> {
             auth,
             clock: chrono::Utc::now().fixed_offset(),
             resilience,
+            sla: cfg.sla.clone(),
         },
     )
     .await?;

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -101,6 +101,7 @@ pub async fn run(args: RunArgs) -> CliResult<()> {
             // cooperatively cancels in-flight rows on `on_error: stop`.
             cancel: None,
             resilience,
+            sla: cfg.sla.clone(),
             #[cfg(feature = "lineage")]
             lineage,
             #[cfg(feature = "lineage")]

--- a/cli/src/commands/schedule.rs
+++ b/cli/src/commands/schedule.rs
@@ -129,6 +129,7 @@ pub async fn run(args: ScheduleArgs) -> CliResult<()> {
             &compiled,
             &pipeline_name,
             &resilience,
+            &cfg.sla,
             #[cfg(feature = "lineage")]
             &lineage,
             #[cfg(feature = "lineage")]
@@ -146,6 +147,7 @@ pub async fn run(args: ScheduleArgs) -> CliResult<()> {
         cron,
         timezone,
         resilience,
+        cfg.sla.clone(),
         #[cfg(feature = "lineage")]
         lineage,
         #[cfg(feature = "lineage")]
@@ -163,6 +165,7 @@ fn make_opts(
     auth: &AuthCatalog,
     clock: chrono::DateTime<chrono::FixedOffset>,
     resilience: &Option<faucet_core::ResiliencePolicy>,
+    sla: &Option<crate::sla::SlaSpec>,
     #[cfg(feature = "lineage")] lineage: &Option<std::sync::Arc<faucet_lineage::LineageEmitter>>,
     #[cfg(feature = "lineage")] lineage_cfg: &Option<faucet_lineage::LineageConfig>,
 ) -> ExecuteOptions {
@@ -177,6 +180,7 @@ fn make_opts(
         clock,
         cancel: None,
         resilience: resilience.clone(),
+        sla: sla.clone(),
         #[cfg(feature = "lineage")]
         lineage: lineage.clone(),
         #[cfg(feature = "lineage")]
@@ -287,6 +291,7 @@ async fn run_once(
     compiled: &CompiledSchedule,
     pipeline_name: &str,
     resilience: &Option<faucet_core::ResiliencePolicy>,
+    sla: &Option<crate::sla::SlaSpec>,
     #[cfg(feature = "lineage")] lineage: &Option<std::sync::Arc<faucet_lineage::LineageEmitter>>,
     #[cfg(feature = "lineage")] lineage_cfg: &Option<faucet_lineage::LineageConfig>,
 ) -> CliResult<()> {
@@ -298,6 +303,7 @@ async fn run_once(
         auth,
         compiled.clock_at(now),
         resilience,
+        sla,
         #[cfg(feature = "lineage")]
         lineage,
         #[cfg(feature = "lineage")]
@@ -333,6 +339,7 @@ async fn run_loop(
     cron: String,
     timezone: String,
     resilience: Option<faucet_core::ResiliencePolicy>,
+    sla: Option<crate::sla::SlaSpec>,
     #[cfg(feature = "lineage")] lineage: Option<std::sync::Arc<faucet_lineage::LineageEmitter>>,
     #[cfg(feature = "lineage")] lineage_cfg: Option<faucet_lineage::LineageConfig>,
 ) -> CliResult<()> {
@@ -402,6 +409,7 @@ async fn run_loop(
                         &auth,
                         compiled.clock_at(next_due),
                         &resilience,
+                        &sla,
                         #[cfg(feature = "lineage")]
                         &lineage,
                         #[cfg(feature = "lineage")]
@@ -537,6 +545,7 @@ async fn run_loop(
                                 &auth,
                                 compiled.clock_at(sched_for),
                                 &resilience,
+                                &sla,
                                 #[cfg(feature = "lineage")]
                                 &lineage,
                                 #[cfg(feature = "lineage")]
@@ -755,6 +764,7 @@ mod tests {
             &auth,
             Utc::now().fixed_offset(),
             &None,
+            &None,
             #[cfg(feature = "lineage")]
             &None,
             #[cfg(feature = "lineage")]
@@ -786,6 +796,7 @@ mod tests {
             &None,
             &auth,
             clock,
+            &None,
             &None,
             #[cfg(feature = "lineage")]
             &None,

--- a/cli/src/commands/schema.rs
+++ b/cli/src/commands/schema.rs
@@ -28,6 +28,10 @@ pub async fn run(args: SchemaArgs) -> CliResult<()> {
             let s = faucet_core::schema_for!(crate::config::ResilienceSpec);
             serde_json::to_value(s).unwrap_or_else(|_| serde_json::json!({"type": "object"}))
         }
+        SchemaTarget::Sla => {
+            let s = faucet_core::schema_for!(crate::sla::SlaSpec);
+            serde_json::to_value(s).unwrap_or_else(|_| serde_json::json!({"type": "object"}))
+        }
         #[cfg(feature = "quality")]
         SchemaTarget::Quality => {
             let quality_schema = faucet_core::schema_for!(faucet_core::QualitySpec);
@@ -121,6 +125,24 @@ mod tests {
         let schema = faucet_core::schema_for!(crate::config::ExecutionSpec);
         let value = serde_json::to_value(schema).expect("execution schema serializes");
         assert!(value["properties"].get("adaptive_batch_size").is_some());
+    }
+
+    #[tokio::test]
+    async fn schema_sla_target_ok() {
+        let r = super::run(SchemaArgs {
+            target: SchemaTarget::Sla,
+        })
+        .await;
+        assert!(r.is_ok(), "{r:?}");
+    }
+
+    #[test]
+    fn sla_schema_exposes_the_three_checks() {
+        let schema = faucet_core::schema_for!(crate::sla::SlaSpec);
+        let out = serde_json::to_string(&schema).expect("sla schema serializes");
+        assert!(out.contains("max_staleness_secs"), "{out}");
+        assert!(out.contains("min_rows_per_run"), "{out}");
+        assert!(out.contains("volume_anomaly"), "{out}");
     }
 
     #[tokio::test]

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -89,6 +89,14 @@ pub struct PipelineConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resilience: Option<ResilienceSpec>,
 
+    /// Optional data-freshness & volume SLA (#202). Top-level in v1 (not
+    /// per-matrix-row, like `resilience:`). Evaluated after every root
+    /// invocation by `faucet run`/`schedule`/`serve`/`replicate`; violations
+    /// emit metrics + warnings and never fail the run. Staleness/volume checks
+    /// require a `state:` block (enforced at expand time).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sla: Option<crate::sla::SlaSpec>,
+
     /// Optional source-shard distribution for clustered (Mode B) execution.
     /// Only consumed by `faucet serve --cluster`: a run whose source
     /// [is shardable](faucet_core::Source::is_shardable) is split into

--- a/cli/src/env_config.rs
+++ b/cli/src/env_config.rs
@@ -326,6 +326,8 @@ pub fn build_pipeline_config(env: &HashMap<String, String>) -> CliResult<Pipelin
         observability: None,
         delivery: faucet_core::DeliveryMode::default(),
         resilience: None,
+        // Pure-env mode doesn't (yet) assemble an `sla:` block.
+        sla: None,
         shard: None,
         replication: None,
         #[cfg(feature = "schedule")]

--- a/cli/src/executor.rs
+++ b/cli/src/executor.rs
@@ -81,6 +81,11 @@ pub struct ExecuteOptions {
     /// rest/xml/graphql sources. Built once from the top-level `resilience:`
     /// block; `None` preserves today's behaviour.
     pub resilience: Option<faucet_core::ResiliencePolicy>,
+    /// Optional freshness/volume SLA (#202), evaluated after every **root**
+    /// invocation against history persisted in the node's state store.
+    /// Violations emit metrics + warnings; they never fail the run. `None`
+    /// disables the pass entirely.
+    pub sla: Option<crate::sla::SlaSpec>,
     /// Shared OpenLineage emitter, built once from the `lineage:` block. `None`
     /// disables lineage (and adds zero overhead). Gated on the `lineage` feature.
     #[cfg(feature = "lineage")]
@@ -840,6 +845,9 @@ async fn run_one_invocation(
     //    executor's per-row state key is used instead of the source's natural
     //    one (which is shared across all matrix rows of the same kind).
     let state = build_state_for_node(node, opts.state_path_override.as_deref()).await?;
+    // Keep a handle for the post-run SLA pass (#202) — `state` itself is moved
+    // into the pipeline below.
+    let sla_store = state.clone();
     // Per-shard bookmark: suffix the state key with the shard id so a reassigned
     // shard resumes where its dead owner left off, independent of sibling shards.
     let effective_state_key = match &opts.shard {
@@ -891,13 +899,11 @@ async fn run_one_invocation(
         pipeline
     };
     // Cooperative cancellation: a cancelled token makes the streaming loop stop
-    // at the next page boundary and flush the sink (#146 H16). Under lineage we
-    // hand the pipeline a clone so the terminal-event classification below can
-    // still read `cancel.is_cancelled()` (cheap — the token is an `Arc`).
-    #[cfg(feature = "lineage")]
+    // at the next page boundary and flush the sink (#146 H16). The pipeline
+    // takes a clone so the lineage terminal-event classification and the SLA
+    // pass below can still read `cancel.is_cancelled()` (cheap — the token is
+    // an `Arc`).
     let pipeline = pipeline.with_cancel(cancel.clone());
-    #[cfg(not(feature = "lineage"))]
-    let pipeline = pipeline.with_cancel(cancel);
     // Pipeline-level quality checks (v1: no matrix-row override). `expand`
     // already validated this spec, but compile again here to obtain the
     // runtime `CompiledQuality`; map any error to a config-level failure.
@@ -1074,6 +1080,38 @@ async fn run_one_invocation(
             Ok(_) => faucet_lineage::EventType::Complete,
         };
         em.emit(ev, &ctx).await;
+    }
+
+    // ── SLA post-run evaluation (#202) ───────────────────────────────────────
+    // Roots only: children fan out per parent record, so their volumes are not
+    // a stable series to baseline (same scoping as `faucet doctor`). Skipped
+    // for dry-run / --limit (synthetic volumes would poison the baseline), for
+    // shard executions (a shard's volume is a fraction of the row's, and shard
+    // counts change run to run), and for cancelled runs (a partial volume is
+    // not a signal). Monitoring never fails the run — see `evaluate_post_run`.
+    if let Some(spec) = &opts.sla
+        && matches!(node.role, NodeRole::Root)
+        && !opts.dry_run
+        && opts.limit.is_none()
+        && opts.shard.is_none()
+        && !cancel.is_cancelled()
+    {
+        let outcome = match &result {
+            Ok(r) => crate::sla::RunOutcome::Success {
+                rows: r.records_written as u64,
+            },
+            Err(_) => crate::sla::RunOutcome::Failure,
+        };
+        crate::sla::evaluate_post_run(
+            spec,
+            sla_store.as_ref(),
+            state_key,
+            &obs_labels.pipeline,
+            &obs_labels.row,
+            outcome,
+            chrono::Utc::now().timestamp(),
+        )
+        .await;
     }
 
     let result = result?;
@@ -1368,6 +1406,7 @@ mod tests {
             observability: None,
             delivery: faucet_core::DeliveryMode::default(),
             resilience: None,
+            sla: None,
             shard: None,
             replication: None,
             #[cfg(feature = "schedule")]
@@ -1398,6 +1437,7 @@ mod tests {
                 clock: chrono::Utc::now().fixed_offset(),
                 cancel: None,
                 resilience: None,
+                sla: None,
                 #[cfg(feature = "lineage")]
                 lineage: None,
                 #[cfg(feature = "lineage")]
@@ -1455,6 +1495,7 @@ matrix:
                 clock: chrono::Utc::now().fixed_offset(),
                 cancel: None,
                 resilience: None,
+                sla: None,
                 #[cfg(feature = "lineage")]
                 lineage: None,
                 #[cfg(feature = "lineage")]
@@ -1512,6 +1553,7 @@ matrix:
                 clock: chrono::Utc::now().fixed_offset(),
                 cancel: None,
                 resilience: None,
+                sla: None,
                 #[cfg(feature = "lineage")]
                 lineage: None,
                 #[cfg(feature = "lineage")]
@@ -1579,6 +1621,7 @@ execution:
                 clock: chrono::Utc::now().fixed_offset(),
                 cancel: None,
                 resilience: None,
+                sla: None,
                 #[cfg(feature = "lineage")]
                 lineage: None,
                 #[cfg(feature = "lineage")]
@@ -1661,6 +1704,7 @@ pipeline:
                 clock: chrono::Utc::now().fixed_offset(),
                 cancel: None,
                 resilience: None,
+                sla: None,
                 #[cfg(feature = "lineage")]
                 lineage: None,
                 #[cfg(feature = "lineage")]
@@ -1717,6 +1761,7 @@ matrix:
                 clock: chrono::Utc::now().fixed_offset(),
                 cancel: None,
                 resilience: None,
+                sla: None,
                 #[cfg(feature = "lineage")]
                 lineage: None,
                 #[cfg(feature = "lineage")]
@@ -1782,6 +1827,7 @@ execution:
                 clock: chrono::Utc::now().fixed_offset(),
                 cancel: None,
                 resilience: None,
+                sla: None,
                 #[cfg(feature = "lineage")]
                 lineage: None,
                 #[cfg(feature = "lineage")]
@@ -1848,6 +1894,7 @@ matrix:
                 clock: chrono::Utc::now().fixed_offset(),
                 cancel: None,
                 resilience: None,
+                sla: None,
                 #[cfg(feature = "lineage")]
                 lineage: None,
                 #[cfg(feature = "lineage")]
@@ -2073,6 +2120,7 @@ matrix:
             clock: chrono::Utc::now().fixed_offset(),
             cancel: None,
             resilience: None,
+            sla: None,
             #[cfg(feature = "lineage")]
             lineage: None,
             #[cfg(feature = "lineage")]
@@ -2476,6 +2524,7 @@ matrix:
                 clock: chrono::Utc::now().fixed_offset(),
                 cancel: None,
                 resilience: None,
+                sla: None,
                 #[cfg(feature = "lineage")]
                 lineage: None,
                 #[cfg(feature = "lineage")]

--- a/cli/src/expand.rs
+++ b/cli/src/expand.rs
@@ -513,6 +513,36 @@ pub fn expand(cfg: &PipelineConfig) -> CliResult<Vec<ExpandedNode>> {
             )));
         }
 
+        // SLA gate (load-time, #202): validate the spec once per row and
+        // require a `state:` block when staleness / volume-anomaly checks need
+        // persisted history. `min_rows_per_run` alone is stateless and passes
+        // without one.
+        if let Some(ref sla) = cfg.sla {
+            sla.validate()
+                .map_err(|e| CliError::Config(format!("sla: {e}")))?;
+            if sla.needs_state() {
+                match state.as_ref() {
+                    None => {
+                        return Err(CliError::Config(format!(
+                            "row '{row_id}': sla.max_staleness_secs / sla.volume_anomaly \
+                             need persisted run history — add a `state:` block \
+                             (min_rows_per_run alone works without one)"
+                        )));
+                    }
+                    Some(s) if s.kind == "memory" => {
+                        tracing::warn!(
+                            row = %row_id,
+                            "sla: the `memory` state store resets on process exit — \
+                             staleness/volume baselines only persist within a single \
+                             `faucet schedule`/`serve` process; use `file`, `redis`, \
+                             or `postgres` for one-shot runs"
+                        );
+                    }
+                    Some(_) => {}
+                }
+            }
+        }
+
         // write_mode × sink validation (load-time): reject an unsupported mode
         // for the sink kind, and upsert/delete without a key, before any run.
         // Runs for every row; append rows pass trivially.

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -35,6 +35,7 @@ pub mod schedule;
 pub mod secrets;
 #[cfg(feature = "serve")]
 pub mod serve;
+pub mod sla;
 pub mod state;
 pub mod transforms;
 
@@ -95,6 +96,7 @@ pub async fn run_from_yaml_str(yaml: &str) -> CliResult<executor::RunSummary> {
             clock: chrono::Utc::now().fixed_offset(),
             cancel: None,
             resilience,
+            sla: cfg.sla.clone(),
             #[cfg(feature = "lineage")]
             lineage: None,
             #[cfg(feature = "lineage")]

--- a/cli/src/replication/orchestrator.rs
+++ b/cli/src/replication/orchestrator.rs
@@ -25,6 +25,8 @@ pub struct ReplicationOptions {
     pub clock: DateTime<FixedOffset>,
     /// Optional resilience policy, applied to both the snapshot and CDC phases.
     pub resilience: Option<faucet_core::ResiliencePolicy>,
+    /// Optional freshness/volume SLA (#202), evaluated after each phase's runs.
+    pub sla: Option<crate::sla::SlaSpec>,
 }
 
 /// Build the snapshot-phase node by cloning the CDC node and swapping in the
@@ -77,6 +79,7 @@ fn make_opts(opts: &ReplicationOptions, cancel: Option<CancellationToken>) -> Ex
         clock: opts.clock,
         cancel,
         resilience: opts.resilience.clone(),
+        sla: opts.sla.clone(),
         #[cfg(feature = "lineage")]
         lineage: None,
         #[cfg(feature = "lineage")]

--- a/cli/src/serve/runner.rs
+++ b/cli/src/serve/runner.rs
@@ -425,6 +425,9 @@ async fn execute_shard(
         clock,
         cancel: Some(coop.clone()),
         resilience,
+        // Inert under `shard: Some(..)` (a shard's volume is not the row's) —
+        // carried for uniformity with the whole-run path below.
+        sla: cfg.sla.clone(),
         #[cfg(feature = "lineage")]
         lineage,
         #[cfg(feature = "lineage")]
@@ -766,7 +769,21 @@ pub(crate) async fn run_doctor_first(
     let ctx = CheckContext {
         timeout: state.probe_timeout(),
     };
-    let mut invs = crate::commands::doctor::probe_roots(&loaded.nodes, &auth, &ctx).await;
+    // Same pipeline-name derivation as the run path above, so SLA probes read
+    // the state keys the executor writes.
+    let pipeline_name = loaded
+        .cfg
+        .name
+        .clone()
+        .unwrap_or_else(|| "serve".to_string());
+    let mut invs = crate::commands::doctor::probe_roots(
+        &loaded.nodes,
+        &auth,
+        &ctx,
+        loaded.cfg.sla.as_ref(),
+        &pipeline_name,
+    )
+    .await;
     let failed = crate::commands::doctor::count_failures(&invs);
     // Redact regardless of outcome — the report is surfaced either way (as the
     // 422 `details` on failure, or stored on the run record on success).
@@ -1123,6 +1140,7 @@ async fn execute_run(
         clock,
         cancel: Some(coop.clone()),
         resilience,
+        sla: cfg.sla.clone(),
         #[cfg(feature = "lineage")]
         lineage,
         #[cfg(feature = "lineage")]

--- a/cli/src/sla/eval.rs
+++ b/cli/src/sla/eval.rs
@@ -1,0 +1,309 @@
+//! Pure SLA evaluation: staleness, static volume floor, and learned-baseline
+//! volume anomaly detection (z-score / Tukey IQR fences). No I/O — the
+//! orchestration in `sla::evaluate_post_run` owns state loading/persisting.
+
+use super::spec::{AnomalyMethod, SlaSpec, VolumeAnomalySpec};
+use super::state::SlaState;
+use std::fmt;
+
+/// One detected SLA violation.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SlaViolation {
+    /// No successful run within `max_staleness_secs`.
+    Staleness { since_secs: u64, max_secs: u64 },
+    /// A successful run wrote fewer records than `min_rows_per_run`.
+    MinRows { rows: u64, min: u64 },
+    /// A successful run's volume is anomalous against the rolling baseline.
+    Volume { rows: u64, detail: String },
+}
+
+impl SlaViolation {
+    /// Stable metric-label value (`kind` on
+    /// `faucet_pipeline_sla_violations_total`).
+    pub fn kind(&self) -> &'static str {
+        match self {
+            SlaViolation::Staleness { .. } => "staleness",
+            SlaViolation::MinRows { .. } => "min_rows",
+            SlaViolation::Volume { .. } => "volume",
+        }
+    }
+}
+
+impl fmt::Display for SlaViolation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SlaViolation::Staleness {
+                since_secs,
+                max_secs,
+            } => write!(
+                f,
+                "pipeline is stale: last success {since_secs}s ago exceeds max_staleness_secs {max_secs}"
+            ),
+            SlaViolation::MinRows { rows, min } => write!(
+                f,
+                "run wrote {rows} record(s), below min_rows_per_run {min}"
+            ),
+            SlaViolation::Volume { rows, detail } => {
+                write!(f, "run volume {rows} is anomalous: {detail}")
+            }
+        }
+    }
+}
+
+/// Checks that apply to a **successful** run: the static floor and the
+/// learned-baseline anomaly, both against the *prior* baseline (before this
+/// run's volume is folded in).
+pub fn evaluate_success(spec: &SlaSpec, prior: &SlaState, rows: u64) -> Vec<SlaViolation> {
+    let mut out = Vec::new();
+    if let Some(min) = spec.min_rows_per_run
+        && rows < min
+    {
+        out.push(SlaViolation::MinRows { rows, min });
+    }
+    if let Some(va) = &spec.volume_anomaly
+        && prior.volumes.len() >= va.min_history as usize
+        && let Some(detail) = detect_anomaly(&prior.volumes, rows, va)
+    {
+        out.push(SlaViolation::Volume { rows, detail });
+    }
+    out
+}
+
+/// Checks that apply to a **failed** run: staleness of the last success. A
+/// pipeline with no recorded success yet cannot be measured (cold start).
+pub fn evaluate_failure(spec: &SlaSpec, prior: &SlaState, now_unix: i64) -> Vec<SlaViolation> {
+    match (spec.max_staleness_secs, prior.last_success_unix) {
+        (Some(max_secs), Some(last)) => {
+            let since_secs = now_unix.saturating_sub(last).max(0) as u64;
+            if since_secs > max_secs {
+                vec![SlaViolation::Staleness {
+                    since_secs,
+                    max_secs,
+                }]
+            } else {
+                Vec::new()
+            }
+        }
+        _ => Vec::new(),
+    }
+}
+
+/// Run the configured detector; `Some(detail)` when `rows` is anomalous
+/// against `baseline`. Callers guarantee `baseline.len() >= min_history >= 2`.
+pub fn detect_anomaly(baseline: &[u64], rows: u64, va: &VolumeAnomalySpec) -> Option<String> {
+    let sensitivity = va.effective_sensitivity();
+    match va.method {
+        AnomalyMethod::Zscore => zscore_anomaly(baseline, rows, sensitivity),
+        AnomalyMethod::Iqr => iqr_anomaly(baseline, rows, sensitivity),
+    }
+}
+
+fn zscore_anomaly(baseline: &[u64], rows: u64, sensitivity: f64) -> Option<String> {
+    let n = baseline.len() as f64;
+    let mean = baseline.iter().map(|&v| v as f64).sum::<f64>() / n;
+    let var = baseline
+        .iter()
+        .map(|&v| {
+            let d = v as f64 - mean;
+            d * d
+        })
+        .sum::<f64>()
+        / n;
+    let std = var.sqrt();
+    let x = rows as f64;
+    if std == 0.0 {
+        // Constant baseline: any deviation is a regime change.
+        if x != mean {
+            return Some(format!(
+                "deviates from a constant baseline of {mean:.0} records/run"
+            ));
+        }
+        return None;
+    }
+    let z = (x - mean).abs() / std;
+    if z > sensitivity {
+        return Some(format!(
+            "|z| {z:.2} exceeds {sensitivity} (baseline mean {mean:.1}, std {std:.1}, n {})",
+            baseline.len()
+        ));
+    }
+    None
+}
+
+fn iqr_anomaly(baseline: &[u64], rows: u64, sensitivity: f64) -> Option<String> {
+    let mut sorted = baseline.to_vec();
+    sorted.sort_unstable();
+    let q1 = quantile(&sorted, 0.25);
+    let q3 = quantile(&sorted, 0.75);
+    let iqr = q3 - q1;
+    let lower = q1 - sensitivity * iqr;
+    let upper = q3 + sensitivity * iqr;
+    let x = rows as f64;
+    if x < lower || x > upper {
+        return Some(format!(
+            "outside [{lower:.1}, {upper:.1}] (q1 {q1:.1}, q3 {q3:.1}, fence {sensitivity}×IQR, n {})",
+            baseline.len()
+        ));
+    }
+    None
+}
+
+/// Linear-interpolation quantile (R type-7) over an ascending slice.
+/// Callers guarantee `sorted` is non-empty.
+fn quantile(sorted: &[u64], q: f64) -> f64 {
+    let n = sorted.len();
+    if n == 1 {
+        return sorted[0] as f64;
+    }
+    let pos = q * (n - 1) as f64;
+    let lo = pos.floor() as usize;
+    let hi = pos.ceil() as usize;
+    let frac = pos - lo as f64;
+    sorted[lo] as f64 + (sorted[hi] as f64 - sorted[lo] as f64) * frac
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::spec::{DEFAULT_MIN_HISTORY, DEFAULT_WINDOW};
+    use super::*;
+
+    fn spec(
+        staleness: Option<u64>,
+        min_rows: Option<u64>,
+        va: Option<VolumeAnomalySpec>,
+    ) -> SlaSpec {
+        SlaSpec {
+            max_staleness_secs: staleness,
+            min_rows_per_run: min_rows,
+            volume_anomaly: va,
+        }
+    }
+
+    fn va(method: AnomalyMethod, sensitivity: Option<f64>) -> VolumeAnomalySpec {
+        VolumeAnomalySpec {
+            method,
+            sensitivity,
+            min_history: DEFAULT_MIN_HISTORY,
+            window: DEFAULT_WINDOW,
+        }
+    }
+
+    fn state_with(volumes: &[u64], last_success: Option<i64>) -> SlaState {
+        SlaState {
+            last_success_unix: last_success,
+            volumes: volumes.to_vec(),
+        }
+    }
+
+    #[test]
+    fn min_rows_fires_below_floor_only() {
+        let s = spec(None, Some(10), None);
+        let prior = SlaState::default();
+        let v = evaluate_success(&s, &prior, 3);
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].kind(), "min_rows");
+        assert!(v[0].to_string().contains("below min_rows_per_run 10"));
+        assert!(evaluate_success(&s, &prior, 10).is_empty());
+    }
+
+    #[test]
+    fn volume_anomaly_waits_for_min_history() {
+        let s = spec(None, None, Some(va(AnomalyMethod::Zscore, None)));
+        // 4 samples < min_history 5 → no evaluation even for a wild outlier.
+        let prior = state_with(&[100, 100, 100, 100], None);
+        assert!(evaluate_success(&s, &prior, 0).is_empty());
+        // 5 samples → the same outlier fires.
+        let prior = state_with(&[100, 100, 100, 100, 100], None);
+        let v = evaluate_success(&s, &prior, 0);
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].kind(), "volume");
+    }
+
+    #[test]
+    fn zscore_flags_injected_drop_and_passes_normal() {
+        let baseline = [100, 105, 95, 102, 98, 101, 99, 103];
+        let cfg = va(AnomalyMethod::Zscore, None);
+        assert!(detect_anomaly(&baseline, 0, &cfg).is_some(), "drop to zero");
+        assert!(detect_anomaly(&baseline, 500, &cfg).is_some(), "spike");
+        assert!(detect_anomaly(&baseline, 101, &cfg).is_none(), "normal");
+    }
+
+    #[test]
+    fn zscore_constant_baseline_flags_any_deviation() {
+        let baseline = [50, 50, 50, 50, 50];
+        let cfg = va(AnomalyMethod::Zscore, None);
+        let detail = detect_anomaly(&baseline, 49, &cfg).expect("deviation from constant");
+        assert!(detail.contains("constant baseline"), "{detail}");
+        assert!(detect_anomaly(&baseline, 50, &cfg).is_none());
+    }
+
+    #[test]
+    fn zscore_sensitivity_widens_the_pass_band() {
+        let baseline = [100, 110, 90, 105, 95];
+        // 120 is ~2.7σ here: anomalous at sensitivity 1, normal at 3 (default).
+        assert!(detect_anomaly(&baseline, 120, &va(AnomalyMethod::Zscore, Some(1.0))).is_some());
+        assert!(detect_anomaly(&baseline, 120, &va(AnomalyMethod::Zscore, None)).is_none());
+    }
+
+    #[test]
+    fn iqr_flags_outliers_outside_fences() {
+        let baseline = [100, 102, 98, 101, 99, 103, 97, 100];
+        let cfg = va(AnomalyMethod::Iqr, None);
+        assert!(detect_anomaly(&baseline, 0, &cfg).is_some(), "drop");
+        assert!(detect_anomaly(&baseline, 1000, &cfg).is_some(), "spike");
+        assert!(detect_anomaly(&baseline, 100, &cfg).is_none(), "median");
+    }
+
+    #[test]
+    fn iqr_zero_spread_flags_any_outside_value() {
+        let baseline = [70, 70, 70, 70, 70];
+        let cfg = va(AnomalyMethod::Iqr, None);
+        assert!(detect_anomaly(&baseline, 71, &cfg).is_some());
+        assert!(detect_anomaly(&baseline, 70, &cfg).is_none());
+    }
+
+    #[test]
+    fn quantile_interpolates() {
+        let sorted = [10, 20, 30, 40];
+        assert_eq!(quantile(&sorted, 0.0), 10.0);
+        assert_eq!(quantile(&sorted, 1.0), 40.0);
+        assert_eq!(quantile(&sorted, 0.5), 25.0);
+        assert_eq!(quantile(&sorted, 0.25), 17.5);
+        assert_eq!(quantile(&[42], 0.75), 42.0);
+    }
+
+    #[test]
+    fn staleness_fires_only_past_threshold_with_history() {
+        let s = spec(Some(3600), None, None);
+        // Fresh enough.
+        let prior = state_with(&[], Some(10_000));
+        assert!(evaluate_failure(&s, &prior, 10_000 + 3600).is_empty());
+        // Stale.
+        let v = evaluate_failure(&s, &prior, 10_000 + 3601);
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].kind(), "staleness");
+        assert!(v[0].to_string().contains("3601s ago"));
+        // No success ever recorded → unmeasurable, no violation.
+        assert!(evaluate_failure(&s, &SlaState::default(), 999_999).is_empty());
+        // No staleness configured → nothing.
+        let s = spec(None, Some(1), None);
+        assert!(evaluate_failure(&s, &prior, 999_999).is_empty());
+    }
+
+    #[test]
+    fn staleness_tolerates_clock_skew() {
+        // A last-success timestamp in the future must not underflow or fire.
+        let s = spec(Some(60), None, None);
+        let prior = state_with(&[], Some(2_000));
+        assert!(evaluate_failure(&s, &prior, 1_000).is_empty());
+    }
+
+    #[test]
+    fn success_checks_combine() {
+        let s = spec(Some(3600), Some(50), Some(va(AnomalyMethod::Zscore, None)));
+        let prior = state_with(&[100, 101, 99, 100, 100], Some(0));
+        let v = evaluate_success(&s, &prior, 10);
+        let kinds: Vec<_> = v.iter().map(|x| x.kind()).collect();
+        assert_eq!(kinds, vec!["min_rows", "volume"]);
+    }
+}

--- a/cli/src/sla/metrics.rs
+++ b/cli/src/sla/metrics.rs
@@ -1,0 +1,65 @@
+//! Prometheus surface for SLA monitoring (#202).
+//!
+//! - `faucet_pipeline_sla_violations_total{pipeline,row,kind}` — counter;
+//!   `kind` ∈ `staleness` | `min_rows` | `volume`.
+//! - `faucet_pipeline_sla_baseline_runs{pipeline,row}` — gauge; successful
+//!   runs currently in the rolling volume baseline (cold-start visibility).
+//!
+//! Emission follows the CLI-side convention (`faucet_schedule_*`,
+//! `faucet_serve_*`): plain `metrics` macros against whatever recorder
+//! `install_observability` installed. Labels stay low-cardinality (`pipeline`
+//! + `row` only, like every pipeline metric — never record keys or run ids).
+
+use metrics::{counter, describe_counter, describe_gauge, gauge};
+use std::sync::Once;
+
+static DESCRIBE: Once = Once::new();
+
+fn describe() {
+    DESCRIBE.call_once(|| {
+        describe_counter!(
+            "faucet_pipeline_sla_violations_total",
+            "SLA violations detected post-run, by kind (staleness | min_rows | volume)"
+        );
+        describe_gauge!(
+            "faucet_pipeline_sla_baseline_runs",
+            "Successful runs currently in the rolling SLA volume baseline"
+        );
+    });
+}
+
+/// Count one detected violation.
+pub fn record_violation(pipeline: &str, row: &str, kind: &'static str) {
+    describe();
+    counter!(
+        "faucet_pipeline_sla_violations_total",
+        "pipeline" => pipeline.to_owned(),
+        "row" => row.to_owned(),
+        "kind" => kind,
+    )
+    .increment(1);
+}
+
+/// Publish the baseline depth after a successful run folds in.
+pub fn set_baseline_runs(pipeline: &str, row: &str, n: usize) {
+    describe();
+    gauge!(
+        "faucet_pipeline_sla_baseline_runs",
+        "pipeline" => pipeline.to_owned(),
+        "row" => row.to_owned(),
+    )
+    .set(n as f64);
+}
+
+#[cfg(test)]
+mod tests {
+    // The emit helpers are exercised end-to-end by the executor integration
+    // tests; here we only pin that they are callable without an installed
+    // recorder (the `metrics` macros no-op) — a panic here would take down
+    // every pipeline run in a build without observability installed.
+    #[test]
+    fn emitting_without_recorder_is_a_noop() {
+        super::record_violation("p", "r", "staleness");
+        super::set_baseline_runs("p", "r", 3);
+    }
+}

--- a/cli/src/sla/mod.rs
+++ b/cli/src/sla/mod.rs
@@ -1,0 +1,368 @@
+//! Data-freshness & volume SLA monitoring (#202).
+//!
+//! The top-level `sla:` block declares freshness/volume expectations for a
+//! pipeline; the executor evaluates them after every **root** invocation
+//! (`faucet run`, `schedule`, `serve`, and `replicate` all flow through
+//! [`crate::executor::run_expanded`], so every runtime gets the same
+//! evaluation). Violations emit
+//! `faucet_pipeline_sla_violations_total{pipeline,row,kind}` and a structured
+//! warning — they never fail or abort the run. `faucet doctor` additionally
+//! reports staleness / baseline health read-only.
+//!
+//! Module layout (mirrors `schedule/` / `replication/`):
+//! - [`spec`] — serde config types + validation (`faucet schema sla`).
+//! - [`state`] — the persisted history (`{state_key}::__sla__`).
+//! - [`eval`] — pure staleness / floor / anomaly math.
+//! - [`metrics`] — the Prometheus surface.
+
+pub mod eval;
+pub mod metrics;
+pub mod spec;
+pub mod state;
+
+pub use eval::SlaViolation;
+pub use spec::{AnomalyMethod, SlaSpec, VolumeAnomalySpec};
+pub use state::{SLA_STATE_SUFFIX, SlaState, sla_state_key};
+
+use faucet_core::StateStore;
+use faucet_core::check::Probe;
+use std::sync::Arc;
+use std::time::Instant;
+
+/// How the run being evaluated ended.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RunOutcome {
+    /// The pipeline (and final flush) succeeded, writing `rows` records.
+    Success { rows: u64 },
+    /// The pipeline failed; staleness is measured against the prior success.
+    Failure,
+}
+
+/// Post-run SLA evaluation for one root invocation: load prior history,
+/// evaluate, persist the updated baseline on success, and emit
+/// metrics/warnings for every violation. Returns the violations found.
+///
+/// This is monitoring — it must never take down the run it observes. State
+/// I/O errors are logged and swallowed; a failed *read* also skips the
+/// baseline update so a transient state-store outage cannot clobber the
+/// accumulated history with a fresh one.
+pub async fn evaluate_post_run(
+    spec: &SlaSpec,
+    store: Option<&Arc<dyn StateStore>>,
+    base_state_key: &str,
+    pipeline: &str,
+    row: &str,
+    outcome: RunOutcome,
+    now_unix: i64,
+) -> Vec<SlaViolation> {
+    let key = sla_state_key(base_state_key);
+    let (mut history, store) = match store {
+        // No state store: only the stateless floor check can run (the expand
+        // gate guarantees staleness/volume checks come with a `state:` block;
+        // this is the defensive path).
+        None => (SlaState::default(), None),
+        Some(s) => match s.get(&key).await {
+            Ok(v) => (v.map(SlaState::from_value).unwrap_or_default(), Some(s)),
+            Err(e) => {
+                tracing::warn!(
+                    pipeline,
+                    row,
+                    key,
+                    error = %e,
+                    "reading SLA state failed — skipping SLA evaluation for this run"
+                );
+                return Vec::new();
+            }
+        },
+    };
+
+    let violations = match outcome {
+        RunOutcome::Success { rows } => {
+            let violations = eval::evaluate_success(spec, &history, rows);
+            if let Some(s) = store {
+                history.record_success(rows, now_unix, spec.window());
+                if let Err(e) = s.put(&key, &history.to_value()).await {
+                    tracing::warn!(
+                        pipeline,
+                        row,
+                        key,
+                        error = %e,
+                        "persisting SLA state failed — baseline not updated"
+                    );
+                } else {
+                    metrics::set_baseline_runs(pipeline, row, history.volumes.len());
+                }
+            }
+            violations
+        }
+        RunOutcome::Failure => eval::evaluate_failure(spec, &history, now_unix),
+    };
+
+    for v in &violations {
+        metrics::record_violation(pipeline, row, v.kind());
+        tracing::warn!(pipeline, row, kind = v.kind(), "SLA violation: {v}");
+    }
+    violations
+}
+
+/// Read-only SLA probes for `faucet doctor` (and serve's `doctor_first`):
+/// staleness of the last recorded success and volume-baseline warm-up state.
+/// `min_rows_per_run` has nothing to probe without a run, so it is not
+/// represented here.
+pub async fn doctor_probes(
+    spec: &SlaSpec,
+    store: Option<&Arc<dyn StateStore>>,
+    base_state_key: &str,
+    now_unix: i64,
+) -> Vec<Probe> {
+    let start = Instant::now();
+    let history = match store {
+        None => {
+            // Only reachable when every configured check is stateless.
+            return if spec.needs_state() {
+                vec![Probe::skip("history", "no state store configured")]
+            } else {
+                Vec::new()
+            };
+        }
+        Some(s) => match s.get(&sla_state_key(base_state_key)).await {
+            Ok(v) => v.map(SlaState::from_value).unwrap_or_default(),
+            Err(e) => {
+                return vec![Probe::fail(
+                    "history",
+                    start.elapsed(),
+                    format!("reading SLA state: {e}"),
+                )];
+            }
+        },
+    };
+
+    let mut probes = Vec::new();
+    if let Some(max_secs) = spec.max_staleness_secs {
+        probes.push(match history.last_success_unix {
+            None => Probe::skip("staleness", "no successful run recorded yet"),
+            Some(last) => {
+                let since = now_unix.saturating_sub(last).max(0) as u64;
+                if since > max_secs {
+                    Probe::fail_hint(
+                        "staleness",
+                        start.elapsed(),
+                        format!("last success {since}s ago exceeds max_staleness_secs {max_secs}"),
+                        "check the pipeline's schedule and recent run failures",
+                    )
+                } else {
+                    Probe::pass("staleness", start.elapsed())
+                }
+            }
+        });
+    }
+    if let Some(va) = &spec.volume_anomaly {
+        let n = history.volumes.len();
+        probes.push(if n < va.min_history as usize {
+            Probe::skip(
+                "baseline",
+                format!(
+                    "volume baseline warming up: {n}/{} successful runs",
+                    va.min_history
+                ),
+            )
+        } else {
+            Probe::pass("baseline", start.elapsed())
+        });
+    }
+    probes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::spec::{AnomalyMethod, VolumeAnomalySpec};
+    use super::*;
+    use faucet_core::MemoryStateStore;
+    use faucet_core::check::ProbeStatus;
+
+    fn full_spec() -> SlaSpec {
+        SlaSpec {
+            max_staleness_secs: Some(3600),
+            min_rows_per_run: Some(5),
+            volume_anomaly: Some(VolumeAnomalySpec {
+                method: AnomalyMethod::Zscore,
+                sensitivity: None,
+                min_history: 3,
+                window: 10,
+            }),
+        }
+    }
+
+    fn mem() -> Arc<dyn StateStore> {
+        Arc::new(MemoryStateStore::new())
+    }
+
+    #[tokio::test]
+    async fn success_updates_baseline_and_failure_reads_it() {
+        let spec = full_spec();
+        let store = mem();
+        // Three successful runs at t=0, 10, 20 warm the baseline.
+        for (i, rows) in [100u64, 101, 99].iter().enumerate() {
+            let v = evaluate_post_run(
+                &spec,
+                Some(&store),
+                "p::default",
+                "p",
+                "default",
+                RunOutcome::Success { rows: *rows },
+                (i as i64) * 10,
+            )
+            .await;
+            assert!(v.is_empty(), "warm-up run {i} should not violate: {v:?}");
+        }
+        let stored = store.get("p::default::__sla__").await.unwrap().unwrap();
+        let st = SlaState::from_value(stored);
+        assert_eq!(st.volumes, vec![100, 101, 99]);
+        assert_eq!(st.last_success_unix, Some(20));
+
+        // A failure 2h later is stale.
+        let v = evaluate_post_run(
+            &spec,
+            Some(&store),
+            "p::default",
+            "p",
+            "default",
+            RunOutcome::Failure,
+            20 + 7200,
+        )
+        .await;
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].kind(), "staleness");
+
+        // A failure within the window is not.
+        let v = evaluate_post_run(
+            &spec,
+            Some(&store),
+            "p::default",
+            "p",
+            "default",
+            RunOutcome::Failure,
+            20 + 60,
+        )
+        .await;
+        assert!(v.is_empty(), "{v:?}");
+    }
+
+    #[tokio::test]
+    async fn success_detects_floor_and_anomaly_against_prior_baseline() {
+        let spec = full_spec();
+        let store = mem();
+        for (i, rows) in [100u64, 100, 100].iter().enumerate() {
+            evaluate_post_run(
+                &spec,
+                Some(&store),
+                "p::default",
+                "p",
+                "default",
+                RunOutcome::Success { rows: *rows },
+                i as i64,
+            )
+            .await;
+        }
+        // rows=2: below the floor of 5 AND anomalous vs the constant baseline.
+        let v = evaluate_post_run(
+            &spec,
+            Some(&store),
+            "p::default",
+            "p",
+            "default",
+            RunOutcome::Success { rows: 2 },
+            100,
+        )
+        .await;
+        let kinds: Vec<_> = v.iter().map(|x| x.kind()).collect();
+        assert_eq!(kinds, vec!["min_rows", "volume"]);
+        // The anomalous volume still folds into the (adaptive) baseline.
+        let st = SlaState::from_value(store.get("p::default::__sla__").await.unwrap().unwrap());
+        assert_eq!(st.volumes, vec![100, 100, 100, 2]);
+    }
+
+    #[tokio::test]
+    async fn no_store_runs_only_stateless_checks() {
+        let spec = SlaSpec {
+            max_staleness_secs: None,
+            min_rows_per_run: Some(10),
+            volume_anomaly: None,
+        };
+        let v = evaluate_post_run(
+            &spec,
+            None,
+            "p::default",
+            "p",
+            "default",
+            RunOutcome::Success { rows: 1 },
+            0,
+        )
+        .await;
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].kind(), "min_rows");
+        // Failure with no store and no staleness config → nothing.
+        let v = evaluate_post_run(
+            &spec,
+            None,
+            "p::default",
+            "p",
+            "default",
+            RunOutcome::Failure,
+            0,
+        )
+        .await;
+        assert!(v.is_empty());
+    }
+
+    #[tokio::test]
+    async fn doctor_probes_cover_cold_fresh_and_stale() {
+        let spec = full_spec();
+        let store = mem();
+
+        // Cold start: staleness + baseline both skip.
+        let probes = doctor_probes(&spec, Some(&store), "p::default", 0).await;
+        assert_eq!(probes.len(), 2);
+        assert!(matches!(probes[0].status, ProbeStatus::Skip { .. }));
+        assert!(matches!(probes[1].status, ProbeStatus::Skip { .. }));
+
+        // Warm history: both pass while fresh.
+        for i in 0..3i64 {
+            evaluate_post_run(
+                &spec,
+                Some(&store),
+                "p::default",
+                "p",
+                "default",
+                RunOutcome::Success { rows: 100 },
+                i,
+            )
+            .await;
+        }
+        let probes = doctor_probes(&spec, Some(&store), "p::default", 10).await;
+        assert!(matches!(probes[0].status, ProbeStatus::Pass), "{probes:?}");
+        assert!(matches!(probes[1].status, ProbeStatus::Pass), "{probes:?}");
+
+        // Long after the last success the staleness probe fails.
+        let probes = doctor_probes(&spec, Some(&store), "p::default", 2 + 7200).await;
+        assert!(
+            matches!(probes[0].status, ProbeStatus::Fail { .. }),
+            "{probes:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn doctor_probes_without_store() {
+        // Stateless spec → no probes at all.
+        let stateless = SlaSpec {
+            max_staleness_secs: None,
+            min_rows_per_run: Some(1),
+            volume_anomaly: None,
+        };
+        assert!(doctor_probes(&stateless, None, "k", 0).await.is_empty());
+        // Stateful spec, missing store (defensive) → a single skip.
+        let probes = doctor_probes(&full_spec(), None, "k", 0).await;
+        assert_eq!(probes.len(), 1);
+        assert!(matches!(probes[0].status, ProbeStatus::Skip { .. }));
+    }
+}

--- a/cli/src/sla/spec.rs
+++ b/cli/src/sla/spec.rs
@@ -1,0 +1,294 @@
+//! Config types for the top-level `sla:` block (#202).
+//!
+//! An SLA declares freshness and volume expectations for a pipeline. It is
+//! pipeline-level in v1 (no matrix-row override, like `resilience:`) and is
+//! evaluated after every **root** invocation by the executor — children fan
+//! out per parent record, so their volumes are not a stable series to baseline.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Default number of successful runs required before volume anomaly detection
+/// starts firing (cold-start guard).
+pub const DEFAULT_MIN_HISTORY: u32 = 5;
+/// Default rolling-window size (successful runs kept in the volume baseline).
+pub const DEFAULT_WINDOW: u32 = 20;
+/// Default z-score threshold.
+pub const DEFAULT_ZSCORE_SENSITIVITY: f64 = 3.0;
+/// Default Tukey-fence IQR multiplier.
+pub const DEFAULT_IQR_SENSITIVITY: f64 = 1.5;
+
+/// Declared service-level agreement for a pipeline: freshness and volume
+/// expectations. Violations emit the
+/// `faucet_pipeline_sla_violations_total{pipeline,row,kind}` counter and a
+/// structured warning log; they never fail the run.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct SlaSpec {
+    /// Maximum seconds since the last *successful* run before the pipeline
+    /// counts as stale. Evaluated when a run fails (against the previous
+    /// success) and by `faucet doctor`. Requires a `state:` block to persist
+    /// the last-success timestamp.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_staleness_secs: Option<u64>,
+
+    /// Static volume floor: a successful run that writes fewer records than
+    /// this violates the SLA (catches a source silently returning nothing).
+    /// Stateless — works without a `state:` block.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub min_rows_per_run: Option<u64>,
+
+    /// Learned-baseline volume anomaly detection over recent successful runs.
+    /// Requires a `state:` block to persist the rolling baseline.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub volume_anomaly: Option<VolumeAnomalySpec>,
+}
+
+/// How a run's record volume is flagged as anomalous against the rolling
+/// baseline of recent successful runs.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct VolumeAnomalySpec {
+    /// Detection method. Default `zscore`.
+    #[serde(default)]
+    pub method: AnomalyMethod,
+
+    /// Detection threshold. For `zscore`: the maximum |x − mean| / std
+    /// (default 3.0). For `iqr`: the Tukey fence multiplier — a volume outside
+    /// [Q1 − k·IQR, Q3 + k·IQR] is anomalous (default 1.5).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sensitivity: Option<f64>,
+
+    /// Minimum successful runs of history before detection starts (cold-start
+    /// guard). Default 5; must be at least 2.
+    #[serde(default = "default_min_history")]
+    pub min_history: u32,
+
+    /// Rolling-window size: how many recent successful-run volumes form the
+    /// baseline. Default 20; must be ≥ `min_history`.
+    #[serde(default = "default_window")]
+    pub window: u32,
+}
+
+fn default_min_history() -> u32 {
+    DEFAULT_MIN_HISTORY
+}
+
+fn default_window() -> u32 {
+    DEFAULT_WINDOW
+}
+
+/// Volume anomaly detection method.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AnomalyMethod {
+    /// Flag when |volume − mean| / std exceeds `sensitivity`.
+    #[default]
+    Zscore,
+    /// Flag when the volume falls outside the Tukey fences
+    /// [Q1 − k·IQR, Q3 + k·IQR] with k = `sensitivity`.
+    Iqr,
+}
+
+impl VolumeAnomalySpec {
+    /// The configured sensitivity, or the method's conventional default.
+    pub fn effective_sensitivity(&self) -> f64 {
+        self.sensitivity.unwrap_or(match self.method {
+            AnomalyMethod::Zscore => DEFAULT_ZSCORE_SENSITIVITY,
+            AnomalyMethod::Iqr => DEFAULT_IQR_SENSITIVITY,
+        })
+    }
+}
+
+impl SlaSpec {
+    /// Fail-fast validation, surfaced at config-load time by `expand`.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.max_staleness_secs.is_none()
+            && self.min_rows_per_run.is_none()
+            && self.volume_anomaly.is_none()
+        {
+            return Err("declares no checks — set max_staleness_secs, \
+                 min_rows_per_run, or volume_anomaly"
+                .into());
+        }
+        if self.max_staleness_secs == Some(0) {
+            return Err("max_staleness_secs must be at least 1".into());
+        }
+        if self.min_rows_per_run == Some(0) {
+            return Err("min_rows_per_run must be at least 1 (omit the field to disable)".into());
+        }
+        if let Some(va) = &self.volume_anomaly {
+            if let Some(s) = va.sensitivity
+                && (!s.is_finite() || s <= 0.0)
+            {
+                return Err(format!(
+                    "volume_anomaly.sensitivity must be a finite number > 0, got {s}"
+                ));
+            }
+            if va.min_history < 2 {
+                return Err(format!(
+                    "volume_anomaly.min_history must be at least 2, got {}",
+                    va.min_history
+                ));
+            }
+            if va.window < va.min_history {
+                return Err(format!(
+                    "volume_anomaly.window ({}) must be >= min_history ({})",
+                    va.window, va.min_history
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    /// Whether any configured check needs persisted history (a `state:` block).
+    pub fn needs_state(&self) -> bool {
+        self.max_staleness_secs.is_some() || self.volume_anomaly.is_some()
+    }
+
+    /// The rolling-window size to keep in the persisted baseline. Volumes are
+    /// tracked even when `volume_anomaly` is unset (as long as a state store
+    /// exists) so enabling anomaly detection later starts with warm history.
+    pub fn window(&self) -> usize {
+        self.volume_anomaly
+            .as_ref()
+            .map(|va| va.window as usize)
+            .unwrap_or(DEFAULT_WINDOW as usize)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn minimal() -> SlaSpec {
+        SlaSpec {
+            max_staleness_secs: Some(3600),
+            min_rows_per_run: None,
+            volume_anomaly: None,
+        }
+    }
+
+    #[test]
+    fn empty_spec_is_rejected() {
+        let s = SlaSpec {
+            max_staleness_secs: None,
+            min_rows_per_run: None,
+            volume_anomaly: None,
+        };
+        let err = s.validate().unwrap_err();
+        assert!(err.contains("declares no checks"), "{err}");
+    }
+
+    #[test]
+    fn zero_staleness_and_zero_min_rows_are_rejected() {
+        let mut s = minimal();
+        s.max_staleness_secs = Some(0);
+        assert!(s.validate().unwrap_err().contains("max_staleness_secs"));
+
+        let mut s = minimal();
+        s.min_rows_per_run = Some(0);
+        assert!(s.validate().unwrap_err().contains("min_rows_per_run"));
+    }
+
+    #[test]
+    fn bad_sensitivity_is_rejected() {
+        for bad in [0.0, -1.0, f64::NAN, f64::INFINITY] {
+            let s = SlaSpec {
+                max_staleness_secs: None,
+                min_rows_per_run: None,
+                volume_anomaly: Some(VolumeAnomalySpec {
+                    method: AnomalyMethod::Zscore,
+                    sensitivity: Some(bad),
+                    min_history: DEFAULT_MIN_HISTORY,
+                    window: DEFAULT_WINDOW,
+                }),
+            };
+            assert!(
+                s.validate().unwrap_err().contains("sensitivity"),
+                "sensitivity {bad} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn window_and_min_history_bounds() {
+        let s = SlaSpec {
+            max_staleness_secs: None,
+            min_rows_per_run: None,
+            volume_anomaly: Some(VolumeAnomalySpec {
+                method: AnomalyMethod::Iqr,
+                sensitivity: None,
+                min_history: 1,
+                window: DEFAULT_WINDOW,
+            }),
+        };
+        assert!(s.validate().unwrap_err().contains("min_history"));
+
+        let s = SlaSpec {
+            max_staleness_secs: None,
+            min_rows_per_run: None,
+            volume_anomaly: Some(VolumeAnomalySpec {
+                method: AnomalyMethod::Iqr,
+                sensitivity: None,
+                min_history: 10,
+                window: 5,
+            }),
+        };
+        assert!(s.validate().unwrap_err().contains("window"));
+    }
+
+    #[test]
+    fn effective_sensitivity_defaults_per_method() {
+        let z = VolumeAnomalySpec {
+            method: AnomalyMethod::Zscore,
+            sensitivity: None,
+            min_history: 5,
+            window: 20,
+        };
+        assert_eq!(z.effective_sensitivity(), DEFAULT_ZSCORE_SENSITIVITY);
+        let i = VolumeAnomalySpec {
+            method: AnomalyMethod::Iqr,
+            sensitivity: None,
+            min_history: 5,
+            window: 20,
+        };
+        assert_eq!(i.effective_sensitivity(), DEFAULT_IQR_SENSITIVITY);
+        let e = VolumeAnomalySpec {
+            sensitivity: Some(2.5),
+            ..z
+        };
+        assert_eq!(e.effective_sensitivity(), 2.5);
+    }
+
+    #[test]
+    fn needs_state_reflects_configured_checks() {
+        assert!(minimal().needs_state());
+        let rows_only = SlaSpec {
+            max_staleness_secs: None,
+            min_rows_per_run: Some(1),
+            volume_anomaly: None,
+        };
+        assert!(!rows_only.needs_state());
+        assert!(rows_only.validate().is_ok());
+    }
+
+    #[test]
+    fn deserializes_from_yaml_with_defaults() {
+        let s: SlaSpec =
+            serde_yaml::from_str("max_staleness_secs: 900\nvolume_anomaly:\n  method: iqr\n")
+                .unwrap();
+        assert_eq!(s.max_staleness_secs, Some(900));
+        let va = s.volume_anomaly.unwrap();
+        assert_eq!(va.method, AnomalyMethod::Iqr);
+        assert_eq!(va.min_history, DEFAULT_MIN_HISTORY);
+        assert_eq!(va.window, DEFAULT_WINDOW);
+        assert!(va.sensitivity.is_none());
+    }
+
+    #[test]
+    fn unknown_fields_are_rejected() {
+        let r: Result<SlaSpec, _> = serde_yaml::from_str("max_staleness: 900\n");
+        assert!(r.is_err());
+    }
+}

--- a/cli/src/sla/state.rs
+++ b/cli/src/sla/state.rs
@@ -1,0 +1,106 @@
+//! Persisted SLA history: last-success timestamp + rolling volume baseline.
+//!
+//! Stored in the pipeline's `StateStore` under `{base_state_key}::__sla__`
+//! (mirroring the `{name}::__replication__` reserved-suffix convention), so
+//! the history rides whatever durability the user configured for bookmarks.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Reserved suffix appended to the invocation's state key.
+pub const SLA_STATE_SUFFIX: &str = "__sla__";
+
+/// The SLA-history key for one invocation: `{base}::__sla__`.
+pub fn sla_state_key(base: &str) -> String {
+    format!("{base}::{SLA_STATE_SUFFIX}")
+}
+
+/// Rolling SLA history for one root invocation.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct SlaState {
+    /// Unix seconds of the most recent successful run.
+    pub last_success_unix: Option<i64>,
+    /// Records written by recent successful runs, oldest first, trimmed to the
+    /// configured window.
+    pub volumes: Vec<u64>,
+}
+
+impl SlaState {
+    /// Decode a stored value; a corrupt/foreign shape degrades to an empty
+    /// history (with a warning) rather than failing the run.
+    pub fn from_value(v: Value) -> Self {
+        match serde_json::from_value(v) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(error = %e, "unreadable SLA state — starting a fresh baseline");
+                Self::default()
+            }
+        }
+    }
+
+    /// Encode for the state store.
+    pub fn to_value(&self) -> Value {
+        serde_json::to_value(self).unwrap_or(Value::Null)
+    }
+
+    /// Fold a successful run into the history, trimming to `window` volumes.
+    pub fn record_success(&mut self, rows: u64, now_unix: i64, window: usize) {
+        self.last_success_unix = Some(now_unix);
+        self.volumes.push(rows);
+        if self.volumes.len() > window {
+            let excess = self.volumes.len() - window;
+            self.volumes.drain(..excess);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn key_is_suffixed() {
+        assert_eq!(sla_state_key("orders::default"), "orders::default::__sla__");
+    }
+
+    #[test]
+    fn round_trips_through_value() {
+        let mut s = SlaState::default();
+        s.record_success(100, 1_750_000_000, 20);
+        s.record_success(120, 1_750_003_600, 20);
+        let v = s.to_value();
+        assert_eq!(SlaState::from_value(v), s);
+        assert_eq!(s.volumes, vec![100, 120]);
+        assert_eq!(s.last_success_unix, Some(1_750_003_600));
+    }
+
+    #[test]
+    fn corrupt_value_degrades_to_default() {
+        assert_eq!(
+            SlaState::from_value(json!({"volumes": "not-an-array"})),
+            SlaState::default()
+        );
+        assert_eq!(SlaState::from_value(json!([1, 2, 3])), SlaState::default());
+    }
+
+    #[test]
+    fn missing_fields_default() {
+        // A future field addition must not invalidate old stored state.
+        let s = SlaState::from_value(json!({"last_success_unix": 5}));
+        assert_eq!(s.last_success_unix, Some(5));
+        assert!(s.volumes.is_empty());
+    }
+
+    #[test]
+    fn window_trims_oldest_first() {
+        let mut s = SlaState::default();
+        for i in 0..25u64 {
+            s.record_success(i, i as i64, 20);
+        }
+        assert_eq!(s.volumes.len(), 20);
+        assert_eq!(s.volumes[0], 5);
+        assert_eq!(*s.volumes.last().unwrap(), 24);
+    }
+}

--- a/cli/tests/replication.rs
+++ b/cli/tests/replication.rs
@@ -113,6 +113,7 @@ async fn run_once(url: &str, state_dir: &str) {
             auth: Default::default(),
             clock: chrono::Utc::now().fixed_offset(),
             resilience: None,
+            sla: None,
         },
     )
     .await

--- a/cli/tests/sla_monitoring.rs
+++ b/cli/tests/sla_monitoring.rs
@@ -1,0 +1,304 @@
+//! End-to-end wiring for the top-level `sla:` block (#202): the expand-time
+//! gates, the executor's post-run evaluation + baseline persistence, the
+//! never-fails-the-run guarantee, and the `faucet doctor` SLA probes.
+
+use faucet_cli::config::PipelineConfig;
+use faucet_cli::error::CliError;
+use faucet_cli::expand::expand;
+use faucet_core::StateStore;
+use std::path::Path;
+
+fn csv_to_jsonl_yaml(input: &Path, output: &Path, state_dir: &Path, sla: &str) -> String {
+    format!(
+        r#"version: 1
+name: slatest
+pipeline:
+  source: {{ type: csv, config: {{ path: {input} }} }}
+  sink: {{ type: jsonl, config: {{ path: {output} }} }}
+  state: {{ type: file, config: {{ path: {state} }} }}
+{sla}
+"#,
+        input = input.display(),
+        output = output.display(),
+        state = state_dir.display(),
+    )
+}
+
+fn parse(yaml: &str) -> PipelineConfig {
+    PipelineConfig::from_text(yaml, Path::new("sla.yaml")).expect("config parses")
+}
+
+// ── expand-time gates ────────────────────────────────────────────────────────
+
+#[test]
+fn expand_rejects_stateful_sla_without_state_block() {
+    let cfg = parse(
+        r#"version: 1
+pipeline:
+  source: { type: csv, config: { path: in.csv } }
+  sink: { type: jsonl, config: { path: out.jsonl } }
+sla:
+  max_staleness_secs: 3600
+"#,
+    );
+    let err = expand(&cfg).unwrap_err();
+    assert!(
+        matches!(&err, CliError::Config(m) if m.contains("state") && m.contains("sla")),
+        "expected the sla-needs-state gate, got: {err}"
+    );
+}
+
+#[test]
+fn expand_rejects_invalid_sla_spec() {
+    // An empty block declares no checks — caught by SlaSpec::validate.
+    let cfg = parse(
+        r#"version: 1
+pipeline:
+  source: { type: csv, config: { path: in.csv } }
+  sink: { type: jsonl, config: { path: out.jsonl } }
+sla: {}
+"#,
+    );
+    let err = expand(&cfg).unwrap_err();
+    assert!(
+        matches!(&err, CliError::Config(m) if m.contains("declares no checks")),
+        "expected the empty-spec rejection, got: {err}"
+    );
+
+    // A zero sensitivity is rejected by the same gate.
+    let cfg = parse(
+        r#"version: 1
+pipeline:
+  source: { type: csv, config: { path: in.csv } }
+  sink: { type: jsonl, config: { path: out.jsonl } }
+  state: { type: memory, config: {} }
+sla:
+  volume_anomaly: { method: zscore, sensitivity: 0 }
+"#,
+    );
+    let err = expand(&cfg).unwrap_err();
+    assert!(
+        matches!(&err, CliError::Config(m) if m.contains("sensitivity")),
+        "expected the sensitivity rejection, got: {err}"
+    );
+}
+
+#[test]
+fn expand_allows_stateless_min_rows_without_state() {
+    let cfg = parse(
+        r#"version: 1
+pipeline:
+  source: { type: csv, config: { path: in.csv } }
+  sink: { type: jsonl, config: { path: out.jsonl } }
+sla:
+  min_rows_per_run: 1
+"#,
+    );
+    let nodes = expand(&cfg).expect("stateless min_rows needs no state block");
+    assert_eq!(nodes.len(), 1);
+}
+
+// ── executor post-run evaluation ─────────────────────────────────────────────
+
+#[tokio::test]
+async fn successful_run_persists_sla_baseline() {
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("in.csv");
+    let output = dir.path().join("out.jsonl");
+    let state_dir = dir.path().join("state");
+    std::fs::write(&input, "id\n1\n2\n3\n").unwrap();
+
+    let yaml = csv_to_jsonl_yaml(
+        &input,
+        &output,
+        &state_dir,
+        "sla:\n  max_staleness_secs: 3600\n  min_rows_per_run: 1\n",
+    );
+    let summary = faucet_cli::run_from_yaml_str(&yaml).await.expect("run ok");
+    assert!(!summary.had_failures());
+    assert_eq!(summary.invocations[0].records_written, 3);
+
+    // The baseline landed under `{name}::{row}::__sla__` in the file store.
+    let store = faucet_core::FileStateStore::new(&state_dir);
+    let v = store
+        .get("slatest::row-0::__sla__")
+        .await
+        .unwrap()
+        .expect("SLA state persisted");
+    assert_eq!(v["volumes"], serde_json::json!([3]));
+    assert!(v["last_success_unix"].as_i64().unwrap() > 0);
+
+    // A second run appends to the rolling baseline.
+    let summary = faucet_cli::run_from_yaml_str(&yaml).await.expect("run ok");
+    assert!(!summary.had_failures());
+    let v = store.get("slatest::row-0::__sla__").await.unwrap().unwrap();
+    assert_eq!(v["volumes"], serde_json::json!([3, 3]));
+}
+
+#[tokio::test]
+async fn sla_violation_never_fails_the_run() {
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("in.csv");
+    let output = dir.path().join("out.jsonl");
+    let state_dir = dir.path().join("state");
+    std::fs::write(&input, "id\n1\n").unwrap();
+
+    // The floor is far above the actual volume — the violation fires, but the
+    // run must still succeed and write its records.
+    let yaml = csv_to_jsonl_yaml(
+        &input,
+        &output,
+        &state_dir,
+        "sla:\n  min_rows_per_run: 100\n",
+    );
+    let summary = faucet_cli::run_from_yaml_str(&yaml).await.expect("run ok");
+    assert!(!summary.had_failures(), "SLA violations must not fail runs");
+    assert_eq!(summary.invocations[0].records_written, 1);
+}
+
+#[tokio::test]
+async fn failed_run_evaluates_staleness_without_breaking_error_reporting() {
+    let dir = tempfile::tempdir().unwrap();
+    let missing = dir.path().join("nope.csv");
+    let output = dir.path().join("out.jsonl");
+    let state_dir = dir.path().join("state");
+
+    // Seed a last-success far in the past so the failure path walks the
+    // staleness branch (violation fires; the run error is preserved).
+    let store = faucet_core::FileStateStore::new(&state_dir);
+    store
+        .put(
+            "slatest::row-0::__sla__",
+            &serde_json::json!({"last_success_unix": 1, "volumes": [5, 5, 5]}),
+        )
+        .await
+        .unwrap();
+
+    let yaml = csv_to_jsonl_yaml(
+        &missing,
+        &output,
+        &state_dir,
+        "sla:\n  max_staleness_secs: 60\n",
+    );
+    let summary = faucet_cli::run_from_yaml_str(&yaml).await.expect("summary");
+    assert!(summary.had_failures(), "the source error is still reported");
+    // The failed run must not have touched the success history.
+    let v = store.get("slatest::row-0::__sla__").await.unwrap().unwrap();
+    assert_eq!(v["last_success_unix"], serde_json::json!(1));
+    assert_eq!(v["volumes"], serde_json::json!([5, 5, 5]));
+}
+
+#[tokio::test]
+async fn dry_run_skips_sla_evaluation() {
+    use faucet_cli::executor::{ExecuteOptions, run_expanded};
+
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("in.csv");
+    let output = dir.path().join("out.jsonl");
+    let state_dir = dir.path().join("state");
+    std::fs::write(&input, "id\n1\n").unwrap();
+
+    let yaml = csv_to_jsonl_yaml(&input, &output, &state_dir, "sla:\n  min_rows_per_run: 1\n");
+    let cfg = parse(&yaml);
+    let nodes = expand(&cfg).unwrap();
+    let summary = run_expanded(
+        nodes,
+        ExecuteOptions {
+            pipeline_name: "slatest".into(),
+            execution: None,
+            dry_run: true,
+            limit: None,
+            state_path_override: None,
+            shard: None,
+            auth: Default::default(),
+            clock: chrono::Utc::now().fixed_offset(),
+            cancel: None,
+            resilience: None,
+            sla: cfg.sla.clone(),
+            #[cfg(feature = "lineage")]
+            lineage: None,
+            #[cfg(feature = "lineage")]
+            lineage_cfg: None,
+        },
+    )
+    .await
+    .unwrap();
+    assert!(!summary.had_failures());
+
+    // No baseline recorded: a dry-run's synthetic volume must not poison it.
+    let store = faucet_core::FileStateStore::new(&state_dir);
+    assert!(
+        store
+            .get("slatest::row-0::__sla__")
+            .await
+            .unwrap()
+            .is_none()
+    );
+}
+
+// ── doctor probes ────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn doctor_reports_sla_probes_cold_and_warm() {
+    use faucet_cli::commands::doctor::probe_roots;
+    use faucet_core::check::{CheckContext, ProbeStatus};
+
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("in.csv");
+    let output = dir.path().join("out.jsonl");
+    let state_dir = dir.path().join("state");
+    std::fs::write(&input, "id\n1\n2\n").unwrap();
+
+    let yaml = csv_to_jsonl_yaml(
+        &input,
+        &output,
+        &state_dir,
+        "sla:\n  max_staleness_secs: 86400\n  volume_anomaly: { min_history: 3 }\n",
+    );
+    let cfg = parse(&yaml);
+    let nodes = expand(&cfg).unwrap();
+    let auth = Default::default();
+    let ctx = CheckContext::default();
+
+    // Cold start: staleness (no success yet) and baseline (0/3) both skip.
+    let invs = probe_roots(&nodes, &auth, &ctx, cfg.sla.as_ref(), "slatest").await;
+    let sla_probes: Vec<_> = invs[0].probes.iter().filter(|p| p.role == "sla").collect();
+    assert_eq!(sla_probes.len(), 2, "{:?}", invs[0].probes);
+    assert_eq!(sla_probes[0].name, "staleness");
+    assert!(matches!(sla_probes[0].status, ProbeStatus::Skip { .. }));
+    assert_eq!(sla_probes[1].name, "baseline");
+    assert!(matches!(sla_probes[1].status, ProbeStatus::Skip { .. }));
+
+    // After a successful run the staleness probe passes (fresh); the baseline
+    // is still warming (1/3).
+    faucet_cli::run_from_yaml_str(&yaml).await.expect("run ok");
+    let invs = probe_roots(&nodes, &auth, &ctx, cfg.sla.as_ref(), "slatest").await;
+    let sla_probes: Vec<_> = invs[0].probes.iter().filter(|p| p.role == "sla").collect();
+    assert!(
+        matches!(sla_probes[0].status, ProbeStatus::Pass),
+        "{sla_probes:?}"
+    );
+    assert!(matches!(sla_probes[1].status, ProbeStatus::Skip { .. }));
+
+    // A stale history turns the staleness probe red.
+    let store = faucet_core::FileStateStore::new(&state_dir);
+    store
+        .put(
+            "slatest::row-0::__sla__",
+            &serde_json::json!({"last_success_unix": 1, "volumes": [2, 2, 2]}),
+        )
+        .await
+        .unwrap();
+    let invs = probe_roots(&nodes, &auth, &ctx, cfg.sla.as_ref(), "slatest").await;
+    let sla_probes: Vec<_> = invs[0].probes.iter().filter(|p| p.role == "sla").collect();
+    assert!(
+        matches!(sla_probes[0].status, ProbeStatus::Fail { .. }),
+        "{sla_probes:?}"
+    );
+    // Warm baseline (3/3) now passes.
+    assert!(matches!(sla_probes[1].status, ProbeStatus::Pass));
+
+    // Without an `sla:` block no probes are added.
+    let invs = probe_roots(&nodes, &auth, &ctx, None, "slatest").await;
+    assert!(invs[0].probes.iter().all(|p| p.role != "sla"));
+}

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -27,6 +27,7 @@
 - [Resilience (retry / circuit breaker / poison-pill)](./cookbook/resilience.md)
 - [Data-quality checks](./cookbook/quality.md)
 - [Data contracts](./cookbook/contracts.md)
+- [SLA monitoring (freshness & volume)](./cookbook/sla.md)
 - [Testing pipelines](./cookbook/testing.md)
 - [Compression](./cookbook/compression.md)
 - [Record transforms](./cookbook/transforms.md)

--- a/docs/book/src/cookbook/sla.md
+++ b/docs/book/src/cookbook/sla.md
@@ -1,0 +1,128 @@
+# SLA monitoring: freshness & volume
+
+The most damaging pipeline failures are *silent*: a source quietly starts
+returning nothing, or a pipeline stops advancing, and nobody notices until a
+dashboard is empty. The top-level `sla:` block turns faucet's raw run telemetry
+into a declared contract — evaluated automatically after every root invocation
+by `faucet run`, `schedule`, `serve`, and `replicate`.
+
+It is **fully opt-in** and it **never fails a run**: a violation emits a
+Prometheus counter and a structured warning, and shows up in `faucet doctor` —
+the run itself completes exactly as it would have without the block.
+
+```yaml
+version: 1
+name: orders
+pipeline:
+  source: { type: postgres, config: { connection_url: "${env:PG_URL}", query: "SELECT * FROM orders" } }
+  sink: { type: jsonl, config: { path: ./orders.jsonl } }
+  state: { type: file, config: { path: ./state } }
+sla:
+  max_staleness_secs: 7200     # alert when no successful run within 2 hours
+  min_rows_per_run: 1          # a successful run writing 0 rows is a violation
+  volume_anomaly:
+    method: zscore             # zscore | iqr
+    min_history: 5             # don't alert until 5 successful runs of history
+```
+
+A runnable example lives at `cli/examples/csv_to_jsonl_with_sla.yaml`.
+
+## The three checks
+
+| Check | Fires when… | Needs `state:`? |
+|-------|-------------|-----------------|
+| `max_staleness_secs` | a run **fails** and the last successful run is older than the threshold (also probed read-only by `faucet doctor`) | yes |
+| `min_rows_per_run` | a run **succeeds** but writes fewer records than the floor | no |
+| `volume_anomaly` | a run **succeeds** but its volume is anomalous against the rolling baseline of recent successful runs | yes |
+
+The three compose freely — declare any subset. An `sla:` block that declares
+none of them is rejected at config load, as is a stateful check without a
+`state:` block (`faucet validate` catches both).
+
+## How the baseline works
+
+After every successful root invocation the executor folds the run's record
+count and timestamp into a small history object stored **next to the
+pipeline's bookmarks** in the configured state store, under
+`{name}::{row}::__sla__`. The history keeps the last `window` (default 20)
+successful-run volumes; failed, cancelled, `--dry-run`, and `--limit` runs
+never touch it, so synthetic or partial volumes cannot poison the baseline.
+
+`volume_anomaly` compares each new successful run against that baseline
+*before* folding it in:
+
+- **`zscore`** (default) — anomalous when |volume − mean| / std exceeds
+  `sensitivity` (default `3.0`). A constant baseline (std = 0) flags any
+  deviation.
+- **`iqr`** — anomalous when the volume falls outside the Tukey fences
+  `[Q1 − k·IQR, Q3 + k·IQR]` with `k = sensitivity` (default `1.5`). More
+  robust than z-score when the baseline itself contains outliers.
+
+Both are two-sided: a silent drop to zero and a 10× spike both fire. Detection
+stays quiet until `min_history` (default 5) successful runs have accumulated,
+and the anomalous volume still joins the rolling window afterwards — a genuine
+regime change (e.g. a backfill doubling daily volume) stops alerting once the
+window adapts, rather than firing forever.
+
+Staleness is measured against the last *successful* run: when a run fails, the
+executor checks how long ago the pipeline last succeeded and fires the
+`staleness` violation once that exceeds `max_staleness_secs`. Under
+`faucet schedule` this means every failing tick past the threshold re-alerts,
+which is exactly what you want a pager rule keyed on.
+
+## Metrics & alerting
+
+| Metric | Type | Labels | Meaning |
+|--------|------|--------|---------|
+| `faucet_pipeline_sla_violations_total` | counter | `pipeline`, `row`, `kind` | One increment per detected violation; `kind` ∈ `staleness` \| `min_rows` \| `volume`. |
+| `faucet_pipeline_sla_baseline_runs` | gauge | `pipeline`, `row` | Successful runs currently in the rolling volume baseline (cold-start visibility). |
+
+A minimal Prometheus alert:
+
+```yaml
+- alert: FaucetSlaViolation
+  expr: increase(faucet_pipeline_sla_violations_total[15m]) > 0
+  labels: { severity: page }
+  annotations:
+    summary: "faucet pipeline {{ $labels.pipeline }}/{{ $labels.row }} violated its {{ $labels.kind }} SLA"
+```
+
+Every violation is also logged as a `WARN` with `pipeline`, `row`, and `kind`
+fields, so log-based alerting works without Prometheus.
+
+## `faucet doctor`
+
+When an `sla:` block is present, `doctor` adds read-only probes per root
+invocation:
+
+```text
+▸ Invocation row-0  (source=postgres, sink=jsonl)
+  ✓ source [postgres] read                          42 ms
+  ✓ sink   [jsonl] io                                1 ms
+  ✓ state  [file] sentinel                           0 ms
+  ✗ sla    [sla] staleness (last success 9341s ago exceeds max_staleness_secs 7200)
+        hint: check the pipeline's schedule and recent run failures
+  • sla    [sla] baseline (skip: volume baseline warming up: 2/5 successful runs)
+```
+
+A stale pipeline makes `doctor` exit non-zero — usable as a standalone
+freshness check in CI or a cron health probe, independent of any run.
+
+## Scoping & interactions
+
+- **Root invocations only.** Matrix children fan out per parent record, so
+  their volumes are not a stable series to baseline (same scoping as
+  `faucet doctor` probes). Each matrix **row** gets its own independent
+  history and baseline.
+- **`state:` required for staleness/volume** — the history rides whatever
+  durability your bookmarks have. `memory` works within a long-running
+  `schedule`/`serve` process but resets on restart (faucet warns at load
+  time); use `file`/`redis`/`postgres` for one-shot runs.
+- **`serve` cluster shard runs are exempt** — a shard's volume is a fraction
+  of the row's and shard counts change between runs. Whole-run `serve`
+  executions evaluate normally.
+- **`--dry-run` / `--limit` skip evaluation** entirely.
+- The block is pipeline-level in v1 (no per-matrix-row override, like
+  `resilience:`).
+
+Schema: `faucet schema sla`.

--- a/docs/book/src/cookbook/troubleshooting.md
+++ b/docs/book/src/cookbook/troubleshooting.md
@@ -48,6 +48,7 @@ faucet doctor pipeline.yaml || { echo "preflight failed"; exit 1; }
 | `redis` / `mongodb` / `elasticsearch` / `http` sinks | `PING` / `ping` / cluster health / a `HEAD` request. |
 | File sinks (`jsonl`/`csv`/`parquet`/`stdout`) | Target directory is writable (`stdout` always passes). |
 | State stores (`redis`/`postgres`/`file`/`memory`) | A sentinel `put`/`get`/`delete` that leaves no residue. |
+| SLA (`sla:` block) | Read-only staleness / volume-baseline probes against the persisted run history — see [SLA monitoring](sla.md). |
 
 ## Reading the result
 

--- a/docs/book/src/reference/cli.md
+++ b/docs/book/src/reference/cli.md
@@ -108,6 +108,7 @@ faucet schema transform keys_case
 faucet schema dlq
 faucet schema execution
 faucet schema contract
+faucet schema sla
 faucet schema secrets
 faucet schema triggers
 ```
@@ -118,6 +119,9 @@ transform (e.g. `keys_case` lists the valid `mode:` values). Run
 
 `faucet schema execution` prints the schema for the top-level `execution:`
 block, including concurrency, error handling, and adaptive batch sizing.
+
+`faucet schema sla` prints the schema for the top-level `sla:`
+(freshness/volume SLA) block — see [SLA monitoring](../cookbook/sla.md).
 
 `faucet schema secrets` prints the directive grammar and auth requirements for
 all four secrets-manager backends in machine-readable JSON — useful for tooling
@@ -159,6 +163,9 @@ times; the **exit code equals the number of failed probes** (clamped to 255).
   `PING`, `tables.get`, cluster health, `fetch_metadata`, or a directory-writable
   check for file sinks. Never a real write.
 - **State stores** do a sentinel `put`/`get`/`delete` that leaves no residue.
+- **SLA** (when a top-level [`sla:` block](config.md#sla) is configured) reads the
+  persisted run history and reports staleness of the last successful run vs
+  `max_staleness_secs` and volume-baseline warm-up state — read-only.
 
 Child invocations (parent/child matrix rows) are listed but not probed — their
 configs depend on parent records that only exist at run time. Probe messages are

--- a/docs/book/src/reference/config.md
+++ b/docs/book/src/reference/config.md
@@ -469,6 +469,42 @@ explicitly; otherwise the injected policy's `max_attempts` + `base` apply (its
 `retry_on` / `max` / `jitter` are inert on REST, honored on `xml` / `graphql`
 and on every sink-side write).
 
+## `sla`
+
+Optional top-level block declaring a freshness/volume SLA for the pipeline
+(evaluated after every root invocation by `faucet run` / `schedule` / `serve` /
+`replicate`). Fully opt-in and **never fails a run**: violations emit the
+`faucet_pipeline_sla_violations_total{pipeline,row,kind}` counter and a
+structured warning, and `faucet doctor` reports staleness / baseline health.
+See the [SLA monitoring cookbook](../cookbook/sla.md).
+
+```yaml
+sla:
+  max_staleness_secs: 7200     # stale when no successful run within 2h
+  min_rows_per_run: 1          # a successful run writing fewer records violates
+  volume_anomaly:              # learned-baseline anomaly detection
+    method: zscore             # zscore | iqr
+    sensitivity: 3.0           # zscore default 3.0; iqr default 1.5
+    min_history: 5             # successful runs before detection starts
+    window: 20                 # rolling baseline size
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `max_staleness_secs` | int | — | Maximum seconds since the last **successful** run. Evaluated when a run fails (against the previous success) and by `faucet doctor`. Requires a `state:` block. |
+| `min_rows_per_run` | int | — | Static volume floor for a successful run (catches a source silently returning nothing). Stateless — works without a `state:` block. |
+| `volume_anomaly.method` | `zscore` \| `iqr` | `zscore` | How a successful run's volume is compared against the rolling baseline of recent successful runs. |
+| `volume_anomaly.sensitivity` | float | `3.0` / `1.5` | `zscore`: max \|x − mean\| / std. `iqr`: Tukey fence multiplier. Defaults per method. |
+| `volume_anomaly.min_history` | int | `5` | Cold-start guard: successful runs of history required before detection fires (min 2). |
+| `volume_anomaly.window` | int | `20` | Rolling window of successful-run volumes kept as the baseline (≥ `min_history`). |
+
+At least one of the three checks must be set. `max_staleness_secs` /
+`volume_anomaly` require a `state:` block (enforced at config load); the
+history is persisted next to the pipeline's bookmarks under
+`{name}::{row}::__sla__`. With a `memory` state store the history only
+persists within a single `faucet schedule` / `serve` process. Schema:
+`faucet schema sla`.
+
 ## `replication`
 
 Present only when you run [`faucet replicate`](cli.md#replicate). It turns the

--- a/examples/README.md
+++ b/examples/README.md
@@ -33,6 +33,7 @@ These run immediately after installing the CLI — great for a first smoke test:
 |---------|-------|
 | `csv_to_jsonl.yaml` | the canonical smoke test (`make demo` runs this) |
 | `csv_to_jsonl_with_contract.yaml` | a versioned data contract (`contract:` block) quarantining breaching records to a DLQ; inspect with `faucet contract` |
+| `csv_to_jsonl_with_sla.yaml` | freshness/volume SLA monitoring (`sla:` block) — staleness, min-rows floor, and learned-baseline volume anomaly detection |
 | `csv_to_jsonl_sql.yaml` | CSV → SQL GROUP BY + LEFT JOIN (embedded DuckDB) → JSONL; requires `--features transform-sql` |
 | `csv_to_sqlite.yaml` | CSV → local SQLite file |
 | `sqlite_to_jsonl.yaml`, `sqlite_to_csv.yaml` | local SQLite → file |


### PR DESCRIPTION
## Summary

Adds **data-freshness & volume SLA monitoring** (#202): a top-level `sla:` block that declares what "healthy" looks like for a pipeline, evaluated automatically after every root invocation by `faucet run` / `schedule` / `serve` / `replicate`. Turns faucet's existing run telemetry into a declared contract that catches the worst class of failure — the *silent* one, where a source quietly returns nothing or a pipeline stops advancing.

**Monitoring never fails the run.** A violation emits a Prometheus counter and a `WARN` log, and shows up read-only in `faucet doctor`; the run itself completes exactly as it would have without the block.

```yaml
sla:
  max_staleness_secs: 7200     # stale when no successful run within 2h (needs state:)
  min_rows_per_run: 1          # a successful run writing fewer records violates
  volume_anomaly:              # learned baseline over recent successful runs (needs state:)
    method: zscore             # zscore | iqr
    sensitivity: 3.0
    min_history: 5
    window: 20
```

## The three checks

| Check | Fires when… | Needs `state:`? |
|-------|-------------|-----------------|
| `max_staleness_secs` | a run **fails** and the last successful run is older than the threshold (also probed by `faucet doctor`) | yes |
| `min_rows_per_run` | a run **succeeds** but writes fewer records than the floor | no |
| `volume_anomaly` | a run **succeeds** but its volume is anomalous vs the rolling baseline (z-score or Tukey IQR, two-sided) | yes |

## Design

- **New `cli/src/sla/` module** (always compiled, no Cargo feature), mirroring `schedule/` / `replication/`: `spec.rs` (config + fail-fast validation), `state.rs` (rolling history persisted at `{name}::{row}::__sla__` in the node's `StateStore`), `eval.rs` (pure staleness / floor / anomaly math), `metrics.rs` (Prometheus surface), `mod.rs` (`evaluate_post_run` orchestration + `doctor_probes`).
- **Evaluated in `executor::run_one_invocation`** after every **root** invocation, so all four runtimes inherit it. Skipped for dry-run / `--limit` / shard / cancelled runs so synthetic or partial volumes can't poison the baseline. A failed *state read* skips evaluation (never clobbers accumulated history); the pass is wrapped so it can never fail the run.
- **`faucet doctor`** gains read-only `sla` probes (staleness vs `max_staleness_secs`, volume-baseline warm-up); wired into serve's `doctor_first` too.
- **Expand-time gates**: stateful checks require a `state:` block (rejected at load, with a `memory`-store warning); the spec is validated fail-fast (empty spec, zero thresholds, bad sensitivity, `window < min_history`).
- **`faucet schema sla`** prints the block's JSON Schema.

## Metrics

- `faucet_pipeline_sla_violations_total{pipeline,row,kind}` — counter; `kind` ∈ `staleness` | `min_rows` | `volume`.
- `faucet_pipeline_sla_baseline_runs{pipeline,row}` — gauge; successful runs in the rolling baseline (cold-start visibility).

## Tests

- Unit tests for the anomaly math (z-score incl. constant baseline, IQR fences, quantile interpolation, sensitivity band), spec validation, state round-trip / corruption-tolerance / window trimming, and the `evaluate_post_run` / `doctor_probes` orchestration.
- Integration tests (`cli/tests/sla_monitoring.rs`) covering the expand gates, baseline persistence across runs, the never-fails-the-run guarantee, the failed-run staleness path (history untouched), dry-run skip, and the doctor cold/warm/stale probe transitions.

## Docs

- New cookbook page `docs/book/src/cookbook/sla.md` + `## sla` in `reference/config.md`; updated `reference/cli.md`, `cookbook/troubleshooting.md`, `cli/README.md`, root `README.md`, `examples/README.md`, and a runnable `cli/examples/csv_to_jsonl_with_sla.yaml`.

Closes #202. Part of the roadmap epic #38 (Observability / data-observability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
