### PR TITLE
docs: WS-11 — Airflow/Dagster+dbt orchestration recipe & evergreen posts (#314)

### DIFF
--- a/README.md
+++ b/README.md
@@ -818,6 +818,7 @@ cli/                          — faucet-cli: `faucet` binary, YAML/JSON pipelin
   examples/                   — ready-to-run pipeline YAMLs
   tests/                      — assert_cmd + wiremock integration tests
 examples/                     — repo-level examples: docker-compose infra stack + run index
+  orchestration/              — ELT recipe: faucet (EL) + dbt (T) + Airflow/Dagster
 scripts/                      — helper scripts (try-local.sh interactive demo, cleanup-artifacts.sh)
 docs/book/                    — mdBook documentation site (source under docs/book/src)
 .github/workflows/            — ci.yml, release-plz.yml, docs.yml (mdBook → GitHub Pages)

--- a/docs/blog/README.md
+++ b/docs/blog/README.md
@@ -1,0 +1,16 @@
+# Blog / evergreen posts
+
+Long-form, evergreen content for cross-posting (dev.to, Hashnode, Medium,
+lobste.rs) and for feeding the per-release publicity checklist in
+[`../launch/RELEASE_PUBLICITY.md`](../launch/RELEASE_PUBLICITY.md). Every post is
+grounded in real, shipped configs from [`cli/examples/`](../../cli/examples) —
+edit voice/framing for the target platform before publishing, but keep the
+technical claims accurate to the code.
+
+| Post | Type | Grounded in |
+|------|------|-------------|
+| [Exactly-once delivery without a broker](exactly-once-without-a-broker.md) | Engineering deep-dive | `cli/examples/kafka_to_postgres_exactly_once.yaml`, the `delivery: exactly_once` machinery |
+| [Migrating from Meltano/Singer to faucet-stream](migrating-from-meltano.md) | Migration guide | `cli/examples/rest_to_postgres.yaml`, the vs-Meltano comparison |
+
+When you publish one, link it from the relevant `docs/book/src/comparison/*.md`
+page and add the URL to the release-publicity checklist so it gets syndicated.

--- a/docs/blog/exactly-once-without-a-broker.md
+++ b/docs/blog/exactly-once-without-a-broker.md
@@ -1,0 +1,141 @@
+# Exactly-once delivery without a broker
+
+*An engineering deep-dive into how faucet-stream delivers effectively-once
+without Kafka transactions, a two-phase commit coordinator, or an external
+dedup store — just a commit token that rides along with your data.*
+
+> Grounded in [`cli/examples/kafka_to_postgres_exactly_once.yaml`](https://github.com/PawanSikawat/faucet-stream/blob/main/cli/examples/kafka_to_postgres_exactly_once.yaml).
+> Reflects faucet-stream as of 2026-07.
+
+## The problem
+
+Move data from A to B, and sooner or later a run dies halfway — a network blip, a
+deploy, an OOM. When it restarts, you get one of two bad outcomes:
+
+- **At-most-once**: you advanced your read position *before* the write landed, so
+  the crash ate the in-flight batch. Data lost.
+- **At-least-once**: you advanced your read position *after* the write, but the
+  crash happened in between, so the restart re-reads and re-writes the batch.
+  Duplicates.
+
+The usual fix is heavy: Kafka's transactional producer, an external two-phase
+commit, or a dedup table keyed on every record. All of them add a moving part
+you now have to operate.
+
+faucet-stream takes a smaller path. The insight: **the only durable fact that
+matters is "which records has the destination already accepted?" — so store that
+fact *in the destination*, atomically with the data itself.**
+
+## The setup
+
+Exactly-once in faucet composes three things, and validation rejects the config
+if any is missing:
+
+1. A **positional-replay source** — one whose stream position is an immutable,
+   re-readable coordinate. Kafka (partition offsets), Postgres/MySQL/MongoDB CDC
+   (log positions). You can ask it "give me everything after position X" and get
+   a deterministic answer.
+2. An **idempotent sink** — one that can commit rows *and* a watermark in a
+   single atomic unit. Eleven sinks qualify today (Postgres, MySQL, SQLite,
+   MSSQL, BigQuery, Snowflake, Spanner, MongoDB, Redis, Kafka, Iceberg).
+3. A **durable state store** — file, Redis, or Postgres. `memory` is rejected.
+
+You ask for it with one line:
+
+```yaml
+delivery: exactly_once
+```
+
+`faucet validate` then reports the guarantee it derived, per row:
+
+```
+delivery=effectively-once (atomic watermark)
+```
+
+Note the honest word: **effectively-once**, not a physics-defying "exactly-once."
+No record is duplicated and none is skipped from the *consumer's* perspective —
+which is what people actually mean when they say exactly-once.
+
+## The mechanism: a commit token in the destination
+
+Here's the whole trick. Each page faucet reads from the source carries a
+**complete bookmark** — for Kafka, the next offset for every partition in the
+page. When the sink writes that page, it does **not** just insert the rows. It
+inserts the rows **and** a monotonic **commit token** — which embeds that
+bookmark — inside **one transaction**.
+
+For the Postgres sink, that token lives in a `_faucet_commit_token` watermark
+table. The transaction looks like:
+
+```sql
+BEGIN;
+  INSERT INTO orders_events (...) VALUES ...;         -- the page's rows
+  UPDATE _faucet_commit_token SET token = <bookmark>; -- the watermark
+COMMIT;
+```
+
+Because both statements are in the same transaction, they are **all-or-nothing**.
+There is no window where the rows exist but the watermark doesn't, or vice versa.
+The destination's own ACID guarantee is doing the coordination — no external
+coordinator required.
+
+## What happens on a crash
+
+Walk the dangerous window: the sink has `COMMIT`ted, but the process dies
+*before* faucet persists the bookmark to the state store. Naively, the restart
+would re-read from the last state-store position and duplicate the page.
+
+faucet doesn't trust the state store as the source of truth here. On resume, it
+reads the **commit token back out of the sink's watermark table**, and
+re-anchors the source consumer to *that* position — not the (possibly stale)
+state-store bookmark. The sink knows the truth about what it accepted, because
+the truth was committed atomically with the data.
+
+So:
+
+- Rows committed, watermark committed, state store stale → resume from the
+  **watermark**, skip what's already there. No duplicates.
+- Transaction never committed → the rows were rolled back too; resume re-reads
+  and writes them for the first time. No loss.
+
+This works **even though page boundaries can differ on replay.** Kafka might
+hand you differently-sized pages the second time; doesn't matter, because the
+watermark is a stream *position*, not a page identity. faucet skips everything at
+or before the recovered position regardless of how it's re-chunked.
+
+## Why not just use Kafka transactions?
+
+You can — the Kafka *sink* uses a transactional producer for its effectively-once
+path. But the watermark approach generalizes to sinks that have **no** notion of
+producer transactions: Postgres, BigQuery, Spanner, MongoDB. As long as the sink
+can commit "data + one extra row" atomically, it gets effectively-once for free,
+with the same mental model across all eleven. One pattern, not eleven
+special-cases.
+
+It also means **no dedup table keyed on every record** — the watermark is O(1)
+per page, not O(rows). You're storing one position, not a set of every id you've
+ever seen.
+
+## The keyed-upsert alternative
+
+Positional replay isn't the only route. If your source isn't a log but your sink
+is upsert-capable, you get idempotency a different way: write with
+`write_mode: upsert` keyed on the primary key. A replayed row overwrites itself
+instead of duplicating. That's a weaker guarantee (it needs a stable key and
+last-write-wins semantics) but it covers non-log sources into any of the eight
+upsert-capable sinks. See the [upsert cookbook](https://pawansikawat.github.io/faucet-stream/cookbook/upsert.html).
+
+## Try it
+
+```bash
+export DEST_PG_URL=postgres://faucet:faucet@localhost:5432/warehouse
+faucet run cli/examples/kafka_to_postgres_exactly_once.yaml
+```
+
+Kill it mid-run. Restart it. Count the rows. They'll be right.
+
+---
+
+*faucet-stream is an MIT/Apache-2.0 Rust library + CLI for moving data between
+28 sources and 21 sinks. [Docs](https://pawansikawat.github.io/faucet-stream/) ·
+[GitHub](https://github.com/PawanSikawat/faucet-stream).*

--- a/docs/blog/migrating-from-meltano.md
+++ b/docs/blog/migrating-from-meltano.md
@@ -1,0 +1,179 @@
+# Migrating from Meltano/Singer to faucet-stream
+
+*A concept-by-concept, config-by-config guide for teams running Singer taps on
+Meltano who want a single fast binary instead of a Python plugin runtime — with
+an honest note on when you shouldn't switch.*
+
+> Grounded in [`cli/examples/rest_to_postgres.yaml`](https://github.com/PawanSikawat/faucet-stream/blob/main/cli/examples/rest_to_postgres.yaml).
+> Reflects both tools as of 2026-07. See the [full comparison](https://pawansikawat.github.io/faucet-stream/comparison/meltano.html)
+> and [our benchmarks](https://github.com/PawanSikawat/faucet-stream/blob/main/BENCHMARKS.md).
+
+## Should you migrate?
+
+Straight answer first, because it makes the rest credible.
+
+**Stay on Meltano if** your first requirement is **connector breadth** — 600+
+Singer taps vs faucet's ~49 built-in connectors. If you depend on a long-tail
+SaaS tap that faucet doesn't have, Meltano wins today, full stop.
+
+**Move to faucet if** you feel the cost of the Python plugin runtime and want:
+
+- **Throughput.** On a reproducible 1M-row CSV→JSONL move, faucet does 712k
+  rows/s in 11.8 MiB vs Meltano's 7.4k rows/s in 724 MiB — output identical
+  row-for-row. Sink-bound moves narrow the gap (the benchmarks show that too,
+  honestly), but the structural win — no per-row Python overhead, bounded
+  streaming memory — is real.
+- **Operational simplicity.** faucet is one static binary. No virtualenv, no
+  plugin resolution, no Python-version matrix to keep green in CI and prod.
+- **Governance in the movement path.** Data quality, versioned data contracts,
+  PII masking (applied before any sink sees a row), schema-drift policy, and
+  lineage are native and zero-config — not assembled from mappers + dbt tests +
+  external tooling.
+
+If you're doing EL→dbt today, note faucet doesn't replace dbt either — see the
+[orchestration recipe](https://pawansikawat.github.io/faucet-stream/cookbook/orchestration.html)
+(faucet for EL, dbt for T, Airflow/Dagster to schedule).
+
+## The mental model maps cleanly
+
+| Meltano / Singer | faucet-stream |
+|---|---|
+| extractor (tap) | a `source` |
+| loader (target) | a `sink` |
+| `meltano.yml` | a `faucet.yaml` `pipeline:` block |
+| Singer `STATE` message | a resumable `state:` bookmark |
+| `replication-method: INCREMENTAL` | `replication_method: { type: Incremental }` |
+| `replication-key` | `replication_key` |
+| stream maps / mappers | `transforms:` (incl. the embedded-DuckDB `sql` transform) |
+| plugin config / env | `${env:VAR}`, `${file:...}`, `${secret:...}` interpolation |
+| `meltano run tap target` | `faucet run pipeline.yaml` |
+
+## Before / after: Stripe charges → Postgres
+
+### Before — Meltano
+
+```yaml
+# meltano.yml
+plugins:
+  extractors:
+    - name: tap-stripe
+      config:
+        client_secret: ${STRIPE_TOKEN}
+      select:
+        - charges.*
+      metadata:
+        charges:
+          replication-method: INCREMENTAL
+          replication-key: created
+  loaders:
+    - name: target-postgres
+      config:
+        host: localhost
+        database: app
+        default_target_schema: public
+```
+
+```bash
+# plus: a virtualenv, `meltano install`, plugin resolution, then:
+meltano run tap-stripe target-postgres
+```
+
+### After — faucet
+
+```yaml
+# faucet.yaml
+version: 1
+name: stripe_charges_to_postgres
+
+pipeline:
+  source:
+    type: rest
+    config:
+      base_url: https://api.stripe.com/v1
+      path: /charges
+      auth:
+        type: bearer
+        config: { token: ${env:STRIPE_TOKEN} }
+      pagination:
+        type: Cursor
+        next_token_path: $.next_page
+        param_name: starting_after
+      replication_method: { type: Incremental }
+      replication_key: created
+      primary_keys: ["id"]
+      state_key: stripe:charges
+
+  transforms:
+    - type: keys_case
+      config: { mode: snake }
+
+  sink:
+    type: postgres
+    config:
+      connection_url: ${env:PG_URL}
+      table_name: stripe_charges
+      column_mapping: { type: jsonb, column: data }
+
+  state:
+    type: file
+    config: { path: ./.faucet-state }
+```
+
+```bash
+cargo install faucet-cli
+faucet run faucet.yaml            # no install/resolve step — one binary
+```
+
+This is a real, runnable config —
+[`cli/examples/rest_to_postgres.yaml`](https://github.com/PawanSikawat/faucet-stream/blob/main/cli/examples/rest_to_postgres.yaml).
+
+## Migration steps
+
+1. **Inventory your taps and targets.** For each, check the
+   [connector catalog](https://pawansikawat.github.io/faucet-stream/reference/connectors.html).
+   Native SaaS taps (Stripe, Shopify, …) usually map onto faucet's generic
+   `rest` / `graphql` source pointed at the same API. Databases, warehouses,
+   files, and streaming systems map to dedicated connectors.
+2. **Translate one pipeline** using the table above. Keep the raw-JSONB landing
+   pattern (`column_mapping: { type: jsonb }`) if you transform downstream in
+   dbt — it mirrors how most Singer targets land data.
+3. **Port your STATE.** faucet keeps its own bookmark in the `state:` store; you
+   don't hand-migrate Singer STATE. On first run, set the initial position via
+   the source's replication config (or just let it do a full initial load).
+4. **`faucet validate faucet.yaml`** — checks the config without running it or
+   touching infra, ideal for CI.
+5. **`faucet preview faucet.yaml --limit 10`** — runs just the source and prints
+   records, so you confirm extraction before wiring the sink.
+6. **Run it, and diff row counts** against your Meltano output for the same
+   window.
+7. **Adopt the governance you were bolting on** — replace mapper-based redaction
+   with native [masking](https://pawansikawat.github.io/faucet-stream/cookbook/masking.html),
+   dbt data tests at the edge with in-path [quality checks](https://pawansikawat.github.io/faucet-stream/cookbook/quality.html)
+   and [contracts](https://pawansikawat.github.io/faucet-stream/cookbook/contracts.html).
+
+## Gotchas
+
+- **No tap for your source?** If it's a REST or GraphQL API, the generic source
+  usually covers it with `pagination` + `auth` config — you're configuring, not
+  writing a plugin. If it's a truly bespoke SaaS with no HTTP-shaped API, that's
+  the case to stay on Meltano (or file a connector request).
+- **Mappers → transforms.** Simple renames/casts/drops map to built-in
+  [record transforms](https://pawansikawat.github.io/faucet-stream/cookbook/transforms.html);
+  anything SQL-shaped maps to the embedded-DuckDB
+  [`sql` transform](https://pawansikawat.github.io/faucet-stream/cookbook/sql-transform.html).
+- **Orchestration.** If you drove Meltano from Airflow, keep Airflow — just swap
+  the `meltano run` call for `faucet run`. See the
+  [orchestration recipe](https://pawansikawat.github.io/faucet-stream/cookbook/orchestration.html).
+
+## Try it in 60 seconds
+
+```bash
+cargo install faucet-cli
+faucet run cli/examples/csv_to_jsonl.yaml   # no infra needed
+```
+
+---
+
+*faucet-stream is an MIT/Apache-2.0 Rust library + CLI for moving data between
+28 sources and 21 sinks. [Docs](https://pawansikawat.github.io/faucet-stream/) ·
+[GitHub](https://github.com/PawanSikawat/faucet-stream).*

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -43,6 +43,7 @@
 - [Adaptive batching](./cookbook/adaptive-batching.md)
 - [Throughput tuning](./cookbook/tuning.md)
 - [Scheduling](./cookbook/scheduling.md)
+- [Orchestration (Airflow / Dagster + dbt)](./cookbook/orchestration.md)
 - [Running faucet as a service](./cookbook/serve.md)
 - [Web console (`serve-ui`)](./cookbook/web-console.md)
 - [Running a cluster](./cookbook/cluster.md)

--- a/docs/book/src/comparison/meltano.md
+++ b/docs/book/src/comparison/meltano.md
@@ -55,7 +55,9 @@ The mental model maps cleanly:
 | Singer `STATE` | a resumable `state:` bookmark |
 | stream maps / mappers | `transforms:` (incl. the `sql` transform) |
 
-Start from [your first pipeline](../getting-started/first-pipeline.md) and the [connector catalog](../reference/connectors.md).
+For a full step-by-step walkthrough with before/after configs, see the
+[**Migrating from Meltano/Singer** guide](https://github.com/PawanSikawat/faucet-stream/blob/main/docs/blog/migrating-from-meltano.md).
+Then start from [your first pipeline](../getting-started/first-pipeline.md) and the [connector catalog](../reference/connectors.md).
 
 ## See for yourself
 

--- a/docs/book/src/cookbook/orchestration.md
+++ b/docs/book/src/cookbook/orchestration.md
@@ -1,0 +1,154 @@
+# Orchestration (Airflow / Dagster + dbt)
+
+faucet is an **EL** engine: it moves data fast and reliably from a source into a
+destination. It is **complementary to dbt**, not a replacement — the idiomatic
+ELT stack loads with faucet and transforms with dbt, scheduled by an
+orchestrator. Because faucet is a single static binary, "orchestrate faucet" is
+just "run a shell command" — there is no plugin runtime to install on your
+workers and no Python-version matrix to keep green.
+
+```
+   REST API ──faucet run──▶ Postgres (raw, JSONB)
+                                │
+                                └──dbt build──▶ analytics.stg_charges (typed, tested)
+                                                     ▲
+                    Airflow DAG / Dagster job runs both steps in order
+```
+
+| Stage | Owner | What it does |
+|-------|-------|--------------|
+| Extract + Load | **faucet** | Pull from the source, land raw lossless rows in the warehouse. Incremental replication + a durable [state bookmark](./state.md) mean each run only fetches new data. |
+| Transform | **dbt** | Build typed, tested models on the raw landing table, inside the warehouse. |
+| Schedule | **Airflow / Dagster** | Run the two steps in order; retry on failure. |
+
+## The runnable recipe
+
+A complete, working example lives at
+[`examples/orchestration/`](https://github.com/PawanSikawat/faucet-stream/tree/main/examples/orchestration):
+
+| File | Role |
+|------|------|
+| `faucet_pipeline.yaml` | EL step — REST → Postgres raw JSONB landing table (based on the shipped [`rest_to_postgres.yaml`](https://github.com/PawanSikawat/faucet-stream/blob/main/cli/examples/rest_to_postgres.yaml)). |
+| `dbt/` | A minimal dbt project — a source over the raw table and a `stg_charges` model that unpacks the JSONB into typed, tested columns. |
+| `airflow_dag.py` | Airflow DAG: `faucet run` → `dbt build`, chained with `>>`. |
+| `dagster_defs.py` | Dagster equivalent: two assets with a dependency edge. |
+
+### Load with faucet
+
+faucet lands the source payload verbatim in a single JSONB column, so the load
+stays lossless and schema-agnostic — dbt does the typed unpacking downstream:
+
+```yaml
+pipeline:
+  source:
+    type: rest
+    config:
+      base_url: https://api.stripe.com/v1
+      path: /charges
+      auth:
+        type: bearer
+        config: { token: ${env:STRIPE_TOKEN} }
+      pagination:
+        type: Cursor
+        next_token_path: $.next_page
+        param_name: starting_after
+      replication_method: { type: Incremental }
+      replication_key: created
+      primary_keys: ["id"]
+      state_key: charges:raw
+  sink:
+    type: postgres
+    config:
+      connection_url: ${env:PG_URL}
+      table_name: charges_raw       # dbt reads this raw landing table
+      column_mapping: { type: jsonb, column: data }
+  state:
+    type: file
+    config: { path: ./.faucet-state }
+```
+
+### Transform with dbt
+
+The staging model reads faucet's raw table as a dbt `source` and casts the JSONB
+fields into typed columns:
+
+```sql
+-- stg_charges.sql — faucet did the lossless load; dbt does the typing.
+select
+    data ->> 'id'                              as charge_id,
+    (data ->> 'amount')::bigint                as amount_cents,
+    data ->> 'currency'                        as currency,
+    data ->> 'status'                          as status,
+    to_timestamp((data ->> 'created')::bigint) as created_at
+from {{ source('raw', 'charges_raw') }}
+```
+
+### Schedule with Airflow
+
+The DAG is two `BashOperator`s with a dependency edge — `faucet run` exits
+non-zero on failure, so Airflow's task-failure handling works with no extra glue:
+
+```python
+extract_load = BashOperator(
+    task_id="faucet_extract_load",
+    bash_command=f"faucet run {FAUCET_CONFIG}",
+)
+dbt_transform = BashOperator(
+    task_id="dbt_build",
+    bash_command=f"dbt build --project-dir {DBT_DIR} --profiles-dir {DBT_DIR}",
+)
+extract_load >> dbt_transform
+```
+
+### Or with Dagster
+
+The same shell-out pattern, expressed as two assets:
+
+```python
+@asset
+def charges_raw(context):
+    subprocess.run(["faucet", "run", str(FAUCET_CONFIG)], check=True)
+
+@asset(deps=[charges_raw])
+def stg_charges(context):
+    subprocess.run(["dbt", "build", "--project-dir", str(DBT_DIR),
+                    "--profiles-dir", str(DBT_DIR)], check=True)
+```
+
+## Why frequent scheduling is cheap
+
+faucet's [incremental replication + durable bookmark](./state.md) mean a run
+scheduled every few minutes only fetches rows newer than the last persisted
+position — not a full re-scan. The bookmark advances only after the sink confirms
+the batch, so a crashed run resumes exactly where it left off. That is what makes
+a `*/15 * * * *` schedule practical rather than wasteful.
+
+## Observe the EL half
+
+Every faucet run emits Prometheus metrics automatically, and faucet ships
+ready-made **Grafana dashboards** and **Prometheus alert rules** — so the EL
+stage of an orchestrated pipeline is observable out of the box (run outcomes,
+throughput, bookmark staleness, retries, DLQ traffic). See
+[Dashboards & alerts](./dashboards.md) for the full set. Bring up the
+pre-provisioned stack alongside the recipe:
+
+```bash
+docker compose -f examples/docker-compose.yml up -d prometheus grafana
+```
+
+Enable the exporter in `faucet_pipeline.yaml`:
+
+```yaml
+observability:
+  prometheus:
+    listen_addr: 0.0.0.0:9464
+```
+
+## See also
+
+- [Scheduling](./scheduling.md) — faucet's own built-in cron (`faucet schedule`),
+  if you'd rather not run a separate orchestrator for simple cases.
+- [Incremental replication & state](./state.md) — how the durable bookmark works.
+- [Dashboards & alerts](./dashboards.md) — the shipped Grafana/Prometheus artifacts.
+- [vs. Meltano](../comparison/meltano.md) — how the faucet + dbt split compares to
+  Singer + dbt.

--- a/docs/launch/RELEASE_PUBLICITY.md
+++ b/docs/launch/RELEASE_PUBLICITY.md
@@ -53,6 +53,9 @@ Front-load the high-signal, low-effort channels; do the rest as time allows.
 7. [ ] **Aggregator refresh (major releases only)** — bump the entry/description on
        AlternativeTo, StackShare, LibHunt, and the awesome-lists (status in
        [`DISTRIBUTION.md`](./DISTRIBUTION.md)).
+8. [ ] **Recirculate an evergreen post** — the deep-dives and migration guides in
+       [`../blog/`](../blog/) don't expire. Each release, re-share one (dev.to / lobste.rs /
+       the relevant subreddit) alongside the changelog post to reach people who missed it.
 
 ## Copy templates
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -53,6 +53,16 @@ These run immediately after installing the CLI — great for a first smoke test:
 > (the configs use a placeholder `base_url`). Edit it to a real API — there's no
 > mock server in the stack.
 
+## Orchestration (Airflow / Dagster + dbt)
+
+[`orchestration/`](orchestration/) is a complete **ELT** recipe: load with
+faucet, transform with dbt, schedule with Airflow or Dagster. faucet is
+complementary to dbt — it owns Extract + Load (raw lossless rows into Postgres),
+dbt owns Transform (typed, tested staging models), and because faucet is a single
+binary the orchestrator just shells out to `faucet run`. See
+[`orchestration/README.md`](orchestration/README.md) and the
+[Orchestration cookbook page](../docs/book/src/cookbook/orchestration.md).
+
 ## Dashboards & alerts
 
 The stack also provisions the shipped observability artifacts (issue #200):

--- a/examples/orchestration/README.md
+++ b/examples/orchestration/README.md
@@ -1,0 +1,90 @@
+# Orchestration: faucet + dbt (Airflow / Dagster)
+
+**Load with faucet, transform with dbt, schedule with your orchestrator.**
+
+faucet is deliberately an **EL** tool — it moves data fast and reliably from a
+source into a destination. It does not replace dbt; the two are complementary.
+The idiomatic ELT stack is:
+
+- **faucet** — Extract + Load. Pulls from the source and lands raw, lossless
+  rows in your warehouse. Incremental replication + a durable bookmark mean each
+  run only fetches new data.
+- **dbt** — Transform. Builds typed, tested models on top of the raw landing
+  table, in the warehouse.
+- **Airflow / Dagster** — orchestration. Because faucet is a single static
+  binary, "orchestrate faucet" is just "run a shell command" — no plugin
+  runtime, no Python-version matrix to keep green.
+
+```
+   REST API ──faucet run──▶ Postgres (raw.charges_raw, JSONB)
+                                │
+                                └──dbt build──▶ analytics.stg_charges (typed, tested)
+                                                     ▲
+                    Airflow DAG / Dagster job runs both steps in order
+```
+
+## What's here
+
+| File | Role |
+|------|------|
+| `faucet_pipeline.yaml` | The EL step — REST → Postgres raw JSONB landing table (based on [`cli/examples/rest_to_postgres.yaml`](../../cli/examples/rest_to_postgres.yaml)). |
+| `dbt/` | A minimal dbt project — a source over `charges_raw` and a `stg_charges` staging model that unpacks the JSONB into typed, tested columns. |
+| `airflow_dag.py` | Airflow DAG: `faucet run` → `dbt build`, chained with `>>`. |
+| `dagster_defs.py` | Dagster equivalent: two assets with a dependency edge. |
+
+## Prerequisites
+
+```bash
+cargo install faucet-cli          # the `faucet` binary
+pip install dbt-postgres          # the `dbt` binary
+# plus apache-airflow or dagster, whichever you orchestrate with
+```
+
+A Postgres to load into — the [examples Docker stack](../README.md) provides one:
+
+```bash
+docker compose -f examples/docker-compose.yml up -d postgres
+export PG_URL=postgres://faucet:faucet@localhost:5432/appdb
+export STRIPE_TOKEN=sk_test_...        # or point the source at any REST API
+```
+
+## Run it by hand first
+
+Prove each step works before handing it to an orchestrator:
+
+```bash
+# 1. EL — faucet lands raw rows in public.charges_raw
+faucet run examples/orchestration/faucet_pipeline.yaml
+
+# 2. T — dbt builds + tests the staging model in the analytics schema
+cd examples/orchestration/dbt
+dbt build --profiles-dir .
+```
+
+`faucet run` exits non-zero on failure, so any orchestrator's task-failure
+handling works without extra glue.
+
+## Then schedule it
+
+- **Airflow** — drop `airflow_dag.py` in your `dags/` folder. It schedules every
+  15 minutes; faucet's durable bookmark makes frequent runs cheap (only new rows
+  are fetched).
+- **Dagster** — `dagster dev -f examples/orchestration/dagster_defs.py`, then
+  materialize the assets or add a schedule.
+
+Both simply shell out to `faucet run` then `dbt build`.
+
+## Observe it
+
+Every faucet run emits Prometheus metrics automatically. faucet ships
+ready-made **Grafana dashboards** and **Prometheus alert rules** (under
+[`observability/`](../../observability)) so the EL half of this pipeline is
+observable out of the box — run outcomes, throughput, bookmark staleness,
+retries, and DLQ traffic. See the
+[Dashboards & alerts cookbook](../../docs/book/src/cookbook/dashboards.md) and
+the [Orchestration cookbook page](../../docs/book/src/cookbook/orchestration.md)
+for the full walkthrough. Bring up the pre-provisioned stack with:
+
+```bash
+docker compose -f examples/docker-compose.yml up -d prometheus grafana
+```

--- a/examples/orchestration/airflow_dag.py
+++ b/examples/orchestration/airflow_dag.py
@@ -1,0 +1,54 @@
+"""Airflow DAG: EL with faucet, T with dbt.
+
+faucet is a single static binary, so orchestration is just "shell out to it" —
+no plugin runtime, no Python-version matrix. This DAG runs the faucet EL config
+to land raw rows in Postgres, then runs `dbt build` to transform + test them.
+
+Drop this file in your Airflow `dags/` folder. It assumes the `faucet` and
+`dbt` binaries are on the worker's PATH (`cargo install faucet-cli`;
+`pip install dbt-postgres`) and that the pipeline's env vars (PG_URL,
+STRIPE_TOKEN, and the dbt PG* vars) are set in the worker environment.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from airflow import DAG
+from airflow.operators.bash import BashOperator
+
+HERE = Path(__file__).resolve().parent
+FAUCET_CONFIG = HERE / "faucet_pipeline.yaml"
+DBT_DIR = HERE / "dbt"
+
+default_args = {
+    "retries": 2,
+    "retry_delay": timedelta(minutes=1),
+}
+
+with DAG(
+    dag_id="faucet_charges_elt",
+    description="EL with faucet, T with dbt",
+    schedule="*/15 * * * *",  # faucet's durable bookmark makes frequent runs cheap
+    start_date=datetime(2026, 1, 1),
+    catchup=False,
+    default_args=default_args,
+    tags=["faucet", "dbt", "elt"],
+) as dag:
+    # Extract + Load: faucet fetches new charges and lands them in Postgres.
+    # `faucet run` exits non-zero on failure, so Airflow marks the task failed.
+    extract_load = BashOperator(
+        task_id="faucet_extract_load",
+        bash_command=f"faucet run {FAUCET_CONFIG}",
+    )
+
+    # Transform + test: dbt builds the staging models over the raw load.
+    dbt_transform = BashOperator(
+        task_id="dbt_build",
+        bash_command=f"dbt build --project-dir {DBT_DIR} --profiles-dir {DBT_DIR}",
+        env={**os.environ, "DBT_PROFILES_DIR": str(DBT_DIR)},
+    )
+
+    extract_load >> dbt_transform

--- a/examples/orchestration/dagster_defs.py
+++ b/examples/orchestration/dagster_defs.py
@@ -1,0 +1,49 @@
+"""Dagster definitions: EL with faucet, T with dbt.
+
+The same shell-out pattern as the Airflow DAG, expressed as two Dagster assets
+with a dependency edge. faucet being a single binary keeps the op bodies to a
+one-line subprocess call — no runtime to embed.
+
+Run the UI with:
+    dagster dev -f examples/orchestration/dagster_defs.py
+
+Assumes `faucet` and `dbt` are on PATH and the pipeline env vars are set.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from dagster import AssetExecutionContext, Definitions, asset
+
+HERE = Path(__file__).resolve().parent
+FAUCET_CONFIG = HERE / "faucet_pipeline.yaml"
+DBT_DIR = HERE / "dbt"
+
+
+@asset
+def charges_raw(context: AssetExecutionContext) -> None:
+    """Extract + Load: faucet lands raw charges in Postgres."""
+    context.log.info("Running faucet EL")
+    subprocess.run(["faucet", "run", str(FAUCET_CONFIG)], check=True)
+
+
+@asset(deps=[charges_raw])
+def stg_charges(context: AssetExecutionContext) -> None:
+    """Transform + test: dbt builds the staging models over the raw load."""
+    context.log.info("Running dbt build")
+    subprocess.run(
+        [
+            "dbt",
+            "build",
+            "--project-dir",
+            str(DBT_DIR),
+            "--profiles-dir",
+            str(DBT_DIR),
+        ],
+        check=True,
+    )
+
+
+defs = Definitions(assets=[charges_raw, stg_charges])

--- a/examples/orchestration/dbt/dbt_project.yml
+++ b/examples/orchestration/dbt/dbt_project.yml
@@ -1,0 +1,15 @@
+# Minimal dbt project that transforms the raw table faucet loads
+# (public.charges_raw) into a typed staging model. This is the "T" in ELT —
+# faucet owns extract + load, dbt owns transform. See ../README.md.
+name: faucet_charges
+version: "1.0.0"
+config-version: 2
+
+profile: faucet_charges
+
+model-paths: ["models"]
+
+models:
+  faucet_charges:
+    staging:
+      +materialized: view

--- a/examples/orchestration/dbt/models/staging/_sources.yml
+++ b/examples/orchestration/dbt/models/staging/_sources.yml
@@ -1,0 +1,14 @@
+version: 2
+
+sources:
+  - name: raw
+    # The schema faucet's Postgres sink writes into (default: public).
+    schema: public
+    tables:
+      - name: charges_raw
+        description: >
+          Raw Stripe charges as loaded by faucet — one row per charge, the full
+          API payload in the JSONB column `data`.
+        columns:
+          - name: data
+            description: Full source record (JSONB).

--- a/examples/orchestration/dbt/models/staging/schema.yml
+++ b/examples/orchestration/dbt/models/staging/schema.yml
@@ -1,0 +1,19 @@
+version: 2
+
+models:
+  - name: stg_charges
+    description: Typed, one-row-per-charge staging model over the raw faucet load.
+    columns:
+      - name: charge_id
+        description: Stripe charge id.
+        data_tests:
+          - unique
+          - not_null
+      - name: amount_cents
+        description: Charge amount in the smallest currency unit.
+      - name: status
+        description: Charge status (succeeded / pending / failed).
+      - name: created_at
+        description: Charge creation timestamp.
+        data_tests:
+          - not_null

--- a/examples/orchestration/dbt/models/staging/stg_charges.sql
+++ b/examples/orchestration/dbt/models/staging/stg_charges.sql
@@ -1,0 +1,10 @@
+-- Unpack the raw JSONB payload faucet landed into typed columns.
+-- faucet did the extract + load losslessly; dbt does the typing + shaping.
+select
+    data ->> 'id'                                as charge_id,
+    (data ->> 'amount')::bigint                  as amount_cents,
+    data ->> 'currency'                          as currency,
+    data ->> 'status'                            as status,
+    (data ->> 'paid')::boolean                   as paid,
+    to_timestamp((data ->> 'created')::bigint)   as created_at
+from {{ source('raw', 'charges_raw') }}

--- a/examples/orchestration/dbt/profiles.yml
+++ b/examples/orchestration/dbt/profiles.yml
@@ -1,0 +1,15 @@
+# Example dbt profile pointing at the same Postgres faucet loaded into.
+# In real use, keep this in ~/.dbt/profiles.yml and read secrets from the env.
+# The orchestrator examples set DBT_PROFILES_DIR to this directory.
+faucet_charges:
+  target: dev
+  outputs:
+    dev:
+      type: postgres
+      host: "{{ env_var('PGHOST', 'localhost') }}"
+      port: "{{ env_var('PGPORT', '5432') | int }}"
+      user: "{{ env_var('PGUSER', 'faucet') }}"
+      password: "{{ env_var('PGPASSWORD', 'faucet') }}"
+      dbname: "{{ env_var('PGDATABASE', 'appdb') }}"
+      schema: analytics
+      threads: 4

--- a/examples/orchestration/faucet_pipeline.yaml
+++ b/examples/orchestration/faucet_pipeline.yaml
@@ -1,0 +1,63 @@
+# EL step, owned by faucet: extract from a REST API and load raw rows into
+# Postgres. Transformation (T) is left to dbt — see ./dbt. An orchestrator
+# (Airflow or Dagster) runs this config, then runs `dbt build`; see README.md.
+#
+# faucet lands the source payload verbatim in a single JSONB column so the load
+# stays lossless and schema-agnostic — dbt does the typed unpacking downstream.
+# Incremental replication + a durable bookmark mean re-runs only fetch new rows,
+# so the orchestrator can schedule this every few minutes cheaply.
+#
+# Required env vars:
+#   PG_URL        — Postgres connection URL, e.g.
+#                   postgres://faucet:faucet@localhost:5432/appdb
+#   STRIPE_TOKEN  — bearer token for the source API
+#
+# Run standalone:
+#   faucet run examples/orchestration/faucet_pipeline.yaml
+version: 1
+name: charges_el
+
+pipeline:
+  source:
+    type: rest
+    config:
+      base_url: https://api.stripe.com/v1
+      path: /charges
+      method: GET
+      auth:
+        type: bearer
+        config:
+          token: ${env:STRIPE_TOKEN}
+      query_params:
+        limit: "100"
+      pagination:
+        type: Cursor
+        next_token_path: $.next_page
+        param_name: starting_after
+      max_retries: 5
+      retry_backoff: 2
+      replication_method:
+        type: Incremental
+      replication_key: created
+      primary_keys: ["id"]
+      schema_sample_size: 200
+      state_key: charges:raw
+
+  sink:
+    type: postgres
+    config:
+      connection_url: ${env:PG_URL}
+      # dbt reads from this raw landing table (source: raw.charges_raw).
+      table_name: charges_raw
+      column_mapping:
+        type: jsonb
+        column: data
+      batch_size: 500
+      max_connections: 5
+
+  # Durable bookmark so the orchestrator can run this on a schedule and only
+  # pull new charges each tick.
+  state:
+    type: file
+    config:
+      path: ./.faucet-state


### PR DESCRIPTION
Closes the two remaining in-repo WS-11 (#314) acceptance criteria.

## Orchestration recipe (criterion 5)
- **`examples/orchestration/`** — a runnable ELT recipe: faucet (EL) → dbt (T), scheduled by **Airflow** (`airflow_dag.py`) or **Dagster** (`dagster_defs.py`). The faucet config is based on the shipped `rest_to_postgres.yaml` (loads REST → Postgres raw JSONB; `faucet validate` passes), and a minimal dbt project unpacks the raw load into a tested `stg_charges` staging model.
- **`docs/book/src/cookbook/orchestration.md`** (registered in `SUMMARY.md`) — cookbook page for the pattern, with a prominent link to the shipped **Grafana dashboards / Prometheus alerts**.

## Evergreen posts (criterion 3)
- **`docs/blog/exactly-once-without-a-broker.md`** — engineering deep-dive grounded in the real `_faucet_commit_token` watermark mechanism.
- **`docs/blog/migrating-from-meltano.md`** — migration guide with before/after `meltano.yml` → `faucet.yaml` configs.
- **`docs/blog/README.md`** — index tying both into the release cadence.

## Docs-sync
- `examples/README.md` (orchestration section), root README (Project Structure), `comparison/meltano.md` (links the migration guide), `RELEASE_PUBLICITY.md` (recirculate-evergreen step).

## Notes
- **Docs/examples only** — no Rust source; `docs:` prefix so release-plz won't trigger a publish.
- mdBook builds cleanly; `faucet validate` passes on the recipe config; the Python files compile.
- Remaining #314 items are traction-gated (awesome-rust/awesome-etl) or maintainer-driven (posting/videos/talks) — no further in-repo PR work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)