### PR TITLE
feat(connectors): Redshift, Pub/Sub, ClickHouse, Azure Blob, and SQL Server CDC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,11 @@ jobs:
           - source-mysql
           - source-mysql-cdc
           - source-mssql
+          - source-mssql-cdc
+          - source-redshift
+          - source-pubsub
+          - source-clickhouse
+          - source-azure-blob
           - source-sqlite
           - source-s3
           - source-mongodb
@@ -203,6 +208,10 @@ jobs:
           - sink-parquet
           - sink-delta
           - sink-gcs
+          - sink-redshift
+          - sink-pubsub
+          - sink-clickhouse
+          - sink-azure-blob
           # Kafka extras
           - kafka-schema-registry
           # State-store backends

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "RustyXML"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b5ace29ee3216de37c0546865ad08edef58b0f9e76838ed8959a84a990e58c5"
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -756,7 +762,30 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
 dependencies = [
- "event-listener",
+ "event-listener 5.4.1",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
@@ -780,7 +809,7 @@ version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
 dependencies = [
- "event-listener",
+ "event-listener 5.4.1",
  "event-listener-strategy",
  "pin-project-lite",
 ]
@@ -891,7 +920,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "fastrand",
+ "fastrand 2.4.1",
  "hex",
  "http 1.4.0",
  "sha1 0.10.6",
@@ -954,7 +983,7 @@ dependencies = [
  "aws-types",
  "bytes",
  "bytes-utils",
- "fastrand",
+ "fastrand 2.4.1",
  "http 0.2.12",
  "http 1.4.0",
  "http-body 0.4.6",
@@ -984,7 +1013,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "fastrand",
+ "fastrand 2.4.1",
  "http 0.2.12",
  "http 1.4.0",
  "regex-lite",
@@ -1008,7 +1037,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "fastrand",
+ "fastrand 2.4.1",
  "http 0.2.12",
  "http 1.4.0",
  "regex-lite",
@@ -1033,7 +1062,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "fastrand",
+ "fastrand 2.4.1",
  "http 0.2.12",
  "http 1.4.0",
  "regex-lite",
@@ -1061,7 +1090,7 @@ dependencies = [
  "aws-smithy-xml",
  "aws-types",
  "bytes",
- "fastrand",
+ "fastrand 2.4.1",
  "hex",
  "hmac 0.13.0",
  "http 0.2.12",
@@ -1092,7 +1121,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "fastrand",
+ "fastrand 2.4.1",
  "http 0.2.12",
  "http 1.4.0",
  "regex-lite",
@@ -1116,7 +1145,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "fastrand",
+ "fastrand 2.4.1",
  "http 0.2.12",
  "http 1.4.0",
  "regex-lite",
@@ -1140,7 +1169,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "fastrand",
+ "fastrand 2.4.1",
  "http 0.2.12",
  "http 1.4.0",
  "regex-lite",
@@ -1165,7 +1194,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-smithy-xml",
  "aws-types",
- "fastrand",
+ "fastrand 2.4.1",
  "http 0.2.12",
  "http 1.4.0",
  "regex-lite",
@@ -1388,7 +1417,7 @@ dependencies = [
  "aws-smithy-schema",
  "aws-smithy-types",
  "bytes",
- "fastrand",
+ "fastrand 2.4.1",
  "http 0.2.12",
  "http 1.4.0",
  "http-body 0.4.6",
@@ -1544,6 +1573,36 @@ dependencies = [
 
 [[package]]
 name = "azure_core"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b552ad43a45a746461ec3d3a51dfb6466b4759209414b439c165eb6a6b7729e"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "dyn-clone",
+ "futures",
+ "getrandom 0.2.17",
+ "hmac 0.12.1",
+ "http-types",
+ "once_cell",
+ "paste",
+ "pin-project",
+ "quick-xml 0.31.0",
+ "rand 0.8.6",
+ "reqwest 0.12.28",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "time",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "azure_core"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe6a26a7d374b440015cbbcbf2d9d8be5a133aa940599f5e5dc569504baa262e"
@@ -1583,7 +1642,7 @@ checksum = "32edf96b356ca7c51d7590c4925cc36efc3947a5da4468e8e0b25c56ecbb3de5"
 dependencies = [
  "async-lock",
  "async-trait",
- "azure_core",
+ "azure_core 1.0.0",
  "futures",
  "pin-project",
  "serde",
@@ -1601,7 +1660,7 @@ checksum = "e96b370d75ebb8807cc1ccfc6fe647b1e61e13052cba2e800b95f0cf0bd27d9a"
 dependencies = [
  "async-lock",
  "async-trait",
- "azure_core",
+ "azure_core 1.0.0",
  "futures",
  "rustc_version",
  "serde",
@@ -1611,12 +1670,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "azure_storage"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59f838159f4d29cb400a14d9d757578ba495ae64feb07a7516bf9e4415127126"
+dependencies = [
+ "RustyXML",
+ "async-lock",
+ "async-trait",
+ "azure_core 0.21.0",
+ "bytes",
+ "serde",
+ "serde_derive",
+ "time",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "azure_storage_blobs"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97e83c3636ae86d9a6a7962b2112e3b19eb3903915c50ce06ff54ff0a2e6a7e4"
+dependencies = [
+ "RustyXML",
+ "azure_core 0.21.0",
+ "azure_storage",
+ "azure_svc_blobstorage",
+ "bytes",
+ "futures",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "azure_svc_blobstorage"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e6c6f20c5611b885ba94c7bae5e02849a267381aecb8aee577e8c35ff4064c6"
+dependencies = [
+ "azure_core 0.21.0",
+ "bytes",
+ "futures",
+ "log",
+ "once_cell",
+ "serde",
+ "serde_json",
+ "time",
+]
+
+[[package]]
 name = "backon"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
 dependencies = [
- "fastrand",
+ "fastrand 2.4.1",
  "gloo-timers",
  "tokio",
 ]
@@ -1626,6 +1741,12 @@ name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -3509,6 +3630,12 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
@@ -3524,7 +3651,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener",
+ "event-listener 5.4.1",
  "pin-project-lite",
 ]
 
@@ -3608,6 +3735,15 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
@@ -3650,7 +3786,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-secretsmanager",
  "axum",
- "azure_core",
+ "azure_core 1.0.0",
  "azure_identity",
  "azure_security_keyvault_secrets",
  "base64 0.22.1",
@@ -3663,7 +3799,9 @@ dependencies = [
  "faucet-auth",
  "faucet-core",
  "faucet-lineage",
+ "faucet-sink-azure-blob",
  "faucet-sink-bigquery",
+ "faucet-sink-clickhouse",
  "faucet-sink-csv",
  "faucet-sink-delta",
  "faucet-sink-elasticsearch",
@@ -3678,13 +3816,17 @@ dependencies = [
  "faucet-sink-mysql",
  "faucet-sink-parquet",
  "faucet-sink-postgres",
+ "faucet-sink-pubsub",
  "faucet-sink-redis",
+ "faucet-sink-redshift",
  "faucet-sink-s3",
  "faucet-sink-snowflake",
  "faucet-sink-spanner",
  "faucet-sink-sqlite",
  "faucet-sink-stdout",
+ "faucet-source-azure-blob",
  "faucet-source-bigquery",
+ "faucet-source-clickhouse",
  "faucet-source-csv",
  "faucet-source-databricks",
  "faucet-source-delta",
@@ -3697,12 +3839,15 @@ dependencies = [
  "faucet-source-mongodb",
  "faucet-source-mongodb-cdc",
  "faucet-source-mssql",
+ "faucet-source-mssql-cdc",
  "faucet-source-mysql",
  "faucet-source-mysql-cdc",
  "faucet-source-parquet",
  "faucet-source-postgres",
  "faucet-source-postgres-cdc",
+ "faucet-source-pubsub",
  "faucet-source-redis",
+ "faucet-source-redshift",
  "faucet-source-rest",
  "faucet-source-s3",
  "faucet-source-singer",
@@ -3757,6 +3902,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "faucet-common-azure"
+version = "1.0.0"
+dependencies = [
+ "faucet-core",
+ "object_store",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "faucet-common-bigquery"
 version = "1.0.5"
 dependencies = [
@@ -3766,6 +3922,17 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+]
+
+[[package]]
+name = "faucet-common-clickhouse"
+version = "1.0.0"
+dependencies = [
+ "faucet-core",
+ "reqwest 0.13.3",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3863,6 +4030,33 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "faucet-common-pubsub"
+version = "1.0.0"
+dependencies = [
+ "faucet-core",
+ "gcloud-auth",
+ "gcloud-googleapis",
+ "gcloud-pubsub",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "tokio",
+]
+
+[[package]]
+name = "faucet-common-redshift"
+version = "1.0.0"
+dependencies = [
+ "faucet-core",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "tokio",
 ]
 
 [[package]]
@@ -3975,6 +4169,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "faucet-sink-azure-blob"
+version = "1.0.0"
+dependencies = [
+ "async-trait",
+ "azure_storage",
+ "azure_storage_blobs",
+ "bytes",
+ "faucet-common-azure",
+ "faucet-conformance",
+ "faucet-core",
+ "futures",
+ "object_store",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "testcontainers",
+ "testcontainers-modules",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "faucet-sink-bigquery"
 version = "1.3.1"
 dependencies = [
@@ -3991,6 +4208,23 @@ dependencies = [
  "tokio",
  "tracing",
  "wiremock",
+]
+
+[[package]]
+name = "faucet-sink-clickhouse"
+version = "1.0.0"
+dependencies = [
+ "async-trait",
+ "faucet-common-clickhouse",
+ "faucet-core",
+ "reqwest 0.13.3",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "testcontainers",
+ "testcontainers-modules",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -4279,6 +4513,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "faucet-sink-pubsub"
+version = "1.0.0"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "faucet-common-pubsub",
+ "faucet-core",
+ "futures",
+ "gcloud-pubsub",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "testcontainers",
+ "testcontainers-modules",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "faucet-sink-redis"
 version = "1.2.1"
 dependencies = [
@@ -4294,6 +4548,27 @@ dependencies = [
  "testcontainers-modules",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "faucet-sink-redshift"
+version = "1.0.0"
+dependencies = [
+ "async-trait",
+ "aws-config",
+ "aws-sdk-s3",
+ "faucet-common-redshift",
+ "faucet-conformance",
+ "faucet-core",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "testcontainers",
+ "testcontainers-modules",
+ "tokio",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -4388,6 +4663,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "faucet-source-azure-blob"
+version = "1.0.0"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "azure_storage",
+ "azure_storage_blobs",
+ "faucet-common-azure",
+ "faucet-conformance",
+ "faucet-core",
+ "futures",
+ "object_store",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "testcontainers",
+ "testcontainers-modules",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "faucet-source-bigquery"
 version = "1.2.0"
 dependencies = [
@@ -4405,6 +4703,26 @@ dependencies = [
  "tokio",
  "tracing",
  "wiremock",
+]
+
+[[package]]
+name = "faucet-source-clickhouse"
+version = "1.0.0"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "faucet-common-clickhouse",
+ "faucet-core",
+ "futures",
+ "reqwest 0.13.3",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "testcontainers",
+ "testcontainers-modules",
+ "tokio",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -4667,6 +4985,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "faucet-source-mssql-cdc"
+version = "1.0.0"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "base64 0.22.1",
+ "chrono",
+ "faucet-common-mssql",
+ "faucet-conformance",
+ "faucet-core",
+ "futures",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "testcontainers",
+ "testcontainers-modules",
+ "tiberius",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "faucet-source-mysql"
 version = "1.4.0"
 dependencies = [
@@ -4779,6 +5120,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "faucet-source-pubsub"
+version = "1.0.0"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "base64 0.22.1",
+ "faucet-common-pubsub",
+ "faucet-core",
+ "futures",
+ "gcloud-pubsub",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "testcontainers",
+ "testcontainers-modules",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "faucet-source-redis"
 version = "1.2.1"
 dependencies = [
@@ -4791,6 +5153,27 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_json",
+ "testcontainers",
+ "testcontainers-modules",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "faucet-source-redshift"
+version = "1.0.0"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "base64 0.22.1",
+ "faucet-common-redshift",
+ "faucet-conformance",
+ "faucet-core",
+ "futures",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "sqlx",
  "testcontainers",
  "testcontainers-modules",
  "tokio",
@@ -5014,15 +5397,21 @@ name = "faucet-stream"
 version = "1.4.0"
 dependencies = [
  "faucet-auth",
+ "faucet-common-azure",
  "faucet-common-bigquery",
+ "faucet-common-clickhouse",
  "faucet-common-gcs",
  "faucet-common-kafka",
  "faucet-common-kinesis",
+ "faucet-common-pubsub",
+ "faucet-common-redshift",
  "faucet-common-snowflake",
  "faucet-common-spanner",
  "faucet-core",
  "faucet-lineage",
+ "faucet-sink-azure-blob",
  "faucet-sink-bigquery",
+ "faucet-sink-clickhouse",
  "faucet-sink-csv",
  "faucet-sink-delta",
  "faucet-sink-elasticsearch",
@@ -5037,13 +5426,17 @@ dependencies = [
  "faucet-sink-mysql",
  "faucet-sink-parquet",
  "faucet-sink-postgres",
+ "faucet-sink-pubsub",
  "faucet-sink-redis",
+ "faucet-sink-redshift",
  "faucet-sink-s3",
  "faucet-sink-snowflake",
  "faucet-sink-spanner",
  "faucet-sink-sqlite",
  "faucet-sink-stdout",
+ "faucet-source-azure-blob",
  "faucet-source-bigquery",
+ "faucet-source-clickhouse",
  "faucet-source-csv",
  "faucet-source-databricks",
  "faucet-source-delta",
@@ -5056,12 +5449,15 @@ dependencies = [
  "faucet-source-mongodb",
  "faucet-source-mongodb-cdc",
  "faucet-source-mssql",
+ "faucet-source-mssql-cdc",
  "faucet-source-mysql",
  "faucet-source-mysql-cdc",
  "faucet-source-parquet",
  "faucet-source-postgres",
  "faucet-source-postgres-cdc",
+ "faucet-source-pubsub",
  "faucet-source-redis",
+ "faucet-source-redshift",
  "faucet-source-rest",
  "faucet-source-s3",
  "faucet-source-singer",
@@ -5237,6 +5633,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5334,6 +5745,21 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
+dependencies = [
+ "fastrand 1.9.0",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
 
 [[package]]
 name = "futures-macro"
@@ -5449,6 +5875,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "gcloud-pubsub"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61e5cf71d2c2531fbae1d000dc05fa161272c7407c539157598fc9dee234c285"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-stream",
+ "gcloud-auth",
+ "gcloud-gax",
+ "gcloud-googleapis",
+ "prost-types 0.14.3",
+ "thiserror 2.0.18",
+ "token-source",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "gcloud-spanner"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5528,6 +5972,17 @@ dependencies = [
  "typenum",
  "version_check",
  "zeroize",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -6112,6 +6567,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-types"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e9b187a72d63adbfba487f48095306ac823049cb504ee195541e91c7775f5ad"
+dependencies = [
+ "anyhow",
+ "async-channel 1.9.0",
+ "base64 0.13.1",
+ "futures-lite",
+ "infer",
+ "pin-project-lite",
+ "rand 0.7.3",
+ "serde",
+ "serde_json",
+ "serde_qs",
+ "serde_urlencoded",
+ "url",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6241,6 +6716,22 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.9.0",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
  "tower-service",
 ]
 
@@ -6602,6 +7093,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "infer"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
+
+[[package]]
 name = "inotify"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6664,6 +7161,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -7553,7 +8059,7 @@ dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
  "equivalent",
- "event-listener",
+ "event-listener 5.4.1",
  "futures-util",
  "parking_lot",
  "portable-atomic",
@@ -7774,6 +8280,23 @@ dependencies = [
  "thiserror 2.0.18",
  "uuid",
  "zstd",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe 0.2.1",
+ "openssl-sys",
+ "schannel",
+ "security-framework 3.7.0",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -8121,6 +8644,31 @@ dependencies = [
  "tokio",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -9321,6 +9869,16 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "quick-xml"
 version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
@@ -9453,6 +10011,19 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
@@ -9486,6 +10057,16 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
@@ -9502,6 +10083,15 @@ checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -9528,6 +10118,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
+]
 
 [[package]]
 name = "rand_xorshift"
@@ -9904,9 +10503,11 @@ dependencies = [
  "http-body-util",
  "hyper 1.9.0",
  "hyper-rustls 0.27.9",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -9918,6 +10519,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls 0.26.4",
  "tokio-util",
  "tower",
@@ -10649,6 +11251,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_qs"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7715380eec75f029a4ef7de39a9200e0a63823176b759d055b613f5a87df6a6"
+dependencies = [
+ "percent-encoding",
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11056,7 +11669,7 @@ dependencies = [
  "crc",
  "crossbeam-queue",
  "either",
- "event-listener",
+ "event-listener 5.4.1",
  "futures-core",
  "futures-intrusive",
  "futures-io",
@@ -11443,7 +12056,7 @@ version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
- "fastrand",
+ "fastrand 2.4.1",
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
@@ -11562,6 +12175,7 @@ dependencies = [
  "memchr",
  "parse-display",
  "pin-project-lite",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "serde_with",
@@ -11678,6 +12292,7 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
+ "js-sys",
  "libc",
  "num-conv",
  "num_threads",
@@ -11782,6 +12397,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -12670,6 +13295,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "waker-fn"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12687,6 +13318,12 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ members = [
     "crates/common/kinesis",
     "crates/common/spanner",
     "crates/common/delta",
+    "crates/common/redshift",
+    "crates/common/pubsub",
+    "crates/common/clickhouse",
+    "crates/common/azure",
     "crates/source/rest",
     "crates/source/singer",
     "crates/conformance",
@@ -31,6 +35,11 @@ members = [
     "crates/source/mongodb",
     "crates/source/mongodb-cdc",
     "crates/source/mysql-cdc",
+    "crates/source/mssql-cdc",
+    "crates/source/redshift",
+    "crates/source/pubsub",
+    "crates/source/clickhouse",
+    "crates/source/azure-blob",
     "crates/source/redis",
     "crates/source/webhook",
     "crates/source/websocket",
@@ -66,6 +75,10 @@ members = [
     "crates/sink/iceberg",
     "crates/sink/delta",
     "crates/sink/spanner",
+    "crates/sink/redshift",
+    "crates/sink/pubsub",
+    "crates/sink/clickhouse",
+    "crates/sink/azure-blob",
     "crates/state/redis",
     "crates/state/postgres",
     "faucet-stream",
@@ -156,6 +169,19 @@ faucet-state-redis = { path = "crates/state/redis", version = "1.0.6" }
 faucet-state-postgres = { path = "crates/state/postgres", version = "1.2.0" }
 faucet-cli = { path = "cli", version = "1.5.0" }
 faucet-transform-sql = { path = "crates/transform-sql", version = "1.0.4" }
+faucet-common-redshift = { path = "crates/common/redshift", version = "1.0.0" }
+faucet-source-redshift = { path = "crates/source/redshift", version = "1.0.0" }
+faucet-sink-redshift = { path = "crates/sink/redshift", version = "1.0.0" }
+faucet-common-pubsub = { path = "crates/common/pubsub", version = "1.0.0" }
+faucet-source-pubsub = { path = "crates/source/pubsub", version = "1.0.0" }
+faucet-sink-pubsub = { path = "crates/sink/pubsub", version = "1.0.0" }
+faucet-common-clickhouse = { path = "crates/common/clickhouse", version = "1.0.0" }
+faucet-source-clickhouse = { path = "crates/source/clickhouse", version = "1.0.0" }
+faucet-sink-clickhouse = { path = "crates/sink/clickhouse", version = "1.0.0" }
+faucet-common-azure = { path = "crates/common/azure", version = "1.0.0" }
+faucet-source-azure-blob = { path = "crates/source/azure-blob", version = "1.0.0" }
+faucet-sink-azure-blob = { path = "crates/sink/azure-blob", version = "1.0.0" }
+faucet-source-mssql-cdc = { path = "crates/source/mssql-cdc", version = "1.0.0" }
 
 # Shared external deps
 serde = { version = "1", features = ["derive"] }
@@ -212,6 +238,11 @@ gcloud-googleapis = { version = "1.3", features = ["spanner"] }
 # gRPC plumbing for gcloud-spanner; needed directly only for
 # `google_cloud_gax::conn::Environment` (the emulator-endpoint override).
 gcloud-gax = "1.4"
+# Cloud Pub/Sub client from the same yoshidan gcloud-* stack (source/sink pubsub,
+# #347). default-features off + jwt-rust-crypto to stay coherent with the Spanner
+# stack (avoids the dual-jwt compile_error in gcloud-auth).
+gcloud-pubsub = { version = "1", default-features = false, features = ["auth", "rustls-tls", "jwt-rust-crypto"] }
+gcloud-auth = { version = "1", default-features = false, features = ["rustls-tls", "jwt-rust-crypto"] }
 aws-sdk-kinesis = "1"
 aws-sdk-s3 = "1"
 aws-sdk-secretsmanager = "1"

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@
 ~62× less memory than Meltano**, output identical row-for-row ([see the benchmarks](BENCHMARKS.md)).
 No Python runtime, no platform to stand up, no daemon to babysit.
 
-faucet-stream is a **data-movement platform** for Rust — with governance built in: **28 source**
-and **21 sink** connectors (**49 in total**) plus in-flight transforms, including a page-level
+faucet-stream is a **data-movement platform** for Rust — with governance built in: **33 source**
+and **25 sink** connectors (**58 in total**) plus in-flight transforms, including a page-level
 embedded-DuckDB `sql` transform — wired by a single `faucet` binary that runs pipelines
 declaratively from YAML/JSON (no Rust code required), or embedded in your own service through
 the typed `Source` / `Sink` traits. One platform, whether you want a CLI you can drop on any
@@ -64,7 +64,7 @@ cargo add faucet-stream           # the library
   sink sees a row), schema-drift detection & policy, column-level lineage (OpenLineage) + a
   data-movement catalog, and freshness/volume SLA monitoring.
 - **📦 Pay only for what you use** — every connector is a Cargo feature, so a slim build can
-  be just REST + JSONL, or pull in all 49 connectors with `--features full`.
+  be just REST + JSONL, or pull in all 58 connectors with `--features full`.
 
 **Documentation:** the [faucet-stream guide](https://pawansikawat.github.io/faucet-stream/)
 (getting started, tutorials, cookbook, operations) · API reference on
@@ -195,7 +195,7 @@ one-block addition to your YAML:
 |---|---|---|
 | **Streaming, bounded memory** | Sources stream page-by-page; sinks write each page as it arrives — memory stays at one `batch_size` regardless of total volume. | [concepts](https://pawansikawat.github.io/faucet-stream/getting-started/concepts.html) |
 | **Incremental + resumable** | Bookmark-based replication: only fetch what changed, resume mid-run from a durable state store (file / Redis / Postgres). | [state](https://pawansikawat.github.io/faucet-stream/cookbook/state.html) |
-| **Change data capture** | Streaming row-level CDC for **PostgreSQL** (logical replication), **MySQL** (binlog), and **MongoDB** (change streams) — resumable. | [CDC guide](https://pawansikawat.github.io/faucet-stream/reference/connectors.html) |
+| **Change data capture** | Streaming row-level CDC for **PostgreSQL** (logical replication), **MySQL** (binlog), **MongoDB** (change streams), and **SQL Server** (CDC change tables) — resumable. | [CDC guide](https://pawansikawat.github.io/faucet-stream/reference/connectors.html) |
 | **Effectively-once delivery** | Monotonic per-page commit tokens committed atomically with the data (SQL sinks, Iceberg, BigQuery), so a resumed run re-delivers no duplicates. This is idempotent at-least-once (dedup on resume), not distributed-consensus exactly-once. | [state](https://pawansikawat.github.io/faucet-stream/cookbook/state.html) |
 | **Upsert / delete write modes** | `write_mode: upsert \| delete` with a `key` + `delete_marker` — merge by key on Postgres / MySQL / SQL Server / SQLite / Mongo / Elasticsearch. | [upsert](https://pawansikawat.github.io/faucet-stream/cookbook/upsert.html) |
 | **Data-quality checks** | 13 per-record and per-batch assertions (not-null, regex, ranges, uniqueness, row-count, JSON Schema, …) with quarantine routing or abort policies. | [quality](https://pawansikawat.github.io/faucet-stream/cookbook/quality.html) |
@@ -243,7 +243,7 @@ for help picking between overlapping connectors (Postgres query vs CDC, S3 vs Pa
 > production — Tier-2 means "not certified," **not** "low quality." The Singer
 > bridge is additionally **experimental (v0, single-stream)** ⚠️.
 
-### Sources (28)
+### Sources (33)
 
 `Tier`: **T1 ✅** = passes the `faucet-conformance` battery in CI; **T2** = not yet
 wired into the battery (see the support-tiers note above).
@@ -259,17 +259,22 @@ wired into the battery (see the support-tiers note above).
 | [`faucet-source-mysql`](crates/source/mysql) | T1 ✅ | MySQL — run SQL queries, return rows as JSON |
 | [`faucet-source-mysql-cdc`](crates/source/mysql-cdc) | T1 ✅ | MySQL CDC — binlog row events, resumable via file/pos or GTID |
 | [`faucet-source-mssql`](crates/source/mssql) | T1 ✅ | Microsoft SQL Server — streaming queries, incremental replication |
+| [`faucet-source-mssql-cdc`](crates/source/mssql-cdc) | T1 ✅ | Microsoft SQL Server CDC — change tables (`fn_cdc_get_all_changes`), LSN bookmarks, resumable |
 | [`faucet-source-sqlite`](crates/source/sqlite) | **T1 ✅** | SQLite — run SQL queries, return rows as JSON |
 | [`faucet-source-mongodb`](crates/source/mongodb) | T1 ✅ | MongoDB — find() with filter, projection, sort |
 | [`faucet-source-mongodb-cdc`](crates/source/mongodb-cdc) | T1 ✅ | MongoDB CDC — Change Streams, resumable via resumeToken |
 | [`faucet-source-redis`](crates/source/redis) | T1 ✅ | Redis — read from streams, lists, or key patterns |
 | [`faucet-source-kafka`](crates/source/kafka) | T1 ✅ | Apache Kafka — consumer with idle/max-messages termination |
 | [`faucet-source-kinesis`](crates/source/kinesis) | T1 ✅ | AWS Kinesis Data Streams — sharded consumer with resumable sequence checkpoints |
+| [`faucet-source-pubsub`](crates/source/pubsub) | T2 | Google Cloud Pub/Sub — streaming pull; per-message records + attributes, resumable |
 | [`faucet-source-s3`](crates/source/s3) | T1 ✅ | AWS S3 — read objects as JSONL, JSON array, or raw text |
 | [`faucet-source-gcs`](crates/source/gcs) | T2 | Google Cloud Storage — read objects as JSONL, JSON array, or raw text |
+| [`faucet-source-azure-blob`](crates/source/azure-blob) | T1 ✅ | Azure Blob / ADLS Gen2 — read objects as JSONL, JSON array, or raw text |
 | [`faucet-source-parquet`](crates/source/parquet) | T1 ✅ | Apache Parquet — local file, glob, or S3; vectorized Arrow reader, projection |
 | [`faucet-source-delta`](crates/source/delta) | T2 | Apache Delta Lake — local FS or S3/Azure/GCS; time travel, projection pushdown |
 | [`faucet-source-databricks`](crates/source/databricks) | T3 | Databricks SQL query source (Statement Execution API) — typed rows, chunk pagination, incremental |
+| [`faucet-source-redshift`](crates/source/redshift) | T1 ✅ | Amazon Redshift — SQL query over the PostgreSQL wire, incremental replication |
+| [`faucet-source-clickhouse`](crates/source/clickhouse) | T2 | ClickHouse — HTTP interface, `FORMAT JSONEachRow` streaming, incremental replication |
 | [`faucet-source-elasticsearch`](crates/source/elasticsearch) | T1 ✅ᵐ | Elasticsearch — search/scroll API |
 | [`faucet-source-bigquery`](crates/source/bigquery) | T1 ✅ᵐ | Google BigQuery — `jobs.query` + `getQueryResults`, type-aware decoding |
 | [`faucet-source-snowflake`](crates/source/snowflake) | T1 ✅ᵐ | Snowflake — SQL REST API, server-side partition pagination, JWT / OAuth |
@@ -279,7 +284,7 @@ wired into the battery (see the support-tiers note above).
 | [`faucet-source-csv`](crates/source/csv) | **T1 ✅** | CSV — read CSV files as JSON objects |
 | [`faucet-source-singer`](crates/source/singer) | T2 ⚠️ | **Singer tap bridge** — run any Singer tap and adapt its output. Passes the battery, but **experimental (v0, single-stream)** |
 
-### Sinks (21)
+### Sinks (25)
 
 | Crate | Tier | Description |
 |-------|------|-------------|
@@ -290,14 +295,18 @@ wired into the battery (see the support-tiers note above).
 | [`faucet-sink-mssql`](crates/sink/mssql) | T1 ✅ | Microsoft SQL Server — JSON or auto-mapped columns, 2100-param split |
 | [`faucet-sink-sqlite`](crates/sink/sqlite) | **T1 ✅** | SQLite — JSON column or auto-mapped columns; upsert/delete; effectively-once |
 | [`faucet-sink-snowflake`](crates/sink/snowflake) | T2 | Snowflake — SQL REST API with JWT/OAuth |
+| [`faucet-sink-redshift`](crates/sink/redshift) | T1 ✅ | Amazon Redshift — COPY-from-S3 (staged) or multi-row `INSERT`; append-only |
+| [`faucet-sink-clickhouse`](crates/sink/clickhouse) | T2 | ClickHouse — `INSERT … FORMAT JSONEachRow`; optional `async_insert`; append-only |
 | [`faucet-sink-mongodb`](crates/sink/mongodb) | T1 ✅ | MongoDB — insert_many; upsert/delete by key |
 | [`faucet-sink-redis`](crates/sink/redis) | T1 ✅ | Redis — write to streams, lists, or key-value |
 | [`faucet-sink-kafka`](crates/sink/kafka) | T1 ✅ | Apache Kafka — producer with batching, multi-topic routing |
 | [`faucet-sink-kinesis`](crates/sink/kinesis) | T1 ✅ | AWS Kinesis Data Streams — batched PutRecords with partition-key routing |
+| [`faucet-sink-pubsub`](crates/sink/pubsub) | T2 | Google Cloud Pub/Sub — batched publish; optional ordering key, per-entry retry |
 | [`faucet-sink-spanner`](crates/sink/spanner) | T1 ✅ᵉ | Google Cloud Spanner — batched mutations; upsert/delete, effectively-once commit tokens, schema evolution |
 | [`faucet-sink-elasticsearch`](crates/sink/elasticsearch) | T2 | Elasticsearch — bulk index API; upsert/delete by `_id` |
 | [`faucet-sink-s3`](crates/sink/s3) | T1 ✅ | AWS S3 — write JSONL files to bucket |
 | [`faucet-sink-gcs`](crates/sink/gcs) | T2 | Google Cloud Storage — write JSONL files to bucket |
+| [`faucet-sink-azure-blob`](crates/sink/azure-blob) | T2 | Azure Blob / ADLS Gen2 — write JSONL blobs; batch/byte rollover |
 | [`faucet-sink-parquet`](crates/sink/parquet) | T1 ✅ | Apache Parquet — local file or S3; schema inference, row/byte rollover |
 | [`faucet-sink-delta`](crates/sink/delta) | T2 | Apache Delta Lake — append-only; local FS or S3/Azure/GCS; one commit per flush |
 | [`faucet-sink-jsonl`](crates/sink/jsonl) | **T1 ✅** | JSON Lines — file output with append/truncate |
@@ -383,8 +392,8 @@ own service.
 | Single static binary | ✓ | ✗ | ✗ | ✓ | ✓ | n/a |
 | Config-driven (YAML/JSON) | ✓ | ✓ | via UI/API | ✓ | ✓ | via UI |
 | Embeddable as a library | ✓ (Rust) | ✗ | ✗ | ✓ (Go) | ✗ | ✗ |
-| Connector count | 49, growing | 600+ taps | 350+ | dozens | dozens | 500+ |
-| Change data capture | ✓ Postgres / MySQL / Mongo | partial¹ | ✓ | partial | ✗ | ✓ |
+| Connector count | 58, growing | 600+ taps | 350+ | dozens | dozens | 500+ |
+| Change data capture | ✓ Postgres / MySQL / Mongo / SQL Server | partial¹ | ✓ | partial | ✗ | ✓ |
 | Incremental + resumable state | ✓ | ✓ | ✓ | partial | n/a | ✓ |
 | Effectively-once delivery³ | ✓ (11 sinks incl. Kafka, Iceberg, BigQuery) | ✗ | partial | ✗ | ✗ | ✓ |
 | Built-in data-quality checks | ✓ native | ✗ | paywalled add-on | ✗ | ✗ | paywalled add-on |
@@ -458,7 +467,7 @@ flowchart LR
     class K sink
 ```
 
-faucet-stream is a Cargo workspace with **67 crates** — 28 sources, 21 sinks, 9 shared
+faucet-stream is a Cargo workspace with **80 crates** — 33 sources, 25 sinks, 13 shared
 connector libraries, the shared auth-provider library, 2 state-store backends, the lineage
 crate, the SQL transform crate, the conformance test battery, the shared core, the umbrella
 crate, and the CLI binary. See
@@ -510,14 +519,17 @@ Default features: `source-rest`, `transform-flatten`, `transform-rename-keys`,
 | `source-mysql` | no | MySQL query source |
 | `source-mysql-cdc` | no | MySQL CDC source (binlog replication) |
 | `source-mssql` | no | Microsoft SQL Server query source |
+| `source-mssql-cdc` | no | Microsoft SQL Server CDC source (change tables) |
 | `source-sqlite` | no | SQLite query source |
 | `source-mongodb` | no | MongoDB query source |
 | `source-mongodb-cdc` | no | MongoDB CDC source (Change Streams) |
 | `source-redis` | no | Redis source |
 | `source-kafka` | no | Apache Kafka consumer source |
 | `source-kinesis` | no | AWS Kinesis Data Streams source |
+| `source-pubsub` | no | Google Cloud Pub/Sub source |
 | `source-s3` | no | AWS S3 file source |
 | `source-gcs` | no | Google Cloud Storage file source |
+| `source-azure-blob` | no | Azure Blob / ADLS Gen2 file source |
 | `source-parquet` | no | Apache Parquet file source (local, glob, S3) |
 | `source-delta` | no | Apache Delta Lake source (local FS; S3/Azure/GCS via `delta-s3`/`delta-azure`/`delta-gcs`) |
 | `source-databricks` | no | Databricks SQL query source (Statement Execution API) |
@@ -525,6 +537,8 @@ Default features: `source-rest`, `transform-flatten`, `transform-rename-keys`,
 | `source-elasticsearch` | no | Elasticsearch source |
 | `source-bigquery` | no | Google BigQuery query source |
 | `source-snowflake` | no | Snowflake query source |
+| `source-redshift` | no | Amazon Redshift query source (PostgreSQL wire) |
+| `source-clickhouse` | no | ClickHouse query source (HTTP interface) |
 | `source-spanner` | no | Google Cloud Spanner query source |
 | `source-webhook` | no | Webhook HTTP receiver |
 | `source-websocket` | no | WebSocket live streaming source |
@@ -536,14 +550,18 @@ Default features: `source-rest`, `transform-flatten`, `transform-rename-keys`,
 | `sink-mssql` | no | Microsoft SQL Server sink |
 | `sink-sqlite` | no | SQLite sink |
 | `sink-snowflake` | no | Snowflake sink |
+| `sink-redshift` | no | Amazon Redshift sink (COPY-from-S3 or multi-row INSERT) |
+| `sink-clickhouse` | no | ClickHouse sink (INSERT … FORMAT JSONEachRow) |
 | `sink-mongodb` | no | MongoDB sink |
 | `sink-redis` | no | Redis sink |
 | `sink-kafka` | no | Apache Kafka producer sink |
 | `sink-kinesis` | no | AWS Kinesis Data Streams sink |
+| `sink-pubsub` | no | Google Cloud Pub/Sub sink |
 | `sink-spanner` | no | Google Cloud Spanner sink |
 | `sink-elasticsearch` | no | Elasticsearch bulk index sink |
 | `sink-s3` | no | AWS S3 file sink |
 | `sink-gcs` | no | Google Cloud Storage file sink |
+| `sink-azure-blob` | no | Azure Blob / ADLS Gen2 file sink |
 | `sink-parquet` | no | Apache Parquet file sink (local, S3) |
 | `sink-jsonl` | no | JSON Lines file sink |
 | `sink-csv` | no | CSV file sink |
@@ -803,13 +821,13 @@ and the runnable [`cli/examples/custom-cli/`](cli/examples/custom-cli/main.rs).
 ## Project structure
 
 ```
-Cargo.toml                    — workspace manifest (67 crates)
+Cargo.toml                    — workspace manifest (80 crates)
 crates/
   core/                       — faucet-core: shared types, traits, pipeline, transforms, config
   auth/                       — faucet-auth: shared OAuth2 / token-endpoint providers
-  source/                     — 28 source connectors (rest, graphql, xml, grpc, *-cdc, kafka, s3, delta, databricks, singer, …)
-  sink/                       — 21 sink connectors (bigquery, iceberg, delta, postgres, parquet, kafka, …)
-  common/                     — 6 shared connector libraries (bigquery, elasticsearch, gcs, kafka, snowflake, mssql)
+  source/                     — 33 source connectors (rest, graphql, xml, grpc, *-cdc, kafka, s3, azure-blob, redshift, clickhouse, pubsub, delta, databricks, singer, …)
+  sink/                       — 25 sink connectors (bigquery, iceberg, delta, postgres, parquet, kafka, redshift, clickhouse, pubsub, azure-blob, …)
+  common/                     — 13 shared connector libraries (bigquery, elasticsearch, gcs, kafka, snowflake, mssql, kinesis, spanner, delta, redshift, pubsub, clickhouse, azure)
   state/                      — Redis- and Postgres-backed StateStore backends
   lineage/                    — faucet-lineage: OpenLineage event emission
   transform-sql/              — faucet-transform-sql: embedded DuckDB SQL transform

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -75,6 +75,11 @@ source = [
     "source-mongodb",
     "source-mongodb-cdc",
     "source-mysql-cdc",
+    "source-mssql-cdc",
+    "source-redshift",
+    "source-pubsub",
+    "source-clickhouse",
+    "source-azure-blob",
     "source-redis",
     "source-webhook",
     "source-websocket",
@@ -113,6 +118,10 @@ sink = [
     "sink-gcs",
     "sink-iceberg",
     "sink-spanner",
+    "sink-redshift",
+    "sink-pubsub",
+    "sink-clickhouse",
+    "sink-azure-blob",
 ]
 state = ["state-redis", "state-postgres"]
 
@@ -129,6 +138,11 @@ source-s3 = ["dep:faucet-source-s3"]
 source-mongodb = ["dep:faucet-source-mongodb"]
 source-mongodb-cdc = ["dep:faucet-source-mongodb-cdc"]
 source-mysql-cdc = ["dep:faucet-source-mysql-cdc"]
+source-mssql-cdc = ["dep:faucet-source-mssql-cdc"]
+source-redshift = ["dep:faucet-source-redshift"]
+source-pubsub = ["dep:faucet-source-pubsub"]
+source-clickhouse = ["dep:faucet-source-clickhouse"]
+source-azure-blob = ["dep:faucet-source-azure-blob"]
 source-redis = ["dep:faucet-source-redis"]
 source-webhook = ["dep:faucet-source-webhook"]
 source-websocket = ["dep:faucet-source-websocket"]
@@ -166,6 +180,10 @@ sink-spanner = ["dep:faucet-sink-spanner"]
 sink-parquet = ["dep:faucet-sink-parquet"]
 sink-delta = ["dep:faucet-sink-delta"]
 sink-gcs = ["dep:faucet-sink-gcs"]
+sink-redshift = ["dep:faucet-sink-redshift"]
+sink-pubsub = ["dep:faucet-sink-pubsub"]
+sink-clickhouse = ["dep:faucet-sink-clickhouse"]
+sink-azure-blob = ["dep:faucet-sink-azure-blob"]
 
 ## Delta Lake cloud object-store backends. Forwarded to whichever delta
 ## connector is enabled via optional-dep (`?`) syntax, so they don't pull the
@@ -191,6 +209,8 @@ compression = [
     "faucet-sink-csv?/compression",
     "faucet-sink-s3?/compression",
     "faucet-sink-gcs?/compression",
+    "faucet-source-azure-blob?/compression",
+    "faucet-sink-azure-blob?/compression",
 ]
 
 # Secrets-manager interpolation resolvers for the config layer. None in
@@ -293,6 +313,11 @@ faucet-source-s3 = { workspace = true, optional = true }
 faucet-source-mongodb = { workspace = true, optional = true }
 faucet-source-mongodb-cdc = { workspace = true, optional = true }
 faucet-source-mysql-cdc = { workspace = true, optional = true }
+faucet-source-mssql-cdc = { workspace = true, optional = true }
+faucet-source-redshift = { workspace = true, optional = true }
+faucet-source-pubsub = { workspace = true, optional = true }
+faucet-source-clickhouse = { workspace = true, optional = true }
+faucet-source-azure-blob = { workspace = true, optional = true }
 faucet-source-redis = { workspace = true, optional = true }
 faucet-source-webhook = { workspace = true, optional = true }
 faucet-source-websocket = { workspace = true, optional = true }
@@ -329,6 +354,10 @@ faucet-sink-stdout = { workspace = true, optional = true }
 faucet-sink-parquet = { workspace = true, optional = true }
 faucet-sink-delta = { workspace = true, optional = true }
 faucet-sink-gcs = { workspace = true, optional = true }
+faucet-sink-redshift = { workspace = true, optional = true }
+faucet-sink-pubsub = { workspace = true, optional = true }
+faucet-sink-clickhouse = { workspace = true, optional = true }
+faucet-sink-azure-blob = { workspace = true, optional = true }
 faucet-state-redis = { workspace = true, optional = true }
 faucet-state-postgres = { workspace = true, optional = true }
 faucet-lineage = { workspace = true, optional = true }

--- a/cli/connectors/registry.json
+++ b/cli/connectors/registry.json
@@ -10,6 +10,11 @@
     { "name": "postgres-cdc", "kind": "source", "verified": true, "description": "PostgreSQL CDC source (logical replication)" },
     { "name": "mysql", "kind": "source", "verified": true, "description": "MySQL query source" },
     { "name": "mysql-cdc", "kind": "source", "verified": true, "description": "MySQL CDC source (binlog replication)" },
+    { "name": "mssql-cdc", "kind": "source", "verified": true, "description": "Microsoft SQL Server CDC source (change data capture, exactly-once capable)" },
+    { "name": "redshift", "kind": "source", "verified": true, "description": "Amazon Redshift query source (PostgreSQL wire; streaming rows, incremental replication)" },
+    { "name": "pubsub", "kind": "source", "verified": true, "description": "Google Cloud Pub/Sub consumer with ack at durable page boundaries" },
+    { "name": "clickhouse", "kind": "source", "verified": true, "description": "ClickHouse query source (HTTP interface, JSONEachRow streaming)" },
+    { "name": "azure-blob", "kind": "source", "verified": true, "description": "Azure Blob Storage / ADLS Gen2 source — JSONL, JSON array, or raw text" },
     { "name": "mssql", "kind": "source", "verified": true, "description": "Microsoft SQL Server query source" },
     { "name": "sqlite", "kind": "source", "verified": true, "description": "SQLite query source" },
     { "name": "mongodb", "kind": "source", "verified": true, "description": "MongoDB query source" },
@@ -51,6 +56,10 @@
     { "name": "http", "kind": "sink", "verified": true, "description": "HTTP POST sink (individual or array batch)" },
     { "name": "stdout", "kind": "sink", "verified": true, "description": "Stdout / stderr sink (JSON Lines, pretty, TSV)" },
     { "name": "parquet", "kind": "sink", "verified": true, "description": "Apache Parquet file sink (local path or S3)" },
-    { "name": "delta", "kind": "sink", "verified": true, "description": "Apache Delta Lake sink (append-only; local FS or S3/Azure/GCS)" }
+    { "name": "delta", "kind": "sink", "verified": true, "description": "Apache Delta Lake sink (append-only; local FS or S3/Azure/GCS)" },
+    { "name": "redshift", "kind": "sink", "verified": true, "description": "Amazon Redshift sink (COPY-from-S3 or multi-row INSERT)" },
+    { "name": "pubsub", "kind": "sink", "verified": true, "description": "Google Cloud Pub/Sub producer with ordering keys and partial-failure retry" },
+    { "name": "clickhouse", "kind": "sink", "verified": true, "description": "ClickHouse sink (HTTP INSERT … FORMAT JSONEachRow; optional async inserts)" },
+    { "name": "azure-blob", "kind": "sink", "verified": true, "description": "Azure Blob Storage / ADLS Gen2 sink — JSONL files" }
   ]
 }

--- a/cli/examples/azure_blob_to_jsonl.yaml
+++ b/cli/examples/azure_blob_to_jsonl.yaml
@@ -1,0 +1,30 @@
+# Azure Blob / ADLS Gen2 -> JSONL.
+#
+# Reads JSON Lines objects under a prefix in an Azure Blob container (via
+# object_store) and writes them to a local JSON Lines file.
+#
+# Run:
+#   faucet run cli/examples/azure_blob_to_jsonl.yaml
+#
+# Prereqs:
+#   - An Azure storage account `mystorageacct` with a `raw` container holding
+#     `.jsonl` objects under the `events/2026/` prefix.
+version: 1
+name: azure_blob_to_jsonl
+
+pipeline:
+  source:
+    type: azure-blob
+    config:
+      container: raw
+      account: mystorageacct
+      # Prefer ${env:...} / a SAS token / managed identity in real configs.
+      auth: { type: account_key, config: { account_key: "dGVzdC1hY2NvdW50LWtleQ==" } }
+      prefix: events/2026/
+      file_format: json_lines
+      batch_size: 1000
+
+  sink:
+    type: jsonl
+    config:
+      path: ./out/events.jsonl

--- a/cli/examples/clickhouse_to_jsonl.yaml
+++ b/cli/examples/clickhouse_to_jsonl.yaml
@@ -1,0 +1,29 @@
+# ClickHouse -> JSONL.
+#
+# Streams rows from ClickHouse over the HTTP interface (FORMAT JSONEachRow) and
+# writes them to a local JSON Lines file.
+#
+# Run:
+#   faucet run cli/examples/clickhouse_to_jsonl.yaml
+#
+# Prereqs:
+#   - ClickHouse reachable at http://clickhouse:8123 with an `events` table.
+#   - Do NOT append a FORMAT clause to `query` — the source sets JSONEachRow.
+version: 1
+name: clickhouse_to_jsonl
+
+pipeline:
+  source:
+    type: clickhouse
+    config:
+      # Endpoint — either `url` OR `host` (+ optional `http_port` / `tls`).
+      url: http://clickhouse:8123
+      database: default
+      user: default
+      query: SELECT id, email, updated_at FROM events
+      batch_size: 1000
+
+  sink:
+    type: jsonl
+    config:
+      path: ./out/events.jsonl

--- a/cli/examples/csv_to_clickhouse.yaml
+++ b/cli/examples/csv_to_clickhouse.yaml
@@ -1,0 +1,31 @@
+# Local CSV -> ClickHouse.
+#
+# Loads a CSV file into a ClickHouse table via INSERT ... FORMAT JSONEachRow.
+# Set `async_insert: true` to let the server buffer small batches server-side.
+#
+# Run:
+#   faucet run cli/examples/csv_to_clickhouse.yaml
+#
+# Prereqs:
+#   - ClickHouse reachable at http://clickhouse:8123 with a `default.events`
+#     table whose columns match the CSV headers.
+version: 1
+name: csv_to_clickhouse
+
+pipeline:
+  source:
+    type: csv
+    config:
+      path: ./data/input.csv
+
+  sink:
+    type: clickhouse
+    config:
+      url: http://clickhouse:8123
+      database: default
+      user: default
+      table: events
+      batch_size: 1000
+      # Server-side async buffering; keep wait_for_async_insert for durability.
+      async_insert: false
+      wait_for_async_insert: true

--- a/cli/examples/mssql_cdc_to_postgres_upsert.yaml
+++ b/cli/examples/mssql_cdc_to_postgres_upsert.yaml
@@ -1,0 +1,64 @@
+# End-to-end SQL Server CDC -> Postgres upsert mirror, exactly-once.
+#
+# Streams change-table rows from SQL Server CDC (fn_cdc_get_all_changes; LSN
+# bookmarks), normalizes the change envelope with `cdc_unwrap`, and mirrors them
+# into a destination Postgres table with `write_mode: upsert` — inserts/updates
+# become UPSERTs and deletes become row deletes, so the mirror table stays an
+# exact replica of the captured source table.
+#
+# Setup on the SOURCE SQL Server (CDC must be enabled on DB + tables):
+#   EXEC sys.sp_cdc_enable_db;
+#   EXEC sys.sp_cdc_enable_table @source_schema='dbo', @source_name='Orders',
+#        @role_name=NULL, @capture_instance='dbo_Orders';
+#
+# Setup on the DEST Postgres (upsert/delete need a UNIQUE/PRIMARY KEY on `key`):
+#   CREATE TABLE IF NOT EXISTS orders_mirror (id int4 PRIMARY KEY, total numeric);
+#
+# Then:
+#   faucet run cli/examples/mssql_cdc_to_postgres_upsert.yaml
+version: 1
+name: mssql_cdc_mirror
+
+# Exactly-once delivery: a keyed upsert into an idempotent SQL sink makes each
+# committed batch replay-safe, so a crash/resume never re-applies or skips a row.
+delivery: exactly_once
+
+pipeline:
+  source:
+    type: mssql-cdc
+    config:
+      connection_url: "mssql://faucet:Str0ng%40Pass@sqlserver:1433/sales"
+      # Self-signed dev cert: trust it. Use `require`/`verify_ca` in production.
+      tls:
+        type: trust_server_certificate
+      capture_instances: ["dbo_Orders"]
+      start_position: { type: current }
+      poll_interval: 1
+      idle_timeout: 30
+      batch_size: 1000
+      max_connections: 5
+
+  # Normalize the CDC envelope ({op, before, after}) into a flat row plus a
+  # `__op` marker. Inserts/updates emit the post-image; deletes emit the key
+  # from the pre-image. DDL/truncate events are dropped.
+  transforms:
+    - type: cdc_unwrap
+
+  sink:
+    type: postgres
+    config:
+      connection_url: "postgres://faucet:faucet@localhost:5432/warehouse"
+      table_name: orders_mirror
+      # Upsert/delete require column-mapping mode (not the JSONB blob mode).
+      column_mapping: auto_map
+      max_connections: 5
+      # Insert-or-update by `id` (the mirror table needs a UNIQUE/PRIMARY KEY on
+      # it); rows whose `__op` is "d" are routed to DELETE instead.
+      write_mode: upsert
+      key: [id]
+      delete_marker: { field: __op, values: [d] }
+
+  state:
+    type: file
+    config:
+      path: ./state

--- a/cli/examples/pubsub_to_jsonl.yaml
+++ b/cli/examples/pubsub_to_jsonl.yaml
@@ -1,0 +1,34 @@
+# Google Cloud Pub/Sub -> JSONL.
+#
+# Streams messages from a Pub/Sub subscription (streaming pull) and writes each
+# message body to a local JSON Lines file. Messages are acked at the durable
+# page boundary (at-least-once). The fetch cycle ends after `idle_termination_secs`
+# of quiet or after `max_messages` messages.
+#
+# Run:
+#   faucet run cli/examples/pubsub_to_jsonl.yaml
+#
+# Prereqs:
+#   - A Pub/Sub subscription `orders-sub` in project `my-gcp-project`, or point
+#     `emulator_host` at a running Pub/Sub emulator.
+version: 1
+name: pubsub_to_jsonl
+
+pipeline:
+  source:
+    type: pubsub
+    config:
+      subscription: orders-sub
+      project_id: my-gcp-project
+      # emulator_host: "localhost:8085"   # or set PUBSUB_EMULATOR_HOST
+      credentials: { type: application_default }
+      value_format: json
+      attributes_key: __attributes
+      idle_termination_secs: 30
+      max_messages: 100000
+      batch_size: 1000
+
+  sink:
+    type: jsonl
+    config:
+      path: ./out/orders.jsonl

--- a/cli/examples/redshift_to_jsonl.yaml
+++ b/cli/examples/redshift_to_jsonl.yaml
@@ -1,0 +1,34 @@
+# Amazon Redshift -> JSONL.
+#
+# Runs a SQL query over the Redshift PostgreSQL wire protocol and writes the
+# rows to a local JSON Lines file. Add a `replication:` block to track a
+# monotonically increasing column across runs (incremental replication).
+#
+# Run:
+#   faucet run cli/examples/redshift_to_jsonl.yaml
+#
+# Prereqs:
+#   - A reachable Redshift cluster with an `events` table.
+version: 1
+name: redshift_to_jsonl
+
+pipeline:
+  source:
+    type: redshift
+    config:
+      host: my-cluster.abc123.us-east-1.redshift.amazonaws.com
+      database: dev
+      user: admin
+      credentials:
+        type: password
+        config:
+          # Prefer ${env:...} / ${vault:...} in real configs; literal here so the
+          # shipped example validates offline.
+          password: changeme
+      query: SELECT id, email, updated_at FROM events ORDER BY updated_at
+      batch_size: 1000
+
+  sink:
+    type: jsonl
+    config:
+      path: ./out/events.jsonl

--- a/cli/src/registry.rs
+++ b/cli/src/registry.rs
@@ -512,6 +512,54 @@ pub async fn build_source(
             }
             Ok(Box::new(s))
         }
+        #[cfg(feature = "source-mssql-cdc")]
+        "mssql-cdc" => {
+            let cfg = decode::<faucet_source_mssql_cdc::MssqlCdcSourceConfig>(
+                "source",
+                "mssql-cdc",
+                config,
+            )?;
+            Ok(Box::new(
+                faucet_source_mssql_cdc::MssqlCdcSource::new(cfg).await?,
+            ))
+        }
+        #[cfg(feature = "source-redshift")]
+        "redshift" => {
+            let cfg = decode::<faucet_source_redshift::RedshiftSourceConfig>(
+                "source", "redshift", config,
+            )?;
+            Ok(Box::new(faucet_source_redshift::RedshiftSource::new(cfg)?))
+        }
+        #[cfg(feature = "source-pubsub")]
+        "pubsub" => {
+            let cfg =
+                decode::<faucet_source_pubsub::PubsubSourceConfig>("source", "pubsub", config)?;
+            Ok(Box::new(
+                faucet_source_pubsub::PubsubSource::new(cfg).await?,
+            ))
+        }
+        #[cfg(feature = "source-clickhouse")]
+        "clickhouse" => {
+            let cfg = decode::<faucet_source_clickhouse::ClickHouseSourceConfig>(
+                "source",
+                "clickhouse",
+                config,
+            )?;
+            Ok(Box::new(faucet_source_clickhouse::ClickHouseSource::new(
+                cfg,
+            )?))
+        }
+        #[cfg(feature = "source-azure-blob")]
+        "azure-blob" => {
+            let cfg = decode::<faucet_source_azure_blob::AzureBlobSourceConfig>(
+                "source",
+                "azure-blob",
+                config,
+            )?;
+            Ok(Box::new(
+                faucet_source_azure_blob::AzureBlobSource::new(cfg).await?,
+            ))
+        }
         other => Err(unknown(other, "source", source_kinds())),
     }
 }
@@ -653,6 +701,39 @@ pub async fn build_sink(kind: &str, config: Value, auth: &AuthCatalog) -> CliRes
             let cfg = decode::<faucet_sink_gcs::GcsSinkConfig>("sink", "gcs", config)?;
             Ok(Box::new(faucet_sink_gcs::GcsSink::new(cfg).await?))
         }
+        #[cfg(feature = "sink-redshift")]
+        "redshift" => {
+            let cfg =
+                decode::<faucet_sink_redshift::RedshiftSinkConfig>("sink", "redshift", config)?;
+            Ok(Box::new(
+                faucet_sink_redshift::RedshiftSink::new(cfg).await?,
+            ))
+        }
+        #[cfg(feature = "sink-pubsub")]
+        "pubsub" => {
+            let cfg = decode::<faucet_sink_pubsub::PubsubSinkConfig>("sink", "pubsub", config)?;
+            Ok(Box::new(faucet_sink_pubsub::PubsubSink::new(cfg).await?))
+        }
+        #[cfg(feature = "sink-clickhouse")]
+        "clickhouse" => {
+            let cfg = decode::<faucet_sink_clickhouse::ClickHouseSinkConfig>(
+                "sink",
+                "clickhouse",
+                config,
+            )?;
+            Ok(Box::new(faucet_sink_clickhouse::ClickHouseSink::new(cfg)?))
+        }
+        #[cfg(feature = "sink-azure-blob")]
+        "azure-blob" => {
+            let cfg = decode::<faucet_sink_azure_blob::AzureBlobSinkConfig>(
+                "sink",
+                "azure-blob",
+                config,
+            )?;
+            Ok(Box::new(
+                faucet_sink_azure_blob::AzureBlobSink::new(cfg).await?,
+            ))
+        }
         other => Err(unknown(other, "sink", sink_kinds())),
     }
 }
@@ -663,8 +744,13 @@ pub async fn build_sink(kind: &str, config: Value, auth: &AuthCatalog) -> CliRes
 /// human-readable list shown in error messages (F44). `kafka` qualifies because
 /// partitions are immutable logs and every page carries a complete offsets
 /// bookmark (#291).
-pub const EXACTLY_ONCE_SOURCE_KINDS: &[&str] =
-    &["postgres-cdc", "mysql-cdc", "mongodb-cdc", "kafka"];
+pub const EXACTLY_ONCE_SOURCE_KINDS: &[&str] = &[
+    "postgres-cdc",
+    "mysql-cdc",
+    "mssql-cdc",
+    "mongodb-cdc",
+    "kafka",
+];
 
 /// Sink connector kinds that can durably commit a token atomically with data.
 /// Mirrors `Sink::supports_idempotent_writes` overrides — keep in sync when a
@@ -848,6 +934,16 @@ pub fn source_schema(kind: &str) -> CliResult<Value> {
         "bigquery" => Ok(schema::<faucet_source_bigquery::BigQuerySourceConfig>()),
         #[cfg(feature = "source-snowflake")]
         "snowflake" => Ok(schema::<faucet_source_snowflake::SnowflakeSourceConfig>()),
+        #[cfg(feature = "source-mssql-cdc")]
+        "mssql-cdc" => Ok(schema::<faucet_source_mssql_cdc::MssqlCdcSourceConfig>()),
+        #[cfg(feature = "source-redshift")]
+        "redshift" => Ok(schema::<faucet_source_redshift::RedshiftSourceConfig>()),
+        #[cfg(feature = "source-pubsub")]
+        "pubsub" => Ok(schema::<faucet_source_pubsub::PubsubSourceConfig>()),
+        #[cfg(feature = "source-clickhouse")]
+        "clickhouse" => Ok(schema::<faucet_source_clickhouse::ClickHouseSourceConfig>()),
+        #[cfg(feature = "source-azure-blob")]
+        "azure-blob" => Ok(schema::<faucet_source_azure_blob::AzureBlobSourceConfig>()),
         other => Err(unknown(other, "source", source_kinds())),
     }
 }
@@ -910,6 +1006,14 @@ pub fn sink_schema(kind: &str) -> CliResult<Value> {
         "parquet" => Ok(schema::<faucet_sink_parquet::ParquetSinkConfig>()),
         #[cfg(feature = "sink-gcs")]
         "gcs" => Ok(schema::<faucet_sink_gcs::GcsSinkConfig>()),
+        #[cfg(feature = "sink-redshift")]
+        "redshift" => Ok(schema::<faucet_sink_redshift::RedshiftSinkConfig>()),
+        #[cfg(feature = "sink-pubsub")]
+        "pubsub" => Ok(schema::<faucet_sink_pubsub::PubsubSinkConfig>()),
+        #[cfg(feature = "sink-clickhouse")]
+        "clickhouse" => Ok(schema::<faucet_sink_clickhouse::ClickHouseSinkConfig>()),
+        #[cfg(feature = "sink-azure-blob")]
+        "azure-blob" => Ok(schema::<faucet_sink_azure_blob::AzureBlobSinkConfig>()),
         other => Err(unknown(other, "sink", sink_kinds())),
     }
 }
@@ -956,6 +1060,31 @@ fn builtin_source_descriptions() -> Vec<(&'static str, &'static str)> {
     v.push(("mongodb-cdc", "MongoDB CDC source (Change Streams)"));
     #[cfg(feature = "source-mysql-cdc")]
     v.push(("mysql-cdc", "MySQL CDC source (binlog replication)"));
+    #[cfg(feature = "source-mssql-cdc")]
+    v.push((
+        "mssql-cdc",
+        "Microsoft SQL Server CDC source (change data capture, exactly-once capable)",
+    ));
+    #[cfg(feature = "source-redshift")]
+    v.push((
+        "redshift",
+        "Amazon Redshift query source (PostgreSQL wire; streaming rows, incremental replication)",
+    ));
+    #[cfg(feature = "source-pubsub")]
+    v.push((
+        "pubsub",
+        "Google Cloud Pub/Sub consumer — streaming pull with per-message records, attribute mapping, and ack at durable page boundaries (at-least-once)",
+    ));
+    #[cfg(feature = "source-clickhouse")]
+    v.push((
+        "clickhouse",
+        "ClickHouse query source (HTTP interface, JSONEachRow streaming)",
+    ));
+    #[cfg(feature = "source-azure-blob")]
+    v.push((
+        "azure-blob",
+        "Azure Blob Storage / ADLS Gen2 source — JSONL, JSON array, or raw text",
+    ));
     #[cfg(feature = "source-redis")]
     v.push(("redis", "Redis (streams, lists, keys) source"));
     #[cfg(feature = "source-webhook")]
@@ -1065,6 +1194,26 @@ fn builtin_sink_descriptions() -> Vec<(&'static str, &'static str)> {
     v.push(("delta", "Apache Delta Lake sink (local FS or S3/Azure/GCS). Append-only, schema-inferred table creation, one commit per flush."));
     #[cfg(feature = "sink-gcs")]
     v.push(("gcs", "Google Cloud Storage sink — JSONL files"));
+    #[cfg(feature = "sink-redshift")]
+    v.push((
+        "redshift",
+        "Amazon Redshift sink (COPY-from-S3 or multi-row INSERT)",
+    ));
+    #[cfg(feature = "sink-pubsub")]
+    v.push((
+        "pubsub",
+        "Google Cloud Pub/Sub producer — batched publish with optional ordering keys, bounded concurrency, and partial-failure retry (DLQ-routable)",
+    ));
+    #[cfg(feature = "sink-clickhouse")]
+    v.push((
+        "clickhouse",
+        "ClickHouse sink (HTTP INSERT … FORMAT JSONEachRow; optional async inserts)",
+    ));
+    #[cfg(feature = "sink-azure-blob")]
+    v.push((
+        "azure-blob",
+        "Azure Blob Storage / ADLS Gen2 sink — JSONL files",
+    ));
     v
 }
 

--- a/crates/common/azure/Cargo.toml
+++ b/crates/common/azure/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "faucet-common-azure"
+version = "1.0.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Shared Azure Blob Storage / ADLS Gen2 credential and client types for the faucet-stream ecosystem"
+readme = "README.md"
+keywords = ["azure", "blob", "adls", "storage", "connector"]
+categories.workspace = true
+
+[dependencies]
+faucet-core.workspace = true
+schemars.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+object_store = { workspace = true, features = ["azure"] }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/common/azure/README.md
+++ b/crates/common/azure/README.md
@@ -1,0 +1,46 @@
+# faucet-common-azure
+
+Shared Azure Blob Storage / ADLS Gen2 credential and client types for the
+[`faucet-stream`](https://crates.io/crates/faucet-stream) ecosystem.
+
+Both `faucet-source-azure-blob` and `faucet-sink-azure-blob` depend on this
+crate for a single, consistent way to authenticate against Azure storage and
+build an [`object_store`](https://crates.io/crates/object_store)-backed client.
+ADLS Gen2 and classic Blob share the same `MicrosoftAzureBuilder`, so one code
+path serves both.
+
+## Credentials
+
+`AzureCredentials` serializes as `{ type, config }` (the project-wide auth wire
+shape). Variants:
+
+| `type` | Fields | Notes |
+|---|---|---|
+| `account_key` | `account_key` | Shared storage-account key |
+| `sas_token` | `sas_token` | Shared-access-signature token |
+| `connection_string` | `connection_string` | Full storage connection string |
+| `managed_identity` | `client_id` (optional) | IMDS; omit `client_id` for the system-assigned identity |
+| `service_principal` | `client_id`, `client_secret`, `tenant_id` | Azure AD client credentials |
+| `default` | — | Default credential chain (env / workload identity / managed identity / Azure CLI). **Default.** |
+
+## Connection
+
+`AzureConnection` carries `container` (required), `account`, `auth`, `endpoint`,
+`allow_http`, and `use_emulator`. `build_store(&AzureConnection)` returns an
+`Arc<dyn ObjectStore>` ready for reads and writes. The builder starts from
+`MicrosoftAzureBuilder::from_env()`, so `AZURE_*` environment variables act as a
+fallback that explicit config overrides.
+
+```rust
+use faucet_common_azure::{AzureConnection, AzureCredentials, build_store};
+
+let conn = AzureConnection::new("my-container")
+    .account("mystorageacct")
+    .auth(AzureCredentials::AccountKey { account_key: "…".into() });
+let store = build_store(&conn)?;
+# Ok::<(), faucet_core::FaucetError>(())
+```
+
+## License
+
+MIT

--- a/crates/common/azure/src/lib.rs
+++ b/crates/common/azure/src/lib.rs
@@ -1,0 +1,462 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+//! Shared Azure Blob Storage / ADLS Gen2 credential and client construction for
+//! the faucet source and sink connectors.
+//!
+//! Both `faucet-source-azure-blob` and `faucet-sink-azure-blob` build a single
+//! [`object_store`]-backed Azure store from an [`AzureConnection`] (account +
+//! container + credentials), so end users see one consistent config surface for
+//! both directions. ADLS Gen2 and classic Blob share the same
+//! `MicrosoftAzureBuilder`, so a single code path serves both.
+
+use std::str::FromStr;
+use std::sync::Arc;
+
+use faucet_core::FaucetError;
+use object_store::ObjectStore;
+use object_store::azure::{AzureConfigKey, MicrosoftAzureBuilder};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Credential source for an Azure storage client.
+///
+/// Serializes as `{ type: <method>, config: { … } }` (adjacent tagging,
+/// snake_case discriminators) — the consistent auth wire shape shared by every
+/// faucet connector, e.g.
+/// `{ type: account_key, config: { account_key: "…" } }`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(tag = "type", content = "config", rename_all = "snake_case")]
+pub enum AzureCredentials {
+    /// Shared storage-account access key (the primary/secondary key).
+    AccountKey {
+        /// Base64 account key.
+        account_key: String,
+    },
+    /// Shared-access-signature token (with or without a leading `?`).
+    SasToken {
+        /// SAS token string.
+        sas_token: String,
+    },
+    /// Full storage connection string
+    /// (`DefaultEndpointsProtocol=…;AccountName=…;AccountKey=…;…`).
+    ConnectionString {
+        /// Connection string.
+        connection_string: String,
+    },
+    /// Azure Managed Identity (IMDS). For a user-assigned identity, set
+    /// `client_id`; leave it unset for the system-assigned identity.
+    ManagedIdentity {
+        /// Optional user-assigned managed-identity client id.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        client_id: Option<String>,
+    },
+    /// Azure AD service principal (client credentials).
+    ServicePrincipal {
+        /// Application (client) id.
+        client_id: String,
+        /// Client secret.
+        client_secret: String,
+        /// Directory (tenant) id.
+        tenant_id: String,
+    },
+    /// `DefaultAzureCredential`-style resolution: the object-store builder's
+    /// default chain (environment variables, workload identity, managed
+    /// identity, Azure CLI), honouring `AZURE_*` env vars. This is the default.
+    #[default]
+    Default,
+}
+
+impl AzureCredentials {
+    /// Map this credential to the set of `object_store` Azure config
+    /// key/value pairs that select it.
+    ///
+    /// Keys are the canonical `azure_storage_*` alias strings that
+    /// [`AzureConfigKey::from_str`] accepts; returning them as plain strings
+    /// keeps this mapping unit-testable without constructing a live store.
+    /// [`Default`](AzureCredentials::Default) returns an empty set — the
+    /// builder's default credential chain is used unchanged.
+    pub fn config_entries(&self) -> Vec<(&'static str, String)> {
+        match self {
+            AzureCredentials::AccountKey { account_key } => {
+                vec![("azure_storage_access_key", account_key.clone())]
+            }
+            AzureCredentials::SasToken { sas_token } => {
+                vec![("azure_storage_sas_key", sas_token.clone())]
+            }
+            // `object_store` has no single connection-string config key, so we
+            // parse the string into the account/key/sas/endpoint config keys it
+            // does understand.
+            AzureCredentials::ConnectionString { connection_string } => {
+                parse_connection_string(connection_string)
+            }
+            // Setting the client id selects the user-assigned managed identity;
+            // a system-assigned identity (no client id) is picked up by the
+            // builder's default credential chain (IMDS), so no key is needed.
+            AzureCredentials::ManagedIdentity { client_id } => match client_id {
+                Some(id) => vec![("azure_storage_client_id", id.clone())],
+                None => Vec::new(),
+            },
+            AzureCredentials::ServicePrincipal {
+                client_id,
+                client_secret,
+                tenant_id,
+            } => vec![
+                ("azure_storage_client_id", client_id.clone()),
+                ("azure_storage_client_secret", client_secret.clone()),
+                ("azure_storage_tenant_id", tenant_id.clone()),
+            ],
+            AzureCredentials::Default => Vec::new(),
+        }
+    }
+}
+
+/// Parse an Azure storage connection string into the `object_store` config
+/// key/value pairs it understands.
+///
+/// A connection string is a `;`-separated list of `Key=Value` segments, e.g.
+/// `DefaultEndpointsProtocol=https;AccountName=x;AccountKey=y;EndpointSuffix=core.windows.net`.
+/// Only the segments that map to an authentication/endpoint config key are
+/// emitted (`AccountName`, `AccountKey`, `SharedAccessSignature`,
+/// `BlobEndpoint`); protocol/suffix hints are ignored, so the default public-cloud
+/// endpoint is used. Pure — unit-tested without a live store.
+fn parse_connection_string(cs: &str) -> Vec<(&'static str, String)> {
+    let mut entries: Vec<(&'static str, String)> = Vec::new();
+    for segment in cs.split(';') {
+        let segment = segment.trim();
+        if segment.is_empty() {
+            continue;
+        }
+        let Some((key, value)) = segment.split_once('=') else {
+            continue;
+        };
+        let value = value.trim().to_string();
+        if value.is_empty() {
+            continue;
+        }
+        // `AccountKey` values may themselves contain `=` (base64 padding); the
+        // `split_once` above keeps everything after the first `=` intact.
+        match key.trim() {
+            "AccountName" => entries.push(("azure_storage_account_name", value)),
+            "AccountKey" => entries.push(("azure_storage_access_key", value)),
+            "SharedAccessSignature" => entries.push(("azure_storage_sas_key", value)),
+            "BlobEndpoint" => entries.push(("azure_storage_endpoint", value)),
+            _ => {}
+        }
+    }
+    entries
+}
+
+/// Connection parameters shared by the Azure source and sink.
+///
+/// Flattened into each connector's config via `#[serde(flatten)]`, so
+/// `container`, `account`, `auth`, … appear at the top level of the source /
+/// sink config.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct AzureConnection {
+    /// Blob container / ADLS Gen2 filesystem name. Required.
+    pub container: String,
+    /// Storage-account name. Optional when a connection string or the
+    /// emulator supplies it, otherwise required.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub account: Option<String>,
+    /// Credential source. Defaults to the environment / managed-identity
+    /// credential chain.
+    #[serde(default)]
+    pub auth: AzureCredentials,
+    /// Custom blob endpoint (e.g. an Azurite emulator or a sovereign cloud).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub endpoint: Option<String>,
+    /// Permit plaintext HTTP (required for a local Azurite emulator).
+    #[serde(default)]
+    pub allow_http: bool,
+    /// Target the Azurite storage emulator with its well-known
+    /// `devstoreaccount1` credentials.
+    #[serde(default)]
+    pub use_emulator: bool,
+}
+
+impl AzureConnection {
+    /// New connection targeting `container` with default credentials.
+    pub fn new(container: impl Into<String>) -> Self {
+        Self {
+            container: container.into(),
+            account: None,
+            auth: AzureCredentials::default(),
+            endpoint: None,
+            allow_http: false,
+            use_emulator: false,
+        }
+    }
+
+    /// Set the storage-account name.
+    pub fn account(mut self, account: impl Into<String>) -> Self {
+        self.account = Some(account.into());
+        self
+    }
+
+    /// Set the credential source.
+    pub fn auth(mut self, auth: AzureCredentials) -> Self {
+        self.auth = auth;
+        self
+    }
+
+    /// Set a custom blob endpoint (emulator / sovereign cloud).
+    pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
+        self.endpoint = Some(endpoint.into());
+        self
+    }
+
+    /// Permit plaintext HTTP.
+    pub fn allow_http(mut self, allow: bool) -> Self {
+        self.allow_http = allow;
+        self
+    }
+
+    /// Target the Azurite emulator.
+    pub fn use_emulator(mut self, use_emulator: bool) -> Self {
+        self.use_emulator = use_emulator;
+        self
+    }
+}
+
+/// Build an [`object_store`] Azure store from an [`AzureConnection`].
+///
+/// The builder starts from [`MicrosoftAzureBuilder::from_env`] so `AZURE_*`
+/// environment variables act as a fallback; explicit config overrides them.
+/// All build failures map to [`FaucetError::Config`].
+pub fn build_store(conn: &AzureConnection) -> Result<Arc<dyn ObjectStore>, FaucetError> {
+    if conn.container.trim().is_empty() {
+        return Err(FaucetError::Config(
+            "azure: container name must not be empty".into(),
+        ));
+    }
+
+    let mut builder = MicrosoftAzureBuilder::from_env().with_container_name(&conn.container);
+
+    if let Some(account) = &conn.account {
+        builder = builder.with_account(account);
+    }
+    if conn.use_emulator {
+        builder = builder.with_use_emulator(true);
+    }
+    if let Some(endpoint) = &conn.endpoint {
+        builder = builder.with_endpoint(endpoint.clone());
+    }
+    if conn.allow_http {
+        builder = builder.with_allow_http(true);
+    }
+
+    for (key, value) in conn.auth.config_entries() {
+        let config_key = AzureConfigKey::from_str(key)
+            .map_err(|e| FaucetError::Config(format!("azure: unknown config key '{key}': {e}")))?;
+        builder = builder.with_config(config_key, value);
+    }
+
+    let store = builder
+        .build()
+        .map_err(|e| FaucetError::Config(format!("azure: failed to build client: {e}")))?;
+    Ok(Arc::new(store))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn credentials_default_is_default_variant() {
+        assert_eq!(AzureCredentials::default(), AzureCredentials::Default);
+    }
+
+    #[test]
+    fn default_credential_has_no_config_entries() {
+        assert!(AzureCredentials::Default.config_entries().is_empty());
+    }
+
+    #[test]
+    fn account_key_sets_access_key() {
+        let creds = AzureCredentials::AccountKey {
+            account_key: "abc123".into(),
+        };
+        assert_eq!(
+            creds.config_entries(),
+            vec![("azure_storage_access_key", "abc123".to_string())]
+        );
+    }
+
+    #[test]
+    fn sas_token_sets_sas_key() {
+        let creds = AzureCredentials::SasToken {
+            sas_token: "sv=2021".into(),
+        };
+        assert_eq!(
+            creds.config_entries(),
+            vec![("azure_storage_sas_key", "sv=2021".to_string())]
+        );
+    }
+
+    #[test]
+    fn connection_string_parses_into_account_and_key() {
+        let creds = AzureCredentials::ConnectionString {
+            connection_string:
+                "DefaultEndpointsProtocol=https;AccountName=acct;AccountKey=a2V5==;EndpointSuffix=core.windows.net"
+                    .into(),
+        };
+        let entries = creds.config_entries();
+        assert!(entries.contains(&("azure_storage_account_name", "acct".to_string())));
+        // AccountKey value retains its base64 padding (`=`).
+        assert!(entries.contains(&("azure_storage_access_key", "a2V5==".to_string())));
+        // Protocol / suffix hints are ignored.
+        assert_eq!(entries.len(), 2);
+    }
+
+    #[test]
+    fn connection_string_parses_sas_and_endpoint() {
+        let creds = AzureCredentials::ConnectionString {
+            connection_string:
+                "SharedAccessSignature=sv=2021&sig=abc;BlobEndpoint=http://127.0.0.1:10000/acct"
+                    .into(),
+        };
+        let entries = creds.config_entries();
+        assert!(entries.contains(&("azure_storage_sas_key", "sv=2021&sig=abc".to_string())));
+        assert!(entries.contains(&(
+            "azure_storage_endpoint",
+            "http://127.0.0.1:10000/acct".to_string()
+        )));
+    }
+
+    #[test]
+    fn connection_string_ignores_blank_and_unknown_segments() {
+        assert!(parse_connection_string("").is_empty());
+        assert!(parse_connection_string(";;Foo=bar;").is_empty());
+        assert!(parse_connection_string("AccountKey=").is_empty());
+    }
+
+    #[test]
+    fn managed_identity_user_assigned_sets_client_id() {
+        let creds = AzureCredentials::ManagedIdentity {
+            client_id: Some("mi-client".into()),
+        };
+        assert_eq!(
+            creds.config_entries(),
+            vec![("azure_storage_client_id", "mi-client".to_string())]
+        );
+    }
+
+    #[test]
+    fn managed_identity_system_assigned_sets_no_config() {
+        let creds = AzureCredentials::ManagedIdentity { client_id: None };
+        assert!(creds.config_entries().is_empty());
+    }
+
+    #[test]
+    fn service_principal_sets_all_three_fields() {
+        let creds = AzureCredentials::ServicePrincipal {
+            client_id: "cid".into(),
+            client_secret: "secret".into(),
+            tenant_id: "tid".into(),
+        };
+        let entries = creds.config_entries();
+        assert!(entries.contains(&("azure_storage_client_id", "cid".to_string())));
+        assert!(entries.contains(&("azure_storage_client_secret", "secret".to_string())));
+        assert!(entries.contains(&("azure_storage_tenant_id", "tid".to_string())));
+    }
+
+    #[test]
+    fn credentials_serde_account_key_round_trip() {
+        let creds = AzureCredentials::AccountKey {
+            account_key: "k".into(),
+        };
+        let v = serde_json::to_value(&creds).unwrap();
+        assert_eq!(
+            v,
+            json!({"type": "account_key", "config": {"account_key": "k"}})
+        );
+        let back: AzureCredentials = serde_json::from_value(v).unwrap();
+        assert_eq!(back, creds);
+    }
+
+    #[test]
+    fn credentials_serde_default_round_trip() {
+        let v = serde_json::to_value(AzureCredentials::Default).unwrap();
+        assert_eq!(v, json!({"type": "default"}));
+        let back: AzureCredentials = serde_json::from_value(v).unwrap();
+        assert_eq!(back, AzureCredentials::Default);
+    }
+
+    #[test]
+    fn credentials_serde_service_principal_round_trip() {
+        let creds = AzureCredentials::ServicePrincipal {
+            client_id: "cid".into(),
+            client_secret: "sec".into(),
+            tenant_id: "tid".into(),
+        };
+        let v = serde_json::to_value(&creds).unwrap();
+        assert_eq!(v["type"], "service_principal");
+        let back: AzureCredentials = serde_json::from_value(v).unwrap();
+        assert_eq!(back, creds);
+    }
+
+    #[test]
+    fn connection_builder_sets_fields() {
+        let conn = AzureConnection::new("data")
+            .account("acct")
+            .auth(AzureCredentials::AccountKey {
+                account_key: "k".into(),
+            })
+            .endpoint("http://127.0.0.1:10000/devstoreaccount1")
+            .allow_http(true)
+            .use_emulator(true);
+        assert_eq!(conn.container, "data");
+        assert_eq!(conn.account.as_deref(), Some("acct"));
+        assert!(conn.allow_http);
+        assert!(conn.use_emulator);
+        assert_eq!(
+            conn.endpoint.as_deref(),
+            Some("http://127.0.0.1:10000/devstoreaccount1")
+        );
+    }
+
+    #[test]
+    fn build_store_rejects_empty_container() {
+        let conn = AzureConnection::new("   ");
+        let err = build_store(&conn).unwrap_err();
+        assert!(matches!(err, FaucetError::Config(_)));
+    }
+
+    #[test]
+    fn build_store_succeeds_lazily_with_account_key() {
+        // The builder is lazy (no I/O at build time), so a well-formed config
+        // constructs a store even without a reachable backend. This exercises
+        // the full config-entry → with_config wiring for the account-key path.
+        let conn = AzureConnection::new("data")
+            .account("devstoreaccount1")
+            .auth(AzureCredentials::AccountKey {
+                account_key: "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==".into(),
+            })
+            .endpoint("http://127.0.0.1:10000/devstoreaccount1")
+            .allow_http(true);
+        assert!(build_store(&conn).is_ok());
+    }
+
+    #[test]
+    fn build_store_succeeds_lazily_with_emulator_and_default_creds() {
+        let conn = AzureConnection::new("data")
+            .use_emulator(true)
+            .allow_http(true);
+        assert!(build_store(&conn).is_ok());
+    }
+
+    #[test]
+    fn build_store_succeeds_lazily_with_service_principal() {
+        let conn =
+            AzureConnection::new("data")
+                .account("acct")
+                .auth(AzureCredentials::ServicePrincipal {
+                    client_id: "cid".into(),
+                    client_secret: "sec".into(),
+                    tenant_id: "tid".into(),
+                });
+        assert!(build_store(&conn).is_ok());
+    }
+}

--- a/crates/common/clickhouse/Cargo.toml
+++ b/crates/common/clickhouse/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "faucet-common-clickhouse"
+version = "1.0.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Shared configuration and HTTP-protocol helpers for the faucet-stream ClickHouse source and sink connectors"
+readme = "README.md"
+keywords = ["clickhouse", "olap", "etl", "pipeline", "faucet"]
+categories.workspace = true
+
+[dependencies]
+faucet-core.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+schemars.workspace = true
+reqwest.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/common/clickhouse/README.md
+++ b/crates/common/clickhouse/README.md
@@ -1,0 +1,37 @@
+# faucet-common-clickhouse
+
+Shared configuration and HTTP-protocol helpers for the
+[`faucet-stream`](https://crates.io/crates/faucet-stream) ClickHouse **source**
+(`faucet-source-clickhouse`) and **sink** (`faucet-sink-clickhouse`) connectors.
+
+Both connectors talk to ClickHouse over its
+[HTTP interface](https://clickhouse.com/docs/en/interfaces/http) using
+[`reqwest`](https://crates.io/crates/reqwest), so this crate holds the surface
+they share:
+
+- **`ClickHouseConnection`** — endpoint (`url` **or** `host` + `http_port` +
+  `tls`), target `database`, and optional `user` / `password`. Flattened into
+  both end configs so the wire shape is identical on the source and the sink.
+  Its `Debug` impl masks the password as `***`.
+- **`base_url()`** — resolves the `scheme://host:port` base URL (no trailing
+  slash) the HTTP interface is reached at.
+- **`build_client`** — the single place a reqwest `Client` is constructed.
+- **`query_params`** — builds the `?database=…&<setting>=…` query string
+  (settings such as `async_insert`, `default_format`).
+- **`apply_auth`** — attaches the `X-ClickHouse-User` / `X-ClickHouse-Key`
+  authentication headers (never URL query parameters, so credentials do not leak
+  into request logs).
+- **`parse_json_each_row`** / **`build_json_each_row`** — decode / encode the
+  newline-delimited `JSONEachRow` format used for both reads and writes.
+- **`sql_literal`** — injection-safe SQL literal encoding for a JSON scalar,
+  used to push an incremental bookmark down into a `WHERE` clause.
+
+Authentication is username + password (ClickHouse native HTTP auth) only in v1.
+
+You normally depend on `faucet-source-clickhouse` / `faucet-sink-clickhouse`,
+which re-export `ClickHouseConnection` — not on this crate directly.
+
+## License
+
+Licensed under either of Apache License, Version 2.0 or MIT license at your
+option.

--- a/crates/common/clickhouse/src/lib.rs
+++ b/crates/common/clickhouse/src/lib.rs
@@ -1,0 +1,440 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+//! # faucet-common-clickhouse
+//!
+//! Shared configuration and HTTP-protocol helpers for the
+//! [`faucet-stream`](https://crates.io/crates/faucet-stream) ClickHouse source
+//! and sink connectors. Both connectors talk to ClickHouse over its
+//! [HTTP interface](https://clickhouse.com/docs/en/interfaces/http) using
+//! [`reqwest`], so the shared surface here is:
+//!
+//! - [`ClickHouseConnection`] — endpoint (`url` **or** `host` + `http_port` +
+//!   `tls`), target `database`, and optional `user` / `password`. Flattened
+//!   into both end configs so the wire shape is identical on the source and the
+//!   sink. Its `Debug` impl masks the password as `"***"`.
+//! - [`ClickHouseConnection::base_url`] — resolves the scheme://host:port base
+//!   URL (no trailing slash) the HTTP interface is reached at.
+//! - [`build_client`] — the single place a reqwest [`Client`](reqwest::Client)
+//!   is constructed.
+//! - [`query_params`] — builds the `?database=…&<setting>=…` query string the
+//!   HTTP interface expects (settings such as `async_insert`,
+//!   `default_format`).
+//! - [`apply_auth`] — attaches the `X-ClickHouse-User` / `X-ClickHouse-Key`
+//!   authentication headers.
+//! - [`parse_json_each_row`] / [`build_json_each_row`] — decode / encode the
+//!   newline-delimited `JSONEachRow` format used for both reads and writes.
+//! - [`sql_literal`] — inject-safe SQL literal encoding for a JSON scalar
+//!   (used to push an incremental bookmark down into the `WHERE` clause).
+//!
+//! Authentication is username + password (ClickHouse native HTTP auth) only in
+//! v1.
+
+use faucet_core::FaucetError;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Default ClickHouse HTTP-interface port.
+pub const DEFAULT_HTTP_PORT: u16 = 8123;
+/// Default ClickHouse database when none is configured.
+pub const DEFAULT_DATABASE: &str = "default";
+
+fn default_database() -> String {
+    DEFAULT_DATABASE.to_string()
+}
+
+/// Shared connection configuration for the ClickHouse source and sink.
+///
+/// The endpoint is specified **either** as a full `url`
+/// (`http://host:8123`) **or** as a `host` (+ optional `http_port` / `tls`).
+/// Exactly one of the two forms must be provided.
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ClickHouseConnection {
+    /// Full base URL of the ClickHouse HTTP interface, e.g.
+    /// `"http://localhost:8123"`. Mutually exclusive with
+    /// [`host`](Self::host). A trailing slash is trimmed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    /// Hostname of the ClickHouse server. Mutually exclusive with
+    /// [`url`](Self::url); combined with [`http_port`](Self::http_port) and
+    /// [`tls`](Self::tls) to build the base URL.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub host: Option<String>,
+    /// HTTP-interface port used with [`host`](Self::host). Defaults to
+    /// [`DEFAULT_HTTP_PORT`] (`8123`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub http_port: Option<u16>,
+    /// Use `https://` instead of `http://` when building the base URL from
+    /// [`host`](Self::host). Ignored when [`url`](Self::url) is set. Defaults to
+    /// `false`.
+    #[serde(default)]
+    pub tls: bool,
+    /// Target database. Defaults to [`DEFAULT_DATABASE`] (`"default"`).
+    #[serde(default = "default_database")]
+    pub database: String,
+    /// ClickHouse user. When set, sent as the `X-ClickHouse-User` header.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user: Option<String>,
+    /// ClickHouse password. When set, sent as the `X-ClickHouse-Key` header.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub password: Option<String>,
+}
+
+impl Default for ClickHouseConnection {
+    fn default() -> Self {
+        Self {
+            url: None,
+            host: None,
+            http_port: None,
+            tls: false,
+            database: default_database(),
+            user: None,
+            password: None,
+        }
+    }
+}
+
+impl std::fmt::Debug for ClickHouseConnection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ClickHouseConnection")
+            .field("url", &self.url)
+            .field("host", &self.host)
+            .field("http_port", &self.http_port)
+            .field("tls", &self.tls)
+            .field("database", &self.database)
+            .field("user", &self.user)
+            .field("password", &self.password.as_ref().map(|_| "***"))
+            .finish()
+    }
+}
+
+impl ClickHouseConnection {
+    /// Build a connection from a full base URL, leaving credentials unset.
+    pub fn from_url(url: impl Into<String>) -> Self {
+        Self {
+            url: Some(url.into()),
+            ..Default::default()
+        }
+    }
+
+    /// Validate that exactly one of `url` / `host` is set.
+    pub fn validate(&self) -> Result<(), FaucetError> {
+        match (&self.url, &self.host) {
+            (Some(_), Some(_)) => Err(FaucetError::Config(
+                "ClickHouse config sets both `url` and `host`; set exactly one".into(),
+            )),
+            (None, None) => Err(FaucetError::Config(
+                "ClickHouse config requires either `url` or `host`".into(),
+            )),
+            _ => Ok(()),
+        }
+    }
+
+    /// Resolve the base URL (scheme://host:port, no trailing slash) of the
+    /// ClickHouse HTTP interface.
+    ///
+    /// Returns [`FaucetError::Config`] when neither `url` nor `host` is set.
+    pub fn base_url(&self) -> Result<String, FaucetError> {
+        if let Some(url) = &self.url {
+            return Ok(url.trim_end_matches('/').to_string());
+        }
+        if let Some(host) = &self.host {
+            let scheme = if self.tls { "https" } else { "http" };
+            let port = self.http_port.unwrap_or(DEFAULT_HTTP_PORT);
+            return Ok(format!("{scheme}://{host}:{port}"));
+        }
+        Err(FaucetError::Config(
+            "ClickHouse config requires either `url` or `host`".into(),
+        ))
+    }
+}
+
+/// Build a reqwest [`Client`](reqwest::Client) for the ClickHouse HTTP
+/// interface. Kept in one place so both connectors share the client-construction
+/// path and connection pool.
+pub fn build_client(_conn: &ClickHouseConnection) -> Result<reqwest::Client, FaucetError> {
+    reqwest::Client::builder()
+        .build()
+        .map_err(FaucetError::Http)
+}
+
+/// Build the ordered `(key, value)` query parameters for a ClickHouse HTTP
+/// request: the `database` parameter followed by any extra `settings`
+/// (e.g. `("default_format", "JSONEachRow")`, `("async_insert", "1")`).
+///
+/// The values are handed to reqwest's `.query()`, which performs URL encoding.
+pub fn query_params(database: &str, settings: &[(&str, &str)]) -> Vec<(String, String)> {
+    let mut params = Vec::with_capacity(1 + settings.len());
+    params.push(("database".to_string(), database.to_string()));
+    for (k, v) in settings {
+        params.push((k.to_string(), v.to_string()));
+    }
+    params
+}
+
+/// Attach the ClickHouse authentication headers to a request when a user /
+/// password is configured. Uses the `X-ClickHouse-User` / `X-ClickHouse-Key`
+/// headers (never URL query parameters, so credentials do not leak into
+/// request logs).
+pub fn apply_auth(
+    mut req: reqwest::RequestBuilder,
+    conn: &ClickHouseConnection,
+) -> reqwest::RequestBuilder {
+    if let Some(user) = &conn.user {
+        req = req.header("X-ClickHouse-User", user);
+    }
+    if let Some(password) = &conn.password {
+        req = req.header("X-ClickHouse-Key", password);
+    }
+    req
+}
+
+/// Parse a `JSONEachRow` response body (one JSON object per line) into records.
+///
+/// Blank lines are skipped. A line that is not valid JSON surfaces as a typed
+/// [`FaucetError::Source`] naming the 1-based line number — never a silent drop.
+pub fn parse_json_each_row(body: &str) -> Result<Vec<Value>, FaucetError> {
+    let mut out = Vec::new();
+    for (idx, line) in body.lines().enumerate() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let value: Value = serde_json::from_str(trimmed).map_err(|e| {
+            FaucetError::Source(format!(
+                "ClickHouse: failed to parse JSONEachRow line {}: {e}",
+                idx + 1
+            ))
+        })?;
+        out.push(value);
+    }
+    Ok(out)
+}
+
+/// Serialize records into a `JSONEachRow` request body (one JSON object per
+/// line, each line newline-terminated).
+///
+/// A record that cannot be serialized surfaces as a typed
+/// [`FaucetError::Sink`].
+pub fn build_json_each_row(records: &[Value]) -> Result<String, FaucetError> {
+    let mut body = String::new();
+    for record in records {
+        let line = serde_json::to_string(record).map_err(|e| {
+            FaucetError::Sink(format!("ClickHouse: failed to serialize record: {e}"))
+        })?;
+        body.push_str(&line);
+        body.push('\n');
+    }
+    Ok(body)
+}
+
+/// Encode a JSON scalar as an injection-safe ClickHouse SQL literal.
+///
+/// Strings are single-quoted with `\` and `'` backslash-escaped (ClickHouse
+/// accepts C-style escapes inside string literals), booleans map to `1` / `0`,
+/// numbers pass through, and `null` becomes `NULL`. Non-scalar values (arrays /
+/// objects) fall back to their quoted JSON string form. Used to push an
+/// incremental-replication bookmark down into a `WHERE` clause without
+/// interpolating attacker-influenced text unescaped.
+pub fn sql_literal(value: &Value) -> String {
+    match value {
+        Value::Null => "NULL".to_string(),
+        Value::Bool(b) => {
+            if *b {
+                "1".to_string()
+            } else {
+                "0".to_string()
+            }
+        }
+        Value::Number(n) => n.to_string(),
+        Value::String(s) => quote_string(s),
+        other => quote_string(&other.to_string()),
+    }
+}
+
+fn quote_string(s: &str) -> String {
+    let escaped = s.replace('\\', "\\\\").replace('\'', "\\'");
+    format!("'{escaped}'")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn base_url_from_url_trims_trailing_slash() {
+        let conn = ClickHouseConnection::from_url("http://localhost:8123/");
+        assert_eq!(conn.base_url().unwrap(), "http://localhost:8123");
+    }
+
+    #[test]
+    fn base_url_from_host_defaults_port_and_scheme() {
+        let conn = ClickHouseConnection {
+            host: Some("db.example.com".into()),
+            ..Default::default()
+        };
+        assert_eq!(conn.base_url().unwrap(), "http://db.example.com:8123");
+    }
+
+    #[test]
+    fn base_url_from_host_honors_tls_and_port() {
+        let conn = ClickHouseConnection {
+            host: Some("db.example.com".into()),
+            http_port: Some(8443),
+            tls: true,
+            ..Default::default()
+        };
+        assert_eq!(conn.base_url().unwrap(), "https://db.example.com:8443");
+    }
+
+    #[test]
+    fn base_url_requires_url_or_host() {
+        let conn = ClickHouseConnection::default();
+        assert!(conn.base_url().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_both_and_neither() {
+        let both = ClickHouseConnection {
+            url: Some("http://h:8123".into()),
+            host: Some("h".into()),
+            ..Default::default()
+        };
+        assert!(both.validate().is_err());
+        assert!(ClickHouseConnection::default().validate().is_err());
+    }
+
+    #[test]
+    fn validate_accepts_exactly_one() {
+        assert!(
+            ClickHouseConnection::from_url("http://h:8123")
+                .validate()
+                .is_ok()
+        );
+        let host_only = ClickHouseConnection {
+            host: Some("h".into()),
+            ..Default::default()
+        };
+        assert!(host_only.validate().is_ok());
+    }
+
+    #[test]
+    fn debug_masks_password() {
+        let conn = ClickHouseConnection {
+            url: Some("http://h:8123".into()),
+            user: Some("alice".into()),
+            password: Some("s3cret".into()),
+            ..Default::default()
+        };
+        let dbg = format!("{conn:?}");
+        assert!(dbg.contains("alice"));
+        assert!(dbg.contains("***"));
+        assert!(!dbg.contains("s3cret"));
+    }
+
+    #[test]
+    fn database_defaults_when_missing() {
+        let conn: ClickHouseConnection =
+            serde_json::from_value(json!({ "url": "http://h:8123" })).unwrap();
+        assert_eq!(conn.database, "default");
+    }
+
+    #[test]
+    fn query_params_puts_database_first_then_settings() {
+        let params = query_params("analytics", &[("default_format", "JSONEachRow")]);
+        assert_eq!(
+            params,
+            vec![
+                ("database".to_string(), "analytics".to_string()),
+                ("default_format".to_string(), "JSONEachRow".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn query_params_async_insert_on_and_off() {
+        let on = query_params(
+            "db",
+            &[("async_insert", "1"), ("wait_for_async_insert", "1")],
+        );
+        assert!(on.contains(&("async_insert".to_string(), "1".to_string())));
+        let off = query_params("db", &[]);
+        assert_eq!(off.len(), 1, "only the database param when no settings");
+    }
+
+    #[test]
+    fn parse_json_each_row_multiple_rows() {
+        let body = "{\"a\":1}\n{\"a\":2}\n{\"a\":3}\n";
+        let rows = parse_json_each_row(body).unwrap();
+        assert_eq!(rows.len(), 3);
+        assert_eq!(rows[2]["a"], 3);
+    }
+
+    #[test]
+    fn parse_json_each_row_empty_result_is_empty() {
+        assert!(parse_json_each_row("").unwrap().is_empty());
+        assert!(parse_json_each_row("\n\n").unwrap().is_empty());
+    }
+
+    #[test]
+    fn parse_json_each_row_skips_blank_lines_between_rows() {
+        let rows = parse_json_each_row("{\"a\":1}\n\n{\"a\":2}\n").unwrap();
+        assert_eq!(rows.len(), 2);
+    }
+
+    #[test]
+    fn parse_json_each_row_malformed_line_is_typed_error() {
+        let err = parse_json_each_row("{\"a\":1}\nnot-json\n").unwrap_err();
+        match err {
+            FaucetError::Source(m) => assert!(m.contains("line 2"), "got: {m}"),
+            other => panic!("expected Source error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn build_json_each_row_exact_ndjson() {
+        let page = vec![json!({"id": 1, "v": "a"}), json!({"id": 2, "v": "b"})];
+        let body = build_json_each_row(&page).unwrap();
+        assert_eq!(body, "{\"id\":1,\"v\":\"a\"}\n{\"id\":2,\"v\":\"b\"}\n");
+    }
+
+    #[test]
+    fn build_json_each_row_empty_is_empty_string() {
+        assert_eq!(build_json_each_row(&[]).unwrap(), "");
+    }
+
+    #[test]
+    fn build_and_parse_round_trip() {
+        let page = vec![json!({"id": 1, "s": "héllo"}), json!({"id": 2, "s": "x"})];
+        let body = build_json_each_row(&page).unwrap();
+        let back = parse_json_each_row(&body).unwrap();
+        assert_eq!(back, page);
+    }
+
+    #[test]
+    fn sql_literal_scalars() {
+        assert_eq!(sql_literal(&Value::Null), "NULL");
+        assert_eq!(sql_literal(&json!(true)), "1");
+        assert_eq!(sql_literal(&json!(false)), "0");
+        assert_eq!(sql_literal(&json!(42)), "42");
+        assert_eq!(sql_literal(&json!(-1.5)), "-1.5");
+        assert_eq!(sql_literal(&json!("2024-01-01")), "'2024-01-01'");
+    }
+
+    #[test]
+    fn sql_literal_escapes_quote_and_backslash() {
+        assert_eq!(sql_literal(&json!("O'Brien")), "'O\\'Brien'");
+        assert_eq!(sql_literal(&json!("a\\b")), "'a\\\\b'");
+        // A classic injection attempt is neutralised into a single quoted literal.
+        assert_eq!(
+            sql_literal(&json!("x' OR '1'='1")),
+            "'x\\' OR \\'1\\'=\\'1'"
+        );
+    }
+
+    #[test]
+    fn build_client_succeeds() {
+        assert!(build_client(&ClickHouseConnection::from_url("http://h:8123")).is_ok());
+    }
+}

--- a/crates/common/pubsub/Cargo.toml
+++ b/crates/common/pubsub/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "faucet-common-pubsub"
+version = "1.0.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Shared Google Cloud Pub/Sub credentials and client construction for the faucet-stream Pub/Sub source and sink connectors"
+readme = "README.md"
+keywords = ["pubsub", "gcp", "messaging", "etl", "faucet"]
+categories.workspace = true
+
+[dependencies]
+faucet-core.workspace = true
+schemars.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+gcloud-pubsub.workspace = true
+gcloud-auth.workspace = true
+gcloud-googleapis = { version = "1.3", features = ["pubsub"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }
+serde_yaml = "0.9"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/common/pubsub/README.md
+++ b/crates/common/pubsub/README.md
@@ -1,0 +1,32 @@
+# faucet-common-pubsub
+
+Shared Google Cloud Pub/Sub configuration for the
+[faucet-stream](https://github.com/PawanSikawat/faucet-stream) Pub/Sub
+connectors — `faucet-source-pubsub` and `faucet-sink-pubsub`. Both connector
+crates depend on this crate and re-export its types, so end-user imports do not
+change.
+
+## Contents
+
+- **`PubsubCredentials`** — the auth enum, serialized as the project-wide
+  `{ type, config }` shape:
+  - `{ type: application_default }` — Application Default Credentials.
+  - `{ type: service_account_json_file, config: { path } }` — key file on disk.
+  - `{ type: service_account_json_inline, config: { json } }` — inline key
+    (pair with `${secret:…}` / `${env:…}` interpolation).
+  - `{ type: anonymous }` — no credentials (for the emulator).
+- **`PubsubConnection`** — flattened connection block: `project_id`,
+  `endpoint`, `emulator_host`, `credentials`.
+- **`build_client`** — assembles a `gcloud_pubsub::client::Client`, honouring
+  `emulator_host` / `PUBSUB_EMULATOR_HOST` (auth skipped) or resolving
+  credentials for real Pub/Sub.
+- **`PubsubMessage`** — re-exported from `gcloud-googleapis` so connector code
+  round-trips messages without adding that crate directly.
+
+## Delivery semantics
+
+Pub/Sub is **at-least-once**. Neither connector advertises exactly-once
+delivery — pair the source with an upsert sink keyed on `message_id` when
+replays must converge.
+
+License: MIT OR Apache-2.0.

--- a/crates/common/pubsub/src/client.rs
+++ b/crates/common/pubsub/src/client.rs
@@ -1,0 +1,84 @@
+//! Pub/Sub client construction. **This is the only module in the crate that
+//! touches the `gcloud-pubsub` / `gcloud-auth` SDK**, so a real-compile fixup
+//! (if the pinned SDK version's API differs) is localised here.
+
+use crate::config::{PubsubConnection, PubsubCredentials};
+use faucet_core::FaucetError;
+use gcloud_auth::credentials::CredentialsFile;
+use gcloud_pubsub::client::{Client, ClientConfig};
+
+fn auth_err(context: &str, e: impl std::fmt::Display) -> FaucetError {
+    FaucetError::Auth(format!("pubsub auth ({context}): {e}"))
+}
+
+/// Build a Pub/Sub [`Client`] from a [`PubsubConnection`].
+///
+/// * When an emulator host is configured (config `emulator_host` or the
+///   `PUBSUB_EMULATOR_HOST` env var), auth is skipped entirely and the client
+///   talks plaintext to the emulator.
+/// * Otherwise credentials are resolved per [`PubsubCredentials`] — ADC, a
+///   service-account key file, or an inline key — and all failures map to
+///   [`FaucetError::Auth`].
+///
+/// Construction is I/O-light: ADC token acquisition may touch the metadata
+/// server, but gRPC channels connect lazily on first RPC.
+pub async fn build_client(conn: &PubsubConnection) -> Result<Client, FaucetError> {
+    // The SDK reads `PUBSUB_EMULATOR_HOST` when assembling `ClientConfig`.
+    // Export an explicit config value so both signals converge on one code
+    // path. Connectors build their client once at startup, before spawning
+    // any worker task, so this process-env write is not racing readers.
+    if let Some(host) = &conn.emulator_host
+        && std::env::var_os("PUBSUB_EMULATOR_HOST").is_none()
+    {
+        // SAFETY: single-threaded startup path (no concurrent env access).
+        unsafe {
+            std::env::set_var("PUBSUB_EMULATOR_HOST", host);
+        }
+    }
+
+    let mut config = ClientConfig::default();
+    if let Some(project) = &conn.project_id {
+        config.project_id = Some(project.clone());
+    }
+    if let Some(endpoint) = &conn.endpoint {
+        config.endpoint = endpoint.clone();
+    }
+
+    // Emulator (or explicitly anonymous): no credentials.
+    let use_auth = conn.effective_emulator_host().is_none()
+        && conn.credentials != PubsubCredentials::Anonymous;
+
+    let config = if use_auth {
+        match &conn.credentials {
+            PubsubCredentials::Anonymous => config, // unreachable: filtered above
+            PubsubCredentials::ApplicationDefault => config
+                .with_auth()
+                .await
+                .map_err(|e| auth_err("application default", e))?,
+            PubsubCredentials::ServiceAccountJsonFile { path } => {
+                let cf = CredentialsFile::new_from_file(path.clone())
+                    .await
+                    .map_err(|e| auth_err("service-account file", e))?;
+                config
+                    .with_credentials(cf)
+                    .await
+                    .map_err(|e| auth_err("service-account file", e))?
+            }
+            PubsubCredentials::ServiceAccountJsonInline { json } => {
+                let cf = CredentialsFile::new_from_str(json)
+                    .await
+                    .map_err(|e| auth_err("inline service-account key", e))?;
+                config
+                    .with_credentials(cf)
+                    .await
+                    .map_err(|e| auth_err("inline service-account key", e))?
+            }
+        }
+    } else {
+        config
+    };
+
+    Client::new(config)
+        .await
+        .map_err(|e| FaucetError::Source(format!("pubsub: client build failed: {e}")))
+}

--- a/crates/common/pubsub/src/config.rs
+++ b/crates/common/pubsub/src/config.rs
@@ -1,0 +1,174 @@
+//! Credential + connection configuration shared by the Pub/Sub source and
+//! sink. No I/O here — the client builder lives in `client.rs`.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// How to authenticate with Google Cloud Pub/Sub.
+///
+/// Serializes as `{ type: <method>, config: { … } }` (adjacent tagging,
+/// snake_case discriminators) — the consistent auth wire shape shared by
+/// every faucet connector:
+/// `{ type: service_account_json_file, config: { path: "/run/secrets/sa.json" } }`.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "type", content = "config", rename_all = "snake_case")]
+pub enum PubsubCredentials {
+    /// Application Default Credentials — honours
+    /// `GOOGLE_APPLICATION_CREDENTIALS`, `GOOGLE_APPLICATION_CREDENTIALS_JSON`,
+    /// gcloud user creds, and the GCE/GKE metadata server, in that order.
+    #[default]
+    ApplicationDefault,
+    /// Path to a service-account JSON key file on disk.
+    ServiceAccountJsonFile {
+        /// Filesystem path to the service-account key JSON.
+        path: String,
+    },
+    /// Service-account JSON key as an inline string. Pair with
+    /// `${env:GCP_SA_JSON}` / `${secret:…}` interpolation in CLI configs so
+    /// the key never sits in the config file verbatim.
+    ServiceAccountJsonInline {
+        /// The service-account key JSON document.
+        json: String,
+    },
+    /// No credentials. Use with the Pub/Sub emulator, which does not validate
+    /// bearer tokens — the SDK otherwise tries to fetch ADC tokens at startup
+    /// and fails in environments without GCP credentials.
+    Anonymous,
+}
+
+/// Connection settings shared by the Pub/Sub source and sink. Flattened into
+/// each connector config via `#[serde(flatten)]`, so `project_id` /
+/// `endpoint` / `emulator_host` / `credentials` appear at the config top
+/// level.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct PubsubConnection {
+    /// GCP project id that owns the topic / subscription. Required for real
+    /// Pub/Sub; the emulator infers it from `PUBSUB_PROJECT_ID` when unset.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<String>,
+    /// Override the Pub/Sub API endpoint (host:port or URL). Rarely needed —
+    /// prefer `emulator_host` for the emulator.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub endpoint: Option<String>,
+    /// Point the client at a Pub/Sub emulator (`host:port`). When set, auth is
+    /// skipped and the endpoint is taken from this value — mirrors the
+    /// `PUBSUB_EMULATOR_HOST` environment variable the SDK honours.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub emulator_host: Option<String>,
+    /// How to authenticate. Defaults to Application Default Credentials.
+    #[serde(default)]
+    pub credentials: PubsubCredentials,
+}
+
+impl PubsubConnection {
+    /// Effective emulator host: the explicit config value, else the
+    /// `PUBSUB_EMULATOR_HOST` environment variable. `None` = real Pub/Sub.
+    pub fn effective_emulator_host(&self) -> Option<String> {
+        self.emulator_host
+            .clone()
+            .or_else(|| std::env::var("PUBSUB_EMULATOR_HOST").ok())
+            .filter(|h| !h.trim().is_empty())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn credentials_default_is_adc() {
+        assert_eq!(
+            PubsubCredentials::default(),
+            PubsubCredentials::ApplicationDefault
+        );
+    }
+
+    #[test]
+    fn credentials_serde_application_default() {
+        let v = serde_json::to_value(PubsubCredentials::ApplicationDefault).unwrap();
+        assert_eq!(v, json!({"type": "application_default"}));
+        let back: PubsubCredentials = serde_json::from_value(v).unwrap();
+        assert_eq!(back, PubsubCredentials::ApplicationDefault);
+    }
+
+    #[test]
+    fn credentials_serde_service_account_file_and_inline() {
+        let file = PubsubCredentials::ServiceAccountJsonFile {
+            path: "/run/secrets/sa.json".into(),
+        };
+        let v = serde_json::to_value(&file).unwrap();
+        assert_eq!(
+            v,
+            json!({"type": "service_account_json_file", "config": {"path": "/run/secrets/sa.json"}})
+        );
+        assert_eq!(
+            serde_json::from_value::<PubsubCredentials>(v).unwrap(),
+            file
+        );
+
+        let inline = PubsubCredentials::ServiceAccountJsonInline {
+            json: "{\"client_email\":\"x@y\"}".into(),
+        };
+        let v = serde_json::to_value(&inline).unwrap();
+        assert_eq!(v["type"], "service_account_json_inline");
+        assert_eq!(
+            serde_json::from_value::<PubsubCredentials>(v).unwrap(),
+            inline
+        );
+    }
+
+    #[test]
+    fn credentials_serde_anonymous() {
+        let v = serde_json::to_value(PubsubCredentials::Anonymous).unwrap();
+        assert_eq!(v, json!({"type": "anonymous"}));
+        assert_eq!(
+            serde_json::from_value::<PubsubCredentials>(v).unwrap(),
+            PubsubCredentials::Anonymous
+        );
+    }
+
+    #[test]
+    fn connection_flatten_shape_parses() {
+        let yaml = r#"
+project_id: my-proj
+emulator_host: "localhost:8085"
+credentials: { type: anonymous }
+"#;
+        let c: PubsubConnection = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(c.project_id.as_deref(), Some("my-proj"));
+        assert_eq!(c.emulator_host.as_deref(), Some("localhost:8085"));
+        assert_eq!(c.credentials, PubsubCredentials::Anonymous);
+    }
+
+    #[test]
+    fn connection_defaults() {
+        let c = PubsubConnection::default();
+        assert!(c.project_id.is_none());
+        assert!(c.endpoint.is_none());
+        assert!(c.emulator_host.is_none());
+        assert_eq!(c.credentials, PubsubCredentials::ApplicationDefault);
+    }
+
+    #[test]
+    fn effective_emulator_host_prefers_explicit() {
+        let c = PubsubConnection {
+            emulator_host: Some("localhost:8085".into()),
+            ..Default::default()
+        };
+        assert_eq!(
+            c.effective_emulator_host().as_deref(),
+            Some("localhost:8085")
+        );
+
+        // Blank explicit value is ignored.
+        let c = PubsubConnection {
+            emulator_host: Some("   ".into()),
+            ..Default::default()
+        };
+        // Only asserts the blank-explicit path; env-var state is process-wide
+        // so we don't assert on its presence/absence here.
+        let got = c.effective_emulator_host();
+        assert!(got.as_deref() != Some("   "));
+    }
+}

--- a/crates/common/pubsub/src/lib.rs
+++ b/crates/common/pubsub/src/lib.rs
@@ -1,0 +1,24 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+//! # faucet-common-pubsub
+//!
+//! Shared configuration types for the faucet-stream Google Cloud Pub/Sub
+//! source (`faucet-source-pubsub`) and sink (`faucet-sink-pubsub`)
+//! connectors: the [`PubsubCredentials`] auth enum, the [`PubsubConnection`]
+//! project / endpoint / emulator block, and the [`build_client`] helper that
+//! assembles a `gcloud_pubsub::client::Client`. Both connector crates
+//! re-export these so end-user imports do not change.
+//!
+//! Delivery is **at-least-once** — Pub/Sub itself provides no exactly-once
+//! primitive that composes with faucet's watermark model, so neither
+//! connector advertises exactly-once support.
+
+mod client;
+mod config;
+
+pub use client::build_client;
+pub use config::{PubsubConnection, PubsubCredentials};
+
+// Re-export the SDK message type connector authors round-trip through, so
+// downstream crates need only this crate on their import path.
+pub use gcloud_googleapis::pubsub::v1::PubsubMessage;

--- a/crates/common/redshift/Cargo.toml
+++ b/crates/common/redshift/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "faucet-common-redshift"
+version = "1.0.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Shared connection, credentials, and connection-pool types for the faucet-stream Amazon Redshift source and sink connectors"
+readme = "README.md"
+keywords = ["redshift", "postgres", "sql", "etl", "pipeline"]
+categories.workspace = true
+
+[dependencies]
+faucet-core.workspace = true
+serde = { workspace = true, features = ["derive"] }
+schemars.workspace = true
+sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls", "postgres"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
+serde_json.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/common/redshift/README.md
+++ b/crates/common/redshift/README.md
@@ -1,0 +1,46 @@
+# faucet-common-redshift
+
+Shared connection, credentials, and connection-pool types for the
+[`faucet-stream`](https://crates.io/crates/faucet-stream) Amazon Redshift
+**source** (`faucet-source-redshift`) and **sink** (`faucet-sink-redshift`)
+connectors.
+
+Redshift speaks the PostgreSQL wire protocol, so both connectors connect through
+`sqlx`'s Postgres driver. This crate centralises that so TLS, auth, and pooling
+behave identically on both sides.
+
+## Types
+
+- **`RedshiftCredentials`** — adjacently-tagged `{ type, config }` enum:
+  - `password` — username/password auth (the user comes from the connection
+    block). **The only mechanism implemented in v1.**
+  - `iam` / `redshift_data_api` — reserved for a future release; building a
+    client with either currently returns a typed
+    `FaucetError::Config`.
+- **`RedshiftConnection`** — `host`, `port` (default `5439`), `database`,
+  `user`, `credentials`, and a `tls` toggle (default `true`). Flattened into
+  both end configs.
+
+## Helpers
+
+- `build_connect_options(&RedshiftConnection)` — pure `PgConnectOptions` builder.
+  `tls: true` → `sslmode=require`; `tls: false` → `sslmode=prefer`.
+- `build_pool_lazy(conn, max)` — lazily-connected pool (no I/O at construction).
+- `build_pool(conn, max)` — eagerly validated pool (fails fast on bad creds).
+- `resolve_password(&RedshiftCredentials)` — extracts the password.
+
+## Example
+
+```yaml
+host: my-cluster.abc123.us-east-1.redshift.amazonaws.com
+port: 5439
+database: dev
+user: admin
+credentials:
+  type: password
+  config:
+    password: ${env:REDSHIFT_PASSWORD}
+tls: true
+```
+
+License: MIT OR Apache-2.0

--- a/crates/common/redshift/src/config.rs
+++ b/crates/common/redshift/src/config.rs
@@ -1,0 +1,269 @@
+//! Shared Amazon Redshift connection + credentials configuration.
+//!
+//! Redshift speaks the PostgreSQL wire protocol, so both the source and the
+//! sink connect through `sqlx`'s Postgres driver. This module holds the
+//! connection block (host / port / database / user + a TLS toggle) and the
+//! credentials enum that both connectors flatten into their own configs.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Default Redshift port.
+pub const DEFAULT_PORT: u16 = 5439;
+
+fn default_port() -> u16 {
+    DEFAULT_PORT
+}
+
+fn default_tls() -> bool {
+    true
+}
+
+/// How to authenticate with Amazon Redshift.
+///
+/// Serializes as `{ type: <method>, config: { … } }` (adjacent tagging,
+/// snake_case discriminators) — the consistent auth wire shape shared by every
+/// faucet connector.
+///
+/// v1 implements only [`RedshiftCredentials::Password`]. The [`Iam`] and
+/// [`RedshiftDataApi`] variants are accepted by the config parser (so a future
+/// version can add them without a breaking change) but currently return a typed
+/// [`FaucetError::Config`](faucet_core::FaucetError::Config) at client-build
+/// time.
+///
+/// [`Iam`]: RedshiftCredentials::Iam
+/// [`RedshiftDataApi`]: RedshiftCredentials::RedshiftDataApi
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "type", content = "config", rename_all = "snake_case")]
+pub enum RedshiftCredentials {
+    /// Username/password authentication (the user comes from
+    /// [`RedshiftConnection::user`]). The only mechanism supported in v1.
+    Password {
+        /// The password (use `${env:…}` / `${vault:…}` to inject it, never a
+        /// literal).
+        password: String,
+    },
+    /// IAM authentication via temporary cluster credentials
+    /// (`GetClusterCredentials`). **Not yet supported** — reserved for a future
+    /// version; building a client with this variant returns a typed error.
+    Iam {
+        /// AWS region of the cluster.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        region: Option<String>,
+        /// Provisioned cluster identifier used to request temporary credentials.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cluster_identifier: Option<String>,
+        /// Database user to authenticate as.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        db_user: Option<String>,
+    },
+    /// Authentication through the Redshift Data API (HTTP, not the PG wire).
+    /// **Not yet supported** — reserved for a future version; building a client
+    /// with this variant returns a typed error.
+    RedshiftDataApi {
+        /// AWS region.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        region: Option<String>,
+        /// Provisioned cluster identifier.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cluster_identifier: Option<String>,
+        /// Serverless workgroup name (alternative to `cluster_identifier`).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        workgroup_name: Option<String>,
+        /// Secrets Manager ARN holding the database credentials.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        secret_arn: Option<String>,
+        /// Database user to authenticate as.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        db_user: Option<String>,
+    },
+}
+
+impl std::fmt::Debug for RedshiftCredentials {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Password { .. } => write!(f, "Password(***)"),
+            Self::Iam {
+                region,
+                cluster_identifier,
+                db_user,
+            } => f
+                .debug_struct("Iam")
+                .field("region", region)
+                .field("cluster_identifier", cluster_identifier)
+                .field("db_user", db_user)
+                .finish(),
+            Self::RedshiftDataApi {
+                region,
+                cluster_identifier,
+                workgroup_name,
+                secret_arn,
+                db_user,
+            } => f
+                .debug_struct("RedshiftDataApi")
+                .field("region", region)
+                .field("cluster_identifier", cluster_identifier)
+                .field("workgroup_name", workgroup_name)
+                .field("secret_arn", secret_arn)
+                .field("db_user", db_user)
+                .finish(),
+        }
+    }
+}
+
+/// A Redshift connection: endpoint, database, user, credentials, and a TLS
+/// toggle. Flattened (`#[serde(flatten)]`) into both the source and sink
+/// configs so the connection fields appear at the config top level.
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+pub struct RedshiftConnection {
+    /// Cluster / endpoint host (e.g. `my-cluster.abc123.us-east-1.redshift.amazonaws.com`).
+    pub host: String,
+    /// Port. Defaults to [`DEFAULT_PORT`] (5439).
+    #[serde(default = "default_port")]
+    pub port: u16,
+    /// Database name.
+    pub database: String,
+    /// Database user.
+    pub user: String,
+    /// Authentication credentials.
+    pub credentials: RedshiftCredentials,
+    /// Whether to require TLS. Defaults to `true` (Redshift clusters require SSL
+    /// by default). `true` maps to `sslmode=require`; `false` maps to
+    /// `sslmode=prefer` (opportunistic TLS with plaintext fallback) — it never
+    /// forbids encryption outright.
+    #[serde(default = "default_tls")]
+    pub tls: bool,
+}
+
+impl RedshiftConnection {
+    /// Build a `Password` connection with sensible defaults (port 5439, TLS on).
+    pub fn new(
+        host: impl Into<String>,
+        database: impl Into<String>,
+        user: impl Into<String>,
+        password: impl Into<String>,
+    ) -> Self {
+        Self {
+            host: host.into(),
+            port: DEFAULT_PORT,
+            database: database.into(),
+            user: user.into(),
+            credentials: RedshiftCredentials::Password {
+                password: password.into(),
+            },
+            tls: true,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn debug_masks_password() {
+        let c = RedshiftCredentials::Password {
+            password: "s3cr3t".into(),
+        };
+        let dbg = format!("{c:?}");
+        assert!(dbg.contains("***"));
+        assert!(!dbg.contains("s3cr3t"));
+    }
+
+    #[test]
+    fn connection_debug_does_not_leak_password() {
+        let conn = RedshiftConnection::new("host", "db", "user", "hunter2");
+        let dbg = format!("{conn:?}");
+        assert!(!dbg.contains("hunter2"));
+        assert!(dbg.contains("host"));
+        assert!(dbg.contains("user"));
+    }
+
+    #[test]
+    fn password_credentials_round_trip() {
+        let c = RedshiftCredentials::Password {
+            password: "pw".into(),
+        };
+        let json = serde_json::to_string(&c).unwrap();
+        assert_eq!(json, r#"{"type":"password","config":{"password":"pw"}}"#);
+        let back: RedshiftCredentials = serde_json::from_str(&json).unwrap();
+        assert!(matches!(back, RedshiftCredentials::Password { .. }));
+    }
+
+    #[test]
+    fn connection_defaults_port_and_tls() {
+        let json = r#"{
+            "host": "h",
+            "database": "db",
+            "user": "u",
+            "credentials": {"type": "password", "config": {"password": "pw"}}
+        }"#;
+        let conn: RedshiftConnection = serde_json::from_str(json).unwrap();
+        assert_eq!(conn.port, DEFAULT_PORT);
+        assert!(conn.tls);
+    }
+
+    #[test]
+    fn iam_variant_deserializes() {
+        let json = r#"{"type":"iam","config":{"region":"us-east-1","db_user":"analyst"}}"#;
+        let c: RedshiftCredentials = serde_json::from_str(json).unwrap();
+        match c {
+            RedshiftCredentials::Iam {
+                region, db_user, ..
+            } => {
+                assert_eq!(region.as_deref(), Some("us-east-1"));
+                assert_eq!(db_user.as_deref(), Some("analyst"));
+            }
+            _ => panic!("expected Iam"),
+        }
+    }
+
+    #[test]
+    fn redshift_data_api_variant_deserializes() {
+        let json =
+            r#"{"type":"redshift_data_api","config":{"workgroup_name":"wg","secret_arn":"arn:x"}}"#;
+        let c: RedshiftCredentials = serde_json::from_str(json).unwrap();
+        assert!(matches!(c, RedshiftCredentials::RedshiftDataApi { .. }));
+    }
+
+    #[test]
+    fn iam_debug_renders_fields() {
+        let c = RedshiftCredentials::Iam {
+            region: Some("us-west-2".into()),
+            cluster_identifier: Some("prod-cluster".into()),
+            db_user: Some("analyst".into()),
+        };
+        let dbg = format!("{c:?}");
+        assert!(dbg.contains("Iam"));
+        assert!(dbg.contains("us-west-2"));
+        assert!(dbg.contains("prod-cluster"));
+        assert!(dbg.contains("analyst"));
+    }
+
+    #[test]
+    fn redshift_data_api_debug_renders_fields() {
+        let c = RedshiftCredentials::RedshiftDataApi {
+            region: Some("eu-central-1".into()),
+            cluster_identifier: None,
+            workgroup_name: Some("wg-1".into()),
+            secret_arn: Some("arn:aws:secretsmanager:x".into()),
+            db_user: Some("svc".into()),
+        };
+        let dbg = format!("{c:?}");
+        assert!(dbg.contains("RedshiftDataApi"));
+        assert!(dbg.contains("eu-central-1"));
+        assert!(dbg.contains("wg-1"));
+        assert!(dbg.contains("svc"));
+    }
+
+    #[test]
+    fn iam_and_data_api_round_trip_full_fields() {
+        let iam = r#"{"type":"iam","config":{"region":"us-east-1","cluster_identifier":"c1","db_user":"u"}}"#;
+        let back: RedshiftCredentials = serde_json::from_str(iam).unwrap();
+        assert_eq!(serde_json::to_string(&back).unwrap(), iam);
+
+        let api = r#"{"type":"redshift_data_api","config":{"region":"us-east-1","cluster_identifier":"c1","workgroup_name":"wg","secret_arn":"arn","db_user":"u"}}"#;
+        let back: RedshiftCredentials = serde_json::from_str(api).unwrap();
+        assert_eq!(serde_json::to_string(&back).unwrap(), api);
+    }
+}

--- a/crates/common/redshift/src/lib.rs
+++ b/crates/common/redshift/src/lib.rs
@@ -1,0 +1,27 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+//! # faucet-common-redshift
+//!
+//! Shared connection, credentials, and connection-pool types for the
+//! [`faucet-stream`](https://crates.io/crates/faucet-stream) Amazon Redshift
+//! source and sink connectors.
+//!
+//! Redshift is wire-compatible with PostgreSQL, so both connectors talk to it
+//! through `sqlx`'s Postgres driver.
+//!
+//! - [`RedshiftCredentials`] — `password` (implemented in v1), plus reserved
+//!   `iam` / `redshift_data_api` variants that currently return a typed error.
+//! - [`RedshiftConnection`] — host / port / database / user + a TLS toggle;
+//!   flattened into both end configs so the wire shape matches the other SQL
+//!   connectors.
+//! - [`build_connect_options`] / [`build_pool`] / [`build_pool_lazy`] — the
+//!   single place a `sqlx` [`PgConnectOptions`](sqlx::postgres::PgConnectOptions)
+//!   and a [`PgPool`](sqlx::PgPool) are constructed.
+//! - [`resolve_password`] — extracts the password (and is where an unsupported
+//!   credential variant surfaces its error).
+
+mod config;
+mod pool;
+
+pub use config::{DEFAULT_PORT, RedshiftConnection, RedshiftCredentials};
+pub use pool::{build_connect_options, build_pool, build_pool_lazy, resolve_password};

--- a/crates/common/redshift/src/pool.rs
+++ b/crates/common/redshift/src/pool.rs
@@ -1,0 +1,196 @@
+//! Connection-option and pool construction over `sqlx`'s Postgres driver.
+//!
+//! Both the Redshift source and sink build their pools here so TLS, auth, and
+//! pooling behave identically. Redshift is wire-compatible with PostgreSQL, so
+//! this is the same `sqlx::PgPool` machinery the native Postgres connectors use.
+
+use faucet_core::FaucetError;
+use sqlx::PgPool;
+use sqlx::postgres::{PgConnectOptions, PgPoolOptions, PgSslMode};
+
+use crate::config::{RedshiftConnection, RedshiftCredentials};
+
+/// Resolve the password for the connection's credentials.
+///
+/// Returns [`FaucetError::Config`] for the `iam` / `redshift_data_api` variants,
+/// which are reserved but not yet implemented in v1.
+pub fn resolve_password(creds: &RedshiftCredentials) -> Result<&str, FaucetError> {
+    match creds {
+        RedshiftCredentials::Password { password } => Ok(password.as_str()),
+        RedshiftCredentials::Iam { .. } => Err(FaucetError::Config(
+            "redshift: IAM authentication is not yet supported (v1 supports password auth only) \
+             — use credentials: { type: password, config: { password: … } }"
+                .into(),
+        )),
+        RedshiftCredentials::RedshiftDataApi { .. } => Err(FaucetError::Config(
+            "redshift: Redshift Data API authentication is not yet supported (v1 supports \
+             password auth only) — use credentials: { type: password, config: { password: … } }"
+                .into(),
+        )),
+    }
+}
+
+/// Build the `sqlx` [`PgConnectOptions`] for a [`RedshiftConnection`].
+///
+/// Pure (no I/O): validates the required fields, resolves the password (this is
+/// where an unsupported credential variant surfaces its typed error), and maps
+/// the TLS toggle onto an `sslmode`.
+pub fn build_connect_options(conn: &RedshiftConnection) -> Result<PgConnectOptions, FaucetError> {
+    if conn.host.trim().is_empty() {
+        return Err(FaucetError::Config(
+            "redshift: `host` must not be empty".into(),
+        ));
+    }
+    if conn.database.trim().is_empty() {
+        return Err(FaucetError::Config(
+            "redshift: `database` must not be empty".into(),
+        ));
+    }
+    if conn.user.trim().is_empty() {
+        return Err(FaucetError::Config(
+            "redshift: `user` must not be empty".into(),
+        ));
+    }
+    let password = resolve_password(&conn.credentials)?;
+    let ssl_mode = if conn.tls {
+        PgSslMode::Require
+    } else {
+        PgSslMode::Prefer
+    };
+    Ok(PgConnectOptions::new()
+        .host(&conn.host)
+        .port(conn.port)
+        .database(&conn.database)
+        .username(&conn.user)
+        .password(password)
+        .ssl_mode(ssl_mode)
+        .application_name("faucet"))
+}
+
+/// Build a lazily-connected pool (no I/O at construction). The first query
+/// establishes the connection; connectivity/auth errors surface then (or via
+/// [`faucet_core::Source::check`] / [`faucet_core::Sink::check`]). Used by the
+/// connectors' `new()` so construction stays offline-safe.
+pub fn build_pool_lazy(
+    conn: &RedshiftConnection,
+    max_connections: u32,
+) -> Result<PgPool, FaucetError> {
+    let opts = build_connect_options(conn)?;
+    Ok(PgPoolOptions::new()
+        .max_connections(max_connections.max(1))
+        .connect_lazy_with(opts))
+}
+
+/// Build a pool and eagerly validate one connection so bad credentials / an
+/// unreachable host fail fast.
+pub async fn build_pool(
+    conn: &RedshiftConnection,
+    max_connections: u32,
+) -> Result<PgPool, FaucetError> {
+    let opts = build_connect_options(conn)?;
+    PgPoolOptions::new()
+        .max_connections(max_connections.max(1))
+        .connect_with(opts)
+        .await
+        .map_err(|e| FaucetError::Config(format!("redshift connection failed: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn conn() -> RedshiftConnection {
+        RedshiftConnection::new("host.example.com", "dev", "admin", "pw")
+    }
+
+    #[test]
+    fn build_options_succeeds_for_password() {
+        assert!(build_connect_options(&conn()).is_ok());
+    }
+
+    #[test]
+    fn build_options_rejects_empty_host() {
+        let mut c = conn();
+        c.host = "  ".into();
+        assert!(matches!(
+            build_connect_options(&c),
+            Err(FaucetError::Config(_))
+        ));
+    }
+
+    #[test]
+    fn build_options_rejects_empty_database() {
+        let mut c = conn();
+        c.database = String::new();
+        assert!(matches!(
+            build_connect_options(&c),
+            Err(FaucetError::Config(_))
+        ));
+    }
+
+    #[test]
+    fn build_options_rejects_empty_user() {
+        let mut c = conn();
+        c.user = String::new();
+        assert!(matches!(
+            build_connect_options(&c),
+            Err(FaucetError::Config(_))
+        ));
+    }
+
+    #[test]
+    fn resolve_password_returns_password() {
+        let creds = RedshiftCredentials::Password {
+            password: "hunter2".into(),
+        };
+        assert_eq!(resolve_password(&creds).unwrap(), "hunter2");
+    }
+
+    #[test]
+    fn resolve_password_rejects_iam_with_typed_error() {
+        let creds = RedshiftCredentials::Iam {
+            region: None,
+            cluster_identifier: None,
+            db_user: None,
+        };
+        match resolve_password(&creds) {
+            Err(FaucetError::Config(m)) => assert!(m.contains("IAM"), "got: {m}"),
+            other => panic!("expected Config error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_password_rejects_data_api_with_typed_error() {
+        let creds = RedshiftCredentials::RedshiftDataApi {
+            region: None,
+            cluster_identifier: None,
+            workgroup_name: None,
+            secret_arn: None,
+            db_user: None,
+        };
+        match resolve_password(&creds) {
+            Err(FaucetError::Config(m)) => assert!(m.contains("Data API"), "got: {m}"),
+            other => panic!("expected Config error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn build_connect_options_surfaces_unsupported_credentials() {
+        let mut c = conn();
+        c.credentials = RedshiftCredentials::Iam {
+            region: None,
+            cluster_identifier: None,
+            db_user: None,
+        };
+        assert!(build_connect_options(&c).is_err());
+    }
+
+    #[tokio::test]
+    async fn build_pool_lazy_does_no_io() {
+        // connect_lazy_with never contacts the server, so this is Ok even
+        // against an unreachable host, and no connections are opened yet.
+        // (sqlx spawns a pool maintenance task, so this needs a Tokio runtime.)
+        let pool = build_pool_lazy(&conn(), 4).unwrap();
+        assert_eq!(pool.size(), 0);
+    }
+}

--- a/crates/sink/azure-blob/Cargo.toml
+++ b/crates/sink/azure-blob/Cargo.toml
@@ -1,0 +1,49 @@
+[package]
+name = "faucet-sink-azure-blob"
+version = "1.0.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Azure Blob Storage / ADLS Gen2 sink connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords = ["azure", "blob", "adls", "storage", "sink"]
+categories.workspace = true
+
+[dependencies]
+faucet-core.workspace = true
+faucet-common-azure.workspace = true
+schemars.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+async-trait.workspace = true
+tracing.workspace = true
+tokio.workspace = true
+futures.workspace = true
+bytes.workspace = true
+uuid.workspace = true
+object_store = { workspace = true, features = ["azure"] }
+
+[features]
+compression = ["faucet-core/compression"]
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "io-util", "sync"] }
+serde_json.workspace = true
+faucet-conformance.workspace = true
+schemars.workspace = true
+futures.workspace = true
+testcontainers = "0.27"
+testcontainers-modules = { version = "0.15", features = ["azurite"] }
+# Verifies written blobs against Azurite through the same `object_store` Azure
+# client the connector uses (available to the integration-test target because
+# `object_store` is a normal dependency).
+object_store = { workspace = true, features = ["azure"] }
+# `object_store` cannot create a blob container; the Azure SDK does (this is the
+# proven Azurite path used by `testcontainers-modules`' own tests).
+azure_storage = "0.21"
+azure_storage_blobs = "0.21"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/sink/azure-blob/README.md
+++ b/crates/sink/azure-blob/README.md
@@ -1,0 +1,54 @@
+# faucet-sink-azure-blob
+
+Azure Blob Storage / ADLS Gen2 **sink** connector for the
+[`faucet-stream`](https://crates.io/crates/faucet-stream) ecosystem.
+
+Writes JSON records to an Azure blob container (or ADLS Gen2 filesystem) as JSON
+Lines objects. Built on [`object_store`](https://crates.io/crates/object_store)'s
+Azure backend, so classic Blob and ADLS Gen2 are served through one code path.
+
+## Config
+
+Connection fields come from `faucet-common-azure` and are set at the top level:
+
+| Field | Type | Notes |
+|---|---|---|
+| `container` | string | **Required.** Blob container / ADLS filesystem (must already exist). |
+| `account` | string | Storage-account name (optional with a connection string / emulator). |
+| `auth` | `{ type, config }` | `account_key` / `sas_token` / `connection_string` / `managed_identity` / `service_principal` / `default`. |
+| `endpoint` | string | Custom blob endpoint (emulator / sovereign cloud). |
+| `allow_http` | bool | Permit plaintext HTTP (Azurite). |
+| `use_emulator` | bool | Target the Azurite emulator. |
+
+Sink-specific fields:
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `prefix` | string | `""` | Object-name prefix; a virtual "directory" in the flat blob namespace. |
+| `file_extension` | string | `.jsonl` | Extension for written objects. |
+| `max_records_per_file` | int | — | Cap records per object (file rollover). |
+| `concurrency` | int | `10` | Max concurrent uploads. |
+| `batch_size` | int | `1000` | Records per object; `0` writes one object per `write_batch` (recommended). |
+| `compression` | enum | `auto` | `auto` / `gzip` / `zstd` (requires the `compression` feature); resolved from `file_extension`. |
+
+Object names are `{prefix}{uuidv7}{file_extension}` — time-sortable so a listing
+returns objects in write order. The container is not created automatically; the
+prefix is virtual (blob namespaces are flat).
+
+## Example
+
+```yaml
+pipeline:
+  sink:
+    type: azure-blob
+    config:
+      container: exports
+      account: mystorageacct
+      auth: { type: account_key, config: { account_key: "${env:AZURE_KEY}" } }
+      prefix: events/2026/
+      batch_size: 0
+```
+
+## License
+
+MIT

--- a/crates/sink/azure-blob/src/config.rs
+++ b/crates/sink/azure-blob/src/config.rs
@@ -1,0 +1,216 @@
+//! Azure Blob sink configuration.
+
+use faucet_common_azure::{AzureConnection, AzureCredentials};
+use faucet_core::DEFAULT_BATCH_SIZE;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Configuration for the Azure Blob sink connector.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct AzureBlobSinkConfig {
+    /// Azure connection (container, account, credentials, endpoint, …).
+    #[serde(flatten)]
+    pub connection: AzureConnection,
+    /// Object-name prefix for written objects.
+    #[serde(default)]
+    pub prefix: String,
+    /// File extension for written objects (default `.jsonl`).
+    #[serde(default = "default_file_extension")]
+    pub file_extension: String,
+    /// Hard cap on records per uploaded object. `None` means a single object
+    /// per `write_batch` call (still subject to `batch_size`).
+    pub max_records_per_file: Option<usize>,
+    /// Maximum number of concurrent uploads (default 10).
+    #[serde(default = "default_concurrency")]
+    pub concurrency: usize,
+    /// Records per uploaded object from a single `write_batch` call.
+    /// `batch_size = 0` writes whatever upstream hands the sink as one object.
+    /// Recommended value for object stores is `0` — many tiny objects is a
+    /// well-known anti-pattern.
+    #[serde(default = "default_batch_size")]
+    pub batch_size: usize,
+    /// Compression codec applied to each uploaded object body. Defaults to
+    /// [`CompressionConfig::Auto`](faucet_core::CompressionConfig::Auto) —
+    /// resolves against `file_extension` (so `.jsonl.gz` triggers gzip).
+    /// Requires the crate-local `compression` feature. Note: this sink does
+    /// **not** set any `Content-Encoding` metadata, so consumers must
+    /// decompress explicitly.
+    #[cfg(feature = "compression")]
+    #[serde(default)]
+    pub compression: faucet_core::CompressionConfig,
+}
+
+fn default_file_extension() -> String {
+    ".jsonl".to_string()
+}
+fn default_batch_size() -> usize {
+    DEFAULT_BATCH_SIZE
+}
+fn default_concurrency() -> usize {
+    10
+}
+
+impl AzureBlobSinkConfig {
+    /// Create a new config for `container` with sensible defaults.
+    pub fn new(container: impl Into<String>) -> Self {
+        Self {
+            connection: AzureConnection::new(container),
+            prefix: String::new(),
+            file_extension: default_file_extension(),
+            max_records_per_file: None,
+            concurrency: default_concurrency(),
+            batch_size: default_batch_size(),
+            #[cfg(feature = "compression")]
+            compression: faucet_core::CompressionConfig::Auto,
+        }
+    }
+
+    /// Set the storage-account name.
+    pub fn account(mut self, account: impl Into<String>) -> Self {
+        self.connection = self.connection.account(account);
+        self
+    }
+
+    /// Set the credential source.
+    pub fn auth(mut self, creds: AzureCredentials) -> Self {
+        self.connection = self.connection.auth(creds);
+        self
+    }
+
+    /// Set a custom blob endpoint (emulator / sovereign cloud).
+    pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
+        self.connection = self.connection.endpoint(endpoint);
+        self
+    }
+
+    /// Permit plaintext HTTP (required for the Azurite emulator).
+    pub fn allow_http(mut self, allow: bool) -> Self {
+        self.connection = self.connection.allow_http(allow);
+        self
+    }
+
+    /// Target the Azurite emulator.
+    pub fn use_emulator(mut self, use_emulator: bool) -> Self {
+        self.connection = self.connection.use_emulator(use_emulator);
+        self
+    }
+
+    /// Set the written-object name prefix.
+    pub fn prefix(mut self, p: impl Into<String>) -> Self {
+        self.prefix = p.into();
+        self
+    }
+
+    /// Set the written-object file extension.
+    pub fn file_extension(mut self, ext: impl Into<String>) -> Self {
+        self.file_extension = ext.into();
+        self
+    }
+
+    /// Cap records per uploaded object.
+    pub fn max_records_per_file(mut self, n: usize) -> Self {
+        self.max_records_per_file = Some(n);
+        self
+    }
+
+    /// Set the maximum concurrent uploads.
+    pub fn concurrency(mut self, n: usize) -> Self {
+        self.concurrency = n;
+        self
+    }
+
+    /// Set the records-per-object `batch_size`.
+    pub fn with_batch_size(mut self, n: usize) -> Self {
+        self.batch_size = n;
+        self
+    }
+
+    /// Set the compression codec. Available only with the `compression` feature.
+    #[cfg(feature = "compression")]
+    pub fn compression(mut self, c: faucet_core::CompressionConfig) -> Self {
+        self.compression = c;
+        self
+    }
+
+    /// The container name.
+    pub fn container(&self) -> &str {
+        &self.connection.container
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults() {
+        let c = AzureBlobSinkConfig::new("cont");
+        assert_eq!(c.container(), "cont");
+        assert_eq!(c.prefix, "");
+        assert_eq!(c.connection.auth, AzureCredentials::Default);
+        assert_eq!(c.file_extension, ".jsonl");
+        assert!(c.max_records_per_file.is_none());
+        assert_eq!(c.concurrency, 10);
+        assert_eq!(c.batch_size, faucet_core::DEFAULT_BATCH_SIZE);
+    }
+
+    #[test]
+    fn builder_methods() {
+        let c = AzureBlobSinkConfig::new("cont")
+            .account("acct")
+            .prefix("out/")
+            .file_extension(".ndjson")
+            .max_records_per_file(500)
+            .concurrency(4)
+            .with_batch_size(0)
+            .auth(AzureCredentials::SasToken {
+                sas_token: "sv=x".into(),
+            });
+        assert_eq!(c.connection.account.as_deref(), Some("acct"));
+        assert_eq!(c.prefix, "out/");
+        assert_eq!(c.file_extension, ".ndjson");
+        assert_eq!(c.max_records_per_file, Some(500));
+        assert_eq!(c.concurrency, 4);
+        assert_eq!(c.batch_size, 0);
+        assert!(matches!(
+            c.connection.auth,
+            AzureCredentials::SasToken { .. }
+        ));
+    }
+
+    #[test]
+    fn batch_size_sentinel_accepted_and_above_max_rejected() {
+        assert!(faucet_core::validate_batch_size(0).is_ok());
+        assert!(faucet_core::validate_batch_size(faucet_core::MAX_BATCH_SIZE + 1).is_err());
+    }
+
+    #[test]
+    fn deserializes_flattened_connection() {
+        let json = r#"{
+            "container": "cont",
+            "account": "acct",
+            "prefix": "out/",
+            "auth": { "type": "sas_token", "config": { "sas_token": "sv=x" } }
+        }"#;
+        let c: AzureBlobSinkConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(c.container(), "cont");
+        assert_eq!(c.prefix, "out/");
+        assert_eq!(c.batch_size, faucet_core::DEFAULT_BATCH_SIZE);
+        assert!(matches!(
+            c.connection.auth,
+            AzureCredentials::SasToken { .. }
+        ));
+    }
+
+    #[test]
+    fn schema_generates_without_panicking() {
+        let _ = faucet_core::schema_for!(AzureBlobSinkConfig);
+    }
+
+    #[cfg(feature = "compression")]
+    #[test]
+    fn compression_default_is_auto() {
+        let cfg = AzureBlobSinkConfig::new("cont");
+        assert_eq!(cfg.compression, faucet_core::CompressionConfig::Auto);
+    }
+}

--- a/crates/sink/azure-blob/src/lib.rs
+++ b/crates/sink/azure-blob/src/lib.rs
@@ -1,0 +1,14 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+//! Azure Blob Storage / ADLS Gen2 sink connector.
+//!
+//! Writes JSON records to an Azure blob container (or ADLS Gen2 filesystem) as
+//! JSON Lines objects. See the crate-level README for the config-field
+//! reference.
+
+mod config;
+mod sink;
+
+pub use config::AzureBlobSinkConfig;
+pub use faucet_common_azure::{AzureConnection, AzureCredentials};
+pub use sink::AzureBlobSink;

--- a/crates/sink/azure-blob/src/sink.rs
+++ b/crates/sink/azure-blob/src/sink.rs
@@ -1,0 +1,260 @@
+//! Azure Blob sink executor.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use faucet_common_azure::build_store;
+use faucet_core::FaucetError;
+use futures::stream::{self, StreamExt, TryStreamExt};
+use object_store::path::Path as ObjectPath;
+use object_store::{ObjectStore, ObjectStoreExt};
+use serde_json::Value;
+
+use crate::config::AzureBlobSinkConfig;
+
+/// A sink that writes JSON records to Azure Blob as JSON Lines objects.
+pub struct AzureBlobSink {
+    config: AzureBlobSinkConfig,
+    store: Arc<dyn ObjectStore>,
+}
+
+impl AzureBlobSink {
+    /// Construct the sink, building the object store eagerly so it is reused
+    /// across calls.
+    pub async fn new(config: AzureBlobSinkConfig) -> Result<Self, FaucetError> {
+        faucet_core::validate_batch_size(config.batch_size)?;
+        let store = build_store(&config.connection)?;
+        Ok(Self { config, store })
+    }
+
+    /// Serialize a slice of records as a JSON Lines byte buffer.
+    fn serialize_jsonl(records: &[Value]) -> Result<Vec<u8>, FaucetError> {
+        let mut buf: Vec<u8> = Vec::new();
+        for record in records {
+            let line = serde_json::to_vec(record)
+                .map_err(|e| FaucetError::Sink(format!("JSON serialization failed: {e}")))?;
+            buf.extend_from_slice(&line);
+            buf.push(b'\n');
+        }
+        Ok(buf)
+    }
+
+    /// Generate a time-sortable UUIDv7 object name.
+    fn generate_key(&self) -> String {
+        generate_object_key(&self.config.prefix, &self.config.file_extension)
+    }
+
+    /// Upload a single JSONL object.
+    async fn upload_file(&self, key: &str, body: Vec<u8>) -> Result<(), FaucetError> {
+        #[cfg(feature = "compression")]
+        let body = {
+            let codec = self.config.compression.resolve(&self.config.file_extension);
+            faucet_core::compression::warn_mismatch(&self.config.file_extension, codec);
+            faucet_core::compression::compress_buf(&body, codec)?
+        };
+
+        let path = ObjectPath::from(key);
+        let payload = bytes::Bytes::from(body);
+        self.store.put(&path, payload.into()).await.map_err(|e| {
+            FaucetError::Sink(format!("azure put object error for key '{key}': {e}"))
+        })?;
+        tracing::debug!(key = %key, "Uploaded Azure object");
+        Ok(())
+    }
+
+    /// Effective per-object chunk size (smaller of `batch_size` and
+    /// `max_records_per_file`).
+    fn effective_chunk_size(&self) -> usize {
+        resolve_effective_chunk_size(&self.config)
+    }
+}
+
+#[async_trait]
+impl faucet_core::Sink for AzureBlobSink {
+    fn dataset_uri(&self) -> String {
+        format!("az://{}/{}", self.config.container(), self.config.prefix)
+    }
+
+    async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
+        if records.is_empty() {
+            return Ok(0);
+        }
+        let chunk = self.effective_chunk_size();
+        let concurrency = self.config.concurrency.max(1);
+
+        let uploads: Vec<(String, Vec<u8>)> = records
+            .chunks(chunk)
+            .map(|slice| {
+                let body = Self::serialize_jsonl(slice)?;
+                Ok::<(String, Vec<u8>), FaucetError>((self.generate_key(), body))
+            })
+            .collect::<Result<_, _>>()?;
+
+        let written = records.len();
+        let files = uploads.len();
+        stream::iter(uploads)
+            .map(|(key, body)| async move { self.upload_file(&key, body).await })
+            .buffer_unordered(concurrency)
+            .try_collect::<Vec<()>>()
+            .await?;
+
+        tracing::info!(records = written, files, "Azure batch write complete");
+        Ok(written)
+    }
+
+    fn config_schema(&self) -> Value {
+        serde_json::to_value(faucet_core::schema_for!(AzureBlobSinkConfig))
+            .expect("schema serialization")
+    }
+
+    fn connector_name(&self) -> &'static str {
+        "azure-blob"
+    }
+
+    /// Preflight probe: confirm the container is reachable and the credentials
+    /// work via a non-mutating listing capped at a single item. Uploads
+    /// nothing.
+    async fn check(
+        &self,
+        ctx: &faucet_core::check::CheckContext,
+    ) -> Result<faucet_core::check::CheckReport, FaucetError> {
+        use faucet_core::check::{CheckReport, Probe};
+
+        let started = std::time::Instant::now();
+        let probe = match tokio::time::timeout(ctx.timeout, async {
+            let mut listing = self.store.list(None);
+            listing.next().await
+        })
+        .await
+        {
+            Ok(None) | Ok(Some(Ok(_))) => Probe::pass("auth", started.elapsed()),
+            Ok(Some(Err(e))) => Probe::fail_hint(
+                "auth",
+                started.elapsed(),
+                e.to_string(),
+                "check account, container, credentials, and network",
+            ),
+            Err(_) => Probe::fail("network", started.elapsed(), "timed out"),
+        };
+        Ok(CheckReport::single(probe))
+    }
+}
+
+/// Pure chunk-size resolution — unit tested directly so the test surface needs
+/// no object store.
+fn resolve_effective_chunk_size(config: &AzureBlobSinkConfig) -> usize {
+    let bs = if config.batch_size == 0 {
+        usize::MAX
+    } else {
+        config.batch_size
+    };
+    let mr = config.max_records_per_file.unwrap_or(usize::MAX);
+    bs.min(mr)
+}
+
+/// Pure object-key generation — UUIDv7 makes keys time-sortable so a listing of
+/// the destination returns objects in write order.
+fn generate_object_key(prefix: &str, file_extension: &str) -> String {
+    format!("{prefix}{}{file_extension}", uuid::Uuid::now_v7())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn new_rejects_out_of_range_batch_size() {
+        let mut config = AzureBlobSinkConfig::new("cont");
+        config.batch_size = faucet_core::MAX_BATCH_SIZE + 1;
+        match AzureBlobSink::new(config).await {
+            Err(FaucetError::Config(m)) => assert!(m.contains("batch_size"), "got: {m}"),
+            Ok(_) => panic!("expected a batch_size Config error, got Ok(sink)"),
+            Err(e) => panic!("expected a batch_size Config error, got {e:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn new_rejects_empty_container() {
+        let config = AzureBlobSinkConfig::new("   ");
+        match AzureBlobSink::new(config).await {
+            Err(FaucetError::Config(m)) => assert!(m.contains("container"), "got: {m}"),
+            Ok(_) => panic!("expected a container Config error, got Ok(sink)"),
+            Err(e) => panic!("expected a container Config error, got {e:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn new_builds_lazily_with_emulator() {
+        use faucet_core::Sink as _;
+        let config = AzureBlobSinkConfig::new("cont")
+            .prefix("out/")
+            .use_emulator(true)
+            .allow_http(true);
+        let sink = AzureBlobSink::new(config).await.unwrap();
+        assert_eq!(sink.connector_name(), "azure-blob");
+        assert_eq!(sink.dataset_uri(), "az://cont/out/");
+    }
+
+    #[test]
+    fn serialize_jsonl_two_records() {
+        let body = AzureBlobSink::serialize_jsonl(&[json!({"a": 1}), json!({"b": 2})]).unwrap();
+        assert_eq!(
+            std::str::from_utf8(&body).unwrap(),
+            "{\"a\":1}\n{\"b\":2}\n"
+        );
+    }
+
+    #[test]
+    fn serialize_jsonl_empty_is_empty() {
+        let body = AzureBlobSink::serialize_jsonl(&[]).unwrap();
+        assert!(body.is_empty());
+    }
+
+    #[test]
+    fn effective_chunk_size_unlimited_when_both_unset() {
+        let cfg = AzureBlobSinkConfig::new("c").with_batch_size(0);
+        assert_eq!(resolve_effective_chunk_size(&cfg), usize::MAX);
+    }
+
+    #[test]
+    fn effective_chunk_size_takes_smaller_limit() {
+        let cfg = AzureBlobSinkConfig::new("c")
+            .with_batch_size(500)
+            .max_records_per_file(100);
+        assert_eq!(resolve_effective_chunk_size(&cfg), 100);
+    }
+
+    #[test]
+    fn effective_chunk_size_uses_batch_size_when_smaller() {
+        let cfg = AzureBlobSinkConfig::new("c")
+            .with_batch_size(50)
+            .max_records_per_file(500);
+        assert_eq!(resolve_effective_chunk_size(&cfg), 50);
+    }
+
+    #[test]
+    fn generate_key_uses_prefix_and_extension() {
+        let key = generate_object_key("out/", ".ndjson");
+        assert!(key.starts_with("out/"));
+        assert!(key.ends_with(".ndjson"));
+    }
+
+    #[test]
+    fn generate_key_yields_distinct_time_ordered_keys() {
+        let a = generate_object_key("p/", ".jsonl");
+        let b = generate_object_key("p/", ".jsonl");
+        assert_ne!(a, b);
+        assert!(a < b, "expected UUIDv7 keys to sort by generation order");
+    }
+
+    #[cfg(feature = "compression")]
+    #[test]
+    fn compress_buf_used_for_gzip_extension() {
+        let cfg = AzureBlobSinkConfig::new("c").file_extension(".jsonl.gz");
+        let codec = cfg.compression.resolve(&cfg.file_extension);
+        assert_eq!(codec, faucet_core::Compression::Gzip);
+        let compressed = faucet_core::compression::compress_buf(b"hello\n", codec).unwrap();
+        assert_eq!(&compressed[..2], b"\x1f\x8b");
+    }
+}

--- a/crates/sink/azure-blob/tests/integration.rs
+++ b/crates/sink/azure-blob/tests/integration.rs
@@ -1,0 +1,300 @@
+//! Integration tests for `faucet-sink-azure-blob` against an auto-started
+//! Azurite emulator (via `testcontainers-modules`).
+//!
+//! These boot a real Azurite container, create a destination blob container,
+//! drive the connector's real write path (`write_batch` + `flush`), then read
+//! the written objects back through an `object_store` Azure client and assert
+//! the JSONL bodies. They are **not** `#[ignore]`d and **not** env-gated — CI's
+//! `--all-features` test/coverage jobs run them with Docker present, which is
+//! what exercises the serialize / key-generation / upload / rollover lines in
+//! `src/sink.rs`.
+//!
+//! Container creation goes through the Azure SDK (`object_store` cannot create a
+//! container); every other blob operation goes through `object_store`.
+
+#![cfg(not(target_os = "windows"))]
+
+use std::sync::Arc;
+
+use faucet_core::Sink;
+use faucet_sink_azure_blob::{AzureBlobSink, AzureBlobSinkConfig, AzureCredentials};
+use futures::StreamExt;
+use object_store::azure::MicrosoftAzureBuilder;
+use object_store::path::Path as ObjPath;
+use object_store::{ObjectStore, ObjectStoreExt};
+use serde_json::{Value, json};
+use testcontainers_modules::azurite::{Azurite, BLOB_PORT};
+use testcontainers_modules::testcontainers::ContainerAsync;
+use testcontainers_modules::testcontainers::runners::AsyncRunner;
+
+/// Well-known Azurite dev account + key (`devstoreaccount1`).
+const AZURITE_ACCOUNT: &str = "devstoreaccount1";
+const AZURITE_KEY: &str =
+    "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
+const CONTAINER: &str = "faucet-test";
+
+// Azurite is lightweight, but `cargo test` runs a binary's tests concurrently;
+// serialize so at most one emulator container runs at a time (steadier on CI).
+static SERIAL: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+/// Start Azurite; return the container handle plus its mapped blob port. The
+/// handle must be held for the duration of the test to keep the container up.
+async fn start_azurite() -> (ContainerAsync<Azurite>, u16) {
+    let container = Azurite::default()
+        .start()
+        .await
+        .expect("start azurite container");
+    let port = container
+        .get_host_port_ipv4(BLOB_PORT)
+        .await
+        .expect("azurite blob host port");
+    (container, port)
+}
+
+fn endpoint(port: u16) -> String {
+    format!("http://127.0.0.1:{port}/{AZURITE_ACCOUNT}")
+}
+
+/// Create the destination blob container via the Azure SDK (`object_store` has
+/// no container-management API).
+async fn create_container(port: u16) {
+    use azure_storage::{CloudLocation, prelude::*};
+    use azure_storage_blobs::prelude::*;
+
+    ClientBuilder::with_location(
+        CloudLocation::Emulator {
+            address: "127.0.0.1".to_owned(),
+            port,
+        },
+        StorageCredentials::emulator(),
+    )
+    .container_client(CONTAINER)
+    .create()
+    .await
+    .expect("create azurite blob container");
+}
+
+/// Build an `object_store` Azure client for reading the written objects back.
+fn verify_store(port: u16) -> Arc<dyn ObjectStore> {
+    Arc::new(
+        MicrosoftAzureBuilder::new()
+            .with_account(AZURITE_ACCOUNT)
+            .with_access_key(AZURITE_KEY)
+            .with_container_name(CONTAINER)
+            .with_endpoint(endpoint(port))
+            .with_allow_http(true)
+            .build()
+            .expect("build verifying object store"),
+    )
+}
+
+/// List every object key under `prefix`, sorted (UUIDv7 keys sort by write order).
+async fn list_keys(store: &Arc<dyn ObjectStore>, prefix: &str) -> Vec<String> {
+    let mut listing = store.list(Some(&ObjPath::from(prefix)));
+    let mut keys = Vec::new();
+    while let Some(meta) = listing.next().await {
+        keys.push(meta.expect("list meta").location.to_string());
+    }
+    keys.sort();
+    keys
+}
+
+/// Download an object body and parse it as JSON Lines records.
+async fn read_jsonl(store: &Arc<dyn ObjectStore>, key: &str) -> Vec<Value> {
+    let bytes = store
+        .get(&ObjPath::from(key))
+        .await
+        .expect("get object")
+        .bytes()
+        .await
+        .expect("read object bytes");
+    let text = String::from_utf8(bytes.to_vec()).expect("utf8 body");
+    text.lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str::<Value>(l).expect("parse jsonl line"))
+        .collect()
+}
+
+fn sink_config(port: u16) -> AzureBlobSinkConfig {
+    AzureBlobSinkConfig::new(CONTAINER)
+        .account(AZURITE_ACCOUNT)
+        .auth(AzureCredentials::AccountKey {
+            account_key: AZURITE_KEY.into(),
+        })
+        .endpoint(endpoint(port))
+        .allow_http(true)
+}
+
+// ── Happy path: write a batch as one object and read the rows back ───────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn sink_writes_and_reads_back() {
+    let _serial = SERIAL.lock().await;
+    let (_c, port) = start_azurite().await;
+    create_container(port).await;
+
+    // batch_size = 0 → the whole page is written as a single object.
+    let sink = AzureBlobSink::new(sink_config(port).prefix("out/").with_batch_size(0))
+        .await
+        .expect("sink new");
+
+    let records = vec![json!({"id": 1}), json!({"id": 2}), json!({"id": 3})];
+    let written = sink.write_batch(&records).await.expect("write_batch");
+    assert_eq!(written, 3);
+    sink.flush().await.expect("flush");
+
+    let store = verify_store(port);
+    let keys = list_keys(&store, "out").await;
+    assert_eq!(keys.len(), 1, "batch_size=0 writes a single object");
+    assert!(keys[0].starts_with("out/") && keys[0].ends_with(".jsonl"));
+
+    let rows = read_jsonl(&store, &keys[0]).await;
+    let mut ids: Vec<i64> = rows.iter().map(|r| r["id"].as_i64().unwrap()).collect();
+    ids.sort_unstable();
+    assert_eq!(ids, vec![1, 2, 3]);
+}
+
+// ── Rollover: max_records_per_file splits a batch across multiple objects ────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn sink_rolls_over_multiple_files() {
+    let _serial = SERIAL.lock().await;
+    let (_c, port) = start_azurite().await;
+    create_container(port).await;
+
+    let sink = AzureBlobSink::new(
+        sink_config(port)
+            .prefix("roll/")
+            .with_batch_size(0)
+            .max_records_per_file(2)
+            .concurrency(4),
+    )
+    .await
+    .expect("sink new");
+
+    let records: Vec<Value> = (1..=5).map(|i| json!({ "id": i })).collect();
+    let written = sink.write_batch(&records).await.expect("write_batch");
+    assert_eq!(written, 5);
+
+    let store = verify_store(port);
+    let keys = list_keys(&store, "roll").await;
+    assert_eq!(keys.len(), 3, "5 records at 2/file → 3 objects");
+
+    // Every record must land exactly once across the rolled-over objects.
+    let mut all_ids = Vec::new();
+    for key in &keys {
+        for row in read_jsonl(&store, key).await {
+            all_ids.push(row["id"].as_i64().unwrap());
+        }
+    }
+    all_ids.sort_unstable();
+    assert_eq!(all_ids, vec![1, 2, 3, 4, 5]);
+}
+
+// ── Empty batch is a no-op (no object written) ───────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn sink_write_batch_empty_is_noop() {
+    let _serial = SERIAL.lock().await;
+    let (_c, port) = start_azurite().await;
+    create_container(port).await;
+
+    let sink = AzureBlobSink::new(sink_config(port).prefix("empty/"))
+        .await
+        .expect("sink new");
+
+    let written = sink.write_batch(&[]).await.expect("write_batch");
+    assert_eq!(written, 0);
+
+    let store = verify_store(port);
+    assert!(list_keys(&store, "empty").await.is_empty());
+}
+
+// ── Preflight check succeeds against a reachable, credentialed container ──────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn sink_check_passes() {
+    let _serial = SERIAL.lock().await;
+    let (_c, port) = start_azurite().await;
+    create_container(port).await;
+
+    let sink = AzureBlobSink::new(sink_config(port).prefix("chk/"))
+        .await
+        .expect("sink new");
+
+    let ctx = faucet_core::check::CheckContext {
+        timeout: std::time::Duration::from_secs(10),
+    };
+    let report = sink.check(&ctx).await.expect("check");
+    assert!(
+        report
+            .probes
+            .iter()
+            .all(|p| matches!(p.status, faucet_core::check::ProbeStatus::Pass)),
+        "expected all probes to pass, got {:?}",
+        report.probes
+    );
+}
+
+// ── Compressed (.gz) upload (requires the `compression` feature) ─────────────
+
+#[cfg(feature = "compression")]
+#[tokio::test(flavor = "multi_thread")]
+async fn sink_writes_gzip_when_compression_enabled() {
+    let _serial = SERIAL.lock().await;
+    let (_c, port) = start_azurite().await;
+    create_container(port).await;
+
+    // `.jsonl.gz` extension + Compression::Auto → the body is gzip-compressed.
+    let sink = AzureBlobSink::new(
+        sink_config(port)
+            .prefix("gz/")
+            .file_extension(".jsonl.gz")
+            .with_batch_size(0),
+    )
+    .await
+    .expect("sink new");
+
+    let written = sink
+        .write_batch(&[json!({"id": 1}), json!({"id": 2})])
+        .await
+        .expect("write_batch");
+    assert_eq!(written, 2);
+
+    let store = verify_store(port);
+    let keys = list_keys(&store, "gz").await;
+    assert_eq!(keys.len(), 1);
+    assert!(keys[0].ends_with(".jsonl.gz"));
+
+    let bytes = store
+        .get(&ObjPath::from(keys[0].as_str()))
+        .await
+        .expect("get object")
+        .bytes()
+        .await
+        .expect("read bytes");
+    // Gzip magic header.
+    assert_eq!(
+        &bytes[..2],
+        b"\x1f\x8b",
+        "object body must be gzip-compressed"
+    );
+
+    // And it must round-trip back to the original records once decompressed.
+    use std::io::Read as _;
+    let mut reader =
+        faucet_core::compression::wrap_sync_reader(&bytes[..], faucet_core::Compression::Gzip);
+    let mut decompressed = Vec::new();
+    reader.read_to_end(&mut decompressed).expect("gunzip");
+    let text = String::from_utf8(decompressed).expect("utf8");
+    let ids: Vec<i64> = text
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| {
+            serde_json::from_str::<Value>(l).unwrap()["id"]
+                .as_i64()
+                .unwrap()
+        })
+        .collect();
+    assert_eq!(ids, vec![1, 2]);
+}

--- a/crates/sink/clickhouse/Cargo.toml
+++ b/crates/sink/clickhouse/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "faucet-sink-clickhouse"
+version = "1.0.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "ClickHouse sink connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords = ["clickhouse", "olap", "sink", "pipeline", "connector"]
+categories.workspace = true
+
+[dependencies]
+faucet-core.workspace = true
+faucet-common-clickhouse.workspace = true
+schemars.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+async-trait.workspace = true
+tracing.workspace = true
+reqwest.workspace = true
+tokio = { workspace = true, features = ["time"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync"] }
+serde_json.workspace = true
+schemars.workspace = true
+reqwest = { workspace = true }
+testcontainers = "0.27"
+testcontainers-modules = { version = "0.15", features = ["clickhouse"] }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/sink/clickhouse/README.md
+++ b/crates/sink/clickhouse/README.md
@@ -1,0 +1,61 @@
+# faucet-sink-clickhouse
+
+ClickHouse **sink** for the
+[`faucet-stream`](https://crates.io/crates/faucet-stream) ecosystem.
+
+Writes each page over the ClickHouse
+[HTTP interface](https://clickhouse.com/docs/en/interfaces/http) as a batched
+`INSERT … FORMAT JSONEachRow` request (the statement travels in the `query` URL
+parameter, the newline-delimited JSON rows in the request body). Records are
+type-round-tripped through `JSONEachRow`, which maps cleanly onto ClickHouse
+column types.
+
+## Configuration
+
+```yaml
+sink:
+  kind: clickhouse
+  config:
+    # Endpoint — either `url` OR `host` (+ optional `http_port` / `tls`).
+    url: http://localhost:8123
+    # host: localhost
+    # http_port: 8123
+    # tls: false
+    database: default
+    user: default          # optional; sent as X-ClickHouse-User
+    password: ${env:CH_PASSWORD}   # optional; sent as X-ClickHouse-Key
+    table: events          # may be schema-qualified, e.g. analytics.events
+    batch_size: 1000       # records per INSERT; 0 = whole page in one request
+    async_insert: false    # true → server-side async buffering (async_insert=1)
+    wait_for_async_insert: true  # wait for the flush ack (keeps at-least-once durability)
+```
+
+The `table` (including a `db.table` qualifier) is identifier-quoted before use,
+so it is safe against injection.
+
+### Authentication
+
+Username + password (ClickHouse native HTTP auth), sent as the
+`X-ClickHouse-User` / `X-ClickHouse-Key` headers.
+
+### Asynchronous inserts
+
+Set `async_insert: true` to enable ClickHouse
+[asynchronous inserts](https://clickhouse.com/docs/en/optimize/asynchronous-inserts),
+where the server buffers rows and flushes them in the background — a large
+throughput win for many small inserts. Keep `wait_for_async_insert: true` (the
+default) so the request is only acknowledged once the batch is durably accepted,
+preserving faucet's at-least-once contract (the bookmark advances only after the
+write is confirmed).
+
+## Write modes
+
+The sink is **append-only**. ClickHouse upsert semantics are engine-dependent —
+use a [`ReplacingMergeTree`](https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/replacingmergetree)
+(or `CollapsingMergeTree` / `AggregatingMergeTree`) table to deduplicate by key
+at merge time. The sink never emulates upsert, so `write_mode` must be `append`.
+
+## License
+
+Licensed under either of Apache License, Version 2.0 or MIT license at your
+option.

--- a/crates/sink/clickhouse/src/config.rs
+++ b/crates/sink/clickhouse/src/config.rs
@@ -1,0 +1,156 @@
+//! Configuration for the ClickHouse sink.
+
+use faucet_common_clickhouse::ClickHouseConnection;
+use faucet_core::{DEFAULT_BATCH_SIZE, FaucetError, validate_batch_size};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+fn default_batch_size() -> usize {
+    DEFAULT_BATCH_SIZE
+}
+
+fn default_wait_for_async_insert() -> bool {
+    true
+}
+
+/// Configuration for [`ClickHouseSink`](crate::ClickHouseSink).
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ClickHouseSinkConfig {
+    /// Connection settings (`url` or `host`, `database`, credentials).
+    #[serde(flatten)]
+    pub connection: ClickHouseConnection,
+    /// Target table. May be schema-qualified (`db.table`); each identifier
+    /// segment is quoted before use.
+    pub table: String,
+    /// Records per `INSERT` request. When the upstream `StreamPage` carries more
+    /// records than `batch_size`, the sink splits it into `batch_size`-row
+    /// chunks and issues one `INSERT … FORMAT JSONEachRow` per chunk. `0`
+    /// forwards the whole page as a single request. Defaults to
+    /// [`DEFAULT_BATCH_SIZE`].
+    #[serde(default = "default_batch_size")]
+    pub batch_size: usize,
+    /// Enable ClickHouse [asynchronous inserts](https://clickhouse.com/docs/en/optimize/asynchronous-inserts)
+    /// (`async_insert=1`): the server buffers rows and flushes them in the
+    /// background, which greatly improves throughput for many small inserts.
+    /// Defaults to `false`.
+    #[serde(default)]
+    pub async_insert: bool,
+    /// When [`async_insert`](Self::async_insert) is enabled, whether the server
+    /// waits for the buffered rows to be flushed before acknowledging the
+    /// request (`wait_for_async_insert=1`). Keeping this `true` (the default)
+    /// preserves faucet's at-least-once durability contract — the bookmark only
+    /// advances after ClickHouse has durably accepted the batch. Ignored when
+    /// `async_insert` is `false`.
+    #[serde(default = "default_wait_for_async_insert")]
+    pub wait_for_async_insert: bool,
+}
+
+impl std::fmt::Debug for ClickHouseSinkConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ClickHouseSinkConfig")
+            .field("connection", &self.connection)
+            .field("table", &self.table)
+            .field("batch_size", &self.batch_size)
+            .field("async_insert", &self.async_insert)
+            .field("wait_for_async_insert", &self.wait_for_async_insert)
+            .finish()
+    }
+}
+
+impl ClickHouseSinkConfig {
+    /// Build a config from a base URL and table, with defaults elsewhere.
+    pub fn new(url: impl Into<String>, table: impl Into<String>) -> Self {
+        Self {
+            connection: ClickHouseConnection::from_url(url),
+            table: table.into(),
+            batch_size: default_batch_size(),
+            async_insert: false,
+            wait_for_async_insert: default_wait_for_async_insert(),
+        }
+    }
+
+    /// Set the per-request record count.
+    pub fn with_batch_size(mut self, batch_size: usize) -> Self {
+        self.batch_size = batch_size;
+        self
+    }
+
+    /// Enable ClickHouse asynchronous inserts.
+    pub fn with_async_insert(mut self, async_insert: bool) -> Self {
+        self.async_insert = async_insert;
+        self
+    }
+
+    /// Validate connection, table, and batch size.
+    pub fn validate(&self) -> Result<(), FaucetError> {
+        self.connection.validate()?;
+        validate_batch_size(self.batch_size)?;
+        if self.table.trim().is_empty() {
+            return Err(FaucetError::Config(
+                "ClickHouse sink requires a non-empty `table`".into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn config_flattens_connection_and_defaults() {
+        let cfg: ClickHouseSinkConfig = serde_json::from_value(json!({
+            "url": "http://localhost:8123",
+            "table": "events",
+        }))
+        .unwrap();
+        assert_eq!(cfg.table, "events");
+        assert_eq!(cfg.batch_size, DEFAULT_BATCH_SIZE);
+        assert!(!cfg.async_insert);
+        assert!(cfg.wait_for_async_insert, "wait defaults to true");
+    }
+
+    #[test]
+    fn async_insert_parses() {
+        let cfg: ClickHouseSinkConfig = serde_json::from_value(json!({
+            "url": "http://h:8123",
+            "table": "t",
+            "async_insert": true,
+            "wait_for_async_insert": false,
+        }))
+        .unwrap();
+        assert!(cfg.async_insert);
+        assert!(!cfg.wait_for_async_insert);
+    }
+
+    #[test]
+    fn validate_rejects_empty_table() {
+        let cfg = ClickHouseSinkConfig::new("http://h:8123", "   ");
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_bad_batch_size() {
+        let cfg = ClickHouseSinkConfig::new("http://h:8123", "t")
+            .with_batch_size(faucet_core::MAX_BATCH_SIZE + 1);
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_missing_endpoint() {
+        let mut cfg = ClickHouseSinkConfig::new("http://h:8123", "t");
+        cfg.connection.url = None;
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn debug_masks_password() {
+        let mut cfg = ClickHouseSinkConfig::new("http://h:8123", "t");
+        cfg.connection.password = Some("s3cret".into());
+        let dbg = format!("{cfg:?}");
+        assert!(dbg.contains("***"));
+        assert!(!dbg.contains("s3cret"));
+    }
+}

--- a/crates/sink/clickhouse/src/lib.rs
+++ b/crates/sink/clickhouse/src/lib.rs
@@ -1,0 +1,39 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+//! # faucet-sink-clickhouse
+//!
+//! ClickHouse sink for the
+//! [`faucet-stream`](https://crates.io/crates/faucet-stream) ecosystem, built on
+//! the ClickHouse [HTTP interface](https://clickhouse.com/docs/en/interfaces/http)
+//! via [`reqwest`](https://crates.io/crates/reqwest).
+//!
+//! Writes each page as a batched `INSERT … FORMAT JSONEachRow` request (the
+//! statement travels in the `query` URL parameter, the newline-delimited JSON
+//! rows in the request body). Optionally enables ClickHouse
+//! [asynchronous inserts](https://clickhouse.com/docs/en/optimize/asynchronous-inserts)
+//! (`async_insert`) for high-throughput small-batch ingestion.
+//!
+//! Upsert semantics in ClickHouse are **engine-dependent** (e.g.
+//! `ReplacingMergeTree` collapses duplicate keys at merge time). The sink is
+//! therefore **append-only** ([`WriteMode::Append`](faucet_core::WriteMode)) and
+//! never emulates upsert — model deduplication in the table's engine instead.
+//!
+//! ```no_run
+//! # use faucet_sink_clickhouse::{ClickHouseSink, ClickHouseSinkConfig};
+//! # fn run() -> Result<(), faucet_core::FaucetError> {
+//! let cfg = ClickHouseSinkConfig::new("http://localhost:8123", "events");
+//! let sink = ClickHouseSink::new(cfg)?;
+//! # let _ = sink;
+//! # Ok(())
+//! # }
+//! ```
+
+mod config;
+mod sink;
+
+pub use config::ClickHouseSinkConfig;
+pub use sink::ClickHouseSink;
+
+// Re-export the shared connection type so users configure the sink without
+// depending on `faucet-common-clickhouse` directly.
+pub use faucet_common_clickhouse::ClickHouseConnection;

--- a/crates/sink/clickhouse/src/sink.rs
+++ b/crates/sink/clickhouse/src/sink.rs
@@ -1,0 +1,283 @@
+//! The ClickHouse [`Sink`] implementation — HTTP client and batched
+//! `INSERT … FORMAT JSONEachRow` writes.
+
+use async_trait::async_trait;
+use faucet_common_clickhouse::{apply_auth, build_client, build_json_each_row, query_params};
+use faucet_core::check::{CheckContext, CheckReport, Probe};
+use faucet_core::util::{DEFAULT_ERROR_BODY_MAX_LEN, check_http_response};
+use faucet_core::{FaucetError, Sink};
+use serde_json::Value;
+
+use crate::config::ClickHouseSinkConfig;
+
+/// ClickHouse sink (HTTP interface, `INSERT … FORMAT JSONEachRow`).
+pub struct ClickHouseSink {
+    config: ClickHouseSinkConfig,
+    client: reqwest::Client,
+    /// Resolved once in [`ClickHouseSink::new`] so the hot path never re-parses.
+    base_url: String,
+}
+
+/// Quote a (possibly schema-qualified) table name. Each `.`-separated segment
+/// is quoted with [`faucet_core::util::quote_ident`] so `db.table` becomes
+/// `"db"."table"` — safe against identifier injection while preserving the
+/// database/table split.
+fn quote_table(table: &str) -> String {
+    table
+        .split('.')
+        .map(faucet_core::util::quote_ident)
+        .collect::<Vec<_>>()
+        .join(".")
+}
+
+/// Build the `INSERT … FORMAT JSONEachRow` statement (carried in the `query`
+/// URL parameter; the row data travels in the request body).
+fn insert_statement(table: &str) -> String {
+    format!("INSERT INTO {} FORMAT JSONEachRow", quote_table(table))
+}
+
+/// Build the ordered query parameters for an insert request: the `database`,
+/// any async-insert settings, and the `query` statement. Pure and
+/// unit-testable.
+fn insert_params(
+    database: &str,
+    statement: &str,
+    async_insert: bool,
+    wait_for_async_insert: bool,
+) -> Vec<(String, String)> {
+    let mut settings: Vec<(&str, &str)> = Vec::new();
+    if async_insert {
+        settings.push(("async_insert", "1"));
+        settings.push((
+            "wait_for_async_insert",
+            if wait_for_async_insert { "1" } else { "0" },
+        ));
+    }
+    settings.push(("query", statement));
+    query_params(database, &settings)
+}
+
+impl ClickHouseSink {
+    /// Validate the config and build the reusable HTTP client.
+    pub fn new(config: ClickHouseSinkConfig) -> Result<Self, FaucetError> {
+        config.validate()?;
+        let base_url = config.connection.base_url()?;
+        let client = build_client(&config.connection)?;
+        Ok(Self {
+            config,
+            client,
+            base_url,
+        })
+    }
+
+    /// Send one `INSERT … FORMAT JSONEachRow` request for a slice of records.
+    async fn send_insert(&self, records: &[Value]) -> Result<(), FaucetError> {
+        let body = build_json_each_row(records)?;
+        let statement = insert_statement(&self.config.table);
+        let params = insert_params(
+            &self.config.connection.database,
+            &statement,
+            self.config.async_insert,
+            self.config.wait_for_async_insert,
+        );
+        let req = self.client.post(&self.base_url).query(&params).body(body);
+        let req = apply_auth(req, &self.config.connection);
+        let resp = req.send().await?;
+        check_http_response(resp, DEFAULT_ERROR_BODY_MAX_LEN).await?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Sink for ClickHouseSink {
+    /// Insert records via `INSERT … FORMAT JSONEachRow`.
+    ///
+    /// When `batch_size > 0` and the page is larger, it is split into
+    /// `batch_size`-row chunks, each sent as its own request. `batch_size = 0`
+    /// forwards the whole page as a single request.
+    async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
+        if records.is_empty() {
+            return Ok(0);
+        }
+
+        let chunks: Vec<&[Value]> = if self.config.batch_size == 0 {
+            vec![records]
+        } else {
+            records.chunks(self.config.batch_size).collect()
+        };
+
+        let mut total = 0;
+        for chunk in chunks {
+            self.send_insert(chunk).await?;
+            total += chunk.len();
+            tracing::debug!(records = chunk.len(), "ClickHouse insert chunk written");
+        }
+        Ok(total)
+    }
+
+    fn config_schema(&self) -> Value {
+        serde_json::to_value(faucet_core::schema_for!(ClickHouseSinkConfig))
+            .expect("schema serialization")
+    }
+
+    fn connector_name(&self) -> &'static str {
+        "clickhouse"
+    }
+
+    fn dataset_uri(&self) -> String {
+        format!(
+            "{}/{}",
+            faucet_core::redact_uri_credentials(&self.base_url),
+            self.config.table
+        )
+    }
+
+    /// Non-mutating preflight probe (`connect`): runs `SELECT 1` over the HTTP
+    /// interface. Deliberately does **not** touch the target table (no inserts,
+    /// no residual rows).
+    async fn check(&self, ctx: &CheckContext) -> Result<CheckReport, FaucetError> {
+        let started = std::time::Instant::now();
+        let hint = "check url / host / database / credentials / that the server is reachable";
+        let params = query_params(&self.config.connection.database, &[]);
+        let req = self
+            .client
+            .post(&self.base_url)
+            .query(&params)
+            .body("SELECT 1");
+        let req = apply_auth(req, &self.config.connection);
+        let probe = match tokio::time::timeout(ctx.timeout, req.send()).await {
+            Ok(Ok(resp)) => match check_http_response(resp, DEFAULT_ERROR_BODY_MAX_LEN).await {
+                Ok(_) => Probe::pass("connect", started.elapsed()),
+                Err(e) => Probe::fail_hint("connect", started.elapsed(), e.to_string(), hint),
+            },
+            Ok(Err(e)) => Probe::fail_hint("connect", started.elapsed(), e.to_string(), hint),
+            Err(_) => Probe::fail_hint("connect", started.elapsed(), "timed out", hint),
+        };
+        Ok(CheckReport::single(probe))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn sink() -> ClickHouseSink {
+        ClickHouseSink::new(ClickHouseSinkConfig::new(
+            "http://db.example.com:8123",
+            "events",
+        ))
+        .unwrap()
+    }
+
+    #[test]
+    fn quote_table_quotes_each_segment() {
+        assert_eq!(quote_table("events"), "\"events\"");
+        assert_eq!(quote_table("analytics.events"), "\"analytics\".\"events\"");
+    }
+
+    #[test]
+    fn quote_table_escapes_hostile_identifier() {
+        // A double quote in the identifier is doubled by quote_ident, so it
+        // cannot break out of the quoting.
+        let q = quote_table("we\"ird");
+        assert_eq!(q, "\"we\"\"ird\"");
+    }
+
+    #[test]
+    fn insert_statement_uses_json_each_row() {
+        assert_eq!(
+            insert_statement("events"),
+            "INSERT INTO \"events\" FORMAT JSONEachRow"
+        );
+    }
+
+    #[test]
+    fn insert_params_without_async_insert() {
+        let params = insert_params("analytics", "INSERT INTO x FORMAT JSONEachRow", false, true);
+        assert_eq!(params[0], ("database".to_string(), "analytics".to_string()));
+        // Only database + query when async insert is off.
+        assert_eq!(params.len(), 2);
+        assert_eq!(
+            params[1],
+            (
+                "query".to_string(),
+                "INSERT INTO x FORMAT JSONEachRow".to_string()
+            )
+        );
+        assert!(!params.iter().any(|(k, _)| k == "async_insert"));
+    }
+
+    #[test]
+    fn insert_params_with_async_insert_and_wait() {
+        let params = insert_params("db", "INSERT INTO x FORMAT JSONEachRow", true, true);
+        assert!(params.contains(&("async_insert".to_string(), "1".to_string())));
+        assert!(params.contains(&("wait_for_async_insert".to_string(), "1".to_string())));
+    }
+
+    #[test]
+    fn insert_params_async_insert_no_wait() {
+        let params = insert_params("db", "INSERT INTO x FORMAT JSONEachRow", true, false);
+        assert!(params.contains(&("wait_for_async_insert".to_string(), "0".to_string())));
+    }
+
+    #[test]
+    fn build_body_produces_ndjson() {
+        // The body builder is shared with the source's decoder; assert the
+        // exact wire bytes the sink would POST.
+        let page = vec![json!({"id": 1}), json!({"id": 2})];
+        assert_eq!(
+            build_json_each_row(&page).unwrap(),
+            "{\"id\":1}\n{\"id\":2}\n"
+        );
+    }
+
+    #[test]
+    fn dataset_uri_combines_base_url_and_table() {
+        assert_eq!(sink().dataset_uri(), "http://db.example.com:8123/events");
+    }
+
+    #[test]
+    fn connector_name_is_clickhouse() {
+        assert_eq!(sink().connector_name(), "clickhouse");
+    }
+
+    #[test]
+    fn config_schema_is_object() {
+        assert_eq!(sink().config_schema()["type"], "object");
+    }
+
+    #[test]
+    fn append_is_the_only_write_mode() {
+        // ClickHouse upsert is engine-dependent (ReplacingMergeTree) and is not
+        // emulated by the sink — see the crate README.
+        assert_eq!(
+            sink().supported_write_modes(),
+            &[faucet_core::WriteMode::Append]
+        );
+    }
+
+    #[test]
+    fn new_rejects_invalid_config() {
+        assert!(ClickHouseSink::new(ClickHouseSinkConfig::new("http://h:8123", "")).is_err());
+    }
+
+    #[tokio::test]
+    async fn write_batch_empty_is_noop() {
+        assert_eq!(sink().write_batch(&[]).await.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn check_fails_against_unreachable_server() {
+        let sink =
+            ClickHouseSink::new(ClickHouseSinkConfig::new("http://127.0.0.1:1", "t")).unwrap();
+        let ctx = CheckContext {
+            timeout: std::time::Duration::from_secs(2),
+        };
+        let report = sink.check(&ctx).await.unwrap();
+        assert!(matches!(
+            report.probes[0].status,
+            faucet_core::check::ProbeStatus::Fail { .. }
+        ));
+    }
+}

--- a/crates/sink/clickhouse/tests/integration.rs
+++ b/crates/sink/clickhouse/tests/integration.rs
@@ -1,0 +1,168 @@
+//! Integration tests against a real ClickHouse server in Docker.
+//!
+//! These **auto-start** a `clickhouse/clickhouse-server` container via
+//! `testcontainers` (no env var, not `#[ignore]`d), so they run in CI wherever
+//! Docker is present and count toward patch coverage. They exercise the HTTP
+//! I/O paths in `src/sink.rs` — the `INSERT … FORMAT JSONEachRow` body builder,
+//! the async-insert query-param toggle, `batch_size` re-chunking, `flush`, and
+//! the live `check()` probe — that the pure unit tests can't reach. Mirrors the
+//! postgres/mssql integration-test pattern.
+//!
+//! Run explicitly with:
+//! `cargo test -p faucet-sink-clickhouse --test integration`.
+
+use faucet_core::Sink as _;
+use faucet_core::check::{CheckContext, ProbeStatus};
+use faucet_sink_clickhouse::{ClickHouseSink, ClickHouseSinkConfig};
+use serde_json::{Value, json};
+use testcontainers_modules::clickhouse::ClickHouse;
+use testcontainers_modules::testcontainers::ContainerAsync;
+use testcontainers_modules::testcontainers::runners::AsyncRunner;
+
+// `cargo test` runs a binary's tests in parallel; serialize so at most one
+// container runs at a time on a small CI runner. Mirrors the mssql/postgres
+// integration suites.
+static SERIAL: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+async fn start_clickhouse() -> (ContainerAsync<ClickHouse>, String) {
+    let container = ClickHouse::default()
+        .start()
+        .await
+        .expect("start clickhouse container");
+    let port = container
+        .get_host_port_ipv4(8123)
+        .await
+        .expect("clickhouse host port");
+    let base = format!("http://127.0.0.1:{port}");
+    (container, base)
+}
+
+/// POST a statement over the HTTP interface, asserting a 2xx. Used to run DDL
+/// out-of-band from the sink under test.
+async fn http_exec(base: &str, sql: &str) {
+    let resp = reqwest::Client::new()
+        .post(base)
+        .body(sql.to_string())
+        .send()
+        .await
+        .expect("http exec send");
+    let status = resp.status();
+    let body = resp.text().await.unwrap_or_default();
+    assert!(
+        status.is_success(),
+        "statement failed ({status}): {sql}\n{body}"
+    );
+}
+
+/// Read rows back with `FORMAT JSONEachRow` and decode each line into a
+/// [`Value`]. The independent read path confirms the sink's writes landed.
+async fn read_rows(base: &str, sql: &str) -> Vec<Value> {
+    let body = reqwest::Client::new()
+        .post(base)
+        .body(format!("{sql} FORMAT JSONEachRow"))
+        .send()
+        .await
+        .expect("query send")
+        .text()
+        .await
+        .expect("query body");
+    body.lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str(l).expect("decode JSONEachRow line"))
+        .collect()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn write_batch_inserts_rows_and_rechunks() {
+    let _serial = SERIAL.lock().await;
+    let (_c, base) = start_clickhouse().await;
+
+    http_exec(
+        &base,
+        "CREATE TABLE events (id UInt32, name String, score Float64) \
+         ENGINE = MergeTree ORDER BY id",
+    )
+    .await;
+
+    // Single-chunk write (default batch_size) exercises the JSONEachRow body
+    // builder + a plain (non-async) INSERT request, and type round-tripping.
+    let sink = ClickHouseSink::new(ClickHouseSinkConfig::new(&base, "events")).expect("sink");
+    let rows = vec![
+        json!({"id": 1, "name": "alice", "score": 1.5}),
+        json!({"id": 2, "name": "bob", "score": 2.25}),
+        json!({"id": 3, "name": "carol", "score": 3.0}),
+    ];
+    let written = sink.write_batch(&rows).await.expect("write_batch");
+    assert_eq!(written, 3);
+    sink.flush().await.expect("flush");
+
+    let back = read_rows(&base, "SELECT id, name, score FROM events ORDER BY id").await;
+    assert_eq!(back.len(), 3);
+    assert_eq!(back[0]["id"], json!(1));
+    assert_eq!(back[0]["name"], json!("alice"));
+    assert_eq!(back[0]["score"], json!(1.5));
+    assert_eq!(back[2]["name"], json!("carol"));
+
+    // batch_size = 2 over 5 rows splits into requests of 2 + 2 + 1; the return
+    // value is the total, and every row must land.
+    http_exec(
+        &base,
+        "CREATE TABLE nums (n UInt32) ENGINE = MergeTree ORDER BY n",
+    )
+    .await;
+    let sink2 = ClickHouseSink::new(ClickHouseSinkConfig::new(&base, "nums").with_batch_size(2))
+        .expect("sink");
+    let nums: Vec<Value> = (1..=5).map(|n| json!({ "n": n })).collect();
+    assert_eq!(sink2.write_batch(&nums).await.expect("chunked write"), 5);
+    let back = read_rows(&base, "SELECT n FROM nums ORDER BY n").await;
+    let got: Vec<i64> = back.iter().map(|r| r["n"].as_i64().unwrap()).collect();
+    assert_eq!(got, vec![1, 2, 3, 4, 5]);
+
+    // An empty page is a no-op that issues no request.
+    assert_eq!(sink.write_batch(&[]).await.expect("empty"), 0);
+
+    // Write modes + a live connect probe.
+    assert_eq!(
+        sink.supported_write_modes(),
+        &[faucet_core::WriteMode::Append]
+    );
+    let ctx = CheckContext {
+        timeout: std::time::Duration::from_secs(5),
+    };
+    let report = sink.check(&ctx).await.expect("check");
+    assert!(
+        matches!(report.probes[0].status, ProbeStatus::Pass),
+        "connect probe against a live server must pass: {:?}",
+        report.probes[0].status
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn write_batch_with_async_insert_lands_rows() {
+    let _serial = SERIAL.lock().await;
+    let (_c, base) = start_clickhouse().await;
+
+    http_exec(
+        &base,
+        "CREATE TABLE async_events (id UInt32, name String) ENGINE = MergeTree ORDER BY id",
+    )
+    .await;
+
+    // async_insert = 1 with wait_for_async_insert = 1 (the default) preserves
+    // at-least-once durability, so the rows are queryable immediately after the
+    // acknowledged write. Exercises the async-insert query-param branch.
+    let sink = ClickHouseSink::new(
+        ClickHouseSinkConfig::new(&base, "async_events").with_async_insert(true),
+    )
+    .expect("sink");
+    let rows = vec![
+        json!({"id": 10, "name": "x"}),
+        json!({"id": 20, "name": "y"}),
+    ];
+    assert_eq!(sink.write_batch(&rows).await.expect("async write"), 2);
+
+    let back = read_rows(&base, "SELECT id, name FROM async_events ORDER BY id").await;
+    let ids: Vec<i64> = back.iter().map(|r| r["id"].as_i64().unwrap()).collect();
+    assert_eq!(ids, vec![10, 20]);
+    assert_eq!(back[0]["name"], json!("x"));
+}

--- a/crates/sink/pubsub/Cargo.toml
+++ b/crates/sink/pubsub/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "faucet-sink-pubsub"
+version = "1.0.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Google Cloud Pub/Sub sink connector for faucet-stream (batched publish, ordering keys, bounded concurrency, partial-failure DLQ)"
+readme = "README.md"
+keywords = ["pubsub", "gcp", "messaging", "etl", "connector"]
+categories.workspace = true
+
+[dependencies]
+faucet-core.workspace = true
+faucet-common-pubsub.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+schemars.workspace = true
+gcloud-pubsub.workspace = true
+async-trait.workspace = true
+futures.workspace = true
+tokio = { workspace = true, features = ["rt", "macros", "sync"] }
+tracing.workspace = true
+base64.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time", "sync"] }
+serde_yaml = "0.9"
+testcontainers = "0.27"
+testcontainers-modules = { version = "0.15", features = ["google_cloud_sdk_emulators"] }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/sink/pubsub/README.md
+++ b/crates/sink/pubsub/README.md
@@ -1,0 +1,68 @@
+# faucet-sink-pubsub
+
+Google Cloud Pub/Sub **sink** connector for
+[faucet-stream](https://github.com/PawanSikawat/faucet-stream). Publishes each
+record as a Pub/Sub message with a configurable encoding, optional ordering
+key, bounded concurrency, and per-message partial-failure routing to a DLQ.
+
+## Configuration
+
+```yaml
+sink:
+  kind: pubsub
+  config:
+    topic: orders                     # required (short id, not the full path)
+    project_id: my-gcp-project        # required for real Pub/Sub
+    # emulator_host: "localhost:8085" # or set PUBSUB_EMULATOR_HOST
+    credentials: { type: application_default }
+    value_format: json                # json | string | bytes  (default json)
+    ordering_key: { type: field, name: customer_id }   # none | field | jsonpath
+    attributes_field: __attributes    # optional: record field -> msg attributes
+    batch_size: 100                   # records per publish batch (1..=1000)
+    concurrency: 4                     # bounded in-flight publishes
+```
+
+### Ordering key
+
+- `{ type: none }` — no ordering (default).
+- `{ type: field, name: <field> }` — a top-level field value.
+- `{ type: jsonpath, path: a.b.c }` — a dot-path value.
+
+When an ordering-key strategy is set, message ordering is enabled on the
+publisher and messages with the same key are delivered in publish order. A
+record missing the key (or with a null / container value) fails **per-record**
+(DLQ-routable), never the whole batch.
+
+### Attributes
+
+If `attributes_field` names a record field holding a JSON object of scalars,
+those key/value pairs become the message attributes and the field is stripped
+from the published payload — the inverse of the source's `attributes_key`, so a
+Pub/Sub → Pub/Sub pipeline round-trips attributes.
+
+### `value_format`
+
+`json` serializes the whole record; `string` requires a JSON string record
+(raw UTF-8 bytes); `bytes` requires a base64 JSON string (decoded bytes).
+
+## Delivery semantics — at-least-once
+
+Pub/Sub is at-least-once and this sink does not implement idempotent writes, so
+`delivery: exactly_once` is not supported. De-duplicate downstream on
+`message_id` if replays must converge. Per-record encode failures and
+per-message publish rejections surface via `write_batch_partial`, so a DLQ
+captures individual bad records instead of failing the whole page.
+
+## Testing
+
+Unit tests are fully offline. Integration tests (`tests/integration.rs`)
+require the Pub/Sub emulator and are skipped unless `PUBSUB_EMULATOR_HOST` is
+set:
+
+```bash
+gcloud beta emulators pubsub start --host-port=localhost:8085 &
+export PUBSUB_EMULATOR_HOST=localhost:8085
+cargo test -p faucet-sink-pubsub
+```
+
+License: MIT OR Apache-2.0.

--- a/crates/sink/pubsub/src/config.rs
+++ b/crates/sink/pubsub/src/config.rs
@@ -1,0 +1,225 @@
+//! Configuration for the Pub/Sub sink. No I/O here.
+
+use faucet_common_pubsub::PubsubConnection;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// How each record is encoded into the Pub/Sub message `data` blob.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ValueFormat {
+    /// Serialize the whole record as JSON bytes.
+    #[default]
+    Json,
+    /// The record must be a JSON string → raw UTF-8 bytes.
+    String,
+    /// The record must be a base64 JSON string → decoded bytes.
+    Bytes,
+}
+
+/// How each message's ordering key is derived. When any non-empty ordering key
+/// is produced, message ordering is enabled on the publisher.
+///
+/// Serializes as `{ type: <strategy>, … }` (snake_case discriminators).
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum OrderingKey {
+    /// No ordering key — messages may be delivered in any order (default).
+    #[default]
+    None,
+    /// A top-level field's value, stringified. A record missing the field (or
+    /// with a null / container value) fails per-record (DLQ-routable).
+    Field {
+        /// Top-level field name.
+        name: String,
+    },
+    /// A dot-path into the record (`a.b.c`, object keys only), stringified.
+    Jsonpath {
+        /// Dot path, e.g. `order.id`.
+        path: String,
+    },
+}
+
+impl OrderingKey {
+    /// Whether this strategy ever produces an ordering key (so the publisher
+    /// must enable message ordering).
+    pub fn enables_ordering(&self) -> bool {
+        !matches!(self, OrderingKey::None)
+    }
+}
+
+/// Configuration for [`PubsubSink`](crate::PubsubSink).
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct PubsubSinkConfig {
+    /// Topic id (short name, not the fully-qualified path). The client forms
+    /// `projects/<project>/topics/<id>` from the connection's project.
+    pub topic: String,
+
+    /// Project / endpoint / emulator / credentials (flattened).
+    #[serde(flatten)]
+    pub connection: PubsubConnection,
+
+    /// Record payload encoding. Default: `json`.
+    #[serde(default)]
+    pub value_format: ValueFormat,
+
+    /// Ordering-key derivation. Default: `none`.
+    #[serde(default)]
+    pub ordering_key: OrderingKey,
+
+    /// Optional record field holding a JSON object of message attributes.
+    /// Values are stringified; the field is stripped from the payload before
+    /// encoding. Absent field → no attributes (not an error).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attributes_field: Option<String>,
+
+    /// Records per publish batch (1–1000). Default 100.
+    #[serde(default = "default_batch_size")]
+    pub batch_size: usize,
+
+    /// Bounded concurrent in-flight publishes. Default 4.
+    #[serde(default = "default_concurrency")]
+    pub concurrency: usize,
+}
+
+/// Pub/Sub caps a single `Publish` request at 1000 messages.
+pub const MAX_BATCH: usize = 1000;
+
+fn default_batch_size() -> usize {
+    100
+}
+fn default_concurrency() -> usize {
+    4
+}
+
+impl PubsubSinkConfig {
+    /// Minimal config with defaults for everything but the topic id.
+    pub fn new(topic: impl Into<String>) -> Self {
+        Self {
+            topic: topic.into(),
+            connection: PubsubConnection::default(),
+            value_format: ValueFormat::default(),
+            ordering_key: OrderingKey::default(),
+            attributes_field: None,
+            batch_size: default_batch_size(),
+            concurrency: default_concurrency(),
+        }
+    }
+
+    /// Fail-fast validation, called from `PubsubSink::new`.
+    pub fn validate(&self) -> Result<(), faucet_core::FaucetError> {
+        use faucet_core::FaucetError;
+        if self.topic.trim().is_empty() {
+            return Err(FaucetError::Config(
+                "pubsub sink: topic must not be empty".into(),
+            ));
+        }
+        if self.batch_size == 0 || self.batch_size > MAX_BATCH {
+            return Err(FaucetError::Config(format!(
+                "pubsub sink: batch_size must be 1..={MAX_BATCH} (got {})",
+                self.batch_size
+            )));
+        }
+        if self.concurrency == 0 {
+            return Err(FaucetError::Config(
+                "pubsub sink: concurrency must be at least 1".into(),
+            ));
+        }
+        match &self.ordering_key {
+            OrderingKey::Field { name } if name.trim().is_empty() => {
+                return Err(FaucetError::Config(
+                    "pubsub sink: ordering_key.name must not be empty".into(),
+                ));
+            }
+            OrderingKey::Jsonpath { path } if path.trim().is_empty() => {
+                return Err(FaucetError::Config(
+                    "pubsub sink: ordering_key.path must not be empty".into(),
+                ));
+            }
+            _ => {}
+        }
+        if let Some(field) = &self.attributes_field
+            && field.trim().is_empty()
+        {
+            return Err(FaucetError::Config(
+                "pubsub sink: attributes_field must not be empty when set".into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_are_sensible() {
+        let c = PubsubSinkConfig::new("orders");
+        c.validate().unwrap();
+        assert_eq!(c.value_format, ValueFormat::Json);
+        assert_eq!(c.ordering_key, OrderingKey::None);
+        assert!(!c.ordering_key.enables_ordering());
+        assert_eq!(c.batch_size, 100);
+        assert_eq!(c.concurrency, 4);
+    }
+
+    #[test]
+    fn ordering_key_enables_flag() {
+        assert!(OrderingKey::Field { name: "k".into() }.enables_ordering());
+        assert!(OrderingKey::Jsonpath { path: "a.b".into() }.enables_ordering());
+        assert!(!OrderingKey::None.enables_ordering());
+    }
+
+    #[test]
+    fn validation_bounds() {
+        let mut c = PubsubSinkConfig::new("orders");
+        c.topic = "  ".into();
+        assert!(c.validate().is_err());
+
+        let mut c = PubsubSinkConfig::new("orders");
+        c.batch_size = 0;
+        assert!(c.validate().is_err());
+        c.batch_size = MAX_BATCH + 1;
+        assert!(c.validate().is_err());
+
+        let mut c = PubsubSinkConfig::new("orders");
+        c.concurrency = 0;
+        assert!(c.validate().is_err());
+
+        let mut c = PubsubSinkConfig::new("orders");
+        c.ordering_key = OrderingKey::Field { name: " ".into() };
+        assert!(c.validate().is_err());
+        c.ordering_key = OrderingKey::Jsonpath { path: "".into() };
+        assert!(c.validate().is_err());
+
+        let mut c = PubsubSinkConfig::new("orders");
+        c.attributes_field = Some("".into());
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn full_config_parses_from_yaml() {
+        let yaml = r#"
+topic: orders
+project_id: my-proj
+credentials: { type: application_default }
+value_format: json
+ordering_key: { type: field, name: customer_id }
+attributes_field: __attributes
+batch_size: 250
+concurrency: 8
+"#;
+        let c: PubsubSinkConfig = serde_yaml::from_str(yaml).unwrap();
+        c.validate().unwrap();
+        assert_eq!(
+            c.ordering_key,
+            OrderingKey::Field {
+                name: "customer_id".into()
+            }
+        );
+        assert_eq!(c.attributes_field.as_deref(), Some("__attributes"));
+        assert_eq!(c.batch_size, 250);
+        assert_eq!(c.concurrency, 8);
+    }
+}

--- a/crates/sink/pubsub/src/encode.rs
+++ b/crates/sink/pubsub/src/encode.rs
@@ -1,0 +1,323 @@
+//! Pure ordering-key extraction, attribute building, and payload encoding.
+//! No SDK types here — `sink.rs` turns a [`Prepared`] into a `PubsubMessage`.
+
+use crate::config::{OrderingKey, ValueFormat};
+use faucet_core::FaucetError;
+use serde_json::Value;
+use std::collections::HashMap;
+
+/// A record encoded and ready to become a `PubsubMessage`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Prepared {
+    pub data: Vec<u8>,
+    pub attributes: HashMap<String, String>,
+    /// Empty when no ordering key applies.
+    pub ordering_key: String,
+}
+
+/// Resolve a dot path (`a.b.c`, object keys only) into a record.
+fn resolve_path<'a>(record: &'a Value, path: &str) -> Option<&'a Value> {
+    let mut cur = record;
+    for seg in path.split('.') {
+        cur = cur.get(seg)?;
+    }
+    Some(cur)
+}
+
+fn type_name(v: &Value) -> &'static str {
+    match v {
+        Value::Null => "null",
+        Value::Bool(_) => "bool",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+/// Stringify a scalar. Containers and null are per-record errors.
+fn scalar_to_string(v: &Value, what: &str) -> Result<String, FaucetError> {
+    match v {
+        Value::String(s) => Ok(s.clone()),
+        Value::Number(n) => Ok(n.to_string()),
+        Value::Bool(b) => Ok(b.to_string()),
+        Value::Null => Err(FaucetError::Sink(format!(
+            "pubsub: {what} resolved to null"
+        ))),
+        Value::Array(_) | Value::Object(_) => Err(FaucetError::Sink(format!(
+            "pubsub: {what} resolved to a {} — must be a scalar",
+            type_name(v)
+        ))),
+    }
+}
+
+/// Derive the ordering key for one record. `Ok(None)` = no ordering key.
+pub(crate) fn derive_ordering_key(
+    record: &Value,
+    strategy: &OrderingKey,
+) -> Result<Option<String>, FaucetError> {
+    match strategy {
+        OrderingKey::None => Ok(None),
+        OrderingKey::Field { name } => {
+            let v = record.get(name).ok_or_else(|| {
+                FaucetError::Sink(format!(
+                    "pubsub: record has no top-level field '{name}' for the ordering key"
+                ))
+            })?;
+            Ok(Some(scalar_to_string(v, &format!("field '{name}'"))?))
+        }
+        OrderingKey::Jsonpath { path } => {
+            let v = resolve_path(record, path).ok_or_else(|| {
+                FaucetError::Sink(format!(
+                    "pubsub: path '{path}' matched nothing for the ordering key"
+                ))
+            })?;
+            Ok(Some(scalar_to_string(v, &format!("path '{path}'"))?))
+        }
+    }
+}
+
+/// Encode one record's payload bytes per the configured format. Pure.
+pub(crate) fn encode_payload(record: &Value, format: ValueFormat) -> Result<Vec<u8>, FaucetError> {
+    match format {
+        ValueFormat::Json => serde_json::to_vec(record)
+            .map_err(|e| FaucetError::Sink(format!("pubsub: record serialization failed: {e}"))),
+        ValueFormat::String => match record {
+            Value::String(s) => Ok(s.clone().into_bytes()),
+            other => Err(FaucetError::Sink(format!(
+                "pubsub: value_format 'string' requires string records (got {})",
+                type_name(other)
+            ))),
+        },
+        ValueFormat::Bytes => match record {
+            Value::String(s) => {
+                use base64::Engine as _;
+                base64::engine::general_purpose::STANDARD
+                    .decode(s.as_bytes())
+                    .map_err(|e| {
+                        FaucetError::Sink(format!(
+                            "pubsub: value_format 'bytes' requires base64 strings: {e}"
+                        ))
+                    })
+            }
+            other => Err(FaucetError::Sink(format!(
+                "pubsub: value_format 'bytes' requires base64 string records (got {})",
+                type_name(other)
+            ))),
+        },
+    }
+}
+
+/// Pull a message-attribute map out of `attributes_field` (a JSON object of
+/// scalars). Returns the attributes and the payload record with that field
+/// removed. Absent field → empty attributes + the record unchanged.
+fn extract_attributes<'a>(
+    record: &'a Value,
+    attributes_field: Option<&str>,
+) -> Result<(HashMap<String, String>, std::borrow::Cow<'a, Value>), FaucetError> {
+    let Some(field) = attributes_field else {
+        return Ok((HashMap::new(), std::borrow::Cow::Borrowed(record)));
+    };
+    let Some(raw) = record.get(field) else {
+        return Ok((HashMap::new(), std::borrow::Cow::Borrowed(record)));
+    };
+    let obj = raw.as_object().ok_or_else(|| {
+        FaucetError::Sink(format!(
+            "pubsub: attributes_field '{field}' must be a JSON object (got {})",
+            type_name(raw)
+        ))
+    })?;
+    let mut attributes = HashMap::with_capacity(obj.len());
+    for (k, v) in obj {
+        attributes.insert(k.clone(), scalar_to_string(v, &format!("attribute '{k}'"))?);
+    }
+    // Strip the attributes field from the payload.
+    let mut stripped = record.clone();
+    if let Some(map) = stripped.as_object_mut() {
+        map.remove(field);
+    }
+    Ok((attributes, std::borrow::Cow::Owned(stripped)))
+}
+
+/// Build the full [`Prepared`] message for one record. Pure — the single
+/// per-record entry point `sink.rs` calls.
+pub(crate) fn prepare(
+    record: &Value,
+    value_format: ValueFormat,
+    ordering_key: &OrderingKey,
+    attributes_field: Option<&str>,
+) -> Result<Prepared, FaucetError> {
+    let ordering = derive_ordering_key(record, ordering_key)?.unwrap_or_default();
+    let (attributes, payload) = extract_attributes(record, attributes_field)?;
+    let data = encode_payload(payload.as_ref(), value_format)?;
+    Ok(Prepared {
+        data,
+        attributes,
+        ordering_key: ordering,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn ordering_key_strategies() {
+        let r = json!({"customer_id": 42, "nested": {"id": "abc"}, "flag": true});
+        assert_eq!(derive_ordering_key(&r, &OrderingKey::None).unwrap(), None);
+        assert_eq!(
+            derive_ordering_key(
+                &r,
+                &OrderingKey::Field {
+                    name: "customer_id".into()
+                }
+            )
+            .unwrap()
+            .as_deref(),
+            Some("42")
+        );
+        assert_eq!(
+            derive_ordering_key(
+                &r,
+                &OrderingKey::Jsonpath {
+                    path: "nested.id".into()
+                }
+            )
+            .unwrap()
+            .as_deref(),
+            Some("abc")
+        );
+        assert_eq!(
+            derive_ordering_key(
+                &r,
+                &OrderingKey::Field {
+                    name: "flag".into()
+                }
+            )
+            .unwrap()
+            .as_deref(),
+            Some("true")
+        );
+        // Missing / null / container fail per-record.
+        assert!(
+            derive_ordering_key(
+                &r,
+                &OrderingKey::Field {
+                    name: "nope".into()
+                }
+            )
+            .is_err()
+        );
+        let bad = json!({"k": null, "obj": {"a": 1}});
+        assert!(derive_ordering_key(&bad, &OrderingKey::Field { name: "k".into() }).is_err());
+        assert!(derive_ordering_key(&bad, &OrderingKey::Field { name: "obj".into() }).is_err());
+        assert!(
+            derive_ordering_key(
+                &r,
+                &OrderingKey::Jsonpath {
+                    path: "no.pe".into()
+                }
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn payload_encoding_per_format() {
+        let obj = json!({"a": 1});
+        assert_eq!(
+            encode_payload(&obj, ValueFormat::Json).unwrap(),
+            br#"{"a":1}"#.to_vec()
+        );
+
+        let s = json!("plain text");
+        assert_eq!(
+            encode_payload(&s, ValueFormat::String).unwrap(),
+            b"plain text".to_vec()
+        );
+        assert!(encode_payload(&obj, ValueFormat::String).is_err());
+
+        assert_eq!(
+            encode_payload(&json!("AQID"), ValueFormat::Bytes).unwrap(),
+            vec![1, 2, 3]
+        );
+        assert!(encode_payload(&json!("!!!"), ValueFormat::Bytes).is_err());
+        assert!(encode_payload(&obj, ValueFormat::Bytes).is_err());
+    }
+
+    #[test]
+    fn attributes_extracted_and_stripped() {
+        let r = json!({"a": 1, "__attributes": {"origin": "eu", "n": 7, "ok": true}});
+        let (attrs, payload) = extract_attributes(&r, Some("__attributes")).unwrap();
+        assert_eq!(attrs.get("origin").map(String::as_str), Some("eu"));
+        assert_eq!(attrs.get("n").map(String::as_str), Some("7"));
+        assert_eq!(attrs.get("ok").map(String::as_str), Some("true"));
+        // The field is removed from the payload.
+        assert!(payload.get("__attributes").is_none());
+        assert_eq!(payload["a"], 1);
+    }
+
+    #[test]
+    fn attributes_absent_field_is_no_op() {
+        let r = json!({"a": 1});
+        let (attrs, payload) = extract_attributes(&r, Some("__attributes")).unwrap();
+        assert!(attrs.is_empty());
+        assert_eq!(payload.as_ref(), &r);
+
+        let (attrs, payload) = extract_attributes(&r, None).unwrap();
+        assert!(attrs.is_empty());
+        assert_eq!(payload.as_ref(), &r);
+    }
+
+    #[test]
+    fn attributes_field_must_be_object_of_scalars() {
+        let r = json!({"__attributes": "not an object"});
+        assert!(extract_attributes(&r, Some("__attributes")).is_err());
+        let r = json!({"__attributes": {"nested": {"x": 1}}});
+        assert!(extract_attributes(&r, Some("__attributes")).is_err());
+    }
+
+    #[test]
+    fn prepare_end_to_end() {
+        let r = json!({"id": "o-1", "amount": 5, "__attributes": {"src": "web"}});
+        let p = prepare(
+            &r,
+            ValueFormat::Json,
+            &OrderingKey::Field { name: "id".into() },
+            Some("__attributes"),
+        )
+        .unwrap();
+        assert_eq!(p.ordering_key, "o-1");
+        assert_eq!(p.attributes.get("src").map(String::as_str), Some("web"));
+        // Payload is the record minus __attributes.
+        let decoded: Value = serde_json::from_slice(&p.data).unwrap();
+        assert_eq!(decoded["id"], "o-1");
+        assert_eq!(decoded["amount"], 5);
+        assert!(decoded.get("__attributes").is_none());
+    }
+
+    #[test]
+    fn prepare_no_ordering_no_attributes() {
+        let r = json!({"id": "o-2"});
+        let p = prepare(&r, ValueFormat::Json, &OrderingKey::None, None).unwrap();
+        assert!(p.ordering_key.is_empty());
+        assert!(p.attributes.is_empty());
+        assert_eq!(serde_json::from_slice::<Value>(&p.data).unwrap(), r);
+    }
+
+    #[test]
+    fn prepare_propagates_ordering_error() {
+        let r = json!({"id": "o-3"});
+        let err = prepare(
+            &r,
+            ValueFormat::Json,
+            &OrderingKey::Field {
+                name: "missing".into(),
+            },
+            None,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("missing"), "{err}");
+    }
+}

--- a/crates/sink/pubsub/src/lib.rs
+++ b/crates/sink/pubsub/src/lib.rs
@@ -1,0 +1,24 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+//! # faucet-sink-pubsub
+//!
+//! Google Cloud Pub/Sub sink connector for
+//! [faucet-stream](https://github.com/PawanSikawat/faucet-stream): batched
+//! `publish` to a topic with a configurable `value_format` (json / string /
+//! bytes), optional per-message `ordering_key` (field or dot-path) that
+//! enables message ordering, bounded publish concurrency, and per-message
+//! partial-failure outcomes that route to a DLQ.
+//!
+//! **Delivery is at-least-once** — Pub/Sub provides no primitive that composes
+//! with faucet's exactly-once watermark model, so this sink does not advertise
+//! idempotent writes. De-duplicate downstream on `message_id` if needed.
+
+mod config;
+mod encode;
+mod sink;
+
+pub use config::{MAX_BATCH, OrderingKey, PubsubSinkConfig, ValueFormat};
+pub use sink::PubsubSink;
+
+// Shared connection types, re-exported so users need only this crate.
+pub use faucet_common_pubsub::{PubsubConnection, PubsubCredentials};

--- a/crates/sink/pubsub/src/sink.rs
+++ b/crates/sink/pubsub/src/sink.rs
@@ -1,0 +1,315 @@
+//! The Pub/Sub `Sink` implementation: encode → batched publish with bounded
+//! concurrency → per-message partial-failure outcomes (DLQ-routable).
+//!
+//! **SDK-touching module.** All `gcloud-pubsub` calls live here (client
+//! construction is in `faucet-common-pubsub`), so a real-compile fixup for a
+//! differing SDK version is localised to `PubsubSink::new`, `publish_chunk`,
+//! and `check`. The record→message logic (`encode_records`,
+//! `assemble_row_outcomes`) is pure and unit-tested offline.
+
+use crate::config::PubsubSinkConfig;
+use crate::encode::{Prepared, prepare};
+use faucet_common_pubsub::PubsubMessage;
+use faucet_core::{FaucetError, RowOutcome};
+use gcloud_pubsub::client::Client;
+use gcloud_pubsub::publisher::{Publisher, PublisherConfig};
+use serde_json::Value;
+use std::collections::BTreeMap;
+
+/// Google Cloud Pub/Sub sink. See the crate README for semantics.
+pub struct PubsubSink {
+    config: PubsubSinkConfig,
+    client: Client,
+    publisher: Publisher,
+}
+
+/// Encode every record; per-record failures (bad payload, unresolvable
+/// ordering key, malformed attributes) land in the error map keyed by input
+/// index. Pure.
+pub(crate) fn encode_records(
+    records: &[Value],
+    config: &PubsubSinkConfig,
+) -> (Vec<(usize, Prepared)>, BTreeMap<usize, FaucetError>) {
+    let mut prepared = Vec::with_capacity(records.len());
+    let mut failures = BTreeMap::new();
+    for (index, record) in records.iter().enumerate() {
+        match prepare(
+            record,
+            config.value_format,
+            &config.ordering_key,
+            config.attributes_field.as_deref(),
+        ) {
+            Ok(p) => prepared.push((index, p)),
+            Err(e) => {
+                failures.insert(index, e);
+            }
+        }
+    }
+    (prepared, failures)
+}
+
+/// Merge encode failures + publish outcomes into input-ordered per-row
+/// results. Pure.
+pub(crate) fn assemble_row_outcomes(
+    len: usize,
+    mut encode_failures: BTreeMap<usize, FaucetError>,
+    mut shipped: BTreeMap<usize, Result<(), FaucetError>>,
+) -> Vec<RowOutcome> {
+    (0..len)
+        .map(|i| {
+            if let Some(err) = encode_failures.remove(&i) {
+                Err(err)
+            } else {
+                shipped.remove(&i).unwrap_or(Ok(()))
+            }
+        })
+        .collect()
+}
+
+impl PubsubSink {
+    /// Create a new Pub/Sub sink. Validates the config, builds the client, and
+    /// opens a reusable publisher. Ordered delivery is driven per-message: when
+    /// an `ordering_key` strategy is configured, `encode` stamps each message's
+    /// ordering key and the publisher sequences same-key messages automatically
+    /// (the `gcloud-pubsub` publisher has no client-level ordering toggle).
+    pub async fn new(config: PubsubSinkConfig) -> Result<Self, FaucetError> {
+        config.validate()?;
+        let client = faucet_common_pubsub::build_client(&config.connection).await?;
+        let publisher = client
+            .topic(&config.topic)
+            .new_publisher(Some(PublisherConfig::default()));
+        Ok(Self {
+            config,
+            client,
+            publisher,
+        })
+    }
+
+    /// Publish one chunk of prepared records concurrently, returning per-index
+    /// outcomes.
+    async fn publish_chunk(
+        &self,
+        chunk: Vec<(usize, Prepared)>,
+    ) -> BTreeMap<usize, Result<(), FaucetError>> {
+        use futures::StreamExt;
+        // Enqueue every message; the publisher bundles them internally.
+        let mut awaiters = Vec::with_capacity(chunk.len());
+        for (index, p) in chunk {
+            let msg = PubsubMessage {
+                data: p.data,
+                attributes: p.attributes,
+                ordering_key: p.ordering_key,
+                ..Default::default()
+            };
+            let awaiter = self.publisher.publish(msg).await;
+            awaiters.push((index, awaiter));
+        }
+        let mut outcomes = BTreeMap::new();
+        let mut stream =
+            futures::stream::iter(awaiters.into_iter().map(|(index, awaiter)| async move {
+                let result = awaiter
+                    .get()
+                    .await
+                    .map(|_message_id| ())
+                    .map_err(|e| FaucetError::Sink(format!("pubsub: publish failed: {e}")));
+                (index, result)
+            }))
+            .buffer_unordered(self.config.concurrency);
+        while let Some((index, result)) = stream.next().await {
+            outcomes.insert(index, result);
+        }
+        outcomes
+    }
+
+    /// Publish all prepared records in `batch_size` chunks, merging outcomes.
+    async fn publish_all(
+        &self,
+        prepared: Vec<(usize, Prepared)>,
+    ) -> BTreeMap<usize, Result<(), FaucetError>> {
+        let mut merged = BTreeMap::new();
+        let mut iter = prepared.into_iter();
+        loop {
+            let chunk: Vec<_> = iter.by_ref().take(self.config.batch_size).collect();
+            if chunk.is_empty() {
+                break;
+            }
+            merged.extend(self.publish_chunk(chunk).await);
+        }
+        merged
+    }
+}
+
+#[faucet_core::async_trait]
+impl faucet_core::Sink for PubsubSink {
+    async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
+        if records.is_empty() {
+            return Ok(0);
+        }
+        let (prepared, encode_failures) = encode_records(records, &self.config);
+        let outcomes = self.publish_all(prepared).await;
+        let delivered = outcomes.values().filter(|o| o.is_ok()).count();
+        let failed = encode_failures.len() + (outcomes.len() - delivered);
+        if failed > 0 {
+            let first = encode_failures
+                .values()
+                .next()
+                .map(ToString::to_string)
+                .or_else(|| {
+                    outcomes
+                        .values()
+                        .find_map(|o| o.as_ref().err().map(ToString::to_string))
+                })
+                .unwrap_or_default();
+            return Err(FaucetError::Sink(format!(
+                "pubsub: {failed} of {} record(s) failed to publish (first: {first})",
+                records.len()
+            )));
+        }
+        tracing::info!(
+            topic = %self.config.topic,
+            records = delivered,
+            "pubsub sink write complete"
+        );
+        Ok(delivered)
+    }
+
+    /// Per-row outcomes in input order: encode failures and per-message publish
+    /// rejections come back as `Err` rows for the DLQ router.
+    async fn write_batch_partial(&self, records: &[Value]) -> Result<Vec<RowOutcome>, FaucetError> {
+        let (prepared, encode_failures) = encode_records(records, &self.config);
+        let shipped = self.publish_all(prepared).await;
+        Ok(assemble_row_outcomes(
+            records.len(),
+            encode_failures,
+            shipped,
+        ))
+    }
+
+    fn config_schema(&self) -> Value {
+        serde_json::to_value(faucet_core::schema_for!(PubsubSinkConfig))
+            .expect("schema serialization")
+    }
+
+    fn connector_name(&self) -> &'static str {
+        "pubsub"
+    }
+
+    fn dataset_uri(&self) -> String {
+        format!(
+            "pubsub://{}/topics/{}",
+            self.config
+                .connection
+                .project_id
+                .as_deref()
+                .unwrap_or("default"),
+            self.config.topic
+        )
+    }
+
+    /// Side-effect-free probe: confirm the topic exists (no messages written).
+    async fn check(
+        &self,
+        ctx: &faucet_core::CheckContext,
+    ) -> Result<faucet_core::CheckReport, FaucetError> {
+        use faucet_core::{CheckReport, Probe};
+        let start = std::time::Instant::now();
+        let topic = self.client.topic(&self.config.topic);
+        let fut = topic.exists(None);
+        let probe = match tokio::time::timeout(ctx.timeout, fut).await {
+            Err(_) => Probe::fail("topic_exists", start.elapsed(), "timed out"),
+            Ok(Ok(true)) => Probe::pass("topic_exists", start.elapsed()),
+            Ok(Ok(false)) => Probe::fail(
+                "topic_exists",
+                start.elapsed(),
+                format!("topic '{}' does not exist", self.config.topic),
+            ),
+            Ok(Err(e)) => Probe::fail("topic_exists", start.elapsed(), e.to_string()),
+        };
+        Ok(CheckReport::single(probe))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{OrderingKey, ValueFormat};
+    use serde_json::json;
+
+    #[test]
+    fn encode_records_partitions_failures_by_index() {
+        let mut cfg = PubsubSinkConfig::new("orders");
+        cfg.ordering_key = OrderingKey::Field { name: "id".into() };
+        let records = vec![
+            json!({"id": "a", "v": 1}), // ok
+            json!({"v": 2}),            // no ordering-key field
+            json!({"id": "c", "v": 3}), // ok
+        ];
+        let (prepared, failures) = encode_records(&records, &cfg);
+        assert_eq!(prepared.len(), 2);
+        assert_eq!(prepared[0].0, 0);
+        assert_eq!(prepared[1].0, 2);
+        assert_eq!(failures.len(), 1);
+        assert!(failures[&1].to_string().contains("id"), "{}", failures[&1]);
+    }
+
+    #[test]
+    fn encode_records_string_format_failure_is_per_record() {
+        let mut cfg = PubsubSinkConfig::new("orders");
+        cfg.value_format = ValueFormat::String;
+        let (prepared, failures) = encode_records(&[json!({"not": "a string"}), json!("ok")], &cfg);
+        assert_eq!(prepared.len(), 1, "only the string record encodes");
+        assert_eq!(prepared[0].0, 1);
+        assert_eq!(failures.len(), 1);
+        assert!(failures.contains_key(&0));
+    }
+
+    #[test]
+    fn assemble_row_outcomes_interleaves_encode_and_publish_results() {
+        let mut encode_failures = BTreeMap::new();
+        encode_failures.insert(1usize, FaucetError::Sink("bad encode".into()));
+        let mut shipped = BTreeMap::new();
+        shipped.insert(0usize, Ok(()));
+        shipped.insert(2usize, Err(FaucetError::Sink("publish rejected".into())));
+        // index 3 absent from both → defaults to Ok
+
+        let outcomes = assemble_row_outcomes(4, encode_failures, shipped);
+        assert_eq!(outcomes.len(), 4);
+        assert!(outcomes[0].is_ok());
+        assert!(
+            outcomes[1]
+                .as_ref()
+                .unwrap_err()
+                .to_string()
+                .contains("bad encode")
+        );
+        assert!(
+            outcomes[2]
+                .as_ref()
+                .unwrap_err()
+                .to_string()
+                .contains("publish rejected")
+        );
+        assert!(outcomes[3].is_ok());
+    }
+
+    #[test]
+    fn config_schema_exposes_fields() {
+        let schema = serde_json::to_value(faucet_core::schema_for!(PubsubSinkConfig)).unwrap();
+        assert!(schema["properties"]["topic"].is_object());
+        assert!(schema["properties"]["ordering_key"].is_object());
+    }
+
+    #[tokio::test]
+    async fn new_rejects_invalid_config() {
+        // Validation runs before any client build → offline config error.
+        let mut cfg = PubsubSinkConfig::new("orders");
+        cfg.batch_size = 0;
+        // `PubsubSink` holds a non-`Debug` SDK publisher, so `unwrap_err` (which
+        // needs the `Ok` type to be `Debug`) is unavailable — match instead.
+        let err = match PubsubSink::new(cfg).await {
+            Ok(_) => panic!("expected a config error for batch_size = 0"),
+            Err(e) => e,
+        };
+        assert!(err.to_string().contains("batch_size"), "{err}");
+    }
+}

--- a/crates/sink/pubsub/tests/integration.rs
+++ b/crates/sink/pubsub/tests/integration.rs
@@ -1,0 +1,272 @@
+//! Integration tests against a real Google Cloud Pub/Sub **emulator** started
+//! automatically in Docker via testcontainers — no external infra, no env
+//! gating, not `#[ignore]`d. Mirrors the DB testcontainer template
+//! (`crates/source/mssql/tests/integration.rs`).
+//!
+//! Requires Docker (the `google/cloud-sdk:*-emulators` image). Run with:
+//! `cargo test -p faucet-sink-pubsub --test integration`.
+//!
+//! A single emulator container is shared across every test in this binary (via
+//! a leaked `OnceCell`), so its mapped port is stable. `PUBSUB_EMULATOR_HOST`
+//! is written exactly once, inside the guarded init — the SDK's
+//! `ClientConfig::default()` (used both by the read-back client here and by the
+//! sink's `build_client`) reads that env var and switches to the emulator
+//! environment (no auth). Each test uses distinct topic / subscription names so
+//! they run concurrently against the one emulator without a serialization lock.
+
+use faucet_core::{CheckContext, Sink};
+use faucet_sink_pubsub::{
+    OrderingKey, PubsubConnection, PubsubCredentials, PubsubSink, PubsubSinkConfig, ValueFormat,
+};
+use gcloud_pubsub::client::{Client, ClientConfig};
+use gcloud_pubsub::subscriber::ReceivedMessage;
+use gcloud_pubsub::subscription::Subscription;
+use serde_json::{Value, json};
+use std::time::{Duration, Instant};
+use tokio::sync::OnceCell;
+
+use testcontainers_modules::google_cloud_sdk_emulators::{CloudSdk, PUBSUB_PORT};
+use testcontainers_modules::testcontainers::runners::AsyncRunner;
+
+const PROJECT: &str = "faucet-test";
+
+static EMULATOR_HOST: OnceCell<String> = OnceCell::const_new();
+
+async fn emulator_host() -> &'static str {
+    EMULATOR_HOST
+        .get_or_init(|| async {
+            let container = CloudSdk::pubsub()
+                .start()
+                .await
+                .expect("start pubsub emulator container");
+            let port = container
+                .get_host_port_ipv4(PUBSUB_PORT)
+                .await
+                .expect("pubsub emulator host port");
+            let host = format!("127.0.0.1:{port}");
+            // SAFETY: written exactly once — `get_or_init` serializes concurrent
+            // callers, and no client is built until this future has completed.
+            unsafe {
+                std::env::set_var("PUBSUB_EMULATOR_HOST", &host);
+            }
+            // Keep the container alive for the process lifetime: never run its
+            // `Drop` (which would stop/remove it), so later tests — on their own
+            // per-test runtimes — can keep connecting to it via the host string.
+            std::mem::forget(container);
+            host
+        })
+        .await
+        .as_str()
+}
+
+async fn setup_client() -> Client {
+    // `ClientConfig` is `#[non_exhaustive]`, so struct-update syntax is
+    // unavailable — reassign the one field we need after `default()`.
+    #[allow(clippy::field_reassign_with_default)]
+    let config = {
+        let mut config = ClientConfig::default(); // reads PUBSUB_EMULATOR_HOST
+        config.project_id = Some(PROJECT.to_string());
+        config
+    };
+    Client::new(config).await.expect("emulator setup client")
+}
+
+fn conn(host: &str) -> PubsubConnection {
+    PubsubConnection {
+        project_id: Some(PROJECT.into()),
+        emulator_host: Some(host.to_string()),
+        credentials: PubsubCredentials::Anonymous,
+        ..Default::default()
+    }
+}
+
+/// Create the topic + a subscription and return a handle to the subscription so
+/// the test can read the published messages back.
+async fn create_topic_sub(client: &Client, topic_id: &str, sub_id: &str) -> Subscription {
+    let topic = client
+        .create_topic(topic_id, None, None)
+        .await
+        .expect("create topic");
+    client
+        .create_subscription(
+            sub_id,
+            topic.fully_qualified_name(),
+            Default::default(),
+            None,
+        )
+        .await
+        .expect("create subscription");
+    client.subscription(sub_id)
+}
+
+/// Pull (and ack) until `want` messages are collected or a deadline passes.
+/// Pub/Sub `pull` may return the messages across several calls.
+async fn drain(sub: &Subscription, want: usize) -> Vec<ReceivedMessage> {
+    let deadline = Instant::now() + Duration::from_secs(20);
+    let mut out = Vec::new();
+    while out.len() < want && Instant::now() < deadline {
+        let msgs = sub.pull(want as i32, None).await.expect("pull");
+        if msgs.is_empty() {
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            continue;
+        }
+        for m in &msgs {
+            let _ = m.ack().await;
+        }
+        out.extend(msgs);
+    }
+    out
+}
+
+fn payload_json(m: &ReceivedMessage) -> Value {
+    serde_json::from_slice(&m.message.data).expect("payload is JSON")
+}
+
+/// JSON value_format with an attributes field: records publish, are pullable,
+/// the attribute map arrives on the message, and the attributes field is
+/// stripped from the payload. Also exercises the `check()` topic-exists probe.
+/// Covers `sink.rs` `write_batch` → `publish_all` → `publish_chunk`.
+#[tokio::test(flavor = "multi_thread")]
+async fn sink_json_publishes_with_attributes_and_check() {
+    let host = emulator_host().await;
+    let client = setup_client().await;
+    let sub = create_topic_sub(&client, "sink-json-t", "sink-json-s").await;
+
+    let mut cfg = PubsubSinkConfig::new("sink-json-t");
+    cfg.connection = conn(host);
+    cfg.value_format = ValueFormat::Json;
+    cfg.attributes_field = Some("__attributes".into());
+    let sink = PubsubSink::new(cfg).await.expect("sink builds");
+
+    // Side-effect-free preflight probe (topic exists).
+    let report = sink
+        .check(&CheckContext::default())
+        .await
+        .expect("check runs");
+    assert_eq!(report.failed_count(), 0, "topic-exists probe passes");
+
+    let written = sink
+        .write_batch(&[
+            json!({"id": "a", "n": 1, "__attributes": {"src": "test"}}),
+            json!({"id": "b", "n": 2}),
+        ])
+        .await
+        .expect("write");
+    assert_eq!(written, 2);
+
+    let got = drain(&sub, 2).await;
+    assert!(got.len() >= 2, "published messages are pullable");
+
+    let mut ns: Vec<i64> = got
+        .iter()
+        .map(|m| payload_json(m)["n"].as_i64().unwrap())
+        .collect();
+    ns.sort();
+    assert_eq!(ns, vec![1, 2]);
+    // The record with `__attributes` carries `src=test` as a message attribute.
+    assert!(
+        got.iter()
+            .any(|m| m.message.attributes.get("src").map(String::as_str) == Some("test")),
+        "attribute mapping onto the message"
+    );
+    // The attributes field is stripped from every payload.
+    assert!(
+        got.iter()
+            .all(|m| payload_json(m).get("__attributes").is_none()),
+        "attributes field stripped from payload"
+    );
+}
+
+/// An `ordering_key: field` strategy stamps each message's ordering key and
+/// drives the publisher's ordered send path. The ordering key round-trips onto
+/// the received messages. Covers the ordered branch of `publish_chunk`.
+#[tokio::test(flavor = "multi_thread")]
+async fn sink_ordering_key_field_sets_message_key() {
+    let host = emulator_host().await;
+    let client = setup_client().await;
+    let sub = create_topic_sub(&client, "sink-ord-t", "sink-ord-s").await;
+
+    let mut cfg = PubsubSinkConfig::new("sink-ord-t");
+    cfg.connection = conn(host);
+    cfg.value_format = ValueFormat::Json;
+    cfg.ordering_key = OrderingKey::Field { name: "id".into() };
+    let sink = PubsubSink::new(cfg).await.expect("sink builds");
+
+    let written = sink
+        .write_batch(&[json!({"id": "o-1", "n": 1}), json!({"id": "o-2", "n": 2})])
+        .await
+        .expect("write");
+    assert_eq!(written, 2);
+
+    let got = drain(&sub, 2).await;
+    assert!(got.len() >= 2, "ordered messages are pullable");
+    let keys: std::collections::BTreeSet<&str> = got
+        .iter()
+        .map(|m| m.message.ordering_key.as_str())
+        .collect();
+    assert!(keys.contains("o-1"), "ordering key o-1 present: {keys:?}");
+    assert!(keys.contains("o-2"), "ordering key o-2 present: {keys:?}");
+}
+
+/// `write_batch_partial` returns per-row outcomes in input order: an
+/// unresolvable ordering key fails just that row (DLQ-routable) while the valid
+/// rows publish. Covers `encode_records` failure partitioning +
+/// `assemble_row_outcomes` + `write_batch_partial`.
+#[tokio::test(flavor = "multi_thread")]
+async fn sink_write_batch_partial_reports_row_failures() {
+    let host = emulator_host().await;
+    let client = setup_client().await;
+    let sub = create_topic_sub(&client, "sink-partial-t", "sink-partial-s").await;
+
+    let mut cfg = PubsubSinkConfig::new("sink-partial-t");
+    cfg.connection = conn(host);
+    cfg.ordering_key = OrderingKey::Field { name: "id".into() };
+    let sink = PubsubSink::new(cfg).await.expect("sink builds");
+
+    let records = [
+        json!({"id": "ok1", "n": 1}),
+        json!({"n": 2}), // missing the `id` ordering-key field → per-row failure
+        json!({"id": "ok2", "n": 3}),
+    ];
+    let outcomes = sink
+        .write_batch_partial(&records)
+        .await
+        .expect("partial write");
+    assert_eq!(outcomes.len(), 3);
+    assert!(outcomes[0].is_ok(), "row 0 published");
+    assert!(outcomes[1].is_err(), "row 1 has no ordering key");
+    assert!(
+        outcomes[1].as_ref().unwrap_err().to_string().contains("id"),
+        "error names the missing field: {:?}",
+        outcomes[1]
+    );
+    assert!(outcomes[2].is_ok(), "row 2 published");
+
+    let got = drain(&sub, 2).await;
+    assert!(got.len() >= 2, "the two valid rows are pullable");
+}
+
+/// When every row fails to encode, `write_batch` returns an aggregate error
+/// (rather than a partial success). Covers the `failed > 0` branch of
+/// `write_batch` and its first-error extraction.
+#[tokio::test(flavor = "multi_thread")]
+async fn sink_write_batch_surfaces_encode_failure() {
+    let host = emulator_host().await;
+    let client = setup_client().await;
+    let _sub = create_topic_sub(&client, "sink-fail-t", "sink-fail-s").await;
+
+    let mut cfg = PubsubSinkConfig::new("sink-fail-t");
+    cfg.connection = conn(host);
+    cfg.ordering_key = OrderingKey::Field { name: "id".into() };
+    let sink = PubsubSink::new(cfg).await.expect("sink builds");
+
+    // The single record has no `id` field → encode fails before any publish.
+    let err = match sink.write_batch(&[json!({"n": 1})]).await {
+        Ok(_) => panic!("expected an aggregate publish failure"),
+        Err(e) => e,
+    };
+    assert!(
+        err.to_string().contains("failed to publish"),
+        "aggregate error: {err}"
+    );
+}

--- a/crates/sink/redshift/Cargo.toml
+++ b/crates/sink/redshift/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "faucet-sink-redshift"
+version = "1.0.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Amazon Redshift sink connector (COPY-from-S3 and multi-row INSERT) for the faucet-stream ecosystem"
+readme = "README.md"
+keywords = ["redshift", "aws", "sql", "sink", "pipeline"]
+categories.workspace = true
+
+[dependencies]
+faucet-core.workspace = true
+faucet-common-redshift.workspace = true
+schemars.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+async-trait.workspace = true
+tracing.workspace = true
+sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls", "postgres"] }
+aws-sdk-s3 = { workspace = true }
+aws-config = { workspace = true }
+uuid.workspace = true
+tokio.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time", "sync"] }
+serde_json.workspace = true
+schemars.workspace = true
+faucet-conformance.workspace = true
+sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls", "postgres"] }
+testcontainers = "0.27"
+testcontainers-modules = { version = "0.15", features = ["postgres"] }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/sink/redshift/README.md
+++ b/crates/sink/redshift/README.md
@@ -1,0 +1,60 @@
+# faucet-sink-redshift
+
+Amazon Redshift sink connector for the
+[`faucet-stream`](https://crates.io/crates/faucet-stream) ecosystem.
+
+Redshift speaks the PostgreSQL wire protocol, so the sink connects through
+`sqlx`'s Postgres driver. Two load paths:
+
+- **`copy`** (default) — stage each page to S3 as JSONL or CSV, then bulk-load
+  it with `COPY <table> FROM 's3://…' IAM_ROLE '<arn>' FORMAT …`, and delete the
+  staged object (best-effort). This is Redshift's recommended, fastest bulk-load
+  path.
+- **`insert`** — multi-row `INSERT INTO … VALUES (…), (…)`. Portable and needs
+  no S3, but slower for bulk data. Sub-chunked to respect Redshift's bind-param
+  limit.
+
+Append-only: Redshift has no `ON CONFLICT`, and `COPY` cannot upsert, so
+`supported_write_modes()` is `[Append]`.
+
+## Configuration
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `host` / `port` / `database` / `user` / `credentials` / `tls` | — | Connection block (see `faucet-common-redshift`). |
+| `table_name` | yes | Target table. |
+| `schema` | no | Namespace qualifying the table. |
+| `write_strategy` | no | `copy` (default) or `insert`. |
+| `copy_format` | no | `jsonl` (default, `FORMAT AS JSON 'auto'`) or `csv` (`FORMAT AS CSV`). |
+| `staging_bucket` | copy only | S3 bucket for staged files. |
+| `staging_prefix` | no | Key prefix for staged objects. |
+| `iam_role` | copy only | IAM role ARN Redshift assumes to read the staged file. |
+| `region` | no | AWS region (S3 client + `COPY … REGION`). |
+| `endpoint_url` | no | S3-compatible endpoint override (testing). |
+| `batch_size` | no | Rows per load unit (default `1000`; `0` = whole page). |
+| `max_connections` | no | Pool size (default `5`). |
+
+```yaml
+host: my-cluster.abc123.us-east-1.redshift.amazonaws.com
+database: dev
+user: admin
+credentials:
+  type: password
+  config:
+    password: ${env:REDSHIFT_PASSWORD}
+table_name: events
+write_strategy: copy
+copy_format: jsonl
+staging_bucket: my-redshift-staging
+staging_prefix: faucet/
+iam_role: arn:aws:iam::123456789012:role/redshift-copy
+region: us-east-1
+```
+
+## Testing
+
+Redshift has no local container image, and the `copy` path also needs a real S3
+bucket + IAM role, so live load tests live in `tests/integration.rs` and are
+`#[ignore]`d — they run only when `REDSHIFT_*` environment variables are set.
+
+License: MIT OR Apache-2.0

--- a/crates/sink/redshift/src/config.rs
+++ b/crates/sink/redshift/src/config.rs
@@ -1,0 +1,229 @@
+//! Amazon Redshift sink configuration.
+
+use faucet_common_redshift::RedshiftConnection;
+use faucet_core::{DEFAULT_BATCH_SIZE, FaucetError};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// How the sink loads rows into Redshift.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum RedshiftWriteStrategy {
+    /// Stage each page to S3 and bulk-load it with `COPY … FROM 's3://…'` — the
+    /// default and by far the fastest path for Redshift (the recommended way to
+    /// load data). Requires `staging_bucket` and `iam_role`.
+    #[default]
+    Copy,
+    /// Multi-row `INSERT INTO … VALUES (…), (…)`. Portable and needs no S3, but
+    /// much slower than `COPY` for anything beyond small batches. Redshift does
+    /// not recommend row-by-row inserts for bulk data.
+    Insert,
+}
+
+impl RedshiftWriteStrategy {
+    /// Lower-case wire name, for error messages.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Copy => "copy",
+            Self::Insert => "insert",
+        }
+    }
+}
+
+/// Format of the staged file that `COPY` reads.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum RedshiftCopyFormat {
+    /// Newline-delimited JSON objects, loaded with `FORMAT AS JSON 'auto'`.
+    /// Maps by column **name** (order-independent) and handles NULLs and typed
+    /// columns cleanly — the default.
+    #[default]
+    Jsonl,
+    /// RFC-4180 CSV, loaded with `FORMAT AS CSV`. Column order is taken from the
+    /// destination table's schema and passed explicitly in the `COPY` column
+    /// list.
+    Csv,
+}
+
+fn default_batch_size() -> usize {
+    DEFAULT_BATCH_SIZE
+}
+
+fn default_max_connections() -> u32 {
+    5
+}
+
+/// Configuration for the Amazon Redshift sink.
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+pub struct RedshiftSinkConfig {
+    /// Connection block (host / port / database / user / credentials / tls),
+    /// flattened to the config top level.
+    #[serde(flatten)]
+    pub connection: RedshiftConnection,
+    /// Target table name.
+    pub table_name: String,
+    /// Optional schema (namespace) qualifying [`table_name`](Self::table_name).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub schema: Option<String>,
+    /// How rows are loaded. Defaults to [`RedshiftWriteStrategy::Copy`].
+    #[serde(default)]
+    pub write_strategy: RedshiftWriteStrategy,
+    /// Staged-file format for the `COPY` path. Defaults to
+    /// [`RedshiftCopyFormat::Jsonl`]. Ignored by the `insert` strategy.
+    #[serde(default)]
+    pub copy_format: RedshiftCopyFormat,
+    /// S3 bucket used to stage `COPY` files. **Required** when
+    /// `write_strategy: copy`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub staging_bucket: Option<String>,
+    /// Key prefix for staged objects (e.g. `redshift-staging/`). Defaults to
+    /// empty.
+    #[serde(default)]
+    pub staging_prefix: String,
+    /// IAM role ARN Redshift assumes to read the staged file
+    /// (`COPY … IAM_ROLE '<arn>'`). **Required** when `write_strategy: copy`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub iam_role: Option<String>,
+    /// AWS region of the staging bucket (used for both the S3 client and the
+    /// `COPY … REGION '<region>'` clause). `None` uses the SDK default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub region: Option<String>,
+    /// Custom endpoint URL for S3-compatible services (e.g. MinIO) — testing
+    /// aid; production loads use real S3.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub endpoint_url: Option<String>,
+    /// Rows per load unit. For `insert`, the per-statement multi-row chunk size;
+    /// for `copy`, the number of rows per staged S3 object. Defaults to
+    /// [`DEFAULT_BATCH_SIZE`]. `0` = one unit for the whole page.
+    #[serde(default = "default_batch_size")]
+    pub batch_size: usize,
+    /// Maximum number of connections in the pool. Defaults to 5.
+    #[serde(default = "default_max_connections")]
+    pub max_connections: u32,
+}
+
+impl RedshiftSinkConfig {
+    /// Validate the config. Enforces that the `copy` strategy has a staging
+    /// bucket and IAM role.
+    pub fn validate(&self) -> Result<(), FaucetError> {
+        if self.table_name.trim().is_empty() {
+            return Err(FaucetError::Config(
+                "redshift sink: `table_name` must not be empty".into(),
+            ));
+        }
+        if self.write_strategy == RedshiftWriteStrategy::Copy {
+            let bucket_ok = self
+                .staging_bucket
+                .as_ref()
+                .is_some_and(|b| !b.trim().is_empty());
+            if !bucket_ok {
+                return Err(FaucetError::Config(
+                    "redshift sink: write_strategy: copy requires a non-empty `staging_bucket`"
+                        .into(),
+                ));
+            }
+            let role_ok = self.iam_role.as_ref().is_some_and(|r| !r.trim().is_empty());
+            if !role_ok {
+                return Err(FaucetError::Config(
+                    "redshift sink: write_strategy: copy requires a non-empty `iam_role`".into(),
+                ));
+            }
+        }
+        faucet_core::validate_batch_size(self.batch_size)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use faucet_common_redshift::RedshiftConnection;
+
+    fn base() -> RedshiftSinkConfig {
+        RedshiftSinkConfig {
+            connection: RedshiftConnection::new("host", "db", "user", "pw"),
+            table_name: "events".into(),
+            schema: None,
+            write_strategy: RedshiftWriteStrategy::Copy,
+            copy_format: RedshiftCopyFormat::Jsonl,
+            staging_bucket: Some("stage".into()),
+            staging_prefix: String::new(),
+            iam_role: Some("arn:aws:iam::123:role/redshift".into()),
+            region: None,
+            endpoint_url: None,
+            batch_size: DEFAULT_BATCH_SIZE,
+            max_connections: default_max_connections(),
+        }
+    }
+
+    #[test]
+    fn valid_copy_config_passes() {
+        base().validate().unwrap();
+    }
+
+    #[test]
+    fn valid_insert_config_needs_no_bucket() {
+        let mut c = base();
+        c.write_strategy = RedshiftWriteStrategy::Insert;
+        c.staging_bucket = None;
+        c.iam_role = None;
+        c.validate().unwrap();
+    }
+
+    #[test]
+    fn copy_requires_bucket() {
+        let mut c = base();
+        c.staging_bucket = None;
+        match c.validate() {
+            Err(FaucetError::Config(m)) => assert!(m.contains("staging_bucket"), "got: {m}"),
+            other => panic!("expected Config error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn copy_requires_iam_role() {
+        let mut c = base();
+        c.iam_role = Some("  ".into());
+        match c.validate() {
+            Err(FaucetError::Config(m)) => assert!(m.contains("iam_role"), "got: {m}"),
+            other => panic!("expected Config error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_empty_table_name() {
+        let mut c = base();
+        c.table_name = " ".into();
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_oversized_batch() {
+        let mut c = base();
+        c.batch_size = faucet_core::MAX_BATCH_SIZE + 1;
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn defaults_copy_and_jsonl() {
+        let json = r#"{
+            "host": "h", "database": "db", "user": "u",
+            "credentials": {"type": "password", "config": {"password": "pw"}},
+            "table_name": "t",
+            "staging_bucket": "b",
+            "iam_role": "arn:x"
+        }"#;
+        let c: RedshiftSinkConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(c.write_strategy, RedshiftWriteStrategy::Copy);
+        assert_eq!(c.copy_format, RedshiftCopyFormat::Jsonl);
+        assert_eq!(c.max_connections, 5);
+        assert_eq!(c.batch_size, DEFAULT_BATCH_SIZE);
+        c.validate().unwrap();
+    }
+
+    #[test]
+    fn write_strategy_round_trips() {
+        assert_eq!(RedshiftWriteStrategy::Copy.as_str(), "copy");
+        assert_eq!(RedshiftWriteStrategy::Insert.as_str(), "insert");
+    }
+}

--- a/crates/sink/redshift/src/copy.rs
+++ b/crates/sink/redshift/src/copy.rs
@@ -1,0 +1,321 @@
+//! Pure SQL / payload builders for the Redshift sink.
+//!
+//! Everything here is I/O-free and unit-tested: the `COPY` statement, the
+//! multi-row `INSERT` statement, and the CSV / JSONL serializers. Keeping them
+//! pure means the exact SQL a live cluster receives is asserted in tests without
+//! a database.
+
+use crate::config::RedshiftCopyFormat;
+use faucet_core::FaucetError;
+use faucet_core::util::quote_ident;
+use serde_json::Value;
+
+/// Build a schema-qualified, quoted table reference (`"schema"."table"` or
+/// `"table"`).
+pub(crate) fn qualified_table_ref(schema: Option<&str>, table: &str) -> String {
+    match schema {
+        Some(s) => format!("{}.{}", quote_ident(s), quote_ident(table)),
+        None => quote_ident(table),
+    }
+}
+
+/// Render a value as a single-quoted SQL string literal, doubling interior
+/// single quotes so it is injection-safe.
+pub(crate) fn sql_string_literal(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "''"))
+}
+
+/// The `s3://bucket/key` URI for a staged object.
+pub(crate) fn s3_uri(bucket: &str, key: &str) -> String {
+    format!("s3://{bucket}/{key}")
+}
+
+/// Build the Redshift `COPY` statement.
+///
+/// For JSONL the column list is omitted (`FORMAT AS JSON 'auto'` maps by key
+/// name); for CSV the destination column order is passed explicitly. `s3_path`,
+/// `iam_role`, and `region` are emitted as escaped string literals.
+pub(crate) fn copy_statement(
+    table_ref: &str,
+    columns: Option<&[String]>,
+    s3_path: &str,
+    iam_role: &str,
+    region: Option<&str>,
+    format: RedshiftCopyFormat,
+) -> String {
+    let col_clause = match (format, columns) {
+        // CSV needs an explicit, ordered column list.
+        (RedshiftCopyFormat::Csv, Some(cols)) if !cols.is_empty() => {
+            let list = cols
+                .iter()
+                .map(|c| quote_ident(c))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!(" ({list})")
+        }
+        _ => String::new(),
+    };
+
+    let format_clause = match format {
+        RedshiftCopyFormat::Jsonl => "FORMAT AS JSON 'auto'".to_string(),
+        RedshiftCopyFormat::Csv => "FORMAT AS CSV".to_string(),
+    };
+
+    let mut sql = format!(
+        "COPY {table_ref}{col_clause} FROM {} IAM_ROLE {} {format_clause}",
+        sql_string_literal(s3_path),
+        sql_string_literal(iam_role),
+    );
+    if let Some(r) = region.filter(|r| !r.trim().is_empty()) {
+        sql.push_str(&format!(" REGION {}", sql_string_literal(r)));
+    }
+    sql
+}
+
+/// Build a multi-row `INSERT INTO table (cols) VALUES ($1,$2),($3,$4)…`.
+/// Placeholders are numbered `$1..=$(num_rows*columns.len())`.
+pub(crate) fn insert_statement(table_ref: &str, columns: &[String], num_rows: usize) -> String {
+    let col_list = columns
+        .iter()
+        .map(|c| quote_ident(c))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let num_cols = columns.len();
+    let mut tuples = Vec::with_capacity(num_rows);
+    for row in 0..num_rows {
+        let start = row * num_cols + 1;
+        let placeholders = (0..num_cols)
+            .map(|c| format!("${}", start + c))
+            .collect::<Vec<_>>()
+            .join(", ");
+        tuples.push(format!("({placeholders})"));
+    }
+    format!(
+        "INSERT INTO {table_ref} ({col_list}) VALUES {}",
+        tuples.join(", ")
+    )
+}
+
+/// The set of destination columns present in at least one record, preserving
+/// the destination's declared order.
+pub(crate) fn columns_present<'a>(
+    records: &[Value],
+    table_columns: &'a [String],
+) -> Vec<&'a String> {
+    table_columns
+        .iter()
+        .filter(|col| {
+            records
+                .iter()
+                .any(|r| r.as_object().is_some_and(|o| o.contains_key(col.as_str())))
+        })
+        .collect()
+}
+
+/// Serialize records as newline-delimited JSON (JSONL) bytes for `FORMAT AS
+/// JSON 'auto'`.
+pub(crate) fn serialize_jsonl(records: &[Value]) -> Result<Vec<u8>, FaucetError> {
+    let mut buf = Vec::new();
+    for record in records {
+        let line = serde_json::to_vec(record)
+            .map_err(|e| FaucetError::Sink(format!("redshift: JSON serialization failed: {e}")))?;
+        buf.extend_from_slice(&line);
+        buf.push(b'\n');
+    }
+    Ok(buf)
+}
+
+/// Render one CSV cell from a JSON value (RFC-4180 quoting).
+fn csv_cell(v: Option<&Value>) -> String {
+    match v {
+        None | Some(Value::Null) => String::new(),
+        Some(Value::String(s)) => quote_csv(s),
+        Some(Value::Bool(b)) => b.to_string(),
+        Some(Value::Number(n)) => n.to_string(),
+        // Arrays/objects have no scalar form — emit their JSON text, quoted.
+        Some(other) => quote_csv(&other.to_string()),
+    }
+}
+
+/// RFC-4180 field quoting: wrap in double quotes and double interior quotes when
+/// the field contains a comma, quote, CR, or LF.
+fn quote_csv(s: &str) -> String {
+    if s.contains([',', '"', '\n', '\r']) {
+        format!("\"{}\"", s.replace('"', "\"\""))
+    } else {
+        s.to_string()
+    }
+}
+
+/// Serialize records as CSV, one row per record, columns in the given order.
+pub(crate) fn serialize_csv(records: &[Value], columns: &[String]) -> Result<Vec<u8>, FaucetError> {
+    let mut buf = String::new();
+    for record in records {
+        let obj = record.as_object().ok_or_else(|| {
+            FaucetError::Sink("redshift: CSV requires JSON object records".into())
+        })?;
+        let cells: Vec<String> = columns.iter().map(|c| csv_cell(obj.get(c))).collect();
+        buf.push_str(&cells.join(","));
+        buf.push('\n');
+    }
+    Ok(buf.into_bytes())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn table_ref_qualified_and_bare() {
+        assert_eq!(qualified_table_ref(None, "events"), "\"events\"");
+        assert_eq!(
+            qualified_table_ref(Some("analytics"), "events"),
+            "\"analytics\".\"events\""
+        );
+    }
+
+    #[test]
+    fn table_ref_escapes_quotes() {
+        assert_eq!(
+            qualified_table_ref(Some("we\"ird"), "ta\"ble"),
+            "\"we\"\"ird\".\"ta\"\"ble\""
+        );
+    }
+
+    #[test]
+    fn string_literal_doubles_single_quotes() {
+        assert_eq!(sql_string_literal("a'b"), "'a''b'");
+        assert_eq!(sql_string_literal("plain"), "'plain'");
+    }
+
+    #[test]
+    fn copy_jsonl_omits_columns_and_uses_json_auto() {
+        let sql = copy_statement(
+            "\"public\".\"events\"",
+            Some(&["id".into(), "name".into()]),
+            "s3://bucket/staging/abc.jsonl",
+            "arn:aws:iam::123:role/redshift",
+            None,
+            RedshiftCopyFormat::Jsonl,
+        );
+        assert_eq!(
+            sql,
+            "COPY \"public\".\"events\" FROM 's3://bucket/staging/abc.jsonl' \
+             IAM_ROLE 'arn:aws:iam::123:role/redshift' FORMAT AS JSON 'auto'"
+        );
+    }
+
+    #[test]
+    fn copy_csv_includes_ordered_columns() {
+        let sql = copy_statement(
+            "\"events\"",
+            Some(&["id".into(), "name".into()]),
+            "s3://b/k.csv",
+            "arn:role",
+            Some("us-east-1"),
+            RedshiftCopyFormat::Csv,
+        );
+        assert_eq!(
+            sql,
+            "COPY \"events\" (\"id\", \"name\") FROM 's3://b/k.csv' IAM_ROLE 'arn:role' \
+             FORMAT AS CSV REGION 'us-east-1'"
+        );
+    }
+
+    #[test]
+    fn copy_escapes_injection_in_role_and_path() {
+        let sql = copy_statement(
+            "\"t\"",
+            None,
+            "s3://b/k'; DROP TABLE t;--.jsonl",
+            "arn'evil",
+            None,
+            RedshiftCopyFormat::Jsonl,
+        );
+        assert!(sql.contains("'s3://b/k''; DROP TABLE t;--.jsonl'"));
+        assert!(sql.contains("IAM_ROLE 'arn''evil'"));
+    }
+
+    #[test]
+    fn s3_uri_joins_bucket_and_key() {
+        assert_eq!(
+            s3_uri("my-bucket", "prefix/obj.jsonl"),
+            "s3://my-bucket/prefix/obj.jsonl"
+        );
+    }
+
+    #[test]
+    fn insert_statement_numbers_placeholders_per_row() {
+        let sql = insert_statement("\"t\"", &["a".into(), "b".into()], 2);
+        assert_eq!(
+            sql,
+            "INSERT INTO \"t\" (\"a\", \"b\") VALUES ($1, $2), ($3, $4)"
+        );
+    }
+
+    #[test]
+    fn insert_statement_single_row() {
+        let sql = insert_statement("\"t\"", &["a".into()], 1);
+        assert_eq!(sql, "INSERT INTO \"t\" (\"a\") VALUES ($1)");
+    }
+
+    #[test]
+    fn columns_present_is_union_in_table_order() {
+        let table = vec!["id".to_string(), "name".to_string(), "email".to_string()];
+        let records = vec![json!({"id": 1, "email": "a@b.c"}), json!({"name": "Bob"})];
+        let present = columns_present(&records, &table);
+        assert_eq!(
+            present.into_iter().cloned().collect::<Vec<_>>(),
+            vec!["id".to_string(), "name".to_string(), "email".to_string()]
+        );
+    }
+
+    #[test]
+    fn columns_present_drops_absent_columns() {
+        let table = vec!["id".to_string(), "unused".to_string()];
+        let records = vec![json!({"id": 1})];
+        let present = columns_present(&records, &table);
+        assert_eq!(present, vec![&"id".to_string()]);
+    }
+
+    #[test]
+    fn serialize_jsonl_is_newline_delimited() {
+        let out = serialize_jsonl(&[json!({"id": 1}), json!({"id": 2})]).unwrap();
+        let text = String::from_utf8(out).unwrap();
+        let lines: Vec<&str> = text.trim().split('\n').collect();
+        assert_eq!(lines.len(), 2);
+        assert_eq!(
+            serde_json::from_str::<Value>(lines[0]).unwrap()["id"],
+            json!(1)
+        );
+    }
+
+    #[test]
+    fn serialize_csv_orders_columns_and_quotes() {
+        let cols = vec!["id".to_string(), "note".to_string()];
+        let records = vec![
+            json!({"id": 1, "note": "hello, world"}),
+            json!({"id": 2, "note": "quote\"inside"}),
+            json!({"id": 3}), // missing note → empty cell
+        ];
+        let out = serialize_csv(&records, &cols).unwrap();
+        let text = String::from_utf8(out).unwrap();
+        let lines: Vec<&str> = text.trim_end().split('\n').collect();
+        assert_eq!(lines[0], "1,\"hello, world\"");
+        assert_eq!(lines[1], "2,\"quote\"\"inside\"");
+        assert_eq!(lines[2], "3,");
+    }
+
+    #[test]
+    fn serialize_csv_renders_scalar_types() {
+        let cols = vec!["b".to_string(), "n".to_string(), "nul".to_string()];
+        let out = serialize_csv(&[json!({"b": true, "n": 4.5, "nul": null})], &cols).unwrap();
+        assert_eq!(String::from_utf8(out).unwrap(), "true,4.5,\n");
+    }
+
+    #[test]
+    fn serialize_csv_rejects_non_object() {
+        assert!(serialize_csv(&[json!(5)], &["a".to_string()]).is_err());
+    }
+}

--- a/crates/sink/redshift/src/lib.rs
+++ b/crates/sink/redshift/src/lib.rs
@@ -1,0 +1,24 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+//! # faucet-sink-redshift
+//!
+//! Amazon Redshift sink connector for the faucet-stream ecosystem.
+//!
+//! Two load paths, chosen by `write_strategy`:
+//! - **`copy`** (default) — stage each page to S3 (JSONL or CSV) and bulk-load
+//!   it with `COPY … FROM 's3://…' IAM_ROLE '…'`, then delete the staged object.
+//!   Redshift's recommended, fastest bulk-load path.
+//! - **`insert`** — multi-row `INSERT INTO … VALUES (…), (…)`. Portable and
+//!   needs no S3, but slower for bulk data.
+//!
+//! Append-only: Redshift has no `ON CONFLICT` and `COPY` cannot upsert.
+
+pub mod config;
+pub mod copy;
+pub mod sink;
+
+pub use faucet_core::{FaucetError, Sink};
+
+pub use config::{RedshiftCopyFormat, RedshiftSinkConfig, RedshiftWriteStrategy};
+pub use faucet_common_redshift::{RedshiftConnection, RedshiftCredentials};
+pub use sink::RedshiftSink;

--- a/crates/sink/redshift/src/sink.rs
+++ b/crates/sink/redshift/src/sink.rs
@@ -1,0 +1,458 @@
+//! Amazon Redshift sink implementation.
+//!
+//! Two load paths, selected by `write_strategy`:
+//! - `copy` (default) — stage each page to S3 (JSONL or CSV) and bulk-load it
+//!   with `COPY … FROM 's3://…' IAM_ROLE '…'`, then best-effort delete the
+//!   staged object. This is Redshift's recommended, fastest load path.
+//! - `insert` — multi-row `INSERT INTO … VALUES (…), (…)`. Portable, no S3, but
+//!   slower for bulk data.
+//!
+//! Append-only (`supported_write_modes` = `[Append]`): Redshift has no
+//! `ON CONFLICT`, and `COPY` cannot upsert.
+
+use async_trait::async_trait;
+use aws_sdk_s3::Client as S3Client;
+use faucet_core::FaucetError;
+use serde_json::Value;
+use sqlx::{PgPool, Row};
+
+use crate::config::{RedshiftCopyFormat, RedshiftSinkConfig, RedshiftWriteStrategy};
+use crate::copy::{
+    columns_present, copy_statement, insert_statement, qualified_table_ref, s3_uri, serialize_csv,
+    serialize_jsonl,
+};
+
+/// Redshift caps bind parameters per statement; keep multi-row `INSERT`s under
+/// this by sub-chunking.
+const MAX_REDSHIFT_PARAMS: usize = 32_767;
+
+/// A sink that loads JSON records into an Amazon Redshift table.
+pub struct RedshiftSink {
+    config: RedshiftSinkConfig,
+    pool: PgPool,
+    /// S3 client, built only for the `copy` strategy.
+    s3: Option<S3Client>,
+}
+
+impl RedshiftSink {
+    /// Create a new sink. Validates config, builds a lazily-connected pool (no
+    /// DB I/O), and — for the `copy` strategy — an S3 client.
+    pub async fn new(config: RedshiftSinkConfig) -> Result<Self, FaucetError> {
+        config.validate()?;
+        let pool =
+            faucet_common_redshift::build_pool_lazy(&config.connection, config.max_connections)?;
+        let s3 = if config.write_strategy == RedshiftWriteStrategy::Copy {
+            Some(Self::build_s3_client(&config).await)
+        } else {
+            None
+        };
+        Ok(Self { config, pool, s3 })
+    }
+
+    /// Build an S3 client honouring the optional region / endpoint overrides.
+    async fn build_s3_client(config: &RedshiftSinkConfig) -> S3Client {
+        let mut loader = aws_config::defaults(aws_config::BehaviorVersion::latest());
+        if let Some(region) = &config.region {
+            loader = loader.region(aws_config::Region::new(region.clone()));
+        }
+        if let Some(endpoint) = &config.endpoint_url {
+            loader = loader.endpoint_url(endpoint);
+        }
+        let sdk_config = loader.load().await;
+        S3Client::new(&sdk_config)
+    }
+
+    fn table_ref(&self) -> String {
+        qualified_table_ref(self.config.schema.as_deref(), &self.config.table_name)
+    }
+
+    /// Generate a unique staging object key for one page.
+    fn staging_key(&self, ext: &str) -> String {
+        let id = uuid::Uuid::new_v4();
+        format!("{}{}.{}", self.config.staging_prefix, id, ext)
+    }
+
+    /// Discover the destination table's column names in ordinal order via
+    /// `information_schema.columns`. Used by the `insert` path and the CSV
+    /// `copy` path (both need the column set/order).
+    async fn discover_columns(&self) -> Result<Vec<String>, FaucetError> {
+        let rows = sqlx::query(
+            "SELECT column_name FROM information_schema.columns \
+             WHERE table_name = $1 AND ($2::text IS NULL OR table_schema = $2) \
+             ORDER BY ordinal_position",
+        )
+        .bind(&self.config.table_name)
+        .bind(self.config.schema.as_deref())
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| FaucetError::Sink(format!("redshift: column discovery failed: {e}")))?;
+
+        let cols: Vec<String> = rows
+            .iter()
+            .map(|r| r.get::<String, _>("column_name"))
+            .collect();
+        if cols.is_empty() {
+            return Err(FaucetError::Sink(format!(
+                "redshift: table {} has no columns or does not exist",
+                self.config.table_name
+            )));
+        }
+        Ok(cols)
+    }
+
+    /// Load one chunk via the `COPY`-from-S3 fast path.
+    async fn copy_chunk(&self, records: &[Value]) -> Result<usize, FaucetError> {
+        if records.is_empty() {
+            return Ok(0);
+        }
+        let s3 = self.s3.as_ref().ok_or_else(|| {
+            FaucetError::Sink("redshift: S3 client not initialized for copy strategy".into())
+        })?;
+        let bucket = self.config.staging_bucket.as_deref().ok_or_else(|| {
+            FaucetError::Sink("redshift: staging_bucket is required for copy strategy".into())
+        })?;
+        let iam_role = self.config.iam_role.as_deref().ok_or_else(|| {
+            FaucetError::Sink("redshift: iam_role is required for copy strategy".into())
+        })?;
+
+        // Serialize the page and, for CSV, learn the destination column order.
+        let (body, columns): (Vec<u8>, Option<Vec<String>>) = match self.config.copy_format {
+            RedshiftCopyFormat::Jsonl => (serialize_jsonl(records)?, None),
+            RedshiftCopyFormat::Csv => {
+                let cols = self.discover_columns().await?;
+                (serialize_csv(records, &cols)?, Some(cols))
+            }
+        };
+        let ext = match self.config.copy_format {
+            RedshiftCopyFormat::Jsonl => "jsonl",
+            RedshiftCopyFormat::Csv => "csv",
+        };
+        let key = self.staging_key(ext);
+
+        // 1. Upload the staged object.
+        s3.put_object()
+            .bucket(bucket)
+            .key(&key)
+            .body(body.into())
+            .send()
+            .await
+            .map_err(|e| {
+                FaucetError::Sink(format!("redshift: S3 upload failed for key '{key}': {e}"))
+            })?;
+
+        // 2. COPY it into the table.
+        let sql = copy_statement(
+            &self.table_ref(),
+            columns.as_deref(),
+            &s3_uri(bucket, &key),
+            iam_role,
+            self.config.region.as_deref(),
+            self.config.copy_format,
+        );
+        let copy_result = sqlx::query(&sql).execute(&self.pool).await;
+
+        // 3. Best-effort cleanup of the staged object (regardless of COPY
+        //    outcome — a failed COPY still leaves the object behind).
+        if let Err(e) = s3.delete_object().bucket(bucket).key(&key).send().await {
+            tracing::warn!(key = %key, error = %e, "redshift: failed to delete staged S3 object (best-effort)");
+        }
+
+        copy_result.map_err(|e| FaucetError::Sink(format!("redshift: COPY failed: {e}")))?;
+        Ok(records.len())
+    }
+
+    /// Load one chunk via multi-row `INSERT`, sub-chunked to respect the bind
+    /// parameter cap.
+    async fn insert_chunk(&self, records: &[Value]) -> Result<usize, FaucetError> {
+        if records.is_empty() {
+            return Ok(0);
+        }
+        let table_columns = self.discover_columns().await?;
+        let present: Vec<String> = columns_present(records, &table_columns)
+            .into_iter()
+            .cloned()
+            .collect();
+        if present.is_empty() {
+            tracing::warn!(
+                table = %self.config.table_name,
+                "redshift: no record keys match table columns; skipping insert"
+            );
+            return Ok(0);
+        }
+
+        let num_cols = present.len();
+        let max_rows = (MAX_REDSHIFT_PARAMS / num_cols).max(1);
+        let mut total = 0usize;
+
+        for sub in records.chunks(max_rows) {
+            let sql = insert_statement(&self.table_ref(), &present, sub.len());
+            let mut q = sqlx::query(&sql);
+            for record in sub {
+                let obj = record.as_object().ok_or_else(|| {
+                    FaucetError::Sink("redshift: insert requires JSON object records".into())
+                })?;
+                for col in &present {
+                    q = bind_json(q, obj.get(col));
+                }
+            }
+            q.execute(&self.pool)
+                .await
+                .map_err(|e| FaucetError::Sink(format!("redshift: INSERT failed: {e}")))?;
+            total += sub.len();
+        }
+        Ok(total)
+    }
+}
+
+/// Bind one JSON value onto a `sqlx` query as a native scalar type (so it lands
+/// in a typed Redshift column instead of being coerced from `jsonb`). Missing /
+/// null binds SQL NULL.
+fn bind_json<'q>(
+    query: sqlx::query::Query<'q, sqlx::Postgres, sqlx::postgres::PgArguments>,
+    v: Option<&Value>,
+) -> sqlx::query::Query<'q, sqlx::Postgres, sqlx::postgres::PgArguments> {
+    match v {
+        None | Some(Value::Null) => query.bind(None::<String>),
+        Some(Value::String(s)) => query.bind(s.clone()),
+        Some(Value::Bool(b)) => query.bind(*b),
+        Some(Value::Number(n)) => {
+            if n.is_i64() {
+                query.bind(n.as_i64().unwrap())
+            } else if n.is_u64() {
+                query.bind(n.as_u64().unwrap() as i64)
+            } else {
+                query.bind(n.as_f64().unwrap_or(0.0))
+            }
+        }
+        Some(other) => query.bind(other.to_string()),
+    }
+}
+
+#[async_trait]
+impl faucet_core::Sink for RedshiftSink {
+    fn connector_name(&self) -> &'static str {
+        "redshift"
+    }
+
+    fn config_schema(&self) -> Value {
+        serde_json::to_value(faucet_core::schema_for!(RedshiftSinkConfig))
+            .expect("schema serialization")
+    }
+
+    fn supported_write_modes(&self) -> &'static [faucet_core::WriteMode] {
+        // Append-only: Redshift has no ON CONFLICT and COPY cannot upsert.
+        &[faucet_core::WriteMode::Append]
+    }
+
+    fn dataset_uri(&self) -> String {
+        let table = match &self.config.schema {
+            Some(s) => format!("{}.{}", s, self.config.table_name),
+            None => self.config.table_name.clone(),
+        };
+        format!(
+            "redshift://{}:{}/{}?table={}",
+            self.config.connection.host,
+            self.config.connection.port,
+            self.config.connection.database,
+            table
+        )
+    }
+
+    async fn write_batch(&self, records: &[Value]) -> Result<usize, FaucetError> {
+        if records.is_empty() {
+            return Ok(0);
+        }
+        let chunks: Vec<&[Value]> = if self.config.batch_size == 0 {
+            vec![records]
+        } else {
+            records.chunks(self.config.batch_size).collect()
+        };
+
+        let mut total = 0;
+        for chunk in chunks {
+            total += match self.config.write_strategy {
+                RedshiftWriteStrategy::Copy => self.copy_chunk(chunk).await?,
+                RedshiftWriteStrategy::Insert => self.insert_chunk(chunk).await?,
+            };
+        }
+
+        tracing::info!(
+            table = %self.config.table_name,
+            rows = total,
+            strategy = self.config.write_strategy.as_str(),
+            "Redshift write complete"
+        );
+        Ok(total)
+    }
+
+    /// Preflight connectivity probe (`faucet doctor`): acquire a connection and
+    /// run `SELECT 1`. Non-mutating and idempotent.
+    async fn check(
+        &self,
+        ctx: &faucet_core::check::CheckContext,
+    ) -> Result<faucet_core::check::CheckReport, FaucetError> {
+        use faucet_core::check::{CheckReport, Probe};
+
+        let started = std::time::Instant::now();
+        let probe =
+            match tokio::time::timeout(ctx.timeout, sqlx::query("SELECT 1").execute(&self.pool))
+                .await
+            {
+                Ok(Ok(_)) => Probe::pass("auth", started.elapsed()),
+                Ok(Err(e)) => Probe::fail_hint(
+                    "auth",
+                    started.elapsed(),
+                    e.to_string(),
+                    "check host/port/database/user/credentials and that the cluster is reachable",
+                ),
+                Err(_) => Probe::fail_hint(
+                    "auth",
+                    started.elapsed(),
+                    "timed out",
+                    "check host/port/database/user/credentials and that the cluster is reachable",
+                ),
+            };
+        Ok(CheckReport::single(probe))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{RedshiftCopyFormat, RedshiftWriteStrategy};
+    use faucet_common_redshift::RedshiftConnection;
+    use faucet_core::Sink as _;
+    use serde_json::json;
+
+    fn insert_config() -> RedshiftSinkConfig {
+        RedshiftSinkConfig {
+            connection: RedshiftConnection::new("host", "db", "user", "pw"),
+            table_name: "events".into(),
+            schema: Some("public".into()),
+            write_strategy: RedshiftWriteStrategy::Insert,
+            copy_format: RedshiftCopyFormat::Jsonl,
+            staging_bucket: None,
+            staging_prefix: String::new(),
+            iam_role: None,
+            region: None,
+            endpoint_url: None,
+            batch_size: 1000,
+            max_connections: 5,
+        }
+    }
+
+    fn copy_config() -> RedshiftSinkConfig {
+        RedshiftSinkConfig {
+            write_strategy: RedshiftWriteStrategy::Copy,
+            staging_bucket: Some("stage".into()),
+            staging_prefix: "rs/".into(),
+            iam_role: Some("arn:aws:iam::1:role/r".into()),
+            // Explicit region so building the S3 client resolves without the
+            // default region provider probing IMDS (hermetic, fast tests).
+            region: Some("us-east-1".into()),
+            ..insert_config()
+        }
+    }
+
+    async fn sink(c: RedshiftSinkConfig) -> RedshiftSink {
+        RedshiftSink::new(c).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn new_insert_has_no_s3_client() {
+        let s = sink(insert_config()).await;
+        assert!(s.s3.is_none());
+    }
+
+    #[tokio::test]
+    async fn new_copy_builds_s3_client() {
+        let s = sink(copy_config()).await;
+        assert!(s.s3.is_some());
+    }
+
+    #[tokio::test]
+    async fn new_rejects_copy_without_bucket() {
+        let mut c = copy_config();
+        c.staging_bucket = None;
+        assert!(matches!(
+            RedshiftSink::new(c).await,
+            Err(FaucetError::Config(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn new_surfaces_unsupported_credentials() {
+        let mut c = insert_config();
+        c.connection.credentials = faucet_common_redshift::RedshiftCredentials::RedshiftDataApi {
+            region: None,
+            cluster_identifier: None,
+            workgroup_name: None,
+            secret_arn: None,
+            db_user: None,
+        };
+        assert!(matches!(
+            RedshiftSink::new(c).await,
+            Err(FaucetError::Config(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn connector_name_is_redshift() {
+        assert_eq!(sink(insert_config()).await.connector_name(), "redshift");
+    }
+
+    #[tokio::test]
+    async fn supported_write_modes_is_append_only() {
+        let s = sink(insert_config()).await;
+        assert_eq!(
+            s.supported_write_modes(),
+            [faucet_core::WriteMode::Append].as_slice()
+        );
+    }
+
+    #[tokio::test]
+    async fn dataset_uri_schema_qualified() {
+        let s = sink(insert_config()).await;
+        assert_eq!(
+            s.dataset_uri(),
+            "redshift://host:5439/db?table=public.events"
+        );
+    }
+
+    #[tokio::test]
+    async fn config_schema_reports_required_fields() {
+        let s = sink(insert_config()).await;
+        let schema = s.config_schema();
+        assert!(schema["properties"]["table_name"].is_object());
+        let required = schema["required"].as_array().expect("required array");
+        assert!(required.iter().any(|v| v == "table_name"));
+    }
+
+    #[tokio::test]
+    async fn write_batch_empty_is_zero() {
+        let s = sink(insert_config()).await;
+        assert_eq!(s.write_batch(&[]).await.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn table_ref_and_staging_key() {
+        let s = sink(copy_config()).await;
+        assert_eq!(s.table_ref(), "\"public\".\"events\"");
+        let key = s.staging_key("jsonl");
+        assert!(key.starts_with("rs/"));
+        assert!(key.ends_with(".jsonl"));
+    }
+
+    #[test]
+    fn bind_json_covers_all_scalar_kinds() {
+        // Smoke: binding must not panic for every JSON scalar kind. The actual
+        // wire encoding is exercised by the live integration test.
+        let q = sqlx::query("SELECT $1, $2, $3, $4, $5, $6");
+        let q = bind_json(q, Some(&json!("s")));
+        let q = bind_json(q, Some(&json!(7)));
+        let q = bind_json(q, Some(&json!(7.5)));
+        let q = bind_json(q, Some(&json!(true)));
+        let q = bind_json(q, Some(&Value::Null));
+        let _q = bind_json(q, None);
+    }
+}

--- a/crates/sink/redshift/tests/conformance.rs
+++ b/crates/sink/redshift/tests/conformance.rs
@@ -1,0 +1,17 @@
+//! `faucet-conformance` battery for the Amazon Redshift sink.
+//!
+//! Check 1 — the config JSON Schema is a valid, well-formed value. Redshift has
+//! no local container image and the sink both loads over the PG wire and stages
+//! to S3, so end-to-end load coverage lives in the `#[ignore]`d
+//! `tests/integration.rs` (a live cluster + S3 bucket in CI).
+
+use faucet_conformance::assert_config_schema_valid_value;
+
+#[test]
+fn conformance_config_schema_valid() {
+    let schema = serde_json::to_value(schemars::schema_for!(
+        faucet_sink_redshift::RedshiftSinkConfig
+    ))
+    .unwrap();
+    assert_config_schema_valid_value(&schema, "faucet-sink-redshift");
+}

--- a/crates/sink/redshift/tests/integration.rs
+++ b/crates/sink/redshift/tests/integration.rs
@@ -1,0 +1,314 @@
+//! Integration tests for the Amazon Redshift sink against a real database via
+//! testcontainers.
+//!
+//! Amazon Redshift has **no local container image**, but it speaks the
+//! **PostgreSQL wire protocol** and the sink's `insert` strategy loads through
+//! `sqlx`'s Postgres driver (via `faucet-common-redshift`). A stock Postgres
+//! container therefore exercises the real write path end-to-end: column
+//! discovery, the multi-row `INSERT` builder, bind-param sub-chunking, and
+//! `batch_size` re-chunking (all in `src/sink.rs` / `src/copy.rs`).
+//!
+//! The `copy` strategy stages to S3 and issues Redshift-only `COPY … FROM
+//! 's3://…'` SQL, which a plain Postgres server cannot execute — so it stays
+//! out of scope here (its SQL builders are unit-tested in `src/copy.rs`, and the
+//! full round-trip needs a real cluster + bucket + IAM role). These tests
+//! target `write_strategy: insert` only.
+//!
+//! The connection points at the container with TLS disabled (`tls: false` →
+//! `sslmode=prefer`). These tests require Docker and are **not** `#[ignore]`d —
+//! they auto-start their own container. A process-wide mutex serializes the
+//! containers within this test binary.
+
+use std::sync::OnceLock;
+
+use faucet_common_redshift::RedshiftConnection;
+use faucet_core::Sink;
+use faucet_sink_redshift::{
+    RedshiftCopyFormat, RedshiftSink, RedshiftSinkConfig, RedshiftWriteStrategy,
+};
+use serde_json::{Value, json};
+use sqlx::Row;
+use testcontainers::{ContainerAsync, ImageExt, runners::AsyncRunner};
+use testcontainers_modules::postgres::Postgres;
+
+/// Serialize container startup within this binary.
+fn serial() -> &'static tokio::sync::Mutex<()> {
+    static SERIAL: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+    SERIAL.get_or_init(|| tokio::sync::Mutex::new(()))
+}
+
+async fn start_postgres() -> (ContainerAsync<Postgres>, u16) {
+    let image = Postgres::default().with_tag("16-alpine");
+    let container: ContainerAsync<Postgres> =
+        image.start().await.expect("postgres container start");
+    let port = container
+        .get_host_port_ipv4(5432)
+        .await
+        .expect("postgres port");
+    (container, port)
+}
+
+fn redshift_conn(port: u16) -> RedshiftConnection {
+    let mut conn = RedshiftConnection::new("127.0.0.1", "postgres", "postgres", "postgres");
+    conn.port = port;
+    // No TLS on the test image; `tls: false` → `sslmode=prefer` (plaintext).
+    conn.tls = false;
+    conn
+}
+
+async fn seed_pool(port: u16) -> sqlx::PgPool {
+    let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
+    sqlx::PgPool::connect(&url)
+        .await
+        .expect("seed pool connect")
+}
+
+fn insert_config(port: u16, table: &str, batch_size: usize) -> RedshiftSinkConfig {
+    RedshiftSinkConfig {
+        connection: redshift_conn(port),
+        table_name: table.into(),
+        schema: None,
+        write_strategy: RedshiftWriteStrategy::Insert,
+        copy_format: RedshiftCopyFormat::Jsonl,
+        staging_bucket: None,
+        staging_prefix: String::new(),
+        iam_role: None,
+        region: None,
+        endpoint_url: None,
+        batch_size,
+        max_connections: 2,
+    }
+}
+
+/// Install a per-statement `AFTER INSERT` counter on `table`. Statement-level
+/// triggers fire exactly once per `INSERT` statement regardless of row count, so
+/// the counter is a precise proxy for the number of multi-row INSERT statements
+/// the sink issued.
+async fn install_insert_counter(pool: &sqlx::PgPool, table: &str) {
+    sqlx::query("CREATE TABLE insert_calls (calls BIGINT NOT NULL)")
+        .execute(pool)
+        .await
+        .expect("create counter table");
+    sqlx::query("INSERT INTO insert_calls (calls) VALUES (0)")
+        .execute(pool)
+        .await
+        .expect("seed counter");
+    sqlx::query(
+        "CREATE OR REPLACE FUNCTION bump_insert_calls() RETURNS TRIGGER AS $$ \
+         BEGIN UPDATE insert_calls SET calls = calls + 1; RETURN NULL; END; \
+         $$ LANGUAGE plpgsql",
+    )
+    .execute(pool)
+    .await
+    .expect("create trigger fn");
+    sqlx::query(&format!(
+        "CREATE TRIGGER count_inserts AFTER INSERT ON \"{table}\" \
+         FOR EACH STATEMENT EXECUTE FUNCTION bump_insert_calls()"
+    ))
+    .execute(pool)
+    .await
+    .expect("attach trigger");
+}
+
+async fn insert_call_count(pool: &sqlx::PgPool) -> i64 {
+    sqlx::query_scalar("SELECT calls FROM insert_calls")
+        .fetch_one(pool)
+        .await
+        .expect("query counter")
+}
+
+async fn row_count(pool: &sqlx::PgPool, table: &str) -> i64 {
+    sqlx::query_scalar(&format!("SELECT COUNT(*)::BIGINT FROM {table}"))
+        .fetch_one(pool)
+        .await
+        .expect("count")
+}
+
+/// The multi-row `INSERT` path lands every value in its native, typed column —
+/// integers, text, floats, booleans, and NULL (both explicit and via a missing
+/// key) — and the rows read back with the right types.
+#[tokio::test(flavor = "multi_thread")]
+async fn insert_writes_typed_rows() {
+    let _guard = serial().lock().await;
+    let (_container, port) = start_postgres().await;
+    let pool = seed_pool(port).await;
+    sqlx::query(
+        "CREATE TABLE events (\
+            id BIGINT, name TEXT, amount DOUBLE PRECISION, active BOOLEAN, note TEXT)",
+    )
+    .execute(&pool)
+    .await
+    .expect("create table");
+
+    let sink = RedshiftSink::new(insert_config(port, "events", 1000))
+        .await
+        .expect("sink builds");
+
+    let records = vec![
+        json!({"id": 1, "name": "alice", "amount": 1.5, "active": true, "note": null}),
+        // Row 2 omits `note` entirely → binds SQL NULL for the unioned column.
+        json!({"id": 2, "name": "bob", "amount": 2.5, "active": false}),
+    ];
+    let written = sink.write_batch(&records).await.expect("insert runs");
+    assert_eq!(written, 2);
+    assert_eq!(row_count(&pool, "events").await, 2);
+
+    let row = sqlx::query("SELECT id, name, amount, active, note FROM events WHERE id = 1")
+        .fetch_one(&pool)
+        .await
+        .expect("read back row 1");
+    assert_eq!(row.get::<i64, _>("id"), 1);
+    assert_eq!(row.get::<String, _>("name"), "alice");
+    assert!((row.get::<f64, _>("amount") - 1.5).abs() < 1e-9);
+    assert!(row.get::<bool, _>("active"));
+    assert_eq!(row.get::<Option<String>, _>("note"), None);
+
+    let note2: Option<String> = sqlx::query_scalar("SELECT note FROM events WHERE id = 2")
+        .fetch_one(&pool)
+        .await
+        .expect("row 2 note");
+    assert_eq!(note2, None, "missing key binds SQL NULL");
+    pool.close().await;
+}
+
+/// `write_batch` re-chunks the input into `batch_size` units — 5 rows at
+/// `batch_size = 2` issues exactly 3 INSERT statements — and every row lands.
+#[tokio::test(flavor = "multi_thread")]
+async fn write_batch_re_chunks_by_batch_size() {
+    let _guard = serial().lock().await;
+    let (_container, port) = start_postgres().await;
+    let pool = seed_pool(port).await;
+    sqlx::query("CREATE TABLE events (id BIGINT, name TEXT)")
+        .execute(&pool)
+        .await
+        .expect("create table");
+    install_insert_counter(&pool, "events").await;
+
+    let sink = RedshiftSink::new(insert_config(port, "events", 2))
+        .await
+        .expect("sink builds");
+    let records: Vec<Value> = (1..=5).map(|i| json!({"id": i, "name": "r"})).collect();
+
+    let written = sink.write_batch(&records).await.expect("write");
+    assert_eq!(written, 5);
+    assert_eq!(row_count(&pool, "events").await, 5);
+    assert_eq!(
+        insert_call_count(&pool).await,
+        3,
+        "5 rows at batch_size 2 → 3 INSERT statements (2 + 2 + 1)"
+    );
+
+    // flush() is a no-op for this sink but must succeed.
+    sink.flush().await.expect("flush");
+    pool.close().await;
+}
+
+/// `batch_size = 0` is the "no re-chunking" sentinel: the whole slice is written
+/// in one INSERT statement.
+#[tokio::test(flavor = "multi_thread")]
+async fn batch_size_zero_writes_single_statement() {
+    let _guard = serial().lock().await;
+    let (_container, port) = start_postgres().await;
+    let pool = seed_pool(port).await;
+    sqlx::query("CREATE TABLE events (id BIGINT, name TEXT)")
+        .execute(&pool)
+        .await
+        .expect("create table");
+    install_insert_counter(&pool, "events").await;
+
+    let sink = RedshiftSink::new(insert_config(port, "events", 0))
+        .await
+        .expect("sink builds");
+    let records: Vec<Value> = (1..=4).map(|i| json!({"id": i, "name": "r"})).collect();
+
+    assert_eq!(sink.write_batch(&records).await.expect("write"), 4);
+    assert_eq!(row_count(&pool, "events").await, 4);
+    assert_eq!(
+        insert_call_count(&pool).await,
+        1,
+        "batch_size 0 drains the slice in one INSERT statement"
+    );
+    pool.close().await;
+}
+
+/// A record whose keys match no destination column is a no-op (the sink logs a
+/// warning and skips the insert rather than emitting invalid SQL).
+#[tokio::test(flavor = "multi_thread")]
+async fn insert_with_no_matching_columns_is_a_noop() {
+    let _guard = serial().lock().await;
+    let (_container, port) = start_postgres().await;
+    let pool = seed_pool(port).await;
+    sqlx::query("CREATE TABLE events (id BIGINT)")
+        .execute(&pool)
+        .await
+        .expect("create table");
+
+    let sink = RedshiftSink::new(insert_config(port, "events", 1000))
+        .await
+        .expect("sink builds");
+    // No key overlaps the `id` column.
+    let written = sink
+        .write_batch(&[json!({"unknown": 1})])
+        .await
+        .expect("write");
+    assert_eq!(written, 0);
+    assert_eq!(row_count(&pool, "events").await, 0);
+    pool.close().await;
+}
+
+/// Column discovery against a missing table surfaces a typed sink error.
+#[tokio::test(flavor = "multi_thread")]
+async fn insert_into_missing_table_errors() {
+    let _guard = serial().lock().await;
+    let (_container, port) = start_postgres().await;
+
+    let sink = RedshiftSink::new(insert_config(port, "does_not_exist", 1000))
+        .await
+        .expect("sink builds");
+    let err = sink
+        .write_batch(&[json!({"id": 1})])
+        .await
+        .expect_err("missing table must error");
+    assert!(
+        matches!(err, faucet_core::FaucetError::Sink(_)),
+        "got {err:?}"
+    );
+}
+
+/// Empty input is a no-op, and `supported_write_modes` is append-only.
+#[tokio::test(flavor = "multi_thread")]
+async fn empty_write_and_write_modes() {
+    let _guard = serial().lock().await;
+    let (_container, port) = start_postgres().await;
+
+    let sink = RedshiftSink::new(insert_config(port, "events", 1000))
+        .await
+        .expect("sink builds");
+    assert_eq!(sink.write_batch(&[]).await.expect("empty write"), 0);
+    assert_eq!(
+        sink.supported_write_modes(),
+        [faucet_core::WriteMode::Append].as_slice()
+    );
+}
+
+/// The `check` preflight probe passes against a reachable database.
+#[tokio::test(flavor = "multi_thread")]
+async fn check_probe_passes() {
+    let _guard = serial().lock().await;
+    let (_container, port) = start_postgres().await;
+
+    let sink = RedshiftSink::new(insert_config(port, "events", 1000))
+        .await
+        .expect("sink builds");
+    let ctx = faucet_core::check::CheckContext {
+        timeout: std::time::Duration::from_secs(10),
+    };
+    let report = sink.check(&ctx).await.expect("check runs");
+    assert!(
+        report
+            .probes
+            .iter()
+            .all(|p| matches!(p.status, faucet_core::check::ProbeStatus::Pass)),
+        "all probes should pass against a reachable database: {report:?}"
+    );
+}

--- a/crates/source/azure-blob/Cargo.toml
+++ b/crates/source/azure-blob/Cargo.toml
@@ -1,0 +1,49 @@
+[package]
+name = "faucet-source-azure-blob"
+version = "1.0.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Azure Blob Storage / ADLS Gen2 source connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords = ["azure", "blob", "adls", "storage", "etl"]
+categories.workspace = true
+
+[dependencies]
+faucet-core.workspace = true
+faucet-common-azure.workspace = true
+schemars.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+async-trait.workspace = true
+async-stream.workspace = true
+tracing.workspace = true
+tokio = { workspace = true, features = ["io-util"] }
+tokio-util = { workspace = true, features = ["io"] }
+futures.workspace = true
+object_store = { workspace = true, features = ["azure"] }
+
+[features]
+compression = ["faucet-core/compression"]
+
+[dev-dependencies]
+faucet-conformance.workspace = true
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "io-util", "sync"] }
+serde_json.workspace = true
+schemars.workspace = true
+futures.workspace = true
+testcontainers = "0.27"
+testcontainers-modules = { version = "0.15", features = ["azurite"] }
+# Seeds/verifies blobs against Azurite through the same `object_store` Azure
+# client the connector uses (available to the integration-test target because
+# `object_store` is a normal dependency).
+object_store = { workspace = true, features = ["azure"] }
+# `object_store` cannot create a blob container; the Azure SDK does (this is the
+# proven Azurite path used by `testcontainers-modules`' own tests).
+azure_storage = "0.21"
+azure_storage_blobs = "0.21"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/source/azure-blob/README.md
+++ b/crates/source/azure-blob/README.md
@@ -1,0 +1,59 @@
+# faucet-source-azure-blob
+
+Azure Blob Storage / ADLS Gen2 **source** connector for the
+[`faucet-stream`](https://crates.io/crates/faucet-stream) ecosystem.
+
+Lists and reads objects from an Azure blob container (or ADLS Gen2 filesystem)
+and emits them as JSON records. Built on
+[`object_store`](https://crates.io/crates/object_store)'s Azure backend, so both
+classic Blob and ADLS Gen2 hierarchical namespaces are supported through one
+code path.
+
+## Config
+
+Connection fields come from `faucet-common-azure` and are set at the top level:
+
+| Field | Type | Notes |
+|---|---|---|
+| `container` | string | **Required.** Blob container / ADLS filesystem. |
+| `account` | string | Storage-account name (optional with a connection string / emulator). |
+| `auth` | `{ type, config }` | `account_key` / `sas_token` / `connection_string` / `managed_identity` / `service_principal` / `default`. |
+| `endpoint` | string | Custom blob endpoint (emulator / sovereign cloud). |
+| `allow_http` | bool | Permit plaintext HTTP (Azurite). |
+| `use_emulator` | bool | Target the Azurite emulator. |
+
+Source-specific fields:
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `prefix` | string | — | Object-name prefix filter. Ignored when `object_keys` is set. |
+| `object_keys` | list | — | Explicit object names; skips listing. |
+| `file_format` | enum | `json_lines` | `json_lines` / `json_array` / `raw_text`. |
+| `max_objects` | int | — | Hard cap on objects read. |
+| `concurrency` | int | `10` | Max concurrent object reads. |
+| `batch_size` | int | `1000` | Records per `StreamPage`; `0` = one page per object. |
+| `compression` | enum | `auto` | `auto` / `gzip` / `zstd` (requires the `compression` feature). |
+
+## File formats
+
+- **`json_lines`** — one JSON record per line; streamed line-by-line (bounded memory).
+- **`json_array`** — the whole object is a JSON array; buffered then chunked.
+- **`raw_text`** — each object becomes one record `{ "key", "content" }`.
+
+## Example
+
+```yaml
+pipeline:
+  source:
+    type: azure-blob
+    config:
+      container: raw
+      account: mystorageacct
+      auth: { type: account_key, config: { account_key: "${env:AZURE_KEY}" } }
+      prefix: events/2026/
+      file_format: json_lines
+```
+
+## License
+
+MIT

--- a/crates/source/azure-blob/src/config.rs
+++ b/crates/source/azure-blob/src/config.rs
@@ -1,0 +1,258 @@
+//! Azure Blob source configuration.
+
+use faucet_common_azure::{AzureConnection, AzureCredentials};
+use faucet_core::DEFAULT_BATCH_SIZE;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Format of objects stored in the container.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AzureFileFormat {
+    /// Each line in the object is a separate JSON record.
+    #[default]
+    JsonLines,
+    /// The entire object is a JSON array of records.
+    JsonArray,
+    /// Each object becomes a single record with `"key"` and `"content"` fields.
+    RawText,
+}
+
+/// Configuration for the Azure Blob source connector.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct AzureBlobSourceConfig {
+    /// Azure connection (container, account, credentials, endpoint, …).
+    #[serde(flatten)]
+    pub connection: AzureConnection,
+    /// Object name prefix filter. Ignored when `object_keys` is set.
+    pub prefix: Option<String>,
+    /// Explicit object names. When set, listing is skipped and `prefix`
+    /// is ignored.
+    pub object_keys: Option<Vec<String>>,
+    /// File format.
+    #[serde(default)]
+    pub file_format: AzureFileFormat,
+    /// Hard cap on the number of objects read (after listing).
+    pub max_objects: Option<usize>,
+    /// Maximum concurrent object reads (default: 10).
+    #[serde(default = "default_concurrency")]
+    pub concurrency: usize,
+    /// Records per emitted `StreamPage`. `batch_size = 0` is the "no batching"
+    /// sentinel and emits one page per object.
+    #[serde(default = "default_batch_size")]
+    pub batch_size: usize,
+    /// Compression codec applied to each downloaded object. Defaults to
+    /// [`CompressionConfig::Auto`](faucet_core::CompressionConfig::Auto) — the
+    /// codec is resolved per-object-key, so a single source can read a mix of
+    /// compressed and uncompressed objects. Requires the crate-local
+    /// `compression` feature.
+    #[cfg(feature = "compression")]
+    #[serde(default)]
+    pub compression: faucet_core::CompressionConfig,
+}
+
+fn default_batch_size() -> usize {
+    DEFAULT_BATCH_SIZE
+}
+fn default_concurrency() -> usize {
+    10
+}
+
+impl AzureBlobSourceConfig {
+    /// Create a new config for `container` with sensible defaults.
+    pub fn new(container: impl Into<String>) -> Self {
+        Self {
+            connection: AzureConnection::new(container),
+            prefix: None,
+            object_keys: None,
+            file_format: AzureFileFormat::default(),
+            max_objects: None,
+            concurrency: default_concurrency(),
+            batch_size: default_batch_size(),
+            #[cfg(feature = "compression")]
+            compression: faucet_core::CompressionConfig::default(),
+        }
+    }
+
+    /// Set the storage-account name.
+    pub fn account(mut self, account: impl Into<String>) -> Self {
+        self.connection = self.connection.account(account);
+        self
+    }
+
+    /// Set the credential source.
+    pub fn auth(mut self, creds: AzureCredentials) -> Self {
+        self.connection = self.connection.auth(creds);
+        self
+    }
+
+    /// Set a custom blob endpoint (emulator / sovereign cloud).
+    pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
+        self.connection = self.connection.endpoint(endpoint);
+        self
+    }
+
+    /// Permit plaintext HTTP (required for the Azurite emulator).
+    pub fn allow_http(mut self, allow: bool) -> Self {
+        self.connection = self.connection.allow_http(allow);
+        self
+    }
+
+    /// Target the Azurite emulator.
+    pub fn use_emulator(mut self, use_emulator: bool) -> Self {
+        self.connection = self.connection.use_emulator(use_emulator);
+        self
+    }
+
+    /// Filter objects by name prefix.
+    pub fn prefix(mut self, prefix: impl Into<String>) -> Self {
+        self.prefix = Some(prefix.into());
+        self
+    }
+
+    /// Read an explicit set of object names (skips listing).
+    pub fn object_keys(mut self, keys: Vec<String>) -> Self {
+        self.object_keys = Some(keys);
+        self
+    }
+
+    /// Set the object file format.
+    pub fn file_format(mut self, format: AzureFileFormat) -> Self {
+        self.file_format = format;
+        self
+    }
+
+    /// Cap the number of objects read.
+    pub fn max_objects(mut self, max: usize) -> Self {
+        self.max_objects = Some(max);
+        self
+    }
+
+    /// Set the maximum concurrent object reads.
+    pub fn concurrency(mut self, concurrency: usize) -> Self {
+        self.concurrency = concurrency;
+        self
+    }
+
+    /// Set the records-per-`StreamPage` hint.
+    pub fn with_batch_size(mut self, batch_size: usize) -> Self {
+        self.batch_size = batch_size;
+        self
+    }
+
+    /// Set the compression codec. Available only with the `compression` feature.
+    #[cfg(feature = "compression")]
+    pub fn compression(mut self, c: faucet_core::CompressionConfig) -> Self {
+        self.compression = c;
+        self
+    }
+
+    /// The container name.
+    pub fn container(&self) -> &str {
+        &self.connection.container
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config() {
+        let config = AzureBlobSourceConfig::new("my-container");
+        assert_eq!(config.container(), "my-container");
+        assert!(config.prefix.is_none());
+        assert!(config.object_keys.is_none());
+        assert_eq!(config.connection.auth, AzureCredentials::Default);
+        assert_eq!(config.file_format, AzureFileFormat::JsonLines);
+        assert!(config.max_objects.is_none());
+        assert_eq!(config.concurrency, 10);
+        assert_eq!(config.batch_size, faucet_core::DEFAULT_BATCH_SIZE);
+    }
+
+    #[test]
+    fn builder_methods() {
+        let config = AzureBlobSourceConfig::new("c")
+            .account("acct")
+            .prefix("data/")
+            .file_format(AzureFileFormat::JsonArray)
+            .max_objects(5)
+            .concurrency(20)
+            .with_batch_size(250)
+            .auth(AzureCredentials::AccountKey {
+                account_key: "k".into(),
+            });
+
+        assert_eq!(config.container(), "c");
+        assert_eq!(config.connection.account.as_deref(), Some("acct"));
+        assert_eq!(config.prefix.as_deref(), Some("data/"));
+        assert_eq!(config.file_format, AzureFileFormat::JsonArray);
+        assert_eq!(config.max_objects, Some(5));
+        assert_eq!(config.concurrency, 20);
+        assert_eq!(config.batch_size, 250);
+        assert!(matches!(
+            config.connection.auth,
+            AzureCredentials::AccountKey { .. }
+        ));
+    }
+
+    #[test]
+    fn file_format_default_is_json_lines() {
+        assert_eq!(AzureFileFormat::default(), AzureFileFormat::JsonLines);
+    }
+
+    #[test]
+    fn deserializes_flattened_connection_and_auth() {
+        let json = r#"{
+            "container": "c",
+            "account": "acct",
+            "auth": { "type": "account_key", "config": { "account_key": "k" } },
+            "prefix": "data/",
+            "file_format": "json_array"
+        }"#;
+        let config: AzureBlobSourceConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.container(), "c");
+        assert_eq!(config.connection.account.as_deref(), Some("acct"));
+        assert_eq!(config.file_format, AzureFileFormat::JsonArray);
+        assert!(matches!(
+            config.connection.auth,
+            AzureCredentials::AccountKey { .. }
+        ));
+        // batch_size / concurrency default when omitted.
+        assert_eq!(config.batch_size, faucet_core::DEFAULT_BATCH_SIZE);
+        assert_eq!(config.concurrency, 10);
+    }
+
+    #[test]
+    fn auth_defaults_to_default_when_absent_from_json() {
+        let json = r#"{ "container": "c" }"#;
+        let config: AzureBlobSourceConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.connection.auth, AzureCredentials::Default);
+    }
+
+    #[test]
+    fn batch_size_zero_is_accepted_as_no_batching_sentinel() {
+        let config = AzureBlobSourceConfig::new("c").with_batch_size(0);
+        assert_eq!(config.batch_size, 0);
+        assert!(faucet_core::validate_batch_size(config.batch_size).is_ok());
+    }
+
+    #[test]
+    fn batch_size_above_max_is_rejected() {
+        let config =
+            AzureBlobSourceConfig::new("c").with_batch_size(faucet_core::MAX_BATCH_SIZE + 1);
+        assert!(faucet_core::validate_batch_size(config.batch_size).is_err());
+    }
+
+    #[test]
+    fn schema_generates_without_panicking() {
+        let _ = faucet_core::schema_for!(AzureBlobSourceConfig);
+    }
+
+    #[cfg(feature = "compression")]
+    #[test]
+    fn compression_default_is_auto() {
+        let cfg = AzureBlobSourceConfig::new("c");
+        assert_eq!(cfg.compression, faucet_core::CompressionConfig::Auto);
+    }
+}

--- a/crates/source/azure-blob/src/lib.rs
+++ b/crates/source/azure-blob/src/lib.rs
@@ -1,0 +1,14 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+//! Azure Blob Storage / ADLS Gen2 source connector.
+//!
+//! Lists and reads objects from an Azure blob container (or ADLS Gen2
+//! filesystem) as `jsonl`, `json_array`, or `raw_text`. See the crate-level
+//! README for usage and the config-field reference.
+
+mod config;
+mod stream;
+
+pub use config::{AzureBlobSourceConfig, AzureFileFormat};
+pub use faucet_common_azure::{AzureConnection, AzureCredentials};
+pub use stream::AzureBlobSource;

--- a/crates/source/azure-blob/src/stream.rs
+++ b/crates/source/azure-blob/src/stream.rs
@@ -1,0 +1,552 @@
+//! Azure Blob source stream executor.
+
+use std::collections::HashMap;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use faucet_common_azure::build_store;
+use faucet_core::{FaucetError, Stream, StreamPage};
+use futures::stream::{self, StreamExt, TryStreamExt};
+use object_store::path::Path as ObjectPath;
+use object_store::{ObjectStore, ObjectStoreExt};
+use serde_json::Value;
+use tokio::io::AsyncBufReadExt;
+
+use crate::config::{AzureBlobSourceConfig, AzureFileFormat};
+
+/// An Azure Blob source that lists and reads objects from a container.
+pub struct AzureBlobSource {
+    config: AzureBlobSourceConfig,
+    store: Arc<dyn ObjectStore>,
+}
+
+impl AzureBlobSource {
+    /// Construct the source, building the object store eagerly so it is reused
+    /// across calls.
+    pub async fn new(config: AzureBlobSourceConfig) -> Result<Self, FaucetError> {
+        faucet_core::validate_batch_size(config.batch_size)?;
+        let store = build_store(&config.connection)?;
+        Ok(Self { config, store })
+    }
+
+    /// List object names under the configured (or override) prefix, capped at
+    /// `max_objects` when set. When `object_keys` is configured, listing is
+    /// skipped and those keys are used directly.
+    async fn list_object_names(
+        &self,
+        prefix_override: Option<&str>,
+    ) -> Result<Vec<String>, FaucetError> {
+        if let Some(keys) = &self.config.object_keys {
+            return Ok(cap_keys(keys.clone(), self.config.max_objects));
+        }
+
+        let effective_prefix = prefix_override.or(self.config.prefix.as_deref());
+        let prefix_path = effective_prefix
+            .filter(|p| !p.is_empty())
+            .map(ObjectPath::from);
+
+        let mut listing = self.store.list(prefix_path.as_ref());
+        let mut names: Vec<String> = Vec::new();
+        while let Some(item) = listing.next().await {
+            let meta = item.map_err(|e| {
+                FaucetError::Source(format!(
+                    "azure list error for container '{}': {e}",
+                    self.config.container()
+                ))
+            })?;
+            let name = meta.location.to_string();
+            if name.is_empty() {
+                continue;
+            }
+            names.push(name);
+            if let Some(max) = self.config.max_objects
+                && names.len() >= max
+            {
+                break;
+            }
+        }
+        Ok(names)
+    }
+
+    /// Read the full body of a single object into a UTF-8 `String`.
+    async fn read_object_text(&self, key: &str) -> Result<String, FaucetError> {
+        use tokio::io::AsyncReadExt as _;
+        let mut reader = self.open_object_reader(key).await?;
+        let mut text = String::new();
+        reader.read_to_string(&mut text).await.map_err(|e| {
+            FaucetError::Source(format!(
+                "azure read/decode error for key '{key}' (not valid UTF-8?): {e}"
+            ))
+        })?;
+        Ok(text)
+    }
+
+    /// Open an object as an `AsyncBufRead` over its (optionally decompressed)
+    /// body so callers can decode line-by-line without buffering the whole
+    /// object.
+    async fn open_object_reader(
+        &self,
+        key: &str,
+    ) -> Result<Pin<Box<dyn tokio::io::AsyncBufRead + Send + Unpin>>, FaucetError> {
+        let path = ObjectPath::from(key);
+        let result = self.store.get(&path).await.map_err(|e| {
+            FaucetError::Source(format!(
+                "azure get error for container '{}' key '{key}': {e}",
+                self.config.container()
+            ))
+        })?;
+
+        let byte_stream = result
+            .into_stream()
+            .map_err(|e| std::io::Error::other(e.to_string()));
+        let reader = tokio_util::io::StreamReader::new(byte_stream);
+        let buffered = tokio::io::BufReader::new(reader);
+        #[cfg(feature = "compression")]
+        {
+            let codec = self.config.compression.resolve(key);
+            faucet_core::compression::warn_mismatch(key, codec);
+            Ok(faucet_core::compression::wrap_async_reader(buffered, codec))
+        }
+        #[cfg(not(feature = "compression"))]
+        {
+            Ok(Box::pin(buffered))
+        }
+    }
+
+    /// Parse file content into records based on the configured file format.
+    fn parse_content(&self, key: &str, text: &str) -> Result<Vec<Value>, FaucetError> {
+        parse_file_content(&self.config.file_format, key, text)
+    }
+}
+
+/// Parse object content into records for a given format. Free function (vs. an
+/// `AzureBlobSource` method) so it is unit-testable without an Azure client —
+/// the parsing logic is pure.
+pub(crate) fn parse_file_content(
+    format: &AzureFileFormat,
+    key: &str,
+    text: &str,
+) -> Result<Vec<Value>, FaucetError> {
+    match format {
+        AzureFileFormat::JsonLines => {
+            let mut records = Vec::new();
+            for (line_num, line) in text.lines().enumerate() {
+                let trimmed = line.trim();
+                if trimmed.is_empty() {
+                    continue;
+                }
+                let value: Value = serde_json::from_str(trimmed).map_err(|e| {
+                    FaucetError::Source(format!(
+                        "azure JSON parse error in '{key}' at line {}: {e}",
+                        line_num + 1
+                    ))
+                })?;
+                records.push(value);
+            }
+            Ok(records)
+        }
+        AzureFileFormat::JsonArray => {
+            let value: Value = serde_json::from_str(text).map_err(|e| {
+                FaucetError::Source(format!("azure JSON parse error in '{key}': {e}"))
+            })?;
+            match value {
+                Value::Array(arr) => Ok(arr),
+                other => Err(FaucetError::Source(format!(
+                    "azure expected JSON array in '{key}', got {}",
+                    value_type_name(&other)
+                ))),
+            }
+        }
+        AzureFileFormat::RawText => Ok(vec![serde_json::json!({
+            "key": key,
+            "content": text,
+        })]),
+    }
+}
+
+/// Truncate an explicit object-key list to the `max_objects` cap. `None` leaves
+/// the list untouched.
+fn cap_keys(mut keys: Vec<String>, max: Option<usize>) -> Vec<String> {
+    if let Some(n) = max {
+        keys.truncate(n);
+    }
+    keys
+}
+
+fn value_type_name(v: &Value) -> &'static str {
+    match v {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+#[async_trait]
+impl faucet_core::Source for AzureBlobSource {
+    async fn fetch_with_context(
+        &self,
+        context: &HashMap<String, Value>,
+    ) -> Result<Vec<Value>, FaucetError> {
+        let substituted_prefix: Option<String> = if !context.is_empty() {
+            self.config
+                .prefix
+                .as_ref()
+                .map(|p| faucet_core::util::substitute_context(p, context))
+        } else {
+            None
+        };
+
+        let keys = self
+            .list_object_names(substituted_prefix.as_deref())
+            .await?;
+        tracing::info!(
+            container = %self.config.container(),
+            objects = keys.len(),
+            "Listed Azure objects",
+        );
+
+        let concurrency = self.config.concurrency.max(1);
+        let results: Vec<Vec<Value>> = stream::iter(keys)
+            .map(|key| async move {
+                let text = self.read_object_text(&key).await?;
+                let records = self.parse_content(&key, &text)?;
+                tracing::debug!(key = %key, records = records.len(), "Read Azure object");
+                Ok::<Vec<Value>, FaucetError>(records)
+            })
+            .buffer_unordered(concurrency)
+            .try_collect()
+            .await?;
+
+        let all_records: Vec<Value> = results.into_iter().flatten().collect();
+        tracing::info!(total_records = all_records.len(), "Azure fetch complete");
+        Ok(all_records)
+    }
+
+    /// Stream records from listed Azure objects without buffering the full
+    /// scan. Mirrors the S3/GCS object sources — see those for the per-format
+    /// reasoning. `batch_size = 0` emits one page per object.
+    fn stream_pages<'a>(
+        &'a self,
+        context: &'a HashMap<String, Value>,
+        _batch_size: usize,
+    ) -> Pin<Box<dyn Stream<Item = Result<StreamPage, FaucetError>> + Send + 'a>> {
+        let batch_size = self.config.batch_size;
+
+        Box::pin(async_stream::try_stream! {
+            let substituted_prefix: Option<String> = if !context.is_empty() {
+                self.config
+                    .prefix
+                    .as_ref()
+                    .map(|p| faucet_core::util::substitute_context(p, context))
+            } else {
+                None
+            };
+
+            let keys = self.list_object_names(substituted_prefix.as_deref()).await?;
+            tracing::info!(
+                container = %self.config.container(),
+                objects = keys.len(),
+                "Listed Azure objects (stream)",
+            );
+
+            let chunk = if batch_size == 0 { usize::MAX } else { batch_size };
+            let initial_capacity = if batch_size == 0 { 1024 } else { batch_size };
+            let mut buffer: Vec<Value> = Vec::with_capacity(initial_capacity);
+            let mut total = 0usize;
+
+            for key in &keys {
+                match self.config.file_format {
+                    AzureFileFormat::JsonLines => {
+                        let reader = self.open_object_reader(key).await?;
+                        let mut lines = reader.lines();
+                        let mut line_num: usize = 0;
+                        while let Some(line) = lines
+                            .next_line()
+                            .await
+                            .map_err(|e| FaucetError::Source(format!(
+                                "azure read body error for key '{key}': {e}"
+                            )))?
+                        {
+                            line_num += 1;
+                            let trimmed = line.trim();
+                            if trimmed.is_empty() { continue; }
+                            let value: Value = serde_json::from_str(trimmed).map_err(|e| {
+                                FaucetError::Source(format!(
+                                    "azure JSON parse error in '{key}' at line {line_num}: {e}",
+                                ))
+                            })?;
+                            buffer.push(value);
+                            if batch_size != 0 && buffer.len() >= chunk {
+                                let page = std::mem::replace(
+                                    &mut buffer,
+                                    Vec::with_capacity(initial_capacity),
+                                );
+                                total += page.len();
+                                yield StreamPage { records: page, bookmark: None };
+                            }
+                        }
+                        if batch_size == 0 && !buffer.is_empty() {
+                            let page = std::mem::take(&mut buffer);
+                            total += page.len();
+                            yield StreamPage { records: page, bookmark: None };
+                        }
+                    }
+                    AzureFileFormat::RawText => {
+                        let text = self.read_object_text(key).await?;
+                        let record = serde_json::json!({ "key": key, "content": text });
+                        buffer.push(record);
+                        if batch_size == 0 {
+                            let page = std::mem::take(&mut buffer);
+                            total += page.len();
+                            yield StreamPage { records: page, bookmark: None };
+                        } else if buffer.len() >= chunk {
+                            let page = std::mem::replace(
+                                &mut buffer,
+                                Vec::with_capacity(initial_capacity),
+                            );
+                            total += page.len();
+                            yield StreamPage { records: page, bookmark: None };
+                        }
+                    }
+                    AzureFileFormat::JsonArray => {
+                        let text = self.read_object_text(key).await?;
+                        let value: Value = serde_json::from_str(&text).map_err(|e| {
+                            FaucetError::Source(format!("azure JSON parse error in '{key}': {e}"))
+                        })?;
+                        let array = match value {
+                            Value::Array(arr) => arr,
+                            other => Err(FaucetError::Source(format!(
+                                "azure expected JSON array in '{key}', got {}",
+                                value_type_name(&other)
+                            )))?,
+                        };
+                        if batch_size == 0 {
+                            if !buffer.is_empty() {
+                                let page = std::mem::take(&mut buffer);
+                                total += page.len();
+                                yield StreamPage { records: page, bookmark: None };
+                            }
+                            total += array.len();
+                            yield StreamPage { records: array, bookmark: None };
+                        } else {
+                            for record in array {
+                                buffer.push(record);
+                                if buffer.len() >= chunk {
+                                    let page = std::mem::replace(
+                                        &mut buffer,
+                                        Vec::with_capacity(initial_capacity),
+                                    );
+                                    total += page.len();
+                                    yield StreamPage { records: page, bookmark: None };
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            if !buffer.is_empty() {
+                let page = std::mem::take(&mut buffer);
+                total += page.len();
+                yield StreamPage { records: page, bookmark: None };
+            }
+
+            tracing::info!(
+                total_records = total,
+                batch_size,
+                objects = keys.len(),
+                "Azure source stream complete",
+            );
+        })
+    }
+
+    fn config_schema(&self) -> Value {
+        serde_json::to_value(faucet_core::schema_for!(AzureBlobSourceConfig))
+            .expect("schema serialization")
+    }
+
+    fn connector_name(&self) -> &'static str {
+        "azure-blob"
+    }
+
+    fn dataset_uri(&self) -> String {
+        match &self.config.prefix {
+            Some(p) => format!("az://{}/{}", self.config.container(), p),
+            None => format!("az://{}", self.config.container()),
+        }
+    }
+
+    /// Preflight probe: confirm the container is reachable and the credentials
+    /// work via a non-mutating listing capped at a single item. Reads no object
+    /// bodies.
+    async fn check(
+        &self,
+        ctx: &faucet_core::check::CheckContext,
+    ) -> Result<faucet_core::check::CheckReport, FaucetError> {
+        use faucet_core::check::{CheckReport, Probe};
+
+        let started = std::time::Instant::now();
+        let probe = match tokio::time::timeout(ctx.timeout, async {
+            let mut listing = self.store.list(None);
+            listing.next().await
+        })
+        .await
+        {
+            // Reachable — an empty container (None) is still a pass.
+            Ok(None) | Ok(Some(Ok(_))) => Probe::pass("auth", started.elapsed()),
+            Ok(Some(Err(e))) => Probe::fail_hint(
+                "auth",
+                started.elapsed(),
+                e.to_string(),
+                "check account, container, credentials, and network",
+            ),
+            Err(_) => Probe::fail("network", started.elapsed(), "timed out"),
+        };
+        Ok(CheckReport::single(probe))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use faucet_core::Source as _;
+    use serde_json::json;
+
+    #[test]
+    fn value_type_name_covers_all_json_variants() {
+        assert_eq!(value_type_name(&Value::Null), "null");
+        assert_eq!(value_type_name(&json!(true)), "boolean");
+        assert_eq!(value_type_name(&json!(7)), "number");
+        assert_eq!(value_type_name(&json!("s")), "string");
+        assert_eq!(value_type_name(&json!([1, 2])), "array");
+        assert_eq!(value_type_name(&json!({"k": 1})), "object");
+    }
+
+    #[test]
+    fn parse_json_lines() {
+        let r = parse_file_content(&AzureFileFormat::JsonLines, "t", "{\"id\":1}\n{\"id\":2}\n")
+            .unwrap();
+        assert_eq!(r.len(), 2);
+        assert_eq!(r[0]["id"], 1);
+    }
+
+    #[test]
+    fn parse_json_lines_skips_blanks() {
+        let r = parse_file_content(
+            &AzureFileFormat::JsonLines,
+            "t",
+            "{\"id\":1}\n\n{\"id\":2}\n\n",
+        )
+        .unwrap();
+        assert_eq!(r.len(), 2);
+    }
+
+    #[test]
+    fn parse_json_lines_reports_line_number() {
+        let err = parse_file_content(&AzureFileFormat::JsonLines, "t", "{\"id\":1}\nbad-line\n")
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("line 2"), "unexpected: {msg}");
+    }
+
+    #[test]
+    fn parse_json_array() {
+        let r = parse_file_content(
+            &AzureFileFormat::JsonArray,
+            "t.json",
+            "[{\"id\":1},{\"id\":2}]",
+        )
+        .unwrap();
+        assert_eq!(r.len(), 2);
+    }
+
+    #[test]
+    fn parse_json_array_rejects_non_array() {
+        let err =
+            parse_file_content(&AzureFileFormat::JsonArray, "t.json", "{\"id\":1}").unwrap_err();
+        assert!(err.to_string().contains("expected JSON array"));
+    }
+
+    #[test]
+    fn parse_json_array_rejects_malformed_json() {
+        let err =
+            parse_file_content(&AzureFileFormat::JsonArray, "t.json", "[not json").unwrap_err();
+        assert!(matches!(err, FaucetError::Source(_)));
+    }
+
+    #[test]
+    fn parse_raw_text_yields_single_record() {
+        let r = parse_file_content(&AzureFileFormat::RawText, "p/f.txt", "hello").unwrap();
+        assert_eq!(r, vec![json!({"key": "p/f.txt", "content": "hello"})]);
+    }
+
+    #[test]
+    fn cap_keys_truncates_explicit_list_to_max_objects() {
+        let keys = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+        assert_eq!(
+            cap_keys(keys, Some(2)),
+            vec!["a".to_string(), "b".to_string()]
+        );
+    }
+
+    #[test]
+    fn cap_keys_passes_through_when_no_max() {
+        let keys = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+        assert_eq!(cap_keys(keys.clone(), None), keys);
+    }
+
+    #[test]
+    fn cap_keys_noop_when_max_exceeds_len() {
+        let keys = vec!["a".to_string(), "b".to_string()];
+        assert_eq!(cap_keys(keys.clone(), Some(10)), keys);
+    }
+
+    // dataset_uri logic mirrors the built source without needing an Azure
+    // client (construction builds the object store).
+    #[test]
+    fn dataset_uri_no_prefix_logic() {
+        let config = AzureBlobSourceConfig::new("my-container");
+        let uri = match &config.prefix {
+            Some(p) => format!("az://{}/{}", config.container(), p),
+            None => format!("az://{}", config.container()),
+        };
+        assert_eq!(uri, "az://my-container");
+    }
+
+    #[test]
+    fn dataset_uri_with_prefix_logic() {
+        let config = AzureBlobSourceConfig::new("my-container").prefix("data/2026/");
+        let uri = match &config.prefix {
+            Some(p) => format!("az://{}/{}", config.container(), p),
+            None => format!("az://{}", config.container()),
+        };
+        assert_eq!(uri, "az://my-container/data/2026/");
+    }
+
+    #[tokio::test]
+    async fn new_rejects_out_of_range_batch_size() {
+        let config =
+            AzureBlobSourceConfig::new("c").with_batch_size(faucet_core::MAX_BATCH_SIZE + 1);
+        match AzureBlobSource::new(config).await {
+            Err(FaucetError::Config(m)) => assert!(m.contains("batch_size"), "got: {m}"),
+            Ok(_) => panic!("expected a batch_size Config error, got Ok(source)"),
+            Err(e) => panic!("expected a batch_size Config error, got {e:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn new_builds_lazily_with_emulator() {
+        // The object-store builder is lazy — no I/O — so a well-formed emulator
+        // config constructs a source without a reachable backend.
+        let config = AzureBlobSourceConfig::new("c")
+            .use_emulator(true)
+            .allow_http(true);
+        let source = AzureBlobSource::new(config).await.unwrap();
+        assert_eq!(source.connector_name(), "azure-blob");
+        assert_eq!(source.dataset_uri(), "az://c");
+    }
+}

--- a/crates/source/azure-blob/tests/conformance.rs
+++ b/crates/source/azure-blob/tests/conformance.rs
@@ -1,0 +1,42 @@
+//! `faucet-conformance` battery for the Azure Blob source.
+//!
+//! Check 1 (config-schema validity) is pure and offline and always runs.
+//!
+//! Check 6 (errors, not panics) points the source at an unreachable endpoint
+//! and verifies the read paths surface typed `FaucetError`s rather than
+//! panicking. The `object_store` builder is lazy (no I/O at build time), so no
+//! container is needed — only the failure path is exercised, which an
+//! unreachable host reproduces deterministically.
+
+use faucet_conformance::{assert_config_schema_valid_value, assert_errors_not_panics};
+use faucet_source_azure_blob::{AzureBlobSource, AzureBlobSourceConfig, AzureCredentials};
+
+// ── Check 1: config schema ──────────────────────────────────────────────────
+
+#[test]
+fn conformance_config_schema_valid() {
+    let schema = serde_json::to_value(schemars::schema_for!(AzureBlobSourceConfig)).unwrap();
+    assert_config_schema_valid_value(&schema, "faucet-source-azure-blob");
+}
+
+// ── Check 6: errors, not panics (no container) ──────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn conformance_errors_not_panics() {
+    // `http://127.0.0.1:1` refuses connections immediately. Anonymous-style
+    // build stays lazy, so `new()` succeeds; the first list/get RPC fails with
+    // a typed `FaucetError` on both `fetch_all` and `stream_pages`.
+    let config = AzureBlobSourceConfig::new("does-not-exist")
+        .account("devstoreaccount1")
+        .prefix("data/")
+        .auth(AzureCredentials::AccountKey {
+            account_key: "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==".into(),
+        })
+        .endpoint("http://127.0.0.1:1")
+        .allow_http(true)
+        .with_batch_size(250);
+    let source = AzureBlobSource::new(config)
+        .await
+        .expect("source builds lazily");
+    assert_errors_not_panics(&source).await;
+}

--- a/crates/source/azure-blob/tests/integration.rs
+++ b/crates/source/azure-blob/tests/integration.rs
@@ -1,0 +1,324 @@
+//! Integration tests for `faucet-source-azure-blob` against an auto-started
+//! Azurite emulator (via `testcontainers-modules`).
+//!
+//! These boot a real Azurite container, create a blob container, seed objects
+//! through the same `object_store` Azure client the connector uses, then drive
+//! the connector's real read path (`fetch_all` + `stream_pages`) and assert the
+//! decoded records. They are **not** `#[ignore]`d and **not** env-gated — CI's
+//! `--all-features` test/coverage jobs run them with Docker present, which is
+//! what exercises the object-listing / download / decode / batching lines in
+//! `src/stream.rs`.
+//!
+//! Container creation goes through the Azure SDK (`object_store` cannot create a
+//! container); every other blob operation goes through `object_store` so the
+//! seed path mirrors the connector's own client.
+
+#![cfg(not(target_os = "windows"))]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use faucet_core::Source;
+use faucet_source_azure_blob::{
+    AzureBlobSource, AzureBlobSourceConfig, AzureCredentials, AzureFileFormat,
+};
+use futures::StreamExt;
+use object_store::azure::MicrosoftAzureBuilder;
+use object_store::path::Path as ObjPath;
+use object_store::{ObjectStore, ObjectStoreExt, PutPayload};
+use serde_json::{Value, json};
+use testcontainers_modules::azurite::{Azurite, BLOB_PORT};
+use testcontainers_modules::testcontainers::ContainerAsync;
+use testcontainers_modules::testcontainers::runners::AsyncRunner;
+
+/// Well-known Azurite dev account + key (`devstoreaccount1`).
+const AZURITE_ACCOUNT: &str = "devstoreaccount1";
+const AZURITE_KEY: &str =
+    "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
+const CONTAINER: &str = "faucet-test";
+
+// Azurite is lightweight, but `cargo test` runs a binary's tests concurrently;
+// serialize so at most one emulator container runs at a time (steadier on CI).
+static SERIAL: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+/// Start Azurite and return the container handle plus its mapped blob port. The
+/// handle must be held for the duration of the test to keep the container up.
+async fn start_azurite() -> (ContainerAsync<Azurite>, u16) {
+    let container = Azurite::default()
+        .start()
+        .await
+        .expect("start azurite container");
+    let port = container
+        .get_host_port_ipv4(BLOB_PORT)
+        .await
+        .expect("azurite blob host port");
+    (container, port)
+}
+
+/// The blob endpoint object_store / the connector point at for `devstoreaccount1`.
+fn endpoint(port: u16) -> String {
+    format!("http://127.0.0.1:{port}/{AZURITE_ACCOUNT}")
+}
+
+/// Create the destination blob container via the Azure SDK (`object_store` has
+/// no container-management API). Uses the emulator credentials, so it targets
+/// the same `devstoreaccount1` container the connector reads.
+async fn create_container(port: u16) {
+    use azure_storage::{CloudLocation, prelude::*};
+    use azure_storage_blobs::prelude::*;
+
+    ClientBuilder::with_location(
+        CloudLocation::Emulator {
+            address: "127.0.0.1".to_owned(),
+            port,
+        },
+        StorageCredentials::emulator(),
+    )
+    .container_client(CONTAINER)
+    .create()
+    .await
+    .expect("create azurite blob container");
+}
+
+/// Build an `object_store` Azure client (the same client type the connector
+/// uses) for seeding blobs into the running Azurite container.
+fn seed_store(port: u16) -> Arc<dyn ObjectStore> {
+    Arc::new(
+        MicrosoftAzureBuilder::new()
+            .with_account(AZURITE_ACCOUNT)
+            .with_access_key(AZURITE_KEY)
+            .with_container_name(CONTAINER)
+            .with_endpoint(endpoint(port))
+            .with_allow_http(true)
+            .build()
+            .expect("build seeding object store"),
+    )
+}
+
+/// Put one object with the given raw bytes.
+async fn put_object(store: &Arc<dyn ObjectStore>, key: &str, body: Vec<u8>) {
+    store
+        .put(&ObjPath::from(key), PutPayload::from(body))
+        .await
+        .expect("seed object");
+}
+
+/// The connector config pointed at the running emulator with an explicit
+/// endpoint + shared-key credentials.
+fn source_config(port: u16) -> AzureBlobSourceConfig {
+    AzureBlobSourceConfig::new(CONTAINER)
+        .account(AZURITE_ACCOUNT)
+        .auth(AzureCredentials::AccountKey {
+            account_key: AZURITE_KEY.into(),
+        })
+        .endpoint(endpoint(port))
+        .allow_http(true)
+}
+
+/// Collect all records from a source's streaming path, returning per-page sizes.
+async fn drain_pages(source: &AzureBlobSource) -> (Vec<Value>, Vec<usize>) {
+    let ctx: HashMap<String, Value> = HashMap::new();
+    let mut pages = source.stream_pages(&ctx, 0);
+    let mut records = Vec::new();
+    let mut sizes = Vec::new();
+    while let Some(page) = pages.next().await {
+        let page = page.expect("stream page ok");
+        sizes.push(page.records.len());
+        records.extend(page.records);
+    }
+    (records, sizes)
+}
+
+// ── JSON Lines: fetch_all over a prefix listing of multiple objects ──────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn source_reads_json_lines_via_fetch() {
+    let _serial = SERIAL.lock().await;
+    let (_c, port) = start_azurite().await;
+    create_container(port).await;
+    let store = seed_store(port);
+
+    put_object(
+        &store,
+        "data/a.jsonl",
+        b"{\"id\":1}\n{\"id\":2}\n{\"id\":3}\n".to_vec(),
+    )
+    .await;
+    put_object(&store, "data/b.jsonl", b"{\"id\":4}\n{\"id\":5}\n".to_vec()).await;
+    // An object outside the prefix must be excluded by the listing filter.
+    put_object(&store, "other/c.jsonl", b"{\"id\":99}\n".to_vec()).await;
+
+    let source = AzureBlobSource::new(source_config(port).prefix("data/"))
+        .await
+        .expect("source new");
+
+    let records = source
+        .fetch_with_context(&HashMap::new())
+        .await
+        .expect("fetch");
+
+    assert_eq!(
+        records.len(),
+        5,
+        "prefix listing should read both data/ objects"
+    );
+    assert!(records.iter().all(|r| r.is_object()));
+    let mut ids: Vec<i64> = records.iter().map(|r| r["id"].as_i64().unwrap()).collect();
+    ids.sort_unstable();
+    assert_eq!(ids, vec![1, 2, 3, 4, 5]);
+}
+
+// ── JSON Lines: stream_pages splits into batch_size pages ────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn source_streams_json_lines_in_batch_sized_pages() {
+    let _serial = SERIAL.lock().await;
+    let (_c, port) = start_azurite().await;
+    create_container(port).await;
+    let store = seed_store(port);
+
+    put_object(
+        &store,
+        "page/data.jsonl",
+        b"{\"n\":1}\n{\"n\":2}\n{\"n\":3}\n{\"n\":4}\n{\"n\":5}\n".to_vec(),
+    )
+    .await;
+
+    let source = AzureBlobSource::new(source_config(port).prefix("page/").with_batch_size(2))
+        .await
+        .expect("source new");
+
+    let ctx: HashMap<String, Value> = HashMap::new();
+    let mut pages = source.stream_pages(&ctx, 2);
+    let mut sizes = Vec::new();
+    let mut total = 0;
+    while let Some(page) = pages.next().await {
+        let page = page.expect("stream page ok");
+        total += page.records.len();
+        sizes.push(page.records.len());
+    }
+    assert_eq!(total, 5);
+    assert_eq!(
+        sizes,
+        vec![2, 2, 1],
+        "batch_size=2 over 5 records → [2,2,1]"
+    );
+}
+
+// ── JSON array + raw text formats (fetch + stream) ───────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn source_reads_json_array_and_raw_text() {
+    let _serial = SERIAL.lock().await;
+    let (_c, port) = start_azurite().await;
+    create_container(port).await;
+    let store = seed_store(port);
+
+    put_object(&store, "arr/x.json", b"[{\"id\":1},{\"id\":2}]".to_vec()).await;
+    put_object(&store, "raw/f.txt", b"hello\nworld".to_vec()).await;
+
+    // JSON array: fetch_all (parse_content) + stream_pages (batch_size=0 → one
+    // page per object carrying the whole array).
+    let arr_source = AzureBlobSource::new(
+        source_config(port)
+            .prefix("arr/")
+            .file_format(AzureFileFormat::JsonArray)
+            .with_batch_size(0),
+    )
+    .await
+    .expect("array source new");
+
+    let fetched = arr_source
+        .fetch_with_context(&HashMap::new())
+        .await
+        .expect("fetch array");
+    assert_eq!(fetched.len(), 2);
+    assert_eq!(fetched[0]["id"], 1);
+
+    let (streamed, sizes) = drain_pages(&arr_source).await;
+    assert_eq!(streamed.len(), 2);
+    assert_eq!(
+        sizes,
+        vec![2],
+        "batch_size=0 emits the whole array as one page"
+    );
+
+    // Raw text: each object becomes one {key, content} record.
+    let raw_source = AzureBlobSource::new(
+        source_config(port)
+            .prefix("raw/")
+            .file_format(AzureFileFormat::RawText),
+    )
+    .await
+    .expect("raw source new");
+
+    let raw = raw_source
+        .fetch_with_context(&HashMap::new())
+        .await
+        .expect("fetch raw");
+    assert_eq!(
+        raw,
+        vec![json!({"key": "raw/f.txt", "content": "hello\nworld"})]
+    );
+
+    let (raw_streamed, _sizes) = drain_pages(&raw_source).await;
+    assert_eq!(
+        raw_streamed,
+        vec![json!({"key": "raw/f.txt", "content": "hello\nworld"})]
+    );
+}
+
+// ── Preflight check succeeds against a reachable, credentialed container ──────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn source_check_passes() {
+    let _serial = SERIAL.lock().await;
+    let (_c, port) = start_azurite().await;
+    create_container(port).await;
+
+    let source = AzureBlobSource::new(source_config(port))
+        .await
+        .expect("source new");
+
+    let ctx = faucet_core::check::CheckContext {
+        timeout: std::time::Duration::from_secs(10),
+    };
+    let report = source.check(&ctx).await.expect("check");
+    assert!(
+        report
+            .probes
+            .iter()
+            .all(|p| matches!(p.status, faucet_core::check::ProbeStatus::Pass)),
+        "expected all probes to pass, got {:?}",
+        report.probes
+    );
+}
+
+// ── Compressed (.gz) object decoding (requires the `compression` feature) ────
+
+#[cfg(feature = "compression")]
+#[tokio::test(flavor = "multi_thread")]
+async fn source_reads_gzip_object() {
+    let _serial = SERIAL.lock().await;
+    let (_c, port) = start_azurite().await;
+    create_container(port).await;
+    let store = seed_store(port);
+
+    let jsonl = b"{\"id\":10}\n{\"id\":11}\n";
+    let gz = faucet_core::compression::compress_buf(jsonl, faucet_core::Compression::Gzip)
+        .expect("gzip compress");
+    put_object(&store, "gz/c.jsonl.gz", gz).await;
+
+    // Compression::Auto resolves per object key, so `.gz` triggers gunzip.
+    let source = AzureBlobSource::new(source_config(port).prefix("gz/"))
+        .await
+        .expect("source new");
+
+    let records = source
+        .fetch_with_context(&HashMap::new())
+        .await
+        .expect("fetch gzip");
+    let mut ids: Vec<i64> = records.iter().map(|r| r["id"].as_i64().unwrap()).collect();
+    ids.sort_unstable();
+    assert_eq!(ids, vec![10, 11]);
+}

--- a/crates/source/clickhouse/Cargo.toml
+++ b/crates/source/clickhouse/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "faucet-source-clickhouse"
+version = "1.0.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "ClickHouse query source connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords = ["clickhouse", "olap", "sql", "etl", "pipeline"]
+categories.workspace = true
+
+[dependencies]
+faucet-core.workspace = true
+faucet-common-clickhouse.workspace = true
+schemars.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+async-trait.workspace = true
+tracing.workspace = true
+reqwest = { workspace = true, features = ["stream"] }
+async-stream = { workspace = true }
+futures.workspace = true
+tokio = { workspace = true, features = ["time"] }
+url.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync"] }
+serde_json.workspace = true
+schemars.workspace = true
+futures = { workspace = true }
+reqwest = { workspace = true }
+testcontainers = "0.27"
+testcontainers-modules = { version = "0.15", features = ["clickhouse"] }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/source/clickhouse/README.md
+++ b/crates/source/clickhouse/README.md
@@ -1,0 +1,73 @@
+# faucet-source-clickhouse
+
+ClickHouse query **source** for the
+[`faucet-stream`](https://crates.io/crates/faucet-stream) ecosystem.
+
+Talks to ClickHouse over its
+[HTTP interface](https://clickhouse.com/docs/en/interfaces/http) using
+[`reqwest`](https://crates.io/crates/reqwest): runs a SQL `SELECT`, requests the
+`JSONEachRow` output format, and streams the response body straight into
+`StreamPage`s. Response bytes are line-buffered and decoded incrementally, so
+memory stays bounded (`batch_size` records per page) regardless of how large the
+result set is.
+
+## Configuration
+
+```yaml
+source:
+  kind: clickhouse
+  config:
+    # Endpoint — either `url` OR `host` (+ optional `http_port` / `tls`).
+    url: http://localhost:8123
+    # host: localhost
+    # http_port: 8123
+    # tls: false
+    database: default
+    user: default          # optional; sent as X-ClickHouse-User
+    password: ${env:CH_PASSWORD}   # optional; sent as X-ClickHouse-Key
+    query: SELECT id, email, updated_at FROM events
+    batch_size: 1000       # records per StreamPage; 0 = whole result as one page
+```
+
+Do **not** append a `FORMAT` clause to `query` — the source sets the output
+format to `JSONEachRow` via the request settings.
+
+### Authentication
+
+Username + password (ClickHouse native HTTP auth), sent as the
+`X-ClickHouse-User` / `X-ClickHouse-Key` headers (never URL query parameters, so
+credentials do not leak into request logs).
+
+## Incremental replication
+
+Set `replication` to track a monotonically increasing column across runs. Only
+rows whose column value is strictly greater than the stored bookmark (or
+`initial_value` on the first run) are emitted, and the new maximum is persisted
+on the final page.
+
+```yaml
+    replication:
+      type: incremental
+      column: updated_at
+      initial_value: "1970-01-01 00:00:00"
+    query: SELECT * FROM events WHERE updated_at > @bookmark
+```
+
+Put the literal `@bookmark` token in the `WHERE` clause to push the cursor down
+to the server (efficient); it is substituted as an injection-safe SQL literal.
+The source *also* filters client-side as a correctness backstop. If `@bookmark`
+is omitted the cursor is applied client-side only, so the server returns the
+whole result set on every run (correctness is preserved, but it is a full
+re-scan — a warning is logged).
+
+You can inject parent-context values in a matrix child via `{key}` tokens; they
+are substituted as injection-safe SQL literals.
+
+## Dataset discovery / sharding
+
+Not supported in v1.
+
+## License
+
+Licensed under either of Apache License, Version 2.0 or MIT license at your
+option.

--- a/crates/source/clickhouse/src/config.rs
+++ b/crates/source/clickhouse/src/config.rs
@@ -1,0 +1,234 @@
+//! Configuration for the ClickHouse query source.
+
+use faucet_common_clickhouse::ClickHouseConnection;
+use faucet_core::{DEFAULT_BATCH_SIZE, FaucetError, validate_batch_size};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+fn default_batch_size() -> usize {
+    DEFAULT_BATCH_SIZE
+}
+
+/// How the source replicates rows across runs.
+///
+/// Serializes as `{ type: full }` or
+/// `{ type: incremental, column: "...", initial_value: ... }`.
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, Default, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ClickHouseReplication {
+    /// Every run fetches the full result set (default).
+    #[default]
+    Full,
+    /// Only rows whose `column` is strictly greater than the stored bookmark
+    /// (or `initial_value` on the first run) are emitted.
+    ///
+    /// The bookmark is applied two ways: if the query contains the literal
+    /// token `@bookmark`, it is substituted as an injection-safe SQL literal so
+    /// the server filters (efficient pushdown); the source *also* filters
+    /// client-side as a correctness backstop. The new maximum of `column` is
+    /// persisted on the final page.
+    Incremental {
+        /// Column whose value is the replication cursor (e.g. `updated_at`).
+        column: String,
+        /// Lower bound used on the first run, before any bookmark is stored.
+        initial_value: Value,
+    },
+}
+
+/// Configuration for [`ClickHouseSource`](crate::ClickHouseSource).
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ClickHouseSourceConfig {
+    /// Connection settings (`url` or `host`, `database`, credentials).
+    #[serde(flatten)]
+    pub connection: ClickHouseConnection,
+    /// SQL `SELECT` query to run. The output format is set to `JSONEachRow`
+    /// via the request settings, so **do not** append a `FORMAT` clause. Use
+    /// the literal `@bookmark` token to push the incremental cursor down into
+    /// the `WHERE` clause; use `{key}` tokens to inject parent-context values in
+    /// a matrix child.
+    pub query: String,
+    /// Records per emitted [`StreamPage`](faucet_core::StreamPage). `0` emits
+    /// the whole result set as a single page. Defaults to
+    /// [`DEFAULT_BATCH_SIZE`].
+    #[serde(default = "default_batch_size")]
+    pub batch_size: usize,
+    /// Replication mode. Defaults to [`ClickHouseReplication::Full`].
+    #[serde(default)]
+    pub replication: ClickHouseReplication,
+    /// Explicit state-store key for the bookmark. When unset, a key is derived
+    /// from the connection host and a query fingerprint.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state_key: Option<String>,
+}
+
+impl std::fmt::Debug for ClickHouseSourceConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ClickHouseSourceConfig")
+            .field("connection", &self.connection)
+            .field("query", &self.query)
+            .field("batch_size", &self.batch_size)
+            .field("replication", &self.replication)
+            .field("state_key", &self.state_key)
+            .finish()
+    }
+}
+
+impl ClickHouseSourceConfig {
+    /// Build a config from a base URL and query, with defaults elsewhere.
+    pub fn new(url: impl Into<String>, query: impl Into<String>) -> Self {
+        Self {
+            connection: ClickHouseConnection::from_url(url),
+            query: query.into(),
+            batch_size: default_batch_size(),
+            replication: ClickHouseReplication::Full,
+            state_key: None,
+        }
+    }
+
+    /// Set the per-page record count.
+    pub fn with_batch_size(mut self, batch_size: usize) -> Self {
+        self.batch_size = batch_size;
+        self
+    }
+
+    /// Configure incremental replication on `column`, starting at `initial`.
+    pub fn incremental(mut self, column: impl Into<String>, initial: Value) -> Self {
+        self.replication = ClickHouseReplication::Incremental {
+            column: column.into(),
+            initial_value: initial,
+        };
+        self
+    }
+
+    /// Validate connection, batch size, and replication settings.
+    pub fn validate(&self) -> Result<(), FaucetError> {
+        self.connection.validate()?;
+        validate_batch_size(self.batch_size)?;
+        if let ClickHouseReplication::Incremental { column, .. } = &self.replication
+            && column.trim().is_empty()
+        {
+            return Err(FaucetError::Config(
+                "ClickHouse incremental replication requires a non-empty `column`".into(),
+            ));
+        }
+        if self.incremental_without_bookmark_pushdown() {
+            tracing::warn!(
+                "ClickHouse incremental replication query has no `@bookmark` token: the \
+                 cursor is applied client-side only, so the server returns the ENTIRE \
+                 result set on every run (correctness is preserved, but it is a full \
+                 re-scan). Add `@bookmark` to the WHERE clause to push the cursor down, \
+                 e.g. `... WHERE {column} > @bookmark`",
+                column = match &self.replication {
+                    ClickHouseReplication::Incremental { column, .. } => column.as_str(),
+                    _ => "<column>",
+                }
+            );
+        }
+        Ok(())
+    }
+
+    /// `true` when replication is `Incremental` but the query omits the
+    /// `@bookmark` token, so the cursor cannot be pushed down and every run
+    /// re-scans the whole result set. Pure predicate so the load-time warning's
+    /// condition is unit-testable.
+    pub(crate) fn incremental_without_bookmark_pushdown(&self) -> bool {
+        matches!(self.replication, ClickHouseReplication::Incremental { .. })
+            && !self.query.contains("@bookmark")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn config_flattens_connection_fields() {
+        let cfg: ClickHouseSourceConfig = serde_json::from_value(json!({
+            "url": "http://localhost:8123",
+            "database": "analytics",
+            "query": "SELECT 1",
+        }))
+        .unwrap();
+        assert_eq!(cfg.connection.url.as_deref(), Some("http://localhost:8123"));
+        assert_eq!(cfg.connection.database, "analytics");
+        assert_eq!(cfg.batch_size, DEFAULT_BATCH_SIZE);
+    }
+
+    #[test]
+    fn replication_full_is_default() {
+        let cfg = ClickHouseSourceConfig::new("http://h:8123", "SELECT 1");
+        assert_eq!(cfg.replication, ClickHouseReplication::Full);
+    }
+
+    #[test]
+    fn replication_incremental_parses() {
+        let r: ClickHouseReplication = serde_json::from_value(json!({
+            "type": "incremental",
+            "column": "updated_at",
+            "initial_value": "1970-01-01",
+        }))
+        .unwrap();
+        assert_eq!(
+            r,
+            ClickHouseReplication::Incremental {
+                column: "updated_at".into(),
+                initial_value: json!("1970-01-01"),
+            }
+        );
+    }
+
+    #[test]
+    fn validate_rejects_incremental_without_column() {
+        let cfg = ClickHouseSourceConfig {
+            replication: ClickHouseReplication::Incremental {
+                column: "  ".into(),
+                initial_value: json!(0),
+            },
+            ..ClickHouseSourceConfig::new("http://h:8123", "SELECT 1")
+        };
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_bad_batch_size() {
+        let cfg = ClickHouseSourceConfig::new("http://h:8123", "SELECT 1")
+            .with_batch_size(faucet_core::MAX_BATCH_SIZE + 1);
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_missing_endpoint() {
+        let mut cfg = ClickHouseSourceConfig::new("http://h:8123", "SELECT 1");
+        cfg.connection.url = None;
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn incremental_without_bookmark_pushdown_flags_missing_token() {
+        let missing = ClickHouseSourceConfig::new("http://h:8123", "SELECT * FROM t")
+            .incremental("updated_at", json!("1970-01-01"));
+        assert!(missing.incremental_without_bookmark_pushdown());
+        assert!(missing.validate().is_ok(), "warn, not hard error");
+
+        let with_token = ClickHouseSourceConfig::new(
+            "http://h:8123",
+            "SELECT * FROM t WHERE updated_at > @bookmark",
+        )
+        .incremental("updated_at", json!("1970-01-01"));
+        assert!(!with_token.incremental_without_bookmark_pushdown());
+
+        let full = ClickHouseSourceConfig::new("http://h:8123", "SELECT * FROM t");
+        assert!(!full.incremental_without_bookmark_pushdown());
+    }
+
+    #[test]
+    fn debug_masks_password() {
+        let mut cfg = ClickHouseSourceConfig::new("http://h:8123", "SELECT 1");
+        cfg.connection.password = Some("s3cret".into());
+        let dbg = format!("{cfg:?}");
+        assert!(dbg.contains("***"));
+        assert!(!dbg.contains("s3cret"));
+    }
+}

--- a/crates/source/clickhouse/src/lib.rs
+++ b/crates/source/clickhouse/src/lib.rs
@@ -1,0 +1,38 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+//! # faucet-source-clickhouse
+//!
+//! ClickHouse query source for the
+//! [`faucet-stream`](https://crates.io/crates/faucet-stream) ecosystem, built on
+//! the ClickHouse [HTTP interface](https://clickhouse.com/docs/en/interfaces/http)
+//! via [`reqwest`](https://crates.io/crates/reqwest).
+//!
+//! Runs a SQL `SELECT`, streams the `JSONEachRow` response body straight into
+//! [`StreamPage`](faucet_core::StreamPage)s (bytes are line-buffered and decoded
+//! incrementally, so memory stays bounded regardless of result size), and
+//! supports incremental replication via a tracking column (see
+//! [`ClickHouseReplication`]). Mirrors the `faucet-source-postgres` / `mysql` /
+//! `mssql` query sources.
+//!
+//! ```no_run
+//! # use faucet_source_clickhouse::{ClickHouseSource, ClickHouseSourceConfig};
+//! # fn run() -> Result<(), faucet_core::FaucetError> {
+//! let cfg = ClickHouseSourceConfig::new(
+//!     "http://localhost:8123",
+//!     "SELECT id, email, updated_at FROM events",
+//! );
+//! let source = ClickHouseSource::new(cfg)?;
+//! # let _ = source;
+//! # Ok(())
+//! # }
+//! ```
+
+mod config;
+mod stream;
+
+pub use config::{ClickHouseReplication, ClickHouseSourceConfig};
+pub use stream::ClickHouseSource;
+
+// Re-export the shared connection type so users configure the source without
+// depending on `faucet-common-clickhouse` directly.
+pub use faucet_common_clickhouse::ClickHouseConnection;

--- a/crates/source/clickhouse/src/stream.rs
+++ b/crates/source/clickhouse/src/stream.rs
@@ -1,0 +1,575 @@
+//! The ClickHouse [`Source`] implementation — HTTP client, query execution,
+//! streaming JSONEachRow decode, and incremental-replication bookkeeping.
+
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
+use std::pin::Pin;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use faucet_common_clickhouse::{
+    apply_auth, build_client, parse_json_each_row, query_params, sql_literal,
+};
+use faucet_core::check::{CheckContext, CheckReport, Probe};
+use faucet_core::replication::{filter_incremental, max_replication_value, max_value};
+use faucet_core::util::{DEFAULT_ERROR_BODY_MAX_LEN, check_http_response};
+use faucet_core::{FaucetError, Source, Stream, StreamPage};
+use futures::StreamExt;
+use serde_json::Value;
+
+use crate::config::{ClickHouseReplication, ClickHouseSourceConfig};
+
+/// ClickHouse query source (HTTP interface, `JSONEachRow`).
+pub struct ClickHouseSource {
+    config: ClickHouseSourceConfig,
+    client: reqwest::Client,
+    /// Resolved once in [`ClickHouseSource::new`] so the hot path never re-parses.
+    base_url: String,
+    /// Bookmark loaded via [`Source::apply_start_bookmark`]; overrides the
+    /// configured `initial_value` for incremental runs.
+    start_bookmark: Mutex<Option<Value>>,
+}
+
+/// Incremental-replication context resolved for one run.
+#[derive(Debug, Clone, PartialEq)]
+struct IncrementalCtx {
+    column: String,
+    start: Value,
+}
+
+impl ClickHouseSource {
+    /// Validate the config and build the reusable HTTP client.
+    pub fn new(config: ClickHouseSourceConfig) -> Result<Self, FaucetError> {
+        config.validate()?;
+        let base_url = config.connection.base_url()?;
+        let client = build_client(&config.connection)?;
+        Ok(Self {
+            config,
+            client,
+            base_url,
+            start_bookmark: Mutex::new(None),
+        })
+    }
+
+    fn current_start(&self) -> Option<Value> {
+        self.start_bookmark
+            .lock()
+            .expect("start_bookmark mutex poisoned")
+            .clone()
+    }
+
+    /// Build the POST request that runs `query` and returns `JSONEachRow`.
+    fn request(&self, query: String) -> reqwest::RequestBuilder {
+        let params = query_params(
+            &self.config.connection.database,
+            &[("default_format", "JSONEachRow")],
+        );
+        let req = self.client.post(&self.base_url).query(&params).body(query);
+        apply_auth(req, &self.config.connection)
+    }
+
+    /// Run the query and collect all decoded rows plus (for incremental) the new
+    /// bookmark. Used by the non-streaming convenience methods.
+    async fn collect_all(
+        &self,
+        context: &HashMap<String, Value>,
+    ) -> Result<(Vec<Value>, Option<Value>), FaucetError> {
+        let start = self.current_start();
+        let (query, incr) = build_effective_query(&self.config, context, start.as_ref());
+
+        let resp = self.request(query).send().await?;
+        let resp = check_http_response(resp, DEFAULT_ERROR_BODY_MAX_LEN).await?;
+        let body = resp.text().await.map_err(|e| {
+            FaucetError::Source(format!("ClickHouse: reading response failed: {e}"))
+        })?;
+        let records = parse_json_each_row(&body)?;
+
+        let mut running_max: Option<Value> = None;
+        let records = apply_incremental(records, incr.as_ref(), &mut running_max);
+        let bookmark = if incr.is_some() { running_max } else { None };
+        Ok((records, bookmark))
+    }
+}
+
+/// Build the final query string and (for incremental runs) the client-side
+/// filter context. Pure (no client) so it is unit-testable.
+///
+/// Substitution order: parent-context `{key}` tokens (as injection-safe SQL
+/// literals) → the incremental bookmark bound where the user wrote `@bookmark`.
+fn build_effective_query(
+    config: &ClickHouseSourceConfig,
+    context: &HashMap<String, Value>,
+    start_bookmark: Option<&Value>,
+) -> (String, Option<IncrementalCtx>) {
+    let mut query = if context.is_empty() {
+        config.query.clone()
+    } else {
+        substitute_context_sql(&config.query, context)
+    };
+
+    let incremental = match &config.replication {
+        ClickHouseReplication::Full => None,
+        ClickHouseReplication::Incremental {
+            column,
+            initial_value,
+        } => {
+            let start = start_bookmark
+                .cloned()
+                .unwrap_or_else(|| initial_value.clone());
+            // Server-side pushdown: substitute the cursor as an injection-safe
+            // SQL literal where the user wrote `@bookmark`. If absent, only the
+            // client-side filter applies.
+            if query.contains("@bookmark") {
+                query = query.replace("@bookmark", &sql_literal(&start));
+            }
+            Some(IncrementalCtx {
+                column: column.clone(),
+                start,
+            })
+        }
+    };
+
+    (query, incremental)
+}
+
+/// Replace each `{key}` token with the injection-safe SQL literal of the
+/// corresponding context value. Tokens with no matching context entry are left
+/// verbatim.
+fn substitute_context_sql(query: &str, context: &HashMap<String, Value>) -> String {
+    let mut out = query.to_string();
+    for (key, value) in context {
+        out = out.replace(&format!("{{{key}}}"), &sql_literal(value));
+    }
+    out
+}
+
+/// Filter a page for incremental replication and advance `running_max`.
+/// For full replication the page passes through unchanged.
+fn apply_incremental(
+    page: Vec<Value>,
+    incr: Option<&IncrementalCtx>,
+    running_max: &mut Option<Value>,
+) -> Vec<Value> {
+    match incr {
+        None => page,
+        Some(ctx) => {
+            let kept = filter_incremental(page, &ctx.column, &ctx.start);
+            if let Some(m) = max_replication_value(&kept, &ctx.column) {
+                let m = m.clone();
+                *running_max = Some(match running_max.take() {
+                    Some(prev) => max_value(prev, m),
+                    None => m,
+                });
+            }
+            kept
+        }
+    }
+}
+
+/// Drain every complete `\n`-terminated line from `buf`, returning each line's
+/// bytes (without the trailing newline). Splitting on the `0x0A` byte is safe
+/// for UTF-8 because a newline never appears inside a multi-byte sequence, so a
+/// line split across two network chunks is reassembled correctly. Pure and
+/// unit-testable.
+fn split_complete_lines(buf: &mut Vec<u8>) -> Vec<Vec<u8>> {
+    let mut lines = Vec::new();
+    while let Some(pos) = buf.iter().position(|&b| b == b'\n') {
+        let mut line: Vec<u8> = buf.drain(..=pos).collect();
+        line.pop(); // strip the trailing '\n'
+        lines.push(line);
+    }
+    lines
+}
+
+/// Parse one raw JSONEachRow line into a JSON value. Blank lines yield `None`.
+/// Invalid UTF-8 or JSON surfaces as a typed [`FaucetError::Source`].
+fn parse_line(line: &[u8]) -> Result<Option<Value>, FaucetError> {
+    let text = std::str::from_utf8(line)
+        .map_err(|e| FaucetError::Source(format!("ClickHouse: non-UTF-8 response line: {e}")))?
+        .trim();
+    if text.is_empty() {
+        return Ok(None);
+    }
+    let value: Value = serde_json::from_str(text).map_err(|e| {
+        FaucetError::Source(format!("ClickHouse: failed to parse JSONEachRow line: {e}"))
+    })?;
+    Ok(Some(value))
+}
+
+/// Derive a default state-store key from the connection host + a query
+/// fingerprint, stable across runs.
+fn default_state_key(config: &ClickHouseSourceConfig) -> String {
+    let host = config
+        .connection
+        .base_url()
+        .ok()
+        .and_then(|u| url::Url::parse(&u).ok())
+        .and_then(|u| u.host_str().map(str::to_string))
+        .unwrap_or_else(|| "clickhouse".to_string());
+
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    config.query.hash(&mut hasher);
+    let fingerprint = hasher.finish();
+    let host: String = host
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.') {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    format!("clickhouse:{host}:{fingerprint:016x}")
+}
+
+#[async_trait]
+impl Source for ClickHouseSource {
+    async fn fetch_with_context(
+        &self,
+        context: &HashMap<String, Value>,
+    ) -> Result<Vec<Value>, FaucetError> {
+        Ok(self.collect_all(context).await?.0)
+    }
+
+    async fn fetch_with_context_incremental(
+        &self,
+        context: &HashMap<String, Value>,
+    ) -> Result<(Vec<Value>, Option<Value>), FaucetError> {
+        self.collect_all(context).await
+    }
+
+    /// Stream rows straight off the HTTP response body without buffering the
+    /// whole result set: bytes are accumulated, split into complete
+    /// `JSONEachRow` lines, and yielded in [`ClickHouseSourceConfig::batch_size`]
+    /// pages. The final page carries the incremental bookmark (when replicating
+    /// incrementally) so the pipeline persists only after everything before it
+    /// is written.
+    fn stream_pages<'a>(
+        &'a self,
+        context: &'a HashMap<String, Value>,
+        _batch_size: usize,
+    ) -> Pin<Box<dyn Stream<Item = Result<StreamPage, FaucetError>> + Send + 'a>> {
+        let batch_size = self.config.batch_size;
+        let chunk = if batch_size == 0 {
+            usize::MAX
+        } else {
+            batch_size
+        };
+        let cap = if batch_size == 0 { 1024 } else { batch_size };
+        let start = self.current_start();
+        let (query, incr) = build_effective_query(&self.config, context, start.as_ref());
+
+        Box::pin(async_stream::try_stream! {
+            let resp = self.request(query).send().await?;
+            let resp = check_http_response(resp, DEFAULT_ERROR_BODY_MAX_LEN).await?;
+            let mut body = resp.bytes_stream();
+
+            let mut buf: Vec<u8> = Vec::new();
+            let mut page: Vec<Value> = Vec::with_capacity(cap);
+            let mut running_max: Option<Value> = None;
+            let mut total = 0usize;
+
+            while let Some(chunk_result) = body.next().await {
+                let bytes = chunk_result.map_err(FaucetError::Http)?;
+                buf.extend_from_slice(&bytes);
+                for line in split_complete_lines(&mut buf) {
+                    if let Some(value) = parse_line(&line)? {
+                        page.push(value);
+                        if page.len() >= chunk {
+                            let ready = std::mem::replace(&mut page, Vec::with_capacity(cap));
+                            let kept = apply_incremental(ready, incr.as_ref(), &mut running_max);
+                            total += kept.len();
+                            if !kept.is_empty() {
+                                yield StreamPage { records: kept, bookmark: None };
+                            }
+                        }
+                    }
+                }
+            }
+            // Trailing line without a terminating newline (ClickHouse always
+            // newline-terminates, but be robust).
+            if let Some(value) = parse_line(&buf)? {
+                page.push(value);
+            }
+
+            // Final page carries the bookmark.
+            let kept = apply_incremental(page, incr.as_ref(), &mut running_max);
+            total += kept.len();
+            let bookmark = if incr.is_some() { running_max.clone() } else { None };
+            if !kept.is_empty() || bookmark.is_some() {
+                yield StreamPage { records: kept, bookmark };
+            }
+
+            tracing::info!(rows = total, batch_size, query = %self.config.query, "ClickHouse source stream complete");
+        })
+    }
+
+    fn config_schema(&self) -> Value {
+        serde_json::to_value(faucet_core::schema_for!(ClickHouseSourceConfig))
+            .expect("schema serialization")
+    }
+
+    fn connector_name(&self) -> &'static str {
+        "clickhouse"
+    }
+
+    fn dataset_uri(&self) -> String {
+        format!(
+            "{}?query={}",
+            faucet_core::redact_uri_credentials(&self.base_url),
+            self.config.query
+        )
+    }
+
+    fn state_key(&self) -> Option<String> {
+        match &self.config.replication {
+            ClickHouseReplication::Full => None,
+            ClickHouseReplication::Incremental { .. } => Some(
+                self.config
+                    .state_key
+                    .clone()
+                    .unwrap_or_else(|| default_state_key(&self.config)),
+            ),
+        }
+    }
+
+    async fn apply_start_bookmark(&self, bookmark: Value) -> Result<(), FaucetError> {
+        *self
+            .start_bookmark
+            .lock()
+            .expect("start_bookmark mutex poisoned") = Some(bookmark);
+        Ok(())
+    }
+
+    /// Non-mutating preflight probe (`connect`): runs `SELECT 1` over the HTTP
+    /// interface.
+    async fn check(&self, ctx: &CheckContext) -> Result<CheckReport, FaucetError> {
+        let started = std::time::Instant::now();
+        let hint = "check url / host / database / credentials / that the server is reachable";
+        let req = self.request("SELECT 1".to_string());
+        let probe = match tokio::time::timeout(ctx.timeout, req.send()).await {
+            Ok(Ok(resp)) => match check_http_response(resp, DEFAULT_ERROR_BODY_MAX_LEN).await {
+                Ok(_) => Probe::pass("connect", started.elapsed()),
+                Err(e) => Probe::fail_hint("connect", started.elapsed(), e.to_string(), hint),
+            },
+            Ok(Err(e)) => Probe::fail_hint("connect", started.elapsed(), e.to_string(), hint),
+            Err(_) => Probe::fail_hint("connect", started.elapsed(), "timed out", hint),
+        };
+        Ok(CheckReport::single(probe))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn full_cfg() -> ClickHouseSourceConfig {
+        ClickHouseSourceConfig::new("http://db.example.com:8123", "SELECT * FROM t")
+    }
+
+    #[test]
+    fn build_full_returns_query_unchanged() {
+        let (q, incr) = build_effective_query(&full_cfg(), &HashMap::new(), None);
+        assert_eq!(q, "SELECT * FROM t");
+        assert!(incr.is_none());
+    }
+
+    #[test]
+    fn build_incremental_substitutes_bookmark_literal() {
+        let cfg = ClickHouseSourceConfig::new(
+            "http://h:8123",
+            "SELECT * FROM t WHERE updated_at > @bookmark",
+        )
+        .incremental("updated_at", json!("1970-01-01"));
+        let (q, incr) = build_effective_query(&cfg, &HashMap::new(), None);
+        assert_eq!(q, "SELECT * FROM t WHERE updated_at > '1970-01-01'");
+        assert_eq!(
+            incr,
+            Some(IncrementalCtx {
+                column: "updated_at".into(),
+                start: json!("1970-01-01"),
+            })
+        );
+    }
+
+    #[test]
+    fn build_incremental_prefers_stored_bookmark_over_initial() {
+        let cfg =
+            ClickHouseSourceConfig::new("http://h:8123", "SELECT * FROM t WHERE c > @bookmark")
+                .incremental("c", json!(0));
+        let stored = json!(500);
+        let (q, incr) = build_effective_query(&cfg, &HashMap::new(), Some(&stored));
+        assert_eq!(q, "SELECT * FROM t WHERE c > 500");
+        assert_eq!(incr.unwrap().start, json!(500));
+    }
+
+    #[test]
+    fn build_incremental_without_token_still_returns_filter_ctx() {
+        let cfg = ClickHouseSourceConfig::new("http://h:8123", "SELECT * FROM t")
+            .incremental("c", json!(0));
+        let (q, incr) = build_effective_query(&cfg, &HashMap::new(), None);
+        assert_eq!(q, "SELECT * FROM t");
+        assert!(incr.is_some(), "client-side filter must still run");
+    }
+
+    #[test]
+    fn context_substitution_uses_injection_safe_literals() {
+        let mut ctx = HashMap::new();
+        ctx.insert("tenant".to_string(), json!("ac'me"));
+        ctx.insert("id".to_string(), json!(7));
+        let cfg = ClickHouseSourceConfig::new(
+            "http://h:8123",
+            "SELECT * FROM t WHERE tenant = {tenant} AND id = {id}",
+        );
+        let (q, _incr) = build_effective_query(&cfg, &ctx, None);
+        assert!(q.contains("tenant = 'ac\\'me'"), "got: {q}");
+        assert!(q.contains("id = 7"), "got: {q}");
+    }
+
+    #[test]
+    fn apply_incremental_filters_and_tracks_max() {
+        let ctx = IncrementalCtx {
+            column: "c".into(),
+            start: json!(10),
+        };
+        let mut running = None;
+        let page = vec![json!({"c": 5}), json!({"c": 15}), json!({"c": 20})];
+        let kept = apply_incremental(page, Some(&ctx), &mut running);
+        assert_eq!(kept.len(), 2);
+        assert_eq!(running, Some(json!(20)));
+    }
+
+    #[test]
+    fn apply_incremental_full_passes_through() {
+        let mut running = None;
+        let page = vec![json!({"c": 1}), json!({"c": 2})];
+        let kept = apply_incremental(page, None, &mut running);
+        assert_eq!(kept.len(), 2);
+        assert_eq!(running, None);
+    }
+
+    #[test]
+    fn split_complete_lines_drains_full_lines_only() {
+        let mut buf = b"{\"a\":1}\n{\"a\":2}\n{\"a\":3".to_vec();
+        let lines = split_complete_lines(&mut buf);
+        assert_eq!(lines.len(), 2, "the unterminated tail stays buffered");
+        assert_eq!(lines[0], b"{\"a\":1}");
+        assert_eq!(buf, b"{\"a\":3", "partial line remains in the buffer");
+    }
+
+    #[test]
+    fn split_complete_lines_reassembles_across_chunks() {
+        // A line split across two network chunks is reassembled once the
+        // second chunk (carrying the newline) arrives.
+        let mut buf = b"{\"a\":".to_vec();
+        assert!(split_complete_lines(&mut buf).is_empty());
+        buf.extend_from_slice(b"1}\n");
+        let lines = split_complete_lines(&mut buf);
+        assert_eq!(lines, vec![b"{\"a\":1}".to_vec()]);
+    }
+
+    #[test]
+    fn parse_line_handles_blank_and_valid_and_invalid() {
+        assert_eq!(parse_line(b"").unwrap(), None);
+        assert_eq!(parse_line(b"   ").unwrap(), None);
+        assert_eq!(parse_line(b"{\"a\":1}").unwrap(), Some(json!({"a": 1})));
+        assert!(parse_line(b"not-json").is_err());
+    }
+
+    #[test]
+    fn parse_line_rejects_invalid_utf8() {
+        assert!(parse_line(&[0xff, 0xfe]).is_err());
+    }
+
+    #[test]
+    fn state_key_only_for_incremental_and_is_stable() {
+        let source = ClickHouseSource::new(full_cfg()).unwrap();
+        assert_eq!(source.state_key(), None, "full replication has no bookmark");
+
+        let cfg = ClickHouseSourceConfig::new("http://db.example.com:8123", "SELECT * FROM t")
+            .incremental("c", json!(0));
+        let source = ClickHouseSource::new(cfg).unwrap();
+        let k1 = source.state_key().unwrap();
+        let k2 = source.state_key().unwrap();
+        assert_eq!(k1, k2);
+        assert!(k1.starts_with("clickhouse:db.example.com:"), "got: {k1}");
+        faucet_core::state::validate_state_key(&k1).expect("derived key must be valid");
+    }
+
+    #[test]
+    fn explicit_state_key_overrides_default() {
+        let mut cfg = ClickHouseSourceConfig::new("http://h:8123", "SELECT * FROM t")
+            .incremental("c", json!(0));
+        cfg.state_key = Some("custom-key".into());
+        let source = ClickHouseSource::new(cfg).unwrap();
+        assert_eq!(source.state_key().as_deref(), Some("custom-key"));
+    }
+
+    #[tokio::test]
+    async fn apply_start_bookmark_overrides_initial() {
+        let cfg =
+            ClickHouseSourceConfig::new("http://h:8123", "SELECT * FROM t WHERE c > @bookmark")
+                .incremental("c", json!(0));
+        let source = ClickHouseSource::new(cfg).unwrap();
+        source.apply_start_bookmark(json!(999)).await.unwrap();
+        let (q, incr) = build_effective_query(
+            &source.config,
+            &HashMap::new(),
+            source.current_start().as_ref(),
+        );
+        assert_eq!(q, "SELECT * FROM t WHERE c > 999");
+        assert_eq!(incr.unwrap().start, json!(999));
+    }
+
+    #[test]
+    fn dataset_uri_has_no_credentials() {
+        let source = ClickHouseSource::new(full_cfg()).unwrap();
+        assert_eq!(
+            source.dataset_uri(),
+            "http://db.example.com:8123?query=SELECT * FROM t"
+        );
+    }
+
+    #[test]
+    fn connector_name_is_clickhouse() {
+        let source = ClickHouseSource::new(full_cfg()).unwrap();
+        assert_eq!(source.connector_name(), "clickhouse");
+    }
+
+    #[test]
+    fn config_schema_is_object() {
+        let source = ClickHouseSource::new(full_cfg()).unwrap();
+        assert_eq!(source.config_schema()["type"], "object");
+    }
+
+    #[test]
+    fn new_rejects_invalid_config() {
+        let cfg = ClickHouseSourceConfig::new("http://h:8123", "SELECT 1")
+            .with_batch_size(faucet_core::MAX_BATCH_SIZE + 1);
+        assert!(ClickHouseSource::new(cfg).is_err());
+    }
+
+    #[tokio::test]
+    async fn check_fails_against_unreachable_server() {
+        // Connection-refused on a closed local port exercises the check() I/O
+        // path offline (no external dependency).
+        let source = ClickHouseSource::new(ClickHouseSourceConfig::new(
+            "http://127.0.0.1:1",
+            "SELECT 1",
+        ))
+        .unwrap();
+        let ctx = CheckContext {
+            timeout: std::time::Duration::from_secs(2),
+        };
+        let report = source.check(&ctx).await.unwrap();
+        assert!(
+            matches!(
+                report.probes[0].status,
+                faucet_core::check::ProbeStatus::Fail { .. }
+            ),
+            "unreachable server must fail the connect probe"
+        );
+    }
+}

--- a/crates/source/clickhouse/tests/integration.rs
+++ b/crates/source/clickhouse/tests/integration.rs
@@ -1,0 +1,221 @@
+//! Integration tests against a real ClickHouse server in Docker.
+//!
+//! These **auto-start** a `clickhouse/clickhouse-server` container via
+//! `testcontainers` (no env var, not `#[ignore]`d), so they run in CI wherever
+//! Docker is present and count toward patch coverage. They exercise the
+//! streaming HTTP I/O paths in `src/stream.rs` — the `JSONEachRow` streaming
+//! decoder, line-buffering across chunks, `batch_size` paging, incremental
+//! `@bookmark` pushdown + resume, and the live `check()` probe — that the pure
+//! unit tests can't reach. Mirrors the postgres/mssql integration-test pattern.
+//!
+//! Run explicitly with:
+//! `cargo test -p faucet-source-clickhouse --test integration`.
+
+use std::collections::HashMap;
+
+use faucet_core::Source as _;
+use faucet_core::check::{CheckContext, ProbeStatus};
+use faucet_source_clickhouse::{ClickHouseSource, ClickHouseSourceConfig};
+use futures::StreamExt as _;
+use serde_json::{Value, json};
+use testcontainers_modules::clickhouse::ClickHouse;
+use testcontainers_modules::testcontainers::ContainerAsync;
+use testcontainers_modules::testcontainers::runners::AsyncRunner;
+
+// Serialize container starts so at most one runs at a time on a small CI runner.
+static SERIAL: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+async fn start_clickhouse() -> (ContainerAsync<ClickHouse>, String) {
+    let container = ClickHouse::default()
+        .start()
+        .await
+        .expect("start clickhouse container");
+    let port = container
+        .get_host_port_ipv4(8123)
+        .await
+        .expect("clickhouse host port");
+    let base = format!("http://127.0.0.1:{port}");
+    (container, base)
+}
+
+/// POST a statement over the HTTP interface, asserting a 2xx. Used for DDL and
+/// seeding rows out-of-band from the source under test.
+async fn http_exec(base: &str, sql: &str) {
+    let resp = reqwest::Client::new()
+        .post(base)
+        .body(sql.to_string())
+        .send()
+        .await
+        .expect("http exec send");
+    let status = resp.status();
+    let body = resp.text().await.unwrap_or_default();
+    assert!(
+        status.is_success(),
+        "statement failed ({status}): {sql}\n{body}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fetch_all_decodes_types_and_stream_pages_chunk() {
+    let _serial = SERIAL.lock().await;
+    let (_c, base) = start_clickhouse().await;
+
+    http_exec(
+        &base,
+        "CREATE TABLE types_test (id UInt32, name String, score Float64, flag Bool) \
+         ENGINE = MergeTree ORDER BY id",
+    )
+    .await;
+    http_exec(
+        &base,
+        "INSERT INTO types_test FORMAT JSONEachRow \
+         {\"id\":1,\"name\":\"alice\",\"score\":1.5,\"flag\":true}",
+    )
+    .await;
+
+    // fetch_all drives the buffered collect_all path + JSONEachRow decode.
+    let source = ClickHouseSource::new(ClickHouseSourceConfig::new(
+        &base,
+        "SELECT id, name, score, flag FROM types_test ORDER BY id",
+    ))
+    .expect("source");
+    let rows = source.fetch_all().await.expect("fetch_all");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["id"], json!(1));
+    assert_eq!(rows[0]["name"], json!("alice"));
+    assert_eq!(rows[0]["score"], json!(1.5));
+    assert_eq!(rows[0]["flag"], json!(true));
+
+    // Streaming: 5 rows at batch_size 2 -> pages of 2, 2, 1. This exercises the
+    // streaming decoder, line-buffering, and page-boundary logic in stream_pages.
+    http_exec(
+        &base,
+        "CREATE TABLE nums (n UInt32) ENGINE = MergeTree ORDER BY n",
+    )
+    .await;
+    let vals: Vec<String> = (1..=5).map(|n| format!("{{\"n\":{n}}}")).collect();
+    http_exec(
+        &base,
+        &format!("INSERT INTO nums FORMAT JSONEachRow {}", vals.join(" ")),
+    )
+    .await;
+
+    let source = ClickHouseSource::new(
+        ClickHouseSourceConfig::new(&base, "SELECT n FROM nums ORDER BY n").with_batch_size(2),
+    )
+    .expect("source");
+    let ctx: HashMap<String, Value> = HashMap::new();
+    let pages: Vec<_> = source
+        .stream_pages(&ctx, 2)
+        .map(|p| p.expect("page"))
+        .collect()
+        .await;
+    let sizes: Vec<usize> = pages.iter().map(|p| p.records.len()).collect();
+    assert_eq!(sizes, vec![2, 2, 1], "batch_size=2 over 5 rows");
+    let all: Vec<i64> = pages
+        .iter()
+        .flat_map(|p| p.records.iter())
+        .map(|r| r["n"].as_i64().unwrap())
+        .collect();
+    assert_eq!(all, vec![1, 2, 3, 4, 5]);
+    // Full replication carries no bookmark on any page.
+    assert!(pages.iter().all(|p| p.bookmark.is_none()));
+
+    // A live connect probe.
+    let probe_ctx = CheckContext {
+        timeout: std::time::Duration::from_secs(5),
+    };
+    let report = source.check(&probe_ctx).await.expect("check");
+    assert!(
+        matches!(report.probes[0].status, ProbeStatus::Pass),
+        "connect probe against a live server must pass: {:?}",
+        report.probes[0].status
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn incremental_pushdown_and_resume() {
+    let _serial = SERIAL.lock().await;
+    let (_c, base) = start_clickhouse().await;
+
+    http_exec(
+        &base,
+        "CREATE TABLE events (id UInt32, updated_at String) ENGINE = MergeTree ORDER BY id",
+    )
+    .await;
+    http_exec(
+        &base,
+        "INSERT INTO events FORMAT JSONEachRow \
+         {\"id\":1,\"updated_at\":\"2024-01-01\"} \
+         {\"id\":2,\"updated_at\":\"2024-02-01\"} \
+         {\"id\":3,\"updated_at\":\"2024-03-01\"}",
+    )
+    .await;
+
+    // `@bookmark` is substituted server-side as an injection-safe literal, and
+    // the source also filters client-side. initial_value 2024-01-15 -> rows
+    // 2024-02-01 and 2024-03-01, bookmark = the new max.
+    let source = ClickHouseSource::new(
+        ClickHouseSourceConfig::new(
+            &base,
+            "SELECT id, updated_at FROM events WHERE updated_at > @bookmark ORDER BY updated_at",
+        )
+        .incremental("updated_at", json!("2024-01-15")),
+    )
+    .expect("source");
+
+    let (rows, bookmark) = source.fetch_all_incremental().await.expect("run 1");
+    let ids: Vec<i64> = rows.iter().map(|r| r["id"].as_i64().unwrap()).collect();
+    assert_eq!(ids, vec![2, 3], "run 1 honours initial_value pushdown");
+    assert_eq!(bookmark, Some(json!("2024-03-01")));
+
+    // Persist the bookmark, add a newer row, run again — no duplicates.
+    source
+        .apply_start_bookmark(bookmark.unwrap())
+        .await
+        .expect("apply bookmark");
+    http_exec(
+        &base,
+        "INSERT INTO events FORMAT JSONEachRow {\"id\":4,\"updated_at\":\"2024-04-01\"}",
+    )
+    .await;
+
+    let (rows2, bookmark2) = source.fetch_all_incremental().await.expect("run 2");
+    let ids2: Vec<i64> = rows2.iter().map(|r| r["id"].as_i64().unwrap()).collect();
+    assert_eq!(ids2, vec![4], "run 2 resumes from bookmark, no duplicates");
+    assert_eq!(bookmark2, Some(json!("2024-04-01")));
+
+    // The streaming path carries the incremental bookmark on its final page.
+    // A fresh source (initial_value 2024-01-15) sees rows 2,3,4.
+    let stream_source = ClickHouseSource::new(
+        ClickHouseSourceConfig::new(
+            &base,
+            "SELECT id, updated_at FROM events WHERE updated_at > @bookmark ORDER BY updated_at",
+        )
+        .incremental("updated_at", json!("2024-01-15")),
+    )
+    .expect("stream source");
+    let ctx: HashMap<String, Value> = HashMap::new();
+    let pages: Vec<_> = stream_source
+        .stream_pages(&ctx, 1000)
+        .map(|p| p.expect("page"))
+        .collect()
+        .await;
+    let streamed: Vec<i64> = pages
+        .iter()
+        .flat_map(|p| p.records.iter())
+        .map(|r| r["id"].as_i64().unwrap())
+        .collect();
+    assert_eq!(streamed, vec![2, 3, 4]);
+    assert_eq!(
+        pages.last().and_then(|p| p.bookmark.clone()),
+        Some(json!("2024-04-01")),
+        "final streamed page carries the incremental bookmark"
+    );
+
+    // state_key is stable and derived for incremental replication.
+    assert!(
+        stream_source.state_key().is_some(),
+        "incremental replication must expose a bookmark state key"
+    );
+}

--- a/crates/source/mssql-cdc/Cargo.toml
+++ b/crates/source/mssql-cdc/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "faucet-source-mssql-cdc"
+version = "1.0.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Microsoft SQL Server CDC (change data capture) source for the faucet-stream ecosystem"
+readme = "README.md"
+keywords = ["mssql", "cdc", "sqlserver", "replication", "connector"]
+categories.workspace = true
+
+[dependencies]
+faucet-core.workspace = true
+faucet-common-mssql.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+schemars.workspace = true
+async-trait.workspace = true
+tracing.workspace = true
+tiberius.workspace = true
+chrono.workspace = true
+base64.workspace = true
+url.workspace = true
+futures.workspace = true
+async-stream.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }
+
+[dev-dependencies]
+faucet-conformance.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time", "test-util"] }
+serde_json.workspace = true
+schemars.workspace = true
+futures.workspace = true
+testcontainers = "0.27"
+testcontainers-modules = { version = "0.15", features = ["mssql_server"] }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/source/mssql-cdc/README.md
+++ b/crates/source/mssql-cdc/README.md
@@ -1,0 +1,127 @@
+# faucet-source-mssql-cdc
+
+Microsoft SQL Server **CDC (change data capture)** source for the
+[`faucet-stream`](https://crates.io/crates/faucet-stream) ecosystem.
+
+It polls native SQL Server change data capture — `sys.fn_cdc_get_max_lsn()` for
+the high-water LSN, then `cdc.fn_cdc_get_all_changes_<capture_instance>()` per
+configured capture instance — and emits per-row change events as CDC envelopes.
+Progress is a durable, per-capture-instance **LSN bookmark**, so a resumed run
+never re-reads an already-committed change.
+
+## Highlights
+
+- **Native CDC, LSN-driven.** Advances by Log Sequence Number using the built-in
+  `cdc.fn_cdc_get_all_changes_*` table-valued functions — no triggers, no
+  polling of the base table.
+- **Per-transaction durability.** Change rows are buffered by commit LSN
+  (`__$start_lsn`); each committed transaction is emitted as its own
+  `StreamPage` with a bookmark, so nothing partially-visible ever leaks.
+- **Resumable & exactly-once capable.** The bookmark is a monotonic LSN; on
+  resume the next poll starts at `increment(bookmark)`. `supports_exactly_once()`
+  is `true`, and `capture_resume_position()` anchors CDC before a bulk snapshot
+  for `faucet replicate`.
+- **Preflight checks.** `new()` (and `faucet doctor`) verify CDC is enabled on
+  the database and that every configured capture instance exists, with
+  actionable errors.
+
+## Configuration
+
+```yaml
+pipeline:
+  source:
+    type: mssql-cdc
+    config:
+      # faucet-common-mssql connection block (connection_url OR connection_string + tls)
+      connection_url: "mssql://faucet:${env:MSSQL_PASSWORD}@sqlserver:1433/sales"
+      tls: { type: trust_server_certificate }
+
+      capture_instances: ["dbo_Orders", "dbo_Items"]  # required, non-empty
+      start_position: { type: current }                # current (default) | earliest
+      poll_interval: 1                                 # seconds between empty polls
+      idle_timeout: 30                                 # end the fetch cycle after this much quiet
+      batch_size: 1000                                 # 0 = one aggregate page (test/snapshot)
+      max_staged_records: 500000                       # cap one in-progress transaction
+      max_connections: 5
+      statement_timeout_secs: 300
+      # state_key: "mssql-cdc:sales:dbo_Orders"        # optional override
+```
+
+| Field | Default | Notes |
+|-------|---------|-------|
+| `capture_instances` | — (required) | Capture-instance names (`sys.sp_cdc_enable_table` defaults to `<schema>_<table>`). Only `[A-Za-z0-9_]` accepted (injected into the function name). |
+| `start_position` | `current` | `current` skips existing history; `earliest` replays whatever the CDC cleanup job still retains. Ignored once a bookmark exists. |
+| `poll_interval` | `1s` | Wait between empty polls. |
+| `idle_timeout` | `30s` | End the fetch cycle after this much continuous quiet. A long-running runtime (`faucet schedule` / `faucet serve`) re-invokes to keep tailing. |
+| `batch_size` | `1000` | `0` accumulates every change into a single trailing page. |
+| `max_staged_records` | unbounded | Abort (typed error) if one in-progress transaction buffers more than this. |
+| `state_key` | derived | `mssql-cdc:<db>:<capture_instance>` for one instance, else `mssql-cdc:<db>:<digest>`. |
+
+### Prerequisites
+
+Change data capture must be enabled on the server (requires sysadmin, and SQL
+Server Agent running for the capture job to populate the change tables):
+
+```sql
+EXEC sys.sp_cdc_enable_db;
+EXEC sys.sp_cdc_enable_table
+    @source_schema = N'dbo',
+    @source_name   = N'Orders',
+    @role_name     = NULL,
+    @capture_instance = N'dbo_Orders';
+```
+
+## Change envelope
+
+Each row becomes a CDC envelope with a normalized `op` marker mapped from
+`__$operation`:
+
+| `__$operation` | meaning | `op` |
+|----------------|---------|------|
+| 1 | delete | `d` |
+| 2 | insert | `i` |
+| 3 | update (before image) | *skipped* |
+| 4 | update (after image) | `u` |
+
+```json
+{
+  "op": "i",
+  "schema": "dbo",
+  "table": "Orders",
+  "before": null,
+  "after": { "id": 1, "amount": "9.99" },
+  "lsn": "0000002a000000550003",
+  "seqval": "0000002a000000550003"
+}
+```
+
+Deletes carry the removed row in `before`; inserts and updates carry the current
+image in `after` (the source queries in `N'all'` mode, so an update's pre-image
+is not emitted).
+
+## Mirroring to an upsert sink
+
+Pair the envelope with the `cdc_unwrap` transform stage (which normalizes `op`
+into `__op: "u"`/`"d"` and flattens `after`/`before`) and an upsert-capable sink
+to build a live mirror:
+
+```yaml
+pipeline:
+  transforms:
+    - type: cdc_unwrap
+  source:
+    type: mssql-cdc
+    config: { connection_url: "...", capture_instances: ["dbo_Orders"] }
+  sink:
+    type: postgres
+    config:
+      connection_url: "..."
+      table: orders
+      write_mode: upsert
+      key: ["id"]
+      delete_marker: { field: "__op", values: ["d"] }
+```
+
+## License
+
+Licensed under either of Apache-2.0 or MIT at your option.

--- a/crates/source/mssql-cdc/src/change.rs
+++ b/crates/source/mssql-cdc/src/change.rs
@@ -1,0 +1,366 @@
+//! Pure change-shaping logic: operation-code normalization, the per-poll LSN
+//! range plan, and CDC-envelope assembly. No I/O — every function here is
+//! unit-tested without a live server, because these decisions are load-bearing
+//! for correctness (a wrong op mapping or range bound silently corrupts the
+//! downstream mirror).
+
+use serde_json::{Map, Value, json};
+
+use crate::config::StartPosition;
+use crate::lsn::Lsn;
+
+/// Alias we add to the change query so the commit LSN arrives as a hex string.
+pub const LSN_ALIAS: &str = "__faucet_lsn";
+/// Alias we add so the row sequence value arrives as a hex string.
+pub const SEQVAL_ALIAS: &str = "__faucet_seqval";
+/// The CDC operation column returned by `fn_cdc_get_all_changes`.
+pub const OP_COLUMN: &str = "__$operation";
+
+/// What to do with a CDC change row, from its `__$operation` code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OpAction {
+    /// Emit a change envelope with this normalized `__op` marker.
+    Emit(&'static str),
+    /// Skip the row (the before-image half of an update, `__$operation = 3`).
+    Skip,
+}
+
+/// Normalize a SQL Server `__$operation` code into a change action.
+///
+/// | code | meaning              | `__op` |
+/// |------|----------------------|--------|
+/// | 1    | delete               | `d`    |
+/// | 2    | insert               | `i`    |
+/// | 3    | update (before image)| *skip* |
+/// | 4    | update (after image) | `u`    |
+///
+/// `i`/`u` are non-delete markers so the `cdc_unwrap` stage treats them as
+/// upserts; `d` matches its default delete vocabulary. The source queries in
+/// `N'all'` mode (codes 1/2/4 only), but code 3 is still handled defensively so
+/// an `all update old` result never panics.
+pub fn op_action(operation: i64) -> Result<OpAction, faucet_core::FaucetError> {
+    match operation {
+        1 => Ok(OpAction::Emit("d")),
+        2 => Ok(OpAction::Emit("i")),
+        3 => Ok(OpAction::Skip),
+        4 => Ok(OpAction::Emit("u")),
+        other => Err(faucet_core::FaucetError::Source(format!(
+            "mssql-cdc: unrecognized __$operation code {other} (expected 1, 2, 3, or 4)"
+        ))),
+    }
+}
+
+/// The plan for one capture-instance poll, derived purely from the current
+/// bookmark and the instance's min/max LSN bounds.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PollPlan {
+    /// No range to query this poll. `set_bookmark` is `Some` only on a fresh
+    /// `current` start, where we anchor the bookmark at the live max LSN so
+    /// history is skipped and future polls resume from there.
+    NoChanges { set_bookmark: Option<Lsn> },
+    /// Query the half-open-on-the-low-end range `[from, to]` (the CDC function
+    /// is inclusive of both ends; `from` is already `increment(bookmark)` so the
+    /// last committed change is not re-read). `gap` is `true` when the resume
+    /// point fell before the retained minimum LSN (the cleanup job purged
+    /// changes) — the caller warns loudly.
+    Query { from: Lsn, to: Lsn, gap: bool },
+}
+
+/// Decide what to poll for a capture instance.
+///
+/// - `bookmark`: last committed LSN for this instance (`None` on a fresh run).
+/// - `min_lsn` / `max_lsn`: the instance's retained range (`None` when CDC has
+///   produced nothing yet, or the capture instance is not yet active).
+pub fn plan_poll(
+    bookmark: Option<Lsn>,
+    min_lsn: Option<Lsn>,
+    max_lsn: Option<Lsn>,
+    start: StartPosition,
+) -> PollPlan {
+    // No max LSN => no change activity yet; nothing to do, keep the bookmark.
+    let Some(to) = max_lsn else {
+        return PollPlan::NoChanges { set_bookmark: None };
+    };
+    // No min LSN alongside a max is anomalous (min briefly unavailable); skip.
+    let Some(min) = min_lsn else {
+        return PollPlan::NoChanges { set_bookmark: None };
+    };
+
+    // Determine the candidate lower bound.
+    let candidate = match bookmark {
+        // Resume strictly after the last committed change.
+        Some(bm) => match bm.increment() {
+            Some(next) => next,
+            // Unreachable saturation; nothing sensible to read.
+            None => return PollPlan::NoChanges { set_bookmark: None },
+        },
+        None => match start {
+            // Skip history: anchor at the current max, emit nothing this poll.
+            StartPosition::Current => {
+                return PollPlan::NoChanges {
+                    set_bookmark: Some(to),
+                };
+            }
+            // Replay whatever history is still retained.
+            StartPosition::Earliest => min,
+        },
+    };
+
+    // Nothing new committed since the bookmark.
+    if candidate > to {
+        return PollPlan::NoChanges { set_bookmark: None };
+    }
+
+    // If the resume point predates the retained minimum, the cleanup job removed
+    // changes we never read — clamp forward and flag the gap.
+    if candidate < min {
+        return PollPlan::Query {
+            from: min,
+            to,
+            gap: true,
+        };
+    }
+
+    PollPlan::Query {
+        from: candidate,
+        to,
+        gap: false,
+    }
+}
+
+/// Split a decoded change row's columns into the business columns (the table's
+/// own columns) and drop every CDC metadata / helper column (`__$*` and the
+/// `__faucet_lsn` alias). Pure.
+pub fn business_columns(decoded: &Value) -> Map<String, Value> {
+    let mut out = Map::new();
+    if let Value::Object(map) = decoded {
+        for (k, v) in map {
+            if k == LSN_ALIAS || k == SEQVAL_ALIAS || k.starts_with("__$") {
+                continue;
+            }
+            out.insert(k.clone(), v.clone());
+        }
+    }
+    out
+}
+
+/// Build a CDC change-event envelope for one row.
+///
+/// Delete rows carry the removed values in `before` (so a downstream
+/// `cdc_unwrap` delete can key off them); insert/update rows carry the current
+/// image in `after`. The source queries in `N'all'` mode, so an update's
+/// pre-image is not available and `before` is null for inserts and updates.
+///
+/// ```json
+/// { "op": "i", "schema": "dbo", "table": "Orders",
+///   "before": null, "after": {"id": 1, "amount": 9.99},
+///   "lsn": "0000002a000000550003", "seqval": "0000002a0000005500..." }
+/// ```
+pub fn build_change_envelope(
+    op: &str,
+    schema: &str,
+    table: &str,
+    lsn_hex: &str,
+    seqval_hex: Option<&str>,
+    columns: Map<String, Value>,
+) -> Value {
+    let is_delete = op == "d";
+    let (before, after) = if is_delete {
+        (Value::Object(columns), Value::Null)
+    } else {
+        (Value::Null, Value::Object(columns))
+    };
+
+    let mut obj = Map::new();
+    obj.insert("op".into(), json!(op));
+    obj.insert("schema".into(), json!(schema));
+    obj.insert("table".into(), json!(table));
+    obj.insert("before".into(), before);
+    obj.insert("after".into(), after);
+    obj.insert("lsn".into(), json!(lsn_hex));
+    if let Some(seq) = seqval_hex {
+        obj.insert("seqval".into(), json!(seq));
+    }
+    Value::Object(obj)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lsn(hex: &str) -> Lsn {
+        Lsn::from_hex(hex).unwrap()
+    }
+
+    // ── op_action: all four codes + unknown ───────────────────────────────────
+
+    #[test]
+    fn op_action_maps_all_codes() {
+        assert_eq!(op_action(1).unwrap(), OpAction::Emit("d"));
+        assert_eq!(op_action(2).unwrap(), OpAction::Emit("i"));
+        assert_eq!(op_action(3).unwrap(), OpAction::Skip);
+        assert_eq!(op_action(4).unwrap(), OpAction::Emit("u"));
+    }
+
+    #[test]
+    fn op_action_rejects_unknown_code() {
+        let err = op_action(7).unwrap_err();
+        assert!(err.to_string().contains("__$operation code 7"), "{err}");
+        assert!(op_action(0).is_err());
+    }
+
+    // ── plan_poll ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn plan_no_max_lsn_is_no_changes() {
+        let p = plan_poll(
+            None,
+            Some(lsn("00000000000000000001")),
+            None,
+            StartPosition::Earliest,
+        );
+        assert_eq!(p, PollPlan::NoChanges { set_bookmark: None });
+    }
+
+    #[test]
+    fn plan_fresh_current_anchors_at_max() {
+        let max = lsn("00000000000000000100");
+        let p = plan_poll(
+            None,
+            Some(lsn("00000000000000000001")),
+            Some(max),
+            StartPosition::Current,
+        );
+        assert_eq!(
+            p,
+            PollPlan::NoChanges {
+                set_bookmark: Some(max)
+            }
+        );
+    }
+
+    #[test]
+    fn plan_fresh_earliest_queries_from_min() {
+        let min = lsn("00000000000000000005");
+        let max = lsn("00000000000000000100");
+        let p = plan_poll(None, Some(min), Some(max), StartPosition::Earliest);
+        assert_eq!(
+            p,
+            PollPlan::Query {
+                from: min,
+                to: max,
+                gap: false
+            }
+        );
+    }
+
+    #[test]
+    fn plan_resume_queries_from_increment() {
+        let bm = lsn("00000000000000000010");
+        let min = lsn("00000000000000000001");
+        let max = lsn("00000000000000000100");
+        let p = plan_poll(Some(bm), Some(min), Some(max), StartPosition::Current);
+        assert_eq!(
+            p,
+            PollPlan::Query {
+                from: bm.increment().unwrap(),
+                to: max,
+                gap: false
+            }
+        );
+    }
+
+    #[test]
+    fn plan_resume_no_new_changes() {
+        // bookmark == max: increment(bookmark) > max => nothing new.
+        let bm = lsn("00000000000000000100");
+        let min = lsn("00000000000000000001");
+        let max = lsn("00000000000000000100");
+        let p = plan_poll(Some(bm), Some(min), Some(max), StartPosition::Current);
+        assert_eq!(p, PollPlan::NoChanges { set_bookmark: None });
+    }
+
+    #[test]
+    fn plan_resume_before_min_flags_gap_and_clamps() {
+        // Cleanup purged past our bookmark: increment(bm) < min.
+        let bm = lsn("00000000000000000001");
+        let min = lsn("00000000000000000050");
+        let max = lsn("00000000000000000100");
+        let p = plan_poll(Some(bm), Some(min), Some(max), StartPosition::Current);
+        assert_eq!(
+            p,
+            PollPlan::Query {
+                from: min,
+                to: max,
+                gap: true
+            }
+        );
+    }
+
+    // ── envelope shaping ──────────────────────────────────────────────────────
+
+    #[test]
+    fn business_columns_strips_metadata() {
+        let decoded = json!({
+            "__faucet_lsn": "00000000000000000001",
+            "__faucet_seqval": "00000000000000000001",
+            "__$start_lsn": "AAAA",
+            "__$operation": 2,
+            "__$seqval": "BBBB",
+            "__$update_mask": "CC",
+            "id": 1,
+            "name": "alice"
+        });
+        let cols = business_columns(&decoded);
+        assert_eq!(cols.len(), 2);
+        assert_eq!(cols["id"], json!(1));
+        assert_eq!(cols["name"], json!("alice"));
+        assert!(!cols.contains_key("__$operation"));
+        assert!(!cols.contains_key("__faucet_lsn"));
+        assert!(!cols.contains_key("__faucet_seqval"));
+    }
+
+    #[test]
+    fn insert_envelope_puts_columns_in_after() {
+        let mut cols = Map::new();
+        cols.insert("id".into(), json!(1));
+        let env = build_change_envelope(
+            "i",
+            "dbo",
+            "Orders",
+            "00000000000000000003",
+            Some("0000000000000000000300"),
+            cols,
+        );
+        assert_eq!(env["op"], "i");
+        assert_eq!(env["schema"], "dbo");
+        assert_eq!(env["table"], "Orders");
+        assert_eq!(env["before"], Value::Null);
+        assert_eq!(env["after"]["id"], json!(1));
+        assert_eq!(env["lsn"], "00000000000000000003");
+        assert_eq!(env["seqval"], "0000000000000000000300");
+    }
+
+    #[test]
+    fn delete_envelope_puts_columns_in_before() {
+        let mut cols = Map::new();
+        cols.insert("id".into(), json!(42));
+        let env = build_change_envelope("d", "dbo", "Orders", "00000000000000000004", None, cols);
+        assert_eq!(env["op"], "d");
+        assert_eq!(env["before"]["id"], json!(42));
+        assert_eq!(env["after"], Value::Null);
+        // seqval omitted when not supplied.
+        assert!(env.as_object().unwrap().get("seqval").is_none());
+    }
+
+    #[test]
+    fn update_envelope_is_upsert_after() {
+        let mut cols = Map::new();
+        cols.insert("id".into(), json!(1));
+        cols.insert("name".into(), json!("bob"));
+        let env = build_change_envelope("u", "dbo", "Orders", "00000000000000000005", None, cols);
+        assert_eq!(env["op"], "u");
+        assert_eq!(env["before"], Value::Null);
+        assert_eq!(env["after"]["name"], "bob");
+    }
+}

--- a/crates/source/mssql-cdc/src/config.rs
+++ b/crates/source/mssql-cdc/src/config.rs
@@ -1,0 +1,442 @@
+//! Configuration for [`MssqlCdcSource`](crate::MssqlCdcSource).
+
+use std::fmt;
+use std::time::Duration;
+
+use faucet_common_mssql::MssqlConnectionConfig;
+use faucet_core::{DEFAULT_BATCH_SIZE, FaucetError, validate_batch_size};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+fn default_poll_interval() -> Duration {
+    Duration::from_secs(1)
+}
+fn default_idle_timeout() -> Duration {
+    Duration::from_secs(30)
+}
+fn default_batch_size() -> usize {
+    DEFAULT_BATCH_SIZE
+}
+fn default_max_connections() -> u32 {
+    5
+}
+fn default_statement_timeout_secs() -> u64 {
+    300
+}
+
+/// Where to start reading changes on a fresh run (no persisted bookmark).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum StartPosition {
+    /// Start at the database's current maximum LSN — skip all pre-existing
+    /// change history and only capture changes committed after the source
+    /// starts. Default.
+    #[default]
+    Current,
+    /// Start at the earliest LSN still retained by the CDC capture instance
+    /// (`sys.fn_cdc_get_min_lsn`), replaying whatever history the cleanup job
+    /// has not yet purged.
+    Earliest,
+}
+
+/// Configuration for the Microsoft SQL Server CDC source.
+///
+/// The source polls native SQL Server change data capture: `sys.fn_cdc_get_max_lsn()`
+/// for the high-water LSN, then `cdc.fn_cdc_get_all_changes_<capture_instance>()`
+/// per configured capture instance, advancing a durable per-instance LSN bookmark.
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
+pub struct MssqlCdcSourceConfig {
+    /// Connection + TLS settings (`connection_url` or `connection_string`).
+    #[serde(flatten)]
+    pub connection: MssqlConnectionConfig,
+    /// Capture instances to poll (e.g. `dbo_Orders`). **Required and non-empty.**
+    ///
+    /// A capture instance is created by `sys.sp_cdc_enable_table` and defaults to
+    /// `<schema>_<table>`. Names are used verbatim to build the
+    /// `cdc.fn_cdc_get_all_changes_<name>` table-valued function call, so v1 only
+    /// accepts the SQL Server identifier characters `[A-Za-z0-9_]` (validated at
+    /// load time) to prevent injection into the function name.
+    pub capture_instances: Vec<String>,
+    /// Start position on a fresh run (ignored once a bookmark exists). Default
+    /// `current` (skip existing history).
+    #[serde(default)]
+    pub start_position: StartPosition,
+    /// Seconds to wait between empty polls (no new changes). Default 1s.
+    #[serde(
+        default = "default_poll_interval",
+        with = "faucet_core::config::duration_secs"
+    )]
+    #[schemars(with = "u64")]
+    pub poll_interval: Duration,
+    /// Terminator: end the fetch cycle after this much continuous quiet (no
+    /// change rows across any capture instance). Default 30s. A long-running
+    /// runtime (`faucet schedule` / `faucet serve`) re-invokes the source to
+    /// keep tailing.
+    #[serde(
+        default = "default_idle_timeout",
+        with = "faucet_core::config::duration_secs"
+    )]
+    #[schemars(with = "u64")]
+    pub idle_timeout: Duration,
+    /// Max records buffered for a single in-progress transaction before the run
+    /// aborts with a typed error (rather than risking unbounded memory growth).
+    /// `None` = unbounded.
+    #[serde(default)]
+    pub max_staged_records: Option<usize>,
+    /// Advisory per-page record count. `0` accumulates every change into a
+    /// single trailing page (snapshot/test convenience). Default
+    /// [`DEFAULT_BATCH_SIZE`].
+    #[serde(default = "default_batch_size")]
+    pub batch_size: usize,
+    /// Maximum pooled connections. Defaults to 5.
+    #[serde(default = "default_max_connections")]
+    pub max_connections: u32,
+    /// Per-query timeout in seconds (`0` disables). Defaults to 300.
+    #[serde(default = "default_statement_timeout_secs")]
+    pub statement_timeout_secs: u64,
+    /// Explicit state-store key for the LSN bookmark. When unset, a key is
+    /// derived from the database (or host) and the sorted capture-instance list.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state_key: Option<String>,
+}
+
+impl MssqlCdcSourceConfig {
+    /// Validate fail-fast invariants. Called from [`MssqlCdcSource::new`](crate::MssqlCdcSource::new).
+    pub fn validate(&self) -> Result<(), FaucetError> {
+        self.connection.validate()?;
+        if self.capture_instances.is_empty() {
+            return Err(FaucetError::Config(
+                "mssql-cdc: `capture_instances` must list at least one CDC capture instance".into(),
+            ));
+        }
+        for ci in &self.capture_instances {
+            validate_capture_instance(ci)?;
+        }
+        // Duplicate capture instances would double-emit and fight over the same
+        // bookmark map entry — reject them up front.
+        let mut seen = std::collections::BTreeSet::new();
+        for ci in &self.capture_instances {
+            if !seen.insert(ci) {
+                return Err(FaucetError::Config(format!(
+                    "mssql-cdc: duplicate capture instance {ci:?} in `capture_instances`"
+                )));
+            }
+        }
+        if self.poll_interval.is_zero() {
+            return Err(FaucetError::Config(
+                "mssql-cdc: poll_interval must be > 0".into(),
+            ));
+        }
+        if self.idle_timeout.is_zero() {
+            return Err(FaucetError::Config(
+                "mssql-cdc: idle_timeout must be > 0".into(),
+            ));
+        }
+        validate_batch_size(self.batch_size)?;
+        let key = self.resolved_state_key();
+        faucet_core::state::validate_state_key(&key)?;
+        Ok(())
+    }
+
+    /// The state-store key for this source's LSN bookmark map. Uses the explicit
+    /// `state_key` override when set, otherwise a derived, stable key.
+    pub fn resolved_state_key(&self) -> String {
+        self.state_key
+            .clone()
+            .unwrap_or_else(|| derive_state_key(self))
+    }
+}
+
+/// Validate a capture-instance name: non-empty, ≤128 chars, and only the SQL
+/// Server identifier characters `[A-Za-z0-9_]`. The name is interpolated into
+/// the `cdc.fn_cdc_get_all_changes_<name>` function identifier (which cannot be
+/// bracket-quoted mid-name), so this is the injection guard.
+pub(crate) fn validate_capture_instance(ci: &str) -> Result<(), FaucetError> {
+    if ci.is_empty() {
+        return Err(FaucetError::Config(
+            "mssql-cdc: capture instance name must not be empty".into(),
+        ));
+    }
+    if ci.len() > 128 {
+        return Err(FaucetError::Config(format!(
+            "mssql-cdc: capture instance name {ci:?} exceeds 128 characters"
+        )));
+    }
+    if !ci.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+        return Err(FaucetError::Config(format!(
+            "mssql-cdc: capture instance name {ci:?} may only contain letters, digits, and \
+             underscores (SQL Server identifier characters); other characters are unsupported in v1"
+        )));
+    }
+    Ok(())
+}
+
+/// Derive a stable state key from the target database (or connection host) plus
+/// a fingerprint of the sorted capture-instance list. Pure so it is unit-testable.
+///
+/// - Single instance: `mssql-cdc:<db-or-host>:<capture_instance>` (readable).
+/// - Multiple instances: `mssql-cdc:<db-or-host>:<fnv1a-hex>` (stable digest).
+pub(crate) fn derive_state_key(config: &MssqlCdcSourceConfig) -> String {
+    let scope = database_or_host(config);
+
+    if config.capture_instances.len() == 1 {
+        return format!("mssql-cdc:{scope}:{}", config.capture_instances[0]);
+    }
+
+    let mut sorted: Vec<&str> = config
+        .capture_instances
+        .iter()
+        .map(String::as_str)
+        .collect();
+    sorted.sort_unstable();
+    let digest = fnv1a_hex(&sorted.join(","));
+    format!("mssql-cdc:{scope}:{digest}")
+}
+
+/// Extract the target database name (preferred) or connection host for the state
+/// key scope, sanitising to key-safe characters. Falls back to `mssql`.
+fn database_or_host(config: &MssqlCdcSourceConfig) -> String {
+    let raw = config
+        .connection
+        .connection_url
+        .as_deref()
+        .and_then(|u| url::Url::parse(u).ok())
+        .and_then(|u| {
+            let db = u.path().trim_start_matches('/').to_string();
+            if !db.is_empty() {
+                Some(db)
+            } else {
+                u.host_str().map(str::to_string)
+            }
+        })
+        .or_else(|| {
+            config
+                .connection
+                .connection_string
+                .as_deref()
+                .and_then(database_from_ado_string)
+        })
+        .unwrap_or_else(|| "mssql".to_string());
+
+    let sanitised: String = raw
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.') {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    if sanitised.is_empty() {
+        "mssql".to_string()
+    } else {
+        sanitised
+    }
+}
+
+/// Pull the `Database=`/`Initial Catalog=` value out of an ADO.NET connection
+/// string (case-insensitive key match). Pure.
+fn database_from_ado_string(s: &str) -> Option<String> {
+    for part in s.split(';') {
+        let mut kv = part.splitn(2, '=');
+        let key = kv.next()?.trim();
+        let val = kv.next().unwrap_or("").trim();
+        if key.eq_ignore_ascii_case("database") || key.eq_ignore_ascii_case("initial catalog") {
+            if val.is_empty() {
+                return None;
+            }
+            return Some(val.to_string());
+        }
+    }
+    None
+}
+
+/// 64-bit FNV-1a of `s`, rendered as 16 lowercase hex digits. Deterministic and
+/// dependency-free (used only for a stable state-key digest, not security).
+fn fnv1a_hex(s: &str) -> String {
+    const OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+    const PRIME: u64 = 0x0000_0100_0000_01b3;
+    let mut hash = OFFSET;
+    for b in s.as_bytes() {
+        hash ^= u64::from(*b);
+        hash = hash.wrapping_mul(PRIME);
+    }
+    format!("{hash:016x}")
+}
+
+impl fmt::Debug for MssqlCdcSourceConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MssqlCdcSourceConfig")
+            .field("connection", &"***")
+            .field("capture_instances", &self.capture_instances)
+            .field("start_position", &self.start_position)
+            .field("poll_interval", &self.poll_interval)
+            .field("idle_timeout", &self.idle_timeout)
+            .field("max_staged_records", &self.max_staged_records)
+            .field("batch_size", &self.batch_size)
+            .field("max_connections", &self.max_connections)
+            .field("statement_timeout_secs", &self.statement_timeout_secs)
+            .field("state_key", &self.state_key)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn minimal() -> MssqlCdcSourceConfig {
+        serde_json::from_value(json!({
+            "connection_url": "mssql://sa:pw@localhost:1433/sales",
+            "capture_instances": ["dbo_Orders"]
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn defaults_via_serde() {
+        let c = minimal();
+        assert_eq!(c.poll_interval.as_secs(), 1);
+        assert_eq!(c.idle_timeout.as_secs(), 30);
+        assert_eq!(c.batch_size, DEFAULT_BATCH_SIZE);
+        assert_eq!(c.max_connections, 5);
+        assert_eq!(c.statement_timeout_secs, 300);
+        assert_eq!(c.start_position, StartPosition::Current);
+        assert!(c.max_staged_records.is_none());
+    }
+
+    #[test]
+    fn start_position_tagged_enum() {
+        let c: MssqlCdcSourceConfig = serde_json::from_value(json!({
+            "connection_url": "mssql://sa:pw@h/db",
+            "capture_instances": ["dbo_t"],
+            "start_position": { "type": "earliest" }
+        }))
+        .unwrap();
+        assert_eq!(c.start_position, StartPosition::Earliest);
+    }
+
+    #[test]
+    fn accepts_minimal() {
+        assert!(minimal().validate().is_ok());
+    }
+
+    #[test]
+    fn rejects_empty_capture_instances() {
+        let c: MssqlCdcSourceConfig = serde_json::from_value(json!({
+            "connection_url": "mssql://sa:pw@h/db",
+            "capture_instances": []
+        }))
+        .unwrap();
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_duplicate_capture_instances() {
+        let mut c = minimal();
+        c.capture_instances = vec!["dbo_t".into(), "dbo_t".into()];
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_injection_in_capture_instance() {
+        assert!(validate_capture_instance("dbo_Orders").is_ok());
+        assert!(validate_capture_instance("Orders123").is_ok());
+        // Hostile names that would break out of the function identifier.
+        assert!(validate_capture_instance("dbo.Orders").is_err());
+        assert!(validate_capture_instance("x(1,2,'all')--").is_err());
+        assert!(validate_capture_instance("a b").is_err());
+        assert!(validate_capture_instance("").is_err());
+        assert!(validate_capture_instance(&"a".repeat(129)).is_err());
+    }
+
+    #[test]
+    fn rejects_zero_intervals() {
+        let mut c = minimal();
+        c.poll_interval = Duration::ZERO;
+        assert!(c.validate().is_err());
+
+        let mut c = minimal();
+        c.idle_timeout = Duration::ZERO;
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_bad_batch_size() {
+        let mut c = minimal();
+        c.batch_size = faucet_core::MAX_BATCH_SIZE + 1;
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn requires_a_connection_source() {
+        let c: MssqlCdcSourceConfig = serde_json::from_value(json!({
+            "capture_instances": ["dbo_t"]
+        }))
+        .unwrap();
+        // No connection_url / connection_string -> connection.validate() fails.
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn state_key_single_instance_is_readable() {
+        let c = minimal();
+        let key = c.resolved_state_key();
+        assert_eq!(key, "mssql-cdc:sales:dbo_Orders");
+        faucet_core::state::validate_state_key(&key).expect("derived key must be valid");
+    }
+
+    #[test]
+    fn state_key_multi_instance_is_digest_and_order_independent() {
+        let mut a = minimal();
+        a.capture_instances = vec!["dbo_Orders".into(), "dbo_Items".into()];
+        let mut b = minimal();
+        b.capture_instances = vec!["dbo_Items".into(), "dbo_Orders".into()];
+        let ka = a.resolved_state_key();
+        let kb = b.resolved_state_key();
+        assert_eq!(ka, kb, "sorted digest is order-independent");
+        assert!(ka.starts_with("mssql-cdc:sales:"));
+        assert!(!ka.ends_with("dbo_Orders"));
+        faucet_core::state::validate_state_key(&ka).expect("digest key must be valid");
+    }
+
+    #[test]
+    fn state_key_explicit_override_wins() {
+        let mut c = minimal();
+        c.state_key = Some("custom:key".into());
+        assert_eq!(c.resolved_state_key(), "custom:key");
+    }
+
+    #[test]
+    fn state_key_falls_back_to_host_then_mssql() {
+        // connection_string with a database.
+        let c: MssqlCdcSourceConfig = serde_json::from_value(json!({
+            "connection_string": "Server=tcp:h,1433;Initial Catalog=warehouse;User Id=sa;Password=p",
+            "capture_instances": ["dbo_t"]
+        }))
+        .unwrap();
+        assert_eq!(c.resolved_state_key(), "mssql-cdc:warehouse:dbo_t");
+
+        // connection_string without a database -> "mssql".
+        let c: MssqlCdcSourceConfig = serde_json::from_value(json!({
+            "connection_string": "Server=tcp:h,1433;User Id=sa;Password=p",
+            "capture_instances": ["dbo_t"]
+        }))
+        .unwrap();
+        assert_eq!(c.resolved_state_key(), "mssql-cdc:mssql:dbo_t");
+    }
+
+    #[test]
+    fn debug_redacts_connection() {
+        let c: MssqlCdcSourceConfig = serde_json::from_value(json!({
+            "connection_url": "mssql://sa:secret@h/db",
+            "capture_instances": ["dbo_t"]
+        }))
+        .unwrap();
+        let dbg = format!("{c:?}");
+        assert!(dbg.contains("***"));
+        assert!(!dbg.contains("secret"));
+    }
+}

--- a/crates/source/mssql-cdc/src/decode.rs
+++ b/crates/source/mssql-cdc/src/decode.rs
@@ -1,0 +1,180 @@
+//! Decode a `tiberius` [`Row`] into a `serde_json` object.
+//!
+//! Mirrors the query source's decoder: non-temporal columns are read directly
+//! from their [`ColumnData`] variant (the variant carries the exact width, so
+//! there is no integer-size guessing); temporal columns go through
+//! [`Row::try_get`] with `chrono` target types so the conversion uses
+//! `tiberius`' own epoch math. CDC metadata columns (`__$start_lsn`,
+//! `__$update_mask`, …) come back as `binary` and are decoded to base64 here
+//! (they are stripped from the change envelope downstream — see
+//! [`crate::change`]).
+
+use base64::Engine;
+use chrono::{FixedOffset, NaiveDate, NaiveDateTime, NaiveTime};
+use faucet_core::FaucetError;
+use serde_json::{Map, Value, json};
+use tiberius::numeric::Numeric;
+use tiberius::{ColumnData, Row};
+
+/// Decode every column of `row` into a JSON object keyed by column name.
+pub fn row_to_json(row: &Row) -> Result<Value, FaucetError> {
+    let mut map = Map::with_capacity(row.columns().len());
+    let names: Vec<String> = row.columns().iter().map(|c| c.name().to_string()).collect();
+    for (i, (_col, data)) in row.cells().enumerate() {
+        let value = match scalar_to_json(data) {
+            Some(v) => v,
+            None => decode_temporal(row, i, data)?,
+        };
+        map.insert(names[i].clone(), value);
+    }
+    Ok(Value::Object(map))
+}
+
+/// Convert a non-temporal [`ColumnData`] to JSON. Returns `Some(Value::Null)`
+/// for a SQL NULL in a non-temporal column, and `None` for temporal variants
+/// (decoded by [`decode_temporal`], which needs the [`Row`] for `try_get`).
+fn scalar_to_json(data: &ColumnData<'_>) -> Option<Value> {
+    let v = match data {
+        ColumnData::U8(o) => o.map(|n| json!(n)),
+        ColumnData::I16(o) => o.map(|n| json!(n)),
+        ColumnData::I32(o) => o.map(|n| json!(n)),
+        ColumnData::I64(o) => o.map(|n| json!(n)),
+        ColumnData::F32(o) => o.map(|f| json!(f)),
+        ColumnData::F64(o) => o.map(|f| json!(f)),
+        ColumnData::Bit(o) => o.map(|b| json!(b)),
+        ColumnData::String(o) => o.as_ref().map(|s| json!(s.as_ref())),
+        ColumnData::Guid(o) => o.map(|g| json!(g.to_string())),
+        ColumnData::Binary(o) => o
+            .as_ref()
+            .map(|b| json!(base64::engine::general_purpose::STANDARD.encode(b.as_ref()))),
+        ColumnData::Numeric(o) => o.map(|n| json!(numeric_to_string(n))),
+        ColumnData::Xml(o) => o.as_ref().map(|x| json!(x.as_ref().clone().into_string())),
+        ColumnData::DateTime(_)
+        | ColumnData::SmallDateTime(_)
+        | ColumnData::Date(_)
+        | ColumnData::Time(_)
+        | ColumnData::DateTime2(_)
+        | ColumnData::DateTimeOffset(_) => return None,
+    };
+    Some(v.unwrap_or(Value::Null))
+}
+
+fn decode_temporal(row: &Row, idx: usize, data: &ColumnData<'_>) -> Result<Value, FaucetError> {
+    let conv = |e: tiberius::error::Error| {
+        FaucetError::Source(format!(
+            "mssql-cdc column {idx} temporal decode failed: {e}"
+        ))
+    };
+    let value = match data {
+        ColumnData::Date(_) => row
+            .try_get::<NaiveDate, _>(idx)
+            .map_err(conv)?
+            .map(|d| json!(d.to_string())),
+        ColumnData::Time(_) => row
+            .try_get::<NaiveTime, _>(idx)
+            .map_err(conv)?
+            .map(|t| json!(t.to_string())),
+        ColumnData::DateTime(_) | ColumnData::SmallDateTime(_) | ColumnData::DateTime2(_) => row
+            .try_get::<NaiveDateTime, _>(idx)
+            .map_err(conv)?
+            .map(|dt| json!(dt.format("%Y-%m-%dT%H:%M:%S%.f").to_string())),
+        ColumnData::DateTimeOffset(_) => row
+            .try_get::<chrono::DateTime<FixedOffset>, _>(idx)
+            .map_err(conv)?
+            .map(|dt| json!(dt.to_rfc3339())),
+        _ => unreachable!("decode_temporal called on a non-temporal column"),
+    };
+    Ok(value.unwrap_or(Value::Null))
+}
+
+/// Format an MSSQL DECIMAL/NUMERIC value as a precision-preserving string (JSON
+/// numbers cannot represent arbitrary-precision decimals — mirrors the query
+/// source's NUMERIC-as-string behaviour).
+pub(crate) fn numeric_to_string(n: Numeric) -> String {
+    let scale = n.scale() as usize;
+    let mantissa = n.value();
+    if scale == 0 {
+        return mantissa.to_string();
+    }
+    let negative = mantissa < 0;
+    let mut digits = mantissa.unsigned_abs().to_string();
+    if digits.len() <= scale {
+        digits = format!("{:0>width$}", digits, width = scale + 1);
+    }
+    let split = digits.len() - scale;
+    let (int_part, frac_part) = digits.split_at(split);
+    format!(
+        "{}{}.{}",
+        if negative { "-" } else { "" },
+        int_part,
+        frac_part
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::borrow::Cow;
+
+    #[test]
+    fn numeric_formats_with_scale() {
+        assert_eq!(
+            numeric_to_string(Numeric::new_with_scale(12345, 2)),
+            "123.45"
+        );
+        assert_eq!(numeric_to_string(Numeric::new_with_scale(100, 0)), "100");
+        assert_eq!(numeric_to_string(Numeric::new_with_scale(5, 2)), "0.05");
+        assert_eq!(numeric_to_string(Numeric::new_with_scale(-150, 2)), "-1.50");
+        assert_eq!(numeric_to_string(Numeric::new_with_scale(-5, 2)), "-0.05");
+    }
+
+    #[test]
+    fn scalar_integers_and_floats() {
+        assert_eq!(scalar_to_json(&ColumnData::I32(Some(42))), Some(json!(42)));
+        assert_eq!(scalar_to_json(&ColumnData::U8(Some(7))), Some(json!(7)));
+        assert_eq!(scalar_to_json(&ColumnData::I16(Some(-3))), Some(json!(-3)));
+        assert_eq!(
+            scalar_to_json(&ColumnData::I64(Some(9_000_000_000))),
+            Some(json!(9_000_000_000i64))
+        );
+        assert_eq!(
+            scalar_to_json(&ColumnData::F64(Some(1.5))),
+            Some(json!(1.5))
+        );
+    }
+
+    #[test]
+    fn scalar_bool_string_guid_binary_numeric() {
+        assert_eq!(
+            scalar_to_json(&ColumnData::Bit(Some(true))),
+            Some(json!(true))
+        );
+        assert_eq!(
+            scalar_to_json(&ColumnData::String(Some(Cow::Borrowed("hi")))),
+            Some(json!("hi"))
+        );
+        let id = tiberius::Uuid::nil();
+        assert_eq!(
+            scalar_to_json(&ColumnData::Guid(Some(id))),
+            Some(json!("00000000-0000-0000-0000-000000000000"))
+        );
+        // bytes [1,2,3] -> base64 "AQID" (the shape of an LSN metadata column).
+        let data = ColumnData::Binary(Some(Cow::Borrowed(&[1u8, 2, 3][..])));
+        assert_eq!(scalar_to_json(&data), Some(json!("AQID")));
+        let num = ColumnData::Numeric(Some(Numeric::new_with_scale(12345, 2)));
+        assert_eq!(scalar_to_json(&num), Some(json!("123.45")));
+    }
+
+    #[test]
+    fn scalar_null_is_json_null_not_temporal_none() {
+        assert_eq!(scalar_to_json(&ColumnData::I32(None)), Some(Value::Null));
+        assert_eq!(scalar_to_json(&ColumnData::String(None)), Some(Value::Null));
+    }
+
+    #[test]
+    fn temporal_variants_defer_to_caller() {
+        assert_eq!(scalar_to_json(&ColumnData::Date(None)), None);
+        assert_eq!(scalar_to_json(&ColumnData::DateTime2(None)), None);
+        assert_eq!(scalar_to_json(&ColumnData::DateTimeOffset(None)), None);
+    }
+}

--- a/crates/source/mssql-cdc/src/lib.rs
+++ b/crates/source/mssql-cdc/src/lib.rs
@@ -1,0 +1,25 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+//! Microsoft SQL Server CDC (change data capture) source for the faucet-stream
+//! ecosystem.
+//!
+//! Polls native SQL Server change data capture — `sys.fn_cdc_get_max_lsn()` for
+//! the high-water LSN, then `cdc.fn_cdc_get_all_changes_<capture_instance>()`
+//! per configured capture instance — and emits per-row change events as CDC
+//! envelopes, resumable via a per-instance LSN bookmark. Each committed
+//! transaction is emitted as its own [`StreamPage`](faucet_core::StreamPage),
+//! giving per-transaction durability and exactly-once-capable replay.
+//!
+//! Pair the emitted `{op, before, after, …}` envelopes with the `cdc_unwrap`
+//! transform stage and an upsert-capable sink to build a live mirror pipeline.
+
+mod change;
+mod config;
+mod decode;
+mod lsn;
+mod state;
+mod stream;
+
+pub use config::{MssqlCdcSourceConfig, StartPosition};
+pub use lsn::Lsn;
+pub use state::Bookmarks;
+pub use stream::MssqlCdcSource;

--- a/crates/source/mssql-cdc/src/lsn.rs
+++ b/crates/source/mssql-cdc/src/lsn.rs
@@ -1,0 +1,193 @@
+//! SQL Server Log Sequence Number (LSN) — pure parse / format / compare logic.
+//!
+//! An LSN in SQL Server change data capture is a `binary(10)` value: a 10-byte,
+//! big-endian, fixed-width integer whose lexicographic byte order is exactly its
+//! numeric order. We keep it as `[u8; 10]` and serialise it to the state store as
+//! a 20-character lowercase hex string (matching `CONVERT(VARCHAR(20), lsn, 2)`).
+//!
+//! All logic here is pure and unit-tested without a live server — the LSN is
+//! load-bearing for resumability, so a subtle off-by-one in the increment or a
+//! wrong comparison would silently drop or replay change rows.
+
+use std::fmt;
+
+use faucet_core::FaucetError;
+
+/// Number of bytes in a SQL Server `binary(10)` LSN.
+pub const LSN_BYTES: usize = 10;
+
+/// A SQL Server change data capture Log Sequence Number.
+///
+/// Stored as a big-endian byte array; [`Ord`] is the derived lexicographic
+/// comparison, which for big-endian bytes equals numeric order.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Lsn([u8; LSN_BYTES]);
+
+impl Lsn {
+    /// The all-zero LSN (`0x0000...0000`), the minimum possible value.
+    pub const ZERO: Lsn = Lsn([0u8; LSN_BYTES]);
+
+    /// Wrap a raw 10-byte big-endian array.
+    pub fn from_array(bytes: [u8; LSN_BYTES]) -> Self {
+        Lsn(bytes)
+    }
+
+    /// Build an LSN from a byte slice. The slice must be exactly [`LSN_BYTES`]
+    /// long; any other length is a typed error (SQL Server always returns
+    /// `binary(10)`, so a different width means a decode bug, not a data value).
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, FaucetError> {
+        if bytes.len() != LSN_BYTES {
+            return Err(FaucetError::Source(format!(
+                "mssql-cdc: LSN must be exactly {LSN_BYTES} bytes, got {}",
+                bytes.len()
+            )));
+        }
+        let mut arr = [0u8; LSN_BYTES];
+        arr.copy_from_slice(bytes);
+        Ok(Lsn(arr))
+    }
+
+    /// Parse an LSN from its hex string form (20 hex digits, case-insensitive, an
+    /// optional `0x`/`0X` prefix tolerated). Rejects any other length or a
+    /// non-hex digit with a typed error.
+    pub fn from_hex(s: &str) -> Result<Self, FaucetError> {
+        let hex = s
+            .strip_prefix("0x")
+            .or_else(|| s.strip_prefix("0X"))
+            .unwrap_or(s);
+        if hex.len() != LSN_BYTES * 2 {
+            return Err(FaucetError::Source(format!(
+                "mssql-cdc: LSN hex must be {} digits, got {} ({s:?})",
+                LSN_BYTES * 2,
+                hex.len()
+            )));
+        }
+        let mut arr = [0u8; LSN_BYTES];
+        for (i, byte) in arr.iter_mut().enumerate() {
+            let pair = &hex[i * 2..i * 2 + 2];
+            *byte = u8::from_str_radix(pair, 16).map_err(|e| {
+                FaucetError::Source(format!("mssql-cdc: invalid LSN hex {s:?}: {e}"))
+            })?;
+        }
+        Ok(Lsn(arr))
+    }
+
+    /// Render as a 20-character lowercase hex string (no `0x` prefix), matching
+    /// `CONVERT(VARCHAR(20), lsn, 2)`.
+    pub fn to_hex(&self) -> String {
+        let mut out = String::with_capacity(LSN_BYTES * 2);
+        for b in &self.0 {
+            out.push_str(&format!("{b:02x}"));
+        }
+        out
+    }
+
+    /// The smallest LSN strictly greater than `self` — the client-side analogue
+    /// of `sys.fn_cdc_increment_lsn`. Used to derive the **half-open** lower
+    /// bound for the next poll from a durable bookmark, so a resumed run never
+    /// re-reads the last already-committed change (the `fn_cdc_get_all_changes`
+    /// range is inclusive of `from_lsn`).
+    ///
+    /// Returns `None` only when `self` is the all-`0xFF` maximum (unreachable in
+    /// practice — the log would have to wrap the entire 80-bit LSN space).
+    pub fn increment(&self) -> Option<Self> {
+        let mut arr = self.0;
+        for byte in arr.iter_mut().rev() {
+            if *byte == u8::MAX {
+                *byte = 0;
+            } else {
+                *byte += 1;
+                return Some(Lsn(arr));
+            }
+        }
+        None
+    }
+}
+
+impl fmt::Debug for Lsn {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Lsn({})", self.to_hex())
+    }
+}
+
+impl fmt::Display for Lsn {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.to_hex())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hex_round_trips() {
+        let hex = "0000002a000000550003";
+        let lsn = Lsn::from_hex(hex).unwrap();
+        assert_eq!(lsn.to_hex(), hex);
+    }
+
+    #[test]
+    fn hex_tolerates_0x_prefix_and_uppercase() {
+        let a = Lsn::from_hex("0x0000002A000000550003").unwrap();
+        let b = Lsn::from_hex("0000002a000000550003").unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn hex_rejects_wrong_length_and_non_hex() {
+        assert!(Lsn::from_hex("00").is_err());
+        assert!(Lsn::from_hex("").is_err());
+        // 20 chars but a non-hex digit.
+        assert!(Lsn::from_hex("0000002a000000550zzz").is_err());
+    }
+
+    #[test]
+    fn from_bytes_requires_exact_width() {
+        assert!(Lsn::from_bytes(&[0u8; 10]).is_ok());
+        assert!(Lsn::from_bytes(&[0u8; 9]).is_err());
+        assert!(Lsn::from_bytes(&[0u8; 11]).is_err());
+    }
+
+    #[test]
+    fn ordering_is_numeric_big_endian() {
+        let small = Lsn::from_hex("00000000000000000001").unwrap();
+        let big = Lsn::from_hex("00000000000000000002").unwrap();
+        let bigger_high_byte = Lsn::from_hex("01000000000000000000").unwrap();
+        assert!(small < big);
+        assert!(big < bigger_high_byte);
+        assert_eq!(Lsn::ZERO, Lsn::from_hex("00000000000000000000").unwrap());
+        assert!(Lsn::ZERO < small);
+    }
+
+    #[test]
+    fn increment_is_the_next_value() {
+        let lsn = Lsn::from_hex("000000000000000000ff").unwrap();
+        let next = lsn.increment().unwrap();
+        // 0x...00ff + 1 carries into the next byte -> 0x...0100.
+        assert_eq!(next.to_hex(), "00000000000000000100");
+        assert!(lsn < next);
+        // No LSN sits strictly between lsn and its increment.
+        assert!(Lsn::from_hex("00000000000000000100").unwrap() <= next);
+    }
+
+    #[test]
+    fn increment_simple_low_byte() {
+        let lsn = Lsn::from_hex("00000000000000000001").unwrap();
+        assert_eq!(lsn.increment().unwrap().to_hex(), "00000000000000000002");
+    }
+
+    #[test]
+    fn increment_max_saturates_to_none() {
+        let max = Lsn::from_array([0xFF; LSN_BYTES]);
+        assert!(max.increment().is_none());
+    }
+
+    #[test]
+    fn increment_of_zero_is_one() {
+        assert_eq!(
+            Lsn::ZERO.increment().unwrap().to_hex(),
+            "00000000000000000001"
+        );
+    }
+}

--- a/crates/source/mssql-cdc/src/lsn.rs
+++ b/crates/source/mssql-cdc/src/lsn.rs
@@ -32,7 +32,7 @@ impl Lsn {
         Lsn(bytes)
     }
 
-    /// Build an LSN from a byte slice. The slice must be exactly [`LSN_BYTES`]
+    /// Build an LSN from a byte slice. The slice must be exactly `LSN_BYTES`
     /// long; any other length is a typed error (SQL Server always returns
     /// `binary(10)`, so a different width means a decode bug, not a data value).
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, FaucetError> {

--- a/crates/source/mssql-cdc/src/state.rs
+++ b/crates/source/mssql-cdc/src/state.rs
@@ -1,0 +1,133 @@
+//! Durable bookmark for SQL Server CDC progress.
+//!
+//! Because one source may poll several capture instances, the bookmark is a
+//! **map** of capture-instance name → last-committed LSN (hex). Storing the
+//! whole map in every emitted page's bookmark keeps the pipeline's single
+//! state-key model intact: each page persists the complete, up-to-date map.
+//!
+//! JSON shape:
+//! ```json
+//! { "dbo_Orders": "0000002a000000550003", "dbo_Items": "0000002a000000560001" }
+//! ```
+
+use std::collections::BTreeMap;
+
+use faucet_core::FaucetError;
+use serde_json::Value;
+
+use crate::lsn::Lsn;
+
+/// Per-capture-instance LSN bookmark map. Ordered (`BTreeMap`) so serialization
+/// is deterministic.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Bookmarks(BTreeMap<String, Lsn>);
+
+impl Bookmarks {
+    /// An empty bookmark map (fresh run, nothing committed yet).
+    pub fn new() -> Self {
+        Self(BTreeMap::new())
+    }
+
+    /// The last committed LSN for `capture_instance`, if any.
+    pub fn get(&self, capture_instance: &str) -> Option<Lsn> {
+        self.0.get(capture_instance).copied()
+    }
+
+    /// Record `lsn` as the last committed LSN for `capture_instance`.
+    pub fn set(&mut self, capture_instance: impl Into<String>, lsn: Lsn) {
+        self.0.insert(capture_instance.into(), lsn);
+    }
+
+    /// Parse a bookmark map previously produced by [`to_value`](Self::to_value).
+    ///
+    /// The `null`/absent case yields an empty map (a fresh run). Every value must
+    /// be a valid LSN hex string, else a typed [`FaucetError::State`].
+    pub fn from_value(v: Value) -> Result<Self, FaucetError> {
+        match v {
+            Value::Null => Ok(Self::new()),
+            Value::Object(map) => {
+                let mut out = BTreeMap::new();
+                for (ci, lsn_val) in map {
+                    let hex = lsn_val.as_str().ok_or_else(|| {
+                        FaucetError::State(format!(
+                            "mssql-cdc bookmark: value for {ci:?} must be an LSN hex string"
+                        ))
+                    })?;
+                    let lsn = Lsn::from_hex(hex)
+                        .map_err(|e| FaucetError::State(format!("mssql-cdc bookmark: {e}")))?;
+                    out.insert(ci, lsn);
+                }
+                Ok(Self(out))
+            }
+            other => Err(FaucetError::State(format!(
+                "mssql-cdc bookmark must be a JSON object of capture_instance -> LSN hex, got {other}"
+            ))),
+        }
+    }
+
+    /// Serialize the map for the state store.
+    pub fn to_value(&self) -> Result<Value, FaucetError> {
+        let mut map = serde_json::Map::with_capacity(self.0.len());
+        for (ci, lsn) in &self.0 {
+            map.insert(ci.clone(), Value::String(lsn.to_hex()));
+        }
+        Ok(Value::Object(map))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn lsn(hex: &str) -> Lsn {
+        Lsn::from_hex(hex).unwrap()
+    }
+
+    #[test]
+    fn set_get_round_trip() {
+        let mut b = Bookmarks::new();
+        assert!(b.get("dbo_Orders").is_none());
+        b.set("dbo_Orders", lsn("00000000000000000005"));
+        assert_eq!(b.get("dbo_Orders"), Some(lsn("00000000000000000005")));
+    }
+
+    #[test]
+    fn value_round_trip() {
+        let mut b = Bookmarks::new();
+        b.set("dbo_Orders", lsn("0000002a000000550003"));
+        b.set("dbo_Items", lsn("0000002a000000560001"));
+        let v = b.to_value().unwrap();
+        assert_eq!(Bookmarks::from_value(v).unwrap(), b);
+    }
+
+    #[test]
+    fn value_shape_is_ci_to_hex() {
+        let mut b = Bookmarks::new();
+        b.set("dbo_Orders", lsn("00000000000000000009"));
+        assert_eq!(
+            b.to_value().unwrap(),
+            json!({ "dbo_Orders": "00000000000000000009" })
+        );
+    }
+
+    #[test]
+    fn null_is_empty_map() {
+        assert_eq!(
+            Bookmarks::from_value(Value::Null).unwrap(),
+            Bookmarks::new()
+        );
+    }
+
+    #[test]
+    fn rejects_non_object() {
+        assert!(Bookmarks::from_value(json!("nope")).is_err());
+        assert!(Bookmarks::from_value(json!([1, 2, 3])).is_err());
+    }
+
+    #[test]
+    fn rejects_bad_lsn_value() {
+        assert!(Bookmarks::from_value(json!({ "dbo_Orders": 42 })).is_err());
+        assert!(Bookmarks::from_value(json!({ "dbo_Orders": "xx" })).is_err());
+    }
+}

--- a/crates/source/mssql-cdc/src/stream.rs
+++ b/crates/source/mssql-cdc/src/stream.rs
@@ -1,0 +1,696 @@
+//! The Microsoft SQL Server CDC [`Source`] implementation.
+//!
+//! Polls native SQL Server change data capture: for each configured capture
+//! instance it reads `sys.fn_cdc_get_max_lsn()` / `sys.fn_cdc_get_min_lsn()` for
+//! the retained range, then streams `cdc.fn_cdc_get_all_changes_<ci>(from, to,
+//! 'all')` in commit order, buffering by commit LSN (`__$start_lsn`) so a single
+//! transaction is never split across a bookmark boundary — mirroring the
+//! per-transaction durability contract of postgres-cdc / mysql-cdc.
+//!
+//! **Resumability.** The durable bookmark is a map of capture-instance → last
+//! committed LSN (hex). On resume the next poll starts at `increment(bookmark)`,
+//! so an already-committed change is never re-read. Each emitted page carries
+//! the whole updated map, so the pipeline's single state key stays intact.
+//!
+//! **Exactly-once.** LSNs are a durable, monotonic, deterministic replay
+//! coordinate and each committed transaction is its own page with its own
+//! bookmark, so [`Source::supports_exactly_once`] is `true`.
+
+use std::collections::HashMap;
+use std::pin::Pin;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use faucet_core::check::{CheckContext, CheckReport, Probe};
+use faucet_core::{FaucetError, Source, Stream, StreamPage};
+use futures::TryStreamExt;
+use serde_json::Value;
+use tiberius::{QueryItem, ToSql};
+
+use faucet_common_mssql::{MssqlPool, MssqlPooledConnection, build_pool, with_statement_timeout};
+
+use crate::change::{
+    LSN_ALIAS, OP_COLUMN, OpAction, PollPlan, SEQVAL_ALIAS, build_change_envelope,
+    business_columns, op_action, plan_poll,
+};
+use crate::config::MssqlCdcSourceConfig;
+use crate::decode::row_to_json;
+use crate::lsn::Lsn;
+use crate::state::Bookmarks;
+
+/// A configured Microsoft SQL Server CDC source.
+pub struct MssqlCdcSource {
+    config: MssqlCdcSourceConfig,
+    pool: MssqlPool,
+    state_key_value: String,
+    /// capture_instance -> (source schema, source table), resolved at build time
+    /// from `cdc.change_tables`. Used to stamp `schema`/`table` on envelopes.
+    tables: HashMap<String, (String, String)>,
+    /// Bookmark provided by [`Source::apply_start_bookmark`], consumed at the
+    /// start of the next fetch cycle.
+    pending_bookmark: Mutex<Option<Bookmarks>>,
+}
+
+impl MssqlCdcSource {
+    /// Connect, validate the config, build the pool, and run the CDC preflight
+    /// (verify CDC is enabled on the database and every configured capture
+    /// instance exists).
+    pub async fn new(config: MssqlCdcSourceConfig) -> Result<Self, FaucetError> {
+        config.validate()?;
+        let pool = build_pool(&config.connection, config.max_connections).await?;
+        let state_key_value = config.resolved_state_key();
+
+        let mut conn = pool
+            .get()
+            .await
+            .map_err(|e| FaucetError::Source(format!("mssql-cdc: pool checkout failed: {e}")))?;
+
+        // Preflight: CDC must be enabled on the database.
+        let (db_name, cdc_enabled) = fetch_db_cdc_status(&mut conn).await?;
+        if !cdc_enabled {
+            return Err(FaucetError::Source(format!(
+                "mssql-cdc: change data capture is not enabled on database {db_name:?}; \
+                 run `EXEC sys.sp_cdc_enable_db;` (requires sysadmin)"
+            )));
+        }
+
+        // Preflight: every configured capture instance must exist.
+        let tables = fetch_change_tables(&mut conn).await?;
+        let missing: Vec<&str> = config
+            .capture_instances
+            .iter()
+            .filter(|ci| !tables.contains_key(ci.as_str()))
+            .map(String::as_str)
+            .collect();
+        if !missing.is_empty() {
+            return Err(FaucetError::Source(format!(
+                "mssql-cdc: capture instance(s) {missing:?} not found in cdc.change_tables on \
+                 database {db_name:?}; enable them with \
+                 `EXEC sys.sp_cdc_enable_table @source_schema=..., @source_name=..., \
+                 @role_name=NULL, @capture_instance=...;`"
+            )));
+        }
+        drop(conn);
+
+        Ok(Self {
+            config,
+            pool,
+            state_key_value,
+            tables,
+            pending_bookmark: Mutex::new(None),
+        })
+    }
+
+    fn timeout(&self) -> Option<Duration> {
+        match self.config.statement_timeout_secs {
+            0 => None,
+            secs => Some(Duration::from_secs(secs)),
+        }
+    }
+}
+
+#[async_trait]
+impl Source for MssqlCdcSource {
+    /// Drain a single fetch cycle into a flat `Vec` using the `batch_size = 0`
+    /// aggregate sentinel (matches the convenience-API contract).
+    async fn fetch_with_context(
+        &self,
+        ctx: &HashMap<String, Value>,
+    ) -> Result<Vec<Value>, FaucetError> {
+        use futures::StreamExt;
+        let mut pages = self.stream_pages_impl(ctx, 0);
+        let mut all = Vec::new();
+        while let Some(page) = pages.next().await {
+            all.extend(page?.records);
+        }
+        Ok(all)
+    }
+
+    /// Per-transaction streaming. Each committed transaction is emitted as its
+    /// own [`StreamPage`] with `bookmark = Some(map)`. The trait-level
+    /// `batch_size` argument is ignored in favour of the config field.
+    fn stream_pages<'a>(
+        &'a self,
+        ctx: &'a HashMap<String, Value>,
+        _batch_size: usize,
+    ) -> Pin<Box<dyn Stream<Item = Result<StreamPage, FaucetError>> + Send + 'a>> {
+        self.stream_pages_impl(ctx, self.config.batch_size)
+    }
+
+    fn config_schema(&self) -> Value {
+        serde_json::to_value(schemars::schema_for!(MssqlCdcSourceConfig)).unwrap_or(Value::Null)
+    }
+
+    fn state_key(&self) -> Option<String> {
+        Some(self.state_key_value.clone())
+    }
+
+    async fn apply_start_bookmark(&self, bookmark: Value) -> Result<(), FaucetError> {
+        let marks = Bookmarks::from_value(bookmark)?;
+        *self
+            .pending_bookmark
+            .lock()
+            .expect("pending_bookmark mutex poisoned") = Some(marks);
+        Ok(())
+    }
+
+    /// Capture the database's current max LSN as a bookmark for every configured
+    /// capture instance, without consuming any changes. Used by
+    /// `faucet replicate` to anchor CDC before a bulk snapshot (#189).
+    async fn capture_resume_position(&self) -> Result<Option<Value>, FaucetError> {
+        let mut conn = self.pool.get().await.map_err(|e| {
+            FaucetError::Source(format!("mssql-cdc: capture_position checkout failed: {e}"))
+        })?;
+        let max_lsn = match self.query_max_lsn(&mut conn).await? {
+            Some(lsn) => lsn,
+            // No CDC activity yet: no position to anchor. A fresh CDC run will
+            // start from `current` at first poll.
+            None => return Ok(None),
+        };
+        let mut marks = Bookmarks::new();
+        for ci in &self.config.capture_instances {
+            marks.set(ci.clone(), max_lsn);
+        }
+        Ok(Some(marks.to_value()?))
+    }
+
+    fn supports_exactly_once(&self) -> bool {
+        true
+    }
+
+    fn connector_name(&self) -> &'static str {
+        "mssql-cdc"
+    }
+
+    fn dataset_uri(&self) -> String {
+        let conn = self
+            .config
+            .connection
+            .connection_url
+            .as_deref()
+            .or(self.config.connection.connection_string.as_deref())
+            .unwrap_or("");
+        format!(
+            "{}?capture_instances={}",
+            faucet_core::redact_uri_credentials(conn),
+            self.config.capture_instances.join(",")
+        )
+    }
+
+    /// Preflight probe for `faucet doctor`: connection, CDC-enabled, and
+    /// capture-instances-exist, without opening any change stream.
+    async fn check(&self, ctx: &CheckContext) -> Result<CheckReport, FaucetError> {
+        let start = Instant::now();
+
+        let probe_result = tokio::time::timeout(ctx.timeout, async {
+            let mut conn = self.pool.get().await.map_err(|e| {
+                Probe::fail_hint(
+                    "connection",
+                    start.elapsed(),
+                    format!("could not check out a connection: {e}"),
+                    "verify connection_url / credentials / TLS and that the server is reachable",
+                )
+            })?;
+            let connection = Probe::pass("connection", start.elapsed());
+
+            let cdc = match fetch_db_cdc_status(&mut conn).await {
+                Ok((_db, true)) => Probe::pass("cdc-enabled", start.elapsed()),
+                Ok((db, false)) => Probe::fail_hint(
+                    "cdc-enabled",
+                    start.elapsed(),
+                    format!("CDC is not enabled on database {db:?}"),
+                    "run `EXEC sys.sp_cdc_enable_db;` (requires sysadmin)",
+                ),
+                Err(e) => Probe::fail_hint(
+                    "cdc-enabled",
+                    start.elapsed(),
+                    e.to_string(),
+                    "the CDC status query failed — check permissions on sys.databases",
+                ),
+            };
+
+            let instances = match fetch_change_tables(&mut conn).await {
+                Ok(tables) => {
+                    let missing: Vec<&str> = self
+                        .config
+                        .capture_instances
+                        .iter()
+                        .filter(|ci| !tables.contains_key(ci.as_str()))
+                        .map(String::as_str)
+                        .collect();
+                    if missing.is_empty() {
+                        Probe::pass("capture-instances", start.elapsed())
+                    } else {
+                        Probe::fail_hint(
+                            "capture-instances",
+                            start.elapsed(),
+                            format!("capture instance(s) not found: {missing:?}"),
+                            "enable them with `EXEC sys.sp_cdc_enable_table ...`",
+                        )
+                    }
+                }
+                Err(e) => Probe::fail_hint(
+                    "capture-instances",
+                    start.elapsed(),
+                    e.to_string(),
+                    "reading cdc.change_tables failed — check CDC is enabled and permissions",
+                ),
+            };
+
+            Ok::<Vec<Probe>, Probe>(vec![connection, cdc, instances])
+        })
+        .await;
+
+        match probe_result {
+            Ok(Ok(probes)) => Ok(CheckReport { probes }),
+            Ok(Err(probe)) => Ok(CheckReport::single(probe)),
+            Err(_elapsed) => Ok(CheckReport::single(Probe::fail_hint(
+                "connection",
+                start.elapsed(),
+                "connection timed out",
+                "the database did not respond within the check timeout",
+            ))),
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Metadata queries (I/O)
+// ──────────────────────────────────────────────────────────────────────────────
+
+impl MssqlCdcSource {
+    /// Read the database's current maximum LSN (`None` when CDC has produced no
+    /// changes yet).
+    async fn query_max_lsn(
+        &self,
+        conn: &mut MssqlPooledConnection<'_>,
+    ) -> Result<Option<Lsn>, FaucetError> {
+        const SQL: &str = "SELECT CONVERT(VARCHAR(20), sys.fn_cdc_get_max_lsn(), 2) AS max_lsn";
+        let rows = self.run_collect(conn, SQL, &[]).await?;
+        let Some(row) = rows.first() else {
+            return Ok(None);
+        };
+        opt_lsn(row, "max_lsn")
+    }
+
+    /// Read a capture instance's retained `(min, max)` LSN range. Either may be
+    /// `None` (no changes retained / no changes at all).
+    async fn query_lsn_bounds(
+        &self,
+        conn: &mut MssqlPooledConnection<'_>,
+        capture_instance: &str,
+    ) -> Result<(Option<Lsn>, Option<Lsn>), FaucetError> {
+        const SQL: &str = "SELECT CONVERT(VARCHAR(20), sys.fn_cdc_get_min_lsn(@P1), 2) AS min_lsn, \
+                                  CONVERT(VARCHAR(20), sys.fn_cdc_get_max_lsn(), 2) AS max_lsn";
+        // Bind an owned String (guaranteed `ToSql`) for the capture-instance
+        // name — never interpolate it into the SQL text.
+        let ci_owned = capture_instance.to_string();
+        let ci: &dyn ToSql = &ci_owned;
+        let rows = self.run_collect(conn, SQL, &[ci]).await?;
+        let Some(row) = rows.first() else {
+            return Ok((None, None));
+        };
+        Ok((opt_lsn(row, "min_lsn")?, opt_lsn(row, "max_lsn")?))
+    }
+
+    /// Run a query and collect its first result set, honouring the statement
+    /// timeout.
+    async fn run_collect(
+        &self,
+        conn: &mut MssqlPooledConnection<'_>,
+        sql: &str,
+        params: &[&dyn ToSql],
+    ) -> Result<Vec<tiberius::Row>, FaucetError> {
+        let run = async {
+            conn.query(sql, params)
+                .await
+                .map_err(|e| FaucetError::Source(format!("mssql-cdc: query failed: {e}")))?
+                .into_first_result()
+                .await
+                .map_err(|e| FaucetError::Source(format!("mssql-cdc: result read failed: {e}")))
+        };
+        match self.timeout() {
+            Some(t) => {
+                with_statement_timeout(t, run, || {
+                    FaucetError::Source("mssql-cdc: query timed out".into())
+                })
+                .await
+            }
+            None => run.await,
+        }
+    }
+}
+
+/// Read `(DB_NAME(), is_cdc_enabled)` for the connected database.
+async fn fetch_db_cdc_status(
+    conn: &mut MssqlPooledConnection<'_>,
+) -> Result<(String, bool), FaucetError> {
+    const SQL: &str = "SELECT DB_NAME() AS db, \
+        CONVERT(INT, is_cdc_enabled) AS enabled FROM sys.databases WHERE database_id = DB_ID()";
+    let rows = conn
+        .query(SQL, &[])
+        .await
+        .map_err(|e| FaucetError::Source(format!("mssql-cdc: CDC-status query failed: {e}")))?
+        .into_first_result()
+        .await
+        .map_err(|e| FaucetError::Source(format!("mssql-cdc: CDC-status read failed: {e}")))?;
+    let Some(row) = rows.first() else {
+        return Err(FaucetError::Source(
+            "mssql-cdc: could not resolve the current database (sys.databases returned no row)"
+                .into(),
+        ));
+    };
+    let db = row
+        .try_get::<&str, _>("db")
+        .map_err(|e| FaucetError::Source(format!("mssql-cdc: DB_NAME decode failed: {e}")))?
+        .unwrap_or("")
+        .to_string();
+    let enabled = row
+        .try_get::<i32, _>("enabled")
+        .map_err(|e| FaucetError::Source(format!("mssql-cdc: is_cdc_enabled decode failed: {e}")))?
+        .unwrap_or(0)
+        != 0;
+    Ok((db, enabled))
+}
+
+/// Read every capture instance visible on the database, mapping it to its source
+/// `(schema, table)`.
+async fn fetch_change_tables(
+    conn: &mut MssqlPooledConnection<'_>,
+) -> Result<HashMap<String, (String, String)>, FaucetError> {
+    const SQL: &str = "SELECT ct.capture_instance AS ci, s.name AS src_schema, o.name AS src_table \
+        FROM cdc.change_tables ct \
+        JOIN sys.objects o ON o.object_id = ct.source_object_id \
+        JOIN sys.schemas s ON s.schema_id = o.schema_id";
+    let rows = conn
+        .query(SQL, &[])
+        .await
+        .map_err(|e| FaucetError::Source(format!("mssql-cdc: change_tables query failed: {e}")))?
+        .into_first_result()
+        .await
+        .map_err(|e| FaucetError::Source(format!("mssql-cdc: change_tables read failed: {e}")))?;
+
+    let mut map = HashMap::with_capacity(rows.len());
+    for row in &rows {
+        let get = |col: &str| -> Result<String, FaucetError> {
+            row.try_get::<&str, _>(col)
+                .map_err(|e| {
+                    FaucetError::Source(format!("mssql-cdc: change_tables decode ({col}): {e}"))
+                })?
+                .map(str::to_string)
+                .ok_or_else(|| FaucetError::Source(format!("mssql-cdc: change_tables null {col}")))
+        };
+        map.insert(get("ci")?, (get("src_schema")?, get("src_table")?));
+    }
+    Ok(map)
+}
+
+/// Read an optional LSN column (a hex string or SQL NULL) from a row.
+fn opt_lsn(row: &tiberius::Row, col: &str) -> Result<Option<Lsn>, FaucetError> {
+    match row
+        .try_get::<&str, _>(col)
+        .map_err(|e| FaucetError::Source(format!("mssql-cdc: {col} decode failed: {e}")))?
+    {
+        Some(hex) => Ok(Some(Lsn::from_hex(hex)?)),
+        None => Ok(None),
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Stream loop
+// ──────────────────────────────────────────────────────────────────────────────
+
+impl MssqlCdcSource {
+    fn stream_pages_impl<'a>(
+        &'a self,
+        _ctx: &'a HashMap<String, Value>,
+        batch_size: usize,
+    ) -> Pin<Box<dyn Stream<Item = Result<StreamPage, FaucetError>> + Send + 'a>> {
+        let per_transaction = batch_size != 0;
+        let poll_interval = self.config.poll_interval;
+        let idle_timeout = self.config.idle_timeout;
+        let start_position = self.config.start_position;
+        let max_staged = self.config.max_staged_records;
+
+        Box::pin(async_stream::try_stream! {
+            // Resolve the starting bookmark map for this cycle.
+            let mut marks = self
+                .pending_bookmark
+                .lock()
+                .expect("pending_bookmark mutex poisoned")
+                .take()
+                .unwrap_or_default();
+
+            let mut conn = self
+                .pool
+                .get()
+                .await
+                .map_err(|e| FaucetError::Source(format!("mssql-cdc: pool checkout failed: {e}")))?;
+
+            // Aggregate-mode accumulator (batch_size == 0).
+            let mut agg: Vec<Value> = Vec::new();
+            let mut agg_dirty = false;
+
+            let mut last_activity = Instant::now();
+
+            loop {
+                let mut any_rows = false;
+
+                for ci in &self.config.capture_instances {
+                    let (schema, table) = self
+                        .tables
+                        .get(ci)
+                        .cloned()
+                        .unwrap_or_else(|| ("".to_string(), ci.clone()));
+
+                    let (min_lsn, max_lsn) = self.query_lsn_bounds(&mut conn, ci).await?;
+                    let plan = plan_poll(marks.get(ci), min_lsn, max_lsn, start_position);
+
+                    match plan {
+                        PollPlan::NoChanges { set_bookmark } => {
+                            // Fresh `current` start: anchor the bookmark at the
+                            // live max and persist it so history is skipped.
+                            if let Some(anchor) = set_bookmark
+                                && marks.get(ci).is_none()
+                            {
+                                marks.set(ci.clone(), anchor);
+                                if per_transaction {
+                                    yield StreamPage {
+                                        records: Vec::new(),
+                                        bookmark: Some(marks.to_value()?),
+                                    };
+                                } else {
+                                    agg_dirty = true;
+                                }
+                            }
+                        }
+                        PollPlan::Query { from, to, gap } => {
+                            if gap {
+                                tracing::warn!(
+                                    connector = "mssql-cdc",
+                                    capture_instance = %ci,
+                                    "resume point predates the retained minimum LSN; the CDC \
+                                     cleanup job purged changes before they were read — resuming \
+                                     from the earliest retained change (a data gap is possible)"
+                                );
+                            }
+
+                            let sql = changes_sql(ci);
+                            let from_hex = from.to_hex();
+                            let to_hex = to.to_hex();
+
+                            // Open the change stream (timeout only wraps opening
+                            // it; the QueryStream borrows `conn`, not the params).
+                            let mut stream = {
+                                // `params` is a named local so it outlives the
+                                // `.await` below (tiberius borrows the params
+                                // only until the query future resolves, not for
+                                // the returned QueryStream's lifetime).
+                                let params: [&dyn ToSql; 2] = [&from_hex, &to_hex];
+                                let query_fut = conn.query(&sql, &params);
+                                match self.timeout() {
+                                    Some(t) => {
+                                        with_statement_timeout(t, async {
+                                            query_fut.await.map_err(|e| {
+                                                FaucetError::Source(format!(
+                                                    "mssql-cdc: get_all_changes failed for {ci}: {e}"
+                                                ))
+                                            })
+                                        }, || FaucetError::Source(
+                                            "mssql-cdc: get_all_changes timed out".into()
+                                        ))
+                                        .await?
+                                    }
+                                    None => query_fut.await.map_err(|e| {
+                                        FaucetError::Source(format!(
+                                            "mssql-cdc: get_all_changes failed for {ci}: {e}"
+                                        ))
+                                    })?,
+                                }
+                            };
+
+                            let mut buffer: Vec<Value> = Vec::new();
+                            let mut cur_lsn: Option<Lsn> = None;
+
+                            while let Some(item) = stream.try_next().await.map_err(|e| {
+                                FaucetError::Source(format!(
+                                    "mssql-cdc: change row stream failed for {ci}: {e}"
+                                ))
+                            })? {
+                                let QueryItem::Row(row) = item else { continue };
+                                let decoded = row_to_json(&row)?;
+
+                                let lsn_hex = decoded
+                                    .get(LSN_ALIAS)
+                                    .and_then(Value::as_str)
+                                    .ok_or_else(|| FaucetError::Source(
+                                        "mssql-cdc: change row missing __$start_lsn".into()
+                                    ))?;
+                                let row_lsn = Lsn::from_hex(lsn_hex)?;
+                                let seqval_hex = decoded
+                                    .get(SEQVAL_ALIAS)
+                                    .and_then(Value::as_str)
+                                    .map(str::to_string);
+                                let op_code = decoded
+                                    .get(OP_COLUMN)
+                                    .and_then(Value::as_i64)
+                                    .ok_or_else(|| FaucetError::Source(
+                                        "mssql-cdc: change row missing __$operation".into()
+                                    ))?;
+
+                                // Commit boundary: a new __$start_lsn closes the
+                                // previous transaction. Emit it bookmarked at the
+                                // completed commit LSN (a safe resume point).
+                                if let Some(prev) = cur_lsn
+                                    && prev != row_lsn
+                                {
+                                    marks.set(ci.clone(), prev);
+                                    let recs = std::mem::take(&mut buffer);
+                                    if per_transaction {
+                                        yield StreamPage {
+                                            records: recs,
+                                            bookmark: Some(marks.to_value()?),
+                                        };
+                                    } else {
+                                        agg.extend(recs);
+                                        agg_dirty = true;
+                                    }
+                                }
+                                cur_lsn = Some(row_lsn);
+
+                                match op_action(op_code)? {
+                                    OpAction::Skip => continue,
+                                    OpAction::Emit(op) => {
+                                        if let Some(max) = max_staged
+                                            && buffer.len() >= max
+                                        {
+                                            Err(FaucetError::Source(format!(
+                                                "mssql-cdc: in-progress transaction for {ci} exceeded \
+                                                 max_staged_records ({max}); aborting to avoid \
+                                                 unbounded memory growth. Raise max_staged_records \
+                                                 or reduce the source transaction size."
+                                            )))?;
+                                        }
+                                        let cols = business_columns(&decoded);
+                                        let env = build_change_envelope(
+                                            op,
+                                            &schema,
+                                            &table,
+                                            lsn_hex,
+                                            seqval_hex.as_deref(),
+                                            cols,
+                                        );
+                                        buffer.push(env);
+                                        any_rows = true;
+                                    }
+                                }
+                            }
+                            // Drop the change stream (release the conn borrow) by
+                            // ending the while-loop scope, then flush the tail.
+                            drop(stream);
+
+                            // Final flush: advance to `to` (everything <= to is
+                            // consumed) so we never re-scan this range.
+                            marks.set(ci.clone(), to);
+                            let recs = std::mem::take(&mut buffer);
+                            if per_transaction {
+                                yield StreamPage {
+                                    records: recs,
+                                    bookmark: Some(marks.to_value()?),
+                                };
+                            } else {
+                                agg.extend(recs);
+                                agg_dirty = true;
+                            }
+                        }
+                    }
+                }
+
+                if any_rows {
+                    last_activity = Instant::now();
+                }
+
+                // In aggregate mode we still poll the whole idle window, then
+                // emit a single trailing page below.
+                if last_activity.elapsed() >= idle_timeout {
+                    break;
+                }
+                tokio::time::sleep(poll_interval).await;
+            }
+
+            // Aggregate mode: one trailing page with everything and the final map.
+            if !per_transaction && (agg_dirty || !agg.is_empty()) {
+                yield StreamPage {
+                    records: std::mem::take(&mut agg),
+                    bookmark: Some(marks.to_value()?),
+                };
+            }
+
+            tracing::info!(
+                connector = "mssql-cdc",
+                state_key = %self.state_key_value,
+                "mssql-cdc fetch cycle complete",
+            );
+        })
+    }
+}
+
+/// Build the `fn_cdc_get_all_changes` query for one (already validated) capture
+/// instance. The commit LSN and sequence value are surfaced as hex-string
+/// aliases; the bind markers `@P1`/`@P2` carry the `from`/`to` LSN hex.
+fn changes_sql(capture_instance: &str) -> String {
+    format!(
+        "SELECT CONVERT(VARCHAR(20), __$start_lsn, 2) AS {lsn}, \
+                CONVERT(VARCHAR(20), __$seqval, 2) AS {seq}, * \
+         FROM cdc.fn_cdc_get_all_changes_{ci}(\
+                CONVERT(BINARY(10), @P1, 2), CONVERT(BINARY(10), @P2, 2), N'all') \
+         ORDER BY __$start_lsn, __$seqval, __$operation",
+        lsn = LSN_ALIAS,
+        seq = SEQVAL_ALIAS,
+        ci = capture_instance,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn changes_sql_embeds_validated_instance_and_aliases() {
+        let sql = changes_sql("dbo_Orders");
+        assert!(
+            sql.contains("cdc.fn_cdc_get_all_changes_dbo_Orders("),
+            "{sql}"
+        );
+        assert!(sql.contains("AS __faucet_lsn"), "{sql}");
+        assert!(sql.contains("AS __faucet_seqval"), "{sql}");
+        assert!(sql.contains("N'all'"), "{sql}");
+        assert!(
+            sql.contains("ORDER BY __$start_lsn, __$seqval, __$operation"),
+            "{sql}"
+        );
+        // Bounds are bound, never interpolated.
+        assert!(sql.contains("@P1") && sql.contains("@P2"), "{sql}");
+    }
+}

--- a/crates/source/mssql-cdc/tests/conformance.rs
+++ b/crates/source/mssql-cdc/tests/conformance.rs
@@ -1,0 +1,231 @@
+//! `faucet-conformance` battery for the SQL Server CDC source.
+//!
+//! Check 1: the connector's config JSON Schema is a well-formed schema value
+//!          (pure, offline — always runs).
+//! Check 2: `stream_pages` bounds peak memory. Like postgres-cdc / mysql-cdc,
+//!          this source emits **one page per committed transaction**; a single
+//!          transaction is never split across pages. We seed many *small,
+//!          single-row* autocommitted `INSERT`s — each its own transaction and
+//!          hence its own one-record page — so the peak page (1) is ≤ the batch
+//!          cap and strictly < the total.
+//! Check 3: bookmark round-trip. Because CDC capture is asynchronous (the
+//!          capture job scans the log into the change tables), the changes are
+//!          pre-seeded and drained with `start_position: earliest`, so both
+//!          drives run over an already-populated, static change set.
+//!
+//! `assert_errors_not_panics` is intentionally omitted: this source runs an
+//! eager preflight in `new()` (verifying CDC + capture instances), so the
+//! obvious read-error causes surface at *build* time, not read time — there is
+//! no clean "builds but fails at first read" state to exercise.
+//!
+//! The Docker checks require SQL Server with the Agent enabled (so the capture
+//! job populates the change tables) and are skipped when Docker is absent.
+
+use std::time::Duration;
+
+use faucet_common_mssql::{MssqlConnectionConfig, MssqlPool, MssqlTls, MssqlTlsMode, build_pool};
+use faucet_conformance::{
+    assert_bookmark_roundtrip, assert_bounded_memory, assert_config_schema_valid_value,
+};
+use faucet_source_mssql_cdc::{MssqlCdcSource, MssqlCdcSourceConfig};
+use serde_json::json;
+use testcontainers::ImageExt;
+use testcontainers_modules::mssql_server::MssqlServer;
+use testcontainers_modules::testcontainers::ContainerAsync;
+use testcontainers_modules::testcontainers::runners::AsyncRunner;
+
+const ENCODED_PW: &str = "yourStrong%28%21%29Password";
+const RAW_PW: &str = "yourStrong(!)Password";
+const CAPTURE_INSTANCE: &str = "dbo_events";
+const BATCH: usize = 250;
+const TOTAL: usize = 600;
+
+// SQL Server containers need ~2 GB RAM each; serialize them.
+static SERIAL: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+// ── Check 1: config schema validity (offline) ────────────────────────────────
+
+#[test]
+fn conformance_config_schema_valid() {
+    let schema = serde_json::to_value(schemars::schema_for!(MssqlCdcSourceConfig)).unwrap();
+    assert_config_schema_valid_value(&schema, "faucet-source-mssql-cdc");
+}
+
+// ── Docker helpers ───────────────────────────────────────────────────────────
+
+async fn start_mssql_cdc() -> (ContainerAsync<MssqlServer>, u16) {
+    let container = MssqlServer::default()
+        .with_accept_eula()
+        // SQL Server Agent runs the CDC capture job that moves changes from the
+        // log into the change tables.
+        .with_env_var("MSSQL_AGENT_ENABLED", "true")
+        .start()
+        .await
+        .expect("start mssql container");
+    let port = container
+        .get_host_port_ipv4(1433)
+        .await
+        .expect("mssql host port");
+    (container, port)
+}
+
+fn conn_cfg(port: u16, database: &str) -> MssqlConnectionConfig {
+    MssqlConnectionConfig {
+        connection_url: Some(format!(
+            "mssql://sa:{ENCODED_PW}@127.0.0.1:{port}/{database}"
+        )),
+        connection_string: None,
+        tls: MssqlTls {
+            mode: MssqlTlsMode::TrustServerCertificate,
+            ca_cert_path: None,
+        },
+    }
+}
+
+async fn exec(pool: &MssqlPool, sql: &str) {
+    let mut conn = pool.get().await.expect("checkout");
+    conn.execute(sql, &[]).await.expect("execute setup sql");
+}
+
+async fn scalar_i64(pool: &MssqlPool, sql: &str) -> i64 {
+    let mut conn = pool.get().await.expect("checkout");
+    let rows = conn
+        .query(sql, &[])
+        .await
+        .expect("query")
+        .into_first_result()
+        .await
+        .expect("result");
+    let Some(row) = rows.first() else { return 0 };
+    // tiberius is width-strict on `try_get`: the readiness `CASE … THEN 0 ELSE 1`
+    // comes back as INT (i32) while `CONVERT(BIGINT, COUNT(*))` comes back as
+    // BIGINT (i64). Accept either width so a probe never silently reads 0.
+    if let Ok(Some(v)) = row.try_get::<i64, _>(0) {
+        return v;
+    }
+    row.try_get::<i32, _>(0)
+        .ok()
+        .flatten()
+        .map(i64::from)
+        .unwrap_or(0)
+}
+
+/// Enable CDC on a fresh database, create `dbo.events`, enable a capture
+/// instance, insert `n` single-row transactions, and wait for the capture job
+/// to populate the change table. Returns the master-scoped pool (unused) and the
+/// per-database connection config.
+async fn setup_cdc(port: u16, n: usize) -> MssqlConnectionConfig {
+    let db = "cdc_conformance";
+    let master = build_pool(&conn_cfg(port, "master"), 2)
+        .await
+        .expect("master pool");
+    exec(
+        &master,
+        &format!("IF DB_ID('{db}') IS NULL CREATE DATABASE {db}"),
+    )
+    .await;
+
+    let dbcfg = conn_cfg(port, db);
+    let pool = build_pool(&dbcfg, 4).await.expect("db pool");
+
+    exec(
+        &pool,
+        "IF (SELECT is_cdc_enabled FROM sys.databases WHERE name = DB_NAME()) = 0 \
+                 EXEC sys.sp_cdc_enable_db",
+    )
+    .await;
+    exec(
+        &pool,
+        "IF OBJECT_ID('dbo.events') IS NULL CREATE TABLE dbo.events (id INT PRIMARY KEY)",
+    )
+    .await;
+    exec(
+        &pool,
+        "IF NOT EXISTS (SELECT 1 FROM cdc.change_tables ct \
+             JOIN sys.objects o ON o.object_id = ct.source_object_id WHERE o.name = 'events') \
+         EXEC sys.sp_cdc_enable_table @source_schema = N'dbo', @source_name = N'events', \
+             @role_name = NULL, @capture_instance = N'dbo_events'",
+    )
+    .await;
+
+    // Give the capture job a moment to come up before writing.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    for i in 0..n {
+        exec(&pool, &format!("INSERT INTO dbo.events (id) VALUES ({i})")).await;
+    }
+
+    // Wait for the async capture to move all n rows into the change table.
+    let count_sql = format!(
+        "SELECT CONVERT(BIGINT, COUNT(*)) FROM cdc.fn_cdc_get_all_changes_{CAPTURE_INSTANCE}(\
+             sys.fn_cdc_get_min_lsn(N'{CAPTURE_INSTANCE}'), sys.fn_cdc_get_max_lsn(), N'all')"
+    );
+    let deadline = std::time::Instant::now() + Duration::from_secs(120);
+    loop {
+        // fn_cdc_get_min_lsn is NULL until the first scan; guard with a max check.
+        let max_ready = scalar_i64(
+            &pool,
+            "SELECT CASE WHEN sys.fn_cdc_get_min_lsn(N'dbo_events') IS NULL THEN 0 ELSE 1 END",
+        )
+        .await;
+        if max_ready == 1 && scalar_i64(&pool, &count_sql).await >= n as i64 {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "CDC capture did not populate {n} change rows within the timeout — is the SQL Server \
+             Agent running?"
+        );
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    }
+
+    let _ = RAW_PW;
+    dbcfg
+}
+
+fn build_config(conn: &MssqlConnectionConfig) -> MssqlCdcSourceConfig {
+    serde_json::from_value(json!({
+        "connection_url": conn.connection_url,
+        "tls": { "type": "trust_server_certificate" },
+        "capture_instances": [CAPTURE_INSTANCE],
+        "start_position": { "type": "earliest" },
+        "idle_timeout": 5,
+        "poll_interval": 1,
+        "batch_size": BATCH,
+    }))
+    .expect("config")
+}
+
+// ── Check 2: bounded-memory streaming (Docker) ───────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn conformance_bounded_memory() {
+    let _serial = SERIAL.lock().await;
+    let (_c, port) = start_mssql_cdc().await;
+    let conn = setup_cdc(port, TOTAL).await;
+
+    let source = MssqlCdcSource::new(build_config(&conn))
+        .await
+        .expect("source new");
+
+    // Each committed single-row transaction is its own page (1 record) → peak
+    // == 1, which is ≤ BATCH and < TOTAL.
+    assert_bounded_memory(&source, BATCH, TOTAL).await;
+}
+
+// ── Check 3: bookmark round-trip (Docker) ────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn conformance_bookmark_roundtrip() {
+    let _serial = SERIAL.lock().await;
+    const N: usize = 300;
+    let (_c, port) = start_mssql_cdc().await;
+    let conn = setup_cdc(port, N).await;
+
+    let source = MssqlCdcSource::new(build_config(&conn))
+        .await
+        .expect("source new");
+
+    // First drain consumes all N pre-seeded change rows and emits an LSN
+    // bookmark; no new writes occur, so the resumed drain yields zero.
+    assert_bookmark_roundtrip(&source).await;
+}

--- a/crates/source/mssql-cdc/tests/integration.rs
+++ b/crates/source/mssql-cdc/tests/integration.rs
@@ -1,0 +1,372 @@
+//! Integration tests for `MssqlCdcSource` against a real SQL Server in Docker.
+//!
+//! Requires Docker (the `mcr.microsoft.com/mssql/server` image) with SQL Server
+//! Agent enabled so the CDC capture job populates the change tables. Skipped by
+//! a plain `cargo test --lib`, mirroring the postgres-cdc / mysql-cdc pattern.
+//! On an ARM Mac these run in CI only.
+//!
+//! Change capture is asynchronous, so every test seeds its writes, waits for the
+//! capture job to move them into the change table, and then drains the source
+//! with `start_position: earliest` (a static, fully-populated change set).
+
+use std::time::Duration;
+
+use faucet_common_mssql::{MssqlConnectionConfig, MssqlPool, MssqlTls, MssqlTlsMode, build_pool};
+use faucet_core::Source;
+use faucet_core::check::{CheckContext, ProbeStatus};
+use faucet_source_mssql_cdc::{MssqlCdcSource, MssqlCdcSourceConfig};
+use futures::StreamExt;
+use serde_json::{Value, json};
+use std::collections::HashMap;
+use testcontainers::ImageExt;
+use testcontainers_modules::mssql_server::MssqlServer;
+use testcontainers_modules::testcontainers::ContainerAsync;
+use testcontainers_modules::testcontainers::runners::AsyncRunner;
+
+const ENCODED_PW: &str = "yourStrong%28%21%29Password";
+const CI: &str = "dbo_users";
+
+static SERIAL: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+async fn start_mssql_cdc() -> (ContainerAsync<MssqlServer>, u16) {
+    let container = MssqlServer::default()
+        .with_accept_eula()
+        .with_env_var("MSSQL_AGENT_ENABLED", "true")
+        .start()
+        .await
+        .expect("start mssql container");
+    let port = container
+        .get_host_port_ipv4(1433)
+        .await
+        .expect("mssql host port");
+    (container, port)
+}
+
+fn conn_cfg(port: u16, database: &str) -> MssqlConnectionConfig {
+    MssqlConnectionConfig {
+        connection_url: Some(format!(
+            "mssql://sa:{ENCODED_PW}@127.0.0.1:{port}/{database}"
+        )),
+        connection_string: None,
+        tls: MssqlTls {
+            mode: MssqlTlsMode::TrustServerCertificate,
+            ca_cert_path: None,
+        },
+    }
+}
+
+async fn exec(pool: &MssqlPool, sql: &str) {
+    let mut conn = pool.get().await.expect("checkout");
+    conn.execute(sql, &[]).await.expect("execute setup sql");
+}
+
+async fn scalar_i64(pool: &MssqlPool, sql: &str) -> i64 {
+    let mut conn = pool.get().await.expect("checkout");
+    let rows = conn
+        .query(sql, &[])
+        .await
+        .expect("query")
+        .into_first_result()
+        .await
+        .expect("result");
+    let Some(row) = rows.first() else { return 0 };
+    // tiberius is width-strict on `try_get`: the readiness `CASE … THEN 0 ELSE 1`
+    // comes back as INT (i32) while `CONVERT(BIGINT, COUNT(*))` comes back as
+    // BIGINT (i64). Accept either width so a probe never silently reads 0.
+    if let Ok(Some(v)) = row.try_get::<i64, _>(0) {
+        return v;
+    }
+    row.try_get::<i32, _>(0)
+        .ok()
+        .flatten()
+        .map(i64::from)
+        .unwrap_or(0)
+}
+
+/// Create `db`, enable CDC on it and on `dbo.users`, returning the db pool +
+/// config. `dbo.users(id INT PK, name NVARCHAR(64))`.
+async fn setup(port: u16, db: &str) -> (MssqlPool, MssqlConnectionConfig) {
+    let master = build_pool(&conn_cfg(port, "master"), 2)
+        .await
+        .expect("master pool");
+    exec(
+        &master,
+        &format!("IF DB_ID('{db}') IS NULL CREATE DATABASE {db}"),
+    )
+    .await;
+
+    let dbcfg = conn_cfg(port, db);
+    let pool = build_pool(&dbcfg, 4).await.expect("db pool");
+    exec(
+        &pool,
+        "IF (SELECT is_cdc_enabled FROM sys.databases WHERE name = DB_NAME()) = 0 \
+                 EXEC sys.sp_cdc_enable_db",
+    )
+    .await;
+    exec(
+        &pool,
+        "IF OBJECT_ID('dbo.users') IS NULL \
+                 CREATE TABLE dbo.users (id INT PRIMARY KEY, name NVARCHAR(64))",
+    )
+    .await;
+    exec(
+        &pool,
+        "IF NOT EXISTS (SELECT 1 FROM cdc.change_tables ct \
+             JOIN sys.objects o ON o.object_id = ct.source_object_id WHERE o.name = 'users') \
+         EXEC sys.sp_cdc_enable_table @source_schema = N'dbo', @source_name = N'users', \
+             @role_name = NULL, @capture_instance = N'dbo_users'",
+    )
+    .await;
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    (pool, dbcfg)
+}
+
+/// Wait until the change table holds at least `n` rows.
+async fn wait_for_changes(pool: &MssqlPool, n: i64) {
+    let count_sql = format!(
+        "SELECT CONVERT(BIGINT, COUNT(*)) FROM cdc.fn_cdc_get_all_changes_{CI}(\
+             sys.fn_cdc_get_min_lsn(N'{CI}'), sys.fn_cdc_get_max_lsn(), N'all')"
+    );
+    let deadline = std::time::Instant::now() + Duration::from_secs(120);
+    loop {
+        let ready = scalar_i64(
+            pool,
+            "SELECT CASE WHEN sys.fn_cdc_get_min_lsn(N'dbo_users') IS NULL THEN 0 ELSE 1 END",
+        )
+        .await;
+        if ready == 1 && scalar_i64(pool, &count_sql).await >= n {
+            return;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "CDC capture did not populate {n} rows within the timeout (is SQL Agent running?)"
+        );
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    }
+}
+
+fn build_config(conn: &MssqlConnectionConfig) -> MssqlCdcSourceConfig {
+    serde_json::from_value(json!({
+        "connection_url": conn.connection_url,
+        "tls": { "type": "trust_server_certificate" },
+        "capture_instances": [CI],
+        "start_position": { "type": "earliest" },
+        "idle_timeout": 5,
+        "poll_interval": 1,
+        "batch_size": 0,
+    }))
+    .expect("config")
+}
+
+async fn drain(source: &MssqlCdcSource) -> (Vec<Value>, Option<Value>) {
+    let ctx: HashMap<String, Value> = HashMap::new();
+    let mut pages = source.stream_pages(&ctx, 0);
+    let mut records = Vec::new();
+    let mut bookmark = None;
+    while let Some(page) = pages.next().await {
+        let page = page.expect("page");
+        records.extend(page.records);
+        if page.bookmark.is_some() {
+            bookmark = page.bookmark;
+        }
+    }
+    (records, bookmark)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cdc_captures_crud_then_resumes_without_replay() {
+    let _serial = SERIAL.lock().await;
+    let (_c, port) = start_mssql_cdc().await;
+    let (pool, conn) = setup(port, "cdc_crud").await;
+
+    exec(
+        &pool,
+        "INSERT INTO dbo.users (id, name) VALUES (1, N'alice')",
+    )
+    .await;
+    exec(&pool, "UPDATE dbo.users SET name = N'bob' WHERE id = 1").await;
+    exec(&pool, "DELETE FROM dbo.users WHERE id = 1").await;
+    // insert(op2) + update-after(op4) + delete(op1) = 3 change rows.
+    wait_for_changes(&pool, 3).await;
+
+    let source = MssqlCdcSource::new(build_config(&conn))
+        .await
+        .expect("source new");
+    let (records, bookmark) = drain(&source).await;
+
+    let ops: Vec<&str> = records
+        .iter()
+        .map(|r| r["op"].as_str().unwrap_or(""))
+        .collect();
+    assert!(ops.contains(&"i"), "expected an insert op, got {ops:?}");
+    assert!(ops.contains(&"u"), "expected an update op, got {ops:?}");
+    assert!(ops.contains(&"d"), "expected a delete op, got {ops:?}");
+
+    let insert = records
+        .iter()
+        .find(|r| r["op"] == "i")
+        .expect("insert record");
+    assert_eq!(insert["schema"], "dbo");
+    assert_eq!(insert["table"], "users");
+    assert_eq!(insert["after"]["name"], "alice", "envelope: {insert:?}");
+    assert_eq!(insert["before"], Value::Null);
+    assert!(insert["lsn"].is_string(), "lsn present: {insert:?}");
+
+    let delete = records
+        .iter()
+        .find(|r| r["op"] == "d")
+        .expect("delete record");
+    assert_eq!(
+        delete["before"]["id"],
+        json!(1),
+        "delete before image: {delete:?}"
+    );
+    assert_eq!(delete["after"], Value::Null);
+
+    let bookmark = bookmark.expect("cycle 1 must produce a bookmark");
+    assert!(
+        bookmark.get(CI).and_then(Value::as_str).is_some(),
+        "bookmark map: {bookmark}"
+    );
+
+    // Resume: a new insert (id=2) must be the only thing delivered.
+    source
+        .apply_start_bookmark(bookmark)
+        .await
+        .expect("apply bookmark");
+    exec(
+        &pool,
+        "INSERT INTO dbo.users (id, name) VALUES (2, N'carol')",
+    )
+    .await;
+    wait_for_changes(&pool, 4).await;
+
+    let (records2, _) = drain(&source).await;
+    assert!(!records2.is_empty(), "expected the post-bookmark insert");
+    for r in &records2 {
+        assert_eq!(
+            r["after"]["id"],
+            json!(2),
+            "resume replayed a pre-bookmark event: {r:?}"
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn source_metadata_and_check_probes_pass() {
+    let _serial = SERIAL.lock().await;
+    let (_c, port) = start_mssql_cdc().await;
+    let (_pool, conn) = setup(port, "cdc_meta").await;
+
+    let source = MssqlCdcSource::new(build_config(&conn))
+        .await
+        .expect("source new");
+
+    assert_eq!(source.connector_name(), "mssql-cdc");
+    assert!(source.supports_exactly_once());
+    assert_eq!(
+        source.state_key().as_deref(),
+        Some("mssql-cdc:cdc_meta:dbo_users")
+    );
+
+    let uri = source.dataset_uri();
+    assert!(
+        !uri.contains("sa:") && !uri.contains(ENCODED_PW),
+        "credentials stripped: {uri}"
+    );
+    assert!(
+        uri.ends_with("?capture_instances=dbo_users"),
+        "dataset_uri: {uri}"
+    );
+
+    assert!(source.config_schema().get("properties").is_some());
+
+    // capture_resume_position anchors at the current max LSN (Some once CDC is
+    // active). Enable one write first so a max LSN exists.
+    exec(&_pool, "INSERT INTO dbo.users (id, name) VALUES (9, N'x')").await;
+    wait_for_changes(&_pool, 1).await;
+    let pos = source.capture_resume_position().await.expect("capture");
+    let pos = pos.expect("mssql-cdc must capture a position once CDC is active");
+    assert!(
+        pos.get(CI).and_then(Value::as_str).is_some(),
+        "resume position map: {pos}"
+    );
+
+    let report = source
+        .check(&CheckContext::default())
+        .await
+        .expect("check report");
+    assert_eq!(report.failed_count(), 0, "all probes must pass: {report:?}");
+    let names: Vec<&str> = report.probes.iter().map(|p| p.name).collect();
+    assert!(names.contains(&"connection"));
+    assert!(names.contains(&"cdc-enabled"));
+    assert!(names.contains(&"capture-instances"));
+    for probe in &report.probes {
+        assert!(
+            matches!(probe.status, ProbeStatus::Pass),
+            "probe {} must pass",
+            probe.name
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn new_rejects_missing_capture_instance() {
+    let _serial = SERIAL.lock().await;
+    let (_c, port) = start_mssql_cdc().await;
+    let (_pool, conn) = setup(port, "cdc_missing").await;
+
+    let config: MssqlCdcSourceConfig = serde_json::from_value(json!({
+        "connection_url": conn.connection_url,
+        "tls": { "type": "trust_server_certificate" },
+        "capture_instances": ["dbo_does_not_exist"],
+    }))
+    .expect("config");
+    let msg = match MssqlCdcSource::new(config).await {
+        Ok(_) => panic!("new() must reject a nonexistent capture instance"),
+        Err(e) => e.to_string(),
+    };
+    assert!(
+        msg.contains("dbo_does_not_exist"),
+        "error must name the instance: {msg}"
+    );
+    assert!(
+        msg.contains("sp_cdc_enable_table"),
+        "error must hint the fix: {msg}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn new_rejects_cdc_disabled_database() {
+    let _serial = SERIAL.lock().await;
+    let (_c, port) = start_mssql_cdc().await;
+    // A database that never had `sp_cdc_enable_db` run.
+    let master = build_pool(&conn_cfg(port, "master"), 2)
+        .await
+        .expect("master pool");
+    exec(
+        &master,
+        "IF DB_ID('cdc_off') IS NULL CREATE DATABASE cdc_off",
+    )
+    .await;
+    let conn = conn_cfg(port, "cdc_off");
+
+    let config: MssqlCdcSourceConfig = serde_json::from_value(json!({
+        "connection_url": conn.connection_url,
+        "tls": { "type": "trust_server_certificate" },
+        "capture_instances": ["dbo_anything"],
+    }))
+    .expect("config");
+    let msg = match MssqlCdcSource::new(config).await {
+        Ok(_) => panic!("new() must reject a CDC-disabled database"),
+        Err(e) => e.to_string(),
+    };
+    assert!(
+        msg.contains("change data capture is not enabled"),
+        "msg: {msg}"
+    );
+    assert!(
+        msg.contains("sp_cdc_enable_db"),
+        "error must hint the fix: {msg}"
+    );
+}

--- a/crates/source/pubsub/Cargo.toml
+++ b/crates/source/pubsub/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "faucet-source-pubsub"
+version = "1.0.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Google Cloud Pub/Sub source connector for faucet-stream (streaming pull, ack at durable page boundaries, resumable termination)"
+readme = "README.md"
+keywords = ["pubsub", "gcp", "messaging", "etl", "connector"]
+categories.workspace = true
+
+[dependencies]
+faucet-core.workspace = true
+faucet-common-pubsub.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+schemars.workspace = true
+gcloud-pubsub.workspace = true
+async-trait.workspace = true
+async-stream.workspace = true
+futures.workspace = true
+tokio = { workspace = true, features = ["rt", "macros", "sync", "time"] }
+tracing.workspace = true
+base64.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time", "sync"] }
+serde_yaml = "0.9"
+testcontainers = "0.27"
+testcontainers-modules = { version = "0.15", features = ["google_cloud_sdk_emulators"] }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/source/pubsub/README.md
+++ b/crates/source/pubsub/README.md
@@ -1,0 +1,79 @@
+# faucet-source-pubsub
+
+Google Cloud Pub/Sub **source** connector for
+[faucet-stream](https://github.com/PawanSikawat/faucet-stream). Streams
+messages from a subscription, emits one record per message, and acks messages
+only once the pipeline has durably written them.
+
+## Configuration
+
+```yaml
+source:
+  kind: pubsub
+  config:
+    subscription: orders-sub          # required (short id, not the full path)
+    project_id: my-gcp-project        # required for real Pub/Sub
+    # emulator_host: "localhost:8085" # or set PUBSUB_EMULATOR_HOST
+    credentials: { type: application_default }
+    value_format: json                # json | string | bytes  (default json)
+    attributes_key: __attributes      # JSON key for the message attribute map
+    max_messages_per_pull: 100        # 1..=1000 (default 100)
+    idle_termination_secs: 30         # stop after N idle seconds
+    max_messages: 100000              # or stop after N messages
+    batch_size: 1000                  # records per page (0 = one page per drain)
+```
+
+At least one of `idle_termination_secs` / `max_messages` **must** be set so a
+batch run terminates (mirrors the Kafka / Kinesis sources).
+
+### Credentials
+
+`{ type, config }` shape, same as every faucet connector:
+
+- `{ type: application_default }` — ADC (env, gcloud, metadata server).
+- `{ type: service_account_json_file, config: { path } }`
+- `{ type: service_account_json_inline, config: { json } }` — pair with
+  `${secret:…}` / `${env:…}`.
+- `{ type: anonymous }` — for the emulator.
+
+## Emitted record shape
+
+```json
+{
+  "data": { ... },                 // decoded per value_format
+  "__attributes": { "k": "v" },    // key configurable via attributes_key
+  "message_id": "123456789",
+  "ordering_key": "order-42",      // omitted when empty
+  "publish_time_millis": 1716700000123
+}
+```
+
+`value_format`: `json` parses the payload as JSON; `string` decodes UTF-8 into a
+JSON string; `bytes` base64-encodes the raw payload.
+
+## Delivery semantics — at-least-once
+
+Messages are acked at **durable page boundaries**: a page's messages are acked
+only after the pipeline has written that page to the sink and persisted its
+bookmark. A crash between the sink write and the ack redelivers those messages
+on the next run — never data loss, but duplicates are possible. Pair with an
+upsert sink keyed on `message_id` when replays must converge.
+
+**Exactly-once delivery is not supported** — Pub/Sub offers no primitive that
+composes with faucet's atomic-watermark model. The bookmark this source
+persists is informational only (a cumulative count + last `message_id`); on
+resume the subscription redelivers whatever was never acked.
+
+## Testing
+
+Unit tests are fully offline. Integration tests (`tests/integration.rs`)
+require the Pub/Sub emulator and are skipped unless `PUBSUB_EMULATOR_HOST` is
+set:
+
+```bash
+gcloud beta emulators pubsub start --host-port=localhost:8085 &
+export PUBSUB_EMULATOR_HOST=localhost:8085
+cargo test -p faucet-source-pubsub
+```
+
+License: MIT OR Apache-2.0.

--- a/crates/source/pubsub/src/config.rs
+++ b/crates/source/pubsub/src/config.rs
@@ -1,0 +1,210 @@
+//! Configuration for the Pub/Sub source. No I/O here.
+
+use faucet_common_pubsub::PubsubConnection;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// How each message's `data` payload is decoded into the emitted `data` field.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ValueFormat {
+    /// Parse the payload as JSON. A message that is not valid JSON fails the
+    /// stream with a typed error naming its `message_id`.
+    #[default]
+    Json,
+    /// Decode the payload as UTF-8 (invalid UTF-8 fails the message).
+    String,
+    /// Base64-encode the raw payload bytes into a JSON string.
+    Bytes,
+}
+
+/// The default JSON key the per-message attribute map is surfaced under.
+pub const DEFAULT_ATTRIBUTES_KEY: &str = "__attributes";
+
+/// Configuration for [`PubsubSource`](crate::PubsubSource).
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct PubsubSourceConfig {
+    /// Subscription id (short name, not the fully-qualified path). The client
+    /// forms `projects/<project>/subscriptions/<id>` from the connection's
+    /// project.
+    pub subscription: String,
+
+    /// Project / endpoint / emulator / credentials (flattened).
+    #[serde(flatten)]
+    pub connection: PubsubConnection,
+
+    /// Payload decoding for the message `data` field.
+    #[serde(default)]
+    pub value_format: ValueFormat,
+
+    /// JSON key the message attribute map is surfaced under. Default
+    /// `__attributes`.
+    #[serde(default = "default_attributes_key")]
+    pub attributes_key: String,
+
+    /// Messages requested per `pull` RPC (1–1000). Default 100.
+    #[serde(default = "default_max_messages_per_pull")]
+    pub max_messages_per_pull: usize,
+
+    /// Stop after this many seconds without a new message. At least one of
+    /// `idle_termination_secs` and `max_messages` must be set (mirrors the
+    /// Kafka / Kinesis sources) — a batch run must terminate.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub idle_termination_secs: Option<u64>,
+    /// Stop after this many messages in total.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_messages: Option<usize>,
+
+    /// Records per emitted [`StreamPage`](faucet_core::StreamPage). `0` is the
+    /// "no batching" sentinel: one page per drain. Default 1000. A page's
+    /// messages are acked once the pipeline has durably written the page.
+    #[serde(default = "default_batch_size")]
+    pub batch_size: usize,
+}
+
+fn default_attributes_key() -> String {
+    DEFAULT_ATTRIBUTES_KEY.to_string()
+}
+fn default_max_messages_per_pull() -> usize {
+    100
+}
+fn default_batch_size() -> usize {
+    faucet_core::DEFAULT_BATCH_SIZE
+}
+
+impl PubsubSourceConfig {
+    /// Minimal config with defaults for everything but the subscription id.
+    pub fn new(subscription: impl Into<String>) -> Self {
+        Self {
+            subscription: subscription.into(),
+            connection: PubsubConnection::default(),
+            value_format: ValueFormat::default(),
+            attributes_key: default_attributes_key(),
+            max_messages_per_pull: default_max_messages_per_pull(),
+            idle_termination_secs: None,
+            max_messages: None,
+            batch_size: default_batch_size(),
+        }
+    }
+
+    /// Fail-fast validation, called from `PubsubSource::new`.
+    pub fn validate(&self) -> Result<(), faucet_core::FaucetError> {
+        use faucet_core::FaucetError;
+        if self.subscription.trim().is_empty() {
+            return Err(FaucetError::Config(
+                "pubsub source: subscription must not be empty".into(),
+            ));
+        }
+        if self.attributes_key.trim().is_empty() {
+            return Err(FaucetError::Config(
+                "pubsub source: attributes_key must not be empty".into(),
+            ));
+        }
+        if self.max_messages_per_pull == 0 || self.max_messages_per_pull > 1000 {
+            return Err(FaucetError::Config(format!(
+                "pubsub source: max_messages_per_pull must be 1..=1000 (got {})",
+                self.max_messages_per_pull
+            )));
+        }
+        faucet_core::validate_batch_size(self.batch_size)?;
+        if self.idle_termination_secs.is_none() && self.max_messages.is_none() {
+            return Err(FaucetError::Config(
+                "pubsub source: set at least one of idle_termination_secs / max_messages so a \
+                 run can terminate (mirrors the kafka / kinesis sources)"
+                    .into(),
+            ));
+        }
+        if self.idle_termination_secs == Some(0) {
+            return Err(FaucetError::Config(
+                "pubsub source: idle_termination_secs must be at least 1".into(),
+            ));
+        }
+        if self.max_messages == Some(0) {
+            return Err(FaucetError::Config(
+                "pubsub source: max_messages must be at least 1".into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use faucet_common_pubsub::PubsubCredentials;
+
+    fn valid() -> PubsubSourceConfig {
+        let mut c = PubsubSourceConfig::new("orders-sub");
+        c.max_messages = Some(100);
+        c
+    }
+
+    #[test]
+    fn defaults_are_sensible() {
+        let c = PubsubSourceConfig::new("orders-sub");
+        assert_eq!(c.value_format, ValueFormat::Json);
+        assert_eq!(c.attributes_key, "__attributes");
+        assert_eq!(c.max_messages_per_pull, 100);
+        assert_eq!(c.batch_size, faucet_core::DEFAULT_BATCH_SIZE);
+        assert!(c.idle_termination_secs.is_none() && c.max_messages.is_none());
+    }
+
+    #[test]
+    fn validation_bounds() {
+        valid().validate().unwrap();
+
+        let mut c = valid();
+        c.subscription = "  ".into();
+        assert!(c.validate().is_err());
+
+        let mut c = valid();
+        c.attributes_key = String::new();
+        assert!(c.validate().is_err());
+
+        let mut c = valid();
+        c.max_messages_per_pull = 0;
+        assert!(c.validate().is_err());
+        c.max_messages_per_pull = 1001;
+        assert!(c.validate().is_err());
+
+        let mut c = valid();
+        c.batch_size = faucet_core::MAX_BATCH_SIZE + 1;
+        assert!(c.validate().is_err());
+
+        let mut c = valid();
+        c.idle_termination_secs = None;
+        c.max_messages = None;
+        let err = c.validate().unwrap_err();
+        assert!(err.to_string().contains("idle_termination_secs"), "{err}");
+
+        let mut c = valid();
+        c.idle_termination_secs = Some(0);
+        assert!(c.validate().is_err());
+        let mut c = valid();
+        c.max_messages = Some(0);
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn full_config_parses_from_yaml() {
+        let yaml = r#"
+subscription: orders-sub
+project_id: my-proj
+emulator_host: "localhost:8085"
+credentials: { type: anonymous }
+value_format: string
+attributes_key: attrs
+max_messages_per_pull: 250
+idle_termination_secs: 5
+max_messages: 500
+batch_size: 100
+"#;
+        let c: PubsubSourceConfig = serde_yaml::from_str(yaml).unwrap();
+        c.validate().unwrap();
+        assert_eq!(c.value_format, ValueFormat::String);
+        assert_eq!(c.attributes_key, "attrs");
+        assert_eq!(c.connection.project_id.as_deref(), Some("my-proj"));
+        assert_eq!(c.connection.credentials, PubsubCredentials::Anonymous);
+        assert_eq!(c.max_messages_per_pull, 250);
+    }
+}

--- a/crates/source/pubsub/src/convert.rs
+++ b/crates/source/pubsub/src/convert.rs
@@ -1,0 +1,179 @@
+//! Pure payload decoding and message → record assembly. No SDK types leak in
+//! here beyond the plain fields (`data` / `attributes` / `message_id` / …)
+//! read off a message, so this module unit-tests fully offline.
+
+use crate::config::ValueFormat;
+use faucet_core::FaucetError;
+use serde_json::{Map, Value, json};
+use std::collections::HashMap;
+
+/// Decode one message payload per the configured format. Pure.
+pub(crate) fn decode_payload(
+    data: &[u8],
+    format: ValueFormat,
+    message_id: &str,
+) -> Result<Value, FaucetError> {
+    match format {
+        ValueFormat::Json => serde_json::from_slice(data).map_err(|e| {
+            FaucetError::Source(format!(
+                "pubsub: message {message_id} payload is not valid JSON: {e}"
+            ))
+        }),
+        ValueFormat::String => match std::str::from_utf8(data) {
+            Ok(s) => Ok(Value::String(s.to_string())),
+            Err(e) => Err(FaucetError::Source(format!(
+                "pubsub: message {message_id} payload is not valid UTF-8: {e}"
+            ))),
+        },
+        ValueFormat::Bytes => {
+            use base64::Engine as _;
+            Ok(Value::String(
+                base64::engine::general_purpose::STANDARD.encode(data),
+            ))
+        }
+    }
+}
+
+/// Convert a message's attribute map into a JSON object of strings. Pure.
+pub(crate) fn attributes_to_value(attributes: &HashMap<String, String>) -> Value {
+    let mut map = Map::with_capacity(attributes.len());
+    for (k, v) in attributes {
+        map.insert(k.clone(), Value::String(v.clone()));
+    }
+    Value::Object(map)
+}
+
+/// Assemble the emitted record from a decoded payload + Pub/Sub metadata.
+/// Pure — `publish_time_millis`/`ordering_key` are omitted when absent/empty.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn message_to_record(
+    data: &[u8],
+    attributes: &HashMap<String, String>,
+    message_id: &str,
+    ordering_key: &str,
+    publish_time_millis: Option<i64>,
+    format: ValueFormat,
+    attributes_key: &str,
+) -> Result<Value, FaucetError> {
+    let payload = decode_payload(data, format, message_id)?;
+    let mut record = Map::new();
+    record.insert("data".to_string(), payload);
+    record.insert(attributes_key.to_string(), attributes_to_value(attributes));
+    record.insert("message_id".to_string(), json!(message_id));
+    if !ordering_key.is_empty() {
+        record.insert("ordering_key".to_string(), json!(ordering_key));
+    }
+    if let Some(ms) = publish_time_millis {
+        record.insert("publish_time_millis".to_string(), json!(ms));
+    }
+    Ok(Value::Object(record))
+}
+
+/// Convert a protobuf `Timestamp` (seconds + nanos) to epoch milliseconds.
+/// Pure; saturating so an absurd timestamp never panics.
+pub(crate) fn timestamp_millis(seconds: i64, nanos: i32) -> i64 {
+    seconds
+        .saturating_mul(1000)
+        .saturating_add(i64::from(nanos) / 1_000_000)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn attrs(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn payload_decodes_per_format() {
+        let j = decode_payload(br#"{"a":1}"#, ValueFormat::Json, "m1").unwrap();
+        assert_eq!(j["a"], 1);
+        let err = decode_payload(b"not json", ValueFormat::Json, "m-bad")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("m-bad"), "{err}");
+
+        let s = decode_payload("héllo".as_bytes(), ValueFormat::String, "m1").unwrap();
+        assert_eq!(s, Value::String("héllo".into()));
+        assert!(decode_payload(&[0xff, 0xfe], ValueFormat::String, "m1").is_err());
+
+        let b = decode_payload(&[1, 2, 3], ValueFormat::Bytes, "m1").unwrap();
+        assert_eq!(b, Value::String("AQID".into()));
+    }
+
+    #[test]
+    fn attributes_map_to_string_object() {
+        let v = attributes_to_value(&attrs(&[("k1", "v1"), ("k2", "v2")]));
+        assert_eq!(v["k1"], "v1");
+        assert_eq!(v["k2"], "v2");
+        assert_eq!(attributes_to_value(&HashMap::new()), json!({}));
+    }
+
+    #[test]
+    fn record_shape_full() {
+        let r = message_to_record(
+            br#"{"x":1}"#,
+            &attrs(&[("origin", "eu")]),
+            "msg-7",
+            "order-42",
+            Some(1_716_700_000_123),
+            ValueFormat::Json,
+            "__attributes",
+        )
+        .unwrap();
+        assert_eq!(r["data"]["x"], 1);
+        assert_eq!(r["__attributes"]["origin"], "eu");
+        assert_eq!(r["message_id"], "msg-7");
+        assert_eq!(r["ordering_key"], "order-42");
+        assert_eq!(r["publish_time_millis"], 1_716_700_000_123i64);
+    }
+
+    #[test]
+    fn record_omits_absent_optionals_and_honours_attributes_key() {
+        let r = message_to_record(
+            b"raw text",
+            &HashMap::new(),
+            "msg-8",
+            "", // empty ordering key → omitted
+            None,
+            ValueFormat::String,
+            "attrs",
+        )
+        .unwrap();
+        assert_eq!(r["data"], "raw text");
+        assert!(r.get("attrs").is_some());
+        assert!(r.get("__attributes").is_none());
+        assert!(r.get("ordering_key").is_none());
+        assert!(r.get("publish_time_millis").is_none());
+    }
+
+    #[test]
+    fn record_propagates_decode_error() {
+        let err = message_to_record(
+            b"not json",
+            &HashMap::new(),
+            "msg-9",
+            "",
+            None,
+            ValueFormat::Json,
+            "__attributes",
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("msg-9"), "{err}");
+    }
+
+    #[test]
+    fn timestamp_millis_math() {
+        assert_eq!(
+            timestamp_millis(1_716_700_000, 123_000_000),
+            1_716_700_000_123
+        );
+        assert_eq!(timestamp_millis(0, 0), 0);
+        // Saturating on overflow rather than panicking.
+        assert_eq!(timestamp_millis(i64::MAX, 0), i64::MAX);
+    }
+}

--- a/crates/source/pubsub/src/lib.rs
+++ b/crates/source/pubsub/src/lib.rs
@@ -1,0 +1,29 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+//! # faucet-source-pubsub
+//!
+//! Google Cloud Pub/Sub source connector for
+//! [faucet-stream](https://github.com/PawanSikawat/faucet-stream): streaming
+//! pull from a subscription, per-message record assembly with a configurable
+//! `value_format` (json / string / bytes) and an attribute map surfaced under
+//! a configurable key, and the standard `idle_termination_secs` /
+//! `max_messages` termination knobs (at least one is required).
+//!
+//! **Delivery is at-least-once.** Messages are acked only at **durable page
+//! boundaries** — a page's messages are acked once the pipeline has written
+//! that page to the sink and persisted its bookmark, so a crash between the
+//! sink write and the ack redelivers those messages on the next run. Pair with
+//! an upsert sink keyed on `message_id` when replays must converge. Exactly-once
+//! delivery is out of scope (Pub/Sub provides no compatible primitive).
+
+mod config;
+mod convert;
+mod state;
+mod stream;
+
+pub use config::{DEFAULT_ATTRIBUTES_KEY, PubsubSourceConfig, ValueFormat};
+pub use state::PubsubBookmark;
+pub use stream::PubsubSource;
+
+// Shared connection types, re-exported so users need only this crate.
+pub use faucet_common_pubsub::{PubsubConnection, PubsubCredentials};

--- a/crates/source/pubsub/src/state.rs
+++ b/crates/source/pubsub/src/state.rs
@@ -1,0 +1,81 @@
+//! Bookmark shape + state key for the Pub/Sub source.
+//!
+//! Pub/Sub has **no client-side resume offset** — durability is the server
+//! tracking acked messages on the subscription. So the emitted bookmark is
+//! purely informational (a cumulative count + the last message id): it exists
+//! so each durable page triggers a `flush` + `StateStore::put`, which is the
+//! signal the streaming loop uses to ack the previous page. On resume the
+//! subscription redelivers whatever was never acked, so the persisted
+//! bookmark is not consulted to seek.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// The persisted (informational) bookmark value.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PubsubBookmark {
+    /// Cumulative messages emitted this run.
+    #[serde(default)]
+    pub delivered: u64,
+    /// The most recently emitted message id (for observability).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_message_id: Option<String>,
+}
+
+impl PubsubBookmark {
+    /// Record one more delivered message.
+    pub fn advance(&mut self, message_id: &str) {
+        self.delivered += 1;
+        self.last_message_id = Some(message_id.to_string());
+    }
+
+    pub fn to_value(&self) -> Value {
+        serde_json::to_value(self).unwrap_or(Value::Null)
+    }
+
+    /// Parse a bookmark `Value`; a malformed value is treated as fresh (never
+    /// fails a run — Pub/Sub redelivers unacked messages regardless).
+    pub fn from_value(v: &Value) -> Self {
+        serde_json::from_value(v.clone()).unwrap_or_default()
+    }
+}
+
+/// The source's stable state key.
+pub fn state_key(subscription: &str) -> String {
+    format!("pubsub:{subscription}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn bookmark_advances_and_round_trips() {
+        let mut b = PubsubBookmark::default();
+        b.advance("m1");
+        b.advance("m2");
+        assert_eq!(b.delivered, 2);
+        assert_eq!(b.last_message_id.as_deref(), Some("m2"));
+        let back = PubsubBookmark::from_value(&b.to_value());
+        assert_eq!(back, b);
+    }
+
+    #[test]
+    fn malformed_bookmark_is_fresh() {
+        assert_eq!(
+            PubsubBookmark::from_value(&json!("nope")),
+            PubsubBookmark::default()
+        );
+        assert_eq!(
+            PubsubBookmark::from_value(&json!(null)),
+            PubsubBookmark::default()
+        );
+    }
+
+    #[test]
+    fn state_key_shape_is_valid() {
+        assert_eq!(state_key("orders-sub"), "pubsub:orders-sub");
+        faucet_core::state::validate_state_key(&state_key("orders-sub")).unwrap();
+    }
+}

--- a/crates/source/pubsub/src/stream.rs
+++ b/crates/source/pubsub/src/stream.rs
@@ -1,0 +1,321 @@
+//! The Pub/Sub `Source` implementation: streaming pull, per-message record
+//! assembly, cumulative informational bookmark, ack **at durable page
+//! boundaries**, and idle / max-messages termination.
+//!
+//! **SDK-touching module.** All `gcloud-pubsub` calls live here (client
+//! construction is in `faucet-common-pubsub`), so a real-compile fixup for a
+//! differing SDK version is localised to `pull_messages`, `ack_messages`,
+//! `subscribe`, and `check`.
+
+use crate::config::PubsubSourceConfig;
+use crate::convert::{message_to_record, timestamp_millis};
+use crate::state::{PubsubBookmark, state_key};
+use faucet_core::{FaucetError, Stream, StreamPage};
+use gcloud_pubsub::client::Client;
+use gcloud_pubsub::subscriber::ReceivedMessage;
+use gcloud_pubsub::subscription::Subscription;
+use serde_json::Value;
+use std::pin::Pin;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+/// Google Cloud Pub/Sub source. See the crate README for semantics.
+pub struct PubsubSource {
+    config: PubsubSourceConfig,
+    client: Client,
+    /// Bookmark applied by the pipeline before streaming — informational only
+    /// (Pub/Sub redelivers unacked messages; there is no client-side seek).
+    start_bookmark: Mutex<Option<PubsubBookmark>>,
+}
+
+impl PubsubSource {
+    /// Create a new Pub/Sub source. Validates the config and builds the client.
+    pub async fn new(config: PubsubSourceConfig) -> Result<Self, FaucetError> {
+        config.validate()?;
+        let client = faucet_common_pubsub::build_client(&config.connection).await?;
+        Ok(Self {
+            config,
+            client,
+            start_bookmark: Mutex::new(None),
+        })
+    }
+
+    fn subscription(&self) -> Subscription {
+        self.client.subscription(&self.config.subscription)
+    }
+}
+
+/// Pull up to `max` messages. Thin SDK shim.
+async fn pull_messages(
+    subscription: &Subscription,
+    max: usize,
+) -> Result<Vec<ReceivedMessage>, FaucetError> {
+    subscription
+        .pull(max as i32, None)
+        .await
+        .map_err(|e| FaucetError::Source(format!("pubsub: pull failed: {e}")))
+}
+
+/// Ack a batch of messages (best-effort — a failed ack means redelivery, i.e.
+/// at-least-once, never data loss). Thin SDK shim.
+async fn ack_messages(messages: &[ReceivedMessage]) {
+    for m in messages {
+        if let Err(e) = m.ack().await {
+            tracing::warn!(error = %e, "pubsub: ack failed; message will be redelivered");
+        }
+    }
+}
+
+impl PubsubSource {
+    /// Epoch-millis publish time of a received message, if the server set it.
+    fn publish_millis(m: &ReceivedMessage) -> Option<i64> {
+        m.message
+            .publish_time
+            .as_ref()
+            .map(|t| timestamp_millis(t.seconds, t.nanos))
+    }
+}
+
+#[faucet_core::async_trait]
+impl faucet_core::Source for PubsubSource {
+    async fn fetch_with_context(
+        &self,
+        context: &std::collections::HashMap<String, Value>,
+    ) -> Result<Vec<Value>, FaucetError> {
+        use futures::StreamExt;
+        let mut pages = self.stream_pages(context, self.config.batch_size);
+        let mut all = Vec::new();
+        while let Some(page) = pages.next().await {
+            all.extend(page?.records);
+        }
+        Ok(all)
+    }
+
+    fn stream_pages<'a>(
+        &'a self,
+        _context: &'a std::collections::HashMap<String, Value>,
+        _batch_size: usize,
+    ) -> Pin<Box<dyn Stream<Item = Result<StreamPage, FaucetError>> + Send + 'a>> {
+        let chunk = if self.config.batch_size == 0 {
+            usize::MAX
+        } else {
+            self.config.batch_size
+        };
+        let idle = self.config.idle_termination_secs.map(Duration::from_secs);
+        let max_messages = self.config.max_messages;
+        let per_pull = self.config.max_messages_per_pull;
+        let format = self.config.value_format;
+        let attributes_key = self.config.attributes_key.clone();
+
+        Box::pin(async_stream::try_stream! {
+            let subscription = self.subscription();
+
+            let mut cumulative = self
+                .start_bookmark
+                .lock()
+                .expect("bookmark mutex poisoned")
+                .clone()
+                .unwrap_or_default();
+
+            // Messages of pages yielded since the last ack. Acked at the top of
+            // the next iteration — by then the pipeline has written each page to
+            // the sink and persisted its bookmark, so acking is safe (a crash
+            // before the ack redelivers, i.e. at-least-once).
+            let mut pending: Vec<ReceivedMessage> = Vec::new();
+            let mut buffer: Vec<Value> = Vec::new();
+            let mut page_msgs: Vec<ReceivedMessage> = Vec::new();
+            let mut total = 0usize;
+            let mut last_activity = Instant::now();
+
+            'consume: loop {
+                if !pending.is_empty() {
+                    ack_messages(&pending).await;
+                    pending.clear();
+                }
+
+                let pull = pull_messages(&subscription, per_pull);
+                let messages = match idle {
+                    Some(window) => match tokio::time::timeout(window, pull).await {
+                        Ok(res) => res?,
+                        Err(_) => {
+                            tracing::info!(
+                                subscription = %self.config.subscription,
+                                idle_secs = window.as_secs(),
+                                "pubsub: idle termination reached"
+                            );
+                            break 'consume;
+                        }
+                    },
+                    None => pull.await?,
+                };
+
+                if messages.is_empty() {
+                    if let Some(window) = idle
+                        && last_activity.elapsed() >= window
+                    {
+                        tracing::info!(
+                            subscription = %self.config.subscription,
+                            idle_secs = window.as_secs(),
+                            "pubsub: idle termination reached"
+                        );
+                        break 'consume;
+                    }
+                    // No idle window (max-messages only) and no messages: yield
+                    // to the scheduler briefly to avoid a hot spin.
+                    tokio::time::sleep(Duration::from_millis(200)).await;
+                    continue;
+                }
+                last_activity = Instant::now();
+
+                for m in messages {
+                    let record = message_to_record(
+                        &m.message.data,
+                        &m.message.attributes,
+                        &m.message.message_id,
+                        &m.message.ordering_key,
+                        Self::publish_millis(&m),
+                        format,
+                        &attributes_key,
+                    )?;
+                    cumulative.advance(&m.message.message_id);
+                    buffer.push(record);
+                    page_msgs.push(m);
+                    total += 1;
+
+                    if buffer.len() >= chunk {
+                        let records = std::mem::take(&mut buffer);
+                        yield StreamPage {
+                            records,
+                            bookmark: Some(cumulative.to_value()),
+                        };
+                        pending.append(&mut page_msgs);
+                    }
+
+                    if let Some(max) = max_messages
+                        && total >= max
+                    {
+                        tracing::info!(
+                            subscription = %self.config.subscription,
+                            max,
+                            "pubsub: max_messages reached"
+                        );
+                        break 'consume;
+                    }
+                }
+            }
+
+            // Flush any buffered-but-un-yielded records as a final page.
+            if !buffer.is_empty() {
+                let records = std::mem::take(&mut buffer);
+                let final_msgs = std::mem::take(&mut page_msgs);
+                yield StreamPage {
+                    records,
+                    bookmark: Some(cumulative.to_value()),
+                };
+                pending.extend(final_msgs);
+            }
+
+            // Every remaining page has now resumed past its `yield`, so it is
+            // durable — ack it before returning.
+            if !pending.is_empty() {
+                ack_messages(&pending).await;
+            }
+
+            tracing::info!(
+                subscription = %self.config.subscription,
+                records = total,
+                "pubsub source stream complete"
+            );
+        })
+    }
+
+    fn config_schema(&self) -> Value {
+        serde_json::to_value(faucet_core::schema_for!(PubsubSourceConfig))
+            .expect("schema serialization")
+    }
+
+    fn state_key(&self) -> Option<String> {
+        Some(state_key(&self.config.subscription))
+    }
+
+    async fn apply_start_bookmark(&self, bookmark: Value) -> Result<(), FaucetError> {
+        *self.start_bookmark.lock().expect("bookmark mutex poisoned") =
+            Some(PubsubBookmark::from_value(&bookmark));
+        Ok(())
+    }
+
+    fn connector_name(&self) -> &'static str {
+        "pubsub"
+    }
+
+    fn dataset_uri(&self) -> String {
+        format!(
+            "pubsub://{}/subscriptions/{}",
+            self.config
+                .connection
+                .project_id
+                .as_deref()
+                .unwrap_or("default"),
+            self.config.subscription
+        )
+    }
+
+    /// Side-effect-free probe: confirm the subscription exists (no messages
+    /// consumed). The default first-page probe could block for the full idle
+    /// window on a quiet subscription.
+    async fn check(
+        &self,
+        ctx: &faucet_core::CheckContext,
+    ) -> Result<faucet_core::CheckReport, FaucetError> {
+        use faucet_core::{CheckReport, Probe};
+        let start = std::time::Instant::now();
+        let subscription = self.subscription();
+        let fut = subscription.exists(None);
+        let probe = match tokio::time::timeout(ctx.timeout, fut).await {
+            Err(_) => Probe::fail("subscription_exists", start.elapsed(), "timed out"),
+            Ok(Ok(true)) => Probe::pass("subscription_exists", start.elapsed()),
+            Ok(Ok(false)) => Probe::fail(
+                "subscription_exists",
+                start.elapsed(),
+                format!("subscription '{}' does not exist", self.config.subscription),
+            ),
+            Ok(Err(e)) => Probe::fail("subscription_exists", start.elapsed(), e.to_string()),
+        };
+        Ok(CheckReport::single(probe))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Constructing a live client needs the emulator or real GCP, so the
+    // network-bound trait methods are exercised by `tests/integration.rs`
+    // (emulator-gated). Here we cover the offline, pure-ish surface.
+
+    #[test]
+    fn state_key_and_dataset_uri_helpers() {
+        // dataset_uri/state_key are built from config strings only.
+        assert_eq!(state_key("orders-sub"), "pubsub:orders-sub");
+    }
+
+    #[test]
+    fn config_schema_exposes_fields() {
+        let schema = serde_json::to_value(faucet_core::schema_for!(PubsubSourceConfig)).unwrap();
+        assert!(schema["properties"]["subscription"].is_object());
+        assert!(schema["properties"]["value_format"].is_object());
+    }
+
+    #[tokio::test]
+    async fn new_rejects_config_without_termination() {
+        // Validation runs before any client build, so this fails offline with a
+        // config error (never a network error).
+        // `PubsubSource` holds a non-`Debug` SDK subscription, so `unwrap_err`
+        // (which needs the `Ok` type to be `Debug`) is unavailable — match.
+        let err = match PubsubSource::new(PubsubSourceConfig::new("orders-sub")).await {
+            Ok(_) => panic!("expected a termination-config error"),
+            Err(e) => e,
+        };
+        assert!(err.to_string().contains("idle_termination_secs"), "{err}");
+    }
+}

--- a/crates/source/pubsub/tests/integration.rs
+++ b/crates/source/pubsub/tests/integration.rs
@@ -1,0 +1,243 @@
+//! Integration tests against a real Google Cloud Pub/Sub **emulator** started
+//! automatically in Docker via testcontainers — no external infra, no env
+//! gating, not `#[ignore]`d. Mirrors the DB testcontainer template
+//! (`crates/source/mssql/tests/integration.rs`).
+//!
+//! Requires Docker (the `google/cloud-sdk:*-emulators` image). Run with:
+//! `cargo test -p faucet-source-pubsub --test integration`.
+//!
+//! A single emulator container is shared across every test in this binary (via
+//! a leaked `OnceCell`), so its mapped port is stable. `PUBSUB_EMULATOR_HOST`
+//! is written exactly once, inside the guarded init — the SDK's
+//! `ClientConfig::default()` (used both by the setup client here and by the
+//! connector's `build_client`) reads that env var and switches to the emulator
+//! environment (no auth). Each test uses distinct topic / subscription names so
+//! they run concurrently against the one emulator without a serialization lock.
+
+use faucet_common_pubsub::PubsubMessage;
+use faucet_core::{CheckContext, Source};
+use faucet_source_pubsub::{
+    PubsubConnection, PubsubCredentials, PubsubSource, PubsubSourceConfig, ValueFormat,
+};
+use gcloud_pubsub::client::{Client, ClientConfig};
+use tokio::sync::OnceCell;
+
+use testcontainers_modules::google_cloud_sdk_emulators::{CloudSdk, PUBSUB_PORT};
+use testcontainers_modules::testcontainers::runners::AsyncRunner;
+
+/// Every topic/subscription is created under this project id; the emulator
+/// accepts any project name. The connector and the setup client must agree, or
+/// they would address different `projects/<id>/…` namespaces.
+const PROJECT: &str = "faucet-test";
+
+/// The shared emulator's `host:port` (127.0.0.1:<mapped 8085>).
+static EMULATOR_HOST: OnceCell<String> = OnceCell::const_new();
+
+/// Start (once) the Pub/Sub emulator, publish its host into the process env,
+/// and return `host:port`. The container is intentionally leaked so it lives
+/// for the whole test binary.
+async fn emulator_host() -> &'static str {
+    EMULATOR_HOST
+        .get_or_init(|| async {
+            let container = CloudSdk::pubsub()
+                .start()
+                .await
+                .expect("start pubsub emulator container");
+            let port = container
+                .get_host_port_ipv4(PUBSUB_PORT)
+                .await
+                .expect("pubsub emulator host port");
+            let host = format!("127.0.0.1:{port}");
+            // SAFETY: this write happens exactly once — `get_or_init` serializes
+            // concurrent callers, and no other code reads the env var until
+            // after this future has completed.
+            unsafe {
+                std::env::set_var("PUBSUB_EMULATOR_HOST", &host);
+            }
+            // Keep the container alive for the process lifetime: never run its
+            // `Drop` (which would stop/remove it), so later tests — on their own
+            // per-test runtimes — can keep connecting to it via the host string.
+            std::mem::forget(container);
+            host
+        })
+        .await
+        .as_str()
+}
+
+/// A setup/admin client pointed at the emulator, scoped to `PROJECT`.
+async fn setup_client() -> Client {
+    // `ClientConfig` is `#[non_exhaustive]`, so struct-update syntax is
+    // unavailable — reassign the one field we need after `default()`.
+    #[allow(clippy::field_reassign_with_default)]
+    let config = {
+        let mut config = ClientConfig::default(); // reads PUBSUB_EMULATOR_HOST
+        config.project_id = Some(PROJECT.to_string());
+        config
+    };
+    Client::new(config).await.expect("emulator setup client")
+}
+
+fn conn(host: &str) -> PubsubConnection {
+    PubsubConnection {
+        project_id: Some(PROJECT.into()),
+        emulator_host: Some(host.to_string()),
+        credentials: PubsubCredentials::Anonymous,
+        ..Default::default()
+    }
+}
+
+async fn create_topic_sub(client: &Client, topic_id: &str, sub_id: &str) {
+    let topic = client
+        .create_topic(topic_id, None, None)
+        .await
+        .expect("create topic");
+    client
+        .create_subscription(
+            sub_id,
+            topic.fully_qualified_name(),
+            Default::default(),
+            None,
+        )
+        .await
+        .expect("create subscription");
+}
+
+fn msg(data: &[u8], attrs: &[(&str, &str)], ordering_key: &str) -> PubsubMessage {
+    PubsubMessage {
+        data: data.to_vec(),
+        attributes: attrs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect(),
+        ordering_key: ordering_key.to_string(),
+        ..Default::default()
+    }
+}
+
+async fn publish(client: &Client, topic_id: &str, messages: Vec<PubsubMessage>) {
+    let topic = client.topic(topic_id);
+    let publisher = topic.new_publisher(None);
+    let mut awaiters = Vec::with_capacity(messages.len());
+    for m in messages {
+        awaiters.push(publisher.publish(m).await);
+    }
+    for a in awaiters {
+        a.get().await.expect("publish message");
+    }
+}
+
+/// JSON value_format: attributes surfaced under `__attributes`, `message_id` /
+/// `publish_time_millis` populated by the server, an ordering key round-tripped,
+/// multi-page draining (`batch_size = 2` over 3 messages), and the `check()`
+/// subscription-exists probe. Exercises `stream.rs` streaming-pull + ack path
+/// and `convert.rs` JSON decoding + attribute mapping.
+#[tokio::test(flavor = "multi_thread")]
+async fn source_json_multipage_attributes_and_check() {
+    let host = emulator_host().await;
+    let client = setup_client().await;
+    create_topic_sub(&client, "src-json-t", "src-json-s").await;
+    publish(
+        &client,
+        "src-json-t",
+        vec![
+            msg(br#"{"n":1}"#, &[("origin", "eu")], "ok-1"),
+            msg(br#"{"n":2}"#, &[], ""),
+            msg(br#"{"n":3}"#, &[], ""),
+        ],
+    )
+    .await;
+
+    let mut cfg = PubsubSourceConfig::new("src-json-s");
+    cfg.connection = conn(host);
+    cfg.value_format = ValueFormat::Json;
+    cfg.idle_termination_secs = Some(5);
+    cfg.max_messages = Some(3);
+    cfg.batch_size = 2; // 3 messages → pages of 2 + 1: exercises ack-at-page-boundary
+    let source = PubsubSource::new(cfg).await.expect("source builds");
+
+    // Side-effect-free preflight probe (subscription exists).
+    let report = source
+        .check(&CheckContext::default())
+        .await
+        .expect("check runs");
+    assert_eq!(report.failed_count(), 0, "subscription-exists probe passes");
+
+    let mut records = source.fetch_all().await.expect("drain");
+    assert_eq!(records.len(), 3, "all published messages delivered");
+    records.sort_by_key(|r| r["data"]["n"].as_i64().unwrap());
+    assert_eq!(records[0]["data"]["n"], 1);
+    assert_eq!(records[2]["data"]["n"], 3);
+    assert!(
+        records.iter().all(|r| r["message_id"].is_string()),
+        "server-assigned message_id present"
+    );
+    assert!(
+        records.iter().all(|r| r["publish_time_millis"].is_i64()),
+        "server-assigned publish_time_millis present: {records:?}"
+    );
+    // Attribute map surfaced under the default `__attributes` key.
+    assert!(
+        records.iter().any(|r| r["__attributes"]["origin"] == "eu"),
+        "attribute mapping: {records:?}"
+    );
+    // Ordering key round-tripped onto the record.
+    assert!(
+        records.iter().any(|r| r["ordering_key"] == "ok-1"),
+        "ordering key surfaced: {records:?}"
+    );
+}
+
+/// `value_format: string` decodes the raw payload as UTF-8.
+#[tokio::test(flavor = "multi_thread")]
+async fn source_value_format_string() {
+    let host = emulator_host().await;
+    let client = setup_client().await;
+    create_topic_sub(&client, "src-str-t", "src-str-s").await;
+    publish(
+        &client,
+        "src-str-t",
+        vec![
+            msg(b"hello world", &[], ""),
+            msg("h\u{e9}llo".as_bytes(), &[], ""),
+        ],
+    )
+    .await;
+
+    let mut cfg = PubsubSourceConfig::new("src-str-s");
+    cfg.connection = conn(host);
+    cfg.value_format = ValueFormat::String;
+    cfg.idle_termination_secs = Some(5);
+    cfg.max_messages = Some(2);
+    let source = PubsubSource::new(cfg).await.expect("source builds");
+
+    let records = source.fetch_all().await.expect("drain");
+    let mut datas: Vec<String> = records
+        .iter()
+        .map(|r| r["data"].as_str().unwrap().to_string())
+        .collect();
+    datas.sort();
+    assert_eq!(
+        datas,
+        vec!["hello world".to_string(), "h\u{e9}llo".to_string()]
+    );
+}
+
+/// `value_format: bytes` base64-encodes the raw payload bytes.
+#[tokio::test(flavor = "multi_thread")]
+async fn source_value_format_bytes() {
+    let host = emulator_host().await;
+    let client = setup_client().await;
+    create_topic_sub(&client, "src-bytes-t", "src-bytes-s").await;
+    publish(&client, "src-bytes-t", vec![msg(&[1, 2, 3], &[], "")]).await;
+
+    let mut cfg = PubsubSourceConfig::new("src-bytes-s");
+    cfg.connection = conn(host);
+    cfg.value_format = ValueFormat::Bytes;
+    cfg.idle_termination_secs = Some(5);
+    cfg.max_messages = Some(1);
+    let source = PubsubSource::new(cfg).await.expect("source builds");
+
+    let records = source.fetch_all().await.expect("drain");
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0]["data"], "AQID", "0x010203 → base64");
+}

--- a/crates/source/redshift/Cargo.toml
+++ b/crates/source/redshift/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "faucet-source-redshift"
+version = "1.0.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Amazon Redshift query source connector for the faucet-stream ecosystem"
+readme = "README.md"
+keywords = ["redshift", "aws", "sql", "source", "pipeline"]
+categories.workspace = true
+
+[dependencies]
+faucet-core.workspace = true
+faucet-common-redshift.workspace = true
+schemars.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+async-trait.workspace = true
+tracing.workspace = true
+sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls", "postgres", "json", "chrono", "uuid", "bigdecimal"] }
+base64.workspace = true
+async-stream.workspace = true
+futures.workspace = true
+tokio.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time", "sync"] }
+serde_json.workspace = true
+schemars.workspace = true
+faucet-conformance.workspace = true
+futures.workspace = true
+testcontainers = "0.27"
+testcontainers-modules = { version = "0.15", features = ["postgres"] }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/source/redshift/README.md
+++ b/crates/source/redshift/README.md
@@ -1,0 +1,58 @@
+# faucet-source-redshift
+
+Amazon Redshift query source connector for the
+[`faucet-stream`](https://crates.io/crates/faucet-stream) ecosystem.
+
+Redshift speaks the PostgreSQL wire protocol, so this source connects through
+`sqlx`'s Postgres driver, runs a configurable SQL query, and streams the result
+rows as JSON objects with `O(batch_size)` memory. It supports **full** and
+**incremental** (bookmark-based) replication.
+
+## Configuration
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `host` | yes | Cluster endpoint host. |
+| `port` | no | Port (default `5439`). |
+| `database` | yes | Database name. |
+| `user` | yes | Database user. |
+| `credentials` | yes | `{ type: password, config: { password: … } }`. `iam` / `redshift_data_api` are reserved (not yet supported). |
+| `tls` | no | Require TLS (default `true`; `false` → `sslmode=prefer`). |
+| `query` | yes | SQL query. May contain `${field.path}` context tokens and, for incremental mode, `${bookmark}`. |
+| `params` | no | Positional bind values (`$1, $2, …`) applied before context/bookmark values. |
+| `max_connections` | no | Pool size (default `10`). |
+| `batch_size` | no | Rows per emitted page (default `1000`; `0` = one page). |
+| `replication` | no | `{ type: full }` (default) or `{ type: incremental, column, initial_value }`. |
+| `state_key` | no | Explicit bookmark key; otherwise derived from host/database/query. |
+
+## Incremental replication
+
+With `replication.type = incremental`, only rows whose `column` is strictly
+greater than the stored bookmark (or `initial_value` on the first run) are
+emitted. If the query contains the literal `${bookmark}` token it is replaced
+with a positional bind so Redshift filters server-side; the source also filters
+client-side as a correctness backstop. The new maximum of `column` is persisted
+on the final page.
+
+```yaml
+host: my-cluster.abc123.us-east-1.redshift.amazonaws.com
+database: dev
+user: admin
+credentials:
+  type: password
+  config:
+    password: ${env:REDSHIFT_PASSWORD}
+query: "SELECT * FROM events WHERE updated_at > ${bookmark} ORDER BY updated_at"
+replication:
+  type: incremental
+  column: updated_at
+  initial_value: "2026-01-01T00:00:00Z"
+```
+
+## Testing
+
+Redshift has no local container image, so live round-trip tests live in
+`tests/integration.rs` and are `#[ignore]`d — they run only when `REDSHIFT_*`
+environment variables point at a real cluster.
+
+License: MIT OR Apache-2.0

--- a/crates/source/redshift/src/config.rs
+++ b/crates/source/redshift/src/config.rs
@@ -1,0 +1,185 @@
+//! Amazon Redshift source configuration.
+
+use faucet_common_redshift::RedshiftConnection;
+use faucet_core::{DEFAULT_BATCH_SIZE, FaucetError};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// How the Redshift source replicates rows across runs.
+///
+/// Serializes as `{ type: full }` or
+/// `{ type: incremental, column: "...", initial_value: ... }`.
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, Default, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum RedshiftReplication {
+    /// Every run re-fetches the full result set (default).
+    #[default]
+    Full,
+    /// Only rows whose `column` is strictly greater than the stored bookmark
+    /// (or `initial_value` on the first run) are emitted. If the SQL contains
+    /// the literal token `${bookmark}`, it is replaced with a positional bind
+    /// parameter so Redshift filters server-side (efficient); the source also
+    /// filters client-side as a correctness backstop. The new maximum of
+    /// `column` is persisted on the final page.
+    Incremental {
+        /// Column whose value is the replication cursor (e.g. `updated_at`).
+        column: String,
+        /// Lower bound used on the first run, before any bookmark is stored.
+        initial_value: Value,
+    },
+}
+
+fn default_max_connections() -> u32 {
+    10
+}
+
+fn default_batch_size() -> usize {
+    DEFAULT_BATCH_SIZE
+}
+
+/// Configuration for the Amazon Redshift query source.
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+pub struct RedshiftSourceConfig {
+    /// Connection block (host / port / database / user / credentials / tls),
+    /// flattened to the config top level.
+    #[serde(flatten)]
+    pub connection: RedshiftConnection,
+    /// SQL query to execute. May contain `${field.path}` parent-context tokens
+    /// (resolved to positional binds at runtime) and, for incremental
+    /// replication, a `${bookmark}` token.
+    pub query: String,
+    /// Positional bind parameters for the query, applied in `$1, $2, …` order
+    /// before any context- or bookmark-derived values. Defaults to empty.
+    #[serde(default)]
+    pub params: Vec<Value>,
+    /// Maximum number of connections in the pool. Defaults to 10.
+    #[serde(default = "default_max_connections")]
+    pub max_connections: u32,
+    /// Records per emitted [`StreamPage`](faucet_core::StreamPage). Rows are
+    /// drained from the `sqlx` cursor and yielded whenever the buffer reaches
+    /// this size. Defaults to [`DEFAULT_BATCH_SIZE`].
+    ///
+    /// `batch_size = 0` is the "no batching" sentinel: the cursor is fully
+    /// drained and the entire result set is emitted in a single page.
+    #[serde(default = "default_batch_size")]
+    pub batch_size: usize,
+    /// Replication mode. Defaults to [`RedshiftReplication::Full`].
+    #[serde(default)]
+    pub replication: RedshiftReplication,
+    /// Explicit state-store key for the incremental bookmark. When unset, a key
+    /// is derived from the host / database and a query fingerprint.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state_key: Option<String>,
+}
+
+impl RedshiftSourceConfig {
+    /// Validate the config; returns a human-readable error if invalid.
+    pub fn validate(&self) -> Result<(), FaucetError> {
+        if self.query.trim().is_empty() {
+            return Err(FaucetError::Config(
+                "redshift: `query` must not be empty".into(),
+            ));
+        }
+        if let RedshiftReplication::Incremental { column, .. } = &self.replication
+            && column.trim().is_empty()
+        {
+            return Err(FaucetError::Config(
+                "redshift: incremental replication `column` must not be empty".into(),
+            ));
+        }
+        faucet_core::validate_batch_size(self.batch_size)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use faucet_common_redshift::RedshiftConnection;
+    use serde_json::json;
+
+    fn base() -> RedshiftSourceConfig {
+        RedshiftSourceConfig {
+            connection: RedshiftConnection::new("host", "db", "user", "pw"),
+            query: "SELECT * FROM events".into(),
+            params: Vec::new(),
+            max_connections: default_max_connections(),
+            batch_size: DEFAULT_BATCH_SIZE,
+            replication: RedshiftReplication::Full,
+            state_key: None,
+        }
+    }
+
+    #[test]
+    fn valid_config_passes() {
+        base().validate().unwrap();
+    }
+
+    #[test]
+    fn rejects_empty_query() {
+        let mut c = base();
+        c.query = "  ".into();
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_empty_incremental_column() {
+        let mut c = base();
+        c.replication = RedshiftReplication::Incremental {
+            column: "".into(),
+            initial_value: json!(0),
+        };
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_oversized_batch() {
+        let mut c = base();
+        c.batch_size = faucet_core::MAX_BATCH_SIZE + 1;
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn deserializes_flattened_connection_and_defaults() {
+        let json = r#"{
+            "host": "h",
+            "database": "db",
+            "user": "u",
+            "credentials": {"type": "password", "config": {"password": "pw"}},
+            "query": "SELECT 1"
+        }"#;
+        let c: RedshiftSourceConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(c.connection.host, "h");
+        assert_eq!(c.connection.port, faucet_common_redshift::DEFAULT_PORT);
+        assert_eq!(c.max_connections, 10);
+        assert_eq!(c.batch_size, DEFAULT_BATCH_SIZE);
+        assert!(matches!(c.replication, RedshiftReplication::Full));
+        c.validate().unwrap();
+    }
+
+    #[test]
+    fn deserializes_incremental_replication() {
+        let json = r#"{
+            "host": "h",
+            "database": "db",
+            "user": "u",
+            "credentials": {"type": "password", "config": {"password": "pw"}},
+            "query": "SELECT * FROM t WHERE ts > ${bookmark}",
+            "replication": {"type": "incremental", "column": "ts", "initial_value": "2026-01-01"},
+            "state_key": "my-key"
+        }"#;
+        let c: RedshiftSourceConfig = serde_json::from_str(json).unwrap();
+        match &c.replication {
+            RedshiftReplication::Incremental {
+                column,
+                initial_value,
+            } => {
+                assert_eq!(column, "ts");
+                assert_eq!(initial_value, &json!("2026-01-01"));
+            }
+            _ => panic!("expected incremental"),
+        }
+        assert_eq!(c.state_key.as_deref(), Some("my-key"));
+    }
+}

--- a/crates/source/redshift/src/convert.rs
+++ b/crates/source/redshift/src/convert.rs
@@ -1,0 +1,166 @@
+//! Row decoding and parameter binding for the Redshift source.
+//!
+//! Redshift is PostgreSQL wire-compatible, so this mirrors the native Postgres
+//! source: values decode through `sqlx`'s Postgres row API, and JSON bind values
+//! are classified before binding so large integers keep full precision.
+
+use serde_json::Value;
+use sqlx::{Column, Row};
+
+/// Convert a raw Redshift/Postgres column value to a `serde_json::Value`.
+///
+/// Tries progressively broader decodings and falls back to `Value::Null` for
+/// unsupported or SQL-NULL columns.
+pub(crate) fn pg_value_to_json(row: &sqlx::postgres::PgRow, col_name: &str) -> Value {
+    if let Ok(v) = row.try_get::<Value, _>(col_name) {
+        return v;
+    }
+    if let Ok(v) = row.try_get::<String, _>(col_name) {
+        return Value::String(v);
+    }
+    if let Ok(v) = row.try_get::<i64, _>(col_name) {
+        return Value::Number(v.into());
+    }
+    if let Ok(v) = row.try_get::<i32, _>(col_name) {
+        return Value::Number(v.into());
+    }
+    if let Ok(v) = row.try_get::<i16, _>(col_name) {
+        return Value::Number(v.into());
+    }
+    if let Ok(v) = row.try_get::<f64, _>(col_name) {
+        return serde_json::Number::from_f64(v)
+            .map(Value::Number)
+            .unwrap_or(Value::Null);
+    }
+    if let Ok(v) = row.try_get::<f32, _>(col_name) {
+        return serde_json::Number::from_f64(v as f64)
+            .map(Value::Number)
+            .unwrap_or(Value::Null);
+    }
+    if let Ok(v) = row.try_get::<bool, _>(col_name) {
+        return Value::Bool(v);
+    }
+    // Timestamps → RFC3339 / ISO-8601 strings.
+    if let Ok(v) =
+        row.try_get::<sqlx::types::chrono::DateTime<sqlx::types::chrono::Utc>, _>(col_name)
+    {
+        return Value::String(v.to_rfc3339());
+    }
+    if let Ok(v) = row.try_get::<sqlx::types::chrono::NaiveDateTime, _>(col_name) {
+        return Value::String(v.to_string());
+    }
+    if let Ok(v) = row.try_get::<sqlx::types::chrono::NaiveDate, _>(col_name) {
+        return Value::String(v.to_string());
+    }
+    if let Ok(v) = row.try_get::<sqlx::types::chrono::NaiveTime, _>(col_name) {
+        return Value::String(v.to_string());
+    }
+    if let Ok(v) = row.try_get::<sqlx::types::Uuid, _>(col_name) {
+        return Value::String(v.to_string());
+    }
+    // NUMERIC / DECIMAL → string, preserving exact precision.
+    if let Ok(v) = row.try_get::<sqlx::types::BigDecimal, _>(col_name) {
+        return Value::String(v.to_string());
+    }
+    // Binary (VARBYTE / bytea) → base64 so it survives the JSON round-trip.
+    if let Ok(v) = row.try_get::<Vec<u8>, _>(col_name) {
+        use base64::Engine as _;
+        return Value::String(base64::engine::general_purpose::STANDARD.encode(v));
+    }
+    Value::Null
+}
+
+/// Convert a single row into a JSON object keyed by column name.
+pub(crate) fn row_to_json(row: &sqlx::postgres::PgRow) -> Value {
+    let mut map = serde_json::Map::new();
+    for col in row.columns() {
+        let name = col.name().to_string();
+        let value = pg_value_to_json(row, &name);
+        map.insert(name, value);
+    }
+    Value::Object(map)
+}
+
+/// How a numeric bind value should be bound onto a `sqlx` query. Classifying
+/// before binding keeps any integer in `[i64::MIN, i64::MAX]` exact (binding
+/// large integers as `f64` silently rounds them).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum NumberBind {
+    /// Exact `i64`.
+    I64,
+    /// Above `i64::MAX`; bind the `u64` reinterpreted as `i64` (two's complement).
+    U64,
+    /// Genuine floating-point value.
+    F64,
+}
+
+/// Classify a JSON number into the bind category to use.
+pub(crate) fn classify_number(n: &serde_json::Number) -> NumberBind {
+    if n.is_i64() {
+        NumberBind::I64
+    } else if n.is_u64() {
+        NumberBind::U64
+    } else {
+        NumberBind::F64
+    }
+}
+
+/// Bind a slice of JSON values onto a `sqlx` query as native scalar types, in
+/// positional order (`$1, $2, …`). Binding a raw `serde_json::Value` would
+/// encode as `jsonb` and break comparisons against typed columns, so scalars
+/// are bound as their native types.
+pub(crate) fn bind_params<'q>(
+    mut query: sqlx::query::Query<'q, sqlx::Postgres, sqlx::postgres::PgArguments>,
+    binds: &'q [Value],
+) -> sqlx::query::Query<'q, sqlx::Postgres, sqlx::postgres::PgArguments> {
+    for value in binds {
+        query = match value {
+            Value::String(s) => query.bind(s.clone()),
+            Value::Number(n) => match classify_number(n) {
+                NumberBind::I64 => query.bind(n.as_i64().unwrap()),
+                NumberBind::U64 => query.bind(n.as_u64().unwrap() as i64),
+                NumberBind::F64 => query.bind(n.as_f64().unwrap_or(0.0)),
+            },
+            Value::Bool(b) => query.bind(*b),
+            Value::Null => query.bind(None::<String>),
+            _ => query.bind(value.to_string()),
+        };
+    }
+    query
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn num(v: serde_json::Value) -> serde_json::Number {
+        match v {
+            serde_json::Value::Number(n) => n,
+            _ => panic!("not a number"),
+        }
+    }
+
+    #[test]
+    fn classify_small_int_is_i64() {
+        assert_eq!(classify_number(&num(json!(42))), NumberBind::I64);
+        assert_eq!(classify_number(&num(json!(-7))), NumberBind::I64);
+    }
+
+    #[test]
+    fn classify_above_2_pow_53_stays_i64() {
+        let v = 9_007_199_254_740_993i64; // 2^53 + 1
+        assert_eq!(classify_number(&num(json!(v))), NumberBind::I64);
+    }
+
+    #[test]
+    fn classify_above_i64_max_is_u64() {
+        let v: u64 = i64::MAX as u64 + 1;
+        assert_eq!(classify_number(&num(json!(v))), NumberBind::U64);
+    }
+
+    #[test]
+    fn classify_float_is_f64() {
+        assert_eq!(classify_number(&num(json!(3.5))), NumberBind::F64);
+    }
+}

--- a/crates/source/redshift/src/lib.rs
+++ b/crates/source/redshift/src/lib.rs
@@ -1,0 +1,20 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+//! # faucet-source-redshift
+//!
+//! Amazon Redshift query source connector for the faucet-stream ecosystem.
+//!
+//! Redshift is PostgreSQL wire-compatible, so this source connects through
+//! `sqlx`'s Postgres driver, executes a configurable SQL query, and streams the
+//! result rows as `serde_json::Value` records with `O(batch_size)` memory.
+//! It supports full and incremental (bookmark-based) replication.
+
+pub mod config;
+pub mod convert;
+pub mod stream;
+
+pub use faucet_core::{FaucetError, Source};
+
+pub use config::{RedshiftReplication, RedshiftSourceConfig};
+pub use faucet_common_redshift::{RedshiftConnection, RedshiftCredentials};
+pub use stream::RedshiftSource;

--- a/crates/source/redshift/src/stream.rs
+++ b/crates/source/redshift/src/stream.rs
@@ -1,0 +1,447 @@
+//! Amazon Redshift query source implementation.
+//!
+//! Redshift is PostgreSQL wire-compatible, so the source streams rows through
+//! `sqlx`'s Postgres cursor, re-framing them into `batch_size`-sized pages. It
+//! supports full and incremental replication: the incremental cursor is pushed
+//! down via a `${bookmark}` bind when present and always re-checked client-side.
+
+use std::collections::HashMap;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::pin::Pin;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use faucet_core::replication::{filter_incremental, max_value};
+use faucet_core::util::substitute_context_bind_params;
+use faucet_core::{FaucetError, Source, Stream, StreamPage};
+use futures::TryStreamExt;
+use serde_json::Value;
+use sqlx::PgPool;
+
+use crate::config::{RedshiftReplication, RedshiftSourceConfig};
+use crate::convert::{bind_params, row_to_json};
+
+/// A source that executes a SQL query against Amazon Redshift and returns rows
+/// as JSON objects.
+pub struct RedshiftSource {
+    config: RedshiftSourceConfig,
+    pool: PgPool,
+    /// Bookmark applied via [`Source::apply_start_bookmark`] (incremental only).
+    start_bookmark: Mutex<Option<Value>>,
+}
+
+/// Client-side incremental filter context (column + effective lower bound).
+struct IncrementalCtx {
+    column: String,
+    start: Value,
+}
+
+impl RedshiftSource {
+    /// Create a new source. Validates config and builds a lazily-connected pool
+    /// (no I/O — connectivity is verified on first query or via
+    /// [`Source::check`]).
+    pub fn new(config: RedshiftSourceConfig) -> Result<Self, FaucetError> {
+        config.validate()?;
+        let pool =
+            faucet_common_redshift::build_pool_lazy(&config.connection, config.max_connections)?;
+        Ok(Self {
+            config,
+            pool,
+            start_bookmark: Mutex::new(None),
+        })
+    }
+
+    /// The effective incremental start bookmark (persisted bookmark, else the
+    /// configured `initial_value`), or `None` for full replication.
+    fn incremental_ctx(&self) -> Option<IncrementalCtx> {
+        match &self.config.replication {
+            RedshiftReplication::Full => None,
+            RedshiftReplication::Incremental {
+                column,
+                initial_value,
+            } => {
+                let start = self
+                    .start_bookmark
+                    .lock()
+                    .expect("start_bookmark mutex poisoned")
+                    .clone()
+                    .unwrap_or_else(|| initial_value.clone());
+                Some(IncrementalCtx {
+                    column: column.clone(),
+                    start,
+                })
+            }
+        }
+    }
+
+    /// Build the effective SQL and ordered positional bind values for a parent
+    /// context + optional incremental cursor.
+    ///
+    /// Bind order is: static [`config.params`](RedshiftSourceConfig::params),
+    /// then parent-context `{key}` values, then the `${bookmark}` value (when
+    /// the query contains that token).
+    fn resolve_query(
+        &self,
+        context: &HashMap<String, Value>,
+        incr: Option<&IncrementalCtx>,
+    ) -> (String, Vec<Value>) {
+        let mut binds = self.config.params.clone();
+        let mut sql = self.config.query.clone();
+
+        if !context.is_empty() {
+            let (rewritten, ctx_values) =
+                substitute_context_bind_params(&sql, context, binds.len() + 1, |i| format!("${i}"));
+            sql = rewritten;
+            binds.extend(ctx_values);
+        }
+
+        if let Some(ctx) = incr
+            && sql.contains("${bookmark}")
+        {
+            let marker = format!("${}", binds.len() + 1);
+            sql = sql.replace("${bookmark}", &marker);
+            binds.push(ctx.start.clone());
+        }
+
+        (sql, binds)
+    }
+}
+
+/// Derive a stable state key from the host, database, and query.
+fn default_state_key(config: &RedshiftSourceConfig) -> String {
+    let mut h = DefaultHasher::new();
+    config.connection.host.hash(&mut h);
+    config.connection.port.hash(&mut h);
+    config.connection.database.hash(&mut h);
+    config.query.hash(&mut h);
+    format!("redshift:{:016x}", h.finish())
+}
+
+/// Apply the client-side incremental filter to a page (no-op for full runs).
+fn apply_incr_filter(page: Vec<Value>, incr: Option<&IncrementalCtx>) -> Vec<Value> {
+    match incr {
+        Some(ic) => filter_incremental(page, &ic.column, &ic.start),
+        None => page,
+    }
+}
+
+#[async_trait]
+impl Source for RedshiftSource {
+    fn connector_name(&self) -> &'static str {
+        "redshift"
+    }
+
+    fn config_schema(&self) -> Value {
+        serde_json::to_value(faucet_core::schema_for!(RedshiftSourceConfig))
+            .expect("schema serialization")
+    }
+
+    fn dataset_uri(&self) -> String {
+        format!(
+            "redshift://{}:{}/{}?query={}",
+            self.config.connection.host,
+            self.config.connection.port,
+            self.config.connection.database,
+            self.config.query
+        )
+    }
+
+    fn state_key(&self) -> Option<String> {
+        match &self.config.replication {
+            RedshiftReplication::Full => None,
+            RedshiftReplication::Incremental { .. } => Some(
+                self.config
+                    .state_key
+                    .clone()
+                    .unwrap_or_else(|| default_state_key(&self.config)),
+            ),
+        }
+    }
+
+    async fn apply_start_bookmark(&self, bookmark: Value) -> Result<(), FaucetError> {
+        *self
+            .start_bookmark
+            .lock()
+            .expect("start_bookmark mutex poisoned") = Some(bookmark);
+        Ok(())
+    }
+
+    async fn fetch_with_context(
+        &self,
+        context: &HashMap<String, Value>,
+    ) -> Result<Vec<Value>, FaucetError> {
+        use futures::StreamExt;
+        let mut out = Vec::new();
+        let mut s = self.stream_pages(context, self.config.batch_size);
+        while let Some(page) = s.next().await {
+            out.extend(page?.records);
+        }
+        Ok(out)
+    }
+
+    /// Stream rows from the `sqlx` cursor without buffering the full result set.
+    /// Each emitted [`StreamPage`] holds up to
+    /// [`RedshiftSourceConfig::batch_size`] rows.
+    ///
+    /// For incremental replication the running maximum of the cursor column is
+    /// tracked over the *full* scan (before the client-side filter) and emitted
+    /// as the bookmark on the final page.
+    fn stream_pages<'a>(
+        &'a self,
+        context: &'a HashMap<String, Value>,
+        _batch_size: usize,
+    ) -> Pin<Box<dyn Stream<Item = Result<StreamPage, FaucetError>> + Send + 'a>> {
+        let batch_size = self.config.batch_size;
+
+        Box::pin(async_stream::try_stream! {
+            let incr = self.incremental_ctx();
+            let (query_str, binds) = self.resolve_query(context, incr.as_ref());
+            let query = bind_params(sqlx::query(&query_str), &binds);
+
+            let mut rows = query.fetch(&self.pool);
+            let chunk = if batch_size == 0 { usize::MAX } else { batch_size };
+            let cap = if batch_size == 0 { 1024 } else { batch_size };
+            let mut buffer: Vec<Value> = Vec::with_capacity(cap);
+            let mut running_max: Option<Value> = None;
+            let mut total = 0usize;
+
+            while let Some(row) = rows
+                .try_next()
+                .await
+                .map_err(|e| FaucetError::Source(format!("redshift query failed: {e}")))?
+            {
+                let obj = row_to_json(&row);
+                // Track the running max BEFORE the client-side filter so the
+                // persisted bookmark reflects the full scan.
+                if let Some(ic) = &incr
+                    && let Some(v) = obj.get(&ic.column)
+                {
+                    running_max = Some(match running_max.take() {
+                        Some(m) => max_value(m, v.clone()),
+                        None => v.clone(),
+                    });
+                }
+                buffer.push(obj);
+                if buffer.len() >= chunk {
+                    let page = std::mem::replace(&mut buffer, Vec::with_capacity(cap));
+                    let kept = apply_incr_filter(page, incr.as_ref());
+                    total += kept.len();
+                    if !kept.is_empty() {
+                        yield StreamPage { records: kept, bookmark: None };
+                    }
+                }
+            }
+
+            // Final page carries the new bookmark (incremental only).
+            let kept = apply_incr_filter(buffer, incr.as_ref());
+            total += kept.len();
+            let bookmark = if incr.is_some() { running_max } else { None };
+            if !kept.is_empty() || bookmark.is_some() {
+                yield StreamPage { records: kept, bookmark };
+            }
+
+            tracing::info!(
+                rows = total,
+                batch_size,
+                query = %self.config.query,
+                "Redshift source stream complete",
+            );
+        })
+    }
+
+    /// Preflight probe for `faucet doctor`: acquire a connection and run
+    /// `SELECT 1` (non-scanning — never executes the configured query).
+    async fn check(
+        &self,
+        ctx: &faucet_core::check::CheckContext,
+    ) -> Result<faucet_core::check::CheckReport, FaucetError> {
+        use faucet_core::check::{CheckReport, Probe};
+
+        let started = std::time::Instant::now();
+        let probe =
+            match tokio::time::timeout(ctx.timeout, sqlx::query("SELECT 1").execute(&self.pool))
+                .await
+            {
+                Ok(Ok(_)) => Probe::pass("auth", started.elapsed()),
+                Ok(Err(e)) => Probe::fail_hint(
+                    "auth",
+                    started.elapsed(),
+                    e.to_string(),
+                    "check host/port/database/user/credentials and that the cluster is reachable",
+                ),
+                Err(_) => Probe::fail_hint(
+                    "auth",
+                    started.elapsed(),
+                    "timed out",
+                    "check host/port/database/user/credentials and that the cluster is reachable",
+                ),
+            };
+        Ok(CheckReport::single(probe))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::RedshiftReplication;
+    use faucet_common_redshift::RedshiftConnection;
+    use serde_json::json;
+
+    fn base_config() -> RedshiftSourceConfig {
+        RedshiftSourceConfig {
+            connection: RedshiftConnection::new("host", "db", "user", "pw"),
+            query: "SELECT * FROM t".into(),
+            params: Vec::new(),
+            max_connections: 10,
+            batch_size: 1000,
+            replication: RedshiftReplication::Full,
+            state_key: None,
+        }
+    }
+
+    fn source(c: RedshiftSourceConfig) -> RedshiftSource {
+        RedshiftSource::new(c).unwrap()
+    }
+
+    #[test]
+    fn new_rejects_invalid_batch_size() {
+        let mut c = base_config();
+        c.batch_size = faucet_core::MAX_BATCH_SIZE + 1;
+        match RedshiftSource::new(c) {
+            Err(FaucetError::Config(m)) => assert!(m.contains("batch_size"), "got: {m}"),
+            _ => panic!("expected a batch_size Config error"),
+        }
+    }
+
+    #[test]
+    fn new_surfaces_unsupported_credentials() {
+        let mut c = base_config();
+        c.connection.credentials = faucet_common_redshift::RedshiftCredentials::Iam {
+            region: None,
+            cluster_identifier: None,
+            db_user: None,
+        };
+        assert!(matches!(
+            RedshiftSource::new(c),
+            Err(FaucetError::Config(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn connector_name_is_redshift() {
+        assert_eq!(source(base_config()).connector_name(), "redshift");
+    }
+
+    #[tokio::test]
+    async fn dataset_uri_has_host_db_and_query() {
+        let s = source(base_config());
+        assert_eq!(
+            s.dataset_uri(),
+            "redshift://host:5439/db?query=SELECT * FROM t"
+        );
+    }
+
+    #[tokio::test]
+    async fn config_schema_reports_required_fields() {
+        let s = source(base_config());
+        let schema = s.config_schema();
+        assert!(schema["properties"]["query"].is_object());
+        let required = schema["required"].as_array().expect("required array");
+        assert!(required.iter().any(|v| v == "query"));
+    }
+
+    #[tokio::test]
+    async fn full_mode_has_no_state_key() {
+        assert!(source(base_config()).state_key().is_none());
+    }
+
+    #[tokio::test]
+    async fn incremental_state_key_derived_and_stable() {
+        let mut c = base_config();
+        c.replication = RedshiftReplication::Incremental {
+            column: "ts".into(),
+            initial_value: json!("2026-01-01"),
+        };
+        let k1 = source(c.clone()).state_key().unwrap();
+        let k2 = source(c).state_key().unwrap();
+        assert_eq!(k1, k2);
+        assert!(k1.starts_with("redshift:"));
+    }
+
+    #[tokio::test]
+    async fn explicit_state_key_wins_and_bookmark_overrides_initial() {
+        let mut c = base_config();
+        c.state_key = Some("my-key".into());
+        c.replication = RedshiftReplication::Incremental {
+            column: "ts".into(),
+            initial_value: json!("2026-01-01"),
+        };
+        let s = source(c);
+        assert_eq!(s.state_key().as_deref(), Some("my-key"));
+        s.apply_start_bookmark(json!("2026-06-01")).await.unwrap();
+        assert_eq!(s.incremental_ctx().unwrap().start, json!("2026-06-01"));
+    }
+
+    #[tokio::test]
+    async fn resolve_query_no_context_no_incremental_is_verbatim() {
+        let mut c = base_config();
+        c.params = vec![json!(7)];
+        let s = source(c);
+        let (sql, binds) = s.resolve_query(&HashMap::new(), None);
+        assert_eq!(sql, "SELECT * FROM t");
+        assert_eq!(binds, vec![json!(7)]);
+    }
+
+    #[tokio::test]
+    async fn resolve_query_substitutes_context_positionally() {
+        let mut c = base_config();
+        c.query = "SELECT * FROM t WHERE id = {parent.id}".into();
+        let s = source(c);
+        let mut ctx = HashMap::new();
+        ctx.insert("parent.id".to_string(), json!(42));
+        let (sql, binds) = s.resolve_query(&ctx, None);
+        assert_eq!(sql, "SELECT * FROM t WHERE id = $1");
+        assert_eq!(binds, vec![json!(42)]);
+    }
+
+    #[tokio::test]
+    async fn resolve_query_pushes_down_bookmark_after_params_and_context() {
+        let mut c = base_config();
+        c.params = vec![json!(1)];
+        c.query = "SELECT * FROM t WHERE tenant = {p.t} AND ts > ${bookmark}".into();
+        c.replication = RedshiftReplication::Incremental {
+            column: "ts".into(),
+            initial_value: json!("2026-01-01"),
+        };
+        let s = source(c);
+        let incr = s.incremental_ctx();
+        let mut ctx = HashMap::new();
+        ctx.insert("p.t".to_string(), json!("acme"));
+        let (sql, binds) = s.resolve_query(&ctx, incr.as_ref());
+        // $1 = static param, $2 = context value, $3 = bookmark.
+        assert_eq!(sql, "SELECT * FROM t WHERE tenant = $2 AND ts > $3");
+        assert_eq!(binds, vec![json!(1), json!("acme"), json!("2026-01-01")]);
+    }
+
+    #[test]
+    fn apply_incr_filter_drops_records_at_or_below_start() {
+        let page = vec![
+            json!({"id": 1, "ts": "2026-01-01"}),
+            json!({"id": 2, "ts": "2026-06-01"}),
+        ];
+        let ic = IncrementalCtx {
+            column: "ts".into(),
+            start: json!("2026-01-01"),
+        };
+        let kept = apply_incr_filter(page, Some(&ic));
+        assert_eq!(kept.len(), 1);
+        assert_eq!(kept[0]["id"], 2);
+    }
+
+    #[test]
+    fn apply_incr_filter_is_noop_for_full_mode() {
+        let page = vec![json!({"id": 1})];
+        assert_eq!(apply_incr_filter(page.clone(), None), page);
+    }
+}

--- a/crates/source/redshift/tests/conformance.rs
+++ b/crates/source/redshift/tests/conformance.rs
@@ -1,0 +1,19 @@
+//! `faucet-conformance` battery for the Amazon Redshift source.
+//!
+//! Check 1 — the config JSON Schema is a valid, well-formed value.
+//!
+//! Bounded-memory (Check 2) requires a live Redshift cluster (it speaks the
+//! PostgreSQL wire protocol, so there is no mock/wiremock path as for the
+//! HTTP-based warehouse sources). It is exercised by the `#[ignore]`d
+//! `tests/integration.rs` against a real cluster in CI instead.
+
+use faucet_conformance::assert_config_schema_valid_value;
+
+#[test]
+fn conformance_config_schema_valid() {
+    let schema = serde_json::to_value(schemars::schema_for!(
+        faucet_source_redshift::RedshiftSourceConfig
+    ))
+    .unwrap();
+    assert_config_schema_valid_value(&schema, "faucet-source-redshift");
+}

--- a/crates/source/redshift/tests/integration.rs
+++ b/crates/source/redshift/tests/integration.rs
@@ -1,0 +1,381 @@
+//! Integration tests for the Amazon Redshift source against a real database via
+//! testcontainers.
+//!
+//! Amazon Redshift has **no local container image**, but it speaks the
+//! **PostgreSQL wire protocol** and this source connects through `sqlx`'s
+//! Postgres driver (via `faucet-common-redshift`). A stock Postgres container
+//! therefore exercises the real read path end-to-end: row decoding
+//! (`src/convert.rs`), the streaming/paging loop (`src/stream.rs`), and the
+//! incremental-replication bookmark logic — everything short of Redshift-only
+//! SQL surface, which the source never emits.
+//!
+//! The connection points at the container with TLS disabled (`tls: false` →
+//! `sslmode=prefer`), so it negotiates plaintext against a Postgres image that
+//! has no server certificate. These tests require Docker and are **not**
+//! `#[ignore]`d — they auto-start their own container. A process-wide mutex
+//! serializes the containers within this test binary.
+
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+use faucet_core::Source;
+use faucet_source_redshift::{
+    RedshiftConnection, RedshiftReplication, RedshiftSource, RedshiftSourceConfig,
+};
+use futures::StreamExt;
+use serde_json::{Value, json};
+use testcontainers::{ContainerAsync, ImageExt, runners::AsyncRunner};
+use testcontainers_modules::postgres::Postgres;
+
+/// Serialize container startup within this binary so the tests don't race on
+/// Docker resources (each test still boots + tears down its own container).
+fn serial() -> &'static tokio::sync::Mutex<()> {
+    static SERIAL: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+    SERIAL.get_or_init(|| tokio::sync::Mutex::new(()))
+}
+
+/// Start a Postgres container; return the handle and its mapped host port. The
+/// container stays alive while the returned handle is held.
+async fn start_postgres() -> (ContainerAsync<Postgres>, u16) {
+    let image = Postgres::default().with_tag("16-alpine");
+    let container: ContainerAsync<Postgres> =
+        image.start().await.expect("postgres container start");
+    let port = container
+        .get_host_port_ipv4(5432)
+        .await
+        .expect("postgres port");
+    (container, port)
+}
+
+/// A Redshift `Password` connection pointed at the plaintext test container
+/// (Postgres image defaults: db `postgres`, user/password `postgres`).
+fn redshift_conn(port: u16) -> RedshiftConnection {
+    let mut conn = RedshiftConnection::new("127.0.0.1", "postgres", "postgres", "postgres");
+    conn.port = port;
+    // The Postgres test image serves no TLS certificate; `tls: false` maps to
+    // `sslmode=prefer`, which falls back to a plaintext connection.
+    conn.tls = false;
+    conn
+}
+
+/// Open a raw `sqlx` pool for seeding/verification.
+async fn seed_pool(port: u16) -> sqlx::PgPool {
+    let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
+    sqlx::PgPool::connect(&url)
+        .await
+        .expect("seed pool connect")
+}
+
+fn full_config(port: u16, query: &str, batch_size: usize) -> RedshiftSourceConfig {
+    RedshiftSourceConfig {
+        connection: redshift_conn(port),
+        query: query.into(),
+        params: Vec::new(),
+        max_connections: 2,
+        batch_size,
+        replication: RedshiftReplication::Full,
+        state_key: None,
+    }
+}
+
+/// Drain a source into `(records, final_bookmark)`.
+async fn drain(source: &RedshiftSource) -> (Vec<Value>, Option<Value>) {
+    let ctx: HashMap<String, Value> = HashMap::new();
+    let mut pages = source.stream_pages(&ctx, 0);
+    let mut records = Vec::new();
+    let mut bookmark = None;
+    while let Some(page) = pages.next().await {
+        let page = page.expect("page ok");
+        records.extend(page.records);
+        if page.bookmark.is_some() {
+            bookmark = page.bookmark;
+        }
+    }
+    (records, bookmark)
+}
+
+/// Every branch of `pg_value_to_json` is exercised by selecting one row spanning
+/// int / text / numeric / bool / null / timestamp columns, and the decoded JSON
+/// is asserted field-by-field.
+#[tokio::test(flavor = "multi_thread")]
+async fn decodes_typed_rows_to_json() {
+    let _guard = serial().lock().await;
+    let (_container, port) = start_postgres().await;
+    let pool = seed_pool(port).await;
+    sqlx::query(
+        "CREATE TABLE typed (\
+            id BIGINT, name TEXT, amount NUMERIC(10,2), flag BOOLEAN, \
+            note TEXT, ts TIMESTAMPTZ)",
+    )
+    .execute(&pool)
+    .await
+    .expect("create table");
+    sqlx::query(
+        "INSERT INTO typed VALUES \
+            (1, 'alice', 12.34, true, NULL, '2024-01-02T03:04:05Z'), \
+            (2, 'bob', 99.99, false, 'hi', '2024-06-07T08:09:10Z')",
+    )
+    .execute(&pool)
+    .await
+    .expect("insert");
+    pool.close().await;
+
+    let source = RedshiftSource::new(full_config(
+        port,
+        "SELECT id, name, amount, flag, note, ts FROM typed ORDER BY id",
+        1000,
+    ))
+    .expect("source builds");
+
+    // fetch_all() drives the same stream_pages path as a pipeline run.
+    let rows = source.fetch_all().await.expect("query runs");
+    assert_eq!(rows.len(), 2);
+
+    let r0 = &rows[0];
+    assert_eq!(r0["id"], json!(1));
+    assert_eq!(r0["name"], json!("alice"));
+    // NUMERIC → exact decimal string (sqlx pads scale to a multiple of 4).
+    assert!(
+        r0["amount"].as_str().unwrap().starts_with("12.34"),
+        "numeric should decode as a precise string, got {:?}",
+        r0["amount"]
+    );
+    assert_eq!(r0["flag"], json!(true));
+    assert_eq!(r0["note"], Value::Null, "SQL NULL decodes to JSON null");
+    assert!(
+        r0["ts"]
+            .as_str()
+            .unwrap()
+            .starts_with("2024-01-02T03:04:05"),
+        "timestamptz should render as RFC3339, got {:?}",
+        r0["ts"]
+    );
+
+    assert_eq!(rows[1]["id"], json!(2));
+    assert_eq!(rows[1]["flag"], json!(false));
+    assert_eq!(rows[1]["note"], json!("hi"));
+}
+
+/// The streaming loop re-frames the cursor into `batch_size`-sized pages, with a
+/// partial trailing page for the remainder.
+#[tokio::test(flavor = "multi_thread")]
+async fn stream_pages_chunks_into_batch_sized_pages() {
+    let _guard = serial().lock().await;
+    let (_container, port) = start_postgres().await;
+    let pool = seed_pool(port).await;
+    sqlx::query("CREATE TABLE nums (id BIGINT PRIMARY KEY)")
+        .execute(&pool)
+        .await
+        .expect("create table");
+    sqlx::query("INSERT INTO nums (id) SELECT generate_series(1, 5)")
+        .execute(&pool)
+        .await
+        .expect("seed");
+    pool.close().await;
+
+    let source = RedshiftSource::new(full_config(port, "SELECT id FROM nums ORDER BY id", 2))
+        .expect("source");
+
+    let ctx: HashMap<String, Value> = HashMap::new();
+    let mut pages = source.stream_pages(&ctx, 2);
+    let mut sizes = Vec::new();
+    let mut total = 0;
+    while let Some(page) = pages.next().await {
+        let page = page.expect("page ok");
+        assert!(page.bookmark.is_none(), "full mode never emits a bookmark");
+        sizes.push(page.records.len());
+        total += page.records.len();
+    }
+    assert_eq!(sizes, vec![2, 2, 1], "5 rows at batch_size 2 → [2, 2, 1]");
+    assert_eq!(total, 5);
+}
+
+/// `batch_size = 0` drains the whole cursor into a single page.
+#[tokio::test(flavor = "multi_thread")]
+async fn batch_size_zero_emits_single_page() {
+    let _guard = serial().lock().await;
+    let (_container, port) = start_postgres().await;
+    let pool = seed_pool(port).await;
+    sqlx::query("CREATE TABLE nums (id BIGINT PRIMARY KEY)")
+        .execute(&pool)
+        .await
+        .expect("create table");
+    sqlx::query("INSERT INTO nums (id) SELECT generate_series(1, 7)")
+        .execute(&pool)
+        .await
+        .expect("seed");
+    pool.close().await;
+
+    let source = RedshiftSource::new(full_config(port, "SELECT id FROM nums ORDER BY id", 0))
+        .expect("source");
+
+    let (records, bookmark) = drain(&source).await;
+    assert_eq!(records.len(), 7);
+    assert!(bookmark.is_none());
+}
+
+/// Incremental replication with a `${bookmark}` token: the cursor is pushed down
+/// as a bind param, the running max is emitted as the final bookmark, and a
+/// resume run filters to rows strictly greater than the applied bookmark.
+#[tokio::test(flavor = "multi_thread")]
+async fn incremental_pushes_down_bookmark_and_resumes() {
+    let _guard = serial().lock().await;
+    let (_container, port) = start_postgres().await;
+    let pool = seed_pool(port).await;
+    sqlx::query("CREATE TABLE inc (id BIGINT PRIMARY KEY, val TEXT)")
+        .execute(&pool)
+        .await
+        .expect("create table");
+    sqlx::query(
+        "INSERT INTO inc (id, val) VALUES \
+            (1,'a'), (2,'b'), (3,'c'), (4,'d'), (5,'e')",
+    )
+    .execute(&pool)
+    .await
+    .expect("seed");
+    pool.close().await;
+
+    let mut config = full_config(
+        port,
+        "SELECT id, val FROM inc WHERE id > ${bookmark} ORDER BY id",
+        1000,
+    );
+    config.replication = RedshiftReplication::Incremental {
+        column: "id".into(),
+        initial_value: json!(0),
+    };
+    config.state_key = Some("rs-inc".into());
+
+    // First run: initial_value 0 → all 5 rows; bookmark = max(id) = 5.
+    let source = RedshiftSource::new(config.clone()).expect("source");
+    assert_eq!(source.state_key().as_deref(), Some("rs-inc"));
+    let (records, bookmark) = drain(&source).await;
+    let ids: Vec<i64> = records.iter().map(|r| r["id"].as_i64().unwrap()).collect();
+    assert_eq!(ids, vec![1, 2, 3, 4, 5]);
+    assert_eq!(bookmark, Some(json!(5)), "final page carries max(id)");
+
+    // Resume run: apply bookmark 3 → server-side pushdown returns 4, 5 only.
+    let resumed = RedshiftSource::new(config).expect("source");
+    resumed
+        .apply_start_bookmark(json!(3))
+        .await
+        .expect("apply bookmark");
+    let (records, bookmark) = drain(&resumed).await;
+    let ids: Vec<i64> = records.iter().map(|r| r["id"].as_i64().unwrap()).collect();
+    assert_eq!(
+        ids,
+        vec![4, 5],
+        "resume yields only rows above the bookmark"
+    );
+    assert_eq!(bookmark, Some(json!(5)));
+}
+
+/// Incremental without a `${bookmark}` token: the server returns everything and
+/// the **client-side** filter drops rows at or below the applied bookmark, while
+/// the running max (tracked over the full scan, before the filter) is emitted.
+#[tokio::test(flavor = "multi_thread")]
+async fn incremental_client_side_filter_drops_seen_rows() {
+    let _guard = serial().lock().await;
+    let (_container, port) = start_postgres().await;
+    let pool = seed_pool(port).await;
+    sqlx::query("CREATE TABLE inc (id BIGINT PRIMARY KEY, val TEXT)")
+        .execute(&pool)
+        .await
+        .expect("create table");
+    sqlx::query("INSERT INTO inc (id, val) VALUES (1,'a'),(2,'b'),(3,'c'),(4,'d'),(5,'e')")
+        .execute(&pool)
+        .await
+        .expect("seed");
+    pool.close().await;
+
+    // No ${bookmark} token → no pushdown; the client filter does the work.
+    let mut config = full_config(port, "SELECT id, val FROM inc ORDER BY id", 1000);
+    config.replication = RedshiftReplication::Incremental {
+        column: "id".into(),
+        initial_value: json!(0),
+    };
+
+    let source = RedshiftSource::new(config).expect("source");
+    source
+        .apply_start_bookmark(json!(3))
+        .await
+        .expect("apply bookmark");
+    let (records, bookmark) = drain(&source).await;
+    let ids: Vec<i64> = records.iter().map(|r| r["id"].as_i64().unwrap()).collect();
+    assert_eq!(ids, vec![4, 5], "client filter drops id <= 3");
+    assert_eq!(
+        bookmark,
+        Some(json!(5)),
+        "running max is tracked over the full scan, before the filter"
+    );
+}
+
+/// Exercises every branch of `pg_value_to_json`: a table spanning smallint /
+/// int / real / double / time / date / timestamp (no tz) / uuid / bytea / jsonb
+/// so each `try_get` arm the narrower `decodes_typed_rows_to_json` test doesn't
+/// reach is decoded here.
+#[tokio::test(flavor = "multi_thread")]
+async fn decodes_all_pg_type_arms() {
+    let _guard = serial().lock().await;
+    let (_container, port) = start_postgres().await;
+    let pool = seed_pool(port).await;
+    sqlx::query(
+        "CREATE TABLE wide (\
+            i2 SMALLINT, i4 INT, r4 REAL, f8 DOUBLE PRECISION, \
+            t TIME, d DATE, ts TIMESTAMP, u UUID, b BYTEA, j JSONB)",
+    )
+    .execute(&pool)
+    .await
+    .expect("create wide table");
+    sqlx::query(
+        "INSERT INTO wide VALUES (\
+            7, 70000, 1.5, 2.5, '13:14:15', '2024-05-06', '2024-05-06T07:08:09', \
+            '11111111-2222-3333-4444-555555555555', '\\xdeadbeef', '{\"k\":1}'::jsonb)",
+    )
+    .execute(&pool)
+    .await
+    .expect("insert wide row");
+    pool.close().await;
+
+    let source = RedshiftSource::new(full_config(
+        port,
+        "SELECT i2, i4, r4, f8, t, d, ts, u, b, j FROM wide",
+        1000,
+    ))
+    .expect("source");
+    let rows = source.fetch_all().await.expect("query runs");
+    assert_eq!(rows.len(), 1);
+    let r = &rows[0];
+    assert_eq!(r["i2"], json!(7)); // i16 arm
+    assert_eq!(r["i4"], json!(70000)); // i32 arm
+    assert_eq!(r["r4"].as_f64().unwrap(), 1.5); // f32 arm
+    assert_eq!(r["f8"].as_f64().unwrap(), 2.5); // f64 arm
+    assert_eq!(r["t"], json!("13:14:15")); // NaiveTime arm
+    assert_eq!(r["d"], json!("2024-05-06")); // NaiveDate arm
+    assert!(r["ts"].as_str().unwrap().starts_with("2024-05-06")); // NaiveDateTime arm
+    assert_eq!(r["u"], json!("11111111-2222-3333-4444-555555555555")); // Uuid arm
+    // bytea → base64 of 0xDEADBEEF
+    assert_eq!(r["b"], json!("3q2+7w=="));
+    // jsonb decodes as a real JSON object (the leading Value arm)
+    assert_eq!(r["j"]["k"], json!(1));
+}
+
+/// The `check` preflight probe passes against a reachable database.
+#[tokio::test(flavor = "multi_thread")]
+async fn check_probe_passes() {
+    let _guard = serial().lock().await;
+    let (_container, port) = start_postgres().await;
+
+    let source = RedshiftSource::new(full_config(port, "SELECT 1", 1000)).expect("source");
+    let ctx = faucet_core::check::CheckContext {
+        timeout: std::time::Duration::from_secs(10),
+    };
+    let report = source.check(&ctx).await.expect("check runs");
+    assert!(
+        report
+            .probes
+            .iter()
+            .all(|p| matches!(p.status, faucet_core::check::ProbeStatus::Pass)),
+        "all probes should pass against a reachable database: {report:?}"
+    );
+}

--- a/docs/book/src/comparison/airbyte.md
+++ b/docs/book/src/comparison/airbyte.md
@@ -19,7 +19,7 @@
 
 ## Where Airbyte is the better choice
 
-- **Connector catalog.** 350+ connectors, plus a low-code connector builder. faucet has **49** first-party connectors.
+- **Connector catalog.** 350+ connectors, plus a low-code connector builder. faucet has **58** first-party connectors.
 - **A no-code UI for non-engineers.** Airbyte's web app lets analysts add sources, configure syncs, and browse schemas entirely by point-and-click, with a low-code connector builder for new APIs. faucet ships a web console too (`faucet serve` with the `serve-ui` feature — submit and monitor runs, browse connector schemas, and view the data catalog + lineage), but it's an **operations control plane for engineers**, not a no-code sync builder: pipelines are still authored as config.
 - **Managed Cloud.** If you'd rather not run anything yourself, Airbyte Cloud is a turnkey option. faucet is self-hosted by design.
 - **Maturity & normalization.** A large user base and built-in normalization patterns.
@@ -30,7 +30,7 @@
 |---|---|---|
 | Shape | single binary + library | platform (Docker/K8s) or Cloud |
 | To run one pipeline | a process that exits | a deployed control plane |
-| Connectors | 49, growing | 350+ |
+| Connectors | 58, growing | 350+ |
 | Per-connector runtime | compiled in | a container each |
 | Web console | ✓ ops control plane (`serve`) | ✓ |
 | No-code sync builder for non-engineers | ✗ (pipelines are config) | ✓ |

--- a/docs/book/src/comparison/fivetran.md
+++ b/docs/book/src/comparison/fivetran.md
@@ -34,7 +34,7 @@ Straight with you — a managed service earns its keep in real ways:
 |---|---|---|
 | Model | self-hosted open-source binary + library | fully-managed proprietary SaaS |
 | Pipeline definition | version-controlled YAML/JSON | UI (also API / Terraform) |
-| Connectors | 49 built-in | 500+ managed |
+| Connectors | 58 built-in | 500+ managed |
 | Change data capture | ✓ Postgres / MySQL / Mongo | ✓ log-based |
 | Where data / credentials live | your infrastructure | Fivetran's infrastructure |
 | Cost model | free (compute you already run) | usage-based (monthly active rows) |

--- a/docs/book/src/comparison/index.md
+++ b/docs/book/src/comparison/index.md
@@ -16,7 +16,7 @@ You'd reach for faucet-stream when **throughput, operational simplicity, or in-f
 | Single static binary | ✓ | ✗ | ✗ | ✓ | ✓ | n/a |
 | Config-driven (YAML/JSON) | ✓ | ✓ | via UI/API | ✓ | ✓ | via UI |
 | Embeddable as a library | ✓ (Rust) | ✗ | ✗ | ✓ (Go) | ✗ | ✗ |
-| Connector count | 49, growing | 600+ taps | 350+ | dozens | dozens | 500+ |
+| Connector count | 58, growing | 600+ taps | 350+ | dozens | dozens | 500+ |
 | Change data capture | ✓ Postgres / MySQL / Mongo | partial¹ | ✓ | partial | ✗ | ✓ |
 | Incremental + resumable state | ✓ | ✓ | ✓ | partial | n/a | ✓ |
 | Effectively-once delivery³ | ✓ (11 sinks incl. Kafka, Iceberg, BigQuery) | ✗ | partial | ✗ | ✗ | ✓ |

--- a/docs/book/src/comparison/meltano.md
+++ b/docs/book/src/comparison/meltano.md
@@ -24,7 +24,7 @@ Move to faucet-stream when **throughput, operational simplicity, or in-flight go
 
 Straight with you, because it's what makes the rest credible:
 
-- **Connector breadth.** 600+ Singer taps vs faucet's **49** built-in connectors. Need a long-tail SaaS source today? Meltano (or a Singer tap) probably already has it.
+- **Connector breadth.** 600+ Singer taps vs faucet's **58** built-in connectors. Need a long-tail SaaS source today? Meltano (or a Singer tap) probably already has it.
 - **A mature ecosystem & community.** Years of taps, docs, Meltano Hub, and an active community. faucet is younger.
 - **You're already invested in Singer/dbt.** If your stack is Singer taps + dbt and it's working, switching only pays off where the wins above are things you actually feel.
 
@@ -34,7 +34,7 @@ Straight with you, because it's what makes the rest credible:
 |---|---|---|
 | Runtime | Rust, single native binary | Python |
 | Install | one binary / `brew` / `cargo` | Python env + plugins |
-| Connectors | 49 (28 sources, 21 sinks), growing | 600+ taps |
+| Connectors | 58 (33 sources, 25 sinks), growing | 600+ taps |
 | Throughput (1M-row CSV→JSONL) | **712k rows/s, 11.8 MiB** | 7.4k rows/s, 724 MiB |
 | In-flight transforms | ✓ 11 record transforms + filter/explode/CDC-unwrap + embedded-DuckDB `sql` | mappers; dbt post-load |
 | Data quality / contracts / masking | ✓ native, in-path | assemble (mappers, dbt tests) |

--- a/docs/book/src/comparison/redpanda-connect.md
+++ b/docs/book/src/comparison/redpanda-connect.md
@@ -37,7 +37,7 @@ Straight with you — for its core job it's excellent:
 |---|---|---|
 | Language / runtime | Rust, single binary | Go, single binary |
 | Orientation | discrete runs to completion | continuous stream processing |
-| Connectors | 49 source/sink, ETL/CDC/warehouse | hundreds of components/processors |
+| Connectors | 58 source/sink, ETL/CDC/warehouse | hundreds of components/processors |
 | Change data capture | ✓ engine-level | some CDC inputs (several enterprise-gated) |
 | Warehouse / ELT sinks | ✓ BigQuery, Snowflake, Iceberg, Delta, … | more messaging/stream-oriented |
 | Governance in-path (quality / contracts / masking / lineage / SLA) | ✓ native | ✗ |

--- a/docs/book/src/comparison/vector.md
+++ b/docs/book/src/comparison/vector.md
@@ -34,7 +34,7 @@ Straight with you — it's a different job, and Vector is superb at it:
 |---|---|---|
 | Language / runtime | Rust, single binary | Rust, single binary |
 | Domain | ETL / CDC / warehouse data movement | observability (logs / metrics / traces) |
-| Connectors | 49 DB / API / object-store / warehouse | dozens, observability-oriented |
+| Connectors | 58 DB / API / object-store / warehouse | dozens, observability-oriented |
 | Change data capture | ✓ Postgres / MySQL / Mongo | ✗ |
 | Warehouse / ELT sinks | ✓ BigQuery, Snowflake, Iceberg, Delta, … | ✗ |
 | In-flight transforms | 11 record transforms + embedded-DuckDB `sql` | VRL (Vector Remap Language) |

--- a/docs/book/src/cookbook/state.md
+++ b/docs/book/src/cookbook/state.md
@@ -210,7 +210,7 @@ Only certain connectors are allowed in an effectively-once (`delivery: exactly_o
 
 | Role | Allowed connectors | Why others are excluded |
 |------|--------------------|------------------------|
-| Source | `postgres-cdc`, `mysql-cdc`, `mongodb-cdc`, `kafka` | The source must emit a complete resume position (bookmark) on every page, over an immutable log, so resuming from a bookmark continues the record stream at exactly that position. Query-based sources (REST, SQL query, etc.) can return different data on replay — the pipeline would silently skip records it never wrote. |
+| Source | `postgres-cdc`, `mysql-cdc`, `mssql-cdc`, `mongodb-cdc`, `kafka` | The source must emit a complete resume position (bookmark) on every page, over an immutable log, so resuming from a bookmark continues the record stream at exactly that position. Query-based sources (REST, SQL query, etc.) can return different data on replay — the pipeline would silently skip records it never wrote. |
 | Sink | `sqlite`, `postgres`, `mysql`, `mssql`, `iceberg`, `bigquery`, `kafka`, `snowflake`, `redis`, `mongodb`, `spanner` | The sink must be able to commit data and a watermark token atomically in a single transaction or snapshot. Sinks without transaction support cannot provide this guarantee (they can still reach effectively-once via keyed upsert, below). The MongoDB sink requires a replica set (or sharded cluster) — multi-document transactions are unavailable on a standalone server. |
 
 **Keyed upsert relaxes the source restriction entirely**: any source feeding an

--- a/docs/book/src/introduction.md
+++ b/docs/book/src/introduction.md
@@ -8,7 +8,7 @@
   </div>
 </div>
 
-faucet-stream wires **28 source** and **21 sink** connectors together with a single
+faucet-stream wires **33 source** and **25 sink** connectors together with a single
 `faucet` binary that runs pipelines declaratively from a YAML/JSON file — no Rust
 code required. Or skip the binary and embed the same engine in your own service
 through the typed `Source` / `Sink` traits.

--- a/docs/book/src/reference/connectors.md
+++ b/docs/book/src/reference/connectors.md
@@ -1,6 +1,6 @@
 # Connector catalog
 
-faucet-stream ships **28 sources** and **21 sinks**. Each is a Cargo feature
+faucet-stream ships **33 sources** and **25 sinks**. Each is a Cargo feature
 (`source-<name>` / `sink-<name>`) and an independently published crate. Full API
 docs are on [docs.rs](https://docs.rs/faucet-stream).
 
@@ -24,9 +24,11 @@ Legend: ✓ supported · ✗ not applicable. Tier: T1 = passes the faucet-confor
 | MySQL | T1 ✅ | `source-mysql` | ✓ | ✗ | ✗ | ✗ | ✓ | SQL query, rows as JSON |
 | MySQL CDC | T1 ✅ | `source-mysql-cdc` | ✓ | ✓ | **✓** | ✗ | ✗ | binlog row events, file/pos or GTID bookmarks |
 | Microsoft SQL Server | T1 ✅ | `source-mssql` | ✓ | ✓⁸ | ✗ | ✗ | ✓ | SQL query (tiberius), rows as JSON |
+| Microsoft SQL Server CDC | T1 ✅ | `source-mssql-cdc` | ✓ | ✓ | **✓** | ✗ | ✗ | CDC change tables (`fn_cdc_get_all_changes`), LSN bookmarks, `__op`-normalized |
 | SQLite | T1 ✅ | `source-sqlite` | ✓ | ✗ | ✗ | ✗ | ✓ | SQL query, rows as JSON |
 | AWS S3 | T1 ✅ | `source-s3` | ✓⁵ | ✗ | ✗ | ✓ | ✓ | object reader: JSONL, JSON array, raw text |
 | Google Cloud Storage | T2 | `source-gcs` | ✓⁵ | ✗ | ✗ | ✓ | ✓ | object reader: JSONL, JSON array, raw text |
+| Azure Blob / ADLS Gen2 | T1 ✅ | `source-azure-blob` | ✓⁵ | ✗ | ✗ | ✓ | ✗ | object reader (object_store): JSONL, JSON array, raw text |
 | MongoDB | T1 ✅ | `source-mongodb` | ✓ | ✗ | ✗ | ✗ | ✓ | `find()` with filter/projection/sort |
 | MongoDB CDC | T1 ✅ | `source-mongodb-cdc` | ✓ | ✓ | **✓** | ✗ | ✗ | Change Streams, resumeToken bookmarks; `max_staged_records` buffer cap |
 | Redis | T1 ✅ | `source-redis` | ✓ | ✗ | ✗ | ✗ | ✗ | streams, lists, key patterns |
@@ -36,9 +38,12 @@ Legend: ✓ supported · ✗ not applicable. Tier: T1 = passes the faucet-confor
 | Elasticsearch | T1 ✅ᵐ | `source-elasticsearch` | ✓ | ✗ | ✗ | ✗ | ✓ | search/scroll API |
 | Apache Kafka | T1 ✅ | `source-kafka` | ✓ | ✓ | **✓** | ✗ | ✗ | consumer; idle/max-messages termination, offset bookmarks |
 | AWS Kinesis | T1 ✅ | `source-kinesis` | ✓ | ✓ | ✗ | ✗ | ✗ | per-shard GetRecords workers; sequence-number bookmarks, idle/max-messages termination |
+| Google Cloud Pub/Sub | T2 | `source-pubsub` | ✓ | ✓ | ✗ | ✗ | ✗ | streaming pull; per-message records + attributes, ack at durable page boundary (at-least-once), idle/max-messages termination |
 | Apache Parquet | T1 ✅ | `source-parquet` | ✓ | ✗ | ✗ | ✗ | ✗ | local/glob/S3, vectorized Arrow reader, projection |
 | Apache Delta Lake | T2 | `source-delta` | ✓ | ✗ | ✗ | ✗ | ✗ | local FS or S3/Azure/GCS; time travel (version/timestamp), projection pushdown, partition reconstruction |
 | Databricks SQL | T3 | `source-databricks` | ✓ | ✓ | ✗ | ✗ | ✗ | Statement Execution API; async poll, chunk pagination, typed decode, incremental `${bookmark}` |
+| Amazon Redshift | T1 ✅ | `source-redshift` | ✓ | ✓ | ✗ | ✗ | ✗ | PostgreSQL wire; SQL query, rows as JSON; incremental replication |
+| ClickHouse | T2 | `source-clickhouse` | ✓ | ✓ | ✗ | ✗ | ✗ | HTTP interface, `FORMAT JSONEachRow` streaming; incremental replication |
 | BigQuery | T1 ✅ᵐ | `source-bigquery` | ✓ | ✗ | ✗ | ✗ | ✓ | `jobs.query` + pageToken pagination |
 | Snowflake | T1 ✅ᵐ | `source-snowflake` | ✓ | ✗ | ✗ | ✗ | ✓ | SQL REST API, server-side partitions |
 | Cloud Spanner | T1 ✅ᵉ | `source-spanner` | ✓ | ✓⁸ | ✗ | ✗ | ✓ | streaming SQL (gRPC), incremental `@bookmark` replication, stale reads, PK-range sharding |
@@ -109,11 +114,14 @@ file/append sinks (`jsonl`, `csv`, `stdout`) it's a no-op — they write per rec
 | PostgreSQL | T1 ✅ | `sink-postgres` | ✓ | ✗ | **✓** | **✓** | multi-row `INSERT` (JSONB or mapped cols); `COPY FROM STDIN` fast-path for append (`write_method: copy`) |
 | JSON Lines | T1 ✅ | `sink-jsonl` | no-op | ✓ | ✗ | ✗ | buffered file append |
 | Snowflake | T2 | `sink-snowflake` | ✓ | ✗ | ✗ | **✓** | SQL REST API; multi-statement `BEGIN;INSERT;MERGE;COMMIT` transaction for effectively-once |
+| Amazon Redshift | T1 ✅ | `sink-redshift` | ✓ | ✗ | ✗ | ✗ | COPY-from-S3 (staged) or multi-row `INSERT`; append-only |
+| ClickHouse | T2 | `sink-clickhouse` | ✓ | ✗ | ✗ | ✗ | `INSERT … FORMAT JSONEachRow`; optional `async_insert`; append-only |
 | MySQL | T1 ✅ | `sink-mysql` | ✓ | ✗ | **✓** | **✓** | multi-row `INSERT` |
 | Microsoft SQL Server | T1 ✅ | `sink-mssql` | ✓ | ✗ | **✓** | **✓** | multi-row `INSERT` (2100-param auto-split, per-row DLQ) |
 | SQLite | T1 ✅ | `sink-sqlite` | ✓ | ✗ | **✓** | **✓** | transaction-wrapped batch |
 | AWS S3 | T1 ✅ | `sink-s3` | ✓ | ✓ | ✗ | ✗ | JSONL objects, parallel uploads |
 | Google Cloud Storage | T2 | `sink-gcs` | ✓ | ✓ | ✗ | ✗ | JSONL objects |
+| Azure Blob / ADLS Gen2 | T2 | `sink-azure-blob` | ✓ | ✓ | ✗ | ✗ | JSONL blobs (object_store), batch/byte rollover |
 | MongoDB | T1 ✅ | `sink-mongodb` | ✓ | ✗ | **✓** | **✓** | `insert_many`; multi-document transaction for effectively-once (replica set required) |
 | Redis | T1 ✅ | `sink-redis` | ✓ | ✗ | ✗ | **✓** | streams, lists, key-value (pipelined); `MULTI`/`EXEC` transaction for effectively-once |
 | CSV | T1 ✅ | `sink-csv` | no-op | ✓ | ✗ | ✗ | buffered file rows; column set frozen from first batch (`on_unknown_field: warn`/`error`) |
@@ -122,6 +130,7 @@ file/append sinks (`jsonl`, `csv`, `stdout`) it's a no-op — they write per rec
 | Stdout | T1 ✅ | `sink-stdout` | no-op | ✗ | ✗ | ✗ | JSON Lines / pretty JSON / TSV |
 | Apache Kafka | T1 ✅ | `sink-kafka` | ✓ | ✗ | ✗ | **✓** | producer, batched sends, multi-topic routing; transactional producer + compacted watermark side-topic for effectively-once |
 | AWS Kinesis | T1 ✅ | `sink-kinesis` | ✓ | ✗ | ✗ | ✗ | batched PutRecords; partition-key routing, per-entry partial-failure retry (DLQ-routable) |
+| Google Cloud Pub/Sub | T2 | `sink-pubsub` | ✓ | ✗ | ✗ | ✗ | batched publish; optional ordering key, per-entry partial-failure retry (DLQ-routable) |
 | Cloud Spanner | T1 ✅ᵉ | `sink-spanner` | ✓ | ✗ | **✓** | **✓** | batched mutations (`insert` / `insert_or_update` / `delete`), cell-budget chunking, commit-token transaction for effectively-once |
 | Apache Parquet | T1 ✅ | `sink-parquet` | ✓ | ✗⁶ | ✗ | ✗ | local/S3, schema inference (re-inferred per file on rollover), row/byte rollover |
 | Apache Delta Lake | T2 | `sink-delta` | ✓ | ✗⁶ | ✗ | ✗ | append-only; local FS or S3/Azure/GCS; schema-inferred table creation, partitioning, one commit per flush |

--- a/examples/README.md
+++ b/examples/README.md
@@ -118,6 +118,12 @@ files as each config shows:
 | Example | Notes |
 |---------|-------|
 | `postgres_to_bigquery_with_lineage.yaml` | Postgres → BigQuery with a top-level `lineage:` block — emits OpenLineage RunEvents (schema + column-lineage facets) to a Marquez HTTP endpoint. Needs `--features lineage`, a BigQuery project (`GCP_KEY_JSON`), and `MARQUEZ_URL` (or swap in the commented `transport: { type: file }` for local testing) |
+| `clickhouse_to_jsonl.yaml` | ClickHouse query source (HTTP `JSONEachRow`) → JSONL |
+| `csv_to_clickhouse.yaml` | CSV → ClickHouse sink (`INSERT … FORMAT JSONEachRow`, optional `async_insert`) |
+| `redshift_to_jsonl.yaml` | Amazon Redshift query source (Postgres wire) → JSONL |
+| `pubsub_to_jsonl.yaml` | Google Cloud Pub/Sub subscription → JSONL (streaming pull, at-least-once ack at page boundaries) |
+| `azure_blob_to_jsonl.yaml` | Azure Blob / ADLS Gen2 object source → JSONL |
+| `mssql_cdc_to_postgres_upsert.yaml` | SQL Server CDC → Postgres upsert mirror (`cdc_unwrap` + `write_mode: upsert`) |
 
 ## Tips
 

--- a/faucet-stream/Cargo.toml
+++ b/faucet-stream/Cargo.toml
@@ -31,6 +31,11 @@ source = [
     "source-mongodb",
     "source-mongodb-cdc",
     "source-mysql-cdc",
+    "source-mssql-cdc",
+    "source-redshift",
+    "source-pubsub",
+    "source-clickhouse",
+    "source-azure-blob",
     "source-redis",
     "source-webhook",
     "source-websocket",
@@ -68,6 +73,10 @@ sink = [
     "sink-gcs",
     "sink-iceberg",
     "sink-spanner",
+    "sink-redshift",
+    "sink-pubsub",
+    "sink-clickhouse",
+    "sink-azure-blob",
 ]
 ## All state-store backends (file backend is exposed via `faucet-core` directly).
 state = [
@@ -86,6 +95,8 @@ compression = [
     "faucet-sink-csv?/compression",
     "faucet-sink-s3?/compression",
     "faucet-sink-gcs?/compression",
+    "faucet-source-azure-blob?/compression",
+    "faucet-sink-azure-blob?/compression",
 ]
 ## Shared, single-flight auth providers (OAuth2 client-credentials / refresh,
 ## token-endpoint) usable across connectors via `auth: { ref }`.
@@ -131,6 +142,11 @@ source-s3 = ["dep:faucet-source-s3"]
 source-mongodb = ["dep:faucet-source-mongodb"]
 source-mongodb-cdc = ["dep:faucet-source-mongodb-cdc"]
 source-mysql-cdc = ["dep:faucet-source-mysql-cdc"]
+source-mssql-cdc = ["dep:faucet-source-mssql-cdc"]
+source-redshift = ["dep:faucet-source-redshift", "dep:faucet-common-redshift"]
+source-pubsub = ["dep:faucet-source-pubsub", "dep:faucet-common-pubsub"]
+source-clickhouse = ["dep:faucet-source-clickhouse", "dep:faucet-common-clickhouse"]
+source-azure-blob = ["dep:faucet-source-azure-blob", "dep:faucet-common-azure"]
 source-redis = ["dep:faucet-source-redis"]
 source-webhook = ["dep:faucet-source-webhook"]
 source-websocket = ["dep:faucet-source-websocket"]
@@ -180,6 +196,10 @@ delta-s3 = ["faucet-source-delta?/s3", "faucet-sink-delta?/s3"]
 delta-azure = ["faucet-source-delta?/azure", "faucet-sink-delta?/azure"]
 delta-gcs = ["faucet-source-delta?/gcs", "faucet-sink-delta?/gcs"]
 sink-gcs = ["dep:faucet-sink-gcs", "dep:faucet-common-gcs"]
+sink-redshift = ["dep:faucet-sink-redshift", "dep:faucet-common-redshift"]
+sink-pubsub = ["dep:faucet-sink-pubsub", "dep:faucet-common-pubsub"]
+sink-clickhouse = ["dep:faucet-sink-clickhouse", "dep:faucet-common-clickhouse"]
+sink-azure-blob = ["dep:faucet-sink-azure-blob", "dep:faucet-common-azure"]
 
 ## Kafka Schema Registry support (forwarded to kafka crates).
 kafka-schema-registry = [
@@ -218,6 +238,10 @@ faucet-common-kafka = { workspace = true, optional = true }
 faucet-common-kinesis = { workspace = true, optional = true }
 faucet-common-snowflake = { workspace = true, optional = true }
 faucet-common-spanner = { workspace = true, optional = true }
+faucet-common-redshift = { workspace = true, optional = true }
+faucet-common-pubsub = { workspace = true, optional = true }
+faucet-common-clickhouse = { workspace = true, optional = true }
+faucet-common-azure = { workspace = true, optional = true }
 faucet-source-rest = { workspace = true, optional = true }
 faucet-source-singer = { workspace = true, optional = true }
 faucet-source-graphql = { workspace = true, optional = true }
@@ -234,6 +258,11 @@ faucet-source-s3 = { workspace = true, optional = true }
 faucet-source-mongodb = { workspace = true, optional = true }
 faucet-source-mongodb-cdc = { workspace = true, optional = true }
 faucet-source-mysql-cdc = { workspace = true, optional = true }
+faucet-source-mssql-cdc = { workspace = true, optional = true }
+faucet-source-redshift = { workspace = true, optional = true }
+faucet-source-pubsub = { workspace = true, optional = true }
+faucet-source-clickhouse = { workspace = true, optional = true }
+faucet-source-azure-blob = { workspace = true, optional = true }
 faucet-source-redis = { workspace = true, optional = true }
 faucet-source-webhook = { workspace = true, optional = true }
 faucet-source-websocket = { workspace = true, optional = true }
@@ -268,6 +297,10 @@ faucet-sink-stdout = { workspace = true, optional = true }
 faucet-sink-parquet = { workspace = true, optional = true }
 faucet-sink-delta = { workspace = true, optional = true }
 faucet-sink-gcs = { workspace = true, optional = true }
+faucet-sink-redshift = { workspace = true, optional = true }
+faucet-sink-pubsub = { workspace = true, optional = true }
+faucet-sink-clickhouse = { workspace = true, optional = true }
+faucet-sink-azure-blob = { workspace = true, optional = true }
 
 faucet-state-redis = { workspace = true, optional = true }
 faucet-state-postgres = { workspace = true, optional = true }

--- a/faucet-stream/src/lib.rs
+++ b/faucet-stream/src/lib.rs
@@ -217,6 +217,31 @@ pub mod source {
         pub use faucet_source_gcs::*;
     }
 
+    #[cfg(feature = "source-mssql-cdc")]
+    pub mod mssql_cdc {
+        pub use faucet_source_mssql_cdc::*;
+    }
+
+    #[cfg(feature = "source-redshift")]
+    pub mod redshift {
+        pub use faucet_source_redshift::*;
+    }
+
+    #[cfg(feature = "source-pubsub")]
+    pub mod pubsub {
+        pub use faucet_source_pubsub::*;
+    }
+
+    #[cfg(feature = "source-clickhouse")]
+    pub mod clickhouse {
+        pub use faucet_source_clickhouse::*;
+    }
+
+    #[cfg(feature = "source-azure-blob")]
+    pub mod azure_blob {
+        pub use faucet_source_azure_blob::*;
+    }
+
     #[cfg(feature = "source-singer")]
     pub mod singer {
         pub use faucet_source_singer::*;
@@ -356,6 +381,31 @@ pub mod source {
         pub use faucet_source_gcs::*;
     }
 
+    #[cfg(feature = "source-mssql-cdc")]
+    pub mod mssql_cdc {
+        pub use faucet_source_mssql_cdc::*;
+    }
+
+    #[cfg(feature = "source-redshift")]
+    pub mod redshift {
+        pub use faucet_source_redshift::*;
+    }
+
+    #[cfg(feature = "source-pubsub")]
+    pub mod pubsub {
+        pub use faucet_source_pubsub::*;
+    }
+
+    #[cfg(feature = "source-clickhouse")]
+    pub mod clickhouse {
+        pub use faucet_source_clickhouse::*;
+    }
+
+    #[cfg(feature = "source-azure-blob")]
+    pub mod azure_blob {
+        pub use faucet_source_azure_blob::*;
+    }
+
     #[cfg(feature = "source-singer")]
     pub mod singer {
         pub use faucet_source_singer::*;
@@ -477,6 +527,26 @@ pub mod sink {
     pub mod gcs {
         pub use faucet_sink_gcs::*;
     }
+
+    #[cfg(feature = "sink-redshift")]
+    pub mod redshift {
+        pub use faucet_sink_redshift::*;
+    }
+
+    #[cfg(feature = "sink-pubsub")]
+    pub mod pubsub {
+        pub use faucet_sink_pubsub::*;
+    }
+
+    #[cfg(feature = "sink-clickhouse")]
+    pub mod clickhouse {
+        pub use faucet_sink_clickhouse::*;
+    }
+
+    #[cfg(feature = "sink-azure-blob")]
+    pub mod azure_blob {
+        pub use faucet_sink_azure_blob::*;
+    }
 }
 
 // ── GCS common types ─────────────────────────────────────────────────────────
@@ -506,6 +576,34 @@ pub mod common_kinesis {
 #[cfg(any(feature = "source-spanner", feature = "sink-spanner"))]
 pub mod common_spanner {
     pub use faucet_common_spanner::*;
+}
+
+/// Shared Amazon Redshift types (credentials enum, connection block, pool
+/// builder), re-exported when either Redshift connector is enabled.
+#[cfg(any(feature = "source-redshift", feature = "sink-redshift"))]
+pub mod common_redshift {
+    pub use faucet_common_redshift::*;
+}
+
+/// Shared Google Cloud Pub/Sub types (credentials enum, connection block,
+/// client builder), re-exported when either Pub/Sub connector is enabled.
+#[cfg(any(feature = "source-pubsub", feature = "sink-pubsub"))]
+pub mod common_pubsub {
+    pub use faucet_common_pubsub::*;
+}
+
+/// Shared ClickHouse types (connection block, HTTP client builder), re-exported
+/// when either ClickHouse connector is enabled.
+#[cfg(any(feature = "source-clickhouse", feature = "sink-clickhouse"))]
+pub mod common_clickhouse {
+    pub use faucet_common_clickhouse::*;
+}
+
+/// Shared Azure Blob / ADLS Gen2 types (credentials enum, object-store builder),
+/// re-exported when either Azure Blob connector is enabled.
+#[cfg(any(feature = "source-azure-blob", feature = "sink-azure-blob"))]
+pub mod common_azure {
+    pub use faucet_common_azure::*;
 }
 
 // ── State-store backends ─────────────────────────────────────────────────────

--- a/schemas/faucet.schema.json
+++ b/schemas/faucet.schema.json
@@ -4080,6 +4080,490 @@
         }
       ]
     },
+    "source_mssql-cdc__MssqlTls": {
+      "description": "TLS configuration for an MSSQL connection.\n\nMatches the YAML shape `tls: { type: <mode>, ca_cert_path: <path> }`.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "Encryption mode. Defaults to [`MssqlTlsMode::Prefer`].",
+          "$ref": "#/$defs/source_mssql-cdc__MssqlTlsMode",
+          "default": "prefer"
+        },
+        "ca_cert_path": {
+          "description": "Optional path to a CA certificate (PEM/DER) to trust for server\nvalidation. Ignored when `mode` is [`MssqlTlsMode::Disable`].",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "source_mssql-cdc__MssqlTlsMode": {
+      "description": "MSSQL encryption mode.",
+      "oneOf": [
+        {
+          "description": "Encrypt the connection if the server supports it (the safe modern\ndefault). Maps to `tiberius` `EncryptionLevel::On`.",
+          "type": "string",
+          "const": "prefer"
+        },
+        {
+          "description": "Require encryption; fail if the server does not offer it. Maps to\n`EncryptionLevel::Required`.",
+          "type": "string",
+          "const": "require"
+        },
+        {
+          "description": "Encrypt and accept the server certificate without validating its chain\n(self-signed dev servers). Maps to `EncryptionLevel::On` + `trust_cert()`.\n**Insecure against MITM — never use in production.**",
+          "type": "string",
+          "const": "trust_server_certificate"
+        },
+        {
+          "description": "No transport encryption. Maps to `EncryptionLevel::NotSupported`.",
+          "type": "string",
+          "const": "disable"
+        }
+      ]
+    },
+    "source_mssql-cdc__StartPosition": {
+      "description": "Where to start reading changes on a fresh run (no persisted bookmark).",
+      "oneOf": [
+        {
+          "description": "Start at the database's current maximum LSN — skip all pre-existing\nchange history and only capture changes committed after the source\nstarts. Default.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "current"
+            }
+          }
+        },
+        {
+          "description": "Start at the earliest LSN still retained by the CDC capture instance\n(`sys.fn_cdc_get_min_lsn`), replaying whatever history the cleanup job\nhas not yet purged.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "earliest"
+            }
+          }
+        }
+      ]
+    },
+    "source_redshift__RedshiftCredentials": {
+      "description": "How to authenticate with Amazon Redshift.\n\nSerializes as `{ type: <method>, config: { … } }` (adjacent tagging,\nsnake_case discriminators) — the consistent auth wire shape shared by every\nfaucet connector.\n\nv1 implements only [`RedshiftCredentials::Password`]. The [`Iam`] and\n[`RedshiftDataApi`] variants are accepted by the config parser (so a future\nversion can add them without a breaking change) but currently return a typed\n[`FaucetError::Config`](faucet_core::FaucetError::Config) at client-build\ntime.\n\n[`Iam`]: RedshiftCredentials::Iam\n[`RedshiftDataApi`]: RedshiftCredentials::RedshiftDataApi",
+      "oneOf": [
+        {
+          "description": "Username/password authentication (the user comes from\n[`RedshiftConnection::user`]). The only mechanism supported in v1.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "password"
+            },
+            "config": {
+              "type": "object",
+              "properties": {
+                "password": {
+                  "description": "The password (use `${env:…}` / `${vault:…}` to inject it, never a\nliteral).",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "IAM authentication via temporary cluster credentials\n(`GetClusterCredentials`). **Not yet supported** — reserved for a future\nversion; building a client with this variant returns a typed error.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "iam"
+            },
+            "config": {
+              "type": "object",
+              "properties": {
+                "region": {
+                  "description": "AWS region of the cluster.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "cluster_identifier": {
+                  "description": "Provisioned cluster identifier used to request temporary credentials.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "db_user": {
+                  "description": "Database user to authenticate as.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "Authentication through the Redshift Data API (HTTP, not the PG wire).\n**Not yet supported** — reserved for a future version; building a client\nwith this variant returns a typed error.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "redshift_data_api"
+            },
+            "config": {
+              "type": "object",
+              "properties": {
+                "region": {
+                  "description": "AWS region.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "cluster_identifier": {
+                  "description": "Provisioned cluster identifier.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "workgroup_name": {
+                  "description": "Serverless workgroup name (alternative to `cluster_identifier`).",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "secret_arn": {
+                  "description": "Secrets Manager ARN holding the database credentials.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "db_user": {
+                  "description": "Database user to authenticate as.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "source_redshift__RedshiftReplication": {
+      "description": "How the Redshift source replicates rows across runs.\n\nSerializes as `{ type: full }` or\n`{ type: incremental, column: \"...\", initial_value: ... }`.",
+      "oneOf": [
+        {
+          "description": "Every run re-fetches the full result set (default).",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "full"
+            }
+          }
+        },
+        {
+          "description": "Only rows whose `column` is strictly greater than the stored bookmark\n(or `initial_value` on the first run) are emitted. If the SQL contains\nthe literal token `${bookmark}`, it is replaced with a positional bind\nparameter so Redshift filters server-side (efficient); the source also\nfilters client-side as a correctness backstop. The new maximum of\n`column` is persisted on the final page.",
+          "type": "object",
+          "properties": {
+            "column": {
+              "description": "Column whose value is the replication cursor (e.g. `updated_at`).",
+              "type": "string"
+            },
+            "initial_value": {
+              "description": "Lower bound used on the first run, before any bookmark is stored."
+            },
+            "type": {
+              "type": "string",
+              "const": "incremental"
+            }
+          }
+        }
+      ]
+    },
+    "source_pubsub__PubsubCredentials": {
+      "description": "How to authenticate with Google Cloud Pub/Sub.\n\nSerializes as `{ type: <method>, config: { … } }` (adjacent tagging,\nsnake_case discriminators) — the consistent auth wire shape shared by\nevery faucet connector:\n`{ type: service_account_json_file, config: { path: \"/run/secrets/sa.json\" } }`.",
+      "oneOf": [
+        {
+          "description": "Application Default Credentials — honours\n`GOOGLE_APPLICATION_CREDENTIALS`, `GOOGLE_APPLICATION_CREDENTIALS_JSON`,\ngcloud user creds, and the GCE/GKE metadata server, in that order.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "application_default"
+            }
+          }
+        },
+        {
+          "description": "Path to a service-account JSON key file on disk.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "service_account_json_file"
+            },
+            "config": {
+              "type": "object",
+              "properties": {
+                "path": {
+                  "description": "Filesystem path to the service-account key JSON.",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "Service-account JSON key as an inline string. Pair with\n`${env:GCP_SA_JSON}` / `${secret:…}` interpolation in CLI configs so\nthe key never sits in the config file verbatim.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "service_account_json_inline"
+            },
+            "config": {
+              "type": "object",
+              "properties": {
+                "json": {
+                  "description": "The service-account key JSON document.",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "No credentials. Use with the Pub/Sub emulator, which does not validate\nbearer tokens — the SDK otherwise tries to fetch ADC tokens at startup\nand fails in environments without GCP credentials.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "anonymous"
+            }
+          }
+        }
+      ]
+    },
+    "source_pubsub__ValueFormat": {
+      "description": "How each message's `data` payload is decoded into the emitted `data` field.",
+      "oneOf": [
+        {
+          "description": "Parse the payload as JSON. A message that is not valid JSON fails the\nstream with a typed error naming its `message_id`.",
+          "type": "string",
+          "const": "json"
+        },
+        {
+          "description": "Decode the payload as UTF-8 (invalid UTF-8 fails the message).",
+          "type": "string",
+          "const": "string"
+        },
+        {
+          "description": "Base64-encode the raw payload bytes into a JSON string.",
+          "type": "string",
+          "const": "bytes"
+        }
+      ]
+    },
+    "source_clickhouse__ClickHouseReplication": {
+      "description": "How the source replicates rows across runs.\n\nSerializes as `{ type: full }` or\n`{ type: incremental, column: \"...\", initial_value: ... }`.",
+      "oneOf": [
+        {
+          "description": "Every run fetches the full result set (default).",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "full"
+            }
+          }
+        },
+        {
+          "description": "Only rows whose `column` is strictly greater than the stored bookmark\n(or `initial_value` on the first run) are emitted.\n\nThe bookmark is applied two ways: if the query contains the literal\ntoken `@bookmark`, it is substituted as an injection-safe SQL literal so\nthe server filters (efficient pushdown); the source *also* filters\nclient-side as a correctness backstop. The new maximum of `column` is\npersisted on the final page.",
+          "type": "object",
+          "properties": {
+            "column": {
+              "description": "Column whose value is the replication cursor (e.g. `updated_at`).",
+              "type": "string"
+            },
+            "initial_value": {
+              "description": "Lower bound used on the first run, before any bookmark is stored."
+            },
+            "type": {
+              "type": "string",
+              "const": "incremental"
+            }
+          }
+        }
+      ]
+    },
+    "source_azure-blob__AzureCredentials": {
+      "description": "Credential source for an Azure storage client.\n\nSerializes as `{ type: <method>, config: { … } }` (adjacent tagging,\nsnake_case discriminators) — the consistent auth wire shape shared by every\nfaucet connector, e.g.\n`{ type: account_key, config: { account_key: \"…\" } }`.",
+      "oneOf": [
+        {
+          "description": "Shared storage-account access key (the primary/secondary key).",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "account_key"
+            },
+            "config": {
+              "type": "object",
+              "properties": {
+                "account_key": {
+                  "description": "Base64 account key.",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "Shared-access-signature token (with or without a leading `?`).",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "sas_token"
+            },
+            "config": {
+              "type": "object",
+              "properties": {
+                "sas_token": {
+                  "description": "SAS token string.",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "Full storage connection string\n(`DefaultEndpointsProtocol=…;AccountName=…;AccountKey=…;…`).",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "connection_string"
+            },
+            "config": {
+              "type": "object",
+              "properties": {
+                "connection_string": {
+                  "description": "Connection string.",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "Azure Managed Identity (IMDS). For a user-assigned identity, set\n`client_id`; leave it unset for the system-assigned identity.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "managed_identity"
+            },
+            "config": {
+              "type": "object",
+              "properties": {
+                "client_id": {
+                  "description": "Optional user-assigned managed-identity client id.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "Azure AD service principal (client credentials).",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "service_principal"
+            },
+            "config": {
+              "type": "object",
+              "properties": {
+                "client_id": {
+                  "description": "Application (client) id.",
+                  "type": "string"
+                },
+                "client_secret": {
+                  "description": "Client secret.",
+                  "type": "string"
+                },
+                "tenant_id": {
+                  "description": "Directory (tenant) id.",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "`DefaultAzureCredential`-style resolution: the object-store builder's\ndefault chain (environment variables, workload identity, managed\nidentity, Azure CLI), honouring `AZURE_*` env vars. This is the default.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "default"
+            }
+          }
+        }
+      ]
+    },
+    "source_azure-blob__AzureFileFormat": {
+      "description": "Format of objects stored in the container.",
+      "oneOf": [
+        {
+          "description": "Each line in the object is a separate JSON record.",
+          "type": "string",
+          "const": "json_lines"
+        },
+        {
+          "description": "The entire object is a JSON array of records.",
+          "type": "string",
+          "const": "json_array"
+        },
+        {
+          "description": "Each object becomes a single record with `\"key\"` and `\"content\"` fields.",
+          "type": "string",
+          "const": "raw_text"
+        }
+      ]
+    },
+    "source_azure-blob__CompressionConfig": {
+      "description": "User-facing compression config. Defaults to [`Auto`](Self::Auto).",
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "none",
+            "gzip",
+            "zstd"
+          ]
+        },
+        {
+          "description": "Detect from filename suffix: `.gz` → Gzip, `.zst` → Zstd, anything else → None.",
+          "type": "string",
+          "const": "auto"
+        }
+      ]
+    },
     "source_redis__RedisSourceType": {
       "description": "The type of Redis data structure to read from.",
       "oneOf": [
@@ -7656,6 +8140,411 @@
         }
       ]
     },
+    "sink_redshift__RedshiftCredentials": {
+      "description": "How to authenticate with Amazon Redshift.\n\nSerializes as `{ type: <method>, config: { … } }` (adjacent tagging,\nsnake_case discriminators) — the consistent auth wire shape shared by every\nfaucet connector.\n\nv1 implements only [`RedshiftCredentials::Password`]. The [`Iam`] and\n[`RedshiftDataApi`] variants are accepted by the config parser (so a future\nversion can add them without a breaking change) but currently return a typed\n[`FaucetError::Config`](faucet_core::FaucetError::Config) at client-build\ntime.\n\n[`Iam`]: RedshiftCredentials::Iam\n[`RedshiftDataApi`]: RedshiftCredentials::RedshiftDataApi",
+      "oneOf": [
+        {
+          "description": "Username/password authentication (the user comes from\n[`RedshiftConnection::user`]). The only mechanism supported in v1.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "password"
+            },
+            "config": {
+              "type": "object",
+              "properties": {
+                "password": {
+                  "description": "The password (use `${env:…}` / `${vault:…}` to inject it, never a\nliteral).",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "IAM authentication via temporary cluster credentials\n(`GetClusterCredentials`). **Not yet supported** — reserved for a future\nversion; building a client with this variant returns a typed error.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "iam"
+            },
+            "config": {
+              "type": "object",
+              "properties": {
+                "region": {
+                  "description": "AWS region of the cluster.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "cluster_identifier": {
+                  "description": "Provisioned cluster identifier used to request temporary credentials.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "db_user": {
+                  "description": "Database user to authenticate as.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "Authentication through the Redshift Data API (HTTP, not the PG wire).\n**Not yet supported** — reserved for a future version; building a client\nwith this variant returns a typed error.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "redshift_data_api"
+            },
+            "config": {
+              "type": "object",
+              "properties": {
+                "region": {
+                  "description": "AWS region.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "cluster_identifier": {
+                  "description": "Provisioned cluster identifier.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "workgroup_name": {
+                  "description": "Serverless workgroup name (alternative to `cluster_identifier`).",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "secret_arn": {
+                  "description": "Secrets Manager ARN holding the database credentials.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "db_user": {
+                  "description": "Database user to authenticate as.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "sink_redshift__RedshiftWriteStrategy": {
+      "description": "How the sink loads rows into Redshift.",
+      "oneOf": [
+        {
+          "description": "Stage each page to S3 and bulk-load it with `COPY … FROM 's3://…'` — the\ndefault and by far the fastest path for Redshift (the recommended way to\nload data). Requires `staging_bucket` and `iam_role`.",
+          "type": "string",
+          "const": "copy"
+        },
+        {
+          "description": "Multi-row `INSERT INTO … VALUES (…), (…)`. Portable and needs no S3, but\nmuch slower than `COPY` for anything beyond small batches. Redshift does\nnot recommend row-by-row inserts for bulk data.",
+          "type": "string",
+          "const": "insert"
+        }
+      ]
+    },
+    "sink_redshift__RedshiftCopyFormat": {
+      "description": "Format of the staged file that `COPY` reads.",
+      "oneOf": [
+        {
+          "description": "Newline-delimited JSON objects, loaded with `FORMAT AS JSON 'auto'`.\nMaps by column **name** (order-independent) and handles NULLs and typed\ncolumns cleanly — the default.",
+          "type": "string",
+          "const": "jsonl"
+        },
+        {
+          "description": "RFC-4180 CSV, loaded with `FORMAT AS CSV`. Column order is taken from the\ndestination table's schema and passed explicitly in the `COPY` column\nlist.",
+          "type": "string",
+          "const": "csv"
+        }
+      ]
+    },
+    "sink_pubsub__PubsubCredentials": {
+      "description": "How to authenticate with Google Cloud Pub/Sub.\n\nSerializes as `{ type: <method>, config: { … } }` (adjacent tagging,\nsnake_case discriminators) — the consistent auth wire shape shared by\nevery faucet connector:\n`{ type: service_account_json_file, config: { path: \"/run/secrets/sa.json\" } }`.",
+      "oneOf": [
+        {
+          "description": "Application Default Credentials — honours\n`GOOGLE_APPLICATION_CREDENTIALS`, `GOOGLE_APPLICATION_CREDENTIALS_JSON`,\ngcloud user creds, and the GCE/GKE metadata server, in that order.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "application_default"
+            }
+          }
+        },
+        {
+          "description": "Path to a service-account JSON key file on disk.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "service_account_json_file"
+            },
+            "config": {
+              "type": "object",
+              "properties": {
+                "path": {
+                  "description": "Filesystem path to the service-account key JSON.",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "Service-account JSON key as an inline string. Pair with\n`${env:GCP_SA_JSON}` / `${secret:…}` interpolation in CLI configs so\nthe key never sits in the config file verbatim.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "service_account_json_inline"
+            },
+            "config": {
+              "type": "object",
+              "properties": {
+                "json": {
+                  "description": "The service-account key JSON document.",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "No credentials. Use with the Pub/Sub emulator, which does not validate\nbearer tokens — the SDK otherwise tries to fetch ADC tokens at startup\nand fails in environments without GCP credentials.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "anonymous"
+            }
+          }
+        }
+      ]
+    },
+    "sink_pubsub__ValueFormat": {
+      "description": "How each record is encoded into the Pub/Sub message `data` blob.",
+      "oneOf": [
+        {
+          "description": "Serialize the whole record as JSON bytes.",
+          "type": "string",
+          "const": "json"
+        },
+        {
+          "description": "The record must be a JSON string → raw UTF-8 bytes.",
+          "type": "string",
+          "const": "string"
+        },
+        {
+          "description": "The record must be a base64 JSON string → decoded bytes.",
+          "type": "string",
+          "const": "bytes"
+        }
+      ]
+    },
+    "sink_pubsub__OrderingKey": {
+      "description": "How each message's ordering key is derived. When any non-empty ordering key\nis produced, message ordering is enabled on the publisher.\n\nSerializes as `{ type: <strategy>, … }` (snake_case discriminators).",
+      "oneOf": [
+        {
+          "description": "No ordering key — messages may be delivered in any order (default).",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "none"
+            }
+          }
+        },
+        {
+          "description": "A top-level field's value, stringified. A record missing the field (or\nwith a null / container value) fails per-record (DLQ-routable).",
+          "type": "object",
+          "properties": {
+            "name": {
+              "description": "Top-level field name.",
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "const": "field"
+            }
+          }
+        },
+        {
+          "description": "A dot-path into the record (`a.b.c`, object keys only), stringified.",
+          "type": "object",
+          "properties": {
+            "path": {
+              "description": "Dot path, e.g. `order.id`.",
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "const": "jsonpath"
+            }
+          }
+        }
+      ]
+    },
+    "sink_azure-blob__AzureCredentials": {
+      "description": "Credential source for an Azure storage client.\n\nSerializes as `{ type: <method>, config: { … } }` (adjacent tagging,\nsnake_case discriminators) — the consistent auth wire shape shared by every\nfaucet connector, e.g.\n`{ type: account_key, config: { account_key: \"…\" } }`.",
+      "oneOf": [
+        {
+          "description": "Shared storage-account access key (the primary/secondary key).",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "account_key"
+            },
+            "config": {
+              "type": "object",
+              "properties": {
+                "account_key": {
+                  "description": "Base64 account key.",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "Shared-access-signature token (with or without a leading `?`).",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "sas_token"
+            },
+            "config": {
+              "type": "object",
+              "properties": {
+                "sas_token": {
+                  "description": "SAS token string.",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "Full storage connection string\n(`DefaultEndpointsProtocol=…;AccountName=…;AccountKey=…;…`).",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "connection_string"
+            },
+            "config": {
+              "type": "object",
+              "properties": {
+                "connection_string": {
+                  "description": "Connection string.",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "Azure Managed Identity (IMDS). For a user-assigned identity, set\n`client_id`; leave it unset for the system-assigned identity.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "managed_identity"
+            },
+            "config": {
+              "type": "object",
+              "properties": {
+                "client_id": {
+                  "description": "Optional user-assigned managed-identity client id.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "Azure AD service principal (client credentials).",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "service_principal"
+            },
+            "config": {
+              "type": "object",
+              "properties": {
+                "client_id": {
+                  "description": "Application (client) id.",
+                  "type": "string"
+                },
+                "client_secret": {
+                  "description": "Client secret.",
+                  "type": "string"
+                },
+                "tenant_id": {
+                  "description": "Directory (tenant) id.",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "description": "`DefaultAzureCredential`-style resolution: the object-store builder's\ndefault chain (environment variables, workload identity, managed\nidentity, Azure CLI), honouring `AZURE_*` env vars. This is the default.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "default"
+            }
+          }
+        }
+      ]
+    },
+    "sink_azure-blob__CompressionConfig": {
+      "description": "User-facing compression config. Defaults to [`Auto`](Self::Auto).",
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "none",
+            "gzip",
+            "zstd"
+          ]
+        },
+        {
+          "description": "Detect from filename suffix: `.gz` → Gzip, `.zst` → Zstd, anything else → None.",
+          "type": "string",
+          "const": "auto"
+        }
+      ]
+    },
     "SourceConnector": {
       "oneOf": [
         {
@@ -9121,6 +10010,618 @@
                   },
                   "title": "MysqlCdcSourceConfig",
                   "description": "Configuration for the MySQL CDC (binlog) source.",
+                  "type": "object"
+                },
+                true
+              ]
+            },
+            "transforms": {
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "inherit_transforms": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "title": "mssql-cdc",
+          "properties": {
+            "type": {
+              "const": "mssql-cdc"
+            },
+            "config": {
+              "anyOf": [
+                {
+                  "properties": {
+                    "connection_url": {
+                      "description": "`mssql://user:pass@host:1433/database` URL form. Mutually exclusive with\n[`connection_string`](Self::connection_string).",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "connection_string": {
+                      "description": "ADO.NET-style connection string handed straight to `tiberius`, e.g.\n`Server=tcp:host,1433;Database=db;User Id=sa;Password=...;`. Mutually\nexclusive with [`connection_url`](Self::connection_url).",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "tls": {
+                      "description": "TLS / encryption settings. Defaults to [`MssqlTlsMode::Prefer`].",
+                      "$ref": "#/$defs/source_mssql-cdc__MssqlTls",
+                      "default": {
+                        "type": "prefer"
+                      }
+                    },
+                    "capture_instances": {
+                      "description": "Capture instances to poll (e.g. `dbo_Orders`). **Required and non-empty.**\n\nA capture instance is created by `sys.sp_cdc_enable_table` and defaults to\n`<schema>_<table>`. Names are used verbatim to build the\n`cdc.fn_cdc_get_all_changes_<name>` table-valued function call, so v1 only\naccepts the SQL Server identifier characters `[A-Za-z0-9_]` (validated at\nload time) to prevent injection into the function name.",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "start_position": {
+                      "description": "Start position on a fresh run (ignored once a bookmark exists). Default\n`current` (skip existing history).",
+                      "$ref": "#/$defs/source_mssql-cdc__StartPosition",
+                      "default": {
+                        "type": "current"
+                      }
+                    },
+                    "poll_interval": {
+                      "description": "Seconds to wait between empty polls (no new changes). Default 1s.",
+                      "type": [
+                        "integer",
+                        "string"
+                      ],
+                      "format": "uint64",
+                      "minimum": 0,
+                      "default": 1
+                    },
+                    "idle_timeout": {
+                      "description": "Terminator: end the fetch cycle after this much continuous quiet (no\nchange rows across any capture instance). Default 30s. A long-running\nruntime (`faucet schedule` / `faucet serve`) re-invokes the source to\nkeep tailing.",
+                      "type": [
+                        "integer",
+                        "string"
+                      ],
+                      "format": "uint64",
+                      "minimum": 0,
+                      "default": 30
+                    },
+                    "max_staged_records": {
+                      "description": "Max records buffered for a single in-progress transaction before the run\naborts with a typed error (rather than risking unbounded memory growth).\n`None` = unbounded.",
+                      "type": [
+                        "integer",
+                        "null",
+                        "string"
+                      ],
+                      "format": "uint",
+                      "minimum": 0,
+                      "default": null
+                    },
+                    "batch_size": {
+                      "description": "Advisory per-page record count. `0` accumulates every change into a\nsingle trailing page (snapshot/test convenience). Default\n[`DEFAULT_BATCH_SIZE`].",
+                      "type": [
+                        "integer",
+                        "string"
+                      ],
+                      "format": "uint",
+                      "minimum": 0,
+                      "default": 1000
+                    },
+                    "max_connections": {
+                      "description": "Maximum pooled connections. Defaults to 5.",
+                      "type": [
+                        "integer",
+                        "string"
+                      ],
+                      "format": "uint32",
+                      "minimum": 0,
+                      "default": 5
+                    },
+                    "statement_timeout_secs": {
+                      "description": "Per-query timeout in seconds (`0` disables). Defaults to 300.",
+                      "type": [
+                        "integer",
+                        "string"
+                      ],
+                      "format": "uint64",
+                      "minimum": 0,
+                      "default": 300
+                    },
+                    "state_key": {
+                      "description": "Explicit state-store key for the LSN bookmark. When unset, a key is\nderived from the database (or host) and the sorted capture-instance list.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "title": "MssqlCdcSourceConfig",
+                  "description": "Configuration for the Microsoft SQL Server CDC source.\n\nThe source polls native SQL Server change data capture: `sys.fn_cdc_get_max_lsn()`\nfor the high-water LSN, then `cdc.fn_cdc_get_all_changes_<capture_instance>()`\nper configured capture instance, advancing a durable per-instance LSN bookmark.",
+                  "type": "object"
+                },
+                true
+              ]
+            },
+            "transforms": {
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "inherit_transforms": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "title": "redshift",
+          "properties": {
+            "type": {
+              "const": "redshift"
+            },
+            "config": {
+              "anyOf": [
+                {
+                  "properties": {
+                    "host": {
+                      "description": "Cluster / endpoint host (e.g. `my-cluster.abc123.us-east-1.redshift.amazonaws.com`).",
+                      "type": "string"
+                    },
+                    "port": {
+                      "description": "Port. Defaults to [`DEFAULT_PORT`] (5439).",
+                      "type": [
+                        "integer",
+                        "string"
+                      ],
+                      "format": "uint16",
+                      "minimum": 0,
+                      "maximum": 65535,
+                      "default": 5439
+                    },
+                    "database": {
+                      "description": "Database name.",
+                      "type": "string"
+                    },
+                    "user": {
+                      "description": "Database user.",
+                      "type": "string"
+                    },
+                    "credentials": {
+                      "description": "Authentication credentials.",
+                      "$ref": "#/$defs/source_redshift__RedshiftCredentials"
+                    },
+                    "tls": {
+                      "description": "Whether to require TLS. Defaults to `true` (Redshift clusters require SSL\nby default). `true` maps to `sslmode=require`; `false` maps to\n`sslmode=prefer` (opportunistic TLS with plaintext fallback) — it never\nforbids encryption outright.",
+                      "type": [
+                        "boolean",
+                        "string"
+                      ],
+                      "default": true
+                    },
+                    "query": {
+                      "description": "SQL query to execute. May contain `${field.path}` parent-context tokens\n(resolved to positional binds at runtime) and, for incremental\nreplication, a `${bookmark}` token.",
+                      "type": "string"
+                    },
+                    "params": {
+                      "description": "Positional bind parameters for the query, applied in `$1, $2, …` order\nbefore any context- or bookmark-derived values. Defaults to empty.",
+                      "type": "array",
+                      "items": true,
+                      "default": []
+                    },
+                    "max_connections": {
+                      "description": "Maximum number of connections in the pool. Defaults to 10.",
+                      "type": [
+                        "integer",
+                        "string"
+                      ],
+                      "format": "uint32",
+                      "minimum": 0,
+                      "default": 10
+                    },
+                    "batch_size": {
+                      "description": "Records per emitted [`StreamPage`](faucet_core::StreamPage). Rows are\ndrained from the `sqlx` cursor and yielded whenever the buffer reaches\nthis size. Defaults to [`DEFAULT_BATCH_SIZE`].\n\n`batch_size = 0` is the \"no batching\" sentinel: the cursor is fully\ndrained and the entire result set is emitted in a single page.",
+                      "type": [
+                        "integer",
+                        "string"
+                      ],
+                      "format": "uint",
+                      "minimum": 0,
+                      "default": 1000
+                    },
+                    "replication": {
+                      "description": "Replication mode. Defaults to [`RedshiftReplication::Full`].",
+                      "$ref": "#/$defs/source_redshift__RedshiftReplication",
+                      "default": {
+                        "type": "full"
+                      }
+                    },
+                    "state_key": {
+                      "description": "Explicit state-store key for the incremental bookmark. When unset, a key\nis derived from the host / database and a query fingerprint.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "title": "RedshiftSourceConfig",
+                  "description": "Configuration for the Amazon Redshift query source.",
+                  "type": "object"
+                },
+                true
+              ]
+            },
+            "transforms": {
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "inherit_transforms": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "title": "pubsub",
+          "properties": {
+            "type": {
+              "const": "pubsub"
+            },
+            "config": {
+              "anyOf": [
+                {
+                  "properties": {
+                    "subscription": {
+                      "description": "Subscription id (short name, not the fully-qualified path). The client\nforms `projects/<project>/subscriptions/<id>` from the connection's\nproject.",
+                      "type": "string"
+                    },
+                    "project_id": {
+                      "description": "GCP project id that owns the topic / subscription. Required for real\nPub/Sub; the emulator infers it from `PUBSUB_PROJECT_ID` when unset.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "endpoint": {
+                      "description": "Override the Pub/Sub API endpoint (host:port or URL). Rarely needed —\nprefer `emulator_host` for the emulator.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "emulator_host": {
+                      "description": "Point the client at a Pub/Sub emulator (`host:port`). When set, auth is\nskipped and the endpoint is taken from this value — mirrors the\n`PUBSUB_EMULATOR_HOST` environment variable the SDK honours.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "credentials": {
+                      "description": "How to authenticate. Defaults to Application Default Credentials.",
+                      "$ref": "#/$defs/source_pubsub__PubsubCredentials",
+                      "default": {
+                        "type": "application_default"
+                      }
+                    },
+                    "value_format": {
+                      "description": "Payload decoding for the message `data` field.",
+                      "$ref": "#/$defs/source_pubsub__ValueFormat",
+                      "default": "json"
+                    },
+                    "attributes_key": {
+                      "description": "JSON key the message attribute map is surfaced under. Default\n`__attributes`.",
+                      "type": "string",
+                      "default": "__attributes"
+                    },
+                    "max_messages_per_pull": {
+                      "description": "Messages requested per `pull` RPC (1–1000). Default 100.",
+                      "type": [
+                        "integer",
+                        "string"
+                      ],
+                      "format": "uint",
+                      "minimum": 0,
+                      "default": 100
+                    },
+                    "idle_termination_secs": {
+                      "description": "Stop after this many seconds without a new message. At least one of\n`idle_termination_secs` and `max_messages` must be set (mirrors the\nKafka / Kinesis sources) — a batch run must terminate.",
+                      "type": [
+                        "integer",
+                        "null",
+                        "string"
+                      ],
+                      "format": "uint64",
+                      "minimum": 0
+                    },
+                    "max_messages": {
+                      "description": "Stop after this many messages in total.",
+                      "type": [
+                        "integer",
+                        "null",
+                        "string"
+                      ],
+                      "format": "uint",
+                      "minimum": 0
+                    },
+                    "batch_size": {
+                      "description": "Records per emitted [`StreamPage`](faucet_core::StreamPage). `0` is the\n\"no batching\" sentinel: one page per drain. Default 1000. A page's\nmessages are acked once the pipeline has durably written the page.",
+                      "type": [
+                        "integer",
+                        "string"
+                      ],
+                      "format": "uint",
+                      "minimum": 0,
+                      "default": 1000
+                    }
+                  },
+                  "title": "PubsubSourceConfig",
+                  "description": "Configuration for [`PubsubSource`](crate::PubsubSource).",
+                  "type": "object"
+                },
+                true
+              ]
+            },
+            "transforms": {
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "inherit_transforms": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "title": "clickhouse",
+          "properties": {
+            "type": {
+              "const": "clickhouse"
+            },
+            "config": {
+              "anyOf": [
+                {
+                  "properties": {
+                    "url": {
+                      "description": "Full base URL of the ClickHouse HTTP interface, e.g.\n`\"http://localhost:8123\"`. Mutually exclusive with\n[`host`](Self::host). A trailing slash is trimmed.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "host": {
+                      "description": "Hostname of the ClickHouse server. Mutually exclusive with\n[`url`](Self::url); combined with [`http_port`](Self::http_port) and\n[`tls`](Self::tls) to build the base URL.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "http_port": {
+                      "description": "HTTP-interface port used with [`host`](Self::host). Defaults to\n[`DEFAULT_HTTP_PORT`] (`8123`).",
+                      "type": [
+                        "integer",
+                        "null",
+                        "string"
+                      ],
+                      "format": "uint16",
+                      "minimum": 0,
+                      "maximum": 65535
+                    },
+                    "tls": {
+                      "description": "Use `https://` instead of `http://` when building the base URL from\n[`host`](Self::host). Ignored when [`url`](Self::url) is set. Defaults to\n`false`.",
+                      "type": [
+                        "boolean",
+                        "string"
+                      ],
+                      "default": false
+                    },
+                    "database": {
+                      "description": "Target database. Defaults to [`DEFAULT_DATABASE`] (`\"default\"`).",
+                      "type": "string",
+                      "default": "default"
+                    },
+                    "user": {
+                      "description": "ClickHouse user. When set, sent as the `X-ClickHouse-User` header.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "password": {
+                      "description": "ClickHouse password. When set, sent as the `X-ClickHouse-Key` header.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "query": {
+                      "description": "SQL `SELECT` query to run. The output format is set to `JSONEachRow`\nvia the request settings, so **do not** append a `FORMAT` clause. Use\nthe literal `@bookmark` token to push the incremental cursor down into\nthe `WHERE` clause; use `{key}` tokens to inject parent-context values in\na matrix child.",
+                      "type": "string"
+                    },
+                    "batch_size": {
+                      "description": "Records per emitted [`StreamPage`](faucet_core::StreamPage). `0` emits\nthe whole result set as a single page. Defaults to\n[`DEFAULT_BATCH_SIZE`].",
+                      "type": [
+                        "integer",
+                        "string"
+                      ],
+                      "format": "uint",
+                      "minimum": 0,
+                      "default": 1000
+                    },
+                    "replication": {
+                      "description": "Replication mode. Defaults to [`ClickHouseReplication::Full`].",
+                      "$ref": "#/$defs/source_clickhouse__ClickHouseReplication",
+                      "default": {
+                        "type": "full"
+                      }
+                    },
+                    "state_key": {
+                      "description": "Explicit state-store key for the bookmark. When unset, a key is derived\nfrom the connection host and a query fingerprint.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "title": "ClickHouseSourceConfig",
+                  "description": "Configuration for [`ClickHouseSource`](crate::ClickHouseSource).",
+                  "type": "object"
+                },
+                true
+              ]
+            },
+            "transforms": {
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "inherit_transforms": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "title": "azure-blob",
+          "properties": {
+            "type": {
+              "const": "azure-blob"
+            },
+            "config": {
+              "anyOf": [
+                {
+                  "properties": {
+                    "container": {
+                      "description": "Blob container / ADLS Gen2 filesystem name. Required.",
+                      "type": "string"
+                    },
+                    "account": {
+                      "description": "Storage-account name. Optional when a connection string or the\nemulator supplies it, otherwise required.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "auth": {
+                      "description": "Credential source. Defaults to the environment / managed-identity\ncredential chain.",
+                      "$ref": "#/$defs/source_azure-blob__AzureCredentials",
+                      "default": {
+                        "type": "default"
+                      }
+                    },
+                    "endpoint": {
+                      "description": "Custom blob endpoint (e.g. an Azurite emulator or a sovereign cloud).",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "allow_http": {
+                      "description": "Permit plaintext HTTP (required for a local Azurite emulator).",
+                      "type": [
+                        "boolean",
+                        "string"
+                      ],
+                      "default": false
+                    },
+                    "use_emulator": {
+                      "description": "Target the Azurite storage emulator with its well-known\n`devstoreaccount1` credentials.",
+                      "type": [
+                        "boolean",
+                        "string"
+                      ],
+                      "default": false
+                    },
+                    "prefix": {
+                      "description": "Object name prefix filter. Ignored when `object_keys` is set.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "object_keys": {
+                      "description": "Explicit object names. When set, listing is skipped and `prefix`\nis ignored.",
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "file_format": {
+                      "description": "File format.",
+                      "$ref": "#/$defs/source_azure-blob__AzureFileFormat",
+                      "default": "json_lines"
+                    },
+                    "max_objects": {
+                      "description": "Hard cap on the number of objects read (after listing).",
+                      "type": [
+                        "integer",
+                        "null",
+                        "string"
+                      ],
+                      "format": "uint",
+                      "minimum": 0
+                    },
+                    "concurrency": {
+                      "description": "Maximum concurrent object reads (default: 10).",
+                      "type": [
+                        "integer",
+                        "string"
+                      ],
+                      "format": "uint",
+                      "minimum": 0,
+                      "default": 10
+                    },
+                    "batch_size": {
+                      "description": "Records per emitted `StreamPage`. `batch_size = 0` is the \"no batching\"\nsentinel and emits one page per object.",
+                      "type": [
+                        "integer",
+                        "string"
+                      ],
+                      "format": "uint",
+                      "minimum": 0,
+                      "default": 1000
+                    },
+                    "compression": {
+                      "description": "Compression codec applied to each downloaded object. Defaults to\n[`CompressionConfig::Auto`](faucet_core::CompressionConfig::Auto) — the\ncodec is resolved per-object-key, so a single source can read a mix of\ncompressed and uncompressed objects. Requires the crate-local\n`compression` feature.",
+                      "$ref": "#/$defs/source_azure-blob__CompressionConfig",
+                      "default": "auto"
+                    }
+                  },
+                  "title": "AzureBlobSourceConfig",
+                  "description": "Configuration for the Azure Blob source connector.",
                   "type": "object"
                 },
                 true
@@ -12634,6 +14135,454 @@
                   },
                   "title": "GcsSinkConfig",
                   "description": "Configuration for the GCS sink connector.",
+                  "type": "object"
+                },
+                true
+              ]
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "title": "redshift",
+          "properties": {
+            "type": {
+              "const": "redshift"
+            },
+            "config": {
+              "anyOf": [
+                {
+                  "properties": {
+                    "host": {
+                      "description": "Cluster / endpoint host (e.g. `my-cluster.abc123.us-east-1.redshift.amazonaws.com`).",
+                      "type": "string"
+                    },
+                    "port": {
+                      "description": "Port. Defaults to [`DEFAULT_PORT`] (5439).",
+                      "type": [
+                        "integer",
+                        "string"
+                      ],
+                      "format": "uint16",
+                      "minimum": 0,
+                      "maximum": 65535,
+                      "default": 5439
+                    },
+                    "database": {
+                      "description": "Database name.",
+                      "type": "string"
+                    },
+                    "user": {
+                      "description": "Database user.",
+                      "type": "string"
+                    },
+                    "credentials": {
+                      "description": "Authentication credentials.",
+                      "$ref": "#/$defs/sink_redshift__RedshiftCredentials"
+                    },
+                    "tls": {
+                      "description": "Whether to require TLS. Defaults to `true` (Redshift clusters require SSL\nby default). `true` maps to `sslmode=require`; `false` maps to\n`sslmode=prefer` (opportunistic TLS with plaintext fallback) — it never\nforbids encryption outright.",
+                      "type": [
+                        "boolean",
+                        "string"
+                      ],
+                      "default": true
+                    },
+                    "table_name": {
+                      "description": "Target table name.",
+                      "type": "string"
+                    },
+                    "schema": {
+                      "description": "Optional schema (namespace) qualifying [`table_name`](Self::table_name).",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "write_strategy": {
+                      "description": "How rows are loaded. Defaults to [`RedshiftWriteStrategy::Copy`].",
+                      "$ref": "#/$defs/sink_redshift__RedshiftWriteStrategy",
+                      "default": "copy"
+                    },
+                    "copy_format": {
+                      "description": "Staged-file format for the `COPY` path. Defaults to\n[`RedshiftCopyFormat::Jsonl`]. Ignored by the `insert` strategy.",
+                      "$ref": "#/$defs/sink_redshift__RedshiftCopyFormat",
+                      "default": "jsonl"
+                    },
+                    "staging_bucket": {
+                      "description": "S3 bucket used to stage `COPY` files. **Required** when\n`write_strategy: copy`.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "staging_prefix": {
+                      "description": "Key prefix for staged objects (e.g. `redshift-staging/`). Defaults to\nempty.",
+                      "type": "string",
+                      "default": ""
+                    },
+                    "iam_role": {
+                      "description": "IAM role ARN Redshift assumes to read the staged file\n(`COPY … IAM_ROLE '<arn>'`). **Required** when `write_strategy: copy`.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "region": {
+                      "description": "AWS region of the staging bucket (used for both the S3 client and the\n`COPY … REGION '<region>'` clause). `None` uses the SDK default.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "endpoint_url": {
+                      "description": "Custom endpoint URL for S3-compatible services (e.g. MinIO) — testing\naid; production loads use real S3.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "batch_size": {
+                      "description": "Rows per load unit. For `insert`, the per-statement multi-row chunk size;\nfor `copy`, the number of rows per staged S3 object. Defaults to\n[`DEFAULT_BATCH_SIZE`]. `0` = one unit for the whole page.",
+                      "type": [
+                        "integer",
+                        "string"
+                      ],
+                      "format": "uint",
+                      "minimum": 0,
+                      "default": 1000
+                    },
+                    "max_connections": {
+                      "description": "Maximum number of connections in the pool. Defaults to 5.",
+                      "type": [
+                        "integer",
+                        "string"
+                      ],
+                      "format": "uint32",
+                      "minimum": 0,
+                      "default": 5
+                    }
+                  },
+                  "title": "RedshiftSinkConfig",
+                  "description": "Configuration for the Amazon Redshift sink.",
+                  "type": "object"
+                },
+                true
+              ]
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "title": "pubsub",
+          "properties": {
+            "type": {
+              "const": "pubsub"
+            },
+            "config": {
+              "anyOf": [
+                {
+                  "properties": {
+                    "topic": {
+                      "description": "Topic id (short name, not the fully-qualified path). The client forms\n`projects/<project>/topics/<id>` from the connection's project.",
+                      "type": "string"
+                    },
+                    "project_id": {
+                      "description": "GCP project id that owns the topic / subscription. Required for real\nPub/Sub; the emulator infers it from `PUBSUB_PROJECT_ID` when unset.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "endpoint": {
+                      "description": "Override the Pub/Sub API endpoint (host:port or URL). Rarely needed —\nprefer `emulator_host` for the emulator.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "emulator_host": {
+                      "description": "Point the client at a Pub/Sub emulator (`host:port`). When set, auth is\nskipped and the endpoint is taken from this value — mirrors the\n`PUBSUB_EMULATOR_HOST` environment variable the SDK honours.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "credentials": {
+                      "description": "How to authenticate. Defaults to Application Default Credentials.",
+                      "$ref": "#/$defs/sink_pubsub__PubsubCredentials",
+                      "default": {
+                        "type": "application_default"
+                      }
+                    },
+                    "value_format": {
+                      "description": "Record payload encoding. Default: `json`.",
+                      "$ref": "#/$defs/sink_pubsub__ValueFormat",
+                      "default": "json"
+                    },
+                    "ordering_key": {
+                      "description": "Ordering-key derivation. Default: `none`.",
+                      "$ref": "#/$defs/sink_pubsub__OrderingKey",
+                      "default": {
+                        "type": "none"
+                      }
+                    },
+                    "attributes_field": {
+                      "description": "Optional record field holding a JSON object of message attributes.\nValues are stringified; the field is stripped from the payload before\nencoding. Absent field → no attributes (not an error).",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "batch_size": {
+                      "description": "Records per publish batch (1–1000). Default 100.",
+                      "type": [
+                        "integer",
+                        "string"
+                      ],
+                      "format": "uint",
+                      "minimum": 0,
+                      "default": 100
+                    },
+                    "concurrency": {
+                      "description": "Bounded concurrent in-flight publishes. Default 4.",
+                      "type": [
+                        "integer",
+                        "string"
+                      ],
+                      "format": "uint",
+                      "minimum": 0,
+                      "default": 4
+                    }
+                  },
+                  "title": "PubsubSinkConfig",
+                  "description": "Configuration for [`PubsubSink`](crate::PubsubSink).",
+                  "type": "object"
+                },
+                true
+              ]
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "title": "clickhouse",
+          "properties": {
+            "type": {
+              "const": "clickhouse"
+            },
+            "config": {
+              "anyOf": [
+                {
+                  "properties": {
+                    "url": {
+                      "description": "Full base URL of the ClickHouse HTTP interface, e.g.\n`\"http://localhost:8123\"`. Mutually exclusive with\n[`host`](Self::host). A trailing slash is trimmed.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "host": {
+                      "description": "Hostname of the ClickHouse server. Mutually exclusive with\n[`url`](Self::url); combined with [`http_port`](Self::http_port) and\n[`tls`](Self::tls) to build the base URL.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "http_port": {
+                      "description": "HTTP-interface port used with [`host`](Self::host). Defaults to\n[`DEFAULT_HTTP_PORT`] (`8123`).",
+                      "type": [
+                        "integer",
+                        "null",
+                        "string"
+                      ],
+                      "format": "uint16",
+                      "minimum": 0,
+                      "maximum": 65535
+                    },
+                    "tls": {
+                      "description": "Use `https://` instead of `http://` when building the base URL from\n[`host`](Self::host). Ignored when [`url`](Self::url) is set. Defaults to\n`false`.",
+                      "type": [
+                        "boolean",
+                        "string"
+                      ],
+                      "default": false
+                    },
+                    "database": {
+                      "description": "Target database. Defaults to [`DEFAULT_DATABASE`] (`\"default\"`).",
+                      "type": "string",
+                      "default": "default"
+                    },
+                    "user": {
+                      "description": "ClickHouse user. When set, sent as the `X-ClickHouse-User` header.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "password": {
+                      "description": "ClickHouse password. When set, sent as the `X-ClickHouse-Key` header.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "table": {
+                      "description": "Target table. May be schema-qualified (`db.table`); each identifier\nsegment is quoted before use.",
+                      "type": "string"
+                    },
+                    "batch_size": {
+                      "description": "Records per `INSERT` request. When the upstream `StreamPage` carries more\nrecords than `batch_size`, the sink splits it into `batch_size`-row\nchunks and issues one `INSERT … FORMAT JSONEachRow` per chunk. `0`\nforwards the whole page as a single request. Defaults to\n[`DEFAULT_BATCH_SIZE`].",
+                      "type": [
+                        "integer",
+                        "string"
+                      ],
+                      "format": "uint",
+                      "minimum": 0,
+                      "default": 1000
+                    },
+                    "async_insert": {
+                      "description": "Enable ClickHouse [asynchronous inserts](https://clickhouse.com/docs/en/optimize/asynchronous-inserts)\n(`async_insert=1`): the server buffers rows and flushes them in the\nbackground, which greatly improves throughput for many small inserts.\nDefaults to `false`.",
+                      "type": [
+                        "boolean",
+                        "string"
+                      ],
+                      "default": false
+                    },
+                    "wait_for_async_insert": {
+                      "description": "When [`async_insert`](Self::async_insert) is enabled, whether the server\nwaits for the buffered rows to be flushed before acknowledging the\nrequest (`wait_for_async_insert=1`). Keeping this `true` (the default)\npreserves faucet's at-least-once durability contract — the bookmark only\nadvances after ClickHouse has durably accepted the batch. Ignored when\n`async_insert` is `false`.",
+                      "type": [
+                        "boolean",
+                        "string"
+                      ],
+                      "default": true
+                    }
+                  },
+                  "title": "ClickHouseSinkConfig",
+                  "description": "Configuration for [`ClickHouseSink`](crate::ClickHouseSink).",
+                  "type": "object"
+                },
+                true
+              ]
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "title": "azure-blob",
+          "properties": {
+            "type": {
+              "const": "azure-blob"
+            },
+            "config": {
+              "anyOf": [
+                {
+                  "properties": {
+                    "container": {
+                      "description": "Blob container / ADLS Gen2 filesystem name. Required.",
+                      "type": "string"
+                    },
+                    "account": {
+                      "description": "Storage-account name. Optional when a connection string or the\nemulator supplies it, otherwise required.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "auth": {
+                      "description": "Credential source. Defaults to the environment / managed-identity\ncredential chain.",
+                      "$ref": "#/$defs/sink_azure-blob__AzureCredentials",
+                      "default": {
+                        "type": "default"
+                      }
+                    },
+                    "endpoint": {
+                      "description": "Custom blob endpoint (e.g. an Azurite emulator or a sovereign cloud).",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "allow_http": {
+                      "description": "Permit plaintext HTTP (required for a local Azurite emulator).",
+                      "type": [
+                        "boolean",
+                        "string"
+                      ],
+                      "default": false
+                    },
+                    "use_emulator": {
+                      "description": "Target the Azurite storage emulator with its well-known\n`devstoreaccount1` credentials.",
+                      "type": [
+                        "boolean",
+                        "string"
+                      ],
+                      "default": false
+                    },
+                    "prefix": {
+                      "description": "Object-name prefix for written objects.",
+                      "type": "string",
+                      "default": ""
+                    },
+                    "file_extension": {
+                      "description": "File extension for written objects (default `.jsonl`).",
+                      "type": "string",
+                      "default": ".jsonl"
+                    },
+                    "max_records_per_file": {
+                      "description": "Hard cap on records per uploaded object. `None` means a single object\nper `write_batch` call (still subject to `batch_size`).",
+                      "type": [
+                        "integer",
+                        "null",
+                        "string"
+                      ],
+                      "format": "uint",
+                      "minimum": 0
+                    },
+                    "concurrency": {
+                      "description": "Maximum number of concurrent uploads (default 10).",
+                      "type": [
+                        "integer",
+                        "string"
+                      ],
+                      "format": "uint",
+                      "minimum": 0,
+                      "default": 10
+                    },
+                    "batch_size": {
+                      "description": "Records per uploaded object from a single `write_batch` call.\n`batch_size = 0` writes whatever upstream hands the sink as one object.\nRecommended value for object stores is `0` — many tiny objects is a\nwell-known anti-pattern.",
+                      "type": [
+                        "integer",
+                        "string"
+                      ],
+                      "format": "uint",
+                      "minimum": 0,
+                      "default": 1000
+                    },
+                    "compression": {
+                      "description": "Compression codec applied to each uploaded object body. Defaults to\n[`CompressionConfig::Auto`](faucet_core::CompressionConfig::Auto) —\nresolves against `file_extension` (so `.jsonl.gz` triggers gzip).\nRequires the crate-local `compression` feature. Note: this sink does\n**not** set any `Content-Encoding` metadata, so consumers must\ndecompress explicitly.",
+                      "$ref": "#/$defs/sink_azure-blob__CompressionConfig",
+                      "default": "auto"
+                    }
+                  },
+                  "title": "AzureBlobSinkConfig",
+                  "description": "Configuration for the Azure Blob sink connector.",
                   "type": "object"
                 },
                 true


### PR DESCRIPTION
Adds **five tier-1 connector features** in one change — closing the most conspicuous cloud/warehouse/messaging/CDC gaps.

## Connectors
| Issue | Connector | Crates |
|---|---|---|
| #346 | Amazon Redshift source + sink | `faucet-common-redshift`, `faucet-source-redshift`, `faucet-sink-redshift` |
| #347 | Google Cloud Pub/Sub source + sink | `faucet-common-pubsub`, `faucet-source-pubsub`, `faucet-sink-pubsub` |
| #348 | ClickHouse source + sink | `faucet-common-clickhouse`, `faucet-source-clickhouse`, `faucet-sink-clickhouse` |
| #349 | Azure Blob / ADLS Gen2 source + sink | `faucet-common-azure`, `faucet-source-azure-blob`, `faucet-sink-azure-blob` |
| #350 | SQL Server CDC source | `faucet-source-mssql-cdc` |

## Highlights
- **Redshift** — PostgreSQL-wire query source with incremental replication; sink with staged `COPY`-from-S3 (default) or multi-row `INSERT`.
- **Pub/Sub** — streaming pull, ack at durable page boundaries (at-least-once); batched publish with optional ordering keys + partial-failure retry (DLQ-routable).
- **ClickHouse** — HTTP interface, `FORMAT JSONEachRow` streaming decode; batched `INSERT` with optional `async_insert`.
- **Azure Blob / ADLS Gen2** — `object_store`-backed, mirrors the S3/GCS connectors (jsonl/json_array/raw_text, compression, rollover). First Azure coverage.
- **SQL Server CDC** — `fn_cdc_get_all_changes` over LSN bookmarks, `__op`-normalized change events, **exactly-once capable**, resumable, `faucet replicate`-compatible.

## Wiring & docs
- Workspace members, umbrella + CLI features, `registry.rs` build/schema/description arms, `EXACTLY_ONCE_SOURCE_KINDS`, `connectors/registry.json`, and the CI `feature-check` matrix.
- Docs-site capability matrix + counts (33 sources / 25 sinks / 58 total / 80 crates), comparison pages, cookbook exactly-once list, six runnable `cli/examples/*.yaml`.

## Testing
- Unit tests for all pure logic; **auto-starting testcontainer** integration tests exercising the I/O paths (ClickHouse, Azurite, Postgres-for-Redshift-wire, Pub/Sub emulator, SQL Server CDC) so they run in CI and count toward coverage.
- Verified locally via colima: ClickHouse 98.6%, Redshift 90.5%, Pub/Sub 92.2%, Azure all tests green. mssql-cdc runs in CI (SQL Server container is CI-only on ARM).
- Redshift's `COPY`-from-S3 execution is the one path with no container (no Redshift image); covered via the Postgres-wire path for everything else.

Cross-links the roadmap epic #38.

Closes #346
Closes #347
Closes #348
Closes #349
Closes #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)