### PR TITLE
fix: resolve #321 medium/low audit findings (quality/contract equality, CDC, pagination, serve, observability)

### DIFF
--- a/cli/src/catalog/model.rs
+++ b/cli/src/catalog/model.rs
@@ -16,50 +16,89 @@ use serde_json::Value;
 /// 2. **Credential redaction** — via `faucet_core::redact_uri_credentials`,
 ///    so a `postgres://user:pass@host/db` URI never lands in the store.
 pub fn canonicalize_uri(uri: &str, raw_config: &Value, clock: DateTime<FixedOffset>) -> String {
-    let mut tokens: Vec<String> = Vec::new();
-    collect_now_tokens(raw_config, &mut tokens);
-    tokens.sort();
-    tokens.dedup();
+    let mut ctxs: Vec<TokenCtx> = Vec::new();
+    collect_now_token_contexts(raw_config, &mut ctxs);
 
-    // Render each token with the same clock the run used, then substitute the
-    // rendered text back to the token — longest rendering first, so e.g.
-    // `${now.datetime}` wins over the `${now.year}` embedded within it.
-    let mut pairs: Vec<(String, String)> = tokens
+    // Each token is folded back **anchored to the literal characters that
+    // surround it in the config template** — not by a blind global replace of
+    // the rendered value (audit #321 L8). A short rendering like `${now.month}`
+    // → "07" would otherwise fold a coincidental `bucket-07` on days whose
+    // digits collide, splitting one physical sink into several catalog datasets
+    // with unstable identity. Anchoring `/07/` (the token's real `.../${now.month}/…`
+    // context) leaves `bucket-07` untouched.
+    let mut pairs: Vec<(String, String)> = ctxs
         .into_iter()
-        .filter_map(|t| {
-            crate::interpolate::resolve_now(&t, clock)
-                .ok()
-                .filter(|rendered| !rendered.is_empty() && rendered != &t)
-                .map(|rendered| (rendered, t))
+        .filter_map(|c| {
+            let rendered = crate::interpolate::resolve_now(&c.token, clock).ok()?;
+            if rendered.is_empty() || rendered == c.token {
+                return None;
+            }
+            let mut search = String::new();
+            let mut replace = String::new();
+            if let Some(l) = c.left {
+                search.push(l);
+                replace.push(l);
+            }
+            search.push_str(&rendered);
+            replace.push_str(&c.token);
+            if let Some(r) = c.right {
+                search.push(r);
+                replace.push(r);
+            }
+            Some((search, replace))
         })
         .collect();
-    pairs.sort_by_key(|(rendered, _)| std::cmp::Reverse(rendered.len()));
+    // Dedup identical (search, replace) folds, then apply longest-search first
+    // so `${now.datetime}` wins over the `${now.year}` embedded within it.
+    pairs.sort();
+    pairs.dedup();
+    pairs.sort_by_key(|(search, _)| std::cmp::Reverse(search.len()));
 
     let mut out = uri.to_string();
-    for (rendered, token) in pairs {
-        out = out.replace(&rendered, &token);
+    for (search, replace) in pairs {
+        out = out.replace(&search, &replace);
     }
     faucet_core::redact_uri_credentials(&out)
 }
 
-/// Collect every `${now.…}` token appearing in the string values of `v`.
-fn collect_now_tokens(v: &Value, out: &mut Vec<String>) {
+/// A `${now.*}` token together with the literal characters that immediately
+/// precede and follow it in its config string (used as fold anchors). `None`
+/// when the token sits at the very start / end of the string.
+struct TokenCtx {
+    token: String,
+    left: Option<char>,
+    right: Option<char>,
+}
+
+/// Collect every `${now.…}` token in the string values of `v`, each with its
+/// surrounding-character context. The context anchors keep a short rendered
+/// value from folding coincidental look-alike substrings elsewhere in the URI.
+fn collect_now_token_contexts(v: &Value, out: &mut Vec<TokenCtx>) {
     match v {
         Value::String(s) => {
-            let mut rest = s.as_str();
-            while let Some(start) = rest.find("${now.") {
-                let tail = &rest[start..];
+            let mut search_from = 0;
+            while let Some(rel) = s[search_from..].find("${now.") {
+                let start = search_from + rel;
+                let tail = &s[start..];
                 match tail.find('}') {
-                    Some(end) => {
-                        out.push(tail[..=end].to_string());
-                        rest = &tail[end + 1..];
+                    Some(end_rel) => {
+                        let end = start + end_rel; // index of '}'
+                        let token = s[start..=end].to_string();
+                        let left = s[..start].chars().next_back();
+                        let right = s[end + 1..].chars().next();
+                        out.push(TokenCtx { token, left, right });
+                        search_from = end + 1;
                     }
                     None => break,
                 }
             }
         }
-        Value::Array(items) => items.iter().for_each(|i| collect_now_tokens(i, out)),
-        Value::Object(map) => map.values().for_each(|i| collect_now_tokens(i, out)),
+        Value::Array(items) => items
+            .iter()
+            .for_each(|i| collect_now_token_contexts(i, out)),
+        Value::Object(map) => map
+            .values()
+            .for_each(|i| collect_now_token_contexts(i, out)),
         _ => {}
     }
 }
@@ -112,18 +151,39 @@ mod tests {
     }
 
     #[test]
-    fn collect_finds_multiple_tokens_in_one_string() {
+    fn collect_finds_tokens_with_surrounding_context() {
         let mut out = Vec::new();
-        collect_now_tokens(&json!("a-${now.year}-${now.month}-b"), &mut out);
-        assert_eq!(out, vec!["${now.year}", "${now.month}"]);
+        collect_now_token_contexts(&json!("a-${now.year}-${now.month}-b"), &mut out);
+        let got: Vec<(&str, Option<char>, Option<char>)> = out
+            .iter()
+            .map(|c| (c.token.as_str(), c.left, c.right))
+            .collect();
+        assert_eq!(
+            got,
+            vec![
+                ("${now.year}", Some('-'), Some('-')),
+                ("${now.month}", Some('-'), Some('-')),
+            ]
+        );
         // Unterminated token is ignored, not a panic.
         out.clear();
-        collect_now_tokens(&json!("broken ${now.date"), &mut out);
+        collect_now_token_contexts(&json!("broken ${now.date"), &mut out);
         assert!(out.is_empty());
         // Tokens inside arrays (e.g. a list-valued config field) are found too.
         out.clear();
-        collect_now_tokens(&json!({"paths": ["x", "${now.date}"]}), &mut out);
-        assert_eq!(out, vec!["${now.date}"]);
+        collect_now_token_contexts(&json!({"paths": ["x", "${now.date}"]}), &mut out);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].token, "${now.date}");
+        assert_eq!((out[0].left, out[0].right), (None, None));
+    }
+
+    #[test]
+    fn anchored_fold_does_not_touch_coincidental_substrings() {
+        // #321 L8: a short `${now.month}` → "07" must fold only the real
+        // `.../07/...` path segment, not a coincidental `bucket-07`.
+        let raw = json!({"path": "s3://bucket-07/data/${now.month}/part.jsonl"});
+        let uri = canonicalize_uri("s3://bucket-07/data/07/part.jsonl", &raw, clock());
+        assert_eq!(uri, "s3://bucket-07/data/${now.month}/part.jsonl");
     }
 
     #[test]

--- a/cli/src/dlq_replay/mod.rs
+++ b/cli/src/dlq_replay/mod.rs
@@ -302,9 +302,7 @@ pub fn discard(
             append_to(&archive, &removed)?;
             archived_to.push(archive.to_string_lossy().into_owned());
         }
-        std::fs::write(file, kept.as_bytes()).map_err(|e| {
-            CliError::Internal(format!("rewriting DLQ file '{}': {e}", file.display()))
-        })?;
+        atomic_rewrite(file, kept.as_bytes())?;
         files_rewritten += 1;
     }
 
@@ -313,6 +311,31 @@ pub fn discard(
         files_rewritten,
         archived_to,
     })
+}
+
+/// Rewrite `file` atomically: write the surviving lines to a temp file in the
+/// same directory, then `rename` it over the original. A process kill mid-write
+/// leaves the original intact (the incomplete write lands only in the temp
+/// file), so the un-discarded kept envelopes can never be lost to a truncated
+/// prefix — unlike a direct `fs::write` truncate-then-write (audit #321 L3).
+fn atomic_rewrite(file: &std::path::Path, contents: &[u8]) -> CliResult<()> {
+    let parent = file.parent().unwrap_or_else(|| std::path::Path::new("."));
+    let name = file
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("dlq.jsonl");
+    // Same-directory temp so the rename is atomic (same filesystem). The pid
+    // keeps concurrent discards on the same file from colliding on the temp name.
+    let tmp = parent.join(format!(".{name}.{}.tmp", std::process::id()));
+    std::fs::write(&tmp, contents).map_err(|e| {
+        CliError::Internal(format!("writing temp DLQ file '{}': {e}", tmp.display()))
+    })?;
+    std::fs::rename(&tmp, file).map_err(|e| {
+        // Best-effort cleanup of the temp file if the rename failed.
+        let _ = std::fs::remove_file(&tmp);
+        CliError::Internal(format!("rewriting DLQ file '{}': {e}", file.display()))
+    })?;
+    Ok(())
 }
 
 /// The archive sibling for a DLQ file: `dlq.jsonl` → `dlq.archived.jsonl`.
@@ -431,6 +454,16 @@ mod tests {
         // The archive holds the discarded envelope.
         let archived = std::fs::read_to_string(dir.path().join("dlq.archived.jsonl")).unwrap();
         assert!(archived.contains("QualityFailure"));
+        // #321 L3: the atomic rewrite leaves no lingering temp file behind.
+        let leftover: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|e| e.file_name().to_string_lossy().ends_with(".tmp"))
+            .collect();
+        assert!(
+            leftover.is_empty(),
+            "no .tmp file should remain: {leftover:?}"
+        );
     }
 
     #[test]

--- a/cli/src/notify/dispatch.rs
+++ b/cli/src/notify/dispatch.rs
@@ -111,6 +111,12 @@ impl Notifier {
                 }
             }
             Err(e) => {
+                // The leading-edge delivery failed: roll back the coalesce
+                // timestamp so a retry of an identical event within the window
+                // is NOT silently dropped — otherwise the operator gets zero
+                // notifications about an ongoing outage until the window elapses
+                // (audit #321 L4).
+                self.uncoalesce(rule, event);
                 metrics::record_sent(channel, event.kind.as_str(), false);
                 metrics::record_dropped(channel, "channel_error");
                 tracing::warn!(rule = %rule.name, channel, error = %e, "notification delivery failed");
@@ -209,6 +215,18 @@ impl Notifier {
         }
         map.insert(key, now);
         false
+    }
+
+    /// Remove the coalesce timestamp recorded by [`Self::coalesce`] for this
+    /// (rule, event). Called when the leading-edge delivery fails so the next
+    /// identical event re-attempts delivery instead of being coalesced away
+    /// (audit #321 L4).
+    fn uncoalesce(&self, rule: &NotificationSpec, event: &NotifyEvent) {
+        if rule.dedupe_window_secs.filter(|w| *w > 0).is_none() {
+            return;
+        }
+        let key = format!("{}::{}", rule.name, event.dedupe_key());
+        self.dedupe.lock().unwrap().remove(&key);
     }
 
     /// Test-only view of open incidents.
@@ -346,6 +364,26 @@ mod tests {
         let e = NotifyEvent::run_failure("p", "", "s", "m");
         assert!(!n.coalesce(&r, &e));
         assert!(!n.coalesce(&r, &e));
+    }
+
+    #[test]
+    fn uncoalesce_lets_the_next_event_retry_after_failure() {
+        // #321 L4: a leading-edge failure rolls the coalesce timestamp back, so
+        // the next identical event is delivered rather than silently coalesced.
+        let mut r = rule("a", vec![], slack());
+        r.dedupe_window_secs = Some(3600);
+        let n = Notifier::from_specs(&[r.clone()]).unwrap().unwrap();
+        let e = NotifyEvent::run_failure("p", "", "s", "m");
+        assert!(!n.coalesce(&r, &e), "leading edge records the instant");
+        // Simulate the delivery having failed:
+        n.uncoalesce(&r, &e);
+        // The next identical event must NOT be coalesced (retry allowed).
+        assert!(
+            !n.coalesce(&r, &e),
+            "after rollback the next event retries instead of being dropped"
+        );
+        // And a subsequent one (whose leading edge succeeded) does coalesce.
+        assert!(n.coalesce(&r, &e));
     }
 
     #[test]

--- a/cli/src/serve/handlers/reload.rs
+++ b/cli/src/serve/handlers/reload.rs
@@ -8,14 +8,24 @@
 //! (RBAC [`Permission::Reload`](crate::serve::rbac::Permission::Reload)).
 
 use crate::serve::error::ServeError;
+use crate::serve::rbac::AuthContext;
 use crate::serve::state::ServerState;
 use axum::Json;
-use axum::extract::State;
+use axum::extract::{Extension, State};
 use serde_json::{Value, json};
 
 /// `POST /v1/reload` → 200 `{reloaded, path?}` / 422 (invalid new config).
-pub async fn reload(State(state): State<ServerState>) -> Result<Json<Value>, ServeError> {
+///
+/// Writes a `config.reload` audit record on every outcome — this is a
+/// server-wide privileged mutation (it swaps the config merge base every later
+/// run inherits), so it must be attributable in `GET /v1/audit` like the other
+/// privileged mutations (audit #321 M6).
+pub async fn reload(
+    State(state): State<ServerState>,
+    Extension(actor): Extension<AuthContext>,
+) -> Result<Json<Value>, ServeError> {
     let Some(path) = state.default_config_path().cloned() else {
+        crate::serve::audit::write(&state, &actor, "config.reload", None, None, "noop").await;
         return Ok(Json(json!({
             "reloaded": false,
             "reason": "no --default-config configured; nothing to reload",
@@ -31,14 +41,19 @@ pub async fn reload(State(state): State<ServerState>) -> Result<Json<Value>, Ser
             })?;
             state.set_default_base(Some(value));
             tracing::info!(path = %path.display(), "reloaded --default-config (POST /v1/reload)");
+            crate::serve::audit::write(&state, &actor, "config.reload", None, None, "ok").await;
             Ok(Json(json!({
                 "reloaded": true,
                 "path": path.display().to_string(),
             })))
         }
-        Err(e) => Err(ServeError::Unprocessable {
-            message: format!("reload rejected — keeping previous config: {e}"),
-            details: None,
-        }),
+        Err(e) => {
+            crate::serve::audit::write(&state, &actor, "config.reload", None, None, "rejected")
+                .await;
+            Err(ServeError::Unprocessable {
+                message: format!("reload rejected — keeping previous config: {e}"),
+                details: None,
+            })
+        }
     }
 }

--- a/cli/src/serve/history/sql.rs
+++ b/cli/src/serve/history/sql.rs
@@ -327,9 +327,13 @@ impl Stmts {
                 WHERE status = 'running' \
                 AND (lease_expires_at IS NULL OR lease_expires_at < $1)"
                 .into(),
+            // Preserve `cancel_requested` across a requeue (audit #321 M7): a
+            // cross-instance cancel acknowledged while the owner was partitioned
+            // must survive re-queueing so the next owner still honours it, rather
+            // than the run silently running to completion despite the cancel.
             reclaim_requeue: "UPDATE faucet_serve_runs \
                 SET status = 'pending', owner = NULL, lease_expires_at = NULL, \
-                    cancel_requested = NULL, body = $1 \
+                    body = $1 \
                 WHERE run_id = $2 AND status = 'running' \
                 AND (lease_expires_at IS NULL OR lease_expires_at < $3)"
                 .into(),
@@ -338,9 +342,14 @@ impl Stmts {
                 WHERE run_id = $3 AND status = 'running' \
                 AND (lease_expires_at IS NULL OR lease_expires_at < $4)"
                 .into(),
+            // Status-fenced (audit #321 L5): only finalize a still-non-terminal
+            // record, so a stale zombie execution that shares the same owner (a
+            // lease-lapse re-claim by the same instance) can never overwrite the
+            // terminal record written by the live execution. First finalizer wins.
             finalize_owned: "UPDATE faucet_serve_runs \
                 SET status = $1, finished_at = $2, lease_expires_at = $3, body = $4 \
-                WHERE run_id = $5 AND owner = $6"
+                WHERE run_id = $5 AND owner = $6 \
+                AND status NOT IN ('completed','failed','cancelled')"
                 .into(),
             cancel_pending: "UPDATE faucet_serve_runs \
                 SET status = 'cancelled', finished_at = $1, body = $2 \
@@ -527,9 +536,10 @@ impl Stmts {
                 WHERE status = 'running' \
                 AND (lease_expires_at IS NULL OR lease_expires_at < ?)"
                 .into(),
+            // Preserve `cancel_requested` across a requeue (audit #321 M7).
             reclaim_requeue: "UPDATE faucet_serve_runs \
                 SET status = 'pending', owner = NULL, lease_expires_at = NULL, \
-                    cancel_requested = NULL, body = ? \
+                    body = ? \
                 WHERE run_id = ? AND status = 'running' \
                 AND (lease_expires_at IS NULL OR lease_expires_at < ?)"
                 .into(),
@@ -538,9 +548,11 @@ impl Stmts {
                 WHERE run_id = ? AND status = 'running' \
                 AND (lease_expires_at IS NULL OR lease_expires_at < ?)"
                 .into(),
+            // Status-fenced (audit #321 L5): first finalizer wins.
             finalize_owned: "UPDATE faucet_serve_runs \
                 SET status = ?, finished_at = ?, lease_expires_at = ?, body = ? \
-                WHERE run_id = ? AND owner = ?"
+                WHERE run_id = ? AND owner = ? \
+                AND status NOT IN ('completed','failed','cancelled')"
                 .into(),
             cancel_pending: "UPDATE faucet_serve_runs \
                 SET status = 'cancelled', finished_at = ?, body = ? \

--- a/cli/src/serve/runner.rs
+++ b/cli/src/serve/runner.rs
@@ -29,7 +29,7 @@ const QUEUE_FULL_RETRY_AFTER_SECS: u64 = 5;
 /// aborts the pipeline's task set, the backstop for a run stuck mid-write so a
 /// hung run can't wedge shutdown). Generous enough for an S3 multipart
 /// completion (#146 H16).
-const RUN_FLUSH_GRACE: Duration = Duration::from_secs(30);
+pub(crate) const RUN_FLUSH_GRACE: Duration = Duration::from_secs(30);
 
 /// `POST /v1/runs` request body.
 #[derive(Debug, Deserialize)]

--- a/cli/src/serve/server.rs
+++ b/cli/src/serve/server.rs
@@ -414,10 +414,20 @@ pub async fn serve(config: ServeConfig) -> CliResult<()> {
         None => Vec::new(),
     };
 
-    // The HTTP graceful-shutdown future resolves on signal and stops accepting
-    // new connections / drains in-flight HTTP — it does NOT cancel run tasks.
+    // The HTTP graceful-shutdown future resolves on signal, then drives the run
+    // drain *inside itself* — this is load-bearing: `axum::serve(...).await` does
+    // not return until every open connection closes, and an open SSE
+    // `/v1/runs/{id}/logs` stream stays open until its run ends. If we deferred
+    // `shutdown.cancel()` to after the `.await` (as before), a long run with an
+    // open SSE stream would deadlock shutdown forever (audit #321 M9): axum waits
+    // on the SSE, the SSE waits on the run, the run waits on a cancel that never
+    // fires. Draining + cancelling from within the signal handler breaks that
+    // cycle — cancelled runs end, their SSE streams close, and axum can return.
     // `into_make_service_with_connect_info` exposes the peer address so the auth
     // layer can record a `source_ip` on audit records (#205).
+    let drain_state = state.clone();
+    let drain_shutdown = shutdown.clone();
+    let drain_grace = config.shutdown_grace;
     axum::serve(
         listener,
         app.into_make_service_with_connect_info::<SocketAddr>(),
@@ -425,32 +435,33 @@ pub async fn serve(config: ServeConfig) -> CliResult<()> {
     .with_graceful_shutdown(async move {
         wait_for_signal().await;
         tracing::info!("shutdown signal received; draining in-flight runs");
+        // Stop pulling NEW work the moment we begin draining.
+        if let Some(claim) = claim {
+            claim.abort();
+        }
+        // Grace for in-flight runs to finish naturally, then cooperatively
+        // cancel any still running so their sinks flush at the next page
+        // boundary AND their SSE streams close.
+        let drained =
+            tokio::time::timeout(drain_grace, drain_state.registry().wait_drained()).await;
+        if drained.is_err() {
+            let remaining = drain_state.registry().in_flight();
+            tracing::warn!(remaining, "grace window expired; cancelling in-flight runs");
+            drain_shutdown.cancel();
+        }
     })
     .await
     .map_err(|e| CliError::Serve(format!("server error: {e}")))?;
 
-    // Stop pulling NEW work the moment we begin draining: abort the claim loop so
-    // a shutting-down instance drains its in-flight runs rather than claiming more.
-    // The lease loop keeps heartbeating in-flight runs during the drain so peers
-    // don't reclaim them mid-shutdown.
-    if let Some(claim) = claim {
-        claim.abort();
-    }
-
-    // Now drain run tasks: wait up to the grace window, then cancel the rest.
-    let drained =
-        tokio::time::timeout(config.shutdown_grace, state.registry().wait_drained()).await;
-    if drained.is_err() {
-        let remaining = state.registry().in_flight();
-        tracing::warn!(remaining, "grace window expired; cancelling in-flight runs");
-        shutdown.cancel();
-        // Give cancelled tasks a brief moment to write their terminal status.
-        let _ = tokio::time::timeout(
-            std::time::Duration::from_secs(5),
-            state.registry().wait_drained(),
-        )
-        .await;
-    }
+    // Serve has returned (connections closed). Give any just-cancelled runs the
+    // full cooperative-flush grace to write their terminal status / complete an
+    // S3 multipart upload — matching the pipeline's own `RUN_FLUSH_GRACE`, not
+    // the old hardcoded 5s that cut buffered sinks off early (audit #321 M8).
+    let _ = tokio::time::timeout(
+        crate::serve::runner::RUN_FLUSH_GRACE,
+        state.registry().wait_drained(),
+    )
+    .await;
     maintenance.abort();
     leases.abort();
     #[cfg(feature = "triggers")]

--- a/cli/src/serve/state.rs
+++ b/cli/src/serve/state.rs
@@ -215,9 +215,17 @@ mod tests {
     #[tokio::test]
     async fn reload_handler_noop_without_default_config() {
         let s = state(AuthMode::None);
-        let axum::Json(body) = crate::serve::handlers::reload::reload(axum::extract::State(s))
-            .await
-            .expect("reload ok");
+        let actor = crate::serve::rbac::AuthContext {
+            principal: "admin".into(),
+            role: crate::serve::rbac::Role::Admin,
+            source_ip: None,
+        };
+        let axum::Json(body) = crate::serve::handlers::reload::reload(
+            axum::extract::State(s),
+            axum::extract::Extension(actor),
+        )
+        .await
+        .expect("reload ok");
         assert_eq!(body["reloaded"], serde_json::json!(false));
     }
 

--- a/crates/core/src/contract/mod.rs
+++ b/crates/core/src/contract/mod.rs
@@ -154,7 +154,7 @@ fn evaluate_record(
             ));
         }
         if let Some(values) = &f.allowed_values
-            && !values.iter().any(|v| v == value)
+            && !enum_contains(values, value)
         {
             return Some(violation(
                 "enum",
@@ -244,6 +244,26 @@ fn json_type_name(v: &Value) -> &'static str {
     }
 }
 
+/// Enum membership with numeric-aware equality: two JSON numbers compare by
+/// value (so an integer-spelled enum member `1` matches a conforming `1.0` on a
+/// `number` field), everything else by exact structural equality. `compile`
+/// already accepts an integer enum on a number field, and the per-record type
+/// check runs before this, so no cross-type coercion sneaks in (audit #321 M2).
+fn enum_contains(allowed: &[Value], value: &Value) -> bool {
+    allowed.iter().any(|v| match (v, value) {
+        (Value::Number(a), Value::Number(b)) => {
+            if let (Some(x), Some(y)) = (a.as_i64(), b.as_i64()) {
+                x == y
+            } else if let (Some(x), Some(y)) = (a.as_u64(), b.as_u64()) {
+                x == y
+            } else {
+                matches!((a.as_f64(), b.as_f64()), (Some(x), Some(y)) if x == y)
+            }
+        }
+        _ => v == value,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -278,6 +298,24 @@ mod tests {
         assert_eq!(out.survivors, page);
         assert!(out.quarantined.is_empty());
         assert!(out.warned.is_empty());
+    }
+
+    #[test]
+    fn numeric_enum_matches_across_int_float_spelling() {
+        // #321 M2: an integer-spelled enum on a `number` field must accept a
+        // conforming float value (and vice-versa) instead of spuriously breaching.
+        let c = compiled(json!({
+            "version": "1.0.0",
+            "on_breach": "fail",
+            "fields": [ { "name": "rate", "type": "number", "enum": [1, 2] } ]
+        }));
+        // 1.0 conforms to enum {1, 2} — must pass (was a false breach before).
+        let out = apply_contract(vec![json!({"rate": 1.0})], &c).unwrap();
+        assert_eq!(out.survivors.len(), 1);
+        assert!(out.quarantined.is_empty());
+        // A genuinely out-of-set value still breaches.
+        let err = apply_contract(vec![json!({"rate": 3.0})], &c).unwrap_err();
+        assert!(matches!(err, FaucetError::ContractViolation { .. }));
     }
 
     #[test]

--- a/crates/core/src/observability/decorator.rs
+++ b/crates/core/src/observability/decorator.rs
@@ -184,6 +184,12 @@ impl<'a, S: Source + ?Sized> Source for InstrumentedSource<'a, S> {
                         counter!("faucet_source_pages_total", metric_labels.clone()).increment(1);
                         counter!("faucet_source_records_total", metric_labels.clone())
                             .increment(page.records.len() as u64);
+                        // Close the timing window BEFORE yielding: in an
+                        // `async_stream` the timer local persists across the
+                        // yield, so dropping it at scope-exit would fold the
+                        // downstream sink/consumer latency into the source's
+                        // page-duration histogram (audit #321 M10).
+                        _timer.record_now();
                         yield page;
                     }
                     Ok(Some(Err(e))) => {

--- a/crates/core/src/observability/install.rs
+++ b/crates/core/src/observability/install.rs
@@ -199,9 +199,28 @@ pub fn install_observability(cfg: &ObservabilityConfig) -> Result<InstallReport,
         }
 
         if !installed {
+            // Install the OTLP export-error counter layer whenever ANY otel
+            // signal is exported — not only when a trace layer was installed —
+            // so `faucet_otel_export_failures_total` still fires under
+            // `otel.export: [metrics]` (audit #321 L7). `Option<Layer>` is a
+            // no-op when `None`, so this composes for the non-otel build too.
+            #[cfg(feature = "otel")]
+            let otel_error_layer = cfg
+                .otel
+                .as_ref()
+                .map(|o| {
+                    o.exports(crate::observability::otel::OtelSignal::Traces)
+                        || o.exports(crate::observability::otel::OtelSignal::Metrics)
+                })
+                .unwrap_or(false)
+                .then_some(crate::observability::otel::OtelErrorCountLayer);
+            #[cfg(not(feature = "otel"))]
+            let otel_error_layer: Option<tracing_subscriber::layer::Identity> = None;
+
             let reg = tracing_subscriber::registry()
                 .with(make_filter())
-                .with(tracing_subscriber::fmt::layer());
+                .with(tracing_subscriber::fmt::layer())
+                .with(otel_error_layer);
             if reg.try_init().is_err() {
                 // Some other code path has already set a global default. Log and
                 // continue — observability still works through the previously-

--- a/crates/core/src/observability/timer.rs
+++ b/crates/core/src/observability/timer.rs
@@ -33,6 +33,21 @@ impl DurationGuard {
         self.armed = false;
     }
 
+    /// Record the elapsed sample now and disarm (so a later `Drop` does not
+    /// double-record). Used to close the timing window at a generator `yield`
+    /// point: locals persist across a `yield`, so a drop-on-scope-exit timer
+    /// would wrongly include the time the downstream consumer spends before
+    /// polling the next item. Recording before the yield measures only the
+    /// producer's own work (audit #321 M10).
+    pub fn record_now(&mut self) {
+        if !self.armed {
+            return;
+        }
+        let elapsed = self.started_at.elapsed().as_secs_f64();
+        histogram!(self.name.clone(), self.labels.clone()).record(elapsed);
+        self.armed = false;
+    }
+
     /// Build the canonical (name, pipeline, row, connector) label trio.
     pub fn with_connector(
         name: impl Into<KeyName>,
@@ -102,6 +117,42 @@ mod tests {
             found,
             "expected a histogram sample > 0 on test_duration_records_sample"
         );
+    }
+
+    #[test]
+    fn record_now_records_once_and_disarms() {
+        // #321 M10: record_now() emits exactly one sample and the later drop
+        // does not double-record.
+        let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let snap = snapshotter();
+        {
+            let mut guard = DurationGuard::with_connector(
+                "test_duration_record_now",
+                SharedString::const_str("p"),
+                SharedString::const_str("r"),
+                SharedString::const_str("c"),
+            );
+            thread::sleep(Duration::from_millis(2));
+            guard.record_now();
+        } // drop here must be a no-op (already disarmed)
+        let snapshot = snap.snapshot();
+        let samples = snapshot
+            .into_vec()
+            .into_iter()
+            .find_map(|(key, _u, _d, value)| {
+                (key.key().name() == "test_duration_record_now").then_some(value)
+            });
+        match samples {
+            Some(DebugValue::Histogram(s)) => {
+                assert_eq!(
+                    s.len(),
+                    1,
+                    "record_now + drop must record exactly one sample"
+                );
+                assert!(s[0].into_inner() > 0.0);
+            }
+            other => panic!("expected one histogram sample, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -783,9 +783,17 @@ where
                         page
                     };
 
+                    // True page positions of the records currently flowing, kept
+                    // in lockstep as quality/contract remove rows, so a later
+                    // schema-drift quarantine annotates the envelope with the
+                    // record's real page index — not a survivor-relative one
+                    // (audit #321 L6). Quality's own quarantine already uses the
+                    // true `page_index`; this carries the same truth to drift.
+                    let page_len = page.records.len();
+
                     // ── Quality pass (after transforms, before sink) ─────────
                     #[cfg(feature = "quality")]
-                    let (records, quality_envelopes): (Vec<Value>, Vec<Value>) =
+                    let (records, quality_envelopes, page_indices): (Vec<Value>, Vec<Value>, Vec<usize>) =
                         if let Some(q) = quality.as_ref() {
                             let labels =
                                 crate::observability::Labels::new(&*pipeline_name, &*row, &*run_id);
@@ -794,6 +802,8 @@ where
                                 q,
                                 &labels,
                             )?;
+                            let quarantined_idx: std::collections::HashSet<usize> =
+                                outcome.quarantined.iter().map(|qr| qr.page_index).collect();
                             let envelopes: Vec<Value> = outcome
                                 .quarantined
                                 .iter()
@@ -816,13 +826,15 @@ where
                                     )
                                 })
                                 .collect();
-                            (outcome.survivors, envelopes)
+                            let survivor_idx: Vec<usize> =
+                                (0..page_len).filter(|i| !quarantined_idx.contains(i)).collect();
+                            (outcome.survivors, envelopes, survivor_idx)
                         } else {
-                            (page.records, Vec::new())
+                            (page.records, Vec::new(), (0..page_len).collect())
                         };
                     #[cfg(not(feature = "quality"))]
-                    let (records, quality_envelopes): (Vec<Value>, Vec<Value>) =
-                        (page.records, Vec::new());
+                    let (records, quality_envelopes, page_indices): (Vec<Value>, Vec<Value>, Vec<usize>) =
+                        (page.records, Vec::new(), (0..page_len).collect());
 
                     // ── Contract pass (after quality, before schema drift) ───
                     // `fail` mirrors a quality `abort`: the breach error
@@ -831,7 +843,7 @@ where
                     // (unlike drift `fail`, which defers because its records
                     // are individually fine).
                     #[cfg(feature = "contract")]
-                    let (records, contract_envelopes): (Vec<Value>, Vec<Value>) =
+                    let (records, contract_envelopes, page_indices): (Vec<Value>, Vec<Value>, Vec<usize>) =
                         if let Some(c) = contract.as_ref() {
                             let labels =
                                 crate::observability::Labels::new(&*pipeline_name, &*row, &*run_id);
@@ -869,9 +881,25 @@ where
                                     )
                                 })
                                 .collect();
-                            (outcome.survivors, envelopes)
+                            // Contract's `page_index` is the position within ITS
+                            // input (the quality survivors) — aligned with the
+                            // incoming `page_indices`. Drop those positions so the
+                            // vector still maps each remaining record to its true
+                            // original page index (#321 L6).
+                            let contract_quarantined: std::collections::HashSet<usize> = outcome
+                                .quarantined
+                                .iter()
+                                .map(|vr| vr.violation.page_index)
+                                .collect();
+                            let survivor_idx: Vec<usize> = page_indices
+                                .iter()
+                                .enumerate()
+                                .filter(|(pos, _)| !contract_quarantined.contains(pos))
+                                .map(|(_, orig)| *orig)
+                                .collect();
+                            (outcome.survivors, envelopes, survivor_idx)
                         } else {
-                            (records, Vec::new())
+                            (records, Vec::new(), page_indices)
                         };
 
                     // ── Schema-drift pass (after quality, before sink) ───────
@@ -914,6 +942,7 @@ where
                                             &diff,
                                             &dest_owned,
                                             records,
+                                            &page_indices,
                                             sink,
                                             sink_name,
                                             &pipeline_name,
@@ -1628,6 +1657,7 @@ async fn apply_drift_policy<Si: Sink + ?Sized>(
     diff: &crate::drift::SchemaDiff,
     dest: &Value,
     records: Vec<Value>,
+    page_indices: &[usize],
     sink: &Si,
     sink_name: &str,
     pipeline_name: &str,
@@ -1715,7 +1745,8 @@ async fn apply_drift_policy<Si: Sink + ?Sized>(
             Ok((trimmed, None))
         }
         OnDrift::Quarantine => {
-            let (kept, env) = quarantine_drift_rows(diff, records, sink_name, pipeline_name, row);
+            let (kept, env) =
+                quarantine_drift_rows(diff, records, page_indices, sink_name, pipeline_name, row);
             drift_envelopes.extend(env);
             Ok((kept, None))
         }
@@ -1784,6 +1815,7 @@ async fn apply_drift_policy<Si: Sink + ?Sized>(
                         let (kept, env) = quarantine_drift_rows(
                             &incompat_only,
                             records,
+                            page_indices,
                             sink_name,
                             pipeline_name,
                             row,
@@ -1809,6 +1841,7 @@ async fn apply_drift_policy<Si: Sink + ?Sized>(
 fn quarantine_drift_rows(
     diff: &crate::drift::SchemaDiff,
     records: Vec<Value>,
+    page_indices: &[usize],
     sink_name: &str,
     pipeline_name: &str,
     row: &str,
@@ -1840,6 +1873,9 @@ fn quarantine_drift_rows(
                 columns: diff.changed_columns(),
                 message: "row exhibits schema drift (on_drift=quarantine)".into(),
             };
+            // Map the survivor-relative position back to the record's true page
+            // index so the envelope annotation matches quality/contract (#321 L6).
+            let page_index = page_indices.get(idx).copied().unwrap_or(idx);
             envelopes.push(build_envelope(
                 &rec,
                 &err,
@@ -1847,7 +1883,7 @@ fn quarantine_drift_rows(
                 sink_name,
                 pipeline_name,
                 row,
-                idx,
+                page_index,
             ));
         } else {
             kept.push(rec);
@@ -5335,13 +5371,22 @@ mod tests {
             json!({"id": 3, "legacy": "z"}),                // no widened col, has legacy → kept
             json!({"id": 4}),                               // missing required `legacy` → DLQ
         ];
-        let (kept, env) = quarantine_drift_rows(&diff, records, "sink", "pl", "");
+        // page_indices offset by 10 to prove the envelope carries the TRUE page
+        // index, not the survivor-relative one (#321 L6).
+        let page_indices = vec![10, 11, 12, 13];
+        let (kept, env) = quarantine_drift_rows(&diff, records, &page_indices, "sink", "pl", "");
         assert_eq!(kept, vec![json!({"id": 3, "legacy": "z"})]);
         assert_eq!(
             env.len(),
             3,
             "widening rows + the missing-required row quarantined"
         );
+        // The three quarantined rows are at page positions 10, 11, 13.
+        let indices: Vec<i64> = env
+            .iter()
+            .map(|e| e["record_index"].as_i64().unwrap())
+            .collect();
+        assert_eq!(indices, vec![10, 11, 13]);
     }
 
     #[tokio::test]

--- a/crates/core/src/quality/record.rs
+++ b/crates/core/src/quality/record.rs
@@ -38,12 +38,12 @@ pub fn evaluate_record_check(c: &CompiledRecordCheck, rec: &Value) -> Result<(),
             None => Err("field was missing".into()),
         },
         CompiledRecordKind::ValueInSet { path, values } => match path.resolve(rec).ok().flatten() {
-            Some(v) if values.contains(v) => Ok(()),
+            Some(v) if set_contains(values, v) => Ok(()),
             Some(_) => Err("value not in allowed set".into()),
             None => Err("field was missing".into()),
         },
         CompiledRecordKind::NotInSet { path, values } => match path.resolve(rec).ok().flatten() {
-            Some(v) if values.contains(v) => Err("value is in the forbidden set".into()),
+            Some(v) if set_contains(values, v) => Err("value is in the forbidden set".into()),
             // present-and-not-in-set OR missing -> pass
             _ => Ok(()),
         },
@@ -138,6 +138,14 @@ fn values_equal(a: &Value, b: &Value) -> bool {
         }
         _ => a == b,
     }
+}
+
+/// Set membership for `value_in_set` / `not_in_set` using numeric-aware
+/// equality ([`values_equal`]) rather than structural `Vec::contains`, so an
+/// int/float spelling difference (`0` vs `0.0`) does not bypass the check or
+/// cause a false quarantine (audit #321 M1).
+fn set_contains(values: &[Value], v: &Value) -> bool {
+    values.iter().any(|candidate| values_equal(candidate, v))
 }
 
 /// Evaluate a `compare` check. Ordering ops (`gt`/`gte`/`lt`/`lte`) compare
@@ -283,6 +291,26 @@ mod tests {
         assert!(evaluate_record_check(&not_in, &json!({"status": "active"})).is_ok());
         assert!(evaluate_record_check(&not_in, &json!({"status": "banned"})).is_err());
         assert!(evaluate_record_check(&not_in, &json!({})).is_ok()); // missing -> pass
+    }
+
+    #[test]
+    fn set_checks_match_numerically_not_structurally() {
+        // #321 M1: int/float spelling must not bypass the set checks.
+        let in_set = one(RecordCheck::ValueInSet {
+            field: "n".into(),
+            values: vec![json!(5)],
+            on_failure: OnFailure::Quarantine,
+        });
+        // 5.0 is in {5} numerically → must pass (was wrongly quarantined before).
+        assert!(evaluate_record_check(&in_set, &json!({"n": 5.0})).is_ok());
+
+        let not_in = one(RecordCheck::NotInSet {
+            field: "n".into(),
+            values: vec![json!(0)],
+            on_failure: OnFailure::Quarantine,
+        });
+        // 0.0 is in the forbidden set {0} numerically → must fail (was bypassed).
+        assert!(evaluate_record_check(&not_in, &json!({"n": 0.0})).is_err());
     }
 
     #[test]

--- a/crates/core/src/util.rs
+++ b/crates/core/src/util.rs
@@ -284,9 +284,12 @@ pub fn redact_uri_credentials(uri: &str) -> String {
             out.replace_range(after..after + at + 1, "");
         }
     }
-    // 2) ADO.NET-style and query-string Password=/Pwd= tokens. Splitting on both
-    //    ';' (ADO.NET) and '&'/'?' (URL query) catches a password carried as a
-    //    query parameter (`...?password=secret`) as well as keyword form.
+    // 2) ADO.NET-style and query-string secret tokens. Splitting on both
+    //    ';' (ADO.NET) and '&'/'?' (URL query) catches a secret carried as a
+    //    query parameter (`...?token=secret`) as well as keyword form. The key
+    //    denylist covers the common secret parameter names, not just
+    //    password/pwd (audit #321 M11): a leaked `?api_key=…` or SAS `?sig=…`
+    //    was previously passed through verbatim into lineage / catalog output.
     if out.contains('=') {
         out = out
             .split_inclusive([';', '&', '?'])
@@ -297,12 +300,7 @@ pub fn redact_uri_credentials(uri: &str) -> String {
                     _ => (seg, ""),
                 };
                 match body.find('=') {
-                    Some(eq)
-                        if {
-                            let k = body[..eq].trim();
-                            k.eq_ignore_ascii_case("password") || k.eq_ignore_ascii_case("pwd")
-                        } =>
-                    {
+                    Some(eq) if is_secret_kv_key(&body[..eq]) => {
                         format!("{}=***{delim}", &body[..eq])
                     }
                     _ => seg.to_string(),
@@ -311,6 +309,43 @@ pub fn redact_uri_credentials(uri: &str) -> String {
             .collect::<String>();
     }
     out
+}
+
+/// Whether a connection-string / query-string key names a credential whose
+/// value must be redacted from a lineage / catalog URI.
+///
+/// Matches a denylist case-insensitively after stripping `-`/`_`/space, so
+/// `api_key`, `api-key`, and `apikey` all match one entry. Covers the common
+/// secret parameter names beyond `password`/`pwd` (audit #321 M11).
+fn is_secret_kv_key(key: &str) -> bool {
+    let norm: String = key
+        .trim()
+        .chars()
+        .filter(|c| !matches!(c, '-' | '_' | ' '))
+        .flat_map(char::to_lowercase)
+        .collect();
+    matches!(
+        norm.as_str(),
+        "password"
+            | "pwd"
+            | "token"
+            | "apikey"
+            | "accesstoken"
+            | "refreshtoken"
+            | "sessiontoken"
+            | "clientsecret"
+            | "secret"
+            | "secretkey"
+            | "accesskey"
+            | "accesskeyid"
+            | "secretaccesskey"
+            | "sig"
+            | "sas"
+            | "accountkey"
+            | "sharedaccesskey"
+            | "authorization"
+            | "auth"
+    )
 }
 
 /// Best-effort check that a string looks like a `host[:port]` authority — used
@@ -768,6 +803,34 @@ mod tests {
         assert_eq!(
             redact_uri_credentials("snowflake://host/db?password=secret"),
             "snowflake://host/db?password=***"
+        );
+    }
+
+    #[test]
+    fn redact_strips_common_secret_query_keys() {
+        // #321 M11: secret parameter names beyond password/pwd must be redacted
+        // before a URI is emitted to lineage / the catalog.
+        assert_eq!(
+            redact_uri_credentials("https://api.example.com/v2/?api_key=SECRET"),
+            "https://api.example.com/v2/?api_key=***"
+        );
+        assert_eq!(
+            redact_uri_credentials("https://h/?token=abc&access_token=xyz&keep=1"),
+            "https://h/?token=***&access_token=***&keep=1"
+        );
+        // Azure SAS style, and separator/casing variants normalize to one key.
+        assert_eq!(
+            redact_uri_credentials("https://acct.blob.core.windows.net/c?sig=DEAD&sp=r"),
+            "https://acct.blob.core.windows.net/c?sig=***&sp=r"
+        );
+        assert_eq!(
+            redact_uri_credentials("db=x;Client-Secret=shh;Account_Key=k"),
+            "db=x;Client-Secret=***;Account_Key=***"
+        );
+        // A non-secret key is untouched.
+        assert_eq!(
+            redact_uri_credentials("https://h/?region=us-east-1"),
+            "https://h/?region=us-east-1"
         );
     }
 }

--- a/crates/source/mongodb-cdc/src/envelope.rs
+++ b/crates/source/mongodb-cdc/src/envelope.rs
@@ -123,6 +123,7 @@ mod tests {
     fn bookmark() -> Bookmark {
         Bookmark {
             resume_token: json!({ "_data": "8264AB00" }),
+            ..Default::default()
         }
     }
 

--- a/crates/source/mongodb-cdc/src/state.rs
+++ b/crates/source/mongodb-cdc/src/state.rs
@@ -32,10 +32,25 @@ pub fn state_key(scope: &Scope) -> String {
 }
 
 /// Durable bookmark wrapping a resume token.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
 pub struct Bookmark {
     /// The opaque resume token as relaxed extended JSON (e.g. `{"_data": "..."}`).
     pub resume_token: Value,
+    /// True when this token was captured from an **Invalidate** change event
+    /// (the collection was dropped/renamed, or a dropDatabase for db scope).
+    /// MongoDB forbids `resumeAfter` on an invalidate token — only `startAfter`
+    /// — so on resume the source must open the next stream with `start_after`,
+    /// or every subsequent watch open fails and the CDC pipeline wedges
+    /// permanently (audit #321 M3). Absent from older bookmarks (defaults
+    /// `false`) and omitted from the serialized state when `false`.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub invalidate: bool,
+}
+
+/// `skip_serializing_if` predicate keeping non-invalidate bookmarks byte-compatible
+/// with the pre-#321 state format.
+fn is_false(b: &bool) -> bool {
+    !*b
 }
 
 impl Bookmark {
@@ -45,6 +60,7 @@ impl Bookmark {
             .map_err(|e| FaucetError::State(format!("mongodb-cdc resume token serialize: {e}")))?;
         Ok(Self {
             resume_token: bson.into_relaxed_extjson(),
+            invalidate: false,
         })
     }
 
@@ -104,6 +120,7 @@ mod tests {
     fn bookmark_value_round_trip() {
         let b = Bookmark {
             resume_token: json!({ "_data": "8264AB" }),
+            ..Default::default()
         };
         let v = b.to_value().unwrap();
         let parsed = Bookmark::from_value(v).unwrap();
@@ -114,6 +131,7 @@ mod tests {
     fn bookmark_token_round_trip() {
         let b = Bookmark {
             resume_token: json!({ "_data": "8264AB00" }),
+            ..Default::default()
         };
         let token = b.to_token().unwrap();
         let b2 = Bookmark::from_token(&token).unwrap();
@@ -124,5 +142,26 @@ mod tests {
     fn from_value_rejects_garbage() {
         assert!(Bookmark::from_value(json!({})).is_err());
         assert!(Bookmark::from_value(json!("bare")).is_err());
+    }
+
+    #[test]
+    fn invalidate_flag_serde_is_backward_compatible() {
+        // #321 M3: a legacy bookmark without the field parses as invalidate=false
+        // and a non-invalidate bookmark omits the field entirely (compact state).
+        let legacy = Bookmark::from_value(json!({ "resume_token": { "_data": "AA" } })).unwrap();
+        assert!(!legacy.invalidate);
+        let normal = Bookmark {
+            resume_token: json!({ "_data": "AA" }),
+            invalidate: false,
+        };
+        let v = normal.to_value().unwrap();
+        assert!(v.get("invalidate").is_none(), "false flag is omitted: {v}");
+        // An invalidate bookmark serializes the flag and round-trips.
+        let inv = Bookmark {
+            resume_token: json!({ "_data": "BB" }),
+            invalidate: true,
+        };
+        let back = Bookmark::from_value(inv.to_value().unwrap()).unwrap();
+        assert!(back.invalidate);
     }
 }

--- a/crates/source/mongodb-cdc/src/stream.rs
+++ b/crates/source/mongodb-cdc/src/stream.rs
@@ -23,6 +23,9 @@ pub(crate) enum StartPosition {
     AtOperationTime(Timestamp),
     /// `resume_after(token)`.
     ResumeAfter(ResumeToken),
+    /// `start_after(token)` — required (not `resume_after`) when resuming from an
+    /// **invalidate** token, which MongoDB rejects for `resumeAfter` (#321 M3).
+    StartAfter(ResumeToken),
 }
 
 /// Resolve the effective start position from config + any persisted bookmark.
@@ -37,6 +40,7 @@ pub(crate) fn resolve_start(
         StartFrom::ResumeToken { token } => {
             let b = Bookmark {
                 resume_token: token.clone(),
+                ..Default::default()
             };
             Ok(StartPosition::ResumeAfter(b.to_token()?))
         }
@@ -46,7 +50,14 @@ pub(crate) fn resolve_start(
         })),
         StartFrom::Now | StartFrom::Earliest => {
             if let Some(b) = pending {
-                Ok(StartPosition::ResumeAfter(b.to_token()?))
+                // A bookmark captured from an invalidate event must resume with
+                // `start_after` — `resume_after` on an invalidate token is
+                // rejected by MongoDB and would wedge the pipeline (#321 M3).
+                if b.invalidate {
+                    Ok(StartPosition::StartAfter(b.to_token()?))
+                } else {
+                    Ok(StartPosition::ResumeAfter(b.to_token()?))
+                }
             } else if matches!(start_from, StartFrom::Earliest) {
                 // Earliest retained oplog entry (errors at open if rolled).
                 Ok(StartPosition::AtOperationTime(Timestamp {
@@ -359,6 +370,7 @@ impl MongoCdcSource {
                         StartPosition::Now => w,
                         StartPosition::AtOperationTime(ts) => w.start_at_operation_time(*ts),
                         StartPosition::ResumeAfter(tok) => w.resume_after(tok.clone()),
+                        StartPosition::StartAfter(tok) => w.start_after(tok.clone()),
                     };
                     w.await
                         .map_err(|e| FaucetError::Source(format!("mongodb-cdc watch failed: {e}")))?
@@ -381,6 +393,7 @@ impl MongoCdcSource {
                         StartPosition::Now => w,
                         StartPosition::AtOperationTime(ts) => w.start_at_operation_time(*ts),
                         StartPosition::ResumeAfter(tok) => w.resume_after(tok.clone()),
+                        StartPosition::StartAfter(tok) => w.start_after(tok.clone()),
                     };
                     w.await
                         .map_err(|e| FaucetError::Source(format!("mongodb-cdc watch failed: {e}")))?
@@ -402,6 +415,7 @@ impl MongoCdcSource {
                         StartPosition::Now => w,
                         StartPosition::AtOperationTime(ts) => w.start_at_operation_time(*ts),
                         StartPosition::ResumeAfter(tok) => w.resume_after(tok.clone()),
+                        StartPosition::StartAfter(tok) => w.start_after(tok.clone()),
                     };
                     w.await
                         .map_err(|e| FaucetError::Source(format!("mongodb-cdc watch failed: {e}")))?
@@ -437,7 +451,15 @@ impl MongoCdcSource {
                         // past the cap rather than risk an OOM-kill.
                         check_staging_cap(buffer.len(), max_staged)?;
                         buffer.push(to_envelope(&event, &bookmark)?);
-                        last_bookmark = Some(bookmark.to_value()?);
+                        // The persisted bookmark records whether it is an
+                        // invalidate token, so resume uses `start_after` not
+                        // `resume_after` (#321 M3). The envelope above keeps the
+                        // plain token — only the durable state carries the flag.
+                        let persisted = Bookmark {
+                            invalidate: is_invalidate,
+                            ..bookmark
+                        };
+                        last_bookmark = Some(persisted.to_value()?);
 
                         // An invalidate closes the stream server-side: flush the
                         // page (including the invalidate event) and end.
@@ -547,6 +569,7 @@ mod tests {
     fn explicit_timestamp_overrides_bookmark() {
         let pending = Bookmark {
             resume_token: json!({ "_data": "AA" }),
+            ..Default::default()
         };
         let pos = resolve_start(
             &StartFrom::Timestamp {
@@ -570,6 +593,7 @@ mod tests {
         // bookmark and resolve to ResumeAfter(token).
         let pending = Bookmark {
             resume_token: json!({ "_data": "PENDING" }),
+            ..Default::default()
         };
         let pos = resolve_start(
             &StartFrom::ResumeToken {
@@ -593,9 +617,34 @@ mod tests {
     fn now_yields_to_bookmark() {
         let pending = Bookmark {
             resume_token: json!({ "_data": "8264AB00" }),
+            ..Default::default()
         };
         let pos = resolve_start(&StartFrom::Now, Some(&pending)).unwrap();
         assert!(matches!(pos, StartPosition::ResumeAfter(_)));
+    }
+
+    #[test]
+    fn invalidate_bookmark_resumes_with_start_after() {
+        // #321 M3: a bookmark captured from an invalidate event must resolve to
+        // StartAfter (MongoDB rejects resumeAfter on an invalidate token).
+        let pending = Bookmark {
+            resume_token: json!({ "_data": "8264AB00" }),
+            invalidate: true,
+        };
+        let pos = resolve_start(&StartFrom::Now, Some(&pending)).unwrap();
+        assert!(
+            matches!(pos, StartPosition::StartAfter(_)),
+            "invalidate bookmark must use start_after, got {pos:?}"
+        );
+        // A non-invalidate bookmark still uses resume_after.
+        let normal = Bookmark {
+            resume_token: json!({ "_data": "8264AB00" }),
+            invalidate: false,
+        };
+        assert!(matches!(
+            resolve_start(&StartFrom::Earliest, Some(&normal)).unwrap(),
+            StartPosition::ResumeAfter(_)
+        ));
     }
 
     #[test]

--- a/crates/source/postgres-cdc/src/replication.rs
+++ b/crates/source/postgres-cdc/src/replication.rs
@@ -181,12 +181,14 @@ pub async fn ensure_slot(
     slot_name: &str,
     create_if_missing: bool,
     slot_type: crate::config::SlotType,
+    tls: &crate::config::CdcTls,
 ) -> Result<(), FaucetError> {
     use crate::config::SlotType;
     // Use sqlx for the control-plane query (not a replication connection).
     let opts: PgConnectOptions = connection_url
         .parse()
         .map_err(|e| FaucetError::Config(format!("postgres-cdc: invalid connection URL: {e}")))?;
+    let opts = apply_cdc_tls(opts, tls);
 
     use sqlx::ConnectOptions as _;
     let mut conn: PgConnection = opts
@@ -247,10 +249,15 @@ pub async fn ensure_slot(
 /// Drop a logical replication slot via a control-plane SQL call
 /// (`pg_drop_replication_slot`). A missing slot is treated as success (no-op);
 /// an active slot (currently in use by another connection) surfaces an error.
-pub async fn drop_slot(connection_url: &str, slot_name: &str) -> Result<(), FaucetError> {
+pub async fn drop_slot(
+    connection_url: &str,
+    slot_name: &str,
+    tls: &crate::config::CdcTls,
+) -> Result<(), FaucetError> {
     let opts: PgConnectOptions = connection_url
         .parse()
         .map_err(|e| FaucetError::Config(format!("postgres-cdc: invalid connection URL: {e}")))?;
+    let opts = apply_cdc_tls(opts, tls);
     use sqlx::ConnectOptions as _;
     let mut conn: PgConnection = opts
         .connect()
@@ -275,6 +282,37 @@ pub async fn drop_slot(connection_url: &str, slot_name: &str) -> Result<(), Fauc
         .map_err(|e| FaucetError::Source(format!("postgres-cdc drop slot: {e}")))?;
     debug!("postgres-cdc: dropped replication slot '{slot_name}'");
     Ok(())
+}
+
+/// Apply the CDC [`CdcTls`](crate::config::CdcTls) policy onto the sqlx
+/// `PgConnectOptions` used for the **control-plane** connections (slot
+/// create/drop/advance, LSN capture). Without this these privileged
+/// connections would use sqlx's default `Prefer` SSL mode — opportunistic and
+/// unverified — so `tls: verify_full` would silently fail to protect them, a
+/// TLS-downgrade / MITM window on the same credentials the replication stream
+/// guards (audit #321 M5). The explicit policy overrides any `sslmode=` in the
+/// URL (the config is authoritative).
+fn apply_cdc_tls(opts: PgConnectOptions, tls: &crate::config::CdcTls) -> PgConnectOptions {
+    use crate::config::CdcTls;
+    use sqlx::postgres::PgSslMode;
+    match tls {
+        CdcTls::Disable => opts.ssl_mode(PgSslMode::Disable),
+        CdcTls::Require => opts.ssl_mode(PgSslMode::Require),
+        CdcTls::VerifyCa { ca_path } => {
+            let o = opts.ssl_mode(PgSslMode::VerifyCa);
+            match ca_path {
+                Some(p) => o.ssl_root_cert(p),
+                None => o,
+            }
+        }
+        CdcTls::VerifyFull { ca_path } => {
+            let o = opts.ssl_mode(PgSslMode::VerifyFull);
+            match ca_path {
+                Some(p) => o.ssl_root_cert(p),
+                None => o,
+            }
+        }
+    }
 }
 
 /// Map the user-facing [`CdcTls`](crate::config::CdcTls) config onto
@@ -311,6 +349,7 @@ pub async fn advance_slot(
     connection_url: &str,
     slot_name: &str,
     lsn: u64,
+    tls: &crate::config::CdcTls,
 ) -> Result<(), FaucetError> {
     if lsn == 0 {
         return Ok(());
@@ -318,6 +357,7 @@ pub async fn advance_slot(
     let opts: PgConnectOptions = connection_url
         .parse()
         .map_err(|e| FaucetError::Config(format!("postgres-cdc: invalid connection URL: {e}")))?;
+    let opts = apply_cdc_tls(opts, tls);
 
     use sqlx::ConnectOptions as _;
     let mut conn: PgConnection = opts
@@ -360,6 +400,7 @@ pub async fn ensure_slot_and_current_lsn(
     slot_name: &str,
     create_if_missing: bool,
     slot_type: crate::config::SlotType,
+    tls: &crate::config::CdcTls,
 ) -> Result<u64, FaucetError> {
     // `ensure_slot`'s `_client` arg is unused; `Client` is constructible here
     // (same module). This reuses the existing slot existence/create logic.
@@ -370,12 +411,14 @@ pub async fn ensure_slot_and_current_lsn(
         slot_name,
         create_if_missing,
         slot_type,
+        tls,
     )
     .await?;
 
     let opts: PgConnectOptions = connection_url
         .parse()
         .map_err(|e| FaucetError::Config(format!("postgres-cdc: invalid connection URL: {e}")))?;
+    let opts = apply_cdc_tls(opts, tls);
     use sqlx::ConnectOptions as _;
     let mut conn: PgConnection = opts
         .connect()
@@ -629,6 +672,27 @@ mod tests {
     use crate::config::CdcTls;
     use chrono::{TimeZone, Utc};
     use pgwire_replication::SslMode;
+
+    #[test]
+    fn apply_cdc_tls_sets_ssl_mode_on_control_plane_options() {
+        // #321 M5: the control-plane PgConnectOptions must carry the configured
+        // SSL mode, not sqlx's default `Prefer`. Assert via the Debug view.
+        let base: PgConnectOptions = "postgres://u:p@h:5432/db".parse().unwrap();
+        let dbg = |tls: &CdcTls| format!("{:?}", apply_cdc_tls(base.clone(), tls));
+        assert!(
+            dbg(&CdcTls::Disable).contains("Disable"),
+            "{}",
+            dbg(&CdcTls::Disable)
+        );
+        assert!(dbg(&CdcTls::Require).contains("Require"));
+        assert!(dbg(&CdcTls::VerifyCa { ca_path: None }).contains("VerifyCa"));
+        assert!(
+            dbg(&CdcTls::VerifyFull {
+                ca_path: Some("/ca.pem".into())
+            })
+            .contains("VerifyFull")
+        );
+    }
 
     #[test]
     fn tls_config_maps_each_mode() {

--- a/crates/source/postgres-cdc/src/stream.rs
+++ b/crates/source/postgres-cdc/src/stream.rs
@@ -59,7 +59,12 @@ impl PostgresCdcSource {
     /// active (in use by a live replication connection). Call this when
     /// decommissioning a `permanent` slot so it doesn't leak WAL (#78/#12).
     pub async fn drop_slot(&self) -> Result<(), FaucetError> {
-        replication::drop_slot(&self.config.connection_url, &self.config.slot_name).await
+        replication::drop_slot(
+            &self.config.connection_url,
+            &self.config.slot_name,
+            &self.config.tls,
+        )
+        .await
     }
 }
 
@@ -166,6 +171,7 @@ impl Source for PostgresCdcSource {
             &self.config.slot_name,
             self.config.create_slot_if_missing,
             self.config.slot_type,
+            &self.config.tls,
         )
         .await?;
         Ok(Some(crate::state::Bookmark::from_u64(lsn).to_value()?))
@@ -337,6 +343,7 @@ impl PostgresCdcSource {
                 &self.config.slot_name,
                 self.config.create_slot_if_missing,
                 self.config.slot_type,
+                &self.config.tls,
             )
             .await?;
 
@@ -360,6 +367,7 @@ impl PostgresCdcSource {
                         &self.config.connection_url,
                         &self.config.slot_name,
                         lsn,
+                        &self.config.tls,
                     )
                 })
                 .await?;

--- a/crates/source/rest/src/pagination/mod.rs
+++ b/crates/source/rest/src/pagination/mod.rs
@@ -61,6 +61,13 @@ pub struct PaginationState {
     /// re-return it (non-empty) would otherwise loop until `max_pages`.
     #[doc(hidden)]
     pub previous_page_fingerprint: Option<u64>,
+    /// Set by [`PaginationStyle::advance`] when the body-fingerprint stagnation
+    /// guard fires: the page just handed to `advance` is a duplicate of the
+    /// previous one and the caller must **drop** it rather than emit it a second
+    /// time (audit #321 L1). Only the content-stagnation guards set it; a normal
+    /// last-page stop leaves it `false` so the final page is still emitted.
+    #[doc(hidden)]
+    pub current_page_is_duplicate: bool,
 }
 
 /// Cheap, stable fingerprint of a response body for content-stagnation
@@ -184,6 +191,9 @@ impl PaginationStyle {
                     tracing::warn!(
                         "pagination loop detected: PageNumber returned an identical page — stopping"
                     );
+                    // The current page IS the duplicate — signal the caller to
+                    // drop it rather than emit it a second time (#321 L1).
+                    state.current_page_is_duplicate = true;
                     return Ok(false);
                 }
                 state.previous_page_fingerprint = Some(fp);
@@ -221,6 +231,8 @@ impl PaginationStyle {
                             "pagination loop detected: Offset returned an identical page \
                              (server likely ignoring the offset parameter) — stopping"
                         );
+                        // Drop this duplicate page rather than emit it (#321 L1).
+                        state.current_page_is_duplicate = true;
                         return Ok(false);
                     }
                     state.previous_page_fingerprint = Some(fp);

--- a/crates/source/rest/src/stream.rs
+++ b/crates/source/rest/src/stream.rs
@@ -428,6 +428,12 @@ impl RestStream {
                     // Intermediate page — yield without bookmark so the
                     // pipeline does not persist a partial checkpoint.
                     yield faucet_core::StreamPage { records, bookmark: None };
+                } else if state.current_page_is_duplicate {
+                    // The content-stagnation guard flagged this page as a
+                    // duplicate of the previous one — DROP it (do not emit the
+                    // repeated records to the sink) and stop. The trailing
+                    // bookmark checkpoint below still fires (#321 L1).
+                    break;
                 } else {
                     // Final page — attach the consolidated bookmark.
                     bookmark_emitted = running_max.is_some();
@@ -742,7 +748,12 @@ impl RestStream {
         // returning the error. This gives callers (and logs) the server's
         // error message rather than just a status code.
         if !status.is_success() {
-            let resp_url = resp.url().to_string();
+            // Redact any auth secret carried in the query string before it lands
+            // in the error (which renders the URL in `Display` → logs). The
+            // `api_key_query` value is user-configured, so it is not marked
+            // sensitive like a Bearer/Basic header and would otherwise leak on
+            // any 4xx/5xx (audit #321 L2).
+            let resp_url = redact_error_url(resp.url(), &self.config.auth);
             let body_text = resp.text().await.unwrap_or_default();
             // Truncate very long error bodies to avoid bloating logs/errors.
             let truncated = if body_text.len() > 1024 {
@@ -776,6 +787,35 @@ impl RestStream {
         let body: Value = serde_json::from_slice(&bytes)?;
         Ok((body, resp_headers))
     }
+}
+
+/// Render a response URL for an error message with any auth secret in the query
+/// string redacted (audit #321 L2). Redacts the user-configured
+/// `api_key_query` parameter by name (which `redact_uri_credentials` cannot
+/// know), then applies the shared credential/query-secret redaction for the
+/// common key names and any URL userinfo.
+fn redact_error_url(url: &reqwest::Url, auth: &AuthSpec<Auth>) -> String {
+    let mut redacted = url.clone();
+    if let AuthSpec::Inline(Auth::ApiKeyQuery { param, .. }) = auth {
+        let pairs: Vec<(String, String)> = url
+            .query_pairs()
+            .map(|(k, v)| {
+                if k == param.as_str() {
+                    (k.into_owned(), "***".to_string())
+                } else {
+                    (k.into_owned(), v.into_owned())
+                }
+            })
+            .collect();
+        redacted.set_query(None);
+        if !pairs.is_empty() {
+            let mut qp = redacted.query_pairs_mut();
+            for (k, v) in &pairs {
+                qp.append_pair(k, v);
+            }
+        }
+    }
+    faucet_core::redact_uri_credentials(redacted.as_str())
 }
 
 /// Parse the `Retry-After` header. RFC 7231 permits **either** delta-seconds
@@ -917,6 +957,42 @@ mod tests {
         // Unchanged: the legacy max_retries(7) still wins.
         assert_eq!(stream.retry_policy.max_attempts, 8);
         assert_eq!(stream.retry_policy.base, DEFAULT_RETRY_BACKOFF);
+    }
+
+    #[test]
+    fn redact_error_url_hides_api_key_query_param() {
+        // #321 L2: a custom `api_key_query` param name is redacted by name.
+        let auth = AuthSpec::Inline(Auth::ApiKeyQuery {
+            param: "api_token".into(),
+            value: "SUPERSECRET".into(),
+        });
+        let url =
+            reqwest::Url::parse("https://api.example.com/v1/items?page=2&api_token=SUPERSECRET")
+                .unwrap();
+        let redacted = redact_error_url(&url, &auth);
+        assert!(
+            !redacted.contains("SUPERSECRET"),
+            "secret must be gone: {redacted}"
+        );
+        assert!(redacted.contains("api_token=%2A%2A%2A") || redacted.contains("api_token=***"));
+        assert!(
+            redacted.contains("page=2"),
+            "non-secret param kept: {redacted}"
+        );
+    }
+
+    #[test]
+    fn redact_error_url_without_api_key_query_still_scrubs_common_keys() {
+        // Non-ApiKeyQuery auth: the shared redaction still strips common secret
+        // query keys and userinfo.
+        let auth: AuthSpec<Auth> = AuthSpec::Inline(Auth::None);
+        let url = reqwest::Url::parse("https://u:pw@api.example.com/v1/items?token=abc").unwrap();
+        let redacted = redact_error_url(&url, &auth);
+        assert!(
+            !redacted.contains("abc"),
+            "common secret key redacted: {redacted}"
+        );
+        assert!(!redacted.contains("pw@"), "userinfo redacted: {redacted}");
     }
 
     #[test]

--- a/crates/source/rest/tests/stream_test.rs
+++ b/crates/source/rest/tests/stream_test.rs
@@ -188,13 +188,13 @@ async fn test_offset_pagination_terminates_when_server_ignores_offset() {
         .expect("offset pagination must terminate, not loop forever")
         .unwrap();
 
-    // The repeated page is emitted twice: once as the legitimate first page,
-    // then once more before the guard detects the identical body and stops.
-    // Critically it is bounded — NOT 1000 * 2 records.
+    // #321 L1: only the legitimate first page is emitted. The second, identical
+    // page is detected by the content-stagnation guard and DROPPED rather than
+    // emitted a second time (previously it leaked 4 records = 2 duplicate pages).
     assert_eq!(
         records.len(),
-        4,
-        "stagnation guard must bound emission to the first two identical pages"
+        2,
+        "the duplicate page must be dropped, not emitted again"
     );
 }
 

--- a/crates/source/xml/src/stream.rs
+++ b/crates/source/xml/src/stream.rs
@@ -146,12 +146,13 @@ impl XmlStream {
 
             let record_count = records.len();
             let fingerprint = page_fingerprint(&records);
-            all_records.extend(records);
             pages_fetched += 1;
 
             // Loop guard: a server that ignores the page/offset parameter (or
             // clamps to the last page) returns the same non-empty page forever.
-            // Stop when two consecutive pages are identical (audit #146 H4/H5).
+            // Stop when two consecutive pages are identical (audit #146 H4/H5) —
+            // and do it BEFORE appending, so the duplicate page's records are
+            // never emitted to the sink a second time (audit #321 M4).
             if record_count > 0 && prev_fingerprint == Some(fingerprint) {
                 tracing::warn!(
                     "XML pagination returned an identical page; stopping to avoid an infinite loop"
@@ -159,6 +160,7 @@ impl XmlStream {
                 break;
             }
             prev_fingerprint = Some(fingerprint);
+            all_records.extend(records);
 
             // Advance pagination or stop.
             match &self.config.pagination {
@@ -409,6 +411,20 @@ impl faucet_core::Source for XmlStream {
 
                 let record_count = page_records.len();
                 let fingerprint = page_fingerprint(&page_records);
+                pages_fetched += 1;
+
+                // Loop guard: stop when two consecutive pages are identical — a
+                // server ignoring the page/offset parameter (or clamping to the
+                // last page) returns the same non-empty page forever (#146 H4/H5).
+                // Check BEFORE buffering/yielding so the duplicate page's records
+                // are not emitted to the sink a second time (audit #321 M4).
+                if record_count > 0 && prev_fingerprint == Some(fingerprint) {
+                    tracing::warn!(
+                        "XML pagination returned an identical page; stopping to avoid an infinite loop"
+                    );
+                    break;
+                }
+                prev_fingerprint = Some(fingerprint);
 
                 for rec in page_records.drain(..) {
                     buffer.push(rec);
@@ -418,18 +434,6 @@ impl faucet_core::Source for XmlStream {
                         yield StreamPage { records: flush, bookmark: None };
                     }
                 }
-                pages_fetched += 1;
-
-                // Loop guard: stop when two consecutive pages are identical — a
-                // server ignoring the page/offset parameter (or clamping to the
-                // last page) returns the same non-empty page forever (#146 H4/H5).
-                if record_count > 0 && prev_fingerprint == Some(fingerprint) {
-                    tracing::warn!(
-                        "XML pagination returned an identical page; stopping to avoid an infinite loop"
-                    );
-                    break;
-                }
-                prev_fingerprint = Some(fingerprint);
 
                 // Advance pagination using the same rules as
                 // `fetch_all_with_context`.

--- a/crates/source/xml/tests/fetch_http.rs
+++ b/crates/source/xml/tests/fetch_http.rs
@@ -347,8 +347,10 @@ async fn identical_page_loop_guard_stops_fetch() {
             page_size_param: None,
         });
     let records = XmlStream::new(config).fetch_all().await.unwrap();
-    // Page 1 + identical page 2 (which trips the guard) = 4 records, no loop.
-    assert_eq!(records.len(), 4);
+    // #321 M4: only page 1 is emitted (2 records). The identical page 2 trips
+    // the stagnation guard and is DROPPED rather than emitted a second time
+    // (previously it leaked 4 records = the duplicate page appended).
+    assert_eq!(records.len(), 2);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Fixes the **11 medium** and **8 low** findings from the third pre-1.0 hardening audit (#321). Companion to #322 (the 4 critical + 8 high, already merged).

## Medium
- **M1** quality — `value_in_set`/`not_in_set` use numeric-aware equality (`0` vs `0.0` no longer bypasses / false-quarantines).
- **M2** contract — `enum` compares numbers by value, so an integer-spelled enum accepts a conforming float.
- **M3** mongodb-cdc — an invalidate token is persisted with a flag and resumed via `start_after` (MongoDB rejects `resumeAfter` on it), fixing a permanent CDC wedge.
- **M4** xml — the stagnation guard checks the fingerprint before appending, so a duplicate page isn't emitted twice.
- **M5** postgres-cdc — the `tls:` policy is applied to the control-plane connections (slot create/drop/advance, LSN capture).
- **M6** serve — `POST /v1/reload` writes a `config.reload` audit record on every outcome.
- **M7** serve — `reclaim_requeue` preserves `cancel_requested`, so a cross-instance cancel survives a lease-lapse requeue.
- **M8** serve — the post-cancel shutdown drain waits `RUN_FLUSH_GRACE` (30s), not a hardcoded 5s.
- **M9** serve — the drain + cooperative cancel run inside the graceful-shutdown handler, so an open `/logs` SSE stream can't deadlock shutdown.
- **M10** observability — `faucet_source_page_duration_seconds` records before the generator `yield`, excluding downstream sink latency.
- **M11** core — `redact_uri_credentials` redacts the common secret query keys (token, api_key, access_token, client_secret, sig, sas, accountkey, …), not just password/pwd.

## Low
- **L1** rest — the stagnation guard flags the duplicate page so the caller drops it.
- **L2** rest — the `api_key_query` secret is redacted from the URL captured in an `HttpStatus` error.
- **L3** dlq — `faucet dlq discard` rewrites files atomically (temp + rename).
- **L4** notify — a coalesce timestamp is rolled back when the leading-edge delivery fails.
- **L5** serve — `finalize_owned` is status-fenced, so a zombie owner can't overwrite a live re-run's terminal record.
- **L6** core — schema-drift quarantine envelopes carry the true page `record_index` (threaded through quality/contract).
- **L7** observability — the OTLP export-error counter layer installs whenever any otel signal is exported.
- **L8** catalog — `canonicalize_uri` folds `${now.*}` tokens anchored to their template neighbor chars, avoiding coincidental over-folding.

## Testing
New/updated unit + integration tests for every finding (numeric equality, invalidate resume, pagination drop-duplicate, control-plane TLS mode, reload audit, cancel-preserving requeue, atomic discard, coalesce rollback, status-fenced finalize, true drift index, otel-metrics-only counter, anchored URI fold). `cargo fmt` + `cargo clippy --all-targets --all-features` clean on every touched crate; targeted suites pass.

## Scope
Addresses #321 — **medium + low**. With #322 (critical + high) merged, this completes every finding in the audit, so the tracking issue can be closed once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
