### PR TITLE
docs: constrain mermaid diagrams to the text column (fix overflow)

### DIFF
--- a/docs/book/custom.css
+++ b/docs/book/custom.css
@@ -168,7 +168,7 @@ mark {
 }
 .content table,
 .content pre,
-.content .mermaid,
+
 .content .fs-hero,
 .content .fs-cards {
   max-width: none;
@@ -188,6 +188,7 @@ mark {
 }
 .content .mermaid {
   margin: 1.5rem 0;
+  max-width: 46rem;
   text-align: center;
   overflow-x: auto;
 }


### PR DESCRIPTION
The Learn-page diagrams overflowed to the right of the text because `.content .mermaid` was `max-width: none` (full 62rem) while prose caps at 46rem. Cap the diagram at 46rem so it scales to the text width and aligns with it. Verified by rendered screenshot: Chapter-4 flow now fits within the text column.