### PR TITLE
docs: mermaid useMaxWidth (fit wide flows to the column)

### DIFF
--- a/docs/book/custom.css
+++ b/docs/book/custom.css
@@ -189,6 +189,11 @@ mark {
 .content .mermaid {
   margin: 1.5rem 0;
   text-align: center;
+  overflow-x: auto;
+}
+.content .mermaid svg {
+  max-width: 100%;
+  height: auto;
 }
 
 /* ── Landing hero + cards (introduction.md) ───────────────────────────────── */

--- a/docs/book/mermaid-init.js
+++ b/docs/book/mermaid-init.js
@@ -62,7 +62,7 @@
         startOnLoad: true,
         theme: 'base',
         themeVariables: lastThemeWasLight ? lightVars : darkVars,
-        flowchart: { htmlLabels: true, padding: 12 },
+        flowchart: { htmlLabels: true, padding: 12, useMaxWidth: true, nodeSpacing: 36, rankSpacing: 44 },
     });
 
     // Re-render diagrams in the new palette when the reader switches theme.


### PR DESCRIPTION
Adds the pending resize fix to the (already-green) mermaid diagrams: `flowchart.useMaxWidth: true` + nodeSpacing/rankSpacing in mermaid-init.js, and a CSS guard (`.mermaid svg { max-width:100%; height:auto }` + `overflow-x:auto`). Green theme untouched. Verified the commit contains both edits.