### PR TITLE
docs: improve docs-site readability (measure, size, leading, gutters)

### DIFF
--- a/docs/book/custom.css
+++ b/docs/book/custom.css
@@ -156,9 +156,36 @@ mark {
   background: color-mix(in srgb, var(--fs-green) 30%, transparent);
 }
 
-/* ── Typography ───────────────────────────────────────────────────────────── */
+/* ── Typography ───────────────────────────────────────────────────────────────
+   Grounded in long-form readability research (Bringhurst, "The Elements of
+   Typographic Style" + WCAG 1.4.8), applied site-wide so every chapter reads
+   like the Learn page:
+     · measure  — ~66–72 characters/line is the ideal for sustained reading
+                  (readable range 45–75); set with `ch` so it tracks the font.
+     · leading  — 1.6–1.8 line-height for body copy (WCAG asks for ≥1.5).
+     · size     — 17px body; 16px is the floor, 17–18px is the long-form optimum.
+     · gutters  — wider page padding so text/tables/code never hug the right
+                  edge, plus a roomier reading column so tables have space.
+   mdBook uses the 62.5% trick, so 1rem = 10px here.
+   ──────────────────────────────────────────────────────────────────────────── */
+:root {
+  --page-padding: 24px; /* was 15px — symmetric breathing room on both edges */
+  --content-max-width: 860px; /* was 750px — roomier column for tables/code */
+}
 .content {
-  line-height: 1.7;
+  font-family: "Open Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, sans-serif;
+  font-size: 1.7rem; /* 17px */
+  line-height: 1.72; /* the vertical rhythm / "font gap" */
+}
+.content p,
+.content ul,
+.content ol,
+.content blockquote {
+  max-width: 72ch; /* ~66–72 characters/line — a generous, readable measure */
+}
+.content p {
+  margin: 0 0 1.05em; /* clear separation between paragraphs */
 }
 .content table,
 .content pre,


### PR DESCRIPTION
Makes every docs-site page read like the Learn page by applying research-grounded long-form typography in `docs/book/custom.css`. Rebased onto latest `main` (keeps #360's boxed/centered mermaid treatment); supersedes #363.

## Root cause
Tables/code stopped just **15px** from the right edge, so dense/reference pages hugged the right border ("the gap on the right is too small").

## Changes (Bringhurst's *Elements of Typographic Style* + WCAG 1.4.8)
| Property | Before | After |
|---|---|---|
| Page padding (gutters) | 15px | **24px** |
| Reading column | 750px | **860px** |
| Measure (line length) | prose filled the column | **72ch** (within the ideal 45–75) |
| Body font-size | 16px | **17px** |
| Line-height | 1.7 | **1.72** |
| Font family | Open Sans (implicit) | Open Sans + explicit system fallback |
| Paragraph spacing | default | 1.05em bottom margin |

Note: re-introduces a prose measure cap (72ch). #360 had removed it to let prose fill the column, which produces very long lines; a bounded measure is the readability-correct choice per the request.

## Notes
- **Single file** (`docs/book/custom.css`) — CSS only; auto-deploys to GitHub Pages on merge.
- mdBook builds cleanly; all values verified in the built output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)