### PR TITLE
feat: persistent Data Movement Catalog — datasets, schema timelines & lineage graph

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,9 +251,10 @@ jobs:
           brew install cmake openssl@3 curl
       - name: Check feature in isolation
         run: |
-          # Secrets, schedule, serve, and triggers features live in faucet-cli
-          # (CLI layer), not in the faucet-stream umbrella crate. Route accordingly.
-          if [[ "${{ matrix.feature }}" == secrets-* || "${{ matrix.feature }}" == "schedule" || "${{ matrix.feature }}" == serve* || "${{ matrix.feature }}" == triggers* || "${{ matrix.feature }}" == "notify" ]]; then
+          # Secrets, schedule, serve, catalog, and triggers features live in
+          # faucet-cli (CLI layer), not in the faucet-stream umbrella crate.
+          # Route accordingly.
+          if [[ "${{ matrix.feature }}" == secrets-* || "${{ matrix.feature }}" == "schedule" || "${{ matrix.feature }}" == serve* || "${{ matrix.feature }}" == "catalog" || "${{ matrix.feature }}" == triggers* || "${{ matrix.feature }}" == "notify" ]]; then
             cargo check -p faucet-cli --no-default-features --features ${{ matrix.feature }}
           else
             cargo check -p faucet-stream --no-default-features --features ${{ matrix.feature }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,8 @@ jobs:
           - serve-history-postgres
           - serve-history-sqlite
           - serve-ui
+          # Data Movement Catalog (CLI-only; implies serve + lineage)
+          - catalog
           # Event-driven triggers (CLI-only)
           - triggers
           - triggers-object-store

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -26,7 +26,16 @@ default = ["observability", "source", "sink", "state", "transforms", "compressio
 
 # Everything the default build ships, plus the long-running runtime modes:
 # `schedule` (cron scheduler) and `serve` (HTTP control plane).
-full = ["default", "otel", "schedule", "serve", "serve-ui", "serve-history-postgres", "serve-history-sqlite", "lineage", "lineage-kafka", "notify", "transform-sql", "triggers", "triggers-object-store", "triggers-redis", "triggers-kafka"]
+full = ["default", "otel", "schedule", "serve", "serve-ui", "serve-history-postgres", "serve-history-sqlite", "catalog", "lineage", "lineage-kafka", "notify", "transform-sql", "triggers", "triggers-object-store", "triggers-redis", "triggers-kafka"]
+
+# Data Movement Catalog (#279): the `catalog:` config block + post-run
+# recording (datasets, schema timelines, volume/freshness stats, lineage
+# edges), the `/v1/catalog/*` serve endpoints + console views, and the
+# `faucet catalog` verb. Implies `serve` (catalog storage rides the
+# run-history backends — add `serve-history-sqlite` / `serve-history-postgres`
+# for persistence) and `lineage` (record sampling + column-lineage
+# derivation). Not in `default`; included in `full`.
+catalog = ["serve", "lineage"]
 
 # Data-quality checks (`quality:` config block). `quality-jsonschema` adds the
 # `json_schema` record check via a JSON Schema validator. Forwarded to

--- a/cli/README.md
+++ b/cli/README.md
@@ -37,6 +37,7 @@ cargo install faucet-cli --no-default-features \
 | `faucet test <specs…> [--filter S] [--json] [--clock C]` | Run fixture-based **offline** pipeline tests: stream sample records through a config's transforms/quality/contract with in-memory source/sink/DLQ and assert the output. Exits with the failed-case count. `faucet schema test` prints the spec-file JSON Schema. |
 | `faucet contract <config> [--export contract\|json-schema\|openlineage]` | Validate the `pipeline.contract:` block and print a summary, or export the data contract as canonical JSON / JSON Schema / an OpenLineage schema facet. `faucet schema contract` prints the block's own JSON Schema. |
 | `faucet schedule <config> [--once]` | Run a pipeline on a cron schedule (long-running foreground process). Requires a `schedule:` block. |
+| `faucet catalog datasets\|show\|lineage [--config C] [--json]` | Browse the Data Movement Catalog accumulated by a config's `catalog:` store: dataset list, per-dataset schema timeline / volume / edges, and the lineage graph. Requires the `catalog` build feature. `faucet schema catalog` prints the block's JSON Schema. |
 
 Pass `--log-level debug` (or set `FAUCET_LOG=debug`) for verbose tracing. Logs are written to stderr; pipeline records and command output go to stdout.
 
@@ -845,6 +846,29 @@ sla:
 
 `faucet schema sla` prints the block's JSON Schema. Full model:
 [SLA monitoring](https://pawansikawat.github.io/faucet-stream/cookbook/sla.html).
+
+### `catalog:` (optional)
+
+**Top-level** block (sibling of `pipeline:`) naming the Data Movement Catalog
+store — the persistent, cross-run record of every dataset the pipeline
+touches: identity, a deduplicated schema timeline (with per-version diffs),
+per-run volume + last-success freshness, and source→sink lineage edges.
+Recorded after every successful root invocation by `run`/`schedule`/
+`replicate`; **never fails a run**. `faucet serve` ignores this block and
+records into its `--history` backend automatically. Requires the `catalog`
+build feature (in `full`); SQL stores additionally need
+`serve-history-sqlite` / `serve-history-postgres`.
+
+```yaml
+catalog:
+  url: sqlite:./faucet-catalog.db   # sqlite:<path> | postgres://… | memory
+  sample_records: 100               # schema-inference sample per side
+```
+
+Browse with `faucet catalog datasets|show|lineage`, `GET /v1/catalog/*` on
+`faucet serve`, or the web console's Datasets / Lineage views.
+`faucet schema catalog` prints the block's JSON Schema. Full model:
+[Data Movement Catalog](https://pawansikawat.github.io/faucet-stream/cookbook/catalog.html).
 
 ### Transforms
 

--- a/cli/examples/csv_to_jsonl_with_catalog.yaml
+++ b/cli/examples/csv_to_jsonl_with_catalog.yaml
@@ -1,0 +1,32 @@
+# CSV → JSONL with the Data Movement Catalog (#279): every run accumulates
+# the datasets it touched (identity, schema timeline, volume/freshness) and
+# the source→sink lineage edge into a local SQLite store. Browse it with:
+#
+#   faucet run cli/examples/csv_to_jsonl_with_catalog.yaml
+#   faucet catalog datasets --config cli/examples/csv_to_jsonl_with_catalog.yaml
+#   faucet catalog show <id> --config cli/examples/csv_to_jsonl_with_catalog.yaml
+#   faucet catalog lineage  --config cli/examples/csv_to_jsonl_with_catalog.yaml
+#
+# Or point `faucet serve --history sqlite:./faucet-catalog.db` at the same
+# file and open the web console's Datasets / Lineage views.
+#
+# Requires a build with the `catalog` feature (included in `--features full`)
+# plus `serve-history-sqlite` for the SQLite store.
+version: 1
+name: csv_to_jsonl_with_catalog
+
+catalog:
+  url: sqlite:./faucet-catalog.db
+  # How many records to sample per run for schema inference (default 100).
+  sample_records: 100
+
+pipeline:
+  source:
+    type: csv
+    config:
+      path: ./data/input.csv
+
+  sink:
+    type: jsonl
+    config:
+      path: ./out/records.jsonl

--- a/cli/src/catalog/mod.rs
+++ b/cli/src/catalog/mod.rs
@@ -1,0 +1,129 @@
+//! Data Movement Catalog (#279) — the CLI-side write path.
+//!
+//! The catalog accumulates, run over run, the operational history of every
+//! dataset a pipeline touches: identity, a deduplicated schema timeline,
+//! volume/freshness stats, and lineage edges. Storage rides the serve
+//! run-history backends (`crate::serve::history`); this module is the glue
+//! the executor calls after every successful **root** invocation:
+//!
+//! - [`spec`] — the top-level `catalog:` config block (`faucet schema catalog`).
+//! - [`model`] — pure URI canonicalization + sample-schema inference.
+//! - [`CatalogHandle`] / [`connect_from_spec`] — the store handle carried on
+//!   `ExecuteOptions` (serve passes its own history backend; the CLI runtimes
+//!   connect from the `catalog:` block).
+//! - [`record`] — the never-fails-the-run write (mirrors the SLA / lineage
+//!   "log-and-continue" contract).
+//!
+//! Gated on the `catalog` Cargo feature (implies `serve` for the storage
+//! backends and `lineage` for record sampling + column-lineage derivation).
+
+pub mod model;
+pub mod spec;
+
+pub use spec::CatalogSpec;
+
+use crate::error::{CliError, CliResult};
+use crate::serve::config::HistoryBackendSpec;
+use crate::serve::history::{self, RunHistory, catalog::CatalogUpdate};
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Default per-side schema-inference sample cap when no `catalog:` block set
+/// one (the serve write path, which has no block).
+pub const DEFAULT_SAMPLE_RECORDS: usize = 100;
+
+/// The catalog store handle carried on `ExecuteOptions`. Cheaply cloneable.
+#[derive(Clone)]
+pub struct CatalogHandle {
+    pub store: Arc<dyn RunHistory>,
+    /// Provenance run id recorded on every catalog row this run produces —
+    /// the serve run id when running under `faucet serve`, `None` for CLI
+    /// runtimes (each invocation then stamps its own observability run id).
+    pub run_id: Option<String>,
+    /// Per-side schema-inference sample cap.
+    pub sample_records: usize,
+}
+
+impl std::fmt::Debug for CatalogHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CatalogHandle")
+            .field("run_id", &self.run_id)
+            .field("sample_records", &self.sample_records)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Build a catalog store from the `catalog:` block. Errors are config-level
+/// (bad scheme / missing build feature) and fail fast at load time; an
+/// *unreachable* SQL backend degrades to in-memory via `FallbackHistory`
+/// (logged, run unaffected) exactly like `faucet serve --history`.
+pub async fn connect_from_spec(spec: &CatalogSpec) -> CliResult<CatalogHandle> {
+    let backend = parse_url(&spec.url)?;
+    let store = history::connect(
+        &backend,
+        // Idempotency claims + run leases are run-history concerns; the
+        // catalog-only connection never uses them.
+        Duration::from_secs(3600),
+        Duration::from_secs(30),
+        &uuid::Uuid::now_v7().to_string(),
+    )
+    .await?;
+    Ok(CatalogHandle {
+        store,
+        run_id: None,
+        sample_records: spec.sample_records,
+    })
+}
+
+/// Parse the `catalog.url` field into a history-backend selection.
+fn parse_url(url: &str) -> CliResult<HistoryBackendSpec> {
+    match url {
+        "memory" => Ok(HistoryBackendSpec::Memory),
+        u if u.starts_with("postgres://") || u.starts_with("postgresql://") => {
+            Ok(HistoryBackendSpec::Postgres(u.to_string()))
+        }
+        u if u.starts_with("sqlite:") => Ok(HistoryBackendSpec::Sqlite(u.to_string())),
+        other => Err(CliError::Config(format!(
+            "catalog.url '{other}' is not recognised — expected 'memory', 'sqlite:<path>', \
+             or a 'postgres://…' URL"
+        ))),
+    }
+}
+
+/// Persist one run's catalog update. Monitoring must never take down the run
+/// it observes: any backend error is logged once per call and swallowed.
+pub async fn record(handle: &CatalogHandle, update: &CatalogUpdate) {
+    if let Err(e) = handle.store.catalog_record(update).await {
+        tracing::warn!(
+            pipeline = %update.pipeline,
+            row = %update.row,
+            error = %e,
+            "catalog write failed — run unaffected"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn connect_memory_and_reject_unknown_scheme() {
+        let handle = connect_from_spec(&CatalogSpec {
+            url: "memory".into(),
+            sample_records: 25,
+        })
+        .await
+        .unwrap();
+        assert_eq!(handle.sample_records, 25);
+        assert!(handle.run_id.is_none());
+
+        let err = connect_from_spec(&CatalogSpec {
+            url: "mysql://nope".into(),
+            sample_records: 100,
+        })
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("catalog.url"), "{err}");
+    }
+}

--- a/cli/src/catalog/mod.rs
+++ b/cli/src/catalog/mod.rs
@@ -126,4 +126,38 @@ mod tests {
         .unwrap_err();
         assert!(err.to_string().contains("catalog.url"), "{err}");
     }
+
+    #[test]
+    fn parse_url_recognises_all_three_schemes() {
+        assert!(matches!(
+            parse_url("sqlite:./cat.db"),
+            Ok(HistoryBackendSpec::Sqlite(u)) if u == "sqlite:./cat.db"
+        ));
+        assert!(matches!(
+            parse_url("postgres://h/db"),
+            Ok(HistoryBackendSpec::Postgres(_))
+        ));
+        assert!(matches!(
+            parse_url("postgresql://h/db"),
+            Ok(HistoryBackendSpec::Postgres(_))
+        ));
+        assert!(matches!(
+            parse_url("memory"),
+            Ok(HistoryBackendSpec::Memory)
+        ));
+        assert!(parse_url("bogus").is_err());
+    }
+
+    #[tokio::test]
+    async fn handle_debug_never_prints_the_store() {
+        let handle = connect_from_spec(&CatalogSpec {
+            url: "memory".into(),
+            sample_records: 7,
+        })
+        .await
+        .unwrap();
+        let dbg = format!("{handle:?}");
+        assert!(dbg.contains("sample_records: 7"), "{dbg}");
+        assert!(dbg.contains(".."), "non-exhaustive marker expected: {dbg}");
+    }
 }

--- a/cli/src/catalog/model.rs
+++ b/cli/src/catalog/model.rs
@@ -1,0 +1,133 @@
+//! Pure helpers for building catalog observations (#279): dataset-URI
+//! canonicalization (fold `${now.*}`-derived segments back to their tokens,
+//! redact credentials) and schema inference over the run's record samples.
+
+use chrono::{DateTime, FixedOffset};
+use serde_json::Value;
+
+/// Canonicalize a concrete dataset URI for use as the catalog identity key.
+///
+/// 1. **`${now.*}` folding** — a dated path like `./out/dt=2026-07-06/x.jsonl`
+///    produced by a `${now.date}` template would otherwise mint a new catalog
+///    dataset every day (the cardinality trap called out in #279). For every
+///    `${now.*}` token that appears in the connector's *raw* (pre-resolution)
+///    config, the token's rendered value is replaced back with the token text
+///    in the URI, so all runs of the template converge on one dataset.
+/// 2. **Credential redaction** — via `faucet_core::redact_uri_credentials`,
+///    so a `postgres://user:pass@host/db` URI never lands in the store.
+pub fn canonicalize_uri(uri: &str, raw_config: &Value, clock: DateTime<FixedOffset>) -> String {
+    let mut tokens: Vec<String> = Vec::new();
+    collect_now_tokens(raw_config, &mut tokens);
+    tokens.sort();
+    tokens.dedup();
+
+    // Render each token with the same clock the run used, then substitute the
+    // rendered text back to the token — longest rendering first, so e.g.
+    // `${now.datetime}` wins over the `${now.year}` embedded within it.
+    let mut pairs: Vec<(String, String)> = tokens
+        .into_iter()
+        .filter_map(|t| {
+            crate::interpolate::resolve_now(&t, clock)
+                .ok()
+                .filter(|rendered| !rendered.is_empty() && rendered != &t)
+                .map(|rendered| (rendered, t))
+        })
+        .collect();
+    pairs.sort_by(|a, b| b.0.len().cmp(&a.0.len()));
+
+    let mut out = uri.to_string();
+    for (rendered, token) in pairs {
+        out = out.replace(&rendered, &token);
+    }
+    faucet_core::redact_uri_credentials(&out)
+}
+
+/// Collect every `${now.…}` token appearing in the string values of `v`.
+fn collect_now_tokens(v: &Value, out: &mut Vec<String>) {
+    match v {
+        Value::String(s) => {
+            let mut rest = s.as_str();
+            while let Some(start) = rest.find("${now.") {
+                let tail = &rest[start..];
+                match tail.find('}') {
+                    Some(end) => {
+                        out.push(tail[..=end].to_string());
+                        rest = &tail[end + 1..];
+                    }
+                    None => break,
+                }
+            }
+        }
+        Value::Array(items) => items.iter().for_each(|i| collect_now_tokens(i, out)),
+        Value::Object(map) => map.values().for_each(|i| collect_now_tokens(i, out)),
+        _ => {}
+    }
+}
+
+/// Infer an `infer_schema`-shaped record schema from a run's sample, `None`
+/// when nothing was sampled (empty run, or non-object records only).
+pub fn schema_from_samples(samples: &[Value]) -> Option<Value> {
+    if samples.is_empty() {
+        return None;
+    }
+    let schema = faucet_core::schema::infer_schema(samples);
+    // A sample of non-object records infers no properties — not a schema
+    // worth a timeline entry.
+    schema
+        .get("properties")
+        .and_then(Value::as_object)
+        .is_some_and(|p| !p.is_empty())
+        .then_some(schema)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn clock() -> DateTime<FixedOffset> {
+        DateTime::parse_from_rfc3339("2026-07-06T10:30:00Z").unwrap()
+    }
+
+    #[test]
+    fn folds_now_tokens_back_into_the_uri() {
+        let raw = json!({"path": "./out/dt=${now.date}/part.jsonl"});
+        let uri = canonicalize_uri("file://./out/dt=2026-07-06/part.jsonl", &raw, clock());
+        assert_eq!(uri, "file://./out/dt=${now.date}/part.jsonl");
+    }
+
+    #[test]
+    fn folds_strftime_tokens_and_ignores_unused_ones() {
+        let raw = json!({"path": "./out/${now.strftime.%Y/%m}/x.jsonl", "other": "${now.unix}"});
+        let uri = canonicalize_uri("file://./out/2026/07/x.jsonl", &raw, clock());
+        assert_eq!(uri, "file://./out/${now.strftime.%Y/%m}/x.jsonl");
+    }
+
+    #[test]
+    fn without_now_tokens_the_uri_is_untouched_except_redaction() {
+        let raw = json!({"connection_url": "postgres://u:pw@h:5432/db"});
+        let uri = canonicalize_uri("postgres://u:pw@h:5432/db/public.users", &raw, clock());
+        assert!(!uri.contains("pw"), "credentials must be redacted: {uri}");
+        assert!(uri.contains("h:5432"));
+    }
+
+    #[test]
+    fn collect_finds_multiple_tokens_in_one_string() {
+        let mut out = Vec::new();
+        collect_now_tokens(&json!("a-${now.year}-${now.month}-b"), &mut out);
+        assert_eq!(out, vec!["${now.year}", "${now.month}"]);
+        // Unterminated token is ignored, not a panic.
+        out.clear();
+        collect_now_tokens(&json!("broken ${now.date"), &mut out);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn schema_from_samples_requires_object_records() {
+        assert!(schema_from_samples(&[]).is_none());
+        assert!(schema_from_samples(&[json!("scalar")]).is_none());
+        let schema = schema_from_samples(&[json!({"id": 1, "name": "a"})]).unwrap();
+        assert_eq!(schema["type"], "object");
+        assert!(schema["properties"]["id"].is_object());
+    }
+}

--- a/cli/src/catalog/model.rs
+++ b/cli/src/catalog/model.rs
@@ -120,6 +120,10 @@ mod tests {
         out.clear();
         collect_now_tokens(&json!("broken ${now.date"), &mut out);
         assert!(out.is_empty());
+        // Tokens inside arrays (e.g. a list-valued config field) are found too.
+        out.clear();
+        collect_now_tokens(&json!({"paths": ["x", "${now.date}"]}), &mut out);
+        assert_eq!(out, vec!["${now.date}"]);
     }
 
     #[test]

--- a/cli/src/catalog/model.rs
+++ b/cli/src/catalog/model.rs
@@ -33,7 +33,7 @@ pub fn canonicalize_uri(uri: &str, raw_config: &Value, clock: DateTime<FixedOffs
                 .map(|rendered| (rendered, t))
         })
         .collect();
-    pairs.sort_by(|a, b| b.0.len().cmp(&a.0.len()));
+    pairs.sort_by_key(|(rendered, _)| std::cmp::Reverse(rendered.len()));
 
     let mut out = uri.to_string();
     for (rendered, token) in pairs {

--- a/cli/src/catalog/spec.rs
+++ b/cli/src/catalog/spec.rs
@@ -1,0 +1,56 @@
+//! Serde config types for the top-level `catalog:` block (#279).
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+fn default_sample_records() -> usize {
+    100
+}
+
+/// The top-level `catalog:` block: opts a `faucet run` / `schedule` /
+/// `replicate` pipeline into recording the Data Movement Catalog after every
+/// successful root invocation. `faucet serve` records into its `--history`
+/// backend automatically — this block is for the non-serve runtimes (and for
+/// `faucet catalog`, which reads the same store).
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct CatalogSpec {
+    /// Where the catalog is stored: `sqlite:<path>` (e.g.
+    /// `sqlite:./faucet-catalog.db`), a `postgres://…` URL, or `memory`
+    /// (process-lifetime only — useful for tests). SQL backends require the
+    /// matching `serve-history-sqlite` / `serve-history-postgres` build
+    /// feature. Point `faucet serve --history` at the same URL to browse the
+    /// accumulated catalog in the control plane + web console.
+    pub url: String,
+
+    /// How many records to sample per run for schema inference (per side).
+    /// The sample bounds memory; the schema timeline only ever stores the
+    /// inferred schema, never the records.
+    #[serde(default = "default_sample_records")]
+    pub sample_records: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_minimal_block_with_defaults() {
+        let spec: CatalogSpec = serde_yaml::from_str("url: sqlite:./cat.db").unwrap();
+        assert_eq!(spec.url, "sqlite:./cat.db");
+        assert_eq!(spec.sample_records, 100);
+    }
+
+    #[test]
+    fn rejects_unknown_fields() {
+        let err = serde_yaml::from_str::<CatalogSpec>("url: memory\nnope: 1").unwrap_err();
+        assert!(err.to_string().contains("nope"));
+    }
+
+    #[test]
+    fn schema_generates() {
+        let schema = schemars::schema_for!(CatalogSpec);
+        let v = serde_json::to_value(&schema).unwrap();
+        assert!(v["properties"]["url"].is_object());
+    }
+}

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -61,6 +61,96 @@ pub enum Command {
     /// to validate channel setup end-to-end (no pipeline runs).
     #[cfg(feature = "notify")]
     Notify(NotifyArgs),
+    /// Browse the Data Movement Catalog accumulated by a config's `catalog:`
+    /// store — datasets, schema timelines, volume/freshness, lineage.
+    #[cfg(feature = "catalog")]
+    Catalog(CatalogArgs),
+}
+
+/// `faucet catalog` arguments.
+#[cfg(feature = "catalog")]
+#[derive(Debug, Parser)]
+pub struct CatalogArgs {
+    #[command(subcommand)]
+    pub command: CatalogCommand,
+}
+
+/// `faucet catalog` subcommands.
+#[cfg(feature = "catalog")]
+#[derive(Debug, Subcommand)]
+pub enum CatalogCommand {
+    /// List every catalogued dataset (newest activity first).
+    Datasets(CatalogDatasetsArgs),
+    /// Show one dataset's detail: schema timeline, volume points, edges.
+    Show(CatalogShowArgs),
+    /// Print the dataset lineage graph (optionally rooted at a dataset).
+    Lineage(CatalogLineageArgs),
+}
+
+/// Shared config-loading flags for the `faucet catalog` subcommands.
+#[cfg(feature = "catalog")]
+#[derive(Debug, Parser)]
+pub struct CatalogConfigArgs {
+    /// Path to a `.yaml`, `.yml`, or `.json` pipeline config with a
+    /// `catalog:` block naming the store. If omitted, auto-discover
+    /// `faucet.yaml` / `faucet.yml` / `faucet.json` in cwd.
+    #[arg(long)]
+    pub config: Option<PathBuf>,
+    /// Path to a `.env` file to load for `${env:VAR}` interpolation.
+    /// Defaults to `.env` in cwd if present.
+    #[arg(long, conflicts_with = "no_env_file")]
+    pub env_file: Option<PathBuf>,
+    /// Skip auto-loading `.env` from cwd.
+    #[arg(long)]
+    pub no_env_file: bool,
+    /// Select a named overlay from the config's `profiles:` block.
+    /// Overrides the `FAUCET_PROFILE` env var.
+    #[arg(long, env = "FAUCET_PROFILE")]
+    pub profile: Option<String>,
+    /// Emit machine-readable JSON instead of the human summary.
+    #[arg(long)]
+    pub json: bool,
+}
+
+/// `faucet catalog datasets` arguments.
+#[cfg(feature = "catalog")]
+#[derive(Debug, Parser)]
+pub struct CatalogDatasetsArgs {
+    #[command(flatten)]
+    pub common: CatalogConfigArgs,
+    /// Only datasets of this connector kind (e.g. `postgres`, `csv`).
+    #[arg(long)]
+    pub kind: Option<String>,
+    /// Case-insensitive substring match on the dataset URI.
+    #[arg(long)]
+    pub q: Option<String>,
+    /// Max datasets to list.
+    #[arg(long, default_value_t = 100)]
+    pub limit: usize,
+}
+
+/// `faucet catalog show <id>` arguments.
+#[cfg(feature = "catalog")]
+#[derive(Debug, Parser)]
+pub struct CatalogShowArgs {
+    /// Dataset id (from `faucet catalog datasets`), or a unique prefix of one.
+    pub id: String,
+    #[command(flatten)]
+    pub common: CatalogConfigArgs,
+}
+
+/// `faucet catalog lineage` arguments.
+#[cfg(feature = "catalog")]
+#[derive(Debug, Parser)]
+pub struct CatalogLineageArgs {
+    #[command(flatten)]
+    pub common: CatalogConfigArgs,
+    /// Dataset id to root the graph at (whole graph when omitted).
+    #[arg(long)]
+    pub root: Option<String>,
+    /// BFS hop bound around --root.
+    #[arg(long, default_value_t = 5)]
+    pub depth: u32,
 }
 
 /// `faucet notify test` arguments.
@@ -578,6 +668,9 @@ pub enum SchemaTarget {
     /// JSON Schema for the `notifications:` (incident-routing) block.
     #[cfg(feature = "notify")]
     Notifications,
+    /// JSON Schema for the `catalog:` (Data Movement Catalog store) block.
+    #[cfg(feature = "catalog")]
+    Catalog,
 }
 
 /// `faucet preview` arguments.

--- a/cli/src/commands/catalog.rs
+++ b/cli/src/commands/catalog.rs
@@ -1,0 +1,318 @@
+//! `faucet catalog` — browse the Data Movement Catalog (#279) accumulated by
+//! a config's `catalog:` store: datasets, schema timelines, volume/freshness,
+//! and the lineage graph. Read-only; the same store `faucet run` / `schedule`
+//! / `replicate` write into (point `faucet serve --history` at the same URL to
+//! browse it in the control plane / web console instead).
+
+use crate::catalog::CatalogHandle;
+use crate::cli::{
+    CatalogArgs, CatalogCommand, CatalogConfigArgs, CatalogDatasetsArgs, CatalogLineageArgs,
+    CatalogShowArgs,
+};
+use crate::config::PipelineConfig;
+use crate::error::{CliError, CliResult};
+use crate::serve::history::catalog::{
+    CatalogDataset, CatalogDatasetDetail, CatalogLineageEdge, CatalogListFilter,
+};
+
+/// Pretty-print any serializable value (JSON output mode).
+fn to_pretty<T: serde::Serialize>(value: &T) -> CliResult<String> {
+    serde_json::to_string_pretty(value)
+        .map_err(|e| CliError::Internal(format!("rendering catalog JSON: {e}")))
+}
+
+/// Execute the `catalog` subcommand.
+pub async fn run(args: CatalogArgs) -> CliResult<()> {
+    match args.command {
+        CatalogCommand::Datasets(a) => datasets(a).await,
+        CatalogCommand::Show(a) => show(a).await,
+        CatalogCommand::Lineage(a) => lineage(a).await,
+    }
+}
+
+/// Load the config named by the shared flags and connect its `catalog:` store.
+async fn connect(common: &CatalogConfigArgs) -> CliResult<CatalogHandle> {
+    let cwd = std::env::current_dir()?;
+    let env_path =
+        crate::env_loader::resolve_env_file(common.env_file.as_deref(), common.no_env_file, &cwd)?;
+    crate::env_loader::load_env_file_if_present(env_path.as_deref())?;
+    let path = match &common.config {
+        Some(p) => p.clone(),
+        None => crate::env_loader::discover_config_path(&cwd).ok_or(CliError::NoConfigOrFromEnv)?,
+    };
+    let cfg = PipelineConfig::from_path_async(&path, common.profile.as_deref()).await?;
+    let spec = cfg.catalog.as_ref().ok_or_else(|| {
+        CliError::Config(
+            "no `catalog:` block in this config — add one naming the store (e.g. \
+             `catalog: { url: sqlite:./faucet-catalog.db }`), or run \
+             `faucet schema catalog` for the block's JSON Schema"
+                .to_string(),
+        )
+    })?;
+    crate::catalog::connect_from_spec(spec).await
+}
+
+async fn datasets(args: CatalogDatasetsArgs) -> CliResult<()> {
+    let handle = connect(&args.common).await?;
+    let page = handle
+        .store
+        .catalog_list_datasets(&CatalogListFilter {
+            kind: args.kind,
+            q: args.q,
+            limit: args.limit.max(1),
+            cursor: None,
+        })
+        .await
+        .map_err(|e| CliError::Internal(format!("catalog read: {e}")))?;
+    if args.common.json {
+        println!("{}", to_pretty(&page)?);
+        return Ok(());
+    }
+    if page.datasets.is_empty() {
+        println!("catalog is empty — run a pipeline with this `catalog:` store first");
+        return Ok(());
+    }
+    println!(
+        "{:<16}  {:<12}  {:<12}  {:>5}  {:>12}  {:<20}  URI",
+        "ID", "KIND", "ROLES", "RUNS", "ROWS (LAST)", "LAST SUCCESS"
+    );
+    for d in &page.datasets {
+        println!(
+            "{:<16}  {:<12}  {:<12}  {:>5}  {:>12}  {:<20}  {}",
+            d.id,
+            d.kind,
+            d.roles.join(","),
+            d.runs,
+            d.last_records,
+            d.last_success.format("%Y-%m-%dT%H:%M:%SZ"),
+            d.uri
+        );
+    }
+    if page.next_cursor.is_some() {
+        println!("… more — raise --limit to see the rest");
+    }
+    Ok(())
+}
+
+/// Resolve `id` against the store, accepting a unique prefix of a dataset id.
+async fn resolve_dataset(
+    handle: &CatalogHandle,
+    id: &str,
+) -> CliResult<Option<CatalogDatasetDetail>> {
+    if let Some(detail) = handle
+        .store
+        .catalog_get_dataset(id)
+        .await
+        .map_err(|e| CliError::Internal(format!("catalog read: {e}")))?
+    {
+        return Ok(Some(detail));
+    }
+    // Prefix match over the (bounded) dataset list.
+    let page = handle
+        .store
+        .catalog_list_datasets(&CatalogListFilter {
+            limit: 1000,
+            ..Default::default()
+        })
+        .await
+        .map_err(|e| CliError::Internal(format!("catalog read: {e}")))?;
+    let matches: Vec<&CatalogDataset> = page
+        .datasets
+        .iter()
+        .filter(|d| d.id.starts_with(id))
+        .collect();
+    match matches.as_slice() {
+        [one] => {
+            let full = one.id.clone();
+            handle
+                .store
+                .catalog_get_dataset(&full)
+                .await
+                .map_err(|e| CliError::Internal(format!("catalog read: {e}")))
+        }
+        [] => Ok(None),
+        many => Err(CliError::Config(format!(
+            "dataset id prefix '{id}' is ambiguous ({} matches) — use the full id",
+            many.len()
+        ))),
+    }
+}
+
+async fn show(args: CatalogShowArgs) -> CliResult<()> {
+    let handle = connect(&args.common).await?;
+    let detail = resolve_dataset(&handle, &args.id).await?.ok_or_else(|| {
+        CliError::Config(format!(
+            "no catalogued dataset with id '{}' — list ids with `faucet catalog datasets`",
+            args.id
+        ))
+    })?;
+    if args.common.json {
+        println!("{}", to_pretty(&detail)?);
+        return Ok(());
+    }
+    let d = &detail.dataset;
+    println!("dataset  {}", d.uri);
+    println!("id       {}", d.id);
+    println!("kind     {}   roles {}", d.kind, d.roles.join(","));
+    println!("pipeline {}   last run {}", d.pipeline, d.last_run_id);
+    println!(
+        "runs     {}   rows {} (last) / {} (total)",
+        d.runs, d.last_records, d.total_records
+    );
+    println!(
+        "seen     {} → {}   last success {}",
+        d.first_seen.format("%Y-%m-%dT%H:%M:%SZ"),
+        d.last_seen.format("%Y-%m-%dT%H:%M:%SZ"),
+        d.last_success.format("%Y-%m-%dT%H:%M:%SZ"),
+    );
+
+    println!("\nschema timeline ({} versions):", detail.schema_timeline.len());
+    for v in &detail.schema_timeline {
+        let cols = v.schema["properties"]
+            .as_object()
+            .map(|p| p.len())
+            .unwrap_or(0);
+        print!(
+            "  v{}  {}  {} column(s)  run {}",
+            v.version,
+            v.recorded_at.format("%Y-%m-%dT%H:%M:%SZ"),
+            cols,
+            v.run_id
+        );
+        if let Some(diff) = &v.diff {
+            let names = |key: &str| -> Vec<String> {
+                diff[key]
+                    .as_array()
+                    .map(|a| {
+                        a.iter()
+                            .filter_map(|c| {
+                                c.get("column")
+                                    .or(Some(c))
+                                    .and_then(|v| v.as_str())
+                                    .map(String::from)
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default()
+            };
+            let mut parts = Vec::new();
+            for (label, key) in [("+", "added"), ("~", "widened"), ("!", "changed"), ("-", "removed")] {
+                let n = names(key);
+                if !n.is_empty() {
+                    parts.push(format!("{label}{}", n.join(&format!(" {label}"))));
+                }
+            }
+            if !parts.is_empty() {
+                print!("  [{}]", parts.join("  "));
+            }
+        }
+        println!();
+    }
+
+    println!("\nrecent volume (newest first):");
+    for p in detail.stats.iter().take(10) {
+        println!(
+            "  {}  {:>10} row(s)  run {}",
+            p.recorded_at.format("%Y-%m-%dT%H:%M:%SZ"),
+            p.records,
+            p.run_id
+        );
+    }
+
+    println!("\nupstream:");
+    if detail.upstream.is_empty() {
+        println!("  (none)");
+    }
+    for e in &detail.upstream {
+        println!("  {}  ({} run(s), pipeline {})", e.src_uri, e.runs, e.pipeline);
+    }
+    println!("downstream:");
+    if detail.downstream.is_empty() {
+        println!("  (none)");
+    }
+    for e in &detail.downstream {
+        println!("  {}  ({} run(s), pipeline {})", e.dst_uri, e.runs, e.pipeline);
+    }
+    Ok(())
+}
+
+async fn lineage(args: CatalogLineageArgs) -> CliResult<()> {
+    let handle = connect(&args.common).await?;
+    let edges = handle
+        .store
+        .catalog_lineage(args.root.as_deref(), args.depth.max(1))
+        .await
+        .map_err(|e| CliError::Internal(format!("catalog read: {e}")))?;
+    if args.common.json {
+        println!("{}", to_pretty(&serde_json::json!({ "edges": edges }))?);
+        return Ok(());
+    }
+    if edges.is_empty() {
+        println!("no lineage edges recorded{}", match &args.root {
+            Some(r) => format!(" around '{r}'"),
+            None => String::new(),
+        });
+        return Ok(());
+    }
+    print!("{}", render_edges(&edges));
+    Ok(())
+}
+
+/// Human rendering of the edge list: `src → dst` grouped lines.
+fn render_edges(edges: &[CatalogLineageEdge]) -> String {
+    let mut out = String::new();
+    for e in edges {
+        out.push_str(&format!(
+            "{}  →  {}\n    pipeline {} (row {}), {} run(s), {} row(s) last, last seen {}{}\n",
+            e.src_uri,
+            e.dst_uri,
+            e.pipeline,
+            e.row,
+            e.runs,
+            e.last_records,
+            e.last_seen.format("%Y-%m-%dT%H:%M:%SZ"),
+            if e.column_lineage.is_some() {
+                ", column lineage recorded"
+            } else {
+                ""
+            }
+        ));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::serve::history::catalog::{CatalogUpdate, DatasetObservation, DatasetRole, apply_edge};
+
+    #[test]
+    fn render_edges_lists_each_edge_with_context() {
+        let update = CatalogUpdate {
+            run_id: "r9".into(),
+            pipeline: "p".into(),
+            row: "default".into(),
+            recorded_at: chrono::Utc::now(),
+            source: DatasetObservation {
+                uri: "csv://./in.csv".into(),
+                kind: "csv".into(),
+                role: DatasetRole::Source,
+                schema: None,
+                records: 4,
+            },
+            sink: DatasetObservation {
+                uri: "jsonl://./out.jsonl".into(),
+                kind: "jsonl".into(),
+                role: DatasetRole::Sink,
+                schema: None,
+                records: 4,
+            },
+            column_lineage: Some(serde_json::json!({"fields": {}})),
+        };
+        let edge = apply_edge(None, &update);
+        let text = render_edges(&[edge]);
+        assert!(text.contains("csv://./in.csv  →  jsonl://./out.jsonl"), "{text}");
+        assert!(text.contains("pipeline p (row default), 1 run(s)"), "{text}");
+        assert!(text.contains("column lineage recorded"), "{text}");
+    }
+}

--- a/cli/src/commands/catalog.rs
+++ b/cli/src/commands/catalog.rs
@@ -166,7 +166,10 @@ async fn show(args: CatalogShowArgs) -> CliResult<()> {
         d.last_success.format("%Y-%m-%dT%H:%M:%SZ"),
     );
 
-    println!("\nschema timeline ({} versions):", detail.schema_timeline.len());
+    println!(
+        "\nschema timeline ({} versions):",
+        detail.schema_timeline.len()
+    );
     for v in &detail.schema_timeline {
         let cols = v.schema["properties"]
             .as_object()
@@ -196,7 +199,12 @@ async fn show(args: CatalogShowArgs) -> CliResult<()> {
                     .unwrap_or_default()
             };
             let mut parts = Vec::new();
-            for (label, key) in [("+", "added"), ("~", "widened"), ("!", "changed"), ("-", "removed")] {
+            for (label, key) in [
+                ("+", "added"),
+                ("~", "widened"),
+                ("!", "changed"),
+                ("-", "removed"),
+            ] {
                 let n = names(key);
                 if !n.is_empty() {
                     parts.push(format!("{label}{}", n.join(&format!(" {label}"))));
@@ -224,14 +232,20 @@ async fn show(args: CatalogShowArgs) -> CliResult<()> {
         println!("  (none)");
     }
     for e in &detail.upstream {
-        println!("  {}  ({} run(s), pipeline {})", e.src_uri, e.runs, e.pipeline);
+        println!(
+            "  {}  ({} run(s), pipeline {})",
+            e.src_uri, e.runs, e.pipeline
+        );
     }
     println!("downstream:");
     if detail.downstream.is_empty() {
         println!("  (none)");
     }
     for e in &detail.downstream {
-        println!("  {}  ({} run(s), pipeline {})", e.dst_uri, e.runs, e.pipeline);
+        println!(
+            "  {}  ({} run(s), pipeline {})",
+            e.dst_uri, e.runs, e.pipeline
+        );
     }
     Ok(())
 }
@@ -248,10 +262,13 @@ async fn lineage(args: CatalogLineageArgs) -> CliResult<()> {
         return Ok(());
     }
     if edges.is_empty() {
-        println!("no lineage edges recorded{}", match &args.root {
-            Some(r) => format!(" around '{r}'"),
-            None => String::new(),
-        });
+        println!(
+            "no lineage edges recorded{}",
+            match &args.root {
+                Some(r) => format!(" around '{r}'"),
+                None => String::new(),
+            }
+        );
         return Ok(());
     }
     print!("{}", render_edges(&edges));
@@ -284,7 +301,9 @@ fn render_edges(edges: &[CatalogLineageEdge]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::serve::history::catalog::{CatalogUpdate, DatasetObservation, DatasetRole, apply_edge};
+    use crate::serve::history::catalog::{
+        CatalogUpdate, DatasetObservation, DatasetRole, apply_edge,
+    };
 
     #[test]
     fn render_edges_lists_each_edge_with_context() {
@@ -311,8 +330,14 @@ mod tests {
         };
         let edge = apply_edge(None, &update);
         let text = render_edges(&[edge]);
-        assert!(text.contains("csv://./in.csv  →  jsonl://./out.jsonl"), "{text}");
-        assert!(text.contains("pipeline p (row default), 1 run(s)"), "{text}");
+        assert!(
+            text.contains("csv://./in.csv  →  jsonl://./out.jsonl"),
+            "{text}"
+        );
+        assert!(
+            text.contains("pipeline p (row default), 1 run(s)"),
+            "{text}"
+        );
         assert!(text.contains("column lineage recorded"), "{text}");
     }
 }

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,6 +1,8 @@
 //! Subcommand implementations. Each module owns its `run(...)` entry point
 //! and stays free of clap so the integration tests can drive it directly.
 
+#[cfg(feature = "catalog")]
+pub mod catalog;
 #[cfg(feature = "contract")]
 pub mod contract;
 pub mod dlq;

--- a/cli/src/commands/replicate.rs
+++ b/cli/src/commands/replicate.rs
@@ -46,6 +46,11 @@ pub async fn run(args: ReplicateArgs) -> CliResult<()> {
     };
     #[cfg(feature = "notify")]
     let notifier = crate::notify::Notifier::from_specs(&cfg.notifications)?;
+    #[cfg(feature = "catalog")]
+    let catalog = match cfg.catalog.as_ref() {
+        Some(spec) => Some(crate::catalog::connect_from_spec(spec).await?),
+        None => None,
+    };
 
     run_replication(
         &cfg,
@@ -59,6 +64,8 @@ pub async fn run(args: ReplicateArgs) -> CliResult<()> {
             sla: cfg.sla.clone(),
             #[cfg(feature = "notify")]
             notifier,
+            #[cfg(feature = "catalog")]
+            catalog,
         },
     )
     .await?;

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -87,6 +87,11 @@ pub async fn run(args: RunArgs) -> CliResult<()> {
     };
     #[cfg(feature = "notify")]
     let notifier = crate::notify::Notifier::from_specs(&cfg.notifications)?;
+    #[cfg(feature = "catalog")]
+    let catalog = match cfg.catalog.as_ref() {
+        Some(spec) => Some(crate::catalog::connect_from_spec(spec).await?),
+        None => None,
+    };
     let nodes = expand(&cfg)?;
     let summary = run_expanded(
         nodes,
@@ -110,6 +115,8 @@ pub async fn run(args: RunArgs) -> CliResult<()> {
             lineage_cfg: cfg.lineage.clone(),
             #[cfg(feature = "notify")]
             notifier,
+            #[cfg(feature = "catalog")]
+            catalog,
         },
     )
     .await?;

--- a/cli/src/commands/schedule.rs
+++ b/cli/src/commands/schedule.rs
@@ -118,6 +118,13 @@ pub async fn run(args: ScheduleArgs) -> CliResult<()> {
     // reused for the scheduler-level `scheduler_stuck` signal.
     #[cfg(feature = "notify")]
     let notifier = crate::notify::Notifier::from_specs(&cfg.notifications)?;
+    // Connect the catalog store once; the handle (a pooled connection) is
+    // cloned into each tick's options so every run accumulates into it.
+    #[cfg(feature = "catalog")]
+    let catalog = match cfg.catalog.as_ref() {
+        Some(spec) => Some(crate::catalog::connect_from_spec(spec).await?),
+        None => None,
+    };
     let nodes = expand(&cfg)?; // validate once; cloned per tick
     let execution = cfg.execution.clone();
     let resilience = match &cfg.resilience {
@@ -140,6 +147,8 @@ pub async fn run(args: ScheduleArgs) -> CliResult<()> {
             &lineage_cfg,
             #[cfg(feature = "notify")]
             &notifier,
+            #[cfg(feature = "catalog")]
+            &catalog,
         )
         .await;
     }
@@ -160,6 +169,8 @@ pub async fn run(args: ScheduleArgs) -> CliResult<()> {
         lineage_cfg,
         #[cfg(feature = "notify")]
         notifier,
+        #[cfg(feature = "catalog")]
+        catalog,
     )
     .await
 }
@@ -177,6 +188,7 @@ fn make_opts(
     #[cfg(feature = "lineage")] lineage: &Option<std::sync::Arc<faucet_lineage::LineageEmitter>>,
     #[cfg(feature = "lineage")] lineage_cfg: &Option<faucet_lineage::LineageConfig>,
     #[cfg(feature = "notify")] notifier: &Option<std::sync::Arc<crate::notify::Notifier>>,
+    #[cfg(feature = "catalog")] catalog: &Option<crate::catalog::CatalogHandle>,
 ) -> ExecuteOptions {
     ExecuteOptions {
         pipeline_name: pipeline_name.to_string(),
@@ -196,6 +208,8 @@ fn make_opts(
         lineage_cfg: lineage_cfg.clone(),
         #[cfg(feature = "notify")]
         notifier: notifier.clone(),
+        #[cfg(feature = "catalog")]
+        catalog: catalog.clone(),
     }
 }
 
@@ -306,6 +320,7 @@ async fn run_once(
     #[cfg(feature = "lineage")] lineage: &Option<std::sync::Arc<faucet_lineage::LineageEmitter>>,
     #[cfg(feature = "lineage")] lineage_cfg: &Option<faucet_lineage::LineageConfig>,
     #[cfg(feature = "notify")] notifier: &Option<std::sync::Arc<crate::notify::Notifier>>,
+    #[cfg(feature = "catalog")] catalog: &Option<crate::catalog::CatalogHandle>,
 ) -> CliResult<()> {
     tracing::info!(pipeline = %pipeline_name, "schedule --once: running one pipeline now");
     let now = chrono::Utc::now();
@@ -322,6 +337,8 @@ async fn run_once(
         lineage_cfg,
         #[cfg(feature = "notify")]
         notifier,
+        #[cfg(feature = "catalog")]
+        catalog,
     );
     let span = run_span(1, now, now);
     let fut = run_expanded(nodes.to_vec(), opts).instrument(span);
@@ -357,6 +374,7 @@ async fn run_loop(
     #[cfg(feature = "lineage")] lineage: Option<std::sync::Arc<faucet_lineage::LineageEmitter>>,
     #[cfg(feature = "lineage")] lineage_cfg: Option<faucet_lineage::LineageConfig>,
     #[cfg(feature = "notify")] notifier: Option<std::sync::Arc<crate::notify::Notifier>>,
+    #[cfg(feature = "catalog")] catalog: Option<crate::catalog::CatalogHandle>,
 ) -> CliResult<()> {
     let mut state = SchedulerState::new(&compiled);
     // The circuit-breaker re-entry cooldown, if a breaker is configured. Used to
@@ -431,6 +449,8 @@ async fn run_loop(
                         &lineage_cfg,
                         #[cfg(feature = "notify")]
                         &notifier,
+                        #[cfg(feature = "catalog")]
+                        &catalog,
                     );
                     let span = run_span(run_ordinal, next_due, now);
                     let handle = spawn_run(nodes.clone(), opts, compiled.run_timeout, span);
@@ -579,6 +599,8 @@ async fn run_loop(
                                 &lineage_cfg,
                                 #[cfg(feature = "notify")]
                                 &notifier,
+                                #[cfg(feature = "catalog")]
+                                &catalog,
                             );
                             let span = run_span(run_ordinal, sched_for, done_at);
                             let handle = spawn_run(nodes.clone(), opts, compiled.run_timeout, span);
@@ -800,6 +822,8 @@ mod tests {
             &None,
             #[cfg(feature = "notify")]
             &None,
+            #[cfg(feature = "catalog")]
+            &None,
         );
         // A zero-ish timeout (1ns) virtually guarantees the timeout branch fires
         // even though the pipeline is fast — the timeout races the spawn.
@@ -834,6 +858,8 @@ mod tests {
             #[cfg(feature = "lineage")]
             &None,
             #[cfg(feature = "notify")]
+            &None,
+            #[cfg(feature = "catalog")]
             &None,
         );
         assert_eq!(opts.pipeline_name, "p");

--- a/cli/src/commands/schema.rs
+++ b/cli/src/commands/schema.rs
@@ -72,6 +72,11 @@ pub async fn run(args: SchemaArgs) -> CliResult<()> {
             let s = faucet_core::schema_for!(crate::notify::NotificationSpec);
             serde_json::to_value(s).unwrap_or_else(|_| serde_json::json!({"type": "object"}))
         }
+        #[cfg(feature = "catalog")]
+        SchemaTarget::Catalog => {
+            let s = faucet_core::schema_for!(crate::catalog::CatalogSpec);
+            serde_json::to_value(s).unwrap_or_else(|_| serde_json::json!({"type": "object"}))
+        }
         SchemaTarget::Secrets => serde_json::json!({
             "title": "Secrets-manager interpolation grammar",
             "schemes": {

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -122,6 +122,15 @@ pub struct PipelineConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub lineage: Option<faucet_lineage::LineageConfig>,
 
+    /// Optional Data Movement Catalog store (#279): where `faucet run` /
+    /// `schedule` / `replicate` accumulate the cross-run dataset catalog
+    /// (identity, schema timeline, volume/freshness, lineage edges). `faucet
+    /// serve` ignores this block and records into its `--history` backend.
+    /// Recording never fails a run. See `faucet schema catalog`.
+    #[cfg(feature = "catalog")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub catalog: Option<crate::catalog::CatalogSpec>,
+
     /// Optional notification / incident-routing rules (#280). Fan pipeline
     /// lifecycle and health events (run failure/success, SLA breach, circuit
     /// open, contract abort, DLQ threshold, scheduler stuck) out to Slack /

--- a/cli/src/dlq_replay/mod.rs
+++ b/cli/src/dlq_replay/mod.rs
@@ -196,6 +196,12 @@ pub async fn replay(
             lineage_cfg: None,
             #[cfg(feature = "notify")]
             notifier: None,
+            // A replay is a repair action over quarantined rows, not an
+            // observation of the original source — recording it would
+            // attribute the DLQ reader's rows to the pipeline's source
+            // dataset. Deliberately not catalogued.
+            #[cfg(feature = "catalog")]
+            catalog: None,
         },
     )
     .await?;

--- a/cli/src/env_config.rs
+++ b/cli/src/env_config.rs
@@ -336,6 +336,9 @@ pub fn build_pipeline_config(env: &HashMap<String, String>) -> CliResult<Pipelin
         schedule: None,
         #[cfg(feature = "lineage")]
         lineage: None,
+        // Pure-env mode doesn't (yet) assemble a `catalog:` block.
+        #[cfg(feature = "catalog")]
+        catalog: None,
         #[cfg(feature = "notify")]
         notifications: Vec::new(),
     })

--- a/cli/src/executor.rs
+++ b/cli/src/executor.rs
@@ -1330,9 +1330,7 @@ async fn run_one_invocation(
                     .map(|(out, ins)| {
                         (
                             out.clone(),
-                            Value::Array(
-                                ins.iter().map(|s| Value::String(s.clone())).collect(),
-                            ),
+                            Value::Array(ins.iter().map(|s| Value::String(s.clone())).collect()),
                         )
                     })
                     .collect();
@@ -1932,7 +1930,10 @@ mod tests {
         let summary = run_expanded(nodes, opts_with_catalog("cat-fail", handle))
             .await
             .unwrap();
-        assert!(!summary.had_failures(), "catalog failure must not fail the run");
+        assert!(
+            !summary.had_failures(),
+            "catalog failure must not fail the run"
+        );
         assert_eq!(summary.invocations[0].records_written, 1);
         assert_eq!(
             std::fs::read_to_string(&output).unwrap().lines().count(),

--- a/cli/src/executor.rs
+++ b/cli/src/executor.rs
@@ -106,6 +106,14 @@ pub struct ExecuteOptions {
     /// notifications entirely (zero overhead). Gated on the `notify` feature.
     #[cfg(feature = "notify")]
     pub notifier: Option<std::sync::Arc<crate::notify::Notifier>>,
+    /// Optional Data Movement Catalog store (#279), recorded into after every
+    /// successful **root** invocation (dataset identity, schema timeline,
+    /// volume/freshness, lineage edge). `faucet serve` passes its run-history
+    /// backend + the serve run id; the CLI runtimes connect one from the
+    /// `catalog:` block. `None` disables recording entirely (zero overhead).
+    /// Recording never fails the run. Gated on the `catalog` feature.
+    #[cfg(feature = "catalog")]
+    pub catalog: Option<crate::catalog::CatalogHandle>,
 }
 
 /// Grace window granted to in-flight invocations to flush cooperatively after
@@ -768,6 +776,15 @@ async fn run_one_invocation(
     #[cfg(feature = "lineage")]
     let lineage_cfg = opts.lineage_cfg.clone();
     let obs_labels = Labels::new(pipeline_name.clone(), row_id.clone(), run_id.clone());
+    // Whether this invocation records into the Data Movement Catalog (#279):
+    // roots only, and never for dry-run / --limit / shard runs (their volumes
+    // and datasets are partial or synthetic) — the same scoping as SLA.
+    #[cfg(feature = "catalog")]
+    let catalog_active = opts.catalog.is_some()
+        && matches!(node.role, NodeRole::Root)
+        && !opts.dry_run
+        && opts.limit.is_none()
+        && opts.shard.is_none();
     // 1) Resolve `${parent.path}` in the per-row source + sink configs.
     let mut source_cfg = node.source.config.clone();
     let mut sink_cfg = node.sink.config.clone();
@@ -800,6 +817,11 @@ async fn run_one_invocation(
         }
     };
 
+    // Catalog identity (#279): read the dataset URIs off the *raw* connectors,
+    // before any wrapper is layered on.
+    #[cfg(feature = "catalog")]
+    let source_dataset_uri = source.dataset_uri();
+
     // Clustered Mode B: narrow the raw source to its assigned shard BEFORE any
     // wrapping (the TransformingSource / StateKeyOverride wrappers do not forward
     // apply_shard, so it must reach the concrete connector).
@@ -814,6 +836,8 @@ async fn run_one_invocation(
     } else {
         build_sink(&node.sink.kind, sink_cfg, &opts.auth).await?
     };
+    #[cfg(feature = "catalog")]
+    let sink_dataset_uri = raw_sink.dataset_uri();
     let raw_sink: Box<dyn Sink> = match opts.limit {
         Some(n) => Box::new(LimitedSink::wrap(raw_sink, n)),
         None => raw_sink,
@@ -836,21 +860,35 @@ async fn run_one_invocation(
     #[cfg(feature = "lineage")]
     let (in_sample, out_sample) = {
         use std::sync::Arc as StdArc;
-        match (&lineage, &lineage_cfg) {
-            (Some(_), Some(lc)) => {
-                let want_schema = lc.include_schema_facet || lc.include_column_lineage;
-                let cap = if want_schema { lc.sample_records } else { 0 };
-                let need_counter = lc.emit_on.running;
-                if want_schema || need_counter {
-                    (
-                        Some(StdArc::new(faucet_lineage::SampleState::new(cap))),
-                        Some(StdArc::new(faucet_lineage::SampleState::new(cap))),
-                    )
-                } else {
-                    (None, None)
-                }
+        let mut want = false;
+        let mut cap = 0usize;
+        if let (Some(_), Some(lc)) = (&lineage, &lineage_cfg) {
+            let want_schema = lc.include_schema_facet || lc.include_column_lineage;
+            if want_schema {
+                cap = cap.max(lc.sample_records);
             }
-            _ => (None, None),
+            want = want_schema || lc.emit_on.running;
+        }
+        // The catalog (#279) needs input/output samples for schema inference
+        // and record counts regardless of any `lineage:` block; take the max
+        // of both caps when both are active.
+        #[cfg(feature = "catalog")]
+        if catalog_active {
+            want = true;
+            cap = cap.max(
+                opts.catalog
+                    .as_ref()
+                    .map(|h| h.sample_records)
+                    .unwrap_or(crate::catalog::DEFAULT_SAMPLE_RECORDS),
+            );
+        }
+        if want {
+            (
+                Some(StdArc::new(faucet_lineage::SampleState::new(cap))),
+                Some(StdArc::new(faucet_lineage::SampleState::new(cap))),
+            )
+        } else {
+            (None, None)
         }
     };
 
@@ -1238,6 +1276,94 @@ async fn run_one_invocation(
         }
     }
 
+    // ── Data Movement Catalog (#279) ─────────────────────────────────────────
+    // Fold this run's dataset observations + lineage edge into the catalog.
+    // Successful, complete root runs only (a cancelled run's partial volume is
+    // not a signal). Recording never fails the run — see `catalog::record`.
+    #[cfg(feature = "catalog")]
+    if let Some(handle) = &opts.catalog
+        && catalog_active
+        && !cancel.is_cancelled()
+        && let Ok(pipeline_result) = &result
+    {
+        use crate::catalog::model::{canonicalize_uri, schema_from_samples};
+        use crate::serve::history::catalog::{CatalogUpdate, DatasetObservation, DatasetRole};
+
+        let records_written = pipeline_result.records_written as u64;
+        let source_schema = in_sample
+            .as_ref()
+            .and_then(|s| schema_from_samples(&s.samples()));
+        let sink_schema = out_sample
+            .as_ref()
+            .and_then(|s| schema_from_samples(&s.samples()));
+        // The samplers are always installed while the catalog is active, so the
+        // unwrap_or arms are defensive only.
+        let records_read = in_sample
+            .as_ref()
+            .map(|s| s.count())
+            .unwrap_or(records_written);
+        let records_out = out_sample
+            .as_ref()
+            .map(|s| s.count())
+            .unwrap_or(records_written);
+
+        // Column lineage for the edge — the same derivation `faucet-lineage`
+        // emits, so the catalog's edges match the OpenLineage output.
+        let column_lineage = in_sample.as_ref().and_then(|s| {
+            let input_fields: Vec<String> = s
+                .inferred_schema()
+                .fields
+                .iter()
+                .map(|(n, _)| n.clone())
+                .collect();
+            #[cfg(feature = "masking")]
+            let has_masking = node.masking.is_some();
+            #[cfg(not(feature = "masking"))]
+            let has_masking = false;
+            let ops = crate::lineage_glue::column_ops(&node.transforms, has_masking);
+            faucet_lineage::derive_column_lineage(&input_fields, &ops).map(|cl| {
+                // `ColumnLineage` is not `Serialize` (IndexMap); render the
+                // stable `{"fields": {out: [in, …]}}` shape by hand.
+                let fields: serde_json::Map<String, Value> = cl
+                    .edges
+                    .iter()
+                    .map(|(out, ins)| {
+                        (
+                            out.clone(),
+                            Value::Array(
+                                ins.iter().map(|s| Value::String(s.clone())).collect(),
+                            ),
+                        )
+                    })
+                    .collect();
+                serde_json::json!({ "fields": fields })
+            })
+        });
+
+        let update = CatalogUpdate {
+            run_id: handle.run_id.clone().unwrap_or_else(|| run_id.clone()),
+            pipeline: obs_labels.pipeline.to_string(),
+            row: obs_labels.row.to_string(),
+            recorded_at: chrono::Utc::now(),
+            source: DatasetObservation {
+                uri: canonicalize_uri(&source_dataset_uri, &node.source.config, opts.clock),
+                kind: node.source.kind.clone(),
+                role: DatasetRole::Source,
+                schema: source_schema,
+                records: records_read,
+            },
+            sink: DatasetObservation {
+                uri: canonicalize_uri(&sink_dataset_uri, &node.sink.config, opts.clock),
+                kind: node.sink.kind.clone(),
+                role: DatasetRole::Sink,
+                schema: sink_schema,
+                records: records_out,
+            },
+            column_lineage,
+        };
+        crate::catalog::record(handle, &update).await;
+    }
+
     let result = result?;
 
     let captured = if capture.is_some() {
@@ -1396,6 +1522,9 @@ impl Source for StateKeyOverride {
     fn connector_name(&self) -> &'static str {
         self.inner.connector_name()
     }
+    fn dataset_uri(&self) -> String {
+        self.inner.dataset_uri()
+    }
     fn state_key(&self) -> Option<String> {
         Some(self.key.clone())
     }
@@ -1431,6 +1560,9 @@ impl CapturingSink {
 impl Sink for CapturingSink {
     fn connector_name(&self) -> &'static str {
         self.inner.connector_name()
+    }
+    fn dataset_uri(&self) -> String {
+        self.inner.dataset_uri()
     }
     async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
         let written = self.inner.write_batch(records).await?;
@@ -1471,6 +1603,9 @@ impl LimitedSink {
 impl Sink for LimitedSink {
     fn connector_name(&self) -> &'static str {
         self.inner.connector_name()
+    }
+    fn dataset_uri(&self) -> String {
+        self.inner.dataset_uri()
     }
     async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
         let remaining = self.remaining.load(Ordering::Relaxed);
@@ -1574,6 +1709,8 @@ mod tests {
             schedule: None,
             #[cfg(feature = "lineage")]
             lineage: None,
+            #[cfg(feature = "catalog")]
+            catalog: None,
             #[cfg(feature = "notify")]
             notifications: Vec::new(),
         }
@@ -1607,6 +1744,8 @@ mod tests {
                 lineage_cfg: None,
                 #[cfg(feature = "notify")]
                 notifier: None,
+                #[cfg(feature = "catalog")]
+                catalog: None,
             },
         )
         .await
@@ -1616,6 +1755,190 @@ mod tests {
         assert!(!summary.had_failures());
         let body = std::fs::read_to_string(&output).unwrap();
         assert_eq!(body.lines().count(), 2);
+    }
+
+    /// Minimal options with a catalog handle attached.
+    #[cfg(feature = "catalog")]
+    fn opts_with_catalog(name: &str, handle: crate::catalog::CatalogHandle) -> ExecuteOptions {
+        let mut o = opts(name);
+        o.catalog = Some(handle);
+        o
+    }
+
+    #[cfg(feature = "catalog")]
+    #[tokio::test]
+    async fn catalog_records_schema_timeline_across_two_runs() {
+        // Acceptance (#279): running the same pipeline twice with a schema
+        // change in between produces exactly two schema-timeline entries for
+        // the dataset, the second carrying a computed diff.
+        use crate::catalog::CatalogHandle;
+        use crate::serve::history::RunHistory as _;
+        use crate::serve::history::catalog::{self, CatalogListFilter};
+        use crate::serve::history::memory::MemoryHistory;
+
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("in.csv");
+        let output = dir.path().join("out.jsonl");
+        let store = Arc::new(MemoryHistory::new(std::time::Duration::from_secs(60)));
+        let handle = CatalogHandle {
+            store: store.clone(),
+            run_id: None,
+            sample_records: 10,
+        };
+
+        std::fs::write(&input, "id,name\n1,alice\n2,bob\n").unwrap();
+        let cfg = cfg_csv_to_jsonl(&input, &output);
+        let nodes = expand(&cfg).unwrap();
+        let summary = run_expanded(nodes, opts_with_catalog("cat", handle.clone()))
+            .await
+            .unwrap();
+        assert!(!summary.had_failures());
+
+        // Second run: same pipeline, schema gains an `email` column.
+        std::fs::write(&input, "id,name,email\n1,alice,a@x.io\n2,bob,b@x.io\n").unwrap();
+        let nodes = expand(&cfg).unwrap();
+        let summary = run_expanded(nodes, opts_with_catalog("cat", handle))
+            .await
+            .unwrap();
+        assert!(!summary.had_failures());
+
+        // Two datasets (source + sink), each with a 2-entry deduped timeline.
+        let page = store
+            .catalog_list_datasets(&CatalogListFilter {
+                limit: 10,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(page.datasets.len(), 2, "source + sink datasets");
+        for ds in &page.datasets {
+            let detail = store
+                .catalog_get_dataset(&ds.id)
+                .await
+                .unwrap()
+                .expect("dataset detail");
+            assert_eq!(detail.dataset.runs, 2);
+            assert_eq!(
+                detail.schema_timeline.len(),
+                2,
+                "exactly two timeline entries for {}",
+                ds.uri
+            );
+            assert!(detail.schema_timeline[0].diff.is_none());
+            let diff = detail.schema_timeline[1]
+                .diff
+                .as_ref()
+                .expect("second version carries a diff");
+            assert!(
+                diff["added"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .any(|c| c["column"] == "email"),
+                "diff must show the added email column: {diff}"
+            );
+            assert_eq!(detail.stats.len(), 2, "one volume point per run");
+        }
+        // One lineage edge, csv → jsonl, traversed twice.
+        let edges = store.catalog_lineage(None, 5).await.unwrap();
+        assert_eq!(edges.len(), 1);
+        assert_eq!(edges[0].runs, 2);
+        assert_eq!(edges[0].last_records, 2);
+        assert_eq!(edges[0].src_id, catalog::dataset_id(&edges[0].src_uri));
+    }
+
+    /// A catalog store whose writes always fail — drives the never-fail-the-run
+    /// contract.
+    #[cfg(feature = "catalog")]
+    struct FailingCatalogStore;
+
+    #[cfg(feature = "catalog")]
+    #[async_trait]
+    impl crate::serve::history::RunHistory for FailingCatalogStore {
+        async fn claim_idempotency(
+            &self,
+            _: &str,
+            _: &str,
+            _: &str,
+            _: std::time::Duration,
+        ) -> Result<crate::serve::history::Claim, crate::serve::history::HistoryError> {
+            Err(crate::serve::history::HistoryError::Backend("down".into()))
+        }
+        async fn upsert(
+            &self,
+            _: &crate::serve::history::RunRecord,
+        ) -> Result<(), crate::serve::history::HistoryError> {
+            Err(crate::serve::history::HistoryError::Backend("down".into()))
+        }
+        async fn get(
+            &self,
+            _: &str,
+        ) -> Result<Option<crate::serve::history::RunRecord>, crate::serve::history::HistoryError>
+        {
+            Err(crate::serve::history::HistoryError::Backend("down".into()))
+        }
+        async fn list(
+            &self,
+            _: &crate::serve::history::ListFilter,
+        ) -> Result<crate::serve::history::ListPage, crate::serve::history::HistoryError> {
+            Err(crate::serve::history::HistoryError::Backend("down".into()))
+        }
+        async fn delete(
+            &self,
+            _: &str,
+        ) -> Result<crate::serve::history::DeleteOutcome, crate::serve::history::HistoryError>
+        {
+            Err(crate::serve::history::HistoryError::Backend("down".into()))
+        }
+        async fn purge_expired(
+            &self,
+            _: std::time::Duration,
+        ) -> Result<usize, crate::serve::history::HistoryError> {
+            Err(crate::serve::history::HistoryError::Backend("down".into()))
+        }
+        async fn recover_orphans(&self) -> Result<usize, crate::serve::history::HistoryError> {
+            Err(crate::serve::history::HistoryError::Backend("down".into()))
+        }
+        async fn catalog_record(
+            &self,
+            _: &crate::serve::history::catalog::CatalogUpdate,
+        ) -> Result<(), crate::serve::history::HistoryError> {
+            Err(crate::serve::history::HistoryError::Backend(
+                "catalog write refused".into(),
+            ))
+        }
+        fn degraded(&self) -> bool {
+            false
+        }
+    }
+
+    #[cfg(feature = "catalog")]
+    #[tokio::test]
+    async fn catalog_write_failure_never_fails_the_run() {
+        // Acceptance (#279): a forced catalog-backend error degrades (logged)
+        // while the pipeline still succeeds and writes its output.
+        use crate::catalog::CatalogHandle;
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("in.csv");
+        let output = dir.path().join("out.jsonl");
+        std::fs::write(&input, "name\nalice\n").unwrap();
+        let cfg = cfg_csv_to_jsonl(&input, &output);
+        let nodes = expand(&cfg).unwrap();
+        let handle = CatalogHandle {
+            store: Arc::new(FailingCatalogStore),
+            run_id: None,
+            sample_records: 10,
+        };
+        let summary = run_expanded(nodes, opts_with_catalog("cat-fail", handle))
+            .await
+            .unwrap();
+        assert!(!summary.had_failures(), "catalog failure must not fail the run");
+        assert_eq!(summary.invocations[0].records_written, 1);
+        assert_eq!(
+            std::fs::read_to_string(&output).unwrap().lines().count(),
+            1,
+            "sink output written despite the catalog error"
+        );
     }
 
     #[tokio::test]
@@ -1667,6 +1990,8 @@ matrix:
                 lineage_cfg: None,
                 #[cfg(feature = "notify")]
                 notifier: None,
+                #[cfg(feature = "catalog")]
+                catalog: None,
             },
         )
         .await
@@ -1727,6 +2052,8 @@ matrix:
                 lineage_cfg: None,
                 #[cfg(feature = "notify")]
                 notifier: None,
+                #[cfg(feature = "catalog")]
+                catalog: None,
             },
         )
         .await
@@ -1952,6 +2279,8 @@ execution:
                 lineage_cfg: None,
                 #[cfg(feature = "notify")]
                 notifier: None,
+                #[cfg(feature = "catalog")]
+                catalog: None,
             },
         )
         .await
@@ -2037,6 +2366,8 @@ pipeline:
                 lineage_cfg: None,
                 #[cfg(feature = "notify")]
                 notifier: None,
+                #[cfg(feature = "catalog")]
+                catalog: None,
             },
         )
         .await
@@ -2096,6 +2427,8 @@ matrix:
                 lineage_cfg: None,
                 #[cfg(feature = "notify")]
                 notifier: None,
+                #[cfg(feature = "catalog")]
+                catalog: None,
             },
         )
         .await
@@ -2164,6 +2497,8 @@ execution:
                 lineage_cfg: None,
                 #[cfg(feature = "notify")]
                 notifier: None,
+                #[cfg(feature = "catalog")]
+                catalog: None,
             },
         )
         .await
@@ -2233,6 +2568,8 @@ matrix:
                 lineage_cfg: None,
                 #[cfg(feature = "notify")]
                 notifier: None,
+                #[cfg(feature = "catalog")]
+                catalog: None,
             },
         )
         .await
@@ -2471,6 +2808,8 @@ matrix:
             lineage_cfg: None,
             #[cfg(feature = "notify")]
             notifier: None,
+            #[cfg(feature = "catalog")]
+            catalog: None,
         }
     }
 
@@ -2887,6 +3226,8 @@ matrix:
                 lineage_cfg: None,
                 #[cfg(feature = "notify")]
                 notifier: None,
+                #[cfg(feature = "catalog")]
+                catalog: None,
             },
         )
         .await

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -12,6 +12,8 @@
 //! integrations and tests can reuse them.
 
 pub mod auth_catalog;
+#[cfg(feature = "catalog")]
+pub mod catalog;
 pub mod cli;
 pub mod commands;
 pub mod compose;
@@ -85,6 +87,11 @@ pub async fn run_from_yaml_str(yaml: &str) -> CliResult<executor::RunSummary> {
         Some(spec) => Some(spec.to_policy()?),
         None => None,
     };
+    #[cfg(feature = "catalog")]
+    let catalog = match cfg.catalog.as_ref() {
+        Some(spec) => Some(catalog::connect_from_spec(spec).await?),
+        None => None,
+    };
     let nodes = expand::expand(&cfg)?;
     executor::run_expanded(
         nodes,
@@ -106,6 +113,8 @@ pub async fn run_from_yaml_str(yaml: &str) -> CliResult<executor::RunSummary> {
             lineage_cfg: None,
             #[cfg(feature = "notify")]
             notifier: None,
+            #[cfg(feature = "catalog")]
+            catalog,
         },
     )
     .await

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -41,6 +41,8 @@ async fn main() {
         Command::Serve(args) => commands::serve::run(args, serve_log_level).await,
         #[cfg(feature = "notify")]
         Command::Notify(args) => commands::notify::run(args).await,
+        #[cfg(feature = "catalog")]
+        Command::Catalog(args) => commands::catalog::run(args).await,
     };
 
     if let Err(err) = result {

--- a/cli/src/replication/orchestrator.rs
+++ b/cli/src/replication/orchestrator.rs
@@ -30,6 +30,10 @@ pub struct ReplicationOptions {
     /// Optional notifier (#280), shared across both phases' runs.
     #[cfg(feature = "notify")]
     pub notifier: Option<std::sync::Arc<crate::notify::Notifier>>,
+    /// Optional Data Movement Catalog store (#279), recorded into after both
+    /// the snapshot and each CDC phase run.
+    #[cfg(feature = "catalog")]
+    pub catalog: Option<crate::catalog::CatalogHandle>,
 }
 
 /// Build the snapshot-phase node by cloning the CDC node and swapping in the
@@ -89,6 +93,8 @@ fn make_opts(opts: &ReplicationOptions, cancel: Option<CancellationToken>) -> Ex
         lineage_cfg: None,
         #[cfg(feature = "notify")]
         notifier: opts.notifier.clone(),
+        #[cfg(feature = "catalog")]
+        catalog: opts.catalog.clone(),
     }
 }
 

--- a/cli/src/serve/handlers/catalog.rs
+++ b/cli/src/serve/handlers/catalog.rs
@@ -1,0 +1,94 @@
+//! `GET /v1/catalog/*` — browse the Data Movement Catalog (#279): the
+//! accumulated cross-run picture of every dataset the server's pipelines have
+//! touched. Read-only; all three routes require the `CatalogRead` permission
+//! (granted to every role, `viewer` up), enforced by the auth middleware.
+
+use crate::serve::error::ServeError;
+use crate::serve::history::catalog::{
+    CatalogDatasetDetail, CatalogDatasetPage, CatalogLineageEdge, CatalogListFilter,
+    LINEAGE_DEFAULT_DEPTH,
+};
+use crate::serve::state::ServerState;
+use axum::Json;
+use axum::extract::{Path, Query, State};
+use serde::{Deserialize, Serialize};
+
+const DEFAULT_LIMIT: usize = 100;
+const MAX_LIMIT: usize = 1000;
+const MAX_DEPTH: u32 = 32;
+
+/// `GET /v1/catalog/datasets` query string.
+#[derive(Debug, Deserialize)]
+pub struct DatasetsQuery {
+    /// Exact connector-kind filter (`csv`, `postgres`, …).
+    pub kind: Option<String>,
+    /// Case-insensitive substring match on the dataset URI.
+    pub q: Option<String>,
+    pub limit: Option<usize>,
+    pub cursor: Option<String>,
+}
+
+/// `GET /v1/catalog/datasets` → 200.
+pub async fn list_datasets(
+    State(state): State<ServerState>,
+    Query(query): Query<DatasetsQuery>,
+) -> Result<Json<CatalogDatasetPage>, ServeError> {
+    let filter = CatalogListFilter {
+        kind: query.kind,
+        q: query.q,
+        limit: query.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT),
+        cursor: query.cursor,
+    };
+    let page = state
+        .history()
+        .catalog_list_datasets(&filter)
+        .await
+        .map_err(|e| ServeError::Internal(e.to_string()))?;
+    Ok(Json(page))
+}
+
+/// `GET /v1/catalog/datasets/{id}` → 200 / 404.
+pub async fn get_dataset(
+    State(state): State<ServerState>,
+    Path(id): Path<String>,
+) -> Result<Json<CatalogDatasetDetail>, ServeError> {
+    let detail = state
+        .history()
+        .catalog_get_dataset(&id)
+        .await
+        .map_err(|e| ServeError::Internal(e.to_string()))?
+        .ok_or(ServeError::NotFound)?;
+    Ok(Json(detail))
+}
+
+/// `GET /v1/catalog/lineage` query string.
+#[derive(Debug, Deserialize)]
+pub struct LineageQuery {
+    /// Dataset id to root the graph at; omitted = the whole graph.
+    pub root: Option<String>,
+    /// BFS hop bound around `root` (ignored without one).
+    pub depth: Option<u32>,
+}
+
+/// `GET /v1/catalog/lineage` response body.
+#[derive(Debug, Serialize)]
+pub struct LineageResponse {
+    pub edges: Vec<CatalogLineageEdge>,
+}
+
+/// `GET /v1/catalog/lineage` → 200.
+pub async fn lineage(
+    State(state): State<ServerState>,
+    Query(query): Query<LineageQuery>,
+) -> Result<Json<LineageResponse>, ServeError> {
+    let depth = query
+        .depth
+        .unwrap_or(LINEAGE_DEFAULT_DEPTH)
+        .clamp(1, MAX_DEPTH);
+    let edges = state
+        .history()
+        .catalog_lineage(query.root.as_deref(), depth)
+        .await
+        .map_err(|e| ServeError::Internal(e.to_string()))?;
+    Ok(Json(LineageResponse { edges }))
+}

--- a/cli/src/serve/handlers/mod.rs
+++ b/cli/src/serve/handlers/mod.rs
@@ -1,5 +1,7 @@
 //! serve HTTP handlers.
 pub mod audit;
+#[cfg(feature = "catalog")]
+pub mod catalog;
 pub mod dlq;
 pub mod doctor;
 pub mod health;

--- a/cli/src/serve/history/catalog.rs
+++ b/cli/src/serve/history/catalog.rs
@@ -1,0 +1,745 @@
+//! Data Movement Catalog storage types + pure merge logic (#279).
+//!
+//! The catalog is the accumulating, cross-run picture of every dataset a
+//! pipeline touches: identity (a canonical, credential-redacted dataset URI),
+//! a deduplicated schema timeline, per-run volume/freshness stats, and the
+//! lineage edges between datasets. It rides the run-history backends — the
+//! in-memory store and the shared SQL machinery both implement the
+//! `catalog_*` methods on [`RunHistory`](super::RunHistory) — so persistence
+//! reuses the existing `--history` / `serve-history-*` plumbing and the
+//! `FallbackHistory` degradation contract (a catalog write never fails a run).
+//!
+//! Everything in this module is **pure**: the merge of one run's observation
+//! into a dataset record ([`apply_observation`]), schema hashing/dedup
+//! ([`schema_hash`]), the list filter ([`filter_datasets`]), and the
+//! depth-bounded lineage BFS ([`lineage_slice`]) are shared by both backends
+//! so they can never drift apart. Backends only do I/O.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+/// How many volume points a dataset keeps (older ones are pruned on write).
+pub const STATS_RETAIN: usize = 500;
+
+/// How many of the most recent volume points a detail read returns.
+pub const STATS_DETAIL_LIMIT: usize = 50;
+
+/// Default depth bound for the lineage graph read.
+pub const LINEAGE_DEFAULT_DEPTH: u32 = 5;
+
+/// Which side of a pipeline a dataset was observed on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DatasetRole {
+    Source,
+    Sink,
+}
+
+impl DatasetRole {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Source => "source",
+            Self::Sink => "sink",
+        }
+    }
+}
+
+/// One observation of a dataset from a finished, successful root invocation.
+#[derive(Debug, Clone)]
+pub struct DatasetObservation {
+    /// Canonical dataset URI — credential-redacted and `${now.*}`-templated
+    /// segments folded back to their tokens, so dated paths converge on one
+    /// dataset instead of one per day.
+    pub uri: String,
+    /// Connector kind (`"csv"`, `"postgres"`, …).
+    pub kind: String,
+    pub role: DatasetRole,
+    /// Observed record schema (`infer_schema`-shaped
+    /// `{"type":"object","properties":{…}}`), `None` when nothing was sampled.
+    pub schema: Option<Value>,
+    /// Records read from / written to this dataset in the run.
+    pub records: u64,
+}
+
+/// The composite catalog write for one run: both dataset observations plus the
+/// source→sink lineage edge. One call so backends can keep the write paths
+/// together (and a partial failure degrades the whole update, not half of it).
+#[derive(Debug, Clone)]
+pub struct CatalogUpdate {
+    /// Provenance: the serve run id, or the invocation run id for CLI runs.
+    pub run_id: String,
+    pub pipeline: String,
+    /// Matrix row id (`"default"` for non-matrix runs).
+    pub row: String,
+    pub recorded_at: DateTime<Utc>,
+    pub source: DatasetObservation,
+    pub sink: DatasetObservation,
+    /// Column-lineage facet derived by `faucet-lineage` for the edge, when the
+    /// transform chain is expressible (`None` when opaque).
+    pub column_lineage: Option<Value>,
+}
+
+/// One catalogued dataset — the list element and the head of the detail view.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CatalogDataset {
+    /// Stable id: 16 hex chars of sha256(uri). Used in URLs and edge keys.
+    pub id: String,
+    pub uri: String,
+    pub kind: String,
+    /// Roles this dataset has been seen in (`"source"` / `"sink"`), sorted.
+    pub roles: Vec<String>,
+    pub first_seen: DateTime<Utc>,
+    pub last_seen: DateTime<Utc>,
+    /// Last successful run that touched this dataset (freshness).
+    pub last_success: DateTime<Utc>,
+    pub last_run_id: String,
+    /// Pipeline name of the most recent run that touched this dataset.
+    pub pipeline: String,
+    /// Records moved in the most recent run.
+    pub last_records: u64,
+    /// Records moved across all recorded runs.
+    pub total_records: u64,
+    /// Number of recorded runs that touched this dataset.
+    pub runs: u64,
+    /// Number of schema-timeline entries (0 when never sampled).
+    pub schema_versions: u32,
+    /// Latest observed schema (`None` when never sampled).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current_schema: Option<Value>,
+    /// Content hash of `current_schema` — the dedupe key for the timeline.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current_schema_hash: Option<String>,
+}
+
+/// One schema-timeline entry. Appended only when the observed schema's content
+/// hash differs from the previous entry, so the timeline stays compact.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CatalogSchemaVersion {
+    pub dataset_id: String,
+    /// 1-based, monotonically increasing per dataset.
+    pub version: u32,
+    pub recorded_at: DateTime<Utc>,
+    pub run_id: String,
+    pub schema: Value,
+    pub schema_hash: String,
+    /// Diff against the previous version (computed via
+    /// `faucet_core::drift::diff_schema`); `None` for the first version.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub diff: Option<Value>,
+}
+
+/// One per-run volume point for a dataset.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CatalogStatsPoint {
+    pub recorded_at: DateTime<Utc>,
+    pub run_id: String,
+    pub records: u64,
+}
+
+/// One source→sink lineage edge, keyed by `(src_id, dst_id)`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CatalogLineageEdge {
+    pub src_id: String,
+    pub dst_id: String,
+    pub src_uri: String,
+    pub dst_uri: String,
+    pub pipeline: String,
+    pub row: String,
+    pub first_seen: DateTime<Utc>,
+    pub last_seen: DateTime<Utc>,
+    pub last_run_id: String,
+    /// Recorded runs that traversed this edge.
+    pub runs: u64,
+    /// Records moved along this edge in the most recent run.
+    pub last_records: u64,
+    /// Column-lineage facet from the most recent run (`None` when opaque).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub column_lineage: Option<Value>,
+}
+
+/// Filter + keyset pagination for the dataset list.
+#[derive(Debug, Default, Clone)]
+pub struct CatalogListFilter {
+    /// Exact connector-kind match.
+    pub kind: Option<String>,
+    /// Case-insensitive substring match on the dataset URI.
+    pub q: Option<String>,
+    pub limit: usize,
+    /// Dataset id of the last element of the previous page.
+    pub cursor: Option<String>,
+}
+
+/// One page of the dataset list, ordered `(last_seen DESC, id DESC)`.
+#[derive(Debug, Serialize)]
+pub struct CatalogDatasetPage {
+    pub datasets: Vec<CatalogDataset>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<String>,
+}
+
+/// The full detail view for one dataset.
+#[derive(Debug, Serialize)]
+pub struct CatalogDatasetDetail {
+    #[serde(flatten)]
+    pub dataset: CatalogDataset,
+    /// Schema timeline, oldest first.
+    pub schema_timeline: Vec<CatalogSchemaVersion>,
+    /// Most recent volume points, newest first (bounded by
+    /// [`STATS_DETAIL_LIMIT`]).
+    pub stats: Vec<CatalogStatsPoint>,
+    /// Edges whose destination is this dataset.
+    pub upstream: Vec<CatalogLineageEdge>,
+    /// Edges whose source is this dataset.
+    pub downstream: Vec<CatalogLineageEdge>,
+}
+
+/// Stable dataset id: the first 16 hex chars of sha256(uri). Short enough for
+/// URLs, long enough that collisions are out of reach at catalog scale.
+pub fn dataset_id(uri: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let digest = Sha256::digest(uri.as_bytes());
+    hex_prefix(&digest, 16)
+}
+
+/// Content hash of a schema value over a canonical (recursively key-sorted)
+/// rendering, so the hash is independent of `serde_json`'s map ordering
+/// (`preserve_order` flips between builds).
+pub fn schema_hash(schema: &Value) -> String {
+    use sha2::{Digest, Sha256};
+    let mut canonical = String::new();
+    canonical_json(schema, &mut canonical);
+    let digest = Sha256::digest(canonical.as_bytes());
+    hex_prefix(&digest, 16)
+}
+
+fn hex_prefix(bytes: &[u8], chars: usize) -> String {
+    let mut out = String::with_capacity(chars);
+    for b in bytes {
+        use std::fmt::Write as _;
+        let _ = write!(out, "{b:02x}");
+        if out.len() >= chars {
+            break;
+        }
+    }
+    out.truncate(chars);
+    out
+}
+
+/// Render `v` with object keys sorted recursively (arrays keep order).
+fn canonical_json(v: &Value, out: &mut String) {
+    match v {
+        Value::Object(map) => {
+            let mut keys: Vec<&String> = map.keys().collect();
+            keys.sort();
+            out.push('{');
+            for (i, k) in keys.iter().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                out.push_str(&Value::String((*k).clone()).to_string());
+                out.push(':');
+                canonical_json(&map[*k], out);
+            }
+            out.push('}');
+        }
+        Value::Array(items) => {
+            out.push('[');
+            for (i, item) in items.iter().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                canonical_json(item, out);
+            }
+            out.push(']');
+        }
+        scalar => out.push_str(&scalar.to_string()),
+    }
+}
+
+/// Serialize a `faucet_core::drift::SchemaDiff` (not `Serialize` itself) into
+/// a stable JSON shape for the schema-timeline `diff` field.
+fn diff_to_value(diff: &faucet_core::SchemaDiff) -> Value {
+    let change = |c: &faucet_core::ColumnChange| -> Value {
+        json!({ "column": c.name, "from": c.from, "to": c.to })
+    };
+    json!({
+        "added": diff.additions.iter().map(change).collect::<Vec<_>>(),
+        "widened": diff.widenings.iter().map(change).collect::<Vec<_>>(),
+        "changed": diff.incompatible.iter().map(change).collect::<Vec<_>>(),
+        "removed": diff.droppable_required.clone(),
+    })
+}
+
+/// Whether a diff value carries any actual change (an all-empty diff is
+/// omitted from the timeline entry).
+fn diff_is_empty(diff: &Value) -> bool {
+    ["added", "widened", "changed", "removed"]
+        .iter()
+        .all(|k| diff.get(k).and_then(Value::as_array).is_none_or(Vec::is_empty))
+}
+
+/// Fold one run's observation into the (possibly absent) existing dataset
+/// record. Returns the updated record plus a new schema-timeline entry when —
+/// and only when — the observed schema's content hash differs from the
+/// current one.
+pub fn apply_observation(
+    existing: Option<&CatalogDataset>,
+    obs: &DatasetObservation,
+    run_id: &str,
+    pipeline: &str,
+    row: &str,
+    now: DateTime<Utc>,
+) -> (CatalogDataset, Option<CatalogSchemaVersion>) {
+    let _ = row; // provenance detail carried on the edge, not the dataset
+    let id = dataset_id(&obs.uri);
+    let mut ds = match existing {
+        Some(prev) => prev.clone(),
+        None => CatalogDataset {
+            id: id.clone(),
+            uri: obs.uri.clone(),
+            kind: obs.kind.clone(),
+            roles: Vec::new(),
+            first_seen: now,
+            last_seen: now,
+            last_success: now,
+            last_run_id: run_id.to_string(),
+            pipeline: pipeline.to_string(),
+            last_records: 0,
+            total_records: 0,
+            runs: 0,
+            schema_versions: 0,
+            current_schema: None,
+            current_schema_hash: None,
+        },
+    };
+    let role = obs.role.as_str().to_string();
+    if !ds.roles.contains(&role) {
+        ds.roles.push(role);
+        ds.roles.sort();
+    }
+    ds.kind = obs.kind.clone();
+    ds.last_seen = now;
+    ds.last_success = now;
+    ds.last_run_id = run_id.to_string();
+    ds.pipeline = pipeline.to_string();
+    ds.last_records = obs.records;
+    ds.total_records = ds.total_records.saturating_add(obs.records);
+    ds.runs = ds.runs.saturating_add(1);
+
+    let new_version = match &obs.schema {
+        Some(schema) => {
+            let hash = schema_hash(schema);
+            if ds.current_schema_hash.as_deref() == Some(hash.as_str()) {
+                None
+            } else {
+                let diff = ds.current_schema.as_ref().map(|prev| {
+                    diff_to_value(&faucet_core::drift::diff_schema(prev, schema, true))
+                });
+                let diff = diff.filter(|d| !diff_is_empty(d));
+                ds.schema_versions += 1;
+                ds.current_schema = Some(schema.clone());
+                ds.current_schema_hash = Some(hash.clone());
+                Some(CatalogSchemaVersion {
+                    dataset_id: id,
+                    version: ds.schema_versions,
+                    recorded_at: now,
+                    run_id: run_id.to_string(),
+                    schema: schema.clone(),
+                    schema_hash: hash,
+                    diff,
+                })
+            }
+        }
+        None => None,
+    };
+    (ds, new_version)
+}
+
+/// Fold one run's traversal into the (possibly absent) existing lineage edge.
+pub fn apply_edge(existing: Option<&CatalogLineageEdge>, update: &CatalogUpdate) -> CatalogLineageEdge {
+    let mut edge = match existing {
+        Some(prev) => prev.clone(),
+        None => CatalogLineageEdge {
+            src_id: dataset_id(&update.source.uri),
+            dst_id: dataset_id(&update.sink.uri),
+            src_uri: update.source.uri.clone(),
+            dst_uri: update.sink.uri.clone(),
+            pipeline: update.pipeline.clone(),
+            row: update.row.clone(),
+            first_seen: update.recorded_at,
+            last_seen: update.recorded_at,
+            last_run_id: update.run_id.clone(),
+            runs: 0,
+            last_records: 0,
+            column_lineage: None,
+        },
+    };
+    edge.pipeline = update.pipeline.clone();
+    edge.row = update.row.clone();
+    edge.last_seen = update.recorded_at;
+    edge.last_run_id = update.run_id.clone();
+    edge.runs = edge.runs.saturating_add(1);
+    edge.last_records = update.sink.records;
+    if update.column_lineage.is_some() {
+        edge.column_lineage = update.column_lineage.clone();
+    }
+    edge
+}
+
+/// Filter, order (`last_seen DESC, id DESC`), and keyset-paginate the dataset
+/// list. Shared by the memory and SQL backends (which fetch all rows and
+/// delegate here) so the two can never disagree on filter semantics.
+pub fn filter_datasets(
+    mut all: Vec<CatalogDataset>,
+    filter: &CatalogListFilter,
+) -> CatalogDatasetPage {
+    all.retain(|d| filter.kind.as_deref().is_none_or(|k| d.kind == k));
+    if let Some(q) = filter.q.as_deref() {
+        let q = q.to_lowercase();
+        all.retain(|d| d.uri.to_lowercase().contains(&q));
+    }
+    all.sort_by(|a, b| {
+        b.last_seen
+            .cmp(&a.last_seen)
+            .then_with(|| b.id.cmp(&a.id))
+    });
+    if let Some(cursor) = &filter.cursor
+        && let Some(pos) = all.iter().position(|d| &d.id == cursor)
+    {
+        all.drain(..=pos);
+    }
+    let limit = filter.limit.max(1);
+    let next_cursor = if all.len() > limit {
+        Some(all[limit - 1].id.clone())
+    } else {
+        None
+    };
+    all.truncate(limit);
+    CatalogDatasetPage {
+        datasets: all,
+        next_cursor,
+    }
+}
+
+/// Slice the edge graph for the lineage read: with no root, return everything;
+/// with a root, BFS outward (both directions) up to `depth` hops. Shared by
+/// both backends.
+pub fn lineage_slice(
+    edges: Vec<CatalogLineageEdge>,
+    root: Option<&str>,
+    depth: u32,
+) -> Vec<CatalogLineageEdge> {
+    let Some(root) = root else {
+        return edges;
+    };
+    let mut frontier: std::collections::HashSet<String> =
+        std::collections::HashSet::from([root.to_string()]);
+    let mut reached = frontier.clone();
+    let mut kept: Vec<usize> = Vec::new();
+    let mut kept_set: std::collections::HashSet<usize> = std::collections::HashSet::new();
+    for _ in 0..depth.max(1) {
+        let mut next: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for (i, e) in edges.iter().enumerate() {
+            if kept_set.contains(&i) {
+                continue;
+            }
+            if frontier.contains(&e.src_id) || frontier.contains(&e.dst_id) {
+                kept.push(i);
+                kept_set.insert(i);
+                for id in [&e.src_id, &e.dst_id] {
+                    if reached.insert(id.clone()) {
+                        next.insert(id.clone());
+                    }
+                }
+            }
+        }
+        if next.is_empty() {
+            break;
+        }
+        frontier = next;
+    }
+    kept.sort_unstable();
+    let mut kept_edges = Vec::with_capacity(kept.len());
+    let mut edges = edges;
+    // Drain in reverse so earlier indices stay valid.
+    for i in kept.iter().rev() {
+        kept_edges.push(edges.swap_remove(*i));
+    }
+    kept_edges.reverse();
+    kept_edges
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn obs(uri: &str, role: DatasetRole, schema: Option<Value>, records: u64) -> DatasetObservation {
+        DatasetObservation {
+            uri: uri.into(),
+            kind: "csv".into(),
+            role,
+            schema,
+            records,
+        }
+    }
+
+    fn schema_a() -> Value {
+        json!({"type": "object", "properties": {"id": {"type": "integer"}, "name": {"type": "string"}}})
+    }
+
+    fn schema_b() -> Value {
+        json!({"type": "object", "properties": {"id": {"type": "integer"}, "name": {"type": "string"}, "email": {"type": "string"}}})
+    }
+
+    #[test]
+    fn dataset_id_is_stable_and_short() {
+        let a = dataset_id("csv://./in.csv");
+        assert_eq!(a.len(), 16);
+        assert_eq!(a, dataset_id("csv://./in.csv"));
+        assert_ne!(a, dataset_id("csv://./other.csv"));
+        assert!(a.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn schema_hash_is_key_order_independent() {
+        let a = json!({"properties": {"a": {"type": "string"}, "b": {"type": "integer"}}});
+        let b = json!({"properties": {"b": {"type": "integer"}, "a": {"type": "string"}}});
+        assert_eq!(schema_hash(&a), schema_hash(&b));
+        assert_ne!(
+            schema_hash(&a),
+            schema_hash(&json!({"properties": {"a": {"type": "integer"}}}))
+        );
+    }
+
+    #[test]
+    fn first_observation_creates_dataset_and_version_one() {
+        let now = Utc::now();
+        let (ds, v) = apply_observation(
+            None,
+            &obs("csv://./in.csv", DatasetRole::Source, Some(schema_a()), 10),
+            "r1",
+            "p",
+            "default",
+            now,
+        );
+        assert_eq!(ds.id, dataset_id("csv://./in.csv"));
+        assert_eq!(ds.roles, vec!["source"]);
+        assert_eq!(ds.runs, 1);
+        assert_eq!(ds.total_records, 10);
+        assert_eq!(ds.schema_versions, 1);
+        let v = v.expect("first schema observation appends version 1");
+        assert_eq!(v.version, 1);
+        assert!(v.diff.is_none(), "no previous schema, no diff");
+    }
+
+    #[test]
+    fn unchanged_schema_does_not_append_a_version() {
+        let now = Utc::now();
+        let (ds, _) = apply_observation(
+            None,
+            &obs("csv://./in.csv", DatasetRole::Source, Some(schema_a()), 10),
+            "r1",
+            "p",
+            "default",
+            now,
+        );
+        let (ds2, v2) = apply_observation(
+            Some(&ds),
+            &obs("csv://./in.csv", DatasetRole::Source, Some(schema_a()), 7),
+            "r2",
+            "p",
+            "default",
+            now,
+        );
+        assert!(v2.is_none(), "identical schema must dedupe");
+        assert_eq!(ds2.schema_versions, 1);
+        assert_eq!(ds2.runs, 2);
+        assert_eq!(ds2.total_records, 17);
+        assert_eq!(ds2.last_records, 7);
+        assert_eq!(ds2.last_run_id, "r2");
+    }
+
+    #[test]
+    fn changed_schema_appends_a_version_with_a_diff() {
+        let now = Utc::now();
+        let (ds, _) = apply_observation(
+            None,
+            &obs("csv://./in.csv", DatasetRole::Source, Some(schema_a()), 10),
+            "r1",
+            "p",
+            "default",
+            now,
+        );
+        let (ds2, v2) = apply_observation(
+            Some(&ds),
+            &obs("csv://./in.csv", DatasetRole::Source, Some(schema_b()), 10),
+            "r2",
+            "p",
+            "default",
+            now,
+        );
+        assert_eq!(ds2.schema_versions, 2);
+        let v2 = v2.expect("schema change appends version 2");
+        assert_eq!(v2.version, 2);
+        let diff = v2.diff.expect("second version diffs against the first");
+        let added = diff["added"].as_array().unwrap();
+        assert_eq!(added.len(), 1);
+        assert_eq!(added[0]["column"], "email");
+    }
+
+    #[test]
+    fn roles_accumulate_and_sort() {
+        let now = Utc::now();
+        let (ds, _) = apply_observation(
+            None,
+            &obs("x://d", DatasetRole::Sink, None, 1),
+            "r1",
+            "p",
+            "default",
+            now,
+        );
+        let (ds2, _) = apply_observation(
+            Some(&ds),
+            &obs("x://d", DatasetRole::Source, None, 1),
+            "r2",
+            "p",
+            "default",
+            now,
+        );
+        assert_eq!(ds2.roles, vec!["sink", "source"]);
+        assert!(ds2.current_schema.is_none());
+        assert_eq!(ds2.schema_versions, 0);
+    }
+
+    fn update(src: &str, dst: &str, records: u64) -> CatalogUpdate {
+        CatalogUpdate {
+            run_id: "r1".into(),
+            pipeline: "p".into(),
+            row: "default".into(),
+            recorded_at: Utc::now(),
+            source: obs(src, DatasetRole::Source, None, records),
+            sink: obs(dst, DatasetRole::Sink, None, records),
+            column_lineage: None,
+        }
+    }
+
+    #[test]
+    fn edge_accumulates_and_keeps_last_column_lineage() {
+        let mut u = update("a://1", "b://2", 5);
+        u.column_lineage = Some(json!({"fields": {"x": {}}}));
+        let e = apply_edge(None, &u);
+        assert_eq!(e.runs, 1);
+        assert_eq!(e.last_records, 5);
+        assert!(e.column_lineage.is_some());
+
+        // A later opaque run keeps the previous column lineage.
+        let mut u2 = update("a://1", "b://2", 9);
+        u2.run_id = "r2".into();
+        let e2 = apply_edge(Some(&e), &u2);
+        assert_eq!(e2.runs, 2);
+        assert_eq!(e2.last_records, 9);
+        assert_eq!(e2.last_run_id, "r2");
+        assert!(e2.column_lineage.is_some(), "opaque run keeps prior facet");
+    }
+
+    fn ds(id_uri: &str, kind: &str, last_seen: DateTime<Utc>) -> CatalogDataset {
+        CatalogDataset {
+            id: dataset_id(id_uri),
+            uri: id_uri.into(),
+            kind: kind.into(),
+            roles: vec!["source".into()],
+            first_seen: last_seen,
+            last_seen,
+            last_success: last_seen,
+            last_run_id: "r".into(),
+            pipeline: "p".into(),
+            last_records: 0,
+            total_records: 0,
+            runs: 1,
+            schema_versions: 0,
+            current_schema: None,
+            current_schema_hash: None,
+        }
+    }
+
+    #[test]
+    fn filter_datasets_filters_orders_and_paginates() {
+        let t0 = Utc::now();
+        let all = vec![
+            ds("csv://a", "csv", t0),
+            ds("csv://b", "csv", t0 + chrono::Duration::seconds(1)),
+            ds("postgres://h/db", "postgres", t0 + chrono::Duration::seconds(2)),
+        ];
+        // Kind filter.
+        let page = filter_datasets(
+            all.clone(),
+            &CatalogListFilter {
+                kind: Some("postgres".into()),
+                limit: 10,
+                ..Default::default()
+            },
+        );
+        assert_eq!(page.datasets.len(), 1);
+        assert_eq!(page.datasets[0].kind, "postgres");
+        // Substring filter, case-insensitive.
+        let page = filter_datasets(
+            all.clone(),
+            &CatalogListFilter {
+                q: Some("CSV://".into()),
+                limit: 10,
+                ..Default::default()
+            },
+        );
+        assert_eq!(page.datasets.len(), 2);
+        // Newest-first + pagination.
+        let page = filter_datasets(
+            all.clone(),
+            &CatalogListFilter {
+                limit: 2,
+                ..Default::default()
+            },
+        );
+        assert_eq!(page.datasets[0].kind, "postgres");
+        let cursor = page.next_cursor.expect("3 rows, page of 2");
+        let page2 = filter_datasets(
+            all,
+            &CatalogListFilter {
+                limit: 2,
+                cursor: Some(cursor),
+                ..Default::default()
+            },
+        );
+        assert_eq!(page2.datasets.len(), 1);
+        assert!(page2.next_cursor.is_none());
+    }
+
+    fn edge(src: &str, dst: &str) -> CatalogLineageEdge {
+        apply_edge(None, &update(src, dst, 1))
+    }
+
+    #[test]
+    fn lineage_slice_respects_root_and_depth() {
+        // a → b → c → d, plus x → y off to the side.
+        let edges = vec![
+            edge("a", "b"),
+            edge("b", "c"),
+            edge("c", "d"),
+            edge("x", "y"),
+        ];
+        let all = lineage_slice(edges.clone(), None, 5);
+        assert_eq!(all.len(), 4, "no root returns everything");
+
+        let b = dataset_id("b");
+        // Depth 1 from b: edges touching b only.
+        let d1 = lineage_slice(edges.clone(), Some(&b), 1);
+        assert_eq!(d1.len(), 2);
+        // Depth 2 from b: reaches c→d too, never x→y.
+        let d2 = lineage_slice(edges.clone(), Some(&b), 2);
+        assert_eq!(d2.len(), 3);
+        assert!(d2.iter().all(|e| e.src_uri != "x"));
+        // Unknown root: nothing.
+        assert!(lineage_slice(edges, Some("nope"), 3).is_empty());
+    }
+}

--- a/cli/src/serve/history/catalog.rs
+++ b/cli/src/serve/history/catalog.rs
@@ -520,6 +520,17 @@ mod tests {
     }
 
     #[test]
+    fn schema_hash_covers_arrays_and_preserves_their_order() {
+        // Nullable columns infer as `"type": ["string", "null"]` — the
+        // canonical rendering must keep array ORDER significant while still
+        // sorting object keys.
+        let a = json!({"properties": {"a": {"type": ["string", "null"]}}});
+        let b = json!({"properties": {"a": {"type": ["null", "string"]}}});
+        assert_ne!(schema_hash(&a), schema_hash(&b), "array order is meaning");
+        assert_eq!(schema_hash(&a), schema_hash(&a.clone()));
+    }
+
+    #[test]
     fn first_observation_creates_dataset_and_version_one() {
         let now = Utc::now();
         let (ds, v) = apply_observation(

--- a/cli/src/serve/history/catalog.rs
+++ b/cli/src/serve/history/catalog.rs
@@ -274,9 +274,11 @@ fn diff_to_value(diff: &faucet_core::SchemaDiff) -> Value {
 /// Whether a diff value carries any actual change (an all-empty diff is
 /// omitted from the timeline entry).
 fn diff_is_empty(diff: &Value) -> bool {
-    ["added", "widened", "changed", "removed"]
-        .iter()
-        .all(|k| diff.get(k).and_then(Value::as_array).is_none_or(Vec::is_empty))
+    ["added", "widened", "changed", "removed"].iter().all(|k| {
+        diff.get(k)
+            .and_then(Value::as_array)
+            .is_none_or(Vec::is_empty)
+    })
 }
 
 /// Fold one run's observation into the (possibly absent) existing dataset
@@ -357,7 +359,10 @@ pub fn apply_observation(
 }
 
 /// Fold one run's traversal into the (possibly absent) existing lineage edge.
-pub fn apply_edge(existing: Option<&CatalogLineageEdge>, update: &CatalogUpdate) -> CatalogLineageEdge {
+pub fn apply_edge(
+    existing: Option<&CatalogLineageEdge>,
+    update: &CatalogUpdate,
+) -> CatalogLineageEdge {
     let mut edge = match existing {
         Some(prev) => prev.clone(),
         None => CatalogLineageEdge {
@@ -399,11 +404,7 @@ pub fn filter_datasets(
         let q = q.to_lowercase();
         all.retain(|d| d.uri.to_lowercase().contains(&q));
     }
-    all.sort_by(|a, b| {
-        b.last_seen
-            .cmp(&a.last_seen)
-            .then_with(|| b.id.cmp(&a.id))
-    });
+    all.sort_by(|a, b| b.last_seen.cmp(&a.last_seen).then_with(|| b.id.cmp(&a.id)));
     if let Some(cursor) = &filter.cursor
         && let Some(pos) = all.iter().position(|d| &d.id == cursor)
     {
@@ -475,7 +476,12 @@ mod tests {
     use super::*;
     use serde_json::json;
 
-    fn obs(uri: &str, role: DatasetRole, schema: Option<Value>, records: u64) -> DatasetObservation {
+    fn obs(
+        uri: &str,
+        role: DatasetRole,
+        schema: Option<Value>,
+        records: u64,
+    ) -> DatasetObservation {
         DatasetObservation {
             uri: uri.into(),
             kind: "csv".into(),
@@ -670,7 +676,11 @@ mod tests {
         let all = vec![
             ds("csv://a", "csv", t0),
             ds("csv://b", "csv", t0 + chrono::Duration::seconds(1)),
-            ds("postgres://h/db", "postgres", t0 + chrono::Duration::seconds(2)),
+            ds(
+                "postgres://h/db",
+                "postgres",
+                t0 + chrono::Duration::seconds(2),
+            ),
         ];
         // Kind filter.
         let page = filter_datasets(

--- a/cli/src/serve/history/fallback.rs
+++ b/cli/src/serve/history/fallback.rs
@@ -247,6 +247,34 @@ impl RunHistory for FallbackHistory {
         via!(self, p => p.list_audit(filter), f => f.list_audit(filter))
     }
 
+    // ── Data Movement Catalog (#279) ─────────────────────────────────────────
+
+    async fn catalog_record(
+        &self,
+        update: &crate::serve::history::catalog::CatalogUpdate,
+    ) -> Result<(), HistoryError> {
+        via!(self, p => p.catalog_record(update), f => f.catalog_record(update))
+    }
+    async fn catalog_list_datasets(
+        &self,
+        filter: &crate::serve::history::catalog::CatalogListFilter,
+    ) -> Result<crate::serve::history::catalog::CatalogDatasetPage, HistoryError> {
+        via!(self, p => p.catalog_list_datasets(filter), f => f.catalog_list_datasets(filter))
+    }
+    async fn catalog_get_dataset(
+        &self,
+        id: &str,
+    ) -> Result<Option<crate::serve::history::catalog::CatalogDatasetDetail>, HistoryError> {
+        via!(self, p => p.catalog_get_dataset(id), f => f.catalog_get_dataset(id))
+    }
+    async fn catalog_lineage(
+        &self,
+        root: Option<&str>,
+        depth: u32,
+    ) -> Result<Vec<crate::serve::history::catalog::CatalogLineageEdge>, HistoryError> {
+        via!(self, p => p.catalog_lineage(root, depth), f => f.catalog_lineage(root, depth))
+    }
+
     fn degraded(&self) -> bool {
         self.is_degraded()
     }

--- a/cli/src/serve/history/memory.rs
+++ b/cli/src/serve/history/memory.rs
@@ -2,6 +2,10 @@
 //! documented memory-backend trade-off. Idempotency claims live in a second map
 //! and are pruned both lazily (on re-claim) and by `purge_expired`.
 
+use super::catalog::{
+    self, CatalogDataset, CatalogDatasetDetail, CatalogDatasetPage, CatalogLineageEdge,
+    CatalogListFilter, CatalogSchemaVersion, CatalogStatsPoint, CatalogUpdate,
+};
 use super::{
     AuditEntry, AuditFilter, Claim, DeleteOutcome, HistoryError, ListFilter, ListPage, RunHistory,
     RunRecord,
@@ -23,11 +27,27 @@ struct IdemEntry {
     claimed_at: DateTime<Utc>,
 }
 
+/// In-memory Data Movement Catalog state (#279). One `Mutex` guards the whole
+/// catalog so a `catalog_record` (a read-modify-write across three maps) is
+/// atomic without per-map lock ordering.
+#[derive(Default)]
+struct CatalogState {
+    datasets: std::collections::HashMap<String, CatalogDataset>,
+    /// dataset id → timeline, oldest first.
+    schema_versions: std::collections::HashMap<String, Vec<CatalogSchemaVersion>>,
+    /// dataset id → volume points, oldest first, capped at `STATS_RETAIN`.
+    stats: std::collections::HashMap<String, Vec<CatalogStatsPoint>>,
+    /// (src id, dst id) → edge.
+    edges: std::collections::HashMap<(String, String), CatalogLineageEdge>,
+}
+
 pub struct MemoryHistory {
     runs: DashMap<String, RunRecord>,
     idem: DashMap<String, IdemEntry>,
     /// Bounded, newest-at-back ring of audit records (RBAC, #205).
     audit: Mutex<VecDeque<AuditEntry>>,
+    /// Data Movement Catalog (#279). Ephemeral like everything else here.
+    catalog: Mutex<CatalogState>,
     /// Retention window for idempotency claims (separate from run retention).
     idem_retention: Duration,
 }
@@ -38,6 +58,7 @@ impl MemoryHistory {
             runs: DashMap::new(),
             idem: DashMap::new(),
             audit: Mutex::new(VecDeque::new()),
+            catalog: Mutex::new(CatalogState::default()),
             idem_retention,
         }
     }
@@ -222,6 +243,115 @@ impl RunHistory for MemoryHistory {
             return Ok(true);
         }
         Ok(false)
+    }
+
+    // ── Data Movement Catalog (#279) ─────────────────────────────────────────
+
+    async fn catalog_record(&self, update: &CatalogUpdate) -> Result<(), HistoryError> {
+        let lock_err = |_| HistoryError::Backend("catalog lock poisoned".into());
+        let mut cat = self.catalog.lock().map_err(lock_err)?;
+        for obs in [&update.source, &update.sink] {
+            let id = catalog::dataset_id(&obs.uri);
+            let (ds, new_version) = catalog::apply_observation(
+                cat.datasets.get(&id),
+                obs,
+                &update.run_id,
+                &update.pipeline,
+                &update.row,
+                update.recorded_at,
+            );
+            if let Some(v) = new_version {
+                cat.schema_versions.entry(id.clone()).or_default().push(v);
+            }
+            let points = cat.stats.entry(id.clone()).or_default();
+            points.push(CatalogStatsPoint {
+                recorded_at: update.recorded_at,
+                run_id: update.run_id.clone(),
+                records: obs.records,
+            });
+            if points.len() > catalog::STATS_RETAIN {
+                let drop_n = points.len() - catalog::STATS_RETAIN;
+                points.drain(..drop_n);
+            }
+            cat.datasets.insert(id, ds);
+        }
+        let key = (
+            catalog::dataset_id(&update.source.uri),
+            catalog::dataset_id(&update.sink.uri),
+        );
+        let edge = catalog::apply_edge(cat.edges.get(&key), update);
+        cat.edges.insert(key, edge);
+        Ok(())
+    }
+
+    async fn catalog_list_datasets(
+        &self,
+        filter: &CatalogListFilter,
+    ) -> Result<CatalogDatasetPage, HistoryError> {
+        let cat = self
+            .catalog
+            .lock()
+            .map_err(|_| HistoryError::Backend("catalog lock poisoned".into()))?;
+        Ok(catalog::filter_datasets(
+            cat.datasets.values().cloned().collect(),
+            filter,
+        ))
+    }
+
+    async fn catalog_get_dataset(
+        &self,
+        id: &str,
+    ) -> Result<Option<CatalogDatasetDetail>, HistoryError> {
+        let cat = self
+            .catalog
+            .lock()
+            .map_err(|_| HistoryError::Backend("catalog lock poisoned".into()))?;
+        let Some(dataset) = cat.datasets.get(id).cloned() else {
+            return Ok(None);
+        };
+        let schema_timeline = cat.schema_versions.get(id).cloned().unwrap_or_default();
+        let mut stats: Vec<CatalogStatsPoint> =
+            cat.stats.get(id).cloned().unwrap_or_default();
+        stats.reverse(); // newest first
+        stats.truncate(catalog::STATS_DETAIL_LIMIT);
+        let upstream = cat
+            .edges
+            .values()
+            .filter(|e| e.dst_id == id)
+            .cloned()
+            .collect();
+        let downstream = cat
+            .edges
+            .values()
+            .filter(|e| e.src_id == id)
+            .cloned()
+            .collect();
+        Ok(Some(CatalogDatasetDetail {
+            dataset,
+            schema_timeline,
+            stats,
+            upstream,
+            downstream,
+        }))
+    }
+
+    async fn catalog_lineage(
+        &self,
+        root: Option<&str>,
+        depth: u32,
+    ) -> Result<Vec<CatalogLineageEdge>, HistoryError> {
+        let cat = self
+            .catalog
+            .lock()
+            .map_err(|_| HistoryError::Backend("catalog lock poisoned".into()))?;
+        let mut edges: Vec<CatalogLineageEdge> = cat.edges.values().cloned().collect();
+        // Stable order for pagination-free consumers (newest activity first).
+        edges.sort_by(|a, b| {
+            b.last_seen
+                .cmp(&a.last_seen)
+                .then_with(|| (&a.src_id, &a.dst_id).cmp(&(&b.src_id, &b.dst_id)))
+        });
+        Ok(catalog::lineage_slice(edges, root, depth))
     }
 
     fn degraded(&self) -> bool {
@@ -540,6 +670,84 @@ mod tests {
             .await
             .unwrap();
         assert!(after.is_empty(), "audit purge should clear expired entries");
+    }
+
+    fn catalog_update(src: &str, dst: &str, schema: Option<serde_json::Value>) -> CatalogUpdate {
+        use crate::serve::history::catalog::{DatasetObservation, DatasetRole};
+        CatalogUpdate {
+            run_id: "r1".into(),
+            pipeline: "p".into(),
+            row: "default".into(),
+            recorded_at: Utc::now(),
+            source: DatasetObservation {
+                uri: src.into(),
+                kind: "csv".into(),
+                role: DatasetRole::Source,
+                schema: schema.clone(),
+                records: 10,
+            },
+            sink: DatasetObservation {
+                uri: dst.into(),
+                kind: "jsonl".into(),
+                role: DatasetRole::Sink,
+                schema,
+                records: 10,
+            },
+            column_lineage: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn catalog_record_accumulates_datasets_edges_and_timeline() {
+        use serde_json::json;
+        let h = MemoryHistory::new(Duration::from_secs(60));
+        let schema_v1 = json!({"type": "object", "properties": {"id": {"type": "integer"}}});
+        let schema_v2 = json!({"type": "object", "properties": {"id": {"type": "integer"}, "email": {"type": "string"}}});
+
+        h.catalog_record(&catalog_update("csv://./in.csv", "jsonl://./out.jsonl", Some(schema_v1.clone())))
+            .await
+            .unwrap();
+        // Same schema again → no new version.
+        h.catalog_record(&catalog_update("csv://./in.csv", "jsonl://./out.jsonl", Some(schema_v1)))
+            .await
+            .unwrap();
+        // Changed schema → second version with a diff.
+        h.catalog_record(&catalog_update("csv://./in.csv", "jsonl://./out.jsonl", Some(schema_v2)))
+            .await
+            .unwrap();
+
+        let page = h
+            .catalog_list_datasets(&CatalogListFilter {
+                limit: 10,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(page.datasets.len(), 2, "source + sink datasets");
+
+        let src_id = catalog::dataset_id("csv://./in.csv");
+        let detail = h.catalog_get_dataset(&src_id).await.unwrap().unwrap();
+        assert_eq!(detail.dataset.runs, 3);
+        assert_eq!(detail.dataset.total_records, 30);
+        assert_eq!(
+            detail.schema_timeline.len(),
+            2,
+            "identical schema deduped; change appended"
+        );
+        assert!(detail.schema_timeline[0].diff.is_none());
+        assert!(detail.schema_timeline[1].diff.is_some());
+        assert_eq!(detail.stats.len(), 3);
+        assert_eq!(detail.downstream.len(), 1);
+        assert!(detail.upstream.is_empty());
+        assert_eq!(detail.downstream[0].runs, 3);
+
+        // Lineage: one edge, whole graph == rooted graph.
+        let all = h.catalog_lineage(None, 5).await.unwrap();
+        assert_eq!(all.len(), 1);
+        let rooted = h.catalog_lineage(Some(&src_id), 3).await.unwrap();
+        assert_eq!(rooted.len(), 1);
+        assert!(h.catalog_lineage(Some("missing"), 3).await.unwrap().is_empty());
+        assert!(h.catalog_get_dataset("missing").await.unwrap().is_none());
     }
 
     #[tokio::test]

--- a/cli/src/serve/history/memory.rs
+++ b/cli/src/serve/history/memory.rs
@@ -310,8 +310,7 @@ impl RunHistory for MemoryHistory {
             return Ok(None);
         };
         let schema_timeline = cat.schema_versions.get(id).cloned().unwrap_or_default();
-        let mut stats: Vec<CatalogStatsPoint> =
-            cat.stats.get(id).cloned().unwrap_or_default();
+        let mut stats: Vec<CatalogStatsPoint> = cat.stats.get(id).cloned().unwrap_or_default();
         stats.reverse(); // newest first
         stats.truncate(catalog::STATS_DETAIL_LIMIT);
         let upstream = cat
@@ -704,17 +703,29 @@ mod tests {
         let schema_v1 = json!({"type": "object", "properties": {"id": {"type": "integer"}}});
         let schema_v2 = json!({"type": "object", "properties": {"id": {"type": "integer"}, "email": {"type": "string"}}});
 
-        h.catalog_record(&catalog_update("csv://./in.csv", "jsonl://./out.jsonl", Some(schema_v1.clone())))
-            .await
-            .unwrap();
+        h.catalog_record(&catalog_update(
+            "csv://./in.csv",
+            "jsonl://./out.jsonl",
+            Some(schema_v1.clone()),
+        ))
+        .await
+        .unwrap();
         // Same schema again → no new version.
-        h.catalog_record(&catalog_update("csv://./in.csv", "jsonl://./out.jsonl", Some(schema_v1)))
-            .await
-            .unwrap();
+        h.catalog_record(&catalog_update(
+            "csv://./in.csv",
+            "jsonl://./out.jsonl",
+            Some(schema_v1),
+        ))
+        .await
+        .unwrap();
         // Changed schema → second version with a diff.
-        h.catalog_record(&catalog_update("csv://./in.csv", "jsonl://./out.jsonl", Some(schema_v2)))
-            .await
-            .unwrap();
+        h.catalog_record(&catalog_update(
+            "csv://./in.csv",
+            "jsonl://./out.jsonl",
+            Some(schema_v2),
+        ))
+        .await
+        .unwrap();
 
         let page = h
             .catalog_list_datasets(&CatalogListFilter {
@@ -746,7 +757,12 @@ mod tests {
         assert_eq!(all.len(), 1);
         let rooted = h.catalog_lineage(Some(&src_id), 3).await.unwrap();
         assert_eq!(rooted.len(), 1);
-        assert!(h.catalog_lineage(Some("missing"), 3).await.unwrap().is_empty());
+        assert!(
+            h.catalog_lineage(Some("missing"), 3)
+                .await
+                .unwrap()
+                .is_empty()
+        );
         assert!(h.catalog_get_dataset("missing").await.unwrap().is_none());
     }
 

--- a/cli/src/serve/history/mod.rs
+++ b/cli/src/serve/history/mod.rs
@@ -4,6 +4,7 @@
 //! unreachable backend degrades to in-memory rather than refusing to start.
 //! See spec §11 + §20.
 
+pub mod catalog;
 #[cfg(any(feature = "serve-history-postgres", feature = "serve-history-sqlite"))]
 pub mod fallback;
 pub mod memory;
@@ -550,6 +551,58 @@ pub trait RunHistory: Send + Sync {
     /// Most-recent audit records matching `filter`, newest first. Default: empty.
     async fn list_audit(&self, filter: &AuditFilter) -> Result<Vec<AuditEntry>, HistoryError> {
         let _ = filter;
+        Ok(Vec::new())
+    }
+
+    // ── Data Movement Catalog (#279) ─────────────────────────────────────────
+    //
+    // Accumulating, cross-run picture of every dataset a pipeline touches:
+    // identity, schema timeline, volume/freshness stats, lineage edges. All
+    // defaulted to inert so third-party `RunHistory` impls are unaffected;
+    // implemented by the memory + SQL backends and forwarded by the fallback
+    // wrapper. Catalog rows are deliberately NOT purged by `purge_expired` —
+    // the accumulated history is the point (only per-dataset stats are capped,
+    // at [`catalog::STATS_RETAIN`]).
+
+    /// Fold one run's catalog update (two dataset observations + the lineage
+    /// edge between them) into the store. Idempotent-ish last-write-wins per
+    /// dataset/edge, so concurrent cluster instances converge. Default: no-op.
+    async fn catalog_record(&self, update: &catalog::CatalogUpdate) -> Result<(), HistoryError> {
+        let _ = update;
+        Ok(())
+    }
+
+    /// List catalogued datasets, filtered + keyset-paginated
+    /// (`last_seen DESC, id DESC`). Default: empty.
+    async fn catalog_list_datasets(
+        &self,
+        filter: &catalog::CatalogListFilter,
+    ) -> Result<catalog::CatalogDatasetPage, HistoryError> {
+        let _ = filter;
+        Ok(catalog::CatalogDatasetPage {
+            datasets: Vec::new(),
+            next_cursor: None,
+        })
+    }
+
+    /// One dataset's full detail: current schema, schema timeline, recent
+    /// volume points, and upstream/downstream edges. Default: `None`.
+    async fn catalog_get_dataset(
+        &self,
+        id: &str,
+    ) -> Result<Option<catalog::CatalogDatasetDetail>, HistoryError> {
+        let _ = id;
+        Ok(None)
+    }
+
+    /// The lineage edge graph — everything, or a depth-bounded slice around
+    /// `root` (a dataset id). Default: empty.
+    async fn catalog_lineage(
+        &self,
+        root: Option<&str>,
+        depth: u32,
+    ) -> Result<Vec<catalog::CatalogLineageEdge>, HistoryError> {
+        let _ = (root, depth);
         Ok(Vec::new())
     }
 

--- a/cli/src/serve/history/sql.rs
+++ b/cli/src/serve/history/sql.rs
@@ -94,6 +94,39 @@ pub const DDL: &[&str] = &[
         result TEXT NOT NULL)",
     "CREATE INDEX IF NOT EXISTS faucet_serve_audit_ts_idx \
         ON faucet_serve_audit (ts)",
+    // Data Movement Catalog (#279). Accumulating cross-run state, deliberately
+    // NOT covered by `purge_expired` (the history is the value). Same
+    // TEXT-columns + JSON `body` convention as the run tables: the dedicated
+    // columns exist for filtering only; `body` is the source of truth on read.
+    "CREATE TABLE IF NOT EXISTS faucet_catalog_datasets (\
+        id TEXT PRIMARY KEY,\
+        uri TEXT NOT NULL,\
+        kind TEXT NOT NULL,\
+        last_seen TEXT NOT NULL,\
+        body TEXT NOT NULL)",
+    // One row per (dataset, schema version); appended only on content change.
+    // `version` is an integer stored as TEXT (cast on ORDER BY), matching the
+    // shard table's `size_estimate` convention.
+    "CREATE TABLE IF NOT EXISTS faucet_catalog_schema_versions (\
+        dataset_id TEXT NOT NULL,\
+        version TEXT NOT NULL,\
+        recorded_at TEXT NOT NULL,\
+        body TEXT NOT NULL,\
+        PRIMARY KEY (dataset_id, version))",
+    // One row per (source dataset, sink dataset) lineage edge.
+    "CREATE TABLE IF NOT EXISTS faucet_catalog_edges (\
+        src_id TEXT NOT NULL,\
+        dst_id TEXT NOT NULL,\
+        last_seen TEXT NOT NULL,\
+        body TEXT NOT NULL,\
+        PRIMARY KEY (src_id, dst_id))",
+    // Per-run volume points, capped per dataset at `catalog::STATS_RETAIN`.
+    "CREATE TABLE IF NOT EXISTS faucet_catalog_stats (\
+        dataset_id TEXT NOT NULL,\
+        recorded_at TEXT NOT NULL,\
+        run_id TEXT NOT NULL,\
+        records TEXT NOT NULL,\
+        PRIMARY KEY (dataset_id, recorded_at))",
 ];
 
 /// SQL placeholder dialect.
@@ -200,6 +233,32 @@ pub struct Stmts {
     pub list_audit: String,
     /// Purge audit records older than a threshold (retention).
     pub purge_audit: String,
+    // ── Data Movement Catalog (#279) ─────────────────────────────────────────
+    /// One dataset body by id (the merge read + the detail head).
+    pub catalog_select_dataset: String,
+    /// Upsert one dataset row (filter columns + body). Params: id, uri, kind,
+    /// last_seen, body.
+    pub catalog_upsert_dataset: String,
+    /// Every dataset body — filtering/ordering happens in shared pure code
+    /// ([`catalog::filter_datasets`](super::catalog::filter_datasets)), so the
+    /// memory and SQL backends can never disagree on semantics.
+    pub catalog_select_datasets: String,
+    /// Append one schema-timeline entry; `ON CONFLICT DO NOTHING` so a cluster
+    /// replay of the same (dataset, version) is idempotent.
+    pub catalog_insert_schema_version: String,
+    /// A dataset's schema timeline, oldest first.
+    pub catalog_select_schema_versions: String,
+    /// Upsert one lineage edge. Params: src_id, dst_id, last_seen, body.
+    pub catalog_upsert_edge: String,
+    /// Every edge body, newest activity first.
+    pub catalog_select_edges: String,
+    /// Append one volume point. Params: dataset_id, recorded_at, run_id, records.
+    pub catalog_insert_stat: String,
+    /// A dataset's most recent volume points. Params: dataset_id, limit.
+    pub catalog_select_stats: String,
+    /// Drop volume points beyond the newest `STATS_RETAIN` for one dataset.
+    /// Params: dataset_id, dataset_id, keep-limit.
+    pub catalog_prune_stats: String,
 }
 
 impl Stmts {
@@ -374,6 +433,41 @@ impl Stmts {
                 ORDER BY ts DESC, id DESC LIMIT $9"
                 .into(),
             purge_audit: "DELETE FROM faucet_serve_audit WHERE ts < $1".into(),
+            catalog_select_dataset: "SELECT body FROM faucet_catalog_datasets WHERE id=$1".into(),
+            catalog_upsert_dataset: "INSERT INTO faucet_catalog_datasets \
+                (id, uri, kind, last_seen, body) VALUES ($1,$2,$3,$4,$5) \
+                ON CONFLICT (id) DO UPDATE SET uri=excluded.uri, kind=excluded.kind, \
+                last_seen=excluded.last_seen, body=excluded.body"
+                .into(),
+            catalog_select_datasets: "SELECT body FROM faucet_catalog_datasets".into(),
+            catalog_insert_schema_version: "INSERT INTO faucet_catalog_schema_versions \
+                (dataset_id, version, recorded_at, body) VALUES ($1,$2,$3,$4) \
+                ON CONFLICT (dataset_id, version) DO NOTHING"
+                .into(),
+            catalog_select_schema_versions: "SELECT body FROM faucet_catalog_schema_versions \
+                WHERE dataset_id=$1 ORDER BY CAST(version AS BIGINT) ASC"
+                .into(),
+            catalog_upsert_edge: "INSERT INTO faucet_catalog_edges \
+                (src_id, dst_id, last_seen, body) VALUES ($1,$2,$3,$4) \
+                ON CONFLICT (src_id, dst_id) DO UPDATE SET \
+                last_seen=excluded.last_seen, body=excluded.body"
+                .into(),
+            catalog_select_edges: "SELECT body FROM faucet_catalog_edges \
+                ORDER BY last_seen DESC, src_id, dst_id"
+                .into(),
+            catalog_insert_stat: "INSERT INTO faucet_catalog_stats \
+                (dataset_id, recorded_at, run_id, records) VALUES ($1,$2,$3,$4) \
+                ON CONFLICT (dataset_id, recorded_at) DO NOTHING"
+                .into(),
+            catalog_select_stats: "SELECT recorded_at, run_id, records \
+                FROM faucet_catalog_stats WHERE dataset_id=$1 \
+                ORDER BY recorded_at DESC LIMIT $2"
+                .into(),
+            catalog_prune_stats: "DELETE FROM faucet_catalog_stats \
+                WHERE dataset_id=$1 AND recorded_at NOT IN (\
+                    SELECT recorded_at FROM faucet_catalog_stats WHERE dataset_id=$2 \
+                    ORDER BY recorded_at DESC LIMIT $3)"
+                .into(),
         }
     }
 
@@ -539,6 +633,41 @@ impl Stmts {
                 ORDER BY ts DESC, id DESC LIMIT ?"
                 .into(),
             purge_audit: "DELETE FROM faucet_serve_audit WHERE ts < ?".into(),
+            catalog_select_dataset: "SELECT body FROM faucet_catalog_datasets WHERE id=?".into(),
+            catalog_upsert_dataset: "INSERT INTO faucet_catalog_datasets \
+                (id, uri, kind, last_seen, body) VALUES (?,?,?,?,?) \
+                ON CONFLICT (id) DO UPDATE SET uri=excluded.uri, kind=excluded.kind, \
+                last_seen=excluded.last_seen, body=excluded.body"
+                .into(),
+            catalog_select_datasets: "SELECT body FROM faucet_catalog_datasets".into(),
+            catalog_insert_schema_version: "INSERT INTO faucet_catalog_schema_versions \
+                (dataset_id, version, recorded_at, body) VALUES (?,?,?,?) \
+                ON CONFLICT (dataset_id, version) DO NOTHING"
+                .into(),
+            catalog_select_schema_versions: "SELECT body FROM faucet_catalog_schema_versions \
+                WHERE dataset_id=? ORDER BY CAST(version AS INTEGER) ASC"
+                .into(),
+            catalog_upsert_edge: "INSERT INTO faucet_catalog_edges \
+                (src_id, dst_id, last_seen, body) VALUES (?,?,?,?) \
+                ON CONFLICT (src_id, dst_id) DO UPDATE SET \
+                last_seen=excluded.last_seen, body=excluded.body"
+                .into(),
+            catalog_select_edges: "SELECT body FROM faucet_catalog_edges \
+                ORDER BY last_seen DESC, src_id, dst_id"
+                .into(),
+            catalog_insert_stat: "INSERT INTO faucet_catalog_stats \
+                (dataset_id, recorded_at, run_id, records) VALUES (?,?,?,?) \
+                ON CONFLICT (dataset_id, recorded_at) DO NOTHING"
+                .into(),
+            catalog_select_stats: "SELECT recorded_at, run_id, records \
+                FROM faucet_catalog_stats WHERE dataset_id=? \
+                ORDER BY recorded_at DESC LIMIT ?"
+                .into(),
+            catalog_prune_stats: "DELETE FROM faucet_catalog_stats \
+                WHERE dataset_id=? AND recorded_at NOT IN (\
+                    SELECT recorded_at FROM faucet_catalog_stats WHERE dataset_id=? \
+                    ORDER BY recorded_at DESC LIMIT ?)"
+                .into(),
         }
     }
 }
@@ -579,6 +708,18 @@ pub fn encode_body(rec: &RunRecord) -> Result<String, HistoryError> {
 
 pub fn decode_body(body: &str) -> Result<RunRecord, HistoryError> {
     serde_json::from_str(body).map_err(|e| HistoryError::Backend(format!("decode run record: {e}")))
+}
+
+/// Generic body (de)serialization for the catalog tables (#279).
+pub fn encode_json<T: serde::Serialize>(value: &T, what: &str) -> Result<String, HistoryError> {
+    serde_json::to_string(value).map_err(|e| HistoryError::Backend(format!("encode {what}: {e}")))
+}
+
+pub fn decode_json<T: serde::de::DeserializeOwned>(
+    body: &str,
+    what: &str,
+) -> Result<T, HistoryError> {
+    serde_json::from_str(body).map_err(|e| HistoryError::Backend(format!("decode {what}: {e}")))
 }
 
 pub fn parse_status(s: &str) -> RunStatus {
@@ -1725,10 +1866,232 @@ macro_rules! impl_sql_history {
                 Ok(out)
             }
 
+            // ── Data Movement Catalog (#279) ─────────────────────────────────
+
+            async fn catalog_record(
+                &self,
+                update: &$crate::serve::history::catalog::CatalogUpdate,
+            ) -> Result<(), $crate::serve::history::HistoryError> {
+                use sqlx::Row as _;
+                use $crate::serve::history::HistoryError;
+                use $crate::serve::history::catalog;
+                use $crate::serve::history::sql;
+                let backend = |e: sqlx::Error| HistoryError::Backend(e.to_string());
+                let now_s = sql::fmt_ts(update.recorded_at);
+
+                for obs in [&update.source, &update.sink] {
+                    let id = catalog::dataset_id(&obs.uri);
+                    // Read-merge-write; last-write-wins under cluster concurrency
+                    // (counters may undercount on a race — acceptable for
+                    // operational stats, never for correctness).
+                    let existing = sqlx::query(&self.stmts.catalog_select_dataset)
+                        .bind(&id)
+                        .fetch_optional(&self.pool)
+                        .await
+                        .map_err(backend)?
+                        .map(|r| r.try_get::<String, _>("body"))
+                        .transpose()
+                        .map_err(backend)?
+                        .map(|b| {
+                            sql::decode_json::<catalog::CatalogDataset>(&b, "catalog dataset")
+                        })
+                        .transpose()?;
+                    let (ds, new_version) = catalog::apply_observation(
+                        existing.as_ref(),
+                        obs,
+                        &update.run_id,
+                        &update.pipeline,
+                        &update.row,
+                        update.recorded_at,
+                    );
+                    sqlx::query(&self.stmts.catalog_upsert_dataset)
+                        .bind(&ds.id)
+                        .bind(&ds.uri)
+                        .bind(&ds.kind)
+                        .bind(&now_s)
+                        .bind(sql::encode_json(&ds, "catalog dataset")?)
+                        .execute(&self.pool)
+                        .await
+                        .map_err(backend)?;
+                    if let Some(v) = new_version {
+                        sqlx::query(&self.stmts.catalog_insert_schema_version)
+                            .bind(&v.dataset_id)
+                            .bind(v.version.to_string())
+                            .bind(sql::fmt_ts(v.recorded_at))
+                            .bind(sql::encode_json(&v, "catalog schema version")?)
+                            .execute(&self.pool)
+                            .await
+                            .map_err(backend)?;
+                    }
+                    sqlx::query(&self.stmts.catalog_insert_stat)
+                        .bind(&id)
+                        .bind(&now_s)
+                        .bind(&update.run_id)
+                        .bind(obs.records.to_string())
+                        .execute(&self.pool)
+                        .await
+                        .map_err(backend)?;
+                    sqlx::query(&self.stmts.catalog_prune_stats)
+                        .bind(&id)
+                        .bind(&id)
+                        .bind(catalog::STATS_RETAIN as i64)
+                        .execute(&self.pool)
+                        .await
+                        .map_err(backend)?;
+                }
+
+                let src_id = catalog::dataset_id(&update.source.uri);
+                let dst_id = catalog::dataset_id(&update.sink.uri);
+                let existing_edges = self.catalog_all_edges().await?;
+                let existing = existing_edges
+                    .iter()
+                    .find(|e| e.src_id == src_id && e.dst_id == dst_id);
+                let edge = catalog::apply_edge(existing, update);
+                sqlx::query(&self.stmts.catalog_upsert_edge)
+                    .bind(&edge.src_id)
+                    .bind(&edge.dst_id)
+                    .bind(&now_s)
+                    .bind(sql::encode_json(&edge, "catalog edge")?)
+                    .execute(&self.pool)
+                    .await
+                    .map_err(backend)?;
+                Ok(())
+            }
+
+            async fn catalog_list_datasets(
+                &self,
+                filter: &$crate::serve::history::catalog::CatalogListFilter,
+            ) -> Result<
+                $crate::serve::history::catalog::CatalogDatasetPage,
+                $crate::serve::history::HistoryError,
+            > {
+                use sqlx::Row as _;
+                use $crate::serve::history::HistoryError;
+                use $crate::serve::history::catalog;
+                use $crate::serve::history::sql;
+                let backend = |e: sqlx::Error| HistoryError::Backend(e.to_string());
+                let rows = sqlx::query(&self.stmts.catalog_select_datasets)
+                    .fetch_all(&self.pool)
+                    .await
+                    .map_err(backend)?;
+                let mut all = Vec::with_capacity(rows.len());
+                for r in &rows {
+                    let body: String = r.try_get("body").map_err(backend)?;
+                    all.push(sql::decode_json(&body, "catalog dataset")?);
+                }
+                Ok(catalog::filter_datasets(all, filter))
+            }
+
+            async fn catalog_get_dataset(
+                &self,
+                id: &str,
+            ) -> Result<
+                Option<$crate::serve::history::catalog::CatalogDatasetDetail>,
+                $crate::serve::history::HistoryError,
+            > {
+                use sqlx::Row as _;
+                use $crate::serve::history::HistoryError;
+                use $crate::serve::history::catalog;
+                use $crate::serve::history::sql;
+                let backend = |e: sqlx::Error| HistoryError::Backend(e.to_string());
+                let Some(row) = sqlx::query(&self.stmts.catalog_select_dataset)
+                    .bind(id)
+                    .fetch_optional(&self.pool)
+                    .await
+                    .map_err(backend)?
+                else {
+                    return Ok(None);
+                };
+                let body: String = row.try_get("body").map_err(backend)?;
+                let dataset: catalog::CatalogDataset =
+                    sql::decode_json(&body, "catalog dataset")?;
+
+                let rows = sqlx::query(&self.stmts.catalog_select_schema_versions)
+                    .bind(id)
+                    .fetch_all(&self.pool)
+                    .await
+                    .map_err(backend)?;
+                let mut schema_timeline = Vec::with_capacity(rows.len());
+                for r in &rows {
+                    let body: String = r.try_get("body").map_err(backend)?;
+                    schema_timeline.push(sql::decode_json(&body, "catalog schema version")?);
+                }
+
+                let rows = sqlx::query(&self.stmts.catalog_select_stats)
+                    .bind(id)
+                    .bind(catalog::STATS_DETAIL_LIMIT as i64)
+                    .fetch_all(&self.pool)
+                    .await
+                    .map_err(backend)?;
+                let mut stats = Vec::with_capacity(rows.len());
+                for r in &rows {
+                    let recorded: String = r.try_get("recorded_at").map_err(backend)?;
+                    let run_id: String = r.try_get("run_id").map_err(backend)?;
+                    let records: String = r.try_get("records").map_err(backend)?;
+                    stats.push(catalog::CatalogStatsPoint {
+                        recorded_at: chrono::DateTime::parse_from_rfc3339(&recorded)
+                            .map(|d| d.to_utc())
+                            .unwrap_or_else(|_| chrono::Utc::now()),
+                        run_id,
+                        records: records.parse().unwrap_or(0),
+                    });
+                }
+
+                let edges = self.catalog_all_edges().await?;
+                let (downstream, rest): (Vec<_>, Vec<_>) =
+                    edges.into_iter().partition(|e| e.src_id == id);
+                let upstream = rest.into_iter().filter(|e| e.dst_id == id).collect();
+                Ok(Some(catalog::CatalogDatasetDetail {
+                    dataset,
+                    schema_timeline,
+                    stats,
+                    upstream,
+                    downstream,
+                }))
+            }
+
+            async fn catalog_lineage(
+                &self,
+                root: Option<&str>,
+                depth: u32,
+            ) -> Result<
+                Vec<$crate::serve::history::catalog::CatalogLineageEdge>,
+                $crate::serve::history::HistoryError,
+            > {
+                use $crate::serve::history::catalog;
+                let edges = self.catalog_all_edges().await?;
+                Ok(catalog::lineage_slice(edges, root, depth))
+            }
+
             fn degraded(&self) -> bool {
                 // A live SQL backend is never self-degraded; the FallbackHistory
                 // wrapper owns degradation when the backend becomes unreachable.
                 false
+            }
+        }
+
+        impl $name {
+            /// Every catalog lineage edge, newest activity first (#279).
+            async fn catalog_all_edges(
+                &self,
+            ) -> Result<
+                Vec<$crate::serve::history::catalog::CatalogLineageEdge>,
+                $crate::serve::history::HistoryError,
+            > {
+                use sqlx::Row as _;
+                use $crate::serve::history::HistoryError;
+                use $crate::serve::history::sql;
+                let backend = |e: sqlx::Error| HistoryError::Backend(e.to_string());
+                let rows = sqlx::query(&self.stmts.catalog_select_edges)
+                    .fetch_all(&self.pool)
+                    .await
+                    .map_err(backend)?;
+                let mut edges = Vec::with_capacity(rows.len());
+                for r in &rows {
+                    let body: String = r.try_get("body").map_err(backend)?;
+                    edges.push(sql::decode_json(&body, "catalog edge")?);
+                }
+                Ok(edges)
             }
         }
     };

--- a/cli/src/serve/history/sqlite.rs
+++ b/cli/src/serve/history/sqlite.rs
@@ -306,6 +306,101 @@ mod shard_tests {
     }
 
     #[tokio::test]
+    async fn catalog_record_roundtrips_datasets_timeline_stats_and_edges() {
+        use crate::serve::history::catalog::{
+            self, CatalogListFilter, CatalogUpdate, DatasetObservation, DatasetRole,
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let h = backend(&url_in(dir.path()), "a", Duration::from_secs(60)).await;
+
+        let update = |run: &str, schema: serde_json::Value, records: u64| CatalogUpdate {
+            run_id: run.into(),
+            pipeline: "p".into(),
+            row: "default".into(),
+            recorded_at: chrono::Utc::now(),
+            source: DatasetObservation {
+                uri: "csv://./in.csv".into(),
+                kind: "csv".into(),
+                role: DatasetRole::Source,
+                schema: Some(schema.clone()),
+                records,
+            },
+            sink: DatasetObservation {
+                uri: "jsonl://./out.jsonl".into(),
+                kind: "jsonl".into(),
+                role: DatasetRole::Sink,
+                schema: Some(schema),
+                records,
+            },
+            column_lineage: Some(serde_json::json!({"fields": {}})),
+        };
+        let v1 = serde_json::json!({"type":"object","properties":{"id":{"type":"integer"}}});
+        let v2 = serde_json::json!({"type":"object","properties":{"id":{"type":"integer"},"email":{"type":"string"}}});
+
+        h.catalog_record(&update("r1", v1.clone(), 10)).await.unwrap();
+        h.catalog_record(&update("r2", v1, 12)).await.unwrap(); // same schema → deduped
+        h.catalog_record(&update("r3", v2, 9)).await.unwrap(); // changed → version 2
+
+        // List: two datasets, kind filter narrows to one.
+        let page = h
+            .catalog_list_datasets(&CatalogListFilter {
+                limit: 10,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(page.datasets.len(), 2);
+        let page = h
+            .catalog_list_datasets(&CatalogListFilter {
+                kind: Some("csv".into()),
+                limit: 10,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(page.datasets.len(), 1);
+        assert_eq!(page.datasets[0].uri, "csv://./in.csv");
+
+        // Detail: counters, deduped timeline with a diff, stats, edges.
+        let src_id = catalog::dataset_id("csv://./in.csv");
+        let detail = h.catalog_get_dataset(&src_id).await.unwrap().unwrap();
+        assert_eq!(detail.dataset.runs, 3);
+        assert_eq!(detail.dataset.total_records, 31);
+        assert_eq!(detail.dataset.last_run_id, "r3");
+        assert_eq!(detail.schema_timeline.len(), 2, "same schema deduped");
+        assert_eq!(detail.schema_timeline[0].version, 1);
+        assert!(detail.schema_timeline[0].diff.is_none());
+        let diff = detail.schema_timeline[1].diff.as_ref().expect("v2 diff");
+        assert_eq!(diff["added"][0]["column"], "email");
+        assert_eq!(detail.stats.len(), 3, "one volume point per run");
+        assert_eq!(detail.stats[0].records, 9, "newest first");
+        assert_eq!(detail.downstream.len(), 1);
+        assert!(detail.upstream.is_empty());
+        assert_eq!(detail.downstream[0].runs, 3);
+        assert!(detail.downstream[0].column_lineage.is_some());
+
+        // Lineage graph: whole graph and rooted slice both return the edge.
+        assert_eq!(h.catalog_lineage(None, 5).await.unwrap().len(), 1);
+        assert_eq!(h.catalog_lineage(Some(&src_id), 2).await.unwrap().len(), 1);
+        assert!(h.catalog_get_dataset("missing").await.unwrap().is_none());
+
+        // The catalog survives run-record purges (accumulating value).
+        h.purge_expired(Duration::ZERO).await.unwrap();
+        assert_eq!(
+            h.catalog_list_datasets(&CatalogListFilter {
+                limit: 10,
+                ..Default::default()
+            })
+            .await
+            .unwrap()
+            .datasets
+            .len(),
+            2,
+            "catalog rows are never purged by run retention"
+        );
+    }
+
+    #[tokio::test]
     async fn release_idempotency_drops_the_claim() {
         // F21: releasing a claim lets a replay of the key start fresh instead of
         // 404-ing for the whole retention window.

--- a/cli/src/serve/history/sqlite.rs
+++ b/cli/src/serve/history/sqlite.rs
@@ -337,7 +337,9 @@ mod shard_tests {
         let v1 = serde_json::json!({"type":"object","properties":{"id":{"type":"integer"}}});
         let v2 = serde_json::json!({"type":"object","properties":{"id":{"type":"integer"},"email":{"type":"string"}}});
 
-        h.catalog_record(&update("r1", v1.clone(), 10)).await.unwrap();
+        h.catalog_record(&update("r1", v1.clone(), 10))
+            .await
+            .unwrap();
         h.catalog_record(&update("r2", v1, 12)).await.unwrap(); // same schema → deduped
         h.catalog_record(&update("r3", v2, 9)).await.unwrap(); // changed → version 2
 

--- a/cli/src/serve/rbac.rs
+++ b/cli/src/serve/rbac.rs
@@ -36,6 +36,8 @@ pub enum Permission {
     /// Replay / discard dead-letter-queue envelopes
     /// (`POST /v1/dlq/replay`, `POST /v1/dlq/discard`).
     DlqManage,
+    /// Read the Data Movement Catalog (`GET /v1/catalog/*`, #279) — read-only.
+    CatalogRead,
     /// Read the audit log (`GET /v1/audit`) — admin-only.
     AuditRead,
 }
@@ -60,11 +62,18 @@ impl Role {
     pub fn grants(self, perm: Permission) -> bool {
         use Permission::*;
         match self {
-            Role::Viewer => matches!(perm, RunRead | SchemaRead | DlqRead),
+            Role::Viewer => matches!(perm, RunRead | SchemaRead | DlqRead | CatalogRead),
             Role::Operator => {
                 matches!(
                     perm,
-                    RunRead | SchemaRead | DlqRead | RunWrite | Doctor | TriggerFire | DlqManage
+                    RunRead
+                        | SchemaRead
+                        | DlqRead
+                        | CatalogRead
+                        | RunWrite
+                        | Doctor
+                        | TriggerFire
+                        | DlqManage
                 )
             }
             Role::Admin => true,
@@ -232,6 +241,9 @@ pub fn required_permission(method: &Method, matched_path: &str) -> Option<Permis
         (&Method::GET, "/v1/audit") => Some(AuditRead),
         (&Method::POST, "/v1/triggers/{name}") => Some(TriggerFire),
         (&Method::PUT, "/v1/triggers/{name}") => Some(TriggerFire),
+        (&Method::GET, "/v1/catalog/datasets") => Some(CatalogRead),
+        (&Method::GET, "/v1/catalog/datasets/{id}") => Some(CatalogRead),
+        (&Method::GET, "/v1/catalog/lineage") => Some(CatalogRead),
         _ => None,
     }
 }
@@ -253,6 +265,9 @@ pub fn audit_action(method: &Method, matched_path: &str) -> &'static str {
         (&Method::POST, "/v1/dlq/discard") => "dlq.discard",
         (&Method::GET, "/v1/audit") => "audit.list",
         (&Method::POST | &Method::PUT, "/v1/triggers/{name}") => "trigger.fire",
+        (&Method::GET, "/v1/catalog/datasets") => "catalog.list",
+        (&Method::GET, "/v1/catalog/datasets/{id}") => "catalog.get",
+        (&Method::GET, "/v1/catalog/lineage") => "catalog.lineage",
         _ => "unknown",
     }
 }
@@ -382,9 +397,16 @@ mod tests {
             (Method::POST, "/v1/dlq/inspect", DlqRead),
             (Method::POST, "/v1/dlq/replay", DlqManage),
             (Method::POST, "/v1/dlq/discard", DlqManage),
+            (Method::GET, "/v1/catalog/datasets", CatalogRead),
+            (Method::GET, "/v1/catalog/datasets/{id}", CatalogRead),
+            (Method::GET, "/v1/catalog/lineage", CatalogRead),
         ] {
             assert_eq!(required_permission(&m, path), Some(want), "{m} {path}");
         }
+        // Every role can read the catalog; a viewer still can't write runs.
+        assert!(Role::Viewer.grants(Permission::CatalogRead));
+        assert!(Role::Operator.grants(Permission::CatalogRead));
+        assert!(Role::Admin.grants(Permission::CatalogRead));
     }
 
     #[test]

--- a/cli/src/serve/runner.rs
+++ b/cli/src/serve/runner.rs
@@ -435,6 +435,10 @@ async fn execute_shard(
         lineage_cfg: cfg.lineage.clone(),
         #[cfg(feature = "notify")]
         notifier: None,
+        // Inert under `shard: Some(..)` — a shard's records/URIs are a slice
+        // of the row's; the catalog records whole runs only.
+        #[cfg(feature = "catalog")]
+        catalog: None,
     };
 
     let server_shutdown = state.shutdown_token();
@@ -1184,6 +1188,15 @@ async fn execute_run(
         lineage_cfg: cfg.lineage.clone(),
         #[cfg(feature = "notify")]
         notifier,
+        // Record every serve run into the Data Movement Catalog (#279),
+        // stored alongside the run history (`--history` backend) and
+        // attributed to this serve run id.
+        #[cfg(feature = "catalog")]
+        catalog: Some(crate::catalog::CatalogHandle {
+            store: state.history(),
+            run_id: Some(run_id.clone()),
+            sample_records: crate::catalog::DEFAULT_SAMPLE_RECORDS,
+        }),
     };
 
     let span = tracing::info_span!("faucet.serve.run", serve_run_id = %run_id);

--- a/cli/src/serve/server.rs
+++ b/cli/src/serve/server.rs
@@ -25,7 +25,7 @@ pub fn build_router(state: ServerState, config: &ServeConfig) -> Router {
 
     // `/v1` routes guarded by the bearer middleware via `route_layer` (only runs
     // for matched routes; OPTIONS preflight is allowed through inside the layer).
-    #[cfg_attr(not(feature = "triggers"), allow(unused_mut))]
+    #[cfg_attr(not(any(feature = "triggers", feature = "catalog")), allow(unused_mut))]
     let mut api = Router::new()
         .route("/v1/runs", post(runs::submit_run).get(runs::list_runs))
         .route("/v1/runs/{id}", get(runs::get_run).delete(runs::delete_run))
@@ -45,6 +45,14 @@ pub fn build_router(state: ServerState, config: &ServeConfig) -> Router {
             post(crate::serve::triggers::webhook::handle)
                 .put(crate::serve::triggers::webhook::handle),
         );
+    }
+    #[cfg(feature = "catalog")]
+    {
+        use crate::serve::handlers::catalog;
+        api = api
+            .route("/v1/catalog/datasets", get(catalog::list_datasets))
+            .route("/v1/catalog/datasets/{id}", get(catalog::get_dataset))
+            .route("/v1/catalog/lineage", get(catalog::lineage));
     }
     let api = api.route_layer(axum::middleware::from_fn_with_state(
         state.clone(),

--- a/cli/src/serve/ui/app.js
+++ b/cli/src/serve/ui/app.js
@@ -4,6 +4,8 @@ import { renderRuns } from "./views/runs.js";
 import { renderDetail } from "./views/detail.js";
 import { renderSubmit } from "./views/submit.js";
 import { renderSchemas } from "./views/schemas.js";
+import { renderDatasets, renderDatasetDetail } from "./views/datasets.js";
+import { renderLineage } from "./views/lineage.js";
 import { route } from "./router.js";
 
 // --- theme ---
@@ -32,6 +34,8 @@ function wireChrome() {
   document.getElementById("nav-runs").onclick = () => navigate("#/runs");
   document.getElementById("nav-submit").onclick = () => navigate("#/submit");
   document.getElementById("nav-schemas").onclick = () => navigate("#/schemas");
+  document.getElementById("nav-datasets").onclick = () => navigate("#/catalog");
+  document.getElementById("nav-lineage").onclick = () => navigate("#/lineage");
   document.getElementById("theme-toggle").onclick = () => {
     const cur = document.documentElement.dataset.theme;
     applyTheme(cur === "dark" ? "light" : cur === "light" ? "auto" : "dark");
@@ -56,6 +60,10 @@ function registerRoutes() {
   route("#/runs/:id", renderDetail);
   route("#/submit", renderSubmit);
   route("#/schemas", renderSchemas);
+  route("#/catalog", renderDatasets);
+  route("#/catalog/:id", renderDatasetDetail);
+  route("#/lineage", renderLineage);
+  route("#/lineage/:root", renderLineage);
 }
 
 async function main() {

--- a/cli/src/serve/ui/index.html
+++ b/cli/src/serve/ui/index.html
@@ -17,6 +17,8 @@
         <button id="nav-runs">Runs</button>
         <button id="nav-submit">Submit</button>
         <button id="nav-schemas">Schemas</button>
+        <button id="nav-datasets">Datasets</button>
+        <button id="nav-lineage">Lineage</button>
       </nav>
       <div class="spacer"></div>
       <button id="theme-toggle" class="icon-btn" title="Toggle theme">◐</button>

--- a/cli/src/serve/ui/styles.css
+++ b/cli/src/serve/ui/styles.css
@@ -761,3 +761,28 @@ input::placeholder, textarea::placeholder { color: var(--ink-faint); }
 .dlq-json { white-space: pre-wrap; word-break: break-all; font-size: 0.8rem; overflow-x: auto; }
 .dlq-sample { list-style: none; padding: 0; display: flex; flex-direction: column; gap: 0.5rem; }
 .dlq-replay textarea { width: 100%; font-family: monospace; box-sizing: border-box; }
+
+/* Data Movement Catalog (#279): Datasets browser + Lineage graph */
+.mono { font-family: var(--font-mono); }
+.dataset-title { font-size: 1.05rem; word-break: break-all; }
+.detail-grid label { display: block; font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.04em; color: var(--muted, #888); margin-bottom: 2px; }
+.volume-bars { display: flex; align-items: flex-end; gap: 4px; min-height: 68px; padding: 8px 12px; background: var(--surface); border: 1px solid var(--border); border-radius: var(--r); }
+.volume-bar { width: 14px; border-radius: 3px 3px 0 0; background: var(--running, #4a9eda); opacity: 0.85; }
+.volume-bar:hover { opacity: 1; }
+.schema-version { border: 1px solid var(--border); border-radius: var(--r); background: var(--surface); margin-bottom: 8px; }
+.schema-version summary { display: flex; align-items: center; gap: 10px; padding: 10px 14px; cursor: pointer; flex-wrap: wrap; }
+.schema-json { margin: 0; padding: 12px 14px; border-top: 1px solid var(--border); font-size: 0.78rem; overflow-x: auto; }
+.diff-added   { color: var(--ok);   border-color: color-mix(in srgb, var(--ok) 40%, transparent); }
+.diff-widened { color: var(--queued); border-color: color-mix(in srgb, var(--queued) 40%, transparent); }
+.diff-changed { color: var(--fail); border-color: color-mix(in srgb, var(--fail) 40%, transparent); }
+.diff-removed { color: var(--cancelled); border-color: color-mix(in srgb, var(--cancelled) 40%, transparent); }
+.edge-lists { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 16px; margin-bottom: 12px; }
+.edge-lists h3 { margin: 4px 0; font-size: 0.85rem; color: var(--ink-dim); }
+.lineage-graph { overflow: auto; background: var(--surface); border: 1px solid var(--border); border-radius: var(--r); padding: 8px; }
+.lineage-svg { min-width: 640px; width: 100%; height: auto; }
+.lineage-edge { fill: none; stroke: var(--border); stroke-width: 2; }
+.lineage-edge:hover { stroke: var(--running, #4a9eda); }
+.lineage-node rect { fill: var(--bg, #fff); stroke: var(--border); stroke-width: 1.5; }
+.lineage-node text { fill: var(--ink); font-family: var(--font-mono); font-size: 12px; }
+.lineage-node:hover rect { stroke: var(--running, #4a9eda); }
+.lineage-root rect { stroke: var(--ok); stroke-width: 2.5; }

--- a/cli/src/serve/ui/views/datasets.js
+++ b/cli/src/serve/ui/views/datasets.js
@@ -1,0 +1,202 @@
+// Data Movement Catalog (#279): the Datasets browser — a filterable list of
+// every dataset the server's pipelines have touched, plus a per-dataset
+// detail view (schema timeline with diffs, recent volume, lineage edges).
+import { api, toast } from "../api.js";
+import { navigate } from "../router.js";
+import { escapeHtml } from "../utils.js";
+import { fmtTime } from "./runs.js";
+
+const CATALOG_MISSING =
+  "The Data Movement Catalog endpoints are not available on this server " +
+  "(faucet was built without the `catalog` feature).";
+
+export function catalogUnavailable(e) {
+  // A route that is not wired returns a bare 404 (no ApiError envelope code).
+  return e && e.status === 404 && !e.code;
+}
+
+export async function renderDatasets(container) {
+  container.innerHTML = `
+    <div class="page">
+      <div class="page-head">
+        <h1>Datasets</h1>
+        <button class="btn-ghost" id="d-lineage">Lineage graph →</button>
+      </div>
+      <div class="filters">
+        <input id="f-kind" placeholder="kind (csv, postgres, …)" />
+        <input id="f-q" placeholder="search URI" />
+        <button class="btn-ghost" id="f-apply">Apply</button>
+        <button class="btn-ghost" id="f-refresh">↻</button>
+      </div>
+      <div id="ds-list" class="runs-list"></div>
+      <button class="btn-ghost" id="d-more" hidden>Load more</button>
+    </div>`;
+
+  const list = container.querySelector("#ds-list");
+  container.querySelector("#d-lineage").onclick = () => navigate("#/lineage");
+  let cursor = null;
+
+  async function load(reset) {
+    if (reset) cursor = null;
+    const p = new URLSearchParams();
+    const kind = container.querySelector("#f-kind").value.trim();
+    const q = container.querySelector("#f-q").value.trim();
+    if (kind) p.set("kind", kind);
+    if (q) p.set("q", q);
+    p.set("limit", "50");
+    if (cursor) p.set("cursor", cursor);
+    try {
+      const data = await api(`/v1/catalog/datasets?${p}`);
+      if (reset) list.innerHTML = "";
+      if (!data.datasets.length && reset) {
+        list.innerHTML = `<div class="empty">No datasets catalogued yet — run a pipeline first.</div>`;
+      }
+      for (const d of data.datasets) list.appendChild(row(d));
+      cursor = data.next_cursor || null;
+      container.querySelector("#d-more").hidden = !cursor;
+    } catch (e) {
+      if (catalogUnavailable(e)) list.innerHTML = `<div class="empty">${CATALOG_MISSING}</div>`;
+      else toast(e.message, "error");
+    }
+  }
+
+  container.querySelector("#f-apply").onclick = () => load(true);
+  container.querySelector("#f-refresh").onclick = () => load(true);
+  container.querySelector("#d-more").onclick = () => load(false);
+  await load(true);
+}
+
+function row(d) {
+  const el = document.createElement("div");
+  el.className = "run-row";
+  el.onclick = () => navigate(`#/catalog/${d.id}`);
+  el.innerHTML = `
+    <span class="pill">${escapeHtml(d.kind)}</span>
+    <span class="run-name mono">${escapeHtml(d.uri)}</span>
+    <span class="run-meta">${escapeHtml(d.roles.join("+"))}</span>
+    <span class="run-meta">${d.runs} run${d.runs === 1 ? "" : "s"}</span>
+    <span class="run-meta">${d.last_records} rows</span>
+    <span class="run-meta run-time" title="last success">${fmtTime(d.last_success)}</span>`;
+  return el;
+}
+
+export async function renderDatasetDetail(container, params) {
+  container.innerHTML = `<div class="empty">loading…</div>`;
+  let d;
+  try {
+    d = await api(`/v1/catalog/datasets/${encodeURIComponent(params.id)}`);
+  } catch (e) {
+    container.innerHTML = `<div class="empty">${
+      catalogUnavailable(e) ? CATALOG_MISSING : escapeHtml(e.message)
+    }</div>`;
+    return;
+  }
+
+  const maxRows = Math.max(1, ...d.stats.map((s) => s.records));
+  container.innerHTML = `
+    <div class="page">
+      <div class="page-head">
+        <h1 class="mono dataset-title">${escapeHtml(d.uri)}</h1>
+      </div>
+      <div class="detail-grid">
+        <div><label>Kind</label><span class="pill">${escapeHtml(d.kind)}</span></div>
+        <div><label>Roles</label>${escapeHtml(d.roles.join(", "))}</div>
+        <div><label>Pipeline</label>${escapeHtml(d.pipeline)}</div>
+        <div><label>Runs</label>${d.runs}</div>
+        <div><label>Rows (last / total)</label>${d.last_records} / ${d.total_records}</div>
+        <div><label>First seen</label>${fmtTime(d.first_seen)}</div>
+        <div><label>Last success</label>${fmtTime(d.last_success)}</div>
+        <div><label>Id</label><span class="mono">${escapeHtml(d.id)}</span></div>
+      </div>
+
+      <h2>Volume (recent runs)</h2>
+      <div class="volume-bars">
+        ${
+          d.stats.length
+            ? d.stats
+                .slice()
+                .reverse()
+                .map(
+                  (s) =>
+                    `<div class="volume-bar" title="${escapeHtml(`${s.records} rows — ${fmtTime(s.recorded_at)} (run ${s.run_id})`)}"
+                      style="height:${Math.max(4, Math.round((s.records / maxRows) * 64))}px"></div>`,
+                )
+                .join("")
+            : `<div class="empty">no volume points yet</div>`
+        }
+      </div>
+
+      <h2>Schema timeline</h2>
+      <div id="timeline"></div>
+
+      <h2>Lineage</h2>
+      <div class="edge-lists">
+        <div>
+          <h3>Upstream</h3>
+          ${edgeList(d.upstream, (e) => e.src_id, (e) => e.src_uri)}
+        </div>
+        <div>
+          <h3>Downstream</h3>
+          ${edgeList(d.downstream, (e) => e.dst_id, (e) => e.dst_uri)}
+        </div>
+      </div>
+      <button class="btn-ghost" id="d-graph">View in lineage graph →</button>
+    </div>`;
+
+  container.querySelector("#d-graph").onclick = () => navigate(`#/lineage/${d.id}`);
+  container.querySelectorAll(".edge-link").forEach((a) => {
+    a.onclick = () => navigate(`#/catalog/${a.dataset.id}`);
+  });
+
+  const timeline = container.querySelector("#timeline");
+  if (!d.schema_timeline.length) {
+    timeline.innerHTML = `<div class="empty">no schema observed yet</div>`;
+  }
+  for (const v of d.schema_timeline.slice().reverse()) {
+    timeline.appendChild(versionCard(v));
+  }
+}
+
+function edgeList(edges, idOf, uriOf) {
+  if (!edges.length) return `<div class="empty">none</div>`;
+  return edges
+    .map(
+      (e) =>
+        `<div class="run-row edge-link" data-id="${escapeHtml(idOf(e))}">
+          <span class="run-name mono">${escapeHtml(uriOf(e))}</span>
+          <span class="run-meta">${e.runs} run${e.runs === 1 ? "" : "s"}</span>
+          <span class="run-meta">${e.last_records} rows</span>
+        </div>`,
+    )
+    .join("");
+}
+
+function versionCard(v) {
+  const el = document.createElement("details");
+  el.className = "schema-version";
+  const cols = Object.keys((v.schema && v.schema.properties) || {});
+  el.innerHTML = `
+    <summary>
+      <b>v${v.version}</b>
+      <span class="run-meta">${fmtTime(v.recorded_at)}</span>
+      <span class="run-meta">${cols.length} column${cols.length === 1 ? "" : "s"}</span>
+      ${diffBadges(v.diff)}
+    </summary>
+    <pre class="mono schema-json">${escapeHtml(JSON.stringify(v.schema, null, 2))}</pre>`;
+  return el;
+}
+
+function diffBadges(diff) {
+  if (!diff) return "";
+  const name = (c) => (typeof c === "string" ? c : c.column);
+  const badge = (cls, sym, items) =>
+    (items || [])
+      .map((c) => `<span class="pill diff-${cls}">${sym}${escapeHtml(name(c))}</span>`)
+      .join("");
+  return (
+    badge("added", "+", diff.added) +
+    badge("widened", "~", diff.widened) +
+    badge("changed", "!", diff.changed) +
+    badge("removed", "−", diff.removed)
+  );
+}

--- a/cli/src/serve/ui/views/lineage.js
+++ b/cli/src/serve/ui/views/lineage.js
@@ -1,0 +1,143 @@
+// Data Movement Catalog (#279): the Lineage graph — datasets as nodes laid
+// out in topological layers (sources left, sinks right), edges as curves.
+// Pure SVG, no dependencies. Clicking a node opens its dataset detail.
+import { api } from "../api.js";
+import { navigate } from "../router.js";
+import { escapeHtml } from "../utils.js";
+import { catalogUnavailable } from "./datasets.js";
+
+export async function renderLineage(container, params = {}) {
+  container.innerHTML = `<div class="empty">loading…</div>`;
+  let data;
+  try {
+    const p = new URLSearchParams();
+    if (params.root) {
+      p.set("root", params.root);
+      p.set("depth", "8");
+    }
+    data = await api(`/v1/catalog/lineage?${p}`);
+  } catch (e) {
+    container.innerHTML = `<div class="empty">${
+      catalogUnavailable(e)
+        ? "The Data Movement Catalog endpoints are not available on this server " +
+          "(faucet was built without the `catalog` feature)."
+        : escapeHtml(e.message)
+    }</div>`;
+    return;
+  }
+
+  container.innerHTML = `
+    <div class="page">
+      <div class="page-head">
+        <h1>Lineage${params.root ? " (rooted)" : ""}</h1>
+        <button class="btn-ghost" id="l-datasets">← Datasets</button>
+        ${params.root ? `<button class="btn-ghost" id="l-all">Whole graph</button>` : ""}
+      </div>
+      <div id="graph" class="lineage-graph"></div>
+    </div>`;
+  container.querySelector("#l-datasets").onclick = () => navigate("#/catalog");
+  const all = container.querySelector("#l-all");
+  if (all) all.onclick = () => navigate("#/lineage");
+
+  const graph = container.querySelector("#graph");
+  if (!data.edges.length) {
+    graph.innerHTML = `<div class="empty">No lineage edges recorded yet — run a pipeline first.</div>`;
+    return;
+  }
+  graph.appendChild(buildSvg(layout(data.edges), params.root));
+}
+
+/** Compute topological layers: a node's layer is 1 + max layer of its inputs
+ * (cycle-safe via bounded iteration). Returns { nodes, edges }. */
+export function layout(edges) {
+  const nodes = new Map(); // id → { id, uri, layer }
+  for (const e of edges) {
+    if (!nodes.has(e.src_id)) nodes.set(e.src_id, { id: e.src_id, uri: e.src_uri, layer: 0 });
+    if (!nodes.has(e.dst_id)) nodes.set(e.dst_id, { id: e.dst_id, uri: e.dst_uri, layer: 0 });
+  }
+  // Relax layers |V| times max (cycles just stop improving).
+  for (let i = 0; i < nodes.size; i++) {
+    let changed = false;
+    for (const e of edges) {
+      const s = nodes.get(e.src_id);
+      const d = nodes.get(e.dst_id);
+      if (d.layer < s.layer + 1 && s.layer + 1 <= nodes.size) {
+        d.layer = s.layer + 1;
+        changed = true;
+      }
+    }
+    if (!changed) break;
+  }
+  // Row index within each layer, ordered by URI for stability.
+  const byLayer = new Map();
+  for (const n of [...nodes.values()].sort((a, b) => a.uri.localeCompare(b.uri))) {
+    const rows = byLayer.get(n.layer) || [];
+    n.row = rows.length;
+    rows.push(n);
+    byLayer.set(n.layer, rows);
+  }
+  return { nodes, edges };
+}
+
+const NODE_W = 260;
+const NODE_H = 44;
+const GAP_X = 120;
+const GAP_Y = 24;
+
+function buildSvg({ nodes, edges }, rootId) {
+  const ns = "http://www.w3.org/2000/svg";
+  const layers = Math.max(...[...nodes.values()].map((n) => n.layer)) + 1;
+  const rows = Math.max(...[...nodes.values()].map((n) => n.row)) + 1;
+  const width = layers * NODE_W + (layers - 1) * GAP_X + 32;
+  const height = rows * (NODE_H + GAP_Y) + 32;
+  const svg = document.createElementNS(ns, "svg");
+  svg.setAttribute("viewBox", `0 0 ${width} ${height}`);
+  svg.setAttribute("class", "lineage-svg");
+
+  const x = (n) => 16 + n.layer * (NODE_W + GAP_X);
+  const y = (n) => 16 + n.row * (NODE_H + GAP_Y);
+
+  for (const e of edges) {
+    const s = nodes.get(e.src_id);
+    const d = nodes.get(e.dst_id);
+    const x1 = x(s) + NODE_W;
+    const y1 = y(s) + NODE_H / 2;
+    const x2 = x(d);
+    const y2 = y(d) + NODE_H / 2;
+    const mid = (x1 + x2) / 2;
+    const path = document.createElementNS(ns, "path");
+    path.setAttribute("d", `M ${x1} ${y1} C ${mid} ${y1}, ${mid} ${y2}, ${x2} ${y2}`);
+    path.setAttribute("class", "lineage-edge");
+    const title = document.createElementNS(ns, "title");
+    title.textContent = `${e.pipeline} (row ${e.row}) — ${e.runs} run(s), ${e.last_records} row(s) last`;
+    path.appendChild(title);
+    svg.appendChild(path);
+  }
+
+  for (const n of nodes.values()) {
+    const g = document.createElementNS(ns, "g");
+    g.setAttribute("class", `lineage-node${n.id === rootId ? " lineage-root" : ""}`);
+    g.setAttribute("transform", `translate(${x(n)}, ${y(n)})`);
+    g.style.cursor = "pointer";
+    g.onclick = () => navigate(`#/catalog/${n.id}`);
+    const rect = document.createElementNS(ns, "rect");
+    rect.setAttribute("width", NODE_W);
+    rect.setAttribute("height", NODE_H);
+    rect.setAttribute("rx", 8);
+    const label = document.createElementNS(ns, "text");
+    label.setAttribute("x", 12);
+    label.setAttribute("y", NODE_H / 2 + 4);
+    label.textContent = shorten(n.uri, 34);
+    const title = document.createElementNS(ns, "title");
+    title.textContent = n.uri;
+    g.appendChild(rect);
+    g.appendChild(label);
+    g.appendChild(title);
+    svg.appendChild(g);
+  }
+  return svg;
+}
+
+function shorten(s, max) {
+  return s.length <= max ? s : `…${s.slice(s.length - max + 1)}`;
+}

--- a/cli/tests/catalog_cmd.rs
+++ b/cli/tests/catalog_cmd.rs
@@ -1,0 +1,217 @@
+//! Drives the `faucet catalog` subcommand bodies directly (#279) — the
+//! commands are clap-free by convention exactly so integration tests can call
+//! them in-process (spawned-binary tests are skipped under coverage). Seeds a
+//! real SQLite catalog store by running a csv→jsonl pipeline twice (with a
+//! schema change), then exercises datasets / show / lineage in both human and
+//! `--json` modes plus every user-facing error path.
+#![cfg(all(
+    feature = "catalog",
+    feature = "serve-history-sqlite",
+    feature = "source-csv",
+    feature = "sink-jsonl"
+))]
+
+use faucet_cli::cli::{
+    CatalogArgs, CatalogCommand, CatalogConfigArgs, CatalogDatasetsArgs, CatalogLineageArgs,
+    CatalogShowArgs,
+};
+use faucet_cli::commands::catalog as catalog_cmd;
+use faucet_cli::serve::history::catalog::CatalogListFilter;
+use std::path::{Path, PathBuf};
+
+fn config_yaml(dir: &Path) -> String {
+    format!(
+        "version: 1\nname: catalog-cmd\ncatalog:\n  url: \"sqlite:{dir}/cat.db\"\n  sample_records: 10\npipeline:\n  source: {{ type: csv, config: {{ path: \"{dir}/in.csv\" }} }}\n  sink: {{ type: jsonl, config: {{ path: \"{dir}/out.jsonl\" }} }}\n",
+        dir = dir.display()
+    )
+}
+
+fn common(config: Option<PathBuf>, json: bool) -> CatalogConfigArgs {
+    CatalogConfigArgs {
+        config,
+        env_file: None,
+        no_env_file: true,
+        profile: None,
+        json,
+    }
+}
+
+/// Seed the store: two runs, the second with an added column.
+async fn seed(dir: &Path) -> PathBuf {
+    let yaml = config_yaml(dir);
+    let config_path = dir.join("faucet.yaml");
+    std::fs::write(&config_path, &yaml).unwrap();
+
+    std::fs::write(dir.join("in.csv"), "id,name\n1,alice\n2,bob\n").unwrap();
+    faucet_cli::run_from_yaml_str(&yaml).await.expect("run 1");
+    std::fs::write(
+        dir.join("in.csv"),
+        "id,name,email\n1,alice,a@x.io\n2,bob,b@x.io\n",
+    )
+    .unwrap();
+    faucet_cli::run_from_yaml_str(&yaml).await.expect("run 2");
+    config_path
+}
+
+/// The seeded source dataset's id, read back through the store.
+async fn source_dataset_id(dir: &Path) -> String {
+    let handle = faucet_cli::catalog::connect_from_spec(&faucet_cli::catalog::CatalogSpec {
+        url: format!("sqlite:{}/cat.db", dir.display()),
+        sample_records: 10,
+    })
+    .await
+    .unwrap();
+    let page = handle
+        .store
+        .catalog_list_datasets(&CatalogListFilter {
+            limit: 10,
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert_eq!(page.datasets.len(), 2, "source + sink datasets seeded");
+    page.datasets
+        .iter()
+        .find(|d| d.kind == "csv")
+        .expect("csv dataset")
+        .id
+        .clone()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn catalog_command_datasets_show_lineage_roundtrip() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = seed(dir.path()).await;
+    let id = source_dataset_id(dir.path()).await;
+
+    // datasets — human, json, and filtered variants all succeed.
+    for (json, kind, q) in [
+        (false, None, None),
+        (true, None, None),
+        (false, Some("csv".to_string()), None),
+        (false, None, Some("out.jsonl".to_string())),
+    ] {
+        catalog_cmd::run(CatalogArgs {
+            command: CatalogCommand::Datasets(CatalogDatasetsArgs {
+                common: common(Some(config.clone()), json),
+                kind,
+                q,
+                limit: 50,
+            }),
+        })
+        .await
+        .expect("datasets");
+    }
+
+    // show — full id, unique prefix, human + json.
+    for (shown, json) in [(id.clone(), false), (id[..8].to_string(), true)] {
+        catalog_cmd::run(CatalogArgs {
+            command: CatalogCommand::Show(CatalogShowArgs {
+                id: shown,
+                common: common(Some(config.clone()), json),
+            }),
+        })
+        .await
+        .expect("show");
+    }
+
+    // show — unknown id is a clear config error, not a panic.
+    let err = catalog_cmd::run(CatalogArgs {
+        command: CatalogCommand::Show(CatalogShowArgs {
+            id: "ffffffffffffffff".into(),
+            common: common(Some(config.clone()), false),
+        }),
+    })
+    .await
+    .unwrap_err();
+    assert!(err.to_string().contains("no catalogued dataset"), "{err}");
+
+    // show — an empty prefix matches both datasets → ambiguous error.
+    let err = catalog_cmd::run(CatalogArgs {
+        command: CatalogCommand::Show(CatalogShowArgs {
+            id: "".into(),
+            common: common(Some(config.clone()), false),
+        }),
+    })
+    .await
+    .unwrap_err();
+    assert!(err.to_string().contains("ambiguous"), "{err}");
+
+    // lineage — whole graph (human + json) and the rooted slice.
+    for (json, root) in [(false, None), (true, None), (false, Some(id.clone()))] {
+        catalog_cmd::run(CatalogArgs {
+            command: CatalogCommand::Lineage(CatalogLineageArgs {
+                common: common(Some(config.clone()), json),
+                root,
+                depth: 3,
+            }),
+        })
+        .await
+        .expect("lineage");
+    }
+
+    // lineage — an unknown root yields the empty-graph message, not an error.
+    catalog_cmd::run(CatalogArgs {
+        command: CatalogCommand::Lineage(CatalogLineageArgs {
+            common: common(Some(config.clone()), false),
+            root: Some("ffffffffffffffff".into()),
+            depth: 3,
+        }),
+    })
+    .await
+    .expect("empty rooted lineage");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn catalog_command_errors_without_a_catalog_block() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = dir.path().join("plain.yaml");
+    std::fs::write(
+        &config,
+        "version: 1\npipeline:\n  source: { type: csv, config: { path: ./in.csv } }\n  sink: { type: jsonl, config: { path: ./out.jsonl } }\n",
+    )
+    .unwrap();
+    let err = catalog_cmd::run(CatalogArgs {
+        command: CatalogCommand::Datasets(CatalogDatasetsArgs {
+            common: common(Some(config), false),
+            kind: None,
+            q: None,
+            limit: 10,
+        }),
+    })
+    .await
+    .unwrap_err();
+    assert!(err.to_string().contains("no `catalog:` block"), "{err}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn catalog_command_on_an_empty_store_prints_the_empty_message() {
+    // A memory store that no run has written to: datasets + lineage both
+    // succeed with their "empty" renderings.
+    let dir = tempfile::tempdir().unwrap();
+    let config = dir.path().join("faucet.yaml");
+    std::fs::write(
+        &config,
+        "version: 1\ncatalog: { url: memory }\npipeline:\n  source: { type: csv, config: { path: ./in.csv } }\n  sink: { type: jsonl, config: { path: ./out.jsonl } }\n",
+    )
+    .unwrap();
+    catalog_cmd::run(CatalogArgs {
+        command: CatalogCommand::Datasets(CatalogDatasetsArgs {
+            common: common(Some(config.clone()), false),
+            kind: None,
+            q: None,
+            limit: 10,
+        }),
+    })
+    .await
+    .expect("empty datasets");
+    catalog_cmd::run(CatalogArgs {
+        command: CatalogCommand::Lineage(CatalogLineageArgs {
+            common: common(Some(config), false),
+            root: None,
+            depth: 3,
+        }),
+    })
+    .await
+    .expect("empty lineage");
+}

--- a/cli/tests/cli_end_to_end.rs
+++ b/cli/tests/cli_end_to_end.rs
@@ -879,6 +879,15 @@ fn shipped_example_yamls_pass_validate() {
                 continue;
             }
         }
+        // `catalog:` is a deny_unknown_fields key gated on the `catalog`
+        // feature; a build without it can't parse those examples.
+        #[cfg(not(feature = "catalog"))]
+        {
+            let yaml_text = fs::read_to_string(&path).unwrap_or_default();
+            if yaml_text.contains("\ncatalog:") || yaml_text.starts_with("catalog:") {
+                continue;
+            }
+        }
         count += 1;
         let mut cmd = Command::cargo_bin("faucet").unwrap();
         for (k, v) in env_placeholders {

--- a/cli/tests/replication.rs
+++ b/cli/tests/replication.rs
@@ -116,6 +116,8 @@ async fn run_once(url: &str, state_dir: &str) {
             sla: None,
             #[cfg(feature = "notify")]
             notifier: None,
+            #[cfg(feature = "catalog")]
+            catalog: None,
         },
     )
     .await

--- a/cli/tests/serve_catalog.rs
+++ b/cli/tests/serve_catalog.rs
@@ -1,0 +1,235 @@
+//! Integration tests for the `/v1/catalog/*` control-plane endpoints (#279).
+//! Boots a real RBAC server, runs a pipeline through `POST /v1/runs`, and
+//! asserts the Data Movement Catalog accumulated the run: dataset list /
+//! detail (schema timeline + stats + edges) and the lineage graph — plus RBAC
+//! (a viewer can read the catalog; an unauthenticated caller cannot).
+#![cfg(all(feature = "catalog", feature = "source-csv", feature = "sink-jsonl"))]
+
+use serde_json::Value;
+use std::time::Duration;
+
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+/// `admin-tok` → admin, `viewer-tok` → viewer (read-only).
+const AUTH_CONFIG: &str = "principals:\n\
+    \x20 - name: alice\n\
+    \x20   token: admin-tok\n\
+    \x20   role: admin\n\
+    \x20 - name: bob\n\
+    \x20   token: viewer-tok\n\
+    \x20   role: viewer\n";
+
+fn serve_args(port: u16, auth_config: std::path::PathBuf) -> faucet_cli::cli::ServeArgs {
+    faucet_cli::cli::ServeArgs {
+        listen: format!("127.0.0.1:{port}"),
+        auth_token: None,
+        auth_config: Some(auth_config),
+        no_auth: false,
+        max_concurrent_runs: Some(4),
+        max_queued_runs: Some(16),
+        default_config: None,
+        history: None,
+        cors_origin: vec![],
+        body_limit_bytes: 1_048_576,
+        shutdown_grace_secs: 5,
+        retain_terminal_runs_secs: 604_800,
+        idempotency_retention_secs: 86_400,
+        lease_ttl_secs: 30,
+        probe_timeout_secs: 5,
+        env_file: None,
+        no_env_file: true,
+        no_ui: false,
+        cluster: false,
+        cluster_poll_secs: 2,
+        cluster_max_attempts: 3,
+        triggers: None,
+    }
+}
+
+async fn spawn_server(port: u16, dir: &std::path::Path) {
+    let auth_path = dir.join("auth.yaml");
+    std::fs::write(&auth_path, AUTH_CONFIG).unwrap();
+    let mut config =
+        faucet_cli::serve::ServeConfig::from_args(serve_args(port, auth_path)).unwrap();
+    config.log_level = "warn".into();
+    tokio::spawn(async move {
+        let _ = faucet_cli::serve::run_server(config).await;
+    });
+    let client = reqwest::Client::new();
+    for _ in 0..100 {
+        if client
+            .get(format!("http://127.0.0.1:{port}/healthz"))
+            .send()
+            .await
+            .map(|r| r.status().is_success())
+            .unwrap_or(false)
+        {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    panic!("server did not become healthy on port {port}");
+}
+
+/// Submit a csv→jsonl run and wait for it to complete.
+async fn run_pipeline(base: &str, client: &reqwest::Client, input: &str, output: &str) {
+    let config = format!(
+        "version: 1\nname: cat-e2e\npipeline:\n  source: {{ type: csv, config: {{ path: {input} }} }}\n  sink: {{ type: jsonl, config: {{ path: {output} }} }}\n",
+    );
+    let resp = client
+        .post(format!("{base}/v1/runs"))
+        .bearer_auth("admin-tok")
+        .json(&serde_json::json!({ "config": config }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 202, "{}", resp.text().await.unwrap());
+    let body: Value = resp.json().await.unwrap();
+    let run_id = body["run_id"].as_str().unwrap().to_string();
+
+    for _ in 0..200 {
+        let rec: Value = client
+            .get(format!("{base}/v1/runs/{run_id}"))
+            .bearer_auth("admin-tok")
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        match rec["status"].as_str().unwrap() {
+            "completed" => return,
+            "failed" | "cancelled" => panic!("run finished {rec}"),
+            _ => tokio::time::sleep(Duration::from_millis(25)).await,
+        }
+    }
+    panic!("run did not complete in time");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn catalog_endpoints_accumulate_runs_and_enforce_rbac() {
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("in.csv");
+    let output = dir.path().join("out.jsonl");
+    let port = free_port();
+    spawn_server(port, dir.path()).await;
+    let client = reqwest::Client::new();
+    let base = format!("http://127.0.0.1:{port}");
+    let input_s = input.display().to_string();
+    let output_s = output.display().to_string();
+
+    // Unauthenticated catalog read → 401.
+    let unauth = client
+        .get(format!("{base}/v1/catalog/datasets"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(unauth.status().as_u16(), 401);
+
+    // Before any run: an empty catalog, not an error.
+    let empty: Value = client
+        .get(format!("{base}/v1/catalog/datasets"))
+        .bearer_auth("viewer-tok")
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(empty["datasets"].as_array().unwrap().len(), 0);
+
+    // Run 1, then run 2 with an added column (schema change).
+    std::fs::write(&input, "id,name\n1,alice\n2,bob\n").unwrap();
+    run_pipeline(&base, &client, &input_s, &output_s).await;
+    std::fs::write(&input, "id,name,email\n1,alice,a@x.io\n2,bob,b@x.io\n").unwrap();
+    run_pipeline(&base, &client, &input_s, &output_s).await;
+
+    // A viewer can list the datasets (source + sink).
+    let page: Value = client
+        .get(format!("{base}/v1/catalog/datasets"))
+        .bearer_auth("viewer-tok")
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let datasets = page["datasets"].as_array().unwrap();
+    assert_eq!(datasets.len(), 2, "{page}");
+    let csv = datasets
+        .iter()
+        .find(|d| d["kind"] == "csv")
+        .expect("csv source dataset");
+    assert_eq!(csv["runs"], 2);
+    assert_eq!(csv["schema_versions"], 2);
+
+    // Kind filter narrows the list.
+    let filtered: Value = client
+        .get(format!("{base}/v1/catalog/datasets?kind=jsonl"))
+        .bearer_auth("viewer-tok")
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(filtered["datasets"].as_array().unwrap().len(), 1);
+
+    // Detail: schema timeline (2 entries, the second with a diff), stats, edge.
+    let id = csv["id"].as_str().unwrap();
+    let detail: Value = client
+        .get(format!("{base}/v1/catalog/datasets/{id}"))
+        .bearer_auth("viewer-tok")
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let timeline = detail["schema_timeline"].as_array().unwrap();
+    assert_eq!(timeline.len(), 2, "{detail}");
+    assert!(timeline[0].get("diff").is_none());
+    assert_eq!(timeline[1]["diff"]["added"][0]["column"], "email");
+    assert_eq!(detail["stats"].as_array().unwrap().len(), 2);
+    assert_eq!(detail["downstream"].as_array().unwrap().len(), 1);
+
+    // Unknown dataset → handler 404 with the error envelope.
+    let missing = client
+        .get(format!("{base}/v1/catalog/datasets/nope"))
+        .bearer_auth("viewer-tok")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(missing.status().as_u16(), 404);
+    assert!(missing.text().await.unwrap().contains("\"error\""));
+
+    // Lineage: whole graph and the rooted slice both return the one edge.
+    let graph: Value = client
+        .get(format!("{base}/v1/catalog/lineage"))
+        .bearer_auth("viewer-tok")
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let edges = graph["edges"].as_array().unwrap();
+    assert_eq!(edges.len(), 1, "{graph}");
+    assert_eq!(edges[0]["runs"], 2);
+    let rooted: Value = client
+        .get(format!("{base}/v1/catalog/lineage?root={id}&depth=2"))
+        .bearer_auth("viewer-tok")
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(rooted["edges"].as_array().unwrap().len(), 1);
+}

--- a/cli/tests/serve_catalog.rs
+++ b/cli/tests/serve_catalog.rs
@@ -89,7 +89,12 @@ async fn run_pipeline(base: &str, client: &reqwest::Client, input: &str, output:
         .send()
         .await
         .unwrap();
-    assert_eq!(resp.status().as_u16(), 202, "{}", resp.text().await.unwrap());
+    assert_eq!(
+        resp.status().as_u16(),
+        202,
+        "{}",
+        resp.text().await.unwrap()
+    );
     let body: Value = resp.json().await.unwrap();
     let run_id = body["run_id"].as_str().unwrap().to_string();
 

--- a/cli/tests/serve_openapi.rs
+++ b/cli/tests/serve_openapi.rs
@@ -44,6 +44,14 @@ const ROUTES_TRIGGERS: &[(&str, &str)] = &[
     ("PUT", "/v1/triggers/{name}"),
 ];
 
+/// Routes that are only registered when the `catalog` feature is compiled in.
+#[cfg(feature = "catalog")]
+const ROUTES_CATALOG: &[(&str, &str)] = &[
+    ("GET", "/v1/catalog/datasets"),
+    ("GET", "/v1/catalog/datasets/{id}"),
+    ("GET", "/v1/catalog/lineage"),
+];
+
 /// Returns the full canonical route set for the current feature configuration.
 fn canonical_routes() -> BTreeSet<(String, String)> {
     #[allow(unused_mut)]
@@ -53,6 +61,10 @@ fn canonical_routes() -> BTreeSet<(String, String)> {
         .collect();
     #[cfg(feature = "triggers")]
     for (m, p) in ROUTES_TRIGGERS {
+        set.insert((m.to_string(), p.to_string()));
+    }
+    #[cfg(feature = "catalog")]
+    for (m, p) in ROUTES_CATALOG {
         set.insert((m.to_string(), p.to_string()));
     }
     set
@@ -72,6 +84,11 @@ fn openapi_routes() -> BTreeSet<(String, String)> {
         // for a given feature combination.
         #[cfg(not(feature = "triggers"))]
         if path.starts_with("/v1/triggers") {
+            continue;
+        }
+        // Likewise for the `catalog` feature's routes.
+        #[cfg(not(feature = "catalog"))]
+        if path.starts_with("/v1/catalog") {
             continue;
         }
         let ops = ops.as_mapping().unwrap();

--- a/cli/tests/sla_monitoring.rs
+++ b/cli/tests/sla_monitoring.rs
@@ -221,6 +221,8 @@ async fn dry_run_skips_sla_evaluation() {
             lineage_cfg: None,
             #[cfg(feature = "notify")]
             notifier: None,
+            #[cfg(feature = "catalog")]
+            catalog: None,
         },
     )
     .await

--- a/crates/core/src/transforming_source.rs
+++ b/crates/core/src/transforming_source.rs
@@ -128,6 +128,13 @@ impl Source for TransformingSource {
     fn connector_name(&self) -> &'static str {
         self.inner.connector_name()
     }
+
+    fn dataset_uri(&self) -> String {
+        // Forward the wrapped connector's identity — without this, lineage and
+        // the Data Movement Catalog would see the default
+        // `<connector>://unknown` whenever transforms are attached.
+        self.inner.dataset_uri()
+    }
 }
 
 #[cfg(test)]

--- a/crates/lineage/src/sampling.rs
+++ b/crates/lineage/src/sampling.rs
@@ -45,6 +45,14 @@ impl SampleState {
             s.push(r.clone());
         }
     }
+    /// A copy of the sampled records (bounded by the construction-time cap).
+    /// Used by consumers that run their own schema inference over the sample —
+    /// e.g. the CLI's Data Movement Catalog (#279), which feeds them to
+    /// `faucet_core::schema::infer_schema` for a drift-comparable shape.
+    pub fn samples(&self) -> Vec<Value> {
+        self.sample.lock().unwrap().clone()
+    }
+
     /// Infer an ordered (name, OL-type) schema from the sampled records.
     pub fn inferred_schema(&self) -> InferredSchema {
         let sample = self.sample.lock().unwrap();

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -43,6 +43,7 @@
 - [Running a cluster](./cookbook/cluster.md)
 - [Event-driven triggers](./cookbook/triggers.md)
 - [Lineage (OpenLineage)](./cookbook/lineage.md)
+- [Data Movement Catalog](./cookbook/catalog.md)
 - [Troubleshooting with faucet doctor](./cookbook/troubleshooting.md)
 
 # Reference

--- a/docs/book/src/cookbook/catalog.md
+++ b/docs/book/src/cookbook/catalog.md
@@ -1,0 +1,131 @@
+# Data Movement Catalog
+
+The **Data Movement Catalog** is faucet's first-party, persistent record of
+everything your pipelines touch. Where a run's logs and metrics describe *one*
+run, the catalog accumulates **across** runs:
+
+- **Datasets** — every source and sink a pipeline has read or written, keyed
+  by a canonical, credential-redacted dataset URI.
+- **Schema timelines** — the observed record schema of each dataset, stored as
+  a deduplicated timeline: a new version is appended only when the schema
+  actually changes, together with a computed diff (added / widened /
+  incompatible / removed columns).
+- **Volume & freshness** — per-run record counts and the last-success
+  timestamp for each dataset.
+- **Lineage edges** — which dataset feeds which, with per-edge column lineage
+  whenever the transform chain is expressible (the same derivation the
+  [OpenLineage emitter](./lineage.md) uses).
+- **Provenance** — every catalog row is linked to the run that produced it
+  (the serve run id under `faucet serve`, the invocation run id otherwise).
+
+After a few weeks of runs the catalog answers the operational questions that
+otherwise require spelunking logs: *what's the schema history of this table?*,
+*what feeds it?*, *when did this pipeline last land data, and how much?*
+
+Recording is **observational only**: a catalog write never fails or slows a
+run — a broken store logs a warning and the pipeline continues.
+
+> Requires a build with the `catalog` Cargo feature (included in
+> `--features full`), plus `serve-history-sqlite` / `serve-history-postgres`
+> for persistent stores.
+
+## Recording from `faucet run` / `schedule` / `replicate`
+
+Add a top-level `catalog:` block naming the store:
+
+```yaml
+# cli/examples/csv_to_jsonl_with_catalog.yaml
+version: 1
+name: csv_to_jsonl_with_catalog
+
+catalog:
+  url: sqlite:./faucet-catalog.db
+  sample_records: 100        # schema-inference sample per side (default 100)
+
+pipeline:
+  source: { type: csv,   config: { path: ./data/input.csv } }
+  sink:   { type: jsonl, config: { path: ./out/records.jsonl } }
+```
+
+`url` accepts `sqlite:<path>`, a `postgres://…` URL, or `memory`
+(process-lifetime only — for tests). Every successful **root** invocation then
+folds its observations into the store: dry runs, `--limit` runs, shard
+executions, and cancelled runs are excluded so partial or synthetic volumes
+never pollute the history.
+
+## Recording from `faucet serve`
+
+`faucet serve` needs no config block: every run is recorded into the server's
+`--history` backend automatically, attributed to its serve run id. Use a
+persistent history for a persistent catalog:
+
+```bash
+faucet serve --history sqlite:./faucet-catalog.db --auth-token "$TOKEN"
+```
+
+The run-record retention window does **not** purge the catalog — the
+accumulated history is the point. Only per-dataset volume points are capped
+(newest 500 kept).
+
+## Browsing: CLI
+
+```bash
+faucet catalog datasets --config pipeline.yaml            # list (newest first)
+faucet catalog datasets --config pipeline.yaml --kind csv --q users
+faucet catalog show 3f2a9c1e0b7d4a55 --config pipeline.yaml
+faucet catalog lineage --config pipeline.yaml --root 3f2a9c1e0b7d4a55 --depth 3
+```
+
+`show` accepts a unique prefix of the dataset id. Every subcommand takes
+`--json` for machine-readable output. `faucet schema catalog` prints the
+`catalog:` block's JSON Schema.
+
+`show` renders the schema timeline with diff markers:
+
+```text
+schema timeline (2 versions):
+  v1  2026-07-01T02:00:04Z  2 column(s)  run 0197e6…
+  v2  2026-07-06T02:00:03Z  3 column(s)  run 0197f1…  [+email]
+```
+
+## Browsing: HTTP API + web console
+
+Three read-only endpoints (viewer-readable under RBAC):
+
+| Endpoint | Returns |
+|---|---|
+| `GET /v1/catalog/datasets` | Paginated dataset list (`kind`, `q`, `limit`, `cursor` filters) |
+| `GET /v1/catalog/datasets/{id}` | Current schema, schema timeline (with diffs), recent volume points, upstream/downstream edges |
+| `GET /v1/catalog/lineage` | The edge graph (`root` + `depth` for a bounded slice) |
+
+The embedded [web console](./web-console.md) adds a **Datasets** browser
+(filterable list → per-dataset detail with the schema timeline and volume
+bars) and a **Lineage** graph view (layered SVG; click a node for its detail).
+
+## Dataset identity & cardinality
+
+The catalog key is the connector's dataset URI after two normalizations:
+
+1. **Credentials are redacted** (`postgres://user:***@host/db/table`).
+2. **`${now.*}`-derived path segments are folded back to their tokens** — a
+   sink writing `./out/dt=${now.date}/part.jsonl` catalogues as one dataset
+   (`…/dt=${now.date}/part.jsonl`), not one per day.
+
+Matrix rows that resolve to the same URI converge on one dataset with one
+provenance trail per run.
+
+## Schema observation
+
+Schemas are inferred from a bounded sample of the records actually read
+(source side, pre-transform) and written (sink side, post-transform) — the
+same samplers the lineage emitter uses, capped by `sample_records`. The
+timeline dedupes by a content hash, so re-running an unchanged pipeline never
+grows it; a real change appends one version whose `diff` is computed with the
+same engine as [schema-drift handling](./schema-drift.md).
+
+## Relationship to lineage emission
+
+[OpenLineage emission](./lineage.md) *exports* run events to an external
+backend (Marquez, DataHub, …); the catalog is the *first-party store* faucet
+keeps for itself. They compose — the catalog's per-edge column lineage matches
+the OpenLineage column-lineage facet, and both can be active at once.

--- a/docs/book/src/cookbook/web-console.md
+++ b/docs/book/src/cookbook/web-console.md
@@ -85,6 +85,23 @@ Browses the connector catalog compiled into the running server
 JSON Schema — useful for checking config field names and types without leaving
 the browser.
 
+### Datasets & Lineage (Data Movement Catalog)
+
+When the server is built with the `catalog` feature, two more views browse the
+[Data Movement Catalog](./catalog.md) accumulated in the `--history` backend:
+
+- **Datasets** — a filterable list (kind / URI search) of every dataset the
+  server's pipelines have touched. Clicking a dataset opens its detail:
+  freshness and run counters, per-run volume bars, the deduplicated schema
+  timeline with per-version diff badges, and its upstream/downstream edges.
+- **Lineage** — the source→sink edge graph rendered as a layered SVG (sources
+  left, sinks right). Hover an edge for the pipeline/run context; click a node
+  to open its dataset detail; open a rooted, depth-bounded slice from any
+  dataset's detail page.
+
+On a server built without the `catalog` feature both views show a short
+"not available" notice (the endpoints are absent).
+
 ## Disabling the console at runtime
 
 If you built with `serve-ui` but want to serve only the API (no static assets),

--- a/docs/book/src/reference/cli.md
+++ b/docs/book/src/reference/cli.md
@@ -113,6 +113,7 @@ faucet schema sla
 faucet schema notifications
 faucet schema secrets
 faucet schema triggers
+faucet schema catalog
 ```
 
 `faucet schema transform <name>` prints the inline config schema for a
@@ -135,6 +136,11 @@ that needs to understand the interpolation syntax without reading the docs.
 `faucet schema triggers` prints the JSON Schema for the `--triggers` file format
 (the `TriggersFile` / `TriggerSpec` / `TriggerKind` types). Requires the
 `triggers` Cargo feature.
+
+`faucet schema catalog` prints the JSON Schema for the top-level `catalog:`
+(Data Movement Catalog store) block — see
+[the catalog cookbook](../cookbook/catalog.md). Requires the `catalog` Cargo
+feature.
 
 ## `init`
 
@@ -289,6 +295,24 @@ non-zero with the compile error) and prints, per destination sink, which rules
 apply — the fast way to confirm `applies_to` scoping. Offline-safe: secrets are
 never fetched. Requires the `masking` Cargo feature (in the default build). See
 the [masking](../cookbook/masking.md) cookbook page.
+
+## `catalog`
+
+*(requires the `catalog` build feature — included in `full`)*
+
+```bash
+faucet catalog datasets --config pipeline.yaml                 # list catalogued datasets
+faucet catalog datasets --config pipeline.yaml --kind csv --q users --json
+faucet catalog show 3f2a9c1e0b7d4a55 --config pipeline.yaml    # detail (id prefix ok)
+faucet catalog lineage --config pipeline.yaml --root 3f2a9c1e0b7d4a55 --depth 3
+```
+
+Browses the [Data Movement Catalog](../cookbook/catalog.md) named by the
+config's `catalog:` block: the dataset list (newest activity first, `--kind` /
+`--q` filters), one dataset's detail (schema timeline with diffs, recent
+volume, upstream/downstream edges), and the lineage graph. All subcommands
+accept `--json`; `--config` auto-discovers `faucet.yaml` in cwd when omitted.
+Read-only — it never mutates the store.
 
 ## `notify`
 

--- a/docs/book/src/reference/config.md
+++ b/docs/book/src/reference/config.md
@@ -728,6 +728,27 @@ See the [Lineage cookbook](../cookbook/lineage.md) for the full field reference,
 transports (HTTP, file, Kafka), the column-lineage support matrix, schema-facet behavior, and
 the Prometheus metrics (`faucet_lineage_events_total`, etc.).
 
+## `catalog`
+
+Optional. When present, `faucet run` / `schedule` / `replicate` record every
+successful **root** invocation into the [Data Movement Catalog](../cookbook/catalog.md) —
+the persistent, cross-run store of datasets, schema timelines, volume/freshness
+stats, and lineage edges. Recording **never fails a run**. `faucet serve`
+ignores this block: it records into its `--history` backend automatically.
+Requires a build with the `catalog` feature (in `--features full`).
+
+```yaml
+catalog:
+  url: sqlite:./faucet-catalog.db   # REQUIRED. sqlite:<path> | postgres://… | memory
+  sample_records: 100               # Records sampled per side for schema inference.
+```
+
+SQL stores additionally require the matching `serve-history-sqlite` /
+`serve-history-postgres` build feature. Browse the store with
+[`faucet catalog`](./cli.md#catalog), the `/v1/catalog/*`
+[HTTP endpoints](./http-api.md), or the web console's Datasets / Lineage views.
+Schema: `faucet schema catalog`.
+
 ## `observability`
 
 Optional top-level block that enables runtime observability backends. All

--- a/docs/book/src/reference/http-api.md
+++ b/docs/book/src/reference/http-api.md
@@ -66,6 +66,9 @@ for the SQL backends; an in-memory ring otherwise) and expire with the
 | `POST` | `/v1/runs/{id}/cancel` | `202` / `200` | Request cancel (202) or no-op if terminal (200) |
 | `GET` | `/v1/runs/{id}/logs` | `200` | Stream the run's logs as `text/event-stream` |
 | `GET` | `/v1/audit` | `200` | Read the audit log — **admin only** (RBAC). Filters: `principal`, `action`, `since`, `until`, `limit` |
+| `GET` | `/v1/catalog/datasets` | `200` | List catalogued datasets (`kind`, `q`, `limit`, `cursor`) — requires the `catalog` build feature |
+| `GET` | `/v1/catalog/datasets/{id}` | `200` | One dataset's detail: schema timeline, volume, edges |
+| `GET` | `/v1/catalog/lineage` | `200` | The lineage edge graph (`root`, `depth`) |
 | `GET` | `/healthz` | `200` | Liveness (unauthenticated) |
 | `GET` | `/readyz` | `200`/`503` | Readiness (unauthenticated) |
 | `GET` | `/metrics` | `200` | Prometheus exposition (unauthenticated) |
@@ -163,6 +166,26 @@ whose buffer has expired yields a single `end`.
 ```bash
 curl -N -H "Authorization: Bearer $TOKEN" \
   http://127.0.0.1:8080/v1/runs/0192…/logs
+```
+
+### `GET /v1/catalog/*` (Data Movement Catalog)
+
+Read-only browsing of the [Data Movement Catalog](../cookbook/catalog.md)
+accumulated in the server's `--history` backend (every serve run records into
+it automatically). Viewer-readable under RBAC; requires a build with the
+`catalog` feature.
+
+- `GET /v1/catalog/datasets?kind=&q=&limit=&cursor=` — paginated dataset list,
+  ordered `(last_seen DESC, id DESC)`; `q` is a case-insensitive URI substring.
+- `GET /v1/catalog/datasets/{id}` — the dataset plus its deduplicated schema
+  timeline (each version with a `diff` vs the previous), recent per-run volume
+  points, and upstream/downstream lineage edges. `404` for an unknown id.
+- `GET /v1/catalog/lineage?root=&depth=` — the source→sink edge graph; with
+  `root` (a dataset id), a BFS slice bounded by `depth` hops.
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" \
+  "http://127.0.0.1:8080/v1/catalog/datasets?kind=postgres&limit=20"
 ```
 
 ## Error envelope

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -333,6 +333,83 @@ paths:
         "400": { description: Bad location or reason filter }
         "401": { description: Missing or invalid bearer token }
         "403": { description: Principal's role lacks the required permission }
+  /v1/catalog/datasets:
+    get:
+      summary: List catalogued datasets (Data Movement Catalog)
+      description: >
+        Every dataset the server's pipelines have touched (source or sink),
+        accumulated run over run into the `--history` backend, newest activity
+        first. Requires the `CatalogRead` permission (viewer). Requires the
+        `catalog` Cargo feature.
+      operationId: listCatalogDatasets
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - { name: kind, in: query, required: false, schema: { type: string }, description: "Exact connector-kind filter (csv, postgres, …)." }
+        - { name: q, in: query, required: false, schema: { type: string }, description: "Case-insensitive substring match on the dataset URI." }
+        - { name: limit, in: query, required: false, schema: { type: integer, default: 100, maximum: 1000 } }
+        - { name: cursor, in: query, required: false, schema: { type: string }, description: "Last dataset id from the previous page." }
+      responses:
+        "200":
+          description: A page of datasets, ordered (last_seen DESC, id DESC).
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [datasets]
+                properties:
+                  datasets:
+                    type: array
+                    items: { $ref: "#/components/schemas/CatalogDataset" }
+                  next_cursor: { type: string, nullable: true }
+        "401": { $ref: "#/components/responses/Error" }
+        "403": { description: Principal's role lacks the required permission }
+  /v1/catalog/datasets/{id}:
+    get:
+      summary: Get one dataset's catalog detail
+      description: >
+        Current schema, the deduplicated schema timeline (with per-version
+        diffs), recent per-run volume points, and the dataset's upstream /
+        downstream lineage edges. Requires the `CatalogRead` permission
+        (viewer). Requires the `catalog` Cargo feature.
+      operationId: getCatalogDataset
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - { name: id, in: path, required: true, schema: { type: string }, description: "Dataset id (16-hex sha256 prefix of the canonical URI)." }
+      responses:
+        "200":
+          description: The dataset detail.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/CatalogDatasetDetail" }
+        "401": { $ref: "#/components/responses/Error" }
+        "403": { description: Principal's role lacks the required permission }
+        "404": { $ref: "#/components/responses/Error" }
+  /v1/catalog/lineage:
+    get:
+      summary: Get the dataset lineage graph
+      description: >
+        The source→sink lineage edges accumulated across runs — the whole
+        graph, or a depth-bounded slice around a root dataset. Requires the
+        `CatalogRead` permission (viewer). Requires the `catalog` Cargo feature.
+      operationId: getCatalogLineage
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - { name: root, in: query, required: false, schema: { type: string }, description: "Dataset id to root the graph at; omitted = the whole graph." }
+        - { name: depth, in: query, required: false, schema: { type: integer, default: 5, maximum: 32 }, description: "BFS hop bound around root (ignored without one)." }
+      responses:
+        "200":
+          description: The lineage edges.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [edges]
+                properties:
+                  edges:
+                    type: array
+                    items: { $ref: "#/components/schemas/CatalogLineageEdge" }
+        "401": { $ref: "#/components/responses/Error" }
+        "403": { description: Principal's role lacks the required permission }
   /v1/audit:
     get:
       summary: Read the control-plane audit log (RBAC, admin-only)
@@ -531,6 +608,79 @@ components:
         config_fingerprint: { type: string, nullable: true, description: "sha256 of the merged config (submit actions)." }
         source_ip: { type: string, nullable: true }
         result: { type: string, enum: [ok, denied] }
+    CatalogDataset:
+      type: object
+      required: [id, uri, kind, roles, first_seen, last_seen, last_success, last_run_id, pipeline, last_records, total_records, runs, schema_versions]
+      properties:
+        id: { type: string, description: "16-hex sha256 prefix of the canonical URI." }
+        uri: { type: string, description: "Canonical dataset URI — credential-redacted; ${now.*}-derived segments folded back to their tokens." }
+        kind: { type: string, description: "Connector kind (csv, postgres, …)." }
+        roles: { type: array, items: { type: string, enum: [source, sink] } }
+        first_seen: { type: string, format: date-time }
+        last_seen: { type: string, format: date-time }
+        last_success: { type: string, format: date-time, description: "Last successful run that touched this dataset (freshness)." }
+        last_run_id: { type: string }
+        pipeline: { type: string, description: "Pipeline name of the most recent run." }
+        last_records: { type: integer }
+        total_records: { type: integer }
+        runs: { type: integer }
+        schema_versions: { type: integer }
+        current_schema: { type: object, nullable: true, description: "Latest observed record schema (infer_schema shape)." }
+        current_schema_hash: { type: string, nullable: true }
+    CatalogSchemaVersion:
+      type: object
+      required: [dataset_id, version, recorded_at, run_id, schema, schema_hash]
+      properties:
+        dataset_id: { type: string }
+        version: { type: integer, description: "1-based, appended only on content change." }
+        recorded_at: { type: string, format: date-time }
+        run_id: { type: string }
+        schema: { type: object }
+        schema_hash: { type: string }
+        diff: { type: object, nullable: true, description: "Diff vs the previous version ({added, widened, changed, removed}); absent for version 1." }
+    CatalogStatsPoint:
+      type: object
+      required: [recorded_at, run_id, records]
+      properties:
+        recorded_at: { type: string, format: date-time }
+        run_id: { type: string }
+        records: { type: integer }
+    CatalogLineageEdge:
+      type: object
+      required: [src_id, dst_id, src_uri, dst_uri, pipeline, row, first_seen, last_seen, last_run_id, runs, last_records]
+      properties:
+        src_id: { type: string }
+        dst_id: { type: string }
+        src_uri: { type: string }
+        dst_uri: { type: string }
+        pipeline: { type: string }
+        row: { type: string }
+        first_seen: { type: string, format: date-time }
+        last_seen: { type: string, format: date-time }
+        last_run_id: { type: string }
+        runs: { type: integer }
+        last_records: { type: integer }
+        column_lineage: { type: object, nullable: true, description: "Column-lineage facet from the most recent run ({fields: {out: [in, …]}})." }
+    CatalogDatasetDetail:
+      allOf:
+        - { $ref: "#/components/schemas/CatalogDataset" }
+        - type: object
+          required: [schema_timeline, stats, upstream, downstream]
+          properties:
+            schema_timeline:
+              type: array
+              description: Oldest first.
+              items: { $ref: "#/components/schemas/CatalogSchemaVersion" }
+            stats:
+              type: array
+              description: Most recent volume points, newest first (bounded).
+              items: { $ref: "#/components/schemas/CatalogStatsPoint" }
+            upstream:
+              type: array
+              items: { $ref: "#/components/schemas/CatalogLineageEdge" }
+            downstream:
+              type: array
+              items: { $ref: "#/components/schemas/CatalogLineageEdge" }
     ApiError:
       type: object
       required: [error]


### PR DESCRIPTION
Closes #279. Part of roadmap epic #38.

Adds the **Data Movement Catalog**: a persistent, queryable, cross-run record of everything faucet touches — every dataset seen (source + sink), its schema over time (a deduplicated timeline with computed diffs), per-run volume + last-success freshness, the lineage edges between datasets, and run provenance. Gated on a new CLI-only `catalog` Cargo feature (`= ["serve", "lineage"]`; in `full`, not `default`).

## Storage (rides the run-history backends)
- Shared pure logic + types in `cli/src/serve/history/catalog.rs`: `apply_observation` (content-hash-deduped schema versions; diffs via `faucet_core::drift::diff_schema`), `apply_edge`, `filter_datasets`, depth-bounded `lineage_slice` BFS — one code path for all backends.
- Four defaulted `RunHistory` methods (`catalog_record` / `catalog_list_datasets` / `catalog_get_dataset` / `catalog_lineage`), implemented by the memory backend and the shared `impl_sql_history!` macro (PG + SQLite: `faucet_catalog_{datasets,schema_versions,edges,stats}` tables), forwarded by `FallbackHistory`.
- Catalog rows are **never purged** by run retention (the accumulated history is the point); per-dataset volume points are capped at the newest 500.

## Write path (never fails a run)
- `cli/src/catalog/`: the top-level `catalog:` block (`url`: `sqlite:`/`postgres://`/`memory`, `sample_records`; `faucet schema catalog`), URI canonicalization (credentials redacted via `redact_uri_credentials`; `${now.*}`-derived path segments folded back to their tokens so dated paths converge on one dataset), and the log-and-continue recorder.
- `run_one_invocation` records after every **successful root** invocation (never dry-run / `--limit` / shard / cancelled), reusing the lineage samplers for schema inference and `faucet-lineage`'s column-lineage derivation so catalog edges match the OpenLineage output. `faucet run` / `schedule` / `replicate` connect from `catalog:`; **`faucet serve` records every run into its `--history` backend automatically**, attributed to the serve run id.

## Read paths
- **Serve:** `GET /v1/catalog/datasets` (kind/q/limit/cursor), `GET /v1/catalog/datasets/{id}` (schema timeline + diffs, volume, edges), `GET /v1/catalog/lineage` (root/depth) — new `CatalogRead` permission (viewer+), audited, openapi documented + two-way sync test extended.
- **CLI:** `faucet catalog datasets|show|lineage` (`--json`, id-prefix resolution).
- **Web console:** Datasets browser (schema-timeline diff badges, volume bars) + a layered-SVG Lineage graph view.

## Also fixed
`TransformingSource` / `StateKeyOverride` / `CapturingSink` / `LimitedSink` did not forward `dataset_uri()`, so lineage saw `<kind>://unknown` whenever transforms or per-row state were active — now forwarded (and the catalog reads URIs off the raw connectors). `faucet-lineage` gains `SampleState::samples()`.

## Acceptance criteria (from #279)
- ✅ Same pipeline run twice with a schema change → exactly two timeline entries, second with a computed diff (`executor::tests::catalog_records_schema_timeline_across_two_runs`, `serve_catalog` e2e, SQLite roundtrip test)
- ✅ `GET /v1/catalog/datasets/{id}` returns schema, timeline, volume/freshness series, up/downstream edges — integration-tested against SQLite + memory + live serve
- ✅ Lineage edges match the `faucet-lineage` column-lineage output (same `column_ops` + `derive_column_lineage` derivation)
- ✅ Credentials redacted in every catalog record (asserted in `model::tests` + storage tests)
- ✅ Catalog writes never fail a run (asserted with an always-failing store; connect degradation reuses `FallbackHistory`)
- ✅ Console Datasets list + Lineage graph (behind `serve-ui`)
- ✅ Pure recorder/model/read logic unit-tested throughout (merge/dedupe/diff, canonicalization, filters, BFS, RBAC, rendering)

## Docs
Cookbook page + `## catalog` config reference, CLI + HTTP-API reference sections, web-console page, `cli/README.md`, runnable `cli/examples/csv_to_jsonl_with_catalog.yaml` (validate-tested), CI feature-isolation matrix entry, `docs/openapi.yaml`.

Out of scope per the issue: column-lineage visualization beyond derived edges, profiling stats, external catalog federation, alerting.