### PR TITLE
ci(dist): fix tap repo name in the formula-publish job

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -319,7 +319,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: true
-          repository: "PawanSikawat/homebrew-faucet"
+          repository: "PawanSikawat/homebrew-faucet-stream"
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
       # So we have access to the formula
       - name: Fetch homebrew formulae


### PR DESCRIPTION
The v1.4.0 `publish-homebrew-formula` job failed with 404: the tap repo name is baked into the dist-generated workflow's checkout step at generation time, and #295's rename (`homebrew-faucet` → `homebrew-faucet-stream`) only updated `dist-workspace.toml`. One-line fix. The v1.4.0 formula itself is being pushed to the tap manually (it's already an asset on the GitHub release); this fixes future releases.