### PR TITLE
docs: brand the docs site with the faucet-stream teal (#14B8A6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,9 +386,9 @@ own service.
 | Connector count | 49, growing | 600+ taps | 350+ | dozens | dozens | 500+ |
 | Change data capture | ✓ Postgres / MySQL / Mongo | partial¹ | ✓ | partial | ✗ | ✓ |
 | Incremental + resumable state | ✓ | ✓ | ✓ | partial | n/a | ✓ |
-| Effectively-once delivery³ | ✓ (SQL / Iceberg / BigQuery) | ✗ | partial | ✗ | ✗ | ✓ |
+| Effectively-once delivery³ | ✓ (11 sinks incl. Kafka, Iceberg, BigQuery) | ✗ | partial | ✗ | ✗ | ✓ |
 | Built-in data-quality checks | ✓ native | ✗ | paywalled add-on | ✗ | ✗ | paywalled add-on |
-| Built-in metrics + tracing | ✓ Prometheus + `tracing` | partial | ✓ (platform) | ✓ | ✓ | ✓ (hosted) |
+| Built-in metrics + tracing | ✓ Prometheus + OTLP + `tracing` | partial | ✓ (platform) | ✓ | ✓ | ✓ (hosted) |
 | Self-hosted, no daemon | ✓ run-to-completion | ✓ | ✗ needs platform | usually a service | agent | ✗ SaaS |
 | License | MIT / Apache-2.0 | MIT | ELv2 + MIT | Apache-2.0 / source-available² | MPL-2.0 | Proprietary |
 
@@ -396,9 +396,9 @@ own service.
 
 For reference: **[Singer](https://www.singer.io/)** is a connector spec and **[Meltano](https://meltano.com/)**
 is its most common runtime; both appear above. faucet-stream is a full **ETL** tool — it
-transforms data *in flight* as it moves (13 record transforms plus a page-level
-embedded-DuckDB `sql` transform for aggregation, joins, and filtering), not just
-extract-and-load. **[dbt](https://www.getdbt.com/) is complementary, not a competitor:**
+transforms data *in flight* as it moves (11 record transforms plus filter,
+explode, and CDC-unwrap stages and a page-level embedded-DuckDB `sql` transform
+for aggregation, joins, and filtering), not just extract-and-load. **[dbt](https://www.getdbt.com/) is complementary, not a competitor:**
 it models transformations *in the warehouse* on data already loaded (the "T" of ELT, at
 warehouse scale) — pair the two when you need heavy in-warehouse modeling on top of what
 faucet extracts, transforms, and loads.

--- a/docs/book/custom.css
+++ b/docs/book/custom.css
@@ -21,7 +21,12 @@
   --fs-brand-strong: var(--fs-teal-strong);
   --fs-radius: 10px;
   --fs-shadow: 0 1px 2px rgba(15, 23, 42, 0.06), 0 10px 30px rgba(15, 23, 42, 0.06);
-  --content-max-width: 46rem;
+  /* mdBook defaults to a ~750px column tuned for a short prose line length.
+     These docs lean on wide reference tables (the connector capability matrix,
+     feature grids), so give the column real room — ~1000px. Prose paragraphs
+     are held back to a comfortable measure via `.content p` below so long
+     lines don't hurt readability. */
+  --content-max-width: 62rem;
 }
 
 /* Per-theme accent + ground overrides (mdBook stamps the theme on <html>). */
@@ -86,6 +91,21 @@ html {
 }
 .content {
   line-height: 1.68;
+}
+/* Hold running prose to a comfortable measure even though the column is wide,
+   while tables, code blocks, diagrams, and the hero/cards use the full width. */
+.content p,
+.content ul,
+.content ol,
+.content blockquote {
+  max-width: 46rem;
+}
+.content table,
+.content pre,
+.content .mermaid,
+.content .fs-hero,
+.content .fs-cards {
+  max-width: none;
 }
 .content h1,
 .content h2,

--- a/docs/book/custom.css
+++ b/docs/book/custom.css
@@ -1,18 +1,81 @@
 /* ── faucet-stream documentation theme ──────────────────────────────────────
-   Visual polish layered on top of mdBook's built-in themes via
-   `additional-css` (no preprocessor — a bare `mdbook build` still works).
-   Loaded after mdBook's own CSS, so these rules win. Tuned for the two themes
-   we ship by default (light + navy); the others (rust/coal/ayu) still inherit
-   the brand accent and remain fully legible.
+   Brand-grounded visual identity layered on mdBook via `additional-css`
+   (no preprocessor — a bare `mdbook build` still works). The accent is the
+   faucet-stream icon's own teal (#14B8A6) on slate neutrals (#0F172A), so the
+   docs match the logo, the favicon, and the wordmark. Tuned for the two themes
+   we ship (light default + navy dark → restyled to slate); the others still
+   inherit the teal accent and stay legible.
    ──────────────────────────────────────────────────────────────────────── */
 
 :root {
-  /* faucet-stream brand — a "water/flow" blue, legible on both light and dark. */
-  --fs-brand: #2f7fe0;
-  --fs-brand-strong: #1f66c2;
-  --fs-accent: #0ea5b7;
-  --fs-radius: 8px;
-  --content-max-width: 46rem; /* a touch wider than default for tables/code */
+  /* Brand — the icon's teal on slate. */
+  --fs-teal: #14b8a6; /* logo-mark / favicon / wordmark */
+  --fs-teal-strong: #0d9488;
+  --fs-teal-deep: #0f766e;
+  --fs-teal-bright: #2dd4bf; /* legible on dark grounds */
+  --fs-cyan: #06b6d4; /* gradient partner (the "stream") */
+  --fs-slate: #0f172a; /* wordmark ink / dark ground */
+  --fs-slate-2: #1e293b;
+
+  --fs-brand: var(--fs-teal);
+  --fs-brand-strong: var(--fs-teal-strong);
+  --fs-radius: 10px;
+  --fs-shadow: 0 1px 2px rgba(15, 23, 42, 0.06), 0 10px 30px rgba(15, 23, 42, 0.06);
+  --content-max-width: 46rem;
+}
+
+/* Per-theme accent + ground overrides (mdBook stamps the theme on <html>). */
+.light {
+  --links: var(--fs-teal-deep);
+  --sidebar-active: var(--fs-teal-deep);
+  --fs-brand: var(--fs-teal-deep);
+  --fs-brand-strong: var(--fs-teal);
+  --fs-card-bg: rgba(20, 184, 166, 0.05);
+  --fs-line: #e2e8f0;
+}
+/* Dark theme (navy) → restyle to brand slate + bright teal for legibility. */
+.navy {
+  --bg: #0b1120;
+  --fg: #e2e8f0;
+  --sidebar-bg: #0a0f1c;
+  --sidebar-fg: #cbd5e1;
+  --sidebar-non-existant: #64748b;
+  --links: var(--fs-teal-bright);
+  --sidebar-active: var(--fs-teal-bright);
+  --inline-code-color: var(--fs-teal-bright);
+  --theme-popup-bg: #0f172a;
+  --theme-popup-border: #1e293b;
+  --quote-bg: #101a2e;
+  --quote-border: #1e293b;
+  --table-border-color: #1e293b;
+  --table-header-bg: #0f172a;
+  --table-alternate-bg: #0d1526;
+  --fs-brand: var(--fs-teal-bright);
+  --fs-brand-strong: var(--fs-teal);
+  --fs-card-bg: rgba(45, 212, 191, 0.06);
+  --fs-line: #1e293b;
+}
+.coal,
+.ayu {
+  --links: var(--fs-teal-bright);
+  --sidebar-active: var(--fs-teal-bright);
+  --fs-brand: var(--fs-teal-bright);
+  --fs-brand-strong: var(--fs-teal);
+  --fs-card-bg: rgba(45, 212, 191, 0.06);
+  --fs-line: rgba(148, 163, 184, 0.2);
+}
+.rust {
+  --links: var(--fs-teal-deep);
+  --fs-brand: var(--fs-teal-deep);
+  --fs-brand-strong: var(--fs-teal);
+  --fs-card-bg: rgba(20, 184, 166, 0.06);
+  --fs-line: rgba(148, 163, 184, 0.25);
+}
+
+/* ── Signature gradient rail at the very top ─────────────────────────────── */
+#menu-bar {
+  border-top: 3px solid transparent;
+  border-image: linear-gradient(90deg, var(--fs-teal), var(--fs-cyan)) 1;
 }
 
 /* ── Typography ──────────────────────────────────────────────────────────── */
@@ -22,58 +85,73 @@ html {
   scroll-behavior: smooth;
 }
 .content {
-  line-height: 1.65;
+  line-height: 1.68;
 }
 .content h1,
 .content h2,
 .content h3,
 .content h4 {
-  font-weight: 650;
-  letter-spacing: -0.01em;
-  line-height: 1.25;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
 }
 .content h1 {
-  font-size: 2.1rem;
-  padding-bottom: 0.3em;
-  border-bottom: 2px solid color-mix(in srgb, var(--fs-brand) 30%, transparent);
+  font-size: 2.15rem;
+  padding-bottom: 0.35em;
+  background: linear-gradient(90deg, var(--fs-teal), var(--fs-cyan)) bottom left / 3.5rem 3px no-repeat;
 }
 .content h2 {
-  margin-top: 2.2rem;
-  padding-bottom: 0.2em;
-  border-bottom: 1px solid var(--table-border-color, rgba(128, 128, 128, 0.25));
+  margin-top: 2.4rem;
+  padding-bottom: 0.25em;
+  border-bottom: 1px solid var(--fs-line);
+}
+.content h2::before {
+  content: "";
+  display: inline-block;
+  width: 0.45rem;
+  height: 0.45rem;
+  margin-right: 0.55rem;
+  border-radius: 2px;
+  background: var(--fs-brand);
+  vertical-align: middle;
+  transform: translateY(-0.15em);
 }
 
 /* ── Links ───────────────────────────────────────────────────────────────── */
 .content a:not(.header) {
   color: var(--fs-brand);
   text-decoration: none;
-  border-bottom: 1px solid transparent;
+  border-bottom: 1px solid color-mix(in srgb, var(--fs-brand) 30%, transparent);
   transition: border-color 0.12s ease, color 0.12s ease;
 }
 .content a:not(.header):hover {
   color: var(--fs-brand-strong);
   border-bottom-color: currentColor;
 }
+::selection {
+  background: color-mix(in srgb, var(--fs-teal) 28%, transparent);
+}
 
 /* ── Code ────────────────────────────────────────────────────────────────── */
 .content pre {
   border-radius: var(--fs-radius);
-  border: 1px solid var(--table-border-color, rgba(128, 128, 128, 0.2));
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
-}
-.content code {
-  border-radius: 4px;
+  border: 1px solid var(--fs-line);
+  box-shadow: var(--fs-shadow);
 }
 .content pre > .buttons {
-  opacity: 0.7;
+  opacity: 0.75;
+}
+.content :not(pre) > code {
+  border-radius: 5px;
+  padding: 0.1em 0.35em;
 }
 
-/* ── Blockquotes → callouts ──────────────────────────────────────────────── */
+/* ── Blockquote → callout ────────────────────────────────────────────────── */
 .content blockquote {
   border-inline-start: 4px solid var(--fs-brand);
-  background: color-mix(in srgb, var(--fs-brand) 8%, transparent);
+  background: color-mix(in srgb, var(--fs-teal) 9%, transparent);
   border-radius: 0 var(--fs-radius) var(--fs-radius) 0;
-  padding: 0.6rem 1rem;
+  padding: 0.7rem 1.1rem;
   margin-inline: 0;
   color: inherit;
 }
@@ -84,16 +162,18 @@ html {
   overflow: hidden;
   border-collapse: collapse;
   width: 100%;
+  box-shadow: var(--fs-shadow);
 }
 .content table thead th {
-  background: color-mix(in srgb, var(--fs-brand) 12%, transparent);
+  background: var(--table-header-bg, color-mix(in srgb, var(--fs-teal) 14%, transparent));
+  color: inherit;
   font-weight: 650;
-  border-bottom: 2px solid color-mix(in srgb, var(--fs-brand) 30%, transparent);
+  border-bottom: 2px solid color-mix(in srgb, var(--fs-teal) 45%, transparent);
 }
 .content table td,
 .content table th {
-  border: 1px solid var(--table-border-color, rgba(128, 128, 128, 0.18));
-  padding: 0.45rem 0.7rem;
+  border: 1px solid var(--fs-line);
+  padding: 0.5rem 0.75rem;
 }
 
 /* ── Sidebar ─────────────────────────────────────────────────────────────── */
@@ -101,66 +181,101 @@ html {
   color: var(--fs-brand);
   font-weight: 650;
 }
+.chapter li.chapter-item a:hover {
+  color: var(--fs-brand);
+}
 .sidebar .sidebar-scrollbox {
   padding: 0.75rem 1rem;
 }
 
-/* ── Landing hero (used by introduction.md) ──────────────────────────────── */
+/* ── Mermaid diagrams — let them breathe ─────────────────────────────────── */
+.content .mermaid {
+  margin: 1.4rem 0;
+  text-align: center;
+}
+
+/* ── Landing hero (introduction.md) ──────────────────────────────────────── */
 .fs-hero {
   text-align: center;
-  padding: 1.5rem 0 0.5rem;
+  padding: 2.5rem 1rem 1rem;
+  margin: -1rem -1rem 0;
+  border-radius: 0 0 20px 20px;
+  background: radial-gradient(
+    60% 120% at 50% -10%,
+    color-mix(in srgb, var(--fs-teal) 16%, transparent),
+    transparent 70%
+  );
 }
 .fs-hero img {
-  max-width: 460px;
-  width: 70%;
+  max-width: 440px;
+  width: 72%;
   height: auto;
 }
 .fs-hero .fs-tagline {
-  font-size: 1.25rem;
-  opacity: 0.85;
-  margin: 0.75rem auto 1.25rem;
+  font-size: 1.35rem;
+  font-weight: 500;
+  margin: 1rem auto 1.5rem;
   max-width: 34rem;
-  line-height: 1.5;
+  line-height: 1.45;
+}
+.fs-hero .fs-tagline strong,
+.fs-hero .fs-tagline b {
+  background: linear-gradient(90deg, var(--fs-teal), var(--fs-cyan));
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
 }
 .fs-cta {
   display: inline-flex;
   gap: 0.75rem;
   flex-wrap: wrap;
   justify-content: center;
-  margin-bottom: 1rem;
+  margin-bottom: 0.5rem;
 }
 .fs-cta a {
   display: inline-block;
-  padding: 0.6rem 1.15rem;
+  padding: 0.65rem 1.25rem;
   border-radius: var(--fs-radius);
-  font-weight: 600;
+  font-weight: 650;
   border-bottom: none !important;
+  transition: transform 0.12s ease, box-shadow 0.12s ease, background 0.12s ease;
+}
+.fs-cta a:hover {
+  transform: translateY(-2px);
 }
 .fs-cta a.primary {
-  background: var(--fs-brand);
+  background: linear-gradient(135deg, var(--fs-teal), var(--fs-teal-deep));
   color: #fff !important;
-}
-.fs-cta a.primary:hover {
-  background: var(--fs-brand-strong);
+  box-shadow: 0 6px 18px color-mix(in srgb, var(--fs-teal) 35%, transparent);
 }
 .fs-cta a.secondary {
-  border: 1px solid var(--fs-brand) !important;
+  border: 1px solid color-mix(in srgb, var(--fs-teal) 55%, transparent) !important;
   color: var(--fs-brand) !important;
 }
+.fs-cta a.secondary:hover {
+  background: color-mix(in srgb, var(--fs-teal) 8%, transparent);
+}
 
-/* Card grid for the landing "why" / quick-links sections. */
+/* Card grid for the landing "why" / quick-links. */
 .fs-cards {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 1rem;
-  margin: 1.25rem 0;
+  margin: 1.5rem 0;
 }
 .fs-card {
-  border: 1px solid var(--table-border-color, rgba(128, 128, 128, 0.22));
+  border: 1px solid var(--fs-line);
   border-radius: var(--fs-radius);
-  padding: 1rem 1.1rem;
-  background: color-mix(in srgb, var(--fs-brand) 4%, transparent);
+  padding: 1.1rem 1.2rem;
+  background: var(--fs-card-bg);
+  transition: transform 0.14s ease, box-shadow 0.14s ease, border-color 0.14s ease;
+}
+.fs-card:hover {
+  transform: translateY(-3px);
+  box-shadow: var(--fs-shadow);
+  border-color: color-mix(in srgb, var(--fs-teal) 45%, transparent);
 }
 .fs-card h3 {
   margin-top: 0;
+  color: var(--fs-brand);
 }

--- a/docs/book/src/comparison/airbyte.md
+++ b/docs/book/src/comparison/airbyte.md
@@ -6,7 +6,7 @@
 
 ## The short version
 
-**Airbyte** is a data-integration **platform** with a **350+** connector catalog, a web UI, an API, a scheduler, and a managed Cloud option. Each connector runs as its own container; you operate the platform (Docker/Kubernetes) or pay for Cloud. It's a strong fit when **non-engineers need a UI** and **connector breadth** is paramount.
+**Airbyte** is a data-integration **platform** with a **350+** connector catalog, a web UI, an API, a scheduler, and a managed Cloud option. Each connector runs as its own container; you operate the platform (Docker/Kubernetes) or pay for Cloud. It's a strong fit when **non-engineers need a no-code UI** and **connector breadth** is paramount.
 
 **faucet-stream** is the opposite shape: **a single binary (or an embeddable library)** you run to completion — no platform to stand up, no per-connector containers, no daemon to babysit — with **governance built into the movement path**.
 
@@ -20,7 +20,7 @@
 ## Where Airbyte is the better choice
 
 - **Connector catalog.** 350+ connectors, plus a low-code connector builder. faucet has **49** first-party connectors.
-- **A UI for non-engineers.** Analysts can configure and monitor syncs without touching YAML or a terminal. faucet is engineer-facing (config + CLI + API).
+- **A no-code UI for non-engineers.** Airbyte's web app lets analysts add sources, configure syncs, and browse schemas entirely by point-and-click, with a low-code connector builder for new APIs. faucet ships a web console too (`faucet serve` with the `serve-ui` feature — submit and monitor runs, browse connector schemas, and view the data catalog + lineage), but it's an **operations control plane for engineers**, not a no-code sync builder: pipelines are still authored as config.
 - **Managed Cloud.** If you'd rather not run anything yourself, Airbyte Cloud is a turnkey option. faucet is self-hosted by design.
 - **Maturity & normalization.** A large user base and built-in normalization patterns.
 
@@ -32,7 +32,8 @@
 | To run one pipeline | a process that exits | a deployed control plane |
 | Connectors | 49, growing | 350+ |
 | Per-connector runtime | compiled in | a container each |
-| UI for non-engineers | ✗ (config + API) | ✓ |
+| Web console | ✓ ops control plane (`serve`) | ✓ |
+| No-code sync builder for non-engineers | ✗ (pipelines are config) | ✓ |
 | Governance in-path | ✓ native | partial / paywalled |
 | Embeddable as a library | ✓ (Rust) | ✗ |
 | License | MIT / Apache-2.0 | ELv2 + MIT |
@@ -40,7 +41,7 @@
 ## When to choose which
 
 - **Choose faucet-stream** for engineer-owned pipelines where performance, a tiny footprint, self-hosting simplicity, embedding, or in-flight governance matter — and your sources/sinks are covered.
-- **Choose Airbyte** when many non-engineers need a UI, you need the long-tail connector catalog, or you want a managed Cloud.
+- **Choose Airbyte** when many non-engineers need a no-code UI to self-serve syncs, you need the long-tail connector catalog, or you want a managed Cloud.
 
 ## See for yourself
 

--- a/docs/book/src/comparison/index.md
+++ b/docs/book/src/comparison/index.md
@@ -19,9 +19,9 @@ You'd reach for faucet-stream when **throughput, operational simplicity, or in-f
 | Connector count | 49, growing | 600+ taps | 350+ | dozens | dozens | 500+ |
 | Change data capture | ✓ Postgres / MySQL / Mongo | partial¹ | ✓ | partial | ✗ | ✓ |
 | Incremental + resumable state | ✓ | ✓ | ✓ | partial | n/a | ✓ |
-| Effectively-once delivery³ | ✓ (SQL / Iceberg / BigQuery) | ✗ | partial | ✗ | ✗ | ✓ |
+| Effectively-once delivery³ | ✓ (11 sinks incl. Kafka, Iceberg, BigQuery) | ✗ | partial | ✗ | ✗ | ✓ |
 | Governance in-path (quality / contracts / masking / lineage / SLA) | ✓ native | assemble | partial / paywalled | ✗ | ✗ | partial / paywalled |
-| Built-in metrics + tracing | ✓ Prometheus + `tracing` | partial | ✓ (platform) | ✓ | ✓ | ✓ (hosted) |
+| Built-in metrics + tracing | ✓ Prometheus + OTLP + `tracing` | partial | ✓ (platform) | ✓ | ✓ | ✓ (hosted) |
 | Self-hosted, no daemon | ✓ run-to-completion | ✓ | ✗ needs platform | usually a service | agent | ✗ SaaS |
 | License | MIT / Apache-2.0 | MIT | ELv2 + MIT | Apache-2.0 / source-available² | MPL-2.0 | Proprietary |
 

--- a/docs/book/src/comparison/meltano.md
+++ b/docs/book/src/comparison/meltano.md
@@ -17,7 +17,7 @@ Move to faucet-stream when **throughput, operational simplicity, or in-flight go
 - **Speed you can measure.** On a reproducible 1M-row CSV→JSONL move, faucet does **712k rows/s in 11.8 MiB** vs Meltano's **7.4k rows/s in 724 MiB** — **~96× faster, ~62× less memory**, output identical row-for-row. Sink-bound moves (e.g. Postgres→Postgres) narrow the gap — the [benchmarks](https://github.com/PawanSikawat/faucet-stream/blob/main/BENCHMARKS.md) show that scenario too, honestly. The difference is structural: no per-row Python overhead, native streaming with bounded memory.
 - **No Python runtime.** faucet is a single static binary — `brew install`, drop it on a box, done. No virtualenv, no plugin resolution, no Python-version matrix to keep green in CI and prod.
 - **Governance in the movement path, not bolted on.** Data-quality checks, versioned **data contracts**, **PII masking** (applied *before* any sink sees a row), schema-drift policy, column-level **lineage** (OpenLineage) + a data-movement catalog, and freshness/volume **SLAs** are native and zero-config. In the Singer world these are separate concerns you assemble (mappers, dbt tests, external tooling).
-- **Effectively-once delivery.** Per-page commit tokens commit atomically with the data, so a resumed run drops duplicates — on SQL, Iceberg, and BigQuery sinks.
+- **Effectively-once delivery.** Per-page commit tokens commit atomically with the data, so a resumed run drops duplicates — across **11 sinks** (SQL, Kafka, Iceberg, BigQuery, Snowflake, Spanner, MongoDB, Redis), plus a keyed-upsert path on any source into an upsert-capable sink.
 - **Embeddable.** Compile the same engine into your own Rust service via the typed `Source` / `Sink` traits — not just a CLI.
 
 ## Where Meltano is the better choice
@@ -36,10 +36,10 @@ Straight with you, because it's what makes the rest credible:
 | Install | one binary / `brew` / `cargo` | Python env + plugins |
 | Connectors | 49 (28 sources, 21 sinks), growing | 600+ taps |
 | Throughput (1M-row CSV→JSONL) | **712k rows/s, 11.8 MiB** | 7.4k rows/s, 724 MiB |
-| In-flight transforms | ✓ 13 record transforms + embedded-DuckDB `sql` | mappers; dbt post-load |
+| In-flight transforms | ✓ 11 record transforms + filter/explode/CDC-unwrap + embedded-DuckDB `sql` | mappers; dbt post-load |
 | Data quality / contracts / masking | ✓ native, in-path | assemble (mappers, dbt tests) |
 | Lineage + catalog | ✓ OpenLineage, native | external |
-| Effectively-once delivery | ✓ (SQL / Iceberg / BigQuery) | ✗ |
+| Effectively-once delivery | ✓ (11 sinks incl. Kafka, Iceberg, BigQuery) | ✗ |
 | Embeddable as a library | ✓ (Rust) | ✗ |
 | License | MIT / Apache-2.0 | MIT |
 

--- a/docs/book/src/introduction.md
+++ b/docs/book/src/introduction.md
@@ -1,6 +1,6 @@
 <div class="fs-hero">
   <img src="assets/wordmark.svg" alt="faucet-stream" />
-  <p class="fs-tagline">The fast, config-driven way to move data in Rust.</p>
+  <p class="fs-tagline">The fast, config-driven way to <strong>move data in Rust</strong>.</p>
   <div class="fs-cta">
     <a class="primary" href="getting-started/installation.html">Get started →</a>
     <a class="secondary" href="getting-started/learn.html">Learn the architecture</a>

--- a/docs/book/theme/head.hbs
+++ b/docs/book/theme/head.hbs
@@ -2,7 +2,7 @@
      Adds social-share / SEO metadata; the rest of the <head> uses mdBook
      defaults. Keep values in sync with the README hero + elevator pitch. -->
 <meta name="description" content="faucet-stream — the fast, config-driven way to move data in Rust. Pluggable source and sink connectors plus a declarative CLI: run production data pipelines from YAML, no Rust code required." />
-<meta name="theme-color" content="#2f7fe0" />
+<meta name="theme-color" content="#14b8a6" />
 
 <!-- Open Graph -->
 <meta property="og:type" content="website" />


### PR DESCRIPTION
## What

Reworks the mdBook documentation-site theme to use the **faucet-stream icon's own teal (`#14B8A6`)** on slate neutrals — so the docs match the logo, favicon, and wordmark instead of the earlier invented blue. Addresses the "superbly dull" feedback on the published site.

## Changes

- **`docs/book/custom.css`** — full teal-brand rework:
  - Brand token system (`--fs-teal`/`-strong`/`-deep`/`-bright`, `--fs-cyan`, `--fs-slate`) with per-theme overrides.
  - Signature **teal→cyan gradient rail** across the top menu bar.
  - Teal links (with `color-mix` underlines), `::selection`, blockquote callouts, table headers, sidebar-active, and `h2` bullet markers; gradient-underlined `h1`.
  - Restyled **slate dark theme** (navy → `#0b1120`/`#0a0f1c` grounds, bright-teal accents for legibility); coal/ayu/rust inherit the teal accent.
  - Refined hero (`.fs-hero` radial teal wash + **gradient-clipped tagline**), CTA buttons with teal gradient + hover lift, and hover-lift cards.
- **`docs/book/theme/head.hbs`** — browser `theme-color` meta `#2f7fe0` → `#14b8a6`.
- **`docs/book/src/introduction.md`** — wrap the tagline's key phrase in `<strong>` so the hero gradient text lands.

## Verification

- `mdbook build docs/book` clean (mermaid preprocessor present on main).
- Teal confirmed in emitted `custom-*.css`; hero + all 6 Mermaid diagrams render.
- CSS-only + one meta + one markdown emphasis — no runtime/code changes.