### PR TITLE
docs: even out sidebar spacing (top-level matches nested rhythm)

### DIFF
--- a/docs/book/custom.css
+++ b/docs/book/custom.css
@@ -66,13 +66,13 @@
   padding: 0.6rem 0.8rem;
 }
 .chapter li.chapter-item {
-  margin: 0.12rem 0;
-  line-height: 1.5;
+  margin: 0.04rem 0;
+  line-height: 1.85; /* match the roomy rhythm mdBook gives nested sections */
 }
 .chapter li.chapter-item > a,
 .chapter li.chapter-item > div {
   border-radius: 7px;
-  padding: 0.28rem 0.55rem;
+  padding: 0.32rem 0.55rem;
   transition: background 0.13s ease, color 0.13s ease;
 }
 .chapter li.chapter-item > a:hover {


### PR DESCRIPTION
The top-level nav items were cramped (line-height 1.5) while mdBook gives nested sections a roomy 1.9em. Bumped the chapter-item line-height to 1.85 so the whole sidebar has the same clean, roomy rhythm — no more tight-parent vs airy-child. Verified via a cropped sidebar screenshot.