### PR TITLE
ci(dist): manual dispatch for release-binaries (GITHUB_TOKEN tags don't trigger workflows)

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -44,8 +44,15 @@ permissions:
 # per-crate tag so the ~50 other `<crate>-vX.Y.Z` tags release-plz pushes per
 # release do not trigger binary builds. On pull requests only the cheap
 # `dist plan` job runs (build jobs are gated on publishing).
+# NOTE: release-plz pushes tags with the workflow-scoped GITHUB_TOKEN, and
+# GitHub suppresses workflow triggers from GITHUB_TOKEN-pushed refs — so the
+# tag push does NOT fire this workflow on its own. Until a RELEASE_PLZ_TOKEN
+# PAT is configured for the publish job, trigger a release build manually:
+#   gh workflow run release-binaries.yml --ref faucet-cli-vX.Y.Z
+# (workflow_dispatch on the tag ref; the plan job reads the tag from the ref).
 on:
   pull_request:
+  workflow_dispatch:
   push:
     tags:
       - 'faucet-cli-v[0-9]+.[0-9]+.[0-9]+*'

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -17,6 +17,13 @@ name: Release binaries (dist)
 permissions:
   "contents": "write"
 
+# Harden against transient crates.io connectivity drops (same guards as
+# ci.yml / release-plz.yml): retry more, force HTTP/1.1 to the registry.
+# (Hand edit — see allow-dirty = ["ci"] in dist-workspace.toml.)
+env:
+  CARGO_NET_RETRY: "10"
+  CARGO_HTTP_MULTIPLEXING: "false"
+
 # This task will run whenever you push a git tag that looks like a version
 # like "1.0.0", "v0.1.0-prerelease.1", "my-app/0.1.0", "releases/v1.0.0", etc.
 # Various formats will be parsed into a VERSION and an optional PACKAGE_NAME, where

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -26,6 +26,17 @@ allow-dirty = ["ci"]
 # Whether to install an updater program
 install-updater = false
 
+# System packages for the Linux build runners (mirrors the CI "librdkafka
+# prerequisites" step): sasl2-sys needs libsasl2-dev, rdkafka needs cmake +
+# a C toolchain, openssl-sys needs libssl-dev. macOS runners need nothing
+# extra (verified: aarch64-apple-darwin built clean).
+[dist.dependencies.apt]
+libsasl2-dev = '*'
+libssl-dev = '*'
+libcurl4-openssl-dev = '*'
+cmake = '*'
+build-essential = '*'
+
 # Build Linux aarch64 natively on GitHub's arm runners instead of
 # cross-compiling (librdkafka/openssl make cross builds painful).
 [dist.github-custom-runners]


### PR DESCRIPTION
Discovered on the v1.4.0 release: release-plz pushes the per-crate tags with the workflow-scoped `GITHUB_TOKEN`, and GitHub suppresses workflow triggers from `GITHUB_TOKEN`-pushed refs — so `release-binaries.yml` never fired for `faucet-cli-v1.4.0` (recovered by deleting + re-pushing the tag with user credentials).

This adds a `workflow_dispatch` trigger so future releases can be built with:

```bash
gh workflow run release-binaries.yml --ref faucet-cli-vX.Y.Z
```

The durable fix is to add a `RELEASE_PLZ_TOKEN` PAT secret and use it in the release-plz publish job — tags pushed with a PAT trigger workflows normally (and release PRs would get CI, fixing the other half of the same limitation). Comment-only + trigger-only change.