### PR TITLE
chore: release (resume interrupted publish)

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -70,6 +70,12 @@ release_commits = "^(feat|fix|perf)"
 # uses APIs added to a dependency (e.g. faucet-core) that haven't been
 # published yet — the release PR is what bumps the dependency first.
 release_always = false
+# Recovery note (2026-07-10): if the publish job dies mid-release (e.g. the
+# versioned-dev-dep failure fixed in #296), the release-PR-merge event is
+# consumed and no new release PR appears while main's versions are already
+# bumped. To resume, merge a trivial PR from a `release-plz-*` branch — the
+# publish job keys on that branch prefix and is idempotent (skips
+# already-published crates).
 
 # Disable cargo-semver-checks for all packages. Semver-checks compiles each
 # crate's local and registry sources to compare API surface — for a 47-crate


### PR DESCRIPTION
The #293 release publish aborted at `faucet-source-singer` (fixed in #296), consuming the one release-PR-merge event that `release_always = false` gates publishing on — and no new release PR appears because main's versions/changelogs are already correct. This PR (from a `release-plz-*` branch, which is what the publish job keys on) hands release-plz a fresh release event; the publish is idempotent and resumes from where the failed run stopped, through to the `faucet-cli-v1.4.0` tag → first `release-binaries` run. Diff is a comment-only note in `release-plz.toml` documenting this recovery path.