### PR TITLE
chore(deps): path-only faucet-conformance dev-dependency (unblocks the release publish)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,10 @@ faucet-common-snowflake = { path = "crates/common/snowflake", version = "1.0.4" 
 faucet-common-mssql = { path = "crates/common/mssql", version = "1.0.5" }
 faucet-source-rest = { path = "crates/source/rest", version = "1.2.2" }
 faucet-source-singer = { path = "crates/source/singer", version = "1.0.0" }
-faucet-conformance = { path = "crates/conformance", version = "1.0.0" }
+# Path-only on purpose: faucet-conformance is a test battery consumed only as
+# a dev-dependency; a versioned entry would make dependents' `cargo publish`
+# require it on crates.io first (release-plz does not order by dev-dep edges).
+faucet-conformance = { path = "crates/conformance" }
 faucet-source-graphql = { path = "crates/source/graphql", version = "1.2.2" }
 faucet-source-xml = { path = "crates/source/xml", version = "1.2.2" }
 faucet-source-grpc = { path = "crates/source/grpc", version = "1.2.0" }

--- a/crates/source/singer/Cargo.toml
+++ b/crates/source/singer/Cargo.toml
@@ -33,7 +33,10 @@ libc = "0.2"
 tokio = { version = "1", features = ["full", "test-util"] }
 tracing-subscriber = "0.3"
 tempfile.workspace = true
-faucet-conformance.workspace = true
+# Path-only (no version): cargo strips path-only dev-dependencies when
+# packaging, so publishing this crate does not require faucet-conformance to
+# be on crates.io first (release-plz orders publishes without dev-dep edges).
+faucet-conformance = { path = "../../conformance" }
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
The 2026-07-10 release-plz publish run failed at `faucet-source-singer`: its dev-dependency on `faucet-conformance` carried a version (via the workspace entry), so cargo required the crate to exist on crates.io — but release-plz publishes without dev-dep ordering, so singer went first and the whole run aborted (nothing after `faucet-source-rest-v1.2.2` was published; no `faucet-cli` tag was cut).

Fix: the workspace entry (and singer's direct reference) are now **path-only** — cargo strips path-only dev-dependencies at packaging, so singer and csv publish independently of conformance's registry status, and `faucet-conformance` still publishes as its own package. Verified with `cargo publish --dry-run` for `faucet-source-singer`, `faucet-source-csv`, and `faucet-conformance`.

Merging this re-triggers the release-plz release job, which resumes idempotently (skips already-published crates) and should carry through to the `faucet-cli` tag → first `release-binaries` run.