### PR TITLE
test: resume/checkpoint property tests + cargo-semver-checks API gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,6 +409,39 @@ jobs:
         with:
           command: check advisories
 
+  # Hard gate: the public API must not break without a deliberate major-version
+  # bump. `faucet-core` is the one crate every third-party connector depends on
+  # (the Faucet Connector Protocol, §8) — a breaking change to its object-safe
+  # trait surface would silently break every external `faucet-source-*` /
+  # `faucet-sink-*`. cargo-semver-checks compares this revision's public API
+  # against the version last published to crates.io and fails on any breaking
+  # change; the only sanctioned way past it is bumping the crate's major version
+  # (which moves the baseline). Additive changes (new defaulted trait methods,
+  # new items) are a minor bump and pass. See CONTRIBUTING.md.
+  semver-checks:
+    name: API stability (cargo-semver-checks)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.96.0"
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-semver-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-semver-
+      - name: Check faucet-core public API for breaking changes
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          # `faucet-core` at minimum — the required connector-author dependency.
+          package: faucet-core
+          # Use the 1.96.0 toolchain installed above, not the action's default.
+          rust-toolchain: manual
+
   coverage:
     name: Coverage
     runs-on: ubuntu-latest

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -161,6 +161,18 @@ multi-row `INSERT`s and the `write_method: copy` bulk-load fast-path (#308,
 `COPY … FROM STDIN` — the benchmark config's default since it is the best
 append path).
 
+**Batch parity (both sides write 5,000-row batches).** So the gap below cannot be
+dismissed as a Meltano batch-size misconfiguration: both loaders are pinned to the
+same write batch. faucet emits 5,000-row source pages (`batch_size: 5000`) and
+writes each via `COPY … FROM STDIN` (its `copy` row) or multi-row `INSERT` (its
+`insert` row), and Meltano's `target-postgres` is pinned to `batch_size_rows: 5000`
+and writes multi-row `INSERT`s. `target-postgres` also ships an opt-in COPY loader
+(`use_copy: true`, default off) that this run leaves off — so the faucet-`copy` vs
+Meltano row additionally differs in write *method* (COPY vs INSERT), while the
+faucet-`insert` vs Meltano row is method-matched. See
+[`benchmarks/faucet/postgres_to_postgres.yaml`](benchmarks/faucet/postgres_to_postgres.yaml)
+and [`benchmarks/meltano/meltano.yml`](benchmarks/meltano/meltano.yml).
+
 | Tool | Median wall-clock (s) | Stddev (s) | Throughput (rows/s) | Peak RSS (MiB) | Rows out |
 |---|---|---|---|---|---|
 | **faucet-stream (`write_method: copy`)** | **8.12** | 0.142 | **123,200** | **35.9** | 1,000,000 |
@@ -174,7 +186,19 @@ stddev: faucet is tight (±0.1s) while Meltano's Python/pipe runtime jitters
 badly at scale (±34s). (The Meltano row is from the same-machine PR #307 run;
 the faucet rows were re-measured when the COPY fast-path landed. faucet's
 INSERT number improved slightly between runs — 11.17s → 10.10s — normal
-machine-load drift.) This is the whole point of the scenario: **the gap
+machine-load drift.)
+
+> **Numbers predate the `batch_size_rows: 5000` pin.** The Meltano row above was
+> captured before the explicit batch pin was added to `meltano.yml` (it used
+> `target-postgres`'s prior default); the batch pin makes both sides literally
+> 5,000 rows. In this regime batch size is not the lever (faucet's throughput is
+> flat 500→5000 rows/`INSERT`), so the number is not expected to move materially —
+> but it has not been re-measured under the pinned config. **TODO: run locally**
+> (needs Docker + a Meltano venv, not available in this change):
+> `scripts/run-bench.sh --postgres --rows 1000000`, then refresh this table and
+> `benchmarks/results/results_pg_1m.md` from the real run.
+
+This is the whole point of the scenario: **the gap
 collapses from ~96× to ~16× as the workload moves from parse-bound to
 sink-bound**, because both tools become bounded by the same Postgres write
 path. The narrowing, all at 1M rows on the same machine:
@@ -194,8 +218,11 @@ Postgres rows → JSON → re-encode) and the rest blocked on the destination
 write. `COPY` roughly halves the write step vs multi-row `INSERT` (the 5–10×
 folk number applies to the write step in isolation, and Amdahl caps the
 end-to-end gain at ~1.6× when 62% of the time is decode) — measured end-to-end
-it bought **1.24×** (10.10s → 8.12s). Meltano's `target-postgres` uses
-`INSERT`, so it cannot follow. The remaining headroom is the decode side
+it bought **1.24×** (10.10s → 8.12s). This benchmark runs Meltano's
+`target-postgres` on its default `INSERT` loader (its opt-in `use_copy: true`
+COPY path is left off), so only the faucet-`insert` row is a method-matched
+comparison; against faucet's COPY row the difference is partly write-method, not
+just runtime. The remaining headroom is the decode side
 (skipping the JSON intermediate for same-engine moves), which is niche and
 high-complexity — see issue #308. Batch size is *not* the lever (throughput is
 flat from 500→5000 rows/`INSERT` and worsens past the 65 535 bind-param cap).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,29 @@ independently).
   is the Tier-1 (supported) criterion; wired into `faucet-source-csv` and
   `faucet-source-singer`.
 
+### Testing
+
+- **Resume/checkpoint property tests** for `faucet-source-singer` — `proptest`
+  coverage of the effectively-once resume path over arbitrary Singer message
+  interleavings and arbitrary crash points, generalizing the single hand-written
+  crash-resume case. Asserts the five resume invariants: no loss, no duplicates
+  (keyed sink), the checkpoint is never ahead of durable data, monotonic
+  checkpoints, and empty-with-bookmark.
+
+### CI & Build
+
+- **API-stability gate** — a `cargo-semver-checks` CI job fails on any breaking
+  change to the public `faucet-core` API vs the last crates.io release, so the
+  connector trait surface (FCP §8) can only break with a deliberate major-version
+  bump. Documented in CONTRIBUTING.md.
+
+### Documentation
+
+- **Benchmark batch disclosure** — BENCHMARKS.md Scenario C (Postgres → Postgres)
+  now states the write-batch size and insert strategy on both sides (both pinned
+  to 5,000-row batches; Meltano's opt-in `use_copy` COPY path noted as left off),
+  so the sink-bound gap cannot be read as a Meltano batch misconfiguration.
+
 ## `faucet-cli` — [1.1.0](https://github.com/PawanSikawat/faucet-stream/compare/faucet-cli-v1.0.1...faucet-cli-v1.1.0) - 2026-06-12
 
 ### Bug Fixes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,27 @@ for a worked example and the
 [Faucet Connector Protocol (FCP v0)](./docs/spec/faucet-connector-spec-v0.md)
 for the full contract.
 
+### API stability (the `faucet-core` trait surface)
+
+Third-party connectors depend on **`faucet-core`** — and only on `faucet-core`
+(FCP §8). To protect them, the CI **`API stability (cargo-semver-checks)`** job
+compares this revision's public API against the version last published to
+crates.io and **fails on any breaking change**. It is a required check, so a
+break cannot merge silently.
+
+The rule is simple: **bump the major version, or don't break it.** The only
+sanctioned way past the gate is a deliberate major-version bump (which moves the
+baseline) — there is no bypass flag, matching FCP §8 ("breaking changes bump the
+version"). Additive changes are always fine and pass the gate: new items, and —
+crucially for the object-safe `Source`/`Sink` traits — **new trait methods must
+carry a default implementation** so existing connectors keep compiling (a minor
+bump, not a breaking one). Run it locally before pushing:
+
+```bash
+cargo install cargo-semver-checks --locked   # once
+cargo semver-checks check-release --package faucet-core
+```
+
 Shared types for a source/sink pair (auth, formats) go in a
 `faucet-common-<name>` crate that both depend on. See `faucet-source-rest` for a
 reference implementation.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4318,6 +4318,7 @@ dependencies = [
  "futures",
  "futures-core",
  "libc",
+ "proptest",
  "schemars 1.2.1",
  "serde",
  "serde_json",
@@ -8236,6 +8237,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8538,6 +8558,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quick-xml"
 version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8746,6 +8772,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "rand_xoshiro"
@@ -9424,6 +9459,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -11308,6 +11355,12 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicase"

--- a/benchmarks/faucet/postgres_to_postgres.yaml
+++ b/benchmarks/faucet/postgres_to_postgres.yaml
@@ -29,6 +29,9 @@ pipeline:
       table_name: bench_dest
       column_mapping: auto_map
       max_connections: 8
+      # 5000-row write batch — matches Meltano's target-postgres
+      # `batch_size_rows: 5000` (see ../meltano/meltano.yml) so Scenario C is
+      # an apples-to-apples batch-size comparison.
       batch_size: 5000
       # Benchmark faucet's best append path: the COPY bulk-load fast-path
       # (#308). Drop this line to measure the multi-row INSERT path instead.

--- a/benchmarks/meltano/meltano.yml
+++ b/benchmarks/meltano/meltano.yml
@@ -48,3 +48,9 @@ plugins:
       # its own schema so it never collides with faucet's `bench_dest` table.
       config:
         default_target_schema: bench_meltano
+        # Pin the write batch to match faucet's 5000-row source page (see
+        # ../faucet/postgres_to_postgres.yaml) so Scenario C compares like-for-
+        # like batch sizes — the gap is not a batching artifact. target-postgres
+        # also exposes an opt-in COPY loader (`use_copy: true`, default off);
+        # it is left off here so this row measures its multi-row INSERT path.
+        batch_size_rows: 5000

--- a/crates/source/singer/Cargo.toml
+++ b/crates/source/singer/Cargo.toml
@@ -32,6 +32,8 @@ libc = "0.2"
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }
 tracing-subscriber = "0.3"
+# Property-based tests for the resume/checkpoint state machine (tests/resume_proptest.rs).
+proptest = "1"
 tempfile.workspace = true
 # Path-only (no version): cargo strips path-only dev-dependencies when
 # packaging, so publishing this crate does not require faucet-conformance to

--- a/crates/source/singer/tests/resume_proptest.rs
+++ b/crates/source/singer/tests/resume_proptest.rs
@@ -1,0 +1,375 @@
+//! Property tests for the Singer resume / checkpoint state machine — the proof
+//! of the **effectively-once** (idempotent at-least-once) delivery claim.
+//!
+//! [`tests/integration.rs`] pins one hand-written crash-resume case end-to-end
+//! through a real subprocess. This generalizes that proof: it drives the pure
+//! [`PageAssembler`] state machine (`src/assemble.rs`) plus a faithful model of
+//! the pipeline's resume loop over **arbitrary** message interleavings and
+//! **arbitrary** crash points, with in-memory `Sink` / `StateStore` doubles. No
+//! subprocess, so it is deterministic and fast.
+//!
+//! The model mirrors [`faucet_core::Pipeline`]'s documented ordering exactly:
+//! for each page the sink write happens **first**, and only after it confirms is
+//! the page's bookmark persisted (see `Pipeline::with_state_store`). On a crash
+//! the tap's trailing un-checkpointed buffer is dropped (the stream errors
+//! before `on_eof` commits it), and on resume a real tap replays *coarsely* from
+//! the last persisted STATE — re-emitting the boundary record — so a keyed
+//! (upsert) sink is what turns at-least-once redelivery into no-duplicates.
+//!
+//! Invariants asserted (the "effectively-once" proof):
+//!   1. No loss — after a successful resume the sink holds every id.
+//!   2. No duplicates with a keyed/idempotent sink — each id appears once.
+//!   3. Checkpoint never ahead of durable data — a persisted bookmark never
+//!      references a record not already written to the sink (asserted at *every*
+//!      checkpoint, across the crash, not just at the end).
+//!   4. Monotonic checkpoints — the persisted bookmark never moves backward.
+//!   5. Empty-with-bookmark — a tail that is only a STATE still advances the
+//!      checkpoint and loses nothing.
+//!
+//! Case count defaults to 256; override with `PROPTEST_CASES=<n>` (proptest
+//! reads it automatically), e.g. `PROPTEST_CASES=4096 cargo test -p
+//! faucet-source-singer --test resume_proptest`.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use faucet_core::{StreamPage, Value};
+use faucet_source_singer::assemble::PageAssembler;
+use proptest::prelude::*;
+use serde_json::json;
+
+const STREAM: &str = "s";
+
+/// A record shaped like the fake tap's output (`{"id":N,"name":"row-N"}`).
+fn rec(id: i64) -> Value {
+    json!({ "id": id, "name": format!("row-{id}") })
+}
+
+/// One line of a modeled tap script.
+#[derive(Debug, Clone)]
+enum Msg {
+    /// A RECORD for the target stream with the given id.
+    Record(i64),
+    /// A STATE checkpoint referencing the last emitted record id.
+    State(i64),
+}
+
+/// In-memory stand-in for a keyed/upsert sink + a durable state store, wired in
+/// the pipeline's write-then-checkpoint order. Enforces invariants 3 & 4 the
+/// moment a checkpoint is persisted, so a regression is caught mid-run.
+struct Model {
+    /// Keyed (upsert) sink: a re-delivered id overwrites rather than duplicates.
+    sink: BTreeMap<i64, Value>,
+    /// Every row ever handed to the sink — proves overlap really happened.
+    total_writes: usize,
+    /// The single persisted state bookmark (`{"last_id": N}`), or `None`.
+    store: Option<Value>,
+    /// Last persisted `last_id`, for the monotonicity check.
+    last_ck: Option<i64>,
+    /// Every record id in the *full* script — the ground truth for "durable".
+    all_ids: BTreeSet<i64>,
+}
+
+impl Model {
+    fn new(all_ids: BTreeSet<i64>) -> Self {
+        Self {
+            sink: BTreeMap::new(),
+            total_writes: 0,
+            store: None,
+            last_ck: None,
+            all_ids,
+        }
+    }
+
+    /// Apply one page exactly as `Pipeline::run` does: durably write the records
+    /// first, then (only if the page carries one) persist the bookmark.
+    fn process(&mut self, page: StreamPage) {
+        // 1. Durable write (records become visible in the sink).
+        for r in &page.records {
+            let id = r
+                .get("id")
+                .and_then(Value::as_i64)
+                .expect("modeled record always has an integer id");
+            self.sink.insert(id, r.clone());
+            self.total_writes += 1;
+        }
+
+        // 2. Checkpoint — strictly after the write confirms.
+        if let Some(bm) = page.bookmark {
+            let x = bm
+                .get("last_id")
+                .and_then(Value::as_i64)
+                .expect("modeled STATE always carries last_id");
+
+            // INVARIANT 4: checkpoints never regress.
+            if let Some(prev) = self.last_ck {
+                assert!(
+                    x >= prev,
+                    "checkpoint moved backward: {prev} -> {x} (page bookmark {bm})"
+                );
+            }
+
+            // INVARIANT 3: the checkpoint is never ahead of durable data — every
+            // record id at or below the bookmark must already be in the sink.
+            for id in self.all_ids.iter().copied().filter(|&id| id <= x) {
+                assert!(
+                    self.sink.contains_key(&id),
+                    "bookmark last_id={x} persisted while record id={id} is not \
+                     yet durable in the sink"
+                );
+            }
+
+            self.last_ck = Some(x);
+            self.store = Some(bm);
+        }
+    }
+
+    /// The resume cursor a real tap would receive via `--state` (0 = fresh).
+    fn cursor(&self) -> i64 {
+        self.store
+            .as_ref()
+            .and_then(|v| v.get("last_id"))
+            .and_then(Value::as_i64)
+            .unwrap_or(0)
+    }
+
+    fn sink_ids(&self) -> Vec<i64> {
+        self.sink.keys().copied().collect()
+    }
+}
+
+/// Build the full tap script from record ids + per-record "checkpoint after"
+/// flags + an optional forced trailing STATE (a clean tap's final checkpoint).
+fn build_msgs(ids: &[i64], ck_after: &[bool], final_state: bool) -> Vec<Msg> {
+    let mut v = Vec::new();
+    for (i, &id) in ids.iter().enumerate() {
+        v.push(Msg::Record(id));
+        if ck_after.get(i).copied().unwrap_or(false) {
+            v.push(Msg::State(id));
+        }
+    }
+    if final_state && let Some(&last) = ids.last() {
+        // Only if a STATE for the last id isn't already the tail.
+        if !matches!(v.last(), Some(Msg::State(x)) if *x == last) {
+            v.push(Msg::State(last));
+        }
+    }
+    v
+}
+
+/// A real Singer tap resumes *coarsely*: given a persisted `cursor` it re-emits
+/// from the first record whose id is >= cursor (re-emitting the boundary), with
+/// the same interleaved STATEs. `cursor <= 0` replays from the start.
+fn coarse_resume(full: &[Msg], cursor: i64) -> Vec<Msg> {
+    if cursor <= 0 {
+        return full.to_vec();
+    }
+    match full
+        .iter()
+        .position(|m| matches!(m, Msg::Record(id) if *id >= cursor))
+    {
+        Some(i) => full[i..].to_vec(),
+        None => Vec::new(),
+    }
+}
+
+/// Feed a message sequence through a fresh assembler into `model`.
+///
+/// `crash_after == Some(k)`: the tap emits `k` messages then exits non-zero —
+/// the trailing buffer is dropped and `on_eof` is **not** called (no
+/// un-checkpointed page is committed). `None`: a clean run ending in `on_eof`.
+fn run_pass(
+    model: &mut Model,
+    batch_size: usize,
+    flush_on_state: bool,
+    msgs: &[Msg],
+    crash_after: Option<usize>,
+) {
+    let mut asm = PageAssembler::new(STREAM, batch_size, flush_on_state);
+    let limit = crash_after.map(|k| k.min(msgs.len())).unwrap_or(msgs.len());
+    for m in &msgs[..limit] {
+        let page = match m {
+            Msg::Record(id) => asm.on_record(STREAM, rec(*id)),
+            Msg::State(v) => asm.on_state(json!({ "last_id": v })),
+        };
+        if let Some(page) = page {
+            model.process(page);
+        }
+    }
+    if crash_after.is_none()
+        && let Some(page) = asm.on_eof()
+    {
+        model.process(page);
+    }
+}
+
+/// Run one full crash-then-resume scenario and assert every invariant.
+fn check_scenario(
+    ids: Vec<i64>,
+    ck_after: Vec<bool>,
+    final_state: bool,
+    batch_size: usize,
+    flush_on_state: bool,
+    crash: Option<usize>,
+) {
+    let full = build_msgs(&ids, &ck_after, final_state);
+    let all_ids: BTreeSet<i64> = ids.iter().copied().collect();
+    let mut model = Model::new(all_ids);
+
+    // ── Run 1: may crash. Invariants 3 & 4 are checked inside `process`. ──
+    run_pass(&mut model, batch_size, flush_on_state, &full, crash);
+
+    // The checkpoint must point at durably-written data (invariant 3 at the run
+    // boundary): a non-zero cursor is always an id already in the sink.
+    let cursor = model.cursor();
+    if cursor > 0 {
+        assert!(
+            model.sink.contains_key(&cursor),
+            "resume cursor last_id={cursor} is not durable after run 1"
+        );
+    }
+
+    // ── Run 2: resume from the persisted cursor, replay coarsely, finish. ──
+    let replay = coarse_resume(&full, cursor);
+    run_pass(&mut model, batch_size, flush_on_state, &replay, None);
+
+    // INVARIANT 1 (no loss) + 2 (no duplicates, via the keyed sink): the final
+    // sink holds exactly every id, each once.
+    assert_eq!(
+        model.sink_ids(),
+        ids,
+        "after resume the sink must reconstruct every id exactly once \
+         (batch_size={batch_size}, flush_on_state={flush_on_state}, crash={crash:?})"
+    );
+
+    // The keyed sink must have seen at least every unique id (overlap on resume
+    // only ever adds writes; it never drops one).
+    assert!(
+        model.total_writes >= ids.len(),
+        "total writes {} < unique ids {}",
+        model.total_writes,
+        ids.len()
+    );
+}
+
+/// Strictly-increasing ids (1..) paired with a "checkpoint after" flag, built
+/// from small positive gaps so the sequence is monotonic but not necessarily
+/// contiguous.
+fn script_strategy() -> impl Strategy<Value = (Vec<i64>, Vec<bool>)> {
+    prop::collection::vec((1i64..=5, any::<bool>()), 0..=25).prop_map(|pairs| {
+        let mut acc = 0i64;
+        let mut ids = Vec::with_capacity(pairs.len());
+        let mut ck = Vec::with_capacity(pairs.len());
+        for (gap, checkpoint) in pairs {
+            acc += gap;
+            ids.push(acc);
+            ck.push(checkpoint);
+        }
+        (ids, ck)
+    })
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 256, ..ProptestConfig::default() })]
+
+    /// Arbitrary interleavings × arbitrary crash points × page/flush config all
+    /// satisfy the five resume invariants.
+    #[test]
+    fn resume_invariants_hold(
+        (ids, ck_after) in script_strategy(),
+        final_state in any::<bool>(),
+        batch_size in 0usize..=8,
+        flush_on_state in any::<bool>(),
+        // `None` = clean run; `Some(k)` = crash after k emitted messages
+        // (clamped to the script length in the harness). Covers crashes
+        // before/after a STATE, mid-page, and at page boundaries.
+        crash in prop_oneof![Just(None), (0usize..=60).prop_map(Some)],
+    ) {
+        check_scenario(ids, ck_after, final_state, batch_size, flush_on_state, crash);
+    }
+}
+
+// ─────────────────────────── targeted regression cases ───────────────────────
+// Deterministic corners the generator only rarely hits.
+
+/// Crash in the gap *between* "page written" and "checkpoint persisted": the
+/// records are durable but the bookmark never advances. Resume from the *old*
+/// cursor must redeliver and dedup — no loss, no duplicates.
+#[test]
+fn crash_between_write_and_checkpoint_loses_nothing() {
+    let ids = vec![1, 2, 3, 4];
+    let all_ids: BTreeSet<i64> = ids.iter().copied().collect();
+    let mut model = Model::new(all_ids);
+
+    // A state-bearing page is produced and its records are written…
+    let mut asm = PageAssembler::new(STREAM, 1000, true);
+    assert!(asm.on_record(STREAM, rec(1)).is_none());
+    assert!(asm.on_record(STREAM, rec(2)).is_none());
+    let page = asm
+        .on_state(json!({ "last_id": 2 }))
+        .expect("flush on state");
+    // …but the process dies before the bookmark is persisted: write only.
+    for r in &page.records {
+        let id = r["id"].as_i64().unwrap();
+        model.sink.insert(id, r.clone());
+        model.total_writes += 1;
+    }
+    // Cursor never advanced.
+    assert_eq!(model.cursor(), 0);
+    assert_eq!(model.sink_ids(), vec![1, 2]);
+
+    // Resume from the old cursor (0): the tap replays the whole script.
+    let full = build_msgs(&ids, &[false, true, false, true], true);
+    let replay = coarse_resume(&full, model.cursor());
+    let writes_before = model.total_writes;
+    run_pass(&mut model, 1000, true, &replay, None);
+
+    // Overlap really happened (1 and 2 were re-delivered)…
+    assert!(model.total_writes > writes_before + 2);
+    // …and the keyed sink deduped it: every id, once.
+    assert_eq!(model.sink_ids(), vec![1, 2, 3, 4]);
+    assert_eq!(model.cursor(), 4);
+}
+
+/// A STATE arriving mid-page (with `flush_on_state = false`) is deferred and
+/// attached to the next size-based flush; the checkpoint it carries is still
+/// backed by already-written records (invariant 3).
+#[test]
+fn state_mid_page_defers_and_stays_backed() {
+    let ids = [1, 2, 3];
+    let all_ids: BTreeSet<i64> = ids.iter().copied().collect();
+    let mut model = Model::new(all_ids);
+
+    let mut asm = PageAssembler::new(STREAM, 3, false);
+    assert!(asm.on_record(STREAM, rec(1)).is_none());
+    // STATE mid-page: recorded as pending, no flush.
+    assert!(asm.on_state(json!({ "last_id": 1 })).is_none());
+    assert!(asm.on_record(STREAM, rec(2)).is_none());
+    // Size threshold reached: page carries [1,2,3] with the deferred bookmark.
+    let page = asm.on_record(STREAM, rec(3)).expect("size flush at 3");
+    assert_eq!(page.bookmark, Some(json!({ "last_id": 1 })));
+    // `process` asserts invariant 3 (record 1 is written before last_id=1 is
+    // persisted) and invariant 4 internally.
+    model.process(page);
+    assert_eq!(model.sink_ids(), vec![1, 2, 3]);
+    assert_eq!(model.cursor(), 1);
+}
+
+/// Invariant 5: a script whose only tail is a STATE (an empty page carrying a
+/// bookmark) still advances the checkpoint and loses nothing.
+#[test]
+fn empty_page_with_trailing_state_advances_checkpoint() {
+    // batch_size=1 forces record 1 out as a bookmark-less page; the following
+    // STATE then produces an *empty* page carrying the bookmark.
+    let mut asm = PageAssembler::new(STREAM, 1, true);
+    let first = asm.on_record(STREAM, rec(1)).expect("size flush at 1");
+    assert!(first.bookmark.is_none());
+    let empty = asm.on_state(json!({ "last_id": 1 })).expect("state flush");
+    assert!(empty.records.is_empty(), "trailing-state page is empty");
+    assert_eq!(empty.bookmark, Some(json!({ "last_id": 1 })));
+
+    let mut model = Model::new([1].into_iter().collect());
+    model.process(first);
+    model.process(empty); // invariant 3 holds: record 1 durable before last_id=1
+    assert_eq!(model.cursor(), 1);
+    assert_eq!(model.sink_ids(), vec![1]);
+}


### PR DESCRIPTION
## What & why

The last engineering residue before launch — three independent hardening items, one commit each.

### 1. Property tests for the resume/checkpoint state machine (`test`)
Generalizes the single hand-written crash-resume case in `integration.rs` into `proptest` coverage over **arbitrary** Singer message interleavings × **arbitrary** crash points. Drives the pure `PageAssembler` (`assemble.rs`) plus a faithful model of the pipeline's **write-then-checkpoint** loop with in-memory sink/state doubles — deterministic, no subprocess. Asserts the five effectively-once invariants:
1. No loss · 2. No duplicates (keyed sink) · 3. Checkpoint never ahead of durable data (checked *across* the crash) · 4. Monotonic checkpoints · 5. Empty-with-bookmark.

Plus 3 targeted regression cases (crash in the write→persist gap; STATE mid-page; empty trailing-STATE page). Mutation-verified the suite fails on a broken `on_eof`. Green at `PROPTEST_CASES=4096`.

### 2. `cargo-semver-checks` API-stability gate (`ci`)
New CI job comparing `faucet-core`'s public API against its crates.io baseline; fails on any breaking change so the connector trait surface (**FCP §8**) can only break with a deliberate major-version bump — no bypass. Verified locally: **223 checks pass, no semver update required** vs the published 1.4.0. Policy documented in `CONTRIBUTING.md`. Added to `main`'s branch-protection required set.

### 3. Benchmark batch disclosure (`bench`)
Scenario C now states the write-batch size **and** insert strategy on both sides — both pinned to 5,000-row batches (`meltano.yml` → `batch_size_rows: 5000`, matching faucet's `batch_size: 5000`) — and notes `meltanolabs-target-postgres`'s opt-in `use_copy` COPY path (left off), correcting a misleading "cannot follow" line. The committed numbers predate the batch pin and are flagged **`TODO: run locally`** with the exact command; not re-measured here (Meltano venv not installed) — never fabricated.

## Verification (local)
`cargo fmt --all --check` ✅ · singer `clippy --all-targets` ✅ · singer tests incl. proptests ✅ (39) · `cargo deny check bans licenses sources` ✅ · `mdbook build docs/book` ✅ · `cargo semver-checks check-release -p faucet-core` ✅

## Notes
- Delivery guarantee referred to as **effectively-once** throughout.
- **`faucet-core` changes: none** — the property tests use test-only doubles, not a trait seam.

Addresses #91 (1.0 launch polish); part of the roadmap epic #38.