### PR TITLE
chore(dist): Homebrew tap homebrew-faucet-stream, formula faucet-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ no Python runtime, no platform to stand up, no daemon to babysit — plus a type
 you'd rather compile data movement straight into your own service.
 
 ```bash
-brew install PawanSikawat/faucet/faucet   # the CLI — prebuilt, no Rust needed
+brew install PawanSikawat/faucet-stream/faucet-cli   # the CLI — prebuilt, no Rust needed
 # — or —
 curl -LsSf https://github.com/PawanSikawat/faucet-stream/releases/latest/download/faucet-cli-installer.sh | sh
 # — or —
@@ -297,7 +297,7 @@ and `lineage`:
 
 ```bash
 # Homebrew
-brew install PawanSikawat/faucet/faucet
+brew install PawanSikawat/faucet-stream/faucet-cli
 
 # Shell installer (installs to ~/.cargo/bin by default, checksummed)
 curl -LsSf https://github.com/PawanSikawat/faucet-stream/releases/latest/download/faucet-cli-installer.sh | sh

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ no Python runtime, no platform to stand up, no daemon to babysit — plus a type
 you'd rather compile data movement straight into your own service.
 
 ```bash
-brew install PawanSikawat/faucet/faucet   # the CLI — prebuilt, no Rust needed
+brew install PawanSikawat/faucet-stream/faucet   # the CLI — prebuilt, no Rust needed
 # — or —
 curl -LsSf https://github.com/PawanSikawat/faucet-stream/releases/latest/download/faucet-cli-installer.sh | sh
 # — or —
@@ -297,7 +297,7 @@ and `lineage`:
 
 ```bash
 # Homebrew
-brew install PawanSikawat/faucet/faucet
+brew install PawanSikawat/faucet-stream/faucet
 
 # Shell installer (installs to ~/.cargo/bin by default, checksummed)
 curl -LsSf https://github.com/PawanSikawat/faucet-stream/releases/latest/download/faucet-cli-installer.sh | sh

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ no Python runtime, no platform to stand up, no daemon to babysit — plus a type
 you'd rather compile data movement straight into your own service.
 
 ```bash
-brew install PawanSikawat/faucet-stream/faucet   # the CLI — prebuilt, no Rust needed
+brew install PawanSikawat/faucet/faucet   # the CLI — prebuilt, no Rust needed
 # — or —
 curl -LsSf https://github.com/PawanSikawat/faucet-stream/releases/latest/download/faucet-cli-installer.sh | sh
 # — or —
@@ -297,7 +297,7 @@ and `lineage`:
 
 ```bash
 # Homebrew
-brew install PawanSikawat/faucet-stream/faucet
+brew install PawanSikawat/faucet/faucet
 
 # Shell installer (installs to ~/.cargo/bin by default, checksummed)
 curl -LsSf https://github.com/PawanSikawat/faucet-stream/releases/latest/download/faucet-cli-installer.sh | sh

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -12,12 +12,6 @@ readme = "README.md"
 keywords = ["pipeline", "etl", "cli", "meltano", "faucet"]
 categories = ["command-line-utilities"]
 
-# cargo-dist: name the Homebrew formula after the binary (`faucet`), not the
-# package (`faucet-cli`), so the install command reads
-# `brew install PawanSikawat/faucet/faucet`.
-[package.metadata.dist]
-formula = "faucet"
-
 [[bin]]
 name = "faucet"
 path = "src/main.rs"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["command-line-utilities"]
 
 # cargo-dist: name the Homebrew formula after the binary (`faucet`), not the
 # package (`faucet-cli`), so the install command reads
-# `brew install PawanSikawat/faucet-stream/faucet`.
+# `brew install PawanSikawat/faucet/faucet`.
 [package.metadata.dist]
 formula = "faucet"
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -6,10 +6,17 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage = "https://pawansikawat.github.io/faucet-stream/"
+
 description = "Config-driven CLI runner for faucet-stream pipelines (YAML / JSON, Meltano-style)"
 readme = "README.md"
 keywords = ["pipeline", "etl", "cli", "meltano", "faucet"]
 categories = ["command-line-utilities"]
+
+# cargo-dist: name the Homebrew formula after the binary (`faucet`), not the
+# package (`faucet-cli`), so the install command reads
+# `brew install PawanSikawat/faucet-stream/faucet`.
+[package.metadata.dist]
+formula = "faucet"
 
 [[bin]]
 name = "faucet"

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -10,7 +10,7 @@ ci = "github"
 # The installers to generate for each app
 installers = ["shell", "homebrew"]
 # A GitHub repo to push Homebrew formulas to
-tap = "PawanSikawat/homebrew-faucet"
+tap = "PawanSikawat/homebrew-faucet-stream"
 # Publish jobs to run in CI
 publish-jobs = ["homebrew"]
 # Target platforms to build apps for (Rust target-triple syntax)

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -10,7 +10,7 @@ ci = "github"
 # The installers to generate for each app
 installers = ["shell", "homebrew"]
 # A GitHub repo to push Homebrew formulas to
-tap = "PawanSikawat/homebrew-faucet-stream"
+tap = "PawanSikawat/homebrew-faucet"
 # Publish jobs to run in CI
 publish-jobs = ["homebrew"]
 # Target platforms to build apps for (Rust target-triple syntax)

--- a/docs/book/src/getting-started/installation.md
+++ b/docs/book/src/getting-started/installation.md
@@ -11,8 +11,11 @@ it.
 **Homebrew (macOS / Linux):**
 
 ```bash
-brew install PawanSikawat/faucet/faucet
+brew install PawanSikawat/faucet-stream/faucet-cli
 ```
+
+(The formula is named after the `faucet-cli` package; it installs the `faucet`
+binary.)
 
 **Shell installer (macOS / Linux):**
 

--- a/docs/book/src/getting-started/installation.md
+++ b/docs/book/src/getting-started/installation.md
@@ -11,7 +11,7 @@ it.
 **Homebrew (macOS / Linux):**
 
 ```bash
-brew install PawanSikawat/faucet/faucet
+brew install PawanSikawat/faucet-stream/faucet
 ```
 
 **Shell installer (macOS / Linux):**

--- a/docs/book/src/getting-started/installation.md
+++ b/docs/book/src/getting-started/installation.md
@@ -11,7 +11,7 @@ it.
 **Homebrew (macOS / Linux):**
 
 ```bash
-brew install PawanSikawat/faucet-stream/faucet
+brew install PawanSikawat/faucet/faucet
 ```
 
 **Shell installer (macOS / Linux):**


### PR DESCRIPTION
Follow-up to #294 / #290 — final naming per review: tap **`PawanSikawat/homebrew-faucet-stream`** (matches the project namespace), formula left at the cargo-dist default **`faucet-cli`** (named after the package; installs the `faucet` binary):

```bash
brew install PawanSikawat/faucet-stream/faucet-cli
```

Verified with `dist plan` (emits `faucet-cli.rb`). README + installation docs updated. Pending account-side steps from #290 now target: create the public repo **`PawanSikawat/homebrew-faucet-stream`** + add the **`HOMEBREW_TAP_TOKEN`** secret.