### PR TITLE
ci(release-plz): use RELEASE_PLZ_TOKEN in the publish job (auto-trigger binary releases)

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -136,7 +136,12 @@ jobs:
           command: release
           config: release-plz.toml
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Prefer the RELEASE_PLZ_TOKEN PAT when configured: refs (per-crate
+          # tags) pushed with the default GITHUB_TOKEN do NOT trigger other
+          # workflows, so release-binaries.yml never fires automatically after
+          # a publish. A PAT-pushed tag triggers it normally. Falls back to
+          # GITHUB_TOKEN (today's behavior: trigger release-binaries manually).
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN || secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
       - name: Cool-down for crates.io rate-limit refill (before retry 1)
@@ -154,7 +159,12 @@ jobs:
           command: release
           config: release-plz.toml
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Prefer the RELEASE_PLZ_TOKEN PAT when configured: refs (per-crate
+          # tags) pushed with the default GITHUB_TOKEN do NOT trigger other
+          # workflows, so release-binaries.yml never fires automatically after
+          # a publish. A PAT-pushed tag triggers it normally. Falls back to
+          # GITHUB_TOKEN (today's behavior: trigger release-binaries manually).
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN || secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
       - name: Cool-down for crates.io rate-limit refill (before final attempt)
@@ -170,5 +180,10 @@ jobs:
           command: release
           config: release-plz.toml
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Prefer the RELEASE_PLZ_TOKEN PAT when configured: refs (per-crate
+          # tags) pushed with the default GITHUB_TOKEN do NOT trigger other
+          # workflows, so release-binaries.yml never fires automatically after
+          # a publish. A PAT-pushed tag triggers it normally. Falls back to
+          # GITHUB_TOKEN (today's behavior: trigger release-binaries manually).
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN || secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
The publish job's three attempts were hardcoded to `GITHUB_TOKEN`, whose ref pushes don't trigger workflows — so `release-binaries.yml` never fired after a release (hit on v1.4.0, worked around by re-pushing the tag manually). This prefers `secrets.RELEASE_PLZ_TOKEN` (a fine-grained PAT with Contents + Pull requests read/write on this repo) with a graceful fallback to `GITHUB_TOKEN` until the secret exists. The release-PR job already had this pattern. Once the secret is added: tags trigger the binary build automatically, and release PRs get CI.