### PR TITLE
docs: WS-11 — Vector/Fivetran/Redpanda comparison pages, docs-site SEO, release-publicity runbook (#314)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,6 +47,27 @@ jobs:
           curl -sSL "$url" | tar -xz -C "$HOME/.local/bin"
       - name: Build
         run: mdbook build docs/book
+      - name: Generate sitemap.xml
+        # mdBook has no native sitemap (rust-lang/mdBook#1491); generate one from
+        # the built HTML so search engines can crawl every page. Uses the full
+        # Pages origin (site-url in book.toml is only a path prefix).
+        env:
+          BASE_URL: "https://pawansikawat.github.io/faucet-stream"
+        run: |
+          cd docs/book/book
+          {
+            echo '<?xml version="1.0" encoding="UTF-8"?>'
+            echo '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+            find . -type f -name '*.html' ! -name '404.html' ! -name 'print.html' \
+              | sed 's|^\./||' \
+              | LC_ALL=C sort \
+              | while IFS= read -r f; do
+                  loc="${f%index.html}"
+                  echo "  <url><loc>${BASE_URL}/${loc}</loc></url>"
+                done
+            echo '</urlset>'
+          } > sitemap.xml
+          echo "Wrote $(grep -c '<url>' sitemap.xml) URLs to sitemap.xml"
       - name: Upload Pages artifact
         if: github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@v3

--- a/docs/book/book.toml
+++ b/docs/book/book.toml
@@ -6,6 +6,9 @@ language = "en"
 src = "src"
 
 [output.html]
+# Full origin path for the GitHub Pages project site — fixes 404-page asset/nav
+# links and gives the generated site a stable base URL (pairs with the sitemap).
+site-url = "/faucet-stream/"
 # Clean light default + navy dark — the brand accent in custom.css is tuned for
 # both. (Was rust/ayu; light/navy reads more modern and closer to the reference
 # docs sites.)

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -68,6 +68,9 @@
 - [vs. Meltano (Singer)](./comparison/meltano.md)
 - [vs. Airbyte](./comparison/airbyte.md)
 - [vs. Singer](./comparison/singer.md)
+- [vs. Redpanda Connect (Benthos)](./comparison/redpanda-connect.md)
+- [vs. Vector](./comparison/vector.md)
+- [vs. Fivetran](./comparison/fivetran.md)
 
 # Operations
 

--- a/docs/book/src/comparison/fivetran.md
+++ b/docs/book/src/comparison/fivetran.md
@@ -1,0 +1,63 @@
+# faucet-stream vs. Fivetran
+
+*Fivetran is a fully-managed SaaS; faucet-stream is a binary you own. Here's the honest trade-off.*
+
+> Reflects each tool as of **2026-07**. Fivetran's catalog and pricing change; check [fivetran.com](https://www.fivetran.com/) for current details.
+
+## The short version
+
+**Fivetran** is a fully-managed, closed-source ELT **SaaS**: you configure connectors in its UI, and Fivetran hosts and operates everything — scheduling, retries, schema handling, and connector maintenance. It has a large catalog (500+), strong log-based CDC, and usage-based pricing (monthly active rows).
+
+**faucet-stream** is the opposite model: a **self-hosted, open-source binary (and library)** you run on your own infrastructure, with pipelines defined as version-controlled YAML and governance built into the movement path — no per-row bill, no vendor lock-in, data and credentials never leaving your systems.
+
+Reach for faucet-stream when you want to **own the pipeline** — self-hosted, config-as-code, and free of usage-based cost.
+
+## Where faucet-stream is different
+
+- **Self-hosted and open source.** Data and credentials stay on your infrastructure; there's no third party in the path and no lock-in. You run one binary on compute you already have.
+- **Config-as-code.** Pipelines are version-controlled YAML you diff, review, and run in CI — not UI state in someone else's account.
+- **Predictable cost.** No monthly-active-rows pricing that scales with data volume; you pay only for the compute you'd run anyway.
+- **Governance in the movement path.** Data-quality checks, versioned data contracts, PII masking (before any sink sees a row), schema-drift policy, column-level lineage (OpenLineage) + a catalog, and freshness/volume SLAs — native, not paywalled add-ons.
+- **Embeddable.** Compile the same engine into your own Rust service via the typed `Source` / `Sink` traits.
+
+## Where Fivetran is the better choice
+
+Straight with you — a managed service earns its keep in real ways:
+
+- **Zero maintenance.** Fivetran operates the connectors, absorbs upstream API changes and schema drift, and provides enterprise support and compliance. You don't run or babysit anything.
+- **Catalog breadth.** 500+ professionally-maintained connectors across a long tail of SaaS sources.
+- **You want a product, not a tool.** Where the operational burden of self-hosting outweighs the cost and control trade-offs, a managed SaaS is the right call.
+
+## Side-by-side
+
+| | **faucet-stream** | Fivetran |
+|---|---|---|
+| Model | self-hosted open-source binary + library | fully-managed proprietary SaaS |
+| Pipeline definition | version-controlled YAML/JSON | UI (also API / Terraform) |
+| Connectors | 49 built-in | 500+ managed |
+| Change data capture | ✓ Postgres / MySQL / Mongo | ✓ log-based |
+| Where data / credentials live | your infrastructure | Fivetran's infrastructure |
+| Cost model | free (compute you already run) | usage-based (monthly active rows) |
+| Governance in-path (quality / contracts / masking / lineage / SLA) | ✓ native | partial / paywalled |
+| Embeddable as a library | ✓ (Rust) | ✗ |
+| License | MIT / Apache-2.0 | Proprietary |
+
+## Migrating from Fivetran
+
+The mental model maps cleanly onto config-as-code:
+
+| Fivetran | faucet-stream |
+|---|---|
+| a source connector (UI) | a `source` block |
+| a destination | a `sink` block |
+| connector settings / schedules | `faucet.yaml` + a `schedule:` block (or cron/CI) |
+| incremental sync / CDC | resumable `state:` + CDC sources |
+| dbt transformations | in-flight `transforms:` (or pair with dbt for in-warehouse modeling) |
+
+Start from [your first pipeline](../getting-started/first-pipeline.md) and the [connector catalog](../reference/connectors.md).
+
+## See for yourself
+
+- **[Choosing a connector](../reference/choosing.md)** — confirm your sources and sinks are covered.
+- **[Try it in 60 seconds](../getting-started/try-it-locally.md)** — no infrastructure needed.
+- **[Benchmarks](https://github.com/PawanSikawat/faucet-stream/blob/main/BENCHMARKS.md)** — full methodology and honest caveats.

--- a/docs/book/src/comparison/index.md
+++ b/docs/book/src/comparison/index.md
@@ -32,6 +32,9 @@ You'd reach for faucet-stream when **throughput, operational simplicity, or in-f
 - **[faucet-stream vs. Meltano (Singer)](./meltano.md)** — the Python-runtime comparison most people are weighing.
 - **[faucet-stream vs. Airbyte](./airbyte.md)** — binary-and-library vs. a platform you operate.
 - **[faucet-stream vs. Singer](./singer.md)** — native connectors vs. the tap/target spec.
+- **[faucet-stream vs. Redpanda Connect (Benthos)](./redpanda-connect.md)** — the other declarative-YAML single binary: batch/ELT vs. continuous streaming.
+- **[faucet-stream vs. Vector](./vector.md)** — the closest architectural cousin (Rust, single binary), but a different domain.
+- **[faucet-stream vs. Fivetran](./fivetran.md)** — a binary you own vs. a fully-managed SaaS.
 
 ## dbt is complementary, not a competitor
 

--- a/docs/book/src/comparison/redpanda-connect.md
+++ b/docs/book/src/comparison/redpanda-connect.md
@@ -1,0 +1,56 @@
+# faucet-stream vs. Redpanda Connect (Benthos)
+
+*The other declarative-YAML single binary. Here's where each one wins — including an honest note on the license history.*
+
+> Reflects each tool as of **2026-07**. Verify licensing against the current [project](https://github.com/redpanda-data/connect) `LICENSE` files, which are the source of truth per component.
+
+## The short version
+
+**Redpanda Connect** is the tool formerly known as **Benthos** (acquired by Redpanda in 2024) — a Go stream processor configured with declarative YAML (`input → processors → output`). It's streaming-first, has a large component library, and is the closest architectural analogue to faucet-stream's config-driven model. Ships as a single binary or as managed pipelines on Redpanda Cloud.
+
+**faucet-stream** is built for **batch/ELT data movement** rather than continuous stream processing: incremental + resumable replication, snapshot→CDC, first-class warehouse sinks, and governance in the movement path — under uniform permissive licensing.
+
+Reach for Redpanda Connect for **continuous, record-by-record streaming**; reach for faucet-stream to **move data between databases, object stores, and warehouses** as discrete, resumable, governed runs.
+
+## A note on licensing
+
+Worth stating precisely, because it's a real adoption consideration: Benthos was originally **MIT**. After the Redpanda acquisition the maintained repo moved to a **mix of Apache-2.0 and a source-available Redpanda Enterprise/Community license**, with some components (certain CDC inputs and others) gated behind the enterprise license. The community forked the pre-relicensing project as **[Bento](https://github.com/warpstreamlabs/bento)**, which continues under permissive terms. faucet-stream is uniformly **MIT / Apache-2.0** with no enterprise-gated connectors.
+
+## Where faucet-stream is different
+
+- **Batch/ELT is the home turf.** Incremental + resumable replication, snapshot→CDC handoff, and first-class warehouse sinks (BigQuery, Snowflake, Iceberg, Delta) — the job faucet is built for.
+- **Governance in the movement path.** Data-quality checks, versioned data contracts, PII masking (before any sink sees a row), schema-drift policy, column-level lineage (OpenLineage) + a catalog, and freshness/volume SLAs — native and zero-config.
+- **Effectively-once delivery.** Per-page commit tokens commit atomically with the data, so a resumed run drops duplicates — across 11 sinks (SQL, Kafka, Iceberg, BigQuery, Snowflake, Spanner, MongoDB, Redis).
+- **Uniform permissive licensing.** MIT / Apache-2.0 throughout — no per-component enterprise gate to audit.
+
+## Where Redpanda Connect is the better choice
+
+Straight with you — for its core job it's excellent:
+
+- **Continuous, record-by-record streaming.** It's purpose-built for never-ending stream processing with a rich processor/transform library. faucet runs discrete pipelines to completion — even its long-running modes (`faucet schedule`, `faucet serve`) orchestrate complete runs, not an endless stream.
+- **Deep Redpanda/Kafka ecosystem integration** and a large, mature component catalog.
+- **Battle-tested** across years of production stream-processing use, with a Go library you can embed.
+
+## Side-by-side
+
+| | **faucet-stream** | Redpanda Connect (Benthos) |
+|---|---|---|
+| Language / runtime | Rust, single binary | Go, single binary |
+| Orientation | discrete runs to completion | continuous stream processing |
+| Connectors | 49 source/sink, ETL/CDC/warehouse | hundreds of components/processors |
+| Change data capture | ✓ engine-level | some CDC inputs (several enterprise-gated) |
+| Warehouse / ELT sinks | ✓ BigQuery, Snowflake, Iceberg, Delta, … | more messaging/stream-oriented |
+| Governance in-path (quality / contracts / masking / lineage / SLA) | ✓ native | ✗ |
+| Effectively-once delivery | ✓ (11 sinks incl. Kafka, Iceberg, BigQuery) | ✗ |
+| Embeddable as a library | ✓ (Rust) | ✓ (Go) |
+| License | MIT / Apache-2.0 | Apache-2.0 + source-available enterprise |
+
+## Rule of thumb
+
+If the workload is a **continuous stream** you transform in flight, Redpanda Connect is purpose-built for it. If the workload is **moving data between APIs, databases, object stores, and warehouses** as discrete, resumable, governed runs — see [replication (snapshot → CDC)](../cookbook/replication.md) — that's faucet-stream.
+
+## See for yourself
+
+- **[Choosing a connector](../reference/choosing.md)** — confirm your sources and sinks are covered.
+- **[Try it in 60 seconds](../getting-started/try-it-locally.md)** — no infrastructure needed.
+- **[Benchmarks](https://github.com/PawanSikawat/faucet-stream/blob/main/BENCHMARKS.md)** — full methodology and honest caveats.

--- a/docs/book/src/comparison/vector.md
+++ b/docs/book/src/comparison/vector.md
@@ -1,0 +1,53 @@
+# faucet-stream vs. Vector
+
+*Both are Rust, single-binary, config-driven — but they solve different problems. Here's the honest line between them.*
+
+> Reflects each tool as of **2026-07**. Vector is actively developed by Datadog; check [vector.dev](https://vector.dev/) for its current state.
+
+## The short version
+
+**Vector** is an excellent **observability pipeline** — a Rust, single-binary, config-driven agent/aggregator for collecting, transforming, and routing **logs, metrics, and traces** to observability backends, with its own remap language (VRL). It's MPL-2.0 and fully open source.
+
+**faucet-stream** shares Vector's DNA — Rust, one static binary, declarative config — but a different **domain**: moving **business data** between APIs, databases, object stores, and warehouses, with change data capture, incremental/resumable replication, and governance built into the movement path.
+
+They're cousins, not competitors: reach for Vector for **telemetry**, faucet-stream for **data movement**. Many stacks run both.
+
+## Where faucet-stream is different
+
+- **Domain: databases, SaaS, and warehouses — not telemetry.** faucet connects Postgres, MySQL, MongoDB, Kafka, S3/GCS, BigQuery, Snowflake, Iceberg, Delta, and more, as source→sink pipelines. Vector's sources/sinks are observability-oriented (log shippers, metrics stores, trace backends).
+- **Change data capture.** faucet does engine-level CDC (Postgres / MySQL / Mongo) with resumable state. Vector has no database CDC — it isn't an ELT tool.
+- **Governance in the movement path.** Data-quality checks, versioned data contracts, PII masking (before any sink sees a row), schema-drift policy, column-level lineage (OpenLineage) + a data-movement catalog, and freshness/volume SLAs — native and zero-config.
+- **Effectively-once delivery.** Per-page commit tokens commit atomically with the data, so a resumed run drops duplicates — across 11 sinks (SQL, Kafka, Iceberg, BigQuery, Snowflake, Spanner, MongoDB, Redis).
+- **Embeddable.** Compile the same engine into your own Rust service via the typed `Source` / `Sink` traits.
+
+## Where Vector is the better choice
+
+Straight with you — it's a different job, and Vector is superb at it:
+
+- **Observability telemetry.** If you're collecting and routing logs, metrics, and traces, Vector is purpose-built and battle-tested at scale. faucet doesn't play in that space.
+- **Agent + aggregator topologies.** Vector is designed for fleet-wide telemetry collection with local agents feeding aggregators.
+- **VRL** — a rich, expressive remap language for reshaping telemetry events in flight.
+
+## Side-by-side
+
+| | **faucet-stream** | Vector |
+|---|---|---|
+| Language / runtime | Rust, single binary | Rust, single binary |
+| Domain | ETL / CDC / warehouse data movement | observability (logs / metrics / traces) |
+| Connectors | 49 DB / API / object-store / warehouse | dozens, observability-oriented |
+| Change data capture | ✓ Postgres / MySQL / Mongo | ✗ |
+| Warehouse / ELT sinks | ✓ BigQuery, Snowflake, Iceberg, Delta, … | ✗ |
+| In-flight transforms | 11 record transforms + embedded-DuckDB `sql` | VRL (Vector Remap Language) |
+| Governance in-path (quality / contracts / masking / lineage / SLA) | ✓ native | ✗ |
+| Embeddable as a library | ✓ (Rust) | ✗ (standalone agent/aggregator) |
+| License | MIT / Apache-2.0 | MPL-2.0 |
+
+## Using them together
+
+They coexist cleanly in one stack: **Vector** ships your logs/metrics/traces to your observability backend, while **faucet-stream** moves your business data between databases, object stores, and warehouses. If anything, faucet's own [Prometheus metrics + `tracing`](../operations/observability.md) can flow *through* a Vector pipeline to your telemetry backend.
+
+## See for yourself
+
+- **[Choosing a connector](../reference/choosing.md)** — confirm your sources and sinks are covered.
+- **[Try it in 60 seconds](../getting-started/try-it-locally.md)** — no infrastructure needed.
+- **[Benchmarks](https://github.com/PawanSikawat/faucet-stream/blob/main/BENCHMARKS.md)** — full methodology and honest caveats.

--- a/docs/launch/DISTRIBUTION.md
+++ b/docs/launch/DISTRIBUTION.md
@@ -1,0 +1,84 @@
+# Distribution channels runbook
+
+The **maintainer-driven** channels for keeping faucet-stream in front of Rust and
+data-engineering audiences on an ongoing basis. Nothing here can be automated in-repo — each
+item posts to a third-party platform or needs your account. This file captures the *what* and
+*where* so a future session/maintainer can execute without re-deriving it.
+
+For the **per-release cadence**, see [`RELEASE_PUBLICITY.md`](./RELEASE_PUBLICITY.md). For the
+one-time 1.0 launch copy, see [`README.md`](./README.md). Reuse the single elevator pitch from
+the root [`README.md`](../../README.md) hero verbatim across all of these.
+
+## B. Community platforms & social
+
+- **X / Twitter, Bluesky, Mastodon** (fosstodon.org / hachyderm.io — the Rust community is
+  very active there) — launch + per-release threads.
+- **LinkedIn** — the data-engineering audience skews here; a maintainer post per milestone
+  reaches more DEs than Reddit does.
+- **Reddit** — recurring *value* posts (not just self-promo) in r/rust, r/dataengineering,
+  r/programming, r/ETL. Follow each sub's self-promotion etiquette; consider an AMA once there
+  are real users.
+- **Hacker News** — re-`Show HN` on major versions; participate genuinely in adjacent threads
+  (Airbyte/Fivetran/dbt/CDC) where a link is welcome.
+- **Chat communities** — introduce it once, on-topic: Rust Discord/Zulip, the dbt Community
+  and Locally Optimistic Slacks, data-engineering Discords, DataTalks.Club.
+
+## C. Aggregators, directories & newsletters
+
+### Directories (high-intent, one-time, permanent SEO)
+
+- **AlternativeTo** — list as an alternative to Airbyte / Fivetran / Meltano / Singer. Highest
+  intent: people there are actively shopping.
+- **StackShare, LibHunt, Openbase** — tool directories.
+- **Console.dev** — submit for review.
+
+### awesome-lists — status
+
+| List | Status | Notes |
+|---|---|---|
+| [awesome-streaming](https://github.com/manuzhang/awesome-streaming) | ✅ PR opened | `Data Pipeline` section, `[Rust]` tag |
+| [awesome-dataengineering](https://github.com/igorbarinov/awesome-data-engineering) | ✅ PR opened | `Data Ingestion` section |
+| [awesome-rust](https://github.com/rust-unofficial/awesome-rust) | ⏳ Deferred | Acceptance bar: **stars > 50 OR crates.io downloads > 2000**. Open the PR once `faucet-core` crosses 2,000 downloads or the repo crosses 50 stars. Highest-value list. |
+| [awesome-etl](https://github.com/pawl/awesome-etl) | ⏳ Deferred | Self-submissions need real third-party traction or the PR is closed; no Rust section (ask before adding one). Revisit once there's adoption signal. |
+| awesome-cdc | ❌ Skip | No maintained canonical list exists (the only candidate repo is dead). |
+
+*(Deferral status is also tracked on issue [#314](https://github.com/PawanSikawat/faucet-stream/issues/314).)*
+
+### Newsletters
+
+Rust Weekly, This Week in Rust (see [`RELEASE_PUBLICITY.md`](./RELEASE_PUBLICITY.md)), Data
+Engineering Weekly, Seattle Data Guy, Pointer, Bytes, Software Lead Weekly, Console.dev, TLDR.
+
+### Product Hunt
+
+Schedule Tue–Thu; prep the hunter, gallery images, and a strong first comment in advance.
+
+## D. Video & talks
+
+- **CLI demo** — the asciinema/GIF (WS-3) embedded in the README, plus a **3–5 min YouTube
+  "your first pipeline"** walkthrough and a longer CDC-mirror screencast. A recorded talk is
+  evergreen distribution.
+- **Talks / lightning talks** — submit to RustConf, Rust meetups (incl. virtual), Data
+  Council, and local data-eng meetups.
+
+## Content that compounds (evergreen)
+
+- **Engineering deep-dives** — repurpose the design specs in `docs/superpowers/specs/` (e.g.
+  exactly-once delivery, Postgres CDC in Rust, the DLQ design, the embedded-DuckDB SQL
+  transform). Each doubles as SEO and proof of depth.
+- **Migration guides** (highest-intent) — Singer/Meltano → faucet-stream, Airbyte →
+  faucet-stream, "replacing a pile of Python cron scripts." The docs-site
+  [comparison pages](https://pawansikawat.github.io/faucet-stream/comparison/index.html) are
+  the on-site anchor for these.
+- **"Build X in 10 minutes" tutorials** — REST → BigQuery, Postgres CDC → Kafka, S3 →
+  Parquet. Cross-post to dev.to / Hashnode / Medium / lobste.rs.
+
+## Answer questions where they're asked
+
+Build organic, searchable presence: Stack Overflow (`[rust]` + data-pipeline tags), Reddit,
+and issues in related repos (Airbyte/CDC/dbt threads) where a link genuinely helps.
+
+---
+
+*Grounded in issue [#314](https://github.com/PawanSikawat/faucet-stream/issues/314) (WS-11 of
+the adoption epic). Keep the awesome-list status table current as PRs merge and traction lands.*

--- a/docs/launch/README.md
+++ b/docs/launch/README.md
@@ -24,7 +24,7 @@ add this line under a relevant section (e.g. *Database* → *ETL* or *Data
 processing*), and open a PR:
 
 ```markdown
-* [faucet-stream](https://github.com/PawanSikawat/faucet-stream) — A fast, config-driven data-movement toolkit: 35 source/sink connectors wired by a single `faucet` binary (YAML) or embedded as a Rust library; streaming, CDC, DLQ, and built-in metrics.
+* [faucet-stream](https://github.com/PawanSikawat/faucet-stream) — A fast, config-driven data-movement platform: 49 source and sink connectors wired by a single `faucet` binary (YAML) or embedded as a Rust library; streaming, CDC, DLQ, and built-in metrics.
 ```
 
 Also consider [`awesome-data-engineering`](https://github.com/igorbarinov/awesome-data-engineering).
@@ -34,7 +34,7 @@ Also consider [`awesome-data-engineering`](https://github.com/igorbarinov/awesom
 Submit via the ["Send us a PR" form / issue](https://github.com/rust-lang/this-week-in-rust)
 (Crate of the Week nominations + project updates). Suggested blurb:
 
-> **faucet-stream** — a config-driven data pipeline toolkit: 35 connectors, a
+> **faucet-stream** — a config-driven data-movement platform: 49 connectors, a
 > `faucet` CLI that runs pipelines from YAML, and an embeddable library, with
 > streaming, Postgres CDC, dead-letter queues, and built-in Prometheus/tracing.
 
@@ -44,11 +44,11 @@ Submit via the ["Send us a PR" form / issue](https://github.com/rust-lang/this-w
 
 **Body:**
 
-> Hi HN — I built faucet-stream, a config-driven data-movement toolkit for Rust.
+> Hi HN — I built faucet-stream, a config-driven data-movement platform for Rust.
 > It's a single static binary that runs pipelines from a YAML file (no platform,
 > no Python, no daemon), or an embeddable library with typed Source/Sink traits.
 >
-> 35 connectors today (REST, GraphQL, gRPC, Kafka, Postgres incl. CDC, MySQL,
+> 49 connectors today (REST, GraphQL, gRPC, Kafka, Postgres incl. CDC, MySQL,
 > SQLite, S3/GCS, Parquet, MongoDB, Redis, Elasticsearch, BigQuery, Snowflake),
 > with native streaming (bounded memory), incremental/resumable replication,
 > dead-letter queues, retries, and built-in Prometheus metrics + tracing — no
@@ -64,7 +64,7 @@ Post early in the US morning (Pacific) on a weekday; reply to comments quickly.
 
 ### 4. Reddit — r/rust
 
-**Title:** `faucet-stream: a config-driven data-movement toolkit (35 connectors, streaming, CDC) — CLI or embeddable library`
+**Title:** `faucet-stream: a config-driven data-movement platform (49 connectors, streaming, CDC) — CLI or embeddable library`
 
 Lead with the Rust angle: single binary, typed traits, every connector a Cargo
 feature, performance-first design (connection reuse, multi-row inserts, bounded

--- a/docs/launch/RELEASE_PUBLICITY.md
+++ b/docs/launch/RELEASE_PUBLICITY.md
@@ -1,0 +1,126 @@
+# Release publicity checklist
+
+A **repeatable, per-release** playbook so publicity is routine, not heroic. Where the WS-10
+[`README.md`](./README.md) in this folder covered the *one-time 1.0 launch*, this file is the
+**recurring** counterpart: run it on every notable release.
+
+**Everything here is a maintainer action** — each step posts to an external site or needs your
+account. Keep the copy consistent across channels: consistency compounds recognition.
+
+> **Single source of truth:** the canonical pitch and the connector count live in the root
+> [`README.md`](../../README.md) hero (currently **49 connectors — 28 sources / 21 sinks**).
+> Copy from there; don't invent variants. If the count changed this release, update the
+> templates below in the same PR.
+
+## When to run
+
+Trigger on the **merge of a `chore: release` PR** (release-plz) that cuts a user-meaningful
+release — i.e. the umbrella `faucet-cli-vX.Y.Z` / repo-level `vX.Y.Z` tag, **not** every
+per-crate patch bump. Rule of thumb:
+
+- **Minor / notable release** (new connector, new runtime feature) → run the full checklist.
+- **Patch / internal release** → skip, or at most a single social note if it fixes something
+  user-visible.
+
+## Pre-flight
+
+- [ ] Release PR merged; crates published; the umbrella tag is live and installable
+      (`cargo install faucet-cli` / the Homebrew tap / the installer script all resolve).
+- [ ] Connector count in the templates below still matches reality
+      (`ls crates/source/* crates/sink/*` → currently 28 + 21 = **49**).
+- [ ] Pull the release highlights from the per-crate `CHANGELOG.md` files (release-plz writes
+      these from `feat`/`fix`/`perf` commits). Pick the 2–4 user-facing headlines.
+- [ ] The repo **social-preview image** (Settings → Social preview, 1280×640) is set so
+      shared links unfurl with the banner.
+
+## The checklist (in order)
+
+Front-load the high-signal, low-effort channels; do the rest as time allows.
+
+1. [ ] **Changelog-highlights post** — a short "what's new in vX.Y.Z" note (blog / dev.to),
+       built from the CHANGELOG highlights. This is the artifact every other channel links to.
+2. [ ] **This Week in Rust** — submit the release blurb (template below) via the
+       [TWiR repo](https://github.com/rust-lang/this-week-in-rust).
+3. [ ] **dev.to cross-post** — repost the changelog-highlights post (canonical URL back to
+       your blog), tagged `#rust #dataengineering`.
+4. [ ] **Social threads** — one post each to X, Bluesky, Mastodon (fosstodon / hachyderm),
+       and **LinkedIn** (largest data-eng reach). Use the release-thread template.
+5. [ ] **Reddit** — a *value* post (not pure self-promo) in r/rust and/or r/dataengineering
+       when the release has a genuine story (new connector, big perf win). See
+       [`DISTRIBUTION.md`](./DISTRIBUTION.md) for per-subreddit angles.
+6. [ ] **Newsletter tips** — submit to Rust Weekly, Data Engineering Weekly, TLDR, etc.
+       (full list in [`DISTRIBUTION.md`](./DISTRIBUTION.md)).
+7. [ ] **Aggregator refresh (major releases only)** — bump the entry/description on
+       AlternativeTo, StackShare, LibHunt, and the awesome-lists (status in
+       [`DISTRIBUTION.md`](./DISTRIBUTION.md)).
+
+## Copy templates
+
+Reuse verbatim; swap `vX.Y.Z` and the highlights. All counts are **49**; all benchmark
+figures come from [`BENCHMARKS.md`](../../BENCHMARKS.md) (quote **~16×** for a realistic
+DB→DB move, **~96×** as the CSV→JSONL upper bound — never the ~96× alone).
+
+### Elevator pitch (one-liner — use everywhere)
+
+> **faucet-stream** — the fast, config-driven way to move data in Rust. A data-movement
+> platform with 49 source and sink connectors for ETL, CDC, and streaming, run from a YAML
+> file by a single binary or embedded as a Rust library.
+
+### Release thread (X / Bluesky / Mastodon / LinkedIn)
+
+> faucet-stream vX.Y.Z is out 🚰
+>
+> The fast, config-driven way to move data in Rust — a single binary (or embeddable library)
+> that runs ETL/CDC/streaming pipelines from a YAML file. No Python runtime, no platform.
+>
+> This release: <highlight 1>, <highlight 2>, <highlight 3>.
+>
+> Docs: https://pawansikawat.github.io/faucet-stream/
+> Repo: https://github.com/PawanSikawat/faucet-stream
+
+### This Week in Rust
+
+> **faucet-stream vX.Y.Z** — a config-driven data-movement platform for Rust: 49 connectors,
+> a `faucet` CLI that runs pipelines from YAML, and an embeddable library, with streaming,
+> Postgres CDC, dead-letter queues, and built-in Prometheus/tracing. This release:
+> <one-line highlight>.
+
+### dev.to / blog changelog post skeleton
+
+> # What's new in faucet-stream vX.Y.Z
+>
+> *(1-sentence recap of the elevator pitch + link to the repo.)*
+>
+> ## Highlights
+> - **<highlight 1>** — why it matters.
+> - **<highlight 2>** — why it matters.
+>
+> ## Upgrade
+> `cargo install faucet-cli` / `brew upgrade faucet-cli`
+>
+> Full changelog: <link to the release>. Feedback and connector requests welcome.
+
+### Reddit angles
+
+- **r/rust** — lead with the Rust angle: single binary, typed `Source`/`Sink` traits, every
+  connector a Cargo feature, performance-first design. Frame as "I shipped this, feedback
+  welcome," not an ad.
+- **r/dataengineering** — lead with the DE pain: no platform to operate, version-controlled
+  YAML pipelines, runs on cron/CI, CDC + incremental + DLQ built in. Be honest about
+  connector-count vs. incumbents (link the [comparison pages](https://pawansikawat.github.io/faucet-stream/comparison/index.html)).
+
+## Metrics view (know which channels convert)
+
+Check a few days after each release, so you stop guessing and double down on what works:
+
+- **crates.io downloads** — `faucet-core` / `faucet-cli` trend (per-crate API; use a
+  descriptive `User-Agent`).
+- **GitHub** — stars over time (star-history) and the repo **Insights → Traffic** (views,
+  clones, top referrers — referrers tell you which channel drove visits).
+- **Docs site** — a privacy-friendly analytics tracker (Plausible / Fathom / GoatCounter) to
+  see which pages (especially the `vs.` comparison pages) pull search traffic.
+
+---
+
+*Keep this file in sync with the root README pitch and BENCHMARKS.md. If the connector count
+or the benchmark headline changes, update the templates above in the same PR.*

--- a/docs/launch/blog-post.md
+++ b/docs/launch/blog-post.md
@@ -21,7 +21,7 @@ faucet run pipeline.yaml
 version: 1
 pipeline:
   source: { type: postgres, config: { connection_url: "${env:PG_URL}", query: "select * from events" } }
-  transforms: [{ type: snake_case }]
+  transforms: [{ type: keys_case, config: { mode: snake } }]
   sink: { type: bigquery, config: { project_id: my-proj, dataset_id: analytics, table_id: events } }
 ```
 
@@ -31,7 +31,7 @@ pipeline from Rust with typed `Source`/`Sink` traits.
 
 ## What's in the box
 
-- **35 connectors** across REST, GraphQL, gRPC, Kafka, Postgres/MySQL/SQLite,
+- **49 connectors** across REST, GraphQL, gRPC, Kafka, Postgres/MySQL/SQLite,
   Postgres CDC, S3/GCS, Parquet, MongoDB, Redis, Elasticsearch, BigQuery, and
   Snowflake.
 - **A real runtime, not just connectors:** native streaming with bounded memory,


### PR DESCRIPTION
Part of **#314** (WS-11 of adoption epic #38). Rebased onto current `main` and scoped to **only what's genuinely additive** — the existing `comparison/` section (index/meltano/airbyte/singer) and branded `theme/head.hbs` are left intact.

## 1. Three new comparison deep-dives
Extends the existing **Comparisons** section (which already covered Meltano/Airbyte/Singer) with pages written in the **same house style**:
- `comparison/vector.md` — closest architectural cousin (Rust, single binary) but a different domain (observability, not ELT/CDC); honest "use them together" framing.
- `comparison/fivetran.md` — self-hosted OSS binary vs. fully-managed proprietary SaaS; config-as-code + predictable cost vs. zero-maintenance.
- `comparison/redpanda-connect.md` — the other declarative-YAML single binary; batch/ELT vs. continuous streaming, with a precise note on the Benthos→Redpanda Connect rename + source-available split + Bento fork.

Wired into `comparison/index.md` (Deep dives) and `SUMMARY.md`. No benchmark claims on these three (no head-to-head data exists); the ~96×/~16× Meltano figures stay on the existing meltano page.

## 2. Docs-site SEO
- `book.toml` — `output.html.site-url = "/faucet-stream/"` (fixes the 404 page's absolute asset/nav links; pairs with the sitemap). The existing `theme/head.hbs` already supplies site-wide Open Graph tags — left unchanged.
- `docs.yml` — generate `sitemap.xml` from the built HTML after `mdbook build` (mdBook has no native sitemap); no extra binary.

## 3. Release-publicity runbook (`docs/launch/`)
- `RELEASE_PUBLICITY.md` (new) — repeatable per-release checklist hooked to the release-plz cadence + reusable copy templates + a metrics view.
- `DISTRIBUTION.md` (new) — maintainer-driven B/C/D channels runbook incl. the awesome-list status table.
- Refreshed stale WS-10 launch-kit copy: **35 → 49** connectors, "toolkit" → "data-movement platform", and fixed a broken transform example (`snake_case` → `keys_case`).

## What was dropped (already on `main`)
My initial draft (built on a stale checkout) duplicated `main`'s comparison section and would have clobbered the branded `head.hbs` + re-fixed an already-49 README. All of that is removed — this PR only adds what `main` doesn't have.

## Verification
- `mdbook build docs/book` clean (with the mermaid preprocessor); all 3 new pages build + link from index; OG tags render on the new pages (via existing head.hbs); sitemap emits 65 URLs incl. the new pages; `site-url` verified on 404.html without affecting normal pages' relative asset paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)