### PR TITLE
feat(serve): RBAC + audit log for the control plane

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -249,6 +249,7 @@ Auth is mandatory: without `--auth-token`/`FAUCET_SERVE_AUTH_TOKEN` **and** with
 |------|---------|
 | `--listen <addr>` | Bind address (default `127.0.0.1:8080`; env `FAUCET_SERVE_LISTEN`). |
 | `--auth-token <t>` / `--no-auth` | Bearer token (prefer the env var) or explicit no-auth opt-in. |
+| `--auth-config <path>` | RBAC principals file (`{ name, token, role }`; roles `viewer`/`operator`/`admin`) — role enforcement + admin-only `GET /v1/audit`. Mutually exclusive with `--auth-token`/`--no-auth`. |
 | `--max-concurrent-runs` / `--max-queued-runs` | Concurrency + queue caps (submit past the queue → 429 + `Retry-After`). |
 | `--history <url>` | `postgres://…` / `sqlite:…` for durable history (`serve-history-postgres` / `serve-history-sqlite`; default in-memory). |
 | `--default-config <path>` | Workspace defaults merged **under** every submitted run. |

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -190,6 +190,12 @@ pub struct ServeArgs {
     /// unauthenticated server is never accidental.
     #[arg(long)]
     pub no_auth: bool,
+    /// Path to an RBAC auth config (YAML/JSON) defining principals — each a
+    /// `{ name, token, role }` where role is `viewer` / `operator` / `admin`.
+    /// Enables role-based access control + an audit log. Mutually exclusive with
+    /// `--auth-token` / `--no-auth`.
+    #[arg(long, conflicts_with_all = ["auth_token", "no_auth"])]
+    pub auth_config: Option<std::path::PathBuf>,
     /// Max pipeline runs executing at once. Default: min(16, cpu count).
     #[arg(long)]
     pub max_concurrent_runs: Option<usize>,

--- a/cli/src/serve/audit.rs
+++ b/cli/src/serve/audit.rs
@@ -1,0 +1,38 @@
+//! Audit-log writing for the control plane (RBAC, #205). One choke point both
+//! the auth middleware (denials) and the run handlers (submit / cancel / delete)
+//! funnel through, so every audit record is built the same way and a write
+//! failure is logged — never silently dropped, and never fails the action.
+
+use crate::serve::history::AuditEntry;
+use crate::serve::rbac::AuthContext;
+use crate::serve::state::ServerState;
+
+/// Build + persist one audit record (best-effort). A backend write failure is
+/// logged at WARN and swallowed: auditing must never fail the underlying action,
+/// but the failure is made visible rather than lost.
+pub async fn write(
+    state: &ServerState,
+    ctx: &AuthContext,
+    action: &str,
+    run_id: Option<String>,
+    config_fingerprint: Option<String>,
+    result: &str,
+) {
+    let entry = AuditEntry {
+        id: uuid::Uuid::now_v7().to_string(),
+        timestamp: chrono::Utc::now(),
+        principal: ctx.principal.clone(),
+        role: ctx.role.as_str().to_string(),
+        action: action.to_string(),
+        run_id,
+        config_fingerprint,
+        source_ip: ctx.source_ip.clone(),
+        result: result.to_string(),
+    };
+    if let Err(e) = state.history().record_audit(&entry).await {
+        tracing::warn!(
+            action, principal = %ctx.principal, error = %e,
+            "failed to write audit record"
+        );
+    }
+}

--- a/cli/src/serve/auth.rs
+++ b/cli/src/serve/auth.rs
@@ -1,11 +1,19 @@
-//! Bearer-token authentication for `/v1/*`. Constant-time comparison via
-//! `subtle`; the `Authorization` header is the only accepted credential.
+//! Bearer-token authentication + RBAC authorization for `/v1/*` (#205).
+//! Constant-time comparison via `subtle`; the `Authorization` header is the only
+//! accepted credential. The bearer token resolves (via
+//! [`AuthMode::resolve`](crate::serve::config::AuthMode::resolve)) to an
+//! [`AuthContext`](crate::serve::rbac::AuthContext), the request's matched route declares the required
+//! [`Permission`](crate::serve::rbac::Permission), and a role that lacks it is
+//! denied (`403`) with an audit record.
 
+use crate::serve::audit;
 use crate::serve::error::ServeError;
+use crate::serve::rbac::{self, Role};
 use crate::serve::state::ServerState;
-use axum::extract::{Request, State};
+use axum::extract::{ConnectInfo, MatchedPath, Request, State};
 use axum::middleware::Next;
 use axum::response::Response;
+use std::net::SocketAddr;
 use subtle::ConstantTimeEq;
 
 /// Timing-safe byte-slice equality. Differing lengths return `false` after a
@@ -29,24 +37,88 @@ pub fn authorize_header(header: Option<&str>, expected: &str) -> Result<(), Serv
     }
 }
 
-/// Axum middleware enforcing bearer auth on `/v1/*`. A no-op when the server was
-/// started with `--no-auth`. CORS preflight (`OPTIONS`) is allowed through so
+/// Extract the raw bearer token from an `Authorization: Bearer <token>` header.
+fn bearer_token(headers: &axum::http::HeaderMap) -> Option<&str> {
+    headers
+        .get(axum::http::header::AUTHORIZATION)?
+        .to_str()
+        .ok()?
+        .strip_prefix("Bearer ")
+}
+
+/// Best-effort `run_id` from a `/v1/runs/{id}[/…]` path (for denial audit
+/// attribution). `None` for non-run routes.
+fn extract_run_id(path: &str) -> Option<String> {
+    let rest = path.strip_prefix("/v1/runs/")?;
+    let id = rest.split('/').next()?;
+    (!id.is_empty()).then(|| id.to_string())
+}
+
+/// Axum middleware enforcing bearer auth + RBAC on `/v1/*`. Under `--no-auth`
+/// every request resolves to an implicit `anonymous` admin (all permitted), so
+/// the authz path is uniform. CORS preflight (`OPTIONS`) is allowed through so
 /// browsers (which omit `Authorization` on preflight) work behind a CORS policy.
+///
+/// On success the resolved [`AuthContext`](crate::serve::rbac::AuthContext) is
+/// inserted into the request extensions for handlers (and the audit writer). A
+/// principal whose role lacks the route's required permission gets a `403` and a
+/// `denied` audit record.
 pub async fn require_auth(
     State(state): State<ServerState>,
-    req: Request,
+    mut req: Request,
     next: Next,
 ) -> Result<Response, ServeError> {
     if req.method() == axum::http::Method::OPTIONS {
         return Ok(next.run(req).await);
     }
-    if let Some(expected) = state.auth_token() {
-        let header = req
-            .headers()
-            .get(axum::http::header::AUTHORIZATION)
-            .and_then(|v| v.to_str().ok());
-        authorize_header(header, expected)?;
+
+    let bearer = bearer_token(req.headers());
+    let mut ctx = state
+        .auth_mode()
+        .resolve(bearer)
+        .ok_or(ServeError::Unauthorized)?;
+    // Best-effort source IP (present when the server is served with connect-info;
+    // absent when a handler is called directly in tests).
+    ctx.source_ip = req
+        .extensions()
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|c| c.0.ip().to_string());
+
+    let method = req.method().clone();
+    let matched = req
+        .extensions()
+        .get::<MatchedPath>()
+        .map(|m| m.as_str().to_string());
+
+    // A mapped route requires its permission; an unmapped `/v1` route is
+    // admin-only (fail closed for any endpoint added without an explicit entry).
+    let allowed = match matched.as_deref() {
+        Some(mp) => match rbac::required_permission(&method, mp) {
+            Some(perm) => ctx.role.grants(perm),
+            None => ctx.role == Role::Admin,
+        },
+        None => ctx.role == Role::Admin,
+    };
+
+    if !allowed {
+        let action = matched
+            .as_deref()
+            .map(|mp| rbac::audit_action(&method, mp))
+            .unwrap_or("unknown");
+        let run_id = extract_run_id(req.uri().path());
+        tracing::warn!(
+            principal = %ctx.principal, role = ctx.role.as_str(), action,
+            "RBAC denied a control-plane action"
+        );
+        audit::write(&state, &ctx, action, run_id, None, "denied").await;
+        return Err(ServeError::Forbidden(format!(
+            "principal '{}' (role {}) is not permitted to perform this action",
+            ctx.principal,
+            ctx.role.as_str()
+        )));
     }
+
+    req.extensions_mut().insert(ctx);
     Ok(next.run(req).await)
 }
 

--- a/cli/src/serve/config.rs
+++ b/cli/src/serve/config.rs
@@ -5,15 +5,20 @@
 use crate::cli::ServeArgs;
 use crate::error::{CliError, CliResult};
 use crate::serve::cluster::ClusterConfig;
+use crate::serve::rbac::{AuthContext, RbacConfig, Role};
 use std::net::SocketAddr;
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Duration;
 
 /// How `/v1/*` requests are authenticated.
 #[derive(Clone)]
 pub enum AuthMode {
-    /// Require `Authorization: Bearer <token>`.
+    /// Require `Authorization: Bearer <token>` — a single implicit `admin`
+    /// principal.
     Token(String),
+    /// Multi-principal RBAC from `--auth-config`: bearer token → principal → role.
+    Rbac(Arc<RbacConfig>),
     /// Authentication explicitly disabled via `--no-auth`.
     None,
 }
@@ -26,7 +31,31 @@ impl std::fmt::Debug for AuthMode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             AuthMode::Token(_) => f.debug_tuple("Token").field(&"***").finish(),
+            AuthMode::Rbac(cfg) => f.debug_tuple("Rbac").field(cfg).finish(),
             AuthMode::None => f.write_str("None"),
+        }
+    }
+}
+
+impl AuthMode {
+    /// Resolve a request's `Authorization: Bearer` token to its [`AuthContext`],
+    /// or `None` if the credential is missing / invalid. `--no-auth` yields an
+    /// implicit `anonymous` admin so downstream authz + audit are uniform.
+    pub fn resolve(&self, bearer: Option<&str>) -> Option<AuthContext> {
+        match self {
+            AuthMode::None => Some(AuthContext {
+                principal: "anonymous".to_string(),
+                role: Role::Admin,
+                source_ip: None,
+            }),
+            AuthMode::Token(expected) => bearer
+                .filter(|t| crate::serve::auth::constant_time_eq(t.as_bytes(), expected.as_bytes()))
+                .map(|_| AuthContext {
+                    principal: "token".to_string(),
+                    role: Role::Admin,
+                    source_ip: None,
+                }),
+            AuthMode::Rbac(cfg) => bearer.and_then(|t| cfg.authenticate(t)),
         }
     }
 }
@@ -88,27 +117,40 @@ impl ServeConfig {
     /// Build + validate a `ServeConfig` from parsed CLI args. Enforces the
     /// no-auth gate: a server with neither a token nor `--no-auth` refuses to start.
     pub fn from_args(args: ServeArgs) -> CliResult<Self> {
-        let auth = match (args.auth_token, args.no_auth) {
-            (Some(t), _) if t.is_empty() => {
-                return Err(CliError::Serve(
-                    "--auth-token / FAUCET_SERVE_AUTH_TOKEN must not be empty \
-                     (use --no-auth to explicitly disable authentication)"
-                        .into(),
-                ));
+        // RBAC (`--auth-config`) takes precedence and is mutually exclusive with
+        // `--auth-token` / `--no-auth` (enforced by clap `conflicts_with`).
+        let auth = if let Some(path) = args.auth_config {
+            let rbac = RbacConfig::from_file(&path)?;
+            // Register every principal token so the RedactingWriter scrubs it
+            // from any tracing/log/error output for the process lifetime.
+            for token in rbac.tokens() {
+                crate::secrets::registry::register(token);
             }
-            (Some(t), _) => {
-                // Register so the RedactingWriter scrubs the token from any
-                // tracing/log/error output for the lifetime of the process.
-                crate::secrets::registry::register(&t);
-                AuthMode::Token(t)
-            }
-            (None, true) => AuthMode::None,
-            (None, false) => {
-                return Err(CliError::Serve(
-                    "refusing to start without authentication: pass --auth-token \
-                     (or FAUCET_SERVE_AUTH_TOKEN), or --no-auth to explicitly disable it"
-                        .into(),
-                ));
+            AuthMode::Rbac(Arc::new(rbac))
+        } else {
+            match (args.auth_token, args.no_auth) {
+                (Some(t), _) if t.is_empty() => {
+                    return Err(CliError::Serve(
+                        "--auth-token / FAUCET_SERVE_AUTH_TOKEN must not be empty \
+                         (use --no-auth to explicitly disable authentication)"
+                            .into(),
+                    ));
+                }
+                (Some(t), _) => {
+                    // Register so the RedactingWriter scrubs the token from any
+                    // tracing/log/error output for the lifetime of the process.
+                    crate::secrets::registry::register(&t);
+                    AuthMode::Token(t)
+                }
+                (None, true) => AuthMode::None,
+                (None, false) => {
+                    return Err(CliError::Serve(
+                        "refusing to start without authentication: pass --auth-token \
+                         (or FAUCET_SERVE_AUTH_TOKEN), --auth-config <file> for RBAC, \
+                         or --no-auth to explicitly disable it"
+                            .into(),
+                    ));
+                }
             }
         };
 
@@ -226,6 +268,7 @@ mod tests {
         crate::cli::ServeArgs {
             listen: "127.0.0.1:8080".into(),
             auth_token: None,
+            auth_config: None,
             no_auth: false,
             max_concurrent_runs: None,
             max_queued_runs: None,
@@ -268,6 +311,70 @@ mod tests {
         a.auth_token = Some("hunter2".into());
         let cfg = ServeConfig::from_args(a).unwrap();
         assert!(matches!(cfg.auth, AuthMode::Token(t) if t == "hunter2"));
+    }
+
+    #[test]
+    fn resolve_none_is_anonymous_admin() {
+        let ctx = AuthMode::None.resolve(None).unwrap();
+        assert_eq!(ctx.principal, "anonymous");
+        assert_eq!(ctx.role, Role::Admin);
+    }
+
+    #[test]
+    fn resolve_token_matches_only_exact() {
+        let mode = AuthMode::Token("s3cret".into());
+        let ctx = mode.resolve(Some("s3cret")).unwrap();
+        assert_eq!(ctx.principal, "token");
+        assert_eq!(ctx.role, Role::Admin);
+        assert!(mode.resolve(Some("wrong")).is_none());
+        assert!(mode.resolve(None).is_none());
+    }
+
+    #[test]
+    fn resolve_rbac_maps_token_to_principal() {
+        use crate::serve::rbac::{PrincipalSpec, RbacConfig};
+        let cfg = RbacConfig::new(vec![PrincipalSpec {
+            name: "bob".into(),
+            token: "viewer-tok".into(),
+            role: Role::Viewer,
+        }])
+        .unwrap();
+        let mode = AuthMode::Rbac(Arc::new(cfg));
+        let ctx = mode.resolve(Some("viewer-tok")).unwrap();
+        assert_eq!(ctx.principal, "bob");
+        assert_eq!(ctx.role, Role::Viewer);
+        assert!(mode.resolve(Some("nope")).is_none());
+    }
+
+    #[test]
+    fn auth_config_file_builds_rbac_and_registers_tokens() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth.yaml");
+        std::fs::write(
+            &path,
+            "principals:\n  - name: carol\n    token: rbacsecret12345\n    role: operator\n",
+        )
+        .unwrap();
+        let mut a = base_args();
+        a.auth_config = Some(path);
+        let cfg = ServeConfig::from_args(a).unwrap();
+        assert!(matches!(cfg.auth, AuthMode::Rbac(_)));
+        // Every principal token must be registered for log redaction.
+        let scrubbed = crate::secrets::registry::redact("t=rbacsecret12345 end").into_owned();
+        assert!(!scrubbed.contains("rbacsecret12345"), "{scrubbed}");
+    }
+
+    #[test]
+    fn auth_config_debug_masks_tokens() {
+        use crate::serve::rbac::{PrincipalSpec, RbacConfig};
+        let cfg = RbacConfig::new(vec![PrincipalSpec {
+            name: "x".into(),
+            token: "supersecretrbac".into(),
+            role: Role::Admin,
+        }])
+        .unwrap();
+        let s = format!("{:?}", AuthMode::Rbac(Arc::new(cfg)));
+        assert!(!s.contains("supersecretrbac"), "rbac token leaked: {s}");
     }
 
     #[test]

--- a/cli/src/serve/error.rs
+++ b/cli/src/serve/error.rs
@@ -24,6 +24,8 @@ pub struct ApiErrorBody {
 #[derive(Debug)]
 pub enum ServeError {
     Unauthorized,
+    /// 403 — authenticated but the principal's role lacks the required permission.
+    Forbidden(String),
     NotFound,
     BadConfig(String),
     /// 422 — expand/validation failure or a failed `doctor_first` preflight;
@@ -48,6 +50,7 @@ impl ServeError {
     pub fn status(&self) -> StatusCode {
         match self {
             ServeError::Unauthorized => StatusCode::UNAUTHORIZED,
+            ServeError::Forbidden(_) => StatusCode::FORBIDDEN,
             ServeError::NotFound => StatusCode::NOT_FOUND,
             ServeError::BadConfig(_) => StatusCode::BAD_REQUEST,
             ServeError::Unprocessable { .. } => StatusCode::UNPROCESSABLE_ENTITY,
@@ -61,6 +64,7 @@ impl ServeError {
     fn code(&self) -> &'static str {
         match self {
             ServeError::Unauthorized => "unauthorized",
+            ServeError::Forbidden(_) => "forbidden",
             ServeError::NotFound => "not_found",
             ServeError::BadConfig(_) => "bad_config",
             ServeError::Unprocessable { .. } => "unprocessable",
@@ -74,6 +78,7 @@ impl ServeError {
     fn message(&self) -> String {
         match self {
             ServeError::Unauthorized => "missing or invalid bearer token".into(),
+            ServeError::Forbidden(m) => m.clone(),
             ServeError::NotFound => "not found".into(),
             ServeError::BadConfig(m) => m.clone(),
             ServeError::Unprocessable { message, .. } => message.clone(),

--- a/cli/src/serve/handlers/audit.rs
+++ b/cli/src/serve/handlers/audit.rs
@@ -1,0 +1,79 @@
+//! `GET /v1/audit` — read the control-plane audit log (RBAC, #205). The route
+//! requires the `AuditRead` permission (admin-only), enforced by the auth
+//! middleware, so reaching this handler already means the caller is authorized.
+
+use crate::serve::error::ServeError;
+use crate::serve::history::{AuditEntry, AuditFilter};
+use crate::serve::state::ServerState;
+use axum::Json;
+use axum::extract::{Query, State};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+const DEFAULT_LIMIT: usize = 100;
+const MAX_LIMIT: usize = 1000;
+
+/// `GET /v1/audit` query string.
+#[derive(Debug, Deserialize)]
+pub struct AuditQuery {
+    pub principal: Option<String>,
+    pub action: Option<String>,
+    pub since: Option<String>,
+    pub until: Option<String>,
+    pub limit: Option<usize>,
+}
+
+/// `GET /v1/audit` response body.
+#[derive(Debug, Serialize)]
+pub struct AuditListResponse {
+    pub entries: Vec<AuditEntry>,
+}
+
+/// Parse an RFC3339 query timestamp, restoring the `+` that form-encoding turns
+/// into a space (so explicit offsets like `+05:30` survive).
+fn parse_ts(raw: &str, field: &str) -> Result<DateTime<Utc>, ServeError> {
+    DateTime::parse_from_rfc3339(&raw.replace(' ', "+"))
+        .map(|d| d.to_utc())
+        .map_err(|e| ServeError::BadConfig(format!("invalid `{field}` timestamp: {e}")))
+}
+
+/// `GET /v1/audit` → 200.
+pub async fn list_audit(
+    State(state): State<ServerState>,
+    Query(query): Query<AuditQuery>,
+) -> Result<Json<AuditListResponse>, ServeError> {
+    let filter = AuditFilter {
+        principal: query.principal,
+        action: query.action,
+        since: query
+            .since
+            .as_deref()
+            .map(|s| parse_ts(s, "since"))
+            .transpose()?,
+        until: query
+            .until
+            .as_deref()
+            .map(|s| parse_ts(s, "until"))
+            .transpose()?,
+        limit: query.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT),
+    };
+    let entries = state
+        .history()
+        .list_audit(&filter)
+        .await
+        .map_err(|e| ServeError::Internal(e.to_string()))?;
+    Ok(Json(AuditListResponse { entries }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_ts_accepts_z_and_offset() {
+        assert!(parse_ts("2026-01-01T00:00:00Z", "since").is_ok());
+        // Space in place of '+' (form-encoded offset) is restored.
+        assert!(parse_ts("2026-01-01T00:00:00 05:30", "since").is_ok());
+        assert!(parse_ts("not-a-date", "since").is_err());
+    }
+}

--- a/cli/src/serve/handlers/mod.rs
+++ b/cli/src/serve/handlers/mod.rs
@@ -1,4 +1,5 @@
 //! serve HTTP handlers.
+pub mod audit;
 pub mod doctor;
 pub mod health;
 pub mod logs;

--- a/cli/src/serve/handlers/runs.rs
+++ b/cli/src/serve/handlers/runs.rs
@@ -3,10 +3,11 @@
 
 use crate::serve::error::ServeError;
 use crate::serve::history::{DeleteOutcome, ListFilter, RunRecord, RunStatus};
+use crate::serve::rbac::AuthContext;
 use crate::serve::runner::{self, SubmitRequest, SubmitResponse};
 use crate::serve::state::ServerState;
 use axum::Json;
-use axum::extract::{Path, Query, State};
+use axum::extract::{Extension, Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use chrono::{DateTime, Utc};
@@ -27,12 +28,14 @@ fn redact_record(rec: &mut RunRecord) {
     }
 }
 
-/// `POST /v1/runs` → 202.
+/// `POST /v1/runs` → 202. The auth middleware injects the resolved
+/// [`AuthContext`] so `submit` can attribute the `run.submit` audit record.
 pub async fn submit_run(
     State(state): State<ServerState>,
+    Extension(actor): Extension<AuthContext>,
     Json(req): Json<SubmitRequest>,
 ) -> Result<(StatusCode, Json<SubmitResponse>), ServeError> {
-    let resp = runner::submit(state, req).await?;
+    let resp = runner::submit(state, req, actor).await?;
     Ok((StatusCode::ACCEPTED, Json(resp)))
 }
 
@@ -64,10 +67,13 @@ pub async fn get_run(
 /// instance before that instance processes the flag.
 pub async fn cancel_run(
     State(state): State<ServerState>,
+    Extension(actor): Extension<AuthContext>,
     Path(id): Path<String>,
 ) -> Result<impl IntoResponse, ServeError> {
     // 1. A live local token (this instance is running/queued it) → cancel now.
     if state.registry().cancel(&id) {
+        crate::serve::audit::write(&state, &actor, "run.cancel", Some(id.clone()), None, "ok")
+            .await;
         return Ok(StatusCode::ACCEPTED);
     }
 
@@ -95,6 +101,8 @@ pub async fn cancel_run(
             .await
             .map_err(|e| ServeError::Internal(e.to_string()))?
         {
+            crate::serve::audit::write(&state, &actor, "run.cancel", Some(id.clone()), None, "ok")
+                .await;
             return Ok(StatusCode::ACCEPTED);
         }
         // Otherwise it is running on a peer → flag it; the peer cancels on its
@@ -104,6 +112,8 @@ pub async fn cancel_run(
             .request_cancel(&id)
             .await
             .map_err(|e| ServeError::Internal(e.to_string()))?;
+        crate::serve::audit::write(&state, &actor, "run.cancel", Some(id.clone()), None, "ok")
+            .await;
         return Ok(StatusCode::ACCEPTED);
     }
 
@@ -116,6 +126,7 @@ pub async fn cancel_run(
 /// `DELETE /v1/runs/{id}` → 204 / 404 / 409 (still running).
 pub async fn delete_run(
     State(state): State<ServerState>,
+    Extension(actor): Extension<AuthContext>,
     Path(id): Path<String>,
 ) -> Result<StatusCode, ServeError> {
     match state
@@ -124,7 +135,11 @@ pub async fn delete_run(
         .await
         .map_err(|e| ServeError::Internal(e.to_string()))?
     {
-        DeleteOutcome::Deleted => Ok(StatusCode::NO_CONTENT),
+        DeleteOutcome::Deleted => {
+            crate::serve::audit::write(&state, &actor, "run.delete", Some(id.clone()), None, "ok")
+                .await;
+            Ok(StatusCode::NO_CONTENT)
+        }
         DeleteOutcome::NotFound => Err(ServeError::NotFound),
         DeleteOutcome::StillRunning => Err(ServeError::Conflict(
             "run is still in flight — cancel it before deleting".into(),
@@ -306,6 +321,11 @@ mod tests {
 
         let resp = cancel_run(
             axum::extract::State(state.clone()),
+            axum::extract::Extension(AuthContext {
+                principal: "test".into(),
+                role: crate::serve::rbac::Role::Admin,
+                source_ip: None,
+            }),
             axum::extract::Path("p1".into()),
         )
         .await

--- a/cli/src/serve/history/fallback.rs
+++ b/cli/src/serve/history/fallback.rs
@@ -9,8 +9,8 @@
 
 use super::memory::MemoryHistory;
 use super::{
-    Claim, DeleteOutcome, HistoryError, InstanceHeartbeat, InstanceRecord, ListFilter, ListPage,
-    ReclaimReport, RunHistory, RunRecord, RunStatus,
+    AuditEntry, AuditFilter, Claim, DeleteOutcome, HistoryError, InstanceHeartbeat, InstanceRecord,
+    ListFilter, ListPage, ReclaimReport, RunHistory, RunRecord, RunStatus,
 };
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
@@ -238,6 +238,13 @@ impl RunHistory for FallbackHistory {
     }
     async fn finalize_completed_sharded_parents(&self) -> Result<usize, HistoryError> {
         via!(self, p => p.finalize_completed_sharded_parents(), f => f.finalize_completed_sharded_parents())
+    }
+
+    async fn record_audit(&self, entry: &AuditEntry) -> Result<(), HistoryError> {
+        via!(self, p => p.record_audit(entry), f => f.record_audit(entry))
+    }
+    async fn list_audit(&self, filter: &AuditFilter) -> Result<Vec<AuditEntry>, HistoryError> {
+        via!(self, p => p.list_audit(filter), f => f.list_audit(filter))
     }
 
     fn degraded(&self) -> bool {

--- a/cli/src/serve/history/memory.rs
+++ b/cli/src/serve/history/memory.rs
@@ -2,11 +2,20 @@
 //! documented memory-backend trade-off. Idempotency claims live in a second map
 //! and are pruned both lazily (on re-claim) and by `purge_expired`.
 
-use super::{Claim, DeleteOutcome, HistoryError, ListFilter, ListPage, RunHistory, RunRecord};
+use super::{
+    AuditEntry, AuditFilter, Claim, DeleteOutcome, HistoryError, ListFilter, ListPage, RunHistory,
+    RunRecord,
+};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use dashmap::DashMap;
+use std::collections::VecDeque;
+use std::sync::Mutex;
 use std::time::Duration;
+
+/// Cap on in-memory audit records (oldest dropped past this). The memory backend
+/// is ephemeral anyway; this just bounds growth for a long-lived process.
+const AUDIT_RING_CAP: usize = 10_000;
 
 struct IdemEntry {
     run_id: String,
@@ -17,6 +26,8 @@ struct IdemEntry {
 pub struct MemoryHistory {
     runs: DashMap<String, RunRecord>,
     idem: DashMap<String, IdemEntry>,
+    /// Bounded, newest-at-back ring of audit records (RBAC, #205).
+    audit: Mutex<VecDeque<AuditEntry>>,
     /// Retention window for idempotency claims (separate from run retention).
     idem_retention: Duration,
 }
@@ -26,6 +37,7 @@ impl MemoryHistory {
         Self {
             runs: DashMap::new(),
             idem: DashMap::new(),
+            audit: Mutex::new(VecDeque::new()),
             idem_retention,
         }
     }
@@ -158,7 +170,42 @@ impl RunHistory for MemoryHistory {
         // Also drop stale idempotency claims so the map stays bounded.
         self.idem
             .retain(|_, e| !is_expired(e.claimed_at, now, self.idem_retention));
+        // Trim audit records older than the run-retention window.
+        if let Ok(mut ring) = self.audit.lock() {
+            ring.retain(|e| !is_expired(e.timestamp, now, retain_for));
+        }
         Ok(before.saturating_sub(self.runs.len()))
+    }
+
+    async fn record_audit(&self, entry: &AuditEntry) -> Result<(), HistoryError> {
+        let mut ring = self
+            .audit
+            .lock()
+            .map_err(|_| HistoryError::Backend("audit ring lock poisoned".into()))?;
+        ring.push_back(entry.clone());
+        while ring.len() > AUDIT_RING_CAP {
+            ring.pop_front();
+        }
+        Ok(())
+    }
+
+    async fn list_audit(&self, filter: &AuditFilter) -> Result<Vec<AuditEntry>, HistoryError> {
+        let ring = self
+            .audit
+            .lock()
+            .map_err(|_| HistoryError::Backend("audit ring lock poisoned".into()))?;
+        let mut rows: Vec<AuditEntry> = ring
+            .iter()
+            .filter(|e| filter.principal.as_deref().is_none_or(|p| e.principal == p))
+            .filter(|e| filter.action.as_deref().is_none_or(|a| e.action == a))
+            .filter(|e| filter.since.is_none_or(|t| e.timestamp >= t))
+            .filter(|e| filter.until.is_none_or(|t| e.timestamp <= t))
+            .cloned()
+            .collect();
+        // Newest first (timestamp DESC, id DESC).
+        rows.sort_by(|a, b| b.timestamp.cmp(&a.timestamp).then_with(|| b.id.cmp(&a.id)));
+        rows.truncate(filter.limit.max(1));
+        Ok(rows)
     }
 
     async fn recover_orphans(&self) -> Result<usize, HistoryError> {
@@ -399,6 +446,100 @@ mod tests {
             .unwrap();
         assert_eq!(by_name.runs.len(), 1);
         assert_eq!(by_name.runs[0].run_id, "x");
+    }
+
+    #[tokio::test]
+    async fn audit_record_list_filter_and_purge() {
+        use crate::serve::history::{AuditEntry, AuditFilter};
+        let h = MemoryHistory::new(Duration::from_secs(60));
+        let now = Utc::now();
+        let entry =
+            |id: &str, principal: &str, action: &str, result: &str, ts: DateTime<Utc>| AuditEntry {
+                id: id.into(),
+                timestamp: ts,
+                principal: principal.into(),
+                role: "admin".into(),
+                action: action.into(),
+                run_id: None,
+                config_fingerprint: None,
+                source_ip: None,
+                result: result.into(),
+            };
+        h.record_audit(&entry(
+            "1",
+            "alice",
+            "run.submit",
+            "ok",
+            now - chrono::Duration::seconds(2),
+        ))
+        .await
+        .unwrap();
+        h.record_audit(&entry(
+            "2",
+            "bob",
+            "run.submit",
+            "denied",
+            now - chrono::Duration::seconds(1),
+        ))
+        .await
+        .unwrap();
+        h.record_audit(&entry("3", "alice", "run.cancel", "ok", now))
+            .await
+            .unwrap();
+
+        // Newest first, no filter.
+        let all = h
+            .list_audit(&AuditFilter {
+                limit: 50,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(all.len(), 3);
+        assert_eq!(all[0].id, "3", "newest first");
+
+        // Filter by principal + action.
+        let alice = h
+            .list_audit(&AuditFilter {
+                principal: Some("alice".into()),
+                limit: 50,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(alice.len(), 2);
+        assert!(alice.iter().all(|e| e.principal == "alice"));
+
+        let denied = h
+            .list_audit(&AuditFilter {
+                action: Some("run.submit".into()),
+                limit: 50,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(denied.len(), 2);
+
+        // Limit is honoured.
+        let one = h
+            .list_audit(&AuditFilter {
+                limit: 1,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(one.len(), 1);
+
+        // purge_expired(0) drops all audit records (every ts is "expired").
+        h.purge_expired(Duration::ZERO).await.unwrap();
+        let after = h
+            .list_audit(&AuditFilter {
+                limit: 50,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert!(after.is_empty(), "audit purge should clear expired entries");
     }
 
     #[tokio::test]

--- a/cli/src/serve/history/mod.rs
+++ b/cli/src/serve/history/mod.rs
@@ -266,6 +266,44 @@ impl ShardProgress {
     }
 }
 
+/// One audit-log record: a mutating (or denied) control-plane action attributed
+/// to a principal (#205). Persisted in `faucet_serve_audit` (SQL backends) or an
+/// in-memory ring (memory backend), and surfaced by `GET /v1/audit`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuditEntry {
+    /// Time-ordered id (UUIDv7) — also the ordering key.
+    pub id: String,
+    pub timestamp: DateTime<Utc>,
+    /// Principal name (`"anonymous"` under `--no-auth`, `"token"` under a single
+    /// `--auth-token`, `trigger:<name>` for trigger-originated runs).
+    pub principal: String,
+    /// Role at the time of the action.
+    pub role: String,
+    /// Stable action label (`run.submit` / `run.cancel` / `run.delete` /
+    /// `trigger.fire` / `auth.denied` / …).
+    pub action: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    /// sha256 config fingerprint (submit actions only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config_fingerprint: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_ip: Option<String>,
+    /// Outcome: `"ok"` (action performed) or `"denied"` (403 — insufficient role).
+    pub result: String,
+}
+
+/// Filter + limit for `list_audit` (newest-first). No cursor: a bounded,
+/// most-recent view is the audit-console primitive.
+#[derive(Debug, Default, Clone)]
+pub struct AuditFilter {
+    pub principal: Option<String>,
+    pub action: Option<String>,
+    pub since: Option<DateTime<Utc>>,
+    pub until: Option<DateTime<Utc>>,
+    pub limit: usize,
+}
+
 #[async_trait]
 pub trait RunHistory: Send + Sync {
     /// Atomically claim `key` for `run_id` (or report a replay/conflict). A prior
@@ -489,6 +527,23 @@ pub trait RunHistory: Send + Sync {
     /// nothing to finalize.
     async fn finalize_completed_sharded_parents(&self) -> Result<usize, HistoryError> {
         Ok(0)
+    }
+
+    // ── Audit log (RBAC, #205) ───────────────────────────────────────────────
+
+    /// Append one audit record. Best-effort but visible: the caller logs a
+    /// warning on failure (audit writes must never silently vanish, and must
+    /// never fail the underlying action). Default: no-op — overridden by the
+    /// memory + SQL backends.
+    async fn record_audit(&self, entry: &AuditEntry) -> Result<(), HistoryError> {
+        let _ = entry;
+        Ok(())
+    }
+
+    /// Most-recent audit records matching `filter`, newest first. Default: empty.
+    async fn list_audit(&self, filter: &AuditFilter) -> Result<Vec<AuditEntry>, HistoryError> {
+        let _ = filter;
+        Ok(Vec::new())
     }
 
     /// True when the backend is in fallback mode (drives `/readyz`). Always false

--- a/cli/src/serve/history/sql.rs
+++ b/cli/src/serve/history/sql.rs
@@ -79,6 +79,21 @@ pub const DDL: &[&str] = &[
         PRIMARY KEY (run_id, shard_id))",
     "CREATE INDEX IF NOT EXISTS faucet_serve_shards_claim_idx \
         ON faucet_serve_shards (status, lease_expires_at)",
+    // Audit log for RBAC (#205). One row per mutating (or denied) control-plane
+    // action. `id` is a time-ordered UUIDv7; `ts` is fixed-width RFC3339 so the
+    // newest-first ordering and retention purge sort lexicographically.
+    "CREATE TABLE IF NOT EXISTS faucet_serve_audit (\
+        id TEXT PRIMARY KEY,\
+        ts TEXT NOT NULL,\
+        principal TEXT NOT NULL,\
+        role TEXT NOT NULL,\
+        action TEXT NOT NULL,\
+        run_id TEXT,\
+        config_fingerprint TEXT,\
+        source_ip TEXT,\
+        result TEXT NOT NULL)",
+    "CREATE INDEX IF NOT EXISTS faucet_serve_audit_ts_idx \
+        ON faucet_serve_audit (ts)",
 ];
 
 /// SQL placeholder dialect.
@@ -177,6 +192,14 @@ pub struct Stmts {
     /// Purge shard rows whose parent run no longer exists (run-record purged by
     /// retention, F25). No params — a set-difference against `faucet_serve_runs`.
     pub purge_orphan_shards: String,
+    // ── Audit log (RBAC, #205) ───────────────────────────────────────────────
+    /// Append one audit record.
+    pub insert_audit: String,
+    /// Newest-first audit records matching the (nullable) filters. Param order:
+    /// principal, action, since, until, limit.
+    pub list_audit: String,
+    /// Purge audit records older than a threshold (retention).
+    pub purge_audit: String,
 }
 
 impl Stmts {
@@ -338,6 +361,19 @@ impl Stmts {
             purge_orphan_shards: "DELETE FROM faucet_serve_shards \
                 WHERE run_id NOT IN (SELECT run_id FROM faucet_serve_runs)"
                 .into(),
+            insert_audit: "INSERT INTO faucet_serve_audit \
+                (id, ts, principal, role, action, run_id, config_fingerprint, source_ip, result) \
+                VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)"
+                .into(),
+            list_audit: "SELECT id, ts, principal, role, action, run_id, config_fingerprint, \
+                source_ip, result FROM faucet_serve_audit \
+                WHERE ($1::text IS NULL OR principal = $2::text) \
+                AND ($3::text IS NULL OR action = $4::text) \
+                AND ($5::text IS NULL OR ts >= $6::text) \
+                AND ($7::text IS NULL OR ts <= $8::text) \
+                ORDER BY ts DESC, id DESC LIMIT $9"
+                .into(),
+            purge_audit: "DELETE FROM faucet_serve_audit WHERE ts < $1".into(),
         }
     }
 
@@ -490,6 +526,19 @@ impl Stmts {
             purge_orphan_shards: "DELETE FROM faucet_serve_shards \
                 WHERE run_id NOT IN (SELECT run_id FROM faucet_serve_runs)"
                 .into(),
+            insert_audit: "INSERT INTO faucet_serve_audit \
+                (id, ts, principal, role, action, run_id, config_fingerprint, source_ip, result) \
+                VALUES (?,?,?,?,?,?,?,?,?)"
+                .into(),
+            list_audit: "SELECT id, ts, principal, role, action, run_id, config_fingerprint, \
+                source_ip, result FROM faucet_serve_audit \
+                WHERE (? IS NULL OR principal = ?) \
+                AND (? IS NULL OR action = ?) \
+                AND (? IS NULL OR ts >= ?) \
+                AND (? IS NULL OR ts <= ?) \
+                ORDER BY ts DESC, id DESC LIMIT ?"
+                .into(),
+            purge_audit: "DELETE FROM faucet_serve_audit WHERE ts < ?".into(),
         }
     }
 }
@@ -885,6 +934,11 @@ macro_rules! impl_sql_history {
                 // `purge_runs` removed the expired terminal records above, so any
                 // shard row no longer matching a run is orphaned. Best-effort.
                 let _ = sqlx::query(&self.stmts.purge_orphan_shards)
+                    .execute(&self.pool)
+                    .await;
+                // Drop audit records older than the run-retention window (#205).
+                let _ = sqlx::query(&self.stmts.purge_audit)
+                    .bind(sql::threshold(now, retain_for))
                     .execute(&self.pool)
                     .await;
                 Ok(removed)
@@ -1593,6 +1647,82 @@ macro_rules! impl_sql_history {
                     }
                 }
                 Ok(finalized)
+            }
+
+            // ── Audit log (RBAC, #205) ───────────────────────────────────────
+
+            async fn record_audit(
+                &self,
+                entry: &$crate::serve::history::AuditEntry,
+            ) -> Result<(), $crate::serve::history::HistoryError> {
+                use $crate::serve::history::HistoryError;
+                use $crate::serve::history::sql;
+                let backend = |e: sqlx::Error| HistoryError::Backend(e.to_string());
+                sqlx::query(&self.stmts.insert_audit)
+                    .bind(&entry.id)
+                    .bind(sql::fmt_ts(entry.timestamp))
+                    .bind(&entry.principal)
+                    .bind(&entry.role)
+                    .bind(&entry.action)
+                    .bind(entry.run_id.as_deref())
+                    .bind(entry.config_fingerprint.as_deref())
+                    .bind(entry.source_ip.as_deref())
+                    .bind(&entry.result)
+                    .execute(&self.pool)
+                    .await
+                    .map_err(backend)?;
+                Ok(())
+            }
+
+            async fn list_audit(
+                &self,
+                filter: &$crate::serve::history::AuditFilter,
+            ) -> Result<
+                Vec<$crate::serve::history::AuditEntry>,
+                $crate::serve::history::HistoryError,
+            > {
+                use sqlx::Row as _;
+                use $crate::serve::history::AuditEntry;
+                use $crate::serve::history::HistoryError;
+                use $crate::serve::history::sql;
+                let backend = |e: sqlx::Error| HistoryError::Backend(e.to_string());
+                let principal = filter.principal.as_deref();
+                let action = filter.action.as_deref();
+                let since = filter.since.map(sql::fmt_ts);
+                let until = filter.until.map(sql::fmt_ts);
+                let limit = filter.limit.max(1) as i64;
+                let rows = sqlx::query(&self.stmts.list_audit)
+                    .bind(principal)
+                    .bind(principal)
+                    .bind(action)
+                    .bind(action)
+                    .bind(since.as_deref())
+                    .bind(since.as_deref())
+                    .bind(until.as_deref())
+                    .bind(until.as_deref())
+                    .bind(limit)
+                    .fetch_all(&self.pool)
+                    .await
+                    .map_err(backend)?;
+                let mut out = Vec::with_capacity(rows.len());
+                for r in &rows {
+                    let ts: String = r.try_get("ts").map_err(backend)?;
+                    let timestamp = chrono::DateTime::parse_from_rfc3339(&ts)
+                        .map(|d| d.to_utc())
+                        .unwrap_or_else(|_| chrono::Utc::now());
+                    out.push(AuditEntry {
+                        id: r.try_get("id").map_err(backend)?,
+                        timestamp,
+                        principal: r.try_get("principal").map_err(backend)?,
+                        role: r.try_get("role").map_err(backend)?,
+                        action: r.try_get("action").map_err(backend)?,
+                        run_id: r.try_get("run_id").map_err(backend)?,
+                        config_fingerprint: r.try_get("config_fingerprint").map_err(backend)?,
+                        source_ip: r.try_get("source_ip").map_err(backend)?,
+                        result: r.try_get("result").map_err(backend)?,
+                    });
+                }
+                Ok(out)
             }
 
             fn degraded(&self) -> bool {

--- a/cli/src/serve/history/sqlite.rs
+++ b/cli/src/serve/history/sqlite.rs
@@ -232,6 +232,80 @@ mod shard_tests {
     }
 
     #[tokio::test]
+    async fn audit_record_list_filter_and_purge() {
+        use crate::serve::history::{AuditEntry, AuditFilter};
+        let dir = tempfile::tempdir().unwrap();
+        let h = backend(&url_in(dir.path()), "a", Duration::from_secs(60)).await;
+        let now = chrono::Utc::now();
+        let entry =
+            |id: &str, principal: &str, action: &str, result: &str, secs_ago: i64| AuditEntry {
+                id: id.into(),
+                timestamp: now - chrono::Duration::seconds(secs_ago),
+                principal: principal.into(),
+                role: "admin".into(),
+                action: action.into(),
+                run_id: Some(format!("r-{id}")),
+                config_fingerprint: Some("fp".into()),
+                source_ip: Some("127.0.0.1".into()),
+                result: result.into(),
+            };
+        h.record_audit(&entry("1", "alice", "run.submit", "ok", 3))
+            .await
+            .unwrap();
+        h.record_audit(&entry("2", "bob", "run.submit", "denied", 2))
+            .await
+            .unwrap();
+        h.record_audit(&entry("3", "alice", "run.cancel", "ok", 1))
+            .await
+            .unwrap();
+
+        // Newest first.
+        let all = h
+            .list_audit(&AuditFilter {
+                limit: 50,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(all.len(), 3);
+        assert_eq!(all[0].id, "3");
+        assert_eq!(all[0].run_id.as_deref(), Some("r-3"));
+        assert_eq!(all[0].source_ip.as_deref(), Some("127.0.0.1"));
+
+        // Filters.
+        let alice = h
+            .list_audit(&AuditFilter {
+                principal: Some("alice".into()),
+                limit: 50,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(alice.len(), 2);
+        let submits = h
+            .list_audit(&AuditFilter {
+                action: Some("run.submit".into()),
+                limit: 50,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(submits.len(), 2);
+
+        // purge_expired(0) drops all audit rows.
+        h.purge_expired(Duration::ZERO).await.unwrap();
+        assert!(
+            h.list_audit(&AuditFilter {
+                limit: 50,
+                ..Default::default()
+            })
+            .await
+            .unwrap()
+            .is_empty()
+        );
+    }
+
+    #[tokio::test]
     async fn release_idempotency_drops_the_claim() {
         // F21: releasing a claim lets a replay of the key start fresh instead of
         // 404-ing for the whole retention window.

--- a/cli/src/serve/mod.rs
+++ b/cli/src/serve/mod.rs
@@ -3,6 +3,7 @@
 //! structured like `cli/src/schedule/`. See
 //! `docs/superpowers/specs/2026-05-30-faucet-serve-design.md`.
 
+pub mod audit;
 pub mod auth;
 pub mod cluster;
 pub mod config;
@@ -14,6 +15,7 @@ pub mod load;
 pub mod logs;
 pub mod metrics;
 pub mod observability;
+pub mod rbac;
 pub mod registry;
 pub mod runner;
 pub mod server;

--- a/cli/src/serve/rbac.rs
+++ b/cli/src/serve/rbac.rs
@@ -1,0 +1,416 @@
+//! Role-based access control for the `faucet serve` control plane (#205).
+//!
+//! The default single-`--auth-token` mode is one implicit `admin` principal. A
+//! `--auth-config <file>` promotes serve to a multi-principal deployment: a list
+//! of `{ name, token, role }` principals, each token mapped to a [`Role`] that
+//! grants a fixed set of [`Permission`]s. Every `/v1` route declares the
+//! permission it needs ([`required_permission`]); the auth middleware
+//! (`serve::auth::require_auth`) resolves the bearer token to an
+//! [`AuthContext`] and denies (`403`) any request whose role lacks the permission.
+//!
+//! Tokens are compared in constant time (via `serve::auth::constant_time_eq`)
+//! and never appear in `{:?}` output — [`PrincipalSpec`]'s `Debug` masks them,
+//! and the server registers every token with the redaction writer at startup.
+
+use crate::error::{CliError, CliResult};
+use axum::http::Method;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+/// A discrete capability a route requires. Roles grant a fixed set of these.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Permission {
+    /// Read run records / logs (`GET /v1/runs*`).
+    RunRead,
+    /// Submit / cancel / delete runs (`POST`/`DELETE /v1/runs*`).
+    RunWrite,
+    /// Read the connector/transform schema catalog (`GET /v1/schemas*`).
+    SchemaRead,
+    /// Run the preflight probe (`POST /v1/doctor`).
+    Doctor,
+    /// Fire an event-driven trigger (`POST`/`PUT /v1/triggers/{name}`).
+    TriggerFire,
+    /// Read the audit log (`GET /v1/audit`) — admin-only.
+    AuditRead,
+}
+
+/// A named role. Roles are a fixed, built-in ladder — `viewer` ⊂ `operator` ⊂
+/// `admin` — chosen so the common cases (read-only dashboard user, run
+/// operator, full admin) need no custom permission wiring.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Role {
+    /// Read-only: runs + logs + schemas.
+    Viewer,
+    /// Everything a viewer can do, plus submit/cancel/delete runs, doctor, and
+    /// firing triggers.
+    Operator,
+    /// Full access, including reading the audit log.
+    Admin,
+}
+
+impl Role {
+    /// Whether this role grants `perm`.
+    pub fn grants(self, perm: Permission) -> bool {
+        use Permission::*;
+        match self {
+            Role::Viewer => matches!(perm, RunRead | SchemaRead),
+            Role::Operator => {
+                matches!(perm, RunRead | SchemaRead | RunWrite | Doctor | TriggerFire)
+            }
+            Role::Admin => true,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Role::Viewer => "viewer",
+            Role::Operator => "operator",
+            Role::Admin => "admin",
+        }
+    }
+}
+
+/// One principal entry in an `--auth-config` file: a human-readable `name`, its
+/// bearer `token`, and the `role` it is granted.
+#[derive(Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PrincipalSpec {
+    pub name: String,
+    pub token: String,
+    pub role: Role,
+}
+
+// Hand-written Debug so a `{:?}` of a spec (or the RbacConfig embedding it) never
+// prints the bearer token in clear — mirrors `AuthMode`'s masking.
+impl std::fmt::Debug for PrincipalSpec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PrincipalSpec")
+            .field("name", &self.name)
+            .field("token", &"***")
+            .field("role", &self.role)
+            .finish()
+    }
+}
+
+/// File shape for `--auth-config` (`{ principals: [ … ] }`), parsed from YAML or
+/// JSON (YAML is a JSON superset, so one parser handles both).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct AuthConfigFile {
+    principals: Vec<PrincipalSpec>,
+}
+
+/// A validated RBAC configuration: a non-empty set of principals with unique
+/// names and unique, non-empty tokens.
+#[derive(Debug, Clone)]
+pub struct RbacConfig {
+    principals: Vec<PrincipalSpec>,
+}
+
+/// The resolved identity for one request, carried in the request extensions for
+/// handlers (and the audit writer) to read. Holds no token.
+#[derive(Debug, Clone)]
+pub struct AuthContext {
+    pub principal: String,
+    pub role: Role,
+    pub source_ip: Option<String>,
+}
+
+impl AuthContext {
+    /// Actor for a trigger-originated (non-HTTP) submission — `trigger:<name>`,
+    /// treated as an operator for audit attribution.
+    pub fn trigger(name: &str) -> Self {
+        Self {
+            principal: format!("trigger:{name}"),
+            role: Role::Operator,
+            source_ip: None,
+        }
+    }
+}
+
+impl RbacConfig {
+    /// Load + validate an `--auth-config` file (YAML or JSON).
+    pub fn from_file(path: &Path) -> CliResult<Self> {
+        let text = std::fs::read_to_string(path).map_err(|e| {
+            CliError::Serve(format!("reading --auth-config {}: {e}", path.display()))
+        })?;
+        let file: AuthConfigFile = serde_yaml::from_str(&text).map_err(|e| {
+            CliError::Serve(format!("parsing --auth-config {}: {e}", path.display()))
+        })?;
+        Self::new(file.principals)
+    }
+
+    /// Build from an already-parsed principal list, validating invariants.
+    pub fn new(principals: Vec<PrincipalSpec>) -> CliResult<Self> {
+        if principals.is_empty() {
+            return Err(CliError::Serve(
+                "--auth-config must define at least one principal".into(),
+            ));
+        }
+        let mut seen_names = std::collections::HashSet::new();
+        let mut seen_tokens = std::collections::HashSet::new();
+        for p in &principals {
+            if p.name.trim().is_empty() {
+                return Err(CliError::Serve(
+                    "--auth-config: every principal must have a non-empty name".into(),
+                ));
+            }
+            if p.token.is_empty() {
+                return Err(CliError::Serve(format!(
+                    "--auth-config: principal '{}' has an empty token",
+                    p.name
+                )));
+            }
+            if !seen_names.insert(p.name.clone()) {
+                return Err(CliError::Serve(format!(
+                    "--auth-config: duplicate principal name '{}'",
+                    p.name
+                )));
+            }
+            if !seen_tokens.insert(p.token.clone()) {
+                return Err(CliError::Serve(format!(
+                    "--auth-config: principal '{}' reuses a token already assigned to another \
+                     principal",
+                    p.name
+                )));
+            }
+        }
+        Ok(Self { principals })
+    }
+
+    /// Resolve a bearer token to its principal in constant time. Every principal
+    /// is compared (no early return) so the match position doesn't leak via
+    /// timing; the matched role/name is returned after the full scan.
+    pub fn authenticate(&self, token: &str) -> Option<AuthContext> {
+        let mut matched: Option<(&str, Role)> = None;
+        for p in &self.principals {
+            if crate::serve::auth::constant_time_eq(token.as_bytes(), p.token.as_bytes()) {
+                matched = Some((p.name.as_str(), p.role));
+            }
+        }
+        matched.map(|(name, role)| AuthContext {
+            principal: name.to_string(),
+            role,
+            source_ip: None,
+        })
+    }
+
+    /// Every configured token, for redaction registration at startup.
+    pub fn tokens(&self) -> impl Iterator<Item = &str> {
+        self.principals.iter().map(|p| p.token.as_str())
+    }
+}
+
+/// The permission a `(method, matched-route-template)` pair requires. `None`
+/// means the route has no specific mapping and is therefore admin-only (fail
+/// closed for any route added without an explicit entry here).
+pub fn required_permission(method: &Method, matched_path: &str) -> Option<Permission> {
+    use Permission::*;
+    match (method, matched_path) {
+        (&Method::POST, "/v1/runs") => Some(RunWrite),
+        (&Method::GET, "/v1/runs") => Some(RunRead),
+        (&Method::GET, "/v1/runs/{id}") => Some(RunRead),
+        (&Method::DELETE, "/v1/runs/{id}") => Some(RunWrite),
+        (&Method::POST, "/v1/runs/{id}/cancel") => Some(RunWrite),
+        (&Method::GET, "/v1/runs/{id}/logs") => Some(RunRead),
+        (&Method::GET, "/v1/schemas") => Some(SchemaRead),
+        (&Method::GET, "/v1/schemas/{kind}/{name}") => Some(SchemaRead),
+        (&Method::POST, "/v1/doctor") => Some(Doctor),
+        (&Method::GET, "/v1/audit") => Some(AuditRead),
+        (&Method::POST, "/v1/triggers/{name}") => Some(TriggerFire),
+        (&Method::PUT, "/v1/triggers/{name}") => Some(TriggerFire),
+        _ => None,
+    }
+}
+
+/// A short, stable audit action label for a `(method, matched-route)` pair.
+pub fn audit_action(method: &Method, matched_path: &str) -> &'static str {
+    match (method, matched_path) {
+        (&Method::POST, "/v1/runs") => "run.submit",
+        (&Method::GET, "/v1/runs") => "run.list",
+        (&Method::GET, "/v1/runs/{id}") => "run.get",
+        (&Method::DELETE, "/v1/runs/{id}") => "run.delete",
+        (&Method::POST, "/v1/runs/{id}/cancel") => "run.cancel",
+        (&Method::GET, "/v1/runs/{id}/logs") => "run.logs",
+        (&Method::GET, "/v1/schemas") => "schema.list",
+        (&Method::GET, "/v1/schemas/{kind}/{name}") => "schema.get",
+        (&Method::POST, "/v1/doctor") => "doctor",
+        (&Method::GET, "/v1/audit") => "audit.list",
+        (&Method::POST | &Method::PUT, "/v1/triggers/{name}") => "trigger.fire",
+        _ => "unknown",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spec(name: &str, token: &str, role: Role) -> PrincipalSpec {
+        PrincipalSpec {
+            name: name.into(),
+            token: token.into(),
+            role,
+        }
+    }
+
+    #[test]
+    fn role_permission_ladder() {
+        use Permission::*;
+        // Viewer: reads only.
+        assert!(Role::Viewer.grants(RunRead));
+        assert!(Role::Viewer.grants(SchemaRead));
+        assert!(!Role::Viewer.grants(RunWrite));
+        assert!(!Role::Viewer.grants(Doctor));
+        assert!(!Role::Viewer.grants(AuditRead));
+        // Operator: reads + writes + doctor + triggers, but not audit.
+        assert!(Role::Operator.grants(RunWrite));
+        assert!(Role::Operator.grants(Doctor));
+        assert!(Role::Operator.grants(TriggerFire));
+        assert!(!Role::Operator.grants(AuditRead));
+        // Admin: everything.
+        for p in [
+            RunRead,
+            RunWrite,
+            SchemaRead,
+            Doctor,
+            TriggerFire,
+            AuditRead,
+        ] {
+            assert!(Role::Admin.grants(p));
+        }
+    }
+
+    #[test]
+    fn authenticate_resolves_token_to_principal() {
+        let cfg = RbacConfig::new(vec![
+            spec("alice", "tok-a", Role::Admin),
+            spec("bob", "tok-b", Role::Viewer),
+        ])
+        .unwrap();
+        let a = cfg.authenticate("tok-a").unwrap();
+        assert_eq!(a.principal, "alice");
+        assert_eq!(a.role, Role::Admin);
+        let b = cfg.authenticate("tok-b").unwrap();
+        assert_eq!(b.role, Role::Viewer);
+        assert!(cfg.authenticate("nope").is_none());
+    }
+
+    #[test]
+    fn rejects_empty_duplicate_and_blank() {
+        assert!(RbacConfig::new(vec![]).is_err());
+        assert!(RbacConfig::new(vec![spec("", "t", Role::Admin)]).is_err());
+        assert!(RbacConfig::new(vec![spec("a", "", Role::Admin)]).is_err());
+        // Duplicate name.
+        assert!(
+            RbacConfig::new(vec![
+                spec("a", "t1", Role::Admin),
+                spec("a", "t2", Role::Viewer),
+            ])
+            .is_err()
+        );
+        // Duplicate token.
+        assert!(
+            RbacConfig::new(vec![
+                spec("a", "dup", Role::Admin),
+                spec("b", "dup", Role::Viewer),
+            ])
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn debug_masks_token() {
+        let s = format!("{:?}", spec("alice", "supersecret", Role::Admin));
+        assert!(!s.contains("supersecret"), "token leaked: {s}");
+        assert!(s.contains("***"));
+    }
+
+    #[test]
+    fn trigger_actor_is_operator() {
+        let ctx = AuthContext::trigger("nightly");
+        assert_eq!(ctx.principal, "trigger:nightly");
+        assert_eq!(ctx.role, Role::Operator);
+        assert!(ctx.source_ip.is_none());
+    }
+
+    #[test]
+    fn tokens_iterates_all_principals() {
+        let cfg = RbacConfig::new(vec![
+            spec("a", "t1", Role::Admin),
+            spec("b", "t2", Role::Viewer),
+        ])
+        .unwrap();
+        let toks: Vec<&str> = cfg.tokens().collect();
+        assert_eq!(toks, vec!["t1", "t2"]);
+    }
+
+    #[test]
+    fn required_permission_covers_all_routes() {
+        use Permission::*;
+        for (m, path, want) in [
+            (Method::GET, "/v1/runs/{id}", RunRead),
+            (Method::DELETE, "/v1/runs/{id}", RunWrite),
+            (Method::POST, "/v1/runs/{id}/cancel", RunWrite),
+            (Method::GET, "/v1/runs/{id}/logs", RunRead),
+            (Method::GET, "/v1/schemas", SchemaRead),
+            (Method::GET, "/v1/schemas/{kind}/{name}", SchemaRead),
+            (Method::POST, "/v1/doctor", Doctor),
+            (Method::POST, "/v1/triggers/{name}", TriggerFire),
+            (Method::PUT, "/v1/triggers/{name}", TriggerFire),
+        ] {
+            assert_eq!(required_permission(&m, path), Some(want), "{m} {path}");
+        }
+    }
+
+    #[test]
+    fn role_and_permission_serde_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&Role::Operator).unwrap(),
+            "\"operator\""
+        );
+        assert_eq!(
+            serde_json::to_string(&Permission::AuditRead).unwrap(),
+            "\"audit_read\""
+        );
+    }
+
+    #[test]
+    fn required_permission_maps_routes() {
+        assert_eq!(
+            required_permission(&Method::POST, "/v1/runs"),
+            Some(Permission::RunWrite)
+        );
+        assert_eq!(
+            required_permission(&Method::GET, "/v1/runs"),
+            Some(Permission::RunRead)
+        );
+        assert_eq!(
+            required_permission(&Method::GET, "/v1/audit"),
+            Some(Permission::AuditRead)
+        );
+        // Unmapped → admin-only (None).
+        assert_eq!(required_permission(&Method::GET, "/v1/unknown"), None);
+    }
+
+    #[test]
+    fn parses_yaml_and_json() {
+        let yaml = "principals:\n  - name: alice\n    token: tok-a\n    role: admin\n";
+        let cfg: AuthConfigFile = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(cfg.principals.len(), 1);
+        let json = r#"{"principals":[{"name":"bob","token":"tok-b","role":"viewer"}]}"#;
+        let cfg: AuthConfigFile = serde_yaml::from_str(json).unwrap();
+        assert_eq!(cfg.principals[0].role, Role::Viewer);
+    }
+
+    #[test]
+    fn audit_action_labels() {
+        assert_eq!(audit_action(&Method::POST, "/v1/runs"), "run.submit");
+        assert_eq!(
+            audit_action(&Method::POST, "/v1/runs/{id}/cancel"),
+            "run.cancel"
+        );
+        assert_eq!(audit_action(&Method::GET, "/v1/whatever"), "unknown");
+    }
+}

--- a/cli/src/serve/runner.rs
+++ b/cli/src/serve/runner.rs
@@ -11,6 +11,7 @@ use crate::serve::error::ServeError;
 use crate::serve::history::{Claim, InvocationRecord, RunRecord, RunStatus};
 use crate::serve::history::{ClaimedShard, ShardInsert};
 use crate::serve::load::{ConfigFormat, LoadedSubmission, load_submission};
+use crate::serve::rbac::AuthContext;
 use crate::serve::state::ServerState;
 use crate::serve::{idempotency, metrics};
 use chrono::{DateTime, FixedOffset, Utc};
@@ -603,7 +604,11 @@ async fn release_orphaned_claim(state: &ServerState, req: &SubmitRequest, run_id
 }
 
 /// Validate, idempotency-claim, queue, and spawn a submission.
-pub async fn submit(state: ServerState, req: SubmitRequest) -> Result<SubmitResponse, ServeError> {
+pub async fn submit(
+    state: ServerState,
+    req: SubmitRequest,
+    actor: AuthContext,
+) -> Result<SubmitResponse, ServeError> {
     let format: ConfigFormat = req.config_format.into();
     let loaded = load_submission(&req.config, format, state.default_base()).await?;
 
@@ -636,14 +641,17 @@ pub async fn submit(state: ServerState, req: SubmitRequest) -> Result<SubmitResp
 
     let run_id = uuid::Uuid::now_v7().to_string();
 
+    // Config fingerprint (sha256) — the idempotency identity AND the value
+    // recorded on the `run.submit` audit entry (#205).
+    let merged = serde_json::to_value(&loaded.cfg).unwrap_or(serde_json::Value::Null);
+    let fp_config = idempotency::fingerprint(&merged, loaded.cfg.name.as_deref());
+
     // Idempotency claim (if a key was supplied).
     if let Some(key) = &req.idempotency_key {
-        let merged = serde_json::to_value(&loaded.cfg).unwrap_or(serde_json::Value::Null);
         // Fold the run-affecting request fields (clock / timeout_secs / labels)
         // into the fingerprint, not just the config — so a key replayed with a
         // different backfill `clock` is a 409, not a replay of the original
         // run's window (#146 M7).
-        let fp_config = idempotency::fingerprint(&merged, loaded.cfg.name.as_deref());
         let fp = idempotency::request_fingerprint(
             &fp_config,
             req.clock.as_deref(),
@@ -717,6 +725,15 @@ pub async fn submit(state: ServerState, req: SubmitRequest) -> Result<SubmitResp
         // claim loop + semaphore, not the submit-side queue).
         drop(reservation);
         state.cluster().kick();
+        crate::serve::audit::write(
+            &state,
+            &actor,
+            "run.submit",
+            Some(run_id.clone()),
+            Some(fp_config.clone()),
+            "ok",
+        )
+        .await;
         return Ok(SubmitResponse {
             run_id,
             status: RunStatus::Pending,
@@ -744,6 +761,16 @@ pub async fn submit(state: ServerState, req: SubmitRequest) -> Result<SubmitResp
         run_token,
         submitted_at,
     );
+
+    crate::serve::audit::write(
+        &state,
+        &actor,
+        "run.submit",
+        Some(run_id.clone()),
+        Some(fp_config.clone()),
+        "ok",
+    )
+    .await;
 
     Ok(SubmitResponse {
         run_id,
@@ -1311,6 +1338,15 @@ fn schedule_log_drop(state: ServerState, run_id: String) {
 mod tests {
     use super::*;
 
+    /// A stand-in admin actor for the submit() tests.
+    fn admin_actor() -> AuthContext {
+        AuthContext {
+            principal: "test".into(),
+            role: crate::serve::rbac::Role::Admin,
+            source_ip: None,
+        }
+    }
+
     #[test]
     fn classify_ok_no_failures_is_completed() {
         let summary = RunSummary {
@@ -1423,7 +1459,7 @@ mod tests {
             clock: None,
         };
 
-        let err = submit(state.clone(), req).await.unwrap_err();
+        let err = submit(state.clone(), req, admin_actor()).await.unwrap_err();
         assert!(
             matches!(err, ServeError::Conflict(_)),
             "expected Conflict, got {err:?}"
@@ -1487,7 +1523,7 @@ mod tests {
             idempotency_key: None,
             clock: None,
         };
-        let resp = submit(state.clone(), req).await.unwrap();
+        let resp = submit(state.clone(), req, admin_actor()).await.unwrap();
         assert_eq!(resp.status, RunStatus::Pending);
         // No local queue slot was consumed (cluster runs don't queue locally).
         assert_eq!(state.registry().queued(), 0);
@@ -1667,7 +1703,7 @@ mod tests {
             idempotency_key: None,
             clock: None,
         };
-        let err = submit(state.clone(), req).await.unwrap_err();
+        let err = submit(state.clone(), req, admin_actor()).await.unwrap_err();
         assert!(
             matches!(err, ServeError::Unavailable(_)),
             "expected 503 Unavailable, got {err:?}"

--- a/cli/src/serve/server.rs
+++ b/cli/src/serve/server.rs
@@ -2,13 +2,14 @@
 
 use crate::error::{CliError, CliResult};
 use crate::serve::config::ServeConfig;
-use crate::serve::handlers::{doctor, health, logs, runs, schemas};
+use crate::serve::handlers::{audit, doctor, health, logs, runs, schemas};
 use crate::serve::history::RunHistory;
 use crate::serve::state::ServerState;
 use crate::serve::{auth, metrics};
 use axum::Router;
 use axum::routing::{get, post};
 use serde_json::Value;
+use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio_util::sync::CancellationToken;
@@ -32,7 +33,8 @@ pub fn build_router(state: ServerState, config: &ServeConfig) -> Router {
         .route("/v1/runs/{id}/logs", get(logs::stream_logs))
         .route("/v1/schemas", get(schemas::list_schemas))
         .route("/v1/schemas/{kind}/{name}", get(schemas::get_schema))
-        .route("/v1/doctor", post(doctor::doctor));
+        .route("/v1/doctor", post(doctor::doctor))
+        .route("/v1/audit", get(audit::list_audit));
     #[cfg(feature = "triggers")]
     {
         api = api.route(
@@ -401,13 +403,18 @@ pub async fn serve(config: ServeConfig) -> CliResult<()> {
 
     // The HTTP graceful-shutdown future resolves on signal and stops accepting
     // new connections / drains in-flight HTTP — it does NOT cancel run tasks.
-    axum::serve(listener, app)
-        .with_graceful_shutdown(async move {
-            wait_for_signal().await;
-            tracing::info!("shutdown signal received; draining in-flight runs");
-        })
-        .await
-        .map_err(|e| CliError::Serve(format!("server error: {e}")))?;
+    // `into_make_service_with_connect_info` exposes the peer address so the auth
+    // layer can record a `source_ip` on audit records (#205).
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .with_graceful_shutdown(async move {
+        wait_for_signal().await;
+        tracing::info!("shutdown signal received; draining in-flight runs");
+    })
+    .await
+    .map_err(|e| CliError::Serve(format!("server error: {e}")))?;
 
     // Stop pulling NEW work the moment we begin draining: abort the claim loop so
     // a shutting-down instance drains its in-flight runs rather than claiming more.

--- a/cli/src/serve/state.rs
+++ b/cli/src/serve/state.rs
@@ -68,8 +68,13 @@ impl ServerState {
     pub fn auth_token(&self) -> Option<&str> {
         match &self.inner.auth {
             AuthMode::Token(t) => Some(t),
-            AuthMode::None => None,
+            AuthMode::Rbac(_) | AuthMode::None => None,
         }
+    }
+
+    /// The configured authentication mode (bearer resolution + RBAC).
+    pub fn auth_mode(&self) -> &AuthMode {
+        &self.inner.auth
     }
 
     pub fn render_metrics(&self) -> Option<String> {

--- a/cli/src/serve/triggers/enqueue.rs
+++ b/cli/src/serve/triggers/enqueue.rs
@@ -100,7 +100,10 @@ pub async fn fire(
     // faucet_serve_idempotency_hits_total captures them. A Conflict (same key,
     // different payload hash) is treated as a committed no-op (Coalesced) so a
     // polling watcher does not retry the same event forever.
-    match runner::submit(state.clone(), req).await {
+    // Trigger-originated (non-HTTP) submission → attribute the audit record to
+    // the trigger (`trigger:<name>`).
+    let actor = crate::serve::rbac::AuthContext::trigger(compiled.name());
+    match runner::submit(state.clone(), req, actor).await {
         Ok(resp) => {
             metrics::enqueued(compiled.name());
             FireOutcome::Enqueued(resp.run_id)

--- a/cli/tests/serve_history_sqlite.rs
+++ b/cli/tests/serve_history_sqlite.rs
@@ -304,6 +304,7 @@ async fn server_with_sqlite_history_persists_runs() {
     let args = ServeArgs {
         listen: format!("127.0.0.1:{port}"),
         auth_token: None,
+        auth_config: None,
         no_auth: true,
         max_concurrent_runs: Some(2),
         max_queued_runs: Some(8),

--- a/cli/tests/serve_lifecycle.rs
+++ b/cli/tests/serve_lifecycle.rs
@@ -22,6 +22,7 @@ fn args_on(port: u16, token: Option<&str>) -> ServeArgs {
     ServeArgs {
         listen: format!("127.0.0.1:{port}"),
         auth_token: token.map(|t| t.to_string()),
+        auth_config: None,
         no_auth: token.is_none(),
         max_concurrent_runs: Some(4),
         max_queued_runs: Some(16),

--- a/cli/tests/serve_logs.rs
+++ b/cli/tests/serve_logs.rs
@@ -19,6 +19,7 @@ fn args_on(port: u16) -> ServeArgs {
     ServeArgs {
         listen: format!("127.0.0.1:{port}"),
         auth_token: None,
+        auth_config: None,
         no_auth: true,
         max_concurrent_runs: Some(4),
         max_queued_runs: Some(16),

--- a/cli/tests/serve_metrics.rs
+++ b/cli/tests/serve_metrics.rs
@@ -16,6 +16,7 @@ fn args_on(port: u16, token: Option<&str>) -> ServeArgs {
     ServeArgs {
         listen: format!("127.0.0.1:{port}"),
         auth_token: token.map(|t| t.to_string()),
+        auth_config: None,
         no_auth: token.is_none(),
         max_concurrent_runs: Some(4),
         max_queued_runs: Some(16),

--- a/cli/tests/serve_openapi.rs
+++ b/cli/tests/serve_openapi.rs
@@ -28,6 +28,7 @@ const ROUTES_BASE: &[(&str, &str)] = &[
     ("GET", "/v1/schemas"),
     ("GET", "/v1/schemas/{kind}/{name}"),
     ("POST", "/v1/doctor"),
+    ("GET", "/v1/audit"),
     ("GET", "/healthz"),
     ("GET", "/readyz"),
     ("GET", "/metrics"),
@@ -112,6 +113,7 @@ async fn every_documented_route_is_wired_on_the_live_server() {
     let args = ServeArgs {
         listen: format!("127.0.0.1:{port}"),
         auth_token: None,
+        auth_config: None,
         no_auth: true,
         max_concurrent_runs: Some(2),
         max_queued_runs: Some(8),

--- a/cli/tests/serve_rbac.rs
+++ b/cli/tests/serve_rbac.rs
@@ -1,0 +1,253 @@
+//! RBAC + audit-log integration tests for `faucet serve` (#205). Boots a real
+//! server with a multi-principal `--auth-config` and asserts role enforcement
+//! (`403` for a viewer's write, `200` for its read) and that mutating / denied
+//! actions land in the admin-only audit log. Requires the `serve` feature.
+#![cfg(feature = "serve")]
+
+use faucet_cli::cli::ServeArgs;
+use faucet_cli::serve::ServeConfig;
+use std::time::Duration;
+
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+/// Two principals: `admin-tok` → admin, `viewer-tok` → viewer.
+const AUTH_CONFIG: &str = "principals:\n\
+    \x20 - name: alice\n\
+    \x20   token: admin-tok\n\
+    \x20   role: admin\n\
+    \x20 - name: bob\n\
+    \x20   token: viewer-tok\n\
+    \x20   role: viewer\n";
+
+fn args_with_auth_config(port: u16, auth_config: std::path::PathBuf) -> ServeArgs {
+    ServeArgs {
+        listen: format!("127.0.0.1:{port}"),
+        auth_token: None,
+        auth_config: Some(auth_config),
+        no_auth: false,
+        max_concurrent_runs: Some(4),
+        max_queued_runs: Some(16),
+        default_config: None,
+        history: None,
+        cors_origin: vec![],
+        body_limit_bytes: 1_048_576,
+        shutdown_grace_secs: 5,
+        retain_terminal_runs_secs: 604_800,
+        idempotency_retention_secs: 86_400,
+        lease_ttl_secs: 30,
+        probe_timeout_secs: 5,
+        env_file: None,
+        no_env_file: true,
+        no_ui: false,
+        cluster: false,
+        cluster_poll_secs: 2,
+        cluster_max_attempts: 3,
+        triggers: None,
+    }
+}
+
+/// Boot a server whose auth is the two-principal RBAC config. Returns the
+/// tempdir (kept alive for the server's lifetime — it holds the auth file).
+async fn spawn_rbac_server(port: u16) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    let auth_path = dir.path().join("auth.yaml");
+    std::fs::write(&auth_path, AUTH_CONFIG).unwrap();
+    let mut config = ServeConfig::from_args(args_with_auth_config(port, auth_path)).unwrap();
+    config.log_level = "warn".into();
+    tokio::spawn(async move {
+        let _ = faucet_cli::serve::run_server(config).await;
+    });
+    let client = reqwest::Client::new();
+    for _ in 0..100 {
+        if client
+            .get(format!("http://127.0.0.1:{port}/healthz"))
+            .send()
+            .await
+            .map(|r| r.status().is_success())
+            .unwrap_or(false)
+        {
+            return dir;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    panic!("server did not become healthy on port {port}");
+}
+
+fn csv_to_jsonl_yaml(input: &std::path::Path, output: &std::path::Path) -> String {
+    format!(
+        "version: 1\npipeline:\n  source: {{ type: csv, config: {{ path: \"{}\" }} }}\n  sink: {{ type: jsonl, config: {{ path: \"{}\" }} }}\n",
+        input.display(),
+        output.display()
+    )
+}
+
+/// A viewer is denied `POST /v1/runs` (403) but allowed `GET /v1/runs` (200);
+/// an admin can submit (202). Covers the core acceptance criterion.
+#[tokio::test(flavor = "multi_thread")]
+async fn viewer_is_readonly_admin_can_write() {
+    let port = free_port();
+    let _dir = spawn_rbac_server(port).await;
+    let client = reqwest::Client::new();
+    let base = format!("http://127.0.0.1:{port}");
+
+    // No token → 401.
+    assert_eq!(
+        client
+            .get(format!("{base}/v1/runs"))
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        401
+    );
+
+    // Viewer can read.
+    assert_eq!(
+        client
+            .get(format!("{base}/v1/runs"))
+            .bearer_auth("viewer-tok")
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        200,
+        "viewer must be allowed GET /v1/runs"
+    );
+
+    // Viewer cannot write.
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("in.csv");
+    std::fs::write(&input, "name\nalice\n").unwrap();
+    let cfg = csv_to_jsonl_yaml(&input, &dir.path().join("out.jsonl"));
+    let denied = client
+        .post(format!("{base}/v1/runs"))
+        .bearer_auth("viewer-tok")
+        .json(&serde_json::json!({ "config": cfg }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(denied.status(), 403, "viewer must be denied POST /v1/runs");
+    let err: serde_json::Value = denied.json().await.unwrap();
+    assert_eq!(err["error"]["code"], "forbidden");
+
+    // Admin can write.
+    let accepted = client
+        .post(format!("{base}/v1/runs"))
+        .bearer_auth("admin-tok")
+        .json(&serde_json::json!({ "config": cfg }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        accepted.status(),
+        202,
+        "admin must be allowed POST /v1/runs"
+    );
+}
+
+/// The audit log is admin-only (viewer → 403) and records both a successful
+/// mutating action (admin's `run.submit`, result `ok`) and a denied one
+/// (viewer's `run.submit`, result `denied`).
+#[tokio::test(flavor = "multi_thread")]
+async fn audit_log_records_actions_and_is_admin_only() {
+    let port = free_port();
+    let _dir = spawn_rbac_server(port).await;
+    let client = reqwest::Client::new();
+    let base = format!("http://127.0.0.1:{port}");
+
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("in.csv");
+    std::fs::write(&input, "name\nalice\n").unwrap();
+    let cfg = csv_to_jsonl_yaml(&input, &dir.path().join("out.jsonl"));
+    let body = serde_json::json!({ "config": cfg });
+
+    // Admin submit (recorded ok) and a viewer submit (denied, recorded).
+    let submit: serde_json::Value = client
+        .post(format!("{base}/v1/runs"))
+        .bearer_auth("admin-tok")
+        .json(&body)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let run_id = submit["run_id"].as_str().unwrap().to_string();
+
+    client
+        .post(format!("{base}/v1/runs"))
+        .bearer_auth("viewer-tok")
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    // Viewer is denied the audit log.
+    assert_eq!(
+        client
+            .get(format!("{base}/v1/audit"))
+            .bearer_auth("viewer-tok")
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        403,
+        "viewer must be denied GET /v1/audit"
+    );
+
+    // Admin reads the audit log.
+    let audit: serde_json::Value = client
+        .get(format!("{base}/v1/audit"))
+        .bearer_auth("admin-tok")
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let entries = audit["entries"].as_array().expect("entries array");
+
+    // A successful run.submit by alice, carrying the run_id + a fingerprint.
+    let submit_ok = entries
+        .iter()
+        .find(|e| e["action"] == "run.submit" && e["result"] == "ok" && e["principal"] == "alice");
+    let submit_ok = submit_ok.unwrap_or_else(|| panic!("no admin run.submit entry in {audit:#}"));
+    assert_eq!(submit_ok["run_id"], run_id);
+    assert!(
+        submit_ok["config_fingerprint"].is_string(),
+        "submit audit must carry a config fingerprint"
+    );
+
+    // A denied run.submit by bob.
+    assert!(
+        entries.iter().any(|e| {
+            e["action"] == "run.submit" && e["result"] == "denied" && e["principal"] == "bob"
+        }),
+        "denied viewer submit must be audited; got {audit:#}"
+    );
+
+    // Filtering by principal narrows the result set.
+    let bob_only: serde_json::Value = client
+        .get(format!("{base}/v1/audit?principal=bob"))
+        .bearer_auth("admin-tok")
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert!(
+        bob_only["entries"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|e| e["principal"] == "bob"),
+        "principal filter must only return that principal's entries"
+    );
+}

--- a/cli/tests/serve_skeleton.rs
+++ b/cli/tests/serve_skeleton.rs
@@ -10,6 +10,7 @@ fn test_config(listen: &str) -> ServeConfig {
     let args = faucet_cli::cli::ServeArgs {
         listen: listen.into(),
         auth_token: None,
+        auth_config: None,
         no_auth: true,
         max_concurrent_runs: Some(2),
         max_queued_runs: Some(8),

--- a/cli/tests/serve_triggers.rs
+++ b/cli/tests/serve_triggers.rs
@@ -386,6 +386,7 @@ async fn spawn_serve_with_triggers(
     let args = ServeArgs {
         listen: format!("127.0.0.1:{port}"),
         auth_token: token.map(|t| t.to_string()),
+        auth_config: None,
         no_auth: token.is_none(),
         max_concurrent_runs: Some(4),
         max_queued_runs: Some(16),

--- a/cli/tests/serve_ui.rs
+++ b/cli/tests/serve_ui.rs
@@ -17,6 +17,7 @@ fn args(port: u16) -> ServeArgs {
     ServeArgs {
         listen: format!("127.0.0.1:{port}"),
         auth_token: None,
+        auth_config: None,
         no_auth: true,
         max_concurrent_runs: Some(2),
         max_queued_runs: Some(8),

--- a/docs/book/src/cookbook/serve.md
+++ b/docs/book/src/cookbook/serve.md
@@ -61,6 +61,44 @@ Mitigations are deployment-level and **mandatory**:
   resolved secrets — only faucet's own log output is redacted, not third-party
   connector debug logging.
 
+## RBAC & audit log
+
+A single `--auth-token` is one implicit **admin** principal — fine for a personal
+deployment, but a team needs scoped access and attribution. `--auth-config
+<file>` enables **role-based access control**: a YAML/JSON list of principals,
+each a `{ name, token, role }` where role is `viewer` (read-only), `operator`
+(submit/cancel/delete runs, doctor, triggers), or `admin` (everything, including
+the audit log).
+
+```yaml
+# auth.yaml — tokens can use ${env:…}/${secret:…} interpolation
+principals:
+  - { name: alice, token: "${env:ALICE_TOKEN}", role: admin }
+  - { name: ci,    token: "${env:CI_TOKEN}",    role: operator }
+  - { name: dash,  token: "${env:DASH_TOKEN}",  role: viewer }
+```
+
+```bash
+faucet serve --auth-config auth.yaml --history postgres://…/faucet
+```
+
+A viewer's `POST /v1/runs` returns `403`; its `GET /v1/runs` returns `200`.
+`--auth-config` is mutually exclusive with `--auth-token` / `--no-auth`.
+
+**Every mutating action** (`run.submit` / `run.cancel` / `run.delete`) **and every
+denied attempt** is written to a tamper-evident audit log — principal, role,
+action, run id, config fingerprint, source IP, timestamp, result. Admins read it:
+
+```bash
+curl -H "Authorization: Bearer $ADMIN_TOKEN" \
+  'http://127.0.0.1:8080/v1/audit?action=run.submit&limit=50'
+```
+
+Audit records persist in the run-history backend (`faucet_serve_audit` on the SQL
+backends; an in-memory ring for the default backend, lost on restart) and expire
+with `--retain-terminal-runs-secs`. For a durable trail, use a
+`--history postgres://…`/`sqlite:…` backend.
+
 ## Bounded concurrency & backpressure
 
 `--max-concurrent-runs` (default `min(16, cpu_count())`) bounds how many runs

--- a/docs/book/src/reference/cli.md
+++ b/docs/book/src/reference/cli.md
@@ -319,6 +319,7 @@ Selected flags (`faucet serve --help` for the full list):
 |------|---------|
 | `--listen <addr>` | Bind address (default `127.0.0.1:8080`; env `FAUCET_SERVE_LISTEN`). |
 | `--auth-token <t>` / `--no-auth` | Bearer token (prefer the env var) or explicit no-auth opt-in. |
+| `--auth-config <path>` | RBAC principals file (`{ name, token, role }`; roles `viewer`/`operator`/`admin`) — enables role enforcement + the `GET /v1/audit` log. Mutually exclusive with `--auth-token`/`--no-auth`. |
 | `--max-concurrent-runs <n>` / `--max-queued-runs <n>` | Concurrency + queue caps (429 past the queue). |
 | `--history <url>` | `postgres://…` / `sqlite:…` for durable run history (feature-gated; default in-memory). |
 | `--default-config <path>` | Workspace defaults merged under every submitted run. |

--- a/docs/book/src/reference/http-api.md
+++ b/docs/book/src/reference/http-api.md
@@ -18,6 +18,43 @@ was started with `--no-auth`. The token is compared in constant time; the
 scrapers). `OPTIONS` preflight bypasses auth so browsers behind a CORS policy
 work.
 
+### RBAC & the audit log (`--auth-config`)
+
+A single `--auth-token` is one implicit **admin** principal. For a team
+deployment, `--auth-config <file>` promotes the server to **role-based access
+control**: a YAML/JSON file of principals, each a `{ name, token, role }`. Three
+built-in roles form a ladder:
+
+| Role | Permitted |
+|------|-----------|
+| `viewer` | read-only: `GET /v1/runs*`, `GET /v1/schemas*` |
+| `operator` | everything a viewer can do **plus** submit / cancel / delete runs, `POST /v1/doctor`, and firing triggers |
+| `admin` | everything, including `GET /v1/audit` |
+
+```yaml
+# auth.yaml
+principals:
+  - { name: alice, token: "${env:ALICE_TOKEN}", role: admin }
+  - { name: ci,    token: "${env:CI_TOKEN}",    role: operator }
+  - { name: dash,  token: "${env:DASH_TOKEN}",  role: viewer }
+```
+
+```bash
+faucet serve --auth-config auth.yaml
+```
+
+A request whose role lacks the route's required permission gets `403 forbidden`
+(and a `denied` audit record). `--auth-config` is mutually exclusive with
+`--auth-token` / `--no-auth`. Every token is registered for log redaction at
+startup.
+
+**Audit log.** Every mutating action (`run.submit` / `run.cancel` / `run.delete`)
+and every denied attempt is recorded with principal, role, action, run id,
+config fingerprint (submit), source IP, timestamp, and result. Admins read it via
+`GET /v1/audit`. Records persist in the run-history backend (`faucet_serve_audit`
+for the SQL backends; an in-memory ring otherwise) and expire with the
+`--retain-terminal-runs-secs` window.
+
 ## Endpoints
 
 | Method | Path | Success | Notes |
@@ -28,6 +65,7 @@ work.
 | `DELETE` | `/v1/runs/{id}` | `204` | Remove a terminal run from history |
 | `POST` | `/v1/runs/{id}/cancel` | `202` / `200` | Request cancel (202) or no-op if terminal (200) |
 | `GET` | `/v1/runs/{id}/logs` | `200` | Stream the run's logs as `text/event-stream` |
+| `GET` | `/v1/audit` | `200` | Read the audit log — **admin only** (RBAC). Filters: `principal`, `action`, `since`, `until`, `limit` |
 | `GET` | `/healthz` | `200` | Liveness (unauthenticated) |
 | `GET` | `/readyz` | `200`/`503` | Readiness (unauthenticated) |
 | `GET` | `/metrics` | `200` | Prometheus exposition (unauthenticated) |
@@ -139,6 +177,7 @@ Every error is a JSON `ApiError`:
 |--------|------|
 | `400` | Malformed body / parse / interpolation failure; a `schedule:` block in the config |
 | `401` | Missing/invalid bearer token |
+| `403` | Authenticated, but the principal's role lacks the required permission (RBAC) |
 | `404` | Unknown `run_id` |
 | `409` | `DELETE` on a running run; idempotency key reused with a different payload |
 | `413` | Body exceeds `--body-limit-bytes` |

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -245,6 +245,36 @@ paths:
         "422":
           description: One or more probes failed; report in body
           content: { application/json: { schema: { type: object } } }
+        "403": { description: Principal's role lacks the required permission }
+  /v1/audit:
+    get:
+      summary: Read the control-plane audit log (RBAC, admin-only)
+      description: >
+        Returns recent audit records (newest first), each a mutating or denied
+        control-plane action attributed to a principal. Requires the `AuditRead`
+        permission (admin role). Under a single `--auth-token` or `--no-auth`
+        the implicit principal is admin, so this endpoint is available.
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - { name: principal, in: query, required: false, schema: { type: string } }
+        - { name: action, in: query, required: false, schema: { type: string } }
+        - { name: since, in: query, required: false, schema: { type: string, format: date-time } }
+        - { name: until, in: query, required: false, schema: { type: string, format: date-time } }
+        - { name: limit, in: query, required: false, schema: { type: integer, default: 100, maximum: 1000 } }
+      responses:
+        "200":
+          description: Audit records, newest first.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  entries:
+                    type: array
+                    items: { $ref: "#/components/schemas/AuditEntry" }
+        "400": { description: Malformed `since` / `until` timestamp }
+        "401": { description: Missing or invalid bearer token }
+        "403": { description: Principal's role lacks the AuditRead permission }
   /healthz:
     get:
       summary: Liveness probe (unauthenticated)
@@ -401,6 +431,19 @@ components:
           type: array
           items: { $ref: "#/components/schemas/RunRecord" }
         next_cursor: { type: string, nullable: true }
+    AuditEntry:
+      type: object
+      required: [id, timestamp, principal, role, action, result]
+      properties:
+        id: { type: string, description: "Time-ordered UUIDv7 (also the sort key)." }
+        timestamp: { type: string, format: date-time }
+        principal: { type: string, description: "Principal name (anonymous / token / <name> / trigger:<name>)." }
+        role: { type: string, enum: [viewer, operator, admin] }
+        action: { type: string, description: "e.g. run.submit / run.cancel / run.delete / trigger.fire / <route> (denials)." }
+        run_id: { type: string, nullable: true }
+        config_fingerprint: { type: string, nullable: true, description: "sha256 of the merged config (submit actions)." }
+        source_ip: { type: string, nullable: true }
+        result: { type: string, enum: [ok, denied] }
     ApiError:
       type: object
       required: [error]


### PR DESCRIPTION
## Summary

Promotes the `faucet serve` control plane from a single shared bearer token to **role-based access control** with a persistent **audit log** — the baseline for any team / regulated deployment.

- **`--auth-config <file>`** defines principals (`{ name, token, role }`). Three built-in roles form a ladder: `viewer` (read-only), `operator` (+ submit/cancel/delete runs, doctor, triggers), `admin` (+ audit log). `AuthMode` gains an `Rbac(Arc<RbacConfig>)` variant; `AuthMode::resolve(bearer)` maps a token → `AuthContext { principal, role, source_ip }` in constant time.
- **Enforcement**: the `auth::require_auth` middleware resolves the principal, looks up the route's required `Permission` (`rbac::required_permission`), and returns **403** on insufficient role. An unmapped `/v1` route is admin-only (fail-closed). `--auth-config` is mutually exclusive with `--auth-token` / `--no-auth`; every token is registered for log redaction.
- **Audit log**: every mutating action (`run.submit` / `run.cancel` / `run.delete`) and every denial is recorded with principal, role, action, run id, config sha256 fingerprint, source IP, timestamp, and result. Admins read it via **`GET /v1/audit`** (filters: principal / action / since / until / limit; newest-first). Trigger-originated submits are attributed `trigger:<name>`.
- **Storage**: `RunHistory::record_audit` / `list_audit` — an in-memory ring for the default backend, a `faucet_serve_audit` table in the shared `impl_sql_history!` macro (Postgres + SQLite), forwarded by `FallbackHistory`, purged with the run-retention window.
- **Backward compatible**: single `--auth-token` and `--no-auth` are unchanged (one implicit admin principal), so existing deployments keep working untouched. No new Cargo feature — RBAC/audit ship within `serve`.

## Testing

- Unit tests: role→permission ladder, constant-time principal resolution, config validation, `AuthMode::resolve`, `--auth-config` parsing + redaction, memory & SQLite audit store (record/filter/purge), audit-timestamp parsing.
- Integration (`cli/tests/serve_rbac.rs`, real booted server): a viewer is denied `POST /v1/runs` (403) and allowed `GET /v1/runs` (200); an admin can submit; the audit log records the admin's `run.submit` (with fingerprint) and the viewer's denied attempt; the viewer is denied `GET /v1/audit`; principal filtering works.
- `docs/openapi.yaml` updated + kept in sync by `serve_openapi.rs`.
- `cargo fmt`, `clippy` (serve + history + triggers), and `cargo doc -D warnings` all clean locally.

## Docs

Serve cookbook (RBAC + audit section), HTTP API reference (auth model, endpoint table, error table), and CLI reference (`--auth-config`) updated; crate README updated.

Closes #205. Part of the roadmap epic #38.