### PR TITLE
docs: reconcile counts, annotate benchmark, per-page SEO (closes #335, #336, #337)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,14 @@ jobs:
           components: rustfmt
       - run: cargo fmt --all --check
 
+  doc-counts:
+    name: Doc counts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check connector counts in docs match connector crates
+        run: bash scripts/check-doc-counts.sh
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,6 +47,10 @@ jobs:
           curl -sSL "$url" | tar -xz -C "$HOME/.local/bin"
       - name: Build
         run: mdbook build docs/book
+      - name: Inject per-page SEO metadata
+        # mdBook's head.hbs is site-wide; rewrite per-page description + Open
+        # Graph / Twitter title & description from each page's <h1>/first <p>.
+        run: python3 scripts/inject-page-meta.py docs/book/book
       - name: Generate sitemap.xml
         # mdBook has no native sitemap (rust-lang/mdBook#1491); generate one from
         # the built HTML so search engines can crawl every page. Uses the full

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -177,7 +177,7 @@ and [`benchmarks/meltano/meltano.yml`](benchmarks/meltano/meltano.yml).
 |---|---|---|---|---|---|
 | **faucet-stream (`write_method: copy`)** | **8.12** | 0.142 | **123,200** | **35.9** | 1,000,000 |
 | faucet-stream (multi-row `INSERT`) | 10.10 | 0.112 | 99,000 | 35.9 | 1,000,000 |
-| Meltano (Singer) | 129.8 | 34.347 | 7,706 | 485.7 | 1,000,000 |
+| Meltano (Singer)† | 129.8 | 34.347 | 7,706 | 485.7 | 1,000,000 |
 
 On this workload/hardware faucet's COPY path was **~16× faster** than Meltano
 (and its INSERT path ~12.9×), with **~13.5× less peak memory** (35.9 vs 485.7
@@ -188,15 +188,16 @@ the faucet rows were re-measured when the COPY fast-path landed. faucet's
 INSERT number improved slightly between runs — 11.17s → 10.10s — normal
 machine-load drift.)
 
-> **Numbers predate the `batch_size_rows: 5000` pin.** The Meltano row above was
-> captured before the explicit batch pin was added to `meltano.yml` (it used
-> `target-postgres`'s prior default); the batch pin makes both sides literally
-> 5,000 rows. In this regime batch size is not the lever (faucet's throughput is
-> flat 500→5000 rows/`INSERT`), so the number is not expected to move materially —
-> but it has not been re-measured under the pinned config. **TODO: run locally**
-> (needs Docker + a Meltano venv, not available in this change):
-> `scripts/run-bench.sh --postgres --rows 1000000`, then refresh this table and
-> `benchmarks/results/results_pg_1m.md` from the real run.
+> **† The Meltano row predates the `batch_size_rows: 5000` pin.** It was captured
+> on the same-machine PR #307 run, *before* the explicit batch pin was added to
+> `meltano.yml` (it used `target-postgres`'s prior default). The config is now
+> pinned so both sides write 5,000-row batches, but **this specific Meltano number
+> has not been re-measured under the pin** — read it as pre-pin. In this regime
+> batch size is not the lever (faucet's throughput is flat 500→5000 rows/`INSERT`),
+> so it is not expected to move materially. Re-measuring needs Docker + a Meltano
+> venv on the bench host: run `scripts/run-bench.sh --postgres --rows 1000000` and
+> refresh this table + `benchmarks/results/results_pg_1m.md` when that environment
+> is available (tracked in [#336](https://github.com/PawanSikawat/faucet-stream/issues/336)).
 
 This is the whole point of the scenario: **the gap
 collapses from ~96× to ~16× as the workload moves from parse-bound to

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ for help picking between overlapping connectors (Postgres query vs CDC, S3 vs Pa
 > production — Tier-2 means "not certified," **not** "low quality." The Singer
 > bridge is additionally **experimental (v0, single-stream)** ⚠️.
 
-### Sources (25)
+### Sources (28)
 
 `Tier`: **T1 ✅** = passes the `faucet-conformance` battery in CI; **T2** = not yet
 wired into the battery (see the support-tiers note above).
@@ -279,7 +279,7 @@ wired into the battery (see the support-tiers note above).
 | [`faucet-source-csv`](crates/source/csv) | **T1 ✅** | CSV — read CSV files as JSON objects |
 | [`faucet-source-singer`](crates/source/singer) | T2 ⚠️ | **Singer tap bridge** — run any Singer tap and adapt its output. Passes the battery, but **experimental (v0, single-stream)** |
 
-### Sinks (20)
+### Sinks (21)
 
 | Crate | Tier | Description |
 |-------|------|-------------|
@@ -791,7 +791,7 @@ and the runnable [`cli/examples/custom-cli/`](cli/examples/custom-cli/main.rs).
 ## Project structure
 
 ```
-Cargo.toml                    — workspace manifest (60 crates)
+Cargo.toml                    — workspace manifest (67 crates)
 crates/
   core/                       — faucet-core: shared types, traits, pipeline, transforms, config
   auth/                       — faucet-auth: shared OAuth2 / token-endpoint providers

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -44,7 +44,7 @@ the loop itself in [pipeline](./pipeline.md); the streaming model in
 
 ## Crate topology
 
-The workspace is a Cargo workspace of 63 crates (62 libraries + the `faucet` CLI
+The workspace is a Cargo workspace of 67 crates (66 libraries + the `faucet` CLI
 binary). The topology encodes a hard rule: **connectors depend only on
 `faucet-core`.**
 

--- a/docs/book/src/introduction.md
+++ b/docs/book/src/introduction.md
@@ -8,7 +8,7 @@
   </div>
 </div>
 
-faucet-stream wires **23 source** and **18 sink** connectors together with a single
+faucet-stream wires **28 source** and **21 sink** connectors together with a single
 `faucet` binary that runs pipelines declaratively from a YAML/JSON file — no Rust
 code required. Or skip the binary and embed the same engine in your own service
 through the typed `Source` / `Sink` traits.

--- a/docs/book/src/reference/connectors.md
+++ b/docs/book/src/reference/connectors.md
@@ -1,6 +1,6 @@
 # Connector catalog
 
-faucet-stream ships **25 sources** and **20 sinks**. Each is a Cargo feature
+faucet-stream ships **28 sources** and **21 sinks**. Each is a Cargo feature
 (`source-<name>` / `sink-<name>`) and an independently published crate. Full API
 docs are on [docs.rs](https://docs.rs/faucet-stream).
 

--- a/docs/book/theme/head.hbs
+++ b/docs/book/theme/head.hbs
@@ -1,7 +1,13 @@
 <!-- Injected into <head> on every page (mdBook theme override).
      Adds social-share / SEO metadata; the rest of the <head> uses mdBook
-     defaults. Keep values in sync with the README hero + elevator pitch. -->
-<meta name="description" content="faucet-stream — the fast, config-driven way to move data in Rust. Pluggable source and sink connectors plus a declarative CLI: run production data pipelines from YAML, no Rust code required." />
+     defaults. Keep values in sync with the README hero + elevator pitch.
+
+     These og:/twitter: values are site-wide DEFAULTS. On a built site the CI
+     step `scripts/inject-page-meta.py` rewrites og:title / og:description /
+     twitter:title / twitter:description (and mdBook's own description meta)
+     per page from each page's <h1> + first paragraph. The page-level
+     description meta comes from book.toml [book].description; it is
+     intentionally NOT duplicated here so there is exactly one to rewrite. -->
 <meta name="theme-color" content="#14b8a6" />
 
 <!-- Open Graph -->

--- a/docs/contributing/architecture.md
+++ b/docs/contributing/architecture.md
@@ -9,7 +9,7 @@ see the top-level [`CONTRIBUTING.md`](../../CONTRIBUTING.md).
 
 ## Workspace shape
 
-faucet-stream is a Cargo workspace of ~63 crates. They fall into four layers,
+faucet-stream is a Cargo workspace of 67 crates. They fall into four layers,
 and the dependency direction only ever flows downward:
 
 ```mermaid

--- a/scripts/check-doc-counts.sh
+++ b/scripts/check-doc-counts.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Guard against connector-count drift across user-facing docs.
+#
+# The number of source/sink connectors is stated in several places (README hero,
+# the docs-site connector catalog, the docs intro). They have silently diverged
+# before (issue #335). This asserts every one of them matches the actual number
+# of connector crates on disk, so a connector added without updating the docs
+# fails CI.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+S=$(find crates/source -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')
+K=$(find crates/sink -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')
+T=$((S + K))
+echo "Connector crates on disk: ${S} sources, ${K} sinks, ${T} total"
+
+fail=0
+check() { # <file> <literal-substring>
+  if ! grep -qF -- "$2" "$1"; then
+    echo "  ✗ ${1}: expected to contain '${2}'"
+    fail=1
+  fi
+}
+
+check README.md "**${S} source**"
+check README.md "**${K} sink**"
+check README.md "**${T} in total**"
+check docs/book/src/reference/connectors.md "**${S} sources**"
+check docs/book/src/reference/connectors.md "**${K} sinks**"
+check docs/book/src/introduction.md "**${S} source**"
+check docs/book/src/introduction.md "**${K} sink**"
+
+if [ "${fail}" -ne 0 ]; then
+  echo ""
+  echo "Connector-count drift detected. Update the file(s) above to ${S} sources / ${K} sinks / ${T} total."
+  exit 1
+fi
+echo "OK: connector counts are consistent across docs."

--- a/scripts/inject-page-meta.py
+++ b/scripts/inject-page-meta.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Inject per-page SEO metadata into a built mdBook.
+
+mdBook's theme/head.hbs is the same fragment on every page, so Open Graph and
+meta-description tags are otherwise site-wide (issue #337). This post-build step
+rewrites, per page, the *content* of tags that already exist in <head>:
+
+  - <meta name="description">        (mdBook emits one from book.toml [book].description)
+  - <meta property="og:title">       (from head.hbs)
+  - <meta property="og:description"> (from head.hbs)
+  - <meta name="twitter:title">      (from head.hbs)
+  - <meta name="twitter:description">(from head.hbs)
+
+Per-page values come from the page's first <h1> (title) and first <p>
+(description), taken from inside <main> so nav/sidebar chrome is ignored. Pages
+without a usable <h1>/<p> keep the site-wide defaults. It only edits the content
+attribute of tags that are already present, so it never adds duplicates and is
+idempotent. No external dependencies (stdlib only).
+
+Usage: python3 scripts/inject-page-meta.py docs/book/book
+"""
+import html
+import pathlib
+import re
+import sys
+
+MAX_DESC = 155
+SKIP = {"404.html", "print.html"}
+
+
+def clean(fragment: str) -> str:
+    text = re.sub(r"<[^>]+>", "", fragment)  # strip inline tags
+    text = html.unescape(text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def truncate(text: str, limit: int = MAX_DESC) -> str:
+    if len(text) <= limit:
+        return text
+    cut = text[:limit].rsplit(" ", 1)[0].rstrip(".,;:—- ")
+    return cut + "…"
+
+
+def set_meta_content(head: str, attr: str, value: str, content: str) -> str:
+    """Replace the content="..." of the first <meta {attr}="{value}" ...> tag."""
+    escaped = html.escape(content, quote=True)
+    pattern = re.compile(
+        r'(<meta\s+[^>]*\b' + re.escape(attr) + r'="' + re.escape(value)
+        + r'"[^>]*\bcontent=")[^"]*(")'
+    )
+    new, _ = pattern.subn(lambda m: m.group(1) + escaped + m.group(2), head, count=1)
+    return new
+
+
+def first_match(pattern: str, text: str):
+    m = re.search(pattern, text, re.DOTALL | re.IGNORECASE)
+    return m.group(1) if m else None
+
+
+def process(path: pathlib.Path) -> bool:
+    text = path.read_text(encoding="utf-8")
+    main = first_match(r"<main\b[^>]*>(.*?)</main>", text) or text
+    h1 = first_match(r"<h1\b[^>]*>(.*?)</h1>", main)
+    para = first_match(r"<p\b[^>]*>(.*?)</p>", main)
+
+    title = clean(h1) if h1 else ""
+    desc = truncate(clean(para)) if para else ""
+    if not title and not desc:
+        return False
+
+    head_m = re.search(r"<head\b[^>]*>(.*?)</head>", text, re.DOTALL | re.IGNORECASE)
+    if not head_m:
+        return False
+    head = original = head_m.group(1)
+
+    if desc:
+        head = set_meta_content(head, "name", "description", desc)
+        head = set_meta_content(head, "property", "og:description", desc)
+        head = set_meta_content(head, "name", "twitter:description", desc)
+    if title:
+        page_title = f"{title} · faucet-stream"
+        head = set_meta_content(head, "property", "og:title", page_title)
+        head = set_meta_content(head, "name", "twitter:title", page_title)
+
+    if head == original:
+        return False
+    path.write_text(text[: head_m.start(1)] + head + text[head_m.end(1):], encoding="utf-8")
+    return True
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: inject-page-meta.py <built-book-dir>", file=sys.stderr)
+        return 2
+    root = pathlib.Path(sys.argv[1])
+    if not root.is_dir():
+        print(f"error: {root} is not a directory", file=sys.stderr)
+        return 2
+    updated = sum(
+        process(f) for f in sorted(root.rglob("*.html")) if f.name not in SKIP
+    )
+    print(f"inject-page-meta: updated {updated} pages")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Fixes the three follow-ups filed after the WS-11 docs work (#314).

## #335 — reconcile connector/crate counts + CI guard
Ground truth (`cargo metadata` / crate dirs): **28 sources, 21 sinks = 49 connectors; 67 workspace crates**. Standardized every stale surface:
- README source/sink headings (`25`/`20` → `28`/`21`) and Project-structure crate count (`60` → `67`).
- `docs/book/src/introduction.md` (`23`/`18` → `28`/`21`), `reference/connectors.md` header (`25`/`20` → `28`/`21`).
- `docs/contributing/architecture.md` + `docs/architecture/overview.md` crate counts (`63` → `67`).
- **New anti-drift guard:** `scripts/check-doc-counts.sh` + a `Doc counts` CI job that fails if the documented source/sink counts don't match the number of connector crates on disk.
- The `connectors.md` capability matrix was already complete (all 49 rows present) — only its header was stale.
- Note: `CLAUDE.md` is gitignored in this repo, so its (also-stale) crate table was refreshed **locally only** and isn't part of this PR.

## #336 — annotate the pre-pin benchmark row
`BENCHMARKS.md` Scenario C (Postgres→Postgres): marked the Meltano row with a `†` footnote stating it was captured before the `batch_size_rows=5000` pin and hasn't been re-measured under it, and converted the dangling inline TODO into a tracked follow-up (#336). Re-measuring needs Docker + a Meltano venv on the bench host (can't be done in this change).

## #337 — per-page meta description + Open Graph
`scripts/inject-page-meta.py` (run from the docs workflow after `mdbook build`) rewrites each page's `description` / `og:title` / `og:description` / `twitter:title` / `twitter:description` from its `<h1>` + first paragraph. Dropped the redundant site-wide `description` meta from `theme/head.hbs` (mdBook emits one from `book.toml` that the script now rewrites per page); head.hbs keeps its og/twitter tags as fallback defaults. No new preprocessor.

## Verification
- `mdbook build docs/book` clean; injector updates 64 pages; **62/65** get a per-page `og:title` (the 3 without — incl. the homepage — keep the curated default and still get per-page descriptions); exactly one `description` meta per page.
- `scripts/check-doc-counts.sh` passes (28/21/49); both workflows parse as valid YAML; `inject-page-meta.py` compiles.

Scripts are `git add -f`'d because `.gitignore` has `/scripts/*` — consistent with the existing force-tracked `run-bench.sh` etc.

Closes #335, #336, #337. Part of adoption epic #38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)