### PR TITLE
feat(databricks): Databricks SQL query source via Statement Execution API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,7 @@ jobs:
           - source-kinesis
           - source-parquet
           - source-delta
+          - source-databricks
           - source-gcs
           - source-bigquery
           - source-snowflake

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3686,6 +3686,7 @@ dependencies = [
  "faucet-sink-stdout",
  "faucet-source-bigquery",
  "faucet-source-csv",
+ "faucet-source-databricks",
  "faucet-source-delta",
  "faucet-source-elasticsearch",
  "faucet-source-gcs",
@@ -4425,6 +4426,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "faucet-source-databricks"
+version = "1.0.0"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "faucet-conformance",
+ "faucet-core",
+ "futures",
+ "reqwest 0.13.3",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "wiremock",
+]
+
+[[package]]
 name = "faucet-source-delta"
 version = "1.0.0"
 dependencies = [
@@ -5026,6 +5045,7 @@ dependencies = [
  "faucet-sink-stdout",
  "faucet-source-bigquery",
  "faucet-source-csv",
+ "faucet-source-databricks",
  "faucet-source-delta",
  "faucet-source-elasticsearch",
  "faucet-source-gcs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ members = [
     "crates/source/snowflake",
     "crates/source/spanner",
     "crates/source/delta",
+    "crates/source/databricks",
     "crates/sink/bigquery",
     "crates/sink/postgres",
     "crates/sink/jsonl",
@@ -132,6 +133,7 @@ faucet-source-bigquery = { path = "crates/source/bigquery", version = "1.1.3" }
 faucet-source-snowflake = { path = "crates/source/snowflake", version = "1.1.3" }
 faucet-source-spanner = { path = "crates/source/spanner", version = "1.0.0" }
 faucet-source-delta = { path = "crates/source/delta", version = "1.0.0" }
+faucet-source-databricks = { path = "crates/source/databricks", version = "1.0.0" }
 faucet-sink-mysql = { path = "crates/sink/mysql", version = "1.3.0" }
 faucet-sink-sqlite = { path = "crates/sink/sqlite", version = "1.3.0" }
 faucet-sink-mssql = { path = "crates/sink/mssql", version = "1.3.0" }

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 **The fast, config-driven way to move data in Rust.**
 
 faucet-stream is a complete **ETL** toolkit: **28 source** and **21 sink** connectors
-(**46 in total**) plus in-flight transforms — including a page-level embedded-DuckDB `sql`
+(**49 in total**) plus in-flight transforms — including a page-level embedded-DuckDB `sql`
 transform — wired together by a single `faucet` binary that runs pipelines declaratively
 from a YAML/JSON file, no Rust code required. Or skip the binary and embed the same engine
 in your own service through the typed `Source` / `Sink` traits. One toolkit, whether you
@@ -60,7 +60,7 @@ cargo add faucet-stream           # the library
   cron scheduling, an HTTP control plane with event-driven triggers, OpenLineage emission, and
   built-in Prometheus metrics + `tracing` spans — all with zero per-connector code.
 - **📦 Pay only for what you use** — every connector is a Cargo feature, so a slim build can
-  be just REST + JSONL, or pull in all 46 connectors with `--features full`.
+  be just REST + JSONL, or pull in all 49 connectors with `--features full`.
 
 **Documentation:** the [faucet-stream guide](https://pawansikawat.github.io/faucet-stream/)
 (getting started, tutorials, cookbook, operations) · API reference on

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@
 
 **The fast, config-driven way to move data in Rust.**
 
-faucet-stream is a complete **ETL** toolkit: **27 source** and **21 sink** connectors
-(**45 in total**) plus in-flight transforms — including a page-level embedded-DuckDB `sql`
+faucet-stream is a complete **ETL** toolkit: **28 source** and **21 sink** connectors
+(**46 in total**) plus in-flight transforms — including a page-level embedded-DuckDB `sql`
 transform — wired together by a single `faucet` binary that runs pipelines declaratively
 from a YAML/JSON file, no Rust code required. Or skip the binary and embed the same engine
 in your own service through the typed `Source` / `Sink` traits. One toolkit, whether you
@@ -60,7 +60,7 @@ cargo add faucet-stream           # the library
   cron scheduling, an HTTP control plane with event-driven triggers, OpenLineage emission, and
   built-in Prometheus metrics + `tracing` spans — all with zero per-connector code.
 - **📦 Pay only for what you use** — every connector is a Cargo feature, so a slim build can
-  be just REST + JSONL, or pull in all 45 connectors with `--features full`.
+  be just REST + JSONL, or pull in all 46 connectors with `--features full`.
 
 **Documentation:** the [faucet-stream guide](https://pawansikawat.github.io/faucet-stream/)
 (getting started, tutorials, cookbook, operations) · API reference on
@@ -265,6 +265,7 @@ wired into the battery (see the support-tiers note above).
 | [`faucet-source-gcs`](crates/source/gcs) | T2 | Google Cloud Storage — read objects as JSONL, JSON array, or raw text |
 | [`faucet-source-parquet`](crates/source/parquet) | T1 ✅ | Apache Parquet — local file, glob, or S3; vectorized Arrow reader, projection |
 | [`faucet-source-delta`](crates/source/delta) | T2 | Apache Delta Lake — local FS or S3/Azure/GCS; time travel, projection pushdown |
+| [`faucet-source-databricks`](crates/source/databricks) | T3 | Databricks SQL query source (Statement Execution API) — typed rows, chunk pagination, incremental |
 | [`faucet-source-elasticsearch`](crates/source/elasticsearch) | T1 ✅ᵐ | Elasticsearch — search/scroll API |
 | [`faucet-source-bigquery`](crates/source/bigquery) | T1 ✅ᵐ | Google BigQuery — `jobs.query` + `getQueryResults`, type-aware decoding |
 | [`faucet-source-snowflake`](crates/source/snowflake) | T1 ✅ᵐ | Snowflake — SQL REST API, server-side partition pagination, JWT / OAuth |
@@ -438,7 +439,7 @@ flowchart LR
     P -.->|metrics + spans| O
 ```
 
-faucet-stream is a Cargo workspace with **66 crates** — 27 sources, 21 sinks, 9 shared
+faucet-stream is a Cargo workspace with **67 crates** — 28 sources, 21 sinks, 9 shared
 connector libraries, the shared auth-provider library, 2 state-store backends, the lineage
 crate, the SQL transform crate, the conformance test battery, the shared core, the umbrella
 crate, and the CLI binary. See
@@ -500,6 +501,7 @@ Default features: `source-rest`, `transform-flatten`, `transform-rename-keys`,
 | `source-gcs` | no | Google Cloud Storage file source |
 | `source-parquet` | no | Apache Parquet file source (local, glob, S3) |
 | `source-delta` | no | Apache Delta Lake source (local FS; S3/Azure/GCS via `delta-s3`/`delta-azure`/`delta-gcs`) |
+| `source-databricks` | no | Databricks SQL query source (Statement Execution API) |
 | `sink-delta` | no | Apache Delta Lake sink (local FS; S3/Azure/GCS via `delta-s3`/`delta-azure`/`delta-gcs`) |
 | `source-elasticsearch` | no | Elasticsearch source |
 | `source-bigquery` | no | Google BigQuery query source |
@@ -786,7 +788,7 @@ Cargo.toml                    — workspace manifest (60 crates)
 crates/
   core/                       — faucet-core: shared types, traits, pipeline, transforms, config
   auth/                       — faucet-auth: shared OAuth2 / token-endpoint providers
-  source/                     — 27 source connectors (rest, graphql, xml, grpc, *-cdc, kafka, s3, delta, singer, …)
+  source/                     — 28 source connectors (rest, graphql, xml, grpc, *-cdc, kafka, s3, delta, databricks, singer, …)
   sink/                       — 21 sink connectors (bigquery, iceberg, delta, postgres, parquet, kafka, …)
   common/                     — 6 shared connector libraries (bigquery, elasticsearch, gcs, kafka, snowflake, mssql)
   state/                      — Redis- and Postgres-backed StateStore backends

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -84,6 +84,7 @@ source = [
     "source-kinesis",
     "source-parquet",
     "source-delta",
+    "source-databricks",
     "source-gcs",
     "source-bigquery",
     "source-snowflake",
@@ -137,6 +138,7 @@ source-kafka = ["dep:faucet-source-kafka"]
 source-kinesis = ["dep:faucet-source-kinesis"]
 source-parquet = ["dep:faucet-source-parquet"]
 source-delta = ["dep:faucet-source-delta"]
+source-databricks = ["dep:faucet-source-databricks"]
 source-gcs = ["dep:faucet-source-gcs"]
 source-bigquery = ["dep:faucet-source-bigquery"]
 source-snowflake = ["dep:faucet-source-snowflake"]
@@ -300,6 +302,7 @@ faucet-source-kafka = { workspace = true, optional = true }
 faucet-source-kinesis = { workspace = true, optional = true }
 faucet-source-parquet = { workspace = true, optional = true }
 faucet-source-delta = { workspace = true, optional = true }
+faucet-source-databricks = { workspace = true, optional = true }
 faucet-source-gcs = { workspace = true, optional = true }
 faucet-source-bigquery = { workspace = true, optional = true }
 faucet-source-snowflake = { workspace = true, optional = true }

--- a/cli/examples/databricks_to_jsonl.yaml
+++ b/cli/examples/databricks_to_jsonl.yaml
@@ -1,0 +1,39 @@
+# Run a SQL query against a Databricks SQL Warehouse (Statement Execution API)
+# and write the result rows to JSON Lines. This reads *query results* — for a
+# full-table lakehouse scan use the Delta source instead (`type: delta`).
+#
+# Set DATABRICKS_TOKEN to a Personal Access Token (or OAuth M2M token) and point
+# workspace_url / warehouse_id at your workspace, then:
+#
+#   faucet validate cli/examples/databricks_to_jsonl.yaml
+#   faucet run      cli/examples/databricks_to_jsonl.yaml
+version: 1
+name: databricks_to_jsonl
+
+pipeline:
+  source:
+    type: databricks
+    config:
+      workspace_url: https://dbc-00000000-0000.cloud.databricks.com
+      warehouse_id: 0123456789abcdef
+      catalog: samples
+      schema: tpch
+      sql: >
+        SELECT o_orderkey, o_totalprice, o_orderdate
+        FROM orders
+        WHERE o_totalprice > :min_price
+      parameters:
+        - { name: min_price, value: "100000", type: "DECIMAL(18,2)" }
+      auth:
+        type: pat
+        config:
+          token: ${env:DATABRICKS_TOKEN}
+      # Incremental replication (uncomment to only pull new rows each run):
+      # sql includes `AND o_orderdate > ${bookmark}`
+      # replication: { type: incremental, column: o_orderdate, initial_value: "1990-01-01" }
+      # state: persist the bookmark across runs (required for incremental)
+
+  sink:
+    type: jsonl
+    config:
+      path: ./out/databricks_orders.jsonl

--- a/cli/src/registry.rs
+++ b/cli/src/registry.rs
@@ -472,6 +472,19 @@ pub async fn build_source(
             let cfg = decode::<faucet_source_delta::DeltaSourceConfig>("source", "delta", config)?;
             Ok(Box::new(faucet_source_delta::DeltaSource::new(cfg).await?))
         }
+        #[cfg(feature = "source-databricks")]
+        "databricks" => {
+            let cfg = decode::<faucet_source_databricks::DatabricksSourceConfig>(
+                "source",
+                "databricks",
+                config,
+            )?;
+            let mut s = faucet_source_databricks::DatabricksSource::new(cfg)?;
+            if let Some(name) = &auth_ref {
+                s = s.with_auth_provider(auth_catalog::resolve(auth, name)?);
+            }
+            Ok(Box::new(s))
+        }
         #[cfg(feature = "source-gcs")]
         "gcs" => {
             let cfg = decode::<faucet_source_gcs::GcsSourceConfig>("source", "gcs", config)?;
@@ -805,6 +818,8 @@ pub fn source_schema(kind: &str) -> CliResult<Value> {
         "parquet" => Ok(schema::<faucet_source_parquet::ParquetSourceConfig>()),
         #[cfg(feature = "source-delta")]
         "delta" => Ok(schema::<faucet_source_delta::DeltaSourceConfig>()),
+        #[cfg(feature = "source-databricks")]
+        "databricks" => Ok(schema::<faucet_source_databricks::DatabricksSourceConfig>()),
         #[cfg(feature = "source-gcs")]
         "gcs" => Ok(schema::<faucet_source_gcs::GcsSourceConfig>()),
         #[cfg(feature = "source-bigquery")]
@@ -947,6 +962,8 @@ fn builtin_source_descriptions() -> Vec<(&'static str, &'static str)> {
     v.push(("parquet", "Apache Parquet file source (local path, glob, or S3). Streams record batches via the Arrow async reader."));
     #[cfg(feature = "source-delta")]
     v.push(("delta", "Apache Delta Lake source (local FS or S3/Azure/GCS). Streams active data files with time travel and projection pushdown."));
+    #[cfg(feature = "source-databricks")]
+    v.push(("databricks", "Databricks SQL query source (Statement Execution API). Streams typed query results with chunk pagination and incremental replication."));
     #[cfg(feature = "source-gcs")]
     v.push((
         "gcs",
@@ -1389,6 +1406,29 @@ mod tests {
             .await
             .expect("read");
         assert_eq!(rows.len(), 2);
+    }
+
+    // The Databricks source builds from the registry (no I/O in `new`), and its
+    // schema + description arms resolve.
+    #[cfg(feature = "source-databricks")]
+    #[tokio::test]
+    async fn databricks_registry_source_builds() {
+        assert!(source_schema("databricks").is_ok());
+        assert!(
+            source_descriptions()
+                .iter()
+                .any(|(n, _)| *n == "databricks")
+        );
+        let cfg = serde_json::json!({
+            "workspace_url": "https://x.cloud.databricks.com",
+            "warehouse_id": "wh1",
+            "sql": "SELECT 1",
+            "auth": { "type": "pat", "config": { "token": "t" } }
+        });
+        let src = build_source("databricks", cfg, &AuthCatalog::new(), None)
+            .await
+            .expect("databricks source builds");
+        assert_eq!(src.connector_name(), "databricks");
     }
 
     // A malformed config for a known connector must surface as a typed

--- a/cli/tests/cli_end_to_end.rs
+++ b/cli/tests/cli_end_to_end.rs
@@ -792,6 +792,7 @@ fn shipped_example_yamls_pass_validate() {
         ("API_USER", "x"),
         ("API_PASS", "x"),
         ("AUTH_TOKEN", "x"),
+        ("DATABRICKS_TOKEN", "x"),
         ("ES_USER", "x"),
         ("ES_PASS", "x"),
         ("ES_API_KEY", "x"),

--- a/connectors/registry.json
+++ b/connectors/registry.json
@@ -26,6 +26,7 @@
     { "name": "kinesis", "kind": "source", "verified": true, "description": "AWS Kinesis Data Streams consumer with per-shard checkpoints" },
     { "name": "parquet", "kind": "source", "verified": true, "description": "Apache Parquet file source (local, glob, or S3)" },
     { "name": "delta", "kind": "source", "verified": true, "description": "Apache Delta Lake source (local FS or S3/Azure/GCS; time travel, projection)" },
+    { "name": "databricks", "kind": "source", "verified": true, "description": "Databricks SQL query source (Statement Execution API; typed rows, chunk pagination, incremental)" },
     { "name": "bigquery", "kind": "source", "verified": true, "description": "Google BigQuery query source" },
     { "name": "snowflake", "kind": "source", "verified": true, "description": "Snowflake query source (SQL REST API)" },
     { "name": "spanner", "kind": "source", "verified": true, "description": "Google Cloud Spanner query source (streaming SQL, incremental replication)" },

--- a/crates/source/databricks/Cargo.toml
+++ b/crates/source/databricks/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "faucet-source-databricks"
+version = "1.0.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Databricks SQL query source (Statement Execution API) for the faucet-stream ecosystem"
+readme = "README.md"
+keywords = ["databricks", "sql", "source", "etl", "connector"]
+categories.workspace = true
+
+[dependencies]
+faucet-core.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+schemars.workspace = true
+async-trait.workspace = true
+async-stream.workspace = true
+futures.workspace = true
+tracing.workspace = true
+tokio.workspace = true
+reqwest.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
+wiremock = "0.6"
+faucet-conformance.workspace = true
+serde_json.workspace = true
+schemars.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/source/databricks/README.md
+++ b/crates/source/databricks/README.md
@@ -1,0 +1,60 @@
+# faucet-source-databricks
+
+Databricks **SQL query source** for the [`faucet-stream`](https://crates.io/crates/faucet-stream)
+ecosystem. Runs a SQL statement against a Databricks **SQL Warehouse** via the
+[Statement Execution API](https://docs.databricks.com/api/workspace/statementexecution)
+(plain REST — no JDBC/ODBC driver, no Python) and streams the result rows as
+typed JSON objects.
+
+This is the **query-results** read path for Databricks — joins, aggregates,
+filtered extracts. For full-table lakehouse scans and the **write** path, use
+the Delta Lake connectors ([`faucet-source-delta`](https://crates.io/crates/faucet-source-delta)
+/ [`faucet-sink-delta`](https://crates.io/crates/faucet-sink-delta)); a warehouse
+`INSERT`/`MERGE` sink is intentionally not provided (slow, INSERT-bound, and
+forces billed compute).
+
+## Highlights
+
+- **Async statement lifecycle** — submit → poll until terminal → stream result
+  chunks (INLINE + `JSON_ARRAY`), following `next_chunk_internal_link`.
+- **Type-aware decode** from the response `manifest` column schema (every
+  `JSON_ARRAY` cell is a string; decoded per `type_name` to typed JSON, with
+  `DECIMAL`/large `LONG` preserved losslessly as strings).
+- **Incremental replication** — a bookmark column + a `${bookmark}` token bound
+  as a server-side named parameter, plus a client-side filter backstop.
+- **Bearer auth** (PAT / OAuth M2M), inline or via the shared `auth:` catalog.
+
+## Configuration
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `workspace_url` | string | — (required) | `https://<host>.cloud.databricks.com` |
+| `warehouse_id` | string | — (required) | target SQL Warehouse id |
+| `sql` | string | — (required) | the query; supports `:name` params and a `${bookmark}` token |
+| `auth` | `{ type, config }` / `{ ref }` | — (required) | `pat` or `token` bearer, or a shared provider |
+| `catalog` / `schema` | string? | — | default Unity Catalog catalog / schema |
+| `parameters` | `[{name, value, type?}]` | `[]` | named `:name` SQL parameters |
+| `wait_timeout_secs` | int | `50` | server wait before async (`0` or `5`–`50`) |
+| `poll_interval_secs` | int | `1` | client poll cadence while running |
+| `batch_size` | int | `1000` | rows per emitted page |
+| `replication` | `{ type: full \| incremental, column, initial_value }` | `full` | incremental cursor |
+| `state_key` | string? | derived | explicit bookmark key |
+
+```yaml
+pipeline:
+  source:
+    type: databricks
+    config:
+      workspace_url: https://dbc-xxxx.cloud.databricks.com
+      warehouse_id: 0123456789abcdef
+      sql: SELECT id, ts FROM events WHERE ts > ${bookmark}
+      auth: { type: pat, config: { token: "${env:DATABRICKS_TOKEN}" } }
+      replication: { type: incremental, column: ts, initial_value: "2026-01-01" }
+```
+
+## Out of scope (v1)
+
+`EXTERNAL_LINKS` large-result disposition, `discover()` via `INFORMATION_SCHEMA`,
+Unity Catalog Volumes, and a Databricks SQL sink (use the Delta sink).
+
+License: MIT OR Apache-2.0.

--- a/crates/source/databricks/src/config.rs
+++ b/crates/source/databricks/src/config.rs
@@ -1,0 +1,264 @@
+//! Databricks SQL query source configuration.
+
+use faucet_core::{AuthSpec, DEFAULT_BATCH_SIZE, FaucetError};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// How the source replicates rows across runs.
+///
+/// Serializes as `{ type: full }` or
+/// `{ type: incremental, column: "...", initial_value: ... }`.
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, Default, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum DatabricksReplication {
+    /// Every run fetches the full result set (default).
+    #[default]
+    Full,
+    /// Only rows whose `column` is strictly greater than the stored bookmark
+    /// (or `initial_value` on the first run) are emitted. If the SQL contains
+    /// the literal token `${bookmark}`, it is bound as a `:_faucet_bookmark`
+    /// named parameter so the warehouse filters server-side (efficient); the
+    /// source also filters client-side as a correctness backstop. The new
+    /// maximum of `column` is persisted on the final page.
+    Incremental {
+        /// Column whose value is the replication cursor (e.g. `updated_at`).
+        column: String,
+        /// Lower bound used on the first run, before any bookmark is stored.
+        initial_value: Value,
+    },
+}
+
+fn default_wait_timeout() -> u64 {
+    50
+}
+
+fn default_poll_interval() -> u64 {
+    1
+}
+
+fn default_batch_size() -> usize {
+    DEFAULT_BATCH_SIZE
+}
+
+/// Authentication for the Databricks SQL Statement Execution API.
+///
+/// Both variants send `Authorization: Bearer <token>` — Databricks accepts a
+/// Personal Access Token (PAT) or an OAuth machine-to-machine (M2M) access
+/// token in the same header. Uses the project-wide adjacently-tagged
+/// `{ type, config }` shape, e.g. `auth: { type: pat, config: { token: … } }`.
+/// A shared `auth: { ref: <name> }` provider that yields a `Bearer`/`Token`
+/// credential maps onto [`DatabricksAuth::Token`].
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "type", content = "config", rename_all = "snake_case")]
+pub enum DatabricksAuth {
+    /// Databricks Personal Access Token.
+    Pat {
+        /// The token string (use `${env:…}` / `${vault:…}` to inject).
+        token: String,
+    },
+    /// A pre-obtained OAuth (M2M) bearer token.
+    Token {
+        /// The bearer token string.
+        token: String,
+    },
+}
+
+impl DatabricksAuth {
+    /// The `Authorization` header value (`Bearer <token>`).
+    pub fn authorization_value(&self) -> String {
+        match self {
+            DatabricksAuth::Pat { token } | DatabricksAuth::Token { token } => {
+                format!("Bearer {token}")
+            }
+        }
+    }
+}
+
+/// A named SQL parameter passed to the statement (`:name` markers in the SQL).
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct DatabricksParam {
+    /// Parameter name (the `:name` marker in the SQL, without the colon).
+    pub name: String,
+    /// Parameter value. Sent to Databricks as its string form; `null` binds a
+    /// typed NULL.
+    #[serde(default)]
+    pub value: Value,
+    /// Optional Databricks SQL type (e.g. `INT`, `STRING`, `DATE`, `TIMESTAMP`).
+    /// When omitted, Databricks treats the value as `STRING`.
+    #[serde(rename = "type", default, skip_serializing_if = "Option::is_none")]
+    pub param_type: Option<String>,
+}
+
+/// Configuration for the Databricks SQL query source.
+///
+/// Runs `sql` against a Databricks SQL Warehouse via the Statement Execution
+/// REST API and streams the result rows as typed JSON objects.
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
+pub struct DatabricksSourceConfig {
+    /// Workspace base URL, e.g. `https://dbc-abc123.cloud.databricks.com`.
+    pub workspace_url: String,
+    /// Target SQL Warehouse id.
+    pub warehouse_id: String,
+    /// The SQL statement to run. May contain `:name` parameter markers (see
+    /// [`parameters`](Self::parameters)) and a `${bookmark}` token for
+    /// incremental replication.
+    pub sql: String,
+    /// Authentication (PAT / OAuth bearer), inline or via a shared `auth: { ref }`.
+    pub auth: AuthSpec<DatabricksAuth>,
+    /// Default Unity Catalog catalog for the statement.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub catalog: Option<String>,
+    /// Default schema for the statement.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub schema: Option<String>,
+    /// Named SQL parameters (`:name` markers).
+    #[serde(default)]
+    pub parameters: Vec<DatabricksParam>,
+    /// Server-side wait before the statement goes async (seconds). Databricks
+    /// accepts `0` (fully async) or `5`–`50`. Defaults to `50`.
+    #[serde(default = "default_wait_timeout")]
+    pub wait_timeout_secs: u64,
+    /// Client poll cadence while the statement is `PENDING`/`RUNNING` (seconds).
+    #[serde(default = "default_poll_interval")]
+    pub poll_interval_secs: u64,
+    /// Page size — rows accumulated before a `StreamPage` is emitted.
+    #[serde(default = "default_batch_size")]
+    pub batch_size: usize,
+    /// Replication mode. Defaults to [`DatabricksReplication::Full`].
+    #[serde(default)]
+    pub replication: DatabricksReplication,
+    /// Explicit state-store key for the incremental bookmark. When unset, a key
+    /// is derived from the workspace/warehouse and a query fingerprint.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state_key: Option<String>,
+}
+
+impl DatabricksSourceConfig {
+    /// Validate the config; returns a human-readable error if invalid.
+    pub fn validate(&self) -> Result<(), FaucetError> {
+        if self.workspace_url.trim().is_empty() {
+            return Err(FaucetError::Config(
+                "databricks: `workspace_url` must not be empty".into(),
+            ));
+        }
+        if self.warehouse_id.trim().is_empty() {
+            return Err(FaucetError::Config(
+                "databricks: `warehouse_id` must not be empty".into(),
+            ));
+        }
+        if self.sql.trim().is_empty() {
+            return Err(FaucetError::Config(
+                "databricks: `sql` must not be empty".into(),
+            ));
+        }
+        // Databricks accepts wait_timeout of 0 (async) or 5..=50 seconds.
+        if self.wait_timeout_secs != 0 && !(5..=50).contains(&self.wait_timeout_secs) {
+            return Err(FaucetError::Config(format!(
+                "databricks: `wait_timeout_secs` must be 0 or between 5 and 50 (got {})",
+                self.wait_timeout_secs
+            )));
+        }
+        faucet_core::validate_batch_size(self.batch_size)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn base() -> DatabricksSourceConfig {
+        DatabricksSourceConfig {
+            workspace_url: "https://x.cloud.databricks.com".into(),
+            warehouse_id: "wh1".into(),
+            sql: "SELECT 1".into(),
+            auth: AuthSpec::Inline(DatabricksAuth::Pat { token: "t".into() }),
+            catalog: None,
+            schema: None,
+            parameters: Vec::new(),
+            wait_timeout_secs: default_wait_timeout(),
+            poll_interval_secs: default_poll_interval(),
+            batch_size: DEFAULT_BATCH_SIZE,
+            replication: DatabricksReplication::Full,
+            state_key: None,
+        }
+    }
+
+    #[test]
+    fn valid_config_passes() {
+        base().validate().unwrap();
+    }
+
+    #[test]
+    fn auth_is_bearer_for_both_variants() {
+        assert_eq!(
+            DatabricksAuth::Pat {
+                token: "abc".into()
+            }
+            .authorization_value(),
+            "Bearer abc"
+        );
+        assert_eq!(
+            DatabricksAuth::Token {
+                token: "xyz".into()
+            }
+            .authorization_value(),
+            "Bearer xyz"
+        );
+    }
+
+    #[test]
+    fn rejects_empty_required_fields() {
+        let mut c = base();
+        c.workspace_url = "  ".into();
+        assert!(c.validate().is_err());
+        let mut c = base();
+        c.warehouse_id = "".into();
+        assert!(c.validate().is_err());
+        let mut c = base();
+        c.sql = "".into();
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_bad_wait_timeout() {
+        let mut c = base();
+        c.wait_timeout_secs = 3; // not 0 and not in 5..=50
+        assert!(c.validate().is_err());
+        c.wait_timeout_secs = 51;
+        assert!(c.validate().is_err());
+        c.wait_timeout_secs = 0; // allowed (fully async)
+        assert!(c.validate().is_ok());
+    }
+
+    #[test]
+    fn rejects_oversized_batch() {
+        let mut c = base();
+        c.batch_size = faucet_core::MAX_BATCH_SIZE + 1;
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn deserializes_full_shape() {
+        let v = json!({
+            "workspace_url": "https://x.cloud.databricks.com",
+            "warehouse_id": "wh1",
+            "sql": "SELECT * FROM t WHERE id > :min",
+            "auth": { "type": "pat", "config": { "token": "tok" } },
+            "catalog": "main",
+            "schema": "sales",
+            "parameters": [{ "name": "min", "value": 10, "type": "INT" }],
+            "wait_timeout_secs": 30,
+            "batch_size": 500
+        });
+        let c: DatabricksSourceConfig = serde_json::from_value(v).unwrap();
+        assert_eq!(c.warehouse_id, "wh1");
+        assert_eq!(c.catalog.as_deref(), Some("main"));
+        assert_eq!(c.parameters.len(), 1);
+        assert_eq!(c.parameters[0].name, "min");
+        assert_eq!(c.parameters[0].param_type.as_deref(), Some("INT"));
+        c.validate().unwrap();
+    }
+}

--- a/crates/source/databricks/src/convert.rs
+++ b/crates/source/databricks/src/convert.rs
@@ -1,0 +1,206 @@
+//! Type-aware conversion from Databricks `JSON_ARRAY` result rows to JSON objects.
+//!
+//! In the Statement Execution API's `JSON_ARRAY` format every cell in
+//! `result.data_array` is a JSON **string** (or `null`), regardless of the
+//! column's real type, and the column types ship separately in
+//! `manifest.schema.columns[].type_name`. This module pairs each string cell
+//! with its column type and produces a typed `serde_json::Value::Object` per
+//! row.
+//!
+//! | `type_name`                     | JSON output                                   |
+//! |---------------------------------|-----------------------------------------------|
+//! | `BOOLEAN`                       | `Bool`                                         |
+//! | `BYTE`/`SHORT`/`INT`/`LONG`     | `Number` (i64; kept as `String` if it overflows i64 — full precision) |
+//! | `FLOAT`/`DOUBLE`                | `Number` (f64; `NaN`/`Infinity` → `String`)   |
+//! | `DECIMAL`                       | `String` (exact decimal — no f64 precision loss) |
+//! | `ARRAY`/`MAP`/`STRUCT`          | parsed nested JSON (falls back to `String`)    |
+//! | `STRING`/`DATE`/`TIMESTAMP`/`BINARY`/`CHAR`/`INTERVAL`/… | `String` (raw cell) |
+//!
+//! A `null` cell maps to `Value::Null` regardless of declared type.
+
+use serde::Deserialize;
+use serde_json::{Map, Value};
+
+/// One entry in `manifest.schema.columns`. Only the fields we use are decoded.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ColumnInfo {
+    /// Column name (used as the JSON object key; casing preserved).
+    pub name: String,
+    /// High-level Databricks type — `BOOLEAN`, `LONG`, `DECIMAL`, `STRING`,
+    /// `DATE`, `TIMESTAMP`, `ARRAY`, … (uppercase).
+    #[serde(default)]
+    pub type_name: String,
+}
+
+/// Build a JSON object from one Databricks row (array of string/null cells).
+///
+/// A row shorter than `columns` treats missing trailing cells as `null`;
+/// extra cells are ignored.
+pub fn row_to_json(row: &[Value], columns: &[ColumnInfo]) -> Value {
+    let mut obj = Map::with_capacity(columns.len());
+    for (i, col) in columns.iter().enumerate() {
+        obj.insert(col.name.clone(), cell_to_json(row.get(i), &col.type_name));
+    }
+    Value::Object(obj)
+}
+
+/// Convert a single cell (a JSON string or null) to a typed value.
+fn cell_to_json(cell: Option<&Value>, type_name: &str) -> Value {
+    let Some(cell) = cell else {
+        return Value::Null;
+    };
+    if cell.is_null() {
+        return Value::Null;
+    }
+    // JSON_ARRAY ships every cell as a string; tolerate an already-typed value
+    // defensively (pass through).
+    let s = match cell {
+        Value::String(s) => s.as_str(),
+        other => return other.clone(),
+    };
+
+    match type_name.to_ascii_uppercase().as_str() {
+        "BOOLEAN" => match s {
+            "true" => Value::Bool(true),
+            "false" => Value::Bool(false),
+            _ => Value::String(s.to_owned()),
+        },
+        "BYTE" | "SHORT" | "INT" | "LONG" => parse_int(s),
+        "FLOAT" | "DOUBLE" => parse_float(s),
+        // DECIMAL is preserved as an exact string (serde_json numbers are f64
+        // here, which would lose precision on large/fractional decimals).
+        "DECIMAL" => Value::String(s.to_owned()),
+        "ARRAY" | "MAP" | "STRUCT" => {
+            serde_json::from_str(s).unwrap_or_else(|_| Value::String(s.to_owned()))
+        }
+        // STRING / DATE / TIMESTAMP / BINARY / CHAR / INTERVAL / NULL / UDT / …
+        _ => Value::String(s.to_owned()),
+    }
+}
+
+/// Parse an integer cell, keeping full precision: an `i64` fits into a JSON
+/// number; anything larger (e.g. a `LONG`/`DECIMAL(38,0)` beyond i64) is kept
+/// as a lossless string rather than coerced through `f64`.
+fn parse_int(s: &str) -> Value {
+    match s.parse::<i64>() {
+        Ok(n) => Value::Number(n.into()),
+        Err(_) => Value::String(s.to_owned()),
+    }
+}
+
+/// Parse a float cell. Non-finite values (`NaN`, `Infinity`, `-Infinity`),
+/// which JSON cannot represent, are preserved as strings.
+fn parse_float(s: &str) -> Value {
+    match s.parse::<f64>() {
+        Ok(f) => serde_json::Number::from_f64(f)
+            .map(Value::Number)
+            .unwrap_or_else(|| Value::String(s.to_owned())),
+        Err(_) => Value::String(s.to_owned()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn cols() -> Vec<ColumnInfo> {
+        [
+            "id:LONG",
+            "price:DECIMAL",
+            "ok:BOOLEAN",
+            "score:DOUBLE",
+            "name:STRING",
+            "dt:DATE",
+        ]
+        .iter()
+        .map(|s| {
+            let (n, t) = s.split_once(':').unwrap();
+            ColumnInfo {
+                name: n.into(),
+                type_name: t.into(),
+            }
+        })
+        .collect()
+    }
+
+    #[test]
+    fn decodes_row_by_type() {
+        let row = vec![
+            json!("42"),
+            json!("71433.16"),
+            json!("true"),
+            json!("1.5"),
+            json!("alice"),
+            json!("2026-01-01"),
+        ];
+        let obj = row_to_json(&row, &cols());
+        assert_eq!(obj["id"], json!(42));
+        assert_eq!(obj["price"], json!("71433.16")); // decimal kept as string
+        assert_eq!(obj["ok"], json!(true));
+        assert_eq!(obj["score"], json!(1.5));
+        assert_eq!(obj["name"], json!("alice"));
+        assert_eq!(obj["dt"], json!("2026-01-01"));
+    }
+
+    #[test]
+    fn null_and_missing_cells_are_null() {
+        let row = vec![Value::Null, json!("9.9")]; // shorter than cols
+        let obj = row_to_json(&row, &cols());
+        assert_eq!(obj["id"], Value::Null);
+        assert_eq!(obj["price"], json!("9.9"));
+        assert_eq!(obj["ok"], Value::Null); // missing trailing cell
+        assert_eq!(obj["dt"], Value::Null);
+    }
+
+    #[test]
+    fn huge_long_kept_as_string() {
+        let c = [ColumnInfo {
+            name: "n".into(),
+            type_name: "LONG".into(),
+        }];
+        let obj = row_to_json(&[json!("123456789012345678901234")], &c);
+        assert_eq!(obj["n"], json!("123456789012345678901234"));
+    }
+
+    #[test]
+    fn non_finite_float_kept_as_string() {
+        let c = [ColumnInfo {
+            name: "f".into(),
+            type_name: "DOUBLE".into(),
+        }];
+        assert_eq!(row_to_json(&[json!("NaN")], &c)["f"], json!("NaN"));
+        assert_eq!(
+            row_to_json(&[json!("Infinity")], &c)["f"],
+            json!("Infinity")
+        );
+    }
+
+    #[test]
+    fn nested_types_parsed_or_fallback() {
+        let c = [ColumnInfo {
+            name: "a".into(),
+            type_name: "ARRAY".into(),
+        }];
+        assert_eq!(row_to_json(&[json!("[1,2,3]")], &c)["a"], json!([1, 2, 3]));
+        // Non-JSON string falls back to the raw string.
+        assert_eq!(row_to_json(&[json!("[oops")], &c)["a"], json!("[oops"));
+    }
+
+    #[test]
+    fn boolean_and_int_edge_values() {
+        let c = [ColumnInfo {
+            name: "b".into(),
+            type_name: "BOOLEAN".into(),
+        }];
+        assert_eq!(row_to_json(&[json!("maybe")], &c)["b"], json!("maybe"));
+        let ci = [ColumnInfo {
+            name: "i".into(),
+            type_name: "INT".into(),
+        }];
+        assert_eq!(
+            row_to_json(&[json!("not-a-num")], &ci)["i"],
+            json!("not-a-num")
+        );
+    }
+}

--- a/crates/source/databricks/src/lib.rs
+++ b/crates/source/databricks/src/lib.rs
@@ -1,0 +1,27 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+//! # faucet-source-databricks
+//!
+//! Databricks SQL query source for the [`faucet-stream`](https://crates.io/crates/faucet-stream)
+//! ecosystem. Runs a SQL statement against a Databricks **SQL Warehouse** via
+//! the [Statement Execution API](https://docs.databricks.com/api/workspace/statementexecution)
+//! (plain REST — no JDBC/ODBC driver) and streams the result rows as typed
+//! JSON objects.
+//!
+//! This is the **query-results** read path for Databricks (joins / aggregates /
+//! filtered extracts). For full-table lakehouse scans and the write path, use
+//! the Delta Lake connectors (`faucet-source-delta` / `faucet-sink-delta`).
+//!
+//! - Async statement lifecycle: submit → poll until terminal → stream result
+//!   chunks (INLINE + `JSON_ARRAY`), following `next_chunk_internal_link`.
+//! - Type-aware decode from the response `manifest` column schema.
+//! - Incremental replication via a bookmark column + a `${bookmark}` token
+//!   (server-side named param) plus a client-side filter backstop.
+//! - Bearer auth (PAT / OAuth M2M), inline or via the shared `auth:` catalog.
+
+mod config;
+mod convert;
+mod stream;
+
+pub use config::{DatabricksAuth, DatabricksParam, DatabricksReplication, DatabricksSourceConfig};
+pub use stream::DatabricksSource;

--- a/crates/source/databricks/src/stream.rs
+++ b/crates/source/databricks/src/stream.rs
@@ -1,0 +1,677 @@
+//! Databricks SQL query source over the Statement Execution API.
+//!
+//! Submits `sql` to `POST /api/2.0/sql/statements`, polls
+//! `GET /api/2.0/sql/statements/{id}` until the statement is terminal, then
+//! streams the result chunks (INLINE + JSON_ARRAY) as typed JSON rows,
+//! following `result.next_chunk_internal_link` across chunks. No SDK — plain
+//! `reqwest` over the shared-auth bearer token.
+
+use std::collections::HashMap;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::pin::Pin;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use faucet_core::replication::{filter_incremental, max_value};
+use faucet_core::{AuthSpec, FaucetError, SharedAuthProvider, Source, Stream, StreamPage};
+use reqwest::Client;
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use crate::config::{DatabricksReplication, DatabricksSourceConfig};
+use crate::convert::{ColumnInfo, row_to_json};
+
+/// Databricks SQL query source.
+pub struct DatabricksSource {
+    config: DatabricksSourceConfig,
+    client: Client,
+    /// Base URL override (up to but not including `/api/2.0/...`). `None` uses
+    /// `config.workspace_url`. Set by tests to point at a mock server.
+    endpoint_base: Option<String>,
+    /// Shared auth provider; when set, supplies the bearer token (takes
+    /// precedence over inline auth).
+    auth_provider: Option<SharedAuthProvider>,
+    /// Bookmark applied via [`Source::apply_start_bookmark`].
+    start_bookmark: Mutex<Option<Value>>,
+}
+
+/// The statement lifecycle response (only the fields we consume).
+#[derive(Debug, Deserialize)]
+struct StatementResponse {
+    #[serde(default)]
+    statement_id: Option<String>,
+    #[serde(default)]
+    status: Option<StatusInfo>,
+    #[serde(default)]
+    manifest: Option<Manifest>,
+    #[serde(default)]
+    result: Option<ResultChunk>,
+}
+
+#[derive(Debug, Deserialize)]
+struct StatusInfo {
+    #[serde(default)]
+    state: String,
+    #[serde(default)]
+    error: Option<ErrorInfo>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ErrorInfo {
+    #[serde(default)]
+    error_code: Option<String>,
+    #[serde(default)]
+    message: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Manifest {
+    #[serde(default)]
+    schema: Option<SchemaInfo>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SchemaInfo {
+    #[serde(default)]
+    columns: Vec<ColumnInfo>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ResultChunk {
+    #[serde(default)]
+    data_array: Option<Vec<Vec<Value>>>,
+    #[serde(default)]
+    next_chunk_internal_link: Option<String>,
+}
+
+/// Client-side incremental filter context.
+struct IncrementalCtx {
+    column: String,
+    start: Value,
+}
+
+impl DatabricksSource {
+    /// Create a new source. Validates config; does no I/O.
+    pub fn new(config: DatabricksSourceConfig) -> Result<Self, FaucetError> {
+        config.validate()?;
+        Ok(Self {
+            config,
+            client: Client::new(),
+            endpoint_base: None,
+            auth_provider: None,
+            start_bookmark: Mutex::new(None),
+        })
+    }
+
+    /// Attach a shared auth provider (yields the bearer token). Takes
+    /// precedence over inline auth — lets several connectors share one token.
+    pub fn with_auth_provider(mut self, provider: SharedAuthProvider) -> Self {
+        self.auth_provider = Some(provider);
+        self
+    }
+
+    /// Override the base URL (e.g. a wiremock server). Requests go to
+    /// `{base}/api/2.0/sql/statements`.
+    pub fn with_endpoint_base(mut self, base: impl Into<String>) -> Self {
+        self.endpoint_base = Some(base.into());
+        self
+    }
+
+    fn base_url(&self) -> String {
+        match &self.endpoint_base {
+            Some(b) => b.trim_end_matches('/').to_owned(),
+            None => self.config.workspace_url.trim_end_matches('/').to_owned(),
+        }
+    }
+
+    fn statements_url(&self) -> String {
+        format!("{}/api/2.0/sql/statements", self.base_url())
+    }
+
+    /// Resolve the `Authorization` header value: shared provider first, else
+    /// inline auth.
+    async fn auth_header(&self) -> Result<String, FaucetError> {
+        if let Some(p) = &self.auth_provider {
+            let cred = p.credential().await?;
+            return cred.authorization_value().ok_or_else(|| {
+                FaucetError::Auth("databricks: shared provider yielded no bearer credential".into())
+            });
+        }
+        match &self.config.auth {
+            AuthSpec::Inline(a) => Ok(a.authorization_value()),
+            AuthSpec::Reference(r) => Err(FaucetError::Auth(format!(
+                "databricks: auth references provider '{}' but none was supplied",
+                r.name
+            ))),
+        }
+    }
+
+    /// The effective incremental start bookmark (persisted bookmark, else the
+    /// configured `initial_value`).
+    fn incremental_ctx(&self) -> Option<IncrementalCtx> {
+        match &self.config.replication {
+            DatabricksReplication::Full => None,
+            DatabricksReplication::Incremental {
+                column,
+                initial_value,
+            } => {
+                let start = self
+                    .start_bookmark
+                    .lock()
+                    .expect("start_bookmark mutex poisoned")
+                    .clone()
+                    .unwrap_or_else(|| initial_value.clone());
+                Some(IncrementalCtx {
+                    column: column.clone(),
+                    start,
+                })
+            }
+        }
+    }
+
+    /// Build the request body: the SQL (with `${bookmark}` and `{ctx}` tokens
+    /// rewritten to named params) plus the `parameters` array.
+    fn build_body(&self, context: &HashMap<String, Value>, incr: Option<&IncrementalCtx>) -> Value {
+        let mut sql = self.config.sql.clone();
+        // Named parameters: start with the user's static ones.
+        let mut params: Vec<Value> = self
+            .config
+            .parameters
+            .iter()
+            .map(|p| {
+                json!({
+                    "name": p.name,
+                    "value": value_to_param_string(&p.value),
+                    "type": p.param_type.clone().unwrap_or_else(|| "STRING".into()),
+                })
+            })
+            .collect();
+
+        // Parent-context `{key}` tokens → `:_faucet_ctN` named params.
+        if !context.is_empty() {
+            let (rewritten, ctx_values) =
+                faucet_core::util::substitute_context_bind_params(&sql, context, 0, |i| {
+                    format!(":_faucet_ct{i}")
+                });
+            sql = rewritten;
+            for (i, v) in ctx_values.into_iter().enumerate() {
+                params.push(json!({
+                    "name": format!("_faucet_ct{i}"),
+                    "value": value_to_param_string(&v),
+                }));
+            }
+        }
+
+        // Incremental `${bookmark}` token → `:_faucet_bookmark` named param.
+        if let Some(ctx) = incr
+            && sql.contains("${bookmark}")
+        {
+            sql = sql.replace("${bookmark}", ":_faucet_bookmark");
+            params.push(json!({
+                "name": "_faucet_bookmark",
+                "value": value_to_param_string(&ctx.start),
+            }));
+        }
+
+        let mut body = json!({
+            "statement": sql,
+            "warehouse_id": self.config.warehouse_id,
+            "wait_timeout": format!("{}s", self.config.wait_timeout_secs),
+            "on_wait_timeout": "CONTINUE",
+            "disposition": "INLINE",
+            "format": "JSON_ARRAY",
+        });
+        if let Some(c) = &self.config.catalog {
+            body["catalog"] = json!(c);
+        }
+        if let Some(s) = &self.config.schema {
+            body["schema"] = json!(s);
+        }
+        if !params.is_empty() {
+            body["parameters"] = Value::Array(params);
+        }
+        body
+    }
+
+    /// Submit the statement and poll until it reaches a terminal state.
+    async fn run_statement(
+        &self,
+        context: &HashMap<String, Value>,
+        incr: Option<&IncrementalCtx>,
+    ) -> Result<StatementResponse, FaucetError> {
+        let auth = self.auth_header().await?;
+        let body = self.build_body(context, incr);
+        let resp = self
+            .client
+            .post(self.statements_url())
+            .header("Authorization", &auth)
+            .header("Content-Type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| FaucetError::Source(format!("databricks: submit request failed: {e}")))?;
+        let parsed = parse_http(resp).await?;
+        self.poll_until_terminal(parsed, &auth).await
+    }
+
+    /// Poll `GET /statements/{id}` until the state is terminal (or the initial
+    /// response already is), returning the terminal response.
+    async fn poll_until_terminal(
+        &self,
+        first: StatementResponse,
+        auth: &str,
+    ) -> Result<StatementResponse, FaucetError> {
+        let mut current = first;
+        loop {
+            let state = current
+                .status
+                .as_ref()
+                .map(|s| s.state.as_str())
+                .unwrap_or("");
+            match state {
+                "SUCCEEDED" => return Ok(current),
+                "FAILED" | "CANCELED" | "CLOSED" => {
+                    return Err(statement_error(state, current.status.as_ref()));
+                }
+                "PENDING" | "RUNNING" => {
+                    let id = current.statement_id.clone().ok_or_else(|| {
+                        FaucetError::Source(
+                            "databricks: pending statement without a statement_id to poll".into(),
+                        )
+                    })?;
+                    tokio::time::sleep(Duration::from_secs(self.config.poll_interval_secs.max(1)))
+                        .await;
+                    let url = format!("{}/{}", self.statements_url(), id);
+                    let resp = self
+                        .client
+                        .get(&url)
+                        .header("Authorization", auth)
+                        .send()
+                        .await
+                        .map_err(|e| {
+                            FaucetError::Source(format!("databricks: poll request failed: {e}"))
+                        })?;
+                    current = parse_http(resp).await?;
+                }
+                other => {
+                    return Err(FaucetError::Source(format!(
+                        "databricks: unexpected statement state '{other}'"
+                    )));
+                }
+            }
+        }
+    }
+
+    /// Fetch a follow-up chunk by its `next_chunk_internal_link` (a full API path).
+    async fn fetch_chunk(&self, link: &str, auth: &str) -> Result<ResultChunk, FaucetError> {
+        let url = format!("{}{}", self.base_url(), link);
+        let resp = self
+            .client
+            .get(&url)
+            .header("Authorization", auth)
+            .send()
+            .await
+            .map_err(|e| FaucetError::Source(format!("databricks: chunk request failed: {e}")))?;
+        let parsed = parse_http::<ResultChunk>(resp).await?;
+        Ok(parsed)
+    }
+}
+
+/// Derive a stable state key from the workspace, warehouse, and query.
+fn default_state_key(config: &DatabricksSourceConfig) -> String {
+    let mut h = DefaultHasher::new();
+    config.workspace_url.hash(&mut h);
+    config.warehouse_id.hash(&mut h);
+    config.sql.hash(&mut h);
+    format!("databricks:{:016x}", h.finish())
+}
+
+/// Stringify a JSON value for a Databricks named parameter (`value` is a
+/// string or null in the API).
+fn value_to_param_string(v: &Value) -> Value {
+    match v {
+        Value::Null => Value::Null,
+        Value::String(s) => Value::String(s.clone()),
+        Value::Bool(b) => Value::String(b.to_string()),
+        Value::Number(n) => Value::String(n.to_string()),
+        other => Value::String(other.to_string()),
+    }
+}
+
+/// Build a typed error from a terminal non-success statement state.
+fn statement_error(state: &str, status: Option<&StatusInfo>) -> FaucetError {
+    let detail = status.and_then(|s| s.error.as_ref()).map(|e| {
+        format!(
+            " [{}] {}",
+            e.error_code.as_deref().unwrap_or("UNKNOWN"),
+            e.message.as_deref().unwrap_or("")
+        )
+    });
+    FaucetError::Source(format!(
+        "databricks: statement {state}{}",
+        detail.unwrap_or_default()
+    ))
+}
+
+/// Parse an HTTP response into `T`, surfacing non-2xx as a typed error with the
+/// body (429/5xx/4xx transport errors; SQL errors come back as 200 + FAILED).
+async fn parse_http<T: for<'de> Deserialize<'de>>(
+    resp: reqwest::Response,
+) -> Result<T, FaucetError> {
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        return Err(FaucetError::Source(format!(
+            "databricks: HTTP {status}: {body}"
+        )));
+    }
+    resp.json::<T>()
+        .await
+        .map_err(|e| FaucetError::Source(format!("databricks: could not parse response: {e}")))
+}
+
+#[async_trait]
+impl Source for DatabricksSource {
+    fn config_schema(&self) -> Value {
+        serde_json::to_value(faucet_core::schema_for!(DatabricksSourceConfig))
+            .expect("schema serialization")
+    }
+
+    fn connector_name(&self) -> &'static str {
+        "databricks"
+    }
+
+    fn dataset_uri(&self) -> String {
+        format!(
+            "databricks://{}/warehouses/{}",
+            self.config
+                .workspace_url
+                .trim_start_matches("https://")
+                .trim_end_matches('/'),
+            self.config.warehouse_id
+        )
+    }
+
+    fn state_key(&self) -> Option<String> {
+        match &self.config.replication {
+            DatabricksReplication::Full => None,
+            DatabricksReplication::Incremental { .. } => Some(
+                self.config
+                    .state_key
+                    .clone()
+                    .unwrap_or_else(|| default_state_key(&self.config)),
+            ),
+        }
+    }
+
+    async fn apply_start_bookmark(&self, bookmark: Value) -> Result<(), FaucetError> {
+        *self
+            .start_bookmark
+            .lock()
+            .expect("start_bookmark mutex poisoned") = Some(bookmark);
+        Ok(())
+    }
+
+    fn stream_pages<'a>(
+        &'a self,
+        context: &'a HashMap<String, Value>,
+        _batch_size: usize,
+    ) -> Pin<Box<dyn Stream<Item = Result<StreamPage, FaucetError>> + Send + 'a>> {
+        Box::pin(async_stream::try_stream! {
+            let auth = self.auth_header().await?;
+            let incr = self.incremental_ctx();
+            let resp = self.run_statement(context, incr.as_ref()).await?;
+
+            let columns: Vec<ColumnInfo> = resp
+                .manifest
+                .and_then(|m| m.schema)
+                .map(|s| s.columns)
+                .unwrap_or_default();
+
+            let batch = self.config.batch_size;
+            let cap = if batch == 0 { 1024 } else { batch };
+            let mut buffer: Vec<Value> = Vec::with_capacity(cap);
+            let mut running_max: Option<Value> = None;
+
+            // Walk chunks: the initial `result`, then follow next_chunk_internal_link.
+            let mut chunk = resp.result;
+            while let Some(c) = chunk {
+                if let Some(data) = c.data_array {
+                    for row in &data {
+                        let obj = row_to_json(row, &columns);
+                        // Track the running max BEFORE the client-side filter so
+                        // the persisted bookmark reflects the full scan.
+                        if let Some(ic) = &incr
+                            && let Some(v) = obj.get(&ic.column)
+                        {
+                            running_max = Some(match running_max.take() {
+                                Some(m) => max_value(m, v.clone()),
+                                None => v.clone(),
+                            });
+                        }
+                        buffer.push(obj);
+                        if batch != 0 && buffer.len() >= batch {
+                            let page = std::mem::replace(&mut buffer, Vec::with_capacity(cap));
+                            let kept = apply_incr_filter(page, incr.as_ref());
+                            if !kept.is_empty() {
+                                yield StreamPage { records: kept, bookmark: None };
+                            }
+                        }
+                    }
+                }
+                chunk = match c.next_chunk_internal_link {
+                    Some(link) => Some(self.fetch_chunk(&link, &auth).await?),
+                    None => None,
+                };
+            }
+
+            // Final page carries the new bookmark (incremental only).
+            let kept = apply_incr_filter(buffer, incr.as_ref());
+            let bookmark = if incr.is_some() { running_max } else { None };
+            if !kept.is_empty() || bookmark.is_some() {
+                yield StreamPage { records: kept, bookmark };
+            }
+        })
+    }
+
+    async fn fetch_with_context(
+        &self,
+        context: &HashMap<String, Value>,
+    ) -> Result<Vec<Value>, FaucetError> {
+        use futures::StreamExt;
+        let mut out = Vec::new();
+        let mut s = self.stream_pages(context, self.config.batch_size);
+        while let Some(page) = s.next().await {
+            out.extend(page?.records);
+        }
+        Ok(out)
+    }
+
+    async fn check(
+        &self,
+        ctx: &faucet_core::check::CheckContext,
+    ) -> Result<faucet_core::check::CheckReport, FaucetError> {
+        use faucet_core::check::{CheckReport, Probe};
+        let started = std::time::Instant::now();
+        // Non-scanning probe: run `SELECT 1` on the warehouse.
+        let auth = match self.auth_header().await {
+            Ok(a) => a,
+            Err(e) => {
+                return Ok(CheckReport::single(Probe::fail(
+                    "auth",
+                    started.elapsed(),
+                    e.to_string(),
+                )));
+            }
+        };
+        let body = json!({
+            "statement": "SELECT 1",
+            "warehouse_id": self.config.warehouse_id,
+            "wait_timeout": "50s",
+            "disposition": "INLINE",
+            "format": "JSON_ARRAY",
+        });
+        let fut = self
+            .client
+            .post(self.statements_url())
+            .header("Authorization", &auth)
+            .header("Content-Type", "application/json")
+            .json(&body)
+            .send();
+        let probe = match tokio::time::timeout(ctx.timeout, fut).await {
+            Ok(Ok(r)) if r.status().is_success() => Probe::pass("warehouse", started.elapsed()),
+            Ok(Ok(r)) => Probe::fail_hint(
+                "warehouse",
+                started.elapsed(),
+                format!("databricks probe returned HTTP {}", r.status()),
+                "Verify workspace_url, warehouse_id, and token permissions (CAN USE).",
+            ),
+            Ok(Err(e)) => Probe::fail_hint(
+                "warehouse",
+                started.elapsed(),
+                format!("databricks probe request failed: {e}"),
+                "Verify workspace_url and network reachability.",
+            ),
+            Err(_) => Probe::fail_hint(
+                "warehouse",
+                started.elapsed(),
+                format!("databricks probe timed out after {:?}", ctx.timeout),
+                "Check warehouse availability and network reachability.",
+            ),
+        };
+        Ok(CheckReport::single(probe))
+    }
+}
+
+/// Apply the client-side incremental filter to a page (no-op for full runs).
+fn apply_incr_filter(page: Vec<Value>, incr: Option<&IncrementalCtx>) -> Vec<Value> {
+    match incr {
+        Some(ic) => filter_incremental(page, &ic.column, &ic.start),
+        None => page,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{DatabricksAuth, DatabricksParam};
+
+    fn cfg() -> DatabricksSourceConfig {
+        DatabricksSourceConfig {
+            workspace_url: "https://x.cloud.databricks.com".into(),
+            warehouse_id: "wh1".into(),
+            sql: "SELECT * FROM t WHERE ts > ${bookmark}".into(),
+            auth: AuthSpec::Inline(DatabricksAuth::Pat {
+                token: "tok".into(),
+            }),
+            catalog: Some("main".into()),
+            schema: Some("s".into()),
+            parameters: vec![DatabricksParam {
+                name: "min".into(),
+                value: json!(10),
+                param_type: Some("INT".into()),
+            }],
+            wait_timeout_secs: 50,
+            poll_interval_secs: 1,
+            batch_size: 1000,
+            replication: DatabricksReplication::Incremental {
+                column: "ts".into(),
+                initial_value: json!("2026-01-01"),
+            },
+            state_key: None,
+        }
+    }
+
+    fn source(c: DatabricksSourceConfig) -> DatabricksSource {
+        DatabricksSource::new(c).unwrap()
+    }
+
+    #[test]
+    fn body_has_required_fields_and_params() {
+        let s = source(cfg());
+        let incr = s.incremental_ctx();
+        let body = s.build_body(&HashMap::new(), incr.as_ref());
+        assert_eq!(body["warehouse_id"], json!("wh1"));
+        assert_eq!(body["catalog"], json!("main"));
+        assert_eq!(body["disposition"], json!("INLINE"));
+        assert_eq!(body["format"], json!("JSON_ARRAY"));
+        assert_eq!(body["wait_timeout"], json!("50s"));
+        // ${bookmark} rewritten to the named param marker.
+        assert!(
+            body["statement"]
+                .as_str()
+                .unwrap()
+                .contains(":_faucet_bookmark")
+        );
+        assert!(!body["statement"].as_str().unwrap().contains("${bookmark}"));
+        let params = body["parameters"].as_array().unwrap();
+        // static `min` (typed) + the bookmark param.
+        assert!(
+            params
+                .iter()
+                .any(|p| p["name"] == json!("min") && p["type"] == json!("INT"))
+        );
+        let bm = params
+            .iter()
+            .find(|p| p["name"] == json!("_faucet_bookmark"))
+            .unwrap();
+        assert_eq!(bm["value"], json!("2026-01-01"));
+    }
+
+    #[test]
+    fn full_mode_has_no_state_key_or_bookmark_param() {
+        let mut c = cfg();
+        c.replication = DatabricksReplication::Full;
+        c.sql = "SELECT 1".into();
+        let s = source(c);
+        assert!(s.state_key().is_none());
+        let body = s.build_body(&HashMap::new(), None);
+        assert!(
+            body.get("parameters").is_none()
+                || body["parameters"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .all(|p| p["name"] != json!("_faucet_bookmark"))
+        );
+    }
+
+    #[test]
+    fn incremental_state_key_derived_and_stable() {
+        let s = source(cfg());
+        let k1 = s.state_key().unwrap();
+        let k2 = source(cfg()).state_key().unwrap();
+        assert_eq!(k1, k2);
+        assert!(k1.starts_with("databricks:"));
+    }
+
+    #[tokio::test]
+    async fn explicit_state_key_wins() {
+        let mut c = cfg();
+        c.state_key = Some("my-key".into());
+        let s = source(c);
+        assert_eq!(s.state_key().as_deref(), Some("my-key"));
+        // apply_start_bookmark overrides initial_value in the incr ctx.
+        s.apply_start_bookmark(json!("2026-06-01")).await.unwrap();
+        assert_eq!(s.incremental_ctx().unwrap().start, json!("2026-06-01"));
+    }
+
+    #[test]
+    fn value_to_param_string_stringifies() {
+        assert_eq!(value_to_param_string(&json!(5)), json!("5"));
+        assert_eq!(value_to_param_string(&json!(true)), json!("true"));
+        assert_eq!(value_to_param_string(&json!("x")), json!("x"));
+        assert_eq!(value_to_param_string(&Value::Null), Value::Null);
+    }
+
+    #[test]
+    fn dataset_uri_redacts_scheme() {
+        let s = source(cfg());
+        assert_eq!(
+            s.dataset_uri(),
+            "databricks://x.cloud.databricks.com/warehouses/wh1"
+        );
+    }
+}

--- a/crates/source/databricks/tests/conformance.rs
+++ b/crates/source/databricks/tests/conformance.rs
@@ -1,0 +1,64 @@
+//! `faucet-conformance` battery for the Databricks SQL source.
+//!
+//! Check 1 — the config JSON Schema is a valid, well-formed value.
+//! Check 2 — `stream_pages` pages under a bounded batch size (peak page ≤
+//! batch_size, every row streamed) against a wiremock-served result set, i.e.
+//! memory stays O(batch_size) regardless of total rows.
+
+use faucet_conformance::{assert_bounded_memory, assert_config_schema_valid_value};
+use faucet_core::AuthSpec;
+use faucet_source_databricks::{
+    DatabricksAuth, DatabricksReplication, DatabricksSource, DatabricksSourceConfig,
+};
+use serde_json::json;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[test]
+fn conformance_config_schema_valid() {
+    let schema = serde_json::to_value(schemars::schema_for!(DatabricksSourceConfig)).unwrap();
+    assert_config_schema_valid_value(&schema, "faucet-source-databricks");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn conformance_bounded_memory() {
+    let total = 1_000usize;
+    let batch = 100usize;
+
+    let server = MockServer::start().await;
+    let rows: Vec<Vec<String>> = (0..total).map(|i| vec![i.to_string()]).collect();
+    let body = json!({
+        "statement_id": "conf",
+        "status": { "state": "SUCCEEDED" },
+        "manifest": { "format": "JSON_ARRAY", "schema": {
+            "column_count": 1,
+            "columns": [{ "name": "id", "position": 0, "type_name": "LONG" }]
+        }},
+        "result": { "chunk_index": 0, "row_offset": 0, "row_count": total, "data_array": rows }
+    });
+    Mock::given(method("POST"))
+        .and(path("/api/2.0/sql/statements"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(body))
+        .mount(&server)
+        .await;
+
+    let config = DatabricksSourceConfig {
+        workspace_url: server.uri(),
+        warehouse_id: "wh".into(),
+        sql: "SELECT id FROM t".into(),
+        auth: AuthSpec::Inline(DatabricksAuth::Pat { token: "t".into() }),
+        catalog: None,
+        schema: None,
+        parameters: Vec::new(),
+        wait_timeout_secs: 50,
+        poll_interval_secs: 1,
+        batch_size: batch,
+        replication: DatabricksReplication::Full,
+        state_key: None,
+    };
+    let src = DatabricksSource::new(config)
+        .unwrap()
+        .with_endpoint_base(server.uri());
+
+    assert_bounded_memory(&src, batch, total).await;
+}

--- a/crates/source/databricks/tests/integration.rs
+++ b/crates/source/databricks/tests/integration.rs
@@ -1,0 +1,242 @@
+//! Wiremock-backed integration tests for the Databricks SQL query source.
+//!
+//! Drive the async-statement lifecycle (submit → poll), chunk pagination,
+//! type-aware decode, incremental bookmark round-trip, and error handling —
+//! all against a mock Statement Execution API, no live Databricks needed.
+
+use std::collections::HashMap;
+
+use faucet_core::{AuthSpec, Source};
+use faucet_source_databricks::{DatabricksAuth, DatabricksReplication, DatabricksSourceConfig};
+use serde_json::{Value, json};
+use wiremock::matchers::{method, path, path_regex};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn base_config(uri: &str, sql: &str) -> DatabricksSourceConfig {
+    DatabricksSourceConfig {
+        workspace_url: uri.into(),
+        warehouse_id: "wh1".into(),
+        sql: sql.into(),
+        auth: AuthSpec::Inline(DatabricksAuth::Pat {
+            token: "tok".into(),
+        }),
+        catalog: None,
+        schema: None,
+        parameters: Vec::new(),
+        wait_timeout_secs: 50,
+        poll_interval_secs: 1,
+        batch_size: 1000,
+        replication: DatabricksReplication::Full,
+        state_key: None,
+    }
+}
+
+fn manifest(cols: &[(&str, &str)]) -> Value {
+    let columns: Vec<Value> = cols
+        .iter()
+        .enumerate()
+        .map(|(i, (n, t))| json!({ "name": n, "position": i, "type_name": t }))
+        .collect();
+    json!({ "format": "JSON_ARRAY", "schema": { "column_count": columns.len(), "columns": columns } })
+}
+
+async fn source(uri: &str, sql: &str) -> DatabricksSource {
+    DatabricksSource::new(base_config(uri, sql))
+        .unwrap()
+        .with_endpoint_base(uri)
+}
+
+use faucet_source_databricks::DatabricksSource;
+
+#[tokio::test]
+async fn inline_success_typed_decode() {
+    let server = MockServer::start().await;
+    let body = json!({
+        "statement_id": "s1",
+        "status": { "state": "SUCCEEDED" },
+        "manifest": manifest(&[("id", "LONG"), ("name", "STRING"), ("ok", "BOOLEAN")]),
+        "result": { "chunk_index": 0, "row_offset": 0, "row_count": 2,
+                    "data_array": [["1", "alice", "true"], ["2", "bob", "false"]] }
+    });
+    Mock::given(method("POST"))
+        .and(path("/api/2.0/sql/statements"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(body))
+        .mount(&server)
+        .await;
+
+    let src = source(&server.uri(), "SELECT * FROM t").await;
+    let rows = src.fetch_with_context(&HashMap::new()).await.unwrap();
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0]["id"], json!(1)); // LONG decoded to number
+    assert_eq!(rows[0]["name"], json!("alice"));
+    assert_eq!(rows[0]["ok"], json!(true)); // BOOLEAN decoded to bool
+    assert_eq!(rows[1]["ok"], json!(false));
+}
+
+#[tokio::test]
+async fn async_poll_pending_then_succeeded() {
+    let server = MockServer::start().await;
+    // POST → PENDING (no result yet).
+    Mock::given(method("POST"))
+        .and(path("/api/2.0/sql/statements"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "statement_id": "s2", "status": { "state": "PENDING" }
+        })))
+        .mount(&server)
+        .await;
+    // GET poll → SUCCEEDED with rows.
+    Mock::given(method("GET"))
+        .and(path("/api/2.0/sql/statements/s2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "statement_id": "s2",
+            "status": { "state": "SUCCEEDED" },
+            "manifest": manifest(&[("n", "INT")]),
+            "result": { "data_array": [["7"]] }
+        })))
+        .mount(&server)
+        .await;
+
+    let src = source(&server.uri(), "SELECT 7").await;
+    let rows = src.fetch_with_context(&HashMap::new()).await.unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["n"], json!(7));
+}
+
+#[tokio::test]
+async fn multi_chunk_pagination() {
+    let server = MockServer::start().await;
+    // Initial result = chunk 0 + a link to chunk 1.
+    Mock::given(method("POST"))
+        .and(path("/api/2.0/sql/statements"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "statement_id": "s3",
+            "status": { "state": "SUCCEEDED" },
+            "manifest": manifest(&[("id", "INT")]),
+            "result": { "data_array": [["1"], ["2"]],
+                        "next_chunk_index": 1,
+                        "next_chunk_internal_link": "/api/2.0/sql/statements/s3/result/chunks/1" }
+        })))
+        .mount(&server)
+        .await;
+    // Chunk 1 = final rows, no further link.
+    Mock::given(method("GET"))
+        .and(path("/api/2.0/sql/statements/s3/result/chunks/1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "chunk_index": 1, "data_array": [["3"], ["4"]]
+        })))
+        .mount(&server)
+        .await;
+
+    let src = source(&server.uri(), "SELECT id FROM t").await;
+    let rows = src.fetch_with_context(&HashMap::new()).await.unwrap();
+    let ids: Vec<i64> = rows.iter().map(|r| r["id"].as_i64().unwrap()).collect();
+    assert_eq!(ids, vec![1, 2, 3, 4]); // both chunks, in order
+}
+
+#[tokio::test]
+async fn failed_statement_is_typed_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/2.0/sql/statements"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "statement_id": "s4",
+            "status": { "state": "FAILED",
+                        "error": { "error_code": "BAD_REQUEST", "message": "no such table" } }
+        })))
+        .mount(&server)
+        .await;
+
+    let src = source(&server.uri(), "SELECT * FROM nope").await;
+    let err = src.fetch_with_context(&HashMap::new()).await.unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("FAILED"), "{msg}");
+    assert!(msg.contains("BAD_REQUEST"), "{msg}");
+    assert!(msg.contains("no such table"), "{msg}");
+}
+
+#[tokio::test]
+async fn http_error_surfaces_status_and_body() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/2.0/sql/statements"))
+        .respond_with(ResponseTemplate::new(403).set_body_string("permission denied"))
+        .mount(&server)
+        .await;
+    let src = source(&server.uri(), "SELECT 1").await;
+    let err = src.fetch_with_context(&HashMap::new()).await.unwrap_err();
+    assert!(err.to_string().contains("403"), "{}", err);
+}
+
+#[tokio::test]
+async fn incremental_bookmark_round_trip() {
+    let server = MockServer::start().await;
+    // Rows with a `ts` cursor column; source should emit the max as the bookmark.
+    Mock::given(method("POST"))
+        .and(path_regex(r"^/api/2\.0/sql/statements$"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "statement_id": "s5",
+            "status": { "state": "SUCCEEDED" },
+            "manifest": manifest(&[("id", "INT"), ("ts", "STRING")]),
+            "result": { "data_array": [
+                ["1", "2026-01-01"], ["2", "2026-03-01"], ["3", "2026-02-01"]
+            ] }
+        })))
+        .mount(&server)
+        .await;
+
+    let mut cfg = base_config(&server.uri(), "SELECT id, ts FROM t WHERE ts > ${bookmark}");
+    cfg.replication = DatabricksReplication::Incremental {
+        column: "ts".into(),
+        initial_value: json!("2026-01-15"),
+    };
+    let src = DatabricksSource::new(cfg)
+        .unwrap()
+        .with_endpoint_base(server.uri());
+
+    // state_key derived (incremental).
+    assert!(src.state_key().is_some());
+
+    use futures::StreamExt;
+    let ctx = HashMap::new();
+    let mut pages = src.stream_pages(&ctx, 1000);
+    let mut all_rows = Vec::new();
+    let mut final_bookmark: Option<Value> = None;
+    while let Some(p) = pages.next().await {
+        let page = p.unwrap();
+        if page.bookmark.is_some() {
+            final_bookmark = page.bookmark.clone();
+        }
+        all_rows.extend(page.records);
+    }
+    // Client-side filter drops the row at/below the initial bookmark (2026-01-01).
+    let kept_ts: Vec<&str> = all_rows.iter().map(|r| r["ts"].as_str().unwrap()).collect();
+    assert!(kept_ts.contains(&"2026-03-01") && kept_ts.contains(&"2026-02-01"));
+    assert!(!kept_ts.contains(&"2026-01-01"));
+    // Bookmark is the max cursor across the full scan.
+    assert_eq!(final_bookmark, Some(json!("2026-03-01")));
+}
+
+#[tokio::test]
+async fn check_probe_hits_warehouse() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/2.0/sql/statements"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "statement_id": "chk", "status": { "state": "SUCCEEDED" },
+            "manifest": manifest(&[("one", "INT")]), "result": { "data_array": [["1"]] }
+        })))
+        .mount(&server)
+        .await;
+    let src = source(&server.uri(), "SELECT 1").await;
+    let report = src
+        .check(&faucet_core::check::CheckContext::default())
+        .await
+        .unwrap();
+    assert!(
+        report
+            .probes
+            .iter()
+            .all(|p| matches!(p.status, faucet_core::check::ProbeStatus::Pass)),
+        "{report:?}"
+    );
+}

--- a/docs/book/src/reference/choosing.md
+++ b/docs/book/src/reference/choosing.md
@@ -173,6 +173,26 @@ Delta and Iceberg are the two open lakehouse table formats; faucet ships a sink
 **Rule of thumb:** landing data for Databricks, or you want a catalog-free Delta
 table → `delta`; an Iceberg-native platform or shared catalog → `iceberg`.
 
+## Reading from Databricks: Delta source vs. Databricks SQL source
+
+Two ways to read from Databricks — pick by whether you want a **table** or a
+**query result**:
+
+- **`source-delta`** — scans a whole Delta table on object storage. Highest
+  throughput, no running/billed compute, time travel, projection pushdown. Use
+  it for full-table extracts and backfills.
+- **`source-databricks`** — runs an arbitrary **SQL query** against a running
+  Databricks **SQL Warehouse** via the Statement Execution API and streams the
+  *result rows* (joins, aggregates, filtered slices). Use it when you need the
+  output of a query rather than a raw table, and don't mind that a warehouse
+  must be running (and billed) for the duration.
+
+**Rule of thumb:** whole table, cheapest + fastest → `delta`; the result of a
+SQL query (joins/aggregates/filters) → `databricks`. There is deliberately no
+Databricks *sink* over the SQL API — the write path is the Delta Lake sink (a
+warehouse `INSERT`/`MERGE` sink would be slow, INSERT-bound, and force billed
+compute).
+
 ## Still unsure?
 
 Run `faucet list` to see what's installed, `faucet schema source <name>` to

--- a/docs/book/src/reference/connectors.md
+++ b/docs/book/src/reference/connectors.md
@@ -38,6 +38,7 @@ Legend: ✓ supported · ✗ not applicable. Tier: T1 = passes the faucet-confor
 | AWS Kinesis | T1 ✅ | `source-kinesis` | ✓ | ✓ | ✗ | ✗ | ✗ | per-shard GetRecords workers; sequence-number bookmarks, idle/max-messages termination |
 | Apache Parquet | T1 ✅ | `source-parquet` | ✓ | ✗ | ✗ | ✗ | ✗ | local/glob/S3, vectorized Arrow reader, projection |
 | Apache Delta Lake | T2 | `source-delta` | ✓ | ✗ | ✗ | ✗ | ✗ | local FS or S3/Azure/GCS; time travel (version/timestamp), projection pushdown, partition reconstruction |
+| Databricks SQL | T3 | `source-databricks` | ✓ | ✓ | ✗ | ✗ | ✗ | Statement Execution API; async poll, chunk pagination, typed decode, incremental `${bookmark}` |
 | BigQuery | T1 ✅ᵐ | `source-bigquery` | ✓ | ✗ | ✗ | ✗ | ✓ | `jobs.query` + pageToken pagination |
 | Snowflake | T1 ✅ᵐ | `source-snowflake` | ✓ | ✗ | ✗ | ✗ | ✓ | SQL REST API, server-side partitions |
 | Cloud Spanner | T1 ✅ᵉ | `source-spanner` | ✓ | ✓⁸ | ✗ | ✗ | ✓ | streaming SQL (gRPC), incremental `@bookmark` replication, stale reads, PK-range sharding |

--- a/faucet-stream/Cargo.toml
+++ b/faucet-stream/Cargo.toml
@@ -38,6 +38,7 @@ source = [
     "source-elasticsearch",
     "source-parquet",
     "source-delta",
+    "source-databricks",
     "source-gcs",
     "source-bigquery",
     "source-snowflake",
@@ -139,6 +140,7 @@ source-kafka = ["dep:faucet-source-kafka", "dep:faucet-common-kafka"]
 source-kinesis = ["dep:faucet-source-kinesis", "dep:faucet-common-kinesis"]
 source-parquet = ["dep:faucet-source-parquet"]
 source-delta = ["dep:faucet-source-delta"]
+source-databricks = ["dep:faucet-source-databricks"]
 source-gcs = ["dep:faucet-source-gcs", "dep:faucet-common-gcs"]
 source-bigquery = ["dep:faucet-source-bigquery", "dep:faucet-common-bigquery"]
 source-snowflake = ["dep:faucet-source-snowflake", "dep:faucet-common-snowflake"]
@@ -239,6 +241,7 @@ faucet-source-csv = { workspace = true, optional = true }
 faucet-source-elasticsearch = { workspace = true, optional = true }
 faucet-source-parquet = { workspace = true, optional = true }
 faucet-source-delta = { workspace = true, optional = true }
+faucet-source-databricks = { workspace = true, optional = true }
 faucet-source-gcs = { workspace = true, optional = true }
 faucet-source-bigquery = { workspace = true, optional = true }
 faucet-source-snowflake = { workspace = true, optional = true }

--- a/faucet-stream/src/lib.rs
+++ b/faucet-stream/src/lib.rs
@@ -35,6 +35,7 @@
 //! | `source-spanner` | Google Cloud Spanner query source |
 //! | `source-parquet` | Apache Parquet file source (local, glob, S3) |
 //! | `source-delta` | Apache Delta Lake source (local FS or S3/Azure/GCS, time travel) |
+//! | `source-databricks` | Databricks SQL query source (Statement Execution API) |
 //! | `sink-bigquery` | Google BigQuery streaming insert sink |
 //! | `sink-iceberg` | Apache Iceberg sink (append-only, REST/Glue/SQL/HMS catalogs) |
 //! | `sink-postgres` | PostgreSQL sink (jsonb or auto-mapped columns) |
@@ -206,6 +207,11 @@ pub mod source {
         pub use faucet_source_delta::*;
     }
 
+    #[cfg(feature = "source-databricks")]
+    pub mod databricks {
+        pub use faucet_source_databricks::*;
+    }
+
     #[cfg(feature = "source-gcs")]
     pub mod gcs {
         pub use faucet_source_gcs::*;
@@ -338,6 +344,11 @@ pub mod source {
     #[cfg(feature = "source-delta")]
     pub mod delta {
         pub use faucet_source_delta::*;
+    }
+
+    #[cfg(feature = "source-databricks")]
+    pub mod databricks {
+        pub use faucet_source_databricks::*;
     }
 
     #[cfg(feature = "source-gcs")]

--- a/schemas/faucet.schema.json
+++ b/schemas/faucet.schema.json
@@ -5205,6 +5205,126 @@
         }
       }
     },
+    "source_databricks__AuthSpec": {
+      "description": "A connector's `auth:` field: **either** an inline auth definition `A`\n(the `{ type, config }` shape), **or** a `{ ref: <name> }` reference to a\nshared provider defined in the top-level `auth:` catalog.\n\n`ref` is mutually exclusive with inline fields — supplying both is a\ndeserialization error.",
+      "anyOf": [
+        {
+          "description": "Inline auth, spelled out on the connector.",
+          "$ref": "#/$defs/source_databricks__DatabricksAuth"
+        },
+        {
+          "description": "A reference to a shared provider in the top-level `auth:` catalog.",
+          "$ref": "#/$defs/source_databricks__AuthReference"
+        }
+      ]
+    },
+    "source_databricks__DatabricksAuth": {
+      "description": "Authentication for the Databricks SQL Statement Execution API.\n\nBoth variants send `Authorization: Bearer <token>` — Databricks accepts a\nPersonal Access Token (PAT) or an OAuth machine-to-machine (M2M) access\ntoken in the same header. Uses the project-wide adjacently-tagged\n`{ type, config }` shape, e.g. `auth: { type: pat, config: { token: … } }`.\nA shared `auth: { ref: <name> }` provider that yields a `Bearer`/`Token`\ncredential maps onto [`DatabricksAuth::Token`].",
+      "oneOf": [
+        {
+          "description": "Databricks Personal Access Token.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "pat"
+            },
+            "config": {
+              "type": "object",
+              "properties": {
+                "token": {
+                  "description": "The token string (use `${env:…}` / `${vault:…}` to inject).",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "A pre-obtained OAuth (M2M) bearer token.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "token"
+            },
+            "config": {
+              "type": "object",
+              "properties": {
+                "token": {
+                  "description": "The bearer token string.",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "source_databricks__AuthReference": {
+      "description": "A `{ ref: <name> }` pointer to a named provider in the top-level `auth:`\ncatalog. The only permitted key is `ref`.",
+      "type": "object",
+      "properties": {
+        "ref": {
+          "description": "Name of the provider in the top-level `auth:` catalog.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": true
+    },
+    "source_databricks__DatabricksParam": {
+      "description": "A named SQL parameter passed to the statement (`:name` markers in the SQL).",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Parameter name (the `:name` marker in the SQL, without the colon).",
+          "type": "string"
+        },
+        "value": {
+          "description": "Parameter value. Sent to Databricks as its string form; `null` binds a\ntyped NULL.",
+          "default": null
+        },
+        "type": {
+          "description": "Optional Databricks SQL type (e.g. `INT`, `STRING`, `DATE`, `TIMESTAMP`).\nWhen omitted, Databricks treats the value as `STRING`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "source_databricks__DatabricksReplication": {
+      "description": "How the source replicates rows across runs.\n\nSerializes as `{ type: full }` or\n`{ type: incremental, column: \"...\", initial_value: ... }`.",
+      "oneOf": [
+        {
+          "description": "Every run fetches the full result set (default).",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "full"
+            }
+          }
+        },
+        {
+          "description": "Only rows whose `column` is strictly greater than the stored bookmark\n(or `initial_value` on the first run) are emitted. If the SQL contains\nthe literal token `${bookmark}`, it is bound as a `:_faucet_bookmark`\nnamed parameter so the warehouse filters server-side (efficient); the\nsource also filters client-side as a correctness backstop. The new\nmaximum of `column` is persisted on the final page.",
+          "type": "object",
+          "properties": {
+            "column": {
+              "description": "Column whose value is the replication cursor (e.g. `updated_at`).",
+              "type": "string"
+            },
+            "initial_value": {
+              "description": "Lower bound used on the first run, before any bookmark is stored."
+            },
+            "type": {
+              "type": "string",
+              "const": "incremental"
+            }
+          }
+        }
+      ]
+    },
     "source_gcs__GcsCredentials": {
       "description": "Credential source for a GCS client.\n\nSerializes as `{ type: <method>, config: { … } }` (adjacent tagging,\nsnake_case discriminators) — the consistent auth wire shape shared by\nevery faucet connector:\n`{ type: service_account_json_file, config: { path: \"/run/secrets/sa.json\" } }`.",
       "oneOf": [
@@ -10124,6 +10244,122 @@
                   },
                   "title": "DeltaSourceConfig",
                   "description": "Configuration for the Delta Lake source connector.\n\nThe `table_uri` / `credentials` / `storage_options` keys are flattened in\nfrom the shared [`DeltaConnection`]. Reads scan the table's active data\nfiles at the latest version (or a pinned `version` / `timestamp` for time\ntravel) and yield each row as a JSON object.",
+                  "type": "object"
+                },
+                true
+              ]
+            },
+            "transforms": {
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "inherit_transforms": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "title": "databricks",
+          "properties": {
+            "type": {
+              "const": "databricks"
+            },
+            "config": {
+              "anyOf": [
+                {
+                  "properties": {
+                    "workspace_url": {
+                      "description": "Workspace base URL, e.g. `https://dbc-abc123.cloud.databricks.com`.",
+                      "type": "string"
+                    },
+                    "warehouse_id": {
+                      "description": "Target SQL Warehouse id.",
+                      "type": "string"
+                    },
+                    "sql": {
+                      "description": "The SQL statement to run. May contain `:name` parameter markers (see\n[`parameters`](Self::parameters)) and a `${bookmark}` token for\nincremental replication.",
+                      "type": "string"
+                    },
+                    "auth": {
+                      "description": "Authentication (PAT / OAuth bearer), inline or via a shared `auth: { ref }`.",
+                      "$ref": "#/$defs/source_databricks__AuthSpec"
+                    },
+                    "catalog": {
+                      "description": "Default Unity Catalog catalog for the statement.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "schema": {
+                      "description": "Default schema for the statement.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "parameters": {
+                      "description": "Named SQL parameters (`:name` markers).",
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/$defs/source_databricks__DatabricksParam"
+                      },
+                      "default": []
+                    },
+                    "wait_timeout_secs": {
+                      "description": "Server-side wait before the statement goes async (seconds). Databricks\naccepts `0` (fully async) or `5`–`50`. Defaults to `50`.",
+                      "type": [
+                        "integer",
+                        "string"
+                      ],
+                      "format": "uint64",
+                      "minimum": 0,
+                      "default": 50
+                    },
+                    "poll_interval_secs": {
+                      "description": "Client poll cadence while the statement is `PENDING`/`RUNNING` (seconds).",
+                      "type": [
+                        "integer",
+                        "string"
+                      ],
+                      "format": "uint64",
+                      "minimum": 0,
+                      "default": 1
+                    },
+                    "batch_size": {
+                      "description": "Page size — rows accumulated before a `StreamPage` is emitted.",
+                      "type": [
+                        "integer",
+                        "string"
+                      ],
+                      "format": "uint",
+                      "minimum": 0,
+                      "default": 1000
+                    },
+                    "replication": {
+                      "description": "Replication mode. Defaults to [`DatabricksReplication::Full`].",
+                      "$ref": "#/$defs/source_databricks__DatabricksReplication",
+                      "default": {
+                        "type": "full"
+                      }
+                    },
+                    "state_key": {
+                      "description": "Explicit state-store key for the incremental bookmark. When unset, a key\nis derived from the workspace/warehouse and a query fingerprint.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "title": "DatabricksSourceConfig",
+                  "description": "Configuration for the Databricks SQL query source.\n\nRuns `sql` against a Databricks SQL Warehouse via the Statement Execution\nREST API and streams the result rows as typed JSON objects.",
                   "type": "object"
                 },
                 true


### PR DESCRIPTION
## Summary

Adds `faucet-source-databricks` (`1.0.0`) — a query source over the **Databricks SQL Statement Execution API** (REST). It runs SQL against a Databricks **SQL Warehouse** and streams the result rows as typed JSON, modelled on the Snowflake/BigQuery query sources (no JDBC/ODBC driver, no Python). This is the **query-results** read path for Databricks; full-table lakehouse scans and the write path are the Delta connectors (#317, merged in #319).

## What's included

- **Async statement lifecycle** — `POST /api/2.0/sql/statements` → poll `GET …/{id}` until terminal → stream result chunks (INLINE + `JSON_ARRAY`), following `next_chunk_internal_link`.
- **Type-aware decode** from the response `manifest` column schema — every `JSON_ARRAY` cell is a string, decoded per `type_name` (BOOLEAN→bool, INT/LONG→number with lossless-string fallback for huge values, DECIMAL kept as exact string, ARRAY/MAP/STRUCT parsed, dates/timestamps as strings).
- **Incremental replication** — `{ type: incremental, column, initial_value }` + a `${bookmark}` token bound as a server-side `:_faucet_bookmark` named param, plus a client-side `filter_incremental` backstop; resumable via `state_key` / `apply_start_bookmark`.
- **Bearer auth** (PAT / OAuth M2M), inline or via the shared `auth: { ref }` catalog; named `parameters` (`:name`, typed); `catalog`/`schema`; `check()` runs a non-scanning `SELECT 1` probe; `dataset_uri()` redacts.
- **Deliberately source-only** — no Databricks SQL sink (a warehouse `INSERT`/`MERGE` sink would be slow, INSERT-bound, and force billed compute; the Delta sink is the write path).

## Wiring & docs

Umbrella + CLI registry (`databricks` source kind, shared-auth injection), `feature-check` CI matrix, `connectors/registry.json`, regenerated `schemas/faucet.schema.json`, docs (capability matrix, choosing guide "Delta source vs Databricks SQL source", crate README, root README counts 27→28 sources / 45→46 total), and a runnable `databricks_to_jsonl.yaml` example.

## Testing

- Unit: typed decode (all `type_name` branches, huge-LONG, non-finite float, nested), config validation, request-body/param/`${bookmark}` building, state-key derivation.
- Wiremock integration: inline success + typed decode, async PENDING→SUCCEEDED poll, multi-chunk pagination, FAILED-statement + HTTP-error handling, incremental bookmark round-trip, `check` probe.
- Conformance battery: config-schema validity + bounded-memory (peak page ≤ `batch_size`).
- ~92% line coverage on the new crate; clippy `-D warnings` and rustfmt clean.

## Out of scope (follow-ups)

`EXTERNAL_LINKS` large-result disposition, `discover()` via `INFORMATION_SCHEMA`, Unity Catalog Volumes.

Closes #318. Part of the roadmap epic #38.