### PR TITLE
feat(sink-postgres): COPY bulk-load fast-path (write_method: copy)

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -155,41 +155,50 @@ between two Postgres databases."
 
 **1,000,000 rows** (`bench` → `bench_dest`, seed 42, 1 warmup + 3 timed runs).
 Postgres 16 in Docker (colima) on an Apple M3 Pro; faucet `source-postgres` →
-`sink-postgres` (multi-row `INSERT`s via `sqlx`, AutoMap columns) vs Meltano
-`tap-postgres` → `target-postgres` 0.8.0.
+`sink-postgres` (AutoMap columns) vs Meltano `tap-postgres` →
+`target-postgres` 0.8.0. faucet is measured on both of its append write paths:
+multi-row `INSERT`s and the `write_method: copy` bulk-load fast-path (#308,
+`COPY … FROM STDIN` — the benchmark config's default since it is the best
+append path).
 
 | Tool | Median wall-clock (s) | Stddev (s) | Throughput (rows/s) | Peak RSS (MiB) | Rows out |
 |---|---|---|---|---|---|
-| **faucet-stream** | **11.17** | 0.335 | **89,500** | **35.9** | 1,000,000 |
+| **faucet-stream (`write_method: copy`)** | **8.12** | 0.142 | **123,200** | **35.9** | 1,000,000 |
+| faucet-stream (multi-row `INSERT`) | 10.10 | 0.112 | 99,000 | 35.9 | 1,000,000 |
 | Meltano (Singer) | 129.8 | 34.347 | 7,706 | 485.7 | 1,000,000 |
 
-On this workload/hardware faucet was **~11.6× faster** and used **~13.5× less peak
-memory** (35.9 vs 485.7 MiB), with **exact row-count parity** (1,000,000 =
-1,000,000). Note also the stddev: faucet is tight (±0.3s) while Meltano's Python/
-pipe runtime jitters badly at scale (±34s). This is the whole point of the
-scenario: **the gap collapses from ~96× to ~12× as the workload moves from
-parse-bound to sink-bound**, because both tools become bounded by the same
-Postgres write path. The narrowing, all at 1M rows on the same machine:
+On this workload/hardware faucet's COPY path was **~16× faster** than Meltano
+(and its INSERT path ~12.9×), with **~13.5× less peak memory** (35.9 vs 485.7
+MiB) and **exact row-count parity** (1,000,000 = 1,000,000). Note also the
+stddev: faucet is tight (±0.1s) while Meltano's Python/pipe runtime jitters
+badly at scale (±34s). (The Meltano row is from the same-machine PR #307 run;
+the faucet rows were re-measured when the COPY fast-path landed. faucet's
+INSERT number improved slightly between runs — 11.17s → 10.10s — normal
+machine-load drift.) This is the whole point of the scenario: **the gap
+collapses from ~96× to ~16× as the workload moves from parse-bound to
+sink-bound**, because both tools become bounded by the same Postgres write
+path. The narrowing, all at 1M rows on the same machine:
 
 | Scenario | Bottleneck | faucet (rows/s) | Meltano (rows/s) | Gap |
 |---|---|---|---|---|
 | A — CSV → JSONL | parse/serialize (best case) | 712,403 | 7,383 | **~96×** |
 | B — Postgres → JSONL | typed row decode | 179,700 | 7,184 | **~25×** |
-| C — Postgres → Postgres | **destination write (sink-bound)** | 89,500 | 7,706 | **~12×** |
+| C — Postgres → Postgres | **destination write (sink-bound)** | 123,200 (`copy`) / 99,000 (`insert`) | 7,706 | **~16× / ~13×** |
 
-So quote **~12×** for a realistic DB→DB move, and treat the ~96× CSV→JSONL figure
-as the upper bound, not the typical case.
+So quote **~16×** for a realistic DB→DB move (with `write_method: copy`), and
+treat the ~96× CSV→JSONL figure as the upper bound, not the typical case.
 
-**Why ~12× and not more?** It is near the ceiling for this shape, and the profile
-proves it: at 1M, faucet spends ~62% of its wall on CPU (decode Postgres rows →
-JSON → re-encode/bind) and the rest blocked on the destination's `INSERT` +
-WAL — i.e. faucet is already feeding Postgres near its ingest rate and adds
-little overhead, while Meltano adds ~12×. You cannot out-run the database at a
-task where you are the one feeding it. Batch size is *not* the lever (throughput
-is flat from 500→5000 rows/`INSERT` and worsens past the 65 535 bind-param cap);
-the real headroom is a `COPY`-based bulk-load fast-path (~5–10× faster than
-`INSERT`), which would widen this gap further since Meltano's target uses
-`INSERT` too.
+**Why ~16× and not more?** It is near the ceiling for this shape, and the
+profile proves it: at 1M, faucet spends ~62% of its wall on CPU (decode
+Postgres rows → JSON → re-encode) and the rest blocked on the destination
+write. `COPY` roughly halves the write step vs multi-row `INSERT` (the 5–10×
+folk number applies to the write step in isolation, and Amdahl caps the
+end-to-end gain at ~1.6× when 62% of the time is decode) — measured end-to-end
+it bought **1.24×** (10.10s → 8.12s). Meltano's `target-postgres` uses
+`INSERT`, so it cannot follow. The remaining headroom is the decode side
+(skipping the JSON intermediate for same-engine moves), which is niche and
+high-complexity — see issue #308. Batch size is *not* the lever (throughput is
+flat from 500→5000 rows/`INSERT` and worsens past the 65 535 bind-param cap).
 
 > **Reproduce.** `make bench-postgres` (needs Docker) runs all three scenarios;
 > `scripts/run-bench.sh --postgres --rows 1000000` scales Scenario C to the 1M

--- a/benchmarks/faucet/postgres_to_postgres.yaml
+++ b/benchmarks/faucet/postgres_to_postgres.yaml
@@ -30,3 +30,6 @@ pipeline:
       column_mapping: auto_map
       max_connections: 8
       batch_size: 5000
+      # Benchmark faucet's best append path: the COPY bulk-load fast-path
+      # (#308). Drop this line to measure the multi-row INSERT path instead.
+      write_method: copy

--- a/crates/sink/postgres/README.md
+++ b/crates/sink/postgres/README.md
@@ -72,8 +72,9 @@ faucet run pipeline.yaml
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `batch_size` | int | `1000` | Maximum rows per multi-row `INSERT`. **`0` = no batching** — the whole page is sent in one statement. See [Streaming & batching](#streaming--batching). |
+| `batch_size` | int | `1000` | Maximum rows per multi-row `INSERT` (or per `COPY` under `write_method: copy`). **`0` = no batching** — the whole page is sent in one statement. See [Streaming & batching](#streaming--batching). |
 | `max_connections` | int | `5` | Maximum connections in the `sqlx` pool. |
+| `write_method` | `"insert" \| "copy"` | `"insert"` | How append-mode rows are shipped. `copy` uses the `COPY … FROM STDIN` bulk-load fast-path — see [Bulk load](#bulk-load-write_method-copy). |
 
 ### Write mode
 
@@ -191,6 +192,64 @@ The sink re-chunks each incoming `StreamPage` so individual multi-row `INSERT` s
 - **`batch_size = 0`** — the "no batching" sentinel: the entire upstream page is forwarded in a single logical write. Use it when the source already emits Postgres-tuned page sizes. AutoMap still sub-splits internally to respect the 65 535-parameter ceiling.
 
 `batch_size` is purely a chunk-size knob — connection pooling, identifier quoting, and JSONB vs AutoMap behaviour are unchanged.
+
+## Bulk load (`write_method: copy`)
+
+For **append-mode bulk loads**, set `write_method: copy` to ship rows via
+`COPY … FROM STDIN (FORMAT text)` instead of multi-row `INSERT` — typically
+**5–10× faster** at the destination, because `COPY` skips per-statement
+planning/binding overhead entirely (issue #308).
+
+```yaml
+sink:
+  type: postgres
+  config:
+    connection_url: ${env:PG_URL}
+    table_name: events
+    column_mapping: auto_map     # jsonb mapping works too
+    write_method: copy
+```
+
+Semantics are identical to the `INSERT` path — same rows, same target, same
+durability. The server parses every field with the destination column's
+*input function*, exactly like the `INSERT` path's `$N::<udt>` casts, so
+timestamps, numerics, booleans, and JSONB all land the same way. Values are
+escaped for COPY's text format (tabs, newlines, backslashes, control
+characters), and the column set is the same union-of-present-fields the
+`INSERT` path computes (columns absent from every record keep their
+`DEFAULT`).
+
+Restrictions and interactions:
+
+- **Append-only.** `COPY` has no `ON CONFLICT`, so `write_method: copy` +
+  `write_mode: upsert|delete` is rejected at config load with a typed error.
+- **All-or-nothing per batch.** One bad row fails the whole `COPY` batch —
+  the same behaviour as a failed multi-row `INSERT`. With a `dlq:` block the
+  DLQ router's `on_batch_error` policy applies (`dlq_all` routes the failed
+  page's rows to the DLQ; `propagate` aborts the run).
+- **Exactly-once is unaffected.** Under `delivery: exactly_once` the
+  watermark path (`write_batch_idempotent`) always uses the
+  `INSERT`/transaction machinery regardless of `write_method`, because the
+  page and its commit token must land in one atomic transaction.
+
+## Destination tuning
+
+Knobs that make bulk loads dramatically faster but change durability or
+consistency guarantees are **left to you on the destination** — faucet never
+flips them silently:
+
+- **`UNLOGGED` tables** — skip WAL entirely for the target table. Fastest
+  possible ingest; the table is truncated on crash recovery and is not
+  replicated. Suitable for staging tables you can re-load.
+- **`SET synchronous_commit = off`** (per session/role/database) — commits
+  return before WAL reaches disk. A crash can lose the last few transactions
+  (no corruption). Often a large win on spinning disks or busy WAL devices.
+- **Drop/disable indexes and constraints before the load, rebuild after** —
+  index maintenance frequently dominates bulk-insert cost; one bulk rebuild
+  is much cheaper than a million incremental updates.
+
+See the [throughput tuning guide](https://pawansikawat.github.io/faucet-stream/cookbook/tuning.html)
+for the full decision table.
 
 ## Write modes (upsert / delete)
 

--- a/crates/sink/postgres/src/config.rs
+++ b/crates/sink/postgres/src/config.rs
@@ -24,6 +24,29 @@ impl Default for PostgresColumnMapping {
     }
 }
 
+/// How rows are shipped to PostgreSQL in append mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum PostgresWriteMethod {
+    /// Multi-row `INSERT INTO … VALUES …` — the default. Works with every
+    /// write mode and the exactly-once transaction path.
+    #[default]
+    Insert,
+    /// `COPY … FROM STDIN (FORMAT text)` bulk load — typically **5–10×
+    /// faster** than multi-row `INSERT` for bulk append (issue #308).
+    ///
+    /// **Append-only**: `COPY` has no `ON CONFLICT`, so combining
+    /// `write_method: copy` with `write_mode: upsert|delete` is rejected at
+    /// config load. The exactly-once path (`write_batch_idempotent`) always
+    /// uses the `INSERT`/transaction path regardless of this setting — the
+    /// watermark token must commit atomically with the page's data.
+    ///
+    /// Error semantics are all-or-nothing per batch, the same as a failed
+    /// multi-row `INSERT`: one bad row fails the whole `COPY` and the DLQ
+    /// router's `on_batch_error` policy applies.
+    Copy,
+}
+
 /// Configuration for the PostgreSQL sink.
 #[derive(Clone, Serialize, Deserialize, JsonSchema)]
 pub struct PostgresSinkConfig {
@@ -79,6 +102,13 @@ pub struct PostgresSinkConfig {
     /// and a UNIQUE/PRIMARY KEY constraint on `key`.
     #[serde(flatten)]
     pub write: faucet_core::WriteSpec,
+    /// How append-mode rows are shipped: multi-row `insert` (default) or the
+    /// `copy` bulk-load fast-path (`COPY … FROM STDIN`, typically 5–10×
+    /// faster for bulk append). `copy` is append-only — it is rejected with
+    /// `write_mode: upsert|delete` — and the exactly-once path always stays
+    /// on `insert` so data + watermark commit in one transaction.
+    #[serde(default)]
+    pub write_method: PostgresWriteMethod,
 }
 
 fn default_batch_size() -> usize {
@@ -98,6 +128,7 @@ impl std::fmt::Debug for PostgresSinkConfig {
             .field("column_mapping", &self.column_mapping)
             .field("batch_size", &self.batch_size)
             .field("max_connections", &self.max_connections)
+            .field("write_method", &self.write_method)
             .finish()
     }
 }
@@ -113,6 +144,7 @@ impl PostgresSinkConfig {
             batch_size: DEFAULT_BATCH_SIZE,
             max_connections: 5,
             write: faucet_core::WriteSpec::default(),
+            write_method: PostgresWriteMethod::default(),
         }
     }
 
@@ -142,6 +174,13 @@ impl PostgresSinkConfig {
     /// Set the maximum number of connections in the pool.
     pub fn max_connections(mut self, n: u32) -> Self {
         self.max_connections = n;
+        self
+    }
+
+    /// Choose how append-mode rows are shipped (`insert` vs the `copy`
+    /// bulk-load fast-path). See [`PostgresWriteMethod`].
+    pub fn with_write_method(mut self, method: PostgresWriteMethod) -> Self {
+        self.write_method = method;
         self
     }
 }
@@ -268,5 +307,39 @@ mod tests {
         }"#;
         let config: PostgresSinkConfig = serde_json::from_str(json).unwrap();
         assert_eq!(config.max_connections, 20);
+    }
+
+    #[test]
+    fn write_method_defaults_to_insert() {
+        let config = PostgresSinkConfig::new("postgres://localhost/test", "events");
+        assert_eq!(config.write_method, PostgresWriteMethod::Insert);
+
+        // Absent in JSON → insert (back-compat: existing configs unchanged).
+        let json = r#"{
+            "connection_url": "postgres://localhost/test",
+            "table_name": "events"
+        }"#;
+        let config: PostgresSinkConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.write_method, PostgresWriteMethod::Insert);
+    }
+
+    #[test]
+    fn write_method_serde_round_trips() {
+        let json = r#"{
+            "connection_url": "postgres://localhost/test",
+            "table_name": "events",
+            "write_method": "copy"
+        }"#;
+        let config: PostgresSinkConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.write_method, PostgresWriteMethod::Copy);
+        let text = serde_json::to_string(&config).unwrap();
+        assert!(text.contains("\"write_method\":\"copy\""));
+    }
+
+    #[test]
+    fn with_write_method_builder() {
+        let config = PostgresSinkConfig::new("postgres://localhost/test", "events")
+            .with_write_method(PostgresWriteMethod::Copy);
+        assert_eq!(config.write_method, PostgresWriteMethod::Copy);
     }
 }

--- a/crates/sink/postgres/src/copy.rs
+++ b/crates/sink/postgres/src/copy.rs
@@ -1,0 +1,319 @@
+//! Pure encoding for the `COPY … FROM STDIN (FORMAT text)` bulk-load
+//! fast-path (issue #308).
+//!
+//! COPY text format is line-oriented: one row per `\n`-terminated line,
+//! fields separated by tabs, SQL NULL as the unquoted marker `\N`. The
+//! server parses each field with the destination column's *input function* —
+//! exactly the same semantics as the `INSERT` path's `$N::<udt>` casts — so
+//! type behaviour is identical between the two write methods. What differs
+//! is the wire encoding, and that is where silent corruption lives: a raw
+//! tab, newline, or backslash inside a value would corrupt row/field framing
+//! unless escaped. Everything in this module is pure and unit-tested.
+
+use crate::sink::pg_bind_text;
+use faucet_core::util::quote_ident;
+use serde_json::Value;
+
+/// Append one field's text to `buf`, escaping for COPY text format.
+///
+/// Escapes: `\` → `\\`, tab → `\t`, LF → `\n`, CR → `\r`, and the other
+/// C-style control escapes PostgreSQL itself emits (`\b` backspace, `\f`
+/// form feed, `\v` vertical tab). Everything else — including the literal
+/// characters `N`, quotes, and all multibyte UTF-8 — passes through
+/// unchanged. SQL NULL is *not* handled here: the caller writes the bare
+/// `\N` marker instead of calling this (a literal string `"N"` therefore
+/// stays `N`, and a literal `"\N"` becomes `\\N` — unambiguous).
+pub(crate) fn encode_copy_text_field(buf: &mut String, text: &str) {
+    for ch in text.chars() {
+        match ch {
+            '\\' => buf.push_str("\\\\"),
+            '\t' => buf.push_str("\\t"),
+            '\n' => buf.push_str("\\n"),
+            '\r' => buf.push_str("\\r"),
+            '\u{0008}' => buf.push_str("\\b"),
+            '\u{000C}' => buf.push_str("\\f"),
+            '\u{000B}' => buf.push_str("\\v"),
+            other => buf.push(other),
+        }
+    }
+}
+
+/// The COPY payload for one chunk: the (declared-order) column list actually
+/// present in at least one record, the encoded row data, and how many rows
+/// were encoded.
+#[derive(Debug)]
+pub(crate) struct CopyPayload {
+    pub columns: Vec<String>,
+    pub data: String,
+    pub rows: usize,
+}
+
+/// Encode a chunk of records for AutoMap COPY.
+///
+/// Semantics mirror the `INSERT` path exactly:
+/// - the column set is the **union** of table columns present in *any*
+///   record (declared table order) — a column absent from every record is
+///   left out entirely so its DEFAULT still applies;
+/// - a record missing a unioned column ships SQL NULL (`\N`);
+/// - records with **no** matching columns are skipped (the caller logs);
+/// - non-object records are an error;
+/// - each value is rendered with the same text semantics as the `INSERT`
+///   path's [`pg_bind_text`] (JSON/JSONB columns get JSON text; scalars get
+///   plain text; containers into non-JSON columns get JSON text so the
+///   server's input function fails loudly), then COPY-escaped.
+///
+/// Returns `Ok(None)` when no record matched any column.
+pub(crate) fn build_auto_map_payload(
+    records: &[Value],
+    table_columns: &[(String, String)],
+) -> Result<Option<CopyPayload>, String> {
+    // Pass 1: validate + find which table columns any record uses.
+    let mut used: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    let mut matched_any: Vec<&serde_json::Map<String, Value>> = Vec::with_capacity(records.len());
+    for record in records {
+        let obj = record
+            .as_object()
+            .ok_or_else(|| "AutoMap requires JSON object records".to_string())?;
+        let mut matched = false;
+        for (col, _) in table_columns {
+            if obj.contains_key(col) {
+                used.insert(col.as_str());
+                matched = true;
+            }
+        }
+        if matched {
+            matched_any.push(obj);
+        } else {
+            tracing::warn!(
+                record_keys = ?obj.keys().collect::<Vec<_>>(),
+                "record has no keys matching table columns, skipping"
+            );
+        }
+    }
+    if matched_any.is_empty() {
+        return Ok(None);
+    }
+
+    let insert_columns: Vec<&(String, String)> = table_columns
+        .iter()
+        .filter(|(c, _)| used.contains(c.as_str()))
+        .collect();
+
+    // Pass 2: encode rows.
+    let mut data = String::with_capacity(matched_any.len() * 64);
+    for obj in &matched_any {
+        for (idx, (col, udt)) in insert_columns.iter().enumerate() {
+            if idx > 0 {
+                data.push('\t');
+            }
+            match pg_bind_text(obj.get(col.as_str()), udt) {
+                None => data.push_str("\\N"),
+                Some(text) => encode_copy_text_field(&mut data, &text),
+            }
+        }
+        data.push('\n');
+    }
+
+    Ok(Some(CopyPayload {
+        columns: insert_columns.iter().map(|(c, _)| c.clone()).collect(),
+        rows: matched_any.len(),
+        data,
+    }))
+}
+
+/// Encode a chunk of records for single-JSONB-column COPY: one escaped JSON
+/// text per line. Nothing is skipped — every record has a JSON form.
+pub(crate) fn build_jsonb_payload(records: &[Value]) -> CopyPayload {
+    let mut data = String::with_capacity(records.len() * 64);
+    for record in records {
+        // `pg_bind_text` with a jsonb udt always yields the JSON text for
+        // non-null values; a JSON `null` record ships SQL NULL.
+        match pg_bind_text(Some(record), "jsonb") {
+            None => data.push_str("\\N"),
+            Some(text) => encode_copy_text_field(&mut data, &text),
+        }
+        data.push('\n');
+    }
+    CopyPayload {
+        columns: vec![],
+        rows: records.len(),
+        data,
+    }
+}
+
+/// `COPY <table_ref> ("c1", "c2") FROM STDIN (FORMAT text)`. `table_ref` is
+/// already quoted/qualified; column names are quoted here.
+pub(crate) fn copy_statement(table_ref: &str, columns: &[String]) -> String {
+    let cols = columns
+        .iter()
+        .map(|c| quote_ident(c))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("COPY {table_ref} ({cols}) FROM STDIN (FORMAT text)")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn escaped(s: &str) -> String {
+        let mut buf = String::new();
+        encode_copy_text_field(&mut buf, s);
+        buf
+    }
+
+    #[test]
+    fn every_escape_character_is_escaped() {
+        assert_eq!(escaped("back\\slash"), "back\\\\slash");
+        assert_eq!(escaped("tab\there"), "tab\\there");
+        assert_eq!(escaped("new\nline"), "new\\nline");
+        assert_eq!(escaped("carriage\rreturn"), "carriage\\rreturn");
+        assert_eq!(escaped("back\u{0008}space"), "back\\bspace");
+        assert_eq!(escaped("form\u{000C}feed"), "form\\ffeed");
+        assert_eq!(escaped("vertical\u{000B}tab"), "vertical\\vtab");
+        // All of them at once, adjacent.
+        assert_eq!(escaped("\\\t\n\r"), "\\\\\\t\\n\\r");
+    }
+
+    #[test]
+    fn plain_text_unicode_and_quotes_pass_through() {
+        assert_eq!(
+            escaped("héllo wörld — 日本語 🚰"),
+            "héllo wörld — 日本語 🚰"
+        );
+        assert_eq!(escaped(r#"quotes " and ' fine"#), r#"quotes " and ' fine"#);
+        assert_eq!(escaped(""), "");
+    }
+
+    #[test]
+    fn literal_n_strings_are_distinct_from_the_null_marker() {
+        // The string "N" encodes as plain N — only bare `\N` (emitted by the
+        // caller for SQL NULL) means NULL.
+        assert_eq!(escaped("N"), "N");
+        // The string "\N" escapes its backslash → `\\N`, which COPY decodes
+        // back to the two characters `\N`, not NULL.
+        assert_eq!(escaped("\\N"), "\\\\N");
+    }
+
+    fn cols(pairs: &[(&str, &str)]) -> Vec<(String, String)> {
+        pairs
+            .iter()
+            .map(|(c, u)| (c.to_string(), u.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn auto_map_rows_are_tab_separated_in_declared_column_order() {
+        let table = cols(&[("id", "int8"), ("name", "text"), ("ok", "bool")]);
+        // Record key order differs from table order; encoding must follow
+        // the table's declared order.
+        let payload = build_auto_map_payload(&[json!({"ok": true, "id": 7, "name": "a"})], &table)
+            .unwrap()
+            .unwrap();
+        assert_eq!(payload.columns, vec!["id", "name", "ok"]);
+        assert_eq!(payload.data, "7\ta\ttrue\n");
+        assert_eq!(payload.rows, 1);
+    }
+
+    #[test]
+    fn auto_map_missing_field_ships_null_marker() {
+        let table = cols(&[("id", "int8"), ("name", "text")]);
+        let payload =
+            build_auto_map_payload(&[json!({"id": 1, "name": "a"}), json!({"id": 2})], &table)
+                .unwrap()
+                .unwrap();
+        assert_eq!(payload.data, "1\ta\n2\t\\N\n");
+        // Explicit JSON null also ships NULL.
+        let payload = build_auto_map_payload(&[json!({"id": 3, "name": null})], &table)
+            .unwrap()
+            .unwrap();
+        assert_eq!(payload.data, "3\t\\N\n");
+    }
+
+    #[test]
+    fn auto_map_unused_columns_are_left_out_so_defaults_apply() {
+        // `created` appears in no record → omitted from the column list
+        // (COPYing an explicit NULL would override a column DEFAULT).
+        let table = cols(&[("id", "int8"), ("created", "timestamptz")]);
+        let payload = build_auto_map_payload(&[json!({"id": 1})], &table)
+            .unwrap()
+            .unwrap();
+        assert_eq!(payload.columns, vec!["id"]);
+        assert_eq!(payload.data, "1\n");
+    }
+
+    #[test]
+    fn auto_map_json_column_gets_json_text_and_scalars_stay_plain() {
+        let table = cols(&[("meta", "jsonb"), ("note", "text")]);
+        let payload =
+            build_auto_map_payload(&[json!({"meta": {"a": "x\ty"}, "note": "plain"})], &table)
+                .unwrap()
+                .unwrap();
+        // The tab inside the nested JSON string is escaped by serde_json to
+        // \t (two chars: backslash + t), and COPY escaping doubles the
+        // backslash so the server sees the JSON text {"a":"x\ty"} intact.
+        assert_eq!(payload.data, "{\"a\":\"x\\\\ty\"}\tplain\n");
+    }
+
+    #[test]
+    fn auto_map_object_into_non_json_column_emits_json_text() {
+        // Same loud-failure semantics as the INSERT path: the int8 input
+        // function will reject this text rather than silently coercing.
+        let table = cols(&[("id", "int8")]);
+        let payload = build_auto_map_payload(&[json!({"id": {"a": 1}})], &table)
+            .unwrap()
+            .unwrap();
+        assert_eq!(payload.data, "{\"a\":1}\n");
+    }
+
+    #[test]
+    fn auto_map_skips_no_match_records_and_reports_none_when_empty() {
+        let table = cols(&[("id", "int8")]);
+        let payload =
+            build_auto_map_payload(&[json!({"id": 1}), json!({"unrelated": true})], &table)
+                .unwrap()
+                .unwrap();
+        assert_eq!(payload.rows, 1);
+        assert!(
+            build_auto_map_payload(&[json!({"unrelated": true})], &table)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn auto_map_rejects_non_object_records() {
+        let table = cols(&[("id", "int8")]);
+        let err = build_auto_map_payload(&[json!([1, 2])], &table).unwrap_err();
+        assert!(err.contains("JSON object"));
+    }
+
+    #[test]
+    fn jsonb_rows_escape_embedded_specials_inside_json_text() {
+        let payload = build_jsonb_payload(&[
+            json!({"s": "tab\there and back\\slash and\nnewline"}),
+            json!(null),
+            json!("bare string"),
+        ]);
+        // serde_json escapes specials inside JSON strings (\t, \\, \n as
+        // two-char sequences); COPY escaping then doubles those backslashes.
+        assert_eq!(
+            payload.data,
+            "{\"s\":\"tab\\\\there and back\\\\\\\\slash and\\\\nnewline\"}\n\\N\n\"bare string\"\n"
+        );
+        assert_eq!(payload.rows, 3);
+    }
+
+    #[test]
+    fn copy_statement_quotes_hostile_identifiers() {
+        assert_eq!(
+            copy_statement("\"t\"", &["id".into(), "we\"ird".into()]),
+            "COPY \"t\" (\"id\", \"we\"\"ird\") FROM STDIN (FORMAT text)"
+        );
+        assert_eq!(
+            copy_statement("\"s\".\"t\"", &["data".into()]),
+            "COPY \"s\".\"t\" (\"data\") FROM STDIN (FORMAT text)"
+        );
+    }
+}

--- a/crates/sink/postgres/src/lib.rs
+++ b/crates/sink/postgres/src/lib.rs
@@ -5,12 +5,15 @@
 //! PostgreSQL sink connector for the faucet-stream ecosystem.
 //!
 //! Writes `serde_json::Value` records to a PostgreSQL table using `jsonb`
-//! columns or dynamic column mapping.
+//! columns or dynamic column mapping. Append-mode writes can opt into the
+//! `COPY … FROM STDIN` bulk-load fast-path via `write_method: copy`
+//! (typically 5–10× faster than multi-row `INSERT` — issue #308).
 
 pub mod config;
+mod copy;
 pub mod sink;
 
 pub use faucet_core::{FaucetError, Sink};
 
-pub use config::{PostgresColumnMapping, PostgresSinkConfig};
+pub use config::{PostgresColumnMapping, PostgresSinkConfig, PostgresWriteMethod};
 pub use sink::PostgresSink;

--- a/crates/sink/postgres/src/sink.rs
+++ b/crates/sink/postgres/src/sink.rs
@@ -1,6 +1,7 @@
 //! PostgreSQL sink implementation.
 
-use crate::config::{PostgresColumnMapping, PostgresSinkConfig};
+use crate::config::{PostgresColumnMapping, PostgresSinkConfig, PostgresWriteMethod};
+use crate::copy::{build_auto_map_payload, build_jsonb_payload, copy_statement};
 use async_trait::async_trait;
 use faucet_core::FaucetError;
 use faucet_core::util::quote_ident;
@@ -24,7 +25,7 @@ use sqlx::{PgPool, Row};
 /// keeps its quotes and objects/arrays round-trip); the `::jsonb` cast then
 /// parses it. For every other type the scalar's plain text form is bound and
 /// the column's input function parses it via the cast.
-fn pg_bind_text(value: Option<&Value>, udt: &str) -> Option<String> {
+pub(crate) fn pg_bind_text(value: Option<&Value>, udt: &str) -> Option<String> {
     match value {
         None | Some(Value::Null) => None,
         Some(v) => {
@@ -167,6 +168,15 @@ impl PostgresSink {
                     .into(),
             ));
         }
+        if matches!(config.write_method, PostgresWriteMethod::Copy)
+            && !matches!(config.write.write_mode, faucet_core::WriteMode::Append)
+        {
+            return Err(FaucetError::Config(format!(
+                "postgres sink: write_method: copy is append-only (COPY has no ON CONFLICT); \
+                 it cannot be combined with write_mode: {} — use write_method: insert",
+                config.write.write_mode.as_str()
+            )));
+        }
 
         let pool = PgPoolOptions::new()
             .max_connections(config.max_connections)
@@ -175,6 +185,102 @@ impl PostgresSink {
             .map_err(|e| FaucetError::Sink(format!("PostgreSQL connection failed: {e}")))?;
 
         Ok(Self { config, pool })
+    }
+
+    /// Discover the target relation's column names and underlying types
+    /// (`pg_type.typname`), scoped to the *exact* relation the writes target
+    /// via `to_regclass` (#146 M13). Shared by the INSERT and COPY paths so
+    /// both see an identical column set. `::text` casts the `name`-typed
+    /// catalog columns so sqlx decodes them as `String`.
+    async fn discover_columns(
+        &self,
+        conn: &mut sqlx::PgConnection,
+        table_ref: &str,
+    ) -> Result<Vec<(String, String)>, FaucetError> {
+        let columns: Vec<(String, String)> = sqlx::query(
+            "SELECT a.attname::text AS column_name, t.typname::text AS udt_name \
+             FROM pg_catalog.pg_attribute a \
+             JOIN pg_catalog.pg_type t ON t.oid = a.atttypid \
+             WHERE a.attrelid = to_regclass($1)::oid \
+               AND a.attnum > 0 AND NOT a.attisdropped \
+             ORDER BY a.attnum",
+        )
+        .bind(table_ref)
+        .fetch_all(&mut *conn)
+        .await
+        .map_err(|e| FaucetError::Sink(format!("failed to query table columns: {e}")))?
+        .iter()
+        .map(|row| {
+            (
+                row.get::<String, _>("column_name"),
+                row.get::<String, _>("udt_name"),
+            )
+        })
+        .collect();
+
+        if columns.is_empty() {
+            return Err(FaucetError::Sink(format!(
+                "table {table_ref} has no columns or does not exist"
+            )));
+        }
+        Ok(columns)
+    }
+
+    /// Write one chunk via `COPY … FROM STDIN (FORMAT text)` — the bulk-load
+    /// fast-path (issue #308). Append-only (validated at construction); the
+    /// server parses each field with the destination column's input function,
+    /// so type semantics match the `INSERT` path exactly. A bad row fails the
+    /// whole COPY (all-or-nothing, like a failed multi-row `INSERT`).
+    async fn copy_batch(
+        &self,
+        conn: &mut sqlx::PgConnection,
+        records: &[Value],
+    ) -> Result<usize, FaucetError> {
+        if records.is_empty() {
+            return Ok(0);
+        }
+        let table_ref = qualified_table_ref(self.config.schema.as_deref(), &self.config.table_name);
+
+        let (statement, payload) = match &self.config.column_mapping {
+            PostgresColumnMapping::Jsonb { column } => {
+                let payload = build_jsonb_payload(records);
+                (
+                    copy_statement(&table_ref, std::slice::from_ref(column)),
+                    payload,
+                )
+            }
+            PostgresColumnMapping::AutoMap => {
+                let columns = self.discover_columns(&mut *conn, &table_ref).await?;
+                let Some(payload) =
+                    build_auto_map_payload(records, &columns).map_err(FaucetError::Sink)?
+                else {
+                    return Ok(0);
+                };
+                (copy_statement(&table_ref, &payload.columns), payload)
+            }
+        };
+
+        let mut copy_in = conn
+            .copy_in_raw(&statement)
+            .await
+            .map_err(|e| FaucetError::Sink(format!("PostgreSQL COPY start failed: {e}")))?;
+        // Ship in ~1 MiB slices so a huge page never materializes a second
+        // time inside sqlx's write buffer.
+        const SEND_CHUNK: usize = 1 << 20;
+        for chunk in payload.data.as_bytes().chunks(SEND_CHUNK) {
+            if let Err(e) = copy_in.send(chunk).await {
+                // Dropping the handle aborts the COPY server-side; surface
+                // the original error.
+                return Err(FaucetError::Sink(format!(
+                    "PostgreSQL COPY send failed: {e}"
+                )));
+            }
+        }
+        copy_in
+            .finish()
+            .await
+            .map_err(|e| FaucetError::Sink(format!("PostgreSQL COPY failed: {e}")))?;
+        Ok(payload.rows)
     }
 
     /// Insert a batch of records using JSONB column mode, on the given connection.
@@ -254,35 +360,9 @@ impl PostgresSink {
         // `pg_type.typname` is the concrete type (`int4`, `timestamptz`,
         // `numeric`, `jsonb`, `uuid`, `text`, …) — identical to the old
         // `information_schema.columns.udt_name` — used as the per-placeholder
-        // cast target below. `::text` casts the `name`-typed catalog columns so
-        // sqlx decodes them as `String`.
+        // cast target below.
         let table_ref = qualified_table_ref(self.config.schema.as_deref(), &self.config.table_name);
-        let columns: Vec<(String, String)> = sqlx::query(
-            "SELECT a.attname::text AS column_name, t.typname::text AS udt_name \
-             FROM pg_catalog.pg_attribute a \
-             JOIN pg_catalog.pg_type t ON t.oid = a.atttypid \
-             WHERE a.attrelid = to_regclass($1)::oid \
-               AND a.attnum > 0 AND NOT a.attisdropped \
-             ORDER BY a.attnum",
-        )
-        .bind(&table_ref)
-        .fetch_all(&mut *conn)
-        .await
-        .map_err(|e| FaucetError::Sink(format!("failed to query table columns: {e}")))?
-        .iter()
-        .map(|row| {
-            (
-                row.get::<String, _>("column_name"),
-                row.get::<String, _>("udt_name"),
-            )
-        })
-        .collect();
-
-        if columns.is_empty() {
-            return Err(FaucetError::Sink(format!(
-                "table {table_ref} has no columns or does not exist"
-            )));
-        }
+        let columns = self.discover_columns(&mut *conn, &table_ref).await?;
 
         // Pre-validate all records and collect matched (column, udt, value)
         // triples per record. The INSERT column set is the UNION of table
@@ -428,24 +508,11 @@ impl PostgresSink {
 
         // Underlying types for the key columns → drives the ::udt casts, same
         // source the insert path uses.
-        let udts: std::collections::HashMap<String, String> = sqlx::query(
-            "SELECT a.attname::text AS column_name, t.typname::text AS udt_name \
-             FROM pg_catalog.pg_attribute a \
-             JOIN pg_catalog.pg_type t ON t.oid = a.atttypid \
-             WHERE a.attrelid = to_regclass($1)::oid AND a.attnum > 0 AND NOT a.attisdropped",
-        )
-        .bind(&table_ref)
-        .fetch_all(&mut *conn)
-        .await
-        .map_err(|e| FaucetError::Sink(format!("failed to query table columns: {e}")))?
-        .iter()
-        .map(|row| {
-            (
-                row.get::<String, _>("column_name"),
-                row.get::<String, _>("udt_name"),
-            )
-        })
-        .collect();
+        let udts: std::collections::HashMap<String, String> = self
+            .discover_columns(&mut *conn, &table_ref)
+            .await?
+            .into_iter()
+            .collect();
         let key_udts: Vec<String> = key
             .iter()
             .map(|k| udts.get(k).cloned().unwrap_or_else(|| "text".to_string()))
@@ -740,11 +807,18 @@ impl faucet_core::Sink for PostgresSink {
 
         let mut total = 0;
         for chunk in chunks {
-            total += match &self.config.column_mapping {
-                PostgresColumnMapping::Jsonb { column } => {
-                    self.insert_jsonb(&mut conn, chunk, column).await?
-                }
-                PostgresColumnMapping::AutoMap => self.insert_auto_map(&mut conn, chunk).await?,
+            total += match self.config.write_method {
+                // Bulk-load fast-path: COPY the chunk instead of a multi-row
+                // INSERT (append-only; validated at construction, #308).
+                PostgresWriteMethod::Copy => self.copy_batch(&mut conn, chunk).await?,
+                PostgresWriteMethod::Insert => match &self.config.column_mapping {
+                    PostgresColumnMapping::Jsonb { column } => {
+                        self.insert_jsonb(&mut conn, chunk, column).await?
+                    }
+                    PostgresColumnMapping::AutoMap => {
+                        self.insert_auto_map(&mut conn, chunk).await?
+                    }
+                },
             };
         }
 

--- a/crates/sink/postgres/tests/copy.rs
+++ b/crates/sink/postgres/tests/copy.rs
@@ -1,0 +1,268 @@
+//! Integration tests for the `write_method: copy` bulk-load fast-path
+//! (issue #308) against a real Postgres via testcontainers.
+//!
+//! The core property is **parity**: the same record set written via `insert`
+//! and via `copy` must land byte-identical rows — COPY changes the wire
+//! encoding, never the data. These tests require Docker.
+
+use faucet_core::Sink;
+use faucet_sink_postgres::{
+    PostgresColumnMapping, PostgresSink, PostgresSinkConfig, PostgresWriteMethod,
+};
+use serde_json::{Value, json};
+use testcontainers::{ContainerAsync, ImageExt, runners::AsyncRunner};
+use testcontainers_modules::postgres::Postgres;
+
+async fn start_postgres() -> (ContainerAsync<Postgres>, String) {
+    let image = Postgres::default().with_tag("16-alpine");
+    let container: ContainerAsync<Postgres> =
+        image.start().await.expect("postgres container start");
+    let port = container
+        .get_host_port_ipv4(5432)
+        .await
+        .expect("postgres port");
+    let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
+    (container, url)
+}
+
+/// Records exercising every escaping hazard: tabs, newlines, CRs,
+/// backslashes, the literal strings `N` / `\N`, unicode, nested JSON with
+/// specials, NULLs, and a missing field.
+fn hazard_records() -> Vec<Value> {
+    vec![
+        json!({
+            "id": 1,
+            "name": "tab\there \\ back\nnew\rcr",
+            "score": 1.5,
+            "active": true,
+            "created": "2026-01-02T03:04:05Z",
+            "amount": "12345.678901",
+            "meta": {"nested": "x\ty \\ z\nw", "arr": [1, "a\tb"]}
+        }),
+        json!({
+            "id": 2,
+            "name": "N",
+            "score": null,
+            "active": false,
+            "created": null,
+            "amount": "0.000001",
+            "meta": null
+        }),
+        json!({
+            "id": 3,
+            "name": "\\N — 日本語 🚰",
+            "score": -2.25,
+            "active": null,
+            "created": "1999-12-31T23:59:59Z",
+            "amount": null
+            // `meta` missing entirely → NULL
+        }),
+    ]
+}
+
+const TYPED_DDL: &str = "(id BIGINT PRIMARY KEY, name TEXT, score DOUBLE PRECISION, \
+                         active BOOLEAN, created TIMESTAMPTZ, amount NUMERIC, meta JSONB)";
+
+async fn dump(pool: &sqlx::PgPool, table: &str) -> Vec<Value> {
+    use sqlx::Row;
+    sqlx::query(&format!(
+        "SELECT to_jsonb(t) AS row FROM \"{table}\" t ORDER BY id"
+    ))
+    .fetch_all(pool)
+    .await
+    .expect("dump")
+    .iter()
+    .map(|r| r.get::<Value, _>("row"))
+    .collect()
+}
+
+async fn sink(url: &str, table: &str, method: PostgresWriteMethod) -> PostgresSink {
+    let cfg = PostgresSinkConfig::new(url, table)
+        .column_mapping(PostgresColumnMapping::AutoMap)
+        .with_write_method(method);
+    PostgresSink::new(cfg).await.expect("sink")
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn copy_and_insert_land_identical_rows_auto_map() {
+    let (_c, url) = start_postgres().await;
+    let pool = sqlx::PgPool::connect(&url).await.expect("pool");
+    for table in ["t_insert", "t_copy"] {
+        sqlx::query(&format!("CREATE TABLE \"{table}\" {TYPED_DDL}"))
+            .execute(&pool)
+            .await
+            .expect("create");
+    }
+
+    let records = hazard_records();
+    sink(&url, "t_insert", PostgresWriteMethod::Insert)
+        .await
+        .write_batch(&records)
+        .await
+        .expect("insert write");
+    let written = sink(&url, "t_copy", PostgresWriteMethod::Copy)
+        .await
+        .write_batch(&records)
+        .await
+        .expect("copy write");
+    assert_eq!(written, records.len());
+
+    let via_insert = dump(&pool, "t_insert").await;
+    let via_copy = dump(&pool, "t_copy").await;
+    assert_eq!(via_insert.len(), 3);
+    assert_eq!(
+        via_insert, via_copy,
+        "COPY and INSERT must land identical rows"
+    );
+    // Spot-check the hazards actually round-tripped, not just matched.
+    assert_eq!(via_copy[0]["name"], json!("tab\there \\ back\nnew\rcr"));
+    assert_eq!(via_copy[0]["meta"]["nested"], json!("x\ty \\ z\nw"));
+    assert_eq!(via_copy[1]["name"], json!("N"));
+    assert_eq!(via_copy[2]["name"], json!("\\N — 日本語 🚰"));
+    assert_eq!(via_copy[2]["meta"], json!(null));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn copy_and_insert_land_identical_rows_jsonb_mapping() {
+    let (_c, url) = start_postgres().await;
+    let pool = sqlx::PgPool::connect(&url).await.expect("pool");
+    for table in ["j_insert", "j_copy"] {
+        sqlx::query(&format!(
+            "CREATE TABLE \"{table}\" (id BIGSERIAL PRIMARY KEY, data JSONB)"
+        ))
+        .execute(&pool)
+        .await
+        .expect("create");
+    }
+
+    let records = hazard_records();
+    for (table, method) in [
+        ("j_insert", PostgresWriteMethod::Insert),
+        ("j_copy", PostgresWriteMethod::Copy),
+    ] {
+        let cfg = PostgresSinkConfig::new(&url, table).with_write_method(method);
+        PostgresSink::new(cfg)
+            .await
+            .expect("sink")
+            .write_batch(&records)
+            .await
+            .expect("write");
+    }
+
+    use sqlx::Row;
+    let get = |table: &'static str| {
+        let pool = pool.clone();
+        async move {
+            sqlx::query(&format!("SELECT data FROM \"{table}\" ORDER BY id"))
+                .fetch_all(&pool)
+                .await
+                .expect("dump")
+                .iter()
+                .map(|r| r.get::<Value, _>("data"))
+                .collect::<Vec<_>>()
+        }
+    };
+    let via_insert = get("j_insert").await;
+    let via_copy = get("j_copy").await;
+    assert_eq!(via_insert, via_copy);
+    assert_eq!(via_copy.len(), 3);
+    assert_eq!(via_copy[0]["meta"]["arr"], json!([1, "a\tb"]));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn copy_respects_batch_size_chunking() {
+    let (_c, url) = start_postgres().await;
+    let pool = sqlx::PgPool::connect(&url).await.expect("pool");
+    sqlx::query("CREATE TABLE chunked (id BIGINT PRIMARY KEY, v TEXT)")
+        .execute(&pool)
+        .await
+        .expect("create");
+
+    let cfg = PostgresSinkConfig::new(&url, "chunked")
+        .column_mapping(PostgresColumnMapping::AutoMap)
+        .with_write_method(PostgresWriteMethod::Copy)
+        .with_batch_size(2);
+    let sink = PostgresSink::new(cfg).await.expect("sink");
+    let records: Vec<Value> = (1..=5)
+        .map(|i| json!({"id": i, "v": i.to_string()}))
+        .collect();
+    let written = sink.write_batch(&records).await.expect("write");
+    assert_eq!(written, 5);
+    let rows = dump(&pool, "chunked").await;
+    assert_eq!(rows.len(), 5);
+    assert_eq!(rows[4]["v"], json!("5"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_bad_row_fails_the_whole_copy_batch() {
+    let (_c, url) = start_postgres().await;
+    let pool = sqlx::PgPool::connect(&url).await.expect("pool");
+    sqlx::query("CREATE TABLE strict_t (id BIGINT PRIMARY KEY, n INT)")
+        .execute(&pool)
+        .await
+        .expect("create");
+
+    let sink = sink(&url, "strict_t", PostgresWriteMethod::Copy).await;
+    let err = sink
+        .write_batch(&[
+            json!({"id": 1, "n": 1}),
+            json!({"id": 2, "n": "not-an-int"}),
+        ])
+        .await
+        .expect_err("bad row must fail the batch");
+    assert!(matches!(err, faucet_core::FaucetError::Sink(_)));
+    // All-or-nothing: nothing from the failed batch landed.
+    let rows = dump(&pool, "strict_t").await;
+    assert!(rows.is_empty(), "failed COPY must not leave partial rows");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn idempotent_writes_stay_on_the_insert_path_under_copy() {
+    let (_c, url) = start_postgres().await;
+    let pool = sqlx::PgPool::connect(&url).await.expect("pool");
+    sqlx::query("CREATE TABLE eo_t (id BIGINT PRIMARY KEY, v TEXT)")
+        .execute(&pool)
+        .await
+        .expect("create");
+
+    // A copy-configured sink still supports exactly-once: the watermark path
+    // routes through the INSERT/transaction machinery so data + token commit
+    // atomically.
+    let sink = sink(&url, "eo_t", PostgresWriteMethod::Copy).await;
+    let token = faucet_core::format_token(1);
+    let written = sink
+        .write_batch_idempotent(&[json!({"id": 1, "v": "a"})], "scope::eo", &token)
+        .await
+        .expect("idempotent write");
+    assert_eq!(written, 1);
+    assert_eq!(
+        sink.last_committed_token("scope::eo").await.expect("token"),
+        Some(token)
+    );
+    let rows = dump(&pool, "eo_t").await;
+    assert_eq!(rows.len(), 1);
+}
+
+#[tokio::test]
+async fn copy_with_upsert_or_delete_is_rejected_at_config_load() {
+    // Validation fires before any connection attempt, so a bogus URL is fine.
+    for mode in [
+        faucet_core::WriteMode::Upsert,
+        faucet_core::WriteMode::Delete,
+    ] {
+        let mut cfg = PostgresSinkConfig::new("postgres://127.0.0.1:1/nope", "t")
+            .column_mapping(PostgresColumnMapping::AutoMap)
+            .with_write_method(PostgresWriteMethod::Copy);
+        cfg.write = faucet_core::WriteSpec {
+            write_mode: mode,
+            key: vec!["id".into()],
+            delete_marker: None,
+        };
+        let Err(err) = PostgresSink::new(cfg).await else {
+            panic!("copy + {mode:?} must be rejected");
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("append-only"), "unexpected: {msg}");
+        assert!(msg.contains("write_method"), "unexpected: {msg}");
+    }
+}

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -40,6 +40,7 @@
 - [Secrets-manager interpolation](./cookbook/secrets.md)
 - [Config composition](./cookbook/composition.md)
 - [Adaptive batching](./cookbook/adaptive-batching.md)
+- [Throughput tuning](./cookbook/tuning.md)
 - [Scheduling](./cookbook/scheduling.md)
 - [Running faucet as a service](./cookbook/serve.md)
 - [Web console (`serve-ui`)](./cookbook/web-console.md)

--- a/docs/book/src/cookbook/tuning.md
+++ b/docs/book/src/cookbook/tuning.md
@@ -1,0 +1,87 @@
+# Throughput tuning
+
+faucet's defaults are already tuned for sustained bulk movement (pooled
+clients, multi-row writes, bounded-memory streaming). When you need more,
+work through these levers in order — the first two are faucet config, the
+rest are destination-side decisions faucet deliberately never makes for you.
+
+Benchmarked context for what these levers buy is in
+[BENCHMARKS.md](https://github.com/PawanSikawat/faucet-stream/blob/main/BENCHMARKS.md)
+(Scenario C is the sink-bound case this page mostly talks about).
+
+## 1. `batch_size` — the universal knob
+
+Every source and sink exposes `batch_size` (default `1000`, `0` = "no
+batching": the whole result set / upstream page as one unit).
+
+- **Sink-bound moves rarely improve past ~1000–5000 rows per write.** For
+  the Postgres sink, throughput is flat from 500→5000 rows per `INSERT` and
+  degrades once `rows × columns` approaches the 65 535 bind-parameter cap
+  (the sink auto-splits to stay under it, but the sweet spot is ~1000).
+- **Match source and sink sizes** so pages aren't re-chunked twice; setting
+  only the source's `batch_size` and leaving the sink at `0` forwards each
+  page verbatim.
+
+## 2. Postgres bulk load — `write_method: copy`
+
+For append-only loads into PostgreSQL, switch the sink to the `COPY` wire
+protocol (issue #308):
+
+```yaml
+sink:
+  type: postgres
+  config:
+    connection_url: ${env:PG_URL}
+    table_name: events
+    column_mapping: auto_map
+    write_method: copy       # COPY … FROM STDIN instead of multi-row INSERT
+```
+
+`COPY` skips per-statement parse/bind/plan overhead and is typically **5–10×
+faster** than multi-row `INSERT` at the destination. Semantics are unchanged
+(same rows, same types, same durability); restrictions:
+
+- append-only — rejected with `write_mode: upsert|delete` at config load;
+- all-or-nothing per batch (one bad row fails the whole `COPY`; the DLQ
+  `on_batch_error` policy applies);
+- `delivery: exactly_once` always stays on the `INSERT` transaction path so
+  the watermark commits atomically with the page.
+
+See the [postgres sink README](https://github.com/PawanSikawat/faucet-stream/tree/main/crates/sink/postgres#bulk-load-write_method-copy)
+for details.
+
+## 3. Destination-side knobs (your call, not faucet's)
+
+These make bulk loads dramatically faster but **change durability or
+consistency guarantees**, so faucet never flips them silently. Set them on
+the destination yourself when the trade-off fits:
+
+| Knob | Win | Cost |
+|------|-----|------|
+| `CREATE UNLOGGED TABLE …` (Postgres) | Skips WAL entirely — the fastest ingest path | Table is **truncated on crash recovery** and not replicated. Use for staging tables you can re-load. |
+| `SET synchronous_commit = off` (session/role/database) | Commits return before WAL reaches disk | A crash can lose the last few transactions (never corrupts). Good default for re-runnable batch loads. |
+| Drop/disable indexes + constraints before the load, rebuild after | Index maintenance often dominates bulk-insert cost | A window where constraints aren't enforced; rebuild time at the end. |
+| Load into a staging table, then `INSERT … SELECT` / partition-swap | Keeps the hot table available and indexes warm | Extra disk + a copy step. |
+
+## 4. Parallelism
+
+- **Source sharding (Mode B)** — shardable sources (`postgres`, `mysql`,
+  `mssql`, `sqlite` via `shard: { key }`; `s3`/`gcs`/`parquet` by hash;
+  `kafka` by consumer group) split one dataset across workers under
+  `faucet serve --cluster`. See [Running a cluster](./cluster.md).
+- **Matrix fan-out** — independent tables/endpoints parallelize with matrix
+  rows and `execution.max_concurrent`.
+- Database sinks bound their pools (`max_connections`, default 5) on
+  purpose; raise it explicitly if the destination has headroom.
+
+## Measure, don't guess
+
+Run the shipped harness before and after a change:
+
+```bash
+make bench-smoke      # 100k rows, fast signal
+make bench-postgres   # adds the Docker Postgres scenarios (B & C)
+```
+
+The harness methodology and current numbers live in
+[BENCHMARKS.md](https://github.com/PawanSikawat/faucet-stream/blob/main/BENCHMARKS.md).

--- a/docs/book/src/reference/connectors.md
+++ b/docs/book/src/reference/connectors.md
@@ -100,7 +100,7 @@ file/append sinks (`jsonl`, `csv`, `stdout`) it's a no-op — they write per rec
 | Connector | Tier¹¹ | Feature | `batch_size` | Compression | Upsert⁸ | Effectively-once⁷ | Write unit |
 |-----------|:---:|---------|:---:|:---:|:---:|:---:|------------|
 | BigQuery | T2 | `sink-bigquery` | ✓ | ✗ | **✓** | **✓** | `tabledata.insertAll` streaming; in-place `MERGE` for upsert + effectively-once |
-| PostgreSQL | T1 ✅ | `sink-postgres` | ✓ | ✗ | **✓** | **✓** | multi-row `INSERT` (JSONB or mapped cols) |
+| PostgreSQL | T1 ✅ | `sink-postgres` | ✓ | ✗ | **✓** | **✓** | multi-row `INSERT` (JSONB or mapped cols); `COPY FROM STDIN` fast-path for append (`write_method: copy`) |
 | JSON Lines | T1 ✅ | `sink-jsonl` | no-op | ✓ | ✗ | ✗ | buffered file append |
 | Snowflake | T2 | `sink-snowflake` | ✓ | ✗ | ✗ | **✓** | SQL REST API; multi-statement `BEGIN;INSERT;MERGE;COMMIT` transaction for effectively-once |
 | MySQL | T1 ✅ | `sink-mysql` | ✓ | ✗ | **✓** | **✓** | multi-row `INSERT` |

--- a/schemas/faucet.schema.json
+++ b/schemas/faucet.schema.json
@@ -5561,6 +5561,21 @@
         }
       }
     },
+    "sink_postgres__PostgresWriteMethod": {
+      "description": "How rows are shipped to PostgreSQL in append mode.",
+      "oneOf": [
+        {
+          "description": "Multi-row `INSERT INTO … VALUES …` — the default. Works with every\nwrite mode and the exactly-once transaction path.",
+          "type": "string",
+          "const": "insert"
+        },
+        {
+          "description": "`COPY … FROM STDIN (FORMAT text)` bulk load — typically **5–10×\nfaster** than multi-row `INSERT` for bulk append (issue #308).\n\n**Append-only**: `COPY` has no `ON CONFLICT`, so combining\n`write_method: copy` with `write_mode: upsert|delete` is rejected at\nconfig load. The exactly-once path (`write_batch_idempotent`) always\nuses the `INSERT`/transaction path regardless of this setting — the\nwatermark token must commit atomically with the page's data.\n\nError semantics are all-or-nothing per batch, the same as a failed\nmulti-row `INSERT`: one bad row fails the whole `COPY` and the DLQ\nrouter's `on_batch_error` policy applies.",
+          "type": "string",
+          "const": "copy"
+        }
+      ]
+    },
     "sink_jsonl__CompressionConfig": {
       "description": "User-facing compression config. Defaults to [`Auto`](Self::Auto).",
       "oneOf": [
@@ -10309,6 +10324,11 @@
                           "type": "null"
                         }
                       ]
+                    },
+                    "write_method": {
+                      "description": "How append-mode rows are shipped: multi-row `insert` (default) or the\n`copy` bulk-load fast-path (`COPY … FROM STDIN`, typically 5–10×\nfaster for bulk append). `copy` is append-only — it is rejected with\n`write_mode: upsert|delete` — and the exactly-once path always stays\non `insert` so data + watermark commit in one transaction.",
+                      "$ref": "#/$defs/sink_postgres__PostgresWriteMethod",
+                      "default": "insert"
                     }
                   },
                   "title": "PostgresSinkConfig",


### PR DESCRIPTION
Closes #308

Part of the roadmap epic #38.

## What

Implements #308's primary lever: an opt-in **`COPY … FROM STDIN` bulk-load path** for the postgres sink.

- **Config**: `write_method: insert` (default, fully back-compat) `| copy` on `PostgresSinkConfig`. Explicit + documented, per the issue.
- **Semantics preserved**: COPY text format is parsed by each destination column's *input function* — the same semantics as the INSERT path's `$N::<udt>` casts. Both column mappings supported (AutoMap with the same union-of-present-columns behavior so DEFAULTs still apply; JSONB single-column).
- **Correctness where it lives**: a pure, exhaustively unit-tested encoder for the COPY text escape set (`\` tab LF CR `\b` `\f` `\v`, the `\N` null marker vs literal `"N"`/`"\N"` strings, unicode, empty-vs-null) — plus **Docker parity tests** proving INSERT and COPY land byte-identical rows over a hazard set (tabs/newlines/backslashes/nested-JSON specials/NULLs across bigint/text/double/bool/timestamptz/numeric/jsonb).
- **Guardrails**: `copy` + `write_mode: upsert|delete` rejected at construction (COPY has no `ON CONFLICT`); **exactly-once is untouched** — `write_batch_idempotent` always uses the INSERT+transaction watermark path, covered by a test; COPY failures are all-or-nothing per chunk (same as a failed multi-row INSERT — the DLQ `on_batch_error` policy applies unchanged).

## Benchmark (Scenario C re-run, acceptance criterion)

1M rows, same machine/methodology as PR #307 (Postgres 16 in Docker, 1 warmup + 3 timed runs):

| Path | Median | Throughput |
|---|---|---|
| `write_method: copy` | **8.12 s ± 0.14** | **123k rows/s** |
| multi-row INSERT | 10.10 s ± 0.11 | 99k rows/s |
| Meltano `target-postgres` (prior run) | 129.8 s ± 34.3 | 7.7k rows/s |

End-to-end gain is **1.24×**, not 5–10× — the issue's own profile explains why: ~62% of wall-clock is source decode/re-encode, so Amdahl caps the ceiling at ~1.6× even if the write were free; the write step itself roughly halved. BENCHMARKS.md Scenario C updated with both paths and the honest analysis (~16× vs Meltano on the copy path).

## Docs (lever 3 = documentation, per the issue)

- postgres sink README: `## Bulk load (write_method: copy)` + `## Destination tuning` (UNLOGGED / `synchronous_commit=off` / index management as **user-side** knobs faucet deliberately never flips).
- New `docs/book/src/cookbook/tuning.md` throughput guide (+ SUMMARY).
- Capability matrix: postgres write-unit cell mentions the fast-path.
- `benchmarks/faucet/postgres_to_postgres.yaml` now benchmarks the copy path (commented).

## MySQL (issue lever 1, second target) — blocked upstream

`sqlx-mysql` 0.8 has **no client-side `LOAD DATA LOCAL INFILE` support** (verified against the crate source; there is no infile handler API), so the MySQL analogue cannot be built on the sink's current client. Noted rather than silently dropped; a follow-up would require either upstream sqlx support or swapping the MySQL sink to `mysql_async`.

## Coverage

`copy.rs` 99.5% lines, crate 92.2% (`cargo llvm-cov`), all 40 lib + 33 Docker integration tests green locally.