### PR TITLE
ci(docs): add workflow_dispatch to docs deploy (re-ships pending teal theme)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,11 @@ name: Docs site
 # to "GitHub Actions" (Settings → Pages → Build and deployment → GitHub Actions).
 
 on:
+  # Manual trigger so the site can be re-deployed on demand — e.g. when a docs
+  # change lands via a PR that did NOT touch docs/book/** (the path filter below
+  # only fires the deploy on docs/book changes, so a teal-theme rebuild can be
+  # forced from the Actions tab without a dummy commit).
+  workflow_dispatch:
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
The teal docs-site theme (#332) has been on `main` but never deployed — its docs-deploy run got superseded in the concurrency group, and later PRs touched only `docs/architecture` (not `docs/book/**`), so the path filter never re-triggered a deploy. This adds `workflow_dispatch` for on-demand re-deploys, and **merging it re-fires the docs deploy** (it touches `.github/workflows/docs.yml`), shipping the teal theme + wider column that are already on main.