### PR TITLE
feat: encryption at rest for state/DLQ + live TUI for faucet run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,6 +227,8 @@ jobs:
           - notify
           # Local dev loop — `faucet dev` filesystem watch (CLI-only)
           - cli-dev
+          # Live terminal UI — `faucet run --tui` (CLI-only)
+          - cli-tui
           # Secrets backends
           - secrets-vault
           - secrets-aws-sm
@@ -261,7 +263,7 @@ jobs:
           # Secrets, schedule, serve, catalog, and triggers features live in
           # faucet-cli (CLI layer), not in the faucet-stream umbrella crate.
           # Route accordingly.
-          if [[ "${{ matrix.feature }}" == secrets-* || "${{ matrix.feature }}" == "schedule" || "${{ matrix.feature }}" == serve* || "${{ matrix.feature }}" == "catalog" || "${{ matrix.feature }}" == triggers* || "${{ matrix.feature }}" == "notify" || "${{ matrix.feature }}" == "cli-dev" ]]; then
+          if [[ "${{ matrix.feature }}" == secrets-* || "${{ matrix.feature }}" == "schedule" || "${{ matrix.feature }}" == serve* || "${{ matrix.feature }}" == "catalog" || "${{ matrix.feature }}" == triggers* || "${{ matrix.feature }}" == "notify" || "${{ matrix.feature }}" == "cli-dev" || "${{ matrix.feature }}" == "cli-tui" ]]; then
             cargo check -p faucet-cli --no-default-features --features ${{ matrix.feature }}
           else
             cargo check -p faucet-stream --no-default-features --features ${{ matrix.feature }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,8 @@ jobs:
           - auth
           - full
           - compression
+          # Encryption at rest (state bookmarks + JSONL/DLQ, #207)
+          - encryption
           # Quality checks
           - quality
           - quality-jsonschema

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,14 +9,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+dependencies = [
+ "cipher 0.5.2",
+ "cpubits",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf011db2e21ce0d575593d749db5554b47fed37aff429e4dc50bc91ac93a028"
+dependencies = [
+ "aead",
+ "aes 0.9.1",
+ "cipher 0.5.2",
+ "ctr",
+ "ghash",
+ "subtle",
 ]
 
 [[package]]
@@ -1903,7 +1938,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -1999,7 +2034,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.7",
- "inout",
+ "inout 0.1.4",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -2188,6 +2234,12 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -2416,11 +2468,13 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
+ "getrandom 0.4.2",
  "hybrid-array",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2458,6 +2512,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "ctr"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
+dependencies = [
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -2720,7 +2783,7 @@ checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "ctutils",
 ]
 
@@ -3324,6 +3387,7 @@ dependencies = [
 name = "faucet-core"
 version = "1.4.0"
 dependencies = [
+ "aes-gcm",
  "async-compression",
  "async-stream",
  "async-trait",
@@ -3515,6 +3579,7 @@ name = "faucet-sink-jsonl"
 version = "1.2.0"
 dependencies = [
  "async-trait",
+ "base64 0.22.1",
  "faucet-conformance",
  "faucet-core",
  "schemars 1.2.1",
@@ -4746,6 +4811,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
+dependencies = [
+ "polyval",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5785,6 +5859,15 @@ checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "block-padding",
  "generic-array",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -7714,7 +7797,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
 dependencies = [
- "aes",
+ "aes 0.8.4",
  "cbc",
  "der 0.7.10",
  "pbkdf2",
@@ -7756,6 +7839,17 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "polyval"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b20f20e954175de5f463f67781b35583397d916b1d148738923711b2ad16bee8"
+dependencies = [
+ "cpubits",
+ "cpufeatures 0.3.0",
+ "universal-hash",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -9103,7 +9197,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -11003,6 +11097,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common 0.2.2",
+ "ctutils",
+]
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,11 +210,20 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "snap",
- "strum",
- "strum_macros",
+ "strum 0.27.2",
+ "strum_macros 0.27.2",
  "thiserror 2.0.18",
  "uuid",
  "zstd",
+]
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -617,7 +626,7 @@ version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -828,6 +837,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -1588,12 +1606,27 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -1603,9 +1636,15 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 dependencies = [
  "serde_core",
 ]
@@ -1667,7 +1706,7 @@ checksum = "ee04c4c84f1f811b017f2fbb7dd8815c976e7ca98593de9c1e2afad0f636bff4"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
- "bitflags",
+ "bitflags 2.13.0",
  "bollard-buildkit-proto",
  "bollard-stubs",
  "bytes",
@@ -1868,6 +1907,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
 name = "bytecheck"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1931,6 +1976,15 @@ name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cbc"
@@ -2132,6 +2186,20 @@ dependencies = [
  "crossterm 0.28.1",
  "unicode-segmentation",
  "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
 ]
 
 [[package]]
@@ -2352,7 +2420,7 @@ checksum = "4aa42bcd3d846ebf66e15bd528d1087f75d1c6c1c66ebff626178a106353c576"
 dependencies = [
  "chrono",
  "derive_builder",
- "strum",
+ "strum 0.27.2",
 ]
 
 [[package]]
@@ -2394,7 +2462,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "crossterm_winapi",
  "parking_lot",
  "rustix 0.38.44",
@@ -2407,7 +2475,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -2475,6 +2543,16 @@ dependencies = [
  "getrandom 0.4.2",
  "hybrid-array",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "csscolorparser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
+dependencies = [
+ "lab",
+ "phf 0.11.3",
 ]
 
 [[package]]
@@ -2638,6 +2716,12 @@ name = "deadpool-runtime"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
+name = "deltae"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
 name = "der"
@@ -2855,7 +2939,7 @@ dependencies = [
  "num",
  "num-integer",
  "rust_decimal",
- "strum",
+ "strum 0.27.2",
 ]
 
 [[package]]
@@ -3037,6 +3121,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3098,14 +3191,30 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set 0.5.3",
+ "regex",
+]
+
+[[package]]
+name = "fancy-regex"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
 dependencies = [
- "bit-set",
+ "bit-set 0.8.0",
  "regex-automata",
  "regex-syntax",
 ]
+
+[[package]]
+name = "fast-srgb8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
 name = "fastnum"
@@ -3236,6 +3345,7 @@ dependencies = [
  "notify",
  "object_store",
  "predicates",
+ "ratatui",
  "rdkafka",
  "redis",
  "reqwest 0.13.3",
@@ -4481,6 +4591,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4497,6 +4618,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
 name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4508,7 +4641,7 @@ version = "25.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "rustc_version",
 ]
 
@@ -5592,7 +5725,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "serde_with",
- "strum",
+ "strum 0.27.2",
  "tokio",
  "typed-builder 0.20.1",
  "typetag",
@@ -5671,7 +5804,7 @@ dependencies = [
  "async-trait",
  "iceberg",
  "sqlx",
- "strum",
+ "strum 0.27.2",
 ]
 
 [[package]]
@@ -5832,12 +5965,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "inotify"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "inotify-sys",
  "libc",
 ]
@@ -5876,11 +6018,24 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6654738b8024300cf062d04a1c13c10c8e2cea598ec1c47dc9b6641159429756"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "crossterm 0.29.0",
  "dyn-clone",
  "unicode-segmentation",
  "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling 0.23.0",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6092,7 +6247,7 @@ dependencies = [
  "bytecount",
  "data-encoding",
  "email_address",
- "fancy-regex",
+ "fancy-regex 0.18.0",
  "fraction",
  "getrandom 0.3.4",
  "idna",
@@ -6141,6 +6296,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "keyed_priority_queue"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6165,9 +6331,15 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "libc",
 ]
+
+[[package]]
+name = "lab"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
 
 [[package]]
 name = "lazy_static"
@@ -6287,7 +6459,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "libc",
  "plain",
  "redox_syscall 0.7.5",
@@ -6302,6 +6474,15 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "line-clipping"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
+dependencies = [
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -6450,6 +6631,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix",
+ "winapi",
+]
+
+[[package]]
 name = "macro_magic"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6543,6 +6734,12 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmem"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
 
 [[package]]
 name = "memoffset"
@@ -6675,6 +6872,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6741,7 +6944,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ef2c933617431ad0246fb5b43c425ebdae18c7f7259c87de0726d93b0e7e91b"
 dependencies = [
  "base64 0.22.1",
- "bitflags",
+ "bitflags 2.13.0",
  "bson",
  "derive-where",
  "derive_more",
@@ -6908,7 +7111,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b42ced54aa8ac97226486337973f9bc3956e24f03a23e88a6e18f640959d6e2"
 dependencies = [
  "base64 0.22.1",
- "bitflags",
+ "bitflags 2.13.0",
  "bitvec",
  "btoi",
  "byteorder",
@@ -6945,11 +7148,21 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -6964,7 +7177,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -6982,7 +7195,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -7055,6 +7268,17 @@ name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "num-integer"
@@ -7144,7 +7368,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -7438,6 +7662,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "palette"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+dependencies = [
+ "approx",
+ "fast-srgb8",
+ "libm",
+ "palette_derive",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7653,7 +7901,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.5.7",
  "indexmap 2.14.0",
 ]
 
@@ -7663,7 +7911,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.5.7",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
 ]
@@ -7691,6 +7939,16 @@ dependencies = [
 
 [[package]]
 name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
@@ -7706,6 +7964,48 @@ checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
  "phf_shared 0.13.1",
  "serde",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared 0.11.3",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -8272,7 +8572,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "memchr",
  "unicase",
 ]
@@ -8536,12 +8836,113 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.30.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3274ba0a2c5e1bcad2a2005d20f4dc59dad26b2eb0940fb094500dba4099d57d"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-macros",
+ "ratatui-termina",
+ "ratatui-termwiz",
+ "ratatui-widgets",
+ "serde",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
+dependencies = [
+ "bitflags 2.13.0",
+ "compact_str",
+ "critical-section",
+ "hashbrown 0.17.1",
+ "itertools 0.14.0",
+ "kasuari",
+ "lru 0.18.0",
+ "palette",
+ "serde",
+ "strum 0.28.0",
+ "thiserror 2.0.18",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567584a3b0e6a8203c23de40b4861497266725eb5363dbfd18a1edd603cca9f0"
+dependencies = [
+ "cfg-if",
+ "crossterm 0.29.0",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-macros"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed7dc68daa7498a43e4d68e0eb078427e10c38fbcfbb1e42d955f1fa2140d814"
+dependencies = [
+ "ratatui-core",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-termina"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0bf912d9e66f057a759d92e386a280ea886b352ab757d6ac4d653c7ed2c43c2"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "termina",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf03e0380b7744054d6cb74224fe3adf062a029754933f575ca1e3b4c2ce977"
+dependencies = [
+ "ratatui-core",
+ "termwiz",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66e3d19bcc9130ca376277d93b60767ff121ace3be06f5f95f81dd68956407d1"
+dependencies = [
+ "bitflags 2.13.0",
+ "hashbrown 0.17.1",
+ "indoc",
+ "instability",
+ "itertools 0.14.0",
+ "line-clipping",
+ "ratatui-core",
+ "serde",
+ "strum 0.28.0",
+ "time",
+ "unicode-segmentation",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
 name = "raw-cpuid"
 version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -8604,7 +9005,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -8613,7 +9014,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -9039,7 +9440,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -9052,7 +9453,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -9347,7 +9748,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -9360,7 +9761,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -9975,7 +10376,7 @@ dependencies = [
  "atoi",
  "base64 0.22.1",
  "bigdecimal",
- "bitflags",
+ "bitflags 2.13.0",
  "byteorder",
  "bytes",
  "chrono",
@@ -10020,7 +10421,7 @@ dependencies = [
  "atoi",
  "base64 0.22.1",
  "bigdecimal",
- "bitflags",
+ "bitflags 2.13.0",
  "byteorder",
  "chrono",
  "crc",
@@ -10085,6 +10486,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10130,7 +10537,16 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
 ]
 
 [[package]]
@@ -10138,6 +10554,18 @@ name = "strum_macros"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -10199,7 +10627,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -10266,10 +10694,86 @@ dependencies = [
 ]
 
 [[package]]
+name = "termina"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9048a889effe34a5cddee0af7f53285198b16dca3be510858d38dfdb3e62a04e"
+dependencies = [
+ "bitflags 2.13.0",
+ "parking_lot",
+ "rustix 1.1.4",
+ "signal-hook",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "terminfo"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
+dependencies = [
+ "fnv",
+ "nom",
+ "phf 0.11.3",
+ "phf_codegen",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "termwiz"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "bitflags 2.13.0",
+ "fancy-regex 0.11.0",
+ "filedescriptor",
+ "finl_unicode",
+ "fixedbitset 0.4.2",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "memmem",
+ "nix",
+ "num-derive",
+ "num-traits",
+ "ordered-float 4.6.0",
+ "pest",
+ "pest_derive",
+ "phf 0.11.3",
+ "sha2 0.10.9",
+ "signal-hook",
+ "siphasher",
+ "terminfo",
+ "termios",
+ "thiserror 1.0.69",
+ "ucd-trie",
+ "unicode-segmentation",
+ "vtparse",
+ "wezterm-bidi",
+ "wezterm-blob-leases",
+ "wezterm-color-types",
+ "wezterm-dynamic",
+ "wezterm-input-types",
+ "winapi",
+]
 
 [[package]]
 name = "testcontainers"
@@ -10764,7 +11268,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
  "async-compression",
- "bitflags",
+ "bitflags 2.13.0",
  "bytes",
  "futures-core",
  "futures-util",
@@ -11081,6 +11585,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
+name = "unicode-truncate"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
+dependencies = [
+ "itertools 0.14.0",
+ "unicode-segmentation",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11196,6 +11711,7 @@ version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
+ "atomic",
  "getrandom 0.4.2",
  "js-sys",
  "serde_core",
@@ -11291,6 +11807,15 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "vtparse"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
+dependencies = [
+ "utf8parse",
+]
 
 [[package]]
 name = "wait-timeout"
@@ -11478,7 +12003,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
@@ -11529,6 +12054,78 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "wezterm-bidi"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
+dependencies = [
+ "log",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-blob-leases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
+dependencies = [
+ "getrandom 0.3.4",
+ "mac_address",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
+name = "wezterm-color-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
+dependencies = [
+ "csscolorparser",
+ "deltae",
+ "lazy_static",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-dynamic"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
+dependencies = [
+ "log",
+ "ordered-float 4.6.0",
+ "strsim",
+ "thiserror 1.0.69",
+ "wezterm-dynamic-derive",
+]
+
+[[package]]
+name = "wezterm-dynamic-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "wezterm-input-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
+dependencies = [
+ "bitflags 1.3.2",
+ "euclid",
+ "lazy_static",
+ "serde",
+ "wezterm-dynamic",
 ]
 
 [[package]]
@@ -11979,7 +12576,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.13.0",
  "indexmap 2.14.0",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,6 +177,8 @@ jsonwebtoken = "9"
 base64 = "0.22"
 rsa = "0.9"
 sha2 = "0.10"
+# AEAD for encryption-at-rest of FileStateStore bookmarks + JSONL/DLQ output (#207).
+aes-gcm = "0.11"
 hmac = "0.12"
 crc = "3"
 md-5 = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -245,6 +245,9 @@ zstd = "0.13"
 glob = "0.3"
 duckdb = "1.10503"
 tempfile = "3"
+# Live terminal UI for `faucet run --tui` (#203, CLI-only `cli-tui` feature).
+# Default features include the crossterm backend.
+ratatui = "0.30"
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/README.md
+++ b/README.md
@@ -537,6 +537,7 @@ Default features: `source-rest`, `transform-flatten`, `transform-rename-keys`,
 | `transforms` | no | All built-in transforms above |
 | `transform-sql` | no | Embedded DuckDB SQL transform — run DuckDB SQL over each page (`batch` relation; `batch_size: 0` for global aggregation) |
 | `compression` | no | gzip / zstd read+write on JSONL/CSV/S3/GCS source and sink connectors |
+| `encryption` | no | Encryption at rest (AES-256-GCM) for `file` state-store bookmarks and per-line JSONL/DLQ output |
 
 `RecordTransform::Custom` is always available regardless of feature flags. CLI-only features
 (`schedule`, `serve`, `serve-ui`, `serve-history-*`, `triggers*`, `lineage`, `quality`,

--- a/README.md
+++ b/README.md
@@ -538,6 +538,7 @@ Default features: `source-rest`, `transform-flatten`, `transform-rename-keys`,
 | `transform-sql` | no | Embedded DuckDB SQL transform — run DuckDB SQL over each page (`batch` relation; `batch_size: 0` for global aggregation) |
 | `compression` | no | gzip / zstd read+write on JSONL/CSV/S3/GCS source and sink connectors |
 | `encryption` | no | Encryption at rest (AES-256-GCM) for `file` state-store bookmarks and per-line JSONL/DLQ output |
+| `cli-tui` | no | Live terminal UI for `faucet run --tui` — per-invocation throughput, errors, DLQ, bookmark age |
 
 `RecordTransform::Custom` is always available regardless of feature flags. CLI-only features
 (`schedule`, `serve`, `serve-ui`, `serve-history-*`, `triggers*`, `lineage`, `quality`,

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -379,6 +379,7 @@ redis = { workspace = true, optional = true }
 rdkafka = { workspace = true, optional = true }
 
 [dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }
 tempfile = "3"
 # `faucet schema config` composed-schema tests (#213): validate the shipped
 # example configs against the emitted top-level JSON Schema.

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -28,7 +28,7 @@ default = ["observability", "source", "sink", "state", "transforms", "compressio
 
 # Everything the default build ships, plus the long-running runtime modes:
 # `schedule` (cron scheduler) and `serve` (HTTP control plane).
-full = ["default", "otel", "schedule", "serve", "serve-ui", "serve-history-postgres", "serve-history-sqlite", "catalog", "lineage", "lineage-kafka", "notify", "transform-sql", "triggers", "triggers-object-store", "triggers-redis", "triggers-kafka", "cli-dev", "encryption"]
+full = ["default", "otel", "schedule", "serve", "serve-ui", "serve-history-postgres", "serve-history-sqlite", "catalog", "lineage", "lineage-kafka", "notify", "transform-sql", "triggers", "triggers-object-store", "triggers-redis", "triggers-kafka", "cli-dev", "encryption", "cli-tui"]
 
 # Data Movement Catalog (#279): the `catalog:` config block + post-run
 # recording (datasets, schema timelines, volume/freshness stats, lineage
@@ -207,6 +207,10 @@ cli-interactive = ["dep:inquire"]
 # `faucet dev` — filesystem-watch dev loop (`faucet plan` needs no feature and
 # ships in default).
 cli-dev = ["dep:notify-fs"]
+# Live terminal UI for `faucet run --tui` (#203): full-screen ratatui view of
+# per-row throughput/errors/DLQ/bookmark age, sampled from the in-process
+# Prometheus recorder (implies `observability`). Opt-in; not in `default`.
+cli-tui = ["observability", "dep:ratatui"]
 
 transforms = [
     "faucet-core/transforms",
@@ -326,6 +330,7 @@ inquire = { version = "0.9", optional = true, default-features = false, features
 # `faucet dev` filesystem watch (#283). Renamed key so it doesn't collide with
 # the `notify` *feature* (the notification/incident-routing layer).
 notify-fs = { package = "notify", version = "8", optional = true }
+ratatui = { workspace = true, optional = true }
 futures = { workspace = true }
 glob = { workspace = true }
 reqwest = { workspace = true, optional = true }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -28,7 +28,7 @@ default = ["observability", "source", "sink", "state", "transforms", "compressio
 
 # Everything the default build ships, plus the long-running runtime modes:
 # `schedule` (cron scheduler) and `serve` (HTTP control plane).
-full = ["default", "otel", "schedule", "serve", "serve-ui", "serve-history-postgres", "serve-history-sqlite", "catalog", "lineage", "lineage-kafka", "notify", "transform-sql", "triggers", "triggers-object-store", "triggers-redis", "triggers-kafka", "cli-dev"]
+full = ["default", "otel", "schedule", "serve", "serve-ui", "serve-history-postgres", "serve-history-sqlite", "catalog", "lineage", "lineage-kafka", "notify", "transform-sql", "triggers", "triggers-object-store", "triggers-redis", "triggers-kafka", "cli-dev", "encryption"]
 
 # Data Movement Catalog (#279): the `catalog:` config block + post-run
 # recording (datasets, schema timelines, volume/freshness stats, lineage
@@ -54,6 +54,12 @@ contract = ["faucet-core/contract"]
 # masking` verb, #206): classify sensitive fields and redact/hash/tokenize/
 # partial-mask them per page, before every sink. Forwarded to `faucet-core`.
 masking = ["faucet-core/masking"]
+
+# Encryption at rest (#207): the `encryption:` block on the `file` state store
+# (AES-256-GCM bookmark files) and on the jsonl sink (per-line sealing — the
+# file-DLQ-at-rest shape), plus decryption support in `faucet dlq
+# inspect/replay/discard`. Opt-in; included in `full`.
+encryption = ["faucet-core/encryption", "faucet-sink-jsonl?/encryption", "dep:base64"]
 
 source = [
     "source-rest",

--- a/cli/README.md
+++ b/cli/README.md
@@ -26,7 +26,7 @@ cargo install faucet-cli --no-default-features \
 
 | Command | What it does |
 |---------|--------------|
-| `faucet run <config>` | Execute the pipeline end-to-end. Supports `--dry-run`, `--limit N`, `--state-path PATH`. |
+| `faucet run <config>` | Execute the pipeline end-to-end. Supports `--dry-run`, `--limit N`, `--state-path PATH`, and `--tui` (live full-screen progress view; `cli-tui` build feature, non-TTY falls back to a plain run). |
 | `faucet validate <config>` | Parse + validate without running. Exits non-zero on error. |
 | `faucet schema source|sink|transform <name>` | Print the JSON Schema for a connector's or transform's config. |
 | `faucet schema dlq` | Print the JSON Schema for the dead-letter-queue spec. |

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -597,6 +597,14 @@ pub struct RunArgs {
     /// Not applicable in `--from-env` mode (no config file to compose).
     #[arg(long, env = "FAUCET_PROFILE")]
     pub profile: Option<String>,
+    /// Show a live full-screen terminal UI (per-invocation throughput, errors,
+    /// DLQ counts, bookmark age) while the pipeline runs. Requires a binary
+    /// built with the `cli-tui` feature and a real terminal on stdout —
+    /// on a non-TTY (CI, pipes) the run proceeds normally with a notice.
+    /// Press `q` to cancel cooperatively (in-flight work flushes at the next
+    /// page boundary).
+    #[arg(long)]
+    pub tui: bool,
 }
 
 /// `faucet backfill` arguments.

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -280,6 +280,11 @@ pub struct DlqInspectArgs {
     /// Number of sample records to show. Default: 5.
     #[arg(long, default_value_t = 5)]
     pub limit: usize,
+    /// Key for a DLQ sealed at rest by the jsonl sink's `encryption` block.
+    /// Repeat the flag to also try older (rotated) keys. Requires a build
+    /// with the `encryption` feature.
+    #[arg(long = "encryption-key")]
+    pub encryption_key: Vec<String>,
     /// Emit a machine-readable JSON summary instead of the human report.
     #[arg(long)]
     pub json: bool,
@@ -307,6 +312,13 @@ pub struct DlqReplayArgs {
     /// Report what would be replayed without writing to the sink.
     #[arg(long)]
     pub dry_run: bool,
+    /// Key for a DLQ sealed at rest by the jsonl sink's `encryption` block.
+    /// Repeat the flag to also try older (rotated) keys. Requires a build
+    /// with the `encryption` feature.
+    #[arg(long = "encryption-key")]
+    pub encryption_key: Vec<String>,
+    /// (Replay picks up the config's own dlq `encryption` block automatically
+    /// when no key is passed.)
     /// Emit a machine-readable JSON result instead of the human summary.
     #[arg(long)]
     pub json: bool,
@@ -337,6 +349,11 @@ pub struct DlqDiscardArgs {
     /// `<file>.archived.jsonl` sibling.
     #[arg(long)]
     pub delete: bool,
+    /// Key for a DLQ sealed at rest by the jsonl sink's `encryption` block.
+    /// Repeat the flag to also try older (rotated) keys. Requires a build
+    /// with the `encryption` feature.
+    #[arg(long = "encryption-key")]
+    pub encryption_key: Vec<String>,
     /// Emit a machine-readable JSON result instead of the human summary.
     #[arg(long)]
     pub json: bool,

--- a/cli/src/commands/dlq.rs
+++ b/cli/src/commands/dlq.rs
@@ -6,7 +6,7 @@
 
 use crate::cli::{DlqArgs, DlqCommand, DlqDiscardArgs, DlqInspectArgs, DlqReplayArgs};
 use crate::config::PipelineConfig;
-use crate::dlq_replay::{self, ReplayInputs};
+use crate::dlq_replay::{self, ReplayInputs, reader::DlqDecryptor};
 use crate::error::{CliError, CliResult};
 use chrono::{DateTime, Utc};
 
@@ -27,7 +27,8 @@ pub async fn run(args: DlqArgs) -> CliResult<()> {
 }
 
 fn inspect(args: DlqInspectArgs) -> CliResult<()> {
-    let summary = dlq_replay::inspect(&args.location, args.reason.as_deref(), args.limit)?;
+    let dec = DlqDecryptor::from_keys(&args.encryption_key)?;
+    let summary = dlq_replay::inspect(&args.location, args.reason.as_deref(), args.limit, &dec)?;
     if args.json {
         println!("{}", to_json(&summary)?);
         return Ok(());
@@ -37,6 +38,12 @@ fn inspect(args: DlqInspectArgs) -> CliResult<()> {
         "  files read: {}   envelopes: {}   malformed: {}   non-envelope: {}",
         summary.files_read, summary.total_envelopes, summary.malformed, summary.non_envelope
     );
+    if summary.undecryptable > 0 {
+        println!(
+            "  encrypted lines that could not be decrypted: {} (pass --encryption-key)",
+            summary.undecryptable
+        );
+    }
     if !summary.by_reason.is_empty() {
         println!("  by reason:");
         for (reason, count) in &summary.by_reason {
@@ -99,6 +106,7 @@ async fn replay(args: DlqReplayArgs) -> CliResult<()> {
             execution: cfg.execution.clone(),
             auth,
             clock: Utc::now().fixed_offset(),
+            decryptor: DlqDecryptor::from_keys(&args.encryption_key)?,
         },
     )
     .await?;
@@ -130,11 +138,13 @@ fn discard(args: DlqDiscardArgs) -> CliResult<()> {
         Some(s) => Some(parse_before(s, Utc::now())?),
         None => None,
     };
+    let dec = DlqDecryptor::from_keys(&args.encryption_key)?;
     let outcome = dlq_replay::discard(
         &args.location,
         args.reason.as_deref(),
         before_ms,
         args.delete,
+        &dec,
     )?;
     if args.json {
         println!("{}", to_json(&outcome)?);

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -66,6 +66,36 @@ pub async fn run(args: RunArgs) -> CliResult<()> {
         .await?
     };
 
+    #[cfg(not(feature = "cli-tui"))]
+    if args.tui {
+        return Err(CliError::Config(
+            "--tui requires a binary built with the `cli-tui` feature \
+             (e.g. `cargo install faucet-cli --features cli-tui`)"
+                .into(),
+        ));
+    }
+    #[cfg(feature = "cli-tui")]
+    let tui_active = crate::tui::is_tui_session(args.tui);
+    #[cfg(feature = "cli-tui")]
+    let tui_handle = if tui_active {
+        // The TUI owns the metrics recorder (keeping the /metrics endpoint
+        // when one is configured) so it can render the recorder's output;
+        // the rest of the observability config (tracing level was already
+        // routed into the TUI log ring by `run_main`; OTLP traces) installs
+        // as usual with the prometheus block taken out.
+        let mut obs_cfg = crate::obs::build_observability_config(&cfg);
+        let prom = obs_cfg.prometheus.take();
+        let handle = crate::tui::install_metrics_recorder(prom.as_ref())?;
+        faucet_core::install_observability(&obs_cfg)?;
+        Some(handle)
+    } else {
+        if args.tui {
+            tracing::info!("--tui: stdout is not a terminal; running without the TUI");
+        }
+        crate::obs::install(&cfg)?;
+        None
+    };
+    #[cfg(not(feature = "cli-tui"))]
     crate::obs::install(&cfg)?;
 
     let pipeline_name = cfg.name.clone().unwrap_or_else(|| {
@@ -93,7 +123,13 @@ pub async fn run(args: RunArgs) -> CliResult<()> {
         None => None,
     };
     let nodes = expand(&cfg)?;
-    let summary = run_expanded(
+    // The TUI wires `q` / Ctrl-C to this token: in-flight invocations stop at
+    // their next page boundary and flush (#146 H16). Plain runs keep `None`.
+    #[cfg(feature = "cli-tui")]
+    let tui_cancel = tui_active.then(faucet_core::CancellationToken::new);
+    #[cfg(not(feature = "cli-tui"))]
+    let tui_cancel: Option<faucet_core::CancellationToken> = None;
+    let run_fut = run_expanded(
         nodes,
         ExecuteOptions {
             pipeline_name: pipeline_name.clone(),
@@ -104,9 +140,10 @@ pub async fn run(args: RunArgs) -> CliResult<()> {
             shard: None,
             auth,
             clock: resolve_run_clock(args.clock.as_deref())?,
-            // `faucet run` has no external cancel signal; the executor still
-            // cooperatively cancels in-flight rows on `on_error: stop`.
-            cancel: None,
+            // Plain runs have no external cancel signal (the executor still
+            // cooperatively cancels in-flight rows on `on_error: stop`); a
+            // TUI session cancels via `q` / Ctrl-C.
+            cancel: tui_cancel.clone(),
             resilience,
             sla: cfg.sla.clone(),
             #[cfg(feature = "lineage")]
@@ -118,8 +155,26 @@ pub async fn run(args: RunArgs) -> CliResult<()> {
             #[cfg(feature = "catalog")]
             catalog,
         },
-    )
-    .await?;
+    );
+    #[cfg(feature = "cli-tui")]
+    let summary = match (tui_handle, tui_cancel) {
+        (Some(handle), Some(cancel)) => {
+            let result = crate::tui::drive(run_fut, &pipeline_name, handle, cancel).await;
+            if result
+                .as_ref()
+                .map(|s| s.failure_count() > 0)
+                .unwrap_or(true)
+            {
+                // The failure context lived on the alternate screen — replay
+                // the tail of the log ring to stderr now that it's gone.
+                crate::tui::flush_logs_to_stderr(25);
+            }
+            result?
+        }
+        _ => run_fut.await?,
+    };
+    #[cfg(not(feature = "cli-tui"))]
+    let summary = run_fut.await?;
 
     let total_written: usize = summary.invocations.iter().map(|i| i.records_written).sum();
     let success = summary

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -78,16 +78,7 @@ pub async fn run(args: RunArgs) -> CliResult<()> {
     let tui_active = crate::tui::is_tui_session(args.tui);
     #[cfg(feature = "cli-tui")]
     let tui_handle = if tui_active {
-        // The TUI owns the metrics recorder (keeping the /metrics endpoint
-        // when one is configured) so it can render the recorder's output;
-        // the rest of the observability config (tracing level was already
-        // routed into the TUI log ring by `run_main`; OTLP traces) installs
-        // as usual with the prometheus block taken out.
-        let mut obs_cfg = crate::obs::build_observability_config(&cfg);
-        let prom = obs_cfg.prometheus.take();
-        let handle = crate::tui::install_metrics_recorder(prom.as_ref())?;
-        faucet_core::install_observability(&obs_cfg)?;
-        Some(handle)
+        Some(crate::tui::setup_observability(&cfg)?)
     } else {
         if args.tui {
             tracing::info!("--tui: stdout is not a terminal; running without the TUI");

--- a/cli/src/dlq_replay/mod.rs
+++ b/cli/src/dlq_replay/mod.rs
@@ -20,7 +20,7 @@ use crate::executor::{ExecuteOptions, run_expanded};
 use chrono::{DateTime, FixedOffset};
 use faucet_core::UnwrappedEnvelope;
 use plan::{build_replay_node, default_failed_dlq_path, validate_reason};
-use reader::{expand_location, reason_matches, scan_files};
+use reader::{DlqDecryptor, expand_location, reason_matches, scan_files};
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::BTreeMap;
@@ -63,6 +63,9 @@ pub struct InspectSummary {
     pub malformed: usize,
     /// Valid-JSON lines that were not DLQ envelopes.
     pub non_envelope: usize,
+    /// Sealed (encrypted) lines that could not be decrypted with the
+    /// available keys — pass `--encryption-key` to read them.
+    pub undecryptable: usize,
     pub by_reason: BTreeMap<String, usize>,
     pub by_error_kind: BTreeMap<String, usize>,
     pub sample: Vec<EnvelopeSummary>,
@@ -97,10 +100,11 @@ pub fn inspect(
     location: &str,
     reason: Option<&str>,
     sample_limit: usize,
+    dec: &DlqDecryptor,
 ) -> CliResult<InspectSummary> {
     let reason = validate_reason(reason)?;
     let files = expand_location(location)?;
-    let scan = scan_files(&files)?;
+    let scan = scan_files(&files, dec)?;
     let envs: Vec<UnwrappedEnvelope> = scan
         .envelopes
         .into_iter()
@@ -129,6 +133,7 @@ pub fn inspect(
         total_envelopes: envs.len(),
         malformed: scan.malformed,
         non_envelope: scan.non_envelope,
+        undecryptable: scan.undecryptable,
         by_reason,
         by_error_kind,
         sample,
@@ -148,6 +153,9 @@ pub struct ReplayInputs<'a> {
     pub execution: Option<ExecutionSpec>,
     pub auth: AuthCatalog,
     pub clock: DateTime<FixedOffset>,
+    /// Decryption for sealed DLQ lines. When inert, the referenced config's
+    /// own dlq jsonl `encryption` block is picked up automatically.
+    pub decryptor: DlqDecryptor,
 }
 
 /// Reconstruct a pipeline whose source is the DLQ location (envelopes →
@@ -166,15 +174,36 @@ pub async fn replay(
         .map(PathBuf::from)
         .unwrap_or_else(|| default_failed_dlq_path(&files));
 
-    // Count candidates up front (cheap; the reader scans again at run time).
-    let scan = scan_files(&files)?;
+    // Resolve the effective decryptor once: explicit keys win; otherwise the
+    // `encryption` block of the config's own dlq jsonl sink applies (the file
+    // being replayed was almost always written by exactly that sink).
+    let decryptor = if inputs.decryptor.is_active() {
+        inputs.decryptor.clone()
+    } else {
+        let nodes = crate::expand::expand(cfg)?;
+        let original_dlq = nodes
+            .iter()
+            .find(|n| matches!(n.role, crate::expand::NodeRole::Root))
+            .and_then(|n| n.dlq.as_ref());
+        DlqDecryptor::from_config_value(plan::dlq_encryption_value(original_dlq))?
+    };
+
+    let node = build_replay_node(
+        cfg,
+        files.clone(),
+        reason.clone(),
+        &failed,
+        inputs.row,
+        decryptor.clone(),
+    )?;
+
+    // Count candidates up front with the same decryptor the reader will use.
+    let scan = scan_files(&files, &decryptor)?;
     let candidates = scan
         .envelopes
         .iter()
         .filter(|e| reason_matches(e, reason.as_deref()))
         .count();
-
-    let node = build_replay_node(cfg, files, reason, &failed, inputs.row)?;
 
     let summary = run_expanded(
         vec![node],
@@ -236,6 +265,7 @@ pub fn discard(
     reason: Option<&str>,
     before_ms: Option<i64>,
     delete: bool,
+    dec: &DlqDecryptor,
 ) -> CliResult<DiscardOutcome> {
     let reason = validate_reason(reason)?;
     let files = expand_location(location)?;
@@ -252,7 +282,7 @@ pub fn discard(
         let mut removed = String::new();
         let mut file_discarded = 0usize;
         for line in text.lines() {
-            if plan::discard_keep_line(line, reason.as_deref(), before_ms) {
+            if plan::discard_keep_line(line, dec, reason.as_deref(), before_ms) {
                 kept.push_str(line);
                 kept.push('\n');
             } else {
@@ -340,7 +370,7 @@ mod tests {
             env_line("contract", "ContractViolation", 3, json!({"id": 3})),
         );
         let path = write(dir.path(), "dlq.jsonl", &body);
-        let s = inspect(path.to_str().unwrap(), None, 10).unwrap();
+        let s = inspect(path.to_str().unwrap(), None, 10, &DlqDecryptor::default()).unwrap();
         assert_eq!(s.total_envelopes, 3);
         assert_eq!(s.malformed, 1);
         assert_eq!(s.non_envelope, 1);
@@ -360,7 +390,13 @@ mod tests {
             env_line("contract", "ContractViolation", 3, json!({"id": 3})),
         );
         let path = write(dir.path(), "dlq.jsonl", &body);
-        let s = inspect(path.to_str().unwrap(), Some("quality"), 1).unwrap();
+        let s = inspect(
+            path.to_str().unwrap(),
+            Some("quality"),
+            1,
+            &DlqDecryptor::default(),
+        )
+        .unwrap();
         assert_eq!(s.total_envelopes, 2);
         assert_eq!(s.by_reason.len(), 1);
         assert_eq!(s.sample.len(), 1);
@@ -375,7 +411,14 @@ mod tests {
             env_line("contract", "ContractViolation", 2, json!({"id": 2})),
         );
         let path = write(dir.path(), "dlq.jsonl", &body);
-        let out = discard(path.to_str().unwrap(), Some("quality"), None, false).unwrap();
+        let out = discard(
+            path.to_str().unwrap(),
+            Some("quality"),
+            None,
+            false,
+            &DlqDecryptor::default(),
+        )
+        .unwrap();
         assert_eq!(out.discarded, 1);
         assert_eq!(out.files_rewritten, 1);
         assert_eq!(out.archived_to.len(), 1);
@@ -398,7 +441,14 @@ mod tests {
             env_line("quality", "QualityFailure", 1, json!({"id": 1}))
         );
         let path = write(dir.path(), "dlq.jsonl", &body);
-        let out = discard(path.to_str().unwrap(), None, None, true).unwrap();
+        let out = discard(
+            path.to_str().unwrap(),
+            None,
+            None,
+            true,
+            &DlqDecryptor::default(),
+        )
+        .unwrap();
         assert_eq!(out.discarded, 1);
         assert!(out.archived_to.is_empty());
         assert!(!dir.path().join("dlq.archived.jsonl").exists());
@@ -413,7 +463,14 @@ mod tests {
             env_line("quality", "QualityFailure", 5000, json!({"id": 2})),
         );
         let path = write(dir.path(), "dlq.jsonl", &body);
-        let out = discard(path.to_str().unwrap(), None, Some(1000), true).unwrap();
+        let out = discard(
+            path.to_str().unwrap(),
+            None,
+            Some(1000),
+            true,
+            &DlqDecryptor::default(),
+        )
+        .unwrap();
         assert_eq!(out.discarded, 1);
         let remaining = std::fs::read_to_string(&path).unwrap();
         assert!(remaining.contains("\"id\":2") || remaining.contains("\"id\": 2"));
@@ -428,7 +485,14 @@ mod tests {
         );
         let path = write(dir.path(), "dlq.jsonl", &body);
         let before = std::fs::read_to_string(&path).unwrap();
-        let out = discard(path.to_str().unwrap(), Some("contract"), None, false).unwrap();
+        let out = discard(
+            path.to_str().unwrap(),
+            Some("contract"),
+            None,
+            false,
+            &DlqDecryptor::default(),
+        )
+        .unwrap();
         assert_eq!(out.discarded, 0);
         assert_eq!(out.files_rewritten, 0);
         assert_eq!(std::fs::read_to_string(&path).unwrap(), before);

--- a/cli/src/dlq_replay/plan.rs
+++ b/cli/src/dlq_replay/plan.rs
@@ -4,7 +4,7 @@
 //! unit-testable; the IO shims live in [`mod`](super) and [`reader`](super::reader).
 
 use crate::config::{ConnectorSpec, DlqSpec, OnBatchErrorSpec, PipelineConfig};
-use crate::dlq_replay::reader::{DlqReaderSource, SourceOverride};
+use crate::dlq_replay::reader::{DlqDecryptor, DlqReaderSource, SourceOverride};
 use crate::error::{CliError, CliResult};
 use crate::expand::{ExpandedNode, NodeRole, expand};
 use faucet_core::{DeliveryMode, DlqReason, UnwrappedEnvelope};
@@ -125,6 +125,7 @@ pub fn build_replay_node(
     reason: Option<String>,
     failed_dlq: &Path,
     row: Option<&str>,
+    decryptor: DlqDecryptor,
 ) -> CliResult<ExpandedNode> {
     // Loop guard: the fresh DLQ must not be one of the source files.
     if from_files.iter().any(|f| same_file(f, failed_dlq)) {
@@ -142,7 +143,7 @@ pub fn build_replay_node(
         .and_then(|n| n.dlq.clone());
     let mut node = select_replay_node(nodes, row)?;
 
-    let reader = DlqReaderSource::new(from_files, reason);
+    let reader = DlqReaderSource::new(from_files, reason, decryptor);
     node.source_override = Some(SourceOverride::new(Box::new(reader)));
     // A replay reads the whole DLQ location once — no bookmarking, and never
     // exactly-once (the reader is not a deterministic-replay source).
@@ -150,6 +151,16 @@ pub fn build_replay_node(
     node.delivery = DeliveryMode::AtLeastOnce;
     node.dlq = Some(failed_dlq_spec(failed_dlq, original_dlq.as_ref()));
     Ok(node)
+}
+
+/// The raw `encryption` value of a config's dlq **jsonl** sink, if any —
+/// the key that sealed the DLQ file a replay reads back.
+pub fn dlq_encryption_value(dlq: Option<&DlqSpec>) -> Option<&serde_json::Value> {
+    let dlq = dlq?;
+    if dlq.sink.kind != "jsonl" {
+        return None;
+    }
+    dlq.sink.config.get("encryption")
 }
 
 /// Two paths refer to the same file. Uses canonicalization when both exist,
@@ -184,10 +195,18 @@ pub fn envelope_selected(
 /// Decide whether a raw discard-candidate line should be kept or discarded.
 /// Only DLQ envelopes matching the filter are discarded; blank, malformed,
 /// and non-envelope lines are always kept (we never mangle non-faucet content).
-pub fn discard_keep_line(line: &str, reason: Option<&str>, before_ms: Option<i64>) -> bool {
-    use crate::dlq_replay::reader::{LineOutcome, classify_line};
-    match classify_line(line) {
+pub fn discard_keep_line(
+    line: &str,
+    dec: &DlqDecryptor,
+    reason: Option<&str>,
+    before_ms: Option<i64>,
+) -> bool {
+    use crate::dlq_replay::reader::{LineOutcome, classify_line_with};
+    match classify_line_with(line, dec) {
         LineOutcome::Envelope(env) => !envelope_selected(&env, reason, before_ms),
+        // Blank / malformed / non-envelope / undecryptable lines are always
+        // preserved verbatim — we never mangle content we cannot prove is a
+        // matching envelope.
         _ => true,
     }
 }
@@ -290,12 +309,32 @@ mod tests {
         })
         .to_string();
         // Matching envelope with reason filter → discarded (not kept).
-        assert!(!discard_keep_line(&matching, Some("quality"), None));
+        assert!(!discard_keep_line(
+            &matching,
+            &DlqDecryptor::default(),
+            Some("quality"),
+            None
+        ));
         // Non-matching reason → kept.
-        assert!(discard_keep_line(&matching, Some("contract"), None));
+        assert!(discard_keep_line(
+            &matching,
+            &DlqDecryptor::default(),
+            Some("contract"),
+            None
+        ));
         // Non-envelope / blank / malformed → always kept.
-        assert!(discard_keep_line(r#"{"a":1}"#, None, None));
-        assert!(discard_keep_line("", None, None));
-        assert!(discard_keep_line("not json", Some("quality"), None));
+        assert!(discard_keep_line(
+            r#"{"a":1}"#,
+            &DlqDecryptor::default(),
+            None,
+            None
+        ));
+        assert!(discard_keep_line("", &DlqDecryptor::default(), None, None));
+        assert!(discard_keep_line(
+            "not json",
+            &DlqDecryptor::default(),
+            Some("quality"),
+            None
+        ));
     }
 }

--- a/cli/src/dlq_replay/reader.rs
+++ b/cli/src/dlq_replay/reader.rs
@@ -16,6 +16,128 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
+/// Base64 of the sealed-payload magic `FCT` — every line the jsonl sink
+/// writes under an `encryption:` block starts with this, so sealed lines are
+/// detectable even in builds without the `encryption` feature.
+const SEALED_LINE_PREFIX: &str = "RkNU";
+
+/// Optional decryption for DLQ lines sealed at rest by the jsonl sink's
+/// `encryption:` block (#207). The default carries no keys: sealed lines are
+/// still *detected* (and counted as [`LineOutcome::Undecryptable`]) so an
+/// encrypted DLQ inspected without a key reports what it is instead of "all
+/// lines malformed".
+#[derive(Clone, Default)]
+pub struct DlqDecryptor {
+    #[cfg(feature = "encryption")]
+    inner: Option<Arc<faucet_core::CompiledEncryption>>,
+}
+
+impl std::fmt::Debug for DlqDecryptor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("DlqDecryptor(..)")
+    }
+}
+
+/// How one raw line decodes before classification.
+enum LineDecode {
+    /// Not a sealed line — classify the raw text.
+    Plain,
+    /// Sealed and successfully decrypted — classify the plaintext.
+    #[cfg(feature = "encryption")]
+    Decrypted(String),
+    /// Sealed but no key / wrong key / tampered — counted, never fatal.
+    Undecryptable,
+}
+
+impl DlqDecryptor {
+    /// Build from user-supplied keys (`--encryption-key`, repeatable): the
+    /// first entry is the current key, the rest are rotation candidates.
+    /// An empty slice builds the inert default.
+    pub fn from_keys(keys: &[String]) -> Result<Self, FaucetError> {
+        if keys.is_empty() {
+            return Ok(Self::default());
+        }
+        #[cfg(feature = "encryption")]
+        {
+            let spec = faucet_core::EncryptionSpec {
+                key: keys[0].clone(),
+                previous_keys: keys[1..].to_vec(),
+                algorithm: Default::default(),
+            };
+            Ok(Self {
+                inner: Some(Arc::new(faucet_core::CompiledEncryption::compile(&spec)?)),
+            })
+        }
+        #[cfg(not(feature = "encryption"))]
+        Err(FaucetError::Config(
+            "--encryption-key requires a faucet build with the `encryption` feature \
+             (cargo install faucet-cli --features encryption)"
+                .into(),
+        ))
+    }
+
+    /// Build from a jsonl sink config's raw `encryption` block (as found in a
+    /// config's `dlq:` sink), if present.
+    pub fn from_config_value(value: Option<&Value>) -> Result<Self, FaucetError> {
+        let Some(value) = value else {
+            return Ok(Self::default());
+        };
+        #[cfg(feature = "encryption")]
+        {
+            let spec: faucet_core::EncryptionSpec = serde_json::from_value(value.clone())
+                .map_err(|e| FaucetError::Config(format!("dlq sink `encryption` block: {e}")))?;
+            Ok(Self {
+                inner: Some(Arc::new(faucet_core::CompiledEncryption::compile(&spec)?)),
+            })
+        }
+        #[cfg(not(feature = "encryption"))]
+        Err(FaucetError::Config(
+            "the config's dlq sink has an `encryption` block, but this faucet build has no \
+             `encryption` feature"
+                .into(),
+        ))
+    }
+
+    /// Whether any key is loaded.
+    pub fn is_active(&self) -> bool {
+        #[cfg(feature = "encryption")]
+        {
+            self.inner.is_some()
+        }
+        #[cfg(not(feature = "encryption"))]
+        false
+    }
+
+    fn decode(&self, line: &str) -> LineDecode {
+        let trimmed = line.trim();
+        if !trimmed.starts_with(SEALED_LINE_PREFIX) {
+            return LineDecode::Plain;
+        }
+        #[cfg(feature = "encryption")]
+        if let Some(enc) = &self.inner {
+            use base64::Engine as _;
+            let Ok(sealed) = base64::engine::general_purpose::STANDARD.decode(trimmed) else {
+                // Starts like a sealed line but is not base64 — let the JSON
+                // classifier call it malformed.
+                return LineDecode::Plain;
+            };
+            if !faucet_core::encryption::is_encrypted(&sealed) {
+                return LineDecode::Plain;
+            }
+            return match enc.decrypt(&sealed) {
+                Ok(plain) => match String::from_utf8(plain) {
+                    Ok(text) => LineDecode::Decrypted(text),
+                    Err(_) => LineDecode::Undecryptable,
+                },
+                Err(_) => LineDecode::Undecryptable,
+            };
+        }
+        // Sealed-looking line with no key available (or an encryption-less
+        // build): report it as encrypted rather than malformed.
+        LineDecode::Undecryptable
+    }
+}
+
 /// A pre-built source attached to a single [`ExpandedNode`](crate::expand::ExpandedNode)
 /// so the executor runs it instead of building one from the connector
 /// registry. Used only by `faucet dlq replay`, which runs exactly one
@@ -53,22 +175,40 @@ pub enum LineOutcome {
     /// Valid JSON that is not a DLQ envelope (no `payload`) — skipped and
     /// counted.
     NonEnvelope,
+    /// A line sealed by the jsonl sink's `encryption:` block that could not
+    /// be decrypted (no key, wrong key, or tampering) — skipped and counted.
+    Undecryptable,
     /// A parsed DLQ envelope.
     Envelope(Box<UnwrappedEnvelope>),
 }
 
 /// Classify one raw line. Pure — no IO. Blank lines are ignored; anything
-/// else is either an envelope, malformed JSON, or valid-but-not-an-envelope.
+/// else is either an envelope, malformed JSON, valid-but-not-an-envelope, or
+/// an (un)decryptable sealed line.
 pub fn classify_line(line: &str) -> LineOutcome {
+    classify_line_with(line, &DlqDecryptor::default())
+}
+
+/// [`classify_line`] with decryption support: sealed lines are decrypted
+/// through `dec` before classification.
+pub fn classify_line_with(line: &str, dec: &DlqDecryptor) -> LineOutcome {
     if line.trim().is_empty() {
         return LineOutcome::Blank;
     }
-    match serde_json::from_str::<Value>(line) {
-        Ok(value) => match unwrap_envelope(&value) {
-            Ok(env) => LineOutcome::Envelope(Box::new(env)),
-            Err(_) => LineOutcome::NonEnvelope,
-        },
-        Err(_) => LineOutcome::Malformed,
+    fn classify_text(text: &str) -> LineOutcome {
+        match serde_json::from_str::<Value>(text) {
+            Ok(value) => match unwrap_envelope(&value) {
+                Ok(env) => LineOutcome::Envelope(Box::new(env)),
+                Err(_) => LineOutcome::NonEnvelope,
+            },
+            Err(_) => LineOutcome::Malformed,
+        }
+    }
+    match dec.decode(line) {
+        LineDecode::Plain => classify_text(line),
+        #[cfg(feature = "encryption")]
+        LineDecode::Decrypted(plain) => classify_text(&plain),
+        LineDecode::Undecryptable => LineOutcome::Undecryptable,
     }
 }
 
@@ -81,6 +221,9 @@ pub struct ScanResult {
     pub malformed: usize,
     /// Valid-JSON lines that were not DLQ envelopes (no `payload`).
     pub non_envelope: usize,
+    /// Sealed (encrypted) lines that could not be decrypted with the
+    /// available keys.
+    pub undecryptable: usize,
     /// Files that were read.
     pub files_read: usize,
 }
@@ -130,7 +273,7 @@ pub fn expand_location(location: &str) -> Result<Vec<PathBuf>, FaucetError> {
 /// Read and classify every line of every file, collecting envelopes and
 /// tallies. Blank lines are ignored; malformed / non-envelope lines are
 /// counted but never abort the scan.
-pub fn scan_files(files: &[PathBuf]) -> Result<ScanResult, FaucetError> {
+pub fn scan_files(files: &[PathBuf], dec: &DlqDecryptor) -> Result<ScanResult, FaucetError> {
     let mut out = ScanResult::default();
     for file in files {
         let text = std::fs::read_to_string(file).map_err(|e| {
@@ -138,10 +281,11 @@ pub fn scan_files(files: &[PathBuf]) -> Result<ScanResult, FaucetError> {
         })?;
         out.files_read += 1;
         for line in text.lines() {
-            match classify_line(line) {
+            match classify_line_with(line, dec) {
                 LineOutcome::Blank => {}
                 LineOutcome::Malformed => out.malformed += 1,
                 LineOutcome::NonEnvelope => out.non_envelope += 1,
+                LineOutcome::Undecryptable => out.undecryptable += 1,
                 LineOutcome::Envelope(env) => out.envelopes.push(*env),
             }
         }
@@ -168,13 +312,15 @@ pub fn reason_matches(env: &UnwrappedEnvelope, filter: Option<&str>) -> bool {
 pub struct DlqReaderSource {
     files: Vec<PathBuf>,
     reason: Option<String>,
+    dec: DlqDecryptor,
 }
 
 impl DlqReaderSource {
     /// Build a reader over the already-expanded `files`, keeping only
-    /// envelopes whose reason matches `reason` (if set).
-    pub fn new(files: Vec<PathBuf>, reason: Option<String>) -> Self {
-        Self { files, reason }
+    /// envelopes whose reason matches `reason` (if set). Sealed lines are
+    /// decrypted through `dec`.
+    pub fn new(files: Vec<PathBuf>, reason: Option<String>, dec: DlqDecryptor) -> Self {
+        Self { files, reason, dec }
     }
 }
 
@@ -186,8 +332,9 @@ impl Source for DlqReaderSource {
     ) -> Result<Vec<Value>, FaucetError> {
         let files = self.files.clone();
         let reason = self.reason.clone();
+        let dec = self.dec.clone();
         // Blocking file IO off the async runtime.
-        let scan = tokio::task::spawn_blocking(move || scan_files(&files))
+        let scan = tokio::task::spawn_blocking(move || scan_files(&files, &dec))
             .await
             .map_err(|e| FaucetError::Source(format!("DLQ reader task panicked: {e}")))??;
         Ok(scan
@@ -295,7 +442,7 @@ mod tests {
             envelope_line("contract", json!({"id": 2})),
         );
         let (_dir, path) = write_tmp("dlq.jsonl", &body);
-        let scan = scan_files(&[path]).unwrap();
+        let scan = scan_files(&[path], &DlqDecryptor::default()).unwrap();
         assert_eq!(scan.envelopes.len(), 2);
         assert_eq!(scan.malformed, 1);
         assert_eq!(scan.non_envelope, 1);
@@ -340,11 +487,12 @@ mod tests {
         );
         let (_dir, path) = write_tmp("dlq.jsonl", &body);
         // No filter → both payloads.
-        let src = DlqReaderSource::new(vec![path.clone()], None);
+        let src = DlqReaderSource::new(vec![path.clone()], None, DlqDecryptor::default());
         let all = src.fetch_all().await.unwrap();
         assert_eq!(all, vec![json!({"id": 1}), json!({"id": 2})]);
         // Reason filter → only matching payloads.
-        let src = DlqReaderSource::new(vec![path], Some("contract".into()));
+        let src =
+            DlqReaderSource::new(vec![path], Some("contract".into()), DlqDecryptor::default());
         let filtered = src.fetch_all().await.unwrap();
         assert_eq!(filtered, vec![json!({"id": 2})]);
     }
@@ -364,5 +512,85 @@ mod tests {
         let ov = SourceOverride::new(Box::new(Dummy));
         assert!(ov.take().is_some());
         assert!(ov.take().is_none());
+    }
+
+    #[cfg(feature = "encryption")]
+    mod sealed_lines {
+        use super::*;
+        use base64::Engine as _;
+
+        fn seal(key: &str, text: &str) -> String {
+            let enc = faucet_core::CompiledEncryption::compile(&faucet_core::EncryptionSpec {
+                key: key.into(),
+                previous_keys: vec![],
+                algorithm: Default::default(),
+            })
+            .unwrap();
+            base64::engine::general_purpose::STANDARD.encode(enc.encrypt(text.as_bytes()))
+        }
+
+        #[test]
+        fn sealed_envelope_classifies_with_the_right_key() {
+            let line = seal("k", &envelope_line("quality", serde_json::json!({"id": 1})));
+            let dec = DlqDecryptor::from_keys(&["k".to_string()]).unwrap();
+            assert!(matches!(
+                classify_line_with(&line, &dec),
+                LineOutcome::Envelope(_)
+            ));
+            // Rotation: the sealing key found among the later candidates.
+            let rotated = DlqDecryptor::from_keys(&["new".to_string(), "k".to_string()]).unwrap();
+            assert!(matches!(
+                classify_line_with(&line, &rotated),
+                LineOutcome::Envelope(_)
+            ));
+        }
+
+        #[test]
+        fn sealed_line_without_or_with_wrong_key_is_undecryptable_not_malformed() {
+            let line = seal("k", "{\"payload\": {}}");
+            assert_eq!(
+                classify_line_with(&line, &DlqDecryptor::default()),
+                LineOutcome::Undecryptable
+            );
+            let wrong = DlqDecryptor::from_keys(&["other".to_string()]).unwrap();
+            assert_eq!(
+                classify_line_with(&line, &wrong),
+                LineOutcome::Undecryptable
+            );
+        }
+
+        #[test]
+        fn plain_lines_pass_through_a_keyed_decryptor() {
+            let dec = DlqDecryptor::from_keys(&["k".to_string()]).unwrap();
+            assert!(matches!(
+                classify_line_with(&envelope_line("quality", serde_json::json!({"a": 1})), &dec),
+                LineOutcome::Envelope(_)
+            ));
+            assert_eq!(
+                classify_line_with("{not json", &dec),
+                LineOutcome::Malformed
+            );
+            // A line that merely starts with the sealed prefix but is not
+            // base64/sealed falls back to normal classification.
+            assert_eq!(
+                classify_line_with("RkNU-not-really-sealed!!!", &dec),
+                LineOutcome::Malformed
+            );
+        }
+
+        #[test]
+        fn from_keys_empty_is_inert_and_from_config_value_none_is_inert() {
+            assert!(!DlqDecryptor::from_keys(&[]).unwrap().is_active());
+            assert!(!DlqDecryptor::from_config_value(None).unwrap().is_active());
+            let v = serde_json::json!({"key": "k"});
+            assert!(
+                DlqDecryptor::from_config_value(Some(&v))
+                    .unwrap()
+                    .is_active()
+            );
+            assert!(
+                DlqDecryptor::from_config_value(Some(&serde_json::json!({"nope": 1}))).is_err()
+            );
+        }
     }
 }

--- a/cli/src/dlq_replay/reader.rs
+++ b/cli/src/dlq_replay/reader.rs
@@ -79,6 +79,8 @@ impl DlqDecryptor {
     /// Build from a jsonl sink config's raw `encryption` block (as found in a
     /// config's `dlq:` sink), if present.
     pub fn from_config_value(value: Option<&Value>) -> Result<Self, FaucetError> {
+        // The binding is only consumed under the `encryption` feature.
+        #[cfg_attr(not(feature = "encryption"), allow(unused_variables))]
         let Some(value) = value else {
             return Ok(Self::default());
         };

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -47,6 +47,8 @@ pub mod serve;
 pub mod sla;
 pub mod state;
 pub mod transforms;
+#[cfg(feature = "cli-tui")]
+pub mod tui;
 
 pub use error::{CliError, CliResult};
 
@@ -86,10 +88,20 @@ pub fn run_main(registry: PluginRegistry) -> std::process::ExitCode {
     let is_serve = matches!(cli.command, Command::Serve(_));
     #[cfg(not(feature = "serve"))]
     let is_serve = false;
+    // A `--tui` run on a real terminal routes logs into the TUI's in-memory
+    // ring (the stdout subscriber would corrupt the alternate screen).
+    #[cfg(feature = "cli-tui")]
+    let is_tui = matches!(&cli.command, Command::Run(a) if tui::is_tui_session(a.tui));
+    #[cfg(not(feature = "cli-tui"))]
+    let is_tui = false;
     // `serve` installs its own (redacting, run-scoped) subscriber; every other
     // command uses the plain redacting fmt subscriber.
-    if !is_serve {
+    if !is_serve && !is_tui {
         install_tracing(&cli.log_level);
+    }
+    #[cfg(feature = "cli-tui")]
+    if is_tui {
+        tui::install_tui_tracing(&cli.log_level);
     }
 
     let runtime = match tokio::runtime::Builder::new_multi_thread()

--- a/cli/src/serve/handlers/dlq.rs
+++ b/cli/src/serve/handlers/dlq.rs
@@ -7,7 +7,7 @@
 //! [`crate::serve::rbac::required_permission`].
 
 use crate::auth_catalog::build_auth_catalog;
-use crate::dlq_replay::{self, ReplayInputs};
+use crate::dlq_replay::{self, ReplayInputs, reader::DlqDecryptor};
 use crate::error::CliError;
 use crate::serve::error::ServeError;
 use crate::serve::load::load_submission;
@@ -41,6 +41,9 @@ pub struct DlqInspectRequest {
     pub reason: Option<String>,
     #[serde(default = "default_sample_limit")]
     pub limit: usize,
+    /// Keys for a DLQ sealed at rest (first = current, rest = rotated).
+    #[serde(default)]
+    pub encryption_keys: Vec<String>,
 }
 
 /// `POST /v1/dlq/inspect` → 200 with the grouped
@@ -52,8 +55,11 @@ pub async fn inspect(
     let location = req.location;
     let reason = req.reason;
     let limit = req.limit;
+    let dec = DlqDecryptor::from_keys(&req.encryption_keys)
+        .map_err(CliError::from)
+        .map_err(cli_to_serve)?;
     let summary = tokio::task::spawn_blocking(move || {
-        dlq_replay::inspect(&location, reason.as_deref(), limit)
+        dlq_replay::inspect(&location, reason.as_deref(), limit, &dec)
     })
     .await
     .map_err(|e| ServeError::Internal(format!("dlq inspect task: {e}")))?
@@ -79,6 +85,10 @@ pub struct DlqReplayRequest {
     pub row: Option<String>,
     #[serde(default)]
     pub dry_run: bool,
+    /// Keys for a DLQ sealed at rest (first = current, rest = rotated). When
+    /// empty, the config's own dlq jsonl `encryption` block is used.
+    #[serde(default)]
+    pub encryption_keys: Vec<String>,
 }
 
 /// `POST /v1/dlq/replay` → 200 with the
@@ -114,6 +124,9 @@ pub async fn replay(
             execution: loaded.cfg.execution.clone(),
             auth,
             clock: Utc::now().fixed_offset(),
+            decryptor: DlqDecryptor::from_keys(&req.encryption_keys)
+                .map_err(CliError::from)
+                .map_err(cli_to_serve)?,
         },
     )
     .await;
@@ -137,6 +150,9 @@ pub struct DlqDiscardRequest {
     /// Permanently delete instead of archiving to a `<file>.archived.jsonl` sibling.
     #[serde(default)]
     pub delete: bool,
+    /// Keys for a DLQ sealed at rest (first = current, rest = rotated).
+    #[serde(default)]
+    pub encryption_keys: Vec<String>,
 }
 
 /// `POST /v1/dlq/discard` → 200 with the
@@ -151,8 +167,11 @@ pub async fn discard(
     let reason = req.reason;
     let before_ms = req.before_ms;
     let delete = req.delete;
+    let dec = DlqDecryptor::from_keys(&req.encryption_keys)
+        .map_err(CliError::from)
+        .map_err(cli_to_serve)?;
     let outcome = tokio::task::spawn_blocking(move || {
-        dlq_replay::discard(&location, reason.as_deref(), before_ms, delete)
+        dlq_replay::discard(&location, reason.as_deref(), before_ms, delete, &dec)
     })
     .await
     .map_err(|e| ServeError::Internal(format!("dlq discard task: {e}")));

--- a/cli/src/state.rs
+++ b/cli/src/state.rs
@@ -12,6 +12,11 @@ use std::sync::Arc;
 #[derive(Debug, Deserialize)]
 struct FileStateConfig {
     path: PathBuf,
+    /// Encryption at rest for bookmark files (#207). Parsed as a raw value so
+    /// a build without the `encryption` feature can reject it with a clear
+    /// error instead of a generic unknown-field failure.
+    #[serde(default)]
+    encryption: Option<serde_json::Value>,
 }
 
 #[cfg(feature = "state-redis")]
@@ -57,7 +62,24 @@ pub async fn build_state_store(spec: &StateStoreSpec) -> CliResult<Arc<dyn State
         "memory" => Ok(Arc::new(MemoryStateStore::new())),
         "file" => {
             let cfg = decode::<FileStateConfig>("file", spec.config.clone())?;
-            Ok(Arc::new(FileStateStore::new(cfg.path)))
+            match cfg.encryption {
+                None => Ok(Arc::new(FileStateStore::new(cfg.path))),
+                #[cfg(feature = "encryption")]
+                Some(raw) => {
+                    let enc_spec: faucet_core::EncryptionSpec = serde_json::from_value(raw)
+                        .map_err(|e| CliError::Config(format!("state.config.encryption: {e}")))?;
+                    let compiled = faucet_core::CompiledEncryption::compile(&enc_spec)?;
+                    Ok(Arc::new(
+                        FileStateStore::new(cfg.path).with_encryption(compiled),
+                    ))
+                }
+                #[cfg(not(feature = "encryption"))]
+                Some(_) => Err(CliError::Config(
+                    "state.config.encryption requires a faucet build with the `encryption` \
+                     feature (cargo install faucet-cli --features encryption)"
+                        .into(),
+                )),
+            }
         }
         #[cfg(feature = "state-redis")]
         "redis" => {
@@ -156,6 +178,39 @@ mod tests {
             CliError::Config(msg) => assert!(msg.contains("max_connections"), "{msg}"),
             other => panic!("expected Config error, got {other:?}"),
         }
+    }
+
+    #[cfg(feature = "encryption")]
+    #[tokio::test]
+    async fn builds_encrypted_file_store_and_seals_bookmarks() {
+        let dir = tempfile::tempdir().unwrap();
+        let spec = StateStoreSpec {
+            kind: "file".into(),
+            config: json!({
+                "path": dir.path().to_str().unwrap(),
+                "encryption": { "key": "test-key" },
+            }),
+        };
+        let store = build_state_store(&spec).await.unwrap();
+        store.put("bk", &json!({"pos": 7})).await.unwrap();
+        assert_eq!(store.get("bk").await.unwrap(), Some(json!({"pos": 7})));
+        let raw = std::fs::read(dir.path().join("bk.json")).unwrap();
+        assert!(raw.starts_with(b"FCT1"), "bookmark must be ciphertext");
+    }
+
+    #[cfg(feature = "encryption")]
+    #[tokio::test]
+    async fn encrypted_file_store_rejects_bad_block() {
+        let spec = StateStoreSpec {
+            kind: "file".into(),
+            config: json!({"path": "/tmp/x", "encryption": {"key": ""}}),
+        };
+        assert!(build_state_store(&spec).await.is_err());
+        let spec = StateStoreSpec {
+            kind: "file".into(),
+            config: json!({"path": "/tmp/x", "encryption": {"key": "k", "nope": 1}}),
+        };
+        assert!(build_state_store(&spec).await.is_err());
     }
 
     #[tokio::test]

--- a/cli/src/tui/metrics.rs
+++ b/cli/src/tui/metrics.rs
@@ -1,0 +1,339 @@
+//! Pure Prometheus-text parsing + per-row aggregation for the live TUI.
+//!
+//! The TUI samples the in-process Prometheus recorder's rendered text every
+//! few hundred milliseconds and reduces the handful of `faucet_*` series it
+//! displays into one [`TuiModel`] per tick. Everything in this module is
+//! pure and unit-tested; the terminal loop just calls
+//! [`Sampler::observe`] with the rendered text.
+
+use std::collections::BTreeMap;
+
+/// One parsed sample line: `name{label="v",…} 1.5`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Sample {
+    pub name: String,
+    pub labels: BTreeMap<String, String>,
+    pub value: f64,
+}
+
+/// Parse the Prometheus text exposition format, skipping `# HELP` / `# TYPE`
+/// comments and lines that don't parse (robustness over strictness — the TUI
+/// must never crash on exporter output).
+pub fn parse_samples(text: &str) -> Vec<Sample> {
+    text.lines().filter_map(parse_line).collect()
+}
+
+fn parse_line(line: &str) -> Option<Sample> {
+    let line = line.trim();
+    if line.is_empty() || line.starts_with('#') {
+        return None;
+    }
+    // Split into name[{labels}] and value. The value is the last
+    // whitespace-separated token (an optional timestamp would follow it, but
+    // metrics-exporter-prometheus does not emit timestamps).
+    let (head, value_str) = match line.find('}') {
+        Some(close) => {
+            let (h, rest) = line.split_at(close + 1);
+            (h, rest.trim())
+        }
+        None => {
+            let mut parts = line.split_whitespace();
+            let h = parts.next()?;
+            (h, line[h.len()..].trim())
+        }
+    };
+    let value: f64 = value_str.split_whitespace().next()?.parse().ok()?;
+
+    let (name, labels) = match head.find('{') {
+        None => (head.trim().to_string(), BTreeMap::new()),
+        Some(open) => {
+            let name = head[..open].trim().to_string();
+            let body = head[open + 1..head.len() - 1].trim_end_matches(',');
+            (name, parse_labels(body)?)
+        }
+    };
+    if name.is_empty() {
+        return None;
+    }
+    Some(Sample {
+        name,
+        labels,
+        value,
+    })
+}
+
+/// Parse `k="v",k2="v2"` with Prometheus escaping (`\\`, `\"`, `\n`) inside
+/// label values.
+fn parse_labels(body: &str) -> Option<BTreeMap<String, String>> {
+    let mut labels = BTreeMap::new();
+    let mut chars = body.chars().peekable();
+    loop {
+        // Skip separators / whitespace.
+        while matches!(chars.peek(), Some(',') | Some(' ')) {
+            chars.next();
+        }
+        if chars.peek().is_none() {
+            return Some(labels);
+        }
+        let mut key = String::new();
+        for c in chars.by_ref() {
+            if c == '=' {
+                break;
+            }
+            key.push(c);
+        }
+        if chars.next()? != '"' {
+            return None;
+        }
+        let mut value = String::new();
+        loop {
+            match chars.next()? {
+                '\\' => match chars.next()? {
+                    'n' => value.push('\n'),
+                    '\\' => value.push('\\'),
+                    '"' => value.push('"'),
+                    other => {
+                        value.push('\\');
+                        value.push(other);
+                    }
+                },
+                '"' => break,
+                c => value.push(c),
+            }
+        }
+        labels.insert(key.trim().to_string(), value);
+    }
+}
+
+/// Live view of one matrix row / invocation.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct RowStats {
+    /// `connector` label observed on the source-side series.
+    pub source: String,
+    /// `connector` label observed on the sink-side series.
+    pub sink: String,
+    pub records_in: u64,
+    pub records_out: u64,
+    /// Sink records/second over the last sampling window.
+    pub rate: f64,
+    pub source_errors: u64,
+    pub sink_errors: u64,
+    pub dlq_records: u64,
+    /// `faucet_pipeline_last_bookmark_unix_seconds` gauge (0 = never).
+    pub last_bookmark_unix: f64,
+    /// From `faucet_pipeline_runs_total{status}`: Some(true)=ok, Some(false)=err.
+    pub finished: Option<bool>,
+    pub in_flight: bool,
+}
+
+/// The reduced model the renderer draws.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct TuiModel {
+    /// Row-id → stats, sorted by row id (BTreeMap keeps render order stable).
+    pub rows: BTreeMap<String, RowStats>,
+    pub total_in: u64,
+    pub total_out: u64,
+    pub total_rate: f64,
+}
+
+/// Turns successive Prometheus renders into [`TuiModel`]s, computing
+/// records/s from consecutive sink-records totals.
+#[derive(Debug, Default)]
+pub struct Sampler {
+    pipeline: String,
+    prev_out: BTreeMap<String, (u64, std::time::Duration)>,
+}
+
+impl Sampler {
+    pub fn new(pipeline: impl Into<String>) -> Self {
+        Self {
+            pipeline: pipeline.into(),
+            prev_out: BTreeMap::new(),
+        }
+    }
+
+    /// Reduce one rendered scrape into a model. `elapsed` is time since TUI
+    /// start (monotonic), used for rate windows.
+    pub fn observe(&mut self, text: &str, elapsed: std::time::Duration) -> TuiModel {
+        let mut model = TuiModel::default();
+        for s in parse_samples(text) {
+            if s.labels.get("pipeline").map(String::as_str) != Some(self.pipeline.as_str()) {
+                continue;
+            }
+            let row_id = s.labels.get("row").cloned().unwrap_or_default();
+            let row = model.rows.entry(row_id).or_default();
+            let connector = s.labels.get("connector").cloned().unwrap_or_default();
+            match s.name.as_str() {
+                "faucet_source_records_total" => {
+                    row.records_in += s.value as u64;
+                    if !connector.is_empty() {
+                        row.source = connector;
+                    }
+                }
+                "faucet_sink_records_total" => {
+                    row.records_out += s.value as u64;
+                    if !connector.is_empty() {
+                        row.sink = connector;
+                    }
+                }
+                "faucet_source_errors_total" => row.source_errors += s.value as u64,
+                "faucet_sink_errors_total" => row.sink_errors += s.value as u64,
+                "faucet_sink_dlq_records_total" => row.dlq_records += s.value as u64,
+                "faucet_pipeline_last_bookmark_unix_seconds" => {
+                    row.last_bookmark_unix = s.value;
+                }
+                "faucet_pipeline_in_flight" => {
+                    if s.value > 0.0 {
+                        row.in_flight = true;
+                    }
+                }
+                "faucet_pipeline_runs_total" => {
+                    // Fill connector names even before data flows.
+                    if row.source.is_empty()
+                        && let Some(src) = s.labels.get("source")
+                    {
+                        row.source = src.clone();
+                    }
+                    if row.sink.is_empty()
+                        && let Some(dst) = s.labels.get("sink")
+                    {
+                        row.sink = dst.clone();
+                    }
+                    if s.value > 0.0 {
+                        match s.labels.get("status").map(String::as_str) {
+                            Some("ok") => row.finished = Some(row.finished.unwrap_or(true)),
+                            Some("err") => row.finished = Some(false),
+                            _ => {}
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        // Rates from the previous observation of the same row.
+        let mut prev = std::mem::take(&mut self.prev_out);
+        for (row_id, row) in &mut model.rows {
+            if let Some((prev_count, prev_at)) = prev.remove(row_id) {
+                let dt = elapsed.saturating_sub(prev_at).as_secs_f64();
+                // Counter reset (shouldn't happen in-process) → rate 0.
+                if dt > 0.0 && row.records_out >= prev_count {
+                    row.rate = (row.records_out - prev_count) as f64 / dt;
+                }
+            }
+            self.prev_out
+                .insert(row_id.clone(), (row.records_out, elapsed));
+            model.total_in += row.records_in;
+            model.total_out += row.records_out;
+            model.total_rate += row.rate;
+        }
+        model
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn parses_bare_and_labelled_samples() {
+        let text = "\
+# HELP faucet_x helper
+# TYPE faucet_x counter
+faucet_up 1
+faucet_source_records_total{pipeline=\"p\",row=\"r1\",connector=\"csv\"} 42
+";
+        let samples = parse_samples(text);
+        assert_eq!(samples.len(), 2);
+        assert_eq!(samples[0].name, "faucet_up");
+        assert_eq!(samples[0].value, 1.0);
+        assert!(samples[0].labels.is_empty());
+        assert_eq!(samples[1].labels["connector"], "csv");
+        assert_eq!(samples[1].value, 42.0);
+    }
+
+    #[test]
+    fn parses_escaped_label_values() {
+        let text = r#"m{a="quo\"te",b="back\\slash",c="new\nline"} 7"#;
+        let s = &parse_samples(text)[0];
+        assert_eq!(s.labels["a"], "quo\"te");
+        assert_eq!(s.labels["b"], "back\\slash");
+        assert_eq!(s.labels["c"], "new\nline");
+    }
+
+    #[test]
+    fn garbage_lines_are_skipped_not_fatal() {
+        let text = "not a metric\nname_only\n{}} 3\nok_metric 5\n";
+        let samples = parse_samples(text);
+        assert_eq!(samples.len(), 1);
+        assert_eq!(samples[0].name, "ok_metric");
+    }
+
+    fn render(pipeline: &str, row: &str, out: u64) -> String {
+        format!(
+            "faucet_sink_records_total{{pipeline=\"{pipeline}\",row=\"{row}\",connector=\"jsonl\"}} {out}\n"
+        )
+    }
+
+    #[test]
+    fn sampler_filters_by_pipeline_and_computes_rates() {
+        let mut s = Sampler::new("mine");
+        let t0 = Duration::from_secs(1);
+        let m = s.observe(&(render("mine", "a", 100) + &render("other", "a", 999)), t0);
+        assert_eq!(m.rows.len(), 1);
+        assert_eq!(m.rows["a"].records_out, 100);
+        assert_eq!(m.rows["a"].rate, 0.0, "no window yet");
+
+        let m = s.observe(&render("mine", "a", 300), Duration::from_secs(3));
+        assert!((m.rows["a"].rate - 100.0).abs() < 1e-9, "200 records / 2s");
+        assert_eq!(m.total_out, 300);
+    }
+
+    #[test]
+    fn sampler_counter_reset_yields_zero_rate() {
+        let mut s = Sampler::new("p");
+        s.observe(&render("p", "a", 500), Duration::from_secs(1));
+        let m = s.observe(&render("p", "a", 10), Duration::from_secs(2));
+        assert_eq!(m.rows["a"].rate, 0.0);
+    }
+
+    #[test]
+    fn sampler_aggregates_row_fields() {
+        let text = "\
+faucet_source_records_total{pipeline=\"p\",row=\"r\",connector=\"spanner\"} 10
+faucet_sink_records_total{pipeline=\"p\",row=\"r\",connector=\"jsonl\"} 8
+faucet_source_errors_total{pipeline=\"p\",row=\"r\",connector=\"spanner\",kind=\"http\"} 1
+faucet_sink_errors_total{pipeline=\"p\",row=\"r\",connector=\"jsonl\",kind=\"io\"} 2
+faucet_sink_dlq_records_total{pipeline=\"p\",row=\"r\",connector=\"jsonl\"} 3
+faucet_pipeline_last_bookmark_unix_seconds{pipeline=\"p\",row=\"r\"} 1700000000
+faucet_pipeline_in_flight{pipeline=\"p\",row=\"r\"} 1
+";
+        let mut s = Sampler::new("p");
+        let m = s.observe(text, Duration::from_secs(1));
+        let row = &m.rows["r"];
+        assert_eq!(row.source, "spanner");
+        assert_eq!(row.sink, "jsonl");
+        assert_eq!(row.records_in, 10);
+        assert_eq!(row.records_out, 8);
+        assert_eq!(row.source_errors, 1);
+        assert_eq!(row.sink_errors, 2);
+        assert_eq!(row.dlq_records, 3);
+        assert_eq!(row.last_bookmark_unix, 1_700_000_000.0);
+        assert!(row.in_flight);
+        assert_eq!(row.finished, None);
+    }
+
+    #[test]
+    fn run_status_ok_and_err_map_to_finished() {
+        let ok = "faucet_pipeline_runs_total{pipeline=\"p\",row=\"r\",source=\"csv\",sink=\"stdout\",status=\"ok\"} 1\n";
+        let err = "faucet_pipeline_runs_total{pipeline=\"p\",row=\"r\",source=\"csv\",sink=\"stdout\",status=\"err\",kind=\"sink\"} 1\n";
+        let mut s = Sampler::new("p");
+        let m = s.observe(ok, Duration::from_secs(1));
+        assert_eq!(m.rows["r"].finished, Some(true));
+        assert_eq!(m.rows["r"].source, "csv");
+        assert_eq!(m.rows["r"].sink, "stdout");
+        let m = s.observe(&(ok.to_string() + err), Duration::from_secs(2));
+        // Any err marks the row failed even alongside an ok retry count.
+        assert_eq!(m.rows["r"].finished, Some(false));
+    }
+}

--- a/cli/src/tui/mod.rs
+++ b/cli/src/tui/mod.rs
@@ -1,0 +1,296 @@
+//! Live terminal UI for `faucet run --tui` (#203, `cli-tui` feature).
+//!
+//! The pipeline is untouched: it emits the same `metrics` series it always
+//! does, and the TUI samples the in-process Prometheus recorder's rendered
+//! text a few times per second (read-only — zero hot-path impact) and draws
+//! a full-screen [ratatui] view: per-invocation throughput, errors, DLQ
+//! counts, bookmark age, and a live log pane. `q` (or `Ctrl-C`, which raw
+//! mode delivers as a key event) cancels cooperatively via the executor's
+//! [`CancellationToken`] — in-flight invocations stop at their next page
+//! boundary and flush their sinks.
+//!
+//! Log handling: the normal stdout subscriber would corrupt the alternate
+//! screen, so when a TUI session is detected at startup (`--tui` on a real
+//! TTY), `run_main` routes the fmt subscriber into an in-memory ring
+//! ([`log_buffer`]) that the TUI renders as its log pane. Lines are redacted
+//! at capture with the same registry the stdout writer uses. On a non-TTY
+//! (CI, pipes) the flag degrades to a plain run with a one-line notice.
+
+pub mod metrics;
+pub mod view;
+
+use crate::error::{CliError, CliResult};
+use faucet_core::CancellationToken;
+use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
+use std::collections::VecDeque;
+use std::io::IsTerminal;
+use std::sync::{Arc, Mutex, OnceLock};
+
+/// Ring-buffered log lines shared between the tracing subscriber (writer
+/// side, installed in `run_main`) and the TUI (render side).
+#[derive(Clone, Default)]
+pub struct LogBuffer {
+    inner: Arc<Mutex<VecDeque<String>>>,
+}
+
+const LOG_BUFFER_CAP: usize = 200;
+
+impl LogBuffer {
+    /// Append one already-formatted subscriber line (redacted at capture).
+    pub fn push_line(&self, line: &str) {
+        let line = crate::secrets::registry::redact(line).into_owned();
+        let mut q = self.inner.lock().unwrap_or_else(|p| p.into_inner());
+        if q.len() == LOG_BUFFER_CAP {
+            q.pop_front();
+        }
+        q.push_back(line);
+    }
+
+    /// Snapshot the buffered lines (oldest first).
+    pub fn snapshot(&self) -> Vec<String> {
+        self.inner
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .iter()
+            .cloned()
+            .collect()
+    }
+}
+
+/// Line-splitting `io::Write` adapter for the tracing subscriber.
+pub struct LogBufferWriter {
+    buffer: LogBuffer,
+    partial: String,
+}
+
+impl std::io::Write for LogBufferWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.partial.push_str(&String::from_utf8_lossy(buf));
+        while let Some(at) = self.partial.find('\n') {
+            let line: String = self.partial.drain(..=at).collect();
+            let line = line.trim_end();
+            if !line.is_empty() {
+                self.buffer.push_line(line);
+            }
+        }
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for LogBuffer {
+    type Writer = LogBufferWriter;
+    fn make_writer(&'a self) -> Self::Writer {
+        LogBufferWriter {
+            buffer: self.clone(),
+            partial: String::new(),
+        }
+    }
+}
+
+/// The process-wide TUI log ring. Populated by `run_main` when it detects a
+/// TUI session before installing the subscriber; read by the render loop.
+static TUI_LOGS: OnceLock<LogBuffer> = OnceLock::new();
+
+/// `--tui` was passed *and* stdout is a real terminal — the full-screen UI
+/// applies. On a non-TTY the caller degrades to a plain run.
+pub fn is_tui_session(tui_flag: bool) -> bool {
+    tui_flag && std::io::stdout().is_terminal()
+}
+
+/// Install the ring-buffered tracing subscriber for a TUI session. Called by
+/// `run_main` *instead of* the stdout subscriber, before any log line is
+/// emitted. Returns the buffer for the render loop.
+pub fn install_tui_tracing(level: &str) -> LogBuffer {
+    use tracing_subscriber::EnvFilter;
+    let buffer = TUI_LOGS.get_or_init(LogBuffer::default).clone();
+    let filter = EnvFilter::try_new(level).unwrap_or_else(|_| EnvFilter::new("info"));
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_ansi(false)
+        .with_writer(buffer.clone())
+        .try_init();
+    buffer
+}
+
+/// The TUI log ring, if `run_main` installed one this process.
+pub fn log_buffer() -> Option<LogBuffer> {
+    TUI_LOGS.get().cloned()
+}
+
+/// Default histogram buckets — mirrors `faucet-core`'s installer so a
+/// TUI-owned recorder behaves identically for any `/metrics` scraper.
+const DEFAULT_BUCKETS: &[f64] = &[
+    0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 30.0, 60.0, 300.0,
+];
+
+/// Install the Prometheus recorder for a TUI session and return its render
+/// handle. When the config carries an `observability.prometheus` block the
+/// `/metrics` HTTP endpoint is preserved (recorder + listener, exactly what
+/// `install_observability` would have set up); otherwise a listener-less
+/// recorder is installed purely as the TUI's data source.
+pub fn install_metrics_recorder(
+    prom: Option<&faucet_core::PrometheusConfig>,
+) -> CliResult<PrometheusHandle> {
+    let already = |handle: PrometheusHandle, ok: bool| {
+        if !ok {
+            tracing::warn!(
+                "metrics recorder already installed; the TUI may show no data (was a recorder installed before `faucet run --tui`?)"
+            );
+        }
+        Ok(handle)
+    };
+    match prom {
+        None => {
+            let recorder = PrometheusBuilder::new()
+                .set_buckets(DEFAULT_BUCKETS)
+                .map_err(|e| CliError::Observability(e.to_string()))?
+                .build_recorder();
+            let handle = recorder.handle();
+            let ok = ::metrics::set_global_recorder(recorder).is_ok();
+            already(handle, ok)
+        }
+        Some(p) => {
+            let listen: std::net::SocketAddr = p
+                .listen
+                .parse()
+                .map_err(|e| CliError::Observability(format!("prometheus listen: {e}")))?;
+            let (recorder, exporter) = PrometheusBuilder::new()
+                .with_http_listener(listen)
+                .set_buckets(p.buckets.as_deref().unwrap_or(DEFAULT_BUCKETS))
+                .map_err(|e| CliError::Observability(e.to_string()))?
+                .build()
+                .map_err(|e| CliError::Observability(e.to_string()))?;
+            let handle = recorder.handle();
+            let ok = ::metrics::set_global_recorder(recorder).is_ok();
+            if ok {
+                tokio::spawn(exporter);
+                tracing::info!("Prometheus /metrics listening on {}", p.listen);
+            }
+            already(handle, ok)
+        }
+    }
+}
+
+/// Drive the run future under the full-screen TUI. Returns the run's result
+/// after the terminal is restored. `cancel` is the token wired into
+/// `ExecuteOptions.cancel`; `q` / `Ctrl-C` trigger it.
+pub async fn drive<T>(
+    run: impl Future<Output = T>,
+    pipeline: &str,
+    handle: PrometheusHandle,
+    cancel: CancellationToken,
+) -> T {
+    use ratatui::crossterm::event::{Event, KeyCode, KeyModifiers};
+
+    // `ratatui::init` enters the alternate screen + raw mode and installs a
+    // panic hook that restores the terminal before the default hook runs.
+    let mut terminal = ratatui::init();
+    let started = std::time::Instant::now();
+    let mut sampler = metrics::Sampler::new(pipeline);
+    let logs = log_buffer().unwrap_or_default();
+    let mut interval = tokio::time::interval(std::time::Duration::from_millis(250));
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    tokio::pin!(run);
+    let result = loop {
+        tokio::select! {
+            biased;
+            result = &mut run => break result,
+            _ = interval.tick() => {
+                // Non-blocking key poll: q / Ctrl-C cancel cooperatively.
+                while ratatui::crossterm::event::poll(std::time::Duration::ZERO).unwrap_or(false) {
+                    match ratatui::crossterm::event::read() {
+                        Ok(Event::Key(key)) => {
+                            let ctrl_c = key.code == KeyCode::Char('c')
+                                && key.modifiers.contains(KeyModifiers::CONTROL);
+                            if key.code == KeyCode::Char('q') || ctrl_c {
+                                cancel.cancel();
+                            }
+                        }
+                        Ok(_) => {}
+                        Err(_) => break,
+                    }
+                }
+                handle.run_upkeep();
+                let model = sampler.observe(&handle.render(), started.elapsed());
+                let log_lines = logs.snapshot();
+                let cancelling = cancel.is_cancelled();
+                let _ = terminal.draw(|frame| {
+                    view::draw(frame, pipeline, &model, started.elapsed(), &log_lines, cancelling);
+                });
+            }
+        }
+    };
+    ratatui::restore();
+    result
+}
+
+/// Flush the tail of the buffered log ring to stderr — called after terminal
+/// restore when the run failed, so the operator keeps the context that was
+/// on screen.
+pub fn flush_logs_to_stderr(max_lines: usize) {
+    if let Some(buffer) = log_buffer() {
+        let lines = buffer.snapshot();
+        let start = lines.len().saturating_sub(max_lines);
+        for line in &lines[start..] {
+            eprintln!("{line}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn log_buffer_caps_and_orders_lines() {
+        let buffer = LogBuffer::default();
+        for i in 0..(LOG_BUFFER_CAP + 10) {
+            buffer.push_line(&format!("line {i}"));
+        }
+        let snap = buffer.snapshot();
+        assert_eq!(snap.len(), LOG_BUFFER_CAP);
+        assert_eq!(snap.first().unwrap(), "line 10");
+        assert_eq!(
+            snap.last().unwrap(),
+            &format!("line {}", LOG_BUFFER_CAP + 9)
+        );
+    }
+
+    #[test]
+    fn writer_splits_lines_and_keeps_partials() {
+        let buffer = LogBuffer::default();
+        let mut writer = LogBufferWriter {
+            buffer: buffer.clone(),
+            partial: String::new(),
+        };
+        writer.write_all(b"first line\nsecond ").unwrap();
+        writer.write_all(b"half\ntrailing").unwrap();
+        let snap = buffer.snapshot();
+        assert_eq!(
+            snap,
+            vec!["first line".to_string(), "second half".to_string()]
+        );
+    }
+
+    #[test]
+    fn log_lines_are_redacted_at_capture() {
+        crate::secrets::registry::register("tui-secret-value");
+        let buffer = LogBuffer::default();
+        buffer.push_line("token is tui-secret-value here");
+        let snap = buffer.snapshot();
+        assert!(!snap[0].contains("tui-secret-value"), "got: {}", snap[0]);
+    }
+
+    #[test]
+    fn non_tty_is_not_a_tui_session() {
+        // Test harnesses never run on a TTY stdout, so the flag alone must
+        // not start a session — this is the CI/pipe fallback contract.
+        assert!(!is_tui_session(true) || std::io::stdout().is_terminal());
+        assert!(!is_tui_session(false));
+    }
+}

--- a/cli/src/tui/mod.rs
+++ b/cli/src/tui/mod.rs
@@ -126,37 +126,35 @@ const DEFAULT_BUCKETS: &[f64] = &[
     0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 30.0, 60.0, 300.0,
 ];
 
+/// The handle of the recorder this module installed, if any — makes
+/// [`install_metrics_recorder`] idempotent (second call returns the same
+/// handle instead of racing on the process-global recorder slot).
+static RECORDER_HANDLE: OnceLock<PrometheusHandle> = OnceLock::new();
+
 /// Install the Prometheus recorder for a TUI session and return its render
 /// handle. When the config carries an `observability.prometheus` block the
 /// `/metrics` HTTP endpoint is preserved (recorder + listener, exactly what
 /// `install_observability` would have set up); otherwise a listener-less
-/// recorder is installed purely as the TUI's data source.
+/// recorder is installed purely as the TUI's data source. Idempotent: a
+/// second call returns the first call's handle.
 pub fn install_metrics_recorder(
     prom: Option<&faucet_core::PrometheusConfig>,
 ) -> CliResult<PrometheusHandle> {
-    let already = |handle: PrometheusHandle, ok: bool| {
-        if !ok {
-            tracing::warn!(
-                "metrics recorder already installed; the TUI may show no data (was a recorder installed before `faucet run --tui`?)"
-            );
-        }
-        Ok(handle)
-    };
-    match prom {
-        None => {
-            let recorder = PrometheusBuilder::new()
-                .set_buckets(DEFAULT_BUCKETS)
-                .map_err(|e| CliError::Observability(e.to_string()))?
-                .build_recorder();
-            let handle = recorder.handle();
-            let ok = ::metrics::set_global_recorder(recorder).is_ok();
-            already(handle, ok)
-        }
-        Some(p) => {
-            let listen: std::net::SocketAddr = p
-                .listen
+    // Validate the listener address up front so a config error surfaces even
+    // when the recorder slot is already occupied.
+    let listen: Option<std::net::SocketAddr> = match prom {
+        Some(p) => Some(
+            p.listen
                 .parse()
-                .map_err(|e| CliError::Observability(format!("prometheus listen: {e}")))?;
+                .map_err(|e| CliError::Observability(format!("prometheus listen: {e}")))?,
+        ),
+        None => None,
+    };
+    if let Some(handle) = RECORDER_HANDLE.get() {
+        return Ok(handle.clone());
+    }
+    let handle = match (prom, listen) {
+        (Some(p), Some(listen)) => {
             let (recorder, exporter) = PrometheusBuilder::new()
                 .with_http_listener(listen)
                 .set_buckets(p.buckets.as_deref().unwrap_or(DEFAULT_BUCKETS))
@@ -164,13 +162,77 @@ pub fn install_metrics_recorder(
                 .build()
                 .map_err(|e| CliError::Observability(e.to_string()))?;
             let handle = recorder.handle();
-            let ok = ::metrics::set_global_recorder(recorder).is_ok();
-            if ok {
+            if ::metrics::set_global_recorder(recorder).is_ok() {
                 tokio::spawn(exporter);
                 tracing::info!("Prometheus /metrics listening on {}", p.listen);
+            } else {
+                warn_recorder_occupied();
             }
-            already(handle, ok)
+            handle
         }
+        _ => {
+            let recorder = PrometheusBuilder::new()
+                .set_buckets(DEFAULT_BUCKETS)
+                .map_err(|e| CliError::Observability(e.to_string()))?
+                .build_recorder();
+            let handle = recorder.handle();
+            if ::metrics::set_global_recorder(recorder).is_err() {
+                warn_recorder_occupied();
+            }
+            handle
+        }
+    };
+    Ok(RECORDER_HANDLE.get_or_init(|| handle).clone())
+}
+
+fn warn_recorder_occupied() {
+    tracing::warn!(
+        "metrics recorder already installed; the TUI may show no data (was a recorder installed before `faucet run --tui`?)"
+    );
+}
+
+/// Install the TUI session's observability: the TUI owns the metrics
+/// recorder (keeping the `/metrics` endpoint when one is configured) so it
+/// can render the recorder's output; the rest of the observability config
+/// (OTLP traces — the tracing level was already routed into the TUI log ring
+/// by `run_main`) installs as usual with the prometheus block taken out.
+pub fn setup_observability(cfg: &crate::config::PipelineConfig) -> CliResult<PrometheusHandle> {
+    let mut obs_cfg = crate::obs::build_observability_config(cfg);
+    let prom = obs_cfg.prometheus.take();
+    let handle = install_metrics_recorder(prom.as_ref())?;
+    faucet_core::install_observability(&obs_cfg)?;
+    Ok(handle)
+}
+
+/// Source of user cancel requests — abstracted from crossterm so
+/// [`drive_loop`] is testable against a scripted sequence.
+pub trait CancelEvents {
+    /// Drain any pending input; `true` when the user asked to cancel
+    /// (`q` / `Ctrl-C`).
+    fn cancel_requested(&mut self) -> bool;
+}
+
+/// The real, non-blocking crossterm key poll.
+struct CrosstermEvents;
+
+impl CancelEvents for CrosstermEvents {
+    fn cancel_requested(&mut self) -> bool {
+        use ratatui::crossterm::event::{Event, KeyCode, KeyModifiers};
+        let mut requested = false;
+        while ratatui::crossterm::event::poll(std::time::Duration::ZERO).unwrap_or(false) {
+            match ratatui::crossterm::event::read() {
+                Ok(Event::Key(key)) => {
+                    let ctrl_c = key.code == KeyCode::Char('c')
+                        && key.modifiers.contains(KeyModifiers::CONTROL);
+                    if key.code == KeyCode::Char('q') || ctrl_c {
+                        requested = true;
+                    }
+                }
+                Ok(_) => {}
+                Err(_) => break,
+            }
+        }
+        requested
     }
 }
 
@@ -183,36 +245,52 @@ pub async fn drive<T>(
     handle: PrometheusHandle,
     cancel: CancellationToken,
 ) -> T {
-    use ratatui::crossterm::event::{Event, KeyCode, KeyModifiers};
-
     // `ratatui::init` enters the alternate screen + raw mode and installs a
     // panic hook that restores the terminal before the default hook runs.
     let mut terminal = ratatui::init();
+    let result = drive_loop(
+        &mut terminal,
+        CrosstermEvents,
+        run,
+        pipeline,
+        handle,
+        cancel,
+        std::time::Duration::from_millis(250),
+    )
+    .await;
+    ratatui::restore();
+    result
+}
+
+/// The render/cancel loop behind [`drive`], generic over the terminal
+/// backend and the event source so it runs headless under test.
+pub async fn drive_loop<B, E, T>(
+    terminal: &mut ratatui::Terminal<B>,
+    mut events: E,
+    run: impl Future<Output = T>,
+    pipeline: &str,
+    handle: PrometheusHandle,
+    cancel: CancellationToken,
+    tick: std::time::Duration,
+) -> T
+where
+    B: ratatui::backend::Backend,
+    E: CancelEvents,
+{
     let started = std::time::Instant::now();
     let mut sampler = metrics::Sampler::new(pipeline);
     let logs = log_buffer().unwrap_or_default();
-    let mut interval = tokio::time::interval(std::time::Duration::from_millis(250));
+    let mut interval = tokio::time::interval(tick);
     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     tokio::pin!(run);
-    let result = loop {
+    loop {
         tokio::select! {
             biased;
             result = &mut run => break result,
             _ = interval.tick() => {
-                // Non-blocking key poll: q / Ctrl-C cancel cooperatively.
-                while ratatui::crossterm::event::poll(std::time::Duration::ZERO).unwrap_or(false) {
-                    match ratatui::crossterm::event::read() {
-                        Ok(Event::Key(key)) => {
-                            let ctrl_c = key.code == KeyCode::Char('c')
-                                && key.modifiers.contains(KeyModifiers::CONTROL);
-                            if key.code == KeyCode::Char('q') || ctrl_c {
-                                cancel.cancel();
-                            }
-                        }
-                        Ok(_) => {}
-                        Err(_) => break,
-                    }
+                if events.cancel_requested() {
+                    cancel.cancel();
                 }
                 handle.run_upkeep();
                 let model = sampler.observe(&handle.render(), started.elapsed());
@@ -223,9 +301,7 @@ pub async fn drive<T>(
                 });
             }
         }
-    };
-    ratatui::restore();
-    result
+    }
 }
 
 /// Flush the tail of the buffered log ring to stderr — called after terminal
@@ -292,5 +368,143 @@ mod tests {
         // not start a session — this is the CI/pipe fallback contract.
         assert!(!is_tui_session(true) || std::io::stdout().is_terminal());
         assert!(!is_tui_session(false));
+    }
+
+    /// Scripted event source: yields `true` once at the configured tick.
+    struct ScriptedEvents {
+        cancel_on_call: usize,
+        calls: usize,
+    }
+
+    impl CancelEvents for ScriptedEvents {
+        fn cancel_requested(&mut self) -> bool {
+            self.calls += 1;
+            self.calls == self.cancel_on_call
+        }
+    }
+
+    /// Never cancels.
+    struct NoEvents;
+    impl CancelEvents for NoEvents {
+        fn cancel_requested(&mut self) -> bool {
+            false
+        }
+    }
+
+    fn test_terminal() -> ratatui::Terminal<ratatui::backend::TestBackend> {
+        ratatui::Terminal::new(ratatui::backend::TestBackend::new(100, 24)).expect("terminal")
+    }
+
+    fn recorder_handle() -> PrometheusHandle {
+        // The process-global recorder slot may be taken by any other test in
+        // this binary; install_metrics_recorder tolerates that and hands back
+        // a usable handle either way.
+        install_metrics_recorder(None).expect("recorder")
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn drive_loop_ticks_render_and_exit_on_run_completion() {
+        let mut terminal = test_terminal();
+        let cancel = CancellationToken::new();
+        let result = drive_loop(
+            &mut terminal,
+            NoEvents,
+            async {
+                tokio::time::sleep(std::time::Duration::from_millis(320)).await;
+                42
+            },
+            "loop-pipeline",
+            recorder_handle(),
+            cancel.clone(),
+            std::time::Duration::from_millis(100),
+        )
+        .await;
+        assert_eq!(result, 42);
+        assert!(!cancel.is_cancelled());
+        // At least one tick rendered the header into the test buffer.
+        let text: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+        assert!(text.contains("faucet run · loop-pipeline"), "{text}");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn drive_loop_fires_the_cancel_token_on_user_request() {
+        let mut terminal = test_terminal();
+        let cancel = CancellationToken::new();
+        let run_cancel = cancel.clone();
+        let result = drive_loop(
+            &mut terminal,
+            ScriptedEvents {
+                cancel_on_call: 2,
+                calls: 0,
+            },
+            async move {
+                // A cooperative pipeline: winds down when cancelled.
+                run_cancel.cancelled().await;
+                "cancelled"
+            },
+            "loop-pipeline",
+            recorder_handle(),
+            cancel.clone(),
+            std::time::Duration::from_millis(50),
+        )
+        .await;
+        assert_eq!(result, "cancelled");
+        assert!(cancel.is_cancelled());
+        // The frame after the cancel shows the banner.
+        let text: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+        assert!(text.contains("cancelling…"), "{text}");
+    }
+
+    #[test]
+    fn install_metrics_recorder_is_idempotent() {
+        let first = install_metrics_recorder(None).expect("first install");
+        let second = install_metrics_recorder(None).expect("second install");
+        // Both render (same underlying registry once cached).
+        let _ = first.render();
+        let _ = second.render();
+    }
+
+    #[test]
+    fn install_metrics_recorder_rejects_a_bad_listen_address() {
+        let prom = faucet_core::PrometheusConfig {
+            listen: "not-an-address".into(),
+            buckets: None,
+        };
+        let err = install_metrics_recorder(Some(&prom)).expect_err("bad listen");
+        assert!(matches!(err, CliError::Observability(_)), "{err:?}");
+    }
+
+    #[tokio::test]
+    async fn install_metrics_recorder_accepts_a_listener_config() {
+        // Ephemeral port; whichever install wins the process-global slot,
+        // the call must succeed and hand back a handle.
+        let prom = faucet_core::PrometheusConfig {
+            listen: "127.0.0.1:0".into(),
+            buckets: None,
+        };
+        let handle = install_metrics_recorder(Some(&prom)).expect("listener install");
+        let _ = handle.render();
+    }
+
+    #[test]
+    fn flush_logs_to_stderr_replays_the_tail() {
+        let buffer = install_tui_tracing("info");
+        buffer.push_line("tail line A");
+        buffer.push_line("tail line B");
+        // Covers the ring lookup + tail slicing; output goes to stderr.
+        flush_logs_to_stderr(1);
+        flush_logs_to_stderr(1000);
     }
 }

--- a/cli/src/tui/view.rs
+++ b/cli/src/tui/view.rs
@@ -332,6 +332,157 @@ mod tests {
         }
     }
 
+    fn buffer_text(terminal: &ratatui::Terminal<ratatui::backend::TestBackend>) -> String {
+        terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect()
+    }
+
+    fn sample_model() -> TuiModel {
+        let mut model = TuiModel::default();
+        let mut healthy = RowStats {
+            source: "rest".into(),
+            sink: "jsonl".into(),
+            records_in: 12_500,
+            records_out: 12_400,
+            rate: 830.0,
+            ..Default::default()
+        };
+        healthy.in_flight = true;
+        model.rows.insert("orders".into(), healthy);
+        model.rows.insert(
+            "users".into(),
+            RowStats {
+                source: "postgres".into(),
+                sink: "spanner".into(),
+                records_in: 4,
+                records_out: 2,
+                source_errors: 1,
+                sink_errors: 2,
+                dlq_records: 7,
+                // Recent enough that the rendered age ("1m30s ago") fits
+                // the bookmark column; an epoch-old bookmark would clip the
+                // "ago" suffix this test asserts on.
+                last_bookmark_unix: std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .expect("clock")
+                    .as_secs_f64()
+                    - 90.0,
+                finished: Some(false),
+                ..Default::default()
+            },
+        );
+        model.total_out = 12_402;
+        model.total_rate = 830.0;
+        model
+    }
+
+    fn draw_at(width: u16, height: u16, model: &TuiModel, cancelling: bool) -> String {
+        let backend = ratatui::backend::TestBackend::new(width, height);
+        let mut terminal = ratatui::Terminal::new(backend).expect("test terminal");
+        terminal
+            .draw(|frame| {
+                draw(
+                    frame,
+                    "demo-pipeline",
+                    model,
+                    std::time::Duration::from_secs(65),
+                    &["log line one".to_string(), "log line two".to_string()],
+                    cancelling,
+                )
+            })
+            .expect("draw");
+        buffer_text(&terminal)
+    }
+
+    #[test]
+    fn draws_header_table_logs_and_footer_at_full_width() {
+        let text = draw_at(120, 24, &sample_model(), false);
+        // Header: pipeline name, elapsed, totals.
+        assert!(text.contains("faucet run · demo-pipeline"), "{text}");
+        assert!(text.contains("1m05s"), "{text}");
+        assert!(text.contains("12,402 out"), "{text}");
+        // Table: both rows with routes, counts, statuses.
+        assert!(text.contains("source → sink"), "{text}");
+        assert!(text.contains("rest → jsonl"), "{text}");
+        assert!(text.contains("postgres → spanner"), "{text}");
+        assert!(text.contains("12,400"), "{text}");
+        assert!(text.contains("running"), "{text}");
+        assert!(text.contains("failed"), "{text}");
+        // Errors + DLQ + bookmark columns present at this width.
+        assert!(text.contains("dlq"), "{text}");
+        assert!(text.contains("bookmark"), "{text}");
+        assert!(text.contains("ago"), "{text}");
+        // Log pane + footer.
+        assert!(text.contains("log line two"), "{text}");
+        assert!(text.contains("cancel (flush at page boundary)"), "{text}");
+        assert!(!text.contains("cancelling…"), "{text}");
+    }
+
+    #[test]
+    fn cancelling_banner_shows_when_requested() {
+        let text = draw_at(120, 24, &sample_model(), true);
+        assert!(text.contains("cancelling…"), "{text}");
+    }
+
+    #[test]
+    fn narrow_terminal_drops_optional_columns_but_renders() {
+        let text = draw_at(40, 16, &sample_model(), false);
+        // Essentials survive.
+        assert!(text.contains("row"), "{text}");
+        assert!(text.contains("out"), "{text}");
+        assert!(text.contains("status"), "{text}");
+        assert!(text.contains("running"), "{text}");
+        // Route/bookmark columns are gone at 40 cells.
+        assert!(!text.contains("source → sink"), "{text}");
+        assert!(!text.contains("bookmark"), "{text}");
+    }
+
+    #[test]
+    fn empty_model_renders_headers_and_placeholder_free_table() {
+        let text = draw_at(80, 12, &TuiModel::default(), false);
+        assert!(text.contains("faucet run · demo-pipeline"), "{text}");
+        assert!(text.contains("invocations"), "{text}");
+        assert!(text.contains("0 out"), "{text}");
+    }
+
+    #[test]
+    fn anonymous_row_and_unknown_connectors_render_placeholders() {
+        let mut model = TuiModel::default();
+        model.rows.insert(String::new(), RowStats::default());
+        let text = draw_at(120, 16, &model, false);
+        // Empty row id renders as `-`, unknown connectors as `?`.
+        assert!(text.contains("? → ?"), "{text}");
+        assert!(text.contains("pending"), "{text}");
+    }
+
+    #[test]
+    fn log_pane_shows_only_the_tail_that_fits() {
+        let logs: Vec<String> = (0..40).map(|i| format!("logline-{i:02}")).collect();
+        let backend = ratatui::backend::TestBackend::new(100, 20);
+        let mut terminal = ratatui::Terminal::new(backend).expect("test terminal");
+        terminal
+            .draw(|frame| {
+                draw(
+                    frame,
+                    "p",
+                    &TuiModel::default(),
+                    std::time::Duration::from_secs(1),
+                    &logs,
+                    false,
+                )
+            })
+            .expect("draw");
+        let text = buffer_text(&terminal);
+        // The pane is 6 rows (1 border + 5 lines): newest lines win.
+        assert!(text.contains("logline-39"), "{text}");
+        assert!(!text.contains("logline-00"), "{text}");
+    }
+
     #[test]
     fn statuses_map_from_row_state() {
         let mut row = RowStats::default();

--- a/cli/src/tui/view.rs
+++ b/cli/src/tui/view.rs
@@ -1,0 +1,346 @@
+//! Rendering for the live TUI. The ratatui draw call is thin; everything
+//! that decides *what* to show (formatting, column selection under narrow
+//! widths, status labels) is a pure function with unit tests.
+
+use super::metrics::{RowStats, TuiModel};
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table};
+
+/// A column of the invocation table. Order = display order; `min_width` is
+/// the terminal width at which the column is still shown (columns with the
+/// highest thresholds drop first on narrow terminals).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Column {
+    Row,
+    Route,
+    In,
+    Out,
+    Rate,
+    Errors,
+    Dlq,
+    Bookmark,
+    Status,
+}
+
+impl Column {
+    fn header(self) -> &'static str {
+        match self {
+            Column::Row => "row",
+            Column::Route => "source → sink",
+            Column::In => "in",
+            Column::Out => "out",
+            Column::Rate => "rec/s",
+            Column::Errors => "errors",
+            Column::Dlq => "dlq",
+            Column::Bookmark => "bookmark",
+            Column::Status => "status",
+        }
+    }
+
+    fn constraint(self) -> Constraint {
+        match self {
+            Column::Row => Constraint::Min(8),
+            Column::Route => Constraint::Min(18),
+            Column::In => Constraint::Length(10),
+            Column::Out => Constraint::Length(10),
+            Column::Rate => Constraint::Length(9),
+            Column::Errors => Constraint::Length(7),
+            Column::Dlq => Constraint::Length(6),
+            Column::Bookmark => Constraint::Length(9),
+            Column::Status => Constraint::Length(8),
+        }
+    }
+}
+
+/// Which columns fit a terminal of `width` cells. Drops the least essential
+/// columns first; `row`, `out`, and `status` always survive.
+pub fn visible_columns(width: u16) -> Vec<Column> {
+    let mut cols = vec![Column::Row, Column::Out, Column::Status];
+    if width >= 44 {
+        cols.insert(2, Column::Rate);
+    }
+    if width >= 58 {
+        cols.insert(1, Column::Route);
+    }
+    if width >= 70 {
+        cols.insert(cols.len() - 2, Column::Errors);
+    }
+    if width >= 82 {
+        let at = cols.iter().position(|c| *c == Column::Out).unwrap();
+        cols.insert(at, Column::In);
+    }
+    if width >= 92 {
+        let at = cols.iter().position(|c| *c == Column::Status).unwrap();
+        cols.insert(at, Column::Dlq);
+    }
+    if width >= 104 {
+        let at = cols.iter().position(|c| *c == Column::Status).unwrap();
+        cols.insert(at, Column::Bookmark);
+    }
+    cols
+}
+
+/// `1234567` → `1,234,567`.
+pub fn format_count(n: u64) -> String {
+    let raw = n.to_string();
+    let mut out = String::with_capacity(raw.len() + raw.len() / 3);
+    for (i, c) in raw.chars().enumerate() {
+        if i > 0 && (raw.len() - i).is_multiple_of(3) {
+            out.push(',');
+        }
+        out.push(c);
+    }
+    out
+}
+
+/// Records/second with a sensible precision ramp.
+pub fn format_rate(rate: f64) -> String {
+    if rate <= 0.0 {
+        "-".to_string()
+    } else if rate < 10.0 {
+        format!("{rate:.1}")
+    } else if rate < 100_000.0 {
+        format_count(rate.round() as u64)
+    } else {
+        format!("{:.0}k", rate / 1000.0)
+    }
+}
+
+/// Age of the last persisted bookmark relative to `now_unix`, or `-`.
+pub fn format_bookmark_age(last_bookmark_unix: f64, now_unix: f64) -> String {
+    if last_bookmark_unix <= 0.0 {
+        return "-".to_string();
+    }
+    let secs = (now_unix - last_bookmark_unix).max(0.0) as u64;
+    format_elapsed(std::time::Duration::from_secs(secs)) + " ago"
+}
+
+/// `1h02m03s` / `4m05s` / `12s`.
+pub fn format_elapsed(d: std::time::Duration) -> String {
+    let s = d.as_secs();
+    if s >= 3600 {
+        format!("{}h{:02}m{:02}s", s / 3600, (s % 3600) / 60, s % 60)
+    } else if s >= 60 {
+        format!("{}m{:02}s", s / 60, s % 60)
+    } else {
+        format!("{s}s")
+    }
+}
+
+/// Status label + color for a row.
+pub fn row_status(row: &RowStats) -> (&'static str, Color) {
+    match row.finished {
+        Some(true) => ("done", Color::Green),
+        Some(false) => ("failed", Color::Red),
+        None if row.in_flight => ("running", Color::Cyan),
+        None => ("pending", Color::DarkGray),
+    }
+}
+
+fn cell_for(col: Column, id: &str, row: &RowStats, now_unix: f64) -> Cell<'static> {
+    match col {
+        Column::Row => Cell::from(if id.is_empty() { "-" } else { id }.to_string()),
+        Column::Route => Cell::from(format!(
+            "{} → {}",
+            if row.source.is_empty() {
+                "?"
+            } else {
+                &row.source
+            },
+            if row.sink.is_empty() { "?" } else { &row.sink },
+        )),
+        Column::In => Cell::from(format_count(row.records_in)),
+        Column::Out => Cell::from(format_count(row.records_out)),
+        Column::Rate => Cell::from(format_rate(row.rate)),
+        Column::Errors => {
+            let n = row.source_errors + row.sink_errors;
+            let cell = Cell::from(format_count(n));
+            if n > 0 {
+                cell.style(Style::default().fg(Color::Red))
+            } else {
+                cell
+            }
+        }
+        Column::Dlq => {
+            let cell = Cell::from(format_count(row.dlq_records));
+            if row.dlq_records > 0 {
+                cell.style(Style::default().fg(Color::Yellow))
+            } else {
+                cell
+            }
+        }
+        Column::Bookmark => Cell::from(format_bookmark_age(row.last_bookmark_unix, now_unix)),
+        Column::Status => {
+            let (label, color) = row_status(row);
+            Cell::from(label).style(Style::default().fg(color))
+        }
+    }
+}
+
+/// Draw one frame: header, invocation table, log pane, footer.
+pub fn draw(
+    frame: &mut Frame<'_>,
+    pipeline: &str,
+    model: &TuiModel,
+    elapsed: std::time::Duration,
+    logs: &[String],
+    cancelling: bool,
+) {
+    let area = frame.area();
+    let [header_a, table_a, logs_a, footer_a] = Layout::vertical([
+        Constraint::Length(1),
+        Constraint::Min(4),
+        Constraint::Length(6),
+        Constraint::Length(1),
+    ])
+    .areas(area);
+
+    frame.render_widget(header(pipeline, model, elapsed, cancelling), header_a);
+    render_table(frame, table_a, model);
+    render_logs(frame, logs_a, logs);
+    let footer = Paragraph::new(Line::from(vec![
+        Span::styled(" q ", Style::default().add_modifier(Modifier::BOLD)),
+        Span::raw("cancel (flush at page boundary) · "),
+        Span::styled("Ctrl-C ", Style::default().add_modifier(Modifier::BOLD)),
+        Span::raw("cancel"),
+    ]))
+    .style(Style::default().fg(Color::DarkGray));
+    frame.render_widget(footer, footer_a);
+}
+
+fn header<'a>(
+    pipeline: &'a str,
+    model: &TuiModel,
+    elapsed: std::time::Duration,
+    cancelling: bool,
+) -> Paragraph<'a> {
+    let mut spans = vec![
+        Span::styled(
+            format!(" faucet run · {pipeline} "),
+            Style::default().add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(format!(
+            "· {} · {} out · {} rec/s",
+            format_elapsed(elapsed),
+            format_count(model.total_out),
+            format_rate(model.total_rate),
+        )),
+    ];
+    if cancelling {
+        spans.push(Span::styled(
+            " · cancelling…",
+            Style::default().fg(Color::Yellow),
+        ));
+    }
+    Paragraph::new(Line::from(spans))
+}
+
+fn render_table(frame: &mut Frame<'_>, area: Rect, model: &TuiModel) {
+    let cols = visible_columns(area.width);
+    let now_unix = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs_f64())
+        .unwrap_or(0.0);
+    let header = Row::new(cols.iter().map(|c| Cell::from(c.header())))
+        .style(Style::default().add_modifier(Modifier::BOLD));
+    let rows = model.rows.iter().map(|(id, row)| {
+        Row::new(
+            cols.iter()
+                .map(|c| cell_for(*c, id, row, now_unix))
+                .collect::<Vec<_>>(),
+        )
+    });
+    let widths: Vec<Constraint> = cols.iter().map(|c| c.constraint()).collect();
+    let table = Table::new(rows, widths).header(header).block(
+        Block::default()
+            .borders(Borders::TOP)
+            .title(" invocations "),
+    );
+    frame.render_widget(table, area);
+}
+
+fn render_logs(frame: &mut Frame<'_>, area: Rect, logs: &[String]) {
+    let visible = area.height.saturating_sub(1) as usize;
+    let start = logs.len().saturating_sub(visible);
+    let text: Vec<Line<'_>> = logs[start..]
+        .iter()
+        .map(|l| Line::from(l.as_str()))
+        .collect();
+    let para = Paragraph::new(text)
+        .style(Style::default().fg(Color::DarkGray))
+        .block(Block::default().borders(Borders::TOP).title(" log "));
+    frame.render_widget(para, area);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn counts_group_thousands() {
+        assert_eq!(format_count(0), "0");
+        assert_eq!(format_count(999), "999");
+        assert_eq!(format_count(1_000), "1,000");
+        assert_eq!(format_count(1_234_567), "1,234,567");
+    }
+
+    #[test]
+    fn rates_ramp_precision() {
+        assert_eq!(format_rate(0.0), "-");
+        assert_eq!(format_rate(3.24), "3.2");
+        assert_eq!(format_rate(1234.6), "1,235");
+        assert_eq!(format_rate(250_000.0), "250k");
+    }
+
+    #[test]
+    fn elapsed_formats() {
+        use std::time::Duration;
+        assert_eq!(format_elapsed(Duration::from_secs(12)), "12s");
+        assert_eq!(format_elapsed(Duration::from_secs(65)), "1m05s");
+        assert_eq!(format_elapsed(Duration::from_secs(3723)), "1h02m03s");
+    }
+
+    #[test]
+    fn bookmark_age() {
+        assert_eq!(format_bookmark_age(0.0, 100.0), "-");
+        assert_eq!(format_bookmark_age(40.0, 100.0), "1m00s ago");
+        // Clock skew (bookmark ahead of now) clamps to zero.
+        assert_eq!(format_bookmark_age(200.0, 100.0), "0s ago");
+    }
+
+    #[test]
+    fn narrow_terminals_drop_columns_but_keep_essentials() {
+        for width in [10u16, 30, 44, 58, 70, 82, 92, 104, 200] {
+            let cols = visible_columns(width);
+            assert!(cols.contains(&Column::Row), "width {width}");
+            assert!(cols.contains(&Column::Out), "width {width}");
+            assert!(cols.contains(&Column::Status), "width {width}");
+            // Wider never shows fewer columns.
+        }
+        let narrow = visible_columns(30).len();
+        let wide = visible_columns(200).len();
+        assert!(narrow < wide);
+        assert_eq!(visible_columns(200).len(), 9, "all columns at full width");
+        // Status stays last, row stays first at any width.
+        for width in [30u16, 60, 90, 200] {
+            let cols = visible_columns(width);
+            assert_eq!(*cols.first().unwrap(), Column::Row);
+            assert_eq!(*cols.last().unwrap(), Column::Status);
+        }
+    }
+
+    #[test]
+    fn statuses_map_from_row_state() {
+        let mut row = RowStats::default();
+        assert_eq!(row_status(&row).0, "pending");
+        row.in_flight = true;
+        assert_eq!(row_status(&row).0, "running");
+        row.finished = Some(true);
+        assert_eq!(row_status(&row).0, "done");
+        row.finished = Some(false);
+        assert_eq!(row_status(&row).0, "failed");
+    }
+}

--- a/cli/tests/dlq_cmd.rs
+++ b/cli/tests/dlq_cmd.rs
@@ -38,6 +38,7 @@ fn dlq_file(dir: &Path) -> PathBuf {
 fn inspect_args(location: &Path, reason: Option<&str>, json: bool) -> DlqArgs {
     DlqArgs {
         command: DlqCommand::Inspect(DlqInspectArgs {
+            encryption_key: vec![],
             location: location.to_string_lossy().into_owned(),
             reason: reason.map(str::to_owned),
             limit: 5,
@@ -77,6 +78,7 @@ async fn discard_human_and_json_render() {
     // Archive one reason (human render), then delete the rest (JSON render).
     let archive = DlqArgs {
         command: DlqCommand::Discard(DlqDiscardArgs {
+            encryption_key: vec![],
             location: dlq.to_string_lossy().into_owned(),
             reason: Some("quality".into()),
             before: Some("1s".into()),
@@ -87,6 +89,7 @@ async fn discard_human_and_json_render() {
     dlq::run(archive).await.unwrap();
     let delete = DlqArgs {
         command: DlqCommand::Discard(DlqDiscardArgs {
+            encryption_key: vec![],
             location: dlq.to_string_lossy().into_owned(),
             reason: None,
             before: None,
@@ -98,6 +101,7 @@ async fn discard_human_and_json_render() {
     // A bad --before is rejected.
     let bad = DlqArgs {
         command: DlqCommand::Discard(DlqDiscardArgs {
+            encryption_key: vec![],
             location: dlq.to_string_lossy().into_owned(),
             reason: None,
             before: Some("soon".into()),
@@ -111,6 +115,7 @@ async fn discard_human_and_json_render() {
 fn replay_args(config: PathBuf, from: &Path, dry_run: bool, json: bool) -> DlqArgs {
     DlqArgs {
         command: DlqCommand::Replay(DlqReplayArgs {
+            encryption_key: vec![],
             config: Some(config),
             from: from.to_string_lossy().into_owned(),
             reason: None,

--- a/cli/tests/dlq_encrypted.rs
+++ b/cli/tests/dlq_encrypted.rs
@@ -1,0 +1,170 @@
+//! End-to-end tests for encrypted DLQ files (#207): envelopes written by the
+//! jsonl sink's `encryption:` block are readable by `faucet dlq
+//! inspect/replay/discard` — with an explicit key, or (for replay) picked up
+//! automatically from the config's own `dlq:` block.
+#![cfg(all(feature = "encryption", feature = "sink-jsonl"))]
+
+use faucet_cli::auth_catalog::build_auth_catalog;
+use faucet_cli::config::parse_with_extension;
+use faucet_cli::dlq_replay::{self, ReplayInputs, reader::DlqDecryptor};
+use faucet_core::Sink;
+use serde_json::{Value, json};
+use std::path::Path;
+
+const KEY: &str = "dlq-at-rest-key";
+
+fn envelope(reason: &str, payload: Value) -> Value {
+    json!({
+        "error": { "kind": "QualityFailure", "message": "boom" },
+        "reason": reason,
+        "payload": payload,
+        "ts_ms": 1_751_760_000_000i64,
+        "sink": "jsonl",
+        "pipeline": "orig",
+        "row": "",
+        "record_index": 0,
+    })
+}
+
+/// Write envelope lines the way a real encrypted DLQ does: through the jsonl
+/// sink with an `encryption:` block.
+async fn write_encrypted_dlq(path: &Path, envelopes: &[Value]) {
+    let cfg =
+        faucet_sink_jsonl::JsonlSinkConfig::new(path).encryption(faucet_core::EncryptionSpec {
+            key: KEY.into(),
+            previous_keys: vec![],
+            algorithm: Default::default(),
+        });
+    let sink = faucet_sink_jsonl::JsonlSink::new(cfg);
+    sink.write_batch(envelopes).await.unwrap();
+    sink.flush().await.unwrap();
+}
+
+fn read_lines(path: &Path) -> Vec<Value> {
+    std::fs::read_to_string(path)
+        .unwrap_or_default()
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str(l).unwrap())
+        .collect()
+}
+
+#[tokio::test]
+async fn inspect_reads_sealed_envelopes_with_key_and_reports_without() {
+    let dir = tempfile::tempdir().unwrap();
+    let dlq = dir.path().join("dlq.jsonl");
+    write_encrypted_dlq(
+        &dlq,
+        &[
+            envelope("quality", json!({"id": 1})),
+            envelope("contract", json!({"id": 2})),
+        ],
+    )
+    .await;
+
+    // No key: nothing readable, but honestly reported as encrypted.
+    let blind =
+        dlq_replay::inspect(dlq.to_str().unwrap(), None, 5, &DlqDecryptor::default()).unwrap();
+    assert_eq!(blind.total_envelopes, 0);
+    assert_eq!(blind.undecryptable, 2);
+    assert_eq!(blind.malformed, 0, "sealed lines are not 'malformed'");
+
+    // With the key: fully readable.
+    let dec = DlqDecryptor::from_keys(&[KEY.to_string()]).unwrap();
+    let seen = dlq_replay::inspect(dlq.to_str().unwrap(), None, 5, &dec).unwrap();
+    assert_eq!(seen.total_envelopes, 2);
+    assert_eq!(seen.undecryptable, 0);
+    assert_eq!(seen.by_reason.get("quality"), Some(&1));
+
+    // Wrong key: still counted as undecryptable, never a silent skip.
+    let wrong = DlqDecryptor::from_keys(&["nope".to_string()]).unwrap();
+    let blind = dlq_replay::inspect(dlq.to_str().unwrap(), None, 5, &wrong).unwrap();
+    assert_eq!(blind.undecryptable, 2);
+}
+
+#[tokio::test]
+async fn replay_picks_up_the_configs_dlq_encryption_block() {
+    let dir = tempfile::tempdir().unwrap();
+    let dlq = dir.path().join("dlq.jsonl");
+    let out = dir.path().join("out.jsonl");
+    write_encrypted_dlq(&dlq, &[envelope("quality", json!({"id": 7, "ok": true}))]).await;
+
+    // The config declares the same encrypted jsonl DLQ it originally wrote —
+    // replay derives the key from it, no --encryption-key needed.
+    let cfg_yaml = format!(
+        concat!(
+            "version: 1\nname: replay\npipeline:\n",
+            "  source: {{ type: csv, config: {{ path: /dev/null }} }}\n",
+            "  sink: {{ type: jsonl, config: {{ path: {out} }} }}\n",
+            "  dlq:\n    sink:\n      type: jsonl\n",
+            "      config: {{ path: {dlq}, encryption: {{ key: \"{key}\" }} }}\n",
+        ),
+        out = out.display(),
+        dlq = dlq.display(),
+        key = KEY,
+    );
+    let cfg = parse_with_extension(&cfg_yaml, "yaml").unwrap();
+
+    let outcome = dlq_replay::replay(
+        &cfg,
+        dlq.to_str().unwrap(),
+        ReplayInputs {
+            decryptor: Default::default(), // no explicit key — config-derived
+            reason: None,
+            failed_dlq: None,
+            row: None,
+            dry_run: false,
+            pipeline_name: "replay".into(),
+            execution: None,
+            auth: build_auth_catalog(None).unwrap(),
+            clock: chrono::Utc::now().fixed_offset(),
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(outcome.candidates, 1);
+    assert_eq!(outcome.records_written, 1);
+    let rows = read_lines(&out);
+    assert_eq!(rows, vec![json!({"id": 7, "ok": true})]);
+}
+
+#[tokio::test]
+async fn discard_filters_sealed_envelopes_and_preserves_lines_verbatim() {
+    let dir = tempfile::tempdir().unwrap();
+    let dlq = dir.path().join("dlq.jsonl");
+    write_encrypted_dlq(
+        &dlq,
+        &[
+            envelope("quality", json!({"id": 1})),
+            envelope("contract", json!({"id": 2})),
+        ],
+    )
+    .await;
+    let before = std::fs::read_to_string(&dlq).unwrap();
+    let kept_line = before.lines().nth(1).unwrap().to_string();
+
+    let dec = DlqDecryptor::from_keys(&[KEY.to_string()]).unwrap();
+    let outcome =
+        dlq_replay::discard(dlq.to_str().unwrap(), Some("quality"), None, false, &dec).unwrap();
+    assert_eq!(outcome.discarded, 1);
+
+    // The surviving line is byte-identical (still sealed) and the archive
+    // holds the removed sealed line — nothing was re-encrypted or exposed.
+    let after = std::fs::read_to_string(&dlq).unwrap();
+    assert_eq!(after.trim(), kept_line);
+    let archive = std::fs::read_to_string(dir.path().join("dlq.archived.jsonl")).unwrap();
+    assert!(archive.contains(before.lines().next().unwrap()));
+    assert!(!archive.contains("\"id\":1"), "archive stays sealed");
+
+    // Without a key, a filtered discard removes nothing (undecryptable lines
+    // are preserved).
+    let blind = dlq_replay::discard(
+        dlq.to_str().unwrap(),
+        Some("contract"),
+        None,
+        false,
+        &DlqDecryptor::default(),
+    )
+    .unwrap();
+    assert_eq!(blind.discarded, 0);
+}

--- a/cli/tests/dlq_replay_end_to_end.rs
+++ b/cli/tests/dlq_replay_end_to_end.rs
@@ -42,6 +42,7 @@ fn read_lines(path: &Path) -> Vec<Value> {
 
 async fn inputs(pipeline: &str, dry_run: bool) -> ReplayInputs<'static> {
     ReplayInputs {
+        decryptor: Default::default(),
         reason: None,
         failed_dlq: None,
         row: None,

--- a/cli/tests/lineage_run.rs
+++ b/cli/tests/lineage_run.rs
@@ -19,6 +19,7 @@ fn run_args(config: PathBuf) -> faucet_cli::cli::RunArgs {
         state_path: None,
         clock: None,
         profile: None,
+        tui: false,
     }
 }
 

--- a/cli/tests/tui_fallback.rs
+++ b/cli/tests/tui_fallback.rs
@@ -1,0 +1,64 @@
+//! `--tui` behavior outside a terminal (#203): on a non-TTY stdout the flag
+//! degrades to a plain run (CI/pipe safety), and a build without `cli-tui`
+//! rejects the flag with a clear feature hint. Test-harness stdout is never
+//! a TTY, so spawning the binary exercises the fallback path directly.
+
+use assert_cmd::Command;
+
+/// Skip when running under `cargo llvm-cov` — spawned-binary tests measure
+/// nothing and slow the instrumented suite (repo convention).
+fn under_llvm_cov() -> bool {
+    std::env::var_os("CARGO_LLVM_COV").is_some()
+}
+
+fn write_fixture(dir: &std::path::Path) -> std::path::PathBuf {
+    let csv = dir.join("rows.csv");
+    std::fs::write(&csv, "id,name\n1,a\n2,b\n3,c\n").unwrap();
+    let out = dir.join("out.jsonl");
+    let config = dir.join("pipeline.yaml");
+    std::fs::write(
+        &config,
+        format!(
+            "version: 1\nname: tui_fallback\npipeline:\n  source:\n    type: csv\n    config: {{ path: {} }}\n  sink:\n    type: jsonl\n    config: {{ path: {} }}\n",
+            csv.display(),
+            out.display()
+        ),
+    )
+    .unwrap();
+    config
+}
+
+#[cfg(feature = "cli-tui")]
+#[test]
+fn tui_flag_on_non_tty_falls_back_to_a_plain_run() {
+    if under_llvm_cov() {
+        return;
+    }
+    let dir = tempfile::tempdir().unwrap();
+    let config = write_fixture(dir.path());
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["run", "--tui"])
+        .arg(&config)
+        .assert()
+        .success();
+    let out = std::fs::read_to_string(dir.path().join("out.jsonl")).unwrap();
+    assert_eq!(out.lines().count(), 3, "pipeline ran normally: {out}");
+}
+
+#[cfg(not(feature = "cli-tui"))]
+#[test]
+fn tui_flag_without_the_feature_is_a_clear_error() {
+    if under_llvm_cov() {
+        return;
+    }
+    let dir = tempfile::tempdir().unwrap();
+    let config = write_fixture(dir.path());
+    Command::cargo_bin("faucet")
+        .unwrap()
+        .args(["run", "--tui"])
+        .arg(&config)
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("cli-tui"));
+}

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -68,6 +68,10 @@ contract = ["dep:regex"]
 # explicit list) and redact/hash/tokenize/partial-mask them per page, before
 # every sink. `hmac`+`sha2` back the keyed hashing/tokenization actions.
 masking = ["dep:regex", "dep:sha2", "dep:hmac"]
+# Encryption at rest (#207): AES-256-GCM sealing for FileStateStore bookmark
+# files and per-line JSONL/DLQ output. `sha2` derives the 32-byte key from the
+# configured key string.
+encryption = ["dep:aes-gcm", "dep:sha2"]
 
 [dependencies]
 serde.workspace = true
@@ -109,6 +113,7 @@ zstd = { workspace = true, optional = true }
 chrono = { workspace = true, optional = true }
 jsonschema = { workspace = true, optional = true }
 sha2 = { workspace = true, optional = true }
+aes-gcm = { workspace = true, optional = true }
 hmac = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/core/src/encryption.rs
+++ b/crates/core/src/encryption.rs
@@ -1,0 +1,362 @@
+//! Encryption at rest for faucet-managed local files (#207).
+//!
+//! Seals [`FileStateStore`](crate::state::FileStateStore) bookmark files and
+//! (via the jsonl sink's `encryption` feature) per-line JSONL / DLQ output
+//! with authenticated encryption, so resume positions and dead-lettered
+//! records — which can embed sensitive values — are not stored in plaintext.
+//!
+//! ## On-disk format (v1)
+//!
+//! ```text
+//! +---------+--------+-----------+----------------------+
+//! | "FCT1"  | format | nonce     | ciphertext ‖ GCM tag |
+//! | 4 bytes | 1 byte | 12 bytes  | len(plaintext) + 16  |
+//! +---------+--------+-----------+----------------------+
+//! ```
+//!
+//! - Magic `FCT1` ("faucet ciphertext v1") marks a sealed payload; plaintext
+//!   JSON can never start with these bytes, so [`is_encrypted`] is unambiguous.
+//! - `format` byte `0x01` = AES-256-GCM. Unknown values are a typed error
+//!   (never a panic), leaving room for future algorithms.
+//! - The nonce is random per encryption (never reused across writes).
+//! - The GCM tag authenticates the payload: any tampering — a flipped bit,
+//!   truncation, a swapped nonce — fails decryption loudly.
+//!
+//! ## Keys
+//!
+//! The 32-byte AES key is **derived as `SHA-256(key string)`** — a
+//! derivation, not a stretching KDF: it accepts arbitrary passphrases and
+//! hex/base64 strings uniformly, but offers no brute-force hardening, so the
+//! key string should be high-entropy material from a secrets manager
+//! (`${vault:…}` / `${aws-sm:…}` / `${env:…}`), not a human password.
+//!
+//! Rotation: writes always seal with `key`; decryption tries `key` first and
+//! then each entry of `previous_keys` in order, so a store can be rotated by
+//! moving the old key into `previous_keys` — old files stay readable and are
+//! re-sealed with the new key on their next write.
+
+use crate::error::FaucetError;
+use aes_gcm::aead::{Aead, AeadCore, Generate, KeyInit};
+use aes_gcm::{Aes256Gcm, Nonce};
+
+/// The AES-256-GCM nonce array type (12 bytes).
+type GcmNonce = Nonce<<Aes256Gcm as AeadCore>::NonceSize>;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+/// Magic prefix marking a faucet-sealed payload.
+pub const MAGIC: &[u8; 4] = b"FCT1";
+/// Format byte for AES-256-GCM.
+const FORMAT_AES256GCM: u8 = 0x01;
+/// AES-GCM nonce length in bytes.
+const NONCE_LEN: usize = 12;
+/// Header length: magic + format byte + nonce.
+const HEADER_LEN: usize = 4 + 1 + NONCE_LEN;
+
+/// Supported AEAD algorithms. A single variant today; the format byte in the
+/// on-disk header leaves room for more without breaking old files.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub enum EncryptionAlgorithm {
+    /// AES-256-GCM authenticated encryption (the default and only option).
+    #[default]
+    #[serde(rename = "aes-256-gcm")]
+    Aes256Gcm,
+}
+
+/// The user-facing `encryption:` config block (state store / jsonl sink).
+///
+/// ```yaml
+/// encryption:
+///   key: ${vault:secret/faucet#state-key}
+///   # previous_keys: ["${env:OLD_STATE_KEY}"]   # rotation: read-only
+///   # algorithm: aes-256-gcm                     # default
+/// ```
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct EncryptionSpec {
+    /// Key material used to seal new writes (and tried first on reads).
+    /// Should come from a secrets manager; derived to a 32-byte AES key via
+    /// SHA-256.
+    pub key: String,
+    /// Older keys tried (in order) when decrypting, for rotation. Never used
+    /// to seal new writes.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub previous_keys: Vec<String>,
+    /// AEAD algorithm. Only `aes-256-gcm` today.
+    #[serde(default)]
+    pub algorithm: EncryptionAlgorithm,
+}
+
+impl std::fmt::Debug for EncryptionSpec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Never print key material.
+        f.debug_struct("EncryptionSpec")
+            .field("key", &"***")
+            .field(
+                "previous_keys",
+                &format!("[{} keys]", self.previous_keys.len()),
+            )
+            .field("algorithm", &self.algorithm)
+            .finish()
+    }
+}
+
+/// A compiled, validated encryption policy: the derived write key plus every
+/// derived read key (write key first).
+pub struct CompiledEncryption {
+    /// Cipher used for new writes.
+    write: Aes256Gcm,
+    /// Ciphers tried on read: the write key first, then previous keys.
+    read: Vec<Aes256Gcm>,
+}
+
+impl std::fmt::Debug for CompiledEncryption {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CompiledEncryption")
+            .field("read_keys", &self.read.len())
+            .finish()
+    }
+}
+
+/// `true` when `data` carries the sealed-payload magic. Free function so
+/// callers can detect ciphertext without holding a key.
+pub fn is_encrypted(data: &[u8]) -> bool {
+    data.len() >= MAGIC.len() && &data[..MAGIC.len()] == MAGIC
+}
+
+fn derive_key(key: &str) -> Aes256Gcm {
+    let digest = Sha256::digest(key.as_bytes());
+    // SHA-256 output is exactly the AES-256 key size; `new_from_slice` on a
+    // 32-byte slice cannot fail.
+    Aes256Gcm::new_from_slice(&digest).expect("SHA-256 digest is a valid AES-256 key")
+}
+
+impl CompiledEncryption {
+    /// Validate and compile an [`EncryptionSpec`]. Fail-fast: empty key
+    /// material is a typed config error at load time, never mid-run.
+    pub fn compile(spec: &EncryptionSpec) -> Result<Self, FaucetError> {
+        if spec.key.trim().is_empty() {
+            return Err(FaucetError::Config(
+                "encryption.key must not be empty".into(),
+            ));
+        }
+        if let Some(idx) = spec.previous_keys.iter().position(|k| k.trim().is_empty()) {
+            return Err(FaucetError::Config(format!(
+                "encryption.previous_keys[{idx}] must not be empty"
+            )));
+        }
+        let write = derive_key(&spec.key);
+        let mut read = vec![derive_key(&spec.key)];
+        read.extend(spec.previous_keys.iter().map(|k| derive_key(k)));
+        Ok(Self { write, read })
+    }
+
+    /// Seal `plaintext` with the current key under a fresh random nonce.
+    pub fn encrypt(&self, plaintext: &[u8]) -> Vec<u8> {
+        let nonce = GcmNonce::generate();
+        let ciphertext = self
+            .write
+            .encrypt(&nonce, plaintext)
+            // AES-GCM encryption only fails on plaintexts beyond 2^36 bytes;
+            // faucet payloads (bookmarks, JSON lines) are nowhere near it.
+            .expect("AES-GCM encryption of an in-memory payload cannot fail");
+        let mut out = Vec::with_capacity(HEADER_LEN + ciphertext.len());
+        out.extend_from_slice(MAGIC);
+        out.push(FORMAT_AES256GCM);
+        out.extend_from_slice(&nonce);
+        out.extend_from_slice(&ciphertext);
+        out
+    }
+
+    /// Open a sealed payload, trying the current key and then each previous
+    /// key. Every failure is a typed error — a wrong key or tampered file
+    /// must never be silently treated as "no data".
+    pub fn decrypt(&self, data: &[u8]) -> Result<Vec<u8>, FaucetError> {
+        if !is_encrypted(data) {
+            return Err(FaucetError::State(
+                "payload is not faucet-encrypted (missing FCT1 header)".into(),
+            ));
+        }
+        if data.len() < HEADER_LEN {
+            return Err(FaucetError::State(
+                "encrypted payload is truncated (shorter than its header)".into(),
+            ));
+        }
+        let format = data[MAGIC.len()];
+        if format != FORMAT_AES256GCM {
+            return Err(FaucetError::State(format!(
+                "unknown encrypted-payload format byte 0x{format:02x} — written by a newer \
+                 faucet version?"
+            )));
+        }
+        let nonce_bytes: [u8; NONCE_LEN] = data[MAGIC.len() + 1..HEADER_LEN]
+            .try_into()
+            .expect("slice length checked above");
+        let nonce = GcmNonce::from(nonce_bytes);
+        let ciphertext = &data[HEADER_LEN..];
+        for cipher in &self.read {
+            if let Ok(plaintext) = cipher.decrypt(&nonce, ciphertext) {
+                return Ok(plaintext);
+            }
+        }
+        Err(FaucetError::State(
+            "decryption failed — wrong or rotated key? (tried the configured key and every \
+             previous_keys entry)"
+                .into(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn spec(key: &str) -> EncryptionSpec {
+        EncryptionSpec {
+            key: key.into(),
+            previous_keys: vec![],
+            algorithm: EncryptionAlgorithm::default(),
+        }
+    }
+
+    #[test]
+    fn round_trips() {
+        let enc = CompiledEncryption::compile(&spec("k1")).unwrap();
+        let sealed = enc.encrypt(b"hello bookmark");
+        assert!(is_encrypted(&sealed));
+        assert_eq!(enc.decrypt(&sealed).unwrap(), b"hello bookmark");
+        // Empty plaintext round-trips too.
+        let sealed = enc.encrypt(b"");
+        assert_eq!(enc.decrypt(&sealed).unwrap(), b"");
+    }
+
+    #[test]
+    fn nonces_are_unique_per_encryption() {
+        let enc = CompiledEncryption::compile(&spec("k1")).unwrap();
+        let a = enc.encrypt(b"same plaintext");
+        let b = enc.encrypt(b"same plaintext");
+        assert_ne!(a, b, "two seals of the same plaintext must differ");
+    }
+
+    #[test]
+    fn tampering_is_detected() {
+        let enc = CompiledEncryption::compile(&spec("k1")).unwrap();
+        let sealed = enc.encrypt(b"payload");
+
+        // Flip a ciphertext byte.
+        let mut tampered = sealed.clone();
+        let mid = HEADER_LEN + 1;
+        tampered[mid] ^= 0x01;
+        assert!(enc.decrypt(&tampered).is_err());
+
+        // Flip a tag byte (the tag is the trailing 16 bytes).
+        let mut tampered = sealed.clone();
+        let last = tampered.len() - 1;
+        tampered[last] ^= 0x01;
+        assert!(enc.decrypt(&tampered).is_err());
+
+        // Truncate.
+        let truncated = &sealed[..sealed.len() - 4];
+        assert!(enc.decrypt(truncated).is_err());
+        // Truncated inside the header.
+        assert!(enc.decrypt(&sealed[..6]).is_err());
+    }
+
+    #[test]
+    fn wrong_key_is_a_typed_error() {
+        let enc = CompiledEncryption::compile(&spec("k1")).unwrap();
+        let other = CompiledEncryption::compile(&spec("k2")).unwrap();
+        let sealed = enc.encrypt(b"payload");
+        let err = other.decrypt(&sealed).unwrap_err();
+        assert!(matches!(err, FaucetError::State(_)));
+        assert!(err.to_string().contains("wrong or rotated key"));
+    }
+
+    #[test]
+    fn rotation_reads_old_writes_new() {
+        let old = CompiledEncryption::compile(&spec("old-key")).unwrap();
+        let sealed_old = old.encrypt(b"v1");
+
+        let rotated = CompiledEncryption::compile(&EncryptionSpec {
+            key: "new-key".into(),
+            previous_keys: vec!["old-key".into()],
+            algorithm: EncryptionAlgorithm::default(),
+        })
+        .unwrap();
+        // Reads sealed-with-old.
+        assert_eq!(rotated.decrypt(&sealed_old).unwrap(), b"v1");
+        // Writes seal with the new key only.
+        let sealed_new = rotated.encrypt(b"v2");
+        let new_only = CompiledEncryption::compile(&spec("new-key")).unwrap();
+        assert_eq!(new_only.decrypt(&sealed_new).unwrap(), b"v2");
+        assert!(old.decrypt(&sealed_new).is_err());
+    }
+
+    #[test]
+    fn is_encrypted_detection() {
+        assert!(!is_encrypted(b""));
+        assert!(!is_encrypted(b"FC"));
+        assert!(!is_encrypted(b"{\"json\": true}"));
+        assert!(is_encrypted(b"FCT1 anything"));
+    }
+
+    #[test]
+    fn unknown_format_byte_is_a_typed_error() {
+        let enc = CompiledEncryption::compile(&spec("k1")).unwrap();
+        let mut sealed = enc.encrypt(b"x");
+        sealed[4] = 0x7f; // unknown format
+        let err = enc.decrypt(&sealed).unwrap_err();
+        assert!(err.to_string().contains("format byte 0x7f"));
+    }
+
+    #[test]
+    fn non_encrypted_input_is_a_typed_error() {
+        let enc = CompiledEncryption::compile(&spec("k1")).unwrap();
+        let err = enc.decrypt(b"plain text").unwrap_err();
+        assert!(err.to_string().contains("not faucet-encrypted"));
+    }
+
+    #[test]
+    fn empty_keys_are_rejected_at_compile_time() {
+        assert!(matches!(
+            CompiledEncryption::compile(&spec("  ")),
+            Err(FaucetError::Config(_))
+        ));
+        let bad_prev = EncryptionSpec {
+            key: "k".into(),
+            previous_keys: vec!["ok".into(), "".into()],
+            algorithm: EncryptionAlgorithm::default(),
+        };
+        let err = CompiledEncryption::compile(&bad_prev).unwrap_err();
+        assert!(err.to_string().contains("previous_keys[1]"));
+    }
+
+    #[test]
+    fn spec_serde_shape_and_debug_masking() {
+        let s: EncryptionSpec = serde_json::from_value(json!({
+            "key": "SECRET-MATERIAL",
+            "previous_keys": ["OLD-SECRET"],
+        }))
+        .unwrap();
+        assert_eq!(s.algorithm, EncryptionAlgorithm::Aes256Gcm);
+        let rendered = format!("{s:?}");
+        assert!(!rendered.contains("SECRET-MATERIAL"));
+        assert!(!rendered.contains("OLD-SECRET"));
+        assert!(rendered.contains("[1 keys]"));
+        // Unknown fields are rejected.
+        assert!(serde_json::from_value::<EncryptionSpec>(json!({"key": "k", "nope": 1})).is_err());
+        // Algorithm round-trips by its serde name.
+        let s: EncryptionSpec =
+            serde_json::from_value(json!({"key": "k", "algorithm": "aes-256-gcm"})).unwrap();
+        assert_eq!(s.algorithm, EncryptionAlgorithm::Aes256Gcm);
+    }
+
+    #[test]
+    fn compiled_debug_never_prints_key_material() {
+        let enc = CompiledEncryption::compile(&spec("TOPSECRET")).unwrap();
+        let rendered = format!("{enc:?}");
+        assert!(!rendered.contains("TOPSECRET"));
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -22,6 +22,8 @@ pub mod contract;
 pub mod discover;
 pub mod dlq;
 pub mod drift;
+#[cfg(feature = "encryption")]
+pub mod encryption;
 pub mod error;
 pub mod idempotency;
 #[cfg(feature = "masking")]
@@ -61,6 +63,8 @@ pub use drift::{
     ColumnChange, OnDrift, OnIncompatible, SchemaDiff, SchemaDriftPolicy, SchemaDriftSpec,
     SchemaEvolution, SqlBaseType, adds_null, base_widened, json_schema_base_type,
 };
+#[cfg(feature = "encryption")]
+pub use encryption::{CompiledEncryption, EncryptionAlgorithm, EncryptionSpec};
 pub use error::FaucetError;
 pub use idempotency::{
     DeliveryGuarantee, DeliveryMode, EffectivelyOnceMechanism, GuaranteeInputs, ReplayGuarantee,

--- a/crates/core/src/state.rs
+++ b/crates/core/src/state.rs
@@ -162,6 +162,11 @@ fn safe_filename(key: &str) -> String {
 pub struct FileStateStore {
     root: PathBuf,
     write_lock: Mutex<()>,
+    /// Optional at-rest encryption (#207). When set, `put` seals the JSON
+    /// bytes before the atomic write and `get` unseals; plaintext files
+    /// remain readable (and are sealed on their next write).
+    #[cfg(feature = "encryption")]
+    encryption: Option<crate::encryption::CompiledEncryption>,
 }
 
 impl FileStateStore {
@@ -170,7 +175,17 @@ impl FileStateStore {
         Self {
             root: root.into(),
             write_lock: Mutex::new(()),
+            #[cfg(feature = "encryption")]
+            encryption: None,
         }
+    }
+
+    /// Seal bookmark files at rest with the given policy (#207). Reads accept
+    /// both sealed and (legacy) plaintext files; every write seals.
+    #[cfg(feature = "encryption")]
+    pub fn with_encryption(mut self, encryption: crate::encryption::CompiledEncryption) -> Self {
+        self.encryption = Some(encryption);
+        self
     }
 
     fn entry_path(&self, key: &str) -> PathBuf {
@@ -226,6 +241,43 @@ impl StateStore for FileStateStore {
         let path = self.entry_path(key);
         match tokio::fs::read(&path).await {
             Ok(bytes) => {
+                #[cfg(feature = "encryption")]
+                let bytes: Vec<u8> = if crate::encryption::is_encrypted(&bytes) {
+                    match &self.encryption {
+                        Some(enc) => enc.decrypt(&bytes).map_err(|e| {
+                            // Wrong/rotated key must be a loud, typed error —
+                            // treating it as "no bookmark" would silently
+                            // trigger a full re-sync.
+                            FaucetError::State(format!(
+                                "state file {} could not be decrypted: {e}",
+                                path.display()
+                            ))
+                        })?,
+                        None => {
+                            return Err(FaucetError::State(format!(
+                                "state file {} is encrypted but no `encryption` block is \
+                                 configured on the file state store — add \
+                                 `state.config.encryption` with the original key",
+                                path.display()
+                            )));
+                        }
+                    }
+                } else {
+                    bytes
+                };
+                #[cfg(not(feature = "encryption"))]
+                let bytes = {
+                    // Built without the `encryption` feature: refuse to parse a
+                    // sealed file as JSON garbage.
+                    if bytes.starts_with(b"FCT1") {
+                        return Err(FaucetError::State(format!(
+                            "state file {} is encrypted but this build of faucet has no \
+                             `encryption` feature",
+                            path.display()
+                        )));
+                    }
+                    bytes
+                };
                 let value: Value = serde_json::from_slice(&bytes).map_err(|e| {
                     FaucetError::State(format!(
                         "failed to parse state file {}: {e}",
@@ -249,6 +301,11 @@ impl StateStore for FileStateStore {
         let bytes = serde_json::to_vec(value).map_err(|e| {
             FaucetError::State(format!("failed to serialize state for key '{key}': {e}"))
         })?;
+        #[cfg(feature = "encryption")]
+        let bytes = match &self.encryption {
+            Some(enc) => enc.encrypt(&bytes),
+            None => bytes,
+        };
         let final_path = self.entry_path(key);
         let tmp_path = self.temp_path(key);
 
@@ -759,5 +816,114 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(report.failed_count(), 1, "unusable root should fail");
+    }
+
+    #[cfg(feature = "encryption")]
+    mod encryption_at_rest {
+        use super::*;
+        use crate::encryption::{CompiledEncryption, EncryptionSpec, is_encrypted};
+        use serde_json::json;
+
+        fn enc(key: &str) -> CompiledEncryption {
+            CompiledEncryption::compile(&EncryptionSpec {
+                key: key.into(),
+                previous_keys: vec![],
+                algorithm: Default::default(),
+            })
+            .unwrap()
+        }
+
+        #[tokio::test]
+        async fn encrypted_round_trip_and_ciphertext_on_disk() {
+            let dir = tempfile::tempdir().unwrap();
+            let store = FileStateStore::new(dir.path()).with_encryption(enc("k1"));
+            store.put("bk", &json!({"lsn": 42})).await.unwrap();
+            assert_eq!(store.get("bk").await.unwrap(), Some(json!({"lsn": 42})));
+
+            // On disk it is ciphertext, not JSON.
+            let raw = std::fs::read(dir.path().join("bk.json")).unwrap();
+            assert!(is_encrypted(&raw));
+            assert!(serde_json::from_slice::<Value>(&raw).is_err());
+
+            store.delete("bk").await.unwrap();
+            assert_eq!(store.get("bk").await.unwrap(), None);
+        }
+
+        #[tokio::test]
+        async fn plaintext_file_stays_readable_and_is_sealed_on_next_write() {
+            let dir = tempfile::tempdir().unwrap();
+            // A pre-encryption bookmark written by an older config.
+            let plain = FileStateStore::new(dir.path());
+            plain.put("bk", &json!("legacy")).await.unwrap();
+            let before = std::fs::read(dir.path().join("bk.json")).unwrap();
+            assert!(!is_encrypted(&before));
+
+            let sealed = FileStateStore::new(dir.path()).with_encryption(enc("k1"));
+            assert_eq!(sealed.get("bk").await.unwrap(), Some(json!("legacy")));
+            sealed.put("bk", &json!("updated")).await.unwrap();
+            let after = std::fs::read(dir.path().join("bk.json")).unwrap();
+            assert!(is_encrypted(&after), "next write must seal the file");
+            assert_eq!(sealed.get("bk").await.unwrap(), Some(json!("updated")));
+        }
+
+        #[tokio::test]
+        async fn wrong_key_is_a_typed_error_not_a_missing_bookmark() {
+            let dir = tempfile::tempdir().unwrap();
+            let a = FileStateStore::new(dir.path()).with_encryption(enc("right"));
+            a.put("bk", &json!(1)).await.unwrap();
+
+            let b = FileStateStore::new(dir.path()).with_encryption(enc("wrong"));
+            let err = b.get("bk").await.unwrap_err();
+            assert!(matches!(err, FaucetError::State(_)));
+            assert!(err.to_string().contains("could not be decrypted"), "{err}");
+        }
+
+        #[tokio::test]
+        async fn encrypted_file_with_unconfigured_store_is_a_typed_error() {
+            let dir = tempfile::tempdir().unwrap();
+            let sealed = FileStateStore::new(dir.path()).with_encryption(enc("k1"));
+            sealed.put("bk", &json!(1)).await.unwrap();
+
+            let plain = FileStateStore::new(dir.path());
+            let err = plain.get("bk").await.unwrap_err();
+            assert!(err.to_string().contains("no `encryption` block"), "{err}");
+        }
+
+        #[tokio::test]
+        async fn rotation_reads_old_key_files() {
+            let dir = tempfile::tempdir().unwrap();
+            let old = FileStateStore::new(dir.path()).with_encryption(enc("old"));
+            old.put("bk", &json!("v1")).await.unwrap();
+
+            let rotated = FileStateStore::new(dir.path()).with_encryption(
+                CompiledEncryption::compile(&EncryptionSpec {
+                    key: "new".into(),
+                    previous_keys: vec!["old".into()],
+                    algorithm: Default::default(),
+                })
+                .unwrap(),
+            );
+            assert_eq!(rotated.get("bk").await.unwrap(), Some(json!("v1")));
+            // Re-seal under the new key; a store knowing only "new" can read it.
+            rotated.put("bk", &json!("v2")).await.unwrap();
+            let new_only = FileStateStore::new(dir.path()).with_encryption(enc("new"));
+            assert_eq!(new_only.get("bk").await.unwrap(), Some(json!("v2")));
+        }
+
+        #[tokio::test]
+        async fn no_temp_files_left_behind() {
+            let dir = tempfile::tempdir().unwrap();
+            let store = FileStateStore::new(dir.path()).with_encryption(enc("k1"));
+            store.put("bk", &json!(1)).await.unwrap();
+            let leftovers: Vec<_> = std::fs::read_dir(dir.path())
+                .unwrap()
+                .filter_map(Result::ok)
+                .filter(|e| e.path().to_string_lossy().ends_with(".tmp"))
+                .collect();
+            assert!(
+                leftovers.is_empty(),
+                "atomic write must leave no temp files"
+            );
+        }
     }
 }

--- a/crates/sink/jsonl/Cargo.toml
+++ b/crates/sink/jsonl/Cargo.toml
@@ -18,6 +18,7 @@ serde_json.workspace = true
 async-trait.workspace = true
 tracing.workspace = true
 tokio = { workspace = true, features = ["fs", "io-util"] }
+base64 = { workspace = true, optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt", "fs", "io-util"] }
@@ -28,6 +29,10 @@ faucet-conformance.workspace = true
 
 [features]
 compression = ["faucet-core/compression"]
+# Per-line AES-256-GCM sealing of the output (#207) — each JSON line is
+# encrypted and written as base64. Append-safe; mutually exclusive with
+# `compression` at runtime.
+encryption = ["faucet-core/encryption", "dep:base64"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/sink/jsonl/README.md
+++ b/crates/sink/jsonl/README.md
@@ -15,6 +15,7 @@ It's the workhorse local-file destination: zero credentials, zero connection set
 - **Append or truncate** — `append: true` adds to an existing file; the default truncates on open for a clean export.
 - **Auto-creates parent directories** — missing parents of `path` are created (`mkdir -p` semantics) before the file opens, so dated/partitioned subdirectory paths just work.
 - **Optional compression** — behind the `compression` feature, gzip / zstd are selected automatically from the `.gz` / `.zst` suffix (or set explicitly). Multi-member output stays decoder-compatible across mid-stream flushes.
+- **Optional encryption at rest** — behind the `encryption` feature, every record line is sealed with AES-256-GCM and written base64-encoded (#207). Append-safe; the natural fit for a file-backed DLQ. See [Encryption at rest](#encryption-at-rest).
 - **Pretty-print mode** — `pretty: true` indents each record for human reading (no longer strict JSONL — records span multiple lines).
 - **Flush-safe for CDC** — `flush()` finalises the writer and the next write reopens in append mode regardless of `append`, so a CDC source's per-transaction flush appends rather than truncates — no data loss mid-stream.
 - **`faucet doctor` preflight** — `check()` verifies the parent directory is writable (via a throwaway temp file) without ever touching your real output file.
@@ -72,6 +73,7 @@ Every row of `input.csv` is written to `./out/records.jsonl` as one compact JSON
 | `pretty` | bool | `false` | Pretty-print (indent) each record. This breaks strict JSONL — records span multiple lines. |
 | `batch_size` | int | `1000` | Records per upstream `StreamPage`. **No behavioural effect** at this per-record sink; present only for config parity. See [Streaming & batching](#streaming--batching). |
 | `compression` | `none` \| `gzip` \| `zstd` \| `auto` | `auto` | *(requires the `compression` feature)* Output codec. `auto` picks gzip/zstd from the file suffix; anything else writes uncompressed. See [Compression](#compression). |
+| `encryption` | object | — | *(requires the `encryption` feature)* Seal every line with AES-256-GCM: `{ key, previous_keys?, algorithm? }`. Mutually exclusive with `compression`. See [Encryption at rest](#encryption-at-rest). |
 
 ## Examples
 
@@ -263,6 +265,35 @@ This sink does **not** support effectively-once delivery or upsert/delete write 
 - [`faucet-sink-csv`](https://crates.io/crates/faucet-sink-csv) — CSV/TSV file output with full quoting.
 - [`faucet-sink-s3`](https://crates.io/crates/faucet-sink-s3) / [`faucet-sink-gcs`](https://crates.io/crates/faucet-sink-gcs) — the same JSONL records to object storage.
 - [`faucet-core`](https://crates.io/crates/faucet-core) — the `Sink` trait this connector implements.
+
+## Encryption at rest
+
+Behind the crate-local `encryption` Cargo feature (#207). Each serialized JSON
+line is sealed with AES-256-GCM (a fresh random nonce per record) and written
+as its base64 encoding plus a newline — the file stays line-oriented and
+append-safe across flush/reopen cycles.
+
+```yaml
+sink:
+  type: jsonl
+  config:
+    path: ./dlq/failed.jsonl
+    encryption:
+      key: ${vault:secret/faucet#dlq-key}   # high-entropy material, not a password
+      # previous_keys: ["${env:OLD_KEY}"]   # rotation: read-only candidates
+      # algorithm: aes-256-gcm              # default (and only) option
+```
+
+- The 32-byte AES key is derived as SHA-256 of the key string (a derivation,
+  not a stretching KDF — source the key from a secrets manager).
+- **Mutually exclusive with `compression`** — per-line sealed records cannot
+  form a valid gzip/zstd stream; the conflict is a typed config error before
+  any file is created.
+- `faucet dlq inspect/replay/discard` read sealed DLQ files transparently
+  (`--encryption-key`, or automatically from the config's `dlq:` block).
+- The same `encryption` block seals `file` state-store bookmarks — see the
+  state cookbook.
+
 
 ## License
 

--- a/crates/sink/jsonl/src/config.rs
+++ b/crates/sink/jsonl/src/config.rs
@@ -36,6 +36,15 @@ pub struct JsonlSinkConfig {
     #[cfg(feature = "compression")]
     #[serde(default)]
     pub compression: faucet_core::CompressionConfig,
+    /// Encryption at rest (#207): seal every record line with AES-256-GCM and
+    /// write it base64-encoded (one sealed record per line, append-safe).
+    /// The natural fit for a file-backed DLQ holding sensitive failed rows;
+    /// `faucet dlq inspect/replay/discard` decrypt transparently given the
+    /// key. Mutually exclusive with `compression`. Requires the crate-local
+    /// `encryption` feature.
+    #[cfg(feature = "encryption")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub encryption: Option<faucet_core::EncryptionSpec>,
 }
 
 fn default_batch_size() -> usize {
@@ -52,6 +61,8 @@ impl JsonlSinkConfig {
             batch_size: DEFAULT_BATCH_SIZE,
             #[cfg(feature = "compression")]
             compression: faucet_core::CompressionConfig::Auto,
+            #[cfg(feature = "encryption")]
+            encryption: None,
         }
     }
 
@@ -72,6 +83,14 @@ impl JsonlSinkConfig {
     #[cfg(feature = "compression")]
     pub fn compression(mut self, c: faucet_core::CompressionConfig) -> Self {
         self.compression = c;
+        self
+    }
+
+    /// Seal every record line at rest (#207). Available only with the
+    /// `encryption` feature; mutually exclusive with `compression`.
+    #[cfg(feature = "encryption")]
+    pub fn encryption(mut self, e: faucet_core::EncryptionSpec) -> Self {
+        self.encryption = Some(e);
         self
     }
 

--- a/crates/sink/jsonl/src/sink.rs
+++ b/crates/sink/jsonl/src/sink.rs
@@ -23,6 +23,10 @@ use tokio::sync::Mutex;
 /// sources — every transaction appends rather than truncates.
 pub struct JsonlSink {
     config: JsonlSinkConfig,
+    /// Compiled at-rest encryption (#207), initialized on first use so
+    /// `new()` stays infallible. `Err` results surface as typed sink errors.
+    #[cfg(feature = "encryption")]
+    encryption: tokio::sync::OnceCell<Option<faucet_core::CompiledEncryption>>,
     /// Mutex-protected writer for thread-safe concurrent writes.
     writer: Mutex<Option<std::pin::Pin<Box<dyn tokio::io::AsyncWrite + Send + Unpin>>>>,
     /// Tracks whether `ensure_open` has opened the file at least once.
@@ -39,9 +43,40 @@ impl JsonlSink {
     pub fn new(config: JsonlSinkConfig) -> Self {
         Self {
             config,
+            #[cfg(feature = "encryption")]
+            encryption: tokio::sync::OnceCell::new(),
             writer: Mutex::new(None),
             opened_once: std::sync::atomic::AtomicBool::new(false),
         }
+    }
+
+    /// Compile (once) the configured at-rest encryption, validating the
+    /// compression conflict. `Ok(None)` when no `encryption:` block is set.
+    #[cfg(feature = "encryption")]
+    async fn compiled_encryption(
+        &self,
+    ) -> Result<&Option<faucet_core::CompiledEncryption>, FaucetError> {
+        self.encryption
+            .get_or_try_init(|| async {
+                let Some(spec) = &self.config.encryption else {
+                    return Ok(None);
+                };
+                #[cfg(feature = "compression")]
+                {
+                    let path_str = self.config.path.to_string_lossy();
+                    if self.config.compression.resolve(&path_str) != faucet_core::Compression::None
+                    {
+                        return Err(FaucetError::Config(
+                            "jsonl sink: `encryption` and `compression` are mutually \
+                             exclusive — per-line sealed records cannot form a valid \
+                             gzip/zstd stream"
+                                .into(),
+                        ));
+                    }
+                }
+                faucet_core::CompiledEncryption::compile(spec).map(Some)
+            })
+            .await
     }
 
     /// Ensure the file is open and return a mutable reference to the writer.
@@ -127,6 +162,11 @@ impl faucet_core::Sink for JsonlSink {
             return Ok(0);
         }
 
+        // Validate/compile encryption before touching the file so a bad
+        // `encryption:` block never creates an empty output file.
+        #[cfg(feature = "encryption")]
+        let encryption = self.compiled_encryption().await?;
+
         let mut guard = self.ensure_open().await?;
         let writer = guard.as_mut().expect("writer opened in ensure_open");
 
@@ -137,6 +177,15 @@ impl faucet_core::Sink for JsonlSink {
                 serde_json::to_string(record)
             }
             .map_err(|e| FaucetError::Sink(format!("JSON serialization failed: {e}")))?;
+
+            #[cfg(feature = "encryption")]
+            let line = match encryption {
+                Some(enc) => {
+                    use base64::Engine as _;
+                    base64::engine::general_purpose::STANDARD.encode(enc.encrypt(line.as_bytes()))
+                }
+                None => line,
+            };
 
             writer
                 .write_all(line.as_bytes())
@@ -428,5 +477,99 @@ mod tests {
         let text = String::from_utf8(decoded).unwrap();
         let lines: Vec<&str> = text.trim().split('\n').collect();
         assert_eq!(lines.len(), 2);
+    }
+
+    #[cfg(feature = "encryption")]
+    mod encryption_at_rest {
+        use super::*;
+        use base64::Engine as _;
+        use faucet_core::{EncryptionSpec, Sink};
+        use serde_json::json;
+        use tempfile::NamedTempFile;
+
+        fn spec(key: &str) -> EncryptionSpec {
+            EncryptionSpec {
+                key: key.into(),
+                previous_keys: vec![],
+                algorithm: Default::default(),
+            }
+        }
+
+        fn decrypt_lines(path: &std::path::Path, key: &str) -> Vec<Value> {
+            let enc = faucet_core::CompiledEncryption::compile(&spec(key)).unwrap();
+            std::fs::read_to_string(path)
+                .unwrap()
+                .lines()
+                .map(|line| {
+                    let sealed = base64::engine::general_purpose::STANDARD
+                        .decode(line)
+                        .expect("line is base64");
+                    let plain = enc.decrypt(&sealed).expect("line decrypts");
+                    serde_json::from_slice(&plain).expect("plaintext is JSON")
+                })
+                .collect()
+        }
+
+        #[tokio::test]
+        async fn per_line_encrypted_output_round_trips() {
+            let tmp = NamedTempFile::new().unwrap();
+            let path = tmp.path().to_path_buf();
+            let sink = JsonlSink::new(JsonlSinkConfig::new(&path).encryption(spec("dlq-key")));
+            let records = vec![json!({"id": 1, "pii": "s3cr3t"}), json!({"id": 2})];
+            sink.write_batch(&records).await.unwrap();
+            sink.flush().await.unwrap();
+
+            // Raw file: no plaintext leakage, every line base64.
+            let raw = std::fs::read_to_string(&path).unwrap();
+            assert!(!raw.contains("s3cr3t"));
+            assert_eq!(raw.trim().lines().count(), 2);
+
+            assert_eq!(decrypt_lines(&path, "dlq-key"), records);
+        }
+
+        #[tokio::test]
+        async fn append_across_flush_reopen_keeps_all_sealed_lines() {
+            let tmp = NamedTempFile::new().unwrap();
+            let path = tmp.path().to_path_buf();
+            let sink = JsonlSink::new(JsonlSinkConfig::new(&path).encryption(spec("k")));
+            sink.write_batch(&[json!({"first": 1})]).await.unwrap();
+            sink.flush().await.unwrap();
+            sink.write_batch(&[json!({"second": 2})]).await.unwrap();
+            sink.flush().await.unwrap();
+
+            let lines = decrypt_lines(&path, "k");
+            assert_eq!(lines, vec![json!({"first": 1}), json!({"second": 2})]);
+        }
+
+        #[tokio::test]
+        async fn empty_key_is_a_typed_error_before_any_file_io() {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("out.jsonl");
+            let sink = JsonlSink::new(JsonlSinkConfig::new(&path).encryption(spec(" ")));
+            let err = sink.write_batch(&[json!(1)]).await.unwrap_err();
+            assert!(matches!(err, FaucetError::Config(_)));
+            assert!(!path.exists(), "a bad config must not create the file");
+        }
+
+        #[cfg(feature = "compression")]
+        #[tokio::test]
+        async fn compression_and_encryption_are_mutually_exclusive() {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("out.jsonl.gz"); // Auto resolves gzip
+            let sink = JsonlSink::new(JsonlSinkConfig::new(&path).encryption(spec("k")));
+            let err = sink.write_batch(&[json!(1)]).await.unwrap_err();
+            assert!(err.to_string().contains("mutually"), "{err}");
+        }
+
+        #[cfg(feature = "compression")]
+        #[tokio::test]
+        async fn encryption_with_plain_path_and_auto_compression_is_fine() {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("out.jsonl"); // Auto resolves None
+            let sink = JsonlSink::new(JsonlSinkConfig::new(&path).encryption(spec("k")));
+            sink.write_batch(&[json!({"ok": true})]).await.unwrap();
+            sink.flush().await.unwrap();
+            assert_eq!(decrypt_lines(&path, "k"), vec![json!({"ok": true})]);
+        }
     }
 }

--- a/docs/book/src/cookbook/dlq.md
+++ b/docs/book/src/cookbook/dlq.md
@@ -152,6 +152,42 @@ By default discarded envelopes are moved to a `<file>.archived.jsonl` sibling;
 or a relative age like `7d` / `24h` / `30m`) select what to discard — everything
 else, including non-envelope lines, is left untouched.
 
+## Encryption at rest
+
+DLQ envelopes carry failed records **verbatim** — on a shared or
+compliance-scoped host that can be a plaintext-at-rest gap. When the DLQ sink
+is `jsonl`, seal every envelope line with AES-256-GCM (requires a build with
+the `encryption` feature — included in `--features full`):
+
+```yaml
+dlq:
+  sink:
+    type: jsonl
+    config:
+      path: ./dlq/failed.jsonl
+      encryption:
+        key: ${vault:secret/faucet#dlq-key}
+        # previous_keys: ["${env:OLD_KEY}"]   # rotation: read-only candidates
+```
+
+Each record line is encrypted individually and written base64-encoded, so the
+file stays line-oriented and append-safe. `encryption` is mutually exclusive
+with the jsonl sink's `compression` (per-line sealed records cannot form a
+valid gzip/zstd stream).
+
+The `faucet dlq` verbs handle sealed files transparently:
+
+- `inspect` / `discard` — pass `--encryption-key <KEY>` (repeat the flag to
+  also try rotated keys). Without a key, sealed lines are counted and reported
+  as *encrypted* — never mistaken for malformed lines, never mangled.
+- `replay` — picks the key up **automatically** from the config's own
+  `dlq:` jsonl `encryption` block; `--encryption-key` overrides.
+- `discard` keeps and archives lines **verbatim** (still sealed) — filtering
+  decrypts only in memory; nothing is ever re-written in plaintext.
+
+The same `encryption` block also seals `file` state-store bookmarks — see
+[State & resumability](./state.md#encryption-at-rest-file-backend).
+
 > The full design is in
 > [`docs/superpowers/specs/2026-05-24-dlq-design.md`](https://github.com/PawanSikawat/faucet-stream/blob/main/docs)
 > and the `faucet_core::dlq` module on docs.rs.

--- a/docs/book/src/cookbook/state.md
+++ b/docs/book/src/cookbook/state.md
@@ -64,6 +64,43 @@ Raise it when many concurrent matrix rows share one state store; lower it
 against a connection-limited managed Postgres. A value of `0` is rejected at
 config-load time.
 
+### Encryption at rest (`file` backend)
+
+Bookmarks can embed source positions and key values. On a shared or
+compliance-scoped host, seal the `file` backend's bookmark files with
+AES-256-GCM (requires a build with the `encryption` feature — included in
+`--features full`):
+
+```yaml
+state:
+  type: file
+  config:
+    path: ./state
+    encryption:
+      key: ${vault:secret/faucet#state-key}   # or ${env:FAUCET_STATE_KEY}
+      # previous_keys: ["${env:OLD_KEY}"]     # rotation: read-only candidates
+      # algorithm: aes-256-gcm                # default (and only) option
+```
+
+- **Key handling** — the 32-byte AES key is derived as SHA-256 of the key
+  string. That is a derivation, not a stretching KDF: use high-entropy
+  material from a secrets manager, not a human password. The `state:` block
+  is covered by the secrets pass, so `${vault:…}` / `${aws-sm:…}` keys work
+  and are redacted from faucet's logs.
+- **Rotation** — move the old key into `previous_keys` and set the new `key`:
+  old files stay readable and every write re-seals with the new key.
+- **Backward compatible** — plaintext bookmarks written before encryption was
+  enabled remain readable and are sealed on their next write.
+- **Failure behavior** — a wrong/rotated-away key or a tampered file is a
+  *typed error*, never a silent "no bookmark" (which would trigger a full
+  re-sync); an encrypted file read by a store with no `encryption` block
+  errors with instructions rather than parsing garbage. The atomic
+  temp-file + fsync + rename write path is unchanged.
+
+For the Redis / Postgres backends, rely on the backend's own at-rest
+encryption. To seal a **file-backed DLQ** the same way, see
+[Dead-letter queues](./dlq.md#encryption-at-rest).
+
 ## How bookmarks advance
 
 The pipeline reads the bookmark before fetching, and persists a new one **only

--- a/docs/book/src/reference/cli.md
+++ b/docs/book/src/reference/cli.md
@@ -45,6 +45,7 @@ Flags:
 | `--profile <name>` | Select a named overlay from the config's `profiles:` block (see [Config composition](config.md#config-composition)). Overrides `FAUCET_PROFILE`. |
 | `--env-file <path>` / `--no-env-file` | Same `.env` handling as `validate` / `preview`. |
 | `--from-env` | Build the pipeline entirely from `FAUCET_*` environment variables; mutually exclusive with a positional config path. |
+| `--tui` | Show a live full-screen terminal UI while the pipeline runs: per-invocation source→sink route, records in/out, records/s, errors, DLQ counts, bookmark age, and a scrolling log pane. Press `q` (or `Ctrl-C`) to cancel cooperatively — in-flight invocations stop at their next page boundary and flush their sinks. Requires a binary built with the `cli-tui` feature (`cargo install faucet-cli --features cli-tui`); on a non-TTY stdout (CI, pipes) the flag logs a notice and runs normally. When the config has an `observability.prometheus` block, the `/metrics` endpoint stays up alongside the TUI; OTLP *metrics* export is skipped under `--tui` (traces are unaffected). |
 
 ## `validate`
 

--- a/docs/book/src/reference/cli.md
+++ b/docs/book/src/reference/cli.md
@@ -383,6 +383,7 @@ with a sample.
 |------|--------|
 | `--reason <r>` | Only include envelopes with this reason (`partial` / `dlq_all` / `quality` / `schema_drift` / `contract`). |
 | `--limit <n>` | Sample size. Default: 5. |
+| `--encryption-key <k>` | Key for a DLQ sealed at rest by the jsonl sink's `encryption` block; repeat for rotated keys. Sealed lines without a matching key are counted as *encrypted*, never mistaken for malformed. Requires an `encryption`-feature build. |
 | `--json` | Emit a JSON summary. |
 
 **`faucet dlq replay <config> --from <location>`** — re-feed the quarantined
@@ -393,6 +394,7 @@ fail again go to a *fresh* DLQ, never back to the source.
 |------|--------|
 | `--from <location>` | DLQ location to replay from (required). |
 | `--reason <r>` | Replay only envelopes with this reason. |
+| `--encryption-key <k>` | Key for a sealed DLQ (repeatable). When omitted, the config's own `dlq:` jsonl `encryption` block is used automatically. |
 | `--failed-dlq <path>` | Where re-failed rows go. Default: a `replay-failed.jsonl` sibling of the source. |
 | `--row <id>` | Which root of the config to replay through. Default: the first root. |
 | `--dry-run` | Report what would be replayed without writing. |
@@ -406,6 +408,7 @@ fail again go to a *fresh* DLQ, never back to the source.
 | `--reason <r>` | Only discard envelopes with this reason. |
 | `--before <when>` | Only discard envelopes older than an RFC 3339 timestamp or a relative age (`7d` / `24h` / `30m`). |
 | `--delete` | Permanently delete instead of archiving to a `<file>.archived.jsonl` sibling. |
+| `--encryption-key <k>` | Key for a sealed DLQ (repeatable). Kept/archived lines stay sealed verbatim; decryption happens only in memory for filtering. |
 | `--json` | Emit a JSON result. |
 
 See the [Dead-letter queues](../cookbook/dlq.md) cookbook page for the envelope

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -326,6 +326,10 @@ paths:
                 location: { type: string }
                 reason: { type: string, enum: [partial, dlq_all, quality, schema_drift, contract] }
                 limit: { type: integer, default: 5 }
+                encryption_keys:
+                  type: array
+                  items: { type: string }
+                  description: Keys for a DLQ sealed at rest by the jsonl sink's `encryption` block (first = current, rest = rotated). Requires a server built with the `encryption` feature.
       responses:
         "200":
           description: Grouped DLQ summary
@@ -357,6 +361,11 @@ paths:
                 failed_dlq: { type: string }
                 row: { type: string }
                 dry_run: { type: boolean, default: false }
+                encryption_keys:
+                  type: array
+                  items: { type: string }
+                  description: Keys for a DLQ sealed at rest by the jsonl sink's `encryption` block (first = current, rest = rotated). Requires a server built with the `encryption` feature.
+                  # When empty, the config's own dlq jsonl `encryption` block is used.
       responses:
         "200":
           description: Replay outcome (candidates, records_written, failed_dlq)
@@ -386,6 +395,10 @@ paths:
                 reason: { type: string, enum: [partial, dlq_all, quality, schema_drift, contract] }
                 before_ms: { type: integer, description: Only discard envelopes with ts_ms strictly older than this }
                 delete: { type: boolean, default: false }
+                encryption_keys:
+                  type: array
+                  items: { type: string }
+                  description: Keys for a DLQ sealed at rest by the jsonl sink's `encryption` block (first = current, rest = rotated). Requires a server built with the `encryption` feature.
       responses:
         "200":
           description: Discard outcome (discarded, files_rewritten, archived_to)

--- a/faucet-stream/Cargo.toml
+++ b/faucet-stream/Cargo.toml
@@ -103,8 +103,13 @@ lineage = ["dep:faucet-lineage"]
 lineage-kafka = ["lineage", "faucet-lineage/transport-kafka"]
 ## SQL-as-transform via embedded DuckDB.
 transform-sql = ["dep:faucet-transform-sql"]
+## Encryption at rest (#207): AES-256-GCM for FileStateStore bookmarks and,
+## when `sink-jsonl` is also enabled, per-line JSONL output (the file DLQ
+## shape). Forwarded to `faucet-core` (and the jsonl sink via optional-dep
+## syntax, so this flag never pulls the connector itself).
+encryption = ["faucet-core/encryption", "faucet-sink-jsonl?/encryption"]
 ## Every connector and state backend.
-full = ["source", "sink", "state", "auth", "kafka-schema-registry", "compression", "quality", "quality-jsonschema", "contract", "masking", "lineage", "lineage-kafka", "transform-sql", "transform-cdc-unwrap"]
+full = ["source", "sink", "state", "auth", "kafka-schema-registry", "compression", "quality", "quality-jsonschema", "contract", "masking", "lineage", "lineage-kafka", "transform-sql", "transform-cdc-unwrap", "encryption"]
 
 ## Individual source connectors.
 source-rest = ["dep:faucet-source-rest"]

--- a/faucet-stream/src/lib.rs
+++ b/faucet-stream/src/lib.rs
@@ -51,6 +51,7 @@
 //! | `sink-kafka` | Apache Kafka producer sink |
 //! | `sink-kinesis` | AWS Kinesis Data Streams sink |
 //! | `sink-parquet` | Apache Parquet file sink (local, S3) |
+//! | `encryption` | AES-256-GCM at-rest sealing for file state-store bookmarks and per-line JSONL/DLQ output |
 //! | `kafka-schema-registry` | Schema Registry support for Kafka connectors |
 //! | `source` | All source connectors |
 //! | `sink` | All sink connectors |

--- a/schemas/faucet.schema.json
+++ b/schemas/faucet.schema.json
@@ -5484,6 +5484,39 @@
         }
       ]
     },
+    "sink_jsonl__EncryptionSpec": {
+      "description": "The user-facing `encryption:` config block (state store / jsonl sink).\n\n```yaml\nencryption:\n  key: ${vault:secret/faucet#state-key}\n  # previous_keys: [\"${env:OLD_STATE_KEY}\"]   # rotation: read-only\n  # algorithm: aes-256-gcm                     # default\n```",
+      "type": "object",
+      "properties": {
+        "key": {
+          "description": "Key material used to seal new writes (and tried first on reads).\nShould come from a secrets manager; derived to a 32-byte AES key via\nSHA-256.",
+          "type": "string"
+        },
+        "previous_keys": {
+          "description": "Older keys tried (in order) when decrypting, for rotation. Never used\nto seal new writes.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "algorithm": {
+          "description": "AEAD algorithm. Only `aes-256-gcm` today.",
+          "$ref": "#/$defs/sink_jsonl__EncryptionAlgorithm",
+          "default": "aes-256-gcm"
+        }
+      },
+      "additionalProperties": true
+    },
+    "sink_jsonl__EncryptionAlgorithm": {
+      "description": "Supported AEAD algorithms. A single variant today; the format byte in the\non-disk header leaves room for more without breaking old files.",
+      "oneOf": [
+        {
+          "description": "AES-256-GCM authenticated encryption (the default and only option).",
+          "type": "string",
+          "const": "aes-256-gcm"
+        }
+      ]
+    },
     "sink_snowflake__AuthSpec": {
       "description": "A connector's `auth:` field: **either** an inline auth definition `A`\n(the `{ type, config }` shape), **or** a `{ ref: <name> }` reference to a\nshared provider defined in the top-level `auth:` catalog.\n\n`ref` is mutually exclusive with inline fields — supplying both is a\ndeserialization error.",
       "anyOf": [
@@ -10059,6 +10092,17 @@
                       "description": "Compression codec for the output file. Defaults to\n[`CompressionConfig::Auto`](faucet_core::CompressionConfig::Auto) —\n`.gz` / `.zst` suffix selects gzip / zstd, anything else writes\nuncompressed. Requires the crate-local `compression` feature.",
                       "$ref": "#/$defs/sink_jsonl__CompressionConfig",
                       "default": "auto"
+                    },
+                    "encryption": {
+                      "description": "Encryption at rest (#207): seal every record line with AES-256-GCM and\nwrite it base64-encoded (one sealed record per line, append-safe).\nThe natural fit for a file-backed DLQ holding sensitive failed rows;\n`faucet dlq inspect/replay/discard` decrypt transparently given the\nkey. Mutually exclusive with `compression`. Requires the crate-local\n`encryption` feature.",
+                      "anyOf": [
+                        {
+                          "$ref": "#/$defs/sink_jsonl__EncryptionSpec"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
                     }
                   },
                   "title": "JsonlSinkConfig",


### PR DESCRIPTION
Closes #207
Closes #203

Part of the roadmap epic #38. Two opt-in features, one PR (per request).

## 1. Encryption at rest (#207 — `encryption` feature)

AES-256-GCM at-rest encryption for faucet-managed local files:

- **Core module** (`faucet_core::encryption`): `EncryptionSpec` (`key` / `previous_keys` / `algorithm: aes-256-gcm`), SHA-256 key derivation from the config string (key material should come from `${vault:…}` — the secrets pass covers the `state:`/`dlq:` blocks), `FCT1` + format byte + 12-byte nonce on-disk format (`aes-gcm` 0.11), decrypt tries current → previous keys (**rotation: read old, write new**). Key material is never Debug-printed.
- **`FileStateStore`**: bookmarks sealed on `put` (the atomic temp+fsync+rename guarantee is unchanged), decrypted on `get`. **Wrong/missing key is a typed error, never a silent empty bookmark** (which would cause a full re-sync); tampering and truncation are detected (AEAD); pre-existing plaintext bookmarks stay readable and are sealed on the next write; an encrypted file read by an unconfigured store is a typed error.
- **JSONL sink per-line encryption** — the file-backed **DLQ** story from the issue title: append-safe sealed base64 lines; mutually exclusive with `compression` (typed error).
- **`faucet dlq inspect/replay/discard` understand sealed files**: sealed lines are recognized even in feature-off builds (counted as *encrypted*, never *malformed*); `--encryption-key` (repeatable) decrypts; **replay auto-derives the key from the config's own `dlq:` block**; discard preserves raw lines verbatim. Serve's `/v1/dlq/*` bodies gain `encryption_keys` (openapi synced).
- Opt-in everywhere (in `full`, not `default`); CI feature-isolation entry; state + DLQ cookbooks, READMEs, schema regenerated.

Tests: tamper/truncate/wrong-key/rotation/format-byte/nonce-uniqueness units (encryption.rs **100% line coverage**), state-store at-rest suite, JSONL no-plaintext-leak + append-across-flush, end-to-end encrypted DLQ inspect/replay/discard.

## 2. Live terminal UI (#203 — `cli-tui` feature)

`faucet run --tui` renders a ratatui full-screen live view: per-invocation table (records in/out, rec/s, errors, DLQ, bookmark age — columns drop gracefully on narrow widths), scrolling redacted log pane (tracing routed to a ring buffer so the alternate screen never corrupts), `q`/Ctrl-C wired to the **cooperative CancellationToken** (early quit flush-cancels at the next page boundary).

- **Read-only metrics sampling, zero hot-path changes**: under `--tui` the run command owns the Prometheus recorder (keeping the configured `/metrics` listener when a `prometheus` block exists) and samples `handle.render()` at 4 Hz through a pure, unit-tested parser + counter-reset-safe rate tracker. The run itself executes unchanged.
- **Non-TTY (CI, pipes) falls back cleanly** to today's behavior with a one-line notice — covered by a spawned-binary test. `--tui` without the build feature is a typed error. OTLP-metrics + `--tui` is explicitly unsupported (warn; documented).
- Terminal restore on exit **and panic** (ratatui's init/restore + panic hook). Opt-in (in `full`, not `default`); CI matrix **and** CLI bash-routing updated; CLI reference + READMEs documented.

Tests: 17 new units (prometheus parsing incl. label escapes, rates across counter resets, layout/format/column-drop, log-ring redaction) + the fallback/feature-off integration tests; 642 CLI lib tests green with the feature on; clippy `-D warnings` clean with and without each feature.