### PR TITLE
docs: engineering architecture, ADRs, RFCs, standards & contributor guides

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,133 @@
+# Releasing faucet-stream
+
+*The release process for maintainers — the automated default, the manual fallback, and the gotchas that have bitten real releases.*
+
+faucet-stream is a Cargo workspace of independently-versioned crates published to
+[crates.io](https://crates.io), plus the `faucet` CLI binary distributed as
+prebuilt archives. This document is the public release runbook. It is
+intentionally maintainer-facing; contributors do not need it to open a PR.
+
+> **Versioning rule:** every crate we deploy is versioned **`1.0.0` or higher —
+> never `0.x`**. A *new* crate is created at `1.0.0`. Existing crates keep their
+> independent published versions. Semver is enforced by the `cargo-semver-checks`
+> CI gate on the public API.
+
+## The default path — release-plz
+
+Day-to-day releases go through [release-plz](https://release-plz.dev/)
+(`release-plz.toml` + `.github/workflows/release-plz.yml`):
+
+```mermaid
+flowchart LR
+    A[push to main] --> B["release-plz scans commits<br/>since each crate's last tag"]
+    B --> C["opens/updates a<br/>'chore: release' PR<br/>(version bumps + per-crate CHANGELOG)"]
+    C --> D[maintainer merges the release PR]
+    D --> E["publish to crates.io<br/>in dependency order"]
+    E --> F["push per-crate tags<br/>&lt;crate&gt;-v&lt;X.Y.Z&gt;"]
+    F --> G["faucet-cli-v* tag triggers<br/>prebuilt-binary build"]
+```
+
+1. On every push to `main`, release-plz scans for `feat` / `fix` / `perf`
+   commits since each crate's last `<crate>-v<X.Y.Z>` tag.
+2. It opens (or updates) a **`chore: release` PR** that bumps only the affected
+   crates and prepends a section to each bumped crate's **per-package
+   `CHANGELOG.md`**.
+3. Merging that PR publishes to crates.io **in dependency order** (release-plz
+   waits for sparse-index propagation between dependents) and pushes the tags.
+
+Only `feat` / `fix` / `perf` commits trigger a version bump
+(`release_commits = "^(feat|fix|perf)"`), so `docs` / `chore` / `refactor` /
+`test` / `ci` / `build` commits never cause a publish. **Write
+[Conventional Commit](https://www.conventionalcommits.org/) subjects** so this
+classification and the changelog grouping work.
+
+### Required secrets
+
+- **`CARGO_REGISTRY_TOKEN`** — required, for publishing to crates.io.
+- **`RELEASE_PLZ_TOKEN`** (PAT or GitHub App) — recommended, so the release PR
+  and its tags trigger downstream CI/builds. GitHub forbids the default
+  `GITHUB_TOKEN` from triggering downstream workflows.
+- **`HOMEBREW_TAP_TOKEN`** — PAT with repo scope on the tap repo, for the
+  Homebrew publish step (see below). Without it, archives/installer still
+  publish; only the tap push fails.
+
+## Prebuilt binaries — cargo-dist
+
+When release-plz pushes a `faucet-cli-v*` tag, `dist-workspace.toml` +
+`.github/workflows/release-binaries.yml` build prebuilt `faucet` binaries:
+GitHub Release archives for four targets (macOS arm64/x86_64, Linux
+x86_64/aarch64 — all on native runners), a `curl | sh` installer, SHA256
+checksums, and a Homebrew formula pushed to the `homebrew-faucet-stream` tap.
+
+- release-plz owns the GitHub Release (`create-release = false`); dist only
+  uploads artifacts to it.
+- Shipped feature set: CLI `default` + `serve`, `serve-ui`, `schedule`,
+  `lineage`. Excluded: `transform-sql`, `otel`, `triggers*`, `catalog`,
+  `serve-history-*` (documented in the installation guide).
+- **Tag-trigger gotcha:** tags pushed with the default `GITHUB_TOKEN` do **not**
+  trigger workflows. If `RELEASE_PLZ_TOKEN` is not configured, the binary build
+  will not fire automatically after a release — dispatch it manually with
+  `gh workflow run release-binaries.yml --ref faucet-cli-vX.Y.Z`.
+
+## The manual fallback
+
+`.github/workflows/release.yml` ("Release (manual fallback)") is a
+`workflow_dispatch` workflow for ad-hoc or bulk re-publishes (a registry
+incident, re-publishing every crate from a known-good revision). It bumps with
+`cargo-release` and publishes in **waves of 5 with a 15-minute wait between
+waves**. Use it only as a fallback; day-to-day releases go through release-plz.
+Both paths share the `<crate>-v<X.Y.Z>` tag format so they do not fight.
+
+## Gotchas learned the hard way
+
+These bit during real releases; re-read before any bulk or local publish:
+
+1. **The `no-commit-to-branch` pre-commit hook blocks commits to `main`.** Use
+   `git commit --no-verify` for release commits — this is the intended escape;
+   CI's release-plz does not run pre-commit.
+2. **crates.io new-crate rate limit is a burst of 5, then 1 per 10 minutes.**
+   Publishing many *new* crate names drips slowly. `cargo release --execute`
+   **aborts** when publishing >30 new crates — do not use it for a large bulk
+   publish. Instead drive a **resumable, 429-aware per-crate `cargo publish`
+   loop** in dependency order that skips already-published crates (via the
+   sparse index), sleeps ~10.5 min on `429`, and aborts on any genuine error.
+   New *versions* of existing crates use a separate, generous bucket — fast.
+3. **`cargo-release` bumps `Cargo.toml` only — not version strings in
+   README/docs.** `faucet-* = "X.Y"` install examples baked into a published
+   crate cannot be edited after publish. **Bump README/docs install examples
+   before publishing.**
+4. **The per-crate publish order must include dev-dependency edges** — a
+   versioned dev-dep blocks `cargo publish` until its dep is on crates.io.
+   Compute the order over *all* dependency kinds; confirm there is no dev-dep
+   cycle.
+5. **Keep `Cargo.lock` in sync** — after a bump, run `cargo update --workspace`
+   for the bumped members.
+
+## docs.rs
+
+Every publishable crate must render its full API (including feature-gated code)
+on docs.rs. This requires two pieces on **every** crate:
+
+- a `[package.metadata.docs.rs]` block with `all-features = true` and
+  `rustdoc-args = ["--cfg", "docsrs"]`;
+- `#![cfg_attr(docsrs, feature(doc_cfg))]` as the first line of `lib.rs`.
+
+Verify locally:
+`RUSTDOCFLAGS="--cfg docsrs" rustup run nightly cargo doc --workspace --all-features --no-deps`
+(must be clean). A new crate missing either piece is documented incompletely.
+
+## Pre-release checklist
+
+- [ ] CI is green on `main` (all required checks).
+- [ ] README/docs install examples reflect the new version.
+- [ ] The docs.rs dry-run above is clean.
+- [ ] `cargo publish --dry-run` passes for changed crates.
+- [ ] For a new crate: version is `1.0.0`, keywords/categories set, docs.rs
+  block + `doc_cfg` present, added to the umbrella + CLI features, the CI
+  `feature-check` matrix, and (if a connector) `connectors/registry.json`.
+
+## Related
+
+- [Contributing](./CONTRIBUTING.md) · [Stability policy](./docs/stability.md)
+- [Architecture: extensibility](./docs/architecture/extensibility.md)
+- [Documentation home](./docs/README.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -83,10 +83,13 @@ Forward-looking design proposals for cross-cutting or breaking changes.
 
 ### Cross-cutting documents
 
+- [Glossary](./glossary.md) — the canonical vocabulary (bookmark, page, watermark, effectively-once, …).
+- [Security model](./architecture/security.md) — how faucet handles credentials and data; the redaction boundary and hardening checklist.
 - [Engineering principles](./engineering-principles.md) — the values the code embodies.
-- [Architecture review](./architecture-review.md) — an objective critique of the current state.
+- [Architecture review](./architecture-review.md) — a dated, objective critique of the current state.
 - [Stability policy](./stability.md) — what's Stable / Experimental / Internal.
 - [Roadmap](./roadmap.md) — architectural direction.
+- [Releasing](../RELEASING.md) — the maintainer release runbook.
 
 ## Relationship to the always-on maintainer rules
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,96 @@
+# faucet-stream documentation
+
+*The documentation home — how the project's docs are organized and where to start.*
+
+faucet-stream keeps two complementary bodies of documentation, aimed at two
+different readers:
+
+| Body | Audience | Location |
+|------|----------|----------|
+| **User guide (mdBook)** | *Users* running pipelines — installation, tutorials, cookbook, connector catalog, CLI/config reference. | [`book/`](./book/) → published at <https://pawansikawat.github.io/faucet-stream/> |
+| **Engineering documentation** | *Maintainers and contributors* — why the system is built the way it is. | this tree (`architecture/`, `adr/`, `contributing/`, `standards/`, `../rfcs/`) |
+
+If you want to *use* faucet-stream, start with the [book](./book/src/introduction.md).
+If you want to *change* or *extend* it, start here.
+
+## Engineering documentation map
+
+```mermaid
+flowchart TD
+    Hub["docs/README.md<br/>(this file)"]
+    Hub --> Arch["architecture/<br/>how & why each subsystem works"]
+    Hub --> ADR["adr/<br/>the decisions, with rationale"]
+    Hub --> Contrib["contributing/<br/>how to work in the code"]
+    Hub --> Std["standards/<br/>repo-wide conventions"]
+    Hub --> RFC["../rfcs/<br/>forward-looking proposals"]
+    Hub --> Principles["engineering-principles.md"]
+    Hub --> Review["architecture-review.md"]
+    Hub --> Stability["stability.md"]
+    Hub --> Roadmap["roadmap.md"]
+
+    Arch -. grounds .-> ADR
+    ADR -. evolves into .-> RFC
+    Contrib -. enforces .-> Std
+```
+
+### [Architecture](./architecture/README.md)
+
+How each subsystem works and the trade-offs behind it. Start with the
+[overview](./architecture/overview.md), then the execution spine:
+[execution](./architecture/execution.md) →
+[pipeline](./architecture/pipeline.md) →
+[stream-pages](./architecture/stream-pages.md) →
+[state](./architecture/state-management.md) →
+[recovery](./architecture/recovery.md) →
+[retries](./architecture/retries.md) →
+[observability](./architecture/observability.md).
+The [design invariants](./architecture/invariants.md) are the load-bearing
+rules the whole system depends on.
+
+### [Architecture Decision Records](./adr/)
+
+One record per major decision — Context, Problem, Decision, Alternatives,
+Trade-offs, Consequences, Future work. These explain *why* the architecture is
+what it is. See especially
+[ADR 0002 — checkpoint ordering](./adr/0002-checkpoint-ordering.md), the
+data-integrity keystone.
+
+### [Contributing](./contributing/architecture.md)
+
+Practical, code-level guidance:
+[a map of the codebase](./contributing/architecture.md),
+[authoring a connector](./contributing/connector-authoring.md),
+[testing](./contributing/testing.md),
+[performance](./contributing/performance.md),
+[debugging](./contributing/debugging.md), and a
+[common-mistakes catalogue](./contributing/common-mistakes.md). The
+build/test/PR mechanics live in the top-level
+[`CONTRIBUTING.md`](../CONTRIBUTING.md).
+
+### [Standards](./standards/api-design.md)
+
+Enforceable repo-wide conventions a reviewer can point at:
+[API design](./standards/api-design.md),
+[error handling](./standards/error-handling.md),
+[logging & metrics](./standards/logging.md),
+[testing](./standards/testing.md),
+[performance](./standards/performance.md),
+[state & durability](./standards/state.md).
+
+### [RFCs](../rfcs/README.md)
+
+Forward-looking design proposals for cross-cutting or breaking changes.
+
+### Cross-cutting documents
+
+- [Engineering principles](./engineering-principles.md) — the values the code embodies.
+- [Architecture review](./architecture-review.md) — an objective critique of the current state.
+- [Stability policy](./stability.md) — what's Stable / Experimental / Internal.
+- [Roadmap](./roadmap.md) — architectural direction.
+
+## Relationship to the always-on maintainer rules
+
+The operational rules a maintainer must follow (release flow, coverage gate,
+branch protection, docs-sync triggers) live in `CLAUDE.md` and
+`.claude/rules/*.md` at the repo root. This tree explains the *architecture*
+those rules protect; the two are complementary and should stay consistent.

--- a/docs/adr/0001-stream-pages.md
+++ b/docs/adr/0001-stream-pages.md
@@ -1,0 +1,77 @@
+# ADR 0001 — Page-based streaming (`StreamPage`)
+
+*Move data one bounded page at a time instead of materialising whole datasets.*
+
+- **Status:** Accepted (implemented) — the core streaming model since the earliest pipeline design; `crates/core/src/pipeline.rs`, `traits.rs`.
+
+## Context
+
+faucet-stream must move datasets of unbounded size between arbitrary sources and
+sinks, and its Primary Goal is that every connector be as fast,
+efficient, and reliable as possible. Memory footprint and time-to-first-write are
+both first-order concerns.
+
+## Problem
+
+A "fetch everything, then write everything" model buffers the entire dataset in
+memory and delays the first sink write until the last source record arrives. For a
+multi-gigabyte table or an unbounded CDC stream this is either impossible or
+ruinously slow, and it makes incremental checkpointing impossible (there is nothing
+to checkpoint until the end).
+
+## Decision
+
+The unit of work is a **`StreamPage { records: Vec<Value>, bookmark: Option<Value> }`**.
+`Source::stream_pages(ctx, batch_size)` returns a `Stream` of pages; the pipeline
+writes each page to the sink as it arrives and checkpoints whenever a page carries a
+bookmark. Memory is bounded at `O(batch_size)` on both sides regardless of total
+volume.
+
+`stream_pages` has a **default implementation** that calls `fetch_all` and chunks
+the result — so a connector author can implement only `fetch_with_context` and still
+work (buffered but correct). Connectors that can stream natively (`rest`, the CDC
+sources, `postgres`, `parquet`, `kafka`, `elasticsearch` scroll, …) **override**
+`stream_pages` to be truly incremental.
+
+```mermaid
+flowchart LR
+    SRC[(source primitive)] --> P1[page] --> P2[page] --> P3[page + bookmark]
+    P1 --> W1[write] --> F1[flush]
+    P3 --> CK[checkpoint]
+```
+
+## Alternatives considered
+
+- **Full materialisation (`fetch_all` only).** Simplest trait, but unbounded memory
+  and no incremental checkpointing. Rejected as the *primary* model; kept as the
+  *default* impl for author convenience.
+- **An external queue/broker between source and sink.** Adds an operational
+  dependency and a second durability domain to reason about; overkill for a library
+  whose value is being embeddable and dependency-light.
+- **Row-at-a-time streaming.** Maximal memory frugality but pathological
+  per-record overhead against batch/bulk sink APIs (multi-row INSERT, `_bulk`,
+  `insertAll`). Pages let sinks amortise round-trips.
+
+## Trade-offs
+
+- Page size is a throughput/latency/durability knob (see [batching](../architecture/batching.md)).
+- The default impl buffers — correct but not memory-bounded, a smell for large
+  sources.
+
+## Consequences
+
+- **Positive:** bounded memory, immediate first write, per-page (and per-CDC-txn)
+  checkpointing for free, sink bulk-API friendliness.
+- **Negative:** connectors that want the memory bound must implement `stream_pages`,
+  not just `fetch_all`; throughput is coupled to page size and sink latency.
+
+## Future work
+
+- Backpressure and multi-page pipelining, and a columnar page variant — see
+  [RFC 0004](../../rfcs/0004-streaming-improvements.md) and
+  [RFC 0002](../../rfcs/0002-arrow-support.md).
+
+## Related
+
+- [Architecture: stream pages](../architecture/stream-pages.md) · [batching](../architecture/batching.md) · [pipeline](../architecture/pipeline.md)
+- [ADR 0002 — Checkpoint ordering](./0002-checkpoint-ordering.md)

--- a/docs/adr/0002-checkpoint-ordering.md
+++ b/docs/adr/0002-checkpoint-ordering.md
@@ -1,0 +1,96 @@
+# ADR 0002 — Checkpoint ordering (write → flush → persist)
+
+*Persist a page's bookmark only after the sink has durably written and flushed it. The data-integrity keystone.*
+
+- **Status:** Accepted (implemented) — enforced in all three write paths of `run_stream`, `crates/core/src/pipeline.rs`.
+
+## Context
+
+Incremental replication and crash recovery both hinge on a durable record of
+progress (a **bookmark**). The order in which the sink write and the bookmark
+persist happen — relative to each other and to a possible crash — decides whether a
+failure causes data loss, duplication, or neither.
+
+## Problem
+
+There are two possible orderings:
+
+1. **persist-then-write** — checkpoint first, then write. A crash in between skips
+   the page's records *forever*: silent data loss.
+2. **write-then-persist** — write and flush first, then checkpoint. A crash in
+   between replays the page: at worst a bounded duplicate, never loss.
+
+Silent data loss and silent downstream corruption are the worst bug classes this
+project can ship. The ordering is therefore not a performance choice — it is a
+correctness invariant.
+
+## Decision
+
+**Always write, then flush, then persist the bookmark.** In every one of
+`run_stream`'s three write paths the sequence ends:
+
+```
+… write_batch* (records) …
+… flush() …
+… StateStore::put(key, bookmark) …
+```
+
+The consequence is that the state store is always **equal to or behind** the sink,
+never ahead. Recovery can therefore only ever replay already-attempted work; it can
+never skip data the sink did not receive.
+
+```mermaid
+sequenceDiagram
+    participant Snk as Sink
+    participant SS as StateStore
+    Note over Snk,SS: page N
+    Snk->>Snk: write_batch(records)
+    Snk->>Snk: flush()
+    Note over Snk,SS: ← crash here replays page N (no loss)
+    SS->>SS: put(bookmark N)
+    Note over Snk,SS: page N+1 …
+```
+
+The three paths:
+
+- **Default (at-least-once):** `write_batch` → `flush` → `put`. A window-B crash
+  duplicates the page on resume.
+- **Exactly-once (atomic watermark):** `write_batch_idempotent(scope, token)` →
+  `flush` → `put(wrap_state(bookmark, seq))`. A replayed token-stamped write is a
+  no-op, so the duplicate is neutralised. On resume the sink watermark is authoritative.
+- **DLQ:** `write_batch_partial` (survivors + routed failures) → `flush` (main and
+  DLQ sink) → `put`. Deferred aborts fire only after the page is durable.
+
+## Alternatives considered
+
+- **persist-then-write** — rejected: silent data loss on the crash window.
+- **Two-phase commit across source and sink** — rejected: not all sinks or sources
+  support it; it would exclude most connectors and add large complexity for a
+  guarantee (no duplicates) that the exactly-once mechanism already provides where
+  the sink can support it.
+- **Best-effort "checkpoint every N seconds" independent of writes** — rejected:
+  decouples the checkpoint from durability, reintroducing the loss window.
+
+## Trade-offs
+
+- At-least-once accepts bounded duplicates (one page) as the price of working with
+  any source/sink and needing no watermark table.
+- Flushing per bookmark-carrying page costs a round-trip; sources that bookmark
+  every page (CDC) pay it per transaction — the price of per-transaction durability.
+
+## Consequences
+
+- **Positive:** no ordering-induced data loss, ever; recovery is always "replay from
+  a safe position"; exactly-once and DLQ inherit the same guarantee.
+- **Negative:** at-least-once callers must tolerate duplicates; per-page flush has a
+  latency cost that page sizing must balance.
+
+## Future work
+
+- Fault-injection tests at each crash window as a first-class CI job — see
+  [recovery](../architecture/recovery.md).
+
+## Related
+
+- [Design invariants (I1–I3)](../architecture/invariants.md) · [state management](../architecture/state-management.md) · [recovery](../architecture/recovery.md)
+- [ADR 0005 — Runtime recovery](./0005-runtime-recovery.md) · [ADR 0007 — Retries](./0007-retries.md)

--- a/docs/adr/0003-builder-pattern.md
+++ b/docs/adr/0003-builder-pattern.md
@@ -1,0 +1,81 @@
+# ADR 0003 — Progressive builder + object-safe traits
+
+*Configure the pipeline with `with_*` builder methods and keep connector traits object-safe with defaulted methods.*
+
+- **Status:** Accepted (implemented) — `Pipeline` / `RunStreamOptions` in `crates/core/src/pipeline.rs`; `Source`/`Sink` in `traits.rs`.
+
+## Context
+
+The pipeline has grown many optional cross-cutting concerns — state, DLQ, quality,
+contract, masking, drift, resilience, delivery mode, cancellation, adaptive batching.
+Connectors, meanwhile, must remain trivially implementable by third parties and
+usable as trait objects (`Box<dyn Source>`), because the CLI registry stores
+heterogeneous connectors behind one type.
+
+## Problem
+
+Two related API-shape questions:
+
+1. How does a caller configure a pipeline with a growing set of optional features
+   without a combinatorial explosion of constructors or a breaking change every
+   time a feature is added?
+2. How do the connector traits gain new capabilities (exactly-once, sharding,
+   discovery, schema evolution) over time without breaking existing connectors or
+   losing object-safety?
+
+## Decision
+
+- **Progressive builder for the pipeline.** `Pipeline::new(&source, &sink)` returns a
+  value configured by chained `with_state_store`, `with_dlq`, `with_quality`,
+  `with_delivery`, `with_cancel`, … Each returns `Self`; unspecified features default
+  to off. `run_stream` takes the same shape as `RunStreamOptions` for direct callers.
+- **Object-safe traits with defaulted methods.** `Source` / `Sink` have exactly one
+  required method each (`fetch_with_context` / `write_batch`); every other method
+  (streaming, resumability, exactly-once, sharding, discovery, evolution, probes) has
+  a default. No associated types, no generic methods — so `Box<dyn Source>` works and
+  adding a method is always backward-compatible.
+
+```rust
+let result = Pipeline::new(&source, &sink)
+    .with_state_store(store)
+    .with_delivery(DeliveryMode::ExactlyOnce)
+    .with_dlq(dlq)          // opt in only what you need
+    .run().await?;
+```
+
+## Alternatives considered
+
+- **One giant config struct** passed to a single `run(config)`. Rejected: every new
+  field is a struct change; optional-vs-required is unclear; poor discoverability
+  compared to `.with_*()` autocomplete.
+- **Generics / associated types on the traits** (e.g. `type Bookmark`). More precise,
+  but breaks object-safety — the CLI could not store `Box<dyn Source>` — and forces
+  monomorphisation across dozens of connectors. Rejected.
+- **A separate trait per capability** (`Source: Resumable + Shardable + …`).
+  Object-safety and dyn-upcasting friction make this awkward today; the defaulted-
+  method pattern achieves the same evolvability more simply. Revisited in
+  [RFC 0001](../../rfcs/0001-capability-traits.md).
+
+## Trade-offs
+
+- Defaulted booleans (`supports_idempotent_writes`) are stringly-checked at the CLI
+  gate (allowlists in `registry.rs`) rather than statically — a typed capability
+  model would remove the allowlists at the cost of trait complexity.
+- The builder allows nonsensical combinations to be *expressed*; they are rejected at
+  `run`/`expand` time rather than at compile time.
+
+## Consequences
+
+- **Positive:** connectors implement almost nothing; core adds capabilities without
+  breaking anyone; callers opt into exactly what they need; the API is discoverable.
+- **Negative:** capability checks are runtime, not compile-time; the builder's
+  optional surface must be validated (gates in `expand`/`run_stream`).
+
+## Future work
+
+- Typed capability traits ([RFC 0001](../../rfcs/0001-capability-traits.md)).
+
+## Related
+
+- [Connector SDK](../architecture/connector-sdk.md) · [pipeline](../architecture/pipeline.md)
+- [Standards: API design](../standards/api-design.md) · [API stability](../stability.md)

--- a/docs/adr/0004-json-record-model.md
+++ b/docs/adr/0004-json-record-model.md
@@ -1,0 +1,68 @@
+# ADR 0004 — `serde_json::Value` as the universal record model
+
+*Every record is a `serde_json::Value` end to end — chosen for connector-author ergonomics, at a known allocation cost.*
+
+- **Status:** Accepted (implemented) — the record type throughout `faucet-core` and every connector.
+
+## Context
+
+faucet-stream connects heterogeneous systems whose payloads have no common schema:
+JSON APIs, SQL rows, protobuf messages, CSV lines, Avro, object-store blobs. The
+core must carry records between any source and any sink, apply transforms, and let
+third parties write connectors with minimal friction.
+
+## Problem
+
+The record type is the single most pervasive type in the codebase — it appears in
+every trait method, every transform, every pass. It must be (a) universal enough to
+represent any source's output, (b) trivial for a connector author to produce and
+consume, and (c) compatible with `schemars`-based config introspection and the JSON
+transform/quality/contract layers.
+
+## Decision
+
+Use **`serde_json::Value`** as the universal record. `faucet-core` re-exports
+`serde_json` (and `Value`, `json!`) so a connector author's only dependency is
+`faucet-core`. Every source yields `Vec<Value>`; every sink consumes `&[Value]`;
+transforms, quality checks, contracts, masking, and drift all operate on `Value`.
+
+## Alternatives considered
+
+- **Apache Arrow `RecordBatch`.** Columnar, zero-copy, vectorised — ideal for
+  throughput. But it forces a schema up front (many sources are schemaless or
+  schema-late), complicates row-oriented transforms and CDC envelopes, and would
+  make connector authoring far heavier. Rejected *for now*; the migration path is
+  [RFC 0002](../../rfcs/0002-arrow-support.md).
+- **A bespoke `enum Record` type.** Would let us optimise representation, but
+  reinvents `serde_json::Value`, loses the vast `serde`/`schemars` ecosystem, and
+  raises the connector-authoring bar. Rejected.
+- **Raw bytes + per-connector codecs.** Maximal flexibility, but pushes
+  parse/serialize into every transform and pass and defeats the JSON-native
+  quality/contract/masking layers. Rejected.
+
+## Trade-offs
+
+- **Allocation cost.** `Value` allocates per field (heap `String` keys, boxed
+  arrays/maps). For very high-throughput numeric workloads this is the dominant cost
+  — see [performance](../architecture/performance.md).
+- **No columnar batching.** Sinks that would prefer Arrow (Parquet, BigQuery) shovel
+  JSON↔Arrow internally (e.g. the SQL transform, the Parquet sink) rather than the
+  pipeline carrying columns.
+
+## Consequences
+
+- **Positive:** any payload flows without a declared schema; connector authoring is
+  as simple as producing JSON; the transform/quality/contract/masking layers are
+  uniform and JSON-native; config introspection via `schemars` is free.
+- **Negative:** per-record allocation overhead; a JSON↔columnar boundary inside
+  columnar sinks; no free vectorisation.
+
+## Future work
+
+- An Arrow-backed fast path behind the same `StreamPage` loop, opt-in for
+  columnar-friendly source→sink pairs — [RFC 0002](../../rfcs/0002-arrow-support.md).
+
+## Related
+
+- [Overview](../architecture/overview.md) · [performance](../architecture/performance.md) · [connector SDK](../architecture/connector-sdk.md)
+- [RFC 0002 — Arrow support](../../rfcs/0002-arrow-support.md)

--- a/docs/adr/0005-runtime-recovery.md
+++ b/docs/adr/0005-runtime-recovery.md
@@ -1,0 +1,89 @@
+# ADR 0005 — Sink-anchored resume for exactly-once recovery
+
+*Embed the resume bookmark in the commit token so recovery re-anchors from the sink's watermark, not from replayed page boundaries.*
+
+- **Status:** Accepted (implemented) — issue #291; `crates/core/src/idempotency.rs`, `pipeline.rs`. Orphan recovery: issue #146 H7, `cli/src/serve/history/`.
+
+## Context
+
+Exactly-once delivery needs a way, on resume, to know which pages the sink already
+committed so it can skip re-writing them. The [checkpoint-ordering invariant](./0002-checkpoint-ordering.md)
+leaves a window (sink durable, state store one page behind) that recovery must
+resolve without re-delivering data.
+
+## Problem
+
+The naïve exactly-once resume compares a per-page sequence counter: skip any page
+whose seq ≤ the sink's committed seq. This silently assumes the source **replays
+identical page boundaries** on resume. Log-positional sources like Kafka cannot
+promise that — the same offset range may partition into pages differently — so the
+count-based skip is unsafe for them, which excluded Kafka from exactly-once.
+
+## Decision
+
+Make the **sink's committed watermark the authoritative record of stream position**.
+Each exactly-once commit token embeds the page's resume bookmark
+(`format_token_with_bookmark(seq, bookmark)`). On resume, `Pipeline::run`:
+
+1. reads the sink's `last_committed_token(scope)`;
+2. if the sink's seq is ahead of the state store, decodes the **embedded bookmark**;
+3. calls `apply_start_bookmark` to re-anchor the source to that exact position and
+   fast-forwards the sequence.
+
+Nothing is re-written, and nothing depends on reproducing page boundaries. This is
+what qualifies the Kafka source for exactly-once. Legacy bare tokens (no embedded
+bookmark) fall back to the count-based skip path.
+
+```mermaid
+sequenceDiagram
+    participant SS as StateStore
+    participant Snk as Sink watermark
+    participant P as Pipeline
+    participant Src as Source
+    P->>SS: get → (bookmark, seq=N)
+    P->>Snk: last_committed_token(scope)
+    Snk-->>P: token(seq=N+1, bookmark=B')
+    Note over P,Src: sink ahead of state store → re-anchor
+    P->>Src: apply_start_bookmark(B')
+```
+
+**Orphan recovery (serve).** A separate recovery concern in a clustered/persistent
+`serve` deployment: a run owned by a dead process. Each serve process has a UUID
+`instance_id`; runs carry `owner` + `lease_expires_at`; a lease loop heartbeats an
+instance's own runs, and a run is failed **only** when its owner's lease has expired
+— so a live peer's in-flight runs are never failed on a shared database.
+
+## Alternatives considered
+
+- **Count-based skip only.** Simple, but unsafe for non-deterministic-replay
+  sources; would keep Kafka out of exactly-once. Retained only as the legacy
+  fallback for tokens without an embedded bookmark.
+- **A separate position table** distinct from the commit token. More moving parts
+  and a second write to keep atomic with the data; embedding in the existing token
+  keeps position and durability in one atomic commit.
+- **Requiring deterministic page boundaries from all sources.** Would exclude
+  log-positional sources entirely. Rejected.
+
+## Trade-offs
+
+- The commit token grows to carry a JSON bookmark suffix; sinks store it opaquely
+  (they must never parse it — see [invariant I10](../architecture/invariants.md)).
+- Recovery reads from the sink (`last_committed_token`), adding a resume-time
+  round-trip — negligible next to the safety it buys.
+
+## Consequences
+
+- **Positive:** exactly-once works for log-positional sources; recovery is a no-op
+  re-anchor with zero re-delivery; the sink watermark is a single source of truth.
+- **Negative:** larger tokens; sinks must implement `last_committed_token` to
+  participate; a subtle contract (opaque token, embedded bookmark) that reviewers
+  must respect.
+
+## Future work
+
+- Extending sink-anchored resume to more sinks as their watermark storage matures.
+
+## Related
+
+- [Recovery](../architecture/recovery.md) · [retries](../architecture/retries.md) · [state management](../architecture/state-management.md)
+- [ADR 0002 — Checkpoint ordering](./0002-checkpoint-ordering.md) · [Design invariants (I3)](../architecture/invariants.md)

--- a/docs/adr/0006-state-management.md
+++ b/docs/adr/0006-state-management.md
@@ -1,0 +1,80 @@
+# ADR 0006 — `StateStore` abstraction with pluggable backends
+
+*A three-method async trait over `Value`; light backends in core, heavy ones in their own crates.*
+
+- **Status:** Accepted (implemented) — `crates/core/src/state.rs`; `faucet-state-redis`, `faucet-state-postgres`.
+
+## Context
+
+Bookmarks must be persisted durably for incremental replication and recovery. Where
+and how they are stored varies by deployment: a local file for a single-node run, a
+shared database for a cluster, an in-memory map for tests. The core must not care
+which.
+
+## Problem
+
+Two competing pressures: (1) the pipeline needs *a* durable store to uphold the
+[checkpoint-ordering invariant](./0002-checkpoint-ordering.md); (2) `faucet-core` is
+the crate every connector depends on and must stay dependency-light — it cannot pull
+a Redis or Postgres driver.
+
+## Decision
+
+Define a minimal async trait and split backends by weight:
+
+```rust
+trait StateStore: Send + Sync {
+    async fn get(&self, key: &str) -> Result<Option<Value>, FaucetError>;
+    async fn put(&self, key: &str, value: &Value) -> Result<(), FaucetError>;
+    async fn delete(&self, key: &str) -> Result<(), FaucetError>;
+}
+```
+
+- **In `faucet-core`:** `MemoryStateStore` and `FileStateStore` (one JSON file per
+  key, atomic rename) — zero extra dependencies.
+- **In their own crates:** `faucet-state-redis`, `faucet-state-postgres` — so their
+  drivers never burden a connector author.
+- **Key hygiene:** `validate_state_key` rejects empty/hidden/traversal-unsafe keys
+  so a key is safe as a filename component.
+- **Key scheme:** `{name}::{row_id}` (root), `{name}::{row_id}::{parent_key}`
+  (child), plus subsystem-scoped keys (replication marker, backfill unit). See
+  [state management](../architecture/state-management.md).
+- **Exactly-once envelope:** the stored value is `wrap_state(bookmark, seq)` under
+  exactly-once, still a plain `Value` from the store's perspective.
+
+## Alternatives considered
+
+- **A DB baked into core.** Rejected: forces a driver dependency on every connector
+  and a deployment choice on every user.
+- **A pure key→string KV interface** (no `Value`). Rejected: bookmarks are
+  structured; JSON round-tripping keeps sources free to evolve their bookmark shape
+  (invariant I8).
+- **A richer trait** (range scans, TTLs, CAS). Rejected as premature: bookmarks are
+  tiny and low-frequency; the three-method surface maximises backend portability.
+  CAS is noted as future work.
+
+## Trade-offs
+
+- The `Value`-typed, three-method interface forgoes any backend-specific
+  optimisation, but bookmark traffic is small and infrequent, so this is the right
+  trade.
+- `FileStateStore`'s one-file-per-key is simple and atomic but not ideal for
+  thousands of matrix children — hence the Redis/Postgres backends.
+
+## Consequences
+
+- **Positive:** core stays dependency-light; deployments choose a backend without
+  touching connectors; the store is fully generic over bookmark shape.
+- **Negative:** no compare-and-swap fencing yet (concurrent writers to one key are
+  the deployer's responsibility); heavier backends are separate crates to enable.
+
+## Future work
+
+- Optional CAS semantics for stores that support it, to fence concurrent writers.
+- A typed bookmark trait exposing comparability for lag/SLA math.
+
+## Related
+
+- [State management](../architecture/state-management.md) · [recovery](../architecture/recovery.md)
+- [Standards: state & durability](../standards/state.md)
+- [ADR 0002 — Checkpoint ordering](./0002-checkpoint-ordering.md) · [ADR 0010 — Pipeline runtime](./0010-pipeline-runtime.md)

--- a/docs/adr/0007-retries.md
+++ b/docs/adr/0007-retries.md
@@ -1,0 +1,77 @@
+# ADR 0007 — Two-layer retries with a duplication-safety rule
+
+*Retry transient failures on both the source and sink side — but never retry a non-idempotent write.*
+
+- **Status:** Accepted (implemented) — `crates/core/src/retry.rs`, `resilience/`; `with_retry!` / `with_retry_write!` in `pipeline.rs`; `Source::with_retry_policy`.
+
+## Context
+
+Networked data movement fails transiently all the time — 5xx, rate limits, dropped
+connections, timeouts. Retrying turns a flaky dependency into a reliable pipeline.
+But retrying carelessly is dangerous: a write that committed server-side but lost
+its response, retried, duplicates data — the project's stated worst bug class.
+
+## Problem
+
+Design a retry mechanism that (a) recovers from transient failures on both the
+request (source) and write (sink) side, (b) never introduces duplicates, and (c) is
+inert by default so the simplest pipelines are unchanged.
+
+## Decision
+
+**Two layers, one hard safety rule.**
+
+- **Source side:** HTTP sources retry their own requests. `rest` keeps its bespoke
+  `max_retries` / `retry_backoff` + `429`/`Retry-After` handling; `xml`/`graphql` use
+  the shared `execute_with_retry`. A policy is injected via
+  `Source::with_retry_policy`.
+- **Sink side:** `run_stream` wraps `write_batch*`, `flush`, and `state_put` in
+  `with_retry!`, gated on an attached `ResiliencePolicy`. With no policy the macro is
+  a bare `.await` — the write path is byte-for-byte identical to un-retried code.
+
+**The duplication-safety rule** (`with_retry_write!`): a non-idempotent
+`write_batch` is retried **only** when `sink.supports_idempotent_writes()`.
+Otherwise it falls through to a bare `.await` with no retry. `write_batch_idempotent`
+is always safe to retry (a token-stamped replay is a no-op).
+
+Backoff is `base * 2^attempt` capped at `MAX_BACKOFF`, with decorrelated `[0.5,1.5)`
+jitter seeded per call so concurrent retries don't realign. Only transient
+`RetryClass` errors (`Http5xx`, `RateLimited`, `Connection`, `Timeout`) are retried;
+`Config`/`Auth`/`Json` fail fast.
+
+## Alternatives considered
+
+- **Retry every write unconditionally.** Simplest, but duplicates data on a lost
+  response to a non-idempotent sink. Rejected outright — it is the exact bug the
+  project most wants to avoid.
+- **Retry nothing in the core; leave it to connectors.** Rejected: every connector
+  would reinvent backoff/jitter inconsistently, and sink writes (the risky part)
+  would go unprotected.
+- **Fixed backoff, no jitter.** Rejected: synchronises concurrent retries into a
+  thundering herd.
+
+## Trade-offs
+
+- Declining to retry non-idempotent writes means a transient sink blip aborts the run
+  (to be replayed from the last bookmark) rather than silently retrying — a restart
+  cost paid for correctness.
+- REST keeps its own runner for back-compat, so only `max_attempts` + `base` of the
+  injected policy apply to REST (`retry_on`/`jitter` inert there). An asymmetry.
+
+## Consequences
+
+- **Positive:** transient failures self-heal on both sides; duplicates are never
+  introduced by a retry; the no-policy path is unchanged.
+- **Negative:** a non-idempotent sink under transient failure restarts rather than
+  retries; REST's field precedence is a documented wart.
+
+## Future work
+
+- Fold the bespoke REST runner into the unified policy.
+- Richer per-sink idempotency hints to safely retry more write shapes
+  ([RFC 0001](../../rfcs/0001-capability-traits.md)).
+
+## Related
+
+- [Retries](../architecture/retries.md) · [resilience](../architecture/resilience.md) · [recovery](../architecture/recovery.md)
+- [Design invariants (I2)](../architecture/invariants.md) · [ADR 0002 — Checkpoint ordering](./0002-checkpoint-ordering.md)

--- a/docs/adr/0008-observability.md
+++ b/docs/adr/0008-observability.md
@@ -1,0 +1,72 @@
+# ADR 0008 — Automatic, decorator-based observability
+
+*Instrument sources, sinks, transforms, and state stores from inside the pipeline so connectors write zero metrics code.*
+
+- **Status:** Accepted (implemented) — `crates/core/src/observability/`; `otel` feature for OTLP.
+
+## Context
+
+An operator needs uniform, complete visibility into every pipeline — record counts,
+error rates, latencies, in-flight gauges, bookmark lag — regardless of which
+connector is running. Connectors are written by many hands, including third parties.
+
+## Problem
+
+If each connector emitted its own metrics, coverage would be inconsistent (some
+connectors instrumented, some not), label conventions would drift, and the metric
+surface could explode with high-cardinality labels. But requiring every connector
+author to learn and correctly apply a metrics API is friction that violates the
+[extensibility goal](../architecture/extensibility.md).
+
+## Decision
+
+Instrument **automatically from inside the pipeline** using decorator wrappers:
+`InstrumentedSource`, `InstrumentedSink`, `InstrumentedStateStore`, plus
+transform/pipeline/resilience decorators (`crates/core/src/observability/`).
+`Pipeline::run` wraps the source, sink, and store in these before driving the loop,
+so **every** connector is fully instrumented with **zero** per-connector code. A
+connector's only obligation is to return a non-empty `connector_name()` for the
+label.
+
+Metrics use the `metrics` facade (fanning out to Prometheus and, under the `otel`
+feature, OTLP); traces use `tracing` spans. Common labels are `{pipeline, row,
+connector}`. High-cardinality values (`run_id`, `parent_record_key`, URLs, query
+strings) are **span attributes only, never metric labels**.
+
+## Alternatives considered
+
+- **Per-connector manual instrumentation.** Rejected: inconsistent coverage, drifting
+  labels, author friction, and a real risk of high-cardinality label mistakes in
+  third-party code.
+- **No built-in observability; leave it to the embedding application.** Rejected: the
+  CLI is the primary consumer and needs uniform metrics out of the box; operators
+  should not have to instrument the tool themselves.
+- **A pull-based introspection API instead of push metrics.** Rejected: does not fit
+  Prometheus/OTLP ecosystems operators already run.
+
+## Trade-offs
+
+- Decorators add a thin per-call wrapper (drop-guard timers, counters) — negligible
+  next to network I/O, and the decorators use RAII guards so gauges stay correct even
+  on cancellation.
+- The label set is fixed by the core, so a connector cannot add a bespoke dimension
+  without a core change — intentional, to protect cardinality.
+
+## Consequences
+
+- **Positive:** complete, uniform coverage for every connector including third-party
+  ones; disciplined cardinality; one place to evolve the metric surface; free OTLP.
+- **Negative:** connectors cannot easily add custom metrics; observability is coupled
+  to the pipeline driving the connector (a connector used outside `Pipeline` is
+  uninstrumented).
+
+## Future work
+
+- A sanctioned, cardinality-safe hook for connector-specific metrics if a real need
+  arises.
+
+## Related
+
+- [Observability](../architecture/observability.md) · [resilience](../architecture/resilience.md)
+- [Standards: logging & metrics](../standards/logging.md) · [Design invariants (I11)](../architecture/invariants.md)
+- User guide: [Observability](../book/src/operations/observability.md)

--- a/docs/adr/0009-schema-validation.md
+++ b/docs/adr/0009-schema-validation.md
@@ -1,0 +1,76 @@
+# ADR 0009 — Layered, fixed-order per-page validation passes
+
+*Mask → quality → contract → drift, per page, in a fixed order — because ordering here is a correctness property.*
+
+- **Status:** Accepted (implemented) — the per-page pass sequence in `run_stream`, `crates/core/src/pipeline.rs`; passes in `masking/`, `quality/`, `contract/`, `drift.rs`.
+
+## Context
+
+Records must be protected and validated between source and sink: PII masked,
+bad rows caught, an output contract enforced, and destination schema drift handled.
+These are four distinct concerns, each with its own config surface, and each is
+optional.
+
+## Problem
+
+Two questions: (1) should these be one monolithic validator or separate passes? and
+(2) in what order do they run — and is the order the user's choice or the system's?
+The order is not cosmetic: mask-after-write leaks PII; validate-before-mask lets a
+check read raw PII; commit-before-contract-check writes breaching data.
+
+## Decision
+
+**Four separate passes, run per page, in a fixed, non-configurable order:**
+
+```
+mask → quality → contract → drift → write
+```
+
+- **Masking first, unconditionally** — so PII never reaches a sink, the DLQ, or a
+  lineage sample. (Invariant I5.)
+- **Quality** removes/aborts bad records so later passes see clean data.
+- **Contract** enforces the versioned output promise; `on_breach: fail` aborts the
+  page and **writes nothing** — breaching data must never be committed.
+- **Drift** runs last, on exactly the records about to be written; `on_drift: fail`
+  **defers** its abort until the page's individually-valid survivors are durable
+  (mirroring the DLQ-budget/circuit-breaker deferral).
+
+The passes are separate modules with independent config blocks, compiled fail-fast
+at load time; the *order* is owned by the system, not exposed as a knob.
+
+## Alternatives considered
+
+- **One monolithic validator.** Rejected: couples four independent concerns, makes
+  each harder to test and evolve, and buries the ordering guarantee.
+- **User-configurable pass order.** Rejected: a footgun — an operator could reorder
+  into a PII leak or a bad-row-written bug. The safe order is fixed.
+- **Whole-dataset (not per-page) validation.** Rejected: would require buffering the
+  whole dataset (defeating [streaming](./0001-stream-pages.md)); per-page keeps
+  memory bounded. The known cost is that a cross-page aggregate check only sees one
+  page at a time — documented, and handled by the SQL transform's `batch_size: 0`.
+
+## Trade-offs
+
+- **Per-page semantics** mean a schema/aggregate is only as complete as the page's
+  sample; a column absent from every record on a page is invisible until it appears.
+- **Contract-`fail` aborts vs drift-`fail` defers** is a deliberate asymmetry: a
+  contract breach is about the *data's* validity (never commit it); drift is about
+  *shape* mismatch on otherwise-valid rows (commit them, then stop).
+- **Drift on top-level columns only** trades nested precision for a pure, total diff.
+
+## Consequences
+
+- **Positive:** each pass is independently testable and evolvable; the ordering
+  guarantee is explicit and unbreakable by config; memory stays bounded.
+- **Negative:** no cross-page validation without opting into a buffering transform;
+  the contract/drift abort asymmetry is a subtlety reviewers must know.
+
+## Future work
+
+- Nested-column drift (needs a nested-aware `diff_schema`).
+- Sharing one inferred schema between drift and the lineage facet.
+
+## Related
+
+- [Schema](../architecture/schema.md) · [quality](../architecture/quality.md) · [contracts](../architecture/contracts.md) · [masking](../architecture/masking.md)
+- [Design invariants (I5, I6)](../architecture/invariants.md) · [ADR 0001 — Stream pages](./0001-stream-pages.md)

--- a/docs/adr/0010-pipeline-runtime.md
+++ b/docs/adr/0010-pipeline-runtime.md
@@ -1,0 +1,74 @@
+# ADR 0010 — A lean core library with orchestration in the CLI layer
+
+*`faucet-core` stays a small, embeddable library; all scheduling, HTTP, DAG, and cluster logic lives above it in the CLI.*
+
+- **Status:** Accepted (implemented) — `faucet-core` (library) vs `faucet-cli` (`expand`, `executor`, `serve/`, `schedule/`, `replication/`, `backfill/`).
+
+## Context
+
+faucet-stream ships both a reusable Rust library (`faucet-core`, depended on by 60+
+connectors and by third parties) and a rich runtime (`faucet` CLI) with cron
+scheduling, an HTTP control plane, a matrix DAG executor, snapshot→CDC replication,
+backfill, and clustering. These two roles have very different change rates and
+audiences.
+
+## Problem
+
+Where does orchestration live? If scheduling, `serve`, clustering, and DAG expansion
+go into `faucet-core`, then every connector crate and every third-party embedder
+inherits axum, croner, cluster state machines, and their churn — and the crate that
+must stay stable becomes the crate that changes most.
+
+## Decision
+
+**Keep `faucet-core` a library that knows how to move one source to one sink and
+checkpoint safely — and nothing else.** All orchestration is CLI-layer code built on
+`expand` (config → `Vec<ExpandedNode>`) + `executor::run_expanded`, which drive
+`Pipeline`:
+
+| Concern | Lives in |
+|---|---|
+| move + checkpoint + passes + delivery | `faucet-core` (`Pipeline`, `run_stream`) |
+| matrix DAG, gates, fan-out, cancellation | `cli/src/{expand,executor}.rs` |
+| cron scheduling | `cli/src/schedule/` |
+| HTTP control plane, RBAC, history, cluster | `cli/src/serve/` |
+| snapshot→CDC handoff | `cli/src/replication/` |
+| windowed historical replay | `cli/src/backfill/` |
+
+Every long-running mode is the same `expand` + `run_expanded` wrapped in a driver
+(see [execution](../architecture/execution.md)). The only `faucet-core` changes these
+runtimes needed were tiny, defaulted trait methods (e.g. `capture_resume_position`
+for replication) — never orchestration logic.
+
+## Alternatives considered
+
+- **A monolithic runtime in `faucet-core`.** Rejected: forces heavy dependencies and
+  constant churn onto every connector and embedder; couples the stable contract to
+  the fast-moving runtime.
+- **A separate `faucet-runtime` crate between core and CLI.** Plausible, and may
+  happen if a second front-end (beyond the CLI) ever needs the orchestration. Not
+  done yet because the CLI is the only consumer; premature extraction would add a
+  crate boundary with no second client.
+
+## Trade-offs
+
+- A third-party embedding `faucet-core` gets the safe move/checkpoint engine but must
+  build its own orchestration (or vendor the CLI's). This is the intended split —
+  most embedders want exactly the engine.
+- Orchestration features can only be delivered through the CLI, not the library.
+
+## Consequences
+
+- **Positive:** `faucet-core` stays small, stable, and dependency-light; orchestration
+  evolves fast without touching connectors; third parties embed a lean engine.
+- **Negative:** no reusable orchestration crate for non-CLI embedders (yet); CLI-only
+  features (`serve`, `schedule`) are invisible to library users by design.
+
+## Future work
+
+- Extract a `faucet-runtime` crate if a second orchestration front-end appears.
+
+## Related
+
+- [Execution model](../architecture/execution.md) · [pipeline](../architecture/pipeline.md) · [extensibility](../architecture/extensibility.md)
+- [ADR 0006 — State management](./0006-state-management.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,48 @@
+# Architecture Decision Records
+
+*The log of major architectural decisions, each with the context and trade-offs that produced it.*
+
+An **Architecture Decision Record** (ADR) captures one significant decision:
+what we chose, why, what we rejected, and what we now live with. ADRs are
+immutable once accepted — if a decision is later reversed, a *new* ADR
+supersedes the old one and links back to it, rather than the old one being
+edited. This preserves the reasoning trail for future maintainers who ask "why
+is it done this way?".
+
+ADRs describe decisions **already made and implemented**. Forward-looking
+proposals live in [`../../rfcs/`](../../rfcs/README.md); an accepted-and-shipped
+RFC often produces an ADR here.
+
+## Format
+
+Every ADR follows the same structure: Status · Context · Problem · Decision ·
+Alternatives considered · Trade-offs · Consequences · Future work · Related.
+
+## The records
+
+| ADR | Decision | Anchors |
+|-----|----------|---------|
+| [0001](./0001-stream-pages.md) | Page-based streaming (`StreamPage`) to bound memory at `O(batch_size)` | [stream-pages](../architecture/stream-pages.md) |
+| [0002](./0002-checkpoint-ordering.md) | **Write → flush → checkpoint** ordering — the data-integrity keystone | [invariants](../architecture/invariants.md), [recovery](../architecture/recovery.md) |
+| [0003](./0003-builder-pattern.md) | Progressive builder APIs over object-safe traits with defaulted methods | [connector-sdk](../architecture/connector-sdk.md) |
+| [0004](./0004-json-record-model.md) | `serde_json::Value` as the universal record model | [overview](../architecture/overview.md), [RFC 0002](../../rfcs/0002-arrow-support.md) |
+| [0005](./0005-runtime-recovery.md) | Sink-anchored resume — commit tokens embed the resume bookmark | [recovery](../architecture/recovery.md) |
+| [0006](./0006-state-management.md) | `StateStore` trait; light backends in core, heavy ones in their own crates | [state-management](../architecture/state-management.md) |
+| [0007](./0007-retries.md) | Two-layer retries; never retry a non-idempotent write | [retries](../architecture/retries.md) |
+| [0008](./0008-observability.md) | Automatic instrumentation via pipeline decorators | [observability](../architecture/observability.md) |
+| [0009](./0009-schema-validation.md) | Fixed-order per-page passes: mask → quality → contract → drift | [schema](../architecture/schema.md) |
+| [0010](./0010-pipeline-runtime.md) | Lean core library; all orchestration in the CLI layer | [execution](../architecture/execution.md) |
+
+## Proposing a new ADR
+
+1. Copy the structure of an existing ADR; take the next free number.
+2. If the decision is still open, write an [RFC](../../rfcs/README.md) first and
+   land the ADR once the decision is made and implemented.
+3. Cross-link the architecture pages the decision touches, and add a row above.
+
+## Related
+
+- [Architecture overview](../architecture/README.md)
+- [Design invariants](../architecture/invariants.md)
+- [RFC process](../../rfcs/README.md)
+- [Documentation home](../README.md)

--- a/docs/architecture-review.md
+++ b/docs/architecture-review.md
@@ -1,0 +1,191 @@
+# Architecture Review
+
+*An objective senior-maintainer review of faucet-stream. Every observation is backed by evidence from the implementation; strengths and weaknesses are reported honestly.*
+
+This review is written for maintainers deciding where to invest and for
+prospective adopters assessing risk. It is deliberately balanced: the project has
+unusual strengths for its age, and it also carries real debt. Nothing below is
+fabricated — each point cites the code, the workspace shape, or a documented
+limitation. Where a risk already has a mitigation planned, the relevant
+[ADR](./adr/0001-stream-pages.md) or [RFC](../rfcs/README.md) is linked.
+
+---
+
+## Strengths
+
+- **A single, correct data-integrity protocol, applied uniformly.** The
+  write → flush → checkpoint ordering holds identically across all three write
+  paths (default, DLQ, exactly-once) in `crates/core/src/pipeline.rs`. This is the
+  hardest thing to get right in a data-movement tool, and it is centralized in one
+  place rather than reimplemented per connector. See
+  [ADR 0002](./adr/0002-checkpoint-ordering.md).
+- **Retry safety is treated as a correctness property, not a convenience.** The
+  `with_retry_write!` macro refuses to retry a non-idempotent `write_batch` unless
+  the sink advertises idempotence — directly preventing the silent-duplication
+  bug class that plagues naive ETL tools. See
+  [ADR 0007](./adr/0007-retries.md).
+- **Bounded memory by construction.** The `StreamPage` model keeps memory at
+  O(batch_size) regardless of dataset size (`stream_pages`,
+  `DEFAULT_BATCH_SIZE`/`MAX_BATCH_SIZE`). This is a structural property, not a
+  tuning parameter. See [ADR 0001](./adr/0001-stream-pages.md).
+- **Zero-cost observability.** Automatic instrumentation via the
+  `observability/` decorators means every connector is observable without writing
+  metrics code, and third-party connectors inherit it for free. See
+  [ADR 0008](./adr/0008-observability.md).
+- **A genuinely extensible core.** `faucet-core` is object-safe, has one required
+  dependency, re-exports what authors need, and grows via defaulted trait methods.
+  The compile-time `PluginRegistry` (`cli/src/registry.rs`) lets a third party
+  ship a custom CLI. See [Extensibility](./architecture/extensibility.md).
+- **Operational maturity beyond its version.** A control plane (`faucet serve`),
+  clustering, RBAC + audit log, run history with instance-fenced orphan recovery,
+  OpenLineage emission, a data catalog, and an offline fixture test harness
+  (`faucet test`) are all present. Few frameworks at this stage have this breadth.
+- **High enforced test bar.** The `codecov/patch` gate is a *required* merge check
+  at 90% patch coverage, so new code cannot merge under-tested.
+
+---
+
+## Weaknesses
+
+- **`crates/core/src/pipeline.rs` is a 5,471-line file** with a deeply nested
+  `run_stream` loop that folds masking, quality, contract, drift, DLQ routing,
+  exactly-once, adaptive batching, resilience, and cancellation into one function.
+  It is correct and heavily commented, but it is the single hardest file in the
+  repo to modify safely, and its size is a barrier to new contributors. The
+  layered-pass ordering is load-bearing and only partially guarded by types.
+- **The record model allocates.** `serde_json::Value` per record is ergonomic but
+  costs allocation and blocks zero-copy hand-off to columnar sinks. This is an
+  informed trade-off ([ADR 0004](./adr/0004-json-record-model.md)), not an
+  oversight, but it is the dominant performance ceiling on the hot path.
+- **Exactly-once and DLQ are mutually exclusive.** The atomic-watermark mechanism
+  rejects a configured DLQ (`run_stream` returns `FaucetError::Config`). This is a
+  deliberate safety choice for this version, but it is a real functional gap:
+  users who want both must fall back to keyed-upsert.
+- **Capability discovery is implicit.** A connector's capabilities are a scatter
+  of boolean/defaulted methods (`supports_exactly_once`, `is_shardable`,
+  `supports_discover`, `supports_schema_evolution`, …). There is no single typed
+  capability descriptor, so tooling and docs must enumerate them by hand. See
+  [RFC 0001](../rfcs/0001-capability-traits.md).
+
+## Future risks
+
+- **Upstream dependency pins constrain evolution.** `sqlx` is pinned at 0.8 by
+  `pgwire-replication`; the OpenTelemetry stack is pinned to the 0.31 line by
+  `metrics-exporter-opentelemetry`; Iceberg schema-evolution is blocked on
+  `iceberg-rust` 0.9.1. Each pin is a place where the project cannot move until an
+  upstream does. These are documented in `CLAUDE.md`, which reduces the surprise
+  but not the constraint.
+- **Feature-flag combinatorics.** With per-connector features plus aggregate
+  features (`full`, `source`, `sink`, `secrets`, `triggers*`, serve/history
+  variants), the number of buildable configurations is large. The CI
+  feature-isolation matrix guards against feature-unification bugs, but the matrix
+  itself is a maintenance surface that must grow with every connector.
+
+## Scalability
+
+- **Vertical (single run):** bounded by O(batch_size) memory and by connector
+  throughput; the streaming model scales to datasets larger than RAM cleanly.
+- **Horizontal (many runs / one big source):** addressed by cluster Mode A
+  (whole-run balancing) and Mode B (source sharding), both riding a SQL-backed
+  `RunHistory` with lease-based claiming. This is a real distributed system with
+  the attendant complexity (leases, orphan recovery, poison handling) —
+  well-implemented but a large surface to keep correct.
+- **The `serde_json::Value` allocation cost** is the scaling ceiling for very
+  high-throughput single pipelines; the Arrow path
+  ([RFC 0002](../rfcs/0002-arrow-support.md)) is the planned relief.
+
+## Technical debt
+
+- The monolithic `run_stream` (above) is the primary technical debt. Extracting
+  the per-page pass pipeline (masking → quality → contract → drift) into a typed,
+  independently testable stage chain would reduce risk without changing behaviour.
+- The exactly-once token format is stringly-typed (`format_token` /
+  `format_token_with_bookmark` / `parse_token_parts`); it works and is
+  well-tested, but a typed token would be harder to misuse.
+
+## Architectural debt
+
+- **All orchestration lives in the CLI layer** (expand, executor, serve,
+  schedule, replicate, backfill, cluster). This keeps `faucet-core` lean
+  ([ADR 0010](./adr/0010-pipeline-runtime.md)) — a good decision — but it means a
+  library embedder who wants matrix/DAG execution must either reimplement it or
+  depend on the CLI crate. If embedding-with-orchestration becomes a real use
+  case, some of this may need to move into a reusable runtime crate.
+- **Capability model** (above) is architectural debt as much as a weakness:
+  formalizing it is [RFC 0001](../rfcs/0001-capability-traits.md).
+
+## Maintenance risks
+
+- **Solo-owner bus factor.** The repository is maintained by a single owner (the
+  `PawanSikawat` account self-merges under branch protection with
+  `enforce_admins: false`). The documentation effort this review is part of
+  directly mitigates the knowledge-concentration risk.
+- **Docs-sync burden.** Adding a connector requires touching features in three
+  places, `connectors/registry.json`, the CI matrix, the docs capability table,
+  and the crate README. This is documented as a trigger→update table, but it is
+  manual and easy to get partially wrong. SDK-ergonomics work (near-term roadmap)
+  targets this.
+
+## Contributor experience
+
+- **Strong onboarding surface:** `CONTRIBUTING.md`, the mdBook, `faucet init` /
+  `doctor` / `test`, and now this architecture documentation.
+- **Sharp edges:** the size of `pipeline.rs`, the feature-declaration rule (a
+  crate must declare every dep-feature it uses or feature-isolation CI fails), and
+  the `serde_json::Map` key-order gotcha under `--all-features` are all real
+  traps. These are now catalogued in
+  [common mistakes](./contributing/common-mistakes.md).
+
+## Testing
+
+- **Bar is high and enforced:** 90% required patch coverage, unit + `wiremock` /
+  `testcontainers` integration tests, an offline fixture harness, and property
+  tests for resume/checkpoint. The main caveat is that Docker-dependent
+  integration tests do not count toward patch coverage, so changed lines must be
+  unit-testable — which pushes good design (extract pure logic from I/O).
+
+## Documentation
+
+- **User-facing docs are strong** (the mdBook covers connectors, cookbook,
+  reference, operations). The historical gap — now being closed — was
+  *internal/architectural* documentation explaining *why*. This review and its
+  sibling ADRs/standards are that closure.
+
+## Performance
+
+- The connector-level performance disciplines (client reuse, pooling, multi-row
+  INSERT, `buffer_unordered`, bulk APIs, buffered I/O) are consistently applied
+  and documented as rules ([Performance standard](./standards/performance.md)).
+- Benchmarks exist (`BENCHMARKS.md`) with real scale findings. The gap is a
+  CI-adjacent regression guard on the hot path (medium-term roadmap).
+
+## Extensibility
+
+- **Best-in-class for a project this size.** One required dep, object-safe traits,
+  defaulted growth, a plugin registry, a connector spec, and a naming convention.
+  The remaining step is a conformance/certification kit so third-party connectors
+  can *prove* they honour the contracts — planned, not yet present.
+
+---
+
+## Summary
+
+faucet-stream's architecture is unusually disciplined about correctness and
+memory, and unusually broad in operational capability for its stage. Its principal
+risks are concentration risk (a single monolithic hot-path function, a single
+maintainer) and an allocation-bound record model. Both have identified,
+non-breaking mitigations already scoped in the ADRs and RFCs referenced above. The
+project is in a strong position to grow, provided the near-term consolidation work
+(documentation, capability formalization, SDK ergonomics) lands before the
+platform surface widens further.
+
+---
+
+## Related
+
+- [Architecture overview](./architecture/overview.md)
+- [Design invariants](./architecture/invariants.md)
+- [Architectural roadmap](./roadmap.md)
+- [RFC index](../rfcs/README.md)
+- [Architecture Decision Records](./adr/0001-stream-pages.md)
+- [Engineering principles](./engineering-principles.md)

--- a/docs/architecture-review.md
+++ b/docs/architecture-review.md
@@ -2,6 +2,16 @@
 
 *An objective senior-maintainer review of faucet-stream. Every observation is backed by evidence from the implementation; strengths and weaknesses are reported honestly.*
 
+> **Point-in-time snapshot.** Last reviewed: **2026-07-17**. Suggested cadence:
+> re-review each **minor release** (or ~quarterly). This document is a dated
+> assessment, not a permanent statement of fact — treat any finding older than
+> the last review date with suspicion and verify against the code.
+>
+> **This review drives work, it is not a graveyard.** Every concrete weakness
+> below should map to a tracked GitHub issue or a [roadmap](./roadmap.md) item;
+> when a finding is resolved, mark it here on the next review and link the PR. If
+> a finding has no issue, filing one is the first action.
+
 This review is written for maintainers deciding where to invest and for
 prospective adopters assessing risk. It is deliberately balanced: the project has
 unusual strengths for its age, and it also carries real debt. Nothing below is

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -64,6 +64,7 @@ flowchart LR
 - **[quality](./quality.md)** · **[contracts](./contracts.md)** · **[masking](./masking.md)** — the validation/protection passes.
 - **[observability](./observability.md)** — automatic metrics, spans, and OTLP.
 - **[performance](./performance.md)** — the Primary Goal and how it is upheld.
+- **[security](./security.md)** — credential/secret handling, the redaction boundary, and the hardening checklist.
 - **[extensibility](./extensibility.md)** — the third-party connector ecosystem.
 - **[invariants](./invariants.md)** — the load-bearing guarantees, in one place.
 - **[roadmap](./roadmap.md)** — architectural direction for these subsystems.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,86 @@
+# faucet-stream architecture
+
+*The maintainer's map of how faucet-stream is built and why — read this before changing the runtime.*
+
+This directory is the **internal engineering reference** for faucet-stream. It
+explains the *why* behind the system: the invariants that protect data, the
+trade-offs that shaped each subsystem, and the failure modes each was designed to
+survive. It is deliberately distinct from the **user-facing documentation** under
+[`../book/`](../book/src/introduction.md) (how to *use* the tool) — where a
+how-to already exists there, these pages link to it rather than repeat it.
+
+If you are about to touch `crates/core`, add a connector, or change delivery
+semantics, start here.
+
+## How the documentation is organised
+
+| Set | Location | Audience | Answers |
+|---|---|---|---|
+| Architecture | `docs/architecture/` | Maintainers | *Why is it built this way?* |
+| Decision records | [`../adr/`](../adr/) | Maintainers | *Why did we choose X over Y?* |
+| Contributor guides | [`../contributing/`](../contributing/architecture.md) | New contributors | *How do I add/change things safely?* |
+| Standards | [`../standards/`](../standards/api-design.md) | Everyone | *What are the repo-wide conventions?* |
+| RFCs | [`../../rfcs/`](../../rfcs/README.md) | Proposers | *What might change, and how?* |
+| User docs (mdBook) | [`../book/`](../book/src/introduction.md) | Operators | *How do I run a pipeline?* |
+
+## Reading order
+
+The subsystems form a chain — each page ends with a `## Related` section linking
+forward and back, so the set reads as one book rather than isolated files.
+
+```mermaid
+flowchart LR
+    OV[overview] --> EX[execution]
+    EX --> PL[pipeline]
+    PL --> SP[stream-pages]
+    SP --> BT[batching]
+    PL --> ST[state-management]
+    ST --> RC[recovery]
+    RC --> RT[retries]
+    RT --> RS[resilience]
+    PL --> SC[schema]
+    SC --> QL[quality]
+    QL --> CT[contracts]
+    CT --> MK[masking]
+    PL --> OB[observability]
+    OV --> CS[connector-sdk]
+    CS --> EXT[extensibility]
+    PL --> PF[performance]
+```
+
+### The pages
+
+- **[overview](./overview.md)** — the whole system in one page: crate topology, the data path, layering.
+- **[execution](./execution.md)** — how a run is scheduled and driven, from CLI config to core loop.
+- **[pipeline](./pipeline.md)** — the `Pipeline` / `run_stream` engine and its per-page loop.
+- **[stream-pages](./stream-pages.md)** — the `StreamPage` streaming model that bounds memory.
+- **[batching](./batching.md)** — batch sizing, the `0` sentinel, adaptive control.
+- **[connector-sdk](./connector-sdk.md)** — the `Source` / `Sink` trait contracts.
+- **[state-management](./state-management.md)** — bookmarks, the `StateStore`, key scheme.
+- **[recovery](./recovery.md)** — crash recovery and sink-anchored resume.
+- **[retries](./retries.md)** — the two retry layers and the duplication-safety rule.
+- **[resilience](./resilience.md)** — circuit breaker, poison-pill, backoff policy.
+- **[schema](./schema.md)** — inference and the ordered per-page passes.
+- **[quality](./quality.md)** · **[contracts](./contracts.md)** · **[masking](./masking.md)** — the validation/protection passes.
+- **[observability](./observability.md)** — automatic metrics, spans, and OTLP.
+- **[performance](./performance.md)** — the Primary Goal and how it is upheld.
+- **[extensibility](./extensibility.md)** — the third-party connector ecosystem.
+- **[invariants](./invariants.md)** — the load-bearing guarantees, in one place.
+- **[roadmap](./roadmap.md)** — architectural direction for these subsystems.
+
+## The one invariant to internalise first
+
+> **A page's bookmark is persisted to the state store only *after* the sink has
+> durably written and flushed that page.**
+
+Every recovery, retry, and delivery guarantee in the system is built on this
+single ordering. It is documented in full in **[invariants](./invariants.md)** and
+**[ADR 0002](../adr/0002-checkpoint-ordering.md)**; it is enforced in `run_stream`
+(`crates/core/src/pipeline.rs`).
+
+## Related
+
+- [Engineering principles](../engineering-principles.md)
+- [Architecture review](../architecture-review.md)
+- [API stability](../stability.md)
+- [Contributor architecture guide](../contributing/architecture.md)

--- a/docs/architecture/batching.md
+++ b/docs/architecture/batching.md
@@ -1,0 +1,106 @@
+# Batching
+
+*How records are grouped into pages to bound memory while keeping throughput high.*
+
+## Why it exists
+
+Moving data must not require holding the whole dataset in memory — a 500M-row
+table cannot be buffered. faucet-stream's answer is the **page**: sources emit
+records in chunks (`StreamPage`), the pipeline writes each page to the sink as it
+arrives, and only one page is resident at a time. Batch size is the single knob
+that trades memory against per-request overhead.
+
+## Problem it solves
+
+- **Unbounded memory.** Without paging, a naïve source→sink copy is O(total
+  records) in RAM. Paging makes it O(batch_size) on both sides regardless of
+  total volume.
+- **Per-request overhead.** Writing one record per request wastes round-trips;
+  batching amortizes them (multi-row INSERT, bulk NDJSON, `insertAll`).
+- **Mismatched natural units.** A source's natural read chunk and a sink's
+  natural write chunk differ. Both sides carry their own `batch_size` so each can
+  be tuned independently.
+
+## Major components
+
+- `StreamPage { records, bookmark }` (`crates/core/src/pipeline.rs`) — the unit
+  of transfer. See [stream-pages](./stream-pages.md) for the streaming contract.
+- `DEFAULT_BATCH_SIZE = 1000`, `MAX_BATCH_SIZE = 1_000_000` — the default hint and
+  the hard cap.
+- `validate_batch_size(usize)` — rejects any value above `MAX_BATCH_SIZE` at
+  config-load time to prevent an accidental O(total) buffer via a typo.
+- **`batch_size = 0`** — the opt-out sentinel: sources emit the entire result set
+  in one page, sinks accept whatever arrives without re-chunking. Intended for
+  small lookup tables and for sinks that prefer one large request (SQL `COPY`,
+  BigQuery load jobs, whole-page MERGE).
+- Adaptive controller (`crates/core/src/adaptive.rs`) — an opt-in AIMD controller
+  that resizes sub-batches from observed sink latency + error rate.
+
+## Execution flow
+
+Source `batch_size` shapes the page the source *emits*; sink `batch_size`
+re-chunks the page the sink *writes*. When adaptive batching is enabled
+(`Pipeline::with_adaptive`), each source page is resliced into adaptive
+sub-batches:
+
+```mermaid
+flowchart LR
+    S[Source page: N records] --> A{adaptive enabled?}
+    A -->|no| W[sink.write_batch of N]
+    A -->|yes| C[AimdController.current = k]
+    C --> W1[write_batch chunk k]
+    W1 --> O[observe latency + errors]
+    O -->|latency low, no errors| UP[additive increase k]
+    O -->|errors / high latency| DN[multiplicative decrease k]
+    UP --> C
+    DN --> C
+```
+
+The controller is created lazily on the first non-empty page
+(`AimdController::new`) and never grows a sub-batch beyond the source page it was
+handed.
+
+## Invariants
+
+- **`batch_size` on `Source::stream_pages` is a *hint*.** Every overriding source
+  treats its own config field as authoritative, so a pipeline-supplied hint can
+  never silently override an explicit config value.
+- **Memory is O(batch_size), not O(total).** One page resident at a time is the
+  guarantee that makes arbitrarily large transfers safe.
+- **`batch_size = 0` means "no batching", not "empty batch".** It is a sentinel,
+  handled explicitly at both ends.
+- **Adaptive sub-batches never cross a page boundary** and never change the
+  [checkpoint ordering](./invariants.md) — a bookmark is still persisted only
+  after the full page's writes flush.
+
+## Trade-offs
+
+- **Larger pages = fewer round-trips but more RAM and coarser checkpoints.** A
+  crash re-does the whole in-flight page (at-least-once) or skips it
+  (exactly-once), so page size also sets the replay granularity.
+- **Adaptive batching adds a control loop** whose value shows up only under
+  variable sink latency; it is off by default to keep the common path
+  predictable.
+
+## Failure scenarios
+
+- **A page too large for the sink's request limit** (e.g. BigQuery ~10 MB
+  `jobs.query`) → the operator must size `batch_size` down; the whole-page MERGE
+  path is intentionally not re-chunked.
+- **Config typo `batch_size: 1000000000`** → rejected by `validate_batch_size`
+  before the run starts, not discovered as an OOM mid-run.
+
+## Future evolution
+
+- Byte-aware paging (size pages by serialized bytes, not row count) for sinks with
+  hard request-size limits.
+- An Arrow-native record model (see [RFC 0002](../../rfcs/0002-arrow-support.md))
+  would let a page be a columnar batch, cutting per-record allocation — see
+  [performance](./performance.md).
+
+## Related
+
+- [Stream pages](./stream-pages.md) · [Pipeline](./pipeline.md) · [Performance](./performance.md)
+- [State management](./state-management.md) · [Design invariants](./invariants.md)
+- [ADR 0001 — Stream pages](../adr/0001-stream-pages.md)
+- User guide: [../book/src/cookbook/adaptive-batching.md](../book/src/cookbook/adaptive-batching.md)

--- a/docs/architecture/connector-sdk.md
+++ b/docs/architecture/connector-sdk.md
@@ -1,0 +1,118 @@
+# Connector SDK
+
+*The `Source` and `Sink` trait contracts — small, object-safe, and defaulted, so connectors stay simple and forward-compatible.*
+
+## Why it exists
+
+faucet-stream is a *marketplace ecosystem*: third parties should be able to publish
+`faucet-source-*` / `faucet-sink-*` crates against a stable, minimal surface. The
+two connector traits are the contract that makes that possible. They are designed
+under three hard constraints — **object-safe**, **minimal required surface**, and
+**every new method defaulted** — so that `Box<dyn Source>` works, a new connector
+needs to implement almost nothing, and adding a capability never breaks existing
+connectors. See [ADR 0003](../adr/0003-builder-pattern.md) and
+[extensibility](./extensibility.md).
+
+## The `Source` contract
+
+Defined in `crates/core/src/traits.rs`. The required method is a single fetch; all
+resumability, streaming, exactly-once, sharding, and discovery are **defaulted**.
+
+| Method | Required? | Purpose |
+|---|---|---|
+| `fetch_with_context` | **yes** | the one primitive: pull records for a context |
+| `stream_pages` | defaulted (chunks `fetch_all`) | native streaming — override to bound memory |
+| `state_key` / `apply_start_bookmark` | defaulted (`None` / no-op) | resumability |
+| `capture_resume_position` | defaulted (`None`) | anchor CDC before a snapshot (replication) |
+| `supports_exactly_once` / `replay_guarantee` | defaulted (`false`) | delivery capability |
+| `is_shardable` / `enumerate_shards` / `apply_shard` | defaulted (single shard) | sharded execution |
+| `supports_discover` / `discover` | defaulted (unsupported) | live catalog introspection |
+| `config_schema` / `connector_name` / `dataset_uri` | defaulted | introspection & labels |
+| `check` | defaulted (pulls one page) | `faucet doctor` preflight |
+
+A minimal source implements exactly one method and inherits everything else.
+
+## The `Sink` contract
+
+The required method is a single batch write; everything advanced is defaulted.
+
+| Method | Required? | Purpose |
+|---|---|---|
+| `write_batch` | **yes** | write a slice of records |
+| `flush` | defaulted (no-op) | make buffered writes durable |
+| `write_batch_partial` | defaulted | per-row success/failure for the DLQ path |
+| `supports_idempotent_writes` / `write_batch_idempotent` / `last_committed_token` | defaulted | exactly-once atomic watermark |
+| `sink_guarantee` / `dedups_by_key` | defaulted | typed delivery capability |
+| `supported_write_modes` | defaulted (`[Append]`) | upsert / delete support |
+| `current_schema` / `supports_schema_evolution` / `evolve_schema` | defaulted | schema-drift handling |
+| `config_schema` / `connector_name` / `dataset_uri` / `check` | defaulted | introspection & probes |
+
+## The capability pattern
+
+Advanced behaviour is expressed as **capabilities**: a boolean (or typed) probe
+method plus the methods that implement it. A sink advertises exactly-once with
+`supports_idempotent_writes() → true` and then implements `write_batch_idempotent` +
+`last_committed_token`. The pipeline queries the capability and selects a code path.
+
+```mermaid
+flowchart LR
+    P[run_stream] --> Q{sink.supports_idempotent_writes?}
+    Q -->|yes| EO[write_batch_idempotent path]
+    Q -->|no| DEF[write_batch path]
+    P --> R{sink.dedups_by_key?}
+    R -->|yes| KU[keyed-upsert effectively-once]
+```
+
+This keeps the traits object-safe (no associated types, no generic methods) while
+still letting the runtime specialise. The current pattern uses booleans; a richer,
+typed capability model is proposed in
+[RFC 0001](../../rfcs/0001-capability-traits.md).
+
+## Connector crate layout
+
+Every connector follows the same module layout (enforced by convention, documented
+in `.claude/rules/connectors.md`):
+
+- `lib.rs` — re-exports; first line `#![cfg_attr(docsrs, feature(doc_cfg))]`.
+- `config.rs` — the config struct + sub-enums, deriving
+  `Serialize + Deserialize + JsonSchema`. **No I/O here.**
+- `stream.rs` (source) / `sink.rs` (sink) — the **only** place protocol I/O happens;
+  holds reusable clients/pools created in `new()`.
+- optional helpers — `auth/`, `pagination/`, `extract/`, `convert.rs`, `state.rs`.
+
+The full authoring walkthrough is in
+[the contributor guide](../contributing/connector-authoring.md).
+
+## Invariants
+
+- **Traits are object-safe** — `Box<dyn Source>` / `Box<dyn Sink>` must always work;
+  no associated types or generic trait methods.
+- **New trait methods must be defaulted** — adding a capability never breaks an
+  existing connector. This is a stability guarantee, not a style preference (see
+  [stability](../stability.md)).
+- **`faucet-core` is the only required dependency** for a connector author; it
+  re-exports `async_trait`, `serde_json`, and `schemars`.
+- **`connector_name()` must return a non-empty `&'static str`** — empty falls back to
+  `"unknown"` and breaks metric labels.
+
+## Trade-offs
+
+- **Boolean capabilities** are simple and object-safe but stringly-typed at the CLI
+  gate (allowlists in `registry.rs`). A typed model would remove the allowlists at
+  the cost of trait complexity — deferred to [RFC 0001](../../rfcs/0001-capability-traits.md).
+- **`serde_json::Value` records** maximise author ergonomics at an allocation cost —
+  see [ADR 0004](../adr/0004-json-record-model.md).
+
+## Future evolution
+
+- Typed capability traits ([RFC 0001](../../rfcs/0001-capability-traits.md)).
+- A stable connector ABI for dynamically-loaded plugins
+  ([RFC 0003](../../rfcs/0003-plugin-system.md)); today plugins link at compile time
+  via `PluginRegistry` (see [extensibility](./extensibility.md)).
+
+## Related
+
+- [Extensibility](./extensibility.md) · [Pipeline engine](./pipeline.md) · [Stream pages](./stream-pages.md)
+- [Connector authoring guide](../contributing/connector-authoring.md) · [Standards: API design](../standards/api-design.md)
+- [ADR 0003 — Builder pattern](../adr/0003-builder-pattern.md) · [ADR 0004 — JSON record model](../adr/0004-json-record-model.md)
+- Spec: [Faucet Connector Protocol v0](../spec/faucet-connector-spec-v0.md)

--- a/docs/architecture/contracts.md
+++ b/docs/architecture/contracts.md
@@ -1,0 +1,90 @@
+# Data contracts
+
+*A versioned promise about a pipeline's output shape, enforced per page with fail/quarantine/warn semantics.*
+
+## Why it exists
+
+Quality checks assert ad-hoc invariants; a **contract** is a stronger, versioned
+statement: "this pipeline emits records of exactly this shape, and I will break
+loudly if that stops being true." It is the interface a downstream consumer can
+depend on, and it can be exported as JSON Schema or an OpenLineage facet so the
+promise is machine-readable.
+
+## Problem it solves
+
+- **Undeclared output shape.** Consumers otherwise reverse-engineer the shape and
+  break silently when it changes. A contract makes the shape explicit and
+  versioned.
+- **Choosing the blast radius of a breach.** `fail` stops the run, `quarantine`
+  isolates breaching records, `warn` records-and-continues — the operator picks
+  the severity.
+
+## Major components
+
+Under `crates/core/src/contract/`:
+
+- `ContractSpec` — `version` (required), `on_breach` (`fail` default /
+  `quarantine` / `warn`), `allow_extra_fields`, and `fields[]` with type,
+  `required`/`nullable`, `enum`, `pattern`, numeric `min`/`max`, string
+  `min_length`/`max_length`.
+- `CompiledContract::compile` — fail-fast (regex, enum, bounds, type
+  compatibility validated at load time).
+- `apply_contract(page, &c) -> ContractOutcome { survivors, quarantined, warned }`
+  — per record, first breach wins (fields in declared order, then the extra-field
+  check).
+- `export.rs` — pure `to_json_schema` / `to_openlineage_facet` (used by
+  `faucet contract --export`).
+
+## Execution flow
+
+```mermaid
+flowchart TD
+    PG[quality survivors] --> AP[apply_contract]
+    AP -->|on_breach fail| AB[FaucetError::ContractViolation — write NOTHING]
+    AP -->|on_breach quarantine| DLQ[DLQ envelope DlqReason::Contract]
+    AP -->|on_breach warn| WRN[log once/run, count, write anyway]
+    AP -->|clean| SUR[survivors to drift pass then sink]
+```
+
+Runs after the quality pass and before the schema-drift pass (see
+[schema](./schema.md)).
+
+## Invariants — the fail asymmetry
+
+- **`contract: fail` mirrors a quality `abort`: it propagates immediately and
+  writes nothing from the page.** A contract must never commit breaching data.
+- **`drift: fail` defers** (writes the page's survivors, then aborts) because
+  drift's records are *individually valid* — only their shape diverged. A
+  contract breach means the record itself is wrong. This is the precise reason
+  the two `fail` modes behave differently; conflating them would either strand
+  valid rows or commit invalid ones.
+- **`quarantine` requires a DLQ** (`requires_dlq()`), gated at expand time and at
+  run start; transitively incompatible with exactly-once (which bans a DLQ).
+- **Compilation is fail-fast** — an empty version, duplicate field names, bad
+  regex, type-mismatched enum, or `min > max` is a `FaucetError::Config` at load.
+
+## Trade-offs
+
+- **Top-level fields only**, like drift — nested constraints are out of scope.
+- **`warn` is a foot-gun by design**: it lets breaches through, but makes the
+  breach observable (`faucet_contract_violations_total`) so an operator can tighten
+  to `quarantine`/`fail` once the volume is understood.
+
+## Failure scenarios
+
+- **A required field disappears** → breach; `fail` aborts, `quarantine` routes the
+  record, `warn` counts it.
+- **An enum gains a new value upstream** → breach on `enum`; same three outcomes.
+
+## Future evolution
+
+- Contract *evolution* rules (e.g. additive-only changes auto-accepted across
+  versions), and wiring the exported JSON Schema into the
+  [catalog](./observability.md) schema timeline.
+
+## Related
+
+- [Quality](./quality.md) · [Schema handling](./schema.md) · [Masking](./masking.md)
+- [Pipeline](./pipeline.md) · [Design invariants](./invariants.md)
+- [ADR 0009 — Schema validation](../adr/0009-schema-validation.md)
+- User guide: [../book/src/cookbook/contracts.md](../book/src/cookbook/contracts.md)

--- a/docs/architecture/execution.md
+++ b/docs/architecture/execution.md
@@ -1,0 +1,111 @@
+# Execution model
+
+*How a config becomes a running pipeline — from file to matrix DAG to the core loop.*
+
+## Why it exists
+
+A single `Pipeline` moves one source to one sink. Real deployments need more:
+templated fan-out, per-row overrides, dependency ordering, scheduling, an HTTP
+control plane. Rather than push those concerns into `faucet-core` (which 60+
+connectors depend on), faucet-stream implements them as a thin **orchestration
+layer in the CLI** that compiles a declarative config into a set of independent
+pipeline invocations and drives them. See [ADR 0010](../adr/0010-pipeline-runtime.md).
+
+## The pipeline of compilers
+
+Loading a config is a sequence of pure-ish passes, each with a single job. The
+order matters: composition happens before interpolation, secrets resolve last at
+load time, and expansion produces the executable node set.
+
+```mermaid
+flowchart TD
+    F[config file] --> CP[compose: extends / !include / profiles]
+    CP --> IN[interpolate: env / file / vars / templates]
+    IN --> SEC[secrets: vault / aws-sm / gcp-sm / azure-kv]
+    SEC --> PARSE[parse → PipelineConfig]
+    PARSE --> EXP[expand → Vec of ExpandedNode]
+    EXP --> EXEC[executor: run_expanded]
+    EXEC --> P1[Pipeline::run]
+    EXEC --> P2[Pipeline::run]
+    EXEC --> PN[Pipeline::run]
+```
+
+- **`compose`** (`cli/src/compose.rs`) — stitches `extends:`, substitutes
+  `!include` fragments, overlays the selected `profiles:` overlay, strips
+  metadata. File-loads only (a submitted `serve` body skips it).
+- **`interpolate`** (`cli/src/interpolate.rs`) — resolves `${env:…}`,
+  `${file:…}`, `${vars.X}`, `${sources.NAME.PATH}` at load; leaves `${row_id.path}`
+  and `${now.*}` for runtime.
+- **secrets** (`cli/src/secrets/`) — the final load-time stage; resolves
+  `${vault:…}` and friends over the parsed tree, then installs a redaction boundary.
+- **`expand`** (`cli/src/expand.rs`) — turns the `matrix:` into a `Vec<ExpandedNode>`,
+  validating ids, template refs, `depends_on` edges (Kahn's algorithm), and the
+  **delivery / write-mode / schema gates** *at config-load time* so an invalid
+  topology never starts a run.
+- **`executor`** (`cli/src/executor.rs`) — runs the nodes under one bounded
+  `Semaphore`, honouring `on_error` (continue/stop), parent→child fan-out, and
+  cooperative cancellation.
+
+## The matrix DAG
+
+A `matrix:` row is deep-merged onto the base `pipeline`. Rows form a DAG:
+
+- **parent/child** — a row with `parent: <id>` runs once per record the parent
+  emits, resolving `${parent.path}` per record.
+- **`depends_on`** — pure completion ordering (no record hand-off); a row starts
+  only after every listed row's invocations succeed.
+
+State keys encode the position in the DAG: `{name}::{row_id}` for roots,
+`{name}::{row_id}::{parent_record_key}` for children. This is what makes each
+invocation independently resumable — see [state-management](./state-management.md).
+
+## Runtimes built on the executor
+
+Every long-running mode is the same `expand` + `run_expanded`, wrapped in a driver:
+
+| Runtime | Driver | What it adds |
+|---|---|---|
+| `faucet run` | one-shot | nothing — runs the DAG once |
+| `faucet schedule` | cron loop | croner + chrono-tz ticks, overlap policy, drain |
+| `faucet serve` | axum server | HTTP submit/track, RBAC, idempotency, history, cluster |
+| `faucet replicate` | 2-phase | snapshot → CDC handoff anchored by `capture_resume_position` |
+| `faucet backfill` | windowed | `--from/--to` chunked into units with `${backfill.*}` tokens |
+
+None of these touch `faucet-core`. They are pure CLI logic (`cli/src/schedule/`,
+`cli/src/serve/`, `cli/src/replication/`, `cli/src/backfill/`). That is the
+layering payoff: the core stays a stable, embeddable library while orchestration
+evolves independently.
+
+## Invariants
+
+- **Gates run at load, not mid-run.** Delivery, write-mode, and quarantine-DLQ
+  requirements are validated in `expand`; `faucet validate` catches them before any
+  data moves. A run that starts is a run whose topology is sound.
+- **Each invocation is independent.** No shared mutable state between DAG nodes
+  except the `StateStore` (keyed per node) and shared auth providers (single-flight
+  token cache).
+- **Cancellation is cooperative and flush-completing.** `on_error: stop`, serve
+  timeouts, and shutdown all cancel a token threaded into the pipeline; runs stop at
+  a page boundary and flush. See [recovery](./recovery.md).
+
+## Failure scenarios
+
+- **A child's parent fails** → the child (and its subtree) is skipped, not run
+  against stale data.
+- **A `depends_on` dependency fails or is skipped** → the dependent is skipped,
+  mirroring the failed-parent cascade.
+- **Sibling state-key collision** under one parent → surfaced as
+  `CliError::DuplicateStateKey` before execution.
+
+## Future evolution
+
+- A capability-typed node model so the executor can reason about delivery/shard
+  support without string allowlists ([RFC 0001](../../rfcs/0001-capability-traits.md)).
+- Distributed execution beyond the current serve cluster modes.
+
+## Related
+
+- [Overview](./overview.md) · [Pipeline engine](./pipeline.md)
+- [State management](./state-management.md) · [Recovery](./recovery.md)
+- [ADR 0010 — Pipeline runtime](../adr/0010-pipeline-runtime.md)
+- User guide: [matrix DAGs](../book/src/tutorials/matrix-dag.md) · [serve](../book/src/cookbook/serve.md)

--- a/docs/architecture/extensibility.md
+++ b/docs/architecture/extensibility.md
@@ -1,0 +1,101 @@
+# Extensibility
+
+*The marketplace model: how third parties build, publish, and register connectors with minimal friction.*
+
+## Why it exists
+
+faucet-stream is designed as an *ecosystem*, not a monolith. The explicit goal is
+that a third-party developer can publish a `faucet-source-foo` / `faucet-sink-foo`
+crate and have it be a first-class citizen — as observable, as testable, and as
+composable as a built-in. Every design choice in the connector surface is filtered
+through "does this keep the barrier to a third-party connector low?"
+
+## Problem it solves
+
+- **Coupling to the core.** If connectors depended on many core internals, the
+  ecosystem could not evolve independently. Only `faucet-core` is required.
+- **Trait fragility.** If the `Source`/`Sink` traits were not object-safe or
+  required connector-specific types, `Box<dyn Source>` and the generic pipeline
+  would break. New capabilities must be *additive*.
+- **Registration friction.** A custom binary must be able to add connectors
+  without forking the CLI.
+
+## Major components
+
+- **`faucet-core` is the only required dependency.** It re-exports everything a
+  connector author needs: `async_trait`, `serde_json` (`Value`, `json!`),
+  `schemars` (`JsonSchema`, `schema_for!`), `async_stream`, and
+  `CancellationToken`. If authors need a new common dependency, it is re-exported
+  from core rather than added to their manifest.
+- **Object-safe `Source`/`Sink` traits** (`crates/core/src/traits.rs`) — no
+  associated types, no generics on methods, so `Box<dyn Source>` works. New
+  capabilities (`supports_exactly_once`, `is_shardable`, `supports_discover`,
+  `supports_schema_evolution`) are **defaulted methods**, so existing connectors
+  keep compiling.
+- **`FaucetError::Custom(Box<dyn Error + Send + Sync>)`** — lets authors wrap their
+  own error types without extending the core enum.
+- **Naming convention** `faucet-source-<name>` / `faucet-sink-<name>`; shared
+  source/sink config lives in a `faucet-common-<name>` crate.
+- **`PluginRegistry`** (`cli/src/registry.rs`) — a custom-CLI author calls
+  `faucet_cli::run_main(PluginRegistry::with_builtins().register_source(...).register_sink(...))`;
+  the registry is consulted before built-ins by `build_source`/`build_sink`/
+  `source_schema`/`sink_schema`. Example: `cli/examples/custom-cli/`.
+
+## Capability model
+
+```mermaid
+flowchart LR
+    T[Source / Sink trait] --> B[required: fetch/write + config_schema]
+    T --> D1[default: supports_exactly_once -> false]
+    T --> D2[default: is_shardable -> false]
+    T --> D3[default: supports_discover -> false]
+    T --> D4[default: supports_schema_evolution -> false]
+    D1 -.override to opt in.-> C[CDC / Kafka sources]
+    D2 -.override.-> S[PK-range / hash-shardable sources]
+    D3 -.override.-> DIS[catalog-backed sources]
+    D4 -.override.-> EV[evolvable SQL sinks]
+```
+
+A connector opts into a capability by overriding one defaulted method — it never
+has to know about the runtime machinery that consumes it. This is the mechanism
+that keeps the trait small while the runtime grows.
+
+## Invariants
+
+- **New trait methods must have defaults.** Adding a capability must never break an
+  existing connector — the ecosystem-compatibility contract.
+- **`faucet-core` stays lightweight.** No DB drivers or cloud SDKs in core;
+  connector-specific deps belong in the connector crate.
+- **The pipeline stays generic** over any `Source` + `Sink`; it is never coupled
+  to a specific connector.
+
+## Trade-offs
+
+- **Defaulted-method capabilities** mean a capability is invisible unless queried;
+  the CLI's expand-time gates (`registry::source_supports_exactly_once`, etc.)
+  bridge the gap by validating capability requirements before a run.
+- **`serde_json::Value` record model** keeps authoring trivial at an allocation
+  cost — see [performance](./performance.md) and
+  [ADR 0004](../adr/0004-json-record-model.md).
+
+## Failure scenarios
+
+- **A plugin name collides with a built-in** → the registry is collision-checked
+  and rejects it at registration.
+- **A capability requirement unmet** (exactly-once on a non-deterministic source)
+  → rejected at config-load by the expand gate, not mid-run.
+
+## Future evolution
+
+- Formalized capability traits ([RFC 0001](../../rfcs/0001-capability-traits.md)).
+- A dynamic plugin/ABI story so connectors need not be compiled in
+  ([RFC 0003](../../rfcs/0003-plugin-system.md)).
+- Connector certification (a conformance suite proving a connector honours the
+  contract) — see [roadmap](./roadmap.md).
+
+## Related
+
+- [Connector SDK](./connector-sdk.md) · [Performance](./performance.md) · [Roadmap](./roadmap.md)
+- [Connector protocol (FCP v0)](../spec/faucet-connector-spec-v0.md)
+- [RFC 0001 — Capability traits](../../rfcs/0001-capability-traits.md) · [RFC 0003 — Plugin system](../../rfcs/0003-plugin-system.md)
+- Contributor guide: [../contributing/connector-authoring.md](../contributing/connector-authoring.md)

--- a/docs/architecture/invariants.md
+++ b/docs/architecture/invariants.md
@@ -1,0 +1,191 @@
+# Design invariants
+
+*The load-bearing guarantees the whole system depends on. If you change the write path, you are changing this file — update it deliberately.*
+
+An invariant here is a rule the codebase relies on being true *everywhere*,
+always. They are not aspirations; each is enforced in code and cited below.
+Violating one silently corrupts data or breaks recovery — the worst class of
+bug this project can ship. Treat this page as a contract with future
+maintainers.
+
+Every invariant lists **what it guarantees**, **where it is enforced**, and
+**what breaks if you violate it**.
+
+---
+
+## I1 — A bookmark is persisted only after a durable, flushed write
+
+**Guarantee.** For any page, the state store is updated with that page's
+bookmark only *after* both `write_batch*` and `flush()` have returned `Ok`. The
+ordering is always: **write → flush → checkpoint**. The state store is never
+ahead of the sink.
+
+**Where.** `run_stream` in `crates/core/src/pipeline.rs`, in all three write
+paths (DLQ, exactly-once, default). Each ends with
+`… sink.flush()? … store.put(key, bookmark)?`.
+
+**If violated.** A crash after the checkpoint but before the write would skip
+records permanently — silent data loss. This is the single most important rule
+in the codebase. See [ADR 0002](../adr/0002-checkpoint-ordering.md),
+[recovery](./recovery.md), [state](./state-management.md).
+
+## I2 — Retries never advance state, and never retry a non-idempotent write
+
+**Guarantee.** A retry re-attempts the *same* operation against the *same*
+position; it never moves the bookmark forward. And a plain, non-idempotent
+`write_batch` is retried **only** when the sink commits writes idempotently
+(`Sink::supports_idempotent_writes()`); otherwise a lost-response retry could
+duplicate every row.
+
+**Where.** The `with_retry_write!` macro in `run_stream` gates retrying
+non-idempotent writes on `sink.supports_idempotent_writes()`; the idempotent
+path (`write_batch_idempotent`) is always safe to retry because replaying a
+token-stamped write is a no-op.
+
+**If violated.** Duplicated rows on a lost sink response — the repo's
+#1-worst-bug class. See [retries](./retries.md), [ADR 0007](../adr/0007-retries.md).
+
+## I3 — State reflects only committed work
+
+**Guarantee.** A bookmark read on the next run points at a position for which
+every prior record is durably in the sink. Under exactly-once the stored
+`(bookmark, seq)` envelope is reconciled against the sink's committed watermark,
+so the stored state is never treated as further ahead than the sink.
+
+**Where.** `wrap_state`/`unwrap_state` + the sink-anchored resume block in
+`Pipeline::run` (`crates/core/src/idempotency.rs`, `pipeline.rs`).
+
+**If violated.** Recovery would resume past uncommitted data (loss) or
+re-process committed data as if new (duplication under exactly-once).
+
+## I4 — `StreamPage` ordering is preserved and checkpoints advance monotonically
+
+**Guarantee.** Pages are consumed strictly in the order the source emits them;
+checkpoints only ever move forward. Page N is fully durable before page N+1's
+bookmark can be persisted.
+
+**Where.** The single-threaded page loop in `run_stream`; there is no
+concurrent consumption of the page stream.
+
+**If violated.** Out-of-order checkpointing could persist a later bookmark while
+an earlier page's write is still pending — reintroducing the I1 loss window.
+See [stream-pages](./stream-pages.md).
+
+## I5 — Masking runs first, before anything observes the records
+
+**Guarantee.** When a masking policy is attached, the masking pass runs on each
+page **before** the quality, contract, and drift passes, before any sink write,
+before the DLQ, and before any lineage sample. No downstream component ever sees
+unmasked PII.
+
+**Where.** `run_stream` applies masking as the first per-page transformation
+(`crates/core/src/pipeline.rs`, guarded by `#[cfg(feature = "masking")]`).
+
+**If violated.** PII would leak to a sink, a DLQ envelope, or a lineage sample —
+a security/compliance defect. See [masking](./masking.md).
+
+## I6 — The per-page pass order is fixed: mask → quality → contract → drift
+
+**Guarantee.** The four protection/validation passes always run in this order.
+`contract: on_breach=fail` aborts the page (writes nothing) because breaching
+data must never be committed; `schema: on_drift=fail` *defers* its abort until
+the page's individually-valid survivors are durable.
+
+**Where.** `run_stream` pass sequence in `crates/core/src/pipeline.rs`.
+
+**If violated.** Reordering could let a quality check pass on unmasked data, or
+commit contract-breaching rows. The fixed order removes a footgun config knob.
+See [schema](./schema.md), [contracts](./contracts.md), [quality](./quality.md).
+
+## I7 — Every early exit flushes the sinks
+
+**Guarantee.** A source error, a propagated write/flush/state error, a DLQ-budget
+abort, a circuit-breaker trip, or a cancellation all funnel through a single
+inner future that performs a best-effort final `flush()` before returning.
+
+**Where.** The `loop_result` inner future + trailing flush in `run_stream`.
+
+**If violated.** A buffered sink that only commits on flush (Parquet writes its
+footer there; without it the whole file is unreadable; S3 multipart aborts)
+would orphan everything written so far. See [pipeline](./pipeline.md).
+
+## I8 — Cancellation is cooperative and flush-completing
+
+**Guarantee.** A `CancellationToken` cancel stops the loop at the **next page
+boundary**, flushes the sinks, and returns the *partial* `PipelineResult` as
+`Ok`. It never tears down a run mid-`write_batch` from the core's side (a sink
+stuck inside a write past the caller's grace is hard-dropped by the caller, not
+the core).
+
+**Where.** The `tokio::select! { biased; token.cancelled() … }` page-poll race
+in `run_stream`; the executor's `STOP_FLUSH_GRACE` backstop
+(`cli/src/executor.rs`).
+
+**If violated.** A cancel that dropped the future immediately would flush
+nothing — the difference between a clean stop and a corrupted Parquet file.
+See [execution](./execution.md).
+
+## I9 — Config gates are enforced before any run starts
+
+**Guarantee.** An impossible topology — an invalid exactly-once combination, an
+unsupported `write_mode × sink`, `schema: evolve` on a schemaless sink,
+quarantine without a DLQ — is rejected at config-load in `expand`, so
+`faucet validate` fails before a single record moves.
+
+**Where.** `cli/src/expand.rs`; the atomic-watermark gate is re-checked at the
+core boundary in `run_stream`.
+
+**If violated.** A config that can't work would fail *mid-stream*, potentially
+after partial, unrecoverable side effects.
+
+## I10 — Bookmarks and commit tokens are opaque to everyone but their owner
+
+**Guarantee.** The `StateStore` round-trips a bookmark `Value` without
+interpreting it; only the owning source reads it (`apply_start_bookmark`). A
+sink stores a commit token as an opaque string and never parses it — the token
+may embed a bookmark suffix, which only the pipeline decodes.
+
+**Where.** `StateStore` (`state.rs`), the sink `write_batch_idempotent`
+contracts (`traits.rs`), `format_token`/`parse_token` (`idempotency.rs`).
+
+**If violated.** A backend or sink that interpreted the value would couple to
+connector internals and break the marketplace's connector-independence. See
+[connector SDK](./connector-sdk.md), [extensibility](./extensibility.md).
+
+## I11 — Observability can never fail a run
+
+**Guarantee.** Metrics, spans, lineage emission, and OTLP export are
+best-effort. An export error is logged and counted, never propagated; a panic in
+an instrumented section is isolated (`catch_unwind`) and surfaced as a `Panic`
+error kind, not an aborted process.
+
+**Where.** The decorators in `crates/core/src/observability/`; the lineage
+emitter's swallow-and-count path.
+
+**If violated.** A metrics backend outage could take down data movement — an
+unacceptable coupling. See [observability](./observability.md),
+[standards: logging](../standards/logging.md).
+
+---
+
+## How these compose into delivery guarantees
+
+| Guarantee | Requires | Behaviour on the crash window (I1) |
+|-----------|----------|-------------------------------------|
+| **At-least-once** (default) | nothing | replays the page — may duplicate |
+| **Effectively-once / atomic-watermark** | idempotent sink + deterministic-replay source + durable state + no DLQ | skips or re-anchors the page — no duplication |
+| **Effectively-once / keyed-upsert** | upsert-capable sink + `write_mode: upsert\|delete` + `key` | re-upsert is a no-op — no duplication |
+
+## When you change the write path
+
+If your change touches `run_stream`, ask for each invariant above: *does my
+change preserve it?* If it relaxes one, that is a design decision requiring an
+[ADR](../adr/) or [RFC](../../rfcs/README.md), not a quiet edit. Add a test that
+would fail if the invariant regressed.
+
+## Related
+
+- [ADR 0002 — Checkpoint ordering](../adr/0002-checkpoint-ordering.md) · [ADR 0005 — Runtime recovery](../adr/0005-runtime-recovery.md) · [ADR 0007 — Retries](../adr/0007-retries.md)
+- [Pipeline engine](./pipeline.md) · [Recovery](./recovery.md) · [State management](./state-management.md) · [Retries](./retries.md)
+- [Standards: state & durability](../standards/state.md)
+- [Engineering principles](../engineering-principles.md)

--- a/docs/architecture/masking.md
+++ b/docs/architecture/masking.md
@@ -1,0 +1,96 @@
+# PII masking
+
+*A destination-scoped policy that detects and rewrites sensitive fields before any component observes them.*
+
+## Why it exists
+
+Personally identifiable information must not leak — not to the sink, not to a
+dead-letter queue, not into a lineage sample or a log. The only way to guarantee
+that is to mask *first*, before any other component touches the page. faucet-stream
+therefore runs masking as the very first per-page pass in `run_stream`.
+
+## Problem it solves
+
+- **PII exfiltration through side channels.** A record quarantined by a later
+  quality check would otherwise carry raw PII into the DLQ; a lineage sampler
+  would capture it. Masking-first closes every such channel at once.
+- **Determinism vs secrecy.** Some pipelines need masked values to remain
+  *joinable* across runs (analytics on pseudonymized keys). Keyed HMAC hashing
+  gives determinism; unkeyed hashing gives pseudonymization; both are distinct
+  from redaction.
+
+## Major components
+
+Under `crates/core/src/masking/`:
+
+- `config.rs` — `MaskingSpec`, `MaskRule` (`match`, `action`, `applies_to[]`),
+  `MatchSpec` (`field_pattern` regex over dot-path / `value_detector` /
+  `fields[]`), `Detector` (`email`/`credit_card`/`ssn`/`phone`/`ipv4`),
+  `MaskAction` (`redact` / `hash` / `tokenize` / `partial`).
+- `detect.rs` — conservative, anchored detectors (Luhn for cards; SSN excludes
+  invalid area codes).
+- `hash.rs` — `Hasher` (keyed HMAC-SHA256 or unkeyed SHA-256; `Debug` never prints
+  the key).
+- `compile.rs` — `CompiledMasking::compile` (all rules) and
+  `compile_for_sink(spec, &[ids])` (drops rules whose non-empty `applies_to`
+  names none of the sink's ids, still validating every rule).
+- `mod.rs` — `apply_masking(page, &m) -> MaskingOutcome { records, hits }`
+  (infallible depth-first dot-path walk; first matching rule wins per field).
+
+## Execution flow
+
+```mermaid
+flowchart TD
+    PG[StreamPage records] --> MASK[apply_masking — FIRST pass]
+    MASK --> Q[quality]
+    Q --> C[contract]
+    C --> D[drift]
+    D --> SNK[sink]
+    MASK -.masked records also feed.-> DLQ[DLQ envelopes]
+    MASK -.and.-> LIN[lineage sample]
+```
+
+Because masking runs first, every downstream observer — sink, DLQ, lineage — sees
+only masked values.
+
+## Invariants
+
+- **Masking runs first, unconditionally.** Wired via `Pipeline::with_masking` /
+  `RunStreamOptions::with_masking` ahead of quality/contract/drift and every write.
+- **Key-preserving and value-only.** It never adds/removes fields and never
+  reorders keys, so downstream quality/contract checks remain meaningful over the
+  masked data.
+- **Never quarantines or fails → no DLQ gate.** Unlike quality/contract
+  quarantine, masking cannot route a record away, so it imposes no DLQ requirement.
+- **Determinism is preserved.** Keyed hash/tokenize produce stable outputs, so
+  masked keys stay joinable; per-key uniqueness and non-null-ness are preserved
+  (null is never masked).
+- **The key comes from secrets, resolved before masking.** The masking pass runs
+  after the secrets-interpolation pass, so a `${vault:…}` key is available.
+
+## Trade-offs
+
+- **Scalar-only actions coerce number/bool to string** (a masked value is
+  textual); a name-match on a container redacts the whole subtree, which is
+  coarse but safe.
+- **Unkeyed digests are pseudonymization, not secrecy** — recomputable by anyone
+  with the input space. The docs call this out so operators do not mistake it for
+  encryption.
+
+## Failure scenarios
+
+- **A detector false-negative** (a novel PII format) → not masked; detectors are
+  deliberately conservative (anchored, Luhn-checked) to avoid mangling non-PII,
+  so the mitigation is an explicit `field_pattern`/`fields[]` rule.
+- **Empty rule / bad regex** → `FaucetError::Config` at compile.
+
+## Future evolution
+
+- Additional detectors (IBAN, passport) and format-preserving encryption as a
+  fourth action class.
+
+## Related
+
+- [Schema handling](./schema.md) · [Quality](./quality.md) · [Contracts](./contracts.md)
+- [Pipeline](./pipeline.md) · [Design invariants](./invariants.md)
+- User guide: [../book/src/cookbook/masking.md](../book/src/cookbook/masking.md)

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -1,0 +1,127 @@
+# Observability
+
+*How every pipeline emits tracing spans and metrics automatically, without per-connector code.*
+
+## Why it exists
+
+A data-movement tool is only trustworthy if operators can answer "is it moving,
+how fast, and where did it stall?" without reading source. faucet-stream treats
+observability as a property of the *runtime*, not of each connector: the moment
+a connector is dropped into a `Pipeline`, it is wrapped in instrumentation that
+emits a uniform metric and span vocabulary. This keeps the [connector
+SDK](./connector-sdk.md) minimal (a connector author writes I/O, not telemetry)
+while guaranteeing that a third-party `faucet-source-foo` is exactly as
+observable as a built-in one.
+
+## Problem it solves
+
+- **No telemetry drift between connectors.** If each connector emitted its own
+  metrics, names and label sets would diverge and dashboards would rot. A single
+  decorator layer forces one schema.
+- **Zero-cost to connector authors.** The `Source`/`Sink` traits carry no
+  metrics methods; authors only override `connector_name()` for a friendly
+  label.
+- **Cardinality safety by construction.** High-cardinality identifiers (run ids,
+  record ids, URLs) must never become Prometheus labels. The decorators decide
+  what is a label and what is a span attribute, so an author cannot accidentally
+  explode series count.
+
+## Major components
+
+All live under `crates/core/src/observability/`:
+
+| Module | Role |
+|---|---|
+| `source.rs` / `sink.rs` | `InstrumentedSource` / `InstrumentedSink` wrap a connector and time every page fetch / batch write. |
+| `state.rs` | `InstrumentedStateStore` times `get`/`put`/`delete` and records hit/miss. |
+| `transform.rs` | `instrumented_apply_stages` counts records in/out per page. |
+| `pipeline.rs` | Run-level counters, in-flight gauge, run-duration histogram, bookmark-lag gauges. |
+| `resilience.rs` | Retry / circuit-breaker / poison-pill counters (see [resilience](./resilience.md)). |
+| `otel.rs` | OTLP export lifecycle (`OtelConfig`, `init_otel_provider`, `OtelErrorCountLayer`); gated on the `otel` feature. |
+
+`Pipeline::run` (`crates/core/src/pipeline.rs`) constructs a `Labels` value once
+and threads it through `InstrumentedSource::new`, `InstrumentedSink::new`, and
+`InstrumentedStateStore::new`, so a single identity is shared across the whole
+run.
+
+## Execution flow
+
+```mermaid
+flowchart TD
+    subgraph run["Pipeline::run"]
+        L[Build Labels: pipeline, row, run_id] --> WS[Wrap source/sink/state]
+        WS --> SP[stream_pages]
+    end
+    SP --> P{page}
+    P -->|records| SRC[faucet_source_records_total<br/>faucet_source_page_duration_seconds]
+    P --> TR[transform: records_in/out_total]
+    TR --> QCD[quality / contract / drift counters]
+    QCD --> SNK[faucet_sink_records_total<br/>faucet_sink_write_duration_seconds]
+    SNK --> FL[faucet_sink_flush_duration_seconds]
+    FL --> ST[faucet_state_put_total<br/>faucet_state_put_duration_seconds]
+    ST --> RUN[faucet_pipeline_runs_total<br/>faucet_pipeline_run_duration_seconds]
+```
+
+Every measured operation is also wrapped in a `tracing` span
+(`faucet.pipeline.run`, `faucet.source.*`, etc.). Spans carry the high-cardinality
+attributes (`run_id`, `parent_record_key`) that must not be metric labels.
+
+## Invariants
+
+- **Common labels are exactly `pipeline`, `row`, `connector`.** `row` is `""`
+  for non-matrix runs; Prometheus treats an empty label as absent.
+- **`run_id` is a span attribute only, never a metric label.** Same for
+  `parent_record_key` in parent/child matrices. This is the single most
+  important cardinality rule.
+- **`connector_name()` must return a non-empty `&'static str`.** Empty strings
+  fall back to `"unknown"` in release builds and trip a `debug_assert!` in debug.
+- **Timers are drop-guards.** `DurationGuard` samples on `Drop`, so a duration is
+  recorded even when the run is cancelled mid-await.
+- **Panics are isolated, not swallowed silently.** A connector panic is caught
+  via `AssertUnwindSafe.catch_unwind()` and surfaced as the `Panic` error kind
+  rather than aborting the process.
+- **`install_observability` is idempotent.** A second attempt to install a
+  recorder/subscriber warns rather than panicking.
+
+## Trade-offs
+
+- **A fixed label schema limits per-connector custom metrics.** Connector-specific
+  detail belongs in span attributes or connector-side logging, not new labels —
+  the price of guaranteed dashboard portability.
+- **The decorator adds one indirection per page.** This is negligible against
+  network/DB I/O and buys uniform telemetry; the hot per-record path is untouched
+  (instrumentation is per-page, not per-record).
+- **Metrics fan out to both Prometheus and OTLP when both are configured.** Export
+  failures on the OTLP side are non-fatal (`faucet_otel_export_failures_total`)
+  and never propagate into the pipeline.
+
+## Failure scenarios
+
+- **Metrics endpoint port in use / malformed listen address** → typed
+  `CliError::Observability`, surfaced before any run starts.
+- **OTLP collector unreachable** → export errors counted, pipeline continues; a
+  dropped span/metric is never a data-movement failure.
+- **Recorder already installed** (e.g. embedded in a host process) → warn and
+  reuse, so faucet-as-a-library does not fight the host's telemetry stack.
+
+## Future evolution
+
+- Exemplar linking (trace-id on histogram buckets) once the OTLP stack supports
+  it stably on the pinned 0.31 line.
+- A `build_info`-style gauge already exists (`faucet_build_info{version}`); the
+  direction is more such annotation gauges for `group_left` joins rather than
+  more dynamic labels.
+
+## Related modules
+
+The full metric catalog (every counter/histogram and its labels) is maintained
+in `.claude/rules/architecture.md` under "Observability" — that is the source of
+truth; this page explains the model, not the exhaustive list.
+
+## Related
+
+- [Pipeline](./pipeline.md) · [Execution](./execution.md) · [Resilience](./resilience.md)
+- [State management](./state-management.md) · [Design invariants](./invariants.md)
+- [ADR 0008 — Observability](../adr/0008-observability.md)
+- [Logging standard](../standards/logging.md)
+- User guide: [../book/src/operations/observability.md](../book/src/operations/observability.md)

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,110 @@
+# Architecture overview
+
+*The whole system on one page: crate topology, the data path, and the layering that keeps the core lean.*
+
+## Why faucet-stream exists
+
+faucet-stream moves data between systems — REST APIs, databases, object stores,
+message queues, warehouses — declaratively, from a YAML/JSON config, with no Rust
+code required to run a pipeline. Its stated Primary Goal is that
+**every source and sink is as fast, efficient, and reliable as possible**;
+reliability and correctness are not features layered on top, they are the reason
+the library exists. That goal drives every architectural decision documented here.
+
+## The data path
+
+A run is, at its heart, one loop: pull a page of records from a source, protect
+and validate it, write it to a sink, checkpoint, repeat.
+
+```mermaid
+flowchart LR
+    subgraph Source
+      SP[stream_pages]
+    end
+    subgraph Core[faucet-core pipeline]
+      MK[mask] --> QL[quality] --> CT[contract] --> DR[drift] --> WR[write]
+      WR --> FL[flush] --> CK[checkpoint]
+    end
+    subgraph Sink
+      WB[write_batch]
+    end
+    subgraph State
+      SS[(StateStore)]
+    end
+    SP -->|StreamPage| MK
+    WR --> WB
+    CK --> SS
+    SS -.resume bookmark.-> SP
+```
+
+The per-page passes and their fixed order are covered in [schema](./schema.md);
+the loop itself in [pipeline](./pipeline.md); the streaming model in
+[stream-pages](./stream-pages.md).
+
+## Crate topology
+
+The workspace is a Cargo workspace of 63 crates (62 libraries + the `faucet` CLI
+binary). The topology encodes a hard rule: **connectors depend only on
+`faucet-core`.**
+
+```mermaid
+flowchart TD
+    CORE[faucet-core<br/>traits, pipeline, transforms, error, state]
+    SRC[faucet-source-*<br/>rest, postgres, kafka, s3, ...]
+    SNK[faucet-sink-*<br/>bigquery, jsonl, iceberg, ...]
+    CMN[faucet-common-*<br/>shared source+sink config]
+    STATE[faucet-state-*<br/>redis, postgres]
+    UMB[faucet-stream<br/>umbrella re-exports]
+    CLI[faucet-cli<br/>config runtime, serve, schedule]
+
+    SRC --> CORE
+    SNK --> CORE
+    CMN --> CORE
+    STATE --> CORE
+    SRC -.uses.-> CMN
+    SNK -.uses.-> CMN
+    UMB --> SRC & SNK & STATE
+    CLI --> UMB
+```
+
+- **`faucet-core`** — the only crate every connector depends on. Holds the
+  `Source` / `Sink` / `StateStore` / `AuthProvider` traits, the pipeline engine,
+  transforms, the schema/quality/contract/masking/drift passes, resilience, and
+  `FaucetError`. Kept intentionally lean (see [ADR 0010](../adr/0010-pipeline-runtime.md)).
+- **connector crates** (`faucet-source-*`, `faucet-sink-*`) — one external system
+  each; the only place that performs protocol I/O.
+- **`faucet-common-*`** — shared config types for a source+sink pair of the same
+  system (auth, formats, TLS). See [extensibility](./extensibility.md).
+- **state backends** — heavier `StateStore` implementations (Redis, Postgres) live
+  in their own crates so `faucet-core` stays dependency-light.
+- **`faucet-cli`** — the config-driven runtime: `run`, `validate`, `schema`,
+  `serve`, `schedule`, `replicate`, `backfill`, and the matrix DAG executor.
+
+The full crate table lives in `.claude/rules/architecture.md`.
+
+## Layering: why orchestration lives above the core
+
+`faucet-core` is a *library*, not a runtime. It knows how to move one source to one
+sink and checkpoint safely — nothing about cron, HTTP control planes, matrix
+DAGs, or clustering. Every orchestration concern (scheduling, `serve`, sharded
+execution, snapshot→CDC handoff, backfill windows) is **CLI-layer code built on top
+of `expand` + `executor`**, which in turn drive `Pipeline`. This keeps the core
+embeddable by third parties and keeps orchestration churn out of the crate that 60+
+connectors depend on. See [execution](./execution.md) and
+[ADR 0010](../adr/0010-pipeline-runtime.md).
+
+## The record model
+
+Records are `serde_json::Value` end to end. This maximises connector-author
+ergonomics (any JSON-shaped payload flows without a schema) at the cost of
+per-record allocation and no columnar batching. The trade-off, and the path toward
+Arrow, are in [ADR 0004](../adr/0004-json-record-model.md) and
+[RFC 0002](../../rfcs/0002-arrow-support.md).
+
+## Related
+
+- [Execution model](./execution.md) · [Pipeline engine](./pipeline.md)
+- [Connector SDK](./connector-sdk.md) · [Extensibility](./extensibility.md)
+- [Design invariants](./invariants.md)
+- [ADR 0004 — JSON record model](../adr/0004-json-record-model.md) · [ADR 0010 — Pipeline runtime](../adr/0010-pipeline-runtime.md)
+- User guide: [Core concepts](../book/src/getting-started/concepts.md)

--- a/docs/architecture/performance.md
+++ b/docs/architecture/performance.md
@@ -1,0 +1,94 @@
+# Performance
+
+*Why performance is the reason this project exists, and the concrete disciplines every connector follows.*
+
+## Why it exists
+
+The Primary Goal in `CLAUDE.md` is unambiguous: *all sources and sinks must be as
+fast, efficient, and reliable as possible* — it is the number-one input to every
+architectural decision. faucet-stream aims to be the fastest way to move data
+between two endpoints in Rust. Performance is therefore not a late optimization
+pass; it is a set of standing disciplines encoded in the connector conventions
+and enforced in review.
+
+## Problem it solves
+
+Naïve connectors leak throughput in predictable ways: recreating clients per
+call, one INSERT per row, serial I/O, unbuffered writes. Rather than optimize
+these case-by-case, the project fixes them as *conventions* so every connector —
+built-in or third-party — starts fast.
+
+## The disciplines (from `.claude/rules/connectors.md`)
+
+| Discipline | Rule | Where |
+|---|---|---|
+| **Reuse clients/connections** | Build HTTP/S3/DB clients in `new()`, store in the struct; never per-call. | every connector's `stream.rs`/`sink.rs` |
+| **Connection pooling** | Configurable `max_connections` (default 10 source / 5 sink). | SQL sources/sinks |
+| **Multi-row INSERT** | `INSERT … VALUES (…),(…),…`, never one INSERT per record. | SQL sinks |
+| **Transaction wrapping** | Batches in `BEGIN`/`COMMIT`. | SQLite sink |
+| **Parallel I/O** | `buffer_unordered(concurrency)` for concurrent object reads/writes; semaphore-bounded HTTP fan-out. | S3/GCS/Parquet/HTTP |
+| **Bulk APIs** | Elasticsearch `_bulk`, BigQuery `insertAll`, Mongo `insert_many`, Redis pipelines. | applicable sinks |
+| **Buffered I/O** | Buffered writers; CSV uses `spawn_blocking` to keep the async runtime unblocked. | file sinks |
+| **Configurable concurrency** | Expose `concurrency` / `max_connections` with sane defaults. | all |
+
+These are the same rules the [connector SDK](./connector-sdk.md) and the
+[performance standard](../standards/performance.md) hold authors to.
+
+## The memory model
+
+Throughput is bounded by the [batching](./batching.md) model: memory is
+**O(batch_size)**, not O(total records), because only one [page](./stream-pages.md)
+is resident at a time. This is what lets a connector be both fast *and* safe on
+arbitrarily large datasets — the two are not in tension here.
+
+## Where the cost actually is
+
+The dominant per-record cost in the current design is the record model itself:
+records are `serde_json::Value` (see [ADR 0004](../adr/0004-json-record-model.md)),
+which allocates per field and per string. For I/O-bound connectors (the common
+case) this is dwarfed by network/DB latency, and the paging + bulk-API disciplines
+keep it off the hot path. For CPU-bound, high-fan-in transforms it is the ceiling.
+
+The evidence-backed direction to raise that ceiling is a columnar record model —
+an Arrow-native page — which would make transforms and (de)serialization
+zero-copy for connectors that already speak Arrow (Parquet, Arrow Flight,
+DuckDB). That is deliberately an [RFC](../../rfcs/0002-arrow-support.md), not an
+in-place rewrite, because it touches the one type every connector shares.
+
+## Invariants
+
+- **No per-call client construction** — a reviewable, testable rule (offline
+  `connect_lazy` pool tests exist precisely so this is checkable).
+- **No unbounded buffering** — `validate_batch_size` enforces the cap.
+- **Optimize with evidence.** The benchmark harness (`BENCHMARKS.md`, `scripts/`)
+  exists so a claimed speedup is measured, not asserted; `CLAUDE.md` forbids
+  optimizing code without evidence.
+
+## Trade-offs
+
+- **`serde_json::Value` costs allocations** but keeps the connector SDK trivial
+  (one dependency, no schema ceremony) — a chosen trade in favour of ecosystem
+  friendliness. See [extensibility](./extensibility.md).
+- **Bulk/pooled paths add code** vs a naïve loop, justified by throughput on the
+  hot path.
+
+## Failure scenarios
+
+- **A connector that recreates its client per page** silently caps throughput;
+  caught in review against these conventions, and often visible as inflated
+  `faucet_source_page_duration_seconds`.
+- **A page sized beyond a sink's request limit** — a batching concern; see
+  [batching](./batching.md).
+
+## Future evolution
+
+- Arrow-native pages / zero-copy execution ([RFC 0002](../../rfcs/0002-arrow-support.md)).
+- A standing, tracked benchmark suite gating regressions in CI (see
+  [roadmap](./roadmap.md)).
+
+## Related
+
+- [Batching](./batching.md) · [Stream pages](./stream-pages.md) · [Connector SDK](./connector-sdk.md)
+- [Performance standard](../standards/performance.md) · [Contributing: performance](../contributing/performance.md)
+- [ADR 0004 — JSON record model](../adr/0004-json-record-model.md) · [RFC 0002 — Arrow support](../../rfcs/0002-arrow-support.md)
+- Benchmarks: [../../BENCHMARKS.md](../../BENCHMARKS.md)

--- a/docs/architecture/pipeline.md
+++ b/docs/architecture/pipeline.md
@@ -1,0 +1,113 @@
+# Pipeline engine
+
+*The `Pipeline` / `run_stream` core: one page-at-a-time loop that owns the write→flush→checkpoint contract.*
+
+## Why it exists
+
+`Pipeline` is the single place where a source, a sink, a state store, and the
+protection/validation passes are wired together and driven. Concentrating this in
+one function (`run_stream`, `crates/core/src/pipeline.rs`) means the
+data-integrity ordering is written **once** and every connector inherits it — no
+connector can get checkpointing wrong because no connector implements it.
+
+## Major components
+
+- **`Pipeline<'a, So, Si>`** — a builder over borrowed `&Source` / `&Sink`
+  (object-safe, so `Box<dyn Source>` works). Configured progressively with
+  `with_state_store`, `with_dlq`, `with_quality`, `with_contract`, `with_masking`,
+  `with_schema_drift`, `with_resilience`, `with_delivery`, `with_cancel`,
+  `with_adaptive`. See [ADR 0003](../adr/0003-builder-pattern.md).
+- **`Pipeline::run`** — resolves run identity (name/row/run_id), wraps the source,
+  sink, and state store in observability decorators, performs bookmark resume, then
+  hands off to `run_stream`.
+- **`run_stream`** — the free function that drives the page loop. Also callable
+  directly by library authors who already have a `Stream<StreamPage>`.
+- **`RunStreamOptions`** — the option bag carrying everything the loop needs
+  (state, dlq, quality, contract, masking, drift, resilience, delivery, cancel).
+- **`StreamPage { records, bookmark }`** / **`PipelineResult`** — the unit of work
+  and the run summary. See [stream-pages](./stream-pages.md).
+
+## Execution flow
+
+```mermaid
+flowchart TD
+    START[Pipeline::run] --> RESUME[resume: read bookmark, apply_start_bookmark]
+    RESUME --> SINKANCHOR[exactly-once: re-anchor from sink watermark]
+    SINKANCHOR --> LOOP{next page?}
+    LOOP -->|cancelled| FLUSHOUT[flush + return partial]
+    LOOP -->|Some page| MASK[mask → quality → contract → drift]
+    MASK --> PATH{write path}
+    PATH -->|DLQ| WDLQ[write_batch_partial + route failures]
+    PATH -->|exactly-once| WEO[write_batch_idempotent skip-if-committed]
+    PATH -->|default| WDEF[write_batch]
+    WDLQ & WEO & WDEF --> BM{page has bookmark?}
+    BM -->|yes| FLUSH[flush → checkpoint]
+    BM -->|no| LOOP
+    FLUSH --> LOOP
+    LOOP -->|None| DONE[flush + PipelineResult]
+```
+
+### The three write paths
+
+`run_stream` branches on configuration into three mutually exclusive paths, each
+of which preserves the checkpoint-ordering invariant:
+
+1. **DLQ path** — `write_batch_partial` splits per-row successes from failures;
+   failures are enveloped and routed to the DLQ sink; then flush + checkpoint. A
+   deferred abort (DLQ budget, circuit breaker, drift-`fail`) fires *after* the page
+   is durable so nothing is stranded.
+2. **Exactly-once path** — issues a monotonic commit token per bookmark-carrying
+   page (`format_token_with_bookmark`), skips the write if the sink's committed seq
+   is already ≥ the page's (idempotent replay), else `write_batch_idempotent`; then
+   flush + `wrap_state(bookmark, seq)` checkpoint. See [recovery](./recovery.md).
+3. **Default path** — `write_batch`, then (on a bookmark-carrying page) flush +
+   checkpoint. This is the at-least-once baseline.
+
+## Invariants
+
+- **Write → flush → checkpoint, always.** In all three paths the bookmark is
+  persisted only after `write_batch*` and `flush()` both return `Ok`. This is *the*
+  data-integrity invariant — see [invariants](./invariants.md) and
+  [ADR 0002](../adr/0002-checkpoint-ordering.md).
+- **Empty, bookmark-less pages are skipped** (`records.is_empty() && bookmark.is_none()`).
+- **A bookmark-less page is written but not checkpointed** — it stays at-least-once
+  for that page (rare; CDC sources bookmark every committed transaction).
+- **Every early exit flushes.** The loop runs inside an inner future; a source
+  error, a propagated write/flush/state error, or a cancellation all fall through to
+  a best-effort final flush, so a buffered sink (Parquet footer, S3 multipart)
+  commits what it has rather than orphaning the file.
+- **Masking runs first, unconditionally**, before any sink, the DLQ, or a lineage
+  sample observes the records. See [masking](./masking.md).
+
+## Trade-offs
+
+- **One page in memory at a time** bounds memory at `O(batch_size)` but ties
+  throughput to page size and sink round-trip latency (mitigated by
+  [adaptive batching](./batching.md) and sink-side bulk APIs).
+- **Fixed pass order** removes a config knob but eliminates PII-leak and
+  bad-row-written bug classes. See [schema](./schema.md).
+- **A single hot loop** keeps the contract in one place but means new cross-cutting
+  behaviour (a new pass) is a change to `run_stream` itself — reviewed with care.
+
+## Failure scenarios
+
+- **Crash between flush and checkpoint** → at-least-once replays the page;
+  exactly-once skips it via the committed token. No data loss either way; only
+  at-least-once risks duplicates. See [recovery](./recovery.md).
+- **Sink commits server-side but the response is lost, then a retry fires** →
+  duplication, unless the sink is idempotent. The retry layer refuses to retry a
+  non-idempotent `write_batch` for exactly this reason — see [retries](./retries.md).
+- **A validation pass aborts** → `contract: fail` writes nothing from the page;
+  `drift: fail` defers until survivors are durable.
+
+## Future evolution
+
+- Batch-level parallelism across sinks without breaking per-page ordering.
+- A columnar page type behind the same loop ([RFC 0002](../../rfcs/0002-arrow-support.md)).
+
+## Related
+
+- [Stream pages](./stream-pages.md) · [Batching](./batching.md) · [State management](./state-management.md)
+- [Recovery](./recovery.md) · [Retries](./retries.md) · [Schema](./schema.md)
+- [Design invariants](./invariants.md)
+- [ADR 0002 — Checkpoint ordering](../adr/0002-checkpoint-ordering.md) · [ADR 0003 — Builder pattern](../adr/0003-builder-pattern.md)

--- a/docs/architecture/quality.md
+++ b/docs/architecture/quality.md
@@ -1,0 +1,89 @@
+# Data quality
+
+*Per-record and per-batch checks that quarantine or abort bad data before it reaches a sink.*
+
+## Why it exists
+
+Silent downstream corruption is the worst class of bug this project recognizes:
+a malformed record that lands in a warehouse is far more expensive than a loud
+failure. The quality subsystem lets a pipeline declare invariants about its data
+and choose what happens when a record violates them — drop it to a dead-letter
+queue, or abort the run — *before* the sink writes anything.
+
+## Problem it solves
+
+- **Bad data reaching the destination.** Checks run after transforms and before
+  the sink, so a violating record is caught at the last safe moment.
+- **All-or-nothing failure.** Not every bad row should kill a run; `quarantine`
+  isolates the offenders and lets the rest flow, while `abort` stops on the first
+  breach when correctness demands it.
+- **Late failure.** Compilation is fail-fast: bad regexes, invalid JSON Schemas,
+  out-of-range bounds all surface at config-load, never mid-run.
+
+## Major components
+
+Under `crates/core/src/quality/`:
+
+- `QualitySpec` / `RecordCheck` / `BatchCheck` / `OnFailure` — config types.
+- `CompiledQuality::compile` — fail-fast compilation; `requires_dlq()` reports
+  whether any check uses a quarantine action.
+- `apply_quality` → `QualityOutcome { survivors, quarantined }` + `CheckTally`.
+- Feature-gated: `quality` (base checks) and `quality-jsonschema` (adds the
+  `json_schema` record check).
+
+## Execution flow
+
+```mermaid
+flowchart TD
+    PG[page records] --> RC[per-record checks, declared order, first-failure-wins]
+    RC -->|pass| SUR[survivors]
+    RC -->|fail quarantine| DLQ[DLQ envelope, DlqReason::Quality]
+    RC -->|fail abort| ERR[FaucetError::QualityFailure]
+    SUR --> BC[per-batch checks over survivors]
+    BC -->|unique dup quarantine| DLQ
+    BC -->|row_count/null_rate abort| ERR
+    BC -->|pass| WR[sink write_batch]
+```
+
+Runs inside `run_stream` after the masking pass and before the contract pass (see
+[schema](./schema.md) for the full ordering). Surviving records flow to the sink
+and the bookmark advances only after the sink confirms — an `abort` never commits
+partial progress.
+
+## Invariants
+
+- **Per-record before per-batch.** Aggregate checks (`row_count`, `null_rate`,
+  `distinct_count`, `unique`) run over the *survivor* slice, not the raw page.
+- **`quarantine` requires a DLQ.** `requires_dlq()` is checked at config-load and
+  again at run start; a quarantine action without a `dlq:` block is a
+  `FaucetError::Config`, never a silent drop.
+- **First-failure-wins per record**, checks evaluated in declared order — the
+  envelope records the specific failed check.
+- **`abort` writes nothing from the page** and does not advance the bookmark.
+
+## Trade-offs
+
+- **Per-page semantics.** A `unique`/`distinct_count` check sees one page at a
+  time, not the whole stream. Global uniqueness needs `batch_size: 0` (whole
+  result set in one page) — a deliberate consequence of the streaming model.
+- **Checks add a per-page pass**, negligible against I/O, and only when a spec is
+  attached.
+
+## Failure scenarios
+
+- **Invalid check config** (bad regex, out-of-range bound) → rejected at compile,
+  before any data moves.
+- **Quarantine flood** — if most rows fail, the DLQ absorbs them; the DLQ budget
+  (see [pipeline](./pipeline.md)) can still abort the run as a circuit breaker,
+  but only after the current page is durable.
+
+## Future evolution
+
+- Streaming-window aggregate checks (cross-page uniqueness without
+  `batch_size: 0`), which would require carrying check state across pages.
+
+## Related
+
+- [Schema handling](./schema.md) · [Contracts](./contracts.md) · [Pipeline](./pipeline.md)
+- [Design invariants](./invariants.md) · [ADR 0009 — Schema validation](../adr/0009-schema-validation.md)
+- User guide: [../book/src/cookbook/quality.md](../book/src/cookbook/quality.md)

--- a/docs/architecture/recovery.md
+++ b/docs/architecture/recovery.md
@@ -1,0 +1,125 @@
+# Recovery
+
+*What happens after a crash — the checkpoint contract, sink-anchored resume, and orphan recovery.*
+
+## Why it exists
+
+Any long-running data movement will be interrupted — a deploy, an OOM, a network
+partition, a killed pod. The question is not *whether* a run dies mid-flight but
+*what state it leaves behind*. faucet-stream's recovery design guarantees the worst
+outcome is a bounded, well-understood re-delivery — never silent data loss and
+never silent corruption.
+
+## The two crash windows
+
+A page moves through: `write_batch` → `flush` → `StateStore::put`. A crash can land
+in one of two windows:
+
+```mermaid
+flowchart LR
+    W[write_batch] -->|window A| F[flush] -->|window B| P[put bookmark]
+    P --> NEXT[next page]
+```
+
+- **Window A — crash before flush.** The write may or may not be durable
+  (sink-dependent). The bookmark was not advanced, so the next run replays the page.
+- **Window B — crash after flush, before checkpoint.** The sink is durable but the
+  state store is one page behind. The next run replays a page the sink already has.
+
+Both windows resolve to **re-delivery of at most one page**, never loss. The
+delivery mode decides what re-delivery costs.
+
+## Recovery by delivery mode
+
+### At-least-once (default)
+
+On resume, `Pipeline::run` reads the stored bookmark and calls
+`apply_start_bookmark` on the source. Window-B pages are replayed and re-written.
+Duplicates are possible and acceptable — that is the definition of at-least-once.
+The retry layer refuses to retry a non-idempotent `write_batch` so retries never
+*add* duplicates beyond this bounded window (see [retries](./retries.md)).
+
+### Exactly-once — sink-anchored resume (#291)
+
+The problem with a naïve exactly-once resume is that it assumes the source replays
+*identical page boundaries*. Log-positional sources like Kafka cannot promise that.
+faucet-stream solves this by making the **sink's committed watermark the source of
+truth for position**:
+
+```mermaid
+sequenceDiagram
+    participant SS as StateStore
+    participant Snk as Sink (watermark)
+    participant P as Pipeline
+    participant Src as Source
+    Note over P: resume after crash in window B
+    P->>SS: get → (bookmark, seq=N)
+    P->>Snk: last_committed_token(scope)
+    Snk-->>P: token(seq=N+1, embedded bookmark B')
+    Note over P: sink is ahead of state store
+    P->>Src: apply_start_bookmark(B')
+    Note over P: re-anchor to the exact committed position
+```
+
+Each exactly-once commit token embeds the page's resume bookmark
+(`format_token_with_bookmark`, `crates/core/src/idempotency.rs`). On resume the
+pipeline reads `Sink::last_committed_token`, and if the sink's sequence is ahead of
+the state store, it re-anchors the source to the **embedded** bookmark and
+fast-forwards the sequence. Nothing is re-written, and nothing depends on the
+source reproducing the same page boundaries. This is exactly what qualifies the
+Kafka source for exactly-once. Legacy bare tokens (no embedded bookmark) fall back
+to the count-based skip path, where a page whose seq ≤ committed is skipped. See
+[ADR 0005](../adr/0005-runtime-recovery.md).
+
+## Orphan recovery in `faucet serve`
+
+A clustered/persistent `serve` deployment adds a second recovery concern: a run
+owned by a process that died. The SQL run-history backend stamps each non-terminal
+run with an `owner` (a per-process UUID `instance_id`) and a `lease_expires_at`. A
+lease loop heartbeats this instance's own runs; a run is marked failed **only when
+its owner's lease has expired**. This instance-fencing (#146 H7) means a starting or
+running instance never fails a live peer's in-flight runs on a shared database.
+
+## Invariants
+
+- **No bookmark is ever ahead of a durable write.** The write→flush→checkpoint
+  ordering guarantees the state store is always equal to or behind the sink, never
+  ahead. Recovery therefore only ever *replays*, never *skips unwritten data*.
+- **Re-delivery is bounded to one page.** The unit of potential replay is a single
+  `StreamPage`.
+- **Exactly-once re-delivery is a no-op.** A replayed token-stamped write is skipped
+  or idempotently re-applied; the observable effect is zero.
+- **Cancellation flushes.** A cooperative cancel (`with_cancel`) stops at a page
+  boundary and flushes, so a clean shutdown leaves a durable, checkpointed position
+  — not a torn buffer.
+
+## Trade-offs
+
+- **At-least-once accepts duplicates** in exchange for working with *any* source and
+  sink and requiring no watermark table.
+- **Exactly-once requires** a deterministic-replay source *or* a keyed-upsert sink, a
+  durable state store, and no DLQ — a deliberately narrow, verifiable contract
+  enforced at config-load (see [pipeline](./pipeline.md) and
+  [invariants](./invariants.md)).
+
+## Failure scenarios
+
+- **State store lost entirely** → the run restarts from the source's beginning (or
+  its own natural bookmark). At-least-once re-delivers; exactly-once with a durable
+  sink watermark still de-duplicates via `last_committed_token`.
+- **Sink watermark and state store disagree** → the sink wins (it is the durable
+  record of what was actually committed); the source is re-anchored to it.
+- **`serve` instance killed mid-run** → the lease expires, a peer marks the run
+  failed, and a resubmit (same idempotency key) replays it safely.
+
+## Future evolution
+
+- Extending sink-anchored resume to more sinks as their watermark storage matures.
+- A recovery-simulation test harness (fault injection at each window) as a
+  first-class CI job.
+
+## Related
+
+- [State management](./state-management.md) · [Retries](./retries.md) · [Pipeline engine](./pipeline.md)
+- [Design invariants](./invariants.md)
+- [ADR 0005 — Runtime recovery](../adr/0005-runtime-recovery.md) · [ADR 0002 — Checkpoint ordering](../adr/0002-checkpoint-ordering.md)

--- a/docs/architecture/resilience.md
+++ b/docs/architecture/resilience.md
@@ -1,0 +1,102 @@
+# Resilience
+
+*The unified policy that composes retry, circuit breaking, and poison-pill handling into one declarative block.*
+
+## Why it exists
+
+Retry alone is not resilience. A dependency that is *down* (not merely flaky) should
+not be hammered with retries; a single record that can never be written should not
+wedge a whole pipeline forever. faucet-stream unifies three complementary
+mechanisms — **retry**, a **circuit breaker**, and a **poison-pill** policy — behind
+one opt-in `resilience:` config block so an operator reasons about failure handling
+in a single place. The subsystem lives in `crates/core/src/resilience/`.
+
+## Major components
+
+- **`classify.rs`** — maps a `FaucetError` to a closed `RetryClass`
+  (`Http5xx` / `RateLimited` / `Connection` / `Timeout`) and a `RetryClassSet`. This
+  is the vocabulary the whole policy is expressed in.
+- **`policy.rs`** — the config types: `RetryPolicy`, `BackoffKind`,
+  `CircuitBreakerConfig`, `PoisonPolicy`, `PoisonAction`, and the umbrella
+  `ResiliencePolicy`.
+- **`breaker.rs`** — `CircuitBreaker`, a consecutive-failure counter.
+- **`execute.rs`** — `execute_with_policy[_metered]`, the retry+backoff runner gated
+  on the class set, jitter, and cancel-aware sleeps. This is what
+  [retries](./retries.md) drives.
+
+No Cargo feature gates it — resilience is always compiled; it is simply inert when
+no `resilience:` block is configured.
+
+## How the three mechanisms compose
+
+```mermaid
+flowchart TD
+    OP[sink write / flush / state_put] --> RETRY{retriable class?}
+    RETRY -->|yes| BACKOFF[backoff + jitter, retry up to max_attempts]
+    BACKOFF --> RETRY
+    RETRY -->|exhausted| FAILPAGE[page fails]
+    FAILPAGE --> CB{consecutive failures ≥ threshold?}
+    CB -->|yes| OPEN[CircuitOpen error → abort run]
+    CB -->|no| CONT[continue]
+    ROW[single bad row] --> POISON{poison policy}
+    POISON -->|dlq| Q[route row to DLQ]
+    POISON -->|skip| DROP[drop row + warn]
+```
+
+- **Retry** handles transient, self-healing failures (see [retries](./retries.md)).
+- **The circuit breaker** counts *consecutive fully-failed pages*; on trip it raises
+  `FaucetError::CircuitOpen { failures, cooldown }` and aborts — the signal that the
+  dependency is down, not flaky, and retrying further is futile.
+- **The poison-pill policy** handles a single row that repeatedly fails, routing it
+  to the DLQ (`action: dlq`, which requires a `dlq:` block) or dropping it with a
+  one-shot warning, so one bad record cannot wedge the pipeline.
+
+## Where it wires in
+
+- **Sink side** — `run_stream` wraps `write_batch*` / `flush` / `state_put` via the
+  `with_retry!` macro and holds the `CircuitBreaker`.
+- **Source side** — the `retry` sub-policy is injected into the HTTP sources
+  (`rest`, `xml`, `graphql`) via `Source::with_retry_policy`.
+
+## Invariants
+
+- **The circuit counts consecutive failures**, resetting on the first success — so a
+  pipeline that fails intermittently but makes progress never trips.
+- **`poison.action: dlq` requires a DLQ**, validated at config-load, never
+  discovered mid-run.
+- **Cooldown is advisory for `faucet schedule`** (it delays the next cron tick); an
+  already-queued `overlap: queue` run is not delayed.
+- **The duplication-safety rule from [retries](./retries.md) is preserved** — the
+  circuit and poison layers never cause a non-idempotent write to be retried.
+
+## Trade-offs
+
+- **Fully opt-in.** With no `resilience:` block, sink writes are not retried and
+  sources keep their built-in defaults. This preserves the simplest possible default
+  behaviour and makes the failure model explicit only when an operator asks for it.
+- **Consecutive-failure breaker** (vs. an error-rate window) is simple and
+  predictable but can trip late under a low, steady error rate — an acceptable trade
+  for a mechanism whose job is to detect a *hard down*, not a degraded, dependency.
+- **REST field precedence** — REST's legacy `max_retries` / `retry_backoff` win when
+  explicitly set; only `max_attempts` + `base` of the injected policy apply to REST.
+  See [retries](./retries.md).
+
+## Failure scenarios
+
+- **Dependency hard-down** → retries exhaust per page, consecutive-failure count
+  climbs, breaker opens, run aborts with `CircuitOpen`; the next run resumes from the
+  last durable bookmark.
+- **One malformed row the sink always rejects** → poison policy routes it to the DLQ
+  (or drops it), and the rest of the page proceeds.
+
+## Future evolution
+
+- An error-rate (sliding-window) breaker mode alongside the consecutive-failure one.
+- DLQ-path circuit breaking (the breaker is already threaded for it).
+
+## Related
+
+- [Retries](./retries.md) · [Recovery](./recovery.md) · [Pipeline engine](./pipeline.md)
+- [Observability](./observability.md) (the `faucet_resilience_*` metrics)
+- [ADR 0007 — Retries](../adr/0007-retries.md)
+- User guide: [Resilience cookbook](../book/src/cookbook/resilience.md)

--- a/docs/architecture/retries.md
+++ b/docs/architecture/retries.md
@@ -1,0 +1,115 @@
+# Retries
+
+*Two retry layers, and the one rule that keeps retries from silently duplicating data.*
+
+## Why it exists
+
+Transient failures — a 503, a rate limit, a dropped connection, a timeout — are the
+common case in networked data movement, not the exception. Retrying them turns a
+flaky dependency into a reliable pipeline. But a naïve retry is one of the most
+dangerous things a data tool can do: **retrying a write that already succeeded
+server-side duplicates data**, which is the repository's stated worst bug class
+(silent downstream corruption). The retry design exists to get the upside without
+that downside.
+
+## The two layers
+
+Retries happen in two distinct places, for two distinct reasons:
+
+```mermaid
+flowchart TD
+    subgraph Source side
+      REST[rest / xml / graphql] -->|with_retry_policy| RS[execute_with_retry]
+    end
+    subgraph Sink side
+      RS2[run_stream with_retry! macro] --> WB[write_batch* / flush / state_put]
+    end
+```
+
+1. **Source side** — HTTP sources (`rest`, `xml`, `graphql`) retry their own
+   requests. The `rest` source predates the unified policy and keeps its own
+   `max_retries` / `retry_backoff` plus special `429` / `Retry-After` handling;
+   `xml` / `graphql` use the shared `execute_with_retry` (`crates/core/src/retry.rs`).
+   A `ResiliencePolicy` is injected via `Source::with_retry_policy`.
+2. **Sink side** — `run_stream` wraps every `write_batch*`, `flush`, and
+   `StateStore::put` in a `with_retry!` macro gated on the attached
+   `ResiliencePolicy`. With no policy the macro is a bare `.await`, so the write path
+   is byte-for-byte identical to the un-retried path.
+
+## The duplication-safety rule
+
+This is the single most important line in the retry design (`with_retry_write!` in
+`crates/core/src/pipeline.rs`):
+
+> A non-idempotent `write_batch` is retried **only** when the sink reports
+> `supports_idempotent_writes()`. Otherwise the write falls through to a bare
+> `.await` with no retry.
+
+The reasoning: a bare `write_batch` makes no atomicity promise. If the request
+commits on the server but the response is lost, a pipeline-level retry re-sends
+every row — silent duplication. So faucet-stream *declines to retry* exactly those
+writes. The idempotent exactly-once path (`write_batch_idempotent`) is always safe
+to retry, because a replayed token-stamped write is a no-op. See
+[ADR 0007](../adr/0007-retries.md) and [pipeline](./pipeline.md).
+
+## Backoff and jitter
+
+Retriable errors back off exponentially with jitter (`crates/core/src/retry.rs`):
+
+- **`base * 2^attempt`**, capped at `MAX_BACKOFF` so a large attempt count saturates
+  rather than sleeping unboundedly.
+- **Decorrelated `[0.5, 1.5)` jitter** seeded per-call so concurrent retries in one
+  process draw *different* delays — otherwise they realign and recreate the
+  thundering herd the jitter exists to break.
+- **Cancel-aware sleeps** — a cancellation during a backoff sleep returns the last
+  error promptly so the caller can flush and stop.
+
+## What is retriable
+
+Only errors classified as transient are retried, gated on
+`FaucetError::is_retriable` and the policy's `RetryClass` set
+(`crates/core/src/resilience/classify.rs`): `Http5xx`, `RateLimited`, `Connection`,
+`Timeout`. A `Config`, `Auth`, or `Json` error is not transient and is never
+retried — retrying it would only waste time and delay the real failure.
+
+## Invariants
+
+- **A non-idempotent write is never retried.** (The duplication-safety rule.)
+- **The no-policy path is unchanged.** Attaching no resilience policy leaves the
+  write path allocation-free and identical to the pre-resilience code.
+- **Retries are gated on classification.** Non-transient errors fail fast.
+- **Jitter is per-call random**, never fixed, to avoid synchronised retry storms.
+
+## Trade-offs
+
+- **REST keeps its own retry runner** for back-compat; when its `max_retries` /
+  `retry_backoff` are at defaults the injected policy's `max_attempts` + `base`
+  apply, but `retry_on` / `max` / `jitter` are inert on REST (honoured in full on
+  `xml`/`graphql` and every sink-side write). This asymmetry is a deliberate
+  compatibility concession, documented in [resilience](./resilience.md).
+- **Declining to retry non-idempotent writes** means a transient sink blip aborts
+  the run (to be replayed) rather than silently retrying — the safe default, at the
+  cost of a restart.
+
+## Failure scenarios
+
+- **Sink commits, response lost, retry fires (idempotent sink)** → the re-sent
+  token-stamped write is a no-op; no duplication.
+- **Sink commits, response lost (non-idempotent sink)** → no retry; the run aborts
+  and the page is replayed on the next run (bounded at-least-once duplication).
+- **Persistent 5xx** → retries exhaust `max_attempts`, then the circuit breaker may
+  open — see [resilience](./resilience.md).
+
+## Future evolution
+
+- Folding the bespoke REST retry runner into the unified policy so `retry_on` /
+  `jitter` apply uniformly.
+- Per-sink idempotency hints richer than the current boolean, enabling safe retry of
+  more write shapes ([RFC 0001](../../rfcs/0001-capability-traits.md)).
+
+## Related
+
+- [Resilience](./resilience.md) · [Recovery](./recovery.md) · [Pipeline engine](./pipeline.md)
+- [Design invariants](./invariants.md)
+- [ADR 0007 — Retries](../adr/0007-retries.md)
+- User guide: [Resilience cookbook](../book/src/cookbook/resilience.md)

--- a/docs/architecture/roadmap.md
+++ b/docs/architecture/roadmap.md
@@ -1,0 +1,69 @@
+# Architecture roadmap
+
+*The architectural direction of the runtime and SDK — direction, not dated promises.*
+
+This page tracks where the *architecture* is heading. It is deliberately narrow:
+connector coverage and product features live in the roadmap epic
+([#38](https://github.com/PawanSikawat/faucet-stream/issues/38)) and the
+[community roadmap](../community/roadmap.md); this page is about the shape of the
+core, the SDK, and the record model. The repository-wide phased view is in
+[docs/roadmap.md](../roadmap.md).
+
+## Direction
+
+### Capability traits
+Today, connector capabilities (exactly-once, sharding, discovery, schema
+evolution) are defaulted boolean/methods on the `Source`/`Sink` traits (see
+[extensibility](./extensibility.md)). The direction is to formalize these as
+first-class, composable capability traits with a conformance story, so the
+runtime can reason about a connector's guarantees uniformly and the CLI gates
+become derivations rather than allowlists. Tracked in
+[RFC 0001](../../rfcs/0001-capability-traits.md).
+
+### Arrow-native record model / zero-copy execution
+The record model is `serde_json::Value` ([ADR 0004](../adr/0004-json-record-model.md)),
+which is ideal for SDK simplicity and JSON-shaped sources but allocates per field.
+The direction is an optional columnar (Arrow) page representation so
+Arrow-speaking connectors (Parquet, DuckDB, Arrow Flight) move data zero-copy and
+CPU-bound transforms stop paying JSON allocation. This is an additive path, not a
+replacement — see [performance](./performance.md) and
+[RFC 0002](../../rfcs/0002-arrow-support.md).
+
+### Plugin-system maturity
+Custom connectors are registered by compiling them into a custom CLI via
+`PluginRegistry`. The direction is a dynamic-loading / stable-ABI story so
+connectors can ship independently of a rebuild, without sacrificing the
+object-safe, defaulted-method contract that keeps the ecosystem compatible.
+Tracked in [RFC 0003](../../rfcs/0003-plugin-system.md).
+
+### Streaming-runtime improvements
+The paging model bounds memory but couples checkpoint granularity to page size.
+The direction is finer-grained and byte-aware paging plus richer backpressure
+signalling between source and sink. See
+[RFC 0004](../../rfcs/0004-streaming-improvements.md) and
+[RFC 0005](../../rfcs/0005-async-connector-runtime.md).
+
+### Connector certification
+As the ecosystem grows, "does this third-party connector honour the contract?"
+becomes the key trust question. The direction is a published conformance suite
+(paging, checkpoint ordering, cancellation, observability) that a connector can
+run to earn a certified badge.
+
+### SDK ergonomics
+Continued investment in making the [connector SDK](./connector-sdk.md) the
+easiest correct path: better `check()`/doctor scaffolding, sharper compile-time
+config validation, and templates that bake in the [performance
+disciplines](./performance.md) so authors start fast.
+
+## Non-goals
+
+- No `0.x` crates — everything ships `1.0.0`+.
+- No breaking changes to the object-safe `Source`/`Sink` contract; capabilities
+  are added additively.
+- No coupling of `faucet-core` to specific connectors or heavy dependencies.
+
+## Related
+
+- [Extensibility](./extensibility.md) · [Performance](./performance.md) · [Overview](./overview.md)
+- [docs/roadmap.md](../roadmap.md) · [Stability](../stability.md)
+- RFCs: [0001](../../rfcs/0001-capability-traits.md) · [0002](../../rfcs/0002-arrow-support.md) · [0003](../../rfcs/0003-plugin-system.md) · [0004](../../rfcs/0004-streaming-improvements.md) · [0005](../../rfcs/0005-async-connector-runtime.md)

--- a/docs/architecture/schema.md
+++ b/docs/architecture/schema.md
@@ -1,0 +1,99 @@
+# Schema handling
+
+*Inference, and the ordered per-page passes that mask, validate, and reconcile record shape before a write.*
+
+## Why it exists
+
+Records flowing through faucet-stream are dynamically typed
+(`serde_json::Value` — see [ADR 0004](../adr/0004-json-record-model.md)). To move
+them safely into typed destinations and to catch bad data early, the runtime
+needs (a) a way to *infer* a schema from records and (b) a set of *policies* that
+act on the gap between what arrives and what the destination expects. These
+policies run per page, in a fixed order, inside `run_stream`.
+
+## Problem it solves
+
+- **No schema, no safety.** JSON has no declared shape; `infer_schema` derives
+  one from samples so drift and contracts can be evaluated.
+- **Ordering matters for correctness.** PII must be masked before anything else
+  observes it; a contract breach must abort before a write; drift handling must
+  see the post-contract survivors. A wrong order is a data-safety bug, not a
+  cosmetic one.
+
+## Major components
+
+- `infer_schema` (`crates/core/src/schema.rs`) — merges types across sampled
+  records and detects nullability, producing an `{"type":"object","properties":…}`
+  shape.
+- `drift.rs` — pure `diff_schema(dest, page, allow_widening)` classifying each
+  **top-level** column into additions / widenings / incompatible /
+  droppable-required; `SchemaDriftPolicy` compiled from `SchemaDriftSpec`.
+- `quality/` and `contract/` — the two validation passes (documented in
+  [quality](./quality.md) and [contracts](./contracts.md)).
+- `masking/` — the PII pass (documented in [masking](./masking.md)).
+
+## Execution flow — the per-page pipeline
+
+```mermaid
+flowchart TD
+    PG[StreamPage records] --> M[masking pass FIRST]
+    M --> Q[quality: per-record then per-batch]
+    Q --> C[contract: fail aborts, quarantine to DLQ, warn]
+    C --> D[schema drift: warn/evolve/ignore/quarantine/fail]
+    D --> WR[sink write_batch]
+    WR --> FL[flush]
+    FL --> CK[checkpoint bookmark]
+```
+
+The order — **masking → quality → contract → drift** — is enforced in
+`run_stream` and is deliberate:
+
+1. **Masking first** so PII never reaches a sink, the DLQ, or a lineage sample.
+2. **Quality** removes/aborts bad records so downstream passes see clean data.
+3. **Contract** enforces the versioned output promise; `fail` writes nothing.
+4. **Drift** reconciles shape against the live destination schema last, because it
+   operates on exactly the records about to be written.
+
+## Invariants
+
+- **Drift is evaluated on top-level columns only.** A nested object is one
+  column; changes *inside* it never surface. This keeps `diff_schema` pure and
+  predictable at the cost of nested-field granularity.
+- **`contract: fail` aborts and writes nothing from the page**; **`drift: fail`
+  defers** — the page's survivors are individually valid, so they are committed
+  and the abort fires only after the page is durable (mirrors the DLQ-budget and
+  circuit-breaker deferral). This asymmetry is intentional and documented in
+  [contracts](./contracts.md).
+- **The destination schema is fetched lazily once and refreshed after `evolve`.**
+  A sink reporting `None` (schemaless / not-yet-created) makes the drift pass
+  inert regardless of mode.
+- **`FaucetError::SchemaDrift { columns, message }`** is raised only under an
+  `on_drift: fail` / `on_incompatible: fail` policy.
+
+## Trade-offs
+
+- **Top-level-only drift** trades nested precision for a simple, total diff.
+- **Per-page inference** means a schema is only as good as the page's sample; a
+  column absent from every record on a page is invisible until it appears.
+- **Fixed pass order** removes a configuration knob but eliminates an entire class
+  of "why did my PII leak / why did a bad row get written" bugs.
+
+## Failure scenarios
+
+- **A field narrows type mid-stream** (string→int) under `evolve` → routed by
+  `on_incompatible` (fail or quarantine); never silently coerced.
+- **Sink cannot evolve** but `on_drift: evolve` is set → rejected at config-load
+  by the expand-time gate, not discovered mid-run.
+
+## Future evolution
+
+- Nested-column drift, contingent on a nested-aware `diff_schema`.
+- Sharing the inferred schema with the [lineage](./observability.md) facet so a
+  single inference feeds both drift and the OpenLineage schema facet.
+
+## Related
+
+- [Quality](./quality.md) · [Contracts](./contracts.md) · [Masking](./masking.md)
+- [Pipeline](./pipeline.md) · [Design invariants](./invariants.md)
+- [ADR 0009 — Schema validation](../adr/0009-schema-validation.md)
+- User guide: [../book/src/cookbook/schema-drift.md](../book/src/cookbook/schema-drift.md)

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -1,0 +1,199 @@
+# Security model
+
+*How faucet-stream handles your credentials and your data — the trust boundaries, the redaction boundary and its sharp edges, transport and at-rest posture, and a hardening checklist.*
+
+## Why this exists
+
+faucet-stream is a *data-movement* tool: to do its job it holds credentials for
+dozens of external systems and streams potentially sensitive records between
+them. That makes its security posture a first-class concern, not an afterthought.
+This page is the coherent security model an operator — or an enterprise security
+reviewer — needs before running faucet against production data. It documents
+what faucet protects, what it explicitly does *not*, and how to run it safely.
+
+For **reporting a vulnerability**, see the repository's
+[`SECURITY.md`](../../SECURITY.md). This page is the architecture; that file is
+the disclosure policy.
+
+## Threat model scope
+
+faucet runs in three shapes, each with a different exposure:
+
+| Shape | Surface |
+|-------|---------|
+| **`faucet run` / `schedule` / `replicate` / `backfill`** (CLI) | a local process holding resolved credentials in memory; writes state/DLQ to configured stores; emits logs/metrics |
+| **`faucet serve`** (HTTP control plane) | a long-running network service accepting pipeline configs over HTTP; adds authn/authz, an audit log, and (in cluster mode) a shared database |
+| **embedded library** | the host process owns everything; faucet-core provides the engine only |
+
+**In scope:** credential handling, secret resolution and redaction, transport
+security options, PII handling, the serve auth/authz surface, and SQL-injection
+prevention. **Out of scope (host responsibility):** OS/process isolation,
+network segmentation, the security of the external systems faucet connects to,
+and the secrecy of the environment faucet runs in.
+
+```mermaid
+flowchart LR
+    subgraph Trusted[Trust boundary: the faucet process]
+      cfg[config + resolved secrets in memory]
+      eng[pipeline engine]
+    end
+    SM[(secrets managers<br/>vault / aws-sm / gcp-sm / azure-kv)] -->|load time| cfg
+    src[(source systems)] <-->|TLS?| eng
+    snk[(sink systems)] <-->|TLS?| eng
+    eng --> logs[logs / metrics / lineage]
+    eng --> state[(state store)]
+    eng --> dlq[(DLQ)]
+    client[serve HTTP client] -->|bearer + RBAC| eng
+```
+
+## Credentials and secrets
+
+### The auth model
+
+Every connector's credentials serialize as one adjacently-tagged shape,
+`{ type, config }` (e.g. `auth: { type: bearer, config: { token: … } }`).
+Credentials may be inline **or** referenced from the top-level `auth:` catalog
+via `auth: { ref: <name> }`. The CLI builds each named provider **once**
+(`cli/src/auth_catalog.rs`) and shares one `Arc<dyn AuthProvider>` across every
+connector that references it, so N matrix rows hitting one IdP share a single
+token with single-flight refresh rather than each caching a copy.
+
+### Secret interpolation
+
+Four `${scheme:reference}` directives resolve at config-load time as the final
+load-time stage (`cli/src/secrets/`):
+
+- `${vault:<path>[#field]}` — HashiCorp Vault KV v2
+- `${aws-sm:<name-or-ARN>[#field]}` — AWS Secrets Manager
+- `${gcp-sm:projects/…/secrets/…/versions/…}` — GCP Secret Manager
+- `${azure-kv:<vault>/<secret>[/<version>]}` — Azure Key Vault
+
+They are **off by default** (feature-gated: `secrets-vault`, `secrets-aws-sm`,
+`secrets-gcp-sm`, `secrets-azure-kv`), fetched concurrently and de-duplicated,
+and `#field` extracts one key from a JSON secret body (Vault/AWS). Because the
+secrets pass runs after variable/template resolution and before the `auth:`
+catalog is built, a shared provider can itself hold a `${vault:…}` secret.
+
+## The redaction boundary — and its sharp edges
+
+This is the single most important security caveat in faucet, and the one most
+easily misunderstood. Resolved secret values are scrubbed from output by a
+`RedactingWriter` at the I/O boundary (`cli/src/secrets/registry.rs`). **But the
+boundary covers only faucet's own tracing / log / error output.** It does **not**
+cover:
+
+- **third-party connector debug logging** (a driver that logs its own connection
+  string);
+- **Prometheus metric labels** and **tracing span attributes**;
+- anything written by a library the connector depends on.
+
+The operational rule that follows is absolute:
+
+> **Never run a pipeline with `FAUCET_LOG=debug` (or any verbose third-party log
+> level) when connector configs hold resolved secrets.** Debug logging can emit
+> credentials from outside faucet's redaction boundary.
+
+`faucet serve` additionally registers all bearer tokens (and RBAC principal
+tokens) for redaction, so they are scrubbed from its logs — subject to the same
+boundary limitation.
+
+## Transport security
+
+TLS is configured per connector, and **some connectors default to plaintext —
+explicitly, never silently**. The clearest example is the PostgreSQL CDC source:
+`tls: disable | require | verify_ca | verify_full`, defaulting to `disable`
+(plaintext). This is a deliberate "safe defaults are explicit" choice — the
+default is documented and visible in the config schema, not hidden — but it means
+**an operator moving production data must set TLS explicitly**. Treat every
+connector's `tls` / transport option as something to configure, not to inherit.
+
+## Data handling: PII, DLQ, and state at rest
+
+- **PII masking runs first.** When a `masking:` policy is configured, the masking
+  pass runs *before* quality/contract/drift and before every sink, the DLQ, and
+  any lineage sample — so PII never leaves the pipeline in the clear
+  ([masking](./masking.md)). Masking is deterministic (keyed HMAC), so masked
+  values stay joinable.
+- **The DLQ can hold raw records.** A dead-letter queue stores the *failed*
+  records in an envelope. If masking is **not** configured, those envelopes
+  contain the original (possibly sensitive) data. Treat the DLQ location with the
+  same sensitivity as the source data, and apply masking if the source carries
+  PII. See [`../book/src/cookbook/dlq.md`](../book/src/cookbook/dlq.md).
+- **State at rest.** Bookmarks are usually non-sensitive (offsets, timestamps,
+  max-column values) but can contain primary-key values. `FileStateStore`
+  supports optional at-rest encryption (`crates/core/src/encryption.rs`); the
+  Redis/Postgres backends inherit the security of those stores.
+- **Lineage** emits dataset URIs; `redact_uri_credentials`
+  (`faucet_core::util`) strips embedded credentials from URIs before they appear
+  in OpenLineage events.
+
+## `faucet serve` — the network surface
+
+- **Authentication is mandatory-by-opt-out.** The server refuses to start
+  bearer-less unless `--no-auth` is explicitly passed (a deliberate gate).
+  Bearer checks are constant-time and scoped to `/v1`.
+- **RBAC** (`--auth-config`): principals map to `viewer` (read-only) /
+  `operator` (+ run writes, doctor, triggers) / `admin` (+ audit). An unmapped
+  `/v1` route is **admin-only, fail-closed**.
+- **Audit log** records `run.submit` / `run.cancel` / `run.delete` and every
+  denial, through a single choke point (`serve/audit.rs`).
+- **The static UI shell is public; all `/v1` data is bearer-gated.** The browser
+  stores the token in `localStorage`.
+- **Cluster mode** shares a SQL database across instances; secure that database
+  as a trust-sensitive component (it holds run configs and audit records).
+
+## SQL-injection prevention
+
+Dynamic SQL is a first-class hazard for a tool that templates queries. The core
+provides the safe primitives and marks the unsafe ones:
+
+- `quote_ident` — identifier quoting for dynamically-composed SQL.
+- `substitute_context_bind_params` — SQL-safe value substitution via **bind
+  markers**, not string interpolation.
+- `substitute_context` — placeholder substitution for URLs/paths that is
+  **explicitly documented as NOT safe for SQL or JSON**; `substitute_context_json`
+  is the JSON-safe variant.
+
+Connector authors composing SQL **must** use the bind-parameter path and
+`quote_ident`, never raw string interpolation. See
+[error handling](../standards/error-handling.md) and the connector rules.
+
+## Supply chain
+
+Dependencies are gated by `cargo-deny` (`deny.toml`) as a **required** CI job
+("Supply chain (cargo-deny)"): a new dependency introducing a disallowed license
+fails the build. Toolchain and edition are pinned (`rust-toolchain.toml`); crate
+versions are semver-gated by `cargo-semver-checks`.
+
+## Hardening checklist
+
+For production deployments:
+
+- [ ] Set **TLS explicitly** on every connector that touches production data
+  (do not rely on plaintext defaults).
+- [ ] Keep log levels at `info` or below in any run holding resolved secrets;
+  **never** `debug` with third-party logging enabled.
+- [ ] Configure a **masking** policy if the source carries PII — and remember the
+  DLQ holds raw records without it.
+- [ ] Source secrets from a secrets manager (`${vault:…}` etc.), not inline
+  config or committed files.
+- [ ] For `faucet serve`: never use `--no-auth` outside a trusted network; prefer
+  `--auth-config` RBAC over a single admin token; secure the cluster database.
+- [ ] Restrict filesystem access to the state store and DLQ locations.
+- [ ] Review connector debug output before enabling it anywhere near secrets.
+
+## Non-goals
+
+faucet does not encrypt data in transit between its own components beyond what
+the connectors' TLS options provide, does not manage the lifecycle of the
+external systems' credentials (rotation is the secrets manager's job), and does
+not sandbox third-party connector code — a connector runs with the full trust of
+the faucet process.
+
+## Related
+
+- [Masking](./masking.md) · [State management](./state-management.md) · [Observability](./observability.md)
+- [Standards: logging & redaction](../standards/logging.md) · [Standards: error handling](../standards/error-handling.md)
+- [Glossary](../glossary.md)
+- Disclosure policy: [`SECURITY.md`](../../SECURITY.md)
+- User guide: [Secrets-manager interpolation](../book/src/cookbook/secrets.md) · [Dead-letter queues](../book/src/cookbook/dlq.md)

--- a/docs/architecture/state-management.md
+++ b/docs/architecture/state-management.md
@@ -1,0 +1,124 @@
+# State management
+
+*Durable bookmarks, the `StateStore` abstraction, and the key scheme that makes every invocation independently resumable.*
+
+## Why it exists
+
+Incremental replication and crash recovery both need one thing: a durable record of
+"how far did we get". faucet-stream calls that record a **bookmark** and stores it
+through a single narrow abstraction, the `StateStore`. Keeping state behind one
+trait means connectors never talk to a state backend directly — they produce and
+consume opaque bookmark values, and the pipeline handles persistence with the
+correct ordering. See [ADR 0006](../adr/0006-state-management.md).
+
+## Major components
+
+- **`StateStore`** (`crates/core/src/state.rs`) — an async trait with three
+  operations over `serde_json::Value`:
+
+  ```rust
+  async fn get(&self, key: &str) -> Result<Option<Value>, FaucetError>;
+  async fn put(&self, key: &str, value: &Value) -> Result<(), FaucetError>;
+  async fn delete(&self, key: &str) -> Result<(), FaucetError>;
+  ```
+
+- **Built-in backends in core** — `MemoryStateStore` (ephemeral, single-process) and
+  `FileStateStore` (one JSON file per key, written via atomic rename, optional
+  at-rest encryption). Kept in `faucet-core` because they add no dependencies.
+- **Heavier backends in their own crates** — `faucet-state-redis`
+  (`{namespace}:{key}`) and `faucet-state-postgres` (a single
+  `faucet_state(key, value, updated_at)` table with `ON CONFLICT DO UPDATE`). These
+  live outside core so `faucet-core` stays dependency-light. See
+  [ADR 0006](../adr/0006-state-management.md) and [ADR 0010](../adr/0010-pipeline-runtime.md).
+- **`validate_state_key`** — rejects empty, hidden (`.`-prefixed), and traversal-
+  unsafe keys, so a key can be used as a filename component without escaping the
+  store's root.
+
+## How a bookmark flows
+
+```mermaid
+sequenceDiagram
+    participant SS as StateStore
+    participant P as Pipeline
+    participant Src as Source
+    participant Snk as Sink
+    P->>SS: get(state_key)
+    SS-->>P: prior bookmark (or None)
+    P->>Src: apply_start_bookmark(prior)
+    loop each page
+        Src-->>P: StreamPage{records, bookmark}
+        P->>Snk: write_batch(records)
+        P->>Snk: flush()
+        P->>SS: put(state_key, bookmark)
+    end
+```
+
+The `put` happens **after** `write_batch` + `flush` — never before. That ordering
+is the whole point; it is documented as the central invariant in
+[invariants](./invariants.md) and [ADR 0002](../adr/0002-checkpoint-ordering.md).
+
+## The state-key scheme
+
+A key identifies a resumable position uniquely across the matrix DAG:
+
+| Node | Key |
+|---|---|
+| Source's natural key | `Source::state_key()` (e.g. `postgres-cdc:<slot>`) |
+| Matrix root row | `{name}::{row_id}` |
+| Matrix child (per parent record) | `{name}::{row_id}::{parent_record_key}` |
+| Replication CDC node | `{name}::cdc`; phase marker `{name}::__replication__` |
+| Backfill unit | `{name}::backfill::{unit}` (live bookmark untouched) |
+
+The executor wraps each invocation's source with a `StateKeyOverride` so the
+per-row key wins over the source's natural key. This is why two matrix rows using
+the same connector never clobber each other's progress.
+
+## Exactly-once: the state envelope
+
+Under `delivery: exactly_once` (atomic-watermark mechanism) the stored value is not
+a bare bookmark but an envelope carrying both the bookmark and the monotonic
+sequence: `wrap_state(bookmark, seq)` / `unwrap_state(value)`
+(`crates/core/src/idempotency.rs`). The sequence lets recovery reconcile the state
+store against the sink's committed watermark. See [recovery](./recovery.md).
+
+## Invariants
+
+- **A bookmark is persisted only after a durable, flushed write.** (The central
+  invariant.)
+- **Keys are validated before use** on every `get`/`put`/`delete`, so a malformed
+  key fails loudly rather than escaping the store root.
+- **The bookmark is opaque to the store.** The store round-trips a `Value`; only the
+  source interprets it. This keeps the store fully generic.
+- **`memory` state is not durable.** Gates that require durability
+  (`delivery: exactly_once`, SLA baselines) reject or warn on the memory backend at
+  config-load.
+
+## Trade-offs
+
+- **`Value`-typed, three-method interface** maximises backend portability at the
+  cost of any store-specific optimisation (range scans, TTLs). Bookmarks are tiny
+  and low-frequency, so this is the right trade.
+- **One file per key** (FileStateStore) is simple and atomic but not ideal for
+  thousands of matrix children — that is what the Redis/Postgres backends are for.
+
+## Failure scenarios
+
+- **Store unreachable at checkpoint** → the `put` errors, the run aborts after a
+  flush; the next run re-reads the last durable bookmark and replays from there
+  (at-least-once) or skips (exactly-once).
+- **Corrupt/legacy stored value** → `unwrap_state` tolerates a bare bookmark
+  (legacy) vs. an envelope, so upgrading delivery modes does not strand state.
+
+## Future evolution
+
+- Optional compare-and-swap semantics for stores that support it, to fence
+  concurrent writers to one key.
+- A typed bookmark trait so sources can express bookmark *comparability* (for
+  SLA/lag math) without leaking their internal shape.
+
+## Related
+
+- [Recovery](./recovery.md) · [Pipeline engine](./pipeline.md) · [Stream pages](./stream-pages.md)
+- [Design invariants](./invariants.md) · [Standards: state](../standards/state.md)
+- [ADR 0006 — State management](../adr/0006-state-management.md) · [ADR 0002 — Checkpoint ordering](../adr/0002-checkpoint-ordering.md)
+- User guide: [Incremental replication & state](../book/src/cookbook/state.md)

--- a/docs/architecture/stream-pages.md
+++ b/docs/architecture/stream-pages.md
@@ -1,0 +1,104 @@
+# Stream pages
+
+*The `StreamPage` model — the unit of streaming that bounds memory and carries the checkpoint.*
+
+## Why it exists
+
+The naïve way to move data is to fetch everything, then write everything. That
+buffers the entire dataset in memory and delays the first write until the last
+record arrives — unacceptable for a tool whose Primary Goal is
+efficient, reliable movement of arbitrarily large datasets. The streaming model
+replaces "fetch-all, write-all" with "pull a page, write a page, checkpoint,
+repeat", bounding memory at `O(batch_size)` on both sides regardless of total
+volume. See [ADR 0001](../adr/0001-stream-pages.md).
+
+## The unit of work
+
+```rust
+pub struct StreamPage {
+    pub records: Vec<Value>,       // the chunk to write
+    pub bookmark: Option<Value>,   // Some → checkpoint after this page is durable
+}
+```
+
+`Source::stream_pages(ctx, batch_size) -> Stream<Item = Result<StreamPage, _>>` is
+the primary streaming entry point. The pipeline calls `Sink::write_batch` once per
+yielded page, and flushes + checkpoints whenever a page carries `Some(bookmark)`.
+
+The `bookmark` field is the linchpin of two very different resumption styles under
+one type:
+
+- **Whole-result sources** (a REST paginator, a SQL query) know their bookmark only
+  after seeing every record, so they emit `Some` on the **final** page.
+- **CDC-style sources** (postgres-cdc, mysql-cdc, mongodb-cdc) emit `Some` **per
+  committed transaction**, getting per-transaction durability automatically.
+
+Both are handled by the same loop — the source decides *when* a page is
+checkpointable; the pipeline decides *how* to make it durable.
+
+## Native streaming vs. the default
+
+`stream_pages` has a **default implementation** that calls `fetch_all` and chunks
+the buffered result into pages. This lets a connector author implement only
+`fetch_with_context` and still participate in the streaming loop (buffered, but
+correct). Connectors that can stream from their underlying primitive **override**
+`stream_pages` to be truly incremental:
+
+```mermaid
+flowchart LR
+    subgraph Native override
+      DB[(database cursor)] --> P1[page] --> P2[page] --> P3[page bookmark]
+    end
+    subgraph Default impl
+      FA[fetch_all buffers everything] --> CH[chunk into pages]
+    end
+```
+
+Sources that override for native streaming include `rest`, `postgres`, all three
+CDC sources, `mysql`, `mssql`, `sqlite`, `mongodb`, `s3`/`gcs` (JSONL/raw),
+`parquet`, `csv`, `xml`, `elasticsearch` (scroll), `kafka`, `kinesis`, `spanner`,
+`websocket`, `redis`, and server-streaming `grpc`. Sources that intentionally keep
+the default: unary `grpc` (no paging primitive) and `webhook` (buffer-shaped by
+nature). The authoritative list is in
+`.claude/rules/connectors.md`.
+
+## Invariants
+
+- **`batch_size` passed to `stream_pages` is a hint.** Overriding sources use their
+  own config field as the authoritative knob, so a pipeline hint can never silently
+  override an explicit config value.
+- **A page carrying `Some(bookmark)` triggers flush + checkpoint before the next
+  page is polled.** This is what makes per-transaction CDC durability free.
+- **The bookmark is opaque to the pipeline.** It is a `serde_json::Value` the source
+  produced and only the source interprets (via `apply_start_bookmark`). See
+  [state-management](./state-management.md).
+
+## Trade-offs
+
+- **Page granularity is a throughput/latency/durability three-way.** Smaller pages
+  → lower memory, more frequent checkpoints, more sink round-trips. Larger pages →
+  fewer round-trips, coarser recovery. [Batching](./batching.md) covers the sizing
+  model and the `batch_size: 0` "one giant page" sentinel.
+- **The default impl buffers.** A connector that only implements `fetch_all` gets
+  correctness but not the memory bound — acceptable for small sources, a smell for
+  large ones (the author should implement `stream_pages`).
+
+## Failure scenarios
+
+- **A source yields `Err` mid-stream** → the loop propagates it after a best-effort
+  flush; already-checkpointed pages stay durable, so the next run resumes cleanly.
+- **An empty page with no bookmark** → skipped (no-op), so a source can emit
+  keepalive/empty pages cheaply.
+
+## Future evolution
+
+- Backpressure and multi-page pipelining without breaking per-page ordering.
+- A columnar `StreamPage` variant for zero-copy paths. Both are explored in
+  [RFC 0004](../../rfcs/0004-streaming-improvements.md) and
+  [RFC 0002](../../rfcs/0002-arrow-support.md).
+
+## Related
+
+- [Pipeline engine](./pipeline.md) · [Batching](./batching.md) · [State management](./state-management.md)
+- [Connector SDK](./connector-sdk.md) · [Design invariants](./invariants.md)
+- [ADR 0001 — Stream pages](../adr/0001-stream-pages.md)

--- a/docs/contributing/architecture.md
+++ b/docs/contributing/architecture.md
@@ -1,0 +1,108 @@
+# Contributor's map of the codebase
+
+*Where everything lives, and the order to read it in when you're tracing a record from config to sink.*
+
+This page orients a new contributor inside the workspace. It is deliberately a
+*map*, not a spec — for the "why" behind each subsystem, follow the links into
+[`docs/architecture/`](../architecture/README.md). For build/test/PR mechanics,
+see the top-level [`CONTRIBUTING.md`](../../CONTRIBUTING.md).
+
+## Workspace shape
+
+faucet-stream is a Cargo workspace of ~63 crates. They fall into four layers,
+and the dependency direction only ever flows downward:
+
+```mermaid
+flowchart TD
+    CLI["faucet-cli (cli/)<br/>config · expand · executor · serve · schedule · replicate · backfill"]
+    UMB["faucet-stream (faucet-stream/)<br/>umbrella: feature-gated re-exports"]
+    CONN["connector crates<br/>crates/source/* · crates/sink/* · crates/common/* · crates/state/* · crates/transform-sql · crates/lineage · crates/auth"]
+    CORE["faucet-core (crates/core/)<br/>traits · pipeline · state · error · transforms · observability"]
+
+    CLI --> UMB
+    CLI --> CONN
+    UMB --> CONN
+    CONN --> CORE
+    CLI --> CORE
+```
+
+The invariant that keeps the ecosystem healthy: **every connector crate depends
+only on `faucet-core`.** A connector never depends on another connector, on the
+umbrella, or on the CLI. This is what lets a third party publish a
+`faucet-source-foo` crate against `faucet-core` alone. See
+[extensibility](../architecture/extensibility.md) and the
+[connector spec](../spec/faucet-connector-spec-v0.md).
+
+## Which crate holds what
+
+| You're looking for… | It lives in… |
+|---|---|
+| The `Source` / `Sink` / `StateStore` traits, `FaucetError`, `Pipeline`, `run_stream` | `crates/core/` — see [`traits.rs`](../../crates/core/src/traits.rs), [`pipeline.rs`](../../crates/core/src/pipeline.rs), [`state.rs`](../../crates/core/src/state.rs), [`error.rs`](../../crates/core/src/error.rs) |
+| Record transforms, quality, contracts, masking, drift, resilience, idempotency | `crates/core/src/{transform,stage,quality,contract,masking,drift,resilience,idempotency}.rs` (and their sub-modules) |
+| Automatic metrics/tracing decorators | `crates/core/src/observability/` |
+| A specific connector's I/O | `crates/source/<name>/src/stream.rs` or `crates/sink/<name>/src/sink.rs` |
+| A connector's config shape | `crates/{source,sink}/<name>/src/config.rs` |
+| Shared config for a source+sink pair | `crates/common/<name>/` (e.g. `faucet-common-kafka`) |
+| Config parsing, matrix expansion, execution | `cli/src/{config,expand,executor}.rs` |
+| Connector dispatch + plugin registry | `cli/src/registry.rs` |
+| The CLI verbs (`run`, `validate`, `doctor`, `test`, …) | `cli/src/commands/` |
+| The HTTP control plane | `cli/src/serve/` |
+| The connector inventory used by the CLI's `registry_index` test | [`connectors/registry.json`](../../connectors/registry.json) |
+
+The authoritative, always-current crate table is in
+`.claude/rules/architecture.md`.
+
+## Read-order: tracing one record end to end
+
+When you need to understand how a record actually moves, read the layers in the
+order the data does. Each hop below has a "start here" file:
+
+```mermaid
+flowchart LR
+    A["YAML/JSON config"] --> B["cli/src/config.rs<br/>parse + interpolate + secrets"]
+    B --> C["cli/src/expand.rs<br/>matrix → ExpandedNode[]"]
+    C --> D["cli/src/executor.rs<br/>build source/sink, wire options"]
+    D --> E["Pipeline::run<br/>crates/core/src/pipeline.rs"]
+    E --> F["run_stream loop<br/>mask → quality → contract → drift → write → flush → checkpoint"]
+    F --> G["Source::stream_pages / Sink::write_batch<br/>crates/{source,sink}/*"]
+```
+
+1. **Config** — `cli/src/config.rs` defines `PipelineConfig`; `interpolate.rs`,
+   `compose.rs`, and `secrets/` resolve `${…}` references at load time.
+2. **Expansion** — `cli/src/expand.rs` turns the config (plus any `matrix:`) into
+   a list of `ExpandedNode`s and runs every config-load gate (exactly-once,
+   write-mode, quarantine-requires-DLQ). This is where a bad config is rejected
+   *before* any I/O.
+3. **Execution** — `cli/src/executor.rs` builds the concrete source/sink via
+   `cli/src/registry.rs`, wires the `RunStreamOptions`, and drives each node
+   under a bounded semaphore.
+4. **Core pipeline** — `Pipeline::run` (in [`pipeline.rs`](../../crates/core/src/pipeline.rs))
+   resolves the bookmark, then calls `run_stream`. This is the heart of the
+   system; the [pipeline](../architecture/pipeline.md) and
+   [stream-pages](../architecture/stream-pages.md) docs explain it in full.
+5. **Connector I/O** — the source's `stream_pages` yields
+   [`StreamPage`](../architecture/stream-pages.md)s; the sink's `write_batch`
+   commits them.
+
+The single most important thing to internalize before touching the write path:
+**a page's bookmark is persisted only *after* the sink has durably written and
+flushed that page** (write → flush → `StateStore::put`, in `run_stream`). This is
+the ordering that makes crashes safe. See
+[checkpoint-ordering ADR](../adr/0002-checkpoint-ordering.md).
+
+## Where to go next
+
+- Adding a connector → [connector-authoring](./connector-authoring.md)
+- Writing tests → [testing](./testing.md)
+- Making it fast → [performance](./performance.md)
+- Something's broken → [debugging](./debugging.md)
+- Avoiding the classic traps → [common-mistakes](./common-mistakes.md)
+
+## Related
+
+- [Architecture overview](../architecture/overview.md)
+- [Execution model](../architecture/execution.md)
+- [Pipeline runtime](../architecture/pipeline.md)
+- [Extensibility & plugins](../architecture/extensibility.md)
+- [Engineering principles](../engineering-principles.md)
+- [Top-level CONTRIBUTING.md](../../CONTRIBUTING.md)

--- a/docs/contributing/common-mistakes.md
+++ b/docs/contributing/common-mistakes.md
@@ -1,0 +1,135 @@
+# Common mistakes
+
+*The traps this codebase has actually hit — each with why it bites and the correct pattern.*
+
+Every item below is grounded in a real rule, a real regression, or a real CI
+gate in this repository. Read it before your first PR; it will save you a
+review round-trip.
+
+## 1. Retrying a non-idempotent write
+
+**Mistake:** wrapping a plain `Sink::write_batch` in a retry.
+
+**Why it bites:** `write_batch` makes no atomicity promise. If the request
+commits server-side but the *response* is lost, a retry re-sends the batch and
+**silently duplicates every row** — the worst bug class in a data-movement tool
+(silent downstream corruption).
+
+**Correct pattern:** the pipeline only retries writes when
+`sink.supports_idempotent_writes()` is true (`run_stream`'s `with_retry_write!`
+macro). If you're adding retry logic, gate it the same way, or route through
+`write_batch_idempotent`, which is a no-op to replay. See the
+[retries ADR](../adr/0007-retries.md).
+
+## 2. Persisting a bookmark before the write is durable
+
+**Mistake:** calling `StateStore::put` (or advancing any resume position) before
+the sink has flushed.
+
+**Why it bites:** a crash in that window leaves the checkpoint ahead of the data.
+On resume the source skips records that were never written — silent data loss.
+
+**Correct pattern:** never checkpoint yourself. The pipeline enforces
+write → flush → `put` in that order across all three write paths. Your source
+only needs `state_key` + `apply_start_bookmark`. See the
+[checkpoint-ordering ADR](../adr/0002-checkpoint-ordering.md).
+
+## 3. High-cardinality metric labels
+
+**Mistake:** using a record id, URL, query string, or `parent_record_key` as a
+Prometheus label.
+
+**Why it bites:** cardinality explosion — the metric backend degrades or OOMs.
+
+**Correct pattern:** labels are the fixed set `{pipeline, row, connector}` plus a
+few enum-valued ones. High-cardinality values go on the tracing *span*
+(`run_id`, `parent_record_key`), never a metric label. See
+[observability](../architecture/observability.md).
+
+## 4. Not declaring a crate's own dependency features
+
+**Mistake:** using a dependency feature (e.g. `tokio`'s `macros` for
+`tokio::select!`) without enabling it in *this crate's* `Cargo.toml`, relying on
+another crate in the workspace to turn it on.
+
+**Why it bites:** feature unification makes it compile locally and in a normal
+`--all-features` build, but the `feature-check` CI matrix builds each connector
+**in isolation** and it fails there.
+
+**Correct pattern:** every crate enables in its own manifest every dependency
+feature it uses. Build your crate alone (`cargo build -p faucet-source-foo`) to
+check.
+
+## 5. Asserting `serde_json::Map` key order
+
+**Mistake:** a test asserting the *sequence* of keys in a `serde_json::Map`.
+
+**Why it bites:** the `preserve_order` feature (on under `--all-features`)
+switches the map from `BTreeMap` (sorted) to `IndexMap` (insertion order). The
+test passes under `-p crate` and fails in CI.
+
+**Correct pattern:** assert the *set* of keys/values, not their order.
+
+## 6. Creating a crate at `0.x`
+
+**Mistake:** scaffolding a new crate at `version = "0.1.0"`.
+
+**Why it bites:** it violates a hard workspace rule — nothing we deploy ships a
+`0.x` version — and breaks the coordinated-release assumptions.
+
+**Correct pattern:** new crates start at **`version = "1.0.0"`**, in both the
+crate `Cargo.toml` and its `[workspace.dependencies]` path entry.
+
+## 7. Adding a connector without the registry entry
+
+**Mistake:** wiring a new source/sink into the CLI but forgetting
+[`connectors/registry.json`](../../connectors/registry.json).
+
+**Why it bites:** the CLI `registry_index` test panics under `--all-features`
+(`Test`/`Coverage` jobs) — and this isn't in the docs-sync trigger table, so it's
+easy to miss.
+
+**Correct pattern:** add a verified `registry.json` entry as part of the
+[wiring checklist](./connector-authoring.md#wiring-checklist-ci-enforces-most-of-this).
+
+## 8. Blindly updating a failing test
+
+**Mistake:** changing an assertion so a test goes green after your code change.
+
+**Why it bites:** the test may have been *correctly* catching a regression you
+just introduced. Rewriting it to match hides the bug.
+
+**Correct pattern:** investigate why the test broke first. Only change it once
+you understand that the *new* behavior is the intended one.
+
+## 9. Putting I/O or protocol logic in `config.rs`
+
+**Mistake:** building a client, or encoding protocol details, inside the config
+module.
+
+**Why it bites:** `config.rs` is meant to be pure and trivially unit-testable,
+and it's what `faucet schema`/`init` introspect. Mixing in I/O couples the two
+and makes the config untestable offline.
+
+**Correct pattern:** config structs and enums only in `config.rs`; all I/O in
+`stream.rs`/`sink.rs`. See [connector-authoring](./connector-authoring.md).
+
+## 10. Retrying a source read that isn't safe to replay under exactly-once
+
+**Mistake:** enabling `delivery: exactly_once` with a query-based source.
+
+**Why it bites:** a query re-executed on resume can return *different* content,
+so skipping "already-committed" pages by sequence would drop or duplicate rows.
+
+**Correct pattern:** the exactly-once gate in `cli/src/expand.rs` rejects
+non-deterministic-replay sources up front. Only CDC/log sources qualify — or use
+the keyed-upsert mechanism (`write_mode: upsert` + `key`). See
+[recovery](../architecture/recovery.md).
+
+## Related
+
+- [Connector authoring](./connector-authoring.md)
+- [Testing](./testing.md)
+- [Debugging](./debugging.md)
+- [Retries ADR](../adr/0007-retries.md)
+- [Checkpoint-ordering ADR](../adr/0002-checkpoint-ordering.md)

--- a/docs/contributing/connector-authoring.md
+++ b/docs/contributing/connector-authoring.md
@@ -1,0 +1,137 @@
+# Authoring a connector
+
+*How to build a source or sink that is fast, resumable, and ships cleanly — and every place you must wire it in.*
+
+This is the contributor-facing companion to the user-facing
+[authoring guide](../book/src/extending/authoring-connectors.md) and the
+[connector protocol spec](../spec/faucet-connector-spec-v0.md). Read those for
+the external contract; read this for the *internal* conventions and the wiring
+checklist that CI enforces.
+
+A connector is a crate that implements `faucet_core::Source` or
+`faucet_core::Sink`. The traits are object-safe on purpose (see the
+[builder-pattern ADR](../adr/0003-builder-pattern.md)) — no associated types, no
+generic methods — so `Box<dyn Source>` and `Box<dyn Sink>` work and third-party
+crates need nothing but `faucet-core`.
+
+## Crate layout
+
+Every connector follows the same module split. Stick to it — reviewers expect it
+and it keeps the "pure config vs. I/O" boundary clean:
+
+```
+crates/source/foo/
+├── Cargo.toml        # version = "1.0.0"; per-crate keywords; docs.rs metadata
+└── src/
+    ├── lib.rs        # re-exports; first line is the docsrs attribute
+    ├── config.rs     # config struct(s) — NO I/O, NO protocol logic
+    └── stream.rs     # the ONE place that performs I/O (sink.rs for sinks)
+```
+
+- **`lib.rs`** — re-export the config + the `Source`/`Sink` type. **The very
+  first line must be** `#![cfg_attr(docsrs, feature(doc_cfg))]` so docs.rs
+  renders per-item feature badges (see
+  `.claude/rules/publishing.md`).
+- **`config.rs`** — the config struct and its sub-enums (auth, format,
+  pagination). Derive `Serialize + Deserialize + JsonSchema`. **No I/O and no
+  protocol logic here** — this file must be trivially unit-testable and is what
+  `faucet schema` / `faucet init` introspect.
+- **`stream.rs` / `sink.rs`** — the only file that touches the network or disk.
+  Create reusable clients/pools in `new()` and store them on the struct; never
+  build a client per call (see [performance](./performance.md)).
+
+Optional helper modules (`auth/`, `pagination/`, `extract/`, `convert.rs`,
+`schema.rs`, `state.rs`, `serde_helpers.rs`) hold pure logic that you can unit
+test without a network.
+
+New crates start at **`version = "1.0.0"`** — never `0.x` (a hard workspace
+rule). Set per-crate `keywords` with the system name first; keep
+`categories.workspace = true`; add the `[package.metadata.docs.rs]` block.
+
+## Implement the trait
+
+Minimum viable source:
+
+```rust
+#[async_trait]
+impl Source for FooSource {
+    async fn fetch_with_context(&self, ctx: &HashMap<String, String>)
+        -> Result<Vec<Value>, FaucetError> { /* … */ }
+
+    fn config_schema(&self) -> Value { schema_for!(FooConfig) }
+    fn connector_name(&self) -> &'static str { "foo" }  // friendly, non-empty
+}
+```
+
+`fetch_with_context` is the required method. The default `stream_pages`
+chunks its result — which materializes everything first. **If the underlying
+system has a native paging primitive (cursor, offset, scroll, log position),
+override `stream_pages`** so memory stays O(batch_size). See
+[stream-pages](../architecture/stream-pages.md) for the contract and
+[batching](../architecture/batching.md) for `batch_size` semantics.
+
+`connector_name()` must return a non-empty `&'static str` — it becomes the
+`connector` metric label. Empty strings fall back to `"unknown"`.
+
+### Resumability
+
+If your source can resume, implement two methods:
+
+- `state_key()` → a stable, non-empty key (validated by `validate_state_key`).
+- `apply_start_bookmark(bookmark)` → seek to the position encoded in the
+  bookmark the pipeline read from the [state store](../architecture/state-management.md).
+
+The pipeline handles the rest: it persists the bookmark **only after** the sink
+durably wrote and flushed the page. You never call `StateStore::put` yourself.
+
+### Capability opt-ins (all defaulted — implement only what applies)
+
+| Capability | Trait methods | Notes |
+|---|---|---|
+| Exactly-once (source) | `supports_exactly_once`, `replay_guarantee`, `capture_resume_position` | Only for deterministic-replay sources (CDC, Kafka). See [idempotency](../architecture/recovery.md). |
+| Exactly-once (sink) | `supports_idempotent_writes`, `write_batch_idempotent`, `last_committed_token` | Commit records + the commit token **atomically**. |
+| Upsert / delete | `supported_write_modes`, and use `faucet_core::write_mode::plan_writes` | See the [write-mode](../book/src/cookbook/upsert.md) cookbook. |
+| Discovery | `supports_discover`, `discover` | Read-only, cheap catalog introspection only. |
+| Sharding | `is_shardable`, `enumerate_shards`, `apply_shard` | PK-range or hash-of-key. |
+| Schema evolution (sink) | `current_schema`, `supports_schema_evolution`, `evolve_schema` | Additive/widening DDL. |
+
+Every one of these has a default implementation, so existing connectors never
+break when a new capability lands. That is the whole point of the
+[progressive-trait design](../adr/0003-builder-pattern.md).
+
+## Wiring checklist (CI enforces most of this)
+
+Implementing the trait is half the job. A connector isn't shipped until it's
+wired into every surface. Miss one and a CI job — or a downstream user — breaks:
+
+- [ ] **Umbrella feature** — add `source-foo` / `sink-foo` to `faucet-stream/Cargo.toml`.
+- [ ] **CLI feature** — add the matching feature to `cli/Cargo.toml`.
+- [ ] **CLI dispatch** — add the arm to `build_source`/`build_sink` (and the
+      `*_schema` / `*_descriptions` helpers) in [`cli/src/registry.rs`](../../cli/src/registry.rs).
+- [ ] **Registry index** — add a verified entry to
+      [`connectors/registry.json`](../../connectors/registry.json), or the CLI
+      `registry_index` test panics under `--all-features`.
+- [ ] **CI matrix** — add the connector to the `feature-check` matrix in
+      `.github/workflows/ci.yml` (feature-isolation builds each connector alone).
+- [ ] **Own dep-features** — the crate must enable in *its own* `Cargo.toml`
+      every feature of a dependency it uses. Feature unification hides this
+      locally but the isolation matrix catches it (see [common-mistakes](./common-mistakes.md)).
+- [ ] **README** — crate `README.md` with config fields, auth, defaults.
+- [ ] **Docs site** — the capability matrix in
+      `docs/book/src/reference/connectors.md`, plus a `cli/examples/*.yaml`.
+- [ ] **Shipped example validates** — the example must pass the
+      `cli_end_to_end` validate test (use literal hosts, not `${env:VAR}`
+      unless the var is in the allowlist).
+
+The full docs-sync trigger table is in
+`.claude/rules/maintenance.md`.
+
+## Related
+
+- [Connector SDK](../architecture/connector-sdk.md)
+- [Stream pages](../architecture/stream-pages.md)
+- [State management](../architecture/state-management.md)
+- [Performance](./performance.md)
+- [Testing](./testing.md)
+- [Common mistakes](./common-mistakes.md)
+- [Connector spec (FCP v0)](../spec/faucet-connector-spec-v0.md)

--- a/docs/contributing/debugging.md
+++ b/docs/contributing/debugging.md
@@ -1,0 +1,70 @@
+# Debugging a pipeline
+
+*The tools and order of operations for finding out why a pipeline misbehaves — without shipping a change to find out.*
+
+faucet-stream is designed to be diagnosable *before* you run anything against
+real infrastructure. Reach for the offline tools first; they catch most
+problems in seconds.
+
+```mermaid
+flowchart TD
+    A["Pipeline misbehaving"] --> B["faucet validate<br/>config, gates, secret refs"]
+    B --> C["faucet doctor<br/>preflight probe each connector"]
+    C --> D["faucet test<br/>fixture-based offline run"]
+    D --> E["faucet preview<br/>first root, no writes"]
+    E --> F["faucet run --log-level debug<br/>real run + tracing"]
+    F --> G["metrics + faucet dlq inspect<br/>observe in flight / after"]
+```
+
+## Offline first
+
+- **`faucet validate [--show-composed]`** — parses, composes (`extends`/
+  profiles/`!include`), interpolates, and runs every config-load gate
+  (exactly-once, write-mode, quarantine-requires-DLQ). It also resolves and
+  reports secret references as a real preflight (use `--no-secrets` to stay
+  fully offline). If validate fails, nothing else matters yet.
+- **`faucet doctor [--json]`** — a non-mutating preflight that calls each
+  connector's `check()` (connect/auth/metadata probe) under a timeout and prints
+  a green/red checklist. This is how you confirm credentials and reachability
+  without moving data. See [`crates/core/src/check.rs`](../../crates/core/src/check.rs).
+- **`faucet test <spec>`** — the fixture-based offline harness
+  (`cli/src/pipeline_test/`). It feeds fixture records through the *real*
+  `Pipeline` per-page path (transforms → quality → contract → masking) with an
+  in-memory source and a capturing sink/DLQ, and asserts on the output. This is
+  the fastest way to reproduce a transform/quality/contract bug deterministically
+  — write a failing test case, then fix.
+- **`faucet preview`** — runs only the first root invocation (children need
+  parent records) so you can see real output shape without a full run.
+
+## Live
+
+- **Tracing.** Set `--log-level debug` or `FAUCET_LOG=debug`. Every source,
+  sink, transform, and state op is wrapped in a span
+  (`faucet.pipeline.run` at the top). The `run_id` is a span attribute you can
+  correlate across events.
+- **Metrics.** The universal metric set is emitted automatically — no per-run
+  flag. `faucet_source_records_total`, `faucet_sink_errors_total`,
+  `faucet_pipeline_seconds_since_last_bookmark`, and
+  `faucet_pipeline_pages_skipped_total` are the first gauges to check for a
+  stalled or replaying run. See [observability](../architecture/observability.md).
+- **The DLQ.** If rows are being quarantined, `faucet dlq inspect <location>`
+  classifies and summarizes the dead-letter envelopes, and
+  `faucet dlq replay` re-runs them through a fresh pipeline. See
+  [`cli/src/dlq_replay/`](../../cli/src/dlq_replay/).
+
+## The secret-redaction caveat
+
+faucet redacts resolved secret values from *its own* tracing/log/error output at
+the I/O boundary. That boundary does **not** cover third-party connector debug
+logging (e.g. a database driver's own logs), Prometheus label values, or span
+attributes. **Never run `FAUCET_LOG=debug` on a pipeline whose connector configs
+hold resolved secrets** — a driver may log the connection string with the
+password in it. Debug against non-production credentials.
+
+## Related
+
+- [Observability architecture](../architecture/observability.md)
+- [Recovery & resume](../architecture/recovery.md)
+- [Testing](./testing.md)
+- [Common mistakes](./common-mistakes.md)
+- [Troubleshooting cookbook](../book/src/cookbook/troubleshooting.md)

--- a/docs/contributing/performance.md
+++ b/docs/contributing/performance.md
@@ -1,0 +1,75 @@
+# Performance
+
+*The connector performance checklist, how to measure, and what not to touch without evidence.*
+
+Performance and reliability are the reason this library exists — every connector
+should be the fastest way to move data between its endpoints in Rust. This page
+is the contributor checklist; the *why* behind the design choices is in
+[`docs/architecture/performance.md`](../architecture/performance.md).
+
+## The checklist
+
+Apply these when adding or modifying any connector. They are not optional
+polish — they are the baseline a reviewer will expect:
+
+- **Reuse clients and connections.** Build S3 clients, DB pools, Redis
+  connections, and `reqwest` clients in `new()` and store them on the struct.
+  Never construct a client per call — that is the single most common throughput
+  bug in a connector.
+- **Pool database connections.** Every DB connector exposes a configurable
+  `max_connections` (default 10 for sources, 5 for sinks).
+- **Multi-row `INSERT`.** DB sinks must batch into
+  `INSERT INTO … VALUES (…), (…), …`, never one statement per record.
+- **Wrap batches in transactions** where the backend supports it (the SQLite
+  sink wraps each batch in `BEGIN`/`COMMIT`).
+- **Parallel I/O.** Use `buffer_unordered(concurrency)` for concurrent object
+  reads/writes (S3/GCS/Parquet), a semaphore for concurrent HTTP sends, and
+  concurrent partition processing where the source supports it.
+- **Prefer bulk/batch APIs** — Elasticsearch `_bulk`, BigQuery `insertAll`,
+  MongoDB `insert_many`, Redis pipelines + `MGET`.
+- **Buffered I/O** for file sinks; use `spawn_blocking` for sync CPU/FS work
+  (the CSV sink does) so you never block the async runtime.
+- **Expose configurable concurrency** (`concurrency` / `max_connections`) with
+  sensible defaults.
+
+The memory model is fixed by the pipeline: streaming holds only one
+[page](../architecture/stream-pages.md) at a time, so memory is O(batch_size) on
+both sides regardless of total volume. Don't defeat this by buffering the whole
+result set in your `stream_pages` override.
+
+## Measuring
+
+There is a benchmark harness — see [`BENCHMARKS.md`](../../BENCHMARKS.md) and
+`scripts/`. When you claim a speed-up, back it with a before/after number from
+the harness, not intuition. The benchmark VM and scenarios are documented there
+(Scenario C is the head-to-head throughput comparison).
+
+```mermaid
+flowchart LR
+    A["hypothesis:<br/>'X is slow'"] --> B["measure with BENCHMARKS.md harness"]
+    B --> C{evidence of a<br/>real bottleneck?}
+    C -- yes --> D["change + re-measure<br/>report before/after"]
+    C -- no --> E["leave it alone"]
+```
+
+## What NOT to do
+
+- **Don't micro-optimize without evidence.** A clever allocation-avoidance that
+  isn't on a measured hot path adds risk and review burden for no gain. The
+  hot path is `run_stream` and the per-record transform loop; almost everything
+  else is cold.
+- **Don't trade correctness for speed.** A faster write path that can duplicate
+  rows on retry is a regression, not an optimization — see the
+  [retries ADR](../adr/0007-retries.md). Correctness outranks throughput every
+  time.
+- **Don't add mandatory heavy dependencies to `faucet-core`.** Core must stay
+  lightweight for connector authors; connector-specific deps belong in the
+  connector crate.
+
+## Related
+
+- [Performance architecture](../architecture/performance.md)
+- [Batching & backpressure](../architecture/batching.md)
+- [Stream pages](../architecture/stream-pages.md)
+- [Performance standards](../standards/performance.md)
+- [BENCHMARKS.md](../../BENCHMARKS.md)

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -1,0 +1,82 @@
+# Testing
+
+*What to test, where it lives, and why the 90% patch-coverage gate is a floor, not a target.*
+
+Untested public API surface is a liability. This page covers the philosophy and
+the practical techniques; the repository-wide conventions are in
+[`docs/standards/testing.md`](../standards/testing.md), and the PR mechanics are
+in [`CONTRIBUTING.md`](../../CONTRIBUTING.md).
+
+## Two kinds of test, two homes
+
+- **Unit tests** live in `#[cfg(test)]` modules at the bottom of the source file
+  they exercise. Use them for anything that doesn't need real I/O: pagination
+  state transitions, JSONPath extraction, auth-header generation, config
+  validation, error/`match` branches. This is the bulk of the suite.
+- **Integration tests** live in the crate's `tests/` directory. HTTP connectors
+  use [`wiremock`](https://docs.rs/wiremock); database/queue connectors use
+  [`testcontainers`](https://docs.rs/testcontainers) (these need Docker and are
+  CI-gated).
+
+## The coverage gate
+
+`codecov/patch` is a **required** merge check at **90%** — a PR whose changed
+lines are under 90% covered *cannot merge*. Treat 90% as the floor.
+
+The critical subtlety: **Docker-backed integration tests do not count toward
+patch coverage.** The coverage run is not instrumented with the containers, so
+lines only exercised by a `testcontainers` test show as uncovered. **Unit-test
+your changed lines.** If a line "can't" be unit-tested, that is usually a design
+smell — extract the pure logic and make the I/O a thin shim:
+
+```mermaid
+flowchart LR
+    A["new / changed code"] --> B{needs real I/O?}
+    B -- no --> C["#[cfg(test)] unit test<br/>counts toward patch coverage"]
+    B -- yes --> D["extract pure logic → unit test it<br/>keep I/O a thin shim"]
+    D --> E["cover the shim with wiremock/testcontainers<br/>(does NOT count toward patch)"]
+```
+
+Genuinely untestable surface (a SIGTERM handler, a `main()` dispatch arm, an
+infinite supervisory loop) is the only sanctioned exception — keep it to the few
+unreachable lines and say so in the PR.
+
+Verify locally before pushing, so the gate never surprises you:
+
+```bash
+cargo llvm-cov --workspace --all-features   # then intersect with your diff
+```
+
+## Techniques worth knowing
+
+- **Offline pool tests.** You can unit-test a pool-backed SQL source *without*
+  Docker using `sqlx`'s `connect_lazy` (plus a short `acquire_timeout`): the
+  pool is created but never connects until first use, so you can exercise query
+  building, identifier quoting, and config paths offline. (This does **not** work
+  for MSSQL/`tiberius`, whose `bb8` pool connects eagerly.)
+- **TUI / terminal paths.** Interactive code never runs in CI, so render it
+  through `ratatui`'s `TestBackend` and split the drive-loop from the crossterm
+  setup so the loop is testable.
+- **Spawned-binary tests** need a `CARGO_LLVM_COV` skip-guard, or they fail under
+  the instrumented coverage run.
+
+## Rules
+
+- **Assert the specific outcome, not "no panic".** A test that only checks the
+  call didn't panic proves almost nothing.
+- **New code always gets tests** — non-negotiable.
+- **Do not blindly update an existing test to make it pass.** If your change
+  breaks a test, investigate *why* first — silently rewriting the assertion to
+  match new behavior is how a regression sails through. Modified tests deserve
+  the same scrutiny as modified code.
+- **Watch feature unification in assertions.** `serde_json::Map` iteration order
+  flips between `BTreeMap` and `IndexMap` depending on the `preserve_order`
+  feature, which `--all-features` turns on. Assert the *set* of keys, not the
+  *sequence*, or your test passes under `-p crate` and fails in CI.
+
+## Related
+
+- [Testing standards](../standards/testing.md)
+- [Debugging](./debugging.md)
+- [Common mistakes](./common-mistakes.md)
+- [Performance](./performance.md)

--- a/docs/engineering-principles.md
+++ b/docs/engineering-principles.md
@@ -1,0 +1,295 @@
+# Engineering Principles
+
+*The design principles the faucet-stream codebase actually embodies — each stated, justified, and backed by concrete evidence in the source.*
+
+This document is descriptive, not aspirational. Every principle below is one the
+codebase already follows; the "Evidence" lines point at the code that enforces
+it. New contributions are expected to uphold these principles, and reviewers may
+cite this page directly. Where a principle is codified as an enforceable rule,
+the relevant [standard](./standards/) is linked.
+
+The ordering is deliberate: the first principle — correctness over everything —
+is the reason the project exists, and it breaks every tie below it.
+
+---
+
+## 1. Correctness first — never silently corrupt downstream data
+
+**Statement.** A subtle bug that silently produces wrong output for a downstream
+consumer is the worst class of defect in this codebase, worse than a crash or a
+missing feature. Data-integrity paths (checkpoint ordering, retry safety,
+pagination state, exactly-once) are held to a higher bar than anything else.
+
+**Why.** faucet-stream moves data between systems of record. A crash is visible
+and recoverable; a duplicated or dropped row that lands in a warehouse and feeds
+a report is invisible and may never be caught. The cost asymmetry justifies
+paying for correctness up front.
+
+**Evidence.**
+- The retry layer refuses to retry a non-idempotent `write_batch` unless the sink
+  advertises `supports_idempotent_writes()` — a lost response on a committed
+  write would otherwise duplicate every row (`crates/core/src/pipeline.rs`, the
+  `with_retry_write!` macro). This is the single most load-bearing correctness
+  decision in the runtime; see [ADR 0007](./adr/0007-retries.md).
+- The **central invariant** — a page's bookmark is persisted only *after* the
+  sink has durably written and flushed that page — holds identically across all
+  three write paths in `run_stream`. See [ADR 0002](./adr/0002-checkpoint-ordering.md)
+  and [Design invariants](./architecture/invariants.md).
+- Silent-corruption-prone conditions get their own typed `FaucetError`
+  variants — `QualityFailure`, `SchemaDrift`, `ContractViolation`, `CircuitOpen`
+  (`crates/core/src/error.rs`) — so they surface as explicit, catchable failures
+  rather than being swallowed.
+
+**Standard:** [state](./standards/state.md), [error-handling](./standards/error-handling.md).
+
+---
+
+## 2. Composition over inheritance
+
+**Statement.** Behaviour is layered by *wrapping* a value in another value that
+implements the same trait, never by an inheritance hierarchy. Cross-cutting
+concerns compose as onion layers around a plain connector.
+
+**Why.** Rust has no inheritance, but more importantly composition keeps each
+concern independently testable and optional. A connector author writes a bare
+`Source`; the runtime decides whether to wrap it in instrumentation, transforms,
+sharding, or state overrides. None of those concerns leak into the connector.
+
+**Evidence.**
+- `TransformingSource` (`crates/core/src/transforming_source.rs`) wraps any
+  `Source` to apply transform stages per page — the canonical way transforms
+  attach, with no per-connector escape hatch.
+- `InstrumentedSource` / `InstrumentedSink` / `InstrumentedStateStore`
+  (`crates/core/src/observability/`) wrap connectors to emit metrics and spans;
+  the connector emits none itself.
+- The CLI executor wraps a source in `StateKeyOverride` so per-row state keys
+  override the source's natural one, without the source knowing.
+
+**Standard:** [api-design](./standards/api-design.md). See also
+[ADR 0003](./adr/0003-builder-pattern.md).
+
+---
+
+## 3. Small, focused, object-safe traits with defaulted methods
+
+**Statement.** `Source` and `Sink` stay small and object-safe (`Box<dyn Source>`
+works). Capabilities beyond the minimum are added as trait methods *with default
+implementations*, so existing connectors never break when the trait grows.
+
+**Why.** This is what makes the third-party marketplace viable: a connector from
+2024 keeps compiling when the trait gains `discover()`, `enumerate_shards()`, or
+`sink_guarantee()` in 2026, because each new method has a safe default. It also
+keeps the mental model small — a new author implements two required methods and
+opts into the rest.
+
+**Evidence.**
+- Every capability beyond `fetch_with_context` / `write_batch` is defaulted:
+  `stream_pages`, `state_key`, `apply_start_bookmark`, `supports_exactly_once`,
+  `capture_resume_position`, `is_shardable`/`enumerate_shards`/`apply_shard`,
+  `supports_discover`/`discover`, `check`, `current_schema`/`evolve_schema`,
+  `write_batch_idempotent`/`last_committed_token` (`crates/core/src/traits.rs`).
+- No trait method uses connector-specific types, generics, or associated types
+  that would break object safety — a hard rule for the ecosystem.
+
+**Standard:** [api-design](./standards/api-design.md).
+
+---
+
+## 4. Progressive builder APIs
+
+**Statement.** Optional behaviour is configured through chained `with_*` builder
+methods that each default to the safe, minimal choice. A caller pays only for
+the complexity they opt into.
+
+**Why.** A single wide config struct forces every caller to reason about every
+knob. A progressive builder lets `Pipeline::new(&source, &sink).run()` be the
+complete happy path, while `with_state_store`, `with_dlq`, `with_quality`,
+`with_delivery`, `with_cancel`, etc. remain discoverable and independently
+composable.
+
+**Evidence.**
+- `Pipeline` exposes `with_state_store`, `with_name`, `with_row`, `with_dlq`,
+  `with_quality`, `with_contract`, `with_masking`, `with_adaptive`, `with_cancel`,
+  `with_delivery`, `with_resilience`, `with_schema_drift`
+  (`crates/core/src/pipeline.rs`), each defaulting to "off".
+- `RunStreamOptions` mirrors the same shape for callers who drive `run_stream`
+  directly.
+
+**Standard:** [api-design](./standards/api-design.md). See
+[ADR 0003](./adr/0003-builder-pattern.md).
+
+---
+
+## 5. Observable by default
+
+**Statement.** Every source, sink, transform, and state-store operation emits
+metrics and spans automatically, with zero per-connector instrumentation code.
+
+**Why.** Observability that must be added by hand is observability that is
+missing exactly where it matters. By instrumenting at the pipeline boundary,
+every connector — including third-party ones — is observable the moment it runs.
+
+**Evidence.**
+- The pipeline wraps connectors in the `observability/` decorators before the run
+  starts (`Pipeline::run` in `crates/core/src/pipeline.rs`); connectors implement
+  only `connector_name()` to supply a friendly label.
+- The universal metric set (`faucet_source_*`, `faucet_sink_*`,
+  `faucet_transform_*`, `faucet_state_*`, `faucet_pipeline_*`) is emitted by the
+  decorators, not the connectors.
+
+**Standard:** [logging](./standards/logging.md). See
+[ADR 0008](./adr/0008-observability.md) and
+[Observability architecture](./architecture/observability.md).
+
+---
+
+## 6. Explicit, externalized state
+
+**Statement.** Resumability state lives in an explicit `StateStore`, keyed by a
+validated key, and is written only through the pipeline's durability protocol.
+Bookmarks are opaque values owned by the source that produced them.
+
+**Why.** Hidden or implicit state is impossible to reason about across restarts
+and across a cluster. Making state an explicit, pluggable interface lets the same
+pipeline resume from a file, Redis, or Postgres, and lets the runtime guarantee
+*when* state advances.
+
+**Evidence.**
+- `StateStore` is a three-method async trait (`get`/`put`/`delete` over
+  `serde_json::Value`) with `validate_state_key` guarding every access
+  (`crates/core/src/state.rs`).
+- Bookmarks are opaque `Value`s: the pipeline never interprets them, only the
+  producing source does (via `apply_start_bookmark`). Commit tokens are likewise
+  stored opaquely by sinks and never parsed by them.
+
+**Standard:** [state](./standards/state.md). See
+[ADR 0006](./adr/0006-state-management.md) and
+[State management](./architecture/state-management.md).
+
+---
+
+## 7. Deterministic, safe retries
+
+**Statement.** Retries use bounded exponential backoff with jitter, are gated on
+a typed classification of which errors are retriable, and never retry an
+operation whose replay could duplicate committed data.
+
+**Why.** Undisciplined retries either amplify a thundering herd or silently
+duplicate writes. Both are worse than the original transient failure. Retry
+safety is a special case of Principle 1.
+
+**Evidence.**
+- `crates/core/src/retry.rs` implements capped exponential backoff with
+  decorrelated per-attempt jitter (`backoff_with_jitter`), bounded by
+  `MAX_BACKOFF`.
+- The resilience layer classifies errors into a closed `RetryClass` set and only
+  retries those (`crates/core/src/resilience/classify.rs`).
+- The write path retries `write_batch` only when the sink is idempotent (see
+  Principle 1); `write_batch_idempotent` is always safe to retry because a
+  replayed token-stamped write is a no-op.
+
+**Standard:** [performance](./standards/performance.md) (backoff),
+[state](./standards/state.md) (retry safety). See
+[ADR 0007](./adr/0007-retries.md) and [Resilience](./architecture/resilience.md).
+
+---
+
+## 8. Backward compatibility is a feature
+
+**Statement.** The public API evolves additively. Trait growth uses defaulted
+methods; crates follow semver from a 1.0.0 floor; breaking changes are gated by a
+tool, not vigilance.
+
+**Why.** A connector ecosystem only forms if authors trust that their crate keeps
+working. Compatibility is the contract that makes the marketplace possible.
+
+**Evidence.**
+- Defaulted trait methods (Principle 3) mean trait growth is non-breaking.
+- Every crate is versioned `1.0.0` or higher — never `0.x` — a hard workspace
+  rule; new crates scaffold at `1.0.0`.
+- `cargo-semver-checks` gates the public API in CI.
+
+**Standard:** [api-design](./standards/api-design.md). See
+[Stability policy](./stability.md).
+
+---
+
+## 9. Safe defaults
+
+**Statement.** Every default is the choice that is hardest to get wrong.
+Stronger-but-riskier behaviour is always an explicit opt-in.
+
+**Why.** Most users take the defaults. The default must therefore be the safe
+one, even when a more aggressive setting would be faster or stronger.
+
+**Evidence.**
+- Delivery defaults to `AtLeastOnce`; exactly-once is an explicit
+  `with_delivery(ExactlyOnce)` gated on strict preconditions
+  (`crates/core/src/pipeline.rs`).
+- `batch_size` is bounded by `MAX_BATCH_SIZE` and validated, so a typo cannot
+  cause unbounded O(total) buffering; `0` (opt out of batching) is an explicit,
+  documented sentinel (`validate_batch_size`).
+- Riskier connector settings — e.g. the Postgres CDC replication connection
+  defaulting `tls: disable` — are explicit and warn loudly rather than being
+  silently enabled.
+
+**Standard:** [api-design](./standards/api-design.md).
+
+---
+
+## 10. Bounded memory and minimal allocation
+
+**Statement.** Memory use is O(batch_size), independent of total data volume.
+The runtime holds at most one page of records at a time.
+
+**Why.** A data-movement tool must move datasets larger than RAM. Streaming
+page-by-page is what makes an unbounded source safe to run on a small machine.
+
+**Evidence.**
+- `Pipeline::run` drives `Source::stream_pages` and writes each `StreamPage` as it
+  arrives, never materializing the whole result set (`crates/core/src/pipeline.rs`).
+- `DEFAULT_BATCH_SIZE = 1000`, `MAX_BATCH_SIZE = 1_000_000`; the default
+  `stream_pages` implementation chunks `fetch_all`, and native sources override it
+  to stream from their underlying primitive.
+- The known tension — `serde_json::Value` allocates per record — is acknowledged
+  as the main allocation cost and is the motivation for the Arrow record-model
+  exploration ([RFC 0002](../rfcs/0002-arrow-support.md)).
+
+**Standard:** [performance](./standards/performance.md). See
+[ADR 0001](./adr/0001-stream-pages.md) and [Batching](./architecture/batching.md).
+
+---
+
+## 11. Developer ergonomics for connector authors
+
+**Statement.** Building a connector requires depending on exactly one crate,
+learning one config shape, and implementing two required methods. Tooling makes
+the rest discoverable.
+
+**Why.** The marketplace thesis (a third party can publish
+`faucet-source-*` / `faucet-sink-*` crates) only works if the barrier to entry is
+low. Ergonomics is a growth strategy, not a nicety.
+
+**Evidence.**
+- `faucet-core` is the only required dependency and re-exports everything an
+  author needs (`async_trait`, `serde_json` with `Value`/`json!`, `schemars` with
+  `JsonSchema`/`schema_for!`).
+- Auth/credentials everywhere serialize as one consistent adjacently-tagged
+  `{ type, config }` shape, so learning it once transfers across connectors.
+- `faucet init` scaffolds config from a connector's JSON Schema; `faucet doctor`
+  probes connectivity; `faucet test` runs offline fixture-based pipeline tests.
+
+**Standard:** [api-design](./standards/api-design.md). See
+[Extensibility](./architecture/extensibility.md) and
+[Connector authoring](./contributing/connector-authoring.md).
+
+---
+
+## Related
+
+- [Architecture overview](./architecture/overview.md)
+- [Design invariants](./architecture/invariants.md)
+- [Repository standards](./standards/api-design.md)
+- [Architecture Decision Records](./adr/0001-stream-pages.md)
+- [Stability policy](./stability.md)
+- [Architecture review](./architecture-review.md)

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,153 @@
+# Glossary
+
+*The canonical vocabulary of faucet-stream. These terms are used with these exact meanings throughout the engineering documentation — link here rather than redefining a term in place.*
+
+Terminology precision matters most around delivery semantics, where a loose word
+("exactly-once") hides a real distinction. When in doubt, this page is
+authoritative; if code and this page disagree, the code wins and this page is a
+bug.
+
+---
+
+**Adaptive batching** — an opt-in controller (`crates/core/src/adaptive.rs`,
+AIMD) that reslices a source [page](#page--streampage) into sub-batches whose
+size it tunes from observed sink latency and error rate. Off by default. See
+[batching](./architecture/batching.md).
+
+**At-least-once** — the default [delivery guarantee](#delivery-guarantee). Every
+record reaches the sink one *or more* times; a crash in the
+[checkpoint](#checkpoint) window replays a [page](#page--streampage), which may
+duplicate rows but never loses them. See [recovery](./architecture/recovery.md).
+
+**Atomic-watermark** — one of the two [effectively-once](#effectively-once)
+mechanisms: the sink commits the page's records *and* a monotonic
+[commit token](#commit-token--watermark) atomically. Requires an idempotent sink,
+a deterministic-replay source, durable [state](#state-store), and no
+[DLQ](#dlq-dead-letter-queue).
+
+**Backfill** — a bounded historical replay over a `--from/--to` window, chunked
+into units, each re-running a root with `${backfill.*}` tokens. CLI-layer
+orchestration; see [execution](./architecture/execution.md).
+
+**Bookmark** — the durable value a [source](#source) uses to resume — an
+incrementing column's max value, a CDC log position, a Kafka offset set. Opaque
+to everything but the owning source; the [state store](#state-store) round-trips
+it as a `serde_json::Value` without interpreting it. Persisting a bookmark is a
+[checkpoint](#checkpoint). See [state management](./architecture/state-management.md).
+
+**Checkpoint** — the act of persisting a [bookmark](#bookmark) to the
+[state store](#state-store). The central invariant: a checkpoint happens **only
+after** the sink has durably written and flushed the page
+([invariants I1](./architecture/invariants.md)).
+
+**CDC (Change Data Capture)** — sources that stream a database's change log
+(postgres-cdc, mysql-cdc, mongodb-cdc). They emit a [bookmark](#bookmark) per
+committed transaction, getting per-transaction [checkpoint](#checkpoint)
+durability automatically.
+
+**Commit token / watermark** — the monotonic, fixed-width per-page token issued
+under the [atomic-watermark](#atomic-watermark) mechanism
+(`format_token` / `format_token_with_bookmark`, `crates/core/src/idempotency.rs`).
+Sinks store it opaquely; it may embed the page's resume [bookmark](#bookmark) so
+recovery can re-anchor the source exactly. "Watermark" and "commit token" are
+used interchangeably.
+
+**Connector** — a [source](#source) or a [sink](#sink). The unit of the
+marketplace; each lives in a `faucet-source-*` / `faucet-sink-*` crate depending
+only on `faucet-core`. See [connector SDK](./architecture/connector-sdk.md).
+
+**Contract** — a versioned promise about a pipeline's *output* schema/constraints
+(`pipeline.contract:`). `on_breach: fail` aborts the page (writes nothing);
+`quarantine` routes breaches to the [DLQ](#dlq-dead-letter-queue); `warn` logs.
+See [contracts](./architecture/contracts.md).
+
+**Delivery guarantee** — the promise about how many times a record reaches the
+sink under failure: [at-least-once](#at-least-once) (default) or
+[effectively-once](#effectively-once). Derived per topology in
+`derive_delivery_guarantee` and surfaced by `faucet validate`/`doctor`.
+
+**DLQ (dead-letter queue)** — an optional sink that receives records that failed
+to write (or were quarantined by quality/contract/drift), wrapped in a
+fixed-shape envelope. Note the envelope holds the *raw* failed record — see the
+[security model](./architecture/security.md). See
+[`../book/src/cookbook/dlq.md`](./book/src/cookbook/dlq.md).
+
+**Effectively-once** — the guarantee `delivery: exactly_once` actually provides:
+each record's *effect* on the sink is applied once, via one of two mechanisms —
+[atomic-watermark](#atomic-watermark) or [keyed-upsert](#keyed-upsert). faucet
+avoids the bare term "exactly-once" because true end-to-end exactly-once is not
+achievable across arbitrary systems; the effect being idempotent is what is
+delivered. See [recovery](./architecture/recovery.md).
+
+**Keyed-upsert** — the second [effectively-once](#effectively-once) mechanism:
+any source into an upsert-capable sink configured with `write_mode: upsert|delete`
++ a `key`. Idempotence comes from the sink's own keyed writes (replaying is a
+no-op); needs no watermark and allows a [DLQ](#dlq-dead-letter-queue).
+
+**Matrix** — the CLI's fan-out mechanism: a `matrix:` list where each row is
+deep-merged into the pipeline, with parent/child (`parent:`) and completion
+(`depends_on:`) edges forming a DAG. See [execution](./architecture/execution.md).
+
+**Page / `StreamPage`** — the unit of work: `StreamPage { records, bookmark }`, a
+chunk of records plus an optional [bookmark](#bookmark). Sources emit a stream of
+pages; the pipeline writes one at a time, bounding memory at `O(batch_size)`. See
+[stream-pages](./architecture/stream-pages.md).
+
+**Pipeline** — the engine (`faucet_core::Pipeline` / `run_stream`) that connects
+one [source](#source) to one [sink](#sink) and drives the per-page loop. Owns the
+[checkpoint](#checkpoint) ordering. See [pipeline](./architecture/pipeline.md).
+
+**Quality check** — per-record and per-batch validations
+(`pipeline.quality:`) that run after transforms and before the sink; failures
+`abort` or `quarantine` (to the [DLQ](#dlq-dead-letter-queue)). See
+[quality](./architecture/quality.md).
+
+**Resilience policy** — the opt-in `resilience:` block unifying retry, circuit
+breaker, and poison-pill handling (`crates/core/src/resilience/`). See
+[resilience](./architecture/resilience.md).
+
+**Run** — one execution of a [pipeline](#pipeline) (one invocation of a matrix
+row, one `faucet run`, one scheduled tick, one serve submission).
+
+**Schema drift** — divergence between an incoming page's top-level shape and the
+sink's live schema (`schema:` block). Policies: `warn` / `evolve` / `ignore` /
+`quarantine` / `fail`; `fail` *defers* its abort until survivors are durable
+(unlike a [contract](#contract) `fail`). See [schema](./architecture/schema.md).
+
+**Shard** — a slice of a single source distributed across cluster workers
+(`shard: { count }`), via PK-range, hash-of-key, or Kafka consumer-group
+membership (`crates/core/src/shard.rs`). Distinct from the [matrix](#matrix).
+
+**Sink** — a [connector](#connector) that writes records to a destination.
+Required method: `write_batch`; capabilities (idempotent writes, upsert, schema
+evolution) are opt-in defaulted trait methods. See
+[connector SDK](./architecture/connector-sdk.md).
+
+**Source** — a [connector](#connector) that reads records from an origin.
+Required method: `fetch_with_context`; streaming, resumability, exactly-once,
+sharding, and discovery are opt-in defaulted trait methods.
+
+**State key** — the string identifying a resumable position, validated by
+`validate_state_key`. Scheme: `{name}::{row_id}` for roots,
+`{name}::{row_id}::{parent_record_key}` for matrix children. See
+[state management](./architecture/state-management.md).
+
+**State store** — the `StateStore` trait (`get`/`put`/`delete` over `Value`)
+that persists [bookmarks](#bookmark). Built-in `memory` and `file` in core;
+`redis` and `postgres` in their own crates.
+
+**Transform** — a record-shaping stage (`flatten`, `select`, `cast`, `sql`,
+`cdc_unwrap`, …) applied per page between source and sink. Layered
+pipeline/source/row and resolved additively. See
+[`../book/src/cookbook/transforms.md`](./book/src/cookbook/transforms.md).
+
+**Write mode** — how a [sink](#sink) applies records: `append` (default),
+`upsert`, or `delete` (`faucet_core::write_mode`). Upsert/delete require a `key`
+and an upsert-capable sink; they enable the [keyed-upsert](#keyed-upsert)
+guarantee.
+
+## Related
+
+- [Design invariants](./architecture/invariants.md) — where the load-bearing terms are enforced.
+- [Architecture overview](./architecture/README.md)
+- [Documentation home](./README.md)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,123 @@
+# Architectural Roadmap
+
+*The direction of faucet-stream's architecture — near, medium, and long term. This is direction, not a dated commitment, and is subject to change.*
+
+This roadmap describes where the *architecture* is heading, not which connectors
+ship next. Feature-level and connector-level planning lives in the
+[community roadmap](./community/roadmap.md) and the tracking epic
+[#38](https://github.com/PawanSikawat/faucet-stream/issues/38). Deeper,
+subsystem-scoped direction is in
+[docs/architecture/roadmap.md](./architecture/roadmap.md); concrete design
+proposals live in [rfcs/](../rfcs/README.md).
+
+Each item links to the RFC or ADR that carries its design rationale. Items are
+grouped by architectural horizon, not by date — an item moves forward when its
+dependencies land and its RFC is accepted, not on a calendar.
+
+---
+
+## Guiding constraints
+
+Any change on this roadmap is held to three non-negotiable constraints, in order:
+
+1. **Correctness is never traded for capability.** No item ships if it can
+   silently corrupt downstream data. See
+   [engineering principles](./engineering-principles.md).
+2. **Backward compatibility.** Trait and API growth stays additive via defaulted
+   methods; crates remain semver-clean from a 1.0.0 floor. See
+   [stability](./stability.md).
+3. **`faucet-core` stays lean.** New orchestration and runtime surface belongs in
+   the CLI layer or its own crate, not in the connector-facing core. See
+   [ADR 0010](./adr/0010-pipeline-runtime.md).
+
+---
+
+## Near term — consolidate what exists
+
+Work that hardens and documents the current architecture without adding new
+runtime surface.
+
+- **Documentation maturity.** The architecture docs, ADRs, standards, and RFC
+  process introduced alongside this roadmap. The goal is that a new contributor
+  can understand *why* each subsystem is shaped as it is without reading the
+  5,471-line `crates/core/src/pipeline.rs` cold. Tracked here and across
+  [docs/architecture/](./architecture/README.md).
+- **Capability-trait cleanup.** The `Source`/`Sink` traits have accreted a dozen
+  defaulted capability methods (`supports_exactly_once`, `enumerate_shards`,
+  `supports_discover`, `current_schema`, …). Grouping these into coherent,
+  documented capability sets reduces the cognitive load without breaking object
+  safety. Design in [RFC 0001](../rfcs/0001-capability-traits.md).
+- **Connector SDK ergonomics.** Reduce the boilerplate checklist a new connector
+  must satisfy (feature flags in three places, `connectors/registry.json`, the CI
+  matrix, the docs capability table). Candidate direction: a proc-macro or code
+  generator that derives the wiring. See
+  [Extensibility](./architecture/extensibility.md) and
+  [Connector authoring](./contributing/connector-authoring.md).
+
+## Medium term — grow the platform surface
+
+Work that extends the framework's reach, each gated on an accepted RFC.
+
+- **Plugin-system maturity.** The CLI already supports compile-time plugin
+  registration via `PluginRegistry` (`cli/src/registry.rs`). The next step is a
+  documented, stable SDK contract for out-of-tree connectors — and, longer term,
+  the question of dynamic loading. Design in
+  [RFC 0003](../rfcs/0003-plugin-system.md).
+- **Arrow / columnar record path.** The `serde_json::Value` record model
+  ([ADR 0004](./adr/0004-json-record-model.md)) is ergonomic but allocation-heavy.
+  An optional Arrow-backed batch path would cut allocation and unlock zero-copy
+  hand-off to columnar sinks (Parquet, Iceberg, BigQuery) without replacing the
+  JSON model for the connectors that prefer it. Design in
+  [RFC 0002](../rfcs/0002-arrow-support.md).
+- **Benchmark-suite hardening.** `BENCHMARKS.md` and the scenario scripts exist;
+  the direction is a repeatable, CI-adjacent suite that guards against throughput
+  regressions on the hot `run_stream` path. See
+  [Performance](./architecture/performance.md).
+- **Connector certification.** A conformance test kit — driven by the connector
+  spec ([FCP v0](./spec/faucet-connector-spec-v0.md)) — that any first- or
+  third-party connector can run to prove it honours the streaming, checkpoint,
+  and error contracts. This is the quality gate that makes a marketplace
+  trustworthy.
+
+## Long term — architectural bets
+
+Directional bets that depend on medium-term work landing first. These are
+explicitly speculative.
+
+- **Zero-copy execution.** Building on the Arrow path, a batch representation that
+  flows from a columnar source to a columnar sink without per-record
+  materialization. Depends on [RFC 0002](../rfcs/0002-arrow-support.md).
+- **Dynamic plugins.** Loading connectors that were not compiled into the binary
+  (e.g. via a stable ABI or a WASM boundary). This is a hard problem in Rust and
+  is deliberately downstream of a stable compile-time SDK. Open question in
+  [RFC 0003](../rfcs/0003-plugin-system.md).
+- **Richer streaming runtime.** Windowing, ordering guarantees beyond per-page,
+  and multi-source joins push against the current single-source → single-sink
+  page model. Whether this belongs in `faucet-core` or a separate runtime crate
+  is itself a design question. Exploration in
+  [RFC 0004](../rfcs/0004-streaming-improvements.md) and
+  [RFC 0005](../rfcs/0005-async-connector-runtime.md).
+
+---
+
+## What is deliberately *not* on the roadmap
+
+- **Replacing `serde_json`** as the default record model. Arrow is additive, not a
+  replacement — the JSON model stays for the many connectors and transforms that
+  are natural over `Value`.
+- **Moving orchestration into `faucet-core`.** Scheduling, the HTTP control plane,
+  clustering, and DAG execution stay in the CLI layer by design
+  ([ADR 0010](./adr/0010-pipeline-runtime.md)).
+- **New source/sink connectors as an architectural priority.** Connector breadth
+  is tracked in the epic, not here; this roadmap is about the *framework*.
+
+---
+
+## Related
+
+- [docs/architecture/roadmap.md](./architecture/roadmap.md) — subsystem-level direction
+- [Community roadmap](./community/roadmap.md) — feature/connector planning
+- [RFC index](../rfcs/README.md)
+- [Architecture review](./architecture-review.md) — the risks this roadmap addresses
+- [Stability policy](./stability.md)
+- [Engineering principles](./engineering-principles.md)

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -1,0 +1,148 @@
+# API Stability Policy
+
+*What is stable, what is experimental, what is internal, and the compatibility you can rely on across releases.*
+
+faucet-stream is a Cargo workspace of independently versioned crates (63 as of
+this writing) plus the `faucet` CLI. This document defines which parts of that
+surface carry a stability promise, and what that promise means in practice.
+
+The policy exists to serve two audiences with opposite needs: **connector
+authors** and **library embedders**, who need a stable foundation to build on;
+and **maintainers**, who need room to evolve the runtime. The categories below
+draw the line between them.
+
+---
+
+## Semver expectations
+
+- **Every crate is versioned `1.0.0` or higher — never `0.x`.** A `1.x` release
+  follows semantic versioning: breaking changes to a crate's public API require a
+  major-version bump.
+- **The public API is gated by tooling, not vigilance.** `cargo-semver-checks`
+  runs in CI against each crate's public surface, so an accidental breaking change
+  fails the build rather than shipping.
+- **Object-safe defaulted trait methods are the compatibility workhorse.** When
+  `Source` or `Sink` grows a new capability method, it ships with a default
+  implementation. Existing connectors — including third-party crates compiled
+  against an older `faucet-core` — keep compiling and behave exactly as before.
+  This is why trait growth is *not* a breaking change here. See
+  [ADR 0003](./adr/0003-builder-pattern.md) and
+  [Engineering principles](./engineering-principles.md).
+
+### The feature-flag caveat
+
+Cargo features are part of the compatibility surface but are governed
+separately from semver on types. Enabling a new *optional* feature is additive
+and non-breaking. However, feature *unification* across a workspace can change
+observable behaviour (for example, `serde_json`'s `preserve_order` flips `Map`
+from `BTreeMap` to `IndexMap` under `--all-features`). Code — and especially
+tests — must not depend on behaviour that only holds under a particular feature
+set. Treat feature-gated behaviour as covered by the same stability tier as the
+type it gates.
+
+---
+
+## Stable
+
+Stable APIs carry the full semver promise: they will not break without a major
+version bump, and breaking them requires a deprecation cycle (below). The Stable
+set is grounded in what the crate roots actually re-export.
+
+**`faucet-core` (the connector-facing contract):**
+
+- The `Source` and `Sink` traits, including their defaulted capability methods.
+  New defaulted methods may be *added* (non-breaking); existing signatures are
+  stable.
+- `Pipeline` and its `with_*` builder methods; the free function `run_stream` and
+  `RunStreamOptions`.
+- `StreamPage`, `PipelineResult`, and the batch-size contract
+  (`DEFAULT_BATCH_SIZE`, `MAX_BATCH_SIZE`, `validate_batch_size`, the `0`
+  sentinel).
+- `StateStore` and the built-in `MemoryStateStore` / `FileStateStore`;
+  `validate_state_key`.
+- `FaucetError` and its variants, including `Custom(Box<dyn Error>)` for
+  third-party errors. New variants may be added (the enum is not exhaustively
+  matched by well-behaved external code).
+- The re-exported ecosystem crates connector authors depend on: `async_trait`,
+  `serde_json` (`Value`, `json!`), `schemars` (`JsonSchema`, `schema_for!`).
+
+**CLI:**
+
+- The **config-file grammar `version: 1`** — the top-level `pipeline` / `matrix`
+  / `execution` / `auth` shape, the `{ type, config }` connector shape, and the
+  documented transform/state/dlq blocks. Grammar changes are additive within
+  `version: 1`; an incompatible grammar would be a new `version`.
+- The stable CLI verbs and their documented flags: `run`, `validate`, `schema`,
+  `list`, `preview`, `init`, `doctor`, `test`.
+
+## Experimental
+
+Experimental APIs are shipped, supported, and safe to use, but their surface may
+change in a minor release as the design settles. They are opt-in — a user who
+does not enable them is unaffected. Pin the crate version if you depend on the
+exact shape.
+
+- **Clustered execution** (`--cluster`, Mode A/B) and its `RunHistory` cluster
+  methods.
+- **Event-driven triggers** (`--triggers`, the `triggers*` feature family) — the
+  trigger config schema and `${trigger.*}` tokens.
+- **Data Movement Catalog** (`catalog` feature) — the `catalog:` block, the
+  `/v1/catalog/*` endpoints, and the catalog storage schema.
+- **Adaptive batching** (`with_adaptive`, `crates/core/src/adaptive.rs`) — the
+  AIMD controller knobs.
+- **OTLP export** (`otel` feature) — the `observability.otel:` block. The OTel
+  crate stack is pinned to the 0.31 line, so this surface tracks an
+  upstream-in-flux dependency.
+- **The HTTP control plane** (`faucet serve`) request/response shapes beyond the
+  documented `docs/openapi.yaml` core — the OpenAPI file is the source of truth,
+  and endpoints outside it should be treated as experimental.
+
+## Internal
+
+Internal surface has no stability promise and may change at any time. Do not
+build against it. It is internal precisely because it is not re-exported from a
+crate root.
+
+- Everything under `cli/src/serve/` (the axum server, history backends, RBAC,
+  cluster loops) except the documented HTTP API.
+- The `crates/core/src/observability/` decorator internals (`InstrumentedSource`,
+  `InstrumentedSink`, the metric-emission plumbing). The *metric names and labels*
+  they emit are a stable operational contract; the Rust types are not.
+- Pure helper modules not re-exported from `lib.rs` (compile passes, expand,
+  merge, interpolate, etc. in the CLI).
+- The exactly-once token format (`format_token`, `wrap_state`) — sinks store
+  tokens opaquely and must never parse them; the format is an internal
+  implementation detail of the runtime.
+
+## Deprecated
+
+There are **no deprecated public APIs at this time.** When something is
+deprecated in the future, it will follow this cycle:
+
+1. **Announce** in the crate's `CHANGELOG.md` and mark the item
+   `#[deprecated(since = "...", note = "use X instead")]` so it warns at compile
+   time.
+2. **Coexist** — the deprecated item keeps working for at least one minor release,
+   with the replacement documented alongside it.
+3. **Remove** only in a major version bump, never in a minor or patch release.
+
+This mirrors how trait growth stays additive: users get a compiler-visible signal
+and a migration window before anything they depend on disappears.
+
+---
+
+## Reporting a compatibility break
+
+If a minor or patch release breaks a Stable API, that is a bug — please open an
+issue. The `cargo-semver-checks` gate is meant to make this impossible, so a real
+break is worth investigating as a CI-coverage gap, not just a fix.
+
+---
+
+## Related
+
+- [Engineering principles](./engineering-principles.md) — backward compatibility as a feature
+- [ADR 0003 — builder pattern & object-safe traits](./adr/0003-builder-pattern.md)
+- [Standards: API design](./standards/api-design.md)
+- [Architectural roadmap](./roadmap.md)
+- [Connector protocol (FCP v0)](./spec/faucet-connector-spec-v0.md)

--- a/docs/standards/api-design.md
+++ b/docs/standards/api-design.md
@@ -1,0 +1,67 @@
+# API Design Standard
+
+*Conventions every public type, trait, and connector API in faucet-stream must follow so the ecosystem stays object-safe, additive, and stable.*
+
+This standard governs anything reachable from a crate's public surface — most importantly `faucet_core`, which third-party connector authors depend on directly. The overriding constraint is that faucet-stream is a **marketplace**: a change that forces every `faucet-source-*` / `faucet-sink-*` crate to be edited is a design failure, not a routine bump.
+
+Related decisions: [ADR 0003 — Builder Pattern](../adr/0003-builder-pattern.md), [ADR 0004 — JSON Record Model](../adr/0004-json-record-model.md).
+
+## Traits
+
+- **MUST keep `Source` and `Sink` object-safe.** They are consumed as `Box<dyn Source>` / `Box<dyn Sink>` throughout the pipeline and the CLI registry (`crates/core/src/traits.rs`, `cli/src/registry.rs`). No generic type parameters on trait methods, no associated types, no `Self`-returning methods, no `impl Trait` in return position that would break `dyn`.
+- **MUST give every new trait method a default implementation.** A new method without a default is a breaking change for every existing connector. All capability methods added over time — `stream_pages`, `state_key`, `capture_resume_position`, `supports_exactly_once`, `is_shardable`/`enumerate_shards`/`apply_shard`, `supports_discover`/`discover`, `current_schema`/`supports_schema_evolution`/`evolve_schema`, `check` — ship with a safe default so a connector written against an older core still compiles.
+
+  ```rust
+  // GOOD — additive, defaulted, opt-in.
+  fn supports_discover(&self) -> bool { false }
+  async fn discover(&self) -> Result<Vec<DatasetDescriptor>, FaucetError> {
+      Err(FaucetError::Source("discover not supported".into()))
+  }
+
+  // BAD — no default; breaks every connector on upgrade.
+  async fn discover(&self) -> Result<Vec<DatasetDescriptor>, FaucetError>;
+  ```
+
+- **SHOULD express a new capability as a boolean probe + a defaulted worker method**, mirroring `supports_exactly_once()` + `write_batch_idempotent()`. The probe lets the runtime and `faucet validate`/`doctor` reason about topology *before* a run; the worker stays inert until overridden.
+- **MUST NOT couple a trait to a concrete connector or a driver type.** Method signatures use `serde_json::Value`, `&str`, and core types only. Driver-specific types (a `sqlx::Pool`, an `aws_sdk_s3::Client`) never appear on a trait boundary.
+
+## Builders
+
+- **MUST expose runtime wiring through progressive `with_*` builders**, not wide constructors. `Pipeline::new(&source, &sink)` returns a working pipeline; every optional capability is a chained, order-independent `.with_state_store(..)`, `.with_dlq(..)`, `.with_quality(..)`, `.with_cancel(..)`, `.with_delivery(..)` (see `crates/core/src/pipeline.rs`). The same shape backs `RunStreamOptions`.
+- **Rationale:** a builder is inherently backward-compatible (a new knob is a new method, never a new positional argument) and it keeps the zero-config path a one-liner. See [ADR 0003](../adr/0003-builder-pattern.md).
+
+## Connector dependency surface
+
+- **`faucet-core` MUST remain the only required dependency for a connector author.** It re-exports the crates authors would otherwise pin themselves: `async_trait`, `serde_json` (with `Value`, `json!`), `schemars` (`JsonSchema`, `schema_for!`), `async_stream`, and `tokio_util::sync::CancellationToken`.
+- **MUST re-export a new shared dependency from `faucet-core`** rather than requiring authors to add it to their own `Cargo.toml`.
+- **MUST NOT add a mandatory heavy dependency to `faucet-core`** (DB drivers, cloud SDKs). Core stays lightweight; connector-specific deps belong in the connector crate. See [ADR 0006](../adr/0006-state-management.md) for the same principle applied to state backends.
+
+## Config types
+
+- **Every config struct MUST derive `Serialize + Deserialize + JsonSchema`** and every sub-enum with it. This is what powers `faucet schema`, `faucet init`, and editor autocomplete for free.
+- **Config structs MUST contain no I/O or protocol logic.** They live in `config.rs`; the single I/O module is `stream.rs`/`sink.rs`. A config type is pure data.
+- **Auth/credentials MUST use the adjacently-tagged `{ type, config }` shape** with snake_case discriminators, e.g. `auth: { type: bearer, config: { token: … } }`. This one wire shape is consistent across every connector and the shared `auth:` catalog; it also accepts `auth: { ref: <name> }` for shared providers. Introducing a differently-shaped auth block is a defect.
+
+  ```yaml
+  # GOOD — the canonical adjacently-tagged shape.
+  auth: { type: oauth2, config: { client_id: …, client_secret: … } }
+  # BAD — flat/internally-tagged; inconsistent with the rest of the ecosystem.
+  auth: { type: oauth2, client_id: …, client_secret: … }
+  ```
+
+- **Custom-serde fields MUST carry `#[schemars(with = "...")]`** so the generated schema stays valid (e.g. `reqwest::Method` → `String`).
+
+## Versioning
+
+- **Every crate we ship starts at `1.0.0` or higher — never `0.x`.** A new crate is scaffolded at `version = "1.0.0"` in both its `Cargo.toml` and the `[workspace.dependencies]` path entry.
+- **MUST treat public-API changes under semver discipline.** The `cargo-semver-checks` gate in CI is the backstop; a breaking change requires a major bump and an entry in the change surface described by [docs/stability.md](../stability.md).
+- **SHOULD prefer an additive path over a breaking one.** A defaulted trait method, a new builder method, or a new enum variant behind `#[non_exhaustive]` is almost always available and avoids an ecosystem-wide edit.
+
+## Related
+
+- [ADR 0003 — Builder Pattern](../adr/0003-builder-pattern.md)
+- [ADR 0004 — JSON Record Model](../adr/0004-json-record-model.md)
+- [Public API Stability](../stability.md)
+- [Connector SDK](../architecture/connector-sdk.md)
+- [Extensibility](../architecture/extensibility.md)
+- [Error Handling Standard](./error-handling.md)

--- a/docs/standards/error-handling.md
+++ b/docs/standards/error-handling.md
@@ -1,0 +1,61 @@
+# Error Handling Standard
+
+*Every failure path is explicit, typed, and mapped to a `FaucetError` variant — silent incorrectness is the worst class of bug this project can ship.*
+
+Data movement fails in the field: APIs rate-limit, WAL slots vanish, a page arrives with the wrong shape. The standard exists because a mishandled failure here does not crash loudly — it corrupts a downstream table quietly. Correctness of the failure path is therefore treated as equal to correctness of the happy path.
+
+## The `FaucetError` taxonomy
+
+All fallible operations return `Result<_, FaucetError>` (`crates/core/src/error.rs`). Pick the variant that names the failure; do not flatten everything into a string.
+
+| Variant | Use for |
+|---|---|
+| `Http(reqwest::Error)` | Transport-level HTTP failures (`#[from]`). |
+| `HttpStatus { status, url, body }` | A non-2xx response the connector chooses to surface with context. |
+| `Json(serde_json::Error)` | (De)serialization failures (`#[from]`). |
+| `JsonPath(String)` | A JSONPath/extraction expression that did not resolve as required. |
+| `Auth(String)` | Credential acquisition/refresh failure. |
+| `RateLimited(Duration)` | A throttle signal carrying the retry-after hint. |
+| `Url(String)` | Malformed/unbuildable URL. |
+| `Transform(String)` | A transform stage failed on a record/page. |
+| `Config(String)` | Load-time / validation failure. **Prefer this over a mid-run panic** — reject bad config before any data moves. |
+| `Source(String)` / `Sink(String)` | Connector-specific runtime failures with no better variant. |
+| `QualityFailure { check, message }` | An `abort`-policy quality check tripped. |
+| `SchemaDrift { columns, message }` | A drift policy set to `fail` (or `on_incompatible: fail`). |
+| `ContractViolation { version, message }` | A data-contract breach under `on_breach: fail`. |
+| `State(String)` | State-store get/put/delete failure. |
+| `CircuitOpen { failures, cooldown }` | The resilience circuit breaker tripped after N fully-failed pages. |
+| `Custom(Box<dyn Error + Send + Sync>)` | **Third-party connectors wrap their own error types here** (`#[from]`). Never remove this variant. |
+
+- **MUST use `thiserror`** for all error enums, with a human-readable `#[error("…")]` per variant.
+- **MUST add a typed variant for any silent-corruption-prone path.** The reason `QualityFailure`, `SchemaDrift`, and `ContractViolation` are first-class variants rather than `Source(String)` is that the runtime, the DLQ router, and dashboards must distinguish "a record broke a promise" from "the network hiccupped". If you introduce a new correctness gate, give it a typed variant.
+- **Third-party connectors MUST route their driver errors through `Custom`**, not by stringifying into `Source`/`Sink` (stringifying loses the source chain).
+
+## Panics
+
+- **MUST NOT `.unwrap()` / `.expect()` on a value that can fail at runtime.** Network, parsing, config, and I/O are all runtime-fallible — they return `Result`.
+- **MAY use `.expect()` only for a construction-time invariant** that was validated earlier and cannot be false at that point — and the message must state the invariant.
+
+  ```rust
+  // GOOD — runtime-fallible, returns a typed error.
+  let resp = client.get(&url).send().await.map_err(FaucetError::Http)?;
+
+  // GOOD — invariant validated in new(); message names it.
+  let re = self.compiled.as_ref().expect("regex compiled in QualitySpec::compile");
+
+  // BAD — a lost response or 500 becomes a panic that takes down the run.
+  let resp = client.get(&url).send().await.unwrap();
+  ```
+
+## Explicitness
+
+- **Every failure branch MUST be handled deliberately.** Think through the field failure modes for the code you touch: an empty page mid-stream, a malformed `Link` header, a JSONPath that matches nothing, an API that commits server-side but drops the response. Each must resolve to a defined outcome (typed error, retry, DLQ route, or documented skip) — never an implicit `unwrap`, silent drop, or duplicated write.
+- **Config validation MUST be fail-fast.** Compile regexes, JSON Schemas, bounds, and enum values at load time and return `FaucetError::Config`, so an operator sees the problem at `faucet validate` rather than three hours into a run. This is how `CompiledQuality::compile`, `CompiledContract::compile`, and `SchemaDriftPolicy::compile` behave.
+
+## Related
+
+- [Error taxonomy in core](../architecture/overview.md)
+- [Resilience](../architecture/resilience.md) · [Retries](../architecture/retries.md)
+- [State & Durability Standard](./state.md)
+- [Testing Standard](./testing.md)
+- [Common Mistakes](../contributing/common-mistakes.md)

--- a/docs/standards/logging.md
+++ b/docs/standards/logging.md
@@ -1,0 +1,48 @@
+# Logging & Metrics Standard
+
+*Spans and metrics are emitted automatically by the pipeline; this standard keeps them low-cardinality, consistently labelled, and safe to expose.*
+
+Connectors do **not** write their own metrics code. The pipeline-internal decorators in `crates/core/src/observability/` wrap every source, sink, transform, and state-store call, so instrumentation is uniform whether the connector is built-in or third-party. This standard is the set of rules that keep that surface healthy. See [Observability](../architecture/observability.md) for the mechanism.
+
+## Metric naming & labels
+
+- **Metric names MUST use the `faucet_` prefix** and standard suffix conventions (`_total` counters, `_seconds` histograms, `_unix_seconds` gauges).
+- **The common label set is `pipeline`, `row`, `connector`.** `row` is the matrix-row id (`""` for non-matrix runs); `connector` comes from `connector_name()`.
+- **`run_id` MUST be a span attribute only, never a metric label.** It is unbounded per run and would blow up cardinality.
+
+  ```rust
+  // GOOD — run_id on the span, bounded labels on the metric.
+  let span = info_span!("faucet.pipeline.run", pipeline=%name, row=%row, run_id=%run_id);
+  counter!("faucet_source_records_total", labels).increment(n);
+
+  // BAD — unbounded label; one series per run forever.
+  counter!("faucet_source_records_total", "run_id" => run_id).increment(n);
+  ```
+
+## Cardinality rules
+
+- **MUST NOT use a high-cardinality value as a metric label** — record IDs, URLs, query strings, offsets, cursor tokens, primary keys. These belong in span attributes or structured log fields, never in the Prometheus label set.
+- **`parent_record_key` (in a parent/child matrix) MUST be a span attribute only**, never a metric label.
+- **`connector_name()` MUST return a non-empty `&'static str`.** An empty string falls back to `"unknown"` in release builds and trips a `debug_assert!` in debug. Built-in connectors override the default with a friendly label (`"rest"`, `"jsonl"`, …).
+
+## Spans
+
+- **SHOULD attach identifying context to the span, not the message.** The pipeline opens `faucet.pipeline.run` with `pipeline`, `row`, `run_id`, `source`, `sink`; subordinate spans inherit it. Emit structured fields (`records = n`) rather than interpolating them into a free-text message.
+- **Long-running (streaming/CDC) pipelines** rely on gauge heartbeats (`faucet_pipeline_start_time_unix_seconds`, `faucet_pipeline_seconds_since_last_bookmark`) rather than the run-duration histogram, which never fires until the run ends. Preserve those gauges when touching the run loop.
+
+## Secret redaction boundary
+
+- **The redaction boundary covers faucet's own tracing/log/error output only** — resolved `${vault:…}` / `${aws-sm:…}` values are scrubbed at the I/O boundary by the CLI `RedactingWriter` (`cli/src/secrets/registry.rs`).
+- **MUST NOT assume redaction covers third-party output.** A connector's driver debug logging, Prometheus label values, and span attributes are **outside** the boundary. Never place a resolved secret where a driver might log it, and never enable `FAUCET_LOG=debug` on a pipeline whose connector configs hold resolved secrets.
+- **MUST register any new operator-supplied token/secret for redaction** when adding one (e.g. serve auth tokens are registered so they never appear in run logs).
+
+## Failure isolation
+
+- **Instrumentation MUST NOT be able to fail a run.** Lineage/OTLP export errors are logged and counted (`faucet_lineage_dropped_total`, `faucet_otel_export_failures_total`), never propagated. Metric recorder / subscriber double-install warns rather than panics (`install_observability` is idempotent). Preserve this property.
+
+## Related
+
+- [Observability architecture](../architecture/observability.md)
+- [ADR 0008 — Observability](../adr/0008-observability.md)
+- [Error Handling Standard](./error-handling.md)
+- [Operations: Observability](../../docs/book/src/operations/observability.md)

--- a/docs/standards/performance.md
+++ b/docs/standards/performance.md
@@ -1,0 +1,44 @@
+# Performance Standard
+
+*Throughput and bounded memory are review criteria, not afterthoughts — every connector should be the fastest correct way to move data between its endpoints in Rust.*
+
+The Primary Goal of this project is that all sources and sinks are as fast, efficient, and reliable as possible. That makes performance a **correctness-adjacent review gate**: a connector that recreates a client per call or buffers the whole dataset is not "slow but fine", it is below standard.
+
+## Mandatory disciplines
+
+Apply these when adding or modifying any connector. Each is a MUST unless the connector's protocol makes it impossible (say so in the PR if so).
+
+- **Reuse clients and connections.** Create HTTP clients, S3/GCS clients, DB pools, Redis connections, and Kafka producers once in `new()` and store them on the struct. **MUST NOT** construct a client, pool, or connection inside a per-record or per-page hot path.
+
+  ```rust
+  // GOOD — pool built once, reused per page.
+  struct PostgresSink { pool: PgPool }
+  impl PostgresSink { fn new(cfg) -> Self { Self { pool: build_pool(cfg) } } }
+
+  // BAD — reconnects on every batch; destroys throughput and leaks handles.
+  async fn write_batch(&self, rows) { let pool = build_pool(&self.cfg); … }
+  ```
+
+- **Pool connections with a configurable bound.** Database connectors expose `max_connections` (default 10 sources / 5 sinks).
+- **Use multi-row / bulk APIs.** DB sinks issue multi-row `INSERT … VALUES (…), (…)`; prefer native bulk endpoints (Elasticsearch `_bulk`, BigQuery `insertAll`, Mongo `insert_many`, Redis pipelines). One request per record is a defect.
+- **Wrap batches in a transaction** where the store supports it (the SQLite sink brackets each batch in `BEGIN`/`COMMIT`).
+- **Parallelize I/O with a bound.** Use `buffer_unordered(concurrency)` for concurrent object reads/writes and semaphore-gated concurrent HTTP sends. Expose the bound (`concurrency` / `max_connections`) with a sane default — never unbounded.
+- **Buffer file I/O** and move blocking work (`csv` (de)serialization) onto `spawn_blocking` so the async runtime is never blocked.
+
+## Memory bound
+
+- **The pipeline holds at most O(`batch_size`) records in flight per side**, regardless of total volume, because `run_stream` writes each `StreamPage` as it arrives (`crates/core/src/pipeline.rs`). A connector **MUST NOT** defeat this by materializing the full result set when a streaming primitive exists — override `stream_pages` to stream natively from the underlying cursor/scroll/consumer. See [Batching](../architecture/batching.md) and [Stream Pages](../architecture/stream-pages.md).
+- **`batch_size = 0`** is the explicit opt-out (emit/accept the entire result set in one page) — use it only where a single large request is genuinely better (SQL `COPY`, a load job), not as a shortcut around streaming.
+
+## Optimizing responsibly
+
+- **MUST have evidence before optimizing.** A performance change to working code requires a benchmark or a profile showing the hot path — not intuition. The benchmark harness and scale findings are the reference (`BENCHMARKS.md`, `scripts/`).
+- **MUST NOT trade correctness for speed.** A retry that can duplicate rows, a skipped flush, or a reordered checkpoint is never an acceptable optimization. See [State & Durability Standard](./state.md).
+- **SHOULD prefer the highest-leverage change**: reducing round-trips (batching, pipelining) beats micro-optimizing allocation in almost every connector. The known systemic allocation cost — `serde_json::Value` per record — is tracked for a columnar record model in [RFC 0002](../../rfcs/0002-arrow-support.md), not worked around ad hoc.
+
+## Related
+
+- [Performance architecture](../architecture/performance.md)
+- [Batching](../architecture/batching.md) · [Stream Pages](../architecture/stream-pages.md)
+- [State & Durability Standard](./state.md)
+- [Book: throughput tuning](../../docs/book/src/cookbook/tuning.md)

--- a/docs/standards/state.md
+++ b/docs/standards/state.md
@@ -1,0 +1,48 @@
+# State & Durability Standard
+
+*The write→flush→checkpoint ordering is the project's central data-integrity invariant and must never be reordered.*
+
+State is what makes a run resumable and what stands between a crash and a corrupted destination. The rules here are stricter than the rest of the standards because a violation is silent: it does not fail CI, it loses or duplicates data in production. Read alongside [ADR 0002 — Checkpoint Ordering](../adr/0002-checkpoint-ordering.md) and [Design Invariants](../architecture/invariants.md).
+
+## The ordering invariant
+
+- **A page's bookmark MUST be persisted only AFTER the sink has durably written and flushed that page.** In `run_stream` (`crates/core/src/pipeline.rs`) every one of the three write paths (default, DLQ, exactly-once) follows the same order:
+
+  1. `write_batch` / `write_batch_partial` / `write_batch_idempotent`
+  2. `sink.flush()`
+  3. `StateStore::put(key, bookmark)`
+
+- **This ordering MUST NOT be reordered, "optimized", or short-circuited.** Persisting the bookmark before the flush would advance the checkpoint past records the sink has not durably accepted — a crash there loses data with no way to detect it. The flush matters concretely: a buffered sink (Parquet writes its footer on flush; S3 completes its multipart) is only readable after the flush returns.
+- **The crash window between flush and put is intentional and safe.** If the process dies after the flush but before the put, the run resumes and re-reads the page:
+  - **at-least-once** (default): the page is re-written. Sinks must tolerate this — it is the contract.
+  - **effectively-once**: the sink's committed watermark seq ≥ the page's, so the page is skipped (`faucet_pipeline_pages_skipped_total`), or the sink-anchored resume re-anchors the source to the token-embedded bookmark. See [Recovery](../architecture/recovery.md).
+
+## State keys
+
+- **Every state key MUST pass `validate_state_key`** (`crates/core/src/state.rs`) before a get/put/delete. Keys are colon-namespaced and reject empty, leading-dot, and path-traversal forms.
+- **The CLI owns the key scheme**, not the connector: `{name}::{row_id}` for roots, `{name}::{row_id}::{parent_record_key}` for matrix children, with namespaced variants for backfill (`{name}::backfill::{unit}`) and replication (`{name}::__replication__`). A connector exposes its *natural* key via `state_key()`; the executor overrides it via `StateKeyOverride`.
+
+## Bookmarks are opaque
+
+- **A bookmark is an opaque `serde_json::Value` owned by the source that produced it.** Only that source interprets it (`apply_start_bookmark`). No other component parses a bookmark's internal shape.
+- **A source MUST advance its bookmark monotonically** with respect to committed work, so a resume never moves backward past durably-written records.
+
+## Commit tokens are opaque to sinks
+
+- **A sink MUST store the commit token verbatim and never parse it.** The token may carry a `#<bookmark-json>` suffix (`format_token_with_bookmark`); the sink treats the whole string as an opaque watermark it writes atomically alongside the page and reads back in `last_committed_token`. Only the pipeline (`crates/core/src/idempotency.rs`) parses tokens.
+- **`write_batch_idempotent` MUST commit the page and the token in one atomic unit** — an in-transaction UPSERT into `_faucet_commit_token`, a snapshot summary property, a Kafka transaction, etc. Committing them separately breaks the guarantee.
+
+## Delivery-guarantee gate
+
+- **`delivery: exactly_once` MUST satisfy one of two topologies** (enforced at config-load in `cli/src/expand.rs`, re-checked in `run_stream`):
+  - **atomic-watermark:** an idempotent sink (`supports_idempotent_writes`) + a deterministic-replay source (`replay_guarantee`) + a durable (non-`memory`) state store + **no DLQ** (incompatible in this version); or
+  - **keyed-upsert:** an upsert-capable sink configured with `write_mode: upsert|delete` + non-empty `key`, with any source and no state/DLQ requirement.
+- **Retries on a non-idempotent `write_batch` are forbidden** unless the sink reports `supports_idempotent_writes()` — a retried lost-response write silently duplicates rows. `run_stream`'s `with_retry_write!` enforces this. See [ADR 0007 — Retries](../adr/0007-retries.md).
+
+## Related
+
+- [ADR 0002 — Checkpoint Ordering](../adr/0002-checkpoint-ordering.md)
+- [ADR 0006 — State Management](../adr/0006-state-management.md)
+- [Design Invariants](../architecture/invariants.md)
+- [State Management](../architecture/state-management.md) · [Recovery](../architecture/recovery.md)
+- [Error Handling Standard](./error-handling.md)

--- a/docs/standards/testing.md
+++ b/docs/standards/testing.md
@@ -1,0 +1,43 @@
+# Testing Standard
+
+*Untested public API is a liability; every non-trivial behavior ships with a test, and changed lines must clear a hard 90% patch-coverage gate.*
+
+This is the authoritative statement of the repository's testing rules. The [contributor testing guide](../contributing/testing.md) shows *how* to satisfy them with the project's tooling.
+
+## What must be tested
+
+- **New code MUST have tests.** Every new function or behavior gets a test — non-negotiable. Untested public surface is treated as a defect in review.
+- **Tests MUST assert the specific outcome**, not merely "no panic". Check the extracted records, the pagination-state transition, the exact error variant, the emitted bookmark — the thing that would silently regress.
+- **Correctness gates get failure-path tests.** Config validation, `match` arms, and error branches are all unit-testable and are exactly where silent corruption hides; cover them.
+
+## Where tests live
+
+- **Unit tests MUST live in `#[cfg(test)]` modules** at the bottom of the source file, for logic that needs no network I/O — JSONPath extraction, pagination state, auth-header generation, config validation, pure planning functions (`plan_writes`, `plan_pk_shards`, `diff_schema`).
+- **Integration tests MUST live in the crate's `tests/` directory**, using `wiremock` for HTTP connectors and `testcontainers` for database/queue connectors.
+- **SHOULD refactor an untestable line rather than exempt it.** Extract the pure logic; make the I/O a thin, separately-covered shim. Most low coverage is a design smell, not an inherent limit.
+
+## Modifying existing tests
+
+- **MUST NOT blindly update an existing test to make a change pass.** If a code change breaks a test, investigate first — silently rewriting the assertion to match new behavior hides regressions. Change the test only once you have confirmed the new behavior is correct and intended.
+
+## The coverage gate
+
+- **Every PR MUST land at ≥90% patch (changed-line) coverage.** `codecov/patch` is a **required** status check; a PR below 90% cannot merge. 90% is the floor, not a stretch goal.
+- **MUST verify patch coverage locally before pushing** (`cargo llvm-cov` intersected with the diff) so the gate never surprises you. Docker-gated integration tests do not count toward the instrumented patch number — cover changed lines with unit tests.
+- **MAY take an exception only for genuinely untestable surface** (a SIGTERM handler, a `main()` dispatch arm, an infinite supervisory loop), kept to the few unreachable lines and called out explicitly in the PR.
+
+## Project-specific techniques
+
+These recur; use them instead of reaching for Docker or skipping coverage:
+
+- **Offline pool tests:** `sqlx` `connect_lazy` with a short `acquire_timeout` exercises pool-backed source logic without a live database (does not work for the eager MSSQL pool).
+- **TUI / terminal paths:** render through a `TestBackend` and split the drive loop from the crossterm setup so the interactive path is covered in CI, which has no TTY.
+- **Shipped examples:** every new `cli/examples/*.yaml` must validate under the env-placeholder allowlist in `cli/tests/cli_end_to_end.rs` — use literal hosts/brokers unless the var is allow-listed.
+- **Feature-unification hazards:** a test asserting `serde_json::Map` key *order* passes under `-p <crate>` but fails under CI `--all-features` (the `preserve_order` feature flips `BTreeMap`↔`IndexMap`); assert the *set*, not the sequence.
+
+## Related
+
+- [Contributor testing guide](../contributing/testing.md)
+- [Performance Standard](./performance.md)
+- [Error Handling Standard](./error-handling.md)
+- [Common Mistakes](../contributing/common-mistakes.md)

--- a/rfcs/0000-template.md
+++ b/rfcs/0000-template.md
@@ -1,0 +1,78 @@
+# RFC 0000 — Template
+
+*Copy this file to `rfcs/NNNN-short-title.md` and fill in every section. Delete this italic line.*
+
+| | |
+|---|---|
+| **RFC** | 0000 |
+| **Title** | *A short, descriptive title* |
+| **Status** | Draft \| Discussion \| Accepted \| Rejected \| Implemented |
+| **Authors** | *your name / handle* |
+| **Related issues** | *#NNN, epic #38* |
+| **Related ADRs** | *docs/adr/NNNN-*.md, if any* |
+
+## Summary
+
+One paragraph. What does this RFC propose, in plain terms? A reader should be
+able to decide from this section alone whether the rest is relevant to them.
+
+## Motivation
+
+Why are we doing this? What problem does it solve, and for whom (framework
+maintainers, connector authors, or end users)? Tie the motivation back to a
+concrete pain in the current implementation — cite the code or behaviour that is
+inadequate today, with file paths. Explain what happens if we do nothing.
+
+## Guide-level explanation
+
+Explain the proposal as if it were already implemented and you were teaching it
+to a contributor. Use the project's [terminology](../docs/architecture/README.md)
+(page, bookmark, checkpoint, commit token, connector, run). Show the new config,
+API, or workflow with realistic examples. This section is the "what it feels
+like to use"; the next is the "how it actually works".
+
+## Reference-level explanation
+
+The precise design. Trait signatures, data structures, config field names,
+feature flags, module locations, and how the change interacts with the existing
+execution flow. Be specific enough that the implementation PR is a transcription,
+not a second design exercise. Call out how the change preserves the
+[design invariants](../docs/architecture/invariants.md) — especially the
+write → flush → checkpoint ordering — or argue why an invariant must change.
+
+## Drawbacks
+
+Why might we *not* do this? Every non-trivial change has real costs — added
+surface area, a second code path to maintain, a harder story for connector
+authors, performance regressions, or reduced object-safety. List them honestly.
+An RFC with no drawbacks section is under-examined.
+
+## Rationale and alternatives
+
+- Why is this design the best of the ones considered?
+- What other designs were seriously evaluated, and why were they rejected?
+- What is the impact of not doing this at all?
+
+At least one genuine alternative is required.
+
+## Prior art
+
+How do comparable systems solve this — other Rust data tooling, Arrow, dbt,
+Airflow/Dagster, Kafka Connect, Singer/Meltano? What can we learn or borrow, and
+where do our constraints differ?
+
+## Unresolved questions
+
+What is deliberately left open for the discussion or the implementation to
+settle? Distinguish "must resolve before Accepted" from "can resolve during
+implementation".
+
+## Future possibilities
+
+What does this unlock or make easier later? Note follow-on work without
+committing to it.
+
+## Related
+
+- [RFC process](./README.md)
+- [Documentation hub](../docs/README.md)

--- a/rfcs/0001-capability-traits.md
+++ b/rfcs/0001-capability-traits.md
@@ -1,0 +1,180 @@
+# RFC 0001 — Capability descriptors for connectors
+
+*Replace the scattered set of defaulted `Source`/`Sink` capability methods with one uniform, introspectable capability model.*
+
+| | |
+|---|---|
+| **RFC** | 0001 |
+| **Title** | Capability descriptors for connectors |
+| **Status** | Draft (proposal) |
+| **Authors** | faucet-stream maintainers |
+| **Related issues** | epic #38 |
+| **Related ADRs** | [0003 builder pattern](../docs/adr/0003-builder-pattern.md), [0010 pipeline runtime](../docs/adr/0010-pipeline-runtime.md) |
+
+## Summary
+
+Connector capabilities — exactly-once support, shardability, discoverability,
+schema evolution, supported write modes, keyed dedup — are currently expressed
+as a handful of independent, defaulted trait methods discovered one at a time by
+call sites. This RFC proposes consolidating them behind a single introspectable
+capability surface so that validation, `faucet doctor`, and the various planners
+query capabilities uniformly, and so third-party connectors advertise what they
+support in one obvious place.
+
+## Motivation
+
+Capabilities today are a growing set of boolean/enum methods with defaults, spread
+across `crates/core/src/traits.rs`:
+
+- `Source::supports_exactly_once()` / `replay_guarantee()`
+- `Source::is_shardable()` / `enumerate_shards()` / `apply_shard()`
+- `Source::supports_discover()` / `discover()`
+- `Source::capture_resume_position()`
+- `Sink::supports_idempotent_writes()` / `sink_guarantee()` / `dedups_by_key()`
+- `Sink::supported_write_modes()`
+- `Sink::supports_schema_evolution()` / `current_schema()` / `evolve_schema()`
+
+This has worked — defaulted methods keep the traits object-safe and additive
+(see [ADR 0003](../docs/adr/0003-builder-pattern.md)) — but three problems are
+emerging as the set grows:
+
+1. **Duplication of the capability truth.** The CLI re-encodes several of these
+   as static allowlists so it can validate a config *before* building a
+   connector — e.g. `registry::source_supports_exactly_once`,
+   `sink_supports_idempotent_writes`, `sink_supported_write_modes`,
+   `sink_supports_schema_evolution` in `cli/src/registry.rs`. The trait method
+   and the allowlist can drift, and every new capability requires editing both.
+2. **No uniform introspection.** `faucet validate` and `faucet doctor` reason
+   about capabilities ad hoc. A reader (or a UI) cannot ask a connector "what
+   can you do?" and get a structured answer; they must know which methods to
+   probe.
+3. **Discoverability for authors.** A connector author has to find each method
+   by reading the trait. There is no single "capabilities" concept to implement.
+
+Doing nothing means the allowlist duplication and per-capability call-site
+plumbing keeps growing linearly with each new capability.
+
+## Guide-level explanation
+
+A connector reports a single `Capabilities` value. Planners and diagnostics read
+that value instead of probing individual methods:
+
+```rust
+let caps = source.capabilities();
+if caps.replay == ReplayGuarantee::Deterministic { /* eligible for atomic watermark */ }
+```
+
+For connector authors, the capability set becomes the one place to declare
+support:
+
+```rust
+fn capabilities(&self) -> SinkCapabilities {
+    SinkCapabilities {
+        idempotent_writes: true,
+        write_modes: &[WriteMode::Append, WriteMode::Upsert, WriteMode::Delete],
+        schema_evolution: true,
+        dedups_by_key: self.config.write.dedups_by_key(),
+        ..SinkCapabilities::default()
+    }
+}
+```
+
+`faucet validate` and `faucet doctor` print the derived
+[delivery guarantee](../docs/architecture/invariants.md) and every capability
+from this single source of truth, and the CLI's static allowlists are generated
+from — or replaced by — the same descriptors.
+
+## Reference-level explanation
+
+Introduce two plain-data structs in `faucet-core` (e.g.
+`crates/core/src/capability.rs`):
+
+```rust
+pub struct SourceCapabilities {
+    pub replay: ReplayGuarantee,      // already exists as an enum
+    pub shardable: bool,
+    pub discoverable: bool,
+    pub captures_resume_position: bool,
+}
+
+pub struct SinkCapabilities {
+    pub guarantee: SinkGuarantee,     // already exists as an enum
+    pub idempotent_writes: bool,
+    pub dedups_by_key: bool,
+    pub write_modes: &'static [WriteMode],
+    pub schema_evolution: bool,
+}
+```
+
+Add `fn capabilities(&self) -> …Capabilities` to each trait with a **default
+implementation that derives the struct from the existing methods**. This keeps
+the change additive and object-safe: existing connectors compile unchanged and
+report correct capabilities via the default derivation; connectors may override
+`capabilities()` directly once the individual methods are deprecated.
+
+Migration is staged:
+
+1. Add the structs and defaulted `capabilities()` deriving from today's methods.
+2. Move CLI validation (`cli/src/registry.rs`, `cli/src/expand.rs`) to read the
+   descriptor instead of hand-maintained allowlists.
+3. Optionally deprecate the fine-grained boolean methods in a later release once
+   all call sites read the descriptor.
+
+Object-safety is preserved because `capabilities()` returns an owned/`'static`
+value and takes `&self` — no generics, no associated types (see the
+[extensibility](../docs/architecture/extensibility.md) constraints).
+
+The delivery-guarantee derivation (`derive_delivery_guarantee` in
+`crates/core/src/idempotency.rs`) already consumes a `GuaranteeInputs` bundle;
+that function becomes the model for how planners consume capability bundles.
+
+## Drawbacks
+
+- **Two representations during migration.** Until the individual methods are
+  deprecated, both the methods and the descriptor exist; the defaulted
+  derivation must stay in sync with the methods (mechanically, but still surface).
+- **Coarser overrides.** A connector overriding `capabilities()` wholesale must
+  restate every field; partial overrides rely on `..Default::default()`
+  discipline.
+- **`&'static` write-mode slices** constrain how dynamic a connector's advertised
+  write modes can be; `dedups_by_key` already shows a capability that depends on
+  *live config*, so some fields must be computed per-instance, not `const`.
+
+## Rationale and alternatives
+
+- **Keep the status quo (defaulted methods + CLI allowlists).** Rejected: the
+  duplication and drift risk grow with every capability, and there is no uniform
+  introspection for tooling/UI.
+- **A bitflags-style capability set.** Rejected for the richer fields
+  (`write_modes`, the two guarantee enums) that are not booleans; a struct models
+  them faithfully.
+- **A trait-object registry keyed by capability name (string-typed).** Rejected:
+  loses compile-time checking and invites typo bugs, contrary to the
+  [error-handling standard](../docs/standards/error-handling.md).
+
+## Prior art
+
+Kafka Connect exposes connector capabilities/config via `ConfigDef` + validation
+endpoints. Arrow's `DataType`/`Schema` model shows structured capability data
+consumed by planners. dbt's adapter capabilities registry is the closest analog:
+adapters declare a capability map the core queries uniformly.
+
+## Unresolved questions
+
+- Must resolve before Accepted: whether to deprecate the individual methods or
+  keep them indefinitely as the ergonomic API with the descriptor purely derived.
+- During implementation: exact field set, and whether capabilities should be
+  serializable (`JsonSchema`) for the web console / `faucet doctor --json`.
+
+## Future possibilities
+
+- A `faucet capabilities <connector>` command and a web-console capability matrix
+  generated from the descriptors rather than hand-maintained docs.
+- Version negotiation in a future plugin system (see
+  [RFC 0003](./0003-plugin-system.md)) built on the same descriptor.
+
+## Related
+
+- [RFC process](./README.md) · [RFC 0003 plugin system](./0003-plugin-system.md)
+- [Connector SDK](../docs/architecture/connector-sdk.md) · [Extensibility](../docs/architecture/extensibility.md)
+- [Design invariants](../docs/architecture/invariants.md)

--- a/rfcs/0002-arrow-support.md
+++ b/rfcs/0002-arrow-support.md
@@ -1,0 +1,137 @@
+# RFC 0002 — Optional Apache Arrow record path
+
+*Add an optional columnar (Arrow) batch representation at the `StreamPage` boundary, additive to and coexisting with the `serde_json::Value` record model.*
+
+| | |
+|---|---|
+| **RFC** | 0002 |
+| **Title** | Optional Apache Arrow record path |
+| **Status** | Draft (proposal) |
+| **Authors** | faucet-stream maintainers |
+| **Related issues** | epic #38 |
+| **Related ADRs** | [0004 JSON record model](../docs/adr/0004-json-record-model.md), [0001 stream-pages](../docs/adr/0001-stream-pages.md) |
+
+## Summary
+
+faucet-stream represents every in-flight record as a `serde_json::Value` (see
+[ADR 0004](../docs/adr/0004-json-record-model.md)). That choice buys unmatched
+connector-author ergonomics but pays for it in per-record allocation and the
+absence of vectorized processing. This RFC proposes an **optional, feature-gated
+Arrow columnar batch** that a connector may produce or consume at the
+`StreamPage` boundary, leaving the `Value` path as the default and always-present
+representation.
+
+## Motivation
+
+The `Value` model is the right default and is not going away. But several facts
+in the current codebase point to a columnar fast path being worth its weight:
+
+- **We already cross the Arrow boundary internally.** `faucet-source-parquet` /
+  `faucet-sink-parquet` use `parquet::arrow` async readers/writers; the SQL
+  transform (`faucet-transform-sql`) shovels JSON↔Arrow via `arrow-json` to feed
+  embedded DuckDB; Kafka schema-registry formats decode through Arrow-adjacent
+  paths. Today these connectors convert Arrow → `Value` → Arrow across the
+  pipeline boundary, paying double conversion for data that was already columnar.
+- **Allocation cost.** Every field of every record is a heap-allocated `Value`
+  node. For high-volume numeric/analytical workloads this dominates, and it
+  cannot be vectorized. The [performance architecture](../docs/architecture/performance.md)
+  doc names this as the known structural cost of the record model.
+- **Ecosystem gravity.** Parquet, DuckDB, Polars, DataFusion, Flight, and most
+  modern warehouse loaders speak Arrow natively. A columnar path lets those
+  connectors move batches without ever materializing `Value`.
+
+Doing nothing is a legitimate option — the `Value` path is correct and simple —
+but leaves throughput on the table for exactly the analytical connectors most
+likely to move large volumes.
+
+## Guide-level explanation
+
+`StreamPage` gains an optional columnar payload. A connector that can produce
+columnar data does so; one that cannot keeps emitting `Value` rows exactly as
+today. The pipeline carries whichever representation the source produced and only
+converts when a downstream stage requires the other form.
+
+Conceptually the page becomes "records, in one of two representations, plus the
+bookmark". A sink advertises (via its [capabilities](./0001-capability-traits.md))
+whether it accepts columnar batches directly; if not, the pipeline converts the
+batch to `Value` rows transparently before calling `write_batch`. The
+checkpoint-ordering invariant is unchanged — the representation of the records is
+orthogonal to when the bookmark is persisted.
+
+The feature is opt-in at build time (`arrow` feature). Builds without it are
+byte-for-byte the `Value`-only pipeline of today.
+
+## Reference-level explanation
+
+- **Page shape.** Extend the page type so records are an enum:
+  `Rows(Vec<Value>)` (today) or `Columnar(RecordBatch)` (Arrow). This is an
+  additive change; `StreamPage { records, bookmark }` keeps working via a
+  `Rows` constructor. All existing stages that expect `Vec<Value>` get a helper
+  that converts a `Columnar` page to rows on demand.
+- **Feature gating.** Arrow (`arrow`, `arrow-json`) is pulled only under a new
+  `arrow` feature in `faucet-core`, mirroring how `transform-sql` already pins
+  Arrow v58. Connector crates opt in with their own `arrow` feature per the
+  [feature-isolation rule](../docs/contributing/common-mistakes.md).
+- **Trait touchpoints.** Add defaulted methods so the traits stay object-safe
+  and additive (see [ADR 0003](../docs/adr/0003-builder-pattern.md)):
+  `Source::stream_pages` may yield columnar pages; `Sink` gains an optional
+  `write_batch_columnar(&RecordBatch)` whose default converts to rows and calls
+  `write_batch`. No connector is forced to implement the columnar side.
+- **Conversion shims.** Centralize `RecordBatch ↔ Vec<Value>` in one core module
+  reusing `arrow-json`, so validation/quality/contract/masking (which operate on
+  `Value`) can run against a converted view when a page is columnar. The layered
+  validation passes ([schema architecture](../docs/architecture/schema.md)) stay
+  `Value`-shaped in v1 — a columnar page is converted for those passes and, if
+  unmodified, passed through columnar to the sink.
+
+## Drawbacks
+
+- **Two code paths.** Every stage must handle both representations or rely on a
+  conversion shim; that is real, permanent maintenance surface.
+- **Schema rigidity.** Arrow batches require a fixed schema per batch. Sources
+  with ragged/heterogeneous records (the natural home of `Value`) cannot go
+  columnar without imposing a schema — so the fast path helps analytical
+  connectors, not document-shaped ones.
+- **Connector-author complexity.** The framework's headline simplicity is "a
+  record is a JSON value". Introducing Arrow risks eroding that; it must remain
+  strictly optional and off the beginner path.
+- **Validation semantics.** Running the `Value`-shaped quality/contract/masking
+  passes over a converted view, then writing columnar, needs care so the two
+  representations never diverge (e.g. a masking rewrite must invalidate the
+  columnar payload).
+
+## Rationale and alternatives
+
+- **Replace `Value` with Arrow outright.** Rejected — it would sacrifice the
+  connector-author ergonomics that are a core project value and break the
+  ragged-record use cases.
+- **Keep Arrow purely internal to individual connectors (status quo).** Viable
+  and zero-risk, but forces Arrow-native connectors to round-trip through
+  `Value` at the pipeline boundary, which is exactly the cost this RFC targets.
+- **A separate "columnar pipeline" type.** Rejected — bifurcates the runtime and
+  duplicates the checkpoint/DLQ/observability machinery.
+
+## Prior art
+
+Arrow itself is the reference for the columnar batch and zero-copy semantics.
+Polars/DataFusion show Arrow as an execution substrate; Kafka Connect's
+`SchemaAndValue` and Singer's row model show the row-oriented alternative we keep
+as default. dbt/warehouse loaders increasingly accept Arrow/Parquet directly.
+
+## Unresolved questions
+
+- Must resolve before Accepted: whether the layered validation passes gain
+  native columnar implementations or always operate on a converted view in v1.
+- During implementation: batch-size interaction with `MAX_BATCH_SIZE`; how
+  columnar pages interact with adaptive batching (row reslicing assumes rows).
+
+## Future possibilities
+
+- Zero-copy Arrow Flight transport between faucet instances.
+- Vectorized transforms operating directly on `RecordBatch`.
+- A columnar-aware DLQ envelope for analytical sinks.
+
+## Related
+
+- [RFC process](./README.md) · [RFC 0001 capabilities](./0001-capability-traits.md) · [RFC 0004 streaming](./0004-streaming-improvements.md)
+- [ADR 0004 JSON record model](../docs/adr/0004-json-record-model.md) · [Performance](../docs/architecture/performance.md) · [Batching](../docs/architecture/batching.md)

--- a/rfcs/0003-plugin-system.md
+++ b/rfcs/0003-plugin-system.md
@@ -1,0 +1,147 @@
+# RFC 0003 — Plugin system evolution
+
+*Grow the compile-time `PluginRegistry` toward richer capability/version negotiation and marketplace discovery, while keeping static linking the pragmatic default over dynamic loading.*
+
+| | |
+|---|---|
+| **RFC** | 0003 |
+| **Title** | Plugin system evolution |
+| **Status** | Draft (proposal) |
+| **Authors** | faucet-stream maintainers |
+| **Related issues** | #60, epic #38 |
+| **Related ADRs** | [0010 pipeline runtime](../docs/adr/0010-pipeline-runtime.md), [0003 builder pattern](../docs/adr/0003-builder-pattern.md) |
+
+## Summary
+
+faucet-stream already supports third-party connectors through a **compile-time**
+plugin registry: a custom CLI links its connector crates and registers them via
+`PluginRegistry` before calling `run_main` (`cli/src/registry.rs`). This RFC
+proposes evolving that model with capability/version negotiation and marketplace
+discovery — and argues explicitly for keeping static linking the default rather
+than adopting dynamic `.so`/`.dll` loading.
+
+## Motivation
+
+The current model (issue #60) is solid and safe:
+
+- `PluginRegistry` holds `SourceFactory` / `SinkFactory` closures
+  (`Fn(Value) -> CliResult<Box<dyn Source|Sink>>`), registered via
+  `register_source[_with]` / `register_sink[_with]`, collision-checked against
+  built-ins.
+- A custom-CLI author writes a one-line `main.rs`:
+  `faucet_cli::run_main(PluginRegistry::with_builtins().register_source(...))`.
+- Because it is compile-time, there is no ABI surface, no unsafe dynamic loading,
+  and the borrow checker + type system cover the whole plugin.
+
+Two gaps limit the ecosystem story:
+
+1. **No capability/version negotiation.** A plugin connector implements the same
+   defaulted trait methods as a built-in, but there is no declared contract
+   version or capability handshake — so the host cannot reason about a plugin's
+   support surface uniformly (this is the problem
+   [RFC 0001](./0001-capability-traits.md) addresses on the trait side).
+2. **No discovery.** Finding, trusting, and installing third-party
+   `faucet-source-*` / `faucet-sink-*` crates is manual. The naming convention
+   and the [connector spec](../docs/spec/faucet-connector-spec-v0.md) exist; a
+   discovery/marketplace layer does not.
+
+## Guide-level explanation
+
+Three additive layers on top of the existing registry:
+
+1. **Contract versioning.** Each connector declares which version of the Faucet
+   Connector Protocol (FCP) it targets. `run_main` records this and can warn or
+   refuse on a mismatch, giving a clear error instead of a subtle trait-behaviour
+   drift.
+2. **Capability negotiation.** The host reads a plugin's
+   [capability descriptor](./0001-capability-traits.md) at registration time, so
+   `faucet validate` / `doctor` treat plugin and built-in connectors identically.
+3. **Marketplace discovery.** A `faucet` subcommand and/or a manifest format lets
+   users find connectors following the `faucet-source-*` / `faucet-sink-*`
+   naming convention on crates.io, scaffolded from the FCP spec — still linked at
+   build time, but discoverable and templated.
+
+Nothing here changes how an existing custom CLI is written; a plugin that omits
+the new metadata gets sensible defaults.
+
+## Reference-level explanation
+
+- **FCP version field.** Add a `const FCP_VERSION` / method to the connector
+  contract and record it in the registry entry. `run_main` validates it against
+  the host's supported range and emits a typed `CliError` on incompatibility.
+- **Capabilities at registration.** Once [RFC 0001](./0001-capability-traits.md)
+  lands, the registry stores each connector's capability descriptor so the CLI's
+  static allowlists (`source_supports_exactly_once`,
+  `sink_supported_write_modes`, …) are populated from plugins too, not only
+  built-ins.
+- **Scaffolding + spec.** Formalize [`docs/spec/faucet-connector-spec-v0.md`](../docs/spec/faucet-connector-spec-v0.md)
+  as the normative contract and provide a `cargo generate`-style template so new
+  connectors start compliant.
+- **Static linking stays default.** No `dlopen`. See the drawbacks for why.
+
+### Why static-link-first (and probably static-link-only for v1)
+
+Dynamic loading in Rust is genuinely hazardous:
+
+- **No stable ABI.** Rust has no stable ABI; a plugin `.so` and host built with
+  different compiler versions can violate layout assumptions. A safe dynamic
+  boundary means constraining the interface to `extern "C"` + `#[repr(C)]` +
+  raw pointers, which is exactly the ergonomic surface `faucet-core` avoids
+  (`Box<dyn Source>` and `serde_json::Value` are not FFI-safe).
+- **Safety.** A loaded `.so` runs with full process privileges; a panic across
+  the FFI boundary is undefined behaviour unless carefully caught.
+- **Diminishing returns.** The compile-time model already delivers the headline
+  benefit — third parties ship connectors as ordinary crates and link them into
+  a custom `faucet` binary — with none of the ABI/safety cost.
+
+Static linking keeps the whole plugin inside Rust's type and safety guarantees.
+The pragmatic default is: make the *ecosystem* (discovery, versioning,
+scaffolding, trust) richer, not the *loading mechanism* more dangerous.
+
+## Drawbacks
+
+- **Rebuild to add a connector.** Static linking means users assemble their own
+  binary (or use the full distribution). For most operators the prebuilt CLI
+  with all built-ins suffices; power users already build custom CLIs.
+- **Version field maintenance.** An FCP version introduces a compatibility
+  matrix to keep honest.
+- **Marketplace trust.** Discovery raises supply-chain questions (a connector is
+  arbitrary Rust code linked into the binary) that documentation must address
+  head-on.
+
+## Rationale and alternatives
+
+- **Dynamic `dlopen` plugins.** Rejected as the default for the ABI/safety
+  reasons above; may be revisited only behind a narrow, explicitly-`unsafe`,
+  `extern "C"` shim if a compelling use case (e.g. closed-source connectors)
+  emerges.
+- **WASM component plugins.** Interesting for sandboxing/portability; deferred —
+  the async + native-client (rdkafka, sqlx, cloud SDKs) requirements of real
+  connectors make a WASM boundary costly today. Worth a future RFC.
+- **Status quo (registry only).** Viable, but leaves versioning and discovery
+  unsolved.
+
+## Prior art
+
+Kafka Connect (JAR plugins on a classpath — JVM has a stable-ish ABI we lack);
+Singer/Meltano (process-per-tap over stdio — a robust dynamic boundary we could
+emulate for out-of-process connectors); Terraform providers (separate processes
+over gRPC — the strongest model for a language-agnostic, safe dynamic boundary,
+and the most likely inspiration if we ever go out-of-process).
+
+## Unresolved questions
+
+- Must resolve before Accepted: the FCP version compatibility policy (strict vs
+  range) and whether v1 includes any out-of-process option at all.
+- During implementation: marketplace manifest format; trust/signing story.
+
+## Future possibilities
+
+- Out-of-process connectors over a stable protocol (Terraform-provider style),
+  which *would* be a true dynamic boundary without Rust-ABI risk.
+- WASM-sandboxed transforms/connectors.
+
+## Related
+
+- [RFC process](./README.md) · [RFC 0001 capabilities](./0001-capability-traits.md)
+- [Extensibility](../docs/architecture/extensibility.md) · [Connector spec (FCP v0)](../docs/spec/faucet-connector-spec-v0.md) · [ADR 0010](../docs/adr/0010-pipeline-runtime.md)

--- a/rfcs/0004-streaming-improvements.md
+++ b/rfcs/0004-streaming-improvements.md
@@ -1,0 +1,133 @@
+# RFC 0004 — Streaming pipeline improvements
+
+*Add optional read/write pipelining, explicit backpressure, and a push-source path to `stream_pages`, without weakening the checkpoint-ordering invariant.*
+
+| | |
+|---|---|
+| **RFC** | 0004 |
+| **Title** | Streaming pipeline improvements |
+| **Status** | Draft (proposal) |
+| **Authors** | faucet-stream maintainers |
+| **Related issues** | epic #38 |
+| **Related ADRs** | [0001 stream-pages](../docs/adr/0001-stream-pages.md), [0002 checkpoint ordering](../docs/adr/0002-checkpoint-ordering.md) |
+
+## Summary
+
+The streaming core (`run_stream` in `crates/core/src/pipeline.rs`) processes one
+page at a time: poll a page, run the validation passes, write it, flush, persist
+the bookmark, repeat. This is simple and correct, and it bounds memory at
+O(batch_size). This RFC proposes three optional enhancements — cross-page
+read/write pipelining, explicit backpressure signalling, and a push-based source
+adapter — each additive and each preserving the write → flush → checkpoint
+ordering.
+
+## Motivation
+
+The current loop is strictly sequential across pages. Grounded in the code:
+
+- **No read/write overlap.** While the sink writes page *N*, the source sits
+  idle; while the source fetches page *N+1*, the sink sits idle. For pipelines
+  where read and write latency are comparable (a network source feeding a
+  network sink), roughly half the wall-clock is avoidable stall.
+- **Implicit backpressure only.** Backpressure today is the page cadence itself —
+  the source cannot produce page *N+1* until the pipeline polls for it. That is
+  safe but coarse; there is no way for a fast source to buffer a bounded amount
+  ahead, nor for a slow sink to signal "slow down" beyond blocking the poll.
+- **No push-source story.** `Source::stream_pages` is pull-based. Genuinely
+  push-based inputs (a socket, a subscription, an in-process producer) are shoe-
+  horned into the pull model (e.g. the webhook source buffers). Client-streaming
+  and bidirectional gRPC are explicitly out of scope today.
+
+The [batching architecture](../docs/architecture/batching.md) and
+[ADR 0001](../docs/adr/0001-stream-pages.md) document today's model; this RFC is
+the "future evolution" those docs point to.
+
+## Guide-level explanation
+
+Opt-in, per pipeline:
+
+- **Pipelining (double-buffering).** The pipeline may prefetch the *next* page
+  while the *current* page is being written, using a small bounded channel
+  (depth configurable, default 1 = today's behaviour). Latency becomes
+  `max(read, write)` per page instead of `read + write`.
+- **Explicit backpressure.** The bounded channel *is* the backpressure: a fast
+  source blocks when the buffer is full; a slow sink naturally throttles the
+  source. This is the standard bounded-queue mechanism, made explicit and
+  tunable rather than implicit.
+- **Push sources.** A `Source` may adapt a push input by feeding a bounded
+  channel that the pipeline drains as pages — turning push into pull at the
+  channel boundary, with the same backpressure semantics.
+
+The checkpoint-ordering invariant is untouched: a page's bookmark is still
+persisted only after that page's write is flushed. Prefetching page *N+1* does
+not persist its bookmark until page *N* is durable and page *N+1* itself is
+written and flushed, in order.
+
+## Reference-level explanation
+
+- **Ordered prefetch.** Introduce an optional adapter that wraps the
+  `stream_pages` stream in a bounded look-ahead buffer (e.g. `buffered`/a bounded
+  channel of depth *k*). Crucially, **pages must remain ordered and committed in
+  order** — bookmarks are monotonic and the exactly-once commit-token sequence
+  (`next_seq`) assumes in-order commit. So this is *prefetch*, not out-of-order
+  concurrency: page *N* is always written+flushed+checkpointed before page *N+1*.
+- **Config surface.** A `streaming: { prefetch: <depth> }` knob (default 1). At
+  depth 1 the code path is byte-for-byte today's sequential loop.
+- **Invariant preservation.** The write/flush/checkpoint block in `run_stream`
+  stays exactly as-is; only page *production* is decoupled from page
+  *consumption* via the bounded buffer. The cancellation `select!` (biased,
+  page-boundary flush) continues to work because cancellation is still checked
+  per consumed page.
+- **Push adapter.** Provide a core helper (a bounded-channel `Source` wrapper) so
+  push inputs share one well-tested pull-conversion instead of each connector
+  re-inventing buffering (the webhook source is the reference case). This dovetails
+  with [RFC 0005](./0005-async-connector-runtime.md)'s shared runtime primitives.
+
+## Drawbacks
+
+- **Memory.** Prefetch depth *k* raises the memory bound to O(k · batch_size).
+  Default depth 1 keeps today's bound; the knob makes the trade-off explicit.
+- **Complexity around cancellation and errors.** A prefetched page that is never
+  consumed (because an earlier page failed or the run was cancelled) must be
+  dropped cleanly; the buffered future must be cancel-safe.
+- **Exactly-once ordering constraint.** Prefetch must stay strictly ordered; any
+  temptation toward out-of-order concurrency would break the monotonic
+  commit-token/bookmark assumptions and is out of scope.
+- **Diminishing returns for CDC.** CDC sources emit a bookmark per committed
+  transaction and are often latency- not throughput-bound; prefetch helps
+  paged/query sources most.
+
+## Rationale and alternatives
+
+- **Full parallel page processing (out-of-order).** Rejected — incompatible with
+  monotonic bookmarks and the exactly-once sequence; would require a fundamentally
+  different commit model. Sharding ([`Shardable`](../docs/architecture/connector-sdk.md))
+  already provides *inter-shard* parallelism the safe way.
+- **Do nothing.** Perfectly acceptable for correctness; leaves the read/write
+  stall unaddressed for balanced-latency pipelines.
+- **Unbounded prefetch.** Rejected — reintroduces the O(total) buffering that
+  [ADR 0001](../docs/adr/0001-stream-pages.md) exists to prevent.
+
+## Prior art
+
+Bounded-channel backpressure is standard (`tokio::sync::mpsc`, Akka Streams,
+Reactive Streams). Kafka Connect's `poll()`/`put()` loop with a worker buffer is
+the direct analog. Flink's credit-based backpressure is the richer model we are
+deliberately not adopting in v1.
+
+## Unresolved questions
+
+- Must resolve before Accepted: whether prefetch is a core `run_stream` option or
+  a source-side stream adapter.
+- During implementation: interaction with adaptive batching and with the
+  per-transaction bookmark cadence of CDC sources.
+
+## Future possibilities
+
+- Credit-based backpressure metrics surfaced via the observability layer.
+- First-class bidirectional/streaming gRPC once the push adapter exists.
+
+## Related
+
+- [RFC process](./README.md) · [RFC 0002 Arrow](./0002-arrow-support.md) · [RFC 0005 async runtime](./0005-async-connector-runtime.md)
+- [Stream pages](../docs/architecture/stream-pages.md) · [Batching](../docs/architecture/batching.md) · [ADR 0002 checkpoint ordering](../docs/adr/0002-checkpoint-ordering.md) · [Design invariants](../docs/architecture/invariants.md)

--- a/rfcs/0005-async-connector-runtime.md
+++ b/rfcs/0005-async-connector-runtime.md
@@ -1,0 +1,143 @@
+# RFC 0005 — Shared async connector-runtime primitives
+
+*Expose reusable bounded-concurrency, cancellation-aware retry, and task-supervision helpers from `faucet-core` so connectors stop re-implementing them.*
+
+| | |
+|---|---|
+| **RFC** | 0005 |
+| **Title** | Shared async connector-runtime primitives |
+| **Status** | Draft (proposal) |
+| **Authors** | faucet-stream maintainers |
+| **Related issues** | epic #38 |
+| **Related ADRs** | [0007 retries](../docs/adr/0007-retries.md), [0005 runtime recovery](../docs/adr/0005-runtime-recovery.md) |
+
+## Summary
+
+Each connector currently manages its own async concurrency, retry, and
+task-supervision logic. Some of this is already centralized (`faucet-core`'s
+retry/resilience modules; `tokio_util::sync::CancellationToken` re-exported for
+cooperative cancellation), but bounded-concurrency patterns and per-connector
+retry wrappers are re-implemented repeatedly. This RFC proposes a small set of
+shared runtime primitives in `faucet-core` that connectors reuse, reducing
+duplication and inconsistency without changing any connector's external
+behaviour.
+
+## Motivation
+
+The codebase already shows both the pattern and the duplication:
+
+- **Retry is partly shared, partly bespoke.** `crates/core/src/retry.rs` provides
+  `execute_with_retry` (exponential backoff + jitter, gated on
+  `FaucetError::is_retriable`), used by the XML and GraphQL sources; the
+  `resilience/` module provides `execute_with_policy[_metered]`, a circuit
+  breaker, and classification. But the REST source keeps its *own* retry module
+  for 429/`Retry-After` handling, and the sink-side retry lives inline in
+  `run_stream`'s `with_retry!` macro. Three retry implementations, three
+  behaviours.
+- **Bounded concurrency is copy-pasted.** The performance discipline (see
+  [performance architecture](../docs/architecture/performance.md)) mandates
+  `buffer_unordered`/semaphore-bounded parallel I/O — implemented independently in
+  the S3, GCS, parquet, Kinesis, HTTP, and other connectors, each with its own
+  concurrency knob and glue.
+- **Cancellation is shared but wrapping is not.** `CancellationToken` is
+  re-exported and the pipeline is cancel-aware, but connectors that spawn their
+  own tasks (per-shard workers, per-partition consumers) each wire
+  cancellation/cleanup by hand.
+
+Nothing here is broken; the cost is consistency and connector-author effort. A
+new connector author must re-derive "how do I bound concurrency and retry safely"
+from other connectors rather than reaching for a blessed helper.
+
+## Guide-level explanation
+
+`faucet-core` exposes a small, opt-in runtime toolkit that connector authors
+reach for instead of hand-rolling:
+
+- **`bounded_map(items, concurrency, f)`** — run an async closure over items with
+  a shared semaphore/`buffer_unordered`, the one-true implementation of the
+  parallel-I/O pattern, cancellation-aware.
+- **A unified retry entry point** — one function that all HTTP-style sources and
+  all sink-side writes call, honouring the [resilience policy](../docs/architecture/resilience.md)
+  and the [safety rule](../docs/adr/0007-retries.md) that a non-idempotent write
+  is only retried when the sink commits idempotently.
+- **A task-supervision helper** — spawn-and-supervise for the per-shard /
+  per-partition worker pattern, with cancellation propagation and error
+  aggregation, so connectors like Kinesis and the Kafka member-mode source share
+  one supervisor.
+
+These are helpers, not a framework: a connector may still drop to raw `tokio`
+where it needs to. They live in `faucet-core` so connector authors, who depend
+only on `faucet-core`, get them for free (see the
+[extensibility model](../docs/architecture/extensibility.md)).
+
+## Reference-level explanation
+
+- **Concurrency helper.** A generic `bounded_map`/`for_each_concurrent`-style
+  function taking a concurrency limit and an optional `CancellationToken`,
+  returning results in completion order with per-item error capture (so a
+  connector can route per-item failures to partial-batch handling). No new deps —
+  built on `futures`/`tokio` already in the tree.
+- **Retry consolidation.** Converge the three retry implementations onto the
+  `resilience::execute_with_policy` family. The REST source's 429/`Retry-After`
+  handling becomes a `RetryClass`/policy input rather than a separate module;
+  `retry.rs`'s `execute_with_retry` becomes a thin adapter over the policy runner
+  (it already shares the `BackoffKind::Exponential` + jitter machinery). This is
+  a **behaviour-preserving** refactor gated by tests, not a semantics change.
+- **Supervision.** A `spawn_supervised` helper that owns a `JoinSet`, propagates
+  a parent `CancellationToken` to children, and returns aggregated results — the
+  pattern the CLI executor already implements for matrix fan-out
+  (`cli/src/executor.rs`), lifted to a reusable core primitive for connector-
+  internal worker pools.
+- **Object-safety / additivity.** These are free functions and helper structs,
+  not trait methods, so they add zero surface to `Source`/`Sink` and cannot break
+  object-safety (see [ADR 0003](../docs/adr/0003-builder-pattern.md)).
+
+## Drawbacks
+
+- **Refactor risk.** Consolidating three retry implementations touches the REST
+  source's carefully-tuned 429 handling; the migration must be test-gated to
+  prove behaviour is preserved (the [testing standard](../docs/standards/testing.md)
+  applies — don't blindly update tests to match a regression).
+- **Abstraction leakage.** A too-opinionated helper that doesn't fit a
+  connector's real needs is worse than raw `tokio`; the helpers must stay small
+  and escapable.
+- **Core surface growth.** Every helper added to `faucet-core` is API third
+  parties may depend on and we must keep stable ([stability policy](../docs/stability.md)).
+
+## Rationale and alternatives
+
+- **Status quo (per-connector).** Rejected as the long-term state — it scales
+  duplication linearly with the connector count and lets behaviours drift.
+- **A separate `faucet-runtime` crate.** Rejected for v1 — connectors depend only
+  on `faucet-core` by design; putting the primitives elsewhere would add a
+  required dependency, contrary to the [extensibility](../docs/architecture/extensibility.md)
+  principle. Could be revisited if the toolkit grows large.
+- **Adopt a third-party structured-concurrency crate wholesale.** Rejected —
+  unnecessary dependency weight for the handful of patterns we actually reuse.
+
+## Prior art
+
+`tokio`/`futures` (`buffer_unordered`, `JoinSet`), Tokio's own utilities crate,
+and structured-concurrency libraries (e.g. `async-nursery`) inform the
+supervision helper. Kafka Connect's worker/task model is the domain analog for
+the per-partition supervision pattern.
+
+## Unresolved questions
+
+- Must resolve before Accepted: the exact retry consolidation plan for the REST
+  source's 429/`Retry-After` semantics (fold into `RetryClass` vs keep a
+  specialized adapter).
+- During implementation: whether the concurrency helper should surface partial
+  results for DLQ routing directly.
+
+## Future possibilities
+
+- A shared per-partition/per-shard consumer runtime underpinning the push-source
+  adapter from [RFC 0004](./0004-streaming-improvements.md).
+- Runtime-level metrics for connector-internal worker pools via the existing
+  observability layer.
+
+## Related
+
+- [RFC process](./README.md) · [RFC 0004 streaming](./0004-streaming-improvements.md)
+- [Resilience](../docs/architecture/resilience.md) · [Retries](../docs/architecture/retries.md) · [ADR 0007 retries](../docs/adr/0007-retries.md) · [Recovery](../docs/architecture/recovery.md)

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -1,0 +1,97 @@
+# faucet-stream RFCs
+
+*The design-review process for cross-cutting, breaking, or new-subsystem changes — and how it relates to issues, ADRs, and the roadmap.*
+
+Most changes to faucet-stream do **not** need an RFC. Adding a connector, fixing
+a bug, tuning a hot path, or extending an existing config block is ordinary
+work: open a PR (see [`CONTRIBUTING.md`](../CONTRIBUTING.md)), or file a GitHub
+issue first if the work needs scoping. The RFC process exists for the small
+number of changes whose cost of being wrong is paid by every future contributor
+and every downstream connector author.
+
+## When an RFC is required
+
+Write an RFC when a change touches the parts of the system that are expensive to
+reverse:
+
+- **The connector contract.** Anything that changes the `Source` / `Sink`
+  traits in `crates/core/src/traits.rs`, their object-safety, or the meaning of
+  an existing method. Third-party connectors depend only on `faucet-core`; a
+  trait change is a change to a public compatibility surface.
+- **The record model.** Replacing or supplementing `serde_json::Value` as the
+  in-flight record type (see [ADR 0004](../docs/adr/0004-json-record-model.md)).
+- **Delivery / durability semantics.** Anything that alters the
+  write → flush → checkpoint ordering, the exactly-once mechanisms, or the
+  `StateStore` contract. These carry the framework's data-integrity guarantees
+  (see [ADR 0002](../docs/adr/0002-checkpoint-ordering.md) and the
+  [design invariants](../docs/architecture/invariants.md)).
+- **A new subsystem** that will accrete its own config surface, feature flags,
+  and maintenance burden (e.g. the plugin system, an Arrow record path).
+- **Cross-cutting conventions** that many crates must adopt at once.
+
+If you are unsure, open a GitHub issue and ask. A one-paragraph issue that gets
+the answer "just send the PR" is cheaper than an RFC nobody needed.
+
+## When an RFC is *not* the right tool
+
+- **A single new connector** — this is routine. The standing project preference
+  is to grow runtime/CLI/observability capability rather than the connector
+  count, but adding one follows the connector-authoring guide, not an RFC.
+- **A scoped feature or bug** — file a GitHub issue with the type/tier labels and
+  cross-link it to the roadmap epic (**#38**). The issue *is* the design record
+  for work of that size.
+- **Documentation, refactors, tests, CI** — just open the PR.
+
+The rule of thumb: an **issue** captures *what* to build and *why*; an **RFC**
+is warranted only when the *how* is contentious, hard to reverse, or must be
+agreed before code exists.
+
+## Lifecycle
+
+```mermaid
+flowchart LR
+    Draft --> Discussion
+    Discussion -->|consensus| Accepted
+    Discussion -->|no| Rejected
+    Accepted --> Implemented
+    Implemented -.distills into.-> ADR[docs/adr/*.md]
+```
+
+1. **Draft** — copy [`0000-template.md`](./0000-template.md) to
+   `rfcs/NNNN-short-title.md`, fill it in, open a PR that adds only that file.
+2. **Discussion** — review happens on the PR. The bar is a clear motivation,
+   an honest accounting of drawbacks, and at least one seriously-considered
+   alternative. Grounding claims about *current* behaviour in real code is
+   mandatory — a reviewer must be able to tell exactly what changes.
+3. **Accepted / Rejected** — set the `Status` header. A rejected RFC is still
+   merged (with its rationale) so the decision is not re-litigated.
+4. **Implemented** — once shipped, update the status and link the PRs.
+
+## Numbering
+
+RFCs are numbered sequentially, zero-padded to four digits, in filename order.
+`0000` is the template. Pick the next free number when you open the draft PR;
+if two drafts collide, the second to merge renumbers.
+
+## RFCs, ADRs, and issues
+
+These three records answer different questions and should not be conflated:
+
+| Record | Question | Lives in | Timing |
+|---|---|---|---|
+| **Issue** | What should we build, and why? | GitHub (+ epic #38) | Before/around the work |
+| **RFC** | How should we build a contentious, hard-to-reverse thing — before we commit? | `rfcs/` | Before the code |
+| **ADR** | What did we decide and why, now that it is built? | [`docs/adr/`](../docs/adr/) | After the code, as the durable record |
+
+An accepted-and-implemented RFC frequently distills into an ADR: the RFC keeps
+the full exploratory argument (alternatives, drawbacks, unresolved questions);
+the ADR is the terse "this is how it works and why" that new contributors read.
+The RFCs here that describe *proposed* work (0001–0005) will, if implemented,
+each produce or update an ADR.
+
+## Related
+
+- [`CONTRIBUTING.md`](../CONTRIBUTING.md) — build/test/PR mechanics
+- [Architecture Decision Records](../docs/adr/) — decisions already made
+- [Documentation hub](../docs/README.md) — the full documentation map
+- [Roadmap](../docs/roadmap.md) — architectural direction these RFCs feed


### PR DESCRIPTION
## What

Adds a **maintainer-facing engineering documentation set** — architecture docs, Architecture Decision Records, RFCs, repo standards, and contributor guides — alongside the existing user-facing mdBook. **No runtime behavior changes; documentation only.**

The goal is engineering maturity: explain *why* the system is built the way it is, so future contributors inherit the reasoning instead of re-deriving it.

## Contents (55 new files)

| Area | Files |
|------|-------|
| `docs/architecture/` | 20 — a page per subsystem (overview, execution, pipeline, stream-pages, connector-sdk, state-management, recovery, retries, resilience, observability, batching, schema, quality, contracts, masking, performance, extensibility, **invariants**, roadmap, README) |
| `docs/adr/` | 10 ADRs + index — the major decisions with context, alternatives, trade-offs, consequences |
| `docs/contributing/` | 6 — codebase map, connector authoring, testing, performance, debugging, common mistakes |
| `docs/standards/` | 6 — API design, error handling, logging, testing, performance, state |
| `rfcs/` | process + template + 5 forward-looking proposals |
| top-level | `docs/README.md` hub, engineering-principles, roadmap, stability, architecture-review |

## Grounded, not cosmetic

Every claim is traceable to the implementation (`crates/core/src/pipeline.rs`, `traits.rs`, `idempotency.rs`, `state.rs`, `retry.rs`). Highlights:

- The central invariant — *a bookmark is persisted only after the sink durably wrote and flushed the page* — is documented in `docs/architecture/invariants.md` and ADR-0002 and threaded through every related page.
- The duplication-safety rule (never retry a non-idempotent write), sink-anchored exactly-once resume, and the fixed per-page pass order (mask → quality → contract → drift) are documented against the actual code paths.
- `docs/architecture-review.md` is an objective critique with evidence (monolithic `run_stream`, the `serde_json::Value` allocation ceiling, exactly-once ↔ DLQ exclusivity, upstream dependency pins) and links each risk to the ADR/RFC that addresses it.

## Quality checks

- **714 internal cross-links verified, 0 broken.** Links into gitignored local-only files (`CLAUDE.md`, `.claude/rules/`) were intentionally rendered as plain text so nothing 404s on GitHub.
- Consistent terminology (page / bookmark / checkpoint / watermark; at-least-once vs. effectively-once) and a `## Related` navigation footer on every page.
- Distinct from, and cross-referencing (not duplicating), the user mdBook under `docs/book/`.

Related: roadmap epic #38.
