### PR TITLE
feat(delta): Apache Delta Lake source + sink via delta-rs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,7 @@ jobs:
           - source-kafka
           - source-kinesis
           - source-parquet
+          - source-delta
           - source-gcs
           - source-bigquery
           - source-snowflake
@@ -191,6 +192,7 @@ jobs:
           - sink-kinesis
           - sink-spanner
           - sink-parquet
+          - sink-delta
           - sink-gcs
           # Kafka extras
           - kafka-schema-registry

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,6 +227,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ar_archive_writer"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4087686b4b0a3427190bae57a1d9a478dbb2d40c5dc1bd6e2b6d797913bdd348"
+dependencies = [
+ "object",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,6 +364,7 @@ dependencies = [
  "arrow-data 58.3.0",
  "arrow-schema 58.3.0",
  "chrono",
+ "chrono-tz",
  "half",
  "hashbrown 0.17.1",
  "num-complex",
@@ -627,6 +637,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed"
 dependencies = [
  "bitflags 2.13.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -872,8 +884,8 @@ dependencies = [
  "aws-sdk-ssooidc",
  "aws-sdk-sts",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.5",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -892,9 +904,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.14"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f20799b373a1be121fe3005fba0c2090af9411573878f224df44b42727fcaf7"
+checksum = "e93964ffdaf57857f544be3666a5f57570bb699e934700f11b49708f61bb556e"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -927,15 +939,15 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.7.3"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dcd93c82209ac7413532388067dce79be5a8780c1786e5fae3df22e4dee2864"
+checksum = "7816e98ee912159f45d307e5ee6bfea4a335a55aee15f7f3e32f81a6f3000f1d"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "aws-smithy-async",
- "aws-smithy-eventstream",
- "aws-smithy-http",
+ "aws-smithy-eventstream 0.61.1",
+ "aws-smithy-http 0.64.0",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -954,6 +966,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-dynamodb"
+version = "1.117.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f2b4adcf6592e06ebb2c78235ae09cee178263a5b7fc20ae5ea07ca67067bb6"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.64.0",
+ "aws-smithy-json 0.63.0",
+ "aws-smithy-observability 0.3.0",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
 name = "aws-sdk-glue"
 version = "1.145.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -962,9 +1000,9 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-observability",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.5",
+ "aws-smithy-observability 0.2.6",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -986,10 +1024,10 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-eventstream",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-observability",
+ "aws-smithy-eventstream 0.60.20",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.5",
+ "aws-smithy-observability 0.2.6",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -1013,10 +1051,10 @@ dependencies = [
  "aws-sigv4",
  "aws-smithy-async",
  "aws-smithy-checksums",
- "aws-smithy-eventstream",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-observability",
+ "aws-smithy-eventstream 0.60.20",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.5",
+ "aws-smithy-observability 0.2.6",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -1046,9 +1084,9 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-observability",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.5",
+ "aws-smithy-observability 0.2.6",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -1070,9 +1108,9 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-observability",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.5",
+ "aws-smithy-observability 0.2.6",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -1094,9 +1132,9 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-observability",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.5",
+ "aws-smithy-observability 0.2.6",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -1118,9 +1156,9 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-observability",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.5",
+ "aws-smithy-observability 0.2.6",
  "aws-smithy-query",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -1136,25 +1174,24 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.4.3"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68dc0b907359b120170613b5c09ccc61304eac3998ff6274b97d93ee6490115a"
+checksum = "723c2234ad7511ceef63eab016b7ba6ff7c55590fefb96fa8467af014a07309f"
 dependencies = [
  "aws-credential-types",
- "aws-smithy-eventstream",
- "aws-smithy-http",
+ "aws-smithy-eventstream 0.61.1",
+ "aws-smithy-http 0.64.0",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
- "crypto-bigint 0.5.5",
+ "crypto-bigint",
  "form_urlencoded",
  "hex",
  "hmac 0.13.0",
  "http 0.2.12",
  "http 1.4.0",
- "p256 0.11.1",
+ "p256",
  "percent-encoding",
- "ring",
  "sha2 0.11.0",
  "subtle",
  "time",
@@ -1164,9 +1201,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.14"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
+checksum = "f02e407fb3b54891734224b9ffac8a71fdd35f542500fa1af95754a6b2beb316"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -1179,7 +1216,7 @@ version = "0.64.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10efbbcec1e044b81600e2fc562a391951d291152d95b482d5b7e7132299d762"
 dependencies = [
- "aws-smithy-http",
+ "aws-smithy-http 0.63.6",
  "aws-smithy-types",
  "bytes",
  "crc-fast",
@@ -1206,12 +1243,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-eventstream"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9381123ab62d20c13082b151f30f962a3b112b727345394536dfa39a482944"
+dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
 name = "aws-smithy-http"
 version = "0.63.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
 dependencies = [
- "aws-smithy-eventstream",
+ "aws-smithy-eventstream 0.60.20",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.64.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37843d9add67c3aff5856f409c6dc315d3cdff60f9c0cb5b670dab1e9920306d"
+dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -1229,9 +1298,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.1.12"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a2f165a7feee6f263028b899d0a181987f4fa7179a6411a32a439fba7c5f769"
+checksum = "635d23afda0a6ab48d666c4d447c4873e8d1e83518a2be2093122397e50b838e"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -1267,10 +1336,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-json"
+version = "0.63.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dc65a121adb4b33729919fcfa14fa36fb33c1555a8f06bb0e2188dbfdc1d9ef"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+]
+
+[[package]]
 name = "aws-smithy-observability"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e86338c869539a581bf161247762a6e87f92c5c075060057b5ed6d06632ed0c"
 dependencies = [
  "aws-smithy-runtime-api",
 ]
@@ -1287,15 +1376,16 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0504b1ab12debb5959e5165ee5fe97dd387e7aa7ea6a477bfd7635dfe769a4f5"
+checksum = "bea94a9ff8464016338c851e24b472d7131c388c88898a502e781815b2ee6045"
 dependencies = [
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.64.0",
  "aws-smithy-http-client",
- "aws-smithy-observability",
+ "aws-smithy-observability 0.3.0",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "bytes",
  "fastrand",
@@ -1312,9 +1402,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71a13df6ada0aafbf21a73bdfcdf9324cfa9df77d96b8446045be3cde61b42e"
+checksum = "22ed1ebe6e0a95ea84570225f5a8208dec4b8f77e61a9b0d6f51773fcb4612f0"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
@@ -1330,9 +1420,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api-macros"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
+checksum = "221eaa237ddf1ca79b60d1372aad77e47f9c0ea5b3ce5099da8c61d027dc77b3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1340,10 +1430,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-types"
-version = "1.4.7"
+name = "aws-smithy-schema"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d73dbfbaa8e4bc57b9045137680b958d274823509a360abfd8e1d514d40c95c"
+checksum = "7d56e0a4e53127a632224e43633b0fe045fa9e1e3cfc68b9830f1115e103f910"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "http 1.4.0",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6dc683efb34b9e755675b37fedbe0103141e5b6df7bdc9eb6967756a8c167d8"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -1376,13 +1477,14 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.15"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bbcaa9304ea40902d3d5f42a0428d1bd895a2b0f6999436fb279ffddc58ac"
+checksum = "e957a6c6dbce82b7a91f44231c09273159703769f447cbe85e854dfe9cf67f86"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "rustc_version",
  "tracing",
@@ -1518,12 +1620,6 @@ dependencies = [
  "gloo-timers",
  "tokio",
 ]
-
-[[package]]
-name = "base16ct"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
 name = "base16ct"
@@ -1913,6 +2009,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "buoyant_kernel"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2235eb320cd7178862a32dd111bd0c0f71a368e393add4914c50129add478eab"
+dependencies = [
+ "arrow 58.3.0",
+ "buoyant_kernel_derive",
+ "bytes",
+ "chrono",
+ "crc",
+ "futures",
+ "indexmap 2.14.0",
+ "itertools 0.14.0",
+ "object_store",
+ "parquet 58.3.0",
+ "percent-encoding",
+ "rand 0.9.4",
+ "reqwest 0.13.3",
+ "roaring",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "strum 0.27.2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+ "uuid",
+ "z85",
+]
+
+[[package]]
+name = "buoyant_kernel_derive"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5cdc90bb920438aa9a39089b76f0614183af303f181bf18d05b456a30dd9740"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "by_address"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2276,6 +2416,15 @@ dependencies = [
 
 [[package]]
 name = "convert_case"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db05ffb6856bf0ecdf6367558a76a0e8a77b1713044eb92845c692100ed50190"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
@@ -2510,18 +2659,6 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
-dependencies = [
- "generic-array",
- "rand_core 0.6.4",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "crypto-bigint"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
@@ -2599,6 +2736,23 @@ checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "ctor"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83cf0d42651b16c6dfe68685716d18480d18a9c39c62d76e8cf3eb6ed5d8bcbf"
+dependencies = [
+ "ctor-proc-macro",
+ "dtor",
+ "link-section",
+]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a949c44fcacbbbb7ada007dc7acb34603dd97cd47de5d054f2b6493ecebb483"
 
 [[package]]
 name = "ctr"
@@ -2759,13 +2913,139 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
-name = "der"
-version = "0.6.1"
+name = "deltalake"
+version = "0.32.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
+checksum = "2695b91fd02afd5b4726a190fd58019674492d824e30598391390b0307644da8"
 dependencies = [
- "const-oid 0.9.6",
- "zeroize",
+ "buoyant_kernel",
+ "ctor",
+ "deltalake-aws",
+ "deltalake-azure",
+ "deltalake-core",
+ "deltalake-gcp",
+]
+
+[[package]]
+name = "deltalake-aws"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3ef837d5d58bb0cd62dc9ee3bc201805751090f4bab2ca0ff09669661814fd4"
+dependencies = [
+ "async-trait",
+ "aws-config",
+ "aws-credential-types",
+ "aws-sdk-dynamodb",
+ "aws-sdk-sts",
+ "aws-smithy-runtime-api",
+ "backon",
+ "bytes",
+ "chrono",
+ "deltalake-core",
+ "futures",
+ "object_store",
+ "regex",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "typed-builder 0.23.2",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "deltalake-azure"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1b7099351f8d452374d75eda599cd7633a50f4a36ec318532ec6c5d1f9d908d"
+dependencies = [
+ "bytes",
+ "deltalake-core",
+ "object_store",
+ "thiserror 2.0.18",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "deltalake-core"
+version = "0.32.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4588e95ff3b2ccdba56d9ec262bd3467c0593000f729402528706f62be8be1ca"
+dependencies = [
+ "arrow 58.3.0",
+ "arrow-arith 58.3.0",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-cast 58.3.0",
+ "arrow-ipc 58.3.0",
+ "arrow-json 58.3.0",
+ "arrow-ord 58.3.0",
+ "arrow-row 58.3.0",
+ "arrow-schema 58.3.0",
+ "arrow-select 58.3.0",
+ "async-trait",
+ "buoyant_kernel",
+ "bytes",
+ "cfg-if",
+ "chrono",
+ "dashmap",
+ "deltalake-derive",
+ "dirs",
+ "either",
+ "futures",
+ "humantime",
+ "indexmap 2.14.0",
+ "itertools 0.14.0",
+ "num_cpus",
+ "object_store",
+ "parking_lot",
+ "parquet 58.3.0",
+ "percent-encoding",
+ "percent-encoding-rfc3986",
+ "pin-project-lite",
+ "rand 0.10.1",
+ "regex",
+ "serde",
+ "serde_json",
+ "sqlparser",
+ "strum 0.27.2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
+ "validator",
+]
+
+[[package]]
+name = "deltalake-derive"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5a646e2b05608db1e5f91e75b6af841d92294ea0864789bb01f3f818e5f7b25"
+dependencies = [
+ "convert_case 0.9.0",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "deltalake-gcp"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "909d4c00c77ed1359e2d3b6a25641740f7a068a8c20e951e479e1212e67004ea"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "deltalake-core",
+ "futures",
+ "object_store",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -2868,7 +3148,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
- "convert_case",
+ "convert_case 0.10.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -2904,6 +3184,27 @@ dependencies = [
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
  "ctutils",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2959,6 +3260,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "dtor"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edf234dd1594d6dd434a8fb8cada51ddbbc593e40e4a01556a0b31c62da2775b"
+dependencies = [
+ "dtor-proc-macro",
+]
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2647271c92754afcb174e758003cfd1cbf1e43e5a7853d7b1813e63e19e39a73"
+
+[[package]]
 name = "duckdb"
 version = "1.10503.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3003,28 +3319,16 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecdsa"
-version = "0.14.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
-dependencies = [
- "der 0.6.1",
- "elliptic-curve 0.12.3",
- "rfc6979 0.3.1",
- "signature 1.6.4",
-]
-
-[[package]]
-name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der 0.7.10",
+ "der",
  "digest 0.10.7",
- "elliptic-curve 0.13.8",
- "rfc6979 0.4.0",
- "signature 2.2.0",
- "spki 0.7.3",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
 ]
 
 [[package]]
@@ -3033,8 +3337,8 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8 0.10.2",
- "signature 2.2.0",
+ "pkcs8",
+ "signature",
 ]
 
 [[package]]
@@ -3062,41 +3366,21 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
-dependencies = [
- "base16ct 0.1.1",
- "crypto-bigint 0.4.9",
- "der 0.6.1",
- "digest 0.10.7",
- "ff 0.12.1",
- "generic-array",
- "group 0.12.1",
- "pkcs8 0.9.0",
- "rand_core 0.6.4",
- "sec1 0.3.0",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "elliptic-curve"
 version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct 0.2.0",
- "crypto-bigint 0.5.5",
+ "base16ct",
+ "crypto-bigint",
  "digest 0.10.7",
- "ff 0.13.1",
+ "ff",
  "generic-array",
- "group 0.13.0",
+ "group",
  "hkdf",
  "pem-rfc7468",
- "pkcs8 0.10.2",
+ "pkcs8",
  "rand_core 0.6.4",
- "sec1 0.7.3",
+ "sec1",
  "subtle",
  "zeroize",
 ]
@@ -3381,6 +3665,7 @@ dependencies = [
  "faucet-lineage",
  "faucet-sink-bigquery",
  "faucet-sink-csv",
+ "faucet-sink-delta",
  "faucet-sink-elasticsearch",
  "faucet-sink-gcs",
  "faucet-sink-http",
@@ -3401,6 +3686,7 @@ dependencies = [
  "faucet-sink-stdout",
  "faucet-source-bigquery",
  "faucet-source-csv",
+ "faucet-source-delta",
  "faucet-source-elasticsearch",
  "faucet-source-gcs",
  "faucet-source-graphql",
@@ -3479,6 +3765,22 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+]
+
+[[package]]
+name = "faucet-common-delta"
+version = "1.0.0"
+dependencies = [
+ "arrow 58.3.0",
+ "arrow-json 58.3.0",
+ "chrono",
+ "deltalake",
+ "faucet-core",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -3698,6 +4000,26 @@ dependencies = [
  "csv",
  "faucet-conformance",
  "faucet-core",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "faucet-sink-delta"
+version = "1.0.0"
+dependencies = [
+ "arrow 58.3.0",
+ "arrow-json 58.3.0",
+ "async-trait",
+ "deltalake",
+ "faucet-common-delta",
+ "faucet-conformance",
+ "faucet-core",
+ "faucet-source-delta",
  "schemars 1.2.1",
  "serde",
  "serde_json",
@@ -4094,6 +4416,28 @@ dependencies = [
  "faucet-conformance",
  "faucet-core",
  "futures",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "faucet-source-delta"
+version = "1.0.0"
+dependencies = [
+ "arrow 58.3.0",
+ "async-stream",
+ "async-trait",
+ "deltalake",
+ "faucet-common-delta",
+ "faucet-conformance",
+ "faucet-core",
+ "futures",
+ "object_store",
+ "parquet 58.3.0",
  "schemars 1.2.1",
  "serde",
  "serde_json",
@@ -4661,6 +5005,7 @@ dependencies = [
  "faucet-lineage",
  "faucet-sink-bigquery",
  "faucet-sink-csv",
+ "faucet-sink-delta",
  "faucet-sink-elasticsearch",
  "faucet-sink-gcs",
  "faucet-sink-http",
@@ -4681,6 +5026,7 @@ dependencies = [
  "faucet-sink-stdout",
  "faucet-source-bigquery",
  "faucet-source-csv",
+ "faucet-source-delta",
  "faucet-source-elasticsearch",
  "faucet-source-gcs",
  "faucet-source-graphql",
@@ -4737,16 +5083,6 @@ dependencies = [
  "portable-atomic",
  "rand 0.10.1",
  "web-time",
-]
-
-[[package]]
-name = "ff"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
-dependencies = [
- "rand_core 0.6.4",
- "subtle",
 ]
 
 [[package]]
@@ -5466,22 +5802,11 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
-dependencies = [
- "ff 0.12.1",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff 0.13.1",
+ "ff",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -6574,7 +6899,7 @@ dependencies = [
  "getrandom 0.2.17",
  "hmac 0.12.1",
  "js-sys",
- "p256 0.13.2",
+ "p256",
  "p384",
  "pem",
  "rand 0.8.6",
@@ -6582,7 +6907,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "signature 2.2.0",
+ "signature",
  "simple_asn1",
  "zeroize",
 ]
@@ -6776,6 +7101,12 @@ checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
  "bitflags 2.13.0",
 ]
+
+[[package]]
+name = "link-section"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b685d66585d646efe09fec763d796c291049c8b6bf84e04954bffc8748341f0d"
 
 [[package]]
 name = "linked-hash-map"
@@ -7673,6 +8004,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "object_store"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7688,6 +8028,7 @@ dependencies = [
  "futures-util",
  "http 1.4.0",
  "http-body-util",
+ "httparse",
  "humantime",
  "hyper 1.9.0",
  "itertools 0.14.0",
@@ -7878,6 +8219,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "ordered-float"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7934,23 +8281,12 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "p256"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
-dependencies = [
- "ecdsa 0.14.8",
- "elliptic-curve 0.12.3",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
- "ecdsa 0.16.9",
- "elliptic-curve 0.13.8",
+ "ecdsa",
+ "elliptic-curve",
  "primeorder",
  "sha2 0.10.9",
 ]
@@ -7961,8 +8297,8 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
 dependencies = [
- "ecdsa 0.16.9",
- "elliptic-curve 0.13.8",
+ "ecdsa",
+ "elliptic-curve",
  "primeorder",
  "sha2 0.10.9",
 ]
@@ -8167,6 +8503,12 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "percent-encoding-rfc3986"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3637c05577168127568a64e9dc5a6887da720efef07b3d9472d45f63ab191166"
 
 [[package]]
 name = "pest"
@@ -8402,9 +8744,9 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der 0.7.10",
- "pkcs8 0.10.2",
- "spki 0.7.3",
+ "der",
+ "pkcs8",
+ "spki",
 ]
 
 [[package]]
@@ -8415,21 +8757,11 @@ checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
 dependencies = [
  "aes 0.8.4",
  "cbc",
- "der 0.7.10",
+ "der",
  "pbkdf2",
  "scrypt",
  "sha2 0.10.9",
- "spki 0.7.3",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
-dependencies = [
- "der 0.6.1",
- "spki 0.6.0",
+ "spki",
 ]
 
 [[package]]
@@ -8438,10 +8770,10 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der 0.7.10",
+ "der",
  "pkcs5",
  "rand_core 0.6.4",
- "spki 0.7.3",
+ "spki",
 ]
 
 [[package]]
@@ -8587,7 +8919,7 @@ version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
- "elliptic-curve 0.13.8",
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -8636,9 +8968,9 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
- "bit-set",
- "bit-vec",
- "bitflags",
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
+ "bitflags 2.13.0",
  "num-traits",
  "rand 0.9.4",
  "rand_chacha 0.9.0",
@@ -8868,6 +9200,16 @@ dependencies = [
  "miette",
  "prost-types 0.14.3",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
 ]
 
 [[package]]
@@ -9337,6 +9679,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "recursive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0786a43debb760f491b1bc0269fe5e84155353c67482b9e60d0cfb596054b43e"
+dependencies = [
+ "recursive-proc-macro-impl",
+ "stacker",
+]
+
+[[package]]
+name = "recursive-proc-macro-impl"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76009fbe0614077fc1a2ce255e3a1881a2e3a3527097d5dc6d8212c585e7e38b"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "redis"
 version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9374,6 +9736,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
  "bitflags 2.13.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -9591,17 +9964,6 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "rfc6979"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
-dependencies = [
- "crypto-bigint 0.4.9",
- "hmac 0.12.1",
- "zeroize",
-]
-
-[[package]]
-name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
@@ -9704,11 +10066,11 @@ dependencies = [
  "num-integer",
  "num-traits",
  "pkcs1",
- "pkcs8 0.10.2",
+ "pkcs8",
  "rand_core 0.6.4",
  "sha2 0.10.9",
- "signature 2.2.0",
- "spki 0.7.3",
+ "signature",
+ "spki",
  "subtle",
  "zeroize",
 ]
@@ -10111,28 +10473,14 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "sec1"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
-dependencies = [
- "base16ct 0.1.1",
- "der 0.6.1",
- "generic-array",
- "pkcs8 0.9.0",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct 0.2.0",
- "der 0.7.10",
+ "base16ct",
+ "der",
  "generic-array",
- "pkcs8 0.10.2",
+ "pkcs8",
  "subtle",
  "zeroize",
 ]
@@ -10494,16 +10842,6 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
-dependencies = [
- "digest 0.10.7",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
@@ -10654,22 +10992,22 @@ checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
 name = "spki"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
-dependencies = [
- "base64ct",
- "der 0.6.1",
-]
-
-[[package]]
-name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der 0.7.10",
+ "der",
+]
+
+[[package]]
+name = "sqlparser"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf5ea8d4d7c808e1af1cbabebca9a2abe603bcefc22294c5b95018d53200cb7"
+dependencies = [
+ "log",
+ "recursive",
 ]
 
 [[package]]
@@ -10879,6 +11217,19 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stacker"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "640c8cdd92b6b12f5bcb1803ca3bbf5ab96e5e6b6b96b9ab77dabe9e880b3190"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "static_assertions"
@@ -11840,6 +12191,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-builder"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31aa81521b70f94402501d848ccc0ecaa8f93c8eb6999eb9747e72287757ffda"
+dependencies = [
+ "typed-builder-macro 0.23.2",
+]
+
+[[package]]
 name = "typed-builder-macro"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11855,6 +12215,17 @@ name = "typed-builder-macro"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e48cea23f68d1f78eb7bc092881b6bb88d3d6b5b7e6234f6f9c911da1ffb221"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "076a02dc54dd46795c2e9c8282ed40bcfb1e22747e955de9389a1de28190fb26"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12135,6 +12506,7 @@ dependencies = [
  "atomic",
  "getrandom 0.4.2",
  "js-sys",
+ "rand 0.10.1",
  "serde_core",
  "wasm-bindgen",
 ]
@@ -12147,6 +12519,36 @@ checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
 dependencies = [
  "outref",
  "vsimd",
+]
+
+[[package]]
+name = "validator"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0b4a29d8709210980a09379f27ee31549b73292c87ab9899beee1c0d3be6303"
+dependencies = [
+ "idna",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "url",
+ "validator_derive",
+]
+
+[[package]]
+name = "validator_derive"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bac855a2ce6f843beb229757e6e570a42e837bcb15e5f449dd48d5747d41bf77"
+dependencies = [
+ "darling 0.20.11",
+ "once_cell",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -13105,6 +13507,12 @@ dependencies = [
  "tokio",
  "url",
 ]
+
+[[package]]
+name = "z85"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6e61e59a957b7ccee15d2049f86e8bfd6f66968fcd88f018950662d9b86e675"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/common/mssql",
     "crates/common/kinesis",
     "crates/common/spanner",
+    "crates/common/delta",
     "crates/source/rest",
     "crates/source/singer",
     "crates/conformance",
@@ -41,6 +42,7 @@ members = [
     "crates/source/bigquery",
     "crates/source/snowflake",
     "crates/source/spanner",
+    "crates/source/delta",
     "crates/sink/bigquery",
     "crates/sink/postgres",
     "crates/sink/jsonl",
@@ -61,6 +63,7 @@ members = [
     "crates/sink/stdout",
     "crates/sink/parquet",
     "crates/sink/iceberg",
+    "crates/sink/delta",
     "crates/sink/spanner",
     "crates/state/redis",
     "crates/state/postgres",
@@ -92,6 +95,7 @@ faucet-common-kinesis = { path = "crates/common/kinesis", version = "1.0.0" }
 faucet-common-snowflake = { path = "crates/common/snowflake", version = "1.0.4" }
 faucet-common-spanner = { path = "crates/common/spanner", version = "1.0.0" }
 faucet-common-mssql = { path = "crates/common/mssql", version = "1.0.5" }
+faucet-common-delta = { path = "crates/common/delta", version = "1.0.0" }
 faucet-source-rest = { path = "crates/source/rest", version = "1.2.2" }
 faucet-source-singer = { path = "crates/source/singer", version = "1.0.0" }
 # Path-only on purpose: faucet-conformance is a test battery consumed only as
@@ -127,6 +131,7 @@ faucet-source-parquet = { path = "crates/source/parquet", version = "1.2.1" }
 faucet-source-bigquery = { path = "crates/source/bigquery", version = "1.1.3" }
 faucet-source-snowflake = { path = "crates/source/snowflake", version = "1.1.3" }
 faucet-source-spanner = { path = "crates/source/spanner", version = "1.0.0" }
+faucet-source-delta = { path = "crates/source/delta", version = "1.0.0" }
 faucet-sink-mysql = { path = "crates/sink/mysql", version = "1.3.0" }
 faucet-sink-sqlite = { path = "crates/sink/sqlite", version = "1.3.0" }
 faucet-sink-mssql = { path = "crates/sink/mssql", version = "1.3.0" }
@@ -143,6 +148,7 @@ faucet-sink-kinesis = { path = "crates/sink/kinesis", version = "1.0.0" }
 faucet-sink-stdout = { path = "crates/sink/stdout", version = "1.1.3" }
 faucet-sink-parquet = { path = "crates/sink/parquet", version = "1.1.3" }
 faucet-sink-iceberg = { path = "crates/sink/iceberg", version = "1.2.0" }
+faucet-sink-delta = { path = "crates/sink/delta", version = "1.0.0" }
 faucet-sink-spanner = { path = "crates/sink/spanner", version = "1.0.0" }
 faucet-state-redis = { path = "crates/state/redis", version = "1.0.5" }
 faucet-state-postgres = { path = "crates/state/postgres", version = "1.1.0" }
@@ -257,6 +263,12 @@ criterion = { version = "0.8", default-features = false, features = ["cargo_benc
 arrow-json = "58"
 parquet = { version = "58", features = ["async", "object_store"] }
 object_store = "0.13"
+# Delta Lake (delta-rs). Cloud backends (s3/azure/gcs) are opt-in crate
+# features; default `rustls` covers local FS. Pinned to the arrow-58 line,
+# matching the workspace arrow/parquet pins. datafusion is deliberately NOT
+# enabled — append uses the low-level RecordBatchWriter and reads enumerate
+# active parquet files directly, keeping the dependency tree slim.
+deltalake = { version = "0.32.4", default-features = false, features = ["rustls"] }
 async-compression = { version = "0.4", features = ["tokio", "gzip", "zstd"] }
 flate2 = "1"
 zstd = "0.13"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 **The fast, config-driven way to move data in Rust.**
 
-faucet-stream is a complete **ETL** toolkit: **25 source** and **20 sink** connectors
+faucet-stream is a complete **ETL** toolkit: **27 source** and **21 sink** connectors
 (**45 in total**) plus in-flight transforms — including a page-level embedded-DuckDB `sql`
 transform — wired together by a single `faucet` binary that runs pipelines declaratively
 from a YAML/JSON file, no Rust code required. Or skip the binary and embed the same engine
@@ -264,6 +264,7 @@ wired into the battery (see the support-tiers note above).
 | [`faucet-source-s3`](crates/source/s3) | T1 ✅ | AWS S3 — read objects as JSONL, JSON array, or raw text |
 | [`faucet-source-gcs`](crates/source/gcs) | T2 | Google Cloud Storage — read objects as JSONL, JSON array, or raw text |
 | [`faucet-source-parquet`](crates/source/parquet) | T1 ✅ | Apache Parquet — local file, glob, or S3; vectorized Arrow reader, projection |
+| [`faucet-source-delta`](crates/source/delta) | T2 | Apache Delta Lake — local FS or S3/Azure/GCS; time travel, projection pushdown |
 | [`faucet-source-elasticsearch`](crates/source/elasticsearch) | T1 ✅ᵐ | Elasticsearch — search/scroll API |
 | [`faucet-source-bigquery`](crates/source/bigquery) | T1 ✅ᵐ | Google BigQuery — `jobs.query` + `getQueryResults`, type-aware decoding |
 | [`faucet-source-snowflake`](crates/source/snowflake) | T1 ✅ᵐ | Snowflake — SQL REST API, server-side partition pagination, JWT / OAuth |
@@ -293,6 +294,7 @@ wired into the battery (see the support-tiers note above).
 | [`faucet-sink-s3`](crates/sink/s3) | T1 ✅ | AWS S3 — write JSONL files to bucket |
 | [`faucet-sink-gcs`](crates/sink/gcs) | T2 | Google Cloud Storage — write JSONL files to bucket |
 | [`faucet-sink-parquet`](crates/sink/parquet) | T1 ✅ | Apache Parquet — local file or S3; schema inference, row/byte rollover |
+| [`faucet-sink-delta`](crates/sink/delta) | T2 | Apache Delta Lake — append-only; local FS or S3/Azure/GCS; one commit per flush |
 | [`faucet-sink-jsonl`](crates/sink/jsonl) | **T1 ✅** | JSON Lines — file output with append/truncate |
 | [`faucet-sink-csv`](crates/sink/csv) | T1 ✅ | CSV — write JSON records as CSV rows |
 | [`faucet-sink-http`](crates/sink/http) | T1 ✅ᵐ | HTTP — POST records to any endpoint |
@@ -436,7 +438,7 @@ flowchart LR
     P -.->|metrics + spans| O
 ```
 
-faucet-stream is a Cargo workspace with **63 crates** — 26 sources, 20 sinks, 8 shared
+faucet-stream is a Cargo workspace with **66 crates** — 27 sources, 21 sinks, 9 shared
 connector libraries, the shared auth-provider library, 2 state-store backends, the lineage
 crate, the SQL transform crate, the conformance test battery, the shared core, the umbrella
 crate, and the CLI binary. See
@@ -497,6 +499,8 @@ Default features: `source-rest`, `transform-flatten`, `transform-rename-keys`,
 | `source-s3` | no | AWS S3 file source |
 | `source-gcs` | no | Google Cloud Storage file source |
 | `source-parquet` | no | Apache Parquet file source (local, glob, S3) |
+| `source-delta` | no | Apache Delta Lake source (local FS; S3/Azure/GCS via `delta-s3`/`delta-azure`/`delta-gcs`) |
+| `sink-delta` | no | Apache Delta Lake sink (local FS; S3/Azure/GCS via `delta-s3`/`delta-azure`/`delta-gcs`) |
 | `source-elasticsearch` | no | Elasticsearch source |
 | `source-bigquery` | no | Google BigQuery query source |
 | `source-snowflake` | no | Snowflake query source |
@@ -782,8 +786,8 @@ Cargo.toml                    — workspace manifest (60 crates)
 crates/
   core/                       — faucet-core: shared types, traits, pipeline, transforms, config
   auth/                       — faucet-auth: shared OAuth2 / token-endpoint providers
-  source/                     — 24 source connectors (rest, graphql, xml, grpc, *-cdc, kafka, s3, singer, …)
-  sink/                       — 18 sink connectors (bigquery, iceberg, postgres, parquet, kafka, …)
+  source/                     — 27 source connectors (rest, graphql, xml, grpc, *-cdc, kafka, s3, delta, singer, …)
+  sink/                       — 21 sink connectors (bigquery, iceberg, delta, postgres, parquet, kafka, …)
   common/                     — 6 shared connector libraries (bigquery, elasticsearch, gcs, kafka, snowflake, mssql)
   state/                      — Redis- and Postgres-backed StateStore backends
   lineage/                    — faucet-lineage: OpenLineage event emission

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -28,7 +28,7 @@ default = ["observability", "source", "sink", "state", "transforms", "compressio
 
 # Everything the default build ships, plus the long-running runtime modes:
 # `schedule` (cron scheduler) and `serve` (HTTP control plane).
-full = ["default", "otel", "schedule", "serve", "serve-ui", "serve-history-postgres", "serve-history-sqlite", "catalog", "lineage", "lineage-kafka", "notify", "transform-sql", "triggers", "triggers-object-store", "triggers-redis", "triggers-kafka", "cli-dev", "encryption", "cli-tui"]
+full = ["default", "otel", "schedule", "serve", "serve-ui", "serve-history-postgres", "serve-history-sqlite", "catalog", "lineage", "lineage-kafka", "notify", "transform-sql", "triggers", "triggers-object-store", "triggers-redis", "triggers-kafka", "cli-dev", "encryption", "cli-tui", "delta-s3", "delta-azure", "delta-gcs"]
 
 # Data Movement Catalog (#279): the `catalog:` config block + post-run
 # recording (datasets, schema timelines, volume/freshness stats, lineage
@@ -83,6 +83,7 @@ source = [
     "source-kafka",
     "source-kinesis",
     "source-parquet",
+    "source-delta",
     "source-gcs",
     "source-bigquery",
     "source-snowflake",
@@ -107,6 +108,7 @@ sink = [
     "sink-kafka",
     "sink-kinesis",
     "sink-parquet",
+    "sink-delta",
     "sink-gcs",
     "sink-iceberg",
     "sink-spanner",
@@ -134,6 +136,7 @@ source-elasticsearch = ["dep:faucet-source-elasticsearch"]
 source-kafka = ["dep:faucet-source-kafka"]
 source-kinesis = ["dep:faucet-source-kinesis"]
 source-parquet = ["dep:faucet-source-parquet"]
+source-delta = ["dep:faucet-source-delta"]
 source-gcs = ["dep:faucet-source-gcs"]
 source-bigquery = ["dep:faucet-source-bigquery"]
 source-snowflake = ["dep:faucet-source-snowflake"]
@@ -159,7 +162,15 @@ sink-kafka = ["dep:faucet-sink-kafka"]
 sink-kinesis = ["dep:faucet-sink-kinesis"]
 sink-spanner = ["dep:faucet-sink-spanner"]
 sink-parquet = ["dep:faucet-sink-parquet"]
+sink-delta = ["dep:faucet-sink-delta"]
 sink-gcs = ["dep:faucet-sink-gcs"]
+
+## Delta Lake cloud object-store backends. Forwarded to whichever delta
+## connector is enabled via optional-dep (`?`) syntax, so they don't pull the
+## connectors in themselves. Included in `full`; not in `default` (slim).
+delta-s3 = ["faucet-source-delta?/s3", "faucet-sink-delta?/s3"]
+delta-azure = ["faucet-source-delta?/azure", "faucet-sink-delta?/azure"]
+delta-gcs = ["faucet-source-delta?/gcs", "faucet-sink-delta?/gcs"]
 
 kafka-schema-registry = [
     "faucet-source-kafka?/schema-registry",
@@ -288,6 +299,7 @@ faucet-source-elasticsearch = { workspace = true, optional = true }
 faucet-source-kafka = { workspace = true, optional = true }
 faucet-source-kinesis = { workspace = true, optional = true }
 faucet-source-parquet = { workspace = true, optional = true }
+faucet-source-delta = { workspace = true, optional = true }
 faucet-source-gcs = { workspace = true, optional = true }
 faucet-source-bigquery = { workspace = true, optional = true }
 faucet-source-snowflake = { workspace = true, optional = true }
@@ -312,6 +324,7 @@ faucet-sink-kinesis = { workspace = true, optional = true }
 faucet-sink-spanner = { workspace = true, optional = true }
 faucet-sink-stdout = { workspace = true, optional = true }
 faucet-sink-parquet = { workspace = true, optional = true }
+faucet-sink-delta = { workspace = true, optional = true }
 faucet-sink-gcs = { workspace = true, optional = true }
 faucet-state-redis = { workspace = true, optional = true }
 faucet-state-postgres = { workspace = true, optional = true }

--- a/cli/examples/csv_to_delta.yaml
+++ b/cli/examples/csv_to_delta.yaml
@@ -1,0 +1,26 @@
+# Load a local CSV into an Apache Delta Lake table on the local filesystem.
+# Databricks (and Spark / Trino / DuckDB / Microsoft Fabric) can then read the
+# table natively. Point `table_uri` at `s3://…` / `abfss://…` / `gs://…` and
+# add a `credentials:` block to land in cloud object storage instead (requires
+# the `delta-s3` / `delta-azure` / `delta-gcs` build feature).
+#
+#   faucet validate cli/examples/csv_to_delta.yaml
+#   faucet run      cli/examples/csv_to_delta.yaml
+version: 1
+name: csv_to_delta
+
+pipeline:
+  source:
+    type: csv
+    config:
+      path: ./data/input.csv
+
+  sink:
+    type: delta
+    config:
+      # Local path (promoted to file://). Created on first write from the
+      # inferred schema when create_if_not_missing (the default) is true.
+      table_uri: ./out/delta/events
+      create_if_not_missing: true
+      # Optional Hive-style partitioning applied when the table is created:
+      # partition_by: ["region"]

--- a/cli/examples/delta_to_jsonl.yaml
+++ b/cli/examples/delta_to_jsonl.yaml
@@ -1,0 +1,25 @@
+# Read an Apache Delta Lake table (e.g. one written by csv_to_delta.yaml, or by
+# Databricks/Spark) and stream its rows out as JSON Lines. Set `version:` or
+# `timestamp:` for time travel, and `columns:` for projection pushdown.
+#
+#   faucet run cli/examples/csv_to_delta.yaml    # produce the table first
+#   faucet validate cli/examples/delta_to_jsonl.yaml
+#   faucet run      cli/examples/delta_to_jsonl.yaml
+version: 1
+name: delta_to_jsonl
+
+pipeline:
+  source:
+    type: delta
+    config:
+      table_uri: ./out/delta/events
+      # Time travel (pick at most one):
+      # version: 0
+      # timestamp: "2026-07-15T00:00:00Z"
+      # Projection pushdown (omit for all columns):
+      # columns: ["id", "name"]
+
+  sink:
+    type: jsonl
+    config:
+      path: ./out/delta_events.jsonl

--- a/cli/src/registry.rs
+++ b/cli/src/registry.rs
@@ -467,6 +467,11 @@ pub async fn build_source(
                 faucet_source_parquet::ParquetSource::new(cfg).await?,
             ))
         }
+        #[cfg(feature = "source-delta")]
+        "delta" => {
+            let cfg = decode::<faucet_source_delta::DeltaSourceConfig>("source", "delta", config)?;
+            Ok(Box::new(faucet_source_delta::DeltaSource::new(cfg).await?))
+        }
         #[cfg(feature = "source-gcs")]
         "gcs" => {
             let cfg = decode::<faucet_source_gcs::GcsSourceConfig>("source", "gcs", config)?;
@@ -519,6 +524,11 @@ pub async fn build_sink(kind: &str, config: Value, auth: &AuthCatalog) -> CliRes
         "iceberg" => {
             let cfg = decode::<faucet_sink_iceberg::IcebergSinkConfig>("sink", "iceberg", config)?;
             Ok(Box::new(faucet_sink_iceberg::IcebergSink::new(cfg).await?))
+        }
+        #[cfg(feature = "sink-delta")]
+        "delta" => {
+            let cfg = decode::<faucet_sink_delta::DeltaSinkConfig>("sink", "delta", config)?;
+            Ok(Box::new(faucet_sink_delta::DeltaSink::new(cfg).await?))
         }
         #[cfg(feature = "sink-postgres")]
         "postgres" => {
@@ -793,6 +803,8 @@ pub fn source_schema(kind: &str) -> CliResult<Value> {
         "spanner" => Ok(schema::<faucet_source_spanner::SpannerSourceConfig>()),
         #[cfg(feature = "source-parquet")]
         "parquet" => Ok(schema::<faucet_source_parquet::ParquetSourceConfig>()),
+        #[cfg(feature = "source-delta")]
+        "delta" => Ok(schema::<faucet_source_delta::DeltaSourceConfig>()),
         #[cfg(feature = "source-gcs")]
         "gcs" => Ok(schema::<faucet_source_gcs::GcsSourceConfig>()),
         #[cfg(feature = "source-bigquery")]
@@ -823,6 +835,8 @@ pub fn sink_schema(kind: &str) -> CliResult<Value> {
         "bigquery" => Ok(schema::<faucet_sink_bigquery::BigQuerySinkConfig>()),
         #[cfg(feature = "sink-iceberg")]
         "iceberg" => Ok(schema::<faucet_sink_iceberg::IcebergSinkConfig>()),
+        #[cfg(feature = "sink-delta")]
+        "delta" => Ok(schema::<faucet_sink_delta::DeltaSinkConfig>()),
         #[cfg(feature = "sink-postgres")]
         "postgres" => Ok(schema::<faucet_sink_postgres::PostgresSinkConfig>()),
         #[cfg(feature = "sink-jsonl")]
@@ -931,6 +945,8 @@ fn builtin_source_descriptions() -> Vec<(&'static str, &'static str)> {
     v.push(("spanner", "Google Cloud Spanner query source. Streaming SQL reads with incremental replication bookmarks, stale reads, and PK-range sharding."));
     #[cfg(feature = "source-parquet")]
     v.push(("parquet", "Apache Parquet file source (local path, glob, or S3). Streams record batches via the Arrow async reader."));
+    #[cfg(feature = "source-delta")]
+    v.push(("delta", "Apache Delta Lake source (local FS or S3/Azure/GCS). Streams active data files with time travel and projection pushdown."));
     #[cfg(feature = "source-gcs")]
     v.push((
         "gcs",
@@ -1006,6 +1022,8 @@ fn builtin_sink_descriptions() -> Vec<(&'static str, &'static str)> {
     v.push(("stdout", "Stdout / stderr sink (JSON Lines, pretty, TSV)"));
     #[cfg(feature = "sink-parquet")]
     v.push(("parquet", "Apache Parquet file sink (local path or S3). Schema-inferred, configurable compression, row/byte rollover."));
+    #[cfg(feature = "sink-delta")]
+    v.push(("delta", "Apache Delta Lake sink (local FS or S3/Azure/GCS). Append-only, schema-inferred table creation, one commit per flush."));
     #[cfg(feature = "sink-gcs")]
     v.push(("gcs", "Google Cloud Storage sink — JSONL files"));
     v
@@ -1326,6 +1344,51 @@ mod tests {
         // The stdout sink uses the default `connector_name()` (stripped type
         // name) rather than overriding it with a friendly label.
         assert_eq!(sink.connector_name(), "StdoutSink");
+    }
+
+    // Exercise the Delta source+sink registry arms end to end: build both via
+    // the registry, round-trip a page through a real local table, and confirm
+    // the schema + description arms resolve.
+    #[cfg(all(feature = "source-delta", feature = "sink-delta"))]
+    #[tokio::test]
+    async fn delta_registry_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let uri = dir.path().join("reg_delta").to_string_lossy().into_owned();
+
+        assert!(source_schema("delta").is_ok());
+        assert!(sink_schema("delta").is_ok());
+        assert!(source_descriptions().iter().any(|(n, _)| *n == "delta"));
+        assert!(sink_descriptions().iter().any(|(n, _)| *n == "delta"));
+
+        let sink = build_sink(
+            "delta",
+            serde_json::json!({ "table_uri": uri }),
+            &AuthCatalog::new(),
+        )
+        .await
+        .expect("delta sink builds");
+        assert_eq!(sink.connector_name(), "delta");
+        let n = sink
+            .write_batch(&[serde_json::json!({"id": 1}), serde_json::json!({"id": 2})])
+            .await
+            .expect("write");
+        assert_eq!(n, 2);
+        sink.flush().await.expect("flush");
+
+        let source = build_source(
+            "delta",
+            serde_json::json!({ "table_uri": uri }),
+            &AuthCatalog::new(),
+            None,
+        )
+        .await
+        .expect("delta source builds");
+        assert_eq!(source.connector_name(), "delta");
+        let rows = source
+            .fetch_with_context(&std::collections::HashMap::new())
+            .await
+            .expect("read");
+        assert_eq!(rows.len(), 2);
     }
 
     // A malformed config for a known connector must surface as a typed

--- a/connectors/registry.json
+++ b/connectors/registry.json
@@ -25,6 +25,7 @@
     { "name": "kafka", "kind": "source", "verified": true, "description": "Apache Kafka consumer with idle/max-messages termination" },
     { "name": "kinesis", "kind": "source", "verified": true, "description": "AWS Kinesis Data Streams consumer with per-shard checkpoints" },
     { "name": "parquet", "kind": "source", "verified": true, "description": "Apache Parquet file source (local, glob, or S3)" },
+    { "name": "delta", "kind": "source", "verified": true, "description": "Apache Delta Lake source (local FS or S3/Azure/GCS; time travel, projection)" },
     { "name": "bigquery", "kind": "source", "verified": true, "description": "Google BigQuery query source" },
     { "name": "snowflake", "kind": "source", "verified": true, "description": "Snowflake query source (SQL REST API)" },
     { "name": "spanner", "kind": "source", "verified": true, "description": "Google Cloud Spanner query source (streaming SQL, incremental replication)" },
@@ -48,6 +49,7 @@
     { "name": "spanner", "kind": "sink", "verified": true, "description": "Google Cloud Spanner mutation sink (upsert/delete, exactly-once)" },
     { "name": "http", "kind": "sink", "verified": true, "description": "HTTP POST sink (individual or array batch)" },
     { "name": "stdout", "kind": "sink", "verified": true, "description": "Stdout / stderr sink (JSON Lines, pretty, TSV)" },
-    { "name": "parquet", "kind": "sink", "verified": true, "description": "Apache Parquet file sink (local path or S3)" }
+    { "name": "parquet", "kind": "sink", "verified": true, "description": "Apache Parquet file sink (local path or S3)" },
+    { "name": "delta", "kind": "sink", "verified": true, "description": "Apache Delta Lake sink (append-only; local FS or S3/Azure/GCS)" }
   ]
 }

--- a/crates/common/delta/Cargo.toml
+++ b/crates/common/delta/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "faucet-common-delta"
+version = "1.0.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Shared Delta Lake configuration and helpers for the faucet-stream source and sink connectors"
+readme = "README.md"
+keywords = ["delta", "deltalake", "lakehouse", "etl", "connector"]
+categories.workspace = true
+
+[features]
+default = []
+# Cloud object-store backends. Each forwards to the matching delta-rs feature
+# and, for S3, unlocks the `register_handlers` shim in `table.rs`.
+s3 = ["deltalake/s3"]
+azure = ["deltalake/azure"]
+gcs = ["deltalake/gcs"]
+
+[dependencies]
+faucet-core.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+schemars.workspace = true
+tracing.workspace = true
+deltalake.workspace = true
+arrow.workspace = true
+arrow-json.workspace = true
+chrono.workspace = true
+url.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/common/delta/README.md
+++ b/crates/common/delta/README.md
@@ -1,0 +1,25 @@
+# faucet-common-delta
+
+Shared configuration and helpers for the [`faucet-stream`](https://crates.io/crates/faucet-stream)
+Delta Lake connectors — [`faucet-source-delta`](https://crates.io/crates/faucet-source-delta)
+and [`faucet-sink-delta`](https://crates.io/crates/faucet-sink-delta). Built on
+the Rust [`deltalake`](https://crates.io/crates/deltalake) crate (delta-rs).
+
+Provides:
+
+- **`DeltaCredentials`** — object-store credentials (`default` chain / `aws` /
+  `azure` / `gcp`), each mapping to the `storage_options` keys delta-rs expects.
+- **`DeltaConnection`** — the shared `table_uri` / `credentials` /
+  `storage_options` block (flattened into both connector configs) plus the
+  open-table, time-travel, storage-option, and handler-registration helpers.
+- **`convert`** — Arrow ⇆ JSON conversion (`record_batch_to_json`,
+  `infer_arrow_schema`) reused by the source (read) and sink (write).
+
+Cloud object-store backends are opt-in cargo features (`s3`, `azure`, `gcs`)
+that forward to the matching delta-rs feature; the default build supports the
+local filesystem only.
+
+Connector authors normally depend on `faucet-source-delta` /
+`faucet-sink-delta`, which re-export the types they need from here.
+
+License: MIT OR Apache-2.0.

--- a/crates/common/delta/src/connection.rs
+++ b/crates/common/delta/src/connection.rs
@@ -1,0 +1,237 @@
+//! The shared Delta connection block: `table_uri` + `credentials` +
+//! `storage_options`, and the open-table / handler-registration helpers both
+//! the source and sink rely on.
+
+use std::collections::HashMap;
+
+use faucet_core::FaucetError;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::credentials::DeltaCredentials;
+
+/// Location + credentials for a Delta table. Flattened (`#[serde(flatten)]`)
+/// into both the source and sink config so the same three keys appear at the
+/// connector-config top level.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct DeltaConnection {
+    /// Delta table location URI: `file:///abs/path`, `s3://bucket/key`,
+    /// `abfss://…`, `gs://bucket/key`. A bare local path is accepted and
+    /// treated as `file://`.
+    pub table_uri: String,
+
+    /// Object-store credentials. Defaults to the ambient provider chain.
+    #[serde(default)]
+    pub credentials: DeltaCredentials,
+
+    /// Extra `storage_options` passed verbatim to delta-rs (e.g. a MinIO
+    /// endpoint override, or any object-store key the [`DeltaCredentials`]
+    /// enum does not model). Keys set here **win** over credential-derived
+    /// keys.
+    #[serde(default)]
+    pub storage_options: HashMap<String, String>,
+}
+
+impl DeltaConnection {
+    /// Build the effective `storage_options` map: credential-derived keys with
+    /// the user's explicit `storage_options` layered on top (explicit wins).
+    pub fn merged_storage_options(&self) -> HashMap<String, String> {
+        let mut opts = self.storage_options.clone();
+        self.credentials.apply(&mut opts);
+        opts
+    }
+
+    /// The table URI with any embedded credentials scrubbed — safe for logs,
+    /// lineage, and `dataset_uri()`.
+    pub fn redacted_uri(&self) -> String {
+        faucet_core::util::redact_uri_credentials(&self.table_uri)
+    }
+
+    /// Register the object-store handlers delta-rs needs for this URI's scheme.
+    ///
+    /// delta-rs does not auto-register the cloud object stores; the relevant
+    /// `register_handlers` must run once before opening/creating an `s3://` /
+    /// `abfss://` / `gs://` table. Idempotent and cheap — safe to call before
+    /// every open.
+    pub fn register_handlers(&self) {
+        register_all_handlers();
+    }
+
+    /// Resolve `table_uri` to a `Url`, turning bare local paths into `file://`
+    /// (delta-rs's `open_table*` functions take a `Url`, not a string).
+    fn table_url(&self) -> Result<url::Url, FaucetError> {
+        deltalake::ensure_table_uri(&self.table_uri).map_err(|e| {
+            FaucetError::Config(format!(
+                "delta: invalid table_uri '{}': {e}",
+                self.redacted_uri()
+            ))
+        })
+    }
+
+    /// The resolved table location as a string — for delta-rs builders that
+    /// take a location string (e.g. `CreateBuilder::with_location`).
+    pub fn location_string(&self) -> Result<String, FaucetError> {
+        Ok(self.table_url()?.to_string())
+    }
+
+    /// Open the table at its latest version. Registers handlers first.
+    pub async fn open(&self) -> Result<deltalake::DeltaTable, FaucetError> {
+        self.register_handlers();
+        let url = self.table_url()?;
+        deltalake::open_table_with_storage_options(url, self.merged_storage_options())
+            .await
+            .map_err(|e| self.map_open_error(e))
+    }
+
+    /// Open the table if it exists; return `Ok(None)` when the URI is not (yet)
+    /// a Delta table. Other errors (auth, I/O) propagate. Used by the sink's
+    /// `create_if_not_missing` path.
+    pub async fn open_optional(&self) -> Result<Option<deltalake::DeltaTable>, FaucetError> {
+        self.register_handlers();
+        let url = self.table_url()?;
+        match deltalake::open_table_with_storage_options(url, self.merged_storage_options()).await {
+            Ok(t) => Ok(Some(t)),
+            Err(e) if is_missing_table(&e) => Ok(None),
+            Err(e) => Err(self.map_open_error(e)),
+        }
+    }
+
+    /// Open the table pinned to a specific version (time travel).
+    pub async fn open_at_version(
+        &self,
+        version: u64,
+    ) -> Result<deltalake::DeltaTable, FaucetError> {
+        let mut table = self.open().await?;
+        table
+            .load_version(version)
+            .await
+            .map_err(|e| self.map_open_error(e))?;
+        Ok(table)
+    }
+
+    /// Open the table as of a timestamp (RFC 3339). Time travel.
+    pub async fn open_at_timestamp(
+        &self,
+        timestamp: &str,
+    ) -> Result<deltalake::DeltaTable, FaucetError> {
+        let ts = chrono::DateTime::parse_from_rfc3339(timestamp)
+            .map_err(|e| {
+                FaucetError::Config(format!(
+                    "delta: invalid `timestamp` '{timestamp}' (expected RFC 3339): {e}"
+                ))
+            })?
+            .with_timezone(&chrono::Utc);
+        let mut table = self.open().await?;
+        table
+            .load_with_datetime(ts)
+            .await
+            .map_err(|e| self.map_open_error(e))?;
+        Ok(table)
+    }
+
+    fn map_open_error(&self, e: deltalake::DeltaTableError) -> FaucetError {
+        FaucetError::Source(format!(
+            "delta: failed to open table '{}': {e}",
+            self.redacted_uri()
+        ))
+    }
+}
+
+/// Whether a delta-rs error means "there is no Delta table here (yet)" —
+/// either an explicit `NotATable` or an underlying object-store "not found".
+fn is_missing_table(e: &deltalake::DeltaTableError) -> bool {
+    if matches!(e, deltalake::DeltaTableError::NotATable(_)) {
+        return true;
+    }
+    // A brand-new location surfaces as an object-store NotFound wrapped in a
+    // generic error; match on the rendered message so the create-if-missing
+    // path doesn't treat "empty prefix" as a hard failure.
+    let msg = e.to_string().to_lowercase();
+    msg.contains("not found") || msg.contains("no such file") || msg.contains("does not exist")
+}
+
+/// Register every compiled-in cloud object-store handler exactly once.
+///
+/// Each backend is gated on its cargo feature; with no cloud feature this is a
+/// no-op (local filesystem needs no registration).
+fn register_all_handlers() {
+    #[cfg(feature = "s3")]
+    {
+        use std::sync::Once;
+        static S3: Once = Once::new();
+        S3.call_once(|| deltalake::aws::register_handlers(None));
+    }
+    #[cfg(feature = "azure")]
+    {
+        use std::sync::Once;
+        static AZURE: Once = Once::new();
+        AZURE.call_once(|| deltalake::azure::register_handlers(None));
+    }
+    #[cfg(feature = "gcs")]
+    {
+        use std::sync::Once;
+        static GCS: Once = Once::new();
+        GCS.call_once(|| deltalake::gcp::register_handlers(None));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn conn(uri: &str) -> DeltaConnection {
+        DeltaConnection {
+            table_uri: uri.into(),
+            credentials: DeltaCredentials::default(),
+            storage_options: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn flatten_shape_round_trips() {
+        let v = json!({
+            "table_uri": "s3://bucket/tbl",
+            "credentials": { "type": "aws", "config": { "region": "us-east-1" } },
+            "storage_options": { "AWS_ALLOW_HTTP": "true" }
+        });
+        let c: DeltaConnection = serde_json::from_value(v).unwrap();
+        assert_eq!(c.table_uri, "s3://bucket/tbl");
+        let opts = c.merged_storage_options();
+        assert_eq!(opts["AWS_REGION"], "us-east-1");
+        assert_eq!(opts["AWS_ALLOW_HTTP"], "true");
+    }
+
+    #[test]
+    fn explicit_storage_option_overrides_credential() {
+        let v = json!({
+            "table_uri": "s3://bucket/tbl",
+            "credentials": { "type": "aws", "config": { "region": "us-east-1" } },
+            "storage_options": { "AWS_REGION": "eu-west-1" }
+        });
+        let c: DeltaConnection = serde_json::from_value(v).unwrap();
+        assert_eq!(c.merged_storage_options()["AWS_REGION"], "eu-west-1");
+    }
+
+    #[test]
+    fn defaults_omit_credentials_and_options() {
+        let c: DeltaConnection =
+            serde_json::from_value(json!({ "table_uri": "file:///tmp/t" })).unwrap();
+        assert_eq!(c.credentials, DeltaCredentials::Default);
+        assert!(c.merged_storage_options().is_empty());
+    }
+
+    #[test]
+    fn redacted_uri_passes_plain_uri_through() {
+        assert_eq!(conn("s3://bucket/tbl").redacted_uri(), "s3://bucket/tbl");
+    }
+
+    #[test]
+    fn register_handlers_is_idempotent() {
+        // No cloud feature in the default test build → pure no-op, but must not
+        // panic when called repeatedly.
+        let c = conn("file:///tmp/t");
+        c.register_handlers();
+        c.register_handlers();
+    }
+}

--- a/crates/common/delta/src/convert.rs
+++ b/crates/common/delta/src/convert.rs
@@ -1,0 +1,189 @@
+//! Arrow ⇆ JSON conversion shared by the Delta source and sink.
+//!
+//! * [`record_batch_to_json`] — Arrow `RecordBatch` → `Vec<serde_json::Value>`
+//!   (the read path). Delegates to `arrow_json::ArrayWriter`, which already
+//!   encodes every Arrow logical type.
+//! * [`infer_arrow_schema`] — a nullable-everywhere Arrow schema inferred from
+//!   a sample of JSON records (the write path, when creating a table / decoding
+//!   a batch).
+
+use std::sync::Arc;
+
+use arrow::array::RecordBatch;
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use arrow::error::ArrowError;
+use arrow_json::ArrayWriter;
+use faucet_core::FaucetError;
+use serde_json::Value;
+
+/// Encode a single Arrow `RecordBatch` as `Vec<serde_json::Value>`, one JSON
+/// object per row. An empty batch yields an empty vec.
+pub fn record_batch_to_json(batch: &RecordBatch) -> Result<Vec<Value>, FaucetError> {
+    if batch.num_rows() == 0 {
+        return Ok(Vec::new());
+    }
+
+    let mut buf: Vec<u8> = Vec::with_capacity(batch.num_rows() * 64);
+    {
+        let mut writer = ArrayWriter::new(&mut buf);
+        writer
+            .write(batch)
+            .map_err(|e| FaucetError::Source(format!("delta: arrow_json encode error: {e}")))?;
+        writer
+            .finish()
+            .map_err(|e| FaucetError::Source(format!("delta: arrow_json finish error: {e}")))?;
+    }
+
+    let parsed: Value = serde_json::from_slice(&buf)
+        .map_err(|e| FaucetError::Source(format!("delta: arrow_json output parse error: {e}")))?;
+
+    match parsed {
+        Value::Array(rows) => Ok(rows),
+        other => Err(FaucetError::Source(format!(
+            "delta: arrow_json produced non-array output: {other}"
+        ))),
+    }
+}
+
+/// Infer a fully-nullable Arrow schema from up to `sample_size` JSON records.
+///
+/// Every field (including nested struct/list fields) is forced nullable —
+/// the sink is intentionally forgiving about missing keys, and Delta append
+/// semantics require the physical parquet schema to tolerate nulls.
+pub fn infer_arrow_schema(records: &[Value], sample_size: usize) -> Result<SchemaRef, FaucetError> {
+    if records.is_empty() {
+        return Err(FaucetError::Sink(
+            "delta: cannot infer schema — record sample is empty".to_string(),
+        ));
+    }
+
+    let take = sample_size.min(records.len());
+    let iter = records
+        .iter()
+        .take(take)
+        .filter(|v| v.is_object())
+        .map(Ok::<&Value, ArrowError>);
+
+    let raw = arrow_json::reader::infer_json_schema_from_iterator(iter)
+        .map_err(|e| FaucetError::Sink(format!("delta: schema inference failed: {e}")))?;
+
+    if raw.fields().is_empty() {
+        return Err(FaucetError::Sink(
+            "delta: cannot infer schema — no object records in sample".to_string(),
+        ));
+    }
+
+    Ok(Arc::new(force_nullable(raw)))
+}
+
+/// Recursively force every field in the schema to be nullable.
+fn force_nullable(schema: Schema) -> Schema {
+    let metadata = schema.metadata.clone();
+    let fields: Vec<Field> = schema
+        .fields()
+        .iter()
+        .map(|f| make_nullable(f.as_ref()))
+        .collect();
+    Schema::new_with_metadata(fields, metadata)
+}
+
+fn make_nullable(field: &Field) -> Field {
+    let data_type = match field.data_type() {
+        DataType::Struct(fields) => {
+            let nullable_fields: Vec<Field> =
+                fields.iter().map(|f| make_nullable(f.as_ref())).collect();
+            DataType::Struct(nullable_fields.into())
+        }
+        DataType::List(inner) => DataType::List(Arc::new(make_nullable(inner.as_ref()))),
+        DataType::LargeList(inner) => DataType::LargeList(Arc::new(make_nullable(inner.as_ref()))),
+        other => other.clone(),
+    };
+    Field::new(field.name(), data_type, true).with_metadata(field.metadata().clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Int32Array, StringArray};
+    use serde_json::json;
+
+    #[test]
+    fn empty_batch_is_empty_vec() {
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let batch =
+            RecordBatch::try_new(schema, vec![Arc::new(Int32Array::from(Vec::<i32>::new()))])
+                .unwrap();
+        assert!(record_batch_to_json(&batch).unwrap().is_empty());
+    }
+
+    #[test]
+    fn batch_round_trips_to_objects() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("name", DataType::Utf8, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2])),
+                Arc::new(StringArray::from(vec![Some("Alice"), None])),
+            ],
+        )
+        .unwrap();
+        let rows = record_batch_to_json(&batch).unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0]["id"], 1);
+        assert_eq!(rows[0]["name"], "Alice");
+        assert_eq!(rows[1]["id"], 2);
+        assert!(rows[1].get("name").is_none() || rows[1]["name"].is_null());
+    }
+
+    #[test]
+    fn infers_primitives_all_nullable() {
+        let records = vec![
+            json!({"id": 1, "name": "a", "ok": true, "score": 1.5}),
+            json!({"id": 2, "name": "b", "ok": false, "score": 2.0}),
+        ];
+        let schema = infer_arrow_schema(&records, 10).unwrap();
+        assert_eq!(
+            schema.field_with_name("id").unwrap().data_type(),
+            &DataType::Int64
+        );
+        assert_eq!(
+            schema.field_with_name("score").unwrap().data_type(),
+            &DataType::Float64
+        );
+        for f in schema.fields() {
+            assert!(f.is_nullable(), "{} must be nullable", f.name());
+        }
+    }
+
+    #[test]
+    fn infer_promotes_int_to_float() {
+        let records = vec![json!({"x": 1}), json!({"x": 1.5})];
+        let schema = infer_arrow_schema(&records, 10).unwrap();
+        assert_eq!(
+            schema.field_with_name("x").unwrap().data_type(),
+            &DataType::Float64
+        );
+    }
+
+    #[test]
+    fn infer_empty_sample_errors() {
+        assert!(infer_arrow_schema(&[], 10).is_err());
+        assert!(infer_arrow_schema(&[json!("scalar")], 10).is_err());
+    }
+
+    #[test]
+    fn infer_nested_struct_and_list_forced_nullable() {
+        let records = vec![json!({"meta": {"a": 1, "b": "z"}, "tags": ["x", "y"]})];
+        let schema = infer_arrow_schema(&records, 10).unwrap();
+        match schema.field_with_name("meta").unwrap().data_type() {
+            DataType::Struct(fs) => assert!(fs.iter().all(|f| f.is_nullable())),
+            other => panic!("expected struct, got {other:?}"),
+        }
+        let tags = schema.field_with_name("tags").unwrap();
+        assert!(matches!(tags.data_type(), DataType::List(_)));
+        assert!(tags.is_nullable());
+    }
+}

--- a/crates/common/delta/src/credentials.rs
+++ b/crates/common/delta/src/credentials.rs
@@ -1,0 +1,250 @@
+//! Object-store credentials for Delta tables.
+//!
+//! delta-rs authenticates through a `storage_options: HashMap<String,String>`
+//! map whose keys mirror the underlying `object_store` environment variables
+//! (`AWS_ACCESS_KEY_ID`, `AZURE_STORAGE_ACCOUNT_NAME`, `GOOGLE_SERVICE_ACCOUNT`,
+//! …). [`DeltaCredentials`] is a typed, self-documenting front for the common
+//! cases; anything it does not cover can still be set verbatim via the
+//! connection's `storage_options`. Explicit `storage_options` win on key
+//! collision (see [`DeltaCredentials::apply`]).
+
+use std::collections::HashMap;
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Object-store credentials for reading/writing a Delta table.
+///
+/// Uses the project-wide adjacently-tagged `{ type, config }` shape
+/// (snake_case discriminators): e.g. `credentials: { type: aws, config: { … } }`.
+/// The default is [`DeltaCredentials::Default`], which resolves credentials from
+/// the ambient environment / instance metadata via the object-store default
+/// provider chain — nothing is injected into `storage_options`.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "type", content = "config", rename_all = "snake_case")]
+pub enum DeltaCredentials {
+    /// Resolve credentials from the ambient environment / default provider
+    /// chain (AWS instance profile, `AZURE_*` env, GCP ADC, …). Injects no
+    /// keys of its own.
+    #[default]
+    Default,
+    /// Static AWS credentials (or an S3-compatible endpoint such as MinIO).
+    Aws(AwsCredentials),
+    /// Azure Blob / ADLS Gen2 credentials.
+    Azure(AzureCredentials),
+    /// Google Cloud Storage credentials.
+    Gcp(GcpCredentials),
+}
+
+impl DeltaCredentials {
+    /// Merge the credential-derived keys into `options`, **without** overwriting
+    /// any key the user set explicitly. This makes explicit `storage_options`
+    /// authoritative — an escape hatch for keys this enum does not model.
+    pub fn apply(&self, options: &mut HashMap<String, String>) {
+        let derived = self.storage_options();
+        for (k, v) in derived {
+            options.entry(k).or_insert(v);
+        }
+    }
+
+    /// The `storage_options` entries implied by these credentials.
+    pub fn storage_options(&self) -> HashMap<String, String> {
+        let mut m = HashMap::new();
+        match self {
+            DeltaCredentials::Default => {}
+            DeltaCredentials::Aws(a) => {
+                if let Some(v) = &a.access_key_id {
+                    m.insert("AWS_ACCESS_KEY_ID".into(), v.clone());
+                }
+                if let Some(v) = &a.secret_access_key {
+                    m.insert("AWS_SECRET_ACCESS_KEY".into(), v.clone());
+                }
+                if let Some(v) = &a.session_token {
+                    m.insert("AWS_SESSION_TOKEN".into(), v.clone());
+                }
+                if let Some(v) = &a.region {
+                    m.insert("AWS_REGION".into(), v.clone());
+                }
+                if let Some(v) = &a.endpoint_url {
+                    m.insert("AWS_ENDPOINT_URL".into(), v.clone());
+                }
+                if let Some(v) = a.allow_http {
+                    m.insert("AWS_ALLOW_HTTP".into(), v.to_string());
+                }
+            }
+            DeltaCredentials::Azure(a) => {
+                if let Some(v) = &a.account_name {
+                    m.insert("AZURE_STORAGE_ACCOUNT_NAME".into(), v.clone());
+                }
+                if let Some(v) = &a.access_key {
+                    m.insert("AZURE_STORAGE_ACCESS_KEY".into(), v.clone());
+                }
+                if let Some(v) = &a.sas_token {
+                    m.insert("AZURE_STORAGE_SAS_KEY".into(), v.clone());
+                }
+            }
+            DeltaCredentials::Gcp(g) => {
+                if let Some(v) = &g.service_account_path {
+                    m.insert("GOOGLE_SERVICE_ACCOUNT".into(), v.clone());
+                }
+                if let Some(v) = &g.service_account_key {
+                    m.insert("GOOGLE_SERVICE_ACCOUNT_KEY".into(), v.clone());
+                }
+            }
+        }
+        m
+    }
+}
+
+/// Static AWS credentials and optional S3-compatible endpoint overrides.
+///
+/// Leaving a field unset lets the object-store default chain resolve it (so
+/// `region` alone with an instance profile is valid). `endpoint_url` +
+/// `allow_http: true` targets MinIO / LocalStack.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+pub struct AwsCredentials {
+    /// `AWS_ACCESS_KEY_ID`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub access_key_id: Option<String>,
+    /// `AWS_SECRET_ACCESS_KEY`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub secret_access_key: Option<String>,
+    /// `AWS_SESSION_TOKEN` (temporary credentials).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_token: Option<String>,
+    /// `AWS_REGION`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub region: Option<String>,
+    /// `AWS_ENDPOINT_URL` — override for S3-compatible stores (MinIO, etc.).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub endpoint_url: Option<String>,
+    /// `AWS_ALLOW_HTTP` — permit plaintext HTTP to the endpoint (MinIO in dev).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allow_http: Option<bool>,
+}
+
+/// Azure Blob / ADLS Gen2 credentials.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+pub struct AzureCredentials {
+    /// `AZURE_STORAGE_ACCOUNT_NAME`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub account_name: Option<String>,
+    /// `AZURE_STORAGE_ACCESS_KEY` (shared-key auth).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub access_key: Option<String>,
+    /// `AZURE_STORAGE_SAS_KEY` (SAS-token auth).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sas_token: Option<String>,
+}
+
+/// Google Cloud Storage credentials.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+pub struct GcpCredentials {
+    /// `GOOGLE_SERVICE_ACCOUNT` — path to a service-account JSON key file.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service_account_path: Option<String>,
+    /// `GOOGLE_SERVICE_ACCOUNT_KEY` — inline service-account JSON key.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service_account_key: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn default_injects_nothing() {
+        let c = DeltaCredentials::default();
+        assert!(c.storage_options().is_empty());
+    }
+
+    #[test]
+    fn aws_maps_all_fields() {
+        let c = DeltaCredentials::Aws(AwsCredentials {
+            access_key_id: Some("AK".into()),
+            secret_access_key: Some("SK".into()),
+            session_token: Some("ST".into()),
+            region: Some("us-east-1".into()),
+            endpoint_url: Some("http://localhost:9000".into()),
+            allow_http: Some(true),
+        });
+        let m = c.storage_options();
+        assert_eq!(m["AWS_ACCESS_KEY_ID"], "AK");
+        assert_eq!(m["AWS_SECRET_ACCESS_KEY"], "SK");
+        assert_eq!(m["AWS_SESSION_TOKEN"], "ST");
+        assert_eq!(m["AWS_REGION"], "us-east-1");
+        assert_eq!(m["AWS_ENDPOINT_URL"], "http://localhost:9000");
+        assert_eq!(m["AWS_ALLOW_HTTP"], "true");
+    }
+
+    #[test]
+    fn azure_and_gcp_partial() {
+        let az = DeltaCredentials::Azure(AzureCredentials {
+            account_name: Some("acct".into()),
+            access_key: None,
+            sas_token: Some("sas".into()),
+        });
+        let m = az.storage_options();
+        assert_eq!(m["AZURE_STORAGE_ACCOUNT_NAME"], "acct");
+        assert_eq!(m["AZURE_STORAGE_SAS_KEY"], "sas");
+        assert!(!m.contains_key("AZURE_STORAGE_ACCESS_KEY"));
+
+        let gcp = DeltaCredentials::Gcp(GcpCredentials {
+            service_account_path: Some("/keys/sa.json".into()),
+            service_account_key: None,
+        });
+        assert_eq!(
+            gcp.storage_options()["GOOGLE_SERVICE_ACCOUNT"],
+            "/keys/sa.json"
+        );
+
+        // Azure shared-key and GCP inline-key branches.
+        let az_key = DeltaCredentials::Azure(AzureCredentials {
+            account_name: None,
+            access_key: Some("shared-key".into()),
+            sas_token: None,
+        });
+        assert_eq!(
+            az_key.storage_options()["AZURE_STORAGE_ACCESS_KEY"],
+            "shared-key"
+        );
+        let gcp_key = DeltaCredentials::Gcp(GcpCredentials {
+            service_account_path: None,
+            service_account_key: Some("{\"type\":\"service_account\"}".into()),
+        });
+        assert_eq!(
+            gcp_key.storage_options()["GOOGLE_SERVICE_ACCOUNT_KEY"],
+            "{\"type\":\"service_account\"}"
+        );
+    }
+
+    #[test]
+    fn explicit_options_win_over_credentials() {
+        let c = DeltaCredentials::Aws(AwsCredentials {
+            region: Some("us-east-1".into()),
+            ..Default::default()
+        });
+        let mut opts = HashMap::new();
+        opts.insert("AWS_REGION".to_string(), "eu-west-1".to_string());
+        c.apply(&mut opts);
+        // Explicit value is preserved.
+        assert_eq!(opts["AWS_REGION"], "eu-west-1");
+    }
+
+    #[test]
+    fn tagged_shape_round_trips() {
+        let v = json!({ "type": "aws", "config": { "region": "us-east-1" } });
+        let c: DeltaCredentials = serde_json::from_value(v).unwrap();
+        assert_eq!(
+            c,
+            DeltaCredentials::Aws(AwsCredentials {
+                region: Some("us-east-1".into()),
+                ..Default::default()
+            })
+        );
+        // Default variant is just `{ "type": "default" }`.
+        let d: DeltaCredentials = serde_json::from_value(json!({ "type": "default" })).unwrap();
+        assert_eq!(d, DeltaCredentials::Default);
+    }
+}

--- a/crates/common/delta/src/lib.rs
+++ b/crates/common/delta/src/lib.rs
@@ -1,0 +1,35 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+//! # faucet-common-delta
+//!
+//! Shared configuration types and helpers for the
+//! [`faucet-stream`](https://crates.io/crates/faucet-stream) Delta Lake source
+//! and sink connectors, built on the Rust [`deltalake`](https://crates.io/crates/deltalake)
+//! crate (delta-rs).
+//!
+//! - [`DeltaCredentials`] — object-store credentials (default chain / AWS / Azure / GCP)
+//! - [`DeltaConnection`] — the shared `table_uri` / `credentials` / `storage_options`
+//!   block, flattened into both the source and sink config, plus the
+//!   open-table / storage-option / handler-registration helpers both connectors
+//!   share.
+//! - [`convert`] — Arrow ⇆ JSON conversion (`record_batch_to_json`,
+//!   `infer_arrow_schema`) reused by the source (read path) and sink
+//!   (write path).
+//!
+//! Cloud object-store backends are opt-in cargo features (`s3`, `azure`,
+//! `gcs`) that forward to the matching delta-rs feature; the default build
+//! supports the local filesystem only, keeping slim builds slim.
+//!
+//! All config types derive `Serialize`, `Deserialize`, and `JsonSchema` so they
+//! round-trip through YAML/JSON configs and CLI introspection.
+
+pub mod connection;
+pub mod convert;
+pub mod credentials;
+
+pub use connection::DeltaConnection;
+pub use credentials::{AwsCredentials, AzureCredentials, DeltaCredentials, GcpCredentials};
+
+// Re-export the pieces of `deltalake` connector authors touch so they don't
+// have to add the dependency (and pin its version) themselves.
+pub use deltalake::{self, DeltaTable, DeltaTableError};

--- a/crates/sink/delta/Cargo.toml
+++ b/crates/sink/delta/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "faucet-sink-delta"
+version = "1.0.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Apache Delta Lake sink for the faucet-stream ecosystem — append-only, local FS + S3/Azure/GCS"
+readme = "README.md"
+keywords = ["delta", "deltalake", "lakehouse", "sink", "etl"]
+categories.workspace = true
+
+[features]
+default = []
+s3 = ["faucet-common-delta/s3"]
+azure = ["faucet-common-delta/azure"]
+gcs = ["faucet-common-delta/gcs"]
+
+[dependencies]
+faucet-core.workspace = true
+faucet-common-delta.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+schemars.workspace = true
+async-trait.workspace = true
+tracing.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }
+deltalake.workspace = true
+arrow.workspace = true
+arrow-json.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }
+tempfile = "3"
+faucet-conformance.workspace = true
+faucet-source-delta.workspace = true
+serde_json.workspace = true
+schemars.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/sink/delta/README.md
+++ b/crates/sink/delta/README.md
@@ -1,0 +1,56 @@
+# faucet-sink-delta
+
+Apache **Delta Lake** sink for the [`faucet-stream`](https://crates.io/crates/faucet-stream)
+ecosystem. Appends JSON records to a Delta table on the local filesystem or
+cloud object storage (S3 / Azure / GCS) via the Rust
+[`deltalake`](https://crates.io/crates/deltalake) crate (delta-rs) — the
+idiomatic, high-throughput way to land data for **Databricks** (and Spark,
+Trino, DuckDB, Microsoft Fabric) at the open table-format level, with no
+running/billed compute and no Python.
+
+## Highlights
+
+- **Lazy create** — on first write the table is created from the inferred
+  schema when `create_if_not_missing` (default), honouring `partition_by`.
+- **Atomic commits** — each `flush()` is one Delta transaction, so a
+  bookmark-carrying page commits (and becomes visible) atomically.
+- **Append-only in v1** — `write_mode` is `append`. MERGE/upsert is a
+  version-gated follow-up.
+- **No datafusion** — appends via delta-rs's low-level `RecordBatchWriter`, so
+  the dependency tree (and compile time) stays slim.
+
+## Configuration
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `table_uri` | string | — (required) | `file:///…`, a bare local path, `s3://…`, `abfss://…`, `gs://…` |
+| `credentials` | tagged enum | `{ type: default }` | `default` / `aws` / `azure` / `gcp` |
+| `storage_options` | map | `{}` | Passed verbatim to delta-rs; explicit keys win over `credentials` |
+| `create_if_not_missing` | bool | `true` | Create the table + schema on first write |
+| `partition_by` | string[] | `[]` | Partition columns (applied only on create) |
+| `schema_sample_size` | int | `100` | Records sampled to infer the schema on create |
+| `batch_size` | int | `1000` | Arrow record-batch write size; `0` = no re-chunk |
+| `target_file_size` | int? | — | Advisory data-file size hint |
+
+Cloud backends require the matching crate feature: `s3`, `azure`, `gcs`.
+
+```yaml
+pipeline:
+  sink:
+    type: delta
+    config:
+      table_uri: s3://lake/events
+      credentials:
+        type: aws
+        config:
+          region: us-east-1
+      partition_by: ["region"]
+```
+
+## Contract
+
+Like the Parquet sink, the writer **must be `flush`ed before drop** — a
+dropped, un-flushed writer loses the buffered, uncommitted batch. The
+`faucet` pipeline flushes after every bookmark-carrying page.
+
+License: MIT OR Apache-2.0.

--- a/crates/sink/delta/src/config.rs
+++ b/crates/sink/delta/src/config.rs
@@ -1,0 +1,170 @@
+//! Delta Lake sink configuration.
+
+use faucet_common_delta::DeltaConnection;
+use faucet_core::{DEFAULT_BATCH_SIZE, validate_batch_size};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Default number of records sampled to infer the table schema on first write.
+pub const DEFAULT_SAMPLE_SIZE: usize = 100;
+
+fn default_true() -> bool {
+    true
+}
+
+fn default_sample_size() -> usize {
+    DEFAULT_SAMPLE_SIZE
+}
+
+fn default_batch_size() -> usize {
+    DEFAULT_BATCH_SIZE
+}
+
+/// Configuration for the Delta Lake sink connector (append-only in v1).
+///
+/// The `table_uri` / `credentials` / `storage_options` keys are flattened in
+/// from the shared [`DeltaConnection`]. On first write the sink opens the
+/// table (creating it from the inferred schema when `create_if_not_missing`),
+/// then appends one Delta commit per `flush()`.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct DeltaSinkConfig {
+    /// Table location + object-store credentials.
+    #[serde(flatten)]
+    pub connection: DeltaConnection,
+
+    /// Create the table (and its schema, from the inferred record shape) on the
+    /// first write when it does not already exist. When `false`, an absent
+    /// table fails the first write with a typed error.
+    #[serde(default = "default_true")]
+    pub create_if_not_missing: bool,
+
+    /// Partition columns, applied only when the table is created. Ignored when
+    /// appending to an existing table (its stored partitioning is used).
+    #[serde(default)]
+    pub partition_by: Vec<String>,
+
+    /// Records sampled to infer the Arrow/Delta schema when creating the table.
+    #[serde(default = "default_sample_size")]
+    pub schema_sample_size: usize,
+
+    /// Re-chunk size for [`Sink::write_batch`](faucet_core::Sink::write_batch).
+    /// Incoming pages larger than this are sliced into `batch_size`-row Arrow
+    /// batches before writing. `0` writes each page through as one batch.
+    #[serde(default = "default_batch_size")]
+    pub batch_size: usize,
+
+    /// Optional target data-file size (bytes) hint for the writer's rollover.
+    /// Advisory — delta-rs rolls files at buffer boundaries near this size.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target_file_size: Option<usize>,
+}
+
+impl DeltaSinkConfig {
+    /// Build a sink config for `table_uri` with defaults.
+    pub fn new(table_uri: impl Into<String>) -> Self {
+        Self {
+            connection: DeltaConnection {
+                table_uri: table_uri.into(),
+                credentials: Default::default(),
+                storage_options: Default::default(),
+            },
+            create_if_not_missing: true,
+            partition_by: Vec::new(),
+            schema_sample_size: DEFAULT_SAMPLE_SIZE,
+            batch_size: DEFAULT_BATCH_SIZE,
+            target_file_size: None,
+        }
+    }
+
+    /// Validate the config; returns a human-readable error string if invalid.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.connection.table_uri.trim().is_empty() {
+            return Err("delta sink: `table_uri` must not be empty".to_string());
+        }
+        if self.schema_sample_size == 0 {
+            return Err("delta sink: `schema_sample_size` must be greater than 0".to_string());
+        }
+        if matches!(self.target_file_size, Some(0)) {
+            return Err(
+                "delta sink: `target_file_size` must be greater than 0 when set".to_string(),
+            );
+        }
+        validate_batch_size(self.batch_size)
+            .map_err(|e| format!("delta sink: invalid batch_size: {e}"))?;
+        Ok(())
+    }
+
+    /// Effective schema sample size (never zero after validation).
+    pub fn effective_sample_size(&self) -> usize {
+        self.schema_sample_size.max(1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn new_has_sane_defaults() {
+        let c = DeltaSinkConfig::new("file:///tmp/t");
+        assert!(c.create_if_not_missing);
+        assert_eq!(c.schema_sample_size, DEFAULT_SAMPLE_SIZE);
+        assert_eq!(c.batch_size, DEFAULT_BATCH_SIZE);
+        assert!(c.partition_by.is_empty());
+        c.validate().unwrap();
+    }
+
+    #[test]
+    fn rejects_empty_uri_and_zero_sample() {
+        assert!(DeltaSinkConfig::new("").validate().is_err());
+        let mut c = DeltaSinkConfig::new("file:///tmp/t");
+        c.schema_sample_size = 0;
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_zero_target_file_size() {
+        let mut c = DeltaSinkConfig::new("file:///tmp/t");
+        c.target_file_size = Some(0);
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_oversized_batch() {
+        let mut c = DeltaSinkConfig::new("file:///tmp/t");
+        c.batch_size = faucet_core::MAX_BATCH_SIZE + 1;
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn deserializes_minimal_applies_defaults() {
+        // Only `table_uri` → every `#[serde(default = …)]` fn runs.
+        let c: DeltaSinkConfig =
+            serde_json::from_value(json!({ "table_uri": "file:///t" })).unwrap();
+        assert!(c.create_if_not_missing);
+        assert_eq!(c.schema_sample_size, DEFAULT_SAMPLE_SIZE);
+        assert_eq!(c.batch_size, faucet_core::DEFAULT_BATCH_SIZE);
+        assert_eq!(c.effective_sample_size(), DEFAULT_SAMPLE_SIZE);
+        assert!(c.target_file_size.is_none());
+        c.validate().unwrap();
+    }
+
+    #[test]
+    fn deserializes_flattened_shape_with_partitions() {
+        let v = json!({
+            "table_uri": "s3://b/t",
+            "partition_by": ["dt"],
+            "create_if_not_missing": false,
+            "storage_options": { "AWS_ALLOW_HTTP": "true" }
+        });
+        let c: DeltaSinkConfig = serde_json::from_value(v).unwrap();
+        assert_eq!(c.partition_by, vec!["dt"]);
+        assert!(!c.create_if_not_missing);
+        assert_eq!(
+            c.connection.merged_storage_options()["AWS_ALLOW_HTTP"],
+            "true"
+        );
+        c.validate().unwrap();
+    }
+}

--- a/crates/sink/delta/src/lib.rs
+++ b/crates/sink/delta/src/lib.rs
@@ -1,0 +1,30 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+//! # faucet-sink-delta
+//!
+//! Apache Delta Lake sink for the [`faucet-stream`](https://crates.io/crates/faucet-stream)
+//! ecosystem. Appends JSON records to a Delta table on the local filesystem or
+//! cloud object storage (S3 / Azure / GCS) via the Rust
+//! [`deltalake`](https://crates.io/crates/deltalake) crate — the idiomatic,
+//! high-throughput way to land data for Databricks (and Spark, Trino, DuckDB,
+//! Microsoft Fabric) at the open table-format level.
+//!
+//! - Lazily creates the table from the inferred schema on first write
+//!   (`create_if_not_missing`), honouring `partition_by`.
+//! - Appends one atomic Delta commit per [`flush`](faucet_core::Sink::flush).
+//! - **Append-only in v1** — [`Sink::supported_write_modes`](faucet_core::Sink::supported_write_modes)
+//!   returns `[Append]` (MERGE/upsert is a version-gated follow-up).
+//! - No datafusion dependency: append uses delta-rs's low-level
+//!   `RecordBatchWriter`.
+//!
+//! Cloud backends are opt-in cargo features: `s3`, `azure`, `gcs`.
+
+mod config;
+mod sink;
+
+pub use config::{DEFAULT_SAMPLE_SIZE, DeltaSinkConfig};
+pub use sink::DeltaSink;
+
+// Re-export the shared connection/credentials types so downstream users need
+// only depend on this crate.
+pub use faucet_common_delta::{DeltaConnection, DeltaCredentials};

--- a/crates/sink/delta/src/sink.rs
+++ b/crates/sink/delta/src/sink.rs
@@ -1,0 +1,350 @@
+//! Delta Lake sink executor.
+//!
+//! Lazily opens (or creates) the target Delta table on the first `write_batch`
+//! so the schema can be inferred from real records, then appends via
+//! delta-rs's low-level [`RecordBatchWriter`] — one Delta commit per
+//! [`flush`](faucet_core::Sink::flush). No datafusion is pulled in.
+//!
+//! ## Flush / commit contract
+//!
+//! `RecordBatchWriter` buffers written batches into parquet in memory; the
+//! Delta transaction is only committed by `flush_and_commit`. The pipeline
+//! calls [`flush`](faucet_core::Sink::flush) after every bookmark-carrying
+//! page, so each page becomes its own atomic Delta commit. **A dropped sink
+//! that never `flush`es loses the buffered, uncommitted batch** — the same
+//! contract as the Parquet sink.
+
+use std::collections::HashSet;
+
+use arrow::datatypes::SchemaRef;
+use arrow::record_batch::RecordBatch;
+use async_trait::async_trait;
+use deltalake::DeltaTable;
+use deltalake::kernel::StructType;
+use deltalake::kernel::engine::arrow_conversion::TryIntoKernel;
+use deltalake::operations::create::CreateBuilder;
+use deltalake::writer::{DeltaWriter, RecordBatchWriter};
+use faucet_common_delta::convert::infer_arrow_schema;
+use faucet_core::{FaucetError, WriteMode};
+use serde_json::Value;
+use tokio::sync::Mutex;
+
+use crate::config::DeltaSinkConfig;
+
+/// A sink that appends JSON records to an Apache Delta Lake table.
+pub struct DeltaSink {
+    config: DeltaSinkConfig,
+    state: Mutex<SinkState>,
+}
+
+/// Mutable per-run state, guarded by a `Mutex` so `write_batch(&self, …)` can
+/// mutate the open table / writer.
+struct SinkState {
+    /// The open Delta table, established on first write. Advanced in place by
+    /// each `flush_and_commit`.
+    table: Option<DeltaTable>,
+    /// The record-batch writer bound to `table`. Rebuilt after a table (re)open.
+    writer: Option<RecordBatchWriter>,
+    /// The Arrow schema locked in on first write; every subsequent batch is
+    /// decoded against it. A record that diverges fails the batch (v1: no
+    /// schema evolution).
+    schema: Option<SchemaRef>,
+    /// Fields warned-about as dropped (present in a record, absent from the
+    /// locked schema). Deduped to one line per field per run.
+    warned_fields: HashSet<String>,
+    /// Whether any batch has been buffered since the last commit (so `flush`
+    /// can skip a no-op commit).
+    pending: bool,
+}
+
+impl SinkState {
+    fn new() -> Self {
+        Self {
+            table: None,
+            writer: None,
+            schema: None,
+            warned_fields: HashSet::new(),
+            pending: false,
+        }
+    }
+}
+
+impl DeltaSink {
+    /// Build a new Delta sink. Validates config eagerly; the table is opened
+    /// lazily on the first write.
+    pub async fn new(config: DeltaSinkConfig) -> Result<Self, FaucetError> {
+        config
+            .validate()
+            .map_err(|e| FaucetError::Config(format!("invalid delta sink config: {e}")))?;
+        // Register cloud object-store handlers up front so a bad scheme fails
+        // predictably rather than on first write.
+        config.connection.register_handlers();
+        Ok(Self {
+            config,
+            state: Mutex::new(SinkState::new()),
+        })
+    }
+
+    /// Ensure the table + writer + schema are established, inferring the schema
+    /// from `records` on the very first call.
+    async fn ensure_open(
+        &self,
+        state: &mut SinkState,
+        records: &[Value],
+    ) -> Result<(), FaucetError> {
+        if state.schema.is_none() {
+            let schema = infer_arrow_schema(records, self.config.effective_sample_size())?;
+            state.schema = Some(schema);
+        }
+        let schema = state.schema.clone().expect("schema set above");
+
+        if state.table.is_none() {
+            let table = self.open_or_create(&schema).await?;
+            state.table = Some(table);
+        }
+        if state.writer.is_none() {
+            let table = state.table.as_ref().expect("table set above");
+            let writer = RecordBatchWriter::for_table(table).map_err(|e| {
+                FaucetError::Sink(format!("delta: could not build record-batch writer: {e}"))
+            })?;
+            state.writer = Some(writer);
+        }
+        Ok(())
+    }
+
+    /// Open the existing table or create it from the inferred schema.
+    async fn open_or_create(&self, schema: &SchemaRef) -> Result<DeltaTable, FaucetError> {
+        if let Some(table) = self.config.connection.open_optional().await? {
+            return Ok(table);
+        }
+        if !self.config.create_if_not_missing {
+            return Err(FaucetError::Sink(format!(
+                "delta: table '{}' does not exist and create_if_not_missing is false",
+                self.config.connection.redacted_uri()
+            )));
+        }
+        self.create_table(schema).await
+    }
+
+    /// Create a new Delta table from the inferred Arrow schema + partitioning.
+    async fn create_table(&self, schema: &SchemaRef) -> Result<DeltaTable, FaucetError> {
+        // Every partition column must exist in the record schema.
+        for col in &self.config.partition_by {
+            if schema.field_with_name(col).is_err() {
+                return Err(FaucetError::Sink(format!(
+                    "delta: partition column '{col}' not present in the inferred record schema"
+                )));
+            }
+        }
+
+        let delta_schema: StructType = schema.as_ref().try_into_kernel().map_err(|e| {
+            FaucetError::Sink(format!(
+                "delta: could not convert Arrow schema to Delta: {e}"
+            ))
+        })?;
+
+        let mut builder = CreateBuilder::new()
+            .with_location(self.config.connection.location_string()?)
+            .with_storage_options(self.config.connection.merged_storage_options())
+            .with_columns(delta_schema.fields().cloned());
+        if !self.config.partition_by.is_empty() {
+            builder = builder.with_partition_columns(self.config.partition_by.clone());
+        }
+
+        builder.await.map_err(|e| {
+            FaucetError::Sink(format!(
+                "delta: could not create table '{}': {e}",
+                self.config.connection.redacted_uri()
+            ))
+        })
+    }
+
+    /// Decode a chunk of JSON records into a `RecordBatch` against the locked
+    /// schema, warning once per dropped unknown field.
+    fn encode_batch(
+        &self,
+        warned_fields: &mut HashSet<String>,
+        schema: SchemaRef,
+        records: &[Value],
+    ) -> Result<RecordBatch, FaucetError> {
+        warn_on_unknown_fields(warned_fields, &schema, records);
+
+        let mut decoder = arrow_json::ReaderBuilder::new(schema.clone())
+            .build_decoder()
+            .map_err(|e| FaucetError::Sink(format!("delta: could not build json decoder: {e}")))?;
+        decoder.serialize(records).map_err(|e| {
+            FaucetError::Sink(format!("delta: record does not match table schema: {e}"))
+        })?;
+        decoder
+            .flush()
+            .map_err(|e| FaucetError::Sink(format!("delta: json decode error: {e}")))?
+            .ok_or_else(|| FaucetError::Sink("delta: json decoder produced no batch".to_string()))
+    }
+
+    /// Write one chunk of records into the buffered writer.
+    async fn write_chunk(
+        &self,
+        state: &mut SinkState,
+        records: &[Value],
+    ) -> Result<usize, FaucetError> {
+        if records.is_empty() {
+            return Ok(0);
+        }
+        self.ensure_open(state, records).await?;
+        let schema = state.schema.clone().expect("schema set");
+        let batch = self.encode_batch(&mut state.warned_fields, schema, records)?;
+        let rows = batch.num_rows();
+        let writer = state.writer.as_mut().expect("writer set");
+        writer
+            .write(batch)
+            .await
+            .map_err(|e| FaucetError::Sink(format!("delta: write failed: {e}")))?;
+        state.pending = true;
+        Ok(rows)
+    }
+}
+
+#[async_trait]
+impl faucet_core::Sink for DeltaSink {
+    fn config_schema(&self) -> Value {
+        serde_json::to_value(faucet_core::schema_for!(DeltaSinkConfig))
+            .expect("schema serialization")
+    }
+
+    fn connector_name(&self) -> &'static str {
+        "delta"
+    }
+
+    fn dataset_uri(&self) -> String {
+        self.config.connection.redacted_uri()
+    }
+
+    fn supported_write_modes(&self) -> &'static [WriteMode] {
+        // Append-only in v1 (mirrors the Iceberg sink). MERGE/upsert is a
+        // version-gated follow-up (#317 "Out of scope").
+        &[WriteMode::Append]
+    }
+
+    async fn check(
+        &self,
+        ctx: &faucet_core::check::CheckContext,
+    ) -> Result<faucet_core::check::CheckReport, FaucetError> {
+        use faucet_core::check::{CheckReport, Probe};
+        let started = std::time::Instant::now();
+        // Metadata-only open (no data scan). A reachable store passes whether
+        // or not the table exists yet — `create_if_not_missing` handles an
+        // absent table at write time.
+        let probe =
+            match tokio::time::timeout(ctx.timeout, self.config.connection.open_optional()).await {
+                Ok(Ok(_)) => Probe::pass("table", started.elapsed()),
+                Ok(Err(e)) => Probe::fail_hint(
+                    "table",
+                    started.elapsed(),
+                    format!("delta sink probe failed: {e}"),
+                    "Verify table_uri, credentials, and object-store reachability.",
+                ),
+                Err(_) => Probe::fail_hint(
+                    "table",
+                    started.elapsed(),
+                    format!("delta sink probe timed out after {:?}", ctx.timeout),
+                    "Check object-store network reachability.",
+                ),
+            };
+        Ok(CheckReport::single(probe))
+    }
+
+    async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
+        if records.is_empty() {
+            return Ok(0);
+        }
+        let mut state = self.state.lock().await;
+        let bs = self.config.batch_size;
+        let mut total = 0;
+        if bs == 0 || records.len() <= bs {
+            total += self.write_chunk(&mut state, records).await?;
+        } else {
+            for chunk in records.chunks(bs) {
+                total += self.write_chunk(&mut state, chunk).await?;
+            }
+        }
+        Ok(total)
+    }
+
+    async fn flush(&self) -> Result<(), FaucetError> {
+        let mut state = self.state.lock().await;
+        if !state.pending {
+            return Ok(());
+        }
+        // Take the writer + table out to satisfy the borrow checker, commit,
+        // then put the table back and drop the (now-flushed) writer so the next
+        // page rebuilds a fresh writer against the advanced table.
+        let mut writer = match state.writer.take() {
+            Some(w) => w,
+            None => return Ok(()),
+        };
+        let mut table = state
+            .table
+            .take()
+            .ok_or_else(|| FaucetError::Sink("delta: flush without an open table".to_string()))?;
+        let version = writer
+            .flush_and_commit(&mut table)
+            .await
+            .map_err(|e| FaucetError::Sink(format!("delta: commit failed: {e}")))?;
+        tracing::debug!(version, uri = %self.config.connection.redacted_uri(), "delta commit");
+        state.table = Some(table);
+        state.pending = false;
+        Ok(())
+    }
+}
+
+/// Emit a one-shot warning for each field present in `records` but absent from
+/// the locked `schema` (such fields are dropped by the JSON decoder).
+fn warn_on_unknown_fields(
+    warned_fields: &mut HashSet<String>,
+    schema: &SchemaRef,
+    records: &[Value],
+) {
+    for rec in records {
+        if let Value::Object(map) = rec {
+            for key in map.keys() {
+                if schema.field_with_name(key).is_err() && warned_fields.insert(key.clone()) {
+                    tracing::warn!(
+                        field = %key,
+                        "delta sink: dropping field not present in the table schema"
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use faucet_core::Sink;
+
+    #[tokio::test]
+    async fn trait_metadata_methods() {
+        let sink = DeltaSink::new(DeltaSinkConfig::new("file:///tmp/delta_meta"))
+            .await
+            .unwrap();
+        assert_eq!(sink.connector_name(), "delta");
+        assert_eq!(sink.dataset_uri(), "file:///tmp/delta_meta");
+        assert_eq!(sink.supported_write_modes(), &[WriteMode::Append]);
+        assert!(sink.config_schema().is_object());
+    }
+
+    #[tokio::test]
+    async fn create_table_rejects_missing_partition_column() {
+        let dir = tempfile::tempdir().unwrap();
+        let uri = dir.path().join("p").to_string_lossy().into_owned();
+        let mut cfg = DeltaSinkConfig::new(&uri);
+        cfg.partition_by = vec!["nope".into()];
+        let sink = DeltaSink::new(cfg).await.unwrap();
+        let err = sink
+            .write_batch(&[serde_json::json!({"id": 1})])
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("partition column"), "{err}");
+    }
+}

--- a/crates/sink/delta/tests/roundtrip.rs
+++ b/crates/sink/delta/tests/roundtrip.rs
@@ -1,0 +1,281 @@
+//! End-to-end round-trip tests against a real Delta table on the local
+//! filesystem: write with `DeltaSink`, read back with `DeltaSource`, assert
+//! row-count and content parity. No Docker / object store required.
+
+use std::collections::HashMap;
+
+use faucet_core::{Sink, Source};
+use faucet_sink_delta::{DeltaSink, DeltaSinkConfig};
+use faucet_source_delta::{DeltaSource, DeltaSourceConfig};
+use serde_json::{Value, json};
+
+fn table_uri(dir: &tempfile::TempDir, name: &str) -> String {
+    // Bare absolute path — `ensure_table_uri` promotes it to file://.
+    dir.path().join(name).to_string_lossy().into_owned()
+}
+
+async fn read_all(uri: &str, cfg: impl FnOnce(&mut DeltaSourceConfig)) -> Vec<Value> {
+    let mut sc = DeltaSourceConfig::new(uri);
+    cfg(&mut sc);
+    let source = DeltaSource::new(sc).await.expect("source");
+    source
+        .fetch_with_context(&HashMap::new())
+        .await
+        .expect("read")
+}
+
+#[tokio::test]
+async fn append_new_table_then_read_back() {
+    let dir = tempfile::tempdir().unwrap();
+    let uri = table_uri(&dir, "events");
+
+    let sink = DeltaSink::new(DeltaSinkConfig::new(&uri)).await.unwrap();
+    let batch = vec![
+        json!({"id": 1, "name": "alice"}),
+        json!({"id": 2, "name": "bob"}),
+    ];
+    let n = sink.write_batch(&batch).await.unwrap();
+    assert_eq!(n, 2);
+    sink.flush().await.unwrap();
+
+    let rows = read_all(&uri, |_| {}).await;
+    assert_eq!(rows.len(), 2, "row-count parity");
+    let ids: Vec<i64> = rows.iter().map(|r| r["id"].as_i64().unwrap()).collect();
+    assert!(ids.contains(&1) && ids.contains(&2));
+}
+
+#[tokio::test]
+async fn two_flushes_accumulate_across_commits() {
+    let dir = tempfile::tempdir().unwrap();
+    let uri = table_uri(&dir, "multi");
+
+    let sink = DeltaSink::new(DeltaSinkConfig::new(&uri)).await.unwrap();
+    sink.write_batch(&[json!({"id": 1})]).await.unwrap();
+    sink.flush().await.unwrap();
+    sink.write_batch(&[json!({"id": 2}), json!({"id": 3})])
+        .await
+        .unwrap();
+    sink.flush().await.unwrap();
+
+    let rows = read_all(&uri, |_| {}).await;
+    assert_eq!(rows.len(), 3, "both commits visible");
+}
+
+#[tokio::test]
+async fn append_to_existing_table_across_sink_instances() {
+    let dir = tempfile::tempdir().unwrap();
+    let uri = table_uri(&dir, "existing");
+
+    {
+        let sink = DeltaSink::new(DeltaSinkConfig::new(&uri)).await.unwrap();
+        sink.write_batch(&[json!({"id": 1})]).await.unwrap();
+        sink.flush().await.unwrap();
+    }
+    // A brand-new sink instance opens the existing table and appends.
+    {
+        let mut cfg = DeltaSinkConfig::new(&uri);
+        cfg.create_if_not_missing = false;
+        let sink = DeltaSink::new(cfg).await.unwrap();
+        sink.write_batch(&[json!({"id": 2})]).await.unwrap();
+        sink.flush().await.unwrap();
+    }
+
+    let rows = read_all(&uri, |_| {}).await;
+    assert_eq!(rows.len(), 2);
+}
+
+#[tokio::test]
+async fn partitioned_table_round_trips_partition_column() {
+    let dir = tempfile::tempdir().unwrap();
+    let uri = table_uri(&dir, "part");
+
+    let mut cfg = DeltaSinkConfig::new(&uri);
+    cfg.partition_by = vec!["region".into()];
+    let sink = DeltaSink::new(cfg).await.unwrap();
+    sink.write_batch(&[
+        json!({"id": 1, "region": "us"}),
+        json!({"id": 2, "region": "eu"}),
+        json!({"id": 3, "region": "us"}),
+    ])
+    .await
+    .unwrap();
+    sink.flush().await.unwrap();
+
+    let rows = read_all(&uri, |_| {}).await;
+    assert_eq!(rows.len(), 3);
+    // Partition column (stored in the path, not the file) is reconstructed.
+    let us = rows.iter().filter(|r| r["region"] == json!("us")).count();
+    let eu = rows.iter().filter(|r| r["region"] == json!("eu")).count();
+    assert_eq!(us, 2);
+    assert_eq!(eu, 1);
+}
+
+#[tokio::test]
+async fn projection_limits_columns() {
+    let dir = tempfile::tempdir().unwrap();
+    let uri = table_uri(&dir, "proj");
+
+    let sink = DeltaSink::new(DeltaSinkConfig::new(&uri)).await.unwrap();
+    sink.write_batch(&[json!({"id": 1, "name": "a", "extra": "x"})])
+        .await
+        .unwrap();
+    sink.flush().await.unwrap();
+
+    let rows = read_all(&uri, |c| c.columns = vec!["id".into()]).await;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["id"], json!(1));
+    assert!(rows[0].get("name").is_none());
+    assert!(rows[0].get("extra").is_none());
+}
+
+#[tokio::test]
+async fn time_travel_by_version() {
+    let dir = tempfile::tempdir().unwrap();
+    let uri = table_uri(&dir, "tt");
+
+    let sink = DeltaSink::new(DeltaSinkConfig::new(&uri)).await.unwrap();
+    sink.write_batch(&[json!({"id": 1})]).await.unwrap();
+    sink.flush().await.unwrap(); // version 1 (create = 0)
+    sink.write_batch(&[json!({"id": 2})]).await.unwrap();
+    sink.flush().await.unwrap(); // version 2
+
+    // Latest sees both rows.
+    let latest = read_all(&uri, |_| {}).await;
+    assert_eq!(latest.len(), 2);
+
+    // Version 1 (first data commit) sees only the first row.
+    let v1 = read_all(&uri, |c| c.version = Some(1)).await;
+    assert_eq!(v1.len(), 1);
+    assert_eq!(v1[0]["id"], json!(1));
+}
+
+#[tokio::test]
+async fn missing_table_without_create_errors() {
+    let dir = tempfile::tempdir().unwrap();
+    let uri = table_uri(&dir, "nope");
+
+    let mut cfg = DeltaSinkConfig::new(&uri);
+    cfg.create_if_not_missing = false;
+    let sink = DeltaSink::new(cfg).await.unwrap();
+    let err = sink.write_batch(&[json!({"id": 1})]).await.unwrap_err();
+    assert!(
+        err.to_string().contains("does not exist"),
+        "unexpected error: {err}"
+    );
+}
+
+#[tokio::test]
+async fn empty_batch_is_noop() {
+    let dir = tempfile::tempdir().unwrap();
+    let uri = table_uri(&dir, "empty");
+    let sink = DeltaSink::new(DeltaSinkConfig::new(&uri)).await.unwrap();
+    assert_eq!(sink.write_batch(&[]).await.unwrap(), 0);
+    // Nothing buffered → flush is a clean no-op.
+    sink.flush().await.unwrap();
+}
+
+#[tokio::test]
+async fn sink_check_passes_on_reachable_store() {
+    use faucet_core::check::{CheckContext, ProbeStatus};
+    let dir = tempfile::tempdir().unwrap();
+    let uri = table_uri(&dir, "chk");
+    // Table need not exist — create_if_not_missing handles that at write time,
+    // so a reachable (local) store passes.
+    let sink = DeltaSink::new(DeltaSinkConfig::new(&uri)).await.unwrap();
+    let report = sink.check(&CheckContext::default()).await.unwrap();
+    assert!(
+        report
+            .probes
+            .iter()
+            .all(|p| matches!(p.status, ProbeStatus::Pass)),
+        "sink check should pass: {report:?}"
+    );
+}
+
+#[tokio::test]
+async fn source_check_pass_and_fail() {
+    use faucet_core::check::{CheckContext, ProbeStatus};
+    let dir = tempfile::tempdir().unwrap();
+    let uri = table_uri(&dir, "srcchk");
+
+    // Missing table → probe fails.
+    let missing = DeltaSource::new(DeltaSourceConfig::new(&uri))
+        .await
+        .unwrap();
+    let report = missing.check(&CheckContext::default()).await.unwrap();
+    assert!(
+        report
+            .probes
+            .iter()
+            .any(|p| matches!(p.status, ProbeStatus::Fail { .. })),
+        "source check should fail on a missing table"
+    );
+
+    // After a write the table exists → probe passes.
+    let sink = DeltaSink::new(DeltaSinkConfig::new(&uri)).await.unwrap();
+    sink.write_batch(&[json!({"id": 1})]).await.unwrap();
+    sink.flush().await.unwrap();
+    let source = DeltaSource::new(DeltaSourceConfig::new(&uri))
+        .await
+        .unwrap();
+    let report = source.check(&CheckContext::default()).await.unwrap();
+    assert!(
+        report
+            .probes
+            .iter()
+            .all(|p| matches!(p.status, ProbeStatus::Pass)),
+        "source check should pass on an existing table: {report:?}"
+    );
+}
+
+#[tokio::test]
+async fn time_travel_by_timestamp() {
+    let dir = tempfile::tempdir().unwrap();
+    let uri = table_uri(&dir, "ts");
+    let sink = DeltaSink::new(DeltaSinkConfig::new(&uri)).await.unwrap();
+    sink.write_batch(&[json!({"id": 1})]).await.unwrap();
+    sink.flush().await.unwrap();
+
+    // A far-future timestamp resolves to the latest version (all rows).
+    let rows = read_all(&uri, |c| c.timestamp = Some("2999-01-01T00:00:00Z".into())).await;
+    assert_eq!(rows.len(), 1);
+}
+
+#[tokio::test]
+async fn invalid_timestamp_errors() {
+    let dir = tempfile::tempdir().unwrap();
+    let uri = table_uri(&dir, "badts");
+    let sink = DeltaSink::new(DeltaSinkConfig::new(&uri)).await.unwrap();
+    sink.write_batch(&[json!({"id": 1})]).await.unwrap();
+    sink.flush().await.unwrap();
+
+    let mut sc = DeltaSourceConfig::new(&uri);
+    sc.timestamp = Some("not-a-timestamp".into());
+    let source = DeltaSource::new(sc).await.unwrap();
+    let err = source
+        .fetch_with_context(&HashMap::new())
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().to_lowercase().contains("timestamp"),
+        "{err}"
+    );
+}
+
+#[tokio::test]
+async fn unknown_field_is_dropped_not_fatal() {
+    let dir = tempfile::tempdir().unwrap();
+    let uri = table_uri(&dir, "drift");
+    let sink = DeltaSink::new(DeltaSinkConfig::new(&uri)).await.unwrap();
+    // Schema locked from the first record ({id}); a later record with an
+    // extra field has that field dropped, not erroring the batch.
+    sink.write_batch(&[json!({"id": 1})]).await.unwrap();
+    sink.write_batch(&[json!({"id": 2, "surprise": "x"})])
+        .await
+        .unwrap();
+    sink.flush().await.unwrap();
+
+    let rows = read_all(&uri, |_| {}).await;
+    assert_eq!(rows.len(), 2);
+    assert!(rows.iter().all(|r| r.get("surprise").is_none()));
+}

--- a/crates/source/delta/Cargo.toml
+++ b/crates/source/delta/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+name = "faucet-source-delta"
+version = "1.0.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Apache Delta Lake source for the faucet-stream ecosystem — local FS + S3/Azure/GCS, time travel"
+readme = "README.md"
+keywords = ["delta", "deltalake", "lakehouse", "source", "etl"]
+categories.workspace = true
+
+[features]
+default = []
+s3 = ["faucet-common-delta/s3"]
+azure = ["faucet-common-delta/azure"]
+gcs = ["faucet-common-delta/gcs"]
+
+[dependencies]
+faucet-core.workspace = true
+faucet-common-delta.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+schemars.workspace = true
+async-trait.workspace = true
+tracing.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }
+futures.workspace = true
+async-stream.workspace = true
+deltalake.workspace = true
+arrow.workspace = true
+parquet = { workspace = true }
+object_store.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }
+tempfile = "3"
+faucet-conformance.workspace = true
+serde_json.workspace = true
+schemars.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/source/delta/README.md
+++ b/crates/source/delta/README.md
@@ -1,0 +1,46 @@
+# faucet-source-delta
+
+Apache **Delta Lake** source for the [`faucet-stream`](https://crates.io/crates/faucet-stream)
+ecosystem. Streams the rows of a Delta table on the local filesystem or cloud
+object storage (S3 / Azure / GCS) via the Rust
+[`deltalake`](https://crates.io/crates/deltalake) crate (delta-rs) — reading the
+same open table format **Databricks** (and Spark, Trino, DuckDB, Microsoft
+Fabric) write.
+
+## Highlights
+
+- **Bounded streaming** — the active file set is read from the Delta log and
+  each parquet data file is streamed through the async Arrow reader; memory
+  stays at one `batch_size`, no whole-table buffering, no datafusion.
+- **Time travel** — read a pinned `version` or as-of `timestamp`.
+- **Projection pushdown** — `columns` limits the columns read.
+- **Partition-aware** — partition-column values (stored in the Hive-style path,
+  not the data files) are reconstructed and merged into every row, typed
+  against the table schema.
+
+## Configuration
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `table_uri` | string | — (required) | `file:///…`, a bare local path, `s3://…`, `abfss://…`, `gs://…` |
+| `credentials` | tagged enum | `{ type: default }` | `default` / `aws` / `azure` / `gcp` |
+| `storage_options` | map | `{}` | Passed verbatim to delta-rs; explicit keys win over `credentials` |
+| `version` | int? | — | Time travel: read as of this version (mutually exclusive with `timestamp`) |
+| `timestamp` | string? | — | Time travel: read as of this RFC 3339 timestamp |
+| `columns` | string[] | `[]` (all) | Projection pushdown |
+| `batch_size` | int | `1000` | Page-size hint; `0` = one page per file |
+
+Cloud backends require the matching crate feature: `s3`, `azure`, `gcs`.
+
+```yaml
+pipeline:
+  source:
+    type: delta
+    config:
+      table_uri: s3://lake/events
+      credentials: { type: aws, config: { region: us-east-1 } }
+      version: 42
+      columns: ["id", "ts", "region"]
+```
+
+License: MIT OR Apache-2.0.

--- a/crates/source/delta/src/config.rs
+++ b/crates/source/delta/src/config.rs
@@ -1,0 +1,129 @@
+//! Delta Lake source configuration.
+
+use faucet_common_delta::DeltaConnection;
+use faucet_core::{DEFAULT_BATCH_SIZE, validate_batch_size};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+fn default_batch_size() -> usize {
+    DEFAULT_BATCH_SIZE
+}
+
+/// Configuration for the Delta Lake source connector.
+///
+/// The `table_uri` / `credentials` / `storage_options` keys are flattened in
+/// from the shared [`DeltaConnection`]. Reads scan the table's active data
+/// files at the latest version (or a pinned `version` / `timestamp` for time
+/// travel) and yield each row as a JSON object.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct DeltaSourceConfig {
+    /// Table location + object-store credentials.
+    #[serde(flatten)]
+    pub connection: DeltaConnection,
+
+    /// Time travel: read the table as of this version. Mutually exclusive with
+    /// `timestamp`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<u64>,
+
+    /// Time travel: read the table as of this RFC 3339 timestamp. Mutually
+    /// exclusive with `version`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<String>,
+
+    /// Projection pushdown: only read these columns. Empty = all columns.
+    #[serde(default)]
+    pub columns: Vec<String>,
+
+    /// Page size hint for [`stream_pages`](faucet_core::Source::stream_pages).
+    /// Governs how many rows accumulate before a `StreamPage` is emitted; the
+    /// underlying parquet row-group size still bounds each read. `0` is the
+    /// "no batching" sentinel — one page per file.
+    #[serde(default = "default_batch_size")]
+    pub batch_size: usize,
+}
+
+impl DeltaSourceConfig {
+    /// Build a source config for `table_uri` with defaults.
+    pub fn new(table_uri: impl Into<String>) -> Self {
+        Self {
+            connection: DeltaConnection {
+                table_uri: table_uri.into(),
+                credentials: Default::default(),
+                storage_options: Default::default(),
+            },
+            version: None,
+            timestamp: None,
+            columns: Vec::new(),
+            batch_size: DEFAULT_BATCH_SIZE,
+        }
+    }
+
+    /// Validate the config; returns a human-readable error string if invalid.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.connection.table_uri.trim().is_empty() {
+            return Err("delta source: `table_uri` must not be empty".to_string());
+        }
+        if self.version.is_some() && self.timestamp.is_some() {
+            return Err(
+                "delta source: `version` and `timestamp` are mutually exclusive".to_string(),
+            );
+        }
+        validate_batch_size(self.batch_size)
+            .map_err(|e| format!("delta source: invalid batch_size: {e}"))?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn new_has_sane_defaults() {
+        let c = DeltaSourceConfig::new("file:///tmp/t");
+        assert_eq!(c.connection.table_uri, "file:///tmp/t");
+        assert_eq!(c.batch_size, DEFAULT_BATCH_SIZE);
+        assert!(c.columns.is_empty());
+        c.validate().unwrap();
+    }
+
+    #[test]
+    fn rejects_empty_uri() {
+        let mut c = DeltaSourceConfig::new("");
+        assert!(c.validate().is_err());
+        c.connection.table_uri = "   ".into();
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_version_and_timestamp_together() {
+        let mut c = DeltaSourceConfig::new("file:///tmp/t");
+        c.version = Some(3);
+        c.timestamp = Some("2026-01-01T00:00:00Z".into());
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_oversized_batch() {
+        let mut c = DeltaSourceConfig::new("file:///tmp/t");
+        c.batch_size = faucet_core::MAX_BATCH_SIZE + 1;
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn deserializes_flattened_shape() {
+        let v = json!({
+            "table_uri": "s3://b/t",
+            "credentials": { "type": "aws", "config": { "region": "us-east-1" } },
+            "columns": ["id", "name"],
+            "version": 5
+        });
+        let c: DeltaSourceConfig = serde_json::from_value(v).unwrap();
+        assert_eq!(c.connection.table_uri, "s3://b/t");
+        assert_eq!(c.columns, vec!["id", "name"]);
+        assert_eq!(c.version, Some(5));
+        c.validate().unwrap();
+    }
+}

--- a/crates/source/delta/src/lib.rs
+++ b/crates/source/delta/src/lib.rs
@@ -1,0 +1,30 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+//! # faucet-source-delta
+//!
+//! Apache Delta Lake source for the [`faucet-stream`](https://crates.io/crates/faucet-stream)
+//! ecosystem. Streams the rows of a Delta table on the local filesystem or
+//! cloud object storage (S3 / Azure / GCS) via the Rust
+//! [`deltalake`](https://crates.io/crates/deltalake) crate — reading the same
+//! open table format Databricks (and Spark, Trino, DuckDB, Microsoft Fabric)
+//! write.
+//!
+//! - Native bounded [`stream_pages`](faucet_core::Source::stream_pages): the
+//!   active file set is read from the Delta log and each parquet data file is
+//!   streamed through the async Arrow reader (no whole-table buffering, no
+//!   datafusion).
+//! - Time travel via `version` or `timestamp`.
+//! - Projection pushdown via `columns`; partition-column values are
+//!   reconstructed from the Hive-style path and merged into every row.
+//!
+//! Cloud backends are opt-in cargo features: `s3`, `azure`, `gcs`.
+
+mod config;
+mod stream;
+
+pub use config::DeltaSourceConfig;
+pub use stream::DeltaSource;
+
+// Re-export the shared connection/credentials types so downstream users need
+// only depend on this crate.
+pub use faucet_common_delta::{DeltaConnection, DeltaCredentials};

--- a/crates/source/delta/src/stream.rs
+++ b/crates/source/delta/src/stream.rs
@@ -1,0 +1,474 @@
+//! Delta Lake source stream executor.
+//!
+//! Reads a Delta table's active data files at the latest version (or a pinned
+//! `version` / `timestamp`) and yields each row as a `serde_json::Value`
+//! object. No datafusion: the active file set comes from the Delta log
+//! (`get_files_by_partitions`) and each parquet file is streamed through the async
+//! Arrow reader faucet's Parquet source uses. Partition-column values (which
+//! live in the Hive-style path, not the file) are reconstructed and merged
+//! back into every row, typed against the table schema.
+
+use std::collections::HashMap;
+use std::pin::Pin;
+
+use arrow::datatypes::{DataType, SchemaRef};
+use async_trait::async_trait;
+use faucet_common_delta::convert::record_batch_to_json;
+use faucet_core::{FaucetError, Stream, StreamPage};
+use futures::StreamExt;
+use object_store::path::Path as ObjPath;
+use parquet::arrow::ProjectionMask;
+use parquet::arrow::async_reader::{ParquetObjectReader, ParquetRecordBatchStreamBuilder};
+use serde_json::Value;
+
+use crate::config::DeltaSourceConfig;
+
+/// A source that reads an Apache Delta Lake table into JSON records.
+pub struct DeltaSource {
+    config: DeltaSourceConfig,
+}
+
+/// One active data file plus the partition values encoded in its path.
+struct DataFile {
+    path: ObjPath,
+    /// `col -> JSON value` for every partition column, typed against the table
+    /// schema. `null` for the Hive default-partition sentinel.
+    partitions: HashMap<String, Value>,
+}
+
+impl DeltaSource {
+    /// Build a new Delta source. Validates config eagerly; the table is opened
+    /// on each read so time-travel/version pins re-resolve.
+    pub async fn new(config: DeltaSourceConfig) -> Result<Self, FaucetError> {
+        config
+            .validate()
+            .map_err(|e| FaucetError::Config(format!("invalid delta source config: {e}")))?;
+        config.connection.register_handlers();
+        Ok(Self { config })
+    }
+
+    /// Open the table at the configured version / timestamp / latest.
+    async fn open(&self) -> Result<deltalake::DeltaTable, FaucetError> {
+        match (self.config.version, &self.config.timestamp) {
+            (Some(v), _) => self.config.connection.open_at_version(v).await,
+            (None, Some(ts)) => self.config.connection.open_at_timestamp(ts).await,
+            (None, None) => self.config.connection.open().await,
+        }
+    }
+
+    /// Resolve the active files + their partition values, and the table's Arrow
+    /// schema (used to type partition values and validate projection).
+    async fn resolve(
+        &self,
+        table: &deltalake::DeltaTable,
+    ) -> Result<(Vec<DataFile>, SchemaRef, Vec<String>), FaucetError> {
+        let state = table
+            .snapshot()
+            .map_err(|e| FaucetError::Source(format!("delta: table has no snapshot: {e}")))?;
+        let arrow_schema = state.snapshot().arrow_schema();
+        let partition_cols = state.metadata().partition_columns().to_vec();
+
+        let paths = table
+            .get_files_by_partitions(&[])
+            .await
+            .map_err(|e| FaucetError::Source(format!("delta: could not list table files: {e}")))?;
+
+        let files = paths
+            .into_iter()
+            .map(|path| {
+                let partitions =
+                    parse_partition_values(path.as_ref(), &partition_cols, &arrow_schema);
+                DataFile { path, partitions }
+            })
+            .collect();
+        Ok((files, arrow_schema, partition_cols))
+    }
+
+    /// The projection over the *data* file columns: the requested columns minus
+    /// any partition columns (which are not stored in the file). `None` (read
+    /// all file columns) when no projection is configured.
+    fn data_projection(&self, partition_cols: &[String]) -> Option<Vec<String>> {
+        if self.config.columns.is_empty() {
+            return None;
+        }
+        Some(
+            self.config
+                .columns
+                .iter()
+                .filter(|c| !partition_cols.contains(c))
+                .cloned()
+                .collect(),
+        )
+    }
+}
+
+#[async_trait]
+impl faucet_core::Source for DeltaSource {
+    fn config_schema(&self) -> Value {
+        serde_json::to_value(faucet_core::schema_for!(DeltaSourceConfig))
+            .expect("schema serialization")
+    }
+
+    fn connector_name(&self) -> &'static str {
+        "delta"
+    }
+
+    fn dataset_uri(&self) -> String {
+        self.config.connection.redacted_uri()
+    }
+
+    async fn check(
+        &self,
+        ctx: &faucet_core::check::CheckContext,
+    ) -> Result<faucet_core::check::CheckReport, FaucetError> {
+        use faucet_core::check::{CheckReport, Probe};
+        let started = std::time::Instant::now();
+        // Metadata-only open (no data scan). The source needs the table to
+        // exist, so an absent table fails the probe.
+        let probe =
+            match tokio::time::timeout(ctx.timeout, self.config.connection.open_optional()).await {
+                Ok(Ok(Some(_))) => Probe::pass("table", started.elapsed()),
+                Ok(Ok(None)) => Probe::fail_hint(
+                    "table",
+                    started.elapsed(),
+                    format!(
+                        "delta source: no Delta table at '{}'",
+                        self.config.connection.redacted_uri()
+                    ),
+                    "Verify table_uri points at an existing Delta table.",
+                ),
+                Ok(Err(e)) => Probe::fail_hint(
+                    "table",
+                    started.elapsed(),
+                    format!("delta source probe failed: {e}"),
+                    "Verify table_uri, credentials, and object-store reachability.",
+                ),
+                Err(_) => Probe::fail_hint(
+                    "table",
+                    started.elapsed(),
+                    format!("delta source probe timed out after {:?}", ctx.timeout),
+                    "Check object-store network reachability.",
+                ),
+            };
+        Ok(CheckReport::single(probe))
+    }
+
+    async fn fetch_with_context(
+        &self,
+        _context: &HashMap<String, Value>,
+    ) -> Result<Vec<Value>, FaucetError> {
+        let mut out = Vec::new();
+        let mut stream = self.stream_pages(_context, self.config.batch_size);
+        while let Some(page) = stream.next().await {
+            out.extend(page?.records);
+        }
+        Ok(out)
+    }
+
+    fn stream_pages<'a>(
+        &'a self,
+        _context: &'a HashMap<String, Value>,
+        _batch_size: usize,
+    ) -> Pin<Box<dyn Stream<Item = Result<StreamPage, FaucetError>> + Send + 'a>> {
+        Box::pin(async_stream::try_stream! {
+            let table = self.open().await?;
+            let (files, _schema, partition_cols) = self.resolve(&table).await?;
+            let store = table.object_store();
+            let data_projection = self.data_projection(&partition_cols);
+            let requested: Option<&[String]> =
+                if self.config.columns.is_empty() { None } else { Some(&self.config.columns) };
+
+            tracing::info!(
+                files = files.len(),
+                uri = %self.config.connection.redacted_uri(),
+                "delta source resolved active files",
+            );
+
+            for file in &files {
+                let reader = ParquetObjectReader::new(store.clone(), file.path.clone());
+                let mut builder = ParquetRecordBatchStreamBuilder::new(reader).await.map_err(|e| {
+                    FaucetError::Source(format!(
+                        "delta: could not open data file '{}': {e}",
+                        file.path
+                    ))
+                })?;
+
+                if self.config.batch_size > 0 {
+                    builder = builder.with_batch_size(self.config.batch_size);
+                }
+                if let Some(cols) = &data_projection {
+                    // Only project columns actually present in this file. A
+                    // requested column that is neither a data column here nor a
+                    // partition column is genuinely absent → surface it.
+                    let pq = builder.parquet_schema();
+                    let present: Vec<&str> = cols
+                        .iter()
+                        .filter(|c| pq.columns().iter().any(|col| col.name() == c.as_str()))
+                        .map(String::as_str)
+                        .collect();
+                    let mask = ProjectionMask::columns(pq, present.iter().copied());
+                    builder = builder.with_projection(mask);
+                }
+
+                let mut batches = builder.build().map_err(|e| {
+                    FaucetError::Source(format!(
+                        "delta: could not build reader for '{}': {e}",
+                        file.path
+                    ))
+                })?;
+
+                while let Some(batch) = batches.next().await {
+                    let batch = batch.map_err(|e| {
+                        FaucetError::Source(format!("delta: read error in '{}': {e}", file.path))
+                    })?;
+                    let mut rows = record_batch_to_json(&batch)?;
+                    if !rows.is_empty() {
+                        for row in &mut rows {
+                            merge_partitions(row, &file.partitions, requested);
+                        }
+                        yield StreamPage { records: rows, bookmark: None };
+                    }
+                }
+            }
+        })
+    }
+}
+
+/// Parse Hive-style `col=value` segments out of a data file path, typing each
+/// value against the table's Arrow schema. Only the declared partition columns
+/// are extracted; unknown segments are ignored.
+fn parse_partition_values(
+    path: &str,
+    partition_cols: &[String],
+    schema: &SchemaRef,
+) -> HashMap<String, Value> {
+    let mut out = HashMap::new();
+    if partition_cols.is_empty() {
+        return out;
+    }
+    for segment in path.split('/') {
+        if let Some((k, v)) = segment.split_once('=')
+            && partition_cols.iter().any(|c| c == k)
+        {
+            let decoded = percent_decode(v);
+            let dt = schema
+                .field_with_name(k)
+                .ok()
+                .map(|f| f.data_type().clone())
+                .unwrap_or(DataType::Utf8);
+            out.insert(k.to_string(), coerce_partition_value(&decoded, &dt));
+        }
+    }
+    out
+}
+
+/// The Delta Hive-default-partition sentinel — represents a NULL partition
+/// value.
+const HIVE_NULL: &str = "__HIVE_DEFAULT_PARTITION__";
+
+/// Coerce a string partition value to JSON, typed by the column's Arrow type.
+fn coerce_partition_value(raw: &str, dt: &DataType) -> Value {
+    if raw == HIVE_NULL || raw.is_empty() {
+        return Value::Null;
+    }
+    match dt {
+        DataType::Boolean => match raw {
+            "true" => Value::Bool(true),
+            "false" => Value::Bool(false),
+            _ => Value::String(raw.to_string()),
+        },
+        DataType::Int8
+        | DataType::Int16
+        | DataType::Int32
+        | DataType::Int64
+        | DataType::UInt8
+        | DataType::UInt16
+        | DataType::UInt32
+        | DataType::UInt64 => raw
+            .parse::<i64>()
+            .map(|n| Value::Number(n.into()))
+            .unwrap_or_else(|_| Value::String(raw.to_string())),
+        DataType::Float32 | DataType::Float64 => {
+            serde_json::Number::from_f64(raw.parse::<f64>().unwrap_or(f64::NAN))
+                .map(Value::Number)
+                .unwrap_or_else(|| Value::String(raw.to_string()))
+        }
+        // Dates/timestamps/strings/decimals: keep the logical string form.
+        _ => Value::String(raw.to_string()),
+    }
+}
+
+/// Merge partition values into a data row, then narrow to `requested` columns
+/// (when a projection is configured). Partition values fill keys not present in
+/// the data (the file never stores them).
+fn merge_partitions(
+    row: &mut Value,
+    partitions: &HashMap<String, Value>,
+    requested: Option<&[String]>,
+) {
+    if let Value::Object(map) = row {
+        for (k, v) in partitions {
+            match requested {
+                Some(cols) if !cols.iter().any(|c| c == k) => continue,
+                _ => {
+                    map.entry(k.clone()).or_insert_with(|| v.clone());
+                }
+            }
+        }
+        if let Some(cols) = requested {
+            map.retain(|k, _| cols.iter().any(|c| c == k));
+        }
+    }
+}
+
+/// Minimal `%XX` percent-decoder for Hive-encoded partition path segments.
+/// Leaves malformed escapes untouched.
+fn percent_decode(s: &str) -> String {
+    if !s.contains('%') {
+        return s.to_string();
+    }
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            let hi = (bytes[i + 1] as char).to_digit(16);
+            let lo = (bytes[i + 2] as char).to_digit(16);
+            if let (Some(h), Some(l)) = (hi, lo) {
+                out.push((h * 16 + l) as u8);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::datatypes::{Field, Schema};
+    use serde_json::json;
+    use std::sync::Arc;
+
+    fn schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, true),
+            Field::new("dt", DataType::Utf8, true),
+            Field::new("region", DataType::Utf8, true),
+            Field::new("part", DataType::Int64, true),
+        ]))
+    }
+
+    #[test]
+    fn parses_typed_partition_values() {
+        let s = schema();
+        let cols = vec!["dt".to_string(), "part".to_string()];
+        let m = parse_partition_values("t/dt=2026-01-01/part=7/file.parquet", &cols, &s);
+        assert_eq!(m["dt"], json!("2026-01-01"));
+        assert_eq!(m["part"], json!(7));
+    }
+
+    #[test]
+    fn hive_null_becomes_json_null() {
+        let s = schema();
+        let cols = vec!["region".to_string()];
+        let m = parse_partition_values("t/region=__HIVE_DEFAULT_PARTITION__/f.parquet", &cols, &s);
+        assert_eq!(m["region"], Value::Null);
+    }
+
+    #[test]
+    fn percent_decoding_of_partition_values() {
+        let s = schema();
+        let cols = vec!["region".to_string()];
+        let m = parse_partition_values("t/region=a%2Fb/f.parquet", &cols, &s);
+        assert_eq!(m["region"], json!("a/b"));
+    }
+
+    #[test]
+    fn no_partition_columns_is_empty() {
+        let s = schema();
+        assert!(parse_partition_values("t/f.parquet", &[], &s).is_empty());
+    }
+
+    #[test]
+    fn merge_injects_and_projects() {
+        let mut row = json!({"id": 1});
+        let mut parts = HashMap::new();
+        parts.insert("dt".to_string(), json!("2026-01-01"));
+        merge_partitions(&mut row, &parts, None);
+        assert_eq!(row["dt"], json!("2026-01-01"));
+        assert_eq!(row["id"], json!(1));
+
+        // With projection, only requested keys survive.
+        let mut row2 = json!({"id": 1, "name": "x"});
+        let cols = vec!["id".to_string(), "dt".to_string()];
+        merge_partitions(&mut row2, &parts, Some(&cols));
+        assert_eq!(row2["id"], json!(1));
+        assert_eq!(row2["dt"], json!("2026-01-01"));
+        assert!(row2.get("name").is_none());
+    }
+
+    #[test]
+    fn coerce_bool_and_float() {
+        assert_eq!(
+            coerce_partition_value("true", &DataType::Boolean),
+            json!(true)
+        );
+        assert_eq!(
+            coerce_partition_value("1.5", &DataType::Float64),
+            json!(1.5)
+        );
+        assert_eq!(coerce_partition_value("x", &DataType::Int64), json!("x"));
+        // Non-parseable values for bool/float columns fall back to a string.
+        assert_eq!(
+            coerce_partition_value("maybe", &DataType::Boolean),
+            json!("maybe")
+        );
+        assert_eq!(
+            coerce_partition_value("nan-ish", &DataType::Float32),
+            json!("nan-ish")
+        );
+        // Empty and the Hive sentinel both become JSON null.
+        assert_eq!(coerce_partition_value("", &DataType::Utf8), Value::Null);
+        assert_eq!(
+            coerce_partition_value(HIVE_NULL, &DataType::Int64),
+            Value::Null
+        );
+        // A date column keeps the logical string form.
+        assert_eq!(
+            coerce_partition_value("2026-01-01", &DataType::Date32),
+            json!("2026-01-01")
+        );
+    }
+
+    #[tokio::test]
+    async fn source_trait_metadata_methods() {
+        use faucet_core::Source;
+        let src = DeltaSource::new(DeltaSourceConfig::new("file:///tmp/delta_src_meta"))
+            .await
+            .unwrap();
+        assert_eq!(src.connector_name(), "delta");
+        assert_eq!(src.dataset_uri(), "file:///tmp/delta_src_meta");
+        assert!(src.config_schema().is_object());
+    }
+
+    #[tokio::test]
+    async fn fetch_missing_table_errors() {
+        use faucet_core::Source;
+        let dir = tempfile::tempdir().unwrap();
+        let uri = dir
+            .path()
+            .join("no_such_table")
+            .to_string_lossy()
+            .into_owned();
+        let src = DeltaSource::new(DeltaSourceConfig::new(&uri))
+            .await
+            .unwrap();
+        // `open()` fails (not a Delta table) → mapped to FaucetError::Source.
+        let err = src.fetch_with_context(&HashMap::new()).await.unwrap_err();
+        assert!(matches!(err, FaucetError::Source(_)), "{err}");
+    }
+}

--- a/docs/book/src/reference/choosing.md
+++ b/docs/book/src/reference/choosing.md
@@ -155,6 +155,24 @@ Both write columnar Parquet files, but they serve different use cases:
 **Rule of thumb:** portable raw files with no catalog → `sink-parquet`; managed
 lakehouse table with snapshots, time-travel, and catalog-aware readers → `sink-iceberg`.
 
+## Lakehouse tables: Delta Lake vs. Iceberg
+
+Delta and Iceberg are the two open lakehouse table formats; faucet ships a sink
+(and source) for each. Pick by which format your query engines read:
+
+- **`sink-delta` / `source-delta`** — the **Delta Lake** format on object
+  storage, read natively by **Databricks** (via Unity Catalog) as well as Spark,
+  Trino, DuckDB, and Microsoft Fabric. No catalog service is required — the
+  transaction log lives beside the data in the table directory — so a bare
+  `table_uri` on local FS or S3/Azure/GCS is enough. Append-only today;
+  time-travel reads via `version`/`timestamp`.
+- **`sink-iceberg`** — the **Iceberg** format, registered in a catalog (REST,
+  Glue, SQL, or HMS). Choose it when your platform is Iceberg-native or you need
+  a shared catalog across engines.
+
+**Rule of thumb:** landing data for Databricks, or you want a catalog-free Delta
+table → `delta`; an Iceberg-native platform or shared catalog → `iceberg`.
+
 ## Still unsure?
 
 Run `faucet list` to see what's installed, `faucet schema source <name>` to

--- a/docs/book/src/reference/connectors.md
+++ b/docs/book/src/reference/connectors.md
@@ -37,6 +37,7 @@ Legend: ✓ supported · ✗ not applicable. Tier: T1 = passes the faucet-confor
 | Apache Kafka | T1 ✅ | `source-kafka` | ✓ | ✓ | **✓** | ✗ | ✗ | consumer; idle/max-messages termination, offset bookmarks |
 | AWS Kinesis | T1 ✅ | `source-kinesis` | ✓ | ✓ | ✗ | ✗ | ✗ | per-shard GetRecords workers; sequence-number bookmarks, idle/max-messages termination |
 | Apache Parquet | T1 ✅ | `source-parquet` | ✓ | ✗ | ✗ | ✗ | ✗ | local/glob/S3, vectorized Arrow reader, projection |
+| Apache Delta Lake | T2 | `source-delta` | ✓ | ✗ | ✗ | ✗ | ✗ | local FS or S3/Azure/GCS; time travel (version/timestamp), projection pushdown, partition reconstruction |
 | BigQuery | T1 ✅ᵐ | `source-bigquery` | ✓ | ✗ | ✗ | ✗ | ✓ | `jobs.query` + pageToken pagination |
 | Snowflake | T1 ✅ᵐ | `source-snowflake` | ✓ | ✗ | ✗ | ✗ | ✓ | SQL REST API, server-side partitions |
 | Cloud Spanner | T1 ✅ᵉ | `source-spanner` | ✓ | ✓⁸ | ✗ | ✗ | ✓ | streaming SQL (gRPC), incremental `@bookmark` replication, stale reads, PK-range sharding |
@@ -122,6 +123,7 @@ file/append sinks (`jsonl`, `csv`, `stdout`) it's a no-op — they write per rec
 | AWS Kinesis | T1 ✅ | `sink-kinesis` | ✓ | ✗ | ✗ | ✗ | batched PutRecords; partition-key routing, per-entry partial-failure retry (DLQ-routable) |
 | Cloud Spanner | T1 ✅ᵉ | `sink-spanner` | ✓ | ✗ | **✓** | **✓** | batched mutations (`insert` / `insert_or_update` / `delete`), cell-budget chunking, commit-token transaction for effectively-once |
 | Apache Parquet | T1 ✅ | `sink-parquet` | ✓ | ✗⁶ | ✗ | ✗ | local/S3, schema inference (re-inferred per file on rollover), row/byte rollover |
+| Apache Delta Lake | T2 | `sink-delta` | ✓ | ✗⁶ | ✗ | ✗ | append-only; local FS or S3/Azure/GCS; schema-inferred table creation, partitioning, one commit per flush |
 | Apache Iceberg | T2 | `sink-iceberg` | ✓ | ✗⁶ | ✗ | **✓** | REST/Glue/SQL/HMS catalog, local + cloud (S3/GCS) warehouses, `fast_append` snapshot, Parquet data files |
 
 ⁶ Parquet and Iceberg both handle compression internally at the Parquet column

--- a/examples/README.md
+++ b/examples/README.md
@@ -36,6 +36,8 @@ These run immediately after installing the CLI — great for a first smoke test:
 | `csv_to_jsonl_with_sla.yaml` | freshness/volume SLA monitoring (`sla:` block) — staleness, min-rows floor, and learned-baseline volume anomaly detection |
 | `csv_to_jsonl_sql.yaml` | CSV → SQL GROUP BY + LEFT JOIN (embedded DuckDB) → JSONL; requires `--features transform-sql` |
 | `csv_to_sqlite.yaml` | CSV → local SQLite file |
+| `csv_to_delta.yaml` | CSV → local Apache Delta Lake table (point `table_uri` at `s3://…` + add `credentials:` for cloud) |
+| `delta_to_jsonl.yaml` | local Delta Lake table → JSONL (run `csv_to_delta.yaml` first); supports `version`/`timestamp` time travel |
 | `sqlite_to_jsonl.yaml`, `sqlite_to_csv.yaml` | local SQLite → file |
 | `rest_to_jsonl.yaml`, `rest_streaming.yaml`, `rest_to_stdout_preview.yaml` | point `base_url` at any HTTP API; preview needs no sink setup |
 | `rest_filter_explode_to_stdout.yaml` | `filter` + `explode` + `keys_case` against DummyJSON; demonstrates the v1 JSONPath subset and the merge rule |

--- a/faucet-stream/Cargo.toml
+++ b/faucet-stream/Cargo.toml
@@ -37,6 +37,7 @@ source = [
     "source-csv",
     "source-elasticsearch",
     "source-parquet",
+    "source-delta",
     "source-gcs",
     "source-bigquery",
     "source-snowflake",
@@ -62,6 +63,7 @@ sink = [
     "sink-http",
     "sink-stdout",
     "sink-parquet",
+    "sink-delta",
     "sink-gcs",
     "sink-iceberg",
     "sink-spanner",
@@ -111,7 +113,7 @@ transform-sql = ["dep:faucet-transform-sql"]
 ## syntax, so this flag never pulls the connector itself).
 encryption = ["faucet-core/encryption", "faucet-sink-jsonl?/encryption"]
 ## Every connector and state backend.
-full = ["source", "sink", "state", "auth", "kafka-schema-registry", "compression", "quality", "quality-jsonschema", "contract", "masking", "lineage", "lineage-kafka", "transform-sql", "transform-cdc-unwrap", "encryption"]
+full = ["source", "sink", "state", "auth", "kafka-schema-registry", "compression", "quality", "quality-jsonschema", "contract", "masking", "lineage", "lineage-kafka", "transform-sql", "transform-cdc-unwrap", "encryption", "delta-s3", "delta-azure", "delta-gcs"]
 
 ## Individual source connectors.
 source-rest = ["dep:faucet-source-rest"]
@@ -136,6 +138,7 @@ source-elasticsearch = ["dep:faucet-source-elasticsearch"]
 source-kafka = ["dep:faucet-source-kafka", "dep:faucet-common-kafka"]
 source-kinesis = ["dep:faucet-source-kinesis", "dep:faucet-common-kinesis"]
 source-parquet = ["dep:faucet-source-parquet"]
+source-delta = ["dep:faucet-source-delta"]
 source-gcs = ["dep:faucet-source-gcs", "dep:faucet-common-gcs"]
 source-bigquery = ["dep:faucet-source-bigquery", "dep:faucet-common-bigquery"]
 source-snowflake = ["dep:faucet-source-snowflake", "dep:faucet-common-snowflake"]
@@ -168,6 +171,12 @@ sink-kinesis = ["dep:faucet-sink-kinesis", "dep:faucet-common-kinesis"]
 ## Enable the Google Cloud Spanner sink.
 sink-spanner = ["dep:faucet-sink-spanner", "dep:faucet-common-spanner"]
 sink-parquet = ["dep:faucet-sink-parquet"]
+sink-delta = ["dep:faucet-sink-delta"]
+## Delta Lake cloud object-store backends. Forwarded to whichever delta
+## connector is enabled via optional-dep (`?`) syntax. In `full`; not default.
+delta-s3 = ["faucet-source-delta?/s3", "faucet-sink-delta?/s3"]
+delta-azure = ["faucet-source-delta?/azure", "faucet-sink-delta?/azure"]
+delta-gcs = ["faucet-source-delta?/gcs", "faucet-sink-delta?/gcs"]
 sink-gcs = ["dep:faucet-sink-gcs", "dep:faucet-common-gcs"]
 
 ## Kafka Schema Registry support (forwarded to kafka crates).
@@ -229,6 +238,7 @@ faucet-source-websocket = { workspace = true, optional = true }
 faucet-source-csv = { workspace = true, optional = true }
 faucet-source-elasticsearch = { workspace = true, optional = true }
 faucet-source-parquet = { workspace = true, optional = true }
+faucet-source-delta = { workspace = true, optional = true }
 faucet-source-gcs = { workspace = true, optional = true }
 faucet-source-bigquery = { workspace = true, optional = true }
 faucet-source-snowflake = { workspace = true, optional = true }
@@ -253,6 +263,7 @@ faucet-sink-elasticsearch = { workspace = true, optional = true }
 faucet-sink-http = { workspace = true, optional = true }
 faucet-sink-stdout = { workspace = true, optional = true }
 faucet-sink-parquet = { workspace = true, optional = true }
+faucet-sink-delta = { workspace = true, optional = true }
 faucet-sink-gcs = { workspace = true, optional = true }
 
 faucet-state-redis = { workspace = true, optional = true }

--- a/faucet-stream/src/lib.rs
+++ b/faucet-stream/src/lib.rs
@@ -34,6 +34,7 @@
 //! | `source-kinesis` | AWS Kinesis Data Streams source |
 //! | `source-spanner` | Google Cloud Spanner query source |
 //! | `source-parquet` | Apache Parquet file source (local, glob, S3) |
+//! | `source-delta` | Apache Delta Lake source (local FS or S3/Azure/GCS, time travel) |
 //! | `sink-bigquery` | Google BigQuery streaming insert sink |
 //! | `sink-iceberg` | Apache Iceberg sink (append-only, REST/Glue/SQL/HMS catalogs) |
 //! | `sink-postgres` | PostgreSQL sink (jsonb or auto-mapped columns) |
@@ -54,6 +55,7 @@
 //! | `sink-spanner` | Google Cloud Spanner mutation sink |
 //! | `sink-parquet` | Apache Parquet file sink (local, S3) |
 //! | `encryption` | AES-256-GCM at-rest sealing for file state-store bookmarks and per-line JSONL/DLQ output |
+//! | `sink-delta` | Apache Delta Lake sink (append-only; local FS or S3/Azure/GCS) |
 //! | `kafka-schema-registry` | Schema Registry support for Kafka connectors |
 //! | `source` | All source connectors |
 //! | `sink` | All sink connectors |
@@ -199,6 +201,11 @@ pub mod source {
         pub use faucet_source_parquet::*;
     }
 
+    #[cfg(feature = "source-delta")]
+    pub mod delta {
+        pub use faucet_source_delta::*;
+    }
+
     #[cfg(feature = "source-gcs")]
     pub mod gcs {
         pub use faucet_source_gcs::*;
@@ -328,6 +335,11 @@ pub mod source {
         pub use faucet_source_parquet::*;
     }
 
+    #[cfg(feature = "source-delta")]
+    pub mod delta {
+        pub use faucet_source_delta::*;
+    }
+
     #[cfg(feature = "source-gcs")]
     pub mod gcs {
         pub use faucet_source_gcs::*;
@@ -443,6 +455,11 @@ pub mod sink {
     #[cfg(feature = "sink-parquet")]
     pub mod parquet {
         pub use faucet_sink_parquet::*;
+    }
+
+    #[cfg(feature = "sink-delta")]
+    pub mod delta {
+        pub use faucet_sink_delta::*;
     }
 
     #[cfg(feature = "sink-gcs")]

--- a/schemas/faucet.schema.json
+++ b/schemas/faucet.schema.json
@@ -5055,6 +5055,156 @@
         }
       }
     },
+    "source_delta__DeltaCredentials": {
+      "description": "Object-store credentials for reading/writing a Delta table.\n\nUses the project-wide adjacently-tagged `{ type, config }` shape\n(snake_case discriminators): e.g. `credentials: { type: aws, config: { … } }`.\nThe default is [`DeltaCredentials::Default`], which resolves credentials from\nthe ambient environment / instance metadata via the object-store default\nprovider chain — nothing is injected into `storage_options`.",
+      "oneOf": [
+        {
+          "description": "Resolve credentials from the ambient environment / default provider\nchain (AWS instance profile, `AZURE_*` env, GCP ADC, …). Injects no\nkeys of its own.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "default"
+            }
+          }
+        },
+        {
+          "description": "Static AWS credentials (or an S3-compatible endpoint such as MinIO).",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "aws"
+            },
+            "config": {
+              "$ref": "#/$defs/source_delta__AwsCredentials"
+            }
+          }
+        },
+        {
+          "description": "Azure Blob / ADLS Gen2 credentials.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "azure"
+            },
+            "config": {
+              "$ref": "#/$defs/source_delta__AzureCredentials"
+            }
+          }
+        },
+        {
+          "description": "Google Cloud Storage credentials.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "gcp"
+            },
+            "config": {
+              "$ref": "#/$defs/source_delta__GcpCredentials"
+            }
+          }
+        }
+      ]
+    },
+    "source_delta__AwsCredentials": {
+      "description": "Static AWS credentials and optional S3-compatible endpoint overrides.\n\nLeaving a field unset lets the object-store default chain resolve it (so\n`region` alone with an instance profile is valid). `endpoint_url` +\n`allow_http: true` targets MinIO / LocalStack.",
+      "type": "object",
+      "properties": {
+        "access_key_id": {
+          "description": "`AWS_ACCESS_KEY_ID`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "secret_access_key": {
+          "description": "`AWS_SECRET_ACCESS_KEY`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "session_token": {
+          "description": "`AWS_SESSION_TOKEN` (temporary credentials).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "region": {
+          "description": "`AWS_REGION`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "endpoint_url": {
+          "description": "`AWS_ENDPOINT_URL` — override for S3-compatible stores (MinIO, etc.).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "allow_http": {
+          "description": "`AWS_ALLOW_HTTP` — permit plaintext HTTP to the endpoint (MinIO in dev).",
+          "type": [
+            "boolean",
+            "null",
+            "string"
+          ]
+        }
+      }
+    },
+    "source_delta__AzureCredentials": {
+      "description": "Azure Blob / ADLS Gen2 credentials.",
+      "type": "object",
+      "properties": {
+        "account_name": {
+          "description": "`AZURE_STORAGE_ACCOUNT_NAME`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "access_key": {
+          "description": "`AZURE_STORAGE_ACCESS_KEY` (shared-key auth).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "sas_token": {
+          "description": "`AZURE_STORAGE_SAS_KEY` (SAS-token auth).",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "source_delta__GcpCredentials": {
+      "description": "Google Cloud Storage credentials.",
+      "type": "object",
+      "properties": {
+        "service_account_path": {
+          "description": "`GOOGLE_SERVICE_ACCOUNT` — path to a service-account JSON key file.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "service_account_key": {
+          "description": "`GOOGLE_SERVICE_ACCOUNT_KEY` — inline service-account JSON key.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
     "source_gcs__GcsCredentials": {
       "description": "Credential source for a GCS client.\n\nSerializes as `{ type: <method>, config: { … } }` (adjacent tagging,\nsnake_case discriminators) — the consistent auth wire shape shared by\nevery faucet connector:\n`{ type: service_account_json_file, config: { path: \"/run/secrets/sa.json\" } }`.",
       "oneOf": [
@@ -7156,6 +7306,156 @@
         "zstd",
         "lz4"
       ]
+    },
+    "sink_delta__DeltaCredentials": {
+      "description": "Object-store credentials for reading/writing a Delta table.\n\nUses the project-wide adjacently-tagged `{ type, config }` shape\n(snake_case discriminators): e.g. `credentials: { type: aws, config: { … } }`.\nThe default is [`DeltaCredentials::Default`], which resolves credentials from\nthe ambient environment / instance metadata via the object-store default\nprovider chain — nothing is injected into `storage_options`.",
+      "oneOf": [
+        {
+          "description": "Resolve credentials from the ambient environment / default provider\nchain (AWS instance profile, `AZURE_*` env, GCP ADC, …). Injects no\nkeys of its own.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "default"
+            }
+          }
+        },
+        {
+          "description": "Static AWS credentials (or an S3-compatible endpoint such as MinIO).",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "aws"
+            },
+            "config": {
+              "$ref": "#/$defs/sink_delta__AwsCredentials"
+            }
+          }
+        },
+        {
+          "description": "Azure Blob / ADLS Gen2 credentials.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "azure"
+            },
+            "config": {
+              "$ref": "#/$defs/sink_delta__AzureCredentials"
+            }
+          }
+        },
+        {
+          "description": "Google Cloud Storage credentials.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "gcp"
+            },
+            "config": {
+              "$ref": "#/$defs/sink_delta__GcpCredentials"
+            }
+          }
+        }
+      ]
+    },
+    "sink_delta__AwsCredentials": {
+      "description": "Static AWS credentials and optional S3-compatible endpoint overrides.\n\nLeaving a field unset lets the object-store default chain resolve it (so\n`region` alone with an instance profile is valid). `endpoint_url` +\n`allow_http: true` targets MinIO / LocalStack.",
+      "type": "object",
+      "properties": {
+        "access_key_id": {
+          "description": "`AWS_ACCESS_KEY_ID`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "secret_access_key": {
+          "description": "`AWS_SECRET_ACCESS_KEY`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "session_token": {
+          "description": "`AWS_SESSION_TOKEN` (temporary credentials).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "region": {
+          "description": "`AWS_REGION`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "endpoint_url": {
+          "description": "`AWS_ENDPOINT_URL` — override for S3-compatible stores (MinIO, etc.).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "allow_http": {
+          "description": "`AWS_ALLOW_HTTP` — permit plaintext HTTP to the endpoint (MinIO in dev).",
+          "type": [
+            "boolean",
+            "null",
+            "string"
+          ]
+        }
+      }
+    },
+    "sink_delta__AzureCredentials": {
+      "description": "Azure Blob / ADLS Gen2 credentials.",
+      "type": "object",
+      "properties": {
+        "account_name": {
+          "description": "`AZURE_STORAGE_ACCOUNT_NAME`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "access_key": {
+          "description": "`AZURE_STORAGE_ACCESS_KEY` (shared-key auth).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "sas_token": {
+          "description": "`AZURE_STORAGE_SAS_KEY` (SAS-token auth).",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "sink_delta__GcpCredentials": {
+      "description": "Google Cloud Storage credentials.",
+      "type": "object",
+      "properties": {
+        "service_account_path": {
+          "description": "`GOOGLE_SERVICE_ACCOUNT` — path to a service-account JSON key file.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "service_account_key": {
+          "description": "`GOOGLE_SERVICE_ACCOUNT_KEY` — inline service-account JSON key.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
     },
     "sink_gcs__GcsCredentials": {
       "description": "Credential source for a GCS client.\n\nSerializes as `{ type: <method>, config: { … } }` (adjacent tagging,\nsnake_case discriminators) — the consistent auth wire shape shared by\nevery faucet connector:\n`{ type: service_account_json_file, config: { path: \"/run/secrets/sa.json\" } }`.",
@@ -9758,6 +10058,94 @@
         },
         {
           "type": "object",
+          "title": "delta",
+          "properties": {
+            "type": {
+              "const": "delta"
+            },
+            "config": {
+              "anyOf": [
+                {
+                  "properties": {
+                    "table_uri": {
+                      "description": "Delta table location URI: `file:///abs/path`, `s3://bucket/key`,\n`abfss://…`, `gs://bucket/key`. A bare local path is accepted and\ntreated as `file://`.",
+                      "type": "string"
+                    },
+                    "credentials": {
+                      "description": "Object-store credentials. Defaults to the ambient provider chain.",
+                      "$ref": "#/$defs/source_delta__DeltaCredentials",
+                      "default": {
+                        "type": "default"
+                      }
+                    },
+                    "storage_options": {
+                      "description": "Extra `storage_options` passed verbatim to delta-rs (e.g. a MinIO\nendpoint override, or any object-store key the [`DeltaCredentials`]\nenum does not model). Keys set here **win** over credential-derived\nkeys.",
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "default": {}
+                    },
+                    "version": {
+                      "description": "Time travel: read the table as of this version. Mutually exclusive with\n`timestamp`.",
+                      "type": [
+                        "integer",
+                        "null",
+                        "string"
+                      ],
+                      "format": "uint64",
+                      "minimum": 0
+                    },
+                    "timestamp": {
+                      "description": "Time travel: read the table as of this RFC 3339 timestamp. Mutually\nexclusive with `version`.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "columns": {
+                      "description": "Projection pushdown: only read these columns. Empty = all columns.",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "default": []
+                    },
+                    "batch_size": {
+                      "description": "Page size hint for [`stream_pages`](faucet_core::Source::stream_pages).\nGoverns how many rows accumulate before a `StreamPage` is emitted; the\nunderlying parquet row-group size still bounds each read. `0` is the\n\"no batching\" sentinel — one page per file.",
+                      "type": [
+                        "integer",
+                        "string"
+                      ],
+                      "format": "uint",
+                      "minimum": 0,
+                      "default": 1000
+                    }
+                  },
+                  "title": "DeltaSourceConfig",
+                  "description": "Configuration for the Delta Lake source connector.\n\nThe `table_uri` / `credentials` / `storage_options` keys are flattened in\nfrom the shared [`DeltaConnection`]. Reads scan the table's active data\nfiles at the latest version (or a pinned `version` / `timestamp` for time\ntravel) and yield each row as a JSON object.",
+                  "type": "object"
+                },
+                true
+              ]
+            },
+            "transforms": {
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "inherit_transforms": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
           "title": "gcs",
           "properties": {
             "type": {
@@ -11833,6 +12221,96 @@
                   },
                   "title": "ParquetSinkConfig",
                   "description": "Configuration for the Parquet sink connector.",
+                  "type": "object"
+                },
+                true
+              ]
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "title": "delta",
+          "properties": {
+            "type": {
+              "const": "delta"
+            },
+            "config": {
+              "anyOf": [
+                {
+                  "properties": {
+                    "table_uri": {
+                      "description": "Delta table location URI: `file:///abs/path`, `s3://bucket/key`,\n`abfss://…`, `gs://bucket/key`. A bare local path is accepted and\ntreated as `file://`.",
+                      "type": "string"
+                    },
+                    "credentials": {
+                      "description": "Object-store credentials. Defaults to the ambient provider chain.",
+                      "$ref": "#/$defs/sink_delta__DeltaCredentials",
+                      "default": {
+                        "type": "default"
+                      }
+                    },
+                    "storage_options": {
+                      "description": "Extra `storage_options` passed verbatim to delta-rs (e.g. a MinIO\nendpoint override, or any object-store key the [`DeltaCredentials`]\nenum does not model). Keys set here **win** over credential-derived\nkeys.",
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "default": {}
+                    },
+                    "create_if_not_missing": {
+                      "description": "Create the table (and its schema, from the inferred record shape) on the\nfirst write when it does not already exist. When `false`, an absent\ntable fails the first write with a typed error.",
+                      "type": [
+                        "boolean",
+                        "string"
+                      ],
+                      "default": true
+                    },
+                    "partition_by": {
+                      "description": "Partition columns, applied only when the table is created. Ignored when\nappending to an existing table (its stored partitioning is used).",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "default": []
+                    },
+                    "schema_sample_size": {
+                      "description": "Records sampled to infer the Arrow/Delta schema when creating the table.",
+                      "type": [
+                        "integer",
+                        "string"
+                      ],
+                      "format": "uint",
+                      "minimum": 0,
+                      "default": 100
+                    },
+                    "batch_size": {
+                      "description": "Re-chunk size for [`Sink::write_batch`](faucet_core::Sink::write_batch).\nIncoming pages larger than this are sliced into `batch_size`-row Arrow\nbatches before writing. `0` writes each page through as one batch.",
+                      "type": [
+                        "integer",
+                        "string"
+                      ],
+                      "format": "uint",
+                      "minimum": 0,
+                      "default": 1000
+                    },
+                    "target_file_size": {
+                      "description": "Optional target data-file size (bytes) hint for the writer's rollover.\nAdvisory — delta-rs rolls files at buffer boundaries near this size.",
+                      "type": [
+                        "integer",
+                        "null",
+                        "string"
+                      ],
+                      "format": "uint",
+                      "minimum": 0
+                    }
+                  },
+                  "title": "DeltaSinkConfig",
+                  "description": "Configuration for the Delta Lake sink connector (append-only in v1).\n\nThe `table_uri` / `credentials` / `storage_options` keys are flattened in\nfrom the shared [`DeltaConnection`]. On first write the sink opens the\ntable (creating it from the inferred schema when `create_if_not_missing`),\nthen appends one Delta commit per `flush()`.",
                   "type": "object"
                 },
                 true


### PR DESCRIPTION
## Summary

Adds Apache **Delta Lake** connectors — `faucet-source-delta`, `faucet-sink-delta`, and shared `faucet-common-delta` (all `1.0.0`) — built on the Rust `deltalake` crate (delta-rs 0.32, arrow-58 line, matching the workspace pins). This lands/read the open Delta table format for **Databricks** (and Spark/Trino/DuckDB/Microsoft Fabric) at the object-store level, mirroring the Iceberg sink architecture. No datafusion is pulled in.

## What's included

- **Sink (append-only v1):** lazy open-or-create from the inferred schema, `partition_by`, one atomic Delta commit per `flush()`, `RecordBatchWriter` (no datafusion). `supported_write_modes() = [Append]`.
- **Source:** bounded `stream_pages` — active files from the Delta log read through the async Arrow reader; `version`/`timestamp` time travel; `columns` projection pushdown; partition-value reconstruction from the Hive-style path (typed against the table schema).
- **Shared `DeltaConnection`** (`table_uri` / `credentials` / `storage_options`) + `DeltaCredentials` (default / aws / azure / gcp). Cloud backends are opt-in features: crate `s3`/`azure`/`gcs`, umbrella+CLI `delta-s3`/`delta-azure`/`delta-gcs` (in `full`, not `default`).
- **`check()`** probes table/store reachability with no data scan; `dataset_uri()` redacts credentials.
- **Wiring:** umbrella + CLI registry (`delta` source/sink kinds), `feature-check` CI matrix, docs capability matrix + choosing guide, three crate READMEs, root README counts (27 sources / 21 sinks / 66 crates), and two runnable examples (`csv_to_delta.yaml`, `delta_to_jsonl.yaml`).

## Testing

- Unit: JSON↔Arrow conversion, config + credentials validation, partition-path parsing/typing, percent-decoding.
- Integration (local FS, no Docker): round-trip parity across new/existing tables, partitioning, time travel (version + timestamp), projection, schema-drift drop, error paths.
- CLI registry round-trip covering the `build_source`/`build_sink`/schema arms.
- Verified end-to-end through the `faucet` binary (CSV → partitioned Delta table → JSONL, partition column reconstructed). ~93% line coverage on the new crates; `cargo-deny` licenses clean (delta-rs adds no disallowed licenses).

## Out of scope (follow-ups noted in #317)

Delta `MERGE`/upsert (version-gated on delta-rs), effectively-once via the native `txn` action, Change Data Feed source, and Unity Catalog `discover()`.

Closes #317. Part of the roadmap epic #38.