### PR TITLE
ci(release-plz): survive the crates.io new-crate rate limit

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -112,22 +112,33 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libsasl2-dev libssl-dev libcurl4-openssl-dev cmake build-essential
 
-      # crates.io rate-limits *updates to existing crates* (a burst of ~30, then
-      # a slow refill). A workspace-wide release that bumps more crates than the
-      # burst — e.g. the reliability-audit release that touched all 57 crates
-      # (#264) — exhausts the bucket mid-run, and `cargo publish` aborts with
-      # "429 Too Many Requests". release-plz does NOT wait out the limit; it
-      # exits non-zero, leaving a partially-published release.
+      # crates.io enforces TWO separate publish rate limits, and this ladder must
+      # survive both:
+      #   1. Updates to EXISTING crates — a burst of ~30, then a slow refill. A
+      #      workspace-wide release that bumps more crates than the burst (e.g.
+      #      the reliability-audit release that touched all 57 crates, #264)
+      #      exhausts it mid-run.
+      #   2. Brand-NEW crate names — a burst of ~5, then only **1 new crate per
+      #      ~10 minutes** (much harsher). A release that introduces several new
+      #      1.0.0 crates at once — e.g. the 1.5.0 release adding the delta /
+      #      databricks / spanner source+sink crates — blows past the burst, and
+      #      each remaining new crate must then wait out its own ~10-minute
+      #      window. (This is exactly what left 1.5.0 partially published: the
+      #      old 4m + 6m cool-downs were tuned for limit #1 and could not clear
+      #      limit #2, so `faucet-cli` — published last — never shipped.)
+      # In both cases `cargo publish` aborts with "429 Too Many Requests" and
+      # release-plz exits non-zero, leaving a partially-published release.
       #
       # `release-plz release` is **idempotent** — it checks the sparse index and
-      # skips already-published crates — so the cure is to retry it a few times
-      # with a cool-down between attempts, letting the bucket refill so each
-      # attempt resumes from where the previous one stopped. (A manual re-run of
-      # the failed job ~10 min later is exactly what recovered the #264 release.)
-      # The common case — a handful of crates, well under the burst — publishes
-      # on the first attempt and never sleeps. A release larger than ~3 buckets'
-      # worth could still exhaust all attempts; if so the job fails loudly and a
-      # maintainer re-runs it (idempotent), or uses the manual `release.yml`.
+      # skips already-published crates — so the cure is to retry it with a
+      # cool-down between attempts, letting the limit refill so each attempt
+      # resumes where the last stopped. Because the NEW-crate limit is the
+      # binding one (~1 / 10 min), each cool-down is ~11 minutes and there are
+      # FOUR attempts total — enough to clear a burst of 5 new crates plus ~3
+      # more. The common case (a handful of crates, no new names) publishes on
+      # attempt 1 and never sleeps. A release adding more than ~8 new crates at
+      # once could still exhaust every attempt; if so the job fails loudly and a
+      # maintainer re-runs it (idempotent) or uses the manual `release.yml`.
       - name: Publish to crates.io (attempt 1)
         id: publish1
         continue-on-error: true
@@ -144,11 +155,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN || secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
-      - name: Cool-down for crates.io rate-limit refill (before retry 1)
+      - name: Cool-down for crates.io rate-limit refill (before attempt 2)
         if: steps.publish1.outcome == 'failure'
         run: |
-          echo "::warning::release-plz publish exited non-zero (commonly a crates.io 429 on a large multi-crate release). Waiting 4m for the rate-limit window to refill, then retrying idempotently."
-          sleep 240
+          echo "::warning::release-plz publish exited non-zero (commonly a crates.io 429). Waiting 11m for the new-crate rate-limit window (~1 new crate / 10 min) to refill, then retrying idempotently."
+          sleep 660
 
       - name: Publish to crates.io (attempt 2)
         id: publish2
@@ -167,14 +178,32 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN || secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
-      - name: Cool-down for crates.io rate-limit refill (before final attempt)
+      - name: Cool-down for crates.io rate-limit refill (before attempt 3)
         if: steps.publish1.outcome == 'failure' && steps.publish2.outcome == 'failure'
         run: |
-          echo "::warning::publish still incomplete after 2 attempts. Waiting 6m for a larger rate-limit refill, then making a final idempotent attempt."
-          sleep 360
+          echo "::warning::publish still incomplete after 2 attempts. Waiting 11m for another new-crate rate-limit window to refill, then retrying idempotently."
+          sleep 660
+
+      - name: Publish to crates.io (attempt 3)
+        id: publish3
+        if: steps.publish1.outcome == 'failure' && steps.publish2.outcome == 'failure'
+        continue-on-error: true
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+          config: release-plz.toml
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN || secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Cool-down for crates.io rate-limit refill (before final attempt)
+        if: steps.publish1.outcome == 'failure' && steps.publish2.outcome == 'failure' && steps.publish3.outcome == 'failure'
+        run: |
+          echo "::warning::publish still incomplete after 3 attempts. Waiting 11m for a final new-crate rate-limit window to refill, then making a final idempotent attempt."
+          sleep 660
 
       - name: Publish to crates.io (final attempt)
-        if: steps.publish1.outcome == 'failure' && steps.publish2.outcome == 'failure'
+        if: steps.publish1.outcome == 'failure' && steps.publish2.outcome == 'failure' && steps.publish3.outcome == 'failure'
         uses: release-plz/action@v0.5
         with:
           command: release


### PR DESCRIPTION
## Problem

The 1.5.0 release (`chore: release #302`) left the workspace **partially published**: many crates shipped, but `faucet-cli 1.5.0` (published last) never did — so there's no `faucet-cli-v1.5.0` tag, no 1.5.0 binaries, and Homebrew is stuck at 1.4.0.

Root cause: the publish job's existing 3-attempt retry ladder **ran and still failed**. Its cool-downs (4 min + 6 min) were tuned for crates.io's *existing-crate update* limit (burst ~30). What actually stuck 1.5.0 was the far harsher **new-crate** limit — **~1 new crate per 10 minutes** — because #302 introduced several brand-new `1.0.0` crates (delta / databricks / spanner source+sink). 10 minutes of total cool-down cannot clear several new crates that each need their own ~10-minute window, so all three attempts got 429'd on `faucet-sink-delta`.

## Fix

Retune the retry ladder for the binding (new-crate) limit:

- **Cool-downs 4 m / 6 m → 11 m each** (one full new-crate refill window per wait).
- **Added a 4th attempt** (now attempt 1 → 11 m → 2 → 11 m → 3 → 11 m → final), enough to clear a burst of 5 new crates **plus ~3 more** (~8 new crates in one release).
- Rewrote the explanatory comment to document **both** rate-limit buckets and why the new-crate one is the one that bit us.

Unchanged: the ladder is still idempotent (release-plz skips already-published crates), the common case (no new crate names) still publishes on attempt 1 and never sleeps, and total cool-down (~33 min) stays well under the job timeout. A release adding >~8 new crates at once would still need a manual re-run or the `release.yml` fallback — documented in the comment.

No runtime code changes; CI workflow only.
