### PR TITLE
feat(cli): depends_on — completion ordering between matrix rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,9 @@ pipeline:
       path: ./out/issues.jsonl
 ```
 
-Run many invocations from one config with a `matrix:` block (independent fan-out **or** a
-parent/child DAG), and bound concurrency with `execution:`. See [`cli/README.md`](cli/README.md)
+Run many invocations from one config with a `matrix:` block (independent fan-out, a
+parent/child DAG, **or** `depends_on:` completion ordering between rows), and bound
+concurrency with `execution:`. See [`cli/README.md`](cli/README.md)
 for the full grammar, [`cli/examples/rest_to_bigquery_matrix.yaml`](cli/examples/rest_to_bigquery_matrix.yaml)
 for matrix fan-out, and [`cli/examples/rest_users_posts_dag.yaml`](cli/examples/rest_users_posts_dag.yaml)
 for the DAG pattern. The [`cli/examples/`](cli/examples) directory has runnable configs for

--- a/cli/README.md
+++ b/cli/README.md
@@ -578,7 +578,7 @@ pipeline:
 
 ### Matrix mode — run many invocations from one config
 
-Add a `matrix:` block to run multiple invocations from the same base. Each row is **deep-merged** into `pipeline:` (objects merge recursively, arrays replace wholesale, scalars replace). Rows with `parent:` become children that fan out one invocation per record produced by the parent row.
+Add a `matrix:` block to run multiple invocations from the same base. Each row is **deep-merged** into `pipeline:` (objects merge recursively, arrays replace wholesale, scalars replace). Rows with `parent:` become children that fan out one invocation per record produced by the parent row. Rows with `depends_on:` wait for other rows to finish before starting (pure ordering, no record hand-off).
 
 ```yaml
 version: 1
@@ -612,10 +612,37 @@ matrix:
     source: { config: { path: /v1/users/${users.id}/posts } }
     sink:   { config: { dataset: raw, table: user_posts } }
 
+  # Completion ordering — starts only after `users` AND `products` succeed.
+  - id: order_facts
+    depends_on: [users, products]
+    source: { config: { path: /v1/orders } }
+    sink:   { config: { dataset: marts, table: order_facts } }
+
 execution:
   max_concurrent: 8
   on_error: continue   # or `stop`
 ```
+
+#### `depends_on:` — completion ordering between rows
+
+`depends_on: [row_id, …]` makes a row wait until **every listed row's
+invocations finish successfully** before it starts. Unlike `parent:`, no
+records are consumed and there is no per-record fan-out — it is pure run
+ordering ("load dimensions, then facts"; "ingest raw, then run the rollup
+whose source reads what the first row wrote").
+
+- Rows whose dependencies are all satisfied run concurrently as usual.
+- A failed or skipped dependency **skips** the dependent row (and, in turn,
+  its own children and dependents). The skip is logged; the run's exit code
+  reflects the original failure.
+- Waiting on a row means waiting for that row's own invocations. To also wait
+  for its per-record children, list the child rows explicitly
+  (`depends_on: [dims, dim_details]`).
+- `parent:` and `depends_on:` compose on the same row; the parent edge is
+  itself an implicit dependency.
+- Unknown ids, self-dependencies, and cycles through any mix of `parent:` /
+  `depends_on:` edges are rejected at load time (`faucet validate` catches
+  them).
 
 #### Deep-merge rules
 
@@ -992,6 +1019,7 @@ CLI-only smoke tests:
 
 - [`csv_to_jsonl.yaml`](examples/csv_to_jsonl.yaml) — read a CSV, write JSONL (zero external deps)
 - [`rest_to_stdout_preview.yaml`](examples/rest_to_stdout_preview.yaml) — pipe REST records into `jq`
+- [`matrix_depends_on.yaml`](examples/matrix_depends_on.yaml) — `depends_on` completion ordering: two staging rows, then a report row that waits for both (zero external deps)
 
 Mirrors of the Rust examples (one `.yaml` per `.rs`):
 

--- a/cli/examples/matrix_depends_on.yaml
+++ b/cli/examples/matrix_depends_on.yaml
@@ -1,0 +1,42 @@
+# Completion ordering between matrix rows with `depends_on` (#195).
+#
+# The `stage_countries` and `stage_orders` rows each land a CSV locally;
+# the `report` row waits for BOTH to finish successfully before reading
+# what `stage_orders` wrote. Unlike `parent:`, `depends_on:` hands off no
+# records — it is pure run ordering ("load dims, then facts").
+#
+#   faucet validate cli/examples/matrix_depends_on.yaml
+#   faucet run      cli/examples/matrix_depends_on.yaml
+#
+# A failed or skipped dependency skips the dependent row; unknown ids,
+# self-dependencies, and cycles are rejected at validate time.
+version: 1
+name: matrix_depends_on
+
+pipeline:
+  source:
+    type: csv
+    config:
+      path: cli/examples/data/orders.csv
+
+  sink:
+    type: csv
+    config:
+      path: staged.csv
+
+matrix:
+  # Independent staging rows — run concurrently.
+  - id: stage_countries
+    source: { config: { path: cli/examples/data/countries.csv } }
+    sink: { config: { path: staged_countries.csv } }
+  - id: stage_orders
+    sink: { config: { path: staged_orders.csv } }
+
+  # Runs only after BOTH staging rows succeed, reading the file the
+  # `stage_orders` row just wrote.
+  - id: report
+    depends_on: [stage_countries, stage_orders]
+    source: { config: { path: staged_orders.csv } }
+    sink:
+      type: jsonl
+      config: { path: report.jsonl }

--- a/cli/src/commands/validate.rs
+++ b/cli/src/commands/validate.rs
@@ -118,19 +118,67 @@ pub async fn run(args: ValidateArgs) -> CliResult<()> {
             .unwrap_or_else(|| "(defaults)".to_owned()),
     );
     for node in &nodes {
-        let role = match &node.role {
-            NodeRole::Root => "root".to_owned(),
-            NodeRole::Child {
-                parent_id,
-                parent_key,
-            } => {
-                format!("child of '{parent_id}' (parent_key={parent_key})")
-            }
-        };
-        println!(
-            "  - {} [{}] source={} sink={}",
-            node.id, role, node.source.kind, node.sink.kind
-        );
+        println!("{}", row_line(node));
     }
     Ok(())
+}
+
+/// Render one per-row report line for `faucet validate` output.
+fn row_line(node: &crate::expand::ExpandedNode) -> String {
+    let role = match &node.role {
+        NodeRole::Root => "root".to_owned(),
+        NodeRole::Child {
+            parent_id,
+            parent_key,
+        } => {
+            format!("child of '{parent_id}' (parent_key={parent_key})")
+        }
+    };
+    let deps = if node.depends_on.is_empty() {
+        String::new()
+    } else {
+        format!(" depends_on=[{}]", node.depends_on.join(", "))
+    };
+    format!(
+        "  - {} [{}] source={} sink={}{}",
+        node.id, role, node.source.kind, node.sink.kind, deps
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::row_line;
+    use crate::expand::expand;
+
+    #[test]
+    fn row_line_renders_role_and_depends_on() {
+        let cfg = crate::config::parse_with_extension(
+            r#"
+version: 1
+pipeline:
+  source: { type: rest, config: {} }
+  sink:   { type: jsonl, config: { path: ./o } }
+matrix:
+  - id: dims
+  - id: posts
+    parent: dims
+    parent_key: id
+  - id: facts
+    depends_on: [dims]
+"#,
+            "yaml",
+        )
+        .unwrap();
+        let nodes = expand(&cfg).unwrap();
+        let line_for = |id: &str| row_line(nodes.iter().find(|n| n.id == id).unwrap());
+        assert_eq!(line_for("dims"), "  - dims [root] source=rest sink=jsonl");
+        assert_eq!(
+            line_for("posts"),
+            "  - posts [child of 'dims' (parent_key=id)] source=rest sink=jsonl"
+        );
+        assert_eq!(
+            line_for("facts"),
+            "  - facts [root] source=rest sink=jsonl depends_on=[dims]"
+        );
+    }
 }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -263,6 +263,13 @@ pub struct MatrixRow {
     #[serde(default)]
     pub parent: Option<String>,
 
+    /// Row ids this row waits for. The row starts only after every listed
+    /// row (all of its invocations) finishes successfully; a failed or
+    /// skipped dependency skips this row. Pure completion-ordering — unlike
+    /// `parent:`, no records are consumed and no per-record fan-out occurs.
+    #[serde(default)]
+    pub depends_on: Vec<String>,
+
     /// Dotted field path inside each parent record that uniquely identifies
     /// the record. Used as the state-key suffix. Default: `id`.
     #[serde(default = "default_parent_key")]

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -145,6 +145,14 @@ pub enum CliError {
     #[error("matrix has a parent cycle through: {}", ids.join(" -> "))]
     ParentCycle { ids: Vec<String> },
 
+    /// A row's `depends_on:` list names a row that doesn't exist.
+    #[error("matrix row '{id}' depends on unknown row '{depends_on}'")]
+    UnknownDependency { id: String, depends_on: String },
+
+    /// The combined `parent:` + `depends_on:` graph contains a cycle.
+    #[error("matrix has a dependency cycle involving: {}", ids.join(", "))]
+    DependencyCycle { ids: Vec<String> },
+
     /// Two parent records of the same matrix row resolved to the same
     /// `parent_key` value, producing a colliding state-key suffix.
     #[error(

--- a/cli/src/executor.rs
+++ b/cli/src/executor.rs
@@ -11,6 +11,10 @@
 //!   record via [`interpolate_record`].
 //! - All invocations share one global semaphore — children and roots compete
 //!   for the same budget.
+//! - A node with `depends_on: [row, …]` starts only after every listed row's
+//!   invocations finish successfully — pure completion-ordering, no record
+//!   hand-off. A failed or skipped dependency skips the node (and, in turn,
+//!   its own subtree and dependents).
 //! - `on_error: continue` (default) skips a failed node's subtree but keeps
 //!   running siblings. `on_error: stop` cancels everything after the first
 //!   failure.
@@ -220,16 +224,27 @@ pub async fn run_expanded(nodes: Vec<ExpandedNode>, opts: ExecuteOptions) -> Cli
     };
 
     while !remaining.is_empty() {
-        // Pick every remaining node whose parent (if any) is already
-        // completed, in deterministic BFS order.
+        // Pick every remaining node whose parent (if any) and every
+        // `depends_on` row are already terminal (completed or skipped), in
+        // deterministic BFS order. Whether a skipped/failed prerequisite
+        // *skips* the node is decided in the unit loop below — readiness only
+        // asks "is there anything left to wait for".
         let ready: Vec<String> = bfs_order
             .iter()
             .filter(|id| remaining.contains(*id))
-            .filter(|id| match &nodes_by_id[*id].role {
-                NodeRole::Root => true,
-                NodeRole::Child { parent_id, .. } => {
-                    completed.contains(parent_id) || skipped_subtrees.contains(parent_id)
-                }
+            .filter(|id| {
+                let node = &nodes_by_id[*id];
+                let parent_done = match &node.role {
+                    NodeRole::Root => true,
+                    NodeRole::Child { parent_id, .. } => {
+                        completed.contains(parent_id) || skipped_subtrees.contains(parent_id)
+                    }
+                };
+                parent_done
+                    && node
+                        .depends_on
+                        .iter()
+                        .all(|d| completed.contains(d) || skipped_subtrees.contains(d))
             })
             .cloned()
             .collect();
@@ -242,7 +257,8 @@ pub async fn run_expanded(nodes: Vec<ExpandedNode>, opts: ExecuteOptions) -> Cli
             let mut stuck: Vec<String> = remaining.iter().cloned().collect();
             stuck.sort();
             return Err(CliError::Internal(format!(
-                "executor deadlock: {} node(s) never became ready (no completed/skipped parent): {}",
+                "executor deadlock: {} node(s) never became ready (no completed/skipped \
+                 parent or dependency): {}",
                 stuck.len(),
                 stuck.join(", ")
             )));
@@ -280,6 +296,22 @@ pub async fn run_expanded(nodes: Vec<ExpandedNode>, opts: ExecuteOptions) -> Cli
             {
                 skipped_subtrees.insert(id.clone());
                 tracing::warn!(row = %id, parent = %parent_id, "skipping subtree under failed parent");
+                continue;
+            }
+            // Same for a failed/skipped `depends_on` prerequisite: the row
+            // waited for something that never succeeded, so running it would
+            // violate the ordering contract. Mark it skipped so its own
+            // subtree and dependents cascade too.
+            if let Some(dep) = node
+                .depends_on
+                .iter()
+                .find(|d| skipped_subtrees.contains(d.as_str()))
+            {
+                skipped_subtrees.insert(id.clone());
+                tracing::warn!(
+                    row = %id, dependency = %dep,
+                    "skipping row: a depends_on row failed or was skipped"
+                );
                 continue;
             }
             match &node.role {
@@ -1571,6 +1603,161 @@ matrix:
     }
 
     #[tokio::test]
+    async fn depends_on_root_runs_after_dependency() {
+        // `stage` writes a CSV that `load` reads — `load` can only succeed if
+        // it genuinely starts after `stage` finishes (pure ordering, no
+        // record hand-off).
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("in.csv");
+        let mid = dir.path().join("mid.csv");
+        let out = dir.path().join("out.jsonl");
+        std::fs::write(&input, "name\nalice\nbob\n").unwrap();
+
+        let yaml = format!(
+            r#"version: 1
+pipeline:
+  source: {{ type: csv, config: {{ path: {input} }} }}
+  sink:   {{ type: jsonl, config: {{ path: {out} }} }}
+matrix:
+  - id: stage
+    sink: {{ type: csv, config: {{ path: {mid} }} }}
+  - id: load
+    depends_on: [stage]
+    source: {{ config: {{ path: {mid} }} }}
+"#,
+            input = input.display(),
+            mid = mid.display(),
+            out = out.display(),
+        );
+        let cfg = crate::config::parse_with_extension(&yaml, "yaml").unwrap();
+        let nodes = expand(&cfg).unwrap();
+        let summary = run_expanded(nodes, opts("depsorder")).await.unwrap();
+        assert_eq!(summary.invocations.len(), 2, "{summary:?}");
+        assert!(!summary.had_failures(), "{summary:?}");
+        let load = summary
+            .invocations
+            .iter()
+            .find(|i| i.row_id == "load")
+            .unwrap();
+        assert_eq!(load.records_written, 2);
+        let written = std::fs::read_to_string(&out).unwrap();
+        assert_eq!(written.lines().count(), 2);
+    }
+
+    #[tokio::test]
+    async fn diamond_dependency_waits_for_all_prerequisites() {
+        // c waits on both a and b (a diamond join): readiness must require
+        // *every* dependency to be terminal, not just the first.
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("in.csv");
+        let mid_a = dir.path().join("mid_a.csv");
+        let mid_b = dir.path().join("mid_b.csv");
+        let out = dir.path().join("out.jsonl");
+        std::fs::write(&input, "name\nalice\n").unwrap();
+
+        let yaml = format!(
+            r#"version: 1
+pipeline:
+  source: {{ type: csv, config: {{ path: {input} }} }}
+  sink:   {{ type: jsonl, config: {{ path: {out} }} }}
+matrix:
+  - id: a
+    sink: {{ type: csv, config: {{ path: {mid_a} }} }}
+  - id: b
+    sink: {{ type: csv, config: {{ path: {mid_b} }} }}
+  - id: c
+    depends_on: [a, b]
+    source: {{ config: {{ path: {mid_a} }} }}
+"#,
+            input = input.display(),
+            mid_a = mid_a.display(),
+            mid_b = mid_b.display(),
+            out = out.display(),
+        );
+        let cfg = crate::config::parse_with_extension(&yaml, "yaml").unwrap();
+        let nodes = expand(&cfg).unwrap();
+        let summary = run_expanded(nodes, opts("diamond")).await.unwrap();
+        assert_eq!(summary.invocations.len(), 3, "{summary:?}");
+        assert!(!summary.had_failures(), "{summary:?}");
+        assert!(mid_b.exists(), "b must have run before c became ready");
+        assert!(out.exists());
+    }
+
+    #[tokio::test]
+    async fn failed_dependency_skips_dependent() {
+        // `stage` fails (missing input file); `load` depends on it and must be
+        // skipped — no invocation outcome, no output file.
+        let dir = tempfile::tempdir().unwrap();
+        let good_input = dir.path().join("good.csv");
+        let out = dir.path().join("out.jsonl");
+        std::fs::write(&good_input, "name\nalice\n").unwrap();
+
+        let yaml = format!(
+            r#"version: 1
+pipeline:
+  source: {{ type: csv, config: {{ path: {good} }} }}
+  sink:   {{ type: jsonl, config: {{ path: {out} }} }}
+matrix:
+  - id: stage
+    source: {{ config: {{ path: {missing} }} }}
+  - id: load
+    depends_on: [stage]
+"#,
+            good = good_input.display(),
+            missing = dir.path().join("nonexistent.csv").display(),
+            out = out.display(),
+        );
+        let cfg = crate::config::parse_with_extension(&yaml, "yaml").unwrap();
+        let nodes = expand(&cfg).unwrap();
+        let summary = run_expanded(nodes, opts("depskip")).await.unwrap();
+        assert_eq!(summary.invocations.len(), 1, "{summary:?}");
+        assert_eq!(summary.invocations[0].row_id, "stage");
+        assert!(summary.invocations[0].error.is_some());
+        assert!(
+            !out.exists(),
+            "dependent row must not run after its dependency failed"
+        );
+    }
+
+    #[tokio::test]
+    async fn dependency_on_skipped_row_cascades() {
+        // p fails → its child c is skipped → q (which depends on c) must be
+        // skipped too, even though c itself never *failed*.
+        let dir = tempfile::tempdir().unwrap();
+        let good_input = dir.path().join("good.csv");
+        let out = dir.path().join("q.jsonl");
+        std::fs::write(&good_input, "id\n1\n").unwrap();
+
+        let yaml = format!(
+            r#"version: 1
+pipeline:
+  source: {{ type: csv, config: {{ path: {good} }} }}
+  sink:   {{ type: jsonl, config: {{ path: {out} }} }}
+matrix:
+  - id: p
+    source: {{ config: {{ path: {missing} }} }}
+  - id: c
+    parent: p
+  - id: q
+    depends_on: [c]
+"#,
+            good = good_input.display(),
+            missing = dir.path().join("nonexistent.csv").display(),
+            out = out.display(),
+        );
+        let cfg = crate::config::parse_with_extension(&yaml, "yaml").unwrap();
+        let nodes = expand(&cfg).unwrap();
+        let summary = run_expanded(nodes, opts("depcascade")).await.unwrap();
+        assert_eq!(summary.invocations.len(), 1, "{summary:?}");
+        assert_eq!(summary.invocations[0].row_id, "p");
+        assert!(summary.invocations[0].error.is_some());
+        assert!(
+            !out.exists(),
+            "q must be skipped when its dependency was skipped"
+        );
+    }
+
+    #[tokio::test]
     async fn on_error_stop_reports_failure_and_runs_no_extra_work() {
         // First root writes to an invalid sink path and fails. The second
         // ("good") root would succeed. Under `on_error: stop` the executor
@@ -2030,6 +2217,7 @@ matrix:
                 #[cfg(feature = "contract")]
                 contract: None,
                 schema: None,
+                depends_on: Vec::new(),
                 deferred_refs: refs
                     .iter()
                     .map(|(rid, p)| DeferredRef {
@@ -2095,6 +2283,7 @@ matrix:
             #[cfg(feature = "contract")]
             contract: None,
             schema: None,
+            depends_on: Vec::new(),
             deferred_refs: vec![DeferredRef {
                 referenced_id: "p".into(),
                 dotted_path: "".into(),
@@ -2344,6 +2533,7 @@ matrix:
             #[cfg(feature = "contract")]
             contract: None,
             schema: None,
+            depends_on: Vec::new(),
             deferred_refs: Vec::new(),
         }
     }
@@ -2412,6 +2602,7 @@ matrix:
             #[cfg(feature = "contract")]
             contract: None,
             schema: None,
+            depends_on: Vec::new(),
             deferred_refs: Vec::new(),
         };
         let err = run_expanded(vec![orphan], opts("deadlock"))

--- a/cli/src/expand.rs
+++ b/cli/src/expand.rs
@@ -51,6 +51,10 @@ pub struct ExpandedNode {
     /// Delivery guarantee for this row. Resolved from the row's override or
     /// falls back to the top-level `cfg.delivery`.
     pub delivery: faucet_core::DeliveryMode,
+    /// Row ids this node waits for (deduplicated, declaration order). The
+    /// executor starts the node only after every listed row's invocations
+    /// finish successfully; a failed or skipped dependency skips this node.
+    pub depends_on: Vec<String>,
     /// Every `${id.path}` placeholder that survived load-time interpolation.
     /// Populated by `collect_deferred`; the executor uses this to know
     /// which parent record to feed which row.
@@ -217,6 +221,7 @@ pub fn expand(cfg: &PipelineConfig) -> CliResult<Vec<ExpandedNode>> {
         synthetic_row = [MatrixRow {
             id: None,
             parent: None,
+            depends_on: Vec::new(),
             parent_key: "id".into(),
             source: None,
             sink: None,
@@ -269,6 +274,35 @@ pub fn expand(cfg: &PipelineConfig) -> CliResult<Vec<ExpandedNode>> {
         }
     }
     detect_cycle(&parents)?;
+
+    // 2b) Validate `depends_on` edges (unknown id, self-dependency) and
+    // dedup each row's list while preserving declaration order. Then check
+    // the *combined* parent + depends_on graph for cycles — `detect_cycle`
+    // above only walks single-parent chains, so a cycle routed through a
+    // `depends_on` edge would otherwise deadlock the executor at run time.
+    let mut deps_by_row: Vec<Vec<String>> = Vec::with_capacity(rows.len());
+    for (i, row) in rows.iter().enumerate() {
+        let id = ids[i].as_str();
+        let mut deps: Vec<String> = Vec::with_capacity(row.depends_on.len());
+        for dep in &row.depends_on {
+            if !id_set.contains(dep.as_str()) {
+                return Err(CliError::UnknownDependency {
+                    id: id.to_owned(),
+                    depends_on: dep.clone(),
+                });
+            }
+            if dep == id {
+                return Err(CliError::DependencyCycle {
+                    ids: vec![id.to_owned()],
+                });
+            }
+            if !deps.contains(dep) {
+                deps.push(dep.clone());
+            }
+        }
+        deps_by_row.push(deps);
+    }
+    detect_combined_cycle(&ids, &parents, &deps_by_row)?;
 
     // 3) Validate `${id.path}` references — each `id` must be a known row.
     // We scan the *raw* (pre-merge) row configs because interpolation lives in
@@ -635,6 +669,7 @@ pub fn expand(cfg: &PipelineConfig) -> CliResult<Vec<ExpandedNode>> {
             #[cfg(feature = "contract")]
             contract,
             schema: cfg.pipeline.schema.clone(),
+            depends_on: deps_by_row[i].clone(),
             deferred_refs: deferred,
         });
     }
@@ -659,6 +694,58 @@ fn detect_cycle(parents: &HashMap<&str, &str>) -> CliResult<()> {
                 return Err(CliError::ParentCycle { ids: chain });
             }
         }
+    }
+    Ok(())
+}
+
+/// Kahn's algorithm over the combined `parent:` + `depends_on:` edge set.
+/// Pure-parent cycles are already caught by [`detect_cycle`] (with its more
+/// specific error), so any leftover here necessarily involves a `depends_on`
+/// edge. Rows that cannot be topologically ordered are the cycle participants
+/// (plus any rows downstream of them — still actionable, since the report
+/// names every row that would never become ready).
+fn detect_combined_cycle(
+    ids: &[String],
+    parents: &HashMap<&str, &str>,
+    deps_by_row: &[Vec<String>],
+) -> CliResult<()> {
+    let index_of: HashMap<&str, usize> = ids
+        .iter()
+        .enumerate()
+        .map(|(i, id)| (id.as_str(), i))
+        .collect();
+    let mut in_degree = vec![0usize; ids.len()];
+    let mut dependents: Vec<Vec<usize>> = vec![Vec::new(); ids.len()];
+    for (i, id) in ids.iter().enumerate() {
+        let mut prereqs: Vec<usize> = Vec::new();
+        if let Some(p) = parents.get(id.as_str()) {
+            prereqs.push(index_of[p]);
+        }
+        prereqs.extend(deps_by_row[i].iter().map(|d| index_of[d.as_str()]));
+        for p in prereqs {
+            in_degree[i] += 1;
+            dependents[p].push(i);
+        }
+    }
+    let mut queue: std::collections::VecDeque<usize> =
+        (0..ids.len()).filter(|&i| in_degree[i] == 0).collect();
+    let mut processed = 0usize;
+    while let Some(i) = queue.pop_front() {
+        processed += 1;
+        for &d in &dependents[i] {
+            in_degree[d] -= 1;
+            if in_degree[d] == 0 {
+                queue.push_back(d);
+            }
+        }
+    }
+    if processed < ids.len() {
+        let mut stuck: Vec<String> = (0..ids.len())
+            .filter(|&i| in_degree[i] > 0)
+            .map(|i| ids[i].clone())
+            .collect();
+        stuck.sort();
+        return Err(CliError::DependencyCycle { ids: stuck });
     }
     Ok(())
 }
@@ -929,6 +1016,112 @@ matrix:
             expand(&c).unwrap_err(),
             CliError::ParentCycle { .. }
         ));
+    }
+
+    #[test]
+    fn errors_on_unknown_dependency() {
+        let c = cfg(r#"
+version: 1
+pipeline: { source: { type: rest, config: {} }, sink: { type: jsonl, config: { path: ./o } } }
+matrix:
+  - { id: facts, depends_on: [nobody] }
+"#);
+        match expand(&c).unwrap_err() {
+            CliError::UnknownDependency { id, depends_on } => {
+                assert_eq!(id, "facts");
+                assert_eq!(depends_on, "nobody");
+            }
+            other => panic!("expected UnknownDependency, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn errors_on_self_dependency() {
+        let c = cfg(r#"
+version: 1
+pipeline: { source: { type: rest, config: {} }, sink: { type: jsonl, config: { path: ./o } } }
+matrix:
+  - { id: a, depends_on: [a] }
+"#);
+        match expand(&c).unwrap_err() {
+            CliError::DependencyCycle { ids } => assert_eq!(ids, vec!["a".to_string()]),
+            other => panic!("expected DependencyCycle, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn errors_on_depends_on_cycle() {
+        let c = cfg(r#"
+version: 1
+pipeline: { source: { type: rest, config: {} }, sink: { type: jsonl, config: { path: ./o } } }
+matrix:
+  - { id: a, depends_on: [b] }
+  - { id: b, depends_on: [a] }
+"#);
+        match expand(&c).unwrap_err() {
+            CliError::DependencyCycle { ids } => {
+                assert_eq!(ids, vec!["a".to_string(), "b".to_string()]);
+            }
+            other => panic!("expected DependencyCycle, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn errors_on_mixed_parent_depends_on_cycle() {
+        // `a` is a child of `b` (parent edge b -> a) while `b` waits for `a`
+        // (dependency edge a -> b). Neither the parent-only walk nor a
+        // depends_on-only check sees this — only the combined graph does.
+        let c = cfg(r#"
+version: 1
+pipeline: { source: { type: rest, config: {} }, sink: { type: jsonl, config: { path: ./o } } }
+matrix:
+  - { id: a, parent: b }
+  - { id: b, depends_on: [a] }
+"#);
+        match expand(&c).unwrap_err() {
+            CliError::DependencyCycle { ids } => {
+                assert_eq!(ids, vec!["a".to_string(), "b".to_string()]);
+            }
+            other => panic!("expected DependencyCycle, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn depends_on_is_recorded_and_deduped() {
+        let c = cfg(r#"
+version: 1
+pipeline: { source: { type: rest, config: {} }, sink: { type: jsonl, config: { path: ./o } } }
+matrix:
+  - { id: dims }
+  - { id: staging }
+  - { id: facts, depends_on: [dims, staging, dims] }
+"#);
+        let nodes = expand(&c).unwrap();
+        let facts = nodes.iter().find(|n| n.id == "facts").unwrap();
+        assert_eq!(
+            facts.depends_on,
+            vec!["dims".to_string(), "staging".to_string()]
+        );
+        assert!(matches!(facts.role, NodeRole::Root));
+        let dims = nodes.iter().find(|n| n.id == "dims").unwrap();
+        assert!(dims.depends_on.is_empty());
+    }
+
+    #[test]
+    fn depends_on_may_target_a_child_row() {
+        // Waiting on a per-record fan-out row is legal: the dependent starts
+        // only after every one of the child's invocations completes.
+        let c = cfg(r#"
+version: 1
+pipeline: { source: { type: rest, config: {} }, sink: { type: jsonl, config: { path: ./o } } }
+matrix:
+  - { id: users }
+  - { id: posts, parent: users }
+  - { id: rollup, depends_on: [posts] }
+"#);
+        let nodes = expand(&c).unwrap();
+        let rollup = nodes.iter().find(|n| n.id == "rollup").unwrap();
+        assert_eq!(rollup.depends_on, vec!["posts".to_string()]);
     }
 
     #[test]

--- a/docs/book/src/reference/config.md
+++ b/docs/book/src/reference/config.md
@@ -227,6 +227,41 @@ replace). A row with `parent:` runs once per parent record. See the
 rows, define named templates under `pipeline.sources` / `pipeline.sinks` and
 select them per row with `ref:`.
 
+### `depends_on` — completion ordering between rows
+
+A row with `depends_on: [row_id, …]` starts only after **every listed row's
+invocations finish successfully**. Unlike `parent:`, no records are consumed
+and there is no per-record fan-out — it is pure run ordering ("load
+dimensions, then facts"), typically paired with a downstream row whose source
+reads what the upstream row's sink wrote.
+
+```yaml
+matrix:
+  - id: dims
+    source: { config: { query: "SELECT * FROM src_dims" } }
+    sink:   { config: { table_name: dims } }
+  - id: facts
+    depends_on: [dims]        # starts only after `dims` succeeds
+    source: { config: { query: "SELECT * FROM src_facts" } }
+    sink:   { config: { table_name: facts } }
+```
+
+Semantics:
+
+- Rows whose dependencies are all satisfied run concurrently under the usual
+  `execution.max_concurrent` budget.
+- A failed or skipped dependency **skips** the dependent row (and its own
+  children and dependents in turn); the run's exit code reflects the original
+  failure.
+- Waiting on a row waits for that row's own invocations only. To also wait
+  for its per-record children, list them explicitly.
+- `parent:` and `depends_on:` compose on the same row (the parent edge is an
+  implicit dependency).
+- Unknown ids, self-dependencies, and cycles through any mix of `parent:` /
+  `depends_on:` edges are rejected at load time by `faucet validate`.
+- Ordering works identically under `faucet run`, `schedule`, and `serve` —
+  they all execute the same expanded plan.
+
 ## `auth`
 
 A map of named auth providers, each `{ type, config }` (`type` ∈ `static` /

--- a/docs/book/src/tutorials/matrix-dag.md
+++ b/docs/book/src/tutorials/matrix-dag.md
@@ -55,6 +55,34 @@ matrix:
 The child's state key is suffixed with the parent record's key, so each per-user
 fetch resumes independently.
 
+## Completion ordering with `depends_on`
+
+A row with `depends_on: [row_id, …]` starts only after every listed row's
+invocations finish successfully. Unlike `parent:`, no records are handed off —
+it is pure run ordering, typically with the downstream row's source reading
+what the upstream row's sink wrote:
+
+```yaml
+version: 1
+name: dims_then_facts
+pipeline:
+  source: { type: postgres, config: { connection_url: "postgres://localhost/src" } }
+  sink:   { type: postgres, config: { connection_url: "postgres://localhost/dst", column_mapping: auto_map } }
+matrix:
+  - id: dims
+    source: { config: { query: "SELECT * FROM src_dims" } }
+    sink:   { config: { table_name: dims } }
+  - id: facts
+    depends_on: [dims]     # waits for dims to succeed
+    source: { config: { query: "SELECT * FROM src_facts" } }
+    sink:   { config: { table_name: facts } }
+```
+
+A failed or skipped dependency skips the dependent row (and its own children
+and dependents). Unknown ids, self-dependencies, and cycles through any mix of
+`parent:` / `depends_on:` edges are rejected by `faucet validate`. `parent:`
+and `depends_on:` compose on the same row.
+
 ## Merge semantics
 
 A row is deep-merged onto the base `pipeline`: scalars replace, objects merge

--- a/examples/README.md
+++ b/examples/README.md
@@ -75,6 +75,7 @@ The service column lists what each example touches; all are provided by
 | `mongodb_to_redis.yaml`, `xml_to_mongodb.yaml` | mongodb (single-node replica set; query mode connects to the primary) |
 | `webhook_to_csv.yaml`, `webhook_to_http.yaml`, `grpc_to_http.yaml` | none external beyond the source/HTTP target |
 | `dag_users_posts.yaml`, `rest_users_posts_dag.yaml`, `rest_to_bigquery_matrix.yaml`, `templates_*.yaml` | demonstrate matrix / DAG / template syntax (REST source) |
+| `matrix_depends_on.yaml` | demonstrates `depends_on` completion ordering between matrix rows (local CSV/JSONL, no infra) |
 
 ## Cloud credentials required (not in the stack)
 


### PR DESCRIPTION
## Summary

Adds `depends_on: [row_id, …]` to matrix rows (#195, rescoped design): a row starts only after every listed row's invocations finish successfully. Unlike `parent:`, no records are consumed and there is no per-record fan-out — it is pure completion ordering ("load dims, then facts"; "ingest raw, then run the rollup whose source reads what the first row wrote"), removing the need for an external orchestrator for run-level sequencing.

## Design

- **`config.rs`** — `MatrixRow.depends_on: Vec<String>` (serde default empty; fully backward compatible).
- **`expand.rs`** — validates `depends_on` at load time: `UnknownDependency` for unknown ids, `DependencyCycle` for self-deps and for cycles through **any mix** of `parent:` / `depends_on:` edges (Kahn's algorithm over the combined graph — the existing single-parent walk can't see mixed cycles). Lists are deduped preserving declaration order and threaded onto `ExpandedNode`.
- **`executor.rs`** — readiness now requires the parent (if any) **and** every dependency to be terminal (completed or skipped). A failed or skipped dependency skips the dependent row, cascading exactly like the failed-parent subtree under `on_error: continue`. `parent:` and `depends_on:` compose on the same row.
- **All runtimes for free** — `run` / `schedule` / `serve` / `replicate` all flow through `expand` + `run_expanded`, so ordering works everywhere with zero new CLI surface.
- **`validate`** — per-row output now shows `depends_on=[…]`; rendering extracted into a unit-tested `row_line` helper.

Out of scope (per the issue rescope): cross-config dependencies, tee/merge data-flow topology (#71), inter-row result interpolation.

## Tests

- expand: unknown dependency, self-dependency, two-node `depends_on` cycle, **mixed parent+depends_on cycle**, dedup + declaration order, depending on a child row.
- executor: dependency ordering proven by data flow (downstream row reads the file the upstream row wrote), diamond join (waits for *all* prerequisites), failed dependency skips the dependent, skipped-dependency cascade (parent fails → child skipped → its dependent skipped).
- `faucet validate` row-line rendering.
- Patch coverage measured locally with `cargo llvm-cov`: **97%+** of changed executable lines.
- New runnable example `cli/examples/matrix_depends_on.yaml` validates and runs end-to-end (covered by the shipped-examples validate test).

## Docs

`cli/README.md` (grammar section + example list), `docs/book/src/reference/config.md` (`matrix` → `depends_on`), `docs/book/src/tutorials/matrix-dag.md`, `examples/README.md`, root `README.md` blurb.

Roadmap: #38.

Closes #195