### PR TITLE
docs: recolor sidebar active-section accent bar teal (kills the indigo line)

### DIFF
--- a/docs/book/custom.css
+++ b/docs/book/custom.css
@@ -25,6 +25,7 @@
   --sidebar-active: #0d5c54;
   --sidebar-spacer: rgba(15, 118, 110, 0.16);
   --scrollbar: rgba(15, 118, 110, 0.35);
+  --sidebar-header-border-color: #0f766e; /* the active-section accent bar → teal, not the stock indigo */
   --links: #0f766e;
 }
 
@@ -39,6 +40,7 @@
   --sidebar-active: #ffffff;
   --sidebar-spacer: rgba(255, 255, 255, 0.1);
   --scrollbar: rgba(255, 255, 255, 0.28);
+  --sidebar-header-border-color: #2dd4bf; /* the active-section accent bar → teal, not the stock indigo */
   --links: #2dd4bf;
 }
 


### PR DESCRIPTION
The 'blue-purple line on expanding a section' was mdBook's `--sidebar-header-border-color` default (`#6e6edb` indigo) — the 4px accent bar on the expanded/active section. Verified via pixel-sampling the rendered sidebar. Overrides it to teal per theme (deep teal on the light sidebar, bright teal on the dark), so the accent belongs to the palette. Confirmed locally: 0 indigo pixels, the bar renders `#0f766e`.