### PR TITLE
docs: brand all GitHub-viewed Mermaid diagrams with the faucet teal theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,7 @@ regardless of total volume. The pipeline also drives the cross-cutting runtime (
 dead-letter routing, quality checks, metrics) so connectors stay simple:
 
 ```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
 flowchart LR
     S["<b>Source</b><br/>REST · DB · CDC<br/>Kafka · S3 · Parquet"]
     T["<b>Transforms</b><br/>flatten · rename · keys_case<br/>select · drop · set · cast<br/>redact · value_case · spell_symbols<br/>sql (DuckDB, page-level)"]

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ If you want to *change* or *extend* it, start here.
 ## Engineering documentation map
 
 ```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
 flowchart TD
     Hub["docs/README.md<br/>(this file)"]
     Hub --> Arch["architecture/<br/>how & why each subsystem works"]

--- a/docs/adr/0001-stream-pages.md
+++ b/docs/adr/0001-stream-pages.md
@@ -34,6 +34,7 @@ sources, `postgres`, `parquet`, `kafka`, `elasticsearch` scroll, …) **override
 `stream_pages` to be truly incremental.
 
 ```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
 flowchart LR
     SRC[(source primitive)] --> P1[page] --> P2[page] --> P3[page + bookmark]
     P1 --> W1[write] --> F1[flush]

--- a/docs/adr/0002-checkpoint-ordering.md
+++ b/docs/adr/0002-checkpoint-ordering.md
@@ -40,6 +40,7 @@ never ahead. Recovery can therefore only ever replay already-attempted work; it 
 never skip data the sink did not receive.
 
 ```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
 sequenceDiagram
     participant Snk as Sink
     participant SS as StateStore

--- a/docs/adr/0005-runtime-recovery.md
+++ b/docs/adr/0005-runtime-recovery.md
@@ -35,6 +35,7 @@ what qualifies the Kafka source for exactly-once. Legacy bare tokens (no embedde
 bookmark) fall back to the count-based skip path.
 
 ```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
 sequenceDiagram
     participant SS as StateStore
     participant Snk as Sink watermark

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -42,6 +42,7 @@ The subsystems form a chain — each page ends with a `## Related` section linki
 forward and back, so the set reads as one book rather than isolated files.
 
 ```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
 flowchart LR
     OV[overview] --> EX[execution]
     EX --> PL[pipeline]

--- a/docs/architecture/batching.md
+++ b/docs/architecture/batching.md
@@ -44,6 +44,7 @@ re-chunks the page the sink *writes*. When adaptive batching is enabled
 sub-batches:
 
 ```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
 flowchart LR
     S[Source page: N records] --> A{adaptive enabled?}
     A -->|no| W[sink.write_batch of N]

--- a/docs/architecture/connector-sdk.md
+++ b/docs/architecture/connector-sdk.md
@@ -55,6 +55,7 @@ method plus the methods that implement it. A sink advertises exactly-once with
 `last_committed_token`. The pipeline queries the capability and selects a code path.
 
 ```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
 flowchart LR
     P[run_stream] --> Q{sink.supports_idempotent_writes?}
     Q -->|yes| EO[write_batch_idempotent path]

--- a/docs/architecture/contracts.md
+++ b/docs/architecture/contracts.md
@@ -38,6 +38,7 @@ Under `crates/core/src/contract/`:
 ## Execution flow
 
 ```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
 flowchart TD
     PG[quality survivors] --> AP[apply_contract]
     AP -->|on_breach fail| AB[FaucetError::ContractViolation — write NOTHING]

--- a/docs/architecture/execution.md
+++ b/docs/architecture/execution.md
@@ -18,6 +18,7 @@ order matters: composition happens before interpolation, secrets resolve last at
 load time, and expansion produces the executable node set.
 
 ```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
 flowchart TD
     F[config file] --> CP[compose: extends / !include / profiles]
     CP --> IN[interpolate: env / file / vars / templates]

--- a/docs/architecture/extensibility.md
+++ b/docs/architecture/extensibility.md
@@ -44,6 +44,7 @@ through "does this keep the barrier to a third-party connector low?"
 ## Capability model
 
 ```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
 flowchart LR
     T[Source / Sink trait] --> B[required: fetch/write + config_schema]
     T --> D1[default: supports_exactly_once -> false]

--- a/docs/architecture/learn.md
+++ b/docs/architecture/learn.md
@@ -27,6 +27,7 @@ the tap. You tell it where the data comes from and where it goes, and it moves
 the data — reliably, without losing or scrambling it.
 
 ```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
 flowchart LR
     SRC[(Source<br/>where data comes from)] -->|records| PIPE[faucet pipeline] -->|records| SNK[(Sink<br/>where data goes)]
 ```
@@ -99,6 +100,7 @@ println!("wrote {} records", result.records_written);
 What happens under the hood, in the simplest case:
 
 ```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
 flowchart LR
     A["source.fetch — read ALL records"] --> B["sink.write_batch — write them"] --> C["done: records_written"]
 ```
@@ -132,6 +134,7 @@ a Kafka offset. On the next run, the Source reads that note and resumes from tha
 point instead of the beginning.
 
 ```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
 flowchart LR
     R1["run #1: read rows, remember bookmark = 'updated_at ≤ 09:00'"] --> S[(saved bookmark)]
     S --> R2["run #2: resume from 09:00, only read newer rows"]
@@ -177,6 +180,7 @@ an optional bookmark attached. Instead of one giant read, the Source produces a
 *stream* of pages, and the pipeline handles them one at a time:
 
 ```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
 flowchart LR
     P1[page 1] --> W1[write it] --> P2[page 2] --> W2[write it] --> P3[page 3 + bookmark] --> W3[write it] --> CK[flush + save bookmark]
 ```
@@ -272,6 +276,7 @@ When several of the *data-guarding* tools are on, the pipeline runs them in a
 fixed, safe order on each page — chosen to be *safe*, not arbitrary:
 
 ```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
 flowchart LR
     PAGE[page arrives] --> MASK[1 mask PII] --> Q[2 quality] --> C[3 contract] --> D[4 schema drift] --> WRITE[5 write to sink] --> FLUSH[flush] --> CK[save bookmark]
 ```

--- a/docs/architecture/masking.md
+++ b/docs/architecture/masking.md
@@ -40,6 +40,7 @@ Under `crates/core/src/masking/`:
 ## Execution flow
 
 ```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
 flowchart TD
     PG[StreamPage records] --> MASK[apply_masking — FIRST pass]
     MASK --> Q[quality]

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -47,6 +47,7 @@ run.
 ## Execution flow
 
 ```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
 flowchart TD
     subgraph run["Pipeline::run"]
         L[Build Labels: pipeline, row, run_id] --> WS[Wrap source/sink/state]

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -17,6 +17,7 @@ A run is, at its heart, one loop: pull a page of records from a source, protect
 and validate it, write it to a sink, checkpoint, repeat.
 
 ```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
 flowchart LR
     subgraph Source
       SP[stream_pages]
@@ -48,6 +49,7 @@ binary). The topology encodes a hard rule: **connectors depend only on
 `faucet-core`.**
 
 ```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
 flowchart TD
     CORE[faucet-core<br/>traits, pipeline, transforms, error, state]
     SRC[faucet-source-*<br/>rest, postgres, kafka, s3, ...]

--- a/docs/architecture/pipeline.md
+++ b/docs/architecture/pipeline.md
@@ -30,6 +30,7 @@ connector can get checkpointing wrong because no connector implements it.
 ## Execution flow
 
 ```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
 flowchart TD
     START[Pipeline::run] --> RESUME[resume: read bookmark, apply_start_bookmark]
     RESUME --> SINKANCHOR[exactly-once: re-anchor from sink watermark]

--- a/docs/architecture/quality.md
+++ b/docs/architecture/quality.md
@@ -34,6 +34,7 @@ Under `crates/core/src/quality/`:
 ## Execution flow
 
 ```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
 flowchart TD
     PG[page records] --> RC[per-record checks, declared order, first-failure-wins]
     RC -->|pass| SUR[survivors]

--- a/docs/architecture/recovery.md
+++ b/docs/architecture/recovery.md
@@ -16,6 +16,7 @@ A page moves through: `write_batch` → `flush` → `StateStore::put`. A crash c
 in one of two windows:
 
 ```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
 flowchart LR
     W[write_batch] -->|window A| F[flush] -->|window B| P[put bookmark]
     P --> NEXT[next page]
@@ -47,6 +48,7 @@ faucet-stream solves this by making the **sink's committed watermark the source 
 truth for position**:
 
 ```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
 sequenceDiagram
     participant SS as StateStore
     participant Snk as Sink (watermark)

--- a/docs/architecture/resilience.md
+++ b/docs/architecture/resilience.md
@@ -30,6 +30,7 @@ no `resilience:` block is configured.
 ## How the three mechanisms compose
 
 ```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
 flowchart TD
     OP[sink write / flush / state_put] --> RETRY{retriable class?}
     RETRY -->|yes| BACKOFF[backoff + jitter, retry up to max_attempts]

--- a/docs/architecture/retries.md
+++ b/docs/architecture/retries.md
@@ -17,6 +17,7 @@ that downside.
 Retries happen in two distinct places, for two distinct reasons:
 
 ```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
 flowchart TD
     subgraph Source side
       REST[rest / xml / graphql] -->|with_retry_policy| RS[execute_with_retry]

--- a/docs/architecture/schema.md
+++ b/docs/architecture/schema.md
@@ -35,6 +35,7 @@ policies run per page, in a fixed order, inside `run_stream`.
 ## Execution flow — the per-page pipeline
 
 ```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
 flowchart TD
     PG[StreamPage records] --> M[masking pass FIRST]
     M --> Q[quality: per-record then per-batch]

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -32,6 +32,7 @@ network segmentation, the security of the external systems faucet connects to,
 and the secrecy of the environment faucet runs in.
 
 ```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
 flowchart LR
     subgraph Trusted[Trust boundary: the faucet process]
       cfg[config + resolved secrets in memory]

--- a/docs/architecture/state-management.md
+++ b/docs/architecture/state-management.md
@@ -37,6 +37,7 @@ correct ordering. See [ADR 0006](../adr/0006-state-management.md).
 ## How a bookmark flows
 
 ```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
 sequenceDiagram
     participant SS as StateStore
     participant P as Pipeline

--- a/docs/architecture/stream-pages.md
+++ b/docs/architecture/stream-pages.md
@@ -45,6 +45,7 @@ correct). Connectors that can stream from their underlying primitive **override*
 `stream_pages` to be truly incremental:
 
 ```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
 flowchart LR
     subgraph Native override
       DB[(database cursor)] --> P1[page] --> P2[page] --> P3[page bookmark]

--- a/docs/contributing/architecture.md
+++ b/docs/contributing/architecture.md
@@ -13,6 +13,7 @@ faucet-stream is a Cargo workspace of ~63 crates. They fall into four layers,
 and the dependency direction only ever flows downward:
 
 ```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
 flowchart TD
     CLI["faucet-cli (cli/)<br/>config · expand · executor · serve · schedule · replicate · backfill"]
     UMB["faucet-stream (faucet-stream/)<br/>umbrella: feature-gated re-exports"]
@@ -58,6 +59,7 @@ When you need to understand how a record actually moves, read the layers in the
 order the data does. Each hop below has a "start here" file:
 
 ```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
 flowchart LR
     A["YAML/JSON config"] --> B["cli/src/config.rs<br/>parse + interpolate + secrets"]
     B --> C["cli/src/expand.rs<br/>matrix → ExpandedNode[]"]

--- a/docs/contributing/debugging.md
+++ b/docs/contributing/debugging.md
@@ -7,6 +7,7 @@ real infrastructure. Reach for the offline tools first; they catch most
 problems in seconds.
 
 ```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
 flowchart TD
     A["Pipeline misbehaving"] --> B["faucet validate<br/>config, gates, secret refs"]
     B --> C["faucet doctor<br/>preflight probe each connector"]

--- a/docs/contributing/performance.md
+++ b/docs/contributing/performance.md
@@ -45,6 +45,7 @@ the harness, not intuition. The benchmark VM and scenarios are documented there
 (Scenario C is the head-to-head throughput comparison).
 
 ```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
 flowchart LR
     A["hypothesis:<br/>'X is slow'"] --> B["measure with BENCHMARKS.md harness"]
     B --> C{evidence of a<br/>real bottleneck?}

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -30,6 +30,7 @@ your changed lines.** If a line "can't" be unit-tested, that is usually a design
 smell — extract the pure logic and make the I/O a thin shim:
 
 ```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
 flowchart LR
     A["new / changed code"] --> B{needs real I/O?}
     B -- no --> C["#[cfg(test)] unit test<br/>counts toward patch coverage"]

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -49,6 +49,7 @@ agreed before code exists.
 ## Lifecycle
 
 ```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
 flowchart LR
     Draft --> Discussion
     Discussion -->|consensus| Accepted


### PR DESCRIPTION
## What

Prepends a `%%{init}%%` theme directive (faucet logo **teal** on slate) to **every Mermaid block in the GitHub-rendered docs** — `docs/architecture/`, `docs/adr/`, `docs/contributing/`, `rfcs/`, `README.md`, `docs/README.md` — so GitHub renders them branded instead of its plain gray default.

- **36 blocks across 29 files**, each validated to render (HTTP 200 via mermaid.ink, the same renderer family GitHub uses).
- `docs/book/` (mdBook) diagrams are **left untouched** — they're themed by the `mdbook-mermaid` preprocessor + the site CSS, so an init directive would fight the site theme.

## Why

The architecture diagrams were already valid Mermaid (not ASCII), but GitHub's default theme renders them plain gray. This gives them the same teal identity as the docs-site rebrand (#332), delivering on "beautiful diagrams."

## Note

The diagrams were *already* valid Mermaid on `main` — a report of "raw/ugly diagrams" turned out to be a GitHub render cache, not a source defect. This PR is purely the visual theming.