### PR TITLE
feat: Google Cloud Spanner source + sink connectors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,7 @@ jobs:
           - source-gcs
           - source-bigquery
           - source-snowflake
+          - source-spanner
           - source-singer
           # Sinks
           - sink-bigquery
@@ -181,6 +182,7 @@ jobs:
           - sink-stdout
           - sink-kafka
           - sink-kinesis
+          - sink-spanner
           - sink-parquet
           - sink-gcs
           # Kafka extras

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Free runner disk space
+        # The all-features instrumented build (bundled DuckDB + the full
+        # connector tree) exceeds the hosted runner's free disk. Drop the
+        # large preinstalled toolchains we never use (~25-30 GB).
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          df -h /
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: "1.96.0"
@@ -407,6 +414,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Free runner disk space
+        # The all-features instrumented build (bundled DuckDB + the full
+        # connector tree) exceeds the hosted runner's free disk. Drop the
+        # large preinstalled toolchains we never use (~25-30 GB).
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          df -h /
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: "1.96.0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1099,7 +1099,7 @@ dependencies = [
  "hmac 0.13.0",
  "http 0.2.12",
  "http 1.4.0",
- "p256",
+ "p256 0.11.1",
  "percent-encoding",
  "ring",
  "sha2 0.11.0",
@@ -1471,6 +1471,12 @@ name = "base16ct"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+
+[[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
@@ -2400,8 +2406,10 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
+ "generic-array",
  "rand_core 0.6.4",
  "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2467,6 +2475,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2826,9 +2861,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
 dependencies = [
  "der 0.6.1",
- "elliptic-curve",
- "rfc6979",
+ "elliptic-curve 0.12.3",
+ "rfc6979 0.3.1",
  "signature 1.6.4",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der 0.7.10",
+ "digest 0.10.7",
+ "elliptic-curve 0.13.8",
+ "rfc6979 0.4.0",
+ "signature 2.2.0",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8 0.10.2",
+ "signature 2.2.0",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2846,16 +2919,37 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
 dependencies = [
- "base16ct",
+ "base16ct 0.1.1",
  "crypto-bigint 0.4.9",
  "der 0.6.1",
  "digest 0.10.7",
- "ff",
+ "ff 0.12.1",
  "generic-array",
- "group",
+ "group 0.12.1",
  "pkcs8 0.9.0",
  "rand_core 0.6.4",
- "sec1",
+ "sec1 0.3.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.5",
+ "digest 0.10.7",
+ "ff 0.13.1",
+ "generic-array",
+ "group 0.13.0",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8 0.10.2",
+ "rand_core 0.6.4",
+ "sec1 0.7.3",
  "subtle",
  "zeroize",
 ]
@@ -3130,6 +3224,7 @@ dependencies = [
  "faucet-sink-redis",
  "faucet-sink-s3",
  "faucet-sink-snowflake",
+ "faucet-sink-spanner",
  "faucet-sink-sqlite",
  "faucet-sink-stdout",
  "faucet-source-bigquery",
@@ -3153,6 +3248,7 @@ dependencies = [
  "faucet-source-s3",
  "faucet-source-singer",
  "faucet-source-snowflake",
+ "faucet-source-spanner",
  "faucet-source-sqlite",
  "faucet-source-webhook",
  "faucet-source-websocket",
@@ -3305,6 +3401,22 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "faucet-common-spanner"
+version = "1.0.0"
+dependencies = [
+ "base64 0.22.1",
+ "faucet-core",
+ "gcloud-gax",
+ "gcloud-googleapis",
+ "gcloud-spanner",
+ "prost-types 0.14.3",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]
@@ -3723,6 +3835,27 @@ dependencies = [
  "tracing",
  "uuid",
  "wiremock",
+]
+
+[[package]]
+name = "faucet-sink-spanner"
+version = "1.0.0"
+dependencies = [
+ "async-trait",
+ "faucet-common-spanner",
+ "faucet-conformance",
+ "faucet-core",
+ "futures",
+ "gcloud-gax",
+ "gcloud-googleapis",
+ "gcloud-spanner",
+ "prost-types 0.14.3",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "testcontainers",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -4214,6 +4347,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "faucet-source-spanner"
+version = "1.0.0"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "faucet-common-spanner",
+ "faucet-conformance",
+ "faucet-core",
+ "futures",
+ "gcloud-gax",
+ "gcloud-googleapis",
+ "gcloud-spanner",
+ "prost-types 0.14.3",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "testcontainers",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "faucet-source-sqlite"
 version = "1.3.0"
 dependencies = [
@@ -4325,6 +4480,7 @@ dependencies = [
  "faucet-common-kafka",
  "faucet-common-kinesis",
  "faucet-common-snowflake",
+ "faucet-common-spanner",
  "faucet-core",
  "faucet-lineage",
  "faucet-sink-bigquery",
@@ -4344,6 +4500,7 @@ dependencies = [
  "faucet-sink-redis",
  "faucet-sink-s3",
  "faucet-sink-snowflake",
+ "faucet-sink-spanner",
  "faucet-sink-sqlite",
  "faucet-sink-stdout",
  "faucet-source-bigquery",
@@ -4367,6 +4524,7 @@ dependencies = [
  "faucet-source-s3",
  "faucet-source-singer",
  "faucet-source-snowflake",
+ "faucet-source-spanner",
  "faucet-source-sqlite",
  "faucet-source-webhook",
  "faucet-source-websocket",
@@ -4414,6 +4572,22 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filetime"
@@ -4647,6 +4821,102 @@ dependencies = [
 ]
 
 [[package]]
+name = "gcloud-auth"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b43924e3df02cb3b846ca66a7ee58e8c13eb2556d0308c71f6154083f6980365"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "gcloud-metadata",
+ "home",
+ "jsonwebtoken 10.4.0",
+ "reqwest 0.13.3",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "time",
+ "token-source",
+ "tokio",
+ "tracing",
+ "urlencoding",
+]
+
+[[package]]
+name = "gcloud-gax"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "558634081d1cf458d1bc0166f69475a80f445b5b991f162028b293a38307059d"
+dependencies = [
+ "http 1.4.0",
+ "thiserror 2.0.18",
+ "token-source",
+ "tokio",
+ "tokio-retry2",
+ "tonic 0.14.6",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "gcloud-googleapis"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d79fc4ec36213a21b734a2ce204176eb39c439fa528f9a388c9a1349ca344b0d"
+dependencies = [
+ "prost 0.14.3",
+ "prost-types 0.14.3",
+ "tonic 0.14.6",
+ "tonic-prost",
+]
+
+[[package]]
+name = "gcloud-longrunning"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43ccb50f1b67e61775a2a620b6c09de051e724f1aaf02d6c5b366fd60e7ac59e"
+dependencies = [
+ "gcloud-gax",
+ "gcloud-googleapis",
+ "prost 0.14.3",
+ "tonic 0.14.6",
+]
+
+[[package]]
+name = "gcloud-metadata"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd3152612316be627be52fe9ca72331eb48425059b3a6a700e7adde223e061d5"
+dependencies = [
+ "reqwest 0.13.3",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
+name = "gcloud-spanner"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33dad07fbb7cc49f48b27e9842ebfd977de921cf071ba4fc42d408245b3b7779"
+dependencies = [
+ "base64 0.22.1",
+ "bigdecimal",
+ "gcloud-auth",
+ "gcloud-gax",
+ "gcloud-googleapis",
+ "gcloud-longrunning",
+ "parking_lot",
+ "prost 0.14.3",
+ "prost-types 0.14.3",
+ "thiserror 2.0.18",
+ "time",
+ "token-source",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "gcp-bigquery-client"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4702,6 +4972,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -4991,7 +5262,18 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
- "ff",
+ "ff 0.12.1",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff 0.13.1",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -6049,11 +6331,20 @@ checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
+ "ed25519-dalek",
  "getrandom 0.2.17",
+ "hmac 0.12.1",
  "js-sys",
+ "p256 0.13.2",
+ "p384",
+ "pem",
+ "rand 0.8.6",
+ "rsa",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "signature 2.2.0",
+ "simple_asn1",
  "zeroize",
 ]
 
@@ -7339,8 +7630,32 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
+ "ecdsa 0.14.8",
+ "elliptic-curve 0.12.3",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder",
  "sha2 0.10.9",
 ]
 
@@ -7869,6 +8184,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve 0.13.8",
 ]
 
 [[package]]
@@ -8747,6 +9071,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac 0.12.1",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9239,10 +9573,24 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
- "base16ct",
+ "base16ct 0.1.1",
  "der 0.6.1",
  "generic-array",
  "pkcs8 0.9.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct 0.2.0",
+ "der 0.7.10",
+ "generic-array",
+ "pkcs8 0.10.2",
  "subtle",
  "zeroize",
 ]
@@ -10384,6 +10732,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "token-source"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75746ae15bef509f21039a652383104424208fdae172a964a8930858b9a78412"
+dependencies = [
+ "async-trait",
+]
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10435,6 +10792,16 @@ dependencies = [
  "tokio",
  "tokio-util",
  "whoami 2.1.2",
+]
+
+[[package]]
+name = "tokio-retry2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05e40fd65880de11383bbc693d3c636045ed1b5010ef1265a1d2b41d73334a1"
+dependencies = [
+ "pin-project",
+ "tokio",
 ]
 
 [[package]]
@@ -10588,6 +10955,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "webpki-roots 1.0.7",
  "zstd",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/common/snowflake",
     "crates/common/mssql",
     "crates/common/kinesis",
+    "crates/common/spanner",
     "crates/source/rest",
     "crates/source/singer",
     "crates/conformance",
@@ -39,6 +40,7 @@ members = [
     "crates/source/postgres-cdc",
     "crates/source/bigquery",
     "crates/source/snowflake",
+    "crates/source/spanner",
     "crates/sink/bigquery",
     "crates/sink/postgres",
     "crates/sink/jsonl",
@@ -59,6 +61,7 @@ members = [
     "crates/sink/stdout",
     "crates/sink/parquet",
     "crates/sink/iceberg",
+    "crates/sink/spanner",
     "crates/state/redis",
     "crates/state/postgres",
     "faucet-stream",
@@ -87,6 +90,7 @@ faucet-common-gcs = { path = "crates/common/gcs", version = "1.0.4" }
 faucet-common-kafka = { path = "crates/common/kafka", version = "1.0.4" }
 faucet-common-kinesis = { path = "crates/common/kinesis", version = "1.0.0" }
 faucet-common-snowflake = { path = "crates/common/snowflake", version = "1.0.4" }
+faucet-common-spanner = { path = "crates/common/spanner", version = "1.0.0" }
 faucet-common-mssql = { path = "crates/common/mssql", version = "1.0.5" }
 faucet-source-rest = { path = "crates/source/rest", version = "1.2.2" }
 faucet-source-singer = { path = "crates/source/singer", version = "1.0.0" }
@@ -122,6 +126,7 @@ faucet-source-elasticsearch = { path = "crates/source/elasticsearch", version = 
 faucet-source-parquet = { path = "crates/source/parquet", version = "1.2.1" }
 faucet-source-bigquery = { path = "crates/source/bigquery", version = "1.1.3" }
 faucet-source-snowflake = { path = "crates/source/snowflake", version = "1.1.3" }
+faucet-source-spanner = { path = "crates/source/spanner", version = "1.0.0" }
 faucet-sink-mysql = { path = "crates/sink/mysql", version = "1.3.0" }
 faucet-sink-sqlite = { path = "crates/sink/sqlite", version = "1.3.0" }
 faucet-sink-mssql = { path = "crates/sink/mssql", version = "1.3.0" }
@@ -138,6 +143,7 @@ faucet-sink-kinesis = { path = "crates/sink/kinesis", version = "1.0.0" }
 faucet-sink-stdout = { path = "crates/sink/stdout", version = "1.1.3" }
 faucet-sink-parquet = { path = "crates/sink/parquet", version = "1.1.3" }
 faucet-sink-iceberg = { path = "crates/sink/iceberg", version = "1.2.0" }
+faucet-sink-spanner = { path = "crates/sink/spanner", version = "1.0.0" }
 faucet-state-redis = { path = "crates/state/redis", version = "1.0.5" }
 faucet-state-postgres = { path = "crates/state/postgres", version = "1.1.0" }
 faucet-cli = { path = "cli", version = "1.4.0" }
@@ -184,6 +190,18 @@ dashmap = "6"
 uuid = { version = "1", features = ["v4", "v7"] }
 google-cloud-storage = "1.12"
 google-cloud-auth = "1.10"
+# Cloud Spanner stack: the mature community client (yoshidan/google-cloud-rust,
+# renamed gcloud-*). The official `google-cloud-spanner` is still `-preview`, so
+# per the dependency policy the stable community client is the pick. Default
+# features are off to swap `jwt-aws-lc-rs` for the pure-Rust `jwt-rust-crypto`
+# signer (no aws-lc build dep for JWT signing).
+gcloud-spanner = { version = "1.8", default-features = false, features = ["auth", "rustls-tls", "jwt-rust-crypto"] }
+# Raw protobuf types (Mutation, TypeCode, Field, …) used by the Spanner pair;
+# not re-exported from gcloud-spanner's root.
+gcloud-googleapis = { version = "1.3", features = ["spanner"] }
+# gRPC plumbing for gcloud-spanner; needed directly only for
+# `google_cloud_gax::conn::Environment` (the emulator-endpoint override).
+gcloud-gax = "1.4"
 aws-sdk-kinesis = "1"
 aws-sdk-s3 = "1"
 aws-sdk-secretsmanager = "1"

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@
 
 **The fast, config-driven way to move data in Rust.**
 
-faucet-stream is a complete **ETL** toolkit: **24 source** and **18 sink** connectors
-(**42 in total**) plus in-flight transforms — including a page-level embedded-DuckDB `sql`
+faucet-stream is a complete **ETL** toolkit: **25 source** and **20 sink** connectors
+(**45 in total**) plus in-flight transforms — including a page-level embedded-DuckDB `sql`
 transform — wired together by a single `faucet` binary that runs pipelines declaratively
 from a YAML/JSON file, no Rust code required. Or skip the binary and embed the same engine
 in your own service through the typed `Source` / `Sink` traits. One toolkit, whether you
@@ -60,7 +60,7 @@ cargo add faucet-stream           # the library
   cron scheduling, an HTTP control plane with event-driven triggers, OpenLineage emission, and
   built-in Prometheus metrics + `tracing` spans — all with zero per-connector code.
 - **📦 Pay only for what you use** — every connector is a Cargo feature, so a slim build can
-  be just REST + JSONL, or pull in all 42 connectors with `--features full`.
+  be just REST + JSONL, or pull in all 45 connectors with `--features full`.
 
 **Documentation:** the [faucet-stream guide](https://pawansikawat.github.io/faucet-stream/)
 (getting started, tutorials, cookbook, operations) · API reference on
@@ -226,7 +226,8 @@ for help picking between overlapping connectors (Postgres query vs CDC, S3 vs Pa
 > service (the `rest`, `graphql`, `xml`, `elasticsearch`, `bigquery`, `snowflake`
 > sources and the `http` sink): the mock faithfully drives the paging / schema /
 > error paths the checks assert, but it is not an end-to-end test against the real
-> system.
+> system. **ᵉ** marks the Cloud Spanner pair, whose battery runs against Google's
+> official **Spanner emulator** (Docker) — a real gRPC Spanner implementation.
 > **Tier-2** connectors are **not conformance-certified in CI** — either their
 > full battery can't run without a live cloud backend (the BigQuery / Snowflake /
 > Elasticsearch sinks are tested against wiremock, which can't prove real
@@ -238,7 +239,7 @@ for help picking between overlapping connectors (Postgres query vs CDC, S3 vs Pa
 > production — Tier-2 means "not certified," **not** "low quality." The Singer
 > bridge is additionally **experimental (v0, single-stream)** ⚠️.
 
-### Sources (24)
+### Sources (25)
 
 `Tier`: **T1 ✅** = passes the `faucet-conformance` battery in CI; **T2** = not yet
 wired into the battery (see the support-tiers note above).
@@ -266,12 +267,13 @@ wired into the battery (see the support-tiers note above).
 | [`faucet-source-elasticsearch`](crates/source/elasticsearch) | T1 ✅ᵐ | Elasticsearch — search/scroll API |
 | [`faucet-source-bigquery`](crates/source/bigquery) | T1 ✅ᵐ | Google BigQuery — `jobs.query` + `getQueryResults`, type-aware decoding |
 | [`faucet-source-snowflake`](crates/source/snowflake) | T1 ✅ᵐ | Snowflake — SQL REST API, server-side partition pagination, JWT / OAuth |
+| [`faucet-source-spanner`](crates/source/spanner) | T1 ✅ᵉ | Google Cloud Spanner — streaming SQL over gRPC, incremental replication, stale reads, PK-range sharding |
 | [`faucet-source-webhook`](crates/source/webhook) | T2 | Webhook — temporary HTTP server collecting POST payloads |
 | [`faucet-source-websocket`](crates/source/websocket) | T1 ✅ | WebSocket — live streaming feed; subscribe frames, reconnect, keepalive |
 | [`faucet-source-csv`](crates/source/csv) | **T1 ✅** | CSV — read CSV files as JSON objects |
 | [`faucet-source-singer`](crates/source/singer) | T2 ⚠️ | **Singer tap bridge** — run any Singer tap and adapt its output. Passes the battery, but **experimental (v0, single-stream)** |
 
-### Sinks (18)
+### Sinks (20)
 
 | Crate | Tier | Description |
 |-------|------|-------------|
@@ -286,6 +288,7 @@ wired into the battery (see the support-tiers note above).
 | [`faucet-sink-redis`](crates/sink/redis) | T1 ✅ | Redis — write to streams, lists, or key-value |
 | [`faucet-sink-kafka`](crates/sink/kafka) | T1 ✅ | Apache Kafka — producer with batching, multi-topic routing |
 | [`faucet-sink-kinesis`](crates/sink/kinesis) | T1 ✅ | AWS Kinesis Data Streams — batched PutRecords with partition-key routing |
+| [`faucet-sink-spanner`](crates/sink/spanner) | T1 ✅ᵉ | Google Cloud Spanner — batched mutations; upsert/delete, effectively-once commit tokens, schema evolution |
 | [`faucet-sink-elasticsearch`](crates/sink/elasticsearch) | T2 | Elasticsearch — bulk index API; upsert/delete by `_id` |
 | [`faucet-sink-s3`](crates/sink/s3) | T1 ✅ | AWS S3 — write JSONL files to bucket |
 | [`faucet-sink-gcs`](crates/sink/gcs) | T2 | Google Cloud Storage — write JSONL files to bucket |
@@ -307,6 +310,7 @@ wired into the battery (see the support-tiers note above).
 | [`faucet-common-gcs`](crates/common/gcs) | Shared GCS types — credentials enum, Storage/StorageControl client builders |
 | [`faucet-common-kafka`](crates/common/kafka) | Shared Kafka types — auth, value formats, Schema Registry client |
 | [`faucet-common-snowflake`](crates/common/snowflake) | Shared Snowflake types — `SnowflakeAuth` enum + auth header helpers |
+| [`faucet-common-spanner`](crates/common/spanner) | Shared Cloud Spanner types — credentials enum, connection/client builders, value conversion |
 | [`faucet-common-mssql`](crates/common/mssql) | Shared MSSQL types — connection/TLS config, `tiberius`+`bb8` pool builder, identifier quoting |
 | [`faucet-state-redis`](crates/state/redis) | Redis-backed `StateStore` for persistent bookmarks |
 | [`faucet-state-postgres`](crates/state/postgres) | PostgreSQL-backed `StateStore` for persistent bookmarks |
@@ -432,7 +436,7 @@ flowchart LR
     P -.->|metrics + spans| O
 ```
 
-faucet-stream is a Cargo workspace with **60 crates** — 25 sources, 19 sinks, 7 shared
+faucet-stream is a Cargo workspace with **63 crates** — 26 sources, 20 sinks, 8 shared
 connector libraries, the shared auth-provider library, 2 state-store backends, the lineage
 crate, the SQL transform crate, the conformance test battery, the shared core, the umbrella
 crate, and the CLI binary. See
@@ -496,6 +500,7 @@ Default features: `source-rest`, `transform-flatten`, `transform-rename-keys`,
 | `source-elasticsearch` | no | Elasticsearch source |
 | `source-bigquery` | no | Google BigQuery query source |
 | `source-snowflake` | no | Snowflake query source |
+| `source-spanner` | no | Google Cloud Spanner query source |
 | `source-webhook` | no | Webhook HTTP receiver |
 | `source-websocket` | no | WebSocket live streaming source |
 | `source-csv` | no | CSV file source |
@@ -510,6 +515,7 @@ Default features: `source-rest`, `transform-flatten`, `transform-rename-keys`,
 | `sink-redis` | no | Redis sink |
 | `sink-kafka` | no | Apache Kafka producer sink |
 | `sink-kinesis` | no | AWS Kinesis Data Streams sink |
+| `sink-spanner` | no | Google Cloud Spanner sink |
 | `sink-elasticsearch` | no | Elasticsearch bulk index sink |
 | `sink-s3` | no | AWS S3 file sink |
 | `sink-gcs` | no | Google Cloud Storage file sink |

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -80,6 +80,7 @@ source = [
     "source-gcs",
     "source-bigquery",
     "source-snowflake",
+    "source-spanner",
     "source-singer",
 ]
 sink = [
@@ -102,6 +103,7 @@ sink = [
     "sink-parquet",
     "sink-gcs",
     "sink-iceberg",
+    "sink-spanner",
 ]
 state = ["state-redis", "state-postgres"]
 
@@ -129,6 +131,7 @@ source-parquet = ["dep:faucet-source-parquet"]
 source-gcs = ["dep:faucet-source-gcs"]
 source-bigquery = ["dep:faucet-source-bigquery"]
 source-snowflake = ["dep:faucet-source-snowflake"]
+source-spanner = ["dep:faucet-source-spanner"]
 source-singer = ["dep:faucet-source-singer"]
 
 sink-bigquery = ["dep:faucet-sink-bigquery"]
@@ -148,6 +151,7 @@ sink-http = ["dep:faucet-sink-http"]
 sink-stdout = ["dep:faucet-sink-stdout"]
 sink-kafka = ["dep:faucet-sink-kafka"]
 sink-kinesis = ["dep:faucet-sink-kinesis"]
+sink-spanner = ["dep:faucet-sink-spanner"]
 sink-parquet = ["dep:faucet-sink-parquet"]
 sink-gcs = ["dep:faucet-sink-gcs"]
 
@@ -277,6 +281,7 @@ faucet-source-parquet = { workspace = true, optional = true }
 faucet-source-gcs = { workspace = true, optional = true }
 faucet-source-bigquery = { workspace = true, optional = true }
 faucet-source-snowflake = { workspace = true, optional = true }
+faucet-source-spanner = { workspace = true, optional = true }
 faucet-source-singer = { workspace = true, optional = true }
 faucet-sink-bigquery = { workspace = true, optional = true }
 faucet-sink-iceberg = { workspace = true, optional = true }
@@ -294,6 +299,7 @@ faucet-sink-elasticsearch = { workspace = true, optional = true }
 faucet-sink-http = { workspace = true, optional = true }
 faucet-sink-kafka = { workspace = true, optional = true }
 faucet-sink-kinesis = { workspace = true, optional = true }
+faucet-sink-spanner = { workspace = true, optional = true }
 faucet-sink-stdout = { workspace = true, optional = true }
 faucet-sink-parquet = { workspace = true, optional = true }
 faucet-sink-gcs = { workspace = true, optional = true }

--- a/cli/examples/spanner_to_jsonl.yaml
+++ b/cli/examples/spanner_to_jsonl.yaml
@@ -1,0 +1,45 @@
+# Google Cloud Spanner → JSON Lines (#304).
+#
+# Streams a SQL query out of Spanner with incremental replication: on each
+# run only rows whose `updated_at` is past the persisted bookmark are read
+# (the `@bookmark` named parameter is bound from the state store).
+#
+# Works against the Spanner emulator out of the box:
+#
+#   docker run --rm -p 9010:9010 gcr.io/cloud-spanner-emulator/emulator
+#   # create the instance/database with gcloud or your own bootstrap, then:
+#   faucet run cli/examples/spanner_to_jsonl.yaml
+#
+# Against real Spanner: drop `emulator_host` (Application Default Credentials
+# are used unless an `auth:` block selects a service-account key).
+version: 1
+name: spanner_to_jsonl
+
+pipeline:
+  source:
+    type: spanner
+    config:
+      project_id: local-project
+      instance: test-instance
+      database: local-database
+      emulator_host: localhost:9010   # remove for real Spanner
+      query: >-
+        SELECT id, name, updated_at FROM users
+        WHERE updated_at > TIMESTAMP(@bookmark)
+        ORDER BY updated_at
+      replication:
+        type: incremental
+        column: updated_at
+        initial_value: "1970-01-01T00:00:00Z"
+      batch_size: 1000
+
+  sink:
+    type: jsonl
+    config:
+      path: ./out/spanner-users.jsonl
+
+  # Durable bookmark: a re-run continues from the newest `updated_at` the
+  # sink confirmed instead of re-reading the whole table.
+  state:
+    type: file
+    config: { path: ./.faucet-state }

--- a/cli/src/commands/discover.rs
+++ b/cli/src/commands/discover.rs
@@ -42,7 +42,7 @@ pub async fn run(args: DiscoverArgs) -> CliResult<()> {
         return Err(CliError::Config(format!(
             "source '{}' does not support dataset discovery — discovery is available for \
              catalog-backed sources (postgres, mysql, mssql, sqlite, mongodb, elasticsearch, \
-             bigquery, snowflake, s3, gcs)",
+             bigquery, snowflake, spanner, s3, gcs)",
             spec.kind
         )));
     }

--- a/cli/src/registry.rs
+++ b/cli/src/registry.rs
@@ -451,6 +451,14 @@ pub async fn build_source(
                 faucet_source_kinesis::KinesisSource::new(cfg).await?,
             ))
         }
+        #[cfg(feature = "source-spanner")]
+        "spanner" => {
+            let cfg =
+                decode::<faucet_source_spanner::SpannerSourceConfig>("source", "spanner", config)?;
+            Ok(Box::new(
+                faucet_source_spanner::SpannerSource::new(cfg).await?,
+            ))
+        }
         #[cfg(feature = "source-parquet")]
         "parquet" => {
             let cfg =
@@ -593,6 +601,11 @@ pub async fn build_sink(kind: &str, config: Value, auth: &AuthCatalog) -> CliRes
             let cfg = decode::<faucet_sink_kinesis::KinesisSinkConfig>("sink", "kinesis", config)?;
             Ok(Box::new(faucet_sink_kinesis::KinesisSink::new(cfg).await?))
         }
+        #[cfg(feature = "sink-spanner")]
+        "spanner" => {
+            let cfg = decode::<faucet_sink_spanner::SpannerSinkConfig>("sink", "spanner", config)?;
+            Ok(Box::new(faucet_sink_spanner::SpannerSink::new(cfg).await?))
+        }
         #[cfg(feature = "sink-http")]
         "http" => {
             let cfg = decode::<faucet_sink_http::HttpSinkConfig>("sink", "http", config)?;
@@ -645,6 +658,7 @@ pub const IDEMPOTENT_SINK_KINDS: &[&str] = &[
     "snowflake",
     "redis",
     "mongodb",
+    "spanner",
 ];
 
 /// Sink kinds that can apply additive/widening DDL via `Sink::evolve_schema`.
@@ -657,6 +671,7 @@ pub const SCHEMA_EVOLUTION_SINK_KINDS: &[&str] = &[
     "sqlite",
     "bigquery",
     "elasticsearch",
+    "spanner",
 ];
 
 /// Sink kinds that support `write_mode: upsert|delete`. Mirrors each sink's
@@ -670,6 +685,7 @@ pub const UPSERT_SINK_KINDS: &[&str] = &[
     "mongodb",
     "elasticsearch",
     "bigquery",
+    "spanner",
 ];
 
 /// The typed replay capability a source kind advertises
@@ -773,6 +789,8 @@ pub fn source_schema(kind: &str) -> CliResult<Value> {
         "kafka" => Ok(schema::<faucet_source_kafka::KafkaSourceConfig>()),
         #[cfg(feature = "source-kinesis")]
         "kinesis" => Ok(schema::<faucet_source_kinesis::KinesisSourceConfig>()),
+        #[cfg(feature = "source-spanner")]
+        "spanner" => Ok(schema::<faucet_source_spanner::SpannerSourceConfig>()),
         #[cfg(feature = "source-parquet")]
         "parquet" => Ok(schema::<faucet_source_parquet::ParquetSourceConfig>()),
         #[cfg(feature = "source-gcs")]
@@ -831,6 +849,8 @@ pub fn sink_schema(kind: &str) -> CliResult<Value> {
         "kafka" => Ok(schema::<faucet_sink_kafka::KafkaSinkConfig>()),
         #[cfg(feature = "sink-kinesis")]
         "kinesis" => Ok(schema::<faucet_sink_kinesis::KinesisSinkConfig>()),
+        #[cfg(feature = "sink-spanner")]
+        "spanner" => Ok(schema::<faucet_sink_spanner::SpannerSinkConfig>()),
         #[cfg(feature = "sink-http")]
         "http" => Ok(schema::<faucet_sink_http::HttpSinkConfig>()),
         #[cfg(feature = "sink-stdout")]
@@ -907,6 +927,8 @@ fn builtin_source_descriptions() -> Vec<(&'static str, &'static str)> {
     v.push(("kafka", "Apache Kafka consumer (rdkafka). Subscribes to topics and drains messages with idle/max-messages termination."));
     #[cfg(feature = "source-kinesis")]
     v.push(("kinesis", "AWS Kinesis Data Streams consumer. Per-shard workers with resumable sequence-number checkpoints and idle/max-messages termination."));
+    #[cfg(feature = "source-spanner")]
+    v.push(("spanner", "Google Cloud Spanner query source. Streaming SQL reads with incremental replication bookmarks, stale reads, and PK-range sharding."));
     #[cfg(feature = "source-parquet")]
     v.push(("parquet", "Apache Parquet file source (local path, glob, or S3). Streams record batches via the Arrow async reader."));
     #[cfg(feature = "source-gcs")]
@@ -976,6 +998,8 @@ fn builtin_sink_descriptions() -> Vec<(&'static str, &'static str)> {
     v.push(("kafka", "Apache Kafka producer (rdkafka). FuturesUnordered batched sends with QueueFull retry; supports fixed or per-record topic routing."));
     #[cfg(feature = "sink-kinesis")]
     v.push(("kinesis", "AWS Kinesis Data Streams producer. Batched PutRecords with partition-key routing and partial-failure retry (DLQ-routable)."));
+    #[cfg(feature = "sink-spanner")]
+    v.push(("spanner", "Google Cloud Spanner sink. Batched mutations with upsert/delete write modes, exactly-once commit tokens, and schema evolution."));
     #[cfg(feature = "sink-http")]
     v.push(("http", "HTTP POST sink (individual or array batch)"));
     #[cfg(feature = "sink-stdout")]

--- a/connectors/registry.json
+++ b/connectors/registry.json
@@ -27,6 +27,7 @@
     { "name": "parquet", "kind": "source", "verified": true, "description": "Apache Parquet file source (local, glob, or S3)" },
     { "name": "bigquery", "kind": "source", "verified": true, "description": "Google BigQuery query source" },
     { "name": "snowflake", "kind": "source", "verified": true, "description": "Snowflake query source (SQL REST API)" },
+    { "name": "spanner", "kind": "source", "verified": true, "description": "Google Cloud Spanner query source (streaming SQL, incremental replication)" },
 
     { "name": "bigquery", "kind": "sink", "verified": true, "description": "Google BigQuery streaming-insert sink" },
     { "name": "iceberg", "kind": "sink", "verified": true, "description": "Apache Iceberg sink (append; REST/Glue/SQL/HMS catalogs)" },
@@ -44,6 +45,7 @@
     { "name": "elasticsearch", "kind": "sink", "verified": true, "description": "Elasticsearch bulk index sink" },
     { "name": "kafka", "kind": "sink", "verified": true, "description": "Apache Kafka producer with QueueFull retry and topic routing" },
     { "name": "kinesis", "kind": "sink", "verified": true, "description": "AWS Kinesis Data Streams producer with partial-failure retry" },
+    { "name": "spanner", "kind": "sink", "verified": true, "description": "Google Cloud Spanner mutation sink (upsert/delete, exactly-once)" },
     { "name": "http", "kind": "sink", "verified": true, "description": "HTTP POST sink (individual or array batch)" },
     { "name": "stdout", "kind": "sink", "verified": true, "description": "Stdout / stderr sink (JSON Lines, pretty, TSV)" },
     { "name": "parquet", "kind": "sink", "verified": true, "description": "Apache Parquet file sink (local path or S3)" }

--- a/crates/common/spanner/Cargo.toml
+++ b/crates/common/spanner/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "faucet-common-spanner"
+version = "1.0.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Shared Cloud Spanner credentials, client construction, and value conversion for the faucet-stream Spanner source and sink connectors"
+readme = "README.md"
+keywords = ["spanner", "gcp", "etl", "pipeline", "faucet"]
+categories.workspace = true
+
+[dependencies]
+faucet-core.workspace = true
+gcloud-spanner.workspace = true
+gcloud-googleapis.workspace = true
+gcloud-gax.workspace = true
+prost-types = "0.14"
+base64.workspace = true
+schemars.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/common/spanner/README.md
+++ b/crates/common/spanner/README.md
@@ -1,0 +1,43 @@
+# faucet-common-spanner
+
+Shared configuration and conversion types for the
+[faucet-stream](https://github.com/PawanSikawat/faucet-stream) Google Cloud
+Spanner connectors — [`faucet-source-spanner`](https://crates.io/crates/faucet-source-spanner)
+and [`faucet-sink-spanner`](https://crates.io/crates/faucet-sink-spanner).
+
+Both connectors re-export these types, so you normally depend on the source or
+sink crate rather than this one directly.
+
+## Contents
+
+- **`SpannerCredentials`** — the auth enum, serialized in faucet's consistent
+  `{ type: <method>, config: { … } }` wire shape:
+
+  | `type` | Fields | Meaning |
+  |--------|--------|---------|
+  | `application_default` | — | Application Default Credentials (`GOOGLE_APPLICATION_CREDENTIALS`, `gcloud auth application-default login`, GCE/GKE metadata) — the default |
+  | `service_account_key_path` | `path` | Service-account key JSON loaded from a file |
+  | `service_account_key` | `json` | Inline service-account key JSON — prefer `${vault:…}` / `${env:…}` interpolation over literals; `Debug` masks it |
+
+- **`SpannerConnection`** — the flattened connection block shared by both
+  connector configs: `project_id` / `instance` / `database` / `auth` /
+  `max_sessions` (session-pool bound; channels sized at one per 100 sessions)
+  / `emulator_host` (per-connector emulator override — the process-global
+  `SPANNER_EMULATOR_HOST` env var is also honored when unset). Provides
+  `connect()` (data-plane client) and `connect_admin()` (DDL/instance admin
+  client) plus `database_path()`.
+
+- **`types`** — `parse_spanner_type` (`INFORMATION_SCHEMA` type strings →
+  `SpannerType`, including `ARRAY<…>`) and `spanner_type_to_json_schema`.
+
+- **`decode`** — generic Spanner row → `serde_json::Value` decoding for
+  arbitrary queries: INT64 stays a lossless JSON integer, NUMERIC stays a
+  string, JSON columns parse to structured values, BYTES stay base64,
+  ARRAY/STRUCT recurse.
+
+- **`encode`** — `serde_json::Value` → mutation value encoding keyed by the
+  destination column type, with typed mismatch errors.
+
+## License
+
+MIT OR Apache-2.0

--- a/crates/common/spanner/src/decode.rs
+++ b/crates/common/spanner/src/decode.rs
@@ -1,0 +1,327 @@
+//! Generic Spanner row → `serde_json::Value` decoding.
+//!
+//! faucet sources run arbitrary user SQL, so rows must decode without a
+//! compile-time schema. [`SpannerJson`] implements the client's
+//! `TryFromValue` hook, which hands us the raw protobuf value *plus* the
+//! column's full [`Type`] metadata — enough to decode every Spanner type
+//! into faithful JSON:
+//!
+//! | Spanner | JSON |
+//! |---|---|
+//! | INT64 / ENUM | integer (lossless — arrives string-encoded) |
+//! | FLOAT64 / FLOAT32 | number (`NaN`/`Infinity` → string) |
+//! | BOOL | boolean |
+//! | STRING / TIMESTAMP / DATE / UUID / INTERVAL | string |
+//! | BYTES / PROTO | base64 string (as transmitted) |
+//! | NUMERIC | string (precision preserved) |
+//! | JSON | parsed object/array/scalar |
+//! | ARRAY | array (element type recursed) |
+//! | STRUCT | object keyed by field name |
+
+use gcloud_googleapis::spanner::v1::struct_type::Field;
+use gcloud_googleapis::spanner::v1::{Type, TypeCode};
+use gcloud_spanner::row::{Error as RowError, Row, TryFromValue};
+use prost_types::value::Kind;
+use serde_json::Value;
+
+/// Newtype decoding one Spanner column into a [`serde_json::Value`].
+pub struct SpannerJson(pub Value);
+
+impl TryFromValue for SpannerJson {
+    fn try_from(value: &prost_types::Value, field: &Field) -> Result<Self, RowError> {
+        decode_value(value, field.r#type.as_ref(), &field.name).map(SpannerJson)
+    }
+}
+
+/// Decode a whole [`Row`] into a JSON object keyed by column name, using the
+/// stream's column metadata (`RowIterator::columns_metadata`).
+pub fn row_to_json(row: &Row, fields: &[Field]) -> Result<Value, RowError> {
+    let mut obj = serde_json::Map::with_capacity(fields.len());
+    for (idx, field) in fields.iter().enumerate() {
+        let SpannerJson(v) = row.column::<SpannerJson>(idx)?;
+        obj.insert(field.name.clone(), v);
+    }
+    Ok(Value::Object(obj))
+}
+
+fn type_code(ty: Option<&Type>) -> TypeCode {
+    ty.and_then(|t| TypeCode::try_from(t.code).ok())
+        .unwrap_or(TypeCode::Unspecified)
+}
+
+/// Decode one protobuf value with its (possibly absent) Spanner type.
+pub fn decode_value(
+    value: &prost_types::Value,
+    ty: Option<&Type>,
+    field_name: &str,
+) -> Result<Value, RowError> {
+    let kind = match &value.kind {
+        None | Some(Kind::NullValue(_)) => return Ok(Value::Null),
+        Some(kind) => kind,
+    };
+    let code = type_code(ty);
+    match (code, kind) {
+        // INT64 (and ENUM numbers) arrive string-encoded to survive f64
+        // precision loss; keep them lossless as JSON integers.
+        (TypeCode::Int64 | TypeCode::Enum, Kind::StringValue(s)) => {
+            let n: i64 = s.parse().map_err(|_| {
+                RowError::CustomParseError(format!("{field_name}: non-integer INT64 `{s}`"))
+            })?;
+            Ok(Value::Number(n.into()))
+        }
+        (TypeCode::Float64 | TypeCode::Float32, Kind::NumberValue(f)) => {
+            Ok(serde_json::Number::from_f64(*f).map_or(Value::Null, Value::Number))
+        }
+        // FLOAT64 NaN / Infinity / -Infinity arrive as strings; JSON has no
+        // representation for them, so keep the string form.
+        (TypeCode::Float64 | TypeCode::Float32, Kind::StringValue(s)) => {
+            Ok(Value::String(s.clone()))
+        }
+        (TypeCode::Bool, Kind::BoolValue(b)) => Ok(Value::Bool(*b)),
+        // JSON columns carry their RFC 7159 text in a string value.
+        (TypeCode::Json, Kind::StringValue(s)) => serde_json::from_str(s).map_err(|e| {
+            RowError::CustomParseError(format!("{field_name}: invalid JSON column value: {e}"))
+        }),
+        // Strings and every string-encoded scalar (timestamps, dates,
+        // NUMERIC, base64 bytes, UUID, INTERVAL, PROTO) pass through.
+        (_, Kind::StringValue(s)) => Ok(Value::String(s.clone())),
+        (TypeCode::Array, Kind::ListValue(list)) => {
+            let elem_ty = ty.and_then(|t| t.array_element_type.as_deref());
+            let items: Result<Vec<Value>, RowError> = list
+                .values
+                .iter()
+                .map(|v| decode_value(v, elem_ty, field_name))
+                .collect();
+            Ok(Value::Array(items?))
+        }
+        // STRUCT rows are encoded as a list whose i-th element matches
+        // `struct_type.fields[i]`.
+        (TypeCode::Struct, Kind::ListValue(list)) => {
+            let fields = ty
+                .and_then(|t| t.struct_type.as_ref())
+                .map(|st| st.fields.as_slice())
+                .unwrap_or(&[]);
+            let mut obj = serde_json::Map::with_capacity(list.values.len());
+            for (idx, v) in list.values.iter().enumerate() {
+                let (name, elem_ty) = fields
+                    .get(idx)
+                    .map(|f| (f.name.clone(), f.r#type.as_ref()))
+                    .unwrap_or_else(|| (format!("_{idx}"), None));
+                obj.insert(name, decode_value(v, elem_ty, field_name)?);
+            }
+            Ok(Value::Object(obj))
+        }
+        // Untyped / unexpected pairings: decode the raw protobuf value
+        // structurally so nothing is silently dropped.
+        (_, kind) => Ok(kind_to_json(kind)),
+    }
+}
+
+/// Structural protobuf → JSON fallback for values whose Spanner type is
+/// absent or does not match the wire kind. Infallible: every protobuf value
+/// kind has a structural JSON form.
+fn kind_to_json(kind: &Kind) -> Value {
+    match kind {
+        Kind::NullValue(_) => Value::Null,
+        Kind::BoolValue(b) => Value::Bool(*b),
+        Kind::NumberValue(f) => serde_json::Number::from_f64(*f).map_or(Value::Null, Value::Number),
+        Kind::StringValue(s) => Value::String(s.clone()),
+        Kind::ListValue(list) => Value::Array(
+            list.values
+                .iter()
+                .map(|v| match &v.kind {
+                    None => Value::Null,
+                    Some(k) => kind_to_json(k),
+                })
+                .collect(),
+        ),
+        Kind::StructValue(st) => {
+            let mut obj = serde_json::Map::with_capacity(st.fields.len());
+            for (k, v) in &st.fields {
+                let decoded = match &v.kind {
+                    None => Value::Null,
+                    Some(kind) => kind_to_json(kind),
+                };
+                obj.insert(k.clone(), decoded);
+            }
+            Value::Object(obj)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gcloud_googleapis::spanner::v1::StructType;
+    use serde_json::json;
+
+    fn pv(kind: Kind) -> prost_types::Value {
+        prost_types::Value { kind: Some(kind) }
+    }
+
+    fn ty(code: TypeCode) -> Type {
+        Type {
+            code: code.into(),
+            array_element_type: None,
+            struct_type: None,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn int64_decodes_losslessly_from_string() {
+        let big = 9_007_199_254_740_993_i64; // 2^53 + 1 — breaks under f64
+        let v = decode_value(
+            &pv(Kind::StringValue(big.to_string())),
+            Some(&ty(TypeCode::Int64)),
+            "n",
+        )
+        .unwrap();
+        assert_eq!(v, json!(big));
+    }
+
+    #[test]
+    fn malformed_int64_is_a_typed_error() {
+        let err = decode_value(
+            &pv(Kind::StringValue("abc".into())),
+            Some(&ty(TypeCode::Int64)),
+            "n",
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("non-integer INT64"));
+    }
+
+    #[test]
+    fn floats_bools_strings_and_nulls() {
+        assert_eq!(
+            decode_value(
+                &pv(Kind::NumberValue(1.5)),
+                Some(&ty(TypeCode::Float64)),
+                "f"
+            )
+            .unwrap(),
+            json!(1.5)
+        );
+        assert_eq!(
+            decode_value(
+                &pv(Kind::StringValue("NaN".into())),
+                Some(&ty(TypeCode::Float64)),
+                "f"
+            )
+            .unwrap(),
+            json!("NaN")
+        );
+        assert_eq!(
+            decode_value(&pv(Kind::BoolValue(true)), Some(&ty(TypeCode::Bool)), "b").unwrap(),
+            json!(true)
+        );
+        assert_eq!(
+            decode_value(
+                &pv(Kind::StringValue("hi".into())),
+                Some(&ty(TypeCode::String)),
+                "s"
+            )
+            .unwrap(),
+            json!("hi")
+        );
+        assert_eq!(
+            decode_value(&pv(Kind::NullValue(0)), Some(&ty(TypeCode::String)), "s").unwrap(),
+            Value::Null
+        );
+        assert_eq!(
+            decode_value(&prost_types::Value { kind: None }, None, "x").unwrap(),
+            Value::Null
+        );
+    }
+
+    #[test]
+    fn numeric_timestamp_date_bytes_stay_strings() {
+        for code in [
+            TypeCode::Numeric,
+            TypeCode::Timestamp,
+            TypeCode::Date,
+            TypeCode::Bytes,
+        ] {
+            let v =
+                decode_value(&pv(Kind::StringValue("raw".into())), Some(&ty(code)), "c").unwrap();
+            assert_eq!(v, json!("raw"));
+        }
+    }
+
+    #[test]
+    fn json_columns_parse_to_structured_values() {
+        let v = decode_value(
+            &pv(Kind::StringValue(r#"{"a": [1, 2]}"#.into())),
+            Some(&ty(TypeCode::Json)),
+            "j",
+        )
+        .unwrap();
+        assert_eq!(v, json!({"a": [1, 2]}));
+        let err = decode_value(
+            &pv(Kind::StringValue("{not json".into())),
+            Some(&ty(TypeCode::Json)),
+            "j",
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("invalid JSON column value"));
+    }
+
+    #[test]
+    fn arrays_recurse_with_element_type() {
+        let mut arr_ty = ty(TypeCode::Array);
+        arr_ty.array_element_type = Some(Box::new(ty(TypeCode::Int64)));
+        let v = decode_value(
+            &pv(Kind::ListValue(prost_types::ListValue {
+                values: vec![pv(Kind::StringValue("1".into())), pv(Kind::NullValue(0))],
+            })),
+            Some(&arr_ty),
+            "a",
+        )
+        .unwrap();
+        assert_eq!(v, json!([1, null]));
+    }
+
+    #[test]
+    fn structs_become_objects_keyed_by_field_name() {
+        let mut st_ty = ty(TypeCode::Struct);
+        st_ty.struct_type = Some(StructType {
+            fields: vec![
+                Field {
+                    name: "id".into(),
+                    r#type: Some(ty(TypeCode::Int64)),
+                },
+                Field {
+                    name: "name".into(),
+                    r#type: Some(ty(TypeCode::String)),
+                },
+            ],
+        });
+        let v = decode_value(
+            &pv(Kind::ListValue(prost_types::ListValue {
+                values: vec![
+                    pv(Kind::StringValue("7".into())),
+                    pv(Kind::StringValue("x".into())),
+                ],
+            })),
+            Some(&st_ty),
+            "s",
+        )
+        .unwrap();
+        assert_eq!(v, json!({"id": 7, "name": "x"}));
+    }
+
+    #[test]
+    fn untyped_values_fall_back_to_structural_decode() {
+        let v = decode_value(&pv(Kind::NumberValue(2.0)), None, "u").unwrap();
+        assert_eq!(v, json!(2.0));
+        let v = decode_value(
+            &pv(Kind::ListValue(prost_types::ListValue {
+                values: vec![pv(Kind::BoolValue(false))],
+            })),
+            None,
+            "u",
+        )
+        .unwrap();
+        assert_eq!(v, json!([false]));
+    }
+}

--- a/crates/common/spanner/src/encode.rs
+++ b/crates/common/spanner/src/encode.rs
@@ -1,0 +1,270 @@
+//! `serde_json::Value` → Spanner mutation value encoding.
+//!
+//! The sink writes arbitrary JSON records, so values are encoded against the
+//! *destination column type* (read once from `INFORMATION_SCHEMA`). Mutations
+//! only carry `prost_types::value::Kind`s — Spanner infers the type from the
+//! table schema — so the object-safe [`ToKind`] wrapper [`EncodedKind`] is
+//! all the mutation builders need.
+
+use crate::types::SpannerType;
+use gcloud_googleapis::spanner::v1::{Type, TypeCode};
+use gcloud_spanner::statement::{ToKind, single_type};
+use prost_types::value::Kind;
+use serde_json::Value;
+
+/// A pre-encoded mutation value. `get_type` reports STRING but is never
+/// consulted on the mutation path (mutations infer types server-side from
+/// the table schema); this wrapper must not be used for statement params.
+pub struct EncodedKind(pub Kind);
+
+impl ToKind for EncodedKind {
+    fn to_kind(&self) -> Kind {
+        self.0.clone()
+    }
+    fn get_type() -> Type
+    where
+        Self: Sized,
+    {
+        single_type(TypeCode::String)
+    }
+}
+
+/// Encode one JSON value for a destination column of type `ty`.
+///
+/// Returns a human-readable error naming the mismatch; callers wrap it with
+/// the column name and route the row to the DLQ or fail the batch.
+pub fn encode_to_kind(value: &Value, ty: &SpannerType) -> Result<Kind, String> {
+    if value.is_null() {
+        return Ok(Kind::NullValue(0));
+    }
+    match ty {
+        SpannerType::Bool => match value {
+            Value::Bool(b) => Ok(Kind::BoolValue(*b)),
+            other => Err(mismatch("BOOL", other)),
+        },
+        // INT64 travels string-encoded (f64 would corrupt > 2^53).
+        SpannerType::Int64 => match value {
+            Value::Number(n) => {
+                if let Some(i) = n.as_i64() {
+                    Ok(Kind::StringValue(i.to_string()))
+                } else if let Some(u) = n.as_u64() {
+                    // > i64::MAX cannot be stored in INT64.
+                    i64::try_from(u)
+                        .map(|i| Kind::StringValue(i.to_string()))
+                        .map_err(|_| format!("integer {u} overflows INT64"))
+                } else {
+                    Err(mismatch("INT64", value))
+                }
+            }
+            // Allow pre-stringified integers (common after transforms).
+            Value::String(s) if s.parse::<i64>().is_ok() => Ok(Kind::StringValue(s.clone())),
+            other => Err(mismatch("INT64", other)),
+        },
+        SpannerType::Float32 | SpannerType::Float64 => match value {
+            Value::Number(n) => n
+                .as_f64()
+                .map(Kind::NumberValue)
+                .ok_or_else(|| mismatch("FLOAT64", value)),
+            // NaN / Infinity travel as strings.
+            Value::String(s) if matches!(s.as_str(), "NaN" | "Infinity" | "-Infinity") => {
+                Ok(Kind::StringValue(s.clone()))
+            }
+            other => Err(mismatch("FLOAT64", other)),
+        },
+        SpannerType::String => match value {
+            Value::String(s) => Ok(Kind::StringValue(s.clone())),
+            // Scalars coerce to their canonical text; containers serialize as
+            // JSON text so a bad mapping surfaces visibly, not silently.
+            Value::Number(n) => Ok(Kind::StringValue(n.to_string())),
+            Value::Bool(b) => Ok(Kind::StringValue(b.to_string())),
+            other => Ok(Kind::StringValue(other.to_string())),
+        },
+        // Timestamps/dates must already be RFC 3339 text; bytes must already
+        // be base64 (the same form the source decodes them to).
+        SpannerType::Timestamp | SpannerType::Date | SpannerType::Bytes => match value {
+            Value::String(s) => Ok(Kind::StringValue(s.clone())),
+            other => Err(mismatch(type_name(ty), other)),
+        },
+        SpannerType::Numeric => match value {
+            Value::String(s) => Ok(Kind::StringValue(s.clone())),
+            Value::Number(n) => Ok(Kind::StringValue(n.to_string())),
+            other => Err(mismatch("NUMERIC", other)),
+        },
+        // JSON columns take the value's RFC 7159 serialization verbatim.
+        SpannerType::Json => Ok(Kind::StringValue(value.to_string())),
+        SpannerType::Array(inner) => match value {
+            Value::Array(items) => {
+                let values: Result<Vec<prost_types::Value>, String> = items
+                    .iter()
+                    .map(|item| {
+                        encode_to_kind(item, inner)
+                            .map(|kind| prost_types::Value { kind: Some(kind) })
+                    })
+                    .collect();
+                Ok(Kind::ListValue(prost_types::ListValue { values: values? }))
+            }
+            other => Err(mismatch("ARRAY", other)),
+        },
+        SpannerType::Other => Err(
+            "unsupported destination column type (STRUCT/PROTO columns are not writable)".into(),
+        ),
+    }
+}
+
+fn type_name(ty: &SpannerType) -> &'static str {
+    match ty {
+        SpannerType::Timestamp => "TIMESTAMP",
+        SpannerType::Date => "DATE",
+        SpannerType::Bytes => "BYTES",
+        _ => "value",
+    }
+}
+
+fn mismatch(expected: &str, got: &Value) -> String {
+    let got_ty = match got {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    };
+    format!("expected {expected}-compatible value, got {got_ty}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn null_encodes_as_null_for_every_type() {
+        for ty in [
+            SpannerType::Bool,
+            SpannerType::Int64,
+            SpannerType::Json,
+            SpannerType::Array(Box::new(SpannerType::String)),
+        ] {
+            assert!(matches!(
+                encode_to_kind(&Value::Null, &ty).unwrap(),
+                Kind::NullValue(_)
+            ));
+        }
+    }
+
+    #[test]
+    fn int64_encodes_as_string_losslessly() {
+        let big = 9_007_199_254_740_993_i64;
+        assert_eq!(
+            encode_to_kind(&json!(big), &SpannerType::Int64).unwrap(),
+            Kind::StringValue(big.to_string())
+        );
+        assert_eq!(
+            encode_to_kind(&json!("42"), &SpannerType::Int64).unwrap(),
+            Kind::StringValue("42".into())
+        );
+        assert!(encode_to_kind(&json!(1.5), &SpannerType::Int64).is_err());
+        assert!(encode_to_kind(&json!("abc"), &SpannerType::Int64).is_err());
+        assert!(
+            encode_to_kind(&json!(u64::MAX), &SpannerType::Int64)
+                .unwrap_err()
+                .contains("overflows INT64")
+        );
+    }
+
+    #[test]
+    fn floats_bools_and_special_values() {
+        assert_eq!(
+            encode_to_kind(&json!(2.5), &SpannerType::Float64).unwrap(),
+            Kind::NumberValue(2.5)
+        );
+        assert_eq!(
+            encode_to_kind(&json!("NaN"), &SpannerType::Float64).unwrap(),
+            Kind::StringValue("NaN".into())
+        );
+        assert!(encode_to_kind(&json!("2.5"), &SpannerType::Float64).is_err());
+        assert_eq!(
+            encode_to_kind(&json!(true), &SpannerType::Bool).unwrap(),
+            Kind::BoolValue(true)
+        );
+        assert!(encode_to_kind(&json!(1), &SpannerType::Bool).is_err());
+    }
+
+    #[test]
+    fn strings_coerce_scalars_and_serialize_containers() {
+        assert_eq!(
+            encode_to_kind(&json!("x"), &SpannerType::String).unwrap(),
+            Kind::StringValue("x".into())
+        );
+        assert_eq!(
+            encode_to_kind(&json!(7), &SpannerType::String).unwrap(),
+            Kind::StringValue("7".into())
+        );
+        assert_eq!(
+            encode_to_kind(&json!({"a": 1}), &SpannerType::String).unwrap(),
+            Kind::StringValue("{\"a\":1}".into())
+        );
+    }
+
+    #[test]
+    fn timestamp_date_bytes_require_strings() {
+        assert_eq!(
+            encode_to_kind(&json!("2026-01-01T00:00:00Z"), &SpannerType::Timestamp).unwrap(),
+            Kind::StringValue("2026-01-01T00:00:00Z".into())
+        );
+        assert!(encode_to_kind(&json!(5), &SpannerType::Timestamp).is_err());
+        assert!(encode_to_kind(&json!(5), &SpannerType::Date).is_err());
+        assert!(encode_to_kind(&json!(5), &SpannerType::Bytes).is_err());
+    }
+
+    #[test]
+    fn numeric_accepts_strings_and_numbers() {
+        assert_eq!(
+            encode_to_kind(&json!("123.456789012345"), &SpannerType::Numeric).unwrap(),
+            Kind::StringValue("123.456789012345".into())
+        );
+        assert_eq!(
+            encode_to_kind(&json!(12), &SpannerType::Numeric).unwrap(),
+            Kind::StringValue("12".into())
+        );
+        assert!(encode_to_kind(&json!(true), &SpannerType::Numeric).is_err());
+    }
+
+    #[test]
+    fn json_columns_take_any_value() {
+        assert_eq!(
+            encode_to_kind(&json!({"a": [1]}), &SpannerType::Json).unwrap(),
+            Kind::StringValue("{\"a\":[1]}".into())
+        );
+        // A JSON string value serializes as a quoted JSON string.
+        assert_eq!(
+            encode_to_kind(&json!("s"), &SpannerType::Json).unwrap(),
+            Kind::StringValue("\"s\"".into())
+        );
+    }
+
+    #[test]
+    fn arrays_recurse_and_reject_non_arrays() {
+        let ty = SpannerType::Array(Box::new(SpannerType::Int64));
+        let Kind::ListValue(list) = encode_to_kind(&json!([1, null, 3]), &ty).unwrap() else {
+            panic!("expected list");
+        };
+        assert_eq!(list.values.len(), 3);
+        assert!(encode_to_kind(&json!(1), &ty).is_err());
+        // Element mismatch surfaces.
+        assert!(encode_to_kind(&json!(["x"]), &ty).is_err());
+    }
+
+    #[test]
+    fn unsupported_destination_types_error() {
+        assert!(encode_to_kind(&json!(1), &SpannerType::Other).is_err());
+    }
+
+    #[test]
+    fn encoded_kind_is_a_usable_tokind() {
+        let ek = EncodedKind(Kind::StringValue("v".into()));
+        assert_eq!(ek.to_kind(), Kind::StringValue("v".into()));
+        let dyn_ref: &dyn ToKind = &ek;
+        assert_eq!(dyn_ref.to_kind(), Kind::StringValue("v".into()));
+    }
+}

--- a/crates/common/spanner/src/lib.rs
+++ b/crates/common/spanner/src/lib.rs
@@ -1,0 +1,385 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+//! Shared Google Cloud Spanner types for the faucet-stream ecosystem.
+//!
+//! This crate holds everything the `faucet-source-spanner` and
+//! `faucet-sink-spanner` connectors have in common:
+//!
+//! - [`SpannerCredentials`] — the `{ type, config }` credentials enum shared
+//!   by both connectors (mirrors `faucet-common-bigquery`).
+//! - [`SpannerConnection`] — the flattened connection block (`project_id` /
+//!   `instance` / `database` / `auth` / `max_sessions` / `emulator_host`)
+//!   plus [`SpannerConnection::connect`] / [`SpannerConnection::connect_admin`]
+//!   client builders.
+//! - [`types`] — `INFORMATION_SCHEMA` type-string parsing and the mapping to
+//!   JSON-Schema fragments.
+//! - [`decode`] — generic Spanner row → `serde_json::Value` decoding for
+//!   arbitrary queries (no compile-time schema).
+//! - [`encode`] — `serde_json::Value` → Spanner mutation value encoding keyed
+//!   by the destination column type.
+
+pub mod decode;
+pub mod encode;
+pub mod types;
+
+use faucet_core::FaucetError;
+use gcloud_gax::conn::Environment;
+use gcloud_spanner::admin::AdminClientConfig;
+use gcloud_spanner::admin::client::Client as AdminClient;
+use gcloud_spanner::client::google_cloud_auth::credentials::CredentialsFile;
+use gcloud_spanner::client::{Client, ClientConfig};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+/// Sessions Spanner allows per gRPC channel (a hard server-side limit the
+/// client enforces at construction time).
+const SESSIONS_PER_CHANNEL: usize = 100;
+
+/// How long a session acquisition may wait for a pooled session before
+/// failing. The crate default (1 s) is too tight for bursty page writes
+/// against a small pool; 30 s matches the channel connect/request timeouts.
+const SESSION_GET_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Credentials used to authenticate against Cloud Spanner.
+///
+/// Serialized in the project-wide adjacently-tagged shape:
+///
+/// ```yaml
+/// auth:
+///   type: service_account_key_path
+///   config:
+///     path: /secrets/sa.json
+/// ```
+#[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "type", content = "config", rename_all = "snake_case")]
+pub enum SpannerCredentials {
+    /// Load a service-account key from a JSON file on disk.
+    ServiceAccountKeyPath {
+        /// Filesystem path to the service-account key JSON.
+        path: String,
+    },
+    /// Inline service-account key JSON (prefer `${vault:…}` / `${env:…}`
+    /// interpolation over literal keys in config files).
+    ServiceAccountKey {
+        /// The full service-account key JSON document.
+        json: String,
+    },
+    /// Application Default Credentials: `GOOGLE_APPLICATION_CREDENTIALS`,
+    /// `gcloud auth application-default login`, or the GCE/GKE metadata
+    /// server.
+    #[default]
+    ApplicationDefault,
+}
+
+impl std::fmt::Debug for SpannerCredentials {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ServiceAccountKeyPath { path } => f
+                .debug_struct("ServiceAccountKeyPath")
+                .field("path", path)
+                .finish(),
+            // Never print inline key material.
+            Self::ServiceAccountKey { .. } => f
+                .debug_struct("ServiceAccountKey")
+                .field("json", &"***")
+                .finish(),
+            Self::ApplicationDefault => f.debug_struct("ApplicationDefault").finish(),
+        }
+    }
+}
+
+fn default_max_sessions() -> usize {
+    100
+}
+
+/// Connection block shared by the Spanner source and sink configs (flattened
+/// into each connector config via `#[serde(flatten)]`).
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SpannerConnection {
+    /// GCP project ID that owns the Spanner instance.
+    pub project_id: String,
+    /// Spanner instance ID.
+    pub instance: String,
+    /// Database name within the instance.
+    pub database: String,
+    /// Credentials. Defaults to Application Default Credentials.
+    #[serde(default)]
+    pub auth: SpannerCredentials,
+    /// Upper bound on pooled Spanner sessions (server-side resources).
+    /// Channels are sized automatically at one per 100 sessions.
+    #[serde(default = "default_max_sessions")]
+    pub max_sessions: usize,
+    /// Emulator endpoint override (`host:port`, e.g. `localhost:9010`).
+    /// When set, the connection is plaintext and unauthenticated — exactly
+    /// what `SPANNER_EMULATOR_HOST` does, but scoped to this connector so
+    /// parallel pipelines/tests don't race on a process-global env var.
+    /// The env var is still honored when this field is unset.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub emulator_host: Option<String>,
+}
+
+impl SpannerConnection {
+    /// Fully-qualified database path:
+    /// `projects/{project}/instances/{instance}/databases/{database}`.
+    pub fn database_path(&self) -> String {
+        format!(
+            "projects/{}/instances/{}/databases/{}",
+            self.project_id, self.instance, self.database
+        )
+    }
+
+    /// Validate the connection block at config-load time.
+    pub fn validate(&self) -> Result<(), FaucetError> {
+        for (field, value) in [
+            ("project_id", &self.project_id),
+            ("instance", &self.instance),
+            ("database", &self.database),
+        ] {
+            if value.trim().is_empty() {
+                return Err(FaucetError::Config(format!(
+                    "spanner: `{field}` must not be empty"
+                )));
+            }
+        }
+        if self.max_sessions == 0 {
+            return Err(FaucetError::Config(
+                "spanner: `max_sessions` must be at least 1".into(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Build the data-plane [`Client`]. Honors `emulator_host` (and, when
+    /// unset, the `SPANNER_EMULATOR_HOST` env var via the client default).
+    pub async fn connect(&self) -> Result<Client, FaucetError> {
+        self.validate()?;
+        let mut config = ClientConfig::default();
+        config.channel_config.num_channels = self.max_sessions.div_ceil(SESSIONS_PER_CHANNEL);
+        config.session_config.min_opened = 1;
+        config.session_config.max_idle = self.max_sessions;
+        config.session_config.max_opened = self.max_sessions;
+        config.session_config.session_get_timeout = SESSION_GET_TIMEOUT;
+        if let Some(host) = &self.emulator_host {
+            config.environment = Environment::Emulator(host.clone());
+        }
+        // Credential application is a no-op under an emulator environment,
+        // so it is safe to apply unconditionally.
+        let config = self.apply_data_credentials(config).await?;
+        Client::new(self.database_path(), config)
+            .await
+            .map_err(|e| FaucetError::Custom(Box::new(e)))
+    }
+
+    /// Build the admin (DDL) client. Same credential and emulator handling
+    /// as [`connect`](Self::connect).
+    pub async fn connect_admin(&self) -> Result<AdminClient, FaucetError> {
+        self.validate()?;
+        let mut config = AdminClientConfig::default();
+        if let Some(host) = &self.emulator_host {
+            config.environment = Environment::Emulator(host.clone());
+        }
+        let config = match &self.auth {
+            SpannerCredentials::ApplicationDefault => config
+                .with_auth()
+                .await
+                .map_err(|e| FaucetError::Auth(format!("spanner ADC: {e}")))?,
+            SpannerCredentials::ServiceAccountKeyPath { path } => config
+                .with_credentials(credentials_from_file(path).await?)
+                .await
+                .map_err(|e| FaucetError::Auth(format!("spanner key file {path}: {e}")))?,
+            SpannerCredentials::ServiceAccountKey { json } => config
+                .with_credentials(credentials_from_str(json).await?)
+                .await
+                .map_err(|e| FaucetError::Auth(format!("spanner inline key: {e}")))?,
+        };
+        AdminClient::new(config)
+            .await
+            .map_err(|e| FaucetError::Custom(Box::new(e)))
+    }
+
+    async fn apply_data_credentials(
+        &self,
+        config: ClientConfig,
+    ) -> Result<ClientConfig, FaucetError> {
+        match &self.auth {
+            SpannerCredentials::ApplicationDefault => config
+                .with_auth()
+                .await
+                .map_err(|e| FaucetError::Auth(format!("spanner ADC: {e}"))),
+            SpannerCredentials::ServiceAccountKeyPath { path } => config
+                .with_credentials(credentials_from_file(path).await?)
+                .await
+                .map_err(|e| FaucetError::Auth(format!("spanner key file {path}: {e}"))),
+            SpannerCredentials::ServiceAccountKey { json } => config
+                .with_credentials(credentials_from_str(json).await?)
+                .await
+                .map_err(|e| FaucetError::Auth(format!("spanner inline key: {e}"))),
+        }
+    }
+}
+
+async fn credentials_from_file(path: &str) -> Result<CredentialsFile, FaucetError> {
+    CredentialsFile::new_from_file(path.to_string())
+        .await
+        .map_err(|e| FaucetError::Auth(format!("spanner key file {path}: {e}")))
+}
+
+async fn credentials_from_str(json: &str) -> Result<CredentialsFile, FaucetError> {
+    CredentialsFile::new_from_str(json)
+        .await
+        .map_err(|e| FaucetError::Auth(format!("spanner inline key: {e}")))
+}
+
+/// Quote a Spanner identifier with backticks, doubling any embedded backtick.
+/// Spanner uses GoogleSQL backtick quoting (like BigQuery/MySQL).
+pub fn quote_ident_spanner(ident: &str) -> String {
+    format!("`{}`", ident.replace('`', "``"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn credentials_serde_shape_is_adjacently_tagged() {
+        let c: SpannerCredentials = serde_json::from_value(json!({
+            "type": "service_account_key_path",
+            "config": {"path": "/tmp/sa.json"}
+        }))
+        .unwrap();
+        assert!(matches!(
+            c,
+            SpannerCredentials::ServiceAccountKeyPath { ref path } if path == "/tmp/sa.json"
+        ));
+        let adc: SpannerCredentials =
+            serde_json::from_value(json!({"type": "application_default"})).unwrap();
+        assert!(matches!(adc, SpannerCredentials::ApplicationDefault));
+        assert!(matches!(
+            SpannerCredentials::default(),
+            SpannerCredentials::ApplicationDefault
+        ));
+    }
+
+    #[test]
+    fn debug_masks_inline_key_material() {
+        let c = SpannerCredentials::ServiceAccountKey {
+            json: "{\"private_key\": \"SECRET\"}".into(),
+        };
+        let rendered = format!("{c:?}");
+        assert!(!rendered.contains("SECRET"));
+        assert!(rendered.contains("***"));
+    }
+
+    fn conn() -> SpannerConnection {
+        SpannerConnection {
+            project_id: "p".into(),
+            instance: "i".into(),
+            database: "d".into(),
+            auth: SpannerCredentials::default(),
+            max_sessions: default_max_sessions(),
+            emulator_host: None,
+        }
+    }
+
+    #[test]
+    fn database_path_shape() {
+        assert_eq!(conn().database_path(), "projects/p/instances/i/databases/d");
+    }
+
+    #[test]
+    fn validate_rejects_empty_fields_and_zero_sessions() {
+        let mut c = conn();
+        c.project_id = " ".into();
+        assert!(matches!(c.validate(), Err(FaucetError::Config(_))));
+        let mut c = conn();
+        c.instance = String::new();
+        assert!(c.validate().is_err());
+        let mut c = conn();
+        c.database = String::new();
+        assert!(c.validate().is_err());
+        let mut c = conn();
+        c.max_sessions = 0;
+        assert!(c.validate().is_err());
+        assert!(conn().validate().is_ok());
+    }
+
+    #[test]
+    fn connection_defaults_from_minimal_config() {
+        let c: SpannerConnection = serde_json::from_value(json!({
+            "project_id": "p", "instance": "i", "database": "d"
+        }))
+        .unwrap();
+        assert_eq!(c.max_sessions, 100);
+        assert!(c.emulator_host.is_none());
+        assert!(matches!(c.auth, SpannerCredentials::ApplicationDefault));
+    }
+
+    #[test]
+    fn quote_ident_doubles_backticks() {
+        assert_eq!(quote_ident_spanner("plain"), "`plain`");
+        assert_eq!(quote_ident_spanner("we`ird"), "`we``ird`");
+    }
+
+    #[tokio::test]
+    async fn credentials_from_missing_file_is_a_typed_auth_error() {
+        let Err(err) = credentials_from_file("/definitely/not/here.json").await else {
+            panic!("missing key file unexpectedly loaded");
+        };
+        assert!(matches!(err, FaucetError::Auth(_)));
+        assert!(err.to_string().contains("/definitely/not/here.json"));
+    }
+
+    #[tokio::test]
+    async fn credentials_from_invalid_json_is_a_typed_auth_error() {
+        let Err(err) = credentials_from_str("{not json").await else {
+            panic!("invalid key json unexpectedly parsed");
+        };
+        assert!(matches!(err, FaucetError::Auth(_)));
+        assert!(err.to_string().contains("inline key"));
+    }
+
+    /// A syntactically valid (but fake) service-account document — every
+    /// field except `type` is optional in the credentials-file schema.
+    const FAKE_SA: &str = r#"{"type": "service_account", "project_id": "p"}"#;
+
+    /// Every credential variant must build under an emulator environment
+    /// (where token providers are inert) and then fail fast at client
+    /// construction against a dead endpoint — proving the credential arms
+    /// never panic and map errors into `FaucetError`.
+    #[tokio::test]
+    async fn connect_exercises_every_credential_variant_against_dead_emulator() {
+        let key_path = std::env::temp_dir().join("faucet-spanner-test-sa.json");
+        std::fs::write(&key_path, FAKE_SA).expect("write fake key");
+        let variants = [
+            SpannerCredentials::ApplicationDefault,
+            SpannerCredentials::ServiceAccountKey {
+                json: FAKE_SA.to_string(),
+            },
+            SpannerCredentials::ServiceAccountKeyPath {
+                path: key_path.to_string_lossy().into_owned(),
+            },
+        ];
+        for auth in variants {
+            let mut c = conn();
+            // Port 1 is never a Spanner emulator: connection is refused
+            // immediately, after the credential arm has already run.
+            c.emulator_host = Some("127.0.0.1:1".into());
+            c.auth = auth.clone();
+            let Err(err) = c.connect().await else {
+                panic!("data-plane connect unexpectedly succeeded for {auth:?}");
+            };
+            assert!(
+                matches!(err, FaucetError::Custom(_)),
+                "data-plane connect: unexpected error {err:?} for {auth:?}"
+            );
+            let Err(err) = c.connect_admin().await else {
+                panic!("admin connect unexpectedly succeeded for {auth:?}");
+            };
+            assert!(
+                matches!(err, FaucetError::Custom(_)),
+                "admin connect: unexpected error {err:?} for {auth:?}"
+            );
+        }
+    }
+}

--- a/crates/common/spanner/src/types.rs
+++ b/crates/common/spanner/src/types.rs
@@ -1,0 +1,150 @@
+//! Spanner `INFORMATION_SCHEMA` type-string parsing and the mapping from
+//! Spanner column types to JSON-Schema fragments.
+
+use serde_json::{Value, json};
+
+/// A parsed Spanner column type (GoogleSQL dialect).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SpannerType {
+    Bool,
+    Int64,
+    Float32,
+    Float64,
+    Timestamp,
+    Date,
+    /// `STRING(n)` / `STRING(MAX)` — the length bound is not retained.
+    String,
+    /// `BYTES(n)` / `BYTES(MAX)` — values travel base64-encoded.
+    Bytes,
+    /// Arbitrary-precision decimal; decoded/encoded as a string to preserve
+    /// precision.
+    Numeric,
+    Json,
+    Array(Box<SpannerType>),
+    /// STRUCT / PROTO / ENUM / anything unrecognized — decoded generically,
+    /// not writable by the sink.
+    Other,
+}
+
+/// Parse an `INFORMATION_SCHEMA.COLUMNS.SPANNER_TYPE` string
+/// (e.g. `STRING(MAX)`, `INT64`, `ARRAY<FLOAT64>`) into a [`SpannerType`].
+/// Unrecognized types parse as [`SpannerType::Other`], never an error.
+pub fn parse_spanner_type(raw: &str) -> SpannerType {
+    let s = raw.trim();
+    let upper = s.to_ascii_uppercase();
+    if let Some(inner) = upper
+        .strip_prefix("ARRAY<")
+        .and_then(|rest| rest.strip_suffix('>'))
+    {
+        return SpannerType::Array(Box::new(parse_spanner_type(inner)));
+    }
+    // Strip a length parameter: `STRING(MAX)` / `BYTES(256)`.
+    let base = upper.split('(').next().unwrap_or(&upper).trim();
+    match base {
+        "BOOL" => SpannerType::Bool,
+        "INT64" => SpannerType::Int64,
+        "FLOAT32" => SpannerType::Float32,
+        "FLOAT64" => SpannerType::Float64,
+        "TIMESTAMP" => SpannerType::Timestamp,
+        "DATE" => SpannerType::Date,
+        "STRING" => SpannerType::String,
+        "BYTES" => SpannerType::Bytes,
+        "NUMERIC" => SpannerType::Numeric,
+        "JSON" => SpannerType::Json,
+        _ => SpannerType::Other,
+    }
+}
+
+/// Map a [`SpannerType`] to the JSON-Schema fragment faucet's discover /
+/// schema-drift machinery expects (an `infer_schema`-shaped `{"type": …}`).
+/// `nullable` widens the type with `"null"`.
+///
+/// NUMERIC maps to `string` (matching the decoder, which emits NUMERIC as a
+/// string to preserve precision).
+pub fn spanner_type_to_json_schema(ty: &SpannerType, nullable: bool) -> Value {
+    let base: Value = match ty {
+        SpannerType::Bool => json!({"type": "boolean"}),
+        SpannerType::Int64 => json!({"type": "integer"}),
+        SpannerType::Float32 | SpannerType::Float64 => json!({"type": "number"}),
+        SpannerType::Json => json!({"type": "object"}),
+        SpannerType::Array(inner) => {
+            json!({"type": "array", "items": spanner_type_to_json_schema(inner, false)})
+        }
+        SpannerType::Timestamp
+        | SpannerType::Date
+        | SpannerType::String
+        | SpannerType::Bytes
+        | SpannerType::Numeric => json!({"type": "string"}),
+        SpannerType::Other => json!({"type": "object"}),
+    };
+    if nullable {
+        let mut obj = base;
+        if let Some(t) = obj.get("type").cloned() {
+            obj["type"] = json!([t, "null"]);
+        }
+        obj
+    } else {
+        base
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_scalar_types_case_insensitively_and_strips_lengths() {
+        assert_eq!(parse_spanner_type("INT64"), SpannerType::Int64);
+        assert_eq!(parse_spanner_type("string(MAX)"), SpannerType::String);
+        assert_eq!(parse_spanner_type("BYTES(256)"), SpannerType::Bytes);
+        assert_eq!(parse_spanner_type("Float64"), SpannerType::Float64);
+        assert_eq!(parse_spanner_type("FLOAT32"), SpannerType::Float32);
+        assert_eq!(parse_spanner_type("NUMERIC"), SpannerType::Numeric);
+        assert_eq!(parse_spanner_type("JSON"), SpannerType::Json);
+        assert_eq!(parse_spanner_type("TIMESTAMP"), SpannerType::Timestamp);
+        assert_eq!(parse_spanner_type("DATE"), SpannerType::Date);
+        assert_eq!(parse_spanner_type("BOOL"), SpannerType::Bool);
+    }
+
+    #[test]
+    fn parses_arrays_recursively() {
+        assert_eq!(
+            parse_spanner_type("ARRAY<INT64>"),
+            SpannerType::Array(Box::new(SpannerType::Int64))
+        );
+        assert_eq!(
+            parse_spanner_type("ARRAY<STRING(MAX)>"),
+            SpannerType::Array(Box::new(SpannerType::String))
+        );
+    }
+
+    #[test]
+    fn unknown_types_map_to_other_not_error() {
+        assert_eq!(
+            parse_spanner_type("STRUCT<a INT64, b STRING(MAX)>"),
+            SpannerType::Other
+        );
+        assert_eq!(parse_spanner_type("PROTO<x.Y>"), SpannerType::Other);
+        assert_eq!(parse_spanner_type(""), SpannerType::Other);
+    }
+
+    #[test]
+    fn json_schema_mapping_and_nullability() {
+        assert_eq!(
+            spanner_type_to_json_schema(&SpannerType::Int64, false),
+            serde_json::json!({"type": "integer"})
+        );
+        assert_eq!(
+            spanner_type_to_json_schema(&SpannerType::Numeric, false),
+            serde_json::json!({"type": "string"})
+        );
+        assert_eq!(
+            spanner_type_to_json_schema(&SpannerType::Bool, true),
+            serde_json::json!({"type": ["boolean", "null"]})
+        );
+        assert_eq!(
+            spanner_type_to_json_schema(&SpannerType::Array(Box::new(SpannerType::Float64)), false),
+            serde_json::json!({"type": "array", "items": {"type": "number"}})
+        );
+    }
+}

--- a/crates/sink/spanner/Cargo.toml
+++ b/crates/sink/spanner/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "faucet-sink-spanner"
+version = "1.0.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Google Cloud Spanner sink connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords = ["spanner", "gcp", "etl", "pipeline", "connector"]
+categories.workspace = true
+
+[dependencies]
+faucet-core.workspace = true
+faucet-common-spanner.workspace = true
+gcloud-spanner.workspace = true
+gcloud-googleapis.workspace = true
+gcloud-gax.workspace = true
+prost-types = "0.14"
+schemars.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+async-trait.workspace = true
+tracing.workspace = true
+tokio = { workspace = true, features = ["sync", "time"] }
+
+[dev-dependencies]
+faucet-conformance.workspace = true
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
+testcontainers = "0.27"
+futures.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/sink/spanner/README.md
+++ b/crates/sink/spanner/README.md
@@ -1,0 +1,121 @@
+# faucet-sink-spanner
+
+Google Cloud Spanner sink connector for the [faucet-stream](https://github.com/PawanSikawat/faucet-stream) ecosystem.
+
+Writes JSON records to a Spanner table as batched **mutations** — `Insert` for append, Spanner's native `InsertOrUpdate` for `write_mode: upsert`, and `Delete` mutations for delete mode — one atomic commit per chunk. Supports exactly-once delivery (`delivery: exactly_once`) via a `faucet_commit_token` watermark row committed in the same read-write transaction as the page, and additive schema evolution through the database-admin DDL API.
+
+## Example
+
+```yaml
+version: 1
+name: kafka-to-spanner
+pipeline:
+  source:
+    kind: kafka
+    config:
+      brokers: ["localhost:9092"]
+      topics: ["users"]
+      group_id: faucet
+      max_messages: 10000
+  sink:
+    kind: spanner
+    config:
+      project_id: my-project
+      instance: my-instance
+      database: my-db
+      table_name: users
+      write_mode: upsert
+      key: [id]                  # must equal the table's PRIMARY KEY
+      auth:
+        type: application_default
+```
+
+## Configuration
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `project_id` | string | — | GCP project that owns the Spanner instance. |
+| `instance` | string | — | Spanner instance ID. |
+| `database` | string | — | Database name within the instance. |
+| `table_name` | string | — | Target table. Must already exist (mutations require a schema). |
+| `auth` | object | `application_default` | Credentials — see [Authentication](#authentication). |
+| `max_sessions` | integer | `100` | Upper bound on pooled Spanner sessions. Channels are sized at one per 100 sessions. |
+| `emulator_host` | string | — | Emulator endpoint (`host:port`). Plaintext + unauthenticated; scoped to this connector (no env-var races). `SPANNER_EMULATOR_HOST` is still honored when unset. |
+| `batch_size` | integer | `1000` | Rows per commit. `0` = no row-count re-chunking (the cell budget below still applies). |
+| `ddl_timeout_secs` | integer | `300` | Bound on schema-change (long-running DDL operation) waits. |
+| `write_mode` | string | `append` | `append` \| `upsert` \| `delete`. |
+| `key` | array | `[]` | Key columns for upsert/delete. **Must equal the table's PRIMARY KEY columns** (order-insensitive) — Spanner mutations always key on the PK. |
+| `delete_marker` | object | — | Upsert only: `{ field, values }` — rows whose `field` matches become deletes; the marker field is stripped. |
+
+### Authentication
+
+The `auth` block uses the project-wide `{ type, config }` shape:
+
+```yaml
+auth:
+  type: service_account_key_path   # or service_account_key | application_default
+  config:
+    path: /secrets/sa.json
+```
+
+- `application_default` (default) — `GOOGLE_APPLICATION_CREDENTIALS`, `gcloud auth application-default login`, or the GCE/GKE metadata server.
+- `service_account_key_path` — `config.path` to a key file.
+- `service_account_key` — `config.json` inline key (prefer `${vault:…}` / `${env:…}` interpolation).
+
+## Value encoding
+
+Values are encoded against the destination column types read once from `INFORMATION_SCHEMA`:
+
+| Spanner column | Accepted JSON | Notes |
+|---|---|---|
+| `INT64` | integer, integer-string | String-encoded on the wire — lossless above 2^53. |
+| `FLOAT64` / `FLOAT32` | number, `"NaN"`/`"Infinity"`/`"-Infinity"` | |
+| `BOOL` | boolean | |
+| `STRING` | any | Scalars coerce to text; containers serialize as JSON text. |
+| `TIMESTAMP` / `DATE` | RFC 3339 string | |
+| `BYTES` | base64 string | Same form the Spanner source decodes to. |
+| `NUMERIC` | string or number | Strings pass through losslessly. |
+| `JSON` | any | The value's JSON serialization. |
+| `ARRAY<T>` | array | Elements encoded as `T`. |
+
+Record fields with no matching column are dropped with a one-shot warning per field. A type mismatch fails that row with an error naming the column.
+
+## Write modes
+
+- **`append`** (default) — `Insert` mutations. A duplicate PRIMARY KEY fails the whole commit (chunk); route pages through a DLQ with `on_batch_error: dlq_all` if you need to absorb duplicates, or use `upsert`.
+- **`upsert`** — `InsertOrUpdate` keyed on the table's PRIMARY KEY. `key` must equal the PK column set; this is validated on first write and by `faucet doctor`.
+- **`delete`** / `delete_marker` — `Delete` mutations. Key values are re-ordered into PK order automatically. Note Spanner cascades deletes to `INTERLEAVE IN PARENT … ON DELETE CASCADE` child tables.
+
+## Batching and the 80,000-cell commit limit
+
+Spanner rejects commits above ~80,000 mutated cells (rows × columns, **plus** secondary-index amplification the client cannot see). The sink chunks each page at `batch_size` rows *and* a conservative 60,000-cell budget, whichever comes first. If the target table has many secondary indexes, lower `batch_size` further.
+
+## Exactly-once delivery
+
+`delivery: exactly_once` commits each page's mutations **and** an `InsertOrUpdate` on the watermark table in one read-write transaction:
+
+```sql
+CREATE TABLE IF NOT EXISTS faucet_commit_token (
+  scope      STRING(MAX) NOT NULL,
+  token      STRING(MAX) NOT NULL,
+  updated_at TIMESTAMP OPTIONS (allow_commit_timestamp=true)
+) PRIMARY KEY (scope)
+```
+
+The table is auto-created via the admin DDL API on first use. On crash either the page and its token both landed or neither did; on resume the pipeline reads `last_committed_token` and skips already-committed pages. The idempotent page is a **single commit** (no re-chunking), so it is bounded by the 80,000-cell limit — size the source's `batch_size` down for very wide tables. `ABORTED` commit contention is retried automatically by the client with its recommended backoff.
+
+## Schema evolution (drift `on_drift: evolve`)
+
+- **New columns** — `ALTER TABLE … ADD COLUMN IF NOT EXISTS` (`integer→INT64`, `number→FLOAT64`, `boolean→BOOL`, `string→STRING(MAX)`, `object→JSON`), always nullable.
+- **Nullability relaxations** — the column is re-emitted at its current type without `NOT NULL`.
+- **Base-type widenings (e.g. INT64→FLOAT64) are not supported by Spanner.** The sink returns a typed error advising `allow_type_widening: false`, which makes the drift policy classify the change `incompatible` and route it via `on_incompatible` (`fail` or `quarantine`).
+
+DDL runs as a Spanner long-running operation, bounded by `ddl_timeout_secs`.
+
+## Emulator
+
+Point the sink at the [Cloud Spanner emulator](https://cloud.google.com/spanner/docs/emulator) (`gcr.io/cloud-spanner-emulator/emulator`, gRPC port 9010) with `emulator_host: localhost:9010`. Credentials are ignored against the emulator. The crate's integration tests bootstrap instance + database programmatically through the admin API.
+
+## License
+
+MIT OR Apache-2.0

--- a/crates/sink/spanner/src/config.rs
+++ b/crates/sink/spanner/src/config.rs
@@ -1,0 +1,197 @@
+//! Cloud Spanner sink configuration.
+
+use faucet_common_spanner::SpannerConnection;
+use faucet_core::DEFAULT_BATCH_SIZE;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Configuration for the Cloud Spanner sink.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SpannerSinkConfig {
+    /// Connection block (`project_id` / `instance` / `database` / `auth` /
+    /// `max_sessions` / `emulator_host`), flattened to the config top level.
+    #[serde(flatten)]
+    pub connection: SpannerConnection,
+    /// Target table name.
+    pub table_name: String,
+    /// Maximum rows per Spanner commit. Defaults to [`DEFAULT_BATCH_SIZE`].
+    ///
+    /// Each chunk is applied as one atomic commit. Spanner additionally caps
+    /// a commit at ~80,000 mutated *cells* (rows × columns, plus secondary
+    /// index amplification), so the sink also splits chunks to stay under a
+    /// conservative 60,000-cell budget regardless of `batch_size`.
+    ///
+    /// `batch_size = 0` is the "no batching" sentinel: the entire upstream
+    /// page is written in as few commits as the cell budget allows.
+    #[serde(default = "default_batch_size")]
+    pub batch_size: usize,
+    /// Upper bound (seconds) on waiting for a schema-change operation
+    /// (`ALTER TABLE …` long-running operation) to complete. Defaults to 300.
+    #[serde(default = "default_ddl_timeout_secs")]
+    pub ddl_timeout_secs: u64,
+    /// Write mode, key columns, and optional delete marker. `write_mode`
+    /// defaults to `append`. Upsert/delete require `key` to equal the target
+    /// table's PRIMARY KEY columns (Spanner mutations always key on the PK).
+    #[serde(flatten)]
+    pub write: faucet_core::WriteSpec,
+}
+
+fn default_batch_size() -> usize {
+    DEFAULT_BATCH_SIZE
+}
+
+fn default_ddl_timeout_secs() -> u64 {
+    300
+}
+
+impl SpannerSinkConfig {
+    /// Create a new config with required fields and sensible defaults.
+    pub fn new(
+        project_id: impl Into<String>,
+        instance: impl Into<String>,
+        database: impl Into<String>,
+        table_name: impl Into<String>,
+    ) -> Self {
+        Self {
+            connection: SpannerConnection {
+                project_id: project_id.into(),
+                instance: instance.into(),
+                database: database.into(),
+                auth: Default::default(),
+                max_sessions: 100,
+                emulator_host: None,
+            },
+            table_name: table_name.into(),
+            batch_size: DEFAULT_BATCH_SIZE,
+            ddl_timeout_secs: default_ddl_timeout_secs(),
+            write: faucet_core::WriteSpec::default(),
+        }
+    }
+
+    /// Set the per-commit row count. Pass `0` to opt out of row-count
+    /// re-chunking (the ~60,000-cell budget still applies).
+    pub fn with_batch_size(mut self, batch_size: usize) -> Self {
+        self.batch_size = batch_size;
+        self
+    }
+
+    /// Set the emulator endpoint (`host:port`), for tests and local runs.
+    pub fn with_emulator_host(mut self, host: impl Into<String>) -> Self {
+        self.connection.emulator_host = Some(host.into());
+        self
+    }
+
+    /// Set the bound on schema-change LRO waits.
+    pub fn with_ddl_timeout_secs(mut self, secs: u64) -> Self {
+        self.ddl_timeout_secs = secs;
+        self
+    }
+
+    /// Validate the config at load time: connection block, batch size, and
+    /// write spec (`key` non-empty for upsert/delete).
+    pub fn validate(&self) -> Result<(), faucet_core::FaucetError> {
+        self.connection.validate()?;
+        faucet_core::validate_batch_size(self.batch_size)?;
+        if self.table_name.trim().is_empty() {
+            return Err(faucet_core::FaucetError::Config(
+                "spanner sink: `table_name` must not be empty".into(),
+            ));
+        }
+        self.write.validate()?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use faucet_core::{WriteMode, WriteSpec};
+    use serde_json::json;
+
+    fn base() -> SpannerSinkConfig {
+        SpannerSinkConfig::new("p", "i", "d", "events")
+    }
+
+    #[test]
+    fn default_config() {
+        let config = base();
+        assert_eq!(config.table_name, "events");
+        assert_eq!(config.batch_size, DEFAULT_BATCH_SIZE);
+        assert_eq!(config.ddl_timeout_secs, 300);
+        assert_eq!(config.connection.max_sessions, 100);
+        assert!(matches!(config.write.write_mode, WriteMode::Append));
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn builder_methods() {
+        let config = base()
+            .with_batch_size(50)
+            .with_emulator_host("localhost:9010")
+            .with_ddl_timeout_secs(10);
+        assert_eq!(config.batch_size, 50);
+        assert_eq!(
+            config.connection.emulator_host.as_deref(),
+            Some("localhost:9010")
+        );
+        assert_eq!(config.ddl_timeout_secs, 10);
+    }
+
+    #[test]
+    fn deserializes_flattened_connection_and_write_spec() {
+        let config: SpannerSinkConfig = serde_json::from_value(json!({
+            "project_id": "p",
+            "instance": "i",
+            "database": "d",
+            "table_name": "t",
+            "write_mode": "upsert",
+            "key": ["id"]
+        }))
+        .unwrap();
+        assert_eq!(config.connection.project_id, "p");
+        assert!(matches!(config.write.write_mode, WriteMode::Upsert));
+        assert_eq!(config.write.key, vec!["id".to_string()]);
+        assert_eq!(config.batch_size, DEFAULT_BATCH_SIZE);
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_empty_table_name() {
+        let mut config = base();
+        config.table_name = "  ".into();
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_upsert_without_key() {
+        let mut config = base();
+        config.write = WriteSpec {
+            write_mode: WriteMode::Upsert,
+            key: vec![],
+            delete_marker: None,
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_oversized_batch() {
+        let config = base().with_batch_size(faucet_core::MAX_BATCH_SIZE + 1);
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn batch_size_zero_is_accepted_as_sentinel() {
+        let config = base().with_batch_size(0);
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn debug_does_not_leak_inline_key() {
+        let mut config = base();
+        config.connection.auth = faucet_common_spanner::SpannerCredentials::ServiceAccountKey {
+            json: "TOPSECRET".into(),
+        };
+        let rendered = format!("{config:?}");
+        assert!(!rendered.contains("TOPSECRET"));
+    }
+}

--- a/crates/sink/spanner/src/lib.rs
+++ b/crates/sink/spanner/src/lib.rs
@@ -1,0 +1,34 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+//! Google Cloud Spanner sink connector for faucet-stream.
+//!
+//! Writes JSON records to a Spanner table as batched **mutations**: `Insert`
+//! for append, `InsertOrUpdate` for `write_mode: upsert`, and `Delete`
+//! mutations for `write_mode: delete` / `delete_marker` rows. Exactly-once
+//! delivery (`delivery: exactly_once`) commits each page atomically with a
+//! `_faucet_commit_token` watermark row in one read-write transaction.
+//!
+//! ```yaml
+//! sink:
+//!   kind: spanner
+//!   config:
+//!     project_id: my-project
+//!     instance: my-instance
+//!     database: my-db
+//!     table_name: events
+//!     write_mode: upsert       # append (default) | upsert | delete
+//!     key: [id]                # must equal the table's PRIMARY KEY
+//!     auth:
+//!       type: application_default
+//! ```
+//!
+//! Values are encoded against the destination column types read from
+//! `INFORMATION_SCHEMA`; commits are chunked at `batch_size` rows and a
+//! conservative 60,000-mutated-cell budget (Spanner's hard limit is ~80,000
+//! cells per commit including secondary-index amplification).
+
+mod config;
+mod sink;
+
+pub use config::SpannerSinkConfig;
+pub use faucet_common_spanner::{SpannerConnection, SpannerCredentials};
+pub use sink::SpannerSink;

--- a/crates/sink/spanner/src/sink.rs
+++ b/crates/sink/spanner/src/sink.rs
@@ -1,0 +1,1172 @@
+//! Cloud Spanner sink implementation.
+//!
+//! Records are written as batched **mutations** (`Insert` for append,
+//! `InsertOrUpdate` for upsert, `Delete` for delete mode), one atomic
+//! `Commit` per chunk. Values are encoded against the destination column
+//! types read once from `INFORMATION_SCHEMA` (see
+//! [`faucet_common_spanner::encode`]). Exactly-once delivery commits the
+//! page's mutations and a `faucet_commit_token` watermark row in a single
+//! read-write transaction.
+
+use crate::config::SpannerSinkConfig;
+use async_trait::async_trait;
+use faucet_common_spanner::encode::{EncodedKind, encode_to_kind};
+use faucet_common_spanner::quote_ident_spanner;
+use faucet_common_spanner::types::{SpannerType, parse_spanner_type, spanner_type_to_json_schema};
+use faucet_core::FaucetError;
+use gcloud_googleapis::spanner::admin::database::v1::UpdateDatabaseDdlRequest;
+use gcloud_googleapis::spanner::v1::Mutation;
+use gcloud_spanner::client::Client;
+use gcloud_spanner::key::Key;
+use gcloud_spanner::mutation::{delete, insert, insert_or_update};
+use gcloud_spanner::statement::{Statement, ToKind};
+use gcloud_spanner::value::CommitTimestamp;
+use serde_json::Value;
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Conservative bound on mutated cells per commit. Spanner rejects commits
+/// above ~80,000 mutated cells (rows × columns, **plus** secondary-index
+/// amplification the client cannot see), so the sink chunks well below it.
+const CELL_BUDGET: usize = 60_000;
+
+/// Live table metadata read from `INFORMATION_SCHEMA` (cached per sink).
+#[derive(Debug, Clone)]
+struct TableMeta {
+    /// `(name, type, nullable)` in declared column order.
+    columns: Vec<(String, SpannerType, bool)>,
+    /// PRIMARY KEY column names, in key order.
+    pk: Vec<String>,
+}
+
+impl TableMeta {
+    fn type_of(&self, col: &str) -> Option<&SpannerType> {
+        self.columns
+            .iter()
+            .find(|(name, _, _)| name == col)
+            .map(|(_, ty, _)| ty)
+    }
+
+    fn has_column(&self, col: &str) -> bool {
+        self.columns.iter().any(|(name, _, _)| name == col)
+    }
+}
+
+/// One planned mutation plus the number of cells it mutates (drives the
+/// per-commit cell budget).
+#[derive(Debug)]
+struct Planned {
+    mutation: Mutation,
+    cells: usize,
+}
+
+/// Which write mutation to build for a data row.
+#[derive(Clone, Copy, PartialEq)]
+enum WriteOp {
+    /// Append mode — duplicate PKs fail the commit.
+    Insert,
+    /// Upsert mode — Spanner's native keyed upsert.
+    InsertOrUpdate,
+}
+
+/// Build the mutation for one record: columns are the intersection of the
+/// record's top-level fields with the table's columns, encoded per column
+/// type. Fields with no matching column are dropped with a one-shot warning
+/// (`warned` dedups across the sink's lifetime). A record with *no* matching
+/// column, a non-object record, or an encode failure is an `Err` naming the
+/// column.
+fn build_row_mutation(
+    table: &str,
+    record: &Value,
+    meta: &TableMeta,
+    op: WriteOp,
+    warned: &mut HashSet<String>,
+) -> Result<Planned, String> {
+    let obj = record
+        .as_object()
+        .ok_or_else(|| "record is not a JSON object".to_string())?;
+
+    let mut cols: Vec<&str> = Vec::new();
+    let mut vals: Vec<EncodedKind> = Vec::new();
+    for (name, ty, _) in &meta.columns {
+        if let Some(v) = obj.get(name) {
+            let kind = encode_to_kind(v, ty).map_err(|e| format!("column `{name}`: {e}"))?;
+            cols.push(name.as_str());
+            vals.push(EncodedKind(kind));
+        }
+    }
+    for key in obj.keys() {
+        if !meta.has_column(key) && warned.insert(key.clone()) {
+            tracing::warn!(
+                field = %key,
+                table = %table,
+                "record field has no matching Spanner column; dropping it (warned once per field)"
+            );
+        }
+    }
+    if cols.is_empty() {
+        return Err("record has no fields matching table columns".into());
+    }
+
+    let refs: Vec<&dyn ToKind> = vals.iter().map(|v| v as &dyn ToKind).collect();
+    let mutation = match op {
+        WriteOp::Insert => insert(table, &cols, &refs),
+        WriteOp::InsertOrUpdate => insert_or_update(table, &cols, &refs),
+    };
+    Ok(Planned {
+        mutation,
+        cells: cols.len(),
+    })
+}
+
+/// Build the delete mutation for one planned key tuple. Spanner delete keys
+/// must be supplied in **PRIMARY KEY column order**, which may differ from
+/// the configured `key` order — values are re-ordered here.
+fn build_delete_mutation(
+    table: &str,
+    key_tuple: &faucet_core::KeyTuple,
+    meta: &TableMeta,
+) -> Result<Planned, String> {
+    let mut vals: Vec<EncodedKind> = Vec::with_capacity(meta.pk.len());
+    for pk_col in &meta.pk {
+        let (_, v) = key_tuple
+            .0
+            .iter()
+            .find(|(col, _)| col == pk_col)
+            .ok_or_else(|| format!("delete key is missing PK column `{pk_col}`"))?;
+        let ty = meta
+            .type_of(pk_col)
+            .ok_or_else(|| format!("PK column `{pk_col}` not found in table metadata"))?;
+        let kind = encode_to_kind(v, ty).map_err(|e| format!("key column `{pk_col}`: {e}"))?;
+        vals.push(EncodedKind(kind));
+    }
+    let refs: Vec<&dyn ToKind> = vals.iter().map(|v| v as &dyn ToKind).collect();
+    Ok(Planned {
+        mutation: delete(table, Key::composite(&refs)),
+        cells: meta.pk.len().max(1),
+    })
+}
+
+/// Split planned mutations into commit-sized chunks: at most `batch_size`
+/// rows (0 = unbounded) and at most [`CELL_BUDGET`] cells per chunk. A single
+/// row above the budget still ships alone — Spanner, not the sink, is the
+/// authority on rejecting it.
+fn chunk_by_cells(planned: Vec<Planned>, batch_size: usize, budget: usize) -> Vec<Vec<Mutation>> {
+    let row_cap = if batch_size == 0 {
+        usize::MAX
+    } else {
+        batch_size
+    };
+    let mut chunks: Vec<Vec<Mutation>> = Vec::new();
+    let mut current: Vec<Mutation> = Vec::new();
+    let mut cells = 0usize;
+    for p in planned {
+        if !current.is_empty() && (cells + p.cells > budget || current.len() >= row_cap) {
+            chunks.push(std::mem::take(&mut current));
+            cells = 0;
+        }
+        cells += p.cells;
+        current.push(p.mutation);
+    }
+    if !current.is_empty() {
+        chunks.push(current);
+    }
+    chunks
+}
+
+/// Upsert/delete requires the configured `key` to be exactly the table's
+/// PRIMARY KEY columns (Spanner mutations always key on the PK). Order is
+/// irrelevant — set equality.
+fn validate_key_matches_pk(key: &[String], pk: &[String], table: &str) -> Result<(), FaucetError> {
+    let key_set: HashSet<&str> = key.iter().map(|s| s.as_str()).collect();
+    let pk_set: HashSet<&str> = pk.iter().map(|s| s.as_str()).collect();
+    if key_set != pk_set {
+        return Err(FaucetError::Config(format!(
+            "spanner sink: write key {key:?} must equal table `{table}`'s PRIMARY KEY columns \
+             {pk:?} (Spanner mutations always key on the primary key)"
+        )));
+    }
+    Ok(())
+}
+
+/// Map a [`faucet_core::SqlBaseType`] to the Spanner DDL keyword used when
+/// adding a column during schema evolution. Integers land as `INT64` and
+/// floats as `FLOAT64` — Spanner's widest numeric types.
+fn spanner_keyword(t: faucet_core::SqlBaseType) -> &'static str {
+    use faucet_core::SqlBaseType::*;
+    match t {
+        Integer => "INT64",
+        Double => "FLOAT64",
+        Boolean => "BOOL",
+        Text => "STRING(MAX)",
+        Json => "JSON",
+    }
+}
+
+/// Render a [`SpannerType`] back to its DDL form, used when re-emitting a
+/// column to relax `NOT NULL`. `Other` (STRUCT/PROTO) cannot be re-emitted.
+fn spanner_type_ddl(ty: &SpannerType) -> Result<String, String> {
+    Ok(match ty {
+        SpannerType::Bool => "BOOL".into(),
+        SpannerType::Int64 => "INT64".into(),
+        SpannerType::Float32 => "FLOAT32".into(),
+        SpannerType::Float64 => "FLOAT64".into(),
+        SpannerType::Timestamp => "TIMESTAMP".into(),
+        SpannerType::Date => "DATE".into(),
+        SpannerType::String => "STRING(MAX)".into(),
+        SpannerType::Bytes => "BYTES(MAX)".into(),
+        SpannerType::Numeric => "NUMERIC".into(),
+        SpannerType::Json => "JSON".into(),
+        SpannerType::Array(inner) => format!("ARRAY<{}>", spanner_type_ddl(inner)?),
+        SpannerType::Other => {
+            return Err("cannot re-emit a STRUCT/PROTO column in DDL".into());
+        }
+    })
+}
+
+/// `ALTER TABLE <t> ADD COLUMN IF NOT EXISTS <c> <kw>` — idempotent addition.
+/// New columns are always nullable (Spanner requires a default for NOT NULL
+/// additions, and drift additions are nullable by construction).
+fn build_add_column_sql(table: &str, col: &str, t: faucet_core::SqlBaseType) -> String {
+    format!(
+        "ALTER TABLE {} ADD COLUMN IF NOT EXISTS {} {}",
+        quote_ident_spanner(table),
+        quote_ident_spanner(col),
+        spanner_keyword(t)
+    )
+}
+
+/// `ALTER TABLE <t> ALTER COLUMN <c> <TYPE>` — re-emitting the column at its
+/// current type *without* `NOT NULL` relaxes the null constraint (Spanner has
+/// no `DROP NOT NULL`). Idempotent.
+fn build_alter_column_sql(table: &str, col: &str, type_ddl: &str) -> String {
+    format!(
+        "ALTER TABLE {} ALTER COLUMN {} {}",
+        quote_ident_spanner(table),
+        quote_ident_spanner(col),
+        type_ddl
+    )
+}
+
+/// Commit-token watermark table name. Spanner (GoogleSQL) identifiers must
+/// start with a letter, so the canonical `_faucet_commit_token` used by the
+/// other SQL sinks (`faucet_core::idempotency::COMMIT_TOKEN_TABLE`) is not a
+/// valid Spanner table name — this sink drops the leading underscore.
+pub(crate) const SPANNER_COMMIT_TOKEN_TABLE: &str = "faucet_commit_token";
+
+/// DDL for the commit-token watermark table (exactly-once). `updated_at` is a
+/// commit-timestamp column so replays are debuggable without a clock source.
+fn commit_token_ddl() -> String {
+    format!(
+        "CREATE TABLE IF NOT EXISTS {t} ({s} STRING(MAX) NOT NULL, {k} STRING(MAX) NOT NULL, \
+         updated_at TIMESTAMP OPTIONS (allow_commit_timestamp=true)) PRIMARY KEY ({s})",
+        t = quote_ident_spanner(SPANNER_COMMIT_TOKEN_TABLE),
+        s = quote_ident_spanner(faucet_core::idempotency::COMMIT_TOKEN_SCOPE_COL),
+        k = quote_ident_spanner(faucet_core::idempotency::COMMIT_TOKEN_TOKEN_COL),
+    )
+}
+
+/// Render cached metadata as the `infer_schema`-shaped object
+/// (`{"type":"object","properties":{…}}`) the drift pass diffs against.
+fn current_schema_json(meta: &TableMeta) -> Value {
+    let mut props = serde_json::Map::new();
+    for (name, ty, nullable) in &meta.columns {
+        props.insert(name.clone(), spanner_type_to_json_schema(ty, *nullable));
+    }
+    serde_json::json!({ "type": "object", "properties": props })
+}
+
+fn sink_err(context: &str, e: impl std::fmt::Display) -> FaucetError {
+    FaucetError::Sink(format!("spanner {context}: {e}"))
+}
+
+/// A sink that writes JSON records to a Cloud Spanner table.
+pub struct SpannerSink {
+    config: SpannerSinkConfig,
+    client: Client,
+    /// Cached table metadata; `None` until first use, cleared by
+    /// [`evolve_schema`](faucet_core::Sink::evolve_schema).
+    meta: tokio::sync::RwLock<Option<Arc<TableMeta>>>,
+    /// One-shot commit-token-table creation guard.
+    token_table_ready: tokio::sync::OnceCell<()>,
+    /// Record fields already warned-about as having no matching column.
+    warned_fields: std::sync::Mutex<HashSet<String>>,
+}
+
+impl SpannerSink {
+    /// Create a new Spanner sink. Validates the config and builds the client
+    /// (session pool). Table metadata is read lazily on first write.
+    pub async fn new(config: SpannerSinkConfig) -> Result<Self, FaucetError> {
+        config.validate()?;
+        let client = config.connection.connect().await?;
+        Ok(Self {
+            config,
+            client,
+            meta: tokio::sync::RwLock::new(None),
+            token_table_ready: tokio::sync::OnceCell::new(),
+            warned_fields: std::sync::Mutex::new(HashSet::new()),
+        })
+    }
+
+    /// Read `(columns, pk)` for the target table from `INFORMATION_SCHEMA`.
+    /// Returns `Ok(None)` when the table does not exist.
+    async fn fetch_meta(&self) -> Result<Option<TableMeta>, FaucetError> {
+        let mut columns: Vec<(String, SpannerType, bool)> = Vec::new();
+        {
+            let mut tx = self
+                .client
+                .single()
+                .await
+                .map_err(|e| sink_err("metadata read", e))?;
+            let mut stmt = Statement::new(
+                "SELECT c.COLUMN_NAME AS name, c.SPANNER_TYPE AS spanner_type, \
+                 c.IS_NULLABLE AS is_nullable FROM INFORMATION_SCHEMA.COLUMNS c \
+                 WHERE c.TABLE_SCHEMA = '' AND c.TABLE_NAME = @table \
+                 ORDER BY c.ORDINAL_POSITION",
+            );
+            stmt.add_param("table", &self.config.table_name);
+            let mut iter = tx
+                .query(stmt)
+                .await
+                .map_err(|e| sink_err("metadata query", e))?;
+            while let Some(row) = iter
+                .next()
+                .await
+                .map_err(|e| sink_err("metadata read", e))?
+            {
+                let name = row
+                    .column_by_name::<String>("name")
+                    .map_err(|e| sink_err("metadata decode", e))?;
+                let ty = row
+                    .column_by_name::<String>("spanner_type")
+                    .map_err(|e| sink_err("metadata decode", e))?;
+                let nullable = row
+                    .column_by_name::<String>("is_nullable")
+                    .map_err(|e| sink_err("metadata decode", e))?;
+                columns.push((name, parse_spanner_type(&ty), nullable == "YES"));
+            }
+        }
+        if columns.is_empty() {
+            return Ok(None);
+        }
+
+        let mut pk: Vec<String> = Vec::new();
+        {
+            let mut tx = self
+                .client
+                .single()
+                .await
+                .map_err(|e| sink_err("metadata read", e))?;
+            let mut stmt = Statement::new(
+                "SELECT ic.COLUMN_NAME AS name FROM INFORMATION_SCHEMA.INDEX_COLUMNS ic \
+                 WHERE ic.TABLE_SCHEMA = '' AND ic.TABLE_NAME = @table \
+                 AND ic.INDEX_NAME = 'PRIMARY_KEY' ORDER BY ic.ORDINAL_POSITION",
+            );
+            stmt.add_param("table", &self.config.table_name);
+            let mut iter = tx
+                .query(stmt)
+                .await
+                .map_err(|e| sink_err("primary-key query", e))?;
+            while let Some(row) = iter
+                .next()
+                .await
+                .map_err(|e| sink_err("primary-key read", e))?
+            {
+                pk.push(
+                    row.column_by_name::<String>("name")
+                        .map_err(|e| sink_err("primary-key decode", e))?,
+                );
+            }
+        }
+        Ok(Some(TableMeta { columns, pk }))
+    }
+
+    /// Cached metadata, fetched on first use. Errors when the table is absent
+    /// — every caller here is a write path that requires it.
+    async fn require_meta(&self) -> Result<Arc<TableMeta>, FaucetError> {
+        if let Some(meta) = self.meta.read().await.as_ref() {
+            return Ok(Arc::clone(meta));
+        }
+        let mut slot = self.meta.write().await;
+        // Another writer may have raced us here.
+        if let Some(meta) = slot.as_ref() {
+            return Ok(Arc::clone(meta));
+        }
+        let fetched = self.fetch_meta().await?.ok_or_else(|| {
+            FaucetError::Sink(format!(
+                "spanner table `{}` does not exist in {}",
+                self.config.table_name,
+                self.config.connection.database_path()
+            ))
+        })?;
+        let arc = Arc::new(fetched);
+        *slot = Some(Arc::clone(&arc));
+        Ok(arc)
+    }
+
+    /// Plan the whole page into mutations (mode-aware). Returns the planned
+    /// mutations and the written-row count, or the first failure.
+    fn plan_page(
+        &self,
+        records: &[Value],
+        meta: &TableMeta,
+    ) -> Result<(Vec<Planned>, usize), FaucetError> {
+        let table = &self.config.table_name;
+        let mut warned = self
+            .warned_fields
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+        if matches!(self.config.write.write_mode, faucet_core::WriteMode::Append) {
+            let mut planned = Vec::with_capacity(records.len());
+            for (idx, record) in records.iter().enumerate() {
+                let p = build_row_mutation(table, record, meta, WriteOp::Insert, &mut warned)
+                    .map_err(|msg| {
+                        FaucetError::Sink(format!("spanner append: row {idx}: {msg}"))
+                    })?;
+                planned.push(p);
+            }
+            let count = planned.len();
+            return Ok((planned, count));
+        }
+
+        validate_key_matches_pk(&self.config.write.key, &meta.pk, table)?;
+        let plan = faucet_core::plan_writes(records, &self.config.write);
+        if let Some((idx, msg)) = plan.failed.first() {
+            return Err(FaucetError::Sink(format!(
+                "spanner {}: row {idx}: {msg}",
+                self.config.write.write_mode.as_str()
+            )));
+        }
+        let mut planned = Vec::with_capacity(plan.upserts.len() + plan.deletes.len());
+        for record in &plan.upserts {
+            let p = build_row_mutation(table, record, meta, WriteOp::InsertOrUpdate, &mut warned)
+                .map_err(|msg| FaucetError::Sink(format!("spanner upsert: {msg}")))?;
+            planned.push(p);
+        }
+        for key_tuple in &plan.deletes {
+            let p = build_delete_mutation(table, key_tuple, meta)
+                .map_err(|msg| FaucetError::Sink(format!("spanner delete: {msg}")))?;
+            planned.push(p);
+        }
+        let count = planned.len();
+        Ok((planned, count))
+    }
+
+    /// Run DDL statements through the admin API, bounded by
+    /// `ddl_timeout_secs`.
+    async fn run_ddl(&self, statements: Vec<String>) -> Result<(), FaucetError> {
+        let admin = self.config.connection.connect_admin().await?;
+        let mut op = admin
+            .database()
+            .update_database_ddl(
+                UpdateDatabaseDdlRequest {
+                    database: self.config.connection.database_path(),
+                    statements,
+                    ..Default::default()
+                },
+                None,
+            )
+            .await
+            .map_err(|e| sink_err("DDL submit", e))?;
+        let timeout = Duration::from_secs(self.config.ddl_timeout_secs);
+        match tokio::time::timeout(timeout, op.wait(None)).await {
+            Ok(Ok(_)) => Ok(()),
+            Ok(Err(e)) => Err(sink_err("DDL operation", e)),
+            Err(_) => Err(FaucetError::Sink(format!(
+                "spanner DDL operation did not complete within {}s (ddl_timeout_secs)",
+                self.config.ddl_timeout_secs
+            ))),
+        }
+    }
+
+    /// Ensure the commit-token watermark table exists (once per sink).
+    async fn ensure_token_table(&self) -> Result<(), FaucetError> {
+        self.token_table_ready
+            .get_or_try_init(|| async { self.run_ddl(vec![commit_token_ddl()]).await })
+            .await?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl faucet_core::Sink for SpannerSink {
+    fn config_schema(&self) -> Value {
+        serde_json::to_value(faucet_core::schema_for!(SpannerSinkConfig))
+            .expect("schema serialization")
+    }
+
+    fn connector_name(&self) -> &'static str {
+        "spanner"
+    }
+
+    fn supported_write_modes(&self) -> &'static [faucet_core::WriteMode] {
+        &[
+            faucet_core::WriteMode::Append,
+            faucet_core::WriteMode::Upsert,
+            faucet_core::WriteMode::Delete,
+        ]
+    }
+
+    fn dedups_by_key(&self) -> bool {
+        self.config.write.dedups_by_key()
+    }
+
+    fn supports_schema_evolution(&self) -> bool {
+        true
+    }
+
+    /// Read the live destination schema from `INFORMATION_SCHEMA` as an
+    /// `infer_schema`-shaped object, or `None` when the table does not exist
+    /// yet (issue #194). Always fetches fresh — the drift pass caches on its
+    /// side and refreshes after `evolve`.
+    async fn current_schema(&self) -> Result<Option<Value>, FaucetError> {
+        Ok(self.fetch_meta().await?.map(|m| current_schema_json(&m)))
+    }
+
+    /// Apply additive schema evolution: new columns via `ADD COLUMN IF NOT
+    /// EXISTS`; nullability relaxations by re-emitting the column at its
+    /// current type without `NOT NULL`. Spanner cannot change a column's base
+    /// type (e.g. INT64→FLOAT64), so a base-type widening is a typed error —
+    /// set `allow_type_widening: false` so the drift policy classifies it
+    /// `incompatible` and routes it via `on_incompatible` instead.
+    async fn evolve_schema(
+        &self,
+        evolution: &faucet_core::SchemaEvolution,
+    ) -> Result<(), FaucetError> {
+        let table = &self.config.table_name;
+        let mut statements: Vec<String> = Vec::new();
+
+        for c in &evolution.additions {
+            let t =
+                faucet_core::json_schema_base_type(&c.to).unwrap_or(faucet_core::SqlBaseType::Text);
+            statements.push(build_add_column_sql(table, &c.name, t));
+        }
+
+        // Widenings: Spanner can only "widen" nullability. A widening whose
+        // base type actually changes is unsupported.
+        let meta = if evolution.widenings.is_empty() && evolution.relax_nullability.is_empty() {
+            None
+        } else {
+            Some(self.require_meta().await?)
+        };
+        for c in &evolution.widenings {
+            let from_base = c.from.as_ref().and_then(faucet_core::json_schema_base_type);
+            let to_base = faucet_core::json_schema_base_type(&c.to);
+            if from_base != to_base {
+                return Err(FaucetError::Sink(format!(
+                    "spanner cannot widen column `{}`'s base type ({:?} -> {:?}): Spanner does \
+                     not support changing a column's type; set `allow_type_widening: false` so \
+                     the drift policy treats this as incompatible",
+                    c.name, from_base, to_base
+                )));
+            }
+            let meta = meta.as_ref().expect("meta fetched when widenings present");
+            let ty = meta.type_of(&c.name).ok_or_else(|| {
+                FaucetError::Sink(format!(
+                    "spanner widen: column `{}` not found in table `{table}`",
+                    c.name
+                ))
+            })?;
+            let ddl = spanner_type_ddl(ty).map_err(|e| {
+                FaucetError::Sink(format!("spanner widen column `{}`: {e}", c.name))
+            })?;
+            statements.push(build_alter_column_sql(table, &c.name, &ddl));
+        }
+        for col in &evolution.relax_nullability {
+            let meta = meta
+                .as_ref()
+                .expect("meta fetched when relaxations present");
+            let ty = meta.type_of(col).ok_or_else(|| {
+                FaucetError::Sink(format!(
+                    "spanner relax: column `{col}` not found in table `{table}`"
+                ))
+            })?;
+            let ddl = spanner_type_ddl(ty)
+                .map_err(|e| FaucetError::Sink(format!("spanner relax column `{col}`: {e}")))?;
+            statements.push(build_alter_column_sql(table, col, &ddl));
+        }
+
+        if !statements.is_empty() {
+            self.run_ddl(statements).await?;
+            // The table changed shape — drop the cached metadata.
+            *self.meta.write().await = None;
+        }
+        Ok(())
+    }
+
+    fn dataset_uri(&self) -> String {
+        format!(
+            "spanner://{}/{}/{}/{}",
+            self.config.connection.project_id,
+            self.config.connection.instance,
+            self.config.connection.database,
+            self.config.table_name
+        )
+    }
+
+    /// Preflight probes (`faucet doctor`): `auth` runs `SELECT 1`; `schema`
+    /// verifies the target table exists and — for upsert/delete — that the
+    /// configured `key` equals the table's PRIMARY KEY. Non-mutating.
+    async fn check(
+        &self,
+        ctx: &faucet_core::check::CheckContext,
+    ) -> Result<faucet_core::check::CheckReport, FaucetError> {
+        use faucet_core::check::{CheckReport, Probe};
+
+        let started = std::time::Instant::now();
+        let select_one = async {
+            let mut tx = self.client.single().await.map_err(|e| e.to_string())?;
+            let mut iter = tx
+                .query(Statement::new("SELECT 1"))
+                .await
+                .map_err(|e| e.to_string())?;
+            iter.next().await.map_err(|e| e.to_string())?;
+            Ok::<(), String>(())
+        };
+        let auth = match tokio::time::timeout(ctx.timeout, select_one).await {
+            Ok(Ok(())) => Probe::pass("auth", started.elapsed()),
+            Ok(Err(e)) => Probe::fail_hint(
+                "auth",
+                started.elapsed(),
+                e,
+                "check project/instance/database and credentials",
+            ),
+            Err(_) => Probe::fail_hint(
+                "auth",
+                started.elapsed(),
+                "timed out",
+                "check project/instance/database and credentials",
+            ),
+        };
+
+        let started = std::time::Instant::now();
+        let schema = match tokio::time::timeout(ctx.timeout, self.fetch_meta()).await {
+            Ok(Ok(Some(meta))) => {
+                if matches!(self.config.write.write_mode, faucet_core::WriteMode::Append) {
+                    Probe::pass("schema", started.elapsed())
+                } else {
+                    match validate_key_matches_pk(
+                        &self.config.write.key,
+                        &meta.pk,
+                        &self.config.table_name,
+                    ) {
+                        Ok(()) => Probe::pass("schema", started.elapsed()),
+                        Err(e) => Probe::fail_hint(
+                            "schema",
+                            started.elapsed(),
+                            e.to_string(),
+                            "set `key` to exactly the table's PRIMARY KEY columns",
+                        ),
+                    }
+                }
+            }
+            Ok(Ok(None)) => Probe::fail_hint(
+                "schema",
+                started.elapsed(),
+                format!("table `{}` does not exist", self.config.table_name),
+                "create the table (Spanner mutations require an existing table)",
+            ),
+            Ok(Err(e)) => Probe::fail("schema", started.elapsed(), e.to_string()),
+            Err(_) => Probe::fail("schema", started.elapsed(), "timed out"),
+        };
+
+        Ok(CheckReport {
+            probes: vec![auth, schema],
+        })
+    }
+
+    /// Write records as batched mutations, one atomic commit per chunk
+    /// (`batch_size` rows and ≤60,000 cells per commit). Append mode uses
+    /// `Insert` (a duplicate PK fails the commit); upsert/delete are planned
+    /// via [`faucet_core::plan_writes`].
+    async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
+        if records.is_empty() {
+            return Ok(0);
+        }
+        let meta = self.require_meta().await?;
+        let (planned, count) = self.plan_page(records, &meta)?;
+        for chunk in chunk_by_cells(planned, self.config.batch_size, CELL_BUDGET) {
+            self.client
+                .apply(chunk)
+                .await
+                .map_err(|e| sink_err("commit", e))?;
+        }
+        tracing::info!(
+            table = %self.config.table_name,
+            rows = count,
+            "Spanner write complete"
+        );
+        Ok(count)
+    }
+
+    /// Write a batch and report per-row outcomes.
+    ///
+    /// Append mode delegates to `write_batch` (all-or-nothing per chunk). In
+    /// upsert/delete mode the good rows are applied and rows whose key could
+    /// not be extracted are reported as per-row `Err` so the pipeline routes
+    /// them to the DLQ.
+    async fn write_batch_partial(
+        &self,
+        records: &[Value],
+    ) -> Result<Vec<faucet_core::RowOutcome>, FaucetError> {
+        if matches!(self.config.write.write_mode, faucet_core::WriteMode::Append) {
+            self.write_batch(records).await?;
+            return Ok(records.iter().map(|_| Ok(())).collect());
+        }
+
+        let meta = self.require_meta().await?;
+        validate_key_matches_pk(&self.config.write.key, &meta.pk, &self.config.table_name)?;
+        let plan = faucet_core::plan_writes(records, &self.config.write);
+
+        let table = &self.config.table_name;
+        let mut planned: Vec<Planned> = Vec::with_capacity(plan.upserts.len() + plan.deletes.len());
+        {
+            let mut warned = self
+                .warned_fields
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            for record in &plan.upserts {
+                let p =
+                    build_row_mutation(table, record, &meta, WriteOp::InsertOrUpdate, &mut warned)
+                        .map_err(|msg| FaucetError::Sink(format!("spanner upsert: {msg}")))?;
+                planned.push(p);
+            }
+        }
+        for key_tuple in &plan.deletes {
+            let p = build_delete_mutation(table, key_tuple, &meta)
+                .map_err(|msg| FaucetError::Sink(format!("spanner delete: {msg}")))?;
+            planned.push(p);
+        }
+        for chunk in chunk_by_cells(planned, self.config.batch_size, CELL_BUDGET) {
+            self.client
+                .apply(chunk)
+                .await
+                .map_err(|e| sink_err("commit", e))?;
+        }
+
+        let mut outcomes: Vec<faucet_core::RowOutcome> = records.iter().map(|_| Ok(())).collect();
+        for (idx, msg) in &plan.failed {
+            outcomes[*idx] = Err(FaucetError::Sink(format!(
+                "spanner {}: {msg}",
+                self.config.write.write_mode.as_str()
+            )));
+        }
+        Ok(outcomes)
+    }
+
+    async fn flush(&self) -> Result<(), FaucetError> {
+        // Every commit is already durable; nothing is buffered client-side.
+        Ok(())
+    }
+
+    fn supports_idempotent_writes(&self) -> bool {
+        true
+    }
+
+    /// Read the last committed watermark token for `scope` from the
+    /// `faucet_commit_token` table. `Ok(None)` when the table (or row) does
+    /// not exist yet.
+    async fn last_committed_token(&self, scope: &str) -> Result<Option<String>, FaucetError> {
+        let mut tx = self
+            .client
+            .single()
+            .await
+            .map_err(|e| sink_err("token read", e))?;
+        let scope_key = scope.to_string();
+        match tx
+            .read_row(
+                SPANNER_COMMIT_TOKEN_TABLE,
+                &[faucet_core::idempotency::COMMIT_TOKEN_TOKEN_COL],
+                Key::new(&scope_key),
+            )
+            .await
+        {
+            Ok(Some(row)) => Ok(Some(
+                row.column_by_name::<String>(faucet_core::idempotency::COMMIT_TOKEN_TOKEN_COL)
+                    .map_err(|e| sink_err("token decode", e))?,
+            )),
+            Ok(None) => Ok(None),
+            // First exactly-once run: the watermark table hasn't been created
+            // yet — that's "no token", not an error.
+            Err(status) if status.code() == gcloud_gax::grpc::Code::NotFound => Ok(None),
+            Err(status)
+                if status.message().to_ascii_lowercase().contains("not found")
+                    || status.message().contains(SPANNER_COMMIT_TOKEN_TABLE) =>
+            {
+                Ok(None)
+            }
+            Err(status) => Err(sink_err("token read", status)),
+        }
+    }
+
+    /// Commit the page's mutations **and** the `(scope, token)` watermark in
+    /// one read-write transaction — on crash either both land or neither
+    /// does. The whole page is a single commit here (no re-chunking), so it
+    /// is bounded by Spanner's ~80,000-cell commit limit: size the source's
+    /// `batch_size` down for very wide tables.
+    async fn write_batch_idempotent(
+        &self,
+        records: &[Value],
+        scope: &str,
+        token: &str,
+    ) -> Result<usize, FaucetError> {
+        self.ensure_token_table().await?;
+        let meta = self.require_meta().await?;
+        // Plan before the transaction so planning failures abort cleanly.
+        let (planned, count) = self.plan_page(records, &meta)?;
+
+        let mut mutations: Vec<Mutation> = planned.into_iter().map(|p| p.mutation).collect();
+        let scope_owned = scope.to_string();
+        // The token may carry a `#<bookmark>` suffix — stored verbatim,
+        // never parsed.
+        let token_owned = token.to_string();
+        mutations.push(insert_or_update(
+            SPANNER_COMMIT_TOKEN_TABLE,
+            &[
+                faucet_core::idempotency::COMMIT_TOKEN_SCOPE_COL,
+                faucet_core::idempotency::COMMIT_TOKEN_TOKEN_COL,
+                "updated_at",
+            ],
+            &[&scope_owned, &token_owned, &CommitTimestamp::new()],
+        ));
+
+        // The closure retries on ABORTED and must not keep state between
+        // attempts — it clones the pre-built mutation set per attempt.
+        let mutations = Arc::new(mutations);
+        self.client
+            .read_write_transaction(move |tx| {
+                let mutations = Arc::clone(&mutations);
+                Box::pin(async move {
+                    tx.buffer_write(mutations.as_ref().clone());
+                    Ok::<(), gcloud_spanner::client::Error>(())
+                })
+            })
+            .await
+            .map_err(|e| sink_err("idempotent commit", e))?;
+        Ok(count)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use faucet_core::{WriteMode, WriteSpec};
+    use gcloud_googleapis::spanner::v1::mutation::Operation;
+    use serde_json::json;
+
+    fn meta() -> TableMeta {
+        TableMeta {
+            columns: vec![
+                ("id".into(), SpannerType::Int64, false),
+                ("name".into(), SpannerType::String, true),
+                ("score".into(), SpannerType::Float64, true),
+                ("meta".into(), SpannerType::Json, true),
+            ],
+            pk: vec!["id".into()],
+        }
+    }
+
+    fn composite_meta() -> TableMeta {
+        TableMeta {
+            columns: vec![
+                ("tenant".into(), SpannerType::String, false),
+                ("id".into(), SpannerType::Int64, false),
+                ("v".into(), SpannerType::String, true),
+            ],
+            pk: vec!["tenant".into(), "id".into()],
+        }
+    }
+
+    fn write_columns(m: &Mutation) -> Vec<String> {
+        match m.operation.as_ref().expect("operation") {
+            Operation::Insert(w) | Operation::InsertOrUpdate(w) => w.columns.clone(),
+            other => panic!("expected write mutation, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn row_mutation_intersects_columns_and_encodes() {
+        let mut warned = HashSet::new();
+        let p = build_row_mutation(
+            "t",
+            &json!({"id": 1, "name": "a", "unknown": true}),
+            &meta(),
+            WriteOp::Insert,
+            &mut warned,
+        )
+        .unwrap();
+        assert_eq!(p.cells, 2);
+        assert_eq!(write_columns(&p.mutation), vec!["id", "name"]);
+        // Unknown field warned exactly once.
+        assert!(warned.contains("unknown"));
+        // A second record with the same unknown field doesn't re-insert.
+        let before = warned.len();
+        build_row_mutation(
+            "t",
+            &json!({"id": 2, "unknown": false}),
+            &meta(),
+            WriteOp::Insert,
+            &mut warned,
+        )
+        .unwrap();
+        assert_eq!(warned.len(), before);
+    }
+
+    #[test]
+    fn row_mutation_rejects_non_objects_and_no_matches() {
+        let mut warned = HashSet::new();
+        assert!(
+            build_row_mutation("t", &json!([1]), &meta(), WriteOp::Insert, &mut warned)
+                .unwrap_err()
+                .contains("not a JSON object")
+        );
+        assert!(
+            build_row_mutation(
+                "t",
+                &json!({"nope": 1}),
+                &meta(),
+                WriteOp::Insert,
+                &mut warned
+            )
+            .unwrap_err()
+            .contains("no fields matching")
+        );
+    }
+
+    #[test]
+    fn row_mutation_surfaces_encode_errors_with_column_name() {
+        let mut warned = HashSet::new();
+        let err = build_row_mutation(
+            "t",
+            &json!({"id": "not-an-int-at-all"}),
+            &meta(),
+            WriteOp::Insert,
+            &mut warned,
+        )
+        .unwrap_err();
+        assert!(err.contains("column `id`"), "err: {err}");
+    }
+
+    #[test]
+    fn upsert_op_builds_insert_or_update() {
+        let mut warned = HashSet::new();
+        let p = build_row_mutation(
+            "t",
+            &json!({"id": 1}),
+            &meta(),
+            WriteOp::InsertOrUpdate,
+            &mut warned,
+        )
+        .unwrap();
+        assert!(matches!(
+            p.mutation.operation,
+            Some(Operation::InsertOrUpdate(_))
+        ));
+    }
+
+    #[test]
+    fn delete_mutation_reorders_keys_into_pk_order() {
+        // WriteSpec key order differs from PK order.
+        let kt = faucet_core::KeyTuple(vec![
+            ("id".into(), json!(7)),
+            ("tenant".into(), json!("acme")),
+        ]);
+        let p = build_delete_mutation("t", &kt, &composite_meta()).unwrap();
+        assert_eq!(p.cells, 2);
+        let Some(Operation::Delete(d)) = &p.mutation.operation else {
+            panic!("expected delete");
+        };
+        let keys = &d.key_set.as_ref().expect("key set").keys;
+        assert_eq!(keys.len(), 1);
+        // PK order is (tenant, id) — first value must be the tenant string.
+        let vals = &keys[0].values;
+        assert_eq!(
+            vals[0].kind,
+            Some(prost_types::value::Kind::StringValue("acme".into()))
+        );
+        assert_eq!(
+            vals[1].kind,
+            Some(prost_types::value::Kind::StringValue("7".into()))
+        );
+    }
+
+    #[test]
+    fn delete_mutation_errors_on_missing_pk_column() {
+        let kt = faucet_core::KeyTuple(vec![("id".into(), json!(7))]);
+        let err = build_delete_mutation("t", &kt, &composite_meta()).unwrap_err();
+        assert!(err.contains("missing PK column `tenant`"));
+    }
+
+    fn planned(cells: usize) -> Planned {
+        Planned {
+            mutation: insert("t", &["a"], &[&"x".to_string()]),
+            cells,
+        }
+    }
+
+    #[test]
+    fn chunking_respects_cell_budget() {
+        let chunks = chunk_by_cells(vec![planned(40), planned(40), planned(40)], 0, 100);
+        assert_eq!(chunks.iter().map(Vec::len).collect::<Vec<_>>(), vec![2, 1]);
+    }
+
+    #[test]
+    fn chunking_respects_row_cap() {
+        let chunks = chunk_by_cells((0..5).map(|_| planned(1)).collect(), 2, 1000);
+        assert_eq!(
+            chunks.iter().map(Vec::len).collect::<Vec<_>>(),
+            vec![2, 2, 1]
+        );
+    }
+
+    #[test]
+    fn chunking_lets_an_oversized_row_ship_alone() {
+        let chunks = chunk_by_cells(vec![planned(500), planned(1)], 0, 100);
+        assert_eq!(chunks.iter().map(Vec::len).collect::<Vec<_>>(), vec![1, 1]);
+    }
+
+    #[test]
+    fn chunking_zero_batch_size_is_cell_bounded_only() {
+        let chunks = chunk_by_cells((0..100).map(|_| planned(1)).collect(), 0, 1000);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].len(), 100);
+    }
+
+    #[test]
+    fn chunking_empty_input_is_empty() {
+        assert!(chunk_by_cells(vec![], 10, 100).is_empty());
+    }
+
+    #[test]
+    fn key_pk_validation_is_order_insensitive_set_equality() {
+        let key = vec!["id".to_string(), "tenant".to_string()];
+        let pk = vec!["tenant".to_string(), "id".to_string()];
+        assert!(validate_key_matches_pk(&key, &pk, "t").is_ok());
+        let err = validate_key_matches_pk(&["id".to_string()], &pk, "t").unwrap_err();
+        assert!(err.to_string().contains("PRIMARY KEY"));
+        assert!(matches!(err, FaucetError::Config(_)));
+    }
+
+    #[test]
+    fn add_column_ddl() {
+        assert_eq!(
+            build_add_column_sql("t", "email", faucet_core::SqlBaseType::Text),
+            "ALTER TABLE `t` ADD COLUMN IF NOT EXISTS `email` STRING(MAX)"
+        );
+        assert_eq!(
+            build_add_column_sql("t", "n", faucet_core::SqlBaseType::Integer),
+            "ALTER TABLE `t` ADD COLUMN IF NOT EXISTS `n` INT64"
+        );
+        assert_eq!(
+            build_add_column_sql("t", "j", faucet_core::SqlBaseType::Json),
+            "ALTER TABLE `t` ADD COLUMN IF NOT EXISTS `j` JSON"
+        );
+    }
+
+    #[test]
+    fn alter_column_ddl_reemits_type_without_not_null() {
+        assert_eq!(
+            build_alter_column_sql("t", "name", "STRING(MAX)"),
+            "ALTER TABLE `t` ALTER COLUMN `name` STRING(MAX)"
+        );
+    }
+
+    #[test]
+    fn spanner_type_ddl_round_trips() {
+        assert_eq!(spanner_type_ddl(&SpannerType::Int64).unwrap(), "INT64");
+        assert_eq!(
+            spanner_type_ddl(&SpannerType::Array(Box::new(SpannerType::Float64))).unwrap(),
+            "ARRAY<FLOAT64>"
+        );
+        assert_eq!(spanner_type_ddl(&SpannerType::Bytes).unwrap(), "BYTES(MAX)");
+        assert!(spanner_type_ddl(&SpannerType::Other).is_err());
+    }
+
+    #[test]
+    fn commit_token_ddl_shape() {
+        let ddl = commit_token_ddl();
+        assert!(ddl.contains("CREATE TABLE IF NOT EXISTS `faucet_commit_token`"));
+        assert!(ddl.contains("`scope` STRING(MAX) NOT NULL"));
+        assert!(ddl.contains("`token` STRING(MAX) NOT NULL"));
+        assert!(ddl.contains("allow_commit_timestamp=true"));
+        assert!(ddl.ends_with("PRIMARY KEY (`scope`)"));
+    }
+
+    #[test]
+    fn current_schema_json_shape() {
+        let schema = current_schema_json(&meta());
+        assert_eq!(schema["type"], "object");
+        assert_eq!(schema["properties"]["id"]["type"], "integer");
+        assert_eq!(
+            schema["properties"]["name"]["type"],
+            json!(["string", "null"])
+        );
+        assert_eq!(
+            schema["properties"]["score"]["type"],
+            json!(["number", "null"])
+        );
+    }
+
+    #[test]
+    fn table_meta_lookups() {
+        let m = meta();
+        assert!(m.has_column("id"));
+        assert!(!m.has_column("missing"));
+        assert_eq!(m.type_of("score"), Some(&SpannerType::Float64));
+        assert_eq!(m.type_of("missing"), None);
+    }
+
+    /// Offline plan_page coverage through a sink built without a server —
+    /// exercised via the pure helpers instead (plan_page requires a client).
+    #[test]
+    fn write_spec_key_reorder_composite_delete_encodes_types() {
+        let kt = faucet_core::KeyTuple(vec![
+            ("tenant".into(), json!("t1")),
+            ("id".into(), json!(9_007_199_254_740_993_i64)),
+        ]);
+        let p = build_delete_mutation("t", &kt, &composite_meta()).unwrap();
+        let Some(Operation::Delete(d)) = &p.mutation.operation else {
+            panic!("expected delete");
+        };
+        let vals = &d.key_set.as_ref().unwrap().keys[0].values;
+        // INT64 keys travel string-encoded, losslessly.
+        assert_eq!(
+            vals[1].kind,
+            Some(prost_types::value::Kind::StringValue(
+                "9007199254740993".into()
+            ))
+        );
+    }
+
+    #[test]
+    fn plan_writes_integration_with_write_spec() {
+        // Sanity: plan_writes + our builders compose (dedup by key, delete marker).
+        let spec = WriteSpec {
+            write_mode: WriteMode::Upsert,
+            key: vec!["id".into()],
+            delete_marker: Some(faucet_core::DeleteMarker {
+                field: "__op".into(),
+                values: vec!["d".into()],
+            }),
+        };
+        let page = vec![
+            json!({"id": 1, "name": "a"}),
+            json!({"id": 1, "name": "b"}),
+            json!({"id": 2, "__op": "d"}),
+            json!({"name": "no-key"}),
+        ];
+        let plan = faucet_core::plan_writes(&page, &spec);
+        assert_eq!(plan.upserts.len(), 1); // last-write-wins dedup
+        assert_eq!(plan.deletes.len(), 1);
+        assert_eq!(plan.failed.len(), 1);
+        let mut warned = HashSet::new();
+        for u in &plan.upserts {
+            build_row_mutation("t", u, &meta(), WriteOp::InsertOrUpdate, &mut warned).unwrap();
+        }
+        for d in &plan.deletes {
+            build_delete_mutation("t", d, &meta()).unwrap();
+        }
+    }
+}

--- a/crates/sink/spanner/tests/conformance.rs
+++ b/crates/sink/spanner/tests/conformance.rs
@@ -1,0 +1,72 @@
+//! `faucet-conformance` battery against the real Spanner sink (via the Cloud
+//! Spanner emulator).
+//!
+//! - check 1 `assert_config_schema_valid_value` (offline);
+//! - check 4 `assert_idempotent_replay` — the atomic-watermark path
+//!   (`write_batch_idempotent` + `faucet_commit_token`);
+//! - check 5 `assert_capabilities_truthful` — Append works, the idempotency
+//!   mechanism dedups, and `evolve_schema` is callable.
+//!
+//! Checks 4–5 require Docker (the emulator via testcontainers).
+
+mod support;
+
+use faucet_conformance::assert_config_schema_valid_value;
+use faucet_core::{WriteMode, WriteSpec};
+use faucet_sink_spanner::{SpannerSink, SpannerSinkConfig};
+
+#[test]
+fn conformance_config_schema_valid() {
+    // Check 1: config schema is structurally valid JSON Schema.
+    let schema =
+        serde_json::to_value(schemars::schema_for!(SpannerSinkConfig)).expect("schema to value");
+    assert_config_schema_valid_value(&schema, "spanner");
+}
+
+/// A fresh database + upsert-configured sink (key = PK), mirroring the
+/// postgres conformance setup.
+async fn fresh_sink(database: &str) -> SpannerSink {
+    let conn = support::create_database(
+        database,
+        vec!["CREATE TABLE t (id INT64 NOT NULL, v STRING(MAX)) PRIMARY KEY (id)".to_string()],
+    )
+    .await;
+    let mut cfg = SpannerSinkConfig::new(
+        conn.project_id.clone(),
+        conn.instance.clone(),
+        conn.database.clone(),
+        "t",
+    )
+    .with_batch_size(0);
+    cfg.connection.emulator_host = conn.emulator_host.clone();
+    cfg.write = WriteSpec {
+        write_mode: WriteMode::Upsert,
+        key: vec!["id".to_string()],
+        delete_marker: None,
+    };
+    SpannerSink::new(cfg).await.expect("sink")
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn conformance_idempotent_replay() {
+    // Check 4: re-delivering committed rows leaves no duplicates.
+    let sink = fresh_sink("conf-idem").await;
+    let conn = support::connection("conf-idem", &support::emulator_host().await);
+    faucet_conformance::assert_idempotent_replay(&sink, || {
+        let conn = conn.clone();
+        async move { support::count_rows(&conn, "t").await }
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn conformance_capabilities_truthful() {
+    // Check 5: advertised capabilities match real behaviour.
+    let sink = fresh_sink("conf-caps").await;
+    let conn = support::connection("conf-caps", &support::emulator_host().await);
+    faucet_conformance::assert_capabilities_truthful(&sink, || {
+        let conn = conn.clone();
+        async move { support::count_rows(&conn, "t").await }
+    })
+    .await;
+}

--- a/crates/sink/spanner/tests/emulator.rs
+++ b/crates/sink/spanner/tests/emulator.rs
@@ -1,0 +1,369 @@
+//! Integration tests against the Cloud Spanner emulator (Docker via
+//! testcontainers). One shared emulator per test binary; one database per
+//! test.
+
+mod support;
+
+use faucet_core::{DeleteMarker, FaucetError, Sink, WriteMode, WriteSpec};
+use faucet_sink_spanner::{SpannerSink, SpannerSinkConfig};
+use gcloud_spanner::statement::Statement;
+use serde_json::json;
+
+const TABLE_DDL: &str = "CREATE TABLE t (id INT64 NOT NULL, v STRING(MAX), score FLOAT64, \
+                         ok BOOL, meta JSON, tags ARRAY<INT64>) PRIMARY KEY (id)";
+
+async fn sink_for(
+    database: &str,
+    write: WriteSpec,
+) -> (SpannerSink, faucet_common_spanner::SpannerConnection) {
+    let conn = support::create_database(database, vec![TABLE_DDL.to_string()]).await;
+    let mut cfg = SpannerSinkConfig::new(
+        conn.project_id.clone(),
+        conn.instance.clone(),
+        conn.database.clone(),
+        "t",
+    );
+    cfg.connection.emulator_host = conn.emulator_host.clone();
+    cfg.write = write;
+    (SpannerSink::new(cfg).await.expect("sink"), conn)
+}
+
+fn append_spec() -> WriteSpec {
+    WriteSpec::default()
+}
+
+fn upsert_spec() -> WriteSpec {
+    WriteSpec {
+        write_mode: WriteMode::Upsert,
+        key: vec!["id".to_string()],
+        delete_marker: None,
+    }
+}
+
+async fn fetch_row(
+    conn: &faucet_common_spanner::SpannerConnection,
+    id: i64,
+) -> Option<serde_json::Value> {
+    let client = conn.connect().await.expect("client");
+    let mut tx = client.single().await.expect("txn");
+    let mut stmt = Statement::new("SELECT * FROM t WHERE id = @id");
+    stmt.add_param("id", &id);
+    let mut iter = tx.query(stmt).await.expect("query");
+    let row = iter.next().await.expect("row read")?;
+    let fields = iter.columns_metadata().clone();
+    Some(faucet_common_spanner::decode::row_to_json(&row, &fields).expect("decode"))
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn append_round_trips_all_types() {
+    let (sink, conn) = sink_for("em-append", append_spec()).await;
+    let written = sink
+        .write_batch(&[json!({
+            "id": 9_007_199_254_740_993_i64,
+            "v": "hello",
+            "score": 1.5,
+            "ok": true,
+            "meta": {"a": [1, 2]},
+            "tags": [1, 2, 3],
+            "not_a_column": "dropped-with-warning"
+        })])
+        .await
+        .expect("write");
+    assert_eq!(written, 1);
+
+    let row = fetch_row(&conn, 9_007_199_254_740_993_i64)
+        .await
+        .expect("row");
+    assert_eq!(row["id"], json!(9_007_199_254_740_993_i64));
+    assert_eq!(row["v"], json!("hello"));
+    assert_eq!(row["score"], json!(1.5));
+    assert_eq!(row["ok"], json!(true));
+    assert_eq!(row["meta"], json!({"a": [1, 2]}));
+    assert_eq!(row["tags"], json!([1, 2, 3]));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn append_duplicate_pk_fails_the_batch() {
+    let (sink, _conn) = sink_for("em-appdup", append_spec()).await;
+    sink.write_batch(&[json!({"id": 1, "v": "a"})])
+        .await
+        .expect("first");
+    let err = sink
+        .write_batch(&[json!({"id": 1, "v": "b"})])
+        .await
+        .expect_err("duplicate insert must fail");
+    assert!(matches!(err, FaucetError::Sink(_)));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn upsert_converges_duplicates() {
+    let (sink, conn) = sink_for("em-upsert", upsert_spec()).await;
+    sink.write_batch(&[json!({"id": 1, "v": "first"}), json!({"id": 2, "v": "two"})])
+        .await
+        .expect("page 1");
+    // Redelivery + change: converges, no duplicates.
+    sink.write_batch(&[json!({"id": 1, "v": "second"})])
+        .await
+        .expect("page 2");
+    assert_eq!(support::count_rows(&conn, "t").await, 2);
+    let row = fetch_row(&conn, 1).await.expect("row");
+    assert_eq!(row["v"], json!("second"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_marker_strips_marker_and_deletes() {
+    let (sink, conn) = sink_for(
+        "em-delmark",
+        WriteSpec {
+            write_mode: WriteMode::Upsert,
+            key: vec!["id".to_string()],
+            delete_marker: Some(DeleteMarker {
+                field: "__op".into(),
+                values: vec!["d".into()],
+            }),
+        },
+    )
+    .await;
+    sink.write_batch(&[json!({"id": 1, "v": "keep"}), json!({"id": 2, "v": "gone"})])
+        .await
+        .expect("seed");
+    sink.write_batch(&[
+        json!({"id": 2, "__op": "d"}),
+        json!({"id": 3, "v": "new", "__op": "u"}),
+    ])
+    .await
+    .expect("mixed page");
+    assert_eq!(support::count_rows(&conn, "t").await, 2);
+    assert!(fetch_row(&conn, 2).await.is_none());
+    // The marker field never lands as a column (and isn't a column here anyway).
+    let row = fetch_row(&conn, 3).await.expect("row 3");
+    assert_eq!(row["v"], json!("new"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn write_batch_partial_reports_failed_rows() {
+    let (sink, conn) = sink_for("em-partial", upsert_spec()).await;
+    let outcomes = sink
+        .write_batch_partial(&[
+            json!({"id": 1, "v": "ok"}),
+            json!({"v": "missing key"}),
+            json!({"id": 3, "v": "ok"}),
+        ])
+        .await
+        .expect("partial write");
+    assert_eq!(outcomes.len(), 3);
+    assert!(outcomes[0].is_ok());
+    assert!(outcomes[1].is_err());
+    assert!(outcomes[2].is_ok());
+    assert_eq!(support::count_rows(&conn, "t").await, 2);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn exactly_once_persists_data_and_token_atomically() {
+    let (sink, conn) = sink_for("em-eo", upsert_spec()).await;
+    let scope = "pipeline::row";
+
+    // No token before the first write (the watermark table doesn't exist yet).
+    assert_eq!(
+        sink.last_committed_token(scope).await.expect("token pre"),
+        None
+    );
+
+    let t1 = faucet_core::format_token(1);
+    let written = sink
+        .write_batch_idempotent(
+            &[json!({"id": 1, "v": "a"}), json!({"id": 2, "v": "b"})],
+            scope,
+            &t1,
+        )
+        .await
+        .expect("idempotent write");
+    assert_eq!(written, 2);
+    assert_eq!(support::count_rows(&conn, "t").await, 2);
+    assert_eq!(
+        sink.last_committed_token(scope).await.expect("token"),
+        Some(t1.clone())
+    );
+
+    // A token with a bookmark suffix is stored verbatim, never parsed.
+    let t2 = format!("{}#{{\"pos\":42}}", faucet_core::format_token(2));
+    sink.write_batch_idempotent(&[json!({"id": 3, "v": "c"})], scope, &t2)
+        .await
+        .expect("second idempotent write");
+    assert_eq!(
+        sink.last_committed_token(scope).await.expect("token 2"),
+        Some(t2)
+    );
+    assert_eq!(support::count_rows(&conn, "t").await, 3);
+
+    // Scopes are isolated.
+    assert_eq!(
+        sink.last_committed_token("other::scope")
+            .await
+            .expect("other scope"),
+        None
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn evolve_schema_adds_column_then_write_uses_it() {
+    let (sink, conn) = sink_for("em-evolve", append_spec()).await;
+    let evolution = faucet_core::SchemaEvolution {
+        additions: vec![faucet_core::ColumnChange {
+            name: "extra".into(),
+            from: None,
+            to: json!({"type": "string"}),
+        }],
+        widenings: vec![],
+        relax_nullability: vec![],
+    };
+    sink.evolve_schema(&evolution).await.expect("evolve");
+    sink.write_batch(&[json!({"id": 1, "extra": "landed"})])
+        .await
+        .expect("write with new column");
+    let row = fetch_row(&conn, 1).await.expect("row");
+    assert_eq!(row["extra"], json!("landed"));
+
+    // current_schema reflects the evolved table.
+    let schema = sink.current_schema().await.expect("schema").expect("some");
+    assert_eq!(
+        schema["properties"]["extra"]["type"],
+        json!(["string", "null"])
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn upsert_key_must_match_pk() {
+    let (sink, _conn) = sink_for(
+        "em-badkey",
+        WriteSpec {
+            write_mode: WriteMode::Upsert,
+            key: vec!["v".to_string()],
+            delete_marker: None,
+        },
+    )
+    .await;
+    let err = sink
+        .write_batch(&[json!({"id": 1, "v": "x"})])
+        .await
+        .expect_err("key != PK must be rejected");
+    assert!(matches!(err, FaucetError::Config(_)), "got: {err}");
+    assert!(err.to_string().contains("PRIMARY KEY"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn check_reports_auth_and_schema_probes() {
+    let (sink, _conn) = sink_for("em-check", upsert_spec()).await;
+    let report = sink
+        .check(&faucet_core::check::CheckContext::default())
+        .await
+        .expect("check");
+    assert_eq!(report.probes.len(), 2);
+    assert_eq!(report.failed_count(), 0);
+
+    // A sink pointed at a missing table fails the schema probe but not auth.
+    let conn = support::connection("em-check", &support::emulator_host().await);
+    let mut cfg = SpannerSinkConfig::new(
+        conn.project_id.clone(),
+        conn.instance.clone(),
+        conn.database.clone(),
+        "missing_table",
+    );
+    cfg.connection.emulator_host = conn.emulator_host.clone();
+    let missing = SpannerSink::new(cfg).await.expect("sink");
+    let report = missing
+        .check(&faucet_core::check::CheckContext::default())
+        .await
+        .expect("check");
+    assert_eq!(report.failed_count(), 1);
+}
+
+// ── Coverage: error paths, evolve widening/relax ─────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn missing_table_is_a_clear_error_and_current_schema_is_none() {
+    let conn = support::create_database("em-missing", vec![]).await;
+    let mut cfg = SpannerSinkConfig::new(
+        conn.project_id.clone(),
+        conn.instance.clone(),
+        conn.database.clone(),
+        "nope",
+    );
+    cfg.connection.emulator_host = conn.emulator_host.clone();
+    let sink = SpannerSink::new(cfg).await.expect("sink");
+
+    // A nonexistent target is drift-inert (no schema to diverge from)…
+    assert!(sink.current_schema().await.expect("schema").is_none());
+    // …but writing to it is a typed error naming the table.
+    let err = sink.write_batch(&[json!({"id": 1})]).await.unwrap_err();
+    assert!(
+        err.to_string().contains("does not exist"),
+        "unexpected: {err}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn append_encode_failure_names_the_row_and_column() {
+    let (sink, _conn) = sink_for("em-encode-err", append_spec()).await;
+    let err = sink
+        .write_batch(&[json!({"id": 1, "ok": "not-a-bool"})])
+        .await
+        .unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("row 0"), "unexpected: {msg}");
+    assert!(msg.contains("ok"), "unexpected: {msg}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn evolve_widens_nullability_relaxes_not_null_and_rejects_base_type_change() {
+    let conn = support::create_database(
+        "em-evolve2",
+        vec![
+            "CREATE TABLE t (id INT64 NOT NULL, v STRING(MAX) NOT NULL) PRIMARY KEY (id)"
+                .to_string(),
+        ],
+    )
+    .await;
+    let mut cfg = SpannerSinkConfig::new(
+        conn.project_id.clone(),
+        conn.instance.clone(),
+        conn.database.clone(),
+        "t",
+    );
+    cfg.connection.emulator_host = conn.emulator_host.clone();
+    let sink = SpannerSink::new(cfg).await.expect("sink");
+
+    // A base-type change (INT64 → FLOAT64) is not something Spanner can do.
+    let widen_base = faucet_core::SchemaEvolution {
+        additions: vec![],
+        widenings: vec![faucet_core::ColumnChange {
+            name: "id".into(),
+            from: Some(json!({"type": "integer"})),
+            to: json!({"type": "number"}),
+        }],
+        relax_nullability: vec![],
+    };
+    let err = sink.evolve_schema(&widen_base).await.unwrap_err();
+    assert!(
+        err.to_string().contains("allow_type_widening"),
+        "unexpected: {err}"
+    );
+
+    // A widening that only gains nullability re-emits the column at its
+    // current type, and an explicit NOT NULL relax does the same.
+    let relax = faucet_core::SchemaEvolution {
+        additions: vec![],
+        widenings: vec![faucet_core::ColumnChange {
+            name: "v".into(),
+            from: Some(json!({"type": "string"})),
+            to: json!({"type": ["string", "null"]}),
+        }],
+        relax_nullability: vec!["v".into()],
+    };
+    sink.evolve_schema(&relax).await.expect("relax");
+    sink.write_batch(&[json!({"id": 5, "v": null})])
+        .await
+        .expect("NULL lands after relax");
+    let schema = sink.current_schema().await.expect("schema").expect("some");
+    assert_eq!(schema["properties"]["v"]["type"], json!(["string", "null"]));
+}

--- a/crates/sink/spanner/tests/support/mod.rs
+++ b/crates/sink/spanner/tests/support/mod.rs
@@ -1,0 +1,135 @@
+//! Shared Cloud Spanner **emulator** bootstrap for integration tests.
+//!
+//! One emulator container is shared per test binary (via `OnceCell`); each
+//! test creates its own database so tests stay isolated. The connector is
+//! pointed at the emulator through the config-level `emulator_host` override
+//! — no process-global `SPANNER_EMULATOR_HOST` env var, so parallel tests
+//! never race.
+
+use faucet_common_spanner::SpannerConnection;
+use gcloud_googleapis::spanner::admin::database::v1::CreateDatabaseRequest;
+use gcloud_googleapis::spanner::admin::instance::v1::{CreateInstanceRequest, Instance};
+use gcloud_spanner::statement::Statement;
+use testcontainers::core::ContainerPort;
+use testcontainers::runners::AsyncRunner;
+use testcontainers::{ContainerAsync, GenericImage};
+use tokio::sync::OnceCell;
+
+pub const PROJECT: &str = "test-project";
+pub const INSTANCE: &str = "test-instance";
+
+static EMULATOR: OnceCell<(ContainerAsync<GenericImage>, String)> = OnceCell::const_new();
+
+/// Start (once per test binary) and return the emulator's `host:port`.
+pub async fn emulator_host() -> String {
+    let (_container, host) = EMULATOR
+        .get_or_init(|| async {
+            let image = GenericImage::new("gcr.io/cloud-spanner-emulator/emulator", "latest")
+                .with_exposed_port(ContainerPort::Tcp(9010));
+            let container = image.start().await.expect("spanner emulator start");
+            let port = container
+                .get_host_port_ipv4(9010)
+                .await
+                .expect("spanner emulator port");
+            let host = format!("127.0.0.1:{port}");
+            bootstrap_instance(&host).await;
+            (container, host)
+        })
+        .await;
+    host.clone()
+}
+
+/// A connection config pointing a given database at the emulator.
+pub fn connection(database: &str, host: &str) -> SpannerConnection {
+    SpannerConnection {
+        project_id: PROJECT.into(),
+        instance: INSTANCE.into(),
+        database: database.into(),
+        auth: Default::default(),
+        max_sessions: 20,
+        emulator_host: Some(host.into()),
+    }
+}
+
+/// Create the shared emulator instance, polling until the emulator accepts
+/// gRPC (it needs a moment after the container starts).
+async fn bootstrap_instance(host: &str) {
+    // The database field is irrelevant for instance-admin calls but the
+    // connection block requires one.
+    let conn = connection("bootstrap", host);
+    for attempt in 0..120u32 {
+        let admin = match conn.connect_admin().await {
+            Ok(a) => a,
+            Err(_) if attempt < 119 => {
+                tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                continue;
+            }
+            Err(e) => panic!("spanner emulator admin connect never succeeded: {e}"),
+        };
+        let req = CreateInstanceRequest {
+            parent: format!("projects/{PROJECT}"),
+            instance_id: INSTANCE.into(),
+            instance: Some(Instance {
+                name: format!("projects/{PROJECT}/instances/{INSTANCE}"),
+                config: format!("projects/{PROJECT}/instanceConfigs/emulator-config"),
+                display_name: "conformance".into(),
+                node_count: 1,
+                ..Default::default()
+            }),
+        };
+        match admin.instance().create_instance(req, None).await {
+            Ok(mut op) => {
+                op.wait(None).await.expect("instance create LRO");
+                return;
+            }
+            Err(status) if status.code() == gcloud_gax::grpc::Code::AlreadyExists => return,
+            Err(_) if attempt < 119 => {
+                tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+            }
+            Err(e) => panic!("spanner emulator create_instance failed: {e}"),
+        }
+    }
+    panic!("spanner emulator never became ready");
+}
+
+/// Create a fresh database on the shared emulator with the given DDL and
+/// return a connection config for it. Database ids: `[a-z][a-z0-9_-]{0,28}[a-z0-9]`.
+pub async fn create_database(database: &str, ddl: Vec<String>) -> SpannerConnection {
+    let host = emulator_host().await;
+    let conn = connection(database, &host);
+    let admin = conn.connect_admin().await.expect("admin connect");
+    let mut op = admin
+        .database()
+        .create_database(
+            CreateDatabaseRequest {
+                parent: format!("projects/{PROJECT}/instances/{INSTANCE}"),
+                create_statement: format!("CREATE DATABASE `{database}`"),
+                extra_statements: ddl,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .expect("create database");
+    op.wait(None).await.expect("database create LRO");
+    conn
+}
+
+/// Count rows in `table` via a raw client.
+pub async fn count_rows(conn: &SpannerConnection, table: &str) -> usize {
+    let client = conn.connect().await.expect("count client");
+    let mut tx = client.single().await.expect("single txn");
+    let mut iter = tx
+        .query(Statement::new(format!(
+            "SELECT COUNT(*) AS c FROM `{table}`"
+        )))
+        .await
+        .expect("count query");
+    let row = iter
+        .next()
+        .await
+        .expect("count row")
+        .expect("count row present");
+    let c = row.column_by_name::<i64>("c").expect("count decode");
+    c as usize
+}

--- a/crates/source/spanner/Cargo.toml
+++ b/crates/source/spanner/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "faucet-source-spanner"
+version = "1.0.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Google Cloud Spanner query source connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords = ["spanner", "gcp", "etl", "pipeline", "connector"]
+categories.workspace = true
+
+[dependencies]
+faucet-core.workspace = true
+faucet-common-spanner.workspace = true
+gcloud-spanner.workspace = true
+gcloud-googleapis.workspace = true
+prost-types = "0.14"
+schemars.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+async-trait.workspace = true
+async-stream.workspace = true
+tracing.workspace = true
+tokio.workspace = true
+futures.workspace = true
+
+[dev-dependencies]
+faucet-conformance.workspace = true
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
+testcontainers = "0.27"
+futures.workspace = true
+gcloud-gax.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/source/spanner/README.md
+++ b/crates/source/spanner/README.md
@@ -1,0 +1,131 @@
+# faucet-source-spanner
+
+Google Cloud Spanner query source connector for [faucet-stream](https://crates.io/crates/faucet-stream).
+
+Runs a GoogleSQL query against a Spanner database via the streaming read API
+(`ExecuteStreamingSql`) and emits rows as JSON with bounded memory. Supports
+named bind parameters, stale reads, incremental replication via a monotonic
+column bookmark, live dataset discovery (`faucet discover`), and PK-range
+sharding for clustered (Mode B) execution.
+
+```yaml
+source:
+  kind: spanner
+  config:
+    project_id: my-project
+    instance: my-instance
+    database: my-db
+    query: "SELECT * FROM orders WHERE updated_at > TIMESTAMP(@bookmark)"
+    replication:
+      type: incremental
+      column: updated_at
+      initial_value: "1970-01-01T00:00:00Z"
+sink:
+  kind: jsonl
+  config:
+    path: ./orders.jsonl
+```
+
+## Configuration
+
+| Field | Required | Default | Description |
+|---|---|---|---|
+| `project_id` | ✔ | — | GCP project that owns the Spanner instance. |
+| `instance` | ✔ | — | Spanner instance ID. |
+| `database` | ✔ | — | Database name within the instance. |
+| `query` | ✔ | — | GoogleSQL query. Named parameters (`@name`) bind from `params`; `@bookmark` binds the incremental cursor. |
+| `auth` | | `application_default` | Credentials: `{type: application_default}`, `{type: service_account_key_path, config: {path}}`, or `{type: service_account_key, config: {json}}`. |
+| `params` | | `{}` | Named bind parameters. Values must be scalars (string / integer / float / boolean) — Spanner parameters are typed. |
+| `batch_size` | | `1000` | Records per emitted page. `0` emits the whole result set as one page. |
+| `exact_staleness_secs` | | — | Read at a timestamp this many seconds in the past (stale read, served by any replica) instead of a strong read. |
+| `replication` | | `{type: full}` | `full` or `{type: incremental, column, initial_value}` — see below. |
+| `state_key` | | derived | Explicit state-store key for the bookmark. Defaults to `spanner:<project>.<instance>.<database>:<query-fingerprint>`. |
+| `max_sessions` | | `100` | Upper bound on pooled Spanner sessions (gRPC channels are sized at one per 100 sessions). |
+| `emulator_host` | | — | Spanner emulator endpoint (`host:port`); plaintext + unauthenticated. See [Emulator](#emulator). |
+| `shard` | | — | `{key: <INT64 column>}` — opt in to PK-range sharding for clustered execution. |
+
+## Record shape
+
+Each row becomes one JSON object keyed by column name:
+
+| Spanner type | JSON |
+|---|---|
+| `INT64` | integer (lossless — Spanner string-encodes it on the wire) |
+| `FLOAT64` / `FLOAT32` | number (`NaN` / `Infinity` become strings) |
+| `BOOL` | boolean |
+| `STRING` / `TIMESTAMP` (RFC 3339) / `DATE` / `UUID` / `INTERVAL` | string |
+| `BYTES` / `PROTO` | base64 string |
+| `NUMERIC` | string (precision preserved) |
+| `JSON` | the parsed value (object / array / scalar) |
+| `ARRAY<T>` | array |
+| `STRUCT` | object keyed by field name |
+
+## Incremental replication
+
+```yaml
+query: "SELECT * FROM orders WHERE updated_at > TIMESTAMP(@bookmark)"
+replication:
+  type: incremental
+  column: updated_at
+  initial_value: "1970-01-01T00:00:00Z"
+```
+
+Only rows whose `column` is strictly greater than the stored bookmark (or
+`initial_value` on the first run) are emitted; the new maximum is persisted on
+the final page via the pipeline's `state:` store. When the query contains the
+named parameter `@bookmark`, the cursor is bound server-side (efficient);
+without it the source still filters client-side but the server re-scans the
+whole table every run (a warning is logged at config load).
+
+**Type casts:** Spanner does not implicitly coerce parameter types. A string
+bookmark compared against a `TIMESTAMP` column needs an explicit cast in the
+query — `updated_at > TIMESTAMP(@bookmark)` — and likewise `DATE(@bookmark)`
+for `DATE` columns. Integer bookmarks bind as `INT64` and compare directly.
+
+## Stale reads
+
+Set `exact_staleness_secs: 15` to read at a bounded-staleness timestamp.
+Stale reads can be served by any replica (offloading the leader) but will not
+see rows committed within the window — for incremental replication this can
+delay (never lose) rows, since the bookmark only advances over rows actually
+read.
+
+## Dataset discovery
+
+`faucet discover` enumerates every base table in the database's default
+schema from `INFORMATION_SCHEMA` (system schemas excluded) with column types
+mapped to JSON Schema, and emits one matrix row per table with a
+``{"query": "SELECT * FROM `table`"}`` config patch. Spanner exposes no cheap
+row-count estimate, so descriptors carry none.
+
+## Sharding (clustered Mode B)
+
+```yaml
+shard:
+  key: id   # INT64 column present in the query's output
+```
+
+The cluster coordinator computes `MIN`/`MAX` of `key` over the query and
+splits the range into contiguous half-open slices; each worker streams
+`SELECT * FROM (<query>) AS _faucet_shard WHERE ...` for its slice. Boundary
+shards are open-ended and exactly one shard also matches `key IS NULL`, so
+concurrent inserts outside the enumerated range and NULL-key rows are read by
+exactly one shard. Has no effect outside the cluster coordinator.
+
+## Emulator
+
+Point the source at the [Cloud Spanner emulator](https://cloud.google.com/spanner/docs/emulator)
+(`gcr.io/cloud-spanner-emulator/emulator`, gRPC port 9010) with:
+
+```yaml
+emulator_host: "localhost:9010"
+```
+
+The connection is plaintext and unauthenticated. The process-global
+`SPANNER_EMULATOR_HOST` env var is also honored when `emulator_host` is
+unset. This crate's integration tests provision instance + database
+programmatically against the emulator via testcontainers.
+
+## License
+
+MIT OR Apache-2.0

--- a/crates/source/spanner/src/config.rs
+++ b/crates/source/spanner/src/config.rs
@@ -1,0 +1,381 @@
+//! Configuration for the Cloud Spanner query source.
+
+use std::collections::HashMap;
+
+use faucet_common_spanner::SpannerConnection;
+use faucet_core::{DEFAULT_BATCH_SIZE, FaucetError, validate_batch_size};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+fn default_batch_size() -> usize {
+    DEFAULT_BATCH_SIZE
+}
+
+/// How the source replicates rows across runs.
+///
+/// Serializes as `{ type: full }` or
+/// `{ type: incremental, column: "...", initial_value: ... }`.
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, Default, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum SpannerReplication {
+    /// Every run fetches the full result set (default).
+    #[default]
+    Full,
+    /// Only rows whose `column` is strictly greater than the stored bookmark
+    /// (or `initial_value` on the first run) are emitted.
+    ///
+    /// The bookmark is applied two ways: if the query contains the named
+    /// parameter `@bookmark`, it is bound so the server filters (efficient);
+    /// the source *also* filters client-side as a correctness backstop. The
+    /// new maximum of `column` is persisted on the final page.
+    ///
+    /// Spanner does not implicitly coerce parameter types: a string bookmark
+    /// compared against a `TIMESTAMP` column needs an explicit cast in the
+    /// query, e.g. `WHERE updated_at > TIMESTAMP(@bookmark)`.
+    Incremental {
+        /// Column whose value is the replication cursor (e.g. `updated_at`).
+        column: String,
+        /// Lower bound used on the first run, before any bookmark is stored.
+        initial_value: Value,
+    },
+}
+
+/// Primary-key range sharding settings for the Spanner source (clustered
+/// Mode B execution).
+///
+/// The source is split by contiguous ranges of an **INT64-typed** column:
+/// each shard runs ``SELECT * FROM (<query>) AS _faucet_shard WHERE `key` >=
+/// lo AND `key` < hi``. The column must be present in the query's output.
+///
+/// **Nullable keys:** rows whose key is NULL are invisible to the `MIN`/`MAX`
+/// range enumeration but are still read — exactly one shard (the last)
+/// additionally matches ``key IS NULL``, so NULL-key rows are covered by
+/// precisely one shard with no loss and no duplication.
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct ShardConfig {
+    /// INT64 column to range-partition on. Backtick-quoted before use, so it
+    /// is safe against injection but must name a real output column.
+    pub key: String,
+}
+
+/// Configuration for [`SpannerSource`](crate::SpannerSource).
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SpannerSourceConfig {
+    /// Connection settings (`project_id` / `instance` / `database` / `auth` /
+    /// `max_sessions` / `emulator_host`), flattened.
+    #[serde(flatten)]
+    pub connection: SpannerConnection,
+    /// GoogleSQL query to run. Use named parameters (`@name`) for
+    /// [`params`](Self::params), and the named parameter `@bookmark` to bind
+    /// the incremental cursor server-side.
+    pub query: String,
+    /// Named bind parameters for the query. Values must be scalars (string,
+    /// integer, float, or boolean) — Spanner parameters are typed, and
+    /// null/array/object values have no unambiguous parameter type.
+    #[serde(default)]
+    pub params: HashMap<String, Value>,
+    /// Records per emitted [`StreamPage`](faucet_core::StreamPage). `0` emits
+    /// the whole result set as a single page. Defaults to
+    /// [`DEFAULT_BATCH_SIZE`].
+    #[serde(default = "default_batch_size")]
+    pub batch_size: usize,
+    /// Read at a timestamp this many seconds in the past instead of a strong
+    /// read. Stale reads can be served by any replica, offloading the leader
+    /// — at the cost of missing rows committed within the staleness window.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exact_staleness_secs: Option<u64>,
+    /// Replication mode. Defaults to [`SpannerReplication::Full`].
+    #[serde(default)]
+    pub replication: SpannerReplication,
+    /// Explicit state-store key for the bookmark. When unset, a key is
+    /// derived from the database path and a query fingerprint.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state_key: Option<String>,
+    /// Optional primary-key range sharding for clustered (Mode B) execution.
+    ///
+    /// When set, the source advertises itself as shardable: the cluster
+    /// coordinator splits the query's `key` range into contiguous slices that
+    /// different workers process concurrently. Has **no effect** outside the
+    /// cluster coordinator (a plain `faucet run` streams the whole query).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub shard: Option<ShardConfig>,
+}
+
+impl std::fmt::Debug for SpannerSourceConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // `SpannerConnection`'s Debug masks inline key material already; keep
+        // the connector-level Debug conservative anyway.
+        f.debug_struct("SpannerSourceConfig")
+            .field("connection", &self.connection)
+            .field("query", &self.query)
+            .field("params", &self.params)
+            .field("batch_size", &self.batch_size)
+            .field("exact_staleness_secs", &self.exact_staleness_secs)
+            .field("replication", &self.replication)
+            .field("state_key", &self.state_key)
+            .field("shard", &self.shard)
+            .finish()
+    }
+}
+
+/// `true` when `name` is a valid Spanner parameter name
+/// (`[A-Za-z_][A-Za-z0-9_]*`).
+fn valid_param_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+impl SpannerSourceConfig {
+    /// Build a config from connection identifiers and a query, with defaults
+    /// elsewhere.
+    pub fn new(
+        project_id: impl Into<String>,
+        instance: impl Into<String>,
+        database: impl Into<String>,
+        query: impl Into<String>,
+    ) -> Self {
+        Self {
+            connection: SpannerConnection {
+                project_id: project_id.into(),
+                instance: instance.into(),
+                database: database.into(),
+                auth: Default::default(),
+                max_sessions: 100,
+                emulator_host: None,
+            },
+            query: query.into(),
+            params: HashMap::new(),
+            batch_size: default_batch_size(),
+            exact_staleness_secs: None,
+            replication: SpannerReplication::Full,
+            state_key: None,
+            shard: None,
+        }
+    }
+
+    /// Validate connection, batch size, params, and replication settings.
+    pub fn validate(&self) -> Result<(), FaucetError> {
+        self.connection.validate()?;
+        validate_batch_size(self.batch_size)?;
+        if self.query.trim().is_empty() {
+            return Err(FaucetError::Config(
+                "spanner: `query` must not be empty".into(),
+            ));
+        }
+        for (name, value) in &self.params {
+            if !valid_param_name(name) {
+                return Err(FaucetError::Config(format!(
+                    "spanner: invalid parameter name `{name}` \
+                     (must match [A-Za-z_][A-Za-z0-9_]*)"
+                )));
+            }
+            match value {
+                Value::String(_) | Value::Bool(_) => {}
+                Value::Number(n) => {
+                    if n.as_u64().is_some_and(|u| i64::try_from(u).is_err()) {
+                        return Err(FaucetError::Config(format!(
+                            "spanner: parameter `{name}` ({n}) overflows INT64"
+                        )));
+                    }
+                }
+                _ => {
+                    return Err(FaucetError::Config(format!(
+                        "spanner: parameter `{name}` must be a scalar \
+                         (string / integer / float / boolean) — Spanner \
+                         parameters are typed and null/array/object values \
+                         have no unambiguous type"
+                    )));
+                }
+            }
+        }
+        if let SpannerReplication::Incremental { column, .. } = &self.replication {
+            if column.trim().is_empty() {
+                return Err(FaucetError::Config(
+                    "spanner: incremental replication requires a non-empty `column`".into(),
+                ));
+            }
+            if self.params.contains_key("bookmark") {
+                return Err(FaucetError::Config(
+                    "spanner: the parameter name `bookmark` is reserved for the \
+                     incremental replication cursor"
+                        .into(),
+                ));
+            }
+        }
+        if self.incremental_without_bookmark_pushdown() {
+            tracing::warn!(
+                "spanner incremental replication query has no `@bookmark` parameter: the \
+                 cursor is applied client-side only, so the server returns the ENTIRE \
+                 table on every run (correctness is preserved, but it is a full re-scan). \
+                 Add `@bookmark` to the WHERE clause to push the cursor down, e.g. \
+                 `... WHERE {column} > @bookmark`",
+                column = match &self.replication {
+                    SpannerReplication::Incremental { column, .. } => column.as_str(),
+                    _ => "<column>",
+                }
+            );
+        }
+        Ok(())
+    }
+
+    /// `true` when replication is `Incremental` but the query omits the
+    /// `@bookmark` parameter, so the cursor cannot be pushed down to the
+    /// server and every run re-scans the whole table. Pure predicate so the
+    /// load-time warning's condition is unit-testable.
+    pub(crate) fn incremental_without_bookmark_pushdown(&self) -> bool {
+        matches!(self.replication, SpannerReplication::Incremental { .. })
+            && !self.query.contains("@bookmark")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn base() -> SpannerSourceConfig {
+        SpannerSourceConfig::new("p", "i", "d", "SELECT * FROM t")
+    }
+
+    #[test]
+    fn replication_full_is_default_and_round_trips() {
+        let r: SpannerReplication = serde_json::from_value(json!({"type": "full"})).unwrap();
+        assert_eq!(r, SpannerReplication::Full);
+        assert_eq!(SpannerReplication::default(), SpannerReplication::Full);
+    }
+
+    #[test]
+    fn replication_incremental_parses_column_and_initial_value() {
+        let r: SpannerReplication = serde_json::from_value(json!({
+            "type": "incremental",
+            "column": "updated_at",
+            "initial_value": "1970-01-01T00:00:00Z"
+        }))
+        .unwrap();
+        assert_eq!(
+            r,
+            SpannerReplication::Incremental {
+                column: "updated_at".into(),
+                initial_value: json!("1970-01-01T00:00:00Z"),
+            }
+        );
+    }
+
+    #[test]
+    fn config_flattens_connection_fields() {
+        let cfg: SpannerSourceConfig = serde_json::from_value(json!({
+            "project_id": "p",
+            "instance": "i",
+            "database": "d",
+            "query": "SELECT 1",
+        }))
+        .unwrap();
+        assert_eq!(cfg.connection.project_id, "p");
+        assert_eq!(cfg.connection.max_sessions, 100);
+        assert_eq!(cfg.batch_size, DEFAULT_BATCH_SIZE);
+        assert!(cfg.exact_staleness_secs.is_none());
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_empty_query_and_bad_batch() {
+        let mut cfg = base();
+        cfg.query = "  ".into();
+        assert!(cfg.validate().is_err());
+        let mut cfg = base();
+        cfg.batch_size = faucet_core::MAX_BATCH_SIZE + 1;
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_non_scalar_and_ill_named_params() {
+        let mut cfg = base();
+        cfg.params.insert("ok".into(), json!("x"));
+        assert!(cfg.validate().is_ok());
+
+        let mut cfg = base();
+        cfg.params.insert("bad".into(), json!(null));
+        assert!(cfg.validate().is_err());
+        let mut cfg = base();
+        cfg.params.insert("bad".into(), json!([1]));
+        assert!(cfg.validate().is_err());
+        let mut cfg = base();
+        cfg.params.insert("bad".into(), json!({"a": 1}));
+        assert!(cfg.validate().is_err());
+        let mut cfg = base();
+        cfg.params.insert("9lives".into(), json!(1));
+        assert!(cfg.validate().is_err(), "names must not start with a digit");
+        let mut cfg = base();
+        cfg.params.insert("we-ird".into(), json!(1));
+        assert!(cfg.validate().is_err(), "names must be [A-Za-z0-9_]");
+        let mut cfg = base();
+        cfg.params.insert("big".into(), json!(u64::MAX));
+        assert!(
+            cfg.validate().is_err(),
+            "u64 above i64::MAX overflows INT64"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_incremental_without_column_or_with_reserved_param() {
+        let mut cfg = base();
+        cfg.replication = SpannerReplication::Incremental {
+            column: " ".into(),
+            initial_value: json!(0),
+        };
+        assert!(cfg.validate().is_err());
+
+        let mut cfg = base();
+        cfg.query = "SELECT * FROM t WHERE c > @bookmark".into();
+        cfg.replication = SpannerReplication::Incremental {
+            column: "c".into(),
+            initial_value: json!(0),
+        };
+        cfg.params.insert("bookmark".into(), json!(1));
+        assert!(cfg.validate().is_err(), "`bookmark` is reserved");
+    }
+
+    #[test]
+    fn incremental_without_bookmark_pushdown_flags_missing_token() {
+        let mut missing = base();
+        missing.replication = SpannerReplication::Incremental {
+            column: "updated_at".into(),
+            initial_value: json!("1970-01-01"),
+        };
+        assert!(missing.incremental_without_bookmark_pushdown());
+        // validate still succeeds (warn, not hard-error).
+        assert!(missing.validate().is_ok());
+
+        let mut with_token = missing.clone();
+        with_token.query = "SELECT * FROM t WHERE updated_at > @bookmark".into();
+        assert!(!with_token.incremental_without_bookmark_pushdown());
+
+        assert!(!base().incremental_without_bookmark_pushdown());
+    }
+
+    #[test]
+    fn valid_param_names() {
+        assert!(valid_param_name("cursor"));
+        assert!(valid_param_name("_x9"));
+        assert!(valid_param_name("A_b_1"));
+        assert!(!valid_param_name(""));
+        assert!(!valid_param_name("1abc"));
+        assert!(!valid_param_name("a-b"));
+        assert!(!valid_param_name("a b"));
+    }
+
+    #[test]
+    fn debug_does_not_leak_inline_key() {
+        let mut cfg = base();
+        cfg.connection.auth = faucet_common_spanner::SpannerCredentials::ServiceAccountKey {
+            json: "{\"private_key\":\"SECRET\"}".into(),
+        };
+        let dbg = format!("{cfg:?}");
+        assert!(!dbg.contains("SECRET"));
+    }
+}

--- a/crates/source/spanner/src/lib.rs
+++ b/crates/source/spanner/src/lib.rs
@@ -1,0 +1,34 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+//! Google Cloud Spanner query source connector for
+//! [faucet-stream](https://crates.io/crates/faucet-stream).
+//!
+//! Runs a GoogleSQL query against a Spanner database via the streaming read
+//! API (`ExecuteStreamingSql`) and emits rows as JSON with bounded memory.
+//! Supports named bind parameters, stale reads, incremental replication via
+//! a monotonic column bookmark, live dataset discovery
+//! (`INFORMATION_SCHEMA`), and PK-range sharding for clustered execution.
+//!
+//! ```yaml
+//! source:
+//!   kind: spanner
+//!   config:
+//!     project_id: my-project
+//!     instance: my-instance
+//!     database: my-db
+//!     query: "SELECT * FROM orders WHERE updated_at > TIMESTAMP(@bookmark)"
+//!     replication:
+//!       type: incremental
+//!       column: updated_at
+//!       initial_value: "1970-01-01T00:00:00Z"
+//! ```
+//!
+//! Authentication defaults to Application Default Credentials; a service
+//! account key can be supplied by path or inline via `auth`. Set
+//! `emulator_host` to target the Spanner emulator.
+
+mod config;
+mod stream;
+
+pub use config::{ShardConfig, SpannerReplication, SpannerSourceConfig};
+pub use faucet_common_spanner::{SpannerConnection, SpannerCredentials};
+pub use stream::SpannerSource;

--- a/crates/source/spanner/src/stream.rs
+++ b/crates/source/spanner/src/stream.rs
@@ -1,0 +1,803 @@
+//! The Cloud Spanner [`Source`] implementation — client construction, query
+//! execution, streaming, and incremental-replication bookkeeping.
+
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
+use std::pin::Pin;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use faucet_common_spanner::decode::row_to_json;
+use faucet_common_spanner::quote_ident_spanner;
+use faucet_common_spanner::types::{parse_spanner_type, spanner_type_to_json_schema};
+use faucet_core::replication::{filter_incremental, max_replication_value, max_value};
+use faucet_core::shard::{
+    PkShardBounds, ShardSpec, parse_pk_shard, pk_bounds_query, pk_shards_from_bounds,
+};
+use faucet_core::{FaucetError, Source, StreamPage};
+use futures::Stream;
+use gcloud_spanner::client::Client;
+use gcloud_spanner::statement::Statement;
+use gcloud_spanner::transaction::QueryOptions;
+use gcloud_spanner::transaction_ro::ReadOnlyTransaction;
+use gcloud_spanner::value::TimestampBound;
+use serde_json::Value;
+
+use crate::config::{SpannerReplication, SpannerSourceConfig};
+
+/// Google Cloud Spanner query source.
+pub struct SpannerSource {
+    config: SpannerSourceConfig,
+    client: Client,
+    /// Bookmark loaded via [`Source::apply_start_bookmark`]; overrides the
+    /// configured `initial_value` for incremental runs.
+    start_bookmark: Mutex<Option<Value>>,
+    /// Shard applied by the cluster coordinator (Mode B), if any. `None` (or
+    /// the whole-dataset shard) means the full query is streamed.
+    applied_shard: Mutex<Option<PkShardBounds>>,
+}
+
+impl SpannerSource {
+    /// Validate the config and build the Spanner client (session pool).
+    pub async fn new(config: SpannerSourceConfig) -> Result<Self, FaucetError> {
+        config.validate()?;
+        let client = config.connection.connect().await?;
+        Ok(Self {
+            config,
+            client,
+            start_bookmark: Mutex::new(None),
+            applied_shard: Mutex::new(None),
+        })
+    }
+
+    fn current_start(&self) -> Option<Value> {
+        self.start_bookmark
+            .lock()
+            .expect("start_bookmark mutex poisoned")
+            .clone()
+    }
+
+    /// Apply the currently-set shard (if any) to a resolved query string. The
+    /// `@name` bind parameters inside the wrapped subquery are unaffected
+    /// (they bind by name, not by position in the text).
+    fn shard_wrap(&self, query: String) -> String {
+        match &*self.applied_shard.lock().expect("shard mutex poisoned") {
+            Some(bounds) => bounds.wrap(&query, quote_ident_spanner),
+            None => query,
+        }
+    }
+
+    /// Open the single-use read-only transaction this run reads through,
+    /// honoring `exact_staleness_secs`.
+    async fn read_txn(&self) -> Result<ReadOnlyTransaction, FaucetError> {
+        let result = match self.config.exact_staleness_secs {
+            Some(secs) => {
+                self.client
+                    .single_with_timestamp_bound(TimestampBound::exact_staleness(
+                        Duration::from_secs(secs),
+                    ))
+                    .await
+            }
+            None => self.client.single().await,
+        };
+        result.map_err(|e| FaucetError::Source(format!("spanner: transaction begin failed: {e}")))
+    }
+}
+
+/// Incremental-replication context resolved for one run.
+#[derive(Debug, Clone, PartialEq)]
+struct IncrementalCtx {
+    column: String,
+    start: Value,
+}
+
+/// Build the final query string, the named bind values, and (for incremental
+/// runs) the client-side filter context.
+///
+/// Pure function (no client) so it is unit-testable. Named parameters:
+/// `config.params` keep their user-chosen names, parent-context placeholders
+/// become `@_faucet_ctx_N`, and the incremental cursor binds as `@bookmark`
+/// (only when the query mentions it).
+fn build_query_and_params(
+    config: &SpannerSourceConfig,
+    context: &HashMap<String, Value>,
+    start_bookmark: Option<&Value>,
+) -> (String, Vec<(String, Value)>, Option<IncrementalCtx>) {
+    let mut params: Vec<(String, Value)> = config
+        .params
+        .iter()
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
+    // Deterministic bind order (HashMap iteration order is random).
+    params.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let query = if context.is_empty() {
+        config.query.clone()
+    } else {
+        let (q, ctx_values) =
+            faucet_core::util::substitute_context_bind_params(&config.query, context, 1, |i| {
+                format!("@_faucet_ctx_{i}")
+            });
+        for (i, v) in ctx_values.into_iter().enumerate() {
+            params.push((format!("_faucet_ctx_{}", i + 1), v));
+        }
+        q
+    };
+
+    let incremental = match &config.replication {
+        SpannerReplication::Full => None,
+        SpannerReplication::Incremental {
+            column,
+            initial_value,
+        } => {
+            let start = start_bookmark
+                .cloned()
+                .unwrap_or_else(|| initial_value.clone());
+            // Server-side pushdown: bind the cursor where the user wrote
+            // `@bookmark`. If absent, only the client-side filter applies.
+            if query.contains("@bookmark") {
+                params.push(("bookmark".to_string(), start.clone()));
+            }
+            Some(IncrementalCtx {
+                column: column.clone(),
+                start,
+            })
+        }
+    };
+
+    (query, params, incremental)
+}
+
+/// Bind one JSON scalar as a typed Spanner parameter. Spanner parameters are
+/// typed, so each JSON scalar maps to the concrete Rust type whose
+/// `ToKind::get_type` matches: string→STRING, integer→INT64, float→FLOAT64,
+/// bool→BOOL. Non-scalar values are rejected (config validation catches
+/// user params at load time; this also guards bookmark values at runtime).
+fn bind_json_param(stmt: &mut Statement, name: &str, value: &Value) -> Result<(), FaucetError> {
+    match value {
+        Value::String(s) => stmt.add_param(name, s),
+        Value::Bool(b) => stmt.add_param(name, b),
+        Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                stmt.add_param(name, &i);
+            } else if let Some(u) = n.as_u64() {
+                let i = i64::try_from(u).map_err(|_| {
+                    FaucetError::Config(format!(
+                        "spanner: parameter `{name}` ({u}) overflows INT64"
+                    ))
+                })?;
+                stmt.add_param(name, &i);
+            } else {
+                // Finite f64 (serde_json rejects NaN/Inf at parse time).
+                stmt.add_param(name, &n.as_f64().unwrap_or(0.0));
+            }
+        }
+        other => {
+            return Err(FaucetError::Config(format!(
+                "spanner: parameter `{name}` must be a scalar, got {other}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Build a [`Statement`] from a resolved query and named values.
+fn build_statement(query: &str, params: &[(String, Value)]) -> Result<Statement, FaucetError> {
+    let mut stmt = Statement::new(query);
+    for (name, value) in params {
+        bind_json_param(&mut stmt, name, value)?;
+    }
+    Ok(stmt)
+}
+
+/// One flattened `INFORMATION_SCHEMA.COLUMNS` row used by
+/// [`Source::discover`]: `(table, column, spanner_type, is_nullable)`.
+type CatalogRow = (String, String, String, bool);
+
+/// Group flattened catalog rows (ordered by table, ordinal position) into one
+/// [`DatasetDescriptor`](faucet_core::DatasetDescriptor) per table. Pure —
+/// unit-testable without a live database. Spanner has no cheap row estimate
+/// (no `reltuples` analogue), so descriptors carry none.
+fn descriptors_from_catalog(rows: Vec<CatalogRow>) -> Vec<faucet_core::DatasetDescriptor> {
+    /// In-progress per-table accumulator: `(table, columns)`.
+    type PendingTable = (String, Vec<(String, Value)>);
+
+    let mut out: Vec<faucet_core::DatasetDescriptor> = Vec::new();
+    let mut current: Option<PendingTable> = None;
+
+    let flush = |cur: Option<PendingTable>, out: &mut Vec<faucet_core::DatasetDescriptor>| {
+        if let Some((table, cols)) = cur {
+            let query = format!("SELECT * FROM {}", quote_ident_spanner(&table));
+            out.push(
+                faucet_core::DatasetDescriptor::new(
+                    table,
+                    "table",
+                    serde_json::json!({ "query": query }),
+                )
+                .with_schema(faucet_core::columns_to_schema(cols)),
+            );
+        }
+    };
+
+    for (table, column, spanner_type, is_nullable) in rows {
+        let same = current.as_ref().is_some_and(|(t, _)| *t == table);
+        if !same {
+            flush(current.take(), &mut out);
+            current = Some((table, Vec::new()));
+        }
+        let fragment = spanner_type_to_json_schema(&parse_spanner_type(&spanner_type), is_nullable);
+        if let Some((_, cols)) = current.as_mut() {
+            cols.push((column, fragment));
+        }
+    }
+    flush(current, &mut out);
+    out
+}
+
+/// Derive a default state-store key from the database path + a query
+/// fingerprint, stable across runs.
+fn default_state_key(config: &SpannerSourceConfig) -> String {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    config.query.hash(&mut hasher);
+    let fingerprint = hasher.finish();
+    // Project/instance/database ids are [a-z0-9-] by Spanner's naming rules;
+    // sanitise defensively anyway (`:` is the key-segment separator).
+    let path: String = format!(
+        "{}.{}.{}",
+        config.connection.project_id, config.connection.instance, config.connection.database
+    )
+    .chars()
+    .map(|c| {
+        if c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.') {
+            c
+        } else {
+            '_'
+        }
+    })
+    .collect();
+    format!("spanner:{path}:{fingerprint:016x}")
+}
+
+#[async_trait]
+impl Source for SpannerSource {
+    async fn fetch_with_context(
+        &self,
+        context: &HashMap<String, Value>,
+    ) -> Result<Vec<Value>, FaucetError> {
+        Ok(self.collect_all(context).await?.0)
+    }
+
+    async fn fetch_with_context_incremental(
+        &self,
+        context: &HashMap<String, Value>,
+    ) -> Result<(Vec<Value>, Option<Value>), FaucetError> {
+        self.collect_all(context).await
+    }
+
+    fn stream_pages<'a>(
+        &'a self,
+        context: &'a HashMap<String, Value>,
+        _batch_size: usize,
+    ) -> Pin<Box<dyn Stream<Item = Result<StreamPage, FaucetError>> + Send + 'a>> {
+        let batch_size = self.config.batch_size;
+        let chunk = if batch_size == 0 {
+            usize::MAX
+        } else {
+            batch_size
+        };
+        let cap = if batch_size == 0 { 1024 } else { batch_size };
+        let start = self.current_start();
+        let (query, params, incr) = build_query_and_params(&self.config, context, start.as_ref());
+        let query = self.shard_wrap(query);
+
+        Box::pin(async_stream::try_stream! {
+            let stmt = build_statement(&query, &params)?;
+            let mut tx = self.read_txn().await?;
+            // `enable_resume: false`: the resume path buffers up to 128 MiB
+            // between resume tokens and makes `next()` non-cancel-safe — the
+            // pipeline `select!`s pages against its cancel token, so
+            // cancel-safety wins over transparent stream resumption here.
+            let opts = QueryOptions {
+                enable_resume: false,
+                ..Default::default()
+            };
+            let mut iter = tx
+                .query_with_option(stmt, opts)
+                .await
+                .map_err(|e| FaucetError::Source(format!("spanner: query failed: {e}")))?;
+
+            let mut fields: Option<std::sync::Arc<Vec<_>>> = None;
+            let mut buffer: Vec<Value> = Vec::with_capacity(cap);
+            let mut running_max: Option<Value> = None;
+            let mut total = 0usize;
+
+            while let Some(row) = iter
+                .next()
+                .await
+                .map_err(|e| FaucetError::Source(format!("spanner: row stream failed: {e}")))?
+            {
+                let fields = fields.get_or_insert_with(|| iter.columns_metadata().clone());
+                let record = row_to_json(&row, fields)
+                    .map_err(|e| FaucetError::Source(format!("spanner: row decode failed: {e}")))?;
+                buffer.push(record);
+                if buffer.len() >= chunk {
+                    let page = std::mem::replace(&mut buffer, Vec::with_capacity(cap));
+                    let kept = apply_incremental(page, incr.as_ref(), &mut running_max);
+                    total += kept.len();
+                    if !kept.is_empty() {
+                        yield StreamPage { records: kept, bookmark: None };
+                    }
+                }
+            }
+
+            // Final page carries the bookmark so the pipeline persists only
+            // after everything before it has been written.
+            let kept = apply_incremental(buffer, incr.as_ref(), &mut running_max);
+            total += kept.len();
+            let bookmark = if incr.is_some() { running_max.clone() } else { None };
+            if !kept.is_empty() || bookmark.is_some() {
+                yield StreamPage { records: kept, bookmark };
+            }
+
+            tracing::info!(rows = total, query = %self.config.query, "spanner source stream complete");
+        })
+    }
+
+    fn config_schema(&self) -> Value {
+        serde_json::to_value(faucet_core::schema_for!(SpannerSourceConfig))
+            .expect("schema serialization")
+    }
+
+    fn connector_name(&self) -> &'static str {
+        "spanner"
+    }
+
+    fn dataset_uri(&self) -> String {
+        format!(
+            "spanner://{}/{}/{}?query={}",
+            self.config.connection.project_id,
+            self.config.connection.instance,
+            self.config.connection.database,
+            self.config.query
+        )
+    }
+
+    fn state_key(&self) -> Option<String> {
+        match &self.config.replication {
+            SpannerReplication::Full => None,
+            SpannerReplication::Incremental { .. } => Some(
+                self.config
+                    .state_key
+                    .clone()
+                    .unwrap_or_else(|| default_state_key(&self.config)),
+            ),
+        }
+    }
+
+    async fn apply_start_bookmark(&self, bookmark: Value) -> Result<(), FaucetError> {
+        *self
+            .start_bookmark
+            .lock()
+            .expect("start_bookmark mutex poisoned") = Some(bookmark);
+        Ok(())
+    }
+
+    fn supports_discover(&self) -> bool {
+        true
+    }
+
+    /// Enumerate every base table in the database's default schema with
+    /// column types from `INFORMATION_SCHEMA.COLUMNS` (catalog metadata only
+    /// — no data scan). System schemas (`INFORMATION_SCHEMA`, `SPANNER_SYS`)
+    /// carry a non-empty `TABLE_SCHEMA`, so filtering on the default (empty)
+    /// schema excludes them. Spanner exposes no cheap row estimate, so
+    /// descriptors carry none.
+    async fn discover(&self) -> Result<Vec<faucet_core::DatasetDescriptor>, FaucetError> {
+        const CATALOG_SQL: &str = "SELECT c.TABLE_NAME, c.COLUMN_NAME, c.SPANNER_TYPE, \
+                c.IS_NULLABLE \
+           FROM INFORMATION_SCHEMA.COLUMNS AS c \
+           JOIN INFORMATION_SCHEMA.TABLES AS t \
+             ON t.TABLE_SCHEMA = c.TABLE_SCHEMA AND t.TABLE_NAME = c.TABLE_NAME \
+          WHERE t.TABLE_TYPE = 'BASE TABLE' AND t.TABLE_SCHEMA = '' \
+          ORDER BY c.TABLE_NAME, c.ORDINAL_POSITION";
+
+        let map_err =
+            |e: String| FaucetError::Source(format!("spanner: catalog discovery failed: {e}"));
+
+        let mut tx = self.read_txn().await?;
+        let mut iter = tx
+            .query(Statement::new(CATALOG_SQL))
+            .await
+            .map_err(|e| map_err(e.to_string()))?;
+
+        let mut catalog: Vec<CatalogRow> = Vec::new();
+        while let Some(row) = iter.next().await.map_err(|e| map_err(e.to_string()))? {
+            let table: String = row
+                .column_by_name("TABLE_NAME")
+                .map_err(|e| map_err(e.to_string()))?;
+            let column: String = row
+                .column_by_name("COLUMN_NAME")
+                .map_err(|e| map_err(e.to_string()))?;
+            let spanner_type: String = row
+                .column_by_name("SPANNER_TYPE")
+                .map_err(|e| map_err(e.to_string()))?;
+            // Absent/odd IS_NULLABLE over-approximates to nullable.
+            let nullable: String = row
+                .column_by_name("IS_NULLABLE")
+                .unwrap_or_else(|_| "YES".to_string());
+            catalog.push((
+                table,
+                column,
+                spanner_type,
+                nullable.eq_ignore_ascii_case("YES"),
+            ));
+        }
+
+        Ok(descriptors_from_catalog(catalog))
+    }
+
+    /// Shardable when a [`ShardConfig`](crate::config::ShardConfig) is set.
+    fn is_shardable(&self) -> bool {
+        self.config.shard.is_some()
+    }
+
+    /// Enumerate contiguous primary-key range shards by computing the `key`
+    /// column's `MIN`/`MAX` over the (unsharded) base query and splitting
+    /// that range into ~`target` slices. Returns a single whole-dataset shard
+    /// when no `shard` config is set or the result set is empty.
+    ///
+    /// The base query is resolved through the same query builder as a normal
+    /// fetch first, so a `@bookmark` parameter (incremental replication) is
+    /// bound rather than left dangling — bounds are then computed over the
+    /// not-yet-synced slice, which is exactly the data the shards will read.
+    async fn enumerate_shards(&self, target: usize) -> Result<Vec<ShardSpec>, FaucetError> {
+        let Some(shard_cfg) = &self.config.shard else {
+            return Ok(vec![ShardSpec::whole()]);
+        };
+
+        let start = self.current_start();
+        let (inner, params, _incr) =
+            build_query_and_params(&self.config, &HashMap::new(), start.as_ref());
+        let key = quote_ident_spanner(&shard_cfg.key);
+        let bounds_sql = pk_bounds_query(&inner, &key, "INT64");
+
+        let map_err = |e: String| {
+            FaucetError::Source(format!(
+                "spanner: failed to compute shard bounds for key {:?} \
+                 (it must be an INT64-typed column present in the query's output): {e}",
+                shard_cfg.key
+            ))
+        };
+
+        let stmt = build_statement(&bounds_sql, &params)?;
+        let mut tx = self.read_txn().await?;
+        let mut iter = tx.query(stmt).await.map_err(|e| map_err(e.to_string()))?;
+        let row = iter.next().await.map_err(|e| map_err(e.to_string()))?;
+        let Some(row) = row else {
+            return Ok(vec![ShardSpec::whole()]);
+        };
+        let lo: Option<i64> = row
+            .column_by_name("lo")
+            .map_err(|e| map_err(e.to_string()))?;
+        let hi: Option<i64> = row
+            .column_by_name("hi")
+            .map_err(|e| map_err(e.to_string()))?;
+        Ok(pk_shards_from_bounds(&shard_cfg.key, lo, hi, target))
+    }
+
+    /// Narrow this source to a single PK-range shard. The whole-dataset shard
+    /// clears any applied range (streams the full query).
+    async fn apply_shard(&self, shard: &ShardSpec) -> Result<(), FaucetError> {
+        let bounds = parse_pk_shard(shard, "spanner")?;
+        *self.applied_shard.lock().expect("shard mutex poisoned") = bounds;
+        Ok(())
+    }
+}
+
+impl SpannerSource {
+    /// Run the query and return all decoded rows plus (for incremental) the
+    /// new bookmark. Used by the non-streaming convenience methods.
+    async fn collect_all(
+        &self,
+        context: &HashMap<String, Value>,
+    ) -> Result<(Vec<Value>, Option<Value>), FaucetError> {
+        use futures::TryStreamExt;
+        let mut records: Vec<Value> = Vec::new();
+        let mut bookmark: Option<Value> = None;
+        let mut stream = self.stream_pages(context, self.config.batch_size);
+        while let Some(page) = stream.try_next().await? {
+            records.extend(page.records);
+            if page.bookmark.is_some() {
+                bookmark = page.bookmark;
+            }
+        }
+        Ok((records, bookmark))
+    }
+}
+
+/// Filter a page for incremental replication and advance `running_max`.
+/// For full replication the page passes through unchanged.
+fn apply_incremental(
+    page: Vec<Value>,
+    incr: Option<&IncrementalCtx>,
+    running_max: &mut Option<Value>,
+) -> Vec<Value> {
+    match incr {
+        None => page,
+        Some(ctx) => {
+            let kept = filter_incremental(page, &ctx.column, &ctx.start);
+            if let Some(m) = max_replication_value(&kept, &ctx.column) {
+                let m = m.clone();
+                *running_max = Some(match running_max.take() {
+                    Some(prev) => max_value(prev, m),
+                    None => m,
+                });
+            }
+            kept
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use faucet_core::shard::plan_pk_shards;
+    use serde_json::json;
+
+    fn base() -> SpannerSourceConfig {
+        SpannerSourceConfig::new("proj", "inst", "db", "SELECT * FROM t")
+    }
+
+    #[test]
+    fn build_full_returns_query_and_sorted_params() {
+        let mut cfg = base();
+        cfg.params.insert("zeta".into(), json!(1));
+        cfg.params.insert("alpha".into(), json!("x"));
+        let (q, p, incr) = build_query_and_params(&cfg, &HashMap::new(), None);
+        assert_eq!(q, "SELECT * FROM t");
+        assert_eq!(
+            p,
+            vec![
+                ("alpha".to_string(), json!("x")),
+                ("zeta".to_string(), json!(1))
+            ],
+            "params bind in deterministic (sorted) order"
+        );
+        assert!(incr.is_none());
+    }
+
+    #[test]
+    fn build_incremental_binds_bookmark_param() {
+        let mut cfg = base();
+        cfg.query = "SELECT * FROM t WHERE updated_at > @bookmark".into();
+        cfg.replication = SpannerReplication::Incremental {
+            column: "updated_at".into(),
+            initial_value: json!("1970-01-01"),
+        };
+        let (q, p, incr) = build_query_and_params(&cfg, &HashMap::new(), None);
+        assert_eq!(q, "SELECT * FROM t WHERE updated_at > @bookmark");
+        assert_eq!(p, vec![("bookmark".to_string(), json!("1970-01-01"))]);
+        assert_eq!(
+            incr,
+            Some(IncrementalCtx {
+                column: "updated_at".into(),
+                start: json!("1970-01-01")
+            })
+        );
+    }
+
+    #[test]
+    fn build_incremental_uses_stored_bookmark_over_initial() {
+        let mut cfg = base();
+        cfg.query = "SELECT * FROM t WHERE c > @bookmark".into();
+        cfg.replication = SpannerReplication::Incremental {
+            column: "c".into(),
+            initial_value: json!(0),
+        };
+        let stored = json!(500);
+        let (_q, p, incr) = build_query_and_params(&cfg, &HashMap::new(), Some(&stored));
+        assert_eq!(p, vec![("bookmark".to_string(), json!(500))]);
+        assert_eq!(incr.unwrap().start, json!(500));
+    }
+
+    #[test]
+    fn build_incremental_without_token_still_returns_filter_ctx() {
+        let mut cfg = base();
+        cfg.replication = SpannerReplication::Incremental {
+            column: "c".into(),
+            initial_value: json!(0),
+        };
+        let (q, p, incr) = build_query_and_params(&cfg, &HashMap::new(), None);
+        assert_eq!(q, "SELECT * FROM t");
+        assert!(p.is_empty());
+        assert!(incr.is_some(), "client-side filter must still run");
+    }
+
+    #[test]
+    fn build_context_binds_generated_named_params() {
+        let mut cfg = base();
+        cfg.query = "SELECT * FROM t WHERE tenant = {parent.id}".into();
+        let mut ctx = HashMap::new();
+        ctx.insert("parent.id".to_string(), json!(7));
+        let (q, p, _incr) = build_query_and_params(&cfg, &ctx, None);
+        assert_eq!(q, "SELECT * FROM t WHERE tenant = @_faucet_ctx_1");
+        assert_eq!(p, vec![("_faucet_ctx_1".to_string(), json!(7))]);
+    }
+
+    #[test]
+    fn build_statement_binds_scalars_and_rejects_containers() {
+        let stmt = build_statement(
+            "SELECT 1",
+            &[
+                ("s".to_string(), json!("x")),
+                ("i".to_string(), json!(7)),
+                ("f".to_string(), json!(1.5)),
+                ("b".to_string(), json!(true)),
+            ],
+        );
+        assert!(stmt.is_ok());
+
+        let err = build_statement("SELECT 1", &[("o".to_string(), json!({"a": 1}))]);
+        assert!(matches!(err, Err(FaucetError::Config(_))));
+        let err = build_statement("SELECT 1", &[("n".to_string(), Value::Null)]);
+        assert!(matches!(err, Err(FaucetError::Config(_))));
+        let err = build_statement("SELECT 1", &[("u".to_string(), json!(u64::MAX))]);
+        assert!(matches!(err, Err(FaucetError::Config(_))));
+    }
+
+    #[test]
+    fn apply_incremental_filters_and_tracks_max() {
+        let ctx = IncrementalCtx {
+            column: "c".into(),
+            start: json!(10),
+        };
+        let mut running = None;
+        let page = vec![json!({"c": 5}), json!({"c": 15}), json!({"c": 20})];
+        let kept = apply_incremental(page, Some(&ctx), &mut running);
+        assert_eq!(kept.len(), 2);
+        assert_eq!(running, Some(json!(20)));
+    }
+
+    #[test]
+    fn apply_incremental_full_passes_through() {
+        let mut running = None;
+        let page = vec![json!({"c": 1}), json!({"c": 2})];
+        let kept = apply_incremental(page, None, &mut running);
+        assert_eq!(kept.len(), 2);
+        assert_eq!(running, None);
+    }
+
+    #[test]
+    fn default_state_key_is_stable_and_valid() {
+        let cfg = base();
+        let k1 = default_state_key(&cfg);
+        let k2 = default_state_key(&cfg);
+        assert_eq!(k1, k2);
+        assert!(k1.starts_with("spanner:proj.inst.db:"));
+        faucet_core::state::validate_state_key(&k1).expect("derived key must be valid");
+    }
+
+    #[test]
+    fn dataset_uri_shape() {
+        let cfg = base();
+        let uri = format!(
+            "spanner://{}/{}/{}?query={}",
+            cfg.connection.project_id, cfg.connection.instance, cfg.connection.database, cfg.query
+        );
+        assert_eq!(uri, "spanner://proj/inst/db?query=SELECT * FROM t");
+    }
+
+    // ── PK-range sharding (Mode B) ──────────────────────────────────────────
+
+    #[test]
+    fn shard_wrap_uses_backtick_quoting() {
+        let spec = faucet_core::ShardSpec::new(
+            "1",
+            json!({"key": "id", "lo": 100, "hi": 200, "lo_unbounded": false, "hi_unbounded": false}),
+        );
+        let bounds = PkShardBounds::from_spec(&spec).unwrap();
+        let sql = bounds.wrap("SELECT * FROM t", quote_ident_spanner);
+        assert!(sql.contains("(SELECT * FROM t) AS _faucet_shard"), "{sql}");
+        assert!(sql.contains("`id` >= 100"), "backtick-quoted key: {sql}");
+        assert!(sql.contains("`id` < 200"), "half-open upper bound: {sql}");
+    }
+
+    #[test]
+    fn last_shard_wrap_covers_null_keys() {
+        let shards = plan_pk_shards("id", 0, 99, 3);
+        let last = PkShardBounds::from_spec(shards.last().unwrap()).unwrap();
+        let sql = last.wrap("SELECT * FROM t", quote_ident_spanner);
+        assert!(
+            sql.contains("`id` IS NULL"),
+            "last shard must match NULL keys: {sql}"
+        );
+    }
+
+    #[test]
+    fn shard_wrap_preserves_named_bind_params() {
+        // The @name parameters of a resolved incremental query survive the
+        // wrap — Spanner binds them by name, not by textual position.
+        let mut cfg = base();
+        cfg.query = "SELECT * FROM t WHERE c > @bookmark".into();
+        cfg.replication = SpannerReplication::Incremental {
+            column: "c".into(),
+            initial_value: json!(0),
+        };
+        let (q, p, _incr) = build_query_and_params(&cfg, &HashMap::new(), None);
+        let spec = faucet_core::ShardSpec::new(
+            "0",
+            json!({"key": "id", "lo": 0, "hi": 10, "lo_unbounded": false, "hi_unbounded": false}),
+        );
+        let wrapped = PkShardBounds::from_spec(&spec)
+            .unwrap()
+            .wrap(&q, quote_ident_spanner);
+        assert!(
+            wrapped.contains("@bookmark"),
+            "bind param survives: {wrapped}"
+        );
+        assert_eq!(p.len(), 1, "one bound value for the bookmark");
+    }
+
+    #[test]
+    fn bounds_query_uses_int64_cast() {
+        let sql = pk_bounds_query("SELECT * FROM t", "`id`", "INT64");
+        assert!(sql.contains("CAST(MIN(`id`) AS INT64) AS lo"), "{sql}");
+        assert!(
+            sql.contains("FROM (SELECT * FROM t) AS _faucet_bounds"),
+            "{sql}"
+        );
+    }
+
+    // ── discover: pure catalog-row grouping ─────────────────────────────────
+
+    fn cat_row(t: &str, c: &str, ty: &str, nullable: bool) -> CatalogRow {
+        (t.into(), c.into(), ty.into(), nullable)
+    }
+
+    #[test]
+    fn descriptors_group_catalog_rows_per_table() {
+        let rows = vec![
+            cat_row("orders", "id", "INT64", false),
+            cat_row("orders", "note", "STRING(MAX)", true),
+            cat_row("users", "score", "FLOAT64", false),
+        ];
+        let ds = descriptors_from_catalog(rows);
+        assert_eq!(ds.len(), 2);
+
+        assert_eq!(ds[0].name, "orders");
+        assert_eq!(ds[0].kind, "table");
+        assert_eq!(ds[0].estimated_rows, None, "spanner has no cheap estimate");
+        assert_eq!(ds[0].config_patch["query"], "SELECT * FROM `orders`");
+        let schema = ds[0].schema.as_ref().unwrap();
+        assert_eq!(schema["type"], "object");
+        assert_eq!(schema["properties"]["id"]["type"], "integer");
+        assert_eq!(
+            schema["properties"]["note"]["type"],
+            json!(["string", "null"]),
+            "nullable column"
+        );
+
+        assert_eq!(ds[1].name, "users");
+        assert_eq!(
+            ds[1].schema.as_ref().unwrap()["properties"]["score"]["type"],
+            "number"
+        );
+    }
+
+    #[test]
+    fn descriptors_quote_hostile_identifiers() {
+        let rows = vec![cat_row("we`ird", "id", "INT64", false)];
+        let ds = descriptors_from_catalog(rows);
+        let q = ds[0].config_patch["query"].as_str().unwrap();
+        assert_eq!(
+            q, "SELECT * FROM `we``ird`",
+            "interior backtick must be doubled"
+        );
+    }
+
+    #[test]
+    fn descriptors_empty_catalog_is_empty() {
+        assert!(descriptors_from_catalog(Vec::new()).is_empty());
+    }
+}

--- a/crates/source/spanner/tests/conformance.rs
+++ b/crates/source/spanner/tests/conformance.rs
@@ -1,0 +1,124 @@
+//! `faucet-conformance` Tier-1 battery for the Spanner source.
+//!
+//! Check 1 (config-schema validity) is pure and offline. Checks 2 (bounded
+//! memory), 3 (bookmark round-trip), and 6 (errors, not panics) run against
+//! the Cloud Spanner emulator via testcontainers and skip cleanly when Docker
+//! is unavailable.
+
+mod support;
+
+use faucet_conformance::{
+    assert_bookmark_roundtrip, assert_bounded_memory, assert_config_schema_valid_value,
+    assert_errors_not_panics,
+};
+use faucet_source_spanner::{SpannerReplication, SpannerSource, SpannerSourceConfig};
+
+// ── Check 1: config schema ──────────────────────────────────────────────────
+
+#[test]
+fn conformance_config_schema_valid() {
+    let schema = serde_json::to_value(schemars::schema_for!(SpannerSourceConfig)).unwrap();
+    assert_config_schema_valid_value(&schema, "faucet-source-spanner");
+}
+
+// ── Check 2: bounded-memory streaming (Docker) ──────────────────────────────
+
+/// Seed `n` rows into `nums(id INT64, v STRING)` via batched DML.
+async fn seed_nums(client: &gcloud_spanner::client::Client, n: usize) {
+    for chunk_start in (0..n).step_by(500) {
+        let values: Vec<String> = (chunk_start..(chunk_start + 500).min(n))
+            .map(|i| format!("({i}, 'v{i}')"))
+            .collect();
+        support::execute_dml(
+            client,
+            &format!("INSERT INTO nums (id, v) VALUES {}", values.join(", ")),
+        )
+        .await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn conformance_bounded_memory() {
+    let Some(emu) = support::start_emulator().await else {
+        return;
+    };
+    support::create_database(
+        &emu.host,
+        "conformance",
+        &["CREATE TABLE nums (id INT64 NOT NULL, v STRING(MAX)) PRIMARY KEY (id)"],
+    )
+    .await;
+    let client = support::raw_client(&emu.host, "conformance").await;
+    seed_nums(&client, 5_000).await;
+
+    let mut cfg = SpannerSourceConfig::new(
+        support::PROJECT,
+        support::INSTANCE,
+        "conformance",
+        "SELECT * FROM nums",
+    );
+    cfg.connection = support::connection(&emu.host, "conformance");
+    cfg.batch_size = 500;
+    let source = SpannerSource::new(cfg).await.expect("source");
+
+    assert_bounded_memory(&source, 500, 5_000).await;
+}
+
+// ── Check 3: bookmark round-trip (Docker) ───────────────────────────────────
+
+/// Drive an incremental source to completion once (capturing the max-`id`
+/// bookmark), feed it back via `apply_start_bookmark`, then re-drive with no
+/// new rows. The resumed run must replay strictly fewer records (zero — the
+/// `@bookmark` pushdown filters them all), proving the bookmark is honoured.
+#[tokio::test(flavor = "multi_thread")]
+async fn conformance_bookmark_roundtrip() {
+    let Some(emu) = support::start_emulator().await else {
+        return;
+    };
+    support::create_database(
+        &emu.host,
+        "resume",
+        &["CREATE TABLE nums (id INT64 NOT NULL, v STRING(MAX)) PRIMARY KEY (id)"],
+    )
+    .await;
+    let client = support::raw_client(&emu.host, "resume").await;
+    seed_nums(&client, 500).await;
+
+    let mut cfg = SpannerSourceConfig::new(
+        support::PROJECT,
+        support::INSTANCE,
+        "resume",
+        "SELECT * FROM nums WHERE id > @bookmark",
+    );
+    cfg.connection = support::connection(&emu.host, "resume");
+    cfg.replication = SpannerReplication::Incremental {
+        column: "id".into(),
+        initial_value: serde_json::json!(-1),
+    };
+    let source = SpannerSource::new(cfg).await.expect("source");
+
+    assert_bookmark_roundtrip(&source).await;
+}
+
+// ── Check 6: errors, not panics (Docker) ────────────────────────────────────
+
+/// Query a table that does not exist — both `fetch_all` and `stream_pages`
+/// must surface a typed `FaucetError`, never a panic.
+#[tokio::test(flavor = "multi_thread")]
+async fn conformance_errors_not_panics() {
+    let Some(emu) = support::start_emulator().await else {
+        return;
+    };
+    support::create_database(&emu.host, "errors", &[]).await;
+
+    let mut cfg = SpannerSourceConfig::new(
+        support::PROJECT,
+        support::INSTANCE,
+        "errors",
+        "SELECT * FROM does_not_exist",
+    );
+    cfg.connection = support::connection(&emu.host, "errors");
+    let source = SpannerSource::new(cfg).await.expect("source builds");
+
+    assert_errors_not_panics(&source).await;
+}

--- a/crates/source/spanner/tests/emulator.rs
+++ b/crates/source/spanner/tests/emulator.rs
@@ -1,0 +1,281 @@
+//! Spanner-emulator integration tests: full-type round-trip, incremental
+//! resume, discover, and PK-range sharding. Each test provisions its own
+//! database inside a fresh emulator container and skips cleanly when Docker
+//! is unavailable.
+
+mod support;
+
+use std::collections::HashMap;
+
+use faucet_core::Source;
+use faucet_source_spanner::{ShardConfig, SpannerReplication, SpannerSource, SpannerSourceConfig};
+use futures::TryStreamExt;
+use serde_json::{Value, json};
+
+fn cfg(host: &str, database: &str, query: &str) -> SpannerSourceConfig {
+    let mut cfg = SpannerSourceConfig::new(support::PROJECT, support::INSTANCE, database, query);
+    cfg.connection = support::connection(host, database);
+    cfg
+}
+
+async fn drain(source: &SpannerSource) -> (Vec<Value>, Option<Value>) {
+    let ctx = HashMap::new();
+    let mut stream = source.stream_pages(&ctx, 0);
+    let mut records = Vec::new();
+    let mut bookmark = None;
+    while let Some(page) = stream.try_next().await.expect("page") {
+        records.extend(page.records);
+        if page.bookmark.is_some() {
+            bookmark = page.bookmark;
+        }
+    }
+    (records, bookmark)
+}
+
+// ── Full-type round-trip ─────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn all_types_round_trip_to_json() {
+    let Some(emu) = support::start_emulator().await else {
+        return;
+    };
+    support::create_database(
+        &emu.host,
+        "types",
+        &["CREATE TABLE typed (
+            id INT64 NOT NULL,
+            big INT64,
+            f FLOAT64,
+            b BOOL,
+            s STRING(MAX),
+            bin BYTES(MAX),
+            n NUMERIC,
+            ts TIMESTAMP,
+            d DATE,
+            j JSON,
+            arr ARRAY<INT64>
+        ) PRIMARY KEY (id)"],
+    )
+    .await;
+    let client = support::raw_client(&emu.host, "types").await;
+    // 2^53 + 1 breaks under f64 — must survive losslessly.
+    support::execute_dml(
+        &client,
+        "INSERT INTO typed (id, big, f, b, s, bin, n, ts, d, j, arr) VALUES (
+            1, 9007199254740993, 2.5, TRUE, 'hello',
+            b'\\x01\\x02', NUMERIC '123.456789',
+            TIMESTAMP '2026-01-02 03:04:05+00:00', DATE '2026-01-02',
+            JSON '{\"a\": [1, 2]}', [1, 2, 3]
+        )",
+    )
+    .await;
+    support::execute_dml(
+        &client,
+        "INSERT INTO typed (id) VALUES (2)", // all-NULL row
+    )
+    .await;
+
+    let source = SpannerSource::new(cfg(&emu.host, "types", "SELECT * FROM typed ORDER BY id"))
+        .await
+        .expect("source");
+    let (records, bookmark) = drain(&source).await;
+    assert!(bookmark.is_none(), "full replication carries no bookmark");
+    assert_eq!(records.len(), 2);
+
+    let r = &records[0];
+    assert_eq!(r["id"], json!(1));
+    assert_eq!(r["big"], json!(9007199254740993i64), "INT64 is lossless");
+    assert_eq!(r["f"], json!(2.5));
+    assert_eq!(r["b"], json!(true));
+    assert_eq!(r["s"], json!("hello"));
+    assert_eq!(r["bin"], json!("AQI="), "BYTES arrive base64-encoded");
+    assert_eq!(r["n"], json!("123.456789"), "NUMERIC stays a string");
+    assert!(
+        r["ts"].as_str().unwrap().starts_with("2026-01-02T03:04:05"),
+        "TIMESTAMP is RFC 3339: {}",
+        r["ts"]
+    );
+    assert_eq!(r["d"], json!("2026-01-02"));
+    assert_eq!(r["j"], json!({"a": [1, 2]}), "JSON decodes structurally");
+    assert_eq!(r["arr"], json!([1, 2, 3]));
+
+    let null_row = &records[1];
+    assert_eq!(null_row["id"], json!(2));
+    for col in ["big", "f", "b", "s", "bin", "n", "ts", "d", "j", "arr"] {
+        assert_eq!(null_row[col], Value::Null, "column {col} must be null");
+    }
+}
+
+// ── Incremental resume across two runs ──────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn incremental_resume_reads_only_new_rows() {
+    let Some(emu) = support::start_emulator().await else {
+        return;
+    };
+    support::create_database(
+        &emu.host,
+        "incr",
+        &["CREATE TABLE ev (id INT64 NOT NULL, v STRING(MAX)) PRIMARY KEY (id)"],
+    )
+    .await;
+    let client = support::raw_client(&emu.host, "incr").await;
+    support::execute_dml(&client, "INSERT INTO ev (id, v) VALUES (1, 'a'), (2, 'b')").await;
+
+    let mut config = cfg(&emu.host, "incr", "SELECT * FROM ev WHERE id > @bookmark");
+    config.replication = SpannerReplication::Incremental {
+        column: "id".into(),
+        initial_value: json!(0),
+    };
+    let source = SpannerSource::new(config).await.expect("source");
+    assert!(source.state_key().is_some(), "incremental is resumable");
+
+    let (first, bookmark) = drain(&source).await;
+    assert_eq!(first.len(), 2);
+    let bookmark = bookmark.expect("bookmark on final page");
+    assert_eq!(bookmark, json!(2));
+
+    // New rows land; resume from the bookmark must read only those.
+    support::execute_dml(&client, "INSERT INTO ev (id, v) VALUES (3, 'c'), (4, 'd')").await;
+    source
+        .apply_start_bookmark(bookmark)
+        .await
+        .expect("apply bookmark");
+    let (second, bookmark2) = drain(&source).await;
+    let ids: Vec<i64> = second.iter().map(|r| r["id"].as_i64().unwrap()).collect();
+    assert_eq!(ids, vec![3, 4], "only rows past the bookmark");
+    assert_eq!(bookmark2, Some(json!(4)));
+}
+
+// ── Discover ─────────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn discover_returns_tables_with_schema() {
+    let Some(emu) = support::start_emulator().await else {
+        return;
+    };
+    support::create_database(
+        &emu.host,
+        "disco",
+        &[
+            "CREATE TABLE orders (id INT64 NOT NULL, note STRING(64)) PRIMARY KEY (id)",
+            "CREATE TABLE users (uid INT64 NOT NULL, score FLOAT64 NOT NULL) PRIMARY KEY (uid)",
+        ],
+    )
+    .await;
+
+    let source = SpannerSource::new(cfg(&emu.host, "disco", "SELECT 1"))
+        .await
+        .expect("source");
+    assert!(source.supports_discover());
+    let mut datasets = source.discover().await.expect("discover");
+    datasets.sort_by(|a, b| a.name.cmp(&b.name));
+    assert_eq!(datasets.len(), 2, "system schemas are excluded");
+
+    assert_eq!(datasets[0].name, "orders");
+    assert_eq!(datasets[0].kind, "table");
+    assert_eq!(datasets[0].config_patch["query"], "SELECT * FROM `orders`");
+    let schema = datasets[0].schema.as_ref().expect("schema");
+    assert_eq!(schema["properties"]["id"]["type"], "integer");
+    assert_eq!(
+        schema["properties"]["note"]["type"],
+        json!(["string", "null"])
+    );
+
+    assert_eq!(datasets[1].name, "users");
+    assert_eq!(
+        datasets[1].schema.as_ref().unwrap()["properties"]["score"]["type"],
+        "number"
+    );
+}
+
+// ── PK-range sharding ────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn shards_partition_the_read_without_loss_or_duplication() {
+    let Some(emu) = support::start_emulator().await else {
+        return;
+    };
+    support::create_database(
+        &emu.host,
+        "shards",
+        &["CREATE TABLE items (id INT64 NOT NULL, v STRING(MAX)) PRIMARY KEY (id)"],
+    )
+    .await;
+    let client = support::raw_client(&emu.host, "shards").await;
+    let values: Vec<String> = (0..100).map(|i| format!("({i}, 'v{i}')")).collect();
+    support::execute_dml(
+        &client,
+        &format!("INSERT INTO items (id, v) VALUES {}", values.join(", ")),
+    )
+    .await;
+
+    let mut config = cfg(&emu.host, "shards", "SELECT * FROM items");
+    config.shard = Some(ShardConfig { key: "id".into() });
+    let source = SpannerSource::new(config).await.expect("source");
+    assert!(source.is_shardable());
+
+    let shards = source.enumerate_shards(4).await.expect("enumerate");
+    assert_eq!(shards.len(), 4);
+
+    let mut seen: Vec<i64> = Vec::new();
+    for shard in &shards {
+        source.apply_shard(shard).await.expect("apply");
+        let (records, _) = drain(&source).await;
+        seen.extend(records.iter().map(|r| r["id"].as_i64().unwrap()));
+    }
+    seen.sort_unstable();
+    assert_eq!(seen, (0..100).collect::<Vec<i64>>(), "no loss, no dupes");
+
+    // The whole-dataset shard clears the narrowing.
+    source
+        .apply_shard(&faucet_core::ShardSpec::whole())
+        .await
+        .expect("clear shard");
+    let (all, _) = drain(&source).await;
+    assert_eq!(all.len(), 100);
+}
+
+// ── Coverage: stale reads, convenience fetch, default check probe ────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn stale_reads_fetch_all_and_check_probe() {
+    let Some(emu) = support::start_emulator().await else {
+        return;
+    };
+    support::create_database(
+        &emu.host,
+        "stale",
+        &["CREATE TABLE ev (id INT64 NOT NULL, v STRING(MAX)) PRIMARY KEY (id)"],
+    )
+    .await;
+    let client = support::raw_client(&emu.host, "stale").await;
+    support::execute_dml(&client, "INSERT INTO ev (id, v) VALUES (1, 'a'), (2, 'b')").await;
+    // Let the staleness horizon move safely past the commit.
+    tokio::time::sleep(std::time::Duration::from_millis(1500)).await;
+
+    let mut config = cfg(&emu.host, "stale", "SELECT * FROM ev ORDER BY id");
+    config.exact_staleness_secs = Some(1);
+    let source = SpannerSource::new(config).await.expect("source");
+
+    // The non-streaming convenience path drives the same decode pipeline.
+    let records = source.fetch_all().await.expect("fetch_all");
+    assert_eq!(records.len(), 2);
+    assert_eq!(records[0]["v"], json!("a"));
+
+    // The default check() probe pulls one real page through stream_pages.
+    let report = source
+        .check(&faucet_core::CheckContext::default())
+        .await
+        .expect("check");
+    assert!(
+        report
+            .probes
+            .iter()
+            .all(|p| !matches!(p.status, faucet_core::ProbeStatus::Fail { .. })),
+        "probe failed: {report:?}"
+    );
+
+    assert_eq!(source.connector_name(), "spanner");
+    assert!(source.config_schema().is_object());
+}

--- a/crates/source/spanner/tests/support/mod.rs
+++ b/crates/source/spanner/tests/support/mod.rs
@@ -1,0 +1,137 @@
+//! Shared Spanner-emulator bootstrap for the integration + conformance tests.
+//!
+//! Boots `gcr.io/cloud-spanner-emulator/emulator` via testcontainers and
+//! provisions an instance + database **programmatically** through the crate's
+//! own admin client — no `gcloud` sidecar, no `SPANNER_EMULATOR_HOST` env var
+//! (the emulator endpoint rides the connector's `emulator_host` config field,
+//! so parallel tests never race on process-global state).
+
+use faucet_source_spanner::{SpannerConnection, SpannerCredentials};
+use gcloud_googleapis::spanner::admin::database::v1::CreateDatabaseRequest;
+use gcloud_googleapis::spanner::admin::instance::v1::{CreateInstanceRequest, Instance};
+use gcloud_spanner::client::Client;
+use gcloud_spanner::statement::Statement;
+use testcontainers::{ContainerAsync, GenericImage, core::IntoContainerPort, runners::AsyncRunner};
+
+pub const PROJECT: &str = "test-project";
+pub const INSTANCE: &str = "test-instance";
+
+/// A running emulator + the `host:port` its gRPC endpoint is mapped to.
+pub struct Emulator {
+    pub _container: ContainerAsync<GenericImage>,
+    pub host: String,
+}
+
+/// Start the Spanner emulator. Returns `None` when Docker is unavailable so
+/// tests skip cleanly on machines without a daemon.
+pub async fn start_emulator() -> Option<Emulator> {
+    let image = GenericImage::new("gcr.io/cloud-spanner-emulator/emulator", "latest")
+        .with_exposed_port(9010.tcp());
+    let container = match image.start().await {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Skipping: Docker not available ({e})");
+            return None;
+        }
+    };
+    let port = container.get_host_port_ipv4(9010).await.ok()?;
+    Some(Emulator {
+        _container: container,
+        host: format!("127.0.0.1:{port}"),
+    })
+}
+
+/// A [`SpannerConnection`] pointed at the emulator.
+pub fn connection(host: &str, database: &str) -> SpannerConnection {
+    SpannerConnection {
+        project_id: PROJECT.into(),
+        instance: INSTANCE.into(),
+        database: database.into(),
+        auth: SpannerCredentials::ApplicationDefault,
+        max_sessions: 20,
+        emulator_host: Some(host.to_string()),
+    }
+}
+
+/// Create the shared test instance (idempotent: AlreadyExists is fine) and a
+/// database with the given DDL. The port maps before the emulator's gRPC
+/// server accepts calls, so instance creation doubles as the readiness poll.
+pub async fn create_database(host: &str, database: &str, ddl: &[&str]) {
+    let conn = connection(host, database);
+    // The mapped port exists before the emulator's gRPC server listens, so
+    // even building the admin channel can hit ConnectionRefused — retry it.
+    let mut admin = None;
+    for _ in 0..120 {
+        match conn.connect_admin().await {
+            Ok(a) => {
+                admin = Some(a);
+                break;
+            }
+            Err(_) => tokio::time::sleep(std::time::Duration::from_millis(500)).await,
+        }
+    }
+    let admin = admin.expect("spanner emulator admin endpoint never became reachable");
+
+    let mut created = false;
+    for _ in 0..120 {
+        let req = CreateInstanceRequest {
+            parent: format!("projects/{PROJECT}"),
+            instance_id: INSTANCE.into(),
+            instance: Some(Instance {
+                name: format!("projects/{PROJECT}/instances/{INSTANCE}"),
+                config: format!("projects/{PROJECT}/instanceConfigs/emulator-config"),
+                display_name: "faucet-test".into(),
+                node_count: 1,
+                ..Default::default()
+            }),
+        };
+        match admin.instance().create_instance(req, None).await {
+            Ok(mut op) => {
+                op.wait(None).await.expect("instance LRO");
+                created = true;
+                break;
+            }
+            Err(status) if status.code() == gcloud_gax::grpc::Code::AlreadyExists => {
+                created = true;
+                break;
+            }
+            Err(_) => tokio::time::sleep(std::time::Duration::from_millis(500)).await,
+        }
+    }
+    assert!(created, "spanner emulator never became ready");
+
+    let req = CreateDatabaseRequest {
+        parent: format!("projects/{PROJECT}/instances/{INSTANCE}"),
+        create_statement: format!("CREATE DATABASE `{database}`"),
+        extra_statements: ddl.iter().map(|s| s.to_string()).collect(),
+        ..Default::default()
+    };
+    admin
+        .database()
+        .create_database(req, None)
+        .await
+        .expect("create database")
+        .wait(None)
+        .await
+        .expect("database LRO");
+}
+
+/// Raw data-plane client for seeding/inspecting test data.
+pub async fn raw_client(host: &str, database: &str) -> Client {
+    connection(host, database).connect().await.expect("client")
+}
+
+/// Run a DML statement (INSERT/UPDATE/DELETE) in a read-write transaction.
+pub async fn execute_dml(client: &Client, sql: &str) {
+    let sql = sql.to_string();
+    client
+        .read_write_transaction(|tx| {
+            let sql = sql.clone();
+            Box::pin(async move {
+                tx.update(Statement::new(sql)).await?;
+                Ok::<_, gcloud_spanner::client::Error>(())
+            })
+        })
+        .await
+        .expect("dml");
+}

--- a/docs/book/src/cookbook/discover.md
+++ b/docs/book/src/cookbook/discover.md
@@ -86,6 +86,7 @@ listing, never a data scan.
 | `elasticsearch` | indices (non-`.`-system) | `_mapping` field types | `_cat/indices` docs.count | `index` |
 | `bigquery` | `dataset.table` (physical tables; capped at 500 enumerated / 100 schema fetches, warned) | `tables.get` | `numRows` | `query` |
 | `snowflake` | `schema.table` (base tables) | `information_schema.columns` | `row_count` | `query` |
+| `spanner` | base tables (default schema) | `INFORMATION_SCHEMA.COLUMNS` | — | `query` |
 | `s3` | common prefixes under the configured prefix (one delimiter listing; falls back to per-object entries) | — | — | `prefix` |
 | `gcs` | same as s3 | — | — | `prefix` (objects: `object_keys`) |
 

--- a/docs/book/src/cookbook/schema-drift.md
+++ b/docs/book/src/cookbook/schema-drift.md
@@ -129,11 +129,12 @@ Not every sink can evolve, and a schemaless sink has no schema to diverge from.
 | `postgres`, `mysql`, `mssql`, `sqlite` | ✅ | ✅ |
 | `bigquery` | ✅ | ✅ |
 | `elasticsearch` | ✅ | ✅ (add fields only) |
+| `spanner` | ✅ | ✅ (add + NOT NULL relax; no base-type widening) |
 | `iceberg` | ✅ | ❌ detect-only |
 | `jsonl`, `csv`, `stdout`, `mongodb`, `redis`, `http`, `kafka`, `s3`, `gcs`, `snowflake`, `parquet` | — (inert) | — |
 
-- **Evolvable** (six sinks): postgres, mysql, mssql, sqlite, bigquery,
-  elasticsearch. They implement in-place additive DDL.
+- **Evolvable** (seven sinks): postgres, mysql, mssql, sqlite, bigquery,
+  elasticsearch, spanner. They implement in-place additive DDL.
 - **Iceberg** reports its current schema so detection modes work, but **cannot
   `evolve`** — schema evolution is blocked on upstream `iceberg-rust 0.9.1`
   (issue #255). `on_drift: evolve` against iceberg is rejected at config-load
@@ -151,6 +152,11 @@ Not every sink can evolve, and a schemaless sink has no schema to diverge from.
 - **Elasticsearch** — can only **add** fields. Changing the type of an existing
   field is impossible in Elasticsearch mappings, so an existing-field type change
   is always treated as incompatible (routed by `on_incompatible`).
+- **Cloud Spanner** — adds columns and relaxes NOT NULL (by re-emitting the
+  column without the constraint), but Spanner cannot change a column's base
+  type (e.g. INT64→FLOAT64), so a base-type widening fails with guidance to set
+  `allow_type_widening: false` (classifying it incompatible instead). DDL runs
+  as a bounded long-running operation via the admin API.
 
 ## Composition rules
 

--- a/docs/book/src/cookbook/state.md
+++ b/docs/book/src/cookbook/state.md
@@ -149,6 +149,11 @@ records and the token atomically inside its own transaction:
   page and the watermark in a single Snowflake transaction.
 - **Redis sink** — one `MULTI`/`EXEC` transaction appends the page's commands
   plus a `SET _faucet_commit_token:<scope> <token>`.
+- **Cloud Spanner sink** — one read-write transaction buffers the page's
+  mutations plus an `InsertOrUpdate` on the `faucet_commit_token` table (no
+  leading underscore — Spanner identifiers must start with a letter), so
+  data and watermark commit atomically (the client retries `ABORTED` commits
+  automatically).
 - **MongoDB sink** — one multi-document transaction (replica set required)
   commits the page plus a `{_id: scope, token}` watermark document in the
   `_faucet_commit_token` collection.
@@ -169,11 +174,11 @@ Only certain connectors are allowed in an effectively-once (`delivery: exactly_o
 | Role | Allowed connectors | Why others are excluded |
 |------|--------------------|------------------------|
 | Source | `postgres-cdc`, `mysql-cdc`, `mongodb-cdc`, `kafka` | The source must emit a complete resume position (bookmark) on every page, over an immutable log, so resuming from a bookmark continues the record stream at exactly that position. Query-based sources (REST, SQL query, etc.) can return different data on replay — the pipeline would silently skip records it never wrote. |
-| Sink | `sqlite`, `postgres`, `mysql`, `mssql`, `iceberg`, `bigquery`, `kafka`, `snowflake`, `redis`, `mongodb` | The sink must be able to commit data and a watermark token atomically in a single transaction or snapshot. Sinks without transaction support cannot provide this guarantee (they can still reach effectively-once via keyed upsert, below). The MongoDB sink requires a replica set (or sharded cluster) — multi-document transactions are unavailable on a standalone server. |
+| Sink | `sqlite`, `postgres`, `mysql`, `mssql`, `iceberg`, `bigquery`, `kafka`, `snowflake`, `redis`, `mongodb`, `spanner` | The sink must be able to commit data and a watermark token atomically in a single transaction or snapshot. Sinks without transaction support cannot provide this guarantee (they can still reach effectively-once via keyed upsert, below). The MongoDB sink requires a replica set (or sharded cluster) — multi-document transactions are unavailable on a standalone server. |
 
 **Keyed upsert relaxes the source restriction entirely**: any source feeding an
 upsert-capable sink (`postgres`, `sqlite`, `mysql`, `mssql`, `mongodb`,
-`elasticsearch`, `bigquery`) configured with `write_mode: upsert` + `key` is
+`elasticsearch`, `bigquery`, `spanner`) configured with `write_mode: upsert` + `key` is
 accepted under `delivery: exactly_once` and reported as
 `effectively-once (keyed upsert)`. There is no watermark in this mode — the
 idempotence comes from the sink converging on the keyed row.

--- a/docs/book/src/cookbook/upsert.md
+++ b/docs/book/src/cookbook/upsert.md
@@ -29,7 +29,7 @@ the top level of the sink's `config`, alongside `table_name` etc.):
 
 ## Supported sinks and their native primitives
 
-Seven sinks support `upsert`/`delete`; every other sink is append-only.
+Eight sinks support `upsert`/`delete`; every other sink is append-only.
 
 | Sink | Requires | Native primitive |
 |------|----------|------------------|
@@ -40,6 +40,7 @@ Seven sinks support `upsert`/`delete`; every other sink is append-only.
 | `mongodb` | — (schemaless) | `replace_one(upsert)` / `delete_one`, `key` → match filter |
 | `elasticsearch` | — (schemaless) | `_bulk` `index` / `delete`, `key` → `_id` |
 | `bigquery` | a defined table schema + `key` columns | in-place `MERGE … USING UNNEST(@payload)` (no staging table) |
+| `spanner` | `key` must equal the table's primary-key columns | `InsertOrUpdate` / `Delete` mutations (mutations always address the PK) |
 
 The **SQL sinks require column-mapping mode** — `column_mapping: auto_map`
 (postgres/mysql/sqlite) or `auto_columns` (mssql). The single-JSONB-column blob

--- a/docs/book/src/reference/choosing.md
+++ b/docs/book/src/reference/choosing.md
@@ -103,6 +103,17 @@ Use **`source-bigquery`** / **`source-snowflake`** to *read out of* a warehouse
 **sink**. To transform data already inside the warehouse, reach for
 [dbt](https://www.getdbt.com/) — that's not faucet's job.
 
+## Cloud Spanner: OLTP system of record
+
+Use **`source-spanner`** to move data *out of* Spanner into a warehouse or lake
+(the common direction — Spanner is an expensive OLTP system of record). It
+streams arbitrary SQL over gRPC, supports incremental replication via a
+monotonic column (`@bookmark`), stale reads to offload the leader, and PK-range
+sharding. Use **`sink-spanner`** when Spanner *is* the destination — its
+mutation API pairs naturally with `write_mode: upsert` (`InsertOrUpdate` keyed
+on the primary key) and supports effectively-once delivery via a commit-token
+read-write transaction.
+
 ## Sinks: column-mapped vs. JSON blob (SQL databases)
 
 The Postgres/MySQL/SQLite/SQL Server sinks can write either:

--- a/docs/book/src/reference/connectors.md
+++ b/docs/book/src/reference/connectors.md
@@ -1,6 +1,6 @@
 # Connector catalog
 
-faucet-stream ships **24 sources** and **18 sinks**. Each is a Cargo feature
+faucet-stream ships **25 sources** and **20 sinks**. Each is a Cargo feature
 (`source-<name>` / `sink-<name>`) and an independently published crate. Full API
 docs are on [docs.rs](https://docs.rs/faucet-stream).
 
@@ -39,6 +39,7 @@ Legend: ✓ supported · ✗ not applicable. Tier: T1 = passes the faucet-confor
 | Apache Parquet | T1 ✅ | `source-parquet` | ✓ | ✗ | ✗ | ✗ | ✗ | local/glob/S3, vectorized Arrow reader, projection |
 | BigQuery | T1 ✅ᵐ | `source-bigquery` | ✓ | ✗ | ✗ | ✗ | ✓ | `jobs.query` + pageToken pagination |
 | Snowflake | T1 ✅ᵐ | `source-snowflake` | ✓ | ✗ | ✗ | ✗ | ✓ | SQL REST API, server-side partitions |
+| Cloud Spanner | T1 ✅ᵉ | `source-spanner` | ✓ | ✓⁸ | ✗ | ✗ | ✓ | streaming SQL (gRPC), incremental `@bookmark` replication, stale reads, PK-range sharding |
 | Singer bridge ⚠️ | T2 ⚠️ | `source-singer` | ✓ | ✓⁹ | ✗ | ✗ | ✗ | runs an external Singer tap; NDJSON over stdout, STATE→bookmark. **Tier-2 / experimental** |
 
 ¹⁰ **Discover** = enumerates the datasets behind the connection for
@@ -77,7 +78,10 @@ individual tap — pair it with a keyed/upsert sink for clean, effectively-once
 > `elasticsearch`, `bigquery`, and `snowflake` sources and the `http` sink. The
 > mock faithfully drives the paging, schema, and error-handling behavior the
 > checks assert, but it is not an end-to-end test against the real system (no
-> credentialed cloud/service backend runs in CI).
+> credentialed cloud/service backend runs in CI). **ᵉ** marks the Cloud Spanner
+> pair, whose battery runs against Google's official **Spanner emulator**
+> (Docker) — a real gRPC Spanner implementation, closer to end-to-end than a
+> wiremock but still not the managed service.
 >
 > The connectors still marked **Tier-2** are the ones whose full battery cannot
 > run in CI (so they are not conformance-certified — Tier-2 means "not certified,"
@@ -116,6 +120,7 @@ file/append sinks (`jsonl`, `csv`, `stdout`) it's a no-op — they write per rec
 | Stdout | T1 ✅ | `sink-stdout` | no-op | ✗ | ✗ | ✗ | JSON Lines / pretty JSON / TSV |
 | Apache Kafka | T1 ✅ | `sink-kafka` | ✓ | ✗ | ✗ | **✓** | producer, batched sends, multi-topic routing; transactional producer + compacted watermark side-topic for effectively-once |
 | AWS Kinesis | T1 ✅ | `sink-kinesis` | ✓ | ✗ | ✗ | ✗ | batched PutRecords; partition-key routing, per-entry partial-failure retry (DLQ-routable) |
+| Cloud Spanner | T1 ✅ᵉ | `sink-spanner` | ✓ | ✗ | **✓** | **✓** | batched mutations (`insert` / `insert_or_update` / `delete`), cell-budget chunking, commit-token transaction for effectively-once |
 | Apache Parquet | T1 ✅ | `sink-parquet` | ✓ | ✗⁶ | ✗ | ✗ | local/S3, schema inference (re-inferred per file on rollover), row/byte rollover |
 | Apache Iceberg | T2 | `sink-iceberg` | ✓ | ✗⁶ | ✗ | **✓** | REST/Glue/SQL/HMS catalog, local + cloud (S3/GCS) warehouses, `fast_append` snapshot, Parquet data files |
 
@@ -129,7 +134,9 @@ commit-token record into a compacted side-topic in one Kafka transaction; the
 Snowflake sink runs one multi-statement `BEGIN;INSERT;MERGE;COMMIT` request; the
 Redis sink wraps the page plus a `_faucet_commit_token:<scope>` key in one
 `MULTI`/`EXEC`; the MongoDB sink commits the page plus a watermark document in
-one multi-document transaction (replica set required). Sinks configured with
+one multi-document transaction (replica set required); the Cloud Spanner sink
+buffers the page's mutations plus a `faucet_commit_token` row in one
+read-write transaction. Sinks configured with
 `write_mode: upsert` + `key` also reach effectively-once via keyed dedup, with
 any source. See
 [Effectively-once delivery](../cookbook/state.md#effectively-once-delivery).
@@ -172,6 +179,7 @@ sinks can actually *act* on it varies:
 |------|------------------|
 | `postgres`, `mysql`, `mssql`, `sqlite`, `bigquery` | **✓ evolve** — in-place additive/widening DDL |
 | `elasticsearch` | **✓ evolve** — can add fields only (existing-field type change is incompatible) |
+| `spanner` | **✓ evolve** — additive columns + NOT NULL relax; base-type widening is not supported by Spanner (use `allow_type_widening: false`) |
 | `iceberg` | detect-only — `warn`/`ignore`/`fail`/`quarantine` work; `evolve` blocked on upstream `iceberg-rust` (#255) |
 | `jsonl`, `csv`, `stdout`, `mongodb`, `redis`, `http`, `kafka`, `s3`, `gcs`, `snowflake`, `parquet` | — (schemaless; the `schema:` policy is inert) |
 
@@ -186,6 +194,7 @@ nuances (e.g. SQLite widening is a no-op; Elasticsearch can only add fields).
 | REST / GraphQL / XML | Bearer, Basic, ApiKey (header), ApiKeyQuery, OAuth2 (client-credentials), TokenEndpoint, Custom headers — see [Auth cookbook](../cookbook/auth.md) |
 | BigQuery | service-account key (path or inline JSON), application-default credentials |
 | Snowflake | JWT key-pair, OAuth |
+| Cloud Spanner | service-account key (path or inline JSON), application-default credentials |
 | Kafka | SASL (PLAIN/SCRAM) + TLS |
 | WebSocket | none, Bearer token, Custom headers |
 | Elasticsearch | basic, API key, bearer, none |

--- a/examples/README.md
+++ b/examples/README.md
@@ -43,6 +43,7 @@ These run immediately after installing the CLI — great for a first smoke test:
 | `rest_to_jsonl_with_vault.yaml` | Vault KV v2 secret injected as a Bearer token via `${vault:…#field}`; requires `VAULT_ADDR` + `VAULT_TOKEN` and `--features secrets-vault` |
 | `websocket_to_jsonl.yaml` | none (live public WS endpoint — Binance BTC/USDT trade stream, no auth) |
 | `kinesis_to_jsonl.yaml` | AWS Kinesis → JSONL with resumable per-shard checkpoints; runs against LocalStack (`docker run -p 4566:4566 -e SERVICES=kinesis localstack/localstack`) |
+| `spanner_to_jsonl.yaml` | Cloud Spanner → JSONL with incremental `@bookmark` replication; runs against the Spanner emulator (`docker run -p 9010:9010 gcr.io/cloud-spanner-emulator/emulator`) |
 | `backfill_sqlite_to_jsonl.yaml` | `faucet backfill` — replay a date range from a local SQLite table one day per window unit, one JSONL file per unit (`${backfill.*}` tokens, durable `--resume` marker) |
 | `scheduled_nightly.yaml` | `faucet schedule` — CSV→JSONL pipeline on a nightly cron at 02:00 Pacific; demonstrates timezone, overlap_policy, and max_consecutive_failures |
 

--- a/faucet-stream/Cargo.toml
+++ b/faucet-stream/Cargo.toml
@@ -40,6 +40,7 @@ source = [
     "source-gcs",
     "source-bigquery",
     "source-snowflake",
+    "source-spanner",
     "source-singer",
 ]
 ## All sink connectors.
@@ -63,6 +64,7 @@ sink = [
     "sink-parquet",
     "sink-gcs",
     "sink-iceberg",
+    "sink-spanner",
 ]
 ## All state-store backends (file backend is exposed via `faucet-core` directly).
 state = [
@@ -132,6 +134,8 @@ source-parquet = ["dep:faucet-source-parquet"]
 source-gcs = ["dep:faucet-source-gcs", "dep:faucet-common-gcs"]
 source-bigquery = ["dep:faucet-source-bigquery", "dep:faucet-common-bigquery"]
 source-snowflake = ["dep:faucet-source-snowflake", "dep:faucet-common-snowflake"]
+## Enable the Google Cloud Spanner query source.
+source-spanner = ["dep:faucet-source-spanner", "dep:faucet-common-spanner"]
 
 ## Individual sink connectors.
 sink-bigquery = ["dep:faucet-sink-bigquery"]
@@ -156,6 +160,8 @@ sink-http = ["dep:faucet-sink-http"]
 sink-stdout = ["dep:faucet-sink-stdout"]
 sink-kafka = ["dep:faucet-sink-kafka", "dep:faucet-common-kafka"]
 sink-kinesis = ["dep:faucet-sink-kinesis", "dep:faucet-common-kinesis"]
+## Enable the Google Cloud Spanner sink.
+sink-spanner = ["dep:faucet-sink-spanner", "dep:faucet-common-spanner"]
 sink-parquet = ["dep:faucet-sink-parquet"]
 sink-gcs = ["dep:faucet-sink-gcs", "dep:faucet-common-gcs"]
 
@@ -195,6 +201,7 @@ faucet-common-gcs = { workspace = true, optional = true }
 faucet-common-kafka = { workspace = true, optional = true }
 faucet-common-kinesis = { workspace = true, optional = true }
 faucet-common-snowflake = { workspace = true, optional = true }
+faucet-common-spanner = { workspace = true, optional = true }
 faucet-source-rest = { workspace = true, optional = true }
 faucet-source-singer = { workspace = true, optional = true }
 faucet-source-graphql = { workspace = true, optional = true }
@@ -220,6 +227,7 @@ faucet-source-parquet = { workspace = true, optional = true }
 faucet-source-gcs = { workspace = true, optional = true }
 faucet-source-bigquery = { workspace = true, optional = true }
 faucet-source-snowflake = { workspace = true, optional = true }
+faucet-source-spanner = { workspace = true, optional = true }
 faucet-sink-bigquery = { workspace = true, optional = true }
 faucet-sink-iceberg = { workspace = true, optional = true }
 faucet-sink-postgres = { workspace = true, optional = true }
@@ -227,6 +235,7 @@ faucet-sink-jsonl = { workspace = true, optional = true }
 faucet-sink-snowflake = { workspace = true, optional = true }
 faucet-sink-kafka = { workspace = true, optional = true }
 faucet-sink-kinesis = { workspace = true, optional = true }
+faucet-sink-spanner = { workspace = true, optional = true }
 faucet-sink-mysql = { workspace = true, optional = true }
 faucet-sink-mssql = { workspace = true, optional = true }
 faucet-sink-sqlite = { workspace = true, optional = true }

--- a/faucet-stream/src/lib.rs
+++ b/faucet-stream/src/lib.rs
@@ -32,6 +32,7 @@
 //! | `source-elasticsearch` | Elasticsearch search/scroll source |
 //! | `source-kafka` | Apache Kafka consumer source |
 //! | `source-kinesis` | AWS Kinesis Data Streams source |
+//! | `source-spanner` | Google Cloud Spanner query source |
 //! | `source-parquet` | Apache Parquet file source (local, glob, S3) |
 //! | `sink-bigquery` | Google BigQuery streaming insert sink |
 //! | `sink-iceberg` | Apache Iceberg sink (append-only, REST/Glue/SQL/HMS catalogs) |
@@ -50,6 +51,7 @@
 //! | `sink-http` | HTTP POST sink |
 //! | `sink-kafka` | Apache Kafka producer sink |
 //! | `sink-kinesis` | AWS Kinesis Data Streams sink |
+//! | `sink-spanner` | Google Cloud Spanner mutation sink |
 //! | `sink-parquet` | Apache Parquet file sink (local, S3) |
 //! | `kafka-schema-registry` | Schema Registry support for Kafka connectors |
 //! | `source` | All source connectors |
@@ -176,6 +178,21 @@ pub mod source {
         pub use faucet_source_kinesis::*;
     }
 
+    #[cfg(feature = "source-bigquery")]
+    pub mod bigquery {
+        pub use faucet_source_bigquery::*;
+    }
+
+    #[cfg(feature = "source-snowflake")]
+    pub mod snowflake {
+        pub use faucet_source_snowflake::*;
+    }
+
+    #[cfg(feature = "source-spanner")]
+    pub mod spanner {
+        pub use faucet_source_spanner::*;
+    }
+
     #[cfg(feature = "source-parquet")]
     pub mod parquet {
         pub use faucet_source_parquet::*;
@@ -290,6 +307,21 @@ pub mod source {
         pub use faucet_source_kinesis::*;
     }
 
+    #[cfg(feature = "source-bigquery")]
+    pub mod bigquery {
+        pub use faucet_source_bigquery::*;
+    }
+
+    #[cfg(feature = "source-snowflake")]
+    pub mod snowflake {
+        pub use faucet_source_snowflake::*;
+    }
+
+    #[cfg(feature = "source-spanner")]
+    pub mod spanner {
+        pub use faucet_source_spanner::*;
+    }
+
     #[cfg(feature = "source-parquet")]
     pub mod parquet {
         pub use faucet_source_parquet::*;
@@ -402,6 +434,11 @@ pub mod sink {
         pub use faucet_sink_kinesis::*;
     }
 
+    #[cfg(feature = "sink-spanner")]
+    pub mod spanner {
+        pub use faucet_sink_spanner::*;
+    }
+
     #[cfg(feature = "sink-parquet")]
     pub mod parquet {
         pub use faucet_sink_parquet::*;
@@ -432,6 +469,14 @@ pub mod common_kafka {
 #[cfg(any(feature = "source-kinesis", feature = "sink-kinesis"))]
 pub mod common_kinesis {
     pub use faucet_common_kinesis::*;
+}
+
+/// Shared Cloud Spanner types (credentials enum, connection block, value
+/// conversion), re-exported for library callers when either Spanner
+/// connector is enabled.
+#[cfg(any(feature = "source-spanner", feature = "sink-spanner"))]
+pub mod common_spanner {
+    pub use faucet_common_spanner::*;
 }
 
 // ── State-store backends ─────────────────────────────────────────────────────

--- a/schemas/faucet.schema.json
+++ b/schemas/faucet.schema.json
@@ -4876,6 +4876,101 @@
         }
       ]
     },
+    "source_spanner__SpannerCredentials": {
+      "description": "Credentials used to authenticate against Cloud Spanner.\n\nSerialized in the project-wide adjacently-tagged shape:\n\n```yaml\nauth:\n  type: service_account_key_path\n  config:\n    path: /secrets/sa.json\n```",
+      "oneOf": [
+        {
+          "description": "Load a service-account key from a JSON file on disk.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "service_account_key_path"
+            },
+            "config": {
+              "type": "object",
+              "properties": {
+                "path": {
+                  "description": "Filesystem path to the service-account key JSON.",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "Inline service-account key JSON (prefer `${vault:…}` / `${env:…}`\ninterpolation over literal keys in config files).",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "service_account_key"
+            },
+            "config": {
+              "type": "object",
+              "properties": {
+                "json": {
+                  "description": "The full service-account key JSON document.",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "Application Default Credentials: `GOOGLE_APPLICATION_CREDENTIALS`,\n`gcloud auth application-default login`, or the GCE/GKE metadata\nserver.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "application_default"
+            }
+          }
+        }
+      ]
+    },
+    "source_spanner__SpannerReplication": {
+      "description": "How the source replicates rows across runs.\n\nSerializes as `{ type: full }` or\n`{ type: incremental, column: \"...\", initial_value: ... }`.",
+      "oneOf": [
+        {
+          "description": "Every run fetches the full result set (default).",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "full"
+            }
+          }
+        },
+        {
+          "description": "Only rows whose `column` is strictly greater than the stored bookmark\n(or `initial_value` on the first run) are emitted.\n\nThe bookmark is applied two ways: if the query contains the named\nparameter `@bookmark`, it is bound so the server filters (efficient);\nthe source *also* filters client-side as a correctness backstop. The\nnew maximum of `column` is persisted on the final page.\n\nSpanner does not implicitly coerce parameter types: a string bookmark\ncompared against a `TIMESTAMP` column needs an explicit cast in the\nquery, e.g. `WHERE updated_at > TIMESTAMP(@bookmark)`.",
+          "type": "object",
+          "properties": {
+            "column": {
+              "description": "Column whose value is the replication cursor (e.g. `updated_at`).",
+              "type": "string"
+            },
+            "initial_value": {
+              "description": "Lower bound used on the first run, before any bookmark is stored."
+            },
+            "type": {
+              "type": "string",
+              "const": "incremental"
+            }
+          }
+        }
+      ]
+    },
+    "source_spanner__ShardConfig": {
+      "description": "Primary-key range sharding settings for the Spanner source (clustered\nMode B execution).\n\nThe source is split by contiguous ranges of an **INT64-typed** column:\neach shard runs ``SELECT * FROM (<query>) AS _faucet_shard WHERE `key` >=\nlo AND `key` < hi``. The column must be present in the query's output.\n\n**Nullable keys:** rows whose key is NULL are invisible to the `MIN`/`MAX`\nrange enumeration but are still read — exactly one shard (the last)\nadditionally matches ``key IS NULL``, so NULL-key rows are covered by\nprecisely one shard with no loss and no duplication.",
+      "type": "object",
+      "properties": {
+        "key": {
+          "description": "INT64 column to range-partition on. Backtick-quoted before use, so it\nis safe against injection but must name a real output column.",
+          "type": "string"
+        }
+      }
+    },
     "source_parquet__ParquetLocation": {
       "description": "Where to read Parquet data from.",
       "oneOf": [
@@ -6648,6 +6743,96 @@
           "const": "bytes"
         }
       ]
+    },
+    "sink_spanner__SpannerCredentials": {
+      "description": "Credentials used to authenticate against Cloud Spanner.\n\nSerialized in the project-wide adjacently-tagged shape:\n\n```yaml\nauth:\n  type: service_account_key_path\n  config:\n    path: /secrets/sa.json\n```",
+      "oneOf": [
+        {
+          "description": "Load a service-account key from a JSON file on disk.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "service_account_key_path"
+            },
+            "config": {
+              "type": "object",
+              "properties": {
+                "path": {
+                  "description": "Filesystem path to the service-account key JSON.",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "Inline service-account key JSON (prefer `${vault:…}` / `${env:…}`\ninterpolation over literal keys in config files).",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "service_account_key"
+            },
+            "config": {
+              "type": "object",
+              "properties": {
+                "json": {
+                  "description": "The full service-account key JSON document.",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "Application Default Credentials: `GOOGLE_APPLICATION_CREDENTIALS`,\n`gcloud auth application-default login`, or the GCE/GKE metadata\nserver.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "application_default"
+            }
+          }
+        }
+      ]
+    },
+    "sink_spanner__WriteMode": {
+      "description": "Write semantics for a sink. Serialized snake_case. Default `Append`.",
+      "oneOf": [
+        {
+          "description": "Insert every record (today's behaviour).",
+          "type": "string",
+          "const": "append"
+        },
+        {
+          "description": "Insert-or-update by `key`; optionally route delete-marked rows to deletes.",
+          "type": "string",
+          "const": "upsert"
+        },
+        {
+          "description": "Delete by `key` for every record.",
+          "type": "string",
+          "const": "delete"
+        }
+      ]
+    },
+    "sink_spanner__DeleteMarker": {
+      "description": "Identifies a record as a delete (vs. an upsert) by a marker field's value.\ne.g. `{ field: \"__op\", values: [\"d\", \"delete\"] }`.",
+      "type": "object",
+      "properties": {
+        "field": {
+          "description": "Field name whose value flags a delete.",
+          "type": "string"
+        },
+        "values": {
+          "description": "Values of `field` that mean \"this row is a delete\".",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     },
     "sink_http__AuthSpec": {
       "description": "A connector's `auth:` field: **either** an inline auth definition `A`\n(the `{ type, config }` shape), **or** a `{ ref: <name> }` reference to a\nshared provider defined in the top-level `auth:` catalog.\n\n`ref` is mutually exclusive with inline fields — supplying both is a\ndeserialization error.",
@@ -9331,6 +9516,131 @@
         },
         {
           "type": "object",
+          "title": "spanner",
+          "properties": {
+            "type": {
+              "const": "spanner"
+            },
+            "config": {
+              "anyOf": [
+                {
+                  "properties": {
+                    "project_id": {
+                      "description": "GCP project ID that owns the Spanner instance.",
+                      "type": "string"
+                    },
+                    "instance": {
+                      "description": "Spanner instance ID.",
+                      "type": "string"
+                    },
+                    "database": {
+                      "description": "Database name within the instance.",
+                      "type": "string"
+                    },
+                    "auth": {
+                      "description": "Credentials. Defaults to Application Default Credentials.",
+                      "$ref": "#/$defs/source_spanner__SpannerCredentials",
+                      "default": {
+                        "type": "application_default"
+                      }
+                    },
+                    "max_sessions": {
+                      "description": "Upper bound on pooled Spanner sessions (server-side resources).\nChannels are sized automatically at one per 100 sessions.",
+                      "type": [
+                        "integer",
+                        "string"
+                      ],
+                      "format": "uint",
+                      "minimum": 0,
+                      "default": 100
+                    },
+                    "emulator_host": {
+                      "description": "Emulator endpoint override (`host:port`, e.g. `localhost:9010`).\nWhen set, the connection is plaintext and unauthenticated — exactly\nwhat `SPANNER_EMULATOR_HOST` does, but scoped to this connector so\nparallel pipelines/tests don't race on a process-global env var.\nThe env var is still honored when this field is unset.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "query": {
+                      "description": "GoogleSQL query to run. Use named parameters (`@name`) for\n[`params`](Self::params), and the named parameter `@bookmark` to bind\nthe incremental cursor server-side.",
+                      "type": "string"
+                    },
+                    "params": {
+                      "description": "Named bind parameters for the query. Values must be scalars (string,\ninteger, float, or boolean) — Spanner parameters are typed, and\nnull/array/object values have no unambiguous parameter type.",
+                      "type": "object",
+                      "additionalProperties": true,
+                      "default": {}
+                    },
+                    "batch_size": {
+                      "description": "Records per emitted [`StreamPage`](faucet_core::StreamPage). `0` emits\nthe whole result set as a single page. Defaults to\n[`DEFAULT_BATCH_SIZE`].",
+                      "type": [
+                        "integer",
+                        "string"
+                      ],
+                      "format": "uint",
+                      "minimum": 0,
+                      "default": 1000
+                    },
+                    "exact_staleness_secs": {
+                      "description": "Read at a timestamp this many seconds in the past instead of a strong\nread. Stale reads can be served by any replica, offloading the leader\n— at the cost of missing rows committed within the staleness window.",
+                      "type": [
+                        "integer",
+                        "null",
+                        "string"
+                      ],
+                      "format": "uint64",
+                      "minimum": 0
+                    },
+                    "replication": {
+                      "description": "Replication mode. Defaults to [`SpannerReplication::Full`].",
+                      "$ref": "#/$defs/source_spanner__SpannerReplication",
+                      "default": {
+                        "type": "full"
+                      }
+                    },
+                    "state_key": {
+                      "description": "Explicit state-store key for the bookmark. When unset, a key is\nderived from the database path and a query fingerprint.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "shard": {
+                      "description": "Optional primary-key range sharding for clustered (Mode B) execution.\n\nWhen set, the source advertises itself as shardable: the cluster\ncoordinator splits the query's `key` range into contiguous slices that\ndifferent workers process concurrently. Has **no effect** outside the\ncluster coordinator (a plain `faucet run` streams the whole query).",
+                      "anyOf": [
+                        {
+                          "$ref": "#/$defs/source_spanner__ShardConfig"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "title": "SpannerSourceConfig",
+                  "description": "Configuration for [`SpannerSource`](crate::SpannerSource).",
+                  "type": "object"
+                },
+                true
+              ]
+            },
+            "transforms": {
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "inherit_transforms": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
           "title": "parquet",
           "properties": {
             "type": {
@@ -11129,6 +11439,115 @@
                   },
                   "title": "KinesisSinkConfig",
                   "description": "Configuration for [`KinesisSink`](crate::KinesisSink).",
+                  "type": "object"
+                },
+                true
+              ]
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "title": "spanner",
+          "properties": {
+            "type": {
+              "const": "spanner"
+            },
+            "config": {
+              "anyOf": [
+                {
+                  "properties": {
+                    "project_id": {
+                      "description": "GCP project ID that owns the Spanner instance.",
+                      "type": "string"
+                    },
+                    "instance": {
+                      "description": "Spanner instance ID.",
+                      "type": "string"
+                    },
+                    "database": {
+                      "description": "Database name within the instance.",
+                      "type": "string"
+                    },
+                    "auth": {
+                      "description": "Credentials. Defaults to Application Default Credentials.",
+                      "$ref": "#/$defs/sink_spanner__SpannerCredentials",
+                      "default": {
+                        "type": "application_default"
+                      }
+                    },
+                    "max_sessions": {
+                      "description": "Upper bound on pooled Spanner sessions (server-side resources).\nChannels are sized automatically at one per 100 sessions.",
+                      "type": [
+                        "integer",
+                        "string"
+                      ],
+                      "format": "uint",
+                      "minimum": 0,
+                      "default": 100
+                    },
+                    "emulator_host": {
+                      "description": "Emulator endpoint override (`host:port`, e.g. `localhost:9010`).\nWhen set, the connection is plaintext and unauthenticated — exactly\nwhat `SPANNER_EMULATOR_HOST` does, but scoped to this connector so\nparallel pipelines/tests don't race on a process-global env var.\nThe env var is still honored when this field is unset.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "table_name": {
+                      "description": "Target table name.",
+                      "type": "string"
+                    },
+                    "batch_size": {
+                      "description": "Maximum rows per Spanner commit. Defaults to [`DEFAULT_BATCH_SIZE`].\n\nEach chunk is applied as one atomic commit. Spanner additionally caps\na commit at ~80,000 mutated *cells* (rows × columns, plus secondary\nindex amplification), so the sink also splits chunks to stay under a\nconservative 60,000-cell budget regardless of `batch_size`.\n\n`batch_size = 0` is the \"no batching\" sentinel: the entire upstream\npage is written in as few commits as the cell budget allows.",
+                      "type": [
+                        "integer",
+                        "string"
+                      ],
+                      "format": "uint",
+                      "minimum": 0,
+                      "default": 1000
+                    },
+                    "ddl_timeout_secs": {
+                      "description": "Upper bound (seconds) on waiting for a schema-change operation\n(`ALTER TABLE …` long-running operation) to complete. Defaults to 300.",
+                      "type": [
+                        "integer",
+                        "string"
+                      ],
+                      "format": "uint64",
+                      "minimum": 0,
+                      "default": 300
+                    },
+                    "write_mode": {
+                      "description": "Append (default), upsert, or delete.",
+                      "$ref": "#/$defs/sink_spanner__WriteMode",
+                      "default": "append"
+                    },
+                    "key": {
+                      "description": "Key columns. Required and non-empty for upsert/delete; ignored for append.",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "default": []
+                    },
+                    "delete_marker": {
+                      "description": "Optional. Upsert only: rows whose `field` matches one of `values` are\ndeletes; all others are upserts. The marker field is stripped from\nupsert rows before writing.",
+                      "anyOf": [
+                        {
+                          "$ref": "#/$defs/sink_spanner__DeleteMarker"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "title": "SpannerSinkConfig",
+                  "description": "Configuration for the Cloud Spanner sink.",
                   "type": "object"
                 },
                 true


### PR DESCRIPTION
Closes #304
Closes #305

Part of the roadmap epic #38.

## What

Adds the **Cloud Spanner connector pair** as three new crates (all `1.0.0`), Tier-1 with the full conformance battery running against Google's official Spanner emulator in CI (new **ᵉ** tier marker).

### `faucet-common-spanner`
- `SpannerCredentials` (`application_default` / `service_account_key_path` / `service_account_key`, adjacent-tagged, Debug-masked) + flattened `SpannerConnection` block with `connect()` / `connect_admin()` builders.
- **Per-connector `emulator_host` override** (GCS `storage_host` precedent) so tests/pipelines never race on the process-global `SPANNER_EMULATOR_HOST` env var (still honored when unset).
- `INFORMATION_SCHEMA` type parsing, generic row→JSON decode (INT64 lossless past 2^53, NUMERIC as string, JSON columns parsed, BYTES base64, ARRAY/STRUCT recursed), and JSON→mutation encode keyed by the destination column type.

### `faucet-source-spanner` (#304)
- Streaming SQL over gRPC (`ExecuteStreamingSql`) with `enable_resume: false` so the page loop stays cancel-safe under `run_stream`'s `select!`.
- Named query params; **incremental replication** via the `@bookmark` named param (MSSQL-shaped: server-side pushdown + client-side backstop filter, final page carries the bookmark → resumable).
- Stale reads (`exact_staleness_secs`), `faucet discover` via `INFORMATION_SCHEMA`, INT64 PK-range **Mode-B sharding**, `dataset_uri`, default real-read `check()` probe.
- Conformance checks 1/2/3/6 against the emulator.

### `faucet-sink-spanner` (#305)
- Batched mutations — `Insert` (append), `InsertOrUpdate` (upsert), `Delete` — chunked under a **60,000-cell commit budget** (Spanner's ~80k mutated-cells/commit limit, with headroom for index amplification).
- `write_mode: upsert|delete` through the unified `WriteSpec`; **`key` must set-equal the table PK** (mutations always address the primary key) — validated at first write and in `check()`, delete keys reordered into PK order.
- **Exactly-once**: one `read_write_transaction` commits the page's mutations plus a `faucet_commit_token` watermark row atomically (`InsertOrUpdate` + commit-timestamp column; mutation set cloned per ABORTED auto-retry; token stored opaquely incl. `#<bookmark>` suffixes). *The emulator caught that Spanner identifiers can't start with `_`, so the canonical `_faucet_commit_token` name is dropped for the leading-underscore-free `faucet_commit_token` — documented.*
- **Schema drift**: `current_schema()` from `INFORMATION_SCHEMA`; `evolve_schema` does additive `ADD COLUMN` + NOT NULL relax via the admin DDL LRO (bounded by `ddl_timeout_secs`); base-type widening is impossible in Spanner → typed error advising `allow_type_widening: false`.
- Conformance checks 1/4/5 against the emulator.

## Wiring (maintenance table swept)
Registry dispatch/schemas/descriptions + all four capability allowlists (idempotent, upsert, schema-evolution, discover) · umbrella + CLI features · CI feature-isolation matrix · capability matrix + choosing.md + upsert/state/schema-drift/discover cookbooks · README tables + counts · `cli/examples/spanner_to_jsonl.yaml` + examples README · `connectors/registry.json` · `schemas/faucet.schema.json` regenerated.

## Drive-by fixes
- The umbrella crate never re-exported the **bigquery/snowflake source modules** (features existed, `pub mod`s missing) — fixed alongside the spanner modules.
- Corrected stale connector counts in README/docs (the sinks table had 19 rows under an "(18)" header since the Kinesis PR).

## Tests
- 85 unit tests (pure: decode/encode/type-parse, statement/param building, bookmark precedence, mutation planning, cell-budget chunking, DDL strings, key≡PK validation, discover grouping, shard predicates).
- 24 emulator integration/conformance tests (full-type round-trip, incremental resume, discover, shard partition no-loss/no-dup, upsert convergence, delete markers, exactly-once replay + token-table auto-create + scope isolation, evolve add/relax/reject-widen, doctor probes) — all run locally against the emulator and in CI.
- Patch coverage measured locally at **93.1% lines** across the three crates.