### PR TITLE
docs: upgrade Mermaid diagrams to V2 role-coded style

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ regardless of total volume. The pipeline also drives the cross-cutting runtime (
 dead-letter routing, quality checks, metrics) so connectors stay simple:
 
 ```mermaid
-%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
+%%{init: {'theme':'base','flowchart':{'curve':'basis','nodeSpacing':50,'rankSpacing':72,'padding':14},'themeVariables':{'fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif','fontSize':'14px','lineColor':'#a5b4c4','clusterBkg':'#f8fafc','clusterBorder':'#e2e8f0'}}}%%
 flowchart LR
     S["<b>Source</b><br/>REST · DB · CDC<br/>Kafka · S3 · Parquet"]
     T["<b>Transforms</b><br/>flatten · rename · keys_case<br/>select · drop · set · cast<br/>redact · value_case · spell_symbols<br/>sql (DuckDB, page-level)"]
@@ -444,6 +444,18 @@ flowchart LR
     ST -.->|resume from bookmark| S
     P -.->|failed rows| D
     P -.->|metrics + spans| O
+    classDef src fill:#e0f2f1,stroke:#26a69a,stroke-width:1.5px,color:#00695c
+    classDef proc fill:#eceff8,stroke:#7986cb,stroke-width:1.5px,color:#303f9f
+    classDef dec fill:#fff3e0,stroke:#ffa726,stroke-width:1.5px,color:#e65100
+    classDef bad fill:#fdecec,stroke:#ef9a9a,stroke-width:1.5px,color:#c62828
+    classDef store fill:#f3e5f5,stroke:#ab47bc,stroke-width:1.5px,color:#6a1b9a
+    classDef sink fill:#e3f2fd,stroke:#42a5f5,stroke-width:1.5px,color:#1565c0
+    class S src
+    class T,O proc
+    class P dec
+    class D bad
+    class ST store
+    class K sink
 ```
 
 faucet-stream is a Cargo workspace with **67 crates** — 28 sources, 21 sinks, 9 shared

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ If you want to *change* or *extend* it, start here.
 ## Engineering documentation map
 
 ```mermaid
-%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
+%%{init: {'theme':'base','flowchart':{'curve':'basis','nodeSpacing':50,'rankSpacing':72,'padding':14},'themeVariables':{'fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif','fontSize':'14px','lineColor':'#a5b4c4','clusterBkg':'#f8fafc','clusterBorder':'#e2e8f0'}}}%%
 flowchart TD
     Hub["docs/README.md<br/>(this file)"]
     Hub --> Arch["architecture/<br/>how & why each subsystem works"]
@@ -32,6 +32,10 @@ flowchart TD
     Arch -. grounds .-> ADR
     ADR -. evolves into .-> RFC
     Contrib -. enforces .-> Std
+    classDef src fill:#e0f2f1,stroke:#26a69a,stroke-width:1.5px,color:#00695c
+    classDef proc fill:#eceff8,stroke:#7986cb,stroke-width:1.5px,color:#303f9f
+    class Hub src
+    class Arch,ADR,Contrib,Std,RFC,Principles,Review,Stability,Roadmap proc
 ```
 
 ### [Architecture](./architecture/README.md)

--- a/docs/adr/0001-stream-pages.md
+++ b/docs/adr/0001-stream-pages.md
@@ -34,11 +34,19 @@ sources, `postgres`, `parquet`, `kafka`, `elasticsearch` scroll, …) **override
 `stream_pages` to be truly incremental.
 
 ```mermaid
-%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
+%%{init: {'theme':'base','flowchart':{'curve':'basis','nodeSpacing':50,'rankSpacing':72,'padding':14},'themeVariables':{'fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif','fontSize':'14px','lineColor':'#a5b4c4','clusterBkg':'#f8fafc','clusterBorder':'#e2e8f0'}}}%%
 flowchart LR
     SRC[(source primitive)] --> P1[page] --> P2[page] --> P3[page + bookmark]
     P1 --> W1[write] --> F1[flush]
     P3 --> CK[checkpoint]
+    classDef src fill:#e0f2f1,stroke:#26a69a,stroke-width:1.5px,color:#00695c
+    classDef proc fill:#eceff8,stroke:#7986cb,stroke-width:1.5px,color:#303f9f
+    classDef store fill:#f3e5f5,stroke:#ab47bc,stroke-width:1.5px,color:#6a1b9a
+    classDef sink fill:#e3f2fd,stroke:#42a5f5,stroke-width:1.5px,color:#1565c0
+    class SRC src
+    class P1,P2,P3,F1 proc
+    class CK store
+    class W1 sink
 ```
 
 ## Alternatives considered

--- a/docs/adr/0002-checkpoint-ordering.md
+++ b/docs/adr/0002-checkpoint-ordering.md
@@ -40,7 +40,7 @@ never ahead. Recovery can therefore only ever replay already-attempted work; it 
 never skip data the sink did not receive.
 
 ```mermaid
-%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
+%%{init: {'theme':'base','themeVariables':{'fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif','fontSize':'14px','lineColor':'#a5b4c4','clusterBkg':'#f8fafc','clusterBorder':'#e2e8f0'}}}%%
 sequenceDiagram
     participant Snk as Sink
     participant SS as StateStore

--- a/docs/adr/0005-runtime-recovery.md
+++ b/docs/adr/0005-runtime-recovery.md
@@ -35,7 +35,7 @@ what qualifies the Kafka source for exactly-once. Legacy bare tokens (no embedde
 bookmark) fall back to the count-based skip path.
 
 ```mermaid
-%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
+%%{init: {'theme':'base','themeVariables':{'fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif','fontSize':'14px','lineColor':'#a5b4c4','clusterBkg':'#f8fafc','clusterBorder':'#e2e8f0'}}}%%
 sequenceDiagram
     participant SS as StateStore
     participant Snk as Sink watermark

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -42,7 +42,7 @@ The subsystems form a chain — each page ends with a `## Related` section linki
 forward and back, so the set reads as one book rather than isolated files.
 
 ```mermaid
-%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
+%%{init: {'theme':'base','flowchart':{'curve':'basis','nodeSpacing':50,'rankSpacing':72,'padding':14},'themeVariables':{'fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif','fontSize':'14px','lineColor':'#a5b4c4','clusterBkg':'#f8fafc','clusterBorder':'#e2e8f0'}}}%%
 flowchart LR
     OV[overview] --> EX[execution]
     EX --> PL[pipeline]
@@ -60,6 +60,10 @@ flowchart LR
     OV --> CS[connector-sdk]
     CS --> EXT[extensibility]
     PL --> PF[performance]
+    classDef src fill:#e0f2f1,stroke:#26a69a,stroke-width:1.5px,color:#00695c
+    classDef proc fill:#eceff8,stroke:#7986cb,stroke-width:1.5px,color:#303f9f
+    class OV src
+    class EX,PL,SP,BT,ST,RC,RT,RS,SC,QL,CT,MK,OB,CS,EXT,PF proc
 ```
 
 ### The pages

--- a/docs/architecture/batching.md
+++ b/docs/architecture/batching.md
@@ -44,7 +44,7 @@ re-chunks the page the sink *writes*. When adaptive batching is enabled
 sub-batches:
 
 ```mermaid
-%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
+%%{init: {'theme':'base','flowchart':{'curve':'basis','nodeSpacing':50,'rankSpacing':72,'padding':14},'themeVariables':{'fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif','fontSize':'14px','lineColor':'#a5b4c4','clusterBkg':'#f8fafc','clusterBorder':'#e2e8f0'}}}%%
 flowchart LR
     S[Source page: N records] --> A{adaptive enabled?}
     A -->|no| W[sink.write_batch of N]
@@ -55,6 +55,14 @@ flowchart LR
     O -->|errors / high latency| DN[multiplicative decrease k]
     UP --> C
     DN --> C
+    classDef src fill:#e0f2f1,stroke:#26a69a,stroke-width:1.5px,color:#00695c
+    classDef proc fill:#eceff8,stroke:#7986cb,stroke-width:1.5px,color:#303f9f
+    classDef dec fill:#fff3e0,stroke:#ffa726,stroke-width:1.5px,color:#e65100
+    classDef sink fill:#e3f2fd,stroke:#42a5f5,stroke-width:1.5px,color:#1565c0
+    class S src
+    class C,UP,DN,O proc
+    class A dec
+    class W,W1 sink
 ```
 
 The controller is created lazily on the first non-empty page

--- a/docs/architecture/connector-sdk.md
+++ b/docs/architecture/connector-sdk.md
@@ -55,13 +55,19 @@ method plus the methods that implement it. A sink advertises exactly-once with
 `last_committed_token`. The pipeline queries the capability and selects a code path.
 
 ```mermaid
-%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
+%%{init: {'theme':'base','flowchart':{'curve':'basis','nodeSpacing':50,'rankSpacing':72,'padding':14},'themeVariables':{'fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif','fontSize':'14px','lineColor':'#a5b4c4','clusterBkg':'#f8fafc','clusterBorder':'#e2e8f0'}}}%%
 flowchart LR
     P[run_stream] --> Q{sink.supports_idempotent_writes?}
     Q -->|yes| EO[write_batch_idempotent path]
     Q -->|no| DEF[write_batch path]
     P --> R{sink.dedups_by_key?}
     R -->|yes| KU[keyed-upsert effectively-once]
+    classDef src fill:#e0f2f1,stroke:#26a69a,stroke-width:1.5px,color:#00695c
+    classDef dec fill:#fff3e0,stroke:#ffa726,stroke-width:1.5px,color:#e65100
+    classDef sink fill:#e3f2fd,stroke:#42a5f5,stroke-width:1.5px,color:#1565c0
+    class P src
+    class Q,R dec
+    class EO,DEF,KU sink
 ```
 
 This keeps the traits object-safe (no associated types, no generic methods) while

--- a/docs/architecture/contracts.md
+++ b/docs/architecture/contracts.md
@@ -38,13 +38,21 @@ Under `crates/core/src/contract/`:
 ## Execution flow
 
 ```mermaid
-%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
+%%{init: {'theme':'base','flowchart':{'curve':'basis','nodeSpacing':50,'rankSpacing':72,'padding':14},'themeVariables':{'fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif','fontSize':'14px','lineColor':'#a5b4c4','clusterBkg':'#f8fafc','clusterBorder':'#e2e8f0'}}}%%
 flowchart TD
     PG[quality survivors] --> AP[apply_contract]
     AP -->|on_breach fail| AB[FaucetError::ContractViolation — write NOTHING]
     AP -->|on_breach quarantine| DLQ[DLQ envelope DlqReason::Contract]
     AP -->|on_breach warn| WRN[log once/run, count, write anyway]
     AP -->|clean| SUR[survivors to drift pass then sink]
+    classDef src fill:#e0f2f1,stroke:#26a69a,stroke-width:1.5px,color:#00695c
+    classDef proc fill:#eceff8,stroke:#7986cb,stroke-width:1.5px,color:#303f9f
+    classDef good fill:#e8f5e9,stroke:#66bb6a,stroke-width:1.5px,color:#2e7d32
+    classDef bad fill:#fdecec,stroke:#ef9a9a,stroke-width:1.5px,color:#c62828
+    class PG src
+    class AP proc
+    class WRN,SUR good
+    class AB,DLQ bad
 ```
 
 Runs after the quality pass and before the schema-drift pass (see

--- a/docs/architecture/execution.md
+++ b/docs/architecture/execution.md
@@ -18,7 +18,7 @@ order matters: composition happens before interpolation, secrets resolve last at
 load time, and expansion produces the executable node set.
 
 ```mermaid
-%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
+%%{init: {'theme':'base','flowchart':{'curve':'basis','nodeSpacing':50,'rankSpacing':72,'padding':14},'themeVariables':{'fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif','fontSize':'14px','lineColor':'#a5b4c4','clusterBkg':'#f8fafc','clusterBorder':'#e2e8f0'}}}%%
 flowchart TD
     F[config file] --> CP[compose: extends / !include / profiles]
     CP --> IN[interpolate: env / file / vars / templates]
@@ -29,6 +29,12 @@ flowchart TD
     EXEC --> P1[Pipeline::run]
     EXEC --> P2[Pipeline::run]
     EXEC --> PN[Pipeline::run]
+    classDef src fill:#e0f2f1,stroke:#26a69a,stroke-width:1.5px,color:#00695c
+    classDef proc fill:#eceff8,stroke:#7986cb,stroke-width:1.5px,color:#303f9f
+    classDef good fill:#e8f5e9,stroke:#66bb6a,stroke-width:1.5px,color:#2e7d32
+    class F src
+    class CP,IN,SEC,PARSE,EXP,EXEC proc
+    class P1,P2,PN good
 ```
 
 - **`compose`** (`cli/src/compose.rs`) — stitches `extends:`, substitutes

--- a/docs/architecture/extensibility.md
+++ b/docs/architecture/extensibility.md
@@ -44,7 +44,7 @@ through "does this keep the barrier to a third-party connector low?"
 ## Capability model
 
 ```mermaid
-%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
+%%{init: {'theme':'base','flowchart':{'curve':'basis','nodeSpacing':50,'rankSpacing':72,'padding':14},'themeVariables':{'fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif','fontSize':'14px','lineColor':'#a5b4c4','clusterBkg':'#f8fafc','clusterBorder':'#e2e8f0'}}}%%
 flowchart LR
     T[Source / Sink trait] --> B[required: fetch/write + config_schema]
     T --> D1[default: supports_exactly_once -> false]
@@ -55,6 +55,12 @@ flowchart LR
     D2 -.override.-> S[PK-range / hash-shardable sources]
     D3 -.override.-> DIS[catalog-backed sources]
     D4 -.override.-> EV[evolvable SQL sinks]
+    classDef src fill:#e0f2f1,stroke:#26a69a,stroke-width:1.5px,color:#00695c
+    classDef proc fill:#eceff8,stroke:#7986cb,stroke-width:1.5px,color:#303f9f
+    classDef good fill:#e8f5e9,stroke:#66bb6a,stroke-width:1.5px,color:#2e7d32
+    class T src
+    class B,D1,D2,D3,D4 proc
+    class C,S,DIS,EV good
 ```
 
 A connector opts into a capability by overriding one defaulted method — it never

--- a/docs/architecture/learn.md
+++ b/docs/architecture/learn.md
@@ -27,9 +27,15 @@ the tap. You tell it where the data comes from and where it goes, and it moves
 the data — reliably, without losing or scrambling it.
 
 ```mermaid
-%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
+%%{init: {'theme':'base','flowchart':{'curve':'basis','nodeSpacing':50,'rankSpacing':72,'padding':14},'themeVariables':{'fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif','fontSize':'14px','lineColor':'#a5b4c4','clusterBkg':'#f8fafc','clusterBorder':'#e2e8f0'}}}%%
 flowchart LR
     SRC[(Source<br/>where data comes from)] -->|records| PIPE[faucet pipeline] -->|records| SNK[(Sink<br/>where data goes)]
+    classDef src fill:#e0f2f1,stroke:#26a69a,stroke-width:1.5px,color:#00695c
+    classDef proc fill:#eceff8,stroke:#7986cb,stroke-width:1.5px,color:#303f9f
+    classDef sink fill:#e3f2fd,stroke:#42a5f5,stroke-width:1.5px,color:#1565c0
+    class SRC src
+    class PIPE proc
+    class SNK sink
 ```
 
 Everything else in this project — pages, bookmarks, retries, exactly-once — exists
@@ -100,9 +106,15 @@ println!("wrote {} records", result.records_written);
 What happens under the hood, in the simplest case:
 
 ```mermaid
-%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
+%%{init: {'theme':'base','flowchart':{'curve':'basis','nodeSpacing':50,'rankSpacing':72,'padding':14},'themeVariables':{'fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif','fontSize':'14px','lineColor':'#a5b4c4','clusterBkg':'#f8fafc','clusterBorder':'#e2e8f0'}}}%%
 flowchart LR
     A["source.fetch — read ALL records"] --> B["sink.write_batch — write them"] --> C["done: records_written"]
+    classDef src fill:#e0f2f1,stroke:#26a69a,stroke-width:1.5px,color:#00695c
+    classDef good fill:#e8f5e9,stroke:#66bb6a,stroke-width:1.5px,color:#2e7d32
+    classDef sink fill:#e3f2fd,stroke:#42a5f5,stroke-width:1.5px,color:#1565c0
+    class A src
+    class C good
+    class B sink
 ```
 
 Read everything, write everything, report how many. For a one-time copy — "move
@@ -134,10 +146,14 @@ a Kafka offset. On the next run, the Source reads that note and resumes from tha
 point instead of the beginning.
 
 ```mermaid
-%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
+%%{init: {'theme':'base','flowchart':{'curve':'basis','nodeSpacing':50,'rankSpacing':72,'padding':14},'themeVariables':{'fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif','fontSize':'14px','lineColor':'#a5b4c4','clusterBkg':'#f8fafc','clusterBorder':'#e2e8f0'}}}%%
 flowchart LR
     R1["run #1: read rows, remember bookmark = 'updated_at ≤ 09:00'"] --> S[(saved bookmark)]
     S --> R2["run #2: resume from 09:00, only read newer rows"]
+    classDef proc fill:#eceff8,stroke:#7986cb,stroke-width:1.5px,color:#303f9f
+    classDef store fill:#f3e5f5,stroke:#ab47bc,stroke-width:1.5px,color:#6a1b9a
+    class R1,R2 proc
+    class S store
 ```
 
 Two small additions make a Source resumable:
@@ -180,9 +196,15 @@ an optional bookmark attached. Instead of one giant read, the Source produces a
 *stream* of pages, and the pipeline handles them one at a time:
 
 ```mermaid
-%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
+%%{init: {'theme':'base','flowchart':{'curve':'basis','nodeSpacing':50,'rankSpacing':72,'padding':14},'themeVariables':{'fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif','fontSize':'14px','lineColor':'#a5b4c4','clusterBkg':'#f8fafc','clusterBorder':'#e2e8f0'}}}%%
 flowchart LR
     P1[page 1] --> W1[write it] --> P2[page 2] --> W2[write it] --> P3[page 3 + bookmark] --> W3[write it] --> CK[flush + save bookmark]
+    classDef proc fill:#eceff8,stroke:#7986cb,stroke-width:1.5px,color:#303f9f
+    classDef store fill:#f3e5f5,stroke:#ab47bc,stroke-width:1.5px,color:#6a1b9a
+    classDef sink fill:#e3f2fd,stroke:#42a5f5,stroke-width:1.5px,color:#1565c0
+    class P1,P2,P3 proc
+    class CK store
+    class W1,W2,W3 sink
 ```
 
 Read a page, write a page, move on. Only one page is ever in memory, so it
@@ -276,9 +298,17 @@ When several of the *data-guarding* tools are on, the pipeline runs them in a
 fixed, safe order on each page — chosen to be *safe*, not arbitrary:
 
 ```mermaid
-%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
+%%{init: {'theme':'base','flowchart':{'curve':'basis','nodeSpacing':50,'rankSpacing':72,'padding':14},'themeVariables':{'fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif','fontSize':'14px','lineColor':'#a5b4c4','clusterBkg':'#f8fafc','clusterBorder':'#e2e8f0'}}}%%
 flowchart LR
     PAGE[page arrives] --> MASK[1 mask PII] --> Q[2 quality] --> C[3 contract] --> D[4 schema drift] --> WRITE[5 write to sink] --> FLUSH[flush] --> CK[save bookmark]
+    classDef src fill:#e0f2f1,stroke:#26a69a,stroke-width:1.5px,color:#00695c
+    classDef proc fill:#eceff8,stroke:#7986cb,stroke-width:1.5px,color:#303f9f
+    classDef store fill:#f3e5f5,stroke:#ab47bc,stroke-width:1.5px,color:#6a1b9a
+    classDef sink fill:#e3f2fd,stroke:#42a5f5,stroke-width:1.5px,color:#1565c0
+    class PAGE src
+    class MASK,Q,C,D,FLUSH proc
+    class CK store
+    class WRITE sink
 ```
 
 Masking is first so PII can't leak anywhere. Validation happens before the write

--- a/docs/architecture/masking.md
+++ b/docs/architecture/masking.md
@@ -40,7 +40,7 @@ Under `crates/core/src/masking/`:
 ## Execution flow
 
 ```mermaid
-%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
+%%{init: {'theme':'base','flowchart':{'curve':'basis','nodeSpacing':50,'rankSpacing':72,'padding':14},'themeVariables':{'fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif','fontSize':'14px','lineColor':'#a5b4c4','clusterBkg':'#f8fafc','clusterBorder':'#e2e8f0'}}}%%
 flowchart TD
     PG[StreamPage records] --> MASK[apply_masking — FIRST pass]
     MASK --> Q[quality]
@@ -49,6 +49,14 @@ flowchart TD
     D --> SNK[sink]
     MASK -.masked records also feed.-> DLQ[DLQ envelopes]
     MASK -.and.-> LIN[lineage sample]
+    classDef src fill:#e0f2f1,stroke:#26a69a,stroke-width:1.5px,color:#00695c
+    classDef proc fill:#eceff8,stroke:#7986cb,stroke-width:1.5px,color:#303f9f
+    classDef bad fill:#fdecec,stroke:#ef9a9a,stroke-width:1.5px,color:#c62828
+    classDef sink fill:#e3f2fd,stroke:#42a5f5,stroke-width:1.5px,color:#1565c0
+    class PG src
+    class MASK,Q,C,D,LIN proc
+    class DLQ bad
+    class SNK sink
 ```
 
 Because masking runs first, every downstream observer — sink, DLQ, lineage — sees

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -47,7 +47,7 @@ run.
 ## Execution flow
 
 ```mermaid
-%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
+%%{init: {'theme':'base','flowchart':{'curve':'basis','nodeSpacing':50,'rankSpacing':72,'padding':14},'themeVariables':{'fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif','fontSize':'14px','lineColor':'#a5b4c4','clusterBkg':'#f8fafc','clusterBorder':'#e2e8f0'}}}%%
 flowchart TD
     subgraph run["Pipeline::run"]
         L[Build Labels: pipeline, row, run_id] --> WS[Wrap source/sink/state]
@@ -61,6 +61,18 @@ flowchart TD
     SNK --> FL[faucet_sink_flush_duration_seconds]
     FL --> ST[faucet_state_put_total<br/>faucet_state_put_duration_seconds]
     ST --> RUN[faucet_pipeline_runs_total<br/>faucet_pipeline_run_duration_seconds]
+    classDef src fill:#e0f2f1,stroke:#26a69a,stroke-width:1.5px,color:#00695c
+    classDef proc fill:#eceff8,stroke:#7986cb,stroke-width:1.5px,color:#303f9f
+    classDef dec fill:#fff3e0,stroke:#ffa726,stroke-width:1.5px,color:#e65100
+    classDef good fill:#e8f5e9,stroke:#66bb6a,stroke-width:1.5px,color:#2e7d32
+    classDef store fill:#f3e5f5,stroke:#ab47bc,stroke-width:1.5px,color:#6a1b9a
+    classDef sink fill:#e3f2fd,stroke:#42a5f5,stroke-width:1.5px,color:#1565c0
+    class SP,SRC src
+    class L,WS,TR,QCD,FL proc
+    class P dec
+    class RUN good
+    class ST store
+    class SNK sink
 ```
 
 Every measured operation is also wrapped in a `tracing` span

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -17,7 +17,7 @@ A run is, at its heart, one loop: pull a page of records from a source, protect
 and validate it, write it to a sink, checkpoint, repeat.
 
 ```mermaid
-%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
+%%{init: {'theme':'base','flowchart':{'curve':'basis','nodeSpacing':50,'rankSpacing':72,'padding':14},'themeVariables':{'fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif','fontSize':'14px','lineColor':'#a5b4c4','clusterBkg':'#f8fafc','clusterBorder':'#e2e8f0'}}}%%
 flowchart LR
     subgraph Source
       SP[stream_pages]
@@ -36,6 +36,14 @@ flowchart LR
     WR --> WB
     CK --> SS
     SS -.resume bookmark.-> SP
+    classDef src fill:#e0f2f1,stroke:#26a69a,stroke-width:1.5px,color:#00695c
+    classDef proc fill:#eceff8,stroke:#7986cb,stroke-width:1.5px,color:#303f9f
+    classDef store fill:#f3e5f5,stroke:#ab47bc,stroke-width:1.5px,color:#6a1b9a
+    classDef sink fill:#e3f2fd,stroke:#42a5f5,stroke-width:1.5px,color:#1565c0
+    class SP src
+    class MK,QL,CT,DR,FL,CK proc
+    class SS store
+    class WR,WB sink
 ```
 
 The per-page passes and their fixed order are covered in [schema](./schema.md);
@@ -49,7 +57,7 @@ binary). The topology encodes a hard rule: **connectors depend only on
 `faucet-core`.**
 
 ```mermaid
-%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
+%%{init: {'theme':'base','flowchart':{'curve':'basis','nodeSpacing':50,'rankSpacing':72,'padding':14},'themeVariables':{'fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif','fontSize':'14px','lineColor':'#a5b4c4','clusterBkg':'#f8fafc','clusterBorder':'#e2e8f0'}}}%%
 flowchart TD
     CORE[faucet-core<br/>traits, pipeline, transforms, error, state]
     SRC[faucet-source-*<br/>rest, postgres, kafka, s3, ...]
@@ -67,6 +75,14 @@ flowchart TD
     SNK -.uses.-> CMN
     UMB --> SRC & SNK & STATE
     CLI --> UMB
+    classDef src fill:#e0f2f1,stroke:#26a69a,stroke-width:1.5px,color:#00695c
+    classDef proc fill:#eceff8,stroke:#7986cb,stroke-width:1.5px,color:#303f9f
+    classDef store fill:#f3e5f5,stroke:#ab47bc,stroke-width:1.5px,color:#6a1b9a
+    classDef sink fill:#e3f2fd,stroke:#42a5f5,stroke-width:1.5px,color:#1565c0
+    class SRC src
+    class CMN,UMB,CLI proc
+    class CORE,STATE store
+    class SNK sink
 ```
 
 - **`faucet-core`** — the only crate every connector depends on. Holds the

--- a/docs/architecture/pipeline.md
+++ b/docs/architecture/pipeline.md
@@ -30,7 +30,7 @@ connector can get checkpointing wrong because no connector implements it.
 ## Execution flow
 
 ```mermaid
-%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
+%%{init: {'theme':'base','flowchart':{'curve':'basis','nodeSpacing':50,'rankSpacing':72,'padding':14},'themeVariables':{'fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif','fontSize':'14px','lineColor':'#a5b4c4','clusterBkg':'#f8fafc','clusterBorder':'#e2e8f0'}}}%%
 flowchart TD
     START[Pipeline::run] --> RESUME[resume: read bookmark, apply_start_bookmark]
     RESUME --> SINKANCHOR[exactly-once: re-anchor from sink watermark]
@@ -46,6 +46,16 @@ flowchart TD
     BM -->|no| LOOP
     FLUSH --> LOOP
     LOOP -->|None| DONE[flush + PipelineResult]
+    classDef src fill:#e0f2f1,stroke:#26a69a,stroke-width:1.5px,color:#00695c
+    classDef proc fill:#eceff8,stroke:#7986cb,stroke-width:1.5px,color:#303f9f
+    classDef dec fill:#fff3e0,stroke:#ffa726,stroke-width:1.5px,color:#e65100
+    classDef good fill:#e8f5e9,stroke:#66bb6a,stroke-width:1.5px,color:#2e7d32
+    classDef sink fill:#e3f2fd,stroke:#42a5f5,stroke-width:1.5px,color:#1565c0
+    class START src
+    class RESUME,SINKANCHOR,MASK,FLUSH proc
+    class LOOP,PATH,BM dec
+    class FLUSHOUT,DONE good
+    class WDLQ,WEO,WDEF sink
 ```
 
 ### The three write paths

--- a/docs/architecture/quality.md
+++ b/docs/architecture/quality.md
@@ -34,7 +34,7 @@ Under `crates/core/src/quality/`:
 ## Execution flow
 
 ```mermaid
-%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
+%%{init: {'theme':'base','flowchart':{'curve':'basis','nodeSpacing':50,'rankSpacing':72,'padding':14},'themeVariables':{'fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif','fontSize':'14px','lineColor':'#a5b4c4','clusterBkg':'#f8fafc','clusterBorder':'#e2e8f0'}}}%%
 flowchart TD
     PG[page records] --> RC[per-record checks, declared order, first-failure-wins]
     RC -->|pass| SUR[survivors]
@@ -44,6 +44,16 @@ flowchart TD
     BC -->|unique dup quarantine| DLQ
     BC -->|row_count/null_rate abort| ERR
     BC -->|pass| WR[sink write_batch]
+    classDef src fill:#e0f2f1,stroke:#26a69a,stroke-width:1.5px,color:#00695c
+    classDef proc fill:#eceff8,stroke:#7986cb,stroke-width:1.5px,color:#303f9f
+    classDef good fill:#e8f5e9,stroke:#66bb6a,stroke-width:1.5px,color:#2e7d32
+    classDef bad fill:#fdecec,stroke:#ef9a9a,stroke-width:1.5px,color:#c62828
+    classDef sink fill:#e3f2fd,stroke:#42a5f5,stroke-width:1.5px,color:#1565c0
+    class PG src
+    class RC,BC proc
+    class SUR good
+    class DLQ,ERR bad
+    class WR sink
 ```
 
 Runs inside `run_stream` after the masking pass and before the contract pass (see

--- a/docs/architecture/recovery.md
+++ b/docs/architecture/recovery.md
@@ -16,10 +16,16 @@ A page moves through: `write_batch` → `flush` → `StateStore::put`. A crash c
 in one of two windows:
 
 ```mermaid
-%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
+%%{init: {'theme':'base','flowchart':{'curve':'basis','nodeSpacing':50,'rankSpacing':72,'padding':14},'themeVariables':{'fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif','fontSize':'14px','lineColor':'#a5b4c4','clusterBkg':'#f8fafc','clusterBorder':'#e2e8f0'}}}%%
 flowchart LR
     W[write_batch] -->|window A| F[flush] -->|window B| P[put bookmark]
     P --> NEXT[next page]
+    classDef proc fill:#eceff8,stroke:#7986cb,stroke-width:1.5px,color:#303f9f
+    classDef store fill:#f3e5f5,stroke:#ab47bc,stroke-width:1.5px,color:#6a1b9a
+    classDef sink fill:#e3f2fd,stroke:#42a5f5,stroke-width:1.5px,color:#1565c0
+    class F,NEXT proc
+    class P store
+    class W sink
 ```
 
 - **Window A — crash before flush.** The write may or may not be durable
@@ -48,7 +54,7 @@ faucet-stream solves this by making the **sink's committed watermark the source 
 truth for position**:
 
 ```mermaid
-%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
+%%{init: {'theme':'base','themeVariables':{'fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif','fontSize':'14px','lineColor':'#a5b4c4','clusterBkg':'#f8fafc','clusterBorder':'#e2e8f0'}}}%%
 sequenceDiagram
     participant SS as StateStore
     participant Snk as Sink (watermark)

--- a/docs/architecture/resilience.md
+++ b/docs/architecture/resilience.md
@@ -30,7 +30,7 @@ no `resilience:` block is configured.
 ## How the three mechanisms compose
 
 ```mermaid
-%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
+%%{init: {'theme':'base','flowchart':{'curve':'basis','nodeSpacing':50,'rankSpacing':72,'padding':14},'themeVariables':{'fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif','fontSize':'14px','lineColor':'#a5b4c4','clusterBkg':'#f8fafc','clusterBorder':'#e2e8f0'}}}%%
 flowchart TD
     OP[sink write / flush / state_put] --> RETRY{retriable class?}
     RETRY -->|yes| BACKOFF[backoff + jitter, retry up to max_attempts]
@@ -42,6 +42,14 @@ flowchart TD
     ROW[single bad row] --> POISON{poison policy}
     POISON -->|dlq| Q[route row to DLQ]
     POISON -->|skip| DROP[drop row + warn]
+    classDef src fill:#e0f2f1,stroke:#26a69a,stroke-width:1.5px,color:#00695c
+    classDef proc fill:#eceff8,stroke:#7986cb,stroke-width:1.5px,color:#303f9f
+    classDef dec fill:#fff3e0,stroke:#ffa726,stroke-width:1.5px,color:#e65100
+    classDef bad fill:#fdecec,stroke:#ef9a9a,stroke-width:1.5px,color:#c62828
+    class OP,ROW src
+    class BACKOFF,CONT proc
+    class RETRY,CB,POISON dec
+    class FAILPAGE,OPEN,Q,DROP bad
 ```
 
 - **Retry** handles transient, self-healing failures (see [retries](./retries.md)).

--- a/docs/architecture/retries.md
+++ b/docs/architecture/retries.md
@@ -17,7 +17,7 @@ that downside.
 Retries happen in two distinct places, for two distinct reasons:
 
 ```mermaid
-%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
+%%{init: {'theme':'base','flowchart':{'curve':'basis','nodeSpacing':50,'rankSpacing':72,'padding':14},'themeVariables':{'fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif','fontSize':'14px','lineColor':'#a5b4c4','clusterBkg':'#f8fafc','clusterBorder':'#e2e8f0'}}}%%
 flowchart TD
     subgraph Source side
       REST[rest / xml / graphql] -->|with_retry_policy| RS[execute_with_retry]
@@ -25,6 +25,12 @@ flowchart TD
     subgraph Sink side
       RS2[run_stream with_retry! macro] --> WB[write_batch* / flush / state_put]
     end
+    classDef src fill:#e0f2f1,stroke:#26a69a,stroke-width:1.5px,color:#00695c
+    classDef proc fill:#eceff8,stroke:#7986cb,stroke-width:1.5px,color:#303f9f
+    classDef sink fill:#e3f2fd,stroke:#42a5f5,stroke-width:1.5px,color:#1565c0
+    class REST src
+    class RS,RS2 proc
+    class WB sink
 ```
 
 1. **Source side** — HTTP sources (`rest`, `xml`, `graphql`) retry their own

--- a/docs/architecture/schema.md
+++ b/docs/architecture/schema.md
@@ -35,7 +35,7 @@ policies run per page, in a fixed order, inside `run_stream`.
 ## Execution flow — the per-page pipeline
 
 ```mermaid
-%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
+%%{init: {'theme':'base','flowchart':{'curve':'basis','nodeSpacing':50,'rankSpacing':72,'padding':14},'themeVariables':{'fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif','fontSize':'14px','lineColor':'#a5b4c4','clusterBkg':'#f8fafc','clusterBorder':'#e2e8f0'}}}%%
 flowchart TD
     PG[StreamPage records] --> M[masking pass FIRST]
     M --> Q[quality: per-record then per-batch]
@@ -44,6 +44,14 @@ flowchart TD
     D --> WR[sink write_batch]
     WR --> FL[flush]
     FL --> CK[checkpoint bookmark]
+    classDef src fill:#e0f2f1,stroke:#26a69a,stroke-width:1.5px,color:#00695c
+    classDef proc fill:#eceff8,stroke:#7986cb,stroke-width:1.5px,color:#303f9f
+    classDef store fill:#f3e5f5,stroke:#ab47bc,stroke-width:1.5px,color:#6a1b9a
+    classDef sink fill:#e3f2fd,stroke:#42a5f5,stroke-width:1.5px,color:#1565c0
+    class PG src
+    class M,Q,C,D,FL proc
+    class CK store
+    class WR sink
 ```
 
 The order — **masking → quality → contract → drift** — is enforced in

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -32,7 +32,7 @@ network segmentation, the security of the external systems faucet connects to,
 and the secrecy of the environment faucet runs in.
 
 ```mermaid
-%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
+%%{init: {'theme':'base','flowchart':{'curve':'basis','nodeSpacing':50,'rankSpacing':72,'padding':14},'themeVariables':{'fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif','fontSize':'14px','lineColor':'#a5b4c4','clusterBkg':'#f8fafc','clusterBorder':'#e2e8f0'}}}%%
 flowchart LR
     subgraph Trusted[Trust boundary: the faucet process]
       cfg[config + resolved secrets in memory]
@@ -45,6 +45,16 @@ flowchart LR
     eng --> state[(state store)]
     eng --> dlq[(DLQ)]
     client[serve HTTP client] -->|bearer + RBAC| eng
+    classDef src fill:#e0f2f1,stroke:#26a69a,stroke-width:1.5px,color:#00695c
+    classDef proc fill:#eceff8,stroke:#7986cb,stroke-width:1.5px,color:#303f9f
+    classDef bad fill:#fdecec,stroke:#ef9a9a,stroke-width:1.5px,color:#c62828
+    classDef store fill:#f3e5f5,stroke:#ab47bc,stroke-width:1.5px,color:#6a1b9a
+    classDef sink fill:#e3f2fd,stroke:#42a5f5,stroke-width:1.5px,color:#1565c0
+    class src,SM,client src
+    class cfg,eng proc
+    class dlq bad
+    class state store
+    class snk,logs sink
 ```
 
 ## Credentials and secrets

--- a/docs/architecture/state-management.md
+++ b/docs/architecture/state-management.md
@@ -37,7 +37,7 @@ correct ordering. See [ADR 0006](../adr/0006-state-management.md).
 ## How a bookmark flows
 
 ```mermaid
-%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
+%%{init: {'theme':'base','themeVariables':{'fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif','fontSize':'14px','lineColor':'#a5b4c4','clusterBkg':'#f8fafc','clusterBorder':'#e2e8f0'}}}%%
 sequenceDiagram
     participant SS as StateStore
     participant P as Pipeline

--- a/docs/architecture/stream-pages.md
+++ b/docs/architecture/stream-pages.md
@@ -45,7 +45,7 @@ correct). Connectors that can stream from their underlying primitive **override*
 `stream_pages` to be truly incremental:
 
 ```mermaid
-%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
+%%{init: {'theme':'base','flowchart':{'curve':'basis','nodeSpacing':50,'rankSpacing':72,'padding':14},'themeVariables':{'fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif','fontSize':'14px','lineColor':'#a5b4c4','clusterBkg':'#f8fafc','clusterBorder':'#e2e8f0'}}}%%
 flowchart LR
     subgraph Native override
       DB[(database cursor)] --> P1[page] --> P2[page] --> P3[page bookmark]
@@ -53,6 +53,10 @@ flowchart LR
     subgraph Default impl
       FA[fetch_all buffers everything] --> CH[chunk into pages]
     end
+    classDef src fill:#e0f2f1,stroke:#26a69a,stroke-width:1.5px,color:#00695c
+    classDef proc fill:#eceff8,stroke:#7986cb,stroke-width:1.5px,color:#303f9f
+    class DB,FA src
+    class P1,P2,P3,CH proc
 ```
 
 Sources that override for native streaming include `rest`, `postgres`, all three

--- a/docs/contributing/architecture.md
+++ b/docs/contributing/architecture.md
@@ -13,7 +13,7 @@ faucet-stream is a Cargo workspace of ~63 crates. They fall into four layers,
 and the dependency direction only ever flows downward:
 
 ```mermaid
-%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
+%%{init: {'theme':'base','flowchart':{'curve':'basis','nodeSpacing':50,'rankSpacing':72,'padding':14},'themeVariables':{'fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif','fontSize':'14px','lineColor':'#a5b4c4','clusterBkg':'#f8fafc','clusterBorder':'#e2e8f0'}}}%%
 flowchart TD
     CLI["faucet-cli (cli/)<br/>config · expand · executor · serve · schedule · replicate · backfill"]
     UMB["faucet-stream (faucet-stream/)<br/>umbrella: feature-gated re-exports"]
@@ -25,6 +25,12 @@ flowchart TD
     UMB --> CONN
     CONN --> CORE
     CLI --> CORE
+    classDef src fill:#e0f2f1,stroke:#26a69a,stroke-width:1.5px,color:#00695c
+    classDef proc fill:#eceff8,stroke:#7986cb,stroke-width:1.5px,color:#303f9f
+    classDef store fill:#f3e5f5,stroke:#ab47bc,stroke-width:1.5px,color:#6a1b9a
+    class CLI src
+    class UMB,CONN proc
+    class CORE store
 ```
 
 The invariant that keeps the ecosystem healthy: **every connector crate depends
@@ -59,7 +65,7 @@ When you need to understand how a record actually moves, read the layers in the
 order the data does. Each hop below has a "start here" file:
 
 ```mermaid
-%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
+%%{init: {'theme':'base','flowchart':{'curve':'basis','nodeSpacing':50,'rankSpacing':72,'padding':14},'themeVariables':{'fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif','fontSize':'14px','lineColor':'#a5b4c4','clusterBkg':'#f8fafc','clusterBorder':'#e2e8f0'}}}%%
 flowchart LR
     A["YAML/JSON config"] --> B["cli/src/config.rs<br/>parse + interpolate + secrets"]
     B --> C["cli/src/expand.rs<br/>matrix → ExpandedNode[]"]
@@ -67,6 +73,12 @@ flowchart LR
     D --> E["Pipeline::run<br/>crates/core/src/pipeline.rs"]
     E --> F["run_stream loop<br/>mask → quality → contract → drift → write → flush → checkpoint"]
     F --> G["Source::stream_pages / Sink::write_batch<br/>crates/{source,sink}/*"]
+    classDef src fill:#e0f2f1,stroke:#26a69a,stroke-width:1.5px,color:#00695c
+    classDef proc fill:#eceff8,stroke:#7986cb,stroke-width:1.5px,color:#303f9f
+    classDef sink fill:#e3f2fd,stroke:#42a5f5,stroke-width:1.5px,color:#1565c0
+    class A src
+    class B,C,D,E,F proc
+    class G sink
 ```
 
 1. **Config** — `cli/src/config.rs` defines `PipelineConfig`; `interpolate.rs`,

--- a/docs/contributing/debugging.md
+++ b/docs/contributing/debugging.md
@@ -7,7 +7,7 @@ real infrastructure. Reach for the offline tools first; they catch most
 problems in seconds.
 
 ```mermaid
-%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
+%%{init: {'theme':'base','flowchart':{'curve':'basis','nodeSpacing':50,'rankSpacing':72,'padding':14},'themeVariables':{'fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif','fontSize':'14px','lineColor':'#a5b4c4','clusterBkg':'#f8fafc','clusterBorder':'#e2e8f0'}}}%%
 flowchart TD
     A["Pipeline misbehaving"] --> B["faucet validate<br/>config, gates, secret refs"]
     B --> C["faucet doctor<br/>preflight probe each connector"]
@@ -15,6 +15,12 @@ flowchart TD
     D --> E["faucet preview<br/>first root, no writes"]
     E --> F["faucet run --log-level debug<br/>real run + tracing"]
     F --> G["metrics + faucet dlq inspect<br/>observe in flight / after"]
+    classDef src fill:#e0f2f1,stroke:#26a69a,stroke-width:1.5px,color:#00695c
+    classDef proc fill:#eceff8,stroke:#7986cb,stroke-width:1.5px,color:#303f9f
+    classDef good fill:#e8f5e9,stroke:#66bb6a,stroke-width:1.5px,color:#2e7d32
+    class A src
+    class B,C,D,E,F proc
+    class G good
 ```
 
 ## Offline first

--- a/docs/contributing/performance.md
+++ b/docs/contributing/performance.md
@@ -45,12 +45,20 @@ the harness, not intuition. The benchmark VM and scenarios are documented there
 (Scenario C is the head-to-head throughput comparison).
 
 ```mermaid
-%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
+%%{init: {'theme':'base','flowchart':{'curve':'basis','nodeSpacing':50,'rankSpacing':72,'padding':14},'themeVariables':{'fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif','fontSize':'14px','lineColor':'#a5b4c4','clusterBkg':'#f8fafc','clusterBorder':'#e2e8f0'}}}%%
 flowchart LR
     A["hypothesis:<br/>'X is slow'"] --> B["measure with BENCHMARKS.md harness"]
     B --> C{evidence of a<br/>real bottleneck?}
     C -- yes --> D["change + re-measure<br/>report before/after"]
     C -- no --> E["leave it alone"]
+    classDef src fill:#e0f2f1,stroke:#26a69a,stroke-width:1.5px,color:#00695c
+    classDef proc fill:#eceff8,stroke:#7986cb,stroke-width:1.5px,color:#303f9f
+    classDef dec fill:#fff3e0,stroke:#ffa726,stroke-width:1.5px,color:#e65100
+    classDef good fill:#e8f5e9,stroke:#66bb6a,stroke-width:1.5px,color:#2e7d32
+    class A src
+    class B proc
+    class C dec
+    class D,E good
 ```
 
 ## What NOT to do

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -30,12 +30,18 @@ your changed lines.** If a line "can't" be unit-tested, that is usually a design
 smell — extract the pure logic and make the I/O a thin shim:
 
 ```mermaid
-%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
+%%{init: {'theme':'base','flowchart':{'curve':'basis','nodeSpacing':50,'rankSpacing':72,'padding':14},'themeVariables':{'fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif','fontSize':'14px','lineColor':'#a5b4c4','clusterBkg':'#f8fafc','clusterBorder':'#e2e8f0'}}}%%
 flowchart LR
     A["new / changed code"] --> B{needs real I/O?}
     B -- no --> C["#[cfg(test)] unit test<br/>counts toward patch coverage"]
     B -- yes --> D["extract pure logic → unit test it<br/>keep I/O a thin shim"]
     D --> E["cover the shim with wiremock/testcontainers<br/>(does NOT count toward patch)"]
+    classDef src fill:#e0f2f1,stroke:#26a69a,stroke-width:1.5px,color:#00695c
+    classDef proc fill:#eceff8,stroke:#7986cb,stroke-width:1.5px,color:#303f9f
+    classDef dec fill:#fff3e0,stroke:#ffa726,stroke-width:1.5px,color:#e65100
+    class A src
+    class C,D,E proc
+    class B dec
 ```
 
 Genuinely untestable surface (a SIGTERM handler, a `main()` dispatch arm, an

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -49,13 +49,21 @@ agreed before code exists.
 ## Lifecycle
 
 ```mermaid
-%%{init: {'theme':'base','themeVariables':{'primaryColor':'#ccfbf1','primaryTextColor':'#0f172a','primaryBorderColor':'#0d9488','lineColor':'#0f766e','secondaryColor':'#e0f2fe','tertiaryColor':'#f0fdfa','fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif'}}}%%
+%%{init: {'theme':'base','flowchart':{'curve':'basis','nodeSpacing':50,'rankSpacing':72,'padding':14},'themeVariables':{'fontFamily':'-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif','fontSize':'14px','lineColor':'#a5b4c4','clusterBkg':'#f8fafc','clusterBorder':'#e2e8f0'}}}%%
 flowchart LR
     Draft --> Discussion
     Discussion -->|consensus| Accepted
     Discussion -->|no| Rejected
     Accepted --> Implemented
     Implemented -.distills into.-> ADR[docs/adr/*.md]
+    classDef src fill:#e0f2f1,stroke:#26a69a,stroke-width:1.5px,color:#00695c
+    classDef proc fill:#eceff8,stroke:#7986cb,stroke-width:1.5px,color:#303f9f
+    classDef good fill:#e8f5e9,stroke:#66bb6a,stroke-width:1.5px,color:#2e7d32
+    classDef bad fill:#fdecec,stroke:#ef9a9a,stroke-width:1.5px,color:#c62828
+    class Draft src
+    class Discussion,ADR proc
+    class Accepted,Implemented good
+    class Rejected bad
 ```
 
 1. **Draft** — copy [`0000-template.md`](./0000-template.md) to


### PR DESCRIPTION
## What

Upgrades all **36 GitHub-viewed Mermaid diagrams** from flat teal-tinted boxes to the approved **V2 style**:

- **Curved edges** (`curve: basis`), tuned node/rank spacing, soft cluster backgrounds.
- **Semantic role-coding** via a shared 7-class `classDef` palette — source (teal) · process (indigo) · decision (amber) · commit/success (green) · error/DLQ (rose) · state store (purple) · sink (blue).
- **32 flowcharts** get full role-coding; **4 sequence diagrams** get the init-line refresh only.

## Scope

`README.md`, `docs/README.md`, `rfcs/README.md`, `docs/adr/*`, `docs/contributing/*`, and all 21 `docs/architecture/*` diagrams. **`docs/book/` is untouched** (themed by the `mdbook-mermaid` preprocessor + site CSS).

## Validation

Every one of the 36 blocks was render-validated (HTTP 200 via mermaid.ink, the same renderer GitHub uses) — **0 broken**. Diagram logic is preserved exactly; only the init line was swapped and `classDef`/`class` lines appended.