### PR TITLE
chore(release): resume faucet-cli 1.5.0 publish

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -76,6 +76,13 @@ release_always = false
 # bumped. To resume, merge a trivial PR from a `release-plz-*` branch — the
 # publish job keys on that branch prefix and is idempotent (skips
 # already-published crates).
+# Recovery log (2026-07-18): the 1.5.0 release published every crate except
+# `faucet-cli` (last in dependency order) — its publish failed on the
+# `include_str!` path that read `connectors/registry.json` from outside the
+# crate (fixed in #329). With `faucet-cli` at 1.5.0 in Cargo.toml but 1.4.0 on
+# crates.io and no `faucet-cli-v1.5.0` tag, release-plz opened no new PR. This
+# trivial `release-plz-*` PR re-fires the idempotent publish job to ship the
+# missing `faucet-cli` 1.5.0.
 
 # Disable cargo-semver-checks for all packages. Semver-checks compiles each
 # crate's local and registry sources to compare API surface — for a 47-crate


### PR DESCRIPTION
## Why

The 1.5.0 release published `faucet-core` 1.5.0 and every other crate, but **`faucet-cli` is stuck at 1.4.0** on crates.io while its `Cargo.toml` says 1.5.0. As the last crate in dependency order, it's the one that hit the `include_str!("../../connectors/registry.json")` packaging bug during #302's release run — reading a file outside the crate made `cargo publish` fail verification. #329 fixed the path (moved the file inside `cli/` and corrected the include).

release-plz won't retry on its own: it treats the already-bumped-but-untagged 1.5.0 as "pending" (so opens no new release PR), and its publish job only fires on a `release-plz-*` branch merge (`release_always = false`).

## What this does

Per the documented recovery note in `release-plz.toml`, merging a trivial PR from a `release-plz-*` branch re-fires the **idempotent** publish job. It skips every already-published crate (checks the sparse index) and publishes only the missing **`faucet-cli` 1.5.0**, using the repo's known-good `CARGO_REGISTRY_TOKEN` — then pushes the `faucet-cli-v1.5.0` tag, which triggers `release-binaries.yml` (prebuilt binaries + Homebrew).

The only change is a dated recovery-log comment in `release-plz.toml`; no code or version changes.

## Expected result

- crates.io: `faucet-cli` 1.4.0 → **1.5.0**
- tag `faucet-cli-v1.5.0` pushed
- binaries + Homebrew formula updated for 1.5.0