### PR TITLE
docs: fix muddy teal-on-teal — high-contrast text, clean white content

### DIFF
--- a/docs/book/custom.css
+++ b/docs/book/custom.css
@@ -18,14 +18,13 @@
    in the reading area so the two surfaces belong to one palette. ──────────── */
 .light,
 .rust {
-  --bg: #f8fcfb; /* content: near-white with a hint of teal */
-  --sidebar-bg: #d5f2ec; /* soft light teal, from the logo family */
-  --sidebar-fg: #124f4a; /* dark teal — easy to read on light teal */
-  --sidebar-non-existant: #78b3ab;
-  --sidebar-active: #0d5c54;
-  --sidebar-spacer: rgba(15, 118, 110, 0.16);
-  --scrollbar: rgba(15, 118, 110, 0.35);
-  --sidebar-header-border-color: #0f766e; /* the active-section accent bar → teal, not the stock indigo */
+  --sidebar-bg: #d7f2ec; /* soft light teal, from the logo family */
+  --sidebar-fg: #1c2b3a; /* dark slate — crisp, high-contrast on light teal */
+  --sidebar-non-existant: #6b8a86;
+  --sidebar-active: #0f766e;
+  --sidebar-spacer: rgba(28, 43, 58, 0.12);
+  --scrollbar: rgba(28, 43, 58, 0.28);
+  --sidebar-header-border-color: #0f766e; /* active-section accent bar → teal, not the stock indigo */
   --links: #0f766e;
 }
 
@@ -176,7 +175,7 @@ mark {
 .content h2 {
   margin-top: 2.3rem;
   padding-bottom: 0.2em;
-  border-bottom: 1px solid color-mix(in srgb, var(--fs-teal) 15%, transparent);
+  border-bottom: 1px solid var(--table-border-color, rgba(0, 0, 0, 0.08));
 }
 .content pre {
   border-radius: 8px;


### PR DESCRIPTION
Third round of docs-theme feedback ('still not clean; the original was cleaner'). The root cause was **teal-on-teal everywhere → low contrast → muddy**. Fix: pull teal back to an accent.

- **Sidebar text → crisp dark slate** (`#1c2b3a`) on the light-teal panel — high contrast, readable (was teal-green on teal, the muddy part).
- **Reading area → clean white** (dropped the teal background tint).
- **H2 underline → neutral** hairline (was teal).
- Teal stays as the *accent*: sidebar panel, active-item, links, card headings, active-section bar — cohesive, not a wash.

Verified with a rendered screenshot: crisp dark sidebar text, pure-white content.