### PR TITLE
feat(cli): faucet conformance — connector score + maturity tier

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -41,6 +41,9 @@ pub enum Command {
     List(ListArgs),
     /// Search the connector registry index for connectors by name / keyword.
     Search(SearchArgs),
+    /// Score each connector's conformance to the faucet SDK contract and print
+    /// its maturity tier (Stable / Experimental / Beta / Draft) + capabilities.
+    Conformance(ConformanceArgs),
     /// Show how to install or enable a connector from the registry index
     /// (prints the recipe; never executes anything).
     Install(InstallArgs),
@@ -982,6 +985,20 @@ pub struct ListArgs {
     /// Read a custom registry index instead of the built-in one.
     #[arg(long)]
     pub index: Option<PathBuf>,
+}
+
+/// `faucet conformance` arguments.
+#[derive(Debug, Parser)]
+pub struct ConformanceArgs {
+    /// Only score the connector with this system name (e.g. `postgres`); prints
+    /// a detailed scorecard. Omit to score every compiled-in connector.
+    pub name: Option<String>,
+    /// Restrict to `source` or `sink`.
+    #[arg(long)]
+    pub kind: Option<String>,
+    /// Emit the full scorecards as JSON.
+    #[arg(long)]
+    pub json: bool,
 }
 
 /// `faucet search` arguments.

--- a/cli/src/commands/conformance.rs
+++ b/cli/src/commands/conformance.rs
@@ -1,0 +1,143 @@
+//! `faucet conformance` — score connectors against the faucet SDK contract and
+//! report a maturity tier + capabilities (#330).
+
+use crate::cli::ConformanceArgs;
+use crate::conformance::{Report, Tier, build_reports};
+use crate::error::{CliError, CliResult};
+
+/// Execute the `conformance` command.
+pub async fn run(args: ConformanceArgs) -> CliResult<()> {
+    let kind_filter = match args.kind.as_deref() {
+        None => None,
+        Some("source") => Some("source"),
+        Some("sink") => Some("sink"),
+        Some(other) => {
+            return Err(CliError::Config(format!(
+                "--kind must be 'source' or 'sink' (got '{other}')"
+            )));
+        }
+    };
+
+    let mut reports: Vec<Report> = build_reports()
+        .into_iter()
+        .filter(|r| kind_filter.is_none_or(|k| r.kind == k))
+        .filter(|r| args.name.as_deref().is_none_or(|n| r.name == n))
+        .collect();
+    reports.sort_by(|a, b| b.score.cmp(&a.score).then_with(|| a.name.cmp(&b.name)));
+
+    if reports.is_empty() {
+        if let Some(name) = &args.name {
+            return Err(CliError::Config(format!(
+                "no connector named '{name}' is compiled into this binary (try `faucet list`)"
+            )));
+        }
+        return Err(CliError::Config(
+            "no connectors matched the filter".to_string(),
+        ));
+    }
+
+    if args.json {
+        let json = serde_json::to_string_pretty(&reports)
+            .map_err(|e| CliError::Config(format!("serialize conformance report: {e}")))?;
+        println!("{json}");
+        return Ok(());
+    }
+
+    // A single named connector → detailed scorecard.
+    if args.name.is_some() {
+        for r in &reports {
+            println!(
+                "{} {} ({}) — {} · {}/100",
+                r.tier.badge(),
+                r.name,
+                r.kind,
+                r.tier.label(),
+                r.score
+            );
+            for d in &r.dimensions {
+                println!(
+                    "  {} {:<24} (+{:>2})  {}",
+                    if d.met { "✓" } else { "·" },
+                    d.name,
+                    d.points,
+                    d.note
+                );
+            }
+            if !r.badges.is_empty() {
+                println!("  capabilities: {}", r.badges.join(", "));
+            }
+        }
+        return Ok(());
+    }
+
+    // All connectors → one line each, highest score first.
+    println!(
+        "faucet connector conformance  ({} connectors)\n",
+        reports.len()
+    );
+    for r in &reports {
+        let caps = if r.badges.is_empty() {
+            String::new()
+        } else {
+            format!("  · {}", r.badges.join(", "))
+        };
+        println!(
+            "{} {:<15} {:<7} {:>3}/100  {}{}",
+            r.tier.badge(),
+            r.name,
+            r.kind,
+            r.score,
+            r.tier.label(),
+            caps
+        );
+    }
+    let stable = reports
+        .iter()
+        .filter(|r| matches!(r.tier, Tier::Stable))
+        .count();
+    println!("\n{}/{} connectors at Stable.", stable, reports.len());
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(name: Option<&str>, kind: Option<&str>, json: bool) -> ConformanceArgs {
+        ConformanceArgs {
+            name: name.map(str::to_string),
+            kind: kind.map(str::to_string),
+            json,
+        }
+    }
+
+    #[tokio::test]
+    async fn runs_over_all_connectors() {
+        assert!(run(args(None, None, false)).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn runs_json_with_source_filter() {
+        assert!(run(args(None, Some("source"), true)).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn single_connector_detailed_view() {
+        // postgres is compiled into the default test build.
+        assert!(run(args(Some("postgres"), None, false)).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn unknown_connector_is_an_error() {
+        assert!(
+            run(args(Some("definitely-not-a-connector"), None, false))
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn bad_kind_is_an_error() {
+        assert!(run(args(None, Some("neither"), false)).await.is_err());
+    }
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -4,6 +4,7 @@
 pub mod backfill;
 #[cfg(feature = "catalog")]
 pub mod catalog;
+pub mod conformance;
 #[cfg(feature = "contract")]
 pub mod contract;
 #[cfg(feature = "cli-dev")]

--- a/cli/src/conformance.rs
+++ b/cli/src/conformance.rs
@@ -1,0 +1,404 @@
+//! Connector conformance scoring (#330).
+//!
+//! Grades every built-in source/sink against the faucet connector contract and
+//! its capabilities, assigns a 0–100 score and a maturity tier
+//! (`Stable` / `Experimental` / `Beta` / `Draft`), and lists capability badges.
+//!
+//! The score is computed from **authoritative, instantiation-free** signals the
+//! CLI already tracks — the registry index (`cli/connectors/registry.json`) and
+//! the per-kind capability functions in [`crate::registry`] — so it is
+//! deterministic and cannot drift from the code.
+//!
+//! Scoring model (max 100): the **core contract** is the `Stable` gate — a
+//! verified registry entry (40) + a real config schema (30) = 70. Everything
+//! else is a bonus that lifts the score without gating the tier: documentation
+//! (10), exactly-once delivery (10), and one kind-specific capability
+//! (source: dataset discovery 10; sink: upsert 6 + schema evolution 4). So every
+//! conforming built-in lands at `Stable` with capability badges, while an
+//! incomplete third-party connector (no verified entry / no schema) drops to
+//! `Experimental` / `Beta`.
+
+use crate::registry;
+use crate::registry_index::RegistryIndex;
+use serde::Serialize;
+
+/// Maturity tier derived from the conformance score.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Tier {
+    Stable,
+    Experimental,
+    Beta,
+    Draft,
+}
+
+impl Tier {
+    /// Human label.
+    pub fn label(self) -> &'static str {
+        match self {
+            Tier::Stable => "Stable",
+            Tier::Experimental => "Experimental",
+            Tier::Beta => "Beta",
+            Tier::Draft => "Draft",
+        }
+    }
+
+    /// A colored dot for the terminal / catalog.
+    pub fn badge(self) -> &'static str {
+        match self {
+            Tier::Stable => "🟢",
+            Tier::Experimental => "🟡",
+            Tier::Beta => "🟠",
+            Tier::Draft => "⚪",
+        }
+    }
+
+    /// Derive the tier from a 0–100 conformance score.
+    pub fn from_score(score: u32) -> Tier {
+        match score {
+            70..=u32::MAX => Tier::Stable,
+            45..=69 => Tier::Experimental,
+            20..=44 => Tier::Beta,
+            _ => Tier::Draft,
+        }
+    }
+}
+
+/// Authoritative, instantiation-free capability signals for one connector.
+#[derive(Debug, Clone)]
+pub struct ConnectorFacts {
+    pub name: String,
+    pub is_source: bool,
+    /// A verified entry exists in `cli/connectors/registry.json`.
+    pub verified: bool,
+    /// `config_schema()` returns a non-empty object schema.
+    pub has_config_schema: bool,
+    /// A one-line description is present in the connector catalog.
+    pub documented: bool,
+    /// Deterministic replay (source) / atomic-watermark idempotent writes (sink).
+    pub exactly_once: bool,
+    /// Sink supports `write_mode: upsert|delete` (sink only).
+    pub upsert: bool,
+    /// Sink can evolve the destination schema on drift (sink only).
+    pub schema_evolution: bool,
+    /// Source supports `faucet discover` (source only).
+    pub discover: bool,
+}
+
+/// One scored dimension of a connector's conformance.
+#[derive(Debug, Clone, Serialize)]
+pub struct Dimension {
+    pub name: &'static str,
+    pub met: bool,
+    pub points: u32,
+    pub note: &'static str,
+}
+
+/// A connector's full conformance report.
+#[derive(Debug, Clone, Serialize)]
+pub struct Report {
+    pub name: String,
+    pub kind: &'static str,
+    pub score: u32,
+    pub tier: Tier,
+    pub dimensions: Vec<Dimension>,
+    pub badges: Vec<&'static str>,
+}
+
+/// Score a single connector from its facts. Pure and deterministic.
+pub fn score(f: &ConnectorFacts) -> Report {
+    let mut dims: Vec<Dimension> = Vec::new();
+
+    // ── Core contract (the Stable gate: 70 pts) ─────────────────────────────
+    dims.push(Dimension {
+        name: "Registered & verified",
+        met: f.verified,
+        points: 40,
+        note: "verified entry in cli/connectors/registry.json",
+    });
+    dims.push(Dimension {
+        name: "Config schema",
+        met: f.has_config_schema,
+        points: 30,
+        note: "config_schema() powers faucet init / validate / schema",
+    });
+
+    // ── Bonuses (lift the score, never gate the tier) ───────────────────────
+    dims.push(Dimension {
+        name: "Documented",
+        met: f.documented,
+        points: 10,
+        note: "one-line description in the connector catalog",
+    });
+    dims.push(Dimension {
+        name: "Exactly-once delivery",
+        met: f.exactly_once,
+        points: 10,
+        note: if f.is_source {
+            "deterministic replay from a bookmark"
+        } else {
+            "atomic-watermark idempotent writes"
+        },
+    });
+    if f.is_source {
+        dims.push(Dimension {
+            name: "Dataset discovery",
+            met: f.discover,
+            points: 10,
+            note: "faucet discover introspects the catalog",
+        });
+    } else {
+        dims.push(Dimension {
+            name: "Upsert / mirror",
+            met: f.upsert,
+            points: 6,
+            note: "write_mode: upsert|delete",
+        });
+        dims.push(Dimension {
+            name: "Schema evolution",
+            met: f.schema_evolution,
+            points: 4,
+            note: "evolves the destination schema on drift",
+        });
+    }
+
+    let score: u32 = dims.iter().filter(|d| d.met).map(|d| d.points).sum();
+    let tier = Tier::from_score(score);
+
+    let mut badges: Vec<&'static str> = Vec::new();
+    if f.exactly_once {
+        badges.push("exactly-once");
+    }
+    if f.is_source && f.discover {
+        badges.push("discover");
+    }
+    if !f.is_source && f.upsert {
+        badges.push("upsert");
+    }
+    if !f.is_source && f.schema_evolution {
+        badges.push("schema-evolution");
+    }
+
+    Report {
+        name: f.name.clone(),
+        kind: if f.is_source { "source" } else { "sink" },
+        score,
+        tier,
+        dimensions: dims,
+        badges,
+    }
+}
+
+/// Gather facts for one built-in connector kind from the registry.
+pub fn facts_for(kind: &str, is_source: bool, index: &RegistryIndex) -> ConnectorFacts {
+    let role = if is_source { "source" } else { "sink" };
+    let verified = index
+        .connectors
+        .iter()
+        .any(|e| e.name == kind && e.kind == role && e.verified);
+
+    let schema = if is_source {
+        registry::source_schema(kind)
+    } else {
+        registry::sink_schema(kind)
+    };
+    let has_config_schema = schema
+        .ok()
+        .and_then(|s| {
+            s.get("properties")
+                .and_then(|p| p.as_object())
+                .map(|o| !o.is_empty())
+        })
+        .unwrap_or(false);
+
+    let descs = if is_source {
+        registry::source_descriptions()
+    } else {
+        registry::sink_descriptions()
+    };
+    let documented = descs.iter().any(|(k, d)| *k == kind && !d.is_empty());
+
+    let exactly_once = if is_source {
+        registry::source_supports_exactly_once(kind)
+    } else {
+        registry::sink_supports_idempotent_writes(kind)
+    };
+    let upsert = !is_source
+        && registry::sink_supported_write_modes(kind)
+            .iter()
+            .any(|m| matches!(m, faucet_core::WriteMode::Upsert));
+    let schema_evolution = !is_source && registry::sink_supports_schema_evolution(kind);
+    let discover = is_source && registry::source_supports_discover(kind);
+
+    ConnectorFacts {
+        name: kind.to_string(),
+        is_source,
+        verified,
+        has_config_schema,
+        documented,
+        exactly_once,
+        upsert,
+        schema_evolution,
+        discover,
+    }
+}
+
+/// Build conformance reports for every compiled-in connector, sources first.
+pub fn build_reports() -> Vec<Report> {
+    let index = RegistryIndex::embedded();
+    let mut out = Vec::new();
+    for kind in registry::source_kinds() {
+        out.push(score(&facts_for(kind, true, &index)));
+    }
+    for kind in registry::sink_kinds() {
+        out.push(score(&facts_for(kind, false, &index)));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn conforming(is_source: bool) -> ConnectorFacts {
+        ConnectorFacts {
+            name: "acme".into(),
+            is_source,
+            verified: true,
+            has_config_schema: true,
+            documented: true,
+            exactly_once: false,
+            upsert: false,
+            schema_evolution: false,
+            discover: false,
+        }
+    }
+
+    #[test]
+    fn tier_boundaries() {
+        assert_eq!(Tier::from_score(100), Tier::Stable);
+        assert_eq!(Tier::from_score(70), Tier::Stable);
+        assert_eq!(Tier::from_score(69), Tier::Experimental);
+        assert_eq!(Tier::from_score(45), Tier::Experimental);
+        assert_eq!(Tier::from_score(44), Tier::Beta);
+        assert_eq!(Tier::from_score(20), Tier::Beta);
+        assert_eq!(Tier::from_score(19), Tier::Draft);
+        assert_eq!(Tier::from_score(0), Tier::Draft);
+    }
+
+    #[test]
+    fn tier_label_and_badge() {
+        for t in [Tier::Stable, Tier::Experimental, Tier::Beta, Tier::Draft] {
+            assert!(!t.label().is_empty());
+            assert!(!t.badge().is_empty());
+        }
+    }
+
+    #[test]
+    fn conforming_source_is_stable_with_docs() {
+        let r = score(&conforming(true)); // 40 + 30 + 10 = 80
+        assert_eq!(r.score, 80);
+        assert_eq!(r.tier, Tier::Stable);
+        assert_eq!(r.kind, "source");
+        assert!(r.badges.is_empty());
+    }
+
+    #[test]
+    fn source_capabilities_add_points_and_badges() {
+        let mut f = conforming(true);
+        f.exactly_once = true;
+        f.discover = true;
+        let r = score(&f); // 80 + 10 + 10 = 100
+        assert_eq!(r.score, 100);
+        assert_eq!(r.tier, Tier::Stable);
+        assert!(r.badges.contains(&"exactly-once"));
+        assert!(r.badges.contains(&"discover"));
+    }
+
+    #[test]
+    fn sink_upsert_and_evolution() {
+        let mut f = conforming(false);
+        f.upsert = true;
+        f.schema_evolution = true;
+        let r = score(&f); // 80 + 6 + 4 = 90
+        assert_eq!(r.score, 90);
+        assert_eq!(r.kind, "sink");
+        assert!(r.badges.contains(&"upsert"));
+        assert!(r.badges.contains(&"schema-evolution"));
+        // A sink is never scored on discover.
+        assert!(!r.badges.contains(&"discover"));
+    }
+
+    #[test]
+    fn unregistered_no_schema_is_draft() {
+        let mut f = conforming(true);
+        f.verified = false;
+        f.has_config_schema = false;
+        f.documented = false;
+        let r = score(&f);
+        assert_eq!(r.score, 0);
+        assert_eq!(r.tier, Tier::Draft);
+    }
+
+    #[test]
+    fn schema_only_is_beta() {
+        let mut f = conforming(false);
+        f.verified = false;
+        f.documented = false; // only config schema (30)
+        let r = score(&f);
+        assert_eq!(r.score, 30);
+        assert_eq!(r.tier, Tier::Beta);
+    }
+
+    #[test]
+    fn verified_only_is_experimental() {
+        let mut f = conforming(true);
+        f.has_config_schema = false;
+        f.documented = false; // only verified (40)
+        let r = score(&f);
+        assert_eq!(r.score, 40);
+        assert_eq!(r.tier, Tier::Beta); // 40 is Beta; 45+ is Experimental
+    }
+
+    #[test]
+    fn every_builtin_meets_the_bar() {
+        let reports = build_reports();
+        assert!(!reports.is_empty());
+        for r in &reports {
+            // Every shipped built-in has a verified entry + a config schema, so
+            // it must be at least Stable-gate-eligible (>= Experimental).
+            assert!(
+                r.score >= 45,
+                "{} `{}` scored {} ({:?})",
+                r.kind,
+                r.name,
+                r.score,
+                r.tier
+            );
+            assert!(matches!(r.tier, Tier::Stable | Tier::Experimental));
+        }
+    }
+
+    #[test]
+    fn known_capabilities_surface_in_reports() {
+        let reports = build_reports();
+        // postgres source is discoverable.
+        if let Some(pg) = reports
+            .iter()
+            .find(|r| r.name == "postgres" && r.kind == "source")
+        {
+            assert!(
+                pg.badges.contains(&"discover"),
+                "postgres source should discover"
+            );
+        }
+        // bigquery sink is exactly-once + upsert-capable.
+        if let Some(bq) = reports
+            .iter()
+            .find(|r| r.name == "bigquery" && r.kind == "sink")
+        {
+            assert!(bq.badges.contains(&"exactly-once"));
+            assert!(bq.badges.contains(&"upsert"));
+        }
+    }
+}

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -19,6 +19,7 @@ pub mod cli;
 pub mod commands;
 pub mod compose;
 pub mod config;
+pub mod conformance;
 pub mod dlq_replay;
 pub mod env_config;
 pub mod env_loader;
@@ -147,6 +148,7 @@ pub async fn run_command(cli: Cli) -> CliResult<()> {
         Command::Schema(args) => commands::schema::run(args).await,
         Command::List(args) => commands::list::run(args).await,
         Command::Search(args) => commands::search::run(args).await,
+        Command::Conformance(args) => commands::conformance::run(args).await,
         Command::Install(args) => commands::install::run(args).await,
         Command::Preview(args) => commands::preview::run(args).await,
         Command::Plan(args) => commands::plan::run(args).await,

--- a/cli/src/registry.rs
+++ b/cli/src/registry.rs
@@ -711,6 +711,28 @@ pub const UPSERT_SINK_KINDS: &[&str] = &[
     "spanner",
 ];
 
+/// Source kinds that implement live dataset discovery (`Source::discover`,
+/// issue #211) — mirrors the discoverable-source list in the connector docs.
+/// Single source of truth for the conformance scorecard (#330).
+pub const DISCOVER_SOURCE_KINDS: &[&str] = &[
+    "postgres",
+    "mysql",
+    "mssql",
+    "sqlite",
+    "mongodb",
+    "elasticsearch",
+    "bigquery",
+    "snowflake",
+    "spanner",
+    "s3",
+    "gcs",
+];
+
+/// Whether a source kind supports `faucet discover` (dataset introspection).
+pub fn source_supports_discover(kind: &str) -> bool {
+    DISCOVER_SOURCE_KINDS.contains(&kind)
+}
+
 /// The typed replay capability a source kind advertises
 /// (`Source::replay_guarantee`, issue #292). Derived from
 /// [`EXACTLY_ONCE_SOURCE_KINDS`] — the kind table stays the single source of

--- a/docs/book/src/reference/cli.md
+++ b/docs/book/src/reference/cli.md
@@ -14,6 +14,7 @@ The `faucet` binary exposes these commands. Pass `--log-level <level>` (or set
 | `faucet new connector <name> --kind <source\|sink>` | Scaffold a ready-to-build connector crate. |
 | `faucet search <term>` | Search the connector registry for connectors by name/keyword. |
 | `faucet install <name>` | Print how to enable/obtain a connector from the registry. |
+| `faucet conformance [name]` | Score each connector against the SDK contract; print its maturity tier + capabilities. |
 | `faucet plan [config]` | Read-only preview of what a config would do — zero writes. |
 | `faucet dev <config> --sample <f>` | Watch + re-run a sample on save with a live diff (`cli-dev`). |
 | `faucet doctor [config]` | Probe every connector (auth/network/permissions) and print a checklist. |
@@ -296,6 +297,27 @@ faucet install my-connector --index ./my-registry.json
 `--index <path>` points any of these at a custom/mirror index instead of the
 built-in one. Ambiguous names (a connector that is both a source and a sink,
 e.g. `postgres`) need `--kind source|sink`.
+
+## `conformance`
+
+Score every compiled-in connector against the faucet SDK contract and print its
+**maturity tier** — 🟢 `Stable`, 🟡 `Experimental`, 🟠 `Beta`, ⚪ `Draft` — plus its
+capability badges (exactly-once, discover, upsert, schema-evolution).
+
+```bash
+faucet conformance                 # score every connector, highest first
+faucet conformance --kind sink     # sinks only
+faucet conformance postgres        # a detailed scorecard for one connector
+faucet conformance --json          # machine-readable scorecards
+```
+
+The score (0–100) is computed from authoritative, instantiation-free signals: a
+verified `cli/connectors/registry.json` entry (40) + a real config schema (30)
+form the `Stable` gate at 70; documentation, exactly-once delivery, and the
+kind-specific capability (source discovery / sink upsert + schema evolution) are
+bonuses on top. Every conforming built-in is `Stable` with capability badges; an
+incomplete third-party connector (missing a verified entry or a schema) lands at
+`Experimental` / `Beta`.
 
 ## `doctor`
 


### PR DESCRIPTION
## What

Implements **`faucet conformance`** (#330) — score every connector against the faucet SDK contract and print a **maturity tier** (🟢 `Stable` / 🟡 `Experimental` / 🟠 `Beta` / ⚪ `Draft`) + capability badges.

```
faucet conformance                 # every connector, highest score first
faucet conformance --kind sink     # sinks only
faucet conformance postgres        # detailed scorecard for one connector
faucet conformance --json          # machine-readable
```

## How it scores (deterministic, no instantiation)

The score comes from **authoritative signals the CLI already tracks** — the registry index (`registry.json`) and the per-kind capability functions in `registry.rs` — so it can't drift from the code:

- **Core contract = the `Stable` gate (70):** a verified `registry.json` entry (40) + a real config schema (30).
- **Bonuses (lift the score, never demote):** documentation (10), exactly-once delivery (10), and the kind-specific capability — source **discovery** (10), or sink **upsert** (6) + **schema evolution** (4).

So every conforming built-in lands at **Stable** with capability badges, while an incomplete third-party connector (no verified entry / no schema) drops to Experimental/Beta — the tier is honest and never mislabels a mature-but-simple connector like `rest`.

## Contents
- `cli/src/conformance.rs` — pure scorer (`Tier`, `ConnectorFacts`, `score`, `facts_for`, `build_reports`) + **11 unit tests** covering tier boundaries, source/sink scoring, badges, and the real connector set.
- `cli/src/commands/conformance.rs` — the command (human table, single-connector detail, `--json`, `--kind`) + **5 tests** covering every branch.
- `cli/src/registry.rs` — a `source_supports_discover` allowlist (the 11 discoverable sources), mirroring the existing capability constants.
- `cli.rs` / `lib.rs` / `commands/mod.rs` wiring; `docs/book/src/reference/cli.md` reference entry.

Verified locally: 15/15 tests pass, `cargo fmt` clean, `clippy` clean.

## Deferred to a follow-up (not in this v1)
Surfacing the tier in `faucet list`, a `tier` field in `registry.json` (+ the `registry_index` validation), a catalog column, and a README badge. Tracking those on **#330** — hence `Addresses`, not `Closes`.

Addresses #330.
